### PR TITLE
cve_diff: drop vestigial reflection_injected dead code

### DIFF
--- a/packages/cve_diff/cve_diff/agent/loop.py
+++ b/packages/cve_diff/cve_diff/agent/loop.py
@@ -97,7 +97,7 @@ _SUBMIT_TOOL = Tool(
 
 
 def _rules_disabled() -> bool:
-    """Variant-2 toggle: skip cascade-surrender + iter-3 reflection.
+    """Variant-2 toggle: skip cascade-surrender.
 
     Set ``CVE_DIFF_DISABLE_RULES=1`` to test the purely-agentic path
     where only the hard caps ($2/30 iter/720s) backstop.
@@ -255,8 +255,6 @@ class AgentLoop:
         # How many in-loop LLM retries fired (across all iterations).
         # Surface this to the bench so the report can show retry effects.
         llm_retries: int = 0
-        # The iter-3 reflection hint fires at most once per run.
-        reflection_injected: bool = False
         # Per-call (tool_name, args_repr_first_120chars) — captured to
         # validate args-novelty claims in post-hoc analysis. Privacy-safe:
         # args are CVE IDs, slugs, queries, paths — no secrets. Limited
@@ -301,7 +299,6 @@ class AgentLoop:
                     ),
                     budget, start, tuple(tool_call_log), tuple(verified), llm_retries,
                     tool_calls_with_args=tuple(tool_calls_with_args),
-                    reflection_injected=reflection_injected,
                 )
             if (
                 not rules_disabled
@@ -320,7 +317,6 @@ class AgentLoop:
                     ),
                     budget, start, tuple(tool_call_log), tuple(verified), llm_retries,
                     tool_calls_with_args=tuple(tool_calls_with_args),
-                    reflection_injected=reflection_injected,
                 )
 
             # Prompt caching: mark the system prompt as cacheable so
@@ -381,7 +377,6 @@ class AgentLoop:
                     AgentSurrender(reason="llm_error", detail=str(last_exc)[:200] if last_exc else "unknown"),
                     budget, start, tuple(tool_call_log), tuple(verified), llm_retries,
                     tool_calls_with_args=tuple(tool_calls_with_args),
-                    reflection_injected=reflection_injected,
                 )
 
             budget.iterations += 1
@@ -417,7 +412,6 @@ class AgentLoop:
                     AgentSurrender(reason="model_stopped_without_submit", detail=text_snippet[:200]),
                     budget, start, tuple(tool_call_log), tuple(verified), llm_retries,
                     tool_calls_with_args=tuple(tool_calls_with_args),
-                    reflection_injected=reflection_injected,
                 )
 
             tool_results: list[dict[str, Any]] = []
@@ -462,7 +456,6 @@ class AgentLoop:
                                     budget, start, tuple(tool_call_log),
                                     tuple(verified), llm_retries,
                                     tool_calls_with_args=tuple(tool_calls_with_args),
-                                    reflection_injected=reflection_injected,
                                     unverified_submits=unverified_submits,
                                     not_found_submits=not_found_submits,
                                 )
@@ -505,7 +498,6 @@ class AgentLoop:
                                     budget, start, tuple(tool_call_log),
                                     tuple(verified), llm_retries,
                                     tool_calls_with_args=tuple(tool_calls_with_args),
-                                    reflection_injected=reflection_injected,
                                     unverified_submits=unverified_submits,
                                     not_found_submits=not_found_submits,
                                 )
@@ -604,7 +596,6 @@ class AgentLoop:
             result, budget, start, tuple(tool_call_log),
             tuple(verified), llm_retries,
             tool_calls_with_args=tuple(tool_calls_with_args),
-            reflection_injected=reflection_injected,
             unverified_submits=unverified_submits,
             not_found_submits=not_found_submits,
         )
@@ -619,7 +610,6 @@ class AgentLoop:
         llm_retries: int = 0,
         *,
         tool_calls_with_args: tuple[tuple[str, str], ...] = (),
-        reflection_injected: bool = False,
         unverified_submits: int = 0,
         not_found_submits: int = 0,
     ) -> AgentResult:
@@ -634,7 +624,6 @@ class AgentLoop:
             "elapsed_s": elapsed,
             "tool_calls": list(tool_calls),
             "tool_calls_with_args": [list(t) for t in tool_calls_with_args],
-            "reflection_injected": reflection_injected,
             "llm_retries": llm_retries,
             "unverified_submits": unverified_submits,
             "not_found_submits": not_found_submits,

