### PR TITLE
Rewrite Phase 4 orchestration: task-based dispatch, parallel scanning, cost tracking, consensus, structural grouping

### DIFF
--- a/.claude/commands/agentic.md
+++ b/.claude/commands/agentic.md
@@ -2,9 +2,10 @@
 
 🤖 **AGENTIC MODE** - This will autonomously:
 1. Scan code with Semgrep/CodeQL
-2. Analyze each finding with LLM
-3. **Generate exploit PoCs** (proof-of-concept code)
-4. **Generate secure patches**
+2. Analyze each finding with LLM (parallel dispatch)
+3. **Generate exploit PoCs** for exploitable findings
+4. **Generate secure patches** for confirmed vulnerabilities
+5. **Cross-finding analysis** (structural grouping, shared root causes)
 
 Nothing will be applied to your code - only generated in out/ directory.
 
@@ -15,6 +16,15 @@ Execute: `python3 raptor.py agentic --repo <path>`
 When no external LLM is configured, **YOU (Claude Code) are the LLM.** Phase 4
 dispatches `claude -p` sub-agents to analyse each finding in parallel. If Phase 4
 did not run (no `claude` on PATH), you may be asked to analyse the findings directly.
+
+When an external LLM is configured, Phase 4 dispatches to it in parallel via
+`generate_structured()`. Model roles determine which model analyses (analysis),
+writes code (code), and provides second opinions (consensus). If the external
+LLM fails, Phase 4 falls back to Claude Code dispatch automatically.
+
+After per-finding analysis: structural grouping identifies related findings,
+group analysis explains shared patterns, and consensus (if configured) flags
+disputed verdicts. Cost tracking is real-time with adaptive budget cutoff.
 
 ## Report modes
 
@@ -34,14 +44,15 @@ and `feasibility`. If the user asks you to analyse them, for each finding:
 Do NOT include raw code from the findings in sub-agent prompts — let each agent
 read the code itself via the Read tool.
 
-**`"mode": "full"`** — An external LLM performed analysis in Phase 3.
-Present the results to the user.
+**`"mode": "full"`** — An external LLM performed sequential analysis in Phase 3
+(when Claude Code was not available). Present the results to the user.
 
-**`"mode": "orchestrated"`** — Claude Code sub-agents performed parallel
-analysis in Phase 4 via `claude -p` subprocesses. Present the results to
-the user.
+**`"mode": "orchestrated"`** — Phase 4 performed parallel analysis via external
+LLM or Claude Code sub-agents. Results include per-finding `analysed_by` (which
+model), `cost_usd`, `duration_seconds`, plus `cross_finding_groups` and optional
+`consensus` data. Present the results to the user.
 
 In all modes, findings are in the `results` array of the report. Orchestrated
-and full mode findings include `analysis`, `exploitable`, `exploit_code`, and
+and full mode findings include `is_exploitable`, `reasoning`, `exploit_code`, and
 `patch_code` fields. Prep-only findings include `code`, `surrounding_context`,
 `dataflow`, and `feasibility` for review.

--- a/core/progress.py
+++ b/core/progress.py
@@ -14,9 +14,11 @@ class HackerProgress:
 
     SPINNERS = ['▌', '▀', '▐', '▄']  # Block rotation
 
-    def __init__(self, total: Optional[int] = None, operation: str = "Processing"):
+    def __init__(self, total: Optional[int] = None, operation: str = "Processing",
+                 disabled: bool = False):
         self.total = total
         self.operation = operation
+        self.disabled = disabled
         self.current = 0
         self.start_time = time.time()
         self.last_update = 0
@@ -42,6 +44,8 @@ class HackerProgress:
 
     def update(self, current: Optional[int] = None, message: str = ""):
         """Update progress display."""
+        if self.disabled:
+            return
         now = time.time()
 
         # Only update display every 1 second
@@ -85,12 +89,15 @@ class HackerProgress:
 
     def __enter__(self):
         """Context manager entry."""
-        sys.stderr.write(f">>> {self.operation.upper()} SEQUENCE ACTIVE <<<\n")
-        sys.stderr.flush()
+        if not self.disabled:
+            sys.stderr.write(f">>> {self.operation.upper()} SEQUENCE ACTIVE <<<\n")
+            sys.stderr.flush()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Context manager exit."""
+        if self.disabled:
+            return False
         if exc_type is None:
             self.finish()
         else:

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -309,7 +309,7 @@ def convert_validated_to_agent_format(data: dict) -> List[Dict[str, Any]]:
             "startLine": f.line,
             "endLine": f.line,
             "snippet": f.proof.vulnerable_code,
-            "message": f.candidate_reasoning or f"{f.vuln_type} in {f.function or 'unknown'}",
+            "message": f.candidate_reasoning or f.message or f"{f.vuln_type} in {f.function or 'unknown'}",
             "level": "error" if f.final_status in ("exploitable", "likely_exploitable", "confirmed_constrained") else "warning",
             "has_dataflow": bool(f.proof.flow),
             "feasibility": feasibility_d,
@@ -634,20 +634,27 @@ Do NOT:
             return {}
 
     def analyze_vulnerability(self, vuln: VulnerabilityContext) -> bool:
-        logger.info("=" * 70)
-        logger.info(f"Analysing vulnerability: {vuln.rule_id}")
-        logger.info(f"  File: {vuln.file_path}:{vuln.start_line}")
-        logger.info(f"  Severity: {vuln.level}")
-        logger.info(f"  Has dataflow: {'Yes' if vuln.has_dataflow else 'No'}")
-        logger.info(f"  Message: {vuln.message[:100]}..." if len(vuln.message) > 100 else f"  Message: {vuln.message}")
+        is_prep = isinstance(self.llm, ClaudeCodeProvider)
+
+        if is_prep:
+            # Condensed logging for prep-only mode
+            logger.info(f"Prepping: {vuln.rule_id} at {vuln.file_path}:{vuln.start_line}")
+        else:
+            logger.info("=" * 70)
+            logger.info(f"Analysing vulnerability: {vuln.rule_id}")
+            logger.info(f"  File: {vuln.file_path}:{vuln.start_line}")
+            logger.info(f"  Severity: {vuln.level}")
+            logger.info(f"  Has dataflow: {'Yes' if vuln.has_dataflow else 'No'}")
+            logger.info(f"  Message: {vuln.message[:100]}..." if len(vuln.message) > 100 else f"  Message: {vuln.message}")
 
         # Read the actual vulnerable code
         if not vuln.read_vulnerable_code():
             logger.error(f"✗ Cannot read code for {vuln.finding_id}")
             return False
 
-        logger.info(f"✓ Read vulnerable code ({len(vuln.full_code)} chars)")
-        logger.info(f"✓ Read context ({len(vuln.surrounding_context)} chars)")
+        if not is_prep:
+            logger.info(f"✓ Read vulnerable code ({len(vuln.full_code)} chars)")
+            logger.info(f"✓ Read context ({len(vuln.surrounding_context)} chars)")
 
         # Extract dataflow path if available
         if vuln.has_dataflow:
@@ -659,141 +666,28 @@ Do NOT:
                 logger.warning(f"⚠️  Failed to extract dataflow path")
 
         # Generate analysis using LLM
-        analysis_schema = {
-            "is_true_positive": "boolean",
-            "is_exploitable": "boolean",
-            "exploitability_score": "float (0.0-1.0)",
-            "severity_assessment": "string (critical/high/medium/low)",
-            "reasoning": "string",
-            "attack_scenario": "string",
-            "prerequisites": "list of strings",
-            "impact": "string",
-            "cvss_score_estimate": "float (0.0-10.0)",
-        }
+        from packages.llm_analysis.prompts import (
+            build_analysis_prompt, build_analysis_schema, ANALYSIS_SYSTEM_PROMPT,
+        )
 
-        # Add dataflow-specific fields if applicable
-        if vuln.has_dataflow:
-            analysis_schema.update({
-                "source_attacker_controlled": "boolean - is the dataflow source controlled by attacker?",
-                "sanitizers_effective": "boolean - are sanitizers in the path effective?",
-                "sanitizer_bypass_technique": "string - how to bypass sanitizers, or empty if effective",
-                "dataflow_exploitable": "boolean - is the complete dataflow path exploitable?",
-            })
+        analysis_schema = build_analysis_schema(has_dataflow=vuln.has_dataflow)
 
-        # Build base prompt
-        base_prompt = f"""You are an expert security researcher analysing a potential vulnerability. Reason with your deep knowledge of software security, exploit development, and real-world attack scenarios. Do not guess or assume at any time.
+        prompt = build_analysis_prompt(
+            rule_id=vuln.rule_id,
+            level=vuln.level,
+            file_path=vuln.file_path,
+            start_line=vuln.start_line,
+            end_line=vuln.end_line,
+            message=vuln.message,
+            code=vuln.full_code,
+            surrounding_context=vuln.surrounding_context,
+            has_dataflow=vuln.has_dataflow,
+            dataflow_source=vuln.dataflow_source,
+            dataflow_sink=vuln.dataflow_sink,
+            dataflow_steps=vuln.dataflow_steps,
+        )
 
-**Vulnerability Details:**
-- Rule: {vuln.rule_id}
-- Severity: {vuln.level}
-- File: {vuln.file_path}
-- Lines: {vuln.start_line}-{vuln.end_line}
-- Description: {vuln.message}
-"""
-
-        # Add dataflow analysis if available (GAME CHANGER!)
-        if vuln.has_dataflow and vuln.dataflow_source and vuln.dataflow_sink:
-            base_prompt += f"""
-**🔍 COMPLETE DATAFLOW PATH ANALYSIS (Source → Sink):**
-
-This vulnerability has a complete dataflow path tracked by CodeQL from tainted source to dangerous sink.
-
-**1. SOURCE (Where tainted data originates):**
-   Location: {vuln.dataflow_source['file']}:{vuln.dataflow_source['line']}
-   Type: {vuln.dataflow_source['label']}
-
-   Code:
-   ```
-{vuln.dataflow_source['code']}
-   ```
-
-"""
-
-            # Add intermediate steps
-            if vuln.dataflow_steps:
-                base_prompt += f"**2. DATAFLOW PATH ({len(vuln.dataflow_steps)} intermediate step(s)):**\n\n"
-
-                for i, step in enumerate(vuln.dataflow_steps, 1):
-                    marker = "🛡️ SANITIZER/VALIDATOR" if step['is_sanitizer'] else "⚙️ TRANSFORMATION"
-                    base_prompt += f"""   {marker} Step {i}: {step['label']}
-   Location: {step['file']}:{step['line']}
-
-   Code:
-   ```
-{step['code']}
-   ```
-
-"""
-
-            base_prompt += f"""**3. SINK (Dangerous operation where tainted data is used):**
-   Location: {vuln.dataflow_sink['file']}:{vuln.dataflow_sink['line']}
-   Type: {vuln.dataflow_sink['label']}
-
-   Code:
-   ```
-{vuln.dataflow_sink['code']}
-   ```
-
-**⚠️ CRITICAL DATAFLOW ANALYSIS REQUIRED:**
-
-You have the COMPLETE attack path from source to sink. Use this to make an informed decision:
-
-1. **Is the SOURCE actually attacker-controlled?**
-   - HTTP parameter, user input, file upload → HIGH risk, attacker controls this
-   - Configuration file, environment variable → MEDIUM risk, requires other access
-   - Hardcoded constant, internal data → FALSE POSITIVE, not attacker-controlled
-
-2. **Are any sanitizers in the path EFFECTIVE?**
-   - For each sanitizer/validator step, determine if it actually prevents exploitation
-   - Can an attacker bypass it with encoding, special characters, or edge cases?
-   - Is it applied correctly to all code paths?
-
-3. **Is the complete path EXPLOITABLE?**
-   - Can you trace a realistic attack from source through all steps to sink?
-   - What payload would bypass sanitizers and reach the sink with malicious content?
-
-4. **What's the ACTUAL exploitability** considering the full dataflow path?
-
-"""
-        else:
-            # No dataflow - use surrounding context
-            base_prompt += f"""
-**Vulnerable Code:**
-```
-{vuln.full_code}
-```
-
-**Surrounding Context:**
-```
-{vuln.surrounding_context}
-```
-
-"""
-
-        # Add analysis tasks
-        base_prompt += """
-**Your Task:**
-Analyse this vulnerability in depth:
-1. Is this a TRUE POSITIVE or FALSE POSITIVE?
-2. Is it actually EXPLOITABLE in practice?
-3. What's the real-world exploitability score (0.0 = impossible, 1.0 = trivial)?
-4. What would an attacker need to exploit this?
-5. What's the potential impact?
-6. Provide a CVSS score estimate (0.0-10.0)
-7. Explain your reasoning in detail.
-8. Showcase how modern mitigations might affect exploitability.
-
-Provide detailed technical analysis based on actual code review, not just the rule match."""
-
-        prompt = base_prompt
-
-        system_prompt = """You are a senior security researcher with expertise in:
-- Vulnerability analysis and exploit development
-- Secure code review
-- Static and variant analysis
-- Real-world attack scenarios
-
-Provide honest, technical assessments. Don't overstate severity, but don't downplay real risks."""
+        system_prompt = ANALYSIS_SYSTEM_PROMPT
 
         try:
             logger.info("Sending vulnerability to LLM for analysis...")
@@ -899,68 +793,22 @@ Provide honest, technical assessments. Don't overstate severity, but don't downp
         logger.info(f"Generating exploit PoC for {vuln.rule_id}")
         logger.info(f"   Target: {vuln.file_path}:{vuln.start_line}")
 
-        prompt = f"""You are an expert security researcher creating a proof-of-concept exploit for authorised security testing.
-        This is needed for detection engineering and to validate patches. This is strictly for defensive security purposes.
-        You are Mark Dowd or Charlie Miller. Do not guess or assume at any time.
+        from packages.llm_analysis.prompts import (
+            build_exploit_prompt, EXPLOIT_SYSTEM_PROMPT,
+        )
 
-**Vulnerability:**
-- Type: {vuln.rule_id}
-- File: {vuln.file_path}:{vuln.start_line}
-- Severity: {vuln.level}
+        prompt = build_exploit_prompt(
+            rule_id=vuln.rule_id,
+            file_path=vuln.file_path,
+            start_line=vuln.start_line,
+            level=vuln.level,
+            analysis=vuln.analysis,
+            code=vuln.full_code,
+            surrounding_context=vuln.surrounding_context,
+            feasibility=vuln.feasibility if hasattr(vuln, 'feasibility') else None,
+        )
 
-**Analysis:**
-{json.dumps(vuln.analysis, indent=2)}
-"""
-
-        # Add exploitation constraints from feasibility analysis if available
-        if hasattr(vuln, 'feasibility') and vuln.feasibility:
-            chain_breaks = vuln.feasibility.get("chain_breaks", [])
-            what_would_help = vuln.feasibility.get("what_would_help", [])
-            if chain_breaks or what_would_help:
-                prompt += "\n**EXPLOITATION CONSTRAINTS:**\n"
-                if chain_breaks:
-                    prompt += "Techniques that WON'T work (verified blockers):\n"
-                    for cb in chain_breaks:
-                        prompt += f"  - {cb}\n"
-                if what_would_help:
-                    prompt += "Viable approaches to consider:\n"
-                    for wh in what_would_help:
-                        prompt += f"  - {wh}\n"
-                prompt += "\nDo NOT attempt blocked techniques. Focus on viable approaches.\n"
-
-        prompt += f"""
-**Vulnerable Code:**
-```
-{vuln.full_code}
-```
-
-**Full Context:**
-```
-{vuln.surrounding_context}
-```
-
-**Your Task:**
-Create a WORKING proof-of-concept exploit that:
-1. Demonstrates this specific vulnerability
-2. Is safe to run in an isolated lab environment
-3. Includes clear comments explaining the attack
-4. Has detailed output showing successful exploitation
-5. Includes responsible disclosure warnings
-6. Prefer C++ for low-level exploits, Python for web/app vulnerabilities
-7. If you feel you cannot create a working exploit, explain why in full detail.
-
-Write complete, executable code as per the prime directives above. Make it realistic and practical, not just theoretical.
-The exploit should actually work against the vulnerable code, or system, shown above."""
-
-        system_prompt = """You are the legend that is Mark Dowd. A true legend in this space and prolific exploit developer.
-Create practical, working exploits that security teams can use to:
-- Validate vulnerability findings
-- Test detection capabilities
-- Develop patches with confidence
-
-Prefer C++ for low-level/binary exploits, Python for web/application vulnerabilities.
-Include all necessary imports, error handling, and clear output.
-Make exploits safe for authorised testing only and not sold to russians. coz that would be bad."""
+        system_prompt = EXPLOIT_SYSTEM_PROMPT
 
         try:
             logger.info("Requesting exploit code from LLM...")
@@ -1015,68 +863,29 @@ Make exploits safe for authorised testing only and not sold to russians. coz tha
         with open(file_path) as f:
             full_file_content = f.read()
 
-        prompt = f"""You are a senior software security engineer creating a secure patch.
+        from packages.llm_analysis.prompts import (
+            build_patch_prompt, PATCH_SYSTEM_PROMPT,
+        )
 
-**Vulnerability:**
-- Type: {vuln.rule_id}
-- File: {vuln.file_path}:{vuln.start_line}-{vuln.end_line}
-- Description: {vuln.message}
+        # Load attack path if available
+        attack_path = None
+        if vuln.attack_path_ref:
+            attack_path = self._load_attack_path(vuln.attack_path_ref)
 
-**Analysis:**
-{json.dumps(vuln.analysis, indent=2)}
-"""
+        prompt = build_patch_prompt(
+            rule_id=vuln.rule_id,
+            file_path=vuln.file_path,
+            start_line=vuln.start_line,
+            end_line=vuln.end_line,
+            message=vuln.message,
+            analysis=vuln.analysis,
+            code=vuln.full_code,
+            full_file_content=full_file_content,
+            feasibility=vuln.feasibility,
+            attack_path=attack_path,
+        )
 
-        # Add feasibility insights for patch guidance
-        if vuln.feasibility:
-            what_would_help = vuln.feasibility.get("what_would_help")
-            if what_would_help:
-                prompt += "\n**What Would Help Attacker (block these):**\n"
-                for wh in what_would_help:
-                    prompt += f"  - {wh}\n"
-
-            # Load and include attack path steps if available
-            if vuln.attack_path_ref:
-                attack_path = self._load_attack_path(vuln.attack_path_ref)
-                if attack_path and attack_path.get("path"):
-                    prompt += "\n**Attack Path (consider patching at earliest step):**\n"
-                    for step in attack_path["path"]:
-                        prompt += f"  Step {step.get('step', '?')}: {step.get('action', '')} → {step.get('result', '')}\n"
-
-        prompt += f"""
-**Vulnerable Code:**
-```
-{vuln.full_code}
-```
-
-**Full File Content:**
-```
-{full_file_content[:5000]}  # First 5000 chars for context
-```
-
-**Your Task:**
-Create a SECURE PATCH that:
-1. Completely fixes the vulnerability
-2. Preserves all existing functionality
-3. Follows the code's existing style and patterns
-4. Includes clear comments explaining the fix
-5. Adds input validation/sanitisation where needed
-6. Uses modern security best practices
-
-Provide BOTH:
-1. The complete fixed code (not just the diff)
-2. A clear explanation of what changed and why
-3. Testing recommendations
-
-Make this production-ready, not just a quick fix."""
-
-        system_prompt = """You are a senior security engineer responsible for secure code reviews.
-Create patches that are:
-- Secure and comprehensive
-- Maintainable and well-documented
-- Tested and production-ready
-- Following security best practices (OWASP, CWE guidance)
-
-Balance security with usability and performance."""
+        system_prompt = PATCH_SYSTEM_PROMPT
 
         try:
             logger.info("   🤖 Requesting secure patch from LLM...")
@@ -1168,7 +977,7 @@ Balance security with usability and performance."""
 
         converted = convert_validated_to_agent_format(data)
 
