### PR TITLE
fix(sage): thread-safe singleton, idempotent seed/register, residual misses + cleanup

### DIFF
--- a/core/sage/client.py
+++ b/core/sage/client.py
@@ -180,30 +180,3 @@ class SageClient:
             logger.warning(f"SAGE query failed: {e}")
             return []
 
-    def register(self, name: str) -> bool:
-        """
-        Register this agent identity on the SAGE network.
-
-        Prefers the SDK's register_agent(); falls back to storing a
-        registration memory if the SDK method is unavailable.
-        """
-        client = self._get_client()
-        if client is None:
-            return False
-        try:
-            if hasattr(client, "register_agent"):
-                client.register_agent(name)
-            else:
-                content = f"Agent {name} registered on SAGE network."
-                embedding = client.embed(content)
-                client.propose(
-                    content=content,
-                    memory_type=_MemoryType.fact,
-                    domain_tag="raptor-agents",
-                    confidence=0.95,
-                    embedding=embedding,
-                )
-            return True
-        except Exception as e:
-            logger.warning(f"SAGE register failed: {e}")
-            return False

--- a/core/sage/hooks.py
+++ b/core/sage/hooks.py
@@ -10,6 +10,7 @@ All hooks are no-ops when SAGE is unavailable.
 
 import hashlib
 import os
+import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -21,8 +22,14 @@ from .config import SageConfig
 
 logger = get_logger()
 
-# Singleton client — created on first use
+# Singleton client — created on first use.
+# orchestrator.py dispatches via ThreadPoolExecutor, so the first-use
+# init must be guarded against concurrent first calls racing on the
+# `_client is None` check. Once the init decision is made, it sticks
+# for the process lifetime — no retry-storm if SAGE is down.
+_client_lock = threading.Lock()
 _client: Optional[SageClient] = None
+_client_initialised: bool = False
 
 
 def _throttle() -> None:
@@ -46,15 +53,30 @@ def _throttle() -> None:
 
 
 def _get_client() -> Optional[SageClient]:
-    """Get or create the SAGE client singleton."""
-    global _client
-    if _client is None:
-        config = SageConfig.from_env()
-        _client = SageClient(config)
-        if not _client.is_available():
-            logger.debug("SAGE unavailable — pipeline hooks disabled")
-            _client = None
-    return _client
+    """Get or create the SAGE client singleton.
+
+    Thread-safe: guarded by `_client_lock` because the orchestrator
+    dispatches into SAGE hooks from worker threads concurrently.
+    Without the lock, two threads can both see `_client is None` and
+    each run `is_available()` (duplicate network calls), and a thread
+    can briefly observe a non-None `_client` while another resets it.
+
+    The init decision is cached via `_client_initialised` so that a
+    down-at-first-use SAGE doesn't trigger an `is_available()` probe
+    on every subsequent hook call for the rest of the process lifetime.
+    """
+    global _client, _client_initialised
+    with _client_lock:
+        if not _client_initialised:
+            config = SageConfig.from_env()
+            candidate = SageClient(config)
+            if candidate.is_available():
+                _client = candidate
+            else:
+                logger.debug("SAGE unavailable — pipeline hooks disabled")
+                _client = None
+            _client_initialised = True
+        return _client
 
 
 def _repo_key(repo_path: str) -> str:
@@ -202,8 +224,8 @@ def store_scan_results(
             domain_tag=_findings_domain(repo_path),
             confidence=0.85,
         )
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"SAGE scan summary store failed: {e}")
 
     if stored > 0:
         logger.info(f"SAGE: Stored {stored} findings from scan")

