### PR TITLE
fix: thread repo_path to enrich_analysis_prompt; throttle memory.py sync

### DIFF
--- a/core/sage/memory.py
+++ b/core/sage/memory.py
@@ -5,7 +5,6 @@ Drop-in replacement for FuzzingMemory that stores knowledge in SAGE
 for consensus-validated persistence while keeping JSON as local cache.
 """
 
-import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -13,6 +12,7 @@ from core.logging import get_logger
 
 from .client import SageClient
 from .config import SageConfig
+from .hooks import _throttle
 
 logger = get_logger()
 
@@ -104,8 +104,7 @@ class SageFuzzingMemory(FuzzingMemory):
                     confidence=k.confidence,
                 ):
                     stored += 1
-                # Small delay to avoid overwhelming single-node consensus
-                time.sleep(0.3)
+                _throttle()
             except Exception as e:
                 logger.debug(f"SAGE sync failed for {key}: {e}")
 

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -696,6 +696,7 @@ Do NOT:
             dataflow_source=vuln.dataflow_source,
             dataflow_sink=vuln.dataflow_sink,
             dataflow_steps=vuln.dataflow_steps,
+            repo_path=str(vuln.repo_path),
         )
 
         system_prompt = ANALYSIS_SYSTEM_PROMPT

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -192,6 +192,12 @@ def orchestrate(
         print("\n  No findings to analyse")
         return None
 
+    # Stamp repo_path so build_analysis_prompt_from_finding forwards it to
+    # enrich_analysis_prompt; without this SAGE per-repo scoping (#198) makes
+    # the enrichment a no-op for every finding on the dispatch path.
+    for f in findings:
+        f.setdefault("repo_path", str(repo_path))
+
     if max_findings > 0 and len(findings) > max_findings:
         logger.info(f"Capping at {max_findings} findings (of {len(findings)})")
         findings = findings[:max_findings]

--- a/packages/llm_analysis/prompts/analysis.py
+++ b/packages/llm_analysis/prompts/analysis.py
@@ -44,6 +44,7 @@ def build_analysis_prompt(
     dataflow_sink: Optional[Dict[str, Any]] = None,
     dataflow_steps: Optional[list] = None,
     metadata: Optional[Dict[str, Any]] = None,
+    repo_path: Optional[str] = None,
 ) -> str:
     """Build the vulnerability analysis prompt.
 
@@ -155,7 +156,7 @@ You have the COMPLETE attack path from source to sink. Use this to make an infor
     # Enrich with SAGE historical context (cross-run learning)
     try:
         from core.sage.hooks import enrich_analysis_prompt
-        sage_context = enrich_analysis_prompt(rule_id, file_path)
+        sage_context = enrich_analysis_prompt(rule_id, file_path, repo_path=repo_path)
         if sage_context:
             prompt += sage_context
     except Exception:
@@ -232,4 +233,5 @@ def build_analysis_prompt_from_finding(finding: Dict[str, Any]) -> str:
         dataflow_sink=dataflow.get("sink") if dataflow else None,
         dataflow_steps=dataflow.get("steps") if dataflow else None,
         metadata=finding.get("metadata"),
+        repo_path=finding.get("repo_path"),
     )

--- a/packages/llm_analysis/tests/test_prompts.py
+++ b/packages/llm_analysis/tests/test_prompts.py
@@ -2,6 +2,7 @@
 
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -78,6 +79,44 @@ class TestAnalysisPrompt:
         prompt = build_analysis_prompt_from_finding(finding)
         assert "sqli" in prompt
         assert "bad code" in prompt
+
+    @patch("core.sage.hooks._get_client")
+    def test_threads_repo_path_to_sage_scoped_domain(self, mock_get_client):
+        # With repo_path present, SAGE is queried and the domain tag is
+        # scoped per-repo (raptor-findings-<key>), not the bare domain.
+        mock_client = MagicMock()
+        mock_client.query.return_value = [
+            {"content": "prior SQLi finding in similar code", "score": 0.9},
+        ]
+        mock_get_client.return_value = mock_client
+
+        prompt = build_analysis_prompt_from_finding({
+            "rule_id": "sqli", "level": "error", "file_path": "db.py",
+            "start_line": 10, "end_line": 12, "message": "tainted input",
+            "repo_path": "/path/to/repo",
+        })
+
+        assert "Historical Context from SAGE" in prompt
+        assert mock_client.query.called
+        domain = mock_client.query.call_args.kwargs["domain_tag"]
+        assert domain.startswith("raptor-findings-")
+        assert domain != "raptor-findings"
+
+    @patch("core.sage.hooks._get_client")
+    def test_no_repo_path_skips_sage_enrichment(self, mock_get_client):
+        # Without repo_path the hook short-circuits (per-repo scoping, #198).
+        # Guards against a future regression where the short-circuit is
+        # accidentally removed and recall leaks across repos.
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        prompt = build_analysis_prompt_from_finding({
+            "rule_id": "sqli", "level": "error", "file_path": "db.py",
+            "start_line": 10, "end_line": 12, "message": "tainted input",
+        })
+
+        assert "Historical Context from SAGE" not in prompt
+        mock_client.query.assert_not_called()
 
 
 class TestAnalysisSchema:


### PR DESCRIPTION
#198 made enrich_analysis_prompt require repo_path for per-repo SAGE scoping. Its only caller in prompts/analysis.py still used the pre-#198 signature, so every call silently returned "" — cross-run analysis enrichment was dead at merge.

Thread repo_path through:
- build_analysis_prompt gains an optional repo_path kwarg, forwarded to enrich_analysis_prompt.
- build_analysis_prompt_from_finding reads repo_path from the finding dict (dispatch path).
- orchestrator.py stamps repo_path into each finding after loading the prep report, so AnalysisTask picks it up automatically.
- agent.py passes str(vuln.repo_path) at the direct call site.

memory.py had a leftover time.sleep(0.3) in the fuzzing knowledge sync loop — same dead-delay rationale #192 removed from hooks.py. Replaced with _throttle() so SAGE_PROPOSE_DELAY_MS applies consistently across all propose() sites (default 0 = no delay).

test_prompts.py adds two integration tests that drive the full chain (previously only SAGE's own tests exercised enrich_analysis_prompt, and they called it directly with repo_path= explicit so the caller bug was invisible).