### PR TITLE
add --understand and --validate as opt-in flags to /agentic

### DIFF
--- a/.claude/commands/agentic.md
+++ b/.claude/commands/agentic.md
@@ -9,15 +9,71 @@ description: Full autonomous security workflow — scan, dedup, prep, analyse, c
 2. Deduplicate findings
 3. Prep findings (read code, extract dataflow)
 4. **Validate + analyse** each finding (exploitation-validator methodology, Stages A-D)
-5. **Self-review** — catch contradictions, retry low confidence (Stage F)
-6. **Consensus** — multi-model second opinion (if configured)
+5. **Self-review**: catch contradictions, retry low confidence (Stage F)
+6. **Consensus**: multi-model second opinion (if configured)
 7. **Generate exploit PoCs** for exploitable findings
 8. **Generate secure patches** for confirmed vulnerabilities
 9. **Cross-finding analysis** (structural grouping, shared root causes)
 
-Nothing will be applied to your code - only generated in out/ directory.
+Nothing will be applied to your code - only generated in the out/ directory.
 
 Execute: `python3 raptor.py agentic --repo <path>`
+
+## Optional enrichment flags
+
+By default, `/agentic` scans and analyses findings in isolation. Two optional flags add richer context for more thorough results. They are opt-in because they add time and cost, but if you are doing a proper security review rather than a quick scan, they are well worth it.
+
+| Flag | What it does |
+|------|-------------|
+| `--understand` | Runs `/understand --map` before scanning to build a full context map: entry points, trust boundaries, sinks. This feeds directly into the analysis so findings are evaluated with architectural knowledge rather than in isolation. |
+| `--validate` | After the agentic pipeline completes, runs `/validate` on all findings that came back exploitable or confirmed. Uses the full 8-stage pipeline (Stages 0 through F) for a thorough second pass. |
+
+You can use either flag on its own or combine them:
+
+```bash
+# Recommended for thorough reviews
+python3 raptor.py agentic --repo /path/to/code --understand --validate
+
+# Just pre-scan context mapping, no post-validate
+python3 raptor.py agentic --repo /path/to/code --understand
+
+# Just validate the findings that look exploitable
+python3 raptor.py agentic --repo /path/to/code --validate
+```
+
+## How to handle --understand
+
+Before firing the Python scan, run the understand lifecycle steps as described in the `/understand` skill. Strip `--understand` from the args before passing to `python3 raptor.py agentic`.
+
+**Step 1:** Start the understand run:
+```bash
+libexec/raptor-run-lifecycle start understand --target <resolved_target>
+```
+Use the `OUTPUT_DIR` from this for all subsequent understand steps.
+
+**Step 2:** Build the source inventory:
+```bash
+libexec/raptor-build-checklist <resolved_target> "$OUTPUT_DIR"
+```
+
+**Step 3:** Load `.claude/skills/code-understanding/SKILL.md` and `.claude/skills/code-understanding/map.md`, then perform the `--map` analysis (MAP-0 through MAP-5). Write `context-map.json` to `$OUTPUT_DIR`.
+
+**Step 4:** Record coverage and render diagrams:
+```bash
+libexec/raptor-coverage-summary "$OUTPUT_DIR" --mark-file "$OUTPUT_DIR/reviewed-items.json"
+libexec/raptor-render-diagrams "$OUTPUT_DIR"
+libexec/raptor-run-lifecycle complete "$OUTPUT_DIR"
+```
+
+**Step 5:** Now run the Python scan as normal. The `/validate` bridge will automatically pick up `context-map.json` from the project directory when validate runs later.
+
+## How to handle --validate
+
+After the agentic Python pipeline completes, strip `--validate` from the args and run `/validate` on findings where `is_exploitable` is true or confidence is high. Load `.claude/skills/exploitability-validation/SKILL.md` and follow the full pipeline.
+
+The bridge will automatically find and import the `context-map.json` from the understand run (if `--understand` was also used), pre-populating the attack surface for Stage B. No extra flags needed.
+
+If `--validate` is used without `--understand`, validate still runs normally using whatever context is available in the project directory.
 
 ## How analysis works
 

--- a/.claude/commands/agentic.md
+++ b/.claude/commands/agentic.md
@@ -30,16 +30,18 @@ By default, `/agentic` scans and analyses findings in isolation. Two optional fl
 
 You can use either flag on its own or combine them:
 
-```bash
+```
 # Recommended for thorough reviews
-python3 raptor.py agentic --repo /path/to/code --understand --validate
+/agentic --understand --validate
 
 # Just pre-scan context mapping, no post-validate
-python3 raptor.py agentic --repo /path/to/code --understand
+/agentic --understand
 
 # Just validate the findings that look exploitable
