### PR TITLE
codeql: concurrent-safe DB cache + run-dir collision prevention

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -73,6 +73,17 @@ class RaptorConfig:
     # CodeQL Resource Configuration
     CODEQL_RAM_MB = 8192             # RAM for CodeQL analysis (8GB)
     CODEQL_THREADS = 0               # 0 = use all available CPUs
+
+    # CodeQL DB cache: grace period before _evict_stale_canonical evicts
+    # a canonical that has no metadata yet. The promote sequence has a
+    # gap between os.rename(staging, canonical) and save_metadata
+    # (covers _count_database_files + get_codeql_version subprocess +
+    # save_metadata atomic write). Grace period must exceed worst-case
+    # gap to avoid evicting in-flight writers' just-promoted canonicals.
+    # 60s is well above measured gap (~1s in normal conditions); orphan
+    # canonicals from crashed writers self-heal once their mtime
+    # crosses this threshold.
+    CODEQL_DB_MISSING_METADATA_GRACE = 60   # seconds
     CODEQL_MAX_PATHS = 4             # Max dataflow paths per query
     CODEQL_DB_CACHE_DAYS = 7         # Keep databases for 7 days
     CODEQL_DB_AUTO_CLEANUP = True    # Automatically cleanup old databases

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -9,6 +9,8 @@ import os
 import sys
 from pathlib import Path
 
+from core.run.output import unique_run_suffix
+
 from .project import ProjectManager
 
 
@@ -786,8 +788,8 @@ def _do_merge(project, merge_type, yes):
     groups = mergeable
 
     for cmd_type, dirs in groups.items():
-        timestamp = time.strftime("%Y%m%d-%H%M%S")
-        merged_dir = project.output_path / f"{cmd_type}-{timestamp}"
+        # Collision-prevention via unique_run_suffix — see core/run/output.py.
+        merged_dir = project.output_path / f"{cmd_type}-{unique_run_suffix('-')}"
 
         try:
             stats = merge_runs(dirs, merged_dir)

--- a/core/run/output.py
+++ b/core/run/output.py
@@ -20,6 +20,32 @@ class TargetMismatchError(ValueError):
     pass
 
 
+def unique_run_suffix(separator: str = "_") -> str:
+    """Sub-second-unique suffix for run-dir names: timestamp + PID,
+    joined by ``separator``. Use ``-`` for hyphen-style names (project
+    mode), ``_`` for underscore-style (standalone mode). Only ``-`` and
+    ``_`` are accepted to avoid strftime-directive injection (e.g., a
+    caller passing ``%H`` would get the format string interpreted).
+
+    Original failure mode: two RAPTOR processes starting in the same
+    wall-clock second computed identical run-dir names. Concrete
+    consequences depend on the caller — e.g., ``mkdir(exist_ok=True)``
+    silently shares the dir (interleaved writes), ``mkdir(exist_ok=False)``
+    raises, downstream code may overwrite per-run files. CI saw mtime
+    collisions and intermittent failures.
+
+    Two concurrent processes have different PIDs; PID reuse within the
+    same wall-clock second is essentially impossible on Linux. A single
+    process calling this multiple times within the same second would
+    reuse its PID — not a concern for the lifecycle entry-point use
+    case (one call per run start), but worth knowing.
+    """
+    if separator not in ("_", "-"):
+        raise ValueError(f"separator must be '_' or '-', got {separator!r}")
+    fmt = f"%Y%m%d{separator}%H%M%S"
+    return f"{time.strftime(fmt)}{separator}pid{os.getpid()}"
+
+
 def _resolve_active_project() -> Optional[Tuple[str, str, str]]:
     """Resolve the current active project from the .active symlink.
 
@@ -77,17 +103,18 @@ def get_output_dir(command: str, target_name: str = "", explicit_out: str = None
         if effective_target and project_target:
             _check_target_mismatch(effective_target, project_name, project_target)
 
-        # Project mode: command-YYYYMMDD-HHMMSS (hyphens throughout)
-        timestamp = time.strftime("%Y%m%d-%H%M%S")
-        return Path(project_dir) / f"{command}-{timestamp}"
+        # Project mode: command-YYYYMMDD-HHMMSS-pidNNNNN (hyphens throughout).
+        # See unique_run_suffix() for the collision-prevention rationale.
+        return Path(project_dir) / f"{command}-{unique_run_suffix('-')}"
 
-    # Standalone mode: command_target_timestamp (underscores, backwards
-    # compatible with existing directories created before project support)
-    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    # Standalone mode: command_target_YYYYMMDD_HHMMSS_pidNNNNN (underscores,
+    # backwards compatible with existing directories created before project
+    # support).
+    suffix = unique_run_suffix("_")
     if target_name:
-        dirname = f"{command}_{target_name}_{timestamp}"
+        dirname = f"{command}_{target_name}_{suffix}"
     else:
-        dirname = f"{command}_{timestamp}"
+        dirname = f"{command}_{suffix}"
 
     return RaptorConfig.get_out_dir() / dirname
 

--- a/core/run/tests/test_output.py
+++ b/core/run/tests/test_output.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
-from core.run.output import get_output_dir, TargetMismatchError
+from core.run.output import get_output_dir, TargetMismatchError, unique_run_suffix
 
 # Mock that disables project resolution — for testing standalone (no project) mode.
 _NO_SYMLINK = patch("core.run.output._resolve_active_project", return_value=None)
@@ -41,7 +41,31 @@ class TestGetOutputDir(unittest.TestCase):
         result = get_output_dir("scan", target_name="")
         self.assertTrue(result.name.startswith("scan_"))
         parts = result.name.split("_")
-        self.assertEqual(len(parts), 3)
+        # scan_<date>_<time>_pid<N> — at least 4 parts; using >= so
+        # adding more suffix segments later (e.g., microseconds) doesn't
+        # break this test. Final part must be the pid marker.
+        self.assertGreaterEqual(len(parts), 4)
+        self.assertTrue(parts[-1].startswith("pid"))
+
+    def test_concurrent_same_second_invocations_get_distinct_dirs(self):
+        # The bug being fixed: two RAPTOR processes starting in the same
+        # wall-clock second used to compute identical run-dir names.
+        # mkdir(exist_ok=True) didn't fail; both wrote to the same dir;
+        # CI saw "mtime collisions". PID suffix forces distinct names
+        # because two simultaneous processes have different PIDs.
+        with TemporaryDirectory() as d:
+            with patch("core.run.output._resolve_active_project",
+                       return_value=(d, "test", "")):
+                # Pin the timestamp string so both calls see the same second
+                with patch("time.strftime", return_value="20260427-120000"):
+                    # Simulate sibling process via patched os.getpid
+                    with patch("os.getpid", return_value=11111):
+                        a = get_output_dir("scan")
+                    with patch("os.getpid", return_value=22222):
+                        b = get_output_dir("scan")
+                    self.assertNotEqual(a, b,
+                        "same-second invocations from different processes "
+                        "must produce distinct dir names")
 
 
 def _mock_project(d, name="myapp", target="/tmp/vulns"):
@@ -99,6 +123,64 @@ class TestTargetMismatch(unittest.TestCase):
                 result = get_output_dir("scan", explicit_out="/tmp/manual",
                                         target_path="/tmp/other")
                 self.assertEqual(result, Path("/tmp/manual").resolve())
+
+
+class TestUniqueRunSuffix(unittest.TestCase):
+    """The collision-prevention primitive used by every standalone-mode
+    output-dir computation across RAPTOR."""
+
+    def test_underscore_separator(self):
+        with patch("time.strftime", return_value="20260427_120000"):
+            with patch("os.getpid", return_value=12345):
+                self.assertEqual(unique_run_suffix("_"),
+                                 "20260427_120000_pid12345")
+
+    def test_hyphen_separator(self):
+        with patch("time.strftime", return_value="20260427-120000"):
+            with patch("os.getpid", return_value=12345):
+                self.assertEqual(unique_run_suffix("-"),
+                                 "20260427-120000-pid12345")
+
+    def test_default_separator_is_underscore(self):
+        # Standalone mode is the more common shape, so default to '_'.
+        with patch("time.strftime", return_value="20260427_120000"):
+            with patch("os.getpid", return_value=12345):
+                self.assertEqual(unique_run_suffix(),
+                                 "20260427_120000_pid12345")
+
+    def test_uses_correct_strftime_format_for_separator(self):
+        # The separator threads through into strftime so the date and time
+        # use the same separator as the suffix join — keeps the dirname
+        # visually consistent (no mixed `-` and `_`).
+        captured = {}
+        def capture(fmt):
+            captured["fmt"] = fmt
+            return "20260427-120000"
+        with patch("time.strftime", side_effect=capture):
+            with patch("os.getpid", return_value=99):
+                unique_run_suffix("-")
+        self.assertEqual(captured["fmt"], "%Y%m%d-%H%M%S")
+
+    def test_rejects_unsupported_separator(self):
+        # Defends against strftime-directive injection — passing `%H` as
+        # separator would otherwise interpolate into the format string.
+        with self.assertRaises(ValueError):
+            unique_run_suffix("%H")
+        with self.assertRaises(ValueError):
+            unique_run_suffix("/")
+        with self.assertRaises(ValueError):
+            unique_run_suffix("")
+
+    def test_two_pids_produce_distinct_suffixes(self):
+        # The fundamental property: two concurrent processes get different
+        # PIDs and therefore different suffixes even at the same wall-clock
+        # second.
+        with patch("time.strftime", return_value="20260427_120000"):
+            with patch("os.getpid", return_value=11111):
+                a = unique_run_suffix("_")
+            with patch("os.getpid", return_value=22222):
+                b = unique_run_suffix("_")
+            self.assertNotEqual(a, b)
 
 
 if __name__ == "__main__":

--- a/packages/codeql/agent.py
+++ b/packages/codeql/agent.py
@@ -140,9 +140,10 @@ class CodeQLAgent:
         if out_dir:
             self.out_dir = Path(out_dir)
         else:
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            # Collision-prevention via unique_run_suffix — see core/run/output.py.
+            from core.run.output import unique_run_suffix
             repo_name = self.repo_path.name
-            self.out_dir = RaptorConfig.BASE_OUT_DIR / f"codeql_{repo_name}_{timestamp}"
+            self.out_dir = RaptorConfig.BASE_OUT_DIR / f"codeql_{repo_name}_{unique_run_suffix('_')}"
 
         self.out_dir.mkdir(parents=True, exist_ok=True)
 

--- a/packages/codeql/database_manager.py
+++ b/packages/codeql/database_manager.py
@@ -6,6 +6,7 @@ Manages CodeQL database lifecycle including creation, caching,
 validation, and cleanup.
 """
 
