### PR TITLE
cve_diff: discovery fixes — URL extraction + SSH normalisation

### DIFF
--- a/packages/cve_diff/cve_diff/core/url_re.py
+++ b/packages/cve_diff/cve_diff/core/url_re.py
@@ -70,8 +70,16 @@ def normalize_slug(slug: str) -> str:
 
 
 def extract_github_slug(url: str) -> str | None:
-    """Return the canonical `owner/repo` slug from any GitHub URL, or None."""
-    m = GITHUB_REPO_URL_RE.match(url or "")
+    """Return the canonical `owner/repo` slug from any GitHub URL, or None.
+
+    Uses ``.search()`` so embedded URLs (e.g. an OSV reference body
+    like ``"see fix at https://github.com/owner/repo"``) are matched.
+    Pre-2026-05-02 used ``.match()``, which only matched at position 0
+    and silently dropped any URL with leading prose — a real hit when
+    OSV/NVD authors wrap the URL in advisory text. Consistent with
+    ``discovery/osv.py``'s ``_GITHUB_COMMIT_URL_RE.search()`` usage.
+    """
+    m = GITHUB_REPO_URL_RE.search(url or "")
     if not m:
         return None
     return normalize_slug(m.group(1))

--- a/packages/cve_diff/cve_diff/discovery/nvd.py
+++ b/packages/cve_diff/cve_diff/discovery/nvd.py
@@ -187,10 +187,21 @@ class NvdDiscoverer:
             if "Patch" not in tags:
                 continue
             url = ref.get("url") or ""
-            m = _GITHUB_COMMIT_URL_RE.match(url)
+            # ``.search()`` not ``.match()``: NVD reference URLs are
+            # frequently embedded in advisory prose (``"Patch: <URL>"``,
+            # ``"See <URL> for details"``); ``.match()`` only succeeds
+            # at position 0 and silently dropped them. Parity with
+            # ``discovery/osv.py``'s ``_GITHUB_COMMIT_URL_RE.search()``.
+            m = _GITHUB_COMMIT_URL_RE.search(url)
             if not m:
                 continue
             slug = m.group(1).removesuffix(".git")
+            # ``removesuffix`` is a no-op on inputs without ``.git``,
+            # so a malformed regex group could survive into the slug.
+            # Defence-in-depth — reject anything that doesn't look
+            # like ``owner/repo``.
+            if not slug or slug.count("/") != 1:
+                continue
             sha = m.group(2).lower()
             key = (slug, sha)
             if key in seen:

--- a/packages/cve_diff/cve_diff/discovery/osv.py
+++ b/packages/cve_diff/cve_diff/discovery/osv.py
@@ -174,14 +174,29 @@ class OSVDiscoverer:
 
     @staticmethod
     def _normalize_repo(url: str) -> str:
+        """Convert OSV ``ranges[].repo`` shapes to a canonical HTTPS form.
+
+        OSV records carry repos in several shapes — git://, ssh://git@,
+        and bare ``git@host:path`` SCP-style. We normalise every shape
+        to ``https://<host>/<path>`` so downstream consumers (commit
+        fetchers, slug extractors) only need to handle one form.
+        """
         if not url:
             return ""
         if url.endswith(".git"):
             url = url[:-4]
         if url.startswith("git://"):
-            url = "https://" + url[len("git://") :]
+            url = "https://" + url[len("git://"):]
         elif url.startswith("ssh://git@"):
-            url = "https://" + url[len("ssh://git@") :]
+            url = "https://" + url[len("ssh://git@"):]
         elif url.startswith("git@"):
-            url = url.replace("git@", "https://", 1).replace(":", "/", 1)
+            # SCP-style: ``git@<host>:<path>`` (one colon, no scheme).
+            # The naive ``.replace("git@", "https://").replace(":", "/", 1)``
+            # broke because the second replace clobbered the ``://``
+            # separator from the first replace. Split on the FIRST colon
+            # explicitly so the host and path are unambiguous.
+            rest = url[len("git@"):]
+            if ":" in rest:
+                host, path = rest.split(":", 1)
+                url = f"https://{host}/{path}"
         return url

--- a/packages/cve_diff/tests/unit/discovery/test_nvd.py
+++ b/packages/cve_diff/tests/unit/discovery/test_nvd.py
@@ -119,6 +119,36 @@ class TestFiltersNonPatchTagged:
         assert result is None
 
 
+class TestExtractsEmbeddedUrls:
+    """Pre-2026-05-02 the NVD URL regex used ``.match()``, which only
+    matched at position 0. NVD references are routinely wrapped in
+    advisory text (``"Patch: <URL>"``, ``"See <URL> for details"``);
+    those references were silently dropped. ``.search()`` recovers them.
+    """
+
+    @responses.activate
+    def test_url_with_leading_prose_is_extracted(self) -> None:
+        responses.add(
+            responses.GET,
+            "https://services.nvd.nist.gov/rest/json/cves/2.0",
+            json=_nvd_payload([
+                {
+                    "url": (
+                        "Fixed by commit "
+                        "https://github.com/curl/curl/commit/"
+                        "172e54cda18412da73fd8eb4e444e8a5b371ca59"
+                    ),
+                    "tags": ["Patch"],
+                }
+            ]),
+            status=200,
+        )
+        result = NvdDiscoverer().fetch("CVE-2024-1234")
+        assert result is not None
+        assert len(result.tuples) == 1
+        assert result.tuples[0].repository_url == "https://github.com/curl/curl"
+
+
 class TestRejectsShortShas:
     @responses.activate
     def test_sha_below_seven_chars_rejected(self) -> None:

