### PR TITLE
bump: SAGE sidecar to 6.6.4 — pragma + tx-serialization + tag-ctx fixes

### DIFF
--- a/docker-compose.sage.yml
+++ b/docker-compose.sage.yml
@@ -40,7 +40,7 @@ services:
       - OLLAMA_HOST=http://ollama:11434
 
   sage:
-    image: ghcr.io/l33tdawg/sage:6.6.4
+    image: ghcr.io/l33tdawg/sage:6.6.5
     ports:
       - "8090:8080"
     volumes:

--- a/docker-compose.sage.yml
+++ b/docker-compose.sage.yml
@@ -40,7 +40,7 @@ services:
       - OLLAMA_HOST=http://ollama:11434
 
   sage:
-    image: ghcr.io/l33tdawg/sage:6.6.0
+    image: ghcr.io/l33tdawg/sage:6.6.4
     ports:
       - "8090:8080"
     volumes:


### PR DESCRIPTION
## Summary

Bumps `docker-compose.sage.yml` from `ghcr.io/l33tdawg/sage:6.6.0` → `6.6.4`. One-line change; no raptor code touched.

## What 6.6.4 fixes

Three SAGE-side bugs surfaced by `libexec/raptor-sage-setup`'s concurrent `asyncio.gather(Semaphore(8))` proposes, plus a registration-telemetry cleanup:

1. **SQLite DSN pragmas silently ignored** — `modernc.org/sqlite` needs `_pragma=journal_mode(WAL)` syntax; the `_journal_mode=WAL` form has been silently dropped since the driver switch, so the DB has been running in rollback-journal mode with \`busy_timeout=0\` all along. That's the actual root cause behind the 6.6.1 symptom (which added retries at a different layer). Fixed at the DSN.
2. **Six store methods bypassed `writeMu`** — `SetTags` + 5 others opened transactions via raw `s.db.BeginTx`, racing writeExecContext/RunInTx writes. With busy_timeout=0, every race surfaced as instant SQLITE_BUSY. Fixed via a `beginTxLocked` helper.
3. **Post-commit SetTags ran on `r.Context()`** — client disconnect (SIGKILL, timeout) between `broadcast_tx_commit` returning and tag write left untagged orphan rows that broke tag-based idempotency. Fixed with `context.WithTimeout(context.Background(), 10s)`.
4. **First-register returned `on_chain_height: None`** — `handleAgentRegister` used `broadcastTx` (sync, no height); only the idempotent `already_registered` branch surfaced it. Fixed with `broadcastTxCommitWithHeight`.

## Impact for raptor-sage-setup

Full retest of grokjc's PR #190 checklist against `sage:6.6.4` — see https://github.com/gadievron/raptor/pull/190 for details:

| Test | `sage:6.6.0` | `sage:6.6.4` |
|---|---|---|
| Run-2 seed idempotency | 82/87 re-proposed (5 skipped) | **0/87 re-proposed (87 skipped)** |
| Run-2 agent idempotency | 12/16 re-proposed (1 skipped, 3 partial) | **0/16 re-proposed (16 skipped)** |
| Server SQLITE_BUSY count | 396 | **0** |
| Tag-set failures | 197 | **0** |
| `raptor-seed` first-register height | \`None\` | **`13`** |
| Partial-failure recovery orphans | 8 untagged rows | **0** |

## Test plan

- [x] `docker compose -f docker-compose.sage.yml up -d` with the bump pulls `6.6.4`, health endpoint returns `{"status":"healthy","version":"6.6.4"}`.
- [x] `libexec/raptor-sage-setup` run twice: Run 1 stores 87+16, Run 2 skips all 103.
- [x] `--force` re-proposes 87+16.
- [x] SIGKILL mid-seed, re-run without `--force`: only the missing entries proposed, final count exactly 87.
- [x] `core/sage/tests/test_sage_hooks.py`: 17 passed (thread-safe singleton regressions).

Upstream: https://github.com/l33tdawg/sage/releases/tag/v6.6.4