### PR TITLE
SMT: bridge /understand flow traces into Stage E feasibility

### DIFF
--- a/.claude/skills/code-understanding/trace.md
+++ b/.claude/skills/code-understanding/trace.md
@@ -52,6 +52,21 @@ Identify all branches in the flow — not just the happy path:
 
 Trace each significant branch separately.
 
+**[TRACE-3b] Path Conditions (for SMT consumption)**
+
+Separately from `branches[]` (which describes *alternative* paths), record the **conjunction of guards on the dangerous path** — every condition that must hold for execution to actually reach the sink along the trace you've followed. These are downstream-consumed by the SMT path-feasibility helper (`raptor-smt-validate-path`), so emit them as simple bitvector predicates over named variables:
+
+  - Numeric comparisons: `"size > 0"`, `"offset + length <= buffer_size"`, `"count * 16 < max_alloc"`
+  - Null checks: `"ptr != NULL"`, `"ptr == NULL"`
+  - Bitmask: `"flags & 0x80000000 == 0"`
+  - Negated form (the guard was *bypassed* on the dangerous path): `{"text": "validate(input)", "negated": true}` — but most negations come out clearer as the inverted predicate (`ptr == NULL` instead of `!ptr != NULL`).
+
+For each condition, also record the `step_index` it gates so consumers can correlate back to `steps[]`.
+
+**Avoid:** function calls (`strlen(input)`), type casts (`(uint32_t)x`), struct/array access (`obj.field`, `arr[0]`), pointer deref (`*p`) — the SMT parser can't encode these. Either simplify into a bitvector predicate or omit; "missing" is far better than "wrong shape".
+
+Also pick a `path_profile` describing the dominant C type along the path — `"uint32"` for `int`/`unsigned int` arithmetic, `"uint64"` for `size_t`/`uint64_t`/pointers (default), `"int32"` for signed-overflow UB reasoning. Pre-made profiles: `uint8`, `int8`, `uint16`, `int16`, `uint32`, `int32`, `uint64`, `int64`. Pick one that matches the dominant arithmetic type on the path.
+
 **[TRACE-4] Sink Analysis**
 
 At each sink, record:
@@ -124,6 +139,11 @@ Summarize what the attacker controls:
       "outcome": "Bypasses auth middleware entirely — tainted data reaches same sink via shorter path"
     }
   ],
