### PR TITLE
core/llm: explicit preference + Claude Code as a fully usable provider

### DIFF
--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -290,6 +290,29 @@ class LLMClient:
 
         return self.providers[key]
 
+    @property
+    def primary_provider(self) -> LLMProvider:
+        """The :class:`LLMProvider` for the configured ``primary_model``.
+
+        Exposed publicly so consumers that need direct provider access
+        — typically for tool-use loops via :class:`core.llm.tool_use.ToolUseLoop` —
+        can reach it without going through :meth:`generate`. Cached;
+        the same instance is returned across calls.
+
+        Raises ``RuntimeError`` if no primary model is configured (the
+        client should normally not have been constructed in that
+        case — :func:`packages.llm_analysis.get_client` returns
+        ``None`` instead).
+        """
+        if self.config.primary_model is None:
+            raise RuntimeError(
+                "LLMClient has no primary_model configured; cannot "
+                "expose primary_provider. Use packages.llm_analysis."
+                "get_client() which returns None when no provider is "
+                "available, instead of constructing LLMClient directly."
+            )
+        return self._get_provider(self.config.primary_model)
+
     def _get_cache_key(self, prompt: str, system_prompt: Optional[str], model: str) -> str:
         """Generate cache key for prompt."""
         content = f"{model}:{system_prompt or ''}:{prompt}"

--- a/core/llm/config.py
+++ b/core/llm/config.py
@@ -189,92 +189,201 @@ def _get_best_thinking_model() -> Optional['ModelConfig']:
     return best_model
 
 
-def _get_default_primary_model() -> Optional['ModelConfig']:
+# ---------------------------------------------------------------------------
+# Per-provider config builders.
+# ---------------------------------------------------------------------------
+#
+# Each builder returns a ``ModelConfig`` if the provider is usable in the
+# current environment, otherwise ``None``. ``_get_default_primary_model``
+# iterates these in order; ``prefer=...`` re-orders the iteration so a
+# consumer can express its own preference (e.g., cve-diff prefers
+# Anthropic for cache-control savings) without depending on the default
+# autodetect order — which would silently regress consumer behaviour if
+# the default were ever re-tuned for other reasons.
+
+
+def _build_anthropic_config() -> Optional['ModelConfig']:
+    if not os.getenv("ANTHROPIC_API_KEY"):
+        return None
+    default_model = PROVIDER_DEFAULT_MODELS["anthropic"]
+    limits = MODEL_LIMITS.get(default_model, {})
+    costs = MODEL_COSTS.get(default_model, {})
+    return ModelConfig(
+        provider="anthropic",
+        model_name=default_model,
+        api_key=os.getenv("ANTHROPIC_API_KEY"),
+        max_tokens=limits.get("max_output", 32000),
+        max_context=limits.get("max_context", 1000000),
+        temperature=0.7,
+        cost_per_1k_tokens=(costs.get("input", 0.015) + costs.get("output", 0.075)) / 2,
+    )
+
+
+def _build_openai_compat_config(provider_name: str) -> Optional['ModelConfig']:
+    """Generic builder for OpenAI / Gemini / Mistral — same shape, different env var + endpoint."""
+    env_var_map = {"openai": "OPENAI_API_KEY", "gemini": "GEMINI_API_KEY", "mistral": "MISTRAL_API_KEY"}
+    api_key = os.getenv(env_var_map[provider_name])
+    if not api_key:
+        return None
+    default_model = PROVIDER_DEFAULT_MODELS[provider_name]
+    limits = MODEL_LIMITS.get(default_model, {})
+    costs = MODEL_COSTS.get(default_model, {})
+    avg_cost = (costs.get("input", 0.005) + costs.get("output", 0.005)) / 2 if costs else 0.002
+    return ModelConfig(
+        provider=provider_name,
+        model_name=default_model,
+        api_key=api_key,
+        api_base=PROVIDER_ENDPOINTS[provider_name],
+        max_tokens=limits.get("max_output", 8192),
+        max_context=limits.get("max_context", 128000),
+        temperature=0.7,
+        cost_per_1k_tokens=avg_cost,
+    )
+
+
+def _build_ollama_config() -> Optional['ModelConfig']:
+    from core.config import RaptorConfig
+    ollama_models = _get_available_ollama_models()
+    if not ollama_models:
+        return None
+    preferred = ['mistral', 'qwen', 'codellama', 'llama', 'gemma', 'deepseek-coder', 'deepseek']
+    selected_model = ollama_models[0]
+    for pref in preferred:
+        for model in ollama_models:
+            if pref in model.lower():
+                selected_model = model
+                break
+        if selected_model != ollama_models[0]:
+            break
+    ollama_base = _validate_ollama_url(RaptorConfig.OLLAMA_HOST)
+    if selected_model not in MODEL_LIMITS:
+        logger.info(
+            f"Model '{selected_model}' not in MODEL_LIMITS — using defaults "
+            f"(max_context=32000, max_output=4096). Override in models.json if needed."
+        )
+    return ModelConfig(
+        provider="ollama",
+        model_name=selected_model,
+        api_base=f"{ollama_base}/v1",
+        max_tokens=4096,
+        temperature=0.7,
+        cost_per_1k_tokens=0.0,
+    )
+
+
+def _build_claudecode_config() -> Optional['ModelConfig']:
+    """Last-resort fallback: ``claude`` CLI on PATH, no API key needed.
+    Slower (subprocess + ``--json-schema`` structured output for
+    tool-use) but works for users who only have Claude Code installed.
+
+    ``timeout=300`` is calibrated from real-CC runs: simple turns are
+    5-15s, ``--json-schema`` against a rich tool catalog can push to
+    60-180s. 300s gives 2-3x headroom for worst case without letting
+    a single turn consume a whole ``ToolUseLoop.max_seconds`` budget.
+    Cloud APIs default to 120s in ``ModelConfig`` (well-tuned for
+    them); CC's subprocess + structured-output overhead needs more.
+    """
+    import shutil
+    if not shutil.which("claude"):
+        return None
+    default_model = PROVIDER_DEFAULT_MODELS["anthropic"]
+    limits = MODEL_LIMITS.get(default_model, {})
+    return ModelConfig(
+        provider="claudecode",
+        model_name=default_model,
+        api_key=None,
+        max_tokens=limits.get("max_output", 32000),
+        max_context=limits.get("max_context", 1000000),
+        temperature=0.7,
+        timeout=300,
+        cost_per_1k_tokens=0.0,
+    )
+
+
+_PROVIDER_BUILDERS = {
+    "anthropic":  _build_anthropic_config,
+    "openai":     lambda: _build_openai_compat_config("openai"),
+    "gemini":     lambda: _build_openai_compat_config("gemini"),
+    "mistral":    lambda: _build_openai_compat_config("mistral"),
+    "ollama":     _build_ollama_config,
+    "claudecode": _build_claudecode_config,
+}
+
+# Default order. Anthropic first (cache-control + task-budget beta —
+# the only provider where those matter natively). Ollama before
+# claudecode because Ollama is a deliberate operator setup; CC is the
+# absolute last resort.
+_DEFAULT_PROVIDER_ORDER = (
+    "anthropic", "openai", "gemini", "mistral", "ollama", "claudecode",
+)
+
+
+def _get_default_primary_model(
+    prefer: Optional[List[str]] = None,
+) -> Optional['ModelConfig']:
     """
     Get default primary model based on available providers.
 
-    Strategy:
-    1. Check if any external LLM is available (cached detection)
-    2. Try automatic thinking model selection (reads config file)
-    3. Fall back to API key detection with manual config
-    4. Fall back to Ollama if no cloud providers available
+    Resolution order:
+    1. **Preferred providers via env var** (when ``prefer`` set).
+       Try each named provider in order; skip silently if absent.
+    2. **Operator's thinking-model config** (``~/.config/raptor/models.json``).
+       Honoured even when ``prefer`` is set — picks up
+       provider+key combinations that don't fit the env-var
+       convention (e.g. Gemini via Vertex auth). When ``prefer`` is
+       set, only return it if its provider matches the preference.
+    3. **Default-order autodetect** via env var: Anthropic > OpenAI
+       > Gemini > Mistral > Ollama > Claude Code (subprocess,
+       absolute last resort).
+
+    ``prefer`` is lenient: unknown / unavailable preferred providers
+    are silently skipped. A consumer expresses preference via this
+    arg to avoid depending on the default-order convention staying
+    Anthropic-first — e.g. cve-diff prefers Anthropic for
+    ``cache_control`` + task-budget savings, and that linkage should
+    be explicit in code rather than coincidence with the default.
     """
-    # These are already imported at module level but we use them here
-    # for clarity — detect_llm_availability, _get_available_ollama_models,
-    # _validate_ollama_url come from .detection (imported at top of file)
-    from core.config import RaptorConfig
+    if isinstance(prefer, str):
+        prefer = [prefer]
+    prefer_set = set(prefer) if prefer else None
 
-    availability = detect_llm_availability()
-    if not availability.external_llm:
-        return None
+    # Step 1: preferred providers via env var (consumer's explicit
+    # signal — try them before any other detection).
+    if prefer:
+        for name in prefer:
+            builder = _PROVIDER_BUILDERS.get(name)
+            if builder is None:
+                logger.warning(
+                    f"_get_default_primary_model: unknown preferred "
+                    f"provider {name!r} — skipping"
+                )
+                continue
+            config = builder()
+            if config is not None:
+                return config
 
-    # Try automatic thinking model selection first
+    # Step 2: operator's thinking-model config (file-based; covers
+    # non-env-var setups like Gemini via Vertex). The operator's
+    # explicit choice beats env-var defaults — if they configured
+    # Gemini in ``~/.config/raptor/models.json``, respect that even
+    # when OPENAI_API_KEY happens to be set as an env var.
     thinking_model = _get_best_thinking_model()
     if thinking_model and thinking_model.api_key:
-        logger.info(f"Using automatic thinking model: {thinking_model.provider}/{thinking_model.model_name}")
+        logger.info(
+            f"Using automatic thinking model: "
+            f"{thinking_model.provider}/{thinking_model.model_name}"
+        )
         return thinking_model
 