+import errno
 import hashlib
 import os
 import re
@@ -273,6 +274,135 @@ class DatabaseManager:
         logger.info(f"✓ Using cached database for {language}: {db_path}")
         return db_path
 
+    # Concurrent-write safety: build-in-staging + atomic-promote pattern.
+    # Two parallel /codeql runs against the same target+language used to
+    # race on direct in-place writes to <db_root>/<repo_hash>/<language>-db,
+    # corrupting whichever finished second. Each writer now builds in its
+    # own staging dir on the same filesystem as canonical, then attempts
+    # atomic os.rename to canonical. First to finish wins the cache slot;
+    # losers cleanup their staging and use the winner's canonical. No lock,
+    # no warning, no corruption — readers never see a partial DB because
+    # the canonical slot is only ever replaced atomically by a complete one.
+
+    def _staging_path(self, repo_hash: str, language: str) -> Path:
+        """Return per-process staging path on the same filesystem as canonical.
+
+        Same-parent-dir is required so os.rename is atomic — cross-fs rename
+        falls back to copy-then-delete which is non-atomic and would let
+        readers see partial state.
+
+        **Process-safe, NOT thread-safe.** Two threads in the same process
+        share PID and thus get the same staging path; concurrent writes
+        within the staging dir would race. RAPTOR's parallelism model uses
+        processes (not threads) so this is fine in practice; a future
+        thread-based caller would need a different staging key (e.g.,
+        include thread.get_ident()).
+        """
+        canonical = self.get_database_dir(repo_hash, language)
+        return canonical.parent / f".staging-{language}-{os.getpid()}"
+
+    def _stale_marker_name(self, canonical: Path) -> str:
+        """Build a unique stale-marker name for an evicted canonical.
+
+        Uses time.time_ns() (nanoseconds since epoch, UTC) so two
+        evictions from the same process within the same wall-clock
+        second get distinct names — int(time.time()) would collide and
+        the second os.rename would fail with ENOTEMPTY, leaving the
+        (now-twice-detected-as-stale) canonical in place.
+
+        Note: timestamp here is UTC nanoseconds since epoch; unique_run_suffix
+        in core/run/output.py uses local-time strftime. Inconsistent but
+        intentional — both serve uniqueness, not timezone consistency.
+        """
+        return f"{canonical.name}.stale.{time.time_ns()}.{os.getpid()}"
+
+    def _gc_stale_markers(self, repo_dir: Path, max_age_seconds: int = 3600) -> None:
+        """Best-effort cleanup of `.stale.*` and `.staging-*` markers older
+        than `max_age_seconds`. Called on cache miss so the cache is
+        self-healing without depending on the manual `--cleanup` CLI being
+        run on a schedule.
+
+        1 hour TTL is generous: any active reader will have finished using
+        an evicted DB by then; any abandoned staging from a crashed writer
+        is genuinely orphaned by then.
+        """
+        if not repo_dir.is_dir():
+            return
+        cutoff = time.time() - max_age_seconds
+        for entry in repo_dir.iterdir():
+            name = entry.name
+            if not (name.startswith(".staging-") or ".stale." in name):
+                continue
+            try:
+                if entry.stat().st_mtime < cutoff:
+                    if entry.is_dir():
+                        shutil.rmtree(entry, ignore_errors=True)
+                    else:
+                        entry.unlink(missing_ok=True)
+            except OSError:
+                pass  # best-effort
+
+    def _evict_stale_canonical(
+        self, repo_hash: str, language: str, max_age_days: int,
+    ) -> None:
+        """Atomically rename the canonical DB out of the way if it's
+        stale (older than `max_age_days`), missing metadata for longer
+        than the grace period, or has malformed metadata — so future
+        cache lookups see a miss and trigger rebuild.
+
+        Reader-safety caveat: files a reader had OPEN before the rename
+        keep working — POSIX rename moves the directory entry, not the
+        underlying inode, and existing FDs reference the inode. But
+        readers doing NEW opens through the canonical path after the
+        rename will fail (path no longer points to the dir). CodeQL
+        queries open dataset chunks lazily during execution, so a query
+        in flight when we evict can break mid-run. Eviction only fires
+        on canonicals that are stale-by-age, missing metadata for >60s
+        (a plausibly-orphaned writer), or malformed — so the impact is
+        bounded to operators who chose to query already-broken data.
+
+        In-flight writer protection: the missing-metadata case applies
+        a grace period (`RaptorConfig.CODEQL_DB_MISSING_METADATA_GRACE`)
+        so a sibling in the post-promote / pre-save-metadata window
+        doesn't get its fresh canonical evicted.
+        """
+        canonical = self.get_database_dir(repo_hash, language)
+        if not canonical.exists():
+            return  # nothing to evict; short-circuit before load_metadata
+        metadata = self.load_metadata(repo_hash, language)
+        # Evict if metadata is malformed, stale-by-age, or missing-for-long-
+        # enough-to-rule-out-an-in-flight-writer. The grace period on the
+        # missing-metadata case is the critical one — without it, this
+        # function would race in-flight writers (see the config docstring
+        # on CODEQL_DB_MISSING_METADATA_GRACE for the timing analysis).
+        evict = False
+        if metadata is None:
+            try:
+                age = time.time() - canonical.stat().st_mtime
+            except OSError:
+                return  # canonical disappeared mid-check; harmless
+            if age >= RaptorConfig.CODEQL_DB_MISSING_METADATA_GRACE:
+                evict = True
+        else:
+            try:
+                created_at = datetime.fromisoformat(metadata.created_at)
+                if datetime.now() - created_at > timedelta(days=max_age_days):
+                    evict = True
+            except (ValueError, AttributeError):
+                # Malformed metadata can't come from an in-flight writer
+                # because save_metadata uses atomic temp-rename — readers
+                # see either the old or the new metadata, never partial.
+                # So malformed = on-disk corruption / hand-edit / bug; no
+                # grace period needed (no in-flight case to race).
+                evict = True
+        if not evict:
+            return
+        marker = canonical.with_name(self._stale_marker_name(canonical))
+        try:
+            os.rename(canonical, marker)
+        except OSError:
+            pass  # raced with another evictor; harmless
+
     def create_database(
         self,
         repo_path: Path,
@@ -287,7 +417,13 @@ class DatabaseManager:
             repo_path: Path to source code
             language: Programming language
             build_system: Build system info (None for no-build mode)
-            force: Force recreation even if cached DB exists
+            force: Force recreation even if cached DB exists. Skips both
+                the initial cache check AND the race-absorbing re-check
+                — a sibling who promoted between our entry and our force
+                eviction will have their canonical evicted and rebuilt.
+                That's the "user asked for fresh" semantics; if you want
+                to coalesce concurrent force=True invocations, do it at
+                the orchestrator layer.
 
         Returns:
             DatabaseResult with creation status
@@ -319,24 +455,62 @@ class DatabaseManager:
                     cached=True,
                 )
 
