### PR TITLE
Feat: Add external Ollama server configuration with intelligent retry delays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ out/
 # Local
 .env*
 .claude/*.local.json
+
+# Runtime artifacts
+codeql_dbs/

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -53,6 +53,15 @@ For example CodeQL does not allow commerical use.
 - Usage: RAPTOR calls `codeql` command for deep analysis
 - Note: User installs separately
 
+**Ollama** (Local or remote model server)
+- Install locally: Download from https://ollama.ai
+- Configure remote: Set `OLLAMA_HOST` environment variable
+- Default: `http://localhost:11434`
+- License: MIT
+- Source: https://github.com/ollama/ollama
+- Usage: RAPTOR connects to Ollama server for local model inference
+- Note: User installs separately, supports both local and remote servers
+
 **rr** (Record-replay debugger)
 - Install: `apt install rr` (Linux) or build from https://github.com/rr-debugger/rr
 - License: MIT

--- a/README.md
+++ b/README.md
@@ -243,6 +243,34 @@ Model selection and API use is handled through Claude Code natively.
 **Note:** Exploit generation requires frontier models (Claude, GPT, or Gemini). Local
 models work for analysis but may produce non-compilable exploit code.
 
+### Environment Variables
+
+**LLM Configuration:**
+- `ANTHROPIC_API_KEY` - Anthropic Claude API key
+- `OPENAI_API_KEY` - OpenAI API key
+- `OLLAMA_HOST` - Ollama server URL (default: `http://localhost:11434`)
+
+**Ollama Examples:**
+```bash
+# Local Ollama (default)
+export OLLAMA_HOST=http://localhost:11434
+
+# Remote Ollama server
+export OLLAMA_HOST=https://ollama.example.com:11434
+
+# Remote with custom port
+export OLLAMA_HOST=http://192.168.1.100:8080
+```
+
+**Performance Tuning:**
+
+Remote Ollama servers automatically use longer retry delays (5 seconds vs 2 seconds for local) to account for network latency and processing time, reducing JSON parsing errors.
+
+| Server Type | Base Delay | Retry 1 | Retry 2 | Retry 3 |
+|-------------|------------|---------|---------|---------|
+| **Local** | 2.0s | 2s | 4s | 8s |
+| **Remote** | 5.0s | 5s | 10s | 20s |
+
 ---
 
 ## Python CLI (Alternative)

--- a/core/config.py
+++ b/core/config.py
@@ -91,6 +91,9 @@ class RaptorConfig:
     ENV_JOB_ID = "RAPTOR_JOB_ID"
     ENV_LLM_CMD = "RAPTOR_LLM_CMD"
 
+    # LLM Provider Configuration
+    OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+
     # Proxy variables to strip for security
     PROXY_ENV_VARS = [
         "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",

--- a/packages/llm_analysis/llm/client.py
+++ b/packages/llm_analysis/llm/client.py
@@ -184,8 +184,9 @@ class LLMClient:
                                  f"{model.provider}/{model.model_name}: {e}")
 
                     if attempt < self.config.max_retries - 1:
-                        delay = self.config.retry_delay * (2 ** attempt)  # Exponential backoff
-                        logger.debug(f"Retrying in {delay}s...")
+                        base_delay = self.config.get_retry_delay(model.api_base)
+                        delay = base_delay * (2 ** attempt)  # Exponential backoff
+                        logger.debug(f"Retrying in {delay}s (base: {base_delay}s)...")
                         time.sleep(delay)
 
             logger.warning(f"All attempts failed for {model.provider}/{model.model_name}, trying next model...")
@@ -262,7 +263,9 @@ class LLMClient:
                     logger.warning(f"Structured generation attempt {attempt + 1} failed: {e}")
 
                     if attempt < self.config.max_retries - 1:
-                        time.sleep(self.config.retry_delay)
+                        delay = self.config.get_retry_delay(model.api_base)
+                        logger.debug(f"Retrying structured generation in {delay}s...")
+                        time.sleep(delay)
 
         # All models failed
         error_msg = f"Structured generation failed for all providers. Last error: {last_error}"

--- a/packages/llm_analysis/llm/providers.py
+++ b/packages/llm_analysis/llm/providers.py
@@ -227,9 +227,15 @@ class OllamaProvider(LLMProvider):
 
     def __init__(self, config: ModelConfig):
         super().__init__(config)
-        self.api_base = config.api_base or "http://localhost:11434"
+        if not config.api_base:
+            raise ValueError("Ollama api_base must be configured in ModelConfig")
+        self.api_base = config.api_base
         self.session = requests.Session()
         self.available_models = []
+
+        # Log initialization
+        logger.info(f"Initializing Ollama provider: {self.api_base}")
+        logger.debug(f"Ollama configuration: model={config.model_name}, timeout={config.timeout}s")
 
         # Verify Ollama is available and check models
         try:
@@ -247,8 +253,12 @@ class OllamaProvider(LLMProvider):
                 logger.warning(f"Ollama server returned {response.status_code} at {self.api_base}")
                 raise RuntimeError(f"Ollama not available: {response.status_code}")
         except requests.exceptions.RequestException as e:
-            logger.error(f"Cannot connect to Ollama at {self.api_base}: {e}")
-            logger.error("Make sure Ollama is running: ollama serve")
+            logger.error(f"Cannot connect to Ollama server at {self.api_base}: {e}")
+            if "localhost" in self.api_base or "127.0.0.1" in self.api_base:
+                logger.error("Make sure Ollama is running locally: ollama serve")
+            else:
+                logger.error(f"Check remote Ollama server is accessible: {self.api_base}")
+                logger.error("Verify network connectivity and firewall settings")
             raise RuntimeError(f"Ollama connection failed: {e}")
 
     def generate(self, prompt: str, system_prompt: Optional[str] = None,
@@ -275,7 +285,7 @@ class OllamaProvider(LLMProvider):
                 payload["system"] = system_prompt
 
             logger.debug(f"Sending request to Ollama: {self.api_base}/api/generate")
-            logger.debug(f"Model: {self.config.model_name}")
+            logger.debug(f"Model: {self.config.model_name}, timeout: {self.config.timeout}s")
 
             response = self.session.post(
                 f"{self.api_base}/api/generate",
@@ -321,10 +331,17 @@ class OllamaProvider(LLMProvider):
 
         except requests.exceptions.Timeout:
             logger.error(f"Ollama request timed out after {self.config.timeout}s")
+            if "localhost" not in self.api_base and "127.0.0.1" not in self.api_base:
+                logger.error(f"Remote server {self.api_base} may be slow or overloaded")
+                logger.error("Consider increasing timeout in ModelConfig")
             raise
         except requests.exceptions.ConnectionError as e:
             logger.error(f"Cannot connect to Ollama at {self.api_base}")
-            logger.error("Make sure Ollama is running: ollama serve")
+            if "localhost" in self.api_base or "127.0.0.1" in self.api_base:
+                logger.error("Make sure Ollama is running locally: ollama serve")
+            else:
+                logger.error(f"Check remote Ollama server is accessible: {self.api_base}")
+                logger.error("Verify network connectivity and firewall settings")
             raise RuntimeError(f"Ollama connection failed: {e}")
         except Exception as e:
             logger.error(f"Ollama API error: {e}")

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -416,11 +416,13 @@ Examples:
         # Check if Ollama is running
         try:
             import requests
-            response = requests.get("http://localhost:11434/api/tags", timeout=2)
+            response = requests.get(f"{RaptorConfig.OLLAMA_HOST}/api/tags", timeout=2)
             if response.status_code == 200:
                 llm_available = True
-                logger.info("Ollama server detected")
-        except Exception:
+                logger.info(f"Ollama server detected at {RaptorConfig.OLLAMA_HOST}")
+                logger.debug(f"Ollama available at {RaptorConfig.OLLAMA_HOST}")
+        except Exception as e:
+            logger.debug(f"Ollama not available at {RaptorConfig.OLLAMA_HOST}: {e}")
             pass
 
     analysis = {}


### PR DESCRIPTION
This commit implements two major features for Ollama LLM integration:

1. External Ollama Server Support (OLLAMA_HOST)
   - Add OLLAMA_HOST environment variable for configurable server URL
   - Replace all hardcoded localhost:11434 references throughout architecture
   - Implement URL validation requiring http:// or https:// protocol
   - Enhance error messages to differentiate local vs remote server issues
   - Add comprehensive logging for connection attempts and failures
   - Default: http://localhost:11434 (backwards compatible)

2. Intelligent Retry Delays
   - Implement server location detection (local vs remote)
   - Remote servers: 5s base delay (vs 2s for local)
   - Apply exponential backoff on retry delays
   - Reduce JSON parsing errors from remote Ollama servers
   - Add get_retry_delay() method to LLMConfig for dynamic delay selection

Modified files:
- core/config.py: Add OLLAMA_HOST configuration constant
- packages/llm_analysis/llm/config.py: Add URL validation, retry_delay_remote field, get_retry_delay() method
- packages/llm_analysis/llm/providers.py: Enhanced error handling and logging for local/remote servers
- packages/llm_analysis/llm/client.py: Dynamic retry delays with exponential backoff
- raptor_agentic.py: Use OLLAMA_HOST for Ollama availability checks
- README.md: Document OLLAMA_HOST environment variable and performance tuning
- DEPENDENCIES.md: Add Ollama documentation with remote server configuration
- .gitignore: Add codeql_dbs/ to ignore list

All changes maintain backwards compatibility with existing configurations. Tested with both local and remote Ollama servers successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)