### PR TITLE
feat: add block-no-verify PreToolUse hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx --yes block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #76

Adds a Claude Code PreToolUse hook that prevents the agent from bypassing git hooks when running Bash commands.

The hook configuration in .claude/settings.json uses block-no-verify@1.1.2 from https://github.com/tupe12334/block-no-verify.

Disclosure: I am the author and maintainer of block-no-verify.