### PR TITLE
Fix caplog not capturing RaptorLogger output in Ollama warning tests

### DIFF
--- a/packages/llm_analysis/tests/test_ollama_warning.py
+++ b/packages/llm_analysis/tests/test_ollama_warning.py
@@ -16,6 +16,19 @@ from packages.llm_analysis.llm.client import LLMClient
 from packages.llm_analysis.llm.config import ModelConfig, LLMConfig
 
 
+@pytest.fixture(autouse=True)
+def _attach_caplog_to_raptor_logger(caplog):
+    """RaptorLogger sets propagate=False, so caplog (attached to root) misses
+    its records. Attach caplog's handler directly to the 'raptor' logger for
+    the duration of each test in this module."""
+    raptor_logger = logging.getLogger("raptor")
+    raptor_logger.addHandler(caplog.handler)
+    try:
+        yield
+    finally:
+        raptor_logger.removeHandler(caplog.handler)
+
+
 class TestOllamaWarning:
     """Test 10: Verify warning appears when using Ollama for exploit generation."""
 


### PR DESCRIPTION
PR #201 (which un-skipped test_ollama_warning_on_init and test_warning_appears_once) was incomplete: RaptorLogger sets propagate=False on the 'raptor' logger, so caplog — which attaches to the root logger — captures zero records.

The two tests un-skipped by #201 now silently pass; the two pre-existing tests (message_content, format) were also affected but use 'if ollama_warnings:' so they fall through without asserting. Both behaviours mask the RaptorLogger output.

Add an autouse fixture that attaches caplog's handler directly to the 'raptor' logger for each test, bypassing propagate=False. All four tests now genuinely exercise their assertions.