### PR TITLE
Fix structured generation failing for dataclass schemas

### DIFF
--- a/packages/llm_analysis/llm/providers.py
+++ b/packages/llm_analysis/llm/providers.py
@@ -144,6 +144,10 @@ class LLMProvider(ABC):
         with Pydantic. Works with any LLM that can produce JSON.
         Usage is tracked by self.generate() — no double counting.
         """
+        # Normalize schema to a dict for JSON serialization and coercion
+        # (handles dataclass classes and other non-dict inputs)
+        if not isinstance(schema, dict):
+            schema = pydantic_model.model_json_schema()
         schema_json = json.dumps(schema, indent=2)
         augmented_prompt = (
             f"{prompt}\n\n"
@@ -250,12 +254,36 @@ def _dict_schema_to_pydantic(schema: Union[Dict[str, Any], Type['BaseModel']]):
     Raises:
         ValueError: If schema is invalid or empty
     """
+    from dataclasses import fields as dc_fields, is_dataclass
     from pydantic import BaseModel, Field, create_model
     from typing import get_type_hints
 
     # Check if already a Pydantic model class
     if isclass(schema) and issubclass(schema, BaseModel):
         return schema  # Already Pydantic, return as-is
+
+    # Convert dataclass to JSON Schema dict so it flows through the normal path
+    if isclass(schema) and is_dataclass(schema):
+        hints = get_type_hints(schema)
+        properties = {}
+        # Map Python type annotations to JSON Schema types
+        py_to_json = {
+            bool: "boolean",
+            str: "string",
+            int: "integer",
+            float: "number",
+        }
+        for f in dc_fields(schema):
+            hint = hints.get(f.name, str)
+            origin = getattr(hint, "__origin__", None)
+            if origin is list:
+                properties[f.name] = {"type": "array", "items": {"type": "string"}}
+            elif origin is dict:
+                properties[f.name] = {"type": "object"}
+            else:
+                json_type = py_to_json.get(hint, "string")
+                properties[f.name] = {"type": json_type}
+        schema = {"properties": properties, "required": [f.name for f in dc_fields(schema)]}
 
     # Validate it's a dict if not Pydantic
     if not isinstance(schema, dict):


### PR DESCRIPTION
## Summary
- **Bug:** `generate_structured()` fails when CodeQL autonomous analyzer passes dataclass classes (`VulnerabilityAnalysis`, `DataflowValidation`) as the schema argument. `_dict_schema_to_pydantic()` only accepted `dict` or Pydantic `BaseModel`, rejecting dataclasses with `"Schema must be dict or Pydantic BaseModel class, got type"`.
- **Fix 1:** Add dataclass-to-JSON-Schema conversion in `_dict_schema_to_pydantic()` — extracts field annotations and maps them to JSON Schema types.
- **Fix 2:** Normalize `schema` to a dict in `_structured_fallback()` before passing to `json.dumps()` and `_coerce_to_schema()`, which both require dict input.

**Before:** 0/20 findings analyzed (all failed), 0 exploitable  
**After:** 20/20 findings analyzed, 7 exploitable

## Test plan
- [x] 314 existing tests pass (packages/llm_analysis + packages/codeql)
- [x] Manual verification: dataclass → Pydantic model conversion produces correct fields
- [x] Full CodeQL pipeline run against mcforge repo — LLM analysis completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)