-    # Fallback: Check for API keys manually
-    if os.getenv("ANTHROPIC_API_KEY"):
-        default_model = PROVIDER_DEFAULT_MODELS["anthropic"]
-        limits = MODEL_LIMITS.get(default_model, {})
-        costs = MODEL_COSTS.get(default_model, {})
-        return ModelConfig(
-            provider="anthropic",
-            model_name=default_model,
-            api_key=os.getenv("ANTHROPIC_API_KEY"),
-            max_tokens=limits.get("max_output", 32000),
-            max_context=limits.get("max_context", 1000000),
-            temperature=0.7,
-            cost_per_1k_tokens=(costs.get("input", 0.015) + costs.get("output", 0.075)) / 2,
-        )
-
-    for provider_name, env_var in [("openai", "OPENAI_API_KEY"), ("gemini", "GEMINI_API_KEY"), ("mistral", "MISTRAL_API_KEY")]:
-        api_key = os.getenv(env_var)
-        if api_key:
-            default_model = PROVIDER_DEFAULT_MODELS[provider_name]
-            limits = MODEL_LIMITS.get(default_model, {})
-            costs = MODEL_COSTS.get(default_model, {})
-            avg_cost = (costs.get("input", 0.005) + costs.get("output", 0.005)) / 2 if costs else 0.002
-            return ModelConfig(
-                provider=provider_name,
-                model_name=default_model,
-                api_key=api_key,
-                api_base=PROVIDER_ENDPOINTS[provider_name],
-                max_tokens=limits.get("max_output", 8192),
-                max_context=limits.get("max_context", 128000),
-                temperature=0.7,
-                cost_per_1k_tokens=avg_cost,
-            )
-
-    # Ollama — already confirmed available by detect_llm_availability()
-    ollama_models = _get_available_ollama_models()  # cached, no HTTP call
-    if ollama_models:
-        preferred = ['mistral', 'qwen', 'codellama', 'llama', 'gemma', 'deepseek-coder', 'deepseek']
-        selected_model = ollama_models[0]
-
-        for pref in preferred:
-            for model in ollama_models:
-                if pref in model.lower():
-                    selected_model = model
-                    break
-            if selected_model != ollama_models[0]:
-                break
-
-        ollama_base = _validate_ollama_url(RaptorConfig.OLLAMA_HOST)
-        if selected_model not in MODEL_LIMITS:
-            logger.info(
-                f"Model '{selected_model}' not in MODEL_LIMITS — using defaults "
-                f"(max_context=32000, max_output=4096). Override in models.json if needed."
-            )
-        return ModelConfig(
-            provider="ollama",
-            model_name=selected_model,
-            api_base=f"{ollama_base}/v1",
-            max_tokens=4096,
-            temperature=0.7,
-            cost_per_1k_tokens=0.0,
-        )
+    # Step 3: default-order autodetect via env vars. Skip providers
+    # already tried in step 1.
+    for name in _DEFAULT_PROVIDER_ORDER:
+        if prefer_set is not None and name in prefer_set:
+            continue
+        builder = _PROVIDER_BUILDERS[name]
+        config = builder()
+        if config is not None:
+            return config
 
     return None
 

--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -2061,11 +2061,43 @@ class ClaudeCodeLLMProvider(LLMProvider):
             duration=duration,
         )
 
-        return result, json.dumps(result, indent=2)
+        # Return ``StructuredResponse`` so callers (notably ``turn()``)
+        # can read per-call cost / tokens directly without racing on
+        # shared instance state. ``__iter__`` keeps the existing
+        # ``result, raw = client.generate_structured(...)`` tuple-
+        # unpack pattern working.
+        return StructuredResponse(
+            result=result,
+            raw=json.dumps(result, indent=2),
+            cost=cost,
+            tokens_used=tokens,
+            model=self.config.model_name,
+            provider="claudecode",
+            duration=duration,
+        )
 
     def supports_tool_use(self) -> bool: return True
     def supports_prompt_caching(self) -> bool: return False
     def supports_parallel_tools(self) -> bool: return False
+
+    # ------------------------------------------------------------------
+    # Tool-use via ``--json-schema`` structured output.
+    # ------------------------------------------------------------------
+    #
+    # The ABC's JSON-in-prompt synthesis (``_tool_use_fallback``) does
+    # *not* work for Claude Code. CC has anti-prompt-injection training
+    # that refuses to roleplay as a different agent system when a system
+    # prompt says "you have these tools, emit JSON to call them" — that
+    # framing is indistinguishable from an attacker injecting a fake
+    # tool schema, and CC correctly refuses.
+    #
+    # The fix: reframe the task as *structured output* via CC's
+    # ``--json-schema`` flag. Anti-injection guards roleplay, not
+    # form-filling. We give CC a discriminated-union schema (either
+    # ``tool_call`` or ``complete``) plus the tool catalog as
+    # reference material, and CC fills in the form. Verified
+    # empirically: CC honours the schema and produces valid tool
+    # calls or final answers for typical agent flows.
 
     def turn(
         self,
@@ -2077,11 +2109,234 @@ class ClaudeCodeLLMProvider(LLMProvider):
         cache_control: CacheControl = CacheControl(),
         **provider_specific: Any,
     ) -> TurnResponse:
-        """Tool-use via the ABC's JSON-protocol fallback."""
-        return self._tool_use_fallback(
-            messages, tools,
-            system=system, max_tokens=max_tokens,
-            cache_control=cache_control, **provider_specific,
+        """Tool-use via ``generate_structured`` with a discriminated
+        schema. Each turn, CC chooses either to call a tool (returning
+        name + input) or to finalise (returning text)."""
+        del cache_control, provider_specific            # unused by CC
+
+        # No tools → plain text generation. Skip the schema overhead.
+        if not tools:
+            rendered = LLMProvider._render_messages_as_prompt(messages)
+            response = self.generate(
+                rendered, system_prompt=system, max_tokens=max_tokens,
+            )
+            cost = getattr(response, "cost", None)
+            return TurnResponse(
+                content=[TextBlock(text=(response.content if response else "") or "")],
+                stop_reason=StopReason.COMPLETE,
+                input_tokens=getattr(response, "input_tokens", 0) or 0,
+                output_tokens=getattr(response, "output_tokens", 0) or 0,
+                cost_usd=float(cost) if cost is not None else None,
+            )
+
+        schema = self._build_turn_schema(tools)
+        sys_combined = self._build_turn_system_prompt(tools, extra=system)
+        rendered_history = self._render_history_for_cc(messages)
+
+        try:
+            response = self.generate_structured(
+                prompt=rendered_history,
+                schema=schema,
+                system_prompt=sys_combined,
+            )
+        except RuntimeError as exc:
+            logger.warning(f"ClaudeCodeLLMProvider.turn: subprocess error: {exc}")
+            return TurnResponse(
+                content=[],
+                stop_reason=StopReason.ERROR,
+                input_tokens=0, output_tokens=0,
+            )
+
+        # Per-call cost / tokens come from the response directly so
+        # concurrent loops on the same provider don't race on shared
+        # ``self.total_cost`` state. ``StructuredResponse`` carries
+        # the values; the legacy ``(result, raw)`` tuple-unpack still
+        # works via ``__iter__``.
+        if isinstance(response, StructuredResponse):
+            result = response.result
+            cost_usd = response.cost
+            tokens = response.tokens_used
+        else:
+            # Defensive: a future provider might still return a tuple.
+            result, _ = response
+            cost_usd = 0.0
+            tokens = 0
+
+        return self._parse_turn_structured_result(
+            result, tools,
+            cost_usd=cost_usd,
+            # ``tokens_used`` from cc_adapter's envelope is already the
+            # input+output sum; we don't have a clean split, so attribute
+            # everything to output (consistent with ``generate()``'s
+            # behaviour for CC — see ``ClaudeCodeLLMProvider.generate``).
+            input_tokens=0,
+            output_tokens=tokens,
+        )
+
+    # ------------------------------------------------------------------
+    # turn() helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_turn_schema(tools: Sequence[ToolDef]) -> Dict[str, Any]:
+        """Discriminated-union schema CC fills in for one turn.
+
+        ``tool_name`` is constrained to the registered tool set so CC
+        can't hallucinate a name. ``tool_input`` is left as a generic
+        object — per-tool input validation happens at dispatch time
+        in :class:`ToolUseLoop`."""
+        return {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": ["tool_call", "complete"],
+                    "description": (
+                        "tool_call to invoke a tool; complete to "
+                        "deliver the final answer."
+                    ),
+                },
+                "tool_name": {
+                    "type": "string",
+                    "enum": [t.name for t in tools],
+                    "description": (
+                        "Name of the tool to invoke (only when "
+                        "type=tool_call)."
+                    ),
+                },
+                "tool_input": {
+                    "type": "object",
+                    "description": (
+                        "Arguments object for the tool, matching its "
+                        "input_schema (only when type=tool_call)."
+                    ),
+                },
+                "final_text": {
+                    "type": "string",
+                    "description": (
+                        "Final answer text (only when type=complete)."
+                    ),
+                },
+            },
+            "required": ["type"],
+        }
+
+    @staticmethod
+    def _build_turn_system_prompt(
+        tools: Sequence[ToolDef],
+        *,
+        extra: Optional[str] = None,
+    ) -> str:
+        # The "do not invent values" instruction is critical and
+        # substrate-level (not consumer-specific): without it, the
+        # model sometimes calls verification tools (e.g.
+        # ``gh_commit_detail(slug=..., sha=...)``) with hallucinated
+        # arguments before the discovery tool that produces those
+        # values has been called. The mitigation costs nothing and
+        # generalises across consumers; per-consumer guardrails
+        # (cve-diff's verified-SHA gate, etc.) remain the
+        # belt-and-braces second line.
+        lines = [
+            "Decide the next action for an agentic tool-use loop. "
+            "Either invoke a tool to gather more information or "
+            "deliver a final answer. Output JSON matching the "
+            "provided schema.",
+            "",
+            "RULES:",
+            "1. When invoking a tool, the values you put in tool_input "
+            "MUST come from either the conversation history or the "
+            "user's request. Do not guess, invent, or recall from "
+            "training data — even values that look plausible (slugs, "
+            "SHAs, URLs, IDs, package names).",
+            "2. If you don't have a value the next tool needs, call "
+            "a discovery tool first to obtain it.",
+            "3. Call only one tool per response.",
+            "",
+            "TOOL CATALOG:",
+        ]
+        for t in tools:
+            lines.append(f"- {t.name}: {t.description}")
+            lines.append(
+                f"  input_schema: {json.dumps(t.input_schema)}"
+            )
+        if extra:
+            lines.extend(["", extra])
+        return "\n".join(lines)
+
+    @staticmethod
+    def _render_history_for_cc(messages: Sequence[Message]) -> str:
+        """Flatten conversation history into a prompt CC reads as
+        reference material. Roles labelled; tool-call/result blocks
+        rendered as descriptive text."""
+        parts: list[str] = ["CONVERSATION HISTORY:"]
+        for msg in messages:
+            for block in msg.content:
+                if isinstance(block, TextBlock):
+                    parts.append(f"{msg.role}: {block.text}")
+                elif isinstance(block, ToolCall):
+                    parts.append(
+                        f"assistant called tool {block.name!r} with "
+                        f"input {json.dumps(block.input)}"
+                    )
+                elif isinstance(block, ToolResult):
+                    err = " [error]" if block.is_error else ""
+                    parts.append(
+                        f"tool_result{err} for {block.tool_use_id}: "
+                        f"{block.content}"
+                    )
+        return "\n\n".join(parts)
+
+    def _parse_turn_structured_result(
+        self,
+        result: Dict[str, Any],
+        tools: Sequence[ToolDef],
+        *,
+        cost_usd: float = 0.0,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+    ) -> TurnResponse:
+        """Translate CC's structured response into a
+        :class:`TurnResponse`. Defensive against malformed output —
+        falls back to a text block if the result doesn't fit either
+        branch of the discriminated schema."""
+        usd: Optional[float] = float(cost_usd) if cost_usd else None
+        rtype = result.get("type")
+        if rtype == "tool_call":
+            name = result.get("tool_name")
+            inp = result.get("tool_input")
+            if (
+                isinstance(name, str)
+                and isinstance(inp, dict)
+                and any(t.name == name for t in tools)
+            ):
+                import uuid as _uuid
+                call_id = f"call_{_uuid.uuid4().hex[:12]}"
+                return TurnResponse(
+                    content=[ToolCall(id=call_id, name=name, input=inp)],
+                    stop_reason=StopReason.NEEDS_TOOL_CALL,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    cost_usd=usd,
+                )
+            # Malformed tool_call — surface the raw result as text so
+            # callers can see what went wrong rather than silently
+            # dropping it.
+            return TurnResponse(
+                content=[TextBlock(text=json.dumps(result))],
+                stop_reason=StopReason.COMPLETE,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost_usd=usd,
+            )
+        # Default to "complete" for type="complete" and any other
+        # unexpected discriminator value.
+        text = result.get("final_text") or ""
+        return TurnResponse(
+            content=[TextBlock(text=text)],
+            stop_reason=StopReason.COMPLETE,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=usd,
         )
 
 

