### PR TITLE
single-source verdict enum and Stage E memory-corruption gate

### DIFF
--- a/packages/exploit_feasibility/models.py
+++ b/packages/exploit_feasibility/models.py
@@ -37,7 +37,7 @@ class FeasibilityAssessment:
     Attributes:
         finding_id: The finding's ID (e.g., 'FIND-0001').
         vuln_type: Normalized vulnerability type.
-        verdict: Exploitability verdict (exploitable, likely_exploitable, difficult, unlikely, unknown).
+        verdict: Exploitability verdict — one of ``ExploitabilityVerdict``.
         impact: Expected impact (code_execution, dos, info_leak, etc.).
         exploitation_paths: Specific {technique, target} pairs for this finding.
         blockers: What prevents exploitation.

--- a/packages/exploit_feasibility/schema.py
+++ b/packages/exploit_feasibility/schema.py
@@ -8,6 +8,11 @@ Provides validation for serialized ExploitContext and FeasibilityReport data.
 from typing import Any, Dict, List, Tuple
 import json
 from core.json import load_json
+from .vuln_types import ExploitabilityVerdict
+
+
+# Declaration-order: exploitable → unknown (semantic gradient, not alphabetical).
+_VERDICT_VALUES = tuple(v.value for v in ExploitabilityVerdict)
 
 
 # JSON Schema for ExploitContext/FeasibilityReport context files
@@ -132,7 +137,7 @@ CONTEXT_SCHEMA = {
             },
         },
         # Verdict and analysis
