### PR TITLE
core/security: pass ModelConfig (not model_name) to envelope probe dispatch_fn

### DIFF
--- a/core/security/envelope_probe.py
+++ b/core/security/envelope_probe.py
@@ -10,8 +10,8 @@ Usage (in orchestrator, after model resolution):
 
     from core.security.envelope_probe import probe_envelope_compatibility
 
-    result = probe_envelope_compatibility(model_id, profile, dispatch_fn)
-    defense_telemetry.set_probe_result(model_id, result.compatible)
+    result = probe_envelope_compatibility(model_config, profile, dispatch_fn)
+    defense_telemetry.set_probe_result(model_config.model_name, result.compatible)
     if not result.compatible:
         profile = PASSTHROUGH  # fall back for this model
 """
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
+from typing import Any
 
 from core.security.prompt_envelope import (
     ModelDefenseProfile,
@@ -146,11 +147,21 @@ def evaluate_probe_response(raw_response: str, nonce: str) -> ProbeResult:
 
 
 def probe_envelope_compatibility(
-    model_id: str,
+    analysis_model: Any,
     profile: ModelDefenseProfile,
     dispatch_fn,
 ) -> ProbeResult:
     """Send a canary probe through the dispatch path.
+
+    ``analysis_model`` is the :class:`ModelConfig` (or anything with a
+    ``.model_name`` attribute) that the orchestrator picked. We pass it
+    *unchanged* to ``dispatch_fn`` because that's what the production
+    dispatch_fn expects (its 5th argument lands in
+    ``client.generate_structured(model_config=...)`` which reads
+    ``.max_context`` etc.). Pre-2026-05-04 the probe passed
+    ``model_name`` (a string) here, which surfaced as ``'str' object
+    has no attribute 'max_context'`` once a model was actually probed
+    via the live external-LLM path.
 
     dispatch_fn must accept (prompt, schema, system_prompt, temperature, model)
     and return a DispatchResult (or raise on failure). This is the same
