### PR TITLE
cve_diff: agent tool hardening — substrate consumption + bare-except …

### DIFF
--- a/packages/cve_diff/cve_diff/agent/loop.py
+++ b/packages/cve_diff/cve_diff/agent/loop.py
@@ -531,6 +531,20 @@ class AgentLoop:
                     except TypeError as exc:
                         tool_output = json.dumps({"error": f"bad_arguments: {exc}"[:200]})
                     except Exception as exc:  # noqa: BLE001
+                        # Catch-all so a buggy tool doesn't crash the whole
+                        # loop. But silent swallowing makes future tool
+                        # development hard to debug — anything that ISN'T
+                        # a validation-class exception (ValueError /
+                        # KeyError / similar caller-error shapes) is most
+                        # likely a bug in the tool itself, log to stderr
+                        # so the operator sees it.
+                        if not isinstance(exc, (ValueError, KeyError, LookupError)):
+                            import sys
+                            print(
+                                f"warn: tool {name!r} raised "
+                                f"{type(exc).__name__}: {exc}",
+                                file=sys.stderr,
+                            )
                         tool_output = json.dumps({"error": f"{type(exc).__name__}: {exc}"[:200]})
                 # Capture confirmed (slug, sha) for the retry path on
                 # any verification-class tool success: gh_commit_detail,

--- a/packages/cve_diff/cve_diff/agent/tools.py
+++ b/packages/cve_diff/cve_diff/agent/tools.py
@@ -17,14 +17,19 @@ Design notes:
 
 from __future__ import annotations
 
+import functools
 import json
 import re
 import subprocess
 import time
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, Iterable
+from urllib.parse import quote
 
 import requests
+
+from core.http import HttpError
+from core.http.egress_backend import EgressClient
 
 from cve_diff.discovery.nvd import NvdDiscoverer
 from cve_diff.infra import github_client
@@ -32,6 +37,72 @@ from cve_diff.infra import github_client
 _TIMEOUT_S = 10.0
 _MAX_BYTES = 32 * 1024
 _USER_AGENT = "cve-diff-agent/0.1"
+
+# Forge allowlist for the LLM-supplied URL agent tools (``git_ls_remote``,
+# ``gitlab_commit``, ``cgit_fetch``). The egress proxy enforces this
+# at CONNECT — anything outside the set is refused regardless of where
+# the URL came from. Plus the proxy's private-IP / loopback / link-local
+# block runs unconditionally, closing SSRF and DNS-rebinding.
+#
+# Curated rather than wildcard-pattern because ``EgressClient`` requires
+# a literal hostname allowlist (no glob support today). New forges get
+# added when they show up in bench failures; conservative omission
+# (false-negative "this forge isn't supported") is preferable to a
+# permissive default that lets attacker-influenced URLs through.
+#
+# NOT included by design: ``localhost``, anything under ``*.local``,
+# RFC 1918 / link-local IPs (the proxy denies these regardless), any
+# host with userinfo in the URL (rejected at the URL-shape check
+# inside ``core.git.ls_remote``).
+_AGENT_FORGE_HOSTS: frozenset[str] = frozenset({
+    # Major commercial forges (GitHub itself goes through
+    # ``infra.github_client`` separately; api.github.com is included
+    # here for any direct-API call that bypasses the helper).
+    "github.com", "api.github.com", "codeload.github.com",
+    "objects.githubusercontent.com", "raw.githubusercontent.com",
+    "gitlab.com",
+    "bitbucket.org",
+    # Linux kernel + GNU project forges
+    "git.kernel.org",
+    "git.savannah.gnu.org", "git.savannah.nongnu.org",
+    "sourceware.org",
+    "gcc.gnu.org",
+    # cgit-style vendor forges (one CVE corpus each)
+    "git.tukaani.org",          # xz
+    "git.openssl.org",
+    "git.haproxy.org",
+    "git.busybox.net",
+    "git.zx2c4.com",            # WireGuard
+    "git.gnupg.org",
+    "git.musl-libc.org",
+    "git.qemu.org",
+    "git.libssh.org",
+    # Self-hosted GitLab (the common ones; agent encounters more as
+    # CVE corpora grow — extend as needed)
+    "gitlab.freedesktop.org",
+    "gitlab.kde.org",
+    "gitlab.gnome.org",
+    "gitlab.kitware.com",       # CMake
+    "gitlab.alpinelinux.org",
+    "gitlab.matrix.org",
+    "gitlab.suse.com",
+    # Distro / vendor-specific
+    "pagure.io",                # Fedora
+    "src.fedoraproject.org",
+    "opendev.org",              # OpenStack
+})
+
+
+@functools.lru_cache(maxsize=1)
+def _forge_client() -> EgressClient:
+    """Process-wide ``EgressClient`` for non-GitHub forge HTTP calls.
+
+    Cached so we reuse one urllib3 connection pool. Hostname allowlist
+    enforced at the proxy via ``_AGENT_FORGE_HOSTS``; private-IP block
+    enforced unconditionally. New forges that need to be reachable
+    must be added to ``_AGENT_FORGE_HOSTS`` first.
+    """
+    return EgressClient(allowed_hosts=_AGENT_FORGE_HOSTS, user_agent=_USER_AGENT)
 _OSV_BASE = "https://api.osv.dev/v1"
 _GH_API = "https://api.github.com"
 # GitHub retry budget: 3 attempts on 429 / 5xx, 1s base exponential
