### PR TITLE
Fix findings pipeline: semantic grouping, SARIF dedup, bridge stale filtering, project findings command

### DIFF
--- a/.claude/commands/project.md
+++ b/.claude/commands/project.md
@@ -21,6 +21,7 @@ Manage projects — named workspaces that corral analysis runs into one director
 | `list` | Show all projects (* marks active) |
 | `status [<name>]` | Show project summary with run history |
 | `coverage [<name>] [--detailed]` | Show tool coverage summary (or per-file table) |
+| `findings [<name>] [--detailed]` | Show merged findings (or per-finding detail) |
 | `none` | Clear the active project |
 | `use [<name>]` | Set active project (no arg = show current, `none` = clear) |
 | `delete <name> [--purge] [--yes]` | Remove project (--purge also deletes output) |

--- a/.claude/commands/understand.md
+++ b/.claude/commands/understand.md
@@ -25,7 +25,7 @@ libexec/raptor-run-lifecycle start understand --target <resolved_target>
 The last line of output is `OUTPUT_DIR=<path>` — use that for all subsequent steps.
 
 ```bash
-libexec/raptor-build-checklist <resolved_target> "$OUTPUT_DIR" --fix
+libexec/raptor-build-checklist <resolved_target> "$OUTPUT_DIR"
 ```
 
 **Step 2: Do the analysis** (map, trace, hunt, teach — see skill files).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ VERY IMPORTANT: follow these steps in order.
 
 ## COMMANDS
 
-/project - Project management: create, list, status, diff, merge, report, clean, export
+/project - Project management: create, list, status, coverage, findings, diff, merge, report, clean, export
 /scan /fuzz /web /agentic /codeql /analyze - Security testing
 /exploit /patch - Generate PoCs and fixes (beta)
 /validate - Exploitability validation pipeline (see below)
@@ -40,7 +40,9 @@ Projects are opt-in named workspaces that corral analysis runs into a shared dir
 /project create myapp --target /path/to/code -d "Description"
 /project use myapp
 /scan                          # output goes to project dir
-/project status                # shows all runs and findings
+/project status                # shows all runs
+/project findings              # shows merged findings across runs
+/project coverage              # shows tool coverage summary
 /project report                # merged view across all runs
 /project clean --keep 3        # delete old runs
 /project none                  # clear active project

--- a/core/coverage/summary.py
+++ b/core/coverage/summary.py
@@ -137,14 +137,28 @@ def compute_summary(run_dir: Path) -> Optional[Dict[str, Any]]:
             path = _match_to_inventory(fa.get("file", ""), inventory_paths) or fa.get("file", "")
             analysed_funcs_by_file.add((path, fa.get("function", "")))
 
-    # Count findings per file from findings.json
+    # Count findings and vulns per file from findings.json
     findings_by_file = {}
+    vulns_by_file = {}
     findings_data = load_json(run_dir / "findings.json")
-    if findings_data and isinstance(findings_data, dict):
-        for finding in findings_data.get("findings", []):
+    if findings_data:
+        if isinstance(findings_data, list):
+            findings_list = findings_data
+        elif isinstance(findings_data, dict):
+            findings_list = findings_data.get("findings", findings_data.get("results", []))
+        else:
+            findings_list = []
+        # Group findings per file for vuln counting
+        from collections import defaultdict
+        per_file_findings = defaultdict(list)
+        for finding in findings_list:
             fpath = finding.get("file", "")
             matched = _match_to_inventory(fpath, inventory_paths) or fpath
             findings_by_file[matched] = findings_by_file.get(matched, 0) + 1
+            per_file_findings[matched].append(finding)
+        from core.project.findings_utils import count_vulns
+        for fpath, flist in per_file_findings.items():
+            vulns_by_file[fpath] = count_vulns(flist)
 
     per_file = []
     for f in files:
@@ -169,6 +183,7 @@ def compute_summary(run_dir: Path) -> Optional[Dict[str, Any]]:
             "pct": reviewed / total * 100,
             "sloc": f.get("sloc", 0),
             "findings": findings_by_file.get(path, 0),
+            "vulns": vulns_by_file.get(path, 0),
             "unreviewed_functions": unreviewed_names if unreviewed_names else [],
         }
         # Per-tool scan flags for detailed view
@@ -252,9 +267,9 @@ def format_summary(summary: Dict[str, Any]) -> str:
         if pf.get("findings", 0) > 0 and pf["reviewed"] == 0
     ]
     if unreviewed_with_findings:
-        total_findings = sum(pf["findings"] for pf in unreviewed_with_findings)
+        total_vulns = sum(pf.get("vulns", pf["findings"]) for pf in unreviewed_with_findings)
         actions.append(
-            f"{_pl(total_findings, 'finding')} in {_pl(len(unreviewed_with_findings), 'file')} not yet reviewed"
+            f"{_pl(total_vulns, 'finding')} in {_pl(len(unreviewed_with_findings), 'file')} not yet reviewed"
         )
 
     if actions:
@@ -324,9 +339,9 @@ def format_detailed(summary: Dict[str, Any]) -> str:
                 scanned_flags.append(" ")
         scanned_str = " ".join(scanned_flags) if scanned_flags else "-"
 
-        # Findings
-        findings = pf.get("findings", 0)
-        findings_str = str(findings) if findings else "-"
+        # Findings (grouped — one logical finding may span multiple lines)
+        vulns = pf.get("vulns", pf.get("findings", 0))
+        findings_str = str(vulns) if vulns else "-"
 
         # Reviewed
         if pf["total"] == 0:
@@ -431,8 +446,14 @@ def compute_project_summary(project) -> Optional[Dict[str, Any]]:
     seen = set()
     for d in project.get_run_dirs(sweep=False):
         fdata = load_json(d / "findings.json")
-        if fdata and isinstance(fdata, dict):
-            for f in fdata.get("findings", []):
+        if fdata:
+            if isinstance(fdata, list):
+                flist = fdata
+            elif isinstance(fdata, dict):
+                flist = fdata.get("findings", fdata.get("results", []))
+            else:
+                flist = []
+            for f in flist:
                 key = (f.get("file", ""), f.get("function", ""), f.get("line", 0))
                 if key not in seen:
                     all_findings.append(f)

