### PR TITLE
fix: pass LLM API keys through to scanner subprocesses

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -484,6 +484,32 @@ class RaptorConfig:
         env["PYTHONUNBUFFERED"] = "1"
         return env
 
+    # LLM provider API-key env vars.  These are intentionally NOT in
+    # SAFE_ENV_ALLOWLIST — untrusted-code subprocesses (CodeQL builds,
+    # fuzz harnesses) must never see credentials.  get_llm_env() layers
+    # them on top of get_safe_env() for our own LLM-calling scripts.
+    LLM_API_KEY_VARS = (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+        "MISTRAL_API_KEY",
+    )
+
+    @staticmethod
+    def get_llm_env() -> dict:
+        """Return get_safe_env() plus any LLM API keys present in the
+        real environment.
+
+        Use this for spawning RAPTOR's own analysis scripts that may call
+        LLM providers.  Do NOT use for untrusted-code subprocesses.
+        """
+        env = RaptorConfig.get_safe_env()
+        for var in RaptorConfig.LLM_API_KEY_VARS:
+            val = os.environ.get(var)
+            if val:
+                env[var] = val
+        return env
+
     @staticmethod
     def get_git_env() -> dict:
         """

--- a/core/security/tests/test_security_mitigations.py
+++ b/core/security/tests/test_security_mitigations.py
@@ -116,6 +116,42 @@ class TestSafeEnv:
                 assert name not in env, f"{name} leaked into safe env"
 
 
+class TestLlmEnv:
+    """get_llm_env() passes API keys that get_safe_env() blocks."""
+
+    def test_safe_env_blocks_api_keys(self):
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-ant-test"}):
+            env = RaptorConfig.get_safe_env()
+            assert "ANTHROPIC_API_KEY" not in env
+
+    def test_llm_env_passes_api_keys(self):
+        keys = {
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+            "OPENAI_API_KEY": "sk-test",
+            "GEMINI_API_KEY": "AIza-test",
+            "MISTRAL_API_KEY": "mist-test",
+        }
+        with patch.dict(os.environ, keys):
+            env = RaptorConfig.get_llm_env()
+            for name, val in keys.items():
+                assert env.get(name) == val, f"{name} missing from llm env"
+
+    def test_llm_env_omits_unset_keys(self):
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ["PATH"] = "/usr/bin"
+            os.environ["HOME"] = "/tmp"
+            env = RaptorConfig.get_llm_env()
+            for var in RaptorConfig.LLM_API_KEY_VARS:
+                assert var not in env
+
+    def test_llm_env_still_strips_dangerous(self):
+        with patch.dict(os.environ, {"LD_PRELOAD": "/tmp/evil.so",
+                                      "ANTHROPIC_API_KEY": "sk-ant-test"}):
+            env = RaptorConfig.get_llm_env()
+            assert "LD_PRELOAD" not in env
+            assert env.get("ANTHROPIC_API_KEY") == "sk-ant-test"
+
+
 # NOTE: `TestCheckRepoClaudeSettings` was removed — the function
 # `_check_repo_claude_settings` in raptor_agentic.py was superseded by
 # `check_repo_claude_trust` in `core/security/cc_trust.py` (PR #185).

--- a/raptor.py
+++ b/raptor.py
@@ -163,7 +163,7 @@ def _run_script(script_path: Path, args: list) -> int:
     
     try:
         from core.config import RaptorConfig
-        result = subprocess.run(cmd, env=RaptorConfig.get_safe_env())
+        result = subprocess.run(cmd, env=RaptorConfig.get_llm_env())
         return result.returncode
     except KeyboardInterrupt:
         print("\n\nInterrupted by user")


### PR DESCRIPTION
get_safe_env() intentionally blocks API keys, but raptor.py used it for our own analysis scripts — starving them of provider credentials.  New get_llm_env() layers only the four provider keys on top of get_safe_env(); untrusted-code paths (CodeQL builds, semgrep, fuzz) still use get_safe_env().