@@ -314,38 +385,51 @@ def _gh_compare_impl(slug: str, base: str, head: str) -> str:
 # ---------------------------------------------------------------- Non-GitHub forges
 
 def _git_ls_remote_impl(url: str) -> str:
-    if not url or not re.match(r"^https?://", url):
-        return _err("http(s) url required")
+    """Sandbox-routed ``git ls-remote`` via :func:`core.git.ls_remote`.
+
+    Pre-2026-05-02 used ``subprocess.run(["git", "ls-remote", url])``
+    with no allowlist — LLM-supplied URLs went straight to git with
+    no hostname check. ``core.git.ls_remote`` engages the egress
+    proxy with the forge allowlist + private-IP block, closing the
+    SSRF / DNS-rebinding surface (audit finding #6).
+    """
+    from core.git import ls_remote
     try:
-        proc = subprocess.run(
-            ["git", "ls-remote", "--heads", "--tags", url],
-            capture_output=True, text=True, timeout=20,
-        )
+        refs = ls_remote(url, proxy_hosts=_AGENT_FORGE_HOSTS, timeout=20)
+    except ValueError as exc:
+        # URL fails the urlparse / allowlist / scheme checks. Surface
+        # the helper's message verbatim — it's already operator-friendly
+        # ("URL host 'x' not in proxy_hosts allowlist", etc.).
+        return _err(str(exc))
     except subprocess.TimeoutExpired:
         return _err("timeout")
-    except OSError as exc:
-        return _err(f"git: {exc}")
-    if proc.returncode != 0:
-        return _err(f"git ls-remote failed: {proc.stderr.strip()[:200]}")
-    refs = [line.split("\t") for line in proc.stdout.strip().splitlines() if "\t" in line][:50]
-    return json.dumps({"refs": [{"sha": r[0], "ref": r[1]} for r in refs]})
+    except (RuntimeError, OSError) as exc:
+        return _err(f"git ls-remote failed: {str(exc)[:200]}")
+    return json.dumps({
+        "refs": [{"sha": sha, "ref": ref} for sha, ref in refs[:50]],
+    })
 
 
 def _gitlab_commit_impl(host: str, slug: str, sha: str) -> str:
+    """Sandbox-routed GitLab API call via :func:`_forge_client`.
+
+    Pre-2026-05-02 used raw ``requests.get`` — same SSRF / private-IP
+    surface as ``_git_ls_remote_impl``. EgressClient routes via the
+    proxy with hostname allowlist (``_AGENT_FORGE_HOSTS``).
+    """
     if not host or not slug or not sha:
         return _err("host, slug, sha required")
     host = host.rstrip("/")
-    project = requests.utils.quote(slug, safe="")
+    project = quote(slug, safe="")
     url = f"{host}/api/v4/projects/{project}/repository/commits/{sha}"
     try:
-        resp = requests.get(url, timeout=_TIMEOUT_S, headers={"User-Agent": _USER_AGENT})
-    except requests.RequestException as exc:
-        return _err(f"network: {exc}")
-    if resp.status_code != 200:
-        return _err(f"http {resp.status_code}")
-    try:
-        data = resp.json()
-    except ValueError:
+        data = _forge_client().get_json(url, timeout=int(_TIMEOUT_S), retries=0)
+    except HttpError as exc:
+        # ``HttpError`` covers transport failures (DNS, refused),
+        # non-2xx responses (with .status), and proxy-allowlist
+        # rejections. Surface a compact error string.
+        return _err(f"http {exc.status or 'error'}: {str(exc)[:120]}")
+    if not isinstance(data, dict):
         return _err("non-json")
     return json.dumps({
         "id": data.get("id", ""),
@@ -358,17 +442,26 @@ def _gitlab_commit_impl(host: str, slug: str, sha: str) -> str:
 
 
 def _cgit_fetch_impl(host: str, slug: str, sha: str) -> str:
+    """Sandbox-routed cgit fetch via :func:`_forge_client`.
+
+    Same migration as ``_gitlab_commit_impl`` — raw ``requests.get`` →
+    ``EgressClient`` with the forge allowlist + private-IP block.
+    cgit responses are HTML; we ``get_bytes`` capped at ``_MAX_BYTES``
+    and decode UTF-8 with ``errors="replace"`` so a malformed response
+    doesn't surface as ``UnicodeDecodeError``.
+    """
     if not host or not slug or not sha:
         return _err("host, slug, sha required")
     host = host.rstrip("/")
     url = f"{host}/{slug}/commit/?id={sha}"
     try:
-        resp = requests.get(url, timeout=_TIMEOUT_S, headers={"User-Agent": _USER_AGENT})
-    except requests.RequestException as exc:
-        return _err(f"network: {exc}")
-    if resp.status_code != 200:
-        return _err(f"http {resp.status_code}")
-    return json.dumps({"url": url, "body": resp.text[:_MAX_BYTES]})
+        body_bytes = _forge_client().get_bytes(
+            url, timeout=int(_TIMEOUT_S), max_bytes=_MAX_BYTES, retries=0,
+        )
+    except HttpError as exc:
+        return _err(f"http {exc.status or 'error'}: {str(exc)[:120]}")
+    body = body_bytes.decode("utf-8", errors="replace")
+    return json.dumps({"url": url, "body": body[:_MAX_BYTES]})
 
 
 _distro = None

--- a/packages/cve_diff/tests/unit/agent/test_loop.py
+++ b/packages/cve_diff/tests/unit/agent/test_loop.py
@@ -568,10 +568,7 @@ def test_task_budget_disabled_via_flag_uses_messages_namespace(
 # ---------- CVE_DIFF_DISABLE_RULES env switch (cascade only) ----------
 
 def test_rules_disabled_skips_cascade(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With CVE_DIFF_DISABLE_RULES=1, the cascade-surrender rule is skipped.
-    The iter-3 reflection hint that this flag also gated is now retired
-    (2026-04-26); the flag survives only as the cascade kill-switch.
-    """
+    """With CVE_DIFF_DISABLE_RULES=1, the cascade-surrender rule is skipped."""
     monkeypatch.setenv("CVE_DIFF_DISABLE_RULES", "1")
     osv_tool = _tool("osv_raw", impl=lambda **_: '{"ok": true}')
     responses = [

--- a/packages/cve_diff/tests/unit/agent/test_source_classes.py
+++ b/packages/cve_diff/tests/unit/agent/test_source_classes.py
@@ -86,7 +86,7 @@ def test_no_surrender_when_verification_called() -> None:
     assert should_surrender_no_evidence(log, 2.00) is False
 
 
-# ---------- untried_classes + reflection hint ----------
+# ---------- untried_classes ----------
 
 def test_untried_classes_lists_remaining() -> None:
     log = ["osv_raw", "nvd_raw"]

--- a/packages/cve_diff/tests/unit/agent/test_tools.py
+++ b/packages/cve_diff/tests/unit/agent/test_tools.py
@@ -433,34 +433,77 @@ def test_gh_compare_extracts_status_and_files(monkeypatch) -> None:
 # --- git_ls_remote ----------------------------------------------------------
 
 def test_git_ls_remote_parses_refs(monkeypatch) -> None:
-    class _Proc:
-        returncode = 0
-        stdout = "abc1234\trefs/heads/main\ndef5678\trefs/tags/v1.0\n"
-        stderr = ""
-
-    monkeypatch.setattr(tools_mod.subprocess, "run", lambda *a, **kw: _Proc())
-    out = json.loads(tools_mod._git_ls_remote_impl("https://example.org/foo.git"))
+    """Post-substrate-migration: ``_git_ls_remote_impl`` calls
+    :func:`core.git.ls_remote`. Stub the helper directly so this
+    test asserts the tool's args→output shaping, not the substrate
+    (substrate has its own E2E + unit tests in
+    ``core/git/tests/test_clone.py``)."""
+    fake_refs = [
+        ("abc1234567890abc1234567890abc1234567890a", "refs/heads/main"),
+        ("def1234567890def1234567890def1234567890b", "refs/tags/v1.0"),
+    ]
+    import core.git
+    monkeypatch.setattr(
+        core.git, "ls_remote",
+        lambda url, **kw: fake_refs,
+    )
+    # Use a host that's in ``_AGENT_FORGE_HOSTS`` so the real helper's
+    # allowlist check would pass too — keeps the test honest.
+    out = json.loads(tools_mod._git_ls_remote_impl(
+        "https://git.kernel.org/foo.git",
+    ))
     assert len(out["refs"]) == 2
-    assert out["refs"][0] == {"sha": "abc1234", "ref": "refs/heads/main"}
+    assert out["refs"][0]["sha"].startswith("abc1234567890")
+    assert out["refs"][0]["ref"] == "refs/heads/main"
 
 
 def test_git_ls_remote_handles_failure(monkeypatch) -> None:
-    class _Proc:
-        returncode = 128
-        stdout = ""
-        stderr = "fatal: bad URL"
+    """Substrate raises ``RuntimeError`` on git-failure; tool wraps
+    in JSON error."""
+    import core.git
 
-    monkeypatch.setattr(tools_mod.subprocess, "run", lambda *a, **kw: _Proc())
-    out = json.loads(tools_mod._git_ls_remote_impl("https://example.org/missing"))
+    def _raise(*a, **kw):
+        raise RuntimeError("fatal: bad URL")
+
+    monkeypatch.setattr(core.git, "ls_remote", _raise)
+    out = json.loads(tools_mod._git_ls_remote_impl(
+        "https://git.kernel.org/missing",
+    ))
     assert "error" in out
+
+
+def test_git_ls_remote_rejects_url_outside_forge_allowlist() -> None:
+    """Pre-substrate-migration the tool accepted any ``http(s)://``
+    URL — SSRF surface. Now the substrate's URL/proxy checks reject
+    URLs whose host isn't in ``_AGENT_FORGE_HOSTS``. No subprocess
+    fires; ``ls_remote`` raises ``ValueError`` and the tool wraps
+    it in a JSON error."""
+    out = json.loads(tools_mod._git_ls_remote_impl(
+        "https://evil.example.com/foo",
+    ))
+    assert "error" in out
+    assert "allowlist" in out["error"]
 
 
 # --- gitlab_commit ----------------------------------------------------------
 
 def test_gitlab_commit_extracts_fields(monkeypatch) -> None:
-    payload = {"id": "abcdef0123", "short_id": "abcdef0", "title": "Fix CVE", "message": "details", "parent_ids": ["xxx111"], "created_at": "2024-01-01"}
-    monkeypatch.setattr(tools_mod.requests, "get", lambda *a, **kw: _Resp(200, json_data=payload))
-    out = json.loads(tools_mod._gitlab_commit_impl("https://gitlab.freedesktop.org", "group/project", "abcdef0123"))
+    """Post-substrate-migration: ``_gitlab_commit_impl`` calls
+    ``_forge_client().get_json``. Stub the client at the seam so this
+    test asserts the tool's payload-shaping, not ``EgressClient`` plumbing
+    (covered by ``core/http`` tests)."""
+    payload = {"id": "abcdef0123", "short_id": "abcdef0", "title": "Fix CVE",
+               "message": "details", "parent_ids": ["xxx111"],
+               "created_at": "2024-01-01"}
+
+    class _StubClient:
+        def get_json(self, url, *, timeout, retries=0):
+            return payload
+
+    monkeypatch.setattr(tools_mod, "_forge_client", lambda: _StubClient())
+    out = json.loads(tools_mod._gitlab_commit_impl(
+        "https://gitlab.freedesktop.org", "group/project", "abcdef0123",
+    ))
     assert out["id"] == "abcdef0123"
     assert out["title"] == "Fix CVE"
     assert "xxx111" in out["parent_ids"]
@@ -469,9 +512,19 @@ def test_gitlab_commit_extracts_fields(monkeypatch) -> None:
 # --- cgit_fetch -------------------------------------------------------------
 
 def test_cgit_fetch_caps_body(monkeypatch) -> None:
-    big = "x" * (tools_mod._MAX_BYTES * 4)
-    monkeypatch.setattr(tools_mod.requests, "get", lambda *a, **kw: _Resp(200, text=big, url="https://x.org/y"))
-    out = json.loads(tools_mod._cgit_fetch_impl("https://x.org", "y/z", "abc"))
+    """Post-substrate-migration: ``_cgit_fetch_impl`` calls
+    ``_forge_client().get_bytes``. Stub at the seam and use a host that's
+    in ``_AGENT_FORGE_HOSTS`` so the test resembles the real call shape."""
+    big = b"x" * (tools_mod._MAX_BYTES * 4)
+
+    class _StubClient:
+        def get_bytes(self, url, *, timeout, max_bytes, retries=0):
+            return big[:max_bytes]
+
+    monkeypatch.setattr(tools_mod, "_forge_client", lambda: _StubClient())
+    out = json.loads(tools_mod._cgit_fetch_impl(
+        "https://git.kernel.org", "y/z", "abc",
+    ))
     assert len(out["body"]) <= tools_mod._MAX_BYTES
 
 


### PR DESCRIPTION
…logging

Two audit-follow-up threads against experimental/cve-diff, plus two doc nits left over from PR #264.

  1. agent/tools.py: route forge HTTP through the raptor substrate. Pre-this-commit, ``_git_ls_remote_impl`` shelled out to ``git ls-remote`` directly and ``_gitlab_commit_impl`` / ``_cgit_fetch_impl`` used raw ``requests.get``. Same SSRF / private-IP surface as discovery had pre-#259: agent could be coerced (via tool-args from the model or upstream prompt) into hitting RFC1918 / link-local / loopback hosts. Migrated to ``core.git.ls_remote`` (sandbox-routed) and an ``EgressClient(allowed_hosts=_AGENT_FORGE_HOSTS)`` singleton for HTTP. The ~30-host allowlist covers github / gitlab.com / freedesktop / kernel / kde / gnome / pagure / fedora / sourceware / savannah / tukaani / busybox / qemu / haproxy / openssl etc. — the wider forge set the agent reaches for during cascade. Hostname allowlist is operational hygiene; the proxy's IP block is the load-bearing SSRF defence.

     ``_http_fetch_impl`` deliberately left on raw ``requests.get`` — that tool serves arbitrary advisory URLs (unbounded host space) and is a separate scoping decision.

  2. agent/loop.py: bare-except around the tool-dispatch JSON wrap was swallowing all exceptions (incl. ``KeyboardInterrupt``-class bugs and unexpected substrate failures) into a generic ``{"error": ...}`` string. Now logs non-(ValueError, KeyError, LookupError) to stderr before wrapping, so unexpected failures are visible in run logs rather than silently rendered as model- facing tool errors.

  3. tests/unit/agent/test_source_classes.py: drop stale ``+ reflection hint`` section header (PR #264 retired the iter-3 reflection path).

  4. tests/unit/agent/test_loop.py: simplify ``test_rules_disabled_skips_cascade`` docstring — same retired- path cleanup as (3).