### PR TITLE
Restructure validation pipeline with mechanical scripts and per-stage JSON

### DIFF
--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -8,221 +8,113 @@ Validates that vulnerability findings are real, reachable, and exploitable befor
 
 ## Execution Model
 
-**You (Claude) ARE the LLM for this pipeline.** Don't just run Python and expect results - you must perform the analysis work.
+**You (Claude) ARE the LLM for this pipeline.** You perform the analysis work in LLM stages (A-D, F). Mechanical stages (0, E, 1) run via Python/libexec scripts.
 
-### Step-by-Step Execution
+**Data flow:** Each stage writes a small `stage-X.json` file with only its own output. The prep script merges it into the cumulative `findings.json` and deletes the stage file. Claude never reads or writes findings.json directly.
 
-**All stages are mandatory. Execute in sequence: 0 → A → B → C → D → E → F → 1**
-(Stage E only applies to memory corruption vulnerabilities. All others are mandatory.)
+**Prep script:** Before each LLM stage, run the prep script which merges the previous stage's output, validates, and sets up the current stage:
 
-1. **Stage 0 (Python):** Run `build_checklist()` to get inventory
-   ```python
-   import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
-   from packages.exploitability_validation import build_checklist
-   checklist = build_checklist(target_path, output_dir)
-   ```
-   Output: `{output_dir}/checklist.json` (saved automatically)
-
-2. **Stage A (Claude):** One-shot analysis - identify potential vulnerabilities
-   - Read source files with the Read tool
-   - Look for: injection, overflow, UAF, format string, deserialization, etc.
-   - For each finding, note: file, line, function, vuln_type, proof (actual code)
-   - Output: `findings.json` with status "pending" or "not_disproven"
-
-3. **Stage B (Claude):** Process - systematic analysis with attack trees
-   - Build attack surface: sources, sinks, trust boundaries → `attack-surface.json`
-   - Build attack tree: knowledge graph of attack paths → `attack-tree.json`
-   - Form hypotheses: testable predictions for each finding → `hypotheses.json`
-   - Test hypotheses: gather evidence, verify predictions
-   - Track failures: why approaches didn't work → `disproven.json`
-   - Track proximity: how close to exploitation (0-10 scale) → `attack-paths.json`
-
-   **Stage B produces 5 working documents that MUST be created:**
-   ```
-   attack-surface.json  - Sources, sinks, trust boundaries
-   attack-tree.json     - Attack knowledge graph
-   hypotheses.json      - Testable predictions (status: testing/confirmed/disproven)
-   disproven.json       - Failed approaches and why
-   attack-paths.json    - Paths tried, PROXIMITY scores, blockers
-   ```
-
-4. **Stage C (Claude):** Sanity check - verify against actual code
-   - Confirm file exists at stated path
-   - Confirm vulnerable code exists at stated line (VERBATIM)
-   - Confirm source→sink flow is real
-   - Confirm code is reachable (called from main/handler)
-   - Output: Update `findings.json` with `sanity_check` field
-
-5. **Stage D (Claude):** Ruling - make final determinations
-   - Rule out test code, dead code, already-mitigated code
-   - Check for preconditions that prevent exploitation
-   - Apply hypothesis results from Stage B
-   - Final status: Exploitable, Confirmed, or Ruled Out
-   - Output: Update `findings.json` with `ruling` and `final_status` fields
-
-6. **Stage E (Python):** Feasibility - for memory corruption only
-   ```python
-   import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
-   from packages.exploit_feasibility import analyze_binary
-   result = analyze_binary(binary_path, vuln_type='buffer_overflow')
-   ```
-   Output: `exploit-context.json` (if binary provided)
-
-7. **Stage F (Claude):** Self-review - catch mistakes before finalizing
-   - Verify Stage E verdicts mapped correctly to final_status
-   - Check proximity score consistency across same bug class
-   - Verify all preconditions cite evidence (line numbers, grep results)
-   - Check CVSS vector accuracy (AV, C/I/A reflect inherent impact)
-   - Ask: "What did I get wrong?" — look for misclassifications, missed instances, weak evidence
-   - Fix any issues found, add `stage_f_review` field to corrected findings
-   - **Do not write validation-report.md** — Stage 1 generates it
-
-8. **Stage 1 (Python):** Outputs - CVSS scoring, schema validation, report generation, diagrams
-   ```python
-   import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
-   from packages.exploitability_validation.report import write_validation_report
-   from packages.diagram import render_and_write
-   from pathlib import Path
-   write_validation_report(output_dir)
-   render_and_write(Path(output_dir))
-   ```
-   Then read `{output_dir}/validation-report.md` and add a 1-2 sentence summary paragraph
-   after the `# Exploitability Validation Report` header — e.g., "All 3 buffer overflows are
-   real and reachable. 2 are directly exploitable; the third is constrained by RELRO." Use only
-   facts from the findings data. The report should stand on its own without this paragraph.
-
-   Finally, read `{output_dir}/summary.txt` using the Read tool and output its contents verbatim.
-   Output: `validation-report.md`, findings summary displayed in chat
-
-### Write Results Back
-
-After your analysis, save findings for Stage E:
-```python
-import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
-from packages.exploitability_validation.schemas import create_finding, create_empty_findings
-from core.json import save_json
-from pathlib import Path
-
-findings = create_empty_findings("D", "$TARGET_PATH")  # use the resolved target path
-findings["findings"] = [
-    create_finding("FIND-0001", "/path/file.c", "func_name", 42, "buffer_overflow", "confirmed", cwe_id="CWE-120"),
-    # ... more findings
-]
-save_json(Path(workdir) / "findings.json", findings)
+```bash
+libexec/raptor-prepare-validation-stage <A|B|C|D|E|F> "$OUTPUT_DIR" [--target "$TARGET_PATH"]
 ```
+
+**All stages are mandatory. Execute in sequence: 0 → A → B → C → D → E → F → 1.**
+Stage E only applies to memory corruption vulnerabilities. All others are mandatory.
+
+### Stage 0 (Python): Inventory
+
+```bash
+libexec/raptor-prepare-validation-stage 0 --target "$TARGET_PATH"
+```
+
+This starts the run lifecycle and builds the checklist. The last line of output is `OUTPUT_DIR=<path>` — use that path for all subsequent stages.
+
+### Stage A (Claude): One-Shot Assessment
+
+1. **Prep:** `libexec/raptor-prepare-validation-stage A "$OUTPUT_DIR" --target "$TARGET_PATH"`
+   Discovers binaries, builds PoCs for standalone C files (mitigations disabled, in `$OUTPUT_DIR/build/`).
+2. **Reasoning:** Read source files, assess each function for vulnerabilities. If binaries are available (from prep output), run them for PoC evidence. If no binaries, do source-only analysis.
+3. **Output:** Write `stage-a.json` — full findings array with origin + stage_a_summary
+
+**Carry-forward:** Each finding MUST include `origin` and `stage_a_summary` — downstream stages and the prep script check for these.
+
+### Stage B (Claude): Systematic Analysis
+
+1. **Prep:** `libexec/raptor-prepare-validation-stage B "$OUTPUT_DIR" --target "$TARGET_PATH"`
+   Merges stage-a.json into findings.json. Fast-paths poc_success findings. Reports how many need full analysis.
+2. **Reasoning:** Build attack surface, form hypotheses with value-level predictions, test them, track proximity (0-10 scale). Only analyse findings without `stage_b_summary` (fast-pathed findings already have it).
+3. **Output:** Write 5 working docs directly + `stage-b.json` (per-finding updates with stage_b_summary)
+
+**Why Stage B matters:** Without it, you'd make rulings on gut feel with no audit trail. Stage B forces evidence-backed hypotheses, tracks what was tried and failed (`disproven.json`), and measures how close to exploitation (PROXIMITY). Even "obvious" false positives need a tested hypothesis — sometimes they turn out exploitable.
+
+### Stage C (Claude): Sanity Check
+
+1. **Prep:** `libexec/raptor-prepare-validation-stage C "$OUTPUT_DIR" --target "$TARGET_PATH"`
+   Merges stage-b.json, validates 6 working docs, pre-checks findings against inventory.
+2. **Reasoning:** Open each file, verify code verbatim, confirm source→sink flows are real, confirm reachability
+3. **Output:** Write `stage-c.json` (per-finding sanity_check + stage_c_summary)
+
+### Stage D (Claude): Ruling
+
+1. **Prep:** `libexec/raptor-prepare-validation-stage D "$OUTPUT_DIR" --target "$TARGET_PATH"`
+   Merges stage-c.json, flags test/mock paths, assembles evidence cards from carry-forward.
+2. **Reasoning:** Synthesize evidence from A/B/C, apply disqualifier checks (D-0 through D-4), assign CVSS vectors
+3. **Output:** Write `stage-d.json` (per-finding ruling, cvss_vector, stage_d_summary)
+
+### Stage E (Claude + Python): Feasibility — memory corruption only
+
+1. **Prep:** `libexec/raptor-prepare-validation-stage E "$OUTPUT_DIR" --target "$TARGET_PATH"`
+   Merges stage-d.json, validates Stage D output, auto-discovers binaries in the target directory.
+2. **Analysis:** For each binary group found by prep, run feasibility:
+   ```bash
+   libexec/raptor-run-feasibility <binary_path> "$OUTPUT_DIR/findings.json" "$OUTPUT_DIR"
+   ```
+   This analyzes the binary, maps constraints to findings, and updates findings.json.
+
+3. **Output:** Findings are updated automatically with feasibility verdicts and `final_status`:
+
+| Feasibility Verdict | `final_status` |
+|---------------------|----------------|
+| likely / likely_exploitable | `exploitable` |
+| difficult | `confirmed_constrained` |
+| unlikely | `confirmed_blocked` |
+| not_applicable | `confirmed` (unchanged) |
+| binary_not_found | `confirmed_unverified` |
+
+Skip Stage E if `--skip-feasibility` or no memory corruption findings.
+
+### Stage F (Claude): Self-Review
+
+1. **Prep:** `libexec/raptor-prepare-validation-stage F "$OUTPUT_DIR"`
+   Merges stage-e.json, maps verdicts to final_status, computes CVSS scores, checks consistency.
+2. **Reasoning:** Review all findings — misclassifications, weak evidence, CVSS accuracy, missed instances. Ask: "What did I get wrong?"
+3. **Output:** Write `stage-f.json` (per-finding corrections + stage_f_summary). **Do not write validation-report.md** — Stage 1 generates it.
+
+### Stage 1 (Python): Report Generation
+
+```bash
+libexec/raptor-prepare-validation-stage 1 "$OUTPUT_DIR"
+```
+
+This generates the validation report, diagrams, CVSS scores, and completes the run lifecycle. The summary table is printed to stdout.
+
+Then read `{output_dir}/validation-report.md` and add a 1-2 sentence summary paragraph
+after the `# Exploitability Validation Report` header — e.g., "All 3 buffer overflows are
+real and reachable. 2 are directly exploitable; the third is constrained by RELRO." Use only
+facts from the findings data.
 
 ---
-
-## Agentic vs Non-Agentic Mode
-
-| Mode | Context | How Validation Works |
-|------|---------|---------------------|
-| **Non-Agentic** | `/validate` in Claude Code | Claude (you) performs Stages A-D directly by reading code |
-| **Agentic** | `python3 raptor.py agentic` | Semgrep/CodeQL scan first → SARIF converted → deduplication or LLM API validation |
-
-### Non-Agentic Mode (Claude Code)
-
-When user runs `/validate <path>`:
-1. **You are the LLM** - perform the analysis yourself
-2. Run Stage 0 via Python (inventory) → `checklist.json`
-3. Stage A: Read files, identify vulnerabilities → `findings.json`
-4. **Stage B: Build attack trees, form & test hypotheses** → 5 working docs
-5. Stage C: Verify findings against actual code
-6. Stage D: Make rulings + select CVSS vectors
-7. Run Stage E via Python if binary provided
-8. Stage F: Self-review — catch misclassifications, correct vectors/rulings
-9. Run Stage 1 via Python — CVSS scoring, schema validation, report generation, display summary
-
-```
-User: /validate /tmp/vuln
-       ↓
-Claude: Stage 0 → Stage A → Stage B → Stage C → Stage D → Stage E → Stage F → Stage 1
-              ↓
-        Output: checklist.json, findings.json, attack-surface.json,
-                attack-tree.json, hypotheses.json, disproven.json,
-                attack-paths.json, validation-report.md
-```
-
-### Agentic Mode (Python Orchestration)
-
-When user runs `python3 raptor.py agentic --repo <path>`:
-1. **Semgrep/CodeQL scan first** - produces SARIF files
-2. **SARIF conversion** - deduplicates findings
-3. **If LLM API available** - runs full validation pipeline via API calls
-4. **If no LLM API** - deduplication only, skips validation theater
-5. **Stage E** - runs if binary provided
-
-```
-python3 raptor.py agentic --repo /tmp/vuln
-       ↓
-Semgrep → SARIF (21 findings) → Dedupe (15 unique) → [LLM validation if API key] → Stage E
-```
-
-### Key Difference
-
-| Aspect | Non-Agentic | Agentic |
-|--------|-------------|---------|
-| Scanner | None (Claude analyzes directly) | Semgrep + CodeQL |
-| LLM | Claude (always available) | External API (optional) |
-| Findings source | Claude's analysis | SARIF from scanners |
-| Without LLM API | Always works | Deduplication only |
-
----
-
-## Usage
-
-```
-/validate <target_path> [--vuln-type <type>] [--findings <file>] [--binary <path>] [--out <dir>] [--skip-feasibility]
-```
-
-## Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `target_path` | Directory or file to analyze |
-| `--vuln-type` | Focus on specific vulnerability type (optional) |
-| `--findings` | Pre-existing findings.json to validate (skips discovery) |
-| `--binary` | Path to compiled binary for Stage E feasibility analysis |
-| `--out` | Explicit output directory (bypasses project/default resolution) |
-| `--skip-feasibility` | Skip Stage E even for memory corruption vulns |
-
-## Vulnerability Types
-
-- `command_injection` - OS command injection
-- `sql_injection` - SQL injection
-- `xss` - Cross-site scripting
-- `path_traversal` - Directory traversal
-- `ssrf` - Server-side request forgery
-- `deserialization` - Insecure deserialization
-- `buffer_overflow` - Buffer overflow (memory corruption)
-- `format_string` - Format string vulnerabilities
-
-## What This Does
-
-Runs a 7-stage validation pipeline:
-
-| Stage | Purpose | Output |
-|-------|---------|--------|
-| **0: Inventory** | Build checklist of all code | checklist.json |
-| **A: One-Shot** | Quick exploitability + PoC attempt | findings.json |
-| **B: Process** | Systematic analysis with attack trees | working docs |
-| **C: Sanity** | Verify against actual code (catch hallucinations) | validated findings |
-| **D: Ruling** | Filter test code, preconditions, hedging | confirmed findings |
-| **E: Feasibility** | Binary constraint analysis (memory corruption only) | final findings |
-| **F: Review** | Self-review — catch misclassifications, schema errors | updated outputs |
-
-**Note:** Stage E only runs for memory corruption vulnerabilities (buffer_overflow, format_string, use_after_free, etc.). Web vulnerabilities skip E and proceed directly to F.
 
 ## Examples
 
 ```bash
-# Scan a web application for command injection
-/validate ./webapp --vuln-type command_injection
-
 # Validate all vulnerability types in a codebase
 /validate ./src
 
-# Validate pre-existing scanner findings
+# Focus on a specific vulnerability type
+/validate ./webapp --vuln-type command_injection
+
+# Validate pre-existing scanner findings (skips Stage A discovery)
 /validate ./src --findings scanner-results.json
 
 # Validate memory corruption with binary path for Stage E
@@ -230,72 +122,16 @@ Runs a 7-stage validation pipeline:
 
 # Skip feasibility analysis even for memory corruption
 /validate ./vuln_app --vuln-type buffer_overflow --skip-feasibility
+
+# Use explicit output directory (e.g. shared with /understand)
+/validate ./src --out out/shared-run/
 ```
-
-## Output
-
-Results saved to `out/exploitability-validation-<timestamp>/` (or `$RAPTOR_OUT_DIR`):
-
-```
-out/exploitability-validation-20260122-143022/
-├── checklist.json           # All functions to check
-├── findings.json            # Final validated findings
-├── attack-tree.json         # Attack knowledge graph
-├── hypotheses.json          # Tested hypotheses
-├── disproven.json           # Failed approaches
-├── attack-paths.json        # Paths tried + PROXIMITY
-├── attack-surface.json      # Sources, sinks, boundaries
-├── exploit-context.json     # Binary context (Stage E, if applicable)
-└── validation-report.md     # Human-readable summary
-```
-
-## Stage E: Exploit Feasibility Integration
-
-For memory corruption findings, Stage E automatically runs binary constraint analysis:
-
-```python
-import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
-from packages.exploit_feasibility import analyze_binary, save_exploit_context
-
-# Analyzes: PIE, NX, Canary, RELRO, glibc mitigations, ROP gadgets, bad bytes
-# Returns: verdict (Likely/Difficult/Unlikely) + chain breaks + recommendations
-result = analyze_binary(binary_path, vuln_type='format_string')
-context_file = save_exploit_context(binary_path)  # Survives context compaction
-```
-
-**Final Status After Stage E:**
-
-| Verdict | Final Status | Meaning |
-|---------|--------------|---------|
-| Likely | Exploitable | Clear path to code execution |
-| Difficult | Confirmed (Constrained) | Primitives exist but hard to chain |
-| Unlikely | Confirmed (Blocked) | No viable path with current mitigations |
-| N/A | Confirmed | Web/injection vuln (Stage E skipped) |
-
-## Stage B: Systematic Analysis
-
-Stage B is where superficial scanning becomes thorough validation:
-
-| Without Stage B | With Stage B |
-|-----------------|--------------|
-| Quick ruling based on gut feel | Evidence-backed ruling from tested hypotheses |
-| "Looks like a false positive" | "Hypothesis H2 disproven: ws:// only in comment (evidence: line 463)" |
-| No record of what was tried | `disproven.json` documents failed approaches |
-| No proximity tracking | PROXIMITY scores show how close to exploitation |
-
-**If you're tempted to skip Stage B because findings "obviously" look like false positives:**
-1. Create the hypothesis anyway (e.g., "H1: SSRF via urlretrieve")
-2. List testable predictions (e.g., "P1.1: Script runs at runtime")
-3. Gather evidence to disprove (e.g., "Script outputs .h file → build-time only")
-4. Record in `disproven.json` with lesson learned
-
-This creates an audit trail and catches cases where "obvious" false positives are actually exploitable.
 
 ---
 
 ## MUST-GATEs
 
