### PR TITLE
Install Node.js and Claude CLI in devcontainer (fixes #160)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -151,6 +151,16 @@ RUN pip install --no-cache-dir -r /tmp/packages-web-requirements.txt
 RUN python -m playwright install
 
 # ============================================================================
+# CLAUDE CLI (claude-code npm package)
+# Required to run RAPTOR via bin/raptor
+# ============================================================================
+
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && npm install -g @anthropic-ai/claude-code
+
+# ============================================================================
 # ENVIRONMENT CONFIGURATION
 # ============================================================================
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,8 @@
     "PYTHONDONTWRITEBYTECODE": "1"
   },
   "mounts": [
-    "source=${localWorkspaceFolder}/.env,target=/workspaces/raptor/.env,type=bind,consistency=cached"
+    "source=${localWorkspaceFolder}/.env,target=/workspaces/raptor/.env,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.claude,target=/root/.claude,type=bind,consistency=cached"
   ],
   "postCreateCommand": "pip install -r .devcontainer/requirements-all-optional.txt && pip install -r requirements-dev.txt",
   "postStartCommand": "sudo sh -c 'echo 1 > /proc/sys/kernel/perf_event_paranoid 2>/dev/null || true'",


### PR DESCRIPTION
npm and the `claude-code` CLI are required to run RAPTOR via `bin/raptor` but were missing from the Docker image, forcing users to install them manually (reported in #160).

## Changes

- `.devcontainer/Dockerfile`: add Node.js 20 via nodesource and install `@anthropic-ai/claude-code` globally
- `.devcontainer/devcontainer.json`: mount `~/.claude` so existing Claude Code authentication carries through without re-login

Fixes #160