### PR TITLE
core/llm: add context_window/max_output/price lookup helpers

### DIFF
--- a/core/llm/model_data.py
+++ b/core/llm/model_data.py
@@ -90,3 +90,62 @@ PROVIDER_ENV_KEYS = {
     "gemini": "GEMINI_API_KEY",
     "mistral": "MISTRAL_API_KEY",
 }
+
+
+# ---------------------------------------------------------------------------
+# Lookup helpers
+# ---------------------------------------------------------------------------
+
+def context_window_for(model: str) -> int:
+    """Total input tokens the model accepts in one request.
+
+    Raises ``KeyError`` for unknown models — the tool-use loop's
+    context-policy enforcement (truncate vs raise vs summarise) needs
+    a definite number; an approximate fallback would silently mis-gate.
+    """
+    limits = MODEL_LIMITS.get(model)
+    if limits is None:
+        raise KeyError(f"context_window_for: unknown model {model!r}")
+    return limits["max_context"]
+
+
+def max_output_for(model: str) -> int:
+    """Maximum tokens the model can emit in one response. Raises
+    ``KeyError`` for unknown models — useful for capping ``max_tokens``
+    request kwargs to a value the provider will accept."""
+    limits = MODEL_LIMITS.get(model)
+    if limits is None:
+        raise KeyError(f"max_output_for: unknown model {model!r}")
+    return limits["max_output"]
+
+
+def price_for(
+    model: str,
+    *,
+    default: tuple[float, float] = (0.0, 0.0),
+) -> tuple[float, float]:
+    """Return ``(input_per_million_usd, output_per_million_usd)`` for ``model``.
+
+    ``MODEL_COSTS`` is stored per-1K tokens for human readability; this
+    helper converts to per-million which is the unit consumers (loop
+    cost tracking, ``max_cost_usd`` enforcement) actually want.
+
+    Unknown models return ``default`` rather than raising — the caller
+    chooses between (a) soft warn + treat as $0 (cost tracking degrades
+    cleanly, ``max_cost_usd`` cap effectively disabled) and (b) hard
+    error by passing ``default=None`` and checking — but ``None`` isn't
+    a valid tuple so callers wanting hard errors should test the return
+    against ``(0.0, 0.0)`` and act accordingly.
+    """
+    cost = MODEL_COSTS.get(model)
+    if cost is None:
+        return default
+    return (cost["input"] * 1000.0, cost["output"] * 1000.0)
+
+
+# Anthropic-specific cache pricing multipliers (vs base input rate).
+# Cache writes are 1.25x input; cache reads are 0.1x input. Used by
+# AnthropicToolUseProvider to compute cost when the response carries
+# ``cache_creation_input_tokens`` / ``cache_read_input_tokens``.
+ANTHROPIC_CACHE_WRITE_MULTIPLIER = 1.25
+ANTHROPIC_CACHE_READ_MULTIPLIER = 0.1

