### PR TITLE
defensive: isinstance-guard list iteration over LLM/JSON-loaded data

### DIFF
--- a/core/orchestration/agentic_passes.py
+++ b/core/orchestration/agentic_passes.py
@@ -671,11 +671,19 @@ def _enrich_agentic_checklist(agentic_out_dir: Path, context_map_path: Path) -> 
             )
             return False
         enrich_checklist(checklist, context_map, str(agentic_out_dir))
+        # `or []` falls back only on falsy — a malformed checklist with
+        # files / items / functions as a non-list (string, int, dict)
+        # would still hit `for x in 42` and raise TypeError. Guard each
+        # iteration explicitly so corrupt input degrades to "0 marked"
+        # rather than crashing the post-pass.
+        def _as_list(v):
+            return v if isinstance(v, list) else []
         marked = sum(
             1
-            for f in (checklist.get("files") or [])
-            for fn in (f.get("items") or f.get("functions") or [])
-            if fn.get("priority") == "high"
+            for f in _as_list(checklist.get("files"))
+            if isinstance(f, dict)
+            for fn in (_as_list(f.get("items")) or _as_list(f.get("functions")))
+            if isinstance(fn, dict) and fn.get("priority") == "high"
         )
         if marked == 0:
             # Path-convention mismatch is the most common cause: context-map

--- a/core/orchestration/tests/test_agentic_passes.py
+++ b/core/orchestration/tests/test_agentic_passes.py
@@ -988,6 +988,48 @@ class EnrichmentTests(unittest.TestCase):
             ctx_map.write_text("{}")
             self.assertFalse(_enrich_agentic_checklist(tmp, ctx_map))
 
+    def test_enrichment_does_not_raise_on_non_list_files_in_checklist(self):
+        # The marked-counter inside _enrich_agentic_checklist iterates
+        # checklist["files"] and each file's items/functions. If any of
+        # those is a non-list (corrupt LLM-built checklist), the previous
+        # `or []` fallback would crash with `for x in 42`. Defensive
+        # guard means we degrade to "0 marked" with a warning rather than
+        # blowing up the post-pass.
+        import json
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            for bad_files in (42, "string", {"obj": True}):
+                (tmp / "checklist.json").write_text(json.dumps({
+                    "target_path": str(tmp),
+                    "files": bad_files,
+                }))
+                (tmp / "context-map.json").write_text(json.dumps({
+                    "entry_points": [{"file": "x.py", "name": "f"}],
+                    "sink_details": [],
+                }))
+                # Must not raise. Returns False because nothing got marked.
+                _enrich_agentic_checklist(tmp, tmp / "context-map.json")
+
+    def test_enrichment_does_not_raise_on_non_list_items_in_file_entry(self):
+        # Same gap, deeper iteration: file entry has items/functions as
+        # non-list.
+        import json
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "checklist.json").write_text(json.dumps({
+                "target_path": str(tmp),
+                "files": [
+                    {"path": "a.py", "items": "not a list"},
+                    {"path": "b.py", "functions": 42},
+                ],
+            }))
+            (tmp / "context-map.json").write_text(json.dumps({
+                "entry_points": [{"file": "a.py", "name": "f"}],
+                "sink_details": [],
+            }))
+            # Must not raise.
+            _enrich_agentic_checklist(tmp, tmp / "context-map.json")
+
     def test_enrichment_marks_multiple_files_and_reasons(self):
         # Both entry-points and sinks across multiple files must all land on
         # their corresponding checklist functions.

--- a/packages/exploit_feasibility/models.py
+++ b/packages/exploit_feasibility/models.py
@@ -57,7 +57,13 @@ class FeasibilityAssessment:
     def from_dict(cls, d) -> "FeasibilityAssessment":
         if not d or not isinstance(d, dict):
             return cls()
