### PR TITLE
Fix --target in lifecycle docs, fix sys.path in understand map skill

### DIFF
--- a/.claude/skills/code-understanding/map.md
+++ b/.claude/skills/code-understanding/map.md
@@ -177,7 +177,8 @@ checks), then write a small Python script to record them:
 
 ```python
 # Save as /tmp/record_coverage.py and run: python3 /tmp/record_coverage.py
-import json, sys
+import json, sys, os
+sys.path.insert(0, os.getcwd())  # script is in /tmp but cwd is the raptor repo root
 from core.inventory.coverage import update_coverage
 
 workdir = sys.argv[1]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ When running any analysis command (`/scan`, `/validate`, `/understand`, `/codeql
 OUTPUT_DIR=$(python3 -m core.run start <command> --target <resolved_target>)
 ```
 Always pass `--target` with the resolved target path (see DEFAULT TARGET DIRECTORY for resolution order). This creates the output directory, writes `.raptor-run.json` with `status: running`, and prints the path.
+**Use `$OUTPUT_DIR` for all output files.** Do not construct output paths manually.
 
 **After successful completion:**
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,9 +67,9 @@ When running any analysis command (`/scan`, `/validate`, `/understand`, `/codeql
 
 **Before starting work:**
 ```bash
-OUTPUT_DIR=$(python3 -m core.run start <command>)
+OUTPUT_DIR=$(python3 -m core.run start <command> --target <resolved_target>)
 ```
-This creates the output directory, writes `.raptor-run.json` with `status: running`, and prints the path. Use `$OUTPUT_DIR` for all output files.
+Always pass `--target` with the resolved target path (see DEFAULT TARGET DIRECTORY for resolution order). This creates the output directory, writes `.raptor-run.json` with `status: running`, and prints the path.
 
 **After successful completion:**
 ```bash


### PR DESCRIPTION
Fix --target in lifecycle docs, fix sys.path in understand map skill
  
  Found during E2E testing of coverage tracking.
  
  - CLAUDE.md: run lifecycle start command now requires --target with
    the resolved target path. Without it, the target mismatch guard
    can't verify the scan target matches the active project.
  - map.md: coverage recording script runs from /tmp but needs to
    import from core.inventory. Added sys.path fixup since cwd is
    the raptor repo root, not /tmp.