### PR TITLE
binary_analysis: share GDB input validators, cap address length, validate num_bytes

### DIFF
--- a/packages/binary_analysis/_validators.py
+++ b/packages/binary_analysis/_validators.py
@@ -1,0 +1,58 @@
+"""Shared validators for binary-analysis inputs passed into subprocess tools.
+
+Consolidates the hex-address regex and byte-count bound so GDB, LLDB, and
+addr2line code paths can't drift apart. GDB scripts are newline-delimited,
+so \\n in any string field is an injection vector — every such field should
+route through here.
+"""
+
+import re
+
+# 1-16 hex digits fits every real architecture (64-bit max). Rejecting
+# unbounded length is defence-in-depth, not exploit-prevention.
+_HEX_ADDRESS_RE = re.compile(r'^0x[0-9a-fA-F]{1,16}$')
+
+# 4 KB: well above any realistic `x/Nxb` caller, small enough to prevent
+# a bad int from embedding megabytes of output request into a GDB script.
+_MAX_EXAMINE_BYTES = 4096
+
+
+def is_valid_hex_address(address) -> bool:
+    """Non-raising check for best-effort callers (e.g. symbol resolvers)."""
+    return isinstance(address, str) and bool(_HEX_ADDRESS_RE.match(address))
+
+
+def validate_hex_address(address, *, param_name: str = "address") -> None:
+    """Raise ValueError if address isn't 0x<1-16 hex digits>.
+
+    Non-str inputs are rejected up front so callers see one exception type.
+    """
+    if not isinstance(address, str):
+        raise ValueError(
+            f"Invalid {param_name} {address!r}: expected str, "
+            f"got {type(address).__name__}."
+        )
+    if not _HEX_ADDRESS_RE.match(address):
+        raise ValueError(
+            f"Invalid {param_name} {address!r}: expected 0x<1-16 hex digits>. "
+            "Arbitrary strings are rejected to prevent GDB script injection."
+        )
+
+
+def validate_byte_count(num_bytes, *, param_name: str = "num_bytes") -> None:
+    """Raise ValueError if num_bytes isn't an int in [1, _MAX_EXAMINE_BYTES].
+
+    Guards the f-string path in examine_memory(): a str like "64\\nshell id"
+    passed as num_bytes would otherwise be embedded verbatim into a GDB script.
+    bool is an int subclass in Python, so reject it explicitly.
+    """
+    if isinstance(num_bytes, bool) or not isinstance(num_bytes, int):
+        raise ValueError(
+            f"Invalid {param_name} {num_bytes!r}: expected int, "
+            f"got {type(num_bytes).__name__}."
+        )
+    if num_bytes < 1 or num_bytes > _MAX_EXAMINE_BYTES:
+        raise ValueError(
+            f"Invalid {param_name} {num_bytes}: must be between 1 "
+            f"and {_MAX_EXAMINE_BYTES}."
+        )

--- a/packages/binary_analysis/crash_analyser.py
+++ b/packages/binary_analysis/crash_analyser.py
@@ -16,6 +16,7 @@ from typing import Dict, Optional
 import platform
 
 from core.logging import get_logger
+from packages.binary_analysis._validators import is_valid_hex_address
 
 logger = get_logger()
 
@@ -186,7 +187,7 @@ class CrashAnalyser:
 
     def _resolve_address_to_function(self, address: str) -> str:
         """Resolve a hex address to function name using symbol table."""
-        if not address or not address.startswith("0x"):
+        if not is_valid_hex_address(address):
             return "unknown"
             
         try:
@@ -211,8 +212,8 @@ class CrashAnalyser:
         if not self._available_tools.get("addr2line", False):
             logger.debug("addr2line not available - skipping address resolution")
             return "unknown", "unknown"
-            
-        if not address or not address.startswith("0x"):
+
+        if not is_valid_hex_address(address):
             return "unknown", "unknown"
             
         try:

--- a/packages/binary_analysis/debugger.py
+++ b/packages/binary_analysis/debugger.py
@@ -8,10 +8,12 @@ Security: Input files are passed via subprocess stdin, NOT via GDB's
 `run < path` in-script redirection. This prevents CWE-78 command injection
 through crafted filenames (GDB's parser interprets shell metacharacters).
 
-Address validation: examine_memory() checks the address against
-0x[0-9a-fA-F]+ before writing it into the GDB script. GDB scripts are
-newline-delimited, so a \n injects a second command. GDB has a `shell`
-builtin. That's the bug.
+Address/size validation: examine_memory() routes `address` and `num_bytes`
+through packages.binary_analysis._validators before they land in a GDB
+script. GDB scripts are newline-delimited, so a \n in either field injects
+a second command. GDB has a `shell` builtin. That's the bug. The same
+validators are reused by crash_analyser.py's addr2line path so the two
+sinks can't drift apart.
 
 Not an active issue in RAPTOR right now. CrashAnalyser validates upstream
 and there's no call site that takes unvalidated input. But this is a public
@@ -19,15 +21,14 @@ export and doing it right costs nothing.
 """
 
 import os
-import re
 import subprocess
 from pathlib import Path
 from typing import List, Optional
 
-# Strict hex address pattern. Rejects anything that could inject GDB commands.
-# GDB scripts are newline-delimited, so a \n in an address is the injection vector.
-_HEX_ADDRESS_RE = re.compile(r'^0x[0-9a-fA-F]+$')
-
+from packages.binary_analysis._validators import (
+    validate_byte_count,
+    validate_hex_address,
+)
 from core.logging import get_logger
 
 logger = get_logger()
@@ -121,20 +122,18 @@ class GDBDebugger:
 
         Args:
             input_file: Crash input file fed to the binary via stdin.
-            address: Hex address to examine, e.g. "0xdeadbeef". Must match
-                     0x[0-9a-fA-F]+. GDB scripts are newline-delimited so a \\n
-                     in here injects a second command. GDB has a `shell` builtin.
-                     Yeah, not an issue today, but doing it right costs nothing.
-            num_bytes: Number of bytes to display.
+            address: Hex address, 0x<1-16 hex digits>. See _validators for
+                     the full threat model (GDB scripts are newline-delimited,
+                     so \\n here injects a second command).
+            num_bytes: Byte count, 1..4096. Embedded verbatim into the GDB
+                     script; validated to block str-disguised-as-int inputs
+                     like "64\\nshell id".
 
         Raises:
-            ValueError: If address does not match the expected hex pattern.
+            ValueError: If address or num_bytes fails validation.
         """
-        if not _HEX_ADDRESS_RE.match(address):
-            raise ValueError(
-                f"Invalid address {address!r}: expected 0x<hex digits>. "
-                "Arbitrary strings are rejected to prevent GDB script injection."
-            )
+        validate_hex_address(address)
+        validate_byte_count(num_bytes)
 
         commands = [
             "set pagination off",

--- a/packages/binary_analysis/tests/test_gdb_injection.py
+++ b/packages/binary_analysis/tests/test_gdb_injection.py
@@ -137,6 +137,60 @@ class TestExamineMemoryAddressValidation:
         with pytest.raises(ValueError, match="Invalid address"):
             debugger.examine_memory(input_file, "1234567890")
 
+    def test_overlong_address_rejected(self, debugger, tmp_path):
+        """Addresses over 16 hex digits (64-bit max) are rejected."""
+        input_file = tmp_path / "crash.bin"
+        input_file.write_text("data")
+        with pytest.raises(ValueError, match="Invalid address"):
+            debugger.examine_memory(input_file, "0x" + "f" * 17)
+
+    def test_non_string_address_rejected(self, debugger, tmp_path):
+        """Non-str addresses raise ValueError, not TypeError."""
+        input_file = tmp_path / "crash.bin"
+        input_file.write_text("data")
+        with pytest.raises(ValueError, match="Invalid address"):
+            debugger.examine_memory(input_file, 0xdeadbeef)
+        with pytest.raises(ValueError, match="Invalid address"):
+            debugger.examine_memory(input_file, None)
+
+
+class TestExamineMemoryByteCountValidation:
+    """num_bytes is embedded verbatim into the GDB script. Guard it."""
+
+    @pytest.fixture
+    def debugger(self, tmp_path):
+        from packages.binary_analysis.debugger import GDBDebugger
+        binary = tmp_path / "test_binary"
+        binary.write_text("fake")
+        return GDBDebugger(binary)
+
+    def test_newline_in_num_bytes_rejected(self, debugger, tmp_path):
+        """A str num_bytes with a newline would inject — reject."""
+        input_file = tmp_path / "crash.bin"
+        input_file.write_text("data")
+        with pytest.raises(ValueError, match="Invalid num_bytes"):
+            debugger.examine_memory(input_file, "0xdead", "64\nshell id")
+
+    def test_non_positive_rejected(self, debugger, tmp_path):
+        input_file = tmp_path / "crash.bin"
+        input_file.write_text("data")
+        for bad in [0, -1, -64]:
+            with pytest.raises(ValueError, match="Invalid num_bytes"):
+                debugger.examine_memory(input_file, "0xdead", bad)
+
+    def test_over_cap_rejected(self, debugger, tmp_path):
+        input_file = tmp_path / "crash.bin"
+        input_file.write_text("data")
+        with pytest.raises(ValueError, match="Invalid num_bytes"):
+            debugger.examine_memory(input_file, "0xdead", 4097)
+
+    def test_bool_rejected(self, debugger, tmp_path):
+        """bool is an int subclass; explicit reject."""
+        input_file = tmp_path / "crash.bin"
+        input_file.write_text("data")
+        with pytest.raises(ValueError, match="Invalid num_bytes"):
+            debugger.examine_memory(input_file, "0xdead", True)
+
 
 class TestDebuggerTempFile:
     """Verify debugger.py uses random temp files and cleans them up."""

--- a/packages/binary_analysis/tests/test_validators.py
+++ b/packages/binary_analysis/tests/test_validators.py
@@ -1,0 +1,73 @@
+"""Unit tests for packages.binary_analysis._validators."""
+
+import pytest
+
+from packages.binary_analysis._validators import (
+    is_valid_hex_address,
+    validate_byte_count,
+    validate_hex_address,
+)
+
+
+class TestIsValidHexAddress:
+    @pytest.mark.parametrize("addr", [
+        "0x0", "0xdeadbeef", "0xDEADBEEF", "0x7fff5fbff000",
+        "0x" + "f" * 16,
+    ])
+    def test_valid(self, addr):
+        assert is_valid_hex_address(addr)
+
+    @pytest.mark.parametrize("addr", [
+        "", "0x", "deadbeef", "0xg00d", "0x1234 extra",
+        "0x1234\nshell id", "0x" + "f" * 17,
+        None, 0xdeadbeef, 12345,
+    ])
+    def test_invalid(self, addr):
+        assert not is_valid_hex_address(addr)
+
+
+class TestValidateHexAddress:
+    def test_valid_passes(self):
+        validate_hex_address("0xdeadbeef")
+
+    def test_newline_raises_valueerror(self):
+        with pytest.raises(ValueError, match="Invalid address"):
+            validate_hex_address("0x1234\nshell id")
+
+    def test_overlong_raises(self):
+        with pytest.raises(ValueError, match="Invalid address"):
+            validate_hex_address("0x" + "a" * 17)
+
+    def test_non_str_raises_valueerror_not_typeerror(self):
+        """re.match raises TypeError on non-str; we want consistent ValueError."""
+        with pytest.raises(ValueError, match="expected str"):
+            validate_hex_address(0xdeadbeef)
+        with pytest.raises(ValueError, match="expected str"):
+            validate_hex_address(None)
+
+    def test_param_name_in_message(self):
+        with pytest.raises(ValueError, match="Invalid crash_address"):
+            validate_hex_address("nope", param_name="crash_address")
+
+
+class TestValidateByteCount:
+    @pytest.mark.parametrize("n", [1, 64, 4096])
+    def test_valid(self, n):
+        validate_byte_count(n)
+
+    @pytest.mark.parametrize("n", [0, -1, 4097])
+    def test_out_of_range(self, n):
+        with pytest.raises(ValueError, match="between 1 and 4096"):
+            validate_byte_count(n)
+
+    def test_string_rejected(self):
+        """The bug the review flagged: str that looks like an int."""
+        with pytest.raises(ValueError, match="expected int"):
+            validate_byte_count("64")
+        with pytest.raises(ValueError, match="expected int"):
+            validate_byte_count("64\nshell id")
+
+    def test_bool_rejected(self):
+        """bool is an int subclass; explicit reject."""
+        with pytest.raises(ValueError, match="expected int"):
+            validate_byte_count(True)


### PR DESCRIPTION
Follow-up to #173. Hoists the hex-address regex into a small shared _validators module used by both debugger.examine_memory and crash_analyser's addr2line / symbol-table paths, caps addresses at 16 hex digits, and adds a byte-count guard so a str-disguised-as-int like "64\nshell id" can't inject through num_bytes. Non-str addresses now raise ValueError instead of TypeError.