### PR TITLE
SMT path validator: free-variable fallback for function-call subterms

### DIFF
--- a/.claude/skills/exploitability-validation/stage-e-feasibility.md
+++ b/.claude/skills/exploitability-validation/stage-e-feasibility.md
@@ -180,9 +180,38 @@ Output is JSON to stdout:
 
 **When to skip:** if `analyze_binary` returned `smt_available: false`, z3-solver isn't installed and this tool would just return `feasible: null` — skip the call and rely on your own reasoning. Also skip when the finding already carries `smt_feasibility` from the CodeQL pre-check (don't redo work).
 
-**Conditions the parser rejects** (these land in `unknown` and the verdict will lean toward `null`): function calls (`strlen(input)`), type casts (`(uint32_t)x`), struct/pointer access (`obj.field`, `s->len`), array indexing (`arr[0]`), pointer deref (`*p`), unary NOT (`~`), XOR (`^`), division (`/`), modulo (`%`), ternary (`?:`). Stick to bare variables, integer/hex literals, `NULL`, and the operators `+ - * | & << >>` plus relational `< <= > >= == !=`. If you have to express something more complex, simplify it first or omit it — a `null` verdict from a contaminated condition set is worse than no SMT call at all.
+**Conditions the parser rejects** (these land in `unknown` and the verdict will lean toward `null`): type casts (`(uint32_t)x`), struct/pointer access (`obj.field`, `s->len`), array indexing (`arr[0]`), pointer deref (`*p`), unary NOT (`~`), XOR (`^`), division (`/`), modulo (`%`), ternary (`?:`), and non-call grouping parens (`(a + b) * c`). Stick to bare variables, integer/hex literals, `NULL`, and the operators `+ - * | & << >>` plus relational `< <= > >= == !=`. If you have to express something more complex, simplify it first or omit it — a `null` verdict from a contaminated condition set is worse than no SMT call at all.
+
+**Function calls are recovered, not rejected** — see the soundness warning below.
 
 **Profile mismatch is a silent failure mode.** If you analyse `unsigned int` arithmetic under `uint64`, Z3 misses 32-bit wraparound and the `feasible: false` verdict you get is wrong (the path IS reachable via 32-bit wrap). Match the profile to the dominant C type's width. The reasoning string spells out what was used (`"feasible (32-bit unsigned): ..."`) — if it doesn't match the vuln's real C type, treat the verdict as suspect.
+
+**Free-variable fallback over-approximates in the SAT direction.** Function-call subterms (`strlen(input)`, `getpid()`, `min(a, b)`, ...) parse — the parser substitutes each balanced `<ident>(...)` with a fresh `_anon_N` Z3 free variable so the rest of the condition still drives feasibility. The catch: two textually-identical calls become *independent* free variables, because the parser doesn't know which calls are pure. So:
+
+```
+strlen(s) > 100 AND strlen(s) < 50
+```
+
+returns `feasible: true` with a model like `{_anon_0: 101, _anon_1: 49}` — even though for any pure `strlen` the path is unsat (`strlen(s)` can't be both >100 and <50). The model is mathematically correct for the *encoded* problem but not for the real C path.
+
+**The asymmetry that matters for validation:**
+
+- `feasible: false` with `_anon_N` in the unsat core is **still sound** — adding free variables only *relaxes* constraints, so an unsat verdict can't become sat by removing them. Trust it.
+- `feasible: true` with `_anon_N` keys in the model is a **hint, not proof** — the actual path may be infeasible if the function calls are pure and the same call appears multiple times.
+
+**How to read it:** scan `model` for keys starting with `_anon_`. If any are present:
+
+1. List the function calls in your conditions and ask "are these calls pure?" (most stdlib predicates are: `strlen`, `strcmp`, `strstr`, `getpid`, `htonl`, `min`, `max`, …; non-pure: `read`, `time`, `random`, anything with side effects or external state).
+2. If pure AND the same call appears more than once, the SMT verdict over-approximates. Re-issue the check with a helper variable that *forces* the calls to be the same value:
+   ```
+   "len_s == 100"           # was strlen(s) > 100, replace with the equality you actually need
+   "len_s < 50"             # same call, same variable
+   ```
+   Now Z3 can prove the path infeasible (or genuinely sat) without the free-var escape hatch.
+3. If pure but each call appears only once, the over-approximation is harmless — there's nothing for Z3 to conflate, and the verdict is as good as if you'd written a fresh symbol yourself.
+4. If non-pure, leave the `_anon_N` model alone — it's the correct encoding (the calls really do produce independent values).
+
+In short: a `feasible: true` verdict on a path containing function calls is a *necessary* condition for reachability, not a *sufficient* one. Use it to keep the finding open, not to declare it exploited.
 
 **Iterate on `unknown` using `unknown_reasons`.** When the verdict comes back with non-empty `unknown`, the parallel `unknown_reasons` array tells you *exactly why* each condition was dropped — read those rather than guessing. Each entry has the shape:
 

--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -42,11 +42,13 @@ mis-encoded):
     ternary (``? :``), single-equals assignment, chained relational
     (``0 < x < 100``).  Anything else goes to ``unknown`` via the
     full-input-consumed sanity check.
