### PR TITLE
SMT path validator: C operator precedence + grouping parens  

### DIFF
--- a/core/smt_solver/rejection.py
+++ b/core/smt_solver/rejection.py
@@ -52,13 +52,24 @@ class RejectionKind(str, Enum):
     """An operator outside the accepted set appeared in the expression."""
 
     PARENS_NOT_SUPPORTED = "parens_not_supported"
-    """Input contained ``(`` or ``)`` — function calls and grouping
-    aren't supported by the current grammar."""
+    """Deprecated — kept for backward compatibility with downstream
+    consumers that match on this value.  No encoder emits it any more:
+    the path validator's expression parser now supports grouping
+    parentheses via precedence climbing, and unbalanced cases emit
+    :data:`UNBALANCED_PARENS` instead."""
+
+    UNBALANCED_PARENS = "unbalanced_parens"
+    """Input had ``(`` without a matching ``)`` (or vice versa).  Fired
+    by the path validator's expression parser when the bracket structure
+    of a grouping subexpression doesn't close cleanly, or by the
+    condition-level balance check before dispatch."""
 
     MIXED_PRECEDENCE = "mixed_precedence"
-    """Expression mixed additive and multiplicative/bitwise operators.
-    The parser is strictly left-to-right with no precedence, so it
-    rejects mixed forms rather than risk silent mis-encoding."""
+    """Deprecated — kept for backward compatibility with downstream
+    consumers that match on this value.  No encoder emits it any more:
+    the path validator's expression parser now uses C operator precedence
+    (``*`` > ``+ -`` > ``<< >>`` > ``|``) and accepts mixed-operator
+    expressions directly.  Use parentheses to override precedence."""
 
     TRAILING_TOKENS = "trailing_tokens"
     """Tokens were left unconsumed after parsing (e.g. ``a b``)."""

--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -37,18 +37,17 @@ mis-encoded):
 
   - **Operators outside the supported set.**  Accepted: ``+ - * |``,
     relational ``< <= > >= == !=``, shifts ``<< >>``, bitmask
-    ``&`` (only in the ``flags & MASK == VAL`` form).  Rejected:
-    unary NOT (``~``), XOR (``^``), division (``/``), modulo (``%``),
-    ternary (``? :``), single-equals assignment, chained relational
-    (``0 < x < 100``).  Anything else goes to ``unknown`` via the
-    full-input-consumed sanity check.
-  - **C-syntax constructs (other than function calls).**  Type casts
-    (``(uint32_t)x``), struct/pointer access (``obj.field``,
+    ``&`` (only in the ``flags & MASK == VAL`` form), and grouping
+    parentheses ``( )``.  Rejected: unary NOT (``~``), XOR (``^``),
+    division (``/``), modulo (``%``), ternary (``? :``), single-equals
+    assignment, chained relational (``0 < x < 100``).  Anything else
+    goes to ``unknown`` via the full-input-consumed sanity check.
+  - **C-syntax constructs (other than function calls and grouping).**
+    Type casts (``(uint32_t)x``), struct/pointer access (``obj.field``,
     ``s->len``), array indexing (``arr[0]``), pointer dereference
     (``*p``), ``sizeof``.  Any token containing ``.``, ``->``, ``[``,
-    ``]`` still triggers rejection, as does **non-call grouping parens**
-    (``(a + b) * c``).  Function calls are an exception — see the
-    free-variable fallback below.
+    ``]`` still triggers rejection.  Function calls are an exception —
+    see the free-variable fallback below.
   - **Negative integer literals** (e.g. ``!= -1``) — write the
     bit-pattern in hex instead (``!= 0xFFFFFFFF`` at uint32).
   - **Leading-zero decimals** (e.g. ``01234``) — ambiguous with C
@@ -56,6 +55,8 @@ mis-encoded):
   - **Literals outside the profile's width range** — ``0x100`` at
     uint8 would silently wrap to 0 in z3; we reject so the caller
     knows the profile was wrong for this literal.
+  - **Unbalanced parentheses** — extra ``(`` or ``)``, mismatched
+    nesting (``)(``), or a paren count that doesn't return to zero.
 
 Function-call subterms (``strlen(input)``, ``getpid()``, ...) are
 recovered through a free-variable fallback: each balanced
@@ -68,11 +69,13 @@ chooses the conservative semantics (no false claims of infeasibility).
 
 Other limitations (verdict still trustworthy, but with caveats):
 
