### PR TITLE
fix: scope SAGE domain_tag per-repo to prevent same-basename contamination

### DIFF
--- a/core/sage/hooks.py
+++ b/core/sage/hooks.py
@@ -8,6 +8,7 @@ scan 1 stores findings, scan 2 recalls them as context.
 All hooks are no-ops when SAGE is unavailable.
 """
 
+import hashlib
 import os
 import time
 from pathlib import Path
@@ -56,6 +57,22 @@ def _get_client() -> Optional[SageClient]:
     return _client
 
 
+def _repo_key(repo_path: str) -> str:
+    # Resolve before hashing so that different paths that reach the same repo
+    # (symlinks, relative paths) collapse to the same key, and same-basename
+    # repos at different locations stay distinct.
+    resolved = str(Path(repo_path).resolve()) if repo_path else ""
+    return hashlib.sha256(resolved.encode()).hexdigest()[:12]
+
+
+def _findings_domain(repo_path: str) -> str:
+    return f"raptor-findings-{_repo_key(repo_path)}"
+
+
+def _exploits_domain(repo_path: str) -> str:
+    return f"raptor-exploits-{_repo_key(repo_path)}"
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Pre-analysis hook
 # ─────────────────────────────────────────────────────────────────────────────
@@ -81,7 +98,7 @@ def recall_context_for_scan(
 
         results = client.query(
             text=f"security findings and vulnerability patterns for {lang_str} project {repo_name}",
-            domain_tag="raptor-findings",
+            domain_tag=_findings_domain(repo_path),
             top_k=5,
         )
         methodology = client.query(
@@ -158,7 +175,7 @@ def store_scan_results(
             if client.propose(
                 content=content,
                 memory_type="observation",
-                domain_tag="raptor-findings",
+                domain_tag=_findings_domain(repo_path),
                 confidence=confidence,
             ):
                 stored += 1
@@ -182,7 +199,7 @@ def store_scan_results(
         client.propose(
             content=summary,
             memory_type="observation",
-            domain_tag="raptor-findings",
+            domain_tag=_findings_domain(repo_path),
             confidence=0.85,
         )
     except Exception:
@@ -222,7 +239,7 @@ def store_analysis_results(
         client.propose(
             content=summary,
             memory_type="observation",
-            domain_tag="raptor-findings",
+            domain_tag=_findings_domain(repo_path),
             confidence=0.85,
         )
 
@@ -239,7 +256,7 @@ def store_analysis_results(
                     client.propose(
                         content=content,
                         memory_type="fact",
-                        domain_tag="raptor-exploits",
+                        domain_tag=_exploits_domain(repo_path),
                         confidence=0.90,
                     )
                     _throttle()
@@ -251,20 +268,27 @@ def enrich_analysis_prompt(
     rule_id: str,
     file_path: str,
     language: str = "",
+    repo_path: Optional[str] = None,
 ) -> str:
     """
     Generate additional context from SAGE to enrich an analysis prompt.
-    Returns context string, or empty if SAGE unavailable / no matches.
+    Returns context string, or empty if SAGE unavailable / no matches /
+    no repo_path supplied.
+
+    repo_path is required to scope the recall to this repo's findings;
+    without it we'd query an empty domain (findings live under
+    raptor-findings-<repo_key>) and can't safely fall back to cross-repo
+    recall because same-basename repos would contaminate each other.
     """
     client = _get_client()
-    if client is None:
+    if client is None or not repo_path:
         return ""
 
     try:
         vuln_type = rule_id.rsplit(".", 1)[-1].replace("-", " ").replace("_", " ")
         results = client.query(
             text=f"{vuln_type} vulnerability findings and exploitability in {language} code",
-            domain_tag="raptor-findings",
+            domain_tag=_findings_domain(repo_path),
             top_k=3,
         )
 

--- a/core/sage/tests/test_sage_hooks.py
+++ b/core/sage/tests/test_sage_hooks.py
@@ -90,7 +90,9 @@ class TestEnrichAnalysisPrompt(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         from core.sage.hooks import enrich_analysis_prompt
-        result = enrich_analysis_prompt("sql-injection", "src/db.py", "python")
+        result = enrich_analysis_prompt(
+            "sql-injection", "src/db.py", "python", repo_path="/path/to/repo"
+        )
         self.assertIn("Historical Context from SAGE", result)
         self.assertIn("SQL injection pattern", result)
 
@@ -101,7 +103,20 @@ class TestEnrichAnalysisPrompt(unittest.TestCase):
         mock_get_client.return_value = mock_client
 
         from core.sage.hooks import enrich_analysis_prompt
+        self.assertEqual(
+            enrich_analysis_prompt("rule-123", "src/app.py", repo_path="/repo"), ""
+        )
+
+    @patch("core.sage.hooks._get_client")
+    def test_returns_empty_without_repo_path(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        from core.sage.hooks import enrich_analysis_prompt
+        # No repo_path → skip query entirely (unscoped recall would leak
+        # cross-repo since same-basename repos now live under distinct domains).
         self.assertEqual(enrich_analysis_prompt("rule-123", "src/app.py"), "")
+        mock_client.query.assert_not_called()
 
 
 class TestStoreAnalysisResults(unittest.TestCase):


### PR DESCRIPTION
Addresses @grokjc's review note on #190: `core/sage/hooks.py` was keying SAGE queries and storage off `Path(repo_path).name`, so two repos sharing a basename (e.g. `/a/project` and `/b/project`) would write to and recall from the same `raptor-findings` / `raptor-exploits` domain.

## Change

- Scope key: `sha256(Path(repo_path).resolve())[:12]`, folded into `domain_tag` — that's the only field the REST semantic-query endpoint filters on today, so tags can't carry the scope (I dug into the SAGE server/SDK to confirm).
- `raptor-findings` → `raptor-findings-{repo_key}` (same for `raptor-exploits`).
- `raptor-methodology` stays global — cross-repo generalizable knowledge, not repo identity.
- `enrich_analysis_prompt` gains an optional `repo_path` param and short-circuits without it. Unscoped recall would leak cross-repo, defeating the fix; callers that don't yet thread `repo_path` get a no-op instead of a leak.

## On "project name as tag"

Worth flagging for future: tags exist in the SAGE store layer but aren't wired through on the hot path — `SubmitMemoryRequest` has no `tags` field and the semantic query endpoint has no tag filter. So tags today are attribution metadata for the dashboard, not a recall-filter primitive. I've noted it on the SAGE side to address separately.

## On agent-identity

SAGE already stamps `submitting_agent` on every write and does RBAC-based visibility on reads — a stronger primitive than a path-hash because it's cryptographic. Per-checkout `AgentIdentity` (register once, let `visible_agents` do the namespacing) is a real shape change though — key material per checkout, registration flow — worth a separate PR if that's the direction. Happy to draft.

## Tests

15/15 pass. Preserved `TestThrottle` (from #192), updated the two `enrich_analysis_prompt` tests to pass `repo_path`, added `test_returns_empty_without_repo_path` as regression.

## Branching note

Built fresh off `sage_integration` (cherry-pick from the post-squash #190 branch would've regressed the `_throttle()` env-knob from #192). Targets `sage_integration`.