### PR TITLE
core/llm: provider-agnostic tool-use loop substrate

### DIFF
--- a/core/llm/tool_use/__init__.py
+++ b/core/llm/tool_use/__init__.py
@@ -1,0 +1,59 @@
+"""Provider-agnostic tool-use loop substrate for ``core.llm``.
+
+This package owns the wire-shape types and the loop runner that turns
+those types into multi-turn agentic behaviour. Provider implementations
+(``AnthropicToolUseProvider``, etc.) are sibling modules that translate
+their native API onto these types and back.
+
+Phase 1 ships types-only + the loop + an Anthropic provider. Multi-
+provider support (OpenAI, Gemini, Ollama) follows in their own PRs as
+each provider's :meth:`ToolUseProvider.turn` lands.
+"""
+
+from .loop import ToolUseLoop
+from .providers import ToolUseProvider
+from .types import (
+    CacheControl,
+    ContextOverflow,
+    ContextPolicy,
+    CostBudgetExceeded,
+    LoopEvent,
+    LoopTerminated,
+    Message,
+    StopReason,
+    TextBlock,
+    ToolCall,
+    ToolCallDispatched,
+    ToolCallReturned,
+    ToolDef,
+    ToolHandlerTimeout,
+    ToolLoopResult,
+    ToolResult,
+    TurnCompleted,
+    TurnResponse,
+    TurnStarted,
+)
+
+__all__ = [
+    "CacheControl",
+    "ContextOverflow",
+    "ContextPolicy",
+    "CostBudgetExceeded",
+    "LoopEvent",
+    "LoopTerminated",
+    "Message",
+    "StopReason",
+    "TextBlock",
+    "ToolCall",
+    "ToolCallDispatched",
+    "ToolCallReturned",
+    "ToolDef",
+    "ToolHandlerTimeout",
+    "ToolLoopResult",
+    "ToolResult",
+    "ToolUseLoop",
+    "ToolUseProvider",
+    "TurnCompleted",
+    "TurnResponse",
+    "TurnStarted",
+]

