### PR TITLE
SMT Parser; Set Reasons for better feedback to agent

### DIFF
--- a/.claude/skills/exploitability-validation/stage-e-feasibility.md
+++ b/.claude/skills/exploitability-validation/stage-e-feasibility.md
@@ -184,7 +184,34 @@ Output is JSON to stdout:
 
 **Profile mismatch is a silent failure mode.** If you analyse `unsigned int` arithmetic under `uint64`, Z3 misses 32-bit wraparound and the `feasible: false` verdict you get is wrong (the path IS reachable via 32-bit wrap). Match the profile to the dominant C type's width. The reasoning string spells out what was used (`"feasible (32-bit unsigned): ..."`) — if it doesn't match the vuln's real C type, treat the verdict as suspect.
 
-**Iterate on `unknown`.** If the verdict comes back with a non-empty `unknown` bucket, the parser couldn't encode those forms. Re-read the source, re-express the rejected forms in parser-compatible shape (introduce a helper variable, drop the cast, split a complex condition, replace a function call with the predicate it computes), and re-invoke. One refinement pass usually closes the gap. If a second pass still has unknowns, the conditions are genuinely outside the bitvector fragment — stop iterating and fall back to qualitative reasoning rather than chasing further.
+**Iterate on `unknown` using `unknown_reasons`.** When the verdict comes back with non-empty `unknown`, the parallel `unknown_reasons` array tells you *exactly why* each condition was dropped — read those rather than guessing. Each entry has the shape:
+
+```json
+{
+  "text": "01234 < limit",
+  "kind": "literal_ambiguous",
+  "detail": "leading-zero decimal is ambiguous with C octal",
+  "hint": "rewrite as hex (0x...) or strip the leading zero"
+}
+```
+
+The `kind` values you'll see and the surgical fix for each:
+
+| `kind`                  | What happened                                           | Fix                                                                                              |
+| ----------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `parens_not_supported`  | Function call / cast / grouping parens                  | Replace the call with the predicate it computes, or introduce a helper var (`n = strlen(input)`) |
+| `unrecognized_form`     | No relational / bitmask shape at top level              | Wrap in a relation, e.g. `flag` → `flag != 0`                                                    |
+| `unrecognized_operand`  | Token isn't an ident / NULL / hex / dec literal         | Look at `detail` for the offending token; rename or replace                                      |
+| `unsupported_operator`  | Op outside `{+, -, *, |, >>, <<}` in the expression     | Rewrite using only the supported set, or split into multiple conditions                          |
+| `mixed_precedence`      | Additive *and* multiplicative/bitwise mixed             | Split into two conditions, each using one operator class                                         |
+| `trailing_tokens`       | Tokens left unconsumed (e.g. `a + b c`)                 | Insert the missing operator                                                                      |
+| `literal_ambiguous`     | Leading-zero decimal — could be C octal                 | `01234` → `0x4d2` or `1234`                                                                      |
+| `literal_out_of_range`  | Literal exceeds `--profile` width                       | Switch to a wider profile, or check the literal is correct for the real C type                   |
+| `lex_empty`             | Tokeniser saw no tokens (empty / whitespace-only input) | Drop the condition — there's nothing to encode                                                   |
+| `solver_timeout`        | Z3 couldn't decide within the timeout                   | Simplify the conditions (drop redundant ones); don't keep retrying — the result is still `null`  |
+| `solver_unknown`        | Z3 returned unknown for some other reason               | Same — fall back to qualitative reasoning                                                        |
+
+If the rejection's `hint` field is non-empty, prefer it over your own guess — the hint is written by the parser at the exact failure site and names the concrete fix. One targeted refinement pass usually closes the gap. If a second pass still has the same `kind` for the same `text`, stop iterating and fall back to qualitative reasoning — you're outside the bitvector fragment.
 
 The verdict is only as trustworthy as the conditions you extract — a `false` verdict on an incomplete condition set is a hint, not proof.
 

--- a/core/smt_solver/__init__.py
+++ b/core/smt_solver/__init__.py
@@ -38,7 +38,13 @@ from .config import (
     BV_X86_64,
 )
 from .explain import core_names, track
-from .rejection import Rejection, RejectionKind
+from .rejection import (
+    Rejection,
+    RejectionKind,
+    classify_solver_unknown,
+    parse_literal_value,
+    propagate,
+)
 from .session import DEFAULT_TIMEOUT_MS, new_solver, scoped
 from .witness import bv_to_int, format_vars, format_witness
 
@@ -81,4 +87,7 @@ __all__ = [
     # Structured parser rejection reasons
     "Rejection",
     "RejectionKind",
+    "propagate",
+    "parse_literal_value",
+    "classify_solver_unknown",
 ]

--- a/core/smt_solver/__init__.py
+++ b/core/smt_solver/__init__.py
@@ -38,6 +38,7 @@ from .config import (
     BV_X86_64,
 )
 from .explain import core_names, track
+from .rejection import Rejection, RejectionKind
 from .session import DEFAULT_TIMEOUT_MS, new_solver, scoped
 from .witness import bv_to_int, format_vars, format_witness
 
@@ -77,4 +78,7 @@ __all__ = [
     # Unsat-core explanation
     "track",
     "core_names",
+    # Structured parser rejection reasons
+    "Rejection",
+    "RejectionKind",
 ]

--- a/core/smt_solver/rejection.py
+++ b/core/smt_solver/rejection.py
@@ -1,0 +1,81 @@
+"""Structured rejection reasons for SMT encoder parsers.
+
+When a domain encoder (``smt_path_validator``, ``smt_onegadget``) can't
+turn a constraint string into a Z3 expression, the failure is recorded
+as a :class:`Rejection` rather than just a textual entry in an
+``unknown`` list.  The :class:`RejectionKind` tells callers — and the
+LLM that produced the text — *why* the parse failed, so the long tail
+of unparseable inputs can be retried with a rephrasing or fed back as
+schema feedback rather than disappearing into a bag of strings.
+
+Each domain encoder result keeps its existing ``unknown: List[str]``
+field for backwards compatibility and adds a parallel
+``unknown_reasons: List[Rejection]`` carrying the structured form.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class RejectionKind(str, Enum):
+    """Why the parser refused to encode a constraint."""
+
+    LEX_EMPTY = "lex_empty"
+    """Tokeniser produced no tokens — input was empty or pure whitespace."""
+
+    UNRECOGNIZED_FORM = "unrecognized_form"
+    """Top-level structure didn't match any accepted condition pattern."""
+
+    UNRECOGNIZED_OPERAND = "unrecognized_operand"
+    """A token in operand position isn't a register, identifier, literal,
+    NULL, or memory reference accepted by the encoder."""
+
+    UNSUPPORTED_OPERATOR = "unsupported_operator"
+    """An operator outside the accepted set appeared in the expression."""
+
+    PARENS_NOT_SUPPORTED = "parens_not_supported"
+    """Input contained ``(`` or ``)`` — function calls and grouping
+    aren't supported by the current grammar."""
+
+    MIXED_PRECEDENCE = "mixed_precedence"
+    """Expression mixed additive and multiplicative/bitwise operators.
+    The parser is strictly left-to-right with no precedence, so it
+    rejects mixed forms rather than risk silent mis-encoding."""
+
+    TRAILING_TOKENS = "trailing_tokens"
+    """Tokens were left unconsumed after parsing (e.g. ``a b``)."""
+
+    LITERAL_OUT_OF_RANGE = "literal_out_of_range"
+    """Integer literal doesn't fit in the active profile width;
+    accepting it would silently wrap inside ``z3.BitVecVal``."""
+
+    LITERAL_AMBIGUOUS = "literal_ambiguous"
+    """Decimal literal had a leading zero — ambiguous with C octal."""
+
+    UNKNOWN_REGISTER = "unknown_register"
+    """Token looked register-shaped but isn't in the active
+    architecture's register set."""
+
+    SOLVER_TIMEOUT = "solver_timeout"
+    """Z3 returned ``unknown`` and reported the per-solver timeout was hit."""
+
+    SOLVER_UNKNOWN = "solver_unknown"
+    """Z3 returned ``unknown`` for some other reason (incomplete tactic,
+    construct outside the decidable bitvector fragment)."""
+
+
+@dataclass(frozen=True)
+class Rejection:
+    """Why a single constraint/condition couldn't participate in SMT analysis.
+
+    ``text`` is the original input verbatim so callers can match it back
+    to a source location.  ``kind`` is the machine-readable category;
+    ``detail`` carries free-form context (e.g. the offending token);
+    ``hint`` (when non-empty) names a concrete rephrasing that would let
+    a retry succeed.
+    """
+    text: str
+    kind: RejectionKind
+    detail: str = ""
+    hint: str = ""

--- a/core/smt_solver/rejection.py
+++ b/core/smt_solver/rejection.py
@@ -11,11 +11,28 @@ schema feedback rather than disappearing into a bag of strings.
 Each domain encoder result keeps its existing ``unknown: List[str]``
 field for backwards compatibility and adds a parallel
 ``unknown_reasons: List[Rejection]`` carrying the structured form.