@@ -160,9 +171,10 @@ def probe_envelope_compatibility(
     handled the envelope correctly.
     """
     system, user, nonce = build_canary_prompt(profile)
+    model_name = getattr(analysis_model, "model_name", None) or str(analysis_model)
 
     try:
-        result = dispatch_fn(user, None, system, 0.0, model_id)
+        result = dispatch_fn(user, None, system, 0.0, analysis_model)
         raw = ""
         if hasattr(result, "result") and isinstance(result.result, dict):
             raw = result.result.get("content", "") or json.dumps(result.result)
@@ -185,7 +197,7 @@ def probe_envelope_compatibility(
     if probe_result.compatible:
         logger.info(
             "Envelope probe passed for %s (profile: %s)",
-            model_id, profile.name,
+            model_name, profile.name,
         )
     else:
         logger.warning(
@@ -194,7 +206,7 @@ def probe_envelope_compatibility(
             "for this model. The model-independent floor (autofetch "
             "redaction, control-char sanitisation, role separation) still "
             "applies.",
-            model_id, profile.name, probe_result.error,
+            model_name, profile.name, probe_result.error,
         )
 
     return probe_result

--- a/core/security/tests/test_envelope_probe.py
+++ b/core/security/tests/test_envelope_probe.py
@@ -222,6 +222,41 @@ class TestProbeEnvelopeCompatibility:
         assert not result.compatible
         assert "timed out" in result.error
 
+    def test_passes_analysis_model_object_to_dispatch_fn(self):
+        """The probe must forward its ``analysis_model`` argument
+        unchanged to dispatch_fn. Production dispatch_fn (in
+        ``packages/llm_analysis/orchestrator.py``) plumbs that into
+        ``client.generate_structured(model_config=...)`` which reads
+        ``.max_context`` etc. — passing a string here surfaces as
+        ``'str' object has no attribute 'max_context'`` once a model
+        is actually probed. Regression for the bug introduced in
+        PR #273 / fixed 2026-05-04."""
+        captured = {}
+
+        def recording_dispatch(prompt, schema, system_prompt, temperature, model):
+            captured["model"] = model
+            return FakeDispatchResult(result={"content": json.dumps({
+                "is_vulnerable": True,
+                "vulnerability_type": "buffer_overflow",
+                "confidence": 0.95,
+            })})
+
+        # Stub stand-in for ``ModelConfig`` — the probe must forward
+        # whatever object it was given, not extract fields from it.
+        class _StubModelConfig:
+            model_name = "test-model"
+            max_context = 200_000
+            provider = "test"
+
+        cfg = _StubModelConfig()
+        probe_envelope_compatibility(cfg, CONSERVATIVE, recording_dispatch)
+        # The probe forwarded the ModelConfig object verbatim, not its
+        # ``.model_name`` string.
+        assert captured["model"] is cfg
+        # Sanity: anything with ``.max_context`` works downstream
+        # (string would not).
+        assert hasattr(captured["model"], "max_context")
+
 
 # ============================================================
 # 4. Integration with telemetry probe cache

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -222,7 +222,8 @@ def orchestrate(
 
     # Print dispatch info
     n_consensus = len(role_resolution.get("consensus_models", []))
-    analysis_model_name = role_resolution.get("analysis_model").model_name if role_resolution.get("analysis_model") else ""
+    analysis_model = role_resolution.get("analysis_model")
+    analysis_model_name = analysis_model.model_name if analysis_model else ""
     is_cc_dispatch = not (llm_config and llm_config.primary_model)
     model_label = analysis_model_name or ("Claude Code" if is_cc_dispatch else "unknown")
     n = len(findings)
@@ -255,10 +256,17 @@ def orchestrate(
                     prompt=prompt, schema=schema, system_prompt=system_prompt,
                     model_config=model, temperature=temperature,
                 )
+                result = response.result
+                quality = 1.0
+                if isinstance(result, dict) and "error" not in result:
+                    from core.llm.response_validation import validate_structured_response
+                    validated = validate_structured_response(result, schema)
+                    result = validated.data
+                    quality = validated.quality
                 return DispatchResult(
-                    result=response.result, cost=response.cost,
+                    result=result, cost=response.cost,
                     tokens=response.tokens_used, model=response.model,
-                    duration=response.duration,
+                    duration=response.duration, quality=quality,
                 )
             else:
                 response = client.generate(
@@ -299,8 +307,13 @@ def orchestrate(
     if dispatch_fn and analysis_model_name:
         profile = get_profile_for(analysis_model_name)
         from core.security.envelope_probe import probe_envelope_compatibility
+        # Pass the full ModelConfig: dispatch_fn forwards its 5th arg
+        # to ``client.generate_structured(model_config=...)`` which
+        # needs ``.max_context`` etc. The probe falls back to a
+        # ``str(analysis_model_name)`` label for telemetry on the CC
+        # dispatch path (where the arg is unused anyway).
         probe_result = probe_envelope_compatibility(
-            analysis_model_name, profile, dispatch_fn,
+            analysis_model or analysis_model_name, profile, dispatch_fn,
         )
         defense_telemetry.set_probe_result(analysis_model_name, probe_result.compatible)
         if not probe_result.compatible:


### PR DESCRIPTION
The dispatch_fn defined in packages/llm_analysis/orchestrator.py plumbs its 5th argument into client.generate_structured(model_config=...) which reads model_config.max_context. Pre-fix, envelope_probe.py:165 passed analysis_model_name (a str), surfacing as ``'str' object has no attribute 'max_context'`` once a model was actually probed via the live external-LLM path.

Probe signature changes from ``model_id: str`` to ``analysis_model: Any``; orchestrator now passes the full ModelConfig object. Probe internally reads ``.model_name`` for log labels (with a string fallback for tests / CC dispatch where the arg is unused). Existing string-only test callers keep working — they pass a label that the fake dispatch ignored anyway.

Pre-existing bug from the anti-prompt-injection envelope work (PR #273); not related to PRs #285 / #286.