--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -37,15 +37,16 @@ def build_inventory(
     extensions: Optional[Set[str]] = None,
     skip_generated: bool = True,
     parallel: bool = True,
-    force_rebuild: bool = False,
 ) -> Dict[str, Any]:
     """Build a source inventory of all files and functions in the target path.
 
     Enumerates source files, detects languages, extracts functions via
     AST/regex, computes SHA-256 per file, and records exclusions.
 
-    If an existing checklist.json is found in output_dir, cumulative
-    coverage (checked_by) is carried forward for unchanged files.
+    Always rehashes files on disk.  Unchanged files (SHA-256 match with
+    a previous checklist) reuse their old parsed entries, including
+    coverage marks.  Changed files are re-parsed and their coverage
+    marks cleared.
 
     Args:
         target_path: Directory or file to analyze.
@@ -54,9 +55,6 @@ def build_inventory(
         extensions: File extensions to include (defaults to LANGUAGE_MAP keys).
         skip_generated: Skip auto-generated files.
         parallel: Use parallel processing for large codebases.
-        force_rebuild: Always rehash and rebuild, even if a checklist exists
-            for this target.  Individual unchanged files (SHA-256 match) still
-            reuse their old parsed entries.
 
     Returns:
         Inventory dict (also saved to output_dir/checklist.json).
@@ -83,13 +81,6 @@ def build_inventory(
     output_path.mkdir(parents=True, exist_ok=True)
     checklist_file = output_path / 'checklist.json'
     old_inventory = load_json(checklist_file)
-
-    # When not force-rebuilding, reuse the existing inventory wholesale if
-    # the target path matches.  Consumers detect per-file staleness by
-    # comparing checklist hashes to current disk.
-    if not force_rebuild and old_inventory and old_inventory.get('target_path') == str(target_path):
-        logger.info("Reusing existing inventory for %s", target_path)
-        return old_inventory
 
     old_files_by_path = {}
     if old_inventory:

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -377,12 +377,7 @@ class TestCumulativeCoverage:
         assert inv2["files"][0]["items"][0]["checked_by"] == ["validate:stage-a"]
 
     def test_reuse_when_source_modified(self, tmp_path):
-        """build_inventory returns existing checklist even if source changed.
-
-        The checklist is a snapshot — hashes record state at inventory time.
-        Consumers detect staleness by comparing hashes to disk, not the builder.
-        Pass force_rebuild=True to rehash and rebuild.
-        """
+        """build_inventory picks up source changes and clears stale coverage."""
         import hashlib
         src = tmp_path / "src"
         src.mkdir()
@@ -399,42 +394,16 @@ class TestCumulativeCoverage:
         # Modify source — disk hash now differs from checklist hash
         (src / "app.py").write_text("def main():\n    print('changed')\n")
 
-        # Default: reuses existing inventory (snapshot preserved)
+        # Rebuild picks up the change and clears stale coverage
         inv2 = build_inventory(str(src), str(out))
-        assert inv2["files"][0]["sha256"] == original_hash
-        assert inv2["files"][0]["items"][0]["checked_by"] == ["validate:stage-a"]
-
-        # Consumer can detect staleness by hashing disk
-        disk_hash = hashlib.sha256((src / "app.py").read_bytes()).hexdigest()
-        assert disk_hash != original_hash
-
-    def test_force_rebuild_rehashes(self, tmp_path):
-        """force_rebuild=True rebuilds the checklist even when one exists."""
-        import hashlib
-        src = tmp_path / "src"
-        src.mkdir()
-        (src / "app.py").write_text("def main(): pass\n")
-
-        out = tmp_path / "out"
-
-        inv1 = build_inventory(str(src), str(out))
-        original_hash = inv1["files"][0]["sha256"]
-
-        # Modify source
-        (src / "app.py").write_text("def main():\n    print('changed')\n")
-
-        # force_rebuild picks up the change
-        inv2 = build_inventory(str(src), str(out), force_rebuild=True)
-        assert inv2["files"][0]["sha256"] != original_hash
         disk_hash = hashlib.sha256((src / "app.py").read_bytes()).hexdigest()
         assert inv2["files"][0]["sha256"] == disk_hash
+        assert inv2["files"][0]["sha256"] != original_hash
+        # Coverage marks cleared for changed file
+        assert inv2["files"][0]["items"][0].get("checked_by", []) == []
 
-    def test_reuse_when_file_added(self, tmp_path):
-        """New files on disk don't trigger a rebuild — checklist is a snapshot.
-
-        Consumers discover new files by comparing checklist paths to disk.
-        Use force_rebuild=True to pick up new files.
-        """
+    def test_rebuild_picks_up_new_files(self, tmp_path):
+        """New files on disk are included in the next rebuild."""
         src = tmp_path / "src"
         src.mkdir()
         (src / "app.py").write_text("def main(): pass\n")
@@ -442,17 +411,13 @@ class TestCumulativeCoverage:
         out = tmp_path / "out"
 
         inv1 = build_inventory(str(src), str(out))
+        assert len(inv1["files"]) == 1
+
         (src / "new.py").write_text("def new_func(): pass\n")
 
-        # Default: reuses — new.py is not in the snapshot
         inv2 = build_inventory(str(src), str(out))
-        assert len(inv2["files"]) == 1
-        assert inv2["files"][0]["path"] == "app.py"
-
-        # force_rebuild picks up new.py
-        inv3 = build_inventory(str(src), str(out), force_rebuild=True)
-        assert len(inv3["files"]) == 2
-        paths = {f["path"] for f in inv3["files"]}
+        assert len(inv2["files"]) == 2
+        paths = {f["path"] for f in inv2["files"]}
         assert "new.py" in paths
 
 

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -9,7 +9,6 @@ import os
 import sys
 from pathlib import Path
 
-from .findings_utils import get_finding_id
 from .project import ProjectManager
 
 
@@ -71,6 +70,12 @@ def main():
                            usage="raptor project coverage [<name>] [--detailed]", **_F)
     p_cov.add_argument("name", nargs="?", help="Project name")
     p_cov.add_argument("--detailed", action="store_true", help="Per-file breakdown")
+
+    # findings
+    p_findings = sub.add_parser("findings", help="Show merged findings across all runs",
+                                usage="raptor project findings [<name>] [--detailed]", **_F)
+    p_findings.add_argument("name", nargs="?", help="Project name")
+    p_findings.add_argument("--detailed", action="store_true", help="Per-finding detail (reasoning, proof, PoC)")
 
     # delete
     p_delete = sub.add_parser("delete", help="Delete a project",
@@ -225,6 +230,17 @@ def main():
                 print(f"Project '{name}' not found.")
                 return
             _print_coverage(p, detailed=args.detailed)
+
+        elif args.subcommand == "findings":
+            name = args.name or _get_active_project()
+            if not name:
+                print("No project specified.")
+                return
+            p = mgr.load(name)
+            if not p:
+                print(f"Project '{name}' not found.")
+                return
+            _print_findings(p, detailed=args.detailed)
 
         elif args.subcommand == "use":
             if args.name is None:
@@ -489,7 +505,12 @@ def _print_status(project):
             status = meta.get("status", "?") if meta else "?"
             findings = load_findings_from_dir(d)
             if findings:
-                findings_str = f"{len(findings)} findings"
+                from core.project.findings_utils import count_vulns
+                vuln_count = count_vulns(findings)
+                if vuln_count != len(findings):
+                    findings_str = f"{vuln_count} findings"
+                else:
+                    findings_str = f"{len(findings)} findings"
             else:
                 # Count SARIF results for scan/codeql runs
                 sarif_count = _count_sarif_results(d)
@@ -502,7 +523,7 @@ def _print_status(project):
                 status_str = _yellow(status)
             else:
                 status_str = status
-            print(f"  {d.name:<{name_col}s}  {cmd:12s}  {findings_str:15s}  {status_str}")
+            print(f"  {d.name:<{name_col}s}  {cmd:12s}  {findings_str:24s}  {status_str}")
         # Disk usage — skip symlinks to avoid following outside the project
         total_size = 0
         for d in runs:
@@ -538,23 +559,125 @@ def _print_coverage(project, detailed=False):
         print(format_summary(summary))
 
 
+def _print_findings(project, detailed=False):
+    """Print merged findings across all runs, grouped by vuln."""
+    from .merge import merge_findings
+    from .findings_utils import count_vulns, group_findings
+    from core.reporting.findings import build_findings_summary, findings_summary_line
+    from core.reporting.formatting import get_display_status, title_case_type, truncate_path
+
+    run_dirs = project.get_run_dirs(sweep=False)
+    merged = merge_findings(run_dirs)
+
+    if not merged:
+        print("No findings.")
+        return
+
+    vuln_count = count_vulns(merged)
+    counts = build_findings_summary(merged)
+    groups = group_findings(merged)
+
+    # Summary line
+    print(findings_summary_line(counts, vuln_count).replace("**", ""))
+    print()
+
+    # Build grouped rows: one row per vuln
+    grouped_rows = []  # (file_loc, type, status, cvss, findings_list)
+    for key, findings in groups.items():
+        # Use the first finding for display, pick best status/cvss across group
+        rep = findings[0]  # representative finding
+        fpath = rep.get("file", "")
+        fname = fpath.rsplit("/", 1)[-1] if "/" in fpath else fpath
+
+        # Lines: show all lines in the group
+        lines_in_group = sorted(set(f.get("line", 0) for f in findings))
+        if len(lines_in_group) == 1:
+            loc = f"{fname}:{lines_in_group[0]}"
+        else:
+            loc = f"{fname}:{','.join(str(l) for l in lines_in_group)}"
+        loc = truncate_path(loc) if loc else "—"
+
+        vtype = title_case_type(rep.get("vuln_type", ""))
+        status = get_display_status(rep)
+
+        cvss = rep.get("cvss_score_estimate")
+        cvss_str = str(cvss) if cvss is not None else "—"
+
+        grouped_rows.append((loc, vtype, status, cvss_str, findings, fpath))
+
+    grouped_rows.sort(key=lambda r: (r[5], min(f.get("line", 0) for f in r[4])))
+
+    # Compact table
+    headers = ("File", "Type", "Status", "CVSS")
+    widths = [len(h) for h in headers]
+    for row in grouped_rows:
+        for i, cell in enumerate(row[:4]):
+            widths[i] = max(widths[i], len(cell))
+
+    fmt = f"  {{:<{widths[0]}s}}  {{:<{widths[1]}s}}  {{:<{widths[2]}s}}  {{:>{widths[3]}s}}"
+    print(fmt.format(*headers))
+    print(f"  {'-' * widths[0]}  {'-' * widths[1]}  {'-' * widths[2]}  {'-' * widths[3]}")
+    for row in grouped_rows:
+        print(fmt.format(*row[:4]))
+
+    if not detailed:
+        return
+
+    # Detailed view: per-vuln reasoning, proof, PoC
+    print()
+    pad = len(str(len(grouped_rows)))
+    indent = " " * (pad + 5)  # aligns with text after "  [XX] "
+    for i, (loc, vtype, status, cvss_str, findings, _) in enumerate(grouped_rows, 1):
+        print(f"  [{i:0{pad}d}] {loc} — {vtype} ({status})")
+
+        # Use representative finding for details
+        rep = findings[0]
+
+        # Reasoning (stage summaries or analysis)
+        reasoning = (
+            rep.get("stage_d_summary")
+            or rep.get("stage_b_summary")
+            or rep.get("candidate_reasoning")
+            or rep.get("reasoning")
+        )
+        if reasoning and isinstance(reasoning, str):
+            rlines = reasoning.strip().split("\n")[:2]
+            for ln in rlines:
+                print(f"{indent}{ln.strip()}")
+
+        # Proof
+        proof_source = rep.get("proof_source")
+        proof_sink = rep.get("proof_sink")
+        if proof_source or proof_sink:
+            parts = []
+            if proof_source:
+                parts.append(f"source: {proof_source}")
+            if proof_sink:
+                parts.append(f"sink: {proof_sink}")
+            print(f"{indent}Proof: {', '.join(parts)}")
+
+        print()
+
+
+def _finding_label(f):
+    """Location-based label for a finding."""
+    return f"{f.get('file', '?')}:{f.get('function', '?')}:{f.get('line', '?')}"
+
+
 def _print_diff(result):
     """Print diff results."""
     if result["new"]:
         print(f"New ({len(result['new'])}):")
         for f in result["new"]:
-            fid = get_finding_id(f) or "?"
-            print(_green(f"  + {fid}"))
+            print(_green(f"  + {_finding_label(f)}"))
     if result["removed"]:
         print(f"Removed ({len(result['removed'])}):")
         for f in result["removed"]:
-            fid = get_finding_id(f) or "?"
-            print(_red(f"  - {fid}"))
+            print(_red(f"  - {_finding_label(f)}"))
     if result["changed"]:
         print(f"Changed ({len(result['changed'])}):")
         for c in result["changed"]:
-            # Changed entries have their own "id" field from the diff wrapper
-            print(_yellow(f"  ~ {c['id']} ({c.get('status_before', '?')} → {c.get('status_after', '?')})"))
+            print(_yellow(f"  ~ {c['label']} ({c.get('status_before', '?')} → {c.get('status_after', '?')})"))
     print(f"Unchanged: {result['unchanged']}")
 
 
@@ -660,5 +783,9 @@ def _do_merge(project, merge_type, yes):
             for msg in failed_deletes:
                 print(f"  {cmd_type}: warning — failed to delete {msg}")
 
-        print(f"  {cmd_type}: merged {stats['runs_merged']} runs "
-              f"({stats['unique_findings']} findings)")
+        vuln_count = stats.get("unique_vulns", stats["unique_findings"])
+        if vuln_count != stats["unique_findings"]:
+            findings_label = f"{vuln_count} findings"
+        else:
+            findings_label = f"{stats['unique_findings']} findings"
+        print(f"  {cmd_type}: merged {stats['runs_merged']} runs ({findings_label})")

--- a/core/project/diff.py
+++ b/core/project/diff.py
@@ -2,13 +2,14 @@
 
 Compares findings.json from two runs and reports what changed:
 new findings, removed findings, changed rulings, and unchanged count.
+Matches findings by (file, function, line) — stable across runs.
 """
 
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from core.logging import get_logger
-from core.project.findings_utils import get_finding_id as _get_finding_id
+from core.project.findings_utils import dedup_key as _dedup_key
 from core.project.findings_utils import load_findings_from_dir as _load_findings
 
 logger = get_logger()
@@ -27,13 +28,19 @@ def _get_status(finding: Dict[str, Any]) -> Optional[str]:
     return None
 
 
