### PR TITLE
fix dockerfile for bookworm: drop dead packages, fix libgcc

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,6 +11,8 @@ FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
 # Organized by component that needs them
 # ============================================================================
 
+RUN rm -f /etc/apt/sources.list.d/yarn.list
+
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y --no-install-recommends \
     #
@@ -60,8 +62,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     libdbus-1-3 \
     libexpat1 \
     libfontconfig1 \
-    libgcc1 \
-    libgconf-2-4 \
+    libgcc-s1 \
     libgdk-pixbuf2.0-0 \
     libglib2.0-0 \
     libgtk-3-0 \


### PR DESCRIPTION
## What

Three fixes to get the devcontainer building cleanly on Debian Bookworm:

- Remove `libgcc1` (gone in Bookworm, replaced by `libgcc-s1`)
- Remove `libgconf-2-4` (GNOME 2 package, hasn't existed for years)
- Add `RUN rm -f /etc/apt/sources.list.d/yarn.list` before the main apt block to stop apt falling over on the conflicting repo

## Why

The current Dockerfile fails to build on Bookworm because both `libgcc1` and `libgconf-2-4` no longer exist in the package repositories. This has been blocking devcontainer usage.

Fixes #183. Thanks to @unprovable for the updated Dockerfile.