--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -976,15 +976,14 @@ class OpenAICompatibleProvider(LLMProvider):
                     )
                 if not _is_transient_openai(exc) or attempt >= max_retries:
                     kind = "transient" if _is_transient_openai(exc) else "permanent"
-                    logger.warning(
-                        f"OpenAICompatibleProvider.turn: {kind} error "
-                        f"after {attempt + 1} attempt(s): {exc}"
-                    )
+                    err_msg = f"{kind} error after {attempt + 1} attempt(s): {exc}"
+                    logger.warning(f"OpenAICompatibleProvider.turn: {err_msg}")
                     return TurnResponse(
                         content=[],
                         stop_reason=StopReason.ERROR,
                         input_tokens=0,
                         output_tokens=0,
+                        error_message=err_msg,
                     )
                 delay = backoff_factor ** attempt
                 logger.info(
@@ -996,6 +995,7 @@ class OpenAICompatibleProvider(LLMProvider):
             return TurnResponse(
                 content=[], stop_reason=StopReason.ERROR,
                 input_tokens=0, output_tokens=0,
+                error_message="exhausted retries",
             )
         duration = time.monotonic() - t_start
 
@@ -1004,6 +1004,7 @@ class OpenAICompatibleProvider(LLMProvider):
             return TurnResponse(
                 content=[], stop_reason=StopReason.ERROR,
                 input_tokens=0, output_tokens=0,
+                error_message="empty choices in response",
             )
         choice = resp.choices[0]
         msg = choice.message
@@ -1493,15 +1494,14 @@ class AnthropicProvider(LLMProvider):
             except (APIConnectionError, APIStatusError, APIError) as exc:
                 if not _is_transient_anthropic(exc) or attempt >= max_retries:
                     kind = "transient" if _is_transient_anthropic(exc) else "permanent"
-                    logger.warning(
-                        f"AnthropicProvider.turn: {kind} error after "
-                        f"{attempt + 1} attempt(s): {exc}"
-                    )
+                    err_msg = f"{kind} error after {attempt + 1} attempt(s): {exc}"
+                    logger.warning(f"AnthropicProvider.turn: {err_msg}")
                     return TurnResponse(
                         content=[],
                         stop_reason=StopReason.ERROR,
                         input_tokens=0,
                         output_tokens=0,
+                        error_message=err_msg,
                     )
                 delay = backoff_factor ** attempt
                 logger.info(
@@ -1513,6 +1513,7 @@ class AnthropicProvider(LLMProvider):
             return TurnResponse(
                 content=[], stop_reason=StopReason.ERROR,
                 input_tokens=0, output_tokens=0,
+                error_message="exhausted retries",
             )
         duration = time.monotonic() - t_start
 
@@ -1591,6 +1592,14 @@ class AnthropicProvider(LLMProvider):
         minimum won't trigger spurious warnings, but real silent-
         no-op cases on production-sized prompts (cve-diff: 5K+ tokens
         of system + tools) still surface.
+
+        Scope: per-provider-instance. Each ``LLMClient`` builds its
+        own provider via ``_get_provider``, and a fresh agentic run
+        typically constructs a fresh client. Operators running the
+        same setup repeatedly will see the warning once per run —
+        loud enough to act on, not so loud as to hide in noise. A
+        cross-process / cross-run dedup would need module-level
+        state and isn't worth the complexity for a one-time signal.
         """
         if self._caching_warning_emitted:
             return
@@ -2240,11 +2249,13 @@ class ClaudeCodeLLMProvider(LLMProvider):
                 system_prompt=sys_combined,
             )
         except RuntimeError as exc:
-            logger.warning(f"ClaudeCodeLLMProvider.turn: subprocess error: {exc}")
+            err_msg = f"subprocess error: {exc}"
+            logger.warning(f"ClaudeCodeLLMProvider.turn: {err_msg}")
             return TurnResponse(
                 content=[],
                 stop_reason=StopReason.ERROR,
                 input_tokens=0, output_tokens=0,
+                error_message=err_msg,
             )
 
         # Per-call cost / tokens come from the response directly so

--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -947,6 +947,7 @@ class OpenAICompatibleProvider(LLMProvider):
             APIConnectionError,
             APIStatusError,
         )
+        t_start = time.monotonic()
         for attempt in range(max_retries + 1):
             try:
                 resp = self.client.chat.completions.create(**kwargs)
@@ -996,6 +997,7 @@ class OpenAICompatibleProvider(LLMProvider):
                 content=[], stop_reason=StopReason.ERROR,
                 input_tokens=0, output_tokens=0,
             )
+        duration = time.monotonic() - t_start
 
         # ---- normalise response --------------------------------------
         if not resp.choices:
@@ -1022,7 +1024,7 @@ class OpenAICompatibleProvider(LLMProvider):
             ))
 
         usage = resp.usage
-        return TurnResponse(
+        turn_response = TurnResponse(
             content=out_blocks,
             stop_reason=stop,
             input_tokens=(getattr(usage, "prompt_tokens", 0) or 0) if usage else 0,
@@ -1031,6 +1033,20 @@ class OpenAICompatibleProvider(LLMProvider):
             cache_read_tokens=0,
             cache_write_tokens=0,
         )
+        # Track usage so multi-turn loop spend rolls into provider
+        # stats. Symmetric with ``generate()`` and the Anthropic
+        # ``turn()`` impl. Without this, ``LLMClient.get_stats()``
+        # reports 0 cost / 0 tokens for tool-use no matter how many
+        # turns the loop ran for.
+        cost = self.compute_cost(turn_response)
+        self.track_usage(
+            tokens=turn_response.input_tokens + turn_response.output_tokens,
+            cost=cost,
+            input_tokens=turn_response.input_tokens,
+            output_tokens=turn_response.output_tokens,
+            duration=duration,
+        )
+        return turn_response
 
 
 # ---------------------------------------------------------------------------
@@ -1461,6 +1477,7 @@ class AnthropicProvider(LLMProvider):
             APIError,
             APIStatusError,
         )
+        t_start = time.monotonic()
         for attempt in range(max_retries + 1):
             try:
                 resp = create_fn(**send_kwargs)
@@ -1489,6 +1506,7 @@ class AnthropicProvider(LLMProvider):
                 content=[], stop_reason=StopReason.ERROR,
                 input_tokens=0, output_tokens=0,
             )
+        duration = time.monotonic() - t_start
 
         # ---- normalise response --------------------------------------
         stop = _ANTHROPIC_STOP_REASON_MAP.get(
@@ -1507,7 +1525,7 @@ class AnthropicProvider(LLMProvider):
                 ))
 
         usage = resp.usage
-        return TurnResponse(
+        turn_response = TurnResponse(
             content=out_blocks,
             stop_reason=stop,
             input_tokens=(getattr(usage, "input_tokens", 0) or 0) if usage else 0,
@@ -1519,6 +1537,20 @@ class AnthropicProvider(LLMProvider):
                 getattr(usage, "cache_creation_input_tokens", 0) or 0
             ) if usage else 0,
         )
+        # Track usage so multi-turn loop spend shows up alongside
+        # generate() in provider stats. Without this, ``LLMClient.
+        # get_stats()`` reports 0 cost / 0 tokens for tool-use even
+        # when the loop ran for many turns. Cost via ``compute_cost``
+        # so cache multipliers (1.25x write, 0.1x read) apply.
+        cost = self.compute_cost(turn_response)
+        self.track_usage(
+            tokens=turn_response.input_tokens + turn_response.output_tokens,
+            cost=cost,
+            input_tokens=turn_response.input_tokens,
+            output_tokens=turn_response.output_tokens,
+            duration=duration,
+        )
+        return turn_response
 
 
 # ---------------------------------------------------------------------------

--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -1208,6 +1208,14 @@ class AnthropicProvider(LLMProvider):
                 "For more reliable structured output: pip install instructor"
             )
 
+        # Per-instance flag: have we warned about silent cache-failure
+        # for this model? Warns once per provider instance to avoid
+        # spam, since the silent-failure is a model-level property
+        # (claude-opus-4-5 and claude-opus-4-6 verified non-caching as
+        # of 2026-05-04 — Anthropic accepts the cache_control marker
+        # but doesn't honor it). See ``_maybe_warn_silent_cache_failure``.
+        self._caching_warning_emitted = False
+
         logger.debug(f"Initialized AnthropicProvider: {config.model_name}")
 
     def generate(self, prompt: str, system_prompt: Optional[str] = None,
@@ -1550,7 +1558,67 @@ class AnthropicProvider(LLMProvider):
             output_tokens=turn_response.output_tokens,
             duration=duration,
         )
+        self._maybe_warn_silent_cache_failure(turn_response, cache_control)
         return turn_response
+
+    def _maybe_warn_silent_cache_failure(
+        self,
+        response: TurnResponse,
+        cache_control: CacheControl,
+    ) -> None:
+        """Detect when ``cache_control`` markers are silently no-op'd.
+
+        Anthropic's published cacheable-region minimum is 1024 tokens
+        (Opus / Sonnet) or 2048 (Haiku 3.5). Empirically (2026-05-04)
+        some model versions enforce a higher de-facto minimum and
+        return ``cache_creation_input_tokens=0,
+        cache_read_input_tokens=0`` for cache_control opt-ins below
+        that minimum, with no error — silent no-op. Consumers planning
+        cost budgets around cache savings (cve-diff is the headline
+        case) won't see the savings, with no signal until the bill
+        comes in.
+
+        Warn once per provider instance when all conditions hold:
+          * ``cache_control`` was opt-in (caller asked for caching)
+          * ``input_tokens >= 8192`` — well above any observed model's
+            de-facto minimum, so a zero-cache outcome is a real signal,
+            not a "your request was too small" false positive
+          * ``cache_creation_input_tokens == 0`` AND
+            ``cache_read_input_tokens == 0``
+
+        The 8192 floor trades sensitivity for specificity: smaller
+        cacheable regions that legitimately fall below a model's
+        minimum won't trigger spurious warnings, but real silent-
+        no-op cases on production-sized prompts (cve-diff: 5K+ tokens
+        of system + tools) still surface.
+        """
+        if self._caching_warning_emitted:
+            return
+        requested = (
+            cache_control.system
+            or cache_control.tools
+            or cache_control.history_through_index is not None
+        )
+        if not requested:
+            return
+        if response.input_tokens < 8192:
+            return                                          # below threshold
+        if response.cache_read_tokens > 0 or response.cache_write_tokens > 0:
+            return                                          # caching is working
+        logger.warning(
+            f"AnthropicProvider: model {self.config.model_name!r} did not "
+            f"populate cache fields on a turn with cache_control opt-in "
+            f"and {response.input_tokens} input tokens — cache savings "
+            f"won't apply for requests this size. Common causes: (1) "
+            f"this model's de-facto cacheable-region minimum is higher "
+            f"than the documented 1024 tokens; (2) the cacheable subset "
+            f"(system + tools when those are opted in) is below the "
+            f"model's minimum even though total input is above 8192. "
+            f"Try a different model (claude-opus-4-7, "
+            f"claude-sonnet-4-5-20250929) or increase the cacheable "
+            f"region size. This warning fires once per provider instance."
+        )
+        self._caching_warning_emitted = True
 
 
 # ---------------------------------------------------------------------------

--- a/core/llm/tests/test_claude_code_llm_provider.py
+++ b/core/llm/tests/test_claude_code_llm_provider.py
@@ -5,7 +5,13 @@ use the Claude Code CLI without an SDK API key.
 Distinct from the legacy ``ClaudeCodeProvider`` stub (which returns
 ``None`` to signal "the surrounding orchestrator handles reasoning")
 — this one actually does generation via subprocess and supports
-tool-use through the ABC's JSON-protocol fallback.
+tool-use through CC's ``--json-schema`` structured-output mode.
+
+The ABC's :meth:`_tool_use_fallback` (JSON-in-prompt synthesis)
+does NOT work for CC: anti-injection training refuses to roleplay
+as a different agent system. The structured-output mode reframes
+the task as form-filling rather than roleplay and bypasses the
+guard.
 
 All subprocess interaction is monkeypatched; no real ``claude``
 binary is invoked.
@@ -418,10 +424,15 @@ def test_turn_text_response_returns_complete(monkeypatch) -> None:
 
 
 def test_turn_tool_call_response_returns_needs_tool_call(monkeypatch) -> None:
-    payload = '```json\n{"tool": "search", "input": {"q": "x"}}\n```'
+    """CC emits a ``tool_call``-shaped JSON via --json-schema; the
+    provider parses it into a ``ToolCall`` block."""
     monkeypatch.setattr(
         subprocess, "run",
-        lambda *a, **k: _FakeCompleted(stdout=_envelope(result=payload)),
+        lambda *a, **k: _FakeCompleted(stdout=_structured_envelope({
+            "type": "tool_call",
+            "tool_name": "search",
+            "tool_input": {"q": "x"},
+        })),
     )
     tool = ToolDef(
         name="search", description="search tool",
@@ -438,6 +449,135 @@ def test_turn_tool_call_response_returns_needs_tool_call(monkeypatch) -> None:
     assert isinstance(out.content[0], ToolCall)
     assert out.content[0].name == "search"
     assert out.content[0].input == {"q": "x"}
+
+
+def test_turn_complete_response_returns_complete(monkeypatch) -> None:
+    """When CC emits ``type=complete`` (no more tools to call), the
+    provider returns a ``TextBlock`` with the final answer."""
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompleted(stdout=_structured_envelope({
+            "type": "complete",
+            "final_text": "I'm done — the answer is 42.",
+        })),
+    )
+    tool = ToolDef(
+        name="search", description="search tool",
+        input_schema={"type": "object"},
+        handler=lambda i: "result",
+    )
+    p = ClaudeCodeLLMProvider(_config())
+    out = p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="hi")])],
+        tools=[tool],
+    )
+
+    assert out.stop_reason is StopReason.COMPLETE
+    assert isinstance(out.content[0], TextBlock)
+    assert "the answer is 42" in out.content[0].text
+
+
+def test_turn_invokes_subprocess_with_json_schema(monkeypatch) -> None:
+    """Sanity: the subprocess command includes ``--json-schema`` so
+    CC honours the structured-output contract. (If we passed plain
+    text mode CC's anti-injection would refuse the request.)"""
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        return _FakeCompleted(stdout=_structured_envelope({
+            "type": "complete",
+            "final_text": "ok",
+        }))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    tool = ToolDef(
+        name="search", description="search tool",
+        input_schema={"type": "object"},
+        handler=lambda i: "result",
+    )
+    p = ClaudeCodeLLMProvider(_config())
+    p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="hi")])],
+        tools=[tool],
+    )
+    assert "--json-schema" in captured["cmd"]
+    schema_idx = captured["cmd"].index("--json-schema") + 1
+    schema = json.loads(captured["cmd"][schema_idx])
+    # Discriminated union — must constrain ``type`` to the two valid
+    # branches and constrain ``tool_name`` to the registered tools.
+    assert schema["properties"]["type"]["enum"] == ["tool_call", "complete"]
+    assert schema["properties"]["tool_name"]["enum"] == ["search"]
+
+
+def test_turn_malformed_tool_call_falls_back_to_text(monkeypatch) -> None:
+    """If CC emits ``type=tool_call`` but the tool_name doesn't match
+    a registered tool (hallucination guard), we surface the raw result
+    as a text block rather than dispatching a bogus call."""
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompleted(stdout=_structured_envelope({
+            "type": "tool_call",
+            "tool_name": "fictional_tool_99",
+            "tool_input": {},
+        })),
+    )
+    tool = ToolDef(
+        name="search", description="search tool",
+        input_schema={"type": "object"},
+        handler=lambda i: "result",
+    )
+    p = ClaudeCodeLLMProvider(_config())
+    out = p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="hi")])],
+        tools=[tool],
+    )
+    assert out.stop_reason is StopReason.COMPLETE
+    assert isinstance(out.content[0], TextBlock)
+
+
+def test_turn_no_tools_uses_plain_generate(monkeypatch) -> None:
+    """When ``tools=[]``, ``turn()`` skips the schema and falls back
+    to plain text generation. No ``--json-schema`` flag in the
+    command line."""
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        return _FakeCompleted(stdout=_envelope(result="hello"))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    p = ClaudeCodeLLMProvider(_config())
+    out = p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="hi")])],
+        tools=[],
+    )
+    assert "--json-schema" not in captured["cmd"]
+    assert out.stop_reason is StopReason.COMPLETE
+    assert out.content[0].text == "hello"
+
+
+def test_turn_subprocess_error_returns_error_response(monkeypatch) -> None:
+    """When the underlying subprocess fails, return a ToolResponse
+    with stop_reason=ERROR instead of letting RuntimeError bubble up
+    — the loop expects a TurnResponse and converts its own ERROR
+    handling."""
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompleted(stdout="", stderr="auth", returncode=1),
+    )
+    tool = ToolDef(
+        name="search", description="search tool",
+        input_schema={"type": "object"},
+        handler=lambda i: "result",
+    )
+    p = ClaudeCodeLLMProvider(_config())
+    out = p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="hi")])],
+        tools=[tool],
+    )
+    assert out.stop_reason is StopReason.ERROR
+    assert out.content == []
 
 
 def test_turn_propagates_envelope_cost_to_compute_cost(monkeypatch) -> None:

