### PR TITLE
Harden env vars, fix Stage A API, add SessionStart hook, wire up --out

### DIFF
--- a/.claude/agents/exploitability-validator-agent.md
+++ b/.claude/agents/exploitability-validator-agent.md
@@ -148,6 +148,7 @@ For applicable findings:
 4. Update finding with feasibility verdict and constraints
 
 ```python
+import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
 from packages.exploit_feasibility import (
     analyze_binary,
     format_analysis_summary,

--- a/.claude/commands/diagram.md
+++ b/.claude/commands/diagram.md
@@ -50,6 +50,7 @@ Writes `diagrams.md` into the target directory next to the existing JSON files. 
 
 **Library:**
 ```python
+import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
 from packages.diagram import render_and_write
 from pathlib import Path
 

--- a/.claude/commands/exploit.md
+++ b/.claude/commands/exploit.md
@@ -27,6 +27,7 @@ Generate working exploit proof-of-concepts for vulnerabilities.
 Run this first to check if `/validate` has already produced feasibility data:
 
 ```python
+import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
 from packages.exploitation import exploit_bootstrap
 import json
 
@@ -50,6 +51,7 @@ print(json.dumps(result, indent=2, default=str))
 **DO NOT use checksec, readelf, or other tools instead - they miss critical constraints.**
 
 ```python
+import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
 from packages.exploit_feasibility import save_exploit_context, print_exploit_context
 
 # Run analysis and SAVE to persistent file (survives context compaction)
@@ -66,6 +68,7 @@ The `save_exploit_context()` function saves critical data to a JSON file that su
 context window compaction. If the conversation gets long and context is compacted:
 
 ```python
+import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
 from packages.exploit_feasibility import print_exploit_context, load_exploit_context
 
 # Reload after compaction - use the path printed above

--- a/.claude/commands/project.md
+++ b/.claude/commands/project.md
@@ -40,7 +40,7 @@ Run project commands via the Bash tool:
 
 ```bash
 cd "$RAPTOR_DIR" && python3 -c "
-import sys; sys.path.insert(0, '.')
+import sys, os; sys.path.insert(0, os.environ['RAPTOR_DIR'])
 from core.project.cli import main
 main()
 " <subcommand> [args]

--- a/.claude/commands/understand.md
+++ b/.claude/commands/understand.md
@@ -60,10 +60,17 @@ Understanding output feeds into Gadi & JC's epic exploitability validation:
 - `flow-trace-*.json` → confirms reachability for Stage C
 - `variants.json` → expands `checklist.json` scope for Stage 0
 
+**With a project (recommended):** The bridge auto-detects the most recent `/understand` run. Just run both commands — no manual path wiring needed:
 ```
-# Map first, then validate with richer context
+/project use myapp
+/understand ./src --map
+/validate ./src
+```
+
+**Without a project:** Use `--out` on both commands to share a directory. Using a project is recommended — it handles this automatically.
+```
 /understand ./src --map --out .out/my-run/
-/validate ./src --findings .out/my-run/variants.json
+/validate ./src --out .out/my-run/
 ```
 
 ## Skill Files