-python3 raptor.py agentic --repo /path/to/code --validate
+/agentic --validate
 ```
+
+Note: `--understand` and `--validate` are consumed by the Claude Code `/agentic` skill before the Python layer runs. They have no effect if you invoke `python3 raptor.py agentic` directly.
 
 ## How to handle --understand
 
@@ -69,7 +71,13 @@ libexec/raptor-run-lifecycle complete "$OUTPUT_DIR"
 
 ## How to handle --validate
 
-After the agentic Python pipeline completes, strip `--validate` from the args and run `/validate` on findings where `is_exploitable` is true or confidence is high. Load `.claude/skills/exploitability-validation/SKILL.md` and follow the full pipeline.
+After the agentic Python pipeline completes, strip `--validate` from the args and run `/validate` on findings that meet either condition below. Load `.claude/skills/exploitability-validation/SKILL.md` and follow the full pipeline.
+
+Select findings from `results[]` in the agentic report where:
+- `is_exploitable === true` (boolean field, defined in `packages/llm_analysis/prompts/schemas.py`), **or**
+- `confidence === "high"` (string enum: `"high"` | `"medium"` | `"low"`, same schema file)
+
+Do not use fuzzy matching on these values -- both fields come directly from the LLM analysis schema. If a field is missing or null, skip that finding.
 
 The bridge will automatically find and import the `context-map.json` from the understand run (if `--understand` was also used), pre-populating the attack surface for Stage B. No extra flags needed.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ VERY IMPORTANT: follow these steps in order.
 
 **Coverage:** When asked about coverage, run `libexec/raptor-coverage-summary` (no args = active project). Use `--detailed` for per-file table, `--gaps` for unreviewed functions. See `.claude/skills/coverage.md` for mark/unmark and the full API.
 
-**Note:** `/agentic` runs scan → dedup → prep → analysis (with validation methodology). Use `--sequential` to bypass parallel orchestration.
+**Note:** `/agentic` runs scan → dedup → prep → analysis (with validation methodology). Use `--sequential` to bypass parallel orchestration. Use `--understand` to pre-map the codebase before scanning, and `--validate` to run the full validation pipeline on exploitable findings afterwards. Both flags are opt-in.
 /crash-analysis - Autonomous crash root-cause analysis (see below)
 /oss-forensics - GitHub forensic investigation (see below)
 /create-skill - Save approaches (alpha)

--- a/raptor.py
+++ b/raptor.py
@@ -182,6 +182,11 @@ def mode_agentic(args: list) -> int:
         print(f"✗ Agentic workflow script not found: {agentic_script}")
         return 1
 
+    # --understand and --validate are consumed by the Claude Code agentic
+    # command and never reach this function. Strip them here as a safety net
+    # so raptor_agentic.py doesn't receive unknown flags.
+    args = [a for a in args if a not in ('--understand', '--validate')]
+
     # Enable CodeQL by default for comprehensive agentic mode
     # unless user explicitly specifies --codeql-only or --no-codeql
     if '--codeql' not in args and '--codeql-only' not in args and '--no-codeql' not in args:

--- a/raptor.py
+++ b/raptor.py
@@ -185,6 +185,7 @@ def mode_agentic(args: list) -> int:
     # --understand and --validate are consumed by the Claude Code agentic
     # command and never reach this function. Strip them here as a safety net
     # so raptor_agentic.py doesn't receive unknown flags.
+    # These flags are boolean-only and must never take a value.
     args = [a for a in args if a not in ('--understand', '--validate')]
 
     # Enable CodeQL by default for comprehensive agentic mode


### PR DESCRIPTION
## What

Two new opt-in flags for `/agentic`:

- `--understand` — runs `/understand --map` before the scan, building a full context map (entry points, trust boundaries, sinks) that feeds into the analysis. Findings get evaluated with architectural knowledge rather than in isolation.
- `--validate` — after the pipeline completes, runs the full 8-stage `/validate` pipeline on anything that came back exploitable or confirmed.

## Why

Right now `/agentic` analyses findings in isolation. If you're doing a proper security review on a workstation rather than a quick CI scan, you want the richer context that `/understand` and `/validate` add. The `/validate` bridge already picks up `context-map.json` automatically if it's in the project directory, so the two flags compose nicely.

Both flags are opt-in so nothing breaks for existing workflows. It also means this works better in a pipeline or as an agent you'd call in chat window within the IDE, which is pretty sweet imho 

## How it works

The flags are consumed at the Claude Code layer (`agentic.md`), not by the Python pipeline. `raptor.py` strips them before passing args to `raptor_agentic.py` as a safety net.

## Usage

```bash
# full enriched review
python3 raptor.py agentic --repo /path/to/code --understand --validate

# just pre-scan context mapping
python3 raptor.py agentic --repo /path/to/code --understand

# just post-scan validation on exploitable findings
python3 raptor.py agentic --repo /path/to/code --validate
```

## Files changed

- `.claude/commands/agentic.md` — documents the flags and the orchestration steps Claude follows for each
- `CLAUDE.md` — updated the agentic note to mention both flags
- `raptor.py` — strips `--understand` and `--validate` before they reach `raptor_agentic.py`