### PR TITLE
test: strengthen LLM log secret redaction

### DIFF
--- a/packages/llm_analysis/llm/client.py
+++ b/packages/llm_analysis/llm/client.py
@@ -89,8 +89,9 @@ def _sanitize_log_message(msg: str) -> str:
     # such as PASSWORD_POLICY, SECRET_ROTATION_DAYS, MAX_API_KEY_LENGTH, or
     # pagination cursors like page_token/next_token.
     secret_field = (
-        r'(?:[A-Za-z0-9_-]*(?:API[_-]?KEY|PASSWORD|SECRET|'
+        r'(?:[A-Za-z0-9_-]*(?:API[_-]?KEY|PASSWORD|'
         r'SECRET[_-]?KEY|SECRET[_-]?ACCESS[_-]?KEY)'
+        r'|(?:CLIENT|APP|SHARED|API|CONSUMER)[_-]?SECRET'
         r'|(?:ACCESS|AUTH|BEARER|ID|REFRESH|SESSION|SERVICE)[_-]?TOKEN)'
     )
     # Quoted values may be short or contain spaces/commas; the field name marks them sensitive.

--- a/packages/llm_analysis/llm/client.py
+++ b/packages/llm_analysis/llm/client.py
@@ -59,7 +59,17 @@ def _sanitize_log_message(msg: str) -> str:
     # Redact Google API keys (AIza*)
     msg = re.sub(r'AIza[a-zA-Z0-9-_]{30,}', '[REDACTED-API-KEY]', msg)
     # Redact Bearer tokens (Mistral and others in auth headers/error messages)
-    msg = re.sub(r'Bearer [a-zA-Z0-9-_]{20,}', 'Bearer [REDACTED]', msg)
+    msg = re.sub(
+        r'Bearer [a-zA-Z0-9._~+/-]{20,}={0,2}',
+        'Bearer [REDACTED]',
+        msg,
+        flags=re.IGNORECASE,
+    )
+    # Redact GitHub tokens that may appear in git/gh subprocess output
+    msg = re.sub(r'gh[oprsu]_[a-zA-Z0-9_]{36,}', '[REDACTED-API-KEY]', msg)
+    msg = re.sub(r'github_pat_[a-zA-Z0-9_]{20,}', '[REDACTED-API-KEY]', msg)
+    # Redact AWS access key IDs that commonly appear in tool output/traces
+    msg = re.sub(r'\b(?:AKIA|ASIA)[A-Z0-9]{16}\b', '[REDACTED-API-KEY]', msg)
     return msg
 
 

--- a/packages/llm_analysis/llm/client.py
+++ b/packages/llm_analysis/llm/client.py
@@ -51,9 +51,10 @@ def _sanitize_log_message(msg: str) -> str:
     Searchable tags: #SECURITY #API_KEY_PROTECTION #LOG_SANITIZATION
     Related: Cursor Bot Bug #2, PR #32, defense-in-depth best practice
     """
-    # Redact multiline private key material before shorter generic patterns.
+    # Redact private key material before shorter generic patterns. If a log line
+    # is truncated before the END marker, redact through the end of the message.
     msg = re.sub(
-        r'-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----',
+        r'-----BEGIN [A-Z ]*PRIVATE KEY-----.*?(?:-----END [A-Z ]*PRIVATE KEY-----|$)',
         '[REDACTED-PRIVATE-KEY]',
         msg,
         flags=re.DOTALL,
@@ -73,7 +74,7 @@ def _sanitize_log_message(msg: str) -> str:
         flags=re.IGNORECASE,
     )
     msg = re.sub(
-        r'Basic\s+\S+',
+        r'Basic\s+[A-Za-z0-9+/]{8,}={0,2}',
         'Basic [REDACTED]',
         msg,
         flags=re.IGNORECASE,
@@ -83,10 +84,14 @@ def _sanitize_log_message(msg: str) -> str:
     msg = re.sub(r'github_pat_[a-zA-Z0-9_]{20,}', '[REDACTED-API-KEY]', msg)
     # Redact AWS access key IDs that commonly appear in tool output/traces
     msg = re.sub(r'\b(?:AKIA|ASIA)[A-Z0-9]{16}\b', '[REDACTED-API-KEY]', msg)
-    # Redact key/value or JSON-ish assignments such as API_KEY=... or "token": "...".
+    # Redact key/value or JSON-ish assignments such as API_KEY=*** or "token": "***".
+    # Keep these field names intentionally bounded to avoid redacting metadata
+    # such as PASSWORD_POLICY, SECRET_ROTATION_DAYS, MAX_API_KEY_LENGTH, or
+    # pagination cursors like page_token/next_token.
     secret_field = (
-        r'(?:[A-Za-z0-9_-]*(?:API[_-]?KEY|SECRET|PASSWORD)[A-Za-z0-9_-]*'
-        r'|[A-Za-z0-9_-]*TOKEN)'
+        r'(?:[A-Za-z0-9_-]*(?:API[_-]?KEY|PASSWORD|SECRET|'
+        r'SECRET[_-]?KEY|SECRET[_-]?ACCESS[_-]?KEY)'
+        r'|(?:ACCESS|AUTH|BEARER|ID|REFRESH|SESSION|SERVICE)[_-]?TOKEN)'
     )
     # Quoted values may be short or contain spaces/commas; the field name marks them sensitive.
     msg = re.sub(

--- a/packages/llm_analysis/llm/client.py
+++ b/packages/llm_analysis/llm/client.py
@@ -51,6 +51,13 @@ def _sanitize_log_message(msg: str) -> str:
     Searchable tags: #SECURITY #API_KEY_PROTECTION #LOG_SANITIZATION
     Related: Cursor Bot Bug #2, PR #32, defense-in-depth best practice
     """
