### PR TITLE
Add shared project-level checklist via symlinks and hash-based skip optimisation

### DIFF
--- a/.claude/skills/code-understanding/map.md
+++ b/.claude/skills/code-understanding/map.md
@@ -180,6 +180,7 @@ checks), then write a small Python script to record them:
 import json, sys, os
 sys.path.insert(0, os.getcwd())  # script is in /tmp but cwd is the raptor repo root
 from core.inventory.coverage import update_coverage
+from core.inventory import save_checklist
 
 workdir = sys.argv[1]
 inv = json.load(open(f"{workdir}/checklist.json"))
@@ -190,7 +191,7 @@ checked = [
     # ... etc
 ]
 update_coverage(inv, checked, "understand:map")
-json.dump(inv, open(f"{workdir}/checklist.json", "w"), indent=2)
+save_checklist(workdir, inv)
 print(f"Recorded {len(checked)} functions as checked by understand:map")
 ```
 

--- a/core/inventory/__init__.py
+++ b/core/inventory/__init__.py
@@ -53,3 +53,41 @@ def get_items(file_entry):
     New format: file_entry["items"] (list of CodeItem dicts with "kind" field)
     """
     return file_entry.get("items", file_entry.get("functions", []))
+
+
+def save_checklist(output_dir, data):
+    """Save checklist.json, resolving symlinks and using file locking.
+
+    In project mode, output_dir/checklist.json is a symlink to the
+    project-level checklist. This function resolves the symlink before
+    writing so the symlink is preserved. Uses fcntl.flock for safe
+    concurrent writes.
+
+    In standalone mode, writes directly to output_dir/checklist.json.
+    """
+    import fcntl
+    from pathlib import Path
+    from core.json import save_json
+
+    checklist_path = Path(output_dir) / "checklist.json"
+
+    # Resolve symlink to write to the real file
+    if checklist_path.is_symlink():
+        checklist_path = checklist_path.resolve()
+
+    # Ensure parent exists
+    checklist_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # File lock for concurrent write safety
+    lock_path = checklist_path.with_suffix(".lock")
+    try:
+        lock_file = open(lock_path, "w")
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        save_json(checklist_path, data)
+    finally:
+        try:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+            lock_file.close()
+            lock_path.unlink(missing_ok=True)
+        except Exception:
+            pass

--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -75,6 +75,17 @@ def build_inventory(
     file_list = _collect_source_files(target, extensions)
     logger.info(f"Found {len(file_list)} source files to process")
 
+    # Load previous inventory for hash-based skip optimisation
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    checklist_file = output_path / 'checklist.json'
+    old_inventory = load_json(checklist_file)
+    old_files_by_path = {}
+    if old_inventory:
+        for f in old_inventory.get('files', []):
+            if f.get('path') and f.get('sha256'):
+                old_files_by_path[f['path']] = f
+
     files_info = []
     excluded_files = []
     total_items = 0
@@ -101,7 +112,8 @@ def build_inventory(
         with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
             futures = {
                 executor.submit(
-                    _process_single_file, fp, target, exclude_patterns, skip_generated
+                    _process_single_file, fp, target, exclude_patterns,
+                    skip_generated, old_files_by_path
                 ): fp
                 for fp in file_list
             }
@@ -110,7 +122,8 @@ def build_inventory(
     else:
         for filepath in file_list:
             _collect_result(
-                _process_single_file(filepath, target, exclude_patterns, skip_generated)
+                _process_single_file(filepath, target, exclude_patterns,
+                                     skip_generated, old_files_by_path)
             )
 
     # Sort for consistent output
@@ -146,11 +159,6 @@ def build_inventory(
         inventory['limitations'] = limitations
 
     # Cumulative coverage: carry forward checked_by from previous inventory
-    output_path = Path(output_dir)
-    output_path.mkdir(parents=True, exist_ok=True)
-    checklist_file = output_path / 'checklist.json'
-
-    old_inventory = load_json(checklist_file)
     if old_inventory is not None:
         try:
             diff = compare_inventories(old_inventory, inventory)
@@ -170,7 +178,8 @@ def build_inventory(
         except (KeyError, TypeError):
             pass  # Incompatible old inventory
 
-    save_json(checklist_file, inventory)
+    from core.inventory import save_checklist
+    save_checklist(str(output_path), inventory)
 
     logger.info(f"Built inventory: {len(files_info)} files, {total_items} items "
                 f"({total_functions} functions, {total_sloc} SLOC, "
@@ -240,8 +249,12 @@ def _process_single_file(
     target: Path,
     exclude_patterns: List[str],
     skip_generated: bool = True,
+    old_files: Dict[str, Any] = None,
 ) -> Optional[Dict[str, Any]]:
     """Process a single file for the inventory.
+
+    If old_files contains an entry for this file with a matching SHA-256,
+    the old entry is returned as-is (skipping tree-sitter parsing).
 
     Returns:
         File info dict, exclusion record (with _excluded flag), or None if skipped.
@@ -271,6 +284,12 @@ def _process_single_file(
 
         line_count = content.count('\n') + 1
         sha256 = hashlib.sha256(content.encode('utf-8')).hexdigest()
+
+        # If file unchanged from previous inventory, reuse old entry (skip parsing)
+        if old_files and rel_path in old_files:
+            old_entry = old_files[rel_path]
+            if old_entry.get('sha256') == sha256:
+                return old_entry
 
         tree_cache = {}
         items = extract_items(str(filepath), language, content, _tree_cache=tree_cache)

--- a/core/inventory/tests/test_shared_checklist.py
+++ b/core/inventory/tests/test_shared_checklist.py
@@ -1,0 +1,186 @@
+"""Tests for project-level shared checklist via symlinks."""
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+# core/inventory/tests/test_shared_checklist.py -> repo root
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from core.inventory import save_checklist
+from core.json import load_json, save_json
+from core.run.metadata import _setup_checklist_symlink, _promote_checklist
+
+
+class TestSaveChecklist(unittest.TestCase):
+
+    def test_saves_to_regular_file(self):
+        with TemporaryDirectory() as d:
+            data = {"files": [], "total_items": 0}
+            save_checklist(d, data)
+            loaded = load_json(Path(d) / "checklist.json")
+            self.assertEqual(loaded["total_items"], 0)
+
+    def test_saves_through_symlink(self):
+        with TemporaryDirectory() as d:
+            project_dir = Path(d) / "project"
+            run_dir = project_dir / "run-001"
+            project_dir.mkdir()
+            run_dir.mkdir()
+
+            # Create project-level checklist
+            save_json(project_dir / "checklist.json", {"files": [], "version": "old"})
+
+            # Create symlink
+            (run_dir / "checklist.json").symlink_to("../checklist.json")
+
+            # Save through symlink
+            save_checklist(str(run_dir), {"files": [], "version": "new"})
+
+            # Symlink should still exist
+            self.assertTrue((run_dir / "checklist.json").is_symlink())
+
+            # Project-level file should be updated
+            loaded = load_json(project_dir / "checklist.json")
+            self.assertEqual(loaded["version"], "new")
+
+    def test_symlink_survives_save(self):
+        with TemporaryDirectory() as d:
+            project_dir = Path(d) / "project"
+            run_dir = project_dir / "run-001"
+            project_dir.mkdir()
+            run_dir.mkdir()
+
+            save_json(project_dir / "checklist.json", {"v": 1})
+            (run_dir / "checklist.json").symlink_to("../checklist.json")
+
+            # Multiple saves through symlink
+            for i in range(3):
+                save_checklist(str(run_dir), {"v": i})
+
+            self.assertTrue((run_dir / "checklist.json").is_symlink())
+            loaded = load_json(project_dir / "checklist.json")
+            self.assertEqual(loaded["v"], 2)
+
+
+class TestSetupChecklistSymlink(unittest.TestCase):
+
+    def test_creates_symlink_in_project_mode(self):
+        with TemporaryDirectory() as d:
+            project_dir = Path(d) / "project"
+            run_dir = project_dir / "run-001"
+            project_dir.mkdir()
+            run_dir.mkdir()
+
+            # Create project JSON and .active symlink
+            projects_dir = Path.home() / ".raptor" / "projects"
+            projects_dir.mkdir(parents=True, exist_ok=True)
+            active_link = projects_dir / ".active"
+
+            # Save/restore state
+            old_link = os.readlink(active_link) if active_link.is_symlink() else None
+
+            save_json(projects_dir / "_test_shared.json", {
+                "name": "_test_shared",
+                "target": "/tmp",
+                "output_dir": str(project_dir),
+            })
+            if active_link.is_symlink() or active_link.exists():
+                active_link.unlink()
+            active_link.symlink_to("_test_shared.json")
+
+            try:
+                _setup_checklist_symlink(run_dir)
+                self.assertTrue((run_dir / "checklist.json").is_symlink())
+                target = os.readlink(run_dir / "checklist.json")
+                self.assertEqual(target, "../checklist.json")
+            finally:
+                (projects_dir / "_test_shared.json").unlink(missing_ok=True)
+                if active_link.is_symlink():
+                    active_link.unlink()
+                if old_link:
+                    active_link.symlink_to(old_link)
+
+    def test_no_symlink_in_standalone_mode(self):
+        with TemporaryDirectory() as d:
+            run_dir = Path(d) / "run-001"
+            run_dir.mkdir()
+
+            # Ensure no active project
+            projects_dir = Path.home() / ".raptor" / "projects"
+            active_link = projects_dir / ".active"
+            old_link = os.readlink(active_link) if active_link.is_symlink() else None
+            if active_link.is_symlink():
+                active_link.unlink()
+
+            old_env = os.environ.pop("RAPTOR_PROJECT_DIR", None)
+            try:
+                _setup_checklist_symlink(run_dir)
+                self.assertFalse((run_dir / "checklist.json").exists())
+            finally:
+                if old_link:
+                    active_link.symlink_to(old_link)
+                if old_env:
+                    os.environ["RAPTOR_PROJECT_DIR"] = old_env
+
+    def test_skips_existing_real_file(self):
+        with TemporaryDirectory() as d:
+            run_dir = Path(d) / "run-001"
+            run_dir.mkdir()
+            (run_dir / "checklist.json").write_text('{"existing": true}')
+
+            # Even if we could detect project mode, existing real file is preserved
+            _setup_checklist_symlink(run_dir)
+            self.assertFalse((run_dir / "checklist.json").is_symlink())
+
+
+class TestPromoteChecklist(unittest.TestCase):
+
+    def test_promotes_newest(self):
+        with TemporaryDirectory() as d:
+            project_dir = Path(d)
+
+            # Create two run dirs with checklists
+            run1 = project_dir / "run-001"
+            run2 = project_dir / "run-002"
+            run1.mkdir()
+            run2.mkdir()
+
+            save_json(run1 / "checklist.json", {
+                "files": [{"path": "a.py", "items": [
+                    {"name": "foo", "kind": "function", "line_start": 1, "checked_by": ["old"]}
+                ]}]
+            })
+            save_json(run2 / "checklist.json", {
+                "files": [{"path": "a.py", "items": [
+                    {"name": "foo", "kind": "function", "line_start": 1, "checked_by": ["new"]}
+                ]}]
+            })
+
+            _promote_checklist(project_dir)
+
+            promoted = load_json(project_dir / "checklist.json")
+            self.assertIsNotNone(promoted)
+
+    def test_no_checklists_does_nothing(self):
+        with TemporaryDirectory() as d:
+            _promote_checklist(Path(d))
+            self.assertFalse((Path(d) / "checklist.json").exists())
+
+    def test_skips_symlinks(self):
+        with TemporaryDirectory() as d:
+            project_dir = Path(d)
+            run1 = project_dir / "run-001"
+            run1.mkdir()
+            # Create a symlink (not a real file) — should be skipped
+            (run1 / "checklist.json").symlink_to("../nonexistent.json")
+
+            _promote_checklist(project_dir)
+            self.assertFalse((project_dir / "checklist.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core/run/metadata.py
+++ b/core/run/metadata.py
@@ -49,7 +49,8 @@ def start_run(output_dir: Path, command: str, extra: Dict[str, Any] = None) -> P
     """Write initial .raptor-run.json with status=running.
 
     Call this at the start of a command. Returns the output_dir (for chaining).
-    Creates the directory if it doesn't exist.
+    Creates the directory if it doesn't exist. In project mode, creates a
+    checklist.json symlink pointing to the project-level checklist.
     """
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -63,7 +64,95 @@ def start_run(output_dir: Path, command: str, extra: Dict[str, Any] = None) -> P
     }
 
     save_json(output_dir / RUN_METADATA_FILE, metadata)
+    _setup_checklist_symlink(output_dir)
     return output_dir
+
+
+def _setup_checklist_symlink(run_dir: Path) -> None:
+    """Create a checklist.json symlink in the run dir pointing to the project-level checklist.
+
+    Only acts in project mode (active project detected via .active symlink or
+    RAPTOR_PROJECT_DIR env var). In standalone mode, does nothing.
+
+    If no project-level checklist exists yet, promotes the newest run-level
+    checklist from sibling run dirs.
+    """
+    import os
+
+    # Determine project output dir
+    project_dir = None
+    try:
+        from core.startup import PROJECTS_DIR, get_active_name
+        name = get_active_name()
+        if name:
+            from core.json import load_json as _load
+            data = _load(PROJECTS_DIR / f"{name}.json")
+            if data:
+                candidate = Path(data.get("output_dir", ""))
+                if candidate.is_dir():
+                    project_dir = candidate
+    except Exception:
+        pass
+
+    if not project_dir:
+        pd = os.environ.get("RAPTOR_PROJECT_DIR")
+        if pd and Path(pd).is_dir():
+            project_dir = Path(pd)
+
+    if not project_dir:
+        return  # Standalone mode
+
+    # Don't create symlink if a real checklist already exists in the run dir
+    checklist_in_run = run_dir / "checklist.json"
+    if checklist_in_run.exists() and not checklist_in_run.is_symlink():
+        return
+
+    # Don't create symlink if it already exists
+    if checklist_in_run.is_symlink():
+        return
+
+    # Promote: if no project-level checklist, find the newest run-level one
+    project_checklist = project_dir / "checklist.json"
+    if not project_checklist.exists():
+        _promote_checklist(project_dir)
+
+    # Create relative symlink: run_dir/checklist.json → ../checklist.json
+    try:
+        checklist_in_run.symlink_to("../checklist.json")
+    except OSError:
+        pass  # Silently skip if symlink creation fails
+
+
+def _promote_checklist(project_dir: Path) -> None:
+    """Copy the newest run-level checklist to the project level.
+
+    Scans sibling run dirs for checklist.json files. Takes the newest
+    and copies it to project_dir/checklist.json, merging checked_by
+    from older checklists.
+    """
+    from core.json import load_json, save_json
+
+    checklists = []
+    for d in sorted(project_dir.iterdir(), key=lambda d: d.stat().st_mtime, reverse=True):
+        if not d.is_dir() or d.name.startswith((".", "_")):
+            continue
+        cl = d / "checklist.json"
+        if cl.exists() and not cl.is_symlink():
+            data = load_json(cl)
+            if data:
+                checklists.append(data)
+
+    if not checklists:
+        return
+
+    # Start with newest, merge checked_by from older ones
+    promoted = checklists[0]
+    if len(checklists) > 1:
+        from core.inventory.builder import _carry_forward_coverage
+        for older in checklists[1:]:
+            _carry_forward_coverage(older, promoted)
+
+    save_json(project_dir / "checklist.json", promoted)
 
 
 def complete_run(output_dir: Path, extra: Dict[str, Any] = None) -> None:

--- a/core/understand_bridge.py
+++ b/core/understand_bridge.py
@@ -136,10 +136,12 @@ def load_understand_context(
     return summary
 
 
-def enrich_checklist(checklist: Dict[str, Any], context_map: Dict[str, Any]) -> Dict[str, Any]:
+def enrich_checklist(checklist: Dict[str, Any], context_map: Dict[str, Any],
+                     output_dir: str = None) -> Dict[str, Any]:
     """Mark entry points and sinks as high-priority in a checklist.
 
     Mutates checklist in place. Returns the checklist for chaining.
+    If output_dir is provided, saves the enriched checklist (symlink-safe).
     """
     if not checklist or not context_map:
         return checklist
@@ -186,6 +188,10 @@ def enrich_checklist(checklist: Dict[str, Any], context_map: Dict[str, Any]) -> 
             "understand_bridge: marked %d unchecked flows as priority targets",
             len(unchecked),
         )
+
+    if output_dir:
+        from core.inventory import save_checklist
+        save_checklist(output_dir, checklist)
 
     return checklist
 

--- a/packages/exploitability_validation/__init__.py
+++ b/packages/exploitability_validation/__init__.py
@@ -84,8 +84,8 @@ def build_checklist(target_path, output_dir, exclude_patterns=None, extensions=N
         if binary_info:
             inventory['binary'] = binary_info
             # Re-save so on-disk checklist.json includes binary info
-            checklist_file = Path(output_dir) / 'checklist.json'
-            save_json(checklist_file, inventory)
+            from core.inventory import save_checklist
+            save_checklist(output_dir, inventory)
     return inventory
 
 

--- a/packages/exploitability_validation/orchestrator.py
+++ b/packages/exploitability_validation/orchestrator.py
@@ -1216,7 +1216,7 @@ class ValidationOrchestrator:
 
         # Save checklist (symlink-safe, with file lock)
         from core.inventory import save_checklist
-        save_checklist(self.state.workdir, self.state.checklist)
+        save_checklist(self.state.config.workdir, self.state.checklist)
         logger.info(f"Created minimal checklist: {len(files)} files from findings")
 
     def _generate_report(self):

--- a/packages/exploitability_validation/orchestrator.py
+++ b/packages/exploitability_validation/orchestrator.py
@@ -1214,8 +1214,9 @@ class ValidationOrchestrator:
             'files': [{'path': f, 'language': 'unknown', 'functions': []} for f in sorted(files)]
         }
 
-        # Save checklist
-        path = self.state.save_json('checklist.json', self.state.checklist)
+        # Save checklist (symlink-safe, with file lock)
+        from core.inventory import save_checklist
+        save_checklist(self.state.workdir, self.state.checklist)
         logger.info(f"Created minimal checklist: {len(files)} files from findings")
 
     def _generate_report(self):


### PR DESCRIPTION
When a project is active, run directories get a checklist.json symlink pointing to the project-level copy. This lets /understand and /validate share a single inventory with cumulative coverage tracking. On the first run in a project, the newest run-level checklist is promoted to project level.

Also adds hash-based skip optimisation: when rebuilding inventory, files with unchanged SHA-256 reuse their previous entry (items, SLOC, checked_by) without re-parsing via tree-sitter.

  - Project-level shared checklist via symlinks: `run/checklist.json → ../checklist.json`                                                                                                                          
  - `save_checklist()` resolves symlinks and uses `fcntl.flock` for safe concurrent writes                                                                                                                         
  - `_promote_checklist()` copies newest run-level checklist to project level on first run                                                                                                                         
  - `build_inventory` reuses file entries when SHA-256 unchanged, avoiding redundant tree-sitter parsing                                                                                   
  - All checklist writers updated (`builder`, `validation`, `orchestrator`, `understand_bridge`, `map.md`)