### PR TITLE
cve_diff: rename core/test_path.py → path_classifier.py + colocate tests

### DIFF
--- a/packages/cve_diff/cve_diff/core/path_classifier.py
+++ b/packages/cve_diff/cve_diff/core/path_classifier.py
@@ -12,6 +12,16 @@ The pattern below is the **strict union** of the two divergent regexes
 that previously coexisted — i.e., a path is "test" if EITHER of the old
 patterns already classified it that way. No path that both old patterns
 agreed was non-test gets re-classified.
+
+The classifier is deliberately **extension-agnostic**: ``test_*`` and
+``*_test.*`` filenames match regardless of suffix because legitimate
+test fixtures use ``.txt`` / ``.json`` / ``.bin`` / etc. as often as
+``.py`` / ``.go`` / ``.c``. Callers that need source-language filtering
+should compose with their own extension check.
+
+Module renamed from ``test_path.py`` to ``path_classifier.py`` (2026-05-02)
+to stop pytest's default ``test_*.py`` collection rule from picking up
+application code.
 """
 
 from __future__ import annotations

--- a/packages/cve_diff/cve_diff/diffing/extract_via_api.py
+++ b/packages/cve_diff/cve_diff/diffing/extract_via_api.py
@@ -34,7 +34,7 @@ from cve_diff.core.models import (
     FileChange,
     RepoRef,
 )
-from cve_diff.core.test_path import is_test_path as _is_test_path
+from cve_diff.core.path_classifier import is_test_path
 from cve_diff.diffing import shape_dynamic
 from cve_diff.infra import github_client
 
@@ -129,7 +129,7 @@ def extract_via_api(
         files.append(
             FileChange(
                 path=path,
-                is_test=_is_test_path(path),
+                is_test=is_test_path(path),
                 hunks_count=patch.count("\n@@ ") + (1 if patch.startswith("@@ ") else 0),
                 # API doesn't return full file contents — just patch hunks.
                 # Clone-based extractor populates these blobs; the API path

--- a/packages/cve_diff/cve_diff/diffing/extract_via_gitlab_api.py
+++ b/packages/cve_diff/cve_diff/diffing/extract_via_gitlab_api.py
@@ -25,7 +25,7 @@ import requests
 
 from cve_diff.core.exceptions import AnalysisError
 from cve_diff.core.models import CommitSha, DiffBundle, FileChange, RepoRef
-from cve_diff.core.test_path import is_test_path as _is_test_path
+from cve_diff.core.path_classifier import is_test_path
 from cve_diff.diffing import shape_dynamic
 from cve_diff.diffing.extract_via_api import (
     extract_via_api as _extract_via_api_github,
@@ -152,7 +152,7 @@ def extract_via_gitlab_api(cve_id: str, ref: RepoRef) -> DiffBundle:
         files.append(
             FileChange(
                 path=path,
-                is_test=_is_test_path(path),
+                is_test=is_test_path(path),
                 hunks_count=body.count("\n@@ ") + (1 if body.startswith("@@ ") else 0),
                 before_source=None,
                 after_source=None,

--- a/packages/cve_diff/cve_diff/diffing/extract_via_patch_url.py
+++ b/packages/cve_diff/cve_diff/diffing/extract_via_patch_url.py
@@ -26,7 +26,7 @@ import re
 import requests
 
 from cve_diff.core.models import CommitSha, DiffBundle, FileChange, RepoRef
-from cve_diff.core.test_path import is_test_path as _is_test_path
+from cve_diff.core.path_classifier import is_test_path
 from cve_diff.core.url_re import extract_github_slug
 from cve_diff.diffing import shape_dynamic
 from cve_diff.diffing.extract_via_gitlab_api import _gitlab_host_and_slug
@@ -145,7 +145,7 @@ def extract_via_patch_url(cve_id: str, ref: RepoRef) -> DiffBundle | None:
     files = tuple(
         FileChange(
             path=p,
-            is_test=_is_test_path(p),
+            is_test=is_test_path(p),
             hunks_count=hc,
             before_source=None,
             after_source=None,

--- a/packages/cve_diff/cve_diff/diffing/extractor.py
+++ b/packages/cve_diff/cve_diff/diffing/extractor.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from cve_diff.core.exceptions import AnalysisError
 from cve_diff.core.models import CommitSha, DiffBundle, FileChange, RepoRef
-from cve_diff.core.test_path import is_test_path as _is_test_path
+from cve_diff.core.path_classifier import is_test_path
 from cve_diff.core.url_re import GITHUB_REPO_URL_RE, normalize_slug
 from cve_diff.diffing import shape_dynamic
 from cve_diff.infra import github_client
@@ -166,7 +166,7 @@ def _build_file_changes(
     for path in paths:
         out.append(FileChange(
             path=path,
-            is_test=_is_test_path(path),
+            is_test=is_test_path(path),
             hunks_count=hunk_counts.get(path, 0),
             before_source=_show_blob(repo, before, path, timeout_s, cap_bytes),
             after_source=_show_blob(repo, after, path, timeout_s, cap_bytes),

--- a/packages/cve_diff/tests/unit/test_extractor_tier1.py
+++ b/packages/cve_diff/tests/unit/test_extractor_tier1.py
@@ -1,4 +1,7 @@
-"""Tier-1 extractor additions: test-path heuristic, hunk counting, per-file blobs."""
+"""Tier-1 extractor additions: hunk counting, per-file blobs.
+
+Test-path heuristic tests live in ``tests/unit/test_path_classifier.py``
+(the helper itself moved to ``cve_diff/core/path_classifier.py``)."""
 from __future__ import annotations
 
 import subprocess
@@ -10,40 +13,9 @@ from cve_diff.core.models import CommitSha, FileChange, RepoRef
 from cve_diff.diffing.extractor import (
     MAX_FILE_BYTES,
     _count_hunks_per_file,
-    _is_test_path,
     _show_blob,
     extract_diff,
 )
-
-
-# ---------- test-path heuristic ----------
-
-@pytest.mark.parametrize("path", [
-    "tests/test_foo.py",
-    "src/tests/runner.c",
-    "foo_test.go",
-    "parser.spec.ts",
-    "__tests__/util.js",
-    "test_helper.rb",
-    "testing/fixtures.py",
-])
-def test_is_test_path_positive(path: str) -> None:
-    assert _is_test_path(path) is True
-
-
-@pytest.mark.parametrize("path", [
-    "src/main.c",
-    "lib/auth.go",
-    "README.md",
-    "test_helper_not_py.txt",  # no .py / language extension on base
-    "foo.yaml",
-    "test_path_in_middle.py",  # not prefixed — still test, actually matches
-])
-def test_is_test_path_negative_or_positive(path: str) -> None:
-    # Most of these are False; the last one validates documentation-that-regex-is-broad.
-    # We don't enforce a specific answer here except for the obvious source-file cases.
-    if path in ("src/main.c", "lib/auth.go", "README.md", "foo.yaml"):
-        assert _is_test_path(path) is False
 
 
 # ---------- hunk counting ----------

--- a/packages/cve_diff/tests/unit/test_path_classifier.py
+++ b/packages/cve_diff/tests/unit/test_path_classifier.py
@@ -1,0 +1,66 @@
+"""Tests for ``cve_diff.core.path_classifier.is_test_path``.
+
+The classifier is the single source of truth for ``FileChange.is_test``
+across all four extractors (clone, GitHub API, GitLab API, patch URL),
+so any drift here was a real-world bug pre-2026-05-01.
+
+Moved from ``tests/unit/test_extractor_tier1.py`` (where the helper
+originally lived inside ``extractor.py``) when the helper got promoted
+to ``cve_diff/core/`` and the module was renamed away from the
+pytest-collected ``test_path.py`` to ``path_classifier.py``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from cve_diff.core.path_classifier import is_test_path
+
+
+# ---------- clear positives ----------
+
+@pytest.mark.parametrize("path", [
+    "tests/test_foo.py",
+    "src/tests/runner.c",
+    "foo_test.go",
+    "parser.spec.ts",
+    "__tests__/util.js",
+    "test_helper.rb",
+    "testing/fixtures.py",
+    "fixtures/sample.json",       # plural fixture dir
+    "src/fixture/data.bin",       # singular fixture dir
+    "spec/auth_spec.rb",          # singular spec dir
+    "Tests/Foo.cs",               # case-insensitive directory
+])
+def test_clear_positives(path: str) -> None:
+    assert is_test_path(path) is True
+
+
+# ---------- clear negatives ----------
+
+@pytest.mark.parametrize("path", [
+    "src/main.c",
+    "lib/auth.go",
+    "README.md",
+    "foo.yaml",
+    "MyTests/foo.py",             # 'tests' substring inside another word — no match
+    "pretests/foo.py",            # similarly: 'tests' must follow ^ or '/'
+    "foo.test",                   # missing trailing extension after .test
+    "",                           # empty path is not a test
+])
+def test_clear_negatives(path: str) -> None:
+    assert is_test_path(path) is False
+
+
+# ---------- documented quirks (extension-agnostic on purpose) ----------
+
+@pytest.mark.parametrize("path", [
+    "test_helper_not_py.txt",     # ``test_*`` matches regardless of suffix
+    "test_data.json",             # fixtures legitimately use .json
+    "test_payload.bin",           # binary fixtures
+])
+def test_extension_agnostic_test_prefix_matches(path: str) -> None:
+    """Per the module docstring: ``test_*`` and ``*_test.*`` filenames
+    match regardless of suffix because legitimate test fixtures use
+    ``.txt`` / ``.json`` / ``.bin`` as often as source extensions.
+    Callers needing source-language filtering compose their own check."""
+    assert is_test_path(path) is True


### PR DESCRIPTION
Audit follow-up #11 from the post-substrate sweep. Four small items that travelled together because they all touch the same helper:

  1. Rename ``cve_diff/core/test_path.py`` to ``cve_diff/core/path_classifier.py``. The old name matched pytest's default ``test_*.py`` collection rule — currently a no-op (module had no test functions, 0 collected) but a foot- gun: a future ``def test_X(...)`` added by accident would silently graft tests onto the application surface.

  2. Move ``is_test_path`` unit tests out of ``tests/unit/test_extractor_tier1.py`` (their legacy home, before the helper got promoted to ``core/``) and into a dedicated ``tests/unit/test_path_classifier.py``. Lifts coverage with case-insensitive cases (``Tests/Foo.cs``), substring guards (``MyTests/foo.py``, ``pretests/foo.py`` must NOT match), missing-extension edges (``foo.test``), empty path, and explicit assertions for the documented extension-agnostic ``test_*`` rule (``.txt``/``.json``/``.bin`` fixtures match by design).

  3. Surface the extension-agnostic intent in the module docstring itself. Previously documented only in a parametrize comment