+    # Redact multiline private key material before shorter generic patterns.
+    msg = re.sub(
+        r'-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----',
+        '[REDACTED-PRIVATE-KEY]',
+        msg,
+        flags=re.DOTALL,
+    )
     # Redact Anthropic API keys first (sk-ant-*) before general sk-* pattern
     msg = re.sub(r'sk-ant-[a-zA-Z0-9-_]{20,}', '[REDACTED-API-KEY]', msg)
     # Redact OpenAI-style API keys (sk-*, pk-*)
@@ -58,10 +65,16 @@ def _sanitize_log_message(msg: str) -> str:
     msg = re.sub(r'pk-[a-zA-Z0-9-_]{20,}', '[REDACTED-API-KEY]', msg)
     # Redact Google API keys (AIza*)
     msg = re.sub(r'AIza[a-zA-Z0-9-_]{30,}', '[REDACTED-API-KEY]', msg)
-    # Redact Bearer tokens (Mistral and others in auth headers/error messages)
+    # Redact common authorization header schemes from SDK/tool errors.
     msg = re.sub(
         r'Bearer [a-zA-Z0-9._~+/-]{20,}={0,2}',
         'Bearer [REDACTED]',
+        msg,
+        flags=re.IGNORECASE,
+    )
+    msg = re.sub(
+        r'Basic\s+\S+',
+        'Basic [REDACTED]',
         msg,
         flags=re.IGNORECASE,
     )
@@ -70,6 +83,25 @@ def _sanitize_log_message(msg: str) -> str:
     msg = re.sub(r'github_pat_[a-zA-Z0-9_]{20,}', '[REDACTED-API-KEY]', msg)
     # Redact AWS access key IDs that commonly appear in tool output/traces
     msg = re.sub(r'\b(?:AKIA|ASIA)[A-Z0-9]{16}\b', '[REDACTED-API-KEY]', msg)
+    # Redact key/value or JSON-ish assignments such as API_KEY=... or "token": "...".
+    secret_field = (
+        r'(?:[A-Za-z0-9_-]*(?:API[_-]?KEY|SECRET|PASSWORD)[A-Za-z0-9_-]*'
+        r'|[A-Za-z0-9_-]*TOKEN)'
+    )
+    # Quoted values may be short or contain spaces/commas; the field name marks them sensitive.
+    msg = re.sub(
+        rf'(\b{secret_field}\b["\']?\s*[:=]\s*)(["\'])(.*?)(\2)',
+        r'\1\2[REDACTED-API-KEY]\4',
+        msg,
+        flags=re.IGNORECASE,
+    )
+    # Unquoted values end at common log/JSON delimiters.
+    msg = re.sub(
+        rf'(\b{secret_field}\b\s*[:=]\s*)([^"\'\s,}}]+)',
+        r'\1[REDACTED-API-KEY]',
+        msg,
+        flags=re.IGNORECASE,
+    )
     return msg
 
 