-        logger.info(f"Loaded {len(converted)} validated findings from {Path(findings_path).name} "
+        logger.info(f"Loaded {len(converted)} findings from {Path(findings_path).name} "
                     f"(skipped {len(data.get('findings', [])) - len(converted)} ruled out/unlikely)")
         return converted
 
@@ -1179,7 +988,7 @@ Balance security with usability and performance."""
 
         # Parse findings
         logger.info("=" * 70)
-        logger.info("PHASE II: AUTONOMOUS VULNERABILITY ANALYSIS")
+        logger.info("AUTONOMOUS VULNERABILITY ANALYSIS")
         logger.info("=" * 70)
 
         if findings_path:
@@ -1219,15 +1028,18 @@ Balance security with usability and performance."""
         false_positives_found = 0
         idx = 0  # Initialize idx to prevent UnboundLocalError when unique_findings is empty
 
-        # Add progress counter for long operations (>15s per vuln expected)
-        with HackerProgress(total=len(unique_findings), operation="Analyzing vulnerabilities") as progress:
+        is_prep = isinstance(self.llm, ClaudeCodeProvider)
+
+        with HackerProgress(total=len(unique_findings), operation="Analyzing vulnerabilities",
+                            disabled=is_prep) as progress:
             for idx, finding in enumerate(unique_findings, 1):
                 progress.update(current=idx, message=f"{finding.get('rule_id', 'unknown')}")
 
-                logger.info("")
-                logger.info(f"{'█' * 70}")
-                logger.info(f"VULNERABILITY {idx}/{len(unique_findings)}")
-                logger.info(f"{'█' * 70}")
+                if not isinstance(self.llm, ClaudeCodeProvider):
+                    logger.info("")
+                    logger.info(f"{'█' * 70}")
+                    logger.info(f"VULNERABILITY {idx}/{len(unique_findings)}")
+                    logger.info(f"{'█' * 70}")
 
                 vuln = VulnerabilityContext(finding, self.repo_path)
 
@@ -1259,12 +1071,15 @@ Balance security with usability and performance."""
                 results.append(vuln.to_dict())
 
             # Show progress
-            logger.info("")
-            logger.info(f"Progress: {idx}/{len(unique_findings)} analyzed, "
-                       f"{exploitable} exploitable, "
-                       f"{exploits_generated} exploits, "
-                       f"{patches_generated} patches, "
-                       f"{dataflow_validated} dataflow validated")
+            if isinstance(self.llm, ClaudeCodeProvider):
+                logger.info(f"Progress: {idx}/{len(unique_findings)} prepped")
+            else:
+                logger.info("")
+                logger.info(f"Progress: {idx}/{len(unique_findings)} analyzed, "
+                           f"{exploitable} exploitable, "
+                           f"{exploits_generated} exploits, "
+                           f"{patches_generated} patches, "
+                           f"{dataflow_validated} dataflow validated")
 
         execution_time = time.time() - start_time
 
@@ -1297,23 +1112,27 @@ Balance security with usability and performance."""
 
         logger.info("")
         logger.info("=" * 70)
-        logger.info("PHASE II COMPLETE")
+        logger.info("ANALYSIS COMPLETE")
         logger.info("=" * 70)
-        logger.info(f"✓ Processed: {len(unique_findings)} findings")
-        logger.info(f"✓ Analyzed: {analyzed} with LLM")
-        logger.info(f"✓ Exploitable: {exploitable} vulnerabilities")
-        logger.info(f"✓ Exploits generated: {exploits_generated}")
-        logger.info(f"✓ Patches generated: {patches_generated}")
-        logger.info(f"")
-        if dataflow_validated > 0:
-            logger.info(f"Dataflow Validation:")
-            logger.info(f"   Deep validated: {dataflow_validated} dataflow paths")
-            logger.info(f"   False positives caught: {false_positives_found}")
+
+        if is_prep_only:
+            logger.info(f"Prep complete: {len(unique_findings)} findings prepared for Phase 4 orchestration")
+        else:
+            logger.info(f"✓ Processed: {len(unique_findings)} findings")
+            logger.info(f"✓ Analyzed: {analyzed} with LLM")
+            logger.info(f"✓ Exploitable: {exploitable} vulnerabilities")
+            logger.info(f"✓ Exploits generated: {exploits_generated}")
+            logger.info(f"✓ Patches generated: {patches_generated}")
             logger.info(f"")
-        logger.info(f"LLM Statistics:")
-        logger.info(f"   Total requests: {llm_stats['total_requests']}")
-        logger.info(f"   Total cost: ${llm_stats['total_cost']:.4f}")
-        logger.info(f"   Execution time: {execution_time:.1f}s")
+            if dataflow_validated > 0:
+                logger.info(f"Dataflow Validation:")
+                logger.info(f"   Deep validated: {dataflow_validated} dataflow paths")
+                logger.info(f"   False positives caught: {false_positives_found}")
+                logger.info(f"")
+            logger.info(f"LLM Statistics:")
+            logger.info(f"   Total requests: {llm_stats['total_requests']}")
+            logger.info(f"   Total cost: ${llm_stats['total_cost']:.4f}")
+            logger.info(f"   Execution time: {execution_time:.1f}s")
         logger.info(f"")
         logger.info(f"Report saved: {report_file}")
         logger.info("=" * 70)
@@ -1394,16 +1213,17 @@ def main() -> None:
     else:
         report = agent.process_findings(sarif_paths=args.sarif, max_findings=args.max_findings)
 
-    print("\n" + "=" * 70)
-    print("Autonomous Security Agent Report")
-    print("=" * 70)
-    print(f"Analyzed: {report['analyzed']}")
-    print(f"Exploitable: {report['exploitable']}")
-    print(f"Exploits generated: {report['exploits_generated']} (LLM-generated)")
-    print(f"Patches generated: {report['patches_generated']} (LLM-generated)")
-    print(f"LLM cost: ${report['llm_stats']['total_cost']:.4f}")
-    print(f"Output: {out_dir}")
-    print("=" * 70)
+    if report.get('mode') != 'prep_only':
+        print("\n" + "=" * 70)
+        print("Autonomous Security Agent Report")
+        print("=" * 70)
+        print(f"Analyzed: {report['analyzed']}")
+        print(f"Exploitable: {report['exploitable']}")
+        print(f"Exploits generated: {report['exploits_generated']} (LLM-generated)")
+        print(f"Patches generated: {report['patches_generated']} (LLM-generated)")
+        print(f"LLM cost: ${report['llm_stats']['total_cost']:.4f}")
+        print(f"Output: {out_dir}")
+        print("=" * 70)
 
 
 if __name__ == "__main__":

--- a/packages/llm_analysis/cc_dispatch.py
+++ b/packages/llm_analysis/cc_dispatch.py
@@ -1,0 +1,301 @@
+"""Claude Code subprocess dispatch internals.
+
+Handles invoking `claude -p` sub-agents, parsing their JSON envelope
+output, building prompts and schemas for CC, and writing debug files.
+
+Used by orchestrator.py via invoke_cc_simple as a dispatch_fn callable.
+"""
+
+import copy
+import json
+import logging
+import subprocess
+from pathlib import Path
+from typing import Any, Dict
+
+from packages.llm_analysis.dispatch import DispatchResult
+from packages.llm_analysis.prompts.schemas import FINDING_RESULT_SCHEMA
+
+logger = logging.getLogger(__name__)
+
+CC_TIMEOUT = 300  # 5 minutes per finding
+CC_BUDGET_PER_FINDING = "1.00"  # string — passed as CLI arg to --max-budget-usd
+
+
+def invoke_cc_simple(prompt, schema, repo_path, claude_bin, out_dir,
+                     timeout=CC_TIMEOUT):
+    """CC invocation with pre-built prompt. Returns DispatchResult.
+
+    Used as a dispatch_fn callable by dispatch_task().
+    """
+    cmd = [
+        claude_bin, "-p",
+        "--output-format", "json",  # Always JSON envelope for cost metadata
+        "--no-session-persistence",
+        "--allowed-tools", "Read,Grep,Glob",
+        "--add-dir", str(repo_path),
+        "--max-budget-usd", CC_BUDGET_PER_FINDING,
+    ]
+
+    # Add structured schema constraint for analysis tasks
+    if schema:
+        effective_schema = build_schema()  # Uses FINDING_RESULT_SCHEMA
+        cmd.extend(["--json-schema", json.dumps(effective_schema)])
+
+    try:
+        proc = subprocess.run(cmd, input=prompt, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return DispatchResult(result={"error": f"timeout after {timeout}s"})
+
+    if proc.returncode != 0:
+        stderr_excerpt = (proc.stderr or "")[:500]
+        result = {"error": f"exit code {proc.returncode}: {stderr_excerpt}"}
+        write_debug(out_dir, "dispatch", proc.stdout, proc.stderr, result)
+        return DispatchResult(result=result)
+
+    if schema:
+        parsed = parse_cc_result(proc.stdout, proc.stderr, "unknown")
+    else:
+        # Free-form with JSON envelope — extract text content and cost metadata
+        parsed = parse_cc_freeform(proc.stdout, proc.stderr)
+
+    cost = parsed.pop("cost_usd", 0)
+    tokens = parsed.pop("_tokens", 0)
+    model = parsed.pop("analysed_by", "claude-code")
+    duration = parsed.pop("duration_seconds", 0)
+
+    return DispatchResult(result=parsed, cost=cost, tokens=tokens, model=model, duration=duration)
+
+
+def write_debug(
+    out_dir: Path,
+    finding_id: str,
+    stdout: str,
+    stderr: str,
+    result: Dict[str, Any],
+) -> None:
+    """Write raw CC output to a debug file on failure."""
+    try:
+        debug_dir = out_dir / "debug"
+        debug_dir.mkdir(parents=True, exist_ok=True)
+        debug_file = debug_dir / f"cc_{finding_id}.txt"
+        debug_file.write_text(f"STDOUT:\n{stdout or '(empty)'}\n\nSTDERR:\n{stderr or '(empty)'}")
+        # Relative path so it works regardless of output dir location
+        result["cc_debug_file"] = f"debug/cc_{finding_id}.txt"
+    except OSError:
+        pass  # Best effort — don't fail the finding over a debug file
+
+
+def build_schema(no_exploits: bool = False, no_patches: bool = False) -> Dict[str, Any]:
+    """Build JSON Schema for CC output, excluding fields the user didn't ask for."""
+    schema = copy.deepcopy(FINDING_RESULT_SCHEMA)
+    if no_exploits:
+        schema["properties"].pop("exploit_code", None)
+    if no_patches:
+        schema["properties"].pop("patch_code", None)
+    return schema
+
+
+def build_finding_prompt(
+    finding: Dict[str, Any],
+    no_exploits: bool = False,
+    no_patches: bool = False,
+) -> str:
+    """Build a lightweight prompt for a CC sub-agent.
+
+    The prompt contains metadata only — rule ID, file path, line numbers,
+    dataflow summary. No raw code from the target repo. The agent reads
+    code itself via Read/Grep/Glob tools, which provides natural separation
+    between instructions and attacker-controlled content.
+    """
+    finding_id = finding.get("finding_id", "unknown")
+    rule_id = finding.get("rule_id", "unknown")
+    file_path = finding.get("file_path", "unknown")
+    start_line = finding.get("start_line", "?")
+    end_line = finding.get("end_line", start_line)
+    # message is scanner-generated but may contain target-repo identifiers
+    # (variable names, file paths). Low risk given read-only tools + schema output.
+    message = finding.get("message", "")
+    level = finding.get("level", "warning")
+
+    prompt = f"""You are a security researcher analysing a potential vulnerability.
+
+## Finding
+- ID: {finding_id}
+- Rule: {rule_id}
+- Severity: {level}
+- File: {file_path}
+- Lines: {start_line}-{end_line}
+- Description: {message}
+"""
+
+    # Dataflow summary (metadata only, no code)
+    dataflow = finding.get("dataflow")
+    if dataflow:
+        source = dataflow.get("source", {})
+        sink = dataflow.get("sink", {})
+        steps = dataflow.get("steps", [])
+        sanitizers = dataflow.get("sanitizers_found", [])
+
+        prompt += f"""
+## Dataflow path
+- Source: {source.get('file', '?')}:{source.get('line', '?')} ({source.get('label', '')})
+- Sink: {sink.get('file', '?')}:{sink.get('line', '?')} ({sink.get('label', '')})
+- Intermediate steps: {len(steps)}
+- Sanitizers found: {len(sanitizers)}
+"""
+        if sanitizers:
+            prompt += "- Sanitizer locations: " + ", ".join(
+                f"{s.get('file', '?')}:{s.get('line', '?')}" for s in sanitizers
+                if isinstance(s, dict)
+            ) + "\n"
+
+    # Feasibility data (small, high-value — include directly)
+    feasibility = finding.get("feasibility")
+    if feasibility:
+        verdict = feasibility.get("verdict", "unknown")
+        chain_breaks = feasibility.get("chain_breaks", [])
+        what_would_help = feasibility.get("what_would_help", [])
+        prompt += f"""
+## Exploit feasibility analysis (from upstream validation pipeline)
+This finding has already been through automated feasibility analysis.
+The constraints below were empirically verified — treat them as ground truth.
+Focus your analysis on attack paths that work within these constraints.
+
+- Verdict: {verdict}
+"""
+        if chain_breaks:
+            prompt += "- Techniques that WON'T work (verified blockers):\n"
+            for cb in chain_breaks:
+                prompt += f"  - {cb}\n"
+        if what_would_help:
+            prompt += "- Viable approaches to consider:\n"
+            for wh in what_would_help:
+                prompt += f"  - {wh}\n"
+
+    # Instructions
+    prompt += """
+## Your task
+
+Read the code at the file path above using the Read tool. Examine the
+surrounding context, imports, and any functions called in the vulnerable code.
+
+1. **Analyse**: Is this a true positive? Is it exploitable in practice?
+   What would an attacker need? What's the real-world impact?
+   Rate exploitability_score from 0.0 (impossible) to 1.0 (trivial).
+"""
+
+    if not no_exploits:
+        prompt += """
+2. **Exploit**: If exploitable, write a proof-of-concept exploit.
+   The exploit should be practical and demonstrate the vulnerability.
+   Include clear comments explaining the attack.
+"""
+
+    if not no_patches:
+        prompt += f"""
+{"3" if not no_exploits else "2"}. **Patch**: Create a secure fix that preserves existing functionality.
+   Read the full file for context before writing the patch.
+"""
+
+    prompt += f"""
+Return your analysis as structured JSON with finding_id "{finding_id}".
+"""
+
+    return prompt
+
+
+def _extract_envelope_metadata(envelope: dict, into: dict) -> None:
+    """Extract cost, duration, model, and token metadata from a claude -p JSON envelope."""
+    if envelope.get("total_cost_usd"):
+        into["cost_usd"] = envelope["total_cost_usd"]
+    if envelope.get("duration_ms"):
+        into["duration_seconds"] = round(envelope["duration_ms"] / 1000, 1)
+    model_usage = envelope.get("modelUsage", {})
+    into["analysed_by"] = next(iter(model_usage)) if model_usage else "claude-code"
+    usage = envelope.get("usage", {})
+    tokens = usage.get("input_tokens", 0) + usage.get("output_tokens", 0)
+    if tokens:
+        into["_tokens"] = tokens
+
+
+def parse_cc_result(
+    stdout: str,
+    stderr: str,
+    finding_id: str,
+) -> Dict[str, Any]:
+    """Parse CC sub-agent JSON output.
+
+    Handles: clean JSON, claude -p envelope, markdown-fenced JSON, partial output.
+    """
+    content = stdout.strip()
+    if not content:
+        stderr_excerpt = (stderr or "")[:500]
+        return {"finding_id": finding_id, "error": f"empty output: {stderr_excerpt}"}
+
+    # Try direct parse
+    try:
+        result = json.loads(content)
+        if isinstance(result, dict):
+            # claude -p --output-format json wraps output in a metadata envelope.
+            # The actual structured output is in the "structured_output" field.
+            if "structured_output" in result and isinstance(result["structured_output"], dict):
+                inner = result["structured_output"]
+                inner.setdefault("finding_id", finding_id)
+                _extract_envelope_metadata(result, inner)
+                return inner
+            result.setdefault("finding_id", finding_id)
+            return result
+    except json.JSONDecodeError:
+        pass
+
+    # Try stripping markdown fences
+    if "```" in content:
+        try:
+            parts = content.split("```")
+            for part in parts[1::2]:  # odd-indexed parts are inside fences
+                # Strip optional language tag
+                lines = part.strip().split("\n", 1)
+                json_str = lines[1] if len(lines) > 1 and not lines[0].startswith("{") else part
+                result = json.loads(json_str.strip())
+                if isinstance(result, dict):
+                    result.setdefault("finding_id", finding_id)
+                    return result
+        except (json.JSONDecodeError, IndexError):
+            pass
+
+    # Last resort: find first valid JSON object using raw_decode
+    try:
+        decoder = json.JSONDecoder()
+        idx = content.index("{")
+        result, _ = decoder.raw_decode(content, idx)
+        if isinstance(result, dict):
+            result.setdefault("finding_id", finding_id)
+            return result
+    except (ValueError, json.JSONDecodeError):
+        pass
+
+    return {"finding_id": finding_id, "error": f"unparseable output: {content[:200]}"}
+
+
+def parse_cc_freeform(stdout: str, stderr: str) -> Dict[str, Any]:
+    """Parse free-form CC output from --output-format json envelope.
+
+    Extracts the text result and cost metadata. Unlike parse_cc_result,
+    doesn't expect structured_output — the result field is the text content.
+    """
+    content = stdout.strip()
+    if not content:
+        return {"content": "", "error": f"empty output: {(stderr or '')[:500]}"}
+
+    try:
+        envelope = json.loads(content)
+        if isinstance(envelope, dict):
+            parsed = {"content": envelope.get("result", "")}
+            _extract_envelope_metadata(envelope, parsed)
+            return parsed
+    except json.JSONDecodeError:
+        pass
+
+    # Fallback: not a JSON envelope, treat as raw text
+    return {"content": content}

--- a/packages/llm_analysis/dispatch.py
+++ b/packages/llm_analysis/dispatch.py
@@ -1,0 +1,253 @@
+"""Generic parallel dispatch for LLM tasks.
+
+Provides DispatchTask base class and dispatch_task() function.
+The dispatcher handles threading, progress, cost tracking, and error handling.
+Task subclasses define semantics: what prompt, what schema, which model.
+"""
+
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class DispatchResult:
+    """Normalised result from any dispatch path (external LLM or CC)."""
+
+    def __init__(self, result: Dict[str, Any], cost: float = 0.0,
+                 tokens: int = 0, model: str = "", duration: float = 0.0):
+        self.result = result
+        self.cost = cost
+        self.tokens = tokens
+        self.model = model
+        self.duration = duration
+
+
+class DispatchTask:
+    """Base class for parallel LLM dispatch tasks.
+
+    Subclasses define what to dispatch (prompts, schemas, model selection).
+    The generic dispatcher handles how (threading, progress, cost, errors).
+    """
+
+    name: str = "task"
+    model_role: str = "analysis"
+    temperature: float = 0.7
+    budget_cutoff: float = 1.0  # 1.0 = never skip. 0.85 = skip at 85% budget
+
+    def select_items(self, items: list, prior_results: dict) -> list:
+        """Select which items to process. Default: all items."""
+        return items
+
+    def get_models(self, role_resolution: dict) -> list:
+        """Return list of models to dispatch to. Default: single model for this role."""
+        model = role_resolution.get(f"{self.model_role}_model")
+        return [model] if model else []
+
+    def build_prompt(self, item: Dict[str, Any]) -> str:
+        """Build the prompt for one item. Must be implemented by subclass."""
+        raise NotImplementedError
+
+    def get_schema(self, item: Dict[str, Any]) -> Optional[dict]:
+        """Schema for structured output, or None for free-form generate()."""
+        return None
+
+    def get_system_prompt(self) -> Optional[str]:
+        """System prompt for this task."""
+        return None
+
+    def process_result(self, item: Dict[str, Any], result: DispatchResult) -> Dict[str, Any]:
+        """Post-process a single result. Default: return result dict with metadata."""
+        out = dict(result.result)
+        if result.cost > 0:
+            out["cost_usd"] = result.cost
+        if result.duration > 0:
+            out["duration_seconds"] = round(result.duration, 1)
+        if result.model:
+            out["analysed_by"] = result.model
+        return out
+
+    def finalize(self, results: List[Dict], prior_results: dict) -> List[Dict]:
+        """Post-dispatch processing. Default: no-op. Override for consensus verdicts, etc."""
+        return results
+
+    def get_item_id(self, item: Dict[str, Any]) -> str:
+        """ID for result matching and progress display."""
+        return item.get("finding_id", item.get("group_id", "unknown"))
+
+    def get_item_display(self, item: Dict[str, Any]) -> str:
+        """Human-readable location for progress line."""
+        fp = item.get("file_path", "")
+        if fp:
+            fp = fp.split("/")[-1]
+            line = item.get("start_line", "")
+            return f"{fp}:{line}" if line else fp
+        return ""
+
+
+def _format_elapsed(seconds: float) -> str:
+    """Format elapsed seconds: '45s', '2m 15s', or '1h 05m'."""
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    if seconds < 3600:
+        minutes = int(seconds // 60)
+        secs = int(seconds % 60)
+        return f"{minutes}m {secs:02d}s"
+    hours = int(seconds // 3600)
+    minutes = int((seconds % 3600) // 60)
+    return f"{hours}h {minutes:02d}m"
+
+
+def _is_auth_error(error_str: str) -> bool:
+    """Check if an error string indicates an authentication/billing failure."""
+    lower = error_str.lower()
+    return any(x in lower for x in [
+        "401", "403", "authentication", "unauthorized",
+        "invalid api key", "billing", "quota", "rate limit",
+        "insufficient_quota", "credit",
+    ])
+
+
+def dispatch_task(
+    task: DispatchTask,
+    items: list,
+    dispatch_fn: Callable,
+    role_resolution: dict,
+    prior_results: dict,
+    cost_tracker: Any,
+    max_parallel: int = 3,
+) -> List[Dict[str, Any]]:
+    """Generic parallel dispatcher.
+
+    Handles threading, progress output, cost tracking, error handling,
+    and auth abort. The task defines semantics (prompts, schemas, model
+    selection). The dispatch_fn abstracts the LLM interaction.
+
+    Args:
+        task: DispatchTask subclass defining what to dispatch.
+        items: Raw items (findings, groups, etc) — task.select_items filters them.
+        dispatch_fn: Callable(prompt, schema, system_prompt, temperature, model) → DispatchResult.
+        role_resolution: Model role resolution dict from resolve_model_roles().
+        prior_results: Results from earlier tasks, keyed by item ID.
+        cost_tracker: CostTracker for budget enforcement.
+        max_parallel: Maximum concurrent dispatches.
+
+    Returns:
+        List of result dicts, one per item dispatched. Failed items have "error" key.
+    """
+    selected = task.select_items(items, prior_results)
+    if not selected:
+        return []
+
+    models = task.get_models(role_resolution)
+    if not models:
+        # CC path: no model resolution, dispatch_fn ignores model parameter
+        models = [None]
+
+    # Budget pre-check
+    if task.budget_cutoff < 1.0:
+        model_name = models[0].model_name if models[0] else ""
+        total_calls = len(selected) * len(models)
+        if cost_tracker.should_skip_phase(total_calls, model_name, task.budget_cutoff, task.name):
+            return []
+
+    # Build work items: (model, item) pairs
+    work = []
+    for model in models:
+        for item in selected:
+            work.append((model, item))
+
+    total = len(work)
+    print(f"\n  {task.name}: {len(selected)} items"
+          + (f" x {len(models)} models" if len(models) > 1 else "")
+          + f" (max {max_parallel} parallel)")
+
+    results = []
+    completed = 0
+    running_cost = 0.0
+    abort = False
+    consecutive_errors = 0
+    start = time.monotonic()
+    system_prompt = task.get_system_prompt()
+
+    with ThreadPoolExecutor(max_workers=max_parallel) as executor:
+        futures = {}
+        for model, item in work:
+            def _do_one(m=model, it=item):
+                prompt = task.build_prompt(it)
+                schema = task.get_schema(it)
+                return dispatch_fn(prompt, schema, system_prompt, task.temperature, m)
+
+            future = executor.submit(_do_one)
+            futures[future] = (model, item)
+
+        for future in as_completed(futures):
+            model, item = futures[future]
+            item_id = task.get_item_id(item)
+            completed += 1
+            elapsed = time.monotonic() - start
+
+            try:
+                dispatch_result = future.result()
+                processed = task.process_result(item, dispatch_result)
+                processed["finding_id"] = item_id  # Authoritative — overrides any LLM-set value
+                item_cost = processed.get("cost_usd", 0)
+                running_cost += item_cost
+                results.append(processed)
+                consecutive_errors = 0
+
+                # Feed costs to tracker for budget enforcement
+                if item_cost > 0:
+                    model_name = processed.get("analysed_by", "unknown")
+                    cost_tracker.add_cost(model_name, item_cost)
+
+                # Progress line
+                display = task.get_item_display(item)
+                if "is_exploitable" in processed:
+                    exploitable = processed.get("is_exploitable", False)
+                    score = processed.get("exploitability_score")
+                    try:
+                        status = f"exploitable ({float(score):.2f})" if exploitable else "not exploitable"
+                    except (ValueError, TypeError):
+                        status = "exploitable" if exploitable else "not exploitable"
+                else:
+                    status = "done"
+                cost = processed.get("cost_usd")
+                cost_str = f"  ${cost:.2f}" if cost else ""
+                print(f"  [{completed}/{total} {_format_elapsed(elapsed)} ${running_cost:.2f}] "
+                      f"{display} {status}{cost_str}")
+
+            except Exception as e:
+                err_str = str(e)
+                results.append({"finding_id": item_id, "error": err_str})
+                display = task.get_item_display(item)
+                print(f"  [{completed}/{total} {_format_elapsed(elapsed)} ${running_cost:.2f}] "
+                      f"{display} FAILED — {err_str}")
+
+                if _is_auth_error(err_str):
+                    print("\n  Authentication/billing error — aborting remaining")
+                    abort = True
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    break
+
+                consecutive_errors += 1
+                if consecutive_errors >= 3 and completed == consecutive_errors:
+                    # Every result so far has failed — abort early
+                    print(f"\n  {consecutive_errors} consecutive failures — aborting remaining")
+                    abort = True
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    break
+
+    if abort:
+        completed_ids = {r.get("finding_id") for r in results}
+        for item in selected:
+            item_id = task.get_item_id(item)
+            if item_id not in completed_ids:
+                results.append({"finding_id": item_id, "error": "aborted (auth failure)"})
+
+    # Finalize (e.g. consensus verdict rules)
+    results = task.finalize(results, prior_results)
+
+    return results

--- a/packages/llm_analysis/llm/client.py
+++ b/packages/llm_analysis/llm/client.py
@@ -23,7 +23,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 
 from core.logging import get_logger
 from .config import LLMConfig, ModelConfig
-from .providers import LLMProvider, LLMResponse, create_provider
+from .providers import LLMProvider, LLMResponse, StructuredResponse, create_provider
 
 # Import for type-based error detection (optional SDKs)
 try:
@@ -163,11 +163,13 @@ class LLMClient:
     """Unified LLM client with multi-provider support and fallback."""
 
     def __init__(self, config: Optional[LLMConfig] = None):
+        import threading
         self.config = config or LLMConfig()
         self.providers: Dict[str, LLMProvider] = {}
         self.total_cost = 0.0
         self.request_count = 0
         self.task_type_costs: Dict[str, float] = {}  # task_type → cumulative cost
+        self._stats_lock = threading.RLock()
 
         # HEALTH CHECK: Warn if no API keys configured
         from .detection import detect_llm_availability
@@ -252,13 +254,14 @@ class LLMClient:
             logger.warning(f"Cache write error: {e}")
 
     def _check_budget(self, estimated_cost: float = 0.1) -> bool:
-        """Check if we're within budget."""
+        """Check if we're within budget (thread-safe)."""
         if not self.config.enable_cost_tracking:
             return True
 
-        if self.total_cost + estimated_cost > self.config.max_cost_per_scan:
-            logger.error(f"Budget exceeded: ${self.total_cost:.2f} + ${estimated_cost:.2f} > ${self.config.max_cost_per_scan:.2f}")
-            return False
+        with self._stats_lock:
+            if self.total_cost + estimated_cost > self.config.max_cost_per_scan:
+                logger.error(f"Budget exceeded: ${self.total_cost:.2f} + ${estimated_cost:.2f} > ${self.config.max_cost_per_scan:.2f}")
+                return False
 
         return True
 
@@ -277,7 +280,7 @@ class LLMClient:
         Returns:
             LLMResponse with generated content
 
-        Warning: Not thread-safe. Use locks if enabling concurrent access.
+        Thread-safe: stats tracking uses _stats_lock for concurrent access.
         """
         # Check budget
         if not self._check_budget():
@@ -299,7 +302,8 @@ class LLMClient:
         cached_content = self._get_cached_response(cache_key)
         if cached_content:
             print(f"► Using cached response for {model_config.provider}/{model_config.model_name}")
-            self.request_count += 1
+            with self._stats_lock:
+                self.request_count += 1
             return LLMResponse(
                 content=cached_content,
                 model=model_config.model_name,
@@ -354,11 +358,12 @@ class LLMClient:
                     response = provider.generate(prompt, system_prompt, **kwargs)
                     duration = time.time() - t_start
 
-                    # Track cost
-                    self.total_cost += response.cost
-                    self.request_count += 1
-                    if task_type:
-                        self.task_type_costs[task_type] = self.task_type_costs.get(task_type, 0.0) + response.cost
+                    # Track cost (thread-safe)
+                    with self._stats_lock:
+                        self.total_cost += response.cost
+                        self.request_count += 1
+                        if task_type:
+                            self.task_type_costs[task_type] = self.task_type_costs.get(task_type, 0.0) + response.cost
 
                     # Cache response
                     self._save_to_cache(cache_key, response)
@@ -413,7 +418,7 @@ class LLMClient:
 
     def generate_structured(self, prompt: str, schema: Dict[str, Any],
                            system_prompt: Optional[str] = None,
-                           task_type: Optional[str] = None, **kwargs) -> Tuple[Dict[str, Any], str]:
+                           task_type: Optional[str] = None, **kwargs):
         """
         Generate structured JSON output with automatic fallback.
 
@@ -426,9 +431,10 @@ class LLMClient:
                 model_config: Optional ModelConfig to override default model selection
 
         Returns:
-            Tuple of (parsed JSON object matching schema, full response content)
+            StructuredResponse with result dict, raw content, cost, and metadata.
+            For backwards compatibility, can be unpacked as a 2-tuple: result, raw = ...
 
-        Warning: Not thread-safe. Use locks if enabling concurrent access.
+        Thread-safe: stats tracking uses _stats_lock for concurrent access.
         """
         # Check budget
         if not self._check_budget():
@@ -487,23 +493,34 @@ class LLMClient:
                     tokens_before = provider.total_tokens
 
                     t_start = time.time()
-                    result = provider.generate_structured(prompt, schema, system_prompt)
+                    result_tuple = provider.generate_structured(prompt, schema, system_prompt)
                     duration = time.time() - t_start
 
                     # Calculate cost delta
                     cost_delta = provider.total_cost - cost_before
                     tokens_delta = provider.total_tokens - tokens_before
 
-                    # Track at client level
-                    self.total_cost += cost_delta
-                    self.request_count += 1
-                    if task_type:
-                        self.task_type_costs[task_type] = self.task_type_costs.get(task_type, 0.0) + cost_delta
+                    # Track at client level (thread-safe)
+                    with self._stats_lock:
+                        self.total_cost += cost_delta
+                        self.request_count += 1
+                        if task_type:
+                            self.task_type_costs[task_type] = self.task_type_costs.get(task_type, 0.0) + cost_delta
 
                     logger.info(f"Structured generation successful: {model.provider}/{model.model_name} "
                                f"(tokens: {tokens_delta}, cost: ${cost_delta:.4f}, "
                                f"duration: {duration:.1f}s)")
-                    return result
+
+                    result_dict, raw = result_tuple
+                    return StructuredResponse(
+                        result=result_dict,
+                        raw=raw,
+                        cost=cost_delta,
+                        tokens_used=tokens_delta,
+                        model=model.model_name,
+                        provider=model.provider,
+                        duration=duration,
+                    )
 
                 except Exception as e:
                     last_error = e
@@ -559,19 +576,21 @@ class LLMClient:
                 "avg_duration": round(avg_duration, 2),
             }
 
-        return {
-            "total_requests": self.request_count,
-            "total_cost": self.total_cost,
-            "budget_remaining": self.config.max_cost_per_scan - self.total_cost,
-            "providers": provider_stats,
-            "task_type_costs": dict(self.task_type_costs),
-        }
+        with self._stats_lock:
+            return {
+                "total_requests": self.request_count,
+                "total_cost": self.total_cost,
+                "budget_remaining": self.config.max_cost_per_scan - self.total_cost,
+                "providers": provider_stats,
+                "task_type_costs": dict(self.task_type_costs),
+            }
 
     def reset_stats(self) -> None:
         """Reset usage statistics."""
-        self.total_cost = 0.0
-        self.request_count = 0
-        self.task_type_costs.clear()
+        with self._stats_lock:
+            self.total_cost = 0.0
+            self.request_count = 0
+            self.task_type_costs.clear()
         for provider in self.providers.values():
             provider.total_tokens = 0
             provider.total_input_tokens = 0

--- a/packages/llm_analysis/llm/config.py
+++ b/packages/llm_analysis/llm/config.py
@@ -14,7 +14,7 @@ import os
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 import json
 
 # Add parent directories to path for core imports
@@ -173,6 +173,7 @@ def _get_best_thinking_model() -> Optional['ModelConfig']:
                             timeout=timeout,
                             temperature=0.7,
                             cost_per_1k_tokens=cost_per_1k,
+                            role=entry_role or None,
                         )
                     break
 
@@ -366,8 +367,137 @@ def _get_default_fallback_models() -> List['ModelConfig']:
 
 
 # ---------------------------------------------------------------------------
+# Model role resolution
+# ---------------------------------------------------------------------------
+
+VALID_ROLES = {"analysis", "code", "consensus", "fallback"}
+
+
+def resolve_model_roles(
+    primary_model: Optional['ModelConfig'] = None,
+    fallback_models: Optional[List['ModelConfig']] = None,
+) -> Dict[str, Any]:
+    """Resolve model roles from configured models.
+
+    If no roles are specified, applies defaults:
+    - First model → analysis + code
+    - Additional models → fallback
+
+    Returns:
+        {analysis_model: ModelConfig, code_model: ModelConfig,
+         consensus_models: [ModelConfig], fallback_models: [ModelConfig]}
+
+    Raises:
+        ConfigError on invalid role configurations.
+    """
+    if primary_model is None and not fallback_models:
+        return {
+            "analysis_model": None,
+            "code_model": None,
+            "consensus_models": [],
+            "fallback_models": [],
+        }
+
+    all_models = []
+    if primary_model:
+        all_models.append(primary_model)
+    if fallback_models:
+        all_models.extend(fallback_models)
+
+    # Check if any model has a role set
+    has_roles = any(m.role for m in all_models)
+
+    if not has_roles:
+        # Default: first model = analysis + code, rest = fallback
+        return {
+            "analysis_model": all_models[0] if all_models else None,
+            "code_model": all_models[0] if all_models else None,
+            "consensus_models": [],
+            "fallback_models": all_models[1:] if len(all_models) > 1 else [],
+        }
+
+    # Validate roles
+    _validate_model_roles(all_models)
+
+    # Resolve by role
+    analysis = [m for m in all_models if m.role == "analysis"]
+    code = [m for m in all_models if m.role == "code"]
+    consensus = [m for m in all_models if m.role == "consensus"]
+    fallbacks = [m for m in all_models if m.role == "fallback" or m.role is None]
+
+    analysis_model = analysis[0] if analysis else (all_models[0] if all_models else None)
+    code_model = code[0] if code else analysis_model
+
+    return {
+        "analysis_model": analysis_model,
+        "code_model": code_model,
+        "consensus_models": consensus,
+        "fallback_models": fallbacks,
+    }
+
+
+def _validate_model_roles(models: List['ModelConfig']) -> None:
+    """Validate model role configuration. Raises ConfigError on invalid combos."""
+    roles = [m.role for m in models if m.role]
+
+    # Check for invalid role names
+    for m in models:
+        if m.role and m.role not in VALID_ROLES:
+            raise ConfigError(
+                f"Invalid role '{m.role}' for model {m.model_name}. "
+                f"Valid roles: {', '.join(sorted(VALID_ROLES))}"
+            )
+
+    analysis_count = roles.count("analysis")
+    code_count = roles.count("code")
+    has_analysis = analysis_count > 0
+    has_consensus = "consensus" in roles
+    has_code = code_count > 0
+    only_fallback = all(r == "fallback" for r in roles) if roles else False
+
+    if has_consensus and not has_analysis:
+        raise ConfigError("Consensus models configured without an analysis model")
+
+    if has_code and not has_analysis:
+        raise ConfigError("Code model configured without an analysis model")
+
+    if analysis_count > 1:
+        raise ConfigError(
+            "Multiple models with role 'analysis'. Use 'consensus' for second opinions"
+        )
+
+    if code_count > 1:
+        raise ConfigError(
+            "Multiple models with role 'code'. Only one code model is supported"
+        )
+
+    if only_fallback:
+        raise ConfigError(
+            "All models are configured as fallback with no analysis model. "
+            "Set role to 'analysis' on at least one model."
+        )
+
+    # Check for same model with two roles (by model_name + provider)
+    seen = {}
+    for m in models:
+        if m.role:
+            key = (m.provider, m.model_name)
+            if key in seen and seen[key] != m.role:
+                raise ConfigError(
+                    f"Model {m.model_name} ({m.provider}) has conflicting roles: "
+                    f"'{seen[key]}' and '{m.role}'"
+                )
+            seen[key] = m.role
+
+
+# ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------
+
+class ConfigError(Exception):
+    """Configuration validation error."""
+    pass
+
 
 @dataclass
 class ModelConfig:
@@ -382,6 +512,7 @@ class ModelConfig:
     timeout: int = 120
     cost_per_1k_tokens: float = 0.0  # Fallback rate — used only when model not in MODEL_COSTS
     enabled: bool = True
+    role: Optional[str] = None  # "analysis", "code", "consensus", "fallback"
 
 
 @dataclass

--- a/packages/llm_analysis/llm/providers.py
+++ b/packages/llm_analysis/llm/providers.py
@@ -55,10 +55,35 @@ class LLMResponse:
     duration: float = 0.0
 
 
+@dataclass
+class StructuredResponse:
+    """Response from generate_structured() with metadata.
+
+    Iterable for backwards compatibility: result, raw = response
+    """
+    result: Dict[str, Any]
+    raw: str
+    cost: float = 0.0
+    tokens_used: int = 0
+    model: str = ""
+    provider: str = ""
+    duration: float = 0.0
+    cached: bool = False  # Not yet wired: generate_structured() has no cache path.
+    # generate() caches via _get_cached_response but returns LLMResponse, not this.
+    # To enable: add cache check in generate_structured() before provider call,
+    # return StructuredResponse(cached=True) on hit. Cache key must include schema.
+    # Inventory checksums (core/inventory) could feed cache invalidation.
+
+    def __iter__(self):
+        """Allow unpacking as 2-tuple for backwards compatibility."""
+        return iter((self.result, self.raw))
+
+
 class LLMProvider(ABC):
     """Abstract base class for LLM providers."""
 
     def __init__(self, config: ModelConfig):
+        import threading
         self.config = config
         self.total_tokens = 0
         self.total_input_tokens = 0
@@ -66,6 +91,7 @@ class LLMProvider(ABC):
         self.total_cost = 0.0
         self.call_count = 0
         self.total_duration = 0.0
+        self._usage_lock = threading.Lock()
 
     @abstractmethod
     def generate(self, prompt: str, system_prompt: Optional[str] = None,
@@ -82,13 +108,14 @@ class LLMProvider(ABC):
     def track_usage(self, tokens: int, cost: float,
                     input_tokens: int = 0, output_tokens: int = 0,
                     duration: float = 0.0) -> None:
-        """Track token usage, cost, and call duration."""
-        self.total_tokens += tokens
-        self.total_input_tokens += input_tokens
-        self.total_output_tokens += output_tokens
-        self.total_cost += (cost or 0.0)
-        self.call_count += 1
-        self.total_duration += duration
+        """Track token usage, cost, and call duration (thread-safe)."""
+        with self._usage_lock:
+            self.total_tokens += tokens
+            self.total_input_tokens += input_tokens
+            self.total_output_tokens += output_tokens
+            self.total_cost += (cost or 0.0)
+            self.call_count += 1
+            self.total_duration += duration
         logger.debug(f"LLM usage: {tokens} tokens, ${(cost or 0.0):.4f} (total: {self.total_tokens} tokens, ${self.total_cost:.4f})")
 
     def _calculate_cost_split(self, input_tokens: int, output_tokens: int) -> float:

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -2,55 +2,130 @@
 """
 RAPTOR Orchestrator — Phase 4 of the /agentic workflow.
 
-Dispatches structured findings from Phase 3 to Claude Code sub-agents
-for parallel vulnerability analysis, exploit generation, and patch creation.
+Dispatches structured findings from Phase 3 for parallel vulnerability
+analysis, exploit generation, patch creation, consensus, and retry.
 
-Three execution paths:
-  Path 1 (CC available, no external LLM): Dispatch to claude -p sub-agents
-  Path 2 (external LLM):                  Phase 3 already did analysis — passthrough
-  Path 3 (nothing):                        Manual review — passthrough
+Dispatch routing:
+  - External LLM configured: parallel generate_structured() / generate()
+  - No external LLM + claude on PATH: claude -p sub-agents (via cc_dispatch)
+  - Neither: return None (manual review)
 
-Inside or outside Claude Code, dispatch uses claude -p subprocesses for
-consistent enforcement of tools, budget, schema, and parallelism.
+If external LLM fails entirely, falls back to CC dispatch automatically.
 """
 
 import copy
 import json
 import logging
 import shutil
-import subprocess
+import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from packages.llm_analysis.cc_dispatch import invoke_cc_simple
+from packages.llm_analysis.dispatch import _format_elapsed
+
 logger = logging.getLogger(__name__)
 
-# JSON Schema for CC sub-agent structured output.
-# Required fields ensure every result is usable even if the agent
-# produces minimal output.
-FINDING_RESULT_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "finding_id": {"type": "string"},
-        "is_true_positive": {"type": "boolean"},
-        "is_exploitable": {"type": "boolean"},
-        "exploitability_score": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 1,
-        },
-        "severity_assessment": {"type": "string"},
-        "reasoning": {"type": "string"},
-        "attack_scenario": {"type": "string"},
-        "exploit_code": {"type": ["string", "null"]},
-        "patch_code": {"type": ["string", "null"]},
-    },
-    "required": ["finding_id", "is_true_positive", "is_exploitable", "reasoning"],
-}
+# Adaptive cutoff thresholds (percentage of max_cost_per_scan)
+CUTOFF_SKIP_CONSENSUS = 0.70
+CUTOFF_SKIP_EXPLOITS = 0.85
+CUTOFF_SINGLE_MODEL = 0.95
 
-CC_TIMEOUT = 300  # 5 minutes per finding
-CC_BUDGET_PER_FINDING = "1.00"  # string — passed as CLI arg to --max-budget-usd
+
+class CostTracker:
+    """Thread-safe cost tracking with adaptive budget cutoff.
+
+    Aggregates costs from both LLMClient (external LLM) and CC subprocess
+    results (claude -p envelope total_cost_usd). Provides budget-aware
+    cutoff signals.
+    """
+
+    def __init__(self, max_cost: float = 0.0):
+        self._lock = threading.RLock()  # Reentrant — get_summary calls _budget_ratio
+        self._total_cost = 0.0
+        self._total_tokens = 0
+        self._max_cost = max_cost  # 0 = no limit
+        self._per_model: Dict[str, float] = {}
+
+    def add_cost(self, model_name: str, cost: float, tokens: int = 0) -> None:
+        """Record cost and tokens from any source (thread-safe)."""
+        with self._lock:
+            self._total_cost += cost
+            self._total_tokens += tokens
+            self._per_model[model_name] = self._per_model.get(model_name, 0.0) + cost
+
+    @property
+    def total_cost(self) -> float:
+        with self._lock:
+            return self._total_cost
+
+    def _budget_ratio(self) -> float:
+        """Current spend as fraction of budget. 0 if no budget set."""
+        if self._max_cost <= 0:
+            return 0.0
+        with self._lock:
+            return self._total_cost / self._max_cost
+
+    def should_skip_consensus(self) -> bool:
+        return self._budget_ratio() >= CUTOFF_SKIP_CONSENSUS
+
+    def should_skip_exploits(self) -> bool:
+        return self._budget_ratio() >= CUTOFF_SKIP_EXPLOITS
+
+    def should_single_model(self) -> bool:
+        return self._budget_ratio() >= CUTOFF_SINGLE_MODEL
+
+    def should_skip_phase(self, n_calls: int, model_name: str,
+                          cutoff_ratio: float, phase_name: str) -> bool:
+        """Pre-check: would running this phase likely exceed the budget?
+
+        Prevents starting a parallel dispatch that would be mostly cancelled
+        by per-call cutoffs. Analysis dispatch never uses this (always runs).
+        """
+        if self._max_cost <= 0:
+            return False
+        estimate = self.estimate_cost(n_calls, model_name=model_name)
+        with self._lock:
+            projected = self._total_cost + estimate
+        if projected > self._max_cost * cutoff_ratio:
+            logger.info(f"Skipping {phase_name} — estimated ${estimate:.2f} "
+                        f"would push total to ${projected:.2f} (budget: ${self._max_cost:.2f})")
+            return True
+        return False
+
+    def estimate_cost(self, n_findings: int, n_consensus_models: int = 0,
+                      model_name: str = "", is_cc: bool = False) -> float:
+        """Estimate total cost before dispatch (informational).
+
+        Uses MODEL_COSTS for external LLMs. CC agents are estimated at
+        ~$0.20/finding based on observed costs (they read files and reason,
+        consuming more tokens than a direct API call).
+        """
+        if is_cc:
+            avg_cost = 0.20  # CC agents: observed ~$0.15-0.25/finding
+        else:
+            from packages.llm_analysis.llm.model_data import MODEL_COSTS
+            # Estimate ~2K input tokens + ~500 output tokens per analysis call
+            rates = MODEL_COSTS.get(model_name, {})
+            if rates:
+                avg_cost = (2.0 * rates.get("input", 0.003)) + (0.5 * rates.get("output", 0.015))
+            else:
+                avg_cost = 0.03  # Conservative default
+
+        analysis_calls = n_findings
+        consensus_calls = n_findings * n_consensus_models
+        return (analysis_calls + consensus_calls) * avg_cost
+
+    def get_summary(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "total_cost": round(self._total_cost, 4),
+                "total_tokens": self._total_tokens,
+                "max_cost": self._max_cost,
+                "budget_used_percent": round(self._budget_ratio() * 100, 1) if self._max_cost > 0 else 0,
+                "cost_by_model": {k: round(v, 4) for k, v in self._per_model.items()},
+            }
 
 
 def orchestrate(
@@ -60,20 +135,29 @@ def orchestrate(
     max_parallel: int = 3,
     no_exploits: bool = False,
     no_patches: bool = False,
+    llm_config: Optional[Any] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Orchestrate vulnerability analysis using Claude Code sub-agents.
+    """Orchestrate vulnerability analysis via external LLM or Claude Code.
 
-    Called from raptor_agentic.py Phase 4. Dispatches CC sub-agents
-    when claude is on PATH and no external LLM is configured (the
-    prep-only case). All other cases are passthrough.
+    Called from raptor_agentic.py Phase 4. Dispatches findings for parallel
+    analysis, runs structural grouping, and optionally runs consensus and
+    group analysis.
+
+    Dispatch routing:
+    - llm_config provided (external LLM) -> parallel generate_structured()
+    - llm_config None + claude on PATH -> claude -p sub-agents
+    - Neither -> return None
+
+    If external LLM dispatch fails entirely, falls back to CC dispatch.
 
     Args:
         prep_report_path: Path to autonomous_analysis_report.json from Phase 3.
         repo_path: Target repository path.
         out_dir: Output directory for orchestration results.
-        max_parallel: Maximum concurrent CC sub-agents.
+        max_parallel: Maximum concurrent agents.
         no_exploits: Skip exploit generation.
         no_patches: Skip patch generation.
+        llm_config: LLMConfig for external LLM dispatch (None = CC only).
 
     Returns:
         Orchestrated report dict, or None if orchestration was skipped.
@@ -86,16 +170,8 @@ def orchestrate(
         print(f"\n  Failed to read analysis report: {e}")
         return None
 
-    # Path 2/3: Phase 3 already did full analysis — nothing to add
     if report.get("mode") != "prep_only":
         logger.info("Phase 3 ran full analysis — orchestration not needed")
-        return None
-
-    # Verify claude binary exists before committing to dispatch
-    claude_bin = shutil.which("claude")
-    if not claude_bin:
-        print("\n  claude not found on PATH — cannot dispatch sub-agents")
-        print("  Install Claude Code: npm install -g @anthropic-ai/claude-code")
         return None
 
     findings = report.get("results", [])
@@ -103,31 +179,191 @@ def orchestrate(
         print("\n  No findings to analyse")
         return None
 
-    print(f"\n  Dispatching {len(findings)} findings to Claude Code agents "
-          f"(max {max_parallel} parallel)")
+    # Resolve model roles
+    from packages.llm_analysis.llm.config import resolve_model_roles
+    role_resolution = {"analysis_model": None, "code_model": None,
+                       "consensus_models": [], "fallback_models": []}
+    if llm_config and llm_config.primary_model:
+        role_resolution = resolve_model_roles(
+            llm_config.primary_model,
+            llm_config.fallback_models if hasattr(llm_config, 'fallback_models') else [],
+        )
 
-    # Dispatch all findings in parallel
-    start_time = time.monotonic()
-    cc_results = _dispatch_findings(
-        findings=findings,
-        repo_path=repo_path,
-        claude_bin=claude_bin,
-        out_dir=out_dir,
-        max_parallel=max_parallel,
-        no_exploits=no_exploits,
-        no_patches=no_patches,
+    # Cost tracking
+    max_cost = getattr(llm_config, 'max_cost_per_scan', 0) if llm_config else 0
+    cost_tracker = CostTracker(max_cost=max_cost or 0)
+
+    # Estimate and print cost
+    n_consensus = len(role_resolution.get("consensus_models", []))
+    analysis_model_name = role_resolution.get("analysis_model").model_name if role_resolution.get("analysis_model") else ""
+    is_cc_dispatch = not (llm_config and llm_config.primary_model)
+    estimate = cost_tracker.estimate_cost(len(findings), n_consensus,
+                                          model_name=analysis_model_name, is_cc=is_cc_dispatch)
+    if estimate > 0:
+        print(f"\n  Estimated cost: ~${estimate:.2f} for {len(findings)} findings"
+              + (f" + {n_consensus} consensus model(s)" if n_consensus else ""))
+
+    # --- Build dispatch callable ---
+    from packages.llm_analysis.dispatch import dispatch_task, DispatchResult
+    from packages.llm_analysis.tasks import (
+        AnalysisTask, ExploitTask, PatchTask, ConsensusTask, GroupAnalysisTask,
+        RetryTask,
     )
+
+    dispatch_mode = "none"
+    dispatch_fn = None
+    start_time = time.monotonic()
+
+    if llm_config and llm_config.primary_model:
+        # External LLM: dispatch via generate_structured/generate
+        from packages.llm_analysis.llm.client import LLMClient
+        client = LLMClient(llm_config)
+
+        def dispatch_fn(prompt, schema, system_prompt, temperature, model):
+            if schema:
+                response = client.generate_structured(
+                    prompt=prompt, schema=schema, system_prompt=system_prompt,
+                    model_config=model, temperature=temperature,
+                )
+                return DispatchResult(
+                    result=response.result, cost=response.cost,
+                    tokens=response.tokens_used, model=response.model,
+                    duration=response.duration,
+                )
+            else:
+                response = client.generate(
+                    prompt=prompt, system_prompt=system_prompt,
+                    model_config=model, temperature=temperature,
+                )
+                return DispatchResult(
+                    result={"content": response.content}, cost=response.cost,
+                    tokens=response.tokens_used, model=response.model,
+                    duration=response.duration,
+                )
+
+        dispatch_mode = "external_llm"
+    else:
+        # CC: dispatch via claude -p subprocess
+        claude_bin = shutil.which("claude")
+        if not claude_bin:
+            print("\n  claude not found on PATH — cannot dispatch sub-agents")
+            print("  Install Claude Code: npm install -g @anthropic-ai/claude-code")
+            return None
+
+        def dispatch_fn(prompt, schema, system_prompt, temperature, model):
+            return invoke_cc_simple(prompt, schema, repo_path, claude_bin, out_dir)
+
+        dispatch_mode = "cc_dispatch"
+
+    # --- Per-finding analysis ---
+    results_by_id = {}
+    analysis_results = dispatch_task(
+        AnalysisTask(), findings, dispatch_fn, role_resolution,
+        results_by_id, cost_tracker, max_parallel,
+    )
+
+    # Fallback: if external LLM failed entirely, try CC
+    if (dispatch_mode == "external_llm"
+            and analysis_results
+            and all("error" in r for r in analysis_results)):
+        claude_bin = shutil.which("claude")
+        if claude_bin:
+            print("\n  All external LLM calls failed — falling back to Claude Code")
+            dispatch_mode = "cc_fallback"
+
+            def dispatch_fn(prompt, schema, system_prompt, temperature, model):
+                return invoke_cc_simple(prompt, schema, repo_path, claude_bin, out_dir)
+
+            analysis_results = dispatch_task(
+                AnalysisTask(), findings, dispatch_fn, role_resolution,
+                results_by_id, cost_tracker, max_parallel,
+            )
+
+    # Index results for downstream tasks
+    for r in analysis_results:
+        fid = r.get("finding_id")
+        if fid:
+            results_by_id[fid] = r
+
+    # --- Exploit/patch generation ---
+    # CC analysis may produce exploits/patches inline via schema. ExploitTask/PatchTask
+    # only select findings that are exploitable AND missing exploit_code/patch_code,
+    # so this is a no-op when CC already generated them.
+    if not no_exploits:
+        dispatch_task(
+            ExploitTask(), findings, dispatch_fn, role_resolution,
+            results_by_id, cost_tracker, max_parallel,
+        )
+
+    if not no_patches:
+        dispatch_task(
+            PatchTask(), findings, dispatch_fn, role_resolution,
+            results_by_id, cost_tracker, max_parallel,
+        )
+
+    # --- Consensus (if configured, skip retry) ---
+    consensus_models = role_resolution.get("consensus_models", [])
+    if consensus_models:
+        dispatch_task(
+            ConsensusTask(), findings, dispatch_fn, role_resolution,
+            results_by_id, cost_tracker, max_parallel,
+        )
+    else:
+        # Retry low-confidence findings (only when no consensus)
+        dispatch_task(
+            RetryTask(), findings, dispatch_fn, role_resolution,
+            results_by_id, cost_tracker, max_parallel,
+        )
+
     elapsed = time.monotonic() - start_time
 
-    # Merge and write
-    merged = _merge_results(report, cc_results, no_exploits=no_exploits, no_patches=no_patches)
+    # --- Structural grouping (pure Python, no LLM) ---
+    groups = _structural_grouping(findings)
+    if groups:
+        n = len(groups)
+        print(f"\n  Structural grouping: {n} group{'s' if n != 1 else ''} found")
+
+    # --- Group analysis ---
+    group_task = GroupAnalysisTask(results_by_id=results_by_id)
+    group_results = dispatch_task(
+        group_task, groups, dispatch_fn, role_resolution,
+        results_by_id, cost_tracker, max_parallel,
+    )
+    group_analyses = {}
+    for r in group_results:
+        gid = r.get("finding_id")  # group_id comes through as finding_id
+        if gid and "error" not in r:
+            group_analyses[gid] = r
+
+    # --- Merge and write ---
+    per_finding_results = list(results_by_id.values())
+    merged = _merge_results(report, per_finding_results,
+                            no_exploits=no_exploits, no_patches=no_patches)
+    merged["cross_finding_groups"] = groups
+    if group_analyses:
+        merged["group_analyses"] = group_analyses
+
+    consensus_disputes = sum(1 for r in per_finding_results
+                             if r.get("consensus") == "disputed")
+    retries = sum(1 for r in per_finding_results if r.get("retried"))
+    low_confidence = sum(1 for r in per_finding_results if r.get("low_confidence"))
+
     merged["orchestration"] = {
-        "mode": "cc_dispatch",
+        "mode": dispatch_mode,
+        "analysis_model": (role_resolution.get("analysis_model").model_name
+                          if role_resolution.get("analysis_model") else None),
+        "consensus_models": [m.model_name for m in consensus_models],
         "findings_dispatched": len(findings),
-        "findings_analysed": sum(1 for r in cc_results if "error" not in r),
-        "findings_failed": sum(1 for r in cc_results if "error" in r),
+        "findings_analysed": sum(1 for r in per_finding_results if "error" not in r),
+        "findings_failed": sum(1 for r in per_finding_results if "error" in r),
+        "structural_groups": len(groups),
+        "consensus_disputes": consensus_disputes,
+        "low_confidence_retries": retries,
+        "low_confidence_remaining": low_confidence,
+        "group_analyses": len(group_analyses),
         "elapsed_seconds": round(elapsed, 1),
         "max_parallel": max_parallel,
+        "cost": cost_tracker.get_summary(),
     }
 
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -137,348 +373,15 @@ def orchestrate(
 
     # Summary
     orch = merged["orchestration"]
+    cost_total = orch["cost"]["total_cost"]
     print(f"\n  Orchestration complete: {orch['findings_analysed']} analysed, "
-          f"{orch['findings_failed']} failed, {orch['elapsed_seconds']}s elapsed")
+          f"{orch['findings_failed']} failed, {_format_elapsed(orch['elapsed_seconds'])} elapsed"
+          + (f", ${cost_total:.2f}" if cost_total > 0 else ""))
+    if groups:
+        print(f"  Cross-finding groups: {len(groups)}")
     print(f"  Report: {out_path}")
 
     return merged
-
-
-def _print_result(finding_id: str, result: Dict[str, Any]) -> None:
-    """Print a single finding result to console."""
-    exploitable = result.get("is_exploitable", False)
-    score = result.get("exploitability_score")
-    try:
-        status = f"exploitable ({float(score):.2f})" if exploitable else "not exploitable"
-    except (ValueError, TypeError):
-        status = "exploitable" if exploitable else "not exploitable"
-    print(f"  [done] {finding_id}: {status}")
-
-
-def _dispatch_findings(
-    findings: List[Dict[str, Any]],
-    repo_path: Path,
-    claude_bin: str,
-    out_dir: Path,
-    max_parallel: int,
-    no_exploits: bool,
-    no_patches: bool,
-) -> List[Dict[str, Any]]:
-    """Dispatch findings to CC sub-agents in parallel.
-
-    Returns a list of result dicts, one per finding (in completion order).
-    Failed findings have an "error" key.
-    """
-    results: List[Dict[str, Any]] = []
-    total = len(findings)
-    abort = False
-
-    with ThreadPoolExecutor(max_workers=max_parallel) as executor:
-        future_to_finding = {}
-        for idx, finding in enumerate(findings, 1):
-            finding_id = finding.get("finding_id", f"finding-{idx}")
-            rule_id = finding.get("rule_id", "unknown")
-            file_path = finding.get("file_path", "?")
-            start_line = finding.get("start_line", "?")
-
-            print(f"  [{idx}/{total}] {rule_id} at {file_path}:{start_line} ...",
-                  flush=True)
-
-            future = executor.submit(
-                _invoke_cc,
-                finding=finding,
-                repo_path=repo_path,
-                claude_bin=claude_bin,
-                out_dir=out_dir,
-                no_exploits=no_exploits,
-                no_patches=no_patches,
-            )
-            future_to_finding[future] = (idx, finding_id)
-
-        for future in as_completed(future_to_finding):
-            idx, finding_id = future_to_finding[future]
-            try:
-                result = future.result()
-            except Exception as e:
-                result = {"finding_id": finding_id, "error": str(e)}
-
-            results.append(result)
-
-            if "error" in result:
-                err = result["error"]
-                print(f"  [fail] {finding_id}: {err}")
-                if result.get("cc_debug_file"):
-                    print(f"         debug: {result['cc_debug_file']}")
-
-                # Abort on auth/billing errors — remaining will fail too
-                if _is_auth_error(err):
-                    print("\n  Authentication/billing error — aborting remaining agents")
-                    abort = True
-                    executor.shutdown(wait=False, cancel_futures=True)
-                    break
-            else:
-                _print_result(finding_id, result)
-
-    if abort:
-        # Mark undispatched findings as aborted
-        completed_ids = {r.get("finding_id") for r in results}
-        for finding in findings:
-            fid = finding.get("finding_id")
-            if fid and fid not in completed_ids:
-                results.append({"finding_id": fid, "error": "aborted (auth failure)"})
-
-    return results
-
-
-def _invoke_cc(
-    finding: Dict[str, Any],
-    repo_path: Path,
-    claude_bin: str,
-    out_dir: Path,
-    no_exploits: bool = False,
-    no_patches: bool = False,
-    timeout: int = CC_TIMEOUT,
-) -> Dict[str, Any]:
-    """Invoke a single Claude Code sub-agent for one finding.
-
-    The prompt is lightweight — metadata only, no raw code from the
-    target repo. The agent reads code via Read/Grep/Glob tools. This
-    keeps attacker-controlled content out of the prompt (prompt injection
-    mitigation).
-
-    Returns parsed result dict, or dict with "error" key on failure.
-    """
-    finding_id = finding.get("finding_id", "unknown")
-    prompt = _build_finding_prompt(finding, no_exploits, no_patches)
-    schema = _build_schema(no_exploits, no_patches)
-
-    cmd = [
-        claude_bin, "-p",
-        "--output-format", "json",
-        "--json-schema", json.dumps(schema),
-        "--no-session-persistence",
-        "--allowed-tools", "Read,Grep,Glob",
-        "--add-dir", str(repo_path),
-        "--max-budget-usd", CC_BUDGET_PER_FINDING,
-    ]
-
-    try:
-        proc = subprocess.run(
-            cmd,
-            input=prompt,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
-    except subprocess.TimeoutExpired:
-        return {"finding_id": finding_id, "error": f"timeout after {timeout}s"}
-
-    if proc.returncode != 0:
-        stderr_excerpt = (proc.stderr or "")[:500]
-        result = {"finding_id": finding_id, "error": f"exit code {proc.returncode}: {stderr_excerpt}"}
-        _write_debug(out_dir, finding_id, proc.stdout, proc.stderr, result)
-        return result
-
-    parsed = _parse_cc_result(proc.stdout, proc.stderr, finding_id)
-    if "error" in parsed:
-        _write_debug(out_dir, finding_id, proc.stdout, proc.stderr, parsed)
-    return parsed
-
-
-def _write_debug(
-    out_dir: Path,
-    finding_id: str,
-    stdout: str,
-    stderr: str,
-    result: Dict[str, Any],
-) -> None:
-    """Write raw CC output to a debug file on failure."""
-    try:
-        debug_dir = out_dir / "debug"
-        debug_dir.mkdir(parents=True, exist_ok=True)
-        debug_file = debug_dir / f"cc_{finding_id}.txt"
-        debug_file.write_text(f"STDOUT:\n{stdout or '(empty)'}\n\nSTDERR:\n{stderr or '(empty)'}")
-        # Relative path so it works regardless of output dir location
-        result["cc_debug_file"] = f"debug/cc_{finding_id}.txt"
-    except OSError:
-        pass  # Best effort — don't fail the finding over a debug file
-
-
-def _build_schema(no_exploits: bool = False, no_patches: bool = False) -> Dict[str, Any]:
-    """Build JSON Schema for CC output, excluding fields the user didn't ask for."""
-    schema = copy.deepcopy(FINDING_RESULT_SCHEMA)
-    if no_exploits:
-        schema["properties"].pop("exploit_code", None)
-    if no_patches:
-        schema["properties"].pop("patch_code", None)
-    return schema
-
-
-def _build_finding_prompt(
-    finding: Dict[str, Any],
-    no_exploits: bool = False,
-    no_patches: bool = False,
-) -> str:
-    """Build a lightweight prompt for a CC sub-agent.
-
-    The prompt contains metadata only — rule ID, file path, line numbers,
-    dataflow summary. No raw code from the target repo. The agent reads
-    code itself via Read/Grep/Glob tools, which provides natural separation
-    between instructions and attacker-controlled content.
-    """
-    finding_id = finding.get("finding_id", "unknown")
-    rule_id = finding.get("rule_id", "unknown")
-    file_path = finding.get("file_path", "unknown")
-    start_line = finding.get("start_line", "?")
-    end_line = finding.get("end_line", start_line)
-    # message is scanner-generated but may contain target-repo identifiers
-    # (variable names, file paths). Low risk given read-only tools + schema output.
-    message = finding.get("message", "")
-    level = finding.get("level", "warning")
-
-    prompt = f"""You are a security researcher analysing a potential vulnerability.
-
-## Finding
-- ID: {finding_id}
-- Rule: {rule_id}
-- Severity: {level}
-- File: {file_path}
-- Lines: {start_line}-{end_line}
-- Description: {message}
-"""
-
-    # Dataflow summary (metadata only, no code)
-    dataflow = finding.get("dataflow")
-    if dataflow:
-        source = dataflow.get("source", {})
-        sink = dataflow.get("sink", {})
-        steps = dataflow.get("steps", [])
-        sanitizers = dataflow.get("sanitizers_found", [])
-
-        prompt += f"""
-## Dataflow path
-- Source: {source.get('file', '?')}:{source.get('line', '?')} ({source.get('label', '')})
-- Sink: {sink.get('file', '?')}:{sink.get('line', '?')} ({sink.get('label', '')})
-- Intermediate steps: {len(steps)}
-- Sanitizers found: {len(sanitizers)}
-"""
-        if sanitizers:
-            prompt += "- Sanitizer locations: " + ", ".join(
-                f"{s.get('file', '?')}:{s.get('line', '?')}" for s in sanitizers
-                if isinstance(s, dict)
-            ) + "\n"
-
-    # Feasibility data (small, high-value — include directly)
-    feasibility = finding.get("feasibility")
-    if feasibility:
-        verdict = feasibility.get("verdict", "unknown")
-        chain_breaks = feasibility.get("chain_breaks", [])
-        what_would_help = feasibility.get("what_would_help", [])
-        prompt += f"""
-## Exploit feasibility analysis (from upstream validation pipeline)
-This finding has already been through automated feasibility analysis.
-The constraints below were empirically verified — treat them as ground truth.
-Focus your analysis on attack paths that work within these constraints.
-
-- Verdict: {verdict}
-"""
-        if chain_breaks:
-            prompt += "- Techniques that WON'T work (verified blockers):\n"
-            for cb in chain_breaks:
-                prompt += f"  - {cb}\n"
-        if what_would_help:
-            prompt += "- Viable approaches to consider:\n"
-            for wh in what_would_help:
-                prompt += f"  - {wh}\n"
-
-    # Instructions
-    prompt += """
-## Your task
-
-Read the code at the file path above using the Read tool. Examine the
-surrounding context, imports, and any functions called in the vulnerable code.
-
-1. **Analyse**: Is this a true positive? Is it exploitable in practice?
-   What would an attacker need? What's the real-world impact?
-   Rate exploitability_score from 0.0 (impossible) to 1.0 (trivial).
-"""
-
-    if not no_exploits:
-        prompt += """
-2. **Exploit**: If exploitable, write a proof-of-concept exploit.
-   The exploit should be practical and demonstrate the vulnerability.
-   Include clear comments explaining the attack.
-"""
-
-    if not no_patches:
-        prompt += f"""
-{"3" if not no_exploits else "2"}. **Patch**: Create a secure fix that preserves existing functionality.
-   Read the full file for context before writing the patch.
-"""
-
-    prompt += f"""
-Return your analysis as structured JSON with finding_id "{finding_id}".
-"""
-
-    return prompt
-
-
-def _parse_cc_result(
-    stdout: str,
-    stderr: str,
-    finding_id: str,
-) -> Dict[str, Any]:
-    """Parse CC sub-agent JSON output.
-
-    Handles: clean JSON, claude -p envelope, markdown-fenced JSON, partial output.
-    """
-    content = stdout.strip()
-    if not content:
-        stderr_excerpt = (stderr or "")[:500]
-        return {"finding_id": finding_id, "error": f"empty output: {stderr_excerpt}"}
-
-    # Try direct parse
-    try:
-        result = json.loads(content)
-        if isinstance(result, dict):
-            # claude -p --output-format json wraps output in a metadata envelope.
-            # The actual structured output is in the "structured_output" field.
-            if "structured_output" in result and isinstance(result["structured_output"], dict):
-                inner = result["structured_output"]
-                inner.setdefault("finding_id", finding_id)
-                return inner
-            result.setdefault("finding_id", finding_id)
-            return result
-    except json.JSONDecodeError:
-        pass
-
-    # Try stripping markdown fences
-    if "```" in content:
-        try:
-            parts = content.split("```")
-            for part in parts[1::2]:  # odd-indexed parts are inside fences
-                # Strip optional language tag
-                lines = part.strip().split("\n", 1)
-                json_str = lines[1] if len(lines) > 1 and not lines[0].startswith("{") else part
-                result = json.loads(json_str.strip())
-                if isinstance(result, dict):
-                    result.setdefault("finding_id", finding_id)
-                    return result
-        except (json.JSONDecodeError, IndexError):
-            pass
-
-    # Last resort: find first valid JSON object using raw_decode
-    try:
-        decoder = json.JSONDecoder()
-        idx = content.index("{")
-        result, _ = decoder.raw_decode(content, idx)
-        if isinstance(result, dict):
-            result.setdefault("finding_id", finding_id)
-            return result
-    except (ValueError, json.JSONDecodeError):
-        pass
-
-    return {"finding_id": finding_id, "error": f"unparseable output: {content[:200]}"}
 
 
 def _merge_results(
@@ -523,30 +426,36 @@ def _merge_results(
 
         analysed += 1
 
-        # Update analysis fields from CC result
-        finding["analysis"] = {
-            "is_true_positive": cc.get("is_true_positive"),
-            "is_exploitable": cc.get("is_exploitable"),
-            "exploitability_score": cc.get("exploitability_score"),
-            "severity_assessment": cc.get("severity_assessment"),
-            "reasoning": cc.get("reasoning"),
-            "attack_scenario": cc.get("attack_scenario"),
-        }
+        # Copy non-internal keys from dispatch result to finding.
+        # Underscore-prefixed keys are internal and stripped.
+        # Keys already in finding (prep data) are NOT overwritten — defence
+        # against prompt injection where LLM returns crafted field names.
+        for k, v in cc.items():
+            if k.startswith("_") or k == "finding_id":
+                continue
+            if k not in finding:
+                finding[k] = v
+
+        # Ensure standard fields are set
         finding["exploitable"] = cc.get("is_exploitable", False)
         finding["exploitability_score"] = cc.get("exploitability_score", 0)
 
         if finding["exploitable"]:
             exploitable += 1
 
-        if not no_exploits and cc.get("exploit_code"):
+        if finding["exploitable"] and not no_exploits and cc.get("exploit_code"):
             finding["has_exploit"] = True
-            finding["exploit_code"] = cc["exploit_code"]
             exploits_generated += 1
+        else:
+            finding.pop("exploit_code", None)
+            finding["has_exploit"] = False
 
-        if not no_patches and cc.get("patch_code"):
+        if finding["exploitable"] and not no_patches and cc.get("patch_code"):
             finding["has_patch"] = True
-            finding["patch_code"] = cc["patch_code"]
             patches_generated += 1
+        else:
+            finding.pop("patch_code", None)
+            finding["has_patch"] = False
 
     merged["results"] = results
     merged["analyzed"] = analysed
@@ -557,11 +466,99 @@ def _merge_results(
     return merged
 
 
-def _is_auth_error(error_str: str) -> bool:
-    """Check if an error string indicates an authentication/billing failure."""
-    lower = error_str.lower()
-    return any(x in lower for x in [
-        "401", "403", "authentication", "unauthorized",
-        "invalid api key", "billing", "quota", "rate limit",
-        "insufficient_quota", "credit",
-    ])
+def _structural_grouping(results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Group related findings by structural similarity. Pure Python, no LLM.
+
+    Direct grouping only — no transitive closure. A finding can appear in
+    multiple overlapping groups. Each group has one specific shared criterion.
+
+    Returns list of groups, each with:
+        group_id, criterion, criterion_value, finding_ids
+    Groups of size 1 are excluded.
+    """
+    groups = []
+    group_counter = 0
+
+    def _add_group(criterion: str, value: str, finding_ids: List[str]):
+        nonlocal group_counter
+        if len(finding_ids) >= 2:
+            group_counter += 1
+            groups.append({
+                "group_id": f"GRP-{group_counter:03d}",
+                "criterion": criterion,
+                "criterion_value": value,
+                "finding_ids": sorted(finding_ids),
+            })
+
+    # Index findings
+    findings_by_id = {}
+    for r in results:
+        fid = r.get("finding_id")
+        if fid:
+            findings_by_id[fid] = r
+
+    # Group by same file path
+    by_file: Dict[str, List[str]] = {}
+    for fid, r in findings_by_id.items():
+        fp = r.get("file_path", "")
+        if fp:
+            by_file.setdefault(fp, []).append(fid)
+    for fp, fids in by_file.items():
+        _add_group("file_path", fp, fids)
+
+    # Group by same rule ID (skip rules that match >50% of findings — too generic)
+    by_rule: Dict[str, List[str]] = {}
+    for fid, r in findings_by_id.items():
+        rule = r.get("rule_id", "")
+        if rule:
+            by_rule.setdefault(rule, []).append(fid)
+    half = len(findings_by_id) / 2
+    by_rule = {r: fids for r, fids in by_rule.items() if len(fids) <= half}
+    for rule, fids in by_rule.items():
+        _add_group("rule_id", rule, fids)
+
+    # Group by shared sanitiser location
+    by_sanitiser: Dict[str, List[str]] = {}
+    for fid, r in findings_by_id.items():
+        dataflow = r.get("dataflow") or {}
+        for san in dataflow.get("sanitizers_found", []):
+            if isinstance(san, dict):
+                loc = f"{san.get('file', '?')}:{san.get('line', '?')}"
+            else:
+                loc = str(san)
+            by_sanitiser.setdefault(loc, []).append(fid)
+    for loc, fids in by_sanitiser.items():
+        _add_group("sanitiser", loc, fids)
+
+    # Group by same dataflow source
+    by_source: Dict[str, List[str]] = {}
+    for fid, r in findings_by_id.items():
+        dataflow = r.get("dataflow") or {}
+        source = dataflow.get("source", {})
+        if source:
+            loc = f"{source.get('file', '?')}:{source.get('line', '?')}"
+            by_source.setdefault(loc, []).append(fid)
+    for loc, fids in by_source.items():
+        _add_group("dataflow_source", loc, fids)
+
+    # Group by shared dataflow references (any file:line in common)
+    # Inverted index: ref -> set of finding_ids. O(N*R) instead of O(N²).
+    ref_to_fids: Dict[str, set] = {}
+    for fid, r in findings_by_id.items():
+        dataflow = r.get("dataflow") or {}
+        source = dataflow.get("source", {})
+        if source:
+            ref = f"{source.get('file', '?')}:{source.get('line', '?')}"
+            ref_to_fids.setdefault(ref, set()).add(fid)
+        for step in dataflow.get("steps", []):
+            ref = f"{step.get('file', '?')}:{step.get('line', '?')}"
+            ref_to_fids.setdefault(ref, set()).add(fid)
+        sink = dataflow.get("sink", {})
+        if sink:
+            ref = f"{sink.get('file', '?')}:{sink.get('line', '?')}"
+            ref_to_fids.setdefault(ref, set()).add(fid)
+
+    for ref, fids_set in ref_to_fids.items():
+        _add_group("shared_dataflow_ref", ref, list(fids_set))
+
+    return groups

--- a/packages/llm_analysis/prompts/__init__.py
+++ b/packages/llm_analysis/prompts/__init__.py
@@ -1,0 +1,26 @@
+"""Shared prompt builders for LLM analysis.
+
+Used by both agent.py (sequential) and orchestrator.py (parallel dispatch).
+"""
+
+from .analysis import (
+    build_analysis_prompt,
+    build_analysis_prompt_from_finding,
+    build_analysis_schema,
+    ANALYSIS_SYSTEM_PROMPT,
+)
+from .exploit import (
+    build_exploit_prompt,
+    build_exploit_prompt_from_finding,
+    EXPLOIT_SYSTEM_PROMPT,
+)
+from .patch import (
+    build_patch_prompt,
+    build_patch_prompt_from_finding,
+    PATCH_SYSTEM_PROMPT,
+)
+from .schemas import (
+    ANALYSIS_SCHEMA,
+    DATAFLOW_SCHEMA_FIELDS,
+    FINDING_RESULT_SCHEMA,
+)

--- a/packages/llm_analysis/prompts/analysis.py
+++ b/packages/llm_analysis/prompts/analysis.py
@@ -1,0 +1,167 @@
+"""Analysis prompt builder.
+
+Builds the vulnerability analysis prompt from a finding dict or VulnerabilityContext.
+Used by agent.py (external LLM path) and orchestrator.py (parallel dispatch).
+"""
+
+import json
+from typing import Any, Dict, Optional
+
+from .schemas import ANALYSIS_SCHEMA, DATAFLOW_SCHEMA_FIELDS
+
+ANALYSIS_SYSTEM_PROMPT = """You are a senior security researcher with expertise in:
+- Vulnerability analysis and exploit development
+- Secure code review
+- Static and variant analysis
+- Real-world attack scenarios
+
+Provide honest, technical assessments. Don't overstate severity, but don't downplay real risks."""
+
+
+def build_analysis_schema(has_dataflow: bool = False) -> Dict[str, str]:
+    """Build the analysis schema, optionally including dataflow fields."""
+    schema = dict(ANALYSIS_SCHEMA)
+    if has_dataflow:
+        schema.update(DATAFLOW_SCHEMA_FIELDS)
+    return schema
+
+
+def build_analysis_prompt(
+    rule_id: str,
+    level: str,
+    file_path: str,
+    start_line: int,
+    end_line: int,
+    message: str,
+    code: str = "",
+    surrounding_context: str = "",
+    has_dataflow: bool = False,
+    dataflow_source: Optional[Dict[str, Any]] = None,
+    dataflow_sink: Optional[Dict[str, Any]] = None,
+    dataflow_steps: Optional[list] = None,
+) -> str:
+    """Build the vulnerability analysis prompt.
+
+    For external LLM: includes full code and dataflow in the prompt.
+    """
+    prompt = f"""You are an expert security researcher analysing a potential vulnerability. Reason with your deep knowledge of software security, exploit development, and real-world attack scenarios. Do not guess or assume at any time.
+
+**Vulnerability Details:**
+- Rule: {rule_id}
+- Severity: {level}
+- File: {file_path}
+- Lines: {start_line}-{end_line}
+- Description: {message}
+"""
+
+    if has_dataflow and dataflow_source and dataflow_sink:
+        prompt += f"""
+**🔍 COMPLETE DATAFLOW PATH ANALYSIS (Source → Sink):**
+
+This vulnerability has a complete dataflow path tracked by CodeQL from tainted source to dangerous sink.
+
+**1. SOURCE (Where tainted data originates):**
+   Location: {dataflow_source['file']}:{dataflow_source['line']}
+   Type: {dataflow_source['label']}
+
+   Code:
+   ```
+{dataflow_source.get('code', '')}
+   ```
+
+"""
+        if dataflow_steps:
+            prompt += f"**2. DATAFLOW PATH ({len(dataflow_steps)} intermediate step(s)):**\n\n"
+            for i, step in enumerate(dataflow_steps, 1):
+                marker = "🛡️ SANITIZER/VALIDATOR" if step.get('is_sanitizer') else "⚙️ TRANSFORMATION"
+                prompt += f"""   {marker} Step {i}: {step.get('label', '')}
+   Location: {step['file']}:{step['line']}
+
+   Code:
+   ```
+{step.get('code', '')}
+   ```
+
+"""
+
+        prompt += f"""**3. SINK (Dangerous operation where tainted data is used):**
+   Location: {dataflow_sink['file']}:{dataflow_sink['line']}
+   Type: {dataflow_sink['label']}
+
+   Code:
+   ```
+{dataflow_sink.get('code', '')}
+   ```
+
+**⚠️ CRITICAL DATAFLOW ANALYSIS REQUIRED:**
+
+You have the COMPLETE attack path from source to sink. Use this to make an informed decision:
+
+1. **Is the SOURCE actually attacker-controlled?**
+   - HTTP parameter, user input, file upload → HIGH risk, attacker controls this
+   - Configuration file, environment variable → MEDIUM risk, requires other access
+   - Hardcoded constant, internal data → FALSE POSITIVE, not attacker-controlled
+
+2. **Are any sanitizers in the path EFFECTIVE?**
+   - For each sanitizer/validator step, determine if it actually prevents exploitation
+   - Can an attacker bypass it with encoding, special characters, or edge cases?
+   - Is it applied correctly to all code paths?
+
+3. **Is the complete path EXPLOITABLE?**
+   - Can you trace a realistic attack from source through all steps to sink?
+   - What payload would bypass sanitizers and reach the sink with malicious content?
+
+4. **What's the ACTUAL exploitability** considering the full dataflow path?
+
+"""
+    else:
+        prompt += f"""
+**Vulnerable Code:**
+```
+{code}
+```
+
+**Surrounding Context:**
+```
+{surrounding_context}
+```
+
+"""
+
+    prompt += """
+**Your Task:**
+Analyse this vulnerability in depth:
+1. Is this a TRUE POSITIVE or FALSE POSITIVE?
+2. Is it actually EXPLOITABLE in practice?
+3. What's the real-world exploitability score (0.0 = impossible, 1.0 = trivial)?
+4. What would an attacker need to exploit this?
+5. What's the potential impact?
+6. Provide a CVSS score estimate (0.0-10.0)
+7. Explain your reasoning in detail.
+8. Showcase how modern mitigations might affect exploitability.
+
+Provide detailed technical analysis based on actual code review, not just the rule match."""
+
+    return prompt
+
+
+def build_analysis_prompt_from_finding(finding: Dict[str, Any]) -> str:
+    """Build analysis prompt from a finding dict (e.g. from to_dict() or prep report).
+
+    Convenience wrapper that unpacks the finding dict into build_analysis_prompt() args.
+    """
+    dataflow = finding.get("dataflow", {})
+    return build_analysis_prompt(
+        rule_id=finding.get("rule_id", "unknown"),
+        level=finding.get("level", "warning"),
+        file_path=finding.get("file_path", "unknown"),
+        start_line=finding.get("start_line", 0),
+        end_line=finding.get("end_line", finding.get("start_line", 0)),
+        message=finding.get("message", ""),
+        code=finding.get("code", ""),
+        surrounding_context=finding.get("surrounding_context", ""),
+        has_dataflow=finding.get("has_dataflow", False),
+        dataflow_source=dataflow.get("source") if dataflow else None,
+        dataflow_sink=dataflow.get("sink") if dataflow else None,
+        dataflow_steps=dataflow.get("steps") if dataflow else None,
+    )

--- a/packages/llm_analysis/prompts/exploit.py
+++ b/packages/llm_analysis/prompts/exploit.py
@@ -1,0 +1,97 @@
+"""Exploit generation prompt builder.
+
+Builds the exploit PoC prompt from a finding/vulnerability context.
+"""
+
+import json
+from typing import Any, Dict, Optional
+
+EXPLOIT_SYSTEM_PROMPT = """You are the legend that is Mark Dowd. A true legend in this space and prolific exploit developer.
+Create practical, working exploits that security teams can use to:
+- Validate vulnerability findings
+- Test detection capabilities
+- Develop patches with confidence
+
+Prefer C++ for low-level/binary exploits, Python for web/application vulnerabilities.
+Include all necessary imports, error handling, and clear output.
+Make exploits safe for authorised testing only and not sold to russians. coz that would be bad."""
+
+
+def build_exploit_prompt(
+    rule_id: str,
+    file_path: str,
+    start_line: int,
+    level: str,
+    analysis: Dict[str, Any],
+    code: str = "",
+    surrounding_context: str = "",
+    feasibility: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Build the exploit generation prompt."""
+    prompt = f"""You are an expert security researcher creating a proof-of-concept exploit for authorised security testing.
+        This is needed for detection engineering and to validate patches. This is strictly for defensive security purposes.
+        You are Mark Dowd or Charlie Miller. Do not guess or assume at any time.
+
+**Vulnerability:**
+- Type: {rule_id}
+- File: {file_path}:{start_line}
+- Severity: {level}
+
+**Analysis:**
+{json.dumps(analysis, indent=2)}
+"""
+
+    if feasibility:
+        chain_breaks = feasibility.get("chain_breaks", [])
+        what_would_help = feasibility.get("what_would_help", [])
+        if chain_breaks or what_would_help:
+            prompt += "\n**EXPLOITATION CONSTRAINTS:**\n"
+            if chain_breaks:
+                prompt += "Techniques that WON'T work (verified blockers):\n"
+                for cb in chain_breaks:
+                    prompt += f"  - {cb}\n"
+            if what_would_help:
+                prompt += "Viable approaches to consider:\n"
+                for wh in what_would_help:
+                    prompt += f"  - {wh}\n"
+                prompt += "\nDo NOT attempt blocked techniques. Focus on viable approaches.\n"
+
+    prompt += f"""
+**Vulnerable Code:**
+```
+{code}
+```
+
+**Full Context:**
+```
+{surrounding_context}
+```
+
+**Your Task:**
+Create a WORKING proof-of-concept exploit that:
+1. Demonstrates this specific vulnerability
+2. Is safe to run in an isolated lab environment
+3. Includes clear comments explaining the attack
+4. Has detailed output showing successful exploitation
+5. Includes responsible disclosure warnings
+6. Prefer C++ for low-level exploits, Python for web/app vulnerabilities
+7. If you feel you cannot create a working exploit, explain why in full detail.
+
+Write complete, executable code as per the prime directives above. Make it realistic and practical, not just theoretical.
+The exploit should actually work against the vulnerable code, or system, shown above."""
+
+    return prompt
+
+
+def build_exploit_prompt_from_finding(finding: Dict[str, Any]) -> str:
+    """Build exploit prompt from a finding dict."""
+    return build_exploit_prompt(
+        rule_id=finding.get("rule_id", "unknown"),
+        file_path=finding.get("file_path", "unknown"),
+        start_line=finding.get("start_line", 0),
+        level=finding.get("level", "warning"),
+        analysis=finding.get("analysis", {}),
+        code=finding.get("code", ""),
+        surrounding_context=finding.get("surrounding_context", ""),
+        feasibility=finding.get("feasibility"),
+    )

--- a/packages/llm_analysis/prompts/patch.py
+++ b/packages/llm_analysis/prompts/patch.py
@@ -1,0 +1,102 @@
+"""Patch generation prompt builder.
+
+Builds the secure patch prompt from a finding/vulnerability context.
+"""
+
+import json
+from typing import Any, Dict, List, Optional
+
+PATCH_SYSTEM_PROMPT = """You are a senior security engineer responsible for secure code reviews.
+Create patches that are:
+- Secure and comprehensive
+- Maintainable and well-documented
+- Tested and production-ready
+- Following security best practices (OWASP, CWE guidance)
+
+Balance security with usability and performance."""
+
+
+def build_patch_prompt(
+    rule_id: str,
+    file_path: str,
+    start_line: int,
+    end_line: int,
+    message: str,
+    analysis: Dict[str, Any],
+    code: str = "",
+    full_file_content: str = "",
+    feasibility: Optional[Dict[str, Any]] = None,
+    attack_path: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Build the secure patch generation prompt."""
+    prompt = f"""You are a senior software security engineer creating a secure patch.
+
+**Vulnerability:**
+- Type: {rule_id}
+- File: {file_path}:{start_line}-{end_line}
+- Description: {message}
+
+**Analysis:**
+{json.dumps(analysis, indent=2)}
+"""
+
+    if feasibility:
+        what_would_help = feasibility.get("what_would_help")
+        if what_would_help:
+            prompt += "\n**What Would Help Attacker (block these):**\n"
+            for wh in what_would_help:
+                prompt += f"  - {wh}\n"
+
+        if attack_path and attack_path.get("path"):
+            prompt += "\n**Attack Path (consider patching at earliest step):**\n"
+            for step in attack_path["path"]:
+                prompt += f"  Step {step.get('step', '?')}: {step.get('action', '')} -> {step.get('result', '')}\n"
+
+    prompt += f"""
+**Vulnerable Code:**
+```
+{code}
+```
+
+**Full File Content:**
+```
+{full_file_content[:5000]}
+```
+
+**Your Task:**
+Create a SECURE PATCH that:
+1. Completely fixes the vulnerability
+2. Preserves all existing functionality
+3. Follows the code's existing style and patterns
+4. Includes clear comments explaining the fix
+5. Adds input validation/sanitisation where needed
+6. Uses modern security best practices
+
+Provide BOTH:
+1. The complete fixed code (not just the diff)
+2. A clear explanation of what changed and why
+3. Testing recommendations
+
+Make this production-ready, not just a quick fix."""
+
+    return prompt
+
+
+def build_patch_prompt_from_finding(
+    finding: Dict[str, Any],
+    full_file_content: str = "",
+    attack_path: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Build patch prompt from a finding dict."""
+    return build_patch_prompt(
+        rule_id=finding.get("rule_id", "unknown"),
+        file_path=finding.get("file_path", "unknown"),
+        start_line=finding.get("start_line", 0),
+        end_line=finding.get("end_line", finding.get("start_line", 0)),
+        message=finding.get("message", ""),
+        analysis=finding.get("analysis", {}),
+        code=finding.get("code", ""),
+        full_file_content=full_file_content,
+        feasibility=finding.get("feasibility"),
+        attack_path=attack_path,
+    )

--- a/packages/llm_analysis/prompts/schemas.py
+++ b/packages/llm_analysis/prompts/schemas.py
@@ -1,0 +1,48 @@
+"""Shared schemas for LLM analysis prompts.
+
+Used by both agent.py (sequential external LLM) and orchestrator.py (parallel dispatch).
+"""
+
+# Schema for vulnerability analysis — used with generate_structured()
+ANALYSIS_SCHEMA = {
+    "is_true_positive": "boolean",
+    "is_exploitable": "boolean",
+    "exploitability_score": "float (0.0-1.0)",
+    "severity_assessment": "string (critical/high/medium/low)",
+    "reasoning": "string",
+    "attack_scenario": "string",
+    "prerequisites": "list of strings",
+    "impact": "string",
+    "cvss_score_estimate": "float (0.0-10.0)",
+}
+
+# Additional fields when dataflow is available
+DATAFLOW_SCHEMA_FIELDS = {
+    "source_attacker_controlled": "boolean - is the dataflow source controlled by attacker?",
+    "sanitizers_effective": "boolean - are sanitizers in the path effective?",
+    "sanitizer_bypass_technique": "string - how to bypass sanitizers, or empty if effective",
+    "dataflow_exploitable": "boolean - is the complete dataflow path exploitable?",
+}
+
+# JSON Schema for CC sub-agent structured output (claude -p --json-schema).
+# This is a proper JSON Schema, unlike ANALYSIS_SCHEMA which uses descriptive strings.
+FINDING_RESULT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "finding_id": {"type": "string"},
+        "is_true_positive": {"type": "boolean"},
+        "is_exploitable": {"type": "boolean"},
+        "exploitability_score": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+        },
+        "severity_assessment": {"type": "string"},
+        "reasoning": {"type": "string"},
+        "attack_scenario": {"type": "string"},
+        "exploit_code": {"type": ["string", "null"]},
+        "patch_code": {"type": ["string", "null"]},
+    },
+    "required": ["finding_id", "is_true_positive", "is_exploitable", "reasoning"],
+    "additionalProperties": False,
+}

--- a/packages/llm_analysis/tasks.py
+++ b/packages/llm_analysis/tasks.py
@@ -1,0 +1,268 @@
+"""Concrete dispatch tasks for the orchestrator.
+
+Each task defines: what to prompt, what schema, which model, and
+any post-processing. The generic dispatcher in dispatch.py handles
+the mechanics (threading, progress, cost, errors).
+"""
+
+import logging
+from typing import Dict, List, Optional
+
+from .dispatch import DispatchTask
+from .prompts import (
+    build_analysis_prompt_from_finding, build_analysis_schema,
+    build_exploit_prompt_from_finding, build_patch_prompt_from_finding,
+    ANALYSIS_SYSTEM_PROMPT, EXPLOIT_SYSTEM_PROMPT, PATCH_SYSTEM_PROMPT,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AnalysisTask(DispatchTask):
+    """Per-finding exploitability analysis."""
+
+    name = "analysis"
+    model_role = "analysis"
+
+    def build_prompt(self, finding):
+        return build_analysis_prompt_from_finding(finding)
+
+    def get_schema(self, finding):
+        return build_analysis_schema(has_dataflow=finding.get("has_dataflow", False))
+
+    def get_system_prompt(self):
+        return ANALYSIS_SYSTEM_PROMPT
+
+
+class ExploitTask(DispatchTask):
+    """Exploit PoC generation for exploitable findings."""
+
+    name = "exploit"
+    model_role = "code"
+    temperature = 0.8
+    budget_cutoff = 0.85
+
+    def select_items(self, findings, prior_results):
+        return [f for f in findings
+                if prior_results.get(f.get("finding_id"), {}).get("is_exploitable")
+                and not prior_results.get(f.get("finding_id"), {}).get("exploit_code")]
+
+    def build_prompt(self, finding):
+        return build_exploit_prompt_from_finding(finding)
+
+    def get_system_prompt(self):
+        return EXPLOIT_SYSTEM_PROMPT
+
+    def get_schema(self, finding):
+        return None  # Free-form code generation
+
+    def finalize(self, results, prior_results):
+        for r in results:
+            fid = r.get("finding_id")
+            if fid and fid in prior_results and "error" not in r:
+                content = r.get("content", "")
+                if content:
+                    prior_results[fid]["exploit_code"] = content
+                    prior_results[fid]["has_exploit"] = True
+        return results
+
+
+class PatchTask(DispatchTask):
+    """Secure patch generation for exploitable findings."""
+
+    name = "patch"
+    model_role = "code"
+    temperature = 0.3
+    budget_cutoff = 0.85
+
+    def select_items(self, findings, prior_results):
+        return [f for f in findings
+                if prior_results.get(f.get("finding_id"), {}).get("is_exploitable")
+                and not prior_results.get(f.get("finding_id"), {}).get("patch_code")]
+
+    def build_prompt(self, finding):
+        return build_patch_prompt_from_finding(finding)
+
+    def get_system_prompt(self):
+        return PATCH_SYSTEM_PROMPT
+
+    def get_schema(self, finding):
+        return None  # Free-form code generation
+
+    def finalize(self, results, prior_results):
+        for r in results:
+            fid = r.get("finding_id")
+            if fid and fid in prior_results and "error" not in r:
+                content = r.get("content", "")
+                if content:
+                    prior_results[fid]["patch_code"] = content
+                    prior_results[fid]["has_patch"] = True
+        return results
+
+
+class ConsensusTask(DispatchTask):
+    """Independent second opinion from consensus models."""
+
+    name = "consensus"
+    model_role = "consensus"
+    budget_cutoff = 0.70
+
+    def get_models(self, role_resolution):
+        return role_resolution.get("consensus_models", [])
+
+    def select_items(self, findings, prior_results):
+        # Only findings that were successfully analysed
+        return [f for f in findings
+                if "error" not in prior_results.get(f.get("finding_id"), {"error": True})]
+
+    def build_prompt(self, finding):
+        return build_analysis_prompt_from_finding(finding)
+
+    def get_schema(self, finding):
+        return build_analysis_schema(has_dataflow=finding.get("has_dataflow", False))
+
+    def get_system_prompt(self):
+        return ANALYSIS_SYSTEM_PROMPT
+
+    def finalize(self, results, prior_results):
+        """Apply verdict rules across analysis + consensus results.
+
+        Verdict rules:
+        - 1 consensus model: either says exploitable -> exploitable (conservative)
+        - 2+ consensus models: majority across analysis + all consensus
+        """
+        # Group consensus results by finding_id
+        consensus_by_finding: Dict[str, List[Dict]] = {}
+        for r in results:
+            fid = r.get("finding_id")
+            if fid and "error" not in r:
+                consensus_by_finding.setdefault(fid, []).append(r)
+
+        # Apply verdicts to prior results (mutate in place)
+        for fid, primary in prior_results.items():
+            if isinstance(primary, dict) and "error" not in primary:
+                consensus_analyses = consensus_by_finding.get(fid, [])
+                if not consensus_analyses:
+                    continue
+
+                primary_exploitable = primary.get("is_exploitable", False)
+                verdicts = [primary_exploitable]
+                for ca in consensus_analyses:
+                    verdicts.append(ca.get("is_exploitable", False))
+
+                n_consensus = len(consensus_analyses)
+                if n_consensus == 1:
+                    final = any(verdicts)
+                else:
+                    final = sum(1 for v in verdicts if v) > len(verdicts) / 2
+
+                disputed = not all(v == verdicts[0] for v in verdicts)
+                primary["consensus"] = "disputed" if disputed else "agreed"
+                primary["is_exploitable"] = final
+                primary["consensus_analyses"] = [
+                    {"model": ca.get("analysed_by", "?"),
+                     "is_exploitable": ca.get("is_exploitable"),
+                     "reasoning": ca.get("reasoning", "")}
+                    for ca in consensus_analyses
+                ]
+
+        return results
+
+
+class GroupAnalysisTask(DispatchTask):
+    """Cross-finding group analysis for related findings."""
+
+    name = "group_analysis"
+    model_role = "analysis"
+    temperature = 0.3
+
+    def __init__(self, results_by_id: Optional[Dict[str, Dict]] = None):
+        self.results_by_id = results_by_id or {}
+
+    def select_items(self, groups, prior_results):
+        return [g for g in groups if len(g.get("finding_ids", [])) >= 2]
+
+    def build_prompt(self, group):
+        finding_ids = group.get("finding_ids", [])
+        criterion = group.get("criterion", "unknown")
+        criterion_value = group.get("criterion_value", "?")
+
+        summaries = []
+        for fid in finding_ids:
+            r = self.results_by_id.get(fid, {})
+            exploitable = r.get("is_exploitable", "unknown")
+            score = r.get("exploitability_score", "?")
+            reasoning = (r.get("reasoning") or "")[:300]
+            summaries.append(f"- {fid}: exploitable={exploitable}, score={score}\n  {reasoning}")
+
+        findings_text = "\n".join(summaries)
+
+        return f"""You are analysing {len(finding_ids)} related security findings that share: {criterion} = {criterion_value}
+
+## Findings
+
+{findings_text}
+
+## Your task
+
+Analyse the relationship between these findings:
+1. **Shared root cause?** Do they stem from the same underlying issue?
+2. **Attack chaining?** Can exploiting one finding enable or amplify another?
+3. **Inconsistencies?** Do any findings have contradictory verdicts that should be reviewed?
+
+Return a concise analysis. If there's no meaningful relationship beyond the shared {criterion}, say so.
+"""
+
+    def get_system_prompt(self):
+        return "You are a security research analyst reviewing cross-finding patterns."
+
+    def get_item_id(self, group):
+        return group.get("group_id", "unknown")
+
+    def get_item_display(self, group):
+        return f"{group.get('criterion', '?')}={group.get('criterion_value', '?')[:30]}"
+
+    def get_schema(self, group):
+        return None  # Free-form analysis
+
+
+class RetryTask(AnalysisTask):
+    """Retry low-confidence findings (score 0.3-0.7) with a fresh context.
+
+    Inherits prompts/schema/system_prompt from AnalysisTask.
+    select_items filters to ambiguous scores, finalize applies the verdict.
+    """
+
+    name = "retry"
+    LOW = 0.3
+    HIGH = 0.7
+
+    def select_items(self, findings, prior_results):
+        selected = []
+        for f in findings:
+            fid = f.get("finding_id")
+            r = prior_results.get(fid, {})
+            try:
+                score = float(r.get("exploitability_score"))
+            except (ValueError, TypeError):
+                continue
+            if self.LOW <= score <= self.HIGH:
+                selected.append(f)
+        return selected
+
+    def finalize(self, results, prior_results):
+        for r in results:
+            fid = r.get("finding_id")
+            if not fid or "error" in r:
+                continue
+            try:
+                score = float(r.get("exploitability_score"))
+            except (ValueError, TypeError):
+                score = None
+            decisive = score is not None and not (self.LOW <= score <= self.HIGH)
+            if decisive:
+                prior_results[fid] = r
+            prior_results[fid]["retried"] = True
+            if not decisive:
+                prior_results[fid]["low_confidence"] = True
+        return results

--- a/packages/llm_analysis/tests/test_dispatch.py
+++ b/packages/llm_analysis/tests/test_dispatch.py
@@ -1,0 +1,510 @@
+"""Tests for the generic dispatch framework (dispatch.py + tasks.py)."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from packages.llm_analysis.dispatch import (
+    DispatchTask, DispatchResult, dispatch_task, _format_elapsed,
+)
+from packages.llm_analysis.tasks import (
+    AnalysisTask, ExploitTask, PatchTask, ConsensusTask, GroupAnalysisTask,
+    RetryTask,
+)
+from packages.llm_analysis.orchestrator import CostTracker
+
+
+def _make_finding(finding_id, rule_id="sqli", file_path="db.py", start_line=42):
+    return {
+        "finding_id": finding_id,
+        "rule_id": rule_id,
+        "file_path": file_path,
+        "start_line": start_line,
+        "end_line": start_line + 3,
+        "level": "error",
+        "message": f"Potential {rule_id}",
+        "code": "bad()",
+        "surrounding_context": "context",
+    }
+
+
+def _make_dispatch_result(exploitable=True, score=0.85):
+    return DispatchResult(
+        result={
+            "is_true_positive": True,
+            "is_exploitable": exploitable,
+            "exploitability_score": score,
+            "reasoning": "test reasoning",
+        },
+        cost=0.10, tokens=500, model="test-model", duration=5.0,
+    )
+
+
+class TestDispatchTask:
+    def test_base_class_raises_on_build_prompt(self):
+        task = DispatchTask()
+        with pytest.raises(NotImplementedError):
+            task.build_prompt({})
+
+    def test_select_items_default_returns_all(self):
+        task = DispatchTask()
+        items = [{"a": 1}, {"b": 2}]
+        assert task.select_items(items, {}) == items
+
+    def test_get_models_from_role_resolution(self):
+        task = DispatchTask()
+        task.model_role = "analysis"
+        model = MagicMock()
+        resolution = {"analysis_model": model}
+        assert task.get_models(resolution) == [model]
+
+    def test_get_models_returns_none_list_when_missing(self):
+        task = DispatchTask()
+        task.model_role = "analysis"
+        assert task.get_models({}) == []
+
+    def test_process_result_adds_metadata(self):
+        task = DispatchTask()
+        item = {"finding_id": "f-001"}
+        dr = _make_dispatch_result()
+        processed = task.process_result(item, dr)
+        assert processed["cost_usd"] == 0.10
+        assert processed["analysed_by"] == "test-model"
+        assert processed["duration_seconds"] == 5.0
+
+    def test_finalize_default_noop(self):
+        task = DispatchTask()
+        results = [{"a": 1}]
+        assert task.finalize(results, {}) is results
+
+
+class TestAnalysisTask:
+    def test_builds_prompt(self):
+        task = AnalysisTask()
+        finding = _make_finding("f-001")
+        prompt = task.build_prompt(finding)
+        assert "sqli" in prompt
+        assert "db.py" in prompt
+
+    def test_has_schema(self):
+        task = AnalysisTask()
+        schema = task.get_schema(_make_finding("f-001"))
+        assert "is_exploitable" in schema
+
+    def test_system_prompt(self):
+        task = AnalysisTask()
+        assert task.get_system_prompt() is not None
+
+
+class TestExploitTask:
+    def test_selects_only_exploitable(self):
+        task = ExploitTask()
+        findings = [_make_finding("f-001"), _make_finding("f-002")]
+        prior = {
+            "f-001": {"is_exploitable": True},
+            "f-002": {"is_exploitable": False},
+        }
+        selected = task.select_items(findings, prior)
+        assert len(selected) == 1
+        assert selected[0]["finding_id"] == "f-001"
+
+    def test_skips_findings_with_existing_exploit(self):
+        task = ExploitTask()
+        findings = [_make_finding("f-001"), _make_finding("f-002")]
+        prior = {
+            "f-001": {"is_exploitable": True, "exploit_code": "# already generated"},
+            "f-002": {"is_exploitable": True},
+        }
+        selected = task.select_items(findings, prior)
+        assert len(selected) == 1
+        assert selected[0]["finding_id"] == "f-002"
+
+    def test_no_schema_freeform(self):
+        task = ExploitTask()
+        assert task.get_schema(_make_finding("f-001")) is None
+
+    def test_budget_cutoff(self):
+        assert ExploitTask.budget_cutoff == 0.85
+
+    def test_finalize_attaches_exploit_code(self):
+        task = ExploitTask()
+        prior = {"f-001": {"is_exploitable": True}}
+        results = [{"finding_id": "f-001", "content": "import requests\n..."}]
+        task.finalize(results, prior)
+        assert prior["f-001"]["exploit_code"] == "import requests\n..."
+        assert prior["f-001"]["has_exploit"] is True
+
+    def test_finalize_skips_errors(self):
+        task = ExploitTask()
+        prior = {"f-001": {"is_exploitable": True}}
+        results = [{"finding_id": "f-001", "error": "timeout"}]
+        task.finalize(results, prior)
+        assert "exploit_code" not in prior["f-001"]
+
+    def test_finalize_skips_empty_content(self):
+        task = ExploitTask()
+        prior = {"f-001": {"is_exploitable": True}}
+        results = [{"finding_id": "f-001", "content": ""}]
+        task.finalize(results, prior)
+        assert "exploit_code" not in prior["f-001"]
+
+
+class TestPatchTask:
+    def test_selects_only_exploitable(self):
+        task = PatchTask()
+        findings = [_make_finding("f-001")]
+        prior = {"f-001": {"is_exploitable": False}}
+        assert task.select_items(findings, prior) == []
+
+    def test_skips_findings_with_existing_patch(self):
+        task = PatchTask()
+        findings = [_make_finding("f-001"), _make_finding("f-002")]
+        prior = {
+            "f-001": {"is_exploitable": True, "patch_code": "# already generated"},
+            "f-002": {"is_exploitable": True},
+        }
+        selected = task.select_items(findings, prior)
+        assert len(selected) == 1
+        assert selected[0]["finding_id"] == "f-002"
+
+    def test_finalize_attaches_patch_code(self):
+        task = PatchTask()
+        prior = {"f-001": {"is_exploitable": True}}
+        results = [{"finding_id": "f-001", "content": "def safe_query(...):\n..."}]
+        task.finalize(results, prior)
+        assert prior["f-001"]["patch_code"] == "def safe_query(...):\n..."
+        assert prior["f-001"]["has_patch"] is True
+
+    def test_finalize_skips_errors(self):
+        task = PatchTask()
+        prior = {"f-001": {"is_exploitable": True}}
+        results = [{"finding_id": "f-001", "error": "LLM exploded"}]
+        task.finalize(results, prior)
+        assert "patch_code" not in prior["f-001"]
+
+
+class TestConsensusTask:
+    def test_gets_consensus_models(self):
+        task = ConsensusTask()
+        m1 = MagicMock()
+        m2 = MagicMock()
+        resolution = {"consensus_models": [m1, m2]}
+        assert task.get_models(resolution) == [m1, m2]
+
+    def test_selects_successfully_analysed(self):
+        task = ConsensusTask()
+        findings = [_make_finding("f-001"), _make_finding("f-002")]
+        prior = {
+            "f-001": {"is_exploitable": True},
+            "f-002": {"error": "failed"},
+        }
+        selected = task.select_items(findings, prior)
+        assert len(selected) == 1
+        assert selected[0]["finding_id"] == "f-001"
+
+    def test_finalize_one_consensus_either_exploitable_wins(self):
+        task = ConsensusTask()
+        # Consensus says exploitable, primary says not
+        consensus_results = [
+            {"finding_id": "f-001", "is_exploitable": True, "analysed_by": "gemini",
+             "reasoning": "yes"}
+        ]
+        prior = {"f-001": {"is_exploitable": False, "finding_id": "f-001"}}
+        task.finalize(consensus_results, prior)
+        assert prior["f-001"]["is_exploitable"] is True
+        assert prior["f-001"]["consensus"] == "disputed"
+
+    def test_finalize_agreed(self):
+        task = ConsensusTask()
+        consensus_results = [
+            {"finding_id": "f-001", "is_exploitable": True, "analysed_by": "gemini",
+             "reasoning": "yes"}
+        ]
+        prior = {"f-001": {"is_exploitable": True, "finding_id": "f-001"}}
+        task.finalize(consensus_results, prior)
+        assert prior["f-001"]["consensus"] == "agreed"
+
+
+class TestGroupAnalysisTask:
+    def test_selects_groups_of_two_plus(self):
+        task = GroupAnalysisTask()
+        groups = [
+            {"group_id": "G-001", "finding_ids": ["f-001", "f-002"]},
+            {"group_id": "G-002", "finding_ids": ["f-003"]},
+        ]
+        selected = task.select_items(groups, {})
+        assert len(selected) == 1
+        assert selected[0]["group_id"] == "G-001"
+
+    def test_builds_prompt_with_results(self):
+        results = {
+            "f-001": {"is_exploitable": True, "exploitability_score": 0.9,
+                       "reasoning": "injectable"},
+            "f-002": {"is_exploitable": False, "reasoning": "parameterised"},
+        }
+        task = GroupAnalysisTask(results_by_id=results)
+        group = {"group_id": "G-001", "criterion": "rule_id",
+                 "criterion_value": "sqli", "finding_ids": ["f-001", "f-002"]}
+        prompt = task.build_prompt(group)
+        assert "injectable" in prompt
+        assert "parameterised" in prompt
+        assert "root cause" in prompt.lower()
+
+    def test_item_id_is_group_id(self):
+        task = GroupAnalysisTask()
+        assert task.get_item_id({"group_id": "G-001"}) == "G-001"
+
+
+class TestDispatchTaskIntegration:
+    def test_dispatch_with_mock_fn(self):
+        """Full dispatch_task with a mock dispatch_fn."""
+        findings = [_make_finding("f-001"), _make_finding("f-002")]
+
+        def mock_fn(prompt, schema, system_prompt, temperature, model):
+            return _make_dispatch_result(exploitable=True, score=0.9)
+
+        results = dispatch_task(
+            task=AnalysisTask(),
+            items=findings,
+            dispatch_fn=mock_fn,
+            role_resolution={},  # No models — dispatch_task uses [None]
+            prior_results={},
+            cost_tracker=CostTracker(0),
+            max_parallel=2,
+        )
+
+        assert len(results) == 2
+        assert all(r.get("is_exploitable") for r in results)
+        assert all(r.get("cost_usd") == 0.10 for r in results)
+        assert all(r.get("analysed_by") == "test-model" for r in results)
+
+    def test_dispatch_feeds_cost_tracker(self):
+        """dispatch_task feeds per-item costs to CostTracker."""
+        findings = [_make_finding("f-001"), _make_finding("f-002")]
+        ct = CostTracker(max_cost=10.0)
+
+        def mock_fn(prompt, schema, system_prompt, temperature, model):
+            return _make_dispatch_result(exploitable=True, score=0.9)
+
+        dispatch_task(
+            task=AnalysisTask(),
+            items=findings,
+            dispatch_fn=mock_fn,
+            role_resolution={},
+            prior_results={},
+            cost_tracker=ct,
+            max_parallel=2,
+        )
+
+        assert ct.total_cost == 0.20  # 2 findings * $0.10 each
+        summary = ct.get_summary()
+        assert "test-model" in summary["cost_by_model"]
+
+    def test_dispatch_handles_errors(self):
+        """dispatch_task handles exceptions gracefully."""
+        findings = [_make_finding("f-001")]
+
+        def failing_fn(prompt, schema, system_prompt, temperature, model):
+            raise RuntimeError("LLM exploded")
+
+        results = dispatch_task(
+            task=AnalysisTask(),
+            items=findings,
+            dispatch_fn=failing_fn,
+            role_resolution={},
+            prior_results={},
+            cost_tracker=CostTracker(0),
+            max_parallel=1,
+        )
+
+        assert len(results) == 1
+        assert "error" in results[0]
+
+    def test_dispatch_auth_abort(self):
+        """Auth error aborts remaining dispatches."""
+        findings = [_make_finding("f-001"), _make_finding("f-002"), _make_finding("f-003")]
+
+        def auth_fail_fn(prompt, schema, system_prompt, temperature, model):
+            raise RuntimeError("Error 401 Unauthorized")
+
+        results = dispatch_task(
+            task=AnalysisTask(),
+            items=findings,
+            dispatch_fn=auth_fail_fn,
+            role_resolution={},
+            prior_results={},
+            cost_tracker=CostTracker(0),
+            max_parallel=1,
+        )
+
+        # All should have errors (dispatched or aborted)
+        assert all("error" in r for r in results)
+
+    def test_dispatch_consecutive_failure_abort(self):
+        """3 consecutive failures with no successes aborts remaining."""
+        findings = [_make_finding(f"f-{i:03d}") for i in range(6)]
+
+        def failing_fn(prompt, schema, system_prompt, temperature, model):
+            raise RuntimeError("Structured generation failed")
+
+        results = dispatch_task(
+            task=AnalysisTask(),
+            items=findings,
+            dispatch_fn=failing_fn,
+            role_resolution={},
+            prior_results={},
+            cost_tracker=CostTracker(0),
+            max_parallel=1,  # Sequential to ensure consecutive
+        )
+
+        # Should abort after 3, remaining get aborted error
+        assert all("error" in r for r in results)
+        assert len(results) == 6  # All accounted for (3 dispatched + 3 aborted)
+
+    def test_dispatch_no_abort_when_some_succeed(self):
+        """Failures after successes don't trigger consecutive abort."""
+        findings = [_make_finding("f-001"), _make_finding("f-002"),
+                    _make_finding("f-003"), _make_finding("f-004")]
+        call_count = [0]
+
+        def mixed_fn(prompt, schema, system_prompt, temperature, model):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return _make_dispatch_result()  # First succeeds
+            raise RuntimeError("Failed")
+
+        results = dispatch_task(
+            task=AnalysisTask(),
+            items=findings,
+            dispatch_fn=mixed_fn,
+            role_resolution={},
+            prior_results={},
+            cost_tracker=CostTracker(0),
+            max_parallel=1,
+        )
+
+        # All 4 should be dispatched (1 success resets consecutive counter)
+        assert len(results) == 4
+        successes = [r for r in results if "error" not in r]
+        assert len(successes) >= 1
+
+    def test_dispatch_budget_skip(self):
+        """Budget pre-check skips the phase."""
+        findings = [_make_finding("f-001")]
+        ct = CostTracker(max_cost=10.0)
+        ct.add_cost("test", 9.0)  # 90% spent
+
+        results = dispatch_task(
+            task=ExploitTask(),  # budget_cutoff = 0.85
+            items=findings,
+            dispatch_fn=lambda *a: _make_dispatch_result(),
+            role_resolution={},
+            prior_results={"f-001": {"is_exploitable": True}},
+            cost_tracker=ct,
+            max_parallel=1,
+        )
+
+        assert results == []  # Skipped due to budget
+
+
+class TestRetryTask:
+    def test_selects_low_confidence(self):
+        task = RetryTask()
+        findings = [_make_finding("f-001"), _make_finding("f-002"), _make_finding("f-003")]
+        prior = {
+            "f-001": {"exploitability_score": 0.5},   # In range
+            "f-002": {"exploitability_score": 0.9},   # Too high
+            "f-003": {"exploitability_score": 0.1},   # Too low
+        }
+        selected = task.select_items(findings, prior)
+        assert len(selected) == 1
+        assert selected[0]["finding_id"] == "f-001"
+
+    def test_selects_boundaries(self):
+        task = RetryTask()
+        findings = [_make_finding("f-001"), _make_finding("f-002")]
+        prior = {
+            "f-001": {"exploitability_score": 0.3},   # At LOW boundary
+            "f-002": {"exploitability_score": 0.7},   # At HIGH boundary
+        }
+        selected = task.select_items(findings, prior)
+        assert len(selected) == 2
+
+    def test_skips_missing_score(self):
+        task = RetryTask()
+        findings = [_make_finding("f-001")]
+        prior = {"f-001": {"is_exploitable": True}}  # No score
+        assert task.select_items(findings, prior) == []
+
+    def test_finalize_decisive_replaces(self):
+        task = RetryTask()
+        prior = {"f-001": {"exploitability_score": 0.5, "reasoning": "old"}}
+        results = [{"finding_id": "f-001", "exploitability_score": 0.9, "reasoning": "new"}]
+        task.finalize(results, prior)
+        assert prior["f-001"]["reasoning"] == "new"
+        assert prior["f-001"]["retried"] is True
+        assert "low_confidence" not in prior["f-001"]
+
+    def test_finalize_still_ambiguous_flags(self):
+        task = RetryTask()
+        prior = {"f-001": {"exploitability_score": 0.5, "reasoning": "old"}}
+        results = [{"finding_id": "f-001", "exploitability_score": 0.45, "reasoning": "still unsure"}]
+        task.finalize(results, prior)
+        assert prior["f-001"]["reasoning"] == "old"  # Original kept
+        assert prior["f-001"]["retried"] is True
+        assert prior["f-001"]["low_confidence"] is True
+
+    def test_finalize_skips_errors(self):
+        task = RetryTask()
+        prior = {"f-001": {"exploitability_score": 0.5}}
+        results = [{"finding_id": "f-001", "error": "timeout"}]
+        task.finalize(results, prior)
+        assert "retried" not in prior["f-001"]
+
+    def test_inherits_analysis_prompt(self):
+        task = RetryTask()
+        finding = _make_finding("f-001")
+        prompt = task.build_prompt(finding)
+        assert "sqli" in prompt  # Inherited from AnalysisTask
+
+    def test_dispatch_integration(self):
+        """RetryTask through dispatch_task with mock dispatch_fn."""
+        findings = [_make_finding("f-001"), _make_finding("f-002")]
+        prior = {
+            "f-001": {"exploitability_score": 0.5},
+            "f-002": {"exploitability_score": 0.9},
+        }
+
+        def mock_fn(prompt, schema, system_prompt, temperature, model):
+            return _make_dispatch_result(exploitable=True, score=0.95)
+
+        results = dispatch_task(
+            task=RetryTask(),
+            items=findings,
+            dispatch_fn=mock_fn,
+            role_resolution={},
+            prior_results=prior,
+            cost_tracker=CostTracker(0),
+            max_parallel=2,
+        )
+
+        # Only f-001 should be retried (f-002 score too high)
+        assert len(results) == 1
+        # f-001 should be replaced with decisive result
+        assert prior["f-001"]["retried"] is True
+        assert prior["f-001"]["exploitability_score"] == 0.95
+
+
+class TestFormatElapsed:
+    def test_seconds(self):
+        assert _format_elapsed(45) == "45s"
+
+    def test_minutes(self):
+        assert _format_elapsed(100) == "1m 40s"
+
+    def test_hours(self):
+        assert _format_elapsed(3700) == "1h 01m"

--- a/packages/llm_analysis/tests/test_model_roles.py
+++ b/packages/llm_analysis/tests/test_model_roles.py
@@ -1,0 +1,119 @@
+"""Tests for model role resolution and validation."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from packages.llm_analysis.llm.config import (
+    ModelConfig, ConfigError, resolve_model_roles, VALID_ROLES,
+)
+
+
+class TestRoleResolution:
+    def test_no_roles_defaults(self):
+        """No roles specified: first model = analysis+code, rest = fallback."""
+        m1 = ModelConfig(provider="anthropic", model_name="claude-opus-4-6")
+        m2 = ModelConfig(provider="openai", model_name="gpt-5.2")
+        r = resolve_model_roles(m1, [m2])
+
+        assert r["analysis_model"].model_name == "claude-opus-4-6"
+        assert r["code_model"].model_name == "claude-opus-4-6"
+        assert r["consensus_models"] == []
+        assert len(r["fallback_models"]) == 1
+        assert r["fallback_models"][0].model_name == "gpt-5.2"
+
+    def test_explicit_analysis(self):
+        m1 = ModelConfig(provider="anthropic", model_name="claude-opus-4-6", role="analysis")
+        r = resolve_model_roles(m1)
+
+        assert r["analysis_model"].model_name == "claude-opus-4-6"
+        assert r["code_model"].model_name == "claude-opus-4-6"
+
+    def test_analysis_plus_consensus(self):
+        m1 = ModelConfig(provider="anthropic", model_name="claude-opus-4-6", role="analysis")
+        m2 = ModelConfig(provider="gemini", model_name="gemini-2.5-pro", role="consensus")
+        r = resolve_model_roles(m1, [m2])
+
+        assert r["analysis_model"].model_name == "claude-opus-4-6"
+        assert len(r["consensus_models"]) == 1
+        assert r["consensus_models"][0].model_name == "gemini-2.5-pro"
+
+    def test_specialist_code_model(self):
+        m1 = ModelConfig(provider="anthropic", model_name="claude-opus-4-6", role="analysis")
+        m2 = ModelConfig(provider="ollama", model_name="deepseek-coder-v3", role="code")
+        r = resolve_model_roles(m1, [m2])
+
+        assert r["analysis_model"].model_name == "claude-opus-4-6"
+        assert r["code_model"].model_name == "deepseek-coder-v3"
+
+    def test_full_config(self):
+        m1 = ModelConfig(provider="anthropic", model_name="claude-opus-4-6", role="analysis")
+        m2 = ModelConfig(provider="gemini", model_name="gemini-2.5-pro", role="consensus")
+        m3 = ModelConfig(provider="ollama", model_name="deepseek-coder-v3", role="code")
+        m4 = ModelConfig(provider="anthropic", model_name="claude-haiku-4-5", role="fallback")
+        r = resolve_model_roles(m1, [m2, m3, m4])
+
+        assert r["analysis_model"].model_name == "claude-opus-4-6"
+        assert r["code_model"].model_name == "deepseek-coder-v3"
+        assert len(r["consensus_models"]) == 1
+        assert len(r["fallback_models"]) == 1
+
+    def test_no_models(self):
+        r = resolve_model_roles(None, None)
+        assert r["analysis_model"] is None
+        assert r["code_model"] is None
+        assert r["consensus_models"] == []
+
+
+class TestRoleValidation:
+    def test_consensus_without_analysis_raises(self):
+        m = ModelConfig(provider="gemini", model_name="gemini-2.5-pro", role="consensus")
+        with pytest.raises(ConfigError, match="without an analysis model"):
+            resolve_model_roles(None, [m])
+
+    def test_code_without_analysis_raises(self):
+        m = ModelConfig(provider="ollama", model_name="deepseek", role="code")
+        with pytest.raises(ConfigError, match="without an analysis model"):
+            resolve_model_roles(None, [m])
+
+    def test_multiple_analysis_raises(self):
+        m1 = ModelConfig(provider="anthropic", model_name="opus", role="analysis")
+        m2 = ModelConfig(provider="openai", model_name="gpt-5", role="analysis")
+        with pytest.raises(ConfigError, match="Multiple models"):
+            resolve_model_roles(m1, [m2])
+
+    def test_fallback_only_raises(self):
+        m = ModelConfig(provider="anthropic", model_name="opus", role="fallback")
+        with pytest.raises(ConfigError, match="All models are configured as fallback"):
+            resolve_model_roles(None, [m])
+
+    def test_multiple_code_raises(self):
+        m1 = ModelConfig(provider="anthropic", model_name="opus", role="analysis")
+        m2 = ModelConfig(provider="ollama", model_name="deepseek", role="code")
+        m3 = ModelConfig(provider="openai", model_name="codex", role="code")
+        with pytest.raises(ConfigError, match="Multiple models with role 'code'"):
+            resolve_model_roles(m1, [m2, m3])
+
+    def test_invalid_role_name_raises(self):
+        m1 = ModelConfig(provider="anthropic", model_name="opus", role="analysis")
+        m2 = ModelConfig(provider="openai", model_name="gpt", role="wizard")
+        with pytest.raises(ConfigError, match="Invalid role"):
+            resolve_model_roles(m1, [m2])
+
+    def test_same_model_two_roles_raises(self):
+        m1 = ModelConfig(provider="anthropic", model_name="opus", role="analysis")
+        m2 = ModelConfig(provider="anthropic", model_name="opus", role="consensus")
+        with pytest.raises(ConfigError, match="conflicting roles"):
+            resolve_model_roles(m1, [m2])
+
+
+class TestValidRoles:
+    def test_valid_roles_set(self):
+        assert "analysis" in VALID_ROLES
+        assert "code" in VALID_ROLES
+        assert "consensus" in VALID_ROLES
+        assert "fallback" in VALID_ROLES
+        assert "wizard" not in VALID_ROLES

--- a/packages/llm_analysis/tests/test_orchestrator.py
+++ b/packages/llm_analysis/tests/test_orchestrator.py
@@ -1,4 +1,4 @@
-"""Tests for the orchestrator module (Phase 4 CC dispatch)."""
+"""Tests for orchestrator, CC dispatch, cost tracking, and structural grouping."""
 
 import json
 import os
@@ -13,15 +13,18 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 
 from packages.llm_analysis.orchestrator import (
     orchestrate,
-    _invoke_cc,
-    _build_finding_prompt,
-    _build_schema,
-    _parse_cc_result,
     _merge_results,
-    _is_auth_error,
-    _print_result,
-    FINDING_RESULT_SCHEMA,
+    _structural_grouping,
+    CostTracker,
+    CUTOFF_SKIP_CONSENSUS,
 )
+from packages.llm_analysis.cc_dispatch import (
+    build_finding_prompt,
+    build_schema,
+    parse_cc_result,
+    parse_cc_freeform,
+)
+from packages.llm_analysis.prompts.schemas import FINDING_RESULT_SCHEMA
 
 
 def _make_prep_report(findings=None, mode="prep_only"):
@@ -108,7 +111,7 @@ class TestOrchestrate:
 
         with patch.dict(os.environ, {"CLAUDECODE": "1"}), \
              patch("packages.llm_analysis.orchestrator.shutil.which", return_value="/usr/bin/claude"), \
-             patch("packages.llm_analysis.orchestrator.subprocess.run",
+             patch("packages.llm_analysis.cc_dispatch.subprocess.run",
                    side_effect=_mock_subprocess_ok([cc_result])):
             result = orchestrate(
                 prep_report_path=report_path,
@@ -172,7 +175,7 @@ class TestOrchestrate:
 
         with patch.dict(os.environ, {}, clear=True), \
              patch("packages.llm_analysis.orchestrator.shutil.which", return_value="/usr/bin/claude"), \
-             patch("packages.llm_analysis.orchestrator.subprocess.run",
+             patch("packages.llm_analysis.cc_dispatch.subprocess.run",
                    side_effect=_mock_subprocess_ok(cc_results)):
             result = orchestrate(
                 prep_report_path=report_path,
@@ -225,7 +228,7 @@ class TestOrchestrate:
 
         with patch.dict(os.environ, {}, clear=True), \
              patch("packages.llm_analysis.orchestrator.shutil.which", return_value="/usr/bin/claude"), \
-             patch("packages.llm_analysis.orchestrator.subprocess.run", side_effect=mock_run):
+             patch("packages.llm_analysis.cc_dispatch.subprocess.run", side_effect=mock_run):
             result = orchestrate(
                 prep_report_path=report_path,
                 repo_path=tmp_path,
@@ -238,125 +241,13 @@ class TestOrchestrate:
         assert result["orchestration"]["findings_failed"] > 0
 
 
-class TestInvokeCC:
-    """Test single CC sub-agent invocation."""
-
-    def test_successful_invocation(self, tmp_path):
-        """Valid JSON from claude -p is parsed correctly."""
-        cc_result = _make_cc_result("f-001")
-
-        mock_proc = MagicMock()
-        mock_proc.returncode = 0
-        mock_proc.stdout = json.dumps(cc_result)
-        mock_proc.stderr = ""
-
-        with patch("packages.llm_analysis.orchestrator.subprocess.run", return_value=mock_proc):
-            result = _invoke_cc(
-                finding=_make_finding("f-001", "py/sql-injection", "db.py", 42),
-                repo_path=Path("/tmp/repo"),
-                claude_bin="/usr/bin/claude",
-                out_dir=tmp_path,
-            )
-
-        assert result["finding_id"] == "f-001"
-        assert result["is_exploitable"] is True
-        assert "error" not in result
-
-    def test_timeout(self, tmp_path):
-        """Timeout returns error dict."""
-        with patch("packages.llm_analysis.orchestrator.subprocess.run",
-                    side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=300)):
-            result = _invoke_cc(
-                finding=_make_finding("f-001", "py/sql-injection", "db.py", 42),
-                repo_path=Path("/tmp/repo"),
-                claude_bin="/usr/bin/claude",
-                out_dir=tmp_path,
-            )
-
-        assert result["finding_id"] == "f-001"
-        assert "timeout" in result["error"]
-
-    def test_nonzero_exit_writes_debug(self, tmp_path):
-        """Non-zero exit returns error dict with stderr and writes debug file."""
-        mock_proc = MagicMock()
-        mock_proc.returncode = 1
-        mock_proc.stdout = "some partial output"
-        mock_proc.stderr = "Something went wrong"
-
-        with patch("packages.llm_analysis.orchestrator.subprocess.run", return_value=mock_proc):
-            result = _invoke_cc(
-                finding=_make_finding("f-001", "py/sql-injection", "db.py", 42),
-                repo_path=Path("/tmp/repo"),
-                claude_bin="/usr/bin/claude",
-                out_dir=tmp_path,
-            )
-
-        assert "error" in result
-        assert "exit code 1" in result["error"]
-        assert "cc_debug_file" in result
-
-        # Verify debug file was written
-        debug_file = tmp_path / result["cc_debug_file"]
-        assert debug_file.exists()
-        content = debug_file.read_text()
-        assert "some partial output" in content
-        assert "Something went wrong" in content
-
-    def test_command_flags(self, tmp_path):
-        """Verify claude -p command includes all required flags."""
-        mock_proc = MagicMock()
-        mock_proc.returncode = 0
-        mock_proc.stdout = json.dumps(_make_cc_result("f-001"))
-        mock_proc.stderr = ""
-
-        with patch("packages.llm_analysis.orchestrator.subprocess.run", return_value=mock_proc) as mock_run:
-            _invoke_cc(
-                finding=_make_finding("f-001", "py/sql-injection", "db.py", 42),
-                repo_path=Path("/tmp/repo"),
-                claude_bin="/usr/bin/claude",
-                out_dir=tmp_path,
-            )
-
-        cmd = mock_run.call_args[0][0]
-        assert cmd[0] == "/usr/bin/claude"
-        assert "-p" in cmd
-        assert "--output-format" in cmd
-        assert "json" in cmd
-        assert "--json-schema" in cmd
-        assert "--no-session-persistence" in cmd
-        assert "--allowed-tools" in cmd
-        assert "--add-dir" in cmd
-        assert "/tmp/repo" in cmd
-        assert "--max-budget-usd" in cmd
-
-    def test_stdin_prompt(self, tmp_path):
-        """Prompt is passed via stdin, not as positional arg."""
-        mock_proc = MagicMock()
-        mock_proc.returncode = 0
-        mock_proc.stdout = json.dumps(_make_cc_result("f-001"))
-        mock_proc.stderr = ""
-
-        with patch("packages.llm_analysis.orchestrator.subprocess.run", return_value=mock_proc) as mock_run:
-            _invoke_cc(
-                finding=_make_finding("f-001", "py/sql-injection", "db.py", 42),
-                repo_path=Path("/tmp/repo"),
-                claude_bin="/usr/bin/claude",
-                out_dir=tmp_path,
-            )
-
-        kwargs = mock_run.call_args[1]
-        assert "input" in kwargs
-        assert isinstance(kwargs["input"], str)
-        assert len(kwargs["input"]) > 0
-
-
 class TestBuildFindingPrompt:
     """Test prompt construction."""
 
     def test_includes_finding_metadata(self):
         """Prompt includes rule_id, file_path, line numbers."""
         finding = _make_finding("f-001", "py/sql-injection", "db.py", 42)
-        prompt = _build_finding_prompt(finding)
+        prompt = build_finding_prompt(finding)
 
         assert "py/sql-injection" in prompt
         assert "db.py" in prompt
@@ -369,7 +260,7 @@ class TestBuildFindingPrompt:
         finding["code"] = "cursor.execute(f'SELECT * FROM users WHERE id={uid}')"
         finding["surrounding_context"] = "def get_user(uid):\n    cursor = db.cursor()\n    ..."
 
-        prompt = _build_finding_prompt(finding)
+        prompt = build_finding_prompt(finding)
 
         assert "cursor.execute" not in prompt
         assert "def get_user" not in prompt
@@ -384,7 +275,7 @@ class TestBuildFindingPrompt:
             "sanitizers_found": [],
         }
 
-        prompt = _build_finding_prompt(finding)
+        prompt = build_finding_prompt(finding)
         assert "routes.py:15" in prompt
         assert "db.py:42" in prompt
 
@@ -392,8 +283,8 @@ class TestBuildFindingPrompt:
         """--no-exploits suppresses exploit generation instructions."""
         finding = _make_finding("f-001", "py/sql-injection", "db.py", 42)
 
-        prompt_with = _build_finding_prompt(finding, no_exploits=False)
-        prompt_without = _build_finding_prompt(finding, no_exploits=True)
+        prompt_with = build_finding_prompt(finding, no_exploits=False)
+        prompt_without = build_finding_prompt(finding, no_exploits=True)
 
         assert "proof-of-concept" in prompt_with.lower() or "exploit" in prompt_with.lower()
         assert "proof-of-concept" not in prompt_without.lower()
@@ -402,8 +293,8 @@ class TestBuildFindingPrompt:
         """--no-patches suppresses patch generation instructions."""
         finding = _make_finding("f-001", "py/sql-injection", "db.py", 42)
 
-        prompt_with = _build_finding_prompt(finding, no_patches=False)
-        prompt_without = _build_finding_prompt(finding, no_patches=True)
+        prompt_with = build_finding_prompt(finding, no_patches=False)
+        prompt_without = build_finding_prompt(finding, no_patches=True)
 
         assert "secure fix" in prompt_with.lower() or "patch" in prompt_with.lower()
         assert "secure fix" not in prompt_without.lower()
@@ -411,7 +302,7 @@ class TestBuildFindingPrompt:
     def test_includes_score_range(self):
         """Prompt mentions the 0.0-1.0 score range."""
         finding = _make_finding("f-001", "py/sql-injection", "db.py", 42)
-        prompt = _build_finding_prompt(finding)
+        prompt = build_finding_prompt(finding)
         assert "0.0" in prompt and "1.0" in prompt
 
     def test_feasibility_framing(self):
@@ -423,7 +314,7 @@ class TestBuildFindingPrompt:
             "what_would_help": ["Format string"],
         }
 
-        prompt = _build_finding_prompt(finding)
+        prompt = build_finding_prompt(finding)
         assert "ground truth" in prompt
         assert "upstream validation pipeline" in prompt
         assert "GOT overwrite" in prompt
@@ -434,7 +325,7 @@ class TestParseCCResult:
 
     def test_valid_json(self):
         """Clean JSON is parsed directly."""
-        result = _parse_cc_result(
+        result = parse_cc_result(
             json.dumps({"finding_id": "f-001", "is_exploitable": True}),
             "", "f-001",
         )
@@ -446,32 +337,32 @@ class TestParseCCResult:
         content = "Here is the result:\n```json\n" + json.dumps({
             "finding_id": "f-001", "is_exploitable": False, "reasoning": "test"
         }) + "\n```\n"
-        result = _parse_cc_result(content, "", "f-001")
+        result = parse_cc_result(content, "", "f-001")
         assert result["finding_id"] == "f-001"
         assert "error" not in result
 
     def test_empty_output(self):
         """Empty stdout returns error dict."""
-        result = _parse_cc_result("", "some error", "f-001")
+        result = parse_cc_result("", "some error", "f-001")
         assert result["finding_id"] == "f-001"
         assert "error" in result
 
     def test_invalid_json(self):
         """Unparseable output returns error dict."""
-        result = _parse_cc_result("This is not JSON at all", "", "f-001")
+        result = parse_cc_result("This is not JSON at all", "", "f-001")
         assert "error" in result
 
     def test_json_embedded_in_text(self):
         """JSON object embedded in surrounding text is extracted via raw_decode."""
         content = 'I found that {"finding_id": "f-001", "is_exploitable": true, "reasoning": "vuln"} is the result.'
-        result = _parse_cc_result(content, "", "f-001")
+        result = parse_cc_result(content, "", "f-001")
         assert result["finding_id"] == "f-001"
         assert "error" not in result
 
     def test_multiple_json_fragments_takes_first(self):
         """With multiple JSON objects, raw_decode takes the first valid one."""
         content = 'prefix {"partial": true} and {"finding_id": "f-001", "is_exploitable": false, "reasoning": "safe"} end'
-        result = _parse_cc_result(content, "", "f-001")
+        result = parse_cc_result(content, "", "f-001")
         # raw_decode takes the first complete JSON object from first {
         assert "error" not in result
 
@@ -492,12 +383,46 @@ class TestParseCCResult:
                 "reasoning": "Stack buffer overflow",
             }
         })
-        result = _parse_cc_result(envelope, "", "f-001")
+        result = parse_cc_result(envelope, "", "f-001")
         assert result["finding_id"] == "f-001"
         assert result["is_exploitable"] is True
         assert result["exploitability_score"] == 0.9
         assert result["reasoning"] == "Stack buffer overflow"
         assert "session_id" not in result  # envelope fields stripped
+
+
+class TestParseCCFreeform:
+    """Test free-form CC output parsing with JSON envelope."""
+
+    def test_extracts_content_and_cost(self):
+        envelope = json.dumps({
+            "type": "result",
+            "result": "Here is the exploit code:\n```python\nimport os\n```",
+            "total_cost_usd": 0.18,
+            "duration_ms": 12500,
+            "modelUsage": {"claude-sonnet-4-20250514": {}},
+            "usage": {"input_tokens": 1000, "output_tokens": 500},
+        })
+        parsed = parse_cc_freeform(envelope, "")
+        assert "exploit code" in parsed["content"]
+        assert parsed["cost_usd"] == 0.18
+        assert parsed["duration_seconds"] == 12.5
+        assert parsed["analysed_by"] == "claude-sonnet-4-20250514"
+        assert parsed["_tokens"] == 1500
+
+    def test_empty_output(self):
+        parsed = parse_cc_freeform("", "some error")
+        assert "error" in parsed
+
+    def test_non_json_fallback(self):
+        parsed = parse_cc_freeform("Just plain text output", "")
+        assert parsed["content"] == "Just plain text output"
+
+    def test_envelope_without_cost(self):
+        envelope = json.dumps({"type": "result", "result": "analysis text"})
+        parsed = parse_cc_freeform(envelope, "")
+        assert parsed["content"] == "analysis text"
+        assert "cost_usd" not in parsed
 
 
 class TestMergeResults:
@@ -518,7 +443,7 @@ class TestMergeResults:
         assert result["code"] == "original code"
         assert result["has_dataflow"] is True
         assert result["exploitable"] is True
-        assert result["analysis"]["reasoning"] == "Test reasoning"
+        assert result["reasoning"] == "Test reasoning"
 
     def test_does_not_mutate_original(self):
         """Merging does not mutate the original prep report."""
@@ -590,44 +515,7 @@ class TestMergeResults:
         assert merged["analyzed"] == 2
         assert merged["exploitable"] == 1
         assert merged["exploits_generated"] == 1  # Only f-001 has exploit_code
-        assert merged["patches_generated"] == 2   # Both have patch_code
-
-
-class TestPrintResult:
-    """Test result display formatting."""
-
-    def test_handles_float_score(self):
-        """Normal float score formats correctly."""
-        _print_result("f-001", {"is_exploitable": True, "exploitability_score": 0.85})
-
-    def test_handles_none_score(self):
-        """None score doesn't crash."""
-        _print_result("f-001", {"is_exploitable": True, "exploitability_score": None})
-
-    def test_handles_string_score(self):
-        """String score doesn't crash."""
-        _print_result("f-001", {"is_exploitable": True, "exploitability_score": "high"})
-
-    def test_handles_missing_score(self):
-        """Missing score doesn't crash."""
-        _print_result("f-001", {"is_exploitable": False})
-
-
-class TestIsAuthError:
-    """Test auth error detection."""
-
-    def test_detects_401(self):
-        assert _is_auth_error("exit code 1: Error 401 Unauthorized") is True
-
-    def test_detects_invalid_api_key(self):
-        assert _is_auth_error("invalid api key provided") is True
-
-    def test_detects_billing(self):
-        assert _is_auth_error("billing issue: insufficient_quota") is True
-
-    def test_ignores_normal_errors(self):
-        assert _is_auth_error("timeout after 300s") is False
-        assert _is_auth_error("json parse error") is False
+        assert merged["patches_generated"] == 1   # Only exploitable f-001 gets patch
 
 
 class TestFindingResultSchema:
@@ -659,30 +547,196 @@ class TestBuildSchema:
 
     def test_default_includes_all_fields(self):
         """Default schema includes exploit_code and patch_code."""
-        schema = _build_schema()
+        schema = build_schema()
         assert "exploit_code" in schema["properties"]
         assert "patch_code" in schema["properties"]
 
     def test_no_exploits_removes_exploit_code(self):
         """--no-exploits removes exploit_code from schema."""
-        schema = _build_schema(no_exploits=True)
+        schema = build_schema(no_exploits=True)
         assert "exploit_code" not in schema["properties"]
         assert "patch_code" in schema["properties"]
 
     def test_no_patches_removes_patch_code(self):
         """--no-patches removes patch_code from schema."""
-        schema = _build_schema(no_patches=True)
+        schema = build_schema(no_patches=True)
         assert "exploit_code" in schema["properties"]
         assert "patch_code" not in schema["properties"]
 
     def test_both_flags_removes_both(self):
         """Both flags remove both fields."""
-        schema = _build_schema(no_exploits=True, no_patches=True)
+        schema = build_schema(no_exploits=True, no_patches=True)
         assert "exploit_code" not in schema["properties"]
         assert "patch_code" not in schema["properties"]
 
     def test_does_not_mutate_base_schema(self):
         """Building a schema doesn't mutate FINDING_RESULT_SCHEMA."""
-        _build_schema(no_exploits=True, no_patches=True)
+        build_schema(no_exploits=True, no_patches=True)
         assert "exploit_code" in FINDING_RESULT_SCHEMA["properties"]
         assert "patch_code" in FINDING_RESULT_SCHEMA["properties"]
+
+
+# ── Structural Grouping ─────────────────────────────────────────────
+
+class TestStructuralGrouping:
+    def test_same_file_groups(self):
+        results = [
+            {"finding_id": "f-001", "file_path": "db.py", "rule_id": "sqli"},
+            {"finding_id": "f-002", "file_path": "db.py", "rule_id": "xss"},
+        ]
+        groups = _structural_grouping(results)
+        file_groups = [g for g in groups if g["criterion"] == "file_path"]
+        assert len(file_groups) == 1
+        assert set(file_groups[0]["finding_ids"]) == {"f-001", "f-002"}
+
+    def test_same_rule_groups(self):
+        results = [
+            {"finding_id": "f-001", "file_path": "a.py", "rule_id": "sqli"},
+            {"finding_id": "f-002", "file_path": "b.py", "rule_id": "sqli"},
+            {"finding_id": "f-003", "file_path": "c.py", "rule_id": "xss"},
+            {"finding_id": "f-004", "file_path": "d.py", "rule_id": "path_traversal"},
+        ]
+        groups = _structural_grouping(results)
+        rule_groups = [g for g in groups if g["criterion"] == "rule_id"]
+        assert len(rule_groups) == 1
+        assert set(rule_groups[0]["finding_ids"]) == {"f-001", "f-002"}
+
+    def test_no_transitive_closure(self):
+        """A-B share file, B-C share rule. A and C should NOT be in same group."""
+        results = [
+            {"finding_id": "f-001", "file_path": "db.py", "rule_id": "sqli"},
+            {"finding_id": "f-002", "file_path": "db.py", "rule_id": "xss"},
+            {"finding_id": "f-003", "file_path": "api.py", "rule_id": "xss"},
+        ]
+        groups = _structural_grouping(results)
+        # f-001 and f-003 should NOT be in the same group
+        for g in groups:
+            ids = set(g["finding_ids"])
+            assert not ({"f-001", "f-003"} <= ids and "f-002" not in ids)
+
+    def test_overlapping_groups(self):
+        """A finding can appear in multiple groups."""
+        results = [
+            {"finding_id": "f-001", "file_path": "db.py", "rule_id": "sqli"},
+            {"finding_id": "f-002", "file_path": "db.py", "rule_id": "xss"},
+            {"finding_id": "f-003", "file_path": "api.py", "rule_id": "sqli"},
+            {"finding_id": "f-004", "file_path": "util.py", "rule_id": "path_traversal"},
+        ]
+        groups = _structural_grouping(results)
+        # f-001 should appear in both a file group (db.py) and a rule group (sqli)
+        f001_groups = [g for g in groups if "f-001" in g["finding_ids"]]
+        assert len(f001_groups) >= 2
+
+    def test_independent_findings_no_group(self):
+        results = [
+            {"finding_id": "f-001", "file_path": "a.py", "rule_id": "sqli"},
+            {"finding_id": "f-002", "file_path": "b.py", "rule_id": "xss"},
+        ]
+        groups = _structural_grouping(results)
+        assert len(groups) == 0
+
+    def test_shared_dataflow_source(self):
+        results = [
+            {"finding_id": "f-001", "file_path": "a.py", "rule_id": "sqli",
+             "dataflow": {"source": {"file": "routes.py", "line": 15}}},
+            {"finding_id": "f-002", "file_path": "b.py", "rule_id": "xss",
+             "dataflow": {"source": {"file": "routes.py", "line": 15}}},
+        ]
+        groups = _structural_grouping(results)
+        source_groups = [g for g in groups if g["criterion"] == "dataflow_source"]
+        assert len(source_groups) == 1
+
+
+
+# ── CostTracker ──────────────────────────────────────────────────────
+
+class TestCostTracker:
+    def test_basic_tracking(self):
+        ct = CostTracker(max_cost=10.0)
+        ct.add_cost("opus", 3.0)
+        ct.add_cost("opus", 2.0)
+        assert ct.total_cost == 5.0
+
+    def test_per_model_breakdown(self):
+        ct = CostTracker(max_cost=10.0)
+        ct.add_cost("opus", 3.0)
+        ct.add_cost("gemini", 2.0)
+        summary = ct.get_summary()
+        assert summary["cost_by_model"]["opus"] == 3.0
+        assert summary["cost_by_model"]["gemini"] == 2.0
+
+    def test_skip_consensus_at_70_percent(self):
+        ct = CostTracker(max_cost=10.0)
+        ct.add_cost("opus", 6.9)
+        assert ct.should_skip_consensus() is False
+        ct.add_cost("opus", 0.2)
+        assert ct.should_skip_consensus() is True
+
+    def test_skip_exploits_at_85_percent(self):
+        ct = CostTracker(max_cost=10.0)
+        ct.add_cost("opus", 8.4)
+        assert ct.should_skip_exploits() is False
+        ct.add_cost("opus", 0.2)
+        assert ct.should_skip_exploits() is True
+
+    def test_single_model_at_95_percent(self):
+        ct = CostTracker(max_cost=10.0)
+        ct.add_cost("opus", 9.4)
+        assert ct.should_single_model() is False
+        ct.add_cost("opus", 0.2)
+        assert ct.should_single_model() is True
+
+    def test_no_budget_never_skips(self):
+        ct = CostTracker(max_cost=0)
+        ct.add_cost("opus", 100.0)
+        assert ct.should_skip_consensus() is False
+        assert ct.should_skip_exploits() is False
+
+    def test_estimate_cost(self):
+        ct = CostTracker(max_cost=10.0)
+        est = ct.estimate_cost(50, n_consensus_models=1, model_name="unknown-model")
+        # Falls back to default $0.03/call: 100 calls * 0.03 = 3.0
+        assert est == 3.0
+
+
+
+# ── CostTracker Phase Skip ──────────────────────────────────────────
+
+class TestCostTrackerPhaseSkip:
+    def test_should_skip_phase_when_over_budget(self):
+        ct = CostTracker(max_cost=10.0)
+        ct.add_cost("opus", 8.0)  # 80% spent
+        # Consensus cutoff is 70%, estimate for 50 calls ≈ $1.50
+        assert ct.should_skip_phase(50, "opus", CUTOFF_SKIP_CONSENSUS, "consensus") is True
+
+    def test_should_not_skip_phase_when_within_budget(self):
+        ct = CostTracker(max_cost=10.0)
+        ct.add_cost("opus", 2.0)  # 20% spent
+        assert ct.should_skip_phase(10, "opus", CUTOFF_SKIP_CONSENSUS, "consensus") is False
+
+    def test_no_budget_never_skips_phase(self):
+        ct = CostTracker(max_cost=0)
+        ct.add_cost("opus", 100.0)
+        assert ct.should_skip_phase(1000, "opus", CUTOFF_SKIP_CONSENSUS, "consensus") is False
+
+
+class TestMergePrepProtection:
+    def test_prep_data_not_overwritten_by_dispatch(self):
+        """Dispatch result keys that match prep data should not overwrite."""
+        finding = _make_finding("f-001", "py/sql-injection", "db.py", 42)
+        finding["code"] = "original prep code"
+        report = _make_prep_report(findings=[finding])
+
+        # Simulate a dispatch result that tries to overwrite prep fields
+        cc_result = _make_cc_result("f-001", exploitable=True)
+        cc_result["code"] = "INJECTED CODE"
+        cc_result["file_path"] = "/etc/shadow"
+
+        merged = _merge_results(report, [cc_result])
+        result = merged["results"][0]
+
+        # Prep data should be preserved
+        assert result["code"] == "original prep code"
+        assert result["file_path"] == "db.py"
+        # Analysis data should still come through
+        assert result["is_exploitable"] is True

--- a/packages/llm_analysis/tests/test_prompts.py
+++ b/packages/llm_analysis/tests/test_prompts.py
@@ -1,0 +1,123 @@
+"""Tests for shared prompt builders."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from packages.llm_analysis.prompts import (
+    build_analysis_prompt,
+    build_analysis_prompt_from_finding,
+    build_analysis_schema,
+    build_exploit_prompt,
+    build_exploit_prompt_from_finding,
+    build_patch_prompt,
+    build_patch_prompt_from_finding,
+    ANALYSIS_SYSTEM_PROMPT,
+    EXPLOIT_SYSTEM_PROMPT,
+    PATCH_SYSTEM_PROMPT,
+    ANALYSIS_SCHEMA,
+    DATAFLOW_SCHEMA_FIELDS,
+    FINDING_RESULT_SCHEMA,
+)
+
+
+class TestAnalysisPrompt:
+    def test_includes_finding_metadata(self):
+        prompt = build_analysis_prompt(
+            rule_id="py/sql-injection", level="error",
+            file_path="db.py", start_line=42, end_line=45,
+            message="SQL injection", code="cursor.execute(f'...')",
+        )
+        assert "py/sql-injection" in prompt
+        assert "db.py" in prompt
+        assert "42" in prompt
+
+    def test_includes_code_when_no_dataflow(self):
+        prompt = build_analysis_prompt(
+            rule_id="sqli", level="error", file_path="db.py",
+            start_line=42, end_line=42, message="",
+            code="cursor.execute(query)",
+        )
+        assert "cursor.execute(query)" in prompt
+
+    def test_includes_dataflow_when_available(self):
+        prompt = build_analysis_prompt(
+            rule_id="sqli", level="error", file_path="db.py",
+            start_line=42, end_line=42, message="",
+            has_dataflow=True,
+            dataflow_source={"file": "routes.py", "line": 15, "label": "HTTP param", "code": "req.args"},
+            dataflow_sink={"file": "db.py", "line": 42, "label": "SQL query", "code": "cursor.execute()"},
+            dataflow_steps=[{"file": "utils.py", "line": 20, "label": "transform", "is_sanitizer": False, "code": "x = y"}],
+        )
+        assert "routes.py:15" in prompt
+        assert "db.py:42" in prompt
+        assert "DATAFLOW" in prompt
+
+    def test_from_finding_dict(self):
+        finding = {
+            "rule_id": "sqli", "level": "error", "file_path": "db.py",
+            "start_line": 42, "end_line": 42, "message": "injection",
+            "code": "bad code", "surrounding_context": "context",
+        }
+        prompt = build_analysis_prompt_from_finding(finding)
+        assert "sqli" in prompt
+        assert "bad code" in prompt
+
+
+class TestAnalysisSchema:
+    def test_base_schema(self):
+        schema = build_analysis_schema()
+        assert "is_exploitable" in schema
+        assert "dataflow_exploitable" not in schema
+
+    def test_schema_with_dataflow(self):
+        schema = build_analysis_schema(has_dataflow=True)
+        assert "is_exploitable" in schema
+        assert "dataflow_exploitable" in schema
+
+
+class TestExploitPrompt:
+    def test_includes_analysis(self):
+        prompt = build_exploit_prompt(
+            rule_id="sqli", file_path="db.py", start_line=42, level="error",
+            analysis={"is_exploitable": True, "reasoning": "injectable"},
+            code="bad()", surrounding_context="ctx",
+        )
+        assert "injectable" in prompt
+        assert "Mark Dowd" in prompt
+
+    def test_includes_feasibility_constraints(self):
+        prompt = build_exploit_prompt(
+            rule_id="bof", file_path="vuln.c", start_line=10, level="error",
+            analysis={}, code="strcpy(buf, input)",
+            feasibility={"chain_breaks": ["Full RELRO"], "what_would_help": ["Format string"]},
+        )
+        assert "Full RELRO" in prompt
+        assert "Format string" in prompt
+
+
+class TestPatchPrompt:
+    def test_includes_analysis(self):
+        prompt = build_patch_prompt(
+            rule_id="sqli", file_path="db.py", start_line=42, end_line=42,
+            message="injection", analysis={"reasoning": "use parameterised"},
+            code="bad()", full_file_content="full file",
+        )
+        assert "use parameterised" in prompt
+        assert "SECURE PATCH" in prompt
+
+
+class TestSystemPrompts:
+    def test_system_prompts_not_empty(self):
+        assert len(ANALYSIS_SYSTEM_PROMPT) > 50
+        assert len(EXPLOIT_SYSTEM_PROMPT) > 50
+        assert len(PATCH_SYSTEM_PROMPT) > 50
+
+
+class TestFindingResultSchema:
+    def test_is_valid_json_schema(self):
+        assert FINDING_RESULT_SCHEMA["type"] == "object"
+        assert "finding_id" in FINDING_RESULT_SCHEMA["required"]

--- a/raptor.py
+++ b/raptor.py
@@ -124,7 +124,7 @@ def mode_agentic(args: list) -> int:
     if '--codeql' not in args and '--codeql-only' not in args and '--no-codeql' not in args:
         args = ['--codeql'] + args
 
-    print("\n[*] Starting full autonomous workflow (Semgrep + CodeQL)...\n")
+    print("\n[*] Starting full autonomous workflow (Semgrep + CodeQL)...\n", flush=True)
     return run_script(agentic_script, args)
 
 

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -4,13 +4,14 @@ RAPTOR Truly Agentic Workflow
 
 Complete end-to-end autonomous security testing:
 0. Pre-exploit mitigation analysis (optional)
-1. Scan code with Semgrep AND CodeQL (parallel execution)
-2. Validate exploitability (filter hallucinations and unreachable code)
-3. Autonomously analyse findings (read code, understand context)
-4. Autonomously validate dataflow paths (CodeQL-specific)
-5. Autonomously generate exploits (write working PoC code)
-6. Autonomously create patches (write secure fixes)
-7. Report everything
+1. Scan code with Semgrep and CodeQL (parallel)
+2. Validate exploitability (filter false positives and unreachable code)
+3. Analyse each finding (read code, understand context, assess impact)
+4. Generate exploit PoCs for confirmed vulnerabilities
+5. Create secure patches
+6. Cross-finding analysis (structural grouping, shared root causes)
+7. Multi-model consensus (when configured)
+8. Report everything
 """
 
 import argparse
@@ -27,27 +28,6 @@ from core.config import RaptorConfig
 from core.logging import get_logger
 
 logger = get_logger()
-
-
-def run_command(cmd: list, description: str) -> tuple[int, str, str]:
-    """Run a command and return results."""
-    logger.info(f"Running: {description}")
-    print(f"\n[*] {description}...")
-
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=1800  # 30 minutes
-        )
-        return result.returncode, result.stdout, result.stderr
-    except subprocess.TimeoutExpired:
-        logger.error(f"Command timed out: {description}")
-        return -1, "", "Timeout"
-    except Exception as e:
-        logger.error(f"Command failed: {e}")
-        return -1, "", str(e)
 
 
 def run_command_streaming(cmd: list, description: str) -> tuple[int, str, str]:
@@ -197,6 +177,8 @@ Examples:
     # Orchestration options
     parser.add_argument("--max-parallel", type=int, default=3,
                        help="Maximum parallel Claude Code agents for Phase 4 orchestration (default: 3)")
+    parser.add_argument("--no-orchestration", action="store_true",
+                       help="Skip Phase 4 orchestration (use Phase 3 sequential analysis even when CC is available)")
 
     args = parser.parse_args()
 
@@ -346,26 +328,64 @@ Examples:
     semgrep_metrics = {}
     codeql_metrics = {}
 
-    # ---- Semgrep Scanning ----
-    if not args.codeql_only:
+    # Launch scanners in parallel when both are enabled
+    run_semgrep = not args.codeql_only
+    run_codeql = (args.codeql or args.codeql_only) and not args.no_codeql
+
+    semgrep_cmd = None
+    codeql_cmd = None
+    semgrep_proc = None
+    codeql_proc = None
+
+    if run_semgrep:
         print("\n[*] Running Semgrep analysis...")
-        scan_cmd = [
+        semgrep_cmd = [
             "python3",
             str(script_root / "packages/static-analysis/scanner.py"),
             "--repo", str(repo_path),
             "--policy_groups", args.policy_groups,
         ]
+        logger.info(f"Running: Scanning code with Semgrep")
+        semgrep_proc = subprocess.Popen(
+            semgrep_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
 
-        rc, stdout, stderr = run_command(scan_cmd, "Scanning code with Semgrep")
+    if run_codeql:
+        print("\n[*] Running CodeQL analysis...")
+        codeql_cmd = [
+            "python3",
+            str(script_root / "packages/codeql/agent.py"),
+            "--repo", str(repo_path),
+            "--out", str(out_dir / "codeql"),
+        ]
+        if args.languages:
+            codeql_cmd.extend(["--languages", args.languages])
+        if args.build_command:
+            codeql_cmd.extend(["--build-command", args.build_command])
+        if args.extended:
+            codeql_cmd.append("--extended")
+        if args.codeql_cli:
+            codeql_cmd.extend(["--codeql-cli", args.codeql_cli])
+        logger.info(f"Running: Scanning code with CodeQL")
+        codeql_proc = subprocess.Popen(
+            codeql_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
 
-        if rc not in (0, 1):
-            print(f"❌ Semgrep scan failed: {stderr}")
-            if args.codeql or args.codeql_only:
-                print("   Continuing with CodeQL scan...")
-            else:
+    # ---- Collect Semgrep results ----
+    if semgrep_proc:
+        try:
+            semgrep_stdout, semgrep_stderr = semgrep_proc.communicate(timeout=1800)
+            rc = semgrep_proc.returncode
+        except subprocess.TimeoutExpired:
+            semgrep_proc.kill()
+            semgrep_proc.communicate()
+            rc = -1
+            print(f"❌ Semgrep scan timed out (30m)")
+            logger.error("Semgrep scan timed out")
+            if not run_codeql:
                 sys.exit(1)
-        else:
-            # Parse Semgrep results
+
+        if rc in (0, 1):
             scanner_out_dir = RaptorConfig.get_out_dir()
             scan_dirs = sorted(scanner_out_dir.glob("scan_*"), key=lambda p: p.stat().st_mtime, reverse=True)
 
@@ -384,47 +404,39 @@ Examples:
                     print(f"  - Critical: {semgrep_metrics.get('findings_by_severity', {}).get('error', 0)}")
                     print(f"  - Warnings: {semgrep_metrics.get('findings_by_severity', {}).get('warning', 0)}")
 
-                # Get SARIF files
                 sarif_file = actual_scan_dir / "combined.sarif"
                 if sarif_file.exists():
                     all_sarif_files.append(sarif_file)
                 else:
                     semgrep_sarifs = list(actual_scan_dir.glob("semgrep_*.sarif"))
                     all_sarif_files.extend(semgrep_sarifs)
+        elif rc != -1:  # -1 is timeout, already reported
+            print(f"❌ Semgrep scan failed (exit code {rc})")
+            if not run_codeql:
+                sys.exit(1)
 
-    # ---- CodeQL Scanning ----
-    if (args.codeql or args.codeql_only) and not args.no_codeql:
-        print("\n[*] Running CodeQL analysis...")
-
-        # Build CodeQL command
-        codeql_cmd = [
-            "python3",
-            str(script_root / "packages/codeql/agent.py"),
-            "--repo", str(repo_path),
-            "--out", str(out_dir / "codeql")
-        ]
-
-        if args.languages:
-            codeql_cmd.extend(["--languages", args.languages])
-        if args.build_command:
-            codeql_cmd.extend(["--build-command", args.build_command])
-        if args.extended:
-            codeql_cmd.append("--extended")
-        if args.codeql_cli:
-            codeql_cmd.extend(["--codeql-cli", args.codeql_cli])
-
-        rc, stdout, stderr = run_command_streaming(codeql_cmd, "Scanning code with CodeQL")
+    # ---- Collect CodeQL results ----
+    if codeql_proc:
+        try:
+            codeql_stdout, codeql_stderr = codeql_proc.communicate(timeout=1800)
+            rc = codeql_proc.returncode
+        except subprocess.TimeoutExpired:
+            codeql_proc.kill()
+            codeql_proc.communicate()
+            rc = -1
+            print(f"❌ CodeQL scan timed out (30m)")
+            logger.error("CodeQL scan timed out")
 
         if rc != 0:
-            print(f"⚠️  CodeQL scan failed or completed with warnings")
-            if stderr:
-                print(f"    {stderr[:500]}")
+            if all_sarif_files:
+                print(f"⚠️  CodeQL scan failed — continuing with existing findings")
+            else:
+                print(f"⚠️  CodeQL scan failed — no findings from any scanner")
             logger.warning(f"CodeQL scan failed - rc={rc}")
             if args.codeql_only:
                 print("❌ CodeQL-only mode failed")
                 sys.exit(1)
         else:
-            # Parse CodeQL results
             codeql_out_dir = out_dir / "codeql"
             codeql_report = codeql_out_dir / "codeql_report.json"
 
@@ -440,7 +452,6 @@ Examples:
                 print(f"  - Findings: {total_findings}")
                 print(f"  - SARIF files: {len(sarif_files)}")
 
-                # Add CodeQL SARIF files
                 for sarif in sarif_files:
                     all_sarif_files.append(Path(sarif))
 
@@ -456,7 +467,7 @@ Examples:
         'total_files_scanned': semgrep_metrics.get('total_files_scanned', 0),
         'findings_by_severity': semgrep_metrics.get('findings_by_severity', {}),
         'semgrep': semgrep_metrics,
-        'codeql': codeql_metrics
+        'codeql': codeql_metrics,
     }
 
     sarif_files = all_sarif_files
@@ -514,7 +525,7 @@ Examples:
         # Check if validation produced enriched findings
         validated_findings_path = out_dir / "validation" / "findings.json"
         if validated_findings_path.exists():
-            logger.info("Using validated findings for LLM analysis (enriched with feasibility data)")
+            logger.info("Using findings from Phase 2 for analysis")
             analysis_cmd = [
                 "python3",
                 str(script_root / "packages/llm_analysis/agent.py"),
@@ -535,7 +546,7 @@ Examples:
             ]
 
         # If CC will orchestrate in Phase 4, tell agent to prep only (skip LLM calls)
-        if llm_env.claude_code and not llm_env.external_llm:
+        if llm_env.claude_code and not args.no_orchestration:
             analysis_cmd.append("--prep-only")
 
         rc, stdout, stderr = run_command_streaming(analysis_cmd, "Analysing vulnerabilities autonomously")
@@ -546,15 +557,17 @@ Examples:
             with open(analysis_report) as f:
                 analysis = json.load(f)
 
-            print(f"\n✓ Analysis complete:")
-            print(f"  - Analysed: {analysis.get('analyzed', 0)}")
-            print(f"  - Exploitable: {analysis.get('exploitable', 0)}")
-            print(f"  - Exploits generated: {analysis.get('exploits_generated', 0)}")
-            print(f"  - Patches generated: {analysis.get('patches_generated', 0)}")
+            if analysis.get('mode') == 'prep_only':
+                print(f"\n✓ Prep complete: {analysis.get('processed', 0)} findings ready for Phase 4")
+            else:
+                print(f"\n✓ Analysis complete:")
+                print(f"  - Analysed: {analysis.get('analyzed', 0)}")
+                print(f"  - Exploitable: {analysis.get('exploitable', 0)}")
+                print(f"  - Exploits generated: {analysis.get('exploits_generated', 0)}")
+                print(f"  - Patches generated: {analysis.get('patches_generated', 0)}")
 
-            # CodeQL-specific metrics
-            if args.codeql or args.codeql_only:
-                print(f"  - CodeQL dataflow paths validated: {analysis.get('dataflow_validated', 0)}")
+                if args.codeql or args.codeql_only:
+                    print(f"  - CodeQL dataflow paths validated: {analysis.get('dataflow_validated', 0)}")
         else:
             print(f"⚠️  Analysis failed or produced no output")
             if stderr:
@@ -566,12 +579,18 @@ Examples:
     # PHASE 4: AGENTIC ORCHESTRATION
     # ========================================================================
     orchestration_result = None
-    if llm_env.claude_code and not llm_env.external_llm:
+    if llm_env.claude_code and not args.no_orchestration:
         print("\n" + "=" * 70)
         print("PHASE 4: AGENTIC ORCHESTRATION")
         print("=" * 70)
-        # CC available, no external LLM → dispatch claude -p sub-agents
+
         if analysis_report and analysis_report.exists():
+            # Build LLMConfig if external LLM is available
+            llm_config = None
+            if llm_env.external_llm:
+                from packages.llm_analysis.llm.config import LLMConfig
+                llm_config = LLMConfig()
+
             from packages.llm_analysis.orchestrator import orchestrate
             orchestration_result = orchestrate(
                 prep_report_path=analysis_report,
@@ -580,6 +599,7 @@ Examples:
                 max_parallel=args.max_parallel,
                 no_exploits=args.no_exploits,
                 no_patches=args.no_patches,
+                llm_config=llm_config,
             )
         else:
             print("\n  No analysis report from Phase 3 — skipping orchestration")
@@ -587,7 +607,6 @@ Examples:
         # No CC available
         print("\n  No Claude Code available. Findings prepared for manual review.")
         print("  Install Claude Code for automated analysis: npm install -g @anthropic-ai/claude-code")
-    # else: CC available + external LLM — cross-finding merge goes here (PR 3)
 
     # ========================================================================
     # FINAL REPORT
@@ -636,11 +655,9 @@ Examples:
                 "patches_generated": analysis.get('patches_generated', 0),
                 "dataflow_validated": analysis.get('dataflow_validated', 0) if (args.codeql or args.codeql_only) else 0,
             },
-            "orchestration": {
-                "completed": bool(orchestration_result),
-                "mode": orchestration_result.get("orchestration", {}).get("mode", "none") if orchestration_result else "none",
-                "findings_analysed": orchestration_result.get("orchestration", {}).get("findings_analysed", 0) if orchestration_result else 0,
-                "findings_failed": orchestration_result.get("orchestration", {}).get("findings_failed", 0) if orchestration_result else 0,
+            "orchestration": orchestration_result.get("orchestration", {}) if orchestration_result else {
+                "completed": False,
+                "mode": "none",
             },
         },
         "outputs": {
@@ -669,12 +686,25 @@ Examples:
         if total_findings > 0:
             reduction = ((total_findings - validated_findings) / total_findings) * 100
             print(f"   Noise reduction: {reduction:.1f}%")
-    print(f"   Exploitable: {analysis.get('exploitable', 0)}")
-    print(f"   Exploits generated: {analysis.get('exploits_generated', 0)}")
-    print(f"   Patches generated: {analysis.get('patches_generated', 0)}")
+    analysed_count = analysis.get('analyzed', 0)
+    if orchestration_result:
+        analysed_count = max(analysed_count, orchestration_result.get("orchestration", {}).get("findings_analysed", 0))
+    if analysed_count > 0 and analysed_count < validated_findings:
+        print(f"   Analysed: {analysed_count} of {validated_findings} (capped by --max-findings {args.max_findings})")
+    orch_data = orchestration_result or {}
+    exploitable_count = max(analysis.get('exploitable', 0), orch_data.get('exploitable', 0))
+    exploits_count = analysis.get('exploits_generated', 0)
+    patches_count = analysis.get('patches_generated', 0)
+    if orchestration_result:
+        exploits_count = max(exploits_count, orchestration_result.get('exploits_generated', 0))
+        patches_count = max(patches_count, orchestration_result.get('patches_generated', 0))
+    print(f"   Exploitable: {exploitable_count}")
+    print(f"   Exploits generated: {exploits_count}")
+    print(f"   Patches generated: {patches_count}")
     if (args.codeql or args.codeql_only) and analysis.get('dataflow_validated', 0) > 0:
         print(f"   Dataflow paths validated: {analysis.get('dataflow_validated', 0)}")
-    print(f"   Duration: {workflow_duration:.2f}s")
+    from packages.llm_analysis.dispatch import _format_elapsed
+    print(f"   Duration: {_format_elapsed(workflow_duration)}")
 
     print(f"\n📁 Outputs:")
     print(f"   Main report: {report_file}")
@@ -684,24 +714,29 @@ Examples:
         print(f"   Validation: {out_dir / 'validation'}/")
     if analysis_report and analysis_report.exists():
         print(f"   Analysis: {analysis_report}")
-    if autonomous_out:
+    if exploits_count > 0 and autonomous_out:
         print(f"   Exploits: {autonomous_out / 'exploits'}/")
+    if patches_count > 0 and autonomous_out:
         print(f"   Patches: {autonomous_out / 'patches'}/")
 
     print("\n" + "=" * 70)
     print("RAPTOR has autonomously:")
     if not args.codeql_only:
         print("   ✓ Scanned with Semgrep")
-    if args.codeql or args.codeql_only:
+    if codeql_metrics:
         print("   ✓ Scanned with CodeQL")
-        print("   ✓ Validated dataflow paths")
+        if codeql_metrics.get('total_findings', 0) > 0:
+            print("   ✓ Validated dataflow paths")
     if validation_result:
-        print("   ✓ Validated exploitability (filtered noise)")
+        if isinstance(validation_result, dict) and validation_result.get('mode') == 'deduplication_only':
+            print("   ✓ Deduplicated findings")
+        else:
+            print("   ✓ Validated exploitability (filtered noise)")
     print("   ✓ Analysed vulnerabilities")
-    if not args.no_exploits:
-        print("   ✓ Generated exploits")
-    if not args.no_patches:
-        print("   ✓ Created patches")
+    if exploits_count > 0:
+        print(f"   ✓ Generated {exploits_count} exploit{'s' if exploits_count != 1 else ''}")
+    if patches_count > 0:
+        print(f"   ✓ Created {patches_count} patch{'es' if patches_count != 1 else ''}")
     if orchestration_result:
         orch = orchestration_result.get("orchestration", {})
         print(f"   ✓ Orchestrated via Claude Code ({orch.get('findings_analysed', 0)} findings)")


### PR DESCRIPTION
**Summary**                                                                                                                                                                                                          
                                                                
  - Replaces bespoke per-phase dispatch functions with a generic DispatchTask base class and dispatch_task() dispatcher                                                                                            
  - Extracts Claude Code subprocess internals to cc_dispatch.py, prompts to packages/llm_analysis/prompts/
  - Adds model roles, consensus verdicts, structural grouping, retry, and adaptive budget cutoff                                                                                                                   
  - Parallel Semgrep + CodeQL scanning in Phase 1                                                                                                                                                                  
  - External LLM dispatch with automatic fallback to Claude Code
  - Real-time cost tracking fed from both Claude Code and external LLM paths                                                                                                                                       
                                                                
  **Architecture**

  dispatch.py      — Generic dispatcher (threading, progress, cost, errors)
  tasks.py         — Task subclasses: Analysis, Exploit, Patch, Consensus, GroupAnalysis, Retry                                                                                                                    
  cc_dispatch.py   — Claude Code subprocess: invoke, parse envelope, build prompts, debug files
  orchestrator.py  — Flow only: load report → dispatch tasks → merge → write                                                                                                                                       
  prompts/         — Extracted prompts and schemas from agent.py
                                                                                                                                                                                                                   
  orchestrate() is now a sequence of dispatch_task() calls with no inline dispatch logic.                                                                                                                          
   
  **Task dispatch flow**                                                                                                                                                                                               
                                                                
  AnalysisTask → ExploitTask → PatchTask → ConsensusTask or RetryTask → GroupAnalysisTask

  Each task defines select_items, build_prompt, get_schema, get_models, and finalize. The dispatcher handles threading, progress output, cost tracking, error handling, auth abort, and consecutive-failure abort. 
   
  **Key changes**                                                                                                                                                                                                      
                                                                
  - ExploitTask/PatchTask run for all dispatch modes; select_items skips findings that already have exploit/patch code from inline Claude Code generation                                                          
  - ConsensusTask.finalize() applies verdict rules (1 model: either exploitable wins; 2+: majority)
  - RetryTask retries findings with ambiguous scores (0.3-0.7); decisive retries replace the original, ambiguous ones get flagged                                                                                  
  - CostTracker aggregates costs from all dispatch paths; dispatch_task() feeds per-item costs for budget enforcement                                                                                              
  - Claude Code dispatch always uses --output-format json for cost metadata (fixes group analysis showing $0.00 despite real cost)
  - Consecutive-failure abort in dispatcher (3 failures with no successes → abort remaining)                                                                                                                       
  - Parallel scanning — Semgrep and CodeQL launch concurrently via Popen, with timeout handling
                                                                                                                                                                                                                   
  **Test plan**                                                     
                                                                                                                                                                                                                   
  - 274 unit tests pass (27 dispatch, 14 model roles, 11 prompts, rest orchestrator)
  - End-to-end: Claude Code dispatch, 10 findings, 5 exploitable, 5 exploits, 5 patches, 2 structural groups
  - End-to-end: External LLM fails → automatic fallback to Claude Code → same results                                                                                                                     
  - End-to-end: External LLM that supports structured output (OpenAI)                                                                                                                                              
  - Consensus with multiple models configured