-  - **No operator precedence** — expressions are evaluated strictly
-    left-to-right.  Mixed-operator expressions (e.g. ``a + b * c``)
-    are rejected to avoid mis-encoding; full precedence support is
-    planned for a follow-up.  ``a * b * c`` and ``a + b + c`` are
-    fine (associativity preserves correctness).
+  - **C operator precedence**, not arithmetic-textbook precedence.
+    Within an expression, ``*`` binds tightest, then ``+ -``, then
+    ``<< >>``, then ``|`` (lowest).  All left-associative.  The
+    notable surprise is that shifts bind *less* tightly than additive
+    operators in C — ``a + b << 2`` parses as ``(a + b) << 2``, not
+    ``a + (b << 2)``.  Use parentheses to make the grouping explicit
+    when the C reading isn't what was meant.
   - **Bitmask form** requires both ``MASK`` and ``VAL`` to be integer
     literals; variables on either side go to ``unknown``.
   - **Profile-level signedness conflates** two concerns: comparison
@@ -164,13 +167,31 @@ _INT_RE = re.compile(r'^\d+$')
 _IDENT_RE = re.compile(r'^[a-z_][a-z0-9_]*$', re.IGNORECASE)
 _NULL_RE = re.compile(r'^NULL$', re.IGNORECASE)
 
-# Tokenise: identifiers, hex literals, decimal literals, operators.
+# Tokenise: identifiers, hex literals, decimal literals, operators, parens.
 # '>>' and '<<' appear before '[<>&|]' so they are matched as two-char tokens
 # rather than as two separate single-char tokens.
 _TOKEN_RE = re.compile(
-    r'(0x[0-9a-f]+|\d+|[a-z_][a-z0-9_]*|[+\-*]|<=|>=|!=|==|>>|<<|[<>&|])',
+    r'(0x[0-9a-f]+|\d+|[a-z_][a-z0-9_]*|[+\-*()]|<=|>=|!=|==|>>|<<|[<>&|])',
     re.IGNORECASE,
 )
