### PR TITLE
Wire understand→validate bridge, add libexec helpers

### DIFF
--- a/.claude/commands/diagram.md
+++ b/.claude/commands/diagram.md
@@ -44,25 +44,13 @@ Omit `--type` to render everything in the directory.
 
 Writes `diagrams.md` into the target directory next to the existing JSON files. One Mermaid fenced block per diagram, with section headings. Renders in GitHub, VS Code, Obsidian, or anything Mermaid-aware.
 
-## Implementation
+## Execution
 
-**CLI:** `python3 generate_diagram.py <out-dir> [options]`
-
-**Library:**
-```python
-import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
-from packages.diagram import render_and_write
-from pathlib import Path
-
-out_file = render_and_write(Path(".out/code-understanding-20240101/"), target="myapp")
+```bash
+libexec/raptor-render-diagrams <out-dir> [--target <name>]
 ```
 
-**`packages/diagram/` modules:**
-- `context_map.py`: context-map.json / attack-surface.json → flowchart LR
-- `flow_trace.py`: flow-trace-*.json → flowchart TD
-- `attack_tree.py`: attack-tree.json → flowchart TD with status styling
-- `attack_paths.py`: attack-paths.json → flowchart TD per path with proximity
-- `renderer.py`: discovers files in a directory, combines into diagrams.md
+Parse `$ARGS` for `<out-dir>` and `--target`, then run the command. Show the output path.
 
 ## When to run
 
@@ -71,12 +59,4 @@ After any of:
 - `/understand --trace <entry>` (produces `flow-trace-*.json`)
 - `/validate` (produces `attack-surface.json`, `attack-tree.json`, `attack-paths.json`)
 
-Point it at the same `--out` directory. It picks up whatever JSON is there: no configuration needed.
-
-## Execution
-
-```
-python3 generate_diagram.py "$ARGS"
-```
-
-Parse `$ARGS` for `<out-dir>`, `--target`, `--type`, and `--stdout`, then call the relevant function from `packages/diagram/`. Show the output path (or content if `--stdout`).
+Point it at the same output directory. It picks up whatever JSON is there: no configuration needed.

--- a/.claude/commands/understand.md
+++ b/.claude/commands/understand.md
@@ -18,13 +18,18 @@ If no mode flag is given, default to `--map`.
 
 ## Execution
 
-**Before starting work**, create the output directory via the run lifecycle:
+**Before starting work**, build the inventory and create the output directory:
 ```bash
-libexec/raptor-run-lifecycle start understand --target <resolved_target> [--out <dir>]
+libexec/raptor-prepare-understand inventory <resolved_target>
 ```
-The last line of output is `OUTPUT_DIR=<path>` — use that path as `$WORKDIR` for all subsequent output files.
+This starts the run lifecycle and builds `checklist.json`. The last line of output is `OUTPUT_DIR=<path>` — use that path as `$WORKDIR` for all subsequent output files.
 
-**After successful completion:**
+**After writing JSON outputs** (for `--map` or `--trace`), generate diagrams:
+```bash
+libexec/raptor-render-diagrams "$OUTPUT_DIR"
+```
+
+**After all work is done:**
 ```bash
 libexec/raptor-run-lifecycle complete "$OUTPUT_DIR"
 ```
@@ -78,18 +83,13 @@ Understanding output feeds into Gadi & JC's epic exploitability validation:
 - `flow-trace-*.json` → confirms reachability for Stage C
 - `variants.json` → expands `checklist.json` scope for Stage 0
 
-**With a project (recommended):** The bridge auto-detects the most recent `/understand` run. Just run both commands — no manual path wiring needed:
+**Automatic bridge:** `/validate` Stage 0 automatically finds and imports `/understand` output. No `--out` alignment needed — the bridge searches co-located files, project siblings, and global `out/` (matching by target path and SHA-256 freshness). Just run both commands:
 ```
-/project use myapp
 /understand ./src --map
 /validate ./src
 ```
 
-**Without a project:** Use `--out` on both commands to share a directory. Using a project is recommended — it handles this automatically.
-```
-/understand ./src --map --out .out/my-run/
-/validate ./src --out .out/my-run/
-```
+This works with or without a project. With a project, sibling runs are found first. Without a project, the bridge matches by `checklist.json` target path across `out/`.
 
 ## Skill Files
 
@@ -112,10 +112,3 @@ All JSON outputs write to `$WORKDIR` (resolved by `raptor-run-lifecycle start`, 
 | `diagrams.md` | `--map`, `--trace` | Mermaid diagrams (auto-generated) |
 | *(none)* | `--teach` | Inline explanation — no file written |
 
-**After writing JSON outputs** for `--map` or `--trace`, generate diagrams:
-```python
-import sys, os; sys.path.insert(0, os.environ["RAPTOR_DIR"])
-from packages.diagram import render_and_write
-from pathlib import Path
-render_and_write(Path(workdir))
-```

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -31,6 +31,8 @@ This starts the run lifecycle and builds the checklist. The last line of output 
 
 ### Stage A (Claude): One-Shot Assessment
 
+**Load:** `.claude/skills/exploitability-validation/stage-a-oneshot.md`
+
 1. **Prep:** `libexec/raptor-prepare-validation-stage A "$OUTPUT_DIR" --target "$TARGET_PATH"`
    Discovers binaries, builds PoCs for standalone C files (mitigations disabled, in `$OUTPUT_DIR/build/`).
 2. **Reasoning:** Read source files, assess each function for vulnerabilities. If binaries are available (from prep output), run them for PoC evidence. If no binaries, do source-only analysis.
@@ -39,6 +41,8 @@ This starts the run lifecycle and builds the checklist. The last line of output 
 **Carry-forward:** Each finding MUST include `origin` and `stage_a_summary` — downstream stages and the prep script check for these.
 
 ### Stage B (Claude): Systematic Analysis
+
+**Load:** `.claude/skills/exploitability-validation/stage-b-process.md`
 
 1. **Prep:** `libexec/raptor-prepare-validation-stage B "$OUTPUT_DIR" --target "$TARGET_PATH"`
    Merges stage-a.json into findings.json. Fast-paths poc_success findings. Reports how many need full analysis.
@@ -49,6 +53,8 @@ This starts the run lifecycle and builds the checklist. The last line of output 
 
 ### Stage C (Claude): Sanity Check
 
+**Load:** `.claude/skills/exploitability-validation/stage-c-sanity.md`
+
 1. **Prep:** `libexec/raptor-prepare-validation-stage C "$OUTPUT_DIR" --target "$TARGET_PATH"`
    Merges stage-b.json, validates 6 working docs, pre-checks findings against inventory.
 2. **Reasoning:** Open each file, verify code verbatim, confirm source→sink flows are real, confirm reachability
@@ -56,12 +62,18 @@ This starts the run lifecycle and builds the checklist. The last line of output 
 
 ### Stage D (Claude): Ruling
 
+**Load:** `.claude/skills/exploitability-validation/stage-d-ruling.md`
+
 1. **Prep:** `libexec/raptor-prepare-validation-stage D "$OUTPUT_DIR" --target "$TARGET_PATH"`
    Merges stage-c.json, flags test/mock paths, assembles evidence cards from carry-forward.
 2. **Reasoning:** Synthesize evidence from A/B/C, apply disqualifier checks (D-0 through D-4), assign CVSS vectors
 3. **Output:** Write `stage-d.json` (per-finding ruling, cvss_vector, stage_d_summary)
 
 ### Stage E (Claude + Python): Feasibility — memory corruption only
+
+**Load:** `.claude/skills/exploitability-validation/stage-e-feasibility.md`
+
+**Display rule:** When displaying Stage E verdicts or final statuses in chat, use Title Case (e.g., "Confirmed (Constrained)" not `confirmed_constrained`). snake_case is for JSON only.
 
 1. **Prep:** `libexec/raptor-prepare-validation-stage E "$OUTPUT_DIR" --target "$TARGET_PATH"`
    Merges stage-d.json, validates Stage D output, auto-discovers binaries in the target directory.
@@ -85,6 +97,8 @@ Skip Stage E if `--skip-feasibility` or no memory corruption findings.
 
 ### Stage F (Claude): Self-Review
 
+**Load:** `.claude/skills/exploitability-validation/stage-f-review.md`
+
 1. **Prep:** `libexec/raptor-prepare-validation-stage F "$OUTPUT_DIR"`
    Merges stage-e.json, maps verdicts to final_status, computes CVSS scores, checks consistency.
 2. **Reasoning:** Review all findings — misclassifications, weak evidence, CVSS accuracy, missed instances. Ask: "What did I get wrong?"
@@ -102,6 +116,10 @@ Then read `{output_dir}/validation-report.md` and add a 1-2 sentence summary par
 after the `# Exploitability Validation Report` header — e.g., "All 3 buffer overflows are
 real and reachable. 2 are directly exploitable; the third is constrained by RELRO." Use only
 facts from the findings data.
