### PR TITLE
Add Stage F (Self-Review) to validation pipeline documentation                                                                                                                                                   

### DIFF
--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -8,7 +8,7 @@ Validates that vulnerability findings are real, reachable, and exploitable befor
 
 ### Step-by-Step Execution
 
-**All stages are mandatory. Execute in sequence: 0 → A → B → C → D → E**
+**All stages are mandatory. Execute in sequence: 0 → A → B → C → D → E → F**
 
 1. **Stage 0 (Python):** Run `build_checklist()` to get inventory
    ```python
@@ -61,6 +61,14 @@ Validates that vulnerability findings are real, reachable, and exploitable befor
    ```
    Output: `exploit-context.json` (if binary provided)
 
+7. **Stage F (Claude):** Self-review - catch mistakes before finalizing
+   - Run schema validators against findings.json
+   - Verify Stage E verdicts mapped correctly to final_status
+   - Check proximity score consistency across same bug class
+   - Verify all preconditions cite evidence (line numbers, grep results)
+   - Ask: "What did I get wrong?" — look for misclassifications, missed instances, weak evidence
+   - Fix any issues found, document in validation-report.md under "## Stage F Review"
+
 ### Write Results Back
 
 After your analysis, save findings for Stage E:
@@ -96,11 +104,12 @@ When user runs `/validate <path>`:
 5. Stage C: Verify findings against actual code
 6. Stage D: Make rulings based on Stage B evidence
 7. Run Stage E via Python if binary provided
+8. Stage F: Self-review — catch misclassifications, fix schema errors
 
 ```
 User: /validate /tmp/vuln
        ↓
-Claude: Stage 0 → Stage A → Stage B → Stage C → Stage D → Stage E
+Claude: Stage 0 → Stage A → Stage B → Stage C → Stage D → Stage E → Stage F
               ↓
         Output: checklist.json, findings.json, attack-surface.json,
                 attack-tree.json, hypotheses.json, disproven.json,
@@ -162,7 +171,7 @@ Semgrep → SARIF (21 findings) → Dedupe (15 unique) → [LLM validation if AP
 
 ## What This Does
 
-Runs a 6-stage validation pipeline:
+Runs a 7-stage validation pipeline:
 
 | Stage | Purpose | Output |
 |-------|---------|--------|
@@ -172,8 +181,9 @@ Runs a 6-stage validation pipeline:
 | **C: Sanity** | Verify against actual code (catch hallucinations) | validated findings |
 | **D: Ruling** | Filter test code, preconditions, hedging | confirmed findings |
 | **E: Feasibility** | Binary constraint analysis (memory corruption only) | final findings |
+| **F: Review** | Self-review — catch misclassifications, schema errors | updated outputs |
 
-**Note:** Stage E only runs for memory corruption vulnerabilities (buffer_overflow, format_string, use_after_free, etc.). Web vulnerabilities skip directly to final output after Stage D.
+**Note:** Stage E only runs for memory corruption vulnerabilities (buffer_overflow, format_string, use_after_free, etc.). Web vulnerabilities skip E and proceed directly to F.
 
 ## Examples
 

--- a/packages/exploitability_validation/README.md
+++ b/packages/exploitability_validation/README.md
@@ -15,7 +15,7 @@ from packages.exploitability_validation import build_checklist
 checklist = build_checklist("/path/to/source", "/path/to/output")
 ```
 
-Stages A through D are performed by the LLM (Claude) reading source code directly. Stage E calls into `exploit_feasibility` for binary constraint analysis.
+Stages A through D and F are performed by the LLM (Claude) reading source code directly. Stage E calls into `exploit_feasibility` for binary constraint analysis.
 
 ## Pipeline Stages
 
@@ -27,6 +27,7 @@ Stages A through D are performed by the LLM (Claude) reading source code directl
 | **C** | Sanity | LLM | Verify findings against actual code (catch hallucinations) |
 | **D** | Ruling | LLM | Final determination — exploitable, confirmed, or ruled out |
 | **E** | Feasibility | Python | Binary constraint analysis (memory corruption only) |
+| **F** | Review | LLM | Self-review — catch misclassifications, fix schema errors |
 
 ```
 Stage 0 (Python)     build_checklist() → checklist.json
@@ -40,6 +41,8 @@ Stage C (LLM)       Verify code at stated lines → findings.json (sanity_check 
 Stage D (LLM)       Apply rulings → findings.json (ruling + final_status added)
     |
 Stage E (Python)     analyze_binary() + map_findings_to_constraints() → findings.json (feasibility added)
+    |
+Stage F (LLM)       Self-review → updated outputs + validation-report.md (Stage F section)
 ```
 
 ## Output Files
@@ -94,7 +97,9 @@ Stage E calls ──────────────────>  map_findi
                                    save_exploit_context(): "Persist for /exploit"
 ```
 
-Stage E only applies to memory corruption types (buffer overflow, format string, double-free, etc.). Web vulnerability types (SQLi, XSS, SSRF) complete at Stage D.
+Stage E only applies to memory corruption types (buffer overflow, format string, double-free, etc.). Web vulnerability types (SQLi, XSS, SSRF) skip E and proceed directly to F.
+
+Stage F is a mandatory self-review that catches misclassifications, schema errors, inconsistent proximity scores, and weak evidence. See [Stage F Review](../../.claude/skills/exploitability-validation/stage-f-review.md) for details.
 
 ## Testing
 


### PR DESCRIPTION
**Add Stage F (Self-Review) to validation pipeline documentation**                                                                                                                                                   
                                                                                                                                                                                                                   
  Summary                                                                                                                                                                                                          
   
  - Add **Stage F** to the exploitability validation README pipeline table, flow diagram, and stage descriptions                                                                                                       
  - Add **Stage F** to the _/validate_ command: sequence line, step-by-step instructions, non-agentic flow, ASCII diagram, and summary table                                                                             
  - Update stage counts and notes (6-stage → 7-stage, web vulns skip E → proceed to F)                                                                                                                             
                                                                                                                                                                                                                   
  Context                                                                                                                                                                                                          
                                                                                                                                                                                                                   
  **Stage F** was fully specified in _.claude/skills/exploitability-validation/stage-f-review.md_ and referenced in _CLAUDE.md_, _SKILL.md_, and the integration docs — but missing from the validation README and _/validate_ 
  command. This aligns those two files with the rest of the documentation.
                                                                                                                                                                                                                   
  Test plan                                                 
  
  - 220 exploitability validation tests pass (no code changes, markdown only)                                                                                                                                      
  - Verify _/validate_ command displays correct 7-stage sequence
  - Verify links to _stage-f-review.md_ resolve correctly 