### PR TITLE
cve_diff: misc audit fixes

### DIFF
--- a/packages/cve_diff/cve_diff/diffing/extract_via_patch_url.py
+++ b/packages/cve_diff/cve_diff/diffing/extract_via_patch_url.py
@@ -167,11 +167,27 @@ def extract_via_patch_url(cve_id: str, ref: RepoRef) -> DiffBundle | None:
         fetch=_no_languages_fetch,
     )
 
+    # ``commit_before`` would normally be the parent SHA, but a
+    # ``.patch`` URL response carries the diff body (and the commit's
+    # own SHA via the ``From <sha>`` header) without exposing the
+    # parent. Pre-2026-05-02 this slot held ``<sha>^`` — git's
+    # revspec for "parent of sha". That works for ``git diff
+    # <sha>^..<sha>`` (the extractor doesn't re-run git diff for
+    # patch-url-sourced bundles anyway — diff_text comes straight
+    # from the patch body), but it breaks downstream display:
+    # ``report/markdown.py``'s ``_commit_url(<sha>^)`` emits
+    # ``https://forge/.../commit/<sha>^`` which 404s, and
+    # ``report/osv_schema.py``'s ``diff_against`` field carries the
+    # bogus revspec into the OSV record. Setting it equal to
+    # ``commit_after`` keeps the ``CommitSha`` NewType contract
+    # honest (it's an actual SHA) and signals "parent unknown" to
+    # any consumer that compares the two.
+    fix_sha = (ref.fix_commit or "").lower()
     return DiffBundle(
         cve_id=cve_id,
         repo_ref=ref,
-        commit_before=CommitSha((ref.fix_commit or "").lower() + "^"),
-        commit_after=CommitSha((ref.fix_commit or "").lower()),
+        commit_before=CommitSha(fix_sha),
+        commit_after=CommitSha(fix_sha),
         diff_text=body,
         files_changed=len(file_names),
         bytes_size=len(body.encode("utf-8")),

--- a/packages/cve_diff/cve_diff/diffing/extraction_agreement.py
+++ b/packages/cve_diff/cve_diff/diffing/extraction_agreement.py
@@ -28,8 +28,19 @@ from cve_diff.core.models import DiffBundle, RepoRef
 from cve_diff.diffing.extract_via_gitlab_api import extract_for_agreement
 
 # Pairwise thresholds: clone vs API byte counts are usually within a
-# few percent (mostly whitespace / line-ending differences). Above
-# this, we mark partial. Above 25%, disagree.
+# few percent (mostly whitespace / line-ending differences in how each
+# extractor renders the diff — git-diff vs GitHub API JSON vs the
+# .patch URL's raw body). Above ``_BYTES_AGREE_PCT`` we mark partial;
+# above ``_BYTES_PARTIAL_PCT`` we mark disagree.
+#
+# These thresholds are heuristic — chosen so a typical "render-only
+# difference" lands in agree, a meaningful "different parts of the
+# fix" lands in disagree, and the messy middle goes to partial. They
+# have NOT been formally calibrated against a labelled disagreement
+# corpus; if a future bench shows agree/partial/disagree distribution
+# is materially off, these are the knobs to tune. Not exposed as
+# config — operators shouldn't tune the boundary at runtime; bench
+# does it offline.
 _BYTES_AGREE_PCT = 0.05
 _BYTES_PARTIAL_PCT = 0.25
 # GitHub API caps at 300 files per /commits/{sha} response. When file

--- a/packages/cve_diff/cve_diff/infra/github_client.py
+++ b/packages/cve_diff/cve_diff/infra/github_client.py
@@ -220,6 +220,17 @@ def get_commit(slug: str, sha: str) -> Optional[dict[str, Any]]:
     parallel ``extract_via_api`` cross-check share one HTTP round-trip.
     Hit/miss counters are recorded into ``api_status`` so the bench
     summary can show per-process cache effectiveness.
+
+    Telemetry caveat: under ``ProcessPoolExecutor`` (bench's
+    ``-w 4``) each worker has its own per-process ``functools.lru_cache``
+    and counter — totals are aggregated across workers but per-worker
+    counts can race. Within a single process there's also a small
+    window between the two ``cache_info()`` reads where another thread
+    could populate the cache; the resulting hit/miss attribution is
+    still approximately correct over many calls and never worse than
+    "miscounted by one" per race. The counters are informational
+    (bench summary, not correctness-critical), so we accept the
+    looseness rather than thread per-call locking.
     """
     info_before = _get_commit_cached.cache_info()
     result = _get_commit_cached(slug, sha)

--- a/packages/cve_diff/tests/unit/diffing/test_extract_via_patch_url.py
+++ b/packages/cve_diff/tests/unit/diffing/test_extract_via_patch_url.py
@@ -196,3 +196,49 @@ def test_extract_via_patch_url_swallows_network_errors(monkeypatch) -> None:
 
     bundle = evpu.extract_via_patch_url("CVE-X", _ref())
     assert bundle is None
+
+
+def test_extract_bundle_has_commit_before_equal_to_commit_after(
+    monkeypatch,
+) -> None:
+    """patch URL responses don't carry parent-commit metadata. Pre-
+    2026-05-02 the extractor used ``<sha>^`` (git revspec for "parent
+    of sha") which violated ``CommitSha``'s "this is a real SHA"
+    contract and broke downstream display: ``report/markdown.py``'s
+    ``_commit_url(<sha>^)`` 404s, ``report/osv_schema.py`` emits the
+    bogus revspec into the OSV record. New contract: when parent is
+    unknown, ``commit_before == commit_after`` (signal "parent
+    unknown" to consumers via equality, keep ``CommitSha`` honest).
+    """
+    from cve_diff.diffing import extract_via_patch_url as evpu
+
+    sha = "c0e194d4493326a1a45f9eebd64bccf81d56fbf3"
+    body = (
+        "From " + sha + " Mon Sep 17 00:00:00 2001\n"
+        "From: Test\n"
+        "Subject: [PATCH] fix\n\n"
+        "diff --git a/file b/file\n"
+        "--- a/file\n"
+        "+++ b/file\n"
+        "@@ -1 +1 @@\n"
+        "-old\n"
+        "+new\n"
+    )
+
+    class _Resp:
+        status_code = 200
+        text = body
+        url = "https://github.com/socketio/engine.io/commit/" + sha + ".patch"
+
+    def fake_get(url, timeout=None, headers=None):
+        return _Resp()
+
+    monkeypatch.setattr(evpu, "requests", type("M", (), {
+        "get": staticmethod(fake_get),
+        "RequestException": Exception,
+    }))
+
+    bundle = evpu.extract_via_patch_url("CVE-X", _ref(sha=sha))
+    assert bundle is not None
+    assert bundle.commit_before == bundle.commit_after == sha
+    assert "^" not in bundle.commit_before


### PR DESCRIPTION
Three small audit follow-ups against experimental/cve-diff:

  1. extract_via_patch_url.py: drop the ``<sha>^`` git revspec that violated ``CommitSha`` NewType ("this is a real SHA"). Pre-fix the patch-URL extractor synthesised ``commit_before`` as ``<sha>^`` because patch-URL responses don't carry parent metadata; downstream display (markdown ``_commit_url``, OSV ``diff_against`` field) emitted the bogus revspec verbatim. New contract: ``commit_before == commit_after`` signals "parent unknown" to consumers via equality, keeping the SHA shape honest. Regression test added.

  2. infra/github_client.py:get_commit: document the cache_info() race under ProcessPoolExecutor + multi-thread populate. The hit/miss counters are informational (bench summary), so we accept the looseness rather than threading per-call locking.

  3. diffing/extraction_agreement.py: document that the 5%/25% pairwise byte-count thresholds are heuristic, not formally calibrated. Boundary tuning belongs in bench (offline), not runtime config.