### PR TITLE
startup: auto-chmod models.json to 0600 instead of only warning

### DIFF
--- a/core/startup/init.py
+++ b/core/startup/init.py
@@ -9,6 +9,7 @@ Entry point: `python3 -m core.startup.init`
 import logging
 import os
 import shutil
+import stat
 import sys
 from pathlib import Path
 
@@ -64,6 +65,53 @@ def check_tools() -> tuple[list, list, set]:
     return results, warnings, unavailable_features
 
 
+def _tighten_config_perms(path: Path) -> str | None:
+    """Ensure `path` is 0o600. Returns a one-line notice or None.
+
+    Only acts on regular files owned by the current user. Symlinks are
+    flagged but never chmod'd through (chmod follows links; we refuse to
+    touch something we may not own). chmod failures fall back to the
+    pre-existing warning form.
+
+    Returns:
+        - None if nothing to say (already tight, missing, symlink target OK).
+        - A notice starting with "tightened …" on successful fix.
+        - A warning starting with "⚠ …" on anything we can't fix.
+
+    The caller routes the string; this helper does not log or print.
+    """
+    try:
+        st = path.lstat()
+    except OSError:
+        return None
+
+    if stat.S_ISLNK(st.st_mode):
+        try:
+            tgt_mode = path.stat().st_mode
+        except OSError:
+            return None
+        if tgt_mode & 0o077:
+            return (f"⚠ {path} is a symlink to a permissive target "
+                    f"(mode {oct(tgt_mode)[-3:]}). Fix target perms manually.")
+        return None
+
+    if not (st.st_mode & 0o077):
+        return None
+
+    if st.st_uid != os.getuid():
+        return (f"⚠ {path} not owned by current user "
+                f"(mode {oct(st.st_mode)[-3:]}). Fix perms manually.")
+
+    try:
+        os.chmod(path, 0o600)
+    except OSError as e:
+        return (f"⚠ {path} mode {oct(st.st_mode)[-3:]} and chmod failed: {e}. "
+                f"Run: chmod 600 {path}")
+
+    return (f"tightened {path} permissions to 600 "
+            f"(was {oct(st.st_mode)[-3:]}; contains API keys)")
+
+
 def check_llm() -> tuple[list, list]:
     """Check LLM availability via config file + lightweight key validation.
 
@@ -83,13 +131,10 @@ def check_llm() -> tuple[list, list]:
         config_path = Path.home() / ".config/raptor/models.json"
         models = []
         if config_path.exists():
-            # Warn if models.json is readable by others (contains API keys)
-            try:
-                mode = config_path.stat().st_mode
-                if mode & 0o077:
-                    warnings.append(f"⚠ {config_path} is accessible by other users (mode {oct(mode)[-3:]}). Run: chmod 600 {config_path}")
-            except OSError:
-                pass
+            # Auto-tighten if readable by others (contains API keys).
+            notice = _tighten_config_perms(config_path)
+            if notice:
+                warnings.append(notice)
             try:
                 data = json.loads(config_path.read_text())
                 models = data.get("models", []) if isinstance(data, dict) else data

--- a/core/startup/tests/test_tighten_perms.py
+++ b/core/startup/tests/test_tighten_perms.py
@@ -1,0 +1,86 @@
+"""Tests for _tighten_config_perms() — auto-chmod of ~/.config/raptor/models.json."""
+
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from core.startup.init import _tighten_config_perms
+
+
+class TestTightenConfigPerms(unittest.TestCase):
+
+    def _make_file(self, d: Path, mode: int) -> Path:
+        p = d / "models.json"
+        p.write_text("{}")
+        os.chmod(p, mode)
+        return p
+
+    def test_missing_file_returns_none(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "does-not-exist"
+            self.assertIsNone(_tighten_config_perms(p))
+
+    def test_already_tight_returns_none(self):
+        with TemporaryDirectory() as d:
+            p = self._make_file(Path(d), 0o600)
+            self.assertIsNone(_tighten_config_perms(p))
+            self.assertEqual(p.stat().st_mode & 0o777, 0o600)
+
+    def test_group_readable_gets_tightened(self):
+        with TemporaryDirectory() as d:
+            p = self._make_file(Path(d), 0o640)
+            notice = _tighten_config_perms(p)
+            self.assertIsNotNone(notice)
+            self.assertTrue(notice.startswith("tightened"))
+            self.assertIn("was 640", notice)
+            self.assertEqual(p.stat().st_mode & 0o777, 0o600)
+
+    def test_world_readable_gets_tightened(self):
+        with TemporaryDirectory() as d:
+            p = self._make_file(Path(d), 0o664)
+            notice = _tighten_config_perms(p)
+            self.assertTrue(notice.startswith("tightened"))
+            self.assertIn("was 664", notice)
+            self.assertEqual(p.stat().st_mode & 0o777, 0o600)
+
+    def test_idempotent(self):
+        with TemporaryDirectory() as d:
+            p = self._make_file(Path(d), 0o644)
+            _tighten_config_perms(p)
+            self.assertIsNone(_tighten_config_perms(p))
+            self.assertEqual(p.stat().st_mode & 0o777, 0o600)
+
+    def test_not_owned_warns_no_chmod(self):
+        """If getuid() doesn't match st_uid, we warn and don't touch it."""
+        with TemporaryDirectory() as d:
+            p = self._make_file(Path(d), 0o664)
+            fake_uid = p.stat().st_uid + 1
+            with patch("os.getuid", return_value=fake_uid):
+                notice = _tighten_config_perms(p)
+            self.assertIsNotNone(notice)
+            self.assertTrue(notice.startswith("\u26a0"))
+            self.assertIn("not owned", notice)
+            self.assertEqual(p.stat().st_mode & 0o777, 0o664)
+
+    def test_symlink_to_permissive_target_warns_no_chmod(self):
+        """Never chmod through a symlink; target may not be ours."""
+        with TemporaryDirectory() as d:
+            dp = Path(d)
+            target = self._make_file(dp, 0o664)
+            link = dp / "models.json.link"
+            link.symlink_to(target)
+            notice = _tighten_config_perms(link)
+            self.assertIsNotNone(notice)
+            self.assertTrue(notice.startswith("\u26a0"))
+            self.assertIn("symlink", notice)
+            self.assertEqual(target.stat().st_mode & 0o777, 0o664)
+
+    def test_chmod_failure_falls_back_to_warning(self):
+        with TemporaryDirectory() as d:
+            p = self._make_file(Path(d), 0o644)
+            with patch("os.chmod", side_effect=PermissionError("denied")):
+                notice = _tighten_config_perms(p)
+            self.assertTrue(notice.startswith("\u26a0"))
+            self.assertIn("chmod failed", notice)


### PR DESCRIPTION
Extracts the existing permission check in check_llm into _tighten_config_perms, which chmods the file when it's a regular file owned by the current user, and falls back to a warning otherwise (symlinks, foreign ownership, chmod failure). The file holds API keys; 0664 is never correct, and warning-only left a known-bad state indefinitely.