### PR TITLE
SMT: named verbs for CWE-190 / OOB / null-deref, csem-direct

### DIFF
--- a/.claude/skills/exploitability-validation/stage-e-feasibility.md
+++ b/.claude/skills/exploitability-validation/stage-e-feasibility.md
@@ -147,6 +147,18 @@ arithmetic), CWE-193 (off-by-one), CWE-476 (null deref).
 
 The heuristic `note` field is always preserved alongside `smt_feasibility` — compare both when they conflict. When `smt_feasibility.feasible` is `false`, prefer the SMT verdict for the `chain_breaks` entry.
 
+### [E-3 SMT] Choosing an SMT entry point
+
+You have three SMT tools, listed in the order to reach for them:
+
+| Situation | Tool | Why first |
+|---|---|---|
+| The finding has an imported `/understand` flow trace with `path_conditions` (look in `attack-paths.json` for entries with `source: "understand:trace"` carrying that field) | `raptor-smt-validate-path --from-trace TRACE-ID --workdir "$OUTPUT_DIR"` ([E-3c]) | The trace's conditions were extracted alongside the dataflow walk with full source-code context — usually richer and more accurate than re-extracting from prose |
+| The source matches a named pattern: `count * size` or similar arithmetic-with-guard (CWE-190); `arr[index]` access (CWE-125 / CWE-787); pointer deref of a possibly-null pointer (CWE-476) | Named verb: `raptor-smt-check-overflow` / `-oob` / `-null-deref` ([E-3d]) | The verb's intrinsic predicate is right by construction (csem-built); you only have to extract operands and guards, not derive the encoding |
+| Anything else — bespoke path conditions, multi-stage taint, mixed bitmask/relational guards, or a pattern none of the verbs cover | `raptor-smt-validate-path` with free-form predicates ([E-3c]) | The general-purpose escape hatch; richer expressiveness at the cost of you constructing the predicate |
+
+All three share Z3 availability, profile semantics, and `unknown_reasons` shape, so the iterate-on-rejection loop documented in [E-3c] applies uniformly. **Do not call multiple tools for the same finding** — pick one based on the table and trust the verdict (or its caveats) it returns.
+
 ### [E-3c] Optional: SMT path-condition verification
 
 When you've read the source for a finding and formed a hypothesis about whether the visible guards actually block exploitation — e.g. a CWE-190 where `count < MAX_RECORDS` looks protective but `count * sizeof(record)` might wrap on 32-bit unsigned arithmetic — you can ask Z3 to verify whether the path conditions are jointly satisfiable:
@@ -255,6 +267,76 @@ The `kind` values you'll see and the surgical fix for each:
 If the rejection's `hint` field is non-empty, prefer it over your own guess — the hint is written by the parser at the exact failure site and names the concrete fix. One targeted refinement pass usually closes the gap. If a second pass still has the same `kind` for the same `text`, stop iterating and fall back to qualitative reasoning — you're outside the bitvector fragment.
 
 The verdict is only as trustworthy as the conditions you extract — a `false` verdict on an incomplete condition set is a hint, not proof.
