### PR TITLE
fix: SAGE setup — working healthcheck + correct SDK method on registrar

### DIFF
--- a/core/sage/scripts/register_agents.py
+++ b/core/sage/scripts/register_agents.py
@@ -296,7 +296,7 @@ async def register_agents(sage_url: str, dry_run: bool = False):
 
     # Register the registrar agent first
     try:
-        await client.register("raptor-registrar")
+        await client.register_agent("raptor-registrar")
         print("Registered as raptor-registrar\n")
     except Exception as e:
         print(f"Registration note: {e}\n")

--- a/docker-compose.sage.yml
+++ b/docker-compose.sage.yml
@@ -40,7 +40,7 @@ services:
       - OLLAMA_HOST=http://ollama:11434
 
   sage:
-    image: ghcr.io/l33tdawg/sage:6.5.5
+    image: ghcr.io/l33tdawg/sage:6.6.0
     ports:
       - "8090:8080"
     volumes:

--- a/docker-compose.sage.yml
+++ b/docker-compose.sage.yml
@@ -52,7 +52,8 @@ services:
       - OLLAMA_URL=http://ollama:11434
       - REST_ADDR=0.0.0.0:8080
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      # ghcr.io/l33tdawg/sage images ship with wget, not curl
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/health >/dev/null || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,5 +28,5 @@ tabulate>=0.9.0
 # https://ollama.ai
 
 # SAGE persistent memory (consensus-validated knowledge)
-# pip install sage-agent-sdk==6.5.5
+# pip install sage-agent-sdk==6.6.0
 httpx>=0.27.0


### PR DESCRIPTION
Two small bugs caught during an end-to-end test of `libexec/raptor-sage-setup` (per @grokjc's ask on #190 to give it a shakedown).

## 1. docker-compose.sage.yml healthcheck

`test: ["CMD", "curl", ...]` but the `ghcr.io/l33tdawg/sage:6.5.5` image ships with `wget` only. Container permanently reports `(unhealthy)` even though `/health` returns 200 from the host side:

```
$ docker inspect raptor-sage-1 --format '{{range .State.Health.Log}}{{.Output}}{{end}}'
OCI runtime exec failed: exec: "curl": executable file not found in $PATH
```

No functional break today (nothing `depends_on: service_healthy` for sage), but the status lies and any future dep would wedge. Switch to `wget -qO- .../health`.

## 2. register_agents.py:299 calls nonexistent method

`await client.register("raptor-registrar")` — `AsyncSageClient` exposes `register_agent`, not `register` (verified: `register_agent`, `register_dept`, `register_domain`, `register_org` are the only `register*` methods). The bare `except` swallows the error, prints `Registration note: 'AsyncSageClient' object has no attribute 'register'`, and moves on — so the 16 agent memory-proposes still succeed via `client.propose()`, but the registrar identity itself never gets stamped into SAGE's agent registry.

Fix the method name. `core/sage/client.py:194` already does the right thing via `hasattr(client, "register_agent")` — this script just missed the memo.

## Verification

End-to-end install/uninstall both clean:
- `raptor-sage-1` now shows `Up 4 minutes (healthy)` (was `(unhealthy)`)
- `register_agent` now dispatches correctly (verified via `python3 -c "from sage_sdk.async_client import AsyncSageClient; print([m for m in dir(AsyncSageClient) if 'regist' in m])"`)
- Seeding still writes 87/87 entries, agent proposes still succeed 16/16

## Heads-up on SAGE-side follow-up

Fixing #2 now surfaces a separate **SAGE** bug: 3-way inconsistency on `AgentRegistration.registered_at`:
- Go struct (`internal/store/badger.go:72`): `RegisteredAt int64` — block height
- `openapi.yaml:399`: `string` with `format: date-time`
- Python SDK `models.py:189`: `str | None`

Server sends `{"registered_at": 92}` (int), SDK pydantic-validates as string → `validation error`. Registrar still ends up as a no-op until SAGE patches this. That's a SAGE repo fix, **not raptor** — I'll raise it there. Our `register_agent` call here is correct; when SAGE fixes the type mismatch, raptor benefits automatically with no further change here.

## Risk

Both changes are 1-line, no behavior shifts beyond what the diff literally says. Compose healthcheck change doesn't alter runtime, just reporting. Registrar change is inert until SAGE-side is fixed.