### PR TITLE
packages/osv: shared OSV.dev v1 client + parser

### DIFF
--- a/packages/osv/__init__.py
+++ b/packages/osv/__init__.py
@@ -1,0 +1,30 @@
+"""OSV.dev shared client + parser.
+
+Used by both ``cve_diff`` (commit-SHA discovery for CVE patch hunting)
+and ``sca`` (per-dependency advisory lookup for the security gate).
+
+Each consumer maps :class:`OsvRecord` to its own domain type — this
+package owns wire-format parsing only, no domain logic.
+"""
+
+from .client import OSV_BASE_URL, DEFAULT_TTL_SECONDS, OsvClient
+from .parser import parse_record
+from .types import (
+    OsvAffected,
+    OsvRange,
+    OsvRecord,
+    OsvReference,
+    OsvSeverity,
+)
+
+__all__ = [
+    "DEFAULT_TTL_SECONDS",
+    "OSV_BASE_URL",
+    "OsvAffected",
+    "OsvClient",
+    "OsvRange",
+    "OsvRecord",
+    "OsvReference",
+    "OsvSeverity",
+    "parse_record",
+]

--- a/packages/osv/client.py
+++ b/packages/osv/client.py
@@ -1,0 +1,144 @@
+"""OSV.dev API client.
+
+Two endpoints are exposed:
+
+  - :meth:`OsvClient.get_vuln` — ``GET /v1/vulns/<id>``: fetch one record.
+    The native shape of OSV's "look up by ID (including CVE/GHSA aliases —
+    OSV resolves aliases automatically)".
+  - :meth:`OsvClient.query_batch` — ``POST /v1/querybatch``: bulk lookup
+    by ``(name, ecosystem, version)``. Returns ID lists; consumers hydrate
+    via :meth:`get_vuln`.
+
+The legacy ``POST /v1/query`` endpoint is **not** exposed. cve-diff used
+it as a 404-fallback for ``GET /vulns/<id>`` but the call shape it sent
+(``{"queries": [...]}``) was the querybatch shape, not the query shape,
+so the fallback returned ``None`` deterministically — dead code that
+this rewrite drops.
+
+HTTP transport is :class:`core.http.HttpClient` (mandatory). Optional
+per-vuln caching is via :class:`core.json.JsonCache` and shared
+``ttl_seconds``. ``offline=True`` skips network entirely; cache hits
+flow through, misses return ``None``/empty.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import Any
+
+from core.http import HttpClient, HttpError
+from core.json import JsonCache
+
+from .parser import parse_record
+from .types import OsvRecord
+
+log = logging.getLogger(__name__)
+
+OSV_BASE_URL = "https://api.osv.dev/v1"
+DEFAULT_TTL_SECONDS = 24 * 3600
+
+
+class OsvClient:
+    """Thin client over the OSV.dev v1 API. Construct one per run."""
+
+    def __init__(
+        self,
+        http: HttpClient,
+        cache: JsonCache | None = None,
+        *,
+        offline: bool = False,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    ) -> None:
+        self._http = http
+        self._cache = cache
+        self._offline = offline
+        self._ttl = ttl_seconds
+
+    def get_vuln(self, vuln_id: str) -> OsvRecord | None:
+        """Return a parsed :class:`OsvRecord` or ``None`` on 404 / error / parse failure."""
+        record = self._cached_get_vuln(vuln_id)
+        if record is None:
+            return None
+        try:
+            return parse_record(record)
+        except ValueError as exc:
+            log.debug("osv: skipping malformed record %s: %s", vuln_id, exc)
+            return None
+
+    def query_batch(
+        self,
+        queries: Sequence[dict[str, Any]],
+    ) -> list[list[str]]:
+        """Bulk lookup. Returns one ID list per query slot.
+
+        Each query is the OSV query body shape, e.g.::
+
+            {"package": {"name": "lodash", "ecosystem": "npm"}, "version": "4.17.20"}
+
+        On any network error or malformed response, every slot is
+        returned empty — partial answers are more useful than hard
+        failure for security gates that aggregate across many deps.
+        """
+        if self._offline or not queries:
+            return [[] for _ in queries]
+        body = {"queries": list(queries)}
+        try:
+            data = self._http.post_json(
+                f"{OSV_BASE_URL}/querybatch", body,
+            )
+        except HttpError as exc:
+            log.warning("osv: querybatch failed: %s", exc)
+            return [[] for _ in queries]
+
+        results = data.get("results") if isinstance(data, dict) else None
+        if not isinstance(results, list) or len(results) != len(queries):
+            log.warning(
+                "osv: querybatch returned malformed shape "
+                "(got %d slots vs %d queries)",
+                len(results) if isinstance(results, list) else -1,
+                len(queries),
+            )
+            return [[] for _ in queries]
+
+        out: list[list[str]] = []
+        for slot in results:
+            if not isinstance(slot, dict):
+                out.append([])
+                continue
+            ids: list[str] = []
+            for v in (slot.get("vulns") or []):
+                if isinstance(v, dict) and isinstance(v.get("id"), str):
+                    ids.append(v["id"])
+            out.append(ids)
+        return out
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _cached_get_vuln(self, vuln_id: str) -> dict[str, Any] | None:
+        cache_key = f"osv/vulns/{_safe_id(vuln_id)}"
+        if self._cache is not None:
+            cached = self._cache.get(cache_key, ttl_seconds=self._ttl)
+            if isinstance(cached, dict):
+                return cached
+        if self._offline:
+            return None
+        try:
+            data = self._http.get_json(f"{OSV_BASE_URL}/vulns/{vuln_id}")
+        except HttpError as exc:
+            if exc.status == 404:
+                return None
+            log.warning("osv: get_vuln(%s) failed: %s", vuln_id, exc)
+            return None
+        if not isinstance(data, dict):
+            return None
+        if self._cache is not None:
+            self._cache.put(cache_key, data, ttl_seconds=self._ttl)
+        return data
+
+
+def _safe_id(s: str) -> str:
+    """Make a vuln ID safe for path-segment caching."""
+    return s.replace("/", "_").replace("\\", "_")

--- a/packages/osv/parser.py
+++ b/packages/osv/parser.py
@@ -1,0 +1,135 @@
+"""OSV vulnerability JSON → :class:`OsvRecord` parser.
+
+Schema-agnostic: returns the full structured shape plus the raw dict.
+Consumers map :class:`OsvRecord` to their own domain types (cve-diff
+extracts commit SHAs into ``PatchTuple``; SCA computes CVSS and walks
+SEMVER/ECOSYSTEM ranges into ``Advisory``).
+
+The parser is defensive — every field is guarded with ``isinstance``
+checks because OSV records are user-submitted advisory data and have
+been observed to ship typed-incorrectly fields in the wild. A single
+malformed field never raises; only a missing/empty ``id`` raises
+:class:`ValueError`. Skipping malformed sub-objects (a non-dict in
+``references``, a non-string event value, etc.) keeps best-effort
+extraction useful even when the record is partially corrupt.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from .types import (
+    OsvAffected,
+    OsvRange,
+    OsvRecord,
+    OsvReference,
+    OsvSeverity,
+)
+
+
+def parse_record(record: dict[str, Any]) -> OsvRecord:
+    """Parse one OSV vulnerability record. Raises ``ValueError`` if ``id`` is missing."""
+    osv_id = str(record.get("id") or "")
+    if not osv_id:
+        raise ValueError("OSV record missing id")
+
+    aliases = tuple(
+        x for x in (record.get("aliases") or ()) if isinstance(x, str)
+    )
+    return OsvRecord(
+        id=osv_id,
+        aliases=aliases,
+        summary=str(record.get("summary") or ""),
+        details=str(record.get("details") or ""),
+        references=_parse_references(record.get("references") or []),
+        affected=_parse_affected(record.get("affected") or []),
+        severity=_parse_severity(record.get("severity") or []),
+        published=_parse_iso(record.get("published")),
+        modified=_parse_iso(record.get("modified")),
+        raw=record,
+    )
+
+
+def _parse_references(refs_raw: list[Any]) -> tuple[OsvReference, ...]:
+    out: list[OsvReference] = []
+    for ref in refs_raw:
+        if not isinstance(ref, dict):
+            continue
+        url = ref.get("url")
+        if not isinstance(url, str):
+            continue
+        out.append(OsvReference(url=url, type=str(ref.get("type") or "")))
+    return tuple(out)
+
+
+def _parse_affected(affected_raw: list[Any]) -> tuple[OsvAffected, ...]:
+    out: list[OsvAffected] = []
+    for entry in affected_raw:
+        if not isinstance(entry, dict):
+            continue
+        pkg = entry.get("package")
+        package: dict[str, str] | None = (
+            {k: str(v) for k, v in pkg.items() if isinstance(v, str)}
+            if isinstance(pkg, dict) else None
+        )
+        ranges = _parse_ranges(entry.get("ranges") or [])
+        versions = tuple(
+            v for v in (entry.get("versions") or ()) if isinstance(v, str)
+        )
+        eco = entry.get("ecosystem_specific")
+        db = entry.get("database_specific")
+        out.append(OsvAffected(
+            package=package,
+            ranges=ranges,
+            versions=versions,
+            ecosystem_specific=eco if isinstance(eco, dict) else None,
+            database_specific=db if isinstance(db, dict) else None,
+        ))
+    return tuple(out)
+
+
+def _parse_ranges(ranges_raw: list[Any]) -> tuple[OsvRange, ...]:
+    out: list[OsvRange] = []
+    for r in ranges_raw:
+        if not isinstance(r, dict):
+            continue
+        type_str = r.get("type")
+        # Match SCA's existing behaviour: unknown type is normalised to
+        # ECOSYSTEM so the matcher gets a chance rather than dropping it.
+        if type_str not in ("GIT", "SEMVER", "ECOSYSTEM"):
+            type_str = "ECOSYSTEM"
+        repo = r.get("repo") if isinstance(r.get("repo"), str) else None
+        events: list[dict[str, str]] = []
+        for ev in (r.get("events") or []):
+            if not isinstance(ev, dict):
+                continue
+            events.append(
+                {k: str(v) for k, v in ev.items() if isinstance(v, str)}
+            )
+        out.append(OsvRange(type=type_str, repo=repo, events=tuple(events)))
+    return tuple(out)
+
+
+def _parse_severity(severity_raw: list[Any]) -> tuple[OsvSeverity, ...]:
+    out: list[OsvSeverity] = []
+    for entry in severity_raw:
+        if not isinstance(entry, dict):
+            continue
+        score = entry.get("score")
+        if not isinstance(score, str):
+            continue
+        out.append(OsvSeverity(type=str(entry.get("type") or ""), score=score))
+    return tuple(out)
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        # ``Z`` suffix isn't accepted by fromisoformat <3.11.
+        return datetime.fromisoformat(
+            value.replace("Z", "+00:00"),
+        ).astimezone(timezone.utc)
+    except ValueError:
+        return None

