### PR TITLE
Add Pydantic validation for LiteLLM configs

### DIFF
--- a/packages/llm_analysis/llm/config.py
+++ b/packages/llm_analysis/llm/config.py
@@ -72,6 +72,11 @@ def _get_litellm_models() -> List[Dict]:
         with open(litellm_config_path) as f:
             config = yaml.safe_load(f)
 
+        # Handle empty YAML file (yaml.safe_load returns None for empty files)
+        if config is None:
+            logger.debug("LiteLLM config file is empty or contains only comments")
+            return []
+
         # Validate model_list is actually a list (not int, bool, string, etc.)
         model_list = config.get('model_list', [])
         if not isinstance(model_list, list):

--- a/packages/llm_analysis/llm/config.py
+++ b/packages/llm_analysis/llm/config.py
@@ -276,7 +276,7 @@ def _get_default_primary_model() -> 'ModelConfig':
     # Fallback to Claude (will fail if no API key, but that's expected)
     return ModelConfig(
         provider="anthropic",
-        model_name="claude-opus-4-5-20251101",
+        model_name="claude-opus-4.5",  # Use LiteLLM alias (consistent with other models)
         api_key=os.getenv("ANTHROPIC_API_KEY", ""),
         max_tokens=8192,
         temperature=0.7,

--- a/packages/llm_analysis/llm/config.py
+++ b/packages/llm_analysis/llm/config.py
@@ -128,14 +128,18 @@ def _get_best_thinking_model() -> Optional['ModelConfig']:
             continue
 
         try:
-            model_name = model_entry.get('model_name', '')
-
             # Handle explicit null values (Issue: dict.get() default only used for missing keys, not null)
+            model_name = model_entry.get('model_name', '')
+            if model_name is None:
+                model_name = ''
+
             litellm_params = model_entry.get('litellm_params', {})
             if litellm_params is None:
                 litellm_params = {}
 
             underlying_model = litellm_params.get('model', '')
+            if underlying_model is None:
+                underlying_model = ''
 
             model_info = model_entry.get('model_info', {})
             if model_info is None:

--- a/packages/llm_analysis/llm/config.py
+++ b/packages/llm_analysis/llm/config.py
@@ -154,8 +154,12 @@ def _get_best_thinking_model() -> Optional['ModelConfig']:
                     if score > best_score:
                         best_score = score
 
+                        # Determine which model string to use for provider/cost extraction
+                        # If underlying_model is empty or invalid, fall back to pattern's exact_model
+                        model_for_metadata = underlying_model if underlying_model and '/' in underlying_model else exact_model
+
                         # Extract provider and API key
-                        provider = underlying_model.split('/')[0] if '/' in underlying_model else 'unknown'
+                        provider = model_for_metadata.split('/')[0] if '/' in model_for_metadata else 'unknown'
 
                         # Handle both os.environ/VAR format and literal API keys
                         # Handle explicit null: dict.get() returns None, not default, if key exists with null value
@@ -177,8 +181,9 @@ def _get_best_thinking_model() -> Optional['ModelConfig']:
                         # Extract actual model ID from "provider/model-id" format
                         actual_model_name = underlying_model.split('/')[-1] if '/' in underlying_model else model_name
 
-                        # Determine cost based on actual model tier (use underlying_model, not alias)
-                        is_opus = 'opus' in underlying_model.lower()
+                        # Determine cost based on actual model tier
+                        # Use model_for_metadata (not alias) to ensure correct cost even when matched by alias
+                        is_opus = 'opus' in model_for_metadata.lower()
                         cost_per_1k = 0.015 if is_opus else 0.005
 
                         best_model = ModelConfig(

--- a/packages/llm_analysis/llm/config.py
+++ b/packages/llm_analysis/llm/config.py
@@ -72,7 +72,13 @@ def _get_litellm_models() -> List[Dict]:
         with open(litellm_config_path) as f:
             config = yaml.safe_load(f)
 
-        return config.get('model_list', [])
+        # Validate model_list is actually a list (not int, bool, string, etc.)
+        model_list = config.get('model_list', [])
+        if not isinstance(model_list, list):
+            logger.debug(f"LiteLLM config has non-list model_list (type: {type(model_list).__name__})")
+            return []
+
+        return model_list
     except Exception as e:
         logger.debug(f"Could not read LiteLLM config: {e}")
         return []

--- a/packages/llm_analysis/llm/yaml_schema.py
+++ b/packages/llm_analysis/llm/yaml_schema.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Pydantic schemas for validating LiteLLM YAML configuration.
+
+Provides schema validation at config load time to catch edge cases early:
+- Type mismatches (model_list as int instead of list)
+- Missing required fields (model_name, litellm_params)
+- Invalid formats (model without provider prefix)
+- Invalid ranges (temperature outside 0.0-2.0)
+- Duplicate model aliases
+
+Usage:
+    from .yaml_schema import LiteLLMConfigSchema
+
+    config_dict = yaml.safe_load(f)
+    validated = LiteLLMConfigSchema.model_validate(config_dict)
+    models = [m.model_dump() for m in validated.model_list]
+"""
+
+from pydantic import BaseModel, Field, model_validator, ConfigDict
+from typing import Optional, List
+
+
+class LiteLLMParamsSchema(BaseModel):
+    """
+    Validates litellm_params section of model entry.
+
+    Required:
+        model: Provider/model format (e.g., 'openai/gpt-4o', 'anthropic/claude-sonnet-4.5')
+
+    Optional:
+        api_key: Literal API key or 'os.environ/VAR_NAME' format
+        api_base: Custom API endpoint
+        temperature: Sampling temperature (0.0-2.0)
+        max_tokens: Maximum output tokens (> 0)
+        timeout: Request timeout in seconds
+    """
+    model: str = Field(..., description="Model in 'provider/name' format")
+    api_key: Optional[str] = Field(None, description="API key or os.environ/VAR format")
+    api_base: Optional[str] = Field(None, description="Custom API endpoint URL")
+    temperature: Optional[float] = Field(None, ge=0.0, le=2.0, description="Sampling temperature")
+    max_tokens: Optional[int] = Field(None, gt=0, description="Maximum output tokens")
+    timeout: Optional[int] = Field(None, gt=0, description="Request timeout in seconds")
+
+    # Allow additional fields (LiteLLM supports many provider-specific params)
+    model_config = ConfigDict(extra="allow")
+
+    @model_validator(mode='after')
+    def validate_model_format(self):
+        """Ensure model follows 'provider/name' format."""
+        if not self.model or '/' not in self.model:
+            raise ValueError(
+                f"Model must be in 'provider/name' format (e.g., 'openai/gpt-4o'), "
+                f"got: '{self.model}'. Check litellm_params.model field."
+            )
+
+        # Validate provider is not empty
+        provider, model_name = self.model.split('/', 1)
+        if not provider or not model_name:
+            raise ValueError(
+                f"Both provider and model name must be non-empty, "
+                f"got: '{self.model}'"
+            )
+
+        return self
+
+    @model_validator(mode='after')
+    def validate_api_key_format(self):
+        """Validate API key format if provided."""
+        if self.api_key and self.api_key.startswith('$'):
+            raise ValueError(
+                f"API key uses shell variable syntax: '{self.api_key}'. "
+                f"Use 'os.environ/VAR_NAME' format instead."
+            )
+        return self
+
+
+class ModelInfoSchema(BaseModel):
+    """
+    Validates model_info section of model entry.
+
+    All fields are optional. Provides metadata about model capabilities.
+
+    Common fields:
+        max_input_tokens: Maximum input context size
+        max_output_tokens: Maximum output token limit
+        supports_vision: Whether model supports image inputs
+        supports_function_calling: Whether model supports function/tool calling
+        supports_reasoning: Whether model has explicit reasoning mode (e.g., o1, gemini-deep-think)
+    """
+    max_input_tokens: Optional[int] = Field(None, gt=0, description="Maximum input tokens")
+    max_output_tokens: Optional[int] = Field(None, gt=0, description="Maximum output tokens")
+    supports_vision: Optional[bool] = Field(None, description="Supports image inputs")
+    supports_function_calling: Optional[bool] = Field(None, description="Supports function calling")
+    supports_reasoning: Optional[bool] = Field(None, description="Has explicit reasoning mode")
+
+    # Allow additional capability flags
+    model_config = ConfigDict(extra="allow")
+
+
+class ModelEntrySchema(BaseModel):
+    """
+    Validates a single model entry in model_list.
+
+    Required:
+        model_name: Alias/friendly name for this model (must be unique)
+        litellm_params: Configuration for LiteLLM (provider, model ID, API key, etc.)
+
+    Optional:
+        model_info: Metadata about model capabilities
+    """
+    model_name: str = Field(..., description="Alias for this model (must be unique)")
+    litellm_params: LiteLLMParamsSchema = Field(..., description="LiteLLM configuration")
+    model_info: Optional[ModelInfoSchema] = Field(None, description="Model capabilities metadata")
+
+    @model_validator(mode='after')
+    def validate_model_name_not_empty(self):
+        """Ensure model_name is not empty or whitespace-only."""
+        if not self.model_name or not self.model_name.strip():
+            raise ValueError(
+                "model_name cannot be empty or whitespace-only. "
+                "Provide a unique alias for this model."
+            )
+        return self
+
+
+class LiteLLMConfigSchema(BaseModel):
+    """
+    Validates entire LiteLLM config.yaml file.
+
+    Top-level structure:
+        model_list: List of model entries (required, can be empty)
+
+    Validation:
+        - model_list must be a list (not int, string, bool, null)
+        - Each entry must be a valid ModelEntrySchema
+        - No duplicate model_name aliases allowed
+    """
+    model_list: List[ModelEntrySchema] = Field(
+        default_factory=list,
+        description="List of available models"
+    )
+
+    @model_validator(mode='after')
+    def validate_no_duplicate_aliases(self):
+        """Ensure model_name aliases are unique."""
+        if not self.model_list:
+            return self  # Empty list is valid
+
+        aliases = [m.model_name for m in self.model_list]
+        seen = set()
+        duplicates = set()
+
+        for alias in aliases:
+            if alias in seen:
+                duplicates.add(alias)
+            seen.add(alias)
+
+        if duplicates:
+            raise ValueError(
+                f"Duplicate model_name aliases found: {sorted(duplicates)}. "
+                f"Each model must have a unique alias. Check your config.yaml model_list."
+            )
+
+        return self


### PR DESCRIPTION
# Add Pydantic Validation for LiteLLM Configs

## What

Validates LiteLLM YAML configuration files at load time using Pydantic schemas.

## Why

Provides immediate, clear error messages for invalid configs instead of runtime failures.

## Changes

- `yaml_schema.py` - Pydantic validation schemas (169 lines)
- `config.py` - Validation integration  
- `litellm-model-configuration-guide.md` - Documentation (331 lines)

## Validation Rules

- Model format: `provider/name` (e.g., `openai/gpt-4o`)
- Temperature: 0.0-2.0
- Max tokens: positive integers
- No duplicate model names
- Required fields enforced

## Backward Compatible

No breaking changes. Invalid configs return empty list and fall back to environment variables.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces schema-validated LiteLLM config loading and smarter model selection with updated defaults.
> 
> - New `yaml_schema.py` (Pydantic) validates `model_list`, `litellm_params`, and `model_info` (format/ranges/duplicates) and is used in `config.py` when reading YAML from standard paths or `LITELLM_CONFIG_PATH`
> - Adds `_get_litellm_models` and `_get_best_thinking_model` to discover and score models (reasoning-capable prioritized), including env-var API key resolution, and cost tiering (`COST_OPUS_PER_1K`, `COST_DEFAULT_PER_1K`)
> - Updates default primary model selection: try auto-selected thinking model first; else fall back to API keys (Anthropic/OpenAI/Gemini) using latest aliases and larger `max_tokens`; else Ollama; final Claude fallback
> - Expands fallback model list: includes Opus/Sonnet, GPT-5.2 (+ thinking), Gemini 3 (pro + deep-think), and first 3 local Ollama models; uses LiteLLM aliases and tier-aware behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ceb9c6a335f4df9fa09fb91a49e44d5625a9f36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->