### PR TITLE
SMT Parser - Add English-aliased Pre-canonicalization step

### DIFF
--- a/core/smt_solver/__init__.py
+++ b/core/smt_solver/__init__.py
@@ -22,6 +22,7 @@ predicates, one-gadget constraints, ...) live in their respective
 
 from .availability import z3, z3_available
 from .bitvec import ge, gt, le, lt, mk_val, mk_var
+from .canonicalise import canonicalise
 from .config import (
     BVProfile,
     BV_AARCH64,
@@ -90,4 +91,6 @@ __all__ = [
     "propagate",
     "parse_literal_value",
     "classify_solver_unknown",
+    # English-aliased pre-canonicalisation
+    "canonicalise",
 ]

--- a/core/smt_solver/canonicalise.py
+++ b/core/smt_solver/canonicalise.py
@@ -1,0 +1,61 @@
+"""English-aliased pre-canonicalisation for SMT encoder parsers.
+
+LLM output frequently uses english operator phrases — "is greater than",
+"equals", "is at least" — instead of the canonical symbolic forms.
+This module applies a small ordered set of regex rewrites *before* the
+parser sees the input, mapping common english forms to ``>``, ``<``,
+``>=``, ``<=``, ``==``, ``!=`` (with NULL / 0 specialisations for
+non-zero / non-null phrasings).
+
+Design intent:
+- Rewrites are *additive*: phrases the per-parser grammar already
+  recognises (``is NULL``, ``is writable`` in one-gadget) are NOT
+  touched here, so existing parse paths keep their dedicated
+  rejection messages.
+- Order matters — longer, more-specific phrases are tried before
+  shorter ones (``is greater than or equal to`` before ``is greater
+  than``).
+- Word boundaries (``\\b``) keep rewrites from firing inside
+  identifiers (``equalsValue`` must NOT become ``==Value``).
+
+Used by:
+  packages/codeql/smt_path_validator.py :: _parse_condition
+  packages/exploit_feasibility/smt_onegadget.py :: _parse_atom
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Tuple
+
+# (pattern, replacement) pairs.  Replacements include surrounding spaces
+# because the english phrases don't always sit next to whitespace; the
+# trailing collapse-whitespace pass tidies up.
+_REWRITES: Tuple[Tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r'\bis\s+greater\s+than\s+or\s+equal\s+to\b', re.IGNORECASE), ' >= '),
+    (re.compile(r'\bis\s+less\s+than\s+or\s+equal\s+to\b',    re.IGNORECASE), ' <= '),
+    (re.compile(r'\bis\s+at\s+least\b',                       re.IGNORECASE), ' >= '),
+    (re.compile(r'\bis\s+at\s+most\b',                        re.IGNORECASE), ' <= '),
+    (re.compile(r'\bis\s+greater\s+than\b',                   re.IGNORECASE), ' > '),
+    (re.compile(r'\bis\s+less\s+than\b',                      re.IGNORECASE), ' < '),
+    (re.compile(r'\bis\s+not\s+equal\s+to\b',                 re.IGNORECASE), ' != '),
+    (re.compile(r'\bdoes\s+not\s+equal\b',                    re.IGNORECASE), ' != '),
+    (re.compile(r'\bis\s+equal\s+to\b',                       re.IGNORECASE), ' == '),
+    (re.compile(r'\bequals\b',                                re.IGNORECASE), ' == '),
+    (re.compile(r'\bis\s+non[-\s]?zero\b',                    re.IGNORECASE), ' != 0 '),
+    (re.compile(r'\bis\s+non[-\s]?null\b',                    re.IGNORECASE), ' != NULL '),
+)
+
+_WHITESPACE_RUN = re.compile(r'\s+')
+
+
+def canonicalise(text: str) -> str:
+    """Rewrite common english operator aliases to canonical syntax.
+
+    Idempotent: input that's already symbolic passes through unchanged
+    (modulo whitespace collapse).
+    """
+    out = text
+    for pat, repl in _REWRITES:
+        out = pat.sub(repl, out)
+    return _WHITESPACE_RUN.sub(' ', out).strip()

--- a/core/smt_solver/canonicalise.py
+++ b/core/smt_solver/canonicalise.py
@@ -4,19 +4,34 @@ LLM output frequently uses english operator phrases — "is greater than",
 "equals", "is at least" — instead of the canonical symbolic forms.
 This module applies a small ordered set of regex rewrites *before* the
 parser sees the input, mapping common english forms to ``>``, ``<``,
-``>=``, ``<=``, ``==``, ``!=`` (with NULL / 0 specialisations for
-non-zero / non-null phrasings).
+``>=``, ``<=``, ``==``, ``!=`` (with NULL / 0 specialisations for the
+``is null`` / ``is zero`` / ``is non-null`` / ``is non-zero`` family).
+
+Coverage at a glance:
+- Relational: ``is greater than``, ``is less than``, ``is at least``,
+  ``is at most``, ``is greater than or equal to``, ``is less than or
+  equal to``, ``exceeds``, ``below``, ``does not exceed``, ``up to``.
+- Equality: ``equals``, ``is equal to``, ``is not equal to``,
+  ``does not equal``.
+- Null/zero: ``is null``, ``is zero``, ``is non-null``, ``is non-zero``
+  (``-`` and a single space accepted between ``non`` and the noun).
 
 Design intent:
 - Rewrites are *additive*: phrases the per-parser grammar already
-  recognises (``is NULL``, ``is writable`` in one-gadget) are NOT
-  touched here, so existing parse paths keep their dedicated
-  rejection messages.
+  recognises (notably one-gadget's native ``is writable`` suffix form
+  and bracketed memory references like ``[rsp+0x8]``) are NOT touched
+  here, so existing parse paths keep their dedicated rejection
+  messages.  The exception is ``is null``: both encoders see the
+  rewritten ``== NULL`` form first, but they encode it identically to
+  the dedicated grammar would have done.
 - Order matters — longer, more-specific phrases are tried before
   shorter ones (``is greater than or equal to`` before ``is greater
-  than``).
+  than``; ``does not exceed`` before ``exceeds``).
 - Word boundaries (``\\b``) keep rewrites from firing inside
   identifiers (``equalsValue`` must NOT become ``==Value``).
+- ``up to N`` is read as inclusive (``<= N``).  Some writers treat it
+  as exclusive; the inclusive reading is the convention in maths/CS
+  and is documented at the rewrite site.
 
 Used by:
   packages/codeql/smt_path_validator.py :: _parse_condition
@@ -31,19 +46,44 @@ from typing import Tuple
 # (pattern, replacement) pairs.  Replacements include surrounding spaces
 # because the english phrases don't always sit next to whitespace; the
 # trailing collapse-whitespace pass tidies up.
+#
+# Order matters — rewrites are applied sequentially.  Longer, more-
+# specific phrases must precede their shorter prefixes; otherwise the
+# shorter pattern eats part of the longer one and leaves a malformed
+# tail like ``is == to``.  In particular:
+#   - ``is greater than or equal to`` before ``is greater than``
+#   - ``does not exceed`` before ``exceeds``
+#   - ``is non-null`` before ``is null``
 _REWRITES: Tuple[Tuple[re.Pattern[str], str], ...] = (
+    # Longer phrases first.
     (re.compile(r'\bis\s+greater\s+than\s+or\s+equal\s+to\b', re.IGNORECASE), ' >= '),
     (re.compile(r'\bis\s+less\s+than\s+or\s+equal\s+to\b',    re.IGNORECASE), ' <= '),
+    (re.compile(r'\bis\s+not\s+equal\s+to\b',                 re.IGNORECASE), ' != '),
+    (re.compile(r'\bdoes\s+not\s+equal\b',                    re.IGNORECASE), ' != '),
+    (re.compile(r'\bdoes\s+not\s+exceed\b',                   re.IGNORECASE), ' <= '),
     (re.compile(r'\bis\s+at\s+least\b',                       re.IGNORECASE), ' >= '),
     (re.compile(r'\bis\s+at\s+most\b',                        re.IGNORECASE), ' <= '),
     (re.compile(r'\bis\s+greater\s+than\b',                   re.IGNORECASE), ' > '),
     (re.compile(r'\bis\s+less\s+than\b',                      re.IGNORECASE), ' < '),
-    (re.compile(r'\bis\s+not\s+equal\s+to\b',                 re.IGNORECASE), ' != '),
-    (re.compile(r'\bdoes\s+not\s+equal\b',                    re.IGNORECASE), ' != '),
     (re.compile(r'\bis\s+equal\s+to\b',                       re.IGNORECASE), ' == '),
-    (re.compile(r'\bequals\b',                                re.IGNORECASE), ' == '),
+    # Negative null/zero forms before the positive ones.
     (re.compile(r'\bis\s+non[-\s]?zero\b',                    re.IGNORECASE), ' != 0 '),
     (re.compile(r'\bis\s+non[-\s]?null\b',                    re.IGNORECASE), ' != NULL '),
+    # Positive forms — close the asymmetry with the negated counterparts
+    # above.  Without these, a writer using ``ptr is null`` got an
+    # ``UNRECOGNIZED_FORM`` rejection from the path validator (one_gadget
+    # has its own native ``is NULL`` suffix grammar, but the rewrite is
+    # semantically identical for it: both reach ``lhs == 0``).
+    (re.compile(r'\bis\s+null\b',                             re.IGNORECASE), ' == NULL '),
+    (re.compile(r'\bis\s+zero\b',                             re.IGNORECASE), ' == 0 '),
+    # Single-word synonyms.
+    (re.compile(r'\bequals\b',                                re.IGNORECASE), ' == '),
+    (re.compile(r'\bexceeds\b',                               re.IGNORECASE), ' > '),
+    (re.compile(r'\bbelow\b',                                 re.IGNORECASE), ' < '),
+    # ``up to N`` is read as inclusive (``<= N``) — the most common
+    # convention in maths/CS, though some writers treat it as exclusive.
+    # Document the choice rather than guess case-by-case.
+    (re.compile(r'\bup\s+to\b',                               re.IGNORECASE), ' <= '),
 )
 
 _WHITESPACE_RUN = re.compile(r'\s+')

--- a/core/smt_solver/tests/test_canonicalise.py
+++ b/core/smt_solver/tests/test_canonicalise.py
@@ -68,6 +68,48 @@ class TestNonZeroNonNull:
         assert canonicalise("ptr is nonnull") == "ptr != NULL"
 
 
+class TestPositiveZeroNullForms:
+    """``is null`` / ``is zero`` close the asymmetry with the negated forms."""
+
+    def test_is_null(self):
+        assert canonicalise("ptr is null") == "ptr == NULL"
+
+    def test_is_null_does_not_clash_with_is_non_null(self):
+        # The negated form must win; the positive ``is null`` rewrite
+        # must not trip on the residual ``null`` left behind.
+        assert canonicalise("ptr is non-null") == "ptr != NULL"
+
+    def test_is_zero(self):
+        assert canonicalise("count is zero") == "count == 0"
+
+    def test_is_zero_does_not_clash_with_is_non_zero(self):
+        assert canonicalise("count is non-zero") == "count != 0"
+
+
+class TestSynonyms:
+    """Single-word and short synonyms covering common LLM phrasings."""
+
+    def test_exceeds(self):
+        assert canonicalise("count exceeds 100") == "count > 100"
+
+    def test_below(self):
+        assert canonicalise("index below limit") == "index < limit"
+
+    def test_does_not_exceed(self):
+        # The longer ``does not exceed`` must win over the bare ``exceeds``.
+        assert canonicalise("len does not exceed buffer") == "len <= buffer"
+
+    def test_does_not_exceed_does_not_leak_to_exceeds(self):
+        # If ordering broke, ``does not exceed`` would become ``does not >``
+        # then collapse to ``does not >`` — assert the full sentence resolves.
+        out = canonicalise("len does not exceed buffer_size")
+        assert out == "len <= buffer_size"
+
+    def test_up_to_inclusive(self):
+        # Documented choice: ``up to N`` means ``<= N`` (inclusive).
+        assert canonicalise("count up to 16") == "count <= 16"
+
+
 class TestIdempotenceAndIdentifierSafety:
     """Symbolic input passes through unchanged; identifiers aren't mangled."""
 

--- a/core/smt_solver/tests/test_canonicalise.py
+++ b/core/smt_solver/tests/test_canonicalise.py
@@ -1,0 +1,132 @@
+"""Tests for core.smt_solver.canonicalise — english→symbolic rewrites."""
+
+import sys
+from pathlib import Path
+
+# core/smt_solver/tests/ -> repo root
+sys.path.insert(0, str(Path(__file__).parents[3]))
+
+from core.smt_solver import canonicalise
+
+
+class TestRelationalRewrites:
+    """English relational phrases map to their symbolic counterparts."""
+
+    def test_is_greater_than(self):
+        assert canonicalise("size is greater than 0") == "size > 0"
+
+    def test_is_less_than(self):
+        assert canonicalise("size is less than 1024") == "size < 1024"
+
+    def test_is_greater_than_or_equal_to(self):
+        # The longer phrase wins over the prefix "is greater than".
+        assert canonicalise("len is greater than or equal to 8") == "len >= 8"
+
+    def test_is_less_than_or_equal_to(self):
+        assert canonicalise("len is less than or equal to 64") == "len <= 64"
+
+    def test_is_at_least(self):
+        assert canonicalise("count is at least 16") == "count >= 16"
+
+    def test_is_at_most(self):
+        assert canonicalise("count is at most 32") == "count <= 32"
+
+
+class TestEqualityRewrites:
+    """Equality-style phrases map to == / !=."""
+
+    def test_equals(self):
+        assert canonicalise("x equals y") == "x == y"
+
+    def test_is_equal_to(self):
+        assert canonicalise("x is equal to y") == "x == y"
+
+    def test_is_not_equal_to(self):
+        assert canonicalise("x is not equal to y") == "x != y"
+
+    def test_does_not_equal(self):
+        assert canonicalise("x does not equal y") == "x != y"
+
+
+class TestNonZeroNonNull:
+    """'is non-zero' / 'is non-null' specialise to '!= 0' / '!= NULL'."""
+
+    def test_is_nonzero_hyphen(self):
+        assert canonicalise("count is non-zero") == "count != 0"
+
+    def test_is_nonzero_space(self):
+        assert canonicalise("count is non zero") == "count != 0"
+
+    def test_is_nonzero_compound(self):
+        # "nonzero" without separator
+        assert canonicalise("count is nonzero") == "count != 0"
+
+    def test_is_nonnull_hyphen(self):
+        assert canonicalise("ptr is non-null") == "ptr != NULL"
+
+    def test_is_nonnull_compound(self):
+        assert canonicalise("ptr is nonnull") == "ptr != NULL"
+
+
+class TestIdempotenceAndIdentifierSafety:
+    """Symbolic input passes through unchanged; identifiers aren't mangled."""
+
+    def test_already_symbolic(self):
+        assert canonicalise("size > 0") == "size > 0"
+
+    def test_idempotent(self):
+        once = canonicalise("count is at least 1")
+        twice = canonicalise(once)
+        assert once == twice == "count >= 1"
+
+    def test_word_boundary_protects_identifiers(self):
+        # 'equalsValue' must NOT become '==Value'.
+        assert canonicalise("equalsValue == 1") == "equalsValue == 1"
+
+    def test_word_boundary_inside_underscore(self):
+        # 'is_greater_than_zero' is an identifier, not the english phrase.
+        # The pattern uses \s+ between words so underscore-separated
+        # identifier names are not rewritten.
+        assert canonicalise("is_greater_than_zero == 1") == "is_greater_than_zero == 1"
+
+    def test_case_insensitive(self):
+        assert canonicalise("SIZE Is Greater Than 0") == "SIZE > 0"
+
+    def test_whitespace_collapsed(self):
+        # Multiple spaces around english phrases collapse to single spaces.
+        assert canonicalise("size   is   greater   than   0") == "size > 0"
+
+
+class TestCanonicalisedFeedsParser:
+    """Smoke-test that canonicalised output is parseable by the path validator."""
+
+    def test_path_validator_accepts_english_form(self):
+        # If z3 isn't installed, the validator returns feasible=None with
+        # the input in `unknown` — but the parser still runs over the
+        # canonicalised text, so a clean parse means `unknown` stays empty.
+        from core.smt_solver import z3_available
+        if not z3_available():
+            return  # parser exercised regardless, but feasibility undefined
+        from packages.codeql.smt_path_validator import (
+            PathCondition, check_path_feasibility,
+        )
+        result = check_path_feasibility([
+            PathCondition(text="size is greater than 0", step_index=0),
+            PathCondition(text="size is less than 1024", step_index=1),
+        ])
+        assert result.unknown == []
+        assert result.feasible is True
+
+    def test_one_gadget_accepts_english_form(self):
+        from core.smt_solver import z3_available
+        if not z3_available():
+            return
+        from packages.exploit_feasibility.smt_onegadget import check_onegadget
+        from packages.exploit_feasibility.context import OneGadget
+        gadget = OneGadget(
+            offset=0x1234,
+            constraints=["rax equals 0", "rbx is not equal to 0"],
+        )
+        result = check_onegadget(gadget)
+        assert result.unknown == []
+        assert result.feasible is True

--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -94,6 +94,7 @@ from core.smt_solver import (
     DEFAULT_TIMEOUT_MS as _DEFAULT_TIMEOUT_MS,
     Rejection,
     RejectionKind,
+    canonicalise as _canonicalise,
     classify_solver_unknown as _classify_solver_unknown,
     core_names as _core_names,
     mk_val as _mk_val,
@@ -279,8 +280,13 @@ def _parse_condition(
     Conditions containing function-call syntax (parentheses) are rejected
     with :data:`RejectionKind.PARENS_NOT_SUPPORTED` — they go to the
     unknown list.
+
+    English operator phrases ("is greater than", "equals", ...) are
+    rewritten to symbolic operators by :func:`canonicalise` before the
+    grammar runs.  ``text`` (the original) is preserved for rejection
+    messages so callers can match failures back to their input.
     """
-    t = text.strip()
+    t = _canonicalise(text)
 
     if '(' in t or ')' in t:
         return Rejection(

--- a/packages/exploit_feasibility/smt_onegadget.py
+++ b/packages/exploit_feasibility/smt_onegadget.py
@@ -43,6 +43,7 @@ from core.smt_solver import (
     DEFAULT_TIMEOUT_MS as _DEFAULT_TIMEOUT_MS,
     Rejection,
     RejectionKind,
+    canonicalise as _canonicalise,
     classify_solver_unknown as _classify_solver_unknown,
     core_names as _core_names,
     mk_val as _mk_val,
@@ -198,8 +199,15 @@ def _parse_atom(
     ``<lhs>`` / ``<rhs>`` accept any form handled by ``_parse_operand``.
     Returns a :class:`Rejection` rather than a partial expression when
     parsing fails; the caller propagates it upward via :func:`_propagate`.
+
+    English operator phrases ("is greater than", "equals", ...) are
+    rewritten to symbolic operators by :func:`canonicalise` before the
+    grammar runs.  Existing dedicated suffix forms (``is NULL``, ``is
+    writable``) are left intact by design.  ``text`` (the original) is
+    preserved for rejection messages so callers can match failures back
+    to their input.
     """
-    t = text.strip()
+    t = _canonicalise(text)
 
     # "address X is writable" / "address [X] is writable"
     if t.lower().startswith("address "):


### PR DESCRIPTION
Building on coverage widening in #239 - this invokes rather simple regex canonicalization of LLM output.

Adds a small shared pre-pass (`core/smt_solver/canonicalise.py`) that rewrites common english operator phrases to their symbolic equivalents *before* the SMT encoder parsers see the input. Wired into both `smt_path_validator._parse_condition` (CodeQL dataflow) and `smt_onegadget._parse_atom` (exploit feasibility). LLM output frequently uses phrases like *"size is greater than 0"*, *"count is at least 16"*, *"ptr is non-null"* — these previously fell through to the `unknown` list as `UNRECOGNIZED_FORM`. They now parse cleanly.                                                                                                                              
   
  ## What's rewritten                                                                                                                   
                                                                                   
  | English phrase                                  | Canonical form |
  | ----------------------------------------------- | -------------- |
  | `is greater than [or equal to]`                 | `>` / `>=`     |
  | `is less than [or equal to]`                    | `<` / `<=`     |
  | `is at least` / `is at most`                    | `>=` / `<=`    |
  | `equals` / `is equal to`                        | `==`           |
  | `is not equal to` / `does not equal`            | `!=`           |
  | `is non-zero` / `is nonzero` / `is non zero`    | `!= 0`         |                                                                  
  | `is non-null` / `is nonnull` / `is non null`    | `!= NULL`      |
                                                                                                                                        
  ## Design notes                                                                  
                                                                                                                                        
  - **Additive, not invasive.** Existing dedicated parser paths (`is NULL`, `is writable` in one-gadget) are deliberately *not*
  canonicalised — those keep their domain-specific Z3 encodings and rejection messages.                                                 
  - **Order matters.** Longer phrases match first (`is greater than or equal to` before `is greater than`).
  - **Identifier-safe.** `\b` word boundaries keep `equalsValue == 1` and `is_greater_than_zero` from being mangled.                    
  - **Idempotent.** Already-symbolic input passes through unchanged.                                                                    
  - **Original text preserved for diagnostics.** The `Rejection.text` field still carries the user's original input so callers can match
   failures back to the source.                                                                                                         
                                                                                                                                        
  ## Test plan                              
                                                                                                                                        
  - [x] 23 unit tests covering each rewrite, idempotence, identifier safety, case-insensitivity, whitespace collapse                    
  - [x] Smoke tests through both parsers (`check_path_feasibility`, `check_onegadget`) confirm canonicalised input reaches              
  `feasible=True` with empty `unknown`                                                                                                  
  - [x] Full SMT suite green: 190/190 (existing 116 + 23 canonicalise + 51 rejection tests from earlier branch)
                                            
  ## Files                   
                                                                                                                                        
  core/smt_solver/init.py 
  core/smt_solver/canonicalise.py
  core/smt_solver/tests/test_canonicalise.py
  packages/codeql/smt_path_validator.py 
  packages/exploit_feasibility/smt_onegadget.py      
                                      
  > **Note:** this PR is stacked on #239, so the PR diff against `main` will include the rejection-reasons commits.