### PR TITLE
Security hardening: env sanitisation, path traversal, symlink, TOCTOU, injection fixes

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -123,11 +123,22 @@ class RaptorConfig:
     # tool-specific vars). Needs testing of what semgrep, codeql, git, gdb,
     # afl-fuzz each require.
     DANGEROUS_ENV_VARS = [
-        "TERMINAL",       # Shell-evaluated by command lookup utilities
-        "BROWSER",        # Shell-evaluated by open/xdg-open
-        "PAGER",          # Shell-evaluated by less/more invocation
-        "VISUAL",         # Shell-evaluated by editor invocation
-        "EDITOR",         # Shell-evaluated by editor invocation
+        "TERMINAL",        # Shell-evaluated by command lookup utilities
+        "BROWSER",         # Shell-evaluated by open/xdg-open
+        "PAGER",           # Shell-evaluated by less/more invocation
+        "VISUAL",          # Shell-evaluated by editor invocation
+        "EDITOR",          # Shell-evaluated by editor invocation
+        "IFS",             # Changes shell word splitting — classic injection vector
+        "CDPATH",          # Alters cd behaviour, can redirect working directory
+        "BASH_ENV",        # Executed by bash on startup in non-interactive mode
+        "ENV",             # Executed by sh/dash on startup
+        "PROMPT_COMMAND",  # Executed before every bash prompt (if child is interactive)
+        "LD_PRELOAD",      # Injects shared libraries into child processes
+        "LD_LIBRARY_PATH", # Redirects shared library resolution
+        "PYTHONSTARTUP",   # Executed by Python on startup
+        "PERL5OPT",        # Injects Perl command-line options
+        "RUBYOPT",         # Injects Ruby command-line options
+        "NODE_OPTIONS",    # Injects Node.js command-line options
         # Note: TERM is NOT stripped — it's read as a string (terminfo lookup),
         # not shell-evaluated. Stripping it breaks colour output in git/grep/etc.
     ]
@@ -152,11 +163,24 @@ class RaptorConfig:
         """
         Resolve the output directory, honoring RAPTOR_OUT_DIR environment variable.
 
+        Warns if the output directory is a system path that could be dangerous.
+
         Returns:
             Path: Resolved output directory path
         """
         base = os.environ.get(RaptorConfig.ENV_OUT_DIR)
-        return Path(base).resolve() if base else RaptorConfig.BASE_OUT_DIR
+        if not base:
+            return RaptorConfig.BASE_OUT_DIR
+        resolved = Path(base).resolve()
+        forbidden = ("/etc", "/usr", "/bin", "/sbin", "/boot", "/dev", "/proc", "/sys")
+        for prefix in forbidden:
+            if str(resolved).startswith(prefix):
+                import logging
+                logging.getLogger(__name__).warning(
+                    f"RAPTOR_OUT_DIR points to system path {resolved} — this is likely a misconfiguration"
+                )
+                break
+        return resolved
 
     @staticmethod
     def get_job_out_dir(job_id: str) -> Path:

--- a/core/coverage/track_read.py
+++ b/core/coverage/track_read.py
@@ -87,9 +87,16 @@ def main():
     if dot == -1 or file_path[dot:].lower() not in _SOURCE_EXTENSIONS:
         return
 
-    # Skip files outside the target directory
-    if target and not file_path.startswith(target):
-        return
+    # Skip files outside the target directory (path-level check, not string prefix)
+    if target:
+        try:
+            # Resolve symlinks and check proper path containment
+            resolved = os.path.realpath(file_path)
+            resolved_target = os.path.realpath(target)
+            if not resolved.startswith(resolved_target + os.sep) and resolved != resolved_target:
+                return
+        except (OSError, ValueError):
+            return
 
     # Append to manifest
     try:

--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -237,11 +237,16 @@ def _collect_source_files(target: Path, extensions: Set[str]) -> List[Path]:
 
     file_list = []
     for root, dirs, files in os.walk(target):
-        dirs[:] = [d for d in dirs if not d.startswith('.')]
+        # Skip hidden directories and symlinked directories
+        dirs[:] = [d for d in dirs
+                   if not d.startswith('.') and not (Path(root) / d).is_symlink()]
         for filename in files:
+            filepath = Path(root) / filename
+            if filepath.is_symlink():
+                continue  # Don't follow symlinks into files outside the repo
             ext = Path(filename).suffix.lower()
             if ext in extensions:
-                file_list.append(Path(root) / filename)
+                file_list.append(filepath)
 
     return file_list
 

