### PR TITLE
core/git: add sandbox-routed ls_remote() helper

### DIFF
--- a/core/git/__init__.py
+++ b/core/git/__init__.py
@@ -1,10 +1,12 @@
-"""Git operations — sandbox-routed clone + targeted fetch + URL allowlist.
+"""Git operations — sandbox-routed clone / fetch / ls-remote + URL allowlist.
 
 Public entry points:
 
   - ``validate_repo_url(url)``: regex allowlist for github / gitlab
     HTTPS + SSH URLs. Designed to fail-closed: anything not matching
-    is rejected.
+    is rejected. Used by ``clone_repository`` / ``fetch_commit``
+    (which are scoped to GitHub + GitLab); ``ls_remote`` is wider
+    and accepts a caller-supplied hostname allowlist instead.
 
   - ``clone_repository(url, target, depth=1)``: shallow clone routed
     through ``core.sandbox.run_untrusted`` with the egress proxy
@@ -18,22 +20,33 @@ Public entry points:
     HEAD wouldn't reach it (old fixes, deleted-branch commits). Same
     sandbox / proxy / env / timeout posture as ``clone_repository``.
 
+  - ``ls_remote(url, *, proxy_hosts)``: read-only ref enumeration
+    against arbitrary forges. Caller supplies the proxy allowlist
+    because consumers (cve_diff's agent, etc.) cover wider host sets
+    than the github/gitlab pair. SSRF / DNS-rebinding / private-IP
+    block enforced by ``core.sandbox.proxy`` regardless of allowlist
+    breadth.
+
 The sandbox routing is the security-load-bearing piece. Pre-#210 this
 module would have been a plain subprocess wrapper; post-#210 every
-clone or fetch of an untrusted URL passes through namespace + Landlock
-+ a network namespace pinned to a hostname allowlist. ``git`` itself
-runs as the untrusted process — a malicious server-side hook on a
-forked clone (or a compromised mirror) is contained.
+clone, fetch, or ls-remote of an untrusted URL passes through
+namespace + Landlock + a network namespace pinned to a hostname
+allowlist. ``git`` itself runs as the untrusted process — a malicious
+server-side hook on a forked clone (or a compromised mirror) is
+contained.
 """
 
 from __future__ import annotations
 
-from core.git.clone import clone_repository, fetch_commit, get_safe_git_env
+from core.git.clone import (
+    clone_repository, fetch_commit, get_safe_git_env, ls_remote,
+)
 from core.git.validate import validate_repo_url
 
 __all__ = [
     "clone_repository",
     "fetch_commit",
     "get_safe_git_env",
+    "ls_remote",
     "validate_repo_url",
 ]

--- a/core/git/clone.py
+++ b/core/git/clone.py
@@ -31,8 +31,10 @@ from __future__ import annotations
 
 import logging
 import re
+import tempfile
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
+from urllib.parse import urlparse
 
 from core.config import RaptorConfig
 from core.git.validate import validate_repo_url
@@ -47,6 +49,14 @@ from core.git.validate import validate_repo_url
 # matches *just before* a trailing newline, so ``"deadbeef\n"`` would
 # otherwise sneak past a ``^...$`` check.
 _SHA_RE = re.compile(r"[0-9a-fA-F]{4,40}")
+
+# Strict 40-char SHA for ``ls-remote`` output parsing. Git always
+# emits full SHAs; a line with a shorter "SHA" is malformed and
+# possibly hostile (a remote can return arbitrary bytes), so we
+# don't accept abbreviated SHAs in this position. (Distinct from
+# ``_SHA_RE`` above, which validates *caller-supplied* SHAs that
+# may be abbreviated by intent.)
+_LS_REMOTE_SHA_RE = re.compile(r"[0-9a-fA-F]{40}")
 
 logger = logging.getLogger(__name__)
 
@@ -309,4 +319,166 @@ def fetch_commit(
     return True
 
 
-__all__ = ["clone_repository", "fetch_commit", "get_safe_git_env"]
+def ls_remote(
+    url: str,
+    *,
+    proxy_hosts: Iterable[str],
+    timeout: int = 20,
+) -> List[Tuple[str, str]]:
+    """Run ``git ls-remote --heads --tags`` against ``url``.
+
+    Read-only operation that returns the refs the remote advertises.
+    Sandbox-routed via ``run_untrusted`` with the egress proxy pinned
+    to ``proxy_hosts``. Caller supplies the allowlist because consumers
+    of this helper cover wider forge sets than the github/gitlab pair
+    ``clone_repository`` accepts (cve_diff's agent uses it to probe
+    non-GitHub forges like git.kernel.org, git.savannah.gnu.org,
+    git.tukaani.org, etc).
+
+    The egress proxy enforces:
+
+      - hostname allowlist: connections to anything outside
+        ``proxy_hosts`` are refused at CONNECT;
+      - private-IP / loopback / link-local block: hostnames that
+        resolve to RFC 1918 / 127.0.0.0/8 / 169.254.0.0/16 / etc.
+        are refused regardless of the allowlist (closes the SSRF
+        and DNS-rebinding surface);
+      - HTTPS-only transport: SSH / git:// schemes can't tunnel
+        through HTTPS-CONNECT.
+
+    Args:
+        url: HTTPS git URL. Must have a hostname and no userinfo.
+            ``http://`` is rejected because the in-process egress
+            proxy is HTTPS-CONNECT exclusively.
+        proxy_hosts: hostname allowlist passed to the proxy. Must be
+            non-empty, and bare hostnames only (no ``host:port``
+            entries — the URL's port is unrelated to the allowlist
+            check). The URL's host must also appear here (defence
+            in depth — the proxy would refuse anyway).
+        timeout: per-call wall-clock cap (seconds; default 20).
+            Tighter than ``RaptorConfig.GIT_CLONE_TIMEOUT`` because
+            ls-remote returns a ref-list, not whole repos.
+
+    Returns:
+        ``[(sha, ref), ...]`` — e.g.
+        ``[("abc...", "refs/heads/main"), ("def...", "refs/tags/v1")]``.
+        Lines whose first column isn't a SHA shape are skipped
+        defensively.
+
+    Raises:
+        ValueError: URL fails scheme/userinfo/hostname checks, or
+            ``proxy_hosts`` is empty, or URL host isn't in
+            ``proxy_hosts``.
+        RuntimeError: sandbox unavailable, or ``git ls-remote``
+            exited non-zero.
+        subprocess.TimeoutExpired: ``timeout`` elapsed before git
+            returned. Propagated unchanged so callers handling the
+            ``(RuntimeError, TimeoutExpired)`` tuple cover both
+            shapes — same contract as ``clone_repository`` /
+            ``fetch_commit``.
+        FileNotFoundError: ``git`` binary not on PATH inside the
+            sandbox. Caller-trusted (CI environments always have
+            it); propagated for diagnosability.
+    """
+    proxy_host_list = list(proxy_hosts)
+    if not proxy_host_list:
+        raise ValueError("ls_remote requires non-empty proxy_hosts")
+
+    # ``urlparse`` is more honest than a regex for the "is this a
+    # safe URL shape" check — handles userinfo, fragments, ports
+    # cleanly. ValueError surfaces on URLs containing null bytes /
+    # invalid IPv6 / etc.; rare but worth surfacing as a ValueError
+    # so callers don't see a stdlib internal type.
+    try:
+        parsed = urlparse(url)
+    except ValueError as e:
+        raise ValueError(f"ls_remote: malformed URL: {e}") from None
+
+    # ``https`` only — the in-process egress proxy is HTTPS-CONNECT
+    # exclusively, so plain ``http://`` would pass this check but
+    # fail at the proxy with a confusing transport error. Refuse
+    # upfront for a clearer contract.
+    if parsed.scheme != "https":
+        raise ValueError(
+            f"ls_remote requires https URL; got scheme={parsed.scheme!r}"
+        )
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError(
+            "ls_remote refuses URLs with userinfo (credentials in URL)"
+        )
+    if not parsed.hostname:
+        raise ValueError(f"ls_remote: URL has no hostname: {url!r}")
+
+    # Pre-check the hostname is in the supplied allowlist. The proxy
+    # enforces too — this is defence-in-depth and a clearer error
+    # before the subprocess fires.
+    host = parsed.hostname.lower()
+    allowed_lower = {h.lower() for h in proxy_host_list}
+    if host not in allowed_lower:
+        raise ValueError(
+            f"ls_remote: URL host {host!r} not in proxy_hosts allowlist"
+        )
+
+    try:
+        from core.sandbox import run_untrusted
+    except ImportError:
+        raise RuntimeError(
+            "core.sandbox unavailable - git ls-remote refuses to run "
+            "without sandbox isolation"
+        )
+
+    # ``ls-remote`` doesn't write to the host filesystem, but
+    # ``run_untrusted`` requires a non-empty ``output`` so Landlock
+    # engages and ``fake_home`` has somewhere to materialise.
+    # An ephemeral temp dir gives the sandbox a writable scratch
+    # area that's discarded as soon as we leave the with-block.
+    with tempfile.TemporaryDirectory(prefix="raptor-ls-remote-") as td:
+        logger.info("git ls-remote: %s (allowlist=%s)",
+                     url, ",".join(sorted(allowed_lower)))
+        proc = run_untrusted(
+            ["git", "ls-remote", "--heads", "--tags", url],
+            target=td,
+            output=td,
+            env=get_safe_git_env(),
+            use_egress_proxy=True,
+            proxy_hosts=proxy_host_list,
+            timeout=timeout,
+            capture_output=True,
+            text=True,
+            # ``errors="replace"`` so a hostile remote returning
+            # non-UTF-8 bytes doesn't surface as
+            # ``UnicodeDecodeError``. The output parser uses a
+            # strict 40-hex-char SHA regex below, so any U+FFFD
+            # replacement chars in the SHA position fail the regex
+            # and the line is skipped defensively.
+            encoding="utf-8",
+            errors="replace",
+        )
+
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        stdout = (proc.stdout or "").strip()
+        raise RuntimeError(
+            f"git ls-remote failed: {stderr or stdout or 'unknown error'}"
+        )
+
+    refs: List[Tuple[str, str]] = []
+    for line in (proc.stdout or "").splitlines():
+        # Each line is: ``<40-hex sha>\t<ref>``.
+        parts = line.split("\t", 1)
+        if len(parts) != 2:
+            continue
+        sha, ref = parts
+        # Strict 40-char SHA — git always emits full SHAs in
+        # ls-remote output. A shorter "SHA" is malformed and possibly
+        # hostile (a remote can return arbitrary bytes), so we don't
+        # accept abbreviated SHAs here. Distinct from caller-supplied
+        # SHA validation in ``fetch_commit`` which allows abbreviation.
+        if not _LS_REMOTE_SHA_RE.fullmatch(sha):
+            continue
+        refs.append((sha, ref))
+
+    return refs
+
+
+__all__ = ["clone_repository", "fetch_commit", "get_safe_git_env", "ls_remote"]

--- a/core/git/tests/test_clone.py
+++ b/core/git/tests/test_clone.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-from core.git.clone import clone_repository, fetch_commit
+from core.git.clone import clone_repository, fetch_commit, ls_remote
 
 
 _VALID_SHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
@@ -333,3 +333,211 @@ def test_fetch_passes_sanitised_env_and_timeout(tmp_path: Path) -> None:
         assert "GIT_TERMINAL_PROMPT" in kwargs["env"]
         assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
         assert kwargs["timeout"] == RaptorConfig.GIT_CLONE_TIMEOUT
+
+
+# ---------------------------------------------------------------------------
+# ls_remote
+# ---------------------------------------------------------------------------
+
+_KERNEL_HOSTS = ("git.kernel.org", "git.savannah.gnu.org")
+
+
+def test_ls_remote_rejects_empty_proxy_hosts() -> None:
+    """``proxy_hosts`` must be non-empty — the proxy would refuse
+    every connection otherwise, so we surface a clear ValueError
+    rather than a confusing transport failure."""
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        with pytest.raises(ValueError, match="proxy_hosts"):
+            ls_remote("https://git.kernel.org/foo", proxy_hosts=[])
+        mock_run.assert_not_called()
+
+
+@pytest.mark.parametrize("bad_url", [
+    "ssh://git@github.com/foo/bar",       # SSH unsupported (proxy is HTTPS)
+    "git://git.kernel.org/foo",            # git protocol unsupported
+    "file:///etc/passwd",                  # file scheme blocked
+    "ftp://example.com/foo",               # arbitrary non-http
+    "http://git.kernel.org/foo",           # plain HTTP rejected (proxy
+                                            # is HTTPS-CONNECT exclusively)
+    "https://user:pass@git.kernel.org/x",  # userinfo
+    "https://user@git.kernel.org/x",       # bare username
+    "https:///no-host/path",               # missing host
+    "not a url",                           # not parseable
+])
+def test_ls_remote_rejects_bad_url_shapes(bad_url: str) -> None:
+    """URL must be ``https://<host>/...`` with no userinfo. ``http://``
+    is also rejected because the in-process egress proxy is
+    HTTPS-CONNECT exclusively."""
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        with pytest.raises(ValueError):
+            ls_remote(bad_url, proxy_hosts=_KERNEL_HOSTS)
+        mock_run.assert_not_called()
+
+
+def test_ls_remote_rejects_url_host_outside_allowlist() -> None:
+    """Pre-check is defence-in-depth — proxy enforces too — but we
+    surface a clear error before the subprocess fires."""
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        with pytest.raises(ValueError, match="not in proxy_hosts"):
+            ls_remote(
+                "https://evil.example.com/foo",
+                proxy_hosts=_KERNEL_HOSTS,
+            )
+        mock_run.assert_not_called()
+
+
+def test_ls_remote_host_match_is_case_insensitive() -> None:
+    """Hostnames are case-insensitive per RFC 1035; uppercase variants
+    of allowlisted hosts must still pass."""
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        mock_run.return_value = _completed(0, stdout="")
+        ls_remote(
+            "https://Git.Kernel.Org/foo",
+            proxy_hosts=_KERNEL_HOSTS,
+        )
+        assert mock_run.called
+
+
+def test_ls_remote_engages_egress_proxy(tmp_path: Path) -> None:
+    """Sandbox call must pin both ``use_egress_proxy=True`` and
+    ``proxy_hosts``. Without the flag the proxy never starts and
+    ``run_untrusted``'s forced ``block_network=True`` would silently
+    drop the connection."""
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        mock_run.return_value = _completed(0)
+        ls_remote("https://git.kernel.org/foo", proxy_hosts=_KERNEL_HOSTS)
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs.get("use_egress_proxy") is True
+        assert "git.kernel.org" in kwargs.get("proxy_hosts", [])
+        assert kwargs.get("timeout") == 20  # default
+
+
+def test_ls_remote_parses_refs() -> None:
+    """Each ``<sha>\\t<ref>`` line is parsed; malformed lines are
+    skipped defensively (a hostile remote could craft them).
+
+    The SHA-shape check is strict 40 hex (not the 4-40 input
+    validator) — git always emits full SHAs in ls-remote output;
+    abbreviated "SHAs" from a remote are malformed.
+    """
+    stdout = (
+        "abc1234567890abc1234567890abc1234567890a\trefs/heads/main\n"
+        "def1234567890def1234567890def1234567890b\trefs/tags/v1.0\n"
+        "garbage_line_no_tab\n"
+        "not-a-sha\trefs/heads/funny\n"
+        "0000\trefs/heads/short-sha\n"  # too short — strict regex rejects
+        "12345678901234567890123456789012345678901234\trefs/x\n"  # too long
+    )
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        mock_run.return_value = _completed(0, stdout=stdout)
+        refs = ls_remote(
+            "https://git.kernel.org/foo",
+            proxy_hosts=_KERNEL_HOSTS,
+        )
+    assert refs == [
+        ("abc1234567890abc1234567890abc1234567890a", "refs/heads/main"),
+        ("def1234567890def1234567890def1234567890b", "refs/tags/v1.0"),
+    ]
+
+
+def test_ls_remote_failure_raises_runtime_error() -> None:
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        mock_run.return_value = _completed(
+            128, stderr="fatal: repository not found",
+        )
+        with pytest.raises(RuntimeError, match="repository not found"):
+            ls_remote(
+                "https://git.kernel.org/foo",
+                proxy_hosts=_KERNEL_HOSTS,
+            )
+
+
+def test_ls_remote_passes_sanitised_env() -> None:
+    """``GIT_TERMINAL_PROMPT=0`` and the rest of ``get_git_env``
+    must reach the subprocess so a malformed credential prompt
+    can't hang the run."""
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        mock_run.return_value = _completed(0, stdout="")
+        ls_remote("https://git.kernel.org/foo", proxy_hosts=_KERNEL_HOSTS)
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+
+
+def test_ls_remote_custom_timeout_propagates() -> None:
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        mock_run.return_value = _completed(0, stdout="")
+        ls_remote(
+            "https://git.kernel.org/foo",
+            proxy_hosts=_KERNEL_HOSTS,
+            timeout=60,
+        )
+        assert mock_run.call_args.kwargs["timeout"] == 60
+
+
+def test_ls_remote_propagates_filenotfounderror() -> None:
+    """If ``git`` isn't installed in the sandbox, ``run_untrusted``
+    surfaces ``FileNotFoundError`` and the helper lets it propagate.
+    Caller-trusted (raptor's CI environment always has git); test
+    pins the propagation contract so a future change that swallows
+    the exception is caught."""
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        mock_run.side_effect = FileNotFoundError("git: command not found")
+        with pytest.raises(FileNotFoundError):
+            ls_remote(
+                "https://git.kernel.org/foo",
+                proxy_hosts=_KERNEL_HOSTS,
+            )
+
+
+def test_ls_remote_propagates_timeout_expired() -> None:
+    """``subprocess.TimeoutExpired`` propagates from ``run_untrusted``
+    unchanged. Same contract as ``clone_repository`` and
+    ``fetch_commit`` — callers handling the (RuntimeError,
+    subprocess.TimeoutExpired) tuple cover both shapes."""
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        mock_run.side_effect = subprocess.TimeoutExpired(
+            cmd=["git", "ls-remote"], timeout=20,
+        )
+        with pytest.raises(subprocess.TimeoutExpired):
+            ls_remote(
+                "https://git.kernel.org/foo",
+                proxy_hosts=_KERNEL_HOSTS,
+            )
+
+
+def test_ls_remote_resilient_to_non_utf8_replacement_chars() -> None:
+    """``errors="replace"`` plus the strict 40-char SHA regex means a
+    hostile remote returning non-UTF-8 bytes (here represented as
+    U+FFFD replacement chars) can't crash the helper — malformed
+    lines just fail the SHA-shape check and are skipped."""
+    # Real subprocess decode would have already replaced; simulate
+    # the post-decode shape directly.
+    stdout = (
+        "abc1234567890abc1234567890abc1234567890a\trefs/heads/main\n"
+        "\ufffd\ufffd\ufffdabc1234567890abc1234567890abc1234567\trefs/garbage\n"
+    )
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        mock_run.return_value = _completed(0, stdout=stdout)
+        refs = ls_remote(
+            "https://git.kernel.org/foo",
+            proxy_hosts=_KERNEL_HOSTS,
+        )
+    assert refs == [
+        ("abc1234567890abc1234567890abc1234567890a", "refs/heads/main"),
+    ]
+
+
+def test_ls_remote_uses_strict_40char_sha_regex() -> None:
+    """Caller-supplied SHAs (``fetch_commit``) accept 4-40 hex; the
+    ls-remote parser is strict 40 because git always emits full
+    SHAs and a shorter "SHA" from a remote is malformed (or hostile)."""
+    # SHA at the lower bound the caller-input regex would accept (8
+    # chars) MUST be rejected by the output parser.
+    stdout = "deadbeef\trefs/heads/short\n"
+    with patch("core.sandbox.run_untrusted") as mock_run:
+        mock_run.return_value = _completed(0, stdout=stdout)
+        refs = ls_remote(
+            "https://git.kernel.org/foo",
+            proxy_hosts=_KERNEL_HOSTS,
+        )
+    assert refs == []  # nothing parsed