--- a/packages/cve_diff/cve_diff/agent/source_classes.py
+++ b/packages/cve_diff/cve_diff/agent/source_classes.py
@@ -13,7 +13,6 @@ Used by `agent/loop.py` to:
 1. Track which source classes the agent has already tried.
 2. Surrender no_evidence when ALL applicable classes are exhausted AND
    no verification call has succeeded.
-3. Inject a one-shot reflection hint at iter 4 listing untried classes.
 
 Distinct from the no-lists mandate: this is a tool-name → source-class
 mapping (intrinsic to the tools we built, not a discovery list of
@@ -113,8 +112,6 @@ def should_surrender_no_evidence(
 
 
 def untried_classes(tool_call_log: list[str]) -> frozenset[str]:
-    """Source classes the agent hasn't invoked yet — kept for the
-    cascade rule's tried-set logic and the per-stage retrospective
-    (`scripts/retrospective_per_stage.py`). The iter-3 reflection
-    hint that originally consumed this is retired (2026-04-26)."""
+    """Source classes the agent hasn't invoked yet — used by the
+    cascade rule's tried-set logic."""
     return frozenset(SOURCE_CLASSES.keys()) - tried_classes(tool_call_log)

--- a/packages/cve_diff/cve_diff/cli/bench.py
+++ b/packages/cve_diff/cve_diff/cli/bench.py
@@ -71,10 +71,6 @@ class _CveResult:
     # "agent re-queried with varied args" — relevant for validating
     # Action A's claims and analyzing walker patterns.
     agent_tool_calls_with_args: tuple[tuple[str, str], ...] = ()
-    # Whether the iter-4 reflection hint actually fired during this
-    # run. Helps measure how often the agent reaches the hint vs
-    # solves before iter-4.
-    reflection_fired: bool = False
     agent_model: str = ""
     # Recovery telemetry: how many in-loop LLM retries fired (3-attempt
     # backoff inside AgentLoop), whether the pipeline's meta-retry on
@@ -227,7 +223,6 @@ def _agent_attrs(pipeline: "Pipeline", model_id: str) -> dict:
         "agent_tool_calls_with_args": tuple(
             tuple(t) for t in tel.get("tool_calls_with_args", [])
         ),
-        "reflection_fired": bool(tel.get("reflection_injected", False)),
         "agent_model": model_id,
         "llm_retries": int(tel.get("llm_retries", 0)),
         "meta_retry_attempted": bool(getattr(pipeline, "_last_meta_retry_attempted", False)),

--- a/packages/cve_diff/tests/unit/cli/test_main.py
+++ b/packages/cve_diff/tests/unit/cli/test_main.py
@@ -84,7 +84,7 @@ def _patch_agent_loop(monkeypatch, result):
                 ("osv_raw", '{"cve_id": "CVE-X"}'),
                 ("submit_result", '{"outcome": "rescued"}'),
             ],
-            "reflection_injected": False, "llm_retries": 0,
+            "llm_retries": 0,
         }
         return result
     monkeypatch.setattr(AgentLoop, "run", stub_run)


### PR DESCRIPTION
## Summary
- Removes the `reflection_injected` flag and `reflection_fired` field — vestigial plumbing left behind when Action F (iter-3 reflection hint) was retired on 2026-04-29.
- Behaviour-neutral: every live path was already passing the always-False flag through.
- 4 files touched in `packages/cve_diff/`.

## Why
The firing logic was deleted in `383dfb0` (2026-04-29 *"Phase 2 retirement: delete iter-3 reflection (F) + verify-by-position nudge (G)"*). What remained: the local declaration at `cve_diff/agent/loop.py:259`, the `_finalize` parameter, the `"reflection_injected"` key in `last_telemetry`, the `_CveResult.reflection_fired` field, and the test stub. None of these can flip True — there is no assignment site anywhere. Structurally dead, not "rarely fires."

## Test plan
- [x] `pytest packages/cve_diff/tests/unit -q` → **629 passed, 1 deselected**
- [x] `git grep -nE 'reflection_injected|reflection_fired' packages/cve_diff/cve_diff/ packages/cve_diff/tests/` → zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a behavior-neutral cleanup removing an always-false flag from telemetry and tests.
> 
> **Overview**
> Drops the vestigial iter-3 reflection-hint plumbing by removing the `reflection_injected` flag from `AgentLoop._finalize()`/`last_telemetry` and deleting the corresponding `reflection_fired` field from bench results.
> 
> Updates related docstrings/comments and adjusts the CLI test stub telemetry payload accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b7a0a10de0f64124f0ac45d126a290a16c51608. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->