### PR TITLE
feat: wire cross-family prompt injection checker into orchestrator

### DIFF
--- a/core/security/llm_family.py
+++ b/core/security/llm_family.py
@@ -25,22 +25,27 @@ from __future__ import annotations
 from typing import Iterable, Literal, Optional
 
 
-Family = Literal["anthropic", "openai", "google", "meta", "ollama", "unknown"]
+Family = Literal["anthropic", "openai", "google", "meta", "mistral", "ollama", "unknown"]
 
 
-_FAMILY_PREFIXES: tuple[tuple[str, Family], ...] = (
-    ("claude-", "anthropic"),
-    ("anthropic/", "anthropic"),
-    ("gpt-", "openai"),
-    ("o1-", "openai"),
-    ("o3-", "openai"),
-    ("openai/", "openai"),
-    ("gemini-", "google"),
-    ("gemini/", "google"),
-    ("google/", "google"),
-    ("llama-", "meta"),
-    ("meta-llama/", "meta"),
-    ("ollama/", "ollama"),
+_PROVIDER_STEMS: tuple[tuple[str, Family], ...] = (
+    ("anthropic", "anthropic"),
+    ("openai", "openai"),
+    ("gemini", "google"),
+    ("google", "google"),
+    ("meta-llama", "meta"),
+    ("mistral", "mistral"),
+    ("ollama", "ollama"),
+)
+
+_MODEL_STEMS: tuple[tuple[str, Family], ...] = (
+    ("claude", "anthropic"),
+    ("gpt", "openai"),
+    ("o1", "openai"),
+    ("o3", "openai"),
+    ("gemini", "google"),
+    ("llama", "meta"),
+    ("mistral", "mistral"),
 )
 
 
@@ -49,11 +54,16 @@ def family_of(model_id: str) -> Family:
 
     Matching is by prefix on the lowered identifier (so ``claude-opus-4-7``
     and ``anthropic/claude-haiku-4-5`` both resolve to ``"anthropic"``).
+    Provider routing prefixes (``provider/model``) are checked first so
+    that e.g. ``ollama/llama-3`` resolves to ``ollama`` not ``meta``.
     Unknown identifiers return ``"unknown"``.
     """
     needle = model_id.lower()
-    for prefix, family in _FAMILY_PREFIXES:
-        if needle.startswith(prefix):
+    for stem, family in _PROVIDER_STEMS:
+        if needle.startswith(stem + "/"):
+            return family
+    for stem, family in _MODEL_STEMS:
+        if needle.startswith(stem + "-"):
             return family
     return "unknown"
 

--- a/core/security/tests/test_llm_family.py
+++ b/core/security/tests/test_llm_family.py
@@ -39,10 +39,16 @@ def test_meta_models_resolve_to_meta():
 def test_ollama_resolves_to_ollama():
     assert family_of("ollama/llama3-8b") == "ollama"
     assert family_of("ollama/qwen2.5-7b") == "ollama"
+    assert family_of("ollama/llama-3.1-8b") == "ollama"  # not meta
+
+
+def test_mistral_family():
+    assert family_of("mistral-7b") == "mistral"
+    assert family_of("mistral-small-latest") == "mistral"
+    assert family_of("mistral/mistral-large") == "mistral"
 
 
 def test_unknown_models_resolve_to_unknown():
-    assert family_of("mistral-7b") == "unknown"
     assert family_of("custom-model-xyz") == "unknown"
     assert family_of("") == "unknown"
 

--- a/packages/llm_analysis/dispatch.py
+++ b/packages/llm_analysis/dispatch.py
@@ -241,6 +241,7 @@ def dispatch_task(
                 dispatch_result = future.result()
                 processed = task.process_result(item, dispatch_result)
                 processed["finding_id"] = item_id  # Authoritative — overrides any LLM-set value
+                processed["_quality"] = getattr(dispatch_result, "quality", 1.0)
                 item_cost = processed.get("cost_usd", 0)
                 running_cost += item_cost
                 results.append(processed)
@@ -253,14 +254,18 @@ def dispatch_task(
                     raw = ""
                     if hasattr(dispatch_result, "result") and isinstance(dispatch_result.result, dict):
                         raw = dispatch_result.result.get("content", "")
+                    raw_text = raw or str(dispatch_result.result)
                     defense_telemetry.record_response(
                         model_id=processed.get("analysed_by", "unknown"),
                         profile_name=profile_name,
                         nonce=nonce,
-                        raw_response=raw or str(dispatch_result.result),
+                        raw_response=raw_text,
                         schema_accepted=True,
                         schema_retried=False,
                     )
+                    from core.security.prompt_envelope import nonce_leaked_in
+                    if nonce_leaked_in(nonce, raw_text):
+                        processed["_nonce_leaked"] = True
 
                 # Feed costs to tracker for budget enforcement
                 if item_cost > 0:

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -234,7 +234,7 @@ def orchestrate(
     from packages.llm_analysis.dispatch import dispatch_task, DispatchResult
     from packages.llm_analysis.tasks import (
         AnalysisTask, ExploitTask, PatchTask, ConsensusTask, GroupAnalysisTask,
-        RetryTask,
+        RetryTask, CrossFamilyCheckTask,
     )
     from core.security.prompt_defense_profiles import (
         CONSERVATIVE, PASSTHROUGH, get_profile_for,
@@ -378,10 +378,30 @@ def orchestrate(
     # Its results are in finding["feasibility"] and included in the prompt.
     #
     # AnalysisTask (above)  → Stages A-D: is this real? how exploitable?
+    # CrossFamilyCheckTask  → Re-check suspicious responses via different family
     # RetryTask             → Stage F: self-consistency check + retry
     # ConsensusTask         → Second model votes (if configured)
     # ExploitTask/PatchTask → Generate code (only for final-verdict exploitable)
     # GroupAnalysisTask     → Cross-finding patterns
+
+    # Cross-family re-check: suspicious responses (low quality / nonce leaked)
+    # re-dispatched through a model from a different training lineage.
+    if dispatch_mode == "external_llm" and analysis_model:
+        checker_model = _resolve_cross_family_checker(
+            analysis_model, role_resolution,
+        )
+        if checker_model:
+            checker_name = checker_model.model_name
+            checker_profile = get_profile_for(checker_name)
+            dispatch_task(
+                CrossFamilyCheckTask(
+                    checker_model=checker_model,
+                    results_by_id=results_by_id,
+                    profile=checker_profile,
+                ),
+                findings, dispatch_fn, role_resolution,
+                results_by_id, cost_tracker, max_parallel,
+            )
 
     # Stage F: self-consistency check + retry contradictions and low confidence
     dispatch_task(
@@ -443,6 +463,10 @@ def orchestrate(
 
     consensus_disputes = sum(1 for r in per_finding_results
                              if r.get("consensus") == "disputed")
+    cross_family_checked = sum(1 for r in per_finding_results
+                               if r.get("cross_family_check"))
+    cross_family_disputes = sum(1 for r in per_finding_results
+                                if r.get("cross_family_disputed"))
     retries = sum(1 for r in per_finding_results if r.get("retried"))
     low_confidence = sum(1 for r in per_finding_results if r.get("low_confidence"))
 
@@ -458,6 +482,8 @@ def orchestrate(
         "findings_failed": sum(1 for r in per_finding_results if "error" in r),
         "structural_groups": len(groups),
         "consensus_disputes": consensus_disputes,
+        "cross_family_checked": cross_family_checked,
+        "cross_family_disputes": cross_family_disputes,
         "low_confidence_retries": retries,
         "low_confidence_remaining": low_confidence,
         "group_analyses": len(group_analyses),
@@ -501,11 +527,69 @@ def orchestrate(
     thinking = cost_summary.get("thinking_tokens", 0)
     if thinking > 0:
         print(f"  Thinking tokens: {thinking:,}")
+    if cross_family_checked:
+        cf_parts = [f"{cross_family_checked} cross-family checked"]
+        if cross_family_disputes:
+            cf_parts.append(f"{cross_family_disputes} disputed")
+        print(f"  {', '.join(cf_parts)}")
     if groups:
         print(f"  Cross-finding groups: {len(groups)}")
     print(f"  Report: {out_path}")
 
     return merged
+
+
+def _resolve_cross_family_checker(
+    analysis_model: Any,
+    role_resolution: Dict[str, Any],
+) -> Optional[Any]:
+    """Pick a cross-family checker model from resolved roles or env auto-detect.
+
+    Returns a ModelConfig from a different training lineage than the
+    analysis model, or None if none is available.  Prefers models already
+    in the role resolution (consensus / fallback); falls back to
+    auto-detecting a cheap model from an env-var API key.
+    """
+    from core.security.llm_family import family_of, same_family
+
+    primary_name = analysis_model.model_name
+    primary_family = family_of(primary_name)
+
+    candidates = (
+        role_resolution.get("consensus_models", [])
+        + role_resolution.get("fallback_models", [])
+    )
+    for m in candidates:
+        if not same_family(primary_name, m.model_name):
+            logger.info("Cross-family checker: %s (from resolved roles)", m.model_name)
+            return m
+
+    return _auto_detect_cross_family_checker(primary_family)
+
+
+def _auto_detect_cross_family_checker(primary_family: str) -> Optional[Any]:
+    """Auto-detect a cheap cross-family model from environment API keys."""
+    import os
+    from core.llm.config import ModelConfig
+    from core.llm.model_data import PROVIDER_ENV_KEYS
+
+    _CHEAP_CHECKERS: dict[str, tuple[str, str]] = {
+        "anthropic": ("anthropic", "claude-haiku-4-5-20251001"),
+        "google": ("gemini", "gemini-2.5-flash"),
+        "openai": ("openai", "gpt-4.1-mini"),
+        "mistral": ("mistral", "mistral-small-latest"),
+    }
+    for family, (provider, model_name) in _CHEAP_CHECKERS.items():
+        if family == primary_family:
+            continue
+        env_key = PROVIDER_ENV_KEYS.get(provider)
+        if env_key and os.environ.get(env_key):
+            logger.info(
+                "Cross-family checker: %s (auto-detected from %s)",
+                model_name, env_key,
+            )
+            return ModelConfig(provider=provider, model_name=model_name)
+    return None
 
 
 def _check_self_consistency(results_by_id: Dict[str, Dict]) -> None:

--- a/packages/llm_analysis/tasks.py
+++ b/packages/llm_analysis/tasks.py
@@ -454,3 +454,87 @@ class RetryTask(AnalysisTask):
             if not was_contradictory and not decisive:
                 prior_results[fid]["low_confidence"] = True
         return results
+
+
+class CrossFamilyCheckTask(AnalysisTask):
+    """Re-analyse suspicious findings through a model from a different family.
+
+    Triggers on low quality or nonce leakage.  If the checker disagrees
+    with the primary, takes the conservative (exploitable) verdict and
+    flags ``cross_family_disputed``.  Agreed verdicts get
+    ``cross_family_agreed``.
+    """
+
+    name = "cross-family-check"
+    QUALITY_THRESHOLD = 0.7
+
+    def __init__(self, checker_model, results_by_id=None,
+                 profile: ModelDefenseProfile = CONSERVATIVE):
+        super().__init__(profile=profile)
+        self.checker_model = checker_model
+        self.results_by_id = results_by_id or {}
+
+    def get_models(self, role_resolution):
+        return [self.checker_model]
+
+    def select_items(self, findings, prior_results):
+        selected = []
+        for f in findings:
+            fid = f.get("finding_id")
+            r = prior_results.get(fid, {})
+            if "error" in r:
+                continue
+            quality = r.get("_quality", 1.0)
+            nonce_leaked = r.get("_nonce_leaked", False)
+            if quality < self.QUALITY_THRESHOLD or nonce_leaked:
+                selected.append(f)
+        return selected
+
+    def finalize(self, results, prior_results):
+        from core.security.llm_family import same_family
+
+        for r in results:
+            fid = r.get("finding_id")
+            if not fid or "error" in r:
+                continue
+            primary = prior_results.get(fid, {})
+            if "error" in primary:
+                continue
+
+            actual_model = r.get("analysed_by", "unknown")
+            primary_model = primary.get("analysed_by", "unknown")
+            trigger = "nonce_leaked" if primary.get("_nonce_leaked") else "low_quality"
+
+            # Guard: LLMClient internal fallback can silently route
+            # through a same-family model, defeating the cross-family
+            # intent. If the actual responder is same-family as the
+            # primary, record the failure but don't adjudicate.
+            if same_family(primary_model, actual_model):
+                prior_results[fid]["cross_family_check"] = {
+                    "checker_model": actual_model,
+                    "intended_model": self.checker_model.model_name,
+                    "trigger": trigger,
+                    "verdict": "skipped — checker fell back to same family",
+                }
+                continue
+
+            primary_exploitable = primary.get("is_exploitable", False)
+            checker_exploitable = r.get("is_exploitable", False)
+
+            check_record = {
+                "checker_model": actual_model,
+                "checker_exploitable": checker_exploitable,
+                "checker_ruling": r.get("ruling"),
+                "trigger": trigger,
+            }
+
+            if primary_exploitable != checker_exploitable:
+                prior_results[fid]["is_exploitable"] = True
+                prior_results[fid]["cross_family_disputed"] = True
+                check_record["verdict"] = "disputed — conservative override"
+            else:
+                prior_results[fid]["cross_family_agreed"] = True
+                check_record["verdict"] = "agreed"
+
+            prior_results[fid]["cross_family_check"] = check_record
+        return results

--- a/packages/llm_analysis/tests/test_cross_family.py
+++ b/packages/llm_analysis/tests/test_cross_family.py
@@ -1,0 +1,367 @@
+"""Tests for cross-family checker wiring.
+
+Covers:
+- CrossFamilyCheckTask selection (quality threshold, nonce leaked)
+- CrossFamilyCheckTask adjudication (agree, dispute → conservative override)
+- _resolve_cross_family_checker (resolved roles, auto-detect from env)
+- dispatch.py quality/nonce persistence on result dicts
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from core.llm.config import ModelConfig
+from core.security.llm_family import (
+    Family,
+    family_of,
+    same_family,
+    select_cross_family_checker,
+)
+from core.security.prompt_defense_profiles import CONSERVATIVE
+from packages.llm_analysis.dispatch import DispatchResult
+from packages.llm_analysis.tasks import CrossFamilyCheckTask
+
+
+# ---------------------------------------------------------------------------
+# Helper fixtures
+# ---------------------------------------------------------------------------
+
+def _model(provider: str, name: str, role: str | None = None) -> ModelConfig:
+    return ModelConfig(provider=provider, model_name=name, role=role)
+
+
+GEMINI_PRIMARY = _model("gemini", "gemini-2.5-pro", role="analysis")
+ANTHROPIC_CHECKER = _model("anthropic", "claude-haiku-4-5-20251001")
+OPENAI_FALLBACK = _model("openai", "gpt-4.1-mini", role="fallback")
+
+
+def _finding(fid: str) -> dict:
+    return {"finding_id": fid, "file_path": "vuln.c", "start_line": 10,
+            "rule_id": "CWE-120", "code_snippet": "strcpy(buf, input);"}
+
+
+def _result(fid: str, exploitable: bool = True, quality: float = 0.9,
+            nonce_leaked: bool = False,
+            analysed_by: str = "gemini-2.5-pro") -> dict:
+    r = {
+        "finding_id": fid,
+        "is_exploitable": exploitable,
+        "is_true_positive": True,
+        "ruling": "validated" if exploitable else "false_positive",
+        "reasoning": "test reasoning",
+        "confidence": "high",
+        "analysed_by": analysed_by,
+        "_quality": quality,
+    }
+    if nonce_leaked:
+        r["_nonce_leaked"] = True
+    return r
+
+
+# ---------------------------------------------------------------------------
+# llm_family.py — already exists, but verify our assumptions
+# ---------------------------------------------------------------------------
+
+class TestFamilyOf:
+    def test_anthropic(self):
+        assert family_of("claude-opus-4-6") == "anthropic"
+        assert family_of("claude-haiku-4-5-20251001") == "anthropic"
+
+    def test_google(self):
+        assert family_of("gemini-2.5-pro") == "google"
+        assert family_of("gemini-2.5-flash") == "google"
+
+    def test_openai(self):
+        assert family_of("gpt-4.1-mini") == "openai"
+        assert family_of("o3-mini") == "openai"
+
+    def test_unknown(self):
+        assert family_of("some-random-model") == "unknown"
+
+    def test_cross_family(self):
+        assert not same_family("claude-opus-4-6", "gemini-2.5-pro")
+        assert same_family("claude-opus-4-6", "claude-haiku-4-5-20251001")
+
+    def test_unknown_not_same(self):
+        assert not same_family("unknown-a", "unknown-b")
+
+
+class TestSelectCrossFamilyChecker:
+    def test_picks_different_family(self):
+        result = select_cross_family_checker(
+            "gemini-2.5-pro",
+            ["gemini-2.5-flash", "claude-haiku-4-5-20251001", "gpt-4.1-mini"],
+        )
+        assert result == "claude-haiku-4-5-20251001"
+
+    def test_skips_same_family(self):
+        result = select_cross_family_checker(
+            "gemini-2.5-pro",
+            ["gemini-2.5-flash", "gemini/gemini-pro"],
+        )
+        assert result is None
+
+    def test_skips_unknown(self):
+        result = select_cross_family_checker(
+            "gemini-2.5-pro",
+            ["mystery-model"],
+        )
+        assert result is None
+
+    def test_preserves_order(self):
+        result = select_cross_family_checker(
+            "claude-opus-4-6",
+            ["gpt-4.1-mini", "gemini-2.5-flash"],
+        )
+        assert result == "gpt-4.1-mini"
+
+
+# ---------------------------------------------------------------------------
+# CrossFamilyCheckTask
+# ---------------------------------------------------------------------------
+
+class TestCrossFamilyCheckTaskSelection:
+    def test_selects_low_quality(self):
+        findings = [_finding("F-001"), _finding("F-002"), _finding("F-003")]
+        prior = {
+            "F-001": _result("F-001", quality=0.5),   # below threshold
+            "F-002": _result("F-002", quality=0.9),   # above threshold
+            "F-003": _result("F-003", quality=0.69),  # just below threshold
+        }
+        task = CrossFamilyCheckTask(ANTHROPIC_CHECKER, results_by_id=prior)
+        selected = task.select_items(findings, prior)
+        ids = [f["finding_id"] for f in selected]
+        assert "F-001" in ids
+        assert "F-003" in ids
+        assert "F-002" not in ids
+
+    def test_selects_nonce_leaked(self):
+        findings = [_finding("F-001"), _finding("F-002")]
+        prior = {
+            "F-001": _result("F-001", quality=0.95, nonce_leaked=True),
+            "F-002": _result("F-002", quality=0.95),
+        }
+        task = CrossFamilyCheckTask(ANTHROPIC_CHECKER, results_by_id=prior)
+        selected = task.select_items(findings, prior)
+        ids = [f["finding_id"] for f in selected]
+        assert "F-001" in ids
+        assert "F-002" not in ids
+
+    def test_skips_errors(self):
+        findings = [_finding("F-001")]
+        prior = {"F-001": {"finding_id": "F-001", "error": "timeout"}}
+        task = CrossFamilyCheckTask(ANTHROPIC_CHECKER, results_by_id=prior)
+        assert task.select_items(findings, prior) == []
+
+    def test_empty_when_all_high_quality(self):
+        findings = [_finding("F-001")]
+        prior = {"F-001": _result("F-001", quality=0.95)}
+        task = CrossFamilyCheckTask(ANTHROPIC_CHECKER, results_by_id=prior)
+        assert task.select_items(findings, prior) == []
+
+
+class TestCrossFamilyCheckTaskAdjudication:
+    def test_agree_exploitable(self):
+        prior = {"F-001": _result("F-001", exploitable=True, quality=0.5)}
+        checker_results = [
+            {"finding_id": "F-001", "is_exploitable": True, "ruling": "validated",
+             "analysed_by": "claude-haiku-4-5-20251001"},
+        ]
+        task = CrossFamilyCheckTask(ANTHROPIC_CHECKER, results_by_id=prior)
+        task.finalize(checker_results, prior)
+
+        assert prior["F-001"].get("cross_family_agreed") is True
+        assert prior["F-001"].get("cross_family_disputed") is None
+        check = prior["F-001"]["cross_family_check"]
+        assert check["verdict"] == "agreed"
+        assert check["checker_model"] == "claude-haiku-4-5-20251001"
+
+    def test_agree_not_exploitable(self):
+        prior = {"F-001": _result("F-001", exploitable=False, quality=0.5)}
+        checker_results = [
+            {"finding_id": "F-001", "is_exploitable": False, "ruling": "false_positive",
+             "analysed_by": "claude-haiku-4-5-20251001"},
+        ]
+        task = CrossFamilyCheckTask(ANTHROPIC_CHECKER, results_by_id=prior)
+        task.finalize(checker_results, prior)
+
+        assert prior["F-001"].get("cross_family_agreed") is True
+        assert prior["F-001"]["is_exploitable"] is False
+
+    def test_dispute_conservative_override(self):
+        """When primary says not-exploitable but checker says exploitable,
+        the conservative (exploitable) verdict wins."""
+        prior = {"F-001": _result("F-001", exploitable=False, quality=0.5)}
+        checker_results = [
+            {"finding_id": "F-001", "is_exploitable": True, "ruling": "validated",
+             "analysed_by": "claude-haiku-4-5-20251001"},
+        ]
+        task = CrossFamilyCheckTask(ANTHROPIC_CHECKER, results_by_id=prior)
+        task.finalize(checker_results, prior)
+
+        assert prior["F-001"]["is_exploitable"] is True
+        assert prior["F-001"].get("cross_family_disputed") is True
+        check = prior["F-001"]["cross_family_check"]
+        assert check["verdict"] == "disputed — conservative override"
+
+    def test_dispute_reverse(self):
+        """Primary says exploitable, checker says not. Conservative → exploitable."""
+        prior = {"F-001": _result("F-001", exploitable=True, quality=0.5)}
+        checker_results = [
+            {"finding_id": "F-001", "is_exploitable": False, "ruling": "false_positive",
+             "analysed_by": "claude-haiku-4-5-20251001"},
+        ]
+        task = CrossFamilyCheckTask(ANTHROPIC_CHECKER, results_by_id=prior)
+        task.finalize(checker_results, prior)
+
+        assert prior["F-001"]["is_exploitable"] is True
+        assert prior["F-001"].get("cross_family_disputed") is True
+
+    def test_nonce_trigger_recorded(self):
+        prior = {"F-001": _result("F-001", quality=0.5, nonce_leaked=True)}
+        checker_results = [
+            {"finding_id": "F-001", "is_exploitable": True,
+             "analysed_by": "claude-haiku-4-5-20251001"},
+        ]
+        task = CrossFamilyCheckTask(ANTHROPIC_CHECKER, results_by_id=prior)
+        task.finalize(checker_results, prior)
+        assert prior["F-001"]["cross_family_check"]["trigger"] == "nonce_leaked"
+
+    def test_quality_trigger_recorded(self):
+        prior = {"F-001": _result("F-001", quality=0.5)}
+        checker_results = [
+            {"finding_id": "F-001", "is_exploitable": True,
+             "analysed_by": "claude-haiku-4-5-20251001"},
+        ]
+        task = CrossFamilyCheckTask(ANTHROPIC_CHECKER, results_by_id=prior)
+        task.finalize(checker_results, prior)
+        assert prior["F-001"]["cross_family_check"]["trigger"] == "low_quality"
+
+    def test_checker_error_skipped(self):
+        prior = {"F-001": _result("F-001", quality=0.5)}
+        checker_results = [
+            {"finding_id": "F-001", "error": "timeout"},
+        ]
+        task = CrossFamilyCheckTask(ANTHROPIC_CHECKER, results_by_id=prior)
+        task.finalize(checker_results, prior)
+        assert "cross_family_check" not in prior["F-001"]
+
+    def test_get_models(self):
+        task = CrossFamilyCheckTask(ANTHROPIC_CHECKER, results_by_id={})
+        models = task.get_models({})
+        assert models == [ANTHROPIC_CHECKER]
+
+    def test_same_family_fallback_guard(self):
+        """LLMClient may fall back to a same-family model. The guard should
+        detect this and skip adjudication instead of falsely claiming agreement."""
+        prior = {"F-001": _result("F-001", quality=0.5, analysed_by="gemini-2.5-pro")}
+        checker_results = [
+            {"finding_id": "F-001", "is_exploitable": True, "ruling": "validated",
+             "analysed_by": "gemini-2.5-flash"},  # same family as primary!
+        ]
+        task = CrossFamilyCheckTask(ANTHROPIC_CHECKER, results_by_id=prior)
+        task.finalize(checker_results, prior)
+
+        assert prior["F-001"].get("cross_family_agreed") is None
+        assert prior["F-001"].get("cross_family_disputed") is None
+        check = prior["F-001"]["cross_family_check"]
+        assert "skipped" in check["verdict"]
+        assert check["intended_model"] == "claude-haiku-4-5-20251001"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_cross_family_checker / auto-detect
+# ---------------------------------------------------------------------------
+
+class TestResolveCrossFamilyChecker:
+    def test_from_consensus_models(self):
+        from packages.llm_analysis.orchestrator import _resolve_cross_family_checker
+        role_res = {
+            "analysis_model": GEMINI_PRIMARY,
+            "consensus_models": [ANTHROPIC_CHECKER],
+            "fallback_models": [],
+        }
+        result = _resolve_cross_family_checker(GEMINI_PRIMARY, role_res)
+        assert result is ANTHROPIC_CHECKER
+
+    def test_from_fallback_models(self):
+        from packages.llm_analysis.orchestrator import _resolve_cross_family_checker
+        role_res = {
+            "analysis_model": GEMINI_PRIMARY,
+            "consensus_models": [],
+            "fallback_models": [OPENAI_FALLBACK],
+        }
+        result = _resolve_cross_family_checker(GEMINI_PRIMARY, role_res)
+        assert result is OPENAI_FALLBACK
+
+    def test_skips_same_family(self):
+        from packages.llm_analysis.orchestrator import _resolve_cross_family_checker
+        same_family_model = _model("gemini", "gemini-2.5-flash", role="fallback")
+        role_res = {
+            "analysis_model": GEMINI_PRIMARY,
+            "consensus_models": [],
+            "fallback_models": [same_family_model],
+        }
+        # Falls through to auto-detect; with no env vars set, returns None
+        with patch.dict(os.environ, {}, clear=True):
+            result = _resolve_cross_family_checker(GEMINI_PRIMARY, role_res)
+        assert result is None
+
+    def test_auto_detect_anthropic_key(self):
+        from packages.llm_analysis.orchestrator import _resolve_cross_family_checker
+        role_res = {
+            "analysis_model": GEMINI_PRIMARY,
+            "consensus_models": [],
+            "fallback_models": [],
+        }
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}, clear=True):
+            result = _resolve_cross_family_checker(GEMINI_PRIMARY, role_res)
+        assert result is not None
+        assert result.provider == "anthropic"
+        assert result.model_name == "claude-haiku-4-5-20251001"
+
+    def test_auto_detect_gemini_key_for_anthropic_primary(self):
+        from packages.llm_analysis.orchestrator import _resolve_cross_family_checker
+        anthropic_primary = _model("anthropic", "claude-opus-4-6", role="analysis")
+        role_res = {
+            "analysis_model": anthropic_primary,
+            "consensus_models": [],
+            "fallback_models": [],
+        }
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"}, clear=True):
+            result = _resolve_cross_family_checker(anthropic_primary, role_res)
+        assert result is not None
+        assert result.provider == "gemini"
+        assert result.model_name == "gemini-2.5-flash"
+
+    def test_no_cross_family_available(self):
+        from packages.llm_analysis.orchestrator import _resolve_cross_family_checker
+        role_res = {
+            "analysis_model": GEMINI_PRIMARY,
+            "consensus_models": [],
+            "fallback_models": [],
+        }
+        with patch.dict(os.environ, {}, clear=True):
+            result = _resolve_cross_family_checker(GEMINI_PRIMARY, role_res)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# dispatch.py quality/nonce persistence (integration-ish)
+# ---------------------------------------------------------------------------
+
+class TestDispatchQualityPersistence:
+    """Verify that _quality and _nonce_leaked are set on processed results."""
+
+    def test_quality_on_dispatch_result(self):
+        dr = DispatchResult(
+            result={"is_exploitable": True, "reasoning": "test"},
+            quality=0.65,
+        )
+        assert dr.quality == 0.65
+
+    def test_quality_default(self):
+        dr = DispatchResult(result={"is_exploitable": True})
+        assert dr.quality == 1.0


### PR DESCRIPTION
Per arXiv 2510.09023, a single model's output parser is bypassable at 90% ASR. Re-dispatching suspicious responses through a different model family raises the bar to bypassing two unrelated parsers simultaneously.

llm_family.py — refactor flat _FAMILY_PREFIXES tuple into separate _PROVIDER_STEMS (matched with /) and _MODEL_STEMS (matched with -); provider checked first so ollama/llama-3 resolves to ollama not meta; add Mistral family.

dispatch.py — persist _quality score and _nonce_leaked flag on each processed finding so downstream tasks can select on them.

tasks.py — add CrossFamilyCheckTask: selects findings with quality < 0.7 or nonce leaked, re-dispatches through checker model, adjudicates with conservative (exploitable) override on disagreement, guards against same-family fallback from LLMClient.

orchestrator.py — wire CrossFamilyCheckTask between analysis and retry stages; add _resolve_cross_family_checker (picks from resolved roles, falls back to auto-detect from env API keys); add cross-family stats to JSON summary and terminal output; drop ImportError guard around response_validation (PR #288 merged).

tests — 31 unit tests covering task selection, adjudication, resolver, auto-detect, family detection, quality persistence; collision pin for ollama/llama-*.