### PR TITLE
core/http + core/json: HttpClient chokepoint + JsonCache

### DIFF
--- a/core/http/__init__.py
+++ b/core/http/__init__.py
@@ -1,0 +1,270 @@
+"""HTTP client interface — single chokepoint for outbound HTTP from RAPTOR.
+
+Two backends ship today:
+
+  - :class:`~core.http.urllib_backend.UrllibClient` — urllib3-backed
+    with connection pooling, bounded size, gzip-decompress, and
+    exponential backoff. No host allowlist; reaches anywhere. Use
+    only where the egress proxy isn't appropriate (tests, dev paths
+    without sandbox).
+
+  - :class:`~core.http.egress_backend.EgressClient` — routes via the
+    in-process HTTPS proxy at ``core.sandbox.proxy``. Hostname
+    allowlist enforced by the proxy; refuses CONNECT to anything
+    outside the registered hosts. Use this for any production HTTP
+    call where the threat model includes "compromised parser
+    exfiltrates to attacker host".
+
+Callers depend on the :class:`HttpClient` Protocol only — concrete
+backend swap is one factory call, no consumer churn.
+
+Constants below are defaults. Callers may override per-call timeouts
+and per-call max_bytes; the user-agent is fixed at client construction
+(``UrllibClient(user_agent=...)``) but not per-call.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Protocol
+
+# Default size limits — caps protect parser code paths from decompression
+# bombs and pathological response shapes.
+DEFAULT_MAX_BYTES = 50 * 1024 * 1024   # 50MB; covers wheels and source archives
+DEFAULT_TIMEOUT = 30                   # seconds (per-attempt connect+read)
+DEFAULT_TOTAL_TIMEOUT = 600            # seconds (whole-call deadline incl retries)
+# Default count of retries beyond the first attempt — i.e. the default
+# call makes up to (1 + DEFAULT_RETRIES) total attempts. Sized so the
+# default exactly fills the urllib backend's backoff schedule (one slot
+# per attempt, including the initial). Kept here (not in the backend)
+# so the Protocol signature doesn't drift when the schedule is retuned.
+# Backends MUST cap the effective attempt count at their own schedule
+# length, and the urllib backend asserts the relationship at import.
+DEFAULT_RETRIES = 5
+DEFAULT_USER_AGENT = "raptor/0.1 (+https://github.com/gadievron/raptor)"
+
+
+class HttpError(Exception):
+    """Raised when an HTTP call fails after retries."""
+
+    def __init__(
+        self,
+        message: str,
+        status: Optional[int] = None,
+        retry_after: Optional[int] = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        # Seconds the server asked us to wait (Retry-After header). The
+        # backend's retry loop reads this when honouring 429/503; None
+        # means "no Retry-After advertised, use our backoff schedule".
+        self.retry_after = retry_after
+
+
+class SizeLimitExceeded(HttpError):
+    """Raised when a response exceeds max_bytes before we finish reading."""
+
+
+@dataclass(frozen=True)
+class Response:
+    """Lightweight HTTP response wrapper.
+
+    Returned by the low-level :meth:`HttpClient.request` and used
+    internally by the JSON/bytes convenience methods. Bridges between
+    consumer code and the underlying urllib3 response so callers don't
+    depend on urllib3 types directly.
+
+    Use the convenience methods (``get_json``, ``post_json``,
+    ``get_bytes``) when you only need the body. Drop down to
+    ``request()`` when you need response headers — typical case is
+    capturing ``ETag`` / ``Last-Modified`` for a subsequent
+    conditional request via ``If-None-Match`` / ``If-Modified-Since``.
+
+    Header keys are **lowercased on storage** so callers can do
+    ``resp.headers["etag"]`` regardless of how the server cased it.
+    Servers send mixed case (``ETag``, ``Etag``, ``etag``); the
+    HTTP spec says headers are case-insensitive, and forcing one
+    casing keeps caller code simple.
+
+    ``url`` is the final URL after any redirects (or the request URL
+    if redirects were disabled / the backend couldn't determine the
+    final URL).
+    """
+
+    status: int
+    headers: Mapping[str, str]
+    body: bytes
+    url: str
+
+    def json(self) -> Any:
+        """Parse body as JSON. Raises HttpError on parse failure."""
+        try:
+            return json.loads(self.body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            raise HttpError(f"Response is not valid JSON: {e}") from e
+
+
+class NotModified(HttpError):
+    """Raised when a server returns 304 Not Modified.
+
+    Use with conditional requests — pass ``If-None-Match`` (with a
+    cached ETag) or ``If-Modified-Since`` (with a cached Last-Modified
+    timestamp) via the ``headers`` kwarg, then catch this exception to
+    fall back to your cached value:
+
+        try:
+            data = client.get_json(
+                url, headers={"If-None-Match": cached_etag},
+            )
+            store(url, data)
+        except NotModified:
+            data = cache[url]   # still fresh
+
+    Bandwidth + latency win for resources that change rarely (KEV feed,
+    EPSS data, GitHub raw files). Status is always 304.
+    """
+
+    def __init__(self, message: str = "304 Not Modified") -> None:
+        super().__init__(message, status=304)
+
+
+class HttpClient(Protocol):
+    """Interface every HTTP-using module in RAPTOR depends on.
+
+    Callers type-hint this Protocol so the concrete backend can be
+    swapped (UrllibClient ↔ EgressClient ↔ test mock) with no
+    consumer-side changes.
+
+    All methods accept these adoption-friendly kwargs:
+
+      - ``headers``: caller-supplied headers (e.g. Authorization,
+        If-None-Match, Accept-Language). Merged with backend defaults.
+      - ``retries``: maximum **additional** attempts after the first,
+        on transient errors (429, 5xx, network). ``retries=0`` for
+        fail-fast / non-idempotent POSTs / health probes. Backends
+        cap the effective attempt count at their own backoff
+        schedule length, so values larger than the schedule are
+        silently equivalent to "use the whole schedule".
+      - ``follow_redirects``: True (default) follows up to 10 redirects;
+        False surfaces 3xx as ``HttpError`` for caller inspection.
+      - ``total_timeout``: wall-clock cap on the whole retry loop in
+        seconds (default 600).
+    """
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        body: Optional[bytes] = None,
+        headers: Optional[Dict[str, str]] = None,
+        timeout: int = DEFAULT_TIMEOUT,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+        total_timeout: int = DEFAULT_TOTAL_TIMEOUT,
+        retries: int = DEFAULT_RETRIES,
+        follow_redirects: bool = True,
+    ) -> "Response":
+        """Low-level request — returns :class:`Response` with status, headers, body.
+
+        Use for arbitrary HTTP methods (DELETE/PUT/PATCH/HEAD) and when
+        response metadata (ETag, Last-Modified) is needed for the next
+        conditional request.
+        """
+        ...
+
+    def post_json(
+        self,
+        url: str,
+        body: Dict[str, Any],
+        timeout: int = DEFAULT_TIMEOUT,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        total_timeout: int = DEFAULT_TOTAL_TIMEOUT,
+        retries: int = DEFAULT_RETRIES,
+        follow_redirects: bool = True,
+    ) -> Dict[str, Any]:
+        """POST ``body`` as JSON, return decoded JSON response."""
+        ...
+
+    def get_json(
+        self,
+        url: str,
+        timeout: int = DEFAULT_TIMEOUT,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        total_timeout: int = DEFAULT_TOTAL_TIMEOUT,
+        retries: int = DEFAULT_RETRIES,
+        follow_redirects: bool = True,
+    ) -> Dict[str, Any]:
+        """GET ``url``, parse response as JSON."""
+        ...
+
+    def get_bytes(
+        self,
+        url: str,
+        timeout: int = DEFAULT_TIMEOUT,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        total_timeout: int = DEFAULT_TOTAL_TIMEOUT,
+        retries: int = DEFAULT_RETRIES,
+        follow_redirects: bool = True,
+    ) -> bytes:
+        """GET ``url``, return raw bytes capped at ``max_bytes``."""
+        ...
+
+    def stream_bytes(
+        self,
+        url: str,
+        *,
+        timeout: int = DEFAULT_TIMEOUT,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+        headers: Optional[Dict[str, str]] = None,
+        total_timeout: int = DEFAULT_TOTAL_TIMEOUT,
+        retries: int = 0,
+    ) -> Iterator[bytes]:
+        """GET ``url``, yield body chunks without buffering the whole response.
+
+        Single attempt — ``retries`` is accepted for API symmetry but
+        non-zero values raise :class:`ValueError` (mid-stream failures
+        aren't transparently resumable). Cumulative size cap is
+        enforced across yielded chunks; exceeding ``max_bytes`` raises
+        :class:`SizeLimitExceeded` mid-stream.
+        """
+        ...
+
+
+def default_client(
+    allowed_hosts: Optional[List[str]] = None,
+) -> HttpClient:
+    """Construct the right HttpClient backend for the caller.
+
+    - ``allowed_hosts=None`` (default) → :class:`UrllibClient`.
+      No allowlist, unrestricted. For tests + paths where the
+      sandbox proxy is unavailable.
+
+    - ``allowed_hosts=[...]`` → :class:`EgressClient`. Routes through
+      the in-process egress proxy with the given hosts on its
+      allowlist. Production paths SHOULD pass an allowlist.
+    """
+    if allowed_hosts is not None:
+        from core.http.egress_backend import EgressClient
+        return EgressClient(allowed_hosts)
+    from core.http.urllib_backend import UrllibClient
+    return UrllibClient()
+
+
+__all__ = [
+    "DEFAULT_MAX_BYTES",
+    "DEFAULT_RETRIES",
+    "DEFAULT_TIMEOUT",
+    "DEFAULT_TOTAL_TIMEOUT",
+    "DEFAULT_USER_AGENT",
+    "HttpClient",
+    "HttpError",
+    "NotModified",
+    "Response",
+    "SizeLimitExceeded",
+    "default_client",
+]

--- a/core/http/egress_backend.py
+++ b/core/http/egress_backend.py
@@ -1,0 +1,111 @@
+"""Egress-allowlisted backend for :class:`core.http.HttpClient`.
+
+Routes outbound HTTPS through the in-process proxy at
+:mod:`core.sandbox.proxy`. The proxy enforces a hostname allowlist —
+CONNECT to anything outside the registered hosts is refused — closing
+the gap that direct urlopen leaves open: a parser compromise can't
+exfiltrate to attacker hosts, only to the small set of feeds the
+caller declared.
+
+Backend swap is transparent to consumers: same :class:`HttpClient`
+Protocol, same retry/backoff/size-cap behaviour (inherited from
+UrllibClient via the injected pool manager). Only the network path
+changes — every request is forwarded through the in-process
+``ProxyManager``.
+
+``no_proxy`` semantics — important to understand:
+
+  - ``no_proxy`` is honoured **at the chaining layer**, NOT at the
+    chokepoint layer. The in-process proxy reads ``NO_PROXY`` /
+    ``no_proxy`` env vars on first call and uses them to decide
+    whether to chain through ``HTTPS_PROXY`` upstream for a given
+    backend host. So in a corporate-proxy setup
+    (``HTTPS_PROXY=http://corp:8080``, ``no_proxy=internal.corp``),
+    requests to ``internal.corp`` correctly bypass the corporate
+    proxy and connect direct from the in-process proxy. This is
+    the most common ``no_proxy`` use case and works as expected.
+
+  - ``no_proxy`` does NOT bypass the in-process proxy itself.
+    Every EgressClient request is forwarded through the in-process
+    proxy unconditionally — the urllib3 ``ProxyManager`` doesn't
+    read ``no_proxy`` at request time. **The hostname allowlist
+    on the in-process proxy supersedes ``no_proxy``.** If a host
+    needs to bypass the chokepoint, add it to ``allowed_hosts`` at
+    construction; don't expect ``no_proxy`` to do it.
+
+This is intentional: pre-urllib3 we used the stdlib
+``urllib.request.ProxyHandler``, which silently honoured
+``no_proxy`` AT THE CHOKEPOINT and would route direct (skipping
+the in-process proxy entirely) for matching hosts — defeating
+the allowlist. urllib3 closes that bypass; if it accepted a
+``respect_no_proxy=True`` opt-out, the bypass would re-open.
+
+Hosts are registered with the proxy on construction. The proxy is
+process-wide singleton with UNION-of-all-callers allowlist semantics
+(see :func:`core.sandbox.proxy.get_proxy`), so two EgressClient
+instances with different ``allowed_hosts`` lists each see the union
+— acceptable in our threat model since RAPTOR's own code is trusted
+and the allowlist exists to constrain the attack surface, not to
+isolate caller-from-caller.
+
+Upstream proxy autodetect: when ``HTTPS_PROXY`` is set in the parent
+environment at first ``get_proxy`` call, the in-process proxy chains
+through it for outbound connections (except ``NO_PROXY`` matches).
+Lets RAPTOR work behind corporate proxies transparently.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+import urllib3
+
+from core.http import DEFAULT_USER_AGENT
+from core.http.urllib_backend import UrllibClient
+
+logger = logging.getLogger(__name__)
+
+
+class EgressClient(UrllibClient):
+    """HttpClient backend that routes via :mod:`core.sandbox.proxy`.
+
+    Restricts URLs to https only — the underlying proxy is
+    HTTPS-CONNECT-only, so an http:// request would forward-proxy as
+    ``GET http://host/`` and fail at the proxy. Rejecting at the
+    validator gives the caller a clear immediate error rather than
+    a confusing late one.
+    """
+
+    _ALLOWED_SCHEMES = ("https",)
+
+    def __init__(
+        self,
+        allowed_hosts: Iterable[str],
+        user_agent: str = DEFAULT_USER_AGENT,
+    ) -> None:
+        from core.sandbox.proxy import get_proxy
+        proxy = get_proxy(list(allowed_hosts))
+        proxy_url = f"http://127.0.0.1:{proxy.port}"
+        # urllib3.ProxyManager forwards every request through the proxy
+        # unconditionally — no no_proxy autodetect (unlike the stdlib
+        # urllib.request.ProxyHandler we used pre-pooling). retries=False
+        # so urllib3's retry doesn't fight UrllibClient's own.
+        # maxsize matches UrllibClient (10) — connections to the proxy.
+        # Each carries its own CONNECT tunnel; 10 simultaneous tunnels
+        # is well within the in-process proxy's 64-tunnel cap.
+        from core.http.urllib_backend import _DEFAULT_POOL_MAXSIZE
+        proxy_pool = urllib3.ProxyManager(
+            proxy_url,
+            retries=False,
+            cert_reqs="CERT_REQUIRED",
+            maxsize=_DEFAULT_POOL_MAXSIZE,
+        )
+        logger.debug(
+            "core.http.EgressClient: routing via in-process proxy at %s",
+            proxy_url,
+        )
+        super().__init__(user_agent=user_agent, _http=proxy_pool)
+
+
+__all__ = ["EgressClient"]

--- a/core/http/tests/test_egress_backend.py
+++ b/core/http/tests/test_egress_backend.py
@@ -1,0 +1,153 @@
+"""Tests for core.http.egress_backend.EgressClient (urllib3-backed).
+
+End-to-end testing through the real proxy lives in ``core/sandbox/tests/`` —
+the proxy has its own coverage there, and CONNECT-tunnel integration
+tests need an HTTPS stub server with a self-signed cert which is heavy
+infrastructure for limited additional confidence.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import urllib3
+
+# core/http/tests/test_egress_backend.py -> repo root
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from core.http import HttpError, default_client
+from core.http.egress_backend import EgressClient
+from core.http.urllib_backend import UrllibClient
+
+
+# ---------------------------------------------------------------------------
+# Wiring — host registration + ProxyManager construction
+# ---------------------------------------------------------------------------
+
+class TestEgressClientWiring:
+    """Verifies EgressClient registers hosts with the proxy and constructs
+    a urllib3.ProxyManager pointing at the in-process proxy."""
+
+    def _stub_proxy(self, port: int = 12345):
+        proxy = MagicMock()
+        proxy.port = port
+        return proxy
+
+    @patch("core.sandbox.proxy.get_proxy")
+    def test_registers_hosts_with_proxy(self, mock_get_proxy):
+        mock_get_proxy.return_value = self._stub_proxy()
+        EgressClient(["api.osv.dev", "services.nvd.nist.gov"])
+        called_hosts = mock_get_proxy.call_args.args[0]
+        assert "api.osv.dev" in called_hosts
+        assert "services.nvd.nist.gov" in called_hosts
+
+    @patch("core.sandbox.proxy.get_proxy")
+    def test_uses_proxy_manager(self, mock_get_proxy):
+        """The injected pool must be a urllib3.ProxyManager (not a plain
+        PoolManager) — that's what enforces routing through the proxy
+        for every request, with no no_proxy bypass."""
+        mock_get_proxy.return_value = self._stub_proxy(port=54321)
+        client = EgressClient(["api.osv.dev"])
+        assert isinstance(client._http, urllib3.ProxyManager)
+
+    @patch("core.sandbox.proxy.get_proxy")
+    def test_inherits_urllib_retry_logic(self, mock_get_proxy):
+        """EgressClient extends UrllibClient — retry/parse/size-cap all
+        inherited. Smoke-test: isinstance + public API present."""
+        mock_get_proxy.return_value = self._stub_proxy()
+        client = EgressClient(["api.osv.dev"])
+        assert isinstance(client, UrllibClient)
+        assert callable(client.get_json)
+        assert callable(client.post_json)
+        assert callable(client.get_bytes)
+
+    @patch("core.sandbox.proxy.get_proxy")
+    def test_iterable_hosts_accepted(self, mock_get_proxy):
+        """allowed_hosts can be any iterable, not just a list."""
+        mock_get_proxy.return_value = self._stub_proxy()
+        EgressClient(("a.com", "b.com"))
+        EgressClient(h for h in ["c.com"])
+
+    @patch("core.sandbox.proxy.get_proxy")
+    def test_get_request_routes_through_proxy(self, mock_get_proxy):
+        """A GET request must go through the injected ProxyManager —
+        urllib3.ProxyManager forwards every CONNECT to the proxy URL,
+        no no_proxy bypass."""
+        mock_get_proxy.return_value = self._stub_proxy()
+        client = EgressClient(["example.com"])
+        # Replace the pool with a stub.
+        fake_resp = MagicMock()
+        fake_resp.status = 200
+        fake_resp.headers = {}
+        fake_resp.stream = lambda cs, decode_content=True: iter(
+            [b'{"ok": true}'],
+        )
+        fake_resp.release_conn = MagicMock()
+        client._http = MagicMock()
+        client._http.request.return_value = fake_resp
+
+        result = client.get_json("https://example.com/api")
+        assert result == {"ok": True}
+        client._http.request.assert_called_once()
+
+
+class TestProxyManagerHasNoBypass:
+    """The whole reason for the urllib3 swap (besides pooling) was that
+    stdlib urllib's ProxyHandler silently honoured no_proxy env vars,
+    bypassing our chokepoint. urllib3's ProxyManager doesn't read
+    no_proxy at request time — every request is forwarded.
+
+    These tests verify the property by inspecting the constructed pool.
+    """
+
+    @patch("core.sandbox.proxy.get_proxy")
+    def test_no_proxy_env_does_not_affect_pool_construction(
+        self, mock_get_proxy, monkeypatch,
+    ):
+        mock_get_proxy.return_value = MagicMock(port=12345)
+        # Set no_proxy to its most aggressive form before constructing.
+        monkeypatch.setenv("no_proxy", "*")
+        monkeypatch.setenv("NO_PROXY", "*")
+
+        client = EgressClient(["api.osv.dev"])
+
+        # Smoke check: ProxyManager constructed; client._http is the
+        # ProxyManager. The fact that urllib3.ProxyManager doesn't
+        # call proxy_bypass() at request time is intrinsic to urllib3 —
+        # we don't need to test urllib3 itself, only that we use it.
+        assert isinstance(client._http, urllib3.ProxyManager)
+
+
+# ---------------------------------------------------------------------------
+# https-only validation
+# ---------------------------------------------------------------------------
+
+class TestHttpsOnly:
+
+    @patch("core.sandbox.proxy.get_proxy")
+    def test_http_url_rejected(self, mock_get_proxy):
+        """EgressClient narrows _ALLOWED_SCHEMES to https only — the
+        underlying proxy is HTTPS-CONNECT-only and http:// requests
+        would forward-proxy and fail. Reject at the validator with a
+        clear message instead."""
+        mock_get_proxy.return_value = MagicMock(port=12345)
+        client = EgressClient(["example.com"])
+        with pytest.raises(HttpError, match="scheme 'http'"):
+            client.get_json("http://example.com/api")
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+class TestDefaultClientWithHosts:
+
+    @patch("core.sandbox.proxy.get_proxy")
+    def test_with_hosts_returns_egress(self, mock_get_proxy):
+        mock_get_proxy.return_value = MagicMock(port=1234)
+        c = default_client(allowed_hosts=["api.osv.dev"])
+        assert isinstance(c, EgressClient)

--- a/core/http/tests/test_urllib_backend.py
+++ b/core/http/tests/test_urllib_backend.py
@@ -1,0 +1,755 @@
+"""Tests for core.http.urllib_backend.UrllibClient (urllib3-backed)."""
+
+from __future__ import annotations
+
+import gzip
+import sys
+from pathlib import Path
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# core/http/tests/test_urllib_backend.py -> repo root
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from core.http import (
+    DEFAULT_RETRIES,
+    HttpError,
+    Response,
+    SizeLimitExceeded,
+    default_client,
+)
+from core.http.urllib_backend import UrllibClient
+
+
+def _stub_response(body: bytes, *, status: int = 200,
+                   content_encoding: str = "",
+                   reason: str = "OK",
+                   extra_headers: Optional[dict] = None,
+                   final_url: str = "") -> MagicMock:
+    """Build a stub urllib3 HTTPResponse: stream() yields body in one chunk."""
+    resp = MagicMock()
+    resp.status = status
+    resp.reason = reason
+    headers = {"Content-Encoding": content_encoding} if content_encoding else {}
+    if extra_headers:
+        headers.update(extra_headers)
+    resp.headers = headers
+    resp.stream = lambda chunk_size, decode_content=True: iter([body])
+    resp.read = lambda *a, **kw: body[:512]
+    resp.release_conn = MagicMock()
+    resp.geturl = lambda: final_url
+    return resp
+
+
+def _client_with_mock_pool(*responses):
+    """Build a UrllibClient whose injected pool serves the given responses.
+
+    Pass a single response → pool returns that for every call.
+    Pass multiple positional args OR a single list → pool serves them
+    sequentially via side_effect.
+    """
+    pool = MagicMock()
+    # Unwrap a single-list arg so callers can write
+    # _client_with_mock_pool([resp1, resp2, resp3])
+    if len(responses) == 1 and isinstance(responses[0], list):
+        responses = tuple(responses[0])
+    if len(responses) == 1:
+        pool.request.return_value = responses[0]
+    else:
+        pool.request.side_effect = list(responses)
+    return UrllibClient(_http=pool), pool
+
+
+# ---------------------------------------------------------------------------
+# Successful paths
+# ---------------------------------------------------------------------------
+
+class TestSuccess:
+
+    def test_get_json(self):
+        client, pool = _client_with_mock_pool(_stub_response(b'{"a": 1}'))
+        result = client.get_json("https://example.com/api")
+        assert result == {"a": 1}
+        # Verify it called pool.request once with method=GET
+        assert pool.request.call_args.args[0] == "GET"
+
+    def test_post_json_sends_serialised_body(self):
+        client, pool = _client_with_mock_pool(_stub_response(b'{"ok": true}'))
+        client.post_json("https://example.com/api", {"q": "deadbeef"})
+        call = pool.request.call_args
+        assert call.args[0] == "POST"
+        assert call.kwargs["body"] == b'{"q": "deadbeef"}'
+        assert call.kwargs["headers"]["Content-Type"] == "application/json"
+
+    def test_get_bytes(self):
+        client, pool = _client_with_mock_pool(_stub_response(b"\x01\x02\xff"))
+        out = client.get_bytes("https://example.com/binary")
+        assert out == b"\x01\x02\xff"
+
+    def test_gzip_body_decompressed_as_defence_in_depth(self):
+        """If urllib3's auto-decode misses (some servers send gzip without
+        the header), the magic-byte sniffer in _fetch_once decodes it."""
+        body = gzip.compress(b'{"hello": "world"}')
+        # decode_content=True in urllib3 normally decompresses, but to
+        # force the fallback path we lie via the stub: stream() returns
+        # the raw gzipped bytes as if urllib3 didn't decode.
+        client, _ = _client_with_mock_pool(_stub_response(body))
+        result = client.get_json("https://example.com/api")
+        assert result == {"hello": "world"}
+
+    def test_release_conn_called(self):
+        """Connection is returned to the pool after every request — this
+        is the whole point of switching to urllib3."""
+        resp = _stub_response(b'{"ok": true}')
+        client = UrllibClient(_http=MagicMock(request=MagicMock(return_value=resp)))
+        client.get_json("https://example.com/api")
+        resp.release_conn.assert_called_once()
+
+
+class TestConnectionPooling:
+    """Verify connection reuse — the headline win of switching to urllib3."""
+
+    def test_repeat_calls_share_pool(self):
+        """Multiple calls to the same client go through the same pool
+        manager instance (so urllib3 can reuse the connection)."""
+        pool = MagicMock()
+        pool.request.return_value = _stub_response(b'{"a": 1}')
+        client = UrllibClient(_http=pool)
+        for _ in range(5):
+            client.get_json("https://example.com/api")
+        # All 5 calls hit the same pool object — urllib3 internally
+        # reuses connections to the same host.
+        assert pool.request.call_count == 5
+
+    def test_pool_manager_uses_maxsize_default(self):
+        """The default pool manager is constructed with maxsize > 1
+        so concurrent calls to the same host don't serialise on a
+        single connection."""
+        from core.http.urllib_backend import _new_pool_manager, _DEFAULT_POOL_MAXSIZE
+        pool = _new_pool_manager()
+        # urllib3 stores maxsize on connection_pool_kw.
+        assert pool.connection_pool_kw.get("maxsize") == _DEFAULT_POOL_MAXSIZE
+        assert _DEFAULT_POOL_MAXSIZE > 1
+
+
+# ---------------------------------------------------------------------------
+# Caller-supplied headers + 304 Not Modified
+# ---------------------------------------------------------------------------
+
+class TestCallerHeaders:
+
+    def test_get_json_merges_caller_headers(self):
+        client, pool = _client_with_mock_pool(_stub_response(b'{"ok": true}'))
+        client.get_json(
+            "https://example.com/api",
+            headers={"Authorization": "Bearer abc123",
+                     "X-Custom": "hello"},
+        )
+        sent = pool.request.call_args.kwargs["headers"]
+        assert sent["Authorization"] == "Bearer abc123"
+        assert sent["X-Custom"] == "hello"
+        # Defaults still present.
+        assert "User-Agent" in sent
+        assert sent["Accept"] == "application/json"
+
+    def test_caller_can_override_default_header(self):
+        """Caller-supplied headers win over defaults — explicit override
+        is allowed."""
+        client, pool = _client_with_mock_pool(_stub_response(b'{"ok": true}'))
+        client.get_json(
+            "https://example.com/api",
+            headers={"User-Agent": "custom/1.0"},
+        )
+        sent = pool.request.call_args.kwargs["headers"]
+        assert sent["User-Agent"] == "custom/1.0"
+
+    def test_post_json_merges_caller_headers(self):
+        client, pool = _client_with_mock_pool(_stub_response(b'{"ok": true}'))
+        client.post_json(
+            "https://example.com/api", {"x": 1},
+            headers={"Authorization": "Bearer t"},
+        )
+        sent = pool.request.call_args.kwargs["headers"]
+        assert sent["Authorization"] == "Bearer t"
+        assert sent["Content-Type"] == "application/json"
+
+
+class TestNotModified:
+    """Conditional requests via If-None-Match / If-Modified-Since."""
+
+    def test_304_raises_not_modified(self):
+        from core.http import NotModified
+        client, _ = _client_with_mock_pool(
+            _stub_response(b"", status=304, reason="Not Modified"),
+        )
+        with pytest.raises(NotModified):
+            client.get_json(
+                "https://example.com/feed",
+                headers={"If-None-Match": '"abc123"'},
+            )
+
+    def test_304_does_not_retry(self):
+        """304 is a permanent (good) outcome — must not be retried."""
+        from core.http import NotModified
+        client, pool = _client_with_mock_pool(
+            _stub_response(b"", status=304, reason="Not Modified"),
+        )
+        with pytest.raises(NotModified):
+            client.get_json("https://example.com/feed")
+        assert pool.request.call_count == 1
+
+    def test_not_modified_is_subclass_of_http_error(self):
+        """NotModified inherits from HttpError so existing
+        `except HttpError:` handlers don't lose it; callers who want
+        it specifically catch NotModified."""
+        from core.http import HttpError, NotModified
+        assert issubclass(NotModified, HttpError)
+
+
+# ---------------------------------------------------------------------------
+# total_timeout — wall-clock cap on the retry loop
+# ---------------------------------------------------------------------------
+
+class TestTotalTimeout:
+
+    @patch("core.http.urllib_backend.time.monotonic")
+    @patch("core.http.urllib_backend.time.sleep")
+    def test_deadline_caps_retries(self, _mock_sleep, mock_monotonic):
+        """If the wall-clock deadline elapses, raise immediately
+        without continuing the backoff schedule. Worst case without
+        this: ~1 hour spent in retries; with this, capped to total_timeout."""
+        # Simulate clock jumping forward by 1000s on each call. With
+        # default total_timeout=600, the deadline is exceeded before
+        # the second iteration.
+        ticks = iter([0, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000])
+        mock_monotonic.side_effect = lambda: next(ticks)
+        client, pool = _client_with_mock_pool([
+            _stub_response(b"", status=503),
+            _stub_response(b"", status=503),
+        ])
+        with pytest.raises(HttpError, match="Total timeout"):
+            client.get_json("https://example.com/api", total_timeout=600)
+
+    def test_short_total_timeout_actually_fires_real_clock(self):
+        """REGRESSION TEST. Before the fix, deadline was computed as
+        ``time.monotonic() + max(total_timeout, timeout)``. With caller's
+        total_timeout=1 (fail-fast for a health probe) and the default
+        per-attempt timeout=30, ``max(1, 30) = 30`` — so the deadline
+        was 30s away, not 1s. The cap never fired for short total_timeout.
+
+        Mock-based tests didn't catch this: they advanced ``time.monotonic``
+        with synthetic ticks and the bug only manifests when the deadline
+        value is wrong AGAINST REAL WALL-CLOCK. This test uses a stub pool
+        that returns 503 instantly and verifies elapsed wall-clock stays
+        small (under 5s — the sleep clipping bounds the overshoot).
+        """
+        import time as _time
+        pool = MagicMock()
+        pool.request.return_value = _stub_response(b"", status=503)
+        client = UrllibClient(_http=pool)
+
+        t0 = _time.monotonic()
+        with pytest.raises(HttpError):
+            client.get_json("https://example.com/api", total_timeout=1)
+        elapsed = _time.monotonic() - t0
+        # Cap is 1s; allow generous slop for sleep granularity but well
+        # under 5s (which is where the previous bug would have led with
+        # default per-attempt timeout=30). The pre-fix max() would have
+        # let this run through the full backoff schedule.
+        assert elapsed < 5, (
+            f"total_timeout=1 took {elapsed:.1f}s — "
+            f"deadline computation may have regressed to max(total, timeout)"
+        )
+
+
+class TestHeadRequest:
+    """REGRESSION TESTS for HEAD method support.
+
+    urllib3 with ``preload_content=False`` does NOT auto-skip body reading
+    for HEAD responses. If a server replies to HEAD with no body (correct
+    per RFC 7231) and our code tries to ``resp.stream()`` the body, urllib3
+    blocks waiting for bytes that won't come. The stress harness caught
+    this against a real localhost server; mocks couldn't because they
+    don't actually wait.
+
+    Two-part fix in core.http.urllib_backend:
+      1. ``preload_content=is_head`` — for HEAD we let urllib3 preload
+         the (empty) body, sidestepping the streaming hang.
+      2. Short-circuit ``resp.stream()`` loop in _fetch_once for HEAD —
+         defence in depth in case (1) regresses or a future urllib3
+         version changes behaviour.
+    """
+
+    def test_head_does_not_hang(self):
+        """A HEAD response with no body returns cleanly, doesn't hang."""
+        resp = MagicMock()
+        resp.status = 200
+        resp.headers = {"ETag": '"v1"', "Content-Length": "1234"}
+        # If our code calls resp.stream() for HEAD, this would yield
+        # nothing and urllib3 would block (in real life). The mock
+        # would block too if we made it iterate forever — instead we
+        # make stream() raise to prove the code DOESN'T call it.
+        resp.stream = lambda *a, **kw: (_ for _ in ()).throw(
+            AssertionError("stream() must not be called on HEAD response"),
+        )
+        resp.read = lambda *a, **kw: b""
+        resp.release_conn = MagicMock()
+        resp.geturl = lambda: ""
+        client = UrllibClient(_http=MagicMock(request=MagicMock(return_value=resp)))
+
+        response = client.request("HEAD", "https://example.com/api")
+        assert response.status == 200
+        assert response.headers["etag"] == '"v1"'
+        assert response.body == b""
+
+    def test_head_uses_preload_content_true(self):
+        """The pool.request call for HEAD must pass preload_content=True
+        so urllib3 reads the (empty) body upfront and doesn't leave us
+        with a half-finished response that hangs on .stream()."""
+        pool = MagicMock()
+        pool.request.return_value = _stub_response(b"", status=200)
+        client = UrllibClient(_http=pool)
+        client.request("HEAD", "https://example.com/api")
+        assert pool.request.call_args.kwargs["preload_content"] is True
+
+    def test_get_uses_preload_content_false(self):
+        """Sanity: non-HEAD methods still use preload_content=False
+        (so streaming + size cap work)."""
+        pool = MagicMock()
+        pool.request.return_value = _stub_response(b'{"x": 1}')
+        client = UrllibClient(_http=pool)
+        client.get_json("https://example.com/api")
+        assert pool.request.call_args.kwargs["preload_content"] is False
+
+
+# ---------------------------------------------------------------------------
+# stream_bytes — chunked reads without buffering
+# ---------------------------------------------------------------------------
+
+class TestStreamBytes:
+
+    def test_yields_chunks(self):
+        """stream_bytes returns an iterator that yields the body in
+        chunks. Caller can write straight to disk without RSS pressure."""
+        # Stub stream() to yield known-size chunks.
+        resp = MagicMock()
+        resp.status = 200
+        resp.headers = {}
+        resp.stream = lambda cs, decode_content=True: iter(
+            [b"chunk1", b"chunk2", b"chunk3"],
+        )
+        resp.release_conn = MagicMock()
+        client = UrllibClient(_http=MagicMock(request=MagicMock(return_value=resp)))
+
+        chunks = list(client.stream_bytes("https://example.com/big"))
+        assert chunks == [b"chunk1", b"chunk2", b"chunk3"]
+        resp.release_conn.assert_called_once()
+
+    def test_size_cap_enforced_mid_stream(self):
+        """Cumulative size > max_bytes mid-stream raises SizeLimitExceeded."""
+        resp = MagicMock()
+        resp.status = 200
+        resp.headers = {}
+        resp.stream = lambda cs, decode_content=True: iter(
+            [b"x" * 50, b"x" * 50, b"x" * 50, b"x" * 50],
+        )
+        resp.release_conn = MagicMock()
+        client = UrllibClient(_http=MagicMock(request=MagicMock(return_value=resp)))
+
+        with pytest.raises(SizeLimitExceeded):
+            for _ in client.stream_bytes("https://example.com/big", max_bytes=100):
+                pass
+        resp.release_conn.assert_called_once()  # finally fires on exception
+
+    def test_url_validation_at_call_time(self):
+        """URL validation must fail at call time, not deferred to
+        first iteration — the generator-split must preserve fail-fast."""
+        with pytest.raises(HttpError, match="scheme"):
+            UrllibClient().stream_bytes("file:///etc/hostname")
+
+    def test_304_raises_not_modified(self):
+        """Streaming respects conditional requests too."""
+        from core.http import NotModified
+        resp = MagicMock()
+        resp.status = 304
+        resp.headers = {}
+        resp.release_conn = MagicMock()
+        client = UrllibClient(_http=MagicMock(request=MagicMock(return_value=resp)))
+
+        with pytest.raises(NotModified):
+            list(client.stream_bytes("https://example.com/feed",
+                                      headers={"If-None-Match": '"x"'}))
+        resp.release_conn.assert_called_once()
+
+    def test_retries_nonzero_rejected_at_call_time(self):
+        """stream_bytes is single-attempt — retries=N for N != 0 must
+        raise ValueError eagerly, before any HTTP call. Mid-stream
+        failures aren't transparently resumable, so silently honouring
+        retries would mislead callers about restart semantics."""
+        client = UrllibClient(_http=MagicMock())
+        with pytest.raises(ValueError, match="retries"):
+            client.stream_bytes("https://example.com/x", retries=1)
+        # Negative values are equally unsupported.
+        with pytest.raises(ValueError, match="retries"):
+            client.stream_bytes("https://example.com/x", retries=-1)
+        # And no HTTP call should have been issued.
+        assert client._http.request.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+class TestErrors:
+
+    def test_400_raises_immediately_no_retry(self):
+        client, pool = _client_with_mock_pool(
+            _stub_response(b'{"err":"bad"}', status=400, reason="Bad Request"),
+        )
+        with pytest.raises(HttpError) as ei:
+            client.get_json("https://example.com/api")
+        assert ei.value.status == 400
+        assert pool.request.call_count == 1
+
+    @patch("core.http.urllib_backend.time.sleep")
+    def test_429_retries_with_backoff(self, _mock_sleep):
+        # Two 429s, then success.
+        client, pool = _client_with_mock_pool([
+            _stub_response(b"", status=429, reason="Too Many"),
+            _stub_response(b"", status=429, reason="Too Many"),
+            _stub_response(b'{"ok": true}'),
+        ])
+        result = client.get_json("https://example.com/api")
+        assert result == {"ok": True}
+        assert pool.request.call_count == 3
+
+    @patch("core.http.urllib_backend.time.sleep")
+    def test_500_retries_then_raises(self, _mock_sleep):
+        # Always 500 for every attempt — default = 1 initial + DEFAULT_RETRIES.
+        attempts = DEFAULT_RETRIES + 1
+        responses = [_stub_response(b"err", status=500, reason="Internal")
+                     for _ in range(attempts)]
+        client, pool = _client_with_mock_pool(responses)
+        with pytest.raises(HttpError, match="Exhausted retries"):
+            client.get_json("https://example.com/api")
+        assert pool.request.call_count == attempts
+
+    def test_size_limit_enforced(self):
+        # Build a stub whose stream() yields 200 bytes; max_bytes=100.
+        big_body = b"x" * 200
+        resp = _stub_response(big_body)
+        # Re-stub stream to yield in 50-byte chunks so size cap fires
+        # MID-read, not just after the whole thing is buffered.
+        resp.stream = lambda cs, decode_content=True: iter(
+            [b"x" * 50, b"x" * 50, b"x" * 50, b"x" * 50],
+        )
+        client = UrllibClient(_http=MagicMock(request=MagicMock(return_value=resp)))
+        with pytest.raises(SizeLimitExceeded):
+            client.get_bytes("https://example.com/big", max_bytes=100)
+
+    def test_invalid_json_raises(self):
+        client, _ = _client_with_mock_pool(_stub_response(b"not json{"))
+        with pytest.raises(HttpError, match="not valid JSON"):
+            client.get_json("https://example.com/api")
+
+    @patch("core.http.urllib_backend.time.sleep")
+    def test_network_error_retries_then_raises(self, _mock_sleep):
+        """Connection-level errors (urllib3 MaxRetryError, timeout etc.)
+        are retried — same backoff schedule as 5xx."""
+        from urllib3.exceptions import MaxRetryError
+        pool = MagicMock()
+        pool.request.side_effect = MaxRetryError(
+            pool=None, url="https://example.com/api", reason="connection refused",
+        )
+        client = UrllibClient(_http=pool)
+        with pytest.raises(HttpError, match="Exhausted retries"):
+            client.get_json("https://example.com/api")
+        assert pool.request.call_count == DEFAULT_RETRIES + 1
+
+    def test_proxy_403_is_permanent_no_retry(self):
+        """When the in-process proxy returns 403 (host not on allowlist),
+        urllib3 surfaces it as a ProxyError. That's a permanent error
+        — retrying through the full backoff schedule would waste many
+        minutes. Must raise immediately with a clear message about
+        the allowlist."""
+        from urllib3.exceptions import ProxyError
+        pool = MagicMock()
+        pool.request.side_effect = ProxyError(
+            "Cannot connect to proxy.",
+            OSError("Tunnel connection failed: 403 Forbidden"),
+        )
+        client = UrllibClient(_http=pool)
+        with pytest.raises(HttpError, match="not on the allowlist"):
+            client.get_json("https://forbidden.example/api")
+        # Single attempt — no retry storm.
+        assert pool.request.call_count == 1
+
+    @patch("core.http.urllib_backend.time.sleep")
+    def test_other_proxy_errors_are_retried(self, _mock_sleep):
+        """ProxyError that ISN'T a 403 (e.g., proxy unreachable) is
+        transient and should retry like any other connection error."""
+        from urllib3.exceptions import ProxyError
+        pool = MagicMock()
+        # No "403"/"Forbidden" in the message → treated as transient.
+        pool.request.side_effect = ProxyError(
+            "Cannot connect to proxy.",
+            OSError("connection refused"),
+        )
+        client = UrllibClient(_http=pool)
+        with pytest.raises(HttpError, match="Exhausted retries"):
+            client.get_json("https://example.com/api")
+        assert pool.request.call_count == DEFAULT_RETRIES + 1
+
+
+# ---------------------------------------------------------------------------
+# Retry-After parsing
+# ---------------------------------------------------------------------------
+
+class TestRetryAfter:
+
+    @pytest.mark.parametrize("value,expected", [
+        ("5", 5),           # plain seconds
+        ("  10  ", 10),     # whitespace tolerated
+        ("0", 1),           # clamped to min 1
+        ("99999", 1800),    # clamped to max 30min
+        ("Mon, 01 Jan 2030 00:00:00 GMT", None),   # HTTP-date — not supported
+        (None, None),
+        ("", None),
+    ])
+    def test_parses(self, value, expected):
+        assert UrllibClient._parse_retry_after(value) == expected
+
+
+# ---------------------------------------------------------------------------
+# URL validation — adversarial input refused at entry
+# ---------------------------------------------------------------------------
+
+class TestUrlValidation:
+    """The clients refuse non-http(s) schemes and URLs with credentials.
+
+    These guards exist because:
+      - urllib3 only handles http(s), but defence in depth — we don't
+        rely on the underlying library refusing weird schemes; we
+        refuse at our entry point.
+      - URLs with userinfo would leak credentials into log lines and
+        encourage anti-pattern auth flow; callers should pass
+        Authorization headers instead.
+    """
+
+    @pytest.mark.parametrize("url", [
+        "file:///etc/passwd",
+        "file:///etc/hostname",
+        "ftp://example.com/file",
+        "gopher://example.com/",
+        "data:text/plain,hello",
+        "javascript:alert(1)",
+    ])
+    def test_non_http_schemes_rejected(self, url):
+        with pytest.raises(HttpError, match="scheme"):
+            UrllibClient().get_bytes(url)
+
+    @pytest.mark.parametrize("url", [
+        # Standard userinfo forms
+        "https://user:pass@example.com/api",
+        "https://user@example.com/api",
+        "http://admin:secret@example.com/",
+        # Adversarial host-confusion attacks. urlsplit() resolves these
+        # to (hostname=evil.com, username=<...>) — the *real* destination
+        # is evil.com, with the leading "example.com" looking like a host
+        # to a casual reader of the log line. Our `username is not None`
+        # check catches the empty-string form too.
+        "http://example.com@evil.com/",
+        "http://@evil.com/",
+        "http://@ftp://hostname/",
+        "https://example.com:80@evil.com:443/",
+    ])
+    def test_userinfo_in_url_rejected(self, url):
+        with pytest.raises(HttpError, match="credentials"):
+            UrllibClient().get_json(url)
+
+    def test_url_with_no_host_rejected(self):
+        with pytest.raises(HttpError, match="no host"):
+            UrllibClient().get_bytes("https:///path-but-no-host")
+
+    def test_https_with_no_userinfo_accepted(self):
+        client, _ = _client_with_mock_pool(_stub_response(b'{"ok": true}'))
+        client.get_json("https://api.example.com/v1/things?q=foo")
+
+    def test_http_accepted_by_urllib_client(self):
+        """UrllibClient accepts plain http:// — useful for local dev /
+        test stubs hitting localhost. EgressClient narrows to https."""
+        client, _ = _client_with_mock_pool(_stub_response(b'{"ok": true}'))
+        client.get_json("http://127.0.0.1:8080/health")
+
+    def test_post_json_validates_too(self):
+        """Validation hook fires from post_json + get_bytes too, not just get_json."""
+        with pytest.raises(HttpError, match="scheme"):
+            UrllibClient().post_json("file:///etc/hostname", {})
+
+
+class TestSafeUrlForLog:
+    """Defence in depth: even if a credential URL slipped past validation,
+    log lines would still strip it."""
+
+    def test_strips_userinfo(self):
+        from core.http.urllib_backend import _safe_url_for_log
+        assert _safe_url_for_log("https://user:pass@host.example/path") == \
+            "https://host.example/path"
+
+    def test_preserves_port(self):
+        from core.http.urllib_backend import _safe_url_for_log
+        assert _safe_url_for_log("https://user:pass@host.example:8443/path") == \
+            "https://host.example:8443/path"
+
+    def test_passthrough_for_clean_url(self):
+        from core.http.urllib_backend import _safe_url_for_log
+        url = "https://api.example.com/v1/x?q=1"
+        assert _safe_url_for_log(url) == url
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+class TestRequest:
+    """Low-level request() — returns a Response object with status,
+    headers, body, and final URL. Enables ETag-based conditional
+    caching and arbitrary HTTP methods (DELETE/PUT/PATCH/HEAD)."""
+
+    def test_returns_response_with_headers(self):
+        client, _ = _client_with_mock_pool(
+            _stub_response(b'{"ok": true}',
+                           extra_headers={"ETag": '"v1.2.3"',
+                                          "Cache-Control": "max-age=3600"},
+                           final_url="https://example.com/api"),
+        )
+        resp = client.request("GET", "https://example.com/api")
+        assert isinstance(resp, Response)
+        assert resp.status == 200
+        assert resp.body == b'{"ok": true}'
+        # Header keys are lowercased on storage for predictable lookup.
+        assert resp.headers["etag"] == '"v1.2.3"'
+        assert resp.headers["cache-control"] == "max-age=3600"
+
+    def test_response_json_parses_body(self):
+        client, _ = _client_with_mock_pool(
+            _stub_response(b'{"x": 42}'),
+        )
+        resp = client.request("GET", "https://example.com/api")
+        assert resp.json() == {"x": 42}
+
+    def test_response_json_raises_on_invalid(self):
+        client, _ = _client_with_mock_pool(
+            _stub_response(b"not json{"),
+        )
+        resp = client.request("GET", "https://example.com/api")
+        with pytest.raises(HttpError, match="not valid JSON"):
+            resp.json()
+
+    def test_arbitrary_methods_accepted(self):
+        """request() supports DELETE/PUT/PATCH/HEAD without explicit
+        helper methods. Verify the method string is forwarded."""
+        client, pool = _client_with_mock_pool(_stub_response(b""))
+        for method in ("DELETE", "PUT", "PATCH", "HEAD"):
+            client.request(method, "https://example.com/api")
+            assert pool.request.call_args.args[0] == method
+
+
+class TestRetriesOptOut:
+    """retries=0 for fail-fast / non-idempotent POSTs / health probes."""
+
+    def test_retries_zero_means_single_attempt(self):
+        """retries=0 → one attempt then raise; no retry storm even on
+        retryable errors."""
+        client, pool = _client_with_mock_pool(
+            _stub_response(b"", status=503),
+        )
+        with pytest.raises(HttpError):
+            client.get_json("https://example.com/api", retries=0)
+        assert pool.request.call_count == 1
+
+    @patch("core.http.urllib_backend.time.sleep")
+    def test_retries_three_means_four_attempts(self, _mock_sleep):
+        """retries=3 → up to 4 total attempts (1 initial + 3 retries)."""
+        responses = [_stub_response(b"", status=503) for _ in range(8)]
+        client, pool = _client_with_mock_pool(responses)
+        with pytest.raises(HttpError, match="Exhausted retries"):
+            client.get_json("https://example.com/api", retries=3)
+        assert pool.request.call_count == 4
+
+    def test_no_sleep_after_final_attempt(self):
+        """REGRESSION: each schedule slot owns the sleep AFTER its
+        attempt. The final slot has no next attempt, so we MUST NOT
+        sleep before raising 'Exhausted retries' — otherwise retries=0
+        + 503 sleeps schedule[0] (1s), and a default-config full
+        failure burns the trailing 300s slot for nothing.
+        """
+        import time as _time
+        pool = MagicMock()
+        pool.request.return_value = _stub_response(b"", status=503)
+        client = UrllibClient(_http=pool)
+
+        t0 = _time.monotonic()
+        with pytest.raises(HttpError):
+            client.get_json("https://example.com/api", retries=0)
+        elapsed = _time.monotonic() - t0
+        # Real wall-clock — well under schedule[0]=1s. Slop allows
+        # for slow CI scheduling but well below the buggy 1s sleep.
+        assert elapsed < 0.5, (
+            f"retries=0 took {elapsed:.2f}s — likely slept the final "
+            f"schedule slot before raising"
+        )
+
+    def test_post_json_documents_idempotency(self):
+        """The post_json docstring tells callers about retry+idempotency
+        risk for non-idempotent POSTs and recommends retries=0."""
+        assert "idempotent" in UrllibClient.post_json.__doc__.lower()
+        assert "retries=0" in UrllibClient.post_json.__doc__
+
+
+class TestFollowRedirects:
+    """follow_redirects=False surfaces 3xx responses to the caller
+    instead of chasing them — security-scanning patterns need this."""
+
+    def test_default_follows_redirects(self):
+        """Default behaviour passes redirect=True to urllib3."""
+        client, pool = _client_with_mock_pool(_stub_response(b'{"ok": true}'))
+        client.get_json("https://example.com/api")
+        assert pool.request.call_args.kwargs["redirect"] is True
+
+    def test_follow_redirects_false_passed_through(self):
+        client, pool = _client_with_mock_pool(_stub_response(b'{"ok": true}'))
+        client.get_json("https://example.com/api", follow_redirects=False)
+        assert pool.request.call_args.kwargs["redirect"] is False
+
+    def test_3xx_with_no_follow_raises(self):
+        """3xx with follow_redirects=False reaches the >= 400 check via
+        a different path — but actually 301/302 are < 400. The Response
+        is returned. Verify we get a Response with the 301 status,
+        not an exception."""
+        # 302 with redirect=False: urllib3 doesn't auto-chase, returns
+        # the 302 response. Our code only treats >=400 as error, so 302
+        # comes back as a Response. Test via request().
+        client, _ = _client_with_mock_pool(
+            _stub_response(b"", status=302, reason="Found",
+                           extra_headers={"Location": "https://other.example/"}),
+        )
+        resp = client.request(
+            "GET", "https://example.com/api",
+            follow_redirects=False,
+        )
+        assert resp.status == 302
+        assert resp.headers["location"] == "https://other.example/"
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+class TestDefaultClient:
+
+    def test_no_hosts_returns_urllib(self):
+        c = default_client()
+        assert isinstance(c, UrllibClient)

--- a/core/http/urllib_backend.py
+++ b/core/http/urllib_backend.py
@@ -1,0 +1,669 @@
+"""urllib3-backed implementation of :class:`core.http.HttpClient`.
+
+Why urllib3 not stdlib urllib:
+  - **Connection pooling.** urllib3 reuses TCP+TLS connections across
+    requests to the same host. SCA-shaped workloads (~100 calls across
+    ~5 hosts) see ~4× speedup on the HTTP layer because handshakes
+    amortise.
+  - **No surprise no_proxy bypass.** stdlib urllib's ``ProxyHandler``
+    silently honours ``no_proxy`` env vars and skips the proxy for
+    matching hosts; verified empirically that ``no_proxy=*`` lets a
+    request connect direct, defeating EgressClient's chokepoint.
+    urllib3's ``ProxyManager`` does NOT read env vars at request
+    time — every request goes through the configured proxy, full
+    stop. One fewer security-critical workaround to maintain.
+  - **Consistent TLS via certifi.** Stdlib urllib's CA store varies
+    across distros / containers / OSes. urllib3 ships its own
+    bundle and is configured CERT_REQUIRED + hostname-verified by
+    default in 2.x.
+
+Honours Retry-After on 429/503; exponential backoff on other transient
+errors; bounded total retry duration; size caps on responses; gzip
+decompression of responses that arrive compressed even when not
+requested (some servers do this).
+
+No allowlist — UrllibClient can reach any host on :443. For
+allowlisted egress, use :class:`core.http.egress_backend.EgressClient`.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+import time
+from typing import Any, Dict, Iterator, Optional
+from urllib import parse as _urlparse
+
+import urllib3
+from urllib3.exceptions import (
+    HTTPError as _U3HTTPError,
+    MaxRetryError,
+    ProxyError as _U3ProxyError,
+    ReadTimeoutError,
+    SSLError,
+)
+
+from core.http import (
+    DEFAULT_MAX_BYTES,
+    DEFAULT_RETRIES,
+    DEFAULT_TIMEOUT,
+    DEFAULT_TOTAL_TIMEOUT,
+    DEFAULT_USER_AGENT,
+    HttpError,
+    NotModified,
+    Response,
+    SizeLimitExceeded,
+)
+
+logger = logging.getLogger(__name__)
+
+# Backoff schedule for transient errors (5xx, 429). Length is chosen so
+# the cumulative sleep (1+2+5+15+60+300 = 383s) fits comfortably under
+# the default total_timeout of 600s — every slot can actually fire
+# under default config. Callers needing longer retry budgets bump
+# total_timeout AND retries together; the schedule auto-clips against
+# the wall-clock deadline in _fetch so over-long sleeps can't blow past
+# the caller's budget.
+_BACKOFF_SECONDS = (1, 2, 5, 15, 60, 300)
+# One schedule slot per attempt (initial + retries). Default attempt
+# count is therefore len(schedule) and matches DEFAULT_RETRIES + 1 —
+# the assert catches drift if either side is retuned without the other.
+assert len(_BACKOFF_SECONDS) == DEFAULT_RETRIES + 1, (
+    "_BACKOFF_SECONDS length must equal DEFAULT_RETRIES + 1 (one slot "
+    "for the initial attempt + one per retry); update both together"
+)
+
+
+def _safe_url_for_log(url: str) -> str:
+    """Strip userinfo from a URL for log output. Defence in depth — if
+    a URL with credentials slips past _validate_url somehow, this still
+    keeps the creds out of the audit trail.
+
+    NOTE: overlaps with ``core/security/redaction.py`` (tracked in
+    memory ``project_core_http_redaction_overlap``); when that module
+    grows a URL-aware redactor, replace this helper with a thin call
+    through to it."""
+    try:
+        parsed = _urlparse.urlsplit(url)
+        if parsed.username is None and parsed.password is None:
+            return url
+        host = parsed.hostname or ""
+        port = f":{parsed.port}" if parsed.port else ""
+        return _urlparse.urlunsplit((
+            parsed.scheme, f"{host}{port}", parsed.path,
+            parsed.query, parsed.fragment,
+        ))
+    except (ValueError, AttributeError):
+        return "<unparseable URL>"
+
+
+_DEFAULT_POOL_MAXSIZE = 10  # connections per (host, port) — see _new_pool_manager
+
+
+def _new_pool_manager() -> urllib3.PoolManager:
+    """Construct a urllib3.PoolManager with secure defaults.
+
+    - retries=False — we run our own retry/backoff logic with
+      Retry-After awareness; urllib3's default Retry would fight it.
+    - cert_reqs='CERT_REQUIRED' + assert_hostname (urllib3 2.x default) —
+      enforces TLS cert + hostname verification.
+    - maxsize=10 — connections-per-host cap. urllib3's default is 1,
+      which serialises concurrent calls to the same host (e.g. SCA
+      hammering api.osv.dev with parallel queries would queue on a
+      single connection). 10 lets up to 10 in-flight per host without
+      thrashing kernel resources.
+    """
+    return urllib3.PoolManager(
+        retries=False, cert_reqs="CERT_REQUIRED",
+        maxsize=_DEFAULT_POOL_MAXSIZE,
+    )
+
+
+class UrllibClient:
+    """urllib3-backed HttpClient (was stdlib urllib pre-pooling refactor).
+
+    Subclasses (e.g. EgressClient) may inject a custom pool manager via
+    the ``_http`` constructor arg — typically a ``urllib3.ProxyManager``
+    pointing at a chokepoint proxy.
+
+    Subclasses may also tighten ``_ALLOWED_SCHEMES`` to restrict
+    accepted URL schemes — UrllibClient accepts http and https
+    (the latter for production, the former for tests/dev paths
+    hitting localhost stubs); EgressClient narrows to https only
+    because its proxy is HTTPS-CONNECT-only and http requests
+    can't be served through it cleanly.
+    """
+
+    _ALLOWED_SCHEMES = ("http", "https")
+
+    def __init__(
+        self,
+        user_agent: str = DEFAULT_USER_AGENT,
+        _http: Optional[urllib3.PoolManager] = None,
+    ) -> None:
+        self._ua = user_agent
+        # Subclass / test hook. Lazy default avoids spinning up a pool
+        # manager (and its certifi load) when the client is never used.
+        self._http = _http or _new_pool_manager()
+
+    def _validate_url(self, url: str) -> _urlparse.SplitResult:
+        """Reject URLs that don't match (allowed-scheme)://host/...
+
+        Without this guard, a caller-controlled URL could exfiltrate
+        local files via ``file:///etc/passwd`` (urllib3 itself doesn't
+        handle file://, but defence in depth) and the EgressClient
+        proxy would be bypassed for non-http(s) schemes.
+
+        Userinfo (``https://user:pass@host/...``) is also rejected — it
+        would leak into log lines and is an anti-pattern; callers should
+        pass credentials via Authorization headers instead. The
+        ``is not None`` check catches the empty-string variant returned
+        by urlsplit for adversarial forms like ``http://@evil.com/``.
+        """
+        parsed = _urlparse.urlsplit(url)
+        if parsed.scheme not in self._ALLOWED_SCHEMES:
+            permitted = "/".join(self._ALLOWED_SCHEMES)
+            raise HttpError(
+                f"Refused URL with scheme {parsed.scheme!r}: "
+                f"only {permitted} permitted"
+            )
+        if not parsed.hostname:
+            raise HttpError(f"Refused URL with no host: {url!r}")
+        if parsed.username is not None or parsed.password is not None:
+            raise HttpError(
+                "Refused URL with embedded credentials; pass credentials via "
+                "an Authorization header, not in the URL authority"
+            )
+        return parsed
+
+    # -- public API -----------------------------------------------------
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        body: Optional[bytes] = None,
+        headers: Optional[Dict[str, str]] = None,
+        timeout: int = DEFAULT_TIMEOUT,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+        total_timeout: int = DEFAULT_TOTAL_TIMEOUT,
+        retries: int = DEFAULT_RETRIES,
+        follow_redirects: bool = True,
+    ) -> Response:
+        """Low-level HTTP request — returns a full :class:`Response` object.
+
+        Use this when you need response metadata (status, headers, final
+        URL after redirects). Typical case: capturing ``ETag`` /
+        ``Last-Modified`` for a subsequent conditional request.
+
+        For arbitrary HTTP methods (DELETE, PUT, PATCH, HEAD, etc.)
+        callers can pass them via this method — the convenience methods
+        (``get_json``, ``post_json``, ``get_bytes``) only cover the
+        most common shapes.
+        """
+        self._validate_url(url)
+        merged = {"User-Agent": self._ua}
+        if headers:
+            merged.update(headers)
+        return self._fetch(
+            url, method=method, timeout=timeout, body=body,
+            headers=merged, max_bytes=max_bytes,
+            total_timeout=total_timeout,
+            retries=retries,
+            follow_redirects=follow_redirects,
+        )
+
+    def post_json(
+        self,
+        url: str,
+        body: Dict[str, Any],
+        timeout: int = DEFAULT_TIMEOUT,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        total_timeout: int = DEFAULT_TOTAL_TIMEOUT,
+        retries: int = DEFAULT_RETRIES,
+        follow_redirects: bool = True,
+    ) -> Dict[str, Any]:
+        """POST ``body`` as JSON, return decoded JSON response.
+
+        NOTE on retry idempotency: ``post_json`` retries on transient
+        5xx/429 the same as GET. This is safe for POSTs that are
+        semantically idempotent (e.g. OSV's ``querybatch`` API —
+        same input → same output). For non-idempotent POSTs (creating
+        a record, charging a card, sending a message), pass
+        ``retries=0`` so a 5xx after partial server-side processing
+        doesn't retrigger the side effect.
+        """
+        self._validate_url(url)
+        data = json.dumps(body).encode("utf-8")
+        merged = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": self._ua,
+        }
+        if headers:
+            merged.update(headers)
+        resp = self._fetch(url, method="POST", timeout=timeout, body=data,
+                           headers=merged, max_bytes=DEFAULT_MAX_BYTES,
+                           total_timeout=total_timeout, retries=retries,
+                           follow_redirects=follow_redirects)
+        return resp.json()
+
+    def get_json(
+        self,
+        url: str,
+        timeout: int = DEFAULT_TIMEOUT,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        total_timeout: int = DEFAULT_TOTAL_TIMEOUT,
+        retries: int = DEFAULT_RETRIES,
+        follow_redirects: bool = True,
+    ) -> Dict[str, Any]:
+        self._validate_url(url)
+        merged = {"Accept": "application/json", "User-Agent": self._ua}
+        if headers:
+            merged.update(headers)
+        resp = self._fetch(url, method="GET", timeout=timeout, body=None,
+                           headers=merged, max_bytes=DEFAULT_MAX_BYTES,
+                           total_timeout=total_timeout, retries=retries,
+                           follow_redirects=follow_redirects)
+        return resp.json()
+
+    def get_bytes(
+        self,
+        url: str,
+        timeout: int = DEFAULT_TIMEOUT,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        total_timeout: int = DEFAULT_TOTAL_TIMEOUT,
+        retries: int = DEFAULT_RETRIES,
+        follow_redirects: bool = True,
+    ) -> bytes:
+        self._validate_url(url)
+        merged = {"User-Agent": self._ua}
+        if headers:
+            merged.update(headers)
+        resp = self._fetch(url, method="GET", timeout=timeout, body=None,
+                           headers=merged, max_bytes=max_bytes,
+                           total_timeout=total_timeout, retries=retries,
+                           follow_redirects=follow_redirects)
+        return resp.body
+
+    def stream_bytes(
+        self,
+        url: str,
+        *,
+        timeout: int = DEFAULT_TIMEOUT,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+        headers: Optional[Dict[str, str]] = None,
+        total_timeout: int = DEFAULT_TOTAL_TIMEOUT,
+        retries: int = 0,
+    ) -> Iterator[bytes]:
+        """GET ``url``, yield response body chunks without buffering.
+
+        Use for large downloads (multi-100MB+) where ``get_bytes`` would
+        balloon RSS. Cumulative size cap is enforced across yielded
+        chunks; exceeding ``max_bytes`` raises :class:`SizeLimitExceeded`
+        mid-stream.
+
+        ``timeout`` caps the per-attempt connect+read window. The
+        ``total_timeout`` parameter is accepted for **API symmetry**
+        with the buffered methods but only enforced on connection
+        setup — once the iterator yields its first chunk, the body
+        read is bounded by ``timeout`` alone (urllib3 has no clean
+        knob for "wall-clock cap on streamed reads").
+
+        ``retries`` is accepted for API symmetry but **must be 0** —
+        mid-stream failures aren't transparently retryable (would
+        need range-resumed restart). Non-zero values raise
+        :class:`ValueError`. Caller can wrap the iterator in their
+        own retry loop if needed.
+
+        Caller must fully consume the iterator OR call ``.close()`` on
+        it to release the connection back to the pool. A common
+        pattern::
+
+            with open(dest, "wb") as f:
+                for chunk in client.stream_bytes(url):
+                    f.write(chunk)
+        """
+        if retries != 0:
+            raise ValueError(
+                "stream_bytes does not support retries (mid-stream "
+                "failures aren't transparently resumable). "
+                "Pass retries=0 or wrap the iterator in your own "
+                "retry loop."
+            )
+        self._validate_url(url)
+        merged = {"User-Agent": self._ua}
+        if headers:
+            merged.update(headers)
+        # Cap per-attempt timeout by remaining total_timeout so a caller
+        # tightening total_timeout actually shortens the connect window.
+        effective_timeout = min(timeout, total_timeout)
+        # Validation runs at call time; the generator below runs at
+        # iteration time. Splitting them ensures URL errors fail fast
+        # instead of waiting for the first .next() call.
+        return self._stream(url, merged, effective_timeout, max_bytes)
+
+    def _stream(
+        self,
+        url: str,
+        headers: Dict[str, str],
+        timeout: int,
+        max_bytes: int,
+    ) -> Iterator[bytes]:
+        resp = self._http.request(
+            "GET", url,
+            headers=headers,
+            timeout=urllib3.Timeout(total=float(timeout)),
+            preload_content=False,
+            decode_content=True,
+            redirect=True,
+            retries=False,
+        )
+        try:
+            if resp.status == 304:
+                raise NotModified(
+                    f"304 Not Modified for {_safe_url_for_log(url)}",
+                )
+            if resp.status >= 400:
+                snippet = resp.read(512, decode_content=True) or b""
+                reason = resp.reason or "?"
+                raise HttpError(
+                    f"HTTP {resp.status} from {_safe_url_for_log(url)}: "
+                    f"{reason} {snippet!r}"[:200],
+                    status=resp.status,
+                )
+            total = 0
+            for chunk in resp.stream(64 * 1024, decode_content=True):
+                total += len(chunk)
+                if total > max_bytes:
+                    raise SizeLimitExceeded(
+                        f"Stream from {_safe_url_for_log(url)} "
+                        f"exceeded {max_bytes} bytes",
+                    )
+                yield chunk
+        finally:
+            # Released whether the generator was fully consumed,
+            # garbage-collected mid-stream, or .close()-d explicitly.
+            resp.release_conn()
+
+    # -- internals ------------------------------------------------------
+
+    def _fetch(
+        self,
+        url: str,
+        method: str,
+        timeout: int,
+        max_bytes: int,
+        body: Optional[bytes],
+        headers: Dict[str, str],
+        total_timeout: int = DEFAULT_TOTAL_TIMEOUT,
+        retries: int = DEFAULT_RETRIES,
+        follow_redirects: bool = True,
+    ) -> Response:
+        # Wall-clock deadline for the whole retry loop. Without this,
+        # the full backoff schedule (~1h worst case) can dominate
+        # agentic budgets. Caller's total_timeout is authoritative —
+        # if they pass total_timeout=2 (fail-fast for a health probe)
+        # we honour that even when total_timeout < timeout (per-attempt).
+        deadline = time.monotonic() + total_timeout
+        # Caller-cap on the retry count. retries=0 means "single attempt,
+        # don't retry anything" — useful for non-idempotent POSTs and
+        # health probes. The slice gives the same backoff schedule but
+        # truncated; a max() guards against negative values.
+        max_attempts = max(1, min(retries + 1, len(_BACKOFF_SECONDS)))
+        schedule = _BACKOFF_SECONDS[:max_attempts]
+        last_exc: Optional[Exception] = None
+        for attempt, delay in enumerate(schedule):
+            if time.monotonic() >= deadline:
+                raise HttpError(
+                    f"Total timeout ({total_timeout}s) exceeded for "
+                    f"{_safe_url_for_log(url)}",
+                ) from last_exc
+            # Each schedule slot represents one attempt and the sleep
+            # AFTER it (before the next attempt). On the final slot
+            # there is no next attempt, so we skip the post-failure
+            # sleep entirely — otherwise retries=0 against a 503
+            # would sleep schedule[0] seconds (1s) before raising
+            # "Exhausted retries", and a default-config full failure
+            # would burn the trailing 300s slot for no reason.
+            is_last_attempt = attempt + 1 == len(schedule)
+            try:
+                return self._fetch_once(
+                    url, method=method, timeout=timeout, max_bytes=max_bytes,
+                    body=body, headers=headers,
+                    follow_redirects=follow_redirects,
+                )
+            except HttpError as e:
+                # Retry only on transient status codes (429, 5xx).
+                # Everything else — non-retryable 4xx, SizeLimitExceeded
+                # (status=None), JSON-decode errors, etc. — propagates.
+                is_transient = (
+                    e.status == 429
+                    or (e.status is not None and 500 <= e.status < 600)
+                )
+                if not is_transient:
+                    raise
+                last_exc = e
+                if is_last_attempt:
+                    continue
+                # Retry-After honoured by _fetch_once if present.
+                sleep_for = e.retry_after or delay
+                logger.info(
+                    "core.http: %s %s -> %d; sleeping %ds (retry %d)",
+                    method, _safe_url_for_log(url), e.status,
+                    sleep_for, attempt + 1,
+                )
+                # Clip sleep to remaining deadline so a long backoff
+                # doesn't blow past total_timeout.
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise HttpError(
+                        f"Total timeout ({total_timeout}s) exceeded for "
+                        f"{_safe_url_for_log(url)}",
+                    ) from last_exc
+                time.sleep(min(sleep_for, remaining))
+                continue
+            except _U3ProxyError as e:
+                # Distinguish "proxy denied CONNECT" (permanent, our
+                # chokepoint refused the host as off-allowlist) from
+                # "proxy unreachable" (transient). urllib3 surfaces
+                # both as ProxyError with a message; we string-match
+                # for the 403/Forbidden marker the in-process proxy
+                # emits at core/sandbox/proxy.py for off-allowlist
+                # hosts. Permanent errors must NOT loop through the
+                # backoff schedule (minutes of wasted sleep); raise now.
+                # Lower-case the haystack so a future urllib3 release
+                # changing the message casing doesn't silently turn
+                # "off-allowlist" into a transient-retry storm.
+                msg = str(e).lower()
+                if "403" in msg or "forbidden" in msg:
+                    host = _urlparse.urlsplit(url).hostname or "?"
+                    raise HttpError(
+                        f"Egress proxy refused {host!r}: host not on the "
+                        f"allowlist. If you're using EgressClient, add "
+                        f"this host to allowed_hosts at construction — "
+                        f"the chokepoint allowlist supersedes any "
+                        f"no_proxy env var by design (closing it would "
+                        f"reintroduce the bypass urllib3 was chosen to "
+                        f"prevent). Underlying: {e}",
+                    ) from e
+                last_exc = e
+                if is_last_attempt:
+                    continue
+                logger.info(
+                    "core.http: %s %s proxy error: %s; backoff %ds",
+                    method, _safe_url_for_log(url), e, delay,
+                )
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise HttpError(
+                        f"Total timeout ({total_timeout}s) exceeded for "
+                        f"{_safe_url_for_log(url)}",
+                    ) from last_exc
+                time.sleep(min(delay, remaining))
+                continue
+            except (MaxRetryError, ReadTimeoutError, SSLError, _U3HTTPError,
+                    TimeoutError, ConnectionError) as e:
+                last_exc = e
+                if is_last_attempt:
+                    continue
+                logger.info(
+                    "core.http: %s %s network error: %s; backoff %ds",
+                    method, _safe_url_for_log(url), e, delay,
+                )
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise HttpError(
+                        f"Total timeout ({total_timeout}s) exceeded for "
+                        f"{_safe_url_for_log(url)}",
+                    ) from last_exc
+                time.sleep(min(delay, remaining))
+                continue
+        # Exhausted retries
+        raise HttpError(
+            f"Exhausted retries fetching {_safe_url_for_log(url)}: {last_exc}",
+        ) from last_exc
+
+    def _fetch_once(
+        self,
+        url: str,
+        method: str,
+        timeout: int,
+        max_bytes: int,
+        body: Optional[bytes],
+        headers: Dict[str, str],
+        follow_redirects: bool = True,
+    ) -> Response:
+        # urllib3.Timeout(total=N) caps both connect and read; matches
+        # the per-call semantics our public API exposes.
+        # preload_content=False normally so we can stream-read for
+        # size-cap enforcement before buffering the whole response —
+        # but for HEAD requests we use preload_content=True since HEAD
+        # responses have no body. urllib3 with preload_content=False
+        # on a HEAD response can hang reading body bytes that won't
+        # arrive (no clean way to signal "drain zero bytes").
+        # decode_content=True so urllib3 transparently decompresses
+        # gzip/deflate responses from servers that send them whether
+        # or not we asked.
+        # redirect default True follows up to 10 redirects (urllib3 default).
+        # follow_redirects=False lets callers inspect 3xx responses —
+        # useful for security scanning patterns that need to see
+        # Location headers without chasing them.
+        is_head = method.upper() == "HEAD"
+        resp = self._http.request(
+            method, url,
+            body=body,
+            headers=headers,
+            timeout=urllib3.Timeout(total=float(timeout)),
+            preload_content=is_head,   # True for HEAD, False otherwise
+            decode_content=True,
+            redirect=follow_redirects,
+            retries=False,
+        )
+        try:
+            # 304 Not Modified — caller used If-None-Match / If-Modified-Since
+            # and the server says the cached value is still fresh. Surface
+            # via NotModified exception so caller can fall back to cache.
+            # Important: 304 is NOT >= 400, so this needs to come first
+            # before the generic error threshold below.
+            if resp.status == 304:
+                raise NotModified(
+                    f"304 Not Modified for {_safe_url_for_log(url)}",
+                )
+            if resp.status in (429, 503):
+                raise HttpError(
+                    f"HTTP {resp.status} from {_safe_url_for_log(url)}",
+                    status=resp.status,
+                    retry_after=self._parse_retry_after(
+                        resp.headers.get("Retry-After"),
+                    ),
+                )
+            # Treat 4xx/5xx as HttpError. The exception is non-retryable
+            # for 4xx (we don't loop on auth/validation errors) and
+            # retried by _fetch for 5xx via the is_transient check.
+            # 3xx-with-follow_redirects=False reaches here too — surface
+            # the Location header in the exception for caller inspection.
+            if resp.status >= 400:
+                # Drain enough body for the error message — bounded.
+                snippet = resp.read(512, decode_content=True) or b""
+                reason = resp.reason or "?"
+                raise HttpError(
+                    f"HTTP {resp.status} from {_safe_url_for_log(url)}: "
+                    f"{reason} {snippet!r}"[:200],
+                    status=resp.status,
+                )
+
+            # Stream-read the body, enforcing the size cap as we go so
+            # an unexpectedly-huge response doesn't first balloon RSS.
+            # HEAD responses have no body — urllib3 with preload_content=False
+            # would block on resp.stream() waiting for bytes that never
+            # arrive, so short-circuit there.
+            if method.upper() == "HEAD":
+                raw = b""
+            else:
+                buf = bytearray()
+                for chunk in resp.stream(64 * 1024, decode_content=True):
+                    buf.extend(chunk)
+                    if len(buf) > max_bytes:
+                        raise SizeLimitExceeded(
+                            f"Response from {_safe_url_for_log(url)} "
+                            f"exceeded {max_bytes} bytes",
+                        )
+                raw = bytes(buf)
+
+            # Defence in depth: some servers send Content-Encoding: gzip
+            # but urllib3 may not always auto-decode (depends on
+            # decode_content honouring). If body still looks gzip
+            # (magic bytes 1f 8b), decode here. Fall back to the raw
+            # bytes if gzip.decompress raises — the magic-byte check
+            # has a ~1/65k false-positive rate on arbitrary binary
+            # bodies, and we'd rather hand the caller raw data than
+            # corrupt a payload that wasn't actually gzip.
+            if raw.startswith(b"\x1f\x8b"):
+                try:
+                    raw = gzip.decompress(raw)
+                except (OSError, EOFError):
+                    pass
+
+            # Lowercase header keys for predictable case-insensitive
+            # lookup — servers send mixed case, callers shouldn't have
+            # to remember whether a particular server uses "ETag" or
+            # "etag".
+            # urllib3's geturl() returns the post-redirect URL, or the
+            # request URL when no redirect happened. It can return None
+            # (or empty string) if the response object hasn't recorded
+            # the URL yet — fall back to the request URL so callers
+            # always see something parseable. Documented contract on
+            # Response.url.
+            final_url = resp.geturl() or url
+            return Response(
+                status=resp.status,
+                headers={k.lower(): v for k, v in resp.headers.items()},
+                body=raw,
+                url=final_url,
+            )
+        finally:
+            # Return the connection to the pool. Without this, repeated
+            # requests would each open a fresh connection — exactly the
+            # cost we're switching to urllib3 to avoid.
+            resp.release_conn()
+
+    @staticmethod
+    def _parse_retry_after(value: Optional[str]) -> Optional[int]:
+        """Parse Retry-After header (seconds form only; HTTP-date form ignored)."""
+        if not value:
+            return None
+        try:
+            n = int(value.strip())
+            return max(1, min(n, 1800))  # clamp 1s..30min
+        except ValueError:
+            return None
+
+
+__all__ = ["UrllibClient"]

--- a/core/json/__init__.py
+++ b/core/json/__init__.py
@@ -1,3 +1,13 @@
-"""JSON utilities — load, save, and comment-stripping."""
+"""JSON utilities — one-shot load/save + TTL'd disk cache."""
 
+from .cache import CacheEnvelope, JsonCache, TTL_FOREVER
 from .utils import load_json, save_json, load_json_with_comments
+
+__all__ = [
+    "CacheEnvelope",
+    "JsonCache",
+    "TTL_FOREVER",
+    "load_json",
+    "save_json",
+    "load_json_with_comments",
+]

--- a/core/json/cache.py
+++ b/core/json/cache.py
@@ -1,0 +1,259 @@
+"""Disk-backed JSON cache with TTL.
+
+A small key→JSON store with atomic-rename writes and per-entry TTL.
+Designed for caching deterministic, infrequently-changing data —
+e.g. HTTP feed responses, advisory records, lookup tables — where
+re-fetching is expensive and a stale window of seconds-to-days is
+acceptable.
+
+Layout:
+  Each key maps to a file under the supplied root. Keys may contain
+  ``/`` to denote subdirectories, e.g. ``vulns/GHSA-xxx`` →
+  ``<root>/vulns/GHSA-xxx.json``.
+
+Concurrency:
+  Writes use atomic rename — write to ``<path>.tmp.<pid>.<tid>``,
+  then rename. Tempfile names include both pid and thread id so
+  concurrent writers (cross-process or cross-thread within a
+  process) never share a tempfile path. Concurrent writers are
+  last-writer-wins, which is correct because cache values are
+  deterministic per key. Readers see either the old version or
+  the new version, never a torn write.
+
+Failure modes (silent, by design):
+  - Cache root unwritable → in-memory-only mode (every put no-ops,
+    every get returns None). The run still succeeds, just slower.
+  - Corrupted entries (truncated, invalid JSON, missing fields) →
+    treated as miss, caller refetches.
+
+Caller TTL semantics:
+  ``get(key, ttl_seconds=N)`` returns the cached value only if the
+  entry is younger than ``min(stored_ttl, N)``. So a caller can
+  effectively shorten the TTL of pre-existing entries (e.g.
+  ``--offline`` mode might decide that a 24h-old entry is now
+  stale even though it was written with a 7d TTL).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Sentinel TTL meaning "never expire". Use for keys whose freshness
+# is encoded in the key itself (e.g., wheel-metadata keyed on
+# (name, exact-version) — content can't change for a given key).
+TTL_FOREVER = -1
+
+
+@dataclass(frozen=True)
+class CacheEnvelope:
+    """Internal representation of a cached entry."""
+
+    written_at: float    # unix seconds
+    ttl_seconds: int     # ttl from written_at; TTL_FOREVER = no expiry
+    value: Any           # the JSON-serialisable payload
+
+    def is_fresh(self, now: float) -> bool:
+        if self.ttl_seconds == TTL_FOREVER:
+            return True
+        return (now - self.written_at) <= self.ttl_seconds
+
+
+class JsonCache:
+    """Filesystem-backed JSON cache with per-entry TTL.
+
+    Construct one per logical store (one per project run, one per
+    feed source, etc.) and pass it to consumers via dependency
+    injection. The path layout is keyed so different callers can't
+    collide as long as they pick distinct keyspaces.
+    """
+
+    def __init__(self, root: Path) -> None:
+        self._root: Optional[Path] = root
+        self._writable = True
+        # Hit / miss counters for surfacing cache-effectiveness metrics.
+        # Reset only by reconstructing the cache.
+        self.hits = 0
+        self.misses = 0
+        try:
+            self._root.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            logger.warning(
+                "core.json.cache: cache directory %s unwritable (%s); "
+                "running without disk cache.",
+                self._root, e,
+            )
+            self._writable = False
+            self._root = None
+            return
+        self._reap_orphan_tempfiles()
+
+    def _reap_orphan_tempfiles(self) -> None:
+        """Sweep ``*.tmp.<pid>.<tid>`` files left by a previously-crashed writer.
+
+        ``put()`` writes to ``<path>.tmp.<pid>.<tid>`` then renames atomically —
+        if the writer was killed between the open and the rename, the
+        tempfile is orphaned. Without this sweep, every crash leaks one
+        tempfile per partial write, and the cache dir slowly fills up
+        across many runs (each run has a different pid, so old orphans
+        are never overwritten).
+
+        Best-effort: any remove failure is ignored. Runs once at
+        construction time; not in the hot path.
+        """
+        if self._root is None:
+            return
+        try:
+            entries = list(self._root.rglob("*.tmp.*"))
+        except OSError:
+            return
+        for entry in entries:
+            # Defensive: only target files whose suffix matches the
+            # tempfile shape we write — either legacy ``.tmp.<pid>``
+            # (single all-digit segment) or current
+            # ``.tmp.<pid>.<tid>`` (two all-digit segments). Anything
+            # else is left alone so we don't collide with caller-chosen
+            # keys that happen to contain ".tmp.".
+            parts = entry.name.rsplit(".tmp.", 1)
+            if len(parts) != 2:
+                continue
+            tail = parts[1].split(".")
+            if 1 <= len(tail) <= 2 and all(s.isdigit() for s in tail):
+                try:
+                    entry.unlink()
+                except OSError:
+                    pass
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get(self, key: str, *, ttl_seconds: int) -> Optional[Any]:
+        """Return cached value if fresh; else ``None``."""
+        if not self._writable or self._root is None:
+            self.misses += 1
+            return None
+        path = self._path_for(key)
+        if not path.exists():
+            self.misses += 1
+            return None
+        try:
+            envelope = self._read_envelope(path)
+        except (OSError, ValueError, KeyError) as e:
+            logger.debug("core.json.cache: corrupt entry %s: %s", path, e)
+            self.misses += 1
+            return None
+        # Caller may downgrade TTL relative to what was stored. Honour
+        # the *minimum* TTL.
+        effective_ttl = ttl_seconds if ttl_seconds < envelope.ttl_seconds \
+            or envelope.ttl_seconds == TTL_FOREVER else envelope.ttl_seconds
+        envelope = CacheEnvelope(
+            written_at=envelope.written_at,
+            ttl_seconds=effective_ttl,
+            value=envelope.value,
+        )
+        if not envelope.is_fresh(time.time()):
+            self.misses += 1
+            return None
+        self.hits += 1
+        return envelope.value
+
+    def put(self, key: str, value: Any, *, ttl_seconds: int) -> None:
+        """Atomically write ``value`` under ``key``."""
+        if not self._writable or self._root is None:
+            return
+        path = self._path_for(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        envelope = CacheEnvelope(
+            written_at=time.time(),
+            ttl_seconds=ttl_seconds,
+            value=value,
+        )
+        # Tempfile suffix MUST include the thread id, not just pid:
+        # two threads in the same process writing the same key would
+        # otherwise share a tmp path, and ``open("w")`` truncates on
+        # open — clobbering each other's partial writes. With pid+tid
+        # each writer has its own tmpfile, and atomic rename serialises
+        # which one wins (last-writer-wins is the documented contract).
+        tmp = path.with_suffix(f".tmp.{os.getpid()}.{threading.get_ident()}")
+        try:
+            with tmp.open("w", encoding="utf-8") as fh:
+                json.dump({
+                    "written_at": envelope.written_at,
+                    "ttl_seconds": envelope.ttl_seconds,
+                    "value": envelope.value,
+                }, fh)
+            tmp.replace(path)
+        except (OSError, TypeError, ValueError) as e:
+            # OSError: disk full, permission denied, etc.
+            # TypeError/ValueError: caller passed a non-JSON-serialisable
+            # value (e.g. datetime). Clean up the partial temp file
+            # either way so we don't leak stragglers in the cache dir.
+            logger.warning("core.json.cache: failed to write %s: %s", path, e)
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    def invalidate(self, key: str) -> None:
+        """Remove an entry. Safe to call on missing keys."""
+        if not self._writable or self._root is None:
+            return
+        path = self._path_for(key)
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as e:
+            logger.debug("core.json.cache: failed to remove %s: %s", path, e)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _path_for(self, key: str) -> Path:
+        """Resolve a cache key to a filesystem path.
+
+        Keys are caller-chosen and may contain ``/`` to denote a
+        subdirectory (e.g., ``vulns/GHSA-xxx``). They MUST NOT contain
+        ``..`` or absolute paths; we sanitise defensively to keep
+        adversarial input from escaping the cache root.
+        """
+        if self._root is None:
+            raise RuntimeError("cache root not initialised")
+        clean_parts = []
+        for part in key.split("/"):
+            if not part or part in (".", ".."):
+                continue
+            # Strip path separators that may have leaked in.
+            clean_parts.append(part.replace(os.sep, "_"))
+        if not clean_parts:
+            raise ValueError(f"empty cache key after sanitisation: {key!r}")
+        # Append the suffix directly rather than ``Path.with_suffix``:
+        # the last component is typically a version string like
+        # ``4.17.4``, and ``with_suffix(".json")`` would replace the
+        # existing ``.4`` token, collapsing every multi-segment version
+        # for the same package onto the same cache file.
+        final_name = clean_parts[-1] + ".json"
+        return self._root.joinpath(*clean_parts[:-1], final_name)
+
+    @staticmethod
+    def _read_envelope(path: Path) -> CacheEnvelope:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if not isinstance(data, dict):
+            raise ValueError("cache entry is not an object")
+        return CacheEnvelope(
+            written_at=float(data["written_at"]),
+            ttl_seconds=int(data["ttl_seconds"]),
+            value=data["value"],
+        )
+
+
+__all__ = ["JsonCache", "TTL_FOREVER", "CacheEnvelope"]

--- a/core/json/tests/test_cache.py
+++ b/core/json/tests/test_cache.py
@@ -1,0 +1,217 @@
+"""Tests for ``core.json.cache.JsonCache``.
+
+Adapted from the original ``packages/sca/tests/test_cache.py`` written
+for the SCA-specific cache module — same coverage, retargeted to the
+generic ``core.json.cache`` location.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# core/json/tests/test_cache.py -> repo root
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from core.json import TTL_FOREVER, JsonCache
+
+
+def test_put_and_get_roundtrip(tmp_path: Path) -> None:
+    cache = JsonCache(root=tmp_path)
+    cache.put("k", {"v": 1}, ttl_seconds=60)
+    assert cache.get("k", ttl_seconds=60) == {"v": 1}
+
+
+def test_get_returns_none_for_missing_key(tmp_path: Path) -> None:
+    cache = JsonCache(root=tmp_path)
+    assert cache.get("nope", ttl_seconds=60) is None
+
+
+def test_expired_entry_returns_none(tmp_path: Path) -> None:
+    cache = JsonCache(root=tmp_path)
+    cache.put("k", "v", ttl_seconds=1)
+    # Force expiry by rewriting the envelope with an old timestamp.
+    p = tmp_path / "k.json"
+    raw = json.loads(p.read_text())
+    raw["written_at"] = time.time() - 10_000
+    p.write_text(json.dumps(raw))
+    assert cache.get("k", ttl_seconds=1) is None
+
+
+def test_caller_can_downgrade_ttl(tmp_path: Path) -> None:
+    """A fresh entry with TTL=86400 is stale under TTL=1."""
+    cache = JsonCache(root=tmp_path)
+    cache.put("k", "v", ttl_seconds=86400)
+    p = tmp_path / "k.json"
+    raw = json.loads(p.read_text())
+    raw["written_at"] = time.time() - 60   # 1 min old
+    p.write_text(json.dumps(raw))
+    assert cache.get("k", ttl_seconds=10) is None
+    assert cache.get("k", ttl_seconds=300) == "v"
+
+
+def test_ttl_forever_is_never_stale(tmp_path: Path) -> None:
+    cache = JsonCache(root=tmp_path)
+    cache.put("k", "v", ttl_seconds=TTL_FOREVER)
+    p = tmp_path / "k.json"
+    raw = json.loads(p.read_text())
+    raw["written_at"] = 0   # epoch
+    p.write_text(json.dumps(raw))
+    assert cache.get("k", ttl_seconds=TTL_FOREVER) == "v"
+
+
+def test_corrupt_json_treated_as_miss(tmp_path: Path) -> None:
+    cache = JsonCache(root=tmp_path)
+    (tmp_path / "k.json").write_text("not json")
+    assert cache.get("k", ttl_seconds=60) is None
+
+
+def test_truncated_envelope_treated_as_miss(tmp_path: Path) -> None:
+    cache = JsonCache(root=tmp_path)
+    (tmp_path / "k.json").write_text('{"value": "x"}')   # missing ttl
+    assert cache.get("k", ttl_seconds=60) is None
+
+
+def test_subdirectory_keys(tmp_path: Path) -> None:
+    cache = JsonCache(root=tmp_path)
+    cache.put("vulns/GHSA-xxx", {"id": "GHSA-xxx"}, ttl_seconds=60)
+    assert (tmp_path / "vulns" / "GHSA-xxx.json").exists()
+    assert cache.get("vulns/GHSA-xxx", ttl_seconds=60) == {"id": "GHSA-xxx"}
+
+
+def test_path_traversal_in_key_is_blocked(tmp_path: Path) -> None:
+    cache = JsonCache(root=tmp_path)
+    cache.put("../escape", "should-not-escape", ttl_seconds=60)
+    # Either the file lives inside the cache root, or the put silently
+    # discarded the segment; either way, no escape.
+    assert not (tmp_path.parent / "escape.json").exists()
+    assert (tmp_path / "escape.json").exists()
+
+
+def test_empty_key_after_sanitisation_raises(tmp_path: Path) -> None:
+    cache = JsonCache(root=tmp_path)
+    with pytest.raises(ValueError):
+        cache.put("../..", "x", ttl_seconds=60)
+
+
+def test_invalidate_removes_entry(tmp_path: Path) -> None:
+    cache = JsonCache(root=tmp_path)
+    cache.put("k", "v", ttl_seconds=60)
+    cache.invalidate("k")
+    assert cache.get("k", ttl_seconds=60) is None
+
+
+def test_unwritable_root_falls_back_to_no_op(tmp_path: Path) -> None:
+    """If the root can't be created, cache becomes a no-op (warns once)."""
+    bad = tmp_path / "not-a-dir"
+    bad.write_text("file blocking dir creation")
+    cache = JsonCache(root=bad)
+    cache.put("k", "v", ttl_seconds=60)        # silently no-ops
+    assert cache.get("k", ttl_seconds=60) is None
+
+
+def test_atomic_write_does_not_leave_temp_files(tmp_path: Path) -> None:
+    cache = JsonCache(root=tmp_path)
+    cache.put("k", "v", ttl_seconds=60)
+    leftovers = [p for p in tmp_path.iterdir() if ".tmp." in p.name]
+    assert leftovers == []
+
+
+def test_keys_with_dotted_segments_do_not_collide(tmp_path: Path) -> None:
+    """Regression: ``4.17.4`` and ``4.17.21`` used to collide on
+    ``4.17.json`` because ``Path.with_suffix(".json")`` treated the
+    trailing ``.4`` / ``.21`` as the existing suffix and replaced it."""
+    cache = JsonCache(root=tmp_path)
+    cache.put("queries/npm/lodash/4.17.4", ["v1"], ttl_seconds=60)
+    cache.put("queries/npm/lodash/4.17.21", ["v2"], ttl_seconds=60)
+    assert cache.get("queries/npm/lodash/4.17.4", ttl_seconds=60) == ["v1"]
+    assert cache.get("queries/npm/lodash/4.17.21", ttl_seconds=60) == ["v2"]
+    # Both files exist under the same parent.
+    parent = tmp_path / "queries" / "npm" / "lodash"
+    names = sorted(p.name for p in parent.iterdir())
+    assert names == ["4.17.21.json", "4.17.4.json"]
+
+
+def test_key_without_dots_still_lands_with_json_suffix(tmp_path: Path) -> None:
+    cache = JsonCache(root=tmp_path)
+    cache.put("vulns/GHSA-test", {"id": "x"}, ttl_seconds=60)
+    assert (tmp_path / "vulns" / "GHSA-test.json").exists()
+
+
+def test_orphan_tempfiles_are_reaped_at_construction(tmp_path: Path) -> None:
+    """A stale tempfile left by a crashed writer must be cleaned up
+    the next time a JsonCache is constructed against the same root,
+    so the dir doesn't accumulate orphans across runs. Both the
+    legacy single-pid format and the current pid.tid format are
+    recognised.
+    """
+    # Legacy ``.tmp.<pid>`` shape (orphans from earlier code on disk).
+    (tmp_path / "k.tmp.99999").write_text('{"partial": true}')
+    (tmp_path / "vulns").mkdir()
+    (tmp_path / "vulns" / "GHSA-xxx.tmp.12345").write_text('{"x": 1}')
+    # Current ``.tmp.<pid>.<tid>`` shape (what put() writes now).
+    (tmp_path / "current.tmp.12345.67890").write_text('{"partial": true}')
+    # Also a file with a similar but non-matching suffix — must NOT be reaped.
+    decoy = tmp_path / "config.tmp.json"
+    decoy.write_text("user data")
+
+    JsonCache(root=tmp_path)   # construction triggers the sweep
+
+    assert not (tmp_path / "k.tmp.99999").exists()
+    assert not (tmp_path / "vulns" / "GHSA-xxx.tmp.12345").exists()
+    assert not (tmp_path / "current.tmp.12345.67890").exists()
+    assert decoy.exists(), "must not reap files whose suffix isn't .tmp.<digits>[.<digits>]"
+
+
+def test_concurrent_threads_same_key_no_torn_writes(tmp_path: Path) -> None:
+    """REGRESSION: two threads in the same process writing the same key
+    must not share a tempfile path. Earlier code used ``.tmp.<pid>``
+    only — both threads would ``open("w")`` the same path, the second
+    open truncating the first's partial write. Result: a torn file
+    that fails JSON parsing on next read.
+
+    With pid+tid in the suffix, each writer has its own tmpfile; the
+    final atomic rename is last-writer-wins, but both writers complete
+    a whole file independently.
+    """
+    import threading as _threading
+
+    cache = JsonCache(root=tmp_path)
+    barrier = _threading.Barrier(8)
+
+    def writer(i: int) -> None:
+        barrier.wait()
+        for _ in range(50):
+            cache.put("hot-key", {"writer": i, "n": _}, ttl_seconds=60)
+
+    threads = [_threading.Thread(target=writer, args=(i,))
+               for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Whatever the final winner is, the read MUST succeed (no torn
+    # file) and produce a value from one of the writers.
+    got = cache.get("hot-key", ttl_seconds=60)
+    assert got is not None, "concurrent writers produced an unparseable file"
+    assert "writer" in got and 0 <= got["writer"] < 8
+
+
+def test_non_json_serialisable_value_does_not_leak_tempfile(tmp_path: Path) -> None:
+    """If a caller passes a non-JSON-serialisable value, the put silently
+    no-ops AND cleans up its partial tempfile — no .tmp.<pid> leftovers."""
+    import datetime
+    cache = JsonCache(root=tmp_path)
+    # datetime is not JSON-serialisable by default; json.dump will raise
+    # TypeError. Older versions of this code only caught OSError, leaking
+    # the partial tempfile.
+    cache.put("k", datetime.datetime.now(), ttl_seconds=60)
+    leftovers = sorted(p.name for p in tmp_path.rglob("*") if p.is_file())
+    assert leftovers == [], f"tempfile leak: {leftovers}"
+    # And the cache returns None on subsequent get (write was rejected).
+    assert cache.get("k", ttl_seconds=60) is None

--- a/core/json/tests/test_utils.py
+++ b/core/json/tests/test_utils.py
@@ -121,6 +121,45 @@ class TestSaveJson(unittest.TestCase):
             self.assertIn("\n", text)
             self.assertIn("  ", text)
 
+    def test_concurrent_threads_same_path_no_torn_writes(self):
+        """REGRESSION: two threads in the same process saving the same
+        path must not share a tempfile path. Earlier code used a
+        deterministic ``.~<name>.tmp`` suffix; both threads opened the
+        same path with O_TRUNC, the second clobbering the first's
+        partial write and leaving a torn file that fails json.loads.
+
+        With pid+tid in the suffix, each writer has its own tmpfile;
+        the final atomic rename is last-writer-wins, but every reader
+        sees a fully-formed file.
+        """
+        import threading as _threading
+
+        with TemporaryDirectory() as d:
+            p = Path(d) / "hot.json"
+            barrier = _threading.Barrier(8)
+            errors: list[BaseException] = []
+
+            def writer(i: int) -> None:
+                try:
+                    barrier.wait()
+                    for n in range(50):
+                        save_json(p, {"writer": i, "n": n})
+                except BaseException as e:
+                    errors.append(e)
+
+            threads = [_threading.Thread(target=writer, args=(i,))
+                       for i in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            self.assertEqual(errors, [], f"writer raised: {errors}")
+            # Whatever the final winner is, the file MUST parse cleanly.
+            data = json.loads(p.read_text())
+            self.assertIn("writer", data)
+            self.assertIn(data["writer"], range(8))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/core/json/utils.py
+++ b/core/json/utils.py
@@ -8,6 +8,7 @@ serialization of Path/datetime objects.
 import json
 import os
 import re
+import threading
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional, Union
@@ -86,8 +87,14 @@ def save_json(path: Union[str, Path], data: Any, mode: int = None) -> None:
     content = json.dumps(data, indent=2, cls=_RaptorEncoder) + "\n"
 
     # Write to temp file then rename — atomic on POSIX (same filesystem).
-    # .~ prefix makes stale temps visually obvious and excluded by get_run_dirs.
-    tmp = p.with_name(f".~{p.name}.tmp")
+    # .~ prefix makes stale temps visually obvious and excluded by
+    # get_run_dirs. The pid+tid suffix is what makes concurrent writers
+    # safe: two threads (or two processes) writing the same target path
+    # would otherwise share a tempfile path, and the second open with
+    # O_TRUNC would clobber the first's partial write — leaving a torn
+    # file that fails to parse on the next read. With pid+tid each
+    # writer has its own tempfile; the final rename is last-writer-wins.
+    tmp = p.with_name(f".~{p.name}.tmp.{os.getpid()}.{threading.get_ident()}")
     try:
         if mode is not None:
             # Create temp file with explicit permissions — no race window

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,11 @@
 
 # Core dependencies
 requests>=2.31.0
+# core.http.urllib_backend uses urllib3 directly for connection pooling
+# and to avoid the no_proxy bypass that stdlib urllib.request.ProxyHandler
+# silently performs. Already a transitive dep of `requests` but pinned
+# here too because we depend on it directly.
+urllib3>=2.0,<3.0
 pydantic>=2.9.2
 
 # Structured output (works with both OpenAI and Anthropic SDKs)


### PR DESCRIPTION
Adds core/http/ (HttpClient Protocol with UrllibClient + EgressClient backends) and core/json/cache.py (TTL'd JSON disk cache). EgressClient routes through core.sandbox.proxy with hostname allowlist enforcement, closing the exfil-to-attacker-host hole that direct urlopen leaves open.

urllib3-backed for connection pooling and to avoid the no_proxy bypass stdlib's ProxyHandler silently performs. Bounded backoff with wall- clock deadline; URL scheme + userinfo validation; size caps; conditional requests via NotModified; pid+tid tempfile suffixes for safe concurrent cache writers.

Validated against a 17-scenario adversarial stress harness and a real- network E2E through the full chokepoint chain.