### PR TITLE
Fix model costs/limits, add thinking token tracking, expand model coverage

### DIFF
--- a/packages/llm_analysis/llm/config.py
+++ b/packages/llm_analysis/llm/config.py
@@ -73,9 +73,9 @@ def _get_best_thinking_model() -> Optional['ModelConfig']:
     Cached per-process.
 
     Priority:
-    1. Models with explicit reasoning support (gpt-5.2-thinking)
-    2. Most capable models (Opus > Sonnet > others)
-    3. Latest versions
+    1. Most capable models (Opus > gpt-5.4-pro > o3)
+    2. Strong models (gpt-5.2 > o4-mini > Mistral Large)
+    3. Fallback (Sonnet > Gemini Pro > Gemini Flash)
 
     Returns ModelConfig for best available thinking model, or None if none found.
     """
@@ -94,15 +94,19 @@ def _get_best_thinking_model() -> Optional['ModelConfig']:
     thinking_model_patterns = [
         # Tier 1: Most capable models
         ("anthropic", "claude-opus-4-6", 110),
-        ("openai", "gpt-5.2-thinking", 95),
+        ("openai", "gpt-5.4-pro", 100),
+        ("openai", "gpt-5.4", 95),
+        ("openai", "o3", 90),
 
         # Tier 2: Strong models
         ("openai", "gpt-5.2", 80),
+        ("openai", "o4-mini", 78),
         ("mistral", "mistral-large-latest", 75),
 
         # Tier 3: Latest capable models (fallback)
         ("anthropic", "claude-sonnet-4-6", 70),
         ("gemini", "gemini-2.5-pro", 65),
+        ("gemini", "gemini-2.5-flash", 55),
     ]
 
     # Find best matching model
@@ -308,7 +312,7 @@ def _get_default_fallback_models() -> List['ModelConfig']:
             ))
 
     if os.getenv("OPENAI_API_KEY"):
-        for model_name in ["gpt-5.2", "gpt-5.2-thinking"]:
+        for model_name in ["gpt-5.4", "gpt-5.2"]:
             limits = MODEL_LIMITS.get(model_name, {})
             costs = MODEL_COSTS.get(model_name, {})
             fallbacks.append(ModelConfig(

--- a/packages/llm_analysis/llm/model_data.py
+++ b/packages/llm_analysis/llm/model_data.py
@@ -5,6 +5,8 @@ Static model data — costs, limits, endpoints, defaults.
 Pure data, no logic. Updated during development from provider
 documentation. Changes at a different rate than code — when
 providers update pricing or release new models, edit this file.
+
+Last verified: 2026-04-01.
 """
 
 # Provider API endpoints (Anthropic uses native SDK, no base_url needed)