-This command enforces strict validation gates:
+This command enforces strict validation gates. Full definitions are in `.claude/skills/exploitability-validation/SKILL.md` — read it before starting.
 
 1. **ASSUME-EXPLOIT**: Investigate as if exploitable until proven otherwise
 2. **STRICT-SEQUENCE**: Follow methodology, additional ideas presented separately

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,15 @@
     "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": "1",
     "BASH_DEFAULT_TIMEOUT_MS": "300000"
   },
+  "permissions": {
+    "allow": [
+      "Bash(libexec/raptor-prepare-validation-stage *)",
+      "Bash(libexec/raptor-run-feasibility *)",
+      "Bash(libexec/raptor-validate-schema *)",
+      "Write(/out/**)",
+      "Edit(/out/**)"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/.claude/skills/exploitability-validation/SKILL.md
+++ b/.claude/skills/exploitability-validation/SKILL.md
@@ -45,10 +45,17 @@ output_when_additional:
 2. Solve and fix any issues you encounter, unless you failed five times in a row, or need clarification.
 3. Run on latest thinking/reasoning model available (verify model name).
 4. Pipeline must be deterministic - if ran again, results should be the same.
-5. After writing each JSON output file, validate it against the schema: `from packages.exploitability_validation.schemas import validate_checklist, validate_findings, validate_attack_tree, validate_attack_paths, validate_attack_surface, validate_disproven`.
+5. **Validate after writing.** Run `libexec/raptor-validate-schema <type> <file>` after each Write. Match the type to what you wrote:
+   - `stage` for any `stage-*.json` file (e.g., `stage-a.json`, `stage-c.json`, `stage-f.json`)
+   - `attack-tree`, `attack-paths`, `attack-surface`, `hypotheses`, `disproven` for the matching working doc
+
+   Fix any errors before proceeding to the next stage.
 6. No finding may reach Stage D without passing through Stages B and C, even if Stage A produced a successful PoC.
 7. Do not narrate gate compliance ("GATE-8 satisfied"), schema validation passes ("findings.json: OK"), or stage transitions ("Stage C complete") to the user. Do show substantive work: PoC test output, tool investigations (objdump, checksec), binary protections, hypothesis results, and evidence discovered. Document gate compliance in validation-report.md only. Report schema or pipeline failures immediately.
 8. **Python imports:** All `python3 -c` snippets must start with `import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])` before importing from `packages.*` or `core.*`.
+9. **Build directory:** Stage 0 creates `$OUTPUT_DIR/build/`. Compile PoCs and test binaries there, not in the target repo.
+10. **libexec scripts:** Run `libexec/` scripts exactly as shown in the prompts — do not prepend `export` commands, do not use absolute paths, do not wrap in additional shell logic. The permission system auto-approves `libexec/raptor-*` commands only when run in this exact form.
+11. **Per-stage JSON files.** Write your stage's output to `stage-X.json` (e.g., `stage-a.json`, `stage-b.json`), not to `findings.json`. The prep script merges stage files into findings.json automatically. Do not read or write findings.json directly. Do not use `python3 -c` scripts for JSON — use the Write tool.
 
 ---
 
@@ -108,22 +115,23 @@ Title Case is for human-readable display (chat output, validation-report.md, ter
 
 **All stages execute in sequence. No stage may be skipped.** The only exception is Stage E, which only applies to memory corruption vulnerabilities.
 
-Letter stages (A-F) are LLM reasoning from the exploitation-validator methodology. Numeric stages (0, E, 1) are mostly mechanical. See `PIPELINE.md` for the full convention.
+Each stage has up to three phases: **X0** (mechanical prep), **X** (LLM reasoning), **X1** (mechanical validation). Run X0 and X1 via Python snippets in the stage prompt. The X phases are your reasoning work.
 
-| Stage | Type | Purpose | Gates | Output |
-|-------|------|---------|-------|--------|
-| **0** | Mostly mechanical | Build ground truth checklist | - | checklist.json |
-| **A** | LLM | Quick exploitability + PoC | 1, 4, 6, 7, 8 | findings.json |
-| **B** | LLM | Systematic analysis, attack trees | All (1-8) | 5 working docs |
-| **C** | LLM | Validate against actual code | 3, 5, 6 | validated findings.json |
-| **D** | LLM | Ruling + CVSS vector selection | 3, 5, 6, 7 | confirmed findings.json |
-| **E** | Mostly mechanical | Binary constraint analysis | 6 | exploit-context.json |
-| **F** | LLM | Self-review (what did I get wrong?) | 7 | corrected findings.json |
-| **1** | Mostly mechanical | CVSS scoring, schema validation, report | - | validation-report.md |
+| Stage | X0 (prep) | X (reasoning) | X1 (validation) |
+|-------|-----------|---------------|-----------------|
+| **0** | - | Build inventory | - |
+| **A** | Load checklist + existing findings | Vuln assessment + PoC | Dedup flag + schema check |
+| **B** | Load findings + attack surface | Hypotheses, attack trees | Schema check all 5 docs |
+| **C** | Checklist lookup (file+line) | Code verification | Schema check + pass/fail count |
+| **D** | Test/mock pre-filter + evidence card | Ruling + CVSS vectors | Schema check + counts |
+| **E** | Group by binary | Per-binary analysis + mapping | Verdict → status mapping |
+| **F** | CVSS scoring + consistency checks | Self-review + corrections | - |
+| **1** | - | - | Recompute CVSS, report |
 
 **Notes:**
 - Stage E only applies to memory corruption vulnerabilities. Web/injection vulns skip E.
-- Stage 1 computes CVSS scores from vectors (after any Stage F corrections), validates schemas, and generates the report. It never changes verdicts.
+- Stage 1 recomputes CVSS scores from final vectors (after any Stage F corrections), validates schemas, and generates the report. It never changes verdicts.
+- Each stage writes a `stage_X_summary` onto each finding (carry-forward). Later stages read the finding object instead of cross-referencing multiple files.
 
 See stage-specific files for detailed instructions.
 
@@ -144,50 +152,43 @@ See stage-specific files for detailed instructions.
 ## Flow
 
 ```
-STAGE 0:  [Mostly mechanical]  Inventory
+STAGE 0:  Inventory
           │
           ▼ checklist.json
           │
-STAGE A:  [LLM]    One-Shot Analysis
+STAGE A:  A0 load checklist ─► A assess+PoC ─► A1 dedup+validate
           │
-          ▼ findings.json (status: pending/not_disproven)
+          ▼ findings.json (+ origin, stage_a_summary)
           │
-STAGE B:  [LLM]    Process
+STAGE B:  B0 load findings ─► B hypotheses+trees ─► B1 validate 5 docs
           │
-          ├─► attack-surface.json
-          ├─► attack-tree.json
-          ├─► hypotheses.json
-          ├─► disproven.json
-          └─► attack-paths.json
+          ▼ findings.json (+ stage_b_summary), working docs
           │
-          ▼
-STAGE C:  [LLM]    Sanity (file exists? code verbatim? reachable?)
+STAGE C:  C0 checklist lookup ─► C verify code ─► C1 validate
           │
-          ▼ findings.json (sanity_check added)
+          ▼ findings.json (+ sanity_check, stage_c_summary)
           │
-STAGE D:  [LLM]    Ruling (status, CVSS vector)
+STAGE D:  D0 test filter+evidence card ─► D ruling+CVSS ─► D1 validate
           │
-          ▼ findings.json (ruling, cvss_vector)
+          ▼ findings.json (+ ruling, cvss_vector, stage_d_summary)
           │
      ┌────┴────┐
      │         │
-     ▼         ▼
   Memory    Web/Injection
   Corruption    │
      │          │
-     ▼          │
 STAGE E:        │
-[Mostly mech]   │
-Feasibility     │
+  E0 group ─► E analyze ─► E1 verdict map
      │          │
      └────┬─────┘
           │
-          ▼
-STAGE F:  [LLM]    Self-Review (what did I get wrong?)
+          ▼ findings.json (+ feasibility, stage_e_summary, final_status)
           │
-          ▼ corrected findings.json
+STAGE F:  F0 CVSS scores+checks ─► F review+correct ─► findings.json
           │
-STAGE 1:  [Mostly mechanical]  Outputs (CVSS scoring, validation, report)
+          ▼ findings.json (+ stage_f_summary)
+          │
+STAGE 1:  Recompute CVSS, validate, report
           │
           ▼ validation-report.md
 ```

--- a/.claude/skills/exploitability-validation/stage-1-outputs.md
+++ b/.claude/skills/exploitability-validation/stage-1-outputs.md
@@ -6,94 +6,28 @@ user-invocable: false
 
 # [STAGE-1] Output Generation
 
-Terminal stage. Runs after all reasoning (Stages A-F) is complete. Never changes verdicts. Mostly mechanical (Python computation) with optional light enrichment.
-
-**Error handling:** Run each step independently. If report generation fails, still display the summary. If schema validation fails, still generate the report. The summary table ([1-5]) should always be displayed unless findings.json itself is missing.
-
-## Input
-
-INPUT: All output files from Stages 0 through F.
+Terminal stage. Runs after all reasoning (Stages A-F) is complete.
 
 ## Task
 
-### [1-1] Generate Validation Report
+### [1-0] Run the prep script
 
-Generate `validation-report.md` from the pipeline outputs. This also computes CVSS scores from vectors and writes them back to findings.json:
-
-```python
-import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
-from packages.exploitability_validation.report import write_validation_report
-
-report_path = write_validation_report(output_dir)
+```bash
+libexec/raptor-prepare-validation-stage 1 "$OUTPUT_DIR"
 ```
 
-The function:
-- Loads findings.json
-- Computes CVSS scores from vectors (final computation, after any Stage F corrections)
-- Writes computed scores back to findings.json
-- Assembles the full report: header, summary table, findings table, per-finding details, environment constraints, Stage F review, output file listing
+This merges `stage-f.json`, recomputes CVSS scores from final vectors, generates `validation-report.md` and `diagrams.md`, prints the findings summary, and completes the run lifecycle.
 
-The LLM does not write this file — it is assembled mechanically from JSON data. If findings.json is edited and Stage 1 re-run, the report regenerates correctly.
+### [1-1] Enrich Report
 
-### [1-2] Schema Validation
+Read the generated `validation-report.md`. Add a brief summary paragraph after the `# Exploitability Validation Report` header — e.g., "All 4 vulnerabilities are real and reachable. 2 are directly exploitable; the others are constrained by modern mitigations."
 
-Validate findings.json against the pipeline schema:
+Keep it to 1-2 sentences. Use only facts from the findings data. The report should stand on its own without this paragraph.
 
-```python
-import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
-from packages.exploitability_validation.schemas import validate_findings
-import json
+### [1-2] Display Summary
 
-data = json.load(open(f"{output_dir}/findings.json"))
-valid, errors = validate_findings(data)
-if not valid:
-    print(f"Schema errors: {errors}")
-```
-
-If errors are found, fix them and re-validate. Common issues:
-- `ruling.status` must be snake_case (`confirmed`, not `Confirmed`)
-- `vuln_type` must be in the schema enum (`null_deref` not `null_dereference`, `race_condition` not `toctou`)
-- Top-level target field: schema expects `target_path`, not `target`
-
-Report any unfixable errors.
-
-### [1-3] Final File Check
-
-Verify all expected output files exist:
-
-```
-checklist.json           Stage 0
-findings.json            Stages A-F (final)
-attack-surface.json      Stage B
-attack-tree.json         Stage B
-hypotheses.json          Stage B
-disproven.json           Stage B
-attack-paths.json        Stage B
-exploit-context.json     Stage E (if applicable)
-validation-report.md     Stage 1
-```
-
-Report any missing files.
-
-### [1-4] Enrich Report
-
-Read the generated `validation-report.md`. If the findings warrant it, add a brief summary paragraph after the header — e.g., "All 4 vulnerabilities are real and reachable. 2 are directly exploitable; the others are constrained by modern mitigations."
-
-This is the only non-mechanical step. Keep it to 1-2 sentences. The report should stand on its own without this paragraph.
-
-### [1-5] Display Summary
-
-Display the findings summary in chat:
-
-```python
-import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
-from packages.exploitability_validation.report import generate_summary
-
-print(generate_summary(output_dir))
-```
-
-This shows the "Results at a Glance" findings table and status counts.
+**GATE: VERBATIM OUTPUT.** Read `$OUTPUT_DIR/summary.txt` using the Read tool and copy its ENTIRE contents into your response exactly as-is. This is a mechanical copy — no editing, no reformatting, no column removal, no paraphrasing. If the table has 7 columns, your output must have 7 columns. If you produce a table with fewer columns than summary.txt, you have violated this gate.
 
 ## Output
 
-OUTPUT: Validated `findings.json` (with computed CVSS scores), `validation-report.md` (with optional summary), file inventory confirmation, **and the findings table displayed in chat**.
+OUTPUT: `validation-report.md` (with summary paragraph), findings table displayed in chat.

--- a/.claude/skills/exploitability-validation/stage-a-oneshot.md
+++ b/.claude/skills/exploitability-validation/stage-a-oneshot.md
@@ -20,13 +20,29 @@ INPUT: `checklist.json`
 
 Quick initial assessment: Can we immediately prove or disprove exploitability?
 
+## Prep (mechanical)
+
+Load the checklist, discover binaries, and build PoCs for standalone C files:
+
+```bash
+libexec/raptor-prepare-validation-stage A "$OUTPUT_DIR" --target "$TARGET_PATH"
+```
+
+The prep script:
+- Loads checklist.json and any pre-existing findings
+- Builds standalone C/C++ files with mitigations disabled into `$OUTPUT_DIR/build/` (skips if a build system like Makefile exists)
+- Discovers existing binaries in the target and build directories
+- Prints available binaries for PoC testing
+
+If binaries are available, use them for PoC evidence (crash output, leak output). If no binaries, do source-only analysis — the proof is in the code.
+
 ## Task
 
 **Pre-existing data:** If `findings.json` already exists, treat pre-existing entries as prioritised candidates. Re-assess all pre-existing findings against the current code — they may be stale. All gates still apply.
 
 DO:
 1. For each function in checklist.json, assess for target vulnerability type
-2. For promising candidates, attempt to verify exploitability
+2. For promising candidates, attempt to verify exploitability — run the binary from `$OUTPUT_DIR/build/` or the target directory if available
 3. Build a harmless PoC exploit for each verified finding
 
 THEN route based on outcome:
@@ -81,50 +97,35 @@ THEN route based on outcome:
 
 This enforces GATE-1 (ASSUME-EXPLOIT) - lazy dismissal is not allowed.
 
-## Writing findings.json
+## Writing stage-a.json
 
-Use the helper functions. **Do not pass extra keyword arguments to `create_finding`** beyond those in its signature — populate sub-structures on the returned dict afterwards. `cwe_id=` is accepted as an optional keyword argument; provide it whenever a CWE maps to the vuln type.
+Write `$OUTPUT_DIR/stage-a.json` using the Write tool. The next stage's prep script merges it into findings.json automatically.
 
-```python
-import sys, os
-sys.path.insert(0, os.environ["RAPTOR_DIR"])
-from packages.exploitability_validation.schemas import create_finding, create_empty_findings
-from core.json import save_json
-from pathlib import Path
-
-workdir = "$OUTPUT_DIR"  # the run output directory
-
-findings = create_empty_findings("A", target_path="/tmp/vulns", vuln_type="buffer_overflow")
-
-# create_finding signature: (finding_id, file, function, line, vuln_type, status, cwe_id=None)
-# status must be: "poc_success", "not_disproven", or "disproven"
-f = create_finding("FIND-0001", "01_buffer_overflow.c", "main", 6, "buffer_overflow", "not_disproven",
-                   cwe_id="CWE-120")
-
-# Populate sub-structures AFTER creation:
-f["confidence"] = "high"
-f["candidate_reasoning"] = "strcpy with unbounded argv input into fixed-size stack buffer"
-f["dataflow_summary"] = "argv[1] -> strcpy -> buf[16] (no bounds check)"
-f["proof"] = {
-    "vulnerable_code": "strcpy(buf, argv[1]);",
-    "source": "argv[1] (attacker-controlled CLI argument)",
-    "sink": "strcpy into char buf[16] on stack"
+The format for stage-a.json is:
+```json
+{
+  "stage": "A",
+  "target_path": "$TARGET_PATH",
+  "findings": [
+    {... full finding objects ...}
+  ]
 }
-f["poc"] = {
-    "description": "Trigger crash with oversized argument",
-    "payload": "./01 $(python3 -c \"print('A'*32)\")",
-    "result": "Segmentation fault (stack smash)",
-    "harmless": True
-}
-# For disproven findings, set f["disproved_because"] = { "investigated": ..., "conclusion": ..., "would_reconsider_if": ... }
-
-findings["findings"].append(f)
-save_json(Path(workdir) / "findings.json", findings)
 ```
+
+Do not put target code in string values — use `proof_lines` instead. Read proof from source files by line range.
+
+**Field reference:**
+- `vuln_type` must use canonical values: `command_injection`, `sql_injection`, `xss`, `path_traversal`, `ssrf`, `deserialization`, `buffer_overflow`, `heap_overflow`, `stack_overflow`, `format_string`, `use_after_free`, `double_free`, `integer_overflow`, `out_of_bounds_read`, `out_of_bounds_write`, `null_deref`, `type_confusion`, `race_condition`, `memory_leak`, `uninitialized_memory`, `hardcoded_secret`, `weak_crypto`, `other`. Common aliases are accepted and normalised automatically (e.g., `toctou` → `race_condition`, `null_dereference` → `null_deref`, `uaf` → `use_after_free`).
+- `cwe_id`: prefer the root-cause CWE over the consequence CWE (e.g., CWE-806 "buffer access using size of source buffer" over CWE-787 "out-of-bounds write" when the bug is a wrong-size argument to strncpy).
+- `proof_lines`: `[start, end]` — 1-indexed, inclusive. Used to extract `proof.vulnerable_code` from the source file.
+- `proof_source` / `proof_sink`: Your analysis of where input comes from and where it's used unsafely.
+- `disproved_because`: Required when status is `disproven` — include `investigated`, `conclusion`, `would_reconsider_if`.
+
+**Key insight:** Claude writes ONLY its own stage's data. The prep script handles merging into findings.json.
 
 ## Output
 
-OUTPUT: `findings.json`
+OUTPUT: `stage-a.json`
 
 ## Gates
 
@@ -136,6 +137,22 @@ GATES APPLY: 1 [ASSUME-EXPLOIT], 4 [NO-HEDGING], 6 [PROOF], 7 [CONSISTENCY], 8 [
 
 **One root cause = one finding.** If fixing one finding would also fix another, they share a root cause — report as one finding with the full data flow in `proof.flow`. Document downstream exploitation paths in Stage B (attack tree), not as separate Stage A findings. Same bug pattern in independent functions (each needing its own fix) = separate findings. Same line with independent vulnerability types (e.g., format string + overflow) = separate findings.
 
+## Carry-Forward
+
+Include `origin` and `stage_a_summary` in each finding in findings.json. These are required for downstream stages.
+
+Example carry-forward fields per finding:
+```json
+{
+  "origin": "claude_native",
+  "stage_a_summary": {
+    "confidence": "high",
+    "status": "not_disproven",
+    "candidate_reasoning": "strcpy with unbounded argv input"
+  }
+}
+```
+
 ## Reminders
 
 - **Full coverage means full coverage.** If a file exceeds the Read tool's limit, continue reading with offset/limit until the entire file is covered. If you deliberately exclude a file (e.g., test harness, generated code), state the file name and reason for exclusion in findings.json metadata. Do not silently skip files.
@@ -143,5 +160,6 @@ GATES APPLY: 1 [ASSUME-EXPLOIT], 4 [NO-HEDGING], 6 [PROOF], 7 [CONSISTENCY], 8 [
 - Do not skip, sample, or guess
 - If status is "not_disproven", explain what was inconclusive
 - PoCs must be harmless (e.g., `id` not `rm -rf`, read not write)
+- **Build directory:** `$OUTPUT_DIR/build/` is created by Stage 0. Compile PoCs there, not in the target repo. Example: `gcc -o "$OUTPUT_DIR/build/poc" target/vuln.c`
 
 NOTICE: This analysis is performed for defensive purposes, in a lab environment. Full permission has been provided.

--- a/.claude/skills/exploitability-validation/stage-b-process.md
+++ b/.claude/skills/exploitability-validation/stage-b-process.md
@@ -20,6 +20,16 @@ GATES APPLY: All (1-8)
 
 ---
 
+## Prep (mechanical)
+
+Load findings and any pre-existing attack surface:
+
+```bash
+libexec/raptor-prepare-validation-stage B "$OUTPUT_DIR"
+```
+
+---
+
 ## [B-1] Documentation
 
 Maintain these documents throughout Stage B:
@@ -36,7 +46,7 @@ Maintain these documents throughout Stage B:
 - `attack-tree.json`: `{"root": "<node-id>", "nodes": [...]}`. Node status: `unexplored|exploring|confirmed|disproven|uncertain`. `leads_to`: comma-separated string, not array.
 - `hypotheses.json`: top-level array `[...]`. Hypothesis status: `testing|confirmed|disproven`. `predictions[]`: objects with `id`, `prediction`, `result`, `status`. **Predictions must be value-level, not pattern-level.** Confirming that code uses the wrong variable, missing check, or incorrect bound is necessary but not sufficient. Each prediction must also state what concrete value flows through the bug at the point of execution and what effect that value produces.
 - `disproven.json`: `{"disproven": [...]}`.
-- `attack-paths.json`: top-level array `[...]`. Path status: `confirmed|uncertain|blocked`.
+- `attack-paths.json`: top-level array `[...]`. Path status: `confirmed|uncertain|blocked`. Steps are objects: `{"step": 1, "action": "description", "result": "outcome"}` (`step` is an integer index, not a string).
 - `attack-surface.json`: `{"sources": [...], "sinks": [...], "trust_boundaries": [...]}`.
 
 **Value-level prediction examples:**
@@ -75,7 +85,17 @@ Track how close to successful exploitation. Ask: "How close did I come?" Log ans
 
 ---
 
+## [B-2.5] Fast Path (mechanical — done by prep script)
+
+The prep script automatically creates hypotheses, attack-path entries, and `stage_b_summary` for findings where Stage A produced `poc_success` with `high` confidence and observable evidence. These findings already have their audit trail — **do not re-analyse them**.
+
+The prep output tells you how many findings were fast-pathed and how many need full analysis. **Only analyse findings that do NOT already have `stage_b_summary` set.** Check each finding before starting work on it.
+
+---
+
 ## [B-3] Exploitability Validation Process
+
+**Applies to findings WITHOUT `stage_b_summary` only.** Skip findings that the prep script already handled.
 
 IMPORTANT: For every step below, check and update documentation.
 
@@ -117,9 +137,28 @@ For every finding that is not far-fetched, provide a full, end-to-end, step-by-s
 
 ---
 
+## Carry-Forward
+
+After analyzing all findings, write `$OUTPUT_DIR/stage-b.json` using the Write tool. The next stage's prep script merges it into findings.json automatically.
+
+The format for stage-b.json is:
+```json
+{
+  "stage": "B",
+  "updates": {
+    "FIND-0001": {"stage_b_summary": {"hypothesis_id": "H1", "hypothesis_status": "confirmed", "proximity": 8, "attack_path_id": "AP-001"}},
+    ...
+  }
+}
+```
+
+**Key insight:** Claude writes ONLY its own stage's data (stage-b.json). The prep script handles merging into findings.json. The five working docs (attack-tree.json, hypotheses.json, disproven.json, attack-paths.json, attack-surface.json) are still written directly.
+
+---
+
 ## Output
 
-OUTPUT: Updated `findings.json`, `attack-tree.json`, `hypotheses.json`, `disproven.json`, `attack-paths.json`, `attack-surface.json`
+OUTPUT: `stage-b.json`, `attack-tree.json`, `hypotheses.json`, `disproven.json`, `attack-paths.json`, `attack-surface.json`
 
 ## Reminders
 

--- a/.claude/skills/exploitability-validation/stage-c-sanity.md
+++ b/.claude/skills/exploitability-validation/stage-c-sanity.md
@@ -20,6 +20,18 @@ GATES APPLY: 3 [CHECKLIST], 5 [FULL-COVERAGE], 6 [PROOF]
 
 ---
 
+## Prep (mechanical)
+
+Pre-check all findings against the inventory:
+
+```bash
+libexec/raptor-prepare-validation-stage C "$OUTPUT_DIR"
+```
+
+Findings where `checklist_verified` is false have already failed — investigate the path/line mismatch before proceeding with reasoning checks.
+
+---
+
 ## Task
 
 CRITICAL: Open each file. Read the actual line. Verify verbatim. Do not rely on memory.
@@ -69,31 +81,49 @@ For each finding:
 
 ---
 
-## Output
+## Carry-Forward
 
-Update findings.json with sanity_check results:
+After verifying all findings, write `$OUTPUT_DIR/stage-c.json` using the Write tool. The next stage's prep script merges it into findings.json automatically.
 
+Use `verified_code_lines` instead of `verified_code` — read the code from the source file by line range.
+
+The format for stage-c.json is:
 ```json
 {
-  "findings": [
-    {
-      "id": "FIND-001",
+  "stage": "C",
+  "updates": {
+    "FIND-0001": {
       "sanity_check": {
-        "passed": true|false,
-        "file_exists": true|false,
-        "path_correct": true|false,
-        "code_verbatim": true|false,
-        "flow_real": true|false,
-        "code_reachable": true|false,
-        "issues": ["list of any problems found"],
-        "verified_code": "actual code from file"
+        "passed": true,
+        "file_exists": true,
+        "code_verbatim": true,
+        "flow_real": true,
+        "code_reachable": true,
+        "verified_code_lines": [4, 9],
+        "issues": []
+      },
+      "stage_c_summary": {
+        "passed": true,
+        "checks": {
+          "file_exists": true,
+          "code_verbatim": true,
+          "flow_real": true,
+          "reachable": true
+        }
       }
-    }
-  ]
+    },
+    ...
+  }
 }
 ```
 
-OUTPUT: Updated `findings.json`
+**Key insight:** Claude writes ONLY its own stage's data. The prep script handles merging into findings.json.
+
+---
+
+## Output
+
+OUTPUT: `stage-c.json`
 
 ---
 

--- a/.claude/skills/exploitability-validation/stage-d-ruling.md
+++ b/.claude/skills/exploitability-validation/stage-d-ruling.md
@@ -20,6 +20,19 @@ GATES APPLY: 3 [CHECKLIST], 5 [FULL-COVERAGE], 6 [PROOF]
 
 ---
 
+## Prep (mechanical)
+
+Pre-filter test/mock files and assemble evidence cards:
+
+```bash
+libexec/raptor-prepare-validation-stage D "$OUTPUT_DIR"
+```
+
+Findings flagged by `test_code_flag` are candidates for D-1 disqualification — confirm or override during your analysis.
+Findings with carry-forward summaries have pre-assembled evidence cards in `ruling.evidence_synthesis` — complete the `synthesis` field.
+
+---
+
 ## Task
 
 For each finding that passed Stage C, first synthesize evidence from earlier stages, then check disqualifiers.
@@ -52,6 +65,21 @@ Finding is part of:
 - [ ] Commented-out code
 
 **Note:** Distinguish between "test code" (unit tests, integration tests that verify functionality) and "test data" (sample inputs, fixtures, intentionally vulnerable code for security tool testing). Test DATA that contains real vulnerable patterns should NOT be excluded - it represents realistic attack surfaces.
+
+---
+
+## [D-1.5] PRIVILEGE TAUTOLOGY
+
+Does the exploit require privileges that already imply the outcome?
+
+Examples:
+- Root reading a file → not a vulnerability (root already has file access)
+- Admin modifying config → not a vulnerability (admin privilege implies config control)
+- Authenticated user accessing their own data → not a vulnerability
+
+**Exempt:** Auth bypass findings where the privilege IS what's being bypassed. The outcome (access without auth) differs from what the privilege implies.
+
+If the tautology holds → RULE OUT with `disqualifier: "D-1.5"`.
 
 ---
 
@@ -184,9 +212,9 @@ The numeric score is computed by Python (`packages.cvss.compute_base_score`). Do
 }
 ```
 
-OUTPUT: Final `findings.json`
+OUTPUT: `stage-d.json`
 
-**After ruling, update each finding's top-level `status` field to match `ruling.status`.** All findings in the output must have a consistent status — do not leave Stage A statuses on findings that now have rulings.
+**After ruling, include the updated `status` field in each finding's update so the prep script can sync it.** All findings in the merged output must have a consistent status — do not leave Stage A statuses on findings that now have rulings.
 
 ---
 
@@ -199,6 +227,40 @@ The final findings.json after Stage D should contain only confirmed findings wit
 4. No disqualifiers
 
 This becomes the input for exploit feasibility analysis and/or exploit development.
+
+---
+
+## Carry-Forward
+
+After ruling all findings, write `$OUTPUT_DIR/stage-d.json` using the Write tool. The next stage's prep script merges it into findings.json automatically.
+
+The format for stage-d.json is:
+```json
+{
+  "stage": "D",
+  "updates": {
+    "FIND-0001": {
+      "ruling": {
+        "status": "confirmed",
+        "disqualifier": null,
+        "reason": null,
+        "evidence_synthesis": {...},
+        "checks": {...}
+      },
+      "cvss_vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "status": "confirmed",
+      "stage_d_summary": {
+        "ruling": "confirmed",
+        "disqualifier": null,
+        "cvss_vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      }
+    },
+    ...
+  }
+}
+```
+
+**Key insight:** Claude writes ONLY its own stage's data. The prep script handles merging into findings.json.
 
 ---
 

--- a/.claude/skills/exploitability-validation/stage-e-feasibility.md
+++ b/.claude/skills/exploitability-validation/stage-e-feasibility.md
@@ -28,27 +28,33 @@ Stage E bridges this gap by invoking the `exploit_feasibility` package.
 
 ## Applicability
 
-Stage E applies ONLY to memory corruption vulnerability types:
+Stage E applies ONLY to memory corruption vulnerability types. Do not decide this yourself — use the mechanical check:
 
-| Applies | Vulnerability Type |
-|---------|-------------------|
-| YES | buffer_overflow |
-| YES | heap_overflow |
-| YES | stack_overflow |
-| YES | format_string |
-| YES | use_after_free |
-| YES | double_free |
-| YES | integer_overflow (leading to memory corruption) |
-| YES | out_of_bounds_read |
-| YES | out_of_bounds_write |
-| NO | command_injection |
-| NO | sql_injection |
-| NO | xss |
-| NO | path_traversal |
-| NO | ssrf |
-| NO | deserialization (unless native) |
+```python
+from core.schema_constants import needs_feasibility_analysis
 
-For non-applicable types, copy finding to output unchanged with `feasibility: "not_applicable"`.
+for finding in findings:
+    if needs_feasibility_analysis(finding["vuln_type"]):
+        # Run Stage E analysis
+    else:
+        finding["feasibility"] = {"status": "not_applicable"}
+```
+
+The canonical set is `MEMORY_CORRUPTION_TYPES` in `core/schema_constants.py`. Do not maintain a separate list.
+
+---
+
+## Prep (mechanical)
+
+Validate Stage D output, discover binaries, and group findings:
+
+```bash
+libexec/raptor-prepare-validation-stage E "$OUTPUT_DIR" --target "$TARGET_PATH"
+```
+
+This validates the previous stage, scans the target for executables matching source files, sets `feasibility.binary_path` on each finding, and groups them by binary. Non-memory-corruption findings are marked `n/a`.
+
+**IMPORTANT:** You must pass `--target` so binary discovery can scan the target directory. If the output shows matched binaries, Stage E can run. If all findings show "skipped", there are no binaries to analyze — proceed to Stage F.
 
 ---
 
@@ -58,11 +64,15 @@ For non-applicable types, copy finding to output unchanged with `feasibility: "n
 
 For each applicable finding:
 
-1. Check if binary path is provided in finding or context
-2. If not, attempt to locate:
+1. Check if binary path is provided via `--binary` argument or in finding metadata
+2. If not, attempt to locate automatically:
+   - Look for executables next to the source file (e.g., `vuln.c` → `vuln` or `./vuln`)
+   - Check for executables matching the source filename without extension
    - Look for Makefile/CMakeLists.txt to find build output
    - Check common paths: `./build/`, `./bin/`, `./out/`
-   - Ask user if not found
+   - List the target directory for ELF executables: `find <target> -maxdepth 2 -executable -type f`
+3. If multiple binaries found, group findings by which binary they belong to
+4. Only ask the user if no binaries can be discovered
 
 ```json
 {
@@ -76,40 +86,17 @@ For each applicable finding:
 
 ### [E-2] Run Feasibility Analysis
 
-```python
-import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
-from packages.exploit_feasibility import (
-    analyze_binary,
-    save_exploit_context,
-    load_exploit_context,
-    map_findings_to_constraints,
-)
+For each binary group discovered by the prep script, run:
 
-# Run binary analysis — output_dir ensures results go to the run directory
-result = analyze_binary(binary_path, output_dir=output_dir, vuln_type=finding.vuln_type)
-
-# Save context (survives conversation compaction)
-context_file = save_exploit_context(binary_path, output_dir=output_dir)
-
-# Load context for mapper
-constraints = load_exploit_context(context_file)
+```bash
+libexec/raptor-run-feasibility <binary_path> "$OUTPUT_DIR/findings.json" "$OUTPUT_DIR"
 ```
 
-### [E-3] Map Findings to Constraints
+This runs `analyze_binary` once per binary, saves exploit context, maps constraints to all findings referencing that binary, and updates findings.json with feasibility verdicts and `stage_e_summary`.
 
-Use `map_findings_to_constraints()` to get per-finding feasibility instead of generic exploitation paths:
+### [E-3] Review Results
 
-```python
-import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
-# findings: list of Stage D confirmed findings
-# constraints: output of load_exploit_context()
-mapped = map_findings_to_constraints(findings, constraints)
-
-# For kernel vulnerabilities only:
-# mapped = map_findings_to_constraints(findings, constraints, null_deref_exploitable=True)
-```
-
-This returns per-finding verdicts with specific viable targets and blockers based on the actual vuln_type and binary protections. Use these results instead of the generic `exploitation_paths` from `analyze_binary()`.
+The feasibility script updates findings.json with per-finding verdicts. Review the output for each finding — the script prints the verdict and maps constraints to findings automatically.
 
 ### [E-3b] Extract Key Constraints
 
@@ -209,7 +196,7 @@ Attach feasibility analysis to finding:
 }
 ```
 
-OUTPUT: Final `findings.json` with feasibility analysis
+OUTPUT: `stage-e.json`
 
 ---
 
@@ -277,6 +264,33 @@ from packages.exploit_feasibility import load_exploit_context
 ctx = load_exploit_context(finding.feasibility.context_file)
 # Access: ctx['libc'], ctx['gadgets'], ctx['constraints'], etc.
 ```
+
+---
+
+## Carry-Forward
+
+After feasibility analysis, write `$OUTPUT_DIR/stage-e.json` using the Write tool. The next stage's prep script merges it into findings.json automatically.
+
+Note: `raptor-run-feasibility` updates findings.json directly for feasibility data (binary analysis results, verdicts, constraint mapping). Claude writes stage-e.json for any additional notes, corrections, or summaries beyond what the script produced.
+
+The format for stage-e.json is:
+```json
+{
+  "stage": "E",
+  "updates": {
+    "FIND-0001": {
+      "stage_e_summary": {
+        "verdict": "difficult",
+        "binary_path": "/path/to/binary",
+        "impact": "code_execution"
+      }
+    },
+    ...
+  }
+}
+```
+
+**Key insight:** Claude writes ONLY its own stage's data. The prep script handles merging into findings.json.
 
 ---
 

--- a/.claude/skills/exploitability-validation/stage-f-review.md
+++ b/.claude/skills/exploitability-validation/stage-f-review.md
@@ -20,28 +20,29 @@ See `PIPELINE.md` for the full stage flow.
 
 ---
 
+## Prep (mechanical)
+
+Compute CVSS scores and check verdict mapping:
+
+```bash
+libexec/raptor-prepare-validation-stage F "$OUTPUT_DIR"
+```
+
+Review the flags above. Mismatches and anomalies inform your review.
+
+---
+
 ## Task
-
-### [F-1] Verify Stage E Verdicts
-
-For every finding where Stage E ran, does `final_status` in `findings.json` reflect the verdict mapping?
-- likely → exploitable
-- difficult → confirmed_constrained
-- unlikely → confirmed_blocked
-
-If you overrode an automated feasibility verdict, document it: `OVERRIDE: automated=X, final=Y. Reason: ...`
 
 ### [F-2] Check Consistency
 
-1. **Proximity scores.** Do findings with the same bug class and impact have the same proximity score? If two scores differ, state why. If no reason, equalize them.
+1. **Preconditions backed by evidence.** Every precondition in a ruling (e.g., "all handlers check checkfrom()") must cite specific evidence (line numbers, grep results). If asserted without evidence, verify it now.
 
-2. **Preconditions backed by evidence.** Every precondition in a ruling (e.g., "all handlers check checkfrom()") must cite specific evidence (line numbers, grep results). If asserted without evidence, verify it now.
+2. **Value-level traces.** If multiple findings share the same syntactic pattern, does each have a value-level trace explaining why the concrete effect differs (or is the same)?
 
-3. **Value-level traces.** If multiple findings share the same syntactic pattern, does each have a value-level trace explaining why the concrete effect differs (or is the same)?
+3. **Causal claims.** Every causal claim in `disproven.json`, `hypotheses.json`, and `findings.json` must cite a concrete verification method (tool output, line number, test result, disassembly). Examples — PASS: "Disassembly shows password at RSP+0x10, canary at RSP+0x108." PASS: "grep confirms htmlEscape() called at line 47 before template render at line 52." FAIL: "Compiler likely reordered the stack layout" — no evidence cited.
 
-4. **Causal claims.** Every causal claim in `disproven.json`, `hypotheses.json`, and `findings.json` must cite a concrete verification method (tool output, line number, test result, disassembly). Examples — PASS: "Disassembly shows password at RSP+0x10, canary at RSP+0x108." PASS: "grep confirms htmlEscape() called at line 47 before template render at line 52." FAIL: "Compiler likely reordered the stack layout" — no evidence cited.
-
-5. **CVSS vector accuracy.** Verify vector metrics match the finding's access model — AV = how the attacker reaches the code, not the machine. C/I/A reflect inherent impact, not binary mitigations. Flag any vectors that look wrong and correct them. Stage 1 computes the numeric scores.
+4. **CVSS vector accuracy.** Verify vector metrics match the finding's access model — AV = how the attacker reaches the code, not the machine. C/I/A reflect inherent impact, not binary mitigations. Flag any vectors that look wrong and correct them. F0 has computed preliminary scores — review them alongside the vectors. Stage 1 recomputes from final vectors.
 
 ### [F-3] Critical Review
 
@@ -57,8 +58,8 @@ Re-read findings.json, hypotheses.json, and attack-paths.json. Look for:
 ### [F-4] Act on Findings
 
 If the review finds issues:
-- Fix the real fields directly in findings.json (ruling, cvss_vector, vuln_type, etc.)
-- Add a top-level `stage_f_review` field to findings.json summarising what changed
+- Write corrections to `$OUTPUT_DIR/stage-f.json` (not findings.json directly)
+- Include a top-level `stage_f_review` field summarising what changed
   (e.g., `"stage_f_review": "Corrected FIND-0001 AV:N→AV:L (CLI binary). Fixed FIND-0003 CWE-120→CWE-190 (root cause is integer overflow)."`)
 - If nothing changed: `"stage_f_review": "No corrections needed."`
 
@@ -66,6 +67,32 @@ If the review finds issues:
 
 ---
 
+## Carry-Forward
+
+After review, write `$OUTPUT_DIR/stage-f.json` using the Write tool. The next stage's prep script (Stage 1) merges it into findings.json automatically.
+
+The format for stage-f.json is:
+```json
+{
+  "stage": "F",
+  "updates": {
+    "FIND-0001": {
+      "stage_f_summary": {
+        "corrections": ["AV:N->AV:L"],
+        "review_notes": "CLI binary, not network-accessible"
+      },
+      "cvss_vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    },
+    ...
+  },
+  "stage_f_review": "Corrected FIND-0001 AV:N→AV:L (CLI binary)."
+}
+```
+
+**Key insight:** Claude writes ONLY its own stage's data. The prep script handles merging into findings.json.
+
+---
+
 ## Output
 
-OUTPUT: Updated `findings.json` (with corrections if any). Stage 1 runs next for CVSS scoring, schema validation, report generation, and displaying the findings summary.
+OUTPUT: `stage-f.json`. Stage 1 runs next for merging, CVSS scoring, schema validation, report generation, and displaying the findings summary.

--- a/core/reporting/formatting.py
+++ b/core/reporting/formatting.py
@@ -25,15 +25,17 @@ def get_display_status(finding: Dict[str, Any]) -> str:
         if finding.get("is_true_positive"):
             return "Confirmed"
 
-    # Check ruling dict (validate pipeline)
-    ruling = finding.get("ruling", {})
-    if isinstance(ruling, dict):
-        status = ruling.get("status", "")
-    else:
-        status = str(ruling) if ruling else ""
+    # final_status is authoritative (set after Stage E feasibility adjustment)
+    status = finding.get("final_status", "")
 
-    # Fall through to flat fields
-    status = status or finding.get("final_status", "") or finding.get("status", "")
+    # Fall back to ruling.status (Stage D), then top-level status
+    if not status:
+        ruling = finding.get("ruling", {})
+        if isinstance(ruling, dict):
+            status = ruling.get("status", "")
+        else:
+            status = str(ruling) if ruling else ""
+    status = status or finding.get("status", "")
 
     status_map = {
         "exploitable": "Exploitable",

--- a/core/reporting/tests/test_formatting.py
+++ b/core/reporting/tests/test_formatting.py
@@ -45,6 +45,19 @@ class TestGetDisplayStatus(unittest.TestCase):
     def test_validated_ruling(self):
         self.assertEqual(get_display_status({"ruling": {"status": "validated"}}), "Confirmed")
 
+    def test_final_status_overrides_ruling(self):
+        """final_status (post-feasibility) takes priority over ruling.status (Stage D)."""
+        self.assertEqual(get_display_status({
+            "ruling": {"status": "exploitable"},
+            "final_status": "confirmed_constrained",
+        }), "Confirmed (Constrained)")
+
+    def test_final_status_overrides_ruling_blocked(self):
+        self.assertEqual(get_display_status({
+            "ruling": {"status": "confirmed"},
+            "final_status": "confirmed_blocked",
+        }), "Confirmed (Blocked)")
+
     def test_boolean_overrides_ruling_string(self):
         # Agentic: is_exploitable=True should win over ruling=test_code
         self.assertEqual(get_display_status(

--- a/core/schema_constants.py
+++ b/core/schema_constants.py
@@ -61,6 +61,127 @@ VULN_TYPES = [
     "hardcoded_secret", "weak_crypto", "other",
 ]
 
+# Memory corruption vuln_types — Stage E feasibility analysis applies to these.
+# Non-memory-corruption types (command_injection, sql_injection, xss, etc.) skip Stage E.
+MEMORY_CORRUPTION_TYPES = frozenset({
+    "buffer_overflow", "heap_overflow", "stack_overflow",
+    "format_string", "use_after_free", "double_free",
+    "integer_overflow", "out_of_bounds_read", "out_of_bounds_write",
+    "null_deref", "type_confusion", "uninitialized_memory",
+})
+
+def needs_feasibility_analysis(vuln_type: str) -> bool:
+    """Check if a vuln_type requires Stage E binary feasibility analysis."""
+    return normalise_vuln_type(vuln_type) in MEMORY_CORRUPTION_TYPES
+
+
+# ---------------------------------------------------------------------------
+# LLM alias → canonical vuln_type mapping
+# ---------------------------------------------------------------------------
+# LLMs produce varied names for the same vuln type. This maps common
+# alternatives to the canonical VULN_TYPES enum values.
+
+VULN_TYPE_ALIASES = {
+    # Race condition / TOCTOU
+    "toctou": "race_condition",
+    "time_of_check_time_of_use": "race_condition",
+    "time_of_check_to_time_of_use": "race_condition",
+    "race": "race_condition",
+    # Null dereference
+    "null_pointer_dereference": "null_deref",
+    "null_ptr_dereference": "null_deref",
+    "null_dereference": "null_deref",
+    "nullptr_deref": "null_deref",
+    "null_pointer": "null_deref",
+    "null_ptr_deref": "null_deref",
+    "null_pointer_deref": "null_deref",
+    # Buffer overflow
+    "bof": "buffer_overflow",
+    "stack_buffer_overflow": "buffer_overflow",
+    "heap_buffer_overflow": "heap_overflow",
+    "stack_bof": "stack_overflow",
+    "heap_bof": "heap_overflow",
+    # Use-after-free
+    "uaf": "use_after_free",
+    "use_after_free_read": "use_after_free",
+    "use_after_free_write": "use_after_free",
+    # Double free
+    "double-free": "double_free",
+    # Format string
+    "fmt_string": "format_string",
+    "format_string_bug": "format_string",
+    "format_string_vulnerability": "format_string",
+    "printf_vulnerability": "format_string",
+    # XSS
+    "cross_site_scripting": "xss",
+    "reflected_xss": "xss",
+    "stored_xss": "xss",
+    "dom_xss": "xss",
+    # SQL injection
+    "sqli": "sql_injection",
+    "sql_injection_blind": "sql_injection",
+    # Command injection
+    "os_command_injection": "command_injection",
+    "cmd_injection": "command_injection",
+    "shell_injection": "command_injection",
+    "code_injection": "command_injection",
+    "rce": "command_injection",
+    "remote_code_execution": "command_injection",
+    # Path traversal
+    "directory_traversal": "path_traversal",
+    "lfi": "path_traversal",
+    "local_file_inclusion": "path_traversal",
+    "file_inclusion": "path_traversal",
+    # SSRF
+    "server_side_request_forgery": "ssrf",
+    # Integer overflow
+    "int_overflow": "integer_overflow",
+    "integer_underflow": "integer_overflow",
+    "int_underflow": "integer_overflow",
+    "integer_wrap": "integer_overflow",
+    # Out of bounds
+    "oob_read": "out_of_bounds_read",
+    "oob_write": "out_of_bounds_write",
+    "out_of_bounds": "out_of_bounds_read",
+    "stack_overread": "out_of_bounds_read",
+    "heap_overread": "out_of_bounds_read",
+    "buffer_over_read": "out_of_bounds_read",
+    "buffer_overread": "out_of_bounds_read",
+    # Deserialization
+    "insecure_deserialization": "deserialization",
+    "unsafe_deserialization": "deserialization",
+    # Memory leak
+    "information_leak": "memory_leak",
+    "info_leak": "memory_leak",
+    # Crypto
+    "weak_cryptography": "weak_crypto",
+    "insecure_crypto": "weak_crypto",
+    # Type confusion
+    "type_confusion_vulnerability": "type_confusion",
+    # Uninitialized memory
+    "uninitialized_variable": "uninitialized_memory",
+    "uninitialized_read": "uninitialized_memory",
+    # Privilege
+    "privilege_escalation": "privilege_confusion",
+    # Hardcoded secrets
+    "hardcoded_credentials": "hardcoded_secret",
+    "hardcoded_password": "hardcoded_secret",
+    "embedded_secret": "hardcoded_secret",
+}
+
+
+def normalise_vuln_type(vuln_type: str) -> str:
+    """Normalize a vuln_type string to its canonical form.
+
+    Accepts LLM-friendly aliases (toctou, null_pointer_dereference, etc.)
+    and returns the canonical VULN_TYPES enum value. Returns unchanged if
+    already canonical or unrecognised.
+    """
+    if not vuln_type:
+        return vuln_type
+    lower = vuln_type.lower().strip()
+    return VULN_TYPE_ALIASES.get(lower, lower)
+
 # Severity assessment levels.
 SEVERITY_LEVELS = ["critical", "high", "medium", "low", "informational"]
 

--- a/libexec/raptor-prepare-validation-stage
+++ b/libexec/raptor-prepare-validation-stage
@@ -1,0 +1,911 @@
+#!/usr/bin/env python3
+"""Prepare a validation pipeline stage by running all mechanical checks.
+
+Usage:
+  raptor-prepare-validation-stage 0 --target <path>     # start run + inventory
+  raptor-prepare-validation-stage <A|B|C|D|E|F> <workdir> [--target <path>]
+  raptor-prepare-validation-stage 1 <workdir>            # report + complete
+
+Stages:
+  0  Start run lifecycle, build checklist (prints workdir to stdout)
+  A  Load checklist and pre-existing findings
+  B  Validate Stage A output, dedup flag, load attack surface
+  C  Validate Stage B output (5 docs), pre-check findings against inventory
+  D  Validate Stage C output, test/mock path filter, evidence card assembly
+  E  Validate Stage D output, discover binaries (requires --target)
+  F  Map Stage E verdicts, compute CVSS scores, consistency checks
+  1  Generate report + diagrams, complete run lifecycle
+"""
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import hashlib
+from core.json import load_json, save_json
+from core.schema_constants import MEMORY_CORRUPTION_TYPES, normalise_vuln_type
+from core.inventory.lookup import normalise_path
+from packages.exploitability_validation.schemas import (
+    create_empty_findings, validate_findings, validate_attack_tree,
+    validate_attack_paths, validate_attack_surface, validate_hypotheses,
+    validate_disproven,
+)
+
+STAGE_LETTERS = "ABCDEF"
+
+
+def _is_validated(workdir, filename):
+    """Check if a file was already validated (hash matches .validated record)."""
+    vfile = Path(workdir) / ".validated"
+    filepath = Path(workdir) / filename
+    if not vfile.exists() or not filepath.exists():
+        return False
+    current = hashlib.sha256(filepath.read_bytes()).hexdigest()
+    for line in vfile.read_text().splitlines():
+        if line.startswith(f"{filename}:"):
+            return line.split(":", 1)[1].strip() == current
+    return False
+
+
+def _validate_file(workdir, filename, validator_func):
+    """Validate a file, skipping if already validated by raptor-validate-schema."""
+    if _is_validated(workdir, filename):
+        print(f"  {filename}: OK (cached)")
+        return True, []
+    data = load_json(Path(workdir) / filename)
+    if not data:
+        print(f"  {filename}: not found")
+        return True, []
+    valid, errors = validator_func(data)
+    if not valid:
+        print(f"  {filename}: ERRORS {errors}")
+    else:
+        print(f"  {filename}: OK")
+    return valid, errors
+
+
+def _findings(workdir):
+    return load_json(Path(workdir) / "findings.json")
+
+
+def _save_findings(workdir, data):
+    save_json(Path(workdir) / "findings.json", data)
+
+
+WORKING_DOCS = [
+    "findings.json", "attack-surface.json", "attack-tree.json",
+    "hypotheses.json", "disproven.json", "attack-paths.json",
+]
+
+
+def _report_workdir_files(workdir, verb="available"):
+    """Print which working docs exist and which are missing."""
+    present = []
+    missing = []
+    for doc in WORKING_DOCS:
+        if (Path(workdir) / doc).exists():
+            present.append(doc)
+        else:
+            missing.append(doc)
+    ctx_files = list(Path(workdir).glob("*_exploit_context.json"))
+    if ctx_files:
+        present.extend(f.name for f in ctx_files)
+    if missing:
+        print(f"  Create: {', '.join(missing)}")
+    if present:
+        print(f"  {verb.capitalize()}: {', '.join(present)}")
+
+
+def _deep_merge(target, source):
+    """Recursively merge source into target. Source values win."""
+    for key, value in source.items():
+        if key in target and isinstance(target[key], dict) and isinstance(value, dict):
+            _deep_merge(target[key], value)
+        else:
+            target[key] = value
+
+
+def _apply_stage_file(workdir, stage_letter):
+    """Merge stage-X.json into findings.json, then delete the stage file.
+
+    Stage A: stage-a.json contains a full findings container — builds findings.json.
+    Stages B-F: stage-X.json contains per-finding updates — merges into findings.json.
+
+    Returns True if a stage file was found and applied.
+    """
+    stage_path = Path(workdir) / f"stage-{stage_letter.lower()}.json"
+    if not stage_path.exists():
+        return False
+
+    staged = load_json(stage_path)
+    if not staged:
+        print(f"  WARNING: stage-{stage_letter.lower()}.json exists but is empty/invalid")
+        return False
+
+    findings_path = Path(workdir) / "findings.json"
+
+    if stage_letter.upper() == "A":
+        # Build: stage-a.json IS the findings container
+        target_path = staged.get("target_path", "")
+        container = create_empty_findings("A", target_path, staged.get("vuln_type_focus"))
+        container["findings"] = staged.get("findings", [])
+        save_json(findings_path, container)
+        count = len(container["findings"])
+        print(f"  Built findings.json from stage-a.json: {count} findings")
+    else:
+        # Update: merge per-finding updates into existing findings.json
+        container = load_json(findings_path)
+        if not container:
+            print(f"  ERROR: findings.json not found — cannot apply stage-{stage_letter.lower()}.json")
+            return False
+
+        by_id = {f["id"]: f for f in container.get("findings", [])}
+        applied = 0
+
+        if "updates" in staged and isinstance(staged["updates"], dict):
+            # Preferred format: {"updates": {"FIND-001": {fields...}}}
+            for finding_id, update_dict in staged["updates"].items():
+                finding = by_id.get(finding_id)
+                if finding:
+                    _deep_merge(finding, update_dict)
+                    applied += 1
+                else:
+                    print(f"  WARNING: {finding_id} not found in findings.json — skipped")
+
+        elif "findings" in staged and isinstance(staged["findings"], list):
+            # Fallback: Claude wrote a findings array — merge by ID, don't replace
+            for staged_finding in staged["findings"]:
+                fid = staged_finding.get("id")
+                if not fid:
+                    continue
+                existing = by_id.get(fid)
+                if existing:
+                    _deep_merge(existing, staged_finding)
+                    applied += 1
+                else:
+                    # New finding not in findings.json — append
+                    container["findings"].append(staged_finding)
+                    by_id[fid] = staged_finding
+                    applied += 1
+
+        # Copy top-level metadata (but NOT findings or updates — those are handled above)
+        for key, value in staged.items():
+            if key not in ("stage", "updates", "findings"):
+                container[key] = value
+
+        container["stage"] = staged.get("stage", stage_letter.upper())
+        save_json(findings_path, container)
+        print(f"  Merged stage-{stage_letter.lower()}.json: {applied} findings updated")
+
+    # Delete the stage file
+    stage_path.unlink()
+    return True
+
+
+def _active(findings_data):
+    """Non-disproven findings."""
+    return [f for f in findings_data.get("findings", []) if f.get("status") != "disproven"]
+
+
+# ---------------------------------------------------------------------------
+# A: Load checklist and pre-existing findings
+# ---------------------------------------------------------------------------
+
+_POC_GCC_FLAGS = [
+    "-fno-stack-protector", "-no-pie", "-z", "execstack",
+    "-z", "norelro", "-g", "-O0",
+    "-include", "stdio.h", "-include", "stdlib.h",
+    "-include", "string.h", "-include", "unistd.h",
+    "-Wall",  # warnings are useful signals for the LLM
+]
+
+_BUILD_SYSTEM_MARKERS = [
+    "Makefile", "makefile", "CMakeLists.txt", "configure", "meson.build",
+    "Cargo.toml", "go.mod", "build.gradle", "pom.xml", "setup.py",
+    "pyproject.toml", "package.json",
+]
+
+
+def _build_standalone_pocs(target, build_dir):
+    """Build PoC binaries from standalone C/C++ files (no Makefile)."""
+    import subprocess as _sp
+
+    target = Path(target)
+    build_dir = Path(build_dir)
+
+    if any((target / m).exists() for m in _BUILD_SYSTEM_MARKERS):
+        print("Target has a build system — skipping PoC build")
+        return
+
+    extensions = {".c", ".cpp", ".cc", ".cxx"}
+    sources = [
+        f for f in sorted(target.iterdir())
+        if f.is_file() and f.suffix.lower() in extensions
+        and ("int main" in f.read_text(encoding="utf-8", errors="ignore")
+             or "void main" in f.read_text(encoding="utf-8", errors="ignore"))
+    ]
+    if not sources:
+        return
+
+    build_dir.mkdir(parents=True, exist_ok=True)
+
+    compiler = "gcc"
+    try:
+        _sp.run([compiler, "--version"], capture_output=True, check=True)
+    except (FileNotFoundError, _sp.CalledProcessError):
+        compiler = "cc"
+        try:
+            _sp.run([compiler, "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, _sp.CalledProcessError):
+            print("No C compiler found — skipping PoC build")
+            return
+
+    built = 0
+    for source in sources:
+        output = build_dir / source.stem
+        if output.exists():
+            built += 1
+            continue
+        cmd = [compiler] + _POC_GCC_FLAGS + ["-o", str(output), str(source)]
+        try:
+            result = _sp.run(cmd, capture_output=True, text=True, timeout=30)
+            if result.returncode == 0:
+                print(f"  Built: {source.name} -> {output.name}")
+                if result.stderr.strip():
+                    for line in result.stderr.strip().splitlines()[:5]:
+                        print(f"    warning: {line}")
+                built += 1
+            else:
+                print(f"  Build failed: {source.name} ({result.stderr.strip()[:80]})")
+        except Exception:
+            pass
+
+    if built:
+        print(f"PoC binaries: {built}/{len(sources)} in {build_dir}")
+
+
+def prepare_A(workdir, target=None):
+    checklist = load_json(Path(workdir) / "checklist.json")
+    existing = load_json(Path(workdir) / "findings.json")
+    if not checklist:
+        print("ERROR: checklist.json not found")
+        sys.exit(1)
+    total_files = checklist['total_files']
+    total_sloc = checklist.get('total_sloc', 0)
+    print(f"Checklist: {total_files} files, {checklist['total_items']} items, {total_sloc} SLOC")
+    if total_files <= 20 and total_sloc < 2000:
+        print("  Target size: small — keep analysis concise, one tool call per finding where possible")
+    if existing:
+        print(f"Pre-existing findings: {len(existing.get('findings', []))}")
+    else:
+        print("No pre-existing findings")
+
+    # Discover existing binaries and build PoCs for standalone C files
+    if target:
+        build_dir = Path(workdir) / "build"
+        _build_standalone_pocs(target, str(build_dir))
+
+        executables = _discover_executables(target)
+        build_exes = _discover_executables(str(build_dir)) if build_dir.exists() else {}
+        if executables or build_exes:
+            print(f"Source → binary mapping:")
+            for f in checklist.get("files", []):
+                src = f["path"]
+                stem = Path(src).stem
+                prefix = stem.split("_")[0] if "_" in stem else ""
+                poc = build_exes.get(stem) or (build_exes.get(prefix) if prefix else "")
+                orig = executables.get(stem) or (executables.get(prefix) if prefix else "")
+                parts = []
+                if poc:
+                    parts.append(f"poc={poc}")
+                if orig:
+                    parts.append(f"original={orig}")
+                if parts:
+                    print(f"  {src}: {', '.join(parts)}")
+                else:
+                    print(f"  {src}: no binary")
+
+
+# ---------------------------------------------------------------------------
+# B: Validate Stage A output + dedup + load attack surface
+# ---------------------------------------------------------------------------
+
+def prepare_B(workdir, target=None):
+    _apply_stage_file(workdir, "A")
+
+
+    data = _findings(workdir)
+    findings = data.get("findings", [])
+
+    # --- Normalise vuln_types (LLM aliases → canonical) ---
+    for finding in findings:
+        vt = finding.get("vuln_type", "")
+        normalised = normalise_vuln_type(vt)
+        if normalised != vt:
+            print(f"  Normalised: {finding['id']} vuln_type '{vt}' -> '{normalised}'")
+            finding["vuln_type"] = normalised
+
+    # --- Dedup flag ---
+    for i, f1 in enumerate(findings):
+        for f2 in findings[i + 1:]:
+            if f1.get("status") == "disproven" or f2.get("status") == "disproven":
+                continue
+            same_func = (f1.get("file") == f2.get("file")
+                         and f1.get("function") == f2.get("function"))
+            nearby = (f1.get("file") == f2.get("file")
+                      and f1.get("vuln_type") == f2.get("vuln_type")
+                      and abs(f1.get("line", 0) - f2.get("line", 0)) <= 5)
+            if same_func or nearby:
+                f2["dedup_flag"] = f"potential_dup:{f1['id']}"
+                print(f"  Dedup flag: {f2['id']} may duplicate {f1['id']}")
+
+    # --- Carry-forward check (Stage A) ---
+    for finding in findings:
+        if finding.get("status") == "disproven":
+            continue
+        sa = finding.get("stage_a_summary")
+        if not sa:
+            print(f"  WARN: {finding['id']} missing stage_a_summary — add it")
+        elif not all(k in sa for k in ("confidence", "status")):
+            print(f"  WARN: {finding['id']} stage_a_summary incomplete — needs confidence, status")
+        if not finding.get("origin"):
+            print(f"  WARN: {finding['id']} missing origin field")
+
+    _save_findings(workdir, data)
+
+    # --- Schema validation ---
+    _validate_file(workdir, "findings.json", validate_findings)
+
+    # --- Fast-path for poc_success findings ---
+    hypotheses = load_json(Path(workdir) / "hypotheses.json") or []
+    attack_paths = load_json(Path(workdir) / "attack-paths.json") or []
+    existing_hyp_ids = {h.get("id") for h in hypotheses}
+    existing_path_ids = {p.get("id") for p in attack_paths}
+
+    fast_count = 0
+    full_count = 0
+    for finding in findings:
+        if finding.get("status") == "disproven":
+            continue
+        sa = finding.get("stage_a_summary", {})
+        poc = finding.get("poc", {})
+        fid = finding["id"]
+        num = fid.split("-")[-1] if "-" in fid else str(fast_count + 1)
+
+        if (finding.get("status") == "poc_success"
+                and sa.get("confidence") == "high"
+                and poc.get("result") and poc["result"] != "ran without error"):
+
+            # Mechanical fast-path: create audit trail entries
+            hyp_id = f"H{num}"
+            path_id = f"AP-{num}"
+
+            if hyp_id not in existing_hyp_ids:
+                hypotheses.append({
+                    "id": hyp_id,
+                    "finding": fid,
+                    "claim": f"{finding.get('vuln_type', 'vulnerability')} in {finding.get('file', '?')}:{finding.get('line', '?')} — exploitable via {finding.get('dataflow_summary', 'confirmed data flow')}",
+                    "predictions": [{
+                        "id": f"P{num}.1",
+                        "prediction": f"PoC: {poc.get('description', poc.get('payload', 'trigger vulnerability'))}",
+                        "result": poc.get("result", ""),
+                        "status": "confirmed",
+                    }],
+                    "status": "confirmed",
+                })
+
+            if path_id not in existing_path_ids:
+                attack_paths.append({
+                    "id": path_id,
+                    "name": f"PoC-confirmed: {finding.get('vuln_type', '')}",
+                    "finding": fid,
+                    "steps": [{"step": 1, "action": poc.get("description", "Run PoC"),
+                               "result": poc.get("result", "")}],
+                    "proximity": 9,
+                    "blockers": [],
+                    "status": "confirmed",
+                })
+
+            finding["stage_b_summary"] = {
+                "hypothesis_id": hyp_id,
+                "hypothesis_status": "confirmed",
+                "proximity": 9,
+                "attack_path_id": path_id,
+            }
+            fast_count += 1
+        else:
+            full_count += 1
+
+    # Always create all 5 working docs (empty if no data).
+    # This ensures Claude can Read-then-Write without "file not found" errors.
+    wdir = Path(workdir)
+    save_json(wdir / "hypotheses.json", hypotheses)
+    save_json(wdir / "attack-paths.json", attack_paths)
+    if not (wdir / "attack-surface.json").exists():
+        save_json(wdir / "attack-surface.json", {"sources": [], "sinks": [], "trust_boundaries": []})
+    if not (wdir / "attack-tree.json").exists():
+        save_json(wdir / "attack-tree.json", {"root": "ROOT", "nodes": []})
+    if not (wdir / "disproven.json").exists():
+        save_json(wdir / "disproven.json", {"disproven": []})
+    _save_findings(workdir, data)
+
+    if fast_count:
+        print(f"Fast-path: {fast_count} poc_success findings (audit trail created)")
+    if full_count:
+        print(f"Full analysis needed: {full_count} findings")
+
+    # --- Load attack surface ---
+    surface = load_json(wdir / "attack-surface.json")
+    active = _active(data)
+    deduped = [f for f in active if f.get("dedup_flag")]
+    not_done = [f for f in active if not f.get("stage_b_summary")]
+    print(f"{len(not_done)} findings need Stage B analysis (of {len(active)} active)")
+    if surface:
+        print(f"  Pre-existing attack surface: {len(surface.get('sources', []))} sources, "
+              f"{len(surface.get('sinks', []))} sinks")
+    if deduped:
+        print(f"  {len(deduped)} findings flagged as potential duplicates — review during analysis")
+
+    _report_workdir_files(workdir, "existing")
+
+
+# ---------------------------------------------------------------------------
+# C: Validate Stage B output + pre-check findings against inventory
+# ---------------------------------------------------------------------------
+
+def prepare_C(workdir, target=None):
+    _apply_stage_file(workdir, "B")
+
+    # --- Validate 6 working docs ---
+    for name, validator in [
+        ("findings.json", validate_findings),
+        ("attack-tree.json", validate_attack_tree),
+        ("attack-paths.json", validate_attack_paths),
+        ("attack-surface.json", validate_attack_surface),
+        ("hypotheses.json", validate_hypotheses),
+        ("disproven.json", validate_disproven),
+    ]:
+        if (Path(workdir) / name).exists():
+            _validate_file(workdir, name, validator)
+        else:
+            print(f"  {name}: not found")
+
+    # --- Carry-forward check (Stage B) ---
+    findings_data = _findings(workdir)
+    for finding in _active(findings_data):
+        sb = finding.get("stage_b_summary")
+        if not sb:
+            print(f"  WARN: {finding['id']} missing stage_b_summary — add it")
+        elif not all(k in sb for k in ("hypothesis_id", "hypothesis_status", "proximity")):
+            print(f"  WARN: {finding['id']} stage_b_summary incomplete")
+
+    # --- Pre-check findings against inventory ---
+    checklist = load_json(Path(workdir) / "checklist.json")
+    inv_files = {}
+    for f in checklist.get("files", []):
+        inv_files[f["path"]] = f
+    inv_paths = list(inv_files.keys())
+
+    for finding in findings_data.get("findings", []):
+        if finding.get("status") == "disproven":
+            finding["checklist_verified"] = True
+            continue
+        fpath = finding.get("file", "")
+        fline = finding.get("line", 0)
+        inv = inv_files.get(fpath)
+        if inv is None:
+            normalised = normalise_path(fpath, inv_paths)
+            inv = inv_files.get(normalised) if normalised else None
+        if inv is None:
+            finding["checklist_verified"] = False
+            print(f"  C0 FAIL: {finding['id']} — file '{fpath}' not in inventory")
+        elif fline > inv.get("lines", 0):
+            finding["checklist_verified"] = False
+            print(f"  C0 FAIL: {finding['id']} — line {fline} > file length {inv['lines']}")
+        else:
+            finding["checklist_verified"] = True
+
+    _save_findings(workdir, findings_data)
+    failed = sum(1 for f in findings_data["findings"] if f.get("checklist_verified") is False)
+    print(f"Inventory check: {failed} failed, {len(findings_data['findings']) - failed} passed")
+
+
+# ---------------------------------------------------------------------------
+# D: Validate Stage C output + test filter + evidence cards
+# ---------------------------------------------------------------------------
+
+TEST_PATTERNS = [
+    r"(^|/)tests?/", r"(^|/)__tests__/", r"(^|/)spec/",
+    r"(^|/)test_", r"_test\.\w+$", r"_spec\.\w+$",
+    r"(^|/)mock[s_]", r"(^|/)example[s]?/", r"(^|/)demo/",
+    r"(^|/)fixture[s]?/",
+]
+
+
+def prepare_D(workdir, target=None):
+    _apply_stage_file(workdir, "C")
+
+
+    data = _findings(workdir)
+
+    # --- Schema validation ---
+    _validate_file(workdir, "findings.json", validate_findings)
+
+    # --- Carry-forward check (Stage C) ---
+    REQUIRED_CHECKS = ("file_exists", "code_verbatim", "flow_real", "reachable")
+    for finding in data["findings"]:
+        if finding.get("status") == "disproven":
+            continue
+        sc = finding.get("stage_c_summary")
+        if not sc:
+            print(f"  WARN: {finding['id']} missing stage_c_summary — add it")
+        elif not isinstance(sc.get("checks"), dict):
+            print(f"  WARN: {finding['id']} stage_c_summary.checks must be a dict "
+                  f"with keys: {REQUIRED_CHECKS}")
+        elif not all(k in sc["checks"] for k in REQUIRED_CHECKS):
+            print(f"  WARN: {finding['id']} stage_c_summary.checks incomplete")
+
+    passed = sum(1 for f in data["findings"]
+                 if f.get("sanity_check", {}).get("passed"))
+    failed = sum(1 for f in data["findings"]
+                 if f.get("sanity_check", {}).get("passed") is False)
+    print(f"Sanity check: {passed} passed, {failed} failed")
+
+    # --- Test/mock path filter ---
+    for finding in data.get("findings", []):
+        if finding.get("status") == "disproven":
+            continue
+        fpath = finding.get("file", "")
+        finding["test_code_flag"] = any(re.search(p, fpath) for p in TEST_PATTERNS)
+        if finding["test_code_flag"]:
+            print(f"  D0 FLAG: {finding['id']} in test/mock path: {fpath}")
+
+    # --- Evidence card assembly ---
+    for finding in data.get("findings", []):
+        if finding.get("status") == "disproven":
+            continue
+        a = finding.get("stage_a_summary", {})
+        b = finding.get("stage_b_summary", {})
+        c = finding.get("stage_c_summary", {})
+        if a or b or c:
+            finding.setdefault("ruling", {})
+            finding["ruling"]["evidence_synthesis"] = {
+                "stage_a_confidence": a.get("confidence", ""),
+                "stage_b_hypothesis": b.get("hypothesis_status", "none"),
+                "stage_c_passed": c.get("passed"),
+                "synthesis": "",
+            }
+
+    _save_findings(workdir, data)
+    flagged = sum(1 for f in data["findings"] if f.get("test_code_flag"))
+    print(f"Test filter: {flagged} flagged, evidence cards assembled")
+
+
+# ---------------------------------------------------------------------------
+# E: Validate Stage D output + discover binaries
+# ---------------------------------------------------------------------------
+
+def _discover_executables(target):
+    """Find executable files in target directory. Returns {stem: path}."""
+    import subprocess as _sp
+    result = {}
+    try:
+        proc = _sp.run(
+            ["find", target, "-executable", "-type", "f"],
+            capture_output=True, text=True, timeout=30
+        )
+        for line in proc.stdout.strip().split("\n"):
+            if line:
+                p = Path(line)
+                result[p.stem] = str(p)
+    except Exception:
+        pass
+    return result
+
+
+def _match_finding_to_binary(finding, executables):
+    """Match a finding's source file to a discovered binary."""
+    src = finding.get("file", "")
+    if not src:
+        return ""
+    stem = Path(src).stem
+    if stem in executables:
+        return executables[stem]
+    if "_" in stem:
+        prefix = stem.split("_")[0]
+        if prefix in executables:
+            return executables[prefix]
+    for name, path in executables.items():
+        if stem.startswith(name) or name.startswith(stem):
+            return path
+    return ""
+
+
+def _discover_and_match_binaries(workdir, target, data):
+    """Discover binaries and match to findings."""
+
+    executables = _discover_executables(target)
+    if executables:
+        print(f"Discovered {len(executables)} executable(s) in {target}")
+
+    matched = 0
+    skipped = 0
+    for finding in data.get("findings", []):
+        if finding.get("status") == "disproven":
+            continue
+        if finding.get("ruling", {}).get("status") == "ruled_out":
+            continue
+        if finding.get("vuln_type", "") not in MEMORY_CORRUPTION_TYPES:
+            finding.setdefault("feasibility", {})["status"] = "not_applicable"
+            finding["stage_e_summary"] = {"status": "not_applicable"}
+            continue
+        bp = finding.get("feasibility", {}).get("binary_path", "")
+        if not bp and executables:
+            bp = _match_finding_to_binary(finding, executables)
+            if bp:
+                finding.setdefault("feasibility", {})["binary_path"] = bp
+                print(f"  {finding['id']}: matched -> {bp}")
+                matched += 1
+        if not bp:
+            finding.setdefault("feasibility", {})["status"] = "skipped"
+            finding["stage_e_summary"] = {"status": "skipped", "reason": "no binary found"}
+            skipped += 1
+
+    _save_findings(workdir, data)
+
+    groups = {}
+    for f in data.get("findings", []):
+        bp = f.get("feasibility", {}).get("binary_path", "")
+        if bp:
+            groups.setdefault(bp, []).append(f["id"])
+    print(f"{len(groups)} binary group(s), {matched} matched, {skipped} skipped")
+    for bp, ids in groups.items():
+        print(f"  {bp}: {', '.join(ids)}")
+
+
+def prepare_E(workdir, target=None):
+    _apply_stage_file(workdir, "D")
+
+
+    data = _findings(workdir)
+
+    # --- Schema validation ---
+    _validate_file(workdir, "findings.json", validate_findings)
+
+    # --- Carry-forward check (Stage D) ---
+    for finding in data["findings"]:
+        if finding.get("status") == "disproven":
+            continue
+        if finding.get("ruling", {}).get("status") == "ruled_out":
+            continue
+        sd = finding.get("stage_d_summary")
+        if not sd:
+            print(f"  WARN: {finding['id']} missing stage_d_summary — add it")
+        elif "ruling" not in sd:
+            print(f"  WARN: {finding['id']} stage_d_summary missing 'ruling' key")
+
+    ruled_out = sum(1 for f in data["findings"]
+                    if f.get("ruling", {}).get("status") == "ruled_out")
+    confirmed = sum(1 for f in data["findings"]
+                    if f.get("ruling", {}).get("status") in ("confirmed", "exploitable"))
+    print(f"Ruling: {confirmed} confirmed, {ruled_out} ruled out")
+
+    _save_findings(workdir, data)
+
+    # --- Discover binaries ---
+    if target:
+        _discover_and_match_binaries(workdir, target, data)
+    else:
+        print("  No --target provided, skipping binary discovery")
+
+
+# ---------------------------------------------------------------------------
+# F: Map Stage E verdicts + CVSS scoring + consistency checks
+# ---------------------------------------------------------------------------
+
+VERDICT_MAP = {
+    "likely": "exploitable",
+    "likely_exploitable": "exploitable",
+    "exploitable": "exploitable",
+    "difficult": "confirmed_constrained",
+    "unlikely": "confirmed_blocked",
+}
+
+
+def prepare_F(workdir, target=None):
+    _apply_stage_file(workdir, "E")
+
+
+    data = _findings(workdir)
+
+    # --- Verdict-to-status mapping ---
+    for finding in data.get("findings", []):
+        verdict = finding.get("feasibility", {}).get("verdict", "")
+        if verdict and verdict in VERDICT_MAP:
+            mapped = VERDICT_MAP[verdict]
+            finding["final_status"] = mapped
+            # Sync status with final_status so the report reflects Stage E results
+            old_status = finding.get("status", "")
+            if old_status != mapped:
+                finding["status"] = mapped
+                print(f"  {finding['id']}: {verdict} -> {mapped} (was {old_status})")
+            else:
+                print(f"  {finding['id']}: {verdict} -> {mapped}")
+
+    # --- Set final_status for non-memory-corruption findings ---
+    for finding in data.get("findings", []):
+        if not finding.get("final_status") and finding.get("status"):
+            finding["final_status"] = finding["status"]
+
+    # --- Derive is_exploitable from final_status ---
+    for finding in data.get("findings", []):
+        fs = finding.get("final_status", "")
+        if fs in ("exploitable",):
+            finding["is_exploitable"] = True
+        elif fs in ("confirmed_constrained", "confirmed_blocked", "confirmed", "confirmed_unverified"):
+            finding["is_exploitable"] = False
+
+    # --- Carry-forward check (Stage E) ---
+    for finding in data.get("findings", []):
+        se = finding.get("stage_e_summary")
+        if not se and finding.get("vuln_type") in MEMORY_CORRUPTION_TYPES:
+            print(f"  WARN: {finding['id']} missing stage_e_summary — add it")
+
+    _save_findings(workdir, data)
+
+    # --- CVSS score computation ---
+    try:
+        from packages.cvss import score_findings
+        score_findings(data.get("findings", []))
+        for finding in data.get("findings", []):
+            score = finding.get("cvss_score_estimate")
+            vector = finding.get("cvss_vector")
+            if score is not None:
+                print(f"  {finding['id']}: {vector} -> {score}")
+        _save_findings(workdir, data)
+    except Exception as e:
+        print(f"  CVSS scoring error: {e}")
+
+    # --- Verdict mapping consistency ---
+    for finding in data.get("findings", []):
+        verdict = finding.get("feasibility", {}).get("verdict", "")
+        if verdict and verdict in VERDICT_MAP:
+            expected = VERDICT_MAP[verdict]
+            actual = finding.get("final_status")
+            if actual != expected:
+                print(f"  MISMATCH: {finding['id']} verdict={verdict} "
+                      f"expected={expected} got={actual}")
+
+    # --- Proximity consistency ---
+    by_vuln = defaultdict(list)
+    for finding in data.get("findings", []):
+        b = finding.get("stage_b_summary", {})
+        if b.get("proximity") is not None:
+            by_vuln[finding.get("vuln_type", "")].append(
+                (finding["id"], b["proximity"])
+            )
+    for vuln, scores in by_vuln.items():
+        if len(scores) > 1:
+            vals = [s[1] for s in scores]
+            if max(vals) - min(vals) > 3:
+                print(f"  PROXIMITY SPREAD: {vuln} — {scores} (spread > 3)")
+
+    _report_workdir_files(workdir, "available for review")
+
+    print("Stage F prep complete")
+
+
+# ---------------------------------------------------------------------------
+# 0: Start run + build inventory
+# ---------------------------------------------------------------------------
+
+def prepare_0(workdir_unused, target=None):
+    if not target:
+        print("ERROR: --target is required for stage 0", file=sys.stderr)
+        sys.exit(1)
+
+    from core.run.output import get_output_dir, TargetMismatchError
+    from core.run.metadata import start_run
+
+    try:
+        out_dir = get_output_dir("validate", target_path=target)
+    except TargetMismatchError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    start_run(out_dir, "validate")
+
+    from packages.exploitability_validation import build_checklist
+    checklist = build_checklist(target, str(out_dir))
+
+    # Create build directory for PoC compilation
+    (out_dir / "build").mkdir(exist_ok=True)
+
+    print(f"Checklist: {checklist['total_files']} files, {checklist['total_items']} items")
+    print(f"OUTPUT_DIR={out_dir}")
+
+
+# ---------------------------------------------------------------------------
+# 1: Generate report + complete run
+# ---------------------------------------------------------------------------
+
+def prepare_1(workdir, target=None):
+    _apply_stage_file(workdir, "F")
+
+    from packages.exploitability_validation.report import write_validation_report
+    try:
+        write_validation_report(workdir)
+        print("Report generated")
+    except Exception as e:
+        print(f"Report error: {e}")
+
+    try:
+        from packages.diagram import render_and_write
+        render_and_write(Path(workdir))
+        print("Diagrams generated")
+    except Exception as e:
+        print(f"Diagram error: {e}")
+
+    # Print summary
+    from packages.exploitability_validation.report import generate_summary
+    print(generate_summary(workdir))
+
+    # Complete run lifecycle
+    from core.run.metadata import complete_run
+    try:
+        complete_run(Path(workdir))
+    except Exception as e:
+        print(f"Lifecycle error: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+STAGES = {
+    "0": prepare_0,
+    "A": prepare_A,
+    "B": prepare_B,
+    "C": prepare_C,
+    "D": prepare_D,
+    "E": prepare_E,
+    "F": prepare_F,
+    "1": prepare_1,
+}
+
+
+def main():
+    args = sys.argv[1:]
+    if not args or args[0] not in STAGES:
+        print(f"Usage: {sys.argv[0]} <0|A|B|C|D|E|F|1> [workdir] [--target <path>]")
+        sys.exit(1)
+
+    stage = args[0]
+    target = None
+    if "--target" in args:
+        idx = args.index("--target")
+        if idx + 1 < len(args):
+            target = args[idx + 1]
+
+    # Stage 0 doesn't need a workdir (it creates one)
+    if stage == "0":
+        prepare_0(None, target)
+        return
+
+    # All other stages need a workdir
+    if len(args) < 2 or args[1].startswith("--"):
+        print(f"ERROR: workdir required for stage {stage}", file=sys.stderr)
+        sys.exit(1)
+
+    workdir = args[1]
+    if not Path(workdir).is_dir():
+        print(f"ERROR: workdir not found: {workdir}", file=sys.stderr)
+        sys.exit(1)
+
+    STAGES[stage](workdir, target)
+
+
+if __name__ == "__main__":
+    main()

--- a/libexec/raptor-run-feasibility
+++ b/libexec/raptor-run-feasibility
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Run exploit feasibility analysis on a binary for a group of findings.
+
+Usage: raptor-run-feasibility <binary_path> <findings.json> <output_dir> [--vuln-type <type>]
+
+Runs analyze_binary once, saves exploit context, then maps constraints
+to all findings that reference this binary. Updates findings.json in place.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.json import load_json, save_json
+
+
+def main():
+    if len(sys.argv) < 4:
+        print(f"Usage: {sys.argv[0]} <binary_path> <findings.json> <output_dir> [--vuln-type <type>]")
+        sys.exit(1)
+
+    binary_path = sys.argv[1]
+    findings_path = Path(sys.argv[2])
+    output_dir = sys.argv[3]
+
+    vuln_type = None
+    if "--vuln-type" in sys.argv:
+        idx = sys.argv.index("--vuln-type")
+        if idx + 1 < len(sys.argv):
+            vuln_type = sys.argv[idx + 1]
+
+    if not Path(binary_path).exists():
+        print(f"ERROR: binary not found: {binary_path}")
+        sys.exit(1)
+
+    findings_data = load_json(findings_path)
+    if not findings_data:
+        print("ERROR: cannot load findings")
+        sys.exit(1)
+
+    # Find findings that reference this binary
+    group = [
+        f for f in findings_data.get("findings", [])
+        if f.get("feasibility", {}).get("binary_path") == binary_path
+        and f.get("status") != "disproven"
+        and f.get("ruling", {}).get("status") != "ruled_out"
+    ]
+
+    if not group:
+        print(f"No findings reference binary: {binary_path}")
+        return
+
+    # Determine vuln_type from first finding if not specified
+    if not vuln_type:
+        vuln_type = group[0].get("vuln_type", "")
+
+    print(f"Analyzing {binary_path} ({len(group)} finding(s), vuln_type={vuln_type})")
+
+    from packages.exploit_feasibility import (
+        save_exploit_context,
+        load_exploit_context,
+        map_findings_to_constraints,
+    )
+
+    # Run analysis and save context in one call (avoids duplicate analysis)
+    context_file = save_exploit_context(binary_path, output_dir=output_dir, vuln_type=vuln_type)
+    print(f"  Context saved: {context_file}")
+
+    # Load context for mapping
+    constraints = load_exploit_context(context_file)
+    result = constraints
+    print(f"  Binary verdict (generic): {constraints.get('verdict', 'unknown')}")
+    print(f"  Mapping per-finding verdicts (vuln-type-aware)...")
+    mapped = map_findings_to_constraints(
+        [{"id": f["id"], "vuln_type": f.get("vuln_type", "")} for f in group],
+        constraints,
+    )
+
+    # Update findings with feasibility data
+    by_id = {f["id"]: f for f in findings_data.get("findings", [])}
+    for assessment in mapped:
+        finding = by_id.get(assessment.finding_id)
+        if finding:
+            finding["feasibility"] = {
+                "status": "analyzed",
+                "binary_path": binary_path,
+                "context_file": str(context_file),
+                "verdict": assessment.verdict,
+                "impact": assessment.impact,
+                "blockers": assessment.blockers,
+                "chain_breaks": result.get("chain_breaks", []),
+                "what_would_help": result.get("what_would_help", []),
+                "notes": assessment.notes,
+                "exploitation_paths": [
+                    {"technique": p.technique, "target": p.target}
+                    for p in (assessment.exploitation_paths or [])
+                ],
+            }
+            finding["stage_e_summary"] = {
+                "verdict": assessment.verdict,
+                "binary_path": binary_path,
+                "impact": assessment.impact,
+            }
+            print(f"  {finding['id']}: {assessment.verdict}")
+
+    save_json(findings_path, findings_data)
+    print(f"Updated {len(mapped)} finding(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/libexec/raptor-validate-schema
+++ b/libexec/raptor-validate-schema
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Validate a RAPTOR JSON output file against its schema.
+
+Usage: raptor-validate-schema <type> <file>
+
+Types:
+  findings        findings.json
+  checklist       checklist.json
+  attack-tree     attack-tree.json
+  attack-paths    attack-paths.json
+  attack-surface  attack-surface.json
+  hypotheses      hypotheses.json
+  disproven       disproven.json
+
+Exit code 0 on success, 1 on validation errors, 2 on missing file.
+
+On success, records file hash in <dir>/.validated so the prep script
+can skip re-validation if the file hasn't changed.
+"""
+import hashlib
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.json import load_json, save_json
+
+
+VALIDATORS = {
+    "findings": "validate_findings",
+    "checklist": "validate_checklist",
+    "attack-tree": "validate_attack_tree",
+    "attack-paths": "validate_attack_paths",
+    "attack-surface": "validate_attack_surface",
+    "hypotheses": "validate_hypotheses",
+    "disproven": "validate_disproven",
+    "stage": None,  # handled separately
+}
+
+
+def _hash_file(filepath):
+    return hashlib.sha256(filepath.read_bytes()).hexdigest()
+
+
+def _read_validated(directory):
+    """Read .validated hashes. Returns {filename: hash}."""
+    vfile = Path(directory) / ".validated"
+    result = {}
+    if vfile.exists():
+        for line in vfile.read_text().splitlines():
+            if ":" in line:
+                name, h = line.split(":", 1)
+                result[name.strip()] = h.strip()
+    return result
+
+
+def _write_validated(directory, filename, filehash):
+    """Record a validated file hash."""
+    vfile = Path(directory) / ".validated"
+    existing = _read_validated(directory)
+    existing[filename] = filehash
+    lines = [f"{k}:{v}" for k, v in sorted(existing.items())]
+    vfile.write_text("\n".join(lines) + "\n")
+
+
+def _validate_stage_file(data, filename):
+    """Validate a stage-X.json file. Returns list of errors (empty = valid)."""
+    errors = []
+
+    if not isinstance(data, dict):
+        return ["stage file must be a JSON object"]
+
+    stage = data.get("stage", "")
+    if not stage:
+        errors.append("missing 'stage' field")
+
+    # Stage A: build format — has "findings" array
+    if stage.upper() == "A":
+        if "findings" not in data:
+            errors.append("stage-a.json must have 'findings' array")
+        elif not isinstance(data["findings"], list):
+            errors.append("'findings' must be an array")
+        else:
+            for i, f in enumerate(data["findings"]):
+                if not isinstance(f, dict):
+                    errors.append(f"findings[{i}]: must be an object")
+                elif not f.get("id"):
+                    errors.append(f"findings[{i}]: missing 'id'")
+                elif not f.get("vuln_type"):
+                    errors.append(f"findings[{i}]: missing 'vuln_type'")
+    else:
+        # Stages B-F: update format — has "updates" map
+        if "updates" not in data:
+            errors.append(f"{filename} must have 'updates' map")
+        elif not isinstance(data["updates"], dict):
+            errors.append("'updates' must be an object (finding ID -> fields)")
+        else:
+            for fid, update in data["updates"].items():
+                if not isinstance(update, dict):
+                    errors.append(f"updates.{fid}: must be an object")
+
+    return errors
+
+
+def is_already_validated(filepath):
+    """Check if file was already validated and hasn't changed."""
+    filepath = Path(filepath)
+    validated = _read_validated(filepath.parent)
+    recorded = validated.get(filepath.name)
+    if not recorded:
+        return False
+    return recorded == _hash_file(filepath)
+
+
+def main():
+    if len(sys.argv) < 3 or sys.argv[1] not in VALIDATORS:
+        print(f"Usage: {sys.argv[0]} <type> <file>")
+        print(f"Types: {', '.join(sorted(VALIDATORS.keys()))}")
+        sys.exit(2)
+
+    schema_type = sys.argv[1]
+    filepath = Path(sys.argv[2])
+
+    # Auto-detect stage files regardless of what type was requested
+    if filepath.name.startswith("stage-") and filepath.name.endswith(".json"):
+        if schema_type != "stage":
+            print(f"NOTE: auto-detected stage file — using 'stage' validator instead of '{schema_type}'")
+            schema_type = "stage"
+
+    if not filepath.exists():
+        print(f"ERROR: file not found: {filepath}")
+        sys.exit(2)
+
+    data = load_json(filepath)
+    if data is None:
+        print(f"ERROR: cannot parse JSON: {filepath}")
+        sys.exit(2)
+
+    # Stage file validation (different format from findings.json)
+    if schema_type == "stage":
+        errors = _validate_stage_file(data, filepath.name)
+        if not errors:
+            _write_validated(filepath.parent, filepath.name, _hash_file(filepath))
+            print(f"OK: {filepath.name}")
+        else:
+            print(f"ERRORS in {filepath.name}:")
+            for e in errors:
+                print(f"  {e}")
+            sys.exit(1)
+        return
+
+    # Normalise vuln_types before validating findings
+    if schema_type == "findings":
+        from core.schema_constants import normalise_vuln_type
+        changed = False
+        for f in data.get("findings", []):
+            vt = f.get("vuln_type", "")
+            norm = normalise_vuln_type(vt)
+            if norm != vt:
+                f["vuln_type"] = norm
+                changed = True
+        if changed:
+            save_json(filepath, data)
+
+    from packages.exploitability_validation import schemas
+    validator = getattr(schemas, VALIDATORS[schema_type])
+    valid, errors = validator(data)
+
+    if valid:
+        _write_validated(filepath.parent, filepath.name, _hash_file(filepath))
+        print(f"OK: {filepath.name}")
+    else:
+        print(f"ERRORS in {filepath.name}:")
+        for e in errors:
+            print(f"  {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/exploit_feasibility/finding_mapper.py
+++ b/packages/exploit_feasibility/finding_mapper.py
@@ -262,11 +262,11 @@ def _assess_null_deref(finding: Dict, c: Dict, null_deref_exploitable: bool = Fa
         )
 
     return FeasibilityAssessment(
-        verdict='exploitable',
+        verdict='unlikely',
         impact='dos',
         exploitation_paths=[],
-        blockers=['NULL page is unmapped — deref crashes process, no code execution path'],
-        notes=_build_notes('Crash on NULL dereference. DoS only — no write primitive. Use --null-deref-exploitable for kernel vulnerabilities where userspace can mmap page 0.', ctx),
+        blockers=['NULL page is unmapped (mmap_min_addr) — deref crashes process, no code execution path'],
+        notes=_build_notes('Crash on NULL dereference. DoS only — no write primitive, no control flow hijack. Use --null-deref-exploitable for kernel vulnerabilities where userspace can mmap page 0.', ctx),
         preconditions=ctx.get('preconditions', []),
     )
 
@@ -417,6 +417,9 @@ _ASSESSORS = {
     'use_after_free': _assess_use_after_free,
     'heap_overflow': _assess_buffer_overflow,  # same mitigations apply
     'stack_overflow': _assess_buffer_overflow,
+    'integer_overflow': _assess_buffer_overflow,  # typically leads to heap overflow
+    'out_of_bounds_read': _assess_buffer_overflow,
+    'out_of_bounds_write': _assess_buffer_overflow,
 }
 
 

--- a/packages/exploitability_validation/models.py
+++ b/packages/exploitability_validation/models.py
@@ -247,6 +247,22 @@ class Finding:
     ruling: Ruling = field(default_factory=Ruling)
     feasibility: Feasibility = field(default_factory=Feasibility)
 
+    # Per-stage carry-forward summaries (written by each stage as it completes)
+    stage_a_summary: Optional[dict] = None   # {confidence, status, candidate_reasoning}
+    stage_b_summary: Optional[dict] = None   # {hypothesis_id, hypothesis_status, proximity, attack_path_id}
+    stage_c_summary: Optional[dict] = None   # {passed, checks: {file_exists, code_verbatim, flow_real, reachable}}
+    stage_d_summary: Optional[dict] = None   # {ruling, disqualifier, cvss_vector}
+    stage_e_summary: Optional[dict] = None   # {verdict, binary_path, impact}
+    stage_f_summary: Optional[dict] = None   # {corrections: [...], review_notes}
+
+    # Origin tracking (for conditional Stage C behaviour in future)
+    origin: Optional[str] = None             # "claude_native", "sarif_import", "pre_existing"
+
+    # Mechanical pre-check flags
+    dedup_flag: Optional[str] = None         # A1: "potential_dup:<other-id>" or None
+    checklist_verified: Optional[bool] = None  # C0: file+line found in inventory
+    test_code_flag: Optional[bool] = None    # D0: file matches test/mock pattern
+
     # Metadata
     disproved_because: Optional[str] = None
     candidate_reasoning: Optional[str] = None
@@ -288,6 +304,16 @@ class Finding:
             sanity_check=SanityCheck.from_dict(d.get("sanity_check")),
             ruling=Ruling.from_dict(d.get("ruling")),
             feasibility=Feasibility.from_dict(d.get("feasibility")),
+            stage_a_summary=d.get("stage_a_summary"),
+            stage_b_summary=d.get("stage_b_summary"),
+            stage_c_summary=d.get("stage_c_summary"),
+            stage_d_summary=d.get("stage_d_summary"),
+            stage_e_summary=d.get("stage_e_summary"),
+            stage_f_summary=d.get("stage_f_summary"),
+            origin=d.get("origin"),
+            dedup_flag=d.get("dedup_flag"),
+            checklist_verified=d.get("checklist_verified"),
+            test_code_flag=d.get("test_code_flag"),
             disproved_because=d.get("disproved_because"),
             candidate_reasoning=d.get("candidate_reasoning"),
             message=d.get("message"),

--- a/packages/exploitability_validation/report.py
+++ b/packages/exploitability_validation/report.py
@@ -38,7 +38,11 @@ def generate_validation_report(
 
     # Build metadata
     stages_run = ["0", "A", "B", "C", "D"]
-    if (out / "exploit-context.json").exists():
+    stage_e_ran = any(
+        f.get("feasibility", {}).get("status") == "analyzed"
+        for f in findings
+    ) or list(out.glob("*_exploit_context.json"))
+    if stage_e_ran:
         stages_run.append("E")
     stages_run.extend(["F", "1"])
 
@@ -74,8 +78,11 @@ def generate_validation_report(
     # Build extra sections
     extra_sections = []
 
-    # Environment constraints from exploit-context.json
-    exploit_ctx = load_json(out / "exploit-context.json")
+    # Environment constraints from *_exploit_context.json
+    exploit_ctx = None
+    ctx_files = list(out.glob("*_exploit_context.json"))
+    if ctx_files:
+        exploit_ctx = load_json(ctx_files[0])
     if exploit_ctx:
         protections = exploit_ctx.get("binary_analysis", {}).get("protections", {})
         if protections:
@@ -85,6 +92,17 @@ def generate_validation_report(
                     continue
                 lines.append(f"| {name} | {'Enabled' if enabled else 'Disabled'} |")
             extra_sections.append(ReportSection("Environment Constraints", "\n".join(lines)))
+
+    # Stage E skipped warning
+    skipped_e = [f for f in findings if f.get("feasibility", {}).get("status") == "skipped"]
+    if skipped_e:
+        ids = ", ".join(f["id"] for f in skipped_e)
+        extra_sections.append(ReportSection(
+            "Stage E Skipped",
+            f"Feasibility analysis was skipped for {len(skipped_e)} memory corruption "
+            f"finding(s) ({ids}) because no binary was provided. "
+            f"Re-run with `--binary <path>` for exploit constraint analysis."
+        ))
 
     # Stage F review
     stage_f_notes = findings_data.get("stage_f_review")

--- a/packages/exploitability_validation/schemas.py
+++ b/packages/exploitability_validation/schemas.py
@@ -274,7 +274,23 @@ FINDING_SCHEMA = {
             "type": "string",
             "enum": ["exploitable", "confirmed_constrained", "confirmed_blocked",
                      "confirmed", "confirmed_unverified"]
-        }
+        },
+        # --- Per-stage carry-forward summaries ---
+        "stage_a_summary": {"type": "object", "description": "Stage A conclusion: confidence, status, candidate_reasoning"},
+        "stage_b_summary": {"type": "object", "description": "Stage B conclusion: hypothesis_id, hypothesis_status, proximity"},
+        "stage_c_summary": {"type": "object", "description": "Stage C conclusion: passed, checks"},
+        "stage_d_summary": {"type": "object", "description": "Stage D conclusion: ruling, disqualifier, cvss_vector"},
+        "stage_e_summary": {"type": "object", "description": "Stage E conclusion: verdict, binary_path, impact"},
+        "stage_f_summary": {"type": "object", "description": "Stage F conclusion: corrections, review_notes"},
+        # --- Origin and mechanical flags ---
+        "origin": {
+            "type": "string",
+            "enum": ["claude_native", "sarif_import", "pre_existing"],
+            "description": "How this finding entered the pipeline"
+        },
+        "dedup_flag": {"type": ["string", "null"], "description": "A1: potential duplicate indicator"},
+        "checklist_verified": {"type": "boolean", "description": "C0: file+line found in inventory"},
+        "test_code_flag": {"type": "boolean", "description": "D0: file matches test/mock pattern"}
     }
 }
 
@@ -648,6 +664,15 @@ def validate_disproven(data: dict) -> tuple[bool, list]:
     return validate_json(data, DISPROVEN_SCHEMA, "disproven")
 
 
+def validate_hypotheses(data: list) -> tuple[bool, list]:
+    """Validate hypotheses.json (array of hypotheses)"""
+    all_errors = []
+    for i, hyp in enumerate(data):
+        errors = validate_type(hyp, HYPOTHESIS_SCHEMA, f"hypotheses[{i}]")
+        all_errors.extend(errors)
+    return len(all_errors) == 0, all_errors
+
+
 # Convenience function for creating valid structures
 def create_empty_checklist(target_path: str) -> dict:
     """Create an empty but valid checklist structure."""
@@ -675,15 +700,17 @@ def create_finding(
     vuln_type: str,
     status: str = "not_disproven",
     cwe_id: str | None = None,
+    **kwargs,
 ) -> dict:
     """Create a valid finding structure.
 
-    Sub-structures (proof, poc, sanity_check, ruling, feasibility) are
-    initialized as empty dicts (not None), preventing NoneType errors
-    when callers do finding['ruling'].get('status').
+    Accepts **kwargs for any additional Finding fields (description,
+    confidence, candidate_reasoning, etc.) — extras are set on the
+    returned dict after creation. Sub-structures (proof, poc, etc.)
+    should still be set as dicts on the returned object, not via kwargs.
     """
     from .models import Finding
-    return Finding(
+    result = Finding(
         id=finding_id,
         file=file,
         function=function,
@@ -692,6 +719,11 @@ def create_finding(
         status=status,
         cwe_id=cwe_id,
     ).to_dict()
+    # Apply any extra scalar fields Claude passes
+    for k, v in kwargs.items():
+        if k not in result:
+            result[k] = v
+    return result
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/packages/exploitability_validation/tests/test_prepare_validation.py
+++ b/packages/exploitability_validation/tests/test_prepare_validation.py
@@ -1,0 +1,420 @@
+"""Tests for raptor-prepare-validation-stage and related libexec scripts."""
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+# Add repo root to path (packages/exploitability_validation/tests → repo root)
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from core.json import load_json, save_json
+
+
+# ---------------------------------------------------------------------------
+# Import functions from libexec scripts (they're not packages)
+# ---------------------------------------------------------------------------
+
+import importlib.util
+
+def _load_script(name):
+    script = Path(__file__).resolve().parents[3] / "libexec" / name
+    spec = importlib.util.spec_from_file_location(
+        name.replace("-", "_"),
+        script,
+        submodule_search_locations=[],
+    )
+    if spec is None:
+        # Fallback: exec the script contents directly
+        mod_name = name.replace("-", "_")
+        import types
+        mod = types.ModuleType(mod_name)
+        mod.__file__ = str(script)
+        code = compile(script.read_text(), str(script), "exec")
+        exec(code, mod.__dict__)
+        return mod
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+_prep = _load_script("raptor-prepare-validation-stage")
+_validator = _load_script("raptor-validate-schema")
+
+
+# ---------------------------------------------------------------------------
+# _deep_merge
+# ---------------------------------------------------------------------------
+
+class TestDeepMerge(unittest.TestCase):
+
+    def test_shallow_overwrite(self):
+        target = {"a": 1, "b": 2}
+        _prep._deep_merge(target, {"b": 3, "c": 4})
+        self.assertEqual(target, {"a": 1, "b": 3, "c": 4})
+
+    def test_nested_merge(self):
+        target = {"a": {"x": 1, "y": 2}}
+        _prep._deep_merge(target, {"a": {"y": 3, "z": 4}})
+        self.assertEqual(target, {"a": {"x": 1, "y": 3, "z": 4}})
+
+    def test_source_wins_on_type_conflict(self):
+        target = {"a": {"nested": True}}
+        _prep._deep_merge(target, {"a": "flat"})
+        self.assertEqual(target, {"a": "flat"})
+
+    def test_empty_source(self):
+        target = {"a": 1}
+        _prep._deep_merge(target, {})
+        self.assertEqual(target, {"a": 1})
+
+
+# ---------------------------------------------------------------------------
+# _apply_stage_file
+# ---------------------------------------------------------------------------
+
+class TestApplyStageFile(unittest.TestCase):
+
+    def _make_workdir(self, d, findings=None, stage_file=None, stage_name="b"):
+        if findings:
+            save_json(Path(d) / "findings.json", findings)
+        if stage_file:
+            save_json(Path(d) / f"stage-{stage_name}.json", stage_file)
+
+    def _base_findings(self):
+        return {
+            "stage": "A",
+            "findings": [
+                {"id": "FIND-0001", "file": "a.c", "function": "main", "line": 1,
+                 "vuln_type": "buffer_overflow", "status": "not_disproven"},
+                {"id": "FIND-0002", "file": "b.c", "function": "main", "line": 1,
+                 "vuln_type": "command_injection", "status": "not_disproven"},
+            ]
+        }
+
+    def test_stage_a_builds_findings(self):
+        with TemporaryDirectory() as d:
+            stage_a = {
+                "stage": "A",
+                "target_path": "/tmp/test",
+                "findings": [
+                    {"id": "F1", "file": "x.c", "function": "main", "line": 1,
+                     "vuln_type": "buffer_overflow", "status": "not_disproven"}
+                ]
+            }
+            save_json(Path(d) / "stage-a.json", stage_a)
+            result = _prep._apply_stage_file(d, "A")
+            self.assertTrue(result)
+
+            findings = load_json(Path(d) / "findings.json")
+            self.assertEqual(len(findings["findings"]), 1)
+            self.assertEqual(findings["findings"][0]["id"], "F1")
+            # Stage file should be deleted
+            self.assertFalse((Path(d) / "stage-a.json").exists())
+
+    def test_updates_map_merges_by_id(self):
+        with TemporaryDirectory() as d:
+            self._make_workdir(d, findings=self._base_findings())
+            stage_b = {
+                "stage": "B",
+                "updates": {
+                    "FIND-0001": {"stage_b_summary": {"hypothesis_status": "confirmed", "proximity": 9}},
+                }
+            }
+            save_json(Path(d) / "stage-b.json", stage_b)
+            _prep._apply_stage_file(d, "B")
+
+            findings = load_json(Path(d) / "findings.json")
+            # Both findings preserved
+            self.assertEqual(len(findings["findings"]), 2)
+            # FIND-0001 has stage_b_summary
+            f1 = next(f for f in findings["findings"] if f["id"] == "FIND-0001")
+            self.assertEqual(f1["stage_b_summary"]["proximity"], 9)
+            # FIND-0002 unchanged
+            f2 = next(f for f in findings["findings"] if f["id"] == "FIND-0002")
+            self.assertNotIn("stage_b_summary", f2)
+
+    def test_findings_array_merges_by_id_not_replaces(self):
+        """Critical test: findings array in stage file must merge, not replace."""
+        with TemporaryDirectory() as d:
+            self._make_workdir(d, findings=self._base_findings())
+            # Stage file with only 1 finding (the data-loss bug scenario)
+            stage_c = {
+                "stage": "C",
+                "findings": [
+                    {"id": "FIND-0001", "sanity_check": {"passed": True}},
+                ]
+            }
+            save_json(Path(d) / "stage-c.json", stage_c)
+            _prep._apply_stage_file(d, "C")
+
+            findings = load_json(Path(d) / "findings.json")
+            # BOTH findings must still exist
+            self.assertEqual(len(findings["findings"]), 2)
+            # FIND-0001 has sanity_check merged
+            f1 = next(f for f in findings["findings"] if f["id"] == "FIND-0001")
+            self.assertTrue(f1["sanity_check"]["passed"])
+            # FIND-0002 preserved
+            f2 = next(f for f in findings["findings"] if f["id"] == "FIND-0002")
+            self.assertEqual(f2["vuln_type"], "command_injection")
+
+    def test_metadata_copied_but_not_findings_key(self):
+        with TemporaryDirectory() as d:
+            self._make_workdir(d, findings=self._base_findings())
+            stage_f = {
+                "stage": "F",
+                "updates": {},
+                "stage_f_review": "No corrections needed",
+            }
+            save_json(Path(d) / "stage-f.json", stage_f)
+            _prep._apply_stage_file(d, "F")
+
+            findings = load_json(Path(d) / "findings.json")
+            self.assertEqual(findings["stage_f_review"], "No corrections needed")
+            self.assertEqual(findings["stage"], "F")
+
+    def test_missing_finding_id_warned_not_crashed(self):
+        with TemporaryDirectory() as d:
+            self._make_workdir(d, findings=self._base_findings())
+            stage = {"stage": "D", "updates": {"FIND-9999": {"ruling": {"status": "confirmed"}}}}
+            save_json(Path(d) / "stage-d.json", stage)
+            # Should not raise
+            _prep._apply_stage_file(d, "D")
+            findings = load_json(Path(d) / "findings.json")
+            self.assertEqual(len(findings["findings"]), 2)
+
+    def test_no_stage_file_returns_false(self):
+        with TemporaryDirectory() as d:
+            self.assertFalse(_prep._apply_stage_file(d, "B"))
+
+    def test_stage_file_deleted_after_apply(self):
+        with TemporaryDirectory() as d:
+            self._make_workdir(d, findings=self._base_findings())
+            save_json(Path(d) / "stage-c.json", {"stage": "C", "updates": {}})
+            _prep._apply_stage_file(d, "C")
+            self.assertFalse((Path(d) / "stage-c.json").exists())
+
+
+# ---------------------------------------------------------------------------
+# normalise_vuln_type
+# ---------------------------------------------------------------------------
+
+class TestNormaliseVulnType(unittest.TestCase):
+
+    def test_known_aliases(self):
+        from core.schema_constants import normalise_vuln_type
+        self.assertEqual(normalise_vuln_type("toctou"), "race_condition")
+        self.assertEqual(normalise_vuln_type("null_pointer_dereference"), "null_deref")
+        self.assertEqual(normalise_vuln_type("uaf"), "use_after_free")
+        self.assertEqual(normalise_vuln_type("rce"), "command_injection")
+        self.assertEqual(normalise_vuln_type("sqli"), "sql_injection")
+
+    def test_canonical_passthrough(self):
+        from core.schema_constants import normalise_vuln_type
+        self.assertEqual(normalise_vuln_type("buffer_overflow"), "buffer_overflow")
+        self.assertEqual(normalise_vuln_type("xss"), "xss")
+
+    def test_unknown_passthrough(self):
+        from core.schema_constants import normalise_vuln_type
+        self.assertEqual(normalise_vuln_type("exotic_bug"), "exotic_bug")
+
+    def test_empty_string(self):
+        from core.schema_constants import normalise_vuln_type
+        self.assertEqual(normalise_vuln_type(""), "")
+
+    def test_case_insensitive(self):
+        from core.schema_constants import normalise_vuln_type
+        self.assertEqual(normalise_vuln_type("TOCTOU"), "race_condition")
+        self.assertEqual(normalise_vuln_type("Null_Pointer_Dereference"), "null_deref")
+
+
+# ---------------------------------------------------------------------------
+# Stage file validator
+# ---------------------------------------------------------------------------
+
+class TestStageFileValidator(unittest.TestCase):
+
+    def test_stage_a_valid(self):
+        data = {"stage": "A", "target_path": "/tmp", "findings": [
+            {"id": "F1", "vuln_type": "xss"}
+        ]}
+        errors = _validator._validate_stage_file(data, "stage-a.json")
+        self.assertEqual(errors, [])
+
+    def test_stage_b_valid(self):
+        data = {"stage": "B", "updates": {"FIND-001": {"stage_b_summary": {}}}}
+        errors = _validator._validate_stage_file(data, "stage-b.json")
+        self.assertEqual(errors, [])
+
+    def test_missing_stage_field(self):
+        data = {"updates": {}}
+        errors = _validator._validate_stage_file(data, "stage-c.json")
+        self.assertIn("missing 'stage' field", errors)
+
+    def test_stage_a_missing_findings(self):
+        data = {"stage": "A"}
+        errors = _validator._validate_stage_file(data, "stage-a.json")
+        self.assertTrue(any("findings" in e for e in errors))
+
+    def test_updates_must_be_dict(self):
+        data = {"stage": "C", "updates": []}
+        errors = _validator._validate_stage_file(data, "stage-c.json")
+        self.assertTrue(any("object" in e for e in errors))
+
+    def test_finding_missing_id(self):
+        data = {"stage": "A", "findings": [{"vuln_type": "xss"}]}
+        errors = _validator._validate_stage_file(data, "stage-a.json")
+        self.assertTrue(any("id" in e for e in errors))
+
+    def test_auto_detect_stage_file(self):
+        """When wrong type passed for stage-*.json, auto-corrects."""
+        with TemporaryDirectory() as d:
+            p = Path(d) / "stage-b.json"
+            save_json(p, {"stage": "B", "updates": {"F1": {"x": 1}}})
+            # This would fail with "findings" validator but should auto-detect
+            os.chdir(d)
+            # Can't easily test the CLI auto-detect without subprocess,
+            # but we can test the _validate_stage_file function directly
+            errors = _validator._validate_stage_file(
+                load_json(p), "stage-b.json"
+            )
+            self.assertEqual(errors, [])
+
+
+# ---------------------------------------------------------------------------
+# Validation hash caching
+# ---------------------------------------------------------------------------
+
+class TestValidationCache(unittest.TestCase):
+
+    def test_validated_file_recorded(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "test.json"
+            p.write_text('{"x": 1}')
+            _validator._write_validated(d, "test.json", _validator._hash_file(p))
+            self.assertTrue(_validator.is_already_validated(p))
+
+    def test_changed_file_not_cached(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "test.json"
+            p.write_text('{"x": 1}')
+            _validator._write_validated(d, "test.json", _validator._hash_file(p))
+            p.write_text('{"x": 2}')
+            self.assertFalse(_validator.is_already_validated(p))
+
+    def test_no_validated_file(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "test.json"
+            p.write_text('{"x": 1}')
+            self.assertFalse(_validator.is_already_validated(p))
+
+
+# ---------------------------------------------------------------------------
+# Fast-path (prepare_B)
+# ---------------------------------------------------------------------------
+
+class TestFastPath(unittest.TestCase):
+
+    def _make_poc_findings(self):
+        return {
+            "stage": "A",
+            "findings": [
+                {"id": "FIND-0001", "file": "a.c", "function": "main", "line": 1,
+                 "vuln_type": "buffer_overflow", "status": "poc_success",
+                 "confidence": "high", "dataflow_summary": "argv[1] -> strcpy -> buf[16]",
+                 "origin": "claude_native",
+                 "stage_a_summary": {"confidence": "high", "status": "poc_success"},
+                 "poc": {"description": "overflow", "payload": "./a AAAA", "result": "SIGSEGV"}},
+                {"id": "FIND-0002", "file": "b.c", "function": "main", "line": 1,
+                 "vuln_type": "race_condition", "status": "not_disproven",
+                 "confidence": "medium",
+                 "origin": "claude_native",
+                 "stage_a_summary": {"confidence": "medium", "status": "not_disproven"}},
+            ]
+        }
+
+    def test_fast_path_creates_hypothesis(self):
+        with TemporaryDirectory() as d:
+            save_json(Path(d) / "findings.json", self._make_poc_findings())
+            _prep.prepare_B(d)
+
+            hyp = load_json(Path(d) / "hypotheses.json")
+            self.assertTrue(any(h.get("finding") == "FIND-0001" for h in hyp))
+
+    def test_fast_path_creates_attack_path(self):
+        with TemporaryDirectory() as d:
+            save_json(Path(d) / "findings.json", self._make_poc_findings())
+            _prep.prepare_B(d)
+
+            paths = load_json(Path(d) / "attack-paths.json")
+            self.assertTrue(any(p.get("finding") == "FIND-0001" for p in paths))
+
+    def test_fast_path_sets_stage_b_summary(self):
+        with TemporaryDirectory() as d:
+            save_json(Path(d) / "findings.json", self._make_poc_findings())
+            _prep.prepare_B(d)
+
+            findings = load_json(Path(d) / "findings.json")
+            f1 = next(f for f in findings["findings"] if f["id"] == "FIND-0001")
+            self.assertIn("stage_b_summary", f1)
+            self.assertEqual(f1["stage_b_summary"]["hypothesis_status"], "confirmed")
+
+    def test_not_disproven_not_fast_pathed(self):
+        with TemporaryDirectory() as d:
+            save_json(Path(d) / "findings.json", self._make_poc_findings())
+            _prep.prepare_B(d)
+
+            findings = load_json(Path(d) / "findings.json")
+            f2 = next(f for f in findings["findings"] if f["id"] == "FIND-0002")
+            self.assertNotIn("stage_b_summary", f2)
+
+    def test_low_confidence_not_fast_pathed(self):
+        with TemporaryDirectory() as d:
+            data = self._make_poc_findings()
+            data["findings"][0]["confidence"] = "low"
+            data["findings"][0]["stage_a_summary"]["confidence"] = "low"
+            save_json(Path(d) / "findings.json", data)
+            _prep.prepare_B(d)
+
+            findings = load_json(Path(d) / "findings.json")
+            f1 = next(f for f in findings["findings"] if f["id"] == "FIND-0001")
+            self.assertNotIn("stage_b_summary", f1)
+
+
+# ---------------------------------------------------------------------------
+# Null deref verdict fix
+# ---------------------------------------------------------------------------
+
+class TestNullDerefVerdict(unittest.TestCase):
+
+    def test_userland_is_unlikely(self):
+        from packages.exploit_feasibility.finding_mapper import map_findings_to_constraints
+        findings = [{"id": "F1", "vuln_type": "null_deref",
+                     "ruling": {"status": "confirmed"}}]
+        constraints = {"protections": {"canary": False, "nx": True, "pie": False}}
+        result = map_findings_to_constraints(findings, constraints)
+        self.assertEqual(result[0].verdict, "unlikely")
+        self.assertEqual(result[0].impact, "dos")
+
+    def test_kernel_is_exploitable(self):
+        from packages.exploit_feasibility.finding_mapper import map_findings_to_constraints
+        findings = [{"id": "F1", "vuln_type": "null_deref",
+                     "ruling": {"status": "confirmed"}}]
+        constraints = {"protections": {"canary": False, "nx": False, "pie": False}}
+        result = map_findings_to_constraints(findings, constraints,
+                                             null_deref_exploitable=True)
+        self.assertEqual(result[0].verdict, "exploitable")
+
+    def test_integer_overflow_has_assessor(self):
+        from packages.exploit_feasibility.finding_mapper import map_findings_to_constraints
+        findings = [{"id": "F1", "vuln_type": "integer_overflow",
+                     "ruling": {"status": "confirmed"}}]
+        constraints = {"protections": {"canary": False, "nx": True, "pie": False}}
+        result = map_findings_to_constraints(findings, constraints)
+        # Should not be "unknown" — should use buffer_overflow assessor
+        self.assertNotEqual(result[0].verdict, "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/exploitability_validation/tests/test_report.py
+++ b/packages/exploitability_validation/tests/test_report.py
@@ -128,7 +128,7 @@ class TestGenerateReport(unittest.TestCase):
     def test_exploit_context_section(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             (Path(tmpdir) / "findings.json").write_text(json.dumps(MINIMAL_FINDINGS))
-            (Path(tmpdir) / "exploit-context.json").write_text(json.dumps({
+            (Path(tmpdir) / "vuln_exploit_context.json").write_text(json.dumps({
                 "binary_analysis": {
                     "protections": {"relro": True, "pie": False, "nx": True, "canary": False}
                 }

--- a/packages/exploitability_validation/tests/test_validation.py
+++ b/packages/exploitability_validation/tests/test_validation.py
@@ -2907,7 +2907,7 @@ class TestFindingMapper:
         from packages.exploit_feasibility.finding_mapper import map_findings_to_constraints
         findings = [self._make_finding("F1", "null_deref", "confirmed")]
         result = map_findings_to_constraints(findings, self._make_constraints())
-        assert result[0].verdict == "exploitable"
+        assert result[0].verdict == "unlikely"
         assert result[0].impact == "dos"
 
     def test_null_deref_kernel(self):

--- a/packages/llm_analysis/llm/client.py
+++ b/packages/llm_analysis/llm/client.py
@@ -214,7 +214,12 @@ class LLMClient:
 
         # Initialize cache
         if self.config.enable_caching:
-            self.config.cache_dir.mkdir(parents=True, exist_ok=True)
+            try:
+                self.config.cache_dir.mkdir(parents=True, exist_ok=True)
+            except OSError:
+                self.config.enable_caching = False
+                logger.warning("Cannot create cache dir %s — caching disabled",
+                               self.config.cache_dir)
 
         logger.info("LLM Client initialized")
         if self.config.primary_model:

--- a/packages/llm_analysis/llm/client.py
+++ b/packages/llm_analysis/llm/client.py
@@ -218,8 +218,7 @@ class LLMClient:
                 self.config.cache_dir.mkdir(parents=True, exist_ok=True)
             except OSError:
                 self.config.enable_caching = False
-                logger.warning("Cannot create cache dir %s — caching disabled",
-                               self.config.cache_dir)
+                logger.warning(f"Cannot create cache dir {self.config.cache_dir} — caching disabled")
 
         logger.info("LLM Client initialized")
         if self.config.primary_model:


### PR DESCRIPTION
**Summary**                                                                                                                                                                                                          
                                                            
  Major restructure of the /validate pipeline to separate mechanical work                                                                                                                                          
  from LLM reasoning, improve efficiency, and prevent data-loss bugs.                                                                                                                                              
                                                                                                                                                                                                                   
  **Architecture**                                              
   
  - Single libexec/raptor-prepare-validation-stage script handles all mechanical                                                                                                                                   
  work (0, A-F, 1). One permission rule covers the entire pipeline.
  - Per-stage JSON files: Claude writes stage-X.json with only its data. The prep                                                                                                                                  
  script merges into the cumulative findings.json and deletes the stage file.
  - Stage B fast-path: poc_success findings get mechanical audit trail, Claude only                                                                                                                                
  analyses the gaps.
  - Auto-build PoCs for standalone C files with mitigations disabled.                                                                                                                                              
  - Binary autodiscovery matches executables to source files by filename.
  
  **Key fixes**                                                                                                                                                                                                        
   
  - Stage file merger handles both updates map and findings array formats,                                                                                                                                         
  always merges by ID (never replaces — prevents data loss) 
  - Report displays final_status (post-feasibility) not ruling.status (Stage D)
  - Null deref correctly assessed as DoS-only (unlikely, not exploitable)
  - is_exploitable derived mechanically from final_status                                                                                                                                                          
  - vuln_type aliases normalised automatically (toctou→race_condition, etc.)
                                                                                                                                                                                                                   
  **New checks**                                                
  
  - D-1.5 privilege tautology                                                                                                                                                                                      
  - A1 dedup flagging
  - C0 inventory pre-verification                                                                                                                                                                                  
  - D0 test/mock path filter + evidence card assembly       
  - F0 CVSS scoring + verdict/proximity consistency

  **Test plan**

  - 351 tests pass (validation, reporting, libexec, feasibility)                                                                                                                                                   
  - 4 E2E runs on /tmp/vulns (10 C files, 10 findings)
  - Zero pipeline infrastructure errors on final 2 runs                                                                                                                                                            
  - Binary autodiscovery matches 10/10                      
  - Fast-path correctly handles poc_success vs not_disproven                                                                                                                                                       
  - Per-stage JSON merge preserves all findings across stages
  - Report shows correct post-feasibility statuses                      