--- a/packages/osv/tests/test_client.py
+++ b/packages/osv/tests/test_client.py
@@ -1,0 +1,217 @@
+"""Tests for ``packages.osv.client.OsvClient``.
+
+The client is exercised against an in-memory ``HttpClient`` stub so the
+test suite never hits the real OSV API. Cache integration uses a real
+:class:`core.json.JsonCache` over ``tmp_path``.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from core.http import HttpError
+from core.json import JsonCache
+from packages.osv import OsvClient
+from packages.osv.client import OSV_BASE_URL
+
+
+# --- helpers ------------------------------------------------------------
+
+class _FakeHttp:
+    """Minimal HttpClient stub. Records calls; returns canned responses."""
+    def __init__(self) -> None:
+        self.get_responses: dict[str, Any] = {}
+        self.post_responses: dict[str, Any] = {}
+        self.get_calls: list[str] = []
+        self.post_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get_json(self, url: str, **_kw: Any) -> dict[str, Any]:
+        self.get_calls.append(url)
+        resp = self.get_responses.get(url)
+        if isinstance(resp, BaseException):
+            raise resp
+        if resp is None:
+            raise HttpError("not found", status=404)
+        return resp
+
+    def post_json(self, url: str, body: dict[str, Any], **_kw: Any) -> dict[str, Any]:
+        self.post_calls.append((url, body))
+        resp = self.post_responses.get(url)
+        if isinstance(resp, BaseException):
+            raise resp
+        if resp is None:
+            raise HttpError("error", status=500)
+        return resp
+
+
+# --- get_vuln -----------------------------------------------------------
+
+def test_get_vuln_returns_parsed_record() -> None:
+    http = _FakeHttp()
+    http.get_responses[f"{OSV_BASE_URL}/vulns/CVE-2024-1234"] = {
+        "id": "CVE-2024-1234",
+        "summary": "test",
+    }
+    client = OsvClient(http=http)  # type: ignore[arg-type]
+    rec = client.get_vuln("CVE-2024-1234")
+    assert rec is not None
+    assert rec.id == "CVE-2024-1234"
+    assert http.get_calls == [f"{OSV_BASE_URL}/vulns/CVE-2024-1234"]
+
+
+def test_get_vuln_returns_none_on_404() -> None:
+    http = _FakeHttp()
+    # No entry → _FakeHttp raises HttpError(status=404)
+    client = OsvClient(http=http)  # type: ignore[arg-type]
+    assert client.get_vuln("CVE-9999-0000") is None
+
+
+def test_get_vuln_returns_none_on_500() -> None:
+    http = _FakeHttp()
+    http.get_responses[f"{OSV_BASE_URL}/vulns/CVE-X"] = HttpError(
+        "server error", status=500,
+    )
+    client = OsvClient(http=http)  # type: ignore[arg-type]
+    assert client.get_vuln("CVE-X") is None
+
+
+def test_get_vuln_returns_none_on_malformed_record() -> None:
+    """Record missing ``id`` is skipped, not raised."""
+    http = _FakeHttp()
+    http.get_responses[f"{OSV_BASE_URL}/vulns/CVE-Y"] = {"summary": "no id"}
+    client = OsvClient(http=http)  # type: ignore[arg-type]
+    assert client.get_vuln("CVE-Y") is None
+
+
+def test_get_vuln_uses_cache_when_provided(tmp_path) -> None:
+    http = _FakeHttp()
+    http.get_responses[f"{OSV_BASE_URL}/vulns/CVE-Z"] = {
+        "id": "CVE-Z", "summary": "first",
+    }
+    cache = JsonCache(tmp_path / "cache")
+    client = OsvClient(http=http, cache=cache)  # type: ignore[arg-type]
+
+    # First call hits HTTP and populates cache.
+    rec1 = client.get_vuln("CVE-Z")
+    assert rec1 is not None and rec1.id == "CVE-Z"
+    assert len(http.get_calls) == 1
+
+    # Second call serves from cache — no second HTTP call.
+    rec2 = client.get_vuln("CVE-Z")
+    assert rec2 is not None and rec2.id == "CVE-Z"
+    assert len(http.get_calls) == 1
+
+
+def test_offline_mode_skips_network(tmp_path) -> None:
+    http = _FakeHttp()
+    http.get_responses[f"{OSV_BASE_URL}/vulns/CVE-X"] = {"id": "CVE-X"}
+    client = OsvClient(
+        http=http, cache=JsonCache(tmp_path / "cache"),  # type: ignore[arg-type]
+        offline=True,
+    )
+    # Cache is empty + offline → returns None without hitting HTTP.
+    assert client.get_vuln("CVE-X") is None
+    assert http.get_calls == []
+
+
+def test_offline_mode_serves_cached_hits(tmp_path) -> None:
+    cache = JsonCache(tmp_path / "cache")
+    cache.put("osv/vulns/CVE-X", {"id": "CVE-X", "summary": "cached"},
+              ttl_seconds=3600)
+    http = _FakeHttp()
+    client = OsvClient(http=http, cache=cache, offline=True)  # type: ignore[arg-type]
+
+    rec = client.get_vuln("CVE-X")
+    assert rec is not None and rec.id == "CVE-X"
+    assert http.get_calls == []
+
+
+def test_get_vuln_path_safe_encoding(tmp_path) -> None:
+    """Vuln IDs containing ``/`` would corrupt the cache path; safe-id
+    transforms them so the cache file lands in a single segment."""
+    cache = JsonCache(tmp_path / "cache")
+    cache.put("osv/vulns/with_slashes",
+              {"id": "with/slashes", "summary": "edge case"},
+              ttl_seconds=3600)
+    http = _FakeHttp()
+    client = OsvClient(http=http, cache=cache, offline=True)  # type: ignore[arg-type]
+    rec = client.get_vuln("with/slashes")
+    assert rec is not None
+    assert rec.id == "with/slashes"
+
+
+# --- query_batch --------------------------------------------------------
+
+def test_query_batch_returns_id_lists_per_slot() -> None:
+    http = _FakeHttp()
+    http.post_responses[f"{OSV_BASE_URL}/querybatch"] = {
+        "results": [
+            {"vulns": [{"id": "GHSA-aaa"}, {"id": "GHSA-bbb"}]},
+            {"vulns": []},
+            {"vulns": [{"id": "GHSA-ccc"}]},
+        ]
+    }
+    client = OsvClient(http=http)  # type: ignore[arg-type]
+    queries = [
+        {"package": {"name": "lodash", "ecosystem": "npm"}, "version": "4.0.0"},
+        {"package": {"name": "safe-pkg", "ecosystem": "npm"}, "version": "1.0.0"},
+        {"package": {"name": "log4j", "ecosystem": "Maven"}, "version": "2.14.1"},
+    ]
+    result = client.query_batch(queries)
+    assert result == [["GHSA-aaa", "GHSA-bbb"], [], ["GHSA-ccc"]]
+
+
+def test_query_batch_empty_input_returns_empty() -> None:
+    http = _FakeHttp()
+    client = OsvClient(http=http)  # type: ignore[arg-type]
+    assert client.query_batch([]) == []
+    assert http.post_calls == []
+
+
+def test_query_batch_returns_empty_on_http_error() -> None:
+    """Soft-fail: every slot returns empty rather than raising."""
+    http = _FakeHttp()
+    http.post_responses[f"{OSV_BASE_URL}/querybatch"] = HttpError(
+        "boom", status=500,
+    )
+    client = OsvClient(http=http)  # type: ignore[arg-type]
+    queries = [{"package": {"name": "foo", "ecosystem": "npm"}, "version": "1.0"}] * 3
+    assert client.query_batch(queries) == [[], [], []]
+
+
+def test_query_batch_returns_empty_on_malformed_shape() -> None:
+    """Slot count mismatch → all-empty (rather than misalignment errors)."""
+    http = _FakeHttp()
+    http.post_responses[f"{OSV_BASE_URL}/querybatch"] = {
+        "results": [{"vulns": [{"id": "X"}]}],   # 1 slot but caller sent 2 queries
+    }
+    client = OsvClient(http=http)  # type: ignore[arg-type]
+    queries = [
+        {"package": {"name": "a", "ecosystem": "npm"}, "version": "1"},
+        {"package": {"name": "b", "ecosystem": "npm"}, "version": "1"},
+    ]
+    assert client.query_batch(queries) == [[], []]
+
+
+def test_query_batch_skips_non_string_ids() -> None:
+    """Defensive against malformed responses where vuln id isn't a string."""
+    http = _FakeHttp()
+    http.post_responses[f"{OSV_BASE_URL}/querybatch"] = {
+        "results": [{"vulns": [
+            {"id": "GHSA-aaa"},
+            {"id": 42},                # non-string → skipped
+            "not-a-dict",              # non-dict → skipped
+            {"id": "GHSA-bbb"},
+        ]}],
+    }
+    client = OsvClient(http=http)  # type: ignore[arg-type]
+    queries = [{"package": {"name": "x", "ecosystem": "npm"}, "version": "1"}]
+    assert client.query_batch(queries) == [["GHSA-aaa", "GHSA-bbb"]]
+
+
+def test_query_batch_offline_returns_empty_per_slot() -> None:
+    """Offline mode skips the network entirely; every slot returns empty."""
+    http = _FakeHttp()
+    client = OsvClient(http=http, offline=True)  # type: ignore[arg-type]
+    queries = [{"package": {"name": "x", "ecosystem": "npm"}, "version": "1"}] * 2
+    assert client.query_batch(queries) == [[], []]
+    assert http.post_calls == []