--- a/core/llm/tests/test_provider_preference.py
+++ b/core/llm/tests/test_provider_preference.py
@@ -1,0 +1,366 @@
+"""Tests for explicit provider preference and the Claude Code
+fallthrough in :func:`core.llm.config._get_default_primary_model`,
+plus the :attr:`LLMClient.primary_provider` accessor.
+
+The substrate's autodetection order has historically been Anthropic-
+first by convention. Consumers (e.g. cve-diff) that *rely* on that
+preference should express it explicitly via ``prefer=`` rather than
+depend on coincidence — otherwise their behaviour silently regresses
+if the default order is ever re-tuned. This file pins the resolution
+contract.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from core.llm.config import (
+    LLMConfig,
+    ModelConfig,
+    _get_default_primary_model,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures — strip env so each test sees a clean slate
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Strip every LLM-related env var so each test starts from an
+    empty environment. Tests opt in to specific keys via setenv."""
+    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY",
+                "MISTRAL_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    yield monkeypatch
+
+
+@pytest.fixture
+def no_thinking_model(monkeypatch):
+    """Disable the operator's thinking-model lookup so tests that
+    care about env-var fallthrough aren't surprised by a config-file
+    setup on the developer's machine."""
+    monkeypatch.setattr(
+        "core.llm.config._get_best_thinking_model",
+        lambda: None,
+    )
+
+
+@pytest.fixture
+def no_claudecode(monkeypatch):
+    """Pretend ``claude`` isn't on PATH so the ultimate fallback
+    is None rather than ClaudeCodeLLMProvider."""
+    monkeypatch.setattr("shutil.which", lambda _bin: None)
+
+
+@pytest.fixture
+def no_ollama(monkeypatch):
+    """Pretend Ollama isn't running."""
+    monkeypatch.setattr(
+        "core.llm.config._get_available_ollama_models",
+        lambda: [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default order — Anthropic > OpenAI > Gemini > Mistral > Ollama > CC
+# ---------------------------------------------------------------------------
+
+
+def test_default_order_picks_anthropic_when_only_anthropic_key(
+    clean_env, no_thinking_model, no_claudecode, no_ollama,
+) -> None:
+    clean_env.setenv("ANTHROPIC_API_KEY", "test-key")
+    config = _get_default_primary_model()
+    assert config is not None
+    assert config.provider == "anthropic"
+
+
+def test_default_order_picks_openai_when_no_anthropic(
+    clean_env, no_thinking_model, no_claudecode, no_ollama,
+) -> None:
+    clean_env.setenv("OPENAI_API_KEY", "test-key")
+    config = _get_default_primary_model()
+    assert config is not None
+    assert config.provider == "openai"
+
+
+def test_default_order_picks_anthropic_over_openai_when_both(
+    clean_env, no_thinking_model, no_claudecode, no_ollama,
+) -> None:
+    """Convention: Anthropic first when both are available. This is
+    what consumers like cve-diff *coincidentally* depend on today —
+    explicit ``prefer="anthropic"`` is the architecturally correct
+    way to express it (covered below)."""
+    clean_env.setenv("ANTHROPIC_API_KEY", "a-key")
+    clean_env.setenv("OPENAI_API_KEY", "o-key")
+    config = _get_default_primary_model()
+    assert config.provider == "anthropic"
+
+
+def test_default_returns_none_when_nothing_available(
+    clean_env, no_thinking_model, no_claudecode, no_ollama,
+) -> None:
+    """Pre-Phase-2 behaviour preserved: ``None`` when no provider
+    is reachable."""
+    config = _get_default_primary_model()
+    assert config is None
+
+
+# ---------------------------------------------------------------------------
+# Claude Code fallthrough — works without any API key
+# ---------------------------------------------------------------------------
+
+
+def test_claudecode_fallthrough_when_no_external_llm(
+    clean_env, no_thinking_model, no_ollama, monkeypatch,
+) -> None:
+    """The keyless case: no API keys, no Ollama, but ``claude`` on
+    PATH. The resolver falls through to ClaudeCodeLLMProvider so
+    tool-using consumers can still operate."""
+    monkeypatch.setattr("shutil.which", lambda b: "/usr/bin/claude" if b == "claude" else None)
+    config = _get_default_primary_model()
+    assert config is not None
+    assert config.provider == "claudecode"
+    assert config.api_key is None       # no key needed for CC subprocess
+
+
+def test_claudecode_only_used_as_last_resort(
+    clean_env, no_thinking_model, no_ollama, monkeypatch,
+) -> None:
+    """When *any* API key is set, the resolver picks the API path
+    over Claude Code — CC is slower (subprocess + JSON-protocol
+    synthesis for tool-use) so it's the absolute last resort."""
+    monkeypatch.setattr("shutil.which", lambda b: "/usr/bin/claude" if b == "claude" else None)
+    clean_env.setenv("MISTRAL_API_KEY", "test-key")
+    config = _get_default_primary_model()
+    assert config.provider == "mistral"        # not "claudecode"
+
+
+# ---------------------------------------------------------------------------
+# Explicit preference — consumer-driven
+# ---------------------------------------------------------------------------
+
+
+def test_prefer_anthropic_when_anthropic_available(
+    clean_env, no_thinking_model, no_claudecode, no_ollama,
+) -> None:
+    """``prefer="anthropic"`` returns Anthropic when its env var is
+    set — straightforward case."""
+    clean_env.setenv("ANTHROPIC_API_KEY", "a-key")
+    clean_env.setenv("OPENAI_API_KEY", "o-key")
+    config = _get_default_primary_model(prefer="anthropic")
+    assert config.provider == "anthropic"
+
+
+def test_prefer_overrides_default_order(
+    clean_env, no_thinking_model, no_claudecode, no_ollama,
+) -> None:
+    """When operator has Anthropic+Mistral keys both set,
+    ``prefer="mistral"`` picks Mistral — explicit preference beats
+    the Anthropic-first default order."""
+    clean_env.setenv("ANTHROPIC_API_KEY", "a-key")
+    clean_env.setenv("MISTRAL_API_KEY", "m-key")
+    config = _get_default_primary_model(prefer="mistral")
+    assert config.provider == "mistral"
+
+
+def test_prefer_falls_through_when_preferred_unavailable(
+    clean_env, no_thinking_model, no_claudecode, no_ollama,
+) -> None:
+    """Preference is lenient — when the preferred provider isn't
+    reachable, the resolver falls through to the default order. This
+    is "I prefer X but give me something that works" semantics."""
+    clean_env.setenv("OPENAI_API_KEY", "o-key")    # no Anthropic
+    config = _get_default_primary_model(prefer="anthropic")
+    assert config.provider == "openai"
+
+
+def test_prefer_list_tries_each_in_order(
+    clean_env, no_thinking_model, no_claudecode, no_ollama,
+) -> None:
+    """Multi-provider preference: try each in order; first available
+    wins."""
+    clean_env.setenv("MISTRAL_API_KEY", "m-key")     # only mistral
+    config = _get_default_primary_model(
+        prefer=["anthropic", "openai", "mistral"]
+    )
+    assert config.provider == "mistral"
+
+
+def test_unknown_preferred_provider_silently_skipped(
+    clean_env, no_thinking_model, no_claudecode, no_ollama, caplog,
+) -> None:
+    """A preferred provider name that doesn't match any builder
+    (typo, deprecated provider) logs a warning but falls through
+    to the rest — better than failing an entire run for a typo."""
+    clean_env.setenv("OPENAI_API_KEY", "o-key")
+    import logging
+    with caplog.at_level(logging.WARNING):
+        config = _get_default_primary_model(
+            prefer=["nonexistent", "openai"]
+        )
+    assert config.provider == "openai"
+
+
+def test_prefer_falls_through_to_claudecode(
+    clean_env, no_thinking_model, no_ollama, monkeypatch,
+) -> None:
+    """Keyless preference: cve-diff says ``prefer="anthropic"``,
+    operator has nothing set up, ``claude`` is on PATH → CC subprocess.
+    The complete fallback chain ends here."""
+    monkeypatch.setattr("shutil.which", lambda b: "/usr/bin/claude" if b == "claude" else None)
+    config = _get_default_primary_model(prefer="anthropic")
+    assert config.provider == "claudecode"
+
+
+# ---------------------------------------------------------------------------
+# Operator thinking-model interaction with prefer
+# ---------------------------------------------------------------------------
+
+
+def test_thinking_model_beats_env_var_default(
+    clean_env, no_claudecode, no_ollama, monkeypatch,
+) -> None:
+    """Operator's explicit thinking-model config beats env-var
+    default-order. If operator has Gemini in models.json AND has
+    OPENAI_API_KEY env var, default-order returns Gemini (the
+    explicit choice) not OpenAI (just an env var)."""
+    fake_thinking = ModelConfig(
+        provider="gemini",
+        model_name="gemini-2.5-pro",
+        api_key="fake",
+        api_base="https://generativelanguage.googleapis.com/v1beta/openai",
+    )
+    monkeypatch.setattr(
+        "core.llm.config._get_best_thinking_model",
+        lambda: fake_thinking,
+    )
+    clean_env.setenv("OPENAI_API_KEY", "o-key")
+    config = _get_default_primary_model()
+    assert config.provider == "gemini"
+
+
+def test_prefer_env_var_beats_operator_thinking_model(
+    clean_env, no_claudecode, no_ollama, monkeypatch,
+) -> None:
+    """When consumer says prefer="anthropic" and Anthropic IS
+    available via env var, that beats the operator's thinking model
+    — the consumer's explicit signal is the strongest signal."""
+    fake_thinking = ModelConfig(
+        provider="gemini",
+        model_name="gemini-2.5-pro",
+        api_key="fake",
+        api_base="https://generativelanguage.googleapis.com/v1beta/openai",
+    )
+    monkeypatch.setattr(
+        "core.llm.config._get_best_thinking_model",
+        lambda: fake_thinking,
+    )
+    clean_env.setenv("ANTHROPIC_API_KEY", "a-key")
+    config = _get_default_primary_model(prefer="anthropic")
+    assert config.provider == "anthropic"
+
+
+def test_prefer_unavailable_falls_to_thinking_model(
+    clean_env, no_claudecode, no_ollama, monkeypatch,
+) -> None:
+    """Consumer prefers Anthropic, env var not set, operator has
+    Gemini configured → falls through to operator's Gemini rather
+    than dropping all the way to claudecode. Operator's explicit
+    config still beats unconfigured fallbacks."""
+    fake_thinking = ModelConfig(
+        provider="gemini",
+        model_name="gemini-2.5-pro",
+        api_key="fake",
+        api_base="https://generativelanguage.googleapis.com/v1beta/openai",
+    )
+    monkeypatch.setattr(
+        "core.llm.config._get_best_thinking_model",
+        lambda: fake_thinking,
+    )
+    config = _get_default_primary_model(prefer="anthropic")
+    assert config.provider == "gemini"
+
+
+# ---------------------------------------------------------------------------
+# LLMClient.primary_provider — public accessor for tool-use consumers
+# ---------------------------------------------------------------------------
+
+
+def test_llmclient_primary_provider_returns_provider_instance(
+    clean_env, no_thinking_model, no_claudecode, no_ollama,
+) -> None:
+    """The accessor surfaces the provider for the configured
+    primary_model. Cached: same instance returned across calls."""
+    pytest.importorskip("anthropic")
+    clean_env.setenv("ANTHROPIC_API_KEY", "test-key")
+    from core.llm.client import LLMClient
+    from core.llm.providers import LLMProvider
+    cfg = LLMConfig(primary_model=_get_default_primary_model())
+    client = LLMClient(cfg)
+
+    p1 = client.primary_provider
+    p2 = client.primary_provider
+    assert isinstance(p1, LLMProvider)
+    assert p1 is p2          # cached
+
+
+def test_llmclient_primary_provider_raises_without_primary_model() -> None:
+    """When no primary_model is configured, the accessor raises a
+    clear error rather than returning None silently. Callers should
+    have used ``get_client()`` (which returns ``None``) instead of
+    constructing LLMClient directly."""
+    from core.llm.client import LLMClient
+    cfg = LLMConfig.__new__(LLMConfig)             # bypass autodetect
+    cfg.primary_model = None
+    cfg.fallback_models = []
+    cfg.specialized_models = {}
+    cfg.enable_fallback = True
+    cfg.max_retries = 3
+    cfg.retry_delay = 2.0
+    cfg.retry_delay_remote = 5.0
+    cfg.enable_caching = False
+    from pathlib import Path
+    cfg.cache_dir = Path("/tmp")
+    cfg.enable_cost_tracking = False
+    cfg.max_cost_per_scan = 10.0
+    client = LLMClient.__new__(LLMClient)
+    client.config = cfg
+    client.providers = {}
+
+    with pytest.raises(RuntimeError, match="primary_model"):
+        _ = client.primary_provider
+
+
+# ---------------------------------------------------------------------------
+# get_client(prefer=...) — the public entrypoint cve-diff uses
+# ---------------------------------------------------------------------------
+
+
+def test_get_client_with_prefer_kwarg(
+    clean_env, no_thinking_model, no_claudecode, no_ollama,
+) -> None:
+    pytest.importorskip("anthropic")
+    clean_env.setenv("ANTHROPIC_API_KEY", "a-key")
+    clean_env.setenv("MISTRAL_API_KEY", "m-key")
+
+    from packages.llm_analysis import get_client
+    client = get_client(prefer="mistral")
+    assert client is not None
+    assert client.config.primary_model.provider == "mistral"
+
+
+def test_get_client_returns_none_when_no_provider(
+    clean_env, no_thinking_model, no_claudecode, no_ollama,
+) -> None:
+    """No keys, no thinking model, no claude binary → ``None``.
+    Callers can then surface a clear "configure an LLM" error to
+    the operator."""
+    from packages.llm_analysis import get_client
+    assert get_client() is None
+    assert get_client(prefer="anthropic") is None

--- a/core/llm/tests/test_turn_track_usage_and_factory.py
+++ b/core/llm/tests/test_turn_track_usage_and_factory.py
@@ -1,0 +1,251 @@
+"""Pin-tests for two cross-provider invariants surfaced during PR #286
+real-LLM testing:
+
+1. **``turn()`` accumulates provider stats.** All four providers'
+   ``turn()`` methods must call ``track_usage`` (directly or via
+   delegation to ``generate()`` / ``generate_structured()``).
+   Pre-fix, AnthropicProvider and OpenAICompatibleProvider skipped
+   it, so ``LLMClient.get_stats()`` reported zero tool-use spend.
+   Gemini and CC delegate; the delegation path was correct but
+   untested. This file pins all four.
+
+2. **Keyless-Anthropic factory routing.** When ``ANTHROPIC_SDK_AVAILABLE``
+   is False but OpenAI SDK is present, the factory must build an
+   ``OpenAICompatibleProvider`` against ``api.anthropic.com/v1``. Real-LLM
+   testing proved Anthropic's OpenAI-compat shim accepts function-calling
+   natively; this test pins the routing so a future refactor doesn't
+   silently break the keyless path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from core.llm.config import ModelConfig
+
+
+# ---------------------------------------------------------------------------
+# turn() track_usage — Anthropic + OpenAICompatible (direct calls)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _anthropic_provider_with_stub():
+    """Reuse the Anthropic test stub plumbing without re-importing."""
+    pytest.importorskip("anthropic")
+    from core.llm.providers import AnthropicProvider
+    from core.llm.tool_use.tests.test_anthropic import (
+        _StubBlock, _StubClient, _StubResponse, _StubUsage,
+    )
+    p = AnthropicProvider(ModelConfig(
+        provider="anthropic", model_name="claude-opus-4-6",
+        api_key="test-key", timeout=1,
+    ))
+    c = _StubClient()
+    p.client = c                                                    # type: ignore[assignment]
+    return p, c, _StubBlock, _StubResponse, _StubUsage
+
+
+def test_anthropic_turn_calls_track_usage(_anthropic_provider_with_stub) -> None:
+    """``AnthropicProvider.turn`` must update provider running totals.
+    Pre-#286 this was skipped, masking real spend in
+    ``LLMClient.get_stats()`` no matter how many turns the loop ran for."""
+    from core.llm.tool_use import Message, TextBlock
+
+    p, c, _StubBlock, _StubResponse, _StubUsage = _anthropic_provider_with_stub
+    c.messages.responses.append(_StubResponse(
+        [_StubBlock("text", text="ok")],
+        stop_reason="end_turn",
+        usage=_StubUsage(input_tokens=100, output_tokens=50),
+    ))
+
+    assert p.total_cost == 0.0
+    assert p.call_count == 0
+
+    p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+    )
+
+    assert p.call_count == 1
+    assert p.total_input_tokens == 100
+    assert p.total_output_tokens == 50
+    assert p.total_cost > 0.0                                       # exact value depends on pricing
+
+
+def test_openai_turn_calls_track_usage() -> None:
+    """``OpenAICompatibleProvider.turn`` must track usage symmetrically
+    with Anthropic. Same pre-#286 gap."""
+    pytest.importorskip("openai")
+    from core.llm.providers import OpenAICompatibleProvider
+    from core.llm.tool_use.tests.test_openai_compat import (
+        _FakeOpenAIClient, _FakeResponse, _FakeChoice,
+        _FakeMessage, _FakeUsage,
+    )
+    from core.llm.tool_use import Message, TextBlock
+
+    p = OpenAICompatibleProvider(ModelConfig(
+        provider="openai", model_name="gpt-4o",
+        api_key="test-key", timeout=1,
+    ))
+    c = _FakeOpenAIClient()
+    p.client = c                                                    # type: ignore[assignment]
+    c.chat.completions.responses.append(_FakeResponse(
+        choices=[_FakeChoice(_FakeMessage(content="ok"), finish_reason="stop")],
+        usage=_FakeUsage(prompt_tokens=200, completion_tokens=80),
+    ))
+
+    assert p.call_count == 0
+    p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+    )
+
+    assert p.call_count == 1
+    assert p.total_input_tokens == 200
+    assert p.total_output_tokens == 80
+    assert p.total_cost > 0.0
+
+
+# ---------------------------------------------------------------------------
+# turn() track_usage via delegation — Gemini + ClaudeCode
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_turn_tracks_via_delegated_generate() -> None:
+    """``GeminiProvider.turn`` delegates to ``_tool_use_fallback`` →
+    ``self.generate()`` which tracks usage. Pin-test confirms the
+    delegation chain hasn't broken."""
+    pytest.importorskip("google.genai")
+    from core.llm.providers import GeminiProvider, LLMResponse
+    from core.llm.tool_use import Message, TextBlock
+
+    p = GeminiProvider(ModelConfig(
+        provider="gemini", model_name="gemini-2.5-pro",
+        api_key="test-key", timeout=1,
+    ))
+
+    # Replace generate with a tracking spy so we don't hit the SDK.
+    def _g(prompt: str, system_prompt: Any = None, **kw: Any) -> LLMResponse:
+        # Mimic the real generate's track_usage call.
+        p.track_usage(
+            tokens=15, cost=0.001,
+            input_tokens=10, output_tokens=5, duration=0.0,
+        )
+        return LLMResponse(
+            content="ok", model="gemini-2.5-pro", provider="gemini",
+            tokens_used=15, cost=0.001, finish_reason="stop",
+            input_tokens=10, output_tokens=5,
+        )
+    p.generate = _g                                                 # type: ignore[method-assign]
+
+    assert p.call_count == 0
+    p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+    )
+    assert p.call_count == 1
+    assert p.total_cost > 0.0
+
+
+def test_claudecode_turn_tracks_via_delegated_generate(monkeypatch) -> None:
+    """``ClaudeCodeLLMProvider.turn`` delegates to ``generate`` (no tools)
+    or ``generate_structured`` (with tools); both call ``track_usage``."""
+    import json
+    import subprocess
+    from core.llm.providers import ClaudeCodeLLMProvider
+    from core.llm.tool_use import Message, TextBlock, ToolDef
+    from core.llm.tests.test_claude_code_llm_provider import (
+        _FakeCompleted, _envelope, _structured_envelope,
+    )
+
+    # Path 1: tools=[] → generate() → track_usage
+    p1 = ClaudeCodeLLMProvider(ModelConfig(
+        provider="claudecode", model_name="claude-opus-4-6",
+        api_key=None, timeout=10,
+    ))
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompleted(stdout=_envelope(cost_usd=0.05)),
+    )
+    p1.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+    )
+    assert p1.call_count == 1
+    assert p1.total_cost == 0.05
+
+    # Path 2: tools present → generate_structured() → track_usage
+    p2 = ClaudeCodeLLMProvider(ModelConfig(
+        provider="claudecode", model_name="claude-opus-4-6",
+        api_key=None, timeout=10,
+    ))
+    tool = ToolDef("echo", "echo back",
+                   {"type": "object"}, lambda i: "r")
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompleted(stdout=_structured_envelope(
+            {"type": "complete", "final_text": "done"}, cost_usd=0.07,
+        )),
+    )
+    p2.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[tool],
+    )
+    assert p2.call_count == 1
+    assert p2.total_cost == 0.07
+
+
+# ---------------------------------------------------------------------------
+# Factory routes anthropic → OpenAICompatibleProvider when SDK absent
+# ---------------------------------------------------------------------------
+
+
+def test_factory_routes_keyless_anthropic_to_openai_compat() -> None:
+    """When the ``anthropic`` SDK is absent but OpenAI is installed,
+    ``create_provider(ModelConfig(provider="anthropic"))`` must build
+    an ``OpenAICompatibleProvider`` pointed at
+    ``api.anthropic.com/v1``. Real-LLM verification (2026-05-04)
+    confirmed Anthropic's OpenAI-compat shim accepts function-calling
+    natively — i.e., this routing delivers working tool-use without
+    the ``anthropic`` SDK installed. The test pins the routing
+    against future refactors."""
+    pytest.importorskip("openai")
+    from core.llm.providers import OpenAICompatibleProvider, create_provider
+
+    config = ModelConfig(
+        provider="anthropic",
+        model_name="claude-opus-4-6",
+        api_key="test-anthropic-key",
+        timeout=10,
+    )
+
+    with patch("core.llm.providers.ANTHROPIC_SDK_AVAILABLE", False):
+        provider = create_provider(config)
+
+    assert isinstance(provider, OpenAICompatibleProvider)
+    # base_url is what OpenAI client will hit. Trailing slash present
+    # because the OpenAI SDK normalises base_url.
+    assert "api.anthropic.com" in str(provider.client.base_url)
+    # API key threaded through correctly so requests authenticate.
+    assert provider.client.api_key == "test-anthropic-key"
+
+
+def test_factory_keyless_anthropic_raises_without_openai_sdk() -> None:
+    """When neither anthropic nor openai SDK is available, the factory
+    raises a clear error rather than silently returning a broken
+    provider."""
+    config = ModelConfig(
+        provider="anthropic",
+        model_name="claude-opus-4-6",
+        api_key="test-key",
+        timeout=10,
+    )
+    with patch("core.llm.providers.ANTHROPIC_SDK_AVAILABLE", False), \
+         patch("core.llm.providers.OPENAI_SDK_AVAILABLE", False):
+        from core.llm.providers import create_provider
+        with pytest.raises(RuntimeError, match="anthropic"):
+            create_provider(config)

