### PR TITLE
Update Slack invite link and copyright information

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Windsurf, Copilot, or Codex? Devin? Cline? Antigravity?
 Hacker poetry? :)
 
 Chat with us on the #raptor channel at the Prompt||GTFO Slack:
-https://join.slack.com/t/promptgtfo/shared_invite/zt-3kbaqgq2p-O8MAvwU1SPc10KjwJ8MN2w
+[https://join.slack.com/t/promptgtfo/shared_invite/zt-3kbaqgq2p-O8MAvwU1SPc10KjwJ8MN2w](https://join.slack.com/t/promptgtfo/shared_invite/zt-3ri5ndtkl-cXwvzcGAs~xdSqWi0e3BJg)
 
 **See:** `docs/EXTENDING_LAUNCHER.md` for developer guide
 
@@ -442,7 +442,7 @@ https://join.slack.com/t/promptgtfo/shared_invite/zt-3kbaqgq2p-O8MAvwU1SPc10KjwJ
 
 ## License
 
-MIT License - Copyright (c) 2025 Gadi Evron, Daniel Cuthbert, Thomas Dullien (Halvar Flake), and Michael Bargury
+MIT License - Copyright (c) 2025 Gadi Evron, Daniel Cuthbert, Thomas Dullien (Halvar Flake), Michael Bargury, John Cartwright
 
 See LICENSE file for full text.
 
@@ -457,4 +457,4 @@ Make sure and review the licenses for the various tools. For example, CodeQL doe
 **Documentation:** See `docs/` directory
 
 Chat with us on the #raptor channel at the Prompt||GTFO Slack:
-https://join.slack.com/t/promptgtfo/shared_invite/zt-3kbaqgq2p-O8MAvwU1SPc10KjwJ8MN2w
+[https://join.slack.com/t/promptgtfo/shared_invite/zt-3kbaqgq2p-O8MAvwU1SPc10KjwJ8MN2w](https://join.slack.com/t/promptgtfo/shared_invite/zt-3ri5ndtkl-cXwvzcGAs~xdSqWi0e3BJg)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change updating an external Slack invite URL and adding an author name to the MIT copyright line; no runtime or security impact.
> 
> **Overview**
> Updates `README.md` to replace the plain Slack invite URL with a Markdown link pointing to a new invite target in both the *Contribute* and *Support* sections.
> 
> Also amends the MIT copyright line to include **John Cartwright**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 409cb5a8e32d83318b228646ccb43ac6a8191484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->