+
+This module also hosts the small set of helpers every encoder needs to
+*build* and *route* rejections so future encoders pick them up for free
+instead of cloning the logic:
+
+- :func:`propagate` — re-anchor a sub-expression's rejection on its
+  parent's full input text.
+- :func:`parse_literal_value` — validate a hex/decimal literal against
+  the active :class:`BVProfile`, returning the int or a structured
+  :class:`Rejection` (out-of-range, leading-zero ambiguity, or
+  unrecognised shape).
+- :func:`classify_solver_unknown` — translate Z3's ``reason_unknown()``
+  string into ``SOLVER_TIMEOUT`` vs ``SOLVER_UNKNOWN``.
 """
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any, Union
+
+from .config import BVProfile
 
 
 class RejectionKind(str, Enum):
@@ -79,3 +96,78 @@ class Rejection:
     kind: RejectionKind
     detail: str = ""
     hint: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Shared encoder helpers
+# ---------------------------------------------------------------------------
+
+# Anchored via .fullmatch() at the call site, so the patterns themselves
+# are intentionally unanchored — they accept the whole token or nothing.
+_HEX_LITERAL_RE = re.compile(r'0x[0-9a-f]+', re.IGNORECASE)
+_DEC_LITERAL_RE = re.compile(r'\d+')
+
+
+def propagate(text: str, sub: Rejection) -> Rejection:
+    """Re-anchor a sub-expression rejection on the full input text.
+
+    Sub-parsers see only their own slice of input, so ``sub.text``
+    starts out as that slice.  When bubbling up to the caller we
+    replace it with ``text`` (the parent's full input) so consumers
+    can match the rejection back to the original source.
+    """
+    return Rejection(text, sub.kind, sub.detail, sub.hint)
+
+
+def parse_literal_value(tok: str, profile: BVProfile) -> Union[int, Rejection]:
+    """Validate and convert a literal token, or return a structured rejection.
+
+    Centralised so atom-position literals and bitmask-form literals
+    across all encoders reject the same things:
+
+    - Out-of-range for ``profile.width`` (would silently wrap inside
+      ``z3.BitVecVal``, e.g. ``0x100`` at uint8 → 0, producing a
+      misleading verdict) → :data:`RejectionKind.LITERAL_OUT_OF_RANGE`.
+    - Leading-zero decimals (octal in C, ambiguous if interpreted as
+      base-10) → :data:`RejectionKind.LITERAL_AMBIGUOUS`.
+    - Anything that isn't a clean hex or decimal literal
+      → :data:`RejectionKind.UNRECOGNIZED_OPERAND`.
+    """
+    if _HEX_LITERAL_RE.fullmatch(tok):
+        v = int(tok, 16)
+    elif _DEC_LITERAL_RE.fullmatch(tok):
+        if len(tok) > 1 and tok[0] == "0":
+            return Rejection(
+                tok, RejectionKind.LITERAL_AMBIGUOUS,
+                "leading-zero decimal is ambiguous with C octal",
+                hint="rewrite as hex (0x...) or strip the leading zero",
+            )
+        v = int(tok)
+    else:
+        return Rejection(
+            tok, RejectionKind.UNRECOGNIZED_OPERAND,
+            f"token {tok!r} is not a hex or decimal literal",
+        )
+    if v >= (1 << profile.width):
+        return Rejection(
+            tok, RejectionKind.LITERAL_OUT_OF_RANGE,
+            f"value {v:#x} exceeds {profile.width}-bit profile range",
+        )
+    return v
+
+
+def classify_solver_unknown(solver: Any) -> RejectionKind:
+    """Map Z3's ``reason_unknown()`` string to a :class:`RejectionKind`.
+
+    Z3 reports ``"timeout"`` (or, on some builds, ``"canceled"``) when
+    the per-solver timeout fires; anything else is grouped under
+    :data:`RejectionKind.SOLVER_UNKNOWN` (incomplete tactic, undecidable
+    fragment, ...).
+    """
+    try:
+        reason = (solver.reason_unknown() or "").lower()
+    except Exception:
+        return RejectionKind.SOLVER_UNKNOWN
+    if "timeout" in reason or "canceled" in reason or "cancelled" in reason:
+        return RejectionKind.SOLVER_TIMEOUT
+    return RejectionKind.SOLVER_UNKNOWN

--- a/core/smt_solver/tests/test_rejection.py
+++ b/core/smt_solver/tests/test_rejection.py
@@ -1,0 +1,123 @@
+"""Tests for core.smt_solver.rejection helpers."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# core/smt_solver/tests/ -> repo root
+sys.path.insert(0, str(Path(__file__).parents[3]))
+
+from core.smt_solver import (
+    BV_C_UINT8,
+    BV_C_UINT64,
+    Rejection,
+    RejectionKind,
+    classify_solver_unknown,
+    parse_literal_value,
+    propagate,
+)
+
+
+# ---------------------------------------------------------------------------
+# classify_solver_unknown
+# ---------------------------------------------------------------------------
+
+class TestClassifySolverUnknown:
+    """Maps Z3's ``reason_unknown()`` text to SOLVER_TIMEOUT vs SOLVER_UNKNOWN."""
+
+    def _mock(self, reason):
+        m = MagicMock()
+        m.reason_unknown.return_value = reason
+        return m
+
+    def test_timeout(self):
+        assert classify_solver_unknown(self._mock("timeout")) is RejectionKind.SOLVER_TIMEOUT
+
+    def test_canceled_us_spelling(self):
+        assert classify_solver_unknown(self._mock("canceled")) is RejectionKind.SOLVER_TIMEOUT
+
+    def test_cancelled_uk_spelling(self):
+        assert classify_solver_unknown(self._mock("cancelled")) is RejectionKind.SOLVER_TIMEOUT
+
+    def test_uppercase_normalised(self):
+        # The classifier lowercases before matching.
+        assert classify_solver_unknown(self._mock("TIMEOUT")) is RejectionKind.SOLVER_TIMEOUT
+
+    def test_substring_match(self):
+        # Z3 sometimes wraps the reason ("(canceled): ..."); substring is fine.
+        assert classify_solver_unknown(self._mock("(canceled) per-call timeout")) is RejectionKind.SOLVER_TIMEOUT
+
+    def test_other_reason_is_solver_unknown(self):
+        assert classify_solver_unknown(self._mock("incomplete tactic")) is RejectionKind.SOLVER_UNKNOWN
+
+    def test_empty_reason_is_solver_unknown(self):
+        assert classify_solver_unknown(self._mock("")) is RejectionKind.SOLVER_UNKNOWN
+
+    def test_none_reason_is_solver_unknown(self):
+        # Some Z3 builds return None instead of "".  The helper coerces with
+        # ``or ""`` so it still classifies cleanly.
+        assert classify_solver_unknown(self._mock(None)) is RejectionKind.SOLVER_UNKNOWN
+
+    def test_reason_unknown_raises(self):
+        # Defensive: solver missing reason_unknown() shouldn't crash callers.
+        m = MagicMock()
+        m.reason_unknown.side_effect = AttributeError
+        assert classify_solver_unknown(m) is RejectionKind.SOLVER_UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# propagate
+# ---------------------------------------------------------------------------
+
+class TestPropagate:
+    """Re-anchors a sub-rejection's text on the parent input."""
+
+    def test_replaces_text_keeps_other_fields(self):
+        sub = Rejection("inner", RejectionKind.UNRECOGNIZED_OPERAND, "detail", "hint")
+        out = propagate("full outer text", sub)
+        assert out.text == "full outer text"
+        assert out.kind is RejectionKind.UNRECOGNIZED_OPERAND
+        assert out.detail == "detail"
+        assert out.hint == "hint"
+
+    def test_returns_new_instance(self):
+        sub = Rejection("inner", RejectionKind.LEX_EMPTY)
+        out = propagate("outer", sub)
+        assert out is not sub
+
+
+# ---------------------------------------------------------------------------
+# parse_literal_value
+# ---------------------------------------------------------------------------
+
+class TestParseLiteralValue:
+    """Centralised literal validation across all encoders."""
+
+    def test_decimal(self):
+        assert parse_literal_value("42", BV_C_UINT64) == 42
+
+    def test_hex(self):
+        assert parse_literal_value("0xff", BV_C_UINT64) == 0xff
+
+    def test_hex_uppercase(self):
+        assert parse_literal_value("0xFF", BV_C_UINT64) == 0xff
+
+    def test_leading_zero_decimal_rejected(self):
+        r = parse_literal_value("01234", BV_C_UINT64)
+        assert isinstance(r, Rejection)
+        assert r.kind is RejectionKind.LITERAL_AMBIGUOUS
+
+    def test_zero_alone_accepted(self):
+        # "0" has length 1 so the leading-zero check doesn't fire.
+        assert parse_literal_value("0", BV_C_UINT64) == 0
+
+    def test_out_of_range(self):
+        # 0x100 doesn't fit in uint8 (range 0..0xff).
+        r = parse_literal_value("0x100", BV_C_UINT8)
+        assert isinstance(r, Rejection)
+        assert r.kind is RejectionKind.LITERAL_OUT_OF_RANGE
+
+    def test_unrecognised_token(self):
+        r = parse_literal_value("notALiteral", BV_C_UINT64)
+        assert isinstance(r, Rejection)
+        assert r.kind is RejectionKind.UNRECOGNIZED_OPERAND

--- a/libexec/raptor-smt-validate-path
+++ b/libexec/raptor-smt-validate-path
@@ -32,6 +32,10 @@ Output: JSON to stdout with keys
   satisfied       conditions that are tautologies
   unsatisfied     conditions in the unsat core (when feasible=false)
   unknown         conditions the parser could not encode
+  unknown_reasons structured-rejection objects parallel to ``unknown``;
+                  each carries ``kind`` (e.g. "literal_ambiguous",
+                  "parens_not_supported") and an optional ``hint`` for
+                  targeted retry
   smt_available   true if z3-solver is loaded
 
 Exit code: always 0 on a well-formed invocation.  A ``feasible: false``

--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -94,10 +94,13 @@ from core.smt_solver import (
     DEFAULT_TIMEOUT_MS as _DEFAULT_TIMEOUT_MS,
     Rejection,
     RejectionKind,
+    classify_solver_unknown as _classify_solver_unknown,
     core_names as _core_names,
     mk_val as _mk_val,
     mk_var as _mk_var,
     new_solver as _new_solver,
+    parse_literal_value as _parse_literal_value,
+    propagate as _propagate,
     scoped as _scoped,
     track as _track,
     z3,
@@ -156,42 +159,6 @@ _TOKEN_RE = re.compile(
     r'(0x[0-9a-f]+|\d+|[a-z_][a-z0-9_]*|[+\-*]|<=|>=|!=|==|>>|<<|[<>&|])',
     re.IGNORECASE,
 )
-
-
-def _parse_literal_value(tok: str, profile: BVProfile) -> Union[int, Rejection]:
-    """Validate and convert a literal token, or return a structured rejection.
-
-    Centralised so atom-position literals and bitmask-form literals both
-    reject the same things:
-
-    - Out-of-range for profile width (would silently wrap in z3.BitVecVal)
-      → :data:`RejectionKind.LITERAL_OUT_OF_RANGE`.
-    - Leading-zero decimals (octal in C, ambiguous if interpreted as base-10)
-      → :data:`RejectionKind.LITERAL_AMBIGUOUS`.
-    - Anything that isn't a clean hex or decimal literal
-      → :data:`RejectionKind.UNRECOGNIZED_OPERAND`.
-    """
-    if _HEX_RE.match(tok):
-        v = int(tok, 16)
-    elif _INT_RE.match(tok):
-        if len(tok) > 1 and tok[0] == "0":
-            return Rejection(
-                tok, RejectionKind.LITERAL_AMBIGUOUS,
-                "leading-zero decimal is ambiguous with C octal",
-                hint="rewrite as hex (0x...) or strip the leading zero",
-            )
-        v = int(tok)
-    else:
-        return Rejection(
-            tok, RejectionKind.UNRECOGNIZED_OPERAND,
-            f"token {tok!r} is not a hex or decimal literal",
-        )
-    if v >= (1 << profile.width):
-        return Rejection(
-            tok, RejectionKind.LITERAL_OUT_OF_RANGE,
-            f"value {v:#x} exceeds {profile.width}-bit profile range",
-        )
-    return v
 
 
 def _parse_expr(
@@ -296,17 +263,6 @@ def _parse_expr(
         )
 
     return result
-
-
-def _propagate(text: str, sub: Rejection) -> Rejection:
-    """Re-anchor a sub-expression rejection on the full condition text.
-
-    Sub-expression parsers see only their own slice of the input, so a
-    rejection's ``text`` field starts out as that slice.  When bubbling
-    up to the condition level we replace it with the full condition so
-    callers can match the rejection back to the original input.
-    """
-    return Rejection(text, sub.kind, sub.detail, sub.hint)
 
 
 def _parse_condition(
@@ -554,20 +510,3 @@ def check_path_feasibility(
         model={}, smt_available=True,
         reasoning=f"Z3 returned unknown ({mode}) — {detail}",
     )
-
-
-def _classify_solver_unknown(solver: Any) -> RejectionKind:
-    """Map Z3's ``reason_unknown()`` string to our rejection kind.
-
-    Z3 reports ``"timeout"`` (or, on some builds, ``"canceled"``) when
-    the per-solver timeout fires; anything else is grouped under
-    :data:`RejectionKind.SOLVER_UNKNOWN` (incomplete tactic, undecidable
-    fragment, ...).
-    """
-    try:
-        reason = (solver.reason_unknown() or "").lower()
-    except Exception:
-        return RejectionKind.SOLVER_UNKNOWN
-    if "timeout" in reason or "canceled" in reason or "cancelled" in reason:
-        return RejectionKind.SOLVER_TIMEOUT
-    return RejectionKind.SOLVER_UNKNOWN

--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -84,14 +84,16 @@ Integration: packages/codeql/dataflow_validator.py :: DataflowValidator
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from core.logging import get_logger as _get_logger
 from core.smt_solver import (
     BV_C_UINT64,
     BVProfile,
     DEFAULT_TIMEOUT_MS as _DEFAULT_TIMEOUT_MS,
+    Rejection,
+    RejectionKind,
     core_names as _core_names,
     mk_val as _mk_val,
     mk_var as _mk_var,
@@ -120,7 +122,14 @@ class PathCondition:
 
 @dataclass
 class PathSMTResult:
-    """Result of SMT feasibility check over a set of path conditions."""
+    """Result of SMT feasibility check over a set of path conditions.
+
+    ``unknown`` keeps the original list-of-strings form for callers that
+    only care which texts were dropped.  ``unknown_reasons`` carries the
+    same set in :class:`Rejection` form, naming *why* each was dropped
+    (parser failure kind, solver timeout, ...) so consumers can retry,
+    rephrase, or surface diagnostics.
+    """
     feasible: Optional[bool]
     satisfied: List[str]
     unsatisfied: List[str]
@@ -128,6 +137,7 @@ class PathSMTResult:
     model: Dict[str, int]
     smt_available: bool
     reasoning: str
+    unknown_reasons: List[Rejection] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -148,30 +158,45 @@ _TOKEN_RE = re.compile(
 )
 
 
-def _parse_literal_value(tok: str, profile: BVProfile) -> Optional[int]:
-    """Validate and convert a literal token to int, or None if invalid.
+def _parse_literal_value(tok: str, profile: BVProfile) -> Union[int, Rejection]:
+    """Validate and convert a literal token, or return a structured rejection.
 
     Centralised so atom-position literals and bitmask-form literals both
     reject the same things:
 
-    - Out-of-range for profile width (would silently wrap in z3.BitVecVal).
-    - Leading-zero decimals (octal in C, ambiguous if interpreted as base-10).
-    - Anything that isn't a clean hex or decimal literal.
+    - Out-of-range for profile width (would silently wrap in z3.BitVecVal)
+      → :data:`RejectionKind.LITERAL_OUT_OF_RANGE`.
+    - Leading-zero decimals (octal in C, ambiguous if interpreted as base-10)
+      → :data:`RejectionKind.LITERAL_AMBIGUOUS`.
+    - Anything that isn't a clean hex or decimal literal
+      → :data:`RejectionKind.UNRECOGNIZED_OPERAND`.
     """
     if _HEX_RE.match(tok):
         v = int(tok, 16)
     elif _INT_RE.match(tok):
         if len(tok) > 1 and tok[0] == "0":
-            return None  # ambiguous with C octal
+            return Rejection(
+                tok, RejectionKind.LITERAL_AMBIGUOUS,
+                "leading-zero decimal is ambiguous with C octal",
+                hint="rewrite as hex (0x...) or strip the leading zero",
+            )
         v = int(tok)
     else:
-        return None
+        return Rejection(
+            tok, RejectionKind.UNRECOGNIZED_OPERAND,
+            f"token {tok!r} is not a hex or decimal literal",
+        )
     if v >= (1 << profile.width):
-        return None
+        return Rejection(
+            tok, RejectionKind.LITERAL_OUT_OF_RANGE,
+            f"value {v:#x} exceeds {profile.width}-bit profile range",
+        )
     return v
 
 
-def _parse_expr(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Optional[Any]:
+def _parse_expr(
+    text: str, vars_: Dict[str, Any], *, profile: BVProfile,
+) -> Union[Any, Rejection]:
     """Parse an arithmetic expression into a Z3 bitvector at the given profile.
 
     Handles: identifier, NULL, hex literal, decimal literal, and binary
@@ -180,32 +205,46 @@ def _parse_expr(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Opti
     signedness so the same ``>>`` source form encodes differently for
     signed vs unsigned path conditions.
 
-    Returns None — rather than a partial result — when an unsupported
-    token is encountered mid-expression, so the whole condition falls
-    through to the unknown list rather than being silently mis-encoded.
+    Returns a :class:`Rejection` — rather than a partial Z3 expression —
+    when something can't be encoded, so the whole condition falls through
+    to the unknown list with a structured reason rather than being
+    silently mis-encoded.
     """
     tokens = [t for t in _TOKEN_RE.findall(text.strip()) if t not in ('(', ')')]
     if not tokens:
-        return None
+        return Rejection(text, RejectionKind.LEX_EMPTY, "no tokens after tokenisation")
 
     # Reject if any non-whitespace character was silently dropped by the
     # tokeniser — characters like '~' (NOT), '^' (XOR), '/', '%' aren't in
     # the token regex and would otherwise vanish, producing wrong answers
     # (e.g. "~mask == 0xFF" mis-encoded as "mask == 0xFF").
     if "".join(tokens) != re.sub(r"\s+", "", text):
-        return None
+        return Rejection(
+            text, RejectionKind.UNRECOGNIZED_OPERAND,
+            "non-tokenisable character was silently dropped by the tokeniser",
+            hint="remove or rephrase unsupported operators (e.g. ~, ^, /, %)",
+        )
 
     # Reject mixed-operator expressions to avoid silent mis-encoding due to
     # the lack of operator precedence (currently strictly left-to-right).
     if {'+', '-'} & set(tokens[1::2]) and {'*', '>>', '<<', '|'} & set(tokens[1::2]):
-        return None
+        return Rejection(
+            text, RejectionKind.MIXED_PRECEDENCE,
+            "additive and multiplicative/bitwise ops mixed",
+            hint="split into separate conditions, each using one operator class",
+        )
 
     def atom(tok: str) -> Optional[Any]:
         if _NULL_RE.match(tok):
             return _mk_val(0, profile.width)
         if _HEX_RE.match(tok) or _INT_RE.match(tok):
             v = _parse_literal_value(tok, profile)
-            return None if v is None else _mk_val(v, profile.width)
+            # Atom-level literal failures collapse to None and surface as
+            # generic UNRECOGNIZED_OPERAND at the loop boundary; the more
+            # specific reasons (LITERAL_AMBIGUOUS / LITERAL_OUT_OF_RANGE)
+            # are preserved on the bitmask path which calls
+            # _parse_literal_value directly.
+            return None if isinstance(v, Rejection) else _mk_val(v, profile.width)
         if _IDENT_RE.match(tok):
             if tok.lower() not in vars_:
                 vars_[tok.lower()] = _mk_var(tok.lower(), profile.width)
@@ -213,18 +252,27 @@ def _parse_expr(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Opti
         return None
 
     # Left-to-right accumulation of arithmetic and bitwise operators.
-    # Any unsupported operator causes an immediate None return.
+    # Any unsupported operator yields a structured rejection.
     result = atom(tokens[0])
     if result is None:
-        return None
+        return Rejection(
+            text, RejectionKind.UNRECOGNIZED_OPERAND,
+            f"token {tokens[0]!r} is not an identifier, NULL, or numeric literal",
+        )
     i = 1
     while i < len(tokens) - 1:
         op = tokens[i]
         if op not in ('+', '-', '*', '|', '>>', '<<'):
-            return None  # unsupported op — reject cleanly
+            return Rejection(
+                text, RejectionKind.UNSUPPORTED_OPERATOR,
+                f"operator {op!r} not in {{+, -, *, |, >>, <<}}",
+            )
         right = atom(tokens[i + 1])
         if right is None:
-            return None
+            return Rejection(
+                text, RejectionKind.UNRECOGNIZED_OPERAND,
+                f"token {tokens[i + 1]!r} is not an identifier, NULL, or numeric literal",
+            )
         if op == '+':
             result = result + right
         elif op == '-':
@@ -241,14 +289,29 @@ def _parse_expr(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Opti
             result = result << right
         i += 2
 
-    # Reject orphaned trailing tokens.
     if i != len(tokens):
-        return None
+        return Rejection(
+            text, RejectionKind.TRAILING_TOKENS,
+            f"unconsumed token {tokens[i]!r}",
+        )
 
     return result
 
 
-def _parse_condition(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Optional[Any]:
+def _propagate(text: str, sub: Rejection) -> Rejection:
+    """Re-anchor a sub-expression rejection on the full condition text.
+
+    Sub-expression parsers see only their own slice of the input, so a
+    rejection's ``text`` field starts out as that slice.  When bubbling
+    up to the condition level we replace it with the full condition so
+    callers can match the rejection back to the original input.
+    """
+    return Rejection(text, sub.kind, sub.detail, sub.hint)
+
+
+def _parse_condition(
+    text: str, vars_: Dict[str, Any], *, profile: BVProfile,
+) -> Union[Any, Rejection]:
     """Parse a single condition string into a Z3 boolean expression.
 
     Recognised forms:
@@ -258,12 +321,17 @@ def _parse_condition(text: str, vars_: Dict[str, Any], *, profile: BVProfile) ->
       lhs & mask != val
 
     Conditions containing function-call syntax (parentheses) are rejected
-    and return None — they go to the unknown list.
+    with :data:`RejectionKind.PARENS_NOT_SUPPORTED` — they go to the
+    unknown list.
     """
     t = text.strip()
 
     if '(' in t or ')' in t:
-        return None
+        return Rejection(
+            text, RejectionKind.PARENS_NOT_SUPPORTED,
+            "input contains '(' or ')'",
+            hint="rewrite function calls or grouped subterms as a synthetic identifier",
+        )
 
     # Bitmask: lhs & mask (==|!=) val
     m = re.fullmatch(
@@ -272,16 +340,19 @@ def _parse_condition(text: str, vars_: Dict[str, Any], *, profile: BVProfile) ->
     )
     if m:
         lhs = _parse_expr(m.group(1).strip(), vars_, profile=profile)
-        if lhs is None:
-            return None
+        if isinstance(lhs, Rejection):
+            return _propagate(text, lhs)
         # Mask and rhs literals go through the same validation as atom-level
         # literals — width range and leading-zero ambiguity must be rejected
         # the same way, otherwise the bitmask path silently wraps or trips
-        # ValueError on octal-style tokens.
+        # ValueError on octal-style tokens.  Specific Rejection reasons
+        # (LITERAL_AMBIGUOUS / LITERAL_OUT_OF_RANGE) are preserved here.
         mask_val = _parse_literal_value(m.group(2), profile)
+        if isinstance(mask_val, Rejection):
+            return _propagate(text, mask_val)
         rhs_val = _parse_literal_value(m.group(4), profile)
-        if mask_val is None or rhs_val is None:
-            return None
+        if isinstance(rhs_val, Rejection):
+            return _propagate(text, rhs_val)
         masked = lhs & _mk_val(mask_val, profile.width)
         rhs = _mk_val(rhs_val, profile.width)
         return (masked == rhs) if m.group(3) == '==' else (masked != rhs)
@@ -296,9 +367,11 @@ def _parse_condition(text: str, vars_: Dict[str, Any], *, profile: BVProfile) ->
     )
     if m:
         lhs = _parse_expr(m.group(1).strip(), vars_, profile=profile)
+        if isinstance(lhs, Rejection):
+            return _propagate(text, lhs)
         rhs = _parse_expr(m.group(3).strip(), vars_, profile=profile)
-        if lhs is None or rhs is None:
-            return None
+        if isinstance(rhs, Rejection):
+            return _propagate(text, rhs)
         op = m.group(2)
         if op == '==':
             return lhs == rhs
@@ -313,7 +386,12 @@ def _parse_condition(text: str, vars_: Dict[str, Any], *, profile: BVProfile) ->
         if op == '>=':
             return ge(lhs, rhs, signed=profile.signed)
 
-    return None
+    return Rejection(
+        text, RejectionKind.UNRECOGNIZED_FORM,
+        "no relational or bitmask pattern matched",
+        hint="use 'lhs OP rhs' with OP in {==, !=, <, <=, >, >=}, "
+             "or 'lhs & MASK (==|!=) VAL' for bitmask alignment",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -350,6 +428,7 @@ def check_path_feasibility(
             feasible=None,
             satisfied=[], unsatisfied=[],
             unknown=[c.text for c in conditions],
+            unknown_reasons=[],
             model={}, smt_available=False,
             reasoning="z3 not available — install z3-solver for path feasibility analysis",
         )
@@ -358,6 +437,7 @@ def check_path_feasibility(
         return PathSMTResult(
             feasible=True,
             satisfied=[], unsatisfied=[], unknown=[],
+            unknown_reasons=[],
             model={}, smt_available=True,
             reasoning=f"no conditions ({mode}) — path is unconditionally reachable",
         )
@@ -367,13 +447,17 @@ def check_path_feasibility(
 
     satisfied: List[str] = []
     unknown: List[str] = []
+    unknown_reasons: List[Rejection] = []
     pending: List[Tuple[str, Any]] = []
 
     for cond in conditions:
         expr = _parse_condition(cond.text, vars_, profile=profile)
-        if expr is None:
-            _get_logger().debug(f"smt_path_validator: unparseable condition: {cond.text!r}")
+        if isinstance(expr, Rejection):
+            _get_logger().debug(
+                f"smt_path_validator: rejected {cond.text!r} ({expr.kind.value}: {expr.detail})"
+            )
             unknown.append(cond.text)
+            unknown_reasons.append(expr)
             continue
 
         final_expr = z3.Not(expr) if cond.negated else expr
@@ -398,6 +482,7 @@ def check_path_feasibility(
             return PathSMTResult(
                 feasible=None,
                 satisfied=satisfied, unsatisfied=[], unknown=unknown,
+                unknown_reasons=unknown_reasons,
                 model={}, smt_available=True,
                 reasoning=(
                     f"indeterminate ({mode}): {len(satisfied)} trivially satisfied, "
@@ -407,6 +492,7 @@ def check_path_feasibility(
         return PathSMTResult(
             feasible=True,
             satisfied=satisfied, unsatisfied=[], unknown=[],
+            unknown_reasons=[],
             model={}, smt_available=True,
             reasoning=f"all {len(satisfied)} condition(s) trivially satisfied ({mode})",
         )
@@ -419,6 +505,7 @@ def check_path_feasibility(
         return PathSMTResult(
             feasible=True,
             satisfied=satisfied, unsatisfied=[], unknown=unknown,
+            unknown_reasons=unknown_reasons,
             model=model_dict, smt_available=True,
             reasoning=(
                 f"feasible ({mode}): {len(pending)} condition(s) are jointly satisfiable"
@@ -436,18 +523,51 @@ def check_path_feasibility(
         return PathSMTResult(
             feasible=False,
             satisfied=satisfied, unsatisfied=conflict_set, unknown=unknown,
+            unknown_reasons=unknown_reasons,
             model={}, smt_available=True,
             reasoning=reasoning,
         )
 
-    # z3.unknown — timeout or outside decidable fragment
+    # z3.unknown — timeout or outside decidable fragment.  Tag every
+    # pending condition with the structured reason so callers can tell a
+    # solver punt apart from a parser failure.
+    solver_reason = _classify_solver_unknown(solver)
+    pending_texts = [t for t, _ in pending]
+    pending_reasons = [
+        Rejection(
+            t, solver_reason,
+            f"Z3 reason_unknown: {solver.reason_unknown()}"
+            if hasattr(solver, "reason_unknown") else "",
+        )
+        for t in pending_texts
+    ]
+    detail = (
+        f"likely the {_DEFAULT_TIMEOUT_MS}ms timeout"
+        if solver_reason is RejectionKind.SOLVER_TIMEOUT
+        else "conditions outside the decidable bitvector fragment"
+    )
     return PathSMTResult(
         feasible=None,
         satisfied=satisfied, unsatisfied=[],
-        unknown=unknown + [t for t, _ in pending],
+        unknown=unknown + pending_texts,
+        unknown_reasons=unknown_reasons + pending_reasons,
         model={}, smt_available=True,
-        reasoning=(
-            f"Z3 returned unknown ({mode}) — likely the {_DEFAULT_TIMEOUT_MS}ms timeout "
-            f"or conditions outside the bitvector fragment"
-        ),
+        reasoning=f"Z3 returned unknown ({mode}) — {detail}",
     )
+
+
+def _classify_solver_unknown(solver: Any) -> RejectionKind:
+    """Map Z3's ``reason_unknown()`` string to our rejection kind.
+
+    Z3 reports ``"timeout"`` (or, on some builds, ``"canceled"``) when
+    the per-solver timeout fires; anything else is grouped under
+    :data:`RejectionKind.SOLVER_UNKNOWN` (incomplete tactic, undecidable
+    fragment, ...).
+    """
+    try:
+        reason = (solver.reason_unknown() or "").lower()
+    except Exception:
+        return RejectionKind.SOLVER_UNKNOWN
+    if "timeout" in reason or "canceled" in reason or "cancelled" in reason:
+        return RejectionKind.SOLVER_TIMEOUT
+    return RejectionKind.SOLVER_UNKNOWN

--- a/packages/codeql/tests/test_smt_path_validator.py
+++ b/packages/codeql/tests/test_smt_path_validator.py
@@ -624,9 +624,20 @@ class TestStructuredRejection:
         assert self._kind_for(r, "a + b * c == 0") is RejectionKind.MIXED_PRECEDENCE
 
     @_requires_z3
-    def test_trailing_tokens_rejection(self):
+    def test_no_relational_at_top_level_rejection(self):
+        """``a b`` has no relational/bitmask top-level shape, so
+        :func:`_parse_condition` itself rejects with UNRECOGNIZED_FORM —
+        no _parse_expr call ever sees the trailing token."""
         r = check_path_feasibility([PathCondition("a b", step_index=0)])
         assert self._kind_for(r, "a b") is RejectionKind.UNRECOGNIZED_FORM
+
+    @_requires_z3
+    def test_trailing_tokens_rejection(self):
+        """A trailing operand inside an expression slot — the relational
+        top-level matches, then _parse_expr can't consume the dangling
+        ``c`` and emits TRAILING_TOKENS."""
+        r = check_path_feasibility([PathCondition("a + b c == 0", step_index=0)])
+        assert self._kind_for(r, "a + b c == 0") is RejectionKind.TRAILING_TOKENS
 
     @_requires_z3
     def test_unrecognized_form_rejection(self):

--- a/packages/codeql/tests/test_smt_path_validator.py
+++ b/packages/codeql/tests/test_smt_path_validator.py
@@ -9,7 +9,7 @@ import pytest
 # packages/codeql/tests/ -> repo root
 sys.path.insert(0, str(Path(__file__).parents[3]))
 
-from core.smt_solver import z3_available
+from core.smt_solver import RejectionKind, z3_available
 from packages.codeql.smt_path_validator import (
     PathCondition,
     PathSMTResult,
@@ -586,3 +586,70 @@ class TestParametricProfile:
         base, size = r.model["base"], r.model["size"]
         assert (base + size) & 0xFFFFFFFF <= 8192
         assert base > 0x80000000
+
+
+class TestStructuredRejection:
+    """`unknown_reasons` should classify *why* each unparseable condition
+    was dropped, parallel to the textual `unknown` list."""
+
+    def _kind_for(self, result, text):
+        for r in result.unknown_reasons:
+            if r.text == text:
+                return r.kind
+        raise AssertionError(
+            f"no Rejection for {text!r} in {result.unknown_reasons!r}"
+        )
+
+    def test_no_z3_reasons_empty(self):
+        """When Z3 is unavailable everything goes to unknown but we
+        don't synthesise per-condition rejection reasons — there's no
+        parser/solver to assign blame to."""
+        with patch("packages.codeql.smt_path_validator._z3_available", return_value=False):
+            r = check_path_feasibility([PathCondition("size > 0", step_index=0)])
+        assert r.unknown == ["size > 0"]
+        assert r.unknown_reasons == []
+
+    @_requires_z3
+    def test_parens_rejection(self):
+        r = check_path_feasibility([
+            PathCondition("validate(ptr, len) == 0", step_index=0),
+        ])
+        assert self._kind_for(r, "validate(ptr, len) == 0") is RejectionKind.PARENS_NOT_SUPPORTED
+
+    @_requires_z3
+    def test_mixed_precedence_rejection(self):
+        r = check_path_feasibility([
+            PathCondition("a + b * c == 0", step_index=0),
+        ])
+        assert self._kind_for(r, "a + b * c == 0") is RejectionKind.MIXED_PRECEDENCE
+
+    @_requires_z3
+    def test_trailing_tokens_rejection(self):
+        r = check_path_feasibility([PathCondition("a b", step_index=0)])
+        assert self._kind_for(r, "a b") is RejectionKind.UNRECOGNIZED_FORM
+
+    @_requires_z3
+    def test_unrecognized_form_rejection(self):
+        """A condition without a relational/bitmask top-level pattern."""
+        r = check_path_feasibility([PathCondition("size_only", step_index=0)])
+        assert self._kind_for(r, "size_only") is RejectionKind.UNRECOGNIZED_FORM
+
+    @_requires_z3
+    def test_rejection_carries_hint(self):
+        r = check_path_feasibility([
+            PathCondition("validate(ptr, len) == 0", step_index=0),
+        ])
+        rej = next(x for x in r.unknown_reasons if x.text == "validate(ptr, len) == 0")
+        assert rej.hint  # non-empty
+        assert "synthetic identifier" in rej.hint or "rewrite" in rej.hint.lower()
+
+    @_requires_z3
+    def test_rejection_aligned_with_unknown_list(self):
+        """For every entry in `unknown`, there's a `unknown_reasons` entry
+        with the same text."""
+        r = check_path_feasibility([
+            PathCondition("size > 0", step_index=0),                    # parses
+            PathCondition("validate(p) == 0", step_index=1),            # parens
+            PathCondition("a + b * c == 0", step_index=2),              # mixed prec
+        ])
+        assert set(r.unknown) == {x.text for x in r.unknown_reasons}

--- a/packages/exploit_feasibility/smt_onegadget.py
+++ b/packages/exploit_feasibility/smt_onegadget.py
@@ -33,14 +33,16 @@ Crash state sources accepted by check_onegadget():
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from core.logging import get_logger as _get_logger
 from core.smt_solver import (
     BV_X86_64,
     BVProfile,
     DEFAULT_TIMEOUT_MS as _DEFAULT_TIMEOUT_MS,
+    Rejection,
+    RejectionKind,
     core_names as _core_names,
     mk_val as _mk_val,
     mk_var as _mk_var,
@@ -61,7 +63,14 @@ from .context import OneGadget
 
 @dataclass
 class OneGadgetSMTResult:
-    """Result of SMT-based one-gadget constraint analysis."""
+    """Result of SMT-based one-gadget constraint analysis.
+
+    ``unknown`` keeps the original list-of-strings form for callers that
+    only care which constraint texts were dropped.  ``unknown_reasons``
+    carries the same set in :class:`Rejection` form, naming *why* each
+    was dropped (parser failure kind, solver timeout, ...) so consumers
+    can retry, rephrase, or surface diagnostics.
+    """
     feasible: Optional[bool]      # True/False/None (None = z3 unavailable or unparseable)
     satisfied: List[str]          # constraints already met by the provided crash_state
     unsatisfied: List[str]        # constraints proven false given crash_state
@@ -71,6 +80,7 @@ class OneGadgetSMTResult:
     # is separate — see ``analyze_binary()['smt_available']``.
     smt_available: bool
     reasoning: str
+    unknown_reasons: List[Rejection] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -96,43 +106,67 @@ _HEX_LIT_RE = re.compile(r'0x[0-9a-f]+', re.IGNORECASE)
 _DEC_LIT_RE = re.compile(r'\d+')
 
 
-def _parse_literal_value(tok: str, profile: BVProfile) -> Optional[int]:
-    """Validate and convert a literal token to int, or None if invalid.
+def _parse_literal_value(tok: str, profile: BVProfile) -> Union[int, Rejection]:
+    """Validate and convert a literal token, or return a structured rejection.
 
     Centralised so atom-position literals and bitmask-form literals both
     reject the same things:
 
     - Out-of-range for profile width (would silently wrap in z3.BitVecVal,
-      e.g. 0x100 at uint8 → 0, producing a misleading verdict).
-    - Leading-zero decimals (octal in C, ambiguous if interpreted as base-10).
-    - Anything that isn't a clean hex or decimal literal.
+      e.g. 0x100 at uint8 → 0, producing a misleading verdict)
+      → :data:`RejectionKind.LITERAL_OUT_OF_RANGE`.
+    - Leading-zero decimals (octal in C, ambiguous if interpreted as base-10)
+      → :data:`RejectionKind.LITERAL_AMBIGUOUS`.
+    - Anything that isn't a clean hex or decimal literal
+      → :data:`RejectionKind.UNRECOGNIZED_OPERAND`.
     """
     if _HEX_LIT_RE.fullmatch(tok):
         v = int(tok, 16)
     elif _DEC_LIT_RE.fullmatch(tok):
         if len(tok) > 1 and tok[0] == "0":
-            return None  # ambiguous with C octal
+            return Rejection(
+                tok, RejectionKind.LITERAL_AMBIGUOUS,
+                "leading-zero decimal is ambiguous with C octal",
+                hint="rewrite as hex (0x...) or strip the leading zero",
+            )
         v = int(tok)
     else:
-        return None
+        return Rejection(
+            tok, RejectionKind.UNRECOGNIZED_OPERAND,
+            f"token {tok!r} is not a hex or decimal literal",
+        )
     if v >= (1 << profile.width):
-        return None
+        return Rejection(
+            tok, RejectionKind.LITERAL_OUT_OF_RANGE,
+            f"value {v:#x} exceeds {profile.width}-bit profile range",
+        )
     return v
 
 
-def _reg_var(name: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Optional[Any]:
+def _reg_var(name: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Union[Any, Rejection]:
     name = name.lower()
     if name not in _X86_64_REGS:
-        return None
+        return Rejection(
+            name, RejectionKind.UNKNOWN_REGISTER,
+            f"register {name!r} is not in the x86_64 register set",
+            hint="use one of the recognised x86_64 register names "
+                 "(rax, rbx, rcx, rdx, rsi, rdi, rbp, rsp, r8–r15, rip)",
+        )
     if name not in vars_:
         vars_[name] = _mk_var(name, profile.width)
     return vars_[name]
 
 
-def _mem_var(reg: str, op: str, raw_offset: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Optional[Any]:
+def _mem_var(
+    reg: str, op: str, raw_offset: str, vars_: Dict[str, Any], *, profile: BVProfile,
+) -> Union[Any, Rejection]:
     reg_lc = reg.lower()
     if reg_lc not in _X86_64_REGS:
-        return None
+        return Rejection(
+            reg_lc, RejectionKind.UNKNOWN_REGISTER,
+            f"register {reg_lc!r} is not in the x86_64 register set",
+            hint="use one of the recognised x86_64 register names",
+        )
     offset = int(raw_offset, 16) if raw_offset.startswith("0x") else int(raw_offset)
     key = f"mem_{reg_lc}{op}{offset:#x}"
     if key not in vars_:
@@ -140,7 +174,7 @@ def _mem_var(reg: str, op: str, raw_offset: str, vars_: Dict[str, Any], *, profi
     return vars_[key]
 
 
-def _parse_operand(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Optional[Any]:
+def _parse_operand(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Union[Any, Rejection]:
     """Parse a single operand into a Z3 expression at ``profile.width``.
 
     Accepted forms (case-insensitive):
@@ -150,13 +184,20 @@ def _parse_operand(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> O
       [rXX]                → memory at [reg+0]
       [rXX ± offset]       → memory at [reg±offset]
       rXX ± offset         → bracket-free memory form
+
+    Returns a :class:`Rejection` (rather than a partial expression) for
+    anything outside this set, with ``text`` set to the operand slice
+    so callers can re-anchor it on the full constraint via
+    :func:`_propagate`.
     """
     t = text.strip()
     if t.upper() == "NULL":
         return _mk_val(0, profile.width)
     if _HEX_LIT_RE.fullmatch(t) or _DEC_LIT_RE.fullmatch(t):
         v = _parse_literal_value(t, profile)
-        return None if v is None else _mk_val(v, profile.width)
+        if isinstance(v, Rejection):
+            return v
+        return _mk_val(v, profile.width)
 
     mem_m = _MEM_RE.fullmatch(t)
     if mem_m:
@@ -168,12 +209,27 @@ def _parse_operand(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> O
     if _REG_RE.fullmatch(t):
         return _reg_var(t, vars_, profile=profile)
 
-    return None
+    return Rejection(
+        t, RejectionKind.UNRECOGNIZED_OPERAND,
+        f"token {t!r} is not NULL, a literal, a register, or a memory reference",
+    )
 
 
-def _parse_atom(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Optional[Any]:
+def _propagate(text: str, sub: Rejection) -> Rejection:
+    """Re-anchor a sub-expression rejection on the full constraint text.
+
+    Sub-parsers see only their own slice of input, so a rejection's
+    ``text`` field starts out as that slice.  When bubbling up to the
+    constraint level we replace it with the full constraint so callers
+    can match the rejection back to the original input.
     """
-    Parse a single predicate atom into a Z3 expression.
+    return Rejection(text, sub.kind, sub.detail, sub.hint)
+
+
+def _parse_atom(
+    text: str, vars_: Dict[str, Any], *, profile: BVProfile,
+) -> Union[Any, Rejection]:
+    """Parse a single predicate atom into a Z3 expression.
 
     Recognised forms (case-insensitive):
       <lhs> == <rhs>            → equality (rhs may be register, memory, NULL, or integer literal)
@@ -185,8 +241,8 @@ def _parse_atom(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Opti
       <lhs> & <mask> != <val>   → bitmask non-alignment
 
     ``<lhs>`` / ``<rhs>`` accept any form handled by ``_parse_operand``.
-    Constraints that cannot be parsed return ``None`` and are bubbled up
-    to ``_parse_constraint`` as "unknown".
+    Returns a :class:`Rejection` rather than a partial expression when
+    parsing fails; the caller propagates it upward via :func:`_propagate`.
     """
     t = text.strip()
 
@@ -198,13 +254,17 @@ def _parse_atom(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Opti
     m = re.search(r'\s+is\s+writable\s*$', t, re.IGNORECASE)
     if m:
         lhs = _parse_operand(t[:m.start()].strip(), vars_, profile=profile)
-        return None if lhs is None else (lhs != _mk_val(0, profile.width))
+        if isinstance(lhs, Rejection):
+            return _propagate(text, lhs)
+        return lhs != _mk_val(0, profile.width)
 
     # English suffix form: "... is NULL"  → lhs == 0
     m = re.search(r'\s+is\s+null\s*$', t, re.IGNORECASE)
     if m:
         lhs = _parse_operand(t[:m.start()].strip(), vars_, profile=profile)
-        return None if lhs is None else (lhs == _mk_val(0, profile.width))
+        if isinstance(lhs, Rejection):
+            return _propagate(text, lhs)
+        return lhs == _mk_val(0, profile.width)
 
     # Bitmask alignment: <lhs> & <mask> (==|!=) <value>   e.g. "rsp & 0xf == 0"
     m = re.fullmatch(
@@ -213,16 +273,18 @@ def _parse_atom(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Opti
     )
     if m:
         lhs = _parse_operand(m.group(1).strip(), vars_, profile=profile)
-        if lhs is None:
-            return None
+        if isinstance(lhs, Rejection):
+            return _propagate(text, lhs)
         # Mask and rhs literals go through the same validation as atom-level
         # literals — width range and leading-zero ambiguity must be rejected
         # the same way, otherwise the bitmask path silently wraps or trips
         # ValueError on octal-style tokens.
         mask_val = _parse_literal_value(m.group(2), profile)
+        if isinstance(mask_val, Rejection):
+            return _propagate(text, mask_val)
         rhs_val = _parse_literal_value(m.group(4), profile)
-        if mask_val is None or rhs_val is None:
-            return None
+        if isinstance(rhs_val, Rejection):
+            return _propagate(text, rhs_val)
         masked = lhs & _mk_val(mask_val, profile.width)
         rhs    = _mk_val(rhs_val, profile.width)
         return (masked == rhs) if m.group(3) == "==" else (masked != rhs)
@@ -231,17 +293,25 @@ def _parse_atom(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Opti
     m = re.fullmatch(r'(.+?)\s*(==|!=)\s*(.+)', t)
     if m:
         lhs = _parse_operand(m.group(1).strip(), vars_, profile=profile)
+        if isinstance(lhs, Rejection):
+            return _propagate(text, lhs)
         rhs = _parse_operand(m.group(3).strip(), vars_, profile=profile)
-        if lhs is None or rhs is None:
-            return None
+        if isinstance(rhs, Rejection):
+            return _propagate(text, rhs)
         return (lhs == rhs) if m.group(2) == "==" else (lhs != rhs)
 
-    return None
+    return Rejection(
+        text, RejectionKind.UNRECOGNIZED_FORM,
+        "no atom pattern matched",
+        hint="use 'lhs (==|!=) rhs', 'lhs is {writable,NULL}', "
+             "or 'lhs & MASK (==|!=) VAL'",
+    )
 
 
-def _parse_constraint(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Optional[Any]:
-    """
-    Parse a one_gadget constraint line into a Z3 expression.
+def _parse_constraint(
+    text: str, vars_: Dict[str, Any], *, profile: BVProfile,
+) -> Union[Any, Rejection]:
+    """Parse a one_gadget constraint line into a Z3 expression.
 
     Handles:
       atom
@@ -249,9 +319,12 @@ def _parse_constraint(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -
       atom1 AND atom2 AND ...  (conjunction)
       atom1 && atom2 && ...    (conjunction)
 
-    Returns None if any sub-part cannot be parsed — the whole line goes to unknown.
+    Returns the first :class:`Rejection` encountered if any sub-part
+    fails to parse — the whole line goes to unknown with that reason.
     """
     t = text.strip()
+    if not t:
+        return Rejection(text, RejectionKind.LEX_EMPTY, "empty constraint")
 
     or_clauses = re.split(r'\|\|', t)
     or_exprs = []
@@ -260,13 +333,13 @@ def _parse_constraint(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -
         and_exprs = []
         for part in and_parts:
             expr = _parse_atom(part.strip(), vars_, profile=profile)
-            if expr is None:
-                return None
+            if isinstance(expr, Rejection):
+                return _propagate(text, expr)
             and_exprs.append(expr)
         or_exprs.append(z3.And(*and_exprs) if len(and_exprs) > 1 else and_exprs[0])
 
     if not or_exprs:
-        return None
+        return Rejection(text, RejectionKind.LEX_EMPTY, "no clauses")
     return z3.Or(*or_exprs) if len(or_exprs) > 1 else or_exprs[0]
 
 
@@ -346,6 +419,7 @@ def check_onegadget(
             unknown=list(gadget.constraints), model={},
             smt_available=False,
             reasoning="z3 not available — install z3-solver for constraint analysis",
+            unknown_reasons=[],
         )
 
     mode = profile.describe()
@@ -355,6 +429,7 @@ def check_onegadget(
             feasible=True, satisfied=[], unsatisfied=[], unknown=[],
             model={}, smt_available=True,
             reasoning="no constraints — one-gadget is unconditionally usable",
+            unknown_reasons=[],
         )
 
     vars_: Dict[str, Any] = {}
@@ -367,22 +442,29 @@ def check_onegadget(
     base_assertions: List[Any] = []
     for reg, val in concrete.items():
         if reg in _X86_64_REGS:
-            base_assertions.append(
-                _reg_var(reg, vars_, profile=profile) == _mk_val(val, profile.width)
-            )
+            reg_expr = _reg_var(reg, vars_, profile=profile)
+            # `reg in _X86_64_REGS` already filtered to the known set, so
+            # _reg_var cannot return a Rejection here — assert for type
+            # narrowing rather than skip silently.
+            assert not isinstance(reg_expr, Rejection)
+            base_assertions.append(reg_expr == _mk_val(val, profile.width))
     if base_assertions:
         solver.add(*base_assertions)
 
-    satisfied:   List[str] = []
-    unsatisfied: List[str] = []
-    unknown:     List[str] = []
-    pending:     List[Tuple[str, Any]] = []
+    satisfied:       List[str] = []
+    unsatisfied:     List[str] = []
+    unknown:         List[str] = []
+    unknown_reasons: List[Rejection] = []
+    pending:         List[Tuple[str, Any]] = []
 
     for raw in gadget.constraints:
         expr = _parse_constraint(raw, vars_, profile=profile)
-        if expr is None:
-            _get_logger().debug(f"smt_onegadget: unparseable constraint: {raw!r}")
+        if isinstance(expr, Rejection):
+            _get_logger().debug(
+                f"smt_onegadget: rejected {raw!r} ({expr.kind.value}: {expr.detail})"
+            )
             unknown.append(raw)
+            unknown_reasons.append(expr)
             continue
 
         if base_assertions:
@@ -412,6 +494,7 @@ def check_onegadget(
                 f"infeasible ({mode}): {len(unsatisfied)} constraint(s) contradicted by crash state — "
                 + "; ".join(unsatisfied[:2])
             ),
+            unknown_reasons=unknown_reasons,
         )
 
     if not pending:
@@ -427,12 +510,14 @@ def check_onegadget(
                     f"indeterminate ({mode}): {len(satisfied)} met by crash state, "
                     f"{len(unknown)} unparseable — fall back to heuristic note"
                 ),
+                unknown_reasons=unknown_reasons,
             )
         return OneGadgetSMTResult(
             feasible=True, satisfied=satisfied, unsatisfied=[], unknown=[],
             model={k: v for k, v in concrete.items() if k in _X86_64_REGS},
             smt_available=True,
             reasoning=f"all {len(satisfied)} constraint(s) already satisfied by crash state ({mode})",
+            unknown_reasons=[],
         )
 
     # Joint satisfiability of remaining constraints. The solver already
@@ -453,6 +538,7 @@ def check_onegadget(
                 + (f"; {len(satisfied)} already met by crash state" if satisfied else "")
                 + (f"; {len(unknown)} unparsed" if unknown else "")
             ),
+            unknown_reasons=unknown_reasons,
         )
 
     elif result == z3.unsat:
@@ -472,18 +558,51 @@ def check_onegadget(
             unsatisfied=conflict_set, unknown=unknown,
             model={}, smt_available=True,
             reasoning=reasoning,
+            unknown_reasons=unknown_reasons,
         )
 
     else:
+        # z3.unknown — tag every pending constraint with a structured
+        # solver-side rejection so callers can distinguish a parser
+        # failure from Z3 punting on an otherwise well-formed encoding.
+        solver_reason = _classify_solver_unknown(solver)
+        pending_texts = [r for r, _ in pending]
+        pending_detail = (
+            f"Z3 reason_unknown: {solver.reason_unknown()}"
+            if hasattr(solver, "reason_unknown") else ""
+        )
+        pending_rej = [
+            Rejection(t, solver_reason, pending_detail) for t in pending_texts
+        ]
+        detail = (
+            f"likely the {_DEFAULT_TIMEOUT_MS}ms solver timeout"
+            if solver_reason is RejectionKind.SOLVER_TIMEOUT
+            else "constraints outside the decidable bit-vector fragment"
+        )
         return OneGadgetSMTResult(
             feasible=None, satisfied=satisfied, unsatisfied=[],
-            unknown=unknown + [r for r, _ in pending],
+            unknown=unknown + pending_texts,
             model={}, smt_available=True,
-            reasoning=(
-                f"Z3 returned unknown ({mode}) — likely the {_DEFAULT_TIMEOUT_MS}ms "
-                f"solver timeout, or constraints outside the decidable bit-vector fragment"
-            ),
+            reasoning=f"Z3 returned unknown ({mode}) — {detail}",
+            unknown_reasons=unknown_reasons + pending_rej,
         )
+
+
+def _classify_solver_unknown(solver: Any) -> RejectionKind:
+    """Map Z3's ``reason_unknown()`` string to our rejection kind.
+
+    Z3 reports ``"timeout"`` (or, on some builds, ``"canceled"``) when
+    the per-solver timeout fires; anything else is grouped under
+    :data:`RejectionKind.SOLVER_UNKNOWN` (incomplete tactic, undecidable
+    fragment, ...).
+    """
+    try:
+        reason = (solver.reason_unknown() or "").lower()
+    except Exception:
+        return RejectionKind.SOLVER_UNKNOWN
+    if "timeout" in reason or "canceled" in reason or "cancelled" in reason:
+        return RejectionKind.SOLVER_TIMEOUT
+    return RejectionKind.SOLVER_UNKNOWN
 
 
 def rank_onegadgets(

--- a/packages/exploit_feasibility/smt_onegadget.py
+++ b/packages/exploit_feasibility/smt_onegadget.py
@@ -281,6 +281,8 @@ def _parse_constraint(
     if not t:
         return Rejection(text, RejectionKind.LEX_EMPTY, "empty constraint")
 
+    # ``re.split`` on a non-empty string always yields ≥1 element, and the
+    # empty-input path is gated above — so ``or_exprs`` is never empty here.
     or_clauses = re.split(r'\|\|', t)
     or_exprs = []
     for clause in or_clauses:
@@ -293,8 +295,6 @@ def _parse_constraint(
             and_exprs.append(expr)
         or_exprs.append(z3.And(*and_exprs) if len(and_exprs) > 1 else and_exprs[0])
 
-    if not or_exprs:
-        return Rejection(text, RejectionKind.LEX_EMPTY, "no clauses")
     return z3.Or(*or_exprs) if len(or_exprs) > 1 else or_exprs[0]
 
 
@@ -399,9 +399,13 @@ def check_onegadget(
         if reg in _X86_64_REGS:
             reg_expr = _reg_var(reg, vars_, profile=profile)
             # `reg in _X86_64_REGS` already filtered to the known set, so
-            # _reg_var cannot return a Rejection here — assert for type
-            # narrowing rather than skip silently.
-            assert not isinstance(reg_expr, Rejection)
+            # _reg_var cannot return a Rejection here.  Raise rather than
+            # `assert` so the invariant survives under ``python -O``.
+            if isinstance(reg_expr, Rejection):
+                raise RuntimeError(
+                    f"_reg_var unexpectedly rejected x86_64 register {reg!r}: "
+                    f"{reg_expr.kind.value} ({reg_expr.detail})"
+                )
             base_assertions.append(reg_expr == _mk_val(val, profile.width))
     if base_assertions:
         solver.add(*base_assertions)

--- a/packages/exploit_feasibility/smt_onegadget.py
+++ b/packages/exploit_feasibility/smt_onegadget.py
@@ -43,10 +43,13 @@ from core.smt_solver import (
     DEFAULT_TIMEOUT_MS as _DEFAULT_TIMEOUT_MS,
     Rejection,
     RejectionKind,
+    classify_solver_unknown as _classify_solver_unknown,
     core_names as _core_names,
     mk_val as _mk_val,
     mk_var as _mk_var,
     new_solver as _new_solver,
+    parse_literal_value as _parse_literal_value,
+    propagate as _propagate,
     scoped as _scoped,
     track as _track,
     z3,
@@ -104,43 +107,6 @@ _MEM_RE = re.compile(
 _REG_RE = re.compile(r'^(r[a-z0-9]+)$', re.IGNORECASE)
 _HEX_LIT_RE = re.compile(r'0x[0-9a-f]+', re.IGNORECASE)
 _DEC_LIT_RE = re.compile(r'\d+')
-
-
-def _parse_literal_value(tok: str, profile: BVProfile) -> Union[int, Rejection]:
-    """Validate and convert a literal token, or return a structured rejection.
-
-    Centralised so atom-position literals and bitmask-form literals both
-    reject the same things:
-
-    - Out-of-range for profile width (would silently wrap in z3.BitVecVal,
-      e.g. 0x100 at uint8 → 0, producing a misleading verdict)
-      → :data:`RejectionKind.LITERAL_OUT_OF_RANGE`.
-    - Leading-zero decimals (octal in C, ambiguous if interpreted as base-10)
-      → :data:`RejectionKind.LITERAL_AMBIGUOUS`.
-    - Anything that isn't a clean hex or decimal literal
-      → :data:`RejectionKind.UNRECOGNIZED_OPERAND`.
-    """
-    if _HEX_LIT_RE.fullmatch(tok):
-        v = int(tok, 16)
-    elif _DEC_LIT_RE.fullmatch(tok):
-        if len(tok) > 1 and tok[0] == "0":
-            return Rejection(
-                tok, RejectionKind.LITERAL_AMBIGUOUS,
-                "leading-zero decimal is ambiguous with C octal",
-                hint="rewrite as hex (0x...) or strip the leading zero",
-            )
-        v = int(tok)
-    else:
-        return Rejection(
-            tok, RejectionKind.UNRECOGNIZED_OPERAND,
-            f"token {tok!r} is not a hex or decimal literal",
-        )
-    if v >= (1 << profile.width):
-        return Rejection(
-            tok, RejectionKind.LITERAL_OUT_OF_RANGE,
-            f"value {v:#x} exceeds {profile.width}-bit profile range",
-        )
-    return v
 
 
 def _reg_var(name: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Union[Any, Rejection]:
@@ -213,17 +179,6 @@ def _parse_operand(text: str, vars_: Dict[str, Any], *, profile: BVProfile) -> U
         t, RejectionKind.UNRECOGNIZED_OPERAND,
         f"token {t!r} is not NULL, a literal, a register, or a memory reference",
     )
-
-
-def _propagate(text: str, sub: Rejection) -> Rejection:
-    """Re-anchor a sub-expression rejection on the full constraint text.
-
-    Sub-parsers see only their own slice of input, so a rejection's
-    ``text`` field starts out as that slice.  When bubbling up to the
-    constraint level we replace it with the full constraint so callers
-    can match the rejection back to the original input.
-    """
-    return Rejection(text, sub.kind, sub.detail, sub.hint)
 
 
 def _parse_atom(
@@ -586,23 +541,6 @@ def check_onegadget(
             reasoning=f"Z3 returned unknown ({mode}) — {detail}",
             unknown_reasons=unknown_reasons + pending_rej,
         )
-
-
-def _classify_solver_unknown(solver: Any) -> RejectionKind:
-    """Map Z3's ``reason_unknown()`` string to our rejection kind.
-
-    Z3 reports ``"timeout"`` (or, on some builds, ``"canceled"``) when
-    the per-solver timeout fires; anything else is grouped under
-    :data:`RejectionKind.SOLVER_UNKNOWN` (incomplete tactic, undecidable
-    fragment, ...).
-    """
-    try:
-        reason = (solver.reason_unknown() or "").lower()
-    except Exception:
-        return RejectionKind.SOLVER_UNKNOWN
-    if "timeout" in reason or "canceled" in reason or "cancelled" in reason:
-        return RejectionKind.SOLVER_TIMEOUT
-    return RejectionKind.SOLVER_UNKNOWN
 
 
 def rank_onegadgets(

--- a/packages/exploit_feasibility/smt_path.py
+++ b/packages/exploit_feasibility/smt_path.py
@@ -162,6 +162,11 @@ def validate_path(
           identified as the conflict (from the unsat core).
         - ``unknown``: conditions the parser could not encode — bubbled
           back so the caller can reason about them heuristically.
+        - ``unknown_reasons``: structured form of ``unknown``.  Each
+          element is ``{"text": ..., "kind": <RejectionKind value>,
+          "detail": ..., "hint": ...}``.  Callers (e.g. the LLM) use
+          ``kind`` and ``hint`` to drive *targeted* retry of a rejected
+          condition rather than guessing what to rephrase.
         - ``smt_available``: whether ``z3-solver`` was loaded.
     """
     bv = _resolve_profile(profile)
@@ -175,5 +180,14 @@ def validate_path(
         "satisfied": list(smt_result.satisfied),
         "unsatisfied": list(smt_result.unsatisfied),
         "unknown": list(smt_result.unknown),
+        "unknown_reasons": [
+            {
+                "text": r.text,
+                "kind": r.kind.value,
+                "detail": r.detail,
+                "hint": r.hint,
+            }
+            for r in smt_result.unknown_reasons
+        ],
         "smt_available": smt_result.smt_available,
     }

--- a/packages/exploit_feasibility/tests/test_smt_onegadget.py
+++ b/packages/exploit_feasibility/tests/test_smt_onegadget.py
@@ -10,7 +10,7 @@ import pytest
 # packages/exploit_feasibility/tests/ -> repo root
 sys.path.insert(0, str(Path(__file__).parents[3]))
 
-from core.smt_solver import z3_available
+from core.smt_solver import RejectionKind, z3_available
 from packages.exploit_feasibility.smt_onegadget import (
     check_onegadget,
     rank_onegadgets,
@@ -574,3 +574,90 @@ class TestLiteralValidation:
         g = OneGadget(0x100, ["r == 0"])
         r = check_onegadget(g)
         assert "r == 0" in r.unknown
+
+
+class TestStructuredRejection:
+    """``unknown_reasons`` should classify *why* each unparseable
+    constraint was dropped, parallel to ``unknown``."""
+
+    def _kind_for(self, result, text):
+        for r in result.unknown_reasons:
+            if r.text == text:
+                return r.kind
+        raise AssertionError(
+            f"no Rejection for {text!r} in {result.unknown_reasons!r}"
+        )
+
+    @patch("packages.exploit_feasibility.smt_onegadget._z3_available")
+    def test_no_z3_reasons_empty(self, mock_enabled):
+        """Without Z3 there's nothing to assign blame to — the parallel
+        list stays empty even though every constraint goes to unknown."""
+        mock_enabled.return_value = False
+        g = OneGadget(0x100, ["rax == NULL"])
+        r = check_onegadget(g)
+        assert "rax == NULL" in r.unknown
+        assert r.unknown_reasons == []
+
+    @_requires_z3
+    def test_unknown_register_rejection(self):
+        """A non-x86_64 register name is rejected with UNKNOWN_REGISTER."""
+        g = OneGadget(0x100, ["[rex+0x10] == NULL"])
+        r = check_onegadget(g)
+        assert self._kind_for(r, "[rex+0x10] == NULL") is RejectionKind.UNKNOWN_REGISTER
+
+    @_requires_z3
+    def test_literal_out_of_range_rejection(self):
+        from core.smt_solver import BVProfile
+        constraint = "rax == 0x100"
+        g = OneGadget(0x100, [constraint])
+        r = check_onegadget(g, profile=BVProfile(width=8, signed=False))
+        assert self._kind_for(r, constraint) is RejectionKind.LITERAL_OUT_OF_RANGE
+
+    @_requires_z3
+    def test_literal_ambiguous_octal_rejection(self):
+        constraint = "rax == 010"
+        g = OneGadget(0x100, [constraint])
+        r = check_onegadget(g)
+        assert self._kind_for(r, constraint) is RejectionKind.LITERAL_AMBIGUOUS
+
+    @_requires_z3
+    def test_bitmask_literal_out_of_range_rejection(self):
+        from core.smt_solver import BVProfile
+        constraint = "rax & 0x100 == 0"
+        g = OneGadget(0x100, [constraint])
+        r = check_onegadget(g, profile=BVProfile(width=8, signed=False))
+        assert self._kind_for(r, constraint) is RejectionKind.LITERAL_OUT_OF_RANGE
+
+    @_requires_z3
+    def test_bitmask_literal_ambiguous_rejection(self):
+        constraint = "rax & 010 == 0"
+        g = OneGadget(0x100, [constraint])
+        r = check_onegadget(g)
+        assert self._kind_for(r, constraint) is RejectionKind.LITERAL_AMBIGUOUS
+
+    @_requires_z3
+    def test_unrecognized_form_rejection(self):
+        """A constraint without any recognised top-level pattern."""
+        constraint = "rax > 0x10"  # one-gadget parser doesn't accept relational ops
+        g = OneGadget(0x100, [constraint])
+        r = check_onegadget(g)
+        assert self._kind_for(r, constraint) is RejectionKind.UNRECOGNIZED_FORM
+
+    @_requires_z3
+    def test_rejection_carries_hint(self):
+        g = OneGadget(0x100, ["[rex+0x10] == NULL"])
+        r = check_onegadget(g)
+        rej = next(x for x in r.unknown_reasons if x.text == "[rex+0x10] == NULL")
+        assert rej.hint  # non-empty
+        assert "x86_64" in rej.hint
+
+    @_requires_z3
+    def test_rejection_aligned_with_unknown_list(self):
+        """For every entry in `unknown`, there's a matching rejection."""
+        g = OneGadget(0x100, [
+            "rax == NULL",          # parses
+            "[rex+0x10] == NULL",   # unknown register
+            "rax == 010",           # ambiguous octal literal
+        ])
+        r = check_onegadget(g)
+        assert set(r.unknown) == {x.text for x in r.unknown_reasons}


### PR DESCRIPTION
Split the `unknown` bucket by reason in SMT Parser. The largest loss of coverage from the parsers are things sinking into `unknown` without any feedback to the agent. If we provide this feedback, then we should be able to do much better parsing and thin out the pathways to `unknown` to things that we generally have no clue about. 

To do this, we make `unknown: List[str]` --> `unknown: List[UnknownReason]` carrying `(text, kind, hint)` as follows:
  - `LEX_ERROR`, 
  - `UNSUPPORTED_OPERATOR`, 
  - `PARENS_NON_CALL`, 
  - `MIXED_PRECEDENCE`, 
  - `LITERAL_OUT_OF_RANGE`, 
  - `UNKNOWN_REGISTER`, 
  - `SOLVER_TIMEOUT`,
  - `SOLVER_UNKNOWN_FRAGMENT`

  This lets:
  - The LLM/extractor retry only on the textually-fixable cases (massive coverage gain at the source).
  - Tests assert on why something was unknown, not just that it was.
  - Reports show a researcher exactly what to rephrase.

Tests are also included for checking and completeness - thanks be to Claude for the insight on these.