### PR TITLE
Enable Phase 4 orchestration for external LLM without Claude Code

### DIFF
--- a/.claude/commands/agentic.md
+++ b/.claude/commands/agentic.md
@@ -1,3 +1,7 @@
+---
+description: Full autonomous security workflow — scan, validate, analyse, group, consensus, exploit, patch
+---
+
 # /agentic - RAPTOR Full Autonomous Workflow
 
 🤖 **AGENTIC MODE** - This will autonomously:
@@ -11,16 +15,21 @@ Nothing will be applied to your code - only generated in out/ directory.
 
 Execute: `python3 raptor.py agentic --repo <path>`
 
-## Claude Code as the LLM
+## How analysis works
 
-When no external LLM is configured, **YOU (Claude Code) are the LLM.** Phase 4
-dispatches `claude -p` sub-agents to analyse each finding in parallel. If Phase 4
-did not run (no `claude` on PATH), you may be asked to analyse the findings directly.
+Phase 4 dispatches findings for parallel analysis via one of two paths:
 
-When an external LLM is configured, Phase 4 dispatches to it in parallel via
-`generate_structured()`. Model roles determine which model analyses (analysis),
-writes code (code), and provides second opinions (consensus). If the external
-LLM fails, Phase 4 falls back to Claude Code dispatch automatically.
+- **Claude Code on PATH**: dispatches `claude -p` sub-agents (separate processes)
+- **External LLM configured**: dispatches via `generate_structured()` API calls
+- **Both available**: uses external LLM, falls back to Claude Code if it fails
+
+Model roles determine which model analyses (analysis), writes code (code), and
+provides second opinions (consensus).
+
+If **neither** is available, Phase 4 cannot run. The pipeline produces prep-only
+output. In that case, **YOU (Claude Code) are the LLM** — the user may ask you
+to analyse the findings directly in conversation. See the prep_only report mode
+below for instructions.
 
 After per-finding analysis: structural grouping identifies related findings,
 group analysis explains shared patterns, and consensus (if configured) flags

--- a/core/config.py
+++ b/core/config.py
@@ -127,7 +127,7 @@ class RaptorConfig:
 
     # Logging Configuration
     LOG_DIR = BASE_OUT_DIR / "logs"
-    LOG_FORMAT_CONSOLE = "[%(levelname)s] %(module)s: %(message)s"
+    LOG_FORMAT_CONSOLE = "[%(levelname)s] %(message)s"
     LOG_FORMAT_FILE = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
     @staticmethod

--- a/packages/exploitability_validation/orchestrator.py
+++ b/packages/exploitability_validation/orchestrator.py
@@ -1170,7 +1170,7 @@ class ValidationOrchestrator:
             normalize_findings(self.state.findings)
             valid, errs = validate_findings(self.state.findings)
             if not valid:
-                logger.warning(f"Findings file has schema issues: {errs}")
+                logger.debug(f"Findings file has {len(errs)} schema issues (non-critical): {errs[:3]}")
             logger.info(f"Loaded JSON: {len(self.state.findings.get('findings', []))} findings")
 
         # Deduplicate findings

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -309,7 +309,7 @@ def convert_validated_to_agent_format(data: dict) -> List[Dict[str, Any]]:
             "startLine": f.line,
             "endLine": f.line,
             "snippet": f.proof.vulnerable_code,
-            "message": f.candidate_reasoning or f.message or f"{f.vuln_type} in {f.function or 'unknown'}",
+            "message": f.candidate_reasoning or f.message or f.rule_id or f"{f.vuln_type} in {f.function or 'unknown'}",
             "level": "error" if f.final_status in ("exploitable", "likely_exploitable", "confirmed_constrained") else "warning",
             "has_dataflow": bool(f.proof.flow),
             "feasibility": feasibility_d,

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -55,8 +55,12 @@ def run_command_streaming(cmd: list, description: str) -> tuple[int, str, str]:
             for line in iter(pipe.readline, ''):
                 if line:
                     storage.append(line)