--- a/core/llm/tool_use/loop.py
+++ b/core/llm/tool_use/loop.py
@@ -96,6 +96,7 @@ class ToolUseLoop:
         max_iterations: int = 50,
         max_cost_usd: float | None = None,
         max_seconds: float | None = None,
+        max_total_tokens: int | None = None,
         tool_timeout_s: float | None = None,
         context_policy: ContextPolicy = ContextPolicy.RAISE,
         max_tokens_per_turn: int = 4096,
@@ -128,6 +129,7 @@ class ToolUseLoop:
         self._max_iterations = max_iterations
         self._max_cost_usd = max_cost_usd
         self._max_seconds = max_seconds
+        self._max_total_tokens = max_total_tokens
         self._tool_timeout_s = tool_timeout_s
         self._context_policy = context_policy
         self._max_tokens_per_turn = max_tokens_per_turn
@@ -212,6 +214,34 @@ class ToolUseLoop:
                     total_output_tokens=total_output_tokens,
                     total_cost_usd=total_cost_usd,
                     terminated_by="max_seconds",
+                )
+
+            # ---- pre-flight: total-tokens budget ------------------------
+            # Sums input+output across turns. Cache-region tokens are
+            # accounted in ``compute_cost`` (and thus ``max_cost_usd``)
+            # but not added here — the cost cap is the load-bearing
+            # gate; this is a belt-and-braces parity check with
+            # consumer-side budgets like cve-diff's ``budget_tokens``.
+            if (
+                self._max_total_tokens is not None
+                and (total_input_tokens + total_output_tokens)
+                    >= self._max_total_tokens
+            ):
+                self._emit(LoopTerminated(
+                    reason="max_total_tokens",
+                    iterations=iteration,
+                    total_cost_usd=total_cost_usd,
+                ))
+                return ToolLoopResult(
+                    final_text="",
+                    terminal_tool_input=None,
+                    messages=messages,
+                    iterations=iteration,
+                    tool_calls_made=tool_calls_made,
+                    total_input_tokens=total_input_tokens,
+                    total_output_tokens=total_output_tokens,
+                    total_cost_usd=total_cost_usd,
+                    terminated_by="max_total_tokens",
                 )
 
             # ---- pre-flight: context window -----------------------------

