### PR TITLE
Fix: LLM analysis orchestrator ignores max findings option

### DIFF
--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -147,8 +147,8 @@ class AgenticOrchestrator:
             # Note: the agent processes all findings; limiting behaviour is enforced
             # in the agent implementation.
 
-        # Process findings autonomously, passing SARIF paths
-        results = agent.process_findings(sarif_paths)
+        # Process findings autonomously, passing SARIF paths and max_findings limit
+        results = agent.process_findings(sarif_paths, max_findings)
 
         # Generate orchestration report from agent results
         report: Dict[str, Any] = {


### PR DESCRIPTION
## Problem

The orchestrator was ignoring the `--max-findings` command-line parameter and always processing only 10 findings, regardless of what value the user specified.

**Example:**
```bash
# User requests 50 findings
$ python orchestrator.py --repo /path --max-findings 50

# But only 10 are processed (default value from agent.py)
Processed: 10 findings
```

## Root Cause

In `packages/llm_analysis/orchestrator.py:151`, the orchestrator called `agent.process_findings()` without passing the `max_findings` parameter:

```python
# ❌ Before: Missing parameter
results = agent.process_findings(sarif_paths)
```

**The Issue:**
- The orchestrator receives `max_findings` from CLI args (line 361)
- It logs the value and warns if limiting (lines 143-146)
- But it **never forwards** the parameter to the agent
- The agent uses its default value of `10` instead

## Solution

Pass the `max_findings` parameter to `agent.process_findings()`:

```python
# ✅ After: Parameter passed correctly
results = agent.process_findings(sarif_paths, max_findings)
```

## Impact

**Before:**
```bash
$ python orchestrator.py --repo /path --max-findings 50
# Processes only 10 findings (parameter ignored)
```

**After:**
```bash
$ python orchestrator.py --repo /path --max-findings 50
# Processes 50 findings (parameter respected)
```

**Benefits:**
- ✅ Users can now control analysis scope with `--max-findings`
- ✅ Default behavior unchanged (still 10)
- ✅ Warning messages now match actual behavior
- ✅ Allows processing large finding sets when needed

## Testing

```bash
# Test default (10 findings)
python orchestrator.py --repo /path
# Expected: Processes 10 findings ✓

# Test custom limit (50 findings)
python orchestrator.py --repo /path --max-findings 50
# Expected: Processes 50 findings ✓

# Test with fewer findings than limit
python orchestrator.py --repo /path --max-findings 100
# If only 20 findings exist, processes 20 ✓
```

## Files Changed

- `packages/llm_analysis/orchestrator.py` - 1 file, +2 insertions, -2 deletions

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