-                    # Print in real-time (with optional prefix)
-                    print(f"{prefix}{line.rstrip()}", flush=True)
+                    # Strip [INFO] prefix for cleaner output.
+                    # Keep [WARNING], [ERROR], [DEBUG] visible.
+                    display = line.rstrip()
+                    if display.startswith("[INFO] "):
+                        display = display[7:]
+                    print(f"{prefix}{display}", flush=True)
         except Exception:
             pass
         finally:
@@ -545,8 +549,8 @@ Examples:
                 "--max-findings", str(args.max_findings)
             ]
 
-        # If CC will orchestrate in Phase 4, tell agent to prep only (skip LLM calls)
-        if llm_env.claude_code and not args.no_orchestration:
+        # If Phase 4 will orchestrate, tell agent to prep only (skip LLM calls)
+        if (llm_env.claude_code or llm_env.external_llm) and not args.no_orchestration:
             analysis_cmd.append("--prep-only")
 
         rc, stdout, stderr = run_command_streaming(analysis_cmd, "Analysing vulnerabilities autonomously")
@@ -579,7 +583,7 @@ Examples:
     # PHASE 4: AGENTIC ORCHESTRATION
     # ========================================================================
     orchestration_result = None
-    if llm_env.claude_code and not args.no_orchestration:
+    if (llm_env.claude_code or llm_env.external_llm) and not args.no_orchestration:
         print("\n" + "=" * 70)
         print("PHASE 4: AGENTIC ORCHESTRATION")
         print("=" * 70)
@@ -603,10 +607,9 @@ Examples:
             )
         else:
             print("\n  No analysis report from Phase 3 — skipping orchestration")
-    elif not llm_env.claude_code:
-        # No CC available
-        print("\n  No Claude Code available. Findings prepared for manual review.")
-        print("  Install Claude Code for automated analysis: npm install -g @anthropic-ai/claude-code")
+    elif not llm_env.llm_available:
+        print("\n  No LLM available. Findings prepared for manual review.")
+        print("  For automated analysis, set an API key or install Claude Code.")
 
     # ========================================================================
     # FINAL REPORT


### PR DESCRIPTION
**Summary**                                                                                                                                                                                                          
                                                                                                                                                                                                                   
Phase 4 orchestration (parallel dispatch, structural grouping, consensus, retry) was gated on Claude Code being available. Users with only an external LLM (Gemini, OpenAI, etc.) got sequential Phase 3 analysis with no grouping, retry, or cost tracking. Now Phase 4 runs with any available LLM.
                                                                                                                                                                                                                   
  Also fixes several UX issues in the agentic pipeline output.                                                                                                                                                     
   
  **Changes**                                                                                                                                                                                                          
                                                                                                                                                                                                                 
  - Phase 4 gate: llm_env.claude_code → llm_env.claude_code or llm_env.external_llm                                                                                                                                
  - Phase 3 prep: same gate change — Phase 3 preps when Phase 4 will orchestrate via either path
  - Log format: removed %(module)s from console log format (was showing logging: on every line)                                                                                                                    
  - Log streaming: strip [INFO] prefix from subprocess output for cleaner display, keep [WARNING]/[ERROR] visible                                                                                                  
  - Schema validation noise: downgraded verbose findings schema warnings to debug level                                                                                                                            
  - Message fallback: added rule_id to fallback chain, fixing "other in unknown" messages                                                                                                                          
  - Skill doc: updated agentic.md to describe all three analysis paths (CC, external LLM, manual), added description
  - Fallback message: "No Claude Code" → "No LLM available" when neither CC nor external LLM is present                                                                                                            
                                                                                                                                                                                                                   
  **Test plan**                                                                                                                                                                                                        
                                                                                                                                                                                                                   
  - 317 unit tests pass                                                                                                                                                                                            
  - End-to-end: external LLM only — Phase 4 runs, 10 findings analysed via Gemini, structural grouping and retry executed
  - End-to-end: CC only (no external LLM) — unchanged behaviour                                                                                                                                                    
  - End-to-end: no LLM — prep-only output with clear guidance message                                                                                                                                              
  - End-to-end: both CC and external LLM — verify fallback from external to CC on failure