### PR TITLE
Improve /validate pipeline: no stage skip, PoC evidence gate, clean serialisation

### DIFF
--- a/.claude/agents/exploitability-validator-agent.md
+++ b/.claude/agents/exploitability-validator-agent.md
@@ -232,13 +232,14 @@ Generate summary report at `$WORKDIR/validation-report.md`:
 ## Critical Rules
 
 1. **Load SKILL.md first**: Contains gates, execution rules, config
-2. **Follow MUST-GATEs**: All 6 gates apply to every stage
+2. **Follow MUST-GATEs**: All 8 gates apply to every stage
 3. **No sampling**: Check ALL code per checklist.json (GATE-5)
 4. **No hedging**: Verify all uncertain claims (GATE-4)
 5. **Document everything**: Update working docs after every action (GATE-3)
 6. **Proof required**: Every claim needs evidence (GATE-6)
-7. **Harmless PoCs only**: No destructive payloads
-8. **Assume exploitable**: Until proven otherwise (GATE-1)
+7. **PoC evidence required**: Observable effect, not just "ran without error" (GATE-8)
+8. **Harmless PoCs only**: No destructive payloads
+9. **Assume exploitable**: Until proven otherwise (GATE-1)
 
 ---
 

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -278,6 +278,8 @@ This command enforces strict validation gates:
 4. **NO-HEDGING**: Verify all "if/maybe/uncertain" claims
 5. **FULL-COVERAGE**: Check ALL code, no sampling
 6. **PROOF**: Show vulnerable code for every finding
+7. **CONSISTENCY**: Verify vuln_type/severity/status match description and proof
+8. **POC-EVIDENCE**: PoC must produce observable evidence, not just "ran without error"
 
 ## When to Use
 

--- a/.claude/skills/exploitability-validation/SKILL.md
+++ b/.claude/skills/exploitability-validation/SKILL.md
@@ -46,6 +46,8 @@ output_when_additional:
 3. Run on latest thinking/reasoning model available (verify model name).
 4. Pipeline must be deterministic - if ran again, results should be the same.
 5. After writing each JSON output file, validate it against the schema: `from packages.exploitability_validation.schemas import validate_checklist, validate_findings, validate_attack_tree, validate_attack_paths, validate_attack_surface, validate_disproven`.
+6. No finding may reach Stage D without passing through Stages B and C, even if Stage A produced a successful PoC.
+7. Do not narrate gate compliance ("GATE-8 satisfied"), schema validation passes ("findings.json: OK"), or stage transitions ("Stage C complete") to the user. Do show substantive work: PoC test output, tool investigations (objdump, checksec), binary protections, hypothesis results, and evidence discovered. Document gate compliance in validation-report.md only. Report schema or pipeline failures immediately.
 
 ---
 
@@ -66,6 +68,8 @@ Rationale: Without these gates, models sample instead of checking all code, hedg
 **GATE-6 [PROOF]:** Always provide proof and show the vulnerable code.
 
 **GATE-7 [CONSISTENCY]:** Before finalizing each finding, verify that `vuln_type`, `severity`, and `status` are consistent with the `description` and `proof` text. A description that explains why a bug is benign must not carry high severity.
+
+**GATE-8 [POC-EVIDENCE]:** A PoC requires observable evidence: a crash, changed output, callback, file read, error message, or measurable state change. "Ran without error" is not evidence. If the expected effect is not observed, either the PoC is wrong or the bug is not triggered — investigate which.
 
 ---
 
@@ -101,19 +105,19 @@ Title Case is for human-readable display (validation-report.md, terminal output)
 
 ## Stages
 
-**All stages execute in sequence. No stage may be skipped.**
+**All stages execute in sequence. No stage may be skipped, except Stage E which only applies to memory corruption vulnerabilities.**
 
 | Stage | Purpose | Gates | Output |
 |-------|---------|-------|--------|
 | **0: Inventory** | Build ground truth checklist | - | checklist.json |
-| **A: One-Shot** | Quick exploitability + PoC | 1, 4, 6 | findings.json |
-| **B: Process** | Systematic analysis, attack trees | All (1-7) | 5 working docs |
+| **A: One-Shot** | Quick exploitability + PoC | 1, 4, 6, 7, 8 | findings.json |
+| **B: Process** | Systematic analysis, attack trees | All (1-8) | 5 working docs |
 | **C: Sanity** | Validate against actual code | 3, 5, 6 | validated findings.json |
 | **D: Ruling** | Filter preconditions/hedging | 3, 5, 6, 7 | confirmed findings.json |
 | **E: Feasibility** | Binary constraint analysis | 6 | final findings.json |
 | **F: Review** | Self-review before finalizing | 7 | updated outputs |
 
