### PR TITLE
Enhancement of CodeQL Analysis with SMT Solver

### DIFF
--- a/.claude/commands/codeql.md
+++ b/.claude/commands/codeql.md
@@ -25,13 +25,32 @@ python3 raptor.py codeql --repo <path> [options]
 | `--force` | Force database recreation |
 | `--max-findings <n>` | Max findings to analyse (with `--analyze`) |
 
+## SMT Dataflow Pre-Check
+
+When `--analyze` is enabled, dataflow findings are routed through an SMT
+pre-check before the full LLM analysis (`packages/codeql/smt_path_validator.py`):
+
+1. The LLM extracts branch conditions from each path step as structured predicates
+   (`"size > 0"`, `"offset + length <= buffer_size"`, etc.)
+2. Z3 checks whether those conditions are **jointly satisfiable**
+3. **unsat** → path is provably unreachable; finding skipped (no LLM call)
+4. **sat** → concrete satisfying values returned; fed as candidate inputs into the
+   LLM prompt and `prerequisites` field of `DataflowValidation`
+5. **None** → Z3 unavailable or conditions unparseable; full LLM analysis runs
+
+Requires `z3-solver` (`pip install z3-solver`). Degrades gracefully when absent.
+
+**Best coverage:** CWE-190 (integer overflow), CWE-120/122 (buffer size checks),
+CWE-193 (off-by-one), CWE-476 (null deref). String-based findings (CWE-89) fall
+through to LLM analysis.
+
 ## Examples
 
 ```bash
 # Scan only (default) — produces SARIF
 /codeql --repo /tmp/vulns
 
-# Full autonomous analysis
+# Full autonomous analysis (includes SMT dataflow pre-check if z3 installed)
 /codeql --repo /tmp/vulns --analyze
 
 # Specific language with custom build

--- a/.claude/skills/exploitability-validation/stage-e-feasibility.md
+++ b/.claude/skills/exploitability-validation/stage-e-feasibility.md
@@ -113,6 +113,23 @@ From the analysis result, also note:
 | `exploitation_paths` | Structured technique+target pairs |
 | `one_gadget_info.smt_feasibility` | SMT constraint verdict (see below) |
 
+**SMT feasibility (CodeQL dataflow):** For source-level dataflow findings, an SMT
+pre-check runs in `DataflowValidator` before the full LLM analysis
+(`packages/codeql/smt_path_validator.py`). The LLM extracts path conditions as
+structured predicates; Z3 checks joint satisfiability:
+
+- `feasible: true` — path is reachable; `model` contains concrete variable values
+  (candidate PoC inputs). These are injected into the LLM prompt and the
+  `DataflowValidation.prerequisites` field.
+- `feasible: false` — path conditions are mutually exclusive; finding is likely a
+  false positive. The `unsatisfied` list names the specific conflicting conditions
+  (from the unsat core). LLM analysis is skipped entirely.
+- `feasible: null` — Z3 unavailable or all conditions unparseable; full LLM
+  analysis runs unchanged.
+
+Best coverage: CWE-190 (integer overflow — Z3 will find wraparound bypass paths),
+CWE-120/122 (buffer size arithmetic), CWE-193 (off-by-one), CWE-476 (null deref).
+
 **SMT feasibility (one-gadget):** When the optional `z3-solver` package is installed, `analysis.one_gadget_info.smt_feasibility` contains a Z3-backed verdict on whether the best gadget's register/memory constraints can be satisfied:
 
 - `feasible: true` — constraints satisfiable; one-gadget is a viable target. The `model` dict shows what register values Z3 requires.

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,3 @@ out/
 
 # Runtime artifacts
 codeql_dbs/
-
-# Testbench data to ignore
-test/data/testbench

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ out/
 
 # Runtime artifacts
 codeql_dbs/
+
+test/data/

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ out/
 # Runtime artifacts
 codeql_dbs/
 
-test/data/
+# Testbench data to ignore
+test/data/testbench

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,6 +275,20 @@ print(format_analysis_summary(result, verbose=True))
 
 **The `exploitation_paths` section tells you if code execution is actually possible** given the system's mitigations (glibc version, RELRO, etc.).
 
+**SMT integration (optional, requires `pip install z3-solver`):**
+
+Two places Z3 is used — both degrade gracefully when absent:
+
+1. **Binary / one-gadget** (`packages/exploit_feasibility/smt_onegadget.py`): checks
+   whether a one-gadget's register/memory constraints are satisfiable given a crash
+   state. Result in `exploitation_paths[vuln].one_gadget_info.smt_feasibility`.
+
+2. **CodeQL dataflow** (`packages/codeql/smt_path_validator.py`): checks whether the
+   branch conditions along a dataflow path are jointly satisfiable. `unsat` → false
+   positive, skip LLM. `sat` → concrete input values fed into the LLM prompt and
+   `DataflowValidation.prerequisites`. Best coverage: CWE-190, CWE-120/122,
+   CWE-193, CWE-476.
+
 ---
 
 ## EXPLOIT DEVELOPMENT

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ demonstrates how Claude Code can be adapted for **any purpose**, with RAPTOR pac
 - **Cost Management:** Budget enforcement, real-time callbacks, and intelligent quota detection
 - **Enhanced Reliability:** Multiple bug fixes improving robustness across CodeQL, static analysis, and LLM providers
 - **Code Understanding** We wanted to build more adversarial code comprehension, which allows you to map attack surface, trace those vital data flows &amp; hunt for vulnerability variants
-- **Z3 SMT Engine:** Two-layer SMT integration, both optional (`pip install z3-solver`) and gracefully absent-safe. (1) **Dataflow pre-screening:** CodeQL path conditions are checked for joint satisfiability before any LLM call — provably unreachable paths are discarded, satisfiable paths get concrete candidate inputs injected into the prompt. (2) **One-gadget constraint analysis:** during binary feasibility assessment, Z3 checks whether a one-gadget's register/memory constraints are satisfiable given the concrete crash state, ranking gadgets by actual reachability rather than heuristics alone.
+- **Z3 SMT Engine:** Two-layer SMT integration, both optional (`pip install z3-solver`) and gracefully absent-safe.
+  - **Dataflow pre-screening:** CodeQL path conditions are checked for joint satisfiability before any LLM call — provably unreachable paths are discarded, satisfiable paths get concrete candidate inputs injected into the prompt.
+  - **One-gadget constraint analysis:** during binary feasibility assessment, Z3 checks whether a one-gadget's register/memory constraints are satisfiable given the concrete crash state, ranking gadgets by actual reachability rather than heuristics alone.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ demonstrates how Claude Code can be adapted for **any purpose**, with RAPTOR pac
 - **Cost Management:** Budget enforcement, real-time callbacks, and intelligent quota detection
 - **Enhanced Reliability:** Multiple bug fixes improving robustness across CodeQL, static analysis, and LLM providers
 - **Code Understanding** We wanted to build more adversarial code comprehension, which allows you to map attack surface, trace those vital data flows &amp; hunt for vulnerability variants
+- **Z3 SMT Engine:** Two-layer SMT integration, both optional (`pip install z3-solver`) and gracefully absent-safe. (1) **Dataflow pre-screening:** CodeQL path conditions are checked for joint satisfiability before any LLM call — provably unreachable paths are discarded, satisfiable paths get concrete candidate inputs injected into the prompt. (2) **One-gadget constraint analysis:** during binary feasibility assessment, Z3 checks whether a one-gadget's register/memory constraints are satisfiable given the concrete crash state, ranking gadgets by actual reachability rather than heuristics alone.
 
 ---
 
@@ -308,7 +309,7 @@ docker build -f .devcontainer/Dockerfile -t raptor-devcontainer:latest .
 /fuzz     - Binary fuzzing (AFL++ + crash analysis)
 /web      - Web application security testing (STUB - treat as alpha)
 /agentic  - Full autonomous workflow (analysis + exploit/patch generation)
-/codeql   - CodeQL-only deep analysis with dataflow
+/codeql   - CodeQL-only deep analysis with dataflow + Z3 SMT path pre-screening
 /analyze  - LLM analysis only (no exploit/patch generation - 50% faster & cheaper)
 /validate - Exploitability validation pipeline
 ```

--- a/packages/codeql/dataflow_validator.py
+++ b/packages/codeql/dataflow_validator.py
@@ -12,6 +12,12 @@ from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from packages.codeql.smt_path_validator import (
+    PathCondition,
+    PathSMTResult,
+    check_path_feasibility,
+)
+
 # Add parent directory to path for imports
 # packages/codeql/dataflow_validator.py -> repo root
 sys.path.insert(0, str(Path(__file__).parents[2]))
@@ -55,6 +61,11 @@ class DataflowValidation:
     barriers: List[str]
     prerequisites: List[str]
 
