### PR TITLE
core/llm/tool_use: max_seconds wall-clock budget on ToolUseLoop

### DIFF
--- a/core/llm/tool_use/loop.py
+++ b/core/llm/tool_use/loop.py
@@ -95,6 +95,7 @@ class ToolUseLoop:
         terminal_tool: str | None = None,
         max_iterations: int = 50,
         max_cost_usd: float | None = None,
+        max_seconds: float | None = None,
         tool_timeout_s: float | None = None,
         context_policy: ContextPolicy = ContextPolicy.RAISE,
         max_tokens_per_turn: int = 4096,
@@ -126,6 +127,7 @@ class ToolUseLoop:
         self._terminal_tool = terminal_tool
         self._max_iterations = max_iterations
         self._max_cost_usd = max_cost_usd
+        self._max_seconds = max_seconds
         self._tool_timeout_s = tool_timeout_s
         self._context_policy = context_policy
         self._max_tokens_per_turn = max_tokens_per_turn
@@ -165,6 +167,7 @@ class ToolUseLoop:
         total_cost_usd = 0.0
         tool_calls_made = 0
         terminal_tool_input: dict[str, Any] | None = None
+        wall_start = time.monotonic()
 
         for iteration in range(self._max_iterations):
             # ---- pre-flight: cost budget --------------------------------
@@ -181,6 +184,34 @@ class ToolUseLoop:
                     f"cost budget ${self._max_cost_usd:.4f} reached "
                     f"(cumulative ${total_cost_usd:.4f}); aborting "
                     "before next turn"
+                )
+
+            # ---- pre-flight: wall-clock budget --------------------------
+            # Caps the *whole run*, not per-turn. Useful when the loop
+            # is bounded by API latency on slow days (e.g., Anthropic
+            # 529-overloaded waves) where ``max_iterations`` and
+            # ``max_cost_usd`` haven't fired but the operator-side
+            # SLA has. Pre-flight only — a single in-flight ``turn()``
+            # can blow past the cap because we don't preempt it.
+            if (
+                self._max_seconds is not None
+                and (time.monotonic() - wall_start) >= self._max_seconds
+            ):
+                self._emit(LoopTerminated(
+                    reason="max_seconds",
+                    iterations=iteration,
+                    total_cost_usd=total_cost_usd,
+                ))
+                return ToolLoopResult(
+                    final_text="",
+                    terminal_tool_input=None,
+                    messages=messages,
+                    iterations=iteration,
+                    tool_calls_made=tool_calls_made,
+                    total_input_tokens=total_input_tokens,
+                    total_output_tokens=total_output_tokens,
+                    total_cost_usd=total_cost_usd,
+                    terminated_by="max_seconds",
                 )
 
             # ---- pre-flight: context window -----------------------------

--- a/core/llm/tool_use/tests/test_loop.py
+++ b/core/llm/tool_use/tests/test_loop.py
@@ -301,6 +301,99 @@ def test_max_cost_usd_terminates_pre_flight() -> None:
     assert len(fp.calls) == 2
 
 