--- a/core/sage/scripts/_common.py
+++ b/core/sage/scripts/_common.py
@@ -1,0 +1,52 @@
+"""Shared helpers for SAGE setup scripts.
+
+Both `register_agents.py` and `seed_sage_knowledge.py` propose a
+deterministic set of memories on install. Running them twice (e.g. after
+a SAGE volume reset, or when the setup script is re-invoked) creates
+duplicates in the SAGE consensus store.
+
+`async_memory_exists` lets callers skip the propose step for items
+already stored, keyed by a stable per-memory tag that SAGE's 6.6.0
+tags-as-first-class feature makes queryable.
+
+Caveat: SAGE stores tags as **node-local metadata** (not part of the
+on-chain consensus tx). On a single-node deployment — which is what
+`libexec/raptor-sage-setup` spins up by default — submit and query
+hit the same node, so tag-based existence checks are reliable. On a
+distributed SAGE where submit and query can land on different nodes,
+tags would not replicate and re-runs against a fresh node would
+duplicate. Not a concern for current RAPTOR deployments.
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def async_memory_exists(
+    client: Any,
+    domain_tag: str,
+    tag: str,
+) -> bool:
+    """Return True if a memory tagged `tag` exists in `domain_tag`.
+
+    Uses ``list_memories(domain, tag, limit=1)`` — exact-filter lookup
+    with no embedding required. (``query()`` would need an embedding,
+    and tag semantics there are looser.)
+
+    On any error (SAGE unreachable, schema mismatch, timeout) logs at
+    debug level and returns False so the caller re-proposes rather than
+    silently skipping. A duplicate is cheap; a missing memory because of
+    a transient query failure is not.
+    """
+    try:
+        response = await client.list_memories(
+            domain=domain_tag,
+            tag=tag,
+            limit=1,
+        )
+        return bool(response.memories)
+    except Exception as e:
+        logger.debug(f"SAGE tag existence check failed ({domain_tag}/{tag}): {e}")
+        return False

--- a/core/sage/scripts/register_agents.py
+++ b/core/sage/scripts/register_agents.py
@@ -6,7 +6,7 @@ Each agent gets a registered identity and role definition stored
 as consensus-validated fact memories in the raptor-agents domain.
 
 Usage:
-    python3 core/sage/scripts/register_agents.py [--sage-url http://localhost:8090] [--dry-run]
+    python3 core/sage/scripts/register_agents.py [--sage-url http://localhost:8090] [--dry-run] [--force]
 
 Requires:
     pip install sage-agent-sdk
@@ -27,6 +27,13 @@ except ImportError:
     print("ERROR: sage-agent-sdk not installed.")
     print("  pip install sage-agent-sdk")
     sys.exit(1)
+
+from core.sage.scripts._common import async_memory_exists
+
+# Parallelism cap for SAGE proposes. CometBFT batches concurrent txs into
+# the same block, so N sequential rounds collapse to ~1-2 blocks wall time.
+# 8 is conservative enough for 2-core laptops, aggressive enough to matter.
+_PROPOSE_CONCURRENCY = 8
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -264,12 +271,86 @@ RAPTOR_AGENTS = [
 # Registration
 # ─────────────────────────────────────────────────────────────────────────────
 
-async def register_agents(sage_url: str, dry_run: bool = False):
+async def _register_one(
+    client: AsyncSageClient,
+    agent: dict,
+    force: bool,
+    sem: asyncio.Semaphore,
+) -> tuple[str, str]:
+    """Propose an agent's role + xref memories. Returns (name, status).
+
+    status ∈ {"stored", "skipped", "failed: <err>"}. Skipped when both
+    memories are already present in SAGE and --force isn't set.
+    """
+    async with sem:
+        name = agent["name"]
+        caps = ", ".join(agent["capabilities"])
+        domains = ", ".join(agent["domains"])
+        primary_domain = agent["domains"][0]
+        role_tag = f"agent:{name}"
+        xref_tag = f"agent-xref:{name}"
+
+        try:
+            # Check each memory independently so a previous partial failure
+            # (e.g. role stored, xref crashed) re-proposes only the missing
+            # half rather than duplicating what already landed.
+            if force:
+                role_exists = xref_exists = False
+            else:
+                role_exists = await async_memory_exists(client, "raptor-agents", role_tag)
+                xref_exists = await async_memory_exists(client, primary_domain, xref_tag)
+
+            if role_exists and xref_exists:
+                return (name, "skipped")
+
+            if not role_exists:
+                role_content = (
+                    f"RAPTOR agent: {name}. "
+                    f"Role: {agent['role']}. "
+                    f"Description: {agent['description']} "
+                    f"Domains: {domains}. "
+                    f"Capabilities: {caps}."
+                )
+                role_embedding = await client.embed(role_content)
+                await client.propose(
+                    content=role_content,
+                    memory_type=MemoryType.fact,
+                    domain_tag="raptor-agents",
+                    confidence=0.95,
+                    embedding=role_embedding,
+                    tags=[role_tag],
+                )
+
+            if not xref_exists:
+                xref_content = (
+                    f"Agent {name} ({agent['role']}) operates in this domain. "
+                    f"Capabilities: {caps}."
+                )
+                xref_embedding = await client.embed(xref_content)
+                await client.propose(
+                    content=xref_content,
+                    memory_type=MemoryType.fact,
+                    domain_tag=primary_domain,
+                    confidence=0.90,
+                    embedding=xref_embedding,
+                    tags=[xref_tag],
+                )
+
+            if role_exists or xref_exists:
+                return (name, "partial")  # one half was already present
+            return (name, "stored")
+        except Exception as e:
+            return (name, f"failed: {e}")
+
+
+async def register_agents(sage_url: str, dry_run: bool = False, force: bool = False):
     """Register all RAPTOR agents on the SAGE network."""
 
     print("=" * 60)
     print("RAPTOR Agent Registration for SAGE")
     print(f"Agents: {len(RAPTOR_AGENTS)}")
+    if force:
+        print("Mode: --force (re-propose even if memories already exist)")
     print("=" * 60)
     print()
 
@@ -296,74 +377,53 @@ async def register_agents(sage_url: str, dry_run: bool = False):
 
     # Register the registrar agent first
     try:
-        await client.register_agent("raptor-registrar")
-        print("Registered as raptor-registrar\n")
+        # AgentRegistration.on_chain_height (int64) was renamed from
+        # `registered_at` in SAGE 6.6.0 to fix a 3-way type mismatch
+        # (Go int64 vs OpenAPI date-time string vs SDK `str | None`).
+        # Surface it so a grep for "raptor-registrar" in debug logs
+        # confirms the registration actually landed on-chain.
+        reg = await client.register_agent("raptor-registrar")
+        height = getattr(reg, "on_chain_height", None)
+        print(f"Registered as raptor-registrar (on-chain height {height})\n")
     except Exception as e:
         print(f"Registration note: {e}\n")
 
-    # Wake up consensus
+    # Warm the ollama embedding sidecar so the first real embed below
+    # doesn't pay cold-model-load latency. Best-effort; ollama may not be
+    # reachable on some setups and that's fine — the first actual embed
+    # will cold-start normally. (Does NOT touch CometBFT consensus —
+    # /v1/embed is a local ollama roundtrip, nothing on-chain.)
     try:
         await client.embed("wake")
     except Exception:
         pass
 
-    registered = 0
-    failed = 0
+    sem = asyncio.Semaphore(_PROPOSE_CONCURRENCY)
+    results = await asyncio.gather(
+        *(_register_one(client, agent, force, sem) for agent in RAPTOR_AGENTS)
+    )
 
-    for i, agent in enumerate(RAPTOR_AGENTS, 1):
-        try:
-            name = agent["name"]
-            caps = ", ".join(agent["capabilities"])
-            domains = ", ".join(agent["domains"])
+    stored = sum(1 for _, status in results if status == "stored")
+    partial = sum(1 for _, status in results if status == "partial")
+    skipped = sum(1 for _, status in results if status == "skipped")
+    failed = [(name, status) for name, status in results if status.startswith("failed")]
 
-            print(f"[{i}/{len(RAPTOR_AGENTS)}] Registering {name}...", end=" ")
-
-            # Store role definition as a fact memory
-            role_content = (
-                f"RAPTOR agent: {name}. "
-                f"Role: {agent['role']}. "
-                f"Description: {agent['description']} "
-                f"Domains: {domains}. "
-                f"Capabilities: {caps}."
-            )
-
-            embedding = await client.embed(role_content)
-            await client.propose(
-                content=role_content,
-                memory_type=MemoryType.fact,
-                domain_tag="raptor-agents",
-                confidence=0.95,
-                embedding=embedding,
-            )
-
-            # Also store a cross-reference in each agent's primary domain
-            primary_domain = agent["domains"][0]
-            xref_content = (
-                f"Agent {name} ({agent['role']}) operates in this domain. "
-                f"Capabilities: {caps}."
-            )
-            xref_embedding = await client.embed(xref_content)
-            await client.propose(
-                content=xref_content,
-                memory_type=MemoryType.fact,
-                domain_tag=primary_domain,
-                confidence=0.90,
-                embedding=xref_embedding,
-            )
-
-            registered += 1
-            print("OK")
-
-            await asyncio.sleep(0.5)
-        except Exception as e:
-            failed += 1
-            print(f"FAILED: {e}")
+    for name, status in results:
+        if status == "stored":
+            print(f"  stored:  {name}")
+        elif status == "partial":
+            print(f"  partial: {name} (filled in missing half from a prior partial run)")
+        elif status == "skipped":
+            print(f"  skipped: {name} (already registered)")
+        else:
+            print(f"  {status.upper()}: {name}")
 
     print()
     print("=" * 60)
-    print(f"Registered {registered}/{len(RAPTOR_AGENTS)} agents")
-    if failed:
-        print(f"Failed: {failed}")
+    print(
+        f"Stored: {stored}/{len(RAPTOR_AGENTS)}  "
+        f"Partial: {partial}  Skipped: {skipped}  Failed: {len(failed)}"
+    )
     print("=" * 60)
 
 
@@ -381,9 +441,14 @@ def main():
         action="store_true",
         help="Print agent definitions without registering",
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-propose even if the agent's memories are already present in SAGE",
+    )
     args = parser.parse_args()
 
-    asyncio.run(register_agents(args.sage_url, args.dry_run))
+    asyncio.run(register_agents(args.sage_url, args.dry_run, args.force))
 
 
 if __name__ == "__main__":

--- a/core/sage/scripts/seed_sage_knowledge.py
+++ b/core/sage/scripts/seed_sage_knowledge.py
@@ -6,7 +6,7 @@ Extracts hardcoded expert knowledge from Raptor's codebase and stores it
 in SAGE for persistent, consensus-validated memory that improves over time.
 
 Usage:
-    python3 core/sage/scripts/seed_sage_knowledge.py [--sage-url http://localhost:8090] [--dry-run]
+    python3 core/sage/scripts/seed_sage_knowledge.py [--sage-url http://localhost:8090] [--dry-run] [--force]
 
 Requires:
     pip install sage-agent-sdk
@@ -29,6 +29,11 @@ except ImportError:
     print("ERROR: sage-agent-sdk not installed.")
     print("  pip install sage-agent-sdk")
     sys.exit(1)
+
+from core.sage.scripts._common import async_memory_exists
+
+# Parallelism cap — see register_agents.py for rationale.
+_PROPOSE_CONCURRENCY = 8
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -261,7 +266,39 @@ def _chunk_text(text: str, max_chars: int = 1500) -> list[str]:
 # Seeding
 # ─────────────────────────────────────────────────────────────────────────────
 
-async def seed(sage_url: str, dry_run: bool = False):
+async def _seed_one(
+    client: AsyncSageClient,
+    mem: dict,
+    force: bool,
+    sem: asyncio.Semaphore,
+) -> tuple[str, str]:
+    """Propose a single knowledge memory. Returns (label, status).
+
+    status ∈ {"stored", "skipped", "failed: <err>"}.
+    """
+    async with sem:
+        label = mem["label"]
+        domain = mem["domain"]
+        try:
+            if not force and await async_memory_exists(client, domain, label):
+                return (label, "skipped")
+
+            embedding = await client.embed(mem["content"])
+            mt = getattr(MemoryType, mem["memory_type"], MemoryType.observation)
+            await client.propose(
+                content=mem["content"],
+                memory_type=mt,
+                domain_tag=domain,
+                confidence=mem["confidence"],
+                embedding=embedding,
+                tags=[label],
+            )
+            return (label, "stored")
+        except Exception as e:
+            return (label, f"failed: {e}")
+
+
+async def seed(sage_url: str, dry_run: bool = False, force: bool = False):
     """Extract all knowledge and seed into SAGE."""
 
     print("=" * 60)
@@ -328,47 +365,42 @@ async def seed(sage_url: str, dry_run: bool = False):
 
     # Register as raptor-seed agent
     try:
-        await client.register("raptor-seed")
-        print("Registered as raptor-seed")
+        # See register_agents.py for on_chain_height rationale — same
+        # SAGE 6.6.0 type-mismatch fix.
+        reg = await client.register_agent("raptor-seed")
+        height = getattr(reg, "on_chain_height", None)
+        print(f"Registered as raptor-seed (on-chain height {height})")
     except Exception as e:
         print(f"Registration note: {e}")
 
-    # Wake up consensus
+    # Warm the ollama embedding sidecar so the first real embed below
+    # doesn't pay cold-model-load latency. Best-effort; does NOT touch
+    # CometBFT consensus — /v1/embed is a local ollama roundtrip.
     try:
         await client.embed("wake")
     except Exception:
         pass
 
-    # Seed all knowledge
-    stored = 0
-    failed = 0
-    for i, mem in enumerate(all_memories, 1):
-        try:
-            print(f"Seeding [{i}/{len(all_memories)}]: {mem['label']}...", end=" ")
-            embedding = await client.embed(mem["content"])
+    sem = asyncio.Semaphore(_PROPOSE_CONCURRENCY)
+    results = await asyncio.gather(
+        *(_seed_one(client, mem, force, sem) for mem in all_memories)
+    )
 
-            mt = getattr(MemoryType, mem["memory_type"], MemoryType.observation)
-            await client.propose(
-                content=mem["content"],
-                memory_type=mt,
-                domain_tag=mem["domain"],
-                confidence=mem["confidence"],
-                embedding=embedding,
-            )
-            stored += 1
-            print("OK")
+    stored = sum(1 for _, status in results if status == "stored")
+    skipped = sum(1 for _, status in results if status == "skipped")
+    failed = [(label, status) for label, status in results if status.startswith("failed")]
 
-            # Delay between proposals for single-node consensus
-            await asyncio.sleep(0.5)
-        except Exception as e:
-            failed += 1
-            print(f"FAILED: {e}")
+    for label, status in results:
+        if status == "stored":
+            print(f"  stored:  {label}")
+        elif status == "skipped":
+            print(f"  skipped: {label} (already seeded)")
+        else:
+            print(f"  {status.upper()}: {label}")
 
     print()
     print("=" * 60)
-    print(f"Seeded {stored}/{len(all_memories)} knowledge entries")
-    if failed:
-        print(f"Failed: {failed}")
+    print(f"Stored: {stored}/{len(all_memories)}  Skipped: {skipped}  Failed: {len(failed)}")
     print("=" * 60)
 
 
@@ -386,9 +418,14 @@ def main():
         action="store_true",
         help="Print knowledge without storing in SAGE",
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-propose even if memories with the same label are already seeded",
+    )
     args = parser.parse_args()
 
-    asyncio.run(seed(args.sage_url, args.dry_run))
+    asyncio.run(seed(args.sage_url, args.dry_run, args.force))
 
 
 if __name__ == "__main__":

--- a/core/sage/tests/test_sage_client.py
+++ b/core/sage/tests/test_sage_client.py
@@ -82,10 +82,6 @@ class TestSageClientNoSDK(unittest.TestCase):
         from core.sage.client import SageClient
         self.assertFalse(SageClient().propose("test content"))
 
-    def test_register_no_client(self):
-        from core.sage.client import SageClient
-        self.assertFalse(SageClient().register("test-agent"))
-
 
 def _install_mock_sdk(client_mod):
     """Install mock SDK bindings in the client module. Returns (cls, instance)."""

--- a/core/sage/tests/test_sage_hooks.py
+++ b/core/sage/tests/test_sage_hooks.py
@@ -163,5 +163,60 @@ class TestThrottle(unittest.TestCase):
         mock_sleep.assert_not_called()
 
 
+class TestGetClientThreadSafety(unittest.TestCase):
+    """Singleton init is guarded by _client_lock and _client_initialised.
+
+    The orchestrator dispatches via ThreadPoolExecutor, so two workers can
+    call _get_client() before either has finished initialising. Without the
+    lock, both would construct SageClient (wasteful) and one could briefly
+    see a non-None _client while the other resets it to None.
+    """
+
+    def setUp(self):
+        import core.sage.hooks as hooks
+        # Reset module state so each test starts from a cold singleton.
+        hooks._client = None
+        hooks._client_initialised = False
+
+    def tearDown(self):
+        import core.sage.hooks as hooks
+        hooks._client = None
+        hooks._client_initialised = False
+
+    @patch("core.sage.hooks.SageClient")
+    def test_concurrent_first_call_constructs_client_once(self, mock_cls):
+        from concurrent.futures import ThreadPoolExecutor
+        import core.sage.hooks as hooks
+
+        mock_instance = MagicMock()
+        mock_instance.is_available.return_value = True
+        mock_cls.return_value = mock_instance
+
+        with ThreadPoolExecutor(max_workers=16) as pool:
+            results = list(pool.map(lambda _: hooks._get_client(), range(16)))
+
+        self.assertEqual(mock_cls.call_count, 1)
+        self.assertTrue(all(r is mock_instance for r in results))
+
+    @patch("core.sage.hooks.SageClient")
+    def test_unavailable_at_init_sticks(self, mock_cls):
+        """Once SAGE is decided unavailable, don't re-probe on every call."""
+        import core.sage.hooks as hooks
+
+        mock_instance = MagicMock()
+        mock_instance.is_available.return_value = False
+        mock_cls.return_value = mock_instance
+
+        self.assertIsNone(hooks._get_client())
+        self.assertIsNone(hooks._get_client())
+        self.assertIsNone(hooks._get_client())
+
+        # SageClient ctor and is_available each ran exactly once across
+        # three hook calls — cached init prevents the probe-storm the
+        # old code would cause when SAGE is down for the whole run.
+        self.assertEqual(mock_cls.call_count, 1)
+        self.assertEqual(mock_instance.is_available.call_count, 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/core/sage/tests/test_sage_scripts_common.py
+++ b/core/sage/tests/test_sage_scripts_common.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Tests for core/sage/scripts/_common.py."""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+
+class TestAsyncMemoryExists(unittest.TestCase):
+    """async_memory_exists is the idempotency primitive for seed/register.
+
+    Must return False on any error so callers re-propose rather than
+    silently skipping — a duplicate memory is cheap; a missing one
+    because of a transient query failure is not.
+    """
+
+    def test_returns_true_when_results_present(self):
+        from core.sage.scripts._common import async_memory_exists
+        client = MagicMock()
+        response = MagicMock()
+        response.memories = [MagicMock()]
+        client.list_memories = AsyncMock(return_value=response)
+
+        result = asyncio.run(async_memory_exists(client, "raptor-agents", "agent:raptor-scan"))
+
+        self.assertTrue(result)
+        client.list_memories.assert_awaited_once_with(
+            domain="raptor-agents",
+            tag="agent:raptor-scan",
+            limit=1,
+        )
+
+    def test_returns_false_when_empty(self):
+        from core.sage.scripts._common import async_memory_exists
+        client = MagicMock()
+        response = MagicMock()
+        response.memories = []
+        client.list_memories = AsyncMock(return_value=response)
+
+        result = asyncio.run(async_memory_exists(client, "raptor-agents", "agent:unknown"))
+
+        self.assertFalse(result)
+
+    def test_returns_false_on_query_error(self):
+        from core.sage.scripts._common import async_memory_exists
+        client = MagicMock()
+        client.list_memories = AsyncMock(side_effect=RuntimeError("sage unreachable"))
+
+        result = asyncio.run(async_memory_exists(client, "raptor-agents", "agent:anything"))
+
+        # Error → False → caller re-proposes. Duplicate memory is cheaper
+        # than a missing one caused by a transient query failure.
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Post-merge sweep of sage_integration. Four classes of fix:

1. Thread-safe client singleton (core/sage/hooks.py)

   orchestrator.py dispatches via ThreadPoolExecutor(max_workers=N), so worker threads race on the `_client is None` check in `_get_client`. Without a lock, concurrent first calls each construct a SageClient + run `is_available()` (wasteful network duplication), and a thread can briefly observe a non-None `_client` while another resets it.

   Wrap init with threading.Lock; cache the decision in a new `_client_initialised` flag so a SAGE-down-at-first-use doesn't trigger a probe-storm on every subsequent hook call for the rest of the process lifetime.

2. Idempotent seed + register with SAGE 6.6.0 tags

   Both setup scripts re-propose their full memory set every run — 16 agents × 2 memories + ~100 seeded knowledge entries — creating duplicates in consensus store on any re-invocation (volume reset, SAGE image bump, explicit reset).

   Fix via existence-check skip, keyed on stable per-memory tags using SAGE 6.6.0's `list_memories(domain, tag, limit=1)` exact-filter API:
   - register_agents.py: `agent:{name}` for role, `agent-xref:{name}` for per-domain cross-reference. Each memory checked independently so a previous partial failure (role stored, xref crashed) fills in only the missing half rather than duplicating both.
   - seed_sage_knowledge.py: existing `label` field on each memory dict (e.g. `primitive:rop-chain`, `persona:halvar`).

   First in-tree consumer of the tags-as-first-class feature SAGE 6.6.0
   shipped (#199 pinned but didn't consume). Establishes the pattern
   for future SAGE callers.

   Caveat worth flagging: SAGE stores tags as node-local metadata (not part of the on-chain consensus tx), so idempotency is reliable for single-node deployments — which is what libexec/raptor-sage-setup spins up by default — but would not survive submit/query hitting different nodes on a distributed SAGE. Not a concern for any current RAPTOR deployment.

   New `core/sage/scripts/_common.py::async_memory_exists` shared by both scripts. Errors log at debug and return False so callers re-propose — a duplicate memory is cheaper than a missing one from a transient query failure.

   Both scripts gain `--force` to re-propose regardless.

3. Parallelism + residual #192/#199 misses

   - Sequential `await client.propose(...)` per item replaced with `asyncio.gather()` bounded by `Semaphore(8)`. CometBFT batches concurrent txs into the same block, so N sequential rounds collapse to 1-2 blocks of wall time.

   - Dropped `await asyncio.sleep(0.5)` in both loops. Same dead-delay rationale #192 killed in hooks.py (CometBFT already blocks on finalisation). Missed then because grep caught `time.sleep` but not `asyncio.sleep`.

   - Fixed `client.register("raptor-seed")` in seed_sage_knowledge.py:336 — same bug l33tdawg fixed in register_agents.py via #199 (the method is `register_agent`, not `register`). Bare except hid it, so raptor-seed identity has never been stamped since day one.

   - Cleaned up bare `except: pass` at hooks.py:205 to match the module's own debug-log pattern (lines 117, 184, 263, 310 all log at debug; that one didn't).

4. Surface cleanup from cross-check against SAGE 6.6.0 SDK source

   Walked every RAPTOR → SDK call site against sage-agent-sdk 6.6.0 source to verify method names, args, and response shapes. Three non-bug cleanups worth folding in since they're on the same surface:

   - Removed dead `SageClient.register()` wrapper in core/sage/client.py (plus its test). Zero callers anywhere in the tree. Its fallback branch was actively misleading — it wrote a memory claiming the agent was registered rather than actually registering on-chain, so anyone who did call it would have a silently-wrong state (registrar appears registered, isn't). `register_agents.py` and `seed_sage_knowledge.py` both go through `AsyncSageClient.register_agent` directly, which is the correct path.

   - Fixed misleading "Wake up consensus" comment on `await client.embed("wake")` in both scripts. embed() hits /v1/embed which is a local ollama roundtrip for vector generation — it does NOT touch CometBFT consensus. The call is still useful (warms the ollama sidecar so the first real embed below doesn't pay cold-model-load), but the comment was claiming a behaviour it doesn't have.

   - Captured `register_agent` return value in both scripts and surface `on_chain_height` in the registration print. Cost: two lines. Benefit: the field itself is the SAGE 6.6.0 wire-format fix l33tdawg landed to resolve the `registered_at` int-vs-string type mismatch, so logging it gives a trivial confirmation that registration hit on-chain (not just the Python-side success return).

Tests

- test_sage_hooks.py: concurrent first-call constructs exactly one SageClient across 16 worker threads; cached-unavailable decision sticks across three consecutive hook calls (no probe-storm).
- test_sage_scripts_common.py: async_memory_exists True-on-results, False-on-empty, False-on-error (with debug log).
- test_sage_client.py: dropped `test_register_no_client` since the method it tested is gone.

58 SAGE tests pass (5 new, 1 removed net).