+
+# Operator precedence for the arithmetic/bitwise sub-expression.  C-derived:
+#   *               > +-              > << >>            > |
+# All left-associative.  The relational and bitmask layers run in
+# ``_parse_condition`` above this; ``&`` therefore doesn't appear in this
+# table — it's only accepted in the dedicated bitmask form.
+_PRECEDENCE: Dict[str, int] = {
+    '|':  1,
+    '<<': 2, '>>': 2,
+    '+':  3, '-':  3,
+    '*':  4,
+}
+
+# Operator-shaped tokens we recognise but don't accept as binary operators
+# inside ``_parse_expr`` — they belong to the relational or bitmask layer
+# and reaching ``_parse_expr`` with one in operand-trailing position is a
+# user error rather than a malformed expression.
+_RELATIONAL_TOKENS = frozenset({'<=', '>=', '!=', '==', '<', '>', '&'})
 
 
 def _parse_expr(
@@ -178,18 +199,24 @@ def _parse_expr(
 ) -> Union[Any, Rejection]:
     """Parse an arithmetic expression into a Z3 bitvector at the given profile.
 
-    Handles: identifier, NULL, hex literal, decimal literal, and binary
-    +/-/* /|/shifts between those terms (left-to-right, no precedence).
-    Right-shift is routed through ``csem.ashr`` / ``csem.lshr`` by
-    signedness so the same ``>>`` source form encodes differently for
-    signed vs unsigned path conditions.
+    Handles: identifier, NULL, hex literal, decimal literal, parenthesised
+    grouping, and binary ``+ - * | << >>`` between those terms.  Operators
+    bind by C precedence (``*`` > ``+ -`` > ``<< >>`` > ``|``), all
+    left-associative.  Right-shift is routed through ``csem.ashr`` /
+    ``csem.lshr`` by signedness so the same ``>>`` source form encodes
+    differently for signed vs unsigned path conditions.
 
     Returns a :class:`Rejection` — rather than a partial Z3 expression —
     when something can't be encoded, so the whole condition falls through
     to the unknown list with a structured reason rather than being
     silently mis-encoded.
+
+    Implementation: precedence climbing over a flat token list, with a
+    mutable cursor (``pos``) shared by closures.  Atoms include
+    parenthesised subexpressions, which recursively re-enter the climb
+    with ``min_prec=0`` and consume the matching ``)``.
     """
-    tokens = [t for t in _TOKEN_RE.findall(text.strip()) if t not in ('(', ')')]
+    tokens = _TOKEN_RE.findall(text.strip())
     if not tokens:
         return Rejection(text, RejectionKind.LEX_EMPTY, "no tokens after tokenisation")
 
@@ -204,74 +231,110 @@ def _parse_expr(
             hint="remove or rephrase unsupported operators (e.g. ~, ^, /, %)",
         )
 
-    # Reject mixed-operator expressions to avoid silent mis-encoding due to
-    # the lack of operator precedence (currently strictly left-to-right).
-    if {'+', '-'} & set(tokens[1::2]) and {'*', '>>', '<<', '|'} & set(tokens[1::2]):
-        return Rejection(
-            text, RejectionKind.MIXED_PRECEDENCE,
-            "additive and multiplicative/bitwise ops mixed",
-            hint="split into separate conditions, each using one operator class",
-        )
+    pos = [0]
 
-    def atom(tok: str) -> Optional[Any]:
+    def _atom() -> Union[Any, Rejection]:
+        if pos[0] >= len(tokens):
+            return Rejection(
+                text, RejectionKind.UNRECOGNIZED_OPERAND,
+                "unexpected end of expression — operand expected",
+            )
+        tok = tokens[pos[0]]
+        if tok == '(':
+            pos[0] += 1
+            inner = _climb(0)
+            if isinstance(inner, Rejection):
+                return inner
+            if pos[0] >= len(tokens) or tokens[pos[0]] != ')':
+                return Rejection(
+                    text, RejectionKind.UNBALANCED_PARENS,
+                    "expected ')' to close subexpression",
+                )
+            pos[0] += 1
+            return inner
+        if tok == ')':
+            return Rejection(
+                text, RejectionKind.UNBALANCED_PARENS,
+                "expected operand, got ')'",
+            )
         if _NULL_RE.match(tok):
+            pos[0] += 1
             return _mk_val(0, profile.width)
         if _HEX_RE.match(tok) or _INT_RE.match(tok):
             v = _parse_literal_value(tok, profile)
-            # Atom-level literal failures collapse to None and surface as
-            # generic UNRECOGNIZED_OPERAND at the loop boundary; the more
-            # specific reasons (LITERAL_AMBIGUOUS / LITERAL_OUT_OF_RANGE)
-            # are preserved on the bitmask path which calls
-            # _parse_literal_value directly.
-            return None if isinstance(v, Rejection) else _mk_val(v, profile.width)
+            if isinstance(v, Rejection):
+                # Re-anchor the literal-specific rejection (LITERAL_AMBIGUOUS
+                # / LITERAL_OUT_OF_RANGE) on the full input text so callers
+                # can match it back to the original condition.
+                return _propagate(text, v)
+            pos[0] += 1
+            return _mk_val(v, profile.width)
         if _IDENT_RE.match(tok):
-            if tok.lower() not in vars_:
-                vars_[tok.lower()] = _mk_var(tok.lower(), profile.width)
-            return vars_[tok.lower()]
-        return None
-
-    # Left-to-right accumulation of arithmetic and bitwise operators.
-    # Any unsupported operator yields a structured rejection.
-    result = atom(tokens[0])
-    if result is None:
+            key = tok.lower()
+            if key not in vars_:
+                vars_[key] = _mk_var(key, profile.width)
+            pos[0] += 1
+            return vars_[key]
         return Rejection(
             text, RejectionKind.UNRECOGNIZED_OPERAND,
-            f"token {tokens[0]!r} is not an identifier, NULL, or numeric literal",
+            f"token {tok!r} is not an identifier, NULL, or numeric literal",
         )
-    i = 1
-    while i < len(tokens) - 1:
-        op = tokens[i]
-        if op not in ('+', '-', '*', '|', '>>', '<<'):
-            return Rejection(
-                text, RejectionKind.UNSUPPORTED_OPERATOR,
-                f"operator {op!r} not in {{+, -, *, |, >>, <<}}",
-            )
-        right = atom(tokens[i + 1])
-        if right is None:
-            return Rejection(
-                text, RejectionKind.UNRECOGNIZED_OPERAND,
-                f"token {tokens[i + 1]!r} is not an identifier, NULL, or numeric literal",
-            )
-        if op == '+':
-            result = result + right
-        elif op == '-':
-            result = result - right
-        elif op == '*':
-            result = result * right
-        elif op == '|':
-            result = result | right
-        elif op == '>>':
+
+    def _apply(op: str, lhs: Any, rhs: Any) -> Any:
+        if op == '+':  return lhs + rhs
+        if op == '-':  return lhs - rhs
+        if op == '*':  return lhs * rhs
+        if op == '|':  return lhs | rhs
+        if op == '<<': return lhs << rhs
+        if op == '>>':
             # Route right-shift through csem so signedness picks the
             # correct arithmetic vs logical variant.
-            result = _ashr(result, right) if profile.signed else _lshr(result, right)
-        else:  # '<<'
-            result = result << right
-        i += 2
+            return _ashr(lhs, rhs) if profile.signed else _lshr(lhs, rhs)
+        # _PRECEDENCE keys are exhaustive; reaching here is a bug, not user
+        # input.  Raise so the invariant survives under ``python -O``.
+        raise RuntimeError(f"unhandled operator {op!r}")
 
-    if i != len(tokens):
+    def _climb(min_prec: int) -> Union[Any, Rejection]:
+        lhs = _atom()
+        if isinstance(lhs, Rejection):
+            return lhs
+        while pos[0] < len(tokens):
+            tok = tokens[pos[0]]
+            if tok not in _PRECEDENCE:
+                # Anything else — ``)``, a relational op, an extra atom —
+                # ends this climb level.  The outer dispatcher classifies
+                # the leftover (paren imbalance, unsupported operator, or
+                # plain trailing token).
+                break
+            prec = _PRECEDENCE[tok]
+            if prec < min_prec:
+                break
+            pos[0] += 1
+            rhs = _climb(prec + 1)  # left-associative
+            if isinstance(rhs, Rejection):
+                return rhs
+            lhs = _apply(tok, lhs, rhs)
+        return lhs
+
+    result = _climb(0)
+    if isinstance(result, Rejection):
+        return result
+
+    if pos[0] != len(tokens):
+        leftover = tokens[pos[0]]
+        if leftover in ('(', ')'):
+            return Rejection(
+                text, RejectionKind.UNBALANCED_PARENS,
+                f"unexpected {leftover!r} in expression",
+            )
+        if leftover in _RELATIONAL_TOKENS:
+            return Rejection(
+                text, RejectionKind.UNSUPPORTED_OPERATOR,
+                f"operator {leftover!r} not in {{+, -, *, |, >>, <<}}",
+            )
         return Rejection(
             text, RejectionKind.TRAILING_TOKENS,
-            f"unconsumed token {tokens[i]!r}",
+            f"unconsumed token {leftover!r}",
         )
 
     return result
@@ -361,19 +424,36 @@ def _parse_condition(
     free variables by :func:`_substitute_calls`, so conditions like
     ``strlen(input) < 1024`` can still drive feasibility analysis.  Any
     parentheses left behind after that pass are non-call grouping
-    (``(a + b) * c``) and are rejected with
-    :data:`RejectionKind.PARENS_NOT_SUPPORTED`.  ``text`` (the original)
-    is preserved for rejection messages so callers can match failures
-    back to their input.
+    (``(a + b) * c``) and are now supported via precedence climbing in
+    :func:`_parse_expr` — the early balance check below only catches
+    the structurally-broken cases (extra ``)`` or unmatched ``(``)
+    before they fall through to a less specific rejection further down.
+    ``text`` (the original) is preserved for rejection messages so
+    callers can match failures back to their input.
     """
     t = _substitute_calls(_canonicalise(text), vars_, profile=profile)
 
-    if '(' in t or ')' in t:
+    # Early paren-balance scan.  ``_parse_expr`` would catch most imbalances
+    # itself, but only conditions whose top-level matches the relational or
+    # bitmask regex below ever reach it.  Cases like ``strlen(x`` or
+    # ``f(g(x)`` (no relational op) would otherwise fall through to a
+    # generic UNRECOGNIZED_FORM rejection — this loop pre-empts that with
+    # a more specific UNBALANCED_PARENS.
+    depth = 0
+    for ch in t:
+        if ch == '(':
+            depth += 1
+        elif ch == ')':
+            depth -= 1
+            if depth < 0:
+                return Rejection(
+                    text, RejectionKind.UNBALANCED_PARENS,
+                    "')' has no matching '('",
+                )
+    if depth != 0:
         return Rejection(
-            text, RejectionKind.PARENS_NOT_SUPPORTED,
-            "input contains '(' or ')' that is not a recognised function call",
-            hint="function calls (ident(...)) parse via the free-variable fallback; "
-                 "non-call grouping is unsupported — flatten the expression",
+            text, RejectionKind.UNBALANCED_PARENS,
+            f"{depth} unmatched '(' at end of input",
         )
 
     # Bitmask: lhs & mask (==|!=) val

--- a/packages/codeql/tests/test_smt_path_validator.py
+++ b/packages/codeql/tests/test_smt_path_validator.py
@@ -97,17 +97,17 @@ class TestFeasibility:
 
     @_requires_z3
     def test_unparseable_condition_goes_to_unknown(self):
-        """Non-call grouping parens are still rejected — goes to unknown, not crash.
+        """Conditions outside the supported grammar go to unknown, not crash.
 
-        Function-call shapes (``ident(...)``) are recovered via the
-        free-variable fallback; only non-call grouping (``(a + b)``)
-        remains unparseable.
+        Operators silently dropped by the tokeniser (``~``, ``^``, ``/``,
+        ``%``, ...) are caught by the consumed-input check and rejected
+        rather than mis-encoded.
         """
         r = check_path_feasibility([
             PathCondition("size > 0", step_index=0),
-            PathCondition("(size + len) * 2 > 0", step_index=1),
+            PathCondition("~mask == 0xFFFFFFFF", step_index=1),
         ])
-        assert "(size + len) * 2 > 0" in r.unknown
+        assert "~mask == 0xFFFFFFFF" in r.unknown
         # The parseable condition still runs; result is sat or None, not outright infeasible
         assert r.feasible is not False
 
@@ -115,8 +115,7 @@ class TestFeasibility:
     def test_all_unknown_returns_none(self):
         """If nothing is parseable, feasible must be None (not True)."""
         r = check_path_feasibility([
-            # Non-call grouping parens — not eligible for the fallback.
-            PathCondition("(a + b) > (c + d)", step_index=0),
+            PathCondition("~mask == 0", step_index=0),  # NOT silently dropped
         ])
         assert r.feasible is None
 
@@ -616,21 +615,15 @@ class TestStructuredRejection:
         assert r.unknown_reasons == []
 
     @_requires_z3
-    def test_parens_rejection(self):
-        # Non-call grouping parens.  Function-call shapes (``ident(...)``)
-        # are recovered by the free-variable fallback and don't reach
-        # the parens-rejection path.
+    def test_unbalanced_paren_kind(self):
+        """Unbalanced parens (extra ``(`` or ``)``) reject with
+        UNBALANCED_PARENS — the dedicated kind, not the deprecated
+        PARENS_NOT_SUPPORTED.  Balanced grouping parens parse via
+        precedence climbing and don't reach this rejection path."""
         r = check_path_feasibility([
-            PathCondition("(a + b) > 0", step_index=0),
+            PathCondition("(a + b > 0", step_index=0),
         ])
-        assert self._kind_for(r, "(a + b) > 0") is RejectionKind.PARENS_NOT_SUPPORTED
-
-    @_requires_z3
-    def test_mixed_precedence_rejection(self):
-        r = check_path_feasibility([
-            PathCondition("a + b * c == 0", step_index=0),
-        ])
-        assert self._kind_for(r, "a + b * c == 0") is RejectionKind.MIXED_PRECEDENCE
+        assert self._kind_for(r, "(a + b > 0") is RejectionKind.UNBALANCED_PARENS
 
     @_requires_z3
     def test_no_relational_at_top_level_rejection(self):
@@ -656,14 +649,15 @@ class TestStructuredRejection:
 
     @_requires_z3
     def test_rejection_carries_hint(self):
-        # Non-call grouping parens — still rejected, hint suggests
-        # flattening since the call-shape fallback doesn't apply here.
+        # Top-level shape that doesn't match any relational/bitmask form
+        # comes back with UNRECOGNIZED_FORM and a hint pointing at the
+        # accepted templates.
         r = check_path_feasibility([
-            PathCondition("(a + b) * 2 > 0", step_index=0),
+            PathCondition("size_only", step_index=0),
         ])
-        rej = next(x for x in r.unknown_reasons if x.text == "(a + b) * 2 > 0")
+        rej = next(x for x in r.unknown_reasons if x.text == "size_only")
         assert rej.hint  # non-empty
-        assert "flatten" in rej.hint.lower() or "fallback" in rej.hint.lower()
+        assert "lhs" in rej.hint.lower()
 
     @_requires_z3
     def test_rejection_aligned_with_unknown_list(self):
@@ -671,8 +665,8 @@ class TestStructuredRejection:
         with the same text."""
         r = check_path_feasibility([
             PathCondition("size > 0", step_index=0),                    # parses
-            PathCondition("(p + q) == 0", step_index=1),                # grouping parens
-            PathCondition("a + b * c == 0", step_index=2),              # mixed prec
+            PathCondition("~mask == 0", step_index=1),                  # NOT silently dropped
+            PathCondition("a / b > 0", step_index=2),                   # division silently dropped
         ])
         assert set(r.unknown) == {x.text for x in r.unknown_reasons}
 
@@ -782,12 +776,12 @@ class TestFreeVariableFallback:
     def test_unbalanced_parens_still_rejected(self, expr):
         """Any paren imbalance — open without close, close without open,
         or nested mismatch — falls through the substitution and is
-        rejected by the parens-check rather than silently masquerading
-        as a parsed call."""
+        rejected by the balance check (or the expression parser) rather
+        than silently masquerading as a parsed call."""
         r = check_path_feasibility([PathCondition(expr, step_index=0)])
         assert expr in r.unknown
         rej = next(x for x in r.unknown_reasons if x.text == expr)
-        assert rej.kind is RejectionKind.PARENS_NOT_SUPPORTED
+        assert rej.kind is RejectionKind.UNBALANCED_PARENS
 
     @_requires_z3
     def test_fallback_preserves_real_constraints(self):
@@ -826,3 +820,207 @@ class TestFreeVariableFallback:
         ])
         assert r.unknown == []
         assert r.feasible is True
