### PR TITLE
Add Gemma 4 model data and document support

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Try /analyze on one of our tests in /tests/data
 RAPTOR uses the OpenAI and Anthropic SDKs directly for LLM provider integration with automatic fallback, cost tracking, and budget enforcement. Both SDKs are optional — RAPTOR works with just Claude Code installed.
 
 **Key Features:**
-- **Direct SDK Integration:** OpenAI SDK for OpenAI/Gemini/Mistral/Ollama, Anthropic SDK for Claude
+- **Direct SDK Integration:** OpenAI SDK for OpenAI/Mistral/Ollama, Anthropic SDK for Claude, native google-genai SDK for Gemini/Gemma
 - **Smart Model Selection:** Auto-selects best reasoning model from config or environment
 - **Structured Output:** Instructor + Pydantic fallback for reliable JSON responses
 - **Budget Enforcement:** Prevents exceeding cost limits with detailed error messages
@@ -350,10 +350,13 @@ Model selection and API use is handled through Claude Code natively.
 | **Anthropic Claude** | ✅ Compilable C code    | ~$0.03/vuln |
 | **OpenAI GPT-4**     | ✅ Compilable C code    | ~$0.03/vuln |
 | **Gemini 2.5**       | ✅ Compilable C code    | ~$0.03/vuln |
+| **Gemma 4 (local/API)** | ⚠️ Untested          | FREE*       |
 | **Ollama (local)**   | ❌ Often broken         | FREE        |
 
 **Note:** Exploit generation requires frontier models (Claude, GPT, or Gemini). Local
-models work for analysis but may produce non-compilable exploit code.
+models and Gemma work for analysis but may produce non-compilable exploit code.
+
+*Gemma 4 is free locally via Ollama and free tier via the Gemini API (rate-limited, subject to change). Use `provider: "gemini"` with `GEMINI_API_KEY` for API access, or `provider: "ollama"` for local.
 
 ### Environment Variables
 

--- a/packages/llm_analysis/llm/model_data.py
+++ b/packages/llm_analysis/llm/model_data.py
@@ -48,6 +48,8 @@ MODEL_COSTS = {
     "gemini-2.5-pro":          {"input": 0.00125, "output": 0.010},
     "gemini-2.5-flash":        {"input": 0.0003,  "output": 0.0025},
     "gemini-2.5-flash-lite":   {"input": 0.0001,  "output": 0.0004},
+    # Google Gemma (free tier only via Gemini API as of 2026-04, also runs locally via Ollama)
+    "gemma-4-31b-it":          {"input": 0,       "output": 0},
     # Mistral
     "mistral-large-latest":    {"input": 0.0005,  "output": 0.0015},
     "mistral-small-latest":    {"input": 0.00015, "output": 0.0006},
@@ -74,6 +76,8 @@ MODEL_LIMITS = {
     "gemini-2.5-pro":          {"max_context": 1048576, "max_output": 65536},
     "gemini-2.5-flash":        {"max_context": 1048576, "max_output": 65536},
     "gemini-2.5-flash-lite":   {"max_context": 1048576, "max_output": 65536},
+    # Google Gemma (free tier only via Gemini API as of 2026-04, also runs locally via Ollama)
+    "gemma-4-31b-it":          {"max_context": 262144,  "max_output": 32768},
     # Mistral
     "mistral-large-latest":    {"max_context": 262100,  "max_output": 262100},
     "mistral-small-latest":    {"max_context": 256000,  "max_output": 256000},


### PR DESCRIPTION
**Summary**

  Google's Gemma 4 (gemma-4-31b-it) works with RAPTOR via the native Gemini provider — same API, same API key, thinking tokens captured. No code changes needed. This PR adds model data and documentation.

  Verified empirically: gemma-4-31b-it through google-genai SDK returns content, thinking tokens, and usage metadata. Model limits verified via client.models.get() (262K context, 32K output).

  **Changes**

  model_data.py:
  - Added gemma-4-31b-it to MODEL_COSTS (free tier only as of 2026-04) and MODEL_LIMITS (262K context, 32K output)

  README.md:
  - Updated SDK integration line to mention Gemini/Gemma
  - Added Gemma 4 to exploit quality comparison table (untested for exploits)
  - Documented both access paths: provider: "gemini" with API key (free tier, rate-limited) or provider: "ollama" for local

  **Test plan**

  - 307 tests pass
  - Verified via Gemini API: gemma-4-31b-it generates content with thinking tokens (63)
  - Model limits confirmed from API: 262144 input, 32768 output