--- a/core/llm/tool_use/anthropic.py
+++ b/core/llm/tool_use/anthropic.py
@@ -1,0 +1,411 @@
+"""Anthropic ``messages.create`` backed :class:`ToolUseProvider`.
+
+Native tool-use shape — Anthropic's API maps almost directly onto the
+provider-agnostic types in :mod:`.types`. This is the v1 reference
+implementation: every other provider's ``turn()`` translates from its
+native shape onto and back from these wire types, so getting the
+mapping right here matters.
+
+Honoured features:
+
+  * Per-region prompt caching (system / tools / history-through-index)
+    via ``cache_control: {"type": "ephemeral"}`` markers. Anthropic
+    treats each marker as a cache breakpoint; we follow their
+    documented "the last block in each opted-in region carries the
+    marker" pattern.
+  * Cost-aware token accounting that splits cache reads (0.1x input
+    rate) and cache writes (1.25x input rate) per Anthropic's
+    documented multipliers — the loop's ``max_cost_usd`` cap stays
+    accurate when caching is in use.
+  * Beta ``client.beta.messages.create`` task-budget endpoint via
+    ``provider_specific={"anthropic_task_budget_beta": True}`` for
+    consumers (cve-diff today) that opted into the beta.
+
+Not yet exposed (deferred until a consumer asks):
+
+  * Streaming (``stream=True``) — the loop is sync-buffered per turn.
+  * Vision content blocks (image inputs).
+  * Multi-block ``tool_result.content`` (Anthropic accepts a list of
+    text/image blocks; we send the simpler ``str`` shape that maps
+    cleanly to other providers).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Sequence
+from typing import Any
+
+from core.llm.model_data import (
+    ANTHROPIC_CACHE_READ_MULTIPLIER,
+    ANTHROPIC_CACHE_WRITE_MULTIPLIER,
+    context_window_for,
+    price_for,
+)
+
+from .types import (
+    CacheControl,
+    Message,
+    StopReason,
+    TextBlock,
+    ToolCall,
+    ToolDef,
+    ToolResult,
+    TurnResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Optional import — anthropic SDK is a soft dep. Constructor raises a
+# clean error when it's missing rather than failing at module-import.
+try:
+    from anthropic import (                           # type: ignore[import-not-found]
+        Anthropic,
+        APIConnectionError,
+        APIError,
+        APIStatusError,
+    )
+    _ANTHROPIC_AVAILABLE = True
+except ImportError:                                    # pragma: no cover
+    _ANTHROPIC_AVAILABLE = False
+    Anthropic = None                                   # type: ignore[misc]
+    APIConnectionError = APIStatusError = APIError = Exception  # type: ignore[misc]
+
+
+# Anthropic's native stop_reason → our enum.
+_STOP_REASON_MAP = {
+    "end_turn": StopReason.COMPLETE,
+    "stop_sequence": StopReason.COMPLETE,
+    "tool_use": StopReason.NEEDS_TOOL_CALL,
+    "pause_turn": StopReason.PAUSE_TURN,
+    "max_tokens": StopReason.MAX_TOKENS,
+    "refusal": StopReason.REFUSED,
+}
+
+# Beta header name for Anthropic's task-budget endpoint. Activated by
+# the ``anthropic_task_budget_beta=True`` provider-specific kwarg —
+# routing to ``client.beta.messages.create`` is necessary BUT NOT
+# SUFFICIENT; the ``betas=[...]`` parameter must also be passed for
+# the server to actually honour the beta. This constant is the
+# current version cve-diff uses (matches its agent loop).
+_TASK_BUDGET_BETA = "task-budgets-2026-03-13"
+
+
+def _is_transient(exc: BaseException) -> bool:
+    """``True`` when ``exc`` is a connection / 429 / 5xx error worth
+    retrying. Permanent 4xx (auth, schema, not-found) are False so
+    callers fail fast instead of burning budget on hopeless retries.
+    """
+    if isinstance(exc, APIConnectionError):
+        return True
+    if isinstance(exc, APIStatusError):
+        status = getattr(exc, "status_code", None)
+        return status == 429 or (status is not None and 500 <= status < 600)
+    return False
+
+
+class AnthropicToolUseProvider:
+    """``ToolUseProvider`` over Anthropic's ``messages.create``.
+
+    Construct one per ``model``. The bound model's context window and
+    pricing come from :mod:`core.llm.model_data` — unknown models raise
+    ``KeyError`` at construction so misconfiguration surfaces immediately
+    instead of mid-run.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        api_key: str | None = None,
+        timeout_s: float = 120.0,
+        max_retries: int = 3,
+        backoff_factor: float = 2.0,
+    ) -> None:
+        """``max_retries`` is the count of *additional* attempts after
+        the first on transient errors (connection refused, 429, 5xx).
+        ``backoff_factor`` controls exponential delay between attempts:
+        delay = ``backoff_factor ** attempt`` seconds. Permanent errors
+        (4xx other than 429) fail fast without retrying.
+        """
+        if not _ANTHROPIC_AVAILABLE:
+            raise RuntimeError(
+                "AnthropicToolUseProvider requires the ``anthropic`` "
+                "package; install with: pip install anthropic"
+            )
+        # Both lookups raise KeyError on unknown models — caller-visible.
+        self._context_window = context_window_for(model)
+        self._price = price_for(
+            model, default=(0.0, 0.0),
+        )
+        self._model = model
+        self._max_retries = max_retries
+        self._backoff_factor = backoff_factor
+        self._client = Anthropic(api_key=api_key, timeout=timeout_s)
+
+    # ------------------------------------------------------------------
+    # Capability flags
+    # ------------------------------------------------------------------
+
+    def supports_tool_use(self) -> bool: return True
+    def supports_prompt_caching(self) -> bool: return True
+    def supports_parallel_tools(self) -> bool: return True
+    def context_window(self) -> int: return self._context_window
+    def price_per_million(self) -> tuple[float, float]: return self._price
+
+    def estimate_tokens(self, text: str) -> int:
+        """Cheap pre-flight estimator. Anthropic's tokenizer averages
+        ~3.5 chars/token; we round up to 4 to bias toward over-estimation
+        (which only triggers the context-policy gate slightly early —
+        the safe direction)."""
+        return max(len(text) // 4, 1)
+
+    # ------------------------------------------------------------------
+    # Cost computation (cache-aware)
+    # ------------------------------------------------------------------
+
+    def compute_cost(self, response: TurnResponse) -> float:
+        """USD cost per Anthropic's documented rates.
+
+        Cache writes are billed at 1.25x the base input rate; cache
+        reads at 0.1x. Output tokens are billed at the standard output
+        rate. ``input_tokens`` already excludes cache_read /
+        cache_creation tokens per Anthropic's API contract — we add
+        the cache contributions on top rather than substituting.
+        """
+        in_per_m, out_per_m = self._price
+        cost = (
+            response.input_tokens * in_per_m
+            + response.output_tokens * out_per_m
+            + response.cache_write_tokens * in_per_m * ANTHROPIC_CACHE_WRITE_MULTIPLIER
+            + response.cache_read_tokens * in_per_m * ANTHROPIC_CACHE_READ_MULTIPLIER
+        ) / 1_000_000.0
+        return cost
+
+    # ------------------------------------------------------------------
+    # The turn primitive
+    # ------------------------------------------------------------------
+
+    def turn(
+        self,
+        messages: Sequence[Message],
+        tools: Sequence[ToolDef],
+        *,
+        system: str | None = None,
+        max_tokens: int = 4096,
+        cache_control: CacheControl = CacheControl(),
+        anthropic_task_budget_beta: bool = False,
+        **_unused: Any,
+    ) -> TurnResponse:
+        """Send one round-trip to Anthropic.
+
+        Provider-specific kwargs:
+          * ``anthropic_task_budget_beta``: route via
+            ``client.beta.messages.create`` (cost-cap beta endpoint).
+
+        Transient errors (APIConnectionError, 429, 5xx) are retried
+        internally with exponential backoff up to ``max_retries``
+        configured at construction. Permanent errors (4xx other than
+        429) fail fast and surface as ``StopReason.ERROR``.
+        Unrecognised provider-specific kwargs are logged at debug
+        level and ignored — preserves graceful degradation across
+        consumers but makes typos discoverable.
+        """
+        if _unused:
+            logger.debug(
+                "anthropic.turn: ignoring unrecognised kwargs: %s",
+                sorted(_unused),
+            )
+        # ---- system ----------------------------------------------------
+        # Anthropic accepts a string OR a list-of-content-blocks. We use
+        # the list form when caching the system prompt so we can attach
+        # the cache_control marker; otherwise we send the simpler string.
+        system_arg: str | list[dict[str, Any]] | None
+        if system:
+            if cache_control.system:
+                system_arg = [{
+                    "type": "text",
+                    "text": system,
+                    "cache_control": {"type": "ephemeral"},
+                }]
+            else:
+                system_arg = system
+        else:
+            system_arg = None
+
+        # ---- tools -----------------------------------------------------
+        tool_schemas: list[dict[str, Any]] = [
+            {
+                "name": t.name,
+                "description": t.description,
+                "input_schema": t.input_schema,
+            }
+            for t in tools
+        ]
+        if cache_control.tools and tool_schemas:
+            # Anthropic places the cache marker on the LAST tool —
+            # caches the entire tools array up to and including it.
+            last = dict(tool_schemas[-1])
+            last["cache_control"] = {"type": "ephemeral"}
+            tool_schemas[-1] = last
+
+        # ---- messages --------------------------------------------------
+        wire_messages = [_message_to_wire(m) for m in messages]
+        if (
+            cache_control.history_through_index is not None
+            and 0 <= cache_control.history_through_index < len(wire_messages)
+        ):
+            _add_cache_marker_to_last_block(
+                wire_messages[cache_control.history_through_index],
+            )
+
+        # ---- dispatch --------------------------------------------------
+        # Routing to ``client.beta.messages.create`` is necessary but
+        # not sufficient — Anthropic's beta endpoint only activates a
+        # beta when its name appears in the ``betas=[...]`` request
+        # parameter. Without it the call goes through but the beta is
+        # not in effect, silently undoing the opt-in.
+        create_fn = (
+            self._client.beta.messages.create
+            if anthropic_task_budget_beta
+            else self._client.messages.create
+        )
+        kwargs: dict[str, Any] = {
+            "model": self._model,
+            "max_tokens": max_tokens,
+            "messages": wire_messages,
+            "tools": tool_schemas if tool_schemas else None,
+        }
+        if anthropic_task_budget_beta:
+            kwargs["betas"] = [_TASK_BUDGET_BETA]
+        if system_arg is not None:
+            kwargs["system"] = system_arg
+
+        # Retry loop: transient errors get up to ``self._max_retries``
+        # additional attempts after the first, with exponential backoff.
+        # Permanent errors (4xx other than 429) fail fast — burning the
+        # cost budget on hopeless retries helps no-one.
+        send_kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        resp = None
+        last_exc: BaseException | None = None
+        for attempt in range(self._max_retries + 1):
+            try:
+                resp = create_fn(**send_kwargs)
+                break
+            except (APIConnectionError, APIStatusError, APIError) as exc:
+                last_exc = exc
+                if not _is_transient(exc) or attempt >= self._max_retries:
+                    logger.warning(
+                        "anthropic.turn: %s error after %d attempt(s): %s",
+                        "transient" if _is_transient(exc) else "permanent",
+                        attempt + 1, exc,
+                    )
+                    return TurnResponse(
+                        content=[],
+                        stop_reason=StopReason.ERROR,
+                        input_tokens=0,
+                        output_tokens=0,
+                    )
+                delay = self._backoff_factor ** attempt
+                logger.info(
+                    "anthropic.turn: transient error attempt %d, "
+                    "retrying in %.1fs: %s",
+                    attempt + 1, delay, exc,
+                )
+                time.sleep(delay)
+        if resp is None:
+            # Defensive — should be unreachable since the loop either
+            # breaks with resp set or returns on exhaustion.
+            logger.warning(
+                "anthropic.turn: retry loop exited without response: %s",
+                last_exc,
+            )
+            return TurnResponse(
+                content=[],
+                stop_reason=StopReason.ERROR,
+                input_tokens=0,
+                output_tokens=0,
+            )
+
+        # ---- normalise -------------------------------------------------
+        stop = _STOP_REASON_MAP.get(resp.stop_reason or "", StopReason.ERROR)
+        out_blocks: list[TextBlock | ToolCall] = []
+        for block in resp.content:
+            block_type = getattr(block, "type", None)
+            if block_type == "text":
+                out_blocks.append(TextBlock(text=block.text))
+            elif block_type == "tool_use":
+                out_blocks.append(ToolCall(
+                    id=block.id,
+                    name=block.name,
+                    input=dict(block.input) if block.input else {},
+                ))
+            # Other block types (e.g., thinking) are silently dropped —
+            # they don't contribute to the loop's tool-dispatch logic.
+
+        usage = resp.usage
+        # ``cache_read_input_tokens`` and ``cache_creation_input_tokens``
+        # are ``Optional[int]`` on the SDK's ``Usage`` model and arrive
+        # as ``None`` when caching wasn't used. ``getattr(..., 0)``
+        # only kicks in for *missing* attributes — None is a real value
+        # there, so we ``or 0`` to coerce it to the int the
+        # ``TurnResponse`` int-typed fields expect.
+        return TurnResponse(
+            content=out_blocks,
+            stop_reason=stop,
+            input_tokens=(getattr(usage, "input_tokens", 0) or 0) if usage else 0,
+            output_tokens=(getattr(usage, "output_tokens", 0) or 0) if usage else 0,
+            cache_read_tokens=(
+                getattr(usage, "cache_read_input_tokens", 0) or 0
+            ) if usage else 0,
+            cache_write_tokens=(
+                getattr(usage, "cache_creation_input_tokens", 0) or 0
+            ) if usage else 0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Wire-format converters
+# ---------------------------------------------------------------------------
+
+
+def _message_to_wire(m: Message) -> dict[str, Any]:
+    """One :class:`Message` → Anthropic wire dict.
+
+    Anthropic accepts mixed content lists per turn — text, tool_use, and
+    tool_result blocks all live in the same ``content`` array, role
+    determines which subset is valid (assistant: text + tool_use; user:
+    text + tool_result).
+    """
+    out_content: list[dict[str, Any]] = []
+    for block in m.content:
+        if isinstance(block, TextBlock):
+            out_content.append({"type": "text", "text": block.text})
+        elif isinstance(block, ToolCall):              # assistant role only
+            out_content.append({
+                "type": "tool_use",
+                "id": block.id,
+                "name": block.name,
+                "input": block.input,
+            })
+        elif isinstance(block, ToolResult):            # user role only
+            out_content.append({
+                "type": "tool_result",
+                "tool_use_id": block.tool_use_id,
+                "content": block.content,
+                "is_error": block.is_error,
+            })
+    return {"role": m.role, "content": out_content}
+
+
+def _add_cache_marker_to_last_block(message: dict[str, Any]) -> None:
+    """Mutate ``message["content"][-1]`` in-place to carry a cache_control
+    marker. Anthropic places the marker on the LAST block of a region
+    to cache everything preceding it within that message."""
+    if not message["content"]:
+        return
+    last = dict(message["content"][-1])
+    last["cache_control"] = {"type": "ephemeral"}
+    message["content"][-1] = last

--- a/core/llm/tool_use/loop.py
+++ b/core/llm/tool_use/loop.py
@@ -1,0 +1,599 @@
+"""Provider-agnostic agentic tool-use runner.
+
+Multi-turn loop, in order per iteration:
+
+1. Cost budget check: if cumulative cost ≥ ``max_cost_usd``, raise
+   :class:`CostBudgetExceeded`.
+2. Context window check: estimate request tokens; if it would overflow
+   the model's context, apply :class:`ContextPolicy` — ``RAISE``
+   raises :class:`ContextOverflow`, ``TRUNCATE_OLDEST`` drops oldest
+   user/assistant pairs (then raises ``ContextOverflow`` if the
+   trailing message itself can't fit).
+3. Call ``provider.turn()`` with current messages + tools.
+4. Append the model's response to messages.
+5. If response ``stop_reason == COMPLETE``, terminate with reason
+   ``complete`` and the joined text from this turn.
+6. If response ``stop_reason == PAUSE_TURN``, continue to next
+   iteration without dispatching anything (Anthropic extended-thinking
+   pause; conversation resumes by re-sending the same messages).
+7. If response carries no tool calls and is none of the above, the
+   model gave up mid-turn — terminate with ``max_tokens``, ``refused``,
+   or ``provider_error`` per the response's stop reason.
+8. Otherwise, dispatch each :class:`ToolCall` block. Handler exception
+   or :class:`ToolHandlerTimeout` either becomes an ``is_error=True``
+   :class:`ToolResult` (default) or terminates the loop with reason
+   ``tool_error`` and re-raises (``terminate_on_handler_error=True``).
+9. Append tool results as one user message.
+10. If any dispatched call had ``call.name == terminal_tool`` and
+    succeeded, terminate with ``terminal_tool`` and surface the model's
+    structured input via :attr:`ToolLoopResult.terminal_tool_input`.
+
+Cap at ``max_iterations`` regardless.
+
+Every termination emits a :class:`LoopTerminated` event and returns a
+:class:`ToolLoopResult` (or raises, for ``CostBudgetExceeded`` /
+``ContextOverflow`` / handler exceptions under
+``terminate_on_handler_error=True``). Callers distinguish outcomes via
+:attr:`ToolLoopResult.terminated_by` — same string set as
+:attr:`LoopTerminated.reason`.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from .providers import ToolUseProvider
+from .types import (
+    CacheControl,
+    ContextOverflow,
+    ContextPolicy,
+    CostBudgetExceeded,
+    LoopEvent,
+    LoopTerminated,
+    Message,
+    StopReason,
+    TextBlock,
+    ToolCall,
+    ToolCallDispatched,
+    ToolCallReturned,
+    ToolDef,
+    ToolHandlerTimeout,
+    ToolLoopResult,
+    ToolResult,
+    TurnCompleted,
+    TurnResponse,
+    TurnStarted,
+)
+
+
+class ToolUseLoop:
+    """Run an agentic conversation until termination.
+
+    Tools are static for the lifetime of one ``run()`` / ``run_with_history()``
+    call. Phase-shifted toolsets (e.g., discovery tools early, refinement
+    tools later) need a fresh :class:`ToolUseLoop` instance per phase —
+    explicit by design, not an oversight.
+
+    Handlers run synchronously; ``tool_timeout_s`` is enforced on a
+    best-effort basis via a watchdog thread (the handler keeps running
+    in the background if it doesn't honour cancellation, but the loop
+    stops waiting for it). Async handlers / true cancellation come via
+    a parallel ``AsyncToolUseLoop`` if/when a real consumer needs it.
+    """
+
+    def __init__(
+        self,
+        provider: ToolUseProvider,
+        tools: Sequence[ToolDef],
+        *,
+        system: str | None = None,
+        terminal_tool: str | None = None,
+        max_iterations: int = 50,
+        max_cost_usd: float | None = None,
+        tool_timeout_s: float | None = None,
+        context_policy: ContextPolicy = ContextPolicy.RAISE,
+        max_tokens_per_turn: int = 4096,
+        cache_control: CacheControl = CacheControl(),
+        events: Callable[[LoopEvent], None] | None = None,
+        terminate_on_handler_error: bool = False,
+        **provider_specific: Any,
+    ) -> None:
+        if not provider.supports_tool_use():
+            raise ValueError(
+                "ToolUseLoop requires a provider with tool-use support; "
+                "the bound model rejects it"
+            )
+        self._provider = provider
+        self._tools = list(tools)
+        self._tools_by_name: dict[str, ToolDef] = {t.name: t for t in tools}
+        if len(self._tools_by_name) != len(self._tools):
+            raise ValueError(
+                "ToolUseLoop tools must have unique names; "
+                "duplicate handler binding would dispatch ambiguously"
+            )
+        if terminal_tool is not None and terminal_tool not in self._tools_by_name:
+            raise ValueError(
+                f"ToolUseLoop terminal_tool {terminal_tool!r} is not in the "
+                "registered tools; loop would never terminate via that path"
+            )
+
+        self._system = system
+        self._terminal_tool = terminal_tool
+        self._max_iterations = max_iterations
+        self._max_cost_usd = max_cost_usd
+        self._tool_timeout_s = tool_timeout_s
+        self._context_policy = context_policy
+        self._max_tokens_per_turn = max_tokens_per_turn
+        self._cache_control = cache_control
+        self._events = events
+        self._terminate_on_handler_error = terminate_on_handler_error
+        self._provider_specific = provider_specific
+
+    # ------------------------------------------------------------------
+    # Public entrypoints
+    # ------------------------------------------------------------------
+
+    def run(self, prompt: str) -> ToolLoopResult:
+        """Convenience wrapper — equivalent to
+        ``run_with_history([], prompt)``. Use this when starting fresh."""
+        return self.run_with_history([], prompt)
+
+    def run_with_history(
+        self,
+        history: list[Message],
+        next_message: str,
+    ) -> ToolLoopResult:
+        """Resume from a prior conversation. ``history`` is treated as
+        immutable input — the returned :attr:`ToolLoopResult.messages`
+        is a new list including ``history`` + everything appended this
+        run, suitable for persisting back to disk.
+        """
+        messages: list[Message] = list(history)
+        if next_message:
+            messages.append(Message(
+                role="user",
+                content=[TextBlock(text=next_message)],
+            ))
+
+        total_input_tokens = 0
+        total_output_tokens = 0
+        total_cost_usd = 0.0
+        tool_calls_made = 0
+        terminal_tool_input: dict[str, Any] | None = None
+
+        for iteration in range(self._max_iterations):
+            # ---- pre-flight: cost budget --------------------------------
+            if (
+                self._max_cost_usd is not None
+                and total_cost_usd >= self._max_cost_usd
+            ):
+                self._emit(LoopTerminated(
+                    reason="max_cost_usd",
+                    iterations=iteration,
+                    total_cost_usd=total_cost_usd,
+                ))
+                raise CostBudgetExceeded(
+                    f"cost budget ${self._max_cost_usd:.4f} reached "
+                    f"(cumulative ${total_cost_usd:.4f}); aborting "
+                    "before next turn"
+                )
+
+            # ---- pre-flight: context window -----------------------------
+            request_estimate = self._estimate_request_tokens(messages)
+            window = self._provider.context_window()
+            if request_estimate >= window:
+                if self._context_policy is ContextPolicy.RAISE:
+                    self._emit(LoopTerminated(
+                        reason="context_overflow",
+                        iterations=iteration,
+                        total_cost_usd=total_cost_usd,
+                    ))
+                    raise ContextOverflow(
+                        f"request estimate ~{request_estimate} tokens "
+                        f"would exceed model context window {window}; "
+                        "set context_policy=TRUNCATE_OLDEST or shorten "
+                        "input"
+                    )
+                # TRUNCATE_OLDEST: drop oldest user/assistant pair until
+                # estimate fits. Pairing-aware so tool_use/tool_result
+                # links can't dangle.
+                messages = self._truncate_oldest(messages, window)
+
+            cache_breakpoints = self._count_cache_breakpoints(messages)
+            self._emit(TurnStarted(
+                iteration=iteration,
+                input_token_estimate=request_estimate,
+                cache_breakpoints=cache_breakpoints,
+            ))
+
+            # ---- the turn -----------------------------------------------
+            try:
+                response = self._provider.turn(
+                    messages,
+                    self._tools,
+                    system=self._system,
+                    max_tokens=self._max_tokens_per_turn,
+                    cache_control=self._cache_control,
+                    **self._provider_specific,
+                )
+            except Exception:
+                self._emit(LoopTerminated(
+                    reason="provider_error",
+                    iterations=iteration,
+                    total_cost_usd=total_cost_usd,
+                ))
+                raise
+
+            cost = self._provider.compute_cost(response)
+            total_cost_usd += cost
+            total_input_tokens += response.input_tokens
+            total_output_tokens += response.output_tokens
+            self._emit(TurnCompleted(
+                iteration=iteration,
+                response=response,
+                cost_usd=cost,
+            ))
+
+            # Append the assistant turn to history.
+            messages.append(Message(
+                role="assistant",
+                content=list(response.content),
+            ))
+
+            # ---- termination by stop_reason -----------------------------
+            if response.stop_reason is StopReason.COMPLETE:
+                final_text = _join_text(response.content)
+                self._emit(LoopTerminated(
+                    reason="complete",
+                    iterations=iteration + 1,
+                    total_cost_usd=total_cost_usd,
+                ))
+                return ToolLoopResult(
+                    final_text=final_text,
+                    terminal_tool_input=None,
+                    messages=messages,
+                    iterations=iteration + 1,
+                    tool_calls_made=tool_calls_made,
+                    total_input_tokens=total_input_tokens,
+                    total_output_tokens=total_output_tokens,
+                    total_cost_usd=total_cost_usd,
+                    terminated_by="complete",
+                )
+
+            # ---- PAUSE_TURN: model pause-resumed extended thinking ----
+            if response.stop_reason is StopReason.PAUSE_TURN:
+                # The provider signalled an extended-thinking pause —
+                # the conversation continues by re-sending the messages
+                # array (including the partial assistant turn we just
+                # appended) without a new user message. The loop falls
+                # through to the next iteration; nothing to dispatch.
+                continue
+
+            # ---- gather tool calls --------------------------------------
+            tool_calls = [b for b in response.content if isinstance(b, ToolCall)]
+            if not tool_calls:
+                # No tool calls AND not COMPLETE/PAUSE_TURN — model gave
+                # up mid-turn. Map to the matching termination reason
+                # (max_tokens / refused / provider_error) so callers can
+                # tell the difference.
+                term_reason = _stop_reason_to_term(response.stop_reason)
+                self._emit(LoopTerminated(
+                    reason=term_reason,
+                    iterations=iteration + 1,
+                    total_cost_usd=total_cost_usd,
+                ))
+                return ToolLoopResult(
+                    final_text=_join_text(response.content),
+                    terminal_tool_input=None,
+                    messages=messages,
+                    iterations=iteration + 1,
+                    tool_calls_made=tool_calls_made,
+                    total_input_tokens=total_input_tokens,
+                    total_output_tokens=total_output_tokens,
+                    total_cost_usd=total_cost_usd,
+                    terminated_by=term_reason,    # type: ignore[arg-type]
+                )
+
+            # ---- dispatch tools -----------------------------------------
+            # Both handler exceptions and handler timeouts behave the
+            # same under ``terminate_on_handler_error=True``: emit
+            # LoopTerminated(reason="tool_error") then re-raise (the
+            # original exception for handler errors; ToolHandlerTimeout
+            # for timeouts). Without that flag, both convert the failure
+            # to an ``is_error=True`` ToolResult and continue.
+            tool_results: list[ToolResult] = []
+            for call in tool_calls:
+                tool_calls_made += 1
+                self._emit(ToolCallDispatched(iteration=iteration, call=call))
+
+                start = time.monotonic()
+                try:
+                    result = self._dispatch_one(call)
+                except ToolHandlerTimeout as exc:
+                    if self._terminate_on_handler_error:
+                        self._emit(LoopTerminated(
+                            reason="tool_error",
+                            iterations=iteration + 1,
+                            total_cost_usd=total_cost_usd,
+                        ))
+                        raise
+                    result = ToolResult(
+                        tool_use_id=call.id,
+                        content=str(exc),
+                        is_error=True,
+                    )
+                except Exception as exc:
+                    if self._terminate_on_handler_error:
+                        self._emit(LoopTerminated(
+                            reason="tool_error",
+                            iterations=iteration + 1,
+                            total_cost_usd=total_cost_usd,
+                        ))
+                        raise
+                    result = ToolResult(
+                        tool_use_id=call.id,
+                        content=f"handler error: {exc}",
+                        is_error=True,
+                    )
+
+                duration = time.monotonic() - start
+                self._emit(ToolCallReturned(
+                    iteration=iteration,
+                    call_id=call.id,
+                    result=result,
+                    duration_s=duration,
+                ))
+                tool_results.append(result)
+
+                if (
+                    self._terminal_tool is not None
+                    and call.name == self._terminal_tool
+                    and not result.is_error
+                ):
+                    terminal_tool_input = dict(call.input)
+
+            # Append tool results as user message — this keeps multi-call
+            # batches in one message, matching Anthropic's wire shape.
+            messages.append(Message(role="user", content=list(tool_results)))
+
+            # ---- post-dispatch termination checks -----------------------
+            if terminal_tool_input is not None:
+                self._emit(LoopTerminated(
+                    reason="terminal_tool",
+                    iterations=iteration + 1,
+                    total_cost_usd=total_cost_usd,
+                ))
+                return ToolLoopResult(
+                    final_text=_join_text(response.content),
+                    terminal_tool_input=terminal_tool_input,
+                    messages=messages,
+                    iterations=iteration + 1,
+                    tool_calls_made=tool_calls_made,
+                    total_input_tokens=total_input_tokens,
+                    total_output_tokens=total_output_tokens,
+                    total_cost_usd=total_cost_usd,
+                    terminated_by="terminal_tool",
+                )
+
+        # ---- max_iterations hit -----------------------------------------
+        self._emit(LoopTerminated(
+            reason="max_iterations",
+            iterations=self._max_iterations,
+            total_cost_usd=total_cost_usd,
+        ))
+        return ToolLoopResult(
+            final_text="",
+            terminal_tool_input=None,
+            messages=messages,
+            iterations=self._max_iterations,
+            tool_calls_made=tool_calls_made,
+            total_input_tokens=total_input_tokens,
+            total_output_tokens=total_output_tokens,
+            total_cost_usd=total_cost_usd,
+            terminated_by="max_iterations",
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _emit(self, event: LoopEvent) -> None:
+        if self._events is not None:
+            self._events(event)
+
+    def _dispatch_one(self, call: ToolCall) -> ToolResult:
+        """Invoke the handler for ``call.name`` with optional timeout
+        watchdog. Raises :class:`ToolHandlerTimeout` if the wall-clock
+        deadline is exceeded; lets handler exceptions propagate so the
+        caller can decide between feed-back-to-model (default) and
+        terminate-on-error."""
+        tool = self._tools_by_name.get(call.name)
+        if tool is None:
+            return ToolResult(
+                tool_use_id=call.id,
+                content=f"unknown tool: {call.name!r}",
+                is_error=True,
+            )
+
+        if self._tool_timeout_s is None:
+            content = tool.handler(call.input)
+            return ToolResult(tool_use_id=call.id, content=content)
+
+        # Best-effort timeout: run the handler on a thread; the parent
+        # waits up to ``tool_timeout_s``. If the timeout fires the
+        # handler keeps running but we stop waiting — leak documented
+        # in the class docstring.
+        result_holder: dict[str, Any] = {}
+        exc_holder: dict[str, BaseException] = {}
+
+        def _runner() -> None:
+            try:
+                result_holder["text"] = tool.handler(call.input)
+            except BaseException as e:                    # noqa: BLE001
+                exc_holder["exc"] = e
+
+        thread = threading.Thread(target=_runner, daemon=True)
+        thread.start()
+        thread.join(self._tool_timeout_s)
+        if thread.is_alive():
+            raise ToolHandlerTimeout(
+                f"tool {call.name!r} exceeded {self._tool_timeout_s}s timeout"
+            )
+        if "exc" in exc_holder:
+            raise exc_holder["exc"]
+        return ToolResult(tool_use_id=call.id, content=result_holder["text"])
+
+    def _estimate_static_tokens(self) -> int:
+        """System + tools cost. Doesn't change across iterations of a
+        single ``run_with_history`` call, so cache the result on first
+        compute. Tools are rendered as ``name + description + str(input_schema)``
+        — a 4-char-per-token estimator over that text is good enough
+        for the context-policy gate (over-estimating triggers the gate
+        early, the safe direction)."""
+        cached = getattr(self, "_static_tokens_cache", None)
+        if cached is not None:
+            return cached
+        total = 0
+        if self._system:
+            total += self._provider.estimate_tokens(self._system)
+        for t in self._tools:
+            total += self._provider.estimate_tokens(
+                t.name + t.description + str(t.input_schema)
+            )
+        self._static_tokens_cache = total                  # type: ignore[attr-defined]
+        return total
+
+    def _estimate_message_tokens(self, m: Message) -> int:
+        """Estimate of one message's contribution to a request."""
+        total = 0
+        for block in m.content:
+            if isinstance(block, TextBlock):
+                total += self._provider.estimate_tokens(block.text)
+            elif isinstance(block, ToolCall):
+                total += self._provider.estimate_tokens(
+                    block.name + str(block.input)
+                )
+            elif isinstance(block, ToolResult):
+                total += self._provider.estimate_tokens(block.content)
+        return total
+
+    def _estimate_request_tokens(self, messages: Sequence[Message]) -> int:
+        """Coarse pre-flight estimate — system + tools + every message.
+
+        Used purely for the context-policy gate; an over-estimate just
+        triggers the gate slightly early (truncation kicks in or RAISE
+        fires) which is the safe direction.
+        """
+        return self._estimate_static_tokens() + sum(
+            self._estimate_message_tokens(m) for m in messages
+        )
+
+    def _count_cache_breakpoints(self, messages: Sequence[Message]) -> int:
+        """How many regions opted in for caching this turn. Reported in
+        :class:`TurnStarted` events for telemetry; doesn't drive
+        behaviour."""
+        if not self._provider.supports_prompt_caching():
+            return 0
+        n = 0
+        if self._cache_control.system and self._system:
+            n += 1
+        if self._cache_control.tools and self._tools:
+            n += 1
+        if (
+            self._cache_control.history_through_index is not None
+            and 0 <= self._cache_control.history_through_index < len(messages)
+        ):
+            n += 1
+        return n
+
+    def _truncate_oldest(
+        self,
+        messages: list[Message],
+        window: int,
+    ) -> list[Message]:
+        """Drop oldest user/assistant pairs until estimate fits.
+
+        Pairing-aware: a user-role message carrying :class:`ToolResult`\\ s
+        is a *response* to the prior assistant turn. We never drop a
+        ToolResult message without also dropping its matching ToolCall,
+        otherwise the next ``provider.turn()`` rejects the conversation
+        as malformed.
+
+        Cost is computed incrementally — drop a message, subtract its
+        per-message estimate, check total. Avoids re-walking the full
+        history on every truncation step (was O(N²) in v1; now O(N)).
+
+        Raises :class:`ContextOverflow` if even after dropping every
+        droppable message the request would still exceed ``window`` —
+        e.g., a single trailing user message larger than the model's
+        context. Silently sending an oversized request would mis-gate.
+        """
+        static = self._estimate_static_tokens()
+        per_msg = [self._estimate_message_tokens(m) for m in messages]
+        total = static + sum(per_msg)
+
+        while total >= window and len(messages) > 1:
+            # Drop oldest message; track its cost to subtract.
+            head = messages.pop(0)
+            total -= per_msg.pop(0)
+            # If the dropped message was an assistant turn that carried
+            # tool_calls, the next message is the user turn carrying
+            # matching tool_results — drop it too so the link doesn't
+            # dangle (provider would reject a tool_result without a
+            # matching tool_use).
+            if (
+                head.role == "assistant"
+                and any(isinstance(b, ToolCall) for b in head.content)
+                and messages
+                and messages[0].role == "user"
+                and any(isinstance(b, ToolResult) for b in messages[0].content)
+            ):
+                messages.pop(0)
+                total -= per_msg.pop(0)
+
+        if total >= window:
+            raise ContextOverflow(
+                f"request estimate ~{total} tokens still exceeds window "
+                f"{window} after truncating to {len(messages)} message(s); "
+                "the trailing message itself is too large — shorten the "
+                "prompt or use a model with a bigger context"
+            )
+        return messages
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _join_text(content: Sequence[Any]) -> str:
+    """Concatenate :class:`TextBlock` items in ``content``, ignoring
+    other block types. Used for ``ToolLoopResult.final_text``."""
+    return "".join(b.text for b in content if isinstance(b, TextBlock))
+
+
+def _stop_reason_to_term(reason: StopReason) -> str:
+    """Map a :class:`StopReason` from a turn that emitted no tool calls
+    to a :attr:`ToolLoopResult.terminated_by` value.
+
+    Each reason is preserved distinctly — callers care about the
+    difference between a content-filter refusal, a truncated response,
+    and a transport error. Collapsing them all to ``provider_error``
+    (as the v1 mapping did) lost information the caller needed.
+
+    ``NEEDS_TOOL_CALL`` and ``PAUSE_TURN`` are filtered out before this
+    function is called (they're continue-not-terminate states), but
+    they're mapped here defensively in case future callers route
+    differently.
+    """
+    return {
+        StopReason.COMPLETE: "complete",
+        StopReason.MAX_TOKENS: "max_tokens",
+        StopReason.REFUSED: "refused",
+        StopReason.ERROR: "provider_error",
+        StopReason.NEEDS_TOOL_CALL: "provider_error",  # impossible-state
+        StopReason.PAUSE_TURN: "provider_error",       # impossible-state
+    }.get(reason, "provider_error")

--- a/core/llm/tool_use/providers.py
+++ b/core/llm/tool_use/providers.py
@@ -1,0 +1,144 @@
+"""``ToolUseProvider`` Protocol.
+
+Each backend (Anthropic / OpenAI / Gemini / Ollama) implements one
+``turn()`` primitive that translates the provider-agnostic types in
+:mod:`.types` to and from its native wire format. The
+:class:`~.loop.ToolUseLoop` only ever talks to providers through this
+Protocol — provider swaps are zero-churn at the call sites.
+
+Capability flags drive the loop's behaviour without per-provider
+branching: ``cache_control`` is only emitted when
+:meth:`supports_prompt_caching` is True; missing capabilities degrade
+gracefully (the loop emits the request without the unsupported field
+rather than raising).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Protocol, runtime_checkable
+
+from .types import (
+    CacheControl,
+    Message,
+    ToolDef,
+    TurnResponse,
+)
+
+
+@runtime_checkable
+class ToolUseProvider(Protocol):
+    """Capability-flagged single-turn primitive over a tool-using LLM.
+
+    Providers that don't support tool-use at all (e.g., a bare-bones
+    Ollama install with a non-tool-capable model) raise
+    :class:`NotImplementedError` from :meth:`turn`. Callers that care
+    check :meth:`supports_tool_use` first.
+    """
+
+    # ------------------------------------------------------------------
+    # Capability flags
+    # ------------------------------------------------------------------
+
+    def supports_tool_use(self) -> bool:
+        """``True`` when the bound model accepts tool/function-call
+        schemas in requests AND emits structured calls in responses."""
+        ...
+
+    def supports_prompt_caching(self) -> bool:
+        """``True`` for providers with a per-region cache breakpoint
+        mechanism (Anthropic). The loop only forwards
+        :class:`CacheControl` when this returns True; other providers
+        receive the struct but ignore it."""
+        ...
+
+    def supports_parallel_tools(self) -> bool:
+        """``True`` when the provider can return multiple
+        :class:`ToolCall` blocks in one assistant turn AND the loop
+        can dispatch them in parallel. The loop currently dispatches
+        sequentially regardless — this flag is informational for v1
+        and gates a future parallel-dispatch optimisation."""
+        ...
+
+    def context_window(self) -> int:
+        """Total tokens the model accepts in one request. Drives the
+        loop's :class:`ContextPolicy` enforcement — silently falling
+        back to a guess would mis-gate, so providers raise
+        ``KeyError`` on unknown models in their constructor."""
+        ...
+
+    def estimate_tokens(self, text: str) -> int:
+        """Cheap pre-flight token estimator. Used by the loop to
+        decide truncate-or-raise before sending an oversized request.
+        Doesn't need to be exact — within a factor of 2 is fine, since
+        the policy gate fires only at full-window scale.
+
+        Default heuristic for providers that don't ship a tokenizer:
+        ``len(text) // 4`` (English/code averages ~4 chars/token).
+        """
+        ...
+
+    def price_per_million(self) -> tuple[float, float]:
+        """``(input_per_million_usd, output_per_million_usd)`` for the
+        bound model. Cache-read / cache-write multipliers — when
+        relevant — are applied inside :meth:`compute_cost`, not here,
+        so the abstraction stays portable to providers without prompt
+        caching."""
+        ...
+
+    # ------------------------------------------------------------------
+    # Per-turn cost
+    # ------------------------------------------------------------------
+
+    def compute_cost(self, response: TurnResponse) -> float:
+        """USD cost of ``response`` given the bound model's pricing.
+
+        Lives on the provider so each backend's quirks (Anthropic's
+        cache-read 0.1x / cache-write 1.25x multipliers, OpenAI's
+        flat per-million rates, Gemini's tiered pricing for prompts
+        ≤200K vs >200K, Ollama's $0) are handled where they belong.
+        The loop only sees the final number.
+        """
+        ...
+
+    # ------------------------------------------------------------------
+    # The actual turn primitive
+    # ------------------------------------------------------------------
+
+    def turn(
+        self,
+        messages: Sequence[Message],
+        tools: Sequence[ToolDef],
+        *,
+        system: str | None = None,
+        max_tokens: int = 4096,
+        cache_control: CacheControl = CacheControl(),
+        **provider_specific: Any,
+    ) -> TurnResponse:
+        """Send one round-trip to the provider.
+
+        :param messages: full conversation history. The provider
+            translates to its native wire format (Anthropic accepts
+            our ``Message`` shape almost directly; OpenAI splits user
+            messages with multiple :class:`ToolResult`\\ s into N
+            ``role:"tool"`` messages; Gemini / Ollama have their own
+            quirks).
+        :param tools: tool schemas the model is allowed to call. Empty
+            sequence is valid — the model gets no tools and must reply
+            with text only.
+        :param system: top-level system prompt. ``None`` skips the
+            system block. Providers without a system-block concept
+            (some Ollama configurations) prepend it as a synthetic
+            user-role turn.
+        :param max_tokens: cap on response output. Providers clamp to
+            their model's max-output limit if exceeded.
+        :param cache_control: per-region cache opt-ins. Honoured by
+            providers where :meth:`supports_prompt_caching` is True;
+            others ignore.
+        :param provider_specific: opt-in flags / overrides for
+            backend-specific features that other providers can't
+            express (Anthropic's ``anthropic_task_budget_beta=True``,
+            OpenAI's ``parallel_tool_calls=False``, etc.). Receivers
+            ignore unrecognised kwargs.
+        """
+        ...

--- a/core/llm/tool_use/tests/test_anthropic.py
+++ b/core/llm/tool_use/tests/test_anthropic.py
@@ -1,0 +1,629 @@
+"""Tests for ``core.llm.tool_use.anthropic.AnthropicToolUseProvider``.
+
+The provider is exercised against a stub ``Anthropic`` client whose
+``messages.create`` records every call's kwargs and returns a
+pre-scripted response object. This keeps the tests offline while still
+asserting the wire-format conversion (Message → Anthropic message,
+tool schemas, cache_control markers, response normalisation).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.llm.tool_use import (
+    CacheControl,
+    Message,
+    StopReason,
+    TextBlock,
+    ToolCall,
+    ToolDef,
+    ToolResult,
+)
+from core.llm.tool_use.anthropic import AnthropicToolUseProvider
+
+
+# ---------------------------------------------------------------------------
+# Stub SDK objects mirroring just enough of the anthropic SDK's shapes.
+# ---------------------------------------------------------------------------
+
+
+class _StubBlock:
+    def __init__(self, type_: str, **fields: Any) -> None:
+        self.type = type_
+        for k, v in fields.items():
+            setattr(self, k, v)
+
+
+class _StubUsage:
+    def __init__(
+        self,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cache_read_input_tokens: int = 0,
+        cache_creation_input_tokens: int = 0,
+    ) -> None:
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self.cache_read_input_tokens = cache_read_input_tokens
+        self.cache_creation_input_tokens = cache_creation_input_tokens
+
+
+class _StubResponse:
+    def __init__(
+        self,
+        content: list[_StubBlock],
+        stop_reason: str = "end_turn",
+        usage: _StubUsage | None = None,
+    ) -> None:
+        self.content = content
+        self.stop_reason = stop_reason
+        self.usage = usage or _StubUsage()
+
+
+class _StubMessages:
+    """Records calls; returns the next scripted response per call."""
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.responses: list[_StubResponse] = []
+
+    def create(self, **kwargs: Any) -> _StubResponse:
+        self.calls.append(kwargs)
+        if not self.responses:
+            return _StubResponse([])
+        return self.responses.pop(0)
+
+
+class _StubBetaMessages(_StubMessages):
+    """Used to validate the beta task-budget routing path."""
+
+
+class _StubBeta:
+    def __init__(self, messages: _StubBetaMessages) -> None:
+        self.messages = messages
+
+
+class _StubClient:
+    def __init__(self) -> None:
+        self.messages = _StubMessages()
+        self.beta = _StubBeta(_StubBetaMessages())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _provider_with_stub() -> tuple[AnthropicToolUseProvider, _StubClient]:
+    """Construct a provider then swap in our stub client."""
+    p = AnthropicToolUseProvider("claude-opus-4-6")
+    client = _StubClient()
+    p._client = client                                  # type: ignore[attr-defined]
+    return p, client
+
+
+def _echo_tool() -> ToolDef:
+    return ToolDef(
+        name="echo",
+        description="echoes input back",
+        input_schema={"type": "object"},
+        handler=lambda inp: f"echoed:{inp}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Capability flags + lookup
+# ---------------------------------------------------------------------------
+
+
+def test_capabilities_advertised() -> None:
+    p, _ = _provider_with_stub()
+    assert p.supports_tool_use() is True
+    assert p.supports_prompt_caching() is True
+    assert p.supports_parallel_tools() is True
+
+
+def test_unknown_model_at_construction_raises() -> None:
+    """The model lookup happens via ``model_data.context_window_for``
+    which raises ``KeyError`` for unknown models. We let that surface
+    rather than papering over it — silently using a wrong window would
+    mis-gate the loop's context policy."""
+    with pytest.raises(KeyError, match="unknown model"):
+        AnthropicToolUseProvider("model-that-does-not-exist")
+
+
+def test_context_window_and_price_from_model_data() -> None:
+    p, _ = _provider_with_stub()
+    # claude-opus-4-6: 1M context, $0.005/$0.025 per-1K → $5/$25 per-M
+    assert p.context_window() == 1_000_000
+    assert p.price_per_million() == (5.0, 25.0)
+
+
+# ---------------------------------------------------------------------------
+# turn() — request shape
+# ---------------------------------------------------------------------------
+
+
+def test_system_string_passes_through_when_uncached() -> None:
+    """``CacheControl(system=False)`` → system is sent as a plain string,
+    not a list. Avoids the cache_control marker and the list-form
+    overhead when caching isn't wanted."""
+    p, c = _provider_with_stub()
+    c.messages.responses.append(_StubResponse(
+        [_StubBlock("text", text="hi")], stop_reason="end_turn",
+    ))
+    p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="ping")])],
+        tools=[],
+        system="be helpful",
+        cache_control=CacheControl(system=False, tools=False),
+    )
+    assert c.messages.calls[0]["system"] == "be helpful"
+
+
+def test_system_uses_list_form_when_cached() -> None:
+    """``CacheControl(system=True)`` → system is sent as a content list
+    so we can attach the cache_control marker to the system block."""
+    p, c = _provider_with_stub()
+    c.messages.responses.append(_StubResponse(
+        [_StubBlock("text", text="hi")], stop_reason="end_turn",
+    ))
+    p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+        system="hello",
+        cache_control=CacheControl(system=True, tools=False),
+    )
+    sys_arg = c.messages.calls[0]["system"]
+    assert isinstance(sys_arg, list)
+    assert sys_arg[0]["text"] == "hello"
+    assert sys_arg[0]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_tools_cache_marker_on_last_tool() -> None:
+    """``CacheControl(tools=True)`` places the marker on the last tool
+    in the array — Anthropic caches everything up to and including
+    the marked block."""
+    p, c = _provider_with_stub()
+    c.messages.responses.append(_StubResponse(
+        [_StubBlock("text", text="ok")], stop_reason="end_turn",
+    ))
+    p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[_echo_tool(), ToolDef(
+            name="other", description="d", input_schema={},
+            handler=lambda _: "x",
+        )],
+        cache_control=CacheControl(system=False, tools=True),
+    )
+    sent_tools = c.messages.calls[0]["tools"]
+    assert "cache_control" not in sent_tools[0]
+    assert sent_tools[1]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_tools_cache_skipped_when_disabled() -> None:
+    p, c = _provider_with_stub()
+    c.messages.responses.append(_StubResponse(
+        [_StubBlock("text", text="ok")], stop_reason="end_turn",
+    ))
+    p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[_echo_tool()],
+        cache_control=CacheControl(system=False, tools=False),
+    )
+    sent_tools = c.messages.calls[0]["tools"]
+    assert "cache_control" not in sent_tools[0]
+
+
+def test_history_through_index_attaches_cache_marker() -> None:
+    """``CacheControl(history_through_index=i)`` puts the marker on the
+    last content block of message ``i``, so Anthropic caches every
+    turn ≤ i (the stable conversation prefix)."""
+    p, c = _provider_with_stub()
+    c.messages.responses.append(_StubResponse(
+        [_StubBlock("text", text="ok")], stop_reason="end_turn",
+    ))
+    history = [
+        Message(role="user", content=[TextBlock(text="first")]),
+        Message(role="assistant", content=[TextBlock(text="reply")]),
+        Message(role="user", content=[TextBlock(text="latest")]),
+    ]
+    p.turn(
+        messages=history, tools=[],
+        cache_control=CacheControl(
+            system=False, tools=False, history_through_index=1,
+        ),
+    )
+    sent_msgs = c.messages.calls[0]["messages"]
+    # Marker on message[1] (assistant "reply"), not on [0] or [2].
+    assert "cache_control" not in sent_msgs[0]["content"][-1]
+    assert sent_msgs[1]["content"][-1]["cache_control"] == {"type": "ephemeral"}
+    assert "cache_control" not in sent_msgs[2]["content"][-1]
+
+
+def test_message_with_tool_call_passes_through() -> None:
+    """Assistant turn with a :class:`ToolCall` block gets converted to
+    Anthropic's ``tool_use`` shape verbatim."""
+    p, c = _provider_with_stub()
+    c.messages.responses.append(_StubResponse(
+        [_StubBlock("text", text="ok")], stop_reason="end_turn",
+    ))
+    history = [
+        Message(role="user", content=[TextBlock(text="go")]),
+        Message(role="assistant", content=[
+            TextBlock(text="thinking..."),
+            ToolCall(id="t1", name="echo", input={"x": 1}),
+        ]),
+        Message(role="user", content=[
+            ToolResult(tool_use_id="t1", content="echoed:{'x':1}"),
+        ]),
+    ]
+    p.turn(messages=history, tools=[_echo_tool()])
+    sent = c.messages.calls[0]["messages"]
+    assert sent[1]["content"][1] == {
+        "type": "tool_use", "id": "t1", "name": "echo", "input": {"x": 1},
+    }
+    assert sent[2]["content"][0] == {
+        "type": "tool_result", "tool_use_id": "t1",
+        "content": "echoed:{'x':1}", "is_error": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# turn() — response normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_response_text_block_normalises_to_textblock() -> None:
+    p, c = _provider_with_stub()
+    c.messages.responses.append(_StubResponse(
+        [_StubBlock("text", text="hello world")],
+        stop_reason="end_turn",
+        usage=_StubUsage(input_tokens=10, output_tokens=5),
+    ))
+    out = p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+    )
+    assert len(out.content) == 1
+    assert isinstance(out.content[0], TextBlock)
+    assert out.content[0].text == "hello world"
+    assert out.stop_reason is StopReason.COMPLETE
+    assert out.input_tokens == 10
+    assert out.output_tokens == 5
+
+
+def test_response_tool_use_block_normalises_to_toolcall() -> None:
+    p, c = _provider_with_stub()
+    c.messages.responses.append(_StubResponse(
+        [_StubBlock("tool_use",
+                    id="toolu_abc", name="echo", input={"q": "y"})],
+        stop_reason="tool_use",
+    ))
+    out = p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[_echo_tool()],
+    )
+    assert len(out.content) == 1
+    call = out.content[0]
+    assert isinstance(call, ToolCall)
+    assert call.id == "toolu_abc"
+    assert call.name == "echo"
+    assert call.input == {"q": "y"}
+    assert out.stop_reason is StopReason.NEEDS_TOOL_CALL
+
+
+def test_unknown_block_types_dropped() -> None:
+    """Non-text / non-tool_use blocks (e.g. ``thinking``) get dropped —
+    they don't affect the loop's tool-dispatch logic. Future support
+    is additive."""
+    p, c = _provider_with_stub()
+    c.messages.responses.append(_StubResponse(
+        [
+            _StubBlock("thinking", text="..."),
+            _StubBlock("text", text="answer"),
+        ],
+        stop_reason="end_turn",
+    ))
+    out = p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+    )
+    assert len(out.content) == 1
+    assert isinstance(out.content[0], TextBlock)
+    assert out.content[0].text == "answer"
+
+
+def test_stop_reason_mapping() -> None:
+    p, c = _provider_with_stub()
+    cases = [
+        ("end_turn", StopReason.COMPLETE),
+        ("stop_sequence", StopReason.COMPLETE),
+        ("tool_use", StopReason.NEEDS_TOOL_CALL),
+        ("pause_turn", StopReason.PAUSE_TURN),
+        ("max_tokens", StopReason.MAX_TOKENS),
+        ("refusal", StopReason.REFUSED),
+        ("totally_unknown", StopReason.ERROR),
+    ]
+    for native, expected in cases:
+        c.messages.responses.append(_StubResponse(
+            [_StubBlock("text", text="x")],
+            stop_reason=native,
+        ))
+        out = p.turn(
+            messages=[Message(role="user", content=[TextBlock(text="p")])],
+            tools=[],
+        )
+        assert out.stop_reason is expected, native
+
+
+# ---------------------------------------------------------------------------
+# Cost computation (cache-aware)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_cost_no_cache() -> None:
+    """Without cache reads/writes, cost is the standard input + output
+    rates applied to per-million."""
+    p, _ = _provider_with_stub()
+    # opus-4-6: in $5/M, out $25/M
+    from core.llm.tool_use.types import TurnResponse
+    resp = TurnResponse(
+        content=[], stop_reason=StopReason.COMPLETE,
+        input_tokens=1000, output_tokens=500,
+    )
+    expected = (1000 * 5 + 500 * 25) / 1_000_000
+    assert abs(p.compute_cost(resp) - expected) < 1e-12
+
+
+def test_compute_cost_with_cache_reads() -> None:
+    """Cache reads are 0.1x the input rate per Anthropic's documented
+    multipliers."""
+    p, _ = _provider_with_stub()
+    from core.llm.tool_use.types import TurnResponse
+    resp = TurnResponse(
+        content=[], stop_reason=StopReason.COMPLETE,
+        input_tokens=100, output_tokens=50,
+        cache_read_tokens=10_000,
+    )
+    base = (100 * 5 + 50 * 25) / 1_000_000
+    cache = (10_000 * 5 * 0.1) / 1_000_000
+    assert abs(p.compute_cost(resp) - (base + cache)) < 1e-12
+
+
+def test_compute_cost_with_cache_writes() -> None:
+    """Cache writes are 1.25x the input rate per Anthropic's
+    documented multipliers."""
+    p, _ = _provider_with_stub()
+    from core.llm.tool_use.types import TurnResponse
+    resp = TurnResponse(
+        content=[], stop_reason=StopReason.COMPLETE,
+        input_tokens=100, output_tokens=50,
+        cache_write_tokens=10_000,
+    )
+    base = (100 * 5 + 50 * 25) / 1_000_000
+    cache = (10_000 * 5 * 1.25) / 1_000_000
+    assert abs(p.compute_cost(resp) - (base + cache)) < 1e-12
+
+
+# ---------------------------------------------------------------------------
+# Beta task-budget routing
+# ---------------------------------------------------------------------------
+
+
+def test_beta_task_budget_routes_to_beta_messages() -> None:
+    """``anthropic_task_budget_beta=True`` routes through
+    ``client.beta.messages.create`` instead of the standard endpoint
+    AND passes the ``betas=[...]`` parameter — without the parameter
+    the beta endpoint accepts the request but doesn't actually
+    activate the beta (the bug v1 of this code shipped with)."""
+    from core.llm.tool_use.anthropic import _TASK_BUDGET_BETA
+
+    p, c = _provider_with_stub()
+    c.beta.messages.responses.append(_StubResponse(
+        [_StubBlock("text", text="ok")], stop_reason="end_turn",
+    ))
+    p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+        anthropic_task_budget_beta=True,
+    )
+    assert len(c.messages.calls) == 0                # standard endpoint not called
+    assert len(c.beta.messages.calls) == 1           # beta endpoint called
+    sent = c.beta.messages.calls[0]
+    assert sent.get("betas") == [_TASK_BUDGET_BETA]
+
+
+def test_standard_endpoint_does_not_carry_betas_kwarg() -> None:
+    """Without ``anthropic_task_budget_beta=True`` the request goes
+    via the standard endpoint and must NOT carry a ``betas`` kwarg —
+    the standard endpoint rejects unknown parameters."""
+    p, c = _provider_with_stub()
+    c.messages.responses.append(_StubResponse(
+        [_StubBlock("text", text="ok")], stop_reason="end_turn",
+    ))
+    p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+    )
+    assert len(c.messages.calls) == 1
+    assert "betas" not in c.messages.calls[0]
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_api_error_returns_error_stop_reason() -> None:
+    """Permanent API errors surface as ``StopReason.ERROR`` after
+    retries are exhausted (or immediately for non-transient errors)."""
+    from anthropic import APIConnectionError                # type: ignore[import-not-found]
+
+    p, c = _provider_with_stub()
+
+    def _raise(**_kwargs: Any) -> _StubResponse:
+        raise APIConnectionError(request=None)             # type: ignore[arg-type]
+
+    c.messages.create = _raise                             # type: ignore[method-assign]
+
+    out = p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+    )
+    assert out.stop_reason is StopReason.ERROR
+    assert out.content == []
+
+
+# ---------------------------------------------------------------------------
+# Retry on transient errors
+# ---------------------------------------------------------------------------
+
+
+def test_retries_on_transient_then_succeeds(monkeypatch) -> None:
+    """Connection errors are transient — retried with backoff. After
+    one failure the next attempt succeeds and the loop sees the
+    successful response (not ERROR)."""
+    from anthropic import APIConnectionError                # type: ignore[import-not-found]
+
+    p, c = _provider_with_stub()
+    monkeypatch.setattr("core.llm.tool_use.anthropic.time.sleep", lambda _s: None)
+
+    attempts = {"n": 0}
+
+    def _flaky(**_kwargs: Any) -> _StubResponse:
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise APIConnectionError(request=None)         # type: ignore[arg-type]
+        return _StubResponse(
+            [_StubBlock("text", text="recovered")],
+            stop_reason="end_turn",
+        )
+
+    c.messages.create = _flaky                             # type: ignore[method-assign]
+
+    out = p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+    )
+    assert attempts["n"] == 2                              # 1 fail + 1 success
+    assert out.stop_reason is StopReason.COMPLETE
+    assert out.content[0].text == "recovered"
+
+
+def test_retries_exhausted_returns_error(monkeypatch) -> None:
+    """Once ``max_retries`` transient failures have occurred, surface
+    ERROR. Caller (the loop) reports it as ``provider_error``."""
+    from anthropic import APIConnectionError                # type: ignore[import-not-found]
+
+    p = AnthropicToolUseProvider("claude-opus-4-6", max_retries=2)
+    p._client = _StubClient()                              # type: ignore[attr-defined]
+    monkeypatch.setattr("core.llm.tool_use.anthropic.time.sleep", lambda _s: None)
+
+    attempts = {"n": 0}
+
+    def _always_fail(**_kwargs: Any) -> _StubResponse:
+        attempts["n"] += 1
+        raise APIConnectionError(request=None)             # type: ignore[arg-type]
+
+    p._client.messages.create = _always_fail               # type: ignore[method-assign]
+
+    out = p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+    )
+    # max_retries=2 → 1 initial + 2 retries = 3 attempts before giving up.
+    assert attempts["n"] == 3
+    assert out.stop_reason is StopReason.ERROR
+
+
+def test_permanent_4xx_fails_fast_no_retry(monkeypatch) -> None:
+    """4xx errors other than 429 are permanent — burning the retry
+    budget on hopeless retries (auth, schema validation) helps no-one."""
+    from anthropic import APIStatusError                    # type: ignore[import-not-found]
+
+    p = AnthropicToolUseProvider("claude-opus-4-6", max_retries=5)
+    p._client = _StubClient()                              # type: ignore[attr-defined]
+    monkeypatch.setattr("core.llm.tool_use.anthropic.time.sleep", lambda _s: None)
+
+    attempts = {"n": 0}
+
+    def _403(**_kwargs: Any) -> _StubResponse:
+        attempts["n"] += 1
+        # APIStatusError(message, response, body); we synthesise minimum
+        # shape needed for status_code attr.
+        err = APIStatusError.__new__(APIStatusError)
+        err.status_code = 403                              # type: ignore[attr-defined]
+        raise err
+
+    p._client.messages.create = _403                       # type: ignore[method-assign]
+
+    out = p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+    )
+    assert attempts["n"] == 1                              # no retries
+    assert out.stop_reason is StopReason.ERROR
+
+
+def test_429_is_retried(monkeypatch) -> None:
+    """429 (rate limit) is retryable — distinct from 4xx auth errors."""
+    from anthropic import APIStatusError                    # type: ignore[import-not-found]
+
+    p = AnthropicToolUseProvider("claude-opus-4-6", max_retries=2)
+    p._client = _StubClient()                              # type: ignore[attr-defined]
+    monkeypatch.setattr("core.llm.tool_use.anthropic.time.sleep", lambda _s: None)
+
+    attempts = {"n": 0}
+
+    def _flaky(**_kwargs: Any) -> _StubResponse:
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            err = APIStatusError.__new__(APIStatusError)
+            err.status_code = 429                          # type: ignore[attr-defined]
+            raise err
+        return _StubResponse(
+            [_StubBlock("text", text="ok")],
+            stop_reason="end_turn",
+        )
+
+    p._client.messages.create = _flaky                     # type: ignore[method-assign]
+
+    out = p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+    )
+    assert attempts["n"] == 2
+    assert out.stop_reason is StopReason.COMPLETE
+
+
+# ---------------------------------------------------------------------------
+# Provider-specific kwargs handling
+# ---------------------------------------------------------------------------
+
+
+def test_unrecognised_provider_kwargs_logged_at_debug(caplog) -> None:
+    """Typos in provider_specific kwargs (e.g.,
+    ``anthropic_task_budget_bata=True``) are silently accepted but
+    emit a debug log — discoverable when troubleshooting without
+    breaking graceful degradation across providers."""
+    import logging
+
+    p, c = _provider_with_stub()
+    c.messages.responses.append(_StubResponse(
+        [_StubBlock("text", text="ok")], stop_reason="end_turn",
+    ))
+
+    with caplog.at_level(logging.DEBUG, logger="core.llm.tool_use.anthropic"):
+        p.turn(
+            messages=[Message(role="user", content=[TextBlock(text="x")])],
+            tools=[],
+            anthropic_task_budget_bata=True,                # typo — silently accepted
+            random_other_kwarg=42,
+        )
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("ignoring unrecognised" in m for m in msgs)
+    assert any("anthropic_task_budget_bata" in m for m in msgs)