+
+
+# ---------------------------------------------------------------------------
+# C operator precedence
+# ---------------------------------------------------------------------------
+
+class TestPrecedence:
+    """C precedence: ``*`` > ``+ -`` > ``<< >>`` > ``|``, all left-associative.
+
+    The previous parser was strict left-to-right and rejected mixed-class
+    expressions with MIXED_PRECEDENCE.  The current parser binds operators
+    by C precedence, so mixed expressions encode with the grouping a C
+    compiler would produce.  These tests pin that grouping by asserting
+    the *value* a model would have under the correct interpretation.
+    """
+
+    @_requires_z3
+    def test_multiplication_binds_tighter_than_addition_rhs(self):
+        """``a + b * c == 64`` with ``a=4, b=4, c=15`` is feasible iff
+        the parse is ``a + (b * c) = 4 + 60 = 64``.  An LTR parse would
+        compute ``(a + b) * c = 8 * 15 = 120`` — infeasible."""
+        r = check_path_feasibility([
+            PathCondition("a + b * c == 64", step_index=0),
+            PathCondition("a == 4", step_index=1),
+            PathCondition("b == 4", step_index=2),
+            PathCondition("c == 15", step_index=3),
+        ])
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_multiplication_binds_tighter_than_addition_lhs(self):
+        """``a * b + c == 19`` with ``a=2, b=8, c=3`` requires ``(a*b)+c``."""
+        r = check_path_feasibility([
+            PathCondition("a * b + c == 19", step_index=0),
+            PathCondition("a == 2", step_index=1),
+            PathCondition("b == 8", step_index=2),
+            PathCondition("c == 3", step_index=3),
+        ])
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_subtraction_left_associative(self):
+        """``a - b - c`` parses as ``(a - b) - c``.  With a=10, b=3, c=2:
+        ``(10-3)-2 = 5``, not ``10-(3-2) = 9``."""
+        r = check_path_feasibility([
+            PathCondition("a - b - c == 5", step_index=0),
+            PathCondition("a == 10", step_index=1),
+            PathCondition("b == 3", step_index=2),
+            PathCondition("c == 2", step_index=3),
+        ])
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_shift_lower_precedence_than_addition(self):
+        """C surprise: ``a + b << 2`` is ``(a + b) << 2``, not
+        ``a + (b << 2)``.  With a=1, b=3: ``(1+3) << 2 = 16``, not
+        ``1 + (3 << 2) = 13``."""
+        r = check_path_feasibility([
+            PathCondition("a + b << 2 == 16", step_index=0),
+            PathCondition("a == 1", step_index=1),
+            PathCondition("b == 3", step_index=2),
+        ])
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_or_lowest_precedence(self):
+        """``a | b + c`` is ``a | (b + c)``.  Pick values that distinguish
+        the two readings: a=2, b=1, c=2 gives 2|(1+2)=2|3=3, while the
+        LTR misparse (2|1)+2 = 3+2 = 5."""
+        r = check_path_feasibility([
+            PathCondition("a | b + c == 3", step_index=0),
+            PathCondition("a == 2", step_index=1),
+            PathCondition("b == 1", step_index=2),
+            PathCondition("c == 2", step_index=3),
+        ])
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_three_level_mix(self):
+        """``a | b + c * d`` is ``a | (b + (c * d))``.  Values:
+        a=0x10, b=2, c=3, d=4 → 0x10 | (2 + 12) = 0x10 | 14 = 0x1E."""
+        r = check_path_feasibility([
+            PathCondition("a | b + c * d == 0x1E", step_index=0),
+            PathCondition("a == 0x10", step_index=1),
+            PathCondition("b == 2", step_index=2),
+            PathCondition("c == 3", step_index=3),
+            PathCondition("d == 4", step_index=4),
+        ])
+        assert r.feasible is True
+
+
+# ---------------------------------------------------------------------------
+# Parenthesised grouping
+# ---------------------------------------------------------------------------
+
+class TestParensGrouping:
+    """Balanced parens override C precedence and are now accepted by the
+    expression parser.  Function-call shapes (``ident(...)``) still go
+    through the free-variable fallback first; only the leftover ``( ... )``
+    is grouping."""
+
+    @_requires_z3
+    def test_parens_override_precedence(self):
+        """``(a + b) * c == 30`` with a=2, b=3, c=6: ``(2+3)*6 = 30``.
+        Without the parens, the C reading is ``a + (b * c) = 2 + 18 = 20``."""
+        r = check_path_feasibility([
+            PathCondition("(a + b) * c == 30", step_index=0),
+            PathCondition("a == 2", step_index=1),
+            PathCondition("b == 3", step_index=2),
+            PathCondition("c == 6", step_index=3),
+        ])
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_parens_force_shift_then_add(self):
+        """``a + (b << 2) == 13`` with a=1, b=3: ``1 + (3<<2) = 13``.
+        Without the parens, the C reading is ``(a+b) << 2 = 16``."""
+        r = check_path_feasibility([
+            PathCondition("a + (b << 2) == 13", step_index=0),
+            PathCondition("a == 1", step_index=1),
+            PathCondition("b == 3", step_index=2),
+        ])
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_nested_parens(self):
+        """``((x))`` parses as ``x`` — extra outer layers are no-ops."""
+        r = check_path_feasibility([
+            PathCondition("((x)) == 42", step_index=0),
+        ])
+        assert r.feasible is True
+        assert r.model.get("x") == 42
+
+    @_requires_z3
+    def test_deeply_nested_parens(self):
+        r = check_path_feasibility([
+            PathCondition("(((y))) > 0", step_index=0),
+            PathCondition("y < 100", step_index=1),
+        ])
+        assert r.feasible is True
+        assert 0 < r.model["y"] < 100
+
+    @_requires_z3
+    def test_parens_on_both_sides(self):
+        """Relational regex must split at the operator with parens on
+        either side.  ``(a + b) == (c + d)`` — both sides parse."""
+        r = check_path_feasibility([
+            PathCondition("(a + b) == (c + d)", step_index=0),
+            PathCondition("a == 1", step_index=1),
+            PathCondition("b == 2", step_index=2),
+            PathCondition("c == 0", step_index=3),
+        ])
+        assert r.feasible is True
+        assert r.model.get("d") == 3
+
+    @_requires_z3
+    def test_parens_in_bitmask_lhs(self):
+        """Bitmask form's LHS goes through ``_parse_expr``; parens work
+        there too: ``(a + b) & 0xff == 0``."""
+        r = check_path_feasibility([
+            PathCondition("(a + b) & 0xff == 0", step_index=0),
+        ])
+        assert r.feasible is True
+
+    @_requires_z3
+    def test_unmatched_open_paren_in_expression(self):
+        """``(a + b > 0`` — relational splits at ``>``, LHS=``(a + b ``
+        has unmatched ``(``.  The early balance check catches this."""
+        r = check_path_feasibility([
+            PathCondition("(a + b > 0", step_index=0),
+        ])
+        assert "(a + b > 0" in r.unknown
+        rej = next(x for x in r.unknown_reasons if x.text == "(a + b > 0")
+        assert rej.kind is RejectionKind.UNBALANCED_PARENS
+
+    @_requires_z3
+    def test_unmatched_close_paren_in_expression(self):
+        """``a + b) > 0`` — extra ``)``."""
+        r = check_path_feasibility([
+            PathCondition("a + b) > 0", step_index=0),
+        ])
+        assert "a + b) > 0" in r.unknown
+        rej = next(x for x in r.unknown_reasons if x.text == "a + b) > 0")
+        assert rej.kind is RejectionKind.UNBALANCED_PARENS
+
+    @_requires_z3
+    def test_swapped_parens(self):
+        """``)a + b( > 0`` — balanced count but the structure is wrong.
+        The early balance check sees ``)`` first and rejects before
+        ``_parse_expr`` runs."""
+        r = check_path_feasibility([
+            PathCondition(")a + b( > 0", step_index=0),
+        ])
+        assert ")a + b( > 0" in r.unknown
+        rej = next(x for x in r.unknown_reasons if x.text == ")a + b( > 0")
+        assert rej.kind is RejectionKind.UNBALANCED_PARENS
+
+    @_requires_z3
+    def test_empty_parens_in_expression(self):
+        """``() + 1 > 0`` — ``()`` has no operand inside."""
+        r = check_path_feasibility([
+            PathCondition("() + 1 > 0", step_index=0),
+        ])
+        assert "() + 1 > 0" in r.unknown

