### PR TITLE
Tighten SMT one-gadget checker, seed shared harness primitives

### DIFF
--- a/.claude/skills/exploitability-validation/SKILL.md
+++ b/.claude/skills/exploitability-validation/SKILL.md
@@ -224,7 +224,7 @@ The one-gadget encoder pins BitVec width to 64 (x86_64 registers) and treats val
 
 ### One-gadget constraint satisfaction (`smt_onegadget.py`)
 
-Invoked automatically inside `analyze_binary()` when one_gadget offsets are found ([packages/exploit_feasibility/api.py:1888](../../../packages/exploit_feasibility/api.py#L1888)). It ranks each gadget by whether Z3 can satisfy its constraint list (`rank_onegadgets(gadget_objs)`), and stores the verdict for the best-ranked gadget under `analysis.one_gadget_info.smt_feasibility` in the exploit context.
+Invoked automatically when one_gadget offsets are found during exploit-feasibility analysis. It ranks each gadget by whether Z3 can satisfy its constraint list (`rank_onegadgets(gadget_objs)`), and stores the verdict for the best-ranked gadget under `analysis.one_gadget_info.smt_feasibility` in the exploit context.
 
 Constraint forms currently recognised (case-insensitive; combined via `||` / `&&` / `AND` at the disjunction/conjunction layer):
 

--- a/core/smt_solver/__init__.py
+++ b/core/smt_solver/__init__.py
@@ -13,7 +13,8 @@ and import primitives from here.
 from .availability import z3, z3_available
 from .bitvec import ge, gt, le, lt, mk_val, mk_var
 from .config import bv_width, is_signed, mode_tag
-from .session import DEFAULT_TIMEOUT_MS, new_solver
+from .explain import core_names, track
+from .session import DEFAULT_TIMEOUT_MS, new_solver, scoped
 from .witness import bv_to_int, format_vars, format_witness
 
 __all__ = [
@@ -33,4 +34,7 @@ __all__ = [
     "format_witness",
     "DEFAULT_TIMEOUT_MS",
     "new_solver",
+    "scoped",
+    "track",
+    "core_names",
 ]

--- a/core/smt_solver/explain.py
+++ b/core/smt_solver/explain.py
@@ -1,0 +1,55 @@
+"""Unsat-core helpers: name which constraints contradict.
+
+When a solver returns ``unsat`` after asserting a batch of constraints,
+Z3's ``unsat_core()`` tells us which tracked assertions it used to
+derive the contradiction — a subset (not always minimal) that is itself
+unsatisfiable. That turns "some of these conflict" into "specifically X
+contradicts Y", which is stronger evidence for Stage-E chain_breaks than
+a generic "mutually exclusive" note.
+
+Usage::
+
+    rev = track(solver, [(name, expr), ...])
+    if solver.check() == z3.unsat:
+        print(core_names(solver, rev))
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence, Tuple
+
+from .availability import z3
+
+
+def track(solver: Any, labeled: Sequence[Tuple[str, Any]]) -> Dict[str, str]:
+    """Assert each labelled expression via ``assert_and_track``.
+
+    Returns a mapping from the generated Z3 label identifier back to the
+    caller's human-readable name, used by ``core_names`` to translate
+    ``solver.unsat_core()`` output.  Existing (non-tracked) assertions on
+    the solver are unaffected and will not appear in the unsat core.
+
+    One-shot per solver: labels are generated as ``_c0``, ``_c1``, ... so
+    calling ``track`` twice on the same solver will collide.  If you need
+    to probe multiple batches, use a fresh solver (or merge the batches
+    into one call).
+    """
+    rev: Dict[str, str] = {}
+    for i, (name, expr) in enumerate(labeled):
+        label = z3.Bool(f"_c{i}")
+        solver.assert_and_track(expr, label)
+        rev[str(label)] = name
+    return rev
+
+
+def core_names(solver: Any, rev: Dict[str, str]) -> List[str]:
+    """Return human-readable names of assertions in the unsat core.
+
+    Call after ``solver.check()`` returns ``z3.unsat``. Labels added by
+    other callers (not present in ``rev``) are silently omitted.
+    """
+    names: List[str] = []
+    for label in solver.unsat_core():
+        name = rev.get(str(label))
+        if name is not None:
+            names.append(name)
+    return names

--- a/core/smt_solver/session.py
+++ b/core/smt_solver/session.py
@@ -6,7 +6,8 @@ per-call via ``new_solver(timeout_ms=...)``.
 """
 from __future__ import annotations
 
-from typing import Any
+from contextlib import contextmanager
+from typing import Any, Iterator
 
 from .availability import z3
 
@@ -18,3 +19,19 @@ def new_solver(timeout_ms: int = DEFAULT_TIMEOUT_MS) -> Any:
     s = z3.Solver()
     s.set("timeout", timeout_ms)
     return s
+
+
+@contextmanager
+def scoped(solver: Any) -> Iterator[Any]:
+    """Push an assertion scope on ``solver`` for the duration of the block.
+
+    On exit (normal or exception), pops the scope — assertions added
+    inside are removed, assertions from before remain. Lets domain
+    encoders try hypothesis constraints and roll back cheaply without
+    discarding the surrounding solver state.
+    """
+    solver.push()
+    try:
+        yield solver
+    finally:
+        solver.pop()

--- a/core/smt_solver/tests/test_smt_solver.py
+++ b/core/smt_solver/tests/test_smt_solver.py
@@ -56,9 +56,134 @@ class TestSMTSolver:
 
         solver = z3.Solver()
         x = z3.BitVec('x', 64)
-        
+
         # These are 'impassable' constraints...
         solver.add(x == 1)
         solver.add(x == 2)
 
         assert solver.check() == z3.unsat
+
+
+_requires_z3 = pytest.mark.skipif(
+    not z3_available(),
+    reason="z3-solver not installed",
+)
+
+
+class TestScoped:
+    """``session.scoped`` must push/pop correctly around a block, including
+    when the block is exited via exception or ``continue``."""
+
+    @_requires_z3
+    def test_rollback_on_normal_exit(self):
+        from core.smt_solver import new_solver, scoped, z3
+        solver = new_solver()
+        x = z3.BitVec("x", 64)
+        solver.add(x == 1)
+
+        with scoped(solver):
+            solver.add(x == 2)
+            assert solver.check() == z3.unsat
+
+        # Hypothesis removed: only x == 1 remains, which is sat.
+        assert solver.check() == z3.sat
+
+    @_requires_z3
+    def test_rollback_on_exception(self):
+        from core.smt_solver import new_solver, scoped, z3
+        solver = new_solver()
+        x = z3.BitVec("x", 64)
+        solver.add(x == 1)
+
+        class Boom(Exception):
+            pass
+
+        with pytest.raises(Boom):
+            with scoped(solver):
+                solver.add(x == 2)
+                raise Boom
+
+        # Even though the block raised, pop() ran in finally — hypothesis gone.
+        assert solver.check() == z3.sat
+
+    @_requires_z3
+    def test_nested_push_pop(self):
+        from core.smt_solver import new_solver, scoped, z3
+        solver = new_solver()
+        x = z3.BitVec("x", 64)
+        solver.add(x >= 0)
+
+        with scoped(solver):
+            solver.add(x <= 10)
+            with scoped(solver):
+                solver.add(x == 42)
+                assert solver.check() == z3.unsat  # 42 outside [0, 10]
+            # Inner rolled back; outer (x <= 10) still holds.
+            assert solver.check() == z3.sat
+        # Outer rolled back; only x >= 0 remains.
+        assert solver.check() == z3.sat
+
+
+class TestExplain:
+    """``explain.track`` + ``explain.core_names`` must identify which
+    tracked assertions Z3 used to derive an unsat result."""
+
+    @_requires_z3
+    def test_core_names_round_trip(self):
+        from core.smt_solver import core_names, new_solver, track, z3
+        solver = new_solver()
+        x = z3.BitVec("x", 64)
+
+        rev = track(solver, [("x_is_1", x == 1), ("x_is_2", x == 2)])
+        assert solver.check() == z3.unsat
+
+        names = core_names(solver, rev)
+        assert set(names) == {"x_is_1", "x_is_2"}
+
+    @_requires_z3
+    def test_core_names_empty_when_sat(self):
+        """Calling core_names on a sat solver yields no names.
+
+        ``solver.unsat_core()`` is only meaningful after unsat; for sat
+        solvers Z3 typically returns an empty sequence.
+        """
+        from core.smt_solver import core_names, new_solver, track, z3
+        solver = new_solver()
+        x = z3.BitVec("x", 64)
+
+        rev = track(solver, [("x_is_1", x == 1)])
+        assert solver.check() == z3.sat
+        assert core_names(solver, rev) == []
+
+    @_requires_z3
+    def test_core_names_ignores_unknown_labels(self):
+        """Labels not present in ``rev`` are silently omitted — lets
+        callers track only the assertions they care about naming."""
+        from core.smt_solver import core_names, new_solver, track, z3
+        solver = new_solver()
+        x = z3.BitVec("x", 64)
+
+        rev = track(solver, [("keep", x == 1), ("drop", x == 2)])
+        # Simulate a caller that only cares about one label.
+        partial_rev = {k: v for k, v in rev.items() if v == "keep"}
+        assert solver.check() == z3.unsat
+
+        names = core_names(solver, partial_rev)
+        assert names == ["keep"]
+
+    @_requires_z3
+    def test_track_does_not_affect_untracked_assertions(self):
+        """Pre-existing untracked assertions stay in force but don't
+        appear in the unsat core."""
+        from core.smt_solver import core_names, new_solver, track, z3
+        solver = new_solver()
+        x = z3.BitVec("x", 64)
+        solver.add(x == 1)  # untracked
+
+        rev = track(solver, [("clash", x == 2)])
+        assert solver.check() == z3.unsat
+
+        names = core_names(solver, rev)
+        # Only the tracked assertion is named; the untracked `x == 1`
+        # pulled us into unsat but isn't reported by core_names.
+        assert names == ["clash"]

--- a/packages/exploit_feasibility/__init__.py
+++ b/packages/exploit_feasibility/__init__.py
@@ -151,7 +151,6 @@ try:
     ]
 except ImportError:
     get_logger().debug("Failed to load SMT Add-on")
-    pass
 
 
 # =============================================================================

--- a/packages/exploit_feasibility/api.py
+++ b/packages/exploit_feasibility/api.py
@@ -164,6 +164,14 @@ def analyze_binary(binary_path: str, output_dir: str = None,
     result['binary_arch'] = getattr(report, 'binary_arch', None)
     result['binary_os_abi'] = getattr(report, 'binary_os_abi', None)
 
+    # Flag whether the optional SMT harness is loaded.  Lets consumers
+    # distinguish "no gadgets found" from "gadgets found but SMT did not
+    # run" when reading one_gadget_info.smt_feasibility.  This is an
+    # *environment capability* signal — for per-gadget SMT participation
+    # see ``one_gadget_info.smt_feasibility.smt_available`` on each result.
+    from core.smt_solver import z3_available as _z3_available
+    result['smt_available'] = _z3_available()
+
     # Add raw checksec output for LLM context
     if report.raw_checksec:
         result['raw_checksec'] = report.raw_checksec
@@ -1908,8 +1916,8 @@ def find_exploit_paths(
                                 # SMT verdict is stored in smt_feasibility — the
                                 # heuristic note (set above) is preserved independently.
                     except Exception as e:
+                        # SMT add-on failure is non-fatal
                         logger.debug(f"Could not analyze constraints for gadgets: {e}")
-                        pass  # SMT add-on failure is non-fatal
 
         elif 'stack_overflow' in vulnerability or 'buffer_overflow' in vulnerability:
             # Stack overflow specific chain breaks

--- a/packages/exploit_feasibility/smt_onegadget.py
+++ b/packages/exploit_feasibility/smt_onegadget.py
@@ -19,8 +19,10 @@ the shared helper so reasoning strings stay consistent with the rest of
 the harness.
 
 Integration points (do not call from outside these locations):
-  - packages/exploit_feasibility/api.py  ~line 1836  (one_gadget_info note)
-  - packages/exploit_feasibility/api.py  ~line 2889  (rank best gadget)
+  - packages/exploit_feasibility/api.py :: find_exploit_paths
+    (builds one_gadget_info with the heuristic `note`, then calls
+    rank_onegadgets here and stores the verdict under
+    one_gadget_info.smt_feasibility)
 
 Crash state sources accepted by check_onegadget():
   - CrashContext.registers  (Dict[str, str]  — GDB register dump, hex strings)
@@ -34,11 +36,16 @@ import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
+from core.logging import get_logger as _get_logger
 from core.smt_solver import (
+    DEFAULT_TIMEOUT_MS as _DEFAULT_TIMEOUT_MS,
+    core_names as _core_names,
     mk_val as _mk_val,
     mk_var as _mk_var,
     mode_tag as _mode_tag,
     new_solver as _new_solver,
+    scoped as _scoped,
+    track as _track,
     z3,
     z3_available as _z3_available,
 )
@@ -49,8 +56,6 @@ from .context import OneGadget
 
 # x86_64 registers are natively 64-bit, and the values we care about are
 # addresses — treat them as unsigned in any rendered witness.
-# now populate local vars
-
 _REG_WIDTH = 64
 _REG_SIGNED = False
 
@@ -67,7 +72,7 @@ class OneGadgetSMTResult:
     unsatisfied: List[str]        # constraints proven false given crash_state
     unknown: List[str]            # constraint lines that could not be parsed into Z3
     model: Dict[str, int]         # satisfying variable assignments when feasible=True
-    smt_available: bool
+    smt_available: bool           # whether SMT participated in *this* result (env capability is separate; see analyze_binary()['smt_available'])
     reasoning: str
 
 
@@ -94,16 +99,21 @@ _HEX_LIT_RE = re.compile(r'0x[0-9a-f]+', re.IGNORECASE)
 _DEC_LIT_RE = re.compile(r'\d+')
 
 
-def _reg_var(name: str, vars_: Dict[str, Any]) -> Any:
+def _reg_var(name: str, vars_: Dict[str, Any]) -> Optional[Any]:
     name = name.lower()
+    if name not in _X86_64_REGS:
+        return None
     if name not in vars_:
         vars_[name] = _mk_var(name, width=_REG_WIDTH)
     return vars_[name]
 
 
-def _mem_var(reg: str, op: str, raw_offset: str, vars_: Dict[str, Any]) -> Any:
+def _mem_var(reg: str, op: str, raw_offset: str, vars_: Dict[str, Any]) -> Optional[Any]:
+    reg_lc = reg.lower()
+    if reg_lc not in _X86_64_REGS:
+        return None
     offset = int(raw_offset, 16) if raw_offset.startswith("0x") else int(raw_offset)
-    key = f"mem_{reg.lower()}{op}{offset:#x}"
+    key = f"mem_{reg_lc}{op}{offset:#x}"
     if key not in vars_:
         vars_[key] = _mk_var(key, width=_REG_WIDTH)
     return vars_[key]
@@ -315,11 +325,16 @@ def check_onegadget(
     vars_: Dict[str, Any] = {}
     concrete: Dict[str, int] = _normalise_crash_state(crash_state) if crash_state else {}
 
-    # Pin known register values in a base solver
+    # Persist known register values in a solver shared across per-constraint
+    # probes and the final joint-sat check. Each probe pushes a scope so its
+    # hypothesis assertion is rolled back afterwards.
+    solver = _new_solver()
     base_assertions: List[Any] = []
     for reg, val in concrete.items():
         if reg in _X86_64_REGS:
             base_assertions.append(_reg_var(reg, vars_) == _mk_val(val, width=_REG_WIDTH))
+    if base_assertions:
+        solver.add(*base_assertions)
 
     satisfied:   List[str] = []
     unsatisfied: List[str] = []
@@ -329,25 +344,24 @@ def check_onegadget(
     for raw in gadget.constraints:
         expr = _parse_constraint(raw, vars_)
         if expr is None:
+            _get_logger().debug(f"smt_onegadget: unparseable constraint: {raw!r}")
             unknown.append(raw)
             continue
 
         if base_assertions:
-            # Check if crash_state forces this constraint true
-            neg = _new_solver()
-            neg.add(*base_assertions)
-            neg.add(z3.Not(expr))
-            if neg.check() == z3.unsat:
-                satisfied.append(raw)
-                continue
+            # Does the crash state force this constraint true? (Not(expr) unsat)
+            with _scoped(solver):
+                solver.add(z3.Not(expr))
+                if solver.check() == z3.unsat:
+                    satisfied.append(raw)
+                    continue
 
-            # Check if crash_state forces this constraint false
-            pos = _new_solver()
-            pos.add(*base_assertions)
-            pos.add(expr)
-            if pos.check() == z3.unsat:
-                unsatisfied.append(raw)
-                continue
+            # Does the crash state force this constraint false? (expr unsat)
+            with _scoped(solver):
+                solver.add(expr)
+                if solver.check() == z3.unsat:
+                    unsatisfied.append(raw)
+                    continue
 
         pending.append((raw, expr))
 
@@ -364,19 +378,31 @@ def check_onegadget(
         )
 
     if not pending:
-        # All constraints already satisfied by crash_state
+        # Nothing to solve for.  If any constraint was unparseable we don't
+        # actually know whether the gadget is usable — the unknown ones
+        # could be silently false. Only commit to feasible=True when every
+        # constraint was classified and at least one was met by crash state.
+        if unknown:
+            return OneGadgetSMTResult(
+                feasible=None, satisfied=satisfied, unsatisfied=[], unknown=unknown,
+                model={}, smt_available=True,
+                reasoning=(
+                    f"indeterminate ({tag}): {len(satisfied)} met by crash state, "
+                    f"{len(unknown)} unparseable — fall back to heuristic note"
+                ),
+            )
         return OneGadgetSMTResult(
-            feasible=True, satisfied=satisfied, unsatisfied=[], unknown=unknown,
+            feasible=True, satisfied=satisfied, unsatisfied=[], unknown=[],
             model={k: v for k, v in concrete.items() if k in _X86_64_REGS},
             smt_available=True,
             reasoning=f"all {len(satisfied)} constraint(s) already satisfied by crash state ({tag})",
         )
 
-    # Joint satisfiability of remaining constraints
-    solver = _new_solver()
-    solver.add(*base_assertions)
-    for _, expr in pending:
-        solver.add(expr)
+    # Joint satisfiability of remaining constraints. The solver already
+    # holds base_assertions; probes above were each scoped and rolled back.
+    # Track each pending constraint so solver.unsat_core() can name the
+    # specific ones that conflict when the joint check is unsat.
+    label_map = _track(solver, pending)
 
     result = solver.check()
 
@@ -393,13 +419,22 @@ def check_onegadget(
         )
 
     elif result == z3.unsat:
+        conflicts = _core_names(solver, label_map)
+        # `unsatisfied` reports the subset Z3 actually used to derive the
+        # contradiction — pending constraints outside the core were
+        # individually satisfiable (pre-checked above) and only become
+        # problematic in combination with the core.  Falling back to the
+        # full pending list when the core is empty preserves the old
+        # behaviour for theories that don't produce cores.
+        conflict_set = conflicts if conflicts else [r for r, _ in pending]
+        reasoning = f"infeasible ({tag}): {len(pending)} pending constraint(s) are mutually exclusive"
+        if conflicts:
+            reasoning += f"; conflict: {' ⊥ '.join(conflicts[:3])}"
         return OneGadgetSMTResult(
             feasible=False, satisfied=satisfied,
-            unsatisfied=[r for r, _ in pending], unknown=unknown,
+            unsatisfied=conflict_set, unknown=unknown,
             model={}, smt_available=True,
-            reasoning=(
-                f"infeasible ({tag}): {len(pending)} pending constraint(s) are mutually exclusive"
-            ),
+            reasoning=reasoning,
         )
 
     else:
@@ -407,7 +442,10 @@ def check_onegadget(
             feasible=None, satisfied=satisfied, unsatisfied=[],
             unknown=unknown + [r for r, _ in pending],
             model={}, smt_available=True,
-            reasoning=f"Z3 returned unknown ({tag}) — constraints may be outside bit-vector fragment",
+            reasoning=(
+                f"Z3 returned unknown ({tag}) — likely the {_DEFAULT_TIMEOUT_MS}ms "
+                f"solver timeout, or constraints outside the decidable bit-vector fragment"
+            ),
         )
 
 

--- a/packages/exploit_feasibility/tests/test_smt_onegadget.py
+++ b/packages/exploit_feasibility/tests/test_smt_onegadget.py
@@ -233,3 +233,193 @@ class TestConstraintParser:
         assert "rax == NULL" in result.satisfied
         assert "rsp & 0xf == 0" in result.satisfied
         assert "(u16)[rbx] == NULL" in result.unknown
+
+
+class TestIndeterminate:
+    """When constraints cannot be verified we must not claim feasibility.
+
+    Previously any path that reached ``pending == []`` returned
+    ``feasible=True`` even if every constraint had fallen into the
+    ``unknown`` bucket, producing a false positive.  These tests pin the
+    conservative behaviour: if anything is unknown and nothing was
+    actively verified, the verdict is ``None``, not ``True``.
+    """
+
+    @_requires_z3
+    def test_all_unparseable_no_state_is_indeterminate(self):
+        g = OneGadget(0x100, ["(u16)[rbx] == NULL", '{foo} is a valid argv'])
+        r = check_onegadget(g)
+        assert r.feasible is None
+        assert len(r.unknown) == 2
+        assert not r.satisfied and not r.unsatisfied
+        assert "indeterminate" in r.reasoning
+
+    @_requires_z3
+    def test_all_unparseable_with_state_is_indeterminate(self):
+        g = OneGadget(0x100, ["(u16)[rbx] == NULL"])
+        r = check_onegadget(g, {"rax": 0})
+        assert r.feasible is None
+        assert "(u16)[rbx] == NULL" in r.unknown
+
+    @_requires_z3
+    def test_some_satisfied_some_unknown_is_indeterminate(self):
+        """One parseable constraint met by state, one unparseable.
+        The unparseable one could be silently false, so the overall
+        verdict is indeterminate, not True."""
+        g = OneGadget(0x100, ["rax == NULL", "(u16)[rbx] == NULL"])
+        r = check_onegadget(g, {"rax": 0})
+        assert r.feasible is None
+        assert "rax == NULL" in r.satisfied
+        assert "(u16)[rbx] == NULL" in r.unknown
+        assert r.model == {}
+
+
+class TestRegGating:
+    """Non-x86_64 register tokens must not be modeled as free bitvecs.
+    Letting them through would leave the solver with unconstrained
+    variables that trivially satisfy any equality — a false positive."""
+
+    @_requires_z3
+    @pytest.mark.parametrize("constraint", [
+        "rex == NULL",        # typo
+        "rmm0 == NULL",       # not a register at all
+        "really_reg == 0",    # bogus identifier that happens to start with r
+    ])
+    def test_unknown_register_falls_into_unknown(self, constraint):
+        g = OneGadget(0x100, [constraint])
+        r = check_onegadget(g)
+        assert constraint in r.unknown
+
+    @_requires_z3
+    def test_unknown_register_in_memory_form_falls_into_unknown(self):
+        g = OneGadget(0x100, ["[rex+0x10] == NULL"])
+        r = check_onegadget(g)
+        assert "[rex+0x10] == NULL" in r.unknown
+
+
+class TestJointUnsatReasoning:
+    """When multiple pending constraints are mutually exclusive, the
+    reasoning string should name which ones conflict (unsat core)."""
+
+    @_requires_z3
+    def test_joint_unsat_without_state_names_conflict(self):
+        g = OneGadget(0x100, ["rax == 0", "rax != 0"])
+        r = check_onegadget(g)
+        assert r.feasible is False
+        assert "conflict" in r.reasoning
+        assert "rax == 0" in r.reasoning
+        assert "rax != 0" in r.reasoning
+
+    @_requires_z3
+    def test_joint_unsat_unsatisfied_narrowed_to_core(self):
+        """When some pending constraints are independent of the conflict,
+        ``unsatisfied`` should reflect only the conflicting subset —
+        reporting every pending constraint would be misleading since the
+        independent ones are still individually satisfiable."""
+        g = OneGadget(0x100, ["rax == 0", "rax != 0", "rbx == 5"])
+        r = check_onegadget(g)
+        assert r.feasible is False
+        # rax == 0 and rax != 0 are the actual conflict.  rbx == 5 is
+        # independent and shouldn't be fingered as "unsatisfied".
+        assert "rax == 0" in r.unsatisfied
+        assert "rax != 0" in r.unsatisfied
+        assert "rbx == 5" not in r.unsatisfied
+
+    @_requires_z3
+    def test_joint_sat_three_constraints_no_conflict(self):
+        g = OneGadget(0x100, ["rax == 0", "rbx == 1", "rsp & 0xf == 0"])
+        r = check_onegadget(g)
+        assert r.feasible is True
+        assert r.model.get("rax") == 0
+        assert r.model.get("rbx") == 1
+        assert r.model.get("rsp", 0) & 0xf == 0
+
+
+class TestConjunction:
+    """The ``&&`` / ``AND`` (and implicit conjunction via ``||`` branches
+    of conjunctions) paths need direct coverage — the existing suite
+    only exercised disjunction."""
+
+    @_requires_z3
+    def test_conjunction_both_satisfied_by_state(self):
+        constraint = "rax == NULL && rsp & 0xf == 0"
+        g = OneGadget(0x100, [constraint])
+        r = check_onegadget(g, {"rax": 0, "rsp": 0x7ffffff0})
+        assert constraint in r.satisfied
+
+    @_requires_z3
+    def test_conjunction_one_branch_contradicted_is_unsatisfied(self):
+        constraint = "rax == NULL AND rbx == NULL"
+        g = OneGadget(0x100, [constraint])
+        r = check_onegadget(g, {"rax": 0, "rbx": 0x1})
+        assert r.feasible is False
+        assert constraint in r.unsatisfied
+
+
+class TestCrashStateKeys:
+    """Keys in the crash state that aren't x86_64 registers must not
+    leak into the solver as free bitvec equalities — otherwise typoed
+    keys would silently constrain nothing."""
+
+    @_requires_z3
+    def test_non_x86_64_crash_state_key_is_ignored(self):
+        """`eax` is a 32-bit sub-register, not in _X86_64_REGS.  A value
+        pinned to `eax` must not unblock `rax == 0x41` as 'satisfied'."""
+        g = OneGadget(0x100, ["rax == 0x41"])
+        r = check_onegadget(g, {"eax": 0x41})  # wrong-width reg key
+        # Constraint neither met nor contradicted — stays pending; solver
+        # is free to pick rax == 0x41 so feasible remains True, but the
+        # crash-state key should not appear in 'satisfied'.
+        assert "rax == 0x41" not in r.satisfied
+        assert r.feasible is True
+
+    def test_crash_state_from_gdb_lowercases_keys(self):
+        assert crash_state_from_gdb({"RAX": "0x1", "RsP": "0x2"}) == {
+            "rax": 0x1, "rsp": 0x2,
+        }
+
+
+class TestSyntaxTolerance:
+    """Parser should be robust to case and whitespace variations that
+    one_gadget output can contain (upper-case NULL, padding spaces)."""
+
+    @_requires_z3
+    @pytest.mark.parametrize("constraint", [
+        "RAX == NULL",
+        "rax==NULL",
+        "rax  ==  NULL",
+        "  rax == null  ",
+    ])
+    def test_case_and_whitespace_insensitive(self, constraint):
+        g = OneGadget(0x100, [constraint])
+        r = check_onegadget(g, {"rax": 0})
+        assert constraint in r.satisfied
+
+
+class TestRankWithoutCrashState:
+    """`rank_onegadgets` must work when no crash state is provided — the
+    common ``analyze_binary()`` case. Ordering should still rank feasible
+    gadgets ahead of infeasible ones."""
+
+    @_requires_z3
+    def test_rank_without_crash_state_feasible_first(self):
+        feasible_g = OneGadget(0x100, ["rax == 0"])
+        infeasible_g = OneGadget(0x200, ["rax == 0", "rax != 0"])
+        ranked = rank_onegadgets([infeasible_g, feasible_g])
+        assert ranked[0][0].offset == 0x100
+        assert ranked[0][1].feasible is True
+        assert ranked[1][0].offset == 0x200
+        assert ranked[1][1].feasible is False
+
+    @_requires_z3
+    def test_rank_indeterminate_sits_between_feasible_and_infeasible(self):
+        """All-unparseable gadgets return ``feasible=None`` and must
+        rank below verifiably-feasible ones but above verifiably-
+        infeasible ones — ensures the bug-fix-induced verdict shift
+        never regresses back to ranking unverified gadgets at the top.
+        """
+        feasible   = OneGadget(0x100, ["rax == 0"])
+        indet      = OneGadget(0x200, ["(u16)[rbx] == NULL"])
+        infeasible = OneGadget(0x300, ["rax == 0", "rax != 0"])
+        order = [g.offset for g, _ in rank_onegadgets([infeasible, indet, feasible])]
+        assert order == [0x100, 0x200, 0x300]

--- a/packages/exploitability_validation/report.py
+++ b/packages/exploitability_validation/report.py
@@ -52,6 +52,20 @@ def generate_validation_report(
         "Pipeline": " → ".join(stages_run),
     }
 
+    # Flag SMT participation when Stage E ran — otherwise a one-gadget
+    # verdict without smt_feasibility is ambiguous (no gadgets? or z3
+    # missing?). Harmless to include even if no finding used it.
+    if stage_e_ran:
+        try:
+            from core.smt_solver import z3_available
+            metadata["SMT"] = (
+                "Z3 available"
+                if z3_available()
+                else "Z3 unavailable — install z3-solver for one-gadget constraint analysis"
+            )
+        except Exception:
+            pass
+
     # Build extra summary
     extra_summary = {}
     checklist = load_json(out / "checklist.json")

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ instructor>=1.0.0
 # Optional: For enhanced dataflow visualization (recommended)
 tabulate>=0.9.0
 
-# for Z3 solver
+# Optional: For SMT-based constraint analysis (one-gadget feasibility, etc.)
 # z3-solver==4.16.0.0
 
 # Optional: For web scanning package


### PR DESCRIPTION
Fixes two correctness gaps: check_onegadget returned feasible=True when every constraint was unparseable (no actual verification) and named all pending constraints as "unsatisfied" on joint-unsat when only the unsat-core subset actually conflicted. Adds scoped() for push/pop hypothesis probing and explain.track/core_names for naming which assertions Z3 used to derive unsat — both adopted by the refactored check_onegadget and exposed for future encoders. Also reg-gates non-x86_64 tokens, logs unparseable constraints, surfaces SMT status on analyze_binary() output and the /validate report header, and clarifies the z3-unknown reasoning to name the solver timeout. Test coverage roughly doubled (30 → 57).