### PR TITLE
bridge: function-level enrichment, normalisation, and log sanitisation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,7 @@
       "Bash(libexec/raptor-agentic *)",
       "Bash(libexec/raptor-build-checklist *)",
       "Bash(libexec/raptor-coverage-summary *)",
-      "Bash(libexec/raptor-validation-helper *)",
+      "Bash(libexec/raptor-normalize-context-map *)",
       "Bash(libexec/raptor-project-manager *)",
       "Bash(libexec/raptor-render-diagrams *)",
       "Bash(libexec/raptor-run-feasibility *)",
@@ -17,6 +17,7 @@
       "Bash(libexec/raptor-run-sandboxed *)",
       "Bash(libexec/raptor-startup-check *)",
       "Bash(libexec/raptor-validate-schema *)",
+      "Bash(libexec/raptor-validation-helper *)",
       "Write(/out/**)",
       "Edit(/out/**)"
     ]

--- a/.claude/skills/code-understanding/map.md
+++ b/.claude/skills/code-understanding/map.md
@@ -165,7 +165,28 @@ GATES APPLY: U1 [READ-FIRST], U2 [ATTACKER-LENS], U5 [EVIDENCE-ONLY]
 
 Do not populate `sources`, `sinks`, or `entry_points` from file names or common patterns alone — read the code and verify.
 
-**[MAP-5] Record Coverage**
+**[MAP-5] Normalise context-map**
+
+Right after writing `context-map.json`, run the normaliser. It uses the
+checklist in the same dir as ground truth to:
+- backfill missing `name` fields on entry_points / sink_details from line ranges
+- normalise file paths (strip leading `./`, convert absolute paths under
+  the target into relative ones)
+- warn (non-fatal) on hallucinated files / out-of-range line numbers /
+  cross-reference typos in `unchecked_flows`
+
+```bash
+libexec/raptor-normalize-context-map "$WORKDIR"
+```
+
+Idempotent — safe to re-run. Skip this step only if `$WORKDIR/checklist.json`
+doesn't exist (e.g. you skipped MAP-0 inventory build).
+
+When you can, include the function `name` directly on each entry_point and
+sink_detail you emit — it helps the normaliser skip backfill and is
+clearer for human reviewers.
+
+**[MAP-6] Record Coverage**
 
 After writing `context-map.json`, update the inventory with which functions you examined.
 Write a JSON array of every function you read and analysed (entry points, sinks, trust boundary

--- a/core/orchestration/tests/test_agentic_passes.py
+++ b/core/orchestration/tests/test_agentic_passes.py
@@ -443,12 +443,17 @@ class ValidatePostpassTests(unittest.TestCase):
         self.assertIn("not found", result.skipped_reason)
 
     def test_happy_path_runs_lifecycle_and_writes_selection_file(self):
+        # IDs deliberately use a hyphen + uppercase prefix so
+        # `assertNotIn(...)` below isn't a substring-collision risk
+        # against tempfile.mkdtemp's 8-char alphanumeric random suffix
+        # (CI ran into "f1" appearing inside "/tmp/tmpfef1_buh" and
+        # falsely failing the inline-injection check).
         with TemporaryDirectory() as tmp:
             tmp = Path(tmp)
             report = self._make_report(tmp, [
-                {"finding_id": "f1", "is_exploitable": True},
-                {"finding_id": "f2", "confidence": "high"},
-                {"finding_id": "f3", "is_exploitable": False, "confidence": "low"},
+                {"finding_id": "FNDA-EXPLOITABLE", "is_exploitable": True},
+                {"finding_id": "FNDB-HIGHCONF", "confidence": "high"},
+                {"finding_id": "FNDC-IGNORED", "is_exploitable": False, "confidence": "low"},
             ])
             validate_dir = tmp / "validate_run"
             dispatcher = _make_lifecycle_dispatcher(start_dir=validate_dir)
@@ -468,7 +473,10 @@ class ValidatePostpassTests(unittest.TestCase):
             selection_file = validate_dir / "selected-findings.json"
             self.assertTrue(selection_file.exists())
             data = json.loads(selection_file.read_text())
-            self.assertEqual({f["id"] for f in data["findings"]}, {"f1", "f2"})
+            self.assertEqual(
+                {f["id"] for f in data["findings"]},
+                {"FNDA-EXPLOITABLE", "FNDB-HIGHCONF"},
+            )
             # Container metadata is /validate-shaped.
             self.assertIn("target_path", data)
 
@@ -477,9 +485,9 @@ class ValidatePostpassTests(unittest.TestCase):
                                if Path(c.args[0][0]).name == "claude")
             prompt = claude_call.kwargs["input"]
             self.assertIn("selected-findings.json", prompt)
-            self.assertNotIn("f1", prompt)
-            self.assertNotIn("f2", prompt)
-            self.assertNotIn("f3", prompt)
+            self.assertNotIn("FNDA-EXPLOITABLE", prompt)
+            self.assertNotIn("FNDB-HIGHCONF", prompt)
+            self.assertNotIn("FNDC-IGNORED", prompt)
 
     def test_skips_when_lifecycle_start_fails(self):
         with TemporaryDirectory() as tmp:

