### PR TITLE
ci: expand Python test coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,10 +71,15 @@ jobs:
       - name: Restore venv permissions
         run: chmod +x $VENV_PATH/bin/*
 
+      - name: Compile Python sources
+        run: |
+          source $VENV_PATH/bin/activate
+          python -m compileall -q core packages raptor.py raptor_agentic.py raptor_codeql.py raptor_fuzzing.py
+
       - name: Run unit tests
         run: |
           source $VENV_PATH/bin/activate
-          pytest packages/*/tests
+          pytest core packages/*/tests
 
   test-workflows:
     needs: deps

--- a/core/startup/banner.py
+++ b/core/startup/banner.py
@@ -50,7 +50,7 @@ def format_banner(logo, quote, tool_results, tool_warnings, llm_lines,
         lines.append("")
 
     # Tools
-    tool_parts = [f"{name} {'\u2713' if ok else '\u2717'}" for name, ok in tool_results]
+    tool_parts = [f"{name} {'✓' if ok else '✗'}" for name, ok in tool_results]
     lines.append(f" tools: {'  '.join(tool_parts)}")
 
     # Env


### PR DESCRIPTION
## Summary
- add a compile step for RAPTOR Python sources in CI
- expand the unit-test job to run `core` tests in addition to the existing package tests
- fix a startup banner f-string syntax issue that the new compile step catches

## Why
The current unit-test job only runs `packages/*/tests`, so regressions in `core/` can be missed. Adding `python -m compileall` gives CI a fast syntax/import-preflight gate before pytest starts, and including `core` in the pytest target brings the project-management, reporting, run metadata, coverage, SARIF, security, and startup helpers into the normal PR check path.

## Validation
- `python -m compileall -q core packages raptor.py raptor_agentic.py raptor_codeql.py raptor_fuzzing.py` passes under Python 3.12
- `pytest core -q` passes locally under Python 3.12: 687 passed, 9 skipped
- `pytest core packages/*/tests -q` was also run locally under Python 3.12; the expanded suite reaches 1967 passed / 33 skipped, with 4 existing macOS-specific package failures unrelated to this CI change. The GitHub workflow runs on Ubuntu.
- `git diff --check` passes

## Notes
This is intentionally a small CI hardening PR. It avoids overlapping with the larger open sandbox/release PRs and only broadens the existing Python verification surface.