@@ -19,31 +21,62 @@ PROVIDER_ENDPOINTS = {
 # Defaults to the most capable model — quality over cost for security analysis
 PROVIDER_DEFAULT_MODELS = {
     "anthropic": "claude-opus-4-6",
-    "openai":    "gpt-5.2-thinking",
+    "openai":    "gpt-5.4",
     "gemini":    "gemini-2.5-pro",
     "mistral":   "mistral-large-latest",
 }
 
-# Per-1K-token costs (USD), split input/output
+# Per-1K-token costs (USD), split input/output.
+# Thinking/reasoning tokens are billed at the output rate on all providers.
 MODEL_COSTS = {
-    "claude-opus-4-6":       {"input": 0.015, "output": 0.075},
-    "claude-sonnet-4-6":     {"input": 0.003, "output": 0.015},
-    "claude-haiku-4-5":      {"input": 0.0008, "output": 0.004},
-    "gpt-5.2":               {"input": 0.006, "output": 0.030},
-    "gpt-5.2-thinking":      {"input": 0.012, "output": 0.060},
-    "gemini-2.5-pro":        {"input": 0.002, "output": 0.010},
-    "gemini-2.5-flash":      {"input": 0.0002, "output": 0.001},
+    # Anthropic
+    "claude-opus-4-6":         {"input": 0.005,   "output": 0.025},
+    "claude-sonnet-4-6":       {"input": 0.003,   "output": 0.015},
+    "claude-haiku-4-5":        {"input": 0.001,   "output": 0.005},
+    # OpenAI — flagship
+    "gpt-5.4":                 {"input": 0.0025,  "output": 0.015},
+    "gpt-5.4-mini":            {"input": 0.00075, "output": 0.0045},
+    "gpt-5.4-pro":             {"input": 0.030,   "output": 0.180},
+    "gpt-5.2":                 {"input": 0.00175, "output": 0.014},
+    "gpt-4o":                  {"input": 0.0025,  "output": 0.010},
+    "gpt-4o-mini":             {"input": 0.00015, "output": 0.0006},
+    # OpenAI — reasoning (thinking tokens billed as output)
+    "o3":                      {"input": 0.002,   "output": 0.008},
+    "o3-pro":                  {"input": 0.020,   "output": 0.080},
+    "o4-mini":                 {"input": 0.0011,  "output": 0.0044},
+    # Google Gemini (<=200K prompt tier for pro)
+    "gemini-2.5-pro":          {"input": 0.00125, "output": 0.010},
+    "gemini-2.5-flash":        {"input": 0.0003,  "output": 0.0025},
+    "gemini-2.5-flash-lite":   {"input": 0.0001,  "output": 0.0004},
+    # Mistral
+    "mistral-large-latest":    {"input": 0.0005,  "output": 0.0015},
+    "mistral-small-latest":    {"input": 0.00015, "output": 0.0006},
 }
 
 # Per-model context window and max output token limits
 MODEL_LIMITS = {
-    "claude-opus-4-6":       {"max_context": 1000000, "max_output": 32000},
-    "claude-sonnet-4-6":     {"max_context": 1000000, "max_output": 64000},
-    "claude-haiku-4-5":      {"max_context": 200000,  "max_output": 8192},
-    "gpt-5.2":               {"max_context": 128000,  "max_output": 16384},
-    "gpt-5.2-thinking":      {"max_context": 128000,  "max_output": 16384},
-    "gemini-2.5-pro":        {"max_context": 1000000, "max_output": 8192},
-    "gemini-2.5-flash":      {"max_context": 1000000, "max_output": 8192},
+    # Anthropic
+    "claude-opus-4-6":         {"max_context": 1000000, "max_output": 128000},
+    "claude-sonnet-4-6":       {"max_context": 1000000, "max_output": 64000},
+    "claude-haiku-4-5":        {"max_context": 200000,  "max_output": 64000},
+    # OpenAI — flagship
+    "gpt-5.4":                 {"max_context": 1000000, "max_output": 128000},
+    "gpt-5.4-mini":            {"max_context": 1000000, "max_output": 128000},
+    "gpt-5.4-pro":             {"max_context": 1000000, "max_output": 128000},
+    "gpt-5.2":                 {"max_context": 400000,  "max_output": 128000},
+    "gpt-4o":                  {"max_context": 128000,  "max_output": 16384},
+    "gpt-4o-mini":             {"max_context": 128000,  "max_output": 16384},
+    # OpenAI — reasoning
+    "o3":                      {"max_context": 200000,  "max_output": 100000},
+    "o3-pro":                  {"max_context": 200000,  "max_output": 100000},
+    "o4-mini":                 {"max_context": 200000,  "max_output": 100000},
+    # Google Gemini
+    "gemini-2.5-pro":          {"max_context": 1048576, "max_output": 65536},
+    "gemini-2.5-flash":        {"max_context": 1048576, "max_output": 65536},
+    "gemini-2.5-flash-lite":   {"max_context": 1048576, "max_output": 65536},
+    # Mistral
+    "mistral-large-latest":    {"max_context": 262100,  "max_output": 262100},
+    "mistral-small-latest":    {"max_context": 256000,  "max_output": 256000},
 }
 
 # Provider -> env var mapping for API key lookup

--- a/packages/llm_analysis/llm/providers.py
+++ b/packages/llm_analysis/llm/providers.py
@@ -52,6 +52,7 @@ class LLMResponse:
     finish_reason: str
     input_tokens: int = 0
     output_tokens: int = 0
+    thinking_tokens: int = 0
     duration: float = 0.0
 
 
@@ -118,16 +119,21 @@ class LLMProvider(ABC):
             self.total_duration += duration
         logger.debug(f"LLM usage: {tokens} tokens, ${(cost or 0.0):.4f} (total: {self.total_tokens} tokens, ${self.total_cost:.4f})")
 
-    def _calculate_cost_split(self, input_tokens: int, output_tokens: int) -> float:
-        """Calculate cost using split input/output pricing."""
+    def _calculate_cost_split(self, input_tokens: int, output_tokens: int,
+                              thinking_tokens: int = 0) -> float:
+        """Calculate cost using split input/output pricing.
+
+        Thinking/reasoning tokens are billed at the output rate on all
+        providers (OpenAI, Google, Anthropic).
+        """
         from .model_data import MODEL_COSTS
         rates = MODEL_COSTS.get(self.config.model_name)
         if not rates:
             rate = self.config.cost_per_1k_tokens or 0.0
-            return ((input_tokens + output_tokens) / 1000) * rate
+            return ((input_tokens + output_tokens + thinking_tokens) / 1000) * rate
         return (
             (input_tokens / 1000) * rates["input"]
-            + (output_tokens / 1000) * rates["output"]
+            + ((output_tokens + thinking_tokens) / 1000) * rates["output"]
         )
 
     def _structured_fallback(self, prompt: str, schema: Dict[str, Any],
@@ -418,15 +424,24 @@ class OpenAICompatibleProvider(LLMProvider):
 
             input_tokens = 0
             output_tokens = 0
+            thinking_tokens = 0
             if response.usage:
                 input_tokens = response.usage.prompt_tokens or 0
                 output_tokens = response.usage.completion_tokens or 0
+                # Extract thinking/reasoning tokens (o3, o4-mini, etc.)
+                details = getattr(response.usage, 'completion_tokens_details', None)
+                if details:
+                    thinking_tokens = getattr(details, 'reasoning_tokens', 0) or 0
+                    # Reasoning tokens are included in completion_tokens — subtract
+                    # to get actual output tokens for display, but bill both as output
+                    output_tokens = output_tokens - thinking_tokens
 
-            tokens_used = input_tokens + output_tokens
-            cost = self._calculate_cost_split(input_tokens, output_tokens)
+            tokens_used = input_tokens + output_tokens + thinking_tokens
+            cost = self._calculate_cost_split(input_tokens, output_tokens, thinking_tokens)
 
             self.track_usage(tokens_used, cost, input_tokens, output_tokens, duration)
-            logger.debug(f"[OpenAI] model={self.config.model_name}, tokens={tokens_used}, cost=${cost:.4f}, duration={duration:.2f}s")
+            logger.debug(f"[OpenAI] model={self.config.model_name}, tokens={tokens_used}, cost=${cost:.4f}, duration={duration:.2f}s"
+                         + (f", thinking={thinking_tokens}" if thinking_tokens else ""))
 
             return LLMResponse(
                 content=content,
@@ -437,6 +452,7 @@ class OpenAICompatibleProvider(LLMProvider):
                 finish_reason=finish_reason,
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
+                thinking_tokens=thinking_tokens,
                 duration=duration,
             )
 
@@ -473,12 +489,17 @@ class OpenAICompatibleProvider(LLMProvider):
 
                 input_tokens = 0
                 output_tokens = 0
+                thinking_tokens = 0
                 if completion.usage:
                     input_tokens = completion.usage.prompt_tokens or 0
                     output_tokens = completion.usage.completion_tokens or 0
+                    details = getattr(completion.usage, 'completion_tokens_details', None)
+                    if details:
+                        thinking_tokens = getattr(details, 'reasoning_tokens', 0) or 0
+                        output_tokens = output_tokens - thinking_tokens
 
-                tokens_used = input_tokens + output_tokens
-                cost = self._calculate_cost_split(input_tokens, output_tokens)
+                tokens_used = input_tokens + output_tokens + thinking_tokens
+                cost = self._calculate_cost_split(input_tokens, output_tokens, thinking_tokens)
                 self.track_usage(tokens_used, cost, input_tokens, output_tokens, duration)
 
                 return result_dict, full_response
@@ -558,11 +579,14 @@ class AnthropicProvider(LLMProvider):
 
             input_tokens = 0
             output_tokens = 0
+            thinking_tokens = 0
             if response.usage:
                 input_tokens = response.usage.input_tokens or 0
                 output_tokens = response.usage.output_tokens or 0
-            tokens_used = input_tokens + output_tokens
-            cost = self._calculate_cost_split(input_tokens, output_tokens)
+                # Anthropic extended thinking (when available)
+                thinking_tokens = getattr(response.usage, 'thinking_tokens', 0) or 0
+            tokens_used = input_tokens + output_tokens + thinking_tokens
+            cost = self._calculate_cost_split(input_tokens, output_tokens, thinking_tokens)
 
             self.track_usage(tokens_used, cost, input_tokens, output_tokens, duration)
             logger.debug(f"[Anthropic] model={self.config.model_name}, tokens={tokens_used}, cost=${cost:.4f}, duration={duration:.2f}s")
@@ -576,6 +600,7 @@ class AnthropicProvider(LLMProvider):
                 finish_reason=finish_reason,
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
+                thinking_tokens=thinking_tokens,
                 duration=duration,
             )
 
@@ -614,11 +639,13 @@ class AnthropicProvider(LLMProvider):
 
                 input_tokens = 0
                 output_tokens = 0
+                thinking_tokens = 0
                 if completion.usage:
                     input_tokens = completion.usage.input_tokens or 0
                     output_tokens = completion.usage.output_tokens or 0
-                tokens_used = input_tokens + output_tokens
-                cost = self._calculate_cost_split(input_tokens, output_tokens)
+                    thinking_tokens = getattr(completion.usage, 'thinking_tokens', 0) or 0
+                tokens_used = input_tokens + output_tokens + thinking_tokens
+                cost = self._calculate_cost_split(input_tokens, output_tokens, thinking_tokens)
                 self.track_usage(tokens_used, cost, input_tokens, output_tokens, duration)
 
                 return result_dict, full_response

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -45,14 +45,17 @@ class CostTracker:
         self._lock = threading.RLock()  # Reentrant — get_summary calls _budget_ratio
         self._total_cost = 0.0
         self._total_tokens = 0
+        self._thinking_tokens = 0
         self._max_cost = max_cost  # 0 = no limit
         self._per_model: Dict[str, float] = {}
 
-    def add_cost(self, model_name: str, cost: float, tokens: int = 0) -> None:
+    def add_cost(self, model_name: str, cost: float, tokens: int = 0,
+                 thinking_tokens: int = 0) -> None:
         """Record cost and tokens from any source (thread-safe)."""
         with self._lock:
             self._total_cost += cost
             self._total_tokens += tokens
+            self._thinking_tokens += thinking_tokens
             self._per_model[model_name] = self._per_model.get(model_name, 0.0) + cost
 
     @property
@@ -119,13 +122,16 @@ class CostTracker:
 
     def get_summary(self) -> Dict[str, Any]:
         with self._lock:
-            return {
+            summary = {
                 "total_cost": round(self._total_cost, 4),
                 "total_tokens": self._total_tokens,
                 "max_cost": self._max_cost,
                 "budget_used_percent": round(self._budget_ratio() * 100, 1) if self._max_cost > 0 else 0,
                 "cost_by_model": {k: round(v, 4) for k, v in self._per_model.items()},
             }
+            if self._thinking_tokens > 0:
+                summary["thinking_tokens"] = self._thinking_tokens
+            return summary
 
 
 def orchestrate(

--- a/packages/llm_analysis/tests/test_config_file.py
+++ b/packages/llm_analysis/tests/test_config_file.py
@@ -110,8 +110,8 @@ class TestProviderDefaultModels:
     def test_anthropic_defaults_to_opus(self):
         assert PROVIDER_DEFAULT_MODELS["anthropic"] == "claude-opus-4-6"
 
-    def test_openai_defaults_to_thinking(self):
-        assert PROVIDER_DEFAULT_MODELS["openai"] == "gpt-5.2-thinking"
+    def test_openai_defaults_to_gpt54(self):
+        assert PROVIDER_DEFAULT_MODELS["openai"] == "gpt-5.4"
 
     def test_gemini_defaults_to_pro(self):
         assert PROVIDER_DEFAULT_MODELS["gemini"] == "gemini-2.5-pro"
@@ -119,14 +119,12 @@ class TestProviderDefaultModels:
     def test_all_defaults_have_costs(self):
         """Every default model should be in MODEL_COSTS."""
         for provider, model in PROVIDER_DEFAULT_MODELS.items():
-            if model != "mistral-large-latest":  # Mistral not in costs table
-                assert model in MODEL_COSTS, f"Default {provider} model '{model}' not in MODEL_COSTS"
+            assert model in MODEL_COSTS, f"Default {provider} model '{model}' not in MODEL_COSTS"
 
     def test_all_defaults_have_limits(self):
         """Every default model should be in MODEL_LIMITS."""
         for provider, model in PROVIDER_DEFAULT_MODELS.items():
-            if model != "mistral-large-latest":
-                assert model in MODEL_LIMITS, f"Default {provider} model '{model}' not in MODEL_LIMITS"
+            assert model in MODEL_LIMITS, f"Default {provider} model '{model}' not in MODEL_LIMITS"
 
 
 class TestModelDefaulting:
@@ -147,7 +145,7 @@ class TestModelDefaulting:
         assert result.model_name == "claude-opus-4-6"
         assert result.api_key == "sk-ant-test"
 
-    def test_openai_without_model_gets_thinking(self, tmp_path):
+    def test_openai_without_model_gets_gpt54(self, tmp_path):
         config = tmp_path / "models.json"
         config.write_text(json.dumps([
             {"provider": "openai", "api_key": "sk-test"}
@@ -158,7 +156,7 @@ class TestModelDefaulting:
             cfg._cached_thinking_model = None
             result = _get_best_thinking_model()
         assert result is not None
-        assert result.model_name == "gpt-5.2-thinking"
+        assert result.model_name == "gpt-5.4"
 
     def test_api_key_falls_back_to_env_var(self, tmp_path):
         """Config without api_key uses env var."""


### PR DESCRIPTION
**Summary**

All model pricing and limits were wrong (some 3x off). Adds thinking/reasoning token tracking so cost estimates account for o3/o4-mini/Gemini 2.5 thinking tokens. Expands model coverage from 7 to 18 models.   
   
  **Changes**                                                                                                                                                                                                          
                                                            
  Model data (model_data.py):                                                                                                                                                                                      
  - Fixed pricing for claude-opus-4-6, claude-haiku-4-5, gpt-5.2, gemini-2.5-pro, gemini-2.5-flash (all were wrong)
  - Fixed max_output limits for claude-opus-4-6 (32K→128K), claude-haiku-4-5 (8K→64K), gemini models (8K→64K), gpt-5.2 (16K→128K)                                                                                  
  - Added: gpt-5.4, gpt-5.4-mini, gpt-5.4-pro, gpt-4o, gpt-4o-mini, o3, o3-pro, o4-mini, gemini-2.5-flash-lite, mistral-large-latest, mistral-small-latest
  - Removed stale gpt-5.2-thinking (never existed)                                                                                                                                                                 
  - OpenAI default updated from gpt-5.2-thinking to gpt-5.4                                                                                                                                                        
                                                                                                                                                                                                                   
  Thinking token tracking (providers.py, orchestrator.py):                                                                                                                                                         
  - LLMResponse gains thinking_tokens field                                                                                                                                                                        
  - _calculate_cost_split() bills thinking tokens at output rate (correct for all providers)
  - OpenAI provider extracts reasoning_tokens from completion_tokens_details                                                                                                                                       
  - Anthropic provider extracts thinking_tokens from usage (when available) 
  - CostTracker.get_summary() surfaces thinking token count
                                                                                                                                                                                                                   
  Stale references (config.py):
  - Removed gpt-5.2-thinking from thinking model priority list and fallback list                                                                                                                                   
  - Updated priority: gpt-5.4-pro > gpt-5.4 > o3 > gpt-5.2 > o4-mini                                                                                                                                               
   
  **Test plan**                                                                                                                                                                                                        
                                                            
  - 285 tests pass (5 skipped)                                                                                                                                                                                     
  - Smoke test: /agentic --repo /tmp/vulns --max-findings 2 with Gemini — correct per-finding costs at updated rates
