### PR TITLE
Bugfix in SMT - Multiple calls on `track()` might corrupt unsat-core names

### DIFF
--- a/core/smt_solver/explain.py
+++ b/core/smt_solver/explain.py
@@ -15,12 +15,16 @@ Usage::
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from .availability import z3
 
 
-def track(solver: Any, labeled: Sequence[Tuple[str, Any]]) -> Dict[str, str]:
+def track(
+        solver: Any, 
+        labeled: Sequence[Tuple[str, Any]],
+        rev: Optional[Dict[str, str]] = None,
+) -> Dict[str, str]:
     """Assert each labelled expression via ``assert_and_track``.
 
     Returns a mapping from the generated Z3 label identifier back to the
@@ -28,14 +32,18 @@ def track(solver: Any, labeled: Sequence[Tuple[str, Any]]) -> Dict[str, str]:
     ``solver.unsat_core()`` output.  Existing (non-tracked) assertions on
     the solver are unaffected and will not appear in the unsat core.
 
-    One-shot per solver: labels are generated as ``_c0``, ``_c1``, ... so
-    calling ``track`` twice on the same solver will collide.  If you need
-    to probe multiple batches, use a fresh solver (or merge the batches
-    into one call).
+    Pass an existing ``rev`` dict to chain multiple batches on 
+    the same solver safely — the label counter is derived from 
+    ``len(rev)`` so new labels never collide with previously 
+    tracked ones.  When ``rev`` is ``None`` (default) a fresh
+    dict is created, matching the original single-call behaviour.
     """
-    rev: Dict[str, str] = {}
+
+    if rev is None:
+        rev = {}
+    offset = len(rev)
     for i, (name, expr) in enumerate(labeled):
-        label = z3.Bool(f"_c{i}")
+        label = z3.Bool(f"_c{offset+i}")
         solver.assert_and_track(expr, label)
         rev[str(label)] = name
     return rev

--- a/core/smt_solver/tests/test_smt_solver.py
+++ b/core/smt_solver/tests/test_smt_solver.py
@@ -187,3 +187,30 @@ class TestExplain:
         # Only the tracked assertion is named; the untracked `x == 1`
         # pulled us into unsat but isn't reported by core_names.
         assert names == ["clash"]
+
+    @_requires_z3
+    def test_track_chained_batches_no_label_collision(self):
+        """Calling track() twice on the same solver with the same rev dict
+        must not produce colliding labels.  The bug was that both calls
+        would generate ``_c0``, ``_c1``, ... — corrupting the rev map so
+        core_names returned wrong (or missing) constraint names."""
+        from core.smt_solver import core_names, new_solver, track, z3
+        solver = new_solver()
+        x = z3.BitVec("x", 64)
+        y = z3.BitVec("y", 64)
+
+        # First batch: x constraints.
+        rev = track(solver, [("x_is_1", x == 1)])
+        # Second batch chained onto the same rev — labels must start at _c1.
+        track(solver, [("x_is_2", x == 2), ("y_is_0", y == 0)], rev=rev)
+
+        assert solver.check() == z3.unsat
+
+        names = set(core_names(solver, rev))
+        # x_is_1 and x_is_2 are the conflicting pair; y_is_0 is satisfiable
+        # alongside either x constraint, so it may or may not appear in the
+        # minimal core.  The important thing: all three names are in rev and
+        # no name is missing or duplicated due to label collision.
+        assert "x_is_1" in names or "x_is_2" in names
+        assert len(rev) == 3
+        assert set(rev.values()) == {"x_is_1", "x_is_2", "y_is_0"}


### PR DESCRIPTION
Calling `track()` twice on the same solver with the same `rev` dict must not produce colliding labels.  The bug was that both calls would generate `_c0`, `_c1`, ... — corrupting the `rev` map so `core_names` returned wrong (or missing) constraint names, especially for large projects. This would make the output unreliable. 

What's added:
* A Fix in `core/smt_solver/explain.py`
* Tests in `core/smt_solver/tests/test_smt_solver.py`

**NB** - this bug isn't actually triggered in the existing `packages/exploit_feasibility/smt_onegadget.py` usage of `track()` but came up in my testing for other stuff and it seems prudent to lay the groundwork for some flexibility here ahead of time. 😊