+def test_max_seconds_terminates_pre_flight(monkeypatch) -> None:
+    """Wall-clock budget caps the whole run. Pre-flight check before
+    each iteration; once elapsed >= max_seconds, the loop returns a
+    ``terminated_by="max_seconds"`` ToolLoopResult — distinct from
+    cost / iteration / context termination so callers can treat
+    "API was slow today" differently from "we made too many calls"."""
+    # Fake clock: each ``time.monotonic()`` call advances 4 seconds.
+    # First call (wall_start) → 0; second (iter 0 check) → 4;
+    # third (iter 1 check) → 8 → triggers cap at max_seconds=6.
+    clock = {"t": 0.0}
+    def _tick() -> float:
+        v = clock["t"]
+        clock["t"] += 4.0
+        return v
+    monkeypatch.setattr("core.llm.tool_use.loop.time.monotonic", _tick)
+
+    fp = _FakeProvider([
+        _tool_call_response(("c1", "echo", {})),
+        _tool_call_response(("c2", "echo", {})),                   # never reached
+    ])
+    loop = ToolUseLoop(fp, [_echo_tool()], max_seconds=6.0)
+    out = loop.run("slow API")
+    assert out.terminated_by == "max_seconds"
+    assert len(fp.calls) == 1                                       # 1 turn before cap
+
+
+def test_max_seconds_emits_loop_terminated_event() -> None:
+    """The structured event stream surfaces ``LoopTerminated(reason=
+    "max_seconds")`` so subscribers can distinguish wall-clock cap
+    from other termination reasons."""
+    events: list[Any] = []
+    fp = _FakeProvider([
+        _tool_call_response(("c1", "echo", {})),
+    ] * 50)
+    loop = ToolUseLoop(
+        fp, [_echo_tool()],
+        max_seconds=0.0,                                            # immediate cap
+        events=events.append,
+    )
+    out = loop.run("hi")
+    assert out.terminated_by == "max_seconds"
+    terminated = [e for e in events if isinstance(e, LoopTerminated)]
+    assert len(terminated) == 1
+    assert terminated[0].reason == "max_seconds"
+
+
+def test_max_seconds_none_means_no_cap() -> None:
+    """Default behaviour preserved: ``max_seconds=None`` (the default)
+    leaves the wall-clock check disabled. The loop runs to natural
+    completion regardless of how long it takes."""
+    fp = _FakeProvider([_text_response("done")])
+    loop = ToolUseLoop(fp, [_echo_tool()])                          # no max_seconds
+    out = loop.run("hi")
+    assert out.terminated_by == "complete"
+
+
+def test_max_seconds_real_clock_e2e() -> None:
+    """End-to-end against real ``time.monotonic`` (no monkeypatch).
+
+    Verifies the gate fires on actual wall-clock — catches bugs the
+    determinism-mocked tests above can't, e.g. ``time.time()`` vs
+    ``time.monotonic()`` mixups, sign errors in the elapsed
+    computation, or slipped imports of the clock function. ~1s of
+    test time; a slow-handler provider sleeps 0.3s per turn, the
+    cap fires after ~3 turns of a max_seconds=1.0 budget.
+    """
+    class _SlowProvider(_FakeProvider):
+        """Sleep mid-turn to consume real wall-clock between cap checks."""
+        def turn(self, messages, tools, *, system, max_tokens,
+                 cache_control, **provider_specific) -> TurnResponse:
+            time.sleep(0.3)
+            return super().turn(
+                messages, tools, system=system, max_tokens=max_tokens,
+                cache_control=cache_control, **provider_specific,
+            )
+
+    fp = _SlowProvider([
+        _tool_call_response(("c", "echo", {})) for _ in range(20)
+    ])
+    loop = ToolUseLoop(fp, [_echo_tool()], max_seconds=1.0)
+    out = loop.run("slow-api day")
+
+    assert out.terminated_by == "max_seconds"
+    # Expected ~3 turns at 0.3s/turn under a 1.0s cap, but timing slop
+    # under load (CI jitter, GC pauses) widens the window. The
+    # invariant is "the cap fired and bounded iterations" — exact count
+    # is timing-dependent.
+    assert 1 <= out.iterations <= 6
+    # Sanity: at least one turn ran (cap doesn't fire pre-flight on
+    # iter 0 because elapsed is ~0).
+    assert len(fp.calls) >= 1
+
+
 def test_cost_tracking_aggregates_across_turns() -> None:
     """``total_cost_usd`` reports the sum of provider.compute_cost()
     over all turns. With 2 turns at (100*3 + 50*15)/1M = $0.00105 each."""

--- a/core/llm/tool_use/types.py
+++ b/core/llm/tool_use/types.py
@@ -339,6 +339,7 @@ class LoopTerminated:
         "terminal_tool",             # model called designated terminal tool
         "max_iterations",            # loop hit max_iterations cap
         "max_cost_usd",              # cumulative cost crossed cap
+        "max_seconds",               # wall-clock budget exceeded
         "max_tokens",                # provider truncated response (no tool calls)
         "refused",                   # provider safety / content filter
         "tool_error",                # handler exception or timeout under terminate_on_handler_error
@@ -400,6 +401,7 @@ class ToolLoopResult:
         "terminal_tool",
         "max_iterations",
         "max_cost_usd",
+        "max_seconds",
         "max_tokens",
         "refused",
         "tool_error",


### PR DESCRIPTION
Adds an optional ``max_seconds`` cap to the loop. Pre-flight check before each iteration; once elapsed crosses the threshold the loop returns a ToolLoopResult with terminated_by="max_seconds" — distinct from cost / iteration / context termination so callers can treat "API was slow today" differently from "we made too many calls".

Default None preserves existing behaviour. Cost-budget continues to raise CostBudgetExceeded; wall-clock returns gracefully (matching max_iterations) because it's an agreed stop, not a failure. In-flight turn() calls are not preempted — a single slow round-trip can exceed the cap by its own duration.

Closes the substrate gap that cve-diff Phase 2 will need: cve-diff's existing AgentLoop has a budget_s=720 wall-clock cap that doesn't have a substrate equivalent today.