--- a/core/orchestration/tests/test_understand_bridge.py
+++ b/core/orchestration/tests/test_understand_bridge.py
@@ -17,6 +17,7 @@ from core.orchestration.understand_bridge import (
     find_understand_output,
     load_understand_context,
     enrich_checklist,
+    normalize_context_map,
     TRACE_SOURCE_LABEL,
     _extract_hashes,
     _find_stale_files,
@@ -438,6 +439,55 @@ class TestLoadUnderstandContextAttackSurface:
         assert len(surface["sinks"]) == 1
         assert len(surface["trust_boundaries"]) == 1
 
+    def test_does_not_raise_on_non_string_file_during_stale_filter(self, tmp_path):
+        # _references_file does `f in stale_files` — list-typed file would
+        # raise TypeError. Pre-existing weakness, but newly exposed once
+        # normalize_context_map stopped rejecting non-string file values.
+        understand_dir = tmp_path / "understand"
+        validate_dir = tmp_path / "validate"
+        understand_dir.mkdir()
+        validate_dir.mkdir()
+        ctx = {
+            "sources": [], "sinks": [], "trust_boundaries": [],
+            "entry_points": [{"id": "EP-1", "file": ["bad", "list"], "line": 1}],
+        }
+        _write_json(understand_dir / "context-map.json", ctx)
+        # Must not raise.
+        load_understand_context(
+            understand_dir, validate_dir, stale_files={"foo.py"},
+        )
+
+    def test_normalises_paths_before_filtering_stale_files(self, tmp_path):
+        # Regression for an ordering bug: _filter_context_map matches
+        # entry["file"] against stale_files using strict equality. If we
+        # filter first and normalise after, an entry with "./foo.py"
+        # survives a stale_files set containing "foo.py" — leaking a
+        # stale entry to downstream consumers.
+        understand_dir = tmp_path / "understand"
+        validate_dir = tmp_path / "validate"
+        understand_dir.mkdir()
+        validate_dir.mkdir()
+
+        # context-map has the file under "./foo.py" (with the dot-slash
+        # claude sometimes emits) — should be filtered as stale.
+        ctx = {
+            "sources": [], "sinks": [], "trust_boundaries": [],
+            "entry_points": [{"id": "EP-1", "file": "./foo.py", "line": 1}],
+            "sink_details": [{"id": "SINK-1", "file": "./foo.py", "line": 5}],
+        }
+        _write_json(understand_dir / "context-map.json", ctx)
+
+        # stale_files uses canonical relative paths.
+        result = load_understand_context(
+            understand_dir, validate_dir, stale_files={"foo.py"},
+        )
+        # After fix: normalise → "./foo.py" → "foo.py" → matches stale set
+        # → entry filtered. Pre-fix: filter ran first, no match, entry leaked.
+        loaded = result["context_map"]
+        assert len(loaded["entry_points"]) == 0, \
+            "entry should have been filtered as stale once paths were normalised"
+        assert len(loaded["sink_details"]) == 0
+
     def test_merges_into_existing_attack_surface(self, tmp_path):
         understand_dir = tmp_path / "understand"
         validate_dir = tmp_path / "validate"
@@ -602,6 +652,253 @@ class TestLoadUnderstandContextFlowTraces:
 
 
 # ---------------------------------------------------------------------------
+# normalize_context_map
+# ---------------------------------------------------------------------------
+
+class TestNormalizeContextMap:
+    def _checklist(self, files):
+        return {"target_path": "/repo", "files": files}
+
+    def test_backfills_missing_name_from_line_range(self):
+        # claude omitted the `name` field — we look up the function whose
+        # line range contains the entry's line and inject it.
+        ctx = {"entry_points": [{"file": "app.py", "line": 12}]}
+        checklist = self._checklist([{
+            "path": "app.py", "lines": 50,
+            "functions": [{"name": "handle", "line_start": 10, "line_end": 25}],
+        }])
+        normalize_context_map(ctx, checklist)
+        assert ctx["entry_points"][0]["name"] == "handle"
+
+    def test_backfill_falls_back_to_closest_preceding_when_no_line_end(self):
+        # Inventories without line_end can still get best-effort matching:
+        # the closest preceding line_start wins.
+        ctx = {"sink_details": [{"file": "x.py", "line": 50}]}
+        checklist = self._checklist([{
+            "path": "x.py", "lines": 100,
+            "functions": [
+                {"name": "first", "line_start": 10},
+                {"name": "second", "line_start": 40},
+                {"name": "third", "line_start": 70},
+            ],
+        }])
+        normalize_context_map(ctx, checklist)
+        assert ctx["sink_details"][0]["name"] == "second"
+
+    def test_does_not_raise_on_string_typed_line_numbers_in_checklist(self):
+        # If a corrupt checklist has line_start / line_end as strings
+        # (LLM-produced inventory or hand-edited), the comparison
+        # `line_start <= line <= line_end` would raise TypeError
+        # (str vs int). Must be defensive — skip those entries.
+        ctx = {"entry_points": [{"file": "x.py", "line": 12}]}
+        checklist = self._checklist([{
+            "path": "x.py", "lines": 50,
+            "functions": [
+                # All three malformed in different ways.
+                {"name": "stringly_typed", "line_start": "10", "line_end": "25"},
+                {"name": "missing_end", "line_start": 5, "line_end": "fifty"},
+                {"name": "valid", "line_start": 10, "line_end": 25},
+            ],
+        }])
+        # Must not raise; valid entry should still be the backfill source.
+        normalize_context_map(ctx, checklist)
+        assert ctx["entry_points"][0].get("name") == "valid"
+
+    def test_does_not_raise_on_string_typed_line_in_fallback(self):
+        # Same but for the fallback path (no line_end on any function).
+        ctx = {"entry_points": [{"file": "x.py", "line": 50}]}
+        checklist = self._checklist([{
+            "path": "x.py", "lines": 100,
+            "functions": [
+                {"name": "stringly", "line_start": "40"},  # corrupt
+                {"name": "real",     "line_start": 30},     # valid, preceding
+            ],
+        }])
+        normalize_context_map(ctx, checklist)
+        assert ctx["entry_points"][0].get("name") == "real"
+
+    def test_backfill_prefers_smallest_span_for_nested_functions(self):
+        # When functions nest (outer 1-100, inner 30-50) and the entry
+        # references a line inside the inner range, attribute to the
+        # innermost — first-match-wins would falsely pick the outer.
+        ctx = {"entry_points": [{"file": "x.py", "line": 35}]}
+        checklist = self._checklist([{
+            "path": "x.py", "lines": 100,
+            "functions": [
+                {"name": "outer", "line_start": 1,  "line_end": 100},
+                {"name": "inner", "line_start": 30, "line_end": 50},
+            ],
+        }])
+        normalize_context_map(ctx, checklist)
+        assert ctx["entry_points"][0]["name"] == "inner"
+
+    def test_does_not_overwrite_existing_name(self):
+        ctx = {"entry_points": [{"file": "app.py", "line": 5, "name": "claude_said"}]}
+        checklist = self._checklist([{
+            "path": "app.py", "lines": 50,
+            "functions": [{"name": "different", "line_start": 1, "line_end": 30}],
+        }])
+        normalize_context_map(ctx, checklist)
+        assert ctx["entry_points"][0]["name"] == "claude_said"
+
+    def test_strips_leading_dotslash_from_file_paths(self):
+        ctx = {"entry_points": [{"file": "./src/app.py", "line": 5}]}
+        normalize_context_map(ctx, {"files": []})
+        assert ctx["entry_points"][0]["file"] == "src/app.py"
+
+    def test_converts_absolute_path_under_target_to_relative(self, tmp_path):
+        # claude sometimes emits absolute paths; bridge needs relative for
+        # strict-equality match against checklist paths.
+        target = tmp_path / "repo"
+        target.mkdir()
+        (target / "app.py").write_text("x")
+        ctx = {"entry_points": [{"file": str(target / "app.py"), "line": 1}]}
+        normalize_context_map(ctx, {"files": []}, target_path=str(target))
+        assert ctx["entry_points"][0]["file"] == "app.py"
+
+    def test_warns_on_file_not_in_checklist(self, caplog):
+        ctx = {"entry_points": [{"file": "nope.py", "line": 5}]}
+        checklist = self._checklist([{"path": "real.py", "lines": 10}])
+        with caplog.at_level("WARNING", logger="core.orchestration.understand_bridge"):
+            normalize_context_map(ctx, checklist)
+        assert any("not present in checklist" in r.message for r in caplog.records)
+
+    def test_warns_on_line_past_end_of_file(self, caplog):
+        ctx = {"sink_details": [{"file": "app.py", "line": 9999}]}
+        checklist = self._checklist([{"path": "app.py", "lines": 50}])
+        with caplog.at_level("WARNING", logger="core.orchestration.understand_bridge"):
+            normalize_context_map(ctx, checklist)
+        assert any("but file has only" in r.message for r in caplog.records)
+
+    def test_warns_on_unchecked_flow_referencing_missing_entry_id(self, caplog):
+        ctx = {
+            "entry_points": [{"id": "EP-001", "file": "a.py", "line": 1}],
+            "sink_details": [{"id": "SINK-001", "file": "a.py", "line": 5}],
+            "unchecked_flows": [{"entry_point": "EP-999", "sink": "SINK-001"}],
+        }
+        with caplog.at_level("WARNING", logger="core.orchestration.understand_bridge"):
+            normalize_context_map(ctx, {"files": [{"path": "a.py", "lines": 10}]})
+        assert any("EP-999" in r.message for r in caplog.records)
+
+    def test_log_output_escapes_terminal_escapes_in_file_path(self, caplog):
+        # Without escape_nonprintable, a malicious target repo whose file
+        # paths contain CSI 2J (clear screen) or BEL would corrupt the
+        # operator's terminal via raptor's own warning output. Defended
+        # via core.security.log_sanitisation.escape_nonprintable.
+        nasty = "evil\x1b[2J\x07.py"
+        ctx = {"entry_points": [{"file": nasty, "line": 5}]}
+        checklist = self._checklist([{"path": "real.py", "lines": 10}])
+        with caplog.at_level("WARNING", logger="core.orchestration.understand_bridge"):
+            normalize_context_map(ctx, checklist)
+        formatted = " ".join(r.getMessage() for r in caplog.records)
+        assert "\x1b" not in formatted
+        assert "\x07" not in formatted
+        assert "\\x1b" in formatted
+        assert "\\x07" in formatted
+
+    def test_log_output_escapes_terminal_escapes_in_unchecked_flow_id(self, caplog):
+        ctx = {
+            "entry_points": [{"id": "EP-001", "file": "a.py", "line": 1}],
+            "sink_details": [{"id": "SINK-001", "file": "a.py", "line": 5}],
+            "unchecked_flows": [{"entry_point": "EP-\x1bevil", "sink": "SINK-001"}],
+        }
+        with caplog.at_level("WARNING", logger="core.orchestration.understand_bridge"):
+            normalize_context_map(ctx, {"files": [{"path": "a.py", "lines": 10}]})
+        formatted = " ".join(r.getMessage() for r in caplog.records)
+        assert "\x1b" not in formatted
+        assert "\\x1b" in formatted
+
+    def test_idempotent_safe_to_call_twice(self):
+        ctx = {"entry_points": [{"file": "./app.py", "line": 12}]}
+        checklist = self._checklist([{
+            "path": "app.py", "lines": 50,
+            "functions": [{"name": "handle", "line_start": 10, "line_end": 25}],
+        }])
+        normalize_context_map(ctx, checklist)
+        snapshot = json.loads(json.dumps(ctx))
+        normalize_context_map(ctx, checklist)
+        assert ctx == snapshot
+
+    def test_no_op_on_missing_inputs(self):
+        # Must never raise on None / non-dict inputs — defensive.
+        normalize_context_map(None, {})
+        normalize_context_map({}, None)
+        normalize_context_map("not-a-dict", {})
+
+    def test_path_normalisation_runs_even_without_checklist(self):
+        # Path normalisation doesn't depend on the checklist (it just
+        # strips ./ and resolves absolute paths under target_path).
+        # Callers that pass checklist=None should still get clean paths.
+        ctx = {"entry_points": [{"file": "./src/app.py", "line": 5}]}
+        normalize_context_map(ctx, None, target_path="/repo")
+        assert ctx["entry_points"][0]["file"] == "src/app.py"
+
+    def test_cross_ref_validation_handles_list_valued_refs(self):
+        # An unchecked_flow may legitimately reference multiple entry points
+        # or sinks via a list. Set membership on a raw list would raise
+        # TypeError (lists unhashable) — must coerce safely.
+        ctx = {
+            "entry_points": [
+                {"id": "EP-001", "file": "a.py", "line": 1},
+                {"id": "EP-002", "file": "a.py", "line": 5},
+            ],
+            "sink_details": [{"id": "SINK-001", "file": "a.py", "line": 10}],
+            "unchecked_flows": [
+                {"entry_point": ["EP-001", "EP-002"], "sink": "SINK-001"},
+            ],
+        }
+        # Must not raise; both EP IDs are valid so no warning either.
+        normalize_context_map(ctx, {"files": [{"path": "a.py", "lines": 20}]})
+
+    def test_does_not_raise_on_non_string_id_value(self):
+        # Set construction `{e.get("id") for ...}` requires hashable values.
+        # If claude emits id as a list / dict (schema violation), the
+        # comprehension would crash before the validation could even run.
+        ctx = {
+            "entry_points": [
+                {"id": ["EP-001"], "file": "a.py", "line": 1},  # list id
+                {"id": "EP-002",   "file": "a.py", "line": 5},  # control
+            ],
+            "sink_details": [
+                {"id": {"obj": "x"}, "file": "a.py", "line": 10},  # dict id
+                {"id": "SINK-001",   "file": "a.py", "line": 15},  # control
+            ],
+            "unchecked_flows": [{"entry_point": "EP-002", "sink": "SINK-001"}],
+        }
+        # Must not raise.
+        normalize_context_map(ctx, {"files": [{"path": "a.py", "lines": 50}]})
+
+    def test_does_not_raise_on_non_string_file_value(self):
+        # An LLM that emits a list / int / dict for `file:` would crash
+        # str.strip() inside path normalisation. Must be defensive.
+        ctx = {
+            "entry_points": [
+                {"file": ["src/a.py", "src/b.py"], "line": 5},  # list
+                {"file": 42, "line": 10},                        # int
+                {"file": {"path": "x"}, "line": 1},              # dict
+                {"file": "valid.py", "line": 1},                 # control
+            ],
+        }
+        # Must not raise.
+        normalize_context_map(ctx, {"files": []})
+        # Valid one stays unchanged; invalid ones get left alone (no
+        # silent corruption).
+        assert ctx["entry_points"][3]["file"] == "valid.py"
+
+    def test_cross_ref_validation_warns_on_invalid_id_in_list(self, caplog):
+        ctx = {
+            "entry_points": [{"id": "EP-001", "file": "a.py", "line": 1}],
+            "sink_details": [{"id": "SINK-001", "file": "a.py", "line": 10}],
+            "unchecked_flows": [
+                {"entry_point": ["EP-001", "EP-MISSING"], "sink": "SINK-001"},
+            ],
+        }
+        with caplog.at_level("WARNING", logger="core.orchestration.understand_bridge"):
+            normalize_context_map(ctx, {"files": [{"path": "a.py", "lines": 20}]})
+        assert any("EP-MISSING" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
 # enrich_checklist
 # ---------------------------------------------------------------------------
 
@@ -609,7 +906,7 @@ class TestEnrichChecklist:
     def test_marks_entry_point_files_as_high_priority(self):
         checklist = copy.deepcopy(MINIMAL_CHECKLIST)
 
-        enrich_checklist(checklist, MINIMAL_CONTEXT_MAP)
+        enrich_checklist(checklist, copy.deepcopy(MINIMAL_CONTEXT_MAP))
 
         routes_file = next(
             f for f in checklist["files"] if f["path"] == "src/routes/query.py"
@@ -620,17 +917,188 @@ class TestEnrichChecklist:
     def test_marks_sink_files_as_high_priority(self):
         checklist = copy.deepcopy(MINIMAL_CHECKLIST)
 
-        enrich_checklist(checklist, MINIMAL_CONTEXT_MAP)
+        enrich_checklist(checklist, copy.deepcopy(MINIMAL_CONTEXT_MAP))
 
         db_file = next(
             f for f in checklist["files"] if f["path"] == "src/db/query.py"
         )
         assert db_file["functions"][0]["priority"] == "high"
 
+    def test_priority_targets_carry_resolved_entry_and_sink_details(self):
+        # Each priority_target should include resolved file/line/name from
+        # the entry_points/sink_details lists, so consumers don't have to
+        # do the ID → details join. Original ID fields are preserved
+        # (additive enrichment).
+        checklist = copy.deepcopy(MINIMAL_CHECKLIST)
+        # Same shape as MINIMAL_CONTEXT_MAP but with EP-001 used (the
+        # one that DOES exist in entry_points) so we can verify resolution.
+        ctx = copy.deepcopy(MINIMAL_CONTEXT_MAP)
+        ctx["unchecked_flows"] = [
+            {"entry_point": "EP-001", "sink": "SINK-001",
+             "missing_boundary": "..."},
+        ]
+        enrich_checklist(checklist, ctx)
+
+        targets = checklist["priority_targets"]
+        assert len(targets) == 1
+        target = targets[0]
+        # Original fields preserved.
+        assert target["entry_point"] == "EP-001"
+        assert target["sink"] == "SINK-001"
+        # Resolved details added — includes name backfilled by
+        # normalize_context_map from line 34 → handle_query in the
+        # checklist (and similarly for the sink).
+        assert target["entry_points_resolved"] == [{
+            "id": "EP-001",
+            "file": "src/routes/query.py",
+            "line": 34,
+            "name": "handle_query",
+        }]
+        assert target["sinks_resolved"] == [{
+            "id": "SINK-001",
+            "file": "src/db/query.py",
+            "line": 89,
+            "name": "run_query",
+        }]
+
+    def test_priority_targets_handle_list_valued_refs(self):
+        # An unchecked_flow may reference multiple entry_points (multiple
+        # sources reaching one sink). Resolution should produce a list
+        # entry per referenced ID.
+        checklist = copy.deepcopy(MINIMAL_CHECKLIST)
+        ctx = {
+            "entry_points": [
+                {"id": "EP-A", "file": "a.py", "line": 1, "name": "f1"},
+                {"id": "EP-B", "file": "b.py", "line": 2, "name": "f2"},
+            ],
+            "sink_details": [
+                {"id": "S-1", "file": "x.py", "line": 10, "name": "g1"},
+            ],
+            "unchecked_flows": [
+                {"entry_point": ["EP-A", "EP-B"], "sink": "S-1"},
+            ],
+        }
+        enrich_checklist(checklist, ctx)
+        target = checklist["priority_targets"][0]
+        ids = [r["id"] for r in target["entry_points_resolved"]]
+        assert ids == ["EP-A", "EP-B"]
+        assert target["sinks_resolved"][0]["id"] == "S-1"
+
+    def test_priority_targets_drop_malformed_field_types_in_resolved(self):
+        # If an entry_point or sink_detail has corrupt typing on file /
+        # line / name (LLM schema violation), the resolved output should
+        # silently drop the bad field rather than copying it into the
+        # downstream consumer's expected shape.
+        checklist = copy.deepcopy(MINIMAL_CHECKLIST)
+        ctx = {
+            "entry_points": [{
+                "id": "EP-1",
+                "file": ["bad", "list"],   # malformed
+                "line": "thirty-four",     # malformed
+                "name": "good_name",       # valid
+            }],
+            "sink_details": [{
+                "id": "S-1",
+                "file": "ok.py",
+                "line": True,              # malformed (bool, not real int)
+                "name": {"corrupt": True}, # malformed
+            }],
+            "unchecked_flows": [
+                {"entry_point": "EP-1", "sink": "S-1"},
+            ],
+        }
+        enrich_checklist(checklist, ctx)
+        target = checklist["priority_targets"][0]
+
+        # Resolved entry: only the valid `name` survives (id always
+        # included as the lookup key).
+        assert target["entry_points_resolved"] == [
+            {"id": "EP-1", "name": "good_name"},
+        ]
+        # Resolved sink: only the valid `file` survives.
+        assert target["sinks_resolved"] == [
+            {"id": "S-1", "file": "ok.py"},
+        ]
+
+    def test_priority_targets_partial_resolution_when_some_ids_unknown(self):
+        # List-valued entry_point with one known and one unknown ID —
+        # known should resolve, unknown should drop, raw IDs preserved.
+        checklist = copy.deepcopy(MINIMAL_CHECKLIST)
+        ctx = {
+            "entry_points": [{"id": "EP-OK", "file": "a.py", "line": 1, "name": "f"}],
+            "sink_details": [{"id": "S-1", "file": "x.py", "line": 10}],
+            "unchecked_flows": [
+                {"entry_point": ["EP-OK", "EP-MISSING"], "sink": "S-1"},
+            ],
+        }
+        enrich_checklist(checklist, ctx)
+        target = checklist["priority_targets"][0]
+        # Raw IDs untouched (downstream can still see what was requested).
+        assert target["entry_point"] == ["EP-OK", "EP-MISSING"]
+        # Resolved list contains only the valid one.
+        ids = [r["id"] for r in target["entry_points_resolved"]]
+        assert ids == ["EP-OK"]
+
+    def test_does_not_raise_when_entry_points_is_non_list(self):
+        # Same TypeError class as the unchecked_flows case, in different
+        # `for x in d.get("...") or []` sites. Probes the new _record
+        # and _index_entries_by_id helpers plus the file-level walk.
+        checklist = copy.deepcopy(MINIMAL_CHECKLIST)
+        for bad_value in ("a string", {"obj": True}, 42):
+            ctx = {
+                "entry_points": bad_value,   # malformed
+                "sink_details": [],
+                "unchecked_flows": [],
+            }
+            # Must not raise.
+            enrich_checklist(checklist, ctx)
+
+    def test_does_not_raise_when_sink_details_is_non_list(self):
+        checklist = copy.deepcopy(MINIMAL_CHECKLIST)
+        for bad_value in ("a string", {"obj": True}, 42):
+            ctx = {
+                "entry_points": [],
+                "sink_details": bad_value,   # malformed
+                "unchecked_flows": [],
+            }
+            enrich_checklist(checklist, ctx)
+
+    def test_no_priority_targets_when_unchecked_flows_is_non_list(self):
+        # Defensive: unchecked_flows="some string" or other weird shapes
+        # should not produce an empty priority_targets list (which would
+        # be more confusing than just leaving the key absent).
+        checklist = copy.deepcopy(MINIMAL_CHECKLIST)
+        for bad_value in ("a string", {"obj": True}, 42, True):
+            ctx = {
+                "entry_points": [], "sink_details": [],
+                "unchecked_flows": bad_value,
+            }
+            enrich_checklist(checklist, ctx)
+            assert "priority_targets" not in checklist, \
+                f"unchecked_flows={bad_value!r} should not produce priority_targets"
+
+    def test_priority_targets_drop_unknown_ids_silently(self):
+        # If unchecked_flow names a missing ID (already warned by
+        # _validate_cross_refs), resolution drops it from *_resolved
+        # rather than emitting a half-formed dict.
+        checklist = copy.deepcopy(MINIMAL_CHECKLIST)
+        ctx = {
+            "entry_points": [{"id": "EP-1", "file": "a.py", "line": 1}],
+            "sink_details": [{"id": "S-1", "file": "x.py", "line": 10}],
+            "unchecked_flows": [
+                {"entry_point": "EP-MISSING", "sink": "S-1"},
+            ],
+        }
+        enrich_checklist(checklist, ctx)
+        target = checklist["priority_targets"][0]
+        assert target["entry_point"] == "EP-MISSING"  # raw ID preserved
+        assert target["entry_points_resolved"] == []   # but resolution empty
+        assert len(target["sinks_resolved"]) == 1
+
     def test_adds_priority_targets_for_unchecked_flows(self):
         checklist = copy.deepcopy(MINIMAL_CHECKLIST)
 
-        enrich_checklist(checklist, MINIMAL_CONTEXT_MAP)
+        enrich_checklist(checklist, copy.deepcopy(MINIMAL_CONTEXT_MAP))
 
         assert "priority_targets" in checklist
         assert len(checklist["priority_targets"]) == 1
@@ -639,16 +1107,269 @@ class TestEnrichChecklist:
 
     def test_no_unchecked_flows_omits_priority_targets(self):
         checklist = copy.deepcopy(MINIMAL_CHECKLIST)
-        context_map = dict(MINIMAL_CONTEXT_MAP)
+        # deepcopy — enrich_checklist mutates context_map (via
+        # normalize_context_map) and a shallow dict() would let mutation
+        # of nested entry lists leak back into MINIMAL_CONTEXT_MAP.
+        context_map = copy.deepcopy(MINIMAL_CONTEXT_MAP)
         context_map["unchecked_flows"] = []
 
         enrich_checklist(checklist, context_map)
 
         assert "priority_targets" not in checklist
 
+    def test_enrich_is_idempotent_under_repeated_calls(self):
+        # Re-running enrich_checklist with the same inputs should produce
+        # identical output. The clear-step opens a small risk window where
+        # a future bug could leave the checklist in a different shape on
+        # the second call (e.g. by failing to re-write something it just
+        # popped). Snapshot-equal-after-two-calls catches that class of bug.
+        checklist = copy.deepcopy(MINIMAL_CHECKLIST)
+        ctx = copy.deepcopy(MINIMAL_CONTEXT_MAP)
+        enrich_checklist(checklist, ctx)
+        snapshot_after_run1 = json.loads(json.dumps(checklist))
+
+        # Same inputs (deepcopy because enrich mutates context_map) — must
+        # produce the same checklist state.
+        ctx2 = copy.deepcopy(MINIMAL_CONTEXT_MAP)
+        enrich_checklist(checklist, ctx2)
+        snapshot_after_run2 = json.loads(json.dumps(checklist))
+
+        assert snapshot_after_run1 == snapshot_after_run2
+
+    def test_clears_stale_priority_markers_on_re_enrichment(self):
+        # If a function was marked priority=high in a prior enrich run
+        # but the current context-map no longer references it, the marker
+        # should be cleared (not silently retained as stale data).
+        checklist = copy.deepcopy(MINIMAL_CHECKLIST)
+
+        # Run #1: pretend a prior enrich marked handle_query and run_query
+        for f in checklist["files"]:
+            for fn in f["functions"]:
+                fn["priority"] = "high"
+                fn["priority_reason"] = "sink"  # stale reason
+        checklist["priority_targets"] = [{"entry_point": "EP-OLD", "source": "understand:map"}]
+
+        # Run #2: enrich with a context-map that has NO entry_points / sinks
+        # at all — every prior marker should be cleared.
+        empty_ctx = {
+            "sources": [], "sinks": [], "trust_boundaries": [],
+            "entry_points": [], "sink_details": [], "unchecked_flows": [],
+        }
+        enrich_checklist(checklist, empty_ctx)
+
+        for f in checklist["files"]:
+            for fn in f["functions"]:
+                assert "priority" not in fn, \
+                    f"stale priority on {fn['name']} should have been cleared"
+                assert "priority_reason" not in fn
+        assert "priority_targets" not in checklist, \
+            "stale priority_targets at checklist level should have been cleared"
+
+    def test_re_enrichment_with_changed_context_map_overwrites_correctly(self):
+        # Stronger version: prior run marked X as 'sink', new run says X is
+        # only 'entry_point' — verify the reason was OVERWRITTEN, not
+        # accumulated as 'entry_point+sink'.
+        checklist = copy.deepcopy(MINIMAL_CHECKLIST)
+        for f in checklist["files"]:
+            for fn in f["functions"]:
+                fn["priority"] = "high"
+                fn["priority_reason"] = "sink"  # stale from prior run
+
+        # New context-map: handle_query is ONLY an entry point now.
+        ctx = {
+            "sources": [], "sinks": [], "trust_boundaries": [],
+            "entry_points": [{
+                "id": "EP-001", "file": "src/routes/query.py", "line": 34,
+                "name": "handle_query",
+            }],
+            "sink_details": [],
+        }
+        enrich_checklist(checklist, ctx)
+
+        routes_func = next(
+            f["functions"][0] for f in checklist["files"]
+            if f["path"] == "src/routes/query.py"
+        )
+        assert routes_func["priority"] == "high"
+        assert routes_func["priority_reason"] == "entry_point", \
+            "reason should be the new run's value, not the stale 'sink'"
+
     def test_safe_on_empty_inputs(self):
         enrich_checklist({}, {})
         enrich_checklist(None, None)
+
+    def test_does_not_raise_when_context_map_has_non_string_name(self):
+        # If `name` is a list/dict (LLM schema violation), the tuple key
+        # `(file_path, name)` is unhashable and would crash the
+        # priority_functions setdefault. Drop those entries silently
+        # rather than propagating the type bug.
+        checklist = copy.deepcopy(MINIMAL_CHECKLIST)
+        ctx = {
+            "entry_points": [
+                {"id": "EP-1", "file": "src/routes/query.py", "line": 34,
+                 "name": ["weird", "list", "name"]},  # malformed
+            ],
+            "sink_details": [
+                {"id": "S-1", "file": "src/db/query.py", "line": 89,
+                 "name": {"corrupt": True}},  # malformed
+            ],
+            "unchecked_flows": [],
+        }
+        # Must not raise.
+        enrich_checklist(checklist, ctx)
+
+    def test_does_not_raise_when_context_map_has_non_string_file(self):
+        # _normalize_paths leaves non-string `file:` values alone, so they
+        # survive into enrich_checklist's tuple keys. Defend.
+        checklist = copy.deepcopy(MINIMAL_CHECKLIST)
+        ctx = {
+            "entry_points": [
+                {"id": "EP-1", "file": ["a", "b"], "line": 1},  # malformed
+                {"id": "EP-2", "file": "src/routes/query.py", "line": 34},  # control
+            ],
+            "sink_details": [],
+            "unchecked_flows": [],
+        }
+        # Must not raise; the valid control entry should still get marked.
+        enrich_checklist(checklist, ctx)
+        routes_file = next(
+            f for f in checklist["files"] if f["path"] == "src/routes/query.py"
+        )
+        assert routes_file["functions"][0]["priority"] == "high"
+
+    def test_does_not_raise_when_checklist_has_non_string_function_name(self):
+        # If the checklist itself has a corrupt non-string function name,
+        # backfill must not propagate that into context_map (which would
+        # crash enrich_checklist downstream).
+        checklist = {
+            "target_path": "/repo",
+            "files": [{
+                "path": "app.py", "lines": 50,
+                "functions": [
+                    {"name": ["corrupt"], "line_start": 10, "line_end": 25},
+                ],
+            }],
+        }
+        ctx = {"entry_points": [{"file": "app.py", "line": 12}]}  # no name
+        # Must not raise; entry's name should NOT be backfilled with the
+        # corrupt list-typed name from the checklist.
+        normalize_context_map(ctx, checklist)
+        assert "name" not in ctx["entry_points"][0]
+
+    def test_safe_on_non_dict_checklist(self):
+        # A malformed caller passing a list as the checklist would crash
+        # checklist.get("target_path"). Must be defensive — return early.
+        result = enrich_checklist(["not", "a", "dict"], MINIMAL_CONTEXT_MAP)
+        assert result == ["not", "a", "dict"]  # returned unchanged
+
+    def test_function_level_matching_when_context_map_provides_name(self):
+        # When the context map labels an entry point or sink with a
+        # specific function name, only that function should get marked —
+        # not every function in the file. Old behaviour was file-level
+        # always, which falsely promoted unrelated helpers.
+        checklist = {
+            "files": [{
+                "path": "src/handler.py",
+                "language": "python",
+                "lines": 50,
+                "sha256": "h",
+                "functions": [
+                    {"name": "handle_request", "line_start": 10, "checked_by": []},
+                    {"name": "internal_helper", "line_start": 30, "checked_by": []},
+                ],
+            }],
+        }
+        context_map = {
+            "entry_points": [
+                {"file": "src/handler.py", "name": "handle_request"},
+            ],
+            "sink_details": [],
+        }
+        enrich_checklist(checklist, context_map)
+
+        funcs = checklist["files"][0]["functions"]
+        by_name = {f["name"]: f for f in funcs}
+        assert by_name["handle_request"].get("priority") == "high"
+        assert by_name["handle_request"].get("priority_reason") == "entry_point"
+        # The helper sits in the same file but is NOT an entry point —
+        # under the old file-level logic it would be falsely marked.
+        assert "priority" not in by_name["internal_helper"]
+
+    def test_file_level_fallback_when_name_absent(self):
+        # When the context map omits the name field (older /understand
+        # outputs, simpler maps), every function in the file gets marked
+        # — preserves backward compat with the existing fixtures.
+        checklist = {
+            "files": [{
+                "path": "src/handler.py",
+                "language": "python",
+                "lines": 50,
+                "sha256": "h",
+                "functions": [
+                    {"name": "handle_request", "line_start": 10, "checked_by": []},
+                    {"name": "another", "line_start": 30, "checked_by": []},
+                ],
+            }],
+        }
+        context_map = {
+            "entry_points": [{"file": "src/handler.py"}],  # no "name"
+            "sink_details": [],
+        }
+        enrich_checklist(checklist, context_map)
+
+        for func in checklist["files"][0]["functions"]:
+            assert func.get("priority") == "high"
+            assert func.get("priority_reason") == "entry_point"
+
+    def test_function_in_both_entry_and_sink_gets_combined_reason(self):
+        # A function that is both an entry point AND a sink (e.g. a Flask
+        # route that does its own SQL execute) should be tagged with both
+        # — the old code silently overwrote entry_point with "sink".
+        checklist = {
+            "files": [{
+                "path": "src/api.py",
+                "language": "python",
+                "lines": 30,
+                "sha256": "a",
+                "functions": [
+                    {"name": "search", "line_start": 10, "checked_by": []},
+                ],
+            }],
+        }
+        context_map = {
+            "entry_points": [{"file": "src/api.py", "name": "search"}],
+            "sink_details": [{"file": "src/api.py", "name": "search"}],
+        }
+        enrich_checklist(checklist, context_map)
+
+        func = checklist["files"][0]["functions"][0]
+        assert func.get("priority") == "high"
+        # Sorted alphabetically for determinism: entry_point + sink.
+        assert func.get("priority_reason") == "entry_point+sink"
+
+    def test_file_level_entry_plus_function_level_sink_combine(self):
+        # A function that inherits a file-level entry_point marker AND
+        # also matches a function-level sink should get both reasons.
+        # Verifies the union of file-level + function-level lookups.
+        checklist = {
+            "files": [{
+                "path": "src/api.py",
+                "language": "python",
+                "lines": 30,
+                "sha256": "a",
+                "functions": [
+                    {"name": "search", "line_start": 10, "checked_by": []},
+                ],
+            }],
+        }
+        context_map = {
+            "entry_points": [{"file": "src/api.py"}],         # file-level
+            "sink_details": [{"file": "src/api.py", "name": "search"}],  # func-level
+        }
+        enrich_checklist(checklist, context_map)
+
+        func = checklist["files"][0]["functions"][0]
+        assert func.get("priority_reason") == "entry_point+sink"
 
     def test_does_not_touch_unrelated_files(self):
         checklist = copy.deepcopy(MINIMAL_CHECKLIST)
@@ -660,7 +1381,7 @@ class TestEnrichChecklist:
             "functions": [{"name": "format_string", "line_start": 5, "checked_by": []}],
         })
 
-        enrich_checklist(checklist, MINIMAL_CONTEXT_MAP)
+        enrich_checklist(checklist, copy.deepcopy(MINIMAL_CONTEXT_MAP))
 
         helpers_file = next(
             f for f in checklist["files"] if f["path"] == "src/utils/helpers.py"

--- a/core/orchestration/understand_bridge.py
+++ b/core/orchestration/understand_bridge.py
@@ -38,6 +38,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from core.json import load_json, save_json
+from core.security.log_sanitisation import escape_nonprintable
 
 logger = logging.getLogger(__name__)
 
@@ -185,7 +186,7 @@ def _rank_candidates(
             "understand_bridge: best candidate %s has %d stale file(s)"
             " — data for these files will be excluded: %s",
             best_dir.name, best_stale_count,
-            ", ".join(sorted(best_stale_files)),
+            ", ".join(escape_nonprintable(f) for f in sorted(best_stale_files)),
         )
 
     return best_dir, best_stale_files
@@ -315,7 +316,17 @@ def load_understand_context(
         logger.warning("understand_bridge: no context-map.json found in %s", understand_dir)
         return summary
 
-    # --- Filter entries referencing stale files ---
+    # --- Normalise the context-map (path conventions, name backfill,
+    #     hallucination warnings) BEFORE filtering so stale-file matching
+    #     compares canonical paths. Otherwise an entry with `./foo.py`
+    #     would survive a stale-files set containing the canonical
+    #     `foo.py` and leak through. The validate dir's checklist is the
+    #     ground truth for normalisation. ---
+    validate_checklist = load_json(validate_dir / "checklist.json") or {}
+    normalize_context_map(context_map, validate_checklist,
+                          target_path=validate_checklist.get("target_path"))
+
+    # --- Filter entries referencing stale files (now using normalised paths) ---
     filtered = _filter_context_map(context_map, stale_files)
     if filtered:
         logger.info("understand_bridge: excluded %d entries referencing stale files", filtered)
@@ -346,64 +357,522 @@ def load_understand_context(
     return summary
 
 
+def normalize_context_map(context_map: Dict[str, Any], checklist: Dict[str, Any],
+                          target_path: Optional[str] = None) -> Dict[str, Any]:
+    """Mechanically fix up an LLM-produced context-map using the checklist
+    as ground truth.
+
+    Mutates ``context_map`` in place; returns it for chaining. Does five
+    deterministic passes that are safe to run multiple times (idempotent):
+
+    1. **Path normalisation** on every ``file:`` field across entry_points,
+       sink_details, boundary_details. Strips leading ``./``; converts
+       absolute paths under ``target_path`` to relative-from-target. The
+       bridge's downstream strict-equality match is sensitive to this.
+
+    2. **Name backfill** on entry_points and sink_details: when the LLM
+       emitted ``file`` + ``line`` but no ``name``, look up the function
+       in the checklist whose line range contains that line and inject
+       the function's name. Enables function-level enrichment instead of
+       falling back to file-level (which over-marks unrelated helpers).
+
+    3. **File-existence validation**: warns when a context-map entry
+       references a file that doesn't appear in the checklist (LLM
+       hallucination).
+
+    4. **Line-in-file sanity**: warns when a referenced line exceeds the
+       file's known length.
+
+    5. **Cross-reference validation**: warns when ``unchecked_flows``
+       references entry_point or sink IDs that don't exist in the
+       respective lists.
+
+    Returns the (mutated) context_map for caller convenience. Bails as a
+    no-op if either input is missing or wrong-typed.
+    """
+    if not isinstance(context_map, dict):
+        return context_map
+
+    # Path normalisation and cross-ref validation don't need the checklist
+    # — run them unconditionally so callers without an inventory still
+    # benefit from those passes.
+    _normalize_paths(context_map, target_path)
+    _validate_cross_refs(context_map)
+
+    if not isinstance(checklist, dict):
+        # Backfill / hallucination warnings need the checklist as ground truth.
+        return context_map
+
+    files_by_path = {
+        fi.get("path"): fi
+        for fi in _list_at(checklist, "files")
+        if isinstance(fi, dict) and fi.get("path")
+    }
+    _backfill_and_validate_locations(context_map, files_by_path)
+    return context_map
+
+
+# Top-level keys whose entries carry a (file, line) pair worth normalising.
+_LOCATION_BEARING_SECTIONS = ("entry_points", "sink_details", "boundary_details")
+
+
+def _list_at(d: Any, key: str) -> List[Any]:
+    """Return d[key] if it's a list, else an empty list.
+
+    Defensive guard for the many `for x in context_map.get(field) or []`
+    sites: `or []` falls back to `[]` only when the value is *falsy*, so
+    a truthy non-list (string, int, dict) would still hit `for x in 42`
+    and raise TypeError. Use this helper at every iteration site.
+    """
+    if not isinstance(d, dict):
+        return []
+    v = d.get(key)
+    return v if isinstance(v, list) else []
+
+
+def _normalize_path(path: str, target_path: Optional[str]) -> str:
+    """Return the path normalised relative to target_path when possible.
+
+    - Strips a leading ``./`` (claude often emits these).
+    - Converts an absolute path under ``target_path`` to its relative form.
+    - Leaves anything else untouched (no aggressive symlink resolution).
+    """
+    if not path:
+        return path
+    p = path.strip()
+    if p.startswith("./"):
+        p = p[2:]
+    if target_path and p.startswith("/"):
+        try:
+            rel = Path(p).resolve().relative_to(Path(target_path).resolve())
+            return str(rel)
+        except (ValueError, OSError):
+            pass  # not under target_path; leave as-is
+    return p
+
+
+def _normalize_paths(context_map: Dict[str, Any],
+                     target_path: Optional[str]) -> None:
+    for section in _LOCATION_BEARING_SECTIONS:
+        for entry in _list_at(context_map, section):
+            if not isinstance(entry, dict):
+                continue
+            file = entry.get("file")
+            # Only operate on strings — guard against LLM emitting a list,
+            # int, or other non-string for `file:`. _normalize_path's
+            # str.strip() would otherwise raise.
+            if isinstance(file, str) and file:
+                entry["file"] = _normalize_path(file, target_path)
+
+
+def _find_containing_function(file_info: Dict[str, Any],
+                               line: int) -> Optional[Dict[str, Any]]:
+    """Return the function in file_info whose line range contains ``line``.
+
+    Strict pass: collect every function with both ``line_start`` and
+    ``line_end`` such that ``line_start ≤ line ≤ line_end`` and return
+    the one with the smallest span (so nested functions get attributed
+    to the innermost match, not the enclosing function).
+
+    Fallback (when no strict match): return the function with the
+    closest preceding ``line_start`` — best-effort for inventories that
+    don't track function ends. Under-approximates: a line past the end
+    of the closest preceding function still gets attributed to it.
+    """
+    funcs = file_info.get("items")
+    if not isinstance(funcs, list):
+        funcs = _list_at(file_info, "functions")
+    # Strict pass: collect every function whose range contains the line,
+    # then pick the smallest span. Smallest-span wins so that nested
+    # functions (Python closures, JS inner functions) get attributed to
+    # the innermost match, not the outer enclosing function.
+    strict_matches = []
+    for fn in funcs:
+        if not isinstance(fn, dict):
+            continue
+        line_start = fn.get("line_start") or fn.get("line")
+        line_end = fn.get("line_end")
+        # Require both bounds to be ints — string-typed line numbers
+        # from a corrupt checklist would otherwise raise TypeError on
+        # the int-vs-str comparison below. Also reject bools to avoid
+        # weird behaviour even though bool is a subclass of int.
+        if not isinstance(line_start, int) or isinstance(line_start, bool):
+            continue
+        if not isinstance(line_end, int) or isinstance(line_end, bool):
+            continue
+        if line_start <= line <= line_end:
+            strict_matches.append((line_end - line_start, fn))
+    if strict_matches:
+        strict_matches.sort(key=lambda c: c[0])
+        return strict_matches[0][1]
+    # Fallback: closest preceding line_start (under-approximates but better
+    # than nothing for inventories without line_end).
+    candidates = []
+    for fn in funcs:
+        if not isinstance(fn, dict):
+            continue
+        line_start = fn.get("line_start") or fn.get("line")
+        if not isinstance(line_start, int) or isinstance(line_start, bool):
+            continue
+        if line_start > line:
+            continue
+        candidates.append((line_start, fn))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda c: c[0], reverse=True)
+    return candidates[0][1]
+
+
+def _backfill_and_validate_locations(context_map: Dict[str, Any],
+                                      files_by_path: Dict[str, Dict[str, Any]]
+                                      ) -> None:
+    for section in _LOCATION_BEARING_SECTIONS:
+        for entry in _list_at(context_map, section):
+            if not isinstance(entry, dict):
+                continue
+            file = entry.get("file")
+            line = entry.get("line")
+            # files_by_path lookup uses dict.get(), which raises
+            # TypeError on unhashable types (list/dict). Require string.
+            if not isinstance(file, str) or not file or not isinstance(line, int):
+                continue
+
+            file_info = files_by_path.get(file)
+            if file_info is None:
+                logger.warning(
+                    "normalize_context_map: %s entry references file %s "
+                    "not present in checklist (likely LLM hallucination)",
+                    section, escape_nonprintable(file),
+                )
+                continue
+
+            total_lines = file_info.get("lines")
+            if isinstance(total_lines, int) and line > total_lines:
+                # escape_nonprintable on `file` so any control / ANSI / BIDI
+                # chars in an attacker-influenced filename get rendered as
+                # \xHH literals; raw %s would let them corrupt the terminal.
+                logger.warning(
+                    "normalize_context_map: %s entry references %s:%d "
+                    "but file has only %d lines (likely LLM hallucination)",
+                    section, escape_nonprintable(file), line, total_lines,
+                )
+                continue
+
+            # Backfill name if absent. Only backfill string names — a
+            # corrupt checklist with a non-string `name` field would
+            # otherwise propagate the type bug into context_map and
+            # crash enrich_checklist's tuple-key lookup downstream.
+            if not entry.get("name"):
+                func = _find_containing_function(file_info, line)
+                if func:
+                    func_name = func.get("name")
+                    if isinstance(func_name, str) and func_name:
+                        entry["name"] = func_name
+
+
+def _validate_cross_refs(context_map: Dict[str, Any]) -> None:
+    # Set construction requires hashable values — if claude emits an id as
+    # a list / dict, the comprehension would raise. Constrain to strings.
+    ep_ids = {
+        e.get("id") for e in _list_at(context_map, "entry_points")
+        if isinstance(e, dict) and isinstance(e.get("id"), str) and e.get("id")
+    }
+    sink_ids = {
+        s.get("id") for s in _list_at(context_map, "sink_details")
+        if isinstance(s, dict) and isinstance(s.get("id"), str) and s.get("id")
+    }
+    for flow in _list_at(context_map, "unchecked_flows"):
+        if not isinstance(flow, dict):
+            continue
+        # entry_point / sink may legitimately be either a single ID string
+        # ("EP-001") or a list of IDs (multiple sources reaching one sink).
+        # Collect into a uniform list before the membership check — set
+        # membership on a raw list would raise TypeError (lists unhashable).
+        for ep_ref in _as_id_list(flow.get("entry_point")):
+            if ep_ref not in ep_ids:
+                logger.warning(
+                    "normalize_context_map: unchecked_flow references "
+                    "entry_point %s not in entry_points list",
+                    escape_nonprintable(ep_ref),
+                )
+        for sink_ref in _as_id_list(flow.get("sink")):
+            if sink_ref not in sink_ids:
+                logger.warning(
+                    "normalize_context_map: unchecked_flow references "
+                    "sink %s not in sink_details list",
+                    escape_nonprintable(sink_ref),
+                )
+
+
+def _as_id_list(value: Any) -> List[str]:
+    """Coerce a context-map ID reference into a list of string IDs.
+
+    Accepts a single string, a list of strings (or mixed), or any other
+    type. Non-string elements are dropped silently rather than raising —
+    cross-ref validation is best-effort.
+    """
+    if value is None or value == "":
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple)):
+        return [v for v in value if isinstance(v, str) and v]
+    return []
+
+
 def enrich_checklist(checklist: Dict[str, Any], context_map: Dict[str, Any],
                      output_dir: str = None) -> Dict[str, Any]:
     """Mark entry points and sinks as high-priority in a checklist.
 
     Mutates checklist in place. Returns the checklist for chaining.
     If output_dir is provided, saves the enriched checklist (symlink-safe).
+
+    Pipeline (in order):
+      1. Normalise the context-map (path conventions, name backfill, etc.).
+      2. Clear any prior bridge-written priority markers from the
+         checklist — re-runs reflect the current context-map exactly,
+         not stale accumulation from previous runs.
+      3. Build a (file, name|None) → reasons lookup from entry_points
+         and sink_details.
+      4. Walk the checklist; mark functions matching either file-level
+         or function-level lookups; reasons accumulate as ``"+"``-joined
+         sorted strings (single ``"sink"``, paired ``"entry_point+sink"``).
+      5. Write ``priority_targets`` from ``unchecked_flows`` (cleared in
+         step 2 so absent unchecked_flows means absent priority_targets).
+
+    **Side effect:** also mutates ``context_map`` in place via
+    ``normalize_context_map`` so missing names get backfilled (enabling
+    function-level matching) and paths get normalised (avoiding silent
+    strict-equality misses). Callers that need an unmodified context_map
+    should pass a deep copy.
     """
+    # Both inputs must be dict-shaped — defensive against malformed
+    # callers (e.g. a list-typed checklist would crash on .get()).
+    if not isinstance(checklist, dict) or not isinstance(context_map, dict):
+        return checklist
     if not checklist or not context_map:
         return checklist
 
-    # Build lookup sets: (relative_path, function_name) → reason
-    priority_functions: Dict[tuple, str] = {}
+    # Normalise the context-map first so the lookup keys are consistent
+    # with the checklist's path conventions and function names get filled
+    # in from line ranges where claude omitted them.
+    normalize_context_map(context_map, checklist,
+                          target_path=checklist.get("target_path"))
 
-    for ep in context_map.get("entry_points", []):
-        file_path = ep.get("file", "")
-        if file_path:
-            # Entry points reference a file but not always a specific function —
-            # mark the file itself so Stage B reads the whole entry handler.
-            priority_functions[(file_path, None)] = "entry_point"
+    # Clear bridge-written priority markers from any prior enrich run.
+    # Without this, a function previously marked priority=high would
+    # retain that marker even after a refreshed context-map no longer
+    # references it (stale data leak across re-runs). Re-running should
+    # always reflect the current context-map's reasons exactly.
+    # enrich_checklist is the sole writer of these fields, so the clear
+    # is safe — verified by grep across the codebase.
+    _clear_prior_priority_markers(checklist)
 
-    for sink in context_map.get("sink_details", []):
-        file_path = sink.get("file", "")
-        if file_path:
-            priority_functions[(file_path, None)] = "sink"
+    # Build lookup: (relative_path, function_name_or_None) → set of reasons.
+    # When the context map provides a function name on an entry_point /
+    # sink_detail entry we use it to scope the marker to that function only;
+    # when name is absent we fall back to file-level marking (every function
+    # in the file). Reasons accumulate so a function that is both an entry
+    # point and a sink gets both labels rather than only the one written
+    # last.
+    priority_functions: Dict[tuple, set] = {}
 
-    # Walk checklist and mark matching functions
+    def _record(entry: Any, reason: str) -> None:
+        """Record a priority reason against the (file, name) key.
+
+        Constrains both file and name to strings — tuple keys go into a
+        dict and a list/dict-typed file or name would be unhashable and
+        crash setdefault. Drops malformed entries silently rather than
+        propagating the type bug. None for absent name (file-level
+        marking).
+        """
+        if not isinstance(entry, dict):
+            return
+        file_path = entry.get("file", "")
+        if not isinstance(file_path, str) or not file_path:
+            return
+        raw_name = entry.get("name")
+        name = raw_name if isinstance(raw_name, str) and raw_name else None
+        priority_functions.setdefault((file_path, name), set()).add(reason)
+
+    for ep in _list_at(context_map, "entry_points"):
+        _record(ep, "entry_point")
+    for sink in _list_at(context_map, "sink_details"):
+        _record(sink, "sink")
+
+    # Walk checklist and mark matching functions. A function inherits
+    # file-level reasons (entries written without a name) plus any
+    # reasons keyed to its specific function name.
     for file_info in checklist.get("files", []):
+        if not isinstance(file_info, dict):
+            continue
         path = file_info.get("path", "")
-        file_reason = priority_functions.get((path, None))
+        if not isinstance(path, str):
+            continue
+        file_level_reasons = priority_functions.get((path, None), set())
 
-        if file_reason:
-            # Mark all functions in this file as high priority
-            for func in file_info.get("items", file_info.get("functions", [])):
+        funcs = file_info.get("items")
+        if not isinstance(funcs, list):
+            funcs = _list_at(file_info, "functions")
+        for func in funcs:
+            if not isinstance(func, dict):
+                continue
+            raw_fname = func.get("name")
+            # Function-level lookup needs a string name — non-string
+            # would crash dict.get on the tuple key. Falling back to ""
+            # means we just won't find a function-level match (file-level
+            # reasons may still apply).
+            fname = raw_fname if isinstance(raw_fname, str) else ""
+            func_level_reasons = priority_functions.get((path, fname), set())
+            reasons = file_level_reasons | func_level_reasons
+            if reasons:
                 func["priority"] = "high"
-                func["priority_reason"] = file_reason
+                # Deterministic concat — single reason renders as before
+                # ("entry_point" or "sink"); the entry+sink case becomes
+                # "entry_point+sink" (sorted alphabetically). Existing
+                # consumers (analysis prompt builder, agent metadata copy)
+                # render the string verbatim, no equality checks, so the
+                # combined form passes through cleanly.
+                func["priority_reason"] = "+".join(sorted(reasons))
 
-    # Add unchecked flows as priority targets at the checklist level
-    unchecked = context_map.get("unchecked_flows", [])
-    if unchecked:
-        checklist["priority_targets"] = [
-            {
-                "entry_point": flow.get("entry_point"),
-                "sink": flow.get("sink"),
-                "missing_boundary": flow.get("missing_boundary"),
-                "source": "understand:map",
-            }
+    # Add unchecked flows as priority targets at the checklist level.
+    # Each target also carries resolved entry-point / sink details
+    # (file, line, name) looked up from the context-map, so downstream
+    # consumers (Stage B prompts, /diagram, etc.) don't have to do the
+    # ID → details join themselves. Additive — original ID fields are
+    # preserved.
+    unchecked = context_map.get("unchecked_flows")
+    # Require a real list — accepting any truthy value would silently
+    # produce an empty priority_targets for malformed shapes (e.g.
+    # context-map with unchecked_flows: "string"), which is more
+    # surprising than just leaving the cleared key absent.
+    if isinstance(unchecked, list) and unchecked:
+        ep_by_id, sink_by_id = _index_entries_by_id(context_map)
+        targets = [
+            _build_priority_target(flow, ep_by_id, sink_by_id)
             for flow in unchecked
+            if isinstance(flow, dict)
         ]
-        logger.info(
-            "understand_bridge: marked %d unchecked flows as priority targets",
-            len(unchecked),
-        )
+        if targets:
+            checklist["priority_targets"] = targets
+            logger.info(
+                "understand_bridge: marked %d unchecked flows as priority targets",
+                len(targets),
+            )
 
     if output_dir:
         from core.inventory import save_checklist
         save_checklist(output_dir, checklist)
 
     return checklist
+
+
+def _index_entries_by_id(context_map: Dict[str, Any]
+                          ) -> Tuple[Dict[str, Dict[str, Any]],
+                                     Dict[str, Dict[str, Any]]]:
+    """Build {id → entry} lookups for entry_points and sink_details.
+
+    Skips entries with missing or non-string IDs (matching the defensive
+    posture of _validate_cross_refs). Returns a pair (ep_by_id, sink_by_id).
+    """
+    ep_by_id: Dict[str, Dict[str, Any]] = {}
+    for ep in _list_at(context_map, "entry_points"):
+        if not isinstance(ep, dict):
+            continue
+        ep_id = ep.get("id")
+        if isinstance(ep_id, str) and ep_id:
+            ep_by_id[ep_id] = ep
+    sink_by_id: Dict[str, Dict[str, Any]] = {}
+    for sd in _list_at(context_map, "sink_details"):
+        if not isinstance(sd, dict):
+            continue
+        sd_id = sd.get("id")
+        if isinstance(sd_id, str) and sd_id:
+            sink_by_id[sd_id] = sd
+    return ep_by_id, sink_by_id
+
+
+def _resolve_id_to_details(value: Any, by_id: Dict[str, Dict[str, Any]]
+                            ) -> List[Dict[str, Any]]:
+    """Resolve a single ID or list of IDs into a list of detail dicts.
+
+    Each detail keeps only the fields a downstream consumer actually
+    needs: id, file, line, name. Missing IDs (typos, etc.) are dropped
+    silently — _validate_cross_refs has already warned about them.
+    Always returns a list for shape consistency.
+
+    Type-checks each copied field — drops malformed values (list-typed
+    file, string-typed line, etc.) rather than propagating the type bug
+    to downstream consumers.
+    """
+    resolved: List[Dict[str, Any]] = []
+    for ref in _as_id_list(value):
+        entry = by_id.get(ref)
+        if not entry:
+            continue
+        out: Dict[str, Any] = {"id": ref}
+        # file / name must be non-empty strings; line must be int (and
+        # not bool, which is an int subclass in Python).
+        file_v = entry.get("file")
+        if isinstance(file_v, str) and file_v:
+            out["file"] = file_v
+        line_v = entry.get("line")
+        if isinstance(line_v, int) and not isinstance(line_v, bool):
+            out["line"] = line_v
+        name_v = entry.get("name")
+        if isinstance(name_v, str) and name_v:
+            out["name"] = name_v
+        resolved.append(out)
+    return resolved
+
+
+def _build_priority_target(flow: Dict[str, Any],
+                            ep_by_id: Dict[str, Dict[str, Any]],
+                            sink_by_id: Dict[str, Dict[str, Any]]
+                            ) -> Dict[str, Any]:
+    """Build a priority_targets entry from one unchecked_flow.
+
+    Preserves the original raw ID fields for backward compatibility and
+    adds ``entry_points_resolved`` / ``sinks_resolved`` lists with each
+    referenced entry's file / line / name pulled from the context-map.
+    """
+    return {
+        "entry_point": flow.get("entry_point"),
+        "sink": flow.get("sink"),
+        "missing_boundary": flow.get("missing_boundary"),
+        "source": "understand:map",
+        "entry_points_resolved": _resolve_id_to_details(
+            flow.get("entry_point"), ep_by_id),
+        "sinks_resolved": _resolve_id_to_details(
+            flow.get("sink"), sink_by_id),
+    }
+
+
+def _clear_prior_priority_markers(checklist: Dict[str, Any]) -> None:
+    """Remove bridge-written priority data so re-enrichment starts clean.
+
+    Targets:
+      - per-function ``priority`` and ``priority_reason`` fields
+      - top-level ``priority_targets`` list
+
+    Without this, a refreshed context-map that no longer references a
+    previously-marked function would leave the stale marker in place,
+    misleading downstream consumers (analysis prompt enrichment etc.)
+    into thinking a now-irrelevant function is on a security-sensitive
+    path.
+    """
+    checklist.pop("priority_targets", None)
+    for file_info in _list_at(checklist, "files"):
+        if not isinstance(file_info, dict):
+            continue
+        funcs = file_info.get("items")
+        if not isinstance(funcs, list):
+            funcs = _list_at(file_info, "functions")
+        for func in funcs:
+            if not isinstance(func, dict):
+                continue
+            func.pop("priority", None)
+            func.pop("priority_reason", None)
 
 
 # ---------------------------------------------------------------------------
@@ -422,16 +891,20 @@ def _references_file(entry: Dict[str, Any], stale_files: Set[str]) -> bool:
     """
     import re
 
-    # Direct file field (entry_points, sink_details, trust_boundaries)
+    # Direct file field (entry_points, sink_details, trust_boundaries).
+    # Constrain to strings — list/dict values would crash set membership
+    # (lists aren't hashable). Pre-existing weakness exposed once the
+    # upstream normalize started letting non-string `file:` values
+    # through unmodified.
     f = entry.get("file", "")
-    if f and f in stale_files:
+    if isinstance(f, str) and f and f in stale_files:
         return True
 
     # Embedded in string fields — extract filename before ":"
     # Patterns: "... @ file.c:N", "file.c:N — ...", "src/auth.py:12"
     for field in ("entry", "location", "check"):
         val = entry.get(field, "")
-        if not val:
+        if not isinstance(val, str) or not val:
             continue
         # Extract all "word.ext:digits" tokens (filenames with line numbers)
         for match in re.findall(r'[\w./+-]+\.\w+(?=:\d)', val):
@@ -620,16 +1093,19 @@ def _import_flow_traces(
     for trace_file in trace_files:
         trace = load_json(trace_file)
         if not isinstance(trace, dict):
-            logger.warning("understand_bridge: skipping malformed trace file %s", trace_file)
+            logger.warning("understand_bridge: skipping malformed trace file %s",
+                           escape_nonprintable(str(trace_file)))
             continue
 
         path_id = trace.get("id", trace_file.stem)
         if path_id in existing_ids:
-            logger.debug("understand_bridge: skipping already-imported trace %s", path_id)
+            logger.debug("understand_bridge: skipping already-imported trace %s",
+                         escape_nonprintable(str(path_id)))
             continue
 
         if stale_files and _trace_references_stale(trace, stale_files):
-            logger.info("understand_bridge: skipping stale trace %s", path_id)
+            logger.info("understand_bridge: skipping stale trace %s",
+                        escape_nonprintable(str(path_id)))
             skipped_stale += 1
             continue
 

--- a/libexec/raptor-normalize-context-map
+++ b/libexec/raptor-normalize-context-map
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Normalise a context-map.json in place using the run dir's checklist.json.
+
+Usage: raptor-normalize-context-map <understand_dir>
+
+Wraps core.orchestration.understand_bridge.normalize_context_map for
+invocation from skill markdown. Lets /understand --map clean its output
+right after writing context-map.json so anyone reading the on-disk file
+sees the normalised data — not just consumers that go through the bridge
+on read.
+
+Idempotent — safe to run more than once. Logs warnings for any
+hallucinated files / out-of-range lines / cross-ref typos but never
+errors out (a usable context-map should still get saved).
+"""
+import json
+import sys
+from pathlib import Path
+
+# libexec/raptor-normalize-context-map -> repo root (parents[1])
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.json import load_json, save_json
+from core.orchestration.understand_bridge import normalize_context_map
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: raptor-normalize-context-map <understand_dir>",
+              file=sys.stderr)
+        return 1
+
+    understand_dir = Path(sys.argv[1])
+    if not understand_dir.is_dir():
+        print(f"raptor-normalize-context-map: {understand_dir} is not a directory",
+              file=sys.stderr)
+        return 1
+
+    context_map_path = understand_dir / "context-map.json"
+    if not context_map_path.exists():
+        print(f"raptor-normalize-context-map: {context_map_path} does not exist",
+              file=sys.stderr)
+        return 1
+
+    context_map = load_json(context_map_path)
+    if not isinstance(context_map, dict):
+        print(f"raptor-normalize-context-map: {context_map_path} is not a JSON object",
+              file=sys.stderr)
+        return 1
+
+    checklist = load_json(understand_dir / "checklist.json") or {}
+    target_path = checklist.get("target_path") if isinstance(checklist, dict) else None
+
+    normalize_context_map(context_map, checklist, target_path=target_path)
+    save_json(context_map_path, context_map)
+    print(f"raptor-normalize-context-map: normalised {context_map_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/libexec/tests/test_raptor_normalize_context_map.py
+++ b/libexec/tests/test_raptor_normalize_context_map.py
@@ -1,0 +1,113 @@
+"""Tests for the libexec/raptor-normalize-context-map wrapper."""
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WRAPPER = REPO_ROOT / "libexec" / "raptor-normalize-context-map"
+
+
+def _run(*args, **kwargs):
+    """Invoke the wrapper as a real subprocess (matches how skills call it)."""
+    return subprocess.run(
+        [str(WRAPPER), *args],
+        capture_output=True, text=True, timeout=15, **kwargs,
+    )
+
+
+class RaptorNormalizeContextMapWrapperTests(unittest.TestCase):
+
+    def test_wrapper_exists_and_is_executable(self):
+        self.assertTrue(WRAPPER.exists(), msg=f"missing: {WRAPPER}")
+        self.assertTrue(os.access(WRAPPER, os.X_OK),
+                        msg=f"not executable: {WRAPPER}")
+
+    def test_no_args_prints_usage_and_fails(self):
+        proc = _run()
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("Usage:", proc.stderr)
+
+    def test_missing_understand_dir_fails_cleanly(self):
+        proc = _run("/nonexistent/path/that/does/not/exist")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("not a directory", proc.stderr)
+
+    def test_missing_context_map_fails_cleanly(self):
+        with TemporaryDirectory() as tmp:
+            # Dir exists but no context-map.json — should fail with a
+            # specific message, not a Python traceback.
+            proc = _run(tmp)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("does not exist", proc.stderr)
+
+    def test_normalises_in_place_with_checklist(self):
+        # Happy path: context-map.json present, checklist present, wrapper
+        # backfills the name and normalises the path. Verifies the wrapper
+        # actually mutates the file on disk (the whole point of doing this
+        # at write time rather than only on read).
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "context-map.json").write_text(json.dumps({
+                "entry_points": [{"file": "./app.py", "line": 12}],
+            }))
+            (tmp / "checklist.json").write_text(json.dumps({
+                "target_path": str(tmp),
+                "files": [{
+                    "path": "app.py", "lines": 50,
+                    "functions": [{"name": "handle", "line_start": 10, "line_end": 25}],
+                }],
+            }))
+            proc = _run(str(tmp))
+            self.assertEqual(proc.returncode, 0,
+                             msg=f"wrapper failed: {proc.stderr}")
+
+            normalised = json.loads((tmp / "context-map.json").read_text())
+            entry = normalised["entry_points"][0]
+            self.assertEqual(entry["file"], "app.py")  # ./ stripped
+            self.assertEqual(entry["name"], "handle")  # backfilled
+
+    def test_works_without_checklist_present(self):
+        # If checklist.json is absent (e.g. caller skipped MAP-0), the
+        # wrapper should still normalise paths (the only fixup that doesn't
+        # require ground-truth inventory).
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "context-map.json").write_text(json.dumps({
+                "entry_points": [{"file": "./app.py", "line": 5}],
+            }))
+            proc = _run(str(tmp))
+            self.assertEqual(proc.returncode, 0,
+                             msg=f"wrapper failed: {proc.stderr}")
+            normalised = json.loads((tmp / "context-map.json").read_text())
+            self.assertEqual(normalised["entry_points"][0]["file"], "app.py")
+
+    def test_idempotent_on_repeated_invocation(self):
+        # Re-running the wrapper on already-normalised data must not change
+        # it — important because the skill may invoke it multiple times in
+        # iterative sessions.
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "context-map.json").write_text(json.dumps({
+                "entry_points": [{"file": "app.py", "line": 12, "name": "h"}],
+            }))
+            (tmp / "checklist.json").write_text(json.dumps({
+                "files": [{
+                    "path": "app.py", "lines": 50,
+                    "functions": [{"name": "h", "line_start": 10, "line_end": 25}],
+                }],
+            }))
+            _run(str(tmp))
+            first = (tmp / "context-map.json").read_text()
+            _run(str(tmp))
+            second = (tmp / "context-map.json").read_text()
+            self.assertEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reworks core/orchestration/understand_bridge.enrich_checklist so the priority markers it writes into checklist.json reflect the granularity the context map actually provides:

  - Match on (file, function name) when the context map names a function, falling back to (file, None) only when name is absent. Files that contain both an entry point and a sink now retain both signals via a "+"-concatenated priority_reason ("entry_point+sink") rather than the second one overwriting the first.
  - Clear prior priority markers before re-applying so re-runs reflect the current context map instead of accumulating stale markers.
  - Resolve unchecked-flow IDs to full entry/sink details under checklist["priority_targets"] so Stage B has the resolved record in front of it, not a bare ID lookup.

