### PR TITLE
Add stub/alpha warning to /web command

### DIFF
--- a/.claude/commands/raptor-web.md
+++ b/.claude/commands/raptor-web.md
@@ -1,8 +1,8 @@
 # RAPTOR Web Application Scanner
 
-You are helping the user scan a web application for security vulnerabilities.
+WARNING: /web is a STUB and should not be relied upon. Consider a placeholder/in alpha.
 
-## Your Task
+You are helping the user scan a web application for security vulnerabilities.
 
 1. **Understand the target**: Get the web application URL
    - Full URL (e.g., https://example.com)

--- a/raptor.py
+++ b/raptor.py
@@ -98,12 +98,15 @@ def mode_web(args: list) -> int:
     """Run web application security testing."""
     script_root = Path(__file__).parent
     web_script = script_root / "packages/web/scanner.py"
-    
+
     if not web_script.exists():
         print(f"✗ Web scanner not found: {web_script}")
         return 1
-    
-    print("\n[*] Running web application scanner...\n")
+
+    # Display alpha warning
+    print("\nWARNING: /web is a STUB and should not be relied upon. Consider a placeholder/in alpha.\n")
+
+    print("[*] Running web application scanner...\n")
     return run_script(web_script, args)
 
 


### PR DESCRIPTION
# Add stub/alpha warning to /web command

## Summary

Adds a simple warning to the `/web` command indicating it's a stub/placeholder in alpha.

**Warning displayed:**
```
WARNING: /web is a STUB and should not be relied upon. Consider a placeholder/in alpha.
```

## Changes

- `.claude/commands/raptor-web.md`: Warning for Claude Code users
- `raptor.py`: Warning for direct Python invocation

## Display Locations

1. **Claude Code**: When user types `/web` or `/raptor-web`
2. **Direct invocation**: When running `python3 raptor.py web`

## Testing

```bash
# Test 1: Direct Python invocation
python3 raptor.py web

# Output shows:
# WARNING: /web is a STUB and should not be relied upon. Consider a placeholder/in alpha.
```

```bash
# Test 2: Claude Code
# User types: /web
# Claude shows warning before proceeding
```

## Type of Change

- [x] Documentation update
- [x] User-facing warning

## Impact

- **Users**: Will see warning before using /web scanner
- **Code**: Minimal - just print statements added
- **Breaking**: No breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Highlights that the web scanner is not production-ready.
> 
> - `raptor.py`: Prints `WARNING: /web is a STUB and should not be relied upon. Consider a placeholder/in alpha.` before running the web scanner
> - `.claude/commands/raptor-web.md`: Adds the same warning at the top of the command guide
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 728d6b074eab4f852f3368b0843987f2cbf0ae56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->