-**Note:** Stage E only applies to memory corruption vulnerabilities (buffer overflow, format string, UAF, etc.). For web/injection vulnerabilities, skip Stage E.
+**Note:** Stage E is mandatory for memory corruption vulnerabilities (buffer overflow, format string, UAF, etc.). For web/injection vulnerabilities, proceed directly from D to F.
 
 See stage-specific files for detailed instructions.
 

--- a/.claude/skills/exploitability-validation/stage-a-oneshot.md
+++ b/.claude/skills/exploitability-validation/stage-a-oneshot.md
@@ -30,8 +30,8 @@ DO:
 3. Build a harmless PoC exploit for each verified finding
 
 THEN route based on outcome:
-- **PoC succeeds** -> Output to findings.json -> Done (orchestrator routes to STAGE-C)
-- **PoC fails but not disproven** -> Output to findings.json -> Done (orchestrator routes to STAGE-B)
+- **PoC succeeds** -> Output to findings.json -> proceed to STAGE-B (structured analysis still required)
+- **PoC fails but not disproven** -> Output to findings.json -> proceed to STAGE-B
 - **Definitively disproven** -> Mark finding as disproven in findings.json -> Done
 
 ## Output Format
@@ -87,7 +87,7 @@ OUTPUT: `findings.json`
 
 ## Gates
 
-GATES APPLY: 1 [ASSUME-EXPLOIT], 4 [NO-HEDGING], 6 [PROOF], 7 [CONSISTENCY]
+GATES APPLY: 1 [ASSUME-EXPLOIT], 4 [NO-HEDGING], 6 [PROOF], 7 [CONSISTENCY], 8 [POC-EVIDENCE]
 
 **GATE-7 [CONSISTENCY]:** Before finalizing each finding, verify that `vuln_type`, `severity`, and `status` are consistent with the `description` and `proof` text. If your description explains why a bug is benign, do not classify it as high severity. If your proof shows the vulnerable condition cannot occur, do not mark it as not_disproven.
 

