### PR TITLE
fix(diagram): harden Mermaid sanitizer edge cases

### DIFF
--- a/packages/diagram/attack_paths.py
+++ b/packages/diagram/attack_paths.py
@@ -62,9 +62,9 @@ def generate_single(path_data: dict[str, Any], path_index: int) -> str:
         nid = f"P{path_index}S{i+1}"
         # Steps may be objects or strings
         if isinstance(step, dict):
-            step_type = step.get("type", "call")
+            step_type = _sanitize(step.get("type", "call"))
             desc = _sanitize(step.get("description", step.get("action", str(step))))
-            loc = step.get("call_site") or step.get("definition") or ""
+            loc = _sanitize(step.get("call_site") or step.get("definition") or "")
             tainted = _sanitize(step.get("tainted_var", ""))
             parts = [f"[{i+1}] {step_type.upper()}"]
             if loc:

--- a/packages/diagram/attack_paths.py
+++ b/packages/diagram/attack_paths.py
@@ -62,11 +62,11 @@ def generate_single(path_data: dict[str, Any], path_index: int) -> str:
         nid = f"P{path_index}S{i+1}"
         # Steps may be objects or strings
         if isinstance(step, dict):
-            step_type = _sanitize(step.get("type", "call"))
+            step_type = _sanitize(str(step.get("type", "call")).upper())
             desc = _sanitize(step.get("description", step.get("action", str(step))))
             loc = _sanitize(step.get("call_site") or step.get("definition") or "")
             tainted = _sanitize(step.get("tainted_var", ""))
-            parts = [f"[{i+1}] {step_type.upper()}"]
+            parts = [f"[{i+1}] {step_type}"]
             if loc:
                 parts.append(loc)
             if tainted:

--- a/packages/diagram/attack_tree.py
+++ b/packages/diagram/attack_tree.py
@@ -265,7 +265,7 @@ def generate(
     # Style classes
     status_groups: dict[str, list[str]] = {}
     for node in nodes:
-        s = node.get("status", "unexplored")
+        s = _sanitize(node.get("status", "unexplored"))
         status_groups.setdefault(s, []).append(node.get("id", "?"))
 
     lines.append("")

--- a/packages/diagram/attack_tree.py
+++ b/packages/diagram/attack_tree.py
@@ -69,7 +69,7 @@ def _build_hypothesis_index(hypotheses: list[dict]) -> dict[str, str]:
     index: dict[str, str] = {}
     for h in hypotheses:
         fid = h.get("finding") or h.get("finding_id", "")
-        status = h.get("status", "")
+        status = _sanitize(h.get("status", ""))
         claim = h.get("claim") or h.get("hypothesis", "")
         if fid and fid not in index:
             index[fid] = f"{status}: {_sanitize(claim[:60])}" if claim else status
@@ -80,9 +80,7 @@ def _node_label(node: dict, proximity_idx: dict, disproven_idx: dict) -> str:
     nid = node.get("id", "?")
     goal = _sanitize(node.get("goal", node.get("technique", nid)))
     technique = _sanitize(node.get("technique", ""))
-    status = node.get("status", "unexplored")
-    node_type = node.get("type", "")
-
+    status = _sanitize(node.get("status", "unexplored"))
     parts = [goal]
     if technique and technique != goal:
         parts.append(technique)

--- a/packages/diagram/context_map.py
+++ b/packages/diagram/context_map.py
@@ -127,13 +127,13 @@ def generate(data: dict[str, Any]) -> str:
     lines.append("    classDef sink fill:#fee2e2,stroke:#dc2626,color:#7f1d1d")
 
     if entry_points:
-        ep_ids = ",".join(ep.get("id", "") for ep in entry_points)
+        ep_ids = ",".join(_sid(ep.get("id", "")) for ep in entry_points)
         lines.append(f"    class {ep_ids} ep")
     if boundary_details:
-        tb_ids = ",".join(tb.get("id", "") for tb in boundary_details)
+        tb_ids = ",".join(_sid(tb.get("id", "")) for tb in boundary_details)
         lines.append(f"    class {tb_ids} tb")
     if sink_details:
-        sink_ids = ",".join(s.get("id", "") for s in sink_details)
+        sink_ids = ",".join(_sid(s.get("id", "")) for s in sink_details)
         lines.append(f"    class {sink_ids} sink")
 
     return "\n".join(lines)

--- a/packages/diagram/findings_summary.py
+++ b/packages/diagram/findings_summary.py
@@ -6,6 +6,7 @@ Input: findings.json (from /validate) or orchestrated_report.json results (from 
 from typing import Any, Dict, List, Tuple
 
 from core.reporting.formatting import get_display_status, title_case_type
+from .sanitize import sanitize as _sanitize
 
 # Verdict colours — neutral palette, no red/green value judgement.
 # Exploitable vs Ruled Out is perspective-dependent (attacker vs defender).
@@ -74,6 +75,6 @@ def _pie_with_colours(title: str, slices: List[Tuple[str, int, str]]) -> str:
         f"pie title {title}",
     ]
     for label, count, _colour in slices:
-        lines.append(f'    "{label}" : {count}')
+        lines.append(f'    "{_sanitize(label)}" : {count}')
 
     return "\n".join(lines)

--- a/packages/diagram/flow_trace.py
+++ b/packages/diagram/flow_trace.py
@@ -16,7 +16,7 @@ from .sanitize import sanitize as _sanitize, sanitize_id as _sid
 
 def _step_label(step: dict[str, Any]) -> str:
     n = _sanitize(step.get("step", "?"))
-    stype = _sanitize(step.get("type", "call")).upper()
+    stype = _sanitize(str(step.get("type", "call")).upper())
     desc = _sanitize(step.get("description", ""))
     tainted = _sanitize(step.get("tainted_var", ""))
     loc = _sanitize(step.get("definition") or step.get("call_site") or "")

--- a/packages/diagram/flow_trace.py
+++ b/packages/diagram/flow_trace.py
@@ -11,16 +11,16 @@ from core.json import load_json
 from pathlib import Path
 from typing import Any
 
-from .sanitize import sanitize as _sanitize
+from .sanitize import sanitize as _sanitize, sanitize_id as _sid
 
 
 def _step_label(step: dict[str, Any]) -> str:
-    n = step.get("step", "?")
-    stype = step.get("type", "call").upper()
+    n = _sanitize(step.get("step", "?"))
+    stype = _sanitize(step.get("type", "call")).upper()
     desc = _sanitize(step.get("description", ""))
     tainted = _sanitize(step.get("tainted_var", ""))
-    loc = step.get("definition") or step.get("call_site") or ""
-    confidence = step.get("confidence", "")
+    loc = _sanitize(step.get("definition") or step.get("call_site") or "")
+    confidence = _sanitize(step.get("confidence", ""))
 
     parts = [f"[{n}] {stype}"]
     if loc:
@@ -64,18 +64,23 @@ def _step_node_shape(step: dict[str, Any]) -> tuple[str, str]:
     return "[", "]"
 
 
+def _step_node_id(step: dict[str, Any], fallback: int | str = "?") -> str:
+    """Return a safe Mermaid node ID for a flow-trace step."""
+    return _sid(f"S{step.get('step', fallback)}")
+
+
 def generate(data: dict[str, Any]) -> str:
     trace_id = data.get("id", "TRACE")
     name = _sanitize(data.get("name", trace_id))
     steps = data.get("steps", [])
     branches = data.get("branches", [])
     attacker_control = data.get("attacker_control", {})
-    summary = data.get("summary", {})
+
 
     if not steps:
         return f"flowchart TD\n    EMPTY[\"No steps in {trace_id}\"]"
 
-    lines = [f"flowchart TD"]
+    lines = ["flowchart TD"]
     lines.append(f'    TITLE["{name}"]')
     lines.append("    style TITLE fill:#f0f0f0,stroke:#999,font-weight:bold")
     lines.append("")
@@ -83,8 +88,7 @@ def generate(data: dict[str, Any]) -> str:
     node_ids: list[str] = ["TITLE"]
 
     for step in steps:
-        n = step.get("step", len(node_ids))
-        nid = f"S{n}"
+        nid = _step_node_id(step, len(node_ids))
         label = _step_label(step)
         open_ch, close_ch = _step_node_shape(step)
         lines.append(f'    {nid}{open_ch}"{label}"{close_ch}')
@@ -122,8 +126,7 @@ def generate(data: dict[str, Any]) -> str:
                 call_site = step.get("call_site", "") or ""
                 defn = step.get("definition", "") or ""
                 if branch_point_raw and (branch_point_raw in call_site or branch_point_raw in defn):
-                    sn = step.get("step")
-                    lines.append(f"    S{sn} -. \"branch\" .-> {bid}")
+                    lines.append(f"    {_step_node_id(step)} -. \"branch\" .-> {bid}")
                     attached = True
                     break
 
@@ -147,8 +150,7 @@ def generate(data: dict[str, Any]) -> str:
                                 best_dist = dist
                                 best_step = step
                     if best_step is not None:
-                        sn = best_step.get("step")
-                        lines.append(f"    S{sn} -. \"branch\" .-> {bid}")
+                        lines.append(f"    {_step_node_id(best_step)} -. \"branch\" .-> {bid}")
                         attached = True
 
             # --- pass 3: attach to first real step ---
@@ -156,7 +158,7 @@ def generate(data: dict[str, Any]) -> str:
                 lines.append(f"    {node_ids[1]} -. \"branch\" .-> {bid}")
 
     # Attacker control summary node
-    level = attacker_control.get("level", "")
+    level = _sanitize(attacker_control.get("level", ""))
     what = _sanitize(attacker_control.get("what", ""))
     if level and what:
         lines.append("")
@@ -165,9 +167,9 @@ def generate(data: dict[str, Any]) -> str:
         lines.append("    style CTRL fill:#fef9c3,stroke:#ca8a04")
 
     # Style: entry=blue, sink=red, call=default
-    entry_ids = ",".join(f"S{s['step']}" for s in steps if s.get("type") == "entry")
-    sink_ids = ",".join(f"S{s['step']}" for s in steps if s.get("type") == "sink")
-    sanitize_ids = ",".join(f"S{s['step']}" for s in steps if s.get("type") == "sanitize")
+    entry_ids = ",".join(_step_node_id(s) for s in steps if s.get("type") == "entry")
+    sink_ids = ",".join(_step_node_id(s) for s in steps if s.get("type") == "sink")
+    sanitize_ids = ",".join(_step_node_id(s) for s in steps if s.get("type") == "sanitize")
 
     lines.append("")
     lines.append("    classDef entry fill:#dbeafe,stroke:#3b82f6,color:#1e3a5f")

--- a/packages/diagram/flow_trace.py
+++ b/packages/diagram/flow_trace.py
@@ -158,11 +158,11 @@ def generate(data: dict[str, Any]) -> str:
                 lines.append(f"    {node_ids[1]} -. \"branch\" .-> {bid}")
 
     # Attacker control summary node
-    level = _sanitize(attacker_control.get("level", ""))
+    level = _sanitize(str(attacker_control.get("level", "")).upper())
     what = _sanitize(attacker_control.get("what", ""))
     if level and what:
         lines.append("")
-        ac_label = f"Attacker control: {level.upper()}\\n{what}"
+        ac_label = f"Attacker control: {level}\\n{what}"
         lines.append(f'    CTRL["{ac_label}"]')
         lines.append("    style CTRL fill:#fef9c3,stroke:#ca8a04")
 

--- a/packages/diagram/hypotheses.py
+++ b/packages/diagram/hypotheses.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from core.json import load_json
-from .sanitize import sanitize as _sanitize
+from .sanitize import sanitize as _sanitize, sanitize_id as _sid
 
 
 _STATUS_SYMBOL = {
@@ -25,10 +25,10 @@ _STATUS_SYMBOL = {
 
 
 def _prediction_label(pred: dict) -> str:
-    pid = pred.get("id", "?")
+    pid = _sanitize(pred.get("id", "?"))
     prediction = _sanitize(pred.get("prediction", pred.get("test", "")))
     result = _sanitize(pred.get("result", ""))
-    status = pred.get("status", "testing")
+    status = _sanitize(pred.get("status", "testing"))
 
     short_pred = prediction if len(prediction) <= 70 else prediction[:67] + "..."
     parts = [f"{pid} [{status}]", short_pred]
@@ -39,10 +39,10 @@ def _prediction_label(pred: dict) -> str:
 
 
 def _hyp_label(hyp: dict) -> str:
-    hid = hyp.get("id", "?")
+    hid = _sanitize(hyp.get("id", "?"))
     claim = _sanitize(hyp.get("claim") or hyp.get("hypothesis", ""))
-    status = hyp.get("status", "testing")
-    finding = hyp.get("finding") or hyp.get("finding_id", "")
+    status = _sanitize(hyp.get("status", "testing"))
+    finding = _sanitize(hyp.get("finding") or hyp.get("finding_id", ""))
 
     parts = [f"{hid}"]
     if finding:
@@ -84,7 +84,7 @@ def generate(hypotheses: list[dict[str, Any]]) -> str:
         nid = next_id("HN")
         hyp_node_ids[hid] = nid
         label = _hyp_label(hyp)
-        status = hyp.get("status", "testing")
+        status = _sanitize(hyp.get("status", "testing"))
         if status == "confirmed":
             lines.append(f'{indent}{nid}["{label}"]')
         elif status == "disproven":
@@ -96,7 +96,7 @@ def generate(hypotheses: list[dict[str, Any]]) -> str:
         for pred in hyp.get("predictions", []):
             pnid = next_id("PN")
             plabel = _prediction_label(pred)
-            pstatus = pred.get("status", "testing")
+            pstatus = _sanitize(pred.get("status", "testing"))
             if pstatus == "confirmed":
                 lines.append(f'{indent}{pnid}["{plabel}"]')
             elif pstatus == "disproven":
@@ -110,7 +110,7 @@ def generate(hypotheses: list[dict[str, Any]]) -> str:
     # Emit by finding subgraphs
     finding_hyp_nodes: dict[str, list[str]] = {}
     for fid, hyps in by_finding.items():
-        lines.append(f'    subgraph {fid.replace("-", "_")} ["{fid}"]')
+        lines.append(f'    subgraph {_sid(fid)} ["{_sanitize(fid)}"]')
         hyp_nodes = []
         for hyp in hyps:
             nid = emit_hypothesis(hyp, indent="        ")
@@ -139,7 +139,7 @@ def generate(hypotheses: list[dict[str, Any]]) -> str:
         nid = hyp_node_ids.get(hid)
         if not nid:
             continue
-        status = hyp.get("status", "testing")
+        status = _sanitize(hyp.get("status", "testing"))
         if status == "confirmed":
             confirmed_nodes.append(nid)
         elif status == "disproven":

--- a/packages/diagram/sanitize.py
+++ b/packages/diagram/sanitize.py
@@ -26,6 +26,9 @@ def sanitize(text: str, max_len: int = None) -> str:
         .replace("{", "(")
         .replace("}", ")")
         .replace("\n", " ")
+        .replace("\r", " ")
+        .replace("\u2028", " ")
+        .replace("\u2029", " ")
     )
     if max_len and len(result) > max_len:
         result = result[:max_len - 3] + "..."
@@ -41,5 +44,5 @@ def sanitize_id(node_id: str) -> str:
 
     Strips everything except [A-Za-z0-9_-].
     """
-    sanitized = _SAFE_ID_RE.sub('_', str(node_id)).strip('_')
-    return sanitized or "node"
+    sanitized = _SAFE_ID_RE.sub('_', str(node_id))
+    return sanitized if sanitized.strip('_') else "node"

--- a/packages/diagram/sanitize.py
+++ b/packages/diagram/sanitize.py
@@ -19,6 +19,7 @@ def sanitize(text: str, max_len: int = None) -> str:
     """
     result = (
         str(text)
+        .replace("&", "&amp;")
         .replace('"', "'")
         .replace("<", "&lt;")
         .replace(">", "&gt;")
@@ -40,4 +41,5 @@ def sanitize_id(node_id: str) -> str:
 
     Strips everything except [A-Za-z0-9_-].
     """
-    return _SAFE_ID_RE.sub('_', str(node_id)) or "node"
+    sanitized = _SAFE_ID_RE.sub('_', str(node_id)).strip('_')
+    return sanitized or "node"

--- a/packages/diagram/sanitize.py
+++ b/packages/diagram/sanitize.py
@@ -12,9 +12,16 @@ _SAFE_ID_RE = re.compile(r'[^A-Za-z0-9_-]')
 def sanitize(text: str, max_len: int = None) -> str:
     """Escape characters that break Mermaid node labels.
 
+    This sanitizer is for quoted node labels and similarly quoted text. It does
+    not escape ``|`` because Mermaid uses that character as edge-label syntax;
+    callers must not pass user-controlled text into unquoted edge labels.
+
     Args:
         text: Raw label text.
-        max_len: Truncate to this length with '...' suffix.
+        max_len: Truncate the escaped text to this length with '...' suffix.
+                 Because truncation happens after HTML entity escaping, the
+                 result may cut through an entity (for example, ``&am...``);
+                 this is cosmetic only, not a Mermaid injection boundary.
                  Pass None to disable truncation (default).
     """
     result = (

--- a/packages/diagram/tests/test_diagram.py
+++ b/packages/diagram/tests/test_diagram.py
@@ -536,6 +536,27 @@ class TestFlowTrace:
         assert_no_mermaid_directive_injection(out)
         assert_usable_mermaid_flowchart(out)
 
+    def test_uppercase_step_type_preserves_escaped_entities(self):
+        out = gen_flow_trace({
+            "id": "TRACE-X",
+            "name": "trace",
+            "steps": [{"step": 1, "type": "<sink>", "definition": "src/db.py:50"}],
+        })
+        assert "&lt;SINK&gt;" in out
+        assert "&LT;" not in out
+        assert "&GT;" not in out
+
+    def test_uppercase_attacker_control_level_preserves_escaped_entities(self):
+        out = gen_flow_trace({
+            "id": "TRACE-X",
+            "name": "trace",
+            "steps": [{"step": 1, "type": "entry", "definition": "src/routes.py:10"}],
+            "attacker_control": {"level": "<high>", "what": "query"},
+        })
+        assert "Attacker control: &lt;HIGH&gt;" in out
+        assert "&LT;" not in out
+        assert "&GT;" not in out
+
 
 # ---------------------------------------------------------------------------
 # attack_tree tests
@@ -636,6 +657,20 @@ class TestAttackTree:
         }
         hypotheses = [{"finding": "N1", "status": payload, "claim": payload}]
         assert_no_mermaid_directive_injection(gen_attack_tree(tree, hypotheses=hypotheses))
+
+    def test_status_group_keys_do_not_keep_raw_status_text(self):
+        payload = "unexpected<script>"
+        tree = {
+            "root": "ROOT",
+            "nodes": [
+                {"id": "ROOT", "goal": "root", "status": payload, "leads_to": "N1"},
+                {"id": "N1", "goal": "child", "status": "confirmed", "leads_to": ""},
+            ],
+        }
+        out = gen_attack_tree(tree)
+        class_lines = [line for line in out.splitlines() if line.strip().startswith("class ")]
+        assert "unexpected<script>" not in "\n".join(class_lines)
+        assert any(line.strip() == "class ROOT unexplored" for line in class_lines)
 
 
 # ---------------------------------------------------------------------------
@@ -748,6 +783,17 @@ class TestAttackPaths:
             ],
         }, 0)
         assert_no_mermaid_directive_injection(out)
+
+    def test_uppercase_step_type_preserves_escaped_entities(self):
+        out = generate_single({
+            "id": "PATH-X",
+            "name": "path",
+            "status": "confirmed",
+            "steps": [{"step": 1, "type": "<sink>", "definition": "src/db.py:50"}],
+        }, 0)
+        assert "&lt;SINK&gt;" in out
+        assert "&LT;" not in out
+        assert "&GT;" not in out
 
     def test_sanitized_attack_path_is_still_usable_mermaid(self):
         payload = "X\"]\n    click X javascript:alert(1)\n    Y[\""

--- a/packages/diagram/tests/test_diagram.py
+++ b/packages/diagram/tests/test_diagram.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from ..sanitize import sanitize
+from ..sanitize import sanitize, sanitize_id
 from ..findings_summary import generate_verdict_pie, generate_type_pie
 from ..context_map import generate as gen_context_map
 from ..flow_trace import generate as gen_flow_trace
@@ -49,6 +49,23 @@ class TestSanitize:
     def test_no_truncation_by_default(self):
         long = "a" * 200
         assert len(sanitize(long)) == 200
+
+    def test_ampersand_escaped_before_angle_brackets(self):
+        result = sanitize("Tom & Jerry <script>")
+        assert "&amp;" in result
+        assert "&lt;script&gt;" in result
+
+    def test_sanitize_id_removes_mermaid_callback_injection_chars(self):
+        payload = "node1; click node1 javascript:alert(1)"
+        result = sanitize_id(payload)
+        assert ";" not in result
+        assert " " not in result
+        assert ":" not in result
+        assert "(" not in result
+        assert ")" not in result
+
+    def test_sanitize_id_never_returns_empty(self):
+        assert sanitize_id("!@#$%^*()[]{}") == "node"
 
 
 # ---------------------------------------------------------------------------
@@ -288,6 +305,25 @@ class TestContextMap:
         assert '"test>' not in out
         # HTML-escaped angle brackets should be present
         assert "&lt;" in out or "&gt;" in out
+
+    def test_class_assignments_use_sanitized_ids(self):
+        data = {
+            "entry_points": [
+                {"id": "EP-001; click EP-001 javascript:alert(1)", "path": "/"}
+            ],
+            "boundary_details": [
+                {"id": "TB-001; click TB-001 javascript:alert(1)", "covers": []}
+            ],
+            "sink_details": [
+                {"id": "SINK-001; click SINK-001 javascript:alert(1)", "operation": "sink"}
+            ],
+        }
+        out = gen_context_map(data)
+        class_lines = [line.strip() for line in out.splitlines() if line.strip().startswith("class ")]
+        assert class_lines
+        assert all(";" not in line for line in class_lines)
+        assert all("javascript:" not in line for line in class_lines)
+        assert all(" click " not in line for line in class_lines)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/diagram/tests/test_diagram.py
+++ b/packages/diagram/tests/test_diagram.py
@@ -17,6 +17,11 @@ from ..hypotheses import generate as gen_hypotheses
 from ..renderer import render_directory, render_and_write
 
 
+def assert_no_mermaid_directive_injection(output: str) -> None:
+    """Assert payloads did not break out into Mermaid directive lines."""
+    assert "\n    click " not in output.lower()
+
+
 # ---------------------------------------------------------------------------
 # sanitize tests
 # ---------------------------------------------------------------------------
@@ -66,6 +71,16 @@ class TestSanitize:
 
     def test_sanitize_id_never_returns_empty(self):
         assert sanitize_id("!@#$%^*()[]{}") == "node"
+
+    def test_sanitize_id_preserves_replacement_position(self):
+        assert sanitize_id("A!") == "A_"
+        assert sanitize_id("!A") == "_A"
+
+    def test_line_separator_chars_removed(self):
+        result = sanitize("safe\rclick X javascript:alert(1)\u2028more\u2029text")
+        assert "\r" not in result
+        assert "\u2028" not in result
+        assert "\u2029" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -118,6 +133,11 @@ class TestFindingsSummary:
         out = generate_verdict_pie(findings)
         assert "Exploitable" in out
         assert "False Positive" in out
+
+    def test_pie_labels_are_sanitized(self):
+        payload = "xss\"\n    click X javascript:alert(1)\n    X[\""
+        out = generate_type_pie([{"vuln_type": payload}])
+        assert_no_mermaid_directive_injection(out)
 
 
 # ---------------------------------------------------------------------------
@@ -324,6 +344,9 @@ class TestContextMap:
         assert all(";" not in line for line in class_lines)
         assert all("javascript:" not in line for line in class_lines)
         assert all(" click " not in line for line in class_lines)
+        assert f"class {sanitize_id(data['entry_points'][0]['id'])} ep" in out
+        assert f"class {sanitize_id(data['boundary_details'][0]['id'])} tb" in out
+        assert f"class {sanitize_id(data['sink_details'][0]['id'])} sink" in out
 
 
 # ---------------------------------------------------------------------------
@@ -417,6 +440,46 @@ class TestFlowTrace:
         assert "S2 -. \"branch\" .-> BR1" in out
 
 
+    def test_step_ids_and_class_assignments_are_sanitized(self):
+        data = {
+            "id": "TRACE-X",
+            "name": "malicious step id",
+            "steps": [
+                {
+                    "step": "1; click S1 javascript:alert(1)",
+                    "type": "entry",
+                    "definition": "src/routes.py:10",
+                    "description": "entry",
+                }
+            ],
+            "branches": [{"branch_point": "src/routes.py:10", "condition": "x", "outcome": "y"}],
+        }
+        out = gen_flow_trace(data)
+        assert_no_mermaid_directive_injection(out)
+        assert "class S1__click_S1_javascript_alert_1_ entry" in out
+        assert "S1__click_S1_javascript_alert_1_ -. \"branch\" .-> BR1" in out
+
+    def test_label_fields_do_not_escape_into_directives(self):
+        payload = "X\"]\n    click X javascript:alert(1)\n    Y[\""
+        data = {
+            "id": "TRACE-X",
+            "name": payload,
+            "steps": [
+                {
+                    "step": 1,
+                    "type": payload,
+                    "definition": payload,
+                    "description": payload,
+                    "tainted_var": payload,
+                    "confidence": payload,
+                }
+            ],
+            "branches": [{"branch_point": payload, "condition": payload, "outcome": payload}],
+            "attacker_control": {"level": payload, "what": payload},
+        }
+        assert_no_mermaid_directive_injection(gen_flow_trace(data))
+
+
 # ---------------------------------------------------------------------------
 # attack_tree tests
 # ---------------------------------------------------------------------------
@@ -505,6 +568,19 @@ class TestAttackTree:
         assert "subgraph" not in out
 
 
+    def test_status_and_hypothesis_enrichment_are_sanitized(self):
+        payload = "X\"]\n    click X javascript:alert(1)\n    Y[\""
+        tree = {
+            "root": "ROOT",
+            "nodes": [
+                {"id": "ROOT", "goal": "root", "status": payload, "leads_to": "N1"},
+                {"id": "N1", "goal": "child", "status": "confirmed", "leads_to": ""},
+            ],
+        }
+        hypotheses = [{"finding": "N1", "status": payload, "claim": payload}]
+        assert_no_mermaid_directive_injection(gen_attack_tree(tree, hypotheses=hypotheses))
+
+
 # ---------------------------------------------------------------------------
 # hypotheses tests
 # ---------------------------------------------------------------------------
@@ -548,6 +624,23 @@ class TestHypotheses:
         assert "\u2014" not in out
 
 
+    def test_subgraph_and_label_fields_are_sanitized(self):
+        payload = "F1; click F1 javascript:alert(1)"
+        label_payload = "X\"]\n    click X javascript:alert(1)\n    Y[\""
+        data = [{
+            "id": label_payload,
+            "finding": payload,
+            "status": label_payload,
+            "claim": label_payload,
+            "predictions": [
+                {"id": label_payload, "prediction": label_payload, "result": label_payload, "status": label_payload}
+            ],
+        }]
+        out = gen_hypotheses(data)
+        assert_no_mermaid_directive_injection(out)
+        assert "subgraph F1__click_F1_javascript_alert_1_" in out
+
+
 # ---------------------------------------------------------------------------
 # attack_paths tests
 # ---------------------------------------------------------------------------
@@ -579,6 +672,25 @@ class TestAttackPaths:
         assert "P0S1" in out
         assert "P0S2" in out
         assert "P0S1 --> P0S2" in out
+
+
+    def test_step_type_and_location_are_sanitized(self):
+        payload = "X\"]\n    click X javascript:alert(1)\n    Y[\""
+        out = generate_single({
+            "id": "PATH-X",
+            "name": payload,
+            "status": payload,
+            "steps": [
+                {
+                    "step": 1,
+                    "type": payload,
+                    "definition": payload,
+                    "description": payload,
+                    "tainted_var": payload,
+                }
+            ],
+        }, 0)
+        assert_no_mermaid_directive_injection(out)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/diagram/tests/test_diagram.py
+++ b/packages/diagram/tests/test_diagram.py
@@ -2,10 +2,7 @@
 """Tests for the diagram generation package."""
 
 import json
-import tempfile
 from pathlib import Path
-
-import pytest
 
 from ..sanitize import sanitize, sanitize_id
 from ..findings_summary import generate_verdict_pie, generate_type_pie
@@ -20,6 +17,35 @@ from ..renderer import render_directory, render_and_write
 def assert_no_mermaid_directive_injection(output: str) -> None:
     """Assert payloads did not break out into Mermaid directive lines."""
     assert "\n    click " not in output.lower()
+
+
+def assert_usable_mermaid_flowchart(output: str) -> None:
+    """Assert generated Mermaid remains a recognizable, renderable flowchart."""
+    lines = [line.rstrip() for line in output.splitlines() if line.strip()]
+    assert lines, "Mermaid output is empty"
+    assert lines[0] in {"flowchart TD", "flowchart LR"}
+    assert any("-->" in line or "-." in line for line in lines), "flowchart has no edges"
+    assert any("[\"" in line or "[/\"" in line or "([\"" in line for line in lines), "flowchart has no labelled nodes"
+    assert "```" not in output, "raw flowchart generators should not emit markdown fences"
+
+
+def extract_mermaid_blocks(markdown: str) -> list[str]:
+    """Return the contents of fenced Mermaid blocks from rendered markdown."""
+    blocks: list[str] = []
+    in_block = False
+    current: list[str] = []
+    for line in markdown.splitlines():
+        if line.strip() == "```mermaid":
+            in_block = True
+            current = []
+            continue
+        if in_block and line.strip() == "```":
+            blocks.append("\n".join(current).strip())
+            in_block = False
+            continue
+        if in_block:
+            current.append(line)
+    return blocks
 
 
 # ---------------------------------------------------------------------------
@@ -326,6 +352,22 @@ class TestContextMap:
         # HTML-escaped angle brackets should be present
         assert "&lt;" in out or "&gt;" in out
 
+    def test_sanitized_context_map_is_still_usable_mermaid(self):
+        data = {
+            "entry_points": [
+                {"id": "EP-001; click EP-001 javascript:alert(1)", "path": "/api/<tenant>"}
+            ],
+            "boundary_details": [
+                {"id": "TB-001; click TB-001 javascript:alert(1)", "covers": ["EP-001"]}
+            ],
+            "sink_details": [
+                {"id": "SINK-001; click SINK-001 javascript:alert(1)", "operation": "open().write()"}
+            ],
+        }
+        out = gen_context_map(data)
+        assert_no_mermaid_directive_injection(out)
+        assert_usable_mermaid_flowchart(out)
+
     def test_class_assignments_use_sanitized_ids(self):
         data = {
             "entry_points": [
@@ -479,6 +521,21 @@ class TestFlowTrace:
         }
         assert_no_mermaid_directive_injection(gen_flow_trace(data))
 
+    def test_sanitized_flow_trace_is_still_usable_mermaid(self):
+        payload = "X\"]\n    click X javascript:alert(1)\n    Y[\""
+        data = {
+            "id": "TRACE-X",
+            "name": payload,
+            "steps": [
+                {"step": 1, "type": "entry", "definition": "src/routes.py:10", "description": payload},
+                {"step": 2, "type": "sink", "definition": "src/db.py:50", "description": "write"},
+            ],
+            "branches": [{"branch_point": "src/routes.py:10", "condition": payload, "outcome": payload}],
+        }
+        out = gen_flow_trace(data)
+        assert_no_mermaid_directive_injection(out)
+        assert_usable_mermaid_flowchart(out)
+
 
 # ---------------------------------------------------------------------------
 # attack_tree tests
@@ -518,7 +575,7 @@ class TestAttackTree:
         out = gen_attack_tree(ATTACK_TREE_DATA)
         # N1 and N2 have empty leads_to, so no outgoing edges from them
         lines = out.splitlines()
-        n1_edges = [l for l in lines if l.strip().startswith("N1 -->")]
+        n1_edges = [line for line in lines if line.strip().startswith("N1 -->")]
         assert not n1_edges
 
     def test_confirmed_node_shows_proximity_when_provided(self):
@@ -692,6 +749,21 @@ class TestAttackPaths:
         }, 0)
         assert_no_mermaid_directive_injection(out)
 
+    def test_sanitized_attack_path_is_still_usable_mermaid(self):
+        payload = "X\"]\n    click X javascript:alert(1)\n    Y[\""
+        out = generate_single({
+            "id": "PATH-X",
+            "name": payload,
+            "status": "confirmed",
+            "proximity": 8,
+            "steps": [
+                {"step": 1, "type": "entry", "definition": "src/routes.py:10", "description": payload},
+                {"step": 2, "type": "sink", "definition": "src/db.py:50", "description": "write"},
+            ],
+        }, 0)
+        assert_no_mermaid_directive_injection(out)
+        assert_usable_mermaid_flowchart(out)
+
 
 # ---------------------------------------------------------------------------
 # renderer tests
@@ -751,6 +823,28 @@ class TestRenderer:
         assert "Attack Paths" in out
         assert "Hypotheses" in out
         assert out.count("```mermaid") >= 5
+
+    def test_rendered_mermaid_blocks_have_usable_entrypoints(self, tmp_path):
+        self._make_out_dir(tmp_path, {
+            "context-map.json": CONTEXT_MAP_FULL,
+            "flow-trace-EP-001.json": FLOW_TRACE_DATA,
+            "attack-tree.json": ATTACK_TREE_DATA,
+            "attack-paths.json": ATTACK_PATHS_DATA,
+            "hypotheses.json": HYPOTHESES_DATA,
+            "findings.json": {
+                "findings": [
+                    {"ruling": {"status": "exploitable"}, "vuln_type": "buffer_overflow"},
+                    {"ruling": {"status": "confirmed"}, "vuln_type": "xss"},
+                ]
+            },
+        })
+        blocks = extract_mermaid_blocks(render_directory(tmp_path, target="full-run"))
+        assert blocks
+        assert all(
+            block.startswith(("flowchart TD", "flowchart LR", "pie title", "%%{init:"))
+            for block in blocks
+        )
+        assert all("\n```" not in block for block in blocks)
 
     def test_render_attack_tree_enriched_with_companions(self, tmp_path):
         disproven_wrapped = {"disproven": [{"finding": "N2", "why_wrong": "suppressed errors", "lesson": ""}]}


### PR DESCRIPTION
## Summary

This PR tightens RAPTOR's Mermaid diagram sanitization and regression coverage across diagram generators.

Changes:
- escape ampersands before angle brackets and normalize additional line separators in diagram labels;
- keep `sanitize_id()` collision-resistant while still falling back to `node` when an ID contains no safe characters;
- use sanitized IDs in context-map `class` assignments, matching sanitized node declarations;
- sanitize flow-trace step-derived IDs before node, edge, and class emission;
- sanitize label fields in flow traces, hypotheses, attack paths, attack-tree enrichment, and findings-summary pie labels;
- add regression tests for callback-shaped Mermaid payloads, quoted-label breakout attempts, subgraph IDs, class assignments, and pie labels.

## Why

Mermaid node IDs and some directive-like constructs are not quoted. RAPTOR already sanitized several node declarations, but a review pass found additional places where attacker-controlled report data could still be rendered into IDs, class assignments, subgraph declarations, or quoted labels without going through the shared sanitizer. These paths matter because RAPTOR diagrams are generated from analysis artifacts and may be viewed in Mermaid-capable renderers.

## Self-review loops

I ran three improvement passes over the PR:

1. Sanitizer helper pass: added ID fallback/collision checks and line-separator normalization coverage.
2. Context/flow pass: checked class/edge/node sinks and added flow-trace regressions.
3. Cross-generator pass: checked hypotheses, attack paths, attack tree, and findings-summary pie labels for directive breakout cases.

## Files changed

| File | Change |
| --- | --- |
| `packages/diagram/sanitize.py` | Escape `&`, normalize additional line separators, and preserve safe ID replacement positions while retaining empty-ID fallback. |
| `packages/diagram/context_map.py` | Reuse `sanitize_id()` for class assignment IDs. |
| `packages/diagram/flow_trace.py` | Sanitize step-derived node IDs and user-controlled label fields. |
| `packages/diagram/hypotheses.py` | Sanitize subgraph IDs and hypothesis/prediction label fields. |
| `packages/diagram/attack_paths.py` | Sanitize step type and location label fields. |
| `packages/diagram/attack_tree.py` | Sanitize status/enrichment labels. |
| `packages/diagram/findings_summary.py` | Sanitize pie-slice labels before Mermaid emission. |
| `packages/diagram/tests/test_diagram.py` | Add sanitizer and generator regression tests. |

## Test plan

Validated against `8106a0c61af556fdf86ae3fb23cd0e5445948872`:

- [x] `python -m pytest packages/diagram/tests/test_diagram.py -q` — 80 passed
- [x] `python -m compileall -q packages/diagram core/security`
- [x] `git diff --check`
- [x] `python -m ruff check --ignore F401,E741 packages/diagram/sanitize.py packages/diagram/context_map.py packages/diagram/flow_trace.py packages/diagram/hypotheses.py packages/diagram/attack_paths.py packages/diagram/attack_tree.py packages/diagram/findings_summary.py packages/diagram/tests/test_diagram.py`
- [x] added-line scan for obvious fake/real secrets and dangerous Python execution sinks

Note: `ruff format --check` would reformat the legacy diagram test file broadly, so I left formatting churn out of this focused PR.
