### PR TITLE
Track session PID and run metadata for safe sweep and faster status

### DIFF
--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -481,6 +481,44 @@ def _count_sarif_results(run_dir):
     return count
 
 
+def _get_output_summary(run_dir, meta):
+    """Get findings/results string for a run, using cached summary when available.
+
+    On first access for a completed run, computes the summary and writes it
+    back to .raptor-run.json so subsequent calls are instant.
+    """
+    from core.json import save_json
+    from core.run.metadata import RUN_METADATA_FILE
+
+    # Use cached summary if present
+    cached = (meta or {}).get("output_summary")
+    if cached:
+        return cached
+
+    # Compute from findings or SARIF
+    from .findings_utils import load_findings_from_dir, count_vulns
+    findings = load_findings_from_dir(run_dir)
+    if findings:
+        vuln_count = count_vulns(findings)
+        if vuln_count != len(findings):
+            result = f"{vuln_count} findings"
+        else:
+            result = f"{len(findings)} findings"
+    else:
+        sarif_count = _count_sarif_results(run_dir)
+        result = f"{sarif_count} results" if sarif_count else ""
+
+    # Cache in metadata for completed/failed runs (won't change)
+    status = (meta or {}).get("status", "")
+    if result and status in ("completed", "failed"):
+        meta_path = run_dir / RUN_METADATA_FILE
+        if meta_path.exists() and meta:
+            meta["output_summary"] = result
+            save_json(meta_path, meta)
+
+    return result
+
+
 def _print_status(project):
     """Print project status."""
     from core.run import load_run_metadata
@@ -495,7 +533,7 @@ def _print_status(project):
     if project.notes:
         print(f"Notes: {project.notes}")
 
-    runs = project.get_run_dirs()
+    runs = project.get_run_dirs(sweep=False)
     if runs:
         print(f"\nRuns: {len(runs)}")
         name_col = max(max(len(d.name) for d in runs) + 2, 20)
@@ -503,18 +541,7 @@ def _print_status(project):
             meta = load_run_metadata(d)
             cmd = meta.get("command", "?") if meta else "?"
             status = meta.get("status", "?") if meta else "?"
-            findings = load_findings_from_dir(d)
-            if findings:
-                from core.project.findings_utils import count_vulns
-                vuln_count = count_vulns(findings)
-                if vuln_count != len(findings):
-                    findings_str = f"{vuln_count} findings"
-                else:
-                    findings_str = f"{len(findings)} findings"
-            else:
-                # Count SARIF results for scan/codeql runs
-                sarif_count = _count_sarif_results(d)
-                findings_str = f"{sarif_count} results" if sarif_count else ""
+            findings_str = _get_output_summary(d, meta)
             if status == "completed":
                 status_str = _green(status)
             elif status == "failed":

--- a/core/project/project.py
+++ b/core/project/project.py
@@ -68,14 +68,16 @@ class Project:
         return [d for d in self.output_path.iterdir()
                 if d.is_dir() and not d.name.startswith((".", "_"))]
 
-    def get_run_dirs(self, sweep=True) -> List[Path]:
+    def get_run_dirs(self, sweep=False) -> List[Path]:
         """List run directories sorted newest-first.
 
         Uses the timestamp embedded in the directory name when available
         (deterministic), falls back to mtime for non-standard names.
-        When sweep=True (default), marks stale 'running' dirs as failed.
+        When sweep=True, marks stale 'running' dirs as failed.
         Inside Claude Code (CLAUDECODE=1), keeps the newest running dir
         (may be active). Outside Claude Code, sweeps all.
+        Default is sweep=False to avoid damaging active runs from read-only
+        commands (status, findings, coverage).
         """
         from core.run.metadata import parse_timestamp_from_name
 
@@ -104,11 +106,21 @@ class Project:
         return self._sweep_stale(self._list_run_dirs(), keep_latest)
 
     def _sweep_stale(self, dirs: list, keep_latest=False) -> int:
-        """Mark 'running' dirs as failed, optionally keeping the newest."""
-        from core.run.metadata import RUN_METADATA_FILE, fail_run
+        """Mark 'running' dirs as failed if their session is dead.
+
+        Checks session_pid in metadata — if the PID is still alive, the
+        session that started the run is still running and will clean up
+        its own runs. Only sweeps runs whose session has died.
+
+        Args:
+            keep_latest: if True, skip the most recent 'running' dir even
+                         if its session is dead (legacy fallback for runs
+                         without session_pid).
+        """
+        from core.run.metadata import RUN_METADATA_FILE, fail_run, _pid_alive
         from core.json import load_json
 
