### PR TITLE
feat(project): add coverage threshold gate

### DIFF
--- a/core/coverage/summary.py
+++ b/core/coverage/summary.py
@@ -211,6 +211,32 @@ def _pl(n: int, word: str) -> str:
     return f"{n} {word}" if n == 1 else f"{n} {word}s"
 
 
+def llm_item_coverage_percent(summary: Dict[str, Any]) -> float:
+    """Return percentage of inventory items reviewed by LLM coverage records."""
+    if not summary:
+        return 0.0
+    total = summary.get("inventory", {}).get("items", 0)
+    if not total:
+        return 100.0
+    reviewed = total - summary.get("unreviewed_functions", 0)
+    return max(0.0, min(100.0, reviewed / total * 100))
+
+
+def coverage_threshold_met(summary: Dict[str, Any], fail_under: float) -> bool:
+    """Return whether LLM item coverage satisfies ``fail_under`` percent."""
+    return llm_item_coverage_percent(summary) >= fail_under
+
+
+def format_threshold_result(summary: Dict[str, Any], fail_under: float) -> str:
+    """Format a copy-paste friendly coverage threshold result."""
+    pct = llm_item_coverage_percent(summary)
+    status = "PASS" if coverage_threshold_met(summary, fail_under) else "FAIL"
+    return (
+        f"Coverage threshold: {pct:.1f}% LLM item coverage; "
+        f"required {fail_under:.1f}% — {status}"
+    )
+
+
 def format_summary(summary: Dict[str, Any]) -> str:
     """Format coverage summary — Option D (actionable overview)."""
     if not summary:

--- a/core/coverage/tests/test_summary.py
+++ b/core/coverage/tests/test_summary.py
@@ -5,7 +5,14 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from core.coverage.summary import compute_summary, compute_project_summary, format_summary
+from core.coverage.summary import (
+    compute_summary,
+    compute_project_summary,
+    coverage_threshold_met,
+    format_summary,
+    format_threshold_result,
+    llm_item_coverage_percent,
+)
 from core.coverage.record import write_record
 
 
@@ -176,6 +183,28 @@ class TestFormatSummary(unittest.TestCase):
 
     def test_no_data(self):
         self.assertEqual(format_summary(None), "No coverage data available.")
+
+    def test_llm_item_coverage_threshold_helpers(self):
+        summary = {
+            "inventory": {"files": 2, "sloc": 120, "items": 4},
+            "tools": {
+                "llm": {
+                    "files_examined": 1,
+                    "files_total": 2,
+                    "functions_analysed": 3,
+                    "functions_total": 4,
+                }
+            },
+            "unreviewed_functions": 1,
+            "unreviewed_sloc": 30,
+            "missing_groups": [],
+            "per_file": [],
+        }
+        self.assertEqual(llm_item_coverage_percent(summary), 75.0)
+        self.assertTrue(coverage_threshold_met(summary, 75.0))
+        self.assertFalse(coverage_threshold_met(summary, 80.0))
+        self.assertIn("75.0% LLM item coverage", format_threshold_result(summary, 80.0))
+        self.assertIn("FAIL", format_threshold_result(summary, 80.0))
 
 
 class TestProjectSummary(unittest.TestCase):

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -68,10 +68,20 @@ def main():
     p_status.add_argument("name", nargs="?", help="Project name")
 
     # coverage
-    p_cov = sub.add_parser("coverage", help="Show coverage summary",
-                           usage="raptor project coverage [<name>] [--detailed]", **_F)
+    p_cov = sub.add_parser(
+        "coverage",
+        help="Show coverage summary",
+        usage="raptor project coverage [<name>] [--detailed] [--fail-under <pct>]",
+        **_F,
+    )
     p_cov.add_argument("name", nargs="?", help="Project name")
     p_cov.add_argument("--detailed", action="store_true", help="Per-file breakdown")
+    p_cov.add_argument(
+        "--fail-under",
+        type=float,
+        metavar="<pct>",
+        help="Exit non-zero unless LLM item coverage is at least this percentage",
+    )
 
     # findings
     p_findings = sub.add_parser("findings", help="Show merged findings across all runs",
@@ -231,7 +241,9 @@ def main():
             if not p:
                 print(f"Project '{name}' not found.")
                 return
-            _print_coverage(p, detailed=args.detailed)
+            result = _print_coverage(p, detailed=args.detailed, fail_under=args.fail_under)
+            if result is False:
+                sys.exit(1)
 
         elif args.subcommand == "findings":
             name = args.name or _get_active_project()
@@ -581,19 +593,28 @@ def _print_status(project):
         print("\nNo runs.")
 
 
-def _print_coverage(project, detailed=False):
+def _print_coverage(project, detailed=False, fail_under=None):
     """Print project coverage summary or detailed view."""
     from core.coverage.summary import (
-        compute_project_summary, format_summary, format_detailed,
+        compute_project_summary,
+        coverage_threshold_met,
+        format_detailed,
+        format_summary,
+        format_threshold_result,
     )
     summary = compute_project_summary(project)
     if not summary:
         print("No coverage data (no checklist or coverage records found).")
-        return
+        return False if fail_under is not None else None
     if detailed:
         print(format_detailed(summary))
     else:
         print(format_summary(summary))
+    if fail_under is not None:
+        print()
+        print(format_threshold_result(summary, fail_under))
+        return coverage_threshold_met(summary, fail_under)
+    return None
 
 
 def _print_findings(project, detailed=False):


### PR DESCRIPTION
## Summary
- Adds `raptor project coverage --fail-under <pct>` as a coverage gate for project coverage reports.
- Computes LLM item coverage from the existing coverage summary shape.
- Prints a clear PASS/FAIL threshold line and exits non-zero when the threshold is not met.
- Adds unit coverage for the threshold helpers.

Addresses part of #73.

## Why
Issue #73 asks for coverage-backed reporting and enforcement so operators can avoid assuming that an audit reviewed the full target. RAPTOR already records checklist/coverage data; this adds a small enforcement hook that can be used in local workflows and CI.

Example:

```bash
raptor project coverage my-project --fail-under 80
```

## Test plan
- `python3 -m pytest core/coverage/tests -q`
- `python3 -m compileall -q core/coverage core/project/cli.py`
- `git diff --check`
