### PR TITLE
LICENSE file tweak - 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Gadi Evron, Daniel Cuthbert, Thomas Dullien (Halvar Flake),
-and Michael Bargury.
+Copyright (c) 2025 Gadi Evron, Daniel Cuthbert, Thomas Dullien (Halvar Flake), and Michael Bargury.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This should make Github recognize it as MIT license and show  it

<img width="300" height="274" alt="image" src="https://github.com/user-attachments/assets/2d4c710b-7953-4fa0-80b9-bd6dcf547d23" />
<img width="322" height="290" alt="image" src="https://github.com/user-attachments/assets/29d99cd1-9061-4414-a678-6a783d9451a4" />