-        # Find all running dirs with their timestamps
+        # Find all running dirs with their timestamps and PIDs
         running = []
         for d in dirs:
             meta_file = d / RUN_METADATA_FILE
@@ -116,19 +128,27 @@ class Project:
                 continue
             meta = load_json(meta_file)
             if meta and meta.get("status") == "running":
-                running.append((meta.get("timestamp", ""), d))
+                running.append((meta.get("timestamp", ""), d, meta.get("session_pid")))
 
         if not running:
             return 0
 
-        # Sort newest first; optionally skip the newest
+        swept = 0
+        # Sort newest first for keep_latest
         running.sort(reverse=True)
-        to_sweep = running[1:] if keep_latest else running
 
-        for _, d in to_sweep:
-            fail_run(d, "stale — session ended without completion")
+        for i, (ts, d, pid) in enumerate(running):
+            # If session_pid is recorded and alive, skip — session will clean up
+            if pid is not None and _pid_alive(pid):
+                continue
+            # No PID (legacy run) — use keep_latest heuristic
+            if pid is None and keep_latest and i == 0:
+                continue
+            fail_run(d, "stale — session ended without completion",
+                     record_timing=False)
+            swept += 1
 
-        return len(to_sweep)
+        return swept
 
     def get_run_dirs_by_type(self) -> Dict[str, List[Path]]:
         """Group run directories by command type.

--- a/core/project/report.py
+++ b/core/project/report.py
@@ -14,7 +14,7 @@ def generate_project_report(project) -> Dict[str, Any]:
     report_dir = project.output_path / "_report"
     report_dir.mkdir(parents=True, exist_ok=True)
 
-    run_dirs = project.get_run_dirs()
+    run_dirs = project.get_run_dirs(sweep=True)
     if not run_dirs:
         return {"findings": 0, "runs": 0}
 

--- a/core/project/tests/test_project.py
+++ b/core/project/tests/test_project.py
@@ -53,38 +53,63 @@ class TestProject(unittest.TestCase):
             self.assertEqual(dirs[0].name, "scan-20260401")
 
     def test_sweep_marks_stale_running_as_failed(self):
-        """sweep_stale_runs marks 'running' dirs as failed."""
-        from core.run.metadata import start_run, RUN_METADATA_FILE
-        from core.json import load_json
+        """sweep_stale_runs marks 'running' dirs with dead session_pid as failed."""
+        from core.run.metadata import RUN_METADATA_FILE
+        from core.json import load_json, save_json
         with TemporaryDirectory() as d:
-            run1 = Path(d) / "scan-20260401"
-            run1.mkdir()
-            start_run(run1, "scan")
-            run2 = Path(d) / "scan-20260402"
-            run2.mkdir()
-            start_run(run2, "scan")
+            # Simulate runs from a dead session (PID 99999999)
+            for name in ["scan-20260401", "scan-20260402"]:
+                run = Path(d) / name
+                run.mkdir()
+                save_json(run / RUN_METADATA_FILE, {
+                    "version": 1, "command": "scan",
+                    "timestamp": "2026-04-01T00:00:00+00:00",
+                    "status": "running", "extra": {},
+                    "session_pid": 99999999,
+                })
             p = Project(name="test", target="/tmp", output_dir=d)
             count = p.sweep_stale_runs(keep_latest=False)
             self.assertEqual(count, 2)
-            self.assertEqual(load_json(run1 / RUN_METADATA_FILE)["status"], "failed")
-            self.assertEqual(load_json(run2 / RUN_METADATA_FILE)["status"], "failed")
+            self.assertEqual(load_json(Path(d) / "scan-20260401" / RUN_METADATA_FILE)["status"], "failed")
+            self.assertEqual(load_json(Path(d) / "scan-20260402" / RUN_METADATA_FILE)["status"], "failed")
 
-    def test_sweep_keep_latest_preserves_newest(self):
-        """sweep with keep_latest=True skips the newest running dir."""
-        from core.run.metadata import start_run, RUN_METADATA_FILE
-        from core.json import load_json
+    def test_sweep_skips_alive_session(self):
+        """sweep skips runs whose session PID is still alive."""
+        from core.run.metadata import RUN_METADATA_FILE
+        from core.json import load_json, save_json
+        import os
         with TemporaryDirectory() as d:
-            old = Path(d) / "scan-20260401"
-            old.mkdir()
-            start_run(old, "scan")
-            new = Path(d) / "scan-20260402"
-            new.mkdir()
-            start_run(new, "scan")
+            run = Path(d) / "scan-20260401"
+            run.mkdir()
+            save_json(run / RUN_METADATA_FILE, {
+                "version": 1, "command": "scan",
+                "timestamp": "2026-04-01T00:00:00+00:00",
+                "status": "running", "extra": {},
+                "session_pid": os.getpid(),  # our PID — definitely alive
+            })
+            p = Project(name="test", target="/tmp", output_dir=d)
+            count = p.sweep_stale_runs(keep_latest=False)
+            self.assertEqual(count, 0)
+            self.assertEqual(load_json(run / RUN_METADATA_FILE)["status"], "running")
+
+    def test_sweep_keep_latest_legacy_runs(self):
+        """sweep with keep_latest=True skips newest legacy run (no session_pid)."""
+        from core.run.metadata import RUN_METADATA_FILE
+        from core.json import load_json, save_json
+        with TemporaryDirectory() as d:
+            for name, ts in [("scan-20260401", "2026-04-01"), ("scan-20260402", "2026-04-02")]:
+                run = Path(d) / name
+                run.mkdir()
+                save_json(run / RUN_METADATA_FILE, {
+                    "version": 1, "command": "scan",
+                    "timestamp": f"{ts}T00:00:00+00:00",
+                    "status": "running", "extra": {},
+                })
             p = Project(name="test", target="/tmp", output_dir=d)
             count = p.sweep_stale_runs(keep_latest=True)
             self.assertEqual(count, 1)
-            self.assertEqual(load_json(old / RUN_METADATA_FILE)["status"], "failed")
-            self.assertEqual(load_json(new / RUN_METADATA_FILE)["status"], "running")
+            self.assertEqual(load_json(Path(d) / "scan-20260401" / RUN_METADATA_FILE)["status"], "failed")
+            self.assertEqual(load_json(Path(d) / "scan-20260402" / RUN_METADATA_FILE)["status"], "running")
 
     def test_sweep_ignores_completed(self):
         """sweep doesn't touch completed/failed dirs."""

