### PR TITLE
Add automatic thinking model selection and update to latest versions

### DIFF
--- a/packages/llm_analysis/llm/config.py
+++ b/packages/llm_analysis/llm/config.py
@@ -72,6 +72,11 @@ def _get_litellm_models() -> List[Dict]:
         with open(litellm_config_path) as f:
             config = yaml.safe_load(f)
 
+        # Handle empty YAML file (yaml.safe_load returns None for empty files)
+        if config is None:
+            logger.debug("LiteLLM config file is empty or contains only comments")
+            return []
+
         # Validate model_list is actually a list (not int, bool, string, etc.)
         model_list = config.get('model_list', [])
         if not isinstance(model_list, list):


### PR DESCRIPTION
Automatically selects best thinking/reasoning model from LiteLLM config and updates all models to latest versions.

**Changes:**
- Add _get_litellm_models() to read config
- Add _get_best_thinking_model() with priority scoring
- Update to latest models (GPT-5.2, Gemini 3, Claude 4.5)
- Use LiteLLM aliases (stable naming)

**Priority:** Opus 4.5 (110) > GPT-5.2-thinking (105) > Gemini 3 deep-think (100)

**Testing:** Auto-selection verified, fallback tested
**Breaking Changes:** None (better defaults)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces automatic selection of a reasoning-capable model from LiteLLM and refreshes model defaults to latest versions.
> 
> - Adds `_get_litellm_models` and `_get_best_thinking_model` to read LiteLLM YAML and score/select reasoning models (e.g., `claude-opus-4.5`, `gpt-5.2-thinking`, `gemini-3-deep-think`)
> - Updates `_get_default_primary_model` to prefer the auto-selected model; refreshes provider defaults (`gpt-5.2`, `claude-sonnet-4.5`, `gemini-3-pro`) with new `max_tokens` and `cost_per_1k_tokens`
> - Expands `_get_default_fallback_models` to include multiple cloud options per provider and first 3 Ollama models; standardizes on LiteLLM aliases
> - Adds `yaml` dependency and improves debug/log messages
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbf4cc6c1fbcb53cb1015bd94d58548912eb300e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->