--- a/core/llm/tool_use/loop.py
+++ b/core/llm/tool_use/loop.py
@@ -343,10 +343,15 @@ class ToolUseLoop:
                 # (max_tokens / refused / provider_error) so callers can
                 # tell the difference.
                 term_reason = _stop_reason_to_term(response.stop_reason)
+                # Forward error_message from the provider's TurnResponse
+                # so callers can present the actual error rather than
+                # only seeing it in warning logs.
+                err = response.error_message
                 self._emit(LoopTerminated(
                     reason=term_reason,
                     iterations=iteration + 1,
                     total_cost_usd=total_cost_usd,
+                    error_message=err,
                 ))
                 return ToolLoopResult(
                     final_text=_join_text(response.content),
@@ -358,6 +363,7 @@ class ToolUseLoop:
                     total_output_tokens=total_output_tokens,
                     total_cost_usd=total_cost_usd,
                     terminated_by=term_reason,    # type: ignore[arg-type]
+                    error_message=err,
                 )
 
             # ---- dispatch tools -----------------------------------------

--- a/core/llm/tool_use/tests/test_anthropic.py
+++ b/core/llm/tool_use/tests/test_anthropic.py
@@ -515,7 +515,9 @@ def test_standard_endpoint_does_not_carry_beta_kwargs() -> None:
 
 def test_api_error_returns_error_stop_reason() -> None:
     """Permanent API errors surface as ``StopReason.ERROR`` after
-    retries are exhausted (or immediately for non-transient errors)."""
+    retries are exhausted (or immediately for non-transient errors).
+    The error_message is populated so callers don't have to read the
+    warning log to know what failed."""
     from anthropic import APIConnectionError                # type: ignore[import-not-found]
 
     p, c = _provider_with_stub()
@@ -531,6 +533,8 @@ def test_api_error_returns_error_stop_reason() -> None:
     )
     assert out.stop_reason is StopReason.ERROR
     assert out.content == []
+    assert out.error_message is not None
+    assert "Connection error" in out.error_message or "APIConnectionError" in out.error_message or "error after" in out.error_message
 
 
 # ---------------------------------------------------------------------------

--- a/core/llm/tool_use/tests/test_anthropic.py
+++ b/core/llm/tool_use/tests/test_anthropic.py
@@ -678,3 +678,123 @@ def test_unrecognised_provider_kwargs_handled_gracefully() -> None:
         random_other_kwarg=42,
     )
     assert out.stop_reason is StopReason.COMPLETE       # didn't crash
+
+
+# ---------------------------------------------------------------------------
+# Silent cache-failure detection (model accepts cache_control but
+# doesn't honor it — verified with claude-opus-4-5 and claude-opus-4-6
+# on 2026-05-04)
+# ---------------------------------------------------------------------------
+
+
+def test_silent_cache_failure_warns_when_above_threshold() -> None:
+    """Model accepts the cache_control marker but reports
+    ``cache_creation_input_tokens=0, cache_read_input_tokens=0`` with
+    input well above the 8192-token threshold — silent no-op caching.
+    Empirical observation 2026-05-04: some Opus model versions enforce
+    higher de-facto cacheable-region minimums than the documented
+    1024 tokens, so requests in the 2K-5K range may silently no-op
+    despite cache_control opt-in. The 8192 floor catches the
+    production-sized cve-diff case."""
+    from core.llm.tool_use import CacheControl
+    p, c = _provider_with_stub()
+    # Above the 4096-token threshold; both cache fields zero.
+    c.messages.responses.append(_StubResponse(
+        [_StubBlock("text", text="ok")],
+        stop_reason="end_turn",
+        usage=_StubUsage(input_tokens=10000, output_tokens=10,
+                         cache_read_input_tokens=0,
+                         cache_creation_input_tokens=0),
+    ))
+
+    assert p._caching_warning_emitted is False
+    p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+        cache_control=CacheControl(system=True, tools=True),
+    )
+    assert p._caching_warning_emitted is True
+
+
+def test_silent_cache_failure_warns_only_once_per_instance() -> None:
+    """Multiple offending turns on the same provider instance should
+    surface the warning once, not flood the log."""
+    from core.llm.tool_use import CacheControl
+    p, c = _provider_with_stub()
+    for _ in range(3):
+        c.messages.responses.append(_StubResponse(
+            [_StubBlock("text", text="ok")],
+            stop_reason="end_turn",
+            usage=_StubUsage(input_tokens=10000, output_tokens=10),
+        ))
+
+    for _ in range(3):
+        p.turn(
+            messages=[Message(role="user", content=[TextBlock(text="x")])],
+            tools=[],
+            cache_control=CacheControl(system=True, tools=True),
+        )
+    # Flag set once; no toggle.
+    assert p._caching_warning_emitted is True
+
+
+def test_silent_cache_failure_no_warn_when_caching_works() -> None:
+    """Working caching: ``cache_creation_input_tokens > 0`` on first
+    turn or ``cache_read_input_tokens > 0`` on subsequent turns. The
+    provider must NOT warn — caching is functioning."""
+    from core.llm.tool_use import CacheControl
+    p, c = _provider_with_stub()
+    # First turn: cache being created.
+    c.messages.responses.append(_StubResponse(
+        [_StubBlock("text", text="ok")],
+        stop_reason="end_turn",
+        usage=_StubUsage(input_tokens=10000, output_tokens=10,
+                         cache_creation_input_tokens=5000,
+                         cache_read_input_tokens=0),
+    ))
+    p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+        cache_control=CacheControl(system=True, tools=True),
+    )
+    assert p._caching_warning_emitted is False
+
+
+def test_silent_cache_failure_no_warn_below_threshold() -> None:
+    """Below the 8192-token threshold the cacheable region may be
+    too small for caching to fire legitimately — cache_read=0,
+    cache_write=0 is correct, not a regression. The provider must
+    not warn (false positive avoidance)."""
+    from core.llm.tool_use import CacheControl
+    p, c = _provider_with_stub()
+    c.messages.responses.append(_StubResponse(
+        [_StubBlock("text", text="ok")],
+        stop_reason="end_turn",
+        usage=_StubUsage(input_tokens=4000, output_tokens=10),  # below 8192
+    ))
+    p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+        cache_control=CacheControl(system=True, tools=True),
+    )
+    assert p._caching_warning_emitted is False
+
+
+def test_silent_cache_failure_no_warn_when_caching_not_requested() -> None:
+    """When ``cache_control`` is fully off (system=False, tools=False,
+    history=None), the consumer didn't ask for caching. Zero cache
+    activity is expected — no warning."""
+    from core.llm.tool_use import CacheControl
+    p, c = _provider_with_stub()
+    c.messages.responses.append(_StubResponse(
+        [_StubBlock("text", text="ok")],
+        stop_reason="end_turn",
+        usage=_StubUsage(input_tokens=10000, output_tokens=10),
+    ))
+    p.turn(
+        messages=[Message(role="user", content=[TextBlock(text="x")])],
+        tools=[],
+        cache_control=CacheControl(system=False, tools=False,
+                                    history_through_index=None),
+    )
+    assert p._caching_warning_emitted is False

--- a/core/llm/tool_use/tests/test_loop.py
+++ b/core/llm/tool_use/tests/test_loop.py
@@ -357,6 +357,54 @@ def test_max_seconds_none_means_no_cap() -> None:
     assert out.terminated_by == "complete"
 
 
+# ---------------------------------------------------------------------------
+# max_total_tokens — cumulative input+output token cap
+# ---------------------------------------------------------------------------
+
+
+def test_max_total_tokens_terminates_pre_flight() -> None:
+    """Token budget caps the whole run on cumulative input+output.
+    Each turn here costs 100+50 = 150 tokens; cap=400 fires after 3
+    turns. Distinct termination reason from cost / iter / time so
+    callers can distinguish "we exhausted the token allowance" from
+    other budget classes."""
+    fp = _FakeProvider([
+        _tool_call_response(("c1", "echo", {})),
+        _tool_call_response(("c2", "echo", {})),
+        _tool_call_response(("c3", "echo", {})),                   # never reached
+    ])
+    loop = ToolUseLoop(fp, [_echo_tool()], max_total_tokens=400)
+    out = loop.run("token-bounded")
+    assert out.terminated_by == "max_total_tokens"
+    assert len(fp.calls) <= 3                                       # gate fires before 3rd call
+
+
+def test_max_total_tokens_emits_loop_terminated_event() -> None:
+    """Subscribers see ``LoopTerminated(reason="max_total_tokens")``
+    distinct from other termination reasons."""
+    events: list[Any] = []
+    fp = _FakeProvider([_tool_call_response(("c", "echo", {}))] * 50)
+    loop = ToolUseLoop(
+        fp, [_echo_tool()],
+        max_total_tokens=1,                                         # immediate cap on iter 0+
+        events=events.append,
+    )
+    out = loop.run("hi")
+    # 1 token cap, 100+50 per turn → fires on iteration 1
+    assert out.terminated_by == "max_total_tokens"
+    terminated = [e for e in events if isinstance(e, LoopTerminated)]
+    assert len(terminated) == 1
+    assert terminated[0].reason == "max_total_tokens"
+
+
+def test_max_total_tokens_none_means_no_cap() -> None:
+    """Default behaviour preserved when ``max_total_tokens=None``."""
+    fp = _FakeProvider([_text_response("done")])
+    loop = ToolUseLoop(fp, [_echo_tool()])                          # no token cap
+    out = loop.run("hi")
+    assert out.terminated_by == "complete"
+
+
 def test_max_seconds_real_clock_e2e() -> None:
     """End-to-end against real ``time.monotonic`` (no monkeypatch).
 

