### PR TITLE
Fix Gemini 3 model names to match actual API

### DIFF
--- a/packages/llm_analysis/llm/config.py
+++ b/packages/llm_analysis/llm/config.py
@@ -72,6 +72,11 @@ def _get_litellm_models() -> List[Dict]:
         with open(litellm_config_path) as f:
             config = yaml.safe_load(f)
 
+        # Handle empty YAML file (yaml.safe_load returns None for empty files)
+        if config is None:
+            logger.debug("LiteLLM config file is empty or contains only comments")
+            return []
+
         # Validate model_list is actually a list (not int, bool, string, etc.)
         model_list = config.get('model_list', [])
         if not isinstance(model_list, list):

--- a/packages/llm_analysis/llm/config.py
+++ b/packages/llm_analysis/llm/config.py
@@ -276,7 +276,7 @@ def _get_default_primary_model() -> 'ModelConfig':
     # Fallback to Claude (will fail if no API key, but that's expected)
     return ModelConfig(
         provider="anthropic",
-        model_name="claude-opus-4-5-20251101",
+        model_name="claude-opus-4.5",  # Use LiteLLM alias (consistent with other models)
         api_key=os.getenv("ANTHROPIC_API_KEY", ""),
         max_tokens=8192,
         temperature=0.7,

--- a/packages/llm_analysis/llm/config.py
+++ b/packages/llm_analysis/llm/config.py
@@ -128,14 +128,18 @@ def _get_best_thinking_model() -> Optional['ModelConfig']:
             continue
 
         try:
-            model_name = model_entry.get('model_name', '')
-
             # Handle explicit null values (Issue: dict.get() default only used for missing keys, not null)
+            model_name = model_entry.get('model_name', '')
+            if model_name is None:
+                model_name = ''
+
             litellm_params = model_entry.get('litellm_params', {})
             if litellm_params is None:
                 litellm_params = {}
 
             underlying_model = litellm_params.get('model', '')
+            if underlying_model is None:
+                underlying_model = ''
 
             model_info = model_entry.get('model_info', {})
             if model_info is None:

--- a/packages/llm_analysis/llm/config.py
+++ b/packages/llm_analysis/llm/config.py
@@ -94,7 +94,7 @@ def _get_best_thinking_model() -> Optional['ModelConfig']:
     Automatically select the best thinking/reasoning model from LiteLLM config.
 
     Priority:
-    1. Models with explicit reasoning support (gpt-5.2-thinking, gemini-3-deep-think)
+    1. Models with explicit reasoning support (gpt-5.2-thinking, gemini-3-pro-preview)
     2. Most capable models (Opus > Sonnet > others)
     3. Latest versions
 
@@ -111,7 +111,7 @@ def _get_best_thinking_model() -> Optional['ModelConfig']:
         # Tier 1: Most capable models (Opus is preferred for deep reasoning)
         ("anthropic/claude-opus-4.5", "claude-opus-4.5", 110),          # Most capable overall (preferred)
         ("openai/gpt-5.2-thinking", "gpt-5.2-thinking", 95),            # GPT-5.2 with thinking (gets +10 = 105 total)
-        ("gemini/gemini-3-deep-think", "gemini-3-deep-think", 90),      # Gemini reasoning (gets +10 = 100 total)
+        ("gemini/gemini-3-pro-preview", "gemini-3-pro-preview", 90),    # Gemini 3 Pro (thinking built-in)
 
         # Tier 2: Strong models
         ("anthropic/claude-opus-4", "claude-opus-4", 85),               # Previous Opus
@@ -119,7 +119,7 @@ def _get_best_thinking_model() -> Optional['ModelConfig']:
 
         # Tier 3: Latest capable models (fallback)
         ("anthropic/claude-sonnet-4.5", "claude-sonnet-4.5", 70),       # Latest Sonnet
-        ("gemini/gemini-3-pro", "gemini-3-pro", 65),                    # Latest Gemini
+        ("gemini/gemini-3-flash-preview", "gemini-3-flash-preview", 65), # Gemini 3 Flash
     ]
 
     # Find best matching model
@@ -288,9 +288,9 @@ def _get_default_primary_model() -> 'ModelConfig':
     if os.getenv("GEMINI_API_KEY"):
         return ModelConfig(
             provider="gemini",
-            model_name="gemini-3-pro",  # Use LiteLLM alias (not gemini-3.0-pro-latest!)
+            model_name="gemini-3-pro-preview",  # Gemini 3 Pro with thinking
             api_key=os.getenv("GEMINI_API_KEY"),
-            max_tokens=8192,
+            max_tokens=65536,
             temperature=0.7,
             cost_per_1k_tokens=0.0001,
         )