--- a/core/json/utils.py
+++ b/core/json/utils.py
@@ -6,6 +6,7 @@ serialization of Path/datetime objects.
 """
 
 import json
+import os
 import re
 from datetime import datetime
 from pathlib import Path
@@ -68,12 +69,17 @@ class _RaptorEncoder(json.JSONEncoder):
             return str(obj)
 
 
-def save_json(path: Union[str, Path], data: Any) -> None:
+def save_json(path: Union[str, Path], data: Any, mode: int = None) -> None:
     """Save data as pretty-printed JSON. Handles Path/datetime serialization.
 
     Creates parent directories if needed. Uses atomic write (write to temp
     file then rename) to prevent corruption if the process is killed mid-write.
     Raises on write failure — a failed save should not be silent.
+
+    Args:
+        mode: Optional POSIX file permission bits (e.g. 0o600). When set,
+              the temp file is created with these permissions atomically —
+              no window where the file exists with default permissions.
     """
     p = Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
@@ -83,7 +89,13 @@ def save_json(path: Union[str, Path], data: Any) -> None:
     # .~ prefix makes stale temps visually obvious and excluded by get_run_dirs.
     tmp = p.with_name(f".~{p.name}.tmp")
     try:
-        tmp.write_text(content, encoding="utf-8")
+        if mode is not None:
+            # Create temp file with explicit permissions — no race window
+            fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+        else:
+            tmp.write_text(content, encoding="utf-8")
         tmp.replace(p)
     except BaseException:
         # Clean up temp file on any failure

--- a/core/project/project.py
+++ b/core/project/project.py
@@ -397,14 +397,20 @@ class ProjectManager:
         """Set the active project symlink. Pass None to clear.
 
         The symlink is the single source of truth for project state.
+        Uses atomic create-temp-then-rename to avoid TOCTOU races.
         """
+        import os
         active_link = self.projects_dir / ".active"
         auto_marker = self.projects_dir / ".auto"
-        if active_link.is_symlink() or active_link.exists():
-            active_link.unlink()
         auto_marker.unlink(missing_ok=True)
         if name is not None:
-            active_link.symlink_to(f"{name}.json")
+            # Atomic swap: create temp symlink then rename over the active link
+            tmp_link = self.projects_dir / ".active.tmp"
+            tmp_link.unlink(missing_ok=True)
+            tmp_link.symlink_to(f"{name}.json")
+            os.rename(str(tmp_link), str(active_link))
+        else:
+            active_link.unlink(missing_ok=True)
 
     def get_active(self) -> Optional[str]:
         """Get the active project name from the .active symlink."""

--- a/core/sarif/parser.py
+++ b/core/sarif/parser.py
@@ -208,16 +208,19 @@ def load_sarif(sarif_path: Path) -> Optional[Dict[str, Any]]:
         return None
 
     max_size = 100 * 1024 * 1024  # 100 MiB
-    try:
-        file_size = sarif_path.stat().st_size
-        if file_size > max_size:
-            print(f"[SARIF] ERROR: File too large ({file_size / 1024 / 1024:.0f} MiB): {sarif_path}")
-            return None
-    except OSError as e:
-        print(f"[SARIF] WARNING: Could not stat {sarif_path}: {e}")
 
     try:
-        data = json.loads(sarif_path.read_text() or "{}")
+        # Read then check size — avoids TOCTOU between stat() and read()
+        content = sarif_path.read_text()
+        if len(content) > max_size:
+            print(f"[SARIF] ERROR: File too large ({len(content) / 1024 / 1024:.0f} MiB): {sarif_path}")
+            return None
+    except OSError as e:
+        print(f"[SARIF] WARNING: Could not read {sarif_path}: {e}")
+        return None
+
+    try:
+        data = json.loads(content or "{}")
     except json.JSONDecodeError as e:
         print(f"[SARIF] ERROR: Invalid JSON in {sarif_path}: {e}")
         return None

--- a/core/startup/init.py
+++ b/core/startup/init.py
@@ -83,6 +83,13 @@ def check_llm() -> tuple[list, list]:
         config_path = Path.home() / ".config/raptor/models.json"
         models = []
         if config_path.exists():
+            # Warn if models.json is readable by others (contains API keys)
+            try:
+                mode = config_path.stat().st_mode
+                if mode & 0o077:
+                    warnings.append(f"⚠ {config_path} is accessible by other users (mode {oct(mode)[-3:]}). Run: chmod 600 {config_path}")
+            except OSError:
+                pass
             try:
                 data = json.loads(config_path.read_text())
                 models = data.get("models", []) if isinstance(data, dict) else data

--- a/packages/autonomous/exploit_validator.py
+++ b/packages/autonomous/exploit_validator.py
@@ -87,9 +87,10 @@ class ExploitValidator:
         """
         logger.info(f"Validating exploit: {exploit_name}")
 
-        # Write exploit to temporary file
-        exploit_source = self.work_dir / f"{exploit_name}.c"
-        exploit_binary = self.work_dir / exploit_name
+        # Write exploit to temporary file — sanitize name to prevent path traversal
+        safe_name = Path(exploit_name).name.replace("..", "_") if exploit_name else "exploit"
+        exploit_source = self.work_dir / f"{safe_name}.c"
+        exploit_binary = self.work_dir / safe_name
 
         try:
             with open(exploit_source, 'w') as f:
@@ -103,11 +104,13 @@ class ExploitValidator:
                 "-w",  # Suppress warnings for now
             ]
 
+            from core.config import RaptorConfig
             result = subprocess.run(
                 compile_cmd,
                 capture_output=True,
                 text=True,
-                timeout=30
+                timeout=30,
+                env=RaptorConfig.get_safe_env(),
             )
 
             if result.returncode == 0:

--- a/packages/codeql/database_manager.py
+++ b/packages/codeql/database_manager.py
@@ -341,7 +341,12 @@ class DatabaseManager:
         working_dir = build_system.working_dir if build_system else repo_path
         env = RaptorConfig.get_safe_env()
         if build_system and build_system.env_vars:
-            env.update(build_system.env_vars)
+            # Filter build env vars through the same blocklist — a malicious
+            # repo's build config could try to re-inject LD_PRELOAD, BASH_ENV, etc.
+            blocked = set(RaptorConfig.DANGEROUS_ENV_VARS + RaptorConfig.PROXY_ENV_VARS)
+            for k, v in build_system.env_vars.items():
+                if k not in blocked:
+                    env[k] = v
 
         # Add build command if provided.
         # CodeQL splits --command on whitespace without shell interpretation,

--- a/packages/diagram/attack_tree.py
+++ b/packages/diagram/attack_tree.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from core.json import load_json
-from .sanitize import sanitize as _sanitize
+from .sanitize import sanitize as _sanitize, sanitize_id as _sid
 
 
 _PROXIMITY_LABEL = {
@@ -162,13 +162,16 @@ def generate(
     disproven: list[dict] | None = None,
     hypotheses: list[dict] | None = None,
 ) -> str:
-    root_id = data.get("root")
+    root_id = _sid(data.get("root", "ROOT"))
     nodes: list[dict] = data.get("nodes", [])
 
     if not nodes:
         return 'flowchart TD\n    EMPTY["No attack tree nodes"]'
 
-    node_map = {n.get("id"): n for n in nodes}
+    # Sanitize all node IDs upfront to prevent Mermaid markup injection
+    for n in nodes:
+        n["id"] = _sid(n.get("id", "?"))
+    node_map = {n["id"]: n for n in nodes}
 
     # Build enrichment indexes
     proximity_idx = _build_proximity_index(attack_paths or [])
@@ -236,13 +239,13 @@ def generate(
                 continue
             nid = node.get("id", "?")
             leads_to_raw = node.get("leads_to", "") or ""
-            targets = [t.strip() for t in leads_to_raw.split(",") if t.strip() and t.strip() in node_map]
+            targets = [_sid(t.strip()) for t in leads_to_raw.split(",") if t.strip() and _sid(t.strip()) in node_map]
             for target in targets:
                 if target != root_id:  # root edge already drawn above
                     lines.append(f"    {nid} --> {target}")
 
     else:
-        # Flat rendering,original approach
+        # Flat rendering, original approach
         lines.append("")
         lines.append("    %% Nodes")
         for node in nodes:
@@ -257,7 +260,7 @@ def generate(
         for node in nodes:
             nid = node.get("id", "?")
             leads_to_raw = node.get("leads_to", "") or ""
-            targets = [t.strip() for t in leads_to_raw.split(",") if t.strip() and t.strip() in node_map]
+            targets = [_sid(t.strip()) for t in leads_to_raw.split(",") if t.strip() and _sid(t.strip()) in node_map]
             for target in targets:
                 lines.append(f"    {nid} --> {target}")
 

--- a/packages/diagram/context_map.py
+++ b/packages/diagram/context_map.py
@@ -11,7 +11,7 @@ from core.json import load_json
 from pathlib import Path
 from typing import Any
 
-from .sanitize import sanitize as _sanitize
+from .sanitize import sanitize as _sanitize, sanitize_id as _sid
 
 
 def _node_id(prefix: str, index: int) -> str:
@@ -48,7 +48,7 @@ def generate(data: dict[str, Any]) -> str:
         lines.append("")
         lines.append("    %% Entry Points")
     for ep in entry_points:
-        ep_id = ep.get("id", "EP-?")
+        ep_id = _sid(ep.get("id", "EP-?"))
         method = ep.get("method", "")
         path = ep.get("path", ep.get("entry", "?"))
         file_ref = ep.get("file", "")
@@ -63,7 +63,7 @@ def generate(data: dict[str, Any]) -> str:
         lines.append("")
         lines.append("    %% Trust Boundaries")
     for tb in boundary_details:
-        tb_id = tb.get("id", "TB-?")
+        tb_id = _sid(tb.get("id", "TB-?"))
         boundary = _sanitize(tb.get("boundary", tb.get("type", "?")))
         file_ref = tb.get("file", "")
         line_ref = tb.get("line", "")
@@ -76,7 +76,7 @@ def generate(data: dict[str, Any]) -> str:
         lines.append("")
         lines.append("    %% Sinks")
     for sink in sink_details:
-        sink_id = sink.get("id", "SINK-?")
+        sink_id = _sid(sink.get("id", "SINK-?"))
         op = sink.get("operation", sink.get("type", "?"))
         file_ref = sink.get("file", "")
         line_ref = sink.get("line", "")
@@ -89,25 +89,25 @@ def generate(data: dict[str, Any]) -> str:
     lines.append("    %% Flows")
     covered_eps: set[str] = set()
     for tb in boundary_details:
-        tb_id = tb.get("id", "TB-?")
-        for ep_id in tb.get("covers", []):
+        tb_id = _sid(tb.get("id", "TB-?"))
+        for ep_id in [_sid(e) for e in tb.get("covers", [])]:
             lines.append(f"    {ep_id} --> {tb_id}")
             covered_eps.add(ep_id)
 
     # -- Edges: TB → SINK (reaches_from) --
     for sink in sink_details:
-        sink_id = sink.get("id", "SINK-?")
-        for ep_id in sink.get("reaches_from", []):
+        sink_id = _sid(sink.get("id", "SINK-?"))
+        for ep_id in [_sid(e) for e in sink.get("reaches_from", [])]:
             # Find which TB covers this EP
             tb_for_ep = [
-                tb.get("id") for tb in boundary_details
-                if ep_id in tb.get("covers", [])
+                _sid(tb.get("id")) for tb in boundary_details
+                if ep_id in [_sid(e) for e in tb.get("covers", [])]
             ]
             if tb_for_ep:
                 for tb_id in tb_for_ep:
                     lines.append(f"    {tb_id} --> {sink_id}")
             else:
-                # No TB,direct edge (will also appear as unchecked)
+                # No TB, direct edge (will also appear as unchecked)
                 lines.append(f"    {ep_id} --> {sink_id}")
 
     # -- Unchecked flows: dashed red edges --
@@ -115,8 +115,8 @@ def generate(data: dict[str, Any]) -> str:
         lines.append("")
         lines.append("    %% Unchecked Flows (no trust boundary)")
     for flow in unchecked_flows:
-        ep_id = flow.get("entry_point", "?")
-        sink_id = flow.get("sink", "?")
+        ep_id = _sid(flow.get("entry_point", "?"))
+        sink_id = _sid(flow.get("sink", "?"))
         reason = _sanitize(flow.get("missing_boundary", "no check"))
         lines.append(f"    {ep_id} -. \"{reason}\" .-> {sink_id}")
 

--- a/packages/diagram/sanitize.py
+++ b/packages/diagram/sanitize.py
@@ -1,8 +1,12 @@
-"""Mermaid label sanitizer — shared across all diagram renderers."""
+"""Mermaid label and ID sanitizer — shared across all diagram renderers."""
+
+import re
 
 # Default max length for a single line within a node label.
 # Individual renderers can pass a different value or None to disable.
 DEFAULT_MAX_LEN = 80
+
+_SAFE_ID_RE = re.compile(r'[^A-Za-z0-9_-]')
 
 
 def sanitize(text: str, max_len: int = None) -> str:
@@ -25,3 +29,15 @@ def sanitize(text: str, max_len: int = None) -> str:
     if max_len and len(result) > max_len:
         result = result[:max_len - 3] + "..."
     return result
+
+
+def sanitize_id(node_id: str) -> str:
+    """Sanitize a Mermaid node ID to prevent markup injection.
+
+    Node IDs (unlike labels) are not quoted in Mermaid syntax, so a crafted
+    ID can inject arbitrary Mermaid directives including click callbacks
+    that execute JavaScript when rendered in a browser.
+
+    Strips everything except [A-Za-z0-9_-].
+    """
+    return _SAFE_ID_RE.sub('_', str(node_id)) or "node"

--- a/packages/fuzzing/afl_runner.py
+++ b/packages/fuzzing/afl_runner.py
@@ -516,7 +516,8 @@ class AFLRunner:
                 return {}
 
         try:
-            env = os.environ.copy()
+            from core.config import RaptorConfig
+            env = RaptorConfig.get_safe_env()
             if self.input_mode == "file" and test_input:
                 env['AFL_INPUT_FILE'] = str(test_input)
 
@@ -525,6 +526,7 @@ class AFLRunner:
                 capture_output=True,
                 text=True,
                 stdin=stdin_input,
+                close_fds=True,
                 cwd=str(self.output_dir),
                 env=env,
             )

--- a/packages/llm_analysis/cc_dispatch.py
+++ b/packages/llm_analysis/cc_dispatch.py
@@ -78,10 +78,11 @@ def write_debug(
     try:
         debug_dir = out_dir / "debug"
         debug_dir.mkdir(parents=True, exist_ok=True)
-        debug_file = debug_dir / f"cc_{finding_id}.txt"
+        safe_id = Path(finding_id).name.replace("..", "_") if finding_id else "unknown"
+        debug_file = debug_dir / f"cc_{safe_id}.txt"
         debug_file.write_text(f"STDOUT:\n{stdout or '(empty)'}\n\nSTDERR:\n{stderr or '(empty)'}")
         # Relative path so it works regardless of output dir location
-        result["cc_debug_file"] = f"debug/cc_{finding_id}.txt"
+        result["cc_debug_file"] = f"debug/cc_{safe_id}.txt"
     except OSError:
         pass  # Best effort — don't fail the finding over a debug file
 

--- a/packages/llm_analysis/llm/client.py
+++ b/packages/llm_analysis/llm/client.py
@@ -58,9 +58,8 @@ def _sanitize_log_message(msg: str) -> str:
     msg = re.sub(r'pk-[a-zA-Z0-9-_]{20,}', '[REDACTED-API-KEY]', msg)
     # Redact Google API keys (AIza*)
     msg = re.sub(r'AIza[a-zA-Z0-9-_]{30,}', '[REDACTED-API-KEY]', msg)
-    # Redact Bearer tokens (Mistral and others in error messages)
+    # Redact Bearer tokens (Mistral and others in auth headers/error messages)
     msg = re.sub(r'Bearer [a-zA-Z0-9-_]{20,}', 'Bearer [REDACTED]', msg)
-    # TODO: Add patterns for other providers as needed (new key formats, etc.)
     return msg
 
 

--- a/packages/llm_analysis/llm/config.py
+++ b/packages/llm_analysis/llm/config.py
@@ -618,7 +618,7 @@ class LLMConfig:
     max_cost_per_scan: float = 10.0  # USD
 
     def to_file(self, config_path: Path) -> None:
-        """Save configuration to JSON file."""
+        """Save configuration to JSON file with restrictive permissions."""
         from core.json import save_json
         primary = None
         if self.primary_model:
@@ -629,7 +629,7 @@ class LLMConfig:
         save_json(config_path, {
             "primary_model": primary,
             "fallback_enabled": self.enable_fallback,
-        })
+        }, mode=0o600)
 
     def get_model_for_task(self, task_type: str) -> ModelConfig:
         """Get the appropriate model for a specific task type."""

--- a/packages/llm_analysis/llm/detection.py
+++ b/packages/llm_analysis/llm/detection.py
@@ -210,10 +210,9 @@ def _try_auto_migrate(old_config: Path, new_config: Path) -> bool:
         if not models:
             return False
 
-        # Write new config
+        # Write new config with restrictive permissions atomically
         from core.json import save_json
-        save_json(new_config, {"models": models})
-        os.chmod(new_config, 0o600)
+        save_json(new_config, {"models": models}, mode=0o600)
 
         # Check if any keys need attention
         needs_keys = any(

--- a/packages/llm_analysis/prompts/exploit.py
+++ b/packages/llm_analysis/prompts/exploit.py
@@ -38,7 +38,7 @@ def build_exploit_prompt(
 - Severity: {level}
 
 **Analysis:**
-{json.dumps(analysis, indent=2)}
+{json.dumps(analysis, indent=2)[:10000]}
 """
 
     if feasibility:

--- a/packages/llm_analysis/prompts/patch.py
+++ b/packages/llm_analysis/prompts/patch.py
@@ -37,7 +37,7 @@ def build_patch_prompt(
 - Description: {message}
 
 **Analysis:**
-{json.dumps(analysis, indent=2)}
+{json.dumps(analysis, indent=2)[:10000]}
 """
 
     if feasibility:

--- a/packages/recon/agent.py
+++ b/packages/recon/agent.py
@@ -17,6 +17,8 @@ def get_out_dir() -> Path:
 def sha256_tree(root: Path) -> str:
     h = hashlib.sha256()
     for p in sorted(root.rglob("*")):
+        if p.is_symlink():
+            continue
         if p.is_file():
             h.update(p.relative_to(root).as_posix().encode())
             with p.open("rb") as f:
@@ -25,13 +27,12 @@ def sha256_tree(root: Path) -> str:
     return h.hexdigest()
 
 def safe_clone(url: str, dest: Path):
-    env = os.environ.copy()
+    from core.config import RaptorConfig
+    env = RaptorConfig.get_safe_env()
     env.update({
         "GIT_TERMINAL_PROMPT": "0",
         "GIT_ASKPASS": "true",
     })
-    for k in ["HTTP_PROXY","HTTPS_PROXY","NO_PROXY","http_proxy","https_proxy","no_proxy"]:
-        env.pop(k, None)
     cmd = ["git","clone","--depth","1","--no-tags",url,str(dest)]
     p = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=600)
     if p.returncode != 0:

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -38,7 +38,7 @@ def run(cmd, cwd=None, timeout=RaptorConfig.DEFAULT_TIMEOUT, env=None):
     p = subprocess.run(
         cmd,
         cwd=cwd,
-        env=env or os.environ.copy(),
+        env=env or RaptorConfig.get_safe_env(),
         text=True,
         capture_output=True,
         timeout=timeout,
@@ -127,8 +127,8 @@ def run_single_semgrep(
         str(repo_path),
     ]
 
-    # Create clean environment without venv contamination
-    clean_env = os.environ.copy()
+    # Create clean environment without venv contamination or dangerous vars
+    clean_env = RaptorConfig.get_safe_env()
     clean_env.pop('VIRTUAL_ENV', None)
     clean_env.pop('PYTHONPATH', None)
     # Remove venv from PATH

--- a/plugins/coverage/libexec/raptor-hook-read
+++ b/plugins/coverage/libexec/raptor-hook-read
@@ -60,8 +60,10 @@ case "$FILE_PATH" in
     *$'\n'*|*$'\r'*) exit 0 ;;
 esac
 
-# Skip files outside the target directory
+# Resolve symlinks before prefix check to prevent traversal
+FILE_PATH=$(realpath "$FILE_PATH" 2>/dev/null) || exit 0
 if [ -n "$PROJECT_TARGET" ]; then
+    PROJECT_TARGET=$(realpath "$PROJECT_TARGET" 2>/dev/null) || exit 0
     case "$FILE_PATH" in
         "$PROJECT_TARGET"*) ;;
         *) exit 0 ;;