### PR DESCRIPTION
Adds ``core.git.ls_remote(url, *, proxy_hosts, timeout=20)`` — read- only ref enumeration via ``git ls-remote --heads --tags``, sandbox- routed through ``run_untrusted`` with the egress proxy pinned to ``proxy_hosts``. Returns ``[(sha, ref), ...]``.

Caller-supplied allowlist because consumers cover wider forge sets than the github/gitlab pair ``clone_repository`` / ``fetch_commit`` accept. The egress proxy enforces hostname allowlist + private-IP / loopback / link-local block + DNS-rebinding defence regardless of how broad the caller's allowlist is.

Defences:
  - URL-shape validation (urlparse-based): https only, no userinfo, hostname required and must appear in proxy_hosts.
  - Strict 40-hex SHA regex on output — abbreviated "SHAs" or non-UTF-8 garbage from a hostile remote skip the line cleanly.
  - errors="replace" on stdout decode so a hostile remote returning non-UTF-8 bytes can't surface as UnicodeDecodeError.

First consumer queued: cve_diff/agent/tools.py's
_git_ls_remote_impl, which currently shells out to plain subprocess.run(["git", "ls-remote", url]) with no allowlist (audit finding 6 — SSRF surface for LLM-supplied URLs). The follow-up PR against experimental/cve-diff rewires that consumer plus three other requests-based agent tools onto core.http + this new core.git primitive.

Tests: 62/62 in core/git/tests/test_clone.py (21 new for ls_remote).