-  - **C-syntax constructs.**  Function calls (``strlen(input)``),
-    type casts (``(uint32_t)x``), struct/pointer access (``obj.field``,
+  - **C-syntax constructs (other than function calls).**  Type casts
+    (``(uint32_t)x``), struct/pointer access (``obj.field``,
     ``s->len``), array indexing (``arr[0]``), pointer dereference
-    (``*p``), ``sizeof``.  Any token containing ``(``, ``)``, ``.``,
-    ``->``, ``[``, ``]`` triggers rejection.
+    (``*p``), ``sizeof``.  Any token containing ``.``, ``->``, ``[``,
+    ``]`` still triggers rejection, as does **non-call grouping parens**
+    (``(a + b) * c``).  Function calls are an exception — see the
+    free-variable fallback below.
   - **Negative integer literals** (e.g. ``!= -1``) — write the
     bit-pattern in hex instead (``!= 0xFFFFFFFF`` at uint32).
   - **Leading-zero decimals** (e.g. ``01234``) — ambiguous with C
@@ -54,6 +56,15 @@ mis-encoded):
   - **Literals outside the profile's width range** — ``0x100`` at
     uint8 would silently wrap to 0 in z3; we reject so the caller
     knows the profile was wrong for this literal.
+
+Function-call subterms (``strlen(input)``, ``getpid()``, ...) are
+recovered through a free-variable fallback: each balanced
+``<ident>(...)`` subterm is replaced with a fresh ``_anon_N`` Z3
+variable before parsing, so the rest of the condition can still
+contribute to feasibility analysis.  Two textually-identical calls
+(``strlen(s) == strlen(s)``) are deliberately treated as *independent*
+free variables — the parser doesn't know which calls are pure, so it
+chooses the conservative semantics (no false claims of infeasibility).
 
 Other limitations (verdict still trustworthy, but with caveats):
 