--- a/raptor.py
+++ b/raptor.py
@@ -120,7 +120,8 @@ def _run_script(script_path: Path, args: list) -> int:
     cmd = [sys.executable, str(script_path)] + args
     
     try:
-        result = subprocess.run(cmd)
+        from core.config import RaptorConfig
+        result = subprocess.run(cmd, env=RaptorConfig.get_safe_env())
         return result.returncode
     except KeyboardInterrupt:
         print("\n\nInterrupted by user")

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -76,7 +76,8 @@ def run_command_streaming(cmd: list, description: str) -> tuple[int, str, str]:
             stderr=subprocess.PIPE,
             text=True,
             bufsize=1,  # Line buffered
-            universal_newlines=True
+            universal_newlines=True,
+            env=RaptorConfig.get_safe_env()
         )
 
         stdout_lines = []
@@ -276,60 +277,71 @@ Examples:
         print(f"Error: Repository not found: {repo_path}")
         sys.exit(1)
 
+    # Track temp git copy for cleanup
+    _git_temp_dir = None
+    # Keep original target path for metadata/findings (even if we scan a temp copy)
+    original_repo_path = repo_path
+
     # Check for .git directory (required for semgrep)
     git_dir = repo_path / ".git"
     if not git_dir.exists():
         print(f"\n  No .git directory found in {repo_path}")