--- a/core/run/metadata.py
+++ b/core/run/metadata.py
@@ -5,6 +5,7 @@ produced it, when, and whether it succeeded. Tools use start_run/complete_run/fa
 """
 
 import contextlib
+import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
@@ -45,15 +46,49 @@ _PREFIX_MAP = {
 }
 
 
-def start_run(output_dir: Path, command: str, extra: Dict[str, Any] = None) -> Path:
+def _get_session_pid() -> Optional[int]:
+    """Get the PID of the Claude Code session (our parent process).
+
+    Returns None if not running inside Claude Code.
+    """
+    if not os.environ.get("CLAUDECODE"):
+        return None
+    return os.getppid()
+
+
+def _pid_alive(pid: int) -> bool:
+    """Check if a process is alive. Returns False for invalid PIDs."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # alive but owned by another user
+
+
+def start_run(output_dir: Path, command: str, extra: Dict[str, Any] = None,
+              target: str = None) -> Path:
     """Write initial .raptor-run.json with status=running.
 
     Call this at the start of a command. Returns the output_dir (for chaining).
     Creates the directory if it doesn't exist. In project mode, creates a
     checklist.json symlink pointing to the project-level checklist.
+
+    Records the session PID so sweep can check if the session is still alive.
+    Also marks any abandoned runs from the same session and command type as
+    failed (handles the Esc-then-retry scenario).
     """
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    session_pid = _get_session_pid()
+
+    # Clean up abandoned runs: same session, same command type, still "running"
+    if session_pid is not None:
+        _cleanup_abandoned(output_dir.parent, command, session_pid)
 
     metadata = {
         "version": 1,
@@ -62,10 +97,38 @@ def start_run(output_dir: Path, command: str, extra: Dict[str, Any] = None) -> P
         "status": STATUS_RUNNING,
         "extra": extra or {},
     }
-
+    if session_pid is not None:
+        metadata["session_pid"] = session_pid
+    if target:
+        metadata["target_path"] = str(target)
     save_json(output_dir / RUN_METADATA_FILE, metadata)
     _setup_checklist_symlink(output_dir)
     return output_dir