+
+### [E-3d] Named SMT verbs — pattern-shaped helpers
+
+Three pattern-named helpers cover the most common memory-corruption shapes. Use them when the source matches the verb's pattern — they construct the right SMT predicate internally (built directly via `core.smt_solver.csem` — no parser round-trip for the verb's own predicate) so you don't have to derive the encoding from scratch.
+
+**Each verb returns the same JSON shape as `raptor-smt-validate-path`** — `feasible` / `model` / `reasoning` / `unknown_reasons` etc. — so you read the result the same way.
+
+**Operand forms accepted:** identifiers (`count`), numeric literals (`16`, `0x10`), and balanced function-call shapes (`strlen(input)`, `sizeof(record)`, `htonl(x)`). Function calls go through the same free-variable fallback as `validate_path` (PR #244): each call becomes a fresh `_anon_N` Z3 variable. **The over-approximation warning from `[E-3c]` carries through to verbs** — when the verdict is `feasible: true` and the model contains `_anon_N` keys, treat it as a hint not proof: distinct calls become independent free variables, so the solver can satisfy the wrap predicate by picking any value for the anon var.
+
+**Compound expressions are rejected.** `a + b`, `s->len`, `*p`, unbalanced parens — verb returns ValueError. For these, introduce a helper variable in `--guard` (e.g. `--guard 'idx == offset + length'` then pass `idx` as the operand) or use `raptor-smt-validate-path` directly. Caller-supplied **guards** can be compound (they go through the standard parser, which gets canonicalisation #241 + free-var fallback #244 transparently).
+
+#### `check_overflow` — CWE-190 integer overflow / wraparound
+
+When the source shows arithmetic with a guard that *looks* protective but the operand width could wrap (e.g. `count * sizeof(record)` under `count < MAX_RECORDS` where MAX is large enough that `count * sizeof` overflows uint32):
+
+```bash
+libexec/raptor-smt-check-overflow --op '*' \
+  --operand count --operand 16 \
+  --profile uint32 \
+  --kind unsigned_wrap \
+  --guard 'count > 0x10000000' \
+  --guard 'count < 0x40000000'
+```
+
+- `--op` is `+`, `-`, or `*` (csem provides overflow detectors for these binary ops). `--operand` is repeatable; pass each operand as a separate atomic identifier or literal. For 3+ operands, the predicate is "wrap occurs at SOME binary step in the chain", so intermediate wraps are detected even if the final result is in-range.
+- `--profile` must match the kind: `unsigned_wrap` requires unsigned (`uint8` / … / `uint64`); `signed_wrap` requires signed (`int8` / … / `int64`). Defaults to `uint32` (most CWE-190 cases are `int` / `unsigned int`).
+- `--kind unsigned_wrap` (default) uses `csem.{u_add,u_mul}_overflows` for `+`/`*` and `csem.usub_underflows` for `-`. `--kind signed_wrap` uses `csem.{s_add,s_mul}_overflows` (covers both directions) for `+`/`*` only — signed-minus overflow shape is too narrow for this verb's binary template.
+- `--guard` repeats — one visible source-level guard each. Pre-negate bypassed guards.
+
+`feasible: true` means overflow IS reachable under the guards; the model carries operand values that wrap.
+
+#### `check_oob` — CWE-125 / CWE-787 array out-of-bounds
+
+When the source shows `arr[index]` (or `memcpy(buf, src, len)` where `len` could exceed `buf`'s size) and you want to verify whether the bounds checks actually exclude OOB:
+
+```bash
+libexec/raptor-smt-check-oob \
+  --buffer-size buf_size \
+  --index 'offset + length' \
+  --profile uint64 \
+  --guard 'buf_size == 1024' \
+  --guard 'offset + length <= buf_size'
+```
+
+- `--buffer-size` and `--index` are identifiers or expressions naming the buffer length and the index used at the access site. Compound expressions (`'offset + length'`) parse fine.
+- `--profile` defaults to `uint64` (size_t-shaped). Override when the index is `int` / `unsigned int`.
+- `--guard` repeats; same conventions as above.
+
+`feasible: true` means OOB IS reachable; the model shows the escaping `index`/`buffer_size` pair. *Only checks the upper bound* (`index >= buffer_size`); negative-index escapes need a signed profile and an explicit guard.
+
+#### `check_null_deref` — CWE-476 null-pointer dereference
+
+When the source dereferences a pointer that has prior nullness checks but the deref site might be reached through a path that skipped them:
+
+```bash
+libexec/raptor-smt-check-null-deref --ptr ptr \
+  --guard 'ptr == NULL'   # the bypassed null-check, pre-negated
+```
+
+- `--ptr` is the identifier at the deref site. Use the *exact* name as it appears at the deref — `ptr` and `p->next` are distinct symbols to the parser.
+- `--profile` defaults to `uint64`; override to `uint32` for 32-bit targets.
+- `--guard` repeats. **If a null-check was bypassed on the dangerous path**, pass it pre-negated (`--guard 'ptr == NULL'`, not `--guard 'ptr != NULL'`) — the parser doesn't have a unary NOT.
+
+`feasible: true` means the null deref IS reachable; `feasible: false` means a guard genuinely proves `ptr` cannot be NULL here.
+
+#### When to use a verb vs `raptor-smt-validate-path`
+
+- **Use a verb** when the source matches one of the three patterns above — the verb's predicate construction is right by construction, and the witness model is already shaped the way you'd want it for a PoC.
+- **Use `raptor-smt-validate-path`** for free-form path conditions that don't fit a pattern (e.g. multi-stage taint with mixed integer + bitmask + string-shape guards), or when iterating on conditions extracted from a `/understand` flow trace via `--from-trace`.
+- Verbs and `validate-path` share Z3 availability, profile semantics, and `unknown_reasons` behaviour — the iterate-on-rejection loop from [E-3c] applies to verb results too.
 
 ### [E-4] Update Finding
 

--- a/libexec/raptor-smt-check-null-deref
+++ b/libexec/raptor-smt-check-null-deref
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Stage E SMT verb: CWE-476 null-pointer dereference.
+
+Usage:
+  raptor-smt-check-null-deref --ptr PTR
+                              [--profile NAME] [--guard 'condition' ...]
+
+``PTR`` is the identifier naming the pointer at the dereference site.
+Use the *exact* name as it appears at the deref — the parser treats it
+as a free variable, so ``ptr`` and ``p->next`` are distinct symbols.
+
+``--profile`` defaults to ``uint64`` (pointer width on 64-bit targets).
+Override to ``uint32`` for 32-bit targets.
+
+``--guard`` is repeatable.  A null-check that was bypassed on the
+dangerous path should be passed pre-negated:
+``--guard 'ptr == NULL'`` (asserts the bypass condition directly).
+
+Output: JSON to stdout matching :func:`validate_path`'s shape.  Of interest:
+
+  feasible=true   null deref IS reachable
+  feasible=false  guards prove ptr cannot be NULL here
+  feasible=null   Z3 unavailable / unencodable
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from packages.exploit_feasibility.smt_verbs import check_null_deref
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        prog="raptor-smt-check-null-deref",
+        description="Stage E SMT verb for CWE-476 null deref.",
+    )
+    p.add_argument("--ptr", required=True,
+                   help="Identifier naming the pointer at the deref site")
+    p.add_argument("--profile", default="uint64",
+                   help="Bitvector profile name (default: uint64)")
+    p.add_argument("--guard", action="append", default=[],
+                   help="Path condition / null-check (repeat)")
+    args = p.parse_args()
+
+    try:
+        result = check_null_deref(
+            args.ptr,
+            profile=args.profile,
+            guards=args.guard,
+        )
+    except (TypeError, ValueError) as e:
+        print(f"raptor-smt-check-null-deref: {e}", file=sys.stderr)
+        return 2
+
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/libexec/raptor-smt-check-oob
+++ b/libexec/raptor-smt-check-oob
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Stage E SMT verb: CWE-125 / CWE-787 array out-of-bounds.
+
+Usage:
+  raptor-smt-check-oob --buffer-size SIZE --index INDEX
+                       [--profile NAME] [--guard 'condition' ...]
+
+``SIZE`` and ``INDEX`` are identifier or expression strings naming the
+buffer length and the index used at the access site.  Compound
+expressions are accepted (``--index 'offset + length'``) — the parser
+handles arithmetic.
+
+``--profile`` defaults to ``uint64`` since most modern bounds are
+``size_t``-shaped.  Override when the index is ``int`` or narrower.
+
+``--guard`` is repeatable; one visible bounds-check / path condition each.
+If a check was bypassed on the dangerous path, pre-negate manually.
+
+Output: JSON to stdout matching :func:`validate_path`'s shape.  Of interest:
+
+  feasible=true   OOB IS reachable; ``model`` shows escaping index/size
+  feasible=false  guards rule out OOB
+  feasible=null   Z3 unavailable / unencodable
+
+Notes:
+  Only checks the upper bound (``index >= buffer_size``).  Negative-index
+  escapes need a signed profile AND an explicit guard expression.
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from packages.exploit_feasibility.smt_verbs import check_oob
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        prog="raptor-smt-check-oob",
+        description="Stage E SMT verb for CWE-125 / CWE-787 OOB access.",
+    )
+    p.add_argument("--buffer-size", required=True, dest="buffer_size",
+                   help="Identifier/expression naming the buffer length")
+    p.add_argument("--index", required=True,
+                   help="Identifier/expression naming the index")
+    p.add_argument("--profile", default="uint64",
+                   help="Bitvector profile name (default: uint64)")
+    p.add_argument("--guard", action="append", default=[],
+                   help="Visible bounds-check / path condition (repeat)")
+    args = p.parse_args()
+
+    try:
+        result = check_oob(
+            args.buffer_size,
+            args.index,
+            profile=args.profile,
+            guards=args.guard,
+        )
+    except (TypeError, ValueError) as e:
+        print(f"raptor-smt-check-oob: {e}", file=sys.stderr)
+        return 2
+
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/libexec/raptor-smt-check-overflow
+++ b/libexec/raptor-smt-check-overflow
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Stage E SMT verb: CWE-190 integer overflow / wraparound.
+
+Usage:
+  raptor-smt-check-overflow --op OP --operand X --operand Y [--operand Z ...]
+                            [--profile NAME] [--kind KIND]
+                            [--guard 'condition' ...]
+
+Each ``--operand`` is one operand of the suspect arithmetic op.  Operands
+must be atomic — single identifiers (``count``) or numeric literals
+(``16``, ``0x10``).  Compound forms like ``sizeof(record)`` are rejected
+with a clear error; pass the numeric value or use raptor-smt-validate-path
+directly for free-form predicates.
+
+``OP`` is the binary operator: ``+``, ``-``, ``*``.  (``<<`` and bitwise
+ops aren't covered by this verb — use raptor-smt-validate-path directly.)
+
+``--profile`` selects bitvector width / signedness; defaults to ``uint32``
+(most common CWE-190 case).  Must match ``--kind``: unsigned_wrap requires
+an unsigned profile; signed_wrap a signed one.
+
+``--kind`` is ``unsigned_wrap`` (default) or ``signed_wrap``.  signed_wrap
+is supported for ``+`` and ``*`` only — signed-minus overflow shape is
+too narrow for this verb's binary template.
+
+``--guard`` is repeatable — one visible source-level guard each.  If a
+guard was bypassed on the dangerous path, pre-negate it manually:
+``--guard 'len == 0'`` rather than ``--guard '!(len > 0)'``.
+
+Output: JSON to stdout matching validate_path's shape.  Of interest:
+
+  feasible=true   overflow IS reachable; ``model`` carries witness operands
+  feasible=false  guards rule out wrap
+  feasible=null   Z3 unavailable / unencodable
+
+The intrinsic predicate is built directly via core.smt_solver.csem (no
+parser involved for the verb's own predicate), so the verb cannot fail
+at parse time on its own predicate — only on caller-supplied guards.
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# libexec/<this> -> repo root
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from packages.exploit_feasibility.smt_verbs import check_overflow
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        prog="raptor-smt-check-overflow",
+        description="Stage E SMT verb for CWE-190 integer overflow.",
+    )
+    p.add_argument("--op", required=True, choices=["+", "-", "*"],
+                   help="Binary arithmetic operator (csem.{u,s}{add,sub,mul})")
+    p.add_argument("--operand", action="append", required=True, default=[],
+                   help="Operand expression (repeat for each operand; ≥2)")
+    p.add_argument("--profile", default="uint32",
+                   help="Bitvector profile name (default: uint32)")
+    p.add_argument("--kind", default="unsigned_wrap",
+                   choices=["unsigned_wrap", "signed_wrap"],
+                   help="Wrap pattern (default: unsigned_wrap)")
+    p.add_argument("--guard", action="append", default=[],
+                   help="Visible source-level guard (repeat for each)")
+    args = p.parse_args()
+
+    try:
+        result = check_overflow(
+            args.operand,
+            args.op,
+            profile=args.profile,
+            guards=args.guard,
+            kind=args.kind,
+        )
+    except (TypeError, ValueError) as e:
+        print(f"raptor-smt-check-overflow: {e}", file=sys.stderr)
+        return 2
+
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -280,6 +280,69 @@ def _parse_expr(
 _CALL_HEAD_RE = re.compile(r'[a-z_][a-z0-9_]*', re.IGNORECASE)
 
 
+def _next_anon_index(vars_: Dict[str, Any]) -> int:
+    """Return the next free ``_anon_<N>`` index for ``vars_``.
+
+    Seeds from ``max(existing index) + 1`` rather than ``len(existing)``
+    so names stay unique even if a caller has deleted entries from
+    ``vars_`` (a sparse range would otherwise collide with a live anon
+    name).  Defensive against ``_anon_<non-int>`` keys: ignored.
+
+    Shared between :func:`_substitute_calls` (parser-side) and
+    :func:`make_anon_call_var` (verb-side) so both paths allocate from
+    the same counter.
+    """
+    existing_indices: List[int] = []
+    for k in vars_:
+        if k.startswith('_anon_'):
+            try:
+                existing_indices.append(int(k[len('_anon_'):]))
+            except ValueError:
+                pass
+    return max(existing_indices, default=-1) + 1
+
+
+def is_balanced_call(text: str) -> bool:
+    """Match a complete balanced ``<ident>(...)`` form, end-to-end.
+
+    Returns ``True`` only if ``text`` is *entirely* a single function-
+    call-shaped expression.  Used by domain encoders building operand
+    BVs to detect whether a single-operand string is a function call
+    that should be substituted with a free variable, vs an arithmetic
+    expression that should be rejected as compound.
+    """
+    m = _CALL_HEAD_RE.match(text)
+    if not m or m.end() >= len(text) or text[m.end()] != '(':
+        return False
+    depth = 1
+    j = m.end() + 1
+    while j < len(text) and depth > 0:
+        if text[j] == '(':
+            depth += 1
+        elif text[j] == ')':
+            depth -= 1
+        j += 1
+    return depth == 0 and j == len(text)
+
+
+def make_anon_call_var(vars_: Dict[str, Any], *, profile: BVProfile) -> Any:
+    """Allocate a fresh ``_anon_N`` Z3 BV for a function-call operand.
+
+    Two textually-identical calls (``strlen(s) == strlen(s)``) produce
+    *distinct* anon vars — the parser doesn't assume calls are pure.
+    Callers wanting same-call equality should use a helper variable in
+    a guard instead.
+
+    Shares the ``_anon_*`` namespace with the parser-side substitution
+    in :func:`_substitute_calls`, so a verb can build an operand and
+    then a guard that references the same call without index collision.
+    """
+    counter = _next_anon_index(vars_)
+    name = f"_anon_{counter}"
+    vars_[name] = _mk_var(name, profile.width)
+    return vars_[name]
+
+
 def _substitute_calls(
     text: str, vars_: Dict[str, Any], *, profile: BVProfile,
 ) -> str:
@@ -292,11 +355,6 @@ def _substitute_calls(
     preserving correctness: the placeholder is unconstrained, so the
     solver can never claim infeasibility based on the elided subterm.
 
-    The placeholder counter is seeded from ``max(existing index) + 1``
-    rather than ``len(existing)`` so that names stay unique even if a
-    caller has deleted entries from ``vars_`` (a sparse register would
-    otherwise collide with a live anon name).
-
     Nested calls collapse to a single placeholder
     (``f(g(x))`` → ``_anon_0``), since the outer call drives the
     balanced-paren walk.  Two textually-identical calls produce
@@ -305,16 +363,7 @@ def _substitute_calls(
     Unbalanced parens (``strlen(x``) are left in place; the caller's
     parens-check still rejects them.
     """
-    existing_indices: List[int] = []
-    for k in vars_:
-        if k.startswith('_anon_'):
-            try:
-                existing_indices.append(int(k[len('_anon_'):]))
-            except ValueError:
-                # Defensive: ignore any ``_anon_<non-int>`` someone may
-                # have stuffed in vars_ — those don't constrain ours.
-                pass
-    counter = max(existing_indices, default=-1) + 1
+    counter = _next_anon_index(vars_)
     out: List[str] = []
     i = 0
     n = len(text)
@@ -441,6 +490,237 @@ def _parse_condition(
 # Public API
 # ---------------------------------------------------------------------------
 
+def _classify_text_condition(
+    cond: PathCondition,
+    vars_: Dict[str, Any],
+    solver: Any,
+    *,
+    profile: BVProfile,
+) -> Tuple[Optional[str], Optional[Tuple[str, Any]], Optional[Rejection]]:
+    """Parse one text condition and classify it.
+
+    Returns one of:
+      - ``(satisfied_display, None, None)`` — tautology, no further work
+      - ``(None, (display, expr), None)`` — pending, must be solved
+      - ``(None, None, rejection)`` — unparseable, accumulate into unknown
+
+    Factored out so :func:`check_path_feasibility` and
+    :func:`check_verb_feasibility` share the same parse-and-classify
+    semantics.
+    """
+    expr = _parse_condition(cond.text, vars_, profile=profile)
+    if isinstance(expr, Rejection):
+        _get_logger().debug(
+            f"smt_path_validator: rejected {cond.text!r} ({expr.kind.value}: {expr.detail})"
+        )
+        return None, None, expr
+
+    final_expr = z3.Not(expr) if cond.negated else expr
+    # Display form reflects what was actually asserted — without this,
+    # an unsat-core listing for a negated condition shows the un-negated
+    # text and confuses readers ("ptr != NULL ⊥ ptr > 0" looks
+    # consistent until you realise we asserted ptr == 0 not ptr != NULL).
+    display = f"NOT ({cond.text})" if cond.negated else cond.text
+
+    # Quick individual check: is this condition alone satisfiable?
+    with _scoped(solver):
+        solver.add(z3.Not(final_expr))
+        if solver.check() == z3.unsat:
+            return display, None, None  # tautology
+
+    return None, (display, final_expr), None
+
+
+def _solve_pending(
+    pending: List[Tuple[str, Any]],
+    solver: Any,
+    satisfied: List[str],
+    unknown: List[str],
+    unknown_reasons: List[Rejection],
+    *,
+    profile: BVProfile,
+) -> PathSMTResult:
+    """Run the solver over pending predicates and produce a verdict.
+
+    Shared between :func:`check_path_feasibility` and
+    :func:`check_verb_feasibility`.  Caller has already classified
+    each input as tautology/pending/unknown; this function turns the
+    pending list into a sat/unsat/unknown verdict and packages the
+    result.
+    """
+    mode = profile.describe()
+
+    if not pending:
+        if unknown:
+            return PathSMTResult(
+                feasible=None,
+                satisfied=satisfied, unsatisfied=[], unknown=unknown,
+                unknown_reasons=unknown_reasons,
+                model={}, smt_available=True,
+                reasoning=(
+                    f"indeterminate ({mode}): {len(satisfied)} trivially satisfied, "
+                    f"{len(unknown)} unparseable — LLM analysis required"
+                ),
+            )
+        return PathSMTResult(
+            feasible=True,
+            satisfied=satisfied, unsatisfied=[], unknown=[],
+            unknown_reasons=[],
+            model={}, smt_available=True,
+            reasoning=f"all {len(satisfied)} condition(s) trivially satisfied ({mode})",
+        )
+
+    label_map = _track(solver, pending)
+    result = solver.check()
+
+    if result == z3.sat:
+        model_dict = _format_witness(solver.model(), signed=profile.signed)
+        return PathSMTResult(
+            feasible=True,
+            satisfied=satisfied, unsatisfied=[], unknown=unknown,
+            unknown_reasons=unknown_reasons,
+            model=model_dict, smt_available=True,
+            reasoning=(
+                f"feasible ({mode}): {len(pending)} condition(s) are jointly satisfiable"
+                + (f"; {len(satisfied)} trivially satisfied" if satisfied else "")
+                + (f"; {len(unknown)} unparsed" if unknown else "")
+            ),
+        )
+
+    if result == z3.unsat:
+        conflicts = _core_names(solver, label_map)
+        conflict_set = conflicts if conflicts else [t for t, _ in pending]
+        reasoning = f"infeasible ({mode}): path conditions are mutually exclusive"
+        if conflicts:
+            reasoning += f"; conflict: {' ⊥ '.join(conflicts[:3])}"
+        return PathSMTResult(
+            feasible=False,
+            satisfied=satisfied, unsatisfied=conflict_set, unknown=unknown,
+            unknown_reasons=unknown_reasons,
+            model={}, smt_available=True,
+            reasoning=reasoning,
+        )
+
+    # z3.unknown — timeout or outside decidable fragment.
+    solver_reason = _classify_solver_unknown(solver)
+    pending_texts = [t for t, _ in pending]
+    pending_reasons = [
+        Rejection(
+            t, solver_reason,
+            f"Z3 reason_unknown: {solver.reason_unknown()}"
+            if hasattr(solver, "reason_unknown") else "",
+        )
+        for t in pending_texts
+    ]
+    detail = (
+        f"likely the {_DEFAULT_TIMEOUT_MS}ms timeout"
+        if solver_reason is RejectionKind.SOLVER_TIMEOUT
+        else "conditions outside the decidable bitvector fragment"
+    )
+    return PathSMTResult(
+        feasible=None,
+        satisfied=satisfied, unsatisfied=[],
+        unknown=unknown + pending_texts,
+        unknown_reasons=unknown_reasons + pending_reasons,
+        model={}, smt_available=True,
+        reasoning=f"Z3 returned unknown ({mode}) — {detail}",
+    )
+
+
+def make_var(name: str, vars_: Dict[str, Any], *, profile: BVProfile) -> Any:
+    """Get-or-create a Z3 bitvector variable, sharing ``vars_`` with the parser.
+
+    Domain encoders (``smt_verbs``) building Z3 predicates directly via
+    csem need their operand BVs to share names with parser-built BVs so
+    that, e.g., a verb's overflow predicate over ``count`` and a guard
+    ``count < MAX`` constrain the *same* Z3 variable.
+
+    Names are lowercased to match the parser's convention.
+    """
+    key = name.lower()
+    if key not in vars_:
+        vars_[key] = _mk_var(key, profile.width)
+    return vars_[key]
+
+
+def make_val(literal: str, *, profile: BVProfile) -> Any:
+    """Resolve a literal token (``"16"``, ``"0xff"``) to a Z3 BitVecVal.
+
+    Goes through the same width / leading-zero validation as atom-position
+    literals in the parser, so callers get consistent rejection.
+    Raises ``ValueError`` on invalid literal — verbs catch and surface
+    as a verb-layer error.
+    """
+    from core.smt_solver import parse_literal_value
+    v = parse_literal_value(literal, profile)
+    if isinstance(v, Rejection):
+        raise ValueError(
+            f"literal {literal!r} rejected: {v.kind.value} ({v.detail})"
+        )
+    return _mk_val(v, profile.width)
+
+
+def check_verb_feasibility(
+    intrinsic: List[Tuple[str, Any]],
+    text_guards: List[PathCondition],
+    vars_: Dict[str, Any],
+    *,
+    profile: BVProfile = BV_C_UINT64,
+) -> PathSMTResult:
+    """Feasibility analysis for a named SMT verb.
+
+    Verbs build their intrinsic Z3 predicate directly (typically via
+    ``core.smt_solver.csem``) and pass it as ``intrinsic`` — a list of
+    ``(display_text, z3_expr)`` tuples.  ``display_text`` appears in
+    unsat-core conflict listings, so callers should pick a form that
+    reads as the verb's intent (e.g. ``"unsigned mul wraps: count * 16"``).
+
+    ``text_guards`` are caller-supplied path conditions, parsed via the
+    same path as :func:`check_path_feasibility`.  Verbs and the parser
+    share ``vars_`` so identifier-named operands resolve to the same
+    Z3 BV regardless of which path created them.
+
+    Always called with Z3 available; verbs short-circuit the
+    ``smt_available=False`` case before calling this helper.
+    """
+    mode = profile.describe()
+    solver = _new_solver()
+
+    satisfied: List[str] = []
+    unknown: List[str] = []
+    unknown_reasons: List[Rejection] = []
+    pending: List[Tuple[str, Any]] = list(intrinsic)  # intrinsic always solved
+
+    for cond in text_guards:
+        sat_display, pending_pair, rejection = _classify_text_condition(
+            cond, vars_, solver, profile=profile,
+        )
+        if sat_display is not None:
+            satisfied.append(sat_display)
+        elif rejection is not None:
+            unknown.append(cond.text)
+            unknown_reasons.append(rejection)
+        else:
+            assert pending_pair is not None
+            pending.append(pending_pair)
+
+    if not intrinsic and not pending and not unknown and not satisfied:
+        # Defensive: a verb with no intrinsic and no guards is a usage
+        # error but we still return something coherent rather than
+        # divide-by-zero in the verdict logic.
+        return PathSMTResult(
+            feasible=True,
+            satisfied=[], unsatisfied=[], unknown=[],
+            unknown_reasons=[],
+            model={}, smt_available=True,
+            reasoning=f"no predicates ({mode}) — vacuously satisfiable",
+        )
+
+    return _solve_pending(
+        pending, solver, satisfied, unknown, unknown_reasons, profile=profile,
+    )
+
+
 def check_path_feasibility(
     conditions: List[PathCondition],
     *,
@@ -494,106 +774,18 @@ def check_path_feasibility(
     pending: List[Tuple[str, Any]] = []
 
     for cond in conditions:
-        expr = _parse_condition(cond.text, vars_, profile=profile)
-        if isinstance(expr, Rejection):
-            _get_logger().debug(
-                f"smt_path_validator: rejected {cond.text!r} ({expr.kind.value}: {expr.detail})"
-            )
+        sat_display, pending_pair, rejection = _classify_text_condition(
+            cond, vars_, solver, profile=profile,
+        )
+        if sat_display is not None:
+            satisfied.append(sat_display)
+        elif rejection is not None:
             unknown.append(cond.text)
-            unknown_reasons.append(expr)
-            continue
+            unknown_reasons.append(rejection)
+        else:
+            assert pending_pair is not None
+            pending.append(pending_pair)
 
-        final_expr = z3.Not(expr) if cond.negated else expr
-        # Display form reflects what was actually asserted — without this,
-        # an unsat-core listing for a negated condition shows the un-negated
-        # text and confuses readers ("ptr != NULL ⊥ ptr > 0" looks
-        # consistent until you realise we asserted ptr == 0 not ptr != NULL).
-        display = f"NOT ({cond.text})" if cond.negated else cond.text
-
-        # Quick individual check: is this condition alone satisfiable?
-        with _scoped(solver):
-            solver.add(z3.Not(final_expr))
-            if solver.check() == z3.unsat:
-                # Condition is a tautology — trivially satisfied
-                satisfied.append(display)
-                continue
-
-        pending.append((display, final_expr))
-
-    if not pending:
-        if unknown:
-            return PathSMTResult(
-                feasible=None,
-                satisfied=satisfied, unsatisfied=[], unknown=unknown,
-                unknown_reasons=unknown_reasons,
-                model={}, smt_available=True,
-                reasoning=(
-                    f"indeterminate ({mode}): {len(satisfied)} trivially satisfied, "
-                    f"{len(unknown)} unparseable — LLM analysis required"
-                ),
-            )
-        return PathSMTResult(
-            feasible=True,
-            satisfied=satisfied, unsatisfied=[], unknown=[],
-            unknown_reasons=[],
-            model={}, smt_available=True,
-            reasoning=f"all {len(satisfied)} condition(s) trivially satisfied ({mode})",
-        )
-
-    label_map = _track(solver, pending)
-    result = solver.check()
-
-    if result == z3.sat:
-        model_dict = _format_witness(solver.model(), signed=profile.signed)
-        return PathSMTResult(
-            feasible=True,
-            satisfied=satisfied, unsatisfied=[], unknown=unknown,
-            unknown_reasons=unknown_reasons,
-            model=model_dict, smt_available=True,
-            reasoning=(
-                f"feasible ({mode}): {len(pending)} condition(s) are jointly satisfiable"
-                + (f"; {len(satisfied)} trivially satisfied" if satisfied else "")
-                + (f"; {len(unknown)} unparsed" if unknown else "")
-            ),
-        )
-
-    if result == z3.unsat:
-        conflicts = _core_names(solver, label_map)
-        conflict_set = conflicts if conflicts else [t for t, _ in pending]
-        reasoning = f"infeasible ({mode}): path conditions are mutually exclusive"
-        if conflicts:
-            reasoning += f"; conflict: {' ⊥ '.join(conflicts[:3])}"
-        return PathSMTResult(
-            feasible=False,
-            satisfied=satisfied, unsatisfied=conflict_set, unknown=unknown,
-            unknown_reasons=unknown_reasons,
-            model={}, smt_available=True,
-            reasoning=reasoning,
-        )
-
-    # z3.unknown — timeout or outside decidable fragment.  Tag every
-    # pending condition with the structured reason so callers can tell a
-    # solver punt apart from a parser failure.
-    solver_reason = _classify_solver_unknown(solver)
-    pending_texts = [t for t, _ in pending]
-    pending_reasons = [
-        Rejection(
-            t, solver_reason,
-            f"Z3 reason_unknown: {solver.reason_unknown()}"
-            if hasattr(solver, "reason_unknown") else "",
-        )
-        for t in pending_texts
-    ]
-    detail = (
-        f"likely the {_DEFAULT_TIMEOUT_MS}ms timeout"
-        if solver_reason is RejectionKind.SOLVER_TIMEOUT
-        else "conditions outside the decidable bitvector fragment"
-    )
-    return PathSMTResult(
-        feasible=None,
-        satisfied=satisfied, unsatisfied=[],
-        unknown=unknown + pending_texts,
-        unknown_reasons=unknown_reasons + pending_reasons,
-        model={}, smt_available=True,
-        reasoning=f"Z3 returned unknown ({mode}) — {detail}",
+    return _solve_pending(
+        pending, solver, satisfied, unknown, unknown_reasons, profile=profile,
     )

--- a/packages/exploit_feasibility/smt_verbs.py
+++ b/packages/exploit_feasibility/smt_verbs.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python3
+"""Named SMT verbs for Stage E — pattern-specific helpers built on csem.
+
+The Stage E LLM has access to ``validate_path()`` (free-form predicate list)
+but that requires the LLM to reconstruct the encoding for each pattern from
+scratch — variability across runs, missed cases when the pattern doesn't
+"cue" the LLM into reaching for SMT.
+
+Named verbs solve the discovery problem.  Each verb names a vulnerability
+pattern, takes structured inputs that match how the LLM has *already* read
+the source (operands of an arithmetic op, buffer + index, pointer + path
+guards), and emits the right Z3 predicate for that pattern internally.
+The LLM picks a verb the way it would pick a CWE — by recognising the shape
+of the bug.
+
+**Composes on csem.**  The verbs build their intrinsic Z3 predicate via
+``core.smt_solver.csem`` (overflow detectors, width coercion) — not via
+string concatenation through the parser.  This means:
+
+- The intrinsic predicate is provably right by construction (csem is the
+  C-semantics primitives module, exhaustively tested).
+- The verb's own predicate cannot fail at parse time the way text
+  conditions can — it never enters the parser at all.
+- Compound operands are unaffected by the parser's ``MIXED_PRECEDENCE`` /
+  ``PARENS_NOT_SUPPORTED`` rejections, because operands become Z3 variables
+  *before* any parsing happens.
+- Multi-operand chains compose correctly across all binary steps, not just
+  the final one.
+
+Caller-supplied ``guards`` still go through the existing parser, so they
+inherit its rejection messages and ``unknown_reasons`` shape — but the
+verb's own predicate is in a separate path, so the LLM can tell verb
+failures apart from guard failures.
+
+Verbs in this module:
+
+- :func:`check_overflow` — CWE-190 integer overflow / wraparound.  Builds
+  ``csem.{u,s}{add,sub,mul}_overflows`` per op + signedness.  Detects both
+  overflow and underflow directions for signed; unsigned underflow on ``-``
+  routes through ``usub_underflows``.
+- :func:`check_oob` — CWE-125 / CWE-787 out-of-bounds access.  Builds the
+  bound-violation predicate directly (``index >= buffer_size`` with the
+  active profile's signedness routing the comparison).
+- :func:`check_null_deref` — CWE-476 null-pointer dereference.  Builds
+  ``ptr == 0`` directly.
+
+All three return the same JSON-serialisable verdict shape as
+:func:`validate_path` so callers can treat the result uniformly.
+
+Sanitiser-bypass intentionally *not* in this module — bitvector SMT can't
+reason about strings the way XSS / SQLi need.  See
+``project_smt_pr3_named_verbs.md`` for the scope decision.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+from core.smt_solver import (
+    BVProfile,
+    z3_available as _z3_available,
+)
+from core.smt_solver.csem import (
+    sadd_overflows,
+    smul_overflows,
+    uadd_overflows,
+    umul_overflows,
+    usub_underflows,
+)
+from packages.codeql.smt_path_validator import (
+    PathCondition,
+    PathSMTResult,
+    check_verb_feasibility,
+    is_balanced_call,
+    make_anon_call_var,
+    make_val,
+    make_var,
+)
+
+from .smt_path import _normalise_conditions, _resolve_profile
+
+
+_IDENT_RE = re.compile(r"^[a-z_][a-z0-9_]*$", re.IGNORECASE)
+_HEX_LITERAL_RE = re.compile(r"^0x[0-9a-f]+$", re.IGNORECASE)
+_DEC_LITERAL_RE = re.compile(r"^\d+$")
+
+
+def _smt_unavailable_result(
+    intrinsic_display: str,
+    guards: Sequence[Union[str, Dict[str, Any]]],
+) -> Dict[str, Any]:
+    """Degraded result when Z3 is missing.  Mirrors validate_path's shape
+    so callers branching on ``smt_available`` see the same structure."""
+    guard_texts: List[str] = []
+    for g in guards:
+        if isinstance(g, str):
+            guard_texts.append(g)
+        elif isinstance(g, dict):
+            t = g.get("text") or g.get("condition") or ""
+            if t:
+                guard_texts.append(str(t))
+    return {
+        "feasible": None,
+        "reasoning": "z3 not available — install z3-solver for verb analysis",
+        "model": {},
+        "satisfied": [],
+        "unsatisfied": [],
+        "unknown": [intrinsic_display, *guard_texts],
+        "unknown_reasons": [],
+        "smt_available": False,
+    }
+
+
+def _result_to_dict(result: PathSMTResult) -> Dict[str, Any]:
+    """Convert PathSMTResult to validate_path's JSON-serialisable shape."""
+    return {
+        "feasible": result.feasible,
+        "reasoning": result.reasoning,
+        "model": dict(result.model),
+        "satisfied": list(result.satisfied),
+        "unsatisfied": list(result.unsatisfied),
+        "unknown": list(result.unknown),
+        "unknown_reasons": [
+            {"text": r.text, "kind": r.kind.value,
+             "detail": r.detail, "hint": r.hint}
+            for r in result.unknown_reasons
+        ],
+        "smt_available": result.smt_available,
+    }
+
+
+def _build_operand_bv(
+    operand: str,
+    vars_: Dict[str, Any],
+    *,
+    profile: BVProfile,
+    role: str,
+) -> Any:
+    """Resolve an operand string to a Z3 BV — literal, identifier, or
+    function-call-shaped free variable.
+
+    Three accepted forms:
+
+    1. **Numeric literal** (``"16"``, ``"0x10"``) — encoded as a Z3
+       BitVecVal at the profile's width.
+    2. **Identifier** (``"count"``, ``"size"``) — encoded as a Z3 BV
+       variable; shares ``vars_`` with the parser so guards using the
+       same name reuse the same Z3 symbol.
+    3. **Balanced function call** (``"strlen(input)"``, ``"htonl(x)"``)
+       — substituted with a fresh ``_anon_N`` Z3 variable, mirroring
+       the path-validator's free-variable fallback (PR #244).  Lets
+       ``check_overflow(["strlen(s)", "16"], "*")`` work without
+       forcing the LLM into ``validate_path`` for the most common
+       CWE-190 shape.  The over-approximation caveat from #244
+       applies: a ``feasible: true`` verdict on a path containing
+       function-call operands is necessarily a hint, not proof —
+       Z3 ranges over the anon var unconstrained, so distinct calls
+       (``strlen(s) > 100 AND strlen(s) < 50``) become independent
+       free variables and the verdict over-approximates.
+
+    Anything else — arithmetic in the operand (``"a + b"``), pointer
+    deref (``"*p"``), struct access (``"s->len"``), unbalanced parens —
+    is rejected at the verb layer with a clear error.
+    """
+    o = operand.strip()
+    if not o:
+        raise ValueError(f"{role} is empty")
+
+    # Form 1: numeric literal
+    if _HEX_LITERAL_RE.match(o) or _DEC_LITERAL_RE.match(o):
+        return make_val(o, profile=profile)
+
+    # Form 2: bare identifier
+    if _IDENT_RE.match(o):
+        return make_var(o, vars_, profile=profile)
+
+    # Form 3: balanced <ident>(...) — free-variable fallback
+    if is_balanced_call(o):
+        return make_anon_call_var(vars_, profile=profile)
+
+    # Reject everything else with a clear error.  Pointer deref,
+    # struct access, mixed arithmetic, unbalanced parens all land here.
+    raise ValueError(
+        f"{role}={operand!r} is not a recognised form.  Verbs accept "
+        f"identifiers ({role}=count), numeric literals ({role}=16), "
+        f"or balanced function-call shapes ({role}='strlen(input)' — "
+        f"treated as a free variable, see #244 over-approximation "
+        f"caveat).  For compound expressions like 'offset + length', "
+        f"introduce a helper variable in --guard or use "
+        f"raptor-smt-validate-path directly."
+    )
+
+
+# ---------------------------------------------------------------------------
+# check_overflow — CWE-190
+# ---------------------------------------------------------------------------
+
+# Per-op csem dispatch.
+#
+# For chained 3+ operand inputs, we build the predicate as the OR of "op
+# overflows at step k" for each adjacent pair, so wrap at any binary step
+# is detected.  This catches intermediate wraps that the earlier text-
+# concat approach (with a single ``__r < first_operand`` check) missed.
+
+_UNSIGNED_OVERFLOW = {
+    "+":  uadd_overflows,
+    "*":  umul_overflows,
+    "-":  usub_underflows,
+}
+
+_SIGNED_OVERFLOW = {
+    "+":  sadd_overflows,
+    "*":  smul_overflows,
+}
+
+_OVERFLOW_KINDS = {"unsigned_wrap", "signed_wrap"}
+
+_PROFILE_SIGNEDNESS_ERROR = (
+    "{kind} requires a {required} profile; got {actual}.  Pass a "
+    "matching ``profile=`` (e.g. profile='uint32' for unsigned_wrap, "
+    "profile='int32' for signed_wrap)."
+)
+
+
+def check_overflow(
+    operands: Sequence[str],
+    op: str,
+    *,
+    profile: Union[BVProfile, str] = "uint32",
+    guards: Sequence[Union[str, Dict[str, Any]]] = (),
+    kind: str = "unsigned_wrap",
+) -> Dict[str, Any]:
+    """Check whether an arithmetic op can wrap given the visible guards.
+
+    Use this when the source shows arithmetic that *looks* bounded — say
+    ``count * 16`` with a guard ``count < MAX_RECORDS`` — and you want
+    Z3 to verify whether the guards actually rule out wraparound at the
+    operand's real C type width.
+
+    The intrinsic overflow predicate is built directly via
+    ``core.smt_solver.csem`` (no string parsing involved) so the verb's
+    own predicate cannot fail at parse time.  Caller-supplied ``guards``
+    still go through the path-condition parser and inherit its
+    rejection / ``unknown_reasons`` semantics.
+
+    Args:
+        operands: The operand expressions, as identifier strings (``"count"``)
+            or numeric literals (``"16"``, ``"0x10"``).  Must be atomic —
+            compound expressions like ``"sizeof(record)"`` or ``"size * n"``
+            are rejected with a clear error.  For 3+ operands, the predicate
+            is "wrap occurs at SOME binary step", catching intermediate
+            wraparound that a single end-of-chain check would miss.
+        op: ``"+"``, ``"-"``, ``"*"``.  Must be one of the binary
+            arithmetic operators csem provides overflow detectors for.
+        profile: Bitvector width and signedness.  Defaults to ``"uint32"``
+            because most CWE-190s involve ``int`` / ``unsigned int``.
+            **Must match ``kind``**: ``unsigned_wrap`` requires an
+            unsigned profile (``uint8`` / ``uint16`` / ``uint32`` /
+            ``uint64``); ``signed_wrap`` requires a signed one
+            (``int8`` / … / ``int64``).
+        guards: Visible source-level guards on the dangerous path, same
+            shape as :func:`validate_path` (strings or
+            ``{text, negated}`` dicts).  **Pass the actual guards** —
+            without them, the verb just asserts "wrap is possible for
+            *some* operand assignment", trivially true for any
+            non-degenerate op.
+        kind: ``"unsigned_wrap"`` (default) or ``"signed_wrap"``.
+            Unsigned uses ``csem.{u_add,u_mul}_overflows`` for ``+``/``*``
+            and ``csem.usub_underflows`` for ``-``.  Signed uses
+            ``csem.{s_add,s_mul}_overflows`` (covers both overflow and
+            underflow directions) for ``+``/``*`` only — see Notes.
+
+    Returns:
+        Same shape as :func:`validate_path`.  Of interest:
+
+        - ``feasible: true`` — overflow IS reachable; ``model`` carries
+          a concrete operand assignment.
+        - ``feasible: false`` — guards genuinely prevent wraparound.
+        - ``feasible: null`` — Z3 unavailable, an operand was rejected,
+          or solver punted.
+
+    Notes:
+        - ``signed_wrap`` is not supported with ``-``: real signed-minus
+          overflow requires opposite-sign operands and specific magnitude
+          relationships, too narrow for this verb's binary template.
+          Use ``raptor-smt-validate-path`` directly with bespoke
+          predicates for that case.
+        - Shift (``<<``) overflow is also not in this verb — csem doesn't
+          yet have a shift-overflow primitive.  Express via
+          ``raptor-smt-validate-path`` for now.
+
+    Raises:
+        ValueError: ``op`` not supported; ``kind`` unknown; ``operands``
+            has fewer than two entries; profile signedness doesn't match
+            ``kind``; or any operand is non-atomic / unrecognised.
+    """
+    if kind not in _OVERFLOW_KINDS:
+        raise ValueError(
+            f"unknown kind {kind!r}; expected one of {sorted(_OVERFLOW_KINDS)}"
+        )
+
+    overflow_table = _UNSIGNED_OVERFLOW if kind == "unsigned_wrap" else _SIGNED_OVERFLOW
+    if op not in overflow_table:
+        supported = sorted(overflow_table)
+        raise ValueError(
+            f"{kind} not defined for op {op!r}; "
+            f"supported ops are {supported}"
+        )
+
+    if len(operands) < 2:
+        raise ValueError(
+            f"check_overflow needs at least 2 operands for binary op {op!r}"
+        )
+
+    bv_profile = _resolve_profile(profile)
+    if kind == "unsigned_wrap" and bv_profile.signed:
+        raise ValueError(_PROFILE_SIGNEDNESS_ERROR.format(
+            kind=kind, required="unsigned", actual=bv_profile.describe(),
+        ))
+    if kind == "signed_wrap" and not bv_profile.signed:
+        raise ValueError(_PROFILE_SIGNEDNESS_ERROR.format(
+            kind=kind, required="signed", actual=bv_profile.describe(),
+        ))
+
+    if not _z3_available():
+        return _smt_unavailable_result(
+            f"check_overflow({op}, {kind})", guards,
+        )
+
+    # Build operand BVs.  Parser-bound vars are populated in vars_ so
+    # guards using the same identifier name share the Z3 variable.
+    vars_: Dict[str, Any] = {}
+    bv_operands = [
+        _build_operand_bv(o, vars_, profile=bv_profile, role=f"operand[{i}]")
+        for i, o in enumerate(operands)
+    ]
+
+    # Compose intrinsic: "op overflows at step k for some k".  For binary
+    # input this is one term; for chained input we OR the per-step terms,
+    # so wrap at ANY adjacent pair flips the verdict.
+    overflow_fn = overflow_table[op]
+    from core.smt_solver import z3
+    op_chr = op
+    intrinsic_terms: List[Any] = []
+    intrinsic_displays: List[str] = []
+    running = bv_operands[0]
+    running_display = operands[0]
+    for i, rhs in enumerate(bv_operands[1:], start=1):
+        rhs_display = operands[i]
+        intrinsic_terms.append(overflow_fn(running, rhs))
+        intrinsic_displays.append(
+            f"{kind}: {running_display} {op_chr} {rhs_display}"
+        )
+        # Compose the running expression for the next step.  We use
+        # plain Z3 ops here — the wrap detection at THIS step uses csem;
+        # the running value carries forward at modular semantics, which
+        # is exactly what C does.
+        if op_chr == "+":
+            running = running + rhs
+        elif op_chr == "-":
+            running = running - rhs
+        elif op_chr == "*":
+            running = running * rhs
+        running_display = f"({running_display} {op_chr} {rhs_display})"
+
+    if len(intrinsic_terms) == 1:
+        intrinsic = (intrinsic_displays[0], intrinsic_terms[0])
+    else:
+        intrinsic = (
+            f"{kind}: any step in chain ({len(intrinsic_terms)} steps)",
+            z3.Or(*intrinsic_terms),
+        )
+
+    text_guards = _normalise_conditions(list(guards))
+    result = check_verb_feasibility(
+        intrinsic=[intrinsic],
+        text_guards=text_guards,
+        vars_=vars_,
+        profile=bv_profile,
+    )
+    return _result_to_dict(result)
+
+
+# ---------------------------------------------------------------------------
+# check_oob — CWE-125 / CWE-787
+# ---------------------------------------------------------------------------
+
+def check_oob(
+    buffer_size: str,
+    index: str,
+    *,
+    profile: Union[BVProfile, str] = "uint64",
+    guards: Sequence[Union[str, Dict[str, Any]]] = (),
+) -> Dict[str, Any]:
+    """Check whether an array index can fall outside its buffer.
+
+    Use this when the source shows ``arr[index]`` (or ``memcpy(dst, src,
+    len)`` where ``len`` may overflow ``dst``'s size) and you want to
+    verify whether the visible bounds-checks actually exclude the OOB
+    cases.
+
+    Intrinsic predicate: ``index_bv >= buffer_size_bv``, with the
+    profile's signedness routing whether the comparison is unsigned
+    (``BVUGE``) or signed (``BVSGE``).  Built directly as a Z3 expression
+    — no parser involved.
+
+    Args:
+        buffer_size: Identifier or literal naming the buffer length.
+            Must be atomic — compound forms rejected with a clear error.
+            Treat as the right-open upper bound — valid indices are
+            ``[0, buffer_size)``.
+        index: Identifier or literal naming the access index.  Must be
+            atomic.  For compound indices like ``"offset + length"``,
+            introduce a helper variable in ``guards`` (``offset + length
+            == idx``) and pass ``"idx"`` here.
+        profile: Bitvector profile.  Defaults to ``"uint64"`` — most
+            modern bounds are size_t-shaped.  Override to ``"uint32"``
+            for ``int``-shaped bounds, etc.
+        guards: Visible bounds-checks and other path conditions.  **Pass
+            the actual guards** — without them ``feasible: true`` just
+            means "OOB is reachable for some unguarded ``index`` and
+            ``size``" (Z3 picks ``index=1, size=0``), trivially true.
+
+    Returns:
+        Same shape as :func:`validate_path`.
+
+        - ``feasible: true`` — OOB IS reachable; ``model`` shows the
+          escaping ``index``/``buffer_size`` pair.
+        - ``feasible: false`` — guards rule out OOB.
+        - ``feasible: null`` — Z3 unavailable / unencodable.
+
+    Notes:
+        - Only checks the upper bound (``index >= buffer_size``).
+          Negative-index escapes (``index < 0``) require a signed profile
+          AND an explicit guard expression — pass them in ``guards``.
+        - Profile must match the *index*'s C type width — passing
+          ``profile="uint32"`` when the actual index is ``size_t``
+          gives the wrong verdict for indices larger than 0xFFFFFFFF.
+
+    Raises:
+        ValueError: ``buffer_size`` or ``index`` is non-atomic or
+            unrecognised.
+    """
+    bv_profile = _resolve_profile(profile)
+
+    if not _z3_available():
+        return _smt_unavailable_result(
+            f"check_oob({index} >= {buffer_size})", guards,
+        )
+
+    vars_: Dict[str, Any] = {}
+    size_bv = _build_operand_bv(
+        buffer_size, vars_, profile=bv_profile, role="buffer_size",
+    )
+    index_bv = _build_operand_bv(
+        index, vars_, profile=bv_profile, role="index",
+    )
+
+    from core.smt_solver import z3
+    # Profile signedness routes the comparison.  ``bvuge`` for unsigned
+    # bounds (the common case); ``bvsge`` for signed.
+    if bv_profile.signed:
+        intrinsic_expr = index_bv >= size_bv  # BVSGE under signed BVs
+    else:
+        intrinsic_expr = z3.UGE(index_bv, size_bv)
+
+    text_guards = _normalise_conditions(list(guards))
+    result = check_verb_feasibility(
+        intrinsic=[(f"oob: {index} >= {buffer_size}", intrinsic_expr)],
+        text_guards=text_guards,
+        vars_=vars_,
+        profile=bv_profile,
+    )
+    return _result_to_dict(result)
+
+
+# ---------------------------------------------------------------------------
+# check_null_deref — CWE-476
+# ---------------------------------------------------------------------------
+
+def check_null_deref(
+    ptr: str,
+    *,
+    profile: Union[BVProfile, str] = "uint64",
+    guards: Sequence[Union[str, Dict[str, Any]]] = (),
+) -> Dict[str, Any]:
+    """Check whether a pointer can be NULL when dereferenced.
+
+    Use this when the source dereferences a pointer that has prior
+    nullness checks (``if (ptr) { ... *ptr ... }``) but the deref site
+    is reached through a different control-flow path, or when an early-
+    return guard might have been bypassed.
+
+    Intrinsic predicate: ``ptr == 0``, built directly as a Z3 expression
+    — no parser involved.
+
+    Args:
+        ptr: Identifier naming the pointer at the deref site.  Use the
+            *exact* name as it appears at the deref — the parser treats
+            it as a free variable; ``ptr`` and ``p->next`` are distinct
+            symbols.  Must be atomic.
+        profile: Bitvector profile.  Defaults to ``"uint64"`` (pointer
+            width on 64-bit targets).  Override to ``"uint32"`` for
+            32-bit targets.
+        guards: Path conditions that hold at the deref site.  If a
+            null-check was bypassed, pass it as
+            ``{"text": "ptr != NULL", "negated": True}`` — that asserts
+            ``ptr == NULL`` along the dangerous path.
+
+    Returns:
+        Same shape as :func:`validate_path`.
+
+        - ``feasible: true`` — null deref IS reachable.
+        - ``feasible: false`` — guards prove ``ptr`` cannot be NULL here.
+        - ``feasible: null`` — Z3 unavailable / unencodable.
+
+    Notes:
+        The verb's intrinsic is ``ptr == NULL``.  Combined with caller
+        guards, the verdict tells you whether ``ptr == NULL`` AND the
+        guards are jointly satisfiable.  A guard like ``ptr > 0``
+        therefore yields ``feasible: false`` (the guard contradicts the
+        intrinsic) — read this as "the supplied guards exclude null at
+        the deref site," not "null deref is impossible."
+
+    Raises:
+        ValueError: ``ptr`` is non-atomic or unrecognised.
+    """
+    bv_profile = _resolve_profile(profile)
+
+    if not _z3_available():
+        return _smt_unavailable_result(f"null_deref: {ptr} == NULL", guards)
+
+    vars_: Dict[str, Any] = {}
+    ptr_bv = _build_operand_bv(ptr, vars_, profile=bv_profile, role="ptr")
+
+    from core.smt_solver import z3
+    intrinsic_expr = ptr_bv == z3.BitVecVal(0, bv_profile.width)
+
+    text_guards = _normalise_conditions(list(guards))
+    result = check_verb_feasibility(
+        intrinsic=[(f"null_deref: {ptr} == NULL", intrinsic_expr)],
+        text_guards=text_guards,
+        vars_=vars_,
+        profile=bv_profile,
+    )
+    return _result_to_dict(result)

--- a/packages/exploit_feasibility/tests/test_smt_verbs.py
+++ b/packages/exploit_feasibility/tests/test_smt_verbs.py
@@ -1,0 +1,663 @@
+"""Tests for packages.exploit_feasibility.smt_verbs (csem-direct verbs).
+
+The verbs build their intrinsic Z3 predicate via ``core.smt_solver.csem``
+directly — no string concat, no parser round-trip.  Coverage focuses on:
+
+  - the canonical bug shapes (CWE-190 wrap, off-by-one OOB, null deref)
+    return ``feasible=true`` with sensible witness models
+  - subtraction does NOT false-positive overflow — the original draft
+    used ``__r < a`` for every op, which mis-classified every positive
+    subtraction as wrap.  csem-direct fixes this by routing each op
+    through its own primitive (``usub_underflows`` etc.)
+  - compound operands are rejected at the verb layer with a clear error
+    rather than silently parsing as identifiers or going to ``unknown``
+  - profile/kind mismatch (e.g. ``unsigned_wrap`` with a signed profile)
+    is rejected at the verb layer
+  - guards parse via the existing path-condition parser and inherit its
+    rejection / ``unknown_reasons`` semantics
+  - witness model contains real operand assignments only — no synthetic
+    variables (the csem-direct path doesn't introduce any)
+  - degraded behaviour (no Z3) returns the ``smt_available=False`` shape
+  - chained 3+ operand inputs detect intermediate wrap, not just the
+    final-vs-first comparison the earlier draft used
+  - libexec shims pass args through correctly
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# packages/exploit_feasibility/tests/ -> repo root
+sys.path.insert(0, str(Path(__file__).parents[3]))
+
+from core.smt_solver import BV_C_UINT32, BVProfile, z3_available
+from packages.exploit_feasibility.smt_verbs import (
+    check_null_deref,
+    check_oob,
+    check_overflow,
+)
+
+
+_requires_z3 = pytest.mark.skipif(
+    not z3_available(),
+    reason="z3-solver not installed",
+)
+
+
+# ---------------------------------------------------------------------------
+# check_overflow — argument validation (Z3-independent)
+# ---------------------------------------------------------------------------
+
+class TestCheckOverflowArgValidation:
+
+    def test_unsupported_op_for_unsigned_rejected(self):
+        with pytest.raises(ValueError, match="unsigned_wrap not defined for op"):
+            check_overflow(["a", "b"], "&")
+
+    def test_unsupported_op_for_signed_rejected(self):
+        with pytest.raises(ValueError, match="signed_wrap not defined for op"):
+            check_overflow(["a", "b"], "-", profile="int32", kind="signed_wrap")
+
+    def test_unknown_kind_rejected(self):
+        with pytest.raises(ValueError, match="unknown kind"):
+            check_overflow(["a", "b"], "*", kind="weird_wrap")
+
+    def test_too_few_operands_rejected(self):
+        with pytest.raises(ValueError, match="at least 2 operands"):
+            check_overflow(["only_one"], "*")
+
+    def test_unknown_profile_rejected(self):
+        with pytest.raises(ValueError, match="unknown profile"):
+            check_overflow(["a", "b"], "*", profile="size_t")
+
+    def test_unsigned_kind_with_signed_profile_rejected(self):
+        with pytest.raises(ValueError, match="requires a unsigned profile"):
+            check_overflow(["a", "b"], "*", profile="int32", kind="unsigned_wrap")
+
+    def test_signed_kind_with_unsigned_profile_rejected(self):
+        with pytest.raises(ValueError, match="requires a signed profile"):
+            check_overflow(["a", "b"], "*", profile="uint32", kind="signed_wrap")
+
+    def test_signed_minus_rejected(self):
+        """Signed-minus overflow requires opposite-sign operands —
+        outside the binary template these verbs use."""
+        with pytest.raises(ValueError, match="signed_wrap not defined for op"):
+            check_overflow(["a", "b"], "-", profile="int32", kind="signed_wrap")
+
+
+class TestCheckOverflowOperandValidation:
+    """Operands accepted in three forms only: identifier, numeric
+    literal, balanced ``<ident>(...)`` function call.  Anything else
+    (arithmetic, pointer deref, struct access, unbalanced parens) is
+    rejected at the verb layer with a clear error.  Function calls
+    use the same free-variable fallback as PR #244 — distinct calls
+    become independent ``_anon_N`` Z3 vars; verdicts are over-
+    approximate in the SAT direction."""
+
+    def test_arithmetic_in_operand_rejected(self):
+        with pytest.raises(ValueError, match="not a recognised form"):
+            check_overflow(["a + b", "c"], "*")
+
+    def test_relational_in_operand_rejected(self):
+        with pytest.raises(ValueError, match="not a recognised form"):
+            check_overflow(["a == 1", "b"], "+")
+
+    def test_pointer_deref_operand_rejected(self):
+        with pytest.raises(ValueError, match="not a recognised form"):
+            check_overflow(["*p", "b"], "+")
+
+    def test_struct_access_operand_rejected(self):
+        with pytest.raises(ValueError, match="not a recognised form"):
+            check_overflow(["s->len", "b"], "+")
+
+    def test_unbalanced_call_operand_rejected(self):
+        with pytest.raises(ValueError, match="not a recognised form"):
+            check_overflow(["strlen(s", "b"], "+")
+
+    def test_empty_operand_rejected(self):
+        with pytest.raises(ValueError, match="is empty"):
+            check_overflow(["", "b"], "+")
+
+    def test_whitespace_only_operand_rejected(self):
+        with pytest.raises(ValueError, match="is empty"):
+            check_overflow(["   ", "b"], "+")
+
+
+class TestFunctionCallOperands:
+    """Function-call operands (``strlen(input) * 16``) are accepted via
+    the same free-variable fallback as PR #244 — substituted with
+    fresh ``_anon_N`` Z3 vars so the LLM doesn't have to know constant
+    values for csem to compose.  Sibling test class to
+    TestCheckOverflowOperandValidation."""
+
+    @_requires_z3
+    def test_strlen_operand_treated_as_free_var(self):
+        """``strlen(s) * 16`` overflow check — strlen substitutes."""
+        r = check_overflow(
+            ["strlen(s)", "16"], "*",
+            profile="uint32",
+            guards=["strlen(s) > 0x10000000"],
+        )
+        assert r["feasible"] is True
+        # The model should include _anon_N keys (the strlen substitutions);
+        # the LLM should read these per #244's over-approximation warning.
+        assert any(k.startswith("_anon_") for k in r["model"]), (
+            f"expected _anon_N keys in model, got {sorted(r['model'])}"
+        )
+
+    @_requires_z3
+    def test_oob_with_function_call_index(self):
+        """``check_oob(buf_size, strlen(input))`` works."""
+        r = check_oob(
+            "buf_size", "strlen(input)",
+            profile="uint64",
+            guards=["buf_size == 256"],
+        )
+        assert r["feasible"] is True
+
+    @_requires_z3
+    def test_null_deref_with_function_call_ptr(self):
+        """``check_null_deref(getfield(p))`` works."""
+        r = check_null_deref("getfield(p)")
+        assert r["feasible"] is True
+
+    @_requires_z3
+    def test_distinct_calls_get_distinct_anon_vars(self):
+        """Two textually-identical calls become distinct ``_anon_N`` —
+        matches PR #244's "calls aren't pure" semantic.  The verb's
+        operand and a guard with the same call text get independent
+        anon vars, so the over-approximation skill warning applies."""
+        r = check_overflow(
+            ["strlen(s)", "16"], "*",
+            profile="uint32",
+            guards=["strlen(s) > 0x10000000"],
+        )
+        # Two anon vars: one for the operand, one for the guard's
+        # parser-side substitution.
+        anon_keys = [k for k in r["model"] if k.startswith("_anon_")]
+        assert len(anon_keys) == 2
+
+    @_requires_z3
+    def test_nested_call_collapses_to_one_anon(self):
+        """Nested call ``f(g(x))`` is one balanced call, one anon var."""
+        r = check_overflow(
+            ["f(g(x))", "16"], "*",
+            profile="uint32",
+            guards=["f(g(x)) > 0x10000000"],
+        )
+        # operand: 1 anon, guard: 1 anon (distinct) — total 2.
+        anon_keys = [k for k in r["model"] if k.startswith("_anon_")]
+        assert len(anon_keys) == 2
+
+
+# ---------------------------------------------------------------------------
+# check_overflow — feasibility
+# ---------------------------------------------------------------------------
+
+class TestCheckOverflowFeasibility:
+
+    @_requires_z3
+    def test_canonical_cwe190_wraparound_witness(self):
+        """``count * 16`` under uint32 wraps when count is large enough.
+        Z3 must find a witness; csem.umul_overflows directly encodes the
+        wrap predicate so the verdict is provably right by construction."""
+        r = check_overflow(
+            ["count", "16"], "*",
+            profile="uint32",
+            guards=["count < 0x40000000", "count > 0x10000000"],
+        )
+        assert r["feasible"] is True
+        count = r["model"]["count"]
+        # Re-derive: the multiplication must mathematically wrap at uint32.
+        assert (count * 16) > 0xFFFFFFFF, (
+            f"witness count={count:#x} doesn't actually overflow uint32"
+        )
+
+    @_requires_z3
+    def test_tight_guard_blocks_wrap(self):
+        """``count < 100`` is genuinely safe under uint32 * 16."""
+        r = check_overflow(
+            ["count", "16"], "*",
+            profile="uint32",
+            guards=["count < 100"],
+        )
+        assert r["feasible"] is False
+
+    @_requires_z3
+    def test_signed_wrap_witness(self):
+        """Two large positive int32 operands sum to negative — signed
+        overflow shape."""
+        r = check_overflow(
+            ["a", "b"], "+",
+            profile="int32",
+            kind="signed_wrap",
+            guards=["a > 0x70000000", "b > 0x70000000"],
+        )
+        assert r["feasible"] is True
+
+    @_requires_z3
+    def test_addition_wrap(self):
+        """``+`` wraps the same way; offset+length wraps to small value."""
+        r = check_overflow(
+            ["offset", "length"], "+",
+            profile="uint32",
+            guards=["offset > 0xFFFF0000", "length > 0x10000"],
+        )
+        assert r["feasible"] is True
+
+    @_requires_z3
+    def test_bvprofile_object_accepted(self):
+        """Passing a BVProfile directly works the same as the name."""
+        r = check_overflow(
+            ["count", "16"], "*",
+            profile=BV_C_UINT32,
+            guards=["count > 0x10000000"],
+        )
+        assert r["feasible"] is True
+
+    @_requires_z3
+    def test_chained_mul_detects_intermediate_wrap(self):
+        """3-operand chain ``a*b*c`` — wrap can occur at any step.
+        The csem-direct verb ORs per-step predicates so wrap at ``a*b``
+        is detected even if the ``(a*b)*c`` final result is in-range."""
+        r = check_overflow(
+            ["a", "b", "c"], "*",
+            profile="uint32",
+            guards=["a > 0x10000", "b > 0x10000", "c == 1"],
+        )
+        # a*b alone wraps (each > 0x10000, product > 2^32).  c=1 means
+        # the final product ≈ a*b (still wrapped).
+        assert r["feasible"] is True
+
+    @_requires_z3
+    def test_synthetic_var_not_in_returned_model(self):
+        """csem-direct verbs build the intrinsic predicate without
+        introducing a synthetic result variable, so no leakage."""
+        r = check_overflow(
+            ["count", "16"], "*",
+            profile="uint32",
+            guards=["count > 0x10000000"],
+        )
+        # No "_smt_*" key (the only operand was "count")
+        assert all(
+            not k.startswith("_smt_") for k in r["model"]
+        ), f"unexpected synthetic var: {r['model']!r}"
+        assert "count" in r["model"]
+
+    def test_no_z3_returns_smt_unavailable(self):
+        with patch(
+            "packages.exploit_feasibility.smt_verbs._z3_available",
+            return_value=False,
+        ):
+            r = check_overflow(["a", "b"], "*")
+        assert r["feasible"] is None
+        assert r["smt_available"] is False
+
+
+class TestSubtractionDoesNotFalsePositive:
+    """Regression guard for the per-op fix.  An earlier draft used
+    ``__r < a`` for every op, which mis-classifies any positive
+    subtraction as wrap because ``a - b < a`` whenever ``b > 0``.
+    csem.usub_underflows directly encodes the actual underflow
+    predicate."""
+
+    @_requires_z3
+    def test_normal_subtraction_is_not_overflow(self):
+        """``100 - 50 = 50`` — no underflow, must NOT be flagged."""
+        r = check_overflow(
+            ["a", "b"], "-",
+            profile="uint32",
+            guards=["a == 100", "b == 50"],
+        )
+        assert r["feasible"] is False, (
+            "regression: subtraction without underflow flagged as overflow; "
+            "the verb may have reverted to the text-concat ``__r < a`` form"
+        )
+
+    @_requires_z3
+    def test_underflow_subtraction_is_detected(self):
+        """``50 - 100`` under uint32 — real underflow."""
+        r = check_overflow(
+            ["a", "b"], "-",
+            profile="uint32",
+            guards=["a == 50", "b == 100"],
+        )
+        assert r["feasible"] is True
+
+
+# ---------------------------------------------------------------------------
+# check_oob
+# ---------------------------------------------------------------------------
+
+class TestCheckOob:
+
+    @_requires_z3
+    def test_off_by_one_witness(self):
+        """``index <= buf_size`` admits ``index == buf_size`` — classic
+        off-by-one.  OOB IS reachable."""
+        r = check_oob(
+            "buf_size", "i",
+            profile="uint32",
+            guards=["buf_size == 128", "i <= 128"],
+        )
+        assert r["feasible"] is True
+        assert r["model"]["i"] == 128
+        assert r["model"]["buf_size"] == 128
+
+    @_requires_z3
+    def test_strict_guard_blocks_oob(self):
+        """``index < buf_size`` is the correct check — Z3 rules out OOB."""
+        r = check_oob(
+            "buf_size", "i",
+            profile="uint32",
+            guards=["buf_size == 128", "i < 128"],
+        )
+        assert r["feasible"] is False
+
+    def test_arithmetic_buffer_size_rejected(self):
+        """Compound arithmetic expressions are still rejected at the
+        verb layer — only identifiers, literals, and balanced function
+        calls are accepted."""
+        with pytest.raises(ValueError, match="not a recognised form"):
+            check_oob("buf_base + offset", "i")
+
+    def test_arithmetic_index_rejected(self):
+        with pytest.raises(ValueError, match="not a recognised form"):
+            check_oob("buf_size", "offset + length")
+
+    @_requires_z3
+    def test_unsigned_profile_uses_unsigned_compare(self):
+        """Profile signedness routes the comparison.  Under uint32,
+        the OOB predicate uses BVUGE (unsigned >=) so a "very large"
+        index doesn't wrap into negative territory and pass the check."""
+        r = check_oob(
+            "size", "i",
+            profile="uint32",
+            guards=["size == 100", "i == 0xFFFFFFF0"],
+        )
+        # i is huge unsigned, well above size=100 → OOB
+        assert r["feasible"] is True
+
+    def test_no_z3_returns_smt_unavailable(self):
+        with patch(
+            "packages.exploit_feasibility.smt_verbs._z3_available",
+            return_value=False,
+        ):
+            r = check_oob("buf", "i")
+        assert r["feasible"] is None
+        assert r["smt_available"] is False
+
+
+# ---------------------------------------------------------------------------
+# check_null_deref
+# ---------------------------------------------------------------------------
+
+class TestCheckNullDeref:
+
+    @_requires_z3
+    def test_unguarded_ptr_can_be_null(self):
+        r = check_null_deref("ptr")
+        assert r["feasible"] is True
+        assert r["model"]["ptr"] == 0
+
+    @_requires_z3
+    def test_null_check_prevents_deref(self):
+        """``ptr != NULL`` guard rules out the null deref."""
+        r = check_null_deref("ptr", guards=["ptr != NULL"])
+        assert r["feasible"] is False
+
+    @_requires_z3
+    def test_bypassed_null_check_still_admits_null(self):
+        """The dangerous path bypasses the check — pre-negate the guard."""
+        r = check_null_deref(
+            "ptr",
+            guards=[{"text": "ptr != NULL", "negated": True}],
+        )
+        assert r["feasible"] is True
+        assert r["model"]["ptr"] == 0
+
+    @_requires_z3
+    def test_unrelated_guard_passes_through(self):
+        """A non-pointer guard doesn't affect the null verdict."""
+        r = check_null_deref("ptr", guards=["len > 0"])
+        assert r["feasible"] is True
+
+    def test_struct_access_ptr_rejected(self):
+        """``p->next`` isn't a function-call shape — rejected."""
+        with pytest.raises(ValueError, match="not a recognised form"):
+            check_null_deref("p->next")
+
+    def test_no_z3_returns_smt_unavailable(self):
+        with patch(
+            "packages.exploit_feasibility.smt_verbs._z3_available",
+            return_value=False,
+        ):
+            r = check_null_deref("ptr")
+        assert r["feasible"] is None
+        assert r["smt_available"] is False
+
+
+# ---------------------------------------------------------------------------
+# Behaviour pinned for documentation
+# ---------------------------------------------------------------------------
+
+class TestEmptyGuardsDocBehaviour:
+    """Documenting the corner case where verbs return ``feasible: true``
+    trivially because the caller passed no guards.  Not a bug — the
+    verdict is "yes, the bug shape is reachable for SOME assignment" —
+    but the LLM needs to know not to read it as bug confirmation."""
+
+    @_requires_z3
+    def test_overflow_no_guards_is_trivially_feasible(self):
+        r = check_overflow(["a", "b"], "*", profile="uint32")
+        assert r["feasible"] is True
+
+    @_requires_z3
+    def test_oob_no_guards_is_trivially_feasible(self):
+        r = check_oob("size", "i", profile="uint32")
+        assert r["feasible"] is True
+
+    @_requires_z3
+    def test_null_deref_no_guards_is_trivially_feasible(self):
+        r = check_null_deref("p")
+        assert r["feasible"] is True
+
+
+class TestGuardThatContradictsIntrinsic:
+    """If the caller passes a guard that contradicts the verb's intrinsic
+    predicate, the verdict is correctly ``feasible: false`` — but the
+    semantic is "the supplied guards exclude the bug shape", not "the bug
+    is impossible".  Pin the behaviour."""
+
+    @_requires_z3
+    def test_null_deref_with_nonnull_guard_yields_false(self):
+        r = check_null_deref("p", guards=["p > 0"])
+        assert r["feasible"] is False
+
+    @_requires_z3
+    def test_oob_with_strict_inbounds_guard_yields_false(self):
+        r = check_oob("size", "i", guards=["i < size"])
+        assert r["feasible"] is False
+
+
+class TestVerbCallIsolation:
+    """Two consecutive verb calls in the same Python process must not
+    share solver state."""
+
+    @_requires_z3
+    def test_two_calls_independent(self):
+        r1 = check_overflow(
+            ["count", "16"], "*",
+            profile="uint32",
+            guards=["count > 0x10000000"],
+        )
+        r2 = check_overflow(
+            ["count", "16"], "*",
+            profile="uint32",
+            guards=["count < 100"],
+        )
+        assert r1["feasible"] is True
+        assert r2["feasible"] is False
+
+
+# ---------------------------------------------------------------------------
+# JSON round-trip — every verb's result must serialise without conversion
+# ---------------------------------------------------------------------------
+
+class TestJSONRoundTrip:
+    """Stage E invokes verbs from libexec scripts that pipe through
+    ``json.dumps``; the verb result dict must not contain any
+    non-serialisable artefacts."""
+
+    @_requires_z3
+    def test_overflow_serialises(self):
+        r = check_overflow(["a", "b"], "*", guards=["a > 100"])
+        json.dumps(r)
+
+    @_requires_z3
+    def test_oob_serialises(self):
+        r = check_oob("size", "i", guards=["size == 64"])
+        json.dumps(r)
+
+    @_requires_z3
+    def test_null_deref_serialises(self):
+        r = check_null_deref("ptr")
+        json.dumps(r)
+
+
+# ---------------------------------------------------------------------------
+# libexec shims — Stage E invokes via these
+# ---------------------------------------------------------------------------
+
+def _libexec(name: str) -> Path:
+    return Path(__file__).resolve().parents[3] / "libexec" / name
+
+
+def _run(script: str, *args) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(_libexec(script)), *args],
+        capture_output=True, text=True,
+    )
+
+
+class TestLibexecCheckOverflow:
+
+    @_requires_z3
+    def test_finds_cwe190_witness(self):
+        r = _run(
+            "raptor-smt-check-overflow",
+            "--op", "*",
+            "--operand", "count",
+            "--operand", "16",
+            "--profile", "uint32",
+            "--guard", "count > 0x10000000",
+            "--guard", "count < 0x40000000",
+        )
+        assert r.returncode == 0, r.stderr
+        v = json.loads(r.stdout)
+        assert v["feasible"] is True
+        assert "count" in v["model"]
+
+    def test_unsupported_op_in_argparse_choices(self):
+        # argparse rejects ops not in the {+, -, *} choice set
+        r = _run(
+            "raptor-smt-check-overflow",
+            "--op", "&", "--operand", "a", "--operand", "b",
+        )
+        assert r.returncode == 2
+
+    def test_unknown_profile_exits_2(self):
+        r = _run(
+            "raptor-smt-check-overflow",
+            "--op", "*", "--operand", "a", "--operand", "b",
+            "--profile", "size_t",
+        )
+        assert r.returncode == 2
+        assert "unknown profile" in r.stderr
+
+    def test_too_few_operands_exits_2(self):
+        r = _run(
+            "raptor-smt-check-overflow",
+            "--op", "*", "--operand", "only_one",
+        )
+        assert r.returncode == 2
+        assert "at least 2 operands" in r.stderr
+
+    def test_arithmetic_operand_exits_2(self):
+        """Arithmetic in operand is rejected (compound)."""
+        r = _run(
+            "raptor-smt-check-overflow",
+            "--op", "*",
+            "--operand", "a + b",
+            "--operand", "count",
+        )
+        assert r.returncode == 2
+        assert "not a recognised form" in r.stderr
+
+    @_requires_z3
+    def test_function_call_operand_accepted(self):
+        """``sizeof(record) * count`` — function-call operand accepted
+        via free-variable fallback (PR #244 composition)."""
+        r = _run(
+            "raptor-smt-check-overflow",
+            "--op", "*",
+            "--operand", "sizeof(record)",
+            "--operand", "count",
+            "--profile", "uint32",
+            "--guard", "count > 0x10000000",
+        )
+        assert r.returncode == 0, r.stderr
+        v = json.loads(r.stdout)
+        # Verdict is feasible (over-approximate per #244 — sizeof becomes
+        # an unconstrained free var that Z3 picks any value for)
+        assert v["feasible"] is True
+
+
+class TestLibexecCheckOob:
+
+    @_requires_z3
+    def test_finds_off_by_one(self):
+        r = _run(
+            "raptor-smt-check-oob",
+            "--buffer-size", "buf_size",
+            "--index", "i",
+            "--profile", "uint32",
+            "--guard", "buf_size == 128",
+            "--guard", "i <= 128",
+        )
+        assert r.returncode == 0, r.stderr
+        v = json.loads(r.stdout)
+        assert v["feasible"] is True
+
+    def test_missing_required_arg_exits_2(self):
+        r = _run("raptor-smt-check-oob", "--buffer-size", "buf")
+        assert r.returncode == 2  # argparse: missing --index
+
+
+class TestLibexecCheckNullDeref:
+
+    @_requires_z3
+    def test_unguarded_ptr_feasible(self):
+        r = _run("raptor-smt-check-null-deref", "--ptr", "p")
+        assert r.returncode == 0, r.stderr
+        v = json.loads(r.stdout)
+        assert v["feasible"] is True
+
+    @_requires_z3
+    def test_null_check_blocks(self):
+        r = _run(
+            "raptor-smt-check-null-deref",
+            "--ptr", "p",
+            "--guard", "p != NULL",
+        )
+        assert r.returncode == 0, r.stderr
+        v = json.loads(r.stdout)
+        assert v["feasible"] is False
+
+    def test_missing_ptr_exits_2(self):
+        r = _run("raptor-smt-check-null-deref")
+        assert r.returncode == 2


### PR DESCRIPTION
Three pattern-named SMT verbs that the LLM reaches for when the source matches a known shape, instead of reconstructing the encoding ad-hoc through validate_path():

- check_overflow(operands, op, profile, kind=unsigned_wrap|signed_wrap)
- check_oob(buffer_size, index, profile)
- check_null_deref(ptr, profile)

Each is a thin verb that builds its intrinsic Z3 predicate directly via core.smt_solver.csem (uadd_overflows, umul_overflows, usub_underflows, sadd_overflows, smul_overflows) — no string concat, no parser round-trip for the verb's own predicate.  The intrinsic is provably right by construction (csem is the C-semantics module).

Operand forms: identifier (count), numeric literal (16, 0x10), or balanced function-call shape (strlen(input), sizeof(record)) — function calls go through the same free-variable fallback as PR #244, allocating a fresh _anon_N Z3 variable.  The over-approximation caveat from #244 applies and is documented in the skill prompt.

Caller-supplied guards still go through the standard parser, inheriting PR #241 (English-phrase canonicalisation) and PR #244 (free-var fallback) transparently.  Compound non-call operands (a + b, *p, s->len) are rejected at the verb layer with a clear ValueError pointing at raptor-smt-validate-path for free-form predicates.

Multi-operand chains compose correctly: per-step overflow predicates ORed together, so wrap at any binary step in a chain like a*b*c is detected (not just the final result vs first operand).

Profile/kind compatibility checked at the verb layer: unsigned_wrap requires unsigned profile; signed_wrap requires signed. signed_wrap not supported with '-' (subtraction's signed-overflow shape needs opposite-sign operands, too narrow for the binary template).

smt_path_validator.py refactored:
- Factor _classify_text_condition + _solve_pending out of check_path_feasibility — shared with the new check_verb_feasibility
- New public make_var / make_val / make_anon_call_var / is_balanced_call helpers for verb operand construction
- _next_anon_index helper shared between parser-side _substitute_calls (#244) and verb-side make_anon_call_var so anon namespaces don't collide.  Existing 79 path-validator tests pass unchanged.

Stage E skill (stage-e-feasibility.md) gains:
- [E-3 SMT] decision tree: --from-trace first (PR-2), named verbs second (this PR), free-form validate-path third (#225)
- [E-3d] section listing the three verbs with usage and CLI invocations

Tests: 62 verb tests covering canonical bug shapes, profile/kind mismatch rejection, compound-operand rejection, function-call operand fallback, distinct-anon-vars-for-distinct-calls, JSON serialisation, libexec end-to-end. Full repo: 2596 passed, 1 pre-existing skip.