--- a/packages/exploit_feasibility/tests/test_smt_path.py
+++ b/packages/exploit_feasibility/tests/test_smt_path.py
@@ -195,15 +195,16 @@ class TestEndToEnd:
         """Conditions the parser can't encode bubble up to the LLM.
 
         Function-call shapes (``ident(...)``) are recovered via the
-        free-variable fallback, so they DON'T land in ``unknown``.
-        Non-call grouping parens are still rejected — they're what we
-        exercise here.
+        free-variable fallback, and balanced grouping parens parse via
+        precedence climbing.  Operators silently dropped by the
+        tokeniser (``~``, ``^``, ``/``, ``%``) are caught by the
+        consumed-input check — they're what we exercise here.
         """
         r = validate_path([
             "size > 0",                  # parseable
-            "(a + b) > (c + d)",         # grouping parens — still unparseable
+            "~mask == 0xFFFFFFFF",       # NOT silently dropped — unparseable
         ])
-        assert "(a + b) > (c + d)" in r["unknown"]
+        assert "~mask == 0xFFFFFFFF" in r["unknown"]
 
 
 class TestJSONRoundTrip:


### PR DESCRIPTION
Replace the strict left-to-right expression parser in `_parse_expr` with a precedence climber over a four-level C precedence table, and accept balanced grouping parentheses as part of the same change.                                                                                  

