### PR TITLE
core/git: add fetch_commit + fix dead proxy_hosts in clone_repository

### DIFF
--- a/core/git/__init__.py
+++ b/core/git/__init__.py
@@ -1,6 +1,6 @@
-"""Git operations — sandbox-routed clone + URL allowlist.
+"""Git operations — sandbox-routed clone + targeted fetch + URL allowlist.
 
-Two public entry points:
+Public entry points:
 
   - ``validate_repo_url(url)``: regex allowlist for github / gitlab
     HTTPS + SSH URLs. Designed to fail-closed: anything not matching
@@ -12,21 +12,28 @@ Two public entry points:
     semantics ``packages/static-analysis/scanner.py:safe_clone`` had
     pre-centralisation (and which scanner.py now imports from here).
 
+  - ``fetch_commit(repo_dir, url, sha, depth=5)``: targeted fetch of
+    a specific commit into an existing or fresh git directory. Right
+    primitive when the caller already knows the SHA and a clone of
+    HEAD wouldn't reach it (old fixes, deleted-branch commits). Same
+    sandbox / proxy / env / timeout posture as ``clone_repository``.
+
 The sandbox routing is the security-load-bearing piece. Pre-#210 this
 module would have been a plain subprocess wrapper; post-#210 every
-clone of an untrusted URL passes through namespace + Landlock + a
-network namespace pinned to a hostname allowlist. ``git`` itself runs
-as the untrusted process — a malicious server-side hook on a forked
-clone (or a compromised mirror) is contained.
+clone or fetch of an untrusted URL passes through namespace + Landlock
++ a network namespace pinned to a hostname allowlist. ``git`` itself
+runs as the untrusted process — a malicious server-side hook on a
+forked clone (or a compromised mirror) is contained.
 """
 
 from __future__ import annotations
 
-from core.git.clone import clone_repository, get_safe_git_env
+from core.git.clone import clone_repository, fetch_commit, get_safe_git_env
 from core.git.validate import validate_repo_url
 
 __all__ = [
     "clone_repository",
+    "fetch_commit",
     "get_safe_git_env",
     "validate_repo_url",
 ]

--- a/core/git/clone.py
+++ b/core/git/clone.py
@@ -1,12 +1,22 @@
-"""Sandbox-routed git clone.
+"""Sandbox-routed git clone + targeted fetch.
 
-Wraps ``git clone`` in ``core.sandbox.run_untrusted`` with:
+Two entry points:
+
+  - ``clone_repository(url, target, depth=1)`` — shallow or full clone.
+  - ``fetch_commit(repo_dir, url, sha, depth=5)`` — targeted fetch of a
+    specific commit into an existing or fresh git directory. Useful when
+    a full clone would be wasteful: the caller already knows the SHA and
+    wants only that commit's history. Older CVE fix commits are often
+    not reachable from a depth-1 clone of HEAD, so progressive-fetch
+    cascades use this.
+
+Both wrap their ``git`` subprocess in ``core.sandbox.run_untrusted``:
 
   - the egress proxy pinned to the small set of hostnames the URL
     allowlist permits (github.com / gitlab.com plus the known
     object-storage CDNs they redirect to);
-  - landlocked filesystem so the clone process can only write into
-    the target directory;
+  - landlocked filesystem so the git process can only write into
+    the target / repo directory;
   - sanitised env (``RaptorConfig.get_git_env()`` — clears
     HTTP_PROXY / NO_PROXY etc., sets GIT_TERMINAL_PROMPT=0 and
     GIT_ASKPASS=true so a malformed-credential prompt can't hang
@@ -14,17 +24,29 @@ Wraps ``git clone`` in ``core.sandbox.run_untrusted`` with:
   - bounded timeout (``RaptorConfig.GIT_CLONE_TIMEOUT``).
 
 Pre-#210, scanner.py and recon/agent.py both implemented variants of
-this. Post-centralisation everyone calls through here.
+clone. Post-centralisation everyone calls through here.
 """
 
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 from typing import Dict, Optional
 
 from core.config import RaptorConfig
 from core.git.validate import validate_repo_url