+
+
+def _cleanup_abandoned(project_dir: Path, command: str, session_pid: int) -> None:
+    """Mark abandoned runs from the same session and command type as failed.
+
+    An abandoned run is one that has status=running, same session_pid (same
+    Claude Code session), and same command type. This happens when the user
+    presses Esc and retries the same command.
+    """
+    if not project_dir.is_dir():
+        return
+    for d in project_dir.iterdir():
+        if not d.is_dir() or d.name.startswith((".", "_")):
+            continue
+        meta_path = d / RUN_METADATA_FILE
+        if not meta_path.exists():
+            continue
+        meta = load_json(meta_path)
+        if not meta:
+            continue
+        if (meta.get("status") == STATUS_RUNNING
+                and meta.get("command") == command
+                and meta.get("session_pid") == session_pid):
+            fail_run(d, "abandoned — replaced by new run in same session",
+                     record_timing=False)
 
 
 def _setup_checklist_symlink(run_dir: Path) -> None:
@@ -154,12 +217,13 @@ def complete_run(output_dir: Path, extra: Dict[str, Any] = None) -> None:
     _update_status(output_dir, STATUS_COMPLETED, extra)
 
 
-def fail_run(output_dir: Path, error: str = None, extra: Dict[str, Any] = None) -> None:
+def fail_run(output_dir: Path, error: str = None, extra: Dict[str, Any] = None,
+             record_timing: bool = True) -> None:
     """Update .raptor-run.json to status=failed."""
     extra = extra or {}
     if error:
         extra["error"] = error
-    _update_status(output_dir, STATUS_FAILED, extra)
+    _update_status(output_dir, STATUS_FAILED, extra, record_timing=record_timing)
 
 
 def cancel_run(output_dir: Path, extra: Dict[str, Any] = None) -> None:
@@ -268,8 +332,13 @@ def generate_run_metadata(run_dir: Path) -> None:
     save_json(run_dir / RUN_METADATA_FILE, metadata)
 
 
-def _update_status(output_dir: Path, status: str, extra: Dict[str, Any] = None) -> None:
+def _update_status(output_dir: Path, status: str, extra: Dict[str, Any] = None,
+                   record_timing: bool = True) -> None:
     """Update the status field in .raptor-run.json.
+
+    When record_timing is True (default), also records end_timestamp and
+    duration_seconds. Set to False for sweep/cleanup where the run ended
+    at an unknown earlier time.
 
     Raises FileNotFoundError if metadata file doesn't exist (call start_run first).
     """
@@ -278,6 +347,18 @@ def _update_status(output_dir: Path, status: str, extra: Dict[str, Any] = None) 
     if metadata is None:
         raise FileNotFoundError(f"No {RUN_METADATA_FILE} in {output_dir} — call start_run() first")
     metadata["status"] = status
+
+    if record_timing:
+        now = datetime.now(timezone.utc)
+        metadata["end_timestamp"] = now.isoformat()
+        start_ts = metadata.get("timestamp")
+        if start_ts:
+            try:
+                start_dt = datetime.fromisoformat(start_ts)
+                metadata["duration_seconds"] = round((now - start_dt).total_seconds(), 1)
+            except (ValueError, TypeError):
+                pass
+
     if extra:
         existing_extra = metadata.get("extra", {})
         existing_extra.update(extra)

--- a/core/run/tests/test_metadata.py
+++ b/core/run/tests/test_metadata.py
@@ -81,6 +81,54 @@ class TestRunLifecycle(unittest.TestCase):
             with self.assertRaises(FileNotFoundError):
                 fail_run(out, error="test")
 