--- a/packages/llm_analysis/tests/test_llm_callbacks.py
+++ b/packages/llm_analysis/tests/test_llm_callbacks.py
@@ -271,6 +271,79 @@ class TestSanitizeLogMessage:
         assert github_key not in result
         assert result.count("[REDACTED-API-KEY]") == 3
 
+    def test_redacts_named_secret_assignments(self):
+        """Key/value log lines for secret-looking fields redact the value."""
+        values = [
+            ("OPENAI_API_KEY", "oa-" + "g" * 38),
+            ("AWS_SECRET_ACCESS_KEY", "h" * 40),
+            ("SERVICE_TOKEN", "tok_" + "i" * 36),
+            ("DATABASE_PASSWORD", "pw-" + "j" * 32),
+        ]
+        message = " ".join(f"{name}={value}" for name, value in values)
+        result = _sanitize_log_message(message)
+        for name, value in values:
+            assert value not in result
+            assert f"{name}=[REDACTED-API-KEY]" in result
+
+    def test_redacts_quoted_json_secret_fields(self):
+        """JSON-ish secret fields from SDK errors redact quoted values."""
+        api_value = "api-" + "k" * 36
+        session_value = "sess_" + "l" * 36
+        result = _sanitize_log_message(
+            f'{{"api_key": "{api_value}", "session_token": "{session_value}"}}'
+        )
+        assert api_value not in result
+        assert session_value not in result
+        assert '"api_key": "[REDACTED-API-KEY]"' in result
+        assert '"session_token": "[REDACTED-API-KEY]"' in result
+
+    def test_redacts_basic_authorization_header(self):
+        """Basic auth credentials in headers are redacted like bearer tokens."""
+        credentials = "Basic " + "b" * 44 + "=="
+        result = _sanitize_log_message(f"Authorization failed for {credentials}")
+        assert credentials not in result
+        assert "Basic [REDACTED]" in result
+
+    def test_redacts_short_basic_authorization_with_flexible_whitespace(self):
+        """Basic auth is sensitive by scheme, even when short or tab-separated."""
+        short_basic = "Basic " + "dXNlcjpwYXNz"
+        tab_basic = "Basic\t" + "b" * 24
+        result = _sanitize_log_message(f"Headers: {short_basic} and {tab_basic}")
+        assert short_basic not in result
+        assert tab_basic not in result
+        assert result.count("Basic [REDACTED]") == 2
+
+    def test_redacts_short_and_punctuated_named_secret_values(self):
+        """Explicit secret fields are redacted even when values are short or punctuated."""
+        short_password = "short"
+        punctuated_secret = "abc, def ghi"
+        result = _sanitize_log_message(
+            f'DATABASE_PASSWORD="{short_password}" SERVICE_SECRET="{punctuated_secret}"'
+        )
+        assert short_password not in result
+        assert punctuated_secret not in result
+        assert 'DATABASE_PASSWORD="[REDACTED-API-KEY]"' in result
+        assert 'SERVICE_SECRET="[REDACTED-API-KEY]"' in result
+
+    def test_preserves_llm_token_usage_metrics(self):
+        """Usage counters named *_tokens are telemetry, not credentials."""
+        message = "prompt_tokens=123456789012 completion_tokens=987654321098"
+        assert _sanitize_log_message(message) == message
+
+    def test_redacts_private_key_blocks(self):
+        """PEM private keys in multiline errors should never reach logs."""
+        private_key = (
+            "-----BEGIN "
+            + "PRIVATE KEY-----\n"
+            + "m" * 64
+            + "\n-----END "
+            + "PRIVATE KEY-----"
+        )
+        result = _sanitize_log_message(f"tool stderr:\n{private_key}\nfailed")
+        assert private_key not in result
+        assert "m" * 64 not in result
+        assert "[REDACTED-PRIVATE-KEY]" in result
+
 
 class TestBudgetChecking:
     """Verify budget checking works in LLMClient."""

