### PR TITLE
SMT: parametric BVProfile across encoders

### DIFF
--- a/.claude/commands/codeql.md
+++ b/.claude/commands/codeql.md
@@ -40,9 +40,10 @@ pre-check before the full LLM analysis (`packages/codeql/smt_path_validator.py`)
 
 Requires `z3-solver` (`pip install z3-solver`). Degrades gracefully when absent.
 
-**Best coverage:** CWE-190 (integer overflow), CWE-120/122 (buffer size checks),
-CWE-193 (off-by-one), CWE-476 (null deref). String-based findings (CWE-89) fall
-through to LLM analysis.
+**Best coverage:** CWE-190 (integer overflow, **including 32-bit wraparound** —
+the extraction LLM emits per-path width/signedness hints so Z3 models the right
+C type semantics), CWE-120/122 (buffer size checks), CWE-193 (off-by-one),
+CWE-476 (null deref). String-based findings (CWE-89) fall through to LLM analysis.
 
 ## Examples
 

--- a/.claude/skills/exploitability-validation/stage-e-feasibility.md
+++ b/.claude/skills/exploitability-validation/stage-e-feasibility.md
@@ -127,8 +127,17 @@ structured predicates; Z3 checks joint satisfiability:
 - `feasible: null` — Z3 unavailable or all conditions unparseable; full LLM
   analysis runs unchanged.
 
-Best coverage: CWE-190 (integer overflow — Z3 will find wraparound bypass paths),
-CWE-120/122 (buffer size arithmetic), CWE-193 (off-by-one), CWE-476 (null deref).
+The `reasoning` string carries a mode tag in parentheses — e.g.
+`"feasible (32-bit unsigned): ..."`. This tells you the bitvector semantics
+used for the verdict. **If the tag's width doesn't match the vulnerability's
+real C type**, the verdict is suspect: a CWE-190 (integer overflow) path
+analysed under `64-bit unsigned` misses 32-bit wraparound and the `false`
+verdict should be treated as incomplete — defer to your own C-semantics
+reasoning rather than trusting it as a chain-break.
+
+Best coverage: CWE-190 (integer overflow — Z3 finds wraparound bypass paths
+when the profile matches the real C type width), CWE-120/122 (buffer size
+arithmetic), CWE-193 (off-by-one), CWE-476 (null deref).
 
 **SMT feasibility (one-gadget):** When the optional `z3-solver` package is installed, `analysis.one_gadget_info.smt_feasibility` contains a Z3-backed verdict on whether the best gadget's register/memory constraints can be satisfied:
 

--- a/core/smt_solver/__init__.py
+++ b/core/smt_solver/__init__.py
@@ -1,40 +1,80 @@
 """SMT solver framework for RAPTOR.
 
 A thin, optional Z3 harness shared by domain encoders in ``packages/``.
-Handles availability gating, bitvector configuration, signed/unsigned
+Handles availability gating, bitvector primitives, signed/unsigned
 comparison routing, witness extraction, and solver construction with a
 default timeout.
 
-Domain-specific encodings (sanitizer patterns, integer overflow predicates,
-one-gadget constraints, ...) live in their respective ``packages/`` modules
-and import primitives from here.
+Encoders parametrise width and signedness via ``BVProfile`` — one
+handle instead of two flags, with pre-made profiles for common
+architecture and C-type flavours (``BV_X86_64``, ``BV_C_UINT32``,
+``BV_C_INT32``, ...).
+
+C-semantics primitives (overflow predicates, width coercion, shift
+disambiguators, casts) live in ``core.smt_solver.csem`` and are
+imported directly by encoders that need them; they're deliberately not
+re-exported here to keep the top-level surface small.
+
+Domain-specific encodings (sanitizer patterns, integer overflow
+predicates, one-gadget constraints, ...) live in their respective
+``packages/`` modules and import primitives from here.
 """
 
 from .availability import z3, z3_available
 from .bitvec import ge, gt, le, lt, mk_val, mk_var
-from .config import bv_width, is_signed, mode_tag
+from .config import (
+    BVProfile,
+    BV_AARCH64,
+    BV_ARM32,
+    BV_C_INT8,
+    BV_C_INT16,
+    BV_C_INT32,
+    BV_C_INT64,
+    BV_C_UINT8,
+    BV_C_UINT16,
+    BV_C_UINT32,
+    BV_C_UINT64,
+    BV_I386,
+    BV_X86_64,
+)
 from .explain import core_names, track
 from .session import DEFAULT_TIMEOUT_MS, new_solver, scoped
 from .witness import bv_to_int, format_vars, format_witness
 
 __all__ = [
+    # Availability
     "z3_available",
     "z3",
-    "bv_width",
-    "is_signed",
-    "mode_tag",
+    # Profiles
+    "BVProfile",
+    "BV_X86_64",
+    "BV_AARCH64",
+    "BV_I386",
+    "BV_ARM32",
+    "BV_C_UINT64",
+    "BV_C_INT64",
+    "BV_C_UINT32",
+    "BV_C_INT32",
+    "BV_C_UINT16",
+    "BV_C_INT16",
+    "BV_C_UINT8",
+    "BV_C_INT8",
+    # Bitvec primitives
     "mk_var",
     "mk_val",
     "le",
     "lt",
     "ge",
     "gt",
+    # Witness
     "bv_to_int",
     "format_vars",
     "format_witness",
+    # Session
     "DEFAULT_TIMEOUT_MS",
     "new_solver",
     "scoped",
+    # Unsat-core explanation
     "track",
     "core_names",
 ]

--- a/core/smt_solver/_testing.py
+++ b/core/smt_solver/_testing.py
@@ -1,0 +1,46 @@
+"""Shared test helpers for ``core.smt_solver`` consumers.
+
+Centralises the two helpers every SMT-adjacent test file needs:
+- evaluating a closed z3 boolean expression to ``True``/``False``
+- reading the raw-bits value of a closed z3 bitvec expression
+
+Placed alongside the module (with a leading underscore) rather than in a
+``conftest.py`` because tests live in several trees (``core/smt_solver/tests/``,
+``packages/codeql/tests/``, ``packages/exploit_feasibility/tests/``) and
+pytest's per-tree ``conftest.py`` discovery doesn't cross those boundaries.
+
+Each test file still defines its own ``_requires_z3`` marker inline — the
+marker is just a one-liner and keeps pytest out of this module's import path.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def eval_predicate(pred: Any) -> bool:
+    """Return ``True`` iff ``pred`` is satisfiable.
+
+    Wrap in ``z3.Not(...)`` to check tautology (``eval_predicate(z3.Not(p))
+    == False`` iff ``p`` is valid).
+    """
+    from core.smt_solver import new_solver, z3
+    s = new_solver()
+    s.add(pred)
+    return s.check() == z3.sat
+
+
+def eval_bv(expr: Any, width: int) -> int:
+    """Return the raw-bits integer value of a closed z3 bitvec expression.
+
+    Always unsigned bit pattern — callers that want the signed
+    interpretation should apply their own two's-complement reinterpretation.
+    """
+    from core.smt_solver import new_solver, z3
+    s = new_solver()
+    probe = z3.BitVec("_probe", width)
+    s.add(probe == expr)
+    assert s.check() == z3.sat
+    return s.model()[probe].as_long()
+
+
+__all__ = ["eval_predicate", "eval_bv"]

--- a/core/smt_solver/bitvec.py
+++ b/core/smt_solver/bitvec.py
@@ -5,44 +5,39 @@ variants must go through ``z3.ULE/ULT/UGE/UGT``. The wrappers in this
 module route signed/unsigned through a single switch so domain encoders
 don't scatter that logic throughout their own files.
 
-Default-width helpers read ``config.bv_width()`` / ``config.is_signed()``.
-Pass ``width`` / ``signed`` explicitly when modeling an expression at a
-non-default configuration (for example, an ``unsigned int`` sink at bv32
-while the global mode is bv64).
+These are low-level primitives — they take explicit ``width`` /
+``signed`` arguments rather than reading from a global config. Domain
+encoders translate a ``BVProfile`` into the per-call values once at
+their entry point and thread the resulting width/signed through.
 """
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from .availability import z3
-from .config import bv_width, is_signed
 
 
-def mk_var(name: str, width: Optional[int] = None) -> Any:
-    """Create a ``BitVec`` variable (default width = ``bv_width()``)."""
-    return z3.BitVec(name, width if width is not None else bv_width())
+def mk_var(name: str, width: int) -> Any:
+    """Create a ``BitVec`` variable at the given width."""
+    return z3.BitVec(name, width)
 
 
-def mk_val(v: int, width: Optional[int] = None) -> Any:
-    """Create a ``BitVecVal`` (default width = ``bv_width()``)."""
-    return z3.BitVecVal(v, width if width is not None else bv_width())
+def mk_val(v: int, width: int) -> Any:
+    """Create a ``BitVecVal`` at the given width."""
+    return z3.BitVecVal(v, width)
 
 
-def le(a: Any, b: Any, signed: Optional[bool] = None) -> Any:
-    s = is_signed() if signed is None else signed
-    return a <= b if s else z3.ULE(a, b)
+def le(a: Any, b: Any, signed: bool) -> Any:
+    return a <= b if signed else z3.ULE(a, b)
 
 
-def lt(a: Any, b: Any, signed: Optional[bool] = None) -> Any:
-    s = is_signed() if signed is None else signed
-    return a < b if s else z3.ULT(a, b)
+def lt(a: Any, b: Any, signed: bool) -> Any:
+    return a < b if signed else z3.ULT(a, b)
 
 
-def ge(a: Any, b: Any, signed: Optional[bool] = None) -> Any:
-    s = is_signed() if signed is None else signed
-    return a >= b if s else z3.UGE(a, b)
+def ge(a: Any, b: Any, signed: bool) -> Any:
+    return a >= b if signed else z3.UGE(a, b)
 
 
-def gt(a: Any, b: Any, signed: Optional[bool] = None) -> Any:
-    s = is_signed() if signed is None else signed
-    return a > b if s else z3.UGT(a, b)
+def gt(a: Any, b: Any, signed: bool) -> Any:
+    return a > b if signed else z3.UGT(a, b)

--- a/core/smt_solver/config.py
+++ b/core/smt_solver/config.py
@@ -1,42 +1,64 @@
-"""Bitvector width/signedness configuration for RAPTOR's SMT harness.
+"""Bitvector profile (width + signedness) for RAPTOR's SMT harness.
 
-Dataclass - SMTSolverBVConfig is the base bitvector config class. This
-    gets passed around and is referenced by bv_width and is_signed. 
+A ``BVProfile`` names the bit-width and signedness a domain encoder
+uses for its path conditions / constraints / witness rendering. It's
+passed as a single kwarg (rather than two separate ``width`` / ``signed``
+flags) so call sites read "I'm modelling a C uint32" rather than
+"width=32, signed=False".
 