@@ -89,6 +96,7 @@ All JSON outputs write to `$WORKDIR` (`.out/code-understanding-<timestamp>/` by 
 
 **After writing JSON outputs** for `--map` or `--trace`, generate diagrams:
 ```python
+import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
 from packages.diagram import render_and_write
 from pathlib import Path
 render_and_write(Path(workdir))

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -17,6 +17,7 @@ Validates that vulnerability findings are real, reachable, and exploitable befor
 
 1. **Stage 0 (Python):** Run `build_checklist()` to get inventory
    ```python
+   import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
    from packages.exploitability_validation import build_checklist
    checklist = build_checklist(target_path, output_dir)
    ```
@@ -61,6 +62,7 @@ Validates that vulnerability findings are real, reachable, and exploitable befor
 
 6. **Stage E (Python):** Feasibility - for memory corruption only
    ```python
+   import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
    from packages.exploit_feasibility import analyze_binary
    result = analyze_binary(binary_path, vuln_type='buffer_overflow')
    ```
@@ -77,6 +79,7 @@ Validates that vulnerability findings are real, reachable, and exploitable befor
 
 8. **Stage 1 (Python):** Outputs - CVSS scoring, schema validation, report generation, diagrams
    ```python
+   import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
    from packages.exploitability_validation.report import write_validation_report
    from packages.diagram import render_and_write
    from pathlib import Path
@@ -95,16 +98,17 @@ Validates that vulnerability findings are real, reachable, and exploitable befor
 
 After your analysis, save findings for Stage E:
 ```python
+import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
 from packages.exploitability_validation.schemas import create_finding, create_empty_findings
-import json
+from core.json import save_json
+from pathlib import Path
 
-findings = create_empty_findings("D", target_path)
+findings = create_empty_findings("D", "$TARGET_PATH")  # use the resolved target path
 findings["findings"] = [
-    create_finding("FIND-0001", "/path/file.c", "func_name", 42, "buffer_overflow", "confirmed"),
+    create_finding("FIND-0001", "/path/file.c", "func_name", 42, "buffer_overflow", "confirmed", cwe_id="CWE-120"),
     # ... more findings
 ]
-with open(f"{workdir}/findings.json", "w") as f:
-    json.dump(findings, f, indent=2)
+save_json(Path(workdir) / "findings.json", findings)
 ```
 
 ---
@@ -168,7 +172,7 @@ Semgrep → SARIF (21 findings) → Dedupe (15 unique) → [LLM validation if AP
 ## Usage
 
 ```
-/validate <target_path> [--vuln-type <type>] [--findings <file>] [--binary <path>] [--skip-feasibility]
+/validate <target_path> [--vuln-type <type>] [--findings <file>] [--binary <path>] [--out <dir>] [--skip-feasibility]
 ```
 
 ## Arguments
@@ -179,6 +183,7 @@ Semgrep → SARIF (21 findings) → Dedupe (15 unique) → [LLM validation if AP
 | `--vuln-type` | Focus on specific vulnerability type (optional) |
 | `--findings` | Pre-existing findings.json to validate (skips discovery) |
 | `--binary` | Path to compiled binary for Stage E feasibility analysis |
+| `--out` | Explicit output directory (bypasses project/default resolution) |
 | `--skip-feasibility` | Skip Stage E even for memory corruption vulns |
 
 ## Vulnerability Types
@@ -249,6 +254,7 @@ out/exploitability-validation-20260122-143022/
 For memory corruption findings, Stage E automatically runs binary constraint analysis:
 
 ```python
+import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
 from packages.exploit_feasibility import analyze_binary, save_exploit_context
 
 # Analyzes: PIE, NX, Canary, RELRO, glibc mitigations, ROP gadgets, bad bytes

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "env": {
+    "CLAUDE_ENV_FILE": ".claude/raptor.env",
+    "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": "1",
+    "BASH_DEFAULT_TIMEOUT_MS": "300000"
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/libexec/raptor-session-init\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/code-understanding/map.md
+++ b/.claude/skills/code-understanding/map.md
@@ -173,28 +173,29 @@ Do not populate `sources`, `sinks`, or `entry_points` from file names or common 
 
 After writing `context-map.json`, update the inventory with which functions you examined.
 Build a list of every function you read and analysed (entry points, sinks, trust boundary
-checks), then write a small Python script to record them:
+checks), then run a `python3 -c` snippet to record them:
 
-```python
-# Save as /tmp/record_coverage.py and run: python3 /tmp/record_coverage.py
-import json, sys, os
-sys.path.insert(0, os.getcwd())  # script is in /tmp but cwd is the raptor repo root
+```bash
+python3 -c "
+import sys, os, json
+sys.path.insert(0, os.environ['RAPTOR_DIR'])
 from core.inventory.coverage import update_coverage
+from core.json import save_json
+from pathlib import Path
 
 workdir = sys.argv[1]
-inv = json.load(open(f"{workdir}/checklist.json"))
+inv = json.load(open(f'{workdir}/checklist.json'))
 checked = [
     # Add one entry per function you examined:
-    {"file": "src/routes/query.py", "function": "handle_query"},
-    {"file": "src/db/query.py", "function": "run_query"},
+    {'file': 'src/routes/query.py', 'function': 'handle_query'},
+    {'file': 'src/db/query.py', 'function': 'run_query'},
     # ... etc
 ]
-update_coverage(inv, checked, "understand:map")
-json.dump(inv, open(f"{workdir}/checklist.json", "w"), indent=2)
-print(f"Recorded {len(checked)} functions as checked by understand:map")
+update_coverage(inv, checked, 'understand:map')
+save_json(Path(workdir) / 'checklist.json', inv)
+print(f'Recorded {len(checked)} functions as checked by understand:map')
+" <workdir_path>
 ```
-
-Run via Bash tool: `python3 /tmp/record_coverage.py <workdir_path>`
 
 This ensures coverage tracking is cumulative across `/understand` and `/validate` runs.
 

--- a/.claude/skills/exploit-dev/instructions.md
+++ b/.claude/skills/exploit-dev/instructions.md
@@ -14,6 +14,7 @@ from the mitigation analysis phase. DO NOT re-run reconnaissance commands.
 ### Load Context
 
 ```python
+import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
 from packages.exploit_feasibility import FeasibilityReport, ExploitContext
 
 # Option 1: Load full report
@@ -124,6 +125,7 @@ warnings                - List of exploitation warnings
 
 2. **Load and validate context**
    ```python
+   import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
    ctx = FeasibilityReport.load_context(context_path)
 
    # Check for blockers

--- a/.claude/skills/exploitability-validation/SKILL.md
+++ b/.claude/skills/exploitability-validation/SKILL.md
@@ -48,6 +48,7 @@ output_when_additional:
 5. After writing each JSON output file, validate it against the schema: `from packages.exploitability_validation.schemas import validate_checklist, validate_findings, validate_attack_tree, validate_attack_paths, validate_attack_surface, validate_disproven`.
 6. No finding may reach Stage D without passing through Stages B and C, even if Stage A produced a successful PoC.
 7. Do not narrate gate compliance ("GATE-8 satisfied"), schema validation passes ("findings.json: OK"), or stage transitions ("Stage C complete") to the user. Do show substantive work: PoC test output, tool investigations (objdump, checksec), binary protections, hypothesis results, and evidence discovered. Document gate compliance in validation-report.md only. Report schema or pipeline failures immediately.
+8. **Python imports:** All `python3 -c` snippets must start with `import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])` before importing from `packages.*` or `core.*`.
 
 ---
 

--- a/.claude/skills/exploitability-validation/stage-1-outputs.md
+++ b/.claude/skills/exploitability-validation/stage-1-outputs.md
@@ -21,6 +21,7 @@ INPUT: All output files from Stages 0 through F.
 Generate `validation-report.md` from the pipeline outputs. This also computes CVSS scores from vectors and writes them back to findings.json:
 
 ```python
+import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
 from packages.exploitability_validation.report import write_validation_report
 
 report_path = write_validation_report(output_dir)
@@ -39,6 +40,7 @@ The LLM does not write this file — it is assembled mechanically from JSON data
 Validate findings.json against the pipeline schema:
 
 ```python
+import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
 from packages.exploitability_validation.schemas import validate_findings
 import json
 
@@ -84,6 +86,7 @@ This is the only non-mechanical step. Keep it to 1-2 sentences. The report shoul
 Display the findings summary in chat:
 
 ```python
+import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
 from packages.exploitability_validation.report import generate_summary
 
 print(generate_summary(output_dir))

--- a/.claude/skills/exploitability-validation/stage-a-oneshot.md
+++ b/.claude/skills/exploitability-validation/stage-a-oneshot.md
@@ -81,6 +81,47 @@ THEN route based on outcome:
 
 This enforces GATE-1 (ASSUME-EXPLOIT) - lazy dismissal is not allowed.
 
+## Writing findings.json
+
+Use the helper functions. **Do not pass extra keyword arguments to `create_finding`** beyond those in its signature — populate sub-structures on the returned dict afterwards. `cwe_id=` is accepted as an optional keyword argument; provide it whenever a CWE maps to the vuln type.
+
+```python
+import sys, os
+sys.path.insert(0, os.environ["RAPTOR_DIR"])
+from packages.exploitability_validation.schemas import create_finding, create_empty_findings
+from core.json import save_json
+from pathlib import Path
+
+workdir = "$OUTPUT_DIR"  # the run output directory
+
+findings = create_empty_findings("A", target_path="/tmp/vulns", vuln_type="buffer_overflow")
+
+# create_finding signature: (finding_id, file, function, line, vuln_type, status, cwe_id=None)
+# status must be: "poc_success", "not_disproven", or "disproven"
+f = create_finding("FIND-0001", "01_buffer_overflow.c", "main", 6, "buffer_overflow", "not_disproven",
+                   cwe_id="CWE-120")
+
+# Populate sub-structures AFTER creation:
+f["confidence"] = "high"
+f["candidate_reasoning"] = "strcpy with unbounded argv input into fixed-size stack buffer"
+f["dataflow_summary"] = "argv[1] -> strcpy -> buf[16] (no bounds check)"
+f["proof"] = {
+    "vulnerable_code": "strcpy(buf, argv[1]);",
+    "source": "argv[1] (attacker-controlled CLI argument)",
+    "sink": "strcpy into char buf[16] on stack"
+}
+f["poc"] = {
+    "description": "Trigger crash with oversized argument",
+    "payload": "./01 $(python3 -c \"print('A'*32)\")",
+    "result": "Segmentation fault (stack smash)",
+    "harmless": True
+}
+# For disproven findings, set f["disproved_because"] = { "investigated": ..., "conclusion": ..., "would_reconsider_if": ... }
+
+findings["findings"].append(f)
+save_json(Path(workdir) / "findings.json", findings)
+```
+
 ## Output
 
 OUTPUT: `findings.json`

--- a/.claude/skills/exploitability-validation/stage-e-feasibility.md
+++ b/.claude/skills/exploitability-validation/stage-e-feasibility.md
@@ -77,6 +77,7 @@ For each applicable finding:
 ### [E-2] Run Feasibility Analysis
 
 ```python
+import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
 from packages.exploit_feasibility import (
     analyze_binary,
     save_exploit_context,
@@ -84,11 +85,11 @@ from packages.exploit_feasibility import (
     map_findings_to_constraints,
 )
 
-# Run binary analysis
-result = analyze_binary(binary_path, vuln_type=finding.vuln_type)
+# Run binary analysis — output_dir ensures results go to the run directory
+result = analyze_binary(binary_path, output_dir=output_dir, vuln_type=finding.vuln_type)
 
 # Save context (survives conversation compaction)
-context_file = save_exploit_context(binary_path)
+context_file = save_exploit_context(binary_path, output_dir=output_dir)
 
 # Load context for mapper
 constraints = load_exploit_context(context_file)
@@ -99,6 +100,7 @@ constraints = load_exploit_context(context_file)
 Use `map_findings_to_constraints()` to get per-finding feasibility instead of generic exploitation paths:
 
 ```python
+import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
 # findings: list of Stage D confirmed findings
 # constraints: output of load_exploit_context()
 mapped = map_findings_to_constraints(findings, constraints)
@@ -269,6 +271,7 @@ Proceeding with info leak approach...
 The `context_file` from `save_exploit_context()` survives conversation compaction. Reference it in exploit development:
 
 ```python
+import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
 from packages.exploit_feasibility import load_exploit_context
 
 ctx = load_exploit_context(finding.feasibility.context_file)

--- a/.claude/skills/exploitation/post-exploitation-report.md
+++ b/.claude/skills/exploitation/post-exploitation-report.md
@@ -152,6 +152,7 @@ Human-readable report combining both. Structure:
 Use the reporting module:
 
 ```python
+import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
 from packages.exploitation.reporting import ExploitReport
 
 report = ExploitReport(target="/path/to/target", output_dir="out/exploitability-validation-xxx")

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ out/
 # Local
 .env*
 .claude/*.local.json
+.claude/raptor.env
 
 # Runtime artifacts
 codeql_dbs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,9 +67,9 @@ When running any analysis command (`/scan`, `/validate`, `/understand`, `/codeql
 
 **Before starting work:**
 ```bash
-OUTPUT_DIR=$(python3 -m core.run start <command> --target <resolved_target>)
+OUTPUT_DIR=$(python3 -m core.run start <command> --target <resolved_target> [--out <dir>])
 ```
-Always pass `--target` with the resolved target path (see DEFAULT TARGET DIRECTORY for resolution order). This creates the output directory, writes `.raptor-run.json` with `status: running`, and prints the path.
+Always pass `--target` with the resolved target path (see DEFAULT TARGET DIRECTORY for resolution order). Optionally pass `--out <dir>` to use a specific output directory (bypasses project/default resolution — useful for sharing a directory between `/understand` and `/validate` without a project). This creates the output directory, writes `.raptor-run.json` with `status: running`, and prints the path.
 **Use `$OUTPUT_DIR` for all output files.** Do not construct output paths manually.
 
 **After successful completion:**

--- a/bin/raptor
+++ b/bin/raptor
@@ -36,5 +36,6 @@ if [[ "${1:-}" != "project" ]]; then
 fi
 
 export RAPTOR_CALLER_DIR="$(pwd)"
+export RAPTOR_DIR
 cd "$RAPTOR_DIR" || { echo "raptor: cannot cd to $RAPTOR_DIR" >&2; exit 1; }
 exec python3 -m core.startup.launcher "$@"

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -217,6 +217,14 @@ def main():
             if args.name == "none":
                 prev = mgr.get_active()
                 mgr.set_active(None)
+                # Clear env vars so sync_project_env_file removes them from CLAUDE_ENV_FILE
+                for key in ("RAPTOR_PROJECT_DIR", "RAPTOR_PROJECT_NAME", "RAPTOR_PROJECT_TARGET"):
+                    os.environ.pop(key, None)
+                try:
+                    from core.startup import sync_project_env_file
+                    sync_project_env_file()
+                except Exception:
+                    pass
                 if prev:
                     print(f"Cleared active project: {prev}")
                 else:

--- a/core/run/__main__.py
+++ b/core/run/__main__.py
@@ -30,11 +30,12 @@ def main():
 
     if action == "start":
         if len(sys.argv) < 3:
-            print("Usage: python3 -m core.run start <command> [--target <path>]",
+            print("Usage: python3 -m core.run start <command> [--target <path>] [--out <dir>]",
                   file=sys.stderr)
             sys.exit(1)
         command = sys.argv[2]
         target_path = None
+        explicit_out = None
         if "--target" in sys.argv:
             idx = sys.argv.index("--target")
             if idx + 1 < len(sys.argv):
@@ -42,8 +43,12 @@ def main():
         elif len(sys.argv) > 3 and not sys.argv[3].startswith("--"):
             # Accept positional target: python3 -m core.run start <command> <target>
             target_path = sys.argv[3]
+        if "--out" in sys.argv:
+            idx = sys.argv.index("--out")
+            if idx + 1 < len(sys.argv):
+                explicit_out = sys.argv[idx + 1]
         try:
-            out_dir = get_output_dir(command, target_path=target_path)
+            out_dir = get_output_dir(command, target_path=target_path, explicit_out=explicit_out)
         except TargetMismatchError as e:
             print(f"error: {e}", file=sys.stderr)
             sys.exit(1)

--- a/core/run/output.py
+++ b/core/run/output.py
@@ -4,12 +4,15 @@ Centralises the logic for choosing where a command writes its output.
 Checks (in order): explicit --out argument, active project, default out/ dir.
 """
 
+import logging
 import os
 import time
 from pathlib import Path
 from typing import Optional, Tuple
 
 from core.config import RaptorConfig
+
+logger = logging.getLogger(__name__)
 
 
 class TargetMismatchError(ValueError):
@@ -70,6 +73,9 @@ def get_output_dir(command: str, target_name: str = "", explicit_out: str = None
         TargetMismatchError: If target_path is outside the active project's target.
     """
     if explicit_out:
+        active = _resolve_active_project()
+        if active:
+            logger.warning("--out overrides active project '%s' output directory", active[1])
         return Path(explicit_out).resolve()
 
     active = _resolve_active_project()

--- a/core/startup/__init__.py
+++ b/core/startup/__init__.py
@@ -37,15 +37,20 @@ def sync_project_env_file():
         return
 
     lines = [l for l in existing.splitlines()
-             if not l.startswith("export RAPTOR_PROJECT_")]
+             if not l.startswith(("export RAPTOR_PROJECT_", "unset RAPTOR_PROJECT_"))]
 
     project_dir = os.environ.get("RAPTOR_PROJECT_DIR")
+    def _sh(v):
+        return v.replace('\\', '\\\\').replace('"', '\\"')
     if project_dir:
-        def _sh(v):
-            return v.replace('\\', '\\\\').replace('"', '\\"')
         lines.append(f'export RAPTOR_PROJECT_DIR="{_sh(project_dir)}"')
         lines.append(f'export RAPTOR_PROJECT_NAME="{_sh(os.environ.get("RAPTOR_PROJECT_NAME", ""))}"')
         lines.append(f'export RAPTOR_PROJECT_TARGET="{_sh(os.environ.get("RAPTOR_PROJECT_TARGET", ""))}"')
+    else:
+        # Override stale vars inherited from the parent process
+        lines.append('unset RAPTOR_PROJECT_DIR')
+        lines.append('unset RAPTOR_PROJECT_NAME')
+        lines.append('unset RAPTOR_PROJECT_TARGET')
 
     try:
         env_path.write_text("\n".join(lines) + "\n" if lines else "")

--- a/core/startup/init.py
+++ b/core/startup/init.py
@@ -205,12 +205,18 @@ def setup_env_file():
     env_file = os.environ.get("CLAUDE_ENV_FILE")
     if not env_file:
         return
+    repo_root = str(REPO_ROOT)
     bin_dir = str(REPO_ROOT / "bin")
     try:
         existing = Path(env_file).read_text() if Path(env_file).exists() else ""
+        additions = []
         if bin_dir not in existing:
+            additions.append(f'export PATH="$PATH:{bin_dir}"')
+        if "RAPTOR_DIR" not in existing:
+            additions.append(f'export RAPTOR_DIR="{repo_root}"')
+        if additions:
             with open(env_file, "a") as f:
-                f.write(f'export PATH="$PATH:{bin_dir}"\n')
+                f.write("\n".join(additions) + "\n")
     except OSError:
         pass
 

--- a/core/startup/tests/test_env_file.py
+++ b/core/startup/tests/test_env_file.py
@@ -1,0 +1,58 @@
+"""Tests for setup_env_file (CLAUDE_ENV_FILE integration)."""
+
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from core.startup.init import setup_env_file
+
+
+class TestSetupEnvFile(unittest.TestCase):
+
+    def test_writes_raptor_dir(self):
+        with TemporaryDirectory() as d:
+            env_file = Path(d) / "env"
+            os.environ["CLAUDE_ENV_FILE"] = str(env_file)
+            try:
+                setup_env_file()
+                content = env_file.read_text()
+                self.assertIn("RAPTOR_DIR", content)
+                self.assertIn("PATH", content)
+            finally:
+                os.environ.pop("CLAUDE_ENV_FILE", None)
+
+    def test_no_env_file_does_nothing(self):
+        os.environ.pop("CLAUDE_ENV_FILE", None)
+        # Should not raise
+        setup_env_file()
+
+    def test_idempotent(self):
+        with TemporaryDirectory() as d:
+            env_file = Path(d) / "env"
+            os.environ["CLAUDE_ENV_FILE"] = str(env_file)
+            try:
+                setup_env_file()
+                first = env_file.read_text()
+                setup_env_file()
+                second = env_file.read_text()
+                self.assertEqual(first, second)
+            finally:
+                os.environ.pop("CLAUDE_ENV_FILE", None)
+
+    def test_preserves_existing_content(self):
+        with TemporaryDirectory() as d:
+            env_file = Path(d) / "env"
+            env_file.write_text('export FOO="bar"\n')
+            os.environ["CLAUDE_ENV_FILE"] = str(env_file)
+            try:
+                setup_env_file()
+                content = env_file.read_text()
+                self.assertIn('FOO="bar"', content)
+                self.assertIn("RAPTOR_DIR", content)
+            finally:
+                os.environ.pop("CLAUDE_ENV_FILE", None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/libexec/raptor-session-init
+++ b/libexec/raptor-session-init
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""SessionStart hook: ensure RAPTOR env vars are in CLAUDE_ENV_FILE.
+
+Called automatically by Claude Code on session start (via .claude/settings.json).
+Sets RAPTOR_DIR, PATH, and syncs project vars from the .active symlink.
+"""
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.startup.init import setup_env_file
+from core.startup import get_active_name, sync_project_env_file
+
+# Write RAPTOR_DIR and PATH
+setup_env_file()
+
+# Sync project vars from symlink (not from stale env vars)
+active = get_active_name()
+if active:
+    from core.project.project import ProjectManager
+    mgr = ProjectManager()
+    project = mgr.load(active)
+    if project:
+        os.environ["RAPTOR_PROJECT_DIR"] = project.output_dir
+        os.environ["RAPTOR_PROJECT_NAME"] = project.name
+        os.environ["RAPTOR_PROJECT_TARGET"] = project.target
+    else:
+        for key in ("RAPTOR_PROJECT_DIR", "RAPTOR_PROJECT_NAME", "RAPTOR_PROJECT_TARGET"):
+            os.environ.pop(key, None)
+else:
+    for key in ("RAPTOR_PROJECT_DIR", "RAPTOR_PROJECT_NAME", "RAPTOR_PROJECT_TARGET"):
+        os.environ.pop(key, None)
+
+sync_project_env_file()

--- a/packages/exploitability_validation/schemas.py
+++ b/packages/exploitability_validation/schemas.py
@@ -673,7 +673,8 @@ def create_finding(
     function: str,
     line: int,
     vuln_type: str,
-    status: str = "not_disproven"
+    status: str = "not_disproven",
+    cwe_id: str | None = None,
 ) -> dict:
     """Create a valid finding structure.
 
@@ -689,6 +690,7 @@ def create_finding(
         line=line,
         vuln_type=vuln_type,
         status=status,
+        cwe_id=cwe_id,
     ).to_dict()
 
 


### PR DESCRIPTION
**Summary**                                                                                                                                                                                                       
                                         
  - Fix recurring Stage A `TypeError` with correct `create_finding` example and `cwe_id` kwarg                                                                                                                     
  - Harden all prompt Python snippets to use `os.environ["RAPTOR_DIR"]` — no cwd fallback
  - Add SessionStart hook (`libexec/raptor-session-init`) that syncs RAPTOR_DIR, PATH, and                                                                                                                         
    project vars from the `.active` symlink — works for both launcher and direct `claude` users
  - Set `CLAUDE_ENV_FILE`, `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR`, and                                                                                                                                         
    `BASH_DEFAULT_TIMEOUT_MS` via `.claude/settings.json`                                                                                                                                                          
  - Fix stale project env vars after `project use none` (`unset` in env file)                                                                                                                                      
  - Wire up `--out` in run lifecycle CLI for non-project understand→validate workflows                                                                                                                             
  - Replace predictable `/tmp/record_coverage.py` with inline snippet                                                                                                                                              
  - Fix shell quoting and Stage E `output_dir` parameter                                                                                                                                                           
  - Update understand.md bridge docs for project vs `--out` workflows                                                                                                                                              
                                                                                                                                                                                                                   
**Test plan**                                              
                                                                                                                                                                                                                   
  - 168 tests pass (run, project, startup suites)                                                                                                                                                              
  - E2E: `project use none` → env vars cleared in subsequent Bash calls
  - E2E: `/validate /tmp/vulns` — Stage A writes findings.json without TypeError                                                                                                                               
  - E2E: `raptor-session-init` syncs project vars correctly (active and cleared)                                                                                                                               
  - E2E: direct `claude` session — RAPTOR_DIR available after SessionStart hook                                                                                                                                
  - E2E: `/understand --map` then `/validate` with `--out` (non-project mode)      