### PR TITLE
Use dict schemas instead of dataclasses for structured generation

### DIFF
--- a/packages/codeql/autonomous_analyzer.py
+++ b/packages/codeql/autonomous_analyzer.py
@@ -57,6 +57,21 @@ class VulnerabilityAnalysis:
     mitigation: str
 
 
+# Dict schema for LLM structured generation (consistent with other callers)
+VULNERABILITY_ANALYSIS_SCHEMA = {
+    "is_true_positive": "boolean",
+    "is_exploitable": "boolean",
+    "exploitability_score": "float (0.0-1.0)",
+    "severity_assessment": "string (critical/high/medium/low)",
+    "reasoning": "string",
+    "attack_scenario": "string",
+    "prerequisites": "list of strings",
+    "impact": "string",
+    "cvss_estimate": "float (0.0-10.0)",
+    "mitigation": "string",
+}
+
+
 @dataclass
 class AutonomousAnalysisResult:
     """Complete autonomous analysis result."""
@@ -283,7 +298,7 @@ Respond in JSON format:
             # Use LLM for analysis (Bug #15: multi_turn path removed - analyze_vulnerability_deeply() doesn't exist)
             response_dict, _ = self.llm.generate_structured(
                 prompt=prompt,
-                schema=VulnerabilityAnalysis,
+                schema=VULNERABILITY_ANALYSIS_SCHEMA,
                 system_prompt="You are Mark Dowd, an expert security researcher."
             )
 

--- a/packages/codeql/dataflow_validator.py
+++ b/packages/codeql/dataflow_validator.py
@@ -55,6 +55,20 @@ class DataflowValidation:
     prerequisites: List[str]
 
 
+# Dict schema for LLM structured generation (consistent with other callers)
+DATAFLOW_VALIDATION_SCHEMA = {
+    "is_exploitable": "boolean",
+    "confidence": "float (0.0-1.0)",
+    "sanitizers_effective": "boolean",
+    "bypass_possible": "boolean",
+    "bypass_strategy": "string - strategy to bypass sanitizers, or empty if none",
+    "attack_complexity": "string (low/medium/high)",
+    "reasoning": "string",
+    "barriers": "list of strings",
+    "prerequisites": "list of strings",
+}
+
+
 class DataflowValidator:
     """
     Validate CodeQL dataflow findings using LLM analysis.
@@ -263,7 +277,7 @@ Respond in JSON format:
             # Use LLM to analyze
             response_dict, _ = self.llm.generate_structured(
                 prompt=prompt,
-                schema=DataflowValidation,
+                schema=DATAFLOW_VALIDATION_SCHEMA,
                 system_prompt="You are an expert security researcher analyzing dataflow vulnerabilities."
             )
 


### PR DESCRIPTION
## Summary
- `generate_structured()` accepts dicts or Pydantic models, not dataclasses. Instead of teaching the provider about dataclasses (PR #109), make the two callers consistent with every other `generate_structured()` caller.
- Add `VULNERABILITY_ANALYSIS_SCHEMA` dict in `autonomous_analyzer.py`, swap `schema=VulnerabilityAnalysis` → `schema=VULNERABILITY_ANALYSIS_SCHEMA`
- Add `DATAFLOW_VALIDATION_SCHEMA` dict in `dataflow_validator.py`, swap `schema=DataflowValidation` → `schema=DATAFLOW_VALIDATION_SCHEMA`
- Dataclass types retained for constructing typed results from response dicts

Closes #109 (superseded by this simpler approach)

Thanks to @grokjc for suggesting the fix pattern — callers should pass dicts, not push dataclass awareness into the provider.

## Test plan
- [x] Schema fields verified to match dataclass fields exactly (automated check)
- [x] Dict schemas convert to valid Pydantic models via `_dict_schema_to_pydantic()`
- [x] 27 existing llm_analysis tests pass
- [x] Full agentic scan against mcforge repo completes with LLM analysis working

Code reviewed by stevemcgregory, changes made within Claude Code with stevemcgregory at the helm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)