### PR TITLE
feat: add Rust security suites for CodeQL queries

### DIFF
--- a/packages/codeql/query_runner.py
+++ b/packages/codeql/query_runner.py
@@ -80,6 +80,7 @@ class QueryRunner:
         "ruby": "codeql/ruby-queries:codeql-suites/ruby-security-and-quality.qls",
         "swift": "codeql/swift-queries:codeql-suites/swift-security-and-quality.qls",
         "kotlin": "codeql/java-queries:codeql-suites/java-security-and-quality.qls",  # Kotlin uses Java queries
+        "rust": "codeql/rust-queries:codeql-suites/rust-security-and-quality.qls",
     }
 
     # Alternative: security-extended suites (more comprehensive)
@@ -92,6 +93,7 @@ class QueryRunner:
         "cpp": "codeql/cpp-queries:codeql-suites/cpp-security-extended.qls",
         "csharp": "codeql/csharp-queries:codeql-suites/csharp-security-extended.qls",
         "ruby": "codeql/ruby-queries:codeql-suites/ruby-security-extended.qls",
+        "rust": "codeql/rust-queries:codeql-suites/rust-security-extended.qls",
     }
 
     def __init__(self, codeql_cli: Optional[str] = None):
@@ -188,6 +190,7 @@ class QueryRunner:
                     "codeql/go-queries": "go",
                     "codeql/ruby-queries": "ruby",
                     "codeql/swift-queries": "swift",
+                    "codeql/rust-queries": "rust",
                 }
 
                 lang_dir = lang_map.get(pack_name)


### PR DESCRIPTION
While analysing a Rust project, raptor added the security suites for Rust to the CodeQL queries. This might be useful for other users to have it right from the start. 