### PR TITLE
Set Codeql `--build-mode=none` through `--no-build` in raptor codeql

### DIFF
--- a/packages/codeql/agent.py
+++ b/packages/codeql/agent.py
@@ -164,7 +164,8 @@ class CodeQLAgent:
         build_commands: Optional[Dict[str, str]] = None,
         force_db_creation: bool = False,
         use_extended: bool = False,
-        min_files: int = 3
+        min_files: int = 3,
+        no_build_langs: Optional[set] = None,
     ) -> CodeQLWorkflowResult:
         """
         Run complete autonomous CodeQL analysis workflow.
@@ -232,7 +233,10 @@ class CodeQLAgent:
 
             language_build_map = {}
             for lang in detected.keys():
-                if build_commands and lang in build_commands:
+                if no_build_langs and lang in no_build_langs:
+                    logger.info(f"{lang}: Using no-build mode (--no-build)")
+                    language_build_map[lang] = self.build_detector.generate_no_build_config(lang)
+                elif build_commands and lang in build_commands:
                     # Use custom build command
                     logger.info(f"{lang}: Using custom build command")
                     language_build_map[lang] = BuildSystem(

--- a/packages/codeql/database_manager.py
+++ b/packages/codeql/database_manager.py
@@ -352,8 +352,10 @@ class DatabaseManager:
         # CodeQL splits --command on whitespace without shell interpretation,
         # so shell operators (&&, ||, ;, |) break. Wrap in a script unless
         # the command is already a path to an executable (e.g. synthesised builds).
+        # For no-build mode, pass --build-mode=none so CodeQL doesn't invoke autobuild.
         build_script = None
-        if build_system and build_system.command:
+        has_build_cmd = build_system and build_system.command and build_system.type != "no-build"
+        if has_build_cmd:
             build_cmd = build_system.command
             if Path(build_cmd).is_file() or re.fullmatch(r'[a-zA-Z0-9._-]+', build_cmd):
                 cmd.extend(["--command", build_cmd])
@@ -369,6 +371,8 @@ class DatabaseManager:
             logger.info(f"Build command: {build_system.command}")
             logger.info(f"Working directory: {working_dir}")
         else:
+            # Explicitly pass --build-mode=none so CodeQL doesn't fall back to autobuild
+            cmd.append("--build-mode=none")
             logger.info("No build command (interpreted language or no-build mode)")
 
         logger.info(f"Executing: {' '.join(cmd)}")

--- a/raptor_codeql.py
+++ b/raptor_codeql.py
@@ -84,6 +84,8 @@ def run_autonomous_workflow(args):
             sys.exit(1)
         build_commands = {languages[0]: args.build_command}
 
+    no_build_langs = set(languages) if args.no_build and languages else (set(languages) if args.no_build else set())
+
     # PHASE 1: CodeQL Scanning
     logger.info("\n" + "=" * 70)
     logger.info("PHASE 1: CODEQL SCANNING")
@@ -100,7 +102,8 @@ def run_autonomous_workflow(args):
         build_commands=build_commands,
         force_db_creation=args.force,
         use_extended=args.extended,
-        min_files=args.min_files
+        min_files=args.min_files,
+        no_build_langs=no_build_langs if no_build_langs else None,
     )
 
     if not scan_result.success:
@@ -274,6 +277,7 @@ Examples:
     parser.add_argument("--codeql-cli", help="Path to CodeQL CLI")
     parser.add_argument("--scan-only", action="store_true", help="Scan only (skip autonomous analysis)")
     parser.add_argument("--max-findings", type=int, default=20, help="Max findings to analyze")
+    parser.add_argument("--no-build", action="store_true", help="Skip build step — use CodeQL no-build mode (all languages, or just those in --languages)")
     parser.add_argument("--no-visualizations", action="store_true", help="Disable dataflow visualizations")
     parser.add_argument("--trust-repo", action="store_true",
                         help="Trust the target repo's config and skip safety checks "


### PR DESCRIPTION
Fairly self explanatory - sometimes codeql will fail when building a database from building code (not so much an issue for languages like python, but if c/c++ fail then it's annoying). One way through is to allow codeql to have `build-mode: none` set through command line. This slightly clunky PR aims to do just that by adding the option and exposing it to the agent in control. 