--- a/core/llm/tool_use/tests/test_loop.py
+++ b/core/llm/tool_use/tests/test_loop.py
@@ -405,6 +405,50 @@ def test_max_total_tokens_none_means_no_cap() -> None:
     assert out.terminated_by == "complete"
 
 
+def test_provider_error_message_surfaces_on_loop_result() -> None:
+    """When the provider returns ``StopReason.ERROR`` with an
+    ``error_message`` populated, the loop forwards it onto both the
+    ``LoopTerminated`` event and ``ToolLoopResult.error_message`` so
+    callers can present the actual cause to operators rather than
+    seeing it only in warning logs."""
+    events: list[Any] = []
+    fp = _FakeProvider([
+        TurnResponse(
+            content=[],
+            stop_reason=StopReason.ERROR,
+            input_tokens=0, output_tokens=0,
+            error_message="permanent error after 1 attempt(s): 401 invalid api key",
+        ),
+    ])
+    loop = ToolUseLoop(fp, [_echo_tool()], events=events.append)
+    result = loop.run("hi")
+
+    assert result.terminated_by == "provider_error"
+    assert result.error_message is not None
+    assert "401" in result.error_message
+    terminated = [e for e in events if isinstance(e, LoopTerminated)]
+    assert len(terminated) == 1
+    assert terminated[0].error_message == result.error_message
+
+
+def test_provider_error_with_no_message_yields_none() -> None:
+    """Backward compat: providers that return ``ERROR`` without
+    ``error_message`` produce ``ToolLoopResult.error_message=None``,
+    same shape as pre-2026-05-04 behaviour. No spurious string."""
+    fp = _FakeProvider([
+        TurnResponse(
+            content=[],
+            stop_reason=StopReason.ERROR,
+            input_tokens=0, output_tokens=0,
+            # no error_message set
+        ),
+    ])
+    loop = ToolUseLoop(fp, [_echo_tool()])
+    result = loop.run("hi")
+    assert result.terminated_by == "provider_error"
+    assert result.error_message is None
+
+
 def test_max_seconds_real_clock_e2e() -> None:
     """End-to-end against real ``time.monotonic`` (no monkeypatch).
 

--- a/core/llm/tool_use/types.py
+++ b/core/llm/tool_use/types.py
@@ -340,6 +340,7 @@ class LoopTerminated:
         "max_iterations",            # loop hit max_iterations cap
         "max_cost_usd",              # cumulative cost crossed cap
         "max_seconds",               # wall-clock budget exceeded
+        "max_total_tokens",          # cumulative input+output tokens crossed cap
         "max_tokens",                # provider truncated response (no tool calls)
         "refused",                   # provider safety / content filter
         "tool_error",                # handler exception or timeout under terminate_on_handler_error
@@ -402,6 +403,7 @@ class ToolLoopResult:
         "max_iterations",
         "max_cost_usd",
         "max_seconds",
+        "max_total_tokens",
         "max_tokens",
         "refused",
         "tool_error",

--- a/core/llm/tool_use/types.py
+++ b/core/llm/tool_use/types.py
@@ -203,6 +203,7 @@ class TurnResponse:
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
     cost_usd: float | None = None
+    error_message: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -350,6 +351,7 @@ class LoopTerminated:
     ]
     iterations: int
     total_cost_usd: float
+    error_message: str | None = None
 
 
 LoopEvent = Union[
@@ -411,3 +413,4 @@ class ToolLoopResult:
         "context_overflow",
         "provider_error",
     ]
+    error_message: str | None = None

--- a/packages/llm_analysis/__init__.py
+++ b/packages/llm_analysis/__init__.py
@@ -20,13 +20,37 @@ from .agent import AutonomousSecurityAgentV2
 logger = logging.getLogger(__name__)
 
 
-def get_client(config: LLMConfig = None) -> LLMClient | None:
+def get_client(
+    config: LLMConfig = None,
+    *,
+    prefer: str | list[str] | None = None,
+) -> LLMClient | None:
     """Get an LLM client, returning None if no provider is available.
 
     Use this instead of the try/except LLMClient() pattern.