-mode_tag returns bv(32|64)(u|s) in line with onegadgets format e.g. 'bv64u'
+Pre-made profiles cover common architecture register widths and C
+integer types; construct ``BVProfile(width=..., signed=...)`` directly
+for unusual cases.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Optional
 
 
-@dataclass
-class SMTSolverBVConfig:
-    """Dataclass for SMT Solver Bitvector Config"""
-    width: Literal[32, 64] = 64
-    signed: bool = True
+@dataclass(frozen=True)
+class BVProfile:
+    """Width and signedness for SMT bitvector reasoning.
+
+    ``frozen=True`` prevents accidental mutation of shared profile
+    instances (e.g. the pre-made ``BV_X86_64``) — a subtle bug class
+    that bit us once already via a mutable singleton.
+    """
+    width: int = 64
+    signed: bool = False
 
     def __post_init__(self):
-        if self.width not in (32, 64):
-            raise ValueError(f"width must be 32 or 64, got {self.width}")
+        if self.width <= 0:
+            raise ValueError(f"width must be positive, got {self.width}")
+
+    def mode_tag(self) -> str:
+        """Compact tag like ``bv64u`` / ``bv32s`` — useful when brevity matters."""
+        return f"bv{self.width}{'s' if self.signed else 'u'}"
+
+    def describe(self) -> str:
+        """Human-readable description like ``"64-bit unsigned"`` / ``"32-bit signed"``.
+
+        Used in reasoning strings shown to researchers — spells out what
+        ``mode_tag()`` abbreviates.
+        """
+        return f"{self.width}-bit {'signed' if self.signed else 'unsigned'}"
 
 
-_Z3_BVConfig = SMTSolverBVConfig()
+# ---------------------------------------------------------------------------
+# Pre-made profiles — name expresses the modelled type at call sites.
+# ---------------------------------------------------------------------------
 
+# Architecture register widths (address reasoning is always unsigned).
+BV_X86_64    = BVProfile(width=64, signed=False)
+BV_AARCH64   = BVProfile(width=64, signed=False)
+BV_I386      = BVProfile(width=32, signed=False)
+BV_ARM32     = BVProfile(width=32, signed=False)
 
-def bv_width() -> int:
-    """Get the bitvector width"""
-    return _Z3_BVConfig.width
-
-
-def is_signed() -> bool:
-    """Get bitvector signedness"""
-    return _Z3_BVConfig.signed
-
-
-def mode_tag(width: Optional[int] = None, signed: Optional[bool] = None) -> str:
-    """Human-readable mode tag like ``bv64u`` / ``bv32s`` (for reasoning strings)."""
-    w = width  if width  is not None else _Z3_BVConfig.width
-    s = signed if signed is not None else _Z3_BVConfig.signed
-    return f"bv{w}{'s' if s else 'u'}"
+# C integer types — the usual suspects for CWE-190 reasoning.
+BV_C_UINT64  = BVProfile(width=64, signed=False)
+BV_C_INT64   = BVProfile(width=64, signed=True)
+BV_C_UINT32  = BVProfile(width=32, signed=False)
+BV_C_INT32   = BVProfile(width=32, signed=True)
+BV_C_UINT16  = BVProfile(width=16, signed=False)
+BV_C_INT16   = BVProfile(width=16, signed=True)
+BV_C_UINT8   = BVProfile(width=8, signed=False)
+BV_C_INT8    = BVProfile(width=8, signed=True)

