### PR TITLE
Fix LLM cache dir crash when out/ doesn't exist

### DIFF
--- a/packages/llm_analysis/llm/client.py
+++ b/packages/llm_analysis/llm/client.py
@@ -214,7 +214,12 @@ class LLMClient:
 
         # Initialize cache
         if self.config.enable_caching:
-            self.config.cache_dir.mkdir(parents=True, exist_ok=True)
+            try:
+                self.config.cache_dir.mkdir(parents=True, exist_ok=True)
+            except OSError:
+                self.config.enable_caching = False
+                logger.warning("Cannot create cache dir %s — caching disabled",
+                               self.config.cache_dir)
 
         logger.info("LLM Client initialized")
         if self.config.primary_model:


### PR DESCRIPTION
Fix LLM cache dir crash when out/ doesn't exist                                                                                                                                                                  
                                                            
  LLMClient.__init__ calls cache_dir.mkdir(parents=True) which fails                                                                                                                                               
  with FileNotFoundError on CI where out/ doesn't exist. Catch OSError                                                                                                                                             
  and disable caching gracefully instead of crashing.     