--- a/.claude/skills/exploitability-validation/stage-b-process.md
+++ b/.claude/skills/exploitability-validation/stage-b-process.md
@@ -16,7 +16,7 @@ INPUT: `checklist.json`, `findings.json` (from Stage A with status "not_disprove
 
 See `SKILL.md` for configuration, execution rules, and MUST-GATEs.
 
-GATES APPLY: All (1-6)
+GATES APPLY: All (1-8)
 
 ---
 
@@ -38,6 +38,12 @@ Maintain these documents throughout Stage B:
 - `disproven.json`: `{"disproven": [...]}`.
 - `attack-paths.json`: top-level array `[...]`. Path status: `confirmed|uncertain|blocked`.
 - `attack-surface.json`: `{"sources": [...], "sinks": [...], "trust_boundaries": [...]}`.
+
+**Value-level prediction examples:**
+- BAD: "Supplying 24+ bytes overwrites the return address."
+- GOOD: "At offset 24, RIP=0x4141414141414141 → SIGSEGV at attacker-controlled address."
+- BAD: "User input reaches the SQL query."
+- GOOD: "Input `' OR 1=1--` in the `username` parameter returns 200 with all user rows instead of 0."
 
 **Pre-existing data:** If `attack-surface.json` or `attack-paths.json` already exist, load them as starting state. Add new entries and update existing ones as Stage B progresses — do not discard pre-existing data.
 
@@ -82,7 +88,10 @@ Construct an attack path and walk through it, trying to prove exploitability at 
 **[B-3.3] Path Exhaustion**
 Try different attack paths (completely new ones or new directions along each path) until you can't creatively come up with new directions and the attack tree is exhausted. Update attack-paths.json on every attempt.
 
-**[B-3.4] PoC Development**
+**[B-3.4] Verify Before Recording**
+Before writing a prediction result as confirmed or disproven, run the verification command (disassembly, grep, test execution) and include its output in the result field. A reference to a tool is not evidence — the output of the tool is.
+
+**[B-3.5] PoC Development**
 For every finding that is not far-fetched, provide a full, end-to-end, step-by-step, harmless PoC exploit.
 
 ---

--- a/.claude/skills/exploitability-validation/stage-f-review.md
+++ b/.claude/skills/exploitability-validation/stage-f-review.md
@@ -38,11 +38,15 @@ Verify these specific items. Each has been missed in past runs:
 
 2. **Stage E verdict applied.** For every finding where Stage E ran, does `final_status` in `findings.json` reflect the verdict mapping (likely -> exploitable, difficult -> confirmed_constrained, unlikely -> confirmed_blocked)? If not, fix it.
 
-3. **Consistent proximity scores.** Do findings with the same bug class and impact have the same proximity score? If two scores differ, state why. If no reason, equalize them.
+3. **Feasibility overrides documented.** If you overrode an automated feasibility verdict, document in the finding's feasibility notes: `OVERRIDE: automated=X, final=Y. Reason: ...`
 
-4. **Preconditions backed by evidence.** Every precondition stated in a ruling (e.g., "all handlers check checkfrom()") must cite specific evidence (line numbers, grep results). If a precondition is asserted without evidence, verify it now.
+4. **Consistent proximity scores.** Do findings with the same bug class and impact have the same proximity score? If two scores differ, state why. If no reason, equalize them.
 
-5. **Value-level traces for similar bugs.** If multiple findings share the same syntactic pattern, does each have a value-level trace explaining why the concrete effect differs (or is the same)?
+5. **Preconditions backed by evidence.** Every precondition stated in a ruling (e.g., "all handlers check checkfrom()") must cite specific evidence (line numbers, grep results). If a precondition is asserted without evidence, verify it now.
+
+6. **Value-level traces for similar bugs.** If multiple findings share the same syntactic pattern, does each have a value-level trace explaining why the concrete effect differs (or is the same)?
+
+7. **Causal claims backed by evidence.** Every causal claim in `disproven.json` `why_wrong`, `hypotheses.json` `result`, and `findings.json` `notes`/`reason`/`synthesis` must cite a concrete verification method (tool output, line number, test result, disassembly). Examples — PASS: "Disassembly shows password at RSP+0x10, canary at RSP+0x108." PASS: "grep confirms htmlEscape() called at line 47 before template render at line 52." FAIL: "Compiler likely reordered the stack layout" — no evidence cited.
 
 ### [F-2] Critical Review
 

--- a/docs/exploitability-validation-integration.md
+++ b/docs/exploitability-validation-integration.md
@@ -332,6 +332,8 @@ Validation is non-blocking (logs warnings) to prevent pipeline failures from min
 | GATE-4 | Verify all "if/maybe/uncertain" claims | Unverified hedging |
 | GATE-5 | Check ALL code, no sampling | Missed vulnerabilities |
 | GATE-6 | Show proof for every finding | Hallucinations |
+| GATE-7 | Verify vuln_type/severity/status consistency | Misclassifications |
+| GATE-8 | PoC requires observable evidence | Unverified PoCs |
 
 ### Attack Path Reference Validation
 

--- a/packages/exploitability_validation/models.py
+++ b/packages/exploitability_validation/models.py
@@ -23,6 +23,24 @@ from datetime import datetime
 from typing import Optional, List
 
 
+def _clean_dict(d: dict) -> dict:
+    """Recursively strip None values and empty strings from a dict for schema-clean serialization.
+
+    Keeps False, 0, empty lists, and empty dicts — only removes values that
+    represent 'not yet populated' placeholders that fail schema validation.
+    """
+    result = {}
+    for k, v in d.items():
+        if v is None or v == "":
+            continue
+        if isinstance(v, dict):
+            v = _clean_dict(v)
+        elif isinstance(v, list):
+            v = [_clean_dict(item) if isinstance(item, dict) else item for item in v]
+        result[k] = v
+    return result
+
+
 # ── Finding sub-structures ──────────────────────────────────────────────────
 
 
@@ -154,7 +172,7 @@ class Ruling:
         )
 
     def to_dict(self) -> dict:
-        return asdict(self)
+        return _clean_dict(asdict(self))
 
 
 @dataclass
@@ -199,7 +217,7 @@ class Feasibility:
         )
 
     def to_dict(self) -> dict:
-        return asdict(self)
+        return _clean_dict(asdict(self))
 
 
 # ── Core Finding ────────────────────────────────────────────────────────────
@@ -289,7 +307,7 @@ class Finding:
         )
 
     def to_dict(self) -> dict:
-        return asdict(self)
+        return _clean_dict(asdict(self))
 
 
 # ── Container ───────────────────────────────────────────────────────────────
@@ -343,7 +361,9 @@ class FindingsContainer:
         )
 
     def to_dict(self) -> dict:
-        return asdict(self)
+        d = asdict(self)
+        d["findings"] = [_clean_dict(f) for f in d.get("findings", [])]
+        return d
 
     @classmethod
     def create_empty(cls, stage: str, target_path: str = "", vuln_type: str = None) -> "FindingsContainer":

