### PR TITLE
Improve agentic reporting: failure categorisation, severity mismatches, cost breakdown

### DIFF
--- a/packages/llm_analysis/dispatch.py
+++ b/packages/llm_analysis/dispatch.py
@@ -110,6 +110,23 @@ def _is_auth_error(error_str: str) -> bool:
     ])
 
 
+def _classify_error(error_str: str) -> str:
+    """Classify an error for structured reporting.
+
+    Returns: 'blocked' (content filter/safety/refusal), 'auth' (key/billing/quota),
+    'timeout', or 'error' (everything else).
+    """
+    lower = error_str.lower()
+    if any(x in lower for x in ["content filter", "blocked response", "safety",
+                                 "refused request", "refusal"]):
+        return "blocked"
+    if _is_auth_error(error_str):
+        return "auth"
+    if any(x in lower for x in ["timeout", "timed out"]):
+        return "timeout"
+    return "error"
+
+
 def dispatch_task(
     task: DispatchTask,
     items: list,
@@ -226,7 +243,9 @@ def dispatch_task(
 
             except Exception as e:
                 err_str = str(e)
-                results.append({"finding_id": item_id, "error": err_str})
+                error_type = _classify_error(err_str)
+                results.append({"finding_id": item_id, "error": err_str,
+                                "error_type": error_type})
                 display = task.get_item_display(item)
                 print(f"  [{completed}/{total} {_format_elapsed(elapsed)} ${running_cost:.2f}] "
                       f"{display} FAILED — {err_str}")

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -393,10 +393,30 @@ def orchestrate(
 
     # Summary
     orch = merged["orchestration"]
-    cost_total = orch["cost"]["total_cost"]
-    print(f"\n  Orchestration complete: {orch['findings_analysed']} analysed, "
-          f"{orch['findings_failed']} failed, {_format_elapsed(orch['elapsed_seconds'])} elapsed"
-          + (f", ${cost_total:.2f}" if cost_total > 0 else ""))
+    cost_summary = orch["cost"]
+    cost_total = cost_summary["total_cost"]
+    model_name = orch.get("analysis_model") or ""
+    model_str = f" ({model_name})" if model_name else ""
+
+    parts = [f"{orch['findings_analysed']} analysed"]
+    if orch['findings_failed'] > 0:
+        # Break down failures by type
+        blocked = sum(1 for r in per_finding_results if r.get("error_type") == "blocked")
+        other_fails = orch['findings_failed'] - blocked
+        if blocked and other_fails:
+            parts.append(f"{blocked} blocked, {other_fails} failed")
+        elif blocked:
+            parts.append(f"{blocked} blocked")
+        else:
+            parts.append(f"{orch['findings_failed']} failed")
+    parts.append(f"{_format_elapsed(orch['elapsed_seconds'])} elapsed")
+    if cost_total > 0:
+        parts.append(f"${cost_total:.2f}")
+
+    print(f"\n  Orchestration complete{model_str}: {', '.join(parts)}")
+    thinking = cost_summary.get("thinking_tokens", 0)
+    if thinking > 0:
+        print(f"  Thinking tokens: {thinking:,}")
     if groups:
         print(f"  Cross-finding groups: {len(groups)}")
     print(f"  Report: {out_path}")

--- a/packages/llm_analysis/tests/test_dispatch.py
+++ b/packages/llm_analysis/tests/test_dispatch.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 
 from packages.llm_analysis.dispatch import (
     DispatchTask, DispatchResult, dispatch_task, _format_elapsed,
+    _classify_error,
 )
 from packages.llm_analysis.tasks import (
     AnalysisTask, ExploitTask, PatchTask, ConsensusTask, GroupAnalysisTask,
@@ -520,3 +521,31 @@ class TestFormatElapsed:
 
     def test_hours(self):
         assert _format_elapsed(3700) == "1h 01m"
+
+
+class TestClassifyError:
+    """Test error classification for structured reporting."""
+
+    def test_content_filter(self):
+        assert _classify_error("Response blocked by content filter") == "blocked"
+
+    def test_safety_block(self):
+        assert _classify_error("Gemini blocked response (finish_reason=safety)") == "blocked"
+
+    def test_refusal(self):
+        assert _classify_error("Model refused request: I cannot help with exploits") == "blocked"
+
+    def test_auth_error(self):
+        assert _classify_error("401 Unauthorized: invalid API key") == "auth"
+
+    def test_quota_error(self):
+        assert _classify_error("insufficient_quota: billing limit reached") == "auth"
+
+    def test_timeout(self):
+        assert _classify_error("Request timed out after 120s") == "timeout"
+
+    def test_generic_error(self):
+        assert _classify_error("JSON parse failed: unexpected token") == "error"
+
+    def test_empty_string(self):
+        assert _classify_error("") == "error"

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -690,6 +690,9 @@ Examples:
     true_positives = 0
     false_positives = 0
     exploitable_count = 0
+    failed_count = 0
+    blocked_count = 0
+    severity_mismatches = []
     exploits_count = analysis.get('exploits_generated', 0)
     patches_count = analysis.get('patches_generated', 0)
 
@@ -700,12 +703,20 @@ Examples:
         patches_count = max(patches_count, orchestration_result.get('patches_generated', 0))
         for r in orchestration_result.get("results", []):
             if "error" in r:
+                if r.get("error_type") == "blocked":
+                    blocked_count += 1
+                else:
+                    failed_count += 1
                 continue
             # Only count findings that were actually analysed (have explicit verdict)
             if "is_true_positive" not in r:
                 continue
             if r.get("is_true_positive") is False:
                 false_positives += 1
+                # Flag severity mismatches: scanner says error/critical but LLM says false positive
+                scanner_level = r.get("level", "")
+                if scanner_level == "error":
+                    severity_mismatches.append(r)
             else:
                 true_positives += 1
             if r.get("is_exploitable"):
@@ -726,6 +737,13 @@ Examples:
         print(f"   ⚠️  {skipped} finding{'s' if skipped != 1 else ''} skipped (--max-findings {args.max_findings})")
     elif analysed_count > 0:
         print(f"   Analysed: {analysed_count}")
+    if failed_count > 0 or blocked_count > 0:
+        parts = []
+        if blocked_count > 0:
+            parts.append(f"{blocked_count} blocked by content filter")
+        if failed_count > 0:
+            parts.append(f"{failed_count} failed")
+        print(f"   ⚠️  {', '.join(parts)}")
     if true_positives > 0 or false_positives > 0:
         print(f"   True positives: {true_positives}")
         if false_positives > 0:
@@ -734,6 +752,9 @@ Examples:
                          if r.get("self_contradictory")) if orchestration_result else 0
     if contradictions > 0:
         print(f"   ⚠️  Self-contradictory: {contradictions} (review recommended)")
+    if severity_mismatches:
+        print(f"   ⚠️  {len(severity_mismatches)} high-severity finding{'s' if len(severity_mismatches) != 1 else ''} "
+              f"ruled as false positive (review recommended)")
     print(f"   Exploitable: {exploitable_count}")
     if exploits_count > 0:
         print(f"   Exploits generated: {exploits_count}")
@@ -744,9 +765,19 @@ Examples:
     from packages.llm_analysis.dispatch import _format_elapsed
     print(f"   Duration: {_format_elapsed(workflow_duration)}")
     if orchestration_result:
-        cost = orchestration_result.get("orchestration", {}).get("cost", {}).get("total_cost", 0)
+        cost_summary = orchestration_result.get("orchestration", {}).get("cost", {})
+        cost = cost_summary.get("total_cost", 0)
         if cost > 0:
-            print(f"   Cost: ${cost:.2f} (successful calls only)")
+            thinking = cost_summary.get("thinking_tokens", 0)
+            cost_str = f"   Cost: ${cost:.2f}"
+            if thinking > 0:
+                cost_str += f" ({thinking:,} thinking tokens)"
+            print(cost_str)
+            # Per-model breakdown if multiple models used
+            by_model = cost_summary.get("cost_by_model", {})
+            if len(by_model) > 1:
+                for model, mcost in by_model.items():
+                    print(f"     {model}: ${mcost:.2f}")
 
     print(f"\n📁 Outputs:")
     print(f"   Main report: {report_file}")


### PR DESCRIPTION
**Summary**
  
  The agentic summary silently skipped failed findings, didn't distinguish content filter blocks from errors, and didn't surface thinking token costs or severity mismatches. Now provides actionable reporting.
  
  **Changes**
  
  Error categorisation (dispatch.py):
  - _classify_error() categorises failures: blocked (content filter/safety/refusal), auth, timeout, error
  - Failed findings tagged with error_type field in results
  
  Orchestration summary (orchestrator.py):
  - Shows model name: Orchestration complete (gemini-2.5-pro): ...
  - Breaks down failures: 2 blocked, 1 failed instead of 3 failed
  - Shows thinking token count when present

  Final summary (raptor_agentic.py):
  - Counts and displays blocked and failed findings separately
  - Flags high-severity scanner findings ruled as false positive by LLM (severity mismatch — review recommended)
  - Shows thinking token count alongside cost
  - Shows per-model cost breakdown when multiple models used

  **Test plan**

  - 303 tests pass (8 new)
  - Error classifier tested: content filter, safety, refusal → blocked; auth/quota → auth; timeout → timeout; other → error
  - Smoke test: full /agentic pipeline, model name and cost display correctly