### PR TITLE
Add shlex import for future shell command escaping

### DIFF
--- a/packages/codeql/build_detector.py
+++ b/packages/codeql/build_detector.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from shlex import quote
 from typing import Dict, List, Optional
 import xml.etree.ElementTree as ET
 


### PR DESCRIPTION
## Summary
Adds `shlex.quote` import to build_detector.py as preventative measure for future wrapper script generation that will need proper path escaping.

## Problem
Repository paths with spaces, quotes, or special characters (e.g., `/Users/dev/My Projects/app`) must be properly escaped when used in shell commands to prevent failures and potential security issues.

Issue #43 identifies lines 452, 466, and 472 in build_detector.py as locations where wrapper scripts are generated without proper escaping. However, **this code does not currently exist in the codebase**.

## Changes

### File: `packages/codeql/build_detector.py`
**Line:** 14 (imports section)

Added:
```python
from shlex import quote
```

This import will be available when wrapper script generation is implemented in the future.

## Type of Change
- [x] Enhancement (preventative improvement)
- [ ] Bug fix

## Status
This is a **preventative PR**. The wrapper script generation code referenced in issue #43 does not exist in the current codebase. This PR adds the necessary import so it's available when wrapper scripts are implemented.

## Future Implementation
When wrapper scripts are added, paths should be escaped like:
```python
cd {quote(str(self.repo_path))}  # Properly escaped
```

Instead of:
```python
cd {self.repo_path}  # Vulnerable to special characters
```

## Impact
- **Risk:** None - Only adds an import
- **Scope:** Future wrapper script generation
- **Breaking:** No
- **Performance:** None (import only)

Related to #43 (preventative fix)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds import only; no runtime behavior changes.
> 
> - In `packages/codeql/build_detector.py`, added `from shlex import quote` in the imports to enable proper shell escaping when wrapper scripts are implemented later.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bba41cec94a07e559dc728a262ead2e9110d8ef8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->