--- a/core/llm/tool_use/tests/test_anthropic.py
+++ b/core/llm/tool_use/tests/test_anthropic.py
@@ -13,6 +13,11 @@ from typing import Any
 
 import pytest
 
+# AnthropicToolUseProvider's constructor requires the anthropic SDK;
+# CI matrix runs without it skip this whole file cleanly. Import
+# checks happen here (module level) so collection doesn't fail.
+pytest.importorskip("anthropic")
+
 from core.llm.tool_use import (
     CacheControl,
     Message,

--- a/core/llm/tool_use/tests/test_anthropic_schema.py
+++ b/core/llm/tool_use/tests/test_anthropic_schema.py
@@ -21,15 +21,19 @@ from typing import Any
 
 import pytest
 
+# Skip this whole file in environments without the anthropic SDK
+# installed (CI matrix runs that don't pip install it). The provider
+# itself soft-imports and raises a clean RuntimeError on construction;
+# these tests can't run without the real types.
+anthropic_types = pytest.importorskip("anthropic.types")
+
 # Real SDK types — construction here validates fields against the
 # SDK's Pydantic schemas. If anything below fails to import or
 # construct, our wire-format assumptions in anthropic.py are stale.
-from anthropic.types import (                              # type: ignore[import-not-found]
-    Message,
-    TextBlock as SDKTextBlock,
-    ToolUseBlock as SDKToolUseBlock,
-    Usage,
-)
+Message = anthropic_types.Message
+SDKTextBlock = anthropic_types.TextBlock
+SDKToolUseBlock = anthropic_types.ToolUseBlock
+Usage = anthropic_types.Usage
 
 from core.llm.tool_use import (
     Message as OurMessage,

--- a/core/llm/tool_use/tests/test_anthropic_schema.py
+++ b/core/llm/tool_use/tests/test_anthropic_schema.py
@@ -1,0 +1,312 @@
+"""Schema-validated tests for ``AnthropicToolUseProvider``.
+
+The ``test_anthropic.py`` companion file uses hand-built stubs that
+mirror the SDK's wire shape. This file uses the **real** SDK types
+(``anthropic.types.Message``, ``Usage``, ``TextBlock``,
+``ToolUseBlock``) to construct response objects — catching the bug
+class hand-built stubs miss: field-name typos, schema drift, and
+type-shape mismatches.
+
+These tests don't hit the network: the ``Anthropic`` client object is
+still stubbed, but the response objects it returns are validated by
+the SDK's own Pydantic models. If a future ``anthropic`` SDK rev
+renames ``cache_read_input_tokens`` or removes ``pause_turn`` from
+the stop_reason Literal, these tests fail loud at construction —
+exactly when the live API would have started rejecting our requests.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+# Real SDK types — construction here validates fields against the
+# SDK's Pydantic schemas. If anything below fails to import or
+# construct, our wire-format assumptions in anthropic.py are stale.
+from anthropic.types import (                              # type: ignore[import-not-found]
+    Message,
+    TextBlock as SDKTextBlock,
+    ToolUseBlock as SDKToolUseBlock,
+    Usage,
+)
+
+from core.llm.tool_use import (
+    Message as OurMessage,
+    StopReason,
+    TextBlock,
+    ToolCall,
+)
+from core.llm.tool_use.anthropic import AnthropicToolUseProvider
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build a real anthropic.types.Message envelope
+# ---------------------------------------------------------------------------
+
+
+def _make_real_message(
+    content: list[Any],
+    stop_reason: str = "end_turn",
+    *,
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    cache_read_input_tokens: int | None = None,
+    cache_creation_input_tokens: int | None = None,
+) -> Message:
+    """Build a real ``anthropic.types.Message`` from real block types.
+    Pydantic validation runs at construction — any field name or type
+    drift breaks the test immediately."""
+    return Message(
+        id="msg_test_01",
+        model="claude-opus-4-6",
+        role="assistant",
+        type="message",
+        content=content,
+        stop_reason=stop_reason,                           # type: ignore[arg-type]
+        stop_sequence=None,
+        usage=Usage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_input_tokens=cache_read_input_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+        ),
+        container=None,
+    )
+
+
+class _ClientWithRealResponse:
+    """Stub Anthropic client whose ``messages.create`` returns the
+    real ``Message`` we hand it — the rest of the SDK isn't exercised."""
+
+    def __init__(self, response: Message) -> None:
+        self._response = response
+        self.calls: list[dict[str, Any]] = []
+
+        class _Messages:
+            def create(_self, **kwargs: Any) -> Message:
+                self.calls.append(kwargs)
+                return self._response
+
+        self.messages = _Messages()
+        self.beta = type("_Beta", (), {"messages": self.messages})()
+
+
+def _provider_with_real_response(response: Message) -> AnthropicToolUseProvider:
+    p = AnthropicToolUseProvider("claude-opus-4-6")
+    p._client = _ClientWithRealResponse(response)         # type: ignore[attr-defined]
+    return p
+
+
+def _user_msg(text: str) -> OurMessage:
+    return OurMessage(role="user", content=[TextBlock(text=text)])
+
+
+# ---------------------------------------------------------------------------
+# Stop-reason values — schema confirms exact set
+# ---------------------------------------------------------------------------
+
+
+def test_real_sdk_stop_reasons_match_our_mapping() -> None:
+    """The ``Message.stop_reason`` Literal in the real SDK is the
+    authoritative source of valid values. Our ``_STOP_REASON_MAP``
+    must cover every value the SDK can emit, otherwise unmapped
+    stops fall through to ``ERROR`` and the loop terminates wrongly.
+
+    This test extracts the SDK's literal set via Pydantic's field
+    metadata and asserts each value has a corresponding mapping.
+    """
+    import typing
+    from core.llm.tool_use.anthropic import _STOP_REASON_MAP
+
+    # Pydantic stores the field's annotation; Optional[Literal[...]]
+    # → Union[Literal[...], None]. Walk to find the Literal.
+    stop_reason_anno = Message.model_fields["stop_reason"].annotation
+    sdk_literals: set[str] = set()
+    for arg in typing.get_args(stop_reason_anno):
+        if arg is type(None):
+            continue
+        sdk_literals.update(typing.get_args(arg))
+
+    unmapped = sdk_literals - set(_STOP_REASON_MAP.keys())
+    assert not unmapped, (
+        f"SDK stop_reason values not handled by _STOP_REASON_MAP: "
+        f"{unmapped}. Update anthropic.py to map these to a "
+        f"StopReason."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Block normalisation — real SDK blocks survive turn() unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_real_text_block_normalises_correctly() -> None:
+    response = _make_real_message(
+        content=[SDKTextBlock(type="text", text="hello world", citations=None)],
+        stop_reason="end_turn",
+    )
+    p = _provider_with_real_response(response)
+    out = p.turn(messages=[_user_msg("p")], tools=[])
+
+    assert out.stop_reason is StopReason.COMPLETE
+    assert len(out.content) == 1
+    assert isinstance(out.content[0], TextBlock)
+    assert out.content[0].text == "hello world"
+
+
+def test_real_tool_use_block_normalises_correctly() -> None:
+    response = _make_real_message(
+        content=[SDKToolUseBlock(
+            type="tool_use",
+            id="toolu_xyz",
+            name="echo",
+            input={"q": "y", "n": 7},
+        )],
+        stop_reason="tool_use",
+    )
+    p = _provider_with_real_response(response)
+    out = p.turn(messages=[_user_msg("p")], tools=[])
+
+    assert out.stop_reason is StopReason.NEEDS_TOOL_CALL
+    assert len(out.content) == 1
+    call = out.content[0]
+    assert isinstance(call, ToolCall)
+    assert call.id == "toolu_xyz"
+    assert call.name == "echo"
+    assert call.input == {"q": "y", "n": 7}
+
+
+def test_real_mixed_text_plus_tool_use_normalises_both() -> None:
+    """Anthropic emits text + tool_use in a single response. Both
+    must survive the conversion (the loop's tool-dispatch logic
+    iterates ``isinstance(block, ToolCall)`` to find the calls)."""
+    response = _make_real_message(
+        content=[
+            SDKTextBlock(type="text", text="checking...", citations=None),
+            SDKToolUseBlock(type="tool_use", id="toolu_abc",
+                            name="search", input={"q": "x"}),
+        ],
+        stop_reason="tool_use",
+    )
+    p = _provider_with_real_response(response)
+    out = p.turn(messages=[_user_msg("p")], tools=[])
+
+    assert len(out.content) == 2
+    assert isinstance(out.content[0], TextBlock)
+    assert out.content[0].text == "checking..."
+    assert isinstance(out.content[1], ToolCall)
+    assert out.content[1].name == "search"
+
+
+# ---------------------------------------------------------------------------
+# Stop-reason mapping — every real Literal value
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("native, expected", [
+    ("end_turn", StopReason.COMPLETE),
+    ("stop_sequence", StopReason.COMPLETE),
+    ("tool_use", StopReason.NEEDS_TOOL_CALL),
+    ("pause_turn", StopReason.PAUSE_TURN),
+    ("max_tokens", StopReason.MAX_TOKENS),
+    ("refusal", StopReason.REFUSED),
+])
+def test_each_real_stop_reason_normalises(
+    native: str, expected: StopReason,
+) -> None:
+    """Each value in the SDK's ``stop_reason`` Literal maps to the
+    expected ``StopReason``. Constructed via the real ``Message`` so
+    SDK-side validation rejects invalid Literal values at test-build
+    time — no way to silently test against a typo."""
+    response = _make_real_message(
+        content=[SDKTextBlock(type="text", text="x", citations=None)],
+        stop_reason=native,
+    )
+    p = _provider_with_real_response(response)
+    out = p.turn(messages=[_user_msg("p")], tools=[])
+    assert out.stop_reason is expected
+
+
+# ---------------------------------------------------------------------------
+# Usage / cache fields — real SDK Usage shape
+# ---------------------------------------------------------------------------
+
+
+def test_real_usage_input_output_tokens_pass_through() -> None:
+    """``Usage.input_tokens`` and ``Usage.output_tokens`` are required
+    int fields per the SDK schema — we surface them on TurnResponse."""
+    response = _make_real_message(
+        content=[SDKTextBlock(type="text", text="x", citations=None)],
+        stop_reason="end_turn",
+        input_tokens=1234,
+        output_tokens=567,
+    )
+    p = _provider_with_real_response(response)
+    out = p.turn(messages=[_user_msg("p")], tools=[])
+    assert out.input_tokens == 1234
+    assert out.output_tokens == 567
+
+
+def test_real_usage_cache_fields_pass_through() -> None:
+    """``cache_read_input_tokens`` and ``cache_creation_input_tokens``
+    are Optional[int] in the SDK — we surface them as 0 when None,
+    real values when set."""
+    response = _make_real_message(
+        content=[SDKTextBlock(type="text", text="x", citations=None)],
+        stop_reason="end_turn",
+        cache_read_input_tokens=2000,
+        cache_creation_input_tokens=300,
+    )
+    p = _provider_with_real_response(response)
+    out = p.turn(messages=[_user_msg("p")], tools=[])
+    assert out.cache_read_tokens == 2000
+    assert out.cache_write_tokens == 300
+
+
+def test_real_usage_with_none_cache_fields_normalises_to_zero() -> None:
+    """When the API omits cache fields (``None`` per SDK), our wire
+    converter must not propagate None into ``int``-typed
+    ``cache_read_tokens`` / ``cache_write_tokens`` fields. v1 of the
+    code did ``getattr(usage, ..., 0)`` — but ``getattr`` returns the
+    actual ``None`` since the attribute exists, not the default. This
+    test would catch that bug."""
+    response = _make_real_message(
+        content=[SDKTextBlock(type="text", text="x", citations=None)],
+        stop_reason="end_turn",
+        cache_read_input_tokens=None,
+        cache_creation_input_tokens=None,
+    )
+    p = _provider_with_real_response(response)
+    out = p.turn(messages=[_user_msg("p")], tools=[])
+    assert out.cache_read_tokens == 0
+    assert out.cache_write_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# Cost computation against real Usage values
+# ---------------------------------------------------------------------------
+
+
+def test_real_usage_drives_cost_computation_correctly() -> None:
+    """Real Usage with cache fields → cost matches Anthropic's
+    documented multipliers (cache write 1.25x, cache read 0.1x)."""
+    response = _make_real_message(
+        content=[SDKTextBlock(type="text", text="x", citations=None)],
+        stop_reason="end_turn",
+        input_tokens=1000,
+        output_tokens=500,
+        cache_read_input_tokens=10_000,
+        cache_creation_input_tokens=2_000,
+    )
+    p = _provider_with_real_response(response)
+    out = p.turn(messages=[_user_msg("p")], tools=[])
+
+    # opus-4-6: in $5/M, out $25/M
+    expected = (
+        1000 * 5
+        + 500 * 25
+        + 10_000 * 5 * 0.1                                  # cache read
+        + 2_000 * 5 * 1.25                                  # cache write
+    ) / 1_000_000
+    assert abs(p.compute_cost(out) - expected) < 1e-9

--- a/core/llm/tool_use/tests/test_loop.py
+++ b/core/llm/tool_use/tests/test_loop.py
@@ -1,0 +1,673 @@
+"""Tests for ``core.llm.tool_use.loop.ToolUseLoop``.
+
+Loop logic is exercised against an in-memory ``_FakeProvider`` that
+replays a pre-scripted sequence of :class:`TurnResponse`\\ s. This
+isolates loop behaviour from any specific provider's wire format —
+those concerns are tested in the provider-specific test files.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+
+from core.llm.tool_use import (
+    CacheControl,
+    ContextOverflow,
+    ContextPolicy,
+    CostBudgetExceeded,
+    LoopEvent,
+    LoopTerminated,
+    Message,
+    StopReason,
+    TextBlock,
+    ToolCall,
+    ToolCallDispatched,
+    ToolCallReturned,
+    ToolDef,
+    TurnCompleted,
+    TurnResponse,
+    TurnStarted,
+)
+from core.llm.tool_use.loop import ToolUseLoop
+
+
+# ---------------------------------------------------------------------------
+# Fake provider — records calls, replays scripted responses
+# ---------------------------------------------------------------------------
+
+
+class _FakeProvider:
+    """In-memory provider replaying a list of :class:`TurnResponse`\\ s.
+
+    Each ``turn()`` call pops the next scripted response. Records all
+    input messages so tests can assert wire-format behaviour.
+    """
+
+    def __init__(
+        self,
+        responses: list[TurnResponse],
+        *,
+        tool_use: bool = True,
+        prompt_caching: bool = True,
+        parallel_tools: bool = True,
+        ctx_window: int = 200_000,
+        price: tuple[float, float] = (3.0, 15.0),  # opus-ish
+    ) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+        self._tool_use = tool_use
+        self._prompt_caching = prompt_caching
+        self._parallel_tools = parallel_tools
+        self._ctx_window = ctx_window
+        self._price = price
+
+    def supports_tool_use(self) -> bool: return self._tool_use
+    def supports_prompt_caching(self) -> bool: return self._prompt_caching
+    def supports_parallel_tools(self) -> bool: return self._parallel_tools
+    def context_window(self) -> int: return self._ctx_window
+    def price_per_million(self) -> tuple[float, float]: return self._price
+    def estimate_tokens(self, text: str) -> int: return max(len(text) // 4, 1)
+
+    def compute_cost(self, response: TurnResponse) -> float:
+        in_per_m, out_per_m = self._price
+        return (response.input_tokens * in_per_m
+                + response.output_tokens * out_per_m) / 1_000_000
+
+    def turn(self, messages, tools, *, system, max_tokens, cache_control,
+             **provider_specific) -> TurnResponse:
+        self.calls.append({
+            "messages": list(messages),
+            "tools": list(tools),
+            "system": system,
+            "max_tokens": max_tokens,
+            "cache_control": cache_control,
+            "provider_specific": dict(provider_specific),
+        })
+        if not self._responses:
+            raise RuntimeError("fake provider exhausted scripted responses")
+        return self._responses.pop(0)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _text_response(text: str, in_t: int = 100, out_t: int = 50) -> TurnResponse:
+    return TurnResponse(
+        content=[TextBlock(text=text)],
+        stop_reason=StopReason.COMPLETE,
+        input_tokens=in_t, output_tokens=out_t,
+    )
+
+
+def _tool_call_response(
+    *calls: tuple[str, str, dict],
+    in_t: int = 100, out_t: int = 50,
+) -> TurnResponse:
+    return TurnResponse(
+        content=[ToolCall(id=cid, name=name, input=inp)
+                 for cid, name, inp in calls],
+        stop_reason=StopReason.NEEDS_TOOL_CALL,
+        input_tokens=in_t, output_tokens=out_t,
+    )
+
+
+def _echo_tool(name: str = "echo") -> ToolDef:
+    return ToolDef(
+        name=name,
+        description="echoes its input back as JSON",
+        input_schema={"type": "object"},
+        handler=lambda inp: f"echoed: {inp}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Construction validation
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_provider_without_tool_use() -> None:
+    """A provider that says it doesn't support tool-use can't drive the
+    loop — ValueError at construction, not a confusing failure mid-run."""
+    fp = _FakeProvider([], tool_use=False)
+    with pytest.raises(ValueError, match="tool-use"):
+        ToolUseLoop(fp, [_echo_tool()])
+
+
+def test_rejects_duplicate_tool_names() -> None:
+    """Two tools with the same name would dispatch ambiguously — refuse
+    at construction so the bug surfaces immediately."""
+    fp = _FakeProvider([])
+    with pytest.raises(ValueError, match="unique names"):
+        ToolUseLoop(fp, [_echo_tool("dup"), _echo_tool("dup")])
+
+
+def test_rejects_terminal_tool_not_in_tools() -> None:
+    """A loop with ``terminal_tool="never_registered"`` would never
+    terminate via that path — refuse rather than run forever."""
+    fp = _FakeProvider([])
+    with pytest.raises(ValueError, match="not in the registered tools"):
+        ToolUseLoop(fp, [_echo_tool()], terminal_tool="missing")
+
+
+# ---------------------------------------------------------------------------
+# Termination paths
+# ---------------------------------------------------------------------------
+
+
+def test_terminates_on_complete_response() -> None:
+    """Text-only + COMPLETE → loop returns immediately with final text."""
+    fp = _FakeProvider([_text_response("done")])
+    loop = ToolUseLoop(fp, [_echo_tool()])
+    out = loop.run("start")
+    assert out.terminated_by == "complete"
+    assert out.final_text == "done"
+    assert out.iterations == 1
+    assert out.tool_calls_made == 0
+    assert len(fp.calls) == 1
+
+
+def test_terminates_on_terminal_tool_call() -> None:
+    """Loop terminates after dispatching the designated terminal tool;
+    its input is surfaced on the result."""
+    submit = ToolDef(
+        name="submit_result",
+        description="terminate with payload",
+        input_schema={"type": "object"},
+        handler=lambda inp: "submitted",
+    )
+    fp = _FakeProvider([
+        _tool_call_response(("c1", "submit_result",
+                             {"verdict": "match", "sha": "abc"})),
+    ])
+    loop = ToolUseLoop(fp, [submit], terminal_tool="submit_result")
+    out = loop.run("find it")
+    assert out.terminated_by == "terminal_tool"
+    assert out.terminal_tool_input == {"verdict": "match", "sha": "abc"}
+    assert out.tool_calls_made == 1
+    # Only one provider call — terminal-tool short-circuits before next turn.
+    assert len(fp.calls) == 1
+
+
+def test_max_tokens_no_tool_calls_terminates_distinctly() -> None:
+    """Provider returns ``StopReason.MAX_TOKENS`` with no tool calls
+    (model truncated mid-response). Should terminate with the
+    ``max_tokens`` label, distinguishable from ``provider_error``."""
+    fp = _FakeProvider([TurnResponse(
+        content=[TextBlock(text="partial...")],
+        stop_reason=StopReason.MAX_TOKENS,
+        input_tokens=100, output_tokens=4096,
+    )])
+    out = ToolUseLoop(fp, [_echo_tool()]).run("go")
+    assert out.terminated_by == "max_tokens"
+    # final_text still reports the partial response.
+    assert out.final_text == "partial..."
+
+
+def test_refused_no_tool_calls_terminates_distinctly() -> None:
+    """``StopReason.REFUSED`` (content filter / safety) terminates
+    with the ``refused`` label — caller can choose to surface the
+    refusal differently from a transport error."""
+    fp = _FakeProvider([TurnResponse(
+        content=[],
+        stop_reason=StopReason.REFUSED,
+        input_tokens=50, output_tokens=0,
+    )])
+    out = ToolUseLoop(fp, [_echo_tool()]).run("forbidden")
+    assert out.terminated_by == "refused"
+
+
+def test_provider_error_no_tool_calls_terminates_distinctly() -> None:
+    """``StopReason.ERROR`` (transport failure after retries)
+    terminates with ``provider_error``."""
+    fp = _FakeProvider([TurnResponse(
+        content=[],
+        stop_reason=StopReason.ERROR,
+        input_tokens=0, output_tokens=0,
+    )])
+    out = ToolUseLoop(fp, [_echo_tool()]).run("go")
+    assert out.terminated_by == "provider_error"
+
+
+def test_pause_turn_continues_to_next_iteration() -> None:
+    """``StopReason.PAUSE_TURN`` is a continuation signal (Anthropic
+    extended-thinking pause/resume), not a termination. Loop appends
+    the partial assistant turn and proceeds; eventually a non-PAUSE
+    response terminates normally."""
+    fp = _FakeProvider([
+        TurnResponse(
+            content=[TextBlock(text="thinking...")],
+            stop_reason=StopReason.PAUSE_TURN,
+            input_tokens=50, output_tokens=20,
+        ),
+        _text_response("done"),
+    ])
+    out = ToolUseLoop(fp, [_echo_tool()]).run("go")
+    assert out.terminated_by == "complete"
+    assert out.iterations == 2                          # pause + complete
+    # The partial assistant turn was appended to history; on the next
+    # turn we sent it back to the provider so it can resume.
+    second_call_messages = fp.calls[1]["messages"]
+    # messages = [user "go", assistant "thinking..."]
+    assert len(second_call_messages) == 2
+    assert second_call_messages[1].role == "assistant"
+    assert any(
+        isinstance(b, TextBlock) and b.text == "thinking..."
+        for b in second_call_messages[1].content
+    )
+
+
+def test_max_iterations_caps_runaway_loop() -> None:
+    """A loop that keeps emitting tool_calls without terminating gets
+    capped at ``max_iterations`` rather than running forever."""
+    fp = _FakeProvider([
+        _tool_call_response(("c1", "echo", {})),
+        _tool_call_response(("c2", "echo", {})),
+        _tool_call_response(("c3", "echo", {})),
+        _tool_call_response(("c4", "echo", {})),  # never reached
+    ])
+    loop = ToolUseLoop(fp, [_echo_tool()], max_iterations=3)
+    out = loop.run("loop")
+    assert out.terminated_by == "max_iterations"
+    assert out.iterations == 3
+    assert out.tool_calls_made == 3
+    assert len(fp.calls) == 3
+
+
+# ---------------------------------------------------------------------------
+# Cost budget
+# ---------------------------------------------------------------------------
+
+
+def test_max_cost_usd_terminates_pre_flight() -> None:
+    """Cost budget is checked before each turn — once the cumulative
+    cost crosses the cap, ``CostBudgetExceeded`` fires before the next
+    provider call."""
+    # Each turn costs (1000 * 3 + 1000 * 15) / 1M = $0.018
+    fp = _FakeProvider([
+        _tool_call_response(("c1", "echo", {}), in_t=1000, out_t=1000),
+        _tool_call_response(("c2", "echo", {}), in_t=1000, out_t=1000),
+        _text_response("never reached", in_t=1000, out_t=1000),
+    ])
+    loop = ToolUseLoop(fp, [_echo_tool()], max_cost_usd=0.020)
+    with pytest.raises(CostBudgetExceeded):
+        loop.run("expensive")
+    # 2 turns made it through; the 3rd was budget-blocked.
+    assert len(fp.calls) == 2
+
+
+def test_cost_tracking_aggregates_across_turns() -> None:
+    """``total_cost_usd`` reports the sum of provider.compute_cost()
+    over all turns. With 2 turns at (100*3 + 50*15)/1M = $0.00105 each."""
+    fp = _FakeProvider([
+        _tool_call_response(("c1", "echo", {})),
+        _text_response("ok"),
+    ])
+    loop = ToolUseLoop(fp, [_echo_tool()])
+    out = loop.run("hi")
+    assert out.iterations == 2
+    expected = ((100 * 3) + (50 * 15)) / 1_000_000 * 2
+    assert abs(out.total_cost_usd - expected) < 1e-9
+    assert out.total_input_tokens == 200
+    assert out.total_output_tokens == 100
+
+
+# ---------------------------------------------------------------------------
+# Context window
+# ---------------------------------------------------------------------------
+
+
+def test_context_overflow_raise_policy() -> None:
+    """RAISE policy refuses to send a request that exceeds the window."""
+    fp = _FakeProvider([_text_response("ok")], ctx_window=10)
+    loop = ToolUseLoop(
+        fp, [_echo_tool()],
+        system="x" * 1000,                       # 250 tokens at 4-chars/token
+        context_policy=ContextPolicy.RAISE,
+    )
+    with pytest.raises(ContextOverflow):
+        loop.run("y" * 1000)
+    assert len(fp.calls) == 0                     # never reached the provider
+
+
+def test_context_overflow_truncate_raises_when_exhausted() -> None:
+    """TRUNCATE_OLDEST falls back to ContextOverflow when even the
+    irreducible trailing message exceeds the window — silently
+    sending an oversized request would mis-gate the policy."""
+    fp = _FakeProvider([_text_response("ok")], ctx_window=10)
+    loop = ToolUseLoop(
+        fp, [_echo_tool()],
+        context_policy=ContextPolicy.TRUNCATE_OLDEST,
+    )
+    # Single trailing message larger than the whole window — nothing
+    # to drop; truncation runs out of options.
+    with pytest.raises(ContextOverflow, match="still exceeds"):
+        loop.run("y" * 1000)
+    assert len(fp.calls) == 0
+
+
+def test_context_overflow_truncate_policy_drops_oldest() -> None:
+    """TRUNCATE_OLDEST drops oldest history pairs until the request fits.
+    The freshest user message is preserved so the model still has the
+    immediate prompt to act on."""
+    # Provider window 100; system + tools + initial prompt fit; we add
+    # a long history that needs truncating.
+    fp = _FakeProvider([_text_response("ok")], ctx_window=100)
+    loop = ToolUseLoop(
+        fp, [_echo_tool()],
+        context_policy=ContextPolicy.TRUNCATE_OLDEST,
+    )
+    history = [
+        Message(role="user",
+                content=[TextBlock(text="x" * 200)]),     # 50 tokens
+        Message(role="assistant",
+                content=[TextBlock(text="y" * 200)]),     # 50 tokens
+        Message(role="user",
+                content=[TextBlock(text="z" * 200)]),     # 50 tokens
+    ]
+    out = loop.run_with_history(history, "now")
+    assert out.terminated_by == "complete"
+    # Provider was called — truncation succeeded.
+    assert len(fp.calls) == 1
+    sent = fp.calls[0]["messages"]
+    # Some old messages dropped; "now" prompt always preserved.
+    assert sent[-1].role == "user"
+    assert any(
+        isinstance(b, TextBlock) and "now" in b.text
+        for b in sent[-1].content
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_handler_error_default_feeds_back_to_model() -> None:
+    """A handler that raises returns ``ToolResult(is_error=True)`` to
+    the model so it can adapt — matches cve-diff's existing behaviour."""
+    def bad_handler(_inp: dict) -> str:
+        raise RuntimeError("oops")
+
+    bad = ToolDef(name="bad", description="d", input_schema={}, handler=bad_handler)
+    fp = _FakeProvider([
+        _tool_call_response(("c1", "bad", {})),
+        _text_response("ok"),
+    ])
+    loop = ToolUseLoop(fp, [bad])
+    out = loop.run("go")
+    assert out.terminated_by == "complete"
+    # Second turn's input messages include the error tool_result.
+    second = fp.calls[1]["messages"]
+    last_user_msg = second[-1]
+    assert last_user_msg.role == "user"
+    err = last_user_msg.content[0]
+    assert err.is_error is True
+    assert "oops" in err.content
+
+
+def test_handler_error_terminate_on_error_propagates() -> None:
+    """``terminate_on_handler_error=True`` re-raises rather than feeding
+    the error back — for agents wrapping destructive ops. Loop emits
+    ``LoopTerminated(reason="tool_error")`` before the exception
+    propagates so observers see termination."""
+    from core.llm.tool_use import LoopTerminated
+
+    def bad_handler(_inp: dict) -> str:
+        raise RuntimeError("must not retry")
+
+    bad = ToolDef(name="bad", description="d", input_schema={}, handler=bad_handler)
+    fp = _FakeProvider([_tool_call_response(("c1", "bad", {}))])
+    seen: list[LoopEvent] = []
+    loop = ToolUseLoop(
+        fp, [bad],
+        terminate_on_handler_error=True,
+        events=seen.append,
+    )
+    with pytest.raises(RuntimeError, match="must not retry"):
+        loop.run("go")
+    final = next(e for e in seen if isinstance(e, LoopTerminated))
+    assert final.reason == "tool_error"
+
+
+def test_unknown_tool_returns_error_result() -> None:
+    """Model-emitted call to a name we don't know — synthetic
+    ``is_error=True`` result; lets the model recover."""
+    fp = _FakeProvider([
+        _tool_call_response(("c1", "nonexistent_tool", {})),
+        _text_response("ok"),
+    ])
+    loop = ToolUseLoop(fp, [_echo_tool()])
+    out = loop.run("go")
+    assert out.terminated_by == "complete"
+    second = fp.calls[1]["messages"]
+    last = second[-1].content[0]
+    assert last.is_error is True
+    assert "unknown tool" in last.content
+
+
+def test_tool_timeout_returns_error_result() -> None:
+    """A handler that exceeds ``tool_timeout_s`` produces an
+    ``is_error=True`` :class:`ToolResult` (sleeps in background but
+    we stop waiting)."""
+    def slow_handler(_inp: dict) -> str:
+        time.sleep(0.5)
+        return "too late"
+
+    slow = ToolDef(name="slow", description="d", input_schema={}, handler=slow_handler)
+    fp = _FakeProvider([
+        _tool_call_response(("c1", "slow", {})),
+        _text_response("ok"),
+    ])
+    loop = ToolUseLoop(fp, [slow], tool_timeout_s=0.05)
+    out = loop.run("go")
+    assert out.terminated_by == "complete"
+    second = fp.calls[1]["messages"]
+    last = second[-1].content[0]
+    assert last.is_error is True
+    assert "timeout" in last.content
+
+
+def test_tool_timeout_terminate_on_handler_error_raises() -> None:
+    """Aligned with handler-exception behaviour: when
+    ``terminate_on_handler_error=True`` AND a tool times out, the
+    loop emits ``LoopTerminated(reason="tool_error")`` and re-raises
+    ``ToolHandlerTimeout`` instead of converting to a tool_result."""
+    from core.llm.tool_use import LoopTerminated, ToolHandlerTimeout
+
+    def slow_handler(_inp: dict) -> str:
+        time.sleep(0.5)
+        return "too late"
+
+    slow = ToolDef(name="slow", description="d", input_schema={}, handler=slow_handler)
+    fp = _FakeProvider([_tool_call_response(("c1", "slow", {}))])
+    seen: list[LoopEvent] = []
+    loop = ToolUseLoop(
+        fp, [slow],
+        tool_timeout_s=0.05,
+        terminate_on_handler_error=True,
+        events=seen.append,
+    )
+    with pytest.raises(ToolHandlerTimeout, match="exceeded"):
+        loop.run("go")
+
+    # LoopTerminated event was emitted with reason="tool_error" before
+    # the exception propagated.
+    final = next(e for e in seen if isinstance(e, LoopTerminated))
+    assert final.reason == "tool_error"
+
+
+def test_parallel_tool_calls_in_one_turn() -> None:
+    """Provider returns multiple tool_calls in one turn → loop dispatches
+    each, accumulates results, sends all back as one user message."""
+    fp = _FakeProvider([
+        _tool_call_response(
+            ("c1", "echo", {"x": 1}),
+            ("c2", "echo", {"x": 2}),
+            ("c3", "echo", {"x": 3}),
+        ),
+        _text_response("ok"),
+    ])
+    loop = ToolUseLoop(fp, [_echo_tool()])
+    out = loop.run("multi")
+    assert out.tool_calls_made == 3
+    second = fp.calls[1]["messages"]
+    # Last user message in the second call holds all 3 tool_results.
+    last_user = second[-1]
+    assert last_user.role == "user"
+    assert len(last_user.content) == 3
+
+
+# ---------------------------------------------------------------------------
+# Events
+# ---------------------------------------------------------------------------
+
+
+def test_events_emit_in_order_for_simple_run() -> None:
+    """Event sequence for one tool-call turn followed by a COMPLETE turn:
+    TurnStarted → TurnCompleted → ToolCallDispatched → ToolCallReturned →
+    TurnStarted → TurnCompleted → LoopTerminated(complete)."""
+    fp = _FakeProvider([
+        _tool_call_response(("c1", "echo", {})),
+        _text_response("done"),
+    ])
+    seen: list[LoopEvent] = []
+    loop = ToolUseLoop(fp, [_echo_tool()], events=seen.append)
+    loop.run("go")
+    types = [type(e).__name__ for e in seen]
+    assert types == [
+        "TurnStarted", "TurnCompleted",
+        "ToolCallDispatched", "ToolCallReturned",
+        "TurnStarted", "TurnCompleted",
+        "LoopTerminated",
+    ]
+    final = seen[-1]
+    assert isinstance(final, LoopTerminated)
+    assert final.reason == "complete"
+
+
+def test_events_carry_iteration_index() -> None:
+    """Iteration counter increments per turn — telemetry consumers use
+    it to correlate per-iteration tool calls."""
+    fp = _FakeProvider([
+        _tool_call_response(("c1", "echo", {})),
+        _text_response("done"),
+    ])
+    seen: list[LoopEvent] = []
+    loop = ToolUseLoop(fp, [_echo_tool()], events=seen.append)
+    loop.run("go")
+    started = [e for e in seen if isinstance(e, TurnStarted)]
+    assert [s.iteration for s in started] == [0, 1]
+
+
+def test_events_report_cost_and_tokens() -> None:
+    """``TurnCompleted.cost_usd`` matches what
+    ``provider.compute_cost`` returned — allows live cost surveillance
+    from the event stream."""
+    fp = _FakeProvider([_text_response("ok")])
+    seen: list[LoopEvent] = []
+    loop = ToolUseLoop(fp, [_echo_tool()], events=seen.append)
+    loop.run("hi")
+    completed = [e for e in seen if isinstance(e, TurnCompleted)]
+    assert len(completed) == 1
+    expected = (100 * 3 + 50 * 15) / 1_000_000
+    assert abs(completed[0].cost_usd - expected) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Provider-specific kwargs forwarded
+# ---------------------------------------------------------------------------
+
+
+def test_provider_specific_kwargs_forwarded_to_turn() -> None:
+    """``ToolUseLoop(**provider_specific)`` flows through to every
+    ``provider.turn()`` call — providers receive their opt-ins (and
+    ignore unknown ones)."""
+    fp = _FakeProvider([_text_response("ok")])
+    loop = ToolUseLoop(
+        fp, [_echo_tool()],
+        anthropic_task_budget_beta=True,
+        custom_flag="value",
+    )
+    loop.run("hi")
+    assert fp.calls[0]["provider_specific"] == {
+        "anthropic_task_budget_beta": True,
+        "custom_flag": "value",
+    }
+
+
+# ---------------------------------------------------------------------------
+# History resumption
+# ---------------------------------------------------------------------------
+
+
+def test_run_with_history_continues_from_prior_messages() -> None:
+    """``run_with_history`` accepts prior conversation; the result's
+    ``messages`` includes both prior + new turns — caller can persist
+    and resume."""
+    prior = [
+        Message(role="user", content=[TextBlock(text="earlier")]),
+        Message(role="assistant", content=[TextBlock(text="earlier reply")]),
+    ]
+    fp = _FakeProvider([_text_response("now-reply")])
+    loop = ToolUseLoop(fp, [_echo_tool()])
+    out = loop.run_with_history(prior, "now")
+    # Result messages: 2 prior + 1 new user prompt + 1 assistant reply.
+    assert len(out.messages) == 4
+    assert out.messages[0] is prior[0]
+    assert out.messages[1] is prior[1]
+    # Provider saw all messages on its single turn.
+    sent = fp.calls[0]["messages"]
+    assert len(sent) == 3                          # prior + new prompt
+    assert sent[-1].content[0].text == "now"
+
+
+def test_run_with_empty_history_works() -> None:
+    """Empty history is the same as fresh ``run()``."""
+    fp = _FakeProvider([_text_response("hi")])
+    loop = ToolUseLoop(fp, [_echo_tool()])
+    out = loop.run_with_history([], "first")
+    assert out.iterations == 1
+    assert out.messages[0].content[0].text == "first"
+
+
+# ---------------------------------------------------------------------------
+# Cache control + capability gating
+# ---------------------------------------------------------------------------
+
+
+def test_cache_breakpoint_count_zero_when_provider_lacks_caching() -> None:
+    """``TurnStarted.cache_breakpoints`` reports 0 on a non-caching
+    provider regardless of the loop's :class:`CacheControl` settings —
+    capability flag governs reality."""
+    fp = _FakeProvider([_text_response("ok")], prompt_caching=False)
+    seen: list[LoopEvent] = []
+    loop = ToolUseLoop(
+        fp, [_echo_tool()],
+        system="hello",
+        cache_control=CacheControl(system=True, tools=True),
+        events=seen.append,
+    )
+    loop.run("go")
+    started = next(e for e in seen if isinstance(e, TurnStarted))
+    assert started.cache_breakpoints == 0
+
+
+def test_cache_breakpoint_count_reflects_optins_when_supported() -> None:
+    """With caching support: count reflects which regions opted in."""
+    fp = _FakeProvider([_text_response("ok")], prompt_caching=True)
+    seen: list[LoopEvent] = []
+    loop = ToolUseLoop(
+        fp, [_echo_tool()],
+        system="hello",                               # caches if opted in
+        cache_control=CacheControl(system=True, tools=True),
+        events=seen.append,
+    )
+    loop.run("go")
+    started = next(e for e in seen if isinstance(e, TurnStarted))
+    assert started.cache_breakpoints == 2             # system + tools

--- a/core/llm/tool_use/tests/test_types.py
+++ b/core/llm/tool_use/tests/test_types.py
@@ -1,0 +1,202 @@
+"""Tests for ``core.llm.tool_use.types``.
+
+These are immutability + construction-shape sanity checks. The types
+have no logic of their own; behaviour assertions live in the loop and
+provider tests where the types get used.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.llm.tool_use import (
+    CacheControl,
+    ContextOverflow,
+    ContextPolicy,
+    CostBudgetExceeded,
+    LoopTerminated,
+    Message,
+    StopReason,
+    TextBlock,
+    ToolCall,
+    ToolCallDispatched,
+    ToolCallReturned,
+    ToolDef,
+    ToolLoopResult,
+    ToolResult,
+    TurnCompleted,
+    TurnResponse,
+    TurnStarted,
+)
+
+
+# --- StopReason ---------------------------------------------------------
+
+def test_stop_reason_has_six_provider_agnostic_values() -> None:
+    """The six values cover what every provider can normalise to.
+    Adding a seventh means re-checking the Anthropic / OpenAI / Gemini
+    mapping tables in :mod:`core.llm.tool_use.providers`. PAUSE_TURN
+    is Anthropic-specific (extended-thinking pause/resume) but lives
+    here so the loop can recognise the continuation case without
+    provider-specific branching."""
+    assert {r.name for r in StopReason} == {
+        "COMPLETE",
+        "NEEDS_TOOL_CALL",
+        "PAUSE_TURN",
+        "MAX_TOKENS",
+        "REFUSED",
+        "ERROR",
+    }
+
+
+# --- ToolDef + ToolCall + ToolResult -----------------------------------
+
+def test_tooldef_is_frozen() -> None:
+    td = ToolDef(name="t", description="d",
+                 input_schema={"type": "object"},
+                 handler=lambda _: "ok")
+    with pytest.raises(Exception):                  # FrozenInstanceError
+        td.name = "different"                        # type: ignore[misc]
+
+
+def test_toolcall_carries_provider_id() -> None:
+    """``id`` is provider-supplied (Anthropic ``toolu_*``, OpenAI
+    ``call_*``); the loop echoes it back verbatim on the matching
+    :class:`ToolResult`."""
+    call = ToolCall(id="toolu_abc", name="search", input={"q": "x"})
+    assert call.id == "toolu_abc"
+    assert call.name == "search"
+    assert call.input == {"q": "x"}
+
+
+def test_toolresult_default_is_not_error() -> None:
+    """Most tool results are successful — ``is_error`` defaults to
+    False so handlers don't have to remember to set it."""
+    r = ToolResult(tool_use_id="toolu_abc", content="ok")
+    assert r.is_error is False
+
+
+def test_toolresult_error_path() -> None:
+    r = ToolResult(tool_use_id="toolu_abc", content="boom",
+                   is_error=True)
+    assert r.is_error is True
+
+
+# --- Message -----------------------------------------------------------
+
+def test_message_carries_mixed_content() -> None:
+    """One assistant message can carry text + tool_calls; one user
+    message can carry text + tool_results — each provider's wire
+    converter handles the heterogeneous list."""
+    m = Message(
+        role="assistant",
+        content=[
+            TextBlock(text="checking..."),
+            ToolCall(id="t1", name="search", input={}),
+        ],
+    )
+    assert m.role == "assistant"
+    assert len(m.content) == 2
+    assert isinstance(m.content[0], TextBlock)
+    assert isinstance(m.content[1], ToolCall)
+
+
+# --- TurnResponse ------------------------------------------------------
+
+def test_turn_response_default_cache_tokens_zero() -> None:
+    """Providers that lack prompt caching leave the cache fields at
+    0 — capability check is via the provider's
+    ``supports_prompt_caching()`` flag, not by sniffing this field."""
+    r = TurnResponse(
+        content=[TextBlock(text="hi")],
+        stop_reason=StopReason.COMPLETE,
+        input_tokens=10, output_tokens=5,
+    )
+    assert r.cache_read_tokens == 0
+    assert r.cache_write_tokens == 0
+
+
+# --- CacheControl ------------------------------------------------------
+
+def test_cache_control_defaults() -> None:
+    """v1 default: cache the static parts (system + tools), don't cache
+    history (which rolls per turn). Callers who know the conversation
+    has a stable suffix opt in via ``history_through_index``."""
+    cc = CacheControl()
+    assert cc.system is True
+    assert cc.tools is True
+    assert cc.history_through_index is None
+
+
+def test_cache_control_per_region_opt_in() -> None:
+    cc = CacheControl(system=False, tools=True, history_through_index=4)
+    assert cc.system is False
+    assert cc.tools is True
+    assert cc.history_through_index == 4
+
+
+# --- ContextPolicy -----------------------------------------------------
+
+def test_context_policy_v1_values() -> None:
+    """v1 ships RAISE + TRUNCATE_OLDEST. SUMMARISE is deferred until
+    a real consumer asks (needs second-LLM summarisation pass)."""
+    assert {p.name for p in ContextPolicy} == {"RAISE", "TRUNCATE_OLDEST"}
+
+
+# --- Exception types ---------------------------------------------------
+
+def test_exceptions_are_runtime_errors() -> None:
+    """Both subclasses of ``RuntimeError`` so ``except RuntimeError``
+    catches them by default — and so callers can be specific when they
+    want differentiated handling."""
+    assert issubclass(CostBudgetExceeded, RuntimeError)
+    assert issubclass(ContextOverflow, RuntimeError)
+
+
+# --- LoopEvent shapes --------------------------------------------------
+
+def test_event_dataclasses_construct() -> None:
+    """Smoke-check each event variant since they're discriminated only
+    by class — a subscriber doing ``isinstance`` dispatch will only
+    match instances that construct cleanly."""
+    e1 = TurnStarted(iteration=0, input_token_estimate=100,
+                     cache_breakpoints=2)
+    assert e1.iteration == 0
+
+    resp = TurnResponse(content=[], stop_reason=StopReason.COMPLETE,
+                        input_tokens=0, output_tokens=0)
+    e2 = TurnCompleted(iteration=0, response=resp, cost_usd=0.0)
+    assert e2.cost_usd == 0.0
+
+    call = ToolCall(id="t", name="x", input={})
+    e3 = ToolCallDispatched(iteration=0, call=call)
+    assert e3.call.id == "t"
+
+    res = ToolResult(tool_use_id="t", content="ok")
+    e4 = ToolCallReturned(iteration=0, call_id="t",
+                          result=res, duration_s=0.05)
+    assert e4.duration_s == 0.05
+
+    e5 = LoopTerminated(reason="complete", iterations=3,
+                        total_cost_usd=0.012)
+    assert e5.reason == "complete"
+
+
+# --- ToolLoopResult ---------------------------------------------------
+
+def test_tool_loop_result_construction() -> None:
+    """The loop assembles this at the end; the test pins the public
+    shape so adding fields requires updating consumers explicitly."""
+    out = ToolLoopResult(
+        final_text="done",
+        terminal_tool_input={"verdict": "match"},
+        messages=[],
+        iterations=5,
+        tool_calls_made=3,
+        total_input_tokens=1500,
+        total_output_tokens=400,
+        total_cost_usd=0.012,
+        terminated_by="terminal_tool",
+    )
+    assert out.terminal_tool_input == {"verdict": "match"}
+    assert out.terminated_by == "terminal_tool"

--- a/core/llm/tool_use/types.py
+++ b/core/llm/tool_use/types.py
@@ -1,0 +1,401 @@
+"""Provider-agnostic types for the tool-use loop.
+
+This module is the single source of truth for the wire-shapes the
+:class:`ToolUseLoop` and any provider implementation pass between
+themselves. Every provider in ``core.llm.tool_use.providers`` translates
+its native wire format (Anthropic ``tool_use``/``tool_result`` blocks,
+OpenAI ``tool_calls``/``role:"tool"`` messages, Gemini's
+``function_call``/``function_response``, Ollama's tool-call shape) into
+the dataclasses defined here, and back out, on each turn.
+
+Design choices captured here that are easy to miss when reading code
+without context:
+
+- ``Message.content`` is heterogeneous (``TextBlock | ToolCall | ToolResult``)
+  but the *valid* mix depends on ``role`` — assistant turns may carry text
+  + tool_calls, user turns may carry text + tool_results. Type-checking
+  this strictly (``AssistantContent`` / ``UserContent`` newtypes) was
+  considered and rejected: the conversion code in each provider already
+  validates per-role, and lifting the constraint into the type system
+  pushes complexity to every consumer with no real win.
+
+- Tool ``handler`` is sync-only. Async / cancellation come via a parallel
+  ``AsyncToolUseLoop`` if/when a real consumer needs it. Wrapping
+  long-running work with ``tool_timeout_s`` at the loop level is the
+  v1 escape hatch.
+
+- ``StopReason`` is a provider-agnostic enum, not a string union. Each
+  provider maps its native vocabulary onto these five values; the loop
+  consumes the enum directly. Anthropic-only literals were deliberately
+  rejected so multi-provider downstreams don't silently drift.
+
+- ``CacheControl`` is per-region opt-in (system / tools /
+  history-through-index) rather than a single bool. This matches
+  Anthropic's actual cache-breakpoint semantics; providers that don't
+  support caching ignore it entirely (capability flag is False, the
+  loop still passes the struct through unchanged).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Literal, Union
+
+
+# ---------------------------------------------------------------------------
+# Stop reasons
+# ---------------------------------------------------------------------------
+
+
+class StopReason(Enum):
+    """Provider-agnostic terminal state of one turn.
+
+    Mappings (provider-side, in their respective ``turn()`` impls):
+
+    +------------------+------------------+----------------+----------------+
+    | This             | Anthropic        | OpenAI         | Gemini         |
+    +==================+==================+================+================+
+    | COMPLETE         | end_turn,        | stop           | STOP           |
+    |                  | stop_sequence    |                |                |
+    +------------------+------------------+----------------+----------------+
+    | NEEDS_TOOL_CALL  | tool_use         | tool_calls     | FUNCTION_CALL  |
+    +------------------+------------------+----------------+----------------+
+    | PAUSE_TURN       | pause_turn       | (none —        | (none —        |
+    |                  |                  | length covers) | length covers) |
+    +------------------+------------------+----------------+----------------+
+    | MAX_TOKENS       | max_tokens       | length         | MAX_TOKENS     |
+    +------------------+------------------+----------------+----------------+
+    | REFUSED          | refusal          | content_filter | SAFETY         |
+    +------------------+------------------+----------------+----------------+
+    | ERROR            | (transport fail, anything that doesn't map cleanly) |
+    +------------------+----------------------------------+-----------------+
+
+    ``PAUSE_TURN`` is Anthropic's signal that extended-thinking output
+    paused mid-stream and the client should re-send the conversation
+    (with the partial assistant turn appended) to resume. The
+    :class:`~.loop.ToolUseLoop` treats it as "continue" rather than
+    "terminate" — without that, long-thinking turns would terminate
+    prematurely as ``ERROR``.
+    """
+
+    COMPLETE = "complete"
+    NEEDS_TOOL_CALL = "needs_tool_call"
+    PAUSE_TURN = "pause_turn"
+    MAX_TOKENS = "max_tokens"
+    REFUSED = "refused"
+    ERROR = "error"
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions + call/result wire format
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ToolDef:
+    """A tool the model can call.
+
+    ``handler`` runs synchronously when :class:`ToolUseLoop` dispatches
+    a model-emitted :class:`ToolCall`. Returning a ``str`` is the wire
+    format: JSON-encode structured data when the model expects more
+    than free text. The loop wraps handler exceptions per the
+    ``terminate_on_handler_error`` policy on the loop (default: feed
+    the exception text back to the model as a ``ToolResult`` with
+    ``is_error=True`` so the model can adapt).
+    """
+
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+    handler: Callable[[dict[str, Any]], str]
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """Model-emitted request to call a tool. Surfaced as one of the
+    content blocks of an assistant-role :class:`Message`."""
+
+    id: str
+    name: str
+    input: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ToolResult:
+    """Caller's response to a :class:`ToolCall`, fed back to the model
+    on the next turn. Carried as a content block of a user-role
+    :class:`Message`. ``is_error=True`` lets the model distinguish
+    legitimate empty results from handler failures."""
+
+    tool_use_id: str
+    content: str
+    is_error: bool = False
+
+
+@dataclass(frozen=True)
+class TextBlock:
+    """Plain text emitted by either role."""
+
+    text: str
+
+
+# ---------------------------------------------------------------------------
+# Conversation history
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Message:
+    """One turn of conversation history.
+
+    ``content`` is heterogeneous and provider-agnostic:
+
+      * Assistant turns may contain :class:`TextBlock` + :class:`ToolCall`
+        items, in any order — the model emits text and tool calls
+        intermixed.
+      * User turns may contain :class:`TextBlock` + :class:`ToolResult`
+        items. Most often they're a single text block (the initial
+        prompt) or a list of results (mid-loop response to one or more
+        tool calls).
+
+    The "wrong" combinations (e.g., a :class:`ToolResult` in an
+    assistant message) are caught by each provider's wire-format
+    converter, which knows how to translate role-appropriate content
+    only.
+    """
+
+    role: Literal["user", "assistant"]
+    content: list[TextBlock | ToolCall | ToolResult]
+
+
+# ---------------------------------------------------------------------------
+# Per-turn response (one provider round-trip)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TurnResponse:
+    """Result of one :meth:`ToolUseProvider.turn` call.
+
+    The :class:`ToolUseLoop` inspects ``content`` to decide whether to
+    dispatch tools (any :class:`ToolCall` present → dispatch and append
+    results to history) or terminate (text-only with
+    ``stop_reason == COMPLETE``).
+
+    Cache-token fields are 0 on providers that lack prompt caching;
+    this is informational, not a capability check — callers test
+    ``provider.supports_prompt_caching()`` for capability.
+    """
+
+    content: list[TextBlock | ToolCall]
+    stop_reason: StopReason
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Cache-control opt-ins
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CacheControl:
+    """Per-region cache opt-ins for providers that support prompt caching.
+
+    Anthropic places one cache breakpoint per opted-in region. Other
+    providers ignore this entirely (their ``turn()`` implementations
+    don't read any field, capability flag
+    :meth:`ToolUseProvider.supports_prompt_caching` returns False).
+
+    ``history_through_index``: when set to ``i``, the cache breakpoint
+    is placed on the last block of ``messages[i]`` — Anthropic caches
+    everything up to and including that point. Use to cache the stable
+    prefix of a long conversation while leaving the rolling tail
+    uncached. ``None`` skips history caching entirely.
+    """
+
+    system: bool = True
+    tools: bool = True
+    history_through_index: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# Context-window policy
+# ---------------------------------------------------------------------------
+
+
+class ContextPolicy(Enum):
+    """How the loop handles a turn whose request would exceed the
+    model's context window.
+
+    ``RAISE`` is the v1 default — fail loud rather than silently drop
+    history that the model needed for correctness. ``TRUNCATE_OLDEST``
+    is the escape hatch for long-running agents that accept lossy
+    history; it drops oldest user/assistant turn pairs (preserving
+    pairing so tool-results don't dangle without their tool-calls).
+    """
+
+    RAISE = "raise"
+    TRUNCATE_OLDEST = "truncate_oldest"
+    # SUMMARISE — deferred. Needs a separate LLM call to compress
+    # history into a synopsis turn; design TBD when a consumer asks.
+
+
+class ContextOverflow(RuntimeError):
+    """Raised by the loop when ``ContextPolicy.RAISE`` is in effect and
+    the next turn's request would exceed the provider's context
+    window."""
+
+
+# ---------------------------------------------------------------------------
+# Cost-budget enforcement
+# ---------------------------------------------------------------------------
+
+
+class CostBudgetExceeded(RuntimeError):
+    """Raised pre-flight when the next turn's cost estimate would push
+    cumulative cost past ``ToolUseLoop(max_cost_usd=...)``. Parity with
+    cve-diff's existing per-CVE cost cap.
+
+    Pre-flight only: a single surprise-large response cannot be blocked
+    until we know its cost, but subsequent calls in the same loop run
+    cannot pile on once the cap is reached.
+    """
+
+
+class ToolHandlerTimeout(RuntimeError):
+    """Raised when a tool handler exceeds ``tool_timeout_s`` AND the
+    loop is configured with ``terminate_on_handler_error=True``.
+
+    Symmetric with the loop's behaviour for handler exceptions in the
+    same mode: both fail-fast paths re-raise rather than feeding the
+    error back to the model. Without ``terminate_on_handler_error``
+    the loop converts a timeout into an ``is_error=True``
+    :class:`ToolResult` and continues.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Structured event stream (first-class observability)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TurnStarted:
+    iteration: int
+    input_token_estimate: int
+    cache_breakpoints: int
+
+
+@dataclass(frozen=True)
+class TurnCompleted:
+    iteration: int
+    response: TurnResponse
+    cost_usd: float
+
+
+@dataclass(frozen=True)
+class ToolCallDispatched:
+    iteration: int
+    call: ToolCall
+
+
+@dataclass(frozen=True)
+class ToolCallReturned:
+    iteration: int
+    call_id: str
+    result: ToolResult
+    duration_s: float
+
+
+@dataclass(frozen=True)
+class LoopTerminated:
+    """Emitted as the final event of a :meth:`ToolUseLoop.run` call.
+
+    ``reason`` mirrors :attr:`ToolLoopResult.terminated_by` — the same
+    string is in both places so consumers can either subscribe to
+    events live or inspect the result after the fact.
+
+    ``iterations`` always reports turns completed: pre-flight gate
+    termination at iteration N reports ``N`` (N turns 0..N-1 done);
+    post-turn termination at iteration N reports ``N+1`` (N+1 turns
+    0..N done). Same convention as :attr:`ToolLoopResult.iterations`.
+    """
+
+    reason: Literal[
+        "complete",                  # COMPLETE response from model
+        "terminal_tool",             # model called designated terminal tool
+        "max_iterations",            # loop hit max_iterations cap
+        "max_cost_usd",              # cumulative cost crossed cap
+        "max_tokens",                # provider truncated response (no tool calls)
+        "refused",                   # provider safety / content filter
+        "tool_error",                # handler exception or timeout under terminate_on_handler_error
+        "tool_timeout",              # handler timeout, not configured to terminate
+        "context_overflow",          # request would exceed context window
+        "provider_error",            # transport / API failure after retries
+    ]
+    iterations: int
+    total_cost_usd: float
+
+
+LoopEvent = Union[
+    TurnStarted,
+    TurnCompleted,
+    ToolCallDispatched,
+    ToolCallReturned,
+    LoopTerminated,
+]
+
+
+# ---------------------------------------------------------------------------
+# Final loop result
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ToolLoopResult:
+    """Final outcome of a :meth:`ToolUseLoop.run` call.
+
+    ``final_text`` is the joined :class:`TextBlock` text from the
+    LAST assistant turn. For ``COMPLETE`` termination this is the
+    model's final answer. For ``terminal_tool`` termination it's the
+    model's commentary text adjacent to the terminating tool call —
+    typically empty (model just calls the tool) or a short reasoning
+    note. Use :attr:`terminal_tool_input` for the structured payload.
+
+    ``terminal_tool_input`` is the dict the model passed as ``input``
+    to its designated ``terminal_tool``. cve-diff's ``submit_result``
+    pattern uses this to surface validated SHAs / verdicts as a typed
+    dict instead of relying on the model to repeat them in free text.
+    ``None`` for runs that didn't terminate via terminal tool.
+
+    ``iterations`` reports turns completed (same convention as
+    :attr:`LoopTerminated.iterations`). For ``max_iterations`` it
+    equals the configured cap; for ``complete`` / ``terminal_tool``
+    it's the iteration index of the final turn + 1.
+    """
+
+    final_text: str
+    terminal_tool_input: dict[str, Any] | None
+    messages: list[Message]
+    iterations: int
+    tool_calls_made: int
+    total_input_tokens: int
+    total_output_tokens: int
+    total_cost_usd: float
+    terminated_by: Literal[
+        "complete",
+        "terminal_tool",
+        "max_iterations",
+        "max_cost_usd",
+        "max_tokens",
+        "refused",
+        "tool_error",
+        "tool_timeout",
+        "context_overflow",
+        "provider_error",
+    ]


### PR DESCRIPTION
Adds ``core/llm/tool_use/``:

  * ``types.py``     — frozen wire-shape dataclasses, ``StopReason``
    enum, ``CacheControl`` per-region opt-ins, ``LoopEvent`` union
    for structured telemetry, ``ToolHandlerTimeout`` /
    ``CostBudgetExceeded`` / ``ContextOverflow`` exceptions.
  * ``providers.py`` — ``ToolUseProvider`` Protocol with capability
    flags (tool_use / prompt_caching / parallel_tools) and one
    ``turn()`` primitive per backend.
  * ``loop.py``      — ``ToolUseLoop`` runner. Multi-turn dispatch
    with ``max_cost_usd`` cap, ``ContextPolicy.{RAISE,
    TRUNCATE_OLDEST}``, per-tool timeout watchdog, ``terminal_tool``
    recognition surfacing structured payload via
    ``ToolLoopResult.terminal_tool_input``, handler-error policy
    (feed-back-to-model default; ``terminate_on_handler_error``
    fail-fast).
  * ``anthropic.py`` — ``AnthropicToolUseProvider``. Native
    ``messages.create``, ``cache_control`` on system / tools /
    history regions, task-budget beta with the required
    ``betas=["task-budgets-2026-03-13"]`` parameter, cost
    computation with cache-write 1.25× and cache-read 0.1×
    multipliers, retry-with-backoff on transient errors.

80 tests in ``core/llm/tool_use/tests/`` covering loop logic against an in-memory fake provider, Anthropic provider against a stub client, and schema-validated tests using real ``anthropic.types.{Message, Usage, TextBlock, ToolUseBlock}`` to catch field-name drift. Full ``core/llm/`` suite: 292 passed.