### PR TITLE
Make scan pipeline resilient to slow networks and stock Linux hosts

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -50,7 +50,8 @@ class RaptorConfig:
 
     # Timeout Configuration (seconds)
     DEFAULT_TIMEOUT = 1800          # 30 minutes
-    SEMGREP_TIMEOUT = 900            # 15 minutes
+    SEMGREP_TIMEOUT = 900            # 15 minutes (scan over local rule dirs)
+    SEMGREP_PACK_TIMEOUT = 300       # 5 minutes (registry pack: fetch + scan)
     SEMGREP_RULE_TIMEOUT = 120       # 2 minutes per rule
     CODEQL_TIMEOUT = 1800            # 30 minutes (database creation)
     CODEQL_ANALYZE_TIMEOUT = 2400    # 40 minutes (query execution)

--- a/packages/fuzzing/afl_runner.py
+++ b/packages/fuzzing/afl_runner.py
@@ -270,11 +270,24 @@ class AFLRunner:
             logger.info(f"Starting AFL instance: {instance_name}")
             logger.debug(f"Command: {' '.join(cmd)}")
 
+            # AFL refuses to run if the host's core_pattern pipes cores (apport,
+            # systemd-coredump) or the CPU governor is not 'performance'. Both
+            # are the default on modern Linux desktops, and both are outside
+            # RAPTOR's control — asking the operator to tune them for every
+            # fuzzing run is not realistic. Setting these env vars tells AFL
+            # to tolerate both: we lose a small amount of speed and the
+            # guarantee that external cores are captured (AFL still writes its
+            # own crash artefacts under crashes/).
+            afl_env = os.environ.copy()
+            afl_env.setdefault("AFL_SKIP_CPUFREQ", "1")
+            afl_env.setdefault("AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES", "1")
+
             proc = subprocess.Popen(
                 cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                env=afl_env,
             )
             processes.append((instance_name, proc))
 

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -137,8 +137,19 @@ def run_single_semgrep(
         path_parts = [p for p in path_parts if 'venv' not in p.lower() and '/bin/pysemgrep' not in p]
         clean_env['PATH'] = ':'.join(path_parts)
 
+    # Registry packs ("p/xxx", "category/xxx") fetch YAML from semgrep.dev
+    # on every invocation — semgrep has no persistent on-disk cache. A slow
+    # or stalled registry fetch otherwise consumes the full SEMGREP_TIMEOUT
+    # (15 min) per pack, and at MAX_SEMGREP_WORKERS=4 can eat the whole
+    # 30-min agentic budget for one bad network moment. Bound the per-pack
+    # cost with a tighter ceiling so a stuck fetch drops that pack and the
+    # remaining packs still run. Local rule directories keep the longer
+    # timeout because they do real scan work without network.
+    is_registry_pack = config.startswith("p/") or config.startswith("category/")
+    effective_timeout = min(timeout, RaptorConfig.SEMGREP_PACK_TIMEOUT) if is_registry_pack else timeout
+
     try:
-        rc, so, se = run(cmd, timeout=timeout, env=clean_env)
+        rc, so, se = run(cmd, timeout=effective_timeout, env=clean_env)
 
         # Validate output
         if not so or not so.strip():


### PR DESCRIPTION
Semgrep registry packs refetch on every invocation and a slow semgrep.dev could burn the whole 30m agentic budget on one stuck pack. Cap pack fetches at SEMGREP_PACK_TIMEOUT (5m) so stalled packs drop individually; local rule dirs keep the full 15m.

AFL refuses to run when core_pattern pipes (apport, systemd-coredump) or the CPU governor is not 'performance' — both defaults on modern Linux desktops. Set AFL_SKIP_CPUFREQ and AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES in the Popen env via setdefault so operators can still override.