Adds normalize_context_map() — a mechanical pre-pass that strips leading "./", converts absolute paths under target_path to relative, backfills missing function names from line ranges (smallest-span for nested functions), warns on file/line references the checklist disproves, and validates unchecked_flow ID cross-references.  Exposed to the standalone /understand --map flow via a new MAP-5 step in the skill markdown calling the libexec/raptor-normalize-context-map shim, so non-validate runs benefit from the same fixups the bridge applies.

Adopts core/security/log_sanitisation.escape_nonprintable (shipped on main with sandbox #210) for every operator-facing logger call in this file that interpolates an LLM-emitted string — file paths, entry/sink ID references, trace file paths, stale-file lists.  Without this, a malicious target repo could inject ANSI escapes, BIDI overrides, or BEL into raptor's own warning output.  Two regression tests lock the contract in.

Also fixes a CI flake in test_happy_path_runs_lifecycle_and_writes_ selection_file — the assertion that finding IDs do not appear in the post-pass prompt used 1-2 char IDs ("f1", "f2", "f3"), which can collide with the 8-char random suffix tempfile.mkdtemp generates. Renamed to FNDA-EXPLOITABLE / FNDB-HIGHCONF / FNDC-IGNORED so the hyphen + uppercase rules them out of mkdtemp's character set.