### PR TITLE
core/llm/tool_use: anthropic_task_budget_tokens kwarg

### DIFF
--- a/core/llm/tool_use/anthropic.py
+++ b/core/llm/tool_use/anthropic.py
@@ -197,6 +197,7 @@ class AnthropicToolUseProvider:
         max_tokens: int = 4096,
         cache_control: CacheControl = CacheControl(),
         anthropic_task_budget_beta: bool = False,
+        anthropic_task_budget_tokens: int | None = None,
         **_unused: Any,
     ) -> TurnResponse:
         """Send one round-trip to Anthropic.
@@ -204,6 +205,18 @@ class AnthropicToolUseProvider:
         Provider-specific kwargs:
           * ``anthropic_task_budget_beta``: route via
             ``client.beta.messages.create`` (cost-cap beta endpoint).
+            Activating the beta requires both this flag (sets the
+            ``betas=["task-budgets-..."]`` header) AND
+            ``anthropic_task_budget_tokens`` (sets the
+            ``output_config.task_budget`` request body).
+          * ``anthropic_task_budget_tokens``: total token budget
+            communicated to the model via
+            ``output_config: {task_budget: {type: "tokens", total: N}}``.
+            The model self-regulates against this countdown mid-loop;
+            without it the beta header is dead-on-arrival (server
+            accepts the request but no budget is in effect). Required
+            when ``anthropic_task_budget_beta=True``; ignored
+            otherwise.
 
         Transient errors (APIConnectionError, 429, 5xx) are retried
         internally with exponential backoff up to ``max_retries``
@@ -213,6 +226,13 @@ class AnthropicToolUseProvider:
         level and ignored — preserves graceful degradation across
         consumers but makes typos discoverable.
         """
+        if anthropic_task_budget_beta and anthropic_task_budget_tokens is None:
+            raise ValueError(
+                "anthropic_task_budget_beta=True requires "
+                "anthropic_task_budget_tokens=N (total token budget the "
+                "model self-regulates against). Without it the beta "
+                "endpoint accepts the request but no budget is enforced."
+            )
         if _unused:
             logger.debug(
                 "anthropic.turn: ignoring unrecognised kwargs: %s",
@@ -280,6 +300,12 @@ class AnthropicToolUseProvider:
         }
         if anthropic_task_budget_beta:
             kwargs["betas"] = [_TASK_BUDGET_BETA]
+            kwargs["output_config"] = {
+                "task_budget": {
+                    "type": "tokens",
+                    "total": anthropic_task_budget_tokens,
+                },
+            }
         if system_arg is not None:
             kwargs["system"] = system_arg
 

--- a/core/llm/tool_use/tests/test_anthropic.py
+++ b/core/llm/tool_use/tests/test_anthropic.py
@@ -423,7 +423,8 @@ def test_beta_task_budget_routes_to_beta_messages() -> None:
     ``client.beta.messages.create`` instead of the standard endpoint
     AND passes the ``betas=[...]`` parameter — without the parameter
     the beta endpoint accepts the request but doesn't actually
-    activate the beta (the bug v1 of this code shipped with)."""
+    activate the beta. Also requires ``anthropic_task_budget_tokens``
+    so the ``output_config`` request body is set."""
     from core.llm.tool_use.anthropic import _TASK_BUDGET_BETA
 
     p, c = _provider_with_stub()
@@ -434,17 +435,41 @@ def test_beta_task_budget_routes_to_beta_messages() -> None:
         messages=[Message(role="user", content=[TextBlock(text="x")])],
         tools=[],
         anthropic_task_budget_beta=True,
+        anthropic_task_budget_tokens=8000,
     )
     assert len(c.messages.calls) == 0                # standard endpoint not called
     assert len(c.beta.messages.calls) == 1           # beta endpoint called
     sent = c.beta.messages.calls[0]
     assert sent.get("betas") == [_TASK_BUDGET_BETA]
+    assert sent.get("output_config") == {
+        "task_budget": {"type": "tokens", "total": 8000},
+    }
 
 
-def test_standard_endpoint_does_not_carry_betas_kwarg() -> None:
+def test_beta_without_token_budget_raises() -> None:
+    """``anthropic_task_budget_beta=True`` without
+    ``anthropic_task_budget_tokens`` raises at request time — the beta
+    endpoint accepts the request without ``output_config`` but no
+    budget is enforced; failing loud here surfaces the misconfiguration
+    immediately rather than silently producing uncapped runs."""
+    p, c = _provider_with_stub()
+    with pytest.raises(ValueError, match="anthropic_task_budget_tokens=N"):
+        p.turn(
+            messages=[Message(role="user", content=[TextBlock(text="x")])],
+            tools=[],
+            anthropic_task_budget_beta=True,
+        )
+    # Neither endpoint was called — fail-loud happens pre-flight.
+    assert len(c.messages.calls) == 0
+    assert len(c.beta.messages.calls) == 0
+
+
+def test_standard_endpoint_does_not_carry_beta_kwargs() -> None:
     """Without ``anthropic_task_budget_beta=True`` the request goes
-    via the standard endpoint and must NOT carry a ``betas`` kwarg —
-    the standard endpoint rejects unknown parameters."""
+    via the standard endpoint and must NOT carry ``betas`` or
+    ``output_config`` — the standard endpoint rejects unknown
+    parameters. Passing ``anthropic_task_budget_tokens`` alone (no
+    beta flag) is accepted but has no effect."""
     p, c = _provider_with_stub()
     c.messages.responses.append(_StubResponse(
         [_StubBlock("text", text="ok")], stop_reason="end_turn",
@@ -452,9 +477,12 @@ def test_standard_endpoint_does_not_carry_betas_kwarg() -> None:
     p.turn(
         messages=[Message(role="user", content=[TextBlock(text="x")])],
         tools=[],
+        anthropic_task_budget_tokens=8000,            # no-op without beta=True
     )
     assert len(c.messages.calls) == 1
-    assert "betas" not in c.messages.calls[0]
+    sent = c.messages.calls[0]
+    assert "betas" not in sent
+    assert "output_config" not in sent
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The Anthropic task-budget beta requires both a ``betas=[...]`` header AND an ``output_config: {task_budget: {type: "tokens", total: N}}`` request body. v1 of ``AnthropicToolUseProvider`` set the header but not the body — server accepts the request but no budget is in effect, so the beta is dead-on-arrival.

Adds ``anthropic_task_budget_tokens: int | None = None`` to ``turn()``. When ``anthropic_task_budget_beta=True``, also requires this value (raises ``ValueError`` pre-flight when it's missing — fail-loud on misconfiguration rather than silently producing uncapped runs). Test coverage expanded: assert ``output_config`` shape on the beta path, assert standard endpoint doesn't carry either ``betas`` or ``output_config``, assert the fail-loud path.