Two friction points hit real LLM output regularly:

1. Mixed-class expressions like `a + b * c <= max` rejected wholesale with `MIXED_PRECEDENCE`, even though the C reading is unambiguous.
2. Non-call grouping parentheses (`(a + b) * c`) rejected with `PARENS_NOT_SUPPORTED` because the LTR parser had no way to override precedence — the only escape hatch we offered was "flatten by hand."                                                           

Both classes are eliminated by this change. The cost is silent re-interpretation of inputs that previously rejected; the gain is that those inputs now contribute to feasibility analysis with C-correct semantics.                                                           

### Operator precedence 

Within an expression: `*` > `+ -` > `<< >>` > `|`, all left-associative. The notable C surprise: shifts bind **less tightly** than additive operators, so `a + b << 2` parses as `(a + b) << 2`, not `a + (b << 2)`. Documented in the module docstring; use parentheses to make the grouping explicit when the C reading isn't what was meant.                                                                                                   

### Backward compatibility

- Every single-operator-class input that parsed before still parses to the same Z3 expression (additive/multiplicative/shift/OR are all left-associative under both the old and new parser). 
- `RejectionKind.MIXED_PRECEDENCE` and `RejectionKind.PARENS_NOT_SUPPORTED` remain in the enum, marked deprecated. No encoder emits them any more. They are retained so external consumers that match on these values keep compiling.
- New `RejectionKind.UNBALANCED_PARENS` covers the structurally-broken paren cases (extra `(` / `)`, mismatched nesting, count not returning to zero).                                                       
                                                                                                                                    
### What Has Changed                                                                                                                  
                                                                                                                                    
**`core/smt_solver/rejection.py`**
- Added `UNBALANCED_PARENS`
- Updated docstrings on the two deprecated kinds                                                                                  
                                                                                                                                    
**`packages/codeql/smt_path_validator.py`**
- Tokeniser captures `(` and `)`
- `_parse_expr` rewritten as a precedence climber; atoms include parenthesised subexpressions, which recursively re-enter the climb with `min_prec=0`
- Trailing-token classification routes `(`/`)` to `UNBALANCED_PARENS`, relational tokens to `UNSUPPORTED_OPERATOR`, anything else to `TRAILING_TOKENS`
- `_parse_condition` replaces its early `'(' in t` rejection with a one-pass paren-balance scan that emits `UNBALANCED_PARENS` for the no-relational-op cases that wouldn't otherwise reach `_parse_expr`
- Module docstring updated to describe C precedence and the shift surprise                                                        
                                                                                                                                    
  **Tests**                                                                                                                         
  - Repurposed the `MIXED_PRECEDENCE` / `PARENS_NOT_SUPPORTED` assertions in `packages/codeql/tests/test_smt_path_validator.py`                                                                              
  - `test_unbalanced_parens_still_rejected` now asserts `UNBALANCED_PARENS`                                                         
  - Added `TestPrecedence` (6 cases): pin C precedence by asserting concrete values that distinguish the correct parse from any LTR misparse (e.g., `a + b * c == 64` is feasible iff parsed as `a + (b * c)`)                                                               
  - Added `TestParensGrouping` (10 cases): grouping override, nested parens, parens on both sides of a relational, bitmask LHS, all four imbalance modes (open-without-close, close-without-open, swapped `)(`, empty `()`)                                                        
  - Updated `packages/exploit_feasibility/tests/test_smt_path.py`; one downstream test used `(a + b) > (c + d)` as a "still-unparseable" example; replaced with `~mask == 0xFFFFFFFF` (NOT operator silently dropped, caught by the consumed-input check)                                                                                    