--- a/core/llm/tests/test_model_data.py
+++ b/core/llm/tests/test_model_data.py
@@ -1,0 +1,101 @@
+"""Tests for ``core.llm.model_data`` lookup helpers.
+
+The helpers are pure functions over the static ``MODEL_COSTS`` /
+``MODEL_LIMITS`` tables. Tests assert behaviour for known models +
+documented unknown-model semantics (raise vs fallback).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.llm.model_data import (
+    ANTHROPIC_CACHE_READ_MULTIPLIER,
+    ANTHROPIC_CACHE_WRITE_MULTIPLIER,
+    MODEL_COSTS,
+    MODEL_LIMITS,
+    context_window_for,
+    max_output_for,
+    price_for,
+)
+
+
+# --- context_window_for -------------------------------------------------
+
+def test_context_window_returns_known() -> None:
+    """Known models surface ``max_context`` from the limits table."""
+    assert context_window_for("claude-opus-4-6") == 1_000_000
+    assert context_window_for("gpt-4o") == 128_000
+    assert context_window_for("o3") == 200_000
+
+
+def test_context_window_unknown_raises() -> None:
+    """Loop policy enforcement (truncate vs raise vs summarise) needs
+    a definite number — silently falling back would mis-gate."""
+    with pytest.raises(KeyError, match="unknown model 'does-not-exist'"):
+        context_window_for("does-not-exist")
+
+
+# --- max_output_for ------------------------------------------------------
+
+def test_max_output_returns_known() -> None:
+    assert max_output_for("claude-opus-4-6") == 128_000
+    assert max_output_for("gpt-4o") == 16_384
+    assert max_output_for("gemini-2.5-pro") == 65_536
+
+
+def test_max_output_unknown_raises() -> None:
+    with pytest.raises(KeyError, match="unknown model 'mystery'"):
+        max_output_for("mystery")
+
+
+# --- price_for ----------------------------------------------------------
+
+def test_price_for_known_converts_per_1k_to_per_million() -> None:
+    """``MODEL_COSTS`` is per-1K USD for human readability; the helper
+    surfaces per-million which is what cost trackers actually want."""
+    cost = MODEL_COSTS["claude-opus-4-6"]               # {input: 0.005, output: 0.025}
+    assert price_for("claude-opus-4-6") == (cost["input"] * 1000.0,
+                                            cost["output"] * 1000.0)
+    # Sanity-check absolute values for one entry to catch off-by-1000s.
+    assert price_for("claude-opus-4-6") == (5.0, 25.0)
+
+
+def test_price_for_unknown_returns_default() -> None:
+    """Soft fallback so cost tracking degrades cleanly when a new model
+    arrives before ``MODEL_COSTS`` is updated. Caller using a non-zero
+    cap will see the cap effectively disabled — that's the documented
+    contract."""
+    assert price_for("future-model-2030") == (0.0, 0.0)
+
+
+def test_price_for_unknown_honours_explicit_default() -> None:
+    """Caller can pass a probe value to detect "unknown" without a try/except."""
+    sentinel = (-1.0, -1.0)
+    assert price_for("future-model-2030", default=sentinel) == sentinel
+
+
+# --- Anthropic cache multipliers ---------------------------------------
+
+def test_anthropic_cache_multipliers_match_anthropic_docs() -> None:
+    """Cache writes are 1.25x input rate; cache reads are 0.1x.
+    Documented at https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
+    """
+    assert ANTHROPIC_CACHE_WRITE_MULTIPLIER == 1.25
+    assert ANTHROPIC_CACHE_READ_MULTIPLIER == 0.1
+
+
+# --- table consistency --------------------------------------------------
+
+def test_every_priced_model_has_limits() -> None:
+    """Cost and limits tables should agree on which models exist —
+    drift here causes silent ``KeyError`` for callers fetching one
+    after the other."""
+    cost_models = set(MODEL_COSTS.keys())
+    limit_models = set(MODEL_LIMITS.keys())
+    only_in_costs = cost_models - limit_models
+    only_in_limits = limit_models - cost_models
+    assert not only_in_costs, (
+        f"models in MODEL_COSTS but not MODEL_LIMITS: {only_in_costs}")
+    assert not only_in_limits, (
+        f"models in MODEL_LIMITS but not MODEL_COSTS: {only_in_limits}")


### PR DESCRIPTION
Pure functions over the existing static ``MODEL_COSTS`` and ``MODEL_LIMITS`` tables. Three helpers + two Anthropic-specific constants prep the substrate for the upcoming provider-agnostic tool-use loop work, where capability-flagged providers need to surface ``context_window`` (for the loop's context-policy enforcement), ``max_output`` (to cap ``max_tokens`` request kwargs), and ``price_per_million`` (for ``max_cost_usd`` termination).

Two design decisions worth flagging:

  1. Different unknown-model semantics per helper. ``context_window_for`` and ``max_output_for`` raise ``KeyError`` because the loop's context-policy enforcement needs a definite number — silently falling back to a guess would mis-gate. ``price_for`` returns a ``default=(0.0, 0.0)`` because cost tracking degrading to "free" when a new model arrives ahead of the table is the documented contract; a hard error there would break unrelated calls during model rollouts.

  2. ``price_for`` returns per-million USD even though ``MODEL_COSTS`` stores per-1K. The table is per-1K for human readability when editing entries from provider documentation; consumers (cost trackers, budget caps) want per-million which is the unit downstream math operates on. Conversion lives in the helper so it doesn't get re-implemented at every call site.

Anthropic's prompt-cache pricing (writes 1.25x input, reads 0.1x input) is exposed as ``ANTHROPIC_CACHE_WRITE_MULTIPLIER`` / ``ANTHROPIC_CACHE_READ_MULTIPLIER`` so the eventual AnthropicProvider implementation can compute cache-aware costs without duplicating the multipliers.

Tests: 9 new (lookup behaviour + table consistency check that every priced model also has a limits entry — drift between the two tables would cause silent ``KeyError`` for callers fetching one after the other). Full ``core/llm/`` suite still passes (212/212).