### PR TITLE
Fix CodeQL --command failing on shell operators

### DIFF
--- a/packages/codeql/database_manager.py
+++ b/packages/codeql/database_manager.py
@@ -8,11 +8,13 @@ validation, and cleanup.
 
 import hashlib
 import json
+import os
 import re
 import shutil
 import stat
 import subprocess
 import sys
+import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, asdict
@@ -348,7 +350,11 @@ class DatabaseManager:
             if Path(build_cmd).is_file() or re.fullmatch(r'[a-zA-Z0-9._-]+', build_cmd):
                 cmd.extend(["--command", build_cmd])
             else:
-                build_script = Path(working_dir) / ".raptor_codeql_build.sh"
+                fd, script_name = tempfile.mkstemp(
+                    prefix=".raptor_codeql_build_", suffix=".sh", dir=working_dir,
+                )
+                os.close(fd)
+                build_script = Path(script_name)
                 build_script.write_text(f"#!/bin/bash\n{build_cmd}\n")
                 build_script.chmod(build_script.stat().st_mode | stat.S_IEXEC)
                 cmd.extend(["--command", str(build_script)])

--- a/packages/codeql/test_database_manager.py
+++ b/packages/codeql/test_database_manager.py
@@ -1,0 +1,155 @@
+"""Tests for CodeQL database manager build command handling."""
+
+import stat
+import subprocess as sp
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from packages.codeql.build_detector import BuildSystem
+from packages.codeql.database_manager import DatabaseManager
+
+
+@pytest.fixture
+def db_manager(tmp_path):
+    """Create a DatabaseManager with a fake codeql binary."""
+    with patch.object(DatabaseManager, '__init__', lambda self: None):
+        mgr = DatabaseManager()
+        mgr.codeql_cli = "/usr/bin/codeql"
+        mgr.cache_dir = tmp_path / "cache"
+        mgr.cache_dir.mkdir()
+        return mgr
+
+
+def _run_create(db_manager, tmp_path, command, language="javascript"):
+    """Run create_database and capture the subprocess command and script state."""
+    bs = BuildSystem(type="npm", command=command, working_dir=tmp_path,
+                     env_vars={}, confidence=1.0, detected_files=[])
+    captured = {"cmd": [], "script_content": None, "script_mode": None}
+
+    def fake_run(cmd, **kwargs):
+        # Only capture the database create call, not codeql version etc.
+        if "database" in cmd or "create" in cmd:
+            captured["cmd"] = list(cmd)
+            for arg in cmd:
+                p = Path(str(arg))
+                if p.name.startswith(".raptor_codeql_build_") and p.exists():
+                    captured["script_content"] = p.read_text()
+                    captured["script_mode"] = p.stat().st_mode
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = "2.16.0"
+        return r
+
+    db_path = tmp_path / "db"
+    with patch('subprocess.run', side_effect=fake_run), \
+         patch.object(db_manager, '_count_database_files', return_value=0), \
+         patch.object(db_manager, 'save_metadata'), \
+         patch.object(db_manager, 'get_cached_database', return_value=None), \
+         patch.object(db_manager, 'compute_repo_hash', return_value='abc'), \
+         patch.object(db_manager, 'get_database_dir', return_value=db_path):
+        db_manager.create_database(tmp_path, language, bs)
+
+    return captured
+
+
+class TestBuildScript:
+    """CodeQL --command is always wrapped in a build script."""
+
+    def test_simple_command_passed_directly(self, db_manager, tmp_path):
+        """Single-word commands like 'make' pass through without a script."""
+        c = _run_create(db_manager, tmp_path, "make")
+        assert c["script_content"] is None
+        idx = c["cmd"].index("--command")
+        assert c["cmd"][idx + 1] == "make"
+
+    def test_shell_operators_wrapped(self, db_manager, tmp_path):
+        c = _run_create(db_manager, tmp_path, "npm install && npm run build")
+        assert "npm install && npm run build" in c["script_content"]
+
+    def test_or_operator_wrapped(self, db_manager, tmp_path):
+        c = _run_create(db_manager, tmp_path, "pip install -e . || pip install -r requirements.txt")
+        assert "||" in c["script_content"]
+
+    def test_script_has_shebang(self, db_manager, tmp_path):
+        c = _run_create(db_manager, tmp_path, "cmake . && make")
+        assert c["script_content"].startswith("#!/bin/bash\n")
+
+    def test_script_is_executable(self, db_manager, tmp_path):
+        c = _run_create(db_manager, tmp_path, "npm install && npm run build")
+        assert c["script_mode"] & stat.S_IEXEC
+
+    def test_script_passed_as_command_arg(self, db_manager, tmp_path):
+        c = _run_create(db_manager, tmp_path, "cmake . && make")
+        assert "--command" in c["cmd"]
+        idx = c["cmd"].index("--command")
+        assert ".raptor_codeql_build_" in c["cmd"][idx + 1]
+
+    def test_no_command_equals_format(self, db_manager, tmp_path):
+        """Never uses --command=value (the old broken format)."""
+        c = _run_create(db_manager, tmp_path, "make")
+        assert not any(arg.startswith("--command=") for arg in c["cmd"])
+
+    def test_script_cleaned_up_after_success(self, db_manager, tmp_path):
+        _run_create(db_manager, tmp_path, "npm install && npm run build")
+        assert not list(tmp_path.glob(".raptor_codeql_build_*"))
+
+    def test_script_cleaned_up_on_failure(self, db_manager, tmp_path):
+        bs = BuildSystem(type="npm", command="npm install", working_dir=tmp_path,
+                         env_vars={}, confidence=1.0, detected_files=[])
+
+        def fake_run(cmd, **kwargs):
+            r = MagicMock()
+            r.returncode = 1
+            r.stderr = "fail"
+            return r
+
+        db_path = tmp_path / "db"
+        with patch('subprocess.run', side_effect=fake_run), \
+             patch.object(db_manager, '_count_database_files', return_value=0), \
+             patch.object(db_manager, 'save_metadata'), \
+             patch.object(db_manager, 'get_cached_database', return_value=None), \
+             patch.object(db_manager, 'compute_repo_hash', return_value='abc'), \
+             patch.object(db_manager, 'get_database_dir', return_value=db_path):
+            db_manager.create_database(tmp_path, "javascript", bs)
+
+        assert not list(tmp_path.glob(".raptor_codeql_build_*"))
+
+    def test_script_cleaned_up_on_timeout(self, db_manager, tmp_path):
+        bs = BuildSystem(type="npm", command="npm install", working_dir=tmp_path,
+                         env_vars={}, confidence=1.0, detected_files=[])
+
+        db_path = tmp_path / "db"
+        with patch('subprocess.run', side_effect=sp.TimeoutExpired("cmd", 60)), \
+             patch.object(db_manager, 'get_cached_database', return_value=None), \
+             patch.object(db_manager, 'compute_repo_hash', return_value='abc'), \
+             patch.object(db_manager, 'get_database_dir', return_value=db_path):
+            db_manager.create_database(tmp_path, "javascript", bs)
+
+        assert not list(tmp_path.glob(".raptor_codeql_build_*"))
+
+    def test_empty_command_no_script(self, db_manager, tmp_path):
+        bs = BuildSystem(type="no-build", command="", working_dir=tmp_path,
+                         env_vars={}, confidence=1.0, detected_files=[])
+
+        captured_cmd = []
+
+        def fake_run(cmd, **kwargs):
+            nonlocal captured_cmd
+            captured_cmd = list(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            return r
+
+        db_path = tmp_path / "db"
+        with patch('subprocess.run', side_effect=fake_run), \
+             patch.object(db_manager, '_count_database_files', return_value=0), \
+             patch.object(db_manager, 'save_metadata'), \
+             patch.object(db_manager, 'get_cached_database', return_value=None), \
+             patch.object(db_manager, 'compute_repo_hash', return_value='abc'), \
+             patch.object(db_manager, 'get_database_dir', return_value=db_path):
+            db_manager.create_database(tmp_path, "python", bs)
+
+        assert "--command" not in captured_cmd
+        assert not list(tmp_path.glob(".raptor_codeql_build_*"))


### PR DESCRIPTION
Fixes #37. Thanks to @AndrewMohawk for identifying the issue.                                                                                                                                                    
                                                            
  **Summary**                                                                                                                                                                                                          
                                                            
  CodeQL's --command splits on whitespace without shell interpretation, so commands like npm install && npm run build or cmake . && make pass && as a literal argument to the build tool. This broke database creation for most detected build systems.
                                                                                                                                                                                                                   
  **Fix**                                                       
  
  Wrap build commands in a temporary build script (random filename via mkstemp, parallel-safe) and pass that path as --command. Skip wrapping for commands that are already a file path (e.g. synthesised build scripts) or a bare command name (e.g. make). Script is cleaned up in finally.
                                                                                                                                                                                                                   
  Also fixes the --command=value format to --command value (two separate args).                                                                                                                                    
   
  **Test plan**                                                                                                                                                                                                        
                                                            
  - 43 CodeQL tests pass (11 new)                                                                                                                                                                                  
  - End-to-end: echo hello && echo world runs correctly via script wrapper
  - Verified empirically: without fix, CodeQL runs [echo, hello, &&, echo, world] (broken)           