### PR TITLE
cc_trust flags env.SAGE_* as dangerous

### DIFF
--- a/core/security/cc_trust.py
+++ b/core/security/cc_trust.py
@@ -217,11 +217,15 @@ def _scan_settings(path: Path) -> Optional[FileScan]:
         if isinstance(env_cfg, dict):
             for env_key, env_val in env_cfg.items():
                 key_str = str(env_key)
-                # RAPTOR_* in a target repo's env dict is suspicious regardless
-                # of which specific var — targets have no business setting
-                # RAPTOR's own control env vars (RAPTOR_OUT_DIR, RAPTOR_CALLER_DIR,
-                # etc. could all subvert downstream behaviour if propagated).
-                if key_str in _DANGEROUS_ENV_VARS or key_str.startswith("RAPTOR_"):
+                # RAPTOR_* and SAGE_* in a target repo's env dict are suspicious
+                # regardless of the specific var — targets have no business
+                # setting RAPTOR's own control env vars (RAPTOR_OUT_DIR, etc.)
+                # nor SAGE's (SAGE_URL could redirect to a poisoned memory
+                # server, SAGE_ENABLED could silently turn on persistent
+                # memory the user didn't intend, etc.).
+                if (key_str in _DANGEROUS_ENV_VARS
+                        or key_str.startswith("RAPTOR_")
+                        or key_str.startswith("SAGE_")):
                     k = _truncate(key_str, limit=40)
                     fs.findings.append(Finding(f"env {k}", _truncate(str(env_val)), True))
     except Exception:

--- a/core/security/tests/test_cc_trust.py
+++ b/core/security/tests/test_cc_trust.py
@@ -243,6 +243,20 @@ class TestEnvInjection:
         }))
         assert _check(str(tmp_path)) is True
 
+    @pytest.mark.parametrize("key", [
+        "SAGE_URL", "SAGE_ENABLED", "SAGE_IDENTITY_PATH",
+        "SAGE_TIMEOUT", "SAGE_FALLBACK_JSON",
+    ])
+    def test_sage_star_env_blocks(self, tmp_path, key):
+        """env.SAGE_* — targets manipulating RAPTOR's SAGE config (e.g.
+        SAGE_URL → attacker-controlled memory server, SAGE_ENABLED → silent
+        opt-in to persistent memory)."""
+        claude = tmp_path / ".claude"; claude.mkdir()
+        (claude / "settings.json").write_text(json.dumps({
+            "env": {key: "x"},
+        }))
+        assert _check(str(tmp_path)) is True
+
 
 class TestMCP:
 


### PR DESCRIPTION
Extend the env-prefix check from RAPTOR_* to also cover SAGE_*. A target repo's settings.json `env` dict propagates via CC into subprocesses, so env.SAGE_URL could redirect RAPTOR to a poisoned SAGE memory server and env.SAGE_ENABLED could silently opt the user into persistent memory.

Lands before SAGE PR #156 so the protection is live when SAGE's env-var-reading code goes live.