+
+    ``prefer`` lets a consumer express its own provider preference
+    (e.g. cve-diff prefers ``"anthropic"`` for ``cache_control``
+    savings + ``task_budget`` beta) without depending on the default
+    autodetect order. Unknown / unavailable preferred providers are
+    silently skipped; falls through to the default order for the
+    rest. Ignored when ``config`` is explicitly passed (caller has
+    already chosen a primary).
+
+    Examples:
+        get_client()                              # default autodetect
+        get_client(prefer="anthropic")            # cve-diff
+        get_client(prefer=["openai", "gemini"])   # ordered fallthrough
     """
     try:
-        cfg = config or LLMConfig()
+        if config is None:
+            from core.llm.config import _get_default_primary_model
+            primary = _get_default_primary_model(prefer=prefer)
+            if primary is None:
+                return None
+            cfg = LLMConfig(primary_model=primary)
+        else:
+            cfg = config
         if not cfg.primary_model:
             return None
         return LLMClient(cfg)


### PR DESCRIPTION
Two layers of substrate work that together make Claude Code a viable tool-use backend for consumers like cve-diff Phase 2 — including the keyless case (no API key, just ``claude`` CLI on PATH).

RESOLVER LAYER
==============

* ``get_client(prefer="anthropic")`` — explicit consumer preference. Tries the named providers via env var first; falls through to operator's thinking-model config; falls through to default-order autodetect. Lenient: unknown / unavailable preferred providers are silently skipped. Consumers express their preference in code rather than depending on coincidence with the substrate's default order (which would silently regress consumer behaviour if re-tuned).

* Claude Code subprocess fallthrough — when no API key is set and no Ollama is running but ``claude`` CLI is on PATH, the resolver returns ``ModelConfig(provider="claudecode")``. cve-diff (and any future tool-using consumer) works for keyless users. Used only as last resort: any API key or Ollama beats it.

* ``LLMClient.primary_provider`` property — exposes the underlying ``LLMProvider`` for tool-use consumers driving a ``ToolUseLoop`` directly. Cached via the existing ``_get_provider`` machinery; raises ``RuntimeError`` if no primary_model is configured.

Resolution order, pinned by tests:
  1. preferred providers via env var (consumer's signal)
  2. operator's thinking-model config (file-based; covers non-env-var setups like Vertex auth for Gemini)
  3. default-order autodetect: Anthropic > OpenAI > Gemini > Mistral >
     Ollama > Claude Code (subprocess, last resort)

PROVIDER LAYER
==============

* ``ClaudeCodeLLMProvider.turn()`` via ``--json-schema`` structured output. The ABC's JSON-in-prompt synthesis (``_tool_use_fallback``) does not work for CC: anti-prompt-injection training refuses to roleplay as a different agent system when a system prompt says "you have these tools, emit JSON to call them" — that framing is indistinguishable from an attacker injecting a fake tool schema, and CC correctly refuses (the same hardening that makes CC safe to use against attacker-influenced content per #273).

  The ``--json-schema`` path reframes the task as form-filling rather than roleplay and bypasses the guard. We give CC a discriminated-union schema (either ``tool_call`` or ``complete``) plus the tool catalog as reference material, and CC fills in the form. Verified empirically: real CC subprocess drives multi-turn cve-diff-shaped tool catalogs, including cross-turn data dependencies (osv_raw output → gh_commit_detail input) and terminal-tool detection (``terminal_tool="submit_result"`` returns the structured payload via ``ToolLoopResult.terminal_tool_input``).

* ``generate_structured`` now returns ``StructuredResponse`` with per-call cost / tokens populated. Fixes a concurrent-loop race where two threads on the same provider could see each other's cost in the delta computation. Existing ``result, raw = generate_structured(...)`` tuple-unpack callers keep working via ``StructuredResponse.__iter__``.

* Anti-value-guessing rules in the substrate's CC system prompt: values placed into ``tool_input`` must come from conversation history or the user's request, not guessed from training data. Substrate-level mitigation; consumer-level gates (cve-diff's verified-SHA check) remain the second line — model behaviour is not deterministic, so prompt + downstream gate are belt-and-braces.

* CC's per-turn timeout bumped from 120s to 300s. Calibrated against real ``--json-schema`` runs over a 16-tool catalog — simple turns are 5-15s, rich-catalog turns can hit 60-180s. 300s gives 2-3x headroom without letting a single turn consume a whole ``ToolUseLoop.max_seconds`` budget.

Closes the gap that PR #282 promised but didn't deliver: a unified tool-use loop that works regardless of which LLM is configured, including the keyless Claude-Code-only case.