### PR TITLE
add /understand: because grep and pray died in 2003

### DIFF
--- a/.claude/commands/understand.md
+++ b/.claude/commands/understand.md
@@ -10,6 +10,8 @@ It is a work in progress, remember that.
 /understand <target> [--map] [--trace <entry>] [--hunt <pattern>] [--teach <subject>] [--out <dir>]
 ```
 
+If no mode flag is given, default to `--map`.
+
 ## Modes
 
 | Flag | What it does |
@@ -19,7 +21,7 @@ It is a work in progress, remember that.
 | `--hunt <pattern>` | Find all variants of a pattern across the codebase |
 | `--teach <subject>` | Explain a framework, library, or code pattern in depth |
 
-Modes combine. Running `--map --trace EP-001` first maps, then traces the specified entry point.
+Modes combine and run in order: map → trace → hunt → teach. This matches the natural attack progression, so build context first, then trace a specific flow, then hunt for variants. Running `--map --trace EP-001` first maps, then traces the specified entry point.
 
 ## Examples
 
@@ -75,3 +77,4 @@ All JSON outputs write to `$WORKDIR` (`.out/code-understanding-<timestamp>/` by 
 | `context-map.json` | `--map` | Entry points, trust boundaries, sinks |
 | `flow-trace-<id>.json` | `--trace` | Step-by-step data flow with attacker control assessment |
 | `variants.json` | `--hunt` | All pattern matches, taint status, root-cause groups |
+| *(none)* | `--teach` | Inline explanation — no file written |

--- a/.claude/commands/understand.md
+++ b/.claude/commands/understand.md
@@ -1,0 +1,77 @@
+# /understand - RAPTOR Code Understanding
+
+You cannot find bugs if you don't have a deep, adversarial code understanding and comprehension for said codebase. This helps map the attack surface, trace data flows, hunt for vulnerability variants and so much more.....
+
+It is a work in progress, remember that. 
+
+## Usage
+
+```
+/understand <target> [--map] [--trace <entry>] [--hunt <pattern>] [--teach <subject>] [--out <dir>]
+```
+
+## Modes
+
+| Flag | What it does |
+|------|-------------|
+| `--map` | Build context: entry points, trust boundaries, sinks |
+| `--trace <entry>` | Trace one data flow source → sink with full call chain |
+| `--hunt <pattern>` | Find all variants of a pattern across the codebase |
+| `--teach <subject>` | Explain a framework, library, or code pattern in depth |
+
+Modes combine. Running `--map --trace EP-001` first maps, then traces the specified entry point.
+
+## Examples
+
+```
+# Understand a codebase before scanning it
+/understand ./src --map
+
+# Trace a specific endpoint's data flow
+/understand ./src --trace "POST /api/v2/query"
+
+# Find all variants of a finding from validation
+/understand ./src --hunt FIND-001
+
+# Understand an unfamiliar pattern before tracing
+/understand ./src --teach SQLAlchemy
+
+# Full workflow: map, then trace highest-risk flow
+/understand ./src --map --trace EP-001
+
+# Hunt for variants, write output for validator to consume
+/understand ./src --hunt "cursor.execute with f-string" --out .out/my-validation/
+```
+
+## Integration with Validation Pipeline
+
+Understanding output feeds into Gadi & JC's epic exploitability validation:
+
+- `context-map.json` → pre-populates `attack-surface.json` for Stage B
+- `flow-trace-*.json` → confirms reachability for Stage C
+- `variants.json` → expands `checklist.json` scope for Stage 0
+
+```
+# Map first, then validate with richer context
+/understand ./src --map --out .out/my-run/
+/validate ./src --findings .out/my-run/variants.json
+```
+
+## Skill Files
+
+Load before executing:
+- `.claude/skills/code-understanding/SKILL.md` — gates, config, output format
+- `.claude/skills/code-understanding/map.md` — for `--map`
+- `.claude/skills/code-understanding/trace.md` — for `--trace`
+- `.claude/skills/code-understanding/hunt.md` — for `--hunt`
+- `.claude/skills/code-understanding/teach.md` — for `--teach`
+
+## Output
+
+All JSON outputs write to `$WORKDIR` (`.out/code-understanding-<timestamp>/` by default, or `--out <dir>`).
+
+| File | Mode | Contents |
+|------|------|----------|
+| `context-map.json` | `--map` | Entry points, trust boundaries, sinks |
+| `flow-trace-<id>.json` | `--trace` | Step-by-step data flow with attacker control assessment |
+| `variants.json` | `--hunt` | All pattern matches, taint status, root-cause groups |

--- a/.claude/skills/code-understanding/SKILL.md
+++ b/.claude/skills/code-understanding/SKILL.md
@@ -1,0 +1,110 @@
+# Code Understanding Skill
+
+You are a deep thinker. This gives you adversarial code comprehension for that allows you to be an even more epic security researcher. This helps you map architecture, traces those imoportant data flows, and hunts for vulnerability variants before or alongside static analysis.
+
+## Purpose
+
+Complements scanning by building ground-truth knowledge of how code actually works:
+- Understand unfamiliar codebases quickly from an attacker's perspective
+- Trace exact data flows from untrusted input to dangerous sinks
+- Find all instances of a vulnerable pattern once one is identified
+- Build application context that improves scan signal and validation accuracy
+
+## When to Use
+
+- **Before scanning**: Build context so scanner results make sense immediately
+- **During validation**: Trace a finding's real path through the code
+- **After a finding**: Hunt for variants of the same pattern elsewhere
+- **On unfamiliar code**: Map architecture before launching any analysis
+
+## Modes
+
+| Mode | Command flag | Purpose |
+|------|-------------|---------|
+| **Map** | `--map` | Build high-level context: entry points, trust model, data paths |
+| **Trace** | `--trace <entry>` | Follow one flow source → sink with full call chain |
+| **Hunt** | `--hunt <pattern>` | Find all variants of a pattern across the codebase |
+| **Teach** | `--teach` | Explain unfamiliar code, frameworks, or patterns in depth |
+
+Modes can be combined. Map → Trace → Hunt is the natural attack progression.
+
+---
+
+## [CONFIG] Configuration
+
+```yaml
+output_dir: .out/code-understanding-<timestamp>/
+confidence_levels:
+  high: "Direct code evidence — quote the line"
+  medium: "Inferred from context — state the assumption"
+  low: "Speculative — flag explicitly, verify before acting on"
+flow_format: source → transform(s) → sink
+```
+
+---
+
+## [EXEC] Execution Rules
+
+1. Read actual code before making any claim. Do not rely on naming conventions or assumptions.
+2. Quote the exact line (file path + line number) as proof for every assertion.
+3. When tracing a flow, follow it until it terminates — don't stop at the first interesting function.
+4. When hunting variants, search the full codebase. Do not stop at the first match.
+5. When teaching, explain the mechanism, not just the name. Show the code that implements it.
+6. Produce structured output (context-map.json, flow-trace.json, variants.json) for integration with validation pipeline.
+
+---
+
+## [GATES] MUST-GATEs
+
+**GATE-U1 [READ-FIRST]:** Never describe how code works without reading it. If you haven't read a file, say so and read it before continuing.
+
+**GATE-U2 [ATTACKER-LENS]:** When reading any code path, ask: where does trust transfer? Where are checks missing? Where does user input influence execution? These questions drive analysis, not just "does this code do what the comment says."
+
+**GATE-U3 [FULL-FLOW]:** When tracing a data flow, follow every branch: happy path, error paths, middleware, async handlers. A missing check in an error path is still a missing check.
+
+**GATE-U4 [VARIANT-COMPLETE]:** A variant hunt is not complete until the full codebase has been searched. If a pattern appears in one place, assume it appears in others until proven otherwise.
+
+**GATE-U5 [EVIDENCE-ONLY]:** Confidence levels must match evidence. High confidence requires a quoted line. Medium requires a stated assumption. Low must be flagged and not acted on until verified.
+
+---
+
+## [STYLE] Output Formatting
+
+- File references: `path/to/file.py:42` format throughout
+- Flow format: `source (file:line) → transform (file:line) → sink (file:line)`
+- Confidence inline: `(confidence: high — file:line)` or `(confidence: medium — assumed from X)`
+- No red/green status indicators (perspective-dependent)
+- JSON outputs go to `$WORKDIR/` for pipeline integration
+
+---
+
+## Integration with Validation Pipeline
+
+Code understanding output feeds directly into exploitability validation:
+
+| Understanding Output | Validation Input |
+|---------------------|-----------------|
+| `context-map.json` (sources, sinks, trust boundaries) | Pre-populates `attack-surface.json` for Stage B |
+| `flow-trace.json` (confirmed data flow) | Confirms reachability for Stage C sanity check |
+| `variants.json` (pattern matches) | Expands `checklist.json` scope for Stage 0 |
+
+When running `/understand` before `/validate`, pass `--out <workdir>` to write JSON outputs where the validator can consume them.
+
+---
+
+## Stages
+
+| Stage | Mode | Gate(s) | Output |
+|-------|------|---------|--------|
+| **Map** | `--map` | U1, U2 | `context-map.json` |
+| **Trace** | `--trace` | U1, U2, U3, U5 | `flow-trace.json` |
+| **Hunt** | `--hunt` | U1, U4, U5 | `variants.json` |
+| **Teach** | `--teach` | U1, U5 | inline explanation |
+
+See stage-specific files for detailed instructions.
+
+---
+
+## Notice
+
+This analysis is performed for defensive purposes, security research, and authorized security testing only.

--- a/.claude/skills/code-understanding/SKILL.md
+++ b/.claude/skills/code-understanding/SKILL.md
@@ -80,15 +80,7 @@ flow_format: source → transform(s) → sink
 
 ## Integration with Validation Pipeline
 
-Code understanding output feeds directly into exploitability validation:
-
-| Understanding Output | Validation Input |
-|---------------------|-----------------|
-| `context-map.json` (sources, sinks, trust boundaries) | Pre-populates `attack-surface.json` for Stage B |
-| `flow-trace-<id>.json` (confirmed data flow) | Confirms reachability for Stage C sanity check |
-| `variants.json` (pattern matches) | Expands `checklist.json` scope for Stage 0 |
-
-When running `/understand` before `/validate`, pass `--out <workdir>` to write JSON outputs where the validator can consume them.
+Output schemas are aligned with the validation pipeline's formats (`attack-surface.json`, `attack-paths.json`, `findings.json`). Direct pipeline integration is planned for a follow-up.
 
 ---
 

--- a/.claude/skills/code-understanding/SKILL.md
+++ b/.claude/skills/code-understanding/SKILL.md
@@ -1,6 +1,6 @@
 # Code Understanding Skill
 
-You are a deep thinker. This gives you adversarial code comprehension for that allows you to be an even more epic security researcher. This helps you map architecture, traces those imoportant data flows, and hunts for vulnerability variants before or alongside static analysis.
+You are a deep thinker. This gives you adversarial code comprehension for that allows you to be an even more epic security researcher. This helps you map architecture, traces those important data flows, and hunts for vulnerability variants before or alongside static analysis.
 
 ## Purpose
 
@@ -85,7 +85,7 @@ Code understanding output feeds directly into exploitability validation:
 | Understanding Output | Validation Input |
 |---------------------|-----------------|
 | `context-map.json` (sources, sinks, trust boundaries) | Pre-populates `attack-surface.json` for Stage B |
-| `flow-trace.json` (confirmed data flow) | Confirms reachability for Stage C sanity check |
+| `flow-trace-<id>.json` (confirmed data flow) | Confirms reachability for Stage C sanity check |
 | `variants.json` (pattern matches) | Expands `checklist.json` scope for Stage 0 |
 
 When running `/understand` before `/validate`, pass `--out <workdir>` to write JSON outputs where the validator can consume them.
@@ -97,9 +97,9 @@ When running `/understand` before `/validate`, pass `--out <workdir>` to write J
 | Stage | Mode | Gate(s) | Output |
 |-------|------|---------|--------|
 | **Map** | `--map` | U1, U2 | `context-map.json` |
-| **Trace** | `--trace` | U1, U2, U3, U5 | `flow-trace.json` |
+| **Trace** | `--trace` | U1, U2, U3, U5 | `flow-trace-<id>.json` |
 | **Hunt** | `--hunt` | U1, U4, U5 | `variants.json` |
-| **Teach** | `--teach` | U1, U5 | inline explanation |
+| **Teach** | `--teach` | U1, U5 | none --- inline output |
 
 See stage-specific files for detailed instructions.
 

--- a/.claude/skills/code-understanding/hunt.md
+++ b/.claude/skills/code-understanding/hunt.md
@@ -10,6 +10,8 @@ One of:
 - A sink type (`--hunt sink:shell_exec`)
 - A file/function from a completed trace (`--hunt EP-001`)
 
+**Disambiguation:** `FIND-*` or `EP-*` → ID lookup in findings.json / context-map.json. `sink:` prefix → filter by sink type. Everything else → treat as a freeform pattern description.
+
 ## Purpose
 
 Answer: *"Is this the only place this happens, or did the same mistake get made everywhere?"*
@@ -72,6 +74,7 @@ Rank variants by exploitability:
 3. `likely_tainted` with public entry point
 4. `likely_tainted` with authenticated entry point
 5. `unlikely_tainted` — document, low priority
+6. `false_positive` — discard, record why so the same match isn't re-investigated
 
 ## Output Format
 
@@ -91,7 +94,16 @@ Rank variants by exploitability:
     {
       "id": "VAR-001",
       "file": "src/services/query_service.py",
+      "function": "run_query",
       "line": 31,
+      "vuln_type": "sqli",
+      "status": "not_disproven",
+      "confidence": "high",
+      "proof": {
+        "vulnerable_code": "cursor.execute(f'SELECT * FROM {table} WHERE id = {user_id}')",
+        "source": "request.json['user_id'] at src/routes/user.py:22",
+        "sink": "psycopg2.cursor.execute() at src/services/query_service.py:31"
+      },
       "matched_code": "cursor.execute(f'SELECT * FROM {table} WHERE id = {user_id}')",
       "taint_status": "confirmed_tainted",
       "taint_source": "request.json['user_id'] at src/routes/user.py:22",
@@ -133,6 +145,6 @@ If `confirmed_tainted` variants exist, prompt: *"Found N confirmed variants. Run
 
 ## Gates
 
-GATES APPLY: U1 [READ-FIRST], U4 [VARIANT-COMPLETE], U5 [EVIDENCE-ONLY]
+GATES APPLY: U1 [READ-FIRST], U2 [ATTACKER-LENS], U4 [VARIANT-COMPLETE], U5 [EVIDENCE-ONLY]
 
 **GATE-U4 reminder:** Search the full codebase. If the grep returns many results, process all of them — do not sample. Document any files excluded from the hunt (e.g., test harnesses, generated code) and why.

--- a/.claude/skills/code-understanding/hunt.md
+++ b/.claude/skills/code-understanding/hunt.md
@@ -1,0 +1,138 @@
+# [HUNT] Variant Analysis
+
+Once a vulnerability pattern is identified, I need you to systematically find every other location in the codebase where the same pattern could apply. A single finding is rarely isolated. Don't be scared, be curious
+
+## Input
+
+One of:
+- A vulnerability finding (from `/validate` output or SARIF)
+- A code pattern description (`--hunt "raw SQL via f-string"`)
+- A sink type (`--hunt sink:shell_exec`)
+- A file/function from a completed trace (`--hunt EP-001`)
+
+## Purpose
+
+Answer: *"Is this the only place this happens, or did the same mistake get made everywhere?"*
+
+Variant hunting operates at three levels:
+1. **Structural variants** — same code pattern (same API call, same string operation, same missing check)
+2. **Semantic variants** — different code, same vulnerability class (all SQL injection regardless of how it's built)
+3. **Root-cause variants** — if a shared utility function is vulnerable, find every caller
+
+## Task
+
+**[HUNT-1] Pattern Extraction**
+
+From the input finding or description, extract:
+- The dangerous operation (what API or construct is used)
+- The taint source (where user input entered)
+- The missing control (what was absent: validation, parameterization, escaping)
+
+Express this as a searchable pattern before starting.
+
+Example: *"Pattern: `cursor.execute()` called with a string that contains an f-string or `%` or `+` operator, where the string variable is not a fixed constant."*
+
+**[HUNT-2] Structural Search**
+
+Search the codebase for the structural pattern:
+- Use Grep for API calls, function names, and syntax patterns
+- Cast wide first, then narrow — start with the sink, then filter for taint
+
+Record every match with file path, line number, and the matched code.
+
+**[HUNT-3] Taint Qualification**
+
+For each structural match, quickly assess whether attacker-controlled input can reach it:
+- Is there an obvious untrusted source in the same function?
+- Is the variable populated from a request, file, or external source?
+- Does the call sit behind a public entry point?
+
+Classify each match:
+- `confirmed_tainted`: direct evidence of user input reaching the sink
+- `likely_tainted`: plausible path from external input, needs trace to confirm
+- `unlikely_tainted`: value appears to come from internal/trusted sources
+- `false_positive`: value is a constant or clearly safe
+
+Do not discard `likely_tainted` matches — they become candidates for `--trace`.
+
+**[HUNT-4] Root-Cause Grouping**
+
+Group findings by root cause:
+- Same shared utility function → one fix fixes all
+- Same copy-paste pattern → independent findings, need separate fixes
+- Same framework misuse → systemic issue across the codebase
+
+This determines whether one patch addresses the whole class or whether each instance needs separate attention.
+
+**[HUNT-5] Priority Ranking**
+
+Rank variants by exploitability:
+1. `confirmed_tainted` with public entry point — highest priority
+2. `confirmed_tainted` with authenticated entry point
+3. `likely_tainted` with public entry point
+4. `likely_tainted` with authenticated entry point
+5. `unlikely_tainted` — document, low priority
+
+## Output Format
+
+```json
+{
+  "meta": {
+    "seed": "FIND-001 | pattern description",
+    "pattern": "cursor.execute() with non-parameterized string",
+    "timestamp": "ISO timestamp",
+    "total_matches": 8,
+    "confirmed_tainted": 3,
+    "likely_tainted": 2,
+    "unlikely_tainted": 2,
+    "false_positive": 1
+  },
+  "variants": [
+    {
+      "id": "VAR-001",
+      "file": "src/services/query_service.py",
+      "line": 31,
+      "matched_code": "cursor.execute(f'SELECT * FROM {table} WHERE id = {user_id}')",
+      "taint_status": "confirmed_tainted",
+      "taint_source": "request.json['user_id'] at src/routes/user.py:22",
+      "root_cause_group": "direct-fstring-interpolation",
+      "entry_points": ["POST /api/v2/users"],
+      "auth_required": false,
+      "priority": 1,
+      "notes": "Same pattern as seed finding. Public endpoint."
+    }
+  ],
+  "root_cause_groups": [
+    {
+      "id": "RCG-001",
+      "name": "direct-fstring-interpolation",
+      "description": "SQL built via f-string without parameterization",
+      "count": 5,
+      "fix_strategy": "Replace with parameterized queries — one fix pattern applies to all instances"
+    }
+  ],
+  "recommended_traces": ["VAR-002", "VAR-004"],
+  "validation_scope": {
+    "add_to_checklist": ["VAR-001", "VAR-002", "VAR-003"],
+    "note": "Pass variants.json to /validate --findings to expand validation scope"
+  }
+}
+```
+
+## Output
+
+OUTPUT: `$WORKDIR/variants.json`
+
+Display a summary to the user:
+- N total matches
+- N confirmed tainted (ready for `/validate`)
+- N likely tainted (recommend `--trace` on each)
+- N grouped by root cause
+
+If `confirmed_tainted` variants exist, prompt: *"Found N confirmed variants. Run `/validate` with `--findings variants.json` to validate exploitability."*
+
+## Gates
+
+GATES APPLY: U1 [READ-FIRST], U4 [VARIANT-COMPLETE], U5 [EVIDENCE-ONLY]
+
+**GATE-U4 reminder:** Search the full codebase. If the grep returns many results, process all of them — do not sample. Document any files excluded from the hunt (e.g., test harnesses, generated code) and why.

--- a/.claude/skills/code-understanding/hunt.md
+++ b/.claude/skills/code-understanding/hunt.md
@@ -74,7 +74,7 @@ Rank variants by exploitability:
 3. `likely_tainted` with public entry point
 4. `likely_tainted` with authenticated entry point
 5. `unlikely_tainted` — document, low priority
-6. `false_positive` — discard, record why so the same match isn't re-investigated
+6. `false_positive` — retained in `variants.json` for audit trail (with notes explaining why), but excluded from `recommended_traces` and `validation_scope`
 
 ## Output Format
 

--- a/.claude/skills/code-understanding/map.md
+++ b/.claude/skills/code-understanding/map.md
@@ -104,6 +104,29 @@ Produce a brief summary covering:
       "notes": "Auth check at line 38, but only validates token format, not permissions"
     }
   ],
+  "sink_details": [
+    {
+      "id": "SINK-001",
+      "type": "db_query|shell_exec|file_write|file_read|deserialize|network|template|crypto",
+      "operation": "cursor.execute(raw_sql)",
+      "file": "src/db/query.py",
+      "line": 89,
+      "reaches_from": ["EP-001"],
+      "trust_boundaries_crossed": ["TB-001"],
+      "parameterized": false,
+      "notes": "Query string built via f-string at line 87"
+    }
+  ],
+  "boundary_details": [
+    {
+      "id": "TB-001",
+      "type": "auth_check|authz_check|input_validation|privilege_drop",
+      "file": "src/middleware/auth.py",
+      "line": 12,
+      "covers": ["EP-001", "EP-002"],
+      "gaps": "EP-003 bypasses this middleware via direct import at src/admin/bulk.py:67"
+    }
+  ],
   "unchecked_flows": [
     {
       "entry_point": "EP-003",

--- a/.claude/skills/code-understanding/map.md
+++ b/.claude/skills/code-understanding/map.md
@@ -1,0 +1,134 @@
+# [MAP] Application Context Mapping
+
+Build a ground-truth model of the target codebase before attacking it. The goal is to understand the application's trust model, where input enters, where decisions get made, and where dangerous operations occur.
+
+## Input
+
+A target directory or repository.
+
+## Purpose
+
+A context map answers: *"If I were the attacker, what would I care about here?"*
+
+This is not documentation generation. It is adversarial reconnaissance at the source level.
+
+## Task
+
+**[MAP-1] Entry Point Enumeration**
+
+Find all locations where external input enters the application:
+- HTTP routes (GET/POST handlers, REST endpoints, GraphQL resolvers)
+- CLI argument parsers
+- File/socket readers
+- Message queue consumers
+- Deserialization entry points (JSON parsers, pickle loads, XML parsers)
+- IPC handlers
+
+For each: record file path, line number, and what data it accepts.
+
+**[MAP-2] Trust Boundary Identification**
+
+Identify where the code makes (or should make) trust decisions:
+- Authentication checks (where credentials are verified)
+- Authorization checks (where permissions are enforced)
+- Input validation (where sanitization occurs)
+- Privilege transitions (setuid, sudo, elevated operations)
+
+Flag any entry point that reaches a sensitive operation *without* passing through a trust boundary.
+
+**[MAP-3] Sink Catalog**
+
+Find all dangerous operations:
+- Database queries (especially raw/string-concatenated)
+- Shell execution (`subprocess`, `exec`, `system`, `popen`)
+- File system writes and reads (especially with user-controlled paths)
+- Deserialization (`pickle.loads`, `eval`, `yaml.load` without SafeLoader)
+- Network requests with user-controlled URLs (SSRF candidates)
+- Template rendering with user data
+- Cryptographic operations (especially key material handling)
+
+For each: record file path, line number, and what data reaches it.
+
+**[MAP-4] Architecture Summary**
+
+Produce a brief summary covering:
+- Application type (web app, CLI, daemon, library, etc.)
+- Primary language(s) and frameworks
+- Authentication model (session-based, token-based, API key, none)
+- Database(s) and ORM (if any)
+- External service dependencies
+- Notable security controls present (WAF hints in code, CSP headers, rate limiting)
+
+## Output Format
+
+```json
+{
+  "meta": {
+    "target": "path/to/target",
+    "timestamp": "ISO timestamp",
+    "app_type": "web_app|cli|daemon|library",
+    "language": ["python", "go"],
+    "frameworks": ["flask", "sqlalchemy"],
+    "auth_model": "session|token|api_key|none|mixed"
+  },
+  "entry_points": [
+    {
+      "id": "EP-001",
+      "type": "http_route|cli_arg|file_read|socket|queue|ipc|deserialize",
+      "method": "POST",
+      "path": "/api/v2/query",
+      "file": "src/routes/query.py",
+      "line": 34,
+      "accepts": "JSON body: {query: string, params: object}",
+      "auth_required": true,
+      "notes": "Auth check at line 38, but only validates token format, not permissions"
+    }
+  ],
+  "trust_boundaries": [
+    {
+      "id": "TB-001",
+      "type": "auth_check|authz_check|input_validation|privilege_drop",
+      "file": "src/middleware/auth.py",
+      "line": 12,
+      "covers": ["EP-001", "EP-002"],
+      "gaps": "EP-003 bypasses this middleware via direct import at src/admin/bulk.py:67"
+    }
+  ],
+  "sinks": [
+    {
+      "id": "SINK-001",
+      "type": "db_query|shell_exec|file_write|file_read|deserialize|network|template|crypto",
+      "operation": "cursor.execute(raw_sql)",
+      "file": "src/db/query.py",
+      "line": 89,
+      "reaches_from": ["EP-001"],
+      "trust_boundaries_crossed": ["TB-001"],
+      "parameterized": false,
+      "notes": "Query string built via f-string at line 87"
+    }
+  ],
+  "unchecked_flows": [
+    {
+      "entry_point": "EP-003",
+      "sink": "SINK-002",
+      "missing_boundary": "No auth check on admin bulk endpoint"
+    }
+  ]
+}
+```
+
+## Gates
+
+GATES APPLY: U1 [READ-FIRST], U2 [ATTACKER-LENS], U5 [EVIDENCE-ONLY]
+
+Do not populate `entry_points` or `sinks` from file names or common patterns alone — read the code and verify.
+
+## Output
+
+OUTPUT: `$WORKDIR/context-map.json`
+
+Display a summary to the user after writing:
+- N entry points found (N require auth, N are public)
+- N trust boundaries found (N gaps identified)
+- N sinks found (N have unchecked flows)
+- Recommended next step: `--trace <entry-point-id>` for highest-risk unchecked flow

--- a/.claude/skills/code-understanding/map.md
+++ b/.claude/skills/code-understanding/map.md
@@ -61,8 +61,28 @@ Produce a brief summary covering:
 
 ## Output Format
 
+`context-map.json` is a superset of `attack-surface.json`. The top-level `sources`, `sinks`, and `trust_boundaries` keys use the same required fields as Stage B's `attack-surface.json` — so `cp context-map.json attack-surface.json` works. Context-map-specific fields (`meta`, `entry_points`, `unchecked_flows`) sit alongside as extra keys.
+
 ```json
 {
+  "sources": [
+    {
+      "type": "http_route",
+      "entry": "POST /api/v2/query @ src/routes/query.py:34"
+    }
+  ],
+  "sinks": [
+    {
+      "type": "db_query",
+      "location": "src/db/query.py:89"
+    }
+  ],
+  "trust_boundaries": [
+    {
+      "boundary": "JWT auth middleware",
+      "check": "src/middleware/auth.py:12"
+    }
+  ],
   "meta": {
     "target": "path/to/target",
     "timestamp": "ISO timestamp",
@@ -84,29 +104,6 @@ Produce a brief summary covering:
       "notes": "Auth check at line 38, but only validates token format, not permissions"
     }
   ],
