### PR TITLE
ci: cover remaining Python test files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,12 +74,12 @@ jobs:
       - name: Compile Python sources
         run: |
           source $VENV_PATH/bin/activate
-          python -m compileall -q core packages raptor.py raptor_agentic.py raptor_codeql.py raptor_fuzzing.py
+          python -m compileall -q core packages *.py
 
       - name: Run unit tests
         run: |
           source $VENV_PATH/bin/activate
-          pytest core packages/*/tests
+          pytest core packages
 
   test-workflows:
     needs: deps

--- a/core/security/tests/test_cc_trust.py
+++ b/core/security/tests/test_cc_trust.py
@@ -226,12 +226,12 @@ class TestEnvInjection:
         fail-closed scan wrapper must catch it."""
         claude = tmp_path / ".claude"; claude.mkdir()
         depth = sys.getrecursionlimit() + 500
-        nested = 1
-        for _ in range(depth):
-            nested = {"a": nested}
-        (claude / "settings.json").write_text(json.dumps({
-            "env": {"LD_PRELOAD": nested},
-        }))
+        # Avoid json.dumps() here: on some Python versions it can hit the
+        # recursion limit before the scanner gets to exercise its fail-closed
+        # path. Write valid JSON directly so the test covers the scanner.
+        (claude / "settings.json").write_text(
+            '{"env":{"LD_PRELOAD":' + ('{"a":' * depth) + '1' + ('}' * depth) + '}}'
+        )
         assert _check(str(tmp_path)) is True
 
     def test_raptor_star_env_blocks(self, tmp_path):


### PR DESCRIPTION
## Summary
- broaden the Python unit-test job from `pytest core packages/*/tests` to `pytest core packages`
- compile all top-level Python entry points with `python -m compileall -q core packages *.py`
- make the deeply nested Claude trust test portable by avoiding `json.dumps()` recursion before the scanner runs

## Why
PR #211 closed the biggest CI gap by adding `core` tests. This follow-up closes the remaining Python collection gap: `packages/*/tests` misses tests that live directly under a package directory, such as `packages/codeql/test_database_manager.py`.

The compile step also now covers top-level helper scripts such as `build_inventory.py` and `generate_diagram.py`, not only the `raptor*.py` launchers.

## Validation
- `python -m compileall -q core packages *.py` passes locally
- `pytest core -q` passes locally: 687 passed, 9 skipped
- `pytest packages/codeql/test_database_manager.py -q` passes locally: 11 passed
- `git diff --check upstream/main...HEAD` passes

## Notes
A full local `pytest packages -q` run on macOS still reaches the existing platform-specific package failures documented in #211. The GitHub workflow runs on Ubuntu; this PR is intended to make CI collect the remaining Python tests there rather than silently skipping them.