### PR TITLE
Fix NameError in dataflow validation error logging

### DIFF
--- a/packages/codeql/dataflow_validator.py
+++ b/packages/codeql/dataflow_validator.py
@@ -210,7 +210,7 @@ class DataflowValidator:
             path_summary.append(f"STEP {i}: {step.label}")
             path_summary.append(f"  {step.file_path}:{step.line}")
 
-        path_summary.append(f"SINK: {sink.label}")
+        path_summary.append(f"SINK: {dataflow.sink.label}")
         path_summary.append(f"  {dataflow.sink.file_path}:{dataflow.sink.line}")
 
         # Create validation prompt


### PR DESCRIPTION
Fixes #39

## Summary
Fixes undefined variable reference in dataflow validator error handling.

## Changes
- **File:** packages/codeql/dataflow_validator.py:213
- **Fix:** `sink.label` → `dataflow.sink.label`

## Impact
- Prevents secondary NameError when logging validation failures
- Low risk, single line change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a crash when building the dataflow path summary by referencing the sink label correctly.
> 
> - In `packages/codeql/dataflow_validator.py`, changes `SINK:` summary line from `sink.label` to `dataflow.sink.label` to prevent a `NameError` during validation logging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c18bbe718415632bfa9d8e9004c8fcd9d92e959b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->