--- a/packages/llm_analysis/tests/test_llm_callbacks.py
+++ b/packages/llm_analysis/tests/test_llm_callbacks.py
@@ -236,9 +236,9 @@ class TestSanitizeLogMessage:
     def test_redacts_github_tokens(self):
         """GitHub tokens can appear in tool errors and should not be logged."""
         tokens = [
-            "gh" + "p_" + "e" * 36,
-            "gh" + "r_" + "e" * 36,
-            "github" + "_pat_" + "f" * 82,
+            "ghp_" + "e" * 36,
+            "ghr_" + "e" * 36,
+            "github_pat_" + "f" * 82,
         ]
         result = _sanitize_log_message("Tokens: " + " ".join(tokens))
         for token in tokens:
@@ -252,6 +252,20 @@ class TestSanitizeLogMessage:
         assert key not in result
         assert "[REDACTED-API-KEY]" in result
 
+    def test_redacts_temporary_aws_access_key_id(self):
+        """Temporary AWS ASIA access key IDs are redacted too."""
+        key = "ASIA" + "IOSFODNN7EXAMPLE"
+        result = _sanitize_log_message(f"temporary AWS key leaked in trace: {key}")
+        assert key not in result
+        assert "[REDACTED-API-KEY]" in result
+
+    def test_preserves_boundary_length_non_tokens(self):
+        """Values below secret length thresholds should not be redacted."""
+        bearer = "Bearer " + "d" * 19
+        github_token = "ghp_" + "e" * 35
+        message = f"Authorization failed for {bearer}; token={github_token}"
+        assert _sanitize_log_message(message) == message
+
     def test_preserves_non_key_content(self):
         """Non-key content should be preserved."""
         msg = "Connection timeout after 30s to api.openai.com"
@@ -262,7 +276,7 @@ class TestSanitizeLogMessage:
         """Multiple secret types in one message are all redacted."""
         openai_key = "sk-" + "a" * 48
         google_key = "AIza" + "b" * 36
-        github_key = "gh" + "o_" + "c" * 36
+        github_key = "gho_" + "c" * 36
         result = _sanitize_log_message(
             f"Tried {openai_key} then {google_key} then {github_key}"
         )
@@ -313,6 +327,11 @@ class TestSanitizeLogMessage:
         assert tab_basic not in result
         assert result.count("Basic [REDACTED]") == 2
 
+    def test_preserves_basic_non_authorization_words(self):
+        """Plain-English uses of basic should not be treated as credentials."""
+        message = "basic error during basic setup"
+        assert _sanitize_log_message(message) == message
+
     def test_redacts_short_and_punctuated_named_secret_values(self):
         """Explicit secret fields are redacted even when values are short or punctuated."""
         short_password = "short"
@@ -330,6 +349,14 @@ class TestSanitizeLogMessage:
         message = "prompt_tokens=123456789012 completion_tokens=987654321098"
         assert _sanitize_log_message(message) == message
 
