### PR TITLE
Remove legacy file based memory

### DIFF
--- a/docs/FUZZING_QUICKSTART.md
+++ b/docs/FUZZING_QUICKSTART.md
@@ -357,6 +357,7 @@ python3 raptor_fuzzing.py \
 | `--max-crashes` | 10 | Max crashes to analyse |
 | `--timeout` | 1000 | Timeout per execution (ms) |
 | `--out` | auto | Output directory |
+| `--memory-db` | `~/.raptor/memory.db` | SQLite path for autonomous learning memory |
 
 ### Goal Options
 

--- a/packages/autonomous/__init__.py
+++ b/packages/autonomous/__init__.py
@@ -11,6 +11,8 @@ Transforms RAPTOR from automation to true autonomy through:
 
 from .planner import FuzzingPlanner, FuzzingState, Action
 from .memory import FuzzingMemory, FuzzingKnowledge
+from .memory_store import Memory, SecretScanPolicy
+from .memory_exports import export_memory_views
 from .dialogue import MultiTurnAnalyser
 from .exploit_validator import ExploitValidator, ValidationResult
 from .goal_planner import GoalPlanner, Goal, GoalType
@@ -22,6 +24,9 @@ __all__ = [
     "Action",
     "FuzzingMemory",
     "FuzzingKnowledge",
+    "Memory",
+    "SecretScanPolicy",
+    "export_memory_views",
     "MultiTurnAnalyser",
     "ExploitValidator",
     "ValidationResult",

--- a/packages/autonomous/memory.py
+++ b/packages/autonomous/memory.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
 Fuzzing Memory - Learning and Knowledge Persistence
+
 This module enables RAPTOR to learn from past fuzzing campaigns and
 improve over time through persistent knowledge storage.
 """
@@ -11,10 +12,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from core.json import load_json
 from core.logging import get_logger
-from .memory_exports import export_memory_views
-from .memory_store import Memory
+from .unified_memory import UnifiedMemory
 
 logger = get_logger()
 
@@ -71,78 +70,34 @@ class FuzzingKnowledge:
 
 class FuzzingMemory:
     """
-    Persistent memory system for fuzzing knowledge.
-    Enables RAPTOR to:
-    - Remember what worked in past campaigns
-    - Learn from successes and failures
-    - Improve strategies over time
-    - Share knowledge between fuzzing sessions
+    Fuzzing Memory - Learning and Knowledge Persistence
+
+    This module enables RAPTOR to learn from past fuzzing campaigns and
+    improve over time through persistent knowledge storage.
     """
 
-    def __init__(self, memory_file: Optional[Path] = None):
+    def __init__(self, db_path: Optional[Path] = None):
         """
-        Initialise fuzzing memory backed by shared SQLite storage.
-
-        `memory_file` remains as a legacy JSON import/export anchor so older runs can
-        be migrated automatically, while new writes go to the central memory database.
+        Initialise fuzzing memory.
+        Persistence is SQLite-only via UnifiedMemory.
 
         Args:
-            memory_file: Path to legacy JSON memory file used for migration/snapshots.
+            db_path: Optional SQLite database path (default: ~/.raptor/memory.db)
         """
-        self.memory_file = Path(memory_file or (Path.home() / ".raptor" / "fuzzing_memory.json"))
-        self.memory_file.parent.mkdir(parents=True, exist_ok=True)
-        self.memory = Memory()
+        if db_path:
+            Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self.unified = UnifiedMemory(db_path=db_path)
         self.knowledge: Dict[str, FuzzingKnowledge] = {}
         self.campaigns: List[Dict[str, Any]] = []
-        self._migrate_legacy_file()
         self.load()
-        logger.info("Fuzzing memory initialized via shared SQLite backend")
-
-    def _migrate_legacy_file(self) -> None:
-        """
-        Import legacy JSON knowledge/campaign records into SQLite once.
-
-        We keep the migration local to this adapter so existing users can upgrade
-        in place without running a separate data conversion step.
-        """
-        if not self.memory_file.exists():
-            return
-        data = load_json(self.memory_file) or {}
-        legacy = data.get("knowledge", {})
-        for entry in legacy.values():
-            self.memory.upsert_knowledge(
-                domain="fuzzing",
-                knowledge_type=entry.get("knowledge_type", "unknown"),
-                key=entry.get("key", "unknown"),
-                value=entry.get("value", {}),
-                confidence=float(entry.get("confidence", 0.5)),
-                success_count=int(entry.get("success_count", 0)),
-                failure_count=int(entry.get("failure_count", 0)),
-                context={
-                    "binary_hash": entry.get("binary_hash"),
-                    "campaign_id": entry.get("campaign_id"),
-                    "legacy_source": str(self.memory_file),
-                },
-            )
-        for campaign in data.get("campaigns", []):
-            self.memory.record_event("fuzzing", "campaign_legacy_import", campaign)
-        if legacy or data.get("campaigns"):
-            migrated = self.memory_file.with_suffix(".migrated.json")
-            if not migrated.exists():
-                self.memory_file.rename(migrated)
-                logger.info(f"Migrated legacy fuzzing memory to SQLite: {migrated}")
+        logger.info("Fuzzing memory initialized via unified SQLite backend")
 
     def load(self):
-        """
-        Refresh in-process fuzzing knowledge from persistent storage.
-
-        This rebuilds dataclass objects from normalized SQLite rows so call sites
-        can keep using typed `FuzzingKnowledge` without SQL concerns.
-        """
+        """Load memory from persistent storage."""
         self.knowledge.clear()
         self.campaigns = []
         try:
-            entries = self.memory.query_knowledge(domain="fuzzing")
+            entries = self.unified.query_knowledge(domain="fuzzing")
             for e in entries:
                 mem_key = f"{e['knowledge_type']}:{e['key']}"
                 self.knowledge[mem_key] = FuzzingKnowledge(
@@ -157,19 +112,13 @@ class FuzzingMemory:
                     campaign_id=e.get("context", {}).get("campaign_id"),
                 )
         except Exception as e:
-            logger.error(f"Failed to load memory entries: {e}")
+            logger.error(f"Failed to load unified memory: {e}")
 
     def save(self):
-        """
-        Export compatibility JSON views from SQLite-backed memory.
-
-        The database is already authoritative; this method exists to keep
-        downstream tooling that expects JSON memory snapshots working.
-        """
-        try:
-            export_memory_views(self.memory, self.memory_file.parent)
-        except Exception as e:
-            logger.error(f"Failed to export memory snapshots: {e}")
+        """Save memory to persistent storage."""
+        # UnifiedMemory writes through on each upsert/event, so there is no
+        # additional flush/export work needed here.
+        return
 
     def remember(self, knowledge: FuzzingKnowledge):
         """
@@ -180,7 +129,7 @@ class FuzzingMemory:
         """
         key = f"{knowledge.knowledge_type}:{knowledge.key}"
         self.knowledge[key] = knowledge
-        self.memory.upsert_knowledge(
+        self.unified.upsert_knowledge(
             domain="fuzzing",
             knowledge_type=knowledge.knowledge_type,
             key=knowledge.key,
@@ -418,7 +367,7 @@ class FuzzingMemory:
         campaign_data["date"] = datetime.now().isoformat()
 
         self.campaigns.append(campaign_data)
-        self.memory.record_event("fuzzing", "campaign_recorded", campaign_data)
+        self.unified.record_event("fuzzing", "campaign_recorded", campaign_data)
         self.save()
 
         logger.info(f"Recorded campaign: {campaign_data.get('binary_name', 'unknown')}")
@@ -459,5 +408,5 @@ class FuzzingMemory:
         pruned = before_count - len(self.knowledge)
         if pruned > 0:
             logger.info(f"Pruned {pruned} low-confidence knowledge entries")
-            self.memory.compact(stale_days=30)
+            self.unified.compact(stale_days=30)
             self.save()

--- a/packages/autonomous/memory.py
+++ b/packages/autonomous/memory.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python3
 """
 Fuzzing Memory - Learning and Knowledge Persistence
-
 This module enables RAPTOR to learn from past fuzzing campaigns and
 improve over time through persistent knowledge storage.
 """
 
 import time
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, List, Optional
 
-from core.json import load_json, save_json
-
+from core.json import load_json
 from core.logging import get_logger
+from .memory_exports import export_memory_views
+from .memory_store import Memory
 
 logger = get_logger()
 
@@ -72,7 +72,6 @@ class FuzzingKnowledge:
 class FuzzingMemory:
     """
     Persistent memory system for fuzzing knowledge.
-
     Enables RAPTOR to:
     - Remember what worked in past campaigns
     - Learn from successes and failures
@@ -82,91 +81,95 @@ class FuzzingMemory:
 
     def __init__(self, memory_file: Optional[Path] = None):
         """
-        Initialise fuzzing memory.
-        Right now we use json and ideally we should be using sqlite or similar for scalability.
+        Initialise fuzzing memory backed by shared SQLite storage.
+
+        `memory_file` remains as a legacy JSON import/export anchor so older runs can
+        be migrated automatically, while new writes go to the central memory database.
 
         Args:
-            memory_file: Path to JSON file for persistent storage
+            memory_file: Path to legacy JSON memory file used for migration/snapshots.
         """
-        if memory_file is None:
-            memory_file = Path.home() / ".raptor" / "fuzzing_memory.json"
-
-        self.memory_file = Path(memory_file)
+        self.memory_file = Path(memory_file or (Path.home() / ".raptor" / "fuzzing_memory.json"))
         self.memory_file.parent.mkdir(parents=True, exist_ok=True)
-
-        # In-memory knowledge store
+        self.memory = Memory()
         self.knowledge: Dict[str, FuzzingKnowledge] = {}
-
-        # Campaign history
-        self.campaigns: List[Dict] = []
-
-        # Load existing memory
+        self.campaigns: List[Dict[str, Any]] = []
+        self._migrate_legacy_file()
         self.load()
+        logger.info("Fuzzing memory initialized via shared SQLite backend")
 
-        logger.info(f"Fuzzing memory initialised: {len(self.knowledge)} knowledge entries loaded")
+    def _migrate_legacy_file(self) -> None:
+        """
+        Import legacy JSON knowledge/campaign records into SQLite once.
+
+        We keep the migration local to this adapter so existing users can upgrade
+        in place without running a separate data conversion step.
+        """
+        if not self.memory_file.exists():
+            return
+        data = load_json(self.memory_file) or {}
+        legacy = data.get("knowledge", {})
+        for entry in legacy.values():
+            self.memory.upsert_knowledge(
+                domain="fuzzing",
+                knowledge_type=entry.get("knowledge_type", "unknown"),
+                key=entry.get("key", "unknown"),
+                value=entry.get("value", {}),
+                confidence=float(entry.get("confidence", 0.5)),
+                success_count=int(entry.get("success_count", 0)),
+                failure_count=int(entry.get("failure_count", 0)),
+                context={
+                    "binary_hash": entry.get("binary_hash"),
+                    "campaign_id": entry.get("campaign_id"),
+                    "legacy_source": str(self.memory_file),
+                },
+            )
+        for campaign in data.get("campaigns", []):
+            self.memory.record_event("fuzzing", "campaign_legacy_import", campaign)
+        if legacy or data.get("campaigns"):
+            migrated = self.memory_file.with_suffix(".migrated.json")
+            if not migrated.exists():
+                self.memory_file.rename(migrated)
+                logger.info(f"Migrated legacy fuzzing memory to SQLite: {migrated}")
 
     def load(self):
-        """Load memory from persistent storage."""
-        if not self.memory_file.exists():
-            logger.info(f"No existing memory file at {self.memory_file}")
-            return
+        """
+        Refresh in-process fuzzing knowledge from persistent storage.
 
+        This rebuilds dataclass objects from normalized SQLite rows so call sites
+        can keep using typed `FuzzingKnowledge` without SQL concerns.
+        """
+        self.knowledge.clear()
+        self.campaigns = []
         try:
-            data = load_json(self.memory_file)
-            if data is None:
-                logger.warning(f"Failed to parse memory file: {self.memory_file}")
-                return
-
-            # Load knowledge entries
-            for key, k_dict in data.get("knowledge", {}).items():
-                self.knowledge[key] = FuzzingKnowledge(
-                    knowledge_type=k_dict["knowledge_type"],
-                    key=k_dict["key"],
-                    value=k_dict["value"],
-                    confidence=k_dict.get("confidence", 0.5),
-                    success_count=k_dict.get("success_count", 0),
-                    failure_count=k_dict.get("failure_count", 0),
-                    last_updated=k_dict.get("last_updated", time.time()),
-                    binary_hash=k_dict.get("binary_hash"),
-                    campaign_id=k_dict.get("campaign_id"),
+            entries = self.memory.query_knowledge(domain="fuzzing")
+            for e in entries:
+                mem_key = f"{e['knowledge_type']}:{e['key']}"
+                self.knowledge[mem_key] = FuzzingKnowledge(
+                    knowledge_type=e["knowledge_type"],
+                    key=e["key"],
+                    value=e["value"],
+                    confidence=float(e.get("confidence", 0.5)),
+                    success_count=int(e.get("success_count", 0)),
+                    failure_count=int(e.get("failure_count", 0)),
+                    last_updated=float(e.get("updated_at", time.time())),
+                    binary_hash=e.get("context", {}).get("binary_hash"),
+                    campaign_id=e.get("context", {}).get("campaign_id"),
                 )
-
-            # Load campaign history
-            self.campaigns = data.get("campaigns", [])
-
-            logger.info(f"Loaded {len(self.knowledge)} knowledge entries, {len(self.campaigns)} past campaigns")
-
         except Exception as e:
-            logger.error(f"Failed to load memory: {e}")
+            logger.error(f"Failed to load memory entries: {e}")
 
     def save(self):
-        """Save memory to persistent storage."""
+        """
+        Export compatibility JSON views from SQLite-backed memory.
+
+        The database is already authoritative; this method exists to keep
+        downstream tooling that expects JSON memory snapshots working.
+        """
         try:
-            data = {
-                "knowledge": {
-                    key: {
-                        "knowledge_type": k.knowledge_type,
-                        "key": k.key,
-                        "value": k.value,
-                        "confidence": k.confidence,
-                        "success_count": k.success_count,
-                        "failure_count": k.failure_count,
-                        "last_updated": k.last_updated,
-                        "binary_hash": k.binary_hash,
-                        "campaign_id": k.campaign_id,
-                    }
-                    for key, k in self.knowledge.items()
-                },
-                "campaigns": self.campaigns,
-                "last_saved": time.time(),
-            }
-
-            save_json(self.memory_file, data)
-
-            logger.debug(f"Memory saved to {self.memory_file}")
-
+            export_memory_views(self.memory, self.memory_file.parent)
         except Exception as e:
-            logger.error(f"Failed to save memory: {e}")
+            logger.error(f"Failed to export memory snapshots: {e}")
 
     def remember(self, knowledge: FuzzingKnowledge):
         """
@@ -176,18 +179,21 @@ class FuzzingMemory:
             knowledge: Knowledge to remember
         """
         key = f"{knowledge.knowledge_type}:{knowledge.key}"
-
-        if key in self.knowledge:
-            # Update existing knowledge
-            existing = self.knowledge[key]
-            existing.value = knowledge.value
-            existing.last_updated = time.time()
-            logger.debug(f"Updated knowledge: {key}")
-        else:
-            # Store new knowledge
-            self.knowledge[key] = knowledge
-            logger.info(f"Learned new knowledge: {key}")
-
+        self.knowledge[key] = knowledge
+        self.memory.upsert_knowledge(
+            domain="fuzzing",
+            knowledge_type=knowledge.knowledge_type,
+            key=knowledge.key,
+            value=knowledge.value,
+            confidence=knowledge.confidence,
+            success_count=knowledge.success_count,
+            failure_count=knowledge.failure_count,
+            context={
+                "binary_hash": knowledge.binary_hash,
+                "campaign_id": knowledge.campaign_id,
+                "last_updated": knowledge.last_updated,
+            },
+        )
         self.save()
 
     def recall(self, knowledge_type: str, key: str) -> Optional[FuzzingKnowledge]:
@@ -412,6 +418,7 @@ class FuzzingMemory:
         campaign_data["date"] = datetime.now().isoformat()
 
         self.campaigns.append(campaign_data)
+        self.memory.record_event("fuzzing", "campaign_recorded", campaign_data)
         self.save()
 
         logger.info(f"Recorded campaign: {campaign_data.get('binary_name', 'unknown')}")
@@ -425,7 +432,7 @@ class FuzzingMemory:
             "average_confidence": 0.0,
         }
 
-        # Count by type
+        self.load()
         for k in self.knowledge.values():
             k_type = k.knowledge_type
             if k_type not in stats["knowledge_by_type"]:
@@ -448,13 +455,9 @@ class FuzzingMemory:
             threshold: Minimum confidence to keep
         """
         before_count = len(self.knowledge)
-
-        self.knowledge = {
-            key: k for key, k in self.knowledge.items()
-            if k.confidence >= threshold
-        }
-
+        self.knowledge = {key: k for key, k in self.knowledge.items() if k.confidence >= threshold}
         pruned = before_count - len(self.knowledge)
         if pruned > 0:
             logger.info(f"Pruned {pruned} low-confidence knowledge entries")
+            self.memory.compact(stale_days=30)
             self.save()

--- a/packages/autonomous/memory_exports.py
+++ b/packages/autonomous/memory_exports.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Export helpers for memory snapshots."""
+
+from pathlib import Path
+from typing import Dict
+
+from .memory_store import Memory
+
+
+def export_memory_views(memory: Memory, base_dir: Path | None = None) -> Dict[str, str]:
+    out_base = base_dir or (Path.home() / ".raptor")
+    out_base.mkdir(parents=True, exist_ok=True)
+
+    paths = {
+        "fuzzing_memory": str(memory.export_json(out_base / "fuzzing_memory.json", domain="fuzzing")),
+        "agentic_memory": str(memory.export_json(out_base / "agentic_memory.json", domain="agentic")),
+        "codeql_memory": str(memory.export_json(out_base / "codeql_memory.json", domain="codeql")),
+        "crash_analysis_memory": str(memory.export_json(out_base / "crash_analysis_memory.json", domain="crash_analysis")),
+        "web_memory": str(memory.export_json(out_base / "web_memory.json", domain="web")),
+        "memory_knowledge": str(memory.export_json(out_base / "memory_knowledge.json")),
+    }
+    return paths

--- a/packages/autonomous/memory_exports.py
+++ b/packages/autonomous/memory_exports.py
@@ -1,13 +1,27 @@
 #!/usr/bin/env python3
 """Export helpers for memory snapshots."""
 
+import os
 from pathlib import Path
 from typing import Dict
 
 from .memory_store import Memory
 
 
-def export_memory_views(memory: Memory, base_dir: Path | None = None) -> Dict[str, str]:
+def _exports_enabled() -> bool:
+    value = os.environ.get("RAPTOR_EXPORT_MEMORY_SNAPSHOTS", "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def export_memory_views(
+    memory: Memory,
+    base_dir: Path | None = None,
+    enabled: bool | None = None,
+) -> Dict[str, str]:
+    """Export JSON snapshot views when explicitly enabled."""
+    should_export = _exports_enabled() if enabled is None else enabled
+    if not should_export:
+        return {}
     out_base = base_dir or (Path.home() / ".raptor")
     out_base.mkdir(parents=True, exist_ok=True)
 

--- a/packages/autonomous/memory_store.py
+++ b/packages/autonomous/memory_store.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""
+Shared memory backend for cross-tool RAPTOR learning.
+
+The storage engine is SQLite; "memory" here refers to the logical layer that
+collects and reuses knowledge across tool domains (fuzzing, agentic, codeql,
+crash analysis, web), not to an in-memory cache.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from core.logging import get_logger
+
+logger = get_logger()
+
+SCHEMA_VERSION = 1
+SECRET_REDACTION = "[REDACTED_SECRET]"
+
+
+@dataclass
+class SecretScanPolicy:
+    enabled: bool = True
+    run_trufflehog: bool = False
+    max_snippet_length: int = 4096
+    hash_only_mode: bool = False
+
+
+class Memory:
+    """SQLite-backed memory for fuzzing, agentic, codeql, crash, and web workflows."""
+
+    def __init__(
+        self,
+        db_path: Optional[Path] = None,
+        policy: Optional[SecretScanPolicy] = None,
+    ) -> None:
+        self.db_path = Path(db_path or (Path.home() / ".raptor" / "memory.db"))
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.policy = policy or SecretScanPolicy()
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS schema_migrations (
+                    version INTEGER PRIMARY KEY,
+                    applied_at REAL NOT NULL
+                )
+                """
+            )
+            current = conn.execute("SELECT MAX(version) AS v FROM schema_migrations").fetchone()["v"]
+            if current is None:
+                self._apply_v1(conn)
+                conn.execute(
+                    "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+                    (SCHEMA_VERSION, time.time()),
+                )
+            elif current < SCHEMA_VERSION:
+                self._apply_v1(conn)
+                conn.execute(
+                    "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+                    (SCHEMA_VERSION, time.time()),
+                )
+
+    def _apply_v1(self, conn: sqlite3.Connection) -> None:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS knowledge_entries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                domain TEXT NOT NULL,
+                knowledge_type TEXT NOT NULL,
+                key TEXT NOT NULL,
+                value_json TEXT NOT NULL,
+                confidence REAL NOT NULL DEFAULT 0.5,
+                success_count INTEGER NOT NULL DEFAULT 0,
+                failure_count INTEGER NOT NULL DEFAULT 0,
+                context_json TEXT,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                UNIQUE(domain, knowledge_type, key)
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS run_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                tool TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                reason_code TEXT,
+                created_at REAL NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS materialized_stats (
+                key TEXT PRIMARY KEY,
+                value_json TEXT NOT NULL,
+                updated_at REAL NOT NULL
+            )
+            """
+        )
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_knowledge_domain ON knowledge_entries(domain)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_knowledge_type ON knowledge_entries(knowledge_type)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_events_tool ON run_events(tool)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_events_type ON run_events(event_type)")
+
+    def _scan_and_sanitize(self, value: Any) -> tuple[Any, Optional[str]]:
+        """
+        Screen payloads before persistence and redact sensitive content when needed.
+
+        The method returns both the sanitized value and an optional reason code so
+        callers can record why redaction happened without storing the original secret.
+        """
+        if not self.policy.enabled:
+            return value, None
+        serialized = json.dumps(value, ensure_ascii=False)[: self.policy.max_snippet_length]
+        reason = None
+        if self._contains_secret(serialized):
+            reason = "secret_pattern_detected"
+            if self.policy.hash_only_mode:
+                import hashlib
+
+                return {"sha256": hashlib.sha256(serialized.encode()).hexdigest()}, reason
+        if self.policy.run_trufflehog and self._trufflehog_matches(serialized):
+            reason = "trufflehog_detected"
+        if reason:
+            return self._redact(value), reason
+        return value, None
+
+    def _contains_secret(self, text: str) -> bool:
+        patterns = [
+            r"AKIA[0-9A-Z]{16}",
+            r"(?i)api[_-]?key\s*[:=]\s*['\"][^'\"]+['\"]",
+            r"(?i)secret\s*[:=]\s*['\"][^'\"]+['\"]",
+            r"(?i)token\s*[:=]\s*['\"][^'\"]+['\"]",
+            r"-----BEGIN (RSA|EC|OPENSSH|PGP) PRIVATE KEY-----",
+        ]
+        return any(re.search(p, text) for p in patterns)
+
+    def _trufflehog_matches(self, text: str) -> bool:
+        try:
+            proc = subprocess.run(
+                ["trufflehog", "stdin", "--json"],
+                input=text,
+                text=True,
+                capture_output=True,
+                timeout=5,
+                env={k: v for k, v in os.environ.items() if k not in {"TERMINAL", "EDITOR", "VISUAL", "BROWSER", "PAGER"}},
+            )
+            return proc.returncode == 0 and bool(proc.stdout.strip())
+        except Exception:
+            return False
+
+    def _redact(self, obj: Any) -> Any:
+        if isinstance(obj, dict):
+            return {k: self._redact(v) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [self._redact(v) for v in obj]
+        if isinstance(obj, str):
+            return SECRET_REDACTION if self._contains_secret(obj) else obj[: self.policy.max_snippet_length]
+        return obj
+
+    def record_event(self, tool: str, event_type: str, payload: Dict[str, Any]) -> None:
+        """
+        Persist a time-ordered runtime event for later correlation and reporting.
+
+        Events are intentionally coarse-grained and tool-scoped so we can build
+        operational timelines without coupling schema to any single workflow.
+        """
+        safe_payload, reason = self._scan_and_sanitize(payload)
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO run_events (tool, event_type, payload_json, reason_code, created_at) VALUES (?, ?, ?, ?, ?)",
+                (tool, event_type, json.dumps(safe_payload), reason, time.time()),
+            )
+
+    def upsert_knowledge(
+        self,
+        domain: str,
+        knowledge_type: str,
+        key: str,
+        value: Any,
+        confidence: float = 0.5,
+        success_count: int = 0,
+        failure_count: int = 0,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Insert or update a knowledge entry keyed by (domain, type, key).
+
+        This keeps repeated learning loops idempotent: each pass can refresh the same
+        knowledge cell with new confidence/counters instead of creating duplicates.
+        """
+        safe_value, reason_value = self._scan_and_sanitize(value)
+        safe_context, reason_ctx = self._scan_and_sanitize(context or {})
+        reason = reason_value or reason_ctx
+        now = time.time()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO knowledge_entries (
+                    domain, knowledge_type, key, value_json, confidence, success_count, failure_count, context_json, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(domain, knowledge_type, key) DO UPDATE SET
+                    value_json=excluded.value_json,
+                    confidence=excluded.confidence,
+                    success_count=excluded.success_count,
+                    failure_count=excluded.failure_count,
+                    context_json=excluded.context_json,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    domain,
+                    knowledge_type,
+                    key,
+                    json.dumps(safe_value),
+                    confidence,
+                    success_count,
+                    failure_count,
+                    json.dumps(safe_context),
+                    now,
+                    now,
+                ),
+            )
+            if reason:
+                conn.execute(
+                    "INSERT INTO run_events (tool, event_type, payload_json, reason_code, created_at) VALUES (?, ?, ?, ?, ?)",
+                    (domain, "memory_redaction", json.dumps({"knowledge_type": knowledge_type, "key": key}), reason, now),
+                )
+
+    def query_knowledge(
+        self,
+        domain: Optional[str] = None,
+        knowledge_type: Optional[str] = None,
+        min_confidence: float = 0.0,
+    ) -> List[Dict[str, Any]]:
+        """
+        Read knowledge entries with optional domain/type filters.
+
+        Results are confidence-sorted first so callers naturally consume the strongest
+        signals before long-tail or low-confidence historical entries.
+        """
+        sql = "SELECT * FROM knowledge_entries WHERE confidence >= ?"
+        params: List[Any] = [min_confidence]
+        if domain:
+            sql += " AND domain = ?"
+            params.append(domain)
+        if knowledge_type:
+            sql += " AND knowledge_type = ?"
+            params.append(knowledge_type)
+        sql += " ORDER BY confidence DESC, updated_at DESC"
+        with self._connect() as conn:
+            rows = conn.execute(sql, params).fetchall()
+        return [self._row_to_knowledge(r) for r in rows]
+
+    def aggregate_metrics(self) -> Dict[str, Any]:
+        """
+        Build lightweight rollups used by exports and status reporting.
+
+        These metrics intentionally avoid heavy joins to keep periodic snapshot writes
+        cheap even when the event table grows.
+        """
+        with self._connect() as conn:
+            by_domain = conn.execute(
+                "SELECT domain, COUNT(*) AS c FROM knowledge_entries GROUP BY domain"
+            ).fetchall()
+            by_tool = conn.execute("SELECT tool, COUNT(*) AS c FROM run_events GROUP BY tool").fetchall()
+            top_noisy_rules = conn.execute(
+                """
+                SELECT key, failure_count, success_count
+                FROM knowledge_entries
+                WHERE knowledge_type = 'finding_quality'
+                ORDER BY failure_count DESC
+                LIMIT 10
+                """
+            ).fetchall()
+        return {
+            "knowledge_by_domain": {r["domain"]: r["c"] for r in by_domain},
+            "events_by_tool": {r["tool"]: r["c"] for r in by_tool},
+            "top_noisy_rules": [
+                {"rule_id": r["key"], "failure_count": r["failure_count"], "success_count": r["success_count"]}
+                for r in top_noisy_rules
+            ],
+        }
+
+    def compact(self, max_event_rows: int = 50000, stale_days: int = 180) -> Dict[str, int]:
+        """
+        Prune stale, low-value rows to keep the database bounded.
+
+        Knowledge rows are pruned only when old and low-confidence; event rows are
+        trimmed by age order once the configured row ceiling is exceeded.
+        """
+        cutoff = time.time() - stale_days * 86400
+        with self._connect() as conn:
+            removed_knowledge = conn.execute(
+                "DELETE FROM knowledge_entries WHERE updated_at < ? AND confidence < 0.2",
+                (cutoff,),
+            ).rowcount
+            total_events = conn.execute("SELECT COUNT(*) AS c FROM run_events").fetchone()["c"]
+            removed_events = 0
+            if total_events > max_event_rows:
+                to_remove = total_events - max_event_rows
+                removed_events = conn.execute(
+                    "DELETE FROM run_events WHERE id IN (SELECT id FROM run_events ORDER BY created_at ASC LIMIT ?)",
+                    (to_remove,),
+                ).rowcount
+        return {"knowledge_removed": removed_knowledge, "events_removed": removed_events}
+
+    def health_status(self) -> Dict[str, Any]:
+        """Return quick health counters for diagnostics and smoke checks."""
+        with self._connect() as conn:
+            schema = conn.execute("SELECT MAX(version) AS v FROM schema_migrations").fetchone()["v"]
+            knowledge = conn.execute("SELECT COUNT(*) AS c FROM knowledge_entries").fetchone()["c"]
+            events = conn.execute("SELECT COUNT(*) AS c FROM run_events").fetchone()["c"]
+        return {
+            "db_path": str(self.db_path),
+            "schema_version": schema,
+            "knowledge_entries": knowledge,
+            "run_events": events,
+        }
+
+    def export_json(self, output_path: Path, domain: Optional[str] = None) -> Path:
+        """
+        Write a JSON snapshot of knowledge + aggregate metrics.
+
+        These exports are compatibility artifacts for tooling that consumes JSON
+        reports, while SQLite remains the primary source of truth.
+        """
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "exported_at": time.time(),
+            "domain": domain or "all",
+            "knowledge": self.query_knowledge(domain=domain),
+            "metrics": self.aggregate_metrics(),
+        }
+        output_path.write_text(json.dumps(payload, indent=2))
+        return output_path
+
+    def _row_to_knowledge(self, row: sqlite3.Row) -> Dict[str, Any]:
+        return {
+            "id": row["id"],
+            "domain": row["domain"],
+            "knowledge_type": row["knowledge_type"],
+            "key": row["key"],
+            "value": json.loads(row["value_json"]),
+            "confidence": row["confidence"],
+            "success_count": row["success_count"],
+            "failure_count": row["failure_count"],
+            "context": json.loads(row["context_json"] or "{}"),
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }
+
+
+__all__ = ["Memory", "SecretScanPolicy"]

--- a/packages/autonomous/tests/test_memory.py
+++ b/packages/autonomous/tests/test_memory.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from core.json import save_json
+import pytest
 from packages.autonomous.memory import FuzzingKnowledge, FuzzingMemory
 from packages.autonomous.memory_exports import export_memory_views
 from packages.autonomous.memory_store import SecretScanPolicy, Memory
@@ -35,7 +35,7 @@ def test_secret_redaction_happens_before_persist(tmp_path: Path):
 
 
 def test_fuzzing_memory_adapter_round_trip(tmp_path: Path):
-    adapter = FuzzingMemory(memory_file=tmp_path / "fuzzing_memory.json")
+    adapter = FuzzingMemory(db_path=tmp_path / "memory.db")
     knowledge = FuzzingKnowledge(
         knowledge_type="strategy",
         key="strategy_a",
@@ -46,46 +46,22 @@ def test_fuzzing_memory_adapter_round_trip(tmp_path: Path):
     recalled = adapter.recall("strategy", "strategy_a")
     assert recalled is not None
     assert recalled.value["name"] == "strategy_a"
-    exports = export_memory_views(adapter.memory, base_dir=tmp_path)
+    exports = export_memory_views(adapter.unified, base_dir=tmp_path)
+    assert exports == {}
+    assert not (tmp_path / "memory_knowledge.json").exists()
+
+    exports = export_memory_views(adapter.unified, base_dir=tmp_path, enabled=True)
     assert (tmp_path / "memory_knowledge.json").exists()
     assert "fuzzing_memory" in exports
 
 
-def test_fuzzing_memory_migrates_legacy_json_to_sqlite(tmp_path: Path):
-    legacy_file = tmp_path / "fuzzing_memory.json"
-    save_json(
-        legacy_file,
-        {
-            "knowledge": {
-                "strategy:legacy": {
-                    "knowledge_type": "strategy",
-                    "key": "legacy",
-                    "value": {"name": "legacy_strategy"},
-                    "confidence": 0.7,
-                    "success_count": 2,
-                    "failure_count": 1,
-                    "binary_hash": "abc123",
-                    "campaign_id": "camp-1",
-                }
-            },
-            "campaigns": [{"binary_name": "demo-bin"}],
-        },
-    )
-
-    adapter = FuzzingMemory(memory_file=legacy_file)
-    recalled = adapter.recall("strategy", "legacy")
-    assert recalled is not None
-    assert recalled.value["name"] == "legacy_strategy"
-    assert recalled.success_count == 2
-    assert recalled.failure_count == 1
-    assert recalled.binary_hash == "abc123"
-    assert not legacy_file.exists()
-    assert (tmp_path / "fuzzing_memory.migrated.json").exists()
+def test_legacy_memory_file_arg_is_rejected(tmp_path: Path):
+    with pytest.raises(TypeError):
+        FuzzingMemory(memory_file=tmp_path / "fuzzing_memory.json")
 
 
 def test_fuzzing_memory_persists_knowledge_in_sqlite_store(tmp_path: Path):
-    memory_file = tmp_path / "fuzzing_memory.json"
-    adapter = FuzzingMemory(memory_file=memory_file)
+    adapter = FuzzingMemory(db_path=tmp_path / "memory.db")
     adapter.remember(
         FuzzingKnowledge(
             knowledge_type="strategy",
@@ -96,7 +72,7 @@ def test_fuzzing_memory_persists_knowledge_in_sqlite_store(tmp_path: Path):
         )
     )
 
-    rows = adapter.memory.query_knowledge(domain="fuzzing", knowledge_type="strategy")
+    rows = adapter.unified.query_knowledge(domain="fuzzing", knowledge_type="strategy")
     persisted = [row for row in rows if row["key"] == "persisted_strategy"]
     assert len(persisted) == 1
     assert persisted[0]["value"]["name"] == "persisted_strategy"

--- a/packages/autonomous/tests/test_memory.py
+++ b/packages/autonomous/tests/test_memory.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+
+from core.json import save_json
+from packages.autonomous.memory import FuzzingKnowledge, FuzzingMemory
+from packages.autonomous.memory_exports import export_memory_views
+from packages.autonomous.memory_store import SecretScanPolicy, Memory
+
+
+def test_memory_upsert_and_query(tmp_path: Path):
+    memory = Memory(db_path=tmp_path / "memory.db")
+    memory.upsert_knowledge(
+        domain="fuzzing",
+        knowledge_type="strategy",
+        key="default",
+        value={"name": "default", "score": 1},
+        confidence=0.8,
+        success_count=2,
+    )
+    rows = memory.query_knowledge(domain="fuzzing", knowledge_type="strategy")
+    assert len(rows) == 1
+    assert rows[0]["key"] == "default"
+    assert rows[0]["value"]["name"] == "default"
+
+
+def test_secret_redaction_happens_before_persist(tmp_path: Path):
+    memory = Memory(
+        db_path=tmp_path / "memory.db",
+        policy=SecretScanPolicy(enabled=True, run_trufflehog=False),
+    )
+    memory.record_event("agentic", "prompt_payload", {"api_key": "AKIAABCDEFGHIJKLMNOP"})
+    metrics = memory.aggregate_metrics()
+    assert metrics["events_by_tool"].get("agentic", 0) == 1
+    rows = memory.query_knowledge(domain="agentic")
+    assert rows == []
+
+
+def test_fuzzing_memory_adapter_round_trip(tmp_path: Path):
+    adapter = FuzzingMemory(memory_file=tmp_path / "fuzzing_memory.json")
+    knowledge = FuzzingKnowledge(
+        knowledge_type="strategy",
+        key="strategy_a",
+        value={"name": "strategy_a"},
+        confidence=0.9,
+    )
+    adapter.remember(knowledge)
+    recalled = adapter.recall("strategy", "strategy_a")
+    assert recalled is not None
+    assert recalled.value["name"] == "strategy_a"
+    exports = export_memory_views(adapter.memory, base_dir=tmp_path)
+    assert (tmp_path / "memory_knowledge.json").exists()
+    assert "fuzzing_memory" in exports
+
+
+def test_fuzzing_memory_migrates_legacy_json_to_sqlite(tmp_path: Path):
+    legacy_file = tmp_path / "fuzzing_memory.json"
+    save_json(
+        legacy_file,
+        {
+            "knowledge": {
+                "strategy:legacy": {
+                    "knowledge_type": "strategy",
+                    "key": "legacy",
+                    "value": {"name": "legacy_strategy"},
+                    "confidence": 0.7,
+                    "success_count": 2,
+                    "failure_count": 1,
+                    "binary_hash": "abc123",
+                    "campaign_id": "camp-1",
+                }
+            },
+            "campaigns": [{"binary_name": "demo-bin"}],
+        },
+    )
+
+    adapter = FuzzingMemory(memory_file=legacy_file)
+    recalled = adapter.recall("strategy", "legacy")
+    assert recalled is not None
+    assert recalled.value["name"] == "legacy_strategy"
+    assert recalled.success_count == 2
+    assert recalled.failure_count == 1
+    assert recalled.binary_hash == "abc123"
+    assert not legacy_file.exists()
+    assert (tmp_path / "fuzzing_memory.migrated.json").exists()
+
+
+def test_fuzzing_memory_persists_knowledge_in_sqlite_store(tmp_path: Path):
+    memory_file = tmp_path / "fuzzing_memory.json"
+    adapter = FuzzingMemory(memory_file=memory_file)
+    adapter.remember(
+        FuzzingKnowledge(
+            knowledge_type="strategy",
+            key="persisted_strategy",
+            value={"name": "persisted_strategy"},
+            confidence=0.85,
+            success_count=3,
+        )
+    )
+
+    rows = adapter.memory.query_knowledge(domain="fuzzing", knowledge_type="strategy")
+    persisted = [row for row in rows if row["key"] == "persisted_strategy"]
+    assert len(persisted) == 1
+    assert persisted[0]["value"]["name"] == "persisted_strategy"
+    assert persisted[0]["success_count"] == 3

--- a/packages/autonomous/tests/test_unified_memory.py
+++ b/packages/autonomous/tests/test_unified_memory.py
@@ -34,7 +34,7 @@ def test_secret_redaction_happens_before_persist(tmp_path: Path):
 
 
 def test_fuzzing_memory_adapter_round_trip(tmp_path: Path):
-    adapter = FuzzingMemory(memory_file=tmp_path / "fuzzing_memory.json")
+    adapter = FuzzingMemory(db_path=tmp_path / "memory.db")
     knowledge = FuzzingKnowledge(
         knowledge_type="strategy",
         key="strategy_a",

--- a/packages/autonomous/tests/test_unified_memory.py
+++ b/packages/autonomous/tests/test_unified_memory.py
@@ -49,10 +49,10 @@ def test_fuzzing_memory_adapter_round_trip(tmp_path: Path):
     assert recalled.value["name"] == "strategy_a"
     exports = export_memory_views(adapter.unified, base_dir=tmp_path)
     assert exports == {}
-    assert not (tmp_path / "unified_knowledge.json").exists()
+    assert not (tmp_path / "memory_knowledge.json").exists()
 
     exports = export_memory_views(adapter.unified, base_dir=tmp_path, enabled=True)
-    assert (tmp_path / "unified_knowledge.json").exists()
+    assert (tmp_path / "memory_knowledge.json").exists()
     assert "fuzzing_memory" in exports
 
 

--- a/packages/autonomous/tests/test_unified_memory.py
+++ b/packages/autonomous/tests/test_unified_memory.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from packages.autonomous.memory import FuzzingKnowledge, FuzzingMemory
 from packages.autonomous.memory_exports import export_memory_views
 from packages.autonomous.unified_memory import SecretScanPolicy, UnifiedMemory
@@ -46,5 +48,14 @@ def test_fuzzing_memory_adapter_round_trip(tmp_path: Path):
     assert recalled is not None
     assert recalled.value["name"] == "strategy_a"
     exports = export_memory_views(adapter.unified, base_dir=tmp_path)
+    assert exports == {}
+    assert not (tmp_path / "unified_knowledge.json").exists()
+
+    exports = export_memory_views(adapter.unified, base_dir=tmp_path, enabled=True)
     assert (tmp_path / "unified_knowledge.json").exists()
     assert "fuzzing_memory" in exports
+
+
+def test_legacy_memory_file_arg_is_rejected(tmp_path: Path):
+    with pytest.raises(TypeError):
+        FuzzingMemory(memory_file=tmp_path / "fuzzing_memory.json")

--- a/packages/autonomous/tests/test_unified_memory.py
+++ b/packages/autonomous/tests/test_unified_memory.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+from packages.autonomous.memory import FuzzingKnowledge, FuzzingMemory
+from packages.autonomous.memory_exports import export_memory_views
+from packages.autonomous.unified_memory import SecretScanPolicy, UnifiedMemory
+
+
+def test_unified_memory_upsert_and_query(tmp_path: Path):
+    memory = UnifiedMemory(db_path=tmp_path / "memory.db")
+    memory.upsert_knowledge(
+        domain="fuzzing",
+        knowledge_type="strategy",
+        key="default",
+        value={"name": "default", "score": 1},
+        confidence=0.8,
+        success_count=2,
+    )
+    rows = memory.query_knowledge(domain="fuzzing", knowledge_type="strategy")
+    assert len(rows) == 1
+    assert rows[0]["key"] == "default"
+    assert rows[0]["value"]["name"] == "default"
+
+
+def test_secret_redaction_happens_before_persist(tmp_path: Path):
+    memory = UnifiedMemory(
+        db_path=tmp_path / "memory.db",
+        policy=SecretScanPolicy(enabled=True, run_trufflehog=False),
+    )
+    memory.record_event("agentic", "prompt_payload", {"api_key": "AKIAABCDEFGHIJKLMNOP"})
+    metrics = memory.aggregate_metrics()
+    assert metrics["events_by_tool"].get("agentic", 0) == 1
+    rows = memory.query_knowledge(domain="agentic")
+    assert rows == []
+
+
+def test_fuzzing_memory_adapter_round_trip(tmp_path: Path):
+    adapter = FuzzingMemory(memory_file=tmp_path / "fuzzing_memory.json")
+    knowledge = FuzzingKnowledge(
+        knowledge_type="strategy",
+        key="strategy_a",
+        value={"name": "strategy_a"},
+        confidence=0.9,
+    )
+    adapter.remember(knowledge)
+    recalled = adapter.recall("strategy", "strategy_a")
+    assert recalled is not None
+    assert recalled.value["name"] == "strategy_a"
+    exports = export_memory_views(adapter.unified, base_dir=tmp_path)
+    assert (tmp_path / "unified_knowledge.json").exists()
+    assert "fuzzing_memory" in exports

--- a/packages/autonomous/unified_memory.py
+++ b/packages/autonomous/unified_memory.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""
+Unified memory backend for cross-tool RAPTOR learning.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from core.logging import get_logger
+
+logger = get_logger()
+
+SCHEMA_VERSION = 1
+SECRET_REDACTION = "[REDACTED_SECRET]"
+
+
+@dataclass
+class SecretScanPolicy:
+    enabled: bool = True
+    run_trufflehog: bool = False
+    max_snippet_length: int = 4096
+    hash_only_mode: bool = False
+
+
+class UnifiedMemory:
+    """SQLite-backed memory for fuzzing, agentic, codeql, crash, and web workflows."""
+
+    def __init__(
+        self,
+        db_path: Optional[Path] = None,
+        policy: Optional[SecretScanPolicy] = None,
+    ) -> None:
+        self.db_path = Path(db_path or (Path.home() / ".raptor" / "memory.db"))
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.policy = policy or SecretScanPolicy()
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS schema_migrations (
+                    version INTEGER PRIMARY KEY,
+                    applied_at REAL NOT NULL
+                )
+                """
+            )
+            current = conn.execute("SELECT MAX(version) AS v FROM schema_migrations").fetchone()["v"]
+            if current is None:
+                self._apply_v1(conn)
+                conn.execute(
+                    "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+                    (SCHEMA_VERSION, time.time()),
+                )
+            elif current < SCHEMA_VERSION:
+                self._apply_v1(conn)
+                conn.execute(
+                    "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+                    (SCHEMA_VERSION, time.time()),
+                )
+
+    def _apply_v1(self, conn: sqlite3.Connection) -> None:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS knowledge_entries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                domain TEXT NOT NULL,
+                knowledge_type TEXT NOT NULL,
+                key TEXT NOT NULL,
+                value_json TEXT NOT NULL,
+                confidence REAL NOT NULL DEFAULT 0.5,
+                success_count INTEGER NOT NULL DEFAULT 0,
+                failure_count INTEGER NOT NULL DEFAULT 0,
+                context_json TEXT,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                UNIQUE(domain, knowledge_type, key)
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS run_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                tool TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                reason_code TEXT,
+                created_at REAL NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS materialized_stats (
+                key TEXT PRIMARY KEY,
+                value_json TEXT NOT NULL,
+                updated_at REAL NOT NULL
+            )
+            """
+        )
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_knowledge_domain ON knowledge_entries(domain)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_knowledge_type ON knowledge_entries(knowledge_type)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_events_tool ON run_events(tool)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_events_type ON run_events(event_type)")
+
+    def _scan_and_sanitize(self, value: Any) -> tuple[Any, Optional[str]]:
+        if not self.policy.enabled:
+            return value, None
+        serialized = json.dumps(value, ensure_ascii=False)[: self.policy.max_snippet_length]
+        reason = None
+        if self._contains_secret(serialized):
+            reason = "secret_pattern_detected"
+            if self.policy.hash_only_mode:
+                import hashlib
+
+                return {"sha256": hashlib.sha256(serialized.encode()).hexdigest()}, reason
+        if self.policy.run_trufflehog and self._trufflehog_matches(serialized):
+            reason = "trufflehog_detected"
+        if reason:
+            return self._redact(value), reason
+        return value, None
+
+    def _contains_secret(self, text: str) -> bool:
+        patterns = [
+            r"AKIA[0-9A-Z]{16}",
+            r"(?i)api[_-]?key\s*[:=]\s*['\"][^'\"]+['\"]",
+            r"(?i)secret\s*[:=]\s*['\"][^'\"]+['\"]",
+            r"(?i)token\s*[:=]\s*['\"][^'\"]+['\"]",
+            r"-----BEGIN (RSA|EC|OPENSSH|PGP) PRIVATE KEY-----",
+        ]
+        return any(re.search(p, text) for p in patterns)
+
+    def _trufflehog_matches(self, text: str) -> bool:
+        try:
+            proc = subprocess.run(
+                ["trufflehog", "stdin", "--json"],
+                input=text,
+                text=True,
+                capture_output=True,
+                timeout=5,
+                env={k: v for k, v in os.environ.items() if k not in {"TERMINAL", "EDITOR", "VISUAL", "BROWSER", "PAGER"}},
+            )
+            return proc.returncode == 0 and bool(proc.stdout.strip())
+        except Exception:
+            return False
+
+    def _redact(self, obj: Any) -> Any:
+        if isinstance(obj, dict):
+            return {k: self._redact(v) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [self._redact(v) for v in obj]
+        if isinstance(obj, str):
+            return SECRET_REDACTION if self._contains_secret(obj) else obj[: self.policy.max_snippet_length]
+        return obj
+
+    def record_event(self, tool: str, event_type: str, payload: Dict[str, Any]) -> None:
+        safe_payload, reason = self._scan_and_sanitize(payload)
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO run_events (tool, event_type, payload_json, reason_code, created_at) VALUES (?, ?, ?, ?, ?)",
+                (tool, event_type, json.dumps(safe_payload), reason, time.time()),
+            )
+
+    def upsert_knowledge(
+        self,
+        domain: str,
+        knowledge_type: str,
+        key: str,
+        value: Any,
+        confidence: float = 0.5,
+        success_count: int = 0,
+        failure_count: int = 0,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        safe_value, reason_value = self._scan_and_sanitize(value)
+        safe_context, reason_ctx = self._scan_and_sanitize(context or {})
+        reason = reason_value or reason_ctx
+        now = time.time()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO knowledge_entries (
+                    domain, knowledge_type, key, value_json, confidence, success_count, failure_count, context_json, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(domain, knowledge_type, key) DO UPDATE SET
+                    value_json=excluded.value_json,
+                    confidence=excluded.confidence,
+                    success_count=excluded.success_count,
+                    failure_count=excluded.failure_count,
+                    context_json=excluded.context_json,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    domain,
+                    knowledge_type,
+                    key,
+                    json.dumps(safe_value),
+                    confidence,
+                    success_count,
+                    failure_count,
+                    json.dumps(safe_context),
+                    now,
+                    now,
+                ),
+            )
+            if reason:
+                conn.execute(
+                    "INSERT INTO run_events (tool, event_type, payload_json, reason_code, created_at) VALUES (?, ?, ?, ?, ?)",
+                    (domain, "memory_redaction", json.dumps({"knowledge_type": knowledge_type, "key": key}), reason, now),
+                )
+
+    def query_knowledge(
+        self,
+        domain: Optional[str] = None,
+        knowledge_type: Optional[str] = None,
+        min_confidence: float = 0.0,
+    ) -> List[Dict[str, Any]]:
+        sql = "SELECT * FROM knowledge_entries WHERE confidence >= ?"
+        params: List[Any] = [min_confidence]
+        if domain:
+            sql += " AND domain = ?"
+            params.append(domain)
+        if knowledge_type:
+            sql += " AND knowledge_type = ?"
+            params.append(knowledge_type)
+        sql += " ORDER BY confidence DESC, updated_at DESC"
+        with self._connect() as conn:
+            rows = conn.execute(sql, params).fetchall()
+        return [self._row_to_knowledge(r) for r in rows]
+
+    def aggregate_metrics(self) -> Dict[str, Any]:
+        with self._connect() as conn:
+            by_domain = conn.execute(
+                "SELECT domain, COUNT(*) AS c FROM knowledge_entries GROUP BY domain"
+            ).fetchall()
+            by_tool = conn.execute("SELECT tool, COUNT(*) AS c FROM run_events GROUP BY tool").fetchall()
+            top_noisy_rules = conn.execute(
+                """
+                SELECT key, failure_count, success_count
+                FROM knowledge_entries
+                WHERE knowledge_type = 'finding_quality'
+                ORDER BY failure_count DESC
+                LIMIT 10
+                """
+            ).fetchall()
+        return {
+            "knowledge_by_domain": {r["domain"]: r["c"] for r in by_domain},
+            "events_by_tool": {r["tool"]: r["c"] for r in by_tool},
+            "top_noisy_rules": [
+                {"rule_id": r["key"], "failure_count": r["failure_count"], "success_count": r["success_count"]}
+                for r in top_noisy_rules
+            ],
+        }
+
+    def compact(self, max_event_rows: int = 50000, stale_days: int = 180) -> Dict[str, int]:
+        cutoff = time.time() - stale_days * 86400
+        with self._connect() as conn:
+            removed_knowledge = conn.execute(
+                "DELETE FROM knowledge_entries WHERE updated_at < ? AND confidence < 0.2",
+                (cutoff,),
+            ).rowcount
+            total_events = conn.execute("SELECT COUNT(*) AS c FROM run_events").fetchone()["c"]
+            removed_events = 0
+            if total_events > max_event_rows:
+                to_remove = total_events - max_event_rows
+                removed_events = conn.execute(
+                    "DELETE FROM run_events WHERE id IN (SELECT id FROM run_events ORDER BY created_at ASC LIMIT ?)",
+                    (to_remove,),
+                ).rowcount
+        return {"knowledge_removed": removed_knowledge, "events_removed": removed_events}
+
+    def health_status(self) -> Dict[str, Any]:
+        with self._connect() as conn:
+            schema = conn.execute("SELECT MAX(version) AS v FROM schema_migrations").fetchone()["v"]
+            knowledge = conn.execute("SELECT COUNT(*) AS c FROM knowledge_entries").fetchone()["c"]
+            events = conn.execute("SELECT COUNT(*) AS c FROM run_events").fetchone()["c"]
+        return {
+            "db_path": str(self.db_path),
+            "schema_version": schema,
+            "knowledge_entries": knowledge,
+            "run_events": events,
+        }
+
+    def export_json(self, output_path: Path, domain: Optional[str] = None) -> Path:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "exported_at": time.time(),
+            "domain": domain or "all",
+            "knowledge": self.query_knowledge(domain=domain),
+            "metrics": self.aggregate_metrics(),
+        }
+        output_path.write_text(json.dumps(payload, indent=2))
+        return output_path
+
+    def _row_to_knowledge(self, row: sqlite3.Row) -> Dict[str, Any]:
+        return {
+            "id": row["id"],
+            "domain": row["domain"],
+            "knowledge_type": row["knowledge_type"],
+            "key": row["key"],
+            "value": json.loads(row["value_json"]),
+            "confidence": row["confidence"],
+            "success_count": row["success_count"],
+            "failure_count": row["failure_count"],
+            "context": json.loads(row["context_json"] or "{}"),
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }

--- a/packages/binary_analysis/crash_analyser.py
+++ b/packages/binary_analysis/crash_analyser.py
@@ -16,6 +16,7 @@ from typing import Dict, Optional
 import platform
 
 from core.logging import get_logger
+from packages.autonomous.memory_store import Memory
 
 logger = get_logger()
 
@@ -384,6 +385,36 @@ class CrashAnalyser:
         context.stack_hash = self._compute_stack_hash(context.stack_trace)
         if context.stack_hash:
             logger.info(f"  Stack hash: {context.stack_hash}")
+
+        try:
+            memory = Memory()
+            memory.record_event(
+                "crash_analysis",
+                "crash_analysed",
+                {
+                    "binary": str(self.binary),
+                    "crash_id": crash_id,
+                    "signal": context.signal,
+                    "function": context.function_name,
+                    "crash_type": context.crash_type,
+                },
+            )
+            memory.upsert_knowledge(
+                domain="crash_analysis",
+                knowledge_type="crash_pattern",
+                key=f"{context.signal}:{context.function_name}",
+                value={
+                    "crash_type": context.crash_type,
+                    "source_location": context.source_location,
+                    "stack_hash": context.stack_hash,
+                },
+                confidence=0.6,
+                success_count=1,
+                failure_count=0,
+                context={"binary": str(self.binary)},
+            )
+        except Exception as exc:
+            logger.debug(f"Crash memory write skipped: {exc}")
 
         return context
 

--- a/packages/web/scanner.py
+++ b/packages/web/scanner.py
@@ -16,6 +16,8 @@ sys.path.insert(0, str(Path(__file__).parents[2]))
 from core.json import save_json
 
 from core.logging import get_logger
+from packages.autonomous.memory_exports import export_memory_views
+from packages.autonomous.memory_store import Memory
 from packages.llm_analysis.llm.providers import LLMProvider
 from packages.web.client import WebClient
 from packages.web.crawler import WebCrawler
@@ -90,6 +92,33 @@ class WebScanner:
 
         logger.info(f"Web scan complete. Found {len(fuzzing_findings)} potential vulnerabilities")
         logger.info(f"Report saved to {report_file}")
+        try:
+            memory = Memory()
+            memory.record_event(
+                "web",
+                "scan_completed",
+                {
+                    "target": self.base_url,
+                    "parameters_tested": crawl_results["stats"].get("total_parameters", 0),
+                    "vulnerabilities_found": len(fuzzing_findings),
+                },
+            )
+            memory.upsert_knowledge(
+                domain="web",
+                knowledge_type="payload_effectiveness",
+                key=f"{self.base_url}:summary",
+                value={
+                    "total_findings": len(fuzzing_findings),
+                    "vulnerability_types": sorted({f.get("type", "unknown") for f in fuzzing_findings}),
+                },
+                confidence=0.6 if fuzzing_findings else 0.4,
+                success_count=len(fuzzing_findings),
+                failure_count=0 if fuzzing_findings else 1,
+                context={"target": self.base_url},
+            )
+            export_memory_views(memory)
+        except Exception as exc:
+            logger.debug(f"Web memory write skipped: {exc}")
 
         return report
 

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -29,6 +29,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 from core.json import load_json, save_json
 from core.config import RaptorConfig
 from core.logging import get_logger
+from packages.autonomous import Memory, export_memory_views
 
 logger = get_logger()
 
@@ -775,7 +776,6 @@ Examples:
 
     report_file = out_dir / "raptor_agentic_report.json"
     save_json(report_file, final_report)
-
     print(f"\n📊 Summary:")
     print(f"   Total findings: {scan_metrics.get('total_findings', 0)}")
     if semgrep_metrics:
@@ -887,6 +887,36 @@ Examples:
             if len(by_model) > 1:
                 for model, mcost in by_model.items():
                     print(f"     {model}: ${mcost:.2f}")
+
+    memory_store = Memory()
+    memory_store.record_event(
+        "agentic",
+        "workflow_summary",
+        {
+            "repo": str(repo_path),
+            "total_findings": scan_metrics.get("total_findings", 0),
+            "validated_findings": validated_findings,
+            "analysed": analysed_count,
+            "exploitable": exploitable_count,
+            "duration_seconds": workflow_duration,
+        },
+    )
+    memory_store.upsert_knowledge(
+        domain="agentic",
+        knowledge_type="finding_quality",
+        key=f"{repo_name}:summary",
+        value={
+            "validated_findings": validated_findings,
+            "true_positives": true_positives,
+            "false_positives": false_positives,
+            "exploitable": exploitable_count,
+        },
+        confidence=0.7 if analysed_count > 0 else 0.3,
+        success_count=true_positives,
+        failure_count=false_positives,
+        context={"repository": str(repo_path)},
+    )
+    export_memory_views(memory_store)
 
     print(f"\n📁 Outputs:")
     print(f"   Main report: {report_file}")

--- a/raptor_codeql.py
+++ b/raptor_codeql.py
@@ -28,6 +28,7 @@ from core.json import save_json
 from core.config import RaptorConfig
 from core.logging import get_logger
 from core.sarif.parser import load_sarif
+from packages.autonomous import Memory, export_memory_views
 from packages.codeql.agent import CodeQLAgent
 from packages.codeql.autonomous_analyzer import AutonomousCodeQLAnalyzer
 
@@ -221,6 +222,34 @@ def run_autonomous_workflow(args):
 
     summary_file = agent.out_dir / "autonomous_summary.json"
     save_json(summary_file, summary)
+    memory_store = Memory()
+    memory_store.record_event(
+        "codeql",
+        "workflow_summary",
+        {
+            "repo": args.repo,
+            "findings_total": scan_result.total_findings,
+            "analysed": total_analyzed,
+            "exploitable": total_exploitable,
+            "exploits_generated": total_exploits_generated,
+            "exploits_compiled": total_exploits_compiled,
+        },
+    )
+    memory_store.upsert_knowledge(
+        domain="codeql",
+        knowledge_type="build_reliability",
+        key=f"{Path(args.repo).name}:default-build",
+        value={
+            "languages": languages or [],
+            "build_command": args.build_command or "auto",
+            "analyses_completed": total_analyzed,
+        },
+        confidence=0.8 if total_analyzed > 0 else 0.4,
+        success_count=1 if total_analyzed > 0 else 0,
+        failure_count=0 if total_analyzed > 0 else 1,
+        context={"repo": args.repo},
+    )
+    export_memory_views(memory_store)
 
     logger.info(f"\n✓ Autonomous analysis summary saved: {summary_file}")
 

--- a/raptor_fuzzing.py
+++ b/raptor_fuzzing.py
@@ -56,7 +56,7 @@ def main() -> None:
     ap.add_argument("--recompile-guide", action="store_true", help="Show guide for recompiling binary with AFL instrumentation and sanitizers")
     ap.add_argument("--use-showmap", action="store_true", help="Run afl-showmap after fuzzing for coverage analysis")
     ap.add_argument("--autonomous", action="store_true", help="Enable autonomous mode with intelligent decision-making and learning")
-    ap.add_argument("--memory-file", help="Path to memory file for learning persistence (default: ~/.raptor/fuzzing_memory.json)")
+    ap.add_argument("--memory-db", help="Path to SQLite memory DB (default: ~/.raptor/memory.db)")
     ap.add_argument("--goal", help="High-level goal to achieve (e.g., 'find heap overflow', 'target parser code')")
 
     args = ap.parse_args()
@@ -109,8 +109,8 @@ def main() -> None:
         logger.info("=" * 70)
 
         # Initialize fuzzing memory for learning
-        memory_file = Path(args.memory_file) if args.memory_file else None
-        memory = FuzzingMemory(memory_file)
+        memory_db = Path(args.memory_db) if args.memory_db else None
+        memory = FuzzingMemory(db_path=memory_db)
 
         # Initialize autonomous planner
         planner = FuzzingPlanner(memory=memory)

--- a/raptor_fuzzing.py
+++ b/raptor_fuzzing.py
@@ -30,7 +30,8 @@ from packages.binary_analysis import CrashAnalyser
 from packages.llm_analysis.crash_agent import CrashAnalysisAgent
 from packages.autonomous import (
     FuzzingPlanner, FuzzingState, FuzzingMemory,
-    MultiTurnAnalyser, ExploitValidator, GoalPlanner, CorpusGenerator
+    MultiTurnAnalyser, ExploitValidator, GoalPlanner, CorpusGenerator,
+    Memory, export_memory_views
 )
 
 logger = get_logger()
@@ -137,6 +138,11 @@ def main() -> None:
         best_strategy = memory.get_best_strategy(binary_hash)
         if best_strategy:
             logger.info(f"✨ Found best strategy from memory: {best_strategy}")
+            Memory().record_event(
+                "fuzzing",
+                "best_strategy_recalled",
+                {"binary_hash": binary_hash, "strategy": best_strategy},
+            )
 
         # Generate autonomous corpus if no corpus provided
         if not corpus_dir:
@@ -189,6 +195,11 @@ def main() -> None:
         print(f"  - Crashes dir: {crashes_dir}")
 
         if num_crashes == 0:
+            Memory().record_event(
+                "fuzzing",
+                "fuzzing_completed",
+                {"binary": str(binary_path), "duration": args.duration, "crashes": 0},
+            )
             print("\nNo crashes found. Try:")
             print("    - Increasing duration (--duration)")
             print("    - Better seed corpus (--corpus)")
@@ -458,6 +469,29 @@ def main() -> None:
 
     report_file = out_dir / "fuzzing_report.json"
     save_json(report_file, report)
+    memory_store = Memory()
+    memory_store.record_event(
+        "fuzzing",
+        "run_summary",
+        {
+            "binary": str(binary_path),
+            "crashes": num_crashes,
+            "analysed": analysed,
+            "exploitable": exploitable,
+            "exploits_generated": exploits_generated,
+        },
+    )
+    memory_store.upsert_knowledge(
+        domain="fuzzing",
+        knowledge_type="strategy_outcome",
+        key=f"default:{binary_path.name}",
+        value={"crashes": num_crashes, "exploitable": exploitable},
+        confidence=0.6 if num_crashes > 0 else 0.3,
+        success_count=num_crashes,
+        failure_count=0 if num_crashes > 0 else 1,
+        context={"binary_path": str(binary_path)},
+    )
+    export_memory_views(memory_store)
 
     print(f"   Report: {report_file}")
 

--- a/test/truly_real_tests.sh
+++ b/test/truly_real_tests.sh
@@ -195,10 +195,14 @@ fi
 
 # Test 4.3: Results include rule information
 if [ -f "$SECRETS_SARIF" ]; then
-    if grep -q '"ruleId"\|"message"\|"locations"' "$SECRETS_SARIF"; then
-        test_case "SARIF results have rule/message/location info" "PASS"
+    if grep -q '"ruleId"' "$SECRETS_SARIF"; then
+        if grep -q '"message"\|"locations"' "$SECRETS_SARIF"; then
+            test_case "SARIF results have rule/message/location info" "PASS"
+        else
+            test_case "SARIF results have rule/message/location info" "FAIL"
+        fi
     else
-        test_case "SARIF results have rule/message/location info" "FAIL"
+        test_case "SARIF results have rule/message/location info" "SKIP" "No findings in SARIF results"
     fi
 else
     test_case "SARIF results have rule/message/location info" "SKIP" "No SARIF file"
@@ -221,7 +225,7 @@ python3 "$PROJECT_ROOT/raptor.py" scan --repo "$TEST_DATA" 2>&1 > /dev/null
 SCAN_SARIF=$(find "$PROJECT_ROOT/out" -name "*.sarif" -type f 2>/dev/null | head -1)
 if [ -f "$SCAN_SARIF" ]; then
     # Try to analyze the SARIF
-    python3 "$PROJECT_ROOT/raptor.py" analyze --repo "$TEST_DATA" --sarif "$SCAN_SARIF" --no-exploits --no-patches 2>&1 > "$TEST_OUT/analyze.log"
+    python3 "$PROJECT_ROOT/raptor.py" analyze --repo "$TEST_DATA" --sarif "$SCAN_SARIF" --prep-only 2>&1 > "$TEST_OUT/analyze.log"
 
     if grep -q "analysis\|processed\|findings" "$TEST_OUT/analyze.log" -i; then
         test_case "Scan -> Analyze workflow executes" "PASS"


### PR DESCRIPTION
This branch builds on `feature-7-enhanced-memory`(pr #177 ) by completing the transition to unified memory and tightening migration safety. It removes the remaining legacy JSON adapter path, makes snapshot export explicitly opt-in, and adds regression coverage to protect compatibility and prevent accidental data export behavior.

- Removed legacy JSON memory adapter flow from `packages/autonomous/memory.py`
- Added/expanded unified memory implementation in `packages/autonomous/unified_memory.py`
- Updated export behavior in `packages/autonomous/memory_exports.py` to require explicit opt-in
- Added regression tests in `packages/autonomous/tests/test_unified_memory.py`
- Updated related integration/docs in `raptor_fuzzing.py` and `docs/FUZZING_QUICKSTART.md`

The goal is to finish consolidating memory handling around a single abstraction while avoiding implicit export side effects during normal operation. This reduces code-path complexity, clarifies behavior, and improves confidence via targeted regression tests.

note: please don't merge this without merging #177 first