+  "path_conditions": [
+    {"text": "len(query) > 0", "step_index": 1, "negated": false},
+    {"text": "table != NULL", "step_index": 3, "negated": false}
+  ],
+  "path_profile": "uint64",
   "attacker_control": {
     "level": "full|partial|none",
     "what": "Full control over `query` field via POST body",
@@ -142,6 +162,8 @@ Summarize what the attacker controls:
 ```
 
 **Schema note:** `steps[]`, `proximity` (0–10 score: 10 = at the sink, 0 = no viable path), and `blockers[]` are shared with `attack-paths.json` from the validation pipeline. What this means is that a flow-trace can be consumed directly by Stage B. `branches`, `attacker_control`, and `summary` are trace-specific extensions.
+
+`path_conditions` and `path_profile` are forwarded by `core/orchestration/understand_bridge.py` into `attack-paths.json` so /validate's Stage E can feed them straight to the SMT path-feasibility helper without re-extracting from source. Both fields are optional — omit if the trace doesn't lend itself to bitvector predicates (e.g., string/format findings) and Stage E will fall back to its own reasoning.
 
 ## Teach Mode Integration
 

--- a/.claude/skills/exploitability-validation/stage-e-feasibility.md
+++ b/.claude/skills/exploitability-validation/stage-e-feasibility.md
@@ -161,6 +161,18 @@ libexec/raptor-smt-validate-path --profile uint32 \
 
 Each positional argument is one predicate that must hold for the path to be reachable. If a guard is bypassed (must be FALSE on the dangerous path), pre-negate it manually: write `ptr == NULL`, not `!(ptr != NULL)`.
 
+**Prefer pre-extracted conditions when available.** If the finding has an imported attack path (look in `attack-paths.json` for entries with `source: "understand:trace"`) carrying `path_conditions` and `path_profile`, use them via the `--from-trace` form — they were extracted by `/understand --trace` with full source-code context for that flow:
+
+```bash
+libexec/raptor-smt-validate-path --from-trace TRACE-001 --workdir "$OUTPUT_DIR"
+```
+
+The script reads `attack-paths.json` itself, picks the matching trace, and applies its `path_profile`. You can override the profile with an explicit `--profile <name>` if the trace's choice doesn't match the vuln's real C type. Outcomes:
+
+- `path_conditions` missing / `null` → script exits 2 with a clear message; fall back to extracting from source (positional args / `--stdin` form above).
+- `path_conditions: []` (empty list) → script exits 0 with `feasible: true` and `reasoning: "no conditions ..."`. The path is unconditionally reachable from the entry; no re-extraction needed.
+- `path_conditions` non-empty → normal SMT verdict.
+
 **Tip — finding the *exploit* witness, not the trivial one:** Z3 returns the smallest satisfying assignment by default, which is often `count=0`, `length=0`, etc. — mathematically correct but not the bug. Add a lower-bound condition that forces the dangerous range. For the CWE-190 ALLOC pattern above, adding `'count > 0x10000000'` pushes Z3 into the wraparound region and yields a witness like `count=0x30000001, alloc_size=16` (the actual exploit input).
 
 `--profile` matches the C type width in play. Common choices:

--- a/core/orchestration/tests/test_understand_bridge.py
+++ b/core/orchestration/tests/test_understand_bridge.py
@@ -601,6 +601,101 @@ class TestLoadUnderstandContextFlowTraces:
         assert not (validate_dir / "attack-paths.json").exists()
 
 
+class TestPathConditionsForwarding:
+    """Optional ``path_conditions`` and ``path_profile`` fields produced by
+    ``/understand --trace`` should round-trip into ``attack-paths.json``
+    exactly as written, so Stage E can feed them straight to the SMT
+    helper without re-extracting from source.  Malformed values are
+    dropped with a logged warning rather than passed through."""
+
+    def _trace_with(self, **overrides):
+        trace = copy.deepcopy(MINIMAL_FLOW_TRACE)
+        trace.update(overrides)
+        return trace
+
+    def _import_and_get_path(self, tmp_path, trace):
+        understand_dir = tmp_path / "understand"
+        validate_dir = tmp_path / "validate"
+        understand_dir.mkdir()
+        validate_dir.mkdir()
+        _write_json(understand_dir / "context-map.json", MINIMAL_CONTEXT_MAP)
+        _write_json(understand_dir / "flow-trace-001.json", trace)
+        load_understand_context(understand_dir, validate_dir)
+        paths = json.loads((validate_dir / "attack-paths.json").read_text())
+        assert len(paths) == 1
+        return paths[0]
+
+    def test_path_conditions_round_trip(self, tmp_path):
+        trace = self._trace_with(path_conditions=[
+            {"text": "size > 0", "step_index": 1, "negated": False},
+            {"text": "ptr != NULL", "step_index": 2, "negated": False},
+        ])
+        path = self._import_and_get_path(tmp_path, trace)
+        assert path["path_conditions"] == [
+            {"text": "size > 0", "step_index": 1, "negated": False},
+            {"text": "ptr != NULL", "step_index": 2, "negated": False},
+        ]
+
+    def test_path_conditions_bare_strings_round_trip(self, tmp_path):
+        trace = self._trace_with(path_conditions=["size > 0", "count < 1024"])
+        path = self._import_and_get_path(tmp_path, trace)
+        assert path["path_conditions"] == ["size > 0", "count < 1024"]
+
+    def test_path_profile_round_trip(self, tmp_path):
+        trace = self._trace_with(path_profile="uint32")
+        path = self._import_and_get_path(tmp_path, trace)
+        assert path["path_profile"] == "uint32"
+
+    def test_absent_fields_omitted_from_attack_path(self, tmp_path):
+        path = self._import_and_get_path(tmp_path, self._trace_with())
+        assert "path_conditions" not in path
+        assert "path_profile" not in path
+
+    def test_malformed_path_conditions_dropped(self, tmp_path, caplog):
+        # Not a list — entire field dropped
+        trace = self._trace_with(path_conditions="not a list")
+        with caplog.at_level("WARNING", logger="core.orchestration.understand_bridge"):
+            path = self._import_and_get_path(tmp_path, trace)
+        assert "path_conditions" not in path
+        assert any("path_conditions must be a list" in r.message for r in caplog.records)
+
+    def test_path_conditions_with_int_element_dropped(self, tmp_path, caplog):
+        trace = self._trace_with(path_conditions=["size > 0", 42])
+        with caplog.at_level("WARNING", logger="core.orchestration.understand_bridge"):
+            path = self._import_and_get_path(tmp_path, trace)
+        assert "path_conditions" not in path
+
+    def test_path_conditions_dict_missing_text_dropped(self, tmp_path, caplog):
+        trace = self._trace_with(path_conditions=[{"step_index": 1, "negated": False}])
+        with caplog.at_level("WARNING", logger="core.orchestration.understand_bridge"):
+            path = self._import_and_get_path(tmp_path, trace)
+        assert "path_conditions" not in path
+
+    def test_unknown_path_profile_dropped(self, tmp_path, caplog):
+        trace = self._trace_with(path_profile="size_t")
+        with caplog.at_level("WARNING", logger="core.orchestration.understand_bridge"):
+            path = self._import_and_get_path(tmp_path, trace)
+        assert "path_profile" not in path
+        assert any("path_profile must be one of" in r.message for r in caplog.records)
+
+    def test_non_string_path_profile_dropped(self, tmp_path, caplog):
+        trace = self._trace_with(path_profile=32)
+        with caplog.at_level("WARNING", logger="core.orchestration.understand_bridge"):
+            path = self._import_and_get_path(tmp_path, trace)
+        assert "path_profile" not in path
+
+    def test_malformed_field_does_not_break_other_data(self, tmp_path, caplog):
+        """Even when SMT-related fields are malformed, the rest of the
+        attack-path import (steps, proximity, blockers) must still land."""
+        trace = self._trace_with(path_conditions=42, path_profile="bogus")
+        with caplog.at_level("WARNING", logger="core.orchestration.understand_bridge"):
+            path = self._import_and_get_path(tmp_path, trace)
+        assert "path_conditions" not in path
+        assert "path_profile" not in path
+        assert path["steps"] == MINIMAL_FLOW_TRACE["steps"]
+        assert path["proximity"] == MINIMAL_FLOW_TRACE["proximity"]
+
+
 # ---------------------------------------------------------------------------
 # enrich_checklist
 # ---------------------------------------------------------------------------

--- a/core/orchestration/understand_bridge.py
+++ b/core/orchestration/understand_bridge.py
@@ -45,6 +45,14 @@ logger = logging.getLogger(__name__)
 # Stage B uses this to distinguish its own paths from pre-loaded ones.
 TRACE_SOURCE_LABEL = "understand:trace"
 
+# BVProfile name shorthands accepted on the optional ``path_profile`` field
+# of a flow trace.  Mirrors the names accepted by ``raptor-smt-validate-path``
+# so Stage E can pass the value through without translation.
+_VALID_PROFILE_NAMES = frozenset({
+    "uint8", "int8", "uint16", "int16",
+    "uint32", "int32", "uint64", "int64",
+})
+
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -673,7 +681,77 @@ def _trace_to_attack_path(trace: Dict[str, Any], trace_file: Path) -> Dict[str, 
     if summary.get("verdict"):
         path["trace_verdict"] = summary["verdict"]
 
+    # Forward SMT path-feasibility hints when present and well-formed.  Both
+    # fields are optional — Stage E falls back to extracting conditions from
+    # source if absent.  Malformed values are dropped with a logged warning
+    # rather than passed through; better Stage E re-extracts than confuses
+    # itself with bad data.
+    pc = _validate_path_conditions(trace.get("path_conditions"), str(trace_file))
+    if pc is not None:
+        path["path_conditions"] = pc
+    pp = _validate_path_profile(trace.get("path_profile"), str(trace_file))
+    if pp is not None:
+        path["path_profile"] = pp
+
     return path
+
+
+def _validate_path_conditions(
+    conditions: Any, source: str,
+) -> Optional[List[Any]]:
+    """Validate the optional ``path_conditions`` field on a flow trace.
+
+    Returns the conditions list if every element is a string or a
+    ``{"text": str, ...}`` dict (matching the shape
+    ``raptor-smt-validate-path --stdin`` accepts).  Returns ``None`` —
+    dropping the field entirely with a logged warning — if the value is
+    malformed.  Better the consumer re-extracts than confuses itself
+    with bad data.
+    """
+    if conditions is None:
+        return None
+    if not isinstance(conditions, list):
+        logger.warning(
+            "understand_bridge: %s path_conditions must be a list, got %s — dropping",
+            source, type(conditions).__name__,
+        )
+        return None
+    for i, c in enumerate(conditions):
+        if isinstance(c, str):
+            continue
+        if isinstance(c, dict):
+            text = c.get("text") or c.get("condition")
+            if not isinstance(text, str) or not text:
+                logger.warning(
+                    "understand_bridge: %s path_conditions[%d] missing/invalid 'text' — dropping field",
+                    source, i,
+                )
+                return None
+            continue
+        logger.warning(
+            "understand_bridge: %s path_conditions[%d] must be str or dict, got %s — dropping field",
+            source, i, type(c).__name__,
+        )
+        return None
+    return conditions
+
+
+def _validate_path_profile(profile: Any, source: str) -> Optional[str]:
+    """Validate the optional ``path_profile`` field on a flow trace.
+
+    Must be one of the stdint-style names accepted by
+    ``raptor-smt-validate-path``.  Drops the field with a warning on
+    anything else.
+    """
+    if profile is None:
+        return None
+    if not isinstance(profile, str) or profile not in _VALID_PROFILE_NAMES:
+        logger.warning(
+            "understand_bridge: %s path_profile must be one of %s, got %r — dropping",
+            source, sorted(_VALID_PROFILE_NAMES), profile,
+        )
+        return None
+    return profile
 
 
 def _merge_list_by_key(

--- a/libexec/raptor-smt-validate-path
+++ b/libexec/raptor-smt-validate-path
@@ -4,6 +4,7 @@
 Usage:
   raptor-smt-validate-path [--profile <name>] <condition> [<condition> ...]
   raptor-smt-validate-path [--profile <name>] --stdin
+  raptor-smt-validate-path --from-trace <id> --workdir <path>
 
 Each ``<condition>`` is a single predicate string such as ``"size > 0"``
 or ``"alloc_size == count * 16"``.  Conditions must hold simultaneously
@@ -15,6 +16,16 @@ When ``--stdin`` is given, conditions are read as a JSON array.  Each
 element may be either a bare string or a ``{"text": ..., "negated":
 true}`` object — useful when conditions need explicit negation flags
 (e.g. piped from a tool that already extracts them).
+
+When ``--from-trace <id>`` is given, the script reads
+``<workdir>/attack-paths.json`` (or ``--attack-paths <file>`` if given
+explicitly), finds the entry with matching ``id``, and uses its
+``path_conditions`` and ``path_profile`` fields directly.  This is the
+preferred path for /understand-extracted traces — the conditions were
+extracted with full source-code context and don't need re-derivation.
+Explicit ``--profile`` overrides the trace's ``path_profile`` when both
+are supplied.  Fails (exit 2) when the trace has no ``path_conditions``
+or the file/id can't be resolved.
 
 ``--profile`` selects bitvector width and signedness:
 
@@ -49,6 +60,56 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from packages.exploit_feasibility.smt_path import validate_path
 
 
+def _err(msg: str) -> int:
+    print(f"raptor-smt-validate-path: {msg}", file=sys.stderr)
+    return 2
+
+
+def _resolve_from_trace(args) -> "tuple[list, str | None] | int":
+    """Load conditions + profile from an imported attack-paths entry.
+
+    Returns ``(conditions, profile_or_None)`` on success, or an exit-code int
+    on failure.  ``profile_or_None`` is the trace's path_profile when present,
+    else None (caller falls back to --profile arg or default).
+    """
+    if args.attack_paths:
+        ap_path = Path(args.attack_paths)
+    elif args.workdir:
+        ap_path = Path(args.workdir) / "attack-paths.json"
+    else:
+        return _err("--from-trace requires --workdir or --attack-paths")
+
+    if not ap_path.is_file():
+        return _err(f"attack-paths.json not found: {ap_path}")
+
+    try:
+        paths = json.loads(ap_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        return _err(f"failed to read {ap_path}: {e}")
+
+    if not isinstance(paths, list):
+        return _err(f"{ap_path} is not a JSON array")
+
+    matches = [p for p in paths if isinstance(p, dict) and p.get("id") == args.from_trace]
+    if not matches:
+        return _err(f"no attack-path with id {args.from_trace!r} in {ap_path}")
+    if len(matches) > 1:
+        return _err(f"multiple attack-paths with id {args.from_trace!r} in {ap_path}")
+
+    trace = matches[0]
+    conds = trace.get("path_conditions")
+    if conds is None:
+        return _err(
+            f"attack-path {args.from_trace!r} has no path_conditions — "
+            f"the trace was imported but /understand didn't extract them; "
+            f"fall back to extracting from source"
+        )
+    if not isinstance(conds, list):
+        return _err(f"attack-path {args.from_trace!r} path_conditions is not a list")
+
+    return conds, trace.get("path_profile")
+
+
 def main() -> int:
     p = argparse.ArgumentParser(
         prog="raptor-smt-validate-path",
@@ -56,8 +117,9 @@ def main() -> int:
     )
     p.add_argument(
         "--profile",
-        default="uint64",
-        help="Bitvector profile name (default: uint64).",
+        default=None,
+        help="Bitvector profile name.  Defaults to the trace's path_profile "
+             "when --from-trace is used, otherwise to 'uint64'.",
     )
     p.add_argument(
         "--stdin",
@@ -66,48 +128,60 @@ def main() -> int:
              "positional args.",
     )
     p.add_argument(
+        "--from-trace",
+        metavar="ID",
+        help="Use path_conditions/path_profile from the attack-path with "
+             "this id (requires --workdir or --attack-paths).",
+    )
+    p.add_argument(
+        "--workdir",
+        help="Validate run workdir; reads attack-paths.json from here when "
+             "--from-trace is given.",
+    )
+    p.add_argument(
+        "--attack-paths",
+        help="Explicit path to attack-paths.json (alternative to --workdir).",
+    )
+    p.add_argument(
         "conditions",
         nargs="*",
         help="Path-condition strings (each a single predicate).",
     )
     args = p.parse_args()
 
-    if args.stdin:
-        if args.conditions:
-            print(
-                "raptor-smt-validate-path: --stdin and positional conditions "
-                "are mutually exclusive",
-                file=sys.stderr,
-            )
-            return 2
+    # Mutually-exclusive input modes
+    modes = sum([bool(args.from_trace), bool(args.stdin), bool(args.conditions)])
+    if modes > 1:
+        return _err("--from-trace, --stdin, and positional conditions are mutually exclusive")
+    if modes == 0:
+        p.print_usage(sys.stderr)
+        return _err("at least one condition required (or use --stdin / --from-trace)")
+
+    trace_profile: str | None = None
+
+    if args.from_trace:
+        result_or_code = _resolve_from_trace(args)
+        if isinstance(result_or_code, int):
+            return result_or_code
+        conditions, trace_profile = result_or_code
+    elif args.stdin:
         try:
             payload = json.load(sys.stdin)
         except json.JSONDecodeError as e:
-            print(f"raptor-smt-validate-path: invalid JSON on stdin: {e}", file=sys.stderr)
-            return 2
+            return _err(f"invalid JSON on stdin: {e}")
         if not isinstance(payload, list):
-            print(
-                "raptor-smt-validate-path: --stdin payload must be a JSON array",
-                file=sys.stderr,
-            )
-            return 2
+            return _err("--stdin payload must be a JSON array")
         conditions = payload
     else:
-        if not args.conditions:
-            p.print_usage(sys.stderr)
-            print(
-                "raptor-smt-validate-path: at least one condition required "
-                "(or use --stdin)",
-                file=sys.stderr,
-            )
-            return 2
         conditions = list(args.conditions)
 
+    # Profile precedence: explicit --profile > trace's path_profile > "uint64"
+    profile = args.profile or trace_profile or "uint64"
+
     try:
-        result = validate_path(conditions, profile=args.profile)
+        result = validate_path(conditions, profile=profile)
     except (TypeError, ValueError) as e:
-        print(f"raptor-smt-validate-path: {e}", file=sys.stderr)
-        return 2
+        return _err(str(e))
 
     json.dump(result, sys.stdout, indent=2)
     sys.stdout.write("\n")

--- a/packages/exploit_feasibility/tests/test_smt_path.py
+++ b/packages/exploit_feasibility/tests/test_smt_path.py
@@ -308,3 +308,220 @@ class TestCli:
         r = self._run("--stdin", stdin='{"not": "an array"}')
         assert r.returncode == 2
         assert "must be a JSON array" in r.stderr
+
+
+class TestFromTrace:
+    """``--from-trace <id>`` reads ``path_conditions`` and ``path_profile``
+    from an imported attack-paths.json entry, the preferred path when
+    /understand has already extracted conditions for the dataflow."""
+
+    @staticmethod
+    def _script() -> Path:
+        return Path(__file__).resolve().parents[3] / "libexec" / "raptor-smt-validate-path"
+
+    def _run(self, *args, stdin: str = None):
+        import subprocess
+        return subprocess.run(
+            [sys.executable, str(self._script()), *args],
+            input=stdin,
+            capture_output=True, text=True,
+        )
+
+    def _attack_paths(self, tmp_path, paths_data):
+        ap = tmp_path / "attack-paths.json"
+        ap.write_text(json.dumps(paths_data))
+        return ap
+
+    @_requires_z3
+    def test_uses_path_conditions_and_profile_from_trace(self, tmp_path):
+        ap = self._attack_paths(tmp_path, [{
+            "id": "TRACE-001",
+            "path_conditions": [
+                {"text": "x > 0", "negated": False},
+                {"text": "x < 100", "negated": False},
+            ],
+            "path_profile": "uint32",
+        }])
+        r = self._run("--from-trace", "TRACE-001", "--attack-paths", str(ap))
+        assert r.returncode == 0, r.stderr
+        v = json.loads(r.stdout)
+        assert v["feasible"] is True
+        # Profile from trace was honoured (32-bit unsigned)
+        assert "32-bit unsigned" in v["reasoning"]
+
+    @_requires_z3
+    def test_explicit_profile_overrides_trace_profile(self, tmp_path):
+        ap = self._attack_paths(tmp_path, [{
+            "id": "TRACE-001",
+            "path_conditions": ["x > 0"],
+            "path_profile": "uint32",
+        }])
+        r = self._run("--from-trace", "TRACE-001", "--attack-paths", str(ap),
+                      "--profile", "uint64")
+        assert r.returncode == 0
+        v = json.loads(r.stdout)
+        assert "64-bit unsigned" in v["reasoning"]
+
+    @_requires_z3
+    def test_workdir_resolves_attack_paths(self, tmp_path):
+        """``--workdir`` is the convenience form: reads
+        ``<workdir>/attack-paths.json``."""
+        self._attack_paths(tmp_path, [{"id": "T", "path_conditions": ["x > 0"]}])
+        r = self._run("--from-trace", "T", "--workdir", str(tmp_path))
+        assert r.returncode == 0
+        assert json.loads(r.stdout)["feasible"] is True
+
+    def test_missing_path_conditions_exits_2(self, tmp_path):
+        ap = self._attack_paths(tmp_path, [{"id": "T", "name": "no-conds"}])
+        r = self._run("--from-trace", "T", "--attack-paths", str(ap))
+        assert r.returncode == 2
+        assert "no path_conditions" in r.stderr
+
+    def test_unknown_id_exits_2(self, tmp_path):
+        ap = self._attack_paths(tmp_path, [{"id": "T", "path_conditions": ["x > 0"]}])
+        r = self._run("--from-trace", "BOGUS", "--attack-paths", str(ap))
+        assert r.returncode == 2
+        assert "no attack-path with id" in r.stderr
+
+    def test_missing_workdir_or_attack_paths_exits_2(self):
+        r = self._run("--from-trace", "T")
+        assert r.returncode == 2
+        assert "--workdir or --attack-paths" in r.stderr
+
+    def test_attack_paths_file_not_found_exits_2(self, tmp_path):
+        r = self._run("--from-trace", "T", "--attack-paths", str(tmp_path / "missing.json"))
+        assert r.returncode == 2
+        assert "not found" in r.stderr
+
+    def test_combined_with_positional_exits_2(self, tmp_path):
+        ap = self._attack_paths(tmp_path, [{"id": "T", "path_conditions": ["x > 0"]}])
+        r = self._run("--from-trace", "T", "--attack-paths", str(ap), "x > 0")
+        assert r.returncode == 2
+        assert "mutually exclusive" in r.stderr
+
+    def test_combined_with_stdin_exits_2(self, tmp_path):
+        ap = self._attack_paths(tmp_path, [{"id": "T", "path_conditions": ["x > 0"]}])
+        r = self._run("--from-trace", "T", "--attack-paths", str(ap), "--stdin",
+                      stdin="[]")
+        assert r.returncode == 2
+        assert "mutually exclusive" in r.stderr
+
+    def test_attack_paths_not_a_list_exits_2(self, tmp_path):
+        ap = tmp_path / "attack-paths.json"
+        ap.write_text(json.dumps({"not": "a list"}))
+        r = self._run("--from-trace", "T", "--attack-paths", str(ap))
+        assert r.returncode == 2
+        assert "not a JSON array" in r.stderr
+
+    def test_corrupted_attack_paths_json_exits_2(self, tmp_path):
+        """Invalid JSON on disk → clean error, not a Python traceback."""
+        ap = tmp_path / "attack-paths.json"
+        ap.write_text("{not valid json")
+        r = self._run("--from-trace", "T", "--attack-paths", str(ap))
+        assert r.returncode == 2
+        assert "failed to read" in r.stderr
+
+    def test_skips_non_dict_entries_in_attack_paths(self, tmp_path):
+        """If attack-paths.json has non-dict entries (data corruption,
+        legacy schema, etc.), they're silently skipped during the id
+        match — the helper still finds and uses well-formed entries."""
+        ap = self._attack_paths(tmp_path, [
+            "stray string",
+            42,
+            None,
+            {"id": "T", "path_conditions": ["x == 1"]},
+        ])
+        r = self._run("--from-trace", "T", "--attack-paths", str(ap))
+        assert r.returncode == 0
+        assert json.loads(r.stdout)["feasible"] is True
+
+    @_requires_z3
+    def test_empty_path_conditions_returns_no_conditions_verdict(self, tmp_path):
+        """Trace with an empty path_conditions list is technically valid —
+        produces 'no conditions' feasible=true verdict without error."""
+        ap = self._attack_paths(tmp_path, [{"id": "T", "path_conditions": []}])
+        r = self._run("--from-trace", "T", "--attack-paths", str(ap))
+        assert r.returncode == 0
+        v = json.loads(r.stdout)
+        assert v["feasible"] is True
+        assert "no conditions" in v["reasoning"]
+
+    @_requires_z3
+    def test_negated_condition_round_trip_bridge_to_solver(self, tmp_path):
+        """End-to-end: ``negated: true`` flag on a trace condition must
+        survive the full path bridge → attack-paths.json → libexec
+        script → validate_path → Z3.  Negating ``ptr != NULL`` forces
+        ``ptr == 0``, which contradicts the second condition ``ptr > 0``
+        and yields a false verdict.  If the negated flag were dropped
+        anywhere along the chain, both conditions would parse as true
+        constraints (``ptr != NULL && ptr > 0``) and the verdict would
+        flip to true."""
+        # Build a trace dict in the shape /understand --trace produces,
+        # run it through the bridge, and verify the resulting
+        # attack-paths.json round-trips correctly when fed to the
+        # libexec script.
+        from pathlib import Path as _P
+        import sys as _sys
+        _sys.path.insert(0, str(_P(__file__).resolve().parents[3]))
+        from core.orchestration.understand_bridge import _trace_to_attack_path
+
+        trace = {
+            "id": "TRACE-NEG",
+            "name": "negation round-trip test",
+            "meta": {"entry_point": "test", "target_sink": "deref"},
+            "steps": [{"step": 1, "type": "entry", "definition": "x.c:1"}],
+            "proximity": 9,
+            "blockers": [],
+            "summary": {"verdict": "deref"},
+            "path_conditions": [
+                {"text": "ptr != NULL", "negated": True},  # bypassed → ptr == 0
+                {"text": "ptr > 0", "negated": False},      # contradicts
+            ],
+            "path_profile": "uint64",
+        }
+        path = _trace_to_attack_path(trace, _P("flow-trace-NEG.json"))
+        # Bridge must preserve both fields verbatim (modulo dropping)
+        assert path["path_conditions"] == trace["path_conditions"]
+        assert path["path_profile"] == "uint64"
+
+        ap = self._attack_paths(tmp_path, [path])
+        r = self._run("--from-trace", "TRACE-NEG", "--attack-paths", str(ap))
+        assert r.returncode == 0, r.stderr
+        v = json.loads(r.stdout)
+        # If negated were dropped, ptr != NULL && ptr > 0 is satisfiable.
+        # With negated honoured, ptr == 0 && ptr > 0 is unsat.
+        assert v["feasible"] is False, (
+            f"negated flag was dropped somewhere: got verdict {v['feasible']!r} "
+            f"with reasoning {v['reasoning']!r}"
+        )
+
+    def test_duplicate_ids_exits_2(self, tmp_path):
+        """Two attack-paths with the same id is a data-integrity bug
+        upstream — the helper must refuse rather than pick one
+        arbitrarily, since the consumer can't tell which conditions
+        ran."""
+        ap = self._attack_paths(tmp_path, [
+            {"id": "T", "path_conditions": ["x == 1"]},
+            {"id": "T", "path_conditions": ["x == 2"]},
+        ])
+        r = self._run("--from-trace", "T", "--attack-paths", str(ap))
+        assert r.returncode == 2
+        assert "multiple attack-paths" in r.stderr
+
+    @_requires_z3
+    def test_helper_reads_attack_paths_not_source_trace_files(self, tmp_path):
+        """Architectural property: --from-trace reads attack-paths.json
+        only, never the original flow-trace JSON files.  This means a
+        cleaned-up /understand workdir doesn't break Stage E."""
+        ap = self._attack_paths(tmp_path, [{
+            "id": "T",
+            "path_conditions": ["x == 1"],
+            "path_profile": "uint32",
+            # Note: no flow-trace-T.json file in tmp_path — helper must
+            # work entirely from attack-paths.json contents.
+        }])
+        r = self._run("--from-trace", "T", "--attack-paths", str(ap))
+        assert r.returncode == 0
+        v = json.loads(r.stdout)
+        assert v["feasible"] is True
+        assert "32-bit unsigned" in v["reasoning"]


### PR DESCRIPTION
When /understand --trace walks a dataflow, it already extracts the path conditions for that flow.  Stage E was hand-extracting them again from the source — duplicate LLM work, with the LLM sometimes picking a different (wrong) path.

Adds an opt-in passthrough so the trace's conditions feed Stage E directly:

- trace.md schema gains two optional fields, path_conditions (list of predicates the flow knows must hold, as strings or {text, negated} dicts) and path_profile (e.g. "uint32" matching the dominant C type).
- core/orchestration/understand_bridge.py validates and forwards both fields when importing flow traces into attack-paths.json.  Malformed shapes are dropped with a logged warning rather than propagated.
- libexec/raptor-smt-validate-path adds a --from-trace TRACE-ID mode (with --workdir / --attack-paths overrides) that reads attack-paths .json, finds the trace by id, and uses its path_conditions/profile. Profile precedence: --profile flag > trace's path_profile > uint64.
- stage-e-feasibility.md [E-3c] tells the LLM to prefer --from-trace when the finding has an imported flow trace, with explicit handling for missing / empty / non-empty path_conditions.

Tests: 101 in test_smt_path.py + test_understand_bridge.py covering round-trip preservation, malformed-input rejection, profile precedence, trace lookup, conflict-with-stdin error path, and an end-to-end negated-condition round-trip (bridge → file → libexec → solver). Full repo suite: 2427 passed (1 pre-existing skip).