--- a/packages/exploitability_validation/tests/test_validation.py
+++ b/packages/exploitability_validation/tests/test_validation.py
@@ -3163,18 +3163,88 @@ class TestFindingMapper:
         assert f.poc.description == ""
 
     def test_create_finding_no_none_subfields(self):
-        """create_finding() should produce dicts with empty sub-dicts, not None."""
+        """create_finding() should produce clean dicts without None or empty-string placeholders."""
         from packages.exploitability_validation.schemas import create_finding
         f = create_finding("F1", "test.c", "main", 1, "xss")
         # Sub-structures are dicts (from dataclass.to_dict), not None
-        assert isinstance(f["ruling"], dict)
-        assert isinstance(f["feasibility"], dict)
-        assert isinstance(f["sanity_check"], dict)
-        assert isinstance(f["proof"], dict)
-        assert isinstance(f["poc"], dict)
-        # And they have real default values
-        assert f["ruling"]["status"] == ""
-        assert f["feasibility"]["verdict"] == ""
+        assert isinstance(f.get("proof", {}), dict)
+        assert isinstance(f.get("poc", {}), dict)
+        # None and empty-string placeholders are stripped
+        assert "tool" not in f
+        assert "message" not in f
+        # Populated fields survive
+        assert f["id"] == "F1"
+        assert f["vuln_type"] == "xss"
+        assert f["status"] == "not_disproven"
+
+
+class TestCleanDict:
+    """Tests for _clean_dict serialization helper."""
+
+    def test_strips_none(self):
+        from packages.exploitability_validation.models import _clean_dict
+        assert _clean_dict({"a": None, "b": "keep"}) == {"b": "keep"}
+
+    def test_strips_empty_string(self):
+        from packages.exploitability_validation.models import _clean_dict
+        assert _clean_dict({"a": "", "b": "keep"}) == {"b": "keep"}
+
+    def test_preserves_false(self):
+        from packages.exploitability_validation.models import _clean_dict
+        assert _clean_dict({"a": False}) == {"a": False}
+
+    def test_preserves_zero(self):
+        from packages.exploitability_validation.models import _clean_dict
+        assert _clean_dict({"a": 0}) == {"a": 0}
+
+    def test_preserves_empty_list(self):
+        from packages.exploitability_validation.models import _clean_dict
+        assert _clean_dict({"a": []}) == {"a": []}
+
+    def test_preserves_empty_dict(self):
+        from packages.exploitability_validation.models import _clean_dict
+        assert _clean_dict({"a": {}}) == {"a": {}}
+
+    def test_recursive_nested_dict(self):
+        from packages.exploitability_validation.models import _clean_dict
+        d = {"a": {"x": None, "y": "", "z": "keep"}, "b": "top"}
+        assert _clean_dict(d) == {"a": {"z": "keep"}, "b": "top"}
+
+    def test_recursive_list_of_dicts(self):
+        from packages.exploitability_validation.models import _clean_dict
+        d = {"items": [{"a": None, "b": "keep"}, {"c": "", "d": 42}]}
+        assert _clean_dict(d) == {"items": [{"b": "keep"}, {"d": 42}]}
+
+    def test_deeply_nested(self):
+        from packages.exploitability_validation.models import _clean_dict
+        d = {"l1": {"l2": {"l3": None, "l3b": "deep"}}}
+        assert _clean_dict(d) == {"l1": {"l2": {"l3b": "deep"}}}
+
+    def test_container_not_cleaned(self):
+        """FindingsContainer.to_dict() preserves container-level fields."""
+        from packages.exploitability_validation.models import FindingsContainer
+        c = FindingsContainer(stage="A", timestamp="2026-01-01T00:00:00")
+        d = c.to_dict()
+        assert d["stage"] == "A"
+        assert d["timestamp"] == "2026-01-01T00:00:00"
+
+    def test_finding_cleaned_inside_container(self):
+        """Findings inside a container have None/empty stripped."""
+        from packages.exploitability_validation.models import FindingsContainer, Finding
+        from packages.exploitability_validation.schemas import validate_findings
+        c = FindingsContainer(
+            stage="A", timestamp="2026-01-01T00:00:00",
+            findings=[Finding(id="FIND-0001", file="t.c", function="f", line=1,
+                              vuln_type="xss", status="not_disproven", severity="high")]
+        )
+        d = c.to_dict()
+        f = d["findings"][0]
+        assert "tool" not in f
+        assert "message" not in f
+        assert f["id"] == "FIND-0001"
+        assert f["severity"] == "high"
+        ok, errors = validate_findings(d)
+        assert ok, f"Validation failed: {errors}"
 
 
 if __name__ == "__main__":

