### PR TITLE
cvss: accept temporal/environmental extensions on v3.1 vectors

### DIFF
--- a/packages/cvss/calculator.py
+++ b/packages/cvss/calculator.py
@@ -36,20 +36,44 @@ _SEVERITY = [
 _VECTOR_RE = re.compile(
     r"^CVSS:3\.[01]/"
     r"AV:[NALP]/AC:[LH]/PR:[NLH]/UI:[NR]/S:[UC]/"
-    r"C:[NLH]/I:[NLH]/A:[NLH]$"
+    r"C:[NLH]/I:[NLH]/A:[NLH]"
+    # Optional temporal (E, RL, RC) and environmental
+    # (CR/IR/AR, MAV/MAC/MPR/MUI/MS, MC/MI/MA) segments. Real-world
+    # OSV records routinely include these — Log4Shell ships
+    # ``…/A:H/E:H`` — and rejecting them silently degraded scoring to
+    # ``None``. Each extension is ``METRIC:VALUE`` where the metric is
+    # alphabetic and the value is a single token; we accept any such
+    # suffix. ``compute_base_score`` ignores keys it doesn't recognise.
+    r"(?:/[A-Za-z]+:[A-Za-z0-9]+)*"
+    r"$"
 )
 
 
 def validate_vector(vector: str) -> bool:
-    """Check if a CVSS v3.1 vector string is well-formed."""
+    """Check if a CVSS v3.1 vector string is well-formed.
+
+    Accepts base-only vectors and vectors carrying optional temporal /
+    environmental extensions (``/E:H``, ``/RL:O``, ``/CR:H`` …). Only
+    the base segments contribute to the numeric score; the extensions
+    are tolerated, not consumed.
+    """
     return bool(_VECTOR_RE.match(vector))
 
 
 def parse_vector(vector: str) -> dict:
     """Parse a CVSS v3.1 vector string into a metric dict.
 
-    Returns dict like {"AV": "N", "AC": "L", "PR": "N", ...}.
+    Returns dict like ``{"AV": "N", "AC": "L", "PR": "N", ...}``.
     Raises ValueError if the vector is malformed.
+
+    The eight base metrics (``AV``, ``AC``, ``PR``, ``UI``, ``S``,
+    ``C``, ``I``, ``A``) are always present on a valid vector. When
+    the input carries optional temporal (``E``, ``RL``, ``RC``) or
+    environmental (``CR``, ``IR``, ``AR``, ``MAV``…``MA``) extensions,
+    those keys are also returned in the dict — callers iterating
+    ``items()`` will see them. ``compute_base_score`` looks up each
+    base metric by name and ignores extras, so extension keys never
+    influence the numeric output.
     """
     if not validate_vector(vector):
         raise ValueError(f"Invalid CVSS v3.1 vector: {vector}")

--- a/packages/cvss/tests/test_calculator.py
+++ b/packages/cvss/tests/test_calculator.py
@@ -19,6 +19,23 @@ class TestValidateVector:
     def test_valid_v30(self):
         assert validate_vector("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
 
+    def test_valid_with_temporal_suffix(self):
+        # Log4Shell's OSV record carries `/E:H` after the base metrics.
+        assert validate_vector(
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:H"
+        )
+
+    def test_valid_with_full_temporal_chain(self):
+        assert validate_vector(
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:H/RL:O/RC:C"
+        )
+
+    def test_valid_with_environmental_metrics(self):
+        assert validate_vector(
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+            "/CR:H/IR:H/AR:H/MAV:L"
+        )
+
     def test_invalid_prefix(self):
         assert not validate_vector("CVSS:2.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
 
@@ -44,6 +61,23 @@ class TestParseVector:
         with pytest.raises(ValueError):
             parse_vector("garbage")
 
+    def test_parse_with_temporal_suffix(self):
+        # OSV records routinely ship CVSS vectors with a temporal-score
+        # tail (e.g. Log4Shell's `/E:H`). The parser should accept the
+        # full vector and surface the extension keys alongside base.
+        m = parse_vector(
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:H"
+        )
+        assert m["AV"] == "N" and m["S"] == "C"
+        assert m["E"] == "H"
+
+    def test_parse_with_environmental_metrics(self):
+        m = parse_vector(
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+            "/CR:H/IR:H/AR:H"
+        )
+        assert m["CR"] == "H"
+
 
 class TestComputeBaseScore:
     """Test against known CVSS v3.1 scores from NVD.
@@ -54,6 +88,15 @@ class TestComputeBaseScore:
     def test_critical_9_8(self):
         # CVE-2021-44228 (Log4Shell) - AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H = 10.0
         score, label = compute_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H")
+        assert score == 10.0
+        assert label == "Critical"
+
+    def test_temporal_suffix_does_not_affect_base_score(self):
+        # The base score is computed only from the eight base metrics;
+        # a `/E:H` tail must be ignored, returning the same 10.0.
+        score, label = compute_base_score(
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:H"
+        )
         assert score == 10.0
         assert label == "Critical"
 


### PR DESCRIPTION
OSV records routinely ship vectors with temporal-score suffixes (Log4Shell's CVSS:3.1/.../A:H/E:H is the canonical case). The strict base-only regex in validate_vector silently rejected them, so compute_score_safe returned (None, None) and every consumer (sca, exploitability_validation, llm_analysis, raptor_agentic) degraded the affected finding to "no severity available". Relax _VECTOR_RE to allow optional /METRIC:VALUE segments after the eight base metrics; compute_base_score already ignores keys it doesn't recognise, so base scoring is unchanged for any vector that previously parsed. Audit of all consumers confirms each only uses score_finding / score_findings / compute_score_safe — no caller is sensitive to the extra dict keys parse_vector now returns on extended vectors.