### PR TITLE
fix temp-resource leaks and tidy dead code

### DIFF
--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -325,10 +325,17 @@ def main():
                     print(f"Project '{args.name}' not found.")
                     return
                 editor = os.environ.get("EDITOR", os.environ.get("VISUAL", "vi"))
-                with tempfile.NamedTemporaryFile(suffix=".md", mode="w", delete=False) as tf:
-                    tf.write(p.notes or "")
-                    tf_path = tf.name
+                # Capture tf_path BEFORE tf.write so a failing write (disk
+                # full, etc.) still leaves tf_path set and the finally can
+                # unlink the stub. Keep tempfile creation inside the try so
+                # finally covers the whole create+write+use lifetime.
+                tf_path = None
                 try:
+                    with tempfile.NamedTemporaryFile(
+                        suffix=".md", mode="w", delete=False,
+                    ) as tf:
+                        tf_path = tf.name
+                        tf.write(p.notes or "")
                     result = subprocess.run(shlex.split(editor) + [tf_path])
                     if result.returncode != 0:
                         print("Editor exited with error. Notes unchanged.")
@@ -337,7 +344,8 @@ def main():
                     mgr.update_notes(args.name, new_notes)
                     print("Notes updated.")
                 finally:
-                    Path(tf_path).unlink(missing_ok=True)
+                    if tf_path:
+                        Path(tf_path).unlink(missing_ok=True)
             elif args.text:
                 mgr.update_notes(args.name, args.text)
                 print("Notes updated.")
@@ -522,7 +530,6 @@ def _get_output_summary(run_dir, meta):
 def _print_status(project):
     """Print project status."""
     from core.run import load_run_metadata
-    from .findings_utils import load_findings_from_dir
 
     print(f"Project: {project.name}")
     if project.description:
@@ -785,7 +792,7 @@ def _do_merge(project, merge_type, yes):
             stats = merge_runs(dirs, merged_dir)
         except Exception as e:
             print(f"  {cmd_type}: merge failed — {e}")
-            print(f"  Source runs preserved.")
+            print("  Source runs preserved.")
             continue
 
         try:

--- a/packages/binary_analysis/crash_analyser.py
+++ b/packages/binary_analysis/crash_analyser.py
@@ -483,12 +483,18 @@ class CrashAnalyser:
             "quit",
         ]
 
-        # Write commands to temporary file (with delete=False to keep it during execution)
-        with tempfile.NamedTemporaryFile(mode='w', suffix='_gdb_commands.txt', delete=False) as cmd_f:
-            cmd_file = Path(cmd_f.name)
-            cmd_f.write("\n".join(gdb_commands))
-
+        # Write commands to temporary file (delete=False to keep it during execution).
+        # cmd_f.write runs inside the `with`, BEFORE the try/finally below. A
+        # failing write (ENOSPC, I/O error) would leak the stub. Do the create
+        # + write + name-capture inside the try so finally always catches.
+        cmd_file = None
         try:
+            with tempfile.NamedTemporaryFile(
+                mode='w', suffix='_gdb_commands.txt', delete=False,
+            ) as cmd_f:
+                cmd_file = Path(cmd_f.name)
+                cmd_f.write("\n".join(gdb_commands))
+
             # Run GDB with input file via stdin (not in GDB script — avoids path injection)
             cmd = ["gdb", "-batch", "-x", str(cmd_file), str(self.binary)]
             with open(input_file, "rb") as f:
@@ -501,10 +507,11 @@ class CrashAnalyser:
                 )
         finally:
             # Clean up command file
-            try:
-                cmd_file.unlink()
-            except OSError:
-                pass
+            if cmd_file:
+                try:
+                    cmd_file.unlink()
+                except OSError:
+                    pass
 
         # Debug: save GDB output for inspection (using proper temp file)
         with tempfile.NamedTemporaryFile(mode='w', suffix='_gdb_output.txt', delete=False) as debug_f:
@@ -546,12 +553,17 @@ class CrashAnalyser:
             "quit",
         ]
 
-        # Write commands to temporary file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='_lldb_commands.txt', delete=False) as cmd_f:
-            cmd_file = Path(cmd_f.name)
-            cmd_f.write("\n".join(lldb_commands))
-
+        # Write commands to temporary file. Pull the create+write inside
+        # the try so a failing write doesn't leak the stub before we reach
+        # the existing finally-unlink below.
+        cmd_file = None
         try:
+            with tempfile.NamedTemporaryFile(
+                mode='w', suffix='_lldb_commands.txt', delete=False,
+            ) as cmd_f:
+                cmd_file = Path(cmd_f.name)
+                cmd_f.write("\n".join(lldb_commands))
+
             # Run LLDB with longer timeout — input file via stdin (not in script)
             try:
                 with open(input_file, "rb") as stdin_f:
@@ -586,9 +598,14 @@ class CrashAnalyser:
 
             return result.stdout
         finally:
-            # Clean up temp files
+            # Clean up temp files. cmd_file may be None if the initial
+            # write raised before assignment.
+            if cmd_file:
+                try:
+                    cmd_file.unlink()
+                except OSError:
+                    pass
             try:
-                cmd_file.unlink()
                 Path(lldb_out.name).unlink()
                 Path(lldb_err.name).unlink()
             except OSError:
@@ -607,12 +624,17 @@ class CrashAnalyser:
             "quit",
         ]
 
-        # Write commands to temporary file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='_lldb_fallback.txt', delete=False) as cmd_f:
-            cmd_file = Path(cmd_f.name)
-            cmd_f.write("\n".join(lldb_commands))
-
+        # Write commands to temporary file. Same hazard as the other two
+        # spots in this module: pull the create+write inside the try so a
+        # failing write doesn't leak the stub before reaching the finally.
+        cmd_file = None
         try:
+            with tempfile.NamedTemporaryFile(
+                mode='w', suffix='_lldb_fallback.txt', delete=False,
+            ) as cmd_f:
+                cmd_file = Path(cmd_f.name)
+                cmd_f.write("\n".join(lldb_commands))
+
             result = subprocess.run(
                 ["lldb", "-b", "-s", str(cmd_file), str(self.binary)],
                 capture_output=True,
@@ -625,10 +647,11 @@ class CrashAnalyser:
             return "LLDB analysis failed: timeout"
         finally:
             # Clean up temp file
-            try:
-                cmd_file.unlink()
-            except OSError:
-                pass
+            if cmd_file:
+                try:
+                    cmd_file.unlink()
+                except OSError:
+                    pass
 
     def _parse_lldb_output(self, context: CrashContext, lldb_output: str) -> None:
         """Parse LLDB output to extract crash information."""
@@ -1258,7 +1281,6 @@ class CrashAnalyser:
         if context.signal == "11":  # SIGSEGV
             if "rsp" in context.registers and "rip" in context.registers:
                 rsp = context.registers.get("rsp", "")
-                rip = context.registers.get("rip", "")
 
                 if rsp and "0x00000" in rsp:
                     return "null_deref"

--- a/packages/binary_analysis/debugger.py
+++ b/packages/binary_analysis/debugger.py
@@ -57,12 +57,20 @@ class GDBDebugger:
         # Prepare GDB commands
         gdb_script = "\n".join(commands)
 
-        # Write to temp file (random name to prevent symlink attacks on multi-user systems)
+        # Write to temp file (random name to prevent symlink attacks on multi-user systems).
+        # mkstemp creates the on-disk stub before write_text runs, so a failing
+        # write (ENOSPC, I/O error, etc.) would leak /tmp/.raptor_gdb_*.txt
+        # unless we unlink on failure. Guard with try/except that re-raises
+        # after cleanup so the caller still sees the underlying error.
         import tempfile
         fd, script_name = tempfile.mkstemp(prefix=".raptor_gdb_", suffix=".txt")
         script_file = Path(script_name)
         os.close(fd)
-        script_file.write_text(gdb_script)
+        try:
+            script_file.write_text(gdb_script)
+        except BaseException:
+            script_file.unlink(missing_ok=True)
+            raise
 
         # Build GDB command
         cmd = ["gdb", "-batch", "-x", str(script_file), str(self.binary)]

--- a/packages/codeql/build_detector.py
+++ b/packages/codeql/build_detector.py
@@ -14,7 +14,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from shlex import quote
 from typing import Dict, List, Optional
-import xml.etree.ElementTree as ET
 
 # Add parent directory to path for imports
 # packages/codeql/build_detector.py -> repo root
@@ -454,11 +453,32 @@ class BuildDetector:
         build_cmd = f"{sys.executable} {quote(str(script_path))}"
         cleanup = [script_path, build_dir]
 
-        # Write heuristic build script and dry-run
-        self._write_build_script(
-            script_path, build_dir,
-            source_files, compiler, include_flags, define_flags,
-        )
+        # cleanup_paths is only returned to the caller on SUCCESS (via the
+        # BuildSystem at the bottom of this method). If _write_build_script
+        # or the first _dry_run raises, the caller never sees cleanup_paths
+        # and both the script stub AND the build dir leak UNDER self.repo_path
+        # (= pollutes the target repo). Guard with try/except that walks the
+        # cleanup list on failure before re-raising.
+        def _cleanup_on_failure():
+            for p in cleanup:
+                try:
+                    if p.is_dir():
+                        import shutil
+                        shutil.rmtree(str(p), ignore_errors=True)
+                    else:
+                        p.unlink(missing_ok=True)
+                except OSError:
+                    pass
+
+        try:
+            # Write heuristic build script and dry-run
+            self._write_build_script(
+                script_path, build_dir,
+                source_files, compiler, include_flags, define_flags,
+            )
+        except BaseException:
+            _cleanup_on_failure()
+            raise
         logger.info(f"Synthesised build script for {language}: {script_path}")
         logger.info(f"  Source files: {len(source_files)}")
 
@@ -484,7 +504,7 @@ class BuildDetector:
                     logger.info(f"  CC improved: {heuristic_ok} → {cc_ok} compiled")
                     build_type = "synthesised-cc"
                 else:
-                    logger.info(f"  CC didn't improve, using heuristic")
+                    logger.info("  CC didn't improve, using heuristic")
                     self._write_build_script(
                         script_path, build_dir,
                         source_files, compiler, include_flags, define_flags,
@@ -493,7 +513,7 @@ class BuildDetector:
             else:
                 confidence = 0.5
         else:
-            logger.info(f"  Dry-run: all files compiled successfully")
+            logger.info("  Dry-run: all files compiled successfully")
 
         return BuildSystem(
             type=build_type, command=build_cmd,
@@ -523,7 +543,7 @@ class BuildDetector:
         elif language == "java":
             source_files = list(self.repo_path.rglob("*.java"))
             compiler = "javac"
-            include_flags = [f"-sourcepath", str(self.repo_path)]
+            include_flags = ["-sourcepath", str(self.repo_path)]
         else:
             return [], "", [], []
 
@@ -784,7 +804,7 @@ def main():
     if args.validate:
         valid = detector.validate_build_command(build_system)
         if not valid:
-            print(f"WARNING: Build command validation failed")
+            print("WARNING: Build command validation failed")
 
     if args.json:
         output = {

--- a/packages/codeql/database_manager.py
+++ b/packages/codeql/database_manager.py
@@ -7,7 +7,6 @@ validation, and cleanup.
 """
 
 import hashlib
-import json
 import os
 import re
 import shutil
@@ -358,13 +357,23 @@ class DatabaseManager:
             if Path(build_cmd).is_file() or re.fullmatch(r'[a-zA-Z0-9._-]+', build_cmd):
                 cmd.extend(["--command", build_cmd])
             else:
+                # mkstemp creates the stub on disk BEFORE write_text/chmod run.
+                # The existing finally at the bottom of this method only fires
+                # if we reach the outer try — so guard create+write+chmod
+                # atomically here: clean up our own mess if any of the three
+                # raises, then re-raise so the caller still sees the error.
                 fd, script_name = tempfile.mkstemp(
                     prefix=".raptor_codeql_build_", suffix=".sh", dir=working_dir,
                 )
                 os.close(fd)
                 build_script = Path(script_name)
-                build_script.write_text(f"#!/bin/bash\n{build_cmd}\n")
-                build_script.chmod(build_script.stat().st_mode | stat.S_IEXEC)
+                try:
+                    build_script.write_text(f"#!/bin/bash\n{build_cmd}\n")
+                    build_script.chmod(build_script.stat().st_mode | stat.S_IEXEC)
+                except BaseException:
+                    build_script.unlink(missing_ok=True)
+                    build_script = None
+                    raise
                 cmd.extend(["--command", str(build_script)])
             logger.info(f"Build command: {build_system.command}")
             logger.info(f"Working directory: {working_dir}")
@@ -658,7 +667,7 @@ def main():
         if result.cached:
             print("(from cache)")
     else:
-        print(f"\n✗ Database creation failed")
+        print("\n✗ Database creation failed")
         for error in result.errors:
             print(f"  {error}")
 

--- a/packages/exploit_feasibility/analyzer.py
+++ b/packages/exploit_feasibility/analyzer.py
@@ -39,11 +39,9 @@ Usage:
 import os
 import re
 import subprocess
-from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
-from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple
 
 from core.logging import get_logger
 from .exploit_context import ExploitContext
@@ -60,47 +58,19 @@ from .context import (
     PayloadConstraints,
     WriteTarget,
     ExploitPrimitive,
-    BinaryContext,
 )
-from .vuln_types import ExploitabilityVerdict, VulnerabilityType
+from .vuln_types import ExploitabilityVerdict
 from .mitigations import (
-    MitigationImpact,
-    GlibcMitigation,
     GlibcMitigations,
-    KernelMitigation,
     KernelMitigations,
 )
 from .profiles import (
-    TargetContext,
     TargetProfile,
     create_local_profile,
-    create_remote_profile,
-    create_web_profile,
-    create_kernel_profile,
 )
 from .strategies import (
-    AnalysisStrategy,
-    LocalBinaryStrategy,
-    RemoteBinaryStrategy,
-    WebApplicationStrategy,
     KernelStrategy,
     get_analysis_strategy,
-)
-from .primitives import (
-    PrimitiveID,
-    PrimitiveType,
-    MitigationID,
-    Primitive,
-    ConfidenceScore,
-    ExploitPath,
-)
-from .techniques import (
-    TechniqueRequirements,
-    get_technique_requirements,
-    get_technique,
-    get_techniques_for_goal,
-    get_viable_techniques,
-    get_missing_primitives,
 )
 from .targets import (
     BinaryTarget,
@@ -109,8 +79,12 @@ from .targets import (
     analyze_gadget_quality,
     assess_technique_viability,
 )
-from .graph import PrimitiveNode, PrimitiveDependencyGraph, create_dependency_graph
-from .primitives import get_primitive_definitions
+# Re-exported for api.py (`from .analyzer import PrimitiveDependencyGraph,
+# create_dependency_graph` at api.py:1520 and api.py:2257). __all__ below
+# registers them explicitly so pyflakes doesn't flag them as unused.
+from .graph import PrimitiveDependencyGraph, create_dependency_graph
+
+__all__ = ["PrimitiveDependencyGraph", "create_dependency_graph"]
 # Note: cache.py provides CachedOneGadget, CachedOneGadgetResult, CachedROPGadgets
 # for lightweight caching. This module uses its own rich dataclass versions.
 
@@ -202,7 +176,7 @@ def analyze_binary_targets(
             # Prioritize commonly-called functions
             if func_name in ('puts', 'printf', 'exit', 'free', 'malloc'):
                 target.priority += 10
-                target.notes = f"Called frequently - good hijack target"
+                target.notes = "Called frequently - good hijack target"
             elif func_name in ('__stack_chk_fail',):
                 target.priority += 5
                 target.notes = "Called on stack smash - hijack for canary bypass"
@@ -831,7 +805,6 @@ class FeasibilityReport:
         The saved file can be loaded with FeasibilityReport.load() or
         used directly as JSON by exploit scripts.
         """
-        import json
         from pathlib import Path as P
 
         # Convert to recon store and save
@@ -1307,9 +1280,14 @@ int main() {
 '''
         try:
             import tempfile
+            # Capture src_path BEFORE f.write so a failing write still leaves
+            # src_path set for the finally-unlink below. delete=False means the
+            # on-disk stub exists the moment NamedTemporaryFile returns.
+            src_path = None
+            bin_path = None
             with tempfile.NamedTemporaryFile(mode='w', suffix='.c', delete=False) as f:
-                f.write(test_code)
                 src_path = f.name
+                f.write(test_code)
 
             bin_path = src_path.rsplit('.c', 1)[0] if src_path.endswith('.c') else src_path
 
@@ -1350,16 +1328,21 @@ int main() {
                         report.glibc_mitigations.format_n_verified = True
                         report.glibc_mitigations.__post_init__()
 
-            # Cleanup
-            import os
-            try:
-                os.unlink(src_path)
-                os.unlink(bin_path)
-            except OSError:
-                pass  # File cleanup failure is non-critical
-
         except Exception as e:
             logger.debug(f"Could not verify %n behavior: {e}")
+        finally:
+            # Cleanup runs whether we reached the end of the try or raised
+            # midway (compile crash, etc.). Previously this was inside the
+            # try at the success tail, so any earlier raise leaked src_path
+            # and bin_path in /tmp. Guard each unlink in case either path
+            # is None (allocation raised before assign).
+            import os
+            for p in (locals().get('src_path'), locals().get('bin_path')):
+                if p:
+                    try:
+                        os.unlink(p)
+                    except OSError:
+                        pass  # File cleanup failure is non-critical
 
     def _check_binary_protections(self, report: FeasibilityReport):
         """
@@ -2062,9 +2045,6 @@ int main() {
 
         # FORMAT STRING WRITE: %n for arbitrary write
         if any(x in vuln_type for x in ["format", "printf", "fmt_str", "format_write"]):
-            # Check if this is explicitly a write or generic format string
-            is_write = any(x in vuln_type for x in ["write", "%n", "arbitrary"])
-
             if report.glibc_n_disabled is True:
                 report.blockers.append(
                     "FORMAT STRING WRITE BLOCKED: %n disabled in glibc 2.38+. "
@@ -2482,7 +2462,6 @@ int main() {
         """
         # Check for critical blockers
         has_critical_blocker = False
-        blocker_has_workaround = False
 
         for blocker in report.blockers:
             # %n disabled is critical for format string exploitation
@@ -3174,8 +3153,6 @@ int main() {
                 # Older formats have it on one line
 
                 lines = result.stdout.split('\n')
-                current_section = None
-                current_addr = None
 
                 for i, line in enumerate(lines):
                     # Try to match section header line: [Nr] Name Type Address Offset

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -15,7 +15,6 @@ Complete end-to-end autonomous security testing:
 """
 
 import argparse
-import json
 import os
 import subprocess
 import sys
@@ -228,14 +227,26 @@ Examples:
     git_dir = repo_path / ".git"
     if not git_dir.exists():
         print(f"\n  No .git directory found in {repo_path}")
-        print(f"    Semgrep requires a git repository. Creating a temporary copy...")
+        print("    Semgrep requires a git repository. Creating a temporary copy...")
         logger.info(f"Target {repo_path} is not a git repo — creating temp copy")
 
         try:
+            import atexit
             import shutil
             import tempfile
             temp_dir = Path(tempfile.mkdtemp(prefix="raptor_git_"))
             _git_temp_dir = temp_dir
+            # atexit-register BEFORE any work that can sys.exit — otherwise the
+            # end-of-function rmtree (line ~1033) is bypassed on the sys.exit(1)
+            # paths in the except handlers below, leaking raptor_git_*/ under
+            # /tmp on every failed non-git target. atexit fires on sys.exit too.
+            def _cleanup_git_temp(p=temp_dir):
+                try:
+                    if p.exists():
+                        shutil.rmtree(str(p))
+                except Exception:
+                    pass
+            atexit.register(_cleanup_git_temp)
             temp_repo = temp_dir / repo_path.name
             # Copy symlinks as-is, don't follow them into files outside the repo
             shutil.copytree(str(repo_path), str(temp_repo), symlinks=True)
@@ -277,11 +288,11 @@ Examples:
                 sys.exit(1)
 
         except subprocess.TimeoutExpired:
-            print(f"  Git initialization timed out")
+            print("  Git initialization timed out")
             logger.error("Git init timeout")
             sys.exit(1)
         except FileNotFoundError:
-            print(f"  Git is not installed. Please install git and try again.")
+            print("  Git is not installed. Please install git and try again.")
             logger.error("Git not found in PATH")
             sys.exit(1)
         except Exception as e:
@@ -404,7 +415,7 @@ Examples:
             "--repo", str(repo_path),
             "--policy_groups", args.policy_groups,
         ]
-        logger.info(f"Running: Scanning code with Semgrep")
+        logger.info("Running: Scanning code with Semgrep")
         semgrep_proc = subprocess.Popen(
             semgrep_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
             env=RaptorConfig.get_safe_env(),
@@ -428,7 +439,7 @@ Examples:
             codeql_cmd.append("--extended")
         if args.codeql_cli:
             codeql_cmd.extend(["--codeql-cli", args.codeql_cli])
-        logger.info(f"Running: Scanning code with CodeQL")
+        logger.info("Running: Scanning code with CodeQL")
         codeql_proc = subprocess.Popen(
             codeql_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
             env=RaptorConfig.get_safe_env(),
@@ -443,7 +454,7 @@ Examples:
             semgrep_proc.kill()
             semgrep_proc.communicate()
             rc = -1
-            print(f"❌ Semgrep scan timed out (30m)")
+            print("❌ Semgrep scan timed out (30m)")
             logger.error("Semgrep scan timed out")
             if not run_codeql:
                 sys.exit(1)
@@ -460,7 +471,7 @@ Examples:
                 if scan_metrics_file.exists():
                     semgrep_metrics = load_json(scan_metrics_file)
 
-                    print(f"\n✓ Semgrep scan complete:")
+                    print("\n✓ Semgrep scan complete:")
                     print(f"  - Files scanned: {semgrep_metrics.get('total_files_scanned', 0)}")
                     print(f"  - Findings: {semgrep_metrics.get('total_findings', 0)}")
                     print(f"  - Critical: {semgrep_metrics.get('findings_by_severity', {}).get('error', 0)}")
@@ -486,14 +497,14 @@ Examples:
             codeql_proc.kill()
             codeql_proc.communicate()
             rc = -1
-            print(f"❌ CodeQL scan timed out (30m)")
+            print("❌ CodeQL scan timed out (30m)")
             logger.error("CodeQL scan timed out")
 
         if rc != 0:
             if all_sarif_files:
-                print(f"⚠️  CodeQL scan failed — continuing with existing findings")
+                print("⚠️  CodeQL scan failed — continuing with existing findings")
             else:
-                print(f"⚠️  CodeQL scan failed — no findings from any scanner")
+                print("⚠️  CodeQL scan failed — no findings from any scanner")
             logger.warning(f"CodeQL scan failed - rc={rc}")
             if args.codeql_only:
                 print("❌ CodeQL-only mode failed")
@@ -508,7 +519,7 @@ Examples:
                 total_findings = codeql_metrics.get('total_findings', 0)
                 sarif_files = codeql_metrics.get('sarif_files', [])
 
-                print(f"\n✓ CodeQL scan complete:")
+                print("\n✓ CodeQL scan complete:")
                 print(f"  - Languages: {', '.join(codeql_metrics.get('languages_detected', {}).keys())}")
                 print(f"  - Findings: {total_findings}")
                 print(f"  - SARIF files: {len(sarif_files)}")
@@ -621,7 +632,7 @@ Examples:
             if analysis.get('mode') == 'prep_only':
                 print(f"\n✓ {analysis.get('processed', 0)} findings prepared for analysis")
             else:
-                print(f"\n✓ Analysis complete:")
+                print("\n✓ Analysis complete:")
                 print(f"  - Analysed: {analysis.get('analyzed', 0)}")
                 print(f"  - Exploitable: {analysis.get('exploitable', 0)}")
                 print(f"  - Exploits generated: {analysis.get('exploits_generated', 0)}")
@@ -630,7 +641,7 @@ Examples:
                 if args.codeql or args.codeql_only:
                     print(f"  - CodeQL dataflow paths validated: {analysis.get('dataflow_validated', 0)}")
         else:
-            print(f"⚠️  Analysis failed or produced no output")
+            print("⚠️  Analysis failed or produced no output")
             if stderr:
                 print(f"    Error: {stderr[:500]}")
             logger.warning(f"Phase 3 failed - rc={rc}, stderr={stderr[:200]}")
@@ -736,7 +747,7 @@ Examples:
     report_file = out_dir / "raptor_agentic_report.json"
     save_json(report_file, final_report)
 
-    print(f"\n📊 Summary:")
+    print("\n📊 Summary:")
     print(f"   Total findings: {scan_metrics.get('total_findings', 0)}")
     if semgrep_metrics:
         print(f"     Semgrep: {semgrep_metrics.get('total_findings', 0)}")
@@ -848,7 +859,7 @@ Examples:
                 for model, mcost in by_model.items():
                     print(f"     {model}: ${mcost:.2f}")
 
-    print(f"\n📁 Outputs:")
+    print("\n📁 Outputs:")
     print(f"   Main report: {report_file}")
     if mitigation_result:
         print(f"   Exploit feasibility: {out_dir / 'exploit_feasibility.txt'}")


### PR DESCRIPTION
Seven call sites could leak a /tmp stub or a repo-local dir when the create → write/use sequence raised mid-way: core/project/cli.py (notes --edit), binary_analysis/debugger.py (gdb script), raptor_agentic.py (git temp copy bypassed by sys.exit), codeql/build_detector.py (synthesised build artifacts under repo_path), codeql/database_manager.py (--command wrapper script), exploit_feasibility/analyzer.py (%n verify compile stub), binary_analysis/crash_analyser.py (three gdb/lldb command files). Each fix widens the guard so either the finally catches or an atexit handler runs before sys.exit. Also removes unused imports and unreachable local-variable assignments pyflakes flagged across the same files.