### PR TITLE
fixed exploitability verdict bug in tests

### DIFF
--- a/packages/exploit_feasibility/tests/test_integration.py
+++ b/packages/exploit_feasibility/tests/test_integration.py
@@ -88,11 +88,19 @@ class TestAnalyzeBinaryIntegration:
         assert isinstance(result, dict)
 
     def test_analyze_binary_has_verdict(self, test_binary):
-        """Test that result includes verdict."""
+        """Test that result includes verdict.
+
+        The allowed set is derived from ``ExploitabilityVerdict`` so the
+        assertion stays in sync with the enum and tracks every legitimate
+        outcome — including ``unknown``, which the analyzer correctly
+        emits when binary protections and glibc version are both
+        undeterminable (e.g. running on macOS with no checksec).
+        """
         from ..api import analyze_binary
+        from ..vuln_types import ExploitabilityVerdict
         result = analyze_binary(test_binary)
         assert 'verdict' in result
-        valid_verdicts = ['likely_exploitable', 'difficult', 'unlikely', 'blocked', 'requires_environment', 'error']
+        valid_verdicts = {v.value for v in ExploitabilityVerdict}
         assert result['verdict'] in valid_verdicts
 
     def test_analyze_binary_has_protections(self, test_binary):


### PR DESCRIPTION
The ExploitabilityVerdict enum is works, but the test's allowed-list is just wrong and breaks on MacOS so may break elsewhere.
                                                                                                                                        
**Root cause (packages/exploit_feasibility/tests/test_integration.py:95):

```
valid_verdicts = ['likely_exploitable', 'difficult', 'unlikely', 'blocked', 'requires_environment', 'error']
```                   

Compared with the actual ExploitabilityVerdict enum at packages/exploit_feasibility/vuln_types.py:11–17:                              

```
EXPLOITABLE = "exploitable"
LIKELY_EXPLOITABLE = "likely_exploitable"
DIFFICULT = "difficult"
UNLIKELY = "unlikely"
UNKNOWN = "unknown" 
```

The list:                                                                                                                             
  - Mentions three values that don't exist — 'blocked', 'requires_environment', 'error'.
  - Omits two that do — 'exploitable' and 'unknown'.                                                                                    

On macOS the analyzer can't run checksec or detect the system glibc (Linux-only toolchain), so analyzer.py:2535–2542 legitimately assigns UNKNOWN:

```                                                                                                              
  if not protections_collected and not glibc_known:
      report.verdict = ExploitabilityVerdict.UNKNOWN                                                                                    
```

Fix — replace the allowed-list with the actual enum values:                                                                           

```
  valid_verdicts = [v.value for v in ExploitabilityVerdict]
```