-        paths = [ExploitationPath.from_dict(p) for p in (d.get("exploitation_paths") or [])]
+        # `or []` falls back only on falsy — a malformed dict with
+        # exploitation_paths as a string/int/dict would still hit
+        # `for p in 42` and raise TypeError. isinstance-guard so corrupt
+        # input degrades to "no paths" rather than crashing the loader.
+        raw_paths = d.get("exploitation_paths")
+        paths_list = raw_paths if isinstance(raw_paths, list) else []
+        paths = [ExploitationPath.from_dict(p) for p in paths_list]
         return cls(
             finding_id=d.get("finding_id", ""),
             vuln_type=d.get("vuln_type", ""),

--- a/packages/exploit_feasibility/tests/test_models_defensive.py
+++ b/packages/exploit_feasibility/tests/test_models_defensive.py
@@ -1,0 +1,38 @@
+"""Defensive tests for FeasibilityAssessment.from_dict against malformed input.
+
+Same threat-model as the FindingsContainer defensive tests in
+packages/exploitability_validation/tests/test_models_defensive.py:
+the previous `for p in d.get("exploitation_paths") or []` pattern
+crashed on truthy non-list values because `or []` only falls back
+on falsy. These pin the isinstance guard.
+"""
+import unittest
+
+from packages.exploit_feasibility.models import FeasibilityAssessment
+
+
+class FeasibilityAssessmentFromDictDefensiveTests(unittest.TestCase):
+
+    def test_from_dict_does_not_raise_when_exploitation_paths_is_non_list(self):
+        for bad_value in ("a string", {"obj": True}, 42, True):
+            assessment = FeasibilityAssessment.from_dict({
+                "finding_id": "F-1",
+                "exploitation_paths": bad_value,
+            })
+            self.assertEqual(
+                assessment.exploitation_paths, [],
+                msg=f"non-list exploitation_paths={bad_value!r} should "
+                    "degrade to an empty list rather than crash",
+            )
+
+    def test_from_dict_still_loads_valid_paths(self):
+        # Sanity: the defensive guard didn't break the happy path.
+        assessment = FeasibilityAssessment.from_dict({
+            "finding_id": "F-1",
+            "exploitation_paths": [{"name": "ROP", "reliability": 0.7}],
+        })
+        self.assertEqual(len(assessment.exploitation_paths), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/exploitability_validation/models.py
+++ b/packages/exploitability_validation/models.py
@@ -377,7 +377,13 @@ class FindingsContainer:
             return cls()
         if not isinstance(d, dict):
             return cls()
-        findings = [Finding.from_dict(f) for f in (d.get("findings") or [])]
+        # `or []` falls back only on falsy — a malformed dict with
+        # findings as a string/int/dict would still hit `for f in 42`
+        # and raise TypeError. isinstance-guard so corrupt input
+        # degrades to "no findings" rather than crashing the loader.
+        raw_findings = d.get("findings")
+        findings_list = raw_findings if isinstance(raw_findings, list) else []
+        findings = [Finding.from_dict(f) for f in findings_list]
         return cls(
             stage=d.get("stage", ""),
             timestamp=d.get("timestamp", ""),

--- a/packages/exploitability_validation/tests/test_models_defensive.py
+++ b/packages/exploitability_validation/tests/test_models_defensive.py
@@ -1,0 +1,38 @@
+"""Defensive tests for models.from_dict against malformed input.
+
+`*.from_dict` constructors take user-supplied dicts (loaded from JSON
+files or LLM output). The previous `for x in d.get("...") or []` pattern
+crashes on truthy non-list values (string, int, dict) because `or []`
+only falls back on falsy. These tests pin the defensive isinstance guard.
+"""
+import unittest
+
+from packages.exploitability_validation.models import FindingsContainer
+
+
+class FindingsContainerFromDictDefensiveTests(unittest.TestCase):
+
+    def test_from_dict_does_not_raise_when_findings_is_non_list(self):
+        # Each of these would have raised TypeError before the fix
+        # (`for f in 42`, `for f in "string"`, etc.).
+        for bad_value in ("a string", {"obj": True}, 42, True):
+            container = FindingsContainer.from_dict({"findings": bad_value})
+            self.assertEqual(
+                container.findings, [],
+                msg=f"non-list findings={bad_value!r} should degrade to "
+                    "an empty list rather than crash",
+            )
+
+    def test_from_dict_still_loads_valid_findings(self):
+        # Sanity: the defensive guard didn't break the happy path.
+        container = FindingsContainer.from_dict({
+            "target_path": "/repo",
+            "findings": [{"id": "F-1", "file": "a.py"}],
+        })
+        self.assertEqual(len(container.findings), 1)
+        self.assertEqual(container.findings[0].id, "F-1")
+        self.assertEqual(container.target_path, "/repo")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three sites used the `for x in d.get("...") or []` pattern: `or []` falls back only on falsy values, so a malformed dict with the field as a string/int/dict (LLM schema violation, corrupt JSON load) would still hit `for x in 42` and raise TypeError mid-loop.

Affected:
  - FindingsContainer.from_dict (validation pipeline loader)
  - FeasibilityAssessment.from_dict (exploit feasibility loader)
  - _enrich_agentic_checklist marked-counter (agentic post-pass)

Per-site isinstance(value, list) guards so corrupt input degrades to "empty list / 0 marked" rather than crashing the loader.