### PR TITLE
Deleting artifacts requires higher permissions so leave this out for now

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,7 @@ jobs:
           name: venv-${{ github.run_id }}
           path: ${{ env.VENV_PATH }}
           include-hidden-files: true
+          retention-days: 1
 
   python-unit-tests:
     runs-on: ubuntu-latest
@@ -106,17 +107,3 @@ jobs:
     with:
       test_script: integration_tests.sh
       venv_artifact_name: venv-${{ github.run_id }}
-
-  cleanup:
-    runs-on: ubuntu-latest
-    permissions:
-     actions: write
-    needs: [python-unit-tests, test-workflows, test-fast, test-real, test-comprehensive, test-integration]
-    if: always()
-    steps:
-      - name: Delete venv artifact
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          ARTIFACT_ID=$(gh api /repos/${{ github.repository }}/actions/artifacts?name=venv-${{ github.run_id }} --jq '.artifacts[0].id')
-          gh api -X DELETE /repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID


### PR DESCRIPTION
As can be seen [here](https://github.com/gadievron/raptor/pull/60), someone without specific permissions in the repo doesn't have permissions to the delete artifacts function.

Since the delete artifacts function is not essential, I have just removed this workflow and instead will just set the artifact lifetime to as short as possible.