### PR TITLE
SMT one-gadget: harden parser against silent literal mis-encoding

### DIFF
--- a/packages/exploit_feasibility/smt_onegadget.py
+++ b/packages/exploit_feasibility/smt_onegadget.py
@@ -96,6 +96,30 @@ _HEX_LIT_RE = re.compile(r'0x[0-9a-f]+', re.IGNORECASE)
 _DEC_LIT_RE = re.compile(r'\d+')
 
 
+def _parse_literal_value(tok: str, profile: BVProfile) -> Optional[int]:
+    """Validate and convert a literal token to int, or None if invalid.
+
+    Centralised so atom-position literals and bitmask-form literals both
+    reject the same things:
+
+    - Out-of-range for profile width (would silently wrap in z3.BitVecVal,
+      e.g. 0x100 at uint8 → 0, producing a misleading verdict).
+    - Leading-zero decimals (octal in C, ambiguous if interpreted as base-10).
+    - Anything that isn't a clean hex or decimal literal.
+    """
+    if _HEX_LIT_RE.fullmatch(tok):
+        v = int(tok, 16)
+    elif _DEC_LIT_RE.fullmatch(tok):
+        if len(tok) > 1 and tok[0] == "0":
+            return None  # ambiguous with C octal
+        v = int(tok)
+    else:
+        return None
+    if v >= (1 << profile.width):
+        return None
+    return v
+
+
 def _reg_var(name: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Optional[Any]:
     name = name.lower()
     if name not in _X86_64_REGS:
@@ -130,10 +154,9 @@ def _parse_operand(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> O
     t = text.strip()
     if t.upper() == "NULL":
         return _mk_val(0, profile.width)
-    if _HEX_LIT_RE.fullmatch(t):
-        return _mk_val(int(t, 16), profile.width)
-    if _DEC_LIT_RE.fullmatch(t):
-        return _mk_val(int(t), profile.width)
+    if _HEX_LIT_RE.fullmatch(t) or _DEC_LIT_RE.fullmatch(t):
+        v = _parse_literal_value(t, profile)
+        return None if v is None else _mk_val(v, profile.width)
 
     mem_m = _MEM_RE.fullmatch(t)
     if mem_m:
@@ -192,8 +215,16 @@ def _parse_atom(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Opti
         lhs = _parse_operand(m.group(1).strip(), vars_, profile=profile)
         if lhs is None:
             return None
-        masked = lhs & _mk_val(int(m.group(2), 0), profile.width)
-        rhs    = _mk_val(int(m.group(4), 0), profile.width)
+        # Mask and rhs literals go through the same validation as atom-level
+        # literals — width range and leading-zero ambiguity must be rejected
+        # the same way, otherwise the bitmask path silently wraps or trips
+        # ValueError on octal-style tokens.
+        mask_val = _parse_literal_value(m.group(2), profile)
+        rhs_val = _parse_literal_value(m.group(4), profile)
+        if mask_val is None or rhs_val is None:
+            return None
+        masked = lhs & _mk_val(mask_val, profile.width)
+        rhs    = _mk_val(rhs_val, profile.width)
         return (masked == rhs) if m.group(3) == "==" else (masked != rhs)
 
     # Generic equality / inequality:  <lhs> (==|!=) <rhs>

--- a/packages/exploit_feasibility/tests/test_smt_onegadget.py
+++ b/packages/exploit_feasibility/tests/test_smt_onegadget.py
@@ -469,3 +469,108 @@ class TestParametricProfile:
         _, r = ranked[0]
         assert r.feasible is True
         assert r.model.get("rax") == 0xCAFEBABE
+
+
+class TestLiteralValidation:
+    """Parser hardening — same bugs we fixed in smt_path_validator apply
+    here, since both encoders parse hex/decimal literals and feed them
+    to ``z3.BitVecVal`` (which silently wraps out-of-range values) and
+    use ``int(tok, 0)`` in the bitmask path (which crashes on tokens
+    like '010' that look like Python octal)."""
+
+    @_requires_z3
+    def test_hex_literal_too_wide_for_profile_goes_to_unknown(self):
+        """``rax == 0x100`` at uint8 would silently wrap to ``rax == 0``
+        (z3.BitVecVal truncates modulo width); reject so the verdict
+        doesn't lie about what was checked."""
+        from core.smt_solver import BVProfile
+        g = OneGadget(0x100, ["rax == 0x100"])
+        r = check_onegadget(g, profile=BVProfile(width=8, signed=False))
+        assert "rax == 0x100" in r.unknown
+
+    @_requires_z3
+    def test_hex_literal_at_width_boundary_fits(self):
+        """``rax == 0xFF`` at uint8 is exactly the max — must still parse."""
+        from core.smt_solver import BVProfile
+        g = OneGadget(0x100, ["rax == 0xFF"])
+        r = check_onegadget(g, profile=BVProfile(width=8, signed=False))
+        assert r.feasible is True
+        assert r.model["rax"] == 0xFF
+
+    @_requires_z3
+    def test_leading_zero_decimal_goes_to_unknown(self):
+        """``010`` is C octal (8); accepting as base-10 mis-encodes."""
+        g = OneGadget(0x100, ["rax == 010"])
+        r = check_onegadget(g)
+        assert "rax == 010" in r.unknown
+
+    @_requires_z3
+    def test_bare_zero_decimal_accepted(self):
+        """``0`` (single digit) is unambiguous — must still parse."""
+        g = OneGadget(0x100, ["rax == 0"])
+        r = check_onegadget(g)
+        assert r.feasible is True
+        assert r.model.get("rax") == 0
+
+    @_requires_z3
+    def test_bitmask_mask_too_wide_for_profile_goes_to_unknown(self):
+        """The bitmask form (``rax & MASK == VAL``) used to extract MASK
+        and VAL via raw ``int(tok, 0)`` calls that bypassed atom-level
+        validation; both literals must now go through the shared
+        validator."""
+        from core.smt_solver import BVProfile
+        g = OneGadget(0x100, ["rax & 0x100 == 0"])
+        r = check_onegadget(g, profile=BVProfile(width=8, signed=False))
+        assert "rax & 0x100 == 0" in r.unknown
+
+    @_requires_z3
+    def test_bitmask_leading_zero_mask_goes_to_unknown(self):
+        """Leading-zero literals in the bitmask path used to crash with
+        a Python ValueError on tokens like '010' (Python's int(x, 0)
+        rejects modern octal); now rejected cleanly to unknown."""
+        g = OneGadget(0x100, ["rax & 010 == 0"])
+        r = check_onegadget(g)
+        assert "rax & 010 == 0" in r.unknown
+
+    @_requires_z3
+    def test_bitmask_leading_zero_rhs_goes_to_unknown(self):
+        g = OneGadget(0x100, ["rax & 0xff == 010"])
+        r = check_onegadget(g)
+        assert "rax & 0xff == 010" in r.unknown
+
+    @_requires_z3
+    def test_bitmask_normal_form_still_works(self):
+        """Regression: stack-alignment idiom must still parse."""
+        g = OneGadget(0x100, ["rsp & 0xf == 0"])
+        r = check_onegadget(g, {"rsp": 0x7FFFFFF0})
+        assert r.feasible is True
+        assert "rsp & 0xf == 0" in r.satisfied
+
+    @_requires_z3
+    def test_disjunction_with_overflow_branch_is_unknown(self):
+        """If any branch of a disjunction has a width-overflow literal,
+        the whole constraint goes to unknown — _parse_constraint short-
+        circuits on the first unparseable atom."""
+        from core.smt_solver import BVProfile
+        constraint = "rax == 0 || rbx == 0x100"
+        g = OneGadget(0x100, [constraint])
+        r = check_onegadget(g, profile=BVProfile(width=8, signed=False))
+        assert constraint in r.unknown
+
+    @_requires_z3
+    def test_conjunction_with_overflow_branch_is_unknown(self):
+        """Same shape as disjunction: any unparseable atom kills the line."""
+        from core.smt_solver import BVProfile
+        constraint = "rax == 0 && rbx == 0x100"
+        g = OneGadget(0x100, [constraint])
+        r = check_onegadget(g, profile=BVProfile(width=8, signed=False))
+        assert constraint in r.unknown
+
+    @_requires_z3
+    def test_single_char_r_rejected(self):
+        """``r`` alone isn't a valid x86_64 register name (the regex requires
+        ``r`` followed by at least one alphanumeric); without the gating
+        it would silently become a free bitvec variable."""
+        g = OneGadget(0x100, ["r == 0"])
+        r = check_onegadget(g)
+        assert "r == 0" in r.unknown


### PR DESCRIPTION
Mirrors the parser hardening landed for smt_path_validator (PR #225). Three of the same bug classes were latent here:

  - Hex literals exceeding the profile's bitvector width (e.g. 0x100 at uint8) silently wrapped to zero in z3.BitVecVal, producing misleading verdicts.
  - Leading-zero decimal literals (010 — octal in C) were interpreted as base-10, or crashed with a Python ValueError when encountered in the bitmask path's int(tok, 0) call.
  - The bitmask form (rax & MASK == VAL) had its own literal extraction that bypassed atom-level validation; literal handling is now hoisted into a shared _parse_literal_value helper used by both paths, identical in shape to the smt_path_validator version.

Silent character drop (also fixed in #225) is naturally absent here — smt_onegadget uses regex-based whole-form matching rather than a generic tokeniser, so unsupported characters fail the relevant fullmatch and don't sneak through.

11 new regression tests across:

  - Each rejection class plus boundary cases (0xFF at uint8 still accepted, normal bitmask still parses, default profile unchanged).
  - Disjunction / conjunction with one width-overflow branch falls to unknown (whole-line semantics preserved).
  - Single-char "r" rejected by the existing reg-gating, locked in.

Full repo suite: 2106 passed.