### PR TITLE
fix: Remove redundant local 'import re' causing UnboundLocalError

### DIFF
--- a/packages/llm_analysis/llm/providers.py
+++ b/packages/llm_analysis/llm/providers.py
@@ -413,7 +413,6 @@ Respond with ONLY the JSON object, no markdown, no other text."""
             # For exploit generation, try to extract code from the response even if JSON is malformed
             if "exploit" in prompt.lower() and "code" in schema and "reasoning" in schema:
                 logger.warning("Attempting to extract code from malformed response...")
-                import re
 
                 # Try to extract code and reasoning using regex
                 code_match = re.search(r'"code"\s*:\s*"([^"]*(?:\\.[^"]*)*)"', response.content, re.DOTALL)


### PR DESCRIPTION
## Problem

Production failures in Ollama LLM provider with error:
```
UnboundLocalError: cannot access local variable 're' where it is not associated with a value
```

**Impact:** 66 failures in single session (Nov 29, 2025)

## Root Cause

`OllamaProvider.generate_structured()` had redundant `import re` on line 416 inside an except block.

Python treats imports as assignments, making `re` a **local variable for the entire function scope**. When lines 350-402 tried to use `re` before line 416 executed, Python raised `UnboundLocalError`.

**Code structure:**
```python
def generate_structured(...):
    try:
        content = re.sub(...)     # Line 350 - tries to use 're'
        json_match = re.search()  # Line 362 - tries to use 're'
        content = re.sub(...)     # Lines 401-402 - tries to use 're'
    except json.JSONDecodeError:
        import re                 # Line 416 - makes 're' local for ENTIRE function
        code_match = re.search()  # Line 419 - uses local 're'
```

## Solution

Remove line 416. Module-level `import re` (line 9) is sufficient for all uses.

## Verification

- ✅ Python AST analysis confirms scoping bug
- ✅ 11 uses of `re` in method all work with module-level import
- ✅ No other similar issues in codebase
- ✅ Zero functionality lost

## Files Changed

- `packages/llm_analysis/llm/providers.py` (-1 line)

## Testing

Verified by:
1. Python AST scope analysis
2. Production error logs analysis
3. Manual code inspection

**Risk:** None - removes redundant code only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove redundant local `import re` in `OllamaProvider.generate_structured` to prevent `UnboundLocalError` during JSON parsing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee1cf05d0e8ba857c29c19822d56f2bc44f4f9b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->