+
+**GATE: VERBATIM OUTPUT.** Read `$OUTPUT_DIR/summary.txt` and copy its ENTIRE contents
+into your chat response exactly as-is. No editing, no reformatting, no column removal. If
+the table has 7 columns, your output must have 7 columns.
 
 ---
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,11 +6,14 @@
   },
   "permissions": {
     "allow": [
+      "Bash(libexec/raptor-prepare-understand *)",
       "Bash(libexec/raptor-prepare-validation-stage *)",
-      "Bash(libexec/raptor-run-feasibility *)",
-      "Bash(libexec/raptor-validate-schema *)",
       "Bash(libexec/raptor-project-manager *)",
+      "Bash(libexec/raptor-render-diagrams *)",
+      "Bash(libexec/raptor-run-feasibility *)",
       "Bash(libexec/raptor-run-lifecycle *)",
+      "Bash(libexec/raptor-startup-check *)",
+      "Bash(libexec/raptor-validate-schema *)",
       "Write(/out/**)",
       "Edit(/out/**)"
     ]

--- a/.claude/skills/code-understanding/SKILL.md
+++ b/.claude/skills/code-understanding/SKILL.md
@@ -39,7 +39,7 @@ Modes can be combined. Map → Trace → Hunt is the natural attack progression.
 ## [CONFIG] Configuration
 
 ```yaml
-output_dir: resolved by libexec/raptor-run-lifecycle start understand
+output_dir: resolved by libexec/raptor-prepare-understand inventory
 confidence_levels:
   high: "Direct code evidence — quote the line"
   medium: "Inferred from context — state the assumption"
@@ -57,6 +57,7 @@ flow_format: source → transform(s) → sink
 4. When hunting variants, search the full codebase. Do not stop at the first match.
 5. When teaching, explain the mechanism, not just the name. Show the code that implements it.
 6. Produce structured output (context-map.json, flow-trace.json, variants.json) for integration with validation pipeline.
+7. **libexec scripts:** Run `libexec/` scripts exactly as shown in the prompts — do not prepend `bash`, `export` commands, absolute paths, or additional shell logic. The permission system auto-approves `libexec/raptor-*` commands only when run in this exact form.
 
 ---
 

--- a/.claude/skills/code-understanding/map.md
+++ b/.claude/skills/code-understanding/map.md
@@ -25,12 +25,10 @@ This is not documentation generation. It is adversarial reconnaissance at the so
 Before any manual enumeration, run the inventory builder to get a reliable file and function list:
 
 ```bash
-python3 -c "
-import sys; sys.path.insert(0, '.')
-from packages.exploitability_validation import build_checklist
-build_checklist('<target>', '$WORKDIR')
-"
+libexec/raptor-prepare-understand inventory <target>
 ```
+
+The last line of output is `OUTPUT_DIR=<path>` — use that as `$WORKDIR`.
 
 Read the resulting `checklist.json`. It provides every source file with language, line count, SHA-256 checksum, and every function with name, line number, and signature. Excluded files are recorded with reasons.
 
@@ -176,29 +174,22 @@ Do not populate `sources`, `sinks`, or `entry_points` from file names or common 
 **[MAP-5] Record Coverage**
 
 After writing `context-map.json`, update the inventory with which functions you examined.
-Build a list of every function you read and analysed (entry points, sinks, trust boundary
-checks), then run a `python3 -c` snippet to record them:
+Write a JSON array of every function you read and analysed (entry points, sinks, trust boundary
+checks) to `$WORKDIR/coverage-input.json`, then run the coverage recorder:
 
-```bash
-python3 -c "
-import sys, os, json
-sys.path.insert(0, os.environ['RAPTOR_DIR'])
-from core.inventory.coverage import update_coverage
-from core.inventory import save_checklist
-
-workdir = sys.argv[1]
-inv = json.load(open(f'{workdir}/checklist.json'))
-checked = [
-    # Add one entry per function you examined:
-    {'file': 'src/routes/query.py', 'function': 'handle_query'},
-    {'file': 'src/db/query.py', 'function': 'run_query'},
-    # ... etc
+```json
+// $WORKDIR/coverage-input.json
+[
+    {"file": "src/routes/query.py", "function": "handle_query"},
+    {"file": "src/db/query.py", "function": "run_query"}
 ]
-update_coverage(inv, checked, "understand:map")
-save_checklist(workdir, inv)
-print(f"Recorded {len(checked)} functions as checked by understand:map")
 ```
 
+```bash
+libexec/raptor-prepare-understand coverage "$WORKDIR"
+```
+
+The script reads `coverage-input.json`, updates the checklist, and deletes the input file.
 This ensures coverage tracking is cumulative across `/understand` and `/validate` runs.
 
 ## Output

--- a/.claude/skills/exploitability-validation/stage-a-oneshot.md
+++ b/.claude/skills/exploitability-validation/stage-a-oneshot.md
@@ -40,8 +40,10 @@ If binaries are available, use them for PoC evidence (crash output, leak output)
 
 **Pre-existing data:** If `findings.json` already exists, treat pre-existing entries as prioritised candidates. Re-assess all pre-existing findings against the current code — they may be stale. All gates still apply.
 
+**Priority targets from /understand:** If `checklist.json` contains a `priority_targets` array, these are unchecked flows identified by `/understand --map` — entry points that reach sinks without passing through a trust boundary. Assess these first, as they are the highest-value candidates for exploitable findings. The prep output prints them.
+
 DO:
-1. For each function in checklist.json, assess for target vulnerability type
+1. For each function in checklist.json, assess for target vulnerability type (start with priority targets if present)
 2. For promising candidates, attempt to verify exploitability — run the binary from `$OUTPUT_DIR/build/` or the target directory if available
 3. Build a harmless PoC exploit for each verified finding
 

--- a/.claude/skills/exploitability-validation/stage-b-process.md
+++ b/.claude/skills/exploitability-validation/stage-b-process.md
@@ -55,7 +55,9 @@ Maintain these documents throughout Stage B:
 - BAD: "User input reaches the SQL query."
 - GOOD: "Input `' OR 1=1--` in the `username` parameter returns 200 with all user rows instead of 0."
 
-**Pre-existing data:** If `attack-surface.json` or `attack-paths.json` already exist, load them as starting state. Add new entries and update existing ones as Stage B progresses — do not discard pre-existing data.
+**Pre-existing data:** If `attack-surface.json` or `attack-paths.json` already exist, load them as starting state. Add new entries and update existing ones as Stage B progresses — do not discard pre-existing data. When `/understand` ran before `/validate`, the bridge pre-populates these files:
+- `attack-surface.json` — sources, sinks, and trust boundaries from `context-map.json`
+- `attack-paths.json` — flow traces imported with `source: "understand:trace"` and `status: "uncertain"`. Review imported traces rather than discovering from scratch. Use `trace_verdict` and `attacker_control` annotations as starting hypotheses.
 
 **UPDATE TRIGGER:** After every action that changes understanding of attack surface, hypotheses, or paths.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,7 +210,7 @@ The `/understand` command provides deep, adversarial code comprehension for secu
 
 **Output:** Resolved by `libexec/raptor-run-lifecycle start understand` (project dir or `out/understand_<timestamp>/`)
 
-**Pipeline integration:** Output schemas are aligned with validation pipeline formats. Use `--out` to share a directory with `/validate`.
+**Pipeline integration:** `/validate` Stage 0 automatically imports `/understand` output via the bridge (`core/understand_bridge.py`). No `--out` alignment needed — the bridge searches: (1) co-located files, (2) project siblings, (3) global `out/` by target path + SHA-256 freshness. When found, it pre-populates `attack-surface.json`, imports flow traces as attack paths, and marks entry points/sinks as high-priority in the checklist.
 
 ---
 
@@ -230,15 +230,7 @@ very much a WIP but it could be of use for those wanting to see relationships an
 
 **Output:** `diagrams.md` written into the target directory (or `--stdout` to print)
 
-**Implementation:** `generate_diagram.py` (CLI) and `packages/diagram/` (library)
-
-```python
-# Programmatic use
-from packages.diagram import render_and_write
-from pathlib import Path
-
-out_file = render_and_write(Path(".out/code-understanding-20240101/"), target="myapp")
-```
+**Implementation:** `libexec/raptor-render-diagrams <out-dir> [--target <name>]`
 
 **When to run:** Diagrams are auto-generated at the end of `/validate` and `/understand --map`/`--trace`. Use `/diagram <dir>` to re-render after manual edits to JSON outputs.
 

--- a/core/coverage/track_read.py
+++ b/core/coverage/track_read.py
@@ -70,8 +70,7 @@ def main():
     if not run_dir:
         return
 
-    # Also check env var for target (may be more current)
-    target = os.environ.get("RAPTOR_PROJECT_TARGET", target or "")
+    target = target or ""
 
     # Read hook payload from stdin
     try:

--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -75,11 +75,19 @@ def build_inventory(
     file_list = _collect_source_files(target, extensions)
     logger.info(f"Found {len(file_list)} source files to process")
 
-    # Load previous inventory for hash-based skip optimisation
+    # Reuse existing inventory when one exists for the same target.
+    # The checklist is a snapshot: hashes record the state at inventory time.
+    # Consumers (bridge, validation stages) detect staleness by comparing
+    # checklist hashes to current disk — the builder never silently updates them.
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
     checklist_file = output_path / 'checklist.json'
     old_inventory = load_json(checklist_file)
+
+    if old_inventory and old_inventory.get('target_path') == str(target_path):
+        logger.info("Reusing existing inventory for %s", target_path)
+        return old_inventory
+
     old_files_by_path = {}
     if old_inventory:
         for f in old_inventory.get('files', []):
@@ -277,13 +285,14 @@ def _process_single_file(
         return None
 
     try:
-        content = filepath.read_text(encoding='utf-8', errors='ignore')
+        raw_bytes = filepath.read_bytes()
+        content = raw_bytes.decode('utf-8', errors='ignore')
 
         if skip_generated and is_generated_file(content):
             return {"path": rel_path, "_excluded": True, "_reason": "generated_file", "_pattern": None}
 
         line_count = content.count('\n') + 1
-        sha256 = hashlib.sha256(content.encode('utf-8')).hexdigest()
+        sha256 = hashlib.sha256(raw_bytes).hexdigest()
 
         # If file unchanged from previous inventory, reuse old entry (skip parsing)
         if old_files and rel_path in old_files:

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -376,43 +376,55 @@ class TestCumulativeCoverage:
         inv2 = build_inventory(str(src), str(out))
         assert inv2["files"][0]["items"][0]["checked_by"] == ["validate:stage-a"]
 
-    def test_clear_modified_file(self, tmp_path):
+    def test_reuse_when_source_modified(self, tmp_path):
+        """build_inventory returns existing checklist even if source changed.
+
+        The checklist is a snapshot — hashes record state at inventory time.
+        Consumers detect staleness by comparing hashes to disk, not the builder.
+        """
+        import hashlib
         src = tmp_path / "src"
         src.mkdir()
         (src / "app.py").write_text("def main(): pass\n")
 
         out = tmp_path / "out"
 
-        # First run
         inv1 = build_inventory(str(src), str(out))
+        original_hash = inv1["files"][0]["sha256"]
         inv1["files"][0]["items"][0]["checked_by"] = ["validate:stage-a"]
         with open(out / "checklist.json", "w") as f:
             json.dump(inv1, f)
 
-        # Modify source
+        # Modify source — disk hash now differs from checklist hash
         (src / "app.py").write_text("def main():\n    print('changed')\n")
 
-        # Second run
+        # Second call reuses existing inventory (snapshot preserved)
         inv2 = build_inventory(str(src), str(out))
-        assert inv2["files"][0]["items"][0]["checked_by"] == []
+        assert inv2["files"][0]["sha256"] == original_hash
+        assert inv2["files"][0]["items"][0]["checked_by"] == ["validate:stage-a"]
 
-    def test_new_file_empty_coverage(self, tmp_path):
+        # Consumer can detect staleness by hashing disk
+        disk_hash = hashlib.sha256((src / "app.py").read_bytes()).hexdigest()
+        assert disk_hash != original_hash
+
+    def test_reuse_when_file_added(self, tmp_path):
+        """New files on disk don't trigger a rebuild — checklist is a snapshot.
+
+        Consumers discover new files by comparing checklist paths to disk.
+        """
         src = tmp_path / "src"
         src.mkdir()
         (src / "app.py").write_text("def main(): pass\n")
 
         out = tmp_path / "out"
 
-        # First run
-        build_inventory(str(src), str(out))
-
-        # Add new file
+        inv1 = build_inventory(str(src), str(out))
         (src / "new.py").write_text("def new_func(): pass\n")
 
-        # Second run
+        # Second call reuses — new.py is not in the snapshot
         inv2 = build_inventory(str(src), str(out))
-        new_file = next(f for f in inv2["files"] if f["path"] == "new.py")
-        assert new_file["items"][0]["checked_by"] == []
+        assert len(inv2["files"]) == 1
+        assert inv2["files"][0]["path"] == "app.py"
 
 
 # ── Coverage Stats ──────────────────────────────────────────────────

--- a/core/inventory/tests/test_shared_checklist.py
+++ b/core/inventory/tests/test_shared_checklist.py
@@ -116,15 +116,12 @@ class TestSetupChecklistSymlink(unittest.TestCase):
             if active_link.is_symlink():
                 active_link.unlink()
 
-            old_env = os.environ.pop("RAPTOR_PROJECT_DIR", None)
             try:
                 _setup_checklist_symlink(run_dir)
                 self.assertFalse((run_dir / "checklist.json").exists())
             finally:
                 if old_link:
                     active_link.symlink_to(old_link)
-                if old_env:
-                    os.environ["RAPTOR_PROJECT_DIR"] = old_env
 
     def test_skips_existing_real_file(self):
         with TemporaryDirectory() as d:

--- a/core/project/tests/test_cli.py
+++ b/core/project/tests/test_cli.py
@@ -77,25 +77,6 @@ class TestGetActiveProject(unittest.TestCase):
                     result = _get_active_project()
             self.assertIsNone(result)
 
-    def test_symlink_takes_priority_over_env(self):
-        with TemporaryDirectory() as d:
-            projects_dir = Path(d)
-            (projects_dir / "myapp.json").write_text('{"name":"myapp"}')
-            (projects_dir / ".active").symlink_to("myapp.json")
-
-            with patch("core.project.project.PROJECTS_DIR", projects_dir):
-                with patch.dict(os.environ, {"RAPTOR_PROJECT_NAME": "oldproject"}):
-                    result = _get_active_project()
-            # Symlink wins over env var
-            self.assertEqual(result, "myapp")
-
-    def test_no_symlink_returns_none(self):
-        with TemporaryDirectory() as d:
-            projects_dir = Path(d)
-            # No .active symlink — should return None (no env var fallback)
-            with patch("core.project.project.PROJECTS_DIR", projects_dir):
-                result = _get_active_project()
-            self.assertIsNone(result)
 
 
 if __name__ == "__main__":

--- a/core/project/tests/test_project.py
+++ b/core/project/tests/test_project.py
@@ -203,30 +203,6 @@ class TestProjectManager(unittest.TestCase):
         self.mgr.rename("old", "new")
         self.assertEqual(os.readlink(active), "new.json")
 
-    def test_set_active_does_not_modify_env_file(self):
-        """set_active only sets the symlink — no env file modifications."""
-        with TemporaryDirectory() as env_dir:
-            env_file = Path(env_dir) / "claude_env"
-            env_file.write_text('export PATH="$PATH:/something"\n')
-            with patch.dict(os.environ, {"CLAUDE_ENV_FILE": str(env_file)}):
-                self.mgr.create("myapp", "/tmp/code")
-                self.mgr.set_active("myapp")
-                content = env_file.read_text()
-                # Env file should NOT be modified by set_active
-                self.assertNotIn("RAPTOR_PROJECT", content)
-                self.assertIn("/something", content)
-
-    def test_set_active_none_does_not_modify_env_file(self):
-        """Clearing active project only removes symlink — no env file touch."""
-        with TemporaryDirectory() as env_dir:
-            env_file = Path(env_dir) / "claude_env"
-            original = 'export PATH="$PATH:/something"\nexport RAPTOR_PROJECT_DIR="/old"\n'
-            env_file.write_text(original)
-            with patch.dict(os.environ, {"CLAUDE_ENV_FILE": str(env_file)}):
-                self.mgr.set_active(None)
-                # Env file should NOT be modified
-                self.assertEqual(env_file.read_text(), original)
-
     def test_update_notes(self):
         self.mgr.create("myapp", "/tmp/code")
         p = self.mgr.update_notes("myapp", "new notes")
@@ -265,17 +241,6 @@ class TestProjectManager(unittest.TestCase):
         self.mgr.create("myapp", "/tmp/code")
         with self.assertRaises(ValueError):
             self.mgr.remove_run("myapp", "scan-20260406")
-
-
-class TestOutputDirResolution(unittest.TestCase):
-
-    def test_raptor_project_dir_env(self):
-        """RAPTOR_PROJECT_DIR env var should be readable."""
-        os.environ["RAPTOR_PROJECT_DIR"] = "/tmp/test_project"
-        try:
-            self.assertEqual(os.environ.get("RAPTOR_PROJECT_DIR"), "/tmp/test_project")
-        finally:
-            del os.environ["RAPTOR_PROJECT_DIR"]
 
 
 if __name__ == "__main__":

--- a/core/run/metadata.py
+++ b/core/run/metadata.py
@@ -71,15 +71,14 @@ def start_run(output_dir: Path, command: str, extra: Dict[str, Any] = None) -> P
 def _setup_checklist_symlink(run_dir: Path) -> None:
     """Create a checklist.json symlink in the run dir pointing to the project-level checklist.
 
-    Only acts in project mode (active project detected via .active symlink or
-    RAPTOR_PROJECT_DIR env var). In standalone mode, does nothing.
+    Only acts in project mode (active project detected via .active symlink).
+    In standalone mode, does nothing.
 
     If no project-level checklist exists yet, promotes the newest run-level
     checklist from sibling run dirs.
     """
-    import os
 
-    # Determine project output dir
+    # Determine project output dir from .active symlink only
     project_dir = None
     try:
         from core.startup import PROJECTS_DIR, get_active_name
@@ -93,11 +92,6 @@ def _setup_checklist_symlink(run_dir: Path) -> None:
                     project_dir = candidate
     except Exception:
         pass
-
-    if not project_dir:
-        pd = os.environ.get("RAPTOR_PROJECT_DIR")
-        if pd and Path(pd).is_dir():
-            project_dir = Path(pd)
 
     if not project_dir:
         return  # Standalone mode

--- a/core/run/tests/test_output.py
+++ b/core/run/tests/test_output.py
@@ -9,8 +9,7 @@ from unittest.mock import patch
 
 from core.run.output import get_output_dir, TargetMismatchError
 
-# Prevent the .active symlink from interfering with env-var-based tests.
-# Tests control project state entirely through env vars.
+# Mock that disables project resolution — for testing standalone (no project) mode.
 _NO_SYMLINK = patch("core.run.output._resolve_active_project", return_value=None)
 
 
@@ -25,34 +24,24 @@ class TestGetOutputDir(unittest.TestCase):
 
     def test_project_dir_produces_hyphen_subdir(self):
         with TemporaryDirectory() as d:
-            env = {"RAPTOR_PROJECT_DIR": d, "RAPTOR_PROJECT_TARGET": "", "RAPTOR_PROJECT_NAME": "test"}
-            with patch.dict(os.environ, env):
-                with patch("core.run.output._resolve_active_project",
-                           return_value=(d, "test", "")):
-                    result = get_output_dir("scan")
-                    self.assertEqual(result.parent, Path(d))
-                    self.assertTrue(result.name.startswith("scan-"))
-                    self.assertNotIn("_", result.name.split("-", 1)[1][:8])
+            with patch("core.run.output._resolve_active_project",
+                       return_value=(d, "test", "")):
+                result = get_output_dir("scan")
+                self.assertEqual(result.parent, Path(d))
+                self.assertTrue(result.name.startswith("scan-"))
+                self.assertNotIn("_", result.name.split("-", 1)[1][:8])
 
     @_NO_SYMLINK
     def test_default_produces_underscore_dirname(self, _mock):
-        with patch.dict(os.environ, {}, clear=True):
-            env = os.environ.copy()
-            env.pop("RAPTOR_PROJECT_DIR", None)
-            with patch.dict(os.environ, env, clear=True):
-                result = get_output_dir("scan", target_name="myrepo")
-                self.assertIn("scan_myrepo_", result.name)
+        result = get_output_dir("scan", target_name="myrepo")
+        self.assertIn("scan_myrepo_", result.name)
 
     @_NO_SYMLINK
     def test_empty_target_omits_target(self, _mock):
-        with patch.dict(os.environ, {}, clear=True):
-            env = os.environ.copy()
-            env.pop("RAPTOR_PROJECT_DIR", None)
-            with patch.dict(os.environ, env, clear=True):
-                result = get_output_dir("scan", target_name="")
-                self.assertTrue(result.name.startswith("scan_"))
-                parts = result.name.split("_")
-                self.assertEqual(len(parts), 3)
+        result = get_output_dir("scan", target_name="")
+        self.assertTrue(result.name.startswith("scan_"))
+        parts = result.name.split("_")
+        self.assertEqual(len(parts), 3)
 
 
 def _mock_project(d, name="myapp", target="/tmp/vulns"):
@@ -87,15 +76,6 @@ class TestTargetMismatch(unittest.TestCase):
             with _mock_project(d, target=""):
                 get_output_dir("scan", target_path="/tmp/anything")
 
-    @_NO_SYMLINK
-    def test_no_target_no_caller_dir_skips_check(self, _mock):
-        """Without target_path or RAPTOR_CALLER_DIR, mismatch check is skipped."""
-        with TemporaryDirectory() as d:
-            env = {"RAPTOR_PROJECT_DIR": d, "RAPTOR_PROJECT_TARGET": "/tmp/vulns",
-                   "RAPTOR_PROJECT_NAME": "myapp"}
-            with patch.dict(os.environ, env):
-                get_output_dir("scan")
-
     def test_caller_dir_mismatch_raises(self):
         """RAPTOR_CALLER_DIR is used for mismatch check when no explicit target."""
         with TemporaryDirectory() as d:
@@ -113,12 +93,9 @@ class TestTargetMismatch(unittest.TestCase):
                 with _mock_project(d):
                     get_output_dir("scan")
 
-    @_NO_SYMLINK
-    def test_explicit_out_skips_check(self, _mock):
+    def test_explicit_out_skips_check(self):
         with TemporaryDirectory() as d:
-            env = {"RAPTOR_PROJECT_DIR": d, "RAPTOR_PROJECT_TARGET": "/tmp/vulns",
-                   "RAPTOR_PROJECT_NAME": "myapp"}
-            with patch.dict(os.environ, env):
+            with _mock_project(d):
                 result = get_output_dir("scan", explicit_out="/tmp/manual",
                                         target_path="/tmp/other")
                 self.assertEqual(result, Path("/tmp/manual").resolve())

--- a/core/tests/test_understand_bridge.py
+++ b/core/tests/test_understand_bridge.py
@@ -1,8 +1,10 @@
 """Tests for core.understand_bridge — /understand → /validate pipeline handoff."""
 
+import copy
 import json
 import sys
-import tempfile
+import time
+import unittest.mock
 from pathlib import Path
 
 import pytest
@@ -11,10 +13,13 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parents[2]))
 
 from core.understand_bridge import (
-    find_understand_dir,
+    find_understand_output,
     load_understand_context,
     enrich_checklist,
     TRACE_SOURCE_LABEL,
+    _extract_hashes,
+    _count_stale_on_disk,
+    _rank_candidates,
 )
 
 
@@ -147,51 +152,238 @@ def _write_json(path: Path, data: object) -> None:
     path.write_text(json.dumps(data, indent=2))
 
 
+def _make_understand_dir(parent, name="understand-20260401-120000",
+                         context_map=None, checklist=None):
+    """Create a minimal understand run directory with metadata."""
+    d = parent / name
+    d.mkdir(parents=True, exist_ok=True)
+    _write_json(d / "context-map.json", context_map or {"sources": []})
+    # .raptor-run.json so infer_command_type works
+    _write_json(d / ".raptor-run.json", {"version": 1, "command": "understand",
+                                          "status": "completed"})
+    if checklist:
+        _write_json(d / "checklist.json", checklist)
+    return d
+
+
 # ---------------------------------------------------------------------------
-# find_understand_dir
+# find_understand_output — 3-tier search
 # ---------------------------------------------------------------------------
 
-class TestFindUnderstandDir:
-    def test_finds_most_recent_project_mode(self, tmp_path):
-        # Project mode: understand-YYYYMMDD-HHMMSS (via core.run lifecycle)
-        old = tmp_path / "understand-20260401-120000"
-        new = tmp_path / "understand-20260402-120000"
-        for d in (old, new):
-            d.mkdir()
-            _write_json(d / "context-map.json", {"sources": []})
+class TestFindUnderstandOutput:
+    def test_tier1_local_context_map(self, tmp_path):
+        """Tier 1: context-map.json co-located in validate dir (shared --out)."""
+        validate_dir = tmp_path / "shared"
+        validate_dir.mkdir()
+        _write_json(validate_dir / "context-map.json", {"sources": []})
 
-        import time
+        result = find_understand_output(validate_dir)
+        assert result == validate_dir
+
+    def test_tier2_project_sibling(self, tmp_path):
+        """Tier 2: understand run as sibling in same project dir."""
+        project_dir = tmp_path / "project"
+        validate_dir = project_dir / "validate-20260402-120000"
+        validate_dir.mkdir(parents=True)
+
+        _make_understand_dir(project_dir)
+
+        result = find_understand_output(validate_dir)
+        assert result == project_dir / "understand-20260401-120000"
+
+    def test_tier2_picks_newest_sibling(self, tmp_path):
+        project_dir = tmp_path / "project"
+        validate_dir = project_dir / "validate-20260403-120000"
+        validate_dir.mkdir(parents=True)
+
+        old = _make_understand_dir(project_dir, "understand-20260401-120000")
         time.sleep(0.01)
-        (new / "context-map.json").touch()
+        new = _make_understand_dir(project_dir, "understand-20260402-120000")
 
-        result = find_understand_dir(tmp_path)
+        result = find_understand_output(validate_dir)
         assert result == new
 
-    def test_finds_standalone_mode_format(self, tmp_path):
-        # Standalone mode: code-understanding-<timestamp>
-        d = tmp_path / "code-understanding-20260401-120000"
-        d.mkdir()
-        _write_json(d / "context-map.json", {"sources": []})
+    def test_tier3_global_out_by_target_path(self, tmp_path, monkeypatch):
+        """Tier 3: scan out/ matching by checklist target_path."""
+        out_root = tmp_path / "out"
+        out_root.mkdir()
 
-        result = find_understand_dir(tmp_path)
-        assert result == d
+        # Monkeypatch RaptorConfig to use our tmp out/
+        monkeypatch.setattr("core.config.RaptorConfig.get_out_dir",
+                            staticmethod(lambda: out_root))
+
+        _make_understand_dir(
+            out_root, "understand_20260401_120000",
+            checklist={"target_path": "/tmp/vulns", "files": []},
+        )
+
+        # validate_dir outside out/ with no siblings
+        validate_dir = tmp_path / "validate-run"
+        validate_dir.mkdir()
+
+        result = find_understand_output(validate_dir, target_path="/tmp/vulns")
+        assert result == out_root / "understand_20260401_120000"
+
+    def test_tier3_no_match_for_wrong_target(self, tmp_path, monkeypatch):
+        out_root = tmp_path / "out"
+        out_root.mkdir()
+
+        monkeypatch.setattr("core.config.RaptorConfig.get_out_dir",
+                            staticmethod(lambda: out_root))
+
+        _make_understand_dir(
+            out_root, "understand_20260401_120000",
+            checklist={"target_path": "/tmp/vulns", "files": []},
+        )
+
+        validate_dir = tmp_path / "validate-run"
+        validate_dir.mkdir()
+
+        result = find_understand_output(validate_dir, target_path="/tmp/other")
+        assert result is None
+
+    def test_returns_none_when_no_candidates(self, tmp_path, monkeypatch):
+        out_root = tmp_path / "empty-out"
+        out_root.mkdir()
+        monkeypatch.setattr("core.config.RaptorConfig.get_out_dir",
+                            staticmethod(lambda: out_root))
+
+        validate_dir = tmp_path / "validate-run"
+        validate_dir.mkdir()
+
+        result = find_understand_output(validate_dir, target_path="/tmp/vulns")
+        assert result is None
 
     def test_ignores_dirs_without_context_map(self, tmp_path):
-        empty = tmp_path / "understand-20260401-120000"
+        project_dir = tmp_path / "project"
+        validate_dir = project_dir / "validate-20260402-120000"
+        validate_dir.mkdir(parents=True)
+
+        # understand dir exists but has no context-map.json
+        empty = project_dir / "understand-20260401-120000"
         empty.mkdir()
-        # No context-map.json
+        _write_json(empty / ".raptor-run.json", {"version": 1, "command": "understand"})
 
-        assert find_understand_dir(tmp_path) is None
-
-    def test_returns_none_for_nonexistent_dir(self, tmp_path):
-        assert find_understand_dir(tmp_path / "does-not-exist") is None
+        assert find_understand_output(validate_dir) is None
 
     def test_ignores_non_understand_dirs(self, tmp_path):
-        scan = tmp_path / "scan-20260401-120000"
-        scan.mkdir()
-        _write_json(scan / "context-map.json", {})
+        project_dir = tmp_path / "project"
+        validate_dir = project_dir / "validate-20260402-120000"
+        validate_dir.mkdir(parents=True)
 
-        assert find_understand_dir(tmp_path) is None
+        scan = project_dir / "scan-20260401-120000"
+        scan.mkdir()
+        _write_json(scan / "context-map.json", {"sources": []})
+        _write_json(scan / ".raptor-run.json", {"version": 1, "command": "scan"})
+
+        assert find_understand_output(validate_dir) is None
+
+
+# ---------------------------------------------------------------------------
+# Hash freshness ranking
+# ---------------------------------------------------------------------------
+
+class TestHashFreshness:
+    def test_extract_hashes(self):
+        hashes = _extract_hashes(MINIMAL_CHECKLIST)
+        assert hashes == {"src/routes/query.py": "aaa", "src/db/query.py": "bbb"}
+
+    def test_count_stale_zero_when_matching(self, tmp_path):
+        """On-disk files matching understand hashes → 0 stale."""
+        import hashlib
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "a.py").write_text("aaa")
+        (target / "b.py").write_text("bbb")
+        h1 = {
+            "a.py": hashlib.sha256(b"aaa").hexdigest(),
+            "b.py": hashlib.sha256(b"bbb").hexdigest(),
+        }
+        assert _count_stale_on_disk(h1, str(target)) == 0
+
+    def test_count_stale_detects_changed_files(self, tmp_path):
+        """On-disk file differs from understand hash → 1 stale."""
+        import hashlib
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "a.py").write_text("aaa")
+        (target / "b.py").write_text("MODIFIED")
+        h1 = {
+            "a.py": hashlib.sha256(b"aaa").hexdigest(),
+            "b.py": hashlib.sha256(b"bbb").hexdigest(),  # original content
+        }
+        assert _count_stale_on_disk(h1, str(target)) == 1
+
+    def test_count_stale_deleted_file_is_stale(self, tmp_path):
+        """File in understand checklist but deleted from disk → stale."""
+        import hashlib
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "a.py").write_text("aaa")
+        h1 = {
+            "a.py": hashlib.sha256(b"aaa").hexdigest(),
+            "gone.py": hashlib.sha256(b"xyz").hexdigest(),
+        }
+        assert _count_stale_on_disk(h1, str(target)) == 1
+
+    def test_rank_prefers_fresh_over_newest(self, tmp_path):
+        """A fresh older candidate beats a stale newer one."""
+        import hashlib
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "a.py").write_text("current")
+        disk_hash = hashlib.sha256(b"current").hexdigest()
+
+        old_dir = tmp_path / "old"
+        new_dir = tmp_path / "new"
+        old_dir.mkdir()
+        time.sleep(0.01)
+        new_dir.mkdir()
+
+        # old has matching hash, new has stale hash
+        _write_json(old_dir / "checklist.json", {
+            "files": [{"path": "a.py", "sha256": disk_hash}],
+        })
+        _write_json(new_dir / "checklist.json", {
+            "files": [{"path": "a.py", "sha256": "STALE"}],
+        })
+
+        result = _rank_candidates([new_dir, old_dir], str(target))
+        assert result == old_dir
+
+    def test_rank_falls_back_to_newest_when_all_fresh(self, tmp_path):
+        import hashlib
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "a.py").write_text("current")
+        disk_hash = hashlib.sha256(b"current").hexdigest()
+
+        d1 = tmp_path / "d1"
+        d2 = tmp_path / "d2"
+        d1.mkdir()
+        time.sleep(0.01)
+        d2.mkdir()
+
+        for d in (d1, d2):
+            _write_json(d / "checklist.json", {
+                "files": [{"path": "a.py", "sha256": disk_hash}],
+            })
+
+        result = _rank_candidates([d1, d2], str(target))
+        assert result == d2  # newer
+
+    def test_rank_without_target_picks_newest(self, tmp_path):
+        d1 = tmp_path / "d1"
+        d2 = tmp_path / "d2"
+        d1.mkdir()
+        time.sleep(0.01)
+        d2.mkdir()
+
+        result = _rank_candidates([d1, d2], target_path=None)
+        assert result == d2
+
+    def test_rank_empty_candidates(self):
+        assert _rank_candidates([], None) is None
 
 
 # ---------------------------------------------------------------------------
