### PR TITLE
Improve startup UI/UX

### DIFF
--- a/.claude/commands/commands.md
+++ b/.claude/commands/commands.md
@@ -1,0 +1,9 @@
+# RAPTOR Command Reference
+
+Output "Full list of RAPTOR commands:" then list all available RAPTOR slash commands as a bullet list. Format: `- /command <args> — Description`. Derive the list from the available skills — do not use a hardcoded list.
+
+Omit commands flagged as "unavailable" in the most recent startup warnings. Commands flagged as "limited" should still be shown with a note (e.g., `(limited — rr not found)`).
+
+Exclude non-RAPTOR commands (e.g., /commands itself, /help) and internal/duplicate commands (e.g., raptor-scan, raptor-fuzz, raptor-web).
+
+End with: "Commands with missing dependencies are omitted. Check the startup warnings for details."

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ __pycache__/
 .venv/
 .pytest_cache/
 
+# RAPTOR startup
+.startup-output
+
 # RAPTOR outputs
 out/
 .out/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,14 +8,11 @@ Dangerous operations (apply patches, delete, git push): ASK FIRST.
 ## SESSION START
 
 **On first message:**
-VERY IMPORTANT: follow these instructions one by one, in-order.
-1. Read `raptor-offset` as-is with no fixes or changes, display in code block
-2. Read `hackers-8ball`, display random line
-3. Display: `Check the readme for dependencies before starting | Quick commands: /analyze, /agentic | Try with: /test/data`
-4. Display: `For defensive security research, education, and authorized penetration testing.`
-5. Display: `raptor:~$` followed by the selected quote
-6. **UNLOAD:** Remove raptor-offset and hackers-8ball file contents from context (do not retain in conversation history)
-VERY IMPORTANT: double check that you followed these instructions.
+VERY IMPORTANT: follow these steps in order.
+1. Run `python3 raptor_startup.py >/dev/null 2>&1` (generates `.startup-output`)
+2. Read `.startup-output` using the Read tool, then output its contents verbatim as a fenced code block (``` with no language tag). Do NOT paraphrase or reformat.
+3. **UNLOAD:** Remove `.startup-output` contents from context (do not retain in conversation history)
+4. On a single line, output "Quick commands:" then list the /agentic, /scan, /fuzz, /web commands (don't explain what they do) and note /commands for the full list.
 
 ---
 

--- a/bin/raptor
+++ b/bin/raptor
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# raptor — launch RAPTOR via Claude Code
+#
+# Install: add this directory to PATH, or symlink to a directory already on PATH.
+#
+
+set -euo pipefail
+
+# Resolve symlinks to find the real script location
+SCRIPT="$0"
+while [ -L "$SCRIPT" ]; do
+    DIR="$(cd "$(dirname "$SCRIPT")" && pwd)"
+    SCRIPT="$(readlink "$SCRIPT")"
+    [[ "$SCRIPT" != /* ]] && SCRIPT="$DIR/$SCRIPT"
+done
+RAPTOR_DIR="$(cd "$(dirname "$SCRIPT")/.." && pwd)"
+
+# --- Usage ---
+
+usage() {
+    cat <<'EOF'
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣤⣤⣀⣀
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣾⣿⣿⠿⠿⠟
+⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣀⣀⣀⣀⣀⣤⣴⣶⣶⣶⣤⣿⡿⠁
+⣀⠤⠴⠒⠒⠛⠛⠛⠛⠛⠿⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠟⠁
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⣿⣿⣿⡟⠻⢿⡀
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣾⢿⣿⠟⠀⠸⣊⡽
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⡇⣿⡁⠀⠀⠀⠉⠁
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠻⠿⣿⣧
+
+Usage: raptor [options] [target]
+
+Arguments:
+  target             Path or URL to scan (optional)
+
+Options:
+  -c, --continue     Resume last RAPTOR session
+  -m, --model MODEL  Choose model (opus, sonnet, haiku)
+  -v, --verbose      Verbose output
+  -h, --help         Show this help
+
+Any additional flags are passed through to claude.
+EOF
+    exit 0
+}
+
+# --- Parse args ---
+
+CLAUDE_ARGS=(-n RAPTOR)
+INITIAL_PROMPT="/raptor"
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            ;;
+        -c|--continue)
+            CLAUDE_ARGS+=(--continue)
+            INITIAL_PROMPT=""
+            shift
+            ;;
+        -m|--model)
+            [[ $# -ge 2 ]] || { echo "  -m requires a model name"; exit 1; }
+            CLAUDE_ARGS+=(--model "$2")
+            shift 2
+            ;;
+        -v|--verbose)
+            CLAUDE_ARGS+=(--verbose)
+            shift
+            ;;
+        -*)
+            CLAUDE_ARGS+=("$1")
+            shift
+            ;;
+        *)
+            TARGET="${TARGET:+$TARGET }$1"
+            shift
+            ;;
+    esac
+done
+
+if [ -n "$TARGET" ] && [ -n "$INITIAL_PROMPT" ]; then
+    INITIAL_PROMPT="/raptor $TARGET"
+fi
+
+# --- Prerequisites ---
+
+if ! command -v claude >/dev/null 2>&1; then
+    echo "  claude not found on PATH. Install Claude Code first."
+    echo "  https://docs.anthropic.com/en/docs/claude-code/overview"
+    exit 1
+fi
+
+if [ ! -d "$RAPTOR_DIR" ]; then
+    echo "  RAPTOR directory not found: $RAPTOR_DIR"
+    exit 1
+fi
+
+# --- Launch ---
+
+cd "$RAPTOR_DIR"
+if [ -n "$INITIAL_PROMPT" ]; then
+    exec claude "$INITIAL_PROMPT" "${CLAUDE_ARGS[@]}"
+else
+    exec claude "${CLAUDE_ARGS[@]}"
+fi

--- a/core/config.py
+++ b/core/config.py
@@ -17,6 +17,21 @@ class RaptorConfig:
     # Version
     VERSION = "3.0.0"
 
+    # Tool dependencies for startup checks
+    # severity: "required" = feature unavailable, "degrades" = feature limited
+    # group: tools in same group need at least one present
+    TOOL_DEPS = {
+        "afl++":    {"binary": "afl-fuzz",  "severity": "required", "affects": "/fuzz"},
+        "codeql":   {"binary": "codeql",    "group": "scanner",     "affects": "/codeql, /agentic"},
+        "gdb":      {"binary": "gdb",       "severity": "required", "affects": "/crash-analysis, /fuzz"},
+        "rr":       {"binary": "rr",        "severity": "degrades", "affects": "/crash-analysis"},
+        "semgrep":  {"binary": "semgrep",   "group": "scanner",     "affects": "/scan, /agentic"},
+    }
+
+    TOOL_GROUPS = {
+        "scanner": {"min_required": 1, "affects": "/scan, /agentic"},
+    }
+
     # Path Configuration
     REPO_ROOT = Path(__file__).resolve().parent.parent
     ENGINE_DIR = REPO_ROOT / "engine"

--- a/raptor_startup.py
+++ b/raptor_startup.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+RAPTOR startup display — prints banner and environment status.
+
+Called by the /raptor skill. Writes output to .startup-output for the LLM to read.
+"""
+
+import os
+import random
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(REPO_ROOT))
+OUTPUT_FILE = REPO_ROOT / ".startup-output"
+
+
+def _read_logo() -> str:
+    path = REPO_ROOT / "raptor-offset"
+    return path.read_text().rstrip() if path.exists() else ""
+
+
+def _read_random_quote() -> str:
+    path = REPO_ROOT / "hackers-8ball"
+    if path.exists():
+        lines = [l.strip() for l in path.read_text().splitlines() if l.strip()]
+        if lines:
+            return random.choice(lines)
+    return '"Hack the planet!"'
+
+
+def _check_tools() -> tuple[list, list, set]:
+    """Returns (results, warnings, unavailable_features)."""
+    from core.config import RaptorConfig
+
+    results = []
+    available = set()
+    for name in sorted(RaptorConfig.TOOL_DEPS):
+        found = bool(shutil.which(RaptorConfig.TOOL_DEPS[name]["binary"]))
+        results.append((name, found))
+        if found:
+            available.add(name)
+
+    warnings = []
+    unavailable_features = set()
+
+    # Group checks (e.g., need at least one scanner)
+    for group_name, group in RaptorConfig.TOOL_GROUPS.items():
+        members = sorted(n for n, d in RaptorConfig.TOOL_DEPS.items() if d.get("group") == group_name)
+        if not any(m in available for m in members):
+            warnings.append(f"{group['affects']} unavailable \u2014 no scanner ({' or '.join(members)})")
+            for cmd in group["affects"].split(", "):
+                unavailable_features.add(cmd.strip())
+
+    # Individual checks (skip group members)
+    for name in sorted(RaptorConfig.TOOL_DEPS):
+        dep = RaptorConfig.TOOL_DEPS[name]
+        if name in available or dep.get("group"):
+            continue
+        severity = dep.get("severity", "degrades")
+        label = "unavailable" if severity == "required" else "limited"
+        warnings.append(f"{dep['affects']} {label} \u2014 {name} not found")
+        if severity == "required":
+            for cmd in dep["affects"].split(", "):
+                unavailable_features.add(cmd.strip())
+
+    return results, warnings, unavailable_features
+
+
+def _check_llm() -> tuple[list, list]:
+    """Returns (lines, warnings)."""
+    lines = []
+    warnings = []
+
+    try:
+        from packages.llm_analysis.llm.detection import (
+            detect_llm_availability, OPENAI_SDK_AVAILABLE, ANTHROPIC_SDK_AVAILABLE,
+        )
+        from packages.llm_analysis.llm.model_data import PROVIDER_ENV_KEYS
+
+        avail = detect_llm_availability()
+
+        # SDK mismatch warnings
+        sdk_reqs = {
+            "anthropic": ("anthropic", ANTHROPIC_SDK_AVAILABLE or OPENAI_SDK_AVAILABLE),
+            "openai": ("openai", OPENAI_SDK_AVAILABLE),
+            "gemini": ("openai", OPENAI_SDK_AVAILABLE),
+            "mistral": ("openai", OPENAI_SDK_AVAILABLE),
+        }
+        for provider, env_var in PROVIDER_ENV_KEYS.items():
+            if os.getenv(env_var):
+                sdk_name, ok = sdk_reqs.get(provider, ("openai", OPENAI_SDK_AVAILABLE))
+                if not ok:
+                    warnings.append(f"{env_var} set but {sdk_name} SDK missing \u2014 pip install {sdk_name}")
+
+        if avail.external_llm:
+            from packages.llm_analysis.llm.config import LLMConfig
+            cfg = LLMConfig()
+            if cfg.primary_model:
+                pm = cfg.primary_model
+                src = _key_source(pm.provider, PROVIDER_ENV_KEYS)
+                lines.append(f"   llm: {pm.provider}/{pm.model_name} (primary, {src})")
+                for fm in cfg.fallback_models[:3]:
+                    if f"{fm.provider}/{fm.model_name}" != f"{pm.provider}/{pm.model_name}":
+                        lines.append(f"        {fm.provider}/{fm.model_name} (fallback, {_key_source(fm.provider, PROVIDER_ENV_KEYS)})")
+        else:
+            lines.append("   llm: no external LLM configured")
+
+        if avail.claude_code:
+            lines.append("        claude code \u2713")
+
+    except Exception as e:
+        lines.append("   llm: detection error")
+        warnings.append(f"LLM detection: {e}")
+
+    return lines, warnings
+
+
+def _key_source(provider: str, env_keys: dict) -> str:
+    if provider == "ollama":
+        return "local"
+    env_var = env_keys.get(provider, "")
+    if env_var and os.getenv(env_var):
+        return f"via {env_var}"
+    return "via models.json"
+
+
+def _check_env(unavailable_features: set) -> tuple[list, list]:
+    """Returns (env_parts, warnings)."""
+    from core.config import RaptorConfig
+
+    parts = []
+    warnings = []
+
+    out_dir = RaptorConfig.get_out_dir()
+    out_ok = out_dir.exists() and os.access(out_dir, os.W_OK)
+    parts.append("out/ \u2713" if out_ok else "out/ \u2717")
+    if not out_ok:
+        warnings.append("out/ directory not writable")
+
+    try:
+        stat = os.statvfs(str(out_dir if out_dir.exists() else REPO_ROOT))
+        free_bytes = stat.f_bavail * stat.f_frsize
+        free_gb = free_bytes / (1024 ** 3)
+        parts.append(f"disk {free_gb:.0f} GB free" if free_gb >= 1 else f"disk {free_bytes / (1024**2):.0f} MB free")
+        if free_gb < 5 and "/fuzz" not in unavailable_features:
+            warnings.append(f"Low disk space ({free_gb:.1f} GB) \u2014 fuzzing may fail")
+    except OSError:
+        pass
+
+    if os.getenv("RAPTOR_OUT_DIR"):
+        parts.append(f"RAPTOR_OUT_DIR={os.getenv('RAPTOR_OUT_DIR')}")
+    if os.getenv("RAPTOR_CONFIG"):
+        parts.append(f"RAPTOR_CONFIG={os.getenv('RAPTOR_CONFIG')}")
+
+    if not os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
+        warnings.append("/oss-forensics unavailable \u2014 BigQuery not configured")
+
+    return parts, warnings
+
+
+def _format(logo, quote, tool_results, tool_warnings, llm_lines, llm_warnings, env_parts, env_warnings):
+    lines = []
+
+    if logo:
+        lines.append(logo)
+        lines.append("")
+
+    # Tools
+    tool_parts = [f"{name} {'\u2713' if ok else '\u2717'}" for name, ok in tool_results]
+    lines.append(f" tools: {'  '.join(tool_parts)}")
+
+    # Env
+    lines.append(f"   env: {'  '.join(env_parts)}")
+
+    # LLM
+    lines.extend(llm_lines)
+
+    # Warnings: unavailable first, then limited, then other
+    all_raw = tool_warnings + env_warnings + llm_warnings
+    ordered = (
+        [w for w in all_raw if "unavailable" in w] +
+        [w for w in all_raw if "limited" in w] +
+        [w for w in all_raw if "unavailable" not in w and "limited" not in w]
+    )
+    if ordered:
+        lines.append(f"  warn: {ordered[0]}")
+        for w in ordered[1:]:
+            lines.append(f"        {w}")
+
+    lines.append("")
+    lines.append("  For defensive security research, education, and authorized penetration testing.")
+    lines.append("")
+    lines.append(f"raptor:~$ {quote}")
+
+    return "\n".join(lines)
+
+
+def main():
+    logo = _read_logo()
+    quote = _read_random_quote()
+
+    try:
+        import logging
+        logging.disable(logging.WARNING)
+
+        tool_results, tool_warnings, unavailable = _check_tools()
+        llm_lines, llm_warnings = _check_llm()
+        env_parts, env_warnings = _check_env(unavailable)
+
+        logging.disable(logging.NOTSET)
+
+        output = _format(logo, quote, tool_results, tool_warnings, llm_lines, llm_warnings, env_parts, env_warnings)
+    except Exception:
+        output = f"{logo}\n\nraptor:~$ {quote}"
+
+    OUTPUT_FILE.write_text(output)
+    print(output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Improve startup UX: Python status checks, CLI wrapper, /commands reference
  
  ## Summary
  
  - Move deterministic startup checks (tools, environment, LLM config) out of the LLM and into a Python script — no reason to use an LLM for mechanical checks
  - Add `bin/raptor` bash wrapper for launching RAPTOR from anywhere
  - Add `/commands` skill for dynamic command reference, replacing hardcoded lists                                                                                                                                 
  - Move tool dependency declarations to `core/config.py` for single-source-of-truth management
  
  ## UI improvements                                                                                                                                                                                               
   
  - Status block: tools, env, LLM config at a glance with ✓/✗ indicators                                                                                                                                           
                                                                                                                                                                                                                   
  ## UX improvements                                                                                                                                                                                               
                  
  - `raptor` command: launch from anywhere without cd'ing into the repo                                                                                                                                            
  - `/commands`: full command reference, dynamically generated from available skills
                                                                                                                                                                                                                   
  ## What changed                                                                                                                                                                                                  
                                                                                                                                                                                                                   
  **Startup (`raptor_startup.py`)**
  - Tool availability checks against declarative `TOOL_DEPS`/`TOOL_GROUPS` in `core/config.py`
  - LLM provider detection (primary model, fallbacks, claude code)
  - Environment checks (out/ writable, disk space, BigQuery, config overrides)                                                                                                                                     
  - Writes to `.startup-output` for the LLM to read — avoids bash output truncation
                                                                                                                                                                                                                   
  **CLI wrapper (`bin/raptor`)**                                                                                                                                                                                   
  - Resolves symlinks, finds repo root, cd's into it
  - Parses RAPTOR-specific flags, passes everything else through to claude                                                                                                                                         

  **CLAUDE.md**
  - SESSION START simplified 
  
  **`/commands`**
  - Dynamically lists available RAPTOR skills — no hardcoded command list to maintain
  - Omits commands with missing dependencies, notes limited ones
  
  ## Test plan
  
  - [ ] Run `raptor` from shell — banner + status displayed, no truncation
  - [ ] Run `raptor /tmp/some-repo` — startup then scans the target
  - [ ] Run `raptor -c` — resumes last session without re-running startup
  - [ ] Run `raptor --help` — shows usage with dinosaur
  - [ ] Run `/raptor` inside claude directly — same startup behaviour
  - [ ] Run `/commands` — lists available commands, omits unavailable ones
  - [ ] Verify warnings: remove `rr` from PATH, confirm "limited" warning appears
  - [ ] Verify `bin/raptor` works via symlink