### PR TITLE
Add coverage tracking plugin and coverage records

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,10 @@ The `start` command automatically resolves the output directory using the active
 
 Commands run via `python3 raptor.py` (scan, agentic, codeql, fuzz, web) manage lifecycle internally — do not call the stubs separately for those.
 
+### Coverage tracking
+
+The coverage tracking plugin (`plugins/coverage/`) tracks which source files the LLM reads during analysis via a PostToolUse hook. Loaded automatically by the launcher. Logs file paths to a manifest in the active run directory, converted to `coverage-record.json` when the run completes. Zero overhead when no run is active.
+
 ---
 
 ## SECURITY: UNTRUSTED REPOS

--- a/core/coverage/__init__.py
+++ b/core/coverage/__init__.py
@@ -1,0 +1,25 @@
+"""Coverage tracking — records what tools examined during analysis.
+
+Provides coverage record building (from hook manifests and tool output)
+and file read tracking. Phase 2 will add coverage computation and reporting.
+"""
+
+from .record import (
+    build_from_manifest,
+    build_from_semgrep,
+    write_record,
+    load_record,
+    cleanup_manifest,
+    COVERAGE_RECORD_FILE,
+    READS_MANIFEST,
+)
+
+__all__ = [
+    "build_from_manifest",
+    "build_from_semgrep",
+    "write_record",
+    "load_record",
+    "cleanup_manifest",
+    "COVERAGE_RECORD_FILE",
+    "READS_MANIFEST",
+]

--- a/core/coverage/record.py
+++ b/core/coverage/record.py
@@ -1,0 +1,122 @@
+"""Coverage record — what a tool examined during a run.
+
+Written to coverage-record.json in the run output directory.
+Built from the reads manifest (populated by the PostToolUse hook)
+and/or from tool-specific data (Semgrep JSON, CodeQL database).
+"""
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from core.json import load_json, save_json
+
+COVERAGE_RECORD_FILE = "coverage-record.json"
+READS_MANIFEST = ".reads-manifest"
+
+
+def build_from_manifest(run_dir: Path, tool: str,
+                        rules_applied: List[str] = None,
+                        extra_files: List[str] = None) -> Optional[Dict[str, Any]]:
+    """Build a coverage record from the reads manifest.
+
+    The manifest is populated by the PostToolUse hook on Read.
+    Deduplicates and normalises paths relative to the target.
+
+    Args:
+        run_dir: Run output directory containing .reads-manifest.
+        tool: Tool identifier (e.g., "llm:validate", "understand").
+        rules_applied: Optional list of rules/stages that ran.
+        extra_files: Additional files to include (from other sources).
+
+    Returns:
+        Coverage record dict, or None if no manifest exists.
+    """
+    run_dir = Path(run_dir)
+    manifest = run_dir / READS_MANIFEST
+
+    files = set()
+
+    # Read manifest
+    if manifest.exists():
+        try:
+            for line in manifest.read_text().splitlines():
+                line = line.strip()
+                if line:
+                    files.add(line)
+        except OSError:
+            pass
+
+    # Add extra files from tool-specific sources
+    if extra_files:
+        files.update(extra_files)
+
+    if not files:
+        return None
+
+    record = {
+        "tool": tool,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "files_examined": sorted(files),
+    }
+    if rules_applied:
+        record["rules_applied"] = rules_applied
+
+    return record
+
+
+def build_from_semgrep(run_dir: Path, semgrep_json_path: Path,
+                       rules_applied: List[str] = None) -> Optional[Dict[str, Any]]:
+    """Build a coverage record from Semgrep JSON output.
+
+    Reads paths.scanned from Semgrep's JSON output for authoritative
+    file list, and errors for files_failed.
+    """
+    data = load_json(semgrep_json_path)
+    if not data or not isinstance(data, dict):
+        return None
+
+    paths = data.get("paths", {})
+    scanned = paths.get("scanned", [])
+    if not scanned:
+        return None
+
+    errors = data.get("errors", [])
+    version = data.get("version", "")
+
+    record = {
+        "tool": "semgrep",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "files_examined": sorted(scanned),
+    }
+    if version:
+        record["version"] = version
+    if rules_applied:
+        record["rules_applied"] = rules_applied
+    if errors:
+        record["files_failed"] = [
+            {"path": e.get("path", ""), "reason": e.get("message", "error")}
+            for e in errors if e.get("path")
+        ]
+
+    return record
+
+
+def write_record(run_dir: Path, record: Dict[str, Any]) -> Path:
+    """Write a coverage record to the run directory."""
+    path = Path(run_dir) / COVERAGE_RECORD_FILE
+    save_json(path, record)
+    return path
+
+
+def load_record(run_dir: Path) -> Optional[Dict[str, Any]]:
+    """Load a coverage record from a run directory."""
+    return load_json(Path(run_dir) / COVERAGE_RECORD_FILE)
+
+
+def cleanup_manifest(run_dir: Path) -> None:
+    """Remove the reads manifest after converting to a coverage record."""
+    manifest = Path(run_dir) / READS_MANIFEST
+    if manifest.exists():
+        manifest.unlink(missing_ok=True)