@@ -226,7 +418,6 @@ class TestLoadUnderstandContextAttackSurface:
         understand_dir.mkdir()
         validate_dir.mkdir()
 
-        # Pre-existing attack-surface with one source Stage B already wrote
         _write_json(validate_dir / "attack-surface.json", {
             "sources": [
                 {"type": "cli_arg", "entry": "main() arg parsing @ src/main.py:10"},
@@ -240,7 +431,6 @@ class TestLoadUnderstandContextAttackSurface:
         load_understand_context(understand_dir, validate_dir)
 
         surface = json.loads((validate_dir / "attack-surface.json").read_text())
-        # Should have both the pre-existing source and the imported one
         assert len(surface["sources"]) == 2
 
     def test_does_not_duplicate_existing_sources(self, tmp_path):
@@ -249,7 +439,6 @@ class TestLoadUnderstandContextAttackSurface:
         understand_dir.mkdir()
         validate_dir.mkdir()
 
-        # Same entry already exists
         _write_json(validate_dir / "attack-surface.json", {
             "sources": [
                 {"type": "http_route", "entry": "POST /api/query @ src/routes/query.py:34"},
@@ -263,7 +452,7 @@ class TestLoadUnderstandContextAttackSurface:
         load_understand_context(understand_dir, validate_dir)
 
         surface = json.loads((validate_dir / "attack-surface.json").read_text())
-        assert len(surface["sources"]) == 1  # not doubled
+        assert len(surface["sources"]) == 1
 
     def test_gap_annotations_added_to_trust_boundaries(self, tmp_path):
         understand_dir = tmp_path / "understand"
@@ -276,11 +465,7 @@ class TestLoadUnderstandContextAttackSurface:
         load_understand_context(understand_dir, validate_dir)
 
         surface = json.loads((validate_dir / "attack-surface.json").read_text())
-        # The JWT boundary should have a gaps annotation (TB-001 has gaps in fixture)
-        # Note: boundary matching is name-based so this depends on the id containing
-        # a fragment of the boundary name or vice versa — adjust if needed.
         jwt_boundary = surface["trust_boundaries"][0]
-        # Even without a name match, the merge itself should succeed
         assert "boundary" in jwt_boundary
 
     def test_missing_context_map_returns_empty_summary(self, tmp_path):
@@ -343,7 +528,6 @@ class TestLoadUnderstandContextFlowTraces:
         understand_dir.mkdir()
         validate_dir.mkdir()
 
-        # attack-paths.json already has TRACE-001
         _write_json(validate_dir / "attack-paths.json", [
             {"id": "TRACE-001", "status": "confirmed", "steps": [], "proximity": 9},
         ])
@@ -356,7 +540,6 @@ class TestLoadUnderstandContextFlowTraces:
         assert result["flow_traces"]["imported_as_paths"] == 0
         paths = json.loads((validate_dir / "attack-paths.json").read_text())
         assert len(paths) == 1
-        # Original confirmed status preserved
         assert paths[0]["status"] == "confirmed"
 
     def test_merges_with_existing_paths(self, tmp_path):
@@ -398,12 +581,10 @@ class TestLoadUnderstandContextFlowTraces:
 
 class TestEnrichChecklist:
     def test_marks_entry_point_files_as_high_priority(self):
-        import copy
         checklist = copy.deepcopy(MINIMAL_CHECKLIST)
 
         enrich_checklist(checklist, MINIMAL_CONTEXT_MAP)
 
-        # src/routes/query.py is an entry_point file
         routes_file = next(
             f for f in checklist["files"] if f["path"] == "src/routes/query.py"
         )
@@ -411,7 +592,6 @@ class TestEnrichChecklist:
         assert routes_file["functions"][0]["priority_reason"] == "entry_point"
 
     def test_marks_sink_files_as_high_priority(self):
-        import copy
         checklist = copy.deepcopy(MINIMAL_CHECKLIST)
 
         enrich_checklist(checklist, MINIMAL_CONTEXT_MAP)
@@ -422,7 +602,6 @@ class TestEnrichChecklist:
         assert db_file["functions"][0]["priority"] == "high"
 
     def test_adds_priority_targets_for_unchecked_flows(self):
-        import copy
         checklist = copy.deepcopy(MINIMAL_CHECKLIST)
 
         enrich_checklist(checklist, MINIMAL_CONTEXT_MAP)
@@ -433,7 +612,6 @@ class TestEnrichChecklist:
         assert checklist["priority_targets"][0]["source"] == "understand:map"
 
     def test_no_unchecked_flows_omits_priority_targets(self):
-        import copy
         checklist = copy.deepcopy(MINIMAL_CHECKLIST)
         context_map = dict(MINIMAL_CONTEXT_MAP)
         context_map["unchecked_flows"] = []
@@ -447,7 +625,6 @@ class TestEnrichChecklist:
         enrich_checklist(None, None)
 
     def test_does_not_touch_unrelated_files(self):
-        import copy
         checklist = copy.deepcopy(MINIMAL_CHECKLIST)
         checklist["files"].append({
             "path": "src/utils/helpers.py",
@@ -463,3 +640,198 @@ class TestEnrichChecklist:
             f for f in checklist["files"] if f["path"] == "src/utils/helpers.py"
         )
         assert "priority" not in helpers_file["functions"][0]
+
+
+# ---------------------------------------------------------------------------
+# Deduplication and staleness edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_tier2_and_tier3_same_dir_not_duplicated(self, tmp_path, monkeypatch):
+        """Dir found via both project sibling and global scan appears only once."""
+        project_dir = tmp_path / "out" / "projects" / "myapp"
+        validate_dir = project_dir / "validate-20260402-120000"
+        validate_dir.mkdir(parents=True)
+
+        # Create a target dir so on-disk hashing works
+        target_dir = tmp_path / "vulns"
+        target_dir.mkdir()
+
+        understand = _make_understand_dir(
+            project_dir, "understand-20260401-120000",
+            checklist={"target_path": str(target_dir), "files": []},
+        )
+
+        # Point global out/ at the same parent so tier 3 finds same dir
+        monkeypatch.setattr("core.config.RaptorConfig.get_out_dir",
+                            staticmethod(lambda: project_dir))
+
+        result = find_understand_output(
+            validate_dir, target_path=str(target_dir),
+        )
+        assert result == understand
+
+    def test_staleness_warning_logged(self, tmp_path):
+        """When best candidate has stale files, _rank_candidates logs a warning."""
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "a.py").write_text("MODIFIED")
+
+        stale_dir = tmp_path / "stale"
+        stale_dir.mkdir()
+        _write_json(stale_dir / "checklist.json", {
+            "files": [{"path": "a.py", "sha256": "OLD_HASH_WONT_MATCH"}],
+        })
+
+        with unittest.mock.patch("core.understand_bridge.logger") as mock_logger:
+            result = _rank_candidates([stale_dir], str(target))
+
+        assert result == stale_dir
+        mock_logger.warning.assert_called_once()
+        assert "stale" in mock_logger.warning.call_args[0][0].lower()
+
+    def test_tier1_takes_priority_over_fresher_sibling(self, tmp_path):
+        """Co-located context-map (tier 1) wins even if a sibling exists."""
+        project_dir = tmp_path / "project"
+        validate_dir = project_dir / "validate-20260402-120000"
+        validate_dir.mkdir(parents=True)
+
+        # Tier 1: context-map in validate dir itself
+        _write_json(validate_dir / "context-map.json", {"sources": []})
+
+        # Tier 2: sibling that's newer
+        _make_understand_dir(project_dir, "understand-20260403-120000")
+
+        result = find_understand_output(validate_dir)
+        assert result == validate_dir  # tier 1 wins
+
+    def test_candidate_without_checklist_ranked_lowest(self, tmp_path):
+        """Candidate missing checklist.json treated as stale."""
+        import hashlib
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "a.py").write_text("content")
+        disk_hash = hashlib.sha256(b"content").hexdigest()
+
+        d_no_checklist = tmp_path / "no-checklist"
+        d_with_checklist = tmp_path / "with-checklist"
+        d_no_checklist.mkdir()
+        time.sleep(0.01)
+        d_with_checklist.mkdir()
+
+        # Newer dir has no checklist
+        # Older dir has fresh checklist matching disk
+        _write_json(d_with_checklist / "checklist.json", {
+            "files": [{"path": "a.py", "sha256": disk_hash}],
+        })
+
+        # d_no_checklist is newer by mtime but has no checklist → stale_count=1
+        result = _rank_candidates(
+            [d_no_checklist, d_with_checklist], str(target),
+        )
+        assert result == d_with_checklist
+
+
+# ---------------------------------------------------------------------------
+# raptor-prepare-understand script
+# ---------------------------------------------------------------------------
+
+class TestPrepareUnderstandScript:
+    def test_inventory_creates_checklist(self, tmp_path):
+        """inventory subcommand builds checklist and prints OUTPUT_DIR."""
+        import subprocess
+        target = tmp_path / "src"
+        target.mkdir()
+        (target / "hello.c").write_text("int main() { return 0; }\n")
+
+        # Temporarily hide the active project symlink so get_output_dir
+        # doesn't reject our temp target as outside the project.
+        active_link = Path.home() / ".raptor" / "projects" / ".active"
+        hidden_link = active_link.with_suffix(".active.bak")
+        active_existed = active_link.is_symlink()
+        if active_existed:
+            active_link.rename(hidden_link)
+
+        repo_root = Path(__file__).parents[2]
+        try:
+            result = subprocess.run(
+                ["libexec/raptor-prepare-understand", "inventory", str(target)],
+                capture_output=True, text=True, cwd=repo_root,
+            )
+            assert result.returncode == 0, result.stderr
+            assert "OUTPUT_DIR=" in result.stdout
+            output_dir = result.stdout.strip().split("OUTPUT_DIR=")[1]
+            assert (Path(output_dir) / "checklist.json").exists()
+
+            import shutil
+            shutil.rmtree(output_dir, ignore_errors=True)
+        finally:
+            if active_existed and hidden_link.exists():
+                hidden_link.rename(active_link)
+
+    def test_coverage_reads_file_and_deletes(self, tmp_path):
+        """coverage subcommand reads coverage-input.json and deletes it."""
+        from core.json import load_json
+
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        _write_json(workdir / "checklist.json", {
+            "generated_at": "2026-01-01",
+            "target_path": "/tmp/test",
+            "total_files": 1, "total_items": 1, "total_functions": 1,
+            "files": [{
+                "path": "main.c",
+                "language": "c",
+                "lines": 5,
+                "sha256": "abc",
+                "items": [{"name": "main", "kind": "function",
+                           "line_start": 1, "line_end": 5, "checked_by": []}],
+            }],
+        })
+        _write_json(workdir / "coverage-input.json", [
+            {"file": "main.c", "function": "main"},
+        ])
+
+        import subprocess
+        result = subprocess.run(
+            ["libexec/raptor-prepare-understand", "coverage", str(workdir)],
+            capture_output=True, text=True, cwd=Path(__file__).parents[2],
+        )
+        assert result.returncode == 0
+        assert "Recorded 1 functions" in result.stdout
+        assert not (workdir / "coverage-input.json").exists()
+
+        inv = load_json(workdir / "checklist.json")
+        main_func = inv["files"][0]["items"][0]
+        assert "understand:map" in main_func["checked_by"]
+
+    def test_coverage_rejects_missing_file(self, tmp_path):
+        """coverage fails gracefully when coverage-input.json doesn't exist."""
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        _write_json(workdir / "checklist.json", {"files": []})
+
+        import subprocess
+        result = subprocess.run(
+            ["libexec/raptor-prepare-understand", "coverage", str(workdir)],
+            capture_output=True, text=True, cwd=Path(__file__).parents[2],
+        )
+        assert result.returncode != 0
+        assert "coverage-input.json not found" in result.stderr
+
+    def test_coverage_rejects_bad_entries(self, tmp_path):
+        """coverage validates that each entry has file and function keys."""
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        _write_json(workdir / "checklist.json", {"files": []})
+        _write_json(workdir / "coverage-input.json", [
+            {"file": "a.py"},  # missing "function"
+        ])
+
+        import subprocess
+        result = subprocess.run(
+            ["libexec/raptor-prepare-understand", "coverage", str(workdir)],
+            capture_output=True, text=True, cwd=Path(__file__).parents[2],
+        )
+        assert result.returncode != 0
+        assert "missing" in result.stderr.lower()

--- a/core/understand_bridge.py
+++ b/core/understand_bridge.py
@@ -18,17 +18,18 @@ Handles three things automatically so the analyst doesn't have to:
 
 Usage (from Stage 0 in /validate):
 
-    from core.understand_bridge import load_understand_context, enrich_checklist
+    from core.understand_bridge import find_understand_output, load_understand_context, enrich_checklist
 
-    # Auto-detect from active project, or pass an explicit path
-    bridge = load_understand_context(understand_dir=Path("/some/understand-run"), validate_dir=output_dir)
-    if bridge["context_map"]:
-        enrich_checklist(checklist, bridge["context_map"])
+    understand_dir = find_understand_output(validate_dir, target_path=target)
+    if understand_dir:
+        bridge = load_understand_context(understand_dir, validate_dir)
+        if bridge["context_map_loaded"]:
+            enrich_checklist(checklist, bridge["context_map"], str(validate_dir))
 
-Auto-detection (project mode):
-
-    from core.understand_bridge import find_understand_dir
-    understand_dir = find_understand_dir(project_output_dir)  # None if not found
+The three-tier search in find_understand_output() covers:
+  1. Shared --out directory (context-map.json co-located)
+  2. Project sibling directories (same project, different run)
+  3. Global out/ scan (match by checklist target_path — no project needed)
 """
 
 import logging
@@ -49,33 +50,220 @@ TRACE_SOURCE_LABEL = "understand:trace"
 # Public API
 # ---------------------------------------------------------------------------
 
-def find_understand_dir(project_output_dir: Path) -> Optional[Path]:
-    """Find the most recent /understand run inside a project output directory.
 
-    Uses infer_command_type from core.run to identify understand runs regardless
-    of directory naming convention. Returns the most recent by modification time,
-    or None if none exists.
+def find_understand_output(
+    validate_dir: Path,
+    target_path: str = None,
+) -> Optional[Path]:
+    """Find the best /understand output for a validate run.
+
+    Three-tier search eliminates the need for --out alignment:
+
+    1. **Local**: context-map.json already in validate_dir (shared --out case)
+    2. **Project siblings**: sibling run dirs in the same project
+    3. **Global out/**: scan out/ for understand runs matching the same target_path
+
+    When multiple candidates exist across tiers 2+3, they are ranked by
+    hash freshness first (files unchanged since understand ran) then by
+    modification time. A stale candidate is only selected if no fresh one
+    exists.
+
+    Freshness is determined by hashing current files on disk and comparing
+    against the understand run's checklist — not against the validate
+    checklist, which may share a symlinked file in project mode.
+
+    Args:
+        validate_dir: The validate run's output directory.
+        target_path: The target being validated (used for target-path match,
+            global out/ search, and on-disk hash freshness checks).
+
+    Returns:
+        Path to the understand output directory, or None.
+        When tier 1 matches, returns validate_dir itself.
+    """
+    validate_dir = Path(validate_dir)
+
+    # Tier 1: context-map.json co-located (shared --out directory)
+    if (validate_dir / "context-map.json").exists():
+        logger.debug("understand output: tier 1 (local) — %s", validate_dir)
+        return validate_dir
+
+    # Collect candidates from tiers 2 and 3
+    candidates = _collect_candidates(validate_dir, target_path)
+    if not candidates:
+        return None
+
+    # Rank: fresh hashes beat stale, then newest wins
+    best = _rank_candidates(candidates, target_path)
+    if best:
+        logger.debug("understand output: selected %s", best)
+    return best
+
+
+def _collect_candidates(
+    validate_dir: Path, target_path: str = None,
+) -> List[Path]:
+    """Gather understand run directories from tiers 2 and 3."""
+    seen: set = set()
+    results: List[Path] = []
+
+    # Tier 2: project sibling directories
+    parent = validate_dir.parent  # e.g. out/projects/myapp/
+    for d in _search_understand_dirs(parent, exclude=validate_dir,
+                                     require_target=target_path):
+        resolved = d.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            results.append(d)
+
+    # Tier 3: global out/ search (only dirs matching target_path)
+    if target_path:
+        from core.config import RaptorConfig
+        out_root = RaptorConfig.get_out_dir()
+        for d in _search_understand_dirs(out_root, exclude=validate_dir,
+                                         require_target=target_path):
+            resolved = d.resolve()
+            if resolved not in seen:
+                seen.add(resolved)
+                results.append(d)
+
+    return results
+
+
+def _rank_candidates(
+    candidates: List[Path],
+    target_path: str = None,
+) -> Optional[Path]:
+    """Pick the best candidate: fresh hashes > stale, then newest first.
+
+    Freshness is checked by hashing the current files on disk under
+    target_path and comparing against the understand run's checklist.
+    This avoids the symlink problem where project-mode checklists
+    share a single file and the validate rebuild overwrites understand
+    hashes.
+
+    Returns None if candidates is empty.
+    """
+    if not candidates:
+        return None
+
+    if not target_path:
+        # No target — can't hash on disk, just pick newest
+        candidates.sort(key=lambda d: d.stat().st_mtime, reverse=True)
+        return candidates[0]
+
+    scored = []
+    for d in candidates:
+        u_checklist = load_json(d / "checklist.json")
+        if not u_checklist:
+            # No checklist — treat as stale (can't verify)
+            scored.append((1, d.stat().st_mtime, d))
+            continue
+        u_hashes = _extract_hashes(u_checklist)
+        stale_count = _count_stale_on_disk(u_hashes, target_path)
+        # fresh = 0 stale files → sort key 0 (best)
+        scored.append((stale_count, d.stat().st_mtime, d))
+
+    # Sort: fewest stale first, then newest mtime first (negate for descending)
+    scored.sort(key=lambda t: (t[0], -t[1]))
+    best_stale, _, best_dir = scored[0]
+
+    if best_stale > 0:
+        logger.warning(
+            "understand_bridge: best candidate %s has %d stale file(s)"
+            " — importing anyway, Stage C will catch stale refs",
+            best_dir.name, best_stale,
+        )
+
+    return best_dir
+
+
+def _extract_hashes(checklist: Dict[str, Any]) -> Dict[str, str]:
+    """Build {relative_path: sha256} from a checklist."""
+    return {
+        f["path"]: f["sha256"]
+        for f in checklist.get("files", [])
+        if f.get("sha256")
+    }
+
+
+def _count_stale_on_disk(
+    understand_hashes: Dict[str, str],
+    target_path: str,
+) -> int:
+    """Count files whose on-disk SHA-256 differs from the understand checklist.
+
+    Hashes the actual files under target_path rather than comparing against
+    another checklist. This is immune to the project-mode symlink problem
+    where both runs share one checklist.json file.
+    """
+    import hashlib
+
+    target = Path(target_path)
+    stale = 0
+    for rel_path, u_hash in understand_hashes.items():
+        full_path = target / rel_path
+        if not full_path.is_file():
+            # File deleted since understand ran — counts as stale
+            stale += 1
+            continue
+        disk_hash = hashlib.sha256(full_path.read_bytes()).hexdigest()
+        if disk_hash != u_hash:
+            stale += 1
+    return stale
+
+
+def _search_understand_dirs(
+    parent_dir: Path,
+    exclude: Path = None,
+    require_target: str = None,
+) -> List[Path]:
+    """Find understand run directories under parent_dir.
+
+    Args:
+        parent_dir: Directory to scan (e.g. project dir or out/).
+        exclude: Directory to skip (typically the validate dir itself).
+        require_target: If set, only return dirs whose checklist.json
+            target_path resolves to this path.
+
+    Returns:
+        List of matching directories, sorted newest-first by mtime.
     """
     from core.run import infer_command_type
 
-    project_output_dir = Path(project_output_dir)
-    if not project_output_dir.is_dir():
-        return None
+    parent_dir = Path(parent_dir)
+    if not parent_dir.is_dir():
+        return []
 
-    candidates = [
-        d for d in sorted(project_output_dir.iterdir(),
-                          key=lambda d: d.stat().st_mtime, reverse=True)
-        if d.is_dir()
-        and not d.name.startswith((".", "_"))
-        and infer_command_type(d) == "understand"
-        and (d / "context-map.json").exists()
-    ]
+    target_resolved = (
+        str(Path(require_target).resolve()) if require_target else None
+    )
 
-    if candidates:
-        logger.debug("Auto-detected understand dir: %s", candidates[0])
-        return candidates[0]
+    results = []
+    for d in parent_dir.iterdir():
+        try:
+            if not (d.is_dir()
+                    and d != exclude
+                    and not d.name.startswith((".", "_"))
+                    and infer_command_type(d) == "understand"
+                    and (d / "context-map.json").exists()):
+                continue
+        except OSError:
+            continue  # broken symlinks, permission errors
 
-    return None
+        if target_resolved:
+            from core.json import load_json
+            checklist = load_json(d / "checklist.json")
+            if not checklist:
+                continue
+            d_target = checklist.get("target_path", "")
+            if not d_target or str(Path(d_target).resolve()) != target_resolved:
+                continue
+
+        results.append(d)
+
+    results.sort(key=lambda d: d.stat().st_mtime, reverse=True)
+    return results
 
 
 def load_understand_context(

--- a/libexec/raptor-prepare-understand
+++ b/libexec/raptor-prepare-understand
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Mechanical prep for /understand — builds inventory and records coverage.
+
+Subcommands:
+    inventory <target> [--out <dir>]
+                        Build checklist.json in the run's output directory.
+                        Prints OUTPUT_DIR on the last line.
+    coverage <workdir>  Record which functions were examined (reads stdin as JSON).
+
+Examples:
+    # MAP-0: build inventory (run lifecycle starts automatically)
+    libexec/raptor-prepare-understand inventory /tmp/vulns
+
+    # MAP-0: build inventory with explicit output directory
+    libexec/raptor-prepare-understand inventory /tmp/vulns --out /tmp/shared-run
+
+    # MAP-5: record coverage after analysis
+    # (first write coverage-input.json via the Write tool, then:)
+    libexec/raptor-prepare-understand coverage "$WORKDIR"
+"""
+
+import json
+import sys
+from pathlib import Path
+
+# Ensure repo root is on the path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # repo root
+
+
+def cmd_inventory(target, explicit_out=None):
+    """MAP-0: build source inventory and start run lifecycle."""
+    from core.run.output import get_output_dir, TargetMismatchError
+    from core.run.metadata import start_run
+    from packages.exploitability_validation import build_checklist
+
+    try:
+        out_dir = get_output_dir("understand", target_path=target,
+                                 explicit_out=explicit_out)
+    except TargetMismatchError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    start_run(out_dir, "understand")
+    checklist = build_checklist(target, str(out_dir))
+
+    total = checklist["total_files"]
+    items = checklist["total_items"]
+    sloc = checklist.get("total_sloc", 0)
+    print(f"Checklist: {total} files, {items} items, {sloc} SLOC")
+    print(f"OUTPUT_DIR={out_dir}")
+
+
+def cmd_coverage(workdir):
+    """MAP-5: record which functions were examined.
+
+    Reads $WORKDIR/coverage-input.json — a JSON array of objects:
+        [{"file": "path/to/file.py", "function": "func_name"}, ...]
+
+    The file is deleted after successful processing.
+    """
+    from core.inventory.coverage import update_coverage
+    from core.inventory import save_checklist
+    from core.json import load_json
+
+    workdir = Path(workdir)
+    checklist_path = workdir / "checklist.json"
+    if not checklist_path.exists():
+        print("ERROR: checklist.json not found in workdir", file=sys.stderr)
+        sys.exit(1)
+
+    coverage_path = workdir / "coverage-input.json"
+    if not coverage_path.exists():
+        print("ERROR: coverage-input.json not found in workdir", file=sys.stderr)
+        print("  Write it first, then re-run this command.", file=sys.stderr)
+        sys.exit(1)
+
+    checked = load_json(coverage_path)
+    if not isinstance(checked, list):
+        print("ERROR: coverage-input.json must be a JSON array", file=sys.stderr)
+        sys.exit(1)
+
+    # Validate entries: each must have "file" and "function" strings
+    for i, entry in enumerate(checked):
+        if not isinstance(entry, dict):
+            print(f"ERROR: entry {i} is not an object", file=sys.stderr)
+            sys.exit(1)
+        if "file" not in entry or "function" not in entry:
+            print(f"ERROR: entry {i} missing 'file' or 'function' key", file=sys.stderr)
+            sys.exit(1)
+
+    inv = load_json(checklist_path)
+    update_coverage(inv, checked, "understand:map")
+    save_checklist(str(workdir), inv)
+    coverage_path.unlink()
+    print(f"Recorded {len(checked)} functions as checked by understand:map")
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] not in ("inventory", "coverage"):
+        print(f"Usage: {sys.argv[0]} <inventory|coverage> <path> [--out <dir>]")
+        sys.exit(1)
+
+    subcmd = sys.argv[1]
+    args = sys.argv[2:]
+
+    # Extract --out <dir> if present
+    explicit_out = None
+    if "--out" in args:
+        idx = args.index("--out")
+        if idx + 1 >= len(args):
+            print("ERROR: --out requires a directory argument", file=sys.stderr)
+            sys.exit(1)
+        explicit_out = args[idx + 1]
+        args = args[:idx] + args[idx + 2:]
+
+    if not args:
+        print(f"ERROR: {subcmd} requires a path argument", file=sys.stderr)
+        sys.exit(1)
+
+    path = args[0]
+
+    if subcmd == "inventory":
+        cmd_inventory(path, explicit_out=explicit_out)
+    elif subcmd == "coverage":
+        cmd_coverage(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/libexec/raptor-prepare-validation-stage
+++ b/libexec/raptor-prepare-validation-stage
@@ -35,6 +35,47 @@ from packages.exploitability_validation.schemas import (
 
 STAGE_LETTERS = "ABCDEF"
 
+# Schema hints printed at end of each prep so the LLM knows the required
+# output shape before writing.  Keep compact — these go to stdout.
+STAGE_SCHEMA_HINTS = {
+    "A": '''\
+Output: stage-a.json  {"stage":"A", "target_path":"...", "findings":[...]}
+  Each finding requires: id, file, function, line, vuln_type, status, confidence,
+    cwe_id, candidate_reasoning, dataflow_summary, proof_lines, proof_source,
+    proof_sink, origin ("claude_native"|"sarif_import"|"pre_existing"),
+    stage_a_summary: {confidence, status, candidate_reasoning}
+  status: "poc_success"|"not_disproven"|"disproven"
+  confidence: "high"|"medium"|"low"
+  If disproven: disproved_because: {investigated, conclusion, would_reconsider_if}''',
+
+    "B": '''\
+Output: stage-b.json  {"stage":"B", "updates":{"FIND-XXXX": {"stage_b_summary":{...}}, ...}}
+  stage_b_summary: {hypothesis_id, hypothesis_status, proximity (0-10), attack_path_id}
+  Also write: attack-tree.json, hypotheses.json, disproven.json, attack-paths.json, attack-surface.json''',
+
+    "C": '''\
+Output: stage-c.json  {"stage":"C", "updates":{"FIND-XXXX": {sanity_check:{...}, stage_c_summary:{...}}, ...}}
+  sanity_check: {code_verified:bool, flow_confirmed:bool, reachable:bool, notes:str}
+  stage_c_summary: {passed:bool, checks:{file_exists:bool, code_verbatim:bool, flow_real:bool, reachable:bool}}''',
+
+    "D": '''\
+Output: stage-d.json  {"stage":"D", "updates":{"FIND-XXXX": {ruling:{...}, cvss_vector:str, stage_d_summary:{...}}, ...}}
+  ruling: {status:"confirmed"|"ruled_out"|"exploitable", disqualifier:str|null, reason:str|null}
+  cvss_vector: "CVSS:3.1/AV:.../AC:.../PR:.../UI:.../S:.../C:.../I:.../A:..."
+  stage_d_summary: {status, disqualifiers_checked:[], disqualifiers_failed:[], evidence:str}''',
+
+    "F": '''\
+Output: stage-f.json  {"stage":"F", "updates":{"FIND-XXXX": {"stage_f_summary":{...}}, ...}}
+  stage_f_summary: {corrections:[], notes:str}
+  Corrections (if any): {field:str, old_value:str, new_value:str, reason:str}''',
+}
+
+
+def _print_schema_hint(stage):
+    hint = STAGE_SCHEMA_HINTS.get(stage)
+    if hint:
+        print(hint)
+
 
 def _is_validated(workdir, filename):
     """Check if a file was already validated (hash matches .validated record)."""
@@ -282,6 +323,13 @@ def prepare_A(workdir, target=None):
     else:
         print("No pre-existing findings")
 
+    # Surface priority targets from /understand bridge
+    priority_targets = checklist.get("priority_targets", [])
+    if priority_targets:
+        print(f"Priority targets from /understand: {len(priority_targets)} unchecked flows")
+        for pt in priority_targets:
+            print(f"  {pt.get('entry_point')} → {pt.get('sink')}: {pt.get('missing_boundary')}")
+
     # Discover existing binaries and build PoCs for standalone C files
     if target:
         build_dir = Path(workdir) / "build"
@@ -306,6 +354,7 @@ def prepare_A(workdir, target=None):
                     print(f"  {src}: {', '.join(parts)}")
                 else:
                     print(f"  {src}: no binary")
+    _print_schema_hint("A")
 
 
 # ---------------------------------------------------------------------------
@@ -449,6 +498,7 @@ def prepare_B(workdir, target=None):
         print(f"  {len(deduped)} findings flagged as potential duplicates — review during analysis")
 
     _report_workdir_files(workdir, "existing")
+    _print_schema_hint("B")
 
 
 # ---------------------------------------------------------------------------
@@ -510,6 +560,7 @@ def prepare_C(workdir, target=None):
     _save_findings(workdir, findings_data)
     failed = sum(1 for f in findings_data["findings"] if f.get("checklist_verified") is False)
     print(f"Inventory check: {failed} failed, {len(findings_data['findings']) - failed} passed")
+    _print_schema_hint("C")
 
 
 # ---------------------------------------------------------------------------
@@ -581,6 +632,7 @@ def prepare_D(workdir, target=None):
     _save_findings(workdir, data)
     flagged = sum(1 for f in data["findings"] if f.get("test_code_flag"))
     print(f"Test filter: {flagged} flagged, evidence cards assembled")
+    _print_schema_hint("D")
 
 
 # ---------------------------------------------------------------------------
@@ -794,6 +846,7 @@ def prepare_F(workdir, target=None):
 
     _report_workdir_files(workdir, "available for review")
 
+    _print_schema_hint("F")
     print("Stage F prep complete")
 
 
@@ -801,7 +854,53 @@ def prepare_F(workdir, target=None):
 # 0: Start run + build inventory
 # ---------------------------------------------------------------------------
 
-def prepare_0(workdir_unused, target=None):
+def _bridge_understand_output(out_dir, checklist, target):
+    """Import /understand output into the validate run if available.
+
+    Searches three tiers: local co-location, project siblings, global out/.
+    Candidates are ranked by hash freshness (files unchanged since understand
+    ran) then by modification time. Populates attack-surface.json, imports
+    flow traces into attack-paths.json, and enriches the checklist with
+    priority markers for entry points and sinks.
+    """
+    from core.understand_bridge import (
+        find_understand_output, load_understand_context, enrich_checklist,
+    )
+
+    understand_dir = find_understand_output(
+        out_dir, target_path=target,
+    )
+    if not understand_dir:
+        return
+
+    # When understand_dir IS validate_dir (shared --out), skip
+    # load_understand_context since it would read/write the same files.
+    # Just enrich the checklist from the co-located context-map.
+    if understand_dir == out_dir:
+        context_map_path = out_dir / "context-map.json"
+        if context_map_path.exists():
+            from core.json import load_json
+            context_map = load_json(context_map_path)
+            if context_map:
+                enrich_checklist(checklist, context_map, str(out_dir))
+                n_targets = len(checklist.get("priority_targets", []))
+                print(f"  Bridge: enriched checklist from co-located context-map.json"
+                      f" ({n_targets} priority targets)")
+        return
+
+    bridge = load_understand_context(understand_dir, out_dir)
+    if bridge.get("context_map_loaded"):
+        enrich_checklist(checklist, bridge["context_map"], str(out_dir))
+        n_sources = bridge["attack_surface"]["sources"]
+        n_sinks = bridge["attack_surface"]["sinks"]
+        n_traces = bridge["flow_traces"]["imported_as_paths"]
+        n_targets = len(checklist.get("priority_targets", []))
+        print(f"  Bridge: loaded {understand_dir.name}"
+              f" — {n_sources} sources, {n_sinks} sinks,"
+              f" {n_traces} traces, {n_targets} priority targets")
+
+
+def prepare_0(workdir_unused, target=None, explicit_out=None, no_bridge=False):
     if not target:
         print("ERROR: --target is required for stage 0", file=sys.stderr)
         sys.exit(1)
@@ -810,7 +909,8 @@ def prepare_0(workdir_unused, target=None):
     from core.run.metadata import start_run
 
     try:
-        out_dir = get_output_dir("validate", target_path=target)
+        out_dir = get_output_dir("validate", target_path=target,
+                                 explicit_out=explicit_out)
     except TargetMismatchError as e:
         print(f"ERROR: {e}", file=sys.stderr)
         sys.exit(1)
@@ -822,6 +922,10 @@ def prepare_0(workdir_unused, target=None):
 
     # Create build directory for PoC compilation
     (out_dir / "build").mkdir(exist_ok=True)
+
+    # Bridge: import /understand output if available
+    if not no_bridge:
+        _bridge_understand_output(out_dir, checklist, target)
 
     print(f"Checklist: {checklist['total_files']} files, {checklist['total_items']} items")
     print(f"OUTPUT_DIR={out_dir}")
@@ -879,19 +983,25 @@ STAGES = {
 def main():
     args = sys.argv[1:]
     if not args or args[0] not in STAGES:
-        print(f"Usage: {sys.argv[0]} <0|A|B|C|D|E|F|1> [workdir] [--target <path>]")
+        print(f"Usage: {sys.argv[0]} <0|A|B|C|D|E|F|1> [workdir] [--target <path>] [--out <dir>] [--no-bridge]")
         sys.exit(1)
 
     stage = args[0]
     target = None
+    explicit_out = None
     if "--target" in args:
         idx = args.index("--target")
         if idx + 1 < len(args):
             target = args[idx + 1]
+    if "--out" in args:
+        idx = args.index("--out")
+        if idx + 1 < len(args):
+            explicit_out = args[idx + 1]
+    no_bridge = "--no-bridge" in args
 
     # Stage 0 doesn't need a workdir (it creates one)
     if stage == "0":
-        prepare_0(None, target)
+        prepare_0(None, target, explicit_out=explicit_out, no_bridge=no_bridge)
         return
 
     # All other stages need a workdir

--- a/libexec/raptor-render-diagrams
+++ b/libexec/raptor-render-diagrams
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Render Mermaid diagrams from JSON outputs in a directory.
+
+Usage: raptor-render-diagrams <output_dir> [--target <name>]
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: raptor-render-diagrams <output_dir> [--target <name>]",
+              file=sys.stderr)
+        sys.exit(1)
+
+    out_dir = Path(sys.argv[1])
+    target = None
+    if "--target" in sys.argv:
+        idx = sys.argv.index("--target")
+        if idx + 1 < len(sys.argv):
+            target = sys.argv[idx + 1]
+
+    if not out_dir.exists():
+        print(f"ERROR: directory not found: {out_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        from packages.diagram import render_and_write
+        output_file = render_and_write(out_dir, target=target)
+        print(f"Diagrams: {output_file}")
+    except Exception as e:
+        print(f"Diagram error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/exploitability_validation/tests/test_validation.py
+++ b/packages/exploitability_validation/tests/test_validation.py
@@ -2510,29 +2510,34 @@ class TestCompareChecklists:
         new = self._make_checklist([("a.c", "aaa")])
         assert compare_checklists(old, new) is None
 
-    def test_build_checklist_detects_unchanged(self, tmp_path):
-        """Second build_checklist run with same source should set source_unchanged."""
+    def test_build_checklist_reuses_existing(self, tmp_path):
+        """Second build_checklist on same target reuses the snapshot."""
         src = tmp_path / "src"
         src.mkdir()
         (src / "a.c").write_text("int foo() { return 1; }\n")
         out = str(tmp_path / "out")
 
-        build_checklist(str(src), out)
+        c1 = build_checklist(str(src), out)
         c2 = build_checklist(str(src), out)
-        assert c2.get("source_unchanged") is True
+        assert c1["files"][0]["sha256"] == c2["files"][0]["sha256"]
+        assert c1["generated_at"] == c2["generated_at"]
 
-    def test_build_checklist_detects_change(self, tmp_path):
-        """build_checklist should detect when a source file changed between runs."""
+    def test_build_checklist_preserves_hash_when_source_changes(self, tmp_path):
+        """Checklist is a snapshot — hashes are NOT updated when source changes."""
+        import hashlib
         src = tmp_path / "src"
         src.mkdir()
         (src / "a.c").write_text("int foo() { return 1; }\n")
         out = str(tmp_path / "out")
 
-        build_checklist(str(src), out)
+        c1 = build_checklist(str(src), out)
+        original_hash = c1["files"][0]["sha256"]
         (src / "a.c").write_text("int foo() { return 2; }\n")
         c2 = build_checklist(str(src), out)
-        assert "changes_since_last" in c2
-        assert "a.c" in c2["changes_since_last"]["modified"]
+        # Hash preserved — consumer detects staleness by comparing to disk
+        assert c2["files"][0]["sha256"] == original_hash
+        disk_hash = hashlib.sha256((src / "a.c").read_bytes()).hexdigest()
+        assert disk_hash != original_hash
 
 
 class TestDisprovenSchema:


### PR DESCRIPTION
**Bridge integration:**
  - 3-tier understand→validate bridge with on-disk SHA-256 freshness
  - Bridge wired into validate Stage 0, priority targets surfaced in Stage A
  - --out and --no-bridge flags
  
  **Libexec scripts:**
  - raptor-prepare-understand (inventory + coverage)
  - raptor-render-diagrams (shared by understand, validate, /diagram)
  
  **Bug fixes:**
  - SHA-256 hashing on raw bytes not normalised text
  - build_inventory respects existing checklist (snapshot model)
  - Bridge checks disk not checklist-to-checklist
  - Bridge tier 2 filters by target_path
  - Remaining RAPTOR_PROJECT_DIR env var references removed

  **Prompt updates:**
  - All python3 -c snippets in understand/diagram replaced with libexec calls
  - Schema hints from prep scripts
  - Stage skill file loading guidance in validate.md
  - Bridge-aware docs in stage-a and stage-b

  **Tests:**
  - Bridge tests: 21 → 40
  - Updated inventory, validation, output, CLI tests