+
+PATH_CONDITIONS_SCHEMA = {
+    "path_conditions": "list of {step_index: int, condition: str, negated: bool}",
+    "unparseable": "list of strings — conditions too complex to express as simple predicates",
+}
 
 # Dict schema for LLM structured generation (consistent with other callers)
 DATAFLOW_VALIDATION_SCHEMA = {
@@ -188,6 +199,68 @@ class DataflowValidator:
             self.logger.warning(f"Failed to read source context: {e}")
             return ""
 
+    def _extract_path_conditions(
+        self,
+        dataflow: DataflowPath,
+        repo_path: Path,
+    ) -> List[PathCondition]:
+        """Ask the LLM to extract branch conditions from the dataflow path.
+
+        Returns a (possibly empty) list of PathCondition objects.  Failures
+        are non-fatal — an empty list causes SMT to return feasible=True and
+        the full LLM validation still runs.
+        """
+        path_summary = []
+        for i, step in enumerate([dataflow.source] + dataflow.intermediate_steps + [dataflow.sink]):
+            ctx = self.read_source_context(str(repo_path / step.file_path), step.line, context_lines=5)
+            path_summary.append(f"STEP {i} ({step.label}) — {step.file_path}:{step.line}\n{ctx}")
+
+        prompt = f"""You are analysing a CodeQL dataflow path for exploitability.
+
+RULE: {dataflow.rule_id}
+MESSAGE: {dataflow.message}
+
+DATAFLOW STEPS:
+{chr(10).join(path_summary)}
+
+Extract every branch condition or guard that must hold for execution to
+reach the sink. Express each as a simple predicate over named variables,
+for example:
+  "size > 0", "offset + length <= buffer_size", "ptr != NULL",
+  "flags & 0x80000000 == 0"
+
+Set negated=true if the condition must be FALSE for the path to proceed
+(i.e. a check that was bypassed).
+
+Respond in JSON:
+{{
+  "path_conditions": [
+    {{"step_index": 0, "condition": "size > 0", "negated": false}},
+    ...
+  ],
+  "unparseable": ["any condition too complex to express as a simple predicate"]
+}}
+"""
+        try:
+            response, _ = self.llm.generate_structured(
+                prompt=prompt,
+                schema=PATH_CONDITIONS_SCHEMA,
+                system_prompt="You are an expert security researcher extracting path conditions from code.",
+            )
+            conditions = [
+                PathCondition(
+                    text=c.get("condition", ""),
+                    step_index=c.get("step_index", 0),
+                    negated=bool(c.get("negated", False)),
+                )
+                for c in response.get("path_conditions", [])
+                if c.get("condition")
+            ]
+            return conditions
+        except Exception as e:
+            self.logger.debug(f"Path condition extraction failed: {e}")
+            return []
+
     def validate_dataflow_path(
         self,
         dataflow: DataflowPath,
@@ -204,6 +277,35 @@ class DataflowValidator:
             DataflowValidation result
         """
         self.logger.info(f"Validating dataflow path: {dataflow.rule_id}")
+
+        # SMT pre-check: extract path conditions and test joint satisfiability.
+        # If unsat, the path is provably unreachable — skip the expensive LLM call.
+        conditions = self._extract_path_conditions(dataflow, repo_path)
+        smt_result = check_path_feasibility(conditions)
+
+        if smt_result.feasible is False:
+            self.logger.info(
+                f"SMT: path infeasible — {smt_result.reasoning}"
+            )
+            return DataflowValidation(
+                is_exploitable=False,
+                confidence=0.9,
+                sanitizers_effective=True,
+                bypass_possible=False,
+                bypass_strategy=None,
+                attack_complexity="high",
+                reasoning=f"SMT analysis: {smt_result.reasoning}",
+                barriers=smt_result.unsatisfied,
+                prerequisites=[],
+            )
+
+        # Path is sat or indeterminate — run full LLM analysis.
+        # Pass the SMT model (concrete variable values) as 
+        # candidate inputs. Skip if no Z3.
+        smt_hint = (
+            f"\nSMT pre-analysis: {smt_result.reasoning}"
+            + (f"\nCandidate input values: {smt_result.model}" if smt_result.model else "")
+        ) if smt_result.smt_available else ""
 
         # Read source context for key locations
         source_context = self.read_source_context(
@@ -249,7 +351,7 @@ Line: {dataflow.sink.line}
 
 {sink_context}
 
-SANITIZERS DETECTED: {', '.join(dataflow.sanitizers) if dataflow.sanitizers else 'None'}
+SANITIZERS DETECTED: {', '.join(dataflow.sanitizers) if dataflow.sanitizers else 'None'}{smt_hint}
 
 Analyze this dataflow path and determine:
 

--- a/packages/codeql/dataflow_validator.py
+++ b/packages/codeql/dataflow_validator.py
@@ -289,12 +289,16 @@ Respond in JSON:
             )
             return DataflowValidation(
                 is_exploitable=False,
-                confidence=0.9,
+                confidence=0.7,  # Some confidence since SMT is a strong signal, but not perfect
                 sanitizers_effective=True,
                 bypass_possible=False,
                 bypass_strategy=None,
                 attack_complexity="high",
-                reasoning=f"SMT analysis: {smt_result.reasoning}",
+                reasoning=(
+                    f"SMT analysis: {smt_result.reasoning}. Path conditions are mutually exclusive. "
+                    "Confidence is capped at 0.7 because this formal verdict depends on "
+                    "LLM-extracted predicates which may have parsing or coverage limitations."
+                ),
                 barriers=smt_result.unsatisfied,
                 prerequisites=[],
             )

--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""
+SMT-based path condition feasibility checker for CodeQL dataflow findings.
+
+The LLM extracts branch conditions from a dataflow path as structured
+constraint strings; this module encodes them into Z3 bitvector expressions
+and checks whether they are jointly satisfiable.
+
+- sat   → path is reachable; model gives concrete variable values for PoC
+- unsat → path conditions are mutually exclusive (likely false positive);
+          unsat core names the specific conflicting conditions
+- None  → Z3 unavailable or all conditions unparseable; fall back to LLM
+
+Accepted condition forms (case-insensitive):
+  size > 0
+  size < 1024
+  offset + length <= buffer_size
+  ptr != NULL  /  ptr == NULL
+  index >= 0
+  flags & 0x80000000 == 0
+  value == 42
+
+Variables are created as 64-bit bitvectors.  Signed comparisons are used
+by default; pass signed=False for address/pointer predicates.
+
+Integration: packages/codeql/dataflow_validator.py :: DataflowValidator
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from core.logging import get_logger as _get_logger
+from core.smt_solver import (
+    DEFAULT_TIMEOUT_MS as _DEFAULT_TIMEOUT_MS,
+    core_names as _core_names,
+    mk_val as _mk_val,
+    mk_var as _mk_var,
+    new_solver as _new_solver,
+    scoped as _scoped,
+    track as _track,
+    z3,
+    z3_available as _z3_available,
+)
+from core.smt_solver.bitvec import ge, gt, le, lt
+from core.smt_solver.witness import format_witness as _format_witness
+
+_WIDTH = 64
+_SIGNED = False
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PathCondition:
+    """A single guard/branch condition extracted from a dataflow step."""
+    text: str
+    step_index: int
+    negated: bool = False
+
+
+@dataclass
+class PathSMTResult:
+    """Result of SMT feasibility check over a set of path conditions."""
+    feasible: Optional[bool]
+    satisfied: List[str]
+    unsatisfied: List[str]
+    unknown: List[str]
+    model: Dict[str, int]
+    smt_available: bool
+    reasoning: str
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+_HEX_RE = re.compile(r'^0x[0-9a-f]+$', re.IGNORECASE)
+_INT_RE = re.compile(r'^\d+$')
+_IDENT_RE = re.compile(r'^[a-z_][a-z0-9_]*$', re.IGNORECASE)
+_NULL_RE = re.compile(r'^NULL$', re.IGNORECASE)
+
+# Tokenise: identifiers, hex literals, decimal literals, operators
+_TOKEN_RE = re.compile(
+    r'(0x[0-9a-f]+|\d+|[a-z_][a-z0-9_]*|[+\-*]|<=|>=|!=|==|[<>&])',
+    re.IGNORECASE,
+)
+
+
+def _parse_expr(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
+    """Parse an arithmetic expression into a Z3 bitvector.
+
+    Handles: identifier, NULL, hex literal, decimal literal,
+    and binary +/- between those terms.
+    Does NOT handle precedence beyond left-to-right +/-.
+    """
+    tokens = [t for t in _TOKEN_RE.findall(text.strip()) if t not in ('(', ')')]
+    if not tokens:
+        return None
+
+    def atom(tok: str) -> Optional[Any]:
+        if _NULL_RE.match(tok):
+            return _mk_val(0, width=_WIDTH)
+        if _HEX_RE.match(tok):
+            return _mk_val(int(tok, 16), width=_WIDTH)
+        if _INT_RE.match(tok):
+            return _mk_val(int(tok), width=_WIDTH)
+        if _IDENT_RE.match(tok):
+            if tok.lower() not in vars_:
+                vars_[tok.lower()] = _mk_var(tok.lower(), width=_WIDTH)
+            return vars_[tok.lower()]
+        return None
+
+    # Left-to-right accumulation of +/-
+    result = atom(tokens[0])
+    if result is None:
+        return None
+    i = 1
+    while i < len(tokens) - 1:
+        op = tokens[i]
+        if op not in ('+', '-'):
+            break
+        right = atom(tokens[i + 1])
+        if right is None:
+            return None
+        result = (result + right) if op == '+' else (result - right)
+        i += 2
+
+    return result
+
+
+def _parse_condition(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
+    """Parse a single condition string into a Z3 boolean expression.
+
+    Recognised forms:
+      lhs == rhs / lhs != rhs
+      lhs < rhs  / lhs <= rhs / lhs > rhs / lhs >= rhs
+      lhs & mask == val  (bitmask alignment)
+      lhs & mask != val
+
+    Conditions containing function-call syntax (parentheses) are rejected
+    and return None — they go to the unknown list.
+    """
+    t = text.strip()
+
+    if '(' in t or ')' in t:
+        return None
+
+    # Bitmask: lhs & mask (==|!=) val
+    m = re.fullmatch(
+        r'(.+?)\s*&\s*(0x[0-9a-f]+|\d+)\s*(==|!=)\s*(0x[0-9a-f]+|\d+)',
+        t, re.IGNORECASE,
+    )
+    if m:
+        lhs = _parse_expr(m.group(1).strip(), vars_)
+        if lhs is None:
+            return None
+        masked = lhs & _mk_val(int(m.group(2), 0), width=_WIDTH)
+        rhs = _mk_val(int(m.group(4), 0), width=_WIDTH)
+        return (masked == rhs) if m.group(3) == '==' else (masked != rhs)
+
+    # Relational: lhs OP rhs
+    m = re.fullmatch(r'(.+?)\s*(<=|>=|!=|==|<|>)\s*(.+)', t)
+    if m:
+        lhs = _parse_expr(m.group(1).strip(), vars_)
+        rhs = _parse_expr(m.group(3).strip(), vars_)
+        if lhs is None or rhs is None:
+            return None
+        op = m.group(2)
+        if op == '==':
+            return lhs == rhs
+        if op == '!=':
+            return lhs != rhs
+        if op == '<':
+            return lt(lhs, rhs, signed=_SIGNED)
+        if op == '<=':
+            return le(lhs, rhs, signed=_SIGNED)
+        if op == '>':
+            return gt(lhs, rhs, signed=_SIGNED)
+        if op == '>=':
+            return ge(lhs, rhs, signed=_SIGNED)
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def check_path_feasibility(
+    conditions: List[PathCondition],
+) -> PathSMTResult:
+    """
+    Check whether a set of path conditions are jointly satisfiable.
+
+    Args:
+        conditions: Conditions extracted from a dataflow path.  Each has a
+                    ``text`` field (e.g. ``"size < 1024"``) and an optional
+                    ``negated`` flag for conditions that must be *false* for
+                    the path to proceed.
+
+    Returns:
+        PathSMTResult.  feasible=None when Z3 is unavailable or every
+        condition was unparseable.
+    """
+    if not _z3_available():
+        return PathSMTResult(
+            feasible=None,
+            satisfied=[], unsatisfied=[],
+            unknown=[c.text for c in conditions],
+            model={}, smt_available=False,
+            reasoning="z3 not available — install z3-solver for path feasibility analysis",
+        )
+
+    if not conditions:
+        return PathSMTResult(
+            feasible=True,
+            satisfied=[], unsatisfied=[], unknown=[],
+            model={}, smt_available=True,
+            reasoning="no conditions — path is unconditionally reachable",
+        )
+
+    vars_: Dict[str, Any] = {}
+    solver = _new_solver()
+
+    satisfied: List[str] = []
+    unknown: List[str] = []
+    pending: List[Tuple[str, Any]] = []
+
+    for cond in conditions:
+        expr = _parse_condition(cond.text, vars_)
+        if expr is None:
+            _get_logger().debug(f"smt_path_validator: unparseable condition: {cond.text!r}")
+            unknown.append(cond.text)
+            continue
+
+        final_expr = z3.Not(expr) if cond.negated else expr
+
+        # Quick individual check: is this condition alone satisfiable?
+        with _scoped(solver):
+            solver.add(z3.Not(final_expr))
+            if solver.check() == z3.unsat:
+                # Condition is a tautology — trivially satisfied
+                satisfied.append(cond.text)
+                continue
+
+        pending.append((cond.text, final_expr))
+
+    if not pending:
+        if unknown:
+            return PathSMTResult(
+                feasible=None,
+                satisfied=satisfied, unsatisfied=[], unknown=unknown,
+                model={}, smt_available=True,
+                reasoning=(
+                    f"indeterminate: {len(satisfied)} trivially satisfied, "
+                    f"{len(unknown)} unparseable — LLM analysis required"
+                ),
+            )
+        return PathSMTResult(
+            feasible=True,
+            satisfied=satisfied, unsatisfied=[], unknown=[],
+            model={}, smt_available=True,
+            reasoning=f"all {len(satisfied)} condition(s) trivially satisfied",
+        )
+
+    label_map = _track(solver, pending)
+    result = solver.check()
+
+    if result == z3.sat:
+        model_dict = _format_witness(solver.model(), signed=_SIGNED)
+        return PathSMTResult(
+            feasible=True,
+            satisfied=satisfied, unsatisfied=[], unknown=unknown,
+            model=model_dict, smt_available=True,
+            reasoning=(
+                f"feasible: {len(pending)} condition(s) are jointly satisfiable"
+                + (f"; {len(satisfied)} trivially satisfied" if satisfied else "")
+                + (f"; {len(unknown)} unparsed" if unknown else "")
+            ),
+        )
+
+    if result == z3.unsat:
+        conflicts = _core_names(solver, label_map)
+        conflict_set = conflicts if conflicts else [t for t, _ in pending]
+        reasoning = f"infeasible: path conditions are mutually exclusive"
+        if conflicts:
+            reasoning += f"; conflict: {' ⊥ '.join(conflicts[:3])}"
+        return PathSMTResult(
+            feasible=False,
+            satisfied=satisfied, unsatisfied=conflict_set, unknown=unknown,
+            model={}, smt_available=True,
+            reasoning=reasoning,
+        )
+
+    # z3.unknown — timeout or outside decidable fragment
+    return PathSMTResult(
+        feasible=None,
+        satisfied=satisfied, unsatisfied=[],
+        unknown=unknown + [t for t, _ in pending],
+        model={}, smt_available=True,
+        reasoning=(
+            f"Z3 returned unknown — likely the {_DEFAULT_TIMEOUT_MS}ms timeout "
+            f"or conditions outside the bitvector fragment"
+        ),
+    )

--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -15,6 +15,10 @@ Accepted condition forms (case-insensitive):
   size > 0
   size < 1024
   offset + length <= buffer_size
+  count * 16 < max_alloc       (bitvector mul — wraparound at 2^64, not 2^32)
+  n >> 1 < limit               (logical right shift)
+  n << 3 == buf_size           (left shift)
+  flags | 0x1 != 0             (bitwise OR)
   ptr != NULL  /  ptr == NULL
   index >= 0
   flags & 0x80000000 == 0
@@ -22,6 +26,15 @@ Accepted condition forms (case-insensitive):
 
 Variables are created as 64-bit bitvectors.  Signed comparisons are used
 by default; pass signed=False for address/pointer predicates.
+
+Limitations:
+  - Negative integer literals (e.g. != -1) go to the unknown list.
+  - Bitvector width is 64 bits.  Multiplication overflow wraps at 2^64, not
+    at the C type width (32-bit unsigned int overflows are invisible unless
+    the LLM separates the already-computed result as a distinct variable).
+  - Unary NOT (~) is not supported; conditions using it fall through to unknown.
+  - Bitmask form (flags & MASK == val) requires both MASK and val to be
+    integer literals.
 
 Integration: packages/codeql/dataflow_validator.py :: DataflowValidator
 """
@@ -83,9 +96,11 @@ _INT_RE = re.compile(r'^\d+$')
 _IDENT_RE = re.compile(r'^[a-z_][a-z0-9_]*$', re.IGNORECASE)
 _NULL_RE = re.compile(r'^NULL$', re.IGNORECASE)
 
-# Tokenise: identifiers, hex literals, decimal literals, operators
+# Tokenise: identifiers, hex literals, decimal literals, operators.
+# '>>' and '<<' appear before '[<>&|]' so they are matched as two-char tokens
+# rather than as two separate single-char tokens.
 _TOKEN_RE = re.compile(
-    r'(0x[0-9a-f]+|\d+|[a-z_][a-z0-9_]*|[+\-*]|<=|>=|!=|==|[<>&])',
+    r'(0x[0-9a-f]+|\d+|[a-z_][a-z0-9_]*|[+\-*]|<=|>=|!=|==|>>|<<|[<>&|])',
     re.IGNORECASE,
 )
 
@@ -94,8 +109,11 @@ def _parse_expr(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
     """Parse an arithmetic expression into a Z3 bitvector.
 
     Handles: identifier, NULL, hex literal, decimal literal,
-    and binary +/- between those terms.
-    Does NOT handle precedence beyond left-to-right +/-.
+    and binary +/- /* between those terms (left-to-right, no precedence).
+
+    Returns None — rather than a partial result — when an unsupported token
+    is encountered mid-expression.  This prevents conditions like
+    ``count * 16 < MAX`` from being silently mis-encoded as ``count < MAX``.
     """
     tokens = [t for t in _TOKEN_RE.findall(text.strip()) if t not in ('(', ')')]
     if not tokens:
@@ -114,20 +132,43 @@ def _parse_expr(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
             return vars_[tok.lower()]
         return None
 
-    # Left-to-right accumulation of +/-
+    # Left-to-right accumulation of arithmetic and bitwise operators.
+    # Any unsupported operator causes an immediate None return so the
+    # condition falls through to the unknown list rather than encoding
+    # a silently truncated (and incorrect) expression.
+    #
+    # '>>' is logical right shift (z3.LShR) — correct for unsigned values.
+    # '<<' is left shift; '*' and '+'/'-' are standard bitvector arithmetic.
+    # '|' is bitwise OR.
     result = atom(tokens[0])
     if result is None:
         return None
     i = 1
     while i < len(tokens) - 1:
         op = tokens[i]
-        if op not in ('+', '-'):
-            break
+        if op not in ('+', '-', '*', '|', '>>', '<<'):
+            return None  # unsupported op — reject cleanly
         right = atom(tokens[i + 1])
         if right is None:
             return None
-        result = (result + right) if op == '+' else (result - right)
+        if op == '+':
+            result = result + right
+        elif op == '-':
+            result = result - right
+        elif op == '*':
+            result = result * right
+        elif op == '|':
+            result = result | right
+        elif op == '>>':
+            result = z3.LShR(result, right)  # logical (unsigned) right shift
+        else:  # '<<'
+            result = result << right
         i += 2
+
+    # Reject orphaned trailing tokens (e.g. 'flags' when '| 0x1' was silently
+    # dropped by the tokeniser before this fix).
+    if i != len(tokens):
+        return None
 
     return result
 
@@ -163,7 +204,14 @@ def _parse_condition(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
         return (masked == rhs) if m.group(3) == '==' else (masked != rhs)
 
     # Relational: lhs OP rhs
-    m = re.fullmatch(r'(.+?)\s*(<=|>=|!=|==|<|>)\s*(.+)', t)
+    # The LHS pattern consumes '>>' and '<<' as atomic units so the regex
+    # doesn't split inside a shift operator (e.g. 'n >> 1 < limit' must
+    # not split as lhs='n', op='>', rhs='> 1 < limit').
+    m = re.fullmatch(
+        r'((?:>>|<<|[^<>]|(?<![<>])[<>](?![<>]))+?)'
+        r'\s*(<=|>=|!=|==|<(?!<)|>(?!>))\s*(.+)',
+        t,
+    )
     if m:
         lhs = _parse_expr(m.group(1).strip(), vars_)
         rhs = _parse_expr(m.group(3).strip(), vars_)

--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -24,8 +24,9 @@ Accepted condition forms (case-insensitive):
   flags & 0x80000000 == 0
   value == 42
 
-Variables are created as 64-bit bitvectors.  Signed comparisons are used
-by default; pass signed=False for address/pointer predicates.
+Variables are created as 64-bit bitvectors.  Unsigned comparisons are used
+by default (e.g. 0 <= index < size is encoded as index >= 0 and index < size) since
+most dataflow-relevant variables are sizes, offsets, counts, and bitmasks.
 
 Limitations:
   - Negative integer literals (e.g. != -1) go to the unknown list.

--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -34,6 +34,9 @@ Limitations:
     at the C type width (32-bit unsigned int overflows are invisible unless
     the LLM separates the already-computed result as a distinct variable).
   - Unary NOT (~) is not supported; conditions using it fall through to unknown.
+  - No operator precedence (expressions are evaluated strictly left-to-right).
+    Mixed-operator expressions (e.g. `a + b * c`) are rejected to avoid
+    mis-encoding; full precedence support is planned for a follow-up.
   - Bitmask form (flags & MASK == val) requires both MASK and val to be
     integer literals.
 
@@ -118,6 +121,11 @@ def _parse_expr(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
     """
     tokens = [t for t in _TOKEN_RE.findall(text.strip()) if t not in ('(', ')')]
     if not tokens:
+        return None
+
+    # Reject mixed-operator expressions to avoid silent mis-encoding due to 
+    # the lack of operator precedence (currently strictly left-to-right).
+    if {'+', '-'} & set(tokens[1::2]) and {'*', '>>', '<<', '|'} & set(tokens[1::2]):
         return None
 
     def atom(tok: str) -> Optional[Any]:

--- a/packages/codeql/tests/test_smt_path_validator.py
+++ b/packages/codeql/tests/test_smt_path_validator.py
@@ -236,13 +236,6 @@ class TestConditionForms:
         ])
         assert r.feasible is False
 
-    def test_multiplication_with_unsupported_op_goes_to_unknown(self):
-        """a * b | c is not parseable — must go to unknown, not encode partially."""
-        with patch("packages.codeql.smt_path_validator._z3_available", return_value=False):
-            r = check_path_feasibility([PathCondition("a * b | c < 10", step_index=0)])
-        # Without Z3 everything is unknown — just confirming no crash
-        assert r.feasible is None
-
     @_requires_z3
     def test_bitwise_or_sat(self):
         """flags | 0x1 != 0 — any flags value satisfies this (OR with 1 is always >=1)."""

--- a/packages/codeql/tests/test_smt_path_validator.py
+++ b/packages/codeql/tests/test_smt_path_validator.py
@@ -1,0 +1,231 @@
+"""Tests for packages.codeql.smt_path_validator."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# packages/codeql/tests/ -> repo root
+sys.path.insert(0, str(Path(__file__).parents[3]))
+
+from core.smt_solver import z3_available
+from packages.codeql.smt_path_validator import (
+    PathCondition,
+    PathSMTResult,
+    check_path_feasibility,
+)
+
+_requires_z3 = pytest.mark.skipif(
+    not z3_available(),
+    reason="z3-solver not installed",
+)
+
+
+# ---------------------------------------------------------------------------
+# check_path_feasibility — no Z3
+# ---------------------------------------------------------------------------
+
+class TestNoZ3:
+    """Behaviour when Z3 is unavailable — must degrade gracefully."""
+
+    def test_returns_none_feasible(self):
+        with patch("packages.codeql.smt_path_validator._z3_available", return_value=False):
+            r = check_path_feasibility([PathCondition("size > 0", step_index=0)])
+        assert r.feasible is None
+        assert r.smt_available is False
+
+    def test_all_conditions_go_to_unknown(self):
+        conditions = [
+            PathCondition("size > 0", step_index=0),
+            PathCondition("offset < 1024", step_index=1),
+        ]
+        with patch("packages.codeql.smt_path_validator._z3_available", return_value=False):
+            r = check_path_feasibility(conditions)
+        assert set(r.unknown) == {"size > 0", "offset < 1024"}
+
+    def test_empty_conditions_still_returns_none(self):
+        with patch("packages.codeql.smt_path_validator._z3_available", return_value=False):
+            r = check_path_feasibility([])
+        assert r.feasible is None
+        assert r.smt_available is False
+
+
+# ---------------------------------------------------------------------------
+# check_path_feasibility — with Z3
+# ---------------------------------------------------------------------------
+
+class TestFeasibility:
+    """Core sat/unsat/unknown results."""
+
+    @_requires_z3
+    def test_empty_conditions_feasible(self):
+        r = check_path_feasibility([])
+        assert r.feasible is True
+        assert r.smt_available is True
+
+    @_requires_z3
+    def test_satisfiable_range(self):
+        """size > 0 AND size < 1024 — clearly satisfiable."""
+        r = check_path_feasibility([
+            PathCondition("size > 0", step_index=0),
+            PathCondition("size < 1024", step_index=1),
+        ])
+        assert r.feasible is True
+        assert "size" in r.model
+        assert 0 < r.model["size"] < 1024
+
+    @_requires_z3
+    def test_infeasible_contradiction(self):
+        """size > 0 AND size < 0 — mutually exclusive."""
+        r = check_path_feasibility([
+            PathCondition("size > 0", step_index=0),
+            PathCondition("size < 0", step_index=1),
+        ])
+        assert r.feasible is False
+        assert len(r.unsatisfied) >= 1
+
+    @_requires_z3
+    def test_infeasible_names_conflicting_conditions(self):
+        """Unsat core must name the specific conflicting conditions."""
+        r = check_path_feasibility([
+            PathCondition("size > 100", step_index=0),
+            PathCondition("size < 50", step_index=1),
+        ])
+        assert r.feasible is False
+        assert "size > 100" in r.unsatisfied or "size < 50" in r.unsatisfied
+
+    @_requires_z3
+    def test_unparseable_condition_goes_to_unknown(self):
+        """Function-call syntax is rejected by the parser — goes to unknown, not crash."""
+        r = check_path_feasibility([
+            PathCondition("size > 0", step_index=0),
+            PathCondition("validate(ptr, len) == 0", step_index=1),
+        ])
+        assert "validate(ptr, len) == 0" in r.unknown
+        # The parseable condition still runs; result is sat or None, not outright infeasible
+        assert r.feasible is not False
+
+    @_requires_z3
+    def test_all_unknown_returns_none(self):
+        """If nothing is parseable, feasible must be None (not True)."""
+        r = check_path_feasibility([
+            PathCondition("foo(bar) > baz(qux)", step_index=0),
+        ])
+        assert r.feasible is None
+
+    @_requires_z3
+    def test_negated_condition(self):
+        """negated=True means the guard was bypassed (condition is false on path)."""
+        # ptr != NULL with negated=True means ptr IS NULL on this path
+        r = check_path_feasibility([
+            PathCondition("ptr != NULL", step_index=0, negated=True),
+        ])
+        # ptr == NULL is satisfiable (ptr = 0)
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_negated_makes_path_infeasible(self):
+        """ptr != NULL negated (ptr must be NULL) contradicts ptr > 0."""
+        r = check_path_feasibility([
+            PathCondition("ptr != NULL", step_index=0, negated=True),  # ptr == 0
+            PathCondition("ptr > 0", step_index=1),                    # ptr > 0
+        ])
+        assert r.feasible is False
+
+
+class TestConditionForms:
+    """Parser coverage — each accepted condition form."""
+
+    @_requires_z3
+    def test_equality(self):
+        r = check_path_feasibility([PathCondition("x == 42", step_index=0)])
+        assert r.feasible is True
+        assert r.model.get("x") == 42
+
+    @_requires_z3
+    def test_inequality(self):
+        r = check_path_feasibility([PathCondition("x != 0", step_index=0)])
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_null_literal(self):
+        r = check_path_feasibility([PathCondition("ptr == NULL", step_index=0)])
+        assert r.feasible is True
+        assert r.model.get("ptr") == 0
+
+    @_requires_z3
+    def test_hex_literal(self):
+        r = check_path_feasibility([PathCondition("flags == 0xff", step_index=0)])
+        assert r.feasible is True
+        assert r.model.get("flags") == 0xFF
+
+    @_requires_z3
+    def test_addition_in_condition_sat(self):
+        """offset + length <= buffer_size — guard holds when values fit."""
+        r = check_path_feasibility([
+            PathCondition("offset + length <= buffer_size", step_index=0),
+            PathCondition("buffer_size == 64", step_index=1),
+            PathCondition("offset > 0", step_index=2),
+            PathCondition("length > 0", step_index=3),
+        ])
+        assert r.feasible is True
+        assert r.model.get("buffer_size") == 64
+
+    @_requires_z3
+    def test_addition_overflow_path_is_sat(self):
+        """Z3 correctly finds an integer overflow path when the guard can be bypassed
+        via wraparound — this is the desired behaviour for CWE-190 detection.
+        offset(60) + length(very large) overflows, satisfying <= buffer_size(64)."""
+        r = check_path_feasibility([
+            PathCondition("offset + length <= buffer_size", step_index=0),
+            PathCondition("buffer_size == 64", step_index=1),
+            PathCondition("offset == 60", step_index=2),
+            PathCondition("length > 10", step_index=3),
+        ])
+        # sat — Z3 finds a wraparound value for length that bypasses the guard
+        assert r.feasible is True
+        assert r.smt_available is True
+
+    @_requires_z3
+    def test_bitmask_alignment(self):
+        """rsp & 0xf == 0 — stack alignment check."""
+        r = check_path_feasibility([
+            PathCondition("rsp & 0xf == 0", step_index=0),
+        ])
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_bitmask_infeasible(self):
+        r = check_path_feasibility([
+            PathCondition("flags & 0x1 == 0", step_index=0),
+            PathCondition("flags & 0x1 == 1", step_index=1),
+        ])
+        assert r.feasible is False
+
+
+class TestResultStructure:
+    """PathSMTResult fields are populated correctly."""
+
+    @_requires_z3
+    def test_sat_result_has_empty_unsatisfied(self):
+        r = check_path_feasibility([PathCondition("x > 0", step_index=0)])
+        assert r.feasible is True
+        assert r.unsatisfied == []
+        assert r.smt_available is True
+
+    @_requires_z3
+    def test_unsat_result_has_empty_model(self):
+        r = check_path_feasibility([
+            PathCondition("x > 10", step_index=0),
+            PathCondition("x < 5", step_index=1),
+        ])
+        assert r.feasible is False
+        assert r.model == {}
+        assert r.smt_available is True
+
+    @_requires_z3
+    def test_reasoning_string_populated(self):
+        r = check_path_feasibility([PathCondition("x == 1", step_index=0)])
+        assert isinstance(r.reasoning, str)
+        assert len(r.reasoning) > 0

--- a/packages/codeql/tests/test_smt_path_validator.py
+++ b/packages/codeql/tests/test_smt_path_validator.py
@@ -203,6 +203,106 @@ class TestConditionForms:
         ])
         assert r.feasible is False
 
+    @_requires_z3
+    def test_multiplication_sat(self):
+        """count * 16 < 32768 — Z3 finds a small satisfying count (safe path)."""
+        r = check_path_feasibility([
+            PathCondition("count * 16 < 32768", step_index=0),
+            PathCondition("count > 0", step_index=1),
+        ])
+        assert r.feasible is True
+        assert "count" in r.model
+        # 64-bit BV: Z3 finds count <= 2047 (not the 32-bit wraparound path)
+        assert r.model["count"] * 16 < 32768
+
+    @_requires_z3
+    def test_multiplication_propagates_correctly(self):
+        """alloc_size == count * 16 must not silently encode as alloc_size == count."""
+        r = check_path_feasibility([
+            PathCondition("alloc_size == count * 16", step_index=0),
+            PathCondition("count == 4", step_index=1),
+        ])
+        assert r.feasible is True
+        # If * were silently dropped, alloc_size == count → alloc_size == 4.
+        # With correct encoding, alloc_size == 4 * 16 == 64.
+        assert r.model.get("alloc_size") == 64
+
+    @_requires_z3
+    def test_multiplication_makes_path_infeasible(self):
+        """count * 4 == 8 AND count == 3 is unsatisfiable (3*4 = 12, not 8)."""
+        r = check_path_feasibility([
+            PathCondition("count * 4 == 8", step_index=0),
+            PathCondition("count == 3", step_index=1),
+        ])
+        assert r.feasible is False
+
+    def test_multiplication_with_unsupported_op_goes_to_unknown(self):
+        """a * b | c is not parseable — must go to unknown, not encode partially."""
+        with patch("packages.codeql.smt_path_validator._z3_available", return_value=False):
+            r = check_path_feasibility([PathCondition("a * b | c < 10", step_index=0)])
+        # Without Z3 everything is unknown — just confirming no crash
+        assert r.feasible is None
+
+    @_requires_z3
+    def test_bitwise_or_sat(self):
+        """flags | 0x1 != 0 — any flags value satisfies this (OR with 1 is always >=1)."""
+        r = check_path_feasibility([PathCondition("flags | 0x1 != 0", step_index=0)])
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_bitwise_or_infeasible(self):
+        """flags | 0x1 == 0 — impossible since OR with 1 always sets bit 0."""
+        r = check_path_feasibility([PathCondition("flags | 0x1 == 0", step_index=0)])
+        assert r.feasible is False
+
+    @_requires_z3
+    def test_right_shift_in_lhs_of_comparison(self):
+        """n >> 1 < limit — Z3 finds a satisfying n."""
+        r = check_path_feasibility([
+            PathCondition("n >> 1 < limit", step_index=0),
+            PathCondition("limit == 8", step_index=1),
+        ])
+        assert r.feasible is True
+        # n >> 1 < 8 means n < 16; Z3 should give a concrete n
+        assert "n" in r.model
+        assert r.model["n"] >> 1 < 8
+
+    @_requires_z3
+    def test_right_shift_infeasible(self):
+        """n >> 1 < 8 AND n >> 1 >= 8 — mutually exclusive."""
+        r = check_path_feasibility([
+            PathCondition("n >> 1 < 8", step_index=0),
+            PathCondition("n >> 1 >= 8", step_index=1),
+        ])
+        assert r.feasible is False
+
+    @_requires_z3
+    def test_left_shift_sat(self):
+        """size == n << 3 AND n == 4 — size must be 32."""
+        r = check_path_feasibility([
+            PathCondition("size == n << 3", step_index=0),
+            PathCondition("n == 4", step_index=1),
+        ])
+        assert r.feasible is True
+        assert r.model.get("size") == 32
+
+    @_requires_z3
+    def test_shift_in_rhs_of_equality(self):
+        """buf_size == count >> 2 — shift on the RHS of ==."""
+        r = check_path_feasibility([
+            PathCondition("buf_size == count >> 2", step_index=0),
+            PathCondition("count == 64", step_index=1),
+        ])
+        assert r.feasible is True
+        assert r.model.get("buf_size") == 16
+
+    @_requires_z3
+    def test_trailing_orphan_token_goes_to_unknown(self):
+        """Expressions where a token is left unconsumed must go to unknown."""
+        r = check_path_feasibility([PathCondition("a b", step_index=0)])
+        # 'a b' tokenises to ['a', 'b']; 'b' is orphaned — must be unknown, not encode as 'a'
+        assert "a b" in r.unknown
+
 
 class TestResultStructure:
     """PathSMTResult fields are populated correctly."""

--- a/test/data/smt_codeql_testbench/README.md
+++ b/test/data/smt_codeql_testbench/README.md
@@ -1,0 +1,33 @@
+# SMT Testbench
+
+Cases designed to exercise Z3 path condition analysis in CodeQL dataflow findings.
+
+## Group 1 — SAT with non-obvious PoC values
+
+Z3 finds concrete satisfying assignments that require reasoning about unsigned bitvector wraparound or compound inequality constraints.
+
+| Case | File | Sink line | Guard (visible) | Bug | Z3 PoC value |
+|------|------|-----------|-----------------|-----|--------------|
+| `ALLOC` | `smt_testbench.c:93` | `memset(&records[i], ...)` | `count < 0x40000000` | `count * 16` overflows uint32 | `count = 0x10000001` → alloc = 16 bytes, loop writes 4 GB |
+| `SUM` | `smt_testbench.c:132` | `memcpy(shared_buffer + offset, ...)` | `offset + length <= buffer_size` | unsigned sum wraps | `offset=0xFFFF0000, length=0x10010` → sum=0x10 ≤ 64 |
+| `OBO` | `smt_testbench.c:165` | `buf[index] = value` | `index > INDEX_LIMIT` (should be `>=`) | off-by-one | `index=128` passes `> 128` check, writes `buf[128]` |
+| `MASK` | `smt_testbench.c:200` | `memcpy(heap_region + base, ...)` | `base + size <= HEAP_SIZE` | unsigned base+size wrap | `base=0xFFFFE000, size=4000` → sum=0x3E80 ≤ 8192 |
+
+## Group 2 — UNSAT (provably dead paths)
+
+CodeQL reports a flow to the sink; Z3 proves the path conditions are mutually exclusive and suppresses the LLM call.
+
+| Case | File | Sink line | Conditions Z3 checks | Conflict |
+|------|------|-----------|----------------------|----------|
+| `DEAD_RANGE` | `smt_testbench.c:243` | `strcpy(dead_buf, data)` | `x > 100` AND `x < 50` | ⊥ immediately |
+| `DEAD_NULL` | `smt_testbench.c:280` | `strcpy(dst, ptr)` | `ptr != NULL` AND `ptr == NULL` | ⊥ immediately |
+| `DEAD_MASK` | `smt_testbench.c:308` | `memcpy(flag_buf, payload, len)` | `flags & 0x1 == 0` AND `flags & 0x1 == 1` | ⊥ immediately |
+
+## Group 3 — Indeterminate (Z3 falls through to LLM)
+
+Conditions contain function calls the bitvector parser cannot encode. Z3 returns `feasible=None` and full LLM analysis runs unchanged.
+
+| Case | File | Why Z3 returns `None` |
+|------|------|-----------------------|
+| `LLM` | `smt_testbench.c:327` | `strlen(input)` call — parentheses rejected by bitvector parser |
+| `PARTIAL` | `smt_testbench.c:350` | `validate(ptr)` call — same reason; `size < 256` is parseable but alone is indeterminate |

--- a/test/data/smt_codeql_testbench/README.md
+++ b/test/data/smt_codeql_testbench/README.md
@@ -8,10 +8,10 @@ Z3 finds concrete satisfying assignments that require reasoning about unsigned b
 
 | Case | File | Sink line | Guard (visible) | Bug | Z3 PoC value |
 |------|------|-----------|-----------------|-----|--------------|
-| `ALLOC` | `smt_testbench.c:93` | `memset(&records[i], ...)` | `count < 0x40000000` | `count * 16` overflows uint32 | `count = 0x10000001` → alloc = 16 bytes, loop writes 4 GB |
-| `SUM` | `smt_testbench.c:132` | `memcpy(shared_buffer + offset, ...)` | `offset + length <= buffer_size` | unsigned sum wraps | `offset=0xFFFF0000, length=0x10010` → sum=0x10 ≤ 64 |
-| `OBO` | `smt_testbench.c:165` | `buf[index] = value` | `index > INDEX_LIMIT` (should be `>=`) | off-by-one | `index=128` passes `> 128` check, writes `buf[128]` |
-| `MASK` | `smt_testbench.c:200` | `memcpy(heap_region + base, ...)` | `base + size <= HEAP_SIZE` | unsigned base+size wrap | `base=0xFFFFE000, size=4000` → sum=0x3E80 ≤ 8192 |
+| `ALLOC` | `smt_codeql_testbench.c:93` | `memset(&records[i], ...)` | `count < 0x40000000` | `count * 16` overflows uint32 | `count = 0x10000001` → alloc = 16 bytes, loop writes 4 GB |
+| `SUM` | `smt_codeql_testbench.c:132` | `memcpy(shared_buffer + offset, ...)` | `offset + length <= buffer_size` | unsigned sum wraps | `offset=0xFFFF0000, length=0x10010` → sum=0x10 ≤ 64 |
+| `OBO` | `smt_codeql_testbench.c:165` | `buf[index] = value` | `index > INDEX_LIMIT` (should be `>=`) | off-by-one | `index=128` passes `> 128` check, writes `buf[128]` |
+| `MASK` | `smt_codeql_testbench.c:200` | `memcpy(heap_region + base, ...)` | `base + size <= HEAP_SIZE` | unsigned base+size wrap | `base=0xFFFFE000, size=4000` → sum=0x3E80 ≤ 8192 |
 
 ## Group 2 — UNSAT (provably dead paths)
 
@@ -19,9 +19,9 @@ CodeQL reports a flow to the sink; Z3 proves the path conditions are mutually ex
 
 | Case | File | Sink line | Conditions Z3 checks | Conflict |
 |------|------|-----------|----------------------|----------|
-| `DEAD_RANGE` | `smt_testbench.c:243` | `strcpy(dead_buf, data)` | `x > 100` AND `x < 50` | ⊥ immediately |
-| `DEAD_NULL` | `smt_testbench.c:280` | `strcpy(dst, ptr)` | `ptr != NULL` AND `ptr == NULL` | ⊥ immediately |
-| `DEAD_MASK` | `smt_testbench.c:308` | `memcpy(flag_buf, payload, len)` | `flags & 0x1 == 0` AND `flags & 0x1 == 1` | ⊥ immediately |
+| `DEAD_RANGE` | `smt_codeql_testbench.c:243` | `strcpy(dead_buf, data)` | `x > 100` AND `x < 50` | ⊥ immediately |
+| `DEAD_NULL` | `smt_codeql_testbench.c:280` | `strcpy(dst, ptr)` | `ptr != NULL` AND `ptr == NULL` | ⊥ immediately |
+| `DEAD_MASK` | `smt_codeql_testbench.c:308` | `memcpy(flag_buf, payload, len)` | `flags & 0x1 == 0` AND `flags & 0x1 == 1` | ⊥ immediately |
 
 ## Group 3 — Indeterminate (Z3 falls through to LLM)
 
@@ -29,5 +29,5 @@ Conditions contain function calls the bitvector parser cannot encode. Z3 returns
 
 | Case | File | Why Z3 returns `None` |
 |------|------|-----------------------|
-| `LLM` | `smt_testbench.c:327` | `strlen(input)` call — parentheses rejected by bitvector parser |
-| `PARTIAL` | `smt_testbench.c:350` | `validate(ptr)` call — same reason; `size < 256` is parseable but alone is indeterminate |
+| `LLM` | `smt_codeql_testbench.c:327` | `strlen(input)` call — parentheses rejected by bitvector parser |
+| `PARTIAL` | `smt_codeql_testbench.c:350` | `validate(ptr)` call — same reason; `size < 256` is parseable but alone is indeterminate |

--- a/test/data/smt_codeql_testbench/README.md
+++ b/test/data/smt_codeql_testbench/README.md
@@ -2,9 +2,11 @@
 
 Cases designed to exercise Z3 path condition analysis in CodeQL dataflow findings.
 
-## Group 1 — SAT with non-obvious PoC values
+## Group 1 — SAT with non-obvious PoC values (ASPIRATIONAL)
 
-Z3 finds concrete satisfying assignments that require reasoning about unsigned bitvector wraparound or compound inequality constraints.
+Aspirational cases where Z3 finds concrete satisfying assignments that require reasoning about unsigned bitvector wraparound or compound inequality constraints.
+
+**NOTE:** Current SMT encoder is fixed at 64-bit. These cases rely on 32-bit wraparound and will be fully supported once width-parametric encoding is added.
 
 | Case | File | Sink line | Guard (visible) | Bug | Z3 PoC value |
 |------|------|-----------|-----------------|-----|--------------|

--- a/test/data/smt_codeql_testbench/smt_codeql_testbench.c
+++ b/test/data/smt_codeql_testbench/smt_codeql_testbench.c
@@ -3,10 +3,13 @@
  *
  * Organised into three groups:
  *
- *   GROUP 1 — SAT with non-obvious PoC values
+ *   GROUP 1 — SAT with non-obvious PoC values (ASPIRATIONAL)
  *     Z3 finds a concrete satisfying assignment that a human (or LLM) would
  *     likely miss because it requires reasoning about unsigned bitvector
  *     wraparound or compound inequality constraints.
+ *
+ *     NOTE: Current SMT encoder is fixed at 64-bit. These cases rely on 32-bit
+ *     wraparound and will be fully supported once width-parametric encoding is added.
  *
  *   GROUP 2 — UNSAT (provably dead paths)
  *     CodeQL reports a flow to a dangerous sink, but the path conditions are
@@ -47,11 +50,15 @@
 /* -------------------------------------------------------------------------
  * CASE 1a — allocation size overflow (CWE-190 → CWE-122)
  *
+ * [ASPIRATIONAL] Requires 32-bit width encoding.
+ *
  * Guard:    count < MAX_RECORDS  (looks protective)
  * Bug:      count * sizeof(record) overflows to a small value
- * Z3 finds: count = (UINT32_MAX / 16) + 1 = 0x10000001
+ * Z3 (32-bit) finds: count = (UINT32_MAX / 16) + 1 = 0x10000001
  *           0x10000001 * 16 = 0x100000010 truncated to 32 bits = 0x10
  *           0x10 < MAX_ALLOC=0x8000 ✓ — malloc gets 16 bytes
+ *
+ * Z3 (64-bit) sees 0x100000010 > 0x8000 and picks an innocuous count (e.g., 1).
  *           then loop writes count*16 = 2GB+ into it
  *
  * Path conditions for SMT:
@@ -99,6 +106,8 @@ void case_alloc_overflow(unsigned int count) {
 
 /* -------------------------------------------------------------------------
  * CASE 1b — compound bounds check bypass (CWE-190 → CWE-120)
+ *
+ * [ASPIRATIONAL] Requires 32-bit width encoding.
  *
  * This mimics the classic safe-looking copy guard:
  *   if (offset + length <= buffer_size) { memcpy(...) }
@@ -168,6 +177,8 @@ void case_offbyone(int index, char value) {
 
 /* -------------------------------------------------------------------------
  * CASE 1d — bitmask check bypass (alignment constraint + wraparound)
+ *
+ * [ASPIRATIONAL] Requires 32-bit width encoding.
  *
  * Guard:  flags & PRIV_FLAG == 0   ("unprivileged request only")
  *         size < MAX_SIZE

--- a/test/data/smt_codeql_testbench/smt_codeql_testbench.c
+++ b/test/data/smt_codeql_testbench/smt_codeql_testbench.c
@@ -1,0 +1,448 @@
+/*
+ * SMT Testbench — cases designed to exercise Z3 path condition analysis
+ *
+ * Organised into three groups:
+ *
+ *   GROUP 1 — SAT with non-obvious PoC values
+ *     Z3 finds a concrete satisfying assignment that a human (or LLM) would
+ *     likely miss because it requires reasoning about unsigned bitvector
+ *     wraparound or compound inequality constraints.
+ *
+ *   GROUP 2 — UNSAT (provably dead paths)
+ *     CodeQL reports a flow to a dangerous sink, but the path conditions are
+ *     mutually exclusive.  Z3 proves UNSAT and the LLM call is skipped.
+ *     Without Z3 these would be time-wasting false positives.
+ *
+ *   GROUP 3 — INDETERMINATE (Z3 falls through to LLM)
+ *     Conditions involve function calls or idioms the bitvector parser
+ *     cannot encode.  Z3 returns feasible=None and full LLM analysis runs.
+ *     Included to show graceful degradation.
+ *
+ * Compile (no mitigations, so crashes are visible):
+ *   gcc -fno-stack-protector -Wno-format-security -o smt_codeql_testbench smt_codeql_testbench.c
+ *
+ * Input format (stdin):
+ *   <COMMAND>:<args separated by commas>
+ *
+ * Commands match function names below.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+/* =========================================================================
+ * GROUP 1 — SAT WITH NON-OBVIOUS PoC VALUES
+ * =========================================================================
+ *
+ * These functions contain real bugs that are hard to spot by inspection
+ * because the dangerous input is a large unsigned value that still satisfies
+ * all visible guards due to 32-bit wraparound.
+ *
+ * Z3 advantage: bitvector arithmetic finds the exact wraparound value
+ * immediately; the LLM prompt gets it as a concrete candidate input.
+ */
+
+/* -------------------------------------------------------------------------
+ * CASE 1a — allocation size overflow (CWE-190 → CWE-122)
+ *
+ * Guard:    count < MAX_RECORDS  (looks protective)
+ * Bug:      count * sizeof(record) overflows to a small value
+ * Z3 finds: count = (UINT32_MAX / 16) + 1 = 0x10000001
+ *           0x10000001 * 16 = 0x100000010 truncated to 32 bits = 0x10
+ *           0x10 < MAX_ALLOC=0x8000 ✓ — malloc gets 16 bytes
+ *           then loop writes count*16 = 2GB+ into it
+ *
+ * Path conditions for SMT:
+ *   count < 268435456        (count < MAX_RECORDS = 0x10000000)
+ *   alloc_size < 32768       (alloc_size < MAX_ALLOC = 0x8000)
+ *   alloc_size == count * 16 (relation — encoded as alloc_size = count * 16)
+ *
+ * Z3 encodes the multiplication as bitvector mul with wraparound and finds
+ * count=0x10000001 satisfying all three conditions simultaneously.
+ * -------------------------------------------------------------------------*/
+/* MAX_RECORDS must be > UINT32_MAX/RECORD_SIZE so that values passing the
+ * count check can still cause count*RECORD_SIZE to wrap.
+ * UINT32_MAX/16 = 0xFFFFFFF = 268435455; any count > that and < MAX_RECORDS
+ * will overflow the multiplication.  MAX_RECORDS = 0x40000000 gives a wide
+ * window: count in [0x10000001, 0x3FFFFFFF] all pass the guard AND overflow. */
+#define MAX_RECORDS  0x40000000u
+#define MAX_ALLOC    0x8000u
+#define RECORD_SIZE  16u
+
+typedef struct { char data[RECORD_SIZE]; } record_t;
+
+void case_alloc_overflow(unsigned int count) {
+    unsigned int alloc_size = count * RECORD_SIZE;   /* ← wraparound here */
+
+    if (count >= MAX_RECORDS) {
+        fprintf(stderr, "[ALLOC] count too large\n");
+        return;
+    }
+    if (alloc_size >= MAX_ALLOC) {
+        fprintf(stderr, "[ALLOC] allocation too large\n");
+        return;
+    }
+
+    record_t *records = malloc(alloc_size);
+    if (!records) return;
+
+    /* write count records into a buffer sized for alloc_size/RECORD_SIZE */
+    for (unsigned int i = 0; i < count; i++) {
+        memset(&records[i], 'A', RECORD_SIZE);   /* VULNERABILITY: OOB write */
+    }
+
+    printf("[ALLOC] Wrote %u records\n", count);
+    free(records);
+}
+
+/* -------------------------------------------------------------------------
+ * CASE 1b — compound bounds check bypass (CWE-190 → CWE-120)
+ *
+ * This mimics the classic safe-looking copy guard:
+ *   if (offset + length <= buffer_size) { memcpy(...) }
+ *
+ * Guard looks correct; Z3 finds a wraparound assignment:
+ *   offset = 0xffff0000, length = 0x00010001
+ *   sum    = 0x00000001 (wraps!) which is <= buffer_size
+ *
+ * Path conditions:
+ *   offset + length <= buffer_size
+ *   buffer_size == 64
+ *   offset > 0
+ *   length > 0
+ *
+ * Z3 SAT: offset=0xffff0010, length=0x00010000 gives sum=0x10 <= 64
+ * -------------------------------------------------------------------------*/
+#define FIXED_BUFFER_SIZE 64u
+
+static char shared_buffer[FIXED_BUFFER_SIZE];
+
+void case_sum_overflow(unsigned int offset, unsigned int length,
+                       const char *src, unsigned int buffer_size) {
+
+    if (buffer_size > FIXED_BUFFER_SIZE) {
+        fprintf(stderr, "[SUM] buffer_size out of range\n");
+        return;
+    }
+
+    /* Guard looks protective — but both operands are unsigned 32-bit */
+    if (offset + length <= buffer_size) {            /* ← wraparound bypass */
+        memcpy(shared_buffer + offset, src, length); /* VULNERABILITY: OOB */
+        printf("[SUM] Copied %u bytes at offset %u\n", length, offset);
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * CASE 1c — off-by-one via <= instead of < (CWE-193)
+ *
+ * Guard:   index >= 0 AND index <= LIMIT
+ * Bug:     index == LIMIT writes exactly one byte past the array end
+ *
+ * Z3 finds: index = LIMIT (= 128) satisfies all conditions AND
+ *           index = LIMIT makes write land at buf[128] which is OOB
+ *           (buf is declared as char buf[128])
+ *
+ * Path conditions:
+ *   index >= 0
+ *   index <= 128   (should be < 128)
+ * -------------------------------------------------------------------------*/
+#define INDEX_LIMIT 128
+
+void case_offbyone(int index, char value) {
+    char buf[INDEX_LIMIT];   /* buf[0..127] valid */
+
+    if (index < 0) {
+        fprintf(stderr, "[OBO] negative index\n");
+        return;
+    }
+    if (index > INDEX_LIMIT) {       /* BUG: should be >= INDEX_LIMIT */
+        fprintf(stderr, "[OBO] index too large\n");
+        return;
+    }
+
+    buf[index] = value;              /* VULNERABILITY: OOB when index == 128 */
+    printf("[OBO] Wrote 0x%02x at index %d\n", (unsigned char)value, index);
+}
+
+/* -------------------------------------------------------------------------
+ * CASE 1d — bitmask check bypass (alignment constraint + wraparound)
+ *
+ * Guard:  flags & PRIV_FLAG == 0   ("unprivileged request only")
+ *         size < MAX_SIZE
+ * Bug:    a large size combined with a base address causes OOB
+ *         Z3 finds the exact size that passes the guard
+ *
+ * Path conditions (for the dangerous branch):
+ *   flags & 0x80000000 == 0
+ *   size < 4096
+ *   base + size <= 8192   (← another sum that can overflow)
+ * -------------------------------------------------------------------------*/
+#define PRIV_FLAG  0x80000000u
+#define MAX_SIZE   4096u
+#define HEAP_SIZE  8192u
+
+static char heap_region[HEAP_SIZE];
+
+void case_bitmask_bypass(unsigned int flags, unsigned int base,
+                         unsigned int size, const char *payload) {
+    if (flags & PRIV_FLAG) {
+        fprintf(stderr, "[MASK] privileged flag set — rejected\n");
+        return;
+    }
+    if (size >= MAX_SIZE) {
+        fprintf(stderr, "[MASK] size too large\n");
+        return;
+    }
+    /* base + size overflow: base=0xffffE000, size=4000 → sum=0x3ee0 <= 8192 */
+    if (base + size <= HEAP_SIZE) {                  /* ← overflow bypass */
+        memcpy(heap_region + base, payload, size);   /* VULNERABILITY: OOB */
+        printf("[MASK] Wrote %u bytes at base %u\n", size, base);
+    }
+}
+
+
+/* =========================================================================
+ * GROUP 2 — UNSAT (PROVABLY DEAD PATHS / TRUE NEGATIVES)
+ * =========================================================================
+ *
+ * CodeQL will report a flow to the dangerous sink.  Z3 proves the path
+ * conditions are mutually exclusive → finding is skipped, no LLM call.
+ *
+ * Without Z3 these generate expensive false-positive LLM calls and produce
+ * report noise that wastes analyst time.
+ */
+
+/* -------------------------------------------------------------------------
+ * CASE 2a — value range contradiction
+ *
+ * The outer guard requires x > 100.
+ * An inner guard (simulating a second validation layer) requires x < 50.
+ * These are mutually exclusive — Z3 reports UNSAT immediately.
+ *
+ * Path conditions (for the sink):
+ *   x > 100
+ *   x < 50        ← contradiction
+ *
+ * Z3: UNSAT. Conflicting conditions: "x > 100" ⊥ "x < 50"
+ * -------------------------------------------------------------------------*/
+char dead_buf[32];
+
+void case_dead_range(int x, const char *data) {
+    if (x <= 100) {
+        fprintf(stderr, "[DEAD_RANGE] x must be > 100\n");
+        return;
+    }
+
+    /* imagine this is a second validation in a different module */
+    if (x >= 50) {
+        /* this branch is NOT dead — but the sub-condition below is */
+        if (x < 50) {
+            /* provably unreachable: x > 100 AND x < 50 is impossible */
+            strcpy(dead_buf, data);    /* CodeQL flags this; Z3 proves dead */
+            printf("[DEAD_RANGE] unreachable write\n");
+        }
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * CASE 2b — pointer nullness contradiction
+ *
+ * After a NULL check passes (ptr != NULL), a defensive re-check later in
+ * the path tests ptr == NULL.  Z3 encodes both conditions and finds UNSAT.
+ *
+ * Path conditions for the sink:
+ *   ptr != NULL   (guard at top of function)
+ *   ptr == NULL   (defensive re-check that makes the inner branch dead)
+ *
+ * Z3: UNSAT. ptr != NULL AND ptr == NULL is unsatisfiable.
+ * -------------------------------------------------------------------------*/
+void case_dead_null(const char *ptr, char *dst) {
+    if (ptr == NULL) {
+        fprintf(stderr, "[DEAD_NULL] null input\n");
+        return;
+    }
+
+    /* ptr is non-null here — the branch below is dead */
+    if (ptr != NULL) {
+        /* ... do real work ... */
+        strncpy(dst, ptr, 32);
+    } else {
+        /* provably dead: ptr == NULL AND ptr != NULL is impossible */
+        strcpy(dst, ptr);  /* CodeQL may flag; Z3 proves dead */
+        printf("[DEAD_NULL] unreachable strcpy\n");
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * CASE 2c — bitmask contradiction
+ *
+ * An outer check ensures bit 0 of flags is 0 (even).
+ * An inner check requires bit 0 of flags is 1 (odd).
+ * These are mutually exclusive by definition.
+ *
+ * Path conditions:
+ *   flags & 0x1 == 0   (outer: even-only path)
+ *   flags & 0x1 == 1   (inner: odd required)
+ *
+ * Z3: UNSAT. flags & 0x1 cannot be both 0 and 1 simultaneously.
+ * -------------------------------------------------------------------------*/
+char flag_buf[64];
+
+void case_dead_bitmask(unsigned int flags, const char *payload, size_t len) {
+    if (flags & 0x1) {
+        fprintf(stderr, "[DEAD_MASK] odd flags rejected\n");
+        return;
+    }
+    /* flags & 0x1 == 0 here */
+
+    if ((flags & 0x1) == 1) {   /* provably false */
+        /* unreachable: flags & 0x1 was just confirmed to be 0 */
+        if (len < sizeof(flag_buf)) {
+            memcpy(flag_buf, payload, len);  /* CodeQL flags; Z3 proves dead */
+        }
+        printf("[DEAD_MASK] unreachable memcpy\n");
+    }
+}
+
+
+/* =========================================================================
+ * GROUP 3 — INDETERMINATE (Z3 FALLS THROUGH TO LLM)
+ * =========================================================================
+ *
+ * Conditions involve function calls, strlen, or runtime values that the
+ * bitvector parser cannot encode (returns None → full LLM analysis runs).
+ * These are included to demonstrate graceful degradation.
+ */
+
+/* -------------------------------------------------------------------------
+ * CASE 3a — function-call condition (strlen)
+ *
+ * The guard uses strlen() which the SMT parser rejects (contains '(' ')').
+ * Z3 returns feasible=None; LLM analysis runs unchanged.
+ *
+ * This IS a real vulnerability (classic stack overflow via strcpy).
+ * -------------------------------------------------------------------------*/
+void case_llm_fallthrough(const char *input) {
+    char local[64];
+
+    /* strlen() call makes this condition unparseable by the bitvector engine */
+    if (strlen(input) < sizeof(local)) {
+        strcpy(local, input);    /* safe when guard holds; but LLM must verify */
+        printf("[LLM] Copied: %s\n", local);
+    } else {
+        printf("[LLM] Input too long, skipped\n");
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * CASE 3b — combined: one parseable + one unparseable condition
+ *
+ * Z3 can encode `size < 256` but not `validate(ptr)`.
+ * The parseable condition alone gives a partial sat result (feasible=None
+ * because not all conditions could be checked).  LLM still runs.
+ * -------------------------------------------------------------------------*/
+static int validate(const char *ptr) {
+    return ptr != NULL && ptr[0] != '\0';
+}
+
+void case_partial_smt(unsigned int size, const char *ptr) {
+    char buf[256];
+
+    if (size >= sizeof(buf)) {
+        return;
+    }
+    /* validate() call is unparseable; Z3 returns None for this branch */
+    if (validate(ptr)) {
+        memcpy(buf, ptr, size);    /* real vulnerability if ptr is attacker-controlled */
+        printf("[PARTIAL] Copied %u bytes\n", size);
+    }
+}
+
+
+/* =========================================================================
+ * DISPATCHER
+ * =========================================================================*/
+
+static void usage(void) {
+    fprintf(stderr,
+        "Commands (stdin: COMMAND:arg1,arg2,...):\n"
+        "  ALLOC:<count>\n"
+        "  SUM:<offset>,<length>,<buffer_size>\n"
+        "  OBO:<index>,<value_hex>\n"
+        "  MASK:<flags_hex>,<base>,<size>\n"
+        "  DEAD_RANGE:<x>\n"
+        "  DEAD_NULL:<string>\n"
+        "  DEAD_MASK:<flags_hex>\n"
+        "  LLM:<string>\n"
+        "  PARTIAL:<size>,<string>\n"
+    );
+}
+
+int main(void) {
+    char line[4096];
+    if (!fgets(line, sizeof(line), stdin)) {
+        usage();
+        return 1;
+    }
+    line[strcspn(line, "\n")] = '\0';
+
+    char *colon = strchr(line, ':');
+    if (!colon) { usage(); return 1; }
+    *colon = '\0';
+    char *cmd  = line;
+    char *args = colon + 1;
+
+    if (strcmp(cmd, "ALLOC") == 0) {
+        unsigned int count = (unsigned int)strtoul(args, NULL, 0);
+        case_alloc_overflow(count);
+
+    } else if (strcmp(cmd, "SUM") == 0) {
+        unsigned int offset = 0, length = 0, bsz = 0;
+        sscanf(args, "%u,%u,%u", &offset, &length, &bsz);
+        char src[4096] = {0};
+        memset(src, 'S', sizeof(src) - 1);
+        case_sum_overflow(offset, length, src, bsz);
+
+    } else if (strcmp(cmd, "OBO") == 0) {
+        int index = 0; unsigned int val = 0;
+        sscanf(args, "%d,%x", &index, &val);
+        case_offbyone(index, (char)(val & 0xff));
+
+    } else if (strcmp(cmd, "MASK") == 0) {
+        unsigned int flags = 0, base = 0, sz = 0;
+        sscanf(args, "%x,%u,%u", &flags, &base, &sz);
+        char payload[4096];
+        memset(payload, 'P', sizeof(payload));
+        case_bitmask_bypass(flags, base, sz, payload);
+
+    } else if (strcmp(cmd, "DEAD_RANGE") == 0) {
+        int x = atoi(args);
+        case_dead_range(x, "overflow_payload_that_would_crash");
+
+    } else if (strcmp(cmd, "DEAD_NULL") == 0) {
+        char dst[128] = {0};
+        case_dead_null(args, dst);
+        printf("[DEAD_NULL] dst = %.32s\n", dst);
+
+    } else if (strcmp(cmd, "DEAD_MASK") == 0) {
+        unsigned int flags = (unsigned int)strtoul(args, NULL, 16);
+        case_dead_bitmask(flags, "payload_data", 12);
+
+    } else if (strcmp(cmd, "LLM") == 0) {
+        case_llm_fallthrough(args);
+
+    } else if (strcmp(cmd, "PARTIAL") == 0) {
+        unsigned int sz = 0;
+        char *comma = strchr(args, ',');
+        if (comma) { sz = (unsigned int)strtoul(args, NULL, 0); args = comma + 1; }
+        case_partial_smt(sz, args);
+
+    } else {
+        usage();
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Using SMT Solvers where LLMs Struggle

**IDEA** - incorporate the SMT Solver logic from #188 into the CodeQL analysis workflow. This is potentially very useful as bug classes (listed below) that are based in integer bounds/arithmetic/etc. are hard to LLMs to get right, whilst they seem to excel at string-based checking. So, this PR adds the existing SMT Solver core to CodeQL, providing parsers, tests, and analysis shims.

Paging @grokjc for review as this is another biggie (sorry!). 🚀 

On first analysis with Claude, the following bug classes stood out as points where SMT might really help: 

  1. CWE-190 (integer overflow) — pure bitvector arithmetic, Z3 is ideal here!
  2. CWE-122/120 (buffer overflow/size checks) — `size < buf_len` constraints, Z3 should help
  3. CWE-193 (off-by-one) — boundary condition arithmetic
  4. CWE-476 (null deref) — `ptr != NULL` equality

**Note** - bugs like CWE-89 (SQLi) are still best left to something that can parse language strings and  has some inherent abstract notion of string/meaning mutability… you know, like an LLM :-P But LLM’s notoriously fall over when it comes to arithmetic, linear constraints, etc. So this is where an SMT Solver should actually add a lot of value. 

To that end, here’s what’s in the PR box - new files first:

* `packages/codeql/smt_path_validator.py` - this imports the SMT solver harness and adds parsers for codeql output that allows it to then run the solver on the constraints identified through codeql queries. 
* `packages/codeql/tests/test_smt_path_validator.py` - tests for the above, like any responsible citizen. 

Then the modified files:
* `packages/codeql/dataflow_validator.py` - shimming the analysis and parser chain from `smt_path_validator.py` into the dataflow validation pipeline. Before the LLM makes a determination, the code runs the parsers and SMT solver code, and passes the output of the run (any unsat and sat results) to the LLM to enrich exploitability decisions. 
* `.claude/commands/codeql.md`, `.claude/skills/exploitability-validation/stage-e-feasibility.md`, and `CLAUDE.md` - essentially updating the agent with what new toys it has to play with. 

## New SMT-CodeQL Testbench

There is also a new test bench in `test/data/smt_codeql_testbench` that presents the following test case groups for CodeQL analysis:

### Group 1 — SAT with non-obvious PoC values

Z3 finds concrete satisfying assignments that require reasoning about unsigned bitvector wraparound or compound inequality constraints.

| Case | File | Sink line | Guard (visible) | Bug | Z3 PoC value |
|------|------|-----------|-----------------|-----|--------------|
| `ALLOC` | `smt_codeql_testbench.c:93` | `memset(&records[i], ...)` | `count < 0x40000000` | `count * 16` overflows uint32 | `count = 0x10000001` → alloc = 16 bytes, loop writes 4 GB |
| `SUM` | `smt_codeql_testbench.c:132` | `memcpy(shared_buffer + offset, ...)` | `offset + length <= buffer_size` | unsigned sum wraps | `offset=0xFFFF0000, length=0x10010` → sum=0x10 ≤ 64 |
| `OBO` | `smt_codeql_testbench.c:165` | `buf[index] = value` | `index > INDEX_LIMIT` (should be `>=`) | off-by-one | `index=128` passes `> 128` check, writes `buf[128]` |
| `MASK` | `smt_codeql_testbench.c:200` | `memcpy(heap_region + base, ...)` | `base + size <= HEAP_SIZE` | unsigned base+size wrap | `base=0xFFFFE000, size=4000` → sum=0x3E80 ≤ 8192 |

### Group 2 — UNSAT (provably dead paths)

CodeQL reports a flow to the sink; Z3 proves the path conditions are mutually exclusive and suppresses the LLM call.

| Case | File | Sink line | Conditions Z3 checks | Conflict |
|------|------|-----------|----------------------|----------|
| `DEAD_RANGE` | `smt_codeql_testbench.c:243` | `strcpy(dead_buf, data)` | `x > 100` AND `x < 50` | ⊥ immediately |
| `DEAD_NULL` | `smt_codeql_testbench.c:280` | `strcpy(dst, ptr)` | `ptr != NULL` AND `ptr == NULL` | ⊥ immediately |
| `DEAD_MASK` | `smt_codeql_testbench.c:308` | `memcpy(flag_buf, payload, len)` | `flags & 0x1 == 0` AND `flags & 0x1 == 1` | ⊥ immediately |

### Group 3 — Indeterminate (Z3 falls through to LLM)

Conditions contain function calls the bitvector parser cannot encode. Z3 returns `feasible=None` and full LLM analysis runs unchanged.

| Case | File | Why Z3 returns `None` |
|------|------|-----------------------|
| `LLM` | `smt_codeql_testbench.c:327` | `strlen(input)` call — parentheses rejected by bitvector parser |
| `PARTIAL` | `smt_codeql_testbench.c:350` | `validate(ptr)` call — same reason; `size < 256` is parseable but alone is indeterminate |

## What’s missing?

In the parser, `~` (unary NOT) is left as unknown. It requires a unary parser path (no RHS operand), and ~mask in real conditions is almost always wrapped in a bitmask form like `addr & ~PAGE_MASK == 0`. I have essentially chickened out of this level of complexity for now. 🐣 