--- a/packages/osv/tests/test_parser.py
+++ b/packages/osv/tests/test_parser.py
@@ -1,0 +1,198 @@
+"""Tests for ``packages.osv.parser.parse_record``.
+
+The parser must:
+  - extract every structured field consumers care about
+  - never raise on malformed sub-objects (only missing ``id``)
+  - preserve the full original JSON on ``raw`` for fields we don't promote
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from packages.osv import parse_record
+
+
+# --- happy path ----------------------------------------------------------
+
+def test_parses_full_record() -> None:
+    rec = parse_record({
+        "id": "GHSA-aaaa-bbbb-cccc",
+        "aliases": ["CVE-2024-1234", "OSV-2024-001"],
+        "summary": "RCE in foo",
+        "details": "Long description",
+        "references": [
+            {"url": "https://example.org/advisory", "type": "ADVISORY"},
+            {"url": "https://github.com/foo/bar/commit/abc1234", "type": "FIX"},
+        ],
+        "affected": [{
+            "package": {"name": "foo", "ecosystem": "npm"},
+            "ranges": [{
+                "type": "SEMVER",
+                "events": [{"introduced": "0"}, {"fixed": "1.2.3"}],
+            }],
+            "versions": ["1.0.0", "1.1.0", "1.2.0"],
+            "ecosystem_specific": {"imports": ["foo.bar"]},
+            "database_specific": {"github_severity": "CRITICAL"},
+        }],
+        "severity": [
+            {"type": "CVSS_V3",
+             "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
+        ],
+        "published": "2024-01-15T12:00:00Z",
+        "modified": "2024-01-20T08:30:00Z",
+    })
+    assert rec.id == "GHSA-aaaa-bbbb-cccc"
+    assert rec.aliases == ("CVE-2024-1234", "OSV-2024-001")
+    assert rec.summary == "RCE in foo"
+    assert rec.details == "Long description"
+    assert len(rec.references) == 2
+    assert rec.references[0].url == "https://example.org/advisory"
+    assert rec.references[0].type == "ADVISORY"
+    assert len(rec.affected) == 1
+    assert rec.affected[0].package == {"name": "foo", "ecosystem": "npm"}
+    assert rec.affected[0].versions == ("1.0.0", "1.1.0", "1.2.0")
+    assert len(rec.affected[0].ranges) == 1
+    assert rec.affected[0].ranges[0].type == "SEMVER"
+    assert rec.affected[0].ranges[0].events == (
+        {"introduced": "0"}, {"fixed": "1.2.3"},
+    )
+    assert rec.affected[0].ecosystem_specific == {"imports": ["foo.bar"]}
+    assert len(rec.severity) == 1
+    assert rec.severity[0].type == "CVSS_V3"
+    assert rec.severity[0].score.startswith("CVSS:3.1/")
+    assert rec.published == datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+    assert rec.modified == datetime(2024, 1, 20, 8, 30, 0, tzinfo=timezone.utc)
+    # raw pass-through carries everything verbatim.
+    assert rec.raw["id"] == "GHSA-aaaa-bbbb-cccc"
+
+
+# --- edge cases ----------------------------------------------------------
+
+def test_missing_id_raises() -> None:
+    with pytest.raises(ValueError, match="missing id"):
+        parse_record({"summary": "no id"})
+
+    with pytest.raises(ValueError, match="missing id"):
+        parse_record({"id": "", "summary": "empty id"})
+
+
+def test_minimal_record() -> None:
+    """Only ``id`` is required — everything else defaults to empty."""
+    rec = parse_record({"id": "OSV-1"})
+    assert rec.id == "OSV-1"
+    assert rec.aliases == ()
+    assert rec.summary == ""
+    assert rec.details == ""
+    assert rec.references == ()
+    assert rec.affected == ()
+    assert rec.severity == ()
+    assert rec.published is None
+    assert rec.modified is None
+
+
+def test_malformed_subobjects_are_skipped() -> None:
+    """Non-dict references / non-string event values get dropped without raising."""
+    rec = parse_record({
+        "id": "OSV-2",
+        "aliases": ["CVE-X", 42, None, "GHSA-Y"],          # non-strings dropped
+        "references": [
+            "not-a-dict",                                   # skipped
+            {"url": 123},                                   # url not str → skipped
+            {"url": "https://ok.example/", "type": "WEB"}, # kept
+        ],
+        "affected": [
+            "not-a-dict",                                   # skipped
+            {
+                "ranges": [
+                    "not-a-dict",                           # skipped
+                    {
+                        "type": "GIT",
+                        "events": ["not-a-dict",
+                                   {"introduced": 99},      # non-string val dropped
+                                   {"fixed": "abc123"}],
+                    },
+                ],
+            },
+        ],
+        "severity": [
+            "not-a-dict",                                   # skipped
+            {"type": "CVSS_V3", "score": 9.0},              # score not str → skipped
+            {"type": "CVSS_V31",
+             "score": "CVSS:3.1/AV:N/..."},                 # kept
+        ],
+    })
+    assert rec.aliases == ("CVE-X", "GHSA-Y")
+    assert len(rec.references) == 1
+    assert rec.references[0].url == "https://ok.example/"
+    assert len(rec.affected) == 1
+    assert len(rec.affected[0].ranges) == 1
+    range_ = rec.affected[0].ranges[0]
+    assert range_.type == "GIT"
+    # First event-dict had a non-string value, so it's an empty dict; second is OK.
+    assert range_.events == ({}, {"fixed": "abc123"})
+    assert len(rec.severity) == 1
+    assert rec.severity[0].type == "CVSS_V31"
+
+
+def test_unknown_range_type_falls_back_to_ecosystem() -> None:
+    """OSV occasionally ships records with novel range types; the matcher
+    works on ECOSYSTEM-shaped events as a fallback so we don't drop them."""
+    rec = parse_record({
+        "id": "OSV-3",
+        "affected": [{"ranges": [{
+            "type": "FUTURE_TYPE_THAT_DOES_NOT_EXIST",
+            "events": [{"introduced": "1.0.0"}, {"fixed": "1.0.5"}],
+        }]}],
+    })
+    assert rec.affected[0].ranges[0].type == "ECOSYSTEM"
+    assert rec.affected[0].ranges[0].events == (
+        {"introduced": "1.0.0"}, {"fixed": "1.0.5"},
+    )
+
+
+def test_iso_timestamps_with_and_without_z() -> None:
+    rec = parse_record({
+        "id": "OSV-4",
+        "published": "2024-01-15T12:00:00Z",            # Z suffix
+        "modified": "2024-01-20T08:30:00+00:00",        # explicit offset
+    })
+    assert rec.published == datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+    assert rec.modified == datetime(2024, 1, 20, 8, 30, 0, tzinfo=timezone.utc)
+
+
+def test_invalid_iso_timestamp_returns_none() -> None:
+    rec = parse_record({"id": "OSV-5", "published": "not-a-date"})
+    assert rec.published is None
+
+
+def test_raw_field_is_the_original_dict() -> None:
+    """Consumers needing fields we don't promote to structured form
+    (``schema_version``, ``credits``, ...) read them off ``raw``."""
+    src = {"id": "OSV-6", "schema_version": "1.6.0",
+           "credits": [{"name": "researcher"}]}
+    rec = parse_record(src)
+    assert rec.raw is src
+    assert rec.raw["schema_version"] == "1.6.0"
+    assert rec.raw["credits"] == [{"name": "researcher"}]
+
+
+def test_git_range_repo_is_extracted() -> None:
+    """cve-diff needs ``ranges[].repo`` for GIT ranges — make sure it survives."""
+    rec = parse_record({
+        "id": "OSV-7",
+        "affected": [{"ranges": [{
+            "type": "GIT",
+            "repo": "https://github.com/torvalds/linux",
+            "events": [{"introduced": "0"}, {"fixed": "deadbeef0123"}],
+        }]}],
+    })
+    assert rec.affected[0].ranges[0].repo == "https://github.com/torvalds/linux"
+
+
+def test_record_is_immutable() -> None:
+    """Frozen dataclass — assignment to fields should raise."""
+    rec = parse_record({"id": "OSV-8"})
+    with pytest.raises(Exception):  # FrozenInstanceError subclasses AttributeError
+        rec.id = "different"        # type: ignore[misc]