-        print(f"    Semgrep requires the directory to be a git repository.")
-        print(f"\n[*] Initializing git repository...")
-        logger.info(f"Initializing git repository in {repo_path}")
-        
+        print(f"    Semgrep requires a git repository. Creating a temporary copy...")
+        logger.info(f"Target {repo_path} is not a git repo — creating temp copy")
+
         try:
-            # Initialize git repo
+            import shutil
+            import tempfile
+            temp_dir = Path(tempfile.mkdtemp(prefix="raptor_git_"))
+            _git_temp_dir = temp_dir
+            temp_repo = temp_dir / repo_path.name
+            # Copy symlinks as-is, don't follow them into files outside the repo
+            shutil.copytree(str(repo_path), str(temp_repo), symlinks=True)
+
+            env = RaptorConfig.get_safe_env()
+            env.update({
+                "GIT_TERMINAL_PROMPT": "0",
+                # Prevent git hooks and filters from executing on untrusted content
+                "GIT_CONFIG_GLOBAL": "/dev/null",
+                "GIT_CONFIG_SYSTEM": "/dev/null",
+            })
+            # Disable hooks and filters — a malicious .gitattributes filter
+            # directive would otherwise execute arbitrary commands during git add
+            git_safe = ["-c", "core.hooksPath=/dev/null",
+                        "-c", "filter.lfs.clean=true",
+                        "-c", "filter.lfs.smudge=true",
+                        "-c", "filter.lfs.process=true"]
             result = subprocess.run(
-                ["git", "init"],
-                cwd=repo_path,
-                capture_output=True,
-                text=True,
-                timeout=30
+                ["git"] + git_safe + ["init"], cwd=temp_repo,
+                capture_output=True, text=True, timeout=30, env=env
             )