-        # Compute repo hash and database path
+        # Compute repo hash and paths. canonical is the cache slot;
+        # staging is per-process, on the same filesystem so atomic rename
+        # works. See _staging_path docstring for the same-fs requirement.
         repo_hash = self.compute_repo_hash(repo_path)
-        db_path = self.get_database_dir(repo_hash, language)
+        canonical_path = self.get_database_dir(repo_hash, language)
+        staging_path = self._staging_path(repo_hash, language)
 
-        # Ensure parent directory exists
-        db_path.parent.mkdir(parents=True, exist_ok=True)
+        # Ensure parent directory exists (db_root/<repo_hash>/)
+        canonical_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Remove existing database if forcing
-        if db_path.exists():
-            logger.info(f"Removing existing database: {db_path}")
-            shutil.rmtree(db_path)
+        # Self-healing GC of orphaned .staging-*/.stale.* markers from
+        # crashed writers or evicted stale DBs. Cheap (one iterdir).
+        self._gc_stale_markers(canonical_path.parent)
 
-        # Build the codeql command
+        # Force=True: evict canonical so the cache miss flow rebuilds.
+        # Use rename-out-of-the-way rather than rmtree so any concurrent
+        # reader keeps its inode references intact (see _evict_stale_canonical
+        # docstring for the POSIX semantics).
+        if force and canonical_path.exists():
+            logger.info(f"Force rebuild: evicting cached database for {language}")
+            try:
+                marker = canonical_path.with_name(self._stale_marker_name(canonical_path))
+                os.rename(canonical_path, marker)
+            except OSError:
+                pass  # someone else evicted in parallel; harmless
+
+        # Race-absorbing re-check: another concurrent writer may have
+        # promoted their staging to canonical between our initial cache
+        # miss (line 304) and now. If so, use theirs and skip the build.
+        if not force:
+            cached = self.get_cached_database(repo_path, language)
+            if cached:
+                duration = time.time() - start_time
+                metadata = self.load_metadata(repo_hash, language)
+                return DatabaseResult(
+                    success=True, language=language,
+                    database_path=cached, metadata=metadata,
+                    errors=[], duration_seconds=duration, cached=True,
+                )
+
+        # Stale eviction independent of force — handles the case where
+        # canonical exists but is older than the TTL.
+        self._evict_stale_canonical(repo_hash, language, max_age_days=7)
+
+        # Cleanup any prior leftover staging from this same process (e.g.,
+        # from a previous crashed run with the same PID after PID reuse).
+        if staging_path.exists():
+            shutil.rmtree(staging_path, ignore_errors=True)
+
+        # Build the codeql command — point at staging, not canonical, so
+        # readers of canonical never see a partial DB.
         cmd = [
             self.codeql_cli,
             "database",
             "create",
-            str(db_path),
+            str(staging_path),
             f"--language={language}",
             f"--source-root={repo_path}",
         ]
@@ -416,13 +590,110 @@ class DatabaseManager:
                     errors.append(result.stderr[:1000])  # Truncate long errors
                 logger.error(f"✗ Database creation failed for {language}")
                 logger.error(result.stderr[:500])
+                # Cleanup partial staging on build failure — no point keeping
+                # broken DBs around to confuse future cache lookups (they
+                # never reach canonical anyway since promote is gated on
+                # success, but the staging dir would otherwise linger
+                # until _gc_stale_markers picks it up).
+                shutil.rmtree(staging_path, ignore_errors=True)
+                final_path = None
+                did_promote = False
+                used_cached = False
             else:
-                logger.info(f"✓ Database created successfully: {db_path}")
+                # Atomic-promote: try to install our staging as canonical.
+                # Four post-build outcomes:
+                #   A. Won the rename → did_promote=True, used_cached=False
+                #   B. Lost rename, sibling's canonical valid → use theirs;
+                #      did_promote=False, used_cached=True
+                #   C. Lost rename, sibling's canonical invalid → evict it,
+                #      retry-promote our staging:
+                #      C1. Retry succeeds → did_promote=True (filled empty slot)
+                #      C2. Retry fails (third writer) → use our staging;
+                #          did_promote=False, used_cached=False
+                #   D. Other I/O error (perms, disk full) → fall back to our
+                #      staging; did_promote=False, used_cached=False
+                # Note: did_promote=True is set in two places (A and C1) and
+                # both gate save_metadata identically — kept inline rather
+                # than refactored because the surrounding control flow makes
+                # a unified flag harder to read.
+                final_path = canonical_path
+                did_promote = False
+                used_cached = False
+                try:
+                    os.rename(staging_path, canonical_path)
+                    logger.info(f"✓ Database promoted to canonical: {canonical_path}")
+                    did_promote = True
+                except OSError as e:
+                    if e.errno in (errno.ENOTEMPTY, errno.EEXIST):
+                        # Lost the promotion race. Validate the sibling's
+                        # canonical before trusting it — without this check,
+                        # a sibling who promoted broken content would propagate
+                        # to us as success=True pointing at garbage.
+                        if self.validate_database(canonical_path):
+                            logger.info(
+                                f"✓ Database promoted by sibling; using cached "
+                                f"{canonical_path}"
+                            )
+                            shutil.rmtree(staging_path, ignore_errors=True)
+                            used_cached = True
+                        else:
+                            # Sibling's canonical is broken. Best-effort:
+                            # evict it and try to install our (valid)
+                            # staging in its place — fills the cache slot
+                            # so the next run hits cache instead of
+                            # redundantly rebuilding. Both steps can fail
+                            # benignly: if eviction fails, retry-promote
+                            # falls into ENOTEMPTY again and we use staging.
+                            # If eviction succeeds but retry-promote loses
+                            # (third writer slipped in), we use staging.
+                            # Either way the broken canonical eventually
+                            # gets evicted (this run's lost-race branch on
+                            # the next attempt, or _gc_stale_markers).
+                            logger.warning(
+                                f"Canonical {canonical_path} exists but failed "
+                                f"validation; evicting and retrying promote"
+                            )
+                            try:
+                                marker = canonical_path.with_name(
+                                    self._stale_marker_name(canonical_path)
+                                )
+                                os.rename(canonical_path, marker)
+                            except OSError:
+                                pass  # eviction failed; retry-promote will see ENOTEMPTY
+                            try:
+                                os.rename(staging_path, canonical_path)
+                                logger.info(
+                                    f"✓ Database promoted to canonical "
+                                    f"(after evicting broken sibling copy): "
+                                    f"{canonical_path}"
+                                )
+                                did_promote = True
+                            except OSError:
+                                # Eviction may have failed, OR succeeded but
+                                # a third writer slipped into the empty slot.
+                                # Don't validate-and-cascade; keep staging.
+                                final_path = staging_path
+                    else:
+                        # Genuine I/O error (permissions, disk full); fall back
+                        # to using staging directly so the caller's analysis
+                        # can still proceed. Future runs will rebuild.
+                        logger.warning(
+                            f"Could not promote staging to canonical "
+                            f"({e}); using staging path"
+                        )
+                        final_path = staging_path
 
-            # Count files in database
-            file_count = self._count_database_files(db_path) if success else 0
+            # Count files in database (use whatever path won out above).
+            # Cosmetic-only: a force=True writer in another window could
+            # evict canonical between our os.rename above and this call,
+            # leaving file_count=0 in the metadata we eventually save.
+            # Not a correctness issue — the DB content the caller uses
+            # via FDs is unaffected (POSIX inode survives rename).
+            file_count = self._count_database_files(final_path) if success and final_path else 0
 
-            # Create metadata
+            # Create metadata; database_path reflects where the DB actually
+            # lives (canonical if promote succeeded, staging on fallback,
+            # None on build failure)
             metadata = DatabaseMetadata(
                 repo_hash=repo_hash,
                 repo_path=str(repo_path),
@@ -435,20 +706,26 @@ class DatabaseManager:
                 success=success,
                 duration_seconds=time.time() - start_time,
                 errors=errors,
-                database_path=str(db_path),
+                database_path=str(final_path) if final_path else "",
             )
 
-            # Save metadata
-            self.save_metadata(metadata)
+            # Save metadata only when WE promoted to canonical. If we used
+            # the sibling's canonical (used_cached) the winner's metadata
+            # is already there. If we used our own staging (validation
+            # failure or I/O error fallback) the metadata file at canonical
+            # path doesn't apply — saving it would mislead future cache
+            # lookups about what's at canonical.
+            if did_promote:
+                self.save_metadata(metadata)
 
             return DatabaseResult(
                 success=success,
                 language=language,
-                database_path=db_path if success else None,
+                database_path=final_path if success else None,
                 metadata=metadata,
                 errors=errors,
                 duration_seconds=time.time() - start_time,
-                cached=False,
+                cached=used_cached,
             )
 
         except subprocess.TimeoutExpired:
@@ -482,6 +759,16 @@ class DatabaseManager:
         finally:
             if build_script and build_script.exists():
                 build_script.unlink()