--- a/packages/llm_analysis/cc_dispatch.py
+++ b/packages/llm_analysis/cc_dispatch.py
@@ -200,6 +200,7 @@ If your reasoning hedges ("maybe", "in theory"), verify the claim or rule it out
 
 Rules: Investigate as if exploitable until proven otherwise. Do not guess or assume.
 If uncertain, verify by reading the code. Show the vulnerable code for every claim.
+Back causal claims with specifics (function name, line number). "Input is sanitized" is not sufficient; "htmlEscape() at line 47" is.
 Your ruling, is_true_positive, and is_exploitable MUST be consistent with your reasoning.
 """
 

--- a/packages/llm_analysis/prompts/analysis.py
+++ b/packages/llm_analysis/prompts/analysis.py
@@ -18,6 +18,7 @@ Rules (from exploitation-validator methodology):
 - ASSUME-EXPLOIT: Investigate as if exploitable until proven otherwise. Do not dismiss.
 - NO-HEDGING: If your reasoning includes "if", "maybe", or "uncertain", verify the claim.
 - PROOF: Show the vulnerable code for every claim. Quote the actual line.
+- EVIDENCE: Back causal claims with specifics (function name, line number). "Input is sanitized" is not sufficient; "htmlEscape() at line 47" is.
 - FULL-COVERAGE: Assess every aspect — do not skip steps or take shortcuts."""
 
 

--- a/packages/llm_analysis/tests/test_load_findings.py
+++ b/packages/llm_analysis/tests/test_load_findings.py
@@ -119,9 +119,9 @@ class TestMissingOptionalFields:
         result = convert_validated_to_agent_format(data)
         assert len(result) == 1
         assert result[0]["finding_id"] == "FIND-BARE"
-        # Dataclass defaults: feasibility is a full dict with default fields, ruling likewise
+        # Dataclass defaults: feasibility has "pending", ruling has empty strings stripped
         assert result[0]["feasibility"]["status"] == "pending"
-        assert result[0]["ruling"]["status"] == ""
+        assert "status" not in result[0].get("ruling", {})  # empty string stripped by _clean_dict
         assert result[0]["final_status"] == "pending"  # None defaults to "pending"
 
 


### PR DESCRIPTION
Improve /validate pipeline: no stage skip, PoC evidence gate, causal claims check, clean serialisation
  
**Summary**
  
  - **No stage skip (exec rule 6):** All findings must pass through Stages B and C before D, even if Stage A PoC succeeds. Prevents fast-track bypass (gadievron/exploitation-validator#1 proposal 4)
  - **GATE-8 [POC-EVIDENCE]:** PoCs require observable evidence (crash, changed output, callback). "Ran without error" triggers investigation
  - **B-3.4 verify before recording:** Run the verification command and include output before writing confirmed/disproven predictions. Prevents fabricated tool references
  - **F-1.7 causal claims check:** Every causal claim must cite concrete evidence. Catches unverified speculation that self-review misses
  - **EVIDENCE rule (agentic):** Both analysis.py and cc_dispatch.py require causal claims to cite specifics
  - **Clean serialization:** `_clean_dict()` recursively strips None/empty-string placeholders. `create_finding()` now produces schema-valid output. FindingsContainer preserves container-level fields
  - **Output quality:** Suppress gate narration and schema-OK noise; keep PoC output, tool investigations, binary protections visible. Sort tables by finding ID. Document feasibility overrides.
  
**Key findings from e2e testing**
  
  - GATE-8 caught a silent PoC exit  — forced investigation revealing memory as observable evidence
  - B-3.4 forced actual `objdump -d` execution before recording canary reachability claims — prior run cited objdump without running it
  - F-1.7 catches hedging but is gameable without B-3.4 (LLM writes plausible tool references without execution)
  - Output suppression rule overcorrected on first attempt (hid substantive detail) — refined to target only gate refs, schema passes, stage labels
  
**Test plan**
  
  - [x] `pytest packages/exploitability_validation/tests/test_validation.py` — 243 tests (11 new TestCleanDict)
  - [x] `pytest packages/llm_analysis/tests/` — 300 tests (1 updated for _clean_dict)
  - [x] 6 e2e `/validate /tmp/vulns --vuln-type buffer_overflow` runs validating progressive improvements
  - [x] Verified no agentic mode impact (skill files not loaded, _clean_dict is no-op for populated fields)