-            
             if result.returncode == 0:
-                print(f"✓ Git repository initialized successfully")
-                logger.info("Git repository initialized")
-                
-                # Add all files to git
                 subprocess.run(
-                    ["git", "add", "."],
-                    cwd=repo_path,
-                    capture_output=True,
-                    timeout=60
+                    ["git"] + git_safe + ["add", "."], cwd=temp_repo,
+                    capture_output=True, timeout=60, env=env
                 )
-                
-                # Create initial commit
                 subprocess.run(
-                    ["git", "commit", "-m", "Initial commit for RAPTOR scan"],
-                    cwd=repo_path,
-                    capture_output=True,
-                    timeout=60
+                    ["git"] + git_safe + ["commit", "-m", "RAPTOR scan snapshot"],
+                    cwd=temp_repo, capture_output=True, timeout=60, env=env
                 )
-                print(f"✓ Initial commit created")
-                logger.info("Initial commit created")
+                repo_path = temp_repo
+                print(f"  Temporary git repo created at {temp_repo}")
+                logger.info(f"Using temp git repo: {temp_repo}")
             else:
-                print(f" Failed to initialize git repository: {result.stderr}")
+                print(f"  Failed to initialize git repository: {result.stderr}")
                 logger.error(f"Git init failed: {result.stderr}")
                 sys.exit(1)
