### PR TITLE
SMT: Stage E LLM-callable path-feasibility helper + parser hardening

### DIFF
--- a/.claude/skills/exploitability-validation/stage-e-feasibility.md
+++ b/.claude/skills/exploitability-validation/stage-e-feasibility.md
@@ -147,6 +147,45 @@ arithmetic), CWE-193 (off-by-one), CWE-476 (null deref).
 
 The heuristic `note` field is always preserved alongside `smt_feasibility` — compare both when they conflict. When `smt_feasibility.feasible` is `false`, prefer the SMT verdict for the `chain_breaks` entry.
 
+### [E-3c] Optional: SMT path-condition verification
+
+When you've read the source for a finding and formed a hypothesis about whether the visible guards actually block exploitation — e.g. a CWE-190 where `count < MAX_RECORDS` looks protective but `count * sizeof(record)` might wrap on 32-bit unsigned arithmetic — you can ask Z3 to verify whether the path conditions are jointly satisfiable:
+
+```bash
+libexec/raptor-smt-validate-path --profile uint32 \
+  'alloc_size == count * 16' \
+  'alloc_size < 0x8000' \
+  'count > 0x10000000' \
+  'count < 0x40000000'
+```
+
+Each positional argument is one predicate that must hold for the path to be reachable. If a guard is bypassed (must be FALSE on the dangerous path), pre-negate it manually: write `ptr == NULL`, not `!(ptr != NULL)`.
+
+**Tip — finding the *exploit* witness, not the trivial one:** Z3 returns the smallest satisfying assignment by default, which is often `count=0`, `length=0`, etc. — mathematically correct but not the bug. Add a lower-bound condition that forces the dangerous range. For the CWE-190 ALLOC pattern above, adding `'count > 0x10000000'` pushes Z3 into the wraparound region and yields a witness like `count=0x30000001, alloc_size=16` (the actual exploit input).
+
+`--profile` matches the C type width in play. Common choices:
+
+- `uint32` — C `int` / `unsigned int` arithmetic (CWE-190 32-bit wraparound)
+- `uint64` — `size_t` / `uint64_t` / pointer arithmetic (default if omitted)
+- `int32` — signed `int` where overflow UB matters
+- Also: `int64`, `uint16`, `int16`, `uint8`, `int8`
+
+Output is JSON to stdout:
+
+- `feasible: true` — the path is reachable; `model` shows concrete witness values to use as PoC candidates.
+- `feasible: false` — conditions are mutually exclusive; add to `chain_breaks` as "SMT: path infeasible" with the `unsatisfied` list as evidence.
+- `feasible: null` — Z3 unavailable, conditions unparseable, or solver timeout; fall back to your own C-semantics reasoning.
+
+**When to use:** CWE-190 (integer overflow / wraparound), CWE-120/122/787/125 (buffer-size arithmetic), CWE-193 (off-by-one), CWE-476 (null-deref guards) — anywhere "this guard looks protective, is it actually?" applies.
+
+**When to skip:** if `analyze_binary` returned `smt_available: false`, z3-solver isn't installed and this tool would just return `feasible: null` — skip the call and rely on your own reasoning. Also skip when the finding already carries `smt_feasibility` from the CodeQL pre-check (don't redo work).
+
+**Conditions the parser rejects** (these land in `unknown` and the verdict will lean toward `null`): function calls (`strlen(input)`), type casts (`(uint32_t)x`), struct/pointer access (`obj.field`, `s->len`), array indexing (`arr[0]`), pointer deref (`*p`), unary NOT (`~`), XOR (`^`), division (`/`), modulo (`%`), ternary (`?:`). Stick to bare variables, integer/hex literals, `NULL`, and the operators `+ - * | & << >>` plus relational `< <= > >= == !=`. If you have to express something more complex, simplify it first or omit it — a `null` verdict from a contaminated condition set is worse than no SMT call at all.
+
+**Profile mismatch is a silent failure mode.** If you analyse `unsigned int` arithmetic under `uint64`, Z3 misses 32-bit wraparound and the `feasible: false` verdict you get is wrong (the path IS reachable via 32-bit wrap). Match the profile to the dominant C type's width. The reasoning string spells out what was used (`"feasible (32-bit unsigned): ..."`) — if it doesn't match the vuln's real C type, treat the verdict as suspect.
+
+The verdict is only as trustworthy as the conditions you extract — a `false` verdict on an incomplete condition set is a hint, not proof.
+
 ### [E-4] Update Finding
 
 Attach feasibility analysis to finding:

--- a/.claude/skills/exploitability-validation/stage-e-feasibility.md
+++ b/.claude/skills/exploitability-validation/stage-e-feasibility.md
@@ -184,6 +184,8 @@ Output is JSON to stdout:
 
 **Profile mismatch is a silent failure mode.** If you analyse `unsigned int` arithmetic under `uint64`, Z3 misses 32-bit wraparound and the `feasible: false` verdict you get is wrong (the path IS reachable via 32-bit wrap). Match the profile to the dominant C type's width. The reasoning string spells out what was used (`"feasible (32-bit unsigned): ..."`) — if it doesn't match the vuln's real C type, treat the verdict as suspect.
 
+**Iterate on `unknown`.** If the verdict comes back with a non-empty `unknown` bucket, the parser couldn't encode those forms. Re-read the source, re-express the rejected forms in parser-compatible shape (introduce a helper variable, drop the cast, split a complex condition, replace a function call with the predicate it computes), and re-invoke. One refinement pass usually closes the gap. If a second pass still has unknowns, the conditions are genuinely outside the bitvector fragment — stop iterating and fall back to qualitative reasoning rather than chasing further.
+
 The verdict is only as trustworthy as the conditions you extract — a `false` verdict on an incomplete condition set is a hint, not proof.
 
 ### [E-4] Update Finding