+            # Belt-and-braces staging cleanup for timeout / unhandled exception
+            # paths that bypass the success/failure cleanup branches above.
+            # Skip if we ended up using staging as final_path (the fallback
+            # cases where promote failed but we kept staging as a usable DB)
+            # — otherwise we'd delete the very DB we're returning to the
+            # caller. Use locals().get to handle the case where we never
+            # reached the assignment (early exception before final_path set).
+            _final = locals().get('final_path')
+            if staging_path.exists() and _final != staging_path:
+                shutil.rmtree(staging_path, ignore_errors=True)
 
     def create_databases_parallel(
         self,

--- a/packages/codeql/test_database_manager.py
+++ b/packages/codeql/test_database_manager.py
@@ -498,4 +498,3 @@ class TestEvictStaleCanonicalGracePeriod:
             "orphaned canonical past grace period should be evicted"
         assert len(list(canonical.parent.glob("*.stale.*"))) == 1, \
             "exactly one stale marker should be created from eviction"
-

--- a/packages/codeql/test_database_manager.py
+++ b/packages/codeql/test_database_manager.py
@@ -1,7 +1,9 @@
 """Tests for CodeQL database manager build command handling."""
 
+import os
 import stat
 import subprocess as sp
+import time
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
@@ -19,6 +21,10 @@ def db_manager(tmp_path):
         mgr.codeql_cli = "/usr/bin/codeql"
         mgr.cache_dir = tmp_path / "cache"
         mgr.cache_dir.mkdir()
+        # db_root mirrors what real __init__ sets (RaptorConfig.CODEQL_DB_DIR);
+        # needed by load_metadata / get_metadata_path which don't go through
+        # the get_database_dir seam that other tests patch.
+        mgr.db_root = mgr.cache_dir
         return mgr
 
 
@@ -153,3 +159,343 @@ class TestBuildScript:
 
         assert "--command" not in captured_cmd
         assert not list(tmp_path.glob(".raptor_codeql_build_*"))
+
+
+# ---------------------------------------------------------------------------
+# Concurrent-write safety: build-in-staging + atomic-promote
+# ---------------------------------------------------------------------------
+
+
+class TestStagingPromote:
+    """create_database builds in staging, atomic-promotes to canonical;
+    concurrent writers don't corrupt; readers never see partial state."""
+
+    def test_staging_path_is_same_parent_as_canonical(self, db_manager, tmp_path):
+        # Same-fs requirement for atomic rename — staging and canonical
+        # must share a parent directory.
+        canonical = tmp_path / "cache" / "abc" / "python-db"
+        with patch.object(db_manager, 'get_database_dir', return_value=canonical):
+            staging = db_manager._staging_path("abc", "python")
+        assert staging.parent == canonical.parent
+
+    def test_staging_path_includes_pid(self, db_manager, tmp_path):
+        # Per-process staging means concurrent writers don't collide on
+        # the staging dir itself.
+        canonical = tmp_path / "cache" / "abc" / "python-db"
+        with patch.object(db_manager, 'get_database_dir', return_value=canonical):
+            staging = db_manager._staging_path("abc", "python")
+        assert f"-{os.getpid()}" in staging.name
+        assert staging.name.startswith(".staging-")
+
+    def test_successful_build_renames_staging_to_canonical(self, db_manager, tmp_path):
+        # On success, staging dir disappears (was renamed) and canonical
+        # exists with the build's content.
+        canonical = tmp_path / "cache" / "abc" / "python-db"
+        canonical.parent.mkdir(parents=True)
+
+        bs = BuildSystem(type="pip", command="", working_dir=tmp_path,
+                         env_vars={}, confidence=1.0, detected_files=[])
+
+        def fake_sandbox_run(cmd, **kwargs):
+            # Simulate codeql writing the DB to the staging path it was
+            # given on the command line. cmd[3] is the staging path
+            # (codeql, database, create, <staging>, ...).
+            staging_arg = Path(cmd[3])
+            staging_arg.mkdir(parents=True, exist_ok=True)
+            (staging_arg / "db-info.json").write_text("{}")
+            r = MagicMock(); r.returncode = 0; r.stdout = "2.16.0"; r.stderr = ""
+            return r
+
+        with patch('core.sandbox.run', side_effect=fake_sandbox_run), \
+             patch.object(db_manager, '_count_database_files', return_value=1), \
+             patch.object(db_manager, 'save_metadata'), \
+             patch.object(db_manager, 'get_cached_database', return_value=None), \
+             patch.object(db_manager, 'compute_repo_hash', return_value='abc'), \
+             patch.object(db_manager, 'get_database_dir', return_value=canonical):
+            result = db_manager.create_database(tmp_path, "python", bs)
+
+        assert result.success is True
+        assert canonical.exists(), "canonical should exist after promote"
+        assert (canonical / "db-info.json").exists(), "canonical content present"
+        # No staging dirs left behind (the rename ate ours; no orphans).
+        assert not list(canonical.parent.glob(".staging-*"))
+
+    def test_lost_promotion_race_uses_winner_canonical(self, db_manager, tmp_path):
+        # Simulate: another writer populated canonical between our cache-miss
+        # check and our promote attempt. We should cleanup our staging and
+        # return the winner's canonical path. Canonical here is VALID
+        # (has codeql-database.yml) so validate_database in the lost-race
+        # branch accepts it.
+        canonical = tmp_path / "cache" / "abc" / "python-db"
+        canonical.parent.mkdir(parents=True)
+        # Pre-populate canonical (simulating sibling who finished first)
+        canonical.mkdir()
+        (canonical / "codeql-database.yml").write_text("language: python\n")
+        (canonical / "winner-marker").write_text("winner")
+
+        bs = BuildSystem(type="pip", command="", working_dir=tmp_path,
+                         env_vars={}, confidence=1.0, detected_files=[])
+
+        def fake_sandbox_run(cmd, **kwargs):
+            staging_arg = Path(cmd[3])
+            staging_arg.mkdir(parents=True, exist_ok=True)
+            (staging_arg / "loser-marker").write_text("loser")
+            r = MagicMock(); r.returncode = 0; r.stdout = "2.16.0"; r.stderr = ""
+            return r
+
+        # Patch _evict_stale_canonical to no-op so the test stays focused on
+        # the lost-race-with-valid-canonical scenario rather than the
+        # pre-build eviction logic (which has its own dedicated tests).
+        with patch('core.sandbox.run', side_effect=fake_sandbox_run), \
+             patch.object(db_manager, '_count_database_files', return_value=1), \
+             patch.object(db_manager, 'save_metadata') as save_meta_mock, \
+             patch.object(db_manager, '_evict_stale_canonical'), \
+             patch.object(db_manager, 'get_cached_database', return_value=None), \
+             patch.object(db_manager, 'compute_repo_hash', return_value='abc'), \
+             patch.object(db_manager, 'get_database_dir', return_value=canonical):
+            result = db_manager.create_database(tmp_path, "python", bs)
+
+        assert result.success is True
+        assert result.database_path == canonical
+        # Winner's content survived (loser's didn't overwrite)
+        assert (canonical / "winner-marker").exists()
+        assert not (canonical / "loser-marker").exists()
+        # Loser's staging dir is gone (cleanup)
+        assert not list(canonical.parent.glob(".staging-*"))
+        # used_cached=True correctly reflects that we're using sibling's cache
+        assert result.cached is True
+        # Loser must NOT overwrite winner's metadata (winner already saved
+        # consistent metadata; saving again would just be churn)
+        save_meta_mock.assert_not_called()
+
+    def test_lost_promotion_race_with_invalid_canonical_evicts_and_promotes_ours(
+            self, db_manager, tmp_path):
+        """Sibling promoted broken content (e.g., missing codeql-database.yml)
+        between our cache check and our promote attempt. We must:
+        (a) validate canonical before trusting it — without this check,
+            a sibling who promoted broken content would propagate to us
+            as success=True pointing at garbage,
+        (b) evict the broken canonical and retry-promote our valid
+            staging into the now-empty slot — without retry, the next
+            run would redundantly rebuild because the cache slot stays
+            empty.
+
+        We patch _evict_stale_canonical to no-op so this test focuses on
+        the post-build lost-race branch. The pre-build eviction logic
+        has its own dedicated tests in TestEvictStaleCanonicalGracePeriod.
+        """
+        canonical = tmp_path / "cache" / "abc" / "python-db"
+        canonical.parent.mkdir(parents=True)
+        # Pre-populate canonical with INVALID content (no codeql-database.yml).
+        canonical.mkdir()
+        (canonical / "marker").write_text("broken sibling promote")
+
+        bs = BuildSystem(type="pip", command="", working_dir=tmp_path,
+                         env_vars={}, confidence=1.0, detected_files=[])
+
+        def fake_sandbox_run(cmd, **kwargs):
+            staging_arg = Path(cmd[3])
+            staging_arg.mkdir(parents=True, exist_ok=True)
+            (staging_arg / "codeql-database.yml").write_text("language: python\n")
+            (staging_arg / "valid-content").write_text("our build")
+            r = MagicMock(); r.returncode = 0; r.stdout = "2.16.0"; r.stderr = ""
+            return r
+
+        with patch('core.sandbox.run', side_effect=fake_sandbox_run), \
+             patch.object(db_manager, '_count_database_files', return_value=2), \
+             patch.object(db_manager, 'save_metadata') as save_meta_mock, \
+             patch.object(db_manager, '_evict_stale_canonical'), \
+             patch.object(db_manager, 'get_cached_database', return_value=None), \
+             patch.object(db_manager, 'compute_repo_hash', return_value='abc'), \
+             patch.object(db_manager, 'get_database_dir', return_value=canonical):
+            result = db_manager.create_database(tmp_path, "python", bs)
+
+        # We succeeded (didn't propagate sibling's broken canonical as success)
+        assert result.success is True
+        assert result.cached is False  # we used our own build, not cache
+        # Result points at canonical because we retry-promoted our valid
+        # staging into the empty slot (after evicting broken sibling copy).
+        # Pre-R2 behaviour was final_path=staging; R2 now retries the
+        # promote so future runs hit cache instead of redundantly rebuilding.
+        assert result.database_path == canonical, \
+            f"expected canonical (promoted via retry), got: {result.database_path}"
+        assert (canonical / "codeql-database.yml").exists()
+        assert (canonical / "valid-content").exists()
+        # Broken canonical was evicted (renamed to .stale.*) — exactly one
+        # marker since this is a single eviction.
+        stale_markers = list(canonical.parent.glob("*.stale.*"))
+        assert len(stale_markers) == 1, \
+            f"expected 1 stale marker from eviction, got: {len(stale_markers)}"
+        # We DID save metadata because we retry-promoted (did_promote=True)
+        save_meta_mock.assert_called_once()
+        # Our staging dir is gone — got renamed to canonical
+        assert not list(canonical.parent.glob(".staging-*"))
+
+    def test_build_failure_cleans_up_staging(self, db_manager, tmp_path):
+        # Failed builds must not leave staging dirs lying around (would
+        # confuse cache lookups and pollute the cache dir).
+        canonical = tmp_path / "cache" / "abc" / "python-db"
+        canonical.parent.mkdir(parents=True)
+
+        bs = BuildSystem(type="pip", command="", working_dir=tmp_path,
+                         env_vars={}, confidence=1.0, detected_files=[])
+
+        def fake_sandbox_run(cmd, **kwargs):
+            staging_arg = Path(cmd[3])
+            staging_arg.mkdir(parents=True, exist_ok=True)
+            (staging_arg / "partial").write_text("garbage")
+            r = MagicMock(); r.returncode = 1; r.stdout = ""; r.stderr = "build failed"
+            return r
+
+        with patch('core.sandbox.run', side_effect=fake_sandbox_run), \
+             patch.object(db_manager, '_count_database_files', return_value=0), \
+             patch.object(db_manager, 'save_metadata'), \
+             patch.object(db_manager, 'get_cached_database', return_value=None), \
+             patch.object(db_manager, 'compute_repo_hash', return_value='abc'), \
+             patch.object(db_manager, 'get_database_dir', return_value=canonical):
+            result = db_manager.create_database(tmp_path, "python", bs)
+
+        assert result.success is False
+        assert not canonical.exists(), "failed build must not promote"
+        assert not list(canonical.parent.glob(".staging-*")), "staging cleanup"
+
+
+class TestStaleMarkerGC:
+    """_gc_stale_markers reaps abandoned .staging-*/.stale.* dirs after TTL."""
+
+    def test_gc_removes_old_staging_dirs(self, db_manager, tmp_path):
+        repo_dir = tmp_path / "cache" / "abc"
+        repo_dir.mkdir(parents=True)
+        old = repo_dir / ".staging-python-99999"
+        old.mkdir()
+        # Make it look 2 hours old (well past 1-hour TTL)
+        old_mtime = time.time() - 7200
+        os.utime(old, (old_mtime, old_mtime))
+
+        db_manager._gc_stale_markers(repo_dir)
+
+        assert not old.exists()
+
+    def test_gc_preserves_recent_staging(self, db_manager, tmp_path):
+        # Active concurrent writer's staging dir is fresh; must not be GC'd
+        # while the writer might still need it.
+        repo_dir = tmp_path / "cache" / "abc"
+        repo_dir.mkdir(parents=True)
+        recent = repo_dir / ".staging-python-12345"
+        recent.mkdir()  # mtime = now
+
+        db_manager._gc_stale_markers(repo_dir)
+
+        assert recent.exists()
+
+    def test_gc_removes_old_stale_markers(self, db_manager, tmp_path):
+        repo_dir = tmp_path / "cache" / "abc"
+        repo_dir.mkdir(parents=True)
+        # Evicted-stale marker name pattern from _evict_stale_canonical
+        old_stale = repo_dir / "python-db.stale.1234567890.99999"
+        old_stale.mkdir()
+        old_mtime = time.time() - 7200
+        os.utime(old_stale, (old_mtime, old_mtime))
+
+        db_manager._gc_stale_markers(repo_dir)
+
+        assert not old_stale.exists()
+
+    def test_gc_leaves_unrelated_files(self, db_manager, tmp_path):
+        # Real DBs and metadata files in the cache dir must not be touched.
+        repo_dir = tmp_path / "cache" / "abc"
+        repo_dir.mkdir(parents=True)
+        real_db = repo_dir / "python-db"
+        real_db.mkdir()
+        real_meta = repo_dir / "python-metadata.json"
+        real_meta.write_text("{}")
+
+        db_manager._gc_stale_markers(repo_dir)
+
+        assert real_db.exists()
+        assert real_meta.exists()
+
+
+class TestStaleMarkerName:
+    """`_stale_marker_name` must produce nanosecond-unique names so two
+    same-second evictions from the same process don't collide on the
+    rename target (which would silently leave the canonical in place)."""
+
+    def test_marker_includes_nanosecond_timestamp(self, db_manager, tmp_path):
+        canonical = tmp_path / "python-db"
+        marker = db_manager._stale_marker_name(canonical)
+        # Format: <name>.stale.<time_ns>.<pid>
+        # Nanosecond timestamps are 19 digits as of 2026 (approx).
+        parts = marker.split(".stale.")
+        assert parts[0] == "python-db"
+        ts_pid = parts[1].split(".")
+        assert len(ts_pid) == 2
+        ts, pid = ts_pid
+        assert ts.isdigit() and len(ts) >= 18, \
+            f"expected ns-precision timestamp, got {ts!r}"
+        assert pid.startswith("") and pid.isdigit()
+
+    def test_two_calls_in_same_second_produce_distinct_names(
+            self, db_manager, tmp_path):
+        # The whole point of using time_ns: two calls in quick succession
+        # (likely same second) get distinct names so consecutive evictions
+        # don't collide on the rename target.
+        canonical = tmp_path / "python-db"
+        a = db_manager._stale_marker_name(canonical)
+        b = db_manager._stale_marker_name(canonical)
+        assert a != b, f"same-second marker collision: {a} == {b}"
+
+
+class TestEvictStaleCanonicalGracePeriod:
+    """Regression for the R1 race: in-flight writers (just promoted
+    canonical, haven't called save_metadata yet) must NOT have their
+    canonical evicted by a sibling. Before the grace period was added,
+    _evict_stale_canonical aggressively evicted any canonical with no
+    metadata — racing the writer's hundreds-of-ms post-promote/pre-save
+    window."""
+
+    def test_fresh_canonical_with_no_metadata_is_not_evicted(
+            self, db_manager, tmp_path):
+        # Simulate: writer just renamed staging→canonical but hasn't
+        # called save_metadata yet. canonical's mtime is fresh.
+        canonical = tmp_path / "cache" / "abc" / "python-db"
+        canonical.parent.mkdir(parents=True)
+        canonical.mkdir()
+        (canonical / "codeql-database.yml").write_text("language: python\n")
+        # NOTE: deliberately no <lang>-metadata.json file — simulating
+        # the gap between os.rename and save_metadata.
+
+        with patch.object(db_manager, 'get_database_dir', return_value=canonical):
+            db_manager._evict_stale_canonical("abc", "python", max_age_days=7)
+
+        # Fresh canonical without metadata must NOT be evicted (grace
+        # period protects in-flight writers).
+        assert canonical.exists(), \
+            "in-flight writer's fresh canonical was wrongly evicted"
+        assert not list(canonical.parent.glob("*.stale.*")), \
+            "no stale markers should be created"
+
+    def test_old_canonical_with_no_metadata_IS_evicted(
+            self, db_manager, tmp_path):
+        # Simulate: previous writer crashed between rename and
+        # save_metadata, leaving canonical orphaned. It's been there
+        # for longer than the grace period — must be evicted so the
+        # next run can rebuild and save consistent metadata.
+        canonical = tmp_path / "cache" / "abc" / "python-db"
+        canonical.parent.mkdir(parents=True)
+        canonical.mkdir()
+        (canonical / "codeql-database.yml").write_text("language: python\n")
+        # Backdate canonical's mtime well past the grace period.
+        from core.config import RaptorConfig
+        old_mtime = time.time() - (RaptorConfig.CODEQL_DB_MISSING_METADATA_GRACE + 60)
+        os.utime(canonical, (old_mtime, old_mtime))
+
+        with patch.object(db_manager, 'get_database_dir', return_value=canonical):
+            db_manager._evict_stale_canonical("abc", "python", max_age_days=7)
+
+        # Orphan must be evicted to break the rebuild loop.
+        assert not canonical.exists(), \
+            "orphaned canonical past grace period should be evicted"
+        assert len(list(canonical.parent.glob("*.stale.*"))) == 1, \
+            "exactly one stale marker should be created from eviction"
+

--- a/packages/codeql/test_database_manager_integration.py
+++ b/packages/codeql/test_database_manager_integration.py
@@ -1,0 +1,211 @@
+"""Integration tests for CodeQL database_manager concurrent-write safety.
+
+These tests use real multiprocessing (subprocess Popen via mp.Pool) to
+exercise the build-in-staging + atomic-promote flow with real PIDs and
+real concurrent file operations — exactly the conditions where the bug
+this fix addresses (two concurrent /codeql runs corrupting each other's
+canonical DB) actually manifests.
+
+Mocks-only unit tests in test_database_manager.py validate the logic
+shape; these tests validate behaviour under real concurrency.
+
+Tests are timing-sensitive (rely on sleep widening the race window).
+Marked slow; default 30s timeout per test.
+"""
+
+import multiprocessing as mp
+import os
+import random
+import time
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# Module-level worker so it can be pickled by mp.Pool. Cannot reference
+# enclosing test scope; gets all state via args.
+
+
+def _concurrent_create_worker(args):
+    """Worker run inside a subprocess via mp.Pool.
+
+    Each process:
+      - constructs its own DatabaseManager pointing at the shared cache_dir
+      - patches `core.sandbox.run` locally (patches don't cross process
+        boundaries, so each worker sets up its own)
+      - calls create_database; returns the outcome
+    """
+    cache_dir_str, repo_path_str, sleep_min, sleep_max = args
+
+    cache_dir = Path(cache_dir_str)
+    repo_path = Path(repo_path_str)
+
+    from packages.codeql.database_manager import DatabaseManager
+
+    mgr = DatabaseManager.__new__(DatabaseManager)
+    mgr.codeql_cli = "/usr/bin/codeql"
+    mgr.db_root = cache_dir
+
+    def fake_sandbox_run(cmd, **kwargs):
+        # cmd[3] is the staging path the production code told codeql to
+        # write to. Simulate codeql writing real content to that path,
+        # with a randomised delay to widen the race window between
+        # workers.
+        staging = Path(cmd[3])
+        staging.mkdir(parents=True, exist_ok=True)
+        time.sleep(random.uniform(sleep_min, sleep_max))
+        # codeql-database.yml is the marker validate_database checks for.
+        # Without this file, get_cached_database considers the cached
+        # DB invalid even after promotion.
+        (staging / "codeql-database.yml").write_text(
+            "sourceLocationPrefix: /repo\nlanguage: python\n"
+        )
+        (staging / "db-info.json").write_text(f'{{"pid": {os.getpid()}}}')
+        # Add some bulk so the staging dir is non-trivial — better
+        # simulates real codeql DB shape (>= a few files of content)
+        for i in range(3):
+            (staging / f"chunk-{i}.bin").write_bytes(b"x" * 4096)
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = "2.16.0"
+        r.stderr = ""
+        return r
+
+    with patch('core.sandbox.run', side_effect=fake_sandbox_run), \
+         patch.object(mgr, '_count_database_files', return_value=4):
+        result = mgr.create_database(repo_path, "python")
+
+    return {
+        'success': result.success,
+        'database_path': str(result.database_path) if result.database_path else None,
+        'pid': os.getpid(),
+        'cached': result.cached,
+    }
+
+
+class TestConcurrentCreateDatabase:
+    """End-to-end concurrent-write safety: multiple real processes
+    racing to populate the same cache slot must all succeed without
+    corruption, exactly one canonical survives, no orphan staging."""
+
+    def _make_target_repo(self, tmp_path: Path) -> Path:
+        """Build a small fake repo for compute_repo_hash to digest."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "main.py").write_text("def f():\n    return 42\n")
+        (repo / "lib.py").write_text("def g(x):\n    return x * 2\n")
+        return repo
+
+    def test_four_concurrent_writers_all_succeed_no_corruption(self, tmp_path):
+        """Four parallel processes call create_database against the same
+        target. All must succeed; exactly one wins the canonical slot;
+        losers either get a database_path pointing at canonical (race
+        absorbed via re-check) or at their own staging (rare fallback);
+        no orphan .staging-* dirs left behind.
+        """
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        repo_path = self._make_target_repo(tmp_path)
+
+        n_workers = 4
+        # Wide-ish sleep window forces real overlap between workers
+        args = [(str(cache_dir), str(repo_path), 0.1, 0.3)
+                for _ in range(n_workers)]
+
+        # 'spawn' context: avoids fork-related issues with patches in
+        # parent affecting children unexpectedly.
+        ctx = mp.get_context('spawn')
+        with ctx.Pool(n_workers) as pool:
+            results = pool.map(_concurrent_create_worker, args)
+
+        # All workers succeeded
+        for i, r in enumerate(results):
+            assert r['success'], f"worker {i} failed: {r}"
+
+        # All have distinct PIDs (sanity check that mp actually forked)
+        assert len(set(r['pid'] for r in results)) == n_workers
+
+        # Cache slot is populated. Compute hash from the same code path
+        # workers used so we look in the right place.
+        from packages.codeql.database_manager import DatabaseManager
+        helper = DatabaseManager.__new__(DatabaseManager)
+        helper.db_root = cache_dir
+        repo_hash = helper.compute_repo_hash(repo_path)
+        canonical = cache_dir / repo_hash / "python-db"
+
+        assert canonical.exists(), \
+            f"canonical {canonical} should exist after the race"
+        assert (canonical / "db-info.json").exists(), \
+            "canonical should have content from whichever worker won"
+
+        # No orphan staging dirs — every worker either renamed theirs
+        # to canonical or cleaned up after losing the promotion race.
+        repo_dir = canonical.parent
+        orphan_staging = list(repo_dir.glob(".staging-*"))
+        assert orphan_staging == [], \
+            f"orphan staging dirs remain: {orphan_staging}"
+
+        # No stale markers (none should be created on a fresh-cache run)
+        orphan_stale = list(repo_dir.glob("*.stale.*"))
+        assert orphan_stale == [], \
+            f"unexpected stale markers: {orphan_stale}"
+
+    def test_eight_concurrent_writers_with_tighter_race(self, tmp_path):
+        """Higher concurrency with shorter sleep windows — increases the
+        chance of multiple workers ALL hitting cache miss simultaneously,
+        which is the worst case for redundant work but should still
+        produce zero corruption."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        repo_path = self._make_target_repo(tmp_path)
+
+        n_workers = 8
+        args = [(str(cache_dir), str(repo_path), 0.02, 0.1)
+                for _ in range(n_workers)]
+
+        ctx = mp.get_context('spawn')
+        with ctx.Pool(n_workers) as pool:
+            results = pool.map(_concurrent_create_worker, args)
+
+        # Same invariants as the 4-worker case
+        for i, r in enumerate(results):
+            assert r['success'], f"worker {i} failed: {r}"
+
+        from packages.codeql.database_manager import DatabaseManager
+        helper = DatabaseManager.__new__(DatabaseManager)
+        helper.db_root = cache_dir
+        repo_hash = helper.compute_repo_hash(repo_path)
+        canonical = cache_dir / repo_hash / "python-db"
+
+        assert canonical.exists()
+        repo_dir = canonical.parent
+        assert list(repo_dir.glob(".staging-*")) == []
+
+    def test_sequential_after_concurrent_uses_cache(self, tmp_path):
+        """After the race resolves and canonical is populated, a
+        subsequent (sequential) invocation should hit the cache rather
+        than rebuild — confirms the redundant-work cost is bounded to
+        the initial race, not amortised across every later run."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        repo_path = self._make_target_repo(tmp_path)
+
+        # Phase 1: initial concurrent burst populates cache
+        ctx = mp.get_context('spawn')
+        with ctx.Pool(3) as pool:
+            results = pool.map(_concurrent_create_worker,
+                               [(str(cache_dir), str(repo_path), 0.05, 0.15)
+                                for _ in range(3)])
+        assert all(r['success'] for r in results)
+
+        # Phase 2: a fresh single process — should hit cache
+        # NOTE: get_cached_database checks for metadata + valid DB; the
+        # workers' save_metadata DOES run when their staging promotes to
+        # canonical, so the cache hit path should fire.
+        result = _concurrent_create_worker(
+            (str(cache_dir), str(repo_path), 0.05, 0.15)
+        )
+        assert result['success']
+        assert result['cached'], \
+            "second-phase invocation should have hit the cache " \
+            "populated by the first-phase race"

--- a/packages/exploitability_validation/orchestrator.py
+++ b/packages/exploitability_validation/orchestrator.py
@@ -1329,13 +1329,14 @@ def run_validation(
         PipelineState with all results
     """
     if not workdir:
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        # Collision-prevention via unique_run_suffix — see core/run/output.py.
+        from core.run.output import unique_run_suffix
         try:
             from core.config import RaptorConfig
             base = str(RaptorConfig.get_out_dir())
         except ImportError:
             base = "out"
-        workdir = f"{base}/exploitability-validation-{timestamp}"
+        workdir = f"{base}/exploitability-validation-{unique_run_suffix('-')}"
 
     config = PipelineConfig(
         target_path=target_path,

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -28,6 +28,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 from core.config import RaptorConfig
 from core.logging import get_logger
 from core.progress import HackerProgress
+from core.run.output import unique_run_suffix
 from core.sarif.parser import parse_sarif_findings, deduplicate_findings
 from core.inventory.lookup import lookup_function as _lookup_function
 from llm.client import LLMClient, _is_auth_error
@@ -1249,8 +1250,8 @@ def main() -> None:
     if args.out:
         out_dir = Path(args.out).resolve()
     else:
-        timestamp = time.strftime("%Y%m%d_%H%M%S")
-        out_dir = RaptorConfig.get_out_dir() / f"autonomous_v2_{timestamp}"
+        # Collision-prevention via unique_run_suffix — see core/run/output.py.
+        out_dir = RaptorConfig.get_out_dir() / f"autonomous_v2_{unique_run_suffix('_')}"
 
     # Initialize agent with LLM
     agent = AutonomousSecurityAgentV2(repo_path, out_dir, prep_only=args.prep_only)

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -26,6 +26,7 @@ sys.path.insert(0, str(Path(__file__).parents[2]))
 
 from core.json import save_json
 from core.config import RaptorConfig
+from core.run.output import unique_run_suffix
 from core.logging import get_logger
 from core.git import clone_repository
 from core.sarif.parser import generate_scan_metrics, validate_sarif
@@ -442,8 +443,8 @@ def main():
             out_dir = Path(args.out)
         else:
             repo_name = repo_path.name
-            timestamp = time.strftime("%Y%m%d_%H%M%S")
-            out_dir = RaptorConfig.get_out_dir() / f"scan_{repo_name}_{timestamp}"
+            # Collision-prevention via unique_run_suffix — see core/run/output.py.
+            out_dir = RaptorConfig.get_out_dir() / f"scan_{repo_name}_{unique_run_suffix('_')}"
         out_dir.mkdir(parents=True, exist_ok=True)
 
         # Manifest

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -577,5 +577,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-


### PR DESCRIPTION
Two parallel /codeql runs against the same target+language used to race on direct in-place writes to <db_root>/<repo_hash>/<language>-db, corrupting whichever finished second. Each writer now builds in its own per-process staging dir on the same filesystem as canonical, then attempts atomic os.rename to canonical. First to finish wins the cache slot; losers either use the winner's canonical (after validating it) or, on broken canonical, evict-and-retry-promote so the cache slot ends up filled. Never blocks, never warns, never corrupts — readers only ever see a complete DB because the canonical slot is replaced atomically.

Stale eviction (>7 days) and orphan recovery (canonical with no metadata, past a 60s grace period) self-heal the cache without needing the manual --cleanup CLI to run on a schedule. The grace period prevents racing in-flight writers in their post-promote / pre-save-metadata window.

Separately: two RAPTOR processes starting in the same wall-clock second computed identical run-dir names. mkdir(exist_ok=True) silently shared the dir; CI saw mtime collisions and intermittent failures. New core/run/output.unique_run_suffix() composes timestamp
+ PID; applied at every standalone-mode output-dir computation (get_output_dir, /project merge, scanner, llm_analysis/agent, exploitability_validation/orchestrator, codeql/agent).

Tests: 14 unit tests for the cache logic + 3 integration tests via mp.Pool exercising real concurrent file ops, plus 6 tests for the output suffix helper (collision, separator validation, format).