-def _index_by_id(findings: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
-    """Index findings by their ID. Skips findings without an ID."""
+def _finding_label(finding: Dict[str, Any]) -> str:
+    """Human-readable label for a finding: file:function:line."""
+    f = finding.get("file", "?")
+    fn = finding.get("function", "?")
+    line = finding.get("line", "?")
+    return f"{f}:{fn}:{line}"
+
+
+def _index_by_location(findings: List[Dict[str, Any]]) -> Dict[tuple, Dict[str, Any]]:
+    """Index findings by (file, function, line). Stable across runs."""
     indexed = {}
     for f in findings:
-        fid = _get_finding_id(f)
-        if fid:
-            indexed[fid] = f
+        indexed[_dedup_key(f)] = f
     return indexed
 
 
@@ -46,7 +53,7 @@ def diff_runs(run_dir_a: Path, run_dir_b: Path) -> Dict[str, Any]:
 
     Returns:
         Dict with keys:
-            new: findings in B but not A (by finding ID)
+            new: findings in B but not A (by location)
             removed: findings in A but not B
             changed: findings in both but with different status/ruling
             unchanged: count of identical findings
@@ -57,26 +64,26 @@ def diff_runs(run_dir_a: Path, run_dir_b: Path) -> Dict[str, Any]:
     findings_a = _load_findings(run_dir_a)
     findings_b = _load_findings(run_dir_b)
 
-    index_a = _index_by_id(findings_a)
-    index_b = _index_by_id(findings_b)
+    index_a = _index_by_location(findings_a)
+    index_b = _index_by_location(findings_b)
 
-    ids_a = set(index_a.keys())
-    ids_b = set(index_b.keys())
+    keys_a = set(index_a.keys())
+    keys_b = set(index_b.keys())
 
-    new = [index_b[fid] for fid in sorted(ids_b - ids_a)]
-    removed = [index_a[fid] for fid in sorted(ids_a - ids_b)]
+    new = [index_b[k] for k in sorted(keys_b - keys_a)]
+    removed = [index_a[k] for k in sorted(keys_a - keys_b)]
 
     changed = []
     unchanged = 0
 
-    for fid in sorted(ids_a & ids_b):
-        status_a = _get_status(index_a[fid])
-        status_b = _get_status(index_b[fid])
+    for key in sorted(keys_a & keys_b):
+        status_a = _get_status(index_a[key])
+        status_b = _get_status(index_b[key])
         if status_a != status_b:
             changed.append({
-                "id": fid,
-                "before": index_a[fid],
-                "after": index_b[fid],
+                "label": _finding_label(index_b[key]),
+                "before": index_a[key],
+                "after": index_b[key],
                 "status_before": status_a,
                 "status_after": status_b,
             })

--- a/core/project/findings_utils.py
+++ b/core/project/findings_utils.py
@@ -1,11 +1,12 @@
 """Shared findings utilities for diff and merge.
 
-Centralises finding ID extraction and loading to avoid duplication
-across diff.py and merge.py.
+Centralises finding ID extraction, loading, and semantic grouping
+to avoid duplication across diff.py, merge.py, and coverage.
 """
 
+from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from core.json import load_json
 from core.logging import get_logger
@@ -16,6 +17,43 @@ logger = get_logger()
 def get_finding_id(finding: Dict[str, Any]) -> Optional[str]:
     """Extract finding ID, checking both 'id' and 'finding_id' fields."""
     return finding.get("id") or finding.get("finding_id")
+
+
+def dedup_key(finding: Dict[str, Any]) -> Tuple[str, str, int]:
+    """Dedup key for a finding: (file, function, line). More stable than ID."""
+    return (finding.get("file", ""), finding.get("function", ""), finding.get("line", 0))
+
+
+def group_key(finding: Dict[str, Any]) -> Tuple[str, str, str]:
+    """Semantic group key: (file, function, vuln_type).
+
+    Findings with the same group key are likely the same logical bug
+    (e.g. TOCTOU check at line 7 and use at line 10).
+    """
+    return (
+        finding.get("file", ""),
+        finding.get("function", ""),
+        finding.get("vuln_type", ""),
+    )
+
+
+def group_findings(findings: List[Dict[str, Any]]) -> Dict[Tuple, List[Dict[str, Any]]]:
+    """Group findings by (file, function, vuln_type).
+
+    Returns:
+        Dict mapping group_key -> list of findings in that group.
+        Single-finding groups represent unique vulns.
+        Multi-finding groups represent one logical vuln with multiple locations.
+    """
+    groups: Dict[Tuple, List[Dict[str, Any]]] = defaultdict(list)
+    for f in findings:
+        groups[group_key(f)].append(f)
+    return dict(groups)
+
+
+def count_vulns(findings: List[Dict[str, Any]]) -> int:
+    """Count logical vulns (semantic groups) rather than raw findings."""
+    return len(group_findings(findings))
 
 
 def load_findings_from_dir(run_dir: Path) -> List[Dict[str, Any]]:

--- a/core/project/merge.py
+++ b/core/project/merge.py
@@ -1,17 +1,19 @@
 """Merge findings and SARIF across multiple run directories.
 
 Combines findings.json, SARIF files, and artefacts from multiple runs
-into a single output directory. Deduplicates findings by ID (latest wins).
+into a single output directory. Deduplicates findings by (file, function, line),
+latest wins.
 """
 
 import re
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
-from core.json import load_json, save_json
+from core.json import save_json
 from core.logging import get_logger
-from core.project.findings_utils import get_finding_id as _get_finding_id
+from core.project.findings_utils import count_vulns as _count_vulns
+from core.project.findings_utils import dedup_key as _dedup_key
 from core.project.findings_utils import load_findings_from_dir as _load_findings_from_dir
 from core.sarif.parser import merge_sarif
 
@@ -60,11 +62,43 @@ def _extract_date_from_dir(run_dir: Path) -> str:
 
 def _finding_key(finding: Dict[str, Any]) -> tuple:
     """Dedup key for a finding: (file, function, line). More stable than ID."""
-    return (finding.get("file", ""), finding.get("function", ""), finding.get("line", 0))
+    return _dedup_key(finding)
+
+
+# Status progression: higher rank = more information about the finding.
+# When merging across runs, prefer the finding with the highest-ranked status
+# so that a correct ruling from one run isn't overwritten by stale data from
+# another run (e.g. one that hit a pipeline bug or where the LLM got it wrong).
+_STATUS_RANK = {
+    "exploitable": 7,
+    "confirmed_constrained": 6,
+    "confirmed_blocked": 6,
+    "confirmed_unverified": 5,
+    "confirmed": 5,
+    "ruled_out": 4,
+    "disproven": 4,
+    "false_positive": 4,
+    "test_code": 4,
+    "dead_code": 4,
+    "mitigated": 4,
+    "unreachable": 4,
+    "poc_success": 3,
+    "not_disproven": 2,
+}
+
+
+def _status_rank(finding: Dict[str, Any]) -> int:
+    """Return a rank for how far a finding has progressed through validation."""
+    status = finding.get("final_status") or finding.get("status") or ""
+    return _STATUS_RANK.get(status, 0)
 
 
 def merge_findings(run_dirs: List[Path]) -> List[Dict[str, Any]]:
-    """Merge findings from multiple runs. Deduplicate by (file, function, line), latest wins.
+    """Merge findings from multiple runs. Deduplicate by (file, function, line).
+
+    When the same finding appears in multiple runs, prefer the version with the
+    most progressed status (e.g. "confirmed" beats "not_disproven"). Among equal
+    statuses, the latest run wins.
 
     Args:
         run_dirs: Ordered list of run directories (later entries override earlier).
@@ -78,7 +112,9 @@ def merge_findings(run_dirs: List[Path]) -> List[Dict[str, Any]]:
         findings = _load_findings_from_dir(Path(run_dir))
         for finding in findings:
             key = _finding_key(finding)
-            merged[key] = finding
+            existing = merged.get(key)
+            if existing is None or _status_rank(finding) >= _status_rank(existing):
+                merged[key] = finding
 
     return list(merged.values())
 
@@ -139,7 +175,7 @@ def merge_runs(run_dirs: List[Path], output_dir: Path) -> Dict[str, Any]:
         )
 
     if merged:
-        save_json(output_dir / "findings.json", merged)
+        save_json(output_dir / "findings.json", {"findings": merged})
 
     # --- Merge SARIF ---
     sarif_paths: List[str] = []
@@ -192,16 +228,23 @@ def merge_runs(run_dirs: List[Path], output_dir: Path) -> Dict[str, Any]:
                 shutil.copytree(str(item), str(dest))
                 artefacts_preserved += 1
 
+    vuln_count = _count_vulns(merged)
+
     stats = {
         "runs_merged": len(run_dirs),
         "total_findings": total_findings,
         "unique_findings": len(merged),
+        "unique_vulns": vuln_count,
         "sarif_files_merged": sarif_files_merged,
         "artefacts_preserved": artefacts_preserved,
     }
 
+    findings_label = f"{len(merged)} findings"
+    if vuln_count != len(merged):
+        findings_label = f"{vuln_count} findings"
+
     logger.info(
-        f"Merged {len(run_dirs)} runs: {len(merged)} findings, "
+        f"Merged {len(run_dirs)} runs: {findings_label}, "
         f"{sarif_files_merged} SARIF files, {artefacts_preserved} artefacts"
     )
 

--- a/core/project/report.py
+++ b/core/project/report.py
@@ -20,7 +20,7 @@ def generate_project_report(project) -> Dict[str, Any]:
 
     # Merge findings
     merged = merge_findings(run_dirs)
