### PR TITLE
Fix Ollama thinking models returning empty content (#112)

### DIFF
--- a/packages/llm_analysis/llm/providers.py
+++ b/packages/llm_analysis/llm/providers.py
@@ -419,7 +419,11 @@ class OpenAICompatibleProvider(LLMProvider):
 
             if not response.choices:
                 raise RuntimeError("OpenAI returned empty choices")
-            content = response.choices[0].message.content or ""
+            message = response.choices[0].message
+            content = message.content or ""
+            # Ollama thinking models (qwen3, etc.) put responses in reasoning_content
+            if not content:
+                content = getattr(message, 'reasoning_content', '') or ""
             finish_reason = response.choices[0].finish_reason or "complete"
 
             input_tokens = 0

--- a/packages/llm_analysis/tests/test_llm_callbacks_providers.py
+++ b/packages/llm_analysis/tests/test_llm_callbacks_providers.py
@@ -219,6 +219,111 @@ class TestCalculateCostSplit:
         actual_cost = provider._calculate_cost_split(0, 0)
         assert actual_cost == 0.0
 
+class TestThinkingModelFallback:
+    """Verify reasoning_content fallback for Ollama thinking models."""
+
+    def _make_ollama_provider(self):
+        """Create an OpenAICompatibleProvider configured for Ollama."""
+        mock_openai, cleanup = _ensure_mock_sdk(_providers_module, 'OpenAI')
+        with patch("packages.llm_analysis.llm.providers.OPENAI_SDK_AVAILABLE", True), \
+             patch("packages.llm_analysis.llm.providers.INSTRUCTOR_AVAILABLE", False):
+            from packages.llm_analysis.llm.providers import OpenAICompatibleProvider
+            config = ModelConfig(
+                provider="ollama", model_name="qwen3:8b",
+                api_base="http://localhost:11434/v1",
+            )
+            provider = OpenAICompatibleProvider(config)
+        return provider, mock_openai, cleanup
+
+    def test_reasoning_content_used_when_content_empty(self):
+        """Thinking models with empty content fall back to reasoning_content."""
+        provider, mock_openai, cleanup = self._make_ollama_provider()
+        try:
+            response = MagicMock()
+            response.choices = [MagicMock()]
+            response.choices[0].message.content = ""
+            response.choices[0].message.reasoning_content = "The answer is 42"
+            response.choices[0].message.refusal = None
+            response.choices[0].finish_reason = "stop"
+            response.usage = MagicMock()
+            response.usage.prompt_tokens = 50
+            response.usage.completion_tokens = 10
+            response.usage.completion_tokens_details = None
+            mock_openai.return_value.chat.completions.create.return_value = response
+
+            result = provider.generate("What is the answer?")
+            assert result.content == "The answer is 42"
+        finally:
+            cleanup()
+
+    def test_content_preferred_over_reasoning_content(self):
+        """When content is present, reasoning_content is not used."""
+        provider, mock_openai, cleanup = self._make_ollama_provider()
+        try:
+            response = MagicMock()
+            response.choices = [MagicMock()]
+            response.choices[0].message.content = "Normal response"
+            response.choices[0].message.reasoning_content = "Thinking process..."
+            response.choices[0].message.refusal = None
+            response.choices[0].finish_reason = "stop"
+            response.usage = MagicMock()
+            response.usage.prompt_tokens = 50
+            response.usage.completion_tokens = 10
+            response.usage.completion_tokens_details = None
+            mock_openai.return_value.chat.completions.create.return_value = response
+
+            result = provider.generate("test")
+            assert result.content == "Normal response"
+        finally:
+            cleanup()
+
+    def test_both_empty_returns_empty(self):
+        """When both content and reasoning_content are empty, returns empty."""
+        provider, mock_openai, cleanup = self._make_ollama_provider()
+        try:
+            response = MagicMock()
+            response.choices = [MagicMock()]
+            response.choices[0].message.content = ""
+            response.choices[0].message.reasoning_content = ""
+            response.choices[0].message.refusal = None
+            response.choices[0].finish_reason = "stop"
+            response.usage = MagicMock()
+            response.usage.prompt_tokens = 50
+            response.usage.completion_tokens = 0
+            response.usage.completion_tokens_details = None
+            mock_openai.return_value.chat.completions.create.return_value = response
+
+            result = provider.generate("test")
+            assert result.content == ""
+        finally:
+            cleanup()
+
+    def test_no_reasoning_content_attr(self):
+        """Models without reasoning_content attribute work normally."""
+        provider, mock_openai, cleanup = self._make_ollama_provider()
+        try:
+            response = MagicMock()
+            response.choices = [MagicMock()]
+            response.choices[0].message.content = "Normal response"
+            # No reasoning_content attribute
+            del response.choices[0].message.reasoning_content
+            response.choices[0].message.refusal = None
+            response.choices[0].finish_reason = "stop"
+            response.usage = MagicMock()
+            response.usage.prompt_tokens = 50
+            response.usage.completion_tokens = 10
+            response.usage.completion_tokens_details = None
+            mock_openai.return_value.chat.completions.create.return_value = response
+
+            result = provider.generate("test")
+            assert result.content == "Normal response"
+        finally:
+            cleanup()
+
+
+class TestCalculateCostSplit:
+    """Verify _calculate_cost_split uses MODEL_COSTS for known models."""
+
     def test_all_model_costs_have_input_output(self):
         """Every entry in MODEL_COSTS has both 'input' and 'output' keys."""
         for model_name, rates in MODEL_COSTS.items():


### PR DESCRIPTION
Fixes #112. Thanks to @stevemcgregory for identifying the issue.                                                                                                                                                 
                                                                                                                                                                                                                 
  **Summary**                                                                                                                                                                                                          
                                                                                                                                                                                                                 
  Ollama thinking models (qwen3, etc.) put their response in reasoning_content instead of content, causing empty analysis results. This PR checks reasoning_content as a fallback in                               
  OpenAICompatibleProvider.generate() when content is empty.
                                                                                                                                                                                                                   
  **Approach**                                                                                                                                                                                                       

  The original #112 PR reintroduced LiteLLM (removed in #81) with routing changes and a new fallback method. This PR achieves the same result with a 3-line change in the existing provider — no new dependencies, no routing changes.     
                                                                                                                                                                                                                   
  **Changes**                                                                                                                                                                                                        

  providers.py:                                                                                                                                                                                                    
  - Check message.reasoning_content when message.content is empty
  - Uses getattr for safety (non-thinking models don't have the attribute)                                                                                                                                         
  - content preferred when both are present                                                                                                                                                                      
  - Structured generation inherits the fix via _structured_fallback → generate()                                                                                                                                   
                                                                                                                                                                                                                   
  **Test plan**                                                                                                                                                                                                        
                                                                                                                                                                                                                   
  - 295 tests pass (4 new)                                                                                                                                                                                         
  - Empty content + reasoning_content → uses reasoning_content                                                                                                                                                   
  - Both present → prefers content                                                                                                                                                                                 
  - Both empty → returns empty                                                                                                                                                                                     
  - No reasoning_content attribute → works normally