### PR TITLE
Move test_security_mitigations.py into core/security/tests/

### DIFF
--- a/core/security/tests/test_security_mitigations.py
+++ b/core/security/tests/test_security_mitigations.py
@@ -8,8 +8,8 @@ from unittest.mock import patch
 
 import pytest
 
-# tests/test_security_mitigations.py -> repo root
-sys.path.insert(0, str(Path(__file__).parents[1]))
+# core/security/tests/test_security_mitigations.py -> repo root
+sys.path.insert(0, str(Path(__file__).parents[3]))
 
 from core.config import RaptorConfig
 


### PR DESCRIPTION
The file tests get_safe_env() which lives in core/config.py; co-locate with the code it exercises, matching the pattern used by the other tests in core/security/tests/ (test_cc_trust.py, test_wrapper.py). Path-depth constant updated from parents[1] to parents[3].