-  "trust_boundaries": [
-    {
-      "id": "TB-001",
-      "type": "auth_check|authz_check|input_validation|privilege_drop",
-      "file": "src/middleware/auth.py",
-      "line": 12,
-      "covers": ["EP-001", "EP-002"],
-      "gaps": "EP-003 bypasses this middleware via direct import at src/admin/bulk.py:67"
-    }
-  ],
-  "sinks": [
-    {
-      "id": "SINK-001",
-      "type": "db_query|shell_exec|file_write|file_read|deserialize|network|template|crypto",
-      "operation": "cursor.execute(raw_sql)",
-      "file": "src/db/query.py",
-      "line": 89,
-      "reaches_from": ["EP-001"],
-      "trust_boundaries_crossed": ["TB-001"],
-      "parameterized": false,
-      "notes": "Query string built via f-string at line 87"
-    }
-  ],
   "unchecked_flows": [
     {
       "entry_point": "EP-003",
@@ -121,7 +118,7 @@ Produce a brief summary covering:
 
 GATES APPLY: U1 [READ-FIRST], U2 [ATTACKER-LENS], U5 [EVIDENCE-ONLY]
 
-Do not populate `entry_points` or `sinks` from file names or common patterns alone — read the code and verify.
+Do not populate `sources`, `sinks`, or `entry_points` from file names or common patterns alone — read the code and verify.
 
 ## Output
 

--- a/.claude/skills/code-understanding/teach.md
+++ b/.claude/skills/code-understanding/teach.md
@@ -1,0 +1,85 @@
+# [TEACH] Code Explanation Mode
+
+Explain unfamiliar code, frameworks, or patterns in enough depth to reason about their security properties. Used when the analyst hits something they don't understand well enough to attack correctly.
+
+## Input
+
+One of:
+- A code snippet or file path (`--teach src/parsers/query.py`)
+- A framework or library name (`--teach ANTLR`, `--teach SQLAlchemy`)
+- A pattern pulled from an active trace (`--teach` inline during `--trace`)
+
+## Purpose
+
+Answer: *"How does this actually work, and what are the security-relevant properties I need to know before I continue?"*
+
+The goal is not general documentation — it is targeted understanding of the mechanism from an attacker's perspective. How does this thing work? What does it protect against? What does it not protect against? What assumptions does it make?
+
+## Task
+
+**[TEACH-1] Mechanism**
+
+Explain what the code or framework does at the implementation level:
+- Show the actual code path (read the relevant files; don't just describe the API)
+- Explain what the mechanism protects against when used correctly
+- Explain what assumptions it makes about its inputs
+
+**[TEACH-2] Security Properties**
+
+Answer these questions for the subject:
+- Does this prevent a specific class of attack? How? (e.g., "parameterized queries prevent SQL injection by sending query structure and data separately")
+- Under what conditions does the protection fail? (e.g., "SQLAlchemy's `text()` construct bypasses parameterization if the argument contains string interpolation")
+- What does correct use look like vs. incorrect use?
+
+Show both with code examples from the actual codebase when possible.
+
+**[TEACH-3] Return to Analysis**
+
+After explaining the mechanism, return immediately to the interrupted analysis with a clear security conclusion:
+
+```
+[TEACH complete]
+Conclusion: SQLAlchemy's text() construct used at src/db/query.py:89 is NOT parameterized
+because the query string is built before being passed to text(). Attacker input at step 4
+reaches this as a raw string. Continuing trace...
+```
+
+Do not leave the analyst in a state of uncertainty — the teach explanation must resolve into a security verdict.
+
+## Output Format
+
+Teach mode produces inline output (no JSON file). Structure:
+
+```
+[TEACH: <subject>]
+
+Mechanism:
+<explanation of how it works, with code references>
+
+Security properties:
+- Protects against: <what>
+- Fails when: <conditions>
+- Correct use: <example from codebase>
+- Incorrect use: <example from codebase if present>
+
+Relevant to current analysis:
+<specific conclusion for the interrupted trace or analysis>
+
+[TEACH complete — returning to <mode> at step N]
+```
+
+## When to Trigger Teach Mode
+
+Teach mode should be triggered explicitly whenever:
+- A framework or library is encountered that you haven't read in this session
+- A pattern appears whose security properties are ambiguous (e.g., a custom sanitizer)
+- A parsing or serialization mechanism is in the flow path
+- An authentication or session mechanism is being evaluated
+
+**Do not trace through code you don't understand.** Tracing through an opaque function and guessing it's safe is worse than pausing to understand it — it produces false confidence.
+
+## Gates
+
+GATES APPLY: U1 [READ-FIRST], U5 [EVIDENCE-ONLY]
+
+Teach explanations must be grounded in code — either the actual library source, framework documentation read via WebFetch, or the project's own implementation. Do not explain how a library "usually" works without verifying it matches the version in use.

--- a/.claude/skills/code-understanding/trace.md
+++ b/.claude/skills/code-understanding/trace.md
@@ -7,11 +7,13 @@ Follow a single data flow from untrusted input to a dangerous operation. Show ev
 - An entry point: HTTP route path, function name, or `EP-xxx` ID from context-map.json
 - Optionally: a target sink type (`--to db|shell|file|deserialize|network`)
 
+**Disambiguation:** `EP-xxx` → look up by ID in context-map.json. String starting with an HTTP method (e.g. `"POST /api/v2/query"`) → match against route entry points. Anything else → treat as a function name and search the codebase.
+
 ## Purpose
 
 Answer: *"Can I control what reaches this sink, and is anything stopping me?"*
 
-The goal is a complete, step-by-step walkthrough of the code — not a summary, but an actual trace showing the function call and its definition at each hop. This is what distinguishes understanding from guessing.
+The goal is a complete, step-by-step walkthrough of the supplied code, not a summary, but an actual trace showing the function call and its definition at each hop. This is what distinguishes understanding from guessing.
 
 ## Task
 
@@ -56,20 +58,23 @@ At each sink, record:
 
 Summarize what the attacker controls:
 - Input they provide directly (high control)
-- Input filtered by previous checks (partial control — assess bypass potential)
+- Input filtered by previous checks (partial control. assess bypass potential)
 - Input not under attacker control (discard from threat model)
 
 ## Output Format
 
 ```json
 {
+  "id": "TRACE-001",
+  "name": "POST /api/v2/query → db_query",
+  "finding": "FIND-001",
   "meta": {
     "entry_point": "POST /api/v2/query",
     "entry_file": "src/routes/query.py:34",
     "target_sink": "db_query",
     "timestamp": "ISO timestamp"
   },
-  "flow": [
+  "steps": [
     {
       "step": 1,
       "type": "entry",
@@ -104,6 +109,8 @@ Summarize what the attacker controls:
       "injectable": true
     }
   ],
+  "proximity": 9,
+  "blockers": [],
   "branches": [
     {
       "branch_point": "src/routes/query.py:44",
@@ -128,11 +135,13 @@ Summarize what the attacker controls:
 }
 ```
 
+**Schema note:** `steps[]`, `proximity` (0–10 score: 10 = at the sink, 0 = no viable path), and `blockers[]` are shared with `attack-paths.json` from the validation pipeline. What this means is that a flow-trace can be consumed directly by Stage B. `branches`, `attacker_control`, and `summary` are trace-specific extensions.
+
 ## Teach Mode Integration
 
-If you encounter an unfamiliar framework, library, or pattern while tracing — say so explicitly. Switch to [TEACH] mode to understand the mechanism, then return to the trace.
+If you encounter an unfamiliar framework, library, or pattern while tracing, say so explicitly!. Switch to [TEACH] mode to understand the mechanism, then return to the trace.
 
-Example: *"Step 4 uses SQLAlchemy's `text()` construct — loading teach mode to understand whether this is parameterized."*
+Example: *"Step 4 uses SQLAlchemy's `text()` construct, so loading teach mode to understand whether this is parameterised."*
 
 This prevents false confidence from tracing through code you don't fully understand.
 
@@ -140,7 +149,7 @@ This prevents false confidence from tracing through code you don't fully underst
 
 OUTPUT: `$WORKDIR/flow-trace-<entry-id>.json` (one file per traced flow)
 
-Display the flow to the user as a narrative walkthrough after writing — not just the JSON. Show each step as: `[step N] file:line — what happens — what attacker controls`.
+Display the flow to the user as a narrative walkthrough after writing, not just the JSON. Show each step as: `[step N] file:line — what happens — what attacker controls`.
 
 ## Gates
 

--- a/.claude/skills/code-understanding/trace.md
+++ b/.claude/skills/code-understanding/trace.md
@@ -58,7 +58,7 @@ At each sink, record:
 
 Summarize what the attacker controls:
 - Input they provide directly (high control)
-- Input filtered by previous checks (partial control. assess bypass potential)
+- Input filtered by previous checks (partial control — assess bypass potential)
 - Input not under attacker control (discard from threat model)
 
 ## Output Format
@@ -139,7 +139,7 @@ Summarize what the attacker controls:
 
 ## Teach Mode Integration
 
-If you encounter an unfamiliar framework, library, or pattern while tracing, say so explicitly!. Switch to [TEACH] mode to understand the mechanism, then return to the trace.
+If you encounter an unfamiliar framework, library, or pattern while tracing, say so explicitly. Switch to [TEACH] mode to understand the mechanism, then return to the trace.
 
 Example: *"Step 4 uses SQLAlchemy's `text()` construct, so loading teach mode to understand whether this is parameterised."*
 

--- a/.claude/skills/code-understanding/trace.md
+++ b/.claude/skills/code-understanding/trace.md
@@ -1,0 +1,149 @@
+# [TRACE] Data Flow Tracing
+
+Follow a single data flow from untrusted input to a dangerous operation. Show every step: the call site, the function definition, and any transformations along the way. This is verbose, in your face and super helpful. 
+
+## Input
+
+- An entry point: HTTP route path, function name, or `EP-xxx` ID from context-map.json
+- Optionally: a target sink type (`--to db|shell|file|deserialize|network`)
+
+## Purpose
+
+Answer: *"Can I control what reaches this sink, and is anything stopping me?"*
+
+The goal is a complete, step-by-step walkthrough of the code — not a summary, but an actual trace showing the function call and its definition at each hop. This is what distinguishes understanding from guessing.
+
+## Task
+
+**[TRACE-1] Anchor**
+
+Locate the entry point in code. Read it. Record:
+- Exactly what data the entry point accepts (parameter names, types, where it comes from)
+- Any immediate validation at the entry (before it's passed anywhere)
+- The first downstream call
+
+**[TRACE-2] Walk the Chain**
+
+For each function call in the chain:
+1. Show the call site (file:line — the line calling the function)
+2. Show the function definition (file:line — where the function is defined)
+3. Show what happens to the input data inside that function
+4. Identify the next call that carries tainted data forward
+
+Continue until one of:
+- Data reaches a sink (database, shell, filesystem, deserializer, network)
+- Data is definitively sanitized (record what sanitization occurs and assess its completeness)
+- Data reaches a dead end (hardcoded, discarded, never used)
+
+**[TRACE-3] Branch Coverage**
+
+Identify all branches in the flow — not just the happy path:
+- Error handlers (do they short-circuit safely, or do they pass data through anyway?)
+- Conditional branches (does the input take different paths under different conditions?)
+- Async/deferred execution (is the data passed to a queue, goroutine, callback?)
+
+Trace each significant branch separately.
+
+**[TRACE-4] Sink Analysis**
+
+At each sink, record:
+- Exactly what reaches it (the variable name and what it contains)
+- Whether it's parameterized or interpolated
+- What an attacker could inject and what the effect would be
+- What would need to be true for exploitation (prerequisites)
+
+**[TRACE-5] Control Assessment**
+
+Summarize what the attacker controls:
+- Input they provide directly (high control)
+- Input filtered by previous checks (partial control — assess bypass potential)
+- Input not under attacker control (discard from threat model)
+
+## Output Format
+
+```json
+{
+  "meta": {
+    "entry_point": "POST /api/v2/query",
+    "entry_file": "src/routes/query.py:34",
+    "target_sink": "db_query",
+    "timestamp": "ISO timestamp"
+  },
+  "flow": [
+    {
+      "step": 1,
+      "type": "entry",
+      "call_site": null,
+      "definition": "src/routes/query.py:34",
+      "description": "POST handler receives JSON body. `query` field extracted at line 41.",
+      "tainted_var": "request.json['query']",
+      "transform": "none",
+      "confidence": "high"
+    },
+    {
+      "step": 2,
+      "type": "call",
+      "call_site": "src/routes/query.py:48",
+      "definition": "src/services/query_service.py:12",
+      "description": "Passes `query` directly to QueryService.run() without validation.",
+      "tainted_var": "query_str",
+      "transform": "none",
+      "confidence": "high"
+    },
+    {
+      "step": 3,
+      "type": "sink",
+      "call_site": "src/services/query_service.py:31",
+      "definition": "psycopg2.cursor.execute()",
+      "description": "Raw SQL built via f-string: f'SELECT * FROM {table} WHERE query = {query_str}'",
+      "tainted_var": "query_str",
+      "transform": "none",
+      "confidence": "high",
+      "sink_type": "db_query",
+      "parameterized": false,
+      "injectable": true
+    }
+  ],
+  "branches": [
+    {
+      "branch_point": "src/routes/query.py:44",
+      "condition": "if request.json.get('admin')",
+      "outcome": "Bypasses auth middleware entirely — tainted data reaches same sink via shorter path"
+    }
+  ],
+  "attacker_control": {
+    "level": "full|partial|none",
+    "what": "Full control over `query` field via POST body",
+    "bypasses_needed": [],
+    "notes": ""
+  },
+  "summary": {
+    "flow_confirmed": true,
+    "sink_reachable": true,
+    "sanitizers": [],
+    "verdict": "Untrusted POST body reaches raw SQL execution with no parameterization. Direct SQLi.",
+    "confidence": "high",
+    "feeds_validation": true
+  }
+}
+```
+
+## Teach Mode Integration
+
+If you encounter an unfamiliar framework, library, or pattern while tracing — say so explicitly. Switch to [TEACH] mode to understand the mechanism, then return to the trace.
+
+Example: *"Step 4 uses SQLAlchemy's `text()` construct — loading teach mode to understand whether this is parameterized."*
+
+This prevents false confidence from tracing through code you don't fully understand.
+
+## Output
+
+OUTPUT: `$WORKDIR/flow-trace-<entry-id>.json` (one file per traced flow)
+
+Display the flow to the user as a narrative walkthrough after writing — not just the JSON. Show each step as: `[step N] file:line — what happens — what attacker controls`.
+
+## Gates
+
+GATES APPLY: U1 [READ-FIRST], U2 [ATTACKER-LENS], U3 [FULL-FLOW], U5 [EVIDENCE-ONLY]
+
+**Full flow means full flow.** If a function calls another function, read the callee. Do not assume what a function does from its name. Read it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ The `/understand` command provides deep, adversarial code comprehension for secu
 **When developing exploits:** Load `tiers/exploit-guidance.md` (constraints, techniques)
 **When errors occur:** Load `tiers/recovery.md` (recovery protocol)
 **When requested:** Load `tiers/personas/[name].md` (expert personas)
-**When running /understand:** Load `.claude/skills/code-understanding/SKILL.md` (gates, modes)
+**When running /understand:** Load `.claude/skills/code-understanding/SKILL.md` (gates, config) plus the relevant mode file: `map.md`, `trace.md`, `hunt.md`, or `teach.md`
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ VERY IMPORTANT: double check that you followed these instructions.
 /scan /fuzz /web /agentic /codeql /analyze - Security testing
 /exploit /patch - Generate PoCs and fixes (beta)
 /validate - Exploitability validation pipeline (see below)
+/understand - Code understanding: map attack surface, trace flows, hunt variants (see below)
 
 **Note:** `/agentic` now automatically runs exploitability validation (Phase 2) between scanning and analysis. Use `--skip-validation` to bypass.
 /crash-analysis - Autonomous crash root-cause analysis (see below)
@@ -114,6 +115,31 @@ The `/validate` command validates that vulnerability findings are real, reachabl
 
 ---
 
+## CODE UNDERSTANDING
+
+The `/understand` command provides deep, adversarial code comprehension for security research.
+
+**Usage:** `/understand <target> [--map] [--trace <entry>] [--hunt <pattern>] [--teach <subject>] [--out <dir>]`
+
+**Modes:**
+- `--map` — Build context: entry points, trust boundaries, sinks → `context-map.json`
+- `--trace <entry>` — Follow one data flow source → sink with full call chain → `flow-trace-<id>.json`
+- `--hunt <pattern>` — Find all variants of a pattern across the codebase → `variants.json`
+- `--teach <subject>` — Explain a framework, library, or pattern in depth (inline)
+
+**Skills** (in `.claude/skills/code-understanding/`):
+- `SKILL.md` — Gates, config, output format
+- `map.md` — Entry point enumeration, trust boundary mapping, sink catalog
+- `trace.md` — Step-by-step data flow tracing with branch coverage
+- `hunt.md` — Structural, semantic, and root-cause variant analysis
+- `teach.md` — Framework/pattern explanation with security conclusion
+
+**Output:** `.out/code-understanding-<timestamp>/`
+
+**Pipeline integration:** `context-map.json` → `attack-surface.json`, `variants.json` → `checklist.json` for `/validate`
+
+---
+
 ## PROGRESSIVE LOADING
 
 **When scan completes:** Load `tiers/analysis-guidance.md` (adversarial thinking)
@@ -122,6 +148,7 @@ The `/validate` command validates that vulnerability findings are real, reachabl
 **When developing exploits:** Load `tiers/exploit-guidance.md` (constraints, techniques)
 **When errors occur:** Load `tiers/recovery.md` (recovery protocol)
 **When requested:** Load `tiers/personas/[name].md` (expert personas)
+**When running /understand:** Load `.claude/skills/code-understanding/SKILL.md` (gates, modes)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ The `/understand` command provides deep, adversarial code comprehension for secu
 
 **Output:** `.out/code-understanding-<timestamp>/`
 
-**Pipeline integration:** `context-map.json` → `attack-surface.json`, `variants.json` → `checklist.json` for `/validate`
+**Pipeline integration:** Planned — output schemas are aligned with validation pipeline formats for future integration.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ RAPTOR stands for Recursive Autonomous Penetration Testing and Observation Robot
 (We really wanted to name it RAPTOR)
 
 **RAPTOR autonomously**:
-1. **Code Understanding** with adversarial code comprehension, allows you to map attack surface, trace those vital data flows & hunt for vulnerability variants
+1. **Code Understanding:** with adversarial code comprehension, allows you to map attack surface, trace those vital data flows & hunt for vulnerability variants
 2. **Scans** your code with Semgrep and CodeQL and tries dataflow validation
 3. **Fuzzes** your binaries with American Fuzzy Lop (AFL)
 4. **Analyses** vulnerabilities using advanced LLM reasoning

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ RAPTOR stands for Recursive Autonomous Penetration Testing and Observation Robot
 (We really wanted to name it RAPTOR)
 
 **RAPTOR autonomously**:
-1. **Code Understanding:** with adversarial code comprehension, allows you to map attack surface, trace those vital data flows & hunt for vulnerability variants
+1. **Code Understanding:** Adversarial code comprehension — map attack surface, trace data flows, hunt for vulnerability variants
 2. **Scans** your code with Semgrep and CodeQL and tries dataflow validation
 3. **Fuzzes** your binaries with American Fuzzy Lop (AFL)
 4. **Analyses** vulnerabilities using advanced LLM reasoning

--- a/README.md
+++ b/README.md
@@ -55,18 +55,19 @@ RAPTOR stands for Recursive Autonomous Penetration Testing and Observation Robot
 (We really wanted to name it RAPTOR)
 
 **RAPTOR autonomously**:
-1. **Scans** your code with Semgrep and CodeQL and tries dataflow validation
-2. **Fuzzes** your binaries with American Fuzzy Lop (AFL)
-3. **Analyses** vulnerabilities using advanced LLM reasoning
-4. **Exploits** by generating proof-of-concepts
-5. **Patches** with code to fix vulnerabilities
-6. **FFmpeg-specific** patching for Google's recent disclosure
+1. **Code Understanding** with adversarial code comprehension, allows you to map attack surface, trace those vital data flows & hunt for vulnerability variants
+2. **Scans** your code with Semgrep and CodeQL and tries dataflow validation
+3. **Fuzzes** your binaries with American Fuzzy Lop (AFL)
+4. **Analyses** vulnerabilities using advanced LLM reasoning
+5. **Exploits** by generating proof-of-concepts
+6. **Patches** with code to fix vulnerabilities
+7. **FFmpeg-specific** patching for Google's recent disclosure
    (https://news.ycombinator.com/item?id=45891016)
-7. **OSS Forensics** for evidence-backed GitHub repository investigations
-8. **Agentic Skills Engine** for security research & operations ([SecOpsAgentKit](https://github.com/AgentSecOps/SecOpsAgentKit))
-9. **Offensive Security Testing** via autonomous specialist agent with SecOpsAgentKit
-10. **Cost Management** with budget enforcement, real-time tracking, and quota detection
-11. **Reports** everything in structured formats
+8. **OSS Forensics** for evidence-backed GitHub repository investigations
+9. **Agentic Skills Engine** for security research & operations ([SecOpsAgentKit](https://github.com/AgentSecOps/SecOpsAgentKit))
+10. **Offensive Security Testing** via autonomous specialist agent with SecOpsAgentKit
+11. **Cost Management** with budget enforcement, real-time tracking, and quota detection
+12. **Reports** everything in structured formats
 
 RAPTOR combines traditional security tools with agentic automation and analysis, deeply
 understands your code, proves exploitability, and proposes patches.
@@ -93,6 +94,7 @@ demonstrates how Claude Code can be adapted for **any purpose**, with RAPTOR pac
 - **SecOpsAgentKit:** Offensive security specialist agent with comprehensive penetration testing capabilities
 - **Cost Management:** Budget enforcement, real-time callbacks, and intelligent quota detection
 - **Enhanced Reliability:** Multiple bug fixes improving robustness across CodeQL, static analysis, and LLM providers
+- **Code Understanding** We wanted to build more adversarial code comprehension, which allows you to map attack surface, trace those vital data flows & hunt for vulnerability variants
 
 ---
 
@@ -281,6 +283,11 @@ docker build -f .devcontainer/Dockerfile -t raptor-devcontainer:latest .
 /exploit  - Generate exploit proof-of-concepts (beta)
 /patch    - Generate security patches for vulnerabilities (beta)
 /crash-analysis - Analyze an FFmpeg crash and generate a validated root-cause analysis
+```
+
+**Code understanding:**
+```
+/understand - Adversarial code comprehension: map attack surface, trace data flows, hunt variants
 ```
 
 **Forensics & investigation:**


### PR DESCRIPTION
  map it, trace it, hunt the variants. teach yourself why the thing you
  thought was safe absolutely is not. feeds into validation so you can
  stop guessing and start knowing.

  adversarial code comprehension — map your attack surface before you
  attack it. trace flows. hunt variants. teach yourself the framework
  before you trust it. outputs feed /validate so the whole thing hangs
  together.

  yes it has gates. no you cannot skip them.