-                
+
         except subprocess.TimeoutExpired:
-            print(f" Git initialization timed out")
+            print(f"  Git initialization timed out")
             logger.error("Git init timeout")
             sys.exit(1)
         except FileNotFoundError:
-            print(f" Git is not installed. Please install git and try again.")
+            print(f"  Git is not installed. Please install git and try again.")
             logger.error("Git not found in PATH")
             sys.exit(1)
         except Exception as e:
-            print(f" Error initializing git: {e}")
+            print(f"  Error initializing git: {e}")
             logger.error(f"Git init error: {e}")
             sys.exit(1)
 
@@ -341,7 +353,7 @@ Examples:
 
     try:
         from core.run import start_run
-        start_run(out_dir, "agentic", target=str(repo_path))
+        start_run(out_dir, "agentic", target=str(original_repo_path))
     except Exception as e:
         logger.debug(f"Run metadata: {e}")  # Optional — don't fail the pipeline
 
@@ -349,7 +361,7 @@ Examples:
     logger.info("RAPTOR AGENTIC WORKFLOW STARTED")
     logger.info("=" * 70)
     logger.info(f"Repository: {repo_name}")
-    logger.info(f"Full path: {repo_path}")
+    logger.info(f"Full path: {original_repo_path}")
     logger.info(f"Output: {out_dir}")
     logger.info(f"Policy groups: {args.policy_groups}")
     logger.info(f"Max findings: {args.max_findings}")
@@ -409,7 +421,7 @@ Examples:
     # ========================================================================
     # PRE-SCAN: Check target repo for malicious Claude Code settings
     # ========================================================================
-    block_cc_dispatch = _check_repo_claude_settings(repo_path)
+    block_cc_dispatch = _check_repo_claude_settings(original_repo_path)
 
     # ========================================================================
     # PHASE 1: CODE SCANNING (Semgrep + CodeQL)
@@ -422,7 +434,7 @@ Examples:
     try:
         from core.inventory import build_inventory
         if not (out_dir / "checklist.json").exists():
-            build_inventory(str(repo_path), str(out_dir))
+            build_inventory(str(original_repo_path), str(out_dir))
             logger.info(f"Inventory checklist built: {out_dir / 'checklist.json'}")
     except Exception as e:
         logger.warning(f"Inventory build failed (continuing without metadata): {e}")
@@ -451,6 +463,7 @@ Examples:
         logger.info(f"Running: Scanning code with Semgrep")
         semgrep_proc = subprocess.Popen(
             semgrep_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            env=RaptorConfig.get_safe_env(),
         )
 
     if run_codeql:
@@ -464,6 +477,8 @@ Examples:
         if args.languages:
             codeql_cmd.extend(["--languages", args.languages])
         if args.build_command:
+            # SECURITY: build_command is shell-evaluated. Must be operator-supplied,
+            # never derived from repo content (malicious Makefiles, etc.)
             codeql_cmd.extend(["--build-command", args.build_command])
         if args.extended:
             codeql_cmd.append("--extended")
@@ -472,6 +487,7 @@ Examples:
         logger.info(f"Running: Scanning code with CodeQL")
         codeql_proc = subprocess.Popen(
             codeql_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            env=RaptorConfig.get_safe_env(),
         )
 
     # ---- Collect Semgrep results ----