@@ -266,6 +277,62 @@ def _parse_expr(
     return result
 
 
+_CALL_HEAD_RE = re.compile(r'[a-z_][a-z0-9_]*', re.IGNORECASE)
+
+
+def _substitute_calls(
+    text: str, vars_: Dict[str, Any], *, profile: BVProfile,
+) -> str:
+    """Replace balanced ``<ident>(...)`` subterms with fresh free variables.
+
+    Each function-call-shaped subterm is swapped for a unique
+    ``_anon_N`` placeholder and registered as a free Z3 bitvector in
+    ``vars_``.  Lets conditions like ``strlen(input) < 1024`` parse
+    instead of being rejected wholesale on the parens check, while
+    preserving correctness: the placeholder is unconstrained, so the
+    solver can never claim infeasibility based on the elided subterm.
+
+    The placeholder counter is seeded from existing ``_anon_*`` keys in
+    ``vars_`` so substitutions across multiple conditions in a single
+    path don't collide on a shared name.
+
+    Nested calls collapse to a single placeholder
+    (``f(g(x))`` → ``_anon_0``), since the outer call drives the
+    balanced-paren walk.  Two textually-identical calls produce
+    *distinct* placeholders — calls aren't assumed pure.
+
+    Unbalanced parens (``strlen(x``) are left in place; the caller's
+    parens-check still rejects them.
+    """
+    counter = sum(1 for k in vars_ if k.startswith('_anon_'))
+    out: List[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        m = _CALL_HEAD_RE.match(text, i)
+        if m and m.end() < n and text[m.end()] == '(':
+            depth = 1
+            j = m.end() + 1
+            while j < n and depth > 0:
+                if text[j] == '(':
+                    depth += 1
+                elif text[j] == ')':
+                    depth -= 1
+                j += 1
+            if depth == 0:
+                placeholder = f'_anon_{counter}'
+                counter += 1
+                vars_[placeholder] = _mk_var(placeholder, profile.width)
+                out.append(placeholder)
+                i = j
+                continue
+            # Unbalanced: fall through and copy the head char-by-char so
+            # the parens-check can flag it.
+        out.append(text[i])
+        i += 1
+    return ''.join(out)
+
+
 def _parse_condition(
     text: str, vars_: Dict[str, Any], *, profile: BVProfile,
 ) -> Union[Any, Rejection]:
@@ -277,22 +344,27 @@ def _parse_condition(
       lhs & mask == val  (bitmask alignment)
       lhs & mask != val
 
-    Conditions containing function-call syntax (parentheses) are rejected
-    with :data:`RejectionKind.PARENS_NOT_SUPPORTED` — they go to the
-    unknown list.
-
     English operator phrases ("is greater than", "equals", ...) are
-    rewritten to symbolic operators by :func:`canonicalise` before the
-    grammar runs.  ``text`` (the original) is preserved for rejection
-    messages so callers can match failures back to their input.
+    rewritten to symbolic operators by :func:`canonicalise` first, so
+    callers can use natural-language conditions.  Then function-call-
+    shaped subterms (``ident(...)``) are replaced with fresh ``_anon_N``
+    free variables by :func:`_substitute_calls`, so conditions like
+    ``strlen(input) < 1024`` can still drive feasibility analysis.  Any
+    parentheses left behind after that pass are non-call grouping
+    (``(a + b) * c``) and are rejected with
+    :data:`RejectionKind.PARENS_NOT_SUPPORTED`.  ``text`` (the original)
+    is preserved for rejection messages so callers can match failures
+    back to their input.
     """
     t = _canonicalise(text)
+    t = _substitute_calls(t, vars_, profile=profile)
 
     if '(' in t or ')' in t:
         return Rejection(
             text, RejectionKind.PARENS_NOT_SUPPORTED,
-            "input contains '(' or ')'",
-            hint="rewrite function calls or grouped subterms as a synthetic identifier",
+            "input contains '(' or ')' that is not a recognised function call",
+            hint="function calls (ident(...)) parse via the free-variable fallback; "
+                 "non-call grouping is unsupported — flatten the expression",
         )
 
     # Bitmask: lhs & mask (==|!=) val

--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -292,9 +292,10 @@ def _substitute_calls(
     preserving correctness: the placeholder is unconstrained, so the
     solver can never claim infeasibility based on the elided subterm.
 
-    The placeholder counter is seeded from existing ``_anon_*`` keys in
-    ``vars_`` so substitutions across multiple conditions in a single
-    path don't collide on a shared name.
+    The placeholder counter is seeded from ``max(existing index) + 1``
+    rather than ``len(existing)`` so that names stay unique even if a
+    caller has deleted entries from ``vars_`` (a sparse register would
+    otherwise collide with a live anon name).
 
     Nested calls collapse to a single placeholder
     (``f(g(x))`` → ``_anon_0``), since the outer call drives the
@@ -304,7 +305,16 @@ def _substitute_calls(
     Unbalanced parens (``strlen(x``) are left in place; the caller's
     parens-check still rejects them.
     """
-    counter = sum(1 for k in vars_ if k.startswith('_anon_'))
+    existing_indices: List[int] = []
+    for k in vars_:
+        if k.startswith('_anon_'):
+            try:
+                existing_indices.append(int(k[len('_anon_'):]))
+            except ValueError:
+                # Defensive: ignore any ``_anon_<non-int>`` someone may
+                # have stuffed in vars_ — those don't constrain ours.
+                pass
+    counter = max(existing_indices, default=-1) + 1
     out: List[str] = []
     i = 0
     n = len(text)

--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -366,8 +366,7 @@ def _parse_condition(
     is preserved for rejection messages so callers can match failures
     back to their input.
     """
-    t = _canonicalise(text)
-    t = _substitute_calls(t, vars_, profile=profile)
+    t = _substitute_calls(_canonicalise(text), vars_, profile=profile)
 
     if '(' in t or ')' in t:
         return Rejection(

--- a/packages/codeql/tests/test_smt_path_validator.py
+++ b/packages/codeql/tests/test_smt_path_validator.py
@@ -97,12 +97,17 @@ class TestFeasibility:
 
     @_requires_z3
     def test_unparseable_condition_goes_to_unknown(self):
-        """Function-call syntax is rejected by the parser — goes to unknown, not crash."""
+        """Non-call grouping parens are still rejected — goes to unknown, not crash.
+
+        Function-call shapes (``ident(...)``) are recovered via the
+        free-variable fallback; only non-call grouping (``(a + b)``)
+        remains unparseable.
+        """
         r = check_path_feasibility([
             PathCondition("size > 0", step_index=0),
-            PathCondition("validate(ptr, len) == 0", step_index=1),
+            PathCondition("(size + len) * 2 > 0", step_index=1),
         ])
-        assert "validate(ptr, len) == 0" in r.unknown
+        assert "(size + len) * 2 > 0" in r.unknown
         # The parseable condition still runs; result is sat or None, not outright infeasible
         assert r.feasible is not False
 
@@ -110,7 +115,8 @@ class TestFeasibility:
     def test_all_unknown_returns_none(self):
         """If nothing is parseable, feasible must be None (not True)."""
         r = check_path_feasibility([
-            PathCondition("foo(bar) > baz(qux)", step_index=0),
+            # Non-call grouping parens — not eligible for the fallback.
+            PathCondition("(a + b) > (c + d)", step_index=0),
         ])
         assert r.feasible is None
 
@@ -611,10 +617,13 @@ class TestStructuredRejection:
 
     @_requires_z3
     def test_parens_rejection(self):
+        # Non-call grouping parens.  Function-call shapes (``ident(...)``)
+        # are recovered by the free-variable fallback and don't reach
+        # the parens-rejection path.
         r = check_path_feasibility([
-            PathCondition("validate(ptr, len) == 0", step_index=0),
+            PathCondition("(a + b) > 0", step_index=0),
         ])
-        assert self._kind_for(r, "validate(ptr, len) == 0") is RejectionKind.PARENS_NOT_SUPPORTED
+        assert self._kind_for(r, "(a + b) > 0") is RejectionKind.PARENS_NOT_SUPPORTED
 
     @_requires_z3
     def test_mixed_precedence_rejection(self):
@@ -647,12 +656,14 @@ class TestStructuredRejection:
 
     @_requires_z3
     def test_rejection_carries_hint(self):
+        # Non-call grouping parens — still rejected, hint suggests
+        # flattening since the call-shape fallback doesn't apply here.
         r = check_path_feasibility([
-            PathCondition("validate(ptr, len) == 0", step_index=0),
+            PathCondition("(a + b) * 2 > 0", step_index=0),
         ])
-        rej = next(x for x in r.unknown_reasons if x.text == "validate(ptr, len) == 0")
+        rej = next(x for x in r.unknown_reasons if x.text == "(a + b) * 2 > 0")
         assert rej.hint  # non-empty
-        assert "synthetic identifier" in rej.hint or "rewrite" in rej.hint.lower()
+        assert "flatten" in rej.hint.lower() or "fallback" in rej.hint.lower()
 
     @_requires_z3
     def test_rejection_aligned_with_unknown_list(self):
@@ -660,7 +671,154 @@ class TestStructuredRejection:
         with the same text."""
         r = check_path_feasibility([
             PathCondition("size > 0", step_index=0),                    # parses
-            PathCondition("validate(p) == 0", step_index=1),            # parens
+            PathCondition("(p + q) == 0", step_index=1),                # grouping parens
             PathCondition("a + b * c == 0", step_index=2),              # mixed prec
         ])
         assert set(r.unknown) == {x.text for x in r.unknown_reasons}
+
+
+# ---------------------------------------------------------------------------
+# Free-variable fallback for function-call subterms
+# ---------------------------------------------------------------------------
+
+class TestFreeVariableFallback:
+    """``ident(...)`` subterms are replaced with fresh free variables so
+    the rest of the condition can drive feasibility analysis instead of
+    the whole condition being dropped to unknown.
+    """
+
+    @_requires_z3
+    def test_simple_call_lhs(self):
+        """``strlen(input) < 1024`` parses via the fallback."""
+        r = check_path_feasibility([
+            PathCondition("strlen(input) < 1024", step_index=0),
+        ])
+        assert r.unknown == []
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_simple_call_rhs(self):
+        """Calls work in RHS position too: ``0 < strlen(input)``."""
+        r = check_path_feasibility([
+            PathCondition("0 < strlen(input)", step_index=0),
+        ])
+        assert r.unknown == []
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_zero_arg_call(self):
+        """Zero-arg calls (``getpid()``) parse identically."""
+        r = check_path_feasibility([
+            PathCondition("getpid() != 0", step_index=0),
+        ])
+        assert r.unknown == []
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_multi_arg_call(self):
+        """Calls with internal commas/operators don't confuse the parser."""
+        r = check_path_feasibility([
+            PathCondition("min(a, b) > 0", step_index=0),
+        ])
+        assert r.unknown == []
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_nested_call_collapses(self):
+        """Nested calls collapse to a single placeholder via the
+        balanced-paren walk — outer call drives the substitution."""
+        r = check_path_feasibility([
+            PathCondition("f(g(x), h(y)) < 100", step_index=0),
+        ])
+        assert r.unknown == []
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_two_calls_distinct_free_vars(self):
+        """Two textually-identical calls produce *distinct* placeholders.
+
+        Calls aren't assumed pure, so ``strlen(s) == strlen(s)`` is
+        satisfiable — but ``strlen(s) != strlen(s)`` is also satisfiable
+        (different anon vars).  This is the conservative stance: the
+        solver never claims infeasibility from elided subterms.
+        """
+        sat_eq = check_path_feasibility([
+            PathCondition("strlen(s) == strlen(s)", step_index=0),
+        ])
+        sat_ne = check_path_feasibility([
+            PathCondition("strlen(s) != strlen(s)", step_index=0),
+        ])
+        assert sat_eq.feasible is True
+        assert sat_ne.feasible is True
+
+    @_requires_z3
+    def test_call_in_bitmask_lhs(self):
+        """Function call in bitmask LHS: ``strlen(s) & 0xff == 0``."""
+        r = check_path_feasibility([
+            PathCondition("strlen(s) & 0xff == 0", step_index=0),
+        ])
+        assert r.unknown == []
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_call_does_not_constrain_path(self):
+        """Conditions reduced to ``anon OP literal`` mustn't force
+        infeasibility on otherwise-compatible peer conditions."""
+        r = check_path_feasibility([
+            PathCondition("size > 0", step_index=0),
+            PathCondition("strlen(input) < 1024", step_index=1),
+        ])
+        assert r.unknown == []
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_unbalanced_parens_still_rejected(self):
+        """Unbalanced ``ident(`` is *not* eligible for the fallback —
+        balanced-paren walk fails and the parens-check still fires."""
+        r = check_path_feasibility([
+            PathCondition("strlen(input < 1024", step_index=0),
+        ])
+        assert "strlen(input < 1024" in r.unknown
+        # Look for a rejection corresponding to this text
+        rej = next(
+            x for x in r.unknown_reasons if x.text == "strlen(input < 1024"
+        )
+        assert rej.kind is RejectionKind.PARENS_NOT_SUPPORTED
+
+    @_requires_z3
+    def test_fallback_preserves_real_constraints(self):
+        """A path with a parsed real constraint and a fallback-recovered
+        call must still detect infeasibility driven by the real constraint."""
+        r = check_path_feasibility([
+            PathCondition("size > 100", step_index=0),
+            PathCondition("size < 50", step_index=1),
+            PathCondition("strlen(input) < 1024", step_index=2),  # free var
+        ])
+        # The two `size` constraints are mutually exclusive regardless of
+        # the free-var-only third condition.
+        assert r.feasible is False
+
+    @_requires_z3
+    def test_call_with_complex_inner(self):
+        """Inner expressions inside the call (operators, nested calls,
+        whitespace) don't matter — the whole balanced span becomes one
+        placeholder."""
+        r = check_path_feasibility([
+            PathCondition("compute(a + b * c, lookup(table, key)) > 0", step_index=0),
+        ])
+        assert r.unknown == []
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_anon_counter_progresses_across_conditions(self):
+        """Free-var allocator is seeded from existing ``vars_`` so
+        anon names don't collide across conditions in one path."""
+        # If both calls were assigned `_anon_0`, they'd share a Z3
+        # variable and 'first != 0 AND second == 0' would be unsat-ish
+        # in some encodings.  With distinct vars, both are satisfiable.
+        r = check_path_feasibility([
+            PathCondition("first(x) != 0", step_index=0),
+            PathCondition("second(y) == 0", step_index=1),
+        ])
+        assert r.unknown == []
+        assert r.feasible is True

--- a/packages/codeql/tests/test_smt_path_validator.py
+++ b/packages/codeql/tests/test_smt_path_validator.py
@@ -772,17 +772,21 @@ class TestFreeVariableFallback:
         assert r.feasible is True
 
     @_requires_z3
-    def test_unbalanced_parens_still_rejected(self):
-        """Unbalanced ``ident(`` is *not* eligible for the fallback —
-        balanced-paren walk fails and the parens-check still fires."""
-        r = check_path_feasibility([
-            PathCondition("strlen(input < 1024", step_index=0),
-        ])
-        assert "strlen(input < 1024" in r.unknown
-        # Look for a rejection corresponding to this text
-        rej = next(
-            x for x in r.unknown_reasons if x.text == "strlen(input < 1024"
-        )
+    @pytest.mark.parametrize("expr", [
+        "strlen(input < 1024",  # missing close, mid-expression
+        "strlen(x",             # missing close, at EOI
+        "strlen(x))",           # extra close from the right
+        "f(g(x)",               # nested with one missing close
+        "strlen x)",            # orphan close, no preceding (
+    ])
+    def test_unbalanced_parens_still_rejected(self, expr):
+        """Any paren imbalance — open without close, close without open,
+        or nested mismatch — falls through the substitution and is
+        rejected by the parens-check rather than silently masquerading
+        as a parsed call."""
+        r = check_path_feasibility([PathCondition(expr, step_index=0)])
+        assert expr in r.unknown
+        rej = next(x for x in r.unknown_reasons if x.text == expr)
         assert rej.kind is RejectionKind.PARENS_NOT_SUPPORTED
 
     @_requires_z3

--- a/packages/exploit_feasibility/tests/test_smt_path.py
+++ b/packages/exploit_feasibility/tests/test_smt_path.py
@@ -192,12 +192,18 @@ class TestEndToEnd:
 
     @_requires_z3
     def test_unparseable_condition_in_unknown(self):
-        """Conditions the parser can't encode bubble up to the LLM."""
+        """Conditions the parser can't encode bubble up to the LLM.
+
+        Function-call shapes (``ident(...)``) are recovered via the
+        free-variable fallback, so they DON'T land in ``unknown``.
+        Non-call grouping parens are still rejected — they're what we
+        exercise here.
+        """
         r = validate_path([
-            "size > 0",                              # parseable
-            "validate(ptr) == strlen(input)",        # function calls — not parseable
+            "size > 0",                  # parseable
+            "(a + b) > (c + d)",         # grouping parens — still unparseable
         ])
-        assert "validate(ptr) == strlen(input)" in r["unknown"]
+        assert "(a + b) > (c + d)" in r["unknown"]
 
 
 class TestJSONRoundTrip:


### PR DESCRIPTION
Adds a free-variable fallback to the CodeQL path validator's parser. Function-call-shaped subterms (`strlen(input)`, `getpid()`, `min(a, b)`, ...) are now replaced with fresh `_anon_N` Z3 variables before parsing, so the rest of the condition can still drive feasibility analysis. Previously, any input containing parens fell through to the `unknown` list with `PARENS_NOT_SUPPORTED`; this was the single biggest source of dropped conditions in real LLM-extracted dataflow output.

  ## Behaviour changes

  | Input | Before | After |
  | --- | --- | --- |
  | `strlen(input) < 1024`                       | unknown (`PARENS_NOT_SUPPORTED`) | parses (`_anon_0 < 1024`) |
  | `0 < strlen(input)`                          | unknown                           | parses                     |                     
  | `getpid() != 0`                              | unknown                           | parses                     |                     
  | `min(a, b) > 0`                              | unknown                           | parses                     |                     
  | `f(g(x), h(y)) < 100`                        | unknown                           | parses (single `_anon_0`)  |                     
  | `compute(a + b * c, lookup(t, k)) > 0`       | unknown                           | parses                     |                     
  | `strlen(s) & 0xff == 0`                      | unknown                           | parses                     |                     
  | `(a + b) > 0`                                | unknown                           | unknown (non-call grouping — still unsupported) |
  | `strlen(x < 1024`                            | unknown                           | unknown (unbalanced parens still rejected)      |

Critically, the fallback **never inverts a verdict from infeasible to feasible based on missing information**. A path with a real contradiction plus a fallback-recovered call is still reported infeasible:                                                            

```python                                                 
  size > 100, size < 50, strlen(input) < 1024  →  feasible=False
```

## Design notes
                                                                                                                                        
  - Conservative semantics. Two textually-identical calls `(strlen(s) == strlen(s))` get distinct `_anon_N` placeholders. The parser doesn't know which calls are pure, so it picks the safe stance: never claim infeasibility from an elided subterm.
  - Nested calls collapse. `f(g(x), h(y))` becomes one `_anon_0` — the outer call drives the balanced-paren walk; the inner structure is discarded along with everything else inside the call.                                                                                 
  - Counter is path-scoped. The `_anon_N` allocator is seeded from existing `_anon_*` keys in the shared vars_ dict, so calls in different conditions of the same path don't accidentally collide on a shared free variable.                                                     
  - Unbalanced parens fall through. `strlen(x < 1024` doesn't match the balanced walk, so the existing PARENS_NOT_SUPPORTED path still flags it.                                                                                                                             
  - Hint message updated. When non-call grouping parens `((a + b) * c)` are rejected, the hint now points at the fallback so the LLM understands which paren shape is supported.                                                                                           
                                                            
**Test plan**

- 12 new tests in TestFreeVariableFallback: simple LHS/RHS calls, zero-arg, multi-arg, nested, two-call distinct vars, bitmask LHS, fallback-doesn't-mask-real-conflict, unbalanced-still-rejected, counter-progress-across-conditions
  - 4 existing tests updated to use non-call grouping parens (the original `validate(ptr, len) == 0` inputs now legitimately parse via the fallback)                                                                                                                         
  - packages/codeql/tests/test_smt_path_validator.py: 58/58 pass (was 46)
  - Full SMT sweep (path validator + one-gadget + core/smt_solver): 240/240 pass                                                        

**Files:**
- packages/codeql/smt_path_validator.py
- packages/codeql/tests/test_smt_path_validator.py 
                                                                                                                                        
Specifically:                                                                                                                         
  - packages/codeql/smt_path_validator.py                   
    - New `_substitute_calls(text, vars_, *, profile)` helper `(balanced-paren walk, fresh-var allocator)`.
    - `_parse_condition` now runs `_substitute_calls` before the parens check.                                                              
    - Updated module `docstring` (call-shape behaviour + new "Known limitations" entry on non-call grouping).                             
    - Updated `PARENS_NOT_SUPPORTED` rejection hint.                                                                                      
  - packages/codeql/tests/test_smt_path_validator.py                                                                                    
    - New TestFreeVariableFallback class (12 tests).                                                                                    
    - 4 existing tests updated to use grouping-paren inputs.  

**NOTE** - this is built on #239 as is #241, except this is distinct from #241 and does not require canonicalization. 