+
+# Git allows SHA abbreviations of 4+ chars; full SHA-1 is 40 hex.
+# We reject anything that doesn't match this shape so a tainted SHA
+# cannot be parsed as a ``git fetch`` flag (e.g. ``--upload-pack=`` for
+# RCE on SSH transport, CVE-2017-1000117 family). Argument-position
+# defence-in-depth — the URL is already on a regex allowlist.
+#
+# Note: ``re.fullmatch`` (not ``re.match``+``$``) — ``$`` in Python's ``re``
+# matches *just before* a trailing newline, so ``"deadbeef\n"`` would
+# otherwise sneak past a ``^...$`` check.
+_SHA_RE = re.compile(r"[0-9a-fA-F]{4,40}")
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +67,48 @@ def get_safe_git_env() -> Dict[str, str]:
     return RaptorConfig.get_git_env()
 
 
+def _validate_writable_path(p: Path, *, role: str) -> None:
+    """Refuse caller-supplied paths that would unsafely widen the
+    sandbox's writable scope.
+
+    Both ``clone_repository`` and ``fetch_commit`` configure the
+    sandbox writable scope as ``p.parent`` so the auto-materialised
+    ``.home/`` lands sibling to the repo (not inside). That choice
+    means a pathological ``p`` — empty, the filesystem root, or a
+    direct child of ``/`` — turns into "sandbox writable = entire
+    filesystem", which would let a compromised git server clobber
+    arbitrary host paths even with the rest of the isolation engaged.
+
+    Rejected shapes:
+      - relative paths (cwd-dependent writable scope is implicit
+        state — refuse and require the caller to be explicit);
+      - filesystem root (``/``);
+      - direct children of root (``/foo``, ``/etc``, …) where parent
+        is still ``/``.
+    """
+    if not p.is_absolute():
+        raise ValueError(
+            f"{role} must be an absolute path; got {str(p)!r}. Relative "
+            f"paths are unsafe here — the sandbox writable scope "
+            f"({role}.parent) would be cwd-dependent."
+        )
+    # ``.resolve()`` follows symlinks so a pre-staged
+    # ``/tmp/work -> /`` symlink can't sneak past the root checks.
+    resolved = p.resolve()
+    if resolved.parent == resolved:
+        raise ValueError(
+            f"{role}={str(p)!r} resolves to filesystem root; refusing "
+            f"to grant the sandbox write access to the entire "
+            f"filesystem"
+        )
+    if resolved.parent == Path(resolved.anchor):
+        raise ValueError(
+            f"{role}={str(p)!r} has filesystem root as its parent. "
+            f"Sandbox writable scope ({role}.parent) would be the "
+            f"entire root filesystem."
+        )
+
+
 def clone_repository(
     url: str, target: Path, depth: Optional[int] = 1,
 ) -> bool:
@@ -58,11 +122,14 @@ def clone_repository(
             full history.
 
     Raises:
-        ValueError: URL fails the allowlist.
+        ValueError: URL fails the allowlist, or ``target`` fails the
+            writable-path check (relative, filesystem root, or
+            direct child of root — see ``_validate_writable_path``).
         RuntimeError: ``git clone`` exited non-zero.
     """
     if not validate_repo_url(url):
         raise ValueError(f"Invalid or untrusted repository URL: {url}")
+    _validate_writable_path(target, role="target")
 
     cmd = ["git", "clone"]
     if depth is not None:
@@ -84,6 +151,7 @@ def clone_repository(
         target=str(target.parent),
         output=str(target.parent),
         env=get_safe_git_env(),
+        use_egress_proxy=True,
         proxy_hosts=list(_PROXY_HOSTS),
         timeout=RaptorConfig.GIT_CLONE_TIMEOUT,
         capture_output=True,
@@ -98,4 +166,147 @@ def clone_repository(
     return True
 
 
-__all__ = ["clone_repository", "get_safe_git_env"]
+def fetch_commit(
+    repo_dir: Path, url: str, sha: str, depth: int = 5,
+) -> bool:
+    """Fetch a specific ``sha`` from ``url`` into ``repo_dir``.
+
+    Initialises ``repo_dir`` as a fresh git repo if it isn't one already,
+    adds (or replaces) an ``origin`` remote pointing at ``url``, then
+    runs ``git fetch --depth=<depth> origin <sha>``. Same sandbox /
+    proxy / env / timeout posture as :func:`clone_repository`.
+
+    Targeted fetch is the right primitive when:
+
+      - the caller already knows the SHA they need;
+      - a depth-1 clone of HEAD wouldn't reach it (older fix commits,
+        commits on long-since-deleted branches, cherry-picks);
+      - paying the cost of a full clone is wasteful.
+
+    Args:
+        repo_dir: target directory. Created if absent. Must be the
+            only writable path the sandbox grants the git process.
+        url: remote URL; must pass ``validate_repo_url``.
+        sha: commit SHA to fetch. Must be 4–40 hex chars
+            (``[0-9a-fA-F]``) — ``--upload-pack=`` and friends would
+            otherwise be parsed as ``git fetch`` flags.
+        depth: shallow-fetch depth (default 5). The caller should
+            cascade — start small, retry deeper on miss.
+
+    Returns ``True`` on success.
+
+    Raises:
+        ValueError: URL fails the allowlist, ``repo_dir`` fails the
+            writable-path check (relative, filesystem root, or direct
+            child of root — see ``_validate_writable_path``), or SHA
+            fails the shape check.
+        RuntimeError: any of ``git init``, ``git remote``, or
+            ``git fetch`` exited non-zero.
+    """
+    if not validate_repo_url(url):
+        raise ValueError(f"Invalid or untrusted repository URL: {url}")
+    _validate_writable_path(repo_dir, role="repo_dir")
+    if not _SHA_RE.fullmatch(sha):
+        # Defend against ``sha = "--upload-pack=cmd"`` style flag
+        # injection at the ``git fetch <repo> <refspec>`` position.
+        raise ValueError(
+            f"Invalid commit SHA shape (expected 4-40 hex chars): {sha!r}"
+        )
+
+    try:
+        from core.sandbox import run_untrusted
+    except ImportError:
+        raise RuntimeError(
+            "core.sandbox unavailable - git fetch refuses to run "
+            "without sandbox isolation"
+        )
+
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    env = get_safe_git_env()
+    proxy_hosts = list(_PROXY_HOSTS)
+    timeout = RaptorConfig.GIT_CLONE_TIMEOUT
+
+    # ``output`` is the sandbox's writable allowlist. Use ``repo_dir.parent``
+    # to match ``clone_repository``: with ``fake_home=True`` (the
+    # ``run_untrusted`` default), the sandbox materialises ``{output}/.home/``
+    # for the child's HOME. Passing ``repo_dir`` directly would put that
+    # ``.home/`` *inside* the repo, polluting the caller's working tree.
+    # The parent directory is one level wider but matches clone semantics
+    # exactly — ``.home/`` ends up sibling to ``repo_dir``.
+    sandbox_target = str(repo_dir.parent)
+
+    def _run(cmd: list, *, network: bool):
+        # ``git init`` and ``git remote`` are local-only; the sandbox
+        # still runs them through ``run_untrusted`` for env hygiene.
+        # The egress proxy is only engaged for the fetch step — local
+        # ops have no need for it. NB: ``use_egress_proxy=True`` MUST be
+        # paired with ``proxy_hosts`` for the proxy to start; passing
+        # ``proxy_hosts`` alone is a no-op (the sandbox keeps
+        # ``block_network=True`` and the child has no network at all).
+        kwargs = dict(
+            target=sandbox_target,
+            output=sandbox_target,
+            env=env,
+            timeout=timeout,
+            capture_output=True,
+            text=True,
+        )
+        if network:
+            kwargs["use_egress_proxy"] = True
+            kwargs["proxy_hosts"] = proxy_hosts
+        return run_untrusted(cmd, **kwargs)
+
+    is_repo = (repo_dir / ".git").exists()
+    if not is_repo:
+        logger.info("git init: %s", repo_dir)
+        proc = _run(
+            ["git", "-C", str(repo_dir), "init", "--quiet"],
+            network=False,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"git init failed: "
+                f"{(proc.stderr or proc.stdout or 'unknown error').strip()}"
+            )
+
+    # ``remote add`` is idempotent-ish — if origin already exists we
+    # rewrite the URL via ``set-url`` so the caller can reuse a
+    # repo_dir across distinct URLs without surprises. If both fail
+    # we surface BOTH errors so the operator sees the real cause
+    # (e.g. disk full) rather than only the set-url echo.
+    add_proc = _run(
+        ["git", "-C", str(repo_dir), "remote", "add", "origin", url],
+        network=False,
+    )
+    if add_proc.returncode != 0:
+        set_proc = _run(
+            ["git", "-C", str(repo_dir), "remote", "set-url", "origin", url],
+            network=False,
+        )
+        if set_proc.returncode != 0:
+            add_msg = (add_proc.stderr or add_proc.stdout or "").strip()
+            set_msg = (set_proc.stderr or set_proc.stdout or "").strip()
+            raise RuntimeError(
+                f"git remote add/set-url failed: "
+                f"add={add_msg or 'unknown error'}; "
+                f"set-url={set_msg or 'unknown error'}"
+            )
+
+    logger.info("git fetch (depth=%d): %s @ %s", depth, url, sha)
+    proc = _run(
+        [
+            "git", "-C", str(repo_dir), "fetch",
+            "--depth", str(depth), "--no-tags",
+            "origin", sha,
+        ],
+        network=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"git fetch failed: "
+            f"{(proc.stderr or proc.stdout or 'unknown error').strip()}"
+        )
+    return True
+
+
+__all__ = ["clone_repository", "fetch_commit", "get_safe_git_env"]

--- a/core/git/tests/test_clone.py
+++ b/core/git/tests/test_clone.py
@@ -1,4 +1,4 @@
-"""Clone-wrapper tests - subprocess + sandbox stubbed."""
+"""Clone- and fetch-wrapper tests - subprocess + sandbox stubbed."""
 
 from __future__ import annotations
 
@@ -8,7 +8,10 @@ from unittest.mock import patch
 
 import pytest
 
-from core.git.clone import clone_repository
+from core.git.clone import clone_repository, fetch_commit
+
+
+_VALID_SHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 
 
 def _completed(rc: int, stderr: str = "",
@@ -52,6 +55,62 @@ def test_clone_failure_raises_runtime_error(tmp_path: Path) -> None:
                               tmp_path / "out")
 
 
+def test_clone_engages_egress_proxy(tmp_path: Path) -> None:
+    """``proxy_hosts=[...]`` only engages the egress proxy when paired
+    with ``use_egress_proxy=True``. Without the flag, the sandbox keeps
+    ``block_network=True`` and the child has no network at all — clones
+    silently fail. Pin both kwargs so future refactors can't drop one."""
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        mock_run.return_value = _completed(0)
+        clone_repository("https://github.com/foo/bar", tmp_path / "out")
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs.get("use_egress_proxy") is True
+        assert "github.com" in kwargs.get("proxy_hosts", [])
+
+
+# ---------------------------------------------------------------------------
+# Writable-path validator (shared by both functions)
+# ---------------------------------------------------------------------------
+#
+# The sandbox grants the child write access to ``target.parent``
+# (clone) / ``repo_dir.parent`` (fetch). Pathological inputs would
+# silently widen that scope to the entire filesystem.
+
+@pytest.mark.parametrize("bad_path", [
+    Path(""),               # empty → "." (not absolute)
+    Path("."),              # cwd → not absolute
+    Path("relative/repo"),  # not absolute
+    Path("/"),              # filesystem root itself
+    Path("/foo"),           # parent is filesystem root
+    Path("/etc"),           # parent is filesystem root
+])
+def test_clone_rejects_unsafe_target_path_before_subprocess(
+    bad_path: Path,
+) -> None:
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        with pytest.raises(ValueError):
+            clone_repository("https://github.com/foo/bar", bad_path)
+        mock_run.assert_not_called()
+
+
+@pytest.mark.parametrize("bad_path", [
+    Path(""),
+    Path("."),
+    Path("relative/repo"),
+    Path("/"),
+    Path("/foo"),
+    Path("/etc"),
+])
+def test_fetch_rejects_unsafe_repo_dir_before_subprocess(
+    bad_path: Path,
+) -> None:
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        with pytest.raises(ValueError):
+            fetch_commit(bad_path,
+                         "https://github.com/foo/bar", _VALID_SHA)
+        mock_run.assert_not_called()
+
+
 def test_full_clone_drops_depth_flag(tmp_path: Path) -> None:
     with patch("core.sandbox.run_untrusted") as mock_run:
         mock_run.return_value = _completed(0)
@@ -60,3 +119,217 @@ def test_full_clone_drops_depth_flag(tmp_path: Path) -> None:
         cmd = mock_run.call_args.args[0]
         assert "--depth" not in cmd
         assert "--no-tags" not in cmd
+
+
+# ---------------------------------------------------------------------------
+# fetch_commit
+# ---------------------------------------------------------------------------
+
+def test_fetch_invalid_url_raises_before_subprocess(tmp_path: Path) -> None:
+    """Untrusted URL must NOT reach the sandboxed runner."""
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        with pytest.raises(ValueError):
+            fetch_commit(tmp_path / "repo",
+                         "https://evil.example.com/repo",
+                         _VALID_SHA)
+        mock_run.assert_not_called()
+
+
+def test_fetch_into_fresh_dir_runs_init_then_remote_then_fetch(
+    tmp_path: Path,
+) -> None:
+    """Fresh repo_dir → init, remote add, fetch in that order with the
+    expected flags. Network call (fetch) carries proxy_hosts; local
+    calls (init / remote) do not."""
+    repo = tmp_path / "repo"
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        mock_run.return_value = _completed(0)
+        ok = fetch_commit(repo, "https://github.com/foo/bar",
+                           _VALID_SHA, depth=5)
+        assert ok is True
+
+    cmds = [c.args[0] for c in mock_run.call_args_list]
+    assert cmds[0][:4] == ["git", "-C", str(repo), "init"]
+    assert cmds[1][:4] == ["git", "-C", str(repo), "remote"]
+    assert cmds[1][4:] == ["add", "origin", "https://github.com/foo/bar"]
+    assert cmds[2][:5] == ["git", "-C", str(repo), "fetch", "--depth"]
+    assert cmds[2][5] == "5"
+    assert cmds[2][-2:] == ["origin", _VALID_SHA]
+
+    # Network step engages the egress proxy via use_egress_proxy=True
+    # paired with proxy_hosts; local steps don't engage either kwarg.
+    # ``proxy_hosts`` without ``use_egress_proxy=True`` is a no-op (the
+    # sandbox keeps block_network=True), so both must travel together.
+    init_kwargs = mock_run.call_args_list[0].kwargs
+    fetch_kwargs = mock_run.call_args_list[2].kwargs
+    assert "proxy_hosts" not in init_kwargs
+    assert "use_egress_proxy" not in init_kwargs
+    assert fetch_kwargs.get("use_egress_proxy") is True
+    assert "github.com" in fetch_kwargs.get("proxy_hosts", [])
+    assert "codeload.github.com" in fetch_kwargs.get("proxy_hosts", [])
+
+
+def test_fetch_into_existing_repo_skips_init(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        mock_run.return_value = _completed(0)
+        fetch_commit(repo, "https://github.com/foo/bar", _VALID_SHA)
+
+    cmds = [c.args[0] for c in mock_run.call_args_list]
+    # First call should be ``remote add``, not ``init`` —
+    # the ``.git`` dir already exists.
+    assert "init" not in cmds[0]
+    assert cmds[0][3] == "remote"
+
+
+def test_fetch_existing_origin_remote_falls_back_to_set_url(
+    tmp_path: Path,
+) -> None:
+    """``remote add origin`` collides on a re-used repo; fetch_commit
+    must fall through to ``remote set-url`` so the caller can re-aim
+    a repo_dir at a different URL."""
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+
+    def _side_effect(cmd, **kwargs):
+        if cmd[3:5] == ["remote", "add"]:
+            return _completed(128, stderr="error: remote origin already exists")
+        return _completed(0)
+
+    with patch("core.sandbox.run_untrusted", side_effect=_side_effect) as mock_run:
+        ok = fetch_commit(repo, "https://github.com/foo/bar", _VALID_SHA)
+        assert ok is True
+
+    cmds = [c.args[0] for c in mock_run.call_args_list]
+    add_seen = any(c[3:5] == ["remote", "add"] for c in cmds)
+    set_url_seen = any(c[3:5] == ["remote", "set-url"] for c in cmds)
+    assert add_seen and set_url_seen
+
+
+def test_fetch_failure_raises_runtime_error(tmp_path: Path) -> None:
+    def _side_effect(cmd, **kwargs):
+        if cmd[3] == "fetch":
+            return _completed(128, stderr="fatal: couldn't find remote ref")
+        return _completed(0)
+
+    with patch("core.sandbox.run_untrusted", side_effect=_side_effect):
+        with pytest.raises(RuntimeError, match="couldn't find remote ref"):
+            fetch_commit(tmp_path / "repo",
+                         "https://github.com/foo/bar", _VALID_SHA)
+
+
+def test_fetch_init_failure_raises_runtime_error(tmp_path: Path) -> None:
+    def _side_effect(cmd, **kwargs):
+        if "init" in cmd:
+            return _completed(1, stderr="permission denied")
+        return _completed(0)
+
+    with patch("core.sandbox.run_untrusted", side_effect=_side_effect):
+        with pytest.raises(RuntimeError, match="git init failed"):
+            fetch_commit(tmp_path / "repo",
+                         "https://github.com/foo/bar", _VALID_SHA)
+
+
+@pytest.mark.parametrize("bad_sha", [
+    "--upload-pack=evil",
+    "-X",
+    "--exec=cmd",
+    "",
+    "not-hex-zzz",
+    "deadbeef--upload-pack=evil",
+    "deadbeef ",        # trailing whitespace
+    "0123456789abcdef0123456789abcdef0123456701234567",  # >40 chars
+    "abc",              # <4 chars
+    "../../etc/passwd",
+    "deadbeef\n",       # `$` slips trailing newline through; fullmatch rejects
+    "\ndeadbeef",       # leading newline
+    "dead\nbeef",       # embedded newline
+    "deadbeef\x00",     # NUL byte
+])
+def test_fetch_rejects_bad_sha_before_subprocess(
+    tmp_path: Path, bad_sha: str,
+) -> None:
+    """Tainted SHA must NOT reach ``git fetch`` — flag-position
+    injection (``--upload-pack=...``) would otherwise be parsed as a
+    fetch flag and, on SSH transport, run a chosen command remotely
+    (CVE-2017-1000117 family)."""
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        with pytest.raises(ValueError, match="SHA"):
+            fetch_commit(tmp_path / "repo",
+                         "https://github.com/foo/bar", bad_sha)
+        mock_run.assert_not_called()
+
+
+def test_fetch_accepts_short_sha(tmp_path: Path) -> None:
+    """Git allows abbreviated SHAs of 4+ chars; we must too."""
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        mock_run.return_value = _completed(0)
+        fetch_commit(tmp_path / "repo",
+                     "https://github.com/foo/bar", "deadbe")
+
+
+def test_fetch_remote_add_failure_surfaces_both_errors(
+    tmp_path: Path,
+) -> None:
+    """When remote add AND set-url both fail, the raised RuntimeError
+    must include both stderrs so the operator sees the real cause
+    (disk full / FS error / etc.) rather than only the echo from
+    set-url."""
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+
+    def _side_effect(cmd, **kwargs):
+        if cmd[3:5] == ["remote", "add"]:
+            return _completed(128, stderr="error: cannot create file (disk full)")
+        if cmd[3:5] == ["remote", "set-url"]:
+            return _completed(128, stderr="error: No such remote 'origin'")
+        return _completed(0)
+
+    with patch("core.sandbox.run_untrusted", side_effect=_side_effect):
+        with pytest.raises(RuntimeError) as exc:
+            fetch_commit(repo, "https://github.com/foo/bar", _VALID_SHA)
+        msg = str(exc.value)
+        assert "disk full" in msg
+        assert "No such remote" in msg
+
+
+def test_fetch_sandbox_writable_dir_is_parent_not_repo(
+    tmp_path: Path,
+) -> None:
+    """The sandbox ``output`` (writable allowlist + fake HOME root)
+    must be ``repo_dir.parent``, not ``repo_dir`` itself.
+
+    Reason: ``run_untrusted`` defaults to ``fake_home=True`` which
+    materialises ``{output}/.home/`` for the child's HOME. If we
+    passed ``output=str(repo_dir)``, ``.home/`` would land *inside*
+    the fetched repo, polluting the caller's working tree. Matches
+    ``clone_repository``'s pattern (which has the same constraint
+    when target.parent is its writable scope)."""
+    repo = tmp_path / "work" / "repo"
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        mock_run.return_value = _completed(0)
+        fetch_commit(repo, "https://github.com/foo/bar", _VALID_SHA)
+
+    expected_parent = str(repo.parent)
+    for call in mock_run.call_args_list:
+        kwargs = call.kwargs
+        assert kwargs["output"] == expected_parent
+        assert kwargs["target"] == expected_parent
+
+
+def test_fetch_passes_sanitised_env_and_timeout(tmp_path: Path) -> None:
+    """Every call uses ``get_safe_git_env`` and the bounded
+    ``GIT_CLONE_TIMEOUT`` — no caller-controlled bypass."""
+    from core.config import RaptorConfig
+
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        mock_run.return_value = _completed(0)
+        fetch_commit(tmp_path / "repo",
+                     "https://github.com/foo/bar", _VALID_SHA)
+
+    for call in mock_run.call_args_list:
+        kwargs = call.kwargs
+        assert "GIT_TERMINAL_PROMPT" in kwargs["env"]
+        assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+        assert kwargs["timeout"] == RaptorConfig.GIT_CLONE_TIMEOUT


### PR DESCRIPTION
Adds core.git.fetch_commit(repo_dir, url, sha, depth=5) — sandbox-routed targeted fetch as a sibling primitive to clone_repository. Right tool when the caller already knows the SHA they need and where a depth-1 clone of HEAD wouldn't reach it (older fix commits, deleted-branch commits, cherry-picks). First consumer queued: packages/cve_diff/cve_diff/ acquisition/layers.py (PR follow-up against experimental/cve-diff).

Also fixes a pre-existing bug in clone_repository: proxy_hosts=[...] was passed to run_untrusted without use_egress_proxy=True, so the egress proxy never started — and with run_untrusted forcing block_network=True, every clone had zero network. Discovered while writing fetch_commit against the same pattern. Both functions now pin both kwargs together; new test asserts they travel together so a future refactor can't drop one silently.

Hardens both functions against caller-supplied paths that would unsafely widen the sandbox writable scope: relative paths, filesystem root, and direct children of root (/foo, /etc, …) are refused before any subprocess runs. Symlink resolution defends against pre-staged /tmp/work -> / symlinks.

SHA is regex-validated [0-9a-fA-F]{4,40} via re.fullmatch — defends against --upload-pack=cmd style flag injection at the refspec position (CWE-2017-1000117 family) and against the trailing-newline bypass that ^...$ allows in Python's re. Sandbox writable scope uses repo_dir.parent so the auto-materialised .home/ from fake_home=True lands sibling to the repo, not inside.

Tests: 47 in core/git/ (12 new for the writable-path validator, 8 new for fetch flow + proxy engagement, 14 parametrised SHA-shape rejection cases). All 1465 core/ tests pass.