### PR TITLE
feat: consensus verdict improvements — preserve primary, skip cross-family, CLI flag

### DIFF
--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -411,11 +411,19 @@ def orchestrate(
 
     # Consensus (if configured)
     consensus_models = role_resolution.get("consensus_models", [])
+    consensus_budget_skipped = False
     if consensus_models:
+        consensus_task = ConsensusTask(profile=profile)
+        eligible = consensus_task.select_items(findings, results_by_id)
         dispatch_task(
-            ConsensusTask(profile=profile), findings, dispatch_fn, role_resolution,
+            consensus_task, findings, dispatch_fn, role_resolution,
             results_by_id, cost_tracker, max_parallel,
         )
+        if eligible and not any(
+            isinstance(r, dict) and r.get("consensus")
+            for r in results_by_id.values()
+        ):
+            consensus_budget_skipped = True
 
     # Exploit/patch generation — after final verdict
     # CC analysis may produce exploits/patches inline via schema. ExploitTask/PatchTask
@@ -461,6 +469,8 @@ def orchestrate(
     if group_analyses:
         merged["group_analyses"] = group_analyses
 
+    consensus_agreed = sum(1 for r in per_finding_results
+                           if r.get("consensus") == "agreed")
     consensus_disputes = sum(1 for r in per_finding_results
                              if r.get("consensus") == "disputed")
     cross_family_checked = sum(1 for r in per_finding_results
@@ -477,11 +487,13 @@ def orchestrate(
         "defense_profile": profile.name,
         "weakened_defenses": accept_weakened_defenses and profile.name == "passthrough",
         "consensus_models": [m.model_name for m in consensus_models],
+        "consensus_agreed": consensus_agreed,
+        "consensus_disputes": consensus_disputes,
+        "consensus_budget_skipped": consensus_budget_skipped,
         "findings_dispatched": len(findings),
         "findings_analysed": sum(1 for r in per_finding_results if "error" not in r),
         "findings_failed": sum(1 for r in per_finding_results if "error" in r),
         "structural_groups": len(groups),
-        "consensus_disputes": consensus_disputes,
         "cross_family_checked": cross_family_checked,
         "cross_family_disputes": cross_family_disputes,
         "low_confidence_retries": retries,
@@ -527,6 +539,15 @@ def orchestrate(
     thinking = cost_summary.get("thinking_tokens", 0)
     if thinking > 0:
         print(f"  Thinking tokens: {thinking:,}")
+    if consensus_agreed or consensus_disputes:
+        cn_parts = []
+        if consensus_agreed:
+            cn_parts.append(f"{consensus_agreed} agreed")
+        if consensus_disputes:
+            cn_parts.append(f"{consensus_disputes} disputed")
+        print(f"  Consensus: {', '.join(cn_parts)}")
+    elif consensus_budget_skipped:
+        print(f"  Consensus: skipped (budget > {int(ConsensusTask.budget_cutoff * 100)}%)")
     if cross_family_checked:
         cf_parts = [f"{cross_family_checked} cross-family checked"]
         if cross_family_disputes:

--- a/packages/llm_analysis/tasks.py
+++ b/packages/llm_analysis/tasks.py
@@ -196,9 +196,18 @@ class ConsensusTask(DispatchTask):
         return role_resolution.get("consensus_models", [])
 
     def select_items(self, findings, prior_results):
-        return [f for f in findings
-                if "error" not in prior_results.get(f.get("finding_id"), {"error": True})
-                and prior_results.get(f.get("finding_id"), {}).get("is_true_positive", True)]
+        selected = []
+        for f in findings:
+            fid = f.get("finding_id")
+            r = prior_results.get(fid, {"error": True})
+            if "error" in r:
+                continue
+            if not r.get("is_true_positive", True):
+                continue
+            if r.get("cross_family_agreed"):
+                continue
+            selected.append(f)
+        return selected
 
     def build_prompt(self, finding):
         bundle = build_analysis_prompt_bundle_from_finding(finding, profile=self.profile)
@@ -221,17 +230,15 @@ class ConsensusTask(DispatchTask):
         """Apply verdict rules across analysis + consensus results.
 
         Verdict rules:
-        - 1 consensus model: either says exploitable -> exploitable (conservative)
-        - 2+ consensus models: majority across analysis + all consensus
+        - 1 consensus model: flag disagreement but preserve primary verdict
+        - 2+ consensus models: majority across primary + all consensus
         """
-        # Group consensus results by finding_id
         consensus_by_finding: Dict[str, List[Dict]] = {}
         for r in results:
             fid = r.get("finding_id")
             if fid and "error" not in r:
                 consensus_by_finding.setdefault(fid, []).append(r)
 
-        # Apply verdicts to prior results (mutate in place)
         for fid, primary in prior_results.items():
             if isinstance(primary, dict) and "error" not in primary:
                 consensus_analyses = consensus_by_finding.get(fid, [])
@@ -243,13 +250,14 @@ class ConsensusTask(DispatchTask):
                 for ca in consensus_analyses:
                     verdicts.append(ca.get("is_exploitable", False))
 
+                disputed = not all(v == verdicts[0] for v in verdicts)
+
                 n_consensus = len(consensus_analyses)
                 if n_consensus == 1:
-                    final = any(verdicts)
+                    final = primary_exploitable
                 else:
                     final = sum(1 for v in verdicts if v) > len(verdicts) / 2
 
-                disputed = not all(v == verdicts[0] for v in verdicts)
                 primary["consensus"] = "disputed" if disputed else "agreed"
                 primary["is_exploitable"] = final
                 primary["consensus_analyses"] = [

--- a/packages/llm_analysis/tests/test_dispatch.py
+++ b/packages/llm_analysis/tests/test_dispatch.py
@@ -208,14 +208,26 @@ class TestConsensusTask:
         assert len(selected) == 1
         assert selected[0]["finding_id"] == "f-001"
 
-    def test_finalize_one_consensus_either_exploitable_wins(self):
+    def test_finalize_single_consensus_preserves_primary(self):
         task = ConsensusTask()
-        # Consensus says exploitable, primary says not
+        # Consensus says exploitable, primary says not — primary preserved, disputed
         consensus_results = [
             {"finding_id": "f-001", "is_exploitable": True, "analysed_by": "gemini",
              "reasoning": "yes"}
         ]
         prior = {"f-001": {"is_exploitable": False, "finding_id": "f-001"}}
+        task.finalize(consensus_results, prior)
+        assert prior["f-001"]["is_exploitable"] is False
+        assert prior["f-001"]["consensus"] == "disputed"
+
+    def test_finalize_single_consensus_primary_exploitable_preserved(self):
+        task = ConsensusTask()
+        # Primary says exploitable, consensus says not — primary preserved, disputed
+        consensus_results = [
+            {"finding_id": "f-001", "is_exploitable": False, "analysed_by": "gemini",
+             "reasoning": "no"}
+        ]
+        prior = {"f-001": {"is_exploitable": True, "finding_id": "f-001"}}
         task.finalize(consensus_results, prior)
         assert prior["f-001"]["is_exploitable"] is True
         assert prior["f-001"]["consensus"] == "disputed"
@@ -230,6 +242,35 @@ class TestConsensusTask:
         task.finalize(consensus_results, prior)
         assert prior["f-001"]["consensus"] == "agreed"
 
+    def test_finalize_multi_consensus_majority_wins(self):
+        task = ConsensusTask()
+        # 2 consensus models + primary: 2 exploitable vs 1 not → majority wins
+        consensus_results = [
+            {"finding_id": "f-001", "is_exploitable": True, "analysed_by": "gemini",
+             "reasoning": "yes"},
+            {"finding_id": "f-001", "is_exploitable": False, "analysed_by": "mistral",
+             "reasoning": "no"},
+        ]
+        prior = {"f-001": {"is_exploitable": True, "finding_id": "f-001"}}
+        task.finalize(consensus_results, prior)
+        # 2 of 3 say exploitable → majority = True
+        assert prior["f-001"]["is_exploitable"] is True
+        assert prior["f-001"]["consensus"] == "disputed"
+
+    def test_finalize_multi_consensus_majority_not_exploitable(self):
+        task = ConsensusTask()
+        consensus_results = [
+            {"finding_id": "f-001", "is_exploitable": False, "analysed_by": "gemini",
+             "reasoning": "no"},
+            {"finding_id": "f-001", "is_exploitable": False, "analysed_by": "mistral",
+             "reasoning": "no"},
+        ]
+        prior = {"f-001": {"is_exploitable": True, "finding_id": "f-001"}}
+        task.finalize(consensus_results, prior)
+        # 2 of 3 say not exploitable → majority = False
+        assert prior["f-001"]["is_exploitable"] is False
+        assert prior["f-001"]["consensus"] == "disputed"
+
     def test_skips_false_positives(self):
         task = ConsensusTask()
         findings = [_make_finding("f-001"), _make_finding("f-002"), _make_finding("f-003")]
@@ -241,6 +282,30 @@ class TestConsensusTask:
         selected = task.select_items(findings, prior)
         assert len(selected) == 1
         assert selected[0]["finding_id"] == "f-001"
+
+
+    def test_skips_cross_family_agreed(self):
+        task = ConsensusTask()
+        findings = [_make_finding("f-001"), _make_finding("f-002")]
+        prior = {
+            "f-001": {"is_exploitable": True, "cross_family_agreed": True},
+            "f-002": {"is_exploitable": True},
+        }
+        selected = task.select_items(findings, prior)
+        assert len(selected) == 1
+        assert selected[0]["finding_id"] == "f-002"
+
+    def test_consensus_reasoning_in_output(self):
+        task = ConsensusTask()
+        consensus_results = [
+            {"finding_id": "f-001", "is_exploitable": True, "analysed_by": "gemini",
+             "reasoning": "consensus reasoning text"}
+        ]
+        prior = {"f-001": {"is_exploitable": True, "finding_id": "f-001"}}
+        task.finalize(consensus_results, prior)
+        analyses = prior["f-001"]["consensus_analyses"]
+        assert len(analyses) == 1
+        assert analyses[0]["reasoning"] == "consensus reasoning text"
 
 
 class TestGroupAnalysisTask:

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -209,6 +209,13 @@ Examples:
              "Logged in run metadata and flagged in the final report.",
     )
     parser.add_argument(
+        "--consensus",
+        metavar="MODEL",
+        help="Add a consensus model for second-opinion analysis "
+             "(e.g. --consensus gpt-5.4). Can also be set via "
+             "role: \"consensus\" in models.json.",
+    )
+    parser.add_argument(
         "--trust-repo",
         action="store_true",
         help="Trust the target repo's config and skip safety checks. Currently "
@@ -725,6 +732,28 @@ Examples:
             if llm_env.external_llm:
                 from packages.llm_analysis import LLMConfig
                 llm_config = LLMConfig()
+
+            # --consensus flag: inject a consensus model
+            if args.consensus and llm_config:
+                from core.llm.config import _model_config_from_entry
+                from core.security.llm_family import family_of
+                _FAMILY_TO_PROVIDER = {
+                    "anthropic": "anthropic", "openai": "openai",
+                    "google": "gemini", "mistral": "mistral",
+                    "meta": "ollama", "ollama": "ollama",
+                }
+                provider = _FAMILY_TO_PROVIDER.get(
+                    family_of(args.consensus), "")
+                consensus_mc = _model_config_from_entry({
+                    "model": args.consensus,
+                    "provider": provider,
+                    "role": "consensus",
+                })
+                if consensus_mc.api_key:
+                    llm_config.fallback_models.append(consensus_mc)
+                else:
+                    print(f"\n  Warning: no API key found for consensus model {args.consensus}")
+                    print(f"  Set the provider's env var or add it to models.json")
 
             from packages.llm_analysis.orchestrator import orchestrate
             orchestration_result = orchestrate(


### PR DESCRIPTION
Single-consensus now preserves the primary verdict instead of conservative OR; multi-consensus uses majority vote. Findings already validated by the cross-family checker are skipped. --consensus MODEL flag auto-detects provider and injects at runtime. Terminal output shows agreed/disputed/budget-skipped counts.