### PR TITLE
feat(project): add grouped Markdown findings export

### DIFF
--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -411,6 +411,8 @@ def main():
             from .report import generate_project_report
             stats = generate_project_report(p)
             print(f"Report generated: {stats.get('report_dir', p.output_path / '_report')}")
+            if stats.get("findings_dir"):
+                print(f"  Findings directory: {stats['findings_dir']}")
             print(f"  Merged findings: {stats['findings']}")
 
         elif args.subcommand == "export":

--- a/core/project/project.py
+++ b/core/project/project.py
@@ -65,8 +65,11 @@ class Project:
         """List run directories (unsorted). Shared by get_run_dirs and sweep."""
         if not self.output_path.exists():
             return []
+        generated_dirs = {"findings"}
         return [d for d in self.output_path.iterdir()
-                if d.is_dir() and not d.name.startswith((".", "_"))]
+                if d.is_dir()
+                and not d.name.startswith((".", "_"))
+                and d.name not in generated_dirs]
 
     def get_run_dirs(self, sweep=False) -> List[Path]:
         """List run directories sorted newest-first.

--- a/core/project/report.py
+++ b/core/project/report.py
@@ -1,6 +1,304 @@
 """Project report — merged view across all runs."""
 
-from typing import Any, Dict
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+
+_CONFIRMED_STATUSES = {
+    "exploitable",
+    "confirmed",
+    "confirmed_unverified",
+    "confirmed_constrained",
+    "confirmed_blocked",
+    "poc_success",
+}
+
+_RULED_OUT_STATUSES = {
+    "ruled_out",
+    "disproven",
+    "false_positive",
+    "test_code",
+    "dead_code",
+    "mitigated",
+    "unreachable",
+}
+
+
+_FIELD_LABELS = (
+    ("severity", "Severity"),
+    ("confidence", "Confidence"),
+    ("status", "Status"),
+    ("final_status", "Final status"),
+    ("file", "File"),
+    ("function", "Function"),
+    ("line", "Line"),
+    ("vuln_type", "Type"),
+    ("source", "Source"),
+    ("tool", "Tool"),
+)
+
+
+_DETAIL_FIELDS = (
+    ("description", "Description"),
+    ("reasoning", "Reasoning"),
+    ("exploitability", "Exploitability"),
+    ("exploitability_rationale", "Exploitability rationale"),
+    ("evidence", "Evidence"),
+    ("proof", "Proof"),
+    ("poc", "PoC"),
+    ("poc_path", "PoC path"),
+    ("patch", "Patch"),
+    ("patch_path", "Patch path"),
+    ("recommendation", "Recommendation"),
+)
+
+_SEVERITY_ORDER = {
+    "critical": 0,
+    "high": 1,
+    "medium": 2,
+    "moderate": 2,
+    "low": 3,
+    "info": 4,
+    "informational": 4,
+    "unknown": 5,
+}
+
+
+def _finding_status(finding: Dict[str, Any]) -> str:
+    """Return the normalized validation status for a finding."""
+    return (
+        str(finding.get("final_status") or finding.get("status") or "needs_review")
+        .strip()
+        .lower()
+    )
+
+
+def _finding_bucket(finding: Dict[str, Any]) -> str:
+    """Map validation status to a stable findings/ subdirectory."""
+    status = _finding_status(finding)
+    if status in _CONFIRMED_STATUSES:
+        return "confirmed"
+    if status in _RULED_OUT_STATUSES:
+        return "ruled-out"
+    return "needs-review"
+
+
+def _finding_fingerprint(finding: Dict[str, Any]) -> str:
+    """Return a stable short fingerprint for filenames and cross-references."""
+    payload = {
+        "id": finding.get("id") or finding.get("finding_id"),
+        "file": finding.get("file"),
+        "function": finding.get("function"),
+        "line": finding.get("line"),
+        "type": finding.get("vuln_type") or finding.get("type"),
+    }
+    encoded = json.dumps(payload, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:12]
+
+
+def _slug(value: Any, *, fallback: str = "finding") -> str:
+    """Return a filesystem-friendly slug with no path separators."""
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[^a-z0-9._-]+", "-", text)
+    text = text.strip(".-_")
+    return text[:80] or fallback
+
+
+def _finding_title(finding: Dict[str, Any]) -> str:
+    for key in ("title", "name", "summary", "vuln_type", "type"):
+        value = finding.get(key)
+        if value:
+            return str(value)
+    location = finding.get("file") or finding.get("function")
+    if location:
+        return f"Finding in {location}"
+    return "Finding"
+
+
+def _finding_stem(finding: Dict[str, Any], index: int) -> str:
+    finding_id = finding.get("id") or finding.get("finding_id") or f"finding-{index:03d}"
+    title = _finding_title(finding)
+    return (
+        f"{_slug(finding_id, fallback=f'finding-{index:03d}')}-"
+        f"{_slug(title)}-{_finding_fingerprint(finding)}"
+    )
+
+
+def _format_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False, default=str)
+    return str(value)
+
+
+def _md_escape_inline(value: Any) -> str:
+    text = _format_value(value).replace("\n", " ").strip()
+    return text.replace("|", "\\|")
+
+
+def _render_detail(label: str, value: Any) -> str:
+    rendered = _format_value(value).strip()
+    if not rendered:
+        return ""
+    if "\n" in rendered or rendered.startswith(("{", "[")):
+        return f"## {label}\n\n```\n{rendered}\n```\n"
+    return f"## {label}\n\n{rendered}\n"
+
+
+def render_finding_markdown(finding: Dict[str, Any], *, index: int = 1) -> str:
+    """Render one finding as a portable Markdown handoff artifact."""
+    fingerprint = _finding_fingerprint(finding)
+    lines: List[str] = [f"# {_finding_title(finding)}", ""]
+    lines.append(f"Stable fingerprint: `{fingerprint}`")
+    lines.append("")
+    lines.append("| Field | Value |")
+    lines.append("| --- | --- |")
+    finding_id = finding.get("id") or finding.get("finding_id") or f"finding-{index:03d}"
+    lines.append(f"| ID | {_md_escape_inline(finding_id)} |")
+    for key, label in _FIELD_LABELS:
+        value = finding.get(key)
+        if value not in (None, "", [], {}):
+            lines.append(f"| {label} | {_md_escape_inline(value)} |")
+    lines.append("")
+
+    for key, label in _DETAIL_FIELDS:
+        detail = _render_detail(label, finding.get(key))
+        if detail:
+            lines.append(detail.rstrip())
+            lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _severity_key(finding: Dict[str, Any]) -> tuple[int, str]:
+    severity = str(finding.get("severity") or "unknown").strip().lower()
+    return (_SEVERITY_ORDER.get(severity, _SEVERITY_ORDER["unknown"]), severity)
+
+
+def render_grouped_findings_markdown(findings: Iterable[Dict[str, Any]], project_name: str) -> str:
+    """Render all findings into one project-level Markdown report."""
+    findings = sorted(
+        list(findings),
+        key=lambda item: (*_severity_key(item), _finding_title(item).lower()),
+    )
+    lines = [f"# {project_name} findings", ""]
+    if not findings:
+        lines.append("No findings.")
+        return "\n".join(lines) + "\n"
+
+    grouped: Dict[str, List[Dict[str, Any]]] = {}
+    for finding in findings:
+        severity = str(finding.get("severity") or "unknown").strip().lower() or "unknown"
+        grouped.setdefault(severity, []).append(finding)
+
+    for severity in sorted(
+        grouped,
+        key=lambda item: (_SEVERITY_ORDER.get(item, _SEVERITY_ORDER["unknown"]), item),
+    ):
+        lines.append(f"## {severity.title()}")
+        lines.append("")
+        for finding in grouped[severity]:
+            finding_id = (
+                finding.get("id")
+                or finding.get("finding_id")
+                or _finding_fingerprint(finding)
+            )
+            location = finding.get("file") or finding.get("function") or "unknown location"
+            status = _finding_status(finding).replace("_", "-")
+            lines.append(
+                f"- **{_finding_title(finding)}** (`{finding_id}`) — "
+                f"{location} — {status}"
+            )
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _clear_generated_findings_dir(findings_dir: Path) -> None:
+    """Remove prior generated per-finding artifacts without following symlinks."""
+    import shutil
+
+    if findings_dir.is_symlink() or findings_dir.is_file():
+        findings_dir.unlink()
+        return
+    if findings_dir.is_dir():
+        shutil.rmtree(findings_dir)
+
+
+def export_findings_directory(
+    findings: Iterable[Dict[str, Any]], output_dir: Path, *, project_name: str = "project"
+) -> Dict[str, Any]:
+    """Write grouped Markdown/JSON findings under ``output_dir/findings``.
+
+    The directory is intended for handoff to issue trackers, disclosure notes,
+    and audits. It is regenerated from merged findings each time project report
+    runs, so stale findings are not retained after they disappear from inputs.
+    """
+    findings = list(findings)
+    output_dir = Path(output_dir)
+    findings_dir = output_dir / "findings"
+    _clear_generated_findings_dir(findings_dir)
+    findings_dir.mkdir(parents=True, exist_ok=True)
+
+    counts = {"confirmed": 0, "needs-review": 0, "ruled-out": 0}
+    manifest = {"findings": []}
+    jsonl_records = []
+    aggregate_path = findings_dir / f"{_slug(project_name, fallback='project')}.md"
+    aggregate_path.write_text(
+        render_grouped_findings_markdown(findings, project_name),
+        encoding="utf-8",
+    )
+
+    for index, finding in enumerate(findings, start=1):
+        bucket = _finding_bucket(finding)
+        counts[bucket] += 1
+        bucket_dir = findings_dir / bucket
+        bucket_dir.mkdir(parents=True, exist_ok=True)
+        stem = _finding_stem(finding, index)
+        markdown_path = bucket_dir / f"{stem}.md"
+        json_path = bucket_dir / f"{stem}.json"
+
+        markdown_path.write_text(render_finding_markdown(finding, index=index), encoding="utf-8")
+        json_path.write_text(
+            json.dumps(finding, indent=2, sort_keys=True, ensure_ascii=False, default=str) + "\n",
+            encoding="utf-8",
+        )
+
+        record = {
+            "id": finding.get("id") or finding.get("finding_id") or f"finding-{index:03d}",
+            "title": _finding_title(finding),
+            "status": _finding_status(finding),
+            "bucket": bucket,
+            "fingerprint": _finding_fingerprint(finding),
+            "markdown": str(markdown_path.relative_to(output_dir)),
+            "json": str(json_path.relative_to(output_dir)),
+        }
+        manifest["findings"].append(record)
+        jsonl_records.append({**record, "finding": finding})
+
+    (findings_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True, ensure_ascii=False, default=str) + "\n",
+        encoding="utf-8",
+    )
+    (findings_dir / "findings.jsonl").write_text(
+        "".join(
+            json.dumps(record, sort_keys=True, ensure_ascii=False, default=str) + "\n"
+            for record in jsonl_records
+        ),
+        encoding="utf-8",
+    )
+    return {
+        "findings_dir": str(findings_dir),
+        "aggregate_markdown": str(aggregate_path),
+        "counts": counts,
+        "files": len(jsonl_records) * 2 + 3,
+    }
 
 
 def generate_project_report(project) -> Dict[str, Any]:
@@ -21,9 +319,17 @@ def generate_project_report(project) -> Dict[str, Any]:
     # Merge findings
     merged = merge_findings(run_dirs)
     save_json(report_dir / "findings.json", {"findings": merged})
+    findings_export = export_findings_directory(
+        merged,
+        project.output_path,
+        project_name=project.name,
+    )
 
     return {
         "findings": len(merged),
         "runs": len(run_dirs),
         "report_dir": str(report_dir),
+        "findings_dir": findings_export["findings_dir"],
+        "aggregate_markdown": findings_export["aggregate_markdown"],
+        "finding_buckets": findings_export["counts"],
     }

--- a/core/project/tests/test_report.py
+++ b/core/project/tests/test_report.py
@@ -84,6 +84,70 @@ class TestProjectReport(unittest.TestCase):
             stats = generate_project_report(p)
             self.assertEqual(stats["findings"], 1)  # Not 2
 
+    def test_report_writes_grouped_markdown_findings(self):
+        with TemporaryDirectory() as d:
+            p = self._make_project(d, {
+                "scan-20260401": [
+                    {
+                        "id": "RPT-001",
+                        "title": "Command injection",
+                        "status": "confirmed",
+                        "severity": "high",
+                        "file": "src/app.py",
+                        "function": "handler",
+                        "line": 42,
+                        "vuln_type": "command_injection",
+                        "evidence": "attacker-controlled argument reaches subprocess",
+                    },
+                    {
+                        "id": "RPT-002",
+                        "title": "Dead code report",
+                        "status": "ruled_out",
+                        "file": "src/legacy.py",
+                        "function": "old_handler",
+                    },
+                    {
+                        "id": "RPT-003",
+                        "title": "Needs triage",
+                        "status": "not_disproven",
+                        "file": "src/review.py",
+                    },
+                ],
+            })
+
+            stats = generate_project_report(p)
+
+            findings_dir = p.output_path / "findings"
+            self.assertEqual(stats["finding_buckets"], {
+                "confirmed": 1,
+                "needs-review": 1,
+                "ruled-out": 1,
+            })
+            self.assertTrue((findings_dir / "manifest.json").exists())
+            self.assertTrue((findings_dir / "findings.jsonl").exists())
+            self.assertTrue((findings_dir / "test.md").exists())
+            self.assertEqual(len(list((findings_dir / "confirmed").glob("*.md"))), 1)
+            self.assertEqual(len(list((findings_dir / "ruled-out").glob("*.md"))), 1)
+            self.assertEqual(len(list((findings_dir / "needs-review").glob("*.md"))), 1)
+            aggregate = (findings_dir / "test.md").read_text()
+            self.assertIn("# test findings", aggregate)
+            self.assertLess(aggregate.index("## High"), aggregate.index("## Unknown"))
+            markdown = next((findings_dir / "confirmed").glob("*.md")).read_text()
+            self.assertIn("# Command injection", markdown)
+            self.assertIn("Stable fingerprint:", markdown)
+            self.assertIn("| Severity | high |", markdown)
+            self.assertIn("attacker-controlled argument reaches subprocess", markdown)
+
+    def test_generated_findings_directory_is_not_treated_as_run(self):
+        with TemporaryDirectory() as d:
+            p = self._make_project(d, {
+                "scan-20260401": [{"id": "F-001", "status": "confirmed"}],
+            })
+            generate_project_report(p)
+            stats = generate_project_report(p)
+            self.assertEqual(stats["runs"], 1)
+            self.assertEqual(stats["findings"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Adds a generated `findings/` directory when `project report` runs.
- Writes a project-level Markdown report named `<project>.md`, grouped and ordered by severity.
- Writes per-finding Markdown and JSON artifacts grouped by validation status (`confirmed/`, `needs-review/`, `ruled-out/`).
- Adds `manifest.json` and `findings.jsonl` for machine-readable handoff.

Closes #161.

## Why
Issue #161 asks for a standard `/findings` output that is easier to hand off after a RAPTOR run. The existing `_report/findings.json` is useful for machines, but security review and disclosure workflows often need stable Markdown artifacts too.

## Notes
- The generated `findings/` directory is excluded from run discovery so repeated report generation stays idempotent.
- Per-finding filenames include a stable fingerprint to avoid collisions.
- The existing `_report/findings.json` output remains unchanged.

## Test plan
- `python3 -m pytest core/project/tests/test_report.py -q`
- `python3 -m pytest core/project/tests -q`
- `python3 -m compileall -q core/project`
- `git diff --check`

## Local environment note
A broader local `python3 -m pytest core -q` run on macOS/arm64 still shows unrelated existing sandbox/path baseline failures (for example `/private/var` vs `/var`, PID1 shim, and Linux syscall-table expectations). The project-report focused suite above passes locally.