-        "verdict": {"type": "string", "enum": ["exploitable", "likely_exploitable", "difficult", "unlikely", "unknown"]},
+        "verdict": {"type": "string", "enum": list(_VERDICT_VALUES)},
         "blockers": {
             "type": "array",
             "items": {"type": "string"}
@@ -258,9 +263,8 @@ def validate_context(data: Dict[str, Any]) -> Tuple[bool, List[str]]:
 
     # Validate verdict
     if "verdict" in data:
-        valid_verdicts = ["exploitable", "likely_exploitable", "difficult", "unlikely", "unknown"]
-        if data["verdict"] not in valid_verdicts:
-            errors.append(f"verdict must be one of: {', '.join(valid_verdicts)}")
+        if data["verdict"] not in _VERDICT_VALUES:
+            errors.append(f"verdict must be one of: {', '.join(_VERDICT_VALUES)}")
 
     return len(errors) == 0, errors
 

--- a/packages/exploitability_validation/orchestrator.py
+++ b/packages/exploitability_validation/orchestrator.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any, Callable
 from enum import Enum
 
+from core.schema_constants import MEMORY_CORRUPTION_TYPES
+
 from .schemas import (
     validate_checklist,
     validate_findings,
@@ -235,14 +237,6 @@ class PipelineState:
                 normalize_findings(data)
             return data
         return None
-
-
-# Memory corruption types that require Stage E
-MEMORY_CORRUPTION_TYPES = {
-    'buffer_overflow', 'heap_overflow', 'stack_overflow',
-    'format_string', 'use_after_free', 'double_free',
-    'integer_overflow', 'out_of_bounds_read', 'out_of_bounds_write'
-}
 
 
 def normalize_rule_id(rule_id: str, tool_name: str) -> str:

--- a/packages/exploitability_validation/schemas.py
+++ b/packages/exploitability_validation/schemas.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from core.schema_constants import (
     VULN_TYPES, SEVERITY_LEVELS, CONFIDENCE_LEVELS, FP_REASONS,
 )
+from packages.exploit_feasibility.vuln_types import ExploitabilityVerdict
 
 # Stage 0: Inventory - checklist.json
 CHECKLIST_SCHEMA = {
@@ -177,7 +178,7 @@ FINDING_SCHEMA = {
                 "status": {"type": "string", "enum": ["pending", "analyzed", "skipped", "error", "not_applicable"]},
                 "binary_path": {"type": "string"},
                 "context_file": {"type": "string"},
-                "verdict": {"type": "string", "enum": ["exploitable", "likely_exploitable", "difficult", "unlikely", "unknown"]},
+                "verdict": {"type": "string", "enum": [v.value for v in ExploitabilityVerdict]},
                 "impact": {
                     "type": "string",
                     "enum": ["code_execution", "dos", "info_leak", "resource_exhaustion", "data_corruption", "unknown"],

--- a/packages/exploitability_validation/tests/test_validation.py
+++ b/packages/exploitability_validation/tests/test_validation.py
@@ -37,6 +37,7 @@ from core.inventory import (
     GENERATED_MARKERS,
 )
 from packages.exploitability_validation.checklist_builder import get_binary_info
+from packages.exploit_feasibility.vuln_types import ExploitabilityVerdict
 from packages.llm_analysis.agent import convert_validated_to_agent_format
 
 
@@ -401,6 +402,31 @@ class TestSchemaValidation:
         surface = {"sources": "not_a_list"}  # Wrong type
         valid, errors = validate_attack_surface(surface)
         assert not valid
+
+
+class TestMemoryCorruptionTypesSourceOfTruth:
+    """Stage E gate must use the canonical set in core.schema_constants.
+
+    The orchestrator previously kept a local 9-item shadow that omitted
+    null_deref, type_confusion, uninitialized_memory — findings of those
+    types silently skipped Stage E.  Re-introducing a local copy would
+    re-introduce the bug.
+    """
+
+    def test_orchestrator_uses_canonical_set(self):
+        from core.schema_constants import MEMORY_CORRUPTION_TYPES as canonical
+        from packages.exploitability_validation.orchestrator import (
+            MEMORY_CORRUPTION_TYPES as used,
+        )
+        assert used is canonical, (
+            "orchestrator's MEMORY_CORRUPTION_TYPES must be the canonical "
+            "frozenset from core.schema_constants — do not redefine it locally"
+        )
+
+    def test_package_reexport_is_canonical(self):
+        from core.schema_constants import MEMORY_CORRUPTION_TYPES as canonical
+        from packages.exploitability_validation import MEMORY_CORRUPTION_TYPES as exported
+        assert exported is canonical
 
 
 class TestStageEnum:
@@ -1969,7 +1995,7 @@ class TestStageEErrorHandling:
             "error": "confirmed_unverified",
         }
         # All possible verdicts from the enum
-        for verdict in ("exploitable", "likely_exploitable", "difficult", "unlikely", "unknown"):
+        for verdict in (v.value for v in ExploitabilityVerdict):
             assert verdict in verdict_to_status, f"Missing mapping for verdict: {verdict}"
 
     def test_chain_breaks_tagged_by_source(self, tmp_path):


### PR DESCRIPTION
Bug fix: orchestrator's local MEMORY_CORRUPTION_TYPES was a 9-item shadow of core.schema_constants's 12-item canonical set, missing null_deref, type_confusion, and uninitialized_memory. Findings of those types silently skipped Stage E feasibility analysis. Replaces the local copy with the imported canonical set; re-exported MEMORY_CORRUPTION_TYPES now also resolves to the canonical frozenset.

Behaviour change: confirmed null_deref / type_confusion / uninitialized_memory findings now go through Stage E. They previously emerged from validation with `feasibility.status: not_applicable` and `final_status: confirmed`. They will now carry a real Stage E verdict (typically `unlikely` for null_deref per the mmap_min_addr default, varies for the others) and a final_status reflecting the verdict (typically `confirmed_blocked`). The mapper in
exploit_feasibility/finding_mapper.py already supports these types.

Robustness: verdict allowlists in exploit_feasibility/schema.py and exploitability_validation/schemas.py, plus an enumeration loop in test_validation.py, were hand-typed mirrors of ExploitabilityVerdict. Switch them to derive from the enum at module-load time so future enum changes propagate automatically.

Guard test asserts orchestrator's MEMORY_CORRUPTION_TYPES (and the package re-export) is the canonical frozenset — re-introducing a local copy will fail the test.