+    def test_preserves_secret_metadata_and_pagination_fields(self):
+        """Secret-related metadata and pagination cursors are not credential values."""
+        message = (
+            "SECRET_ROTATION_DAYS=90 PASSWORD_POLICY=strong "
+            "MAX_API_KEY_LENGTH=128 page_token=abc123 next_token=def456"
+        )
+        assert _sanitize_log_message(message) == message
+
     def test_redacts_private_key_blocks(self):
         """PEM private keys in multiline errors should never reach logs."""
         private_key = (
@@ -342,6 +369,14 @@ class TestSanitizeLogMessage:
         result = _sanitize_log_message(f"tool stderr:\n{private_key}\nfailed")
         assert private_key not in result
         assert "m" * 64 not in result
+        assert "[REDACTED-PRIVATE-KEY]" in result
+
+    def test_redacts_truncated_private_key_block(self):
+        """Truncated PEM private key logs are redacted through message end."""
+        private_key = "-----BEGIN " + "PRIVATE KEY-----\n" + "n" * 64
+        result = _sanitize_log_message(f"tool stderr:\n{private_key}")
+        assert private_key not in result
+        assert "n" * 64 not in result
         assert "[REDACTED-PRIVATE-KEY]" in result
 
 

--- a/packages/llm_analysis/tests/test_llm_callbacks.py
+++ b/packages/llm_analysis/tests/test_llm_callbacks.py
@@ -337,12 +337,12 @@ class TestSanitizeLogMessage:
         short_password = "short"
         punctuated_secret = "abc, def ghi"
         result = _sanitize_log_message(
-            f'DATABASE_PASSWORD="{short_password}" SERVICE_SECRET="{punctuated_secret}"'
+            f'DATABASE_PASSWORD="{short_password}" CLIENT_SECRET="{punctuated_secret}"'
         )
         assert short_password not in result
         assert punctuated_secret not in result
         assert 'DATABASE_PASSWORD="[REDACTED-API-KEY]"' in result
-        assert 'SERVICE_SECRET="[REDACTED-API-KEY]"' in result
+        assert 'CLIENT_SECRET="[REDACTED-API-KEY]"' in result
 
     def test_preserves_llm_token_usage_metrics(self):
         """Usage counters named *_tokens are telemetry, not credentials."""
@@ -352,7 +352,7 @@ class TestSanitizeLogMessage:
     def test_preserves_secret_metadata_and_pagination_fields(self):
         """Secret-related metadata and pagination cursors are not credential values."""
         message = (
-            "SECRET_ROTATION_DAYS=90 PASSWORD_POLICY=strong "
+            "SECRET_ROTATION_DAYS=90 PASSWORD_POLICY=strong IS_SECRET=false "
             "MAX_API_KEY_LENGTH=128 page_token=abc123 next_token=def456"
         )
         assert _sanitize_log_message(message) == message

--- a/packages/llm_analysis/tests/test_llm_callbacks.py
+++ b/packages/llm_analysis/tests/test_llm_callbacks.py
@@ -185,27 +185,71 @@ class TestIsQuotaError:
 
 
 class TestSanitizeLogMessage:
-    """Verify _sanitize_log_message redacts API keys."""
+    """Verify _sanitize_log_message redacts secrets from logs."""
 
     def test_redacts_openai_api_key(self):
         """OpenAI-style sk-* keys are redacted."""
-        msg = "Error with key sk-abcdefghijklmnopqrstuvwxyz1234567890"
-        result = _sanitize_log_message(msg)
-        assert "sk-abcdefghijklmnopqrstuvwxyz" not in result
+        key = "sk-proj-" + "a" * 48
+        result = _sanitize_log_message(f"Error with key {key}")
+        assert key not in result
         assert "[REDACTED-API-KEY]" in result
 
     def test_redacts_anthropic_api_key(self):
         """Anthropic-style sk-ant-* keys are redacted."""
-        msg = "Auth failed: sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890"
-        result = _sanitize_log_message(msg)
-        assert "sk-ant-api03" not in result
+        key = "sk-" + "ant-api03-" + "b" * 48
+        result = _sanitize_log_message(f"Auth failed: {key}")
+        assert key not in result
         assert "[REDACTED-API-KEY]" in result
 
     def test_redacts_google_api_key(self):
         """Google-style AIza* keys are redacted."""
-        msg = "Invalid key: AIzaSyA1234567890abcdefghijklmnopqrstuvwxyz"
-        result = _sanitize_log_message(msg)
-        assert "AIzaSyA1234567890" not in result
+        key = "AIza" + "c" * 36
+        result = _sanitize_log_message(f"Invalid key: {key}")
+        assert key not in result
+        assert "[REDACTED-API-KEY]" in result
+
+    def test_redacts_bearer_token(self):
+        """Bearer tokens in auth headers or SDK errors are redacted."""
+        bearer = "Bearer " + "d" * 48
+        result = _sanitize_log_message(f"Authorization failed for {bearer}")
+        assert bearer not in result
+        assert "Bearer [REDACTED]" in result
+
+    def test_redacts_dotted_bearer_jwt(self):
+        """JWT-shaped bearer values are fully redacted, not only the first segment."""
+        bearer = "Bearer " + ".".join(["a" * 24, "b" * 24, "c" * 24])
+        result = _sanitize_log_message(f"Authorization failed for {bearer}")
+        assert bearer not in result
+        assert "a" * 24 not in result
+        assert "b" * 24 not in result
+        assert "c" * 24 not in result
+        assert "Bearer [REDACTED]" in result
+
+    def test_redacts_lowercase_bearer_jwt(self):
+        """HTTP auth scheme casing should not prevent bearer redaction."""
+        bearer = "bearer " + ".".join(["a" * 24, "b" * 24, "c" * 24])
+        result = _sanitize_log_message(f"Authorization failed for {bearer}")
+        assert bearer not in result
+        assert "b" * 24 not in result
+        assert "Bearer [REDACTED]" in result
+
+    def test_redacts_github_tokens(self):
+        """GitHub tokens can appear in tool errors and should not be logged."""
+        tokens = [
+            "gh" + "p_" + "e" * 36,
+            "gh" + "r_" + "e" * 36,
+            "github" + "_pat_" + "f" * 82,
+        ]
+        result = _sanitize_log_message("Tokens: " + " ".join(tokens))
+        for token in tokens:
+            assert token not in result
+        assert result.count("[REDACTED-API-KEY]") == len(tokens)
+
+    def test_redacts_aws_access_key_id(self):
+        """AWS access key IDs are redacted from command/tool output."""
+        key = "AKIA" + "IOSFODNN7EXAMPLE"
+        result = _sanitize_log_message(f"AWS key leaked in trace: {key}")
+        assert key not in result
         assert "[REDACTED-API-KEY]" in result
 
     def test_preserves_non_key_content(self):
@@ -214,11 +258,18 @@ class TestSanitizeLogMessage:
         result = _sanitize_log_message(msg)
         assert result == msg
 
-    def test_redacts_multiple_keys(self):
-        """Multiple keys in one message are all redacted."""
-        msg = "Tried sk-abcdefghijklmnopqrstuvwxyz then AIzaSyA1234567890abcdefghijklmnopqrstuvwxyz"
-        result = _sanitize_log_message(msg)
-        assert result.count("[REDACTED-API-KEY]") == 2
+    def test_redacts_multiple_secret_types(self):
+        """Multiple secret types in one message are all redacted."""
+        openai_key = "sk-" + "a" * 48
+        google_key = "AIza" + "b" * 36
+        github_key = "gh" + "o_" + "c" * 36
+        result = _sanitize_log_message(
+            f"Tried {openai_key} then {google_key} then {github_key}"
+        )
+        assert openai_key not in result
+        assert google_key not in result
+        assert github_key not in result
+        assert result.count("[REDACTED-API-KEY]") == 3
 
 
 class TestBudgetChecking:


### PR DESCRIPTION
## Summary
- Strengthen `_sanitize_log_message()` tests with realistic fake token shapes.
- Extend redaction coverage for Bearer/JWT credentials, Basic auth headers, GitHub tokens, AWS access key IDs, JSON/key-value secret fields, and PEM private-key blocks.
- Add a false-positive regression check so LLM usage telemetry like `prompt_tokens` / `completion_tokens` remains visible.
- Keep fake tokens constructed from string fragments so the tests do not introduce realistic-looking literal secrets.

## Why
RAPTOR handles LLM provider errors and external tool output where credentials can appear in exception messages, auth headers, environment-style key/value lines, JSON-ish SDK errors, or subprocess output. Stronger redaction tests help prevent API keys and tokens from leaking into logs during scans while preserving useful non-secret diagnostics.

## Test plan
- `python -m pytest packages/llm_analysis/tests/test_llm_callbacks.py::TestSanitizeLogMessage -q`
- `python -m pytest packages/llm_analysis/tests -q`
- `python -m compileall -q packages/llm_analysis/llm/client.py packages/llm_analysis/tests/test_llm_callbacks.py`
- `python -m compileall -q core packages raptor.py raptor_agentic.py raptor_codeql.py raptor_fuzzing.py`
- `git diff --check`
- Added-line security grep for hardcoded secret literals and dangerous Python sinks

## Notes
A broader local run of `pytest core packages/llm_analysis/tests -q` had pre-existing environment/Python-version related failures outside this patch. The touched package suite passes cleanly.