### PR TITLE
feat: per-field LLM response validation with quality scoring

### DIFF
--- a/core/llm/response_validation.py
+++ b/core/llm/response_validation.py
@@ -1,0 +1,472 @@
+"""Boundary validation for LLM structured responses.
+
+Validates, normalises, and scores LLM-returned dicts field-by-field
+rather than all-or-nothing.  Runs at the generate_structured boundary
+so consumers receive a quality-scored response with bad fields nulled
+and flagged, instead of either a raw unchecked dict or an exception.
+
+Works with both schema formats used in the codebase:
+  - Simple: {"field": "type description"}
+  - JSON Schema: {"properties": {...}, "required": [...]}
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
+
+from core.schema_constants import (
+    AGENTIC_RULING_VALUES,
+    CONFIDENCE_LEVELS,
+    SEVERITY_LEVELS,
+    VULN_TYPES,
+    normalise_vuln_type,
+)
+
+_CVSS_RE = re.compile(
+    r"^CVSS:3\.[01]/"
+    r"AV:[NALP]/AC:[LH]/PR:[NLH]/UI:[NR]/S:[UC]/"
+    r"C:[NLH]/I:[NLH]/A:[NLH]$"
+)
+_CWE_RE = re.compile(r"^CWE-\d+$")
+
+
+@dataclass
+class FieldResult:
+    """Outcome of validating a single field."""
+    status: str   # "ok", "coerced", "missing", "invalid"
+    original: Any = None
+
+
+@dataclass
+class ValidatedResponse:
+    """Result of validate_structured_response."""
+    data: Dict[str, Any]
+    quality: float
+    incomplete: List[str] = field(default_factory=list)
+    coerced: List[str] = field(default_factory=list)
+    fields: Dict[str, FieldResult] = field(default_factory=dict)
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+
+# ---- Field weights per schema ------------------------------------------------
+# Keyed by a schema identifier (first required field tuple as a proxy).
+# Unknown schemas get uniform weights.
+
+_ANALYSIS_WEIGHTS: Dict[str, float] = {
+    "is_true_positive": 1.0,
+    "is_exploitable": 1.0,
+    "reasoning": 1.0,
+    "confidence": 0.8,
+    "severity_assessment": 0.8,
+    "ruling": 0.8,
+    "vuln_type": 0.7,
+    "exploitability_score": 0.6,
+    "attack_scenario": 0.5,
+    "cvss_vector": 0.5,
+    "cwe_id": 0.4,
+    "dataflow_summary": 0.3,
+    "remediation": 0.3,
+    "false_positive_reason": 0.2,
+    "impact": 0.3,
+    "prerequisites": 0.2,
+}
+
+_FINDING_RESULT_WEIGHTS: Dict[str, float] = {
+    "finding_id": 1.0,
+    "is_true_positive": 1.0,
+    "is_exploitable": 1.0,
+    "reasoning": 1.0,
+    "confidence": 0.8,
+    "severity_assessment": 0.8,
+    "ruling": 0.8,
+    "vuln_type": 0.7,
+    "exploitability_score": 0.6,
+    "attack_scenario": 0.5,
+    "cvss_vector": 0.5,
+    "cwe_id": 0.4,
+    "dataflow_summary": 0.3,
+    "remediation": 0.3,
+    "false_positive_reason": 0.2,
+    "tool": 0.1,
+    "rule_id": 0.1,
+    "exploit_code": 0.1,
+    "patch_code": 0.1,
+}
+
+_DATAFLOW_VALIDATION_WEIGHTS: Dict[str, float] = {
+    "is_exploitable": 1.0,
+    "source_attacker_controlled": 1.0,
+    "sanitizers_effective": 0.9,
+    "path_reachable": 0.9,
+    "exploitability_confidence": 0.8,
+    "exploitability_reasoning": 0.8,
+    "false_positive": 0.7,
+    "attack_complexity": 0.6,
+    "source_type": 0.5,
+    "source_reasoning": 0.5,
+    "sanitizers_found": 0.4,
+    "sanitizer_details": 0.3,
+    "reachability_barriers": 0.3,
+    "attack_prerequisites": 0.3,
+    "attack_payload_concept": 0.3,
+    "impact_if_exploited": 0.4,
+    "cvss_estimate": 0.3,
+    "false_positive_reason": 0.2,
+}
+
+# Registry: recognise schema by its field set and return the right weights.
+_WEIGHT_REGISTRY: List[tuple[Set[str], Dict[str, float]]] = [
+    ({"finding_id", "is_true_positive", "is_exploitable", "reasoning"}, _FINDING_RESULT_WEIGHTS),
+    ({"source_attacker_controlled", "sanitizers_effective", "path_reachable"}, _DATAFLOW_VALIDATION_WEIGHTS),
+    ({"is_true_positive", "is_exploitable", "reasoning"}, _ANALYSIS_WEIGHTS),
+]
+
+_DEFAULT_WEIGHT = 0.5
+
+
+def _resolve_weights(schema: Dict[str, Any]) -> Dict[str, float]:
+    """Pick the right weight table for a schema, or fall back to uniform."""
+    props = _get_properties(schema)
+    field_names = set(props.keys())
+    for signature, weights in _WEIGHT_REGISTRY:
+        if signature <= field_names:
+            return weights
+    return {f: _DEFAULT_WEIGHT for f in field_names}
+
+
+# ---- Schema helpers ----------------------------------------------------------
+
+def _get_properties(schema: Dict[str, Any]) -> Dict[str, Any]:
+    if "properties" in schema:
+        return schema.get("properties", {})
+    # Simple schema: values are description strings like "boolean" or
+    # "float (0.0-1.0)".  Return as-is — _get_field_type and _is_nullable
+    # both handle string descriptions.
+    return schema
+
+
+def _get_required(schema: Dict[str, Any]) -> Set[str]:
+    if "properties" in schema:
+        return set(schema.get("required", []))
+    return set(schema.keys())
+
+
+def _get_field_type(field_spec: Any) -> str:
+    """Extract the primary type from a JSON Schema property or simple description."""
+    if isinstance(field_spec, str):
+        token = field_spec.split()[0].strip().lower()
+        return {"bool": "boolean", "str": "string", "int": "integer",
+                "float": "number", "list": "array"}.get(token, token)
+    if isinstance(field_spec, dict):
+        t = field_spec.get("type", "string")
+        if isinstance(t, list):
+            return next((x for x in t if x != "null"), "string")
+        return t
+    return "string"
+
+
+def _is_nullable(field_spec: Any) -> bool:
+    if isinstance(field_spec, str):
+        return "or null" in field_spec.lower() or "null" in field_spec.lower()
+    if isinstance(field_spec, dict):
+        t = field_spec.get("type")
+        if isinstance(t, list) and "null" in t:
+            return True
+    return False
+
+
+# ---- Domain normalisers ------------------------------------------------------
+# Each returns (normalised_value, was_coerced).
+
+def _normalise_vuln_type(value: Any) -> tuple[Any, bool]:
+    if not isinstance(value, str) or not value:
+        return value, False
+    normalised = normalise_vuln_type(value)
+    return normalised, normalised != value
+
+
+def _normalise_status_field(value: Any) -> tuple[Any, bool]:
+    from packages.exploitability_validation.orchestrator import normalize_status
+    if not isinstance(value, str) or not value:
+        return value, False
+    normalised = normalize_status(value)
+    return normalised, normalised != value
+
+
+def _normalise_severity(value: Any) -> tuple[Any, bool]:
+    if not isinstance(value, str) or not value:
+        return value, False
+    lower = value.lower().strip()
+    if lower in SEVERITY_LEVELS:
+        return lower, lower != value
+    return value, False
+
+
+def _normalise_confidence(value: Any) -> tuple[Any, bool]:
+    if not isinstance(value, str) or not value:
+        return value, False
+    lower = value.lower().strip()
+    if lower in CONFIDENCE_LEVELS:
+        return lower, lower != value
+    return value, False
+
+
+_DOMAIN_NORMALISERS: Dict[str, Any] = {
+    "vuln_type": _normalise_vuln_type,
+    "ruling": _normalise_status_field,
+    "severity_assessment": _normalise_severity,
+    "confidence": _normalise_confidence,
+    "final_status": _normalise_status_field,
+    "status": _normalise_status_field,
+}
+
+
+# ---- Domain validators -------------------------------------------------------
+# Each returns True if the value is acceptable after normalisation.
+
+def _validate_vuln_type(value: Any) -> bool:
+    return isinstance(value, str) and value in VULN_TYPES
+
+
+def _validate_ruling(value: Any) -> bool:
+    return isinstance(value, str) and value in AGENTIC_RULING_VALUES
+
+
+def _validate_severity(value: Any) -> bool:
+    return isinstance(value, str) and value in SEVERITY_LEVELS
+
+
+def _validate_confidence(value: Any) -> bool:
+    return isinstance(value, str) and value in CONFIDENCE_LEVELS
+
+
+def _validate_cvss_vector(value: Any) -> bool:
+    return isinstance(value, str) and bool(_CVSS_RE.match(value))
+
+
+def _validate_cwe_id(value: Any) -> bool:
+    return isinstance(value, str) and bool(_CWE_RE.match(value))
+
+
+def _validate_score_0_1(value: Any) -> bool:
+    if not isinstance(value, (int, float)):
+        return False
+    if math.isnan(value) or math.isinf(value):
+        return False
+    return 0.0 <= value <= 1.0
+
+
+def _validate_score_0_10(value: Any) -> bool:
+    if not isinstance(value, (int, float)):
+        return False
+    if math.isnan(value) or math.isinf(value):
+        return False
+    return 0.0 <= value <= 10.0
+
+
+_DOMAIN_VALIDATORS: Dict[str, Any] = {
+    "vuln_type": _validate_vuln_type,
+    "ruling": _validate_ruling,
+    "severity_assessment": _validate_severity,
+    "confidence": _validate_confidence,
+    "cvss_vector": _validate_cvss_vector,
+    "cwe_id": _validate_cwe_id,
+    "exploitability_score": _validate_score_0_1,
+    "exploitability_confidence": _validate_score_0_1,
+    "cvss_score_estimate": _validate_score_0_10,
+    "cvss_estimate": _validate_score_0_10,
+}
+
+
+# ---- Type coercion -----------------------------------------------------------
+
+def _coerce_value(value: Any, field_type: str) -> tuple[Any, bool]:
+    """Coerce a value to the target type.  Returns (value, was_coerced)."""
+    if field_type == "boolean":
+        if isinstance(value, bool):
+            return value, False
+        if isinstance(value, str):
+            return value.lower() in ("true", "yes", "1"), True
+        if isinstance(value, (int, float)):
+            return bool(value), True
+        return False, True
+
+    if field_type == "number":
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return value, False
+        try:
+            return float(value), True
+        except (ValueError, TypeError):
+            return None, True
+
+    if field_type == "integer":
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value, False
+        try:
+            return int(value), True
+        except (ValueError, TypeError):
+            return None, True
+
+    if field_type == "string":
+        if isinstance(value, str):
+            return value, False
+        if value is None:
+            return "", True
+        return str(value), True
+
+    if field_type == "array":
+        if isinstance(value, list):
+            return value, False
+        if isinstance(value, str):
+            return [value], True
+        return [], True
+
+    if field_type == "object":
+        if isinstance(value, dict):
+            return value, False
+        return {}, True
+
+    return value, False
+
+
+# ---- Main entry point --------------------------------------------------------
+
+def validate_structured_response(
+    raw: Dict[str, Any],
+    schema: Dict[str, Any],
+) -> ValidatedResponse:
+    """Validate and normalise an LLM response dict against a schema.
+
+    Per-field: coerce types, apply domain normalisers, validate domain
+    constraints, score quality.  Keeps good fields, nulls bad ones,
+    flags everything.
+    """
+    if not isinstance(raw, dict):
+        return ValidatedResponse(
+            data={}, quality=0.0,
+            incomplete=list(_get_properties(schema).keys()),
+            raw={},
+        )
+
+    properties = _get_properties(schema)
+    required = _get_required(schema)
+    weights = _resolve_weights(schema)
+
+    data: Dict[str, Any] = {}
+    fields: Dict[str, FieldResult] = {}
+    incomplete: List[str] = []
+    coerced_fields: List[str] = []
+
+    weighted_score = 0.0
+    total_weight = 0.0
+
+    for field_name, field_spec in properties.items():
+        weight = weights.get(field_name, _DEFAULT_WEIGHT)
+        total_weight += weight
+        field_type = _get_field_type(field_spec)
+        nullable = _is_nullable(field_spec)
+
+        if field_name not in raw:
+            if nullable or field_name not in required:
+                data[field_name] = None
+                fields[field_name] = FieldResult(status="missing")
+                # Optional missing fields don't penalise quality
+                weighted_score += weight * 0.5
+            else:
+                data[field_name] = None
+                fields[field_name] = FieldResult(status="missing")
+                incomplete.append(field_name)
+            continue
+
+        value = raw[field_name]
+        original = value
+        was_coerced = False
+
+        # Null handling
+        if value is None:
+            if nullable:
+                data[field_name] = None
+                fields[field_name] = FieldResult(status="ok", original=original)
+                weighted_score += weight
+                continue
+            else:
+                data[field_name] = None
+                fields[field_name] = FieldResult(status="invalid", original=original)
+                incomplete.append(field_name)
+                continue
+
+        # Type coercion
+        value, type_coerced = _coerce_value(value, field_type)
+        was_coerced = was_coerced or type_coerced
+
+        if value is None and not nullable:
+            data[field_name] = None
+            fields[field_name] = FieldResult(status="invalid", original=original)
+            incomplete.append(field_name)
+            continue
+
+        # Domain normalisation
+        normaliser = _DOMAIN_NORMALISERS.get(field_name)
+        if normaliser is not None and value is not None:
+            value, norm_coerced = normaliser(value)
+            was_coerced = was_coerced or norm_coerced
+
+        # Domain validation
+        validator = _DOMAIN_VALIDATORS.get(field_name)
+        if validator is not None and value is not None:
+            if not validator(value):
+                data[field_name] = value
+                status = "coerced" if was_coerced else "invalid"
+                fields[field_name] = FieldResult(status=status, original=original)
+                if was_coerced:
+                    coerced_fields.append(field_name)
+                    weighted_score += weight * 0.5
+                else:
+                    incomplete.append(field_name)
+                    weighted_score += weight * 0.25
+                continue
+
+        # Passed
+        data[field_name] = value
+        if was_coerced:
+            fields[field_name] = FieldResult(status="coerced", original=original)
+            coerced_fields.append(field_name)
+            weighted_score += weight * 0.9
+        else:
+            fields[field_name] = FieldResult(status="ok", original=original)
+            weighted_score += weight
+
+    quality = weighted_score / total_weight if total_weight > 0 else 0.0
+    quality = max(0.0, min(1.0, quality))
+
+    return ValidatedResponse(
+        data=data,
+        quality=quality,
+        incomplete=incomplete,
+        coerced=coerced_fields,
+        fields=fields,
+        raw=dict(raw),
+    )
+
+
+def quality_retry_prompt(original_prompt: str, incomplete: List[str],
+                         coerced: List[str]) -> str:
+    """Build a retry prompt that tells the LLM which fields need fixing."""
+    problems = []
+    if incomplete:
+        problems.append(
+            f"Missing or invalid fields: {', '.join(incomplete)}")
+    if coerced:
+        problems.append(
+            f"Fields that needed type coercion (please return correct types): "
+            f"{', '.join(coerced)}")
+    fix_section = "\n".join(f"- {p}" for p in problems)
+    return (
+        f"{original_prompt}\n\n"
+        f"IMPORTANT: Your previous response had these problems:\n"
+        f"{fix_section}\n\n"
+        f"Please fix these fields and return the complete JSON again."
+    )

--- a/core/llm/tests/test_response_validation.py
+++ b/core/llm/tests/test_response_validation.py
@@ -1,0 +1,713 @@
+"""Tests for core.llm.response_validation — per-field LLM response validation."""
+
+import pytest
+
+from core.llm.response_validation import (
+    FieldResult,
+    ValidatedResponse,
+    validate_structured_response,
+    quality_retry_prompt,
+    _coerce_value,
+    _get_field_type,
+    _get_properties,
+    _get_required,
+    _is_nullable,
+    _resolve_weights,
+    _ANALYSIS_WEIGHTS,
+    _FINDING_RESULT_WEIGHTS,
+    _DATAFLOW_VALIDATION_WEIGHTS,
+)
+from packages.llm_analysis.prompts.schemas import (
+    ANALYSIS_SCHEMA,
+    DATAFLOW_VALIDATION_SCHEMA,
+    FINDING_RESULT_SCHEMA,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema helpers
+# ---------------------------------------------------------------------------
+
+class TestGetProperties:
+    def test_simple_schema(self):
+        schema = {"field_a": "boolean", "field_b": "string"}
+        props = _get_properties(schema)
+        assert set(props.keys()) == {"field_a", "field_b"}
+        assert props["field_a"] == "boolean"
+
+    def test_json_schema(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "x": {"type": "string"},
+                "y": {"type": "number"},
+            },
+        }
+        props = _get_properties(schema)
+        assert props == {"x": {"type": "string"}, "y": {"type": "number"}}
+
+    def test_empty_schema(self):
+        assert _get_properties({}) == {}
+
+
+class TestGetRequired:
+    def test_simple_schema_all_required(self):
+        schema = {"a": "bool", "b": "string"}
+        assert _get_required(schema) == {"a", "b"}
+
+    def test_json_schema_explicit_required(self):
+        schema = {
+            "properties": {"a": {}, "b": {}, "c": {}},
+            "required": ["a", "c"],
+        }
+        assert _get_required(schema) == {"a", "c"}
+
+    def test_json_schema_no_required(self):
+        schema = {"properties": {"a": {}, "b": {}}}
+        assert _get_required(schema) == set()
+
+
+class TestGetFieldType:
+    def test_simple_string_descriptions(self):
+        assert _get_field_type("boolean") == "boolean"
+        assert _get_field_type("bool something") == "boolean"
+        assert _get_field_type("float (0.0-1.0)") == "number"
+        assert _get_field_type("int count") == "integer"
+        assert _get_field_type("string or null") == "string"
+        assert _get_field_type("str name") == "string"
+
+    def test_json_schema_type(self):
+        assert _get_field_type({"type": "boolean"}) == "boolean"
+        assert _get_field_type({"type": "number"}) == "number"
+        assert _get_field_type({"type": "string"}) == "string"
+
+    def test_json_schema_nullable_type(self):
+        assert _get_field_type({"type": ["string", "null"]}) == "string"
+        assert _get_field_type({"type": ["null", "number"]}) == "number"
+
+    def test_fallback(self):
+        assert _get_field_type(42) == "string"
+        assert _get_field_type({"no_type": True}) == "string"
+
+
+class TestIsNullable:
+    def test_simple_string_nullable(self):
+        assert _is_nullable("string or null") is True
+        assert _is_nullable("float or null") is True
+        assert _is_nullable("string - reason when null") is True
+
+    def test_simple_string_not_nullable(self):
+        assert _is_nullable("boolean") is False
+        assert _is_nullable("string") is False
+
+    def test_json_schema_nullable(self):
+        assert _is_nullable({"type": ["string", "null"]}) is True
+
+    def test_json_schema_not_nullable(self):
+        assert _is_nullable({"type": "string"}) is False
+        assert _is_nullable({"type": ["string", "number"]}) is False
+
+
+# ---------------------------------------------------------------------------
+# Weight resolution
+# ---------------------------------------------------------------------------
+
+class TestResolveWeights:
+    def test_analysis_schema(self):
+        weights = _resolve_weights(ANALYSIS_SCHEMA)
+        assert weights is _ANALYSIS_WEIGHTS
+
+    def test_finding_result_schema(self):
+        weights = _resolve_weights(FINDING_RESULT_SCHEMA)
+        assert weights is _FINDING_RESULT_WEIGHTS
+
+    def test_dataflow_validation_schema(self):
+        weights = _resolve_weights(DATAFLOW_VALIDATION_SCHEMA)
+        assert weights is _DATAFLOW_VALIDATION_WEIGHTS
+
+    def test_unknown_schema_uniform(self):
+        schema = {"custom_a": "string", "custom_b": "int"}
+        weights = _resolve_weights(schema)
+        assert weights == {"custom_a": 0.5, "custom_b": 0.5}
+
+
+# ---------------------------------------------------------------------------
+# Type coercion
+# ---------------------------------------------------------------------------
+
+class TestCoerceValue:
+    def test_boolean_native(self):
+        assert _coerce_value(True, "boolean") == (True, False)
+        assert _coerce_value(False, "boolean") == (False, False)
+
+    def test_boolean_from_string(self):
+        assert _coerce_value("true", "boolean") == (True, True)
+        assert _coerce_value("yes", "boolean") == (True, True)
+        assert _coerce_value("1", "boolean") == (True, True)
+        assert _coerce_value("false", "boolean") == (False, True)
+        assert _coerce_value("no", "boolean") == (False, True)
+
+    def test_boolean_from_int(self):
+        assert _coerce_value(1, "boolean") == (True, True)
+        assert _coerce_value(0, "boolean") == (False, True)
+
+    def test_number_native(self):
+        assert _coerce_value(3.14, "number") == (3.14, False)
+        assert _coerce_value(42, "number") == (42, False)
+
+    def test_number_from_string(self):
+        assert _coerce_value("3.14", "number") == (3.14, True)
+
+    def test_number_from_bad_string(self):
+        val, coerced = _coerce_value("not_a_number", "number")
+        assert val is None
+        assert coerced is True
+
+    def test_integer_native(self):
+        assert _coerce_value(42, "integer") == (42, False)
+
+    def test_integer_from_string(self):
+        assert _coerce_value("42", "integer") == (42, True)
+
+    def test_integer_bool_not_native(self):
+        val, coerced = _coerce_value(True, "integer")
+        assert coerced is True
+
+    def test_string_native(self):
+        assert _coerce_value("hello", "string") == ("hello", False)
+
+    def test_string_from_none(self):
+        assert _coerce_value(None, "string") == ("", True)
+
+    def test_string_from_int(self):
+        assert _coerce_value(42, "string") == ("42", True)
+
+    def test_array_native(self):
+        assert _coerce_value([1, 2], "array") == ([1, 2], False)
+
+    def test_array_from_string(self):
+        assert _coerce_value("item", "array") == (["item"], True)
+
+    def test_array_from_other(self):
+        assert _coerce_value(42, "array") == ([], True)
+
+    def test_object_native(self):
+        assert _coerce_value({"a": 1}, "object") == ({"a": 1}, False)
+
+    def test_object_from_other(self):
+        assert _coerce_value("nope", "object") == ({}, True)
+
+    def test_unknown_type_passthrough(self):
+        assert _coerce_value("val", "custom") == ("val", False)
+
+
+# ---------------------------------------------------------------------------
+# Full validation — simple schema (ANALYSIS_SCHEMA style)
+# ---------------------------------------------------------------------------
+
+class TestValidateSimpleSchema:
+    SCHEMA = {
+        "is_exploitable": "boolean",
+        "reasoning": "string",
+        "confidence": f"string (high/medium/low)",
+        "vuln_type": "string - vulnerability category",
+        "cvss_vector": "string - CVSS v3.1 vector",
+        "cwe_id": "string - CWE-NNN",
+        "exploitability_score": "float (0.0-1.0)",
+    }
+
+    def test_perfect_response(self):
+        raw = {
+            "is_exploitable": True,
+            "reasoning": "The input reaches the sink unsanitised.",
+            "confidence": "high",
+            "vuln_type": "command_injection",
+            "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "cwe_id": "CWE-78",
+            "exploitability_score": 0.95,
+        }
+        result = validate_structured_response(raw, self.SCHEMA)
+        assert result.quality == 1.0
+        assert result.incomplete == []
+        assert result.coerced == []
+        assert all(f.status == "ok" for f in result.fields.values())
+
+    def test_coerced_boolean(self):
+        raw = {
+            "is_exploitable": "true",
+            "reasoning": "Valid text",
+            "confidence": "high",
+            "vuln_type": "xss",
+            "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "cwe_id": "CWE-79",
+            "exploitability_score": 0.7,
+        }
+        result = validate_structured_response(raw, self.SCHEMA)
+        assert result.fields["is_exploitable"].status == "coerced"
+        assert result.data["is_exploitable"] is True
+        assert "is_exploitable" in result.coerced
+        assert result.quality < 1.0
+
+    def test_missing_required_field(self):
+        raw = {
+            "is_exploitable": True,
+            # "reasoning" missing
+            "confidence": "high",
+            "vuln_type": "xss",
+            "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "cwe_id": "CWE-79",
+            "exploitability_score": 0.7,
+        }
+        result = validate_structured_response(raw, self.SCHEMA)
+        assert "reasoning" in result.incomplete
+        assert result.data["reasoning"] is None
+        assert result.quality < 1.0
+
+    def test_invalid_vuln_type(self):
+        raw = {
+            "is_exploitable": True,
+            "reasoning": "text",
+            "confidence": "high",
+            "vuln_type": "totally_fake_vuln",
+            "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "cwe_id": "CWE-78",
+            "exploitability_score": 0.5,
+        }
+        result = validate_structured_response(raw, self.SCHEMA)
+        assert "vuln_type" in result.incomplete
+        assert result.quality < 1.0
+
+    def test_vuln_type_alias_normalised(self):
+        raw = {
+            "is_exploitable": True,
+            "reasoning": "text",
+            "confidence": "high",
+            "vuln_type": "null_pointer_dereference",
+            "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "cwe_id": "CWE-476",
+            "exploitability_score": 0.6,
+        }
+        result = validate_structured_response(raw, self.SCHEMA)
+        assert result.data["vuln_type"] == "null_deref"
+        assert result.fields["vuln_type"].status == "coerced"
+
+    def test_invalid_cvss_vector(self):
+        raw = {
+            "is_exploitable": True,
+            "reasoning": "text",
+            "confidence": "medium",
+            "vuln_type": "xss",
+            "cvss_vector": "not-a-cvss-vector",
+            "cwe_id": "CWE-79",
+            "exploitability_score": 0.5,
+        }
+        result = validate_structured_response(raw, self.SCHEMA)
+        assert "cvss_vector" in result.incomplete
+
+    def test_invalid_cwe_id(self):
+        raw = {
+            "is_exploitable": True,
+            "reasoning": "text",
+            "confidence": "medium",
+            "vuln_type": "xss",
+            "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "cwe_id": "79",
+            "exploitability_score": 0.5,
+        }
+        result = validate_structured_response(raw, self.SCHEMA)
+        assert "cwe_id" in result.incomplete
+
+    def test_score_out_of_range(self):
+        raw = {
+            "is_exploitable": True,
+            "reasoning": "text",
+            "confidence": "high",
+            "vuln_type": "xss",
+            "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "cwe_id": "CWE-79",
+            "exploitability_score": 1.5,
+        }
+        result = validate_structured_response(raw, self.SCHEMA)
+        assert "exploitability_score" in result.incomplete
+
+    def test_severity_normalised(self):
+        schema = {"severity_assessment": "string (critical/high/medium/low/informational)"}
+        raw = {"severity_assessment": "HIGH"}
+        result = validate_structured_response(raw, schema)
+        assert result.data["severity_assessment"] == "high"
+        assert result.fields["severity_assessment"].status == "coerced"
+
+    def test_confidence_normalised(self):
+        schema = {"confidence": "string (high/medium/low)"}
+        raw = {"confidence": "Medium"}
+        result = validate_structured_response(raw, schema)
+        assert result.data["confidence"] == "medium"
+
+    def test_non_dict_input(self):
+        result = validate_structured_response("garbage", self.SCHEMA)
+        assert result.quality == 0.0
+        assert result.data == {}
+        assert len(result.incomplete) == len(self.SCHEMA)
+
+    def test_empty_dict(self):
+        result = validate_structured_response({}, self.SCHEMA)
+        assert result.quality < 1.0
+        assert len(result.incomplete) > 0
+
+
+# ---------------------------------------------------------------------------
+# Full validation — JSON Schema (FINDING_RESULT_SCHEMA style)
+# ---------------------------------------------------------------------------
+
+class TestValidateJsonSchema:
+    def test_perfect_finding_result(self):
+        raw = {
+            "finding_id": "FIND-001",
+            "is_true_positive": True,
+            "is_exploitable": True,
+            "reasoning": "Clear dataflow from user input to exec().",
+            "confidence": "high",
+            "severity_assessment": "critical",
+            "ruling": "validated",
+            "vuln_type": "command_injection",
+            "exploitability_score": 0.95,
+            "attack_scenario": "Attacker submits crafted input.",
+            "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "cvss_score_estimate": 9.8,
+            "cwe_id": "CWE-78",
+            "dataflow_summary": "user_input → exec()",
+            "remediation": "Use parameterised API",
+            "false_positive_reason": None,
+            "tool": "semgrep",
+            "rule_id": "python.injection.exec",
+            "exploit_code": None,
+            "patch_code": None,
+        }
+        result = validate_structured_response(raw, FINDING_RESULT_SCHEMA)
+        assert result.quality == 1.0
+        assert result.incomplete == []
+        assert result.coerced == []
+
+    def test_minimal_required_only(self):
+        raw = {
+            "finding_id": "FIND-002",
+            "is_true_positive": False,
+            "is_exploitable": False,
+            "reasoning": "Dead code path.",
+        }
+        result = validate_structured_response(raw, FINDING_RESULT_SCHEMA)
+        assert "finding_id" not in result.incomplete
+        assert "reasoning" not in result.incomplete
+        assert result.quality > 0.0
+
+    def test_nullable_fields_accepted(self):
+        raw = {
+            "finding_id": "FIND-003",
+            "is_true_positive": True,
+            "is_exploitable": False,
+            "reasoning": "Sanitiser effective.",
+            "confidence": None,
+            "attack_scenario": None,
+            "exploit_code": None,
+            "patch_code": None,
+            "cvss_vector": None,
+            "vuln_type": None,
+            "cwe_id": None,
+            "false_positive_reason": None,
+            "tool": None,
+            "rule_id": None,
+        }
+        result = validate_structured_response(raw, FINDING_RESULT_SCHEMA)
+        for field_name in ("confidence", "attack_scenario", "exploit_code"):
+            assert result.fields[field_name].status == "ok"
+            assert result.data[field_name] is None
+
+    def test_invalid_ruling_value(self):
+        raw = {
+            "finding_id": "FIND-004",
+            "is_true_positive": True,
+            "is_exploitable": True,
+            "reasoning": "text",
+            "ruling": "DEFINITELY_BAD",
+        }
+        result = validate_structured_response(raw, FINDING_RESULT_SCHEMA)
+        assert "ruling" in result.incomplete or result.fields["ruling"].status in ("invalid", "coerced")
+
+
+# ---------------------------------------------------------------------------
+# Full validation — dataflow schema
+# ---------------------------------------------------------------------------
+
+class TestValidateDataflowSchema:
+    def test_perfect_dataflow(self):
+        raw = {
+            "source_type": "user_input",
+            "source_attacker_controlled": True,
+            "source_reasoning": "HTTP parameter",
+            "sanitizers_found": 1,
+            "sanitizers_effective": False,
+            "sanitizer_details": [{"name": "htmlEscape", "purpose": "XSS", "bypass_possible": True, "bypass_method": "attribute context"}],
+            "path_reachable": True,
+            "reachability_barriers": [],
+            "is_exploitable": True,
+            "exploitability_confidence": 0.9,
+            "exploitability_reasoning": "Direct flow to innerHTML",
+            "attack_complexity": "low",
+            "attack_prerequisites": ["authenticated user"],
+            "attack_payload_concept": "<img onerror=alert(1)>",
+            "impact_if_exploited": "XSS → session hijack",
+            "cvss_estimate": 7.5,
+            "false_positive": False,
+            "false_positive_reason": "",
+        }
+        result = validate_structured_response(raw, DATAFLOW_VALIDATION_SCHEMA)
+        assert result.quality == 1.0
+        assert result.incomplete == []
+
+    def test_exploitability_confidence_out_of_range(self):
+        raw = {
+            "source_type": "user_input",
+            "source_attacker_controlled": True,
+            "source_reasoning": "HTTP param",
+            "sanitizers_found": 0,
+            "sanitizers_effective": False,
+            "sanitizer_details": [],
+            "path_reachable": True,
+            "reachability_barriers": [],
+            "is_exploitable": True,
+            "exploitability_confidence": 1.5,
+            "exploitability_reasoning": "text",
+            "attack_complexity": "low",
+            "attack_prerequisites": [],
+            "attack_payload_concept": "payload",
+            "impact_if_exploited": "RCE",
+            "cvss_estimate": 9.0,
+            "false_positive": False,
+            "false_positive_reason": "",
+        }
+        result = validate_structured_response(raw, DATAFLOW_VALIDATION_SCHEMA)
+        assert "exploitability_confidence" in result.incomplete
+
+    def test_cvss_estimate_out_of_range(self):
+        raw = {
+            "source_type": "config",
+            "source_attacker_controlled": False,
+            "source_reasoning": "hardcoded",
+            "sanitizers_found": 0,
+            "sanitizers_effective": True,
+            "sanitizer_details": [],
+            "path_reachable": False,
+            "reachability_barriers": ["auth required"],
+            "is_exploitable": False,
+            "exploitability_confidence": 0.2,
+            "exploitability_reasoning": "not reachable",
+            "attack_complexity": "high",
+            "attack_prerequisites": ["admin access"],
+            "attack_payload_concept": "",
+            "impact_if_exploited": "none",
+            "cvss_estimate": 15.0,
+            "false_positive": True,
+            "false_positive_reason": "unreachable",
+        }
+        result = validate_structured_response(raw, DATAFLOW_VALIDATION_SCHEMA)
+        assert "cvss_estimate" in result.incomplete
+
+
+# ---------------------------------------------------------------------------
+# Quality scoring
+# ---------------------------------------------------------------------------
+
+class TestQualityScoring:
+    def test_all_present_correct_is_1(self):
+        schema = {"a": "boolean", "b": "string"}
+        raw = {"a": True, "b": "hello"}
+        result = validate_structured_response(raw, schema)
+        assert result.quality == 1.0
+
+    def test_all_missing_required_is_low(self):
+        schema = {"a": "boolean", "b": "string"}
+        result = validate_structured_response({}, schema)
+        assert result.quality < 0.5
+
+    def test_coerced_field_slightly_penalised(self):
+        schema = {"a": "boolean", "b": "string"}
+        raw_perfect = {"a": True, "b": "text"}
+        raw_coerced = {"a": "true", "b": "text"}
+        q_perfect = validate_structured_response(raw_perfect, schema).quality
+        q_coerced = validate_structured_response(raw_coerced, schema).quality
+        assert q_perfect > q_coerced
+        assert q_coerced > 0.8
+
+    def test_quality_bounded_0_1(self):
+        schema = {"x": "string"}
+        for raw in [{}, {"x": "ok"}, {"x": 42}]:
+            result = validate_structured_response(raw, schema)
+            assert 0.0 <= result.quality <= 1.0
+
+    def test_weighted_fields(self):
+        schema = ANALYSIS_SCHEMA
+        raw_high_weight = {
+            "is_exploitable": True,
+            "reasoning": "text",
+            "is_true_positive": True,
+        }
+        raw_low_weight = {
+            "false_positive_reason": "test",
+            "remediation": "fix it",
+            "prerequisites": ["none"],
+        }
+        q_high = validate_structured_response(raw_high_weight, schema).quality
+        q_low = validate_structured_response(raw_low_weight, schema).quality
+        assert q_high > q_low
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_nan_score_rejected(self):
+        schema = {"exploitability_score": "float (0.0-1.0)"}
+        raw = {"exploitability_score": float("nan")}
+        result = validate_structured_response(raw, schema)
+        assert "exploitability_score" in result.incomplete
+
+    def test_inf_score_rejected(self):
+        schema = {"exploitability_score": "float (0.0-1.0)"}
+        raw = {"exploitability_score": float("inf")}
+        result = validate_structured_response(raw, schema)
+        assert "exploitability_score" in result.incomplete
+
+    def test_extra_fields_ignored(self):
+        schema = {"a": "string"}
+        raw = {"a": "hello", "extra": "ignored"}
+        result = validate_structured_response(raw, schema)
+        assert "extra" not in result.data
+        assert result.quality == 1.0
+
+    def test_raw_preserved(self):
+        schema = {"a": "string"}
+        raw = {"a": "hello", "extra": "kept"}
+        result = validate_structured_response(raw, schema)
+        assert result.raw == {"a": "hello", "extra": "kept"}
+
+    def test_original_preserved_on_coercion(self):
+        schema = {"a": "boolean"}
+        raw = {"a": "yes"}
+        result = validate_structured_response(raw, schema)
+        assert result.fields["a"].original == "yes"
+        assert result.data["a"] is True
+
+    def test_null_required_field_invalid(self):
+        schema = {
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        }
+        raw = {"name": None}
+        result = validate_structured_response(raw, schema)
+        assert "name" in result.incomplete
+        assert result.fields["name"].status == "invalid"
+
+    def test_null_nullable_field_ok(self):
+        schema = {
+            "properties": {"name": {"type": ["string", "null"]}},
+            "required": ["name"],
+        }
+        raw = {"name": None}
+        result = validate_structured_response(raw, schema)
+        assert result.fields["name"].status == "ok"
+        assert result.data["name"] is None
+
+
+# ---------------------------------------------------------------------------
+# quality_retry_prompt
+# ---------------------------------------------------------------------------
+
+class TestQualityRetryPrompt:
+    def test_incomplete_fields(self):
+        prompt = quality_retry_prompt("Analyze this.", ["reasoning", "vuln_type"], [])
+        assert "reasoning" in prompt
+        assert "vuln_type" in prompt
+        assert "Missing or invalid" in prompt
+        assert "Analyze this." in prompt
+
+    def test_coerced_fields(self):
+        prompt = quality_retry_prompt("Analyze this.", [], ["is_exploitable"])
+        assert "is_exploitable" in prompt
+        assert "type coercion" in prompt
+
+    def test_both(self):
+        prompt = quality_retry_prompt("Analyze.", ["cwe_id"], ["confidence"])
+        assert "cwe_id" in prompt
+        assert "confidence" in prompt
+
+    def test_empty_no_crash(self):
+        prompt = quality_retry_prompt("Analyze.", [], [])
+        assert "Analyze." in prompt
+
+
+# ---------------------------------------------------------------------------
+# Real-schema integration
+# ---------------------------------------------------------------------------
+
+class TestRealSchemaIntegration:
+    def test_analysis_schema_good_response(self):
+        raw = {
+            "is_true_positive": True,
+            "is_exploitable": True,
+            "exploitability_score": 0.85,
+            "confidence": "high",
+            "severity_assessment": "critical",
+            "ruling": "validated",
+            "reasoning": "Direct user input flows to os.system() without sanitisation.",
+            "attack_scenario": "Attacker sends `; rm -rf /` in the name field.",
+            "prerequisites": ["Network access to web app"],
+            "impact": "Remote code execution",
+            "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "cvss_score_estimate": 9.8,
+            "vuln_type": "command_injection",
+            "cwe_id": "CWE-78",
+            "dataflow_summary": "request.params['name'] → os.system(cmd)",
+            "remediation": "Use subprocess.run with list args",
+            "false_positive_reason": None,
+        }
+        result = validate_structured_response(raw, ANALYSIS_SCHEMA)
+        assert result.quality >= 0.95
+        assert result.incomplete == []
+
+    def test_analysis_schema_typical_llm_sloppiness(self):
+        raw = {
+            "is_true_positive": "yes",
+            "is_exploitable": "True",
+            "exploitability_score": "0.7",
+            "confidence": "HIGH",
+            "severity_assessment": "High",
+            "ruling": "Validated",
+            "reasoning": "Input reaches sink.",
+            "attack_scenario": "Craft malicious input.",
+            "prerequisites": "Network access",
+            "impact": "RCE",
+            "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "cvss_score_estimate": 9.8,
+            "vuln_type": "RCE",
+            "cwe_id": "CWE-78",
+            "dataflow_summary": "input → exec",
+            "remediation": "Fix it",
+            "false_positive_reason": None,
+        }
+        result = validate_structured_response(raw, ANALYSIS_SCHEMA)
+        assert result.data["is_true_positive"] is True
+        assert result.data["is_exploitable"] is True
+        assert result.data["confidence"] == "high"
+        assert result.data["severity_assessment"] == "high"
+        assert result.data["vuln_type"] == "command_injection"
+        assert result.data["prerequisites"] == ["Network access"]
+        assert result.quality > 0.5
+
+    def test_finding_result_schema_weight_detection(self):
+        weights = _resolve_weights(FINDING_RESULT_SCHEMA)
+        assert weights is _FINDING_RESULT_WEIGHTS
+
+    def test_dataflow_schema_weight_detection(self):
+        weights = _resolve_weights(DATAFLOW_VALIDATION_SCHEMA)
+        assert weights is _DATAFLOW_VALIDATION_WEIGHTS

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -459,15 +459,21 @@ class AutonomousSecurityAgentV2:
         try:
             logger.info("Sending dataflow to LLM for deep validation...")
 
-            validation, _response = self.llm.generate_structured(
+            raw_validation, _response = self.llm.generate_structured(
                 prompt=validation_prompt,
                 schema=validation_schema,
                 system_prompt=system_prompt
             )
 
-            if validation is None:
+            if raw_validation is None:
                 logger.info("No external LLM available — skipping dataflow validation")
                 return {}
+
+            from core.llm.response_validation import validate_structured_response
+            validated = validate_structured_response(raw_validation, validation_schema)
+            validation = validated.data
+            if validated.quality < 0.5:
+                logger.warning(f"Low-quality dataflow validation (q={validated.quality:.2f}), incomplete: {validated.incomplete}")
 
             logger.info("✓ Dataflow validation complete:")
             logger.info(f"  Source attacker-controlled: {validation.get('source_attacker_controlled')}")
@@ -562,15 +568,21 @@ class AutonomousSecurityAgentV2:
                 logger.info("Sending vulnerability to LLM for analysis...")
 
             # Use LLM for intelligent analysis
-            analysis, _full_response = self.llm.generate_structured(
+            raw_analysis, _full_response = self.llm.generate_structured(
                 prompt=prompt,
                 schema=analysis_schema,
                 system_prompt=system_prompt
             )
 
-            if analysis is None:
+            if raw_analysis is None:
                 logger.debug("Prep mode — Phase 4 will handle analysis")
                 return False
+
+            from core.llm.response_validation import validate_structured_response
+            validated = validate_structured_response(raw_analysis, analysis_schema)
+            analysis = validated.data
+            if validated.quality < 0.5:
+                logger.warning(f"Low-quality LLM response (q={validated.quality:.2f}), incomplete: {validated.incomplete}")
 
             vuln.exploitable = analysis.get("is_exploitable", False)
             vuln.exploitability_score = analysis.get("exploitability_score", 0.0)

--- a/packages/llm_analysis/cc_dispatch.py
+++ b/packages/llm_analysis/cc_dispatch.py
@@ -73,7 +73,18 @@ def invoke_cc_simple(prompt, schema, repo_path, claude_bin, out_dir,
     model = parsed.pop("analysed_by", "claude-code")
     duration = parsed.pop("duration_seconds", 0)
 
-    return DispatchResult(result=parsed, cost=cost, tokens=tokens, model=model, duration=duration)
+    quality = 1.0
+    if schema and isinstance(parsed, dict) and "error" not in parsed:
+        from core.llm.response_validation import validate_structured_response
+        validated = validate_structured_response(parsed, effective_schema)
+        parsed = validated.data
+        quality = validated.quality
+        if validated.quality < 0.5:
+            logger.warning("Low-quality CC response (q=%.2f), incomplete: %s",
+                           validated.quality, validated.incomplete)
+
+    return DispatchResult(result=parsed, cost=cost, tokens=tokens, model=model,
+                          duration=duration, quality=quality)
 
 
 def write_debug(

--- a/packages/llm_analysis/dispatch.py
+++ b/packages/llm_analysis/dispatch.py
@@ -28,12 +28,14 @@ class DispatchResult:
     """Normalised result from any dispatch path (external LLM or CC)."""
 
     def __init__(self, result: Dict[str, Any], cost: float = 0.0,
-                 tokens: int = 0, model: str = "", duration: float = 0.0):
+                 tokens: int = 0, model: str = "", duration: float = 0.0,
+                 quality: float = 1.0):
         self.result = result
         self.cost = cost
         self.tokens = tokens
         self.model = model
         self.duration = duration
+        self.quality = quality
 
 
 class DispatchTask:

--- a/packages/llm_analysis/tests/test_orchestrator.py
+++ b/packages/llm_analysis/tests/test_orchestrator.py
@@ -192,6 +192,59 @@ class TestOrchestrate:
         out_file = tmp_path / "orch" / "orchestrated_report.json"
         assert out_file.exists()
 
+    def test_sloppy_response_normalised_through_pipeline(self, tmp_path):
+        """Sloppy LLM output is normalised by response validation in cc_dispatch."""
+        findings = [_make_finding("f-001", "py/sql-injection", "db.py", 42)]
+        report = _make_prep_report(findings=findings)
+        report_path = tmp_path / "report.json"
+        report_path.write_text(json.dumps(report))
+
+        sloppy = {
+            "finding_id": "f-001",
+            "is_true_positive": "yes",          # string, not bool
+            "is_exploitable": "True",            # string, not bool
+            "exploitability_score": "0.85",      # string, not float
+            "severity_assessment": "HIGH",       # uppercase
+            "confidence": "Medium",              # title case
+            "ruling": "Validated",               # title case
+            "vuln_type": "sqli",                 # alias
+            "reasoning": "Input reaches query unsanitised.",
+            "attack_scenario": "Inject SQL via name parameter.",
+            "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "cwe_id": "CWE-89",
+        }
+        cc_results = [json.dumps(sloppy)]
+
+        with patch.dict(os.environ, {}, clear=True), \
+             patch("packages.llm_analysis.orchestrator.shutil.which", return_value="/usr/bin/claude"), \
+             patch("packages.llm_analysis.cc_dispatch.subprocess.run",
+                   side_effect=_mock_subprocess_ok(cc_results)):
+            result = orchestrate(
+                prep_report_path=report_path,
+                repo_path=tmp_path,
+                out_dir=tmp_path / "orch",
+            )
+
+        assert result is not None
+        finding = result["results"][0]
+
+        # Bool coercion: string "True"/"yes" → True
+        assert finding["is_true_positive"] is True
+        assert finding["is_exploitable"] is True
+        assert finding["exploitable"] is True
+
+        # Numeric coercion: string "0.85" → 0.85
+        assert finding["exploitability_score"] == 0.85
+
+        # Domain normalisation: uppercase/titlecase → lowercase
+        # severity_assessment is overwritten by score_finding() from CVSS vector
+        # (9.8 = critical), so we check confidence and ruling instead
+        assert finding["confidence"] == "medium"
+        assert finding["ruling"] == "validated"
+
+        # Vuln type alias normalisation: "sqli" → "sql_injection"
+        assert finding["vuln_type"] == "sql_injection"
+
     def test_empty_findings(self, tmp_path):
         """No findings in report -> returns None."""
         report = _make_prep_report(findings=[])


### PR DESCRIPTION
Adds boundary validation at the generate_structured return point. Instead of all-or-nothing Pydantic rejection, validates each field independently — coerces types, normalises domain values (vuln_type aliases, severity/confidence case, CVSS format, CWE format), scores quality with weighted fields, and flags incomplete/coerced fields for potential retry.

Wired into all four primary dispatch paths: agent.py analysis + dataflow validation, cc_dispatch CC subprocess output, and orchestrator external-LLM dispatch. Also fixes envelope probe passing a model-name string where ModelConfig object was expected.