@@ -384,22 +384,22 @@ def _get_default_fallback_models() -> List['ModelConfig']:
         ))
 
     if os.getenv("GEMINI_API_KEY"):
-        # Add reasoning model + latest Gemini
+        # Gemini 3 models (thinking built-in)
         fallbacks.append(ModelConfig(
             provider="gemini",
-            model_name="gemini-3-deep-think",  # LiteLLM alias for reasoning
+            model_name="gemini-3-pro-preview",  # Gemini 3 Pro with thinking
             api_key=os.getenv("GEMINI_API_KEY"),
-            max_tokens=8192,
+            max_tokens=65536,
             temperature=0.7,
-            cost_per_1k_tokens=0.0002,
+            cost_per_1k_tokens=0.0001,
         ))
         fallbacks.append(ModelConfig(
             provider="gemini",
-            model_name="gemini-3-pro",  # LiteLLM alias (NOT gemini-3.0-pro-latest!)
+            model_name="gemini-3-flash-preview",  # Gemini 3 Flash with thinking
             api_key=os.getenv("GEMINI_API_KEY"),
-            max_tokens=8192,
+            max_tokens=65536,
             temperature=0.7,
-            cost_per_1k_tokens=0.0001,
+            cost_per_1k_tokens=0.00005,
         ))
 
     # Add all available local models

--- a/packages/llm_analysis/llm/config.py
+++ b/packages/llm_analysis/llm/config.py
@@ -154,8 +154,12 @@ def _get_best_thinking_model() -> Optional['ModelConfig']:
                     if score > best_score:
                         best_score = score
 
+                        # Determine which model string to use for provider/cost extraction
+                        # If underlying_model is empty or invalid, fall back to pattern's exact_model
+                        model_for_metadata = underlying_model if underlying_model and '/' in underlying_model else exact_model
+
                         # Extract provider and API key
-                        provider = underlying_model.split('/')[0] if '/' in underlying_model else 'unknown'
+                        provider = model_for_metadata.split('/')[0] if '/' in model_for_metadata else 'unknown'
 
                         # Handle both os.environ/VAR format and literal API keys
                         # Handle explicit null: dict.get() returns None, not default, if key exists with null value
@@ -177,8 +181,9 @@ def _get_best_thinking_model() -> Optional['ModelConfig']:
                         # Extract actual model ID from "provider/model-id" format
                         actual_model_name = underlying_model.split('/')[-1] if '/' in underlying_model else model_name
 
-                        # Determine cost based on actual model tier (use underlying_model, not alias)
-                        is_opus = 'opus' in underlying_model.lower()
+                        # Determine cost based on actual model tier
+                        # Use model_for_metadata (not alias) to ensure correct cost even when matched by alias
+                        is_opus = 'opus' in model_for_metadata.lower()
                         cost_per_1k = 0.015 if is_opus else 0.005
 
                         best_model = ModelConfig(

--- a/packages/llm_analysis/llm/config.py
+++ b/packages/llm_analysis/llm/config.py
@@ -72,7 +72,13 @@ def _get_litellm_models() -> List[Dict]:
         with open(litellm_config_path) as f:
             config = yaml.safe_load(f)
 
-        return config.get('model_list', [])
+        # Validate model_list is actually a list (not int, bool, string, etc.)
+        model_list = config.get('model_list', [])
+        if not isinstance(model_list, list):
+            logger.debug(f"LiteLLM config has non-list model_list (type: {type(model_list).__name__})")
+            return []
+
+        return model_list
     except Exception as e:
         logger.debug(f"Could not read LiteLLM config: {e}")
         return []


### PR DESCRIPTION
## Summary
- Fix incorrect Gemini model names that cause 404 errors
- `gemini-3-deep-think` → `gemini-3-pro-preview` (no separate deep-think variant)
- `gemini-3-pro` → `gemini-3-pro-preview` / `gemini-3-flash-preview`
- Update max_tokens from 8192 to 65536

## Verification
Tested via Google API - confirmed `gemini-3-pro-preview` and `gemini-3-flash-preview` are correct names. Both have thinking built-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns Gemini 3 model identifiers and defaults with the actual API.
> 
> - Replace `gemini-3-deep-think` with `gemini-3-pro-preview` and `gemini-3-pro` with `gemini-3-flash-preview` in thinking-model selection and fallbacks
> - Set Gemini default primary model to `gemini-3-pro-preview` with `max_tokens` 65536; update fallbacks to use `gemini-3-pro-preview` and `gemini-3-flash-preview`
> - Adjust Gemini cost settings (`pro-preview` 0.0001, `flash-preview` 0.00005) and increase `max_tokens` from 8192 to 65536 where applicable
> - Update comments/docstrings to reflect new model names and reasoning support
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d89bb1cf05b7824aa32adad7b6a0c3560d672529. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->