--- a/packages/osv/types.py
+++ b/packages/osv/types.py
@@ -1,0 +1,64 @@
+"""Schema-agnostic dataclasses for OSV records.
+
+The shape mirrors the OSV.dev v1 vulnerability schema closely so consumers
+can map raw fields to their own domain types (cve-diff: ``PatchTuple``,
+SCA: ``Advisory``) without further parsing of the wire JSON.
+
+All collections are tuples to make instances hashable-by-identity and to
+discourage in-place mutation by consumers; per-event dicts inside ranges
+remain dicts because OSV's event keys are open-ended (``introduced``,
+``fixed``, ``last_affected``, ``limit``, plus extensions).
+
+The full original JSON is stashed on ``OsvRecord.raw`` so consumers that
+need fields we haven't promoted to structured form (e.g. ``schema_version``,
+``credits``, ``database_specific`` outside ``affected``) can read the raw
+dict directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+
+@dataclass(frozen=True)
+class OsvReference:
+    url: str
+    type: str   # WEB, ADVISORY, REPORT, FIX, PACKAGE, ARTICLE, EVIDENCE, ...
+
+
+@dataclass(frozen=True)
+class OsvRange:
+    type: str                                    # GIT, SEMVER, ECOSYSTEM
+    repo: str | None                             # only for GIT ranges
+    events: tuple[dict[str, str], ...]           # raw event dicts
+
+
+@dataclass(frozen=True)
+class OsvAffected:
+    package: dict[str, str] | None               # {"name": ..., "ecosystem": ...}
+    ranges: tuple[OsvRange, ...]
+    versions: tuple[str, ...]
+    ecosystem_specific: dict[str, Any] | None
+    database_specific: dict[str, Any] | None
+
+
+@dataclass(frozen=True)
+class OsvSeverity:
+    type: str                                    # CVSS_V2, CVSS_V3, CVSS_V31, CVSS_V4, ...
+    score: str                                   # the vector string
+
+
+@dataclass(frozen=True)
+class OsvRecord:
+    id: str
+    aliases: tuple[str, ...]
+    summary: str
+    details: str
+    references: tuple[OsvReference, ...]
+    affected: tuple[OsvAffected, ...]
+    severity: tuple[OsvSeverity, ...]
+    published: datetime | None
+    modified: datetime | None
+    raw: dict[str, Any]                          # full original JSON


### PR DESCRIPTION
OSV.dev (Open Source Vulnerabilities) is the canonical aggregator across npm / PyPI / Maven / Cargo / Go / RubyGems / NuGet / Packagist + generic CVE-by-alias lookup. Multiple subsystems already touch it ad-hoc; this PR adds a shared substrate so future consumers don't re-implement wire-format parsing or HTTP transport.

Design — schema-agnostic record + thin client:

- ``OsvRecord`` (frozen dataclass) mirrors the OSV.dev v1 vulnerability schema closely. ``id`` / ``aliases`` / ``summary`` / ``details`` / ``references`` / ``affected[].ranges`` / ``severity`` / ``published`` / ``modified`` are promoted to structured form; the full original JSON is stashed on ``raw`` so consumers can read fields we haven't promoted (``schema_version``, ``credits``, ecosystem-specific extensions like Go's ``imports``). Wire-format parsing only — no domain types like ``Advisory`` or ``PatchTuple`` here. Each consumer maps ``OsvRecord`` to its own domain shape.

- ``parse_record`` is defensive: every field guarded with ``isinstance``, malformed sub-objects skipped rather than raised, only a missing/empty ``id`` raises ``ValueError``. Real OSV records ship typed-incorrectly fields in the wild.

- ``OsvClient`` exposes two methods: ``get_vuln(id)`` for ID lookup (OSV resolves CVE / GHSA aliases automatically server-side), and ``query_batch(queries)`` for ``POST /v1/querybatch`` — returns ID lists per slot; consumers hydrate via ``get_vuln``. HTTP transport is ``core.http.HttpClient`` (Protocol — backend swap is one factory call). Optional ``core.json.JsonCache`` provides per-vuln caching with ``ttl_seconds``. ``offline=True`` skips the network entirely (cache hits flow through, misses return ``None``).                                        
                                                                     
The legacy ``POST /v1/query`` endpoint is deliberately not exposed — its single-query body shape doesn't match the querybatch shape and the only caller pattern observed in this repo was wrong-shape / deterministically-empty. ``GET /vulns/<id>`` covers the same lookup because OSV resolves aliases server-side