+    def test_start_records_session_pid(self):
+        """start_run records session_pid when CLAUDECODE is set."""
+        import os
+        with TemporaryDirectory() as d:
+            out = Path(d) / "project" / "scan-20260406"
+            # CLAUDECODE is set in our test env (running inside CC)
+            if os.environ.get("CLAUDECODE"):
+                start_run(out, "scan")
+                meta = load_json(out / RUN_METADATA_FILE)
+                self.assertIn("session_pid", meta)
+                self.assertIsInstance(meta["session_pid"], int)
+
+    def test_start_cleanup_abandoned(self):
+        """start_run marks same-session same-type abandoned runs as failed."""
+        import os
+        if not os.environ.get("CLAUDECODE"):
+            self.skipTest("Requires CLAUDECODE environment")
+        with TemporaryDirectory() as d:
+            project = Path(d) / "project"
+            project.mkdir()
+            # First run
+            run1 = project / "validate-20260401"
+            start_run(run1, "validate")
+            meta1 = load_json(run1 / RUN_METADATA_FILE)
+            self.assertEqual(meta1["status"], "running")
+            # Second run of same type — should mark first as failed
+            run2 = project / "validate-20260402"
+            start_run(run2, "validate")
+            meta1 = load_json(run1 / RUN_METADATA_FILE)
+            self.assertEqual(meta1["status"], "failed")
+            meta2 = load_json(run2 / RUN_METADATA_FILE)
+            self.assertEqual(meta2["status"], "running")
+
+    def test_start_no_cleanup_different_type(self):
+        """start_run does not mark runs of a different command type."""
+        import os
+        if not os.environ.get("CLAUDECODE"):
+            self.skipTest("Requires CLAUDECODE environment")
+        with TemporaryDirectory() as d:
+            project = Path(d) / "project"
+            project.mkdir()
+            run1 = project / "validate-20260401"
+            start_run(run1, "validate")
+            run2 = project / "scan-20260402"
+            start_run(run2, "scan")
+            meta1 = load_json(run1 / RUN_METADATA_FILE)
+            self.assertEqual(meta1["status"], "running")  # untouched
+
 
 class TestIsRunDirectory(unittest.TestCase):
 

--- a/libexec/raptor-run-lifecycle
+++ b/libexec/raptor-run-lifecycle
@@ -60,7 +60,7 @@ def main():
             print(f"ERROR: {e}", file=sys.stderr)
             sys.exit(1)
 
-        start_run(out_dir, command)
+        start_run(out_dir, command, target=target_path)
         print(f"OUTPUT_DIR={out_dir}")
 
     elif action == "complete":

--- a/libexec/raptor-validation-helper
+++ b/libexec/raptor-validation-helper
@@ -962,7 +962,7 @@ def prepare_0(workdir_unused, target=None, explicit_out=None, no_bridge=False):
         print(f"ERROR: {e}", file=sys.stderr)
         sys.exit(1)
 
-    start_run(out_dir, "validate")
+    start_run(out_dir, "validate", target=target)
 
     # Snapshot understand hashes before the rebuild overwrites checklist.json.
     # In the shared --out case (tier 1), the understand run's checklist is in

--- a/raptor.py
+++ b/raptor.py
@@ -70,7 +70,7 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
         print(f"✗ {e}", file=sys.stderr)
         return 1
 
-    start_run(out_dir, command)
+    start_run(out_dir, command, target=target)
 
     # Inject --out so the downstream script uses the lifecycle directory
     if "--out" not in args:

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -341,7 +341,7 @@ Examples:
 
     try:
         from core.run import start_run
-        start_run(out_dir, "agentic")
+        start_run(out_dir, "agentic", target=str(repo_path))
     except Exception as e:
         logger.debug(f"Run metadata: {e}")  # Optional — don't fail the pipeline
 


### PR DESCRIPTION
**Summary**
  
  - Record session_pid (Claude Code parent PID) in .raptor-run.json — sweep checks if session is alive before marking runs as failed
  - start_run marks abandoned same-session same-type runs as failed (Esc-then-retry)
  - Default get_run_dirs(sweep=False) — read-only commands never damage active runs
  - Record target_path in .raptor-run.json at start (passed by all call sites)
  - Record end_timestamp and duration_seconds on complete/fail/cancel
  - Sweep and cleanup pass record_timing=False to avoid misleading timestamps on swept runs
  - Lazy-cache output_summary in project status — computed once on first read, written back to metadata for instant subsequent access
  - Legacy runs without session_pid fall back to keep_latest heuristic
  
  Fixes: running raptor project status from a separate terminal while a validate session is active would mark the active run as failed.
  
  **Test plan**
  
  - 185 tests passing across core/project/ and core/run/
  - Sweep with dead PID marks runs as failed
  - Sweep with alive PID skips runs
  - Legacy runs (no session_pid) use keep_latest heuristic
  - start_run marks abandoned same-type run from same session
  - start_run leaves different-type runs untouched
  - complete_run writes end_timestamp and duration_seconds
  - Swept runs do not get end_timestamp/duration
  - start_run writes target_path when provided
  - Second project status call uses cached output_summary