--- a/libexec/raptor-smt-validate-path
+++ b/libexec/raptor-smt-validate-path
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Stage E SMT path-feasibility entry point.
+
+Usage:
+  raptor-smt-validate-path [--profile <name>] <condition> [<condition> ...]
+  raptor-smt-validate-path [--profile <name>] --stdin
+
+Each ``<condition>`` is a single predicate string such as ``"size > 0"``
+or ``"alloc_size == count * 16"``.  Conditions must hold simultaneously
+for the path to be reachable; if a guard was bypassed (the condition
+must be FALSE for the dangerous path), pre-negate it manually
+(``ptr != NULL`` bypassed → ``ptr == NULL``).
+
+When ``--stdin`` is given, conditions are read as a JSON array.  Each
+element may be either a bare string or a ``{"text": ..., "negated":
+true}`` object — useful when conditions need explicit negation flags
+(e.g. piped from a tool that already extracts them).
+
+``--profile`` selects bitvector width and signedness:
+
+  uint64  64-bit unsigned (default — size_t / pointer arithmetic)
+  int64   64-bit signed
+  uint32  32-bit unsigned (CWE-190 32-bit wraparound paths)
+  int32   32-bit signed (signed-overflow UB reasoning)
+  uint16  int16  uint8  int8
+
+Output: JSON to stdout with keys
+
+  feasible        true | false | null
+  reasoning       human-readable explanation
+  model           concrete witness values (when feasible=true)
+  satisfied       conditions that are tautologies
+  unsatisfied     conditions in the unsat core (when feasible=false)
+  unknown         conditions the parser could not encode
+  smt_available   true if z3-solver is loaded
+
+Exit code: always 0 on a well-formed invocation.  A ``feasible: false``
+or ``feasible: null`` verdict is reported via the JSON body, not via
+exit status — the LLM caller inspects ``feasible``.
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# libexec/<this> -> repo root
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from packages.exploit_feasibility.smt_path import validate_path
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        prog="raptor-smt-validate-path",
+        description="SMT path-condition feasibility check for Stage E.",
+    )
+    p.add_argument(
+        "--profile",
+        default="uint64",
+        help="Bitvector profile name (default: uint64).",
+    )
+    p.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read conditions from stdin as a JSON array instead of "
+             "positional args.",
+    )
+    p.add_argument(
+        "conditions",
+        nargs="*",
+        help="Path-condition strings (each a single predicate).",
+    )
+    args = p.parse_args()
+
+    if args.stdin:
+        if args.conditions:
+            print(
+                "raptor-smt-validate-path: --stdin and positional conditions "
+                "are mutually exclusive",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            payload = json.load(sys.stdin)
+        except json.JSONDecodeError as e:
+            print(f"raptor-smt-validate-path: invalid JSON on stdin: {e}", file=sys.stderr)
+            return 2
+        if not isinstance(payload, list):
+            print(
+                "raptor-smt-validate-path: --stdin payload must be a JSON array",
+                file=sys.stderr,
+            )
+            return 2
+        conditions = payload
+    else:
+        if not args.conditions:
+            p.print_usage(sys.stderr)
+            print(
+                "raptor-smt-validate-path: at least one condition required "
+                "(or use --stdin)",
+                file=sys.stderr,
+            )
+            return 2
+        conditions = list(args.conditions)
+
+    try:
+        result = validate_path(conditions, profile=args.profile)
+    except (TypeError, ValueError) as e:
+        print(f"raptor-smt-validate-path: {e}", file=sys.stderr)
+        return 2
+
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -32,23 +32,51 @@ conditions.  Pass ``BV_C_UINT32`` to detect 32-bit unsigned wraparound
 (CWE-190); pass ``BV_C_INT32`` for signed-integer path conditions.
 Pre-made profiles are importable from ``core.smt_solver``.
 
-Known limitations:
-  - Negative integer literals (e.g. ``!= -1``) go to the unknown list.
-  - Unary NOT (``~``) is not supported; conditions using it fall through
-    to unknown.
-  - No operator precedence — expressions are evaluated strictly
-    left-to-right.  Mixed-operator expressions (e.g. ``a + b * c``) are
-    rejected to avoid mis-encoding; full precedence support is planned
-    for a follow-up.
-  - Bitmask form (``flags & MASK == val``) requires both ``MASK`` and
-    ``val`` to be integer literals.
-  - Profile-level signedness conflates two concerns: comparison
+Conditions rejected to the ``unknown`` bucket (rather than silently
+mis-encoded):
+
+  - **Operators outside the supported set.**  Accepted: ``+ - * |``,
+    relational ``< <= > >= == !=``, shifts ``<< >>``, bitmask
+    ``&`` (only in the ``flags & MASK == VAL`` form).  Rejected:
+    unary NOT (``~``), XOR (``^``), division (``/``), modulo (``%``),
+    ternary (``? :``), single-equals assignment, chained relational
+    (``0 < x < 100``).  Anything else goes to ``unknown`` via the
+    full-input-consumed sanity check.
+  - **C-syntax constructs.**  Function calls (``strlen(input)``),
+    type casts (``(uint32_t)x``), struct/pointer access (``obj.field``,
+    ``s->len``), array indexing (``arr[0]``), pointer dereference
+    (``*p``), ``sizeof``.  Any token containing ``(``, ``)``, ``.``,
+    ``->``, ``[``, ``]`` triggers rejection.
+  - **Negative integer literals** (e.g. ``!= -1``) — write the
+    bit-pattern in hex instead (``!= 0xFFFFFFFF`` at uint32).
+  - **Leading-zero decimals** (e.g. ``01234``) — ambiguous with C
+    octal; use hex or remove the leading zero.
+  - **Literals outside the profile's width range** — ``0x100`` at
+    uint8 would silently wrap to 0 in z3; we reject so the caller
+    knows the profile was wrong for this literal.
+
+Other limitations (verdict still trustworthy, but with caveats):
+
+  - **No operator precedence** — expressions are evaluated strictly
+    left-to-right.  Mixed-operator expressions (e.g. ``a + b * c``)
+    are rejected to avoid mis-encoding; full precedence support is
+    planned for a follow-up.  ``a * b * c`` and ``a + b + c`` are
+    fine (associativity preserves correctness).
+  - **Bitmask form** requires both ``MASK`` and ``VAL`` to be integer
+    literals; variables on either side go to ``unknown``.
+  - **Profile-level signedness conflates** two concerns: comparison
     signedness (``<``/``<=``/``>``/``>=`` routed through ``lt``/``le``)
     AND ``>>`` arithmetic-vs-logical shift.  In real C these can
     decouple (``(int)x >> 1`` is always arithmetic regardless of the
-    comparison's signedness).  Single-profile-per-path is the first-cut
-    design; per-variable typing is the next step when a real case
-    demands it.
+    comparison's signedness).  Single-profile-per-path is the
+    first-cut design; per-variable typing is the next step when a
+    real case demands it.
+  - **Z3 picks the smallest satisfying witness by default**, which is
+    often the trivial assignment (``x = 0``).  To find an *exploit*
+    witness, add a lower-bound condition that forces the dangerous
+    range (e.g. ``count > 0x10000000`` for CWE-190 wraparound at
+    uint32).  Will be addressed by Z3 Optimize integration in a
+    follow-up.
 
 Integration: packages/codeql/dataflow_validator.py :: DataflowValidator
 """
@@ -120,6 +148,29 @@ _TOKEN_RE = re.compile(
 )
 
 
+def _parse_literal_value(tok: str, profile: BVProfile) -> Optional[int]:
+    """Validate and convert a literal token to int, or None if invalid.
+
+    Centralised so atom-position literals and bitmask-form literals both
+    reject the same things:
+
+    - Out-of-range for profile width (would silently wrap in z3.BitVecVal).
+    - Leading-zero decimals (octal in C, ambiguous if interpreted as base-10).
+    - Anything that isn't a clean hex or decimal literal.
+    """
+    if _HEX_RE.match(tok):
+        v = int(tok, 16)
+    elif _INT_RE.match(tok):
+        if len(tok) > 1 and tok[0] == "0":
+            return None  # ambiguous with C octal
+        v = int(tok)
+    else:
+        return None
+    if v >= (1 << profile.width):
+        return None
+    return v
+
+
 def _parse_expr(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Optional[Any]:
     """Parse an arithmetic expression into a Z3 bitvector at the given profile.
 
@@ -137,6 +188,13 @@ def _parse_expr(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Opti
     if not tokens:
         return None
 
+    # Reject if any non-whitespace character was silently dropped by the
+    # tokeniser — characters like '~' (NOT), '^' (XOR), '/', '%' aren't in
+    # the token regex and would otherwise vanish, producing wrong answers
+    # (e.g. "~mask == 0xFF" mis-encoded as "mask == 0xFF").
+    if "".join(tokens) != re.sub(r"\s+", "", text):
+        return None
+
     # Reject mixed-operator expressions to avoid silent mis-encoding due to
     # the lack of operator precedence (currently strictly left-to-right).
     if {'+', '-'} & set(tokens[1::2]) and {'*', '>>', '<<', '|'} & set(tokens[1::2]):
@@ -145,10 +203,9 @@ def _parse_expr(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Opti
     def atom(tok: str) -> Optional[Any]:
         if _NULL_RE.match(tok):
             return _mk_val(0, profile.width)
-        if _HEX_RE.match(tok):
-            return _mk_val(int(tok, 16), profile.width)
-        if _INT_RE.match(tok):
-            return _mk_val(int(tok), profile.width)
+        if _HEX_RE.match(tok) or _INT_RE.match(tok):
+            v = _parse_literal_value(tok, profile)
+            return None if v is None else _mk_val(v, profile.width)
         if _IDENT_RE.match(tok):
             if tok.lower() not in vars_:
                 vars_[tok.lower()] = _mk_var(tok.lower(), profile.width)
@@ -217,8 +274,16 @@ def _parse_condition(text: str, vars_: Dict[str, Any], *, profile: BVProfile) ->
         lhs = _parse_expr(m.group(1).strip(), vars_, profile=profile)
         if lhs is None:
             return None
-        masked = lhs & _mk_val(int(m.group(2), 0), profile.width)
-        rhs = _mk_val(int(m.group(4), 0), profile.width)
+        # Mask and rhs literals go through the same validation as atom-level
+        # literals — width range and leading-zero ambiguity must be rejected
+        # the same way, otherwise the bitmask path silently wraps or trips
+        # ValueError on octal-style tokens.
+        mask_val = _parse_literal_value(m.group(2), profile)
+        rhs_val = _parse_literal_value(m.group(4), profile)
+        if mask_val is None or rhs_val is None:
+            return None
+        masked = lhs & _mk_val(mask_val, profile.width)
+        rhs = _mk_val(rhs_val, profile.width)
         return (masked == rhs) if m.group(3) == '==' else (masked != rhs)
 
     # Relational: lhs OP rhs
@@ -312,16 +377,21 @@ def check_path_feasibility(
             continue
 
         final_expr = z3.Not(expr) if cond.negated else expr
+        # Display form reflects what was actually asserted — without this,
+        # an unsat-core listing for a negated condition shows the un-negated
+        # text and confuses readers ("ptr != NULL ⊥ ptr > 0" looks
+        # consistent until you realise we asserted ptr == 0 not ptr != NULL).
+        display = f"NOT ({cond.text})" if cond.negated else cond.text
 
         # Quick individual check: is this condition alone satisfiable?
         with _scoped(solver):
             solver.add(z3.Not(final_expr))
             if solver.check() == z3.unsat:
                 # Condition is a tautology — trivially satisfied
-                satisfied.append(cond.text)
+                satisfied.append(display)
                 continue
 
-        pending.append((cond.text, final_expr))
+        pending.append((display, final_expr))
 
     if not pending:
         if unknown:

--- a/packages/codeql/tests/test_smt_path_validator.py
+++ b/packages/codeql/tests/test_smt_path_validator.py
@@ -115,6 +115,131 @@ class TestFeasibility:
         assert r.feasible is None
 
     @_requires_z3
+    @pytest.mark.parametrize("expr", [
+        "~mask == 0xFFFFFFFF",  # unary NOT silently dropped → would become "mask == ..."
+        "a ^ b == 0",            # XOR silently dropped → "a b == 0" (orphan caught)
+        "a / b > 0",             # division silently dropped
+        "a % 16 == 0",           # modulo silently dropped
+        "x | ~y == 0",           # NOT inside expression
+        "p ? q : r == 0",        # ternary silently dropped
+    ])
+    def test_silently_dropped_chars_go_to_unknown(self, expr):
+        """The tokeniser only matches a fixed set of operator characters;
+        anything outside that set ('~', '^', '/', '%', '?', ':') would
+        otherwise vanish from the token stream and produce a wrong
+        encoding.  The full-input-consumed sanity check rejects these."""
+        r = check_path_feasibility([PathCondition(expr, step_index=0)])
+        assert expr in r.unknown, (
+            f"silently-dropped chars in {expr!r} were not rejected; "
+            f"this is the same class of bug as the operator-precedence "
+            f"silent mis-encoding caught in PR #206."
+        )
+
+    @_requires_z3
+    def test_literal_too_wide_for_profile_goes_to_unknown(self):
+        """``x == 0x100`` at uint8 would silently wrap to ``x == 0`` since
+        Z3's BitVecVal truncates modulo width.  The verdict ``feasible:
+        true with x=0`` would mislead the caller about what was checked.
+        Refuse instead — the profile is wrong for this literal."""
+        from core.smt_solver import BVProfile
+        r = check_path_feasibility(
+            [PathCondition("x == 0x100", step_index=0)],
+            profile=BVProfile(width=8, signed=False),
+        )
+        assert "x == 0x100" in r.unknown
+
+    @_requires_z3
+    def test_literal_at_width_boundary_fits(self):
+        """``x == 0xFF`` at uint8 is exactly the max — must still be accepted."""
+        from core.smt_solver import BVProfile
+        r = check_path_feasibility(
+            [PathCondition("x == 0xFF", step_index=0)],
+            profile=BVProfile(width=8, signed=False),
+        )
+        assert r.feasible is True
+        assert r.model["x"] == 0xFF
+
+    @_requires_z3
+    def test_leading_zero_decimal_goes_to_unknown(self):
+        """``01234`` looks decimal but in C is octal (=668).  Accepting as
+        base-10 silently mis-encodes; reject and let the caller use hex
+        instead."""
+        r = check_path_feasibility([PathCondition("x == 01234", step_index=0)])
+        assert "x == 01234" in r.unknown
+
+    @_requires_z3
+    def test_bare_zero_decimal_accepted(self):
+        """``0`` (single digit) is unambiguous — must still parse."""
+        r = check_path_feasibility([PathCondition("x == 0", step_index=0)])
+        assert r.feasible is True
+        assert r.model.get("x") == 0
+
+    @_requires_z3
+    def test_bitmask_mask_too_wide_for_profile_goes_to_unknown(self):
+        """The bitmask form (``flags & MASK == VAL``) extracts MASK and
+        VAL via its own regex rather than going through ``atom()`` — the
+        same width-range check must apply or 0x100 at uint8 silently
+        wraps to 0, producing a false tautology."""
+        from core.smt_solver import BVProfile
+        r = check_path_feasibility(
+            [PathCondition("flags & 0x100 == 0", step_index=0)],
+            profile=BVProfile(width=8, signed=False),
+        )
+        assert "flags & 0x100 == 0" in r.unknown
+
+    @_requires_z3
+    def test_bitmask_leading_zero_mask_goes_to_unknown(self):
+        """Leading-zero literals in the bitmask path used to crash
+        ``int(tok, 0)`` with a Python ValueError on tokens like '010';
+        now they're rejected cleanly to ``unknown``."""
+        r = check_path_feasibility([PathCondition("flags & 010 == 0", step_index=0)])
+        assert "flags & 010 == 0" in r.unknown
+
+    @_requires_z3
+    def test_bitmask_leading_zero_rhs_goes_to_unknown(self):
+        r = check_path_feasibility([PathCondition("flags & 0xff == 010", step_index=0)])
+        assert "flags & 0xff == 010" in r.unknown
+
+    @_requires_z3
+    def test_bitmask_normal_form_still_works(self):
+        """Regression check: the bitmask-path validation tightening
+        must not break valid bitmask conditions."""
+        r = check_path_feasibility([PathCondition("flags & 0xff == 0", step_index=0)])
+        assert r.feasible is True
+        assert (r.model.get("flags", 0) & 0xff) == 0
+
+
+class TestNegatedDisplay:
+    """When a condition has ``negated=True``, downstream display strings
+    (in ``satisfied`` / ``unsatisfied`` / unsat-core reasoning) must
+    reflect what was actually asserted.  Showing the un-negated text
+    confuses readers — ``"ptr != NULL ⊥ ptr > 0"`` looks consistent
+    until you realise the solver actually asserted ``ptr == 0``."""
+
+    @_requires_z3
+    def test_negated_condition_shown_with_NOT_prefix_in_unsat_core(self):
+        r = check_path_feasibility([
+            PathCondition("ptr != NULL", step_index=0, negated=True),  # asserts ptr == 0
+            PathCondition("ptr > 0", step_index=1),
+        ])
+        assert r.feasible is False
+        # The display reflects what was asserted, not the original text.
+        assert "NOT (ptr != NULL)" in r.unsatisfied
+        # And the un-negated text should NOT appear (it's misleading).
+        assert "ptr != NULL" not in r.unsatisfied
+
+    @_requires_z3
+    def test_non_negated_condition_displayed_as_written(self):
+        """Unmodified conditions still appear verbatim."""
+        r = check_path_feasibility([
+            PathCondition("x > 100", step_index=0),
+            PathCondition("x < 50", step_index=1),
+        ])
+        assert r.feasible is False
+        assert "x > 100" in r.unsatisfied
+        assert "x < 50" in r.unsatisfied
+
+    @_requires_z3
     def test_negated_condition(self):
         """negated=True means the guard was bypassed (condition is false on path)."""
         # ptr != NULL with negated=True means ptr IS NULL on this path

--- a/packages/exploit_feasibility/smt_path.py
+++ b/packages/exploit_feasibility/smt_path.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""SMT path-condition feasibility analysis for Stage E.
+
+Public entry point used during exploitability validation when the LLM
+has extracted branch conditions or a guard predicate from source code
+and wants to know whether they can all be satisfied simultaneously —
+i.e. is the suspected vulnerable path actually reachable, or do the
+visible guards make it dead?
+
+The function takes simple inputs (condition strings, profile-by-name)
+and returns a JSON-serialisable verdict.  Stage E typically invokes it
+indirectly via ``libexec/raptor-smt-validate-path`` rather than calling
+this module directly.
+
+Internally a thin wrapper over ``packages.codeql.smt_path_validator
+.check_path_feasibility``; it reuses the parser, profile machinery,
+and unsat-core explanation already proven in CodeQL dataflow validation.
+
+Z3 is an optional soft dependency.  When ``z3-solver`` is not installed,
+``validate_path`` returns ``{"feasible": null, "smt_available": false,
+…}`` so the caller falls back to LLM reasoning unchanged.
+
+Example::
+
+    from packages.exploit_feasibility.smt_path import validate_path
+    import json
+
+    result = validate_path(
+        ["alloc_size == count * 16",
+         "alloc_size < 0x8000",
+         "count > 0x10000000",
+         "count < 0x40000000"],
+        profile="uint32",
+    )
+    print(json.dumps(result, indent=2))
+    # → feasible: true, model: {count: 0x30000001, alloc_size: 16}
+    #   a wraparound exploit witness
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence, Union
+
+from core.smt_solver import (
+    BVProfile,
+    BV_C_INT8,
+    BV_C_INT16,
+    BV_C_INT32,
+    BV_C_INT64,
+    BV_C_UINT8,
+    BV_C_UINT16,
+    BV_C_UINT32,
+    BV_C_UINT64,
+)
+from packages.codeql.smt_path_validator import (
+    PathCondition,
+    PathSMTResult,
+    check_path_feasibility,
+)
+
+
+# Profile name → BVProfile.  Names match the ``stdint.h`` C types so a
+# Stage E LLM that's just identified an `unsigned int` operand can
+# spell ``profile="uint32"`` without thinking about bitwidth maths.
+_PROFILE_BY_NAME: Dict[str, BVProfile] = {
+    "uint8":  BV_C_UINT8,
+    "int8":   BV_C_INT8,
+    "uint16": BV_C_UINT16,
+    "int16":  BV_C_INT16,
+    "uint32": BV_C_UINT32,
+    "int32":  BV_C_INT32,
+    "uint64": BV_C_UINT64,
+    "int64":  BV_C_INT64,
+}
+
+
+def _resolve_profile(profile: Union[BVProfile, str]) -> BVProfile:
+    if isinstance(profile, BVProfile):
+        return profile
+    if isinstance(profile, str):
+        try:
+            return _PROFILE_BY_NAME[profile]
+        except KeyError:
+            raise ValueError(
+                f"unknown profile name {profile!r}; "
+                f"expected one of {sorted(_PROFILE_BY_NAME)} "
+                f"or a BVProfile instance"
+            )
+    raise TypeError(
+        f"profile must be BVProfile or str, got {type(profile).__name__}"
+    )
+
+
+def _normalise_conditions(
+    conditions: Sequence[Union[str, Dict[str, Any]]],
+) -> List[PathCondition]:
+    """Accept either bare strings or ``{text, negated}`` dicts."""
+    out: List[PathCondition] = []
+    for i, c in enumerate(conditions):
+        if isinstance(c, str):
+            out.append(PathCondition(text=c, step_index=i, negated=False))
+            continue
+        if isinstance(c, dict):
+            text = c.get("text") or c.get("condition")
+            if not text:
+                raise ValueError(
+                    f"condition dict at index {i} is missing 'text' "
+                    f"(or legacy 'condition'): {c!r}"
+                )
+            out.append(PathCondition(
+                text=str(text),
+                step_index=int(c.get("step_index", i)),
+                negated=bool(c.get("negated", False)),
+            ))
+            continue
+        raise TypeError(
+            f"condition at index {i} must be str or dict, got "
+            f"{type(c).__name__}"
+        )
+    return out
+
+
+def validate_path(
+    conditions: Sequence[Union[str, Dict[str, Any]]],
+    profile: Union[BVProfile, str] = "uint64",
+) -> Dict[str, Any]:
+    """Check whether a set of path conditions are jointly satisfiable.
+
+    Args:
+        conditions: Each element is either:
+
+            - A condition string like ``"size > 0"`` or
+              ``"count * 16 < max_alloc"``.  See
+              ``smt_path_validator`` docstring for accepted forms.
+            - A dict ``{"text": str, "negated": bool}`` when the
+              condition must be FALSE for the path to proceed (e.g.
+              a check that was bypassed).  ``"condition"`` is also
+              accepted as the text key for backwards compatibility.
+
+        profile: ``BVProfile`` object, or one of the shorthand names:
+            ``"uint8"`` / ``"int8"`` / ``"uint16"`` / ``"int16"`` /
+            ``"uint32"`` / ``"int32"`` / ``"uint64"`` / ``"int64"``.
+            Defaults to ``"uint64"`` (matches size_t / pointer
+            reasoning, the most common case for path-condition
+            analysis).
+
+    Returns:
+        JSON-serialisable dict with keys:
+
+        - ``feasible``: ``True`` if Z3 found a satisfying assignment,
+          ``False`` if the conditions are mutually exclusive, ``None``
+          when Z3 is unavailable, all conditions are unparseable, or
+          Z3 timed out.
+        - ``reasoning``: human-readable explanation including the
+          bitvector semantics used (e.g. ``"feasible (32-bit
+          unsigned): ..."``).
+        - ``model``: ``{var_name: int}`` mapping with concrete witness
+          values when ``feasible=True``; empty otherwise.
+        - ``satisfied``: tautology conditions (always true regardless
+          of variables).
+        - ``unsatisfied``: when ``feasible=False``, the subset Z3
+          identified as the conflict (from the unsat core).
+        - ``unknown``: conditions the parser could not encode — bubbled
+          back so the caller can reason about them heuristically.
+        - ``smt_available``: whether ``z3-solver`` was loaded.
+    """
+    bv = _resolve_profile(profile)
+    paths = _normalise_conditions(conditions)
+    smt_result: PathSMTResult = check_path_feasibility(paths, profile=bv)
+
+    return {
+        "feasible": smt_result.feasible,
+        "reasoning": smt_result.reasoning,
+        "model": dict(smt_result.model),
+        "satisfied": list(smt_result.satisfied),
+        "unsatisfied": list(smt_result.unsatisfied),
+        "unknown": list(smt_result.unknown),
+        "smt_available": smt_result.smt_available,
+    }

--- a/packages/exploit_feasibility/tests/test_smt_path.py
+++ b/packages/exploit_feasibility/tests/test_smt_path.py
@@ -1,0 +1,310 @@
+"""Tests for packages.exploit_feasibility.smt_path — Stage E LLM-callable
+wrapper for path-condition feasibility analysis."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# packages/exploit_feasibility/tests/ -> repo root
+sys.path.insert(0, str(Path(__file__).parents[3]))
+
+from core.smt_solver import (
+    BVProfile,
+    BV_C_INT8,
+    BV_C_INT16,
+    BV_C_INT32,
+    BV_C_INT64,
+    BV_C_UINT8,
+    BV_C_UINT16,
+    BV_C_UINT32,
+    BV_C_UINT64,
+    z3_available,
+)
+from packages.exploit_feasibility.smt_path import (
+    _normalise_conditions,
+    _resolve_profile,
+    validate_path,
+)
+
+
+_requires_z3 = pytest.mark.skipif(
+    not z3_available(),
+    reason="z3-solver not installed",
+)
+
+
+class TestProfileResolution:
+    """``profile`` accepts either a BVProfile or a stdint-style name."""
+
+    @pytest.mark.parametrize("name,expected", [
+        ("uint8",  BV_C_UINT8),
+        ("int8",   BV_C_INT8),
+        ("uint16", BV_C_UINT16),
+        ("int16",  BV_C_INT16),
+        ("uint32", BV_C_UINT32),
+        ("int32",  BV_C_INT32),
+        ("uint64", BV_C_UINT64),
+        ("int64",  BV_C_INT64),
+    ])
+    def test_each_shorthand_resolves(self, name, expected):
+        assert _resolve_profile(name) == expected
+
+    def test_bvprofile_object_passes_through(self):
+        custom = BVProfile(width=24, signed=False)
+        assert _resolve_profile(custom) is custom
+
+    def test_unknown_name_raises(self):
+        with pytest.raises(ValueError, match="unknown profile name"):
+            _resolve_profile("size_t")
+
+    def test_wrong_type_raises(self):
+        with pytest.raises(TypeError, match="must be BVProfile or str"):
+            _resolve_profile(64)  # type: ignore[arg-type]
+
+
+class TestConditionNormalisation:
+    """``conditions`` accepts strings or {text, negated} dicts mixed."""
+
+    def test_bare_strings(self):
+        out = _normalise_conditions(["a > 0", "b < 10"])
+        assert len(out) == 2
+        assert out[0].text == "a > 0"
+        assert out[0].negated is False
+        assert out[0].step_index == 0
+        assert out[1].step_index == 1
+
+    def test_dict_form(self):
+        out = _normalise_conditions([{"text": "a > 0", "negated": True}])
+        assert out[0].text == "a > 0"
+        assert out[0].negated is True
+
+    def test_dict_legacy_condition_key(self):
+        """``{"condition": ...}`` accepted for backwards compatibility with
+        the dataflow_validator extraction schema."""
+        out = _normalise_conditions([{"condition": "a > 0"}])
+        assert out[0].text == "a > 0"
+        assert out[0].negated is False
+
+    def test_dict_explicit_step_index(self):
+        out = _normalise_conditions([{"text": "a > 0", "step_index": 7}])
+        assert out[0].step_index == 7
+
+    def test_mixed_strings_and_dicts(self):
+        out = _normalise_conditions([
+            "a > 0",
+            {"text": "b == 0", "negated": True},
+            "c < 10",
+        ])
+        assert [(c.text, c.negated) for c in out] == [
+            ("a > 0", False),
+            ("b == 0", True),
+            ("c < 10", False),
+        ]
+
+    def test_missing_text_raises(self):
+        with pytest.raises(ValueError, match="missing 'text'"):
+            _normalise_conditions([{"negated": True}])
+
+    def test_wrong_element_type_raises(self):
+        with pytest.raises(TypeError, match="must be str or dict"):
+            _normalise_conditions([42])  # type: ignore[list-item]
+
+
+class TestNoZ3:
+    """When z3 is missing, ``validate_path`` returns a degraded verdict
+    rather than crashing.  The Stage E LLM checks ``smt_available``
+    before relying on ``feasible``."""
+
+    def test_returns_smt_unavailable(self):
+        with patch(
+            "packages.codeql.smt_path_validator._z3_available",
+            return_value=False,
+        ):
+            r = validate_path(["a > 0"])
+        assert r["feasible"] is None
+        assert r["smt_available"] is False
+        assert "a > 0" in r["unknown"]
+
+
+class TestEndToEnd:
+    """Round-trip through ``check_path_feasibility``."""
+
+    @_requires_z3
+    def test_satisfiable_returns_witness(self):
+        r = validate_path(["x > 0", "x < 100"])
+        assert r["feasible"] is True
+        assert 0 < r["model"]["x"] < 100
+        assert r["smt_available"] is True
+
+    @_requires_z3
+    def test_unsatisfiable_names_conflict(self):
+        r = validate_path(["x > 100", "x < 50"])
+        assert r["feasible"] is False
+        # unsat core should mention at least one of the conflicting forms
+        assert any(
+            "x > 100" in c or "x < 50" in c
+            for c in r["unsatisfied"]
+        )
+        assert r["model"] == {}
+
+    # NOTE: end-to-end SMT correctness (parametric width, wraparound
+    # detection) is covered exhaustively by test_smt_path_validator.py.
+    # Wrapper tests below exercise wrapper-layer concerns specifically:
+    # default-kwarg handling, BVProfile passthrough, dict-vs-string input,
+    # JSON serialisation.
+
+    @_requires_z3
+    def test_negated_condition_means_guard_bypassed(self):
+        """``negated=True`` on ``ptr != NULL`` forces ``ptr == NULL`` —
+        the path is a null-deref, contradicted by ``ptr > 0``."""
+        r = validate_path([
+            {"text": "ptr != NULL", "negated": True},
+            "ptr > 0",
+        ])
+        assert r["feasible"] is False
+
+    @_requires_z3
+    def test_default_profile_is_uint64(self):
+        """Default ``"uint64"`` lets large addresses fit unchanged."""
+        r = validate_path(["addr == 0xDEADBEEFCAFEBABE"])
+        assert r["feasible"] is True
+        assert r["model"]["addr"] == 0xDEADBEEFCAFEBABE
+
+    @_requires_z3
+    def test_bvprofile_object_accepted(self):
+        """Caller can pass a BVProfile directly for non-stdint widths."""
+        r = validate_path(
+            ["x == 0x7FFF"],
+            profile=BVProfile(width=16, signed=False),
+        )
+        assert r["feasible"] is True
+        assert r["model"]["x"] == 0x7FFF
+
+    @_requires_z3
+    def test_int32_signed_comparison(self):
+        """Profile signedness routes through to relational operators."""
+        # Under int32 (signed), ``x < 0`` is satisfiable (x is negative).
+        r = validate_path(["x < 0"], profile="int32")
+        assert r["feasible"] is True
+
+    @_requires_z3
+    def test_unparseable_condition_in_unknown(self):
+        """Conditions the parser can't encode bubble up to the LLM."""
+        r = validate_path([
+            "size > 0",                              # parseable
+            "validate(ptr) == strlen(input)",        # function calls — not parseable
+        ])
+        assert "validate(ptr) == strlen(input)" in r["unknown"]
+
+
+class TestJSONRoundTrip:
+    """Result must be JSON-serialisable without further conversion —
+    Stage E invokes ``validate_path`` from a python3 -c snippet that
+    pipes the result through ``json.dumps``."""
+
+    @_requires_z3
+    def test_sat_result_serialises(self):
+        r = validate_path(["x == 42"])
+        text = json.dumps(r)
+        rehydrated = json.loads(text)
+        assert rehydrated["feasible"] is True
+        assert rehydrated["model"] == {"x": 42}
+
+    @_requires_z3
+    def test_unsat_result_serialises(self):
+        r = validate_path(["x > 10", "x < 5"])
+        text = json.dumps(r)
+        rehydrated = json.loads(text)
+        assert rehydrated["feasible"] is False
+        assert rehydrated["model"] == {}
+
+    def test_no_z3_result_serialises(self):
+        with patch(
+            "packages.codeql.smt_path_validator._z3_available",
+            return_value=False,
+        ):
+            r = validate_path(["x > 0"])
+        text = json.dumps(r)
+        rehydrated = json.loads(text)
+        assert rehydrated["feasible"] is None
+        assert rehydrated["smt_available"] is False
+
+
+class TestCli:
+    """``libexec/raptor-smt-validate-path`` is the entry point Stage E
+    actually invokes.  The LLM passes condition strings as positional
+    args (or a JSON array via stdin); the script prints a JSON verdict
+    to stdout.  No Python visible to the LLM."""
+
+    @staticmethod
+    def _script() -> Path:
+        # packages/exploit_feasibility/tests/ → repo root → libexec/
+        return Path(__file__).resolve().parents[3] / "libexec" / "raptor-smt-validate-path"
+
+    def _run(self, *args, stdin: str = None):
+        import subprocess
+        return subprocess.run(
+            [sys.executable, str(self._script()), *args],
+            input=stdin,
+            capture_output=True,
+            text=True,
+        )
+
+    @_requires_z3
+    def test_positional_conditions_satisfiable(self):
+        r = self._run("--profile", "uint32",
+                      "alloc_size == count * 16",
+                      "alloc_size < 0x8000",
+                      "count > 0x10000000",
+                      "count < 0x40000000")
+        assert r.returncode == 0, r.stderr
+        verdict = json.loads(r.stdout)
+        assert verdict["feasible"] is True
+        assert "count" in verdict["model"]
+
+    @_requires_z3
+    def test_positional_conditions_unsatisfiable(self):
+        r = self._run("x > 100", "x < 50")
+        assert r.returncode == 0
+        verdict = json.loads(r.stdout)
+        assert verdict["feasible"] is False
+
+    @_requires_z3
+    def test_stdin_json_array(self):
+        payload = json.dumps([
+            {"text": "ptr != NULL", "negated": True},
+            "ptr > 0",
+        ])
+        r = self._run("--stdin", "--profile", "uint64", stdin=payload)
+        assert r.returncode == 0, r.stderr
+        verdict = json.loads(r.stdout)
+        # negated 'ptr != NULL' = ptr == 0, which contradicts ptr > 0
+        assert verdict["feasible"] is False
+
+    def test_unknown_profile_exits_2(self):
+        r = self._run("--profile", "size_t", "x > 0")
+        assert r.returncode == 2
+        assert "unknown profile name" in r.stderr
+
+    def test_no_conditions_exits_2(self):
+        r = self._run()
+        assert r.returncode == 2
+        assert "at least one condition" in r.stderr
+
+    def test_stdin_and_positional_conflict(self):
+        r = self._run("--stdin", "x > 0", stdin="[]")
+        assert r.returncode == 2
+        assert "mutually exclusive" in r.stderr
+
+    def test_stdin_invalid_json(self):
+        r = self._run("--stdin", stdin="not json")
+        assert r.returncode == 2
+        assert "invalid JSON" in r.stderr
+
+    def test_stdin_non_array(self):
+        r = self._run("--stdin", stdin='{"not": "an array"}')
+        assert r.returncode == 2
+        assert "must be a JSON array" in r.stderr


### PR DESCRIPTION
Adds raptor-smt-validate-path, a libexec entry point Stage E invokes when the LLM has read source for a finding and wants Z3 to verify whether the visible guards actually block exploitation. The script takes condition strings as positional args (or a JSON array via --stdin), accepts profile by stdint-style name (uint32, int32, uint64, ...), and emits a JSON verdict to stdout. No Python visible to the LLM.

Underlying: a thin Python wrapper (validate_path) over the existing check_path_feasibility, with profile-name resolution, condition normalisation, and JSON-serialisable output. Stage E's stage-e-feasibility.md skill prompt gains an [E-3c] section documenting when to invoke, profile choice guidance, output interpretation, and the trivial-witness gotcha (Z3 picks the smallest satisfying assignment by default — add a lower-bound condition to force the dangerous range).

Adversarial testing of the wrapper surfaced four classes of latent parser bug, all silent encoding mismatches that produced wrong verdicts. The path-condition parser now rejects them cleanly to the unknown bucket:

  - Characters silently dropped by the tokeniser (~, ^, /, %, ?:, =) used to vanish from the token stream and produce mis-encoded expressions; now caught by a full-input-consumed sanity check.
  - Literals exceeding the profile's bitvector width (e.g. 0x100 at uint8) silently wrapped to zero in z3.BitVecVal, producing fake tautologies; now rejected.
  - Leading-zero decimal literals (01234 — octal in C) were interpreted as base-10, or crashed with a Python ValueError when encountered in the bitmask path; now rejected uniformly.
  - The bitmask path (flags & MASK == VAL) had its own literal extraction that bypassed atom-level validation; literal handling is now hoisted into a shared _parse_literal_value helper used by both paths.

Negated conditions in the unsatisfied / unsat-core display now read "NOT (ptr != NULL)" rather than "ptr != NULL" — the previous form showed the original text even though the solver asserted the negation, confusing readers.

Validator docstring's "Known limitations" section rewritten to accurately describe what's rejected and why.

36 wrapper tests + 18 regression tests for the parser hardening. Full repo suite: 2084 passed.