--- a/packages/cve_diff/tests/unit/discovery/test_osv.py
+++ b/packages/cve_diff/tests/unit/discovery/test_osv.py
@@ -231,6 +231,55 @@ class TestOSVFetch:
         assert OSVDiscoverer().fetch("CVE-2024-9999") is None
 
 
+class TestNormalizeRepo:
+    """``_normalize_repo`` collapses git://, ssh://git@, and bare ``git@``
+    SCP-style URLs to ``https://<host>/<path>``. Pre-2026-05-02 the
+    ``git@`` SCP-style branch was broken: a chained
+    ``.replace("git@", "https://").replace(":", "/", 1)`` clobbered the
+    ``://`` separator from the first replace, producing malformed
+    ``https//<host>:<path>`` URLs that downstream slug extractors then
+    silently dropped.
+    """
+
+    def test_git_at_scp_style_normalises(self) -> None:
+        from cve_diff.discovery.osv import OSVDiscoverer
+        out = OSVDiscoverer._normalize_repo("git@github.com:owner/repo")
+        assert out == "https://github.com/owner/repo"
+
+    def test_git_at_scp_style_with_dot_git_suffix(self) -> None:
+        from cve_diff.discovery.osv import OSVDiscoverer
+        out = OSVDiscoverer._normalize_repo("git@github.com:owner/repo.git")
+        assert out == "https://github.com/owner/repo"
+
+    def test_git_at_scp_style_gitlab(self) -> None:
+        from cve_diff.discovery.osv import OSVDiscoverer
+        out = OSVDiscoverer._normalize_repo(
+            "git@gitlab.com:group/subgroup/repo.git",
+        )
+        assert out == "https://gitlab.com/group/subgroup/repo"
+
+    def test_git_protocol_normalises(self) -> None:
+        from cve_diff.discovery.osv import OSVDiscoverer
+        out = OSVDiscoverer._normalize_repo("git://github.com/owner/repo.git")
+        assert out == "https://github.com/owner/repo"
+
+    def test_ssh_git_at_normalises(self) -> None:
+        from cve_diff.discovery.osv import OSVDiscoverer
+        out = OSVDiscoverer._normalize_repo(
+            "ssh://git@github.com/owner/repo.git",
+        )
+        assert out == "https://github.com/owner/repo"
+
+    def test_https_passthrough(self) -> None:
+        from cve_diff.discovery.osv import OSVDiscoverer
+        out = OSVDiscoverer._normalize_repo("https://github.com/owner/repo")
+        assert out == "https://github.com/owner/repo"
+
+    def test_empty_returns_empty(self) -> None:
+        from cve_diff.discovery.osv import OSVDiscoverer
+        assert OSVDiscoverer._normalize_repo("") == ""
+
+
 @pytest.mark.integration
 class TestOSVLive:
     """Live OSV hit — marked `integration`, skipped by default."""

--- a/packages/cve_diff/tests/unit/test_url_re.py
+++ b/packages/cve_diff/tests/unit/test_url_re.py
@@ -49,6 +49,30 @@ def test_extract_slug_lowercases() -> None:
     assert extract_github_slug("https://github.com/Curl/Curl") == "curl/curl"
 
 
+def test_extract_slug_finds_embedded_url() -> None:
+    """``.search()``-not-``.match()``: the slug extractor must find a
+    GitHub URL even when there's leading prose. Pre-2026-05-02 used
+    ``.match()`` and silently dropped any URL not at position 0 —
+    OSV/NVD reference text routinely wraps the URL ("see fix at
+    https://github.com/...", "Mitigated by https://github.com/..."),
+    so the bug suppressed valid references from advisory pages.
+    """
+    cases = {
+        "see fix at https://github.com/torvalds/linux": "torvalds/linux",
+        "Mitigated by https://github.com/curl/curl/pull/1234": "curl/curl",
+        "Reference: https://github.com/python/cpython for details":
+            "python/cpython",
+    }
+    for url, expected in cases.items():
+        assert extract_github_slug(url) == expected, url
+
+
+def test_extract_slug_returns_none_for_no_match() -> None:
+    assert extract_github_slug("") is None
+    assert extract_github_slug("not a url") is None
+    assert extract_github_slug("https://example.com/foo/bar") is None
+
+
 # ---- GITHUB_COMMIT_URL_RE — already correct, just regression-cover
 
 def test_commit_url_re_keeps_dotted_repo_name() -> None:


### PR DESCRIPTION
Four audit findings localised to OSV/NVD/url_re. See commit message for details.