--- a/core/coverage/tests/test_record.py
+++ b/core/coverage/tests/test_record.py
@@ -1,0 +1,223 @@
+"""Tests for coverage record building and tracking."""
+
+import json
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from core.coverage.record import (
+    build_from_manifest,
+    build_from_semgrep,
+    write_record,
+    load_record,
+    cleanup_manifest,
+    READS_MANIFEST,
+    COVERAGE_RECORD_FILE,
+)
+from core.coverage.track_read import main as track_read_main
+
+
+class TestBuildFromManifest(unittest.TestCase):
+
+    def test_builds_from_manifest(self):
+        with TemporaryDirectory() as d:
+            manifest = Path(d) / READS_MANIFEST
+            manifest.write_text("/tmp/src/auth.py\n/tmp/src/db.py\n/tmp/src/auth.py\n")
+            record = build_from_manifest(Path(d), "llm:validate")
+            self.assertEqual(record["tool"], "llm:validate")
+            # Deduplicated and sorted
+            self.assertEqual(len(record["files_examined"]), 2)
+            self.assertIn("/tmp/src/auth.py", record["files_examined"])
+            self.assertIn("/tmp/src/db.py", record["files_examined"])
+
+    def test_returns_none_without_manifest(self):
+        with TemporaryDirectory() as d:
+            self.assertIsNone(build_from_manifest(Path(d), "test"))
+
+    def test_includes_rules(self):
+        with TemporaryDirectory() as d:
+            manifest = Path(d) / READS_MANIFEST
+            manifest.write_text("/tmp/file.py\n")
+            record = build_from_manifest(Path(d), "test", rules_applied=["stage-a"])
+            self.assertEqual(record["rules_applied"], ["stage-a"])
+
+    def test_includes_extra_files(self):
+        with TemporaryDirectory() as d:
+            manifest = Path(d) / READS_MANIFEST
+            manifest.write_text("/tmp/a.py\n")
+            record = build_from_manifest(Path(d), "test", extra_files=["/tmp/b.py"])
+            self.assertIn("/tmp/a.py", record["files_examined"])
+            self.assertIn("/tmp/b.py", record["files_examined"])
+
+
+class TestBuildFromSemgrep(unittest.TestCase):
+
+    def test_builds_from_semgrep_json(self):
+        with TemporaryDirectory() as d:
+            semgrep_json = Path(d) / "semgrep.json"
+            semgrep_json.write_text(json.dumps({
+                "version": "1.67.0",
+                "paths": {"scanned": ["/tmp/src/auth.py", "/tmp/src/db.py"]},
+                "results": [],
+                "errors": [],
+            }))
+            record = build_from_semgrep(Path(d), semgrep_json,
+                                        rules_applied=["p/owasp-top-ten"])
+            self.assertEqual(record["tool"], "semgrep")
+            self.assertEqual(record["version"], "1.67.0")
+            self.assertEqual(len(record["files_examined"]), 2)
+            self.assertEqual(record["rules_applied"], ["p/owasp-top-ten"])
+
+    def test_captures_errors(self):
+        with TemporaryDirectory() as d:
+            semgrep_json = Path(d) / "semgrep.json"
+            semgrep_json.write_text(json.dumps({
+                "paths": {"scanned": ["/tmp/src/ok.py"]},
+                "results": [],
+                "errors": [{"path": "/tmp/src/bad.js", "message": "parse error"}],
+            }))
+            record = build_from_semgrep(Path(d), semgrep_json)
+            self.assertEqual(len(record["files_failed"]), 1)
+            self.assertEqual(record["files_failed"][0]["path"], "/tmp/src/bad.js")
+
+    def test_returns_none_without_scanned(self):
+        with TemporaryDirectory() as d:
+            semgrep_json = Path(d) / "semgrep.json"
+            semgrep_json.write_text(json.dumps({"paths": {}, "results": []}))
+            self.assertIsNone(build_from_semgrep(Path(d), semgrep_json))
+
+
+class TestWriteAndLoad(unittest.TestCase):
+
+    def test_roundtrip(self):
+        with TemporaryDirectory() as d:
+            record = {"tool": "test", "files_examined": ["a.py"]}
+            write_record(Path(d), record)
+            loaded = load_record(Path(d))
+            self.assertEqual(loaded["tool"], "test")
+            self.assertEqual(loaded["files_examined"], ["a.py"])
+
+    def test_load_missing(self):
+        with TemporaryDirectory() as d:
+            self.assertIsNone(load_record(Path(d)))
+
+
+class TestCleanupManifest(unittest.TestCase):
+
+    def test_removes_manifest(self):
+        with TemporaryDirectory() as d:
+            manifest = Path(d) / READS_MANIFEST
+            manifest.write_text("file.py\n")
+            cleanup_manifest(Path(d))
+            self.assertFalse(manifest.exists())
+
+    def test_no_error_if_missing(self):
+        with TemporaryDirectory() as d:
+            cleanup_manifest(Path(d))  # Should not raise
+
+
+class TestTrackReadHook(unittest.TestCase):
+
+    def _setup_project(self, project_dir, run_dir, target="/tmp/src"):
+        """Set up a temporary project with an active symlink and running run."""
+        projects_dir = Path.home() / ".raptor" / "projects"
+        projects_dir.mkdir(parents=True, exist_ok=True)
+
+        # Save existing state
+        active_link = projects_dir / ".active"
+        self._old_link = os.readlink(active_link) if active_link.is_symlink() else None
+        self._old_json = None
+        if active_link.is_symlink():
+            old_json_path = projects_dir / self._old_link
+            self._old_json = old_json_path.read_text() if old_json_path.exists() else None
+
+        # Create test project
+        import json as _json
+        project_json = projects_dir / "_test_hook.json"
+        project_json.write_text(_json.dumps({
+            "name": "_test_hook",
+            "target": target,
+            "output_dir": str(project_dir),
+        }))
+        if active_link.is_symlink() or active_link.exists():
+            active_link.unlink()
+        active_link.symlink_to("_test_hook.json")
+
+        # Create running run
+        run_dir.mkdir(parents=True, exist_ok=True)
+        meta = run_dir / ".raptor-run.json"
+        meta.write_text(_json.dumps({"status": "running", "command": "test"}))
+
+    def _teardown_project(self):
+        """Restore project state."""
+        projects_dir = Path.home() / ".raptor" / "projects"
+        active_link = projects_dir / ".active"
+        test_json = projects_dir / "_test_hook.json"
+        if test_json.exists():
+            test_json.unlink()
+        if active_link.is_symlink() or active_link.exists():
+            active_link.unlink()
+        if self._old_link:
+            active_link.symlink_to(self._old_link)
+
+    def _run_hook(self, file_path, project_dir, run_dir, target="/tmp/src"):
+        """Helper to invoke track_read with a simulated hook payload."""
+        import io
+        self._setup_project(project_dir, run_dir, target)
+        payload = json.dumps({"tool_input": {"file_path": file_path}})
+        old_stdin = __import__("sys").stdin
+        try:
+            __import__("sys").stdin = io.StringIO(payload)
+            track_read_main()
+        finally:
+            __import__("sys").stdin = old_stdin
+            self._teardown_project()
+
+    def test_appends_to_manifest(self):
+        with TemporaryDirectory() as d:
+            project_dir = Path(d) / "project"
+            run_dir = project_dir / "validate-20260408"
+            self._run_hook("/tmp/src/auth.py", project_dir, run_dir)
+            manifest = run_dir / READS_MANIFEST
+            self.assertTrue(manifest.exists())
+            self.assertIn("/tmp/src/auth.py", manifest.read_text())
+
+    def test_skips_non_source(self):
+        with TemporaryDirectory() as d:
+            project_dir = Path(d) / "project"
+            run_dir = project_dir / "validate-20260408"
+            self._run_hook("/tmp/src/image.png", project_dir, run_dir)
+            manifest = run_dir / READS_MANIFEST
+            self.assertFalse(manifest.exists())
+
+    def test_skips_without_active_project(self):
+        """No active project → exits immediately."""
+        import io
+        # Ensure no active symlink
+        active_link = Path.home() / ".raptor" / "projects" / ".active"
+        old_link = os.readlink(active_link) if active_link.is_symlink() else None
+        if active_link.is_symlink():
+            active_link.unlink()
+        payload = json.dumps({"tool_input": {"file_path": "/tmp/src/auth.py"}})
+        old_stdin = __import__("sys").stdin
+        try:
+            __import__("sys").stdin = io.StringIO(payload)
+            track_read_main()  # Should not raise
+        finally:
+            __import__("sys").stdin = old_stdin
+            if old_link:
+                active_link.symlink_to(old_link)
+
+    def test_skips_outside_target(self):
+        """Files outside target are ignored."""
+        with TemporaryDirectory() as d:
+            project_dir = Path(d) / "project"
+            run_dir = project_dir / "validate-20260408"
+            self._run_hook("/home/raptor/raptor/core/config.py", project_dir, run_dir, target="/tmp/vuln")
+            manifest = run_dir / READS_MANIFEST
+            self.assertFalse(manifest.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core/coverage/track_read.py
+++ b/core/coverage/track_read.py
@@ -1,0 +1,104 @@
+"""Track file reads for coverage — Python implementation.
+
+The production hook is libexec/raptor-hook-read (bash+jq, runs async).
+This module provides the same logic in Python for:
+- Testing (test_record.py)
+- Fallback when jq is unavailable
+- Direct invocation: python3 -m core.coverage.track_read
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Ensure repo root is on path regardless of cwd
+# core/coverage/track_read.py -> repo root
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+MANIFEST_NAME = ".reads-manifest"
+
+_SOURCE_EXTENSIONS = frozenset({
+    ".py", ".js", ".ts", ".jsx", ".tsx", ".c", ".h", ".cpp", ".hpp",
+    ".cc", ".cxx", ".java", ".go", ".rs", ".rb", ".php", ".cs",
+    ".swift", ".kt", ".scala", ".sh", ".bash", ".zsh",
+})
+
+
+def _find_active_run():
+    """Find the running run directory via project symlink.
+
+    Returns (run_dir, target) or (None, None).
+    """
+    active_link = Path.home() / ".raptor" / "projects" / ".active"
+    if not active_link.is_symlink():
+        return None, None
+
+    try:
+        link_target = os.readlink(active_link)
+        if not link_target.endswith(".json"):
+            return None, None
+        project_file = active_link.parent / link_target
+        if not project_file.exists():
+            return None, None
+
+        data = json.loads(project_file.read_text())
+        project_dir = data.get("output_dir", "")
+        target = data.get("target", "")
+        if not project_dir or not Path(project_dir).is_dir():
+            return None, None
+
+        # Find most recent running run
+        for d in sorted(Path(project_dir).iterdir(), key=lambda d: d.stat().st_mtime, reverse=True):
+            if not d.is_dir() or d.name.startswith((".", "_")):
+                continue
+            meta_file = d / ".raptor-run.json"
+            if meta_file.exists():
+                meta = json.loads(meta_file.read_text())
+                if meta.get("status") == "running":
+                    return str(d), target
+
+    except (OSError, json.JSONDecodeError, KeyError):
+        pass
+
+    return None, None
+
+
+def main():
+    # Find active run via project symlink
+    run_dir, target = _find_active_run()
+    if not run_dir:
+        return
+
+    # Also check env var for target (may be more current)
+    target = os.environ.get("RAPTOR_PROJECT_TARGET", target or "")
+
+    # Read hook payload from stdin
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return
+
+    file_path = payload.get("tool_input", {}).get("file_path", "")
+    if not file_path:
+        return
+
+    # Skip non-source files
+    dot = file_path.rfind(".")
+    if dot == -1 or file_path[dot:].lower() not in _SOURCE_EXTENSIONS:
+        return
+
+    # Skip files outside the target directory
+    if target and not file_path.startswith(target):
+        return
+
+    # Append to manifest
+    try:
+        with open(os.path.join(run_dir, MANIFEST_NAME), "a") as f:
+            f.write(file_path + "\n")
+    except OSError:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/core/run/__main__.py
+++ b/core/run/__main__.py
@@ -55,7 +55,20 @@ def main():
         if len(sys.argv) < 3:
             print("Usage: python3 -m core.run complete <path>", file=sys.stderr)
             sys.exit(1)
-        complete_run(Path(sys.argv[2]))
+        run_path = Path(sys.argv[2])
+        complete_run(run_path)
+        # Convert reads manifest to coverage record if it exists
+        try:
+            from core.coverage.record import build_from_manifest, write_record, cleanup_manifest
+            from core.run.metadata import load_run_metadata
+            meta = load_run_metadata(run_path)
+            tool = meta.get("command", "unknown") if meta else "unknown"
+            record = build_from_manifest(run_path, tool)
+            if record:
+                write_record(run_path, record)
+                cleanup_manifest(run_path)
+        except Exception:
+            pass  # Coverage record is optional — don't fail the complete
 
     elif action == "fail":
         if len(sys.argv) < 3:

--- a/core/startup/launcher.py
+++ b/core/startup/launcher.py
@@ -235,6 +235,11 @@ def main():
     if bin_dir not in path:
         os.environ["PATH"] = f"{path}:{bin_dir}"
 
+    # --- Load plugins ---
+    coverage_plugin = RAPTOR_DIR / "plugins" / "coverage"
+    if coverage_plugin.is_dir():
+        claude_args.extend(["--plugin-dir", str(coverage_plugin)])
+
     # --- Launch Claude Code ---
     if initial_prompt:
         os.execvp("claude", ["claude", initial_prompt] + claude_args)

--- a/plugins/coverage/hooks/hooks.json
+++ b/plugins/coverage/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/libexec/raptor-hook-read",
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/coverage/libexec/raptor-hook-read
+++ b/plugins/coverage/libexec/raptor-hook-read
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# PostToolUse hook for Read — tracks file reads for coverage.
+# Runs async (configured in .claude/settings.json).
+#
+# Finds the active running run via the project symlink, then
+# appends the file path to the run's reads manifest.
+#
+
+umask 077
+
+# Find active project
+ACTIVE_LINK="$HOME/.raptor/projects/.active"
+[ ! -L "$ACTIVE_LINK" ] && exit 0
+
+LINK_TARGET=$(readlink "$ACTIVE_LINK")
+PROJECT_FILE="$HOME/.raptor/projects/$LINK_TARGET"
+[ ! -f "$PROJECT_FILE" ] && exit 0
+
+# Read project output dir and target
+if command -v jq >/dev/null 2>&1; then
+    PROJECT_DIR=$(jq -r '.output_dir // empty' "$PROJECT_FILE" 2>/dev/null)
+    PROJECT_TARGET=$(jq -r '.target // empty' "$PROJECT_FILE" 2>/dev/null)
+else
+    PROJECT_DIR=$(python3 -c "import json,sys;d=json.load(open(sys.argv[1]));print(d.get('output_dir',''))" "$PROJECT_FILE" 2>/dev/null)
+    PROJECT_TARGET=$(python3 -c "import json,sys;d=json.load(open(sys.argv[1]));print(d.get('target',''))" "$PROJECT_FILE" 2>/dev/null)
+fi
+[ -z "$PROJECT_DIR" ] && exit 0
+[ ! -d "$PROJECT_DIR" ] && exit 0
+
+# Find the most recent running run
+RUN_DIR=""
+for d in "$PROJECT_DIR"/*/; do
+    [ -f "${d}.raptor-run.json" ] || continue
+    if command -v jq >/dev/null 2>&1; then
+        STATUS=$(jq -r '.status // empty' "${d}.raptor-run.json" 2>/dev/null)
+    else
+        STATUS=$(python3 -c "import json;print(json.load(open('${d}.raptor-run.json')).get('status',''))" 2>/dev/null)
+    fi
+    [ "$STATUS" = "running" ] && RUN_DIR="$d" && break
+done
+[ -z "$RUN_DIR" ] && exit 0
+
+# Extract file path from hook payload (JSON on stdin)
+if command -v jq >/dev/null 2>&1; then
+    FILE_PATH=$(jq -r '.tool_input.file_path // empty' 2>/dev/null)
+else
+    FILE_PATH=$(python3 -c "import json,sys;print(json.load(sys.stdin).get('tool_input',{}).get('file_path',''))" 2>/dev/null)
+fi
+[ -z "$FILE_PATH" ] && exit 0
+
+# Skip non-source files
+case "${FILE_PATH##*.}" in
+    py|js|ts|jsx|tsx|c|h|cpp|hpp|cc|cxx|java|go|rs|rb|php|cs|swift|kt|scala|sh) ;;
+    *) exit 0 ;;
+esac
+
+# Reject paths with newlines or control characters
+case "$FILE_PATH" in
+    *$'\n'*|*$'\r'*) exit 0 ;;
+esac
+
+# Skip files outside the target directory
+if [ -n "$PROJECT_TARGET" ]; then
+    case "$FILE_PATH" in
+        "$PROJECT_TARGET"*) ;;
+        *) exit 0 ;;
+    esac
+fi
+
+# Append to manifest
+echo "$FILE_PATH" >> "${RUN_DIR}.reads-manifest"

--- a/plugins/coverage/plugin.json
+++ b/plugins/coverage/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "raptor-coverage",
+  "version": "0.1.0",
+  "description": "Track which source files the LLM reads during analysis for coverage reporting"
+}


### PR DESCRIPTION
Coverage Phase 2 prerequisite. Tracks what tools examined for
  accurate coverage reporting.
  
  - plugins/coverage/: Claude Code plugin with async PostToolUse
    hook on Read. Bash+jq, fails fast when no run active. Filters
    by source extension and target directory.
  - core/coverage/: Python package for coverage records. Builds
    coverage-record.json from hook manifest (LLM tools) or Semgrep
    JSON output (paths.scanned).
  - core.run complete converts manifest to record automatically.
  - Launcher auto-loads the plugin via --plugin-dir.
  
  11 files, 445 tests passing. E2E verified.