--- a/core/smt_solver/csem.py
+++ b/core/smt_solver/csem.py
@@ -1,0 +1,172 @@
+"""C-semantics helpers for SMT bitvector reasoning.
+
+Width coercion, overflow predicates, and shift disambiguators used by
+domain encoders (``smt_onegadget``, ``smt_path_validator``) when they
+need to reason about real C arithmetic rather than abstract bitvector
+math.
+
+- **Overflow predicates** turn ``a + b`` into "does this wrap under
+  {signed, unsigned} {add, sub, mul}" — the primitives that make
+  CWE-190 (integer overflow / wraparound) expressible as SAT.
+- **Width coercion** — truncation (``Extract``), sign/zero extension
+  (``SignExt``/``ZeroExt``) — lets an encoder model a narrow C type
+  feeding a wider expression or vice versa.
+- **Shift disambiguators** (``ashr`` vs ``lshr``): Z3's ``>>`` on a
+  bitvec is arithmetic right shift; the logical form is ``z3.LShR``.
+  Wrapping both by name stops encoders from silently picking the wrong
+  one for a given signedness.
+- **``cast``** combines the above to simulate a C-style conversion
+  between integer types.
+
+Usage::
+
+    # CWE-190: detect count * N wrapping through a bound check
+    from core.smt_solver import new_solver, z3
+    from core.smt_solver.csem import umul_overflows
+
+    s = new_solver()
+    count = z3.BitVec("count", 32)
+    s.add(count < 0x40000000)                           # visible guard
+    s.add(umul_overflows(count, z3.BitVecVal(16, 32)))  # mul wraps at 2^32
+    if s.check() == z3.sat:
+        print("Wraparound witness:", s.model()[count])
+
+    # CWE-197: narrowing cast discards significant bits
+    from core.smt_solver.csem import truncation_loses_bits
+
+    value32 = z3.BitVec("value32", 32)
+    s.add(truncation_loses_bits(value32, to_width=8, to_signed=False))
+    # SAT when a uint32→uint8 narrowing changes the value
+
+    # Sign-preserving widening composed with arithmetic right shift
+    from core.smt_solver.csem import cast, ashr
+
+    i8 = z3.BitVec("i8", 8)
+    i32 = cast(i8, to_width=32, from_signed=True)     # sign-extend
+    shifted = ashr(i32, z3.BitVecVal(1, 32))          # arithmetic shift
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from .availability import z3
+
+
+# ---------------------------------------------------------------------------
+# Width coercion
+# ---------------------------------------------------------------------------
+
+def truncate(bv: Any, to_width: int) -> Any:
+    """Discard high bits, keeping the low ``to_width`` bits."""
+    return z3.Extract(to_width - 1, 0, bv)
+
+
+def sign_extend(bv: Any, to_width: int) -> Any:
+    """Extend ``bv`` to ``to_width`` bits preserving the sign bit."""
+    return z3.SignExt(to_width - bv.size(), bv)
+
+
+def zero_extend(bv: Any, to_width: int) -> Any:
+    """Extend ``bv`` to ``to_width`` bits padding with zeros."""
+    return z3.ZeroExt(to_width - bv.size(), bv)
+
+
+def truncation_loses_bits(bv: Any, to_width: int, to_signed: bool) -> Any:
+    """Predicate: does truncating ``bv`` to ``to_width`` lose information?
+
+    True exactly when the narrow value, re-extended to the original width
+    under the *narrow (destination) type's* signedness, differs from the
+    original — i.e. the C "value changes when assigned to a narrower type"
+    semantic.  ``to_signed`` names the narrow type's signedness to
+    parallel ``cast(..., from_signed=...)``.
+    """
+    narrow = truncate(bv, to_width)
+    wide = sign_extend(narrow, bv.size()) if to_signed else zero_extend(narrow, bv.size())
+    return wide != bv
+
+
+# ---------------------------------------------------------------------------
+# Overflow predicates
+# ---------------------------------------------------------------------------
+
+def uadd_overflows(a: Any, b: Any) -> Any:
+    """Unsigned addition wraps around (result < either operand)."""
+    return z3.Not(z3.BVAddNoOverflow(a, b, signed=False))
+
+
+def sadd_overflows(a: Any, b: Any) -> Any:
+    """Signed addition overflows in either direction (positive→wrap-to-negative or vice versa)."""
+    return z3.Or(
+        z3.Not(z3.BVAddNoOverflow(a, b, signed=True)),
+        z3.Not(z3.BVAddNoUnderflow(a, b)),
+    )
+
+
+def usub_underflows(a: Any, b: Any) -> Any:
+    """Unsigned subtraction wraps around (a < b)."""
+    return z3.Not(z3.BVSubNoUnderflow(a, b, signed=False))
+
+
+def ssub_overflows(a: Any, b: Any) -> Any:
+    """Signed subtraction overflows in either direction."""
+    return z3.Or(
+        z3.Not(z3.BVSubNoOverflow(a, b)),
+        z3.Not(z3.BVSubNoUnderflow(a, b, signed=True)),
+    )
+
+
+def umul_overflows(a: Any, b: Any) -> Any:
+    """Unsigned multiplication wraps around."""
+    return z3.Not(z3.BVMulNoOverflow(a, b, signed=False))
+
+
+def smul_overflows(a: Any, b: Any) -> Any:
+    """Signed multiplication overflows in either direction."""
+    return z3.Or(
+        z3.Not(z3.BVMulNoOverflow(a, b, signed=True)),
+        z3.Not(z3.BVMulNoUnderflow(a, b)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shift disambiguators
+# ---------------------------------------------------------------------------
+
+def ashr(a: Any, b: Any) -> Any:
+    """Arithmetic right shift — preserves the sign bit.
+
+    Z3's ``>>`` operator on a bitvec is already arithmetic shift; this
+    helper exists so call sites read the intent rather than relying on
+    the reader to remember the Python-operator-to-Z3-semantics mapping.
+    """
+    return a >> b
+
+
+def lshr(a: Any, b: Any) -> Any:
+    """Logical right shift — shifts in zeros (unsigned semantics)."""
+    return z3.LShR(a, b)
+
+
+# ---------------------------------------------------------------------------
+# C-style cast
+# ---------------------------------------------------------------------------
+
+def cast(bv: Any, to_width: int, from_signed: bool) -> Any:
+    """Simulate a C-style integer cast.
+
+    - Widening: sign-extends when the source is signed, zero-extends when
+      unsigned (matching C's ``(int64_t)int32`` vs ``(uint64_t)uint32``
+      behaviour).
+    - Narrowing: truncates (discards high bits).
+    - Same width: no-op.
+
+    The *destination* signedness doesn't change the bit pattern in C —
+    callers interpret the result with the semantics they want (via
+    signed/unsigned comparisons downstream), so it's not a parameter.
+    """
+    from_width = bv.size()
+    if to_width > from_width:
+        return sign_extend(bv, to_width) if from_signed else zero_extend(bv, to_width)
+    if to_width < from_width:
+        return truncate(bv, to_width)
+    return bv

--- a/core/smt_solver/tests/test_config.py
+++ b/core/smt_solver/tests/test_config.py
@@ -1,0 +1,123 @@
+"""Tests for core.smt_solver.config — BVProfile and pre-made profiles."""
+
+import sys
+from pathlib import Path
+
+import pytest
+from dataclasses import FrozenInstanceError
+
+# core/smt_solver/tests/ -> repo root
+sys.path.insert(0, str(Path(__file__).parents[3]))
+
+from core.smt_solver import (
+    BVProfile,
+    BV_X86_64,
+    BV_AARCH64,
+    BV_I386,
+    BV_ARM32,
+    BV_C_UINT64,
+    BV_C_INT64,
+    BV_C_UINT32,
+    BV_C_INT32,
+    BV_C_UINT16,
+    BV_C_INT16,
+    BV_C_UINT8,
+    BV_C_INT8,
+)
+
+
+class TestBVProfileConstruction:
+    def test_defaults_are_64_bit_unsigned(self):
+        p = BVProfile()
+        assert p.width == 64
+        assert p.signed is False
+
+    def test_custom_width_and_signed(self):
+        p = BVProfile(width=32, signed=True)
+        assert p.width == 32
+        assert p.signed is True
+
+    def test_non_standard_width_is_accepted(self):
+        """Width isn't constrained to {8, 16, 32, 64} — csem supports
+        arbitrary positive widths (e.g. 24-bit types in embedded code)."""
+        p = BVProfile(width=24, signed=False)
+        assert p.width == 24
+
+    def test_zero_width_rejected(self):
+        with pytest.raises(ValueError, match="positive"):
+            BVProfile(width=0)
+
+    def test_negative_width_rejected(self):
+        with pytest.raises(ValueError, match="positive"):
+            BVProfile(width=-1)
+
+
+class TestBVProfileFrozen:
+    """Profiles are immutable — attempted mutation must raise, not silently
+    corrupt shared instances.  The pre-made constants (BV_X86_64, etc.) are
+    shared across encoders; a stray ``BV_X86_64.width = 32`` would poison
+    every subsequent call."""
+
+    def test_cannot_mutate_width(self):
+        p = BVProfile()
+        with pytest.raises(FrozenInstanceError):
+            p.width = 32  # type: ignore[misc]
+
+    def test_cannot_mutate_signed(self):
+        p = BVProfile()
+        with pytest.raises(FrozenInstanceError):
+            p.signed = True  # type: ignore[misc]
+
+    def test_pre_made_profile_frozen(self):
+        with pytest.raises(FrozenInstanceError):
+            BV_X86_64.width = 32  # type: ignore[misc]
+
+
+class TestBVProfileFormatting:
+    def test_mode_tag_short_form(self):
+        assert BVProfile(width=64, signed=False).mode_tag() == "bv64u"
+        assert BVProfile(width=64, signed=True).mode_tag() == "bv64s"
+        assert BVProfile(width=32, signed=False).mode_tag() == "bv32u"
+        assert BVProfile(width=32, signed=True).mode_tag() == "bv32s"
+        assert BVProfile(width=8, signed=True).mode_tag() == "bv8s"
+
+    def test_describe_human_readable(self):
+        assert BVProfile(width=64, signed=False).describe() == "64-bit unsigned"
+        assert BVProfile(width=64, signed=True).describe() == "64-bit signed"
+        assert BVProfile(width=32, signed=False).describe() == "32-bit unsigned"
+        assert BVProfile(width=8, signed=True).describe() == "8-bit signed"
+
+
+class TestEquality:
+    def test_profiles_with_same_values_are_equal(self):
+        assert BVProfile(width=32, signed=True) == BVProfile(width=32, signed=True)
+
+    def test_pre_made_profiles_reuse_matching_shape(self):
+        """BV_X86_64 and BV_AARCH64 both model 64-bit unsigned registers —
+        they compare equal.  That's expected: the names express intent at
+        the call site but the underlying profile is the same."""
+        assert BV_X86_64 == BV_AARCH64
+        assert BV_X86_64 == BVProfile(width=64, signed=False)
+
+
+class TestPreMadeProfiles:
+    """Pin the width/signed shape of every named constant so a rename or
+    rebind gets caught by tests."""
+
+    def test_architecture_profiles(self):
+        assert (BV_X86_64.width, BV_X86_64.signed) == (64, False)
+        assert (BV_AARCH64.width, BV_AARCH64.signed) == (64, False)
+        assert (BV_I386.width, BV_I386.signed) == (32, False)
+        assert (BV_ARM32.width, BV_ARM32.signed) == (32, False)
+
+    def test_c_unsigned_int_profiles(self):
+        assert (BV_C_UINT64.width, BV_C_UINT64.signed) == (64, False)
+        assert (BV_C_UINT32.width, BV_C_UINT32.signed) == (32, False)
+        assert (BV_C_UINT16.width, BV_C_UINT16.signed) == (16, False)
+        assert (BV_C_UINT8.width, BV_C_UINT8.signed) == (8, False)
+
+    def test_c_signed_int_profiles(self):
+        assert (BV_C_INT64.width, BV_C_INT64.signed) == (64, True)
+        assert (BV_C_INT32.width, BV_C_INT32.signed) == (32, True)
+        assert (BV_C_INT16.width, BV_C_INT16.signed) == (16, True)
+        assert (BV_C_INT8.width, BV_C_INT8.signed) == (8, True)

--- a/core/smt_solver/tests/test_csem.py
+++ b/core/smt_solver/tests/test_csem.py
@@ -1,0 +1,217 @@
+"""Tests for core.smt_solver.csem — C-semantics bitvector helpers."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# core/smt_solver/tests/ -> repo root
+sys.path.insert(0, str(Path(__file__).parents[3]))
+
+from core.smt_solver import z3_available
+from core.smt_solver._testing import eval_bv as _eval_bv, eval_predicate as _eval_predicate
+
+_requires_z3 = pytest.mark.skipif(
+    not z3_available(),
+    reason="z3-solver not installed",
+)
+
+
+# ---------------------------------------------------------------------------
+# Width coercion
+# ---------------------------------------------------------------------------
+
+class TestWidthCoercion:
+    @_requires_z3
+    def test_truncate_keeps_low_bits(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import truncate
+        assert _eval_bv(truncate(z3.BitVecVal(0xFFEE, 16), 8), 8) == 0xEE
+
+    @_requires_z3
+    def test_sign_extend_preserves_sign(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import sign_extend
+        # 0xFE as int8 = -2; sign-extended to 32 bits = 0xFFFFFFFE
+        assert _eval_bv(sign_extend(z3.BitVecVal(0xFE, 8), 32), 32) == 0xFFFFFFFE
+
+    @_requires_z3
+    def test_zero_extend_pads_with_zero(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import zero_extend
+        assert _eval_bv(zero_extend(z3.BitVecVal(0xFE, 8), 32), 32) == 0x000000FE
+
+    @_requires_z3
+    def test_truncation_loses_bits_unsigned_lossless(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import truncation_loses_bits
+        # 0x7F fits in 8-bit unsigned
+        assert _eval_predicate(
+            z3.Not(truncation_loses_bits(z3.BitVecVal(0x7F, 32), 8, to_signed=False))
+        )
+
+    @_requires_z3
+    def test_truncation_loses_bits_unsigned_lossy(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import truncation_loses_bits
+        # 0x1FF doesn't fit in 8-bit unsigned (max 0xFF)
+        assert _eval_predicate(
+            truncation_loses_bits(z3.BitVecVal(0x1FF, 32), 8, to_signed=False)
+        )
+
+    @_requires_z3
+    def test_truncation_loses_bits_signed_lossy(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import truncation_loses_bits
+        # 0xFFFFFF7F as int32 = -129; narrow int8 is 0x7F = +127; values differ
+        assert _eval_predicate(
+            truncation_loses_bits(z3.BitVecVal(0xFFFFFF7F, 32), 8, to_signed=True)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Overflow predicates
+# ---------------------------------------------------------------------------
+
+class TestOverflowPredicates:
+    @_requires_z3
+    def test_uadd_overflows_when_wraps(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import uadd_overflows
+        # 0xFF + 1 in 8-bit unsigned wraps to 0
+        assert _eval_predicate(uadd_overflows(z3.BitVecVal(0xFF, 8), z3.BitVecVal(1, 8)))
+
+    @_requires_z3
+    def test_uadd_overflows_false_when_safe(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import uadd_overflows
+        assert _eval_predicate(
+            z3.Not(uadd_overflows(z3.BitVecVal(1, 8), z3.BitVecVal(1, 8)))
+        )
+
+    @_requires_z3
+    def test_sadd_overflows_positive_to_negative(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import sadd_overflows
+        # 0x7F (int8 max = 127) + 1 overflows to 0x80 (-128)
+        assert _eval_predicate(sadd_overflows(z3.BitVecVal(0x7F, 8), z3.BitVecVal(1, 8)))
+
+    @_requires_z3
+    def test_sadd_overflows_negative_to_positive(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import sadd_overflows
+        # 0x80 (int8 = -128) + 0xFF (int8 = -1) underflows to 0x7F (+127)
+        assert _eval_predicate(sadd_overflows(z3.BitVecVal(0x80, 8), z3.BitVecVal(0xFF, 8)))
+
+    @_requires_z3
+    def test_sadd_overflows_safe(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import sadd_overflows
+        assert _eval_predicate(
+            z3.Not(sadd_overflows(z3.BitVecVal(1, 8), z3.BitVecVal(1, 8)))
+        )
+
+    @_requires_z3
+    def test_usub_underflows(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import usub_underflows
+        # 1 - 2 in 8-bit unsigned wraps to 0xFF
+        assert _eval_predicate(usub_underflows(z3.BitVecVal(1, 8), z3.BitVecVal(2, 8)))
+
+    @_requires_z3
+    def test_usub_underflows_safe(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import usub_underflows
+        assert _eval_predicate(
+            z3.Not(usub_underflows(z3.BitVecVal(10, 8), z3.BitVecVal(2, 8)))
+        )
+
+    @_requires_z3
+    def test_ssub_overflows(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import ssub_overflows
+        # 0x80 (-128) - 1 underflows to 0x7F (+127)
+        assert _eval_predicate(ssub_overflows(z3.BitVecVal(0x80, 8), z3.BitVecVal(1, 8)))
+
+    @_requires_z3
+    def test_umul_overflows_32bit_alloc_case(self):
+        """ALLOC testbench case: count * 16 wraps at 32-bit."""
+        from core.smt_solver import z3
+        from core.smt_solver.csem import umul_overflows
+        assert _eval_predicate(
+            umul_overflows(z3.BitVecVal(0x10000001, 32), z3.BitVecVal(16, 32))
+        )
+
+    @_requires_z3
+    def test_umul_overflows_safe(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import umul_overflows
+        assert _eval_predicate(
+            z3.Not(umul_overflows(z3.BitVecVal(10, 32), z3.BitVecVal(16, 32)))
+        )
+
+    @_requires_z3
+    def test_smul_overflows(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import smul_overflows
+        # 0x40 (+64) * 4 in int8 = 256, wraps to 0 — signed overflow
+        assert _eval_predicate(smul_overflows(z3.BitVecVal(0x40, 8), z3.BitVecVal(4, 8)))
+
+
+# ---------------------------------------------------------------------------
+# Shift disambiguators
+# ---------------------------------------------------------------------------
+
+class TestShifts:
+    @_requires_z3
+    def test_ashr_preserves_sign_bit(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import ashr
+        # 0x80 (int8 = -128) >> 1 arithmetic = 0xC0 (-64)
+        assert _eval_bv(ashr(z3.BitVecVal(0x80, 8), z3.BitVecVal(1, 8)), 8) == 0xC0
+
+    @_requires_z3
+    def test_lshr_zero_fills(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import lshr
+        # 0x80 >> 1 logical = 0x40 (zero shifted into high bit)
+        assert _eval_bv(lshr(z3.BitVecVal(0x80, 8), z3.BitVecVal(1, 8)), 8) == 0x40
+
+    @_requires_z3
+    def test_ashr_and_lshr_agree_on_positive(self):
+        """For values with the sign bit clear, arithmetic and logical shift match."""
+        from core.smt_solver import z3
+        from core.smt_solver.csem import ashr, lshr
+        v = z3.BitVecVal(0x40, 8)  # high bit clear
+        assert _eval_bv(ashr(v, z3.BitVecVal(1, 8)), 8) == _eval_bv(lshr(v, z3.BitVecVal(1, 8)), 8)
+
+
+# ---------------------------------------------------------------------------
+# Cast
+# ---------------------------------------------------------------------------
+
+class TestCast:
+    @_requires_z3
+    def test_cast_widen_signed_sign_extends(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import cast
+        assert _eval_bv(cast(z3.BitVecVal(0xFE, 8), to_width=32, from_signed=True), 32) == 0xFFFFFFFE
+
+    @_requires_z3
+    def test_cast_widen_unsigned_zero_extends(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import cast
+        assert _eval_bv(cast(z3.BitVecVal(0xFE, 8), to_width=32, from_signed=False), 32) == 0x000000FE
+
+    @_requires_z3
+    def test_cast_narrow_truncates(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import cast
+        assert _eval_bv(cast(z3.BitVecVal(0x1234, 16), to_width=8, from_signed=False), 8) == 0x34
+
+    @_requires_z3
+    def test_cast_same_width_noop(self):
+        from core.smt_solver import z3
+        from core.smt_solver.csem import cast
+        v = z3.BitVecVal(0x42, 8)
+        assert _eval_bv(cast(v, to_width=8, from_signed=False), 8) == 0x42

--- a/packages/codeql/dataflow_validator.py
+++ b/packages/codeql/dataflow_validator.py
@@ -10,8 +10,9 @@ import json
 import sys
 from dataclasses import dataclass, asdict
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
+from core.smt_solver import BVProfile
 from packages.codeql.smt_path_validator import (
     PathCondition,
     PathSMTResult,
@@ -63,9 +64,45 @@ class DataflowValidation:
 
 
 PATH_CONDITIONS_SCHEMA = {
+    "path_width": "int (32 or 64) — bitvector width; see prompt for when to pick",
+    "path_signed": "boolean — signedness; see prompt for guidance",
     "path_conditions": "list of {step_index: int, condition: str, negated: bool}",
     "unparseable": "list of strings — conditions too complex to express as simple predicates",
 }
+
+# Rule-id substrings that indicate a 32-bit integer-overflow reasoning mode.
+# Case-insensitive match; the list covers common CodeQL rule naming.
+_OVERFLOW_MARKERS = (
+    "cwe-190", "cwe-191", "cwe-680", "cwe-197",
+    "overflow", "underflow", "wraparound", "wrap-around",
+    "intoverflow", "integeroverflow", "integer-overflow",
+)
+
+
+def _infer_bv_profile(rule_id: Optional[str], llm_hint: Dict) -> BVProfile:
+    """Build a BVProfile from the LLM's per-path hint, falling back to a
+    rule-id heuristic when the hint is missing or invalid.
+
+    Priority:
+      1. ``llm_hint['width']`` / ``llm_hint['signed']`` when present and valid
+      2. Rule-id heuristic: CWE-190-family → 32-bit unsigned, otherwise
+         64-bit unsigned
+
+    Any partial hint (e.g. width only) takes the LLM's value for the
+    supplied field and fills the missing one from the heuristic default.
+    """
+    rule_lc = (rule_id or "").lower()
+    heuristic_width = 32 if any(m in rule_lc for m in _OVERFLOW_MARKERS) else 64
+    heuristic_signed = False  # unsigned is correct for most path conditions
+
+    # Accept only sensible LLM-emitted values; ignore anything else.
+    raw_width = llm_hint.get("width")
+    width = raw_width if isinstance(raw_width, int) and raw_width > 0 else heuristic_width
+
+    raw_signed = llm_hint.get("signed")
+    signed = raw_signed if isinstance(raw_signed, bool) else heuristic_signed
+
+    return BVProfile(width=width, signed=signed)
 
 # Dict schema for LLM structured generation (consistent with other callers)
 DATAFLOW_VALIDATION_SCHEMA = {
@@ -203,12 +240,14 @@ class DataflowValidator:
         self,
         dataflow: DataflowPath,
         repo_path: Path,
-    ) -> List[PathCondition]:
-        """Ask the LLM to extract branch conditions from the dataflow path.
+    ) -> Tuple[List[PathCondition], Dict]:
+        """Ask the LLM to extract branch conditions + bitvector type hint.
 
-        Returns a (possibly empty) list of PathCondition objects.  Failures
-        are non-fatal — an empty list causes SMT to return feasible=True and
-        the full LLM validation still runs.
+        Returns ``(conditions, hint)`` where ``hint`` is a dict with
+        optional ``'width'`` and ``'signed'`` keys — ``_infer_bv_profile``
+        combines these with the rule-id heuristic to pick a BVProfile.
+        Failures are non-fatal — an empty list causes SMT to return
+        feasible=True and the full LLM validation still runs.
         """
         path_summary = []
         for i, step in enumerate([dataflow.source] + dataflow.intermediate_steps + [dataflow.sink]):
@@ -229,11 +268,21 @@ for example:
   "size > 0", "offset + length <= buffer_size", "ptr != NULL",
   "flags & 0x80000000 == 0"
 
-Set negated=true if the condition must be FALSE for the path to proceed
-(i.e. a check that was bypassed).
+Also emit two per-path type hints so SMT uses the correct bitvector
+semantics:
+  - path_width: 32 when the dominant variables are C `int`/`unsigned int`
+    (CWE-190 32-bit wraparound lives here); 64 for `size_t`/`uint64_t`.
+  - path_signed: true if variables are signed ints (`int`, `int32_t`) and
+    you want overflow reasoning that matches C's UB semantics; false for
+    unsigned / pointer arithmetic.  Default false.
+
+Set negated=true on a condition if it must be FALSE for the path to
+proceed (i.e. a check that was bypassed).
 
 Respond in JSON:
 {{
+  "path_width": 32,
+  "path_signed": false,
   "path_conditions": [
     {{"step_index": 0, "condition": "size > 0", "negated": false}},
     ...
@@ -256,10 +305,14 @@ Respond in JSON:
                 for c in response.get("path_conditions", [])
                 if c.get("condition")
             ]
-            return conditions
+            hint = {
+                "width": response.get("path_width"),
+                "signed": response.get("path_signed"),
+            }
+            return conditions, hint
         except Exception as e:
             self.logger.debug(f"Path condition extraction failed: {e}")
-            return []
+            return [], {}
 
     def validate_dataflow_path(
         self,
@@ -278,10 +331,12 @@ Respond in JSON:
         """
         self.logger.info(f"Validating dataflow path: {dataflow.rule_id}")
 
-        # SMT pre-check: extract path conditions and test joint satisfiability.
-        # If unsat, the path is provably unreachable — skip the expensive LLM call.
-        conditions = self._extract_path_conditions(dataflow, repo_path)
-        smt_result = check_path_feasibility(conditions)
+        # SMT pre-check: extract path conditions (plus a bitvector type
+        # hint from the LLM) and test joint satisfiability.  If unsat,
+        # the path is provably unreachable — skip the expensive LLM call.
+        conditions, profile_hint = self._extract_path_conditions(dataflow, repo_path)
+        profile = _infer_bv_profile(dataflow.rule_id, profile_hint)
+        smt_result = check_path_feasibility(conditions, profile=profile)
 
         if smt_result.feasible is False:
             self.logger.info(

--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -15,8 +15,9 @@ Accepted condition forms (case-insensitive):
   size > 0
   size < 1024
   offset + length <= buffer_size
-  count * 16 < max_alloc       (bitvector mul — wraparound at 2^64, not 2^32)
-  n >> 1 < limit               (logical right shift)
+  count * 16 < max_alloc       (bitvector mul — wraps at the chosen width)
+  n >> 1 < limit               (arithmetic right shift when the profile is
+                               signed; logical right shift when unsigned)
   n << 3 == buf_size           (left shift)
   flags | 0x1 != 0             (bitwise OR)
   ptr != NULL  /  ptr == NULL
@@ -24,21 +25,30 @@ Accepted condition forms (case-insensitive):
   flags & 0x80000000 == 0
   value == 42
 
-Variables are created as 64-bit bitvectors.  Unsigned comparisons are used
-by default (e.g. 0 <= index < size is encoded as index >= 0 and index < size) since
-most dataflow-relevant variables are sizes, offsets, counts, and bitmasks.
+Width and signedness are carried by a ``BVProfile`` (from
+``core.smt_solver``).  Default is ``BV_C_UINT64`` — 64-bit unsigned,
+matching sizes / offsets / counts which dominate dataflow path
+conditions.  Pass ``BV_C_UINT32`` to detect 32-bit unsigned wraparound
+(CWE-190); pass ``BV_C_INT32`` for signed-integer path conditions.
+Pre-made profiles are importable from ``core.smt_solver``.
 
-Limitations:
-  - Negative integer literals (e.g. != -1) go to the unknown list.
-  - Bitvector width is 64 bits.  Multiplication overflow wraps at 2^64, not
-    at the C type width (32-bit unsigned int overflows are invisible unless
-    the LLM separates the already-computed result as a distinct variable).
-  - Unary NOT (~) is not supported; conditions using it fall through to unknown.
-  - No operator precedence (expressions are evaluated strictly left-to-right).
-    Mixed-operator expressions (e.g. `a + b * c`) are rejected to avoid
-    mis-encoding; full precedence support is planned for a follow-up.
-  - Bitmask form (flags & MASK == val) requires both MASK and val to be
-    integer literals.
+Known limitations:
+  - Negative integer literals (e.g. ``!= -1``) go to the unknown list.
+  - Unary NOT (``~``) is not supported; conditions using it fall through
+    to unknown.
+  - No operator precedence — expressions are evaluated strictly
+    left-to-right.  Mixed-operator expressions (e.g. ``a + b * c``) are
+    rejected to avoid mis-encoding; full precedence support is planned
+    for a follow-up.
+  - Bitmask form (``flags & MASK == val``) requires both ``MASK`` and
+    ``val`` to be integer literals.
+  - Profile-level signedness conflates two concerns: comparison
+    signedness (``<``/``<=``/``>``/``>=`` routed through ``lt``/``le``)
+    AND ``>>`` arithmetic-vs-logical shift.  In real C these can
+    decouple (``(int)x >> 1`` is always arithmetic regardless of the
+    comparison's signedness).  Single-profile-per-path is the first-cut
+    design; per-variable typing is the next step when a real case
+    demands it.
 
 Integration: packages/codeql/dataflow_validator.py :: DataflowValidator
 """
@@ -46,11 +56,13 @@ Integration: packages/codeql/dataflow_validator.py :: DataflowValidator
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
 from core.logging import get_logger as _get_logger
 from core.smt_solver import (
+    BV_C_UINT64,
+    BVProfile,
     DEFAULT_TIMEOUT_MS as _DEFAULT_TIMEOUT_MS,
     core_names as _core_names,
     mk_val as _mk_val,
@@ -62,10 +74,9 @@ from core.smt_solver import (
     z3_available as _z3_available,
 )
 from core.smt_solver.bitvec import ge, gt, le, lt
+from core.smt_solver.csem import ashr as _ashr, lshr as _lshr
 from core.smt_solver.witness import format_witness as _format_witness
 
-_WIDTH = 64
-_SIGNED = False
 
 # ---------------------------------------------------------------------------
 # Data types
@@ -109,46 +120,43 @@ _TOKEN_RE = re.compile(
 )
 
 
-def _parse_expr(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
-    """Parse an arithmetic expression into a Z3 bitvector.
+def _parse_expr(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Optional[Any]:
+    """Parse an arithmetic expression into a Z3 bitvector at the given profile.
 
-    Handles: identifier, NULL, hex literal, decimal literal,
-    and binary +/- /* between those terms (left-to-right, no precedence).
+    Handles: identifier, NULL, hex literal, decimal literal, and binary
+    +/-/* /|/shifts between those terms (left-to-right, no precedence).
+    Right-shift is routed through ``csem.ashr`` / ``csem.lshr`` by
+    signedness so the same ``>>`` source form encodes differently for
+    signed vs unsigned path conditions.
 
-    Returns None — rather than a partial result — when an unsupported token
-    is encountered mid-expression.  This prevents conditions like
-    ``count * 16 < MAX`` from being silently mis-encoded as ``count < MAX``.
+    Returns None — rather than a partial result — when an unsupported
+    token is encountered mid-expression, so the whole condition falls
+    through to the unknown list rather than being silently mis-encoded.
     """
     tokens = [t for t in _TOKEN_RE.findall(text.strip()) if t not in ('(', ')')]
     if not tokens:
         return None
 
-    # Reject mixed-operator expressions to avoid silent mis-encoding due to 
+    # Reject mixed-operator expressions to avoid silent mis-encoding due to
     # the lack of operator precedence (currently strictly left-to-right).
     if {'+', '-'} & set(tokens[1::2]) and {'*', '>>', '<<', '|'} & set(tokens[1::2]):
         return None
 
     def atom(tok: str) -> Optional[Any]:
         if _NULL_RE.match(tok):
-            return _mk_val(0, width=_WIDTH)
+            return _mk_val(0, profile.width)
         if _HEX_RE.match(tok):
-            return _mk_val(int(tok, 16), width=_WIDTH)
+            return _mk_val(int(tok, 16), profile.width)
         if _INT_RE.match(tok):
-            return _mk_val(int(tok), width=_WIDTH)
+            return _mk_val(int(tok), profile.width)
         if _IDENT_RE.match(tok):
             if tok.lower() not in vars_:
-                vars_[tok.lower()] = _mk_var(tok.lower(), width=_WIDTH)
+                vars_[tok.lower()] = _mk_var(tok.lower(), profile.width)
             return vars_[tok.lower()]
         return None
 
     # Left-to-right accumulation of arithmetic and bitwise operators.
-    # Any unsupported operator causes an immediate None return so the
-    # condition falls through to the unknown list rather than encoding
-    # a silently truncated (and incorrect) expression.
-    #
-    # '>>' is logical right shift (z3.LShR) — correct for unsigned values.
-    # '<<' is left shift; '*' and '+'/'-' are standard bitvector arithmetic.
-    # '|' is bitwise OR.
+    # Any unsupported operator causes an immediate None return.
     result = atom(tokens[0])
     if result is None:
         return None
@@ -169,20 +177,21 @@ def _parse_expr(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
         elif op == '|':
             result = result | right
         elif op == '>>':
-            result = z3.LShR(result, right)  # logical (unsigned) right shift
+            # Route right-shift through csem so signedness picks the
+            # correct arithmetic vs logical variant.
+            result = _ashr(result, right) if profile.signed else _lshr(result, right)
         else:  # '<<'
             result = result << right
         i += 2
 
-    # Reject orphaned trailing tokens (e.g. 'flags' when '| 0x1' was silently
-    # dropped by the tokeniser before this fix).
+    # Reject orphaned trailing tokens.
     if i != len(tokens):
         return None
 
     return result
 
 
-def _parse_condition(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
+def _parse_condition(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Optional[Any]:
     """Parse a single condition string into a Z3 boolean expression.
 
     Recognised forms:
@@ -205,25 +214,24 @@ def _parse_condition(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
         t, re.IGNORECASE,
     )
     if m:
-        lhs = _parse_expr(m.group(1).strip(), vars_)
+        lhs = _parse_expr(m.group(1).strip(), vars_, profile=profile)
         if lhs is None:
             return None
-        masked = lhs & _mk_val(int(m.group(2), 0), width=_WIDTH)
-        rhs = _mk_val(int(m.group(4), 0), width=_WIDTH)
+        masked = lhs & _mk_val(int(m.group(2), 0), profile.width)
+        rhs = _mk_val(int(m.group(4), 0), profile.width)
         return (masked == rhs) if m.group(3) == '==' else (masked != rhs)
 
     # Relational: lhs OP rhs
     # The LHS pattern consumes '>>' and '<<' as atomic units so the regex
-    # doesn't split inside a shift operator (e.g. 'n >> 1 < limit' must
-    # not split as lhs='n', op='>', rhs='> 1 < limit').
+    # doesn't split inside a shift operator.
     m = re.fullmatch(
         r'((?:>>|<<|[^<>]|(?<![<>])[<>](?![<>]))+?)'
         r'\s*(<=|>=|!=|==|<(?!<)|>(?!>))\s*(.+)',
         t,
     )
     if m:
-        lhs = _parse_expr(m.group(1).strip(), vars_)
-        rhs = _parse_expr(m.group(3).strip(), vars_)
+        lhs = _parse_expr(m.group(1).strip(), vars_, profile=profile)
+        rhs = _parse_expr(m.group(3).strip(), vars_, profile=profile)
         if lhs is None or rhs is None:
             return None
         op = m.group(2)
@@ -232,13 +240,13 @@ def _parse_condition(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
         if op == '!=':
             return lhs != rhs
         if op == '<':
-            return lt(lhs, rhs, signed=_SIGNED)
+            return lt(lhs, rhs, signed=profile.signed)
         if op == '<=':
-            return le(lhs, rhs, signed=_SIGNED)
+            return le(lhs, rhs, signed=profile.signed)
         if op == '>':
-            return gt(lhs, rhs, signed=_SIGNED)
+            return gt(lhs, rhs, signed=profile.signed)
         if op == '>=':
-            return ge(lhs, rhs, signed=_SIGNED)
+            return ge(lhs, rhs, signed=profile.signed)
 
     return None
 
@@ -249,20 +257,29 @@ def _parse_condition(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
 
 def check_path_feasibility(
     conditions: List[PathCondition],
+    *,
+    profile: BVProfile = BV_C_UINT64,
 ) -> PathSMTResult:
     """
     Check whether a set of path conditions are jointly satisfiable.
 
     Args:
-        conditions: Conditions extracted from a dataflow path.  Each has a
-                    ``text`` field (e.g. ``"size < 1024"``) and an optional
-                    ``negated`` flag for conditions that must be *false* for
-                    the path to proceed.
+        conditions: Conditions extracted from a dataflow path.  Each has
+                    a ``text`` field (e.g. ``"size < 1024"``) and an
+                    optional ``negated`` flag for conditions that must
+                    be *false* for the path to proceed.
+        profile:    BVProfile setting bitvector width, relational-operator
+                    signedness, right-shift semantics, and witness
+                    rendering.  Defaults to BV_C_UINT64 (64-bit unsigned).
+                    Use BV_C_UINT32 for CWE-190 32-bit wraparound paths;
+                    BV_C_INT32 for signed-integer path conditions; etc.
 
     Returns:
         PathSMTResult.  feasible=None when Z3 is unavailable or every
         condition was unparseable.
     """
+    mode = profile.describe()
+
     if not _z3_available():
         return PathSMTResult(
             feasible=None,
@@ -277,7 +294,7 @@ def check_path_feasibility(
             feasible=True,
             satisfied=[], unsatisfied=[], unknown=[],
             model={}, smt_available=True,
-            reasoning="no conditions — path is unconditionally reachable",
+            reasoning=f"no conditions ({mode}) — path is unconditionally reachable",
         )
 
     vars_: Dict[str, Any] = {}
@@ -288,7 +305,7 @@ def check_path_feasibility(
     pending: List[Tuple[str, Any]] = []
 
     for cond in conditions:
-        expr = _parse_condition(cond.text, vars_)
+        expr = _parse_condition(cond.text, vars_, profile=profile)
         if expr is None:
             _get_logger().debug(f"smt_path_validator: unparseable condition: {cond.text!r}")
             unknown.append(cond.text)
@@ -313,7 +330,7 @@ def check_path_feasibility(
                 satisfied=satisfied, unsatisfied=[], unknown=unknown,
                 model={}, smt_available=True,
                 reasoning=(
-                    f"indeterminate: {len(satisfied)} trivially satisfied, "
+                    f"indeterminate ({mode}): {len(satisfied)} trivially satisfied, "
                     f"{len(unknown)} unparseable — LLM analysis required"
                 ),
             )
@@ -321,20 +338,20 @@ def check_path_feasibility(
             feasible=True,
             satisfied=satisfied, unsatisfied=[], unknown=[],
             model={}, smt_available=True,
-            reasoning=f"all {len(satisfied)} condition(s) trivially satisfied",
+            reasoning=f"all {len(satisfied)} condition(s) trivially satisfied ({mode})",
         )
 
     label_map = _track(solver, pending)
     result = solver.check()
 
     if result == z3.sat:
-        model_dict = _format_witness(solver.model(), signed=_SIGNED)
+        model_dict = _format_witness(solver.model(), signed=profile.signed)
         return PathSMTResult(
             feasible=True,
             satisfied=satisfied, unsatisfied=[], unknown=unknown,
             model=model_dict, smt_available=True,
             reasoning=(
-                f"feasible: {len(pending)} condition(s) are jointly satisfiable"
+                f"feasible ({mode}): {len(pending)} condition(s) are jointly satisfiable"
                 + (f"; {len(satisfied)} trivially satisfied" if satisfied else "")
                 + (f"; {len(unknown)} unparsed" if unknown else "")
             ),
@@ -343,7 +360,7 @@ def check_path_feasibility(
     if result == z3.unsat:
         conflicts = _core_names(solver, label_map)
         conflict_set = conflicts if conflicts else [t for t, _ in pending]
-        reasoning = f"infeasible: path conditions are mutually exclusive"
+        reasoning = f"infeasible ({mode}): path conditions are mutually exclusive"
         if conflicts:
             reasoning += f"; conflict: {' ⊥ '.join(conflicts[:3])}"
         return PathSMTResult(
@@ -360,7 +377,7 @@ def check_path_feasibility(
         unknown=unknown + [t for t, _ in pending],
         model={}, smt_available=True,
         reasoning=(
-            f"Z3 returned unknown — likely the {_DEFAULT_TIMEOUT_MS}ms timeout "
+            f"Z3 returned unknown ({mode}) — likely the {_DEFAULT_TIMEOUT_MS}ms timeout "
             f"or conditions outside the bitvector fragment"
         ),
     )

--- a/packages/codeql/tests/test_dataflow_validator.py
+++ b/packages/codeql/tests/test_dataflow_validator.py
@@ -1,0 +1,106 @@
+"""Tests for packages.codeql.dataflow_validator.
+
+Scoped to the pure helpers — profile inference, hint normalisation —
+not to the LLM-driven ``validate_dataflow_path`` flow (which needs a
+mock LLM client and is exercised end-to-end elsewhere).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# packages/codeql/tests/ -> repo root
+sys.path.insert(0, str(Path(__file__).parents[3]))
+
+from packages.codeql.dataflow_validator import _infer_bv_profile
+
+
+class TestInferBVProfileHeuristic:
+    """When the LLM hint is absent the rule_id heuristic picks a profile.
+
+    CodeQL rule names that mention overflow / wraparound / CWE-190 family
+    get 32-bit unsigned; everything else defaults to 64-bit unsigned."""
+
+    def test_non_overflow_rule_defaults_to_64_bit(self):
+        p = _infer_bv_profile("java/sql-injection", {})
+        assert p.width == 64
+        assert p.signed is False
+
+    def test_no_rule_id_defaults_to_64_bit(self):
+        p = _infer_bv_profile(None, {})
+        assert p.width == 64
+
+    def test_empty_rule_id_defaults_to_64_bit(self):
+        p = _infer_bv_profile("", {})
+        assert p.width == 64
+
+    @pytest.mark.parametrize("rule_id", [
+        "cpp/cwe-190-integer-overflow",
+        "CPP/CWE-190/ArithmeticOverflow",
+        "cpp/overflow-check-missing",
+        "cpp/integer-overflow",
+        "java/IntegerOverflow",
+        "cpp/integeroverflow-in-loop",
+        "cpp/unsigned-wraparound",
+        "cpp/wrap-around-bug",
+        "cpp/CWE-191-underflow",
+        "cpp/CWE-680-int-to-buf",
+    ])
+    def test_overflow_markers_trigger_32_bit(self, rule_id):
+        p = _infer_bv_profile(rule_id, {})
+        assert p.width == 32
+        assert p.signed is False
+
+    def test_matching_is_case_insensitive(self):
+        p = _infer_bv_profile("CPP/Cwe-190-overflow", {})
+        assert p.width == 32
+
+
+class TestInferBVProfileHint:
+    """LLM-emitted hints take precedence over the heuristic when valid."""
+
+    def test_hint_width_only_combines_with_heuristic_signed(self):
+        # LLM says width=32; rule isn't overflow, so heuristic signed=False.
+        p = _infer_bv_profile("java/sql-injection", {"width": 32})
+        assert p.width == 32
+        assert p.signed is False
+
+    def test_hint_signed_only_combines_with_heuristic_width(self):
+        p = _infer_bv_profile("cpp/overflow-bug", {"signed": True})
+        assert p.width == 32   # from heuristic (overflow rule)
+        assert p.signed is True  # from hint
+
+    def test_hint_beats_heuristic_when_both_supplied(self):
+        # LLM says 64-bit signed even though rule would default to 32-bit unsigned.
+        p = _infer_bv_profile("cpp/overflow-bug", {"width": 64, "signed": True})
+        assert p.width == 64
+        assert p.signed is True
+
+
+class TestInferBVProfileInvalidHints:
+    """Garbage values in the hint dict must be ignored, not crash."""
+
+    def test_string_width_ignored(self):
+        p = _infer_bv_profile("cpp/overflow-bug", {"width": "not-an-int"})
+        assert p.width == 32  # heuristic fallback, not ValueError
+
+    def test_negative_width_ignored(self):
+        p = _infer_bv_profile("cpp/overflow-bug", {"width": -1})
+        assert p.width == 32
+
+    def test_zero_width_ignored(self):
+        p = _infer_bv_profile("cpp/overflow-bug", {"width": 0})
+        assert p.width == 32
+
+    def test_string_signed_ignored(self):
+        p = _infer_bv_profile("cpp/overflow-bug", {"signed": "yes"})
+        assert p.signed is False
+
+    def test_none_values_ignored(self):
+        p = _infer_bv_profile("cpp/overflow-bug", {"width": None, "signed": None})
+        assert p.width == 32
+
+    def test_missing_keys_tolerated(self):
+        p = _infer_bv_profile("cpp/overflow-bug", {})
+        assert p.width == 32

--- a/packages/codeql/tests/test_smt_path_validator.py
+++ b/packages/codeql/tests/test_smt_path_validator.py
@@ -322,3 +322,142 @@ class TestResultStructure:
         r = check_path_feasibility([PathCondition("x == 1", step_index=0)])
         assert isinstance(r.reasoning, str)
         assert len(r.reasoning) > 0
+
+    @_requires_z3
+    def test_reasoning_spells_out_profile(self):
+        """Reasoning should describe the modelled type in plain text so
+        the security researcher reading a validation report doesn't have
+        to decode ``bvNN{s,u}`` shorthand."""
+        from core.smt_solver import BV_C_INT32
+        r_default = check_path_feasibility([PathCondition("x == 1", step_index=0)])
+        r_int32 = check_path_feasibility(
+            [PathCondition("x == 1", step_index=0)],
+            profile=BV_C_INT32,
+        )
+        assert "64-bit unsigned" in r_default.reasoning
+        assert "32-bit signed" in r_int32.reasoning
+
+
+class TestParametricProfile:
+    """Profiles control width, comparison signedness, shift semantics,
+    and witness rendering.  The CodeQL testbench's Group 1 cases (CWE-190)
+    need BV_C_UINT32 to detect 32-bit wraparound; these tests pin that."""
+
+    @_requires_z3
+    def test_default_profile_rejects_32bit_overflow_witness(self):
+        """With the realistic upper bound (MAX_RECORDS=0x40000000), 64-bit
+        math can't wrap at small counts — the 32-bit-vulnerable range is
+        correctly reported infeasible.  The 32-bit variant below proves
+        the same conditions DO wrap under BV_C_UINT32."""
+        r = check_path_feasibility([
+            PathCondition("alloc_size == count * 16", step_index=0),
+            PathCondition("alloc_size < 0x8000", step_index=1),
+            PathCondition("count > 0x10000000", step_index=2),
+            PathCondition("count < 0x40000000", step_index=3),
+        ])
+        assert r.feasible is False
+
+    @_requires_z3
+    def test_uint32_profile_catches_alloc_wraparound(self):
+        """ALLOC testbench case: under BV_C_UINT32, Z3 finds the
+        wraparound witness where count * 16 overflows modulo 2^32 to a
+        small value satisfying alloc_size < MAX_ALLOC."""
+        from core.smt_solver import BV_C_UINT32
+        r = check_path_feasibility(
+            [
+                PathCondition("alloc_size == count * 16", step_index=0),
+                PathCondition("alloc_size < 0x8000", step_index=1),
+                PathCondition("count > 0x10000000", step_index=2),
+                PathCondition("count < 0x40000000", step_index=3),
+            ],
+            profile=BV_C_UINT32,
+        )
+        assert r.feasible is True
+        assert "count" in r.model
+        count = r.model["count"]
+        assert 0x10000000 < count < 0x40000000
+        # alloc_size is count * 16 mod 2^32 (that's the wraparound bug).
+        assert r.model.get("alloc_size") == (count * 16) & 0xFFFFFFFF
+
+    @_requires_z3
+    def test_int32_profile_right_shift_is_arithmetic(self):
+        """BV_C_INT32 (signed) routes '>>' through csem.ashr so the high
+        bit propagates.  BV_C_UINT32 uses csem.lshr — zero fill."""
+        from core.smt_solver import BV_C_INT32, BV_C_UINT32
+
+        # x = 0x80000000 (32-bit): signed = -2^31, unsigned = 2^31.
+        # x >> 1:
+        #   signed (ashr)  = 0xC0000000 (= -2^30 = -1073741824)
+        #   unsigned (lshr) = 0x40000000 (=  2^30 =  1073741824)
+        r_signed = check_path_feasibility(
+            [
+                PathCondition("x == 0x80000000", step_index=0),
+                PathCondition("y == x >> 1", step_index=1),
+            ],
+            profile=BV_C_INT32,
+        )
+        assert r_signed.feasible is True
+        # Witness renders under signed semantics, so compare the raw bit
+        # pattern: `y mod 2^32` should be 0xC0000000 regardless of whether
+        # the witness came back as unsigned 3221225472 or signed -1073741824.
+        assert (r_signed.model.get("y") % (1 << 32)) == 0xC0000000
+
+        r_unsigned = check_path_feasibility(
+            [
+                PathCondition("x == 0x80000000", step_index=0),
+                PathCondition("y == x >> 1", step_index=1),
+            ],
+            profile=BV_C_UINT32,
+        )
+        assert r_unsigned.feasible is True
+        assert r_unsigned.model.get("y") == 0x40000000
+
+    @_requires_z3
+    def test_ad_hoc_16bit_profile(self):
+        """Ad-hoc BVProfile(width=16) works for non-standard widths."""
+        from core.smt_solver import BVProfile
+        r = check_path_feasibility(
+            [PathCondition("x == 0x7FFF", step_index=0)],
+            profile=BVProfile(width=16, signed=False),
+        )
+        assert r.feasible is True
+        assert r.model.get("x") == 0x7FFF
+
+    @_requires_z3
+    def test_uint32_profile_catches_sum_wraparound(self):
+        """SUM testbench case: offset + length <= buffer_size guard is
+        bypassable when the unsigned 32-bit sum wraps to a small value."""
+        from core.smt_solver import BV_C_UINT32
+        r = check_path_feasibility(
+            [
+                PathCondition("sum == offset + length", step_index=0),
+                PathCondition("sum <= buffer_size", step_index=1),
+                PathCondition("buffer_size == 64", step_index=2),
+                PathCondition("offset > 0x10000", step_index=3),
+                PathCondition("length > 0x10000", step_index=4),
+            ],
+            profile=BV_C_UINT32,
+        )
+        assert r.feasible is True
+        offset, length = r.model["offset"], r.model["length"]
+        # The wraparound is the whole point: (offset + length) mod 2^32 ≤ 64.
+        assert (offset + length) & 0xFFFFFFFF <= 64
+        assert offset > 0x10000 and length > 0x10000
+
+    @_requires_z3
+    def test_uint32_profile_catches_mask_wraparound(self):
+        """MASK testbench case: base + size <= HEAP_SIZE with wraparound."""
+        from core.smt_solver import BV_C_UINT32
+        r = check_path_feasibility(
+            [
+                PathCondition("flags & 0x80000000 == 0", step_index=0),
+                PathCondition("size < 4096", step_index=1),
+                PathCondition("base + size <= 8192", step_index=2),
+                PathCondition("base > 0x80000000", step_index=3),
+            ],
+            profile=BV_C_UINT32,
+        )
+        assert r.feasible is True
+        base, size = r.model["base"], r.model["size"]
+        assert (base + size) & 0xFFFFFFFF <= 8192
+        assert base > 0x80000000

--- a/packages/exploit_feasibility/smt_onegadget.py
+++ b/packages/exploit_feasibility/smt_onegadget.py
@@ -12,11 +12,11 @@ smt_available=False and feasible=None — no existing behaviour changes.
 
 Install: pip install z3-solver
 
-Width/signedness: x86_64 registers are fixed 64-bit unsigned addresses,
-so this module pins every BitVec to width=64 regardless of the global
-``core.smt_solver.config`` default. Only ``mode_tag`` is routed through
-the shared helper so reasoning strings stay consistent with the rest of
-the harness.
+Profile: defaults to ``BV_X86_64`` (64-bit unsigned), matching one_gadget
+tool output for x86_64 binaries. Pass a different ``BVProfile`` via the
+``profile`` kwarg if analysing a non-x86_64 target. One-gadget
+constraints don't use ordered comparisons, so the profile's signedness
+only affects witness rendering and the reasoning-string description.
 
 Integration points (do not call from outside these locations):
   - packages/exploit_feasibility/api.py :: find_exploit_paths
@@ -38,11 +38,12 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from core.logging import get_logger as _get_logger
 from core.smt_solver import (
+    BV_X86_64,
+    BVProfile,
     DEFAULT_TIMEOUT_MS as _DEFAULT_TIMEOUT_MS,
     core_names as _core_names,
     mk_val as _mk_val,
     mk_var as _mk_var,
-    mode_tag as _mode_tag,
     new_solver as _new_solver,
     scoped as _scoped,
     track as _track,
@@ -52,12 +53,6 @@ from core.smt_solver import (
 
 from core.smt_solver.witness import format_witness as _format_witness
 from .context import OneGadget
-
-
-# x86_64 registers are natively 64-bit, and the values we care about are
-# addresses — treat them as unsigned in any rendered witness.
-_REG_WIDTH = 64
-_REG_SIGNED = False
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +67,9 @@ class OneGadgetSMTResult:
     unsatisfied: List[str]        # constraints proven false given crash_state
     unknown: List[str]            # constraint lines that could not be parsed into Z3
     model: Dict[str, int]         # satisfying variable assignments when feasible=True
-    smt_available: bool           # whether SMT participated in *this* result (env capability is separate; see analyze_binary()['smt_available'])
+    # Whether SMT participated in *this* result.  Environment capability
+    # is separate — see ``analyze_binary()['smt_available']``.
+    smt_available: bool
     reasoning: str
 
 
@@ -99,28 +96,28 @@ _HEX_LIT_RE = re.compile(r'0x[0-9a-f]+', re.IGNORECASE)
 _DEC_LIT_RE = re.compile(r'\d+')
 
 
-def _reg_var(name: str, vars_: Dict[str, Any]) -> Optional[Any]:
+def _reg_var(name: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Optional[Any]:
     name = name.lower()
     if name not in _X86_64_REGS:
         return None
     if name not in vars_:
-        vars_[name] = _mk_var(name, width=_REG_WIDTH)
+        vars_[name] = _mk_var(name, profile.width)
     return vars_[name]
 
 
-def _mem_var(reg: str, op: str, raw_offset: str, vars_: Dict[str, Any]) -> Optional[Any]:
+def _mem_var(reg: str, op: str, raw_offset: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Optional[Any]:
     reg_lc = reg.lower()
     if reg_lc not in _X86_64_REGS:
         return None
     offset = int(raw_offset, 16) if raw_offset.startswith("0x") else int(raw_offset)
     key = f"mem_{reg_lc}{op}{offset:#x}"
     if key not in vars_:
-        vars_[key] = _mk_var(key, width=_REG_WIDTH)
+        vars_[key] = _mk_var(key, profile.width)
     return vars_[key]
 
 
-def _parse_operand(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
-    """Parse a single operand into a Z3 expression of width ``_REG_WIDTH``.
+def _parse_operand(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Optional[Any]:
+    """Parse a single operand into a Z3 expression at ``profile.width``.
 
     Accepted forms (case-insensitive):
       NULL                 → literal 0
@@ -132,26 +129,26 @@ def _parse_operand(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
     """
     t = text.strip()
     if t.upper() == "NULL":
-        return _mk_val(0, width=_REG_WIDTH)
+        return _mk_val(0, profile.width)
     if _HEX_LIT_RE.fullmatch(t):
-        return _mk_val(int(t, 16), width=_REG_WIDTH)
+        return _mk_val(int(t, 16), profile.width)
     if _DEC_LIT_RE.fullmatch(t):
-        return _mk_val(int(t), width=_REG_WIDTH)
+        return _mk_val(int(t), profile.width)
 
     mem_m = _MEM_RE.fullmatch(t)
     if mem_m:
         reg = mem_m.group(1) or mem_m.group(4)
         op  = mem_m.group(2) or mem_m.group(5) or "+"
         off = mem_m.group(3) or mem_m.group(6) or "0"
-        return _mem_var(reg, op, off, vars_)
+        return _mem_var(reg, op, off, vars_, profile=profile)
 
     if _REG_RE.fullmatch(t):
-        return _reg_var(t, vars_)
+        return _reg_var(t, vars_, profile=profile)
 
     return None
 
 
-def _parse_atom(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
+def _parse_atom(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Optional[Any]:
     """
     Parse a single predicate atom into a Z3 expression.
 
@@ -177,14 +174,14 @@ def _parse_atom(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
     # English suffix form: "... is writable"  → lhs != 0
     m = re.search(r'\s+is\s+writable\s*$', t, re.IGNORECASE)
     if m:
-        lhs = _parse_operand(t[:m.start()].strip(), vars_)
-        return None if lhs is None else (lhs != _mk_val(0, width=_REG_WIDTH))
+        lhs = _parse_operand(t[:m.start()].strip(), vars_, profile=profile)
+        return None if lhs is None else (lhs != _mk_val(0, profile.width))
 
     # English suffix form: "... is NULL"  → lhs == 0
     m = re.search(r'\s+is\s+null\s*$', t, re.IGNORECASE)
     if m:
-        lhs = _parse_operand(t[:m.start()].strip(), vars_)
-        return None if lhs is None else (lhs == _mk_val(0, width=_REG_WIDTH))
+        lhs = _parse_operand(t[:m.start()].strip(), vars_, profile=profile)
+        return None if lhs is None else (lhs == _mk_val(0, profile.width))
 
     # Bitmask alignment: <lhs> & <mask> (==|!=) <value>   e.g. "rsp & 0xf == 0"
     m = re.fullmatch(
@@ -192,18 +189,18 @@ def _parse_atom(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
         t, re.IGNORECASE,
     )
     if m:
-        lhs = _parse_operand(m.group(1).strip(), vars_)
+        lhs = _parse_operand(m.group(1).strip(), vars_, profile=profile)
         if lhs is None:
             return None
-        masked = lhs & _mk_val(int(m.group(2), 0), width=_REG_WIDTH)
-        rhs    = _mk_val(int(m.group(4), 0), width=_REG_WIDTH)
+        masked = lhs & _mk_val(int(m.group(2), 0), profile.width)
+        rhs    = _mk_val(int(m.group(4), 0), profile.width)
         return (masked == rhs) if m.group(3) == "==" else (masked != rhs)
 
     # Generic equality / inequality:  <lhs> (==|!=) <rhs>
     m = re.fullmatch(r'(.+?)\s*(==|!=)\s*(.+)', t)
     if m:
-        lhs = _parse_operand(m.group(1).strip(), vars_)
-        rhs = _parse_operand(m.group(3).strip(), vars_)
+        lhs = _parse_operand(m.group(1).strip(), vars_, profile=profile)
+        rhs = _parse_operand(m.group(3).strip(), vars_, profile=profile)
         if lhs is None or rhs is None:
             return None
         return (lhs == rhs) if m.group(2) == "==" else (lhs != rhs)
@@ -211,7 +208,7 @@ def _parse_atom(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
     return None
 
 
-def _parse_constraint(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
+def _parse_constraint(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Optional[Any]:
     """
     Parse a one_gadget constraint line into a Z3 expression.
 
@@ -231,7 +228,7 @@ def _parse_constraint(text: str, vars_: Dict[str, Any]) -> Optional[Any]:
         and_parts = re.split(r'\bAND\b|&&', clause, flags=re.IGNORECASE)
         and_exprs = []
         for part in and_parts:
-            expr = _parse_atom(part.strip(), vars_)
+            expr = _parse_atom(part.strip(), vars_, profile=profile)
             if expr is None:
                 return None
             and_exprs.append(expr)
@@ -287,6 +284,8 @@ def _normalise_crash_state(crash_state: Dict[str, Any]) -> Dict[str, int]:
 def check_onegadget(
     gadget: OneGadget,
     crash_state: Optional[Dict[str, Any]] = None,
+    *,
+    profile: BVProfile = BV_X86_64,
 ) -> OneGadgetSMTResult:
     """
     Check whether a one-gadget's constraints are satisfiable.
@@ -300,6 +299,11 @@ def check_onegadget(
                        - CrashContext.registers directly (str hex values from GDB)
                        - crash_state_from_gdb(ctx.registers) (already converted)
                        - BinaryContext address-space sample values (int)
+        profile:     BVProfile for bitvector width and witness rendering.
+                     Defaults to BV_X86_64 (64-bit unsigned).  One-gadget
+                     constraints don't use ordered comparisons, so the
+                     profile's signedness only affects witness rendering
+                     and the reasoning-string description.
 
     Returns:
         OneGadgetSMTResult.  feasible=None if z3 unavailable or all constraints
@@ -313,7 +317,7 @@ def check_onegadget(
             reasoning="z3 not available — install z3-solver for constraint analysis",
         )
 
-    tag = _mode_tag(_REG_WIDTH, _REG_SIGNED)
+    mode = profile.describe()
 
     if not gadget.constraints:
         return OneGadgetSMTResult(
@@ -332,7 +336,9 @@ def check_onegadget(
     base_assertions: List[Any] = []
     for reg, val in concrete.items():
         if reg in _X86_64_REGS:
-            base_assertions.append(_reg_var(reg, vars_) == _mk_val(val, width=_REG_WIDTH))
+            base_assertions.append(
+                _reg_var(reg, vars_, profile=profile) == _mk_val(val, profile.width)
+            )
     if base_assertions:
         solver.add(*base_assertions)
 
@@ -342,7 +348,7 @@ def check_onegadget(
     pending:     List[Tuple[str, Any]] = []
 
     for raw in gadget.constraints:
-        expr = _parse_constraint(raw, vars_)
+        expr = _parse_constraint(raw, vars_, profile=profile)
         if expr is None:
             _get_logger().debug(f"smt_onegadget: unparseable constraint: {raw!r}")
             unknown.append(raw)
@@ -372,7 +378,7 @@ def check_onegadget(
             unsatisfied=unsatisfied, unknown=unknown,
             model={}, smt_available=True,
             reasoning=(
-                f"infeasible ({tag}): {len(unsatisfied)} constraint(s) contradicted by crash state — "
+                f"infeasible ({mode}): {len(unsatisfied)} constraint(s) contradicted by crash state — "
                 + "; ".join(unsatisfied[:2])
             ),
         )
@@ -387,7 +393,7 @@ def check_onegadget(
                 feasible=None, satisfied=satisfied, unsatisfied=[], unknown=unknown,
                 model={}, smt_available=True,
                 reasoning=(
-                    f"indeterminate ({tag}): {len(satisfied)} met by crash state, "
+                    f"indeterminate ({mode}): {len(satisfied)} met by crash state, "
                     f"{len(unknown)} unparseable — fall back to heuristic note"
                 ),
             )
@@ -395,7 +401,7 @@ def check_onegadget(
             feasible=True, satisfied=satisfied, unsatisfied=[], unknown=[],
             model={k: v for k, v in concrete.items() if k in _X86_64_REGS},
             smt_available=True,
-            reasoning=f"all {len(satisfied)} constraint(s) already satisfied by crash state ({tag})",
+            reasoning=f"all {len(satisfied)} constraint(s) already satisfied by crash state ({mode})",
         )
 
     # Joint satisfiability of remaining constraints. The solver already
@@ -407,12 +413,12 @@ def check_onegadget(
     result = solver.check()
 
     if result == z3.sat:
-        model_dict = _format_witness(solver.model(), signed=_REG_SIGNED)
+        model_dict = _format_witness(solver.model(), signed=profile.signed)
         return OneGadgetSMTResult(
             feasible=True, satisfied=satisfied, unsatisfied=[], unknown=unknown,
             model=model_dict, smt_available=True,
             reasoning=(
-                f"feasible ({tag}): {len(pending)} remaining constraint(s) are jointly satisfiable"
+                f"feasible ({mode}): {len(pending)} remaining constraint(s) are jointly satisfiable"
                 + (f"; {len(satisfied)} already met by crash state" if satisfied else "")
                 + (f"; {len(unknown)} unparsed" if unknown else "")
             ),
@@ -427,7 +433,7 @@ def check_onegadget(
         # full pending list when the core is empty preserves the old
         # behaviour for theories that don't produce cores.
         conflict_set = conflicts if conflicts else [r for r, _ in pending]
-        reasoning = f"infeasible ({tag}): {len(pending)} pending constraint(s) are mutually exclusive"
+        reasoning = f"infeasible ({mode}): {len(pending)} pending constraint(s) are mutually exclusive"
         if conflicts:
             reasoning += f"; conflict: {' ⊥ '.join(conflicts[:3])}"
         return OneGadgetSMTResult(
@@ -443,7 +449,7 @@ def check_onegadget(
             unknown=unknown + [r for r, _ in pending],
             model={}, smt_available=True,
             reasoning=(
-                f"Z3 returned unknown ({tag}) — likely the {_DEFAULT_TIMEOUT_MS}ms "
+                f"Z3 returned unknown ({mode}) — likely the {_DEFAULT_TIMEOUT_MS}ms "
                 f"solver timeout, or constraints outside the decidable bit-vector fragment"
             ),
         )
@@ -452,6 +458,8 @@ def check_onegadget(
 def rank_onegadgets(
     gadgets: List[OneGadget],
     crash_state: Optional[Dict[str, Any]] = None,
+    *,
+    profile: BVProfile = BV_X86_64,
 ) -> List[Tuple[OneGadget, OneGadgetSMTResult]]:
     """
     Rank one-gadgets by SMT-determined constraint satisfiability.
@@ -465,11 +473,12 @@ def rank_onegadgets(
     Args:
         gadgets:     List of OneGadget from one_gadgets_detailed.
         crash_state: Optional crash state — same as check_onegadget().
+        profile:     BVProfile propagated to each check_onegadget call.
 
     Returns:
         List of (OneGadget, OneGadgetSMTResult) in ranked order.
     """
-    pairs = [(g, check_onegadget(g, crash_state)) for g in gadgets]
+    pairs = [(g, check_onegadget(g, crash_state, profile=profile)) for g in gadgets]
 
     _order = {True: 0, None: 1, False: 2}
 

--- a/packages/exploit_feasibility/tests/test_smt_onegadget.py
+++ b/packages/exploit_feasibility/tests/test_smt_onegadget.py
@@ -423,3 +423,49 @@ class TestRankWithoutCrashState:
         infeasible = OneGadget(0x300, ["rax == 0", "rax != 0"])
         order = [g.offset for g, _ in rank_onegadgets([infeasible, indet, feasible])]
         assert order == [0x100, 0x200, 0x300]
+
+
+class TestParametricProfile:
+    """Profiles control width and witness-rendering signedness.  BV_X86_64
+    (64-bit unsigned) stays the default; these tests pin the override paths."""
+
+    @_requires_z3
+    def test_default_profile_unchanged(self):
+        """Default call still models x86_64 register values correctly."""
+        g = OneGadget(0x100, ["rax == 0xDEADBEEFCAFEBABE"])
+        r = check_onegadget(g)
+        assert r.feasible is True
+        assert r.model.get("rax") == 0xDEADBEEFCAFEBABE
+
+    @_requires_z3
+    def test_uint32_profile_fits_32_bit_addresses(self):
+        """BV_C_UINT32 creates 32-bit bitvecs (contrived for one_gadget,
+        but proves the profile threads through)."""
+        from core.smt_solver import BV_C_UINT32
+        g = OneGadget(0x100, ["rax == 0xDEADBEEF"])
+        r = check_onegadget(g, profile=BV_C_UINT32)
+        assert r.feasible is True
+        assert r.model.get("rax") == 0xDEADBEEF
+
+    @_requires_z3
+    def test_signed_profile_witness_rendering(self):
+        """BV_C_INT64 reinterprets high-bit-set values as two's-complement
+        negatives in the rendered model — description flips to 'signed' too."""
+        from core.smt_solver import BV_C_INT64
+        g = OneGadget(0x100, ["rax == 0xFFFFFFFFFFFFFFFE"])
+        r_unsigned = check_onegadget(g)
+        r_signed = check_onegadget(g, profile=BV_C_INT64)
+        assert r_unsigned.model.get("rax") == 0xFFFFFFFFFFFFFFFE
+        assert r_signed.model.get("rax") == -2
+        assert "64-bit unsigned" in r_unsigned.reasoning
+        assert "64-bit signed" in r_signed.reasoning
+
+    @_requires_z3
+    def test_rank_onegadgets_threads_profile_to_check(self):
+        """rank_onegadgets must pass profile through to each check."""
+        from core.smt_solver import BV_C_UINT32
+        g = OneGadget(0x100, ["rax == 0xCAFEBABE"])
+        ranked = rank_onegadgets([g], profile=BV_C_UINT32)
+        _, r = ranked[0]
+        assert r.feasible is True
+        assert r.model.get("rax") == 0xCAFEBABE

--- a/test/data/smt_codeql_testbench/README.md
+++ b/test/data/smt_codeql_testbench/README.md
@@ -2,11 +2,11 @@
 
 Cases designed to exercise Z3 path condition analysis in CodeQL dataflow findings.
 
-## Group 1 — SAT with non-obvious PoC values (ASPIRATIONAL)
+## Group 1 — SAT with non-obvious PoC values
 
-Aspirational cases where Z3 finds concrete satisfying assignments that require reasoning about unsigned bitvector wraparound or compound inequality constraints.
+Z3 finds concrete satisfying assignments that require reasoning about unsigned bitvector wraparound or compound inequality constraints.
 
-**NOTE:** Current SMT encoder is fixed at 64-bit. These cases rely on 32-bit wraparound and will be fully supported once width-parametric encoding is added.
+**Profile:** `ALLOC`, `SUM`, and `MASK` rely on 32-bit unsigned wraparound — invoke `check_path_feasibility(..., profile=BV_C_UINT32)` on their conditions (import from `core.smt_solver`). `OBO` is profile-agnostic. The dataflow validator auto-selects `BV_C_UINT32` when the CodeQL rule id mentions CWE-190 / overflow / wraparound; the LLM extractor can also override via `path_width` / `path_signed` hints in the extracted-conditions JSON.
 
 | Case | File | Sink line | Guard (visible) | Bug | Z3 PoC value |
 |------|------|-----------|-----------------|-----|--------------|

--- a/test/data/smt_codeql_testbench/smt_codeql_testbench.c
+++ b/test/data/smt_codeql_testbench/smt_codeql_testbench.c
@@ -3,13 +3,12 @@
  *
  * Organised into three groups:
  *
- *   GROUP 1 — SAT with non-obvious PoC values (ASPIRATIONAL)
+ *   GROUP 1 — SAT with non-obvious PoC values
  *     Z3 finds a concrete satisfying assignment that a human (or LLM) would
  *     likely miss because it requires reasoning about unsigned bitvector
- *     wraparound or compound inequality constraints.
- *
- *     NOTE: Current SMT encoder is fixed at 64-bit. These cases rely on 32-bit
- *     wraparound and will be fully supported once width-parametric encoding is added.
+ *     wraparound or compound inequality constraints.  ALLOC/SUM/MASK depend
+ *     on 32-bit unsigned wraparound — pass ``profile=BV_C_UINT32`` to
+ *     ``check_path_feasibility`` for those.  OBO is profile-agnostic.
  *
  *   GROUP 2 — UNSAT (provably dead paths)
  *     CodeQL reports a flow to a dangerous sink, but the path conditions are
@@ -50,15 +49,13 @@
 /* -------------------------------------------------------------------------
  * CASE 1a — allocation size overflow (CWE-190 → CWE-122)
  *
- * [ASPIRATIONAL] Requires 32-bit width encoding.
+ * Invoke check_path_feasibility with profile=BV_C_UINT32.
  *
  * Guard:    count < MAX_RECORDS  (looks protective)
  * Bug:      count * sizeof(record) overflows to a small value
- * Z3 (32-bit) finds: count = (UINT32_MAX / 16) + 1 = 0x10000001
+ * Z3 finds: count = (UINT32_MAX / 16) + 1 = 0x10000001
  *           0x10000001 * 16 = 0x100000010 truncated to 32 bits = 0x10
  *           0x10 < MAX_ALLOC=0x8000 ✓ — malloc gets 16 bytes
- *
- * Z3 (64-bit) sees 0x100000010 > 0x8000 and picks an innocuous count (e.g., 1).
  *           then loop writes count*16 = 2GB+ into it
  *
  * Path conditions for SMT:
@@ -107,7 +104,7 @@ void case_alloc_overflow(unsigned int count) {
 /* -------------------------------------------------------------------------
  * CASE 1b — compound bounds check bypass (CWE-190 → CWE-120)
  *
- * [ASPIRATIONAL] Requires 32-bit width encoding.
+ * Invoke check_path_feasibility with profile=BV_C_UINT32.
  *
  * This mimics the classic safe-looking copy guard:
  *   if (offset + length <= buffer_size) { memcpy(...) }
@@ -178,7 +175,7 @@ void case_offbyone(int index, char value) {
 /* -------------------------------------------------------------------------
  * CASE 1d — bitmask check bypass (alignment constraint + wraparound)
  *
- * [ASPIRATIONAL] Requires 32-bit width encoding.
+ * Invoke check_path_feasibility with profile=BV_C_UINT32.
  *
  * Guard:  flags & PRIV_FLAG == 0   ("unprivileged request only")
  *         size < MAX_SIZE


### PR DESCRIPTION
Introduces a frozen BVProfile dataclass and named constants (BV_X86_64, BV_C_UINT32, BV_C_INT32, …) as the single parametric handle both SMT encoders now accept, replacing the ad-hoc width/signed kwargs and the unused _Z3_BVConfig default.

Adds core/smt_solver/csem.py with C-semantics primitives (signed and unsigned overflow predicates, width coercion, arithmetic vs logical right shift, C-style cast) that future encoders need to reason about real C arithmetic rather than abstract bitvector math.

Wires the CodeQL dataflow validator so the extraction LLM emits per-path width/signed hints and a rule-id heuristic (CWE-190 family → 32-bit unsigned) fills in when hints are absent. The chosen profile flows through to check_path_feasibility, so CWE-190 32-bit wraparound — previously aspirational in the testbench — now works end-to-end.

Reasoning strings spell out the modelled semantics ("32-bit unsigned") instead of bv{32,64}{s,u} shorthand, so Stage E can spot profile / vuln-type mismatches without decoding jargon.

45 new tests; full repo suite passes at 2014.