@@ -587,7 +603,7 @@ Examples:
     from packages.exploitability_validation import run_validation_phase
 
     validation_result, validated_findings = run_validation_phase(
-        repo_path=str(repo_path),
+        repo_path=str(original_repo_path),
         out_dir=out_dir,
         sarif_files=sarif_files,
         total_findings=total_findings,
@@ -695,7 +711,7 @@ Examples:
             from packages.llm_analysis.orchestrator import orchestrate
             orchestration_result = orchestrate(
                 prep_report_path=analysis_report,
-                repo_path=repo_path,
+                repo_path=original_repo_path,
                 out_dir=out_dir,
                 max_parallel=args.max_parallel,
                 max_findings=args.max_findings,
@@ -721,7 +737,7 @@ Examples:
 
     final_report = {
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "repository": str(repo_path),
+        "repository": str(original_repo_path),
         "duration_seconds": workflow_duration,
         "tools_used": {
             "semgrep": not args.codeql_only,
@@ -1063,6 +1079,15 @@ Examples:
         })
     except Exception as e:
         logger.debug(f"Run metadata: {e}")  # Optional — don't fail the pipeline
+
+    # Clean up temporary git copy (if we created one for a non-git target)
+    if _git_temp_dir and _git_temp_dir.exists():
+        import shutil
+        try:
+            shutil.rmtree(str(_git_temp_dir))
+            logger.debug(f"Cleaned up temp git dir: {_git_temp_dir}")
+        except Exception as e:
+            logger.debug(f"Failed to clean temp git dir: {e}")
 
 
 from core.schema_constants import VULN_TYPE_TO_CWE as _CWE_FROM_VULN_TYPE


### PR DESCRIPTION
**Summary**
  
  Addresses a bunch of largely hypothetical findings from internal security review. All fixes are defensive - sanitize and continue, never crash the pipeline.
  
  **Environment sanitisation:**
  - Enforce get_safe_env() for all subprocess calls (raptor.py, scanner.py,
    raptor_agentic.py, recon/agent.py, exploit_validator.py, afl_runner.py)                                                                                                                                        
  - Expand dangerous env var blocklist: add IFS, CDPATH, BASH_ENV, ENV,                                                                                                                                            
    PROMPT_COMMAND, LD_PRELOAD, LD_LIBRARY_PATH, PYTHONSTARTUP, PERL5OPT,                                                                                                                                          
    RUBYOPT, NODE_OPTIONS                                                                                                                                                                                          
  - Filter build_system.env_vars through blocklist before re-injecting into                                                                                                                                        
    CodeQL environment (prevents re-injection of stripped vars)                                                                                                                                                    
  - close_fds=True on AFL subprocess to prevent FD leakage  
                                                                                                                                                                                                                   
  **Path traversal / symlink prevention:**                  
  - Sanitize finding_id in cc_dispatch debug file paths                                                                                                                                                            
  - Sanitize exploit_name in exploit_validator file paths                                                                                                                                                          
  - Skip symlinks in inventory builder os.walk (files and directories)                                                                                                                                             
  - Skip symlinks in recon sha256_tree rglob                                                                                                                                                                       
  - copytree with symlinks=True (copy as symlinks, don't follow)                                                                                                                                                   
  - Coverage hook: realpath before prefix check (bash version)                                                                                                                                                     
  - Coverage track_read: path-level containment check with realpath,                                                                                                                                               
    not string startswith (Python version)                                                                                                                                                                         
                                                                                                                                                                                                                   
  **Target repo protection:**                                                                                                                                                                                      
  - Non-git targets: temp copy with git hooks and filters disabled                                                                                                                                                 
    (core.hooksPath=/dev/null, GIT_CONFIG_GLOBAL=/dev/null, filter.lfs neutered)                                                                                                                                   
  - Original target path preserved in all metadata, findings, and reports                                                                                                                                          
  - Temp copy cleaned up after run completes                                                                                                                                                                       
                                                                                                                                                                                                                   
  **Mermaid diagram injection:**                                                                                                                                                                                   
  - sanitize_id() strips node IDs to [A-Za-z0-9_-] in context_map.py and
    attack_tree.py — prevents XSS via Mermaid.js click callbacks                                                                                                                                                   
                                                                                                                                                                                                                   
  **TOCTOU fixes:**                                                                                                                                                                                                
  - SARIF loader: read-then-check-size replaces stat-then-read                                                                                                                                                     
  - Project .active symlink: atomic create-temp-then-rename                                                                                                                                                        
                                                                                                                                                                                                                   
  **Credential protection:**                                                                                                                                                                                       
  - models.json permission warning on startup if group/world-readable                                                                                                                                              
  - save_json(mode=0o600) for atomic restrictive file permissions                                                                                                                                                  
  - Auto-migration and LLMConfig.to_file() use atomic permissions                                                                                                                                                  
                                                                                                                                                                                                                   
  **Input bounds:**                                                                                                                                                                                                
  - Prompt templates truncate analysis dicts to 10K chars                          