### PR TITLE
sandbox: per-run sandbox-summary.json with structured denials and suggested-fix hints

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,7 @@
       "Bash(libexec/raptor-run-feasibility *)",
       "Bash(libexec/raptor-run-lifecycle *)",
       "Bash(libexec/raptor-run-sandboxed *)",
+      "Bash(libexec/raptor-sandbox-summary *)",
       "Bash(libexec/raptor-startup-check *)",
       "Bash(libexec/raptor-validate-schema *)",
       "Write(/out/**)",

--- a/core/run/metadata.py
+++ b/core/run/metadata.py
@@ -101,6 +101,13 @@ def start_run(output_dir: Path, command: str, extra: Dict[str, Any] = None,
         metadata["session_pid"] = session_pid
     if target:
         metadata["target_path"] = str(target)
+    # Mark this run as the active sandbox-summary recording target before
+    # any further setup work — guarantees that any sandbox calls made by
+    # _setup_checklist_symlink (or anything else added later between save_json
+    # and return) get recorded into this run's summary.
+    # Lazy import to avoid circular core.sandbox load on metadata import.
+    from core.sandbox.summary import set_active_run_dir
+    set_active_run_dir(output_dir)
     save_json(output_dir / RUN_METADATA_FILE, metadata)
     _setup_checklist_symlink(output_dir)
     return output_dir
@@ -240,8 +247,61 @@ def _promote_checklist(project_dir: Path) -> None:
     save_json(project_dir / "checklist.json", promoted)
 
 
+def _finalize_sandbox_summary(output_dir: Path) -> None:
+    """Write sandbox-summary.json (if any denials recorded) and clear the
+    active-run state. Called from every terminal-state transition so the
+    summary lands regardless of how the run ended.
+
+    Broad except: lifecycle hooks must never raise out of complete_run /
+    fail_run / cancel_run on account of summary-write failures. Today
+    summarize_and_write catches its own OSErrors and returns None, but a
+    future change introducing a different exception path shouldn't break
+    the lifecycle. The active-run state is always cleared in finally.
+    """
+    # Lazy import to keep core.sandbox out of metadata import time.
+    from core.sandbox.summary import (
+        summarize_and_write, set_active_run_dir, SUMMARY_FILE,
+    )
+    import logging
+    log = logging.getLogger(__name__)
+    try:
+        result = summarize_and_write(output_dir)
+        # Discoverability: if denials were captured, tell operators
+        # where the report is + how many entries. Silent when no denials
+        # (don't add chatter to clean runs).
+        if result is not None:
+            log.info(
+                "sandbox: %d denials this run → %s",
+                result.get("total_denials", 0),
+                output_dir / SUMMARY_FILE,
+            )
+    except Exception:  # noqa: BLE001 — never fail lifecycle on summary error
+        # Debug-only log so a developer can find swallowed exceptions
+        # when investigating "why is my summary missing?". INFO would be
+        # too noisy if the failure is recurrent.
+        log.debug(
+            "_finalize_sandbox_summary: summarize_and_write failed",
+            exc_info=True,
+        )
+    finally:
+        # Always clear active-run state, even if summary write failed —
+        # otherwise subsequent runs would record into a stale path.
+        set_active_run_dir(None)
+
+
+# Sandbox summary is finalized BEFORE the status update in every terminal-
+# state transition. If the process crashes between the two:
+#  - finalize-then-status-update path: status stays "running", summary on
+#    disk. A later cleanup-of-stale-runs marks the status appropriately;
+#    summary is already there. No data lost.
+#  - status-update-then-finalize path (the alternative): status flips to
+#    "completed" but no summary; reader assumes "no denials" because no
+#    file. Misleading.
+# Finalizing first preserves the data; status update is just the signal.
+
 def complete_run(output_dir: Path, extra: Dict[str, Any] = None) -> None:
     """Update .raptor-run.json to status=completed."""
+    _finalize_sandbox_summary(output_dir)
     _update_status(output_dir, STATUS_COMPLETED, extra)
 
 
@@ -251,11 +311,13 @@ def fail_run(output_dir: Path, error: str = None, extra: Dict[str, Any] = None,
     extra = extra or {}
     if error:
         extra["error"] = error
+    _finalize_sandbox_summary(output_dir)
     _update_status(output_dir, STATUS_FAILED, extra, record_timing=record_timing)
 
 
 def cancel_run(output_dir: Path, extra: Dict[str, Any] = None) -> None:
     """Update .raptor-run.json to status=cancelled."""
+    _finalize_sandbox_summary(output_dir)
     _update_status(output_dir, STATUS_CANCELLED, extra)
 
 

--- a/core/sandbox/observe.py
+++ b/core/sandbox/observe.py
@@ -19,6 +19,8 @@ import signal
 import subprocess
 from pathlib import Path
 
+from core.sandbox.summary import record_denial
+
 logger = logging.getLogger(__name__)
 
 # Truncate the command in single-line log messages so scan-loop output
@@ -307,12 +309,17 @@ def _check_blocked(stderr: str, cmd_display: str, returncode: int = 0,
         # Factual, non-accusatory log. Downstream tools still see the evidence
         # in sandbox_info["blocked"]; the human-facing log just notes what
         # happened without speculating about intent.
+        # Each denial also records to the per-run sandbox-summary if a run
+        # is active (see core/sandbox/summary.py) — gives operators a
+        # post-run aggregate of what the sandbox blocked, with suggested
+        # fixes, instead of forcing them to grep log lines.
         if category == "network":
             logger.info(
                 f"Sandbox: outbound network blocked during: {cmd_display} "
                 f"(rc={returncode})"
             )
             blocked_evidence.append("Attempted outbound network connection (blocked by sandbox)")
+            record_denial(cmd_display, returncode, "network")
         elif category == "write":
             path_note = f" to {attempted_path}" if attempted_path else ""
             logger.info(
@@ -321,8 +328,10 @@ def _check_blocked(stderr: str, cmd_display: str, returncode: int = 0,
             )
             if attempted_path:
                 blocked_evidence.append(f"Attempted write to {attempted_path} (blocked by sandbox)")
+                record_denial(cmd_display, returncode, "write", path=attempted_path)
             else:
                 blocked_evidence.append("Attempted write outside allowed paths (blocked by sandbox)")
+                record_denial(cmd_display, returncode, "write")
         elif category == "seccomp":
             # Actionable diagnostic — name the knob users can turn. Debug
             # unblocks ptrace; network-only turns off Landlock AND seccomp
@@ -341,6 +350,8 @@ def _check_blocked(stderr: str, cmd_display: str, returncode: int = 0,
                 f"Syscall denied by seccomp (profile={seccomp_profile!r}) — "
                 f"caller may need to relax sandbox"
             )
+            record_denial(cmd_display, returncode, "seccomp",
+                          profile=seccomp_profile)
 
         reported.add(category)
 

--- a/core/sandbox/summary.py
+++ b/core/sandbox/summary.py
@@ -304,28 +304,105 @@ def summarize_and_write(run_dir: Path) -> Optional[Dict[str, Any]]:
 def _cli_main(argv: Optional[list] = None) -> int:
     """Retroactive summarize CLI.
 
-    Use case: a process crashed mid-run, leaving .sandbox-denials.jsonl
-    on disk but no sandbox-summary.json (lifecycle complete/fail/cancel
-    never ran). An operator (or a recovery script) can finalize the
-    summary after the fact:
+    Rarely needed in normal operation: ``core.run.metadata._cleanup_abandoned``
+    already finalizes the summary for the common Esc-then-retry case (same
+    Claude Code session, same command type) by promoting the prior run from
+    ``status=running`` to ``failed`` — which routes through ``fail_run`` and
+    therefore through the standard ``_finalize_sandbox_summary`` path.
 
-        python -m core.sandbox.summary <run_dir>
+    This CLI is the explicit fallback for cases the auto-recovery doesn't
+    cover: a hard kill, a different session, a different command type, or
+    operator-driven cleanup of a project dir with several stranded runs.
+
+    Two modes:
+
+        # Single-run mode — finalize one specific run dir.
+        libexec/raptor-sandbox-summary <run_dir>
+
+        # Sweep mode — finalize ALL stranded runs under a project dir.
+        # Iterates direct subdirectories, finalizes any with a leftover
+        # .sandbox-denials.jsonl, skips the rest. Useful for one-off
+        # cleanup of a project that accumulated abandoned runs across
+        # past sessions.
+        libexec/raptor-sandbox-summary --sweep <project_dir>
+
+    The ``python -m core.sandbox.summary`` form also works but emits a
+    runpy double-import warning (``core.sandbox.__init__`` imports
+    ``observe``, which imports this module before runpy executes it as
+    ``__main__``). Prefer the libexec shim, which sidesteps runpy.
     """
+    import argparse
     import sys  # local — keeps module import light for non-CLI consumers
-    args = argv if argv is not None else sys.argv[1:]
-    if len(args) != 1:
-        print("Usage: python -m core.sandbox.summary <run_dir>", file=sys.stderr)
-        return 2
-    run_dir = Path(args[0])
-    if not run_dir.is_dir():
-        print(f"error: {run_dir} is not a directory", file=sys.stderr)
+
+    # No explicit prog= — argparse uses sys.argv[0]'s basename, so the
+    # help text reflects whichever entry point invoked us
+    # (libexec/raptor-sandbox-summary, or `python -m core.sandbox.summary`).
+    parser = argparse.ArgumentParser(
+        description="Retroactively finalize sandbox-summary.json for runs "
+                    "whose lifecycle didn't complete.",
+    )
+    parser.add_argument(
+        "path",
+        help="run directory (single-run mode) or project directory (--sweep mode)",
+    )
+    parser.add_argument(
+        "--sweep",
+        action="store_true",
+        help="finalize every stranded run under PATH (treats PATH as a "
+             "project dir containing run subdirectories)",
+    )
+    try:
+        args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+    except SystemExit as e:
+        # argparse exits 2 on bad args; preserve that contract
+        return e.code if isinstance(e.code, int) else 2
+
+    target = Path(args.path)
+    if not target.is_dir():
+        print(f"error: {target} is not a directory", file=sys.stderr)
         return 1
-    result = summarize_and_write(run_dir)
-    if result is None:
-        print(f"(no denials recorded for {run_dir})")
+
+    if not args.sweep:
+        # Single-run mode (original behaviour)
+        result = summarize_and_write(target)
+        if result is None:
+            print(f"(no denials recorded for {target})")
+            return 0
+        print(f"Wrote {target / SUMMARY_FILE} ({result['total_denials']} denials, "
+              f"by_type={result['by_type']})")
         return 0
-    print(f"Wrote {run_dir / SUMMARY_FILE} ({result['total_denials']} denials, "
-          f"by_type={result['by_type']})")
+
+    # Sweep mode — iterate children, finalize anything with a stranded JSONL.
+    swept = 0
+    written = 0
+    total_denials = 0
+    try:
+        children = sorted(target.iterdir())
+    except OSError as e:
+        print(f"error: cannot list {target}: {e}", file=sys.stderr)
+        return 1
+    for child in children:
+        try:
+            if not child.is_dir() or child.name.startswith((".", "_")):
+                continue
+            if not (child / DENIALS_FILE).exists():
+                continue
+        except OSError:
+            continue
+        swept += 1
+        result = summarize_and_write(child)
+        if result is not None:
+            written += 1
+            total_denials += result.get("total_denials", 0)
+            print(f"  {child.name}: {result['total_denials']} denials → "
+                  f"{SUMMARY_FILE}")
+        else:
+            # JSONL was present but summarize_and_write returned None
+            # (empty file or write failure); summarize_and_write already
+            # cleaned the empty JSONL. No per-dir line — keeps output tight.
+            pass
+    print(f"Swept {swept} stranded run(s) under {target}: "
+          f"{written} summary file(s) written, {total_denials} total denials.")
     return 0
 
 

--- a/core/sandbox/summary.py
+++ b/core/sandbox/summary.py
@@ -1,0 +1,333 @@
+"""Per-run sandbox denial summary.
+
+Aggregates sandbox enforcement events (network blocked, write blocked, syscall
+killed) across all sandbox calls in a run, producing a structured
+``sandbox-summary.json`` with suggested-fix hints. Useful regardless of profile
+— even on ``--sandbox full``, operators benefit from a clean post-run report
+of what their workflow tried that the sandbox blocked, instead of grepping
+log lines.
+
+Design:
+- ``set_active_run_dir(path)`` is called by ``core/run/metadata.py:start_run``
+  and cleared at run end.
+- ``record_denial(...)`` is called by ``core/sandbox/observe.py:_check_blocked``
+  for each detected denial. Appends one JSONL line to
+  ``<run_dir>/.sandbox-denials.jsonl``.
+- ``summarize_and_write(run_dir)`` is called by ``core/run/metadata.py``
+  ``complete_run`` / ``fail_run`` / ``cancel_run``. Reads the JSONL, writes
+  ``sandbox-summary.json``, removes the intermediate JSONL.
+
+JSONL append is atomic on POSIX up to PIPE_BUF (~4KB) so concurrent writers
+within the same run (multi-threaded callers) don't corrupt each other. Each
+record is well under PIPE_BUF in practice — `cmd_display` is bounded by
+``_CMD_DISPLAY_MAX_ARGS`` (3 args) and escape_nonprintable'd before reaching
+us. Pathologically long cmd args could exceed PIPE_BUF; defer that defense
+until it surfaces.
+
+Concurrency assumption: the design assumes a single-process, single-active-run
+model. Concurrent threads within a process can record_denial safely (POSIX
+append atomicity). The cross-thread case where one thread is mid-write while
+another thread calls summarize_and_write (which unlinks the JSONL after
+aggregating) is a real but academic race — A's write lands in an orphaned
+inode and is silently lost. If a future caller actually needs concurrent
+finalize, add a per-run lock around record_denial / summarize_and_write.
+
+Multiprocessing caveat: ``_active_run_dir`` is a module global, so child
+processes spawned via ``multiprocessing.Pool`` (or fork+exec from Python)
+inherit ``None`` (or whatever the parent had at fork time, depending on
+the start method). Children's ``record_denial`` calls would no-op unless
+the child explicitly re-establishes active-run state. Today's RAPTOR
+parallelism uses ThreadPoolExecutor (same process, shared state) so this
+isn't a current gap; future authors reaching for ``multiprocessing.Pool``
+should call ``set_active_run_dir(run_dir)`` in the worker initializer.
+
+Opt-out: there's no env var or flag to disable the summary. If a caller
+genuinely doesn't want it (CI noise, perf-sensitive batch), call
+``set_active_run_dir(None)`` after start_run. Per the project's "avoid
+RAPTOR_* env var proliferation" feedback, opt-out via env var is not
+provided.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from core.security.redaction import redact_secrets
+
+logger = logging.getLogger(__name__)
+
+# Module-level active-run state. Set by start_run, cleared at run end.
+# Reads happen unlocked (Python attribute access is atomic — readers see
+# either the old or new pointer, never a torn read). Writes are serialised
+# via _lock so concurrent set/clear can't interleave (matters for
+# tests that exercise the lifecycle from multiple threads).
+_active_run_dir: Optional[Path] = None
+_lock = threading.Lock()
+
+DENIALS_FILE = ".sandbox-denials.jsonl"
+SUMMARY_FILE = "sandbox-summary.json"
+
+# Per-run cap on recorded denials. A malicious target that triggers
+# thousands of network attempts (or any chatty workflow) would otherwise
+# accumulate unbounded GB-scale JSONL. After the cap, further denials
+# are silently dropped with a one-time log warning. The cap reset
+# happens in set_active_run_dir so each run starts fresh.
+MAX_DENIALS_PER_RUN = 10000
+
+# Per-record cmd_display truncation. cmd args are bounded by
+# _CMD_DISPLAY_MAX_ARGS=3 at construction, but pathological single-arg
+# values (very long paths) could push a record past PIPE_BUF (~4KB)
+# and break POSIX append atomicity. 2KB cap leaves room for the rest of
+# the JSON envelope.
+MAX_CMD_LEN = 2048
+
+_denial_count: int = 0  # reset by set_active_run_dir per run
+
+
+def set_active_run_dir(run_dir: Optional[Path]) -> None:
+    """Mark a run as active (or clear it). Subsequent record_denial() calls
+    write to ``<run_dir>/.sandbox-denials.jsonl`` until cleared.
+
+    Resets the per-run denial counter so each run starts with a fresh
+    cap (see MAX_DENIALS_PER_RUN).
+    """
+    global _active_run_dir, _denial_count
+    with _lock:
+        _active_run_dir = Path(run_dir) if run_dir is not None else None
+        _denial_count = 0
+
+
+def get_active_run_dir() -> Optional[Path]:
+    """Return current active run dir, or None if no run is being recorded."""
+    return _active_run_dir
+
+
+def record_denial(cmd_display: str, returncode: int,
+                  denial_type: str, **details: Any) -> None:
+    """Append a denial record to the active run's JSONL file.
+
+    No-op if no active run is set (sandbox call from outside any tracked
+    run, e.g., probes during test setup or sandbox CLI invocations).
+
+    denial_type is one of: ``network``, ``write``, ``seccomp``.
+    details vary by type — `path` for write, `profile` for seccomp, etc.
+    """
+    global _denial_count
+    run_dir = _active_run_dir
+    if run_dir is None:
+        return
+    # Per-run cap: silently drop denials past MAX_DENIALS_PER_RUN. Logs
+    # once at the boundary so a developer can find it. Lock-free
+    # increment is fine under CPython GIL (slight overcount past cap is
+    # acceptable for a DoS defense).
+    _denial_count += 1
+    if _denial_count > MAX_DENIALS_PER_RUN:
+        if _denial_count == MAX_DENIALS_PER_RUN + 1:
+            logger.warning(
+                "sandbox summary cap reached (%d denials this run); "
+                "dropping further denials. Adversarial target or runaway "
+                "workflow?", MAX_DENIALS_PER_RUN,
+            )
+        return
+    # Truncate cmd_display before persisting — defends the POSIX append
+    # atomicity (lines must stay under PIPE_BUF, ~4KB) and bounds JSONL
+    # line size in adversarial cases. _CMD_DISPLAY_MAX_ARGS=3 already
+    # bounds args at the construction site, but pathological single-arg
+    # values (very long paths, env-string args) could still blow up.
+    if len(cmd_display) > MAX_CMD_LEN:
+        cmd_display = cmd_display[:MAX_CMD_LEN - 1] + "…"
+    # Redact secrets in cmd_display before persisting. The string is already
+    # escape_nonprintable'd by context.py at construction, but redact_secrets
+    # is what catches user:pass@host URLs, Bearer/Basic headers, and similar
+    # credential shapes that escape doesn't touch. Logs are typically rotated
+    # frequently (hourly) by syslog/journald; summaries live in the run dir
+    # until the operator runs `/project clean` (days-to-weeks), and operators
+    # paste run-dir contents into bug reports without thinking. The longer
+    # window + the "share without thinking" pattern justify the extra defense.
+    # Spread `details` FIRST so the explicit reserved fields below override
+    # — without this, a caller passing details={"type": "evil", "cmd": ...}
+    # could mask the real denial values.
+    record = {
+        **details,
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "cmd": redact_secrets(cmd_display),
+        "returncode": returncode,
+        "type": denial_type,
+        "suggested_fix": _suggested_fix(denial_type, **details),
+    }
+    # JSONL append: open-write-close per line so each record is atomic.
+    # POSIX guarantees writes < PIPE_BUF (~4KB) are atomic when the file
+    # is opened O_APPEND. Each line is well under that threshold.
+    #
+    # `default=str` defends against future callers passing non-serializable
+    # detail values (Path, datetime, etc.) — without it, json.dumps would
+    # raise TypeError before any I/O, breaking the "sandbox calls must
+    # succeed regardless of summary I/O" promise. We also wrap the whole
+    # block in a broad except to honour that promise even if a future
+    # change introduces a different exception path.
+    try:
+        line = json.dumps(record, ensure_ascii=True, default=str) + "\n"
+        path = run_dir / DENIALS_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # O_NOFOLLOW refuses if path is a symlink — defends against
+        # symlink planted by an attacker who got write access to the
+        # run dir (rare but possible on shared filesystems). Plain
+        # open(path, "a") would have followed and written to the
+        # symlink target. Mode 0o600 keeps the JSONL operator-only.
+        fd = os.open(
+            str(path),
+            os.O_WRONLY | os.O_APPEND | os.O_CREAT | os.O_NOFOLLOW,
+            0o600,
+        )
+        with os.fdopen(fd, "a", encoding="utf-8") as f:
+            f.write(line)
+    except Exception:  # noqa: BLE001 — best-effort; never fail the sandbox call
+        # Debug-only log so a developer chasing "why is my summary empty?"
+        # can find it via RAPTOR_DEBUG / per-module level adjustment.
+        # INFO would be too noisy if the failure is recurrent (e.g., disk
+        # full); DEBUG keeps it findable without flooding normal output.
+        logger.debug("record_denial: failed to append JSONL", exc_info=True)
+
+
+def _suggested_fix(denial_type: str, **details: Any) -> str:
+    """Generate a one-line fix hint mapping denial → operator action.
+
+    Suggestions reference only the actual operator-facing CLI flags
+    exposed by ``core/sandbox/cli.py:add_cli_args`` —
+    ``--sandbox {full,debug,network-only,none}`` and ``--no-sandbox``.
+    Per-host / per-path overrides exist in the sandbox API as kwargs
+    (``proxy_hosts``, ``writable_paths``, ``readable_paths``) but are
+    NOT exposed as CLI flags, so suggesting them would mislead the
+    operator into looking for non-existent flags. The detail value
+    (host, path) appears in the message for context only.
+    """
+    if denial_type == "network":
+        host = details.get("host")
+        ctx = f" to `{host}`" if host else ""
+        return (f"outbound network blocked{ctx}; use `--sandbox none` "
+                f"to allow network (or accept the block)")
+    if denial_type == "write":
+        path = details.get("path")
+        ctx = f" to `{path}`" if path else ""
+        return (f"write outside allowed paths blocked{ctx}; use "
+                f"`--sandbox network-only` or `--sandbox none` to drop "
+                f"Landlock (or move write into target dir)")
+    if denial_type == "seccomp":
+        profile = details.get("profile")
+        if profile == "full":
+            return ("syscall blocked by seccomp; use `--sandbox debug` "
+                    "(allows ptrace) or `--sandbox network-only`/`--sandbox none` "
+                    "(drops seccomp)")
+        return ("syscall blocked by seccomp; use `--sandbox network-only` or "
+                "`--sandbox none` to drop seccomp")
+    return "review denial; no specific suggestion available"
+
+
+def summarize_and_write(run_dir: Path) -> Optional[Dict[str, Any]]:
+    """Read ``<run_dir>/.sandbox-denials.jsonl`` and write
+    ``<run_dir>/sandbox-summary.json`` aggregating all denials.
+
+    Returns the summary dict (also written to disk), or None if no denials
+    were recorded for this run. The intermediate JSONL is removed after
+    successful summary write — operators read the summary, not the JSONL.
+
+    Idempotent: if called again with the same run_dir and no JSONL is
+    present, returns None without writing.
+    """
+    run_dir = Path(run_dir)
+    jsonl = run_dir / DENIALS_FILE
+    if not jsonl.exists():
+        return None
+
+    denials = []
+    try:
+        with open(jsonl, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    denials.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue  # skip malformed lines, keep going
+    except OSError:
+        return None
+
+    if not denials:
+        try:
+            jsonl.unlink()
+        except OSError:
+            pass
+        return None
+
+    by_type: Dict[str, int] = {}
+    for d in denials:
+        t = d.get("type", "unknown")
+        by_type[t] = by_type.get(t, 0) + 1
+
+    summary = {
+        "run_dir": str(run_dir),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "total_denials": len(denials),
+        "by_type": by_type,
+        "denials": denials,
+    }
+
+    summary_path = run_dir / SUMMARY_FILE
+    tmp = summary_path.with_name(f".~{summary_path.name}.tmp")
+    try:
+        tmp.write_text(json.dumps(summary, indent=2, ensure_ascii=True) + "\n",
+                       encoding="utf-8")
+        os.replace(tmp, summary_path)
+    except OSError:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        return None
+
+    # Remove the intermediate JSONL — summary supersedes it.
+    try:
+        jsonl.unlink()
+    except OSError:
+        pass
+
+    return summary
+
+
+def _cli_main(argv: Optional[list] = None) -> int:
+    """Retroactive summarize CLI.
+
+    Use case: a process crashed mid-run, leaving .sandbox-denials.jsonl
+    on disk but no sandbox-summary.json (lifecycle complete/fail/cancel
+    never ran). An operator (or a recovery script) can finalize the
+    summary after the fact:
+
+        python -m core.sandbox.summary <run_dir>
+    """
+    import sys  # local — keeps module import light for non-CLI consumers
+    args = argv if argv is not None else sys.argv[1:]
+    if len(args) != 1:
+        print("Usage: python -m core.sandbox.summary <run_dir>", file=sys.stderr)
+        return 2
+    run_dir = Path(args[0])
+    if not run_dir.is_dir():
+        print(f"error: {run_dir} is not a directory", file=sys.stderr)
+        return 1
+    result = summarize_and_write(run_dir)
+    if result is None:
+        print(f"(no denials recorded for {run_dir})")
+        return 0
+    print(f"Wrote {run_dir / SUMMARY_FILE} ({result['total_denials']} denials, "
+          f"by_type={result['by_type']})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli_main())

--- a/core/sandbox/tests/test_e2e_sandbox.py
+++ b/core/sandbox/tests/test_e2e_sandbox.py
@@ -1871,5 +1871,70 @@ class TestE2EMaliciousMakefile(unittest.TestCase):
             self.assertIn("exfil_blocked", result.stdout + result.stderr)
 
 
+class TestE2ESandboxSummaryRecording(unittest.TestCase):
+    """End-to-end: real sandboxed subprocess produces a real denial → the
+    per-run sandbox-summary.json captures it with structured data and a
+    suggested-fix hint.
+
+    Exercises the full path: lifecycle start_run → sandbox_run with real
+    enforcement → observe._check_blocked detects denial from real stderr →
+    summary.record_denial appends to JSONL → lifecycle complete_run
+    finalizes summary. Unlike TestLifecycleIntegration (which feeds
+    synthetic stderr into _check_blocked), this proves the wiring under
+    the actual sandbox layers."""
+
+    def setUp(self):
+        if not check_net_available():
+            self.skipTest("User namespaces not available")
+
+    def test_blocked_network_lands_in_sandbox_summary(self):
+        import json as _json
+        from core.run.metadata import start_run, complete_run
+        from core.sandbox.summary import (
+            DENIALS_FILE, SUMMARY_FILE, set_active_run_dir,
+        )
+
+        with TemporaryDirectory() as d:
+            run_dir = Path(d) / "scan-e2e"
+            try:
+                start_run(run_dir, command="scan")
+
+                # Real sandboxed subprocess that hits a blocked-network path.
+                # Python socket connect produces a stderr signature
+                # observe._check_blocked recognises (network category).
+                sandbox_run(
+                    ["python3", "-c",
+                     "import socket; s=socket.socket(); s.settimeout(2); "
+                     "s.connect(('1.1.1.1', 80))"],
+                    block_network=True, capture_output=True, text=True, timeout=10,
+                )
+
+                complete_run(run_dir)
+
+                # Summary file present, JSONL cleaned up
+                summary_path = run_dir / SUMMARY_FILE
+                self.assertTrue(summary_path.exists(),
+                                f"sandbox-summary.json missing at {summary_path}")
+                self.assertFalse((run_dir / DENIALS_FILE).exists(),
+                                 "intermediate JSONL should be removed after summary")
+
+                summary = _json.loads(summary_path.read_text())
+                # Network denial captured
+                self.assertGreaterEqual(summary["total_denials"], 1)
+                self.assertIn("network", summary["by_type"])
+                # At least one denial references network with a suggested fix
+                # that mentions a real CLI flag
+                network_denials = [d for d in summary["denials"]
+                                   if d["type"] == "network"]
+                self.assertGreaterEqual(len(network_denials), 1)
+                fix = network_denials[0]["suggested_fix"]
+                self.assertIn("--sandbox", fix)
+            finally:
+                # Defensive: ensure no leaked active-run state if the test
+                # fails partway through (test isolation for any test that
+                # runs after this one in the same process).
+                set_active_run_dir(None)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/core/sandbox/tests/test_summary.py
+++ b/core/sandbox/tests/test_summary.py
@@ -1,0 +1,587 @@
+"""Tests for core.sandbox.summary — per-run sandbox denial aggregation."""
+
+import json
+import os
+import threading
+from pathlib import Path
+
+import pytest
+
+from core.sandbox import summary as summary_mod
+
+
+@pytest.fixture(autouse=True)
+def _isolate_active_run():
+    """Each test starts and ends with no active run set, regardless of
+    whether the test itself sets one."""
+    summary_mod.set_active_run_dir(None)
+    yield
+    summary_mod.set_active_run_dir(None)
+
+
+class TestActiveRunState:
+    def test_initially_none(self):
+        assert summary_mod.get_active_run_dir() is None
+
+    def test_set_and_clear(self, tmp_path):
+        summary_mod.set_active_run_dir(tmp_path)
+        assert summary_mod.get_active_run_dir() == tmp_path
+        summary_mod.set_active_run_dir(None)
+        assert summary_mod.get_active_run_dir() is None
+
+    def test_set_accepts_str_or_path(self, tmp_path):
+        summary_mod.set_active_run_dir(str(tmp_path))
+        assert summary_mod.get_active_run_dir() == Path(tmp_path)
+
+
+class TestRecordDenial:
+    def test_no_op_when_no_active_run(self, tmp_path):
+        # Must not crash, must not write anywhere
+        summary_mod.record_denial("git clone", 1, "network")
+        assert list(tmp_path.iterdir()) == []
+
+    def test_appends_jsonl_when_active(self, tmp_path):
+        summary_mod.set_active_run_dir(tmp_path)
+        summary_mod.record_denial("git clone evil.com", 1, "network")
+        jsonl = tmp_path / summary_mod.DENIALS_FILE
+        assert jsonl.exists()
+        records = [json.loads(line) for line in jsonl.read_text().splitlines() if line]
+        assert len(records) == 1
+        r = records[0]
+        assert r["cmd"] == "git clone evil.com"
+        assert r["returncode"] == 1
+        assert r["type"] == "network"
+        assert "suggested_fix" in r
+        assert "ts" in r
+
+    def test_multiple_records_append(self, tmp_path):
+        summary_mod.set_active_run_dir(tmp_path)
+        summary_mod.record_denial("cmd1", 1, "network")
+        summary_mod.record_denial("cmd2", 1, "write", path="/etc/foo")
+        summary_mod.record_denial("cmd3", 137, "seccomp", profile="full")
+        jsonl = tmp_path / summary_mod.DENIALS_FILE
+        records = [json.loads(line) for line in jsonl.read_text().splitlines() if line]
+        assert len(records) == 3
+        assert [r["type"] for r in records] == ["network", "write", "seccomp"]
+        # type-specific details preserved
+        assert records[1]["path"] == "/etc/foo"
+        assert records[2]["profile"] == "full"
+
+    def test_swallows_oserror_silently(self, tmp_path, monkeypatch):
+        # If the run dir disappears mid-write, record_denial must not
+        # raise — sandbox calls must succeed regardless of summary I/O.
+        summary_mod.set_active_run_dir(tmp_path / "does-not-exist")
+
+        def boom(*a, **k):
+            raise OSError("simulated disk full")
+
+        monkeypatch.setattr("builtins.open", boom)
+        # Must not propagate the OSError
+        summary_mod.record_denial("cmd", 1, "network")
+
+    def test_serialises_non_jsonable_details_via_default_str(self, tmp_path):
+        # Regression for 2R4 / 1R2 fix: future callers passing Path objects
+        # (or other non-JSON-native values) must not crash record_denial.
+        # `default=str` in json.dumps coerces them; the broad except catches
+        # anything else.
+        summary_mod.set_active_run_dir(tmp_path)
+        non_jsonable = Path("/tmp/some/path")  # Path is not JSON-serializable
+        # Must not raise
+        summary_mod.record_denial("cmd", 1, "write", path=non_jsonable)
+        jsonl = tmp_path / summary_mod.DENIALS_FILE
+        records = [json.loads(line) for line in jsonl.read_text().splitlines() if line]
+        assert len(records) == 1
+        # Coerced to string via default=str
+        assert records[0]["path"] == "/tmp/some/path"
+
+
+class TestSuggestedFix:
+    def test_network_with_host(self):
+        s = summary_mod._suggested_fix("network", host="evil.com")
+        assert "evil.com" in s
+        # Must reference an actual operator-facing flag, not the kwarg form.
+        assert "--sandbox" in s
+        assert "none" in s
+
+    def test_network_without_host(self):
+        s = summary_mod._suggested_fix("network")
+        assert "--sandbox" in s
+        assert "none" in s
+
+    def test_write_with_path(self):
+        s = summary_mod._suggested_fix("write", path="/etc/foo")
+        assert "/etc/foo" in s
+        assert "--sandbox" in s
+        # network-only drops Landlock (the layer that blocks writes)
+        assert "network-only" in s
+
+    def test_seccomp_full_profile(self):
+        s = summary_mod._suggested_fix("seccomp", profile="full")
+        assert "--sandbox" in s
+        assert "debug" in s
+
+    def test_seccomp_other_profile(self):
+        s = summary_mod._suggested_fix("seccomp", profile="custom")
+        assert "--sandbox" in s
+
+    def test_unknown_type_returns_generic(self):
+        s = summary_mod._suggested_fix("mystery")
+        assert s  # non-empty
+
+    def test_no_kwarg_flag_names_in_suggestions(self):
+        # Regression for 2R1: suggestions MUST NOT reference --proxy-hosts,
+        # --writable-paths, --readable-paths since none exist as actual CLI
+        # flags (they're sandbox API kwargs only). Operators reading the
+        # summary would otherwise look for flags that don't exist.
+        for dt, kwargs in [
+            ("network", {}), ("network", {"host": "x"}),
+            ("write", {}), ("write", {"path": "/x"}),
+            ("seccomp", {"profile": "full"}),
+            ("seccomp", {"profile": "other"}),
+        ]:
+            s = summary_mod._suggested_fix(dt, **kwargs)
+            assert "--proxy-hosts" not in s, f"stale flag in {dt}: {s}"
+            assert "--writable-paths" not in s, f"stale flag in {dt}: {s}"
+            assert "--readable-paths" not in s, f"stale flag in {dt}: {s}"
+
+
+class TestSummarizeAndWrite:
+    def test_no_jsonl_returns_none(self, tmp_path):
+        result = summary_mod.summarize_and_write(tmp_path)
+        assert result is None
+        assert not (tmp_path / summary_mod.SUMMARY_FILE).exists()
+
+    def test_aggregates_jsonl_into_summary(self, tmp_path):
+        summary_mod.set_active_run_dir(tmp_path)
+        summary_mod.record_denial("cmd1", 1, "network")
+        summary_mod.record_denial("cmd2", 1, "network")
+        summary_mod.record_denial("cmd3", 1, "write", path="/etc/x")
+        summary_mod.record_denial("cmd4", 137, "seccomp", profile="full")
+
+        result = summary_mod.summarize_and_write(tmp_path)
+        assert result is not None
+        assert result["total_denials"] == 4
+        assert result["by_type"] == {"network": 2, "write": 1, "seccomp": 1}
+        assert len(result["denials"]) == 4
+
+        # Summary file written
+        summary_path = tmp_path / summary_mod.SUMMARY_FILE
+        assert summary_path.exists()
+        on_disk = json.loads(summary_path.read_text())
+        assert on_disk["total_denials"] == 4
+
+        # Intermediate JSONL removed
+        assert not (tmp_path / summary_mod.DENIALS_FILE).exists()
+
+    def test_idempotent_when_called_twice(self, tmp_path):
+        summary_mod.set_active_run_dir(tmp_path)
+        summary_mod.record_denial("cmd", 1, "network")
+        first = summary_mod.summarize_and_write(tmp_path)
+        second = summary_mod.summarize_and_write(tmp_path)
+        # First call wrote summary + removed JSONL; second call sees no
+        # JSONL and returns None without overwriting the existing summary.
+        assert first is not None
+        assert second is None
+        # Summary file from first call still intact
+        assert (tmp_path / summary_mod.SUMMARY_FILE).exists()
+
+    def test_skips_malformed_jsonl_lines(self, tmp_path):
+        # Pre-populate JSONL with one valid + one garbage line
+        jsonl = tmp_path / summary_mod.DENIALS_FILE
+        jsonl.write_text(
+            json.dumps({"ts": "x", "type": "network", "cmd": "c", "returncode": 1}) + "\n"
+            "this is not json\n"
+            + json.dumps({"ts": "y", "type": "write", "cmd": "c2", "returncode": 1}) + "\n"
+        )
+        result = summary_mod.summarize_and_write(tmp_path)
+        # Two valid records survived; garbage skipped without error
+        assert result["total_denials"] == 2
+
+    def test_empty_jsonl_returns_none_and_removes_jsonl(self, tmp_path):
+        jsonl = tmp_path / summary_mod.DENIALS_FILE
+        jsonl.write_text("")
+        result = summary_mod.summarize_and_write(tmp_path)
+        assert result is None
+        assert not jsonl.exists()
+
+
+class TestThreadSafety:
+    def test_concurrent_set_clear_is_serialised(self, tmp_path):
+        # Hammer set/clear from multiple threads; the lock should keep
+        # state consistent (no torn reads of the global).
+        results = []
+
+        def worker(d):
+            for _ in range(50):
+                summary_mod.set_active_run_dir(d)
+                got = summary_mod.get_active_run_dir()
+                results.append(got)
+                summary_mod.set_active_run_dir(None)
+
+        threads = [threading.Thread(target=worker, args=(tmp_path / f"d{i}",))
+                   for i in range(4)]
+        for t in threads: t.start()
+        for t in threads: t.join()
+        # All non-None observations should be one of the four target dirs
+        valid = {tmp_path / f"d{i}" for i in range(4)}
+        for r in results:
+            if r is not None:
+                assert r in valid
+
+    def test_concurrent_record_denial_doesnt_lose_records(self, tmp_path):
+        # Multiple threads recording denials concurrently should all land
+        # in the JSONL — POSIX append + small line size means atomicity.
+        summary_mod.set_active_run_dir(tmp_path)
+        n_threads = 8
+        per_thread = 25
+
+        def worker(tid):
+            for i in range(per_thread):
+                summary_mod.record_denial(f"cmd-t{tid}-{i}", 1, "network")
+
+        threads = [threading.Thread(target=worker, args=(t,)) for t in range(n_threads)]
+        for t in threads: t.start()
+        for t in threads: t.join()
+
+        jsonl = tmp_path / summary_mod.DENIALS_FILE
+        records = [json.loads(line) for line in jsonl.read_text().splitlines() if line]
+        # All n_threads * per_thread records should be present
+        assert len(records) == n_threads * per_thread
+
+
+class TestLifecycleIntegration:
+    """End-to-end: start_run → record_denial fires from _check_blocked →
+    complete_run writes summary. Verifies the wiring across modules."""
+
+    def test_full_lifecycle_writes_summary(self, tmp_path):
+        from core.run.metadata import start_run, complete_run
+        from core.sandbox.observe import _check_blocked
+
+        run_dir = tmp_path / "agentic-20260427-150000-pid12345"
+
+        # Start the run — should mark this dir as active for sandbox summary
+        start_run(run_dir, command="agentic")
+        assert summary_mod.get_active_run_dir() == run_dir
+
+        # Simulate a sandbox call that detects an outbound network attempt.
+        # _check_blocked is what observe calls after each subprocess; it
+        # fires record_denial for each detected denial type.
+        sandbox_info = {}
+        _check_blocked(
+            stderr="curl: (7) Failed to connect to evil.com\n",
+            cmd_display="curl evil.com",
+            returncode=7,
+            sandbox_info=sandbox_info,
+            network_engaged=True,
+        )
+
+        # Denial recorded in the JSONL
+        jsonl = run_dir / summary_mod.DENIALS_FILE
+        assert jsonl.exists()
+
+        # Complete the run — should finalize summary + clear active state
+        complete_run(run_dir)
+        assert summary_mod.get_active_run_dir() is None
+
+        # Summary file written, JSONL cleaned up
+        summary_path = run_dir / summary_mod.SUMMARY_FILE
+        assert summary_path.exists()
+        assert not jsonl.exists()
+
+        on_disk = json.loads(summary_path.read_text())
+        assert on_disk["total_denials"] == 1
+        assert on_disk["by_type"] == {"network": 1}
+        assert on_disk["denials"][0]["type"] == "network"
+        assert "--sandbox" in on_disk["denials"][0]["suggested_fix"]
+
+    def test_failed_run_still_writes_summary(self, tmp_path):
+        from core.run.metadata import start_run, fail_run
+        from core.sandbox.observe import _check_blocked
+
+        run_dir = tmp_path / "scan-failed"
+        start_run(run_dir, command="scan")
+        _check_blocked(
+            stderr="cannot create '/etc/blocked': Permission denied\n",
+            cmd_display="tool /etc/blocked",
+            returncode=1,
+            sandbox_info={},
+            landlock_engaged=True,
+        )
+        fail_run(run_dir, error="something broke")
+
+        # Summary lands even on failed run (operators want to see what
+        # was blocked when diagnosing why the run failed)
+        summary_path = run_dir / summary_mod.SUMMARY_FILE
+        assert summary_path.exists()
+        on_disk = json.loads(summary_path.read_text())
+        assert on_disk["by_type"] == {"write": 1}
+
+    def test_sandbox_call_outside_run_does_nothing(self, tmp_path):
+        # No start_run → record_denial is a no-op → no files anywhere
+        from core.sandbox.observe import _check_blocked
+
+        _check_blocked(
+            stderr="curl: (7) Failed to connect\n",
+            cmd_display="curl",
+            returncode=7,
+            sandbox_info={},
+            network_engaged=True,
+        )
+        # No files created
+        assert list(tmp_path.iterdir()) == []
+
+
+class TestTrackedRunIntegration:
+    """tracked_run() context manager wraps start_run + complete/fail/cancel.
+    Summary recording must work for all three exit paths."""
+
+    def _trigger_denial(self, cmd_display="curl", returncode=7):
+        from core.sandbox.observe import _check_blocked
+        _check_blocked(
+            stderr="curl: (7) Failed to connect to evil.com\n",
+            cmd_display=cmd_display,
+            returncode=returncode,
+            sandbox_info={},
+            network_engaged=True,
+        )
+
+    def test_normal_exit_writes_summary(self, tmp_path):
+        from core.run.metadata import tracked_run
+        run_dir = tmp_path / "scan-normal"
+        with tracked_run(run_dir, command="scan") as rd:
+            assert summary_mod.get_active_run_dir() == rd
+            self._trigger_denial()
+        # Context exited normally → complete_run called → summary written
+        assert (run_dir / summary_mod.SUMMARY_FILE).exists()
+        assert summary_mod.get_active_run_dir() is None
+        on_disk = json.loads((run_dir / summary_mod.SUMMARY_FILE).read_text())
+        assert on_disk["total_denials"] == 1
+
+    def test_exception_writes_summary_via_fail_run(self, tmp_path):
+        from core.run.metadata import tracked_run
+        run_dir = tmp_path / "scan-failed"
+
+        with pytest.raises(RuntimeError):
+            with tracked_run(run_dir, command="scan"):
+                self._trigger_denial()
+                raise RuntimeError("simulated workflow failure")
+
+        # Context exited via exception → fail_run called → summary written
+        assert (run_dir / summary_mod.SUMMARY_FILE).exists()
+        assert summary_mod.get_active_run_dir() is None
+
+    def test_keyboard_interrupt_writes_summary_via_cancel_run(self, tmp_path):
+        from core.run.metadata import tracked_run
+        run_dir = tmp_path / "scan-cancelled"
+
+        with pytest.raises(KeyboardInterrupt):
+            with tracked_run(run_dir, command="scan"):
+                self._trigger_denial()
+                raise KeyboardInterrupt()
+
+        # Context exited via Ctrl-C → cancel_run called → summary written
+        # (operators want to see what was blocked even on cancelled runs)
+        assert (run_dir / summary_mod.SUMMARY_FILE).exists()
+        assert summary_mod.get_active_run_dir() is None
+
+
+class TestRedactsSecretsInCmd:
+    """Per 3R1, cmd_display is redact_secrets'd before persisting because
+    the summary lives on disk indefinitely (operators paste run dirs into
+    bug reports). Original log lines are ephemeral; the JSONL/summary is not."""
+
+    def test_url_credentials_redacted(self, tmp_path):
+        summary_mod.set_active_run_dir(tmp_path)
+        summary_mod.record_denial(
+            "git clone https://user:secretpass@github.com/x/y.git",
+            1, "network",
+        )
+        records = [
+            json.loads(line)
+            for line in (tmp_path / summary_mod.DENIALS_FILE).read_text().splitlines()
+            if line
+        ]
+        assert "secretpass" not in records[0]["cmd"]
+        assert "REDACTED" in records[0]["cmd"]
+
+    def test_bearer_header_redacted(self, tmp_path):
+        summary_mod.set_active_run_dir(tmp_path)
+        summary_mod.record_denial(
+            "curl -H 'Authorization: Bearer abcdef1234567890abcdef1234567890' https://api.example.com",
+            1, "network",
+        )
+        records = [
+            json.loads(line)
+            for line in (tmp_path / summary_mod.DENIALS_FILE).read_text().splitlines()
+            if line
+        ]
+        assert "abcdef1234567890" not in records[0]["cmd"]
+        assert "REDACTED" in records[0]["cmd"]
+
+    def test_clean_cmd_passes_through(self, tmp_path):
+        summary_mod.set_active_run_dir(tmp_path)
+        summary_mod.record_denial("git clone https://github.com/foo/bar", 1, "network")
+        records = [
+            json.loads(line)
+            for line in (tmp_path / summary_mod.DENIALS_FILE).read_text().splitlines()
+            if line
+        ]
+        # No secrets to redact → cmd preserved verbatim
+        assert records[0]["cmd"] == "git clone https://github.com/foo/bar"
+
+
+class TestCli:
+    """`python -m core.sandbox.summary <run_dir>` recovery tool — used when
+    a process crashed mid-run and never finalized the summary."""
+
+    def test_summarizes_existing_jsonl(self, tmp_path, capsys):
+        # Pre-populate JSONL as if a crashed run had recorded denials.
+        jsonl = tmp_path / summary_mod.DENIALS_FILE
+        jsonl.write_text(
+            json.dumps({"ts": "2026-04-27T15:00:00Z", "cmd": "c1",
+                        "returncode": 1, "type": "network",
+                        "suggested_fix": "..."}) + "\n"
+            + json.dumps({"ts": "2026-04-27T15:00:01Z", "cmd": "c2",
+                          "returncode": 1, "type": "write",
+                          "suggested_fix": "..."}) + "\n"
+        )
+
+        rc = summary_mod._cli_main([str(tmp_path)])
+        assert rc == 0
+
+        # Stdout reports what was written
+        out = capsys.readouterr().out
+        assert "Wrote" in out
+        assert "2 denials" in out
+
+        # Summary file present, JSONL removed
+        assert (tmp_path / summary_mod.SUMMARY_FILE).exists()
+        assert not jsonl.exists()
+
+    def test_no_denials_message_when_jsonl_absent(self, tmp_path, capsys):
+        # Run dir exists but no JSONL → "no denials" + success exit
+        rc = summary_mod._cli_main([str(tmp_path)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "no denials" in out
+
+    def test_nonexistent_dir_exits_1(self, tmp_path, capsys):
+        bogus = tmp_path / "does-not-exist"
+        rc = summary_mod._cli_main([str(bogus)])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "not a directory" in err
+
+    def test_path_to_file_not_dir_exits_1(self, tmp_path, capsys):
+        f = tmp_path / "a-file"
+        f.write_text("")
+        rc = summary_mod._cli_main([str(f)])
+        assert rc == 1
+
+    def test_no_args_exits_2(self, capsys):
+        rc = summary_mod._cli_main([])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "Usage" in err
+
+    def test_too_many_args_exits_2(self, tmp_path, capsys):
+        rc = summary_mod._cli_main([str(tmp_path), "extra"])
+        assert rc == 2
+
+
+class TestAdversarial:
+    """Adversarial-review fixes — verify defenses against
+    misuse / DoS / symlink attacks / pathological inputs."""
+
+    # ADV1
+    def test_details_cannot_override_reserved_fields(self, tmp_path):
+        # A caller that passed details containing reserved record keys
+        # (`type`, `cmd`, `suggested_fix`, `ts`) used to mask the real
+        # values via the dict spread. Fixed by spreading details FIRST
+        # so explicit fields override.
+        # Note: `returncode` and `denial_type` are positional/named
+        # parameters of record_denial itself — passing them as kwargs
+        # would TypeError before reaching the dict spread, so they're
+        # not in scope for this footgun. The reserved RECORD keys that
+        # CAN slip through via **details are: ts, cmd, type,
+        # suggested_fix.
+        summary_mod.set_active_run_dir(tmp_path)
+        summary_mod.record_denial(
+            "real-cmd", 137, "seccomp",
+            type="EVIL_TYPE",
+            cmd="EVIL_CMD",
+            suggested_fix="EVIL_FIX",
+            ts="EVIL_TS",
+        )
+        records = [json.loads(l) for l in
+                   (tmp_path / summary_mod.DENIALS_FILE).read_text().splitlines() if l]
+        r = records[0]
+        # Explicit args win — the rogue details didn't override
+        assert r["type"] == "seccomp"
+        assert r["cmd"] == "real-cmd"
+        assert r["suggested_fix"] != "EVIL_FIX"
+        assert r["ts"] != "EVIL_TS"
+        assert r["returncode"] == 137
+
+    # ADV2
+    def test_per_run_cap_drops_excess_denials(self, tmp_path, monkeypatch):
+        # Lower the cap so the test runs fast.
+        monkeypatch.setattr(summary_mod, "MAX_DENIALS_PER_RUN", 5)
+        summary_mod.set_active_run_dir(tmp_path)
+        for i in range(20):
+            summary_mod.record_denial(f"cmd{i}", 1, "network")
+        records = [json.loads(l) for l in
+                   (tmp_path / summary_mod.DENIALS_FILE).read_text().splitlines() if l]
+        # Exactly the cap, no more (slight overcount allowed by the
+        # lock-free design — assert <= cap+1 to be tolerant)
+        assert len(records) <= summary_mod.MAX_DENIALS_PER_RUN
+
+    def test_denial_counter_resets_per_run(self, tmp_path, monkeypatch):
+        # Each set_active_run_dir resets the cap counter.
+        monkeypatch.setattr(summary_mod, "MAX_DENIALS_PER_RUN", 3)
+        # Run 1: hit the cap
+        run1 = tmp_path / "r1"
+        run1.mkdir()
+        summary_mod.set_active_run_dir(run1)
+        for i in range(10):
+            summary_mod.record_denial(f"r1c{i}", 1, "network")
+        # Run 2: counter resets, can record again
+        run2 = tmp_path / "r2"
+        run2.mkdir()
+        summary_mod.set_active_run_dir(run2)
+        for i in range(2):
+            summary_mod.record_denial(f"r2c{i}", 1, "network")
+        run2_records = [json.loads(l) for l in
+                        (run2 / summary_mod.DENIALS_FILE).read_text().splitlines() if l]
+        assert len(run2_records) == 2
+
+    # ADV3
+    def test_refuses_to_follow_symlink_at_jsonl_path(self, tmp_path):
+        # If the JSONL path is a symlink (planted by an attacker who
+        # somehow got write access to the run dir), record_denial must
+        # NOT follow it and write to the target.
+        target = tmp_path / "target-of-attack"
+        target.write_text("ATTACKER-OWNED CONTENT\n")
+        link = tmp_path / summary_mod.DENIALS_FILE
+        os.symlink(target, link)
+
+        summary_mod.set_active_run_dir(tmp_path)
+        summary_mod.record_denial("cmd", 1, "network")
+
+        # Target file unmodified — symlink was refused via O_NOFOLLOW
+        assert target.read_text() == "ATTACKER-OWNED CONTENT\n"
+        # The symlink itself is also unchanged (still a symlink, not a regular file)
+        assert link.is_symlink()
+
+    # ADV4
+    def test_long_cmd_display_is_truncated(self, tmp_path):
+        # A pathologically long cmd_display must be truncated to keep
+        # the JSONL line within PIPE_BUF (atomic append guarantee).
+        summary_mod.set_active_run_dir(tmp_path)
+        long_cmd = "x" * 10_000  # well over MAX_CMD_LEN
+        summary_mod.record_denial(long_cmd, 1, "network")
+        records = [json.loads(l) for l in
+                   (tmp_path / summary_mod.DENIALS_FILE).read_text().splitlines() if l]
+        assert len(records[0]["cmd"]) <= summary_mod.MAX_CMD_LEN
+        # Truncation marker present
+        assert records[0]["cmd"].endswith("…")

--- a/core/sandbox/tests/test_summary.py
+++ b/core/sandbox/tests/test_summary.py
@@ -482,11 +482,105 @@ class TestCli:
         rc = summary_mod._cli_main([])
         assert rc == 2
         err = capsys.readouterr().err
-        assert "Usage" in err
+        # argparse emits lowercase "usage:" by default
+        assert "usage" in err.lower()
 
     def test_too_many_args_exits_2(self, tmp_path, capsys):
         rc = summary_mod._cli_main([str(tmp_path), "extra"])
         assert rc == 2
+
+
+class TestCliSweep:
+    """`python -m core.sandbox.summary --sweep <project_dir>` finalizes ALL
+    stranded runs under a project directory, not just one. Used for cleanup
+    of a project that accumulated abandoned runs across past sessions
+    (cases where `_cleanup_abandoned` couldn't run — different session,
+    different command type, or host died)."""
+
+    def _write_jsonl(self, run_dir: Path, n_denials: int) -> None:
+        run_dir.mkdir(parents=True, exist_ok=True)
+        lines = []
+        for i in range(n_denials):
+            lines.append(json.dumps({
+                "ts": f"2026-04-27T15:00:{i:02d}Z",
+                "cmd": f"c{i}",
+                "returncode": 1,
+                "type": "network",
+                "suggested_fix": "...",
+            }))
+        (run_dir / summary_mod.DENIALS_FILE).write_text("\n".join(lines) + "\n")
+
+    def test_sweeps_multiple_stranded_runs(self, tmp_path, capsys):
+        # Project dir with three abandoned runs, each with a JSONL on disk.
+        self._write_jsonl(tmp_path / "scan-A", 2)
+        self._write_jsonl(tmp_path / "scan-B", 5)
+        self._write_jsonl(tmp_path / "scan-C", 1)
+
+        rc = summary_mod._cli_main(["--sweep", str(tmp_path)])
+        assert rc == 0
+
+        # All three got summary files
+        for name in ("scan-A", "scan-B", "scan-C"):
+            assert (tmp_path / name / summary_mod.SUMMARY_FILE).exists()
+            assert not (tmp_path / name / summary_mod.DENIALS_FILE).exists()
+
+        out = capsys.readouterr().out
+        assert "Swept 3" in out
+        assert "3 summary file(s)" in out
+        assert "8 total denials" in out  # 2+5+1
+
+    def test_sweep_skips_already_finalized_runs(self, tmp_path, capsys):
+        # One stranded run + two already-finalized runs (no JSONL, only
+        # summary). Sweep should touch only the stranded one.
+        self._write_jsonl(tmp_path / "scan-stranded", 3)
+        (tmp_path / "scan-clean-1").mkdir()
+        (tmp_path / "scan-clean-1" / summary_mod.SUMMARY_FILE).write_text(
+            json.dumps({"total_denials": 0, "by_type": {}, "denials": []})
+        )
+        (tmp_path / "scan-clean-2").mkdir()  # nothing in it
+
+        rc = summary_mod._cli_main(["--sweep", str(tmp_path)])
+        assert rc == 0
+
+        out = capsys.readouterr().out
+        assert "Swept 1" in out
+        assert "1 summary file(s)" in out
+        assert "3 total denials" in out
+        # clean-1's pre-existing summary untouched
+        clean1 = json.loads((tmp_path / "scan-clean-1" / summary_mod.SUMMARY_FILE).read_text())
+        assert clean1["total_denials"] == 0
+
+    def test_sweep_empty_project_dir(self, tmp_path, capsys):
+        rc = summary_mod._cli_main(["--sweep", str(tmp_path)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Swept 0" in out
+        assert "0 summary file(s)" in out
+
+    def test_sweep_skips_dotfiles_and_underscore_dirs(self, tmp_path, capsys):
+        # Hidden / underscore-prefixed dirs (e.g. .raptor-state, _tmp)
+        # should be skipped even if they happen to contain a JSONL.
+        self._write_jsonl(tmp_path / ".hidden", 1)
+        self._write_jsonl(tmp_path / "_internal", 1)
+        self._write_jsonl(tmp_path / "real-run", 1)
+
+        rc = summary_mod._cli_main(["--sweep", str(tmp_path)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Swept 1" in out  # only real-run
+
+    def test_sweep_nonexistent_path_exits_1(self, tmp_path, capsys):
+        bogus = tmp_path / "does-not-exist"
+        rc = summary_mod._cli_main(["--sweep", str(bogus)])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "not a directory" in err
+
+    def test_sweep_path_to_file_exits_1(self, tmp_path, capsys):
+        f = tmp_path / "a-file"
+        f.write_text("")
+        rc = summary_mod._cli_main(["--sweep", str(f)])
+        assert rc == 1
 
 
 class TestAdversarial:

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -289,6 +289,50 @@ set — useful for post-run auditing. Each sandbox's buffer grows independently
 for its lifetime (no fixed cap, no ring-buffer eviction); the buffer is
 discarded when the sandbox context exits.
 
+### Per-run denial summary
+
+For commands that go through the lifecycle helpers (`core.run.metadata.start_run`
+/ `complete_run` / `fail_run` / `cancel_run` — i.e., everything driven by
+`/scan`, `/agentic`, `/codeql`, `/validate`, `/understand`, `/fuzz`, etc.), every
+sandbox enforcement event seen during the run is aggregated into
+`{run_dir}/sandbox-summary.json` at run-end.
+
+Format:
+
+```json
+{
+  "run_dir": "/path/to/run",
+  "generated_at": "2026-04-27T15:00:00Z",
+  "total_denials": 3,
+  "by_type": {"network": 1, "write": 1, "seccomp": 1},
+  "denials": [
+    {"ts": "...", "cmd": "git clone evil.com",
+     "returncode": 1, "type": "network",
+     "suggested_fix": "outbound network blocked; use `--sandbox none` to allow network (or accept the block)"},
+    {"ts": "...", "cmd": "tool /etc/blocked",
+     "returncode": 1, "type": "write", "path": "/etc/blocked",
+     "suggested_fix": "write outside allowed paths blocked to `/etc/blocked`; use `--sandbox network-only` or `--sandbox none` to drop Landlock (or move write into target dir)"},
+    {"ts": "...", "cmd": "...",
+     "returncode": 137, "type": "seccomp", "profile": "full",
+     "suggested_fix": "syscall blocked by seccomp; use `--sandbox debug` (allows ptrace) or `--sandbox network-only`/`--sandbox none` (drops seccomp)"}
+  ]
+}
+```
+
+`suggested_fix` references only the operator-facing CLI flags exposed by
+`add_cli_args` — `--sandbox {full,debug,network-only,none}`. Per-host or
+per-path overrides exist as sandbox API kwargs (`proxy_hosts`,
+`writable_paths`, `readable_paths`) but aren't exposed at the CLI level,
+so suggestions don't mention them. Generated regardless of profile, so
+even `--sandbox full` runs produce a summary.
+
+If a process crashes mid-run, the intermediate `.sandbox-denials.jsonl`
+is left on disk. To finalize the summary after the fact:
+
+```bash
+python -m core.sandbox.summary <run_dir>
+```
+
 ### Crash signals across the pid-ns boundary
 
 `unshare --pid --fork` makes the forked child pid-1 of the new pid-ns.

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -326,12 +326,31 @@ per-path overrides exist as sandbox API kwargs (`proxy_hosts`,
 so suggestions don't mention them. Generated regardless of profile, so
 even `--sandbox full` runs produce a summary.
 
-If a process crashes mid-run, the intermediate `.sandbox-denials.jsonl`
-is left on disk. To finalize the summary after the fact:
+**Recovery from non-clean exits.** If a run dies before its lifecycle
+hook fires (hard kill, SIGKILL, OOM), the intermediate
+`.sandbox-denials.jsonl` is left on disk and `sandbox-summary.json`
+isn't written. Two paths recover it:
 
-```bash
-python -m core.sandbox.summary <run_dir>
-```
+1. **Automatic** — the next time the same Claude Code session re-runs the
+   same command type (the Esc-then-retry pattern), `start_run`'s
+   `_cleanup_abandoned` sees the prior run still at `status=running`,
+   marks it `failed`, and `fail_run` routes through the standard
+   summary-finalize path. No operator action needed.
+
+2. **Manual** — for cases the auto-recovery doesn't cover (different
+   session, different command, host reboot, deliberate cleanup):
+
+   ```bash
+   # Single run.
+   libexec/raptor-sandbox-summary <run_dir>
+
+   # All stranded runs under a project dir at once.
+   libexec/raptor-sandbox-summary --sweep <project_dir>
+   ```
+
+   Sweep mode iterates direct subdirectories, finalizes each one that
+   still has a `.sandbox-denials.jsonl`, and skips the rest (no JSONL
+   means either nothing was blocked or the summary is already written).
 
 ### Crash signals across the pid-ns boundary
 

--- a/libexec/raptor-sandbox-summary
+++ b/libexec/raptor-sandbox-summary
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Retroactively finalize sandbox-summary.json for runs whose lifecycle
+didn't complete (hard kill, OOM, host reboot — anything that bypassed
+complete_run / fail_run / cancel_run).
+
+Most cases are handled automatically: when the same Claude Code session
+re-runs the same command type, core.run.metadata._cleanup_abandoned
+promotes the prior run from status=running to failed, which routes
+through the standard summary-finalize path. This shim is the explicit
+fallback for the rest.
+
+Usage:
+  raptor-sandbox-summary <run_dir>            # finalize one run
+  raptor-sandbox-summary --sweep <project>    # finalize every stranded
+                                                run under <project>
+
+Implemented as a shim over core.sandbox.summary._cli_main rather than
+`python -m core.sandbox.summary` to avoid the runpy double-import warning
+that fires when core/sandbox/__init__.py transitively imports
+core.sandbox.summary via observe.py before runpy executes it as __main__.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.sandbox.summary import _cli_main  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(_cli_main())


### PR DESCRIPTION
Today every sandbox enforcement event (network blocked, write blocked, syscall killed) gets logged as a one-line message via observe.py. Operators trying to understand "what would I need to allow for this workflow to succeed under --sandbox full" have to grep for "Sandbox: ... blocked" lines and reason about each in isolation.

This commit aggregates them into a per-run sandbox-summary.json with structured records and suggested-fix hints (which --sandbox profile would un-block what they hit). Generated regardless of profile — even --sandbox full benefits from a clean post-run report instead of grep.

How it works:
  - core/sandbox/summary.py provides set_active_run_dir / record_denial / summarize_and_write. Module-level active-run state, JSONL append per denial (POSIX-atomic at ~PIPE_BUF), aggregate JSON written at run end.
  - core/sandbox/observe.py:_check_blocked calls record_denial alongside its existing log line and sandbox_info["blocked"] string.
  - core/run/metadata.py wires it into the lifecycle: start_run sets the active run, complete_run / fail_run / cancel_run finalise the summary before updating .raptor-run.json status.
  - Recovery: `python -m core.sandbox.summary <run_dir>` finalises a crashed mid-run from the on-disk JSONL.

Defences applied:
  - cmd_display redact_secrets()'d before persisting (URLs with userinfo, Bearer/Basic headers) — summaries live longer than logs and get pasted into bug reports.
  - MAX_DENIALS_PER_RUN cap (10000) prevents unbounded JSONL growth from chatty / adversarial workflows.
  - O_NOFOLLOW on JSONL append refuses planted-symlink attacks on shared filesystems.
  - MAX_CMD_LEN truncation (2048) keeps records under PIPE_BUF so POSIX append atomicity holds for concurrent writers.
  - Suggested-fix hints reference only real operator-facing flags (--sandbox {full,debug,network-only,none}) — kwarg-only knobs like proxy_hosts/writable_paths are not suggested because they aren't exposed at the CLI level.
  - Best-effort I/O — record_denial and the lifecycle finaliser swallow all exceptions (debug-logged) so a summary I/O failure never breaks the sandbox call or the lifecycle hook.

Tests: 42 unit (state, recording, suggested fixes, aggregation, thread safety, lifecycle integration, tracked_run, redaction, CLI, adversarial)
+ 1 E2E (real Python subprocess inside a real sandbox attempts a TCP connect to 1.1.1.1; verifies denial flows end-to-end into the summary). 1209 tests pass across core/.

Docs: per-run-denial-summary section added to docs/sandbox.md with the JSON shape, suggested-fix conventions, and recovery CLI usage.