-    save_json(report_dir / "findings.json", merged)
+    save_json(report_dir / "findings.json", {"findings": merged})
 
     return {
         "findings": len(merged),

--- a/core/project/tests/test_add.py
+++ b/core/project/tests/test_add.py
@@ -14,13 +14,14 @@ class TestAddDirectory(unittest.TestCase):
     def setUp(self):
         self.tmpdir = TemporaryDirectory()
         self.projects_dir = Path(self.tmpdir.name) / "projects"
+        self.output_dir = str(Path(self.tmpdir.name) / "output")
         self.mgr = ProjectManager(projects_dir=self.projects_dir)
 
     def tearDown(self):
         self.tmpdir.cleanup()
 
     def test_add_single_run(self):
-        self.mgr.create("myapp", "/tmp/code")
+        self.mgr.create("myapp", "/tmp/code", output_dir=self.output_dir)
         run_dir = Path(self.tmpdir.name) / "scan-20260406"
         run_dir.mkdir()
         (run_dir / "findings.json").write_text("[]")
@@ -28,7 +29,7 @@ class TestAddDirectory(unittest.TestCase):
         self.assertEqual(added, 1)
 
     def test_add_directory_of_runs(self):
-        self.mgr.create("myapp", "/tmp/code")
+        self.mgr.create("myapp", "/tmp/code", output_dir=self.output_dir)
         runs = Path(self.tmpdir.name) / "runs"
         runs.mkdir()
         for name in ["scan_vulns_20260401", "scan_vulns_20260402", "raptor_vulns_20260403"]:
@@ -57,7 +58,7 @@ class TestAddDirectory(unittest.TestCase):
             self.mgr.add_directory("newproject", str(run_dir))
 
     def test_generates_run_metadata(self):
-        self.mgr.create("myapp", "/tmp/code")
+        self.mgr.create("myapp", "/tmp/code", output_dir=self.output_dir)
         run_dir = Path(self.tmpdir.name) / "scan_vulns_20260406_100000"
         run_dir.mkdir()
         (run_dir / "findings.json").write_text("[]")
@@ -68,7 +69,7 @@ class TestAddDirectory(unittest.TestCase):
         self.assertTrue((moved_dir / RUN_METADATA_FILE).exists())
 
     def test_prefix_inference(self):
-        self.mgr.create("myapp", "/tmp/code")
+        self.mgr.create("myapp", "/tmp/code", output_dir=self.output_dir)
         for name, expected_cmd in [
             ("scan_vulns_20260406", "scan"),
             ("raptor_vulns_20260406", "agentic"),
@@ -97,7 +98,7 @@ class TestAddDirectory(unittest.TestCase):
         self.assertIn("validate", types)
 
     def test_skip_non_run_directories(self):
-        self.mgr.create("myapp", "/tmp/code")
+        self.mgr.create("myapp", "/tmp/code", output_dir=self.output_dir)
         runs = Path(self.tmpdir.name) / "mixed"
         runs.mkdir()
         (runs / "scan_20260406").mkdir()

--- a/core/project/tests/test_diff.py
+++ b/core/project/tests/test_diff.py
@@ -19,55 +19,75 @@ class TestDiffRuns(unittest.TestCase):
 
     def test_new_findings(self):
         with TemporaryDirectory() as d:
-            a = self._make_run(d, "a", [{"id": "F-001", "ruling": {"status": "confirmed"}}])
+            a = self._make_run(d, "a", [
+                {"id": "F-001", "file": "a.c", "function": "main", "line": 10, "ruling": {"status": "confirmed"}},
+            ])
             b = self._make_run(d, "b", [
-                {"id": "F-001", "ruling": {"status": "confirmed"}},
-                {"id": "F-002", "ruling": {"status": "exploitable"}},
+                {"id": "F-001", "file": "a.c", "function": "main", "line": 10, "ruling": {"status": "confirmed"}},
+                {"id": "F-002", "file": "b.c", "function": "foo", "line": 20, "ruling": {"status": "exploitable"}},
             ])
             result = diff_runs(a, b)
             self.assertEqual(len(result["new"]), 1)
-            self.assertEqual(result["new"][0]["id"], "F-002")
+            self.assertEqual(result["new"][0]["file"], "b.c")
 
     def test_removed_findings(self):
         with TemporaryDirectory() as d:
             a = self._make_run(d, "a", [
-                {"id": "F-001", "ruling": {"status": "confirmed"}},
-                {"id": "F-002", "ruling": {"status": "exploitable"}},
+                {"id": "F-001", "file": "a.c", "function": "main", "line": 10, "ruling": {"status": "confirmed"}},
+                {"id": "F-002", "file": "b.c", "function": "foo", "line": 20, "ruling": {"status": "exploitable"}},
             ])
-            b = self._make_run(d, "b", [{"id": "F-001", "ruling": {"status": "confirmed"}}])
+            b = self._make_run(d, "b", [
+                {"id": "F-100", "file": "a.c", "function": "main", "line": 10, "ruling": {"status": "confirmed"}},
+            ])
             result = diff_runs(a, b)
             self.assertEqual(len(result["removed"]), 1)
-            self.assertEqual(result["removed"][0]["id"], "F-002")
+            self.assertEqual(result["removed"][0]["file"], "b.c")
 
     def test_changed_findings(self):
         with TemporaryDirectory() as d:
-            a = self._make_run(d, "a", [{"id": "F-001", "ruling": {"status": "confirmed"}}])
-            b = self._make_run(d, "b", [{"id": "F-001", "ruling": {"status": "exploitable"}}])
+            a = self._make_run(d, "a", [
+                {"id": "F-001", "file": "a.c", "function": "main", "line": 10, "ruling": {"status": "confirmed"}},
+            ])
+            b = self._make_run(d, "b", [
+                {"id": "F-100", "file": "a.c", "function": "main", "line": 10, "ruling": {"status": "exploitable"}},
+            ])
             result = diff_runs(a, b)
             self.assertEqual(len(result["changed"]), 1)
-            self.assertEqual(result["changed"][0]["id"], "F-001")
+            self.assertEqual(result["changed"][0]["label"], "a.c:main:10")
+            self.assertEqual(result["changed"][0]["status_before"], "confirmed")
+            self.assertEqual(result["changed"][0]["status_after"], "exploitable")
+
+    def test_matches_by_location_not_id(self):
+        """Same location with different IDs should match as same finding."""
+        with TemporaryDirectory() as d:
+            a = self._make_run(d, "a", [
+                {"id": "F-001", "file": "a.c", "function": "main", "line": 10, "ruling": {"status": "confirmed"}},
+            ])
+            b = self._make_run(d, "b", [
+                {"id": "F-999", "file": "a.c", "function": "main", "line": 10, "ruling": {"status": "confirmed"}},
+            ])
+            result = diff_runs(a, b)
+            self.assertEqual(result["unchanged"], 1)
+            self.assertEqual(len(result["new"]), 0)
+            self.assertEqual(len(result["removed"]), 0)
 
     def test_unchanged_count(self):
         with TemporaryDirectory() as d:
-            findings = [
-                {"id": "F-001", "ruling": {"status": "confirmed"}},
-                {"id": "F-002", "ruling": {"status": "exploitable"}},
+            findings_a = [
+                {"id": "F-001", "file": "a.c", "function": "main", "line": 10, "ruling": {"status": "confirmed"}},
+                {"id": "F-002", "file": "b.c", "function": "foo", "line": 20, "ruling": {"status": "exploitable"}},
             ]
-            a = self._make_run(d, "a", findings)
-            b = self._make_run(d, "b", findings)
+            findings_b = [
+                {"id": "F-100", "file": "a.c", "function": "main", "line": 10, "ruling": {"status": "confirmed"}},
+                {"id": "F-200", "file": "b.c", "function": "foo", "line": 20, "ruling": {"status": "exploitable"}},
+            ]
+            a = self._make_run(d, "a", findings_a)
+            b = self._make_run(d, "b", findings_b)
             result = diff_runs(a, b)
             self.assertEqual(result["unchanged"], 2)
             self.assertEqual(len(result["new"]), 0)
             self.assertEqual(len(result["removed"]), 0)
             self.assertEqual(len(result["changed"]), 0)
-
-    def test_finding_id_field(self):
-        """Agentic findings use finding_id instead of id."""
-        with TemporaryDirectory() as d:
-            a = self._make_run(d, "a", [{"finding_id": "SARIF-001", "is_exploitable": True}])
-            b = self._make_run(d, "b", [{"finding_id": "SARIF-001", "is_exploitable": False}])
-            result = diff_runs(a, b)
-            self.assertEqual(len(result["changed"]), 1)
 
     def test_empty_runs(self):
         with TemporaryDirectory() as d:
@@ -81,7 +101,7 @@ class TestDiffRuns(unittest.TestCase):
         with TemporaryDirectory() as d:
             a = Path(d) / "a"
             a.mkdir()
-            b = self._make_run(d, "b", [{"id": "F-001"}])
+            b = self._make_run(d, "b", [{"id": "F-001", "file": "a.c", "function": "main", "line": 10}])
             result = diff_runs(a, b)
             self.assertEqual(len(result["new"]), 1)
 
@@ -91,13 +111,29 @@ class TestDiffRuns(unittest.TestCase):
             a = Path(d) / "a"
             a.mkdir()
             (a / "findings.json").write_text(json.dumps({
-                "stage": "D", "findings": [{"id": "F-001", "ruling": {"status": "confirmed"}}]
+                "stage": "D", "findings": [
+                    {"id": "F-001", "file": "a.c", "function": "main", "line": 10, "ruling": {"status": "confirmed"}}
+                ]
             }))
             b = Path(d) / "b"
             b.mkdir()
             (b / "findings.json").write_text(json.dumps({
-                "stage": "D", "findings": [{"id": "F-001", "ruling": {"status": "exploitable"}}]
+                "stage": "D", "findings": [
+                    {"id": "F-100", "file": "a.c", "function": "main", "line": 10, "ruling": {"status": "exploitable"}}
+                ]
             }))
+            result = diff_runs(a, b)
+            self.assertEqual(len(result["changed"]), 1)
+
+    def test_agentic_format(self):
+        """Agentic findings use is_exploitable boolean."""
+        with TemporaryDirectory() as d:
+            a = self._make_run(d, "a", [
+                {"finding_id": "SARIF-001", "file": "a.c", "function": "main", "line": 5, "is_exploitable": True},
+            ])
+            b = self._make_run(d, "b", [
+                {"finding_id": "SARIF-002", "file": "a.c", "function": "main", "line": 5, "is_exploitable": False},
+            ])
             result = diff_runs(a, b)
             self.assertEqual(len(result["changed"]), 1)
 

--- a/core/project/tests/test_findings_utils.py
+++ b/core/project/tests/test_findings_utils.py
@@ -1,0 +1,106 @@
+"""Tests for findings_utils — dedup keys, semantic grouping, bug counting."""
+
+import unittest
+
+from core.project.findings_utils import count_vulns, dedup_key, group_findings, group_key
+
+
+class TestDedupKey(unittest.TestCase):
+
+    def test_basic(self):
+        f = {"file": "a.c", "function": "main", "line": 10}
+        self.assertEqual(dedup_key(f), ("a.c", "main", 10))
+
+    def test_missing_fields(self):
+        self.assertEqual(dedup_key({}), ("", "", 0))
+
+
+class TestGroupKey(unittest.TestCase):
+
+    def test_basic(self):
+        f = {"file": "a.c", "function": "main", "vuln_type": "buffer_overflow"}
+        self.assertEqual(group_key(f), ("a.c", "main", "buffer_overflow"))
+
+    def test_missing_vuln_type(self):
+        f = {"file": "a.c", "function": "main", "line": 10}
+        self.assertEqual(group_key(f), ("a.c", "main", ""))
+
+
+class TestGroupFindings(unittest.TestCase):
+
+    def test_toctou_grouped(self):
+        """Two TOCTOU findings at different lines in same function = 1 group."""
+        findings = [
+            {"file": "10_toctou.c", "function": "main", "line": 7, "vuln_type": "race_condition"},
+            {"file": "10_toctou.c", "function": "main", "line": 10, "vuln_type": "race_condition"},
+        ]
+        groups = group_findings(findings)
+        self.assertEqual(len(groups), 1)
+        key = ("10_toctou.c", "main", "race_condition")
+        self.assertEqual(len(groups[key]), 2)
+
+    def test_different_vuln_types_separate(self):
+        """Different vuln_types in same function = separate groups."""
+        findings = [
+            {"file": "a.c", "function": "main", "line": 5, "vuln_type": "buffer_overflow"},
+            {"file": "a.c", "function": "main", "line": 10, "vuln_type": "format_string"},
+        ]
+        groups = group_findings(findings)
+        self.assertEqual(len(groups), 2)
+
+    def test_different_functions_separate(self):
+        findings = [
+            {"file": "a.c", "function": "foo", "line": 5, "vuln_type": "buffer_overflow"},
+            {"file": "a.c", "function": "bar", "line": 10, "vuln_type": "buffer_overflow"},
+        ]
+        groups = group_findings(findings)
+        self.assertEqual(len(groups), 2)
+
+    def test_unique_findings_one_per_group(self):
+        findings = [
+            {"file": "a.c", "function": "main", "line": 5, "vuln_type": "buffer_overflow"},
+            {"file": "b.c", "function": "foo", "line": 10, "vuln_type": "format_string"},
+        ]
+        groups = group_findings(findings)
+        self.assertEqual(len(groups), 2)
+        for group in groups.values():
+            self.assertEqual(len(group), 1)
+
+    def test_empty(self):
+        self.assertEqual(group_findings([]), {})
+
+
+class TestCountVulns(unittest.TestCase):
+
+    def test_no_grouping_needed(self):
+        findings = [
+            {"file": "a.c", "function": "main", "line": 5, "vuln_type": "buffer_overflow"},
+            {"file": "b.c", "function": "foo", "line": 10, "vuln_type": "format_string"},
+        ]
+        self.assertEqual(count_vulns(findings), 2)
+
+    def test_toctou_counts_as_one(self):
+        findings = [
+            {"file": "10_toctou.c", "function": "main", "line": 7, "vuln_type": "race_condition"},
+            {"file": "10_toctou.c", "function": "main", "line": 10, "vuln_type": "race_condition"},
+        ]
+        self.assertEqual(count_vulns(findings), 1)
+
+    def test_mixed(self):
+        """10 unique vulns + 1 TOCTOU (2 findings) = 10 vulns from 11 findings."""
+        findings = [
+            {"file": f"{i:02d}.c", "function": "main", "line": 5, "vuln_type": f"type_{i}"}
+            for i in range(9)
+        ] + [
+            {"file": "10_toctou.c", "function": "main", "line": 7, "vuln_type": "race_condition"},
+            {"file": "10_toctou.c", "function": "main", "line": 10, "vuln_type": "race_condition"},
+        ]
+        self.assertEqual(len(findings), 11)
+        self.assertEqual(count_vulns(findings), 10)
+
+    def test_empty(self):
+        self.assertEqual(count_vulns([]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core/project/tests/test_merge.py
+++ b/core/project/tests/test_merge.py
@@ -77,6 +77,82 @@ class TestMergeFindings(unittest.TestCase):
             self.assertEqual(len(merged), 2)
 
 
+    def test_higher_status_wins_over_later_run(self):
+        """A confirmed finding from an older run beats not_disproven from a newer run."""
+        with TemporaryDirectory() as d:
+            old = self._make_run(d, "old", [
+                {"id": "F-001", "file": "a.c", "function": "main", "line": 10,
+                 "status": "confirmed", "final_status": "confirmed"},
+            ])
+            new = self._make_run(d, "new", [
+                {"id": "F-001", "file": "a.c", "function": "main", "line": 10,
+                 "status": "not_disproven"},
+            ])
+            merged = merge_findings([old, new])
+            self.assertEqual(len(merged), 1)
+            self.assertEqual(merged[0]["final_status"], "confirmed")
+
+    def test_equal_status_latest_wins(self):
+        """Same status rank — later run's finding is used."""
+        with TemporaryDirectory() as d:
+            old = self._make_run(d, "old", [
+                {"id": "F-001", "file": "a.c", "function": "main", "line": 10,
+                 "status": "confirmed", "detail": "from_old"},
+            ])
+            new = self._make_run(d, "new", [
+                {"id": "F-001", "file": "a.c", "function": "main", "line": 10,
+                 "status": "confirmed", "detail": "from_new"},
+            ])
+            merged = merge_findings([old, new])
+            self.assertEqual(len(merged), 1)
+            self.assertEqual(merged[0]["detail"], "from_new")
+
+    def test_findings_without_status_rank_zero(self):
+        """Findings with no status (e.g. from scan/codeql) don't override validated findings."""
+        with TemporaryDirectory() as d:
+            validated = self._make_run(d, "validated", [
+                {"id": "F-001", "file": "a.c", "function": "main", "line": 10,
+                 "status": "confirmed", "final_status": "confirmed"},
+            ])
+            scan = self._make_run(d, "scan", [
+                {"id": "SARIF-001", "file": "a.c", "function": "main", "line": 10,
+                 "description": "scan finding with no status"},
+            ])
+            merged = merge_findings([validated, scan])
+            self.assertEqual(len(merged), 1)
+            self.assertEqual(merged[0]["final_status"], "confirmed")
+
+    def test_exploitable_beats_confirmed(self):
+        """Exploitable (rank 7) beats confirmed (rank 5)."""
+        with TemporaryDirectory() as d:
+            a = self._make_run(d, "a", [
+                {"id": "F-001", "file": "a.c", "function": "main", "line": 10,
+                 "final_status": "exploitable"},
+            ])
+            b = self._make_run(d, "b", [
+                {"id": "F-001", "file": "a.c", "function": "main", "line": 10,
+                 "final_status": "confirmed"},
+            ])
+            merged = merge_findings([a, b])
+            self.assertEqual(len(merged), 1)
+            self.assertEqual(merged[0]["final_status"], "exploitable")
+
+    def test_ruled_out_beats_not_disproven(self):
+        """ruled_out (rank 4) beats not_disproven (rank 2)."""
+        with TemporaryDirectory() as d:
+            a = self._make_run(d, "a", [
+                {"id": "F-001", "file": "a.c", "function": "main", "line": 10,
+                 "final_status": "ruled_out"},
+            ])
+            b = self._make_run(d, "b", [
+                {"id": "F-001", "file": "a.c", "function": "main", "line": 10,
+                 "status": "not_disproven"},
+            ])
+            merged = merge_findings([a, b])
+            self.assertEqual(len(merged), 1)
+            self.assertEqual(merged[0]["final_status"], "ruled_out")
+
+
 class TestVerifyMerge(unittest.TestCase):
 
     def test_valid_merge(self):

--- a/core/project/tests/test_report.py
+++ b/core/project/tests/test_report.py
@@ -25,11 +25,17 @@ class TestProjectReport(unittest.TestCase):
     def test_merged_findings(self):
         with TemporaryDirectory() as d:
             p = self._make_project(d, {
-                "scan-20260401": [{"id": "F-001"}, {"id": "F-002"}],
-                "scan-20260402": [{"id": "F-002"}, {"id": "F-003"}],
+                "scan-20260401": [
+                    {"id": "F-001", "file": "a.c", "function": "main", "line": 10},
+                    {"id": "F-002", "file": "b.c", "function": "foo", "line": 20},
+                ],
+                "scan-20260402": [
+                    {"id": "F-002", "file": "b.c", "function": "foo", "line": 20},
+                    {"id": "F-003", "file": "c.c", "function": "bar", "line": 30},
+                ],
             })
             stats = generate_project_report(p)
-            self.assertEqual(stats["findings"], 3)  # F-001, F-002, F-003
+            self.assertEqual(stats["findings"], 3)  # a.c, b.c, c.c
             self.assertEqual(stats["runs"], 2)
 
     def test_report_dir_created(self):

--- a/core/reporting/findings.py
+++ b/core/reporting/findings.py
@@ -4,7 +4,7 @@ Translates vulnerability findings into ReportSpec for rendering.
 Used by both /validate and /agentic pipelines.
 """
 
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from .formatting import get_display_status, title_case_type, truncate_path
 from .spec import ReportSpec, ReportSection
@@ -87,7 +87,7 @@ def build_findings_summary(findings: List[Dict[str, Any]]) -> Dict[str, int]:
     return counts
 
 
-def findings_summary_line(counts: Dict[str, int]) -> str:
+def findings_summary_line(counts: Dict[str, int], vuln_count: Optional[int] = None) -> str:
     """Build the one-line status summary from counts."""
     parts = []
     if counts["exploitable"]:
@@ -102,9 +102,14 @@ def findings_summary_line(counts: Dict[str, int]) -> str:
         parts.append(f"{counts['error']} Error")
     if counts.get("other"):
         parts.append(f"{counts['other']} Uncategorised")
+    total = counts['total']
+    if vuln_count is not None and vuln_count != total:
+        label = f"{vuln_count} findings"
+    else:
+        label = f"{total} findings"
     if not parts:
-        return f"0 out of {counts['total']} findings categorised."
-    return f"**{', '.join(parts)}** out of {counts['total']} findings."
+        return f"0 out of {label} categorised."
+    return f"**{', '.join(parts)}** out of {label}."
 
 
 def build_finding_detail(finding: Dict[str, Any], index: int) -> ReportSection:
@@ -253,12 +258,18 @@ def findings_summary(findings: List[Dict[str, Any]]) -> str:
     rows = _markdown_rows(build_findings_rows(findings))
     counts = build_findings_summary(findings)
 
+    try:
+        from core.project.findings_utils import count_vulns
+        vuln_count = count_vulns(findings)
+    except Exception:
+        vuln_count = None
+
     lines = []
     lines.append("| " + " | ".join(FINDINGS_COLUMNS) + " |")
     lines.append("|" + "|".join("---" for _ in FINDINGS_COLUMNS) + "|")
     for row in rows:
         lines.append("| " + " | ".join(str(c) for c in row) + " |")
     lines.append("")
-    lines.append(findings_summary_line(counts))
+    lines.append(findings_summary_line(counts, vuln_count))
 
     return "\n".join(lines)

--- a/core/reporting/formatting.py
+++ b/core/reporting/formatting.py
@@ -44,6 +44,8 @@ def get_display_status(finding: Dict[str, Any]) -> str:
         "confirmed_blocked": "Confirmed (Blocked)",
         "ruled_out": "Ruled Out",
         "false_positive": "False Positive",
+        "poc_success": "Exploitable",
+        "not_disproven": "Unconfirmed",
         "disproven": "Ruled Out",
         "validated": "Confirmed",
         "test_code": "Ruled Out",

--- a/core/sarif/parser.py
+++ b/core/sarif/parser.py
@@ -109,26 +109,60 @@ def deduplicate_findings(findings: List[Dict[str, Any]]) -> List[Dict[str, Any]]
     return unique
 
 
+def _result_key(result: Dict[str, Any]) -> Tuple[str, str, int]:
+    """Dedup key for a SARIF result: (ruleId, uri, startLine)."""
+    rule_id = result.get("ruleId", "")
+    locs = result.get("locations", [{}])
+    phys = locs[0].get("physicalLocation", {}) if locs else {}
+    uri = phys.get("artifactLocation", {}).get("uri", "")
+    line = phys.get("region", {}).get("startLine", 0)
+    return (rule_id, uri, line)
+
+
 def merge_sarif(sarif_paths: List[str]) -> Dict[str, Any]:
     """
-    Merge multiple SARIF files into a single SARIF dict with combined runs.
+    Merge multiple SARIF files into a single SARIF dict.
+
+    Groups runs by tool name, deduplicates results within each tool by
+    (ruleId, uri, startLine). Latest occurrence wins on collision.
 
     Args:
         sarif_paths: List of paths to SARIF files
 
     Returns:
-        Merged SARIF dict with all runs combined
+        Merged SARIF dict with deduplicated results per tool
     """
-    merged: Dict[str, Any] = {
-        "version": "2.1.0",
-        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
-        "runs": [],
-    }
+    # Group runs by tool name so same-tool runs get their results merged
+    tool_runs: Dict[str, Dict[str, Any]] = {}  # tool_name -> merged run
+
     for sarif_path in sarif_paths:
         sarif_data = load_sarif(Path(sarif_path))
-        if sarif_data:
-            merged["runs"].extend(sarif_data.get("runs", []))
-    return merged
+        if not sarif_data:
+            continue
+        for run in sarif_data.get("runs", []):
+            tool_name = run.get("tool", {}).get("driver", {}).get("name", "unknown")
+            if tool_name not in tool_runs:
+                tool_runs[tool_name] = {
+                    "tool": run.get("tool", {}),
+                    "results": {},  # keyed by _result_key for dedup
+                }
+            for result in run.get("results", []):
+                key = _result_key(result)
+                tool_runs[tool_name]["results"][key] = result
+
+    # Build final SARIF with one run per tool
+    merged_runs = []
+    for tool_name, run_data in tool_runs.items():
+        merged_runs.append({
+            "tool": run_data["tool"],
+            "results": list(run_data["results"].values()),
+        })
+
+    return {
+        "version": "2.1.0",
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "runs": merged_runs,
+    }
 
 
 def _extract_cwe_from_rule(rule: Dict[str, Any]) -> Optional[str]:

--- a/core/sarif/tests/test_sarif_parser.py
+++ b/core/sarif/tests/test_sarif_parser.py
@@ -127,24 +127,39 @@ class TestLoadSarif(unittest.TestCase):
 class TestMergeSarif(unittest.TestCase):
     """Test merge_sarif — combines multiple SARIF files."""
 
-    def test_merges_runs(self):
+    def test_merges_different_tools(self):
         from core.sarif.parser import merge_sarif
 
         with tempfile.TemporaryDirectory() as tmpdir:
             p1 = Path(tmpdir) / "a.sarif"
             p2 = Path(tmpdir) / "b.sarif"
-            p1.write_text(json.dumps({"runs": [{"results": [{"ruleId": "r1"}]}]}))
-            p2.write_text(json.dumps({"runs": [{"results": [{"ruleId": "r2"}]}]}))
+            p1.write_text(json.dumps({"runs": [{"tool": {"driver": {"name": "ToolA"}}, "results": [{"ruleId": "r1"}]}]}))
+            p2.write_text(json.dumps({"runs": [{"tool": {"driver": {"name": "ToolB"}}, "results": [{"ruleId": "r2"}]}]}))
 
             merged = merge_sarif([str(p1), str(p2)])
             self.assertEqual(len(merged["runs"]), 2)
+
+    def test_dedup_same_tool(self):
+        from core.sarif.parser import merge_sarif
+
+        result = {"ruleId": "r1", "locations": [{"physicalLocation": {
+            "artifactLocation": {"uri": "a.c"}, "region": {"startLine": 10}}}]}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p1 = Path(tmpdir) / "a.sarif"
+            p2 = Path(tmpdir) / "b.sarif"
+            p1.write_text(json.dumps({"runs": [{"tool": {"driver": {"name": "Semgrep"}}, "results": [result]}]}))
+            p2.write_text(json.dumps({"runs": [{"tool": {"driver": {"name": "Semgrep"}}, "results": [result]}]}))
+
+            merged = merge_sarif([str(p1), str(p2)])
+            self.assertEqual(len(merged["runs"]), 1)
+            self.assertEqual(len(merged["runs"][0]["results"]), 1)
 
     def test_skips_invalid_files(self):
         from core.sarif.parser import merge_sarif
 
         with tempfile.TemporaryDirectory() as tmpdir:
             good = Path(tmpdir) / "good.sarif"
-            good.write_text(json.dumps({"runs": [{"results": []}]}))
+            good.write_text(json.dumps({"runs": [{"tool": {"driver": {"name": "T"}}, "results": []}]}))
 
             merged = merge_sarif([str(good), "/nonexistent.sarif"])
             self.assertEqual(len(merged["runs"]), 1)

--- a/core/tests/test_understand_bridge.py
+++ b/core/tests/test_understand_bridge.py
@@ -18,7 +18,7 @@ from core.understand_bridge import (
     enrich_checklist,
     TRACE_SOURCE_LABEL,
     _extract_hashes,
-    _count_stale_on_disk,
+    _find_stale_files,
     _rank_candidates,
 )
 
@@ -177,8 +177,9 @@ class TestFindUnderstandOutput:
         validate_dir.mkdir()
         _write_json(validate_dir / "context-map.json", {"sources": []})
 
-        result = find_understand_output(validate_dir)
-        assert result == validate_dir
+        result_dir, stale = find_understand_output(validate_dir)
+        assert result_dir == validate_dir
+        assert stale == set()
 
     def test_tier2_project_sibling(self, tmp_path):
         """Tier 2: understand run as sibling in same project dir."""
@@ -188,8 +189,8 @@ class TestFindUnderstandOutput:
 
         _make_understand_dir(project_dir)
 
-        result = find_understand_output(validate_dir)
-        assert result == project_dir / "understand-20260401-120000"
+        result_dir, stale = find_understand_output(validate_dir)
+        assert result_dir == project_dir / "understand-20260401-120000"
 
     def test_tier2_picks_newest_sibling(self, tmp_path):
         project_dir = tmp_path / "project"
@@ -200,8 +201,8 @@ class TestFindUnderstandOutput:
         time.sleep(0.01)
         new = _make_understand_dir(project_dir, "understand-20260402-120000")
 
-        result = find_understand_output(validate_dir)
-        assert result == new
+        result_dir, stale = find_understand_output(validate_dir)
+        assert result_dir == new
 
     def test_tier3_global_out_by_target_path(self, tmp_path, monkeypatch):
         """Tier 3: scan out/ matching by checklist target_path."""
@@ -221,8 +222,8 @@ class TestFindUnderstandOutput:
         validate_dir = tmp_path / "validate-run"
         validate_dir.mkdir()
 
-        result = find_understand_output(validate_dir, target_path="/tmp/vulns")
-        assert result == out_root / "understand_20260401_120000"
+        result_dir, stale = find_understand_output(validate_dir, target_path="/tmp/vulns")
+        assert result_dir == out_root / "understand_20260401_120000"
 
     def test_tier3_no_match_for_wrong_target(self, tmp_path, monkeypatch):
         out_root = tmp_path / "out"
@@ -239,8 +240,8 @@ class TestFindUnderstandOutput:
         validate_dir = tmp_path / "validate-run"
         validate_dir.mkdir()
 
-        result = find_understand_output(validate_dir, target_path="/tmp/other")
-        assert result is None
+        result_dir, stale = find_understand_output(validate_dir, target_path="/tmp/other")
+        assert result_dir is None
 
     def test_returns_none_when_no_candidates(self, tmp_path, monkeypatch):
         out_root = tmp_path / "empty-out"
@@ -251,8 +252,8 @@ class TestFindUnderstandOutput:
         validate_dir = tmp_path / "validate-run"
         validate_dir.mkdir()
 
-        result = find_understand_output(validate_dir, target_path="/tmp/vulns")
-        assert result is None
+        result_dir, stale = find_understand_output(validate_dir, target_path="/tmp/vulns")
+        assert result_dir is None
 
     def test_ignores_dirs_without_context_map(self, tmp_path):
         project_dir = tmp_path / "project"
@@ -264,7 +265,8 @@ class TestFindUnderstandOutput:
         empty.mkdir()
         _write_json(empty / ".raptor-run.json", {"version": 1, "command": "understand"})
 
-        assert find_understand_output(validate_dir) is None
+        result_dir, stale = find_understand_output(validate_dir)
+        assert result_dir is None
 
     def test_ignores_non_understand_dirs(self, tmp_path):
         project_dir = tmp_path / "project"
@@ -276,7 +278,8 @@ class TestFindUnderstandOutput:
         _write_json(scan / "context-map.json", {"sources": []})
         _write_json(scan / ".raptor-run.json", {"version": 1, "command": "scan"})
 
-        assert find_understand_output(validate_dir) is None
+        result_dir, stale = find_understand_output(validate_dir)
+        assert result_dir is None
 
 
 # ---------------------------------------------------------------------------
@@ -288,8 +291,8 @@ class TestHashFreshness:
         hashes = _extract_hashes(MINIMAL_CHECKLIST)
         assert hashes == {"src/routes/query.py": "aaa", "src/db/query.py": "bbb"}
 
-    def test_count_stale_zero_when_matching(self, tmp_path):
-        """On-disk files matching understand hashes → 0 stale."""
+    def test_stale_empty_when_matching(self, tmp_path):
+        """On-disk files matching understand hashes → no stale files."""
         import hashlib
         target = tmp_path / "target"
         target.mkdir()
@@ -299,10 +302,10 @@ class TestHashFreshness:
             "a.py": hashlib.sha256(b"aaa").hexdigest(),
             "b.py": hashlib.sha256(b"bbb").hexdigest(),
         }
-        assert _count_stale_on_disk(h1, str(target)) == 0
+        assert _find_stale_files(h1, str(target)) == set()
 
-    def test_count_stale_detects_changed_files(self, tmp_path):
-        """On-disk file differs from understand hash → 1 stale."""
+    def test_stale_detects_changed_files(self, tmp_path):
+        """On-disk file differs from understand hash → returned in stale set."""
         import hashlib
         target = tmp_path / "target"
         target.mkdir()
@@ -312,10 +315,10 @@ class TestHashFreshness:
             "a.py": hashlib.sha256(b"aaa").hexdigest(),
             "b.py": hashlib.sha256(b"bbb").hexdigest(),  # original content
         }
-        assert _count_stale_on_disk(h1, str(target)) == 1
+        assert _find_stale_files(h1, str(target)) == {"b.py"}
 
-    def test_count_stale_deleted_file_is_stale(self, tmp_path):
-        """File in understand checklist but deleted from disk → stale."""
+    def test_stale_deleted_file_is_stale(self, tmp_path):
+        """File in understand checklist but deleted from disk → in stale set."""
         import hashlib
         target = tmp_path / "target"
         target.mkdir()
@@ -324,7 +327,7 @@ class TestHashFreshness:
             "a.py": hashlib.sha256(b"aaa").hexdigest(),
             "gone.py": hashlib.sha256(b"xyz").hexdigest(),
         }
-        assert _count_stale_on_disk(h1, str(target)) == 1
+        assert _find_stale_files(h1, str(target)) == {"gone.py"}
 
     def test_rank_prefers_fresh_over_newest(self, tmp_path):
         """A fresh older candidate beats a stale newer one."""
@@ -348,8 +351,26 @@ class TestHashFreshness:
             "files": [{"path": "a.py", "sha256": "STALE"}],
         })
 
-        result = _rank_candidates([new_dir, old_dir], str(target))
-        assert result == old_dir
+        best_dir, stale = _rank_candidates([new_dir, old_dir], str(target))
+        assert best_dir == old_dir
+        assert stale == set()
+
+    def test_rank_returns_stale_set(self, tmp_path):
+        """When best candidate has stale files, they are returned."""
+        import hashlib
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "a.py").write_text("current")
+
+        d1 = tmp_path / "d1"
+        d1.mkdir()
+        _write_json(d1 / "checklist.json", {
+            "files": [{"path": "a.py", "sha256": "STALE"}],
+        })
+
+        best_dir, stale = _rank_candidates([d1], str(target))
+        assert best_dir == d1
+        assert stale == {"a.py"}
 
     def test_rank_falls_back_to_newest_when_all_fresh(self, tmp_path):
         import hashlib
@@ -369,8 +390,9 @@ class TestHashFreshness:
                 "files": [{"path": "a.py", "sha256": disk_hash}],
             })
 
-        result = _rank_candidates([d1, d2], str(target))
-        assert result == d2  # newer
+        best_dir, stale = _rank_candidates([d1, d2], str(target))
+        assert best_dir == d2  # newer
+        assert stale == set()
 
     def test_rank_without_target_picks_newest(self, tmp_path):
         d1 = tmp_path / "d1"
@@ -379,8 +401,9 @@ class TestHashFreshness:
         time.sleep(0.01)
         d2.mkdir()
 
-        result = _rank_candidates([d1, d2], target_path=None)
-        assert result == d2
+        best_dir, stale = _rank_candidates([d1, d2], target_path=None)
+        assert best_dir == d2
+        assert stale == set()
 
     def test_rank_empty_candidates(self):
         assert _rank_candidates([], None) is None
@@ -666,10 +689,10 @@ class TestEdgeCases:
         monkeypatch.setattr("core.config.RaptorConfig.get_out_dir",
                             staticmethod(lambda: project_dir))
 
-        result = find_understand_output(
+        result_dir, stale = find_understand_output(
             validate_dir, target_path=str(target_dir),
         )
-        assert result == understand
+        assert result_dir == understand
 
     def test_staleness_warning_logged(self, tmp_path):
         """When best candidate has stale files, _rank_candidates logs a warning."""
@@ -684,9 +707,10 @@ class TestEdgeCases:
         })
 
         with unittest.mock.patch("core.understand_bridge.logger") as mock_logger:
-            result = _rank_candidates([stale_dir], str(target))
+            best_dir, stale = _rank_candidates([stale_dir], str(target))
 
-        assert result == stale_dir
+        assert best_dir == stale_dir
+        assert stale == {"a.py"}
         mock_logger.warning.assert_called_once()
         assert "stale" in mock_logger.warning.call_args[0][0].lower()
 
@@ -702,8 +726,9 @@ class TestEdgeCases:
         # Tier 2: sibling that's newer
         _make_understand_dir(project_dir, "understand-20260403-120000")
 
-        result = find_understand_output(validate_dir)
-        assert result == validate_dir  # tier 1 wins
+        result_dir, stale = find_understand_output(validate_dir)
+        assert result_dir == validate_dir  # tier 1 wins
+        assert stale == set()
 
     def test_candidate_without_checklist_ranked_lowest(self, tmp_path):
         """Candidate missing checklist.json treated as stale."""
@@ -726,10 +751,10 @@ class TestEdgeCases:
         })
 
         # d_no_checklist is newer by mtime but has no checklist → stale_count=1
-        result = _rank_candidates(
+        best_dir, stale = _rank_candidates(
             [d_no_checklist, d_with_checklist], str(target),
         )
-        assert result == d_with_checklist
+        assert best_dir == d_with_checklist
 
 
 # ---------------------------------------------------------------------------

--- a/core/understand_bridge.py
+++ b/core/understand_bridge.py
@@ -20,9 +20,9 @@ Usage (from Stage 0 in /validate):
 
     from core.understand_bridge import find_understand_output, load_understand_context, enrich_checklist
 
-    understand_dir = find_understand_output(validate_dir, target_path=target)
+    understand_dir, stale_files = find_understand_output(validate_dir, target_path=target)
     if understand_dir:
-        bridge = load_understand_context(understand_dir, validate_dir)
+        bridge = load_understand_context(understand_dir, validate_dir, stale_files)
         if bridge["context_map_loaded"]:
             enrich_checklist(checklist, bridge["context_map"], str(validate_dir))
 
@@ -35,7 +35,7 @@ The three-tier search in find_understand_output() covers:
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from core.json import load_json, save_json
 
@@ -54,7 +54,7 @@ TRACE_SOURCE_LABEL = "understand:trace"
 def find_understand_output(
     validate_dir: Path,
     target_path: str = None,
-) -> Optional[Path]:
+) -> Tuple[Optional[Path], Set[str]]:
     """Find the best /understand output for a validate run.
 
     Three-tier search eliminates the need for --out alignment:
@@ -78,26 +78,36 @@ def find_understand_output(
             global out/ search, and on-disk hash freshness checks).
 
     Returns:
-        Path to the understand output directory, or None.
-        When tier 1 matches, returns validate_dir itself.
+        (path, stale_files) — path to the understand output directory and
+        set of relative file paths whose hashes no longer match disk.
+        Returns (None, set()) when no understand output is found.
+        When tier 1 matches, returns (validate_dir, empty set) since
+        co-located data is assumed fresh.
     """
     validate_dir = Path(validate_dir)
+    empty: Set[str] = set()
 
-    # Tier 1: context-map.json co-located (shared --out directory)
+    # Tier 1: context-map.json co-located (shared --out directory).
+    # Staleness can't be checked here — the validate rebuild overwrites
+    # the understand checklist before the bridge runs.  The caller
+    # (validation helper) snapshots the pre-rebuild checklist and handles
+    # tier 1 staleness separately.
     if (validate_dir / "context-map.json").exists():
         logger.debug("understand output: tier 1 (local) — %s", validate_dir)
-        return validate_dir
+        return validate_dir, empty
 
     # Collect candidates from tiers 2 and 3
     candidates = _collect_candidates(validate_dir, target_path)
     if not candidates:
-        return None
+        return None, empty
 
     # Rank: fresh hashes beat stale, then newest wins
-    best = _rank_candidates(candidates, target_path)
-    if best:
-        logger.debug("understand output: selected %s", best)
-    return best
+    result = _rank_candidates(candidates, target_path)
+    if result is None:
+        return None, empty
+    best_dir, stale_files = result
+    logger.debug("understand output: selected %s", best_dir)
+    return best_dir, stale_files
 
 
 def _collect_candidates(
@@ -133,7 +143,7 @@ def _collect_candidates(
 def _rank_candidates(
     candidates: List[Path],
     target_path: str = None,
-) -> Optional[Path]:
+) -> Optional[Tuple[Path, Set[str]]]:
     """Pick the best candidate: fresh hashes > stale, then newest first.
 
     Freshness is checked by hashing the current files on disk under
@@ -142,7 +152,7 @@ def _rank_candidates(
     share a single file and the validate rebuild overwrites understand
     hashes.
 
-    Returns None if candidates is empty.
+    Returns (path, stale_files) or None if candidates is empty.
     """
     if not candidates:
         return None
@@ -150,32 +160,33 @@ def _rank_candidates(
     if not target_path:
         # No target — can't hash on disk, just pick newest
         candidates.sort(key=lambda d: d.stat().st_mtime, reverse=True)
-        return candidates[0]
+        return candidates[0], set()
 
     scored = []
     for d in candidates:
         u_checklist = load_json(d / "checklist.json")
         if not u_checklist:
-            # No checklist — treat as stale (can't verify)
-            scored.append((1, d.stat().st_mtime, d))
+            # No checklist — treat as fully stale (can't verify any file)
+            scored.append((1, d.stat().st_mtime, d, set()))
             continue
         u_hashes = _extract_hashes(u_checklist)
-        stale_count = _count_stale_on_disk(u_hashes, target_path)
+        stale = _find_stale_files(u_hashes, target_path)
         # fresh = 0 stale files → sort key 0 (best)
-        scored.append((stale_count, d.stat().st_mtime, d))
+        scored.append((len(stale), d.stat().st_mtime, d, stale))
 
     # Sort: fewest stale first, then newest mtime first (negate for descending)
     scored.sort(key=lambda t: (t[0], -t[1]))
-    best_stale, _, best_dir = scored[0]
+    best_stale_count, _, best_dir, best_stale_files = scored[0]
 
-    if best_stale > 0:
+    if best_stale_count > 0:
         logger.warning(
             "understand_bridge: best candidate %s has %d stale file(s)"
-            " — importing anyway, Stage C will catch stale refs",
-            best_dir.name, best_stale,
+            " — data for these files will be excluded: %s",
+            best_dir.name, best_stale_count,
+            ", ".join(sorted(best_stale_files)),
         )
 
-    return best_dir
+    return best_dir, best_stale_files
 
 
 def _extract_hashes(checklist: Dict[str, Any]) -> Dict[str, str]:
@@ -187,11 +198,11 @@ def _extract_hashes(checklist: Dict[str, Any]) -> Dict[str, str]:
     }
 
 
-def _count_stale_on_disk(
+def _find_stale_files(
     understand_hashes: Dict[str, str],
     target_path: str,
-) -> int:
-    """Count files whose on-disk SHA-256 differs from the understand checklist.
+) -> Set[str]:
+    """Return relative paths whose on-disk SHA-256 differs from the understand checklist.
 
     Hashes the actual files under target_path rather than comparing against
     another checklist. This is immune to the project-mode symlink problem
@@ -200,16 +211,16 @@ def _count_stale_on_disk(
     import hashlib
 
     target = Path(target_path)
-    stale = 0
+    stale: Set[str] = set()
     for rel_path, u_hash in understand_hashes.items():
         full_path = target / rel_path
         if not full_path.is_file():
-            # File deleted since understand ran — counts as stale
-            stale += 1
+            # File deleted since understand ran
+            stale.add(rel_path)
             continue
         disk_hash = hashlib.sha256(full_path.read_bytes()).hexdigest()
         if disk_hash != u_hash:
-            stale += 1
+            stale.add(rel_path)
     return stale
 
 
@@ -269,15 +280,19 @@ def _search_understand_dirs(
 def load_understand_context(
     understand_dir: Path,
     validate_dir: Path,
+    stale_files: Optional[Set[str]] = None,
 ) -> Dict[str, Any]:
     #Import /understand outputs as /validate starting state.
     understand_dir = Path(understand_dir)
     validate_dir = Path(validate_dir)
     validate_dir.mkdir(parents=True, exist_ok=True)
+    if stale_files is None:
+        stale_files = set()
 
     summary: Dict[str, Any] = {
         "understand_dir": str(understand_dir),
         "context_map_loaded": False,
+        "stale_files_excluded": sorted(stale_files),
         "attack_surface": {
             "sources": 0,
             "sinks": 0,
@@ -298,6 +313,11 @@ def load_understand_context(
         logger.warning("understand_bridge: no context-map.json found in %s", understand_dir)
         return summary
 
+    # --- Filter entries referencing stale files ---
+    filtered = _filter_context_map(context_map, stale_files)
+    if filtered:
+        logger.info("understand_bridge: excluded %d entries referencing stale files", filtered)
+
     summary["context_map_loaded"] = True
     summary["context_map"] = context_map
 
@@ -306,7 +326,7 @@ def load_understand_context(
     summary["attack_surface"] = surface_stats
 
     # --- Import flow-trace-*.json into attack-paths.json ---
-    trace_stats = _import_flow_traces(understand_dir, validate_dir)
+    trace_stats = _import_flow_traces(understand_dir, validate_dir, stale_files)
     summary["flow_traces"] = trace_stats
 
     logger.info(
@@ -387,6 +407,82 @@ def enrich_checklist(checklist: Dict[str, Any], context_map: Dict[str, Any],
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _references_file(entry: Dict[str, Any], stale_files: Set[str]) -> bool:
+    """Check if a context-map entry references any stale file.
+
+    Entries use different formats:
+    - entry_points/sink_details: {"file": "foo.c", ...}
+    - sources: {"entry": "argv[1] @ foo.c:6"}
+    - sinks: {"location": "foo.c:6 — strcpy(...)"}
+    - trust_boundaries: {"boundary": "...", "check": "..."}
+    """
+    import re
+
+    # Direct file field (entry_points, sink_details, trust_boundaries)
+    f = entry.get("file", "")
+    if f and f in stale_files:
+        return True
+
+    # Embedded in string fields — extract filename before ":"
+    # Patterns: "... @ file.c:N", "file.c:N — ...", "src/auth.py:12"
+    for field in ("entry", "location", "check"):
+        val = entry.get(field, "")
+        if not val:
+            continue
+        # Extract all "word.ext:digits" tokens (filenames with line numbers)
+        for match in re.findall(r'[\w./+-]+\.\w+(?=:\d)', val):
+            if match in stale_files:
+                return True
+
+    return False
+
+
+def _filter_context_map(context_map: Dict[str, Any], stale_files: Set[str]) -> int:
+    """Remove entries referencing stale files from the context map. Mutates in place.
+
+    Returns the number of entries removed.
+    """
+    if not stale_files:
+        return 0
+
+    removed = 0
+
+    # Filter list-of-dict fields
+    for key in ("entry_points", "sources", "sinks", "sink_details",
+                "trust_boundaries", "boundary_details"):
+        items = context_map.get(key)
+        if not isinstance(items, list):
+            continue
+        clean = [e for e in items if not _references_file(e, stale_files)]
+        removed += len(items) - len(clean)
+        context_map[key] = clean
+
+    # Filter unchecked_flows — references entry_points/sinks by ID, so
+    # resolve IDs to files first, then drop flows touching stale files.
+    stale_ep_ids: Set[str] = set()
+    stale_sink_ids: Set[str] = set()
+
+    # We need the original entry_points/sink_details to know which IDs
+    # were removed. But we already filtered those lists above. Instead,
+    # collect IDs from the entries we kept and drop flows referencing
+    # any ID that's NOT in the kept set.
+    kept_ep_ids = {ep.get("id") for ep in context_map.get("entry_points", []) if ep.get("id")}
+    kept_sink_ids = {s.get("id") for s in context_map.get("sink_details", []) if s.get("id")}
+
+    flows = context_map.get("unchecked_flows", [])
+    if isinstance(flows, list):
+        clean = [
+            f for f in flows
+            if f.get("entry_point") in kept_ep_ids
+            and f.get("sink") in kept_sink_ids
+        ]
+        removed += len(flows) - len(clean)
+        context_map["unchecked_flows"] = clean
+
+    return removed
+
 
 def _load_context_map(understand_dir: Path) -> Optional[Dict[str, Any]]:
     #Load context-map.json from an understand output directory.
@@ -475,14 +571,37 @@ def _merge_attack_surface(
     }
 
 
+def _trace_references_stale(trace: Dict[str, Any], stale_files: Set[str]) -> bool:
+    """Check if a flow trace references any stale file via its steps."""
+    import re
+
+    for step in trace.get("steps", []):
+        # Direct file field — exact match
+        f = step.get("file", "")
+        if f and f in stale_files:
+            return True
+        # Embedded in action/result strings — extract filenames via regex
+        for field in ("action", "result"):
+            val = step.get(field, "")
+            if val:
+                for match in re.findall(r'[\w./+-]+\.\w+(?=:\d)', val):
+                    if match in stale_files:
+                        return True
+    return False
+
+
 def _import_flow_traces(
     understand_dir: Path,
     validate_dir: Path,
+    stale_files: Optional[Set[str]] = None,
 ) -> Dict[str, Any]:
     # Import flow-trace-*.json files as initial entries in attack-paths.json.
     trace_files = sorted(understand_dir.glob("flow-trace-*.json"))
     if not trace_files:
-        return {"count": 0, "imported_as_paths": 0}
+        return {"count": 0, "imported_as_paths": 0, "skipped_stale": 0}
+
+    if stale_files is None:
+        stale_files = set()
 
     paths_path = validate_dir / "attack-paths.json"
     existing_paths: List[Dict[str, Any]] = []
@@ -495,6 +614,7 @@ def _import_flow_traces(
     existing_ids = {p.get("id") for p in existing_paths if p.get("id")}
 
     imported = 0
+    skipped_stale = 0
     for trace_file in trace_files:
         trace = load_json(trace_file)
         if not isinstance(trace, dict):
@@ -506,6 +626,11 @@ def _import_flow_traces(
             logger.debug("understand_bridge: skipping already-imported trace %s", path_id)
             continue
 
+        if stale_files and _trace_references_stale(trace, stale_files):
+            logger.info("understand_bridge: skipping stale trace %s", path_id)
+            skipped_stale += 1
+            continue
+
         attack_path = _trace_to_attack_path(trace, trace_file)
         existing_paths.append(attack_path)
         existing_ids.add(path_id)
@@ -514,7 +639,7 @@ def _import_flow_traces(
     if imported > 0:
         save_json(paths_path, existing_paths)
 
-    return {"count": len(trace_files), "imported_as_paths": imported}
+    return {"count": len(trace_files), "imported_as_paths": imported, "skipped_stale": skipped_stale}
 
 
 def _trace_to_attack_path(trace: Dict[str, Any], trace_file: Path) -> Dict[str, Any]:

--- a/libexec/raptor-build-checklist
+++ b/libexec/raptor-build-checklist
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Build source inventory (checklist.json) for a target directory.
 
-Usage: raptor-build-checklist <target> <output_dir> [--fix]
+Usage: raptor-build-checklist <target> <output_dir>
 
 Produces checklist.json with files, functions, globals, SLOC, and SHA-256
-hashes. Reuses existing checklist if target_path matches, unless --fix is
-passed which forces a full rebuild (rehashing all files on disk).
+hashes. Always rehashes files on disk. Unchanged files reuse their old
+parsed entries (including coverage marks); changed files are re-parsed
+and their coverage marks cleared.
 """
 import sys
 from pathlib import Path
@@ -15,10 +16,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 def main():
     args = [a for a in sys.argv[1:] if not a.startswith('--')]
-    fix = '--fix' in sys.argv[1:]
 
     if len(args) < 2:
-        print("Usage: raptor-build-checklist <target> <output_dir> [--fix]", file=sys.stderr)
+        print("Usage: raptor-build-checklist <target> <output_dir>", file=sys.stderr)
         sys.exit(1)
 
     target = args[0]
@@ -31,7 +31,7 @@ def main():
     Path(output_dir).mkdir(parents=True, exist_ok=True)
 
     from packages.exploitability_validation import build_checklist
-    checklist = build_checklist(target, output_dir, force_rebuild=fix)
+    checklist = build_checklist(target, output_dir)
 
     total = checklist.get("total_files", 0)
     items = checklist.get("total_items", 0)

--- a/libexec/raptor-validation-helper
+++ b/libexec/raptor-validation-helper
@@ -761,8 +761,12 @@ VERDICT_MAP = {
 
 
 def prepare_F(workdir, target=None):
-    _apply_stage_file(workdir, "E")
-
+    merged_e = _apply_stage_file(workdir, "E")
+    if not merged_e:
+        # Stage E may have been skipped (no memory-corruption findings).
+        # Merge stage-d.json here so the ruling data is not lost.
+        if _apply_stage_file(workdir, "D"):
+            print("  (Stage E skipped — merged stage-d.json directly)")
 
     data = _findings(workdir)
 
@@ -780,17 +784,23 @@ def prepare_F(workdir, target=None):
             else:
                 print(f"  {finding['id']}: {verdict} -> {mapped}")
 
-    # --- Set final_status for non-memory-corruption findings ---
+    # --- Set final_status for findings not handled by Stage E verdict mapping ---
+    # Covers two cases: (1) final_status never set, (2) final_status is stale
+    # (e.g. still "not_disproven" after Stage D promoted status to "confirmed").
+    PRE_RULING_STATUSES = {"not_disproven", "poc_success"}
     for finding in data.get("findings", []):
-        if not finding.get("final_status") and finding.get("status"):
-            finding["final_status"] = finding["status"]
+        fs = finding.get("final_status", "")
+        status = finding.get("status", "")
+        if status and (not fs or fs in PRE_RULING_STATUSES):
+            finding["final_status"] = status
 
     # --- Derive is_exploitable from final_status ---
     for finding in data.get("findings", []):
         fs = finding.get("final_status", "")
         if fs in ("exploitable",):
             finding["is_exploitable"] = True
-        elif fs in ("confirmed_constrained", "confirmed_blocked", "confirmed", "confirmed_unverified"):
+        elif fs in ("confirmed_constrained", "confirmed_blocked", "confirmed",
+                    "confirmed_unverified", "ruled_out", "disproven"):
             finding["is_exploitable"] = False
 
     # --- Carry-forward check (Stage E) ---
@@ -848,7 +858,8 @@ def prepare_F(workdir, target=None):
 # 0: Start run + build inventory
 # ---------------------------------------------------------------------------
 
-def _bridge_understand_output(out_dir, checklist, target):
+def _bridge_understand_output(out_dir, checklist, target,
+                              pre_rebuild_checklist=None):
     """Import /understand output into the validate run if available.
 
     Searches three tiers: local co-location, project siblings, global out/.
@@ -856,33 +867,62 @@ def _bridge_understand_output(out_dir, checklist, target):
     ran) then by modification time. Populates attack-surface.json, imports
     flow traces into attack-paths.json, and enriches the checklist with
     priority markers for entry points and sinks.
+
+    pre_rebuild_checklist: The checklist.json snapshot taken before
+        build_checklist overwrote it. Used for tier 1 (shared --out) to
+        detect stale files by comparing the understand run's hashes
+        against current disk.
     """
     from core.understand_bridge import (
         find_understand_output, load_understand_context, enrich_checklist,
+        _extract_hashes, _find_stale_files, _filter_context_map,
     )
 
-    understand_dir = find_understand_output(
+    understand_dir, stale_files = find_understand_output(
         out_dir, target_path=target,
     )
     if not understand_dir:
         return
 
-    # When understand_dir IS validate_dir (shared --out), skip
-    # load_understand_context since it would read/write the same files.
-    # Just enrich the checklist from the co-located context-map.
+    # Tier 1 (shared --out): find_understand_output can't detect stale files
+    # because the checklist was already overwritten by the validate rebuild.
+    # Use the pre-rebuild snapshot to compute staleness now.
+    if understand_dir == out_dir and not stale_files and pre_rebuild_checklist:
+        old_hashes = _extract_hashes(pre_rebuild_checklist)
+        if old_hashes and target:
+            stale_files = _find_stale_files(old_hashes, target)
+
+    if stale_files:
+        print(f"  Bridge: {len(stale_files)} stale file(s) — excluding"
+              f" understand data for: {', '.join(sorted(stale_files))}")
+
+    # When understand_dir IS validate_dir (shared --out), skip the full
+    # load_understand_context (which would re-import traces from itself).
+    # Instead: filter the co-located context-map, write attack-surface.json
+    # from the filtered data, and enrich the checklist.
     if understand_dir == out_dir:
         context_map_path = out_dir / "context-map.json"
         if context_map_path.exists():
-            from core.json import load_json
+            from core.json import load_json, save_json
             context_map = load_json(context_map_path)
             if context_map:
+                if stale_files:
+                    _filter_context_map(context_map, stale_files)
+                # Write attack-surface.json from (filtered) context-map so
+                # Stage B has consistent data.  Matches tier 2/3 behavior
+                # where load_understand_context always writes this file.
+                save_json(out_dir / "attack-surface.json", {
+                    "sources": context_map.get("sources", []),
+                    "sinks": context_map.get("sinks", []),
+                    "trust_boundaries": context_map.get("trust_boundaries", []),
+                })
                 enrich_checklist(checklist, context_map, str(out_dir))
                 n_targets = len(checklist.get("priority_targets", []))
                 print(f"  Bridge: enriched checklist from co-located context-map.json"
                       f" ({n_targets} priority targets)")
         return
 
-    bridge = load_understand_context(understand_dir, out_dir)
+    bridge = load_understand_context(understand_dir, out_dir, stale_files)
     if bridge.get("context_map_loaded"):
         enrich_checklist(checklist, bridge["context_map"], str(out_dir))
         n_sources = bridge["attack_surface"]["sources"]
@@ -923,12 +963,24 @@ def prepare_0(workdir_unused, target=None, explicit_out=None, no_bridge=False):
         sys.exit(1)
 
     start_run(out_dir, "validate")
+
+    # Snapshot understand hashes before the rebuild overwrites checklist.json.
+    # In the shared --out case (tier 1), the understand run's checklist is in
+    # the same directory.  build_checklist will overwrite it with current hashes,
+    # so we capture the old hashes now for stale-file detection.
+    pre_rebuild_checklist = None
+    checklist_path = out_dir / "checklist.json"
+    if checklist_path.exists() and (out_dir / "context-map.json").exists():
+        from core.json import load_json
+        pre_rebuild_checklist = load_json(checklist_path)
+
     checklist = build_checklist(target, str(out_dir))
 
     (out_dir / "build").mkdir(exist_ok=True)
 
     if not no_bridge:
-        _bridge_understand_output(out_dir, checklist, target)
+        _bridge_understand_output(out_dir, checklist, target,
+                                  pre_rebuild_checklist=pre_rebuild_checklist)
 
     print(f"Checklist: {checklist['total_files']} files, {checklist['total_items']} items")
     print(f"OUTPUT_DIR={out_dir}")

--- a/packages/exploitability_validation/__init__.py
+++ b/packages/exploitability_validation/__init__.py
@@ -72,15 +72,13 @@ compare_checklists = compare_inventories
 
 
 def build_checklist(target_path, output_dir, exclude_patterns=None, extensions=None,
-                    skip_generated=True, parallel=True, binary_path=None,
-                    force_rebuild=False):
+                    skip_generated=True, parallel=True, binary_path=None):
     """Build inventory with optional binary metadata (validation-specific)."""
     from pathlib import Path
     from core.json import save_json
 
     inventory = build_inventory(target_path, output_dir, exclude_patterns,
-                                extensions, skip_generated, parallel,
-                                force_rebuild=force_rebuild)
+                                extensions, skip_generated, parallel)
     if binary_path:
         binary_info = get_binary_info(binary_path)
         if binary_info:

--- a/packages/exploitability_validation/report.py
+++ b/packages/exploitability_validation/report.py
@@ -73,7 +73,15 @@ def generate_validation_report(
             else:
                 extra_summary["Functions checked"] = total_funcs
 
-    extra_summary["Findings identified"] = len(findings)
+    try:
+        from core.project.findings_utils import count_vulns
+        vuln_count = count_vulns(findings)
+        if vuln_count != len(findings):
+            extra_summary["Findings identified"] = vuln_count
+        else:
+            extra_summary["Findings identified"] = len(findings)
+    except Exception:
+        extra_summary["Findings identified"] = len(findings)
 
     # Build extra sections
     extra_sections = []

--- a/packages/exploitability_validation/tests/test_validation.py
+++ b/packages/exploitability_validation/tests/test_validation.py
@@ -2510,8 +2510,8 @@ class TestCompareChecklists:
         new = self._make_checklist([("a.c", "aaa")])
         assert compare_checklists(old, new) is None
 
-    def test_build_checklist_reuses_existing(self, tmp_path):
-        """Second build_checklist on same target reuses the snapshot."""
+    def test_build_checklist_rebuilds_same_hashes(self, tmp_path):
+        """Second build_checklist on unchanged target produces same hashes."""
         src = tmp_path / "src"
         src.mkdir()
         (src / "a.c").write_text("int foo() { return 1; }\n")
@@ -2520,10 +2520,9 @@ class TestCompareChecklists:
         c1 = build_checklist(str(src), out)
         c2 = build_checklist(str(src), out)
         assert c1["files"][0]["sha256"] == c2["files"][0]["sha256"]
-        assert c1["generated_at"] == c2["generated_at"]
 
-    def test_build_checklist_preserves_hash_when_source_changes(self, tmp_path):
-        """Checklist is a snapshot — hashes are NOT updated when source changes."""
+    def test_build_checklist_picks_up_source_changes(self, tmp_path):
+        """Rebuild detects source changes and updates hashes."""
         import hashlib
         src = tmp_path / "src"
         src.mkdir()
@@ -2534,10 +2533,10 @@ class TestCompareChecklists:
         original_hash = c1["files"][0]["sha256"]
         (src / "a.c").write_text("int foo() { return 2; }\n")
         c2 = build_checklist(str(src), out)
-        # Hash preserved — consumer detects staleness by comparing to disk
-        assert c2["files"][0]["sha256"] == original_hash
+        # Hash updated to reflect current disk
         disk_hash = hashlib.sha256((src / "a.c").read_bytes()).hexdigest()
-        assert disk_hash != original_hash
+        assert c2["files"][0]["sha256"] == disk_hash
+        assert c2["files"][0]["sha256"] != original_hash
 
 
 class TestDisprovenSchema:


### PR DESCRIPTION
**Summary**

  - Semantic grouping: findings sharing (file, function, vuln_type) are treated as one logical finding (e.g. TOCTOU access+fopen). Grouping is transparent — the grouped count is the finding count throughout.
  - New project findings [--detailed] subcommand showing merged findings across all runs, grouped and sorted by file.
  - SARIF merge deduplicates results by (ruleId, uri, startLine) per tool. Previously merged runs doubled the result count.
  - Cross-run merge now prefers the most-progressed status rather than blindly taking the latest run. Prevents partial/buggy runs from overwriting correct rulings.
  - project diff matches by (file, function, line) instead of finding ID, which was unstable across runs.
  - Understand bridge filters stale files per-entry instead of all-or-nothing, with regex-based filename extraction to avoid substring false positives. Tier 1 (shared --out) now has the same stale detection as tiers 2/3.
  - Validation helper fixes: Stage F merge fallback when Stage E is skipped, final_status sync from pre-ruling values, is_exploitable set for all ruling types.
  - Inventory builder always rebuilds (removed stale fast-path and --fix flag).
  - Display: poc_success → Exploitable, not_disproven → Unconfirmed.
  - Coverage summary handles both bare-list and envelope findings.json.
  - Merge writes envelope format consistently.
  - Fixed flaky test_add.py (stale project data from previous runs).
                                                                                                                                                                                                                   
  **Test plan**
                                                                                                                                                                                                                   
  - 805 tests passing across core/, packages/exploitability_validation/                                                                                                                                          
  - project findings on vulns project shows 10 grouped findings
  - project coverage --detailed shows correct finding counts after merge
  - project status shows grouped counts (10 findings not 11)                                                                                                                                                       
  - project merge deduplicates SARIF (12 results not 24)
  - project diff matches across runs with different finding IDs                                                                                                                                                    
  - /validate on TOCTOU target produces correct rulings end-to-end   