### PR TITLE
remove vestigial SAGE_FALLBACK_JSON

### DIFF
--- a/core/sage/config.py
+++ b/core/sage/config.py
@@ -25,9 +25,6 @@ class SageConfig:
     timeout: float = field(
         default_factory=lambda: float(os.getenv("SAGE_TIMEOUT", "15.0"))
     )
-    fallback_json: bool = field(
-        default_factory=lambda: os.getenv("SAGE_FALLBACK_JSON", "true").lower() in ("true", "1", "yes")
-    )
 
     @staticmethod
     def from_env() -> "SageConfig":

--- a/core/sage/docs/SAGE_INTEGRATION.md
+++ b/core/sage/docs/SAGE_INTEGRATION.md
@@ -107,7 +107,6 @@ docker-compose.sage.yml down -v` to wipe them.
 | `SAGE_URL` | `http://localhost:8090` | SAGE API URL |
 | `SAGE_IDENTITY_PATH` | auto | Path to agent key file |
 | `SAGE_TIMEOUT` | `15.0` | API request timeout (seconds) |
-| `SAGE_FALLBACK_JSON` | `true` | Fall back to JSON when SAGE unavailable |
 
 ### MCP Configuration
 

--- a/core/sage/tests/test_sage_config.py
+++ b/core/sage/tests/test_sage_config.py
@@ -18,7 +18,6 @@ class TestSageConfig(unittest.TestCase):
         self.assertEqual(config.url, "http://localhost:8090")
         self.assertIsNone(config.identity_path)
         self.assertEqual(config.timeout, 15.0)
-        self.assertTrue(config.fallback_json)
 
     @patch.dict(os.environ, {"SAGE_ENABLED": "true"})
     def test_enabled_from_env(self):
@@ -54,13 +53,6 @@ class TestSageConfig(unittest.TestCase):
 
         config = SageConfig()
         self.assertEqual(config.identity_path, "/tmp/agent.key")
-
-    @patch.dict(os.environ, {"SAGE_FALLBACK_JSON": "false"})
-    def test_fallback_json_disabled(self):
-        from core.sage.config import SageConfig
-
-        config = SageConfig()
-        self.assertFalse(config.fallback_json)
 
     def test_from_env_factory(self):
         from core.sage.config import SageConfig

--- a/core/security/tests/test_cc_trust.py
+++ b/core/security/tests/test_cc_trust.py
@@ -245,7 +245,7 @@ class TestEnvInjection:
 
     @pytest.mark.parametrize("key", [
         "SAGE_URL", "SAGE_ENABLED", "SAGE_IDENTITY_PATH",
-        "SAGE_TIMEOUT", "SAGE_FALLBACK_JSON",
+        "SAGE_TIMEOUT",
     ])
     def test_sage_star_env_blocks(self, tmp_path, key):
         """env.SAGE_* — targets manipulating RAPTOR's SAGE config (e.g.


### PR DESCRIPTION
The fallback_json field was declared in config.py, documented, env-tested, and flagged by cc_trust — but never read anywhere in core/sage/*.py.

Per l33tdawg: vestigial from an earlier design that considered SAGE-only (no JSON cache) deployments. _sage_available already handles the whole failure model via the write-both-on-success pattern: SAGE healthy → SAGE + JSON; SAGE down → JSON only. A configurable fallback_json=false would only enable a trap (silent data loss if SAGE drops mid-run).

Removed:
- core/sage/config.py: fallback_json field
- core/sage/docs/SAGE_INTEGRATION.md: SAGE_FALLBACK_JSON doc row
- core/sage/tests/test_sage_config.py: default assertion + env override test
- core/security/tests/test_cc_trust.py: SAGE_FALLBACK_JSON allowlist entry

No behavior change — the field was never consumed.