### PR TITLE
ci: root pytest.ini + remove tests/__init__.py collision

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,22 @@
+[pytest]
+# Root-level pytest configuration.
+#
+# Lives here (not in a per-package pyproject.toml) because raptor's CI
+# invokes ``pytest core packages`` from the rootdir; pytest reads its
+# config from rootdir up. Per-package ``[tool.pytest.ini_options]``
+# sections only apply when their package is run standalone.
+#
+# Currently this file does two things:
+#   1. Registers the ``integration`` marker so live-network tests
+#      (cve_diff's ``TestOSVLive``, ``TestNVDLive``, etc.) don't
+#      emit ``UnknownMarkWarning`` during collection.
+#   2. Deselects integration tests by default. Opt in with
+#      ``pytest -m integration`` (drops the negation).
+#
+# Other packages can extend ``markers`` as they grow their own
+# conventions. Shared raptor-wide pytest config goes here too.
+
+markers =
+    integration: tests that hit live network — deselected by default
+
+addopts = -m "not integration"


### PR DESCRIPTION
Closes the two remaining CI noise sources after #262:

  1. ``UnknownMarkWarning: pytest.mark.integration`` (6 firings). cve-diff's ``[tool.pytest.ini_options]`` registered the marker in its own pyproject, but raptor's CI runs ``pytest core packages`` from the rootdir and only reads rootdir config. A root ``pytest.ini`` now registers the marker AND sets ``addopts = -m "not integration"`` so live-network tests are deselected by default. Opt-in with ``pytest -m integration``.

  2. ``ModuleNotFoundError: No module named 'tests.test_scanner'`` (3 collection errors in packages/static-analysis/tests/). Multiple packages have ``tests/__init__.py``, all named ``tests``. Under pytest's ``prepend`` import mode they collide in sys.modules. ``static-analysis`` (hyphen → invalid Python identifier) is the consistent loser. Removing ``packages/static-analysis/tests/__init__.py`` makes pytest import those test files via rootdir-relative resolution, which is collision-free.