### PR TITLE
Fix structured generation failing for dataclass schemas (#109)

### DIFF
--- a/packages/codeql/autonomous_analyzer.py
+++ b/packages/codeql/autonomous_analyzer.py
@@ -57,6 +57,21 @@ class VulnerabilityAnalysis:
     mitigation: str
 
 
+# Dict schema for generate_structured() — mirrors VulnerabilityAnalysis fields.
+VULNERABILITY_ANALYSIS_SCHEMA = {
+    "is_true_positive": "boolean",
+    "is_exploitable": "boolean",
+    "exploitability_score": "float (0.0-1.0)",
+    "severity_assessment": "string (critical/high/medium/low)",
+    "reasoning": "string",
+    "attack_scenario": "string",
+    "prerequisites": "list of strings",
+    "impact": "string",
+    "cvss_estimate": "float (0.0-10.0)",
+    "mitigation": "string",
+}
+
+
 @dataclass
 class AutonomousAnalysisResult:
     """Complete autonomous analysis result."""
@@ -283,7 +298,7 @@ Respond in JSON format:
             # Use LLM for analysis (Bug #15: multi_turn path removed - analyze_vulnerability_deeply() doesn't exist)
             response_dict, _ = self.llm.generate_structured(
                 prompt=prompt,
-                schema=VulnerabilityAnalysis,
+                schema=VULNERABILITY_ANALYSIS_SCHEMA,
                 system_prompt="You are Mark Dowd, an expert security researcher."
             )
 

--- a/packages/codeql/dataflow_validator.py
+++ b/packages/codeql/dataflow_validator.py
@@ -55,6 +55,20 @@ class DataflowValidation:
     prerequisites: List[str]
 
 
+# Dict schema for generate_structured() — mirrors DataflowValidation fields.
+DATAFLOW_VALIDATION_SCHEMA = {
+    "is_exploitable": "boolean",
+    "confidence": "float (0.0-1.0)",
+    "sanitizers_effective": "boolean",
+    "bypass_possible": "boolean",
+    "bypass_strategy": "string or null",
+    "attack_complexity": "string (low/medium/high)",
+    "reasoning": "string",
+    "barriers": "list of strings",
+    "prerequisites": "list of strings",
+}
+
+
 class DataflowValidator:
     """
     Validate CodeQL dataflow findings using LLM analysis.
@@ -263,7 +277,7 @@ Respond in JSON format:
             # Use LLM to analyze
             response_dict, _ = self.llm.generate_structured(
                 prompt=prompt,
-                schema=DataflowValidation,
+                schema=DATAFLOW_VALIDATION_SCHEMA,
                 system_prompt="You are an expert security researcher analyzing dataflow vulnerabilities."
             )
 


### PR DESCRIPTION
Fixes #109. Thanks to @stevemcgregory for identifying the issue.
  
  **Summary**
                                                            
  generate_structured() only accepts dict or Pydantic schemas, but two CodeQL callers passed dataclass classes directly, causing 100% analysis failure.

  **Fix**

  Define dict schemas alongside the dataclasses (same pattern as ANALYSIS_SCHEMA in packages/llm_analysis/prompts/schemas.py) and pass those instead. No provider layer changes needed.                            
   
  - autonomous_analyzer.py: VULNERABILITY_ANALYSIS_SCHEMA dict, schema=VulnerabilityAnalysis → schema=VULNERABILITY_ANALYSIS_SCHEMA                                                                                
  - dataflow_validator.py: DATAFLOW_VALIDATION_SCHEMA dict, schema=DataflowValidation → schema=DATAFLOW_VALIDATION_SCHEMA
                                                                                                                                                                                                                   
  **Test plan**                                                                                                                                                                                                        
   
  - 327 tests pass                                                        