### PR TITLE
Fix devcontainer Dockerfile - add Yarn GPG key and repository

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,6 +11,11 @@ FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
 # Organized by component that needs them
 # ============================================================================
 
+RUN curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg \
+    | gpg --dearmor -o /usr/share/keyrings/yarnkey.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" \
+    > /etc/apt/sources.list.d/yarn.list
+
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y --no-install-recommends \
     #

--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ claude
 # 4. Get the devcontainer
 A devcontainer with all prerequisites pre-installed is available. Open in VS Code or any of
 its forks with command Dev Container: Open Folder in Container, or build with docker:
-docker build -f .devcontainer/Dockerfile -t raptor-devcontainer:latest ..
+
+docker build -f .devcontainer/Dockerfile -t raptor-devcontainer:latest .
 
 Runs with --privileged flag for rr.
 


### PR DESCRIPTION
Building on Ubuntu 24.04.4 using Docker 29.3.0 hits a missing requirement. The change fixes this by adding the Yarn repo and PGP key.

$ sudo docker build --no-cache -f .devcontainer/Dockerfile -t raptor-devcontainer:latest .
[+] Building 2.4s (6/17)                                                                                                                                                                                                                 docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                               0.0s
 => => transferring dockerfile: 5.86kB                                                                                                                                                                                                             0.0s
 => [internal] load metadata for mcr.microsoft.com/devcontainers/python:1-3.12-bookworm                                                                                                                                                            0.1s
 => [internal] load .dockerignore                                                                                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                                                                                    0.0s
 => CACHED [ 1/13] FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm@sha256:7876580dc67fd460fd962f004cbeb480027e9bbc0657096f1087db11f9eaff39                                                                                             0.0s
 => => resolve mcr.microsoft.com/devcontainers/python:1-3.12-bookworm@sha256:7876580dc67fd460fd962f004cbeb480027e9bbc0657096f1087db11f9eaff39                                                                                                      0.0s
 => [internal] load build context                                                                                                                                                                                                                  0.0s
 => => transferring context: 187B                                                                                                                                                                                                                  0.0s
 => ERROR [ 2/13] RUN apt-get update && export DEBIAN_FRONTEND=noninteractive     && apt-get install -y --no-install-recommends     python3-pip     python3-venv     git     build-essential     gcc     g++     make     cmake     autoconf       2.0s
------                                                                                                                                                                                                                                                  
 > [ 2/13] RUN apt-get update && export DEBIAN_FRONTEND=noninteractive     && apt-get install -y --no-install-recommends     python3-pip     python3-venv     git     build-essential     gcc     g++     make     cmake     autoconf     automake     libtool     libtool-bin     clang-format     gdb     gdb-multiarch     binutils     file     curl     wget     libcapnp-dev     fonts-liberation     libatk1.0-0     libatk-bridge2.0-0     libc6     libcairo2     libcap2     libcups2     libdbus-1-3     libexpat1     libfontconfig1     libgcc1     libgconf-2-4     libgdk-pixbuf2.0-0     libglib2.0-0     libgtk-3-0     libnspr4     libnss3     libpango-1.0-0     libpangocairo-1.0-0     libx11-6     libx11-xcb1     libxcb1     libxcomposite1     libxcursor1     libxdamage1     libxext6     libxfixes3     libxi6     libxrandr2     libxrender1     libxss1     libxtst6     lsb-release     ca-certificates     jq     unzip     && apt-get clean     && rm -rf /var/lib/apt/lists/*:               
0.328 Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB]                                                                                                                                                                                    
0.356 Get:2 http://deb.debian.org/debian bookworm-updates InRelease [55.4 kB]
0.362 Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
0.367 Get:4 https://dl.yarnpkg.com/debian stable InRelease
0.449 Get:5 http://deb.debian.org/debian bookworm/main amd64 Packages [8792 kB]
0.640 Err:4 https://dl.yarnpkg.com/debian stable InRelease
0.640   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 62D54FD4003F6525
0.724 Get:6 http://deb.debian.org/debian bookworm-updates/main amd64 Packages [6924 B]
0.735 Get:7 http://deb.debian.org/debian-security bookworm-security/main amd64 Packages [293 kB]
1.500 Reading package lists...
**1.973 W: GPG error: https://dl.yarnpkg.com/debian stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 62D54FD4003F6525**
**1.973 E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.**
------