### PR TITLE
Correct docker build command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ claude
 # 4. Get the devcontainer
 A devcontainer with all prerequisites pre-installed is available. Open in VS Code or any of
 its forks with command Dev Container: Open Folder in Container, or build with docker:
-docker build -f .devcontainer/Dockerfile -t raptor-devcontainer:latest ..
+
+docker build -f .devcontainer/Dockerfile -t raptor-devcontainer:latest .
 
 Runs with --privileged flag for rr.
 


### PR DESCRIPTION
Fix docker build command by removing unnecessary '.' at the end.