### PR TITLE
feat(sandbox): macOS sandbox-exec/SBPL backend + unified AuditBudget

### DIFF
--- a/core/build/toolchain.py
+++ b/core/build/toolchain.py
@@ -72,28 +72,47 @@ def _resolve_from_which(cmd: str, strip_suffix: str) -> Optional[str]:
 
 def detect_JAVA_HOME() -> Optional[str]:
     """Resolve JAVA_HOME from the host. See module docstring for order."""
+    import sys as _sys
     # 1. Debian/Ubuntu convention
     default_java = "/usr/lib/jvm/default-java"
     if os.path.isdir(default_java):
         return default_java
-    # 2. From `which java`
+    # 2. macOS's canonical helper. MUST run BEFORE the which-java
+    # heuristic on Darwin: `/usr/bin/java` is Apple's stub that
+    # exists even when no JDK is installed, so `which java` returns
+    # `/usr/bin/java` → strip /bin/java → JAVA_HOME = `/usr`. Setting
+    # `JAVA_HOME=/usr` makes the stub recursively re-exec itself
+    # (it finds `/usr/bin/javac` = the stub itself = infinite loop)
+    # and ANY subprocess that invokes javac under that env hangs
+    # indefinitely. Apple's java_home is the authoritative source on
+    # macOS — defer to it. Caught by macOS dogfooding of
+    # packages/codeql build synthesis.
+    if _sys.platform == "darwin":
+        macos_helper = "/usr/libexec/java_home"
+        if os.path.isfile(macos_helper) and os.access(macos_helper, os.X_OK):
+            try:
+                import subprocess
+                r = subprocess.run(
+                    [macos_helper], capture_output=True, text=True, timeout=5,
+                )
+                if r.returncode == 0 and r.stdout.strip():
+                    candidate = r.stdout.strip()
+                    if os.path.isdir(candidate):
+                        return candidate
+            except (OSError, subprocess.SubprocessError):
+                pass
+        # macOS without a JDK: don't fall through to the which-java
+        # heuristic — would hit the stub-loop trap above. Return None
+        # and let the caller's build tool surface the missing-
+        # toolchain error.
+        return None
+    # 3. From `which java` (Linux). Reject `/usr` itself as a
+    # defensive check: any host where the resolved java install
+    # root collapses to `/usr` is misconfigured (would hit the
+    # stub-loop on macOS, surely wrong on Linux too).
     home = _resolve_from_which("java", "bin/java")
-    if home and os.path.isdir(home):
+    if home and home != "/usr" and os.path.isdir(home):
         return home
-    # 3. macOS's canonical helper (no-op on Linux)
-    macos_helper = "/usr/libexec/java_home"
-    if os.path.isfile(macos_helper) and os.access(macos_helper, os.X_OK):
-        try:
-            import subprocess
-            r = subprocess.run(
-                [macos_helper], capture_output=True, text=True, timeout=5,
-            )
-            if r.returncode == 0 and r.stdout.strip():
-                candidate = r.stdout.strip()
-                if os.path.isdir(candidate):
-                    return candidate
-        except (OSError, subprocess.SubprocessError):
-            pass
     return None
 
 

--- a/core/git/clone.py
+++ b/core/git/clone.py
@@ -102,21 +102,37 @@ def _validate_writable_path(p: Path, *, role: str) -> None:
             f"paths are unsafe here — the sandbox writable scope "
             f"({role}.parent) would be cwd-dependent."
         )
-    # ``.resolve()`` follows symlinks so a pre-staged
-    # ``/tmp/work -> /`` symlink can't sneak past the root checks.
+    # Two checks against root, both required:
+    #
+    # 1. The RESOLVED form catches `/tmp/work -> /` symlink attacks
+    #    (caller passes /tmp/work, .resolve() reveals the parent IS
+    #    actually root after symlink follow-through).
+    #
+    # 2. The UNRESOLVED form catches macOS's pervasive
+    #    /etc → /private/etc, /var → /private/var, /tmp → /private/tmp
+    #    symlinks. With ONLY the resolved check, `/etc` on macOS
+    #    resolves to `/private/etc` whose parent is `/private` —
+    #    NOT root — so the validation passes and the sandbox becomes
+    #    writable in `/private`, which is host-wide system state on
+    #    macOS. The unresolved check sees `/etc`.parent == `/` and
+    #    refuses, matching the Linux-side semantic intent.
+    #
+    # Either form being root → reject. Caught by core/sandbox/tests/
+    # — first surfaced when the sandbox suite ran on macOS.
     resolved = p.resolve()
-    if resolved.parent == resolved:
-        raise ValueError(
-            f"{role}={str(p)!r} resolves to filesystem root; refusing "
-            f"to grant the sandbox write access to the entire "
-            f"filesystem"
-        )
-    if resolved.parent == Path(resolved.anchor):
-        raise ValueError(
-            f"{role}={str(p)!r} has filesystem root as its parent. "
-            f"Sandbox writable scope ({role}.parent) would be the "
-            f"entire root filesystem."
-        )
+    for label, candidate in (("resolved", resolved), ("literal", p)):
+        if candidate.parent == candidate:
+            raise ValueError(
+                f"{role}={str(p)!r} {label}-form is the filesystem "
+                f"root; refusing to grant the sandbox write access "
+                f"to the entire filesystem"
+            )
+        if candidate.parent == Path(candidate.anchor):
+            raise ValueError(
+                f"{role}={str(p)!r} {label}-form has filesystem root "
+                f"as its parent. Sandbox writable scope "
+                f"({role}.parent) would be the entire root filesystem."
+            )
 
 
 def clone_repository(

--- a/core/orchestration/agentic_passes.py
+++ b/core/orchestration/agentic_passes.py
@@ -473,7 +473,7 @@ def _start_lifecycle(command: str, target: Path) -> Optional[Path]:
     for line in reversed(proc.stdout.splitlines()):
         line = line.strip()
         if line.startswith("OUTPUT_DIR="):
-            return Path(line[len("OUTPUT_DIR="):])
+            return Path(line[len("OUTPUT_DIR="):]).resolve()
     logger.warning("lifecycle start %s did not emit OUTPUT_DIR=", command)
     return None
 

--- a/core/sandbox/__init__.py
+++ b/core/sandbox/__init__.py
@@ -475,6 +475,7 @@ from .preexec import _DEFAULT_LIMITS, _load_user_limits, _make_preexec_fn
 from .mount import _build_mount_script
 from .probes import (
     check_mount_available, check_net_available, check_sandbox_available,
+    check_seatbelt_available,
 )
 from .profiles import DEFAULT_PROFILE, PROFILES, _SANDBOX_KWARGS
 from .seccomp import check_seccomp_available

--- a/core/sandbox/_macos_spawn.py
+++ b/core/sandbox/_macos_spawn.py
@@ -1,0 +1,343 @@
+"""macOS sandbox-exec wrapper.
+
+This module mirrors core.sandbox._spawn.run_sandboxed() — same kwarg
+contract, same return shape (subprocess.CompletedProcess with
+.sandbox_info attached) — so context.py can dispatch to the
+appropriate backend (Linux vs Darwin) at the spawn-eligibility check
+without callers caring about platform.
+
+Feature parity table (Linux ⇄ macOS):
+
+    Linux layer                       → macOS equivalent
+    ─────────────────────────────────  ────────────────────────────────
+    Landlock writable_paths            → SBPL (deny file-write*
+                                        (require-not (subpath ...)))
+    Landlock readable_paths            → SBPL (deny file-read*
+                                        (require-not ...)) under
+                                        restrict_reads=True
+    Landlock TCP allowlist             → SBPL (allow network-outbound
+                                        (remote tcp "*:PORT"))
+    user-ns network block              → SBPL (deny network*)
+    user-ns PID isolation              → ⚠  no equivalent — host PIDs
+                                        remain visible inside sandbox
+    user-ns IPC isolation              → partial: SBPL (deny mach-
+                                        lookup ...) for specific
+                                        services (not blanket)
+    mount-ns + pivot_root              → ⚠  no equivalent — sandbox
+                                        sees host filesystem (reads
+                                        unrestricted unless restrict_
+                                        reads=True)
+    seccomp filter                     → partial: SBPL (deny process-
+                                        info* (target others)) when
+                                        seccomp_profile is set
+    rlimits via prlimit + preexec      → preexec rlimits (same code
+                                        path); ⚠  RLIMIT_NPROC is
+                                        per-UID host-wide on macOS,
+                                        not per-namespace
+    ptrace tracer (audit_mode)         → `log stream` reader (see
+                                        seatbelt_audit.LogStreamer)
+    fake_home env override             → identical (env mutation)
+    egress proxy + HTTPS_PROXY env     → identical (env mutation +
+                                        SBPL allow for proxy_port)
+    pid-1 shim (signal forwarding)     → ⚠  not needed (no PID-ns)
+    audit_verbose strace-style         → partial: SBPL `(allow X
+                                        (with report))` for an
+                                        extended category set
+                                        (file-read-data, mach-lookup,
+                                        process-exec*, process-fork,
+                                        signal). Coarser than Linux's
+                                        per-syscall trace and no argv,
+                                        but operationally similar
+                                        signal-volume control. See
+                                        seatbelt.build_profile.
+    map_root (--map-root-user)         → ⚠  no equivalent — sandboxed
+                                        process keeps caller UID
+
+Implications of the ⚠ items for the threat model:
+
+  1. PID visibility: a sandboxed child that compromises a same-UID
+     process can still see / signal it. Linux's PID-ns hides this.
+     Mitigation: don't run RAPTOR alongside other valuable same-UID
+     processes; consider a dedicated user account for RAPTOR on
+     shared macOS hosts.
+  2. Filesystem read scope: under default kwargs the sandboxed
+     child can read everything the calling user can. Always pass
+     restrict_reads=True for untrusted code (run_untrusted does this
+     by default).
+  3. RLIMIT_NPROC: a fork-bombing sandboxed child can exhaust the
+     calling user's process table host-wide. Lower nproc_limit on
+     macOS than on Linux when running unknown code.
+  4. audit_verbose granularity: macOS records are SBPL-action-level
+     (e.g. "file-read-data /etc/foo") rather than syscall+argv
+     level. Linux's tracer can show "openat(/etc/foo, O_RDONLY)";
+     macOS can't distinguish reads-of-foo from stats-of-foo. For
+     debugging targets that need argv-level fidelity, use Linux.
+
+What's identical and needs no special handling:
+
+  * Resource limits via POSIX setrlimit (preexec_fn pattern).
+  * fake_home env override (mirrors Linux's per-XDG-subdir layout
+    in core/sandbox/context.py — HOME, XDG_CONFIG_HOME,
+    XDG_CACHE_HOME, XDG_DATA_HOME, XDG_STATE_HOME each point at a
+    distinct subdir of {output}/.home/ so configs don't collide
+    with caches).
+  * Egress proxy + audit-degraded marker semantics (handled at the
+    context.py layer, identical to Linux).
+  * Sandbox-summary JSONL aggregation (same schema, same writer).
+  * Audit budget: same core.sandbox.audit_budget.AuditBudget on
+    both backends — token-bucket + per-category + per-PID +
+    1-in-N sampling + --audit-budget CLI override.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from . import seatbelt
+from .preexec import _make_preexec_fn
+
+logger = logging.getLogger(__name__)
+
+
+SANDBOX_EXEC = "/usr/bin/sandbox-exec"
+
+
+def is_available() -> bool:
+    """True iff /usr/bin/sandbox-exec exists. Caller (context.py) is
+    expected to have already checked check_seatbelt_available() for
+    the deeper smoke-test gate; this is the cheap presence check."""
+    return os.path.exists(SANDBOX_EXEC)
+
+
+def run_sandboxed(cmd: List[str], *,
+                  target: Optional[str] = None,
+                  output: Optional[str] = None,
+                  block_network: bool = False,
+                  nproc_limit: Optional[int] = None,
+                  limits: Optional[dict] = None,
+                  writable_paths: Optional[Iterable[str]] = None,
+                  readable_paths: Optional[Iterable[str]] = None,
+                  allowed_tcp_ports: Optional[Iterable[int]] = None,
+                  # seccomp_profile: macOS has no direct equivalent
+                  # to Linux's libseccomp filter, but we use the
+                  # profile NAME as a coarse "harden" signal — when
+                  # set to anything non-None and not "none", SBPL adds
+                  # a small set of process-info denies (see
+                  # seatbelt.build_profile's docstring). Accepted as
+                  # Linux-named kwarg for signature parity.
+                  # seccomp_block_udp: Linux-only (no UDP-specific
+                  # SBPL primitive). Use block_network=True for the
+                  # macOS equivalent of "no UDP egress".
+                  seccomp_profile: Optional[str] = None,
+                  seccomp_block_udp: bool = False,  # noqa: ARG001
+                  # map_root: Linux-only (`unshare --map-root-user`
+                  # remaps caller UID to 0 inside the user-ns). macOS
+                  # sandbox-exec keeps caller UID; there's no
+                  # unprivileged way to remap. Accepted for signature
+                  # parity, ignored.
+                  map_root: bool = False,  # noqa: ARG001
+                  env: Optional[dict] = None,
+                  cwd: Optional[str] = None,
+                  timeout: Optional[float] = None,
+                  # Defaults match core/sandbox/_spawn.run_sandboxed
+                  # so callers reaching either entry point with the
+                  # same arg list get the same result. (Earlier
+                  # signatures defaulted these to False, diverging
+                  # from Linux; in practice context.py always passes
+                  # the value explicitly so the mismatch was
+                  # invisible — but the signature now lies less.)
+                  capture_output: bool = True,
+                  text: bool = True,
+                  stdin=None,
+                  audit_mode: bool = False,
+                  audit_run_dir: Optional[str] = None,
+                  audit_verbose: bool = False,
+                  restrict_reads: bool = False,
+                  start_new_session: bool = True,
+                  use_egress_proxy: bool = False,
+                  proxy_port: Optional[int] = None,
+                  fake_home: bool = False,
+                  ) -> subprocess.CompletedProcess:
+    """Run ``cmd`` under macOS sandbox-exec with an SBPL profile
+    derived from the logical sandbox kwargs.
+
+    Same return shape as the Linux ``_spawn.run_sandboxed()``; same
+    contract for ``audit_mode`` / ``audit_run_dir`` (caller writes
+    .sandbox-denials.jsonl into audit_run_dir; we route the kernel
+    sandbox log into that file via seatbelt_audit's log streamer).
+
+    audit_verbose: when True (with audit_mode=True), engages the
+    extended SBPL audit category set in seatbelt.build_profile.
+    Each of the following is emitted as `(allow X (with report))`:
+      * file-read-data
+      * file-read-metadata
+      * mach-lookup
+      * process-exec*
+      * process-fork
+      * process-info*
+      * signal
+      * iokit-open
+      * sysctl-read
+    Closest macOS analogue to Linux's strace-style audit. Less
+    fidelity than Linux (no per-syscall, no argv) — see
+    seatbelt.build_profile docstring for the rationale on which
+    categories are included. High-volume categories
+    (file-read-metadata, process-info*, iokit-open, sysctl-read)
+    are bounded by core.sandbox.audit_budget.AuditBudget's per-
+    category caps + 1-in-N sampling so the JSONL doesn't bloat.
+    """
+    # 0. Validate audit-mode + audit_run_dir invariant. Mirrors
+    # core/sandbox/_spawn.py for parity — caller asking for audit
+    # without giving the tracer a place to write JSONL is almost
+    # certainly a mistake (the streamer would no-op silently and
+    # operators would see no audit signal). Raise loudly so they
+    # see the typo at spawn time.
+    if audit_mode and not audit_run_dir:
+        raise ValueError(
+            "audit_mode=True requires audit_run_dir= so the macOS "
+            "log-stream reader has a directory to write "
+            ".sandbox-denials.jsonl into. Pass audit_run_dir=<dir> "
+            "(typically the run's output dir)."
+        )
+
+    # 1. Build SBPL profile from the kwargs.
+    profile = seatbelt.build_profile(
+        target=target,
+        output=output,
+        block_network=block_network,
+        allowed_tcp_ports=list(allowed_tcp_ports) if allowed_tcp_ports else None,
+        use_egress_proxy=use_egress_proxy,
+        proxy_port=proxy_port,
+        restrict_reads=restrict_reads,
+        readable_paths=list(readable_paths) if readable_paths else None,
+        writable_paths=list(writable_paths) if writable_paths else None,
+        fake_home=fake_home,
+        audit_mode=audit_mode,
+        audit_verbose=audit_verbose,
+        seccomp_profile=seccomp_profile,
+    )
+
+    # 2. fake_home: redirect HOME + XDG_*_HOME into output/.home/
+    #    so the child sees no dotfiles. Pre-populate the dir empty.
+    if env is not None:
+        child_env = dict(env)
+    else:
+        from core.config import RaptorConfig
+        child_env = RaptorConfig.get_safe_env()
+    if fake_home and output:
+        # Mirror the Linux layout (context.py:fake_home_env) exactly:
+        # HOME → {output}/.home/
+        # XDG_CONFIG_HOME → {output}/.home/.config
+        # XDG_CACHE_HOME  → {output}/.home/.cache
+        # XDG_DATA_HOME   → {output}/.home/.local/share
+        # XDG_STATE_HOME  → {output}/.home/.local/state
+        # Earlier code mapped ALL XDG vars to the same directory,
+        # which made caches and configs collide for any tool that
+        # writes to multiple XDG roots (e.g., pip, conda). The
+        # docstring claimed "identical (env mutation)" — now true.
+        fake_home_dir = os.path.join(output, ".home")
+        os.makedirs(fake_home_dir, mode=0o700, exist_ok=True)
+        child_env["HOME"] = fake_home_dir
+        xdg_layout = {
+            "XDG_CONFIG_HOME": os.path.join(fake_home_dir, ".config"),
+            "XDG_CACHE_HOME":  os.path.join(fake_home_dir, ".cache"),
+            "XDG_DATA_HOME":   os.path.join(fake_home_dir, ".local",
+                                              "share"),
+            "XDG_STATE_HOME":  os.path.join(fake_home_dir, ".local",
+                                              "state"),
+        }
+        for var, path in xdg_layout.items():
+            child_env[var] = path
+            try:
+                os.makedirs(path, mode=0o700, exist_ok=True)
+            except OSError:
+                # Best-effort. If a fresh sandbox can't pre-create
+                # an XDG dir (e.g., the parent's umask is unusual),
+                # the env var still points to the right location and
+                # the child's first write will create it.
+                pass
+
+    # 3. rlimits via preexec_fn.
+    #
+    # _make_preexec_fn handles memory / CPU / file-size via setrlimit
+    # — works as-is on macOS (POSIX). It deliberately skips
+    # RLIMIT_NPROC on Linux because Linux applies nproc via the
+    # prlimit-inside-unshare wrapper (so the limit counts against the
+    # ns-local UID, not the host's). macOS has no unshare wrapper,
+    # so we apply nproc INSIDE preexec here. The limit then counts
+    # against the calling UID host-wide — coarser than Linux's per-
+    # namespace semantics, but the threat model (bound the fork count
+    # of THIS sandboxed child) is met. Operators on shared hosts
+    # should set a lower nproc on macOS than on Linux. Documented in
+    # this module's top docstring.
+    effective_limits = dict(limits or {})
+    base_preexec = _make_preexec_fn(effective_limits)
+    if nproc_limit and nproc_limit > 0:
+        import resource as _resource
+        _nproc = int(nproc_limit)
+        def preexec():
+            base_preexec()
+            try:
+                _resource.setrlimit(
+                    _resource.RLIMIT_NPROC, (_nproc, _nproc)
+                )
+            except (ValueError, OSError):
+                # Best-effort. Some macOS versions cap NPROC via
+                # different sysctls and setrlimit may EPERM the
+                # call when NPROC > kern.maxproc/UID. Don't crash
+                # the launch on it; the rlimit failure is a
+                # documented soft posture.
+                pass
+    else:
+        preexec = base_preexec
+
+    # 4. Wrap cmd with sandbox-exec.
+    sandbox_cmd = [SANDBOX_EXEC, "-p", profile] + list(cmd)
+
+    # 5. Audit mode: start log streamer BEFORE the workload to capture
+    #    kernel sandbox events. Stop after workload exits.
+    audit_streamer = None
+    if audit_mode and audit_run_dir:
+        from . import seatbelt_audit
+        try:
+            audit_streamer = seatbelt_audit.start_log_streamer(
+                Path(audit_run_dir),
+            )
+        except Exception:
+            logger.debug("seatbelt audit log streamer failed to start",
+                         exc_info=True)
+
+    # 6. Run.
+    try:
+        result = subprocess.run(
+            sandbox_cmd,
+            env=child_env,
+            cwd=cwd,
+            timeout=timeout,
+            capture_output=capture_output,
+            text=text,
+            stdin=stdin,
+            preexec_fn=preexec,
+            start_new_session=start_new_session,
+        )
+    finally:
+        if audit_streamer is not None:
+            try:
+                audit_streamer.stop()
+            except Exception:
+                logger.debug("seatbelt audit streamer stop failed",
+                             exc_info=True)
+
+    # 7. Attach sandbox_info — caller (context.py) populates the rest;
+    #    we just guarantee the attribute exists so callers don't have
+    #    to defensive-attr it.
+    if not hasattr(result, "sandbox_info"):
+        result.sandbox_info = {}
+    result.sandbox_info.setdefault("backend", "macos-seatbelt")
+    return result

--- a/core/sandbox/_spawn.py
+++ b/core/sandbox/_spawn.py
@@ -437,6 +437,13 @@ def run_sandboxed(
             # We signal this by setting read_allowlist to None in
             # the config, which the tracer treats as "skip all
             # read-intent filtering" (every read passes the filter).
+            # `audit_budget` propagates the parent's --audit-budget
+            # CLI override into the tracer subprocess. The tracer
+            # is a fresh Python interpreter so it doesn't inherit
+            # state._cli_sandbox_audit_budget; we must serialise
+            # the value through the same JSON channel as the
+            # filter config. None = use the AuditBudget default.
+            from . import state as _state
             audit_config = {
                 "verbose": bool(audit_verbose),
                 "writable_paths": _writable,
@@ -444,6 +451,9 @@ def run_sandboxed(
                                    else None),
                 "allowed_tcp_ports": list(allowed_tcp_ports)
                     if allowed_tcp_ports else [],
+                "audit_budget": getattr(
+                    _state, "_cli_sandbox_audit_budget", None,
+                ),
             }
             # mkstemp under /tmp; cleaned up after tracer exits.
             # If the write fails (disk full, EIO mid-flight), the

--- a/core/sandbox/audit_budget.py
+++ b/core/sandbox/audit_budget.py
@@ -1,0 +1,551 @@
+"""Centralised audit-record rate / volume control.
+
+Used by both backends:
+  * core.sandbox.tracer            — Linux ptrace tracer
+  * core.sandbox.seatbelt_audit    — macOS log-stream reader
+
+A single source of truth for the budget mechanics keeps the two
+backends from drifting and means a future tweak (new category, new
+sampling rate, new CLI knob) lands in one place.
+
+Four mechanisms compose:
+
+  1. Global cap (`global_cap`). Hard ceiling on total records per
+     run. Once hit, EVERY record is evaluated through sampling
+     (defaulting to drop for un-sampled categories).
+
+  2. Per-category sub-cap (`category_caps`). Stops one chatty
+     category (file-read-metadata, process-info-*) from squeezing
+     low-volume but operationally-important categories (network,
+     exec, mach-lookup) out of the global budget.
+
+  3. Per-PID sub-cap (`pid_cap`). One spamming subprocess can't
+     dominate the JSONL — past the per-PID cap, that PID's records
+     are dropped (with a one-time marker per PID).
+
+  4. Token-bucket rate limiting (`refill_rates`). The cap is a
+     burst capacity; the refill rate is the steady-state allowance.
+     A long-running audited workload that legitimately produces
+     events at e.g. 10/sec for an hour DOESN'T blow through the
+     burst cap — the bucket refills as it drains.
+
+  5. Post-cap sampling (`sampling_rates`). Once a category's burst
+     cap is hit, instead of going completely dark the budget can
+     emit 1-in-N records. Operators see "is this still happening?"
+     at a fraction of the volume.
+
+Decision return shape:
+    (action: str, marker: dict | None)
+
+  action:  "keep" → caller writes the record
+           "drop" → caller drops silently
+  marker:  dict to append to the JSONL BEFORE acting on the action
+           (the caller writes the marker first, then either writes
+           the record or drops it). None when no marker is needed.
+           Markers fire ONCE per category-cap-exhaust and ONCE per
+           pid-cap-exhaust so operators see the suppression in-line.
+
+Thread-safety: each backend's writer is single-threaded (Linux
+tracer is a separate process, macOS LogStreamer has one daemon
+reader thread), so no internal locking. Two budgets in the same
+process must not share state.
+
+CLI:
+  --audit-budget N   set the global cap to N (CLI override of the
+                     default global_cap=10000). Per-category caps
+                     are scaled proportionally so the relative
+                     allocation is preserved.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Dict, Optional, Tuple
+
+
+# ---------------------------------------------------------------------
+# Defaults — STARTING HEURISTICS, not measured truths.
+#
+# These were picked by inspection from a few /scan + /agentic runs
+# and Apple's open-source SBPL profiles. They are NOT calibrated
+# against a corpus of real workloads. After first production
+# deployment, measure the distributions in real `audit_summary`
+# records (see core.sandbox.summary aggregation):
+#
+#   * If a category disappears entirely into `dropped_by_category`
+#     while the workload is still producing useful events, raise
+#     that category's cap and refill rate.
+#   * If the JSONL bloats past operational tolerance under
+#     `--audit-verbose`, tighten the high-volume categories
+#     (file-read-metadata, process-info) further OR add a sampling
+#     rate to a category that currently has none.
+#   * If a long-running workload (>1 hour) drains its bucket at
+#     steady-state, raise that category's `refill_rate` rather than
+#     its cap — caps absorb bursts; refill rate absorbs sustained
+#     load.
+#
+# Operators tuning per-deployment can override via
+# AuditBudget(global_cap=..., category_caps=..., refill_rates=...,
+# sampling_rates=...). The CLI flag --audit-budget=N propagates the
+# global override and scales per-category and per-PID sub-caps
+# proportionally (see __init__ docstring).
+# ---------------------------------------------------------------------
+
+DEFAULT_GLOBAL_CAP = 10000
+
+# Per-category burst caps. Coarse buckets — see _default_categorise()
+# for the action → category mapping.
+DEFAULT_CATEGORY_CAPS = {
+    "file-read-metadata": 500,
+    "file-read-data":    2000,
+    "file-write":        3000,
+    "network":            500,
+    "mach-lookup":       1000,
+    "process-info":       200,
+    "process-exec":       200,
+    "process-fork":       200,
+    "signal":             500,
+    "iokit-open":         500,
+    "sysctl-read":        500,
+    "sysctl-write":       200,
+}
+
+# Per-PID burst cap — half the global cap by default. A single
+# subprocess shouldn't be able to consume more than half the run's
+# budget on its own.
+DEFAULT_PID_CAP = 5000
+
+# Token bucket refill rate (records per second). Bucket capacity
+# equals the per-category cap above. A category with cap 500 +
+# refill 10/sec allows steady-state 10/sec indefinitely (refills
+# replenish the bucket); bursts up to 500 flow through immediately.
+# Refill rates for the residual global category default to
+# global_cap / 600 (tuned so a 1-hour run doesn't drain the bucket
+# at a steady rate of ≤ refill).
+DEFAULT_REFILL_RATES = {
+    "file-read-metadata":  10,
+    "file-read-data":      50,
+    "file-write":          50,
+    "network":             20,
+    "mach-lookup":         30,
+    "process-info":         5,
+    "process-exec":         5,
+    "process-fork":         5,
+    "signal":              10,
+    "iokit-open":          10,
+    "sysctl-read":         20,
+    "sysctl-write":         5,
+}
+
+# Post-cap sampling: 1-in-N once a category's bucket is empty.
+# Categories not listed default to N=0 → drop entirely after cap
+# (no post-cap visibility). Listed categories produce a steady
+# trickle even when fully throttled, so operators can see "is this
+# still happening?" without flooding.
+DEFAULT_SAMPLING_RATES = {
+    "file-read-metadata": 100,   # 1 of every 100
+    "file-read-data":      50,
+    "process-info":        50,
+    "iokit-open":         100,
+    "sysctl-read":         50,
+}
+
+
+def _default_categorise(action: str) -> str:
+    """Map an SBPL or syscall name to a budget category.
+
+    The mapping is deliberately coarse — variants of the same
+    category collapse together so the per-category cap is meaningful.
+    Used by both backends; SBPL action names dominate but Linux
+    syscall names happen to fit too (open/openat → file-read-data,
+    write → file-write, etc.). Unrecognised actions return their
+    own name (sharing only the global cap, no category sub-cap).
+    """
+    if action.startswith("file-write") or action.startswith("file-mknod"):
+        return "file-write"
+    if action == "file-read-metadata":
+        return "file-read-metadata"
+    if action.startswith("file-read"):
+        return "file-read-data"
+    if action.startswith("network"):
+        return "network"
+    if action.startswith("mach-lookup"):
+        return "mach-lookup"
+    if action.startswith("process-info"):
+        return "process-info"
+    if action.startswith("process-exec"):
+        return "process-exec"
+    if action == "process-fork":
+        return "process-fork"
+    if action == "signal":
+        return "signal"
+    if action.startswith("iokit-open"):
+        return "iokit-open"
+    if action == "sysctl-read":
+        return "sysctl-read"
+    if action == "sysctl-write":
+        return "sysctl-write"
+    # Linux syscall-name analogues (no SBPL category match) so the
+    # ptrace tracer benefits from the same coarsening.
+    if action in ("write", "writev", "pwrite64", "pwritev",
+                  "creat", "mknod", "mknodat", "truncate"):
+        return "file-write"
+    if action in ("openat", "open", "stat", "fstat", "lstat",
+                  "newfstatat", "statx", "access", "faccessat"):
+        return "file-read-metadata"
+    if action in ("read", "readv", "pread64", "preadv"):
+        return "file-read-data"
+    if action in ("connect", "sendto", "sendmsg", "socket"):
+        return "network"
+    if action in ("execve", "execveat"):
+        return "process-exec"
+    if action in ("clone", "clone3", "fork", "vfork"):
+        return "process-fork"
+    if action in ("kill", "tkill", "tgkill"):
+        return "signal"
+    return action
+
+
+# ---------------------------------------------------------------------
+# Decision shape
+# ---------------------------------------------------------------------
+
+KEEP = "keep"
+DROP = "drop"
+
+
+# ---------------------------------------------------------------------
+# Budget
+# ---------------------------------------------------------------------
+
+class AuditBudget:
+    """Per-run audit budget. One instance per audit session.
+
+    Constructor knobs let callers override defaults for tests and
+    for the CLI's --audit-budget flag. ``categorise`` and ``clock``
+    are injection points for tests (no real time, deterministic
+    category mapping).
+    """
+
+    def __init__(self,
+                 *,
+                 global_cap: Optional[int] = None,
+                 category_caps: Optional[Dict[str, int]] = None,
+                 pid_cap: Optional[int] = None,
+                 refill_rates: Optional[Dict[str, float]] = None,
+                 sampling_rates: Optional[Dict[str, int]] = None,
+                 categorise: Optional[Callable[[str], str]] = None,
+                 clock: Optional[Callable[[], float]] = None,
+                 ):
+        # Defaults — copy so external dicts can't be mutated through
+        # ours and vice versa.
+        self.global_cap = (DEFAULT_GLOBAL_CAP
+                            if global_cap is None else int(global_cap))
+        self.category_caps = (
+            dict(DEFAULT_CATEGORY_CAPS)
+            if category_caps is None else dict(category_caps)
+        )
+        # Scale per-category caps proportionally to global_cap when
+        # the caller overrides global without overriding categories.
+        # Without this, --audit-budget=100000 would still be capped
+        # per-category at the original 500/2000/3000 numbers and the
+        # operator's intent (10× more headroom) would be partially
+        # ignored.
+        if (global_cap is not None and category_caps is None
+                and self.global_cap != DEFAULT_GLOBAL_CAP):
+            scale = self.global_cap / DEFAULT_GLOBAL_CAP
+            self.category_caps = {
+                k: max(1, int(v * scale))
+                for k, v in self.category_caps.items()
+            }
+        self.pid_cap = (DEFAULT_PID_CAP
+                        if pid_cap is None else int(pid_cap))
+        if (pid_cap is None and global_cap is not None
+                and self.global_cap != DEFAULT_GLOBAL_CAP):
+            self.pid_cap = max(1, int(self.pid_cap
+                                       * (self.global_cap
+                                          / DEFAULT_GLOBAL_CAP)))
+        self.refill_rates = (
+            dict(DEFAULT_REFILL_RATES)
+            if refill_rates is None else dict(refill_rates)
+        )
+        self.sampling_rates = (
+            dict(DEFAULT_SAMPLING_RATES)
+            if sampling_rates is None else dict(sampling_rates)
+        )
+        self._categorise = categorise or _default_categorise
+        self._clock = clock or time.monotonic
+
+        # First-global-drop notification flag. Used by callers (the
+        # Linux tracer in particular) to emit a one-time stderr
+        # message when the global cap fires, restoring the operator-
+        # visible cue that the legacy `_MAX_RECORDS_PER_RUN = 10000`
+        # path used to print to tracer stderr. The dropping is
+        # in-band; this flag just lets callers query "did we just
+        # cross the global ceiling?" via `pop_global_cap_notice()`.
+        self._global_cap_notified = False
+        # Per-instance bookkeeping. dict-based; insertion-ordered
+        # since Python 3.7 so we get LRU semantics on `_pid_counts`
+        # for free (move_to_end on access).
+        self._record_count = 0
+        self._category_counts: Dict[str, int] = {}
+        self._pid_counts: Dict[int, int] = {}
+        self._dropped: Dict[str, int] = {}
+        self._cat_marker_emitted: set = set()
+        self._pid_marker_emitted: set = set()
+        # Token bucket: per-category (current_tokens, last_refill_ts).
+        # Initialised lazily on first event in each category so the
+        # bucket starts at full capacity.
+        self._buckets: Dict[str, Tuple[float, float]] = {}
+        # Sampling counter: per-category modular counter so 1-in-N
+        # is deterministic (caller knows exactly which Nth event
+        # leaked through). Starts at 0; sampled records emitted on
+        # _sampling_counter % N == 0.
+        self._sampling_counters: Dict[str, int] = {}
+        # PID dict cap. A fork-bomb-style target spawning millions
+        # of distinct short-lived PIDs would otherwise grow
+        # _pid_counts unbounded (~120 bytes/entry; 1M PIDs ≈ 120MB
+        # resident in the parent before pid_cap admission stops
+        # accepting new records). LRU-evict past this many entries —
+        # evicted PIDs lose their per-PID accounting and rejoin the
+        # admission flow as if newly seen, which is fine: their
+        # records still count against the GLOBAL cap so the budget
+        # remains bounded. _pid_marker_emitted is also evicted in
+        # lock-step so a re-seen PID can re-emit its marker if it
+        # again hits the per-PID cap.
+        self._pid_dict_cap = 10_000
+
+    # ----- snapshot accessors (for end-of-run summary) -------------
+
+    @property
+    def total_records(self) -> int:
+        return self._record_count
+
+    @property
+    def category_counts(self) -> Dict[str, int]:
+        return dict(self._category_counts)
+
+    @property
+    def dropped_by_category(self) -> Dict[str, int]:
+        return dict(self._dropped)
+
+    @property
+    def pid_counts(self) -> Dict[int, int]:
+        return dict(self._pid_counts)
+
+    # ----- core decision -------------------------------------------
+
+    def evaluate(self, action: str, pid: int) -> Tuple[str, Optional[dict]]:
+        """Decide whether to keep or drop a record.
+
+        Returns ``(KEEP, marker)`` or ``(DROP, marker)``. The marker
+        (when non-None) MUST be appended to the JSONL by the caller
+        BEFORE writing or dropping the record — the marker shows the
+        cap-exhaust point in-line so operators see suppression
+        without a separate sidecar file.
+        """
+        cat = self._categorise(action)
+        marker = None
+
+        # Per-PID cap fires regardless of category. Hits this branch
+        # before the category check so the marker mentions the PID,
+        # not the category.
+        pid_cur = self._pid_counts.get(pid, 0)
+        if pid_cur >= self.pid_cap:
+            self._dropped[cat] = self._dropped.get(cat, 0) + 1
+            if pid not in self._pid_marker_emitted:
+                self._pid_marker_emitted.add(pid)
+                marker = self._make_marker(
+                    "pid_budget_exceeded",
+                    pid=pid, cap=self.pid_cap,
+                    note=(f"Per-PID audit-record cap reached for "
+                          f"pid {pid}; further records from this "
+                          f"PID will be dropped. Tune pid_cap in "
+                          f"AuditBudget or pass a larger "
+                          f"--audit-budget to raise."),
+                )
+            return DROP, marker
+
+        # Token-bucket consumption for the category. The bucket's
+        # capacity is the category cap; refill rate is per-cat.
+        # Categories without an explicit refill rate get a default
+        # tied to the global cap so the residual bucket is non-zero.
+        cap = self.category_caps.get(cat, self.global_cap)
+        refill = self.refill_rates.get(cat, self.global_cap / 600.0)
+        if not self._take_token(cat, cap, refill):
+            self._dropped[cat] = self._dropped.get(cat, 0) + 1
+            # Sampling: 1-in-N once the bucket is empty. Emits a
+            # trickle even at full throttle so operators see "still
+            # happening" without flooding. When sampling is
+            # configured for this category, the marker fires on the
+            # first SAMPLED record (operators see "sampling kicked in
+            # NOW" alongside the first kept-after-cap record). When
+            # sampling is NOT configured, the marker fires on the
+            # first DROP (operators see the cap exhaust there
+            # instead).
+            sample_n = self.sampling_rates.get(cat, 0)
+            if sample_n > 0:
+                # Emit the "sampling kicking in" marker on the FIRST
+                # over-cap drop, regardless of whether THIS event is
+                # the one that gets sampled. Operators see "this
+                # category just hit its cap; from now on you'll see
+                # 1-in-N records" right at the moment the cap fires,
+                # not N events later when the first sampled record
+                # happens to land. (Earlier behaviour emitted the
+                # marker on the Nth event — confusing because by
+                # then the cap had already been exceeded for N-1
+                # silent drops.)
+                if cat not in self._cat_marker_emitted:
+                    self._cat_marker_emitted.add(cat)
+                    marker = self._make_marker(
+                        "category_budget_exceeded_sampling",
+                        category=cat, cap=cap,
+                        sampling_rate=sample_n,
+                        note=(f"Category {cat!r} cap reached; "
+                              f"sampling 1-in-{sample_n} from now."),
+                    )
+                self._sampling_counters[cat] = (
+                    self._sampling_counters.get(cat, 0) + 1
+                )
+                if self._sampling_counters[cat] % sample_n == 0:
+                    # Sampled record IS kept — doesn't refill the
+                    # bucket (already over cap) and doesn't bump
+                    # the global counter (we promised the global
+                    # cap).
+                    return KEEP, marker
+                # Not the sampled one — drop, but the marker (if
+                # any was just generated) still flushes so
+                # operators see the state-change event in-line.
+                return DROP, marker
+            # No sampling configured: emit the "no sampling" marker
+            # on the first drop.
+            if cat not in self._cat_marker_emitted:
+                self._cat_marker_emitted.add(cat)
+                marker = self._make_marker(
+                    "category_budget_exceeded",
+                    category=cat, cap=cap,
+                    note=(f"Category {cat!r} cap reached and no "
+                          f"post-cap sampling rate is configured; "
+                          f"further records dropped silently."),
+                )
+            return DROP, marker
+
+        # Global cap — hits when many small-cap categories
+        # collectively exhaust the global pool. We just took a
+        # category token but the record is being dropped → refund
+        # the token so the bucket is available for future events
+        # (e.g., if an operator-side process raises the global cap
+        # mid-run, or sampling kicks in for this category later).
+        if self._record_count >= self.global_cap:
+            self._dropped[cat] = self._dropped.get(cat, 0) + 1
+            # Refund the token we just consumed in _take_token —
+            # this drop is global-cap, not category-cap. Without
+            # the refund, category buckets stay drained even when
+            # the actual constraint is global.
+            tokens, last_ts = self._buckets[cat]
+            self._buckets[cat] = (
+                min(float(cap), tokens + 1.0), last_ts,
+            )
+            # Set the once-only notification flag so the caller can
+            # surface a stderr warning. Markers in JSONL are nice
+            # but easy to miss — the legacy tracer's stderr line
+            # was the operator's first signal that audit was
+            # truncated. Restore parity.
+            self._global_cap_notified = True
+            return DROP, marker
+
+        # Allowed. Bump counters.
+        self._record_count += 1
+        self._category_counts[cat] = self._category_counts.get(cat, 0) + 1
+        # Move PID to end of insertion order so LRU eviction (below)
+        # discards the genuinely-oldest entries when the cap is hit.
+        if pid in self._pid_counts:
+            self._pid_counts[pid] += 1
+        else:
+            self._pid_counts[pid] = 1
+            if len(self._pid_counts) > self._pid_dict_cap:
+                # Evict the oldest entry — Python dict preserves
+                # insertion order, popitem(last=False) is the LRU
+                # evictee. (Plain dict has no popitem(last=) but
+                # iter+next gives the first key.)
+                oldest = next(iter(self._pid_counts))
+                del self._pid_counts[oldest]
+                # Drop the marker-emitted memory too so a re-seen
+                # PID can re-emit its cap-exceeded marker.
+                self._pid_marker_emitted.discard(oldest)
+        return KEEP, marker
+
+    # ----- helpers --------------------------------------------------
+
+    def _take_token(self, cat: str, capacity: int,
+                    refill_rate: float) -> bool:
+        """Refill the bucket for `cat` based on elapsed time, then
+        try to take one token. Returns True if taken, False if
+        bucket was empty (= over cap)."""
+        now = self._clock()
+        tokens, last_ts = self._buckets.get(cat, (float(capacity), now))
+        # Refill since last check, capped at capacity.
+        elapsed = max(0.0, now - last_ts)
+        tokens = min(float(capacity), tokens + elapsed * refill_rate)
+        if tokens < 1.0:
+            self._buckets[cat] = (tokens, now)
+            return False
+        self._buckets[cat] = (tokens - 1.0, now)
+        return True
+
+    def _make_marker(self, marker_type: str, **fields) -> dict:
+        """Construct a marker record. Caller writes the dict as a
+        JSONL line. Marker shape mirrors the audit_summary record
+        so summary.py can recognise both as control-plane entries
+        (vs data records)."""
+        from datetime import datetime, timezone
+        return {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "type": marker_type,
+            "audit": True,
+            **fields,
+        }
+
+    def pop_global_cap_notice(self) -> bool:
+        """Returns True ONCE if the global cap has fired since last
+        call, then False forever after. Lets callers (e.g., the
+        Linux tracer) emit a one-time stderr line when the cap is
+        crossed without re-emitting it on every subsequent drop."""
+        if self._global_cap_notified:
+            self._global_cap_notified = False
+            return True
+        return False
+
+    def summary_record(self) -> dict:
+        """End-of-run summary. Caller appends this once when the
+        audit session closes (LogStreamer.stop / tracer exit)."""
+        from datetime import datetime, timezone
+        return {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "type": "audit_summary",
+            "audit": True,
+            "total_records": self._record_count,
+            "dropped_by_category": dict(self._dropped),
+            "category_counts": dict(self._category_counts),
+            "pid_counts": dict(self._pid_counts),
+            "global_cap": self.global_cap,
+        }
+
+
+# ---------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------
+
+def from_cli_state() -> AuditBudget:
+    """Construct an AuditBudget honouring the --audit-budget CLI flag.
+
+    Reads `core.sandbox.state._cli_sandbox_audit_budget`. None →
+    defaults; integer → override global_cap (per-category and per-
+    PID caps scaled proportionally inside AuditBudget.__init__).
+
+    Centralised here so consumers (tracer, LogStreamer) don't each
+    have to re-read state directly.
+    """
+    from . import state
+    cli_cap = getattr(state, "_cli_sandbox_audit_budget", None)
+    return AuditBudget(global_cap=cli_cap if cli_cap else None)

--- a/core/sandbox/cli.py
+++ b/core/sandbox/cli.py
@@ -120,6 +120,17 @@ def add_cli_args(parser) -> None:
              "--audit. Distinct from any entry-point's own --verbose "
              "flag (which controls log level, not audit output).",
     )
+    parser.add_argument(
+        "--audit-budget", type=int, dest="audit_budget", default=None,
+        metavar="N",
+        help="With --audit: override the global audit-record cap "
+             "(default 10000). Per-category and per-PID sub-caps "
+             "scale proportionally — set higher for long-running "
+             "workloads under --audit-verbose, lower for quick "
+             "diagnostic runs where you only want the first few "
+             "events. The budget protects the JSONL from a chatty "
+             "target generating gigabytes of records.",
+    )
 
 
 def apply_cli_args(args, parser=None) -> None:
@@ -149,6 +160,7 @@ def apply_cli_args(args, parser=None) -> None:
     """
     audit = bool(getattr(args, "audit", False))
     verbose = bool(getattr(args, "audit_verbose", False))
+    budget = getattr(args, "audit_budget", None)
     no_sandbox = bool(getattr(args, "no_sandbox", False))
     profile = getattr(args, "sandbox", None)
 
@@ -163,6 +175,35 @@ def apply_cli_args(args, parser=None) -> None:
             "--audit-verbose requires --audit (audit-verbose only "
             "controls audit-mode tracer output)"
         )
+    if budget is not None:
+        if not audit:
+            _fail(
+                "--audit-budget requires --audit (the budget only "
+                "applies to audit-mode JSONL output)"
+            )
+        if budget <= 0:
+            _fail(
+                f"--audit-budget must be a positive integer; got "
+                f"{budget!r}. Use a small value (e.g. 100) for "
+                f"quick diagnostic runs, the default 10000 for "
+                f"normal use, or a larger value for long-running "
+                f"--audit-verbose sessions."
+            )
+        # Upper clamp: 10M records at the average ~200 bytes/record
+        # bound (cmd + path + serialised args) is ~2GB of JSONL.
+        # Anything past that almost certainly indicates an
+        # operator typo (one extra zero) rather than a real
+        # intent — fail loud rather than letting a runaway audit
+        # eat /tmp.
+        _AUDIT_BUDGET_MAX = 10_000_000
+        if budget > _AUDIT_BUDGET_MAX:
+            _fail(
+                f"--audit-budget={budget} exceeds the upper clamp "
+                f"({_AUDIT_BUDGET_MAX}). At ~200 bytes per record "
+                f"that's ~2GB of JSONL — almost certainly a typo. "
+                f"Lower the value or split into multiple shorter "
+                f"runs."
+            )
     if audit and (no_sandbox or profile == "none"):
         _fail(
             "--audit is incoherent with --sandbox none / --no-sandbox: "
@@ -183,3 +224,5 @@ def apply_cli_args(args, parser=None) -> None:
         )
     if verbose:
         state._cli_sandbox_audit_verbose = True
+    if budget is not None:
+        state._cli_sandbox_audit_budget = int(budget)

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import stat
 import subprocess
+import sys
 from contextlib import contextmanager
 from typing import List, Optional
 
@@ -41,6 +42,8 @@ def check_mount_available():
     return _probes.check_mount_available()
 def check_seccomp_available():
     return _seccomp.check_seccomp_available()
+def check_seatbelt_available():
+    return _probes.check_seatbelt_available()
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +81,19 @@ def _audit_degrade_reason(b_fallback_reason, b_fallback_instr,
     """
     if b_fallback_reason:
         return (b_fallback_reason, b_fallback_instr)
-    if not check_mount_available():
+    if sys.platform == "darwin":
+        # macOS path. The only spawn-disabling host condition on
+        # darwin (after the pass_fds / input checks below) is
+        # sandbox-exec being missing or smoke-test-failing.
+        if not check_seatbelt_available():
+            return (
+                "macOS sandbox-exec is unavailable (smoke test "
+                "failed or /usr/bin/sandbox-exec missing)",
+                "verify `sandbox-exec -p '(version 1)(allow default)' "
+                "/usr/bin/true` succeeds on this host; reinstall "
+                "Command Line Tools if missing.",
+            )
+    elif not check_mount_available():
         return (
             "mount-ns blocked by host "
             "(apparmor_restrict_unprivileged_userns=1)",
@@ -549,10 +564,25 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
     # Explicitly disabled: no seccomp either (rlimits-only contract).
     if effectively_disabled:
         seccomp_profile = None
-    use_sandbox = not effectively_disabled and check_net_available()
-    # Truthy check to match the rest of the module — empty string / empty
-    # list are treated consistently as "not provided".
-    use_mount = use_sandbox and bool(target or output) and check_mount_available()
+    # Backend selection. Linux uses mount-ns + Landlock + seccomp gated
+    # on `check_net_available()` (the user-namespace foundation); macOS
+    # uses sandbox-exec / SBPL gated on `check_seatbelt_available()`.
+    # `use_sandbox` is the platform-aware "is some host-level isolation
+    # backend live for this call" flag — without the per-platform gate
+    # here, macOS would always see use_sandbox=False (no unshare
+    # binary) and silently never engage seatbelt. Both `use_mount` and
+    # `use_seatbelt` are derived from `use_sandbox` so the rest of the
+    # module reads them uniformly. Truthy check on target/output
+    # matches the rest of the module — empty string / empty list are
+    # treated consistently as "not provided".
+    if sys.platform == "darwin":
+        use_sandbox = not effectively_disabled and check_seatbelt_available()
+        use_mount = False
+        use_seatbelt = use_sandbox
+    else:
+        use_sandbox = not effectively_disabled and check_net_available()
+        use_mount = use_sandbox and bool(target or output) and check_mount_available()
+        use_seatbelt = False
 
     if effectively_disabled and not state._cli_sandbox_disabled:
         logger.info("Sandbox disabled for this call")
@@ -603,7 +633,14 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                 f"to. For a network allowlist, pass block_network=False."
             )
 
-    if not effectively_disabled and not use_mount and (target or output or allowed_tcp_ports):
+    # Skip the entire Landlock-availability warning block on macOS:
+    # seatbelt provides the equivalent enforcement (writable_paths,
+    # readable_paths, allowed_tcp_ports all flow into the SBPL profile).
+    # Without this gate, every macOS sandbox call would fire the
+    # "Landlock unavailable" warning even when seatbelt is fully
+    # engaged — confusing and Linux-flavoured.
+    if (not effectively_disabled and not use_mount and not use_seatbelt
+            and (target or output or allowed_tcp_ports)):
         if not check_landlock_available():
             if state.warn_once("_landlock_warned_unavailable"):
                 logger.warning(
@@ -921,7 +958,17 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
         # ns + IPC ns + user ns, without network ns unless block_network
         # is also set (the egress proxy needs the shared net ns to be
         # reachable on loopback).
-        need_unshare = use_sandbox and (block_network or use_mount or restrict_reads)
+        # `need_unshare` gates the Linux user-namespace bootstrap
+        # (`unshare` + `prlimit` + pid1 shim). On macOS, isolation
+        # comes from sandbox-exec / SBPL — there is no `unshare`
+        # binary to resolve, and the seatbelt path runs through
+        # _macos_spawn instead. Without the use_seatbelt veto, an
+        # ineligible-for-spawn macOS call (or even a fully eligible
+        # one, since the unshare_cmd is built unconditionally below)
+        # tries to resolve `unshare` and crashes the sandbox call.
+        need_unshare = (use_sandbox
+                        and not use_seatbelt
+                        and (block_network or use_mount or restrict_reads))
 
         # Log active sandbox layers for this command. Cache the Landlock
         # probe locally so we don't reacquire the cache lock 2-3× per run().
@@ -1072,7 +1119,14 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
         #     thread to avoid pipe-fill deadlock on large inputs)
         # (`stdin=<fd>` IS plumbed through _spawn.run_sandboxed, so we
         # only exclude `input=` here, not plain stdin=.)
-        spawn_eligible = (use_mount
+        # Either backend (Linux mount-ns or macOS seatbelt) routes through
+        # the spawn path; the same kwarg-compat gate applies to both
+        # (pass_fds / input= aren't plumbed through either backend's
+        # custom spawn implementation — Linux _spawn does its own
+        # os.fork() chain, macOS _macos_spawn wraps subprocess.run with
+        # sandbox-exec but still uses our preexec for rlimits, where
+        # input= would race against the writer-thread we don't have).
+        spawn_eligible = ((use_mount or use_seatbelt)
                           and not kwargs.get("pass_fds")
                           and kwargs.get("input") is None)
         # Track the audit-degraded reason so the audit-mode degraded
@@ -1092,7 +1146,10 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
         # the new rootfs — the subprocess fails with ENOENT (exit
         # 127) and an empty stderr that operators may misread as
         # "tool found nothing" rather than "tool didn't run".
-        if spawn_eligible and cmd:
+        # macOS sandbox-exec doesn't change the filesystem view, so
+        # this check + the speculative-C cache it feeds are skipped
+        # on Darwin (use_mount is always False there).
+        if spawn_eligible and use_mount and cmd:
             _all_extra = list(effective_read_paths or []) + list(tool_paths or [])
             _resolved = shutil.which(cmd[0]) or cmd[0]
             # B fallback: cmd[0] not in mount-ns bind tree → skip
@@ -1200,7 +1257,51 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
         # per-sandbox dict would grow unboundedly across a long
         # session with flaky sandboxes.
         try:
-            if spawn_eligible:
+            if spawn_eligible and use_seatbelt:
+                # macOS sandbox-exec path. No fork/pivot_root chain; no
+                # mount-ns fallback ladder. sandbox-exec wraps a single
+                # execvp with the SBPL profile applied via Sandbox.kext.
+                # No bind-tree visibility check, no speculative-C cache —
+                # the filesystem view is unchanged, so the typical
+                # mount-ns failure modes don't exist.
+                from . import _macos_spawn as _macos_mod
+                _audit_run_dir = (
+                    (audit_run_dir or output)
+                    if nonlocal_audit_mode else None
+                )
+                result = _macos_mod.run_sandboxed(
+                    cmd,
+                    target=target, output=output,
+                    block_network=block_network,
+                    nproc_limit=nproc_limit,
+                    limits=effective_limits,
+                    writable_paths=writable_paths or [],
+                    readable_paths=effective_read_paths or [],
+                    allowed_tcp_ports=list(allowed_tcp_ports)
+                        if allowed_tcp_ports else None,
+                    # Linux-only kwargs accepted for signature parity
+                    # with _spawn.run_sandboxed; ignored by SBPL backend.
+                    seccomp_profile=seccomp_profile,
+                    seccomp_block_udp=seccomp_block_udp,
+                    env=kwargs.get("env"),
+                    cwd=kwargs.get("cwd"),
+                    timeout=kwargs.get("timeout"),
+                    capture_output=kwargs.get("capture_output", False),
+                    text=kwargs.get("text", False),
+                    stdin=kwargs.get("stdin"),
+                    audit_mode=nonlocal_audit_mode,
+                    audit_run_dir=_audit_run_dir,
+                    audit_verbose=audit_verbose_active and nonlocal_audit_mode,
+                    restrict_reads=restrict_reads,
+                    use_egress_proxy=use_egress_proxy,
+                    proxy_port=(proxy_instance.port
+                                if proxy_instance is not None else None),
+                    fake_home=fake_home,
+                    map_root=map_root,
+                    start_new_session=kwargs.get("start_new_session", True),
+                )
+                used_spawn = True
+            elif spawn_eligible:
                 try:
                     from . import _spawn as _spawn_mod
                     if _spawn_mod.mount_ns_available():
@@ -1534,11 +1635,34 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
             stderr_text = raw_stderr.decode("utf-8", errors="replace")
         else:
             stderr_text = ""
-        network_engaged = bool(need_unshare and block_network)
-        landlock_engaged = bool(
-            (writable_paths or allowed_tcp_ports) and landlock_available
+        # Engagement booleans tell _check_blocked which stderr patterns
+        # are admissible evidence of a sandbox firing. macOS via SBPL
+        # uses the SAME stderr patterns ("Permission denied",
+        # "PermissionError", connection refused, ...) — the kernel
+        # turns SBPL denies into the standard EACCES/EPERM errno that
+        # tools surface as the same messages — so we just OR in the
+        # seatbelt-equivalent for each layer:
+        #   network: SBPL (deny network*) is emitted when block_network
+        #     OR use_egress_proxy → network_engaged on the macOS side.
+        #   landlock: the seatbelt profile ALWAYS emits a write-deny
+        #     clause (the default exception list is /private/tmp +
+        #     output + writable_paths), so use_seatbelt itself is
+        #     sufficient signal that fs writes are gated.
+        #   seccomp: macOS has no real equivalent; we treat the
+        #     SBPL hardening clauses (Tier 1.4, deny process-info etc.)
+        #     as a coarse stand-in when seccomp_profile is requested.
+        network_engaged = bool(
+            (need_unshare and block_network)
+            or (use_seatbelt and (block_network or use_egress_proxy))
         )
-        seccomp_engaged = bool(seccomp_profile and check_seccomp_available())
+        landlock_engaged = bool(
+            ((writable_paths or allowed_tcp_ports) and landlock_available)
+            or use_seatbelt
+        )
+        seccomp_engaged = bool(
+            (seccomp_profile and check_seccomp_available())
+            or (use_seatbelt and seccomp_profile and seccomp_profile != "none")
+        )
         if stderr_text and (network_engaged or landlock_engaged or seccomp_engaged):
             _check_blocked(stderr_text, cmd_display, result.returncode,
                           result.sandbox_info,

--- a/core/sandbox/probes.py
+++ b/core/sandbox/probes.py
@@ -205,3 +205,56 @@ def check_mount_available() -> bool:
                 "To enable, run: sudo apt install uidmap"
             )
         return state._mount_available_cache
+
+
+def check_seatbelt_available() -> bool:
+    """macOS-only: check if `sandbox-exec` works for our use case.
+
+    Returns True iff:
+      - Running on darwin
+      - /usr/bin/sandbox-exec exists
+      - A smoke-test invocation under (allow default) baseline
+        succeeds (verifies SBPL parser + kernel support).
+
+    Cached per-process. Linux always returns False without invoking
+    sandbox-exec (saves the subprocess fork on every check).
+
+    The `(allow default)` baseline is the minimal SBPL profile that
+    lets dyld + libSystem load on modern macOS — pure deny-default
+    SIGABRT's the process before dyld can finish. Spike-validated
+    on macOS 26.4.1 (see scripts/macos_sandbox_spike.py).
+    """
+    import sys
+    if sys.platform != "darwin":
+        return False
+    if state._seatbelt_available_cache is not None:
+        return state._seatbelt_available_cache
+    with state._cache_lock:
+        if state._seatbelt_available_cache is not None:
+            return state._seatbelt_available_cache
+        sandbox_exec = "/usr/bin/sandbox-exec"
+        if not Path(sandbox_exec).exists():
+            state._seatbelt_available_cache = False
+            return False
+        # Smoke test: minimal valid profile + /usr/bin/true (always
+        # present on macOS). 5s timeout — sandbox-exec normally
+        # returns in <50ms; anything longer means a real problem.
+        profile = "(version 1)\n(allow default)\n"
+        try:
+            r = subprocess.run(
+                [sandbox_exec, "-p", profile, "/usr/bin/true"],
+                capture_output=True, timeout=5,
+            )
+            ok = (r.returncode == 0)
+        except (subprocess.TimeoutExpired, OSError):
+            ok = False
+        state._seatbelt_available_cache = ok
+        if not ok and state.warn_once("_sandbox_unavailable_warned"):
+            logger.warning(
+                "Sandbox: macOS sandbox-exec smoke test FAILED — "
+                "subprocesses will run without isolation. Verify "
+                "sandbox-exec works on this host: "
+                "`sandbox-exec -p '(version 1)(allow default)' "
+                "/usr/bin/true`"
+            )
+        return ok

--- a/core/sandbox/seatbelt.py
+++ b/core/sandbox/seatbelt.py
@@ -1,0 +1,458 @@
+"""SBPL (Sandbox Profile Language) profile generation for macOS.
+
+Apple's `sandbox-exec(1)` consumes SBPL profiles to enforce file /
+network / IPC restrictions at the kernel boundary via the Sandbox
+kext + TrustedBSD MAC. This module generates SBPL profile strings
+from the same logical kwargs that drive the Linux Landlock + seccomp
++ namespace setup, so callers see one uniform sandbox API regardless
+of host OS.
+
+Design decisions, derived from Phase 0 spike (see
+``scripts/macos_sandbox_spike.py``):
+
+1. **`(allow default)` baseline + targeted denies.** Pure
+   `(deny default)` profiles SIGABRT modern macOS binaries before
+   dyld can load libSystem (spike result rc=-6 / SIGABRT). The
+   community SBPL idiom — and the only one we can rely on without
+   reverse-engineering Apple's `system.sb` — is allow-default with
+   explicit denies layered on top. Inverse of Linux Landlock's
+   deny-default model, but produces the same operator-visible
+   semantics: writes restricted to specific paths, network blocked,
+   etc.
+
+2. **`os.path.realpath()` mandatory before SBPL emission.** macOS has
+   pervasive symlinks (`/var → /private/var`, `/tmp → /private/tmp`,
+   `/etc → /private/etc`). SBPL `(subpath ...)` matches against the
+   canonical resolved path; passing the symlink path silently fails
+   to match. Spike confirmed: `(deny X (require-not (subpath Y)))`
+   denies even legitimate writes when Y is a /var/folders/... path
+   that resolves to /private/var/folders/...
+
+3. **`(deny X (require-not (subpath Y)))` is the deny-with-exception
+   idiom.** Plain ordering (`(deny X)(allow X subpath)`) doesn't work
+   — explicit deny outranks subsequent allow regardless of order.
+   The `require-not` clause is the canonical SBPL way to express
+   "deny X except where Y matches".
+
+4. **Audit mode = `(allow X (with report))`.** When `--audit` is
+   engaged, the file-write deny is replaced (not augmented) with an
+   allow + report modifier. The write succeeds AND a kernel sandbox
+   log entry is emitted. Captured live via `log stream` filtered on
+   `senderImagePath == "/System/Library/Extensions/Sandbox.kext/..."`
+   (see seatbelt_audit.py).
+
+5. **Egress proxy port allowed inline.** When use_egress_proxy=True
+   the parent sets HTTPS_PROXY=localhost:<port> in the child env;
+   the SBPL profile must permit `network-outbound` to that loopback
+   port even though network is otherwise denied.
+
+Architectural correspondence:
+
+    Linux Landlock                  → macOS SBPL
+    ─────────────────────────────   ─────────────────────────────────
+    writable_paths (Landlock allow) → (deny file-write* (require-not
+                                       (subpath REALPATH(...))))
+    block_network (network-ns)      → (deny network*)
+    allowed_tcp_ports               → (allow network-outbound
+                                       (remote tcp "*:PORT"))
+    seccomp blocklist               → (deny mach-lookup),
+                                      (deny iokit-open), etc.
+    audit_mode (SCMP_ACT_TRACE)     → (allow file-write* (with report))
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable, Optional
+
+
+# Sandbox kernel extension path — matches the senderImagePath of audit
+# log entries. Defined here so seatbelt_audit can import the same
+# constant rather than re-stringing it.
+SANDBOX_KEXT_SENDER = (
+    "/System/Library/Extensions/Sandbox.kext/Contents/MacOS/Sandbox"
+)
+
+
+def _realpath_or_none(path: Optional[str]) -> Optional[str]:
+    """Canonicalize ``path`` via os.path.realpath, or None if path is
+    falsy. SBPL's (subpath ...) matches the canonical resolved path
+    only — feeding it /var/folders/... when the actual filesystem
+    location is /private/var/folders/... silently fails to match
+    (spike result, see scripts/macos_sandbox_spike3.py)."""
+    if not path:
+        return None
+    return os.path.realpath(path)
+
+
+def _quote_sbpl(s: str) -> str:
+    """Quote a string literal for SBPL. SBPL uses double-quoted strings
+    with backslash escapes for embedded quotes/backslashes.
+
+    Rejects control characters (newline, NUL, anything <0x20). The
+    SBPL parser is whitespace-sensitive: a path containing `\\n` would
+    close the current s-expression and inject a fresh clause —
+    `output="/tmp/x\\n(allow file-write*)"` becomes a profile that
+    grants blanket write. Realpath canonicalisation only protects
+    paths that exist as inodes; caller-supplied writable_paths /
+    readable_paths come straight from kwargs and may not exist yet
+    (or may have been crafted by a malicious caller passing through).
+    Rejecting control chars at the quoter closes the injection
+    surface uniformly for every (subpath ...) / (literal ...) clause.
+    """
+    if any(ord(c) < 0x20 for c in s):
+        bad = next(c for c in s if ord(c) < 0x20)
+        raise ValueError(
+            f"SBPL string contains control character "
+            f"(ord {ord(bad)}); refusing to quote — would let an "
+            f"attacker-controlled path inject SBPL clauses. Got: "
+            f"{s!r}"
+        )
+    return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def build_profile(*,
+                  target: Optional[str] = None,
+                  output: Optional[str] = None,
+                  block_network: bool = False,
+                  allowed_tcp_ports: Optional[Iterable[int]] = None,
+                  use_egress_proxy: bool = False,
+                  proxy_port: Optional[int] = None,
+                  restrict_reads: bool = False,
+                  readable_paths: Optional[Iterable[str]] = None,
+                  writable_paths: Optional[Iterable[str]] = None,
+                  fake_home: bool = False,  # noqa: ARG001 — env-side, profile is unaffected
+                  audit_mode: bool = False,
+                  audit_verbose: bool = False,
+                  seccomp_profile: Optional[str] = None,
+                  ) -> str:
+    """Generate an SBPL profile string from logical sandbox kwargs.
+
+    The kwarg surface mirrors core.sandbox.context.sandbox()'s contract.
+    Output is a multi-line SBPL source ready for ``sandbox-exec -p``.
+
+    Args:
+      target: read-only bind-mount on Linux; on macOS just an
+        engagement marker (writes are restricted via the deny clauses,
+        reads are always-allowed by the (allow default) baseline).
+      output: writable scratch dir. Realpath'd and added to the
+        write-allowlist exception clause.
+      block_network: emit (deny network*).
+      allowed_tcp_ports: emit (allow network-outbound (remote tcp ...))
+        for each port — typically used for the egress proxy.
+      use_egress_proxy: shorthand — implies block_network=True except
+        for proxy_port. Caller passes the actual proxy_port number.
+      proxy_port: loopback port the egress proxy listens on. Required
+        when use_egress_proxy=True.
+      restrict_reads: when True, layer a (deny file-read*) with an
+        exception clause for system dirs + readable_paths. When False
+        (default), reads are unrestricted (matches Linux Landlock
+        default).
+      readable_paths: extra dirs to allow under restrict_reads=True.
+      writable_paths: extra dirs to add to the write-allowlist
+        exception (in addition to output).
+      fake_home: env-level concern — set HOME to {output}/.home/
+        before exec. The profile itself doesn't reference HOME so this
+        kwarg is here for signature parity; the actual env mutation
+        happens in _macos_spawn.py.
+      audit_mode: when True, replace file-write denies with
+        (allow file-write* (with report)) — the write succeeds AND
+        emits a kernel sandbox log entry that seatbelt_audit captures.
+      audit_verbose: when True (audit_mode must also be True),
+        emit `(allow X (with report))` for an extended set of SBPL
+        action categories: file-read-data, file-read-metadata,
+        mach-lookup, process-exec*, process-fork, process-info*,
+        signal, iokit-open, sysctl-read. Closest macOS analogue to
+        Linux's SCMP_ACT_TRACE-everywhere strace-style audit.
+        Volume protection: seatbelt_audit.LogStreamer routes every
+        parsed record through core.sandbox.audit_budget.AuditBudget
+        (token-bucket + per-category caps from
+        DEFAULT_CATEGORY_CAPS + per-PID cap + 1-in-N sampling for
+        high-volume categories from DEFAULT_SAMPLING_RATES). High-
+        volume categories like
+        file-read-metadata and process-info-* are allowed but
+        their JSONL contribution is bounded; operators see a
+        `budget_exceeded` marker per category once a cap is hit
+        and an `audit_summary` record at stop-time. SBPL is
+        coarser than seccomp: records are action-category +
+        path/target rather than per-syscall + argv.
+      seccomp_profile: name of the requested Linux seccomp profile
+        ("full"/"debug"/"network-only"/"none"/None). macOS has no
+        direct seccomp equivalent, but we approximate the closest
+        policy intent — "block introspection / capability escape
+        vectors that don't break common tools" — by adding a small
+        set of SBPL denies when the profile is anything other than
+        None or "none". The exact set is conservative (see Tier 1.4
+        rationale in module docstring): we deny process-info-pidinfo
+        (block looking up other processes' info) and
+        process-info-pidfdinfo (block looking up other processes'
+        FDs), since those are the closest analogues to Linux's
+        ptrace-deny under "full" seccomp. Other SBPL denies (mach-
+        lookup of specific services, iokit-open, etc.) are too
+        invasive to apply by default — a future "macos-strict"
+        profile could opt in.
+    """
+    parts: list = []
+    parts.append("(version 1)")
+    # Permissive baseline. Cannot be (deny default) — see module docstring.
+    parts.append("(allow default)")
+
+    # --- Filesystem write restriction ---
+    # Build the exception clause (paths the sandbox CAN write to).
+    # Always include /private/tmp (the realpath of /tmp) so tools that
+    # write temp files keep working — matches the Linux Landlock
+    # default of /tmp in writable_paths.
+    write_exceptions: list = ["/private/tmp"]
+    out_real = _realpath_or_none(output)
+    if out_real:
+        write_exceptions.append(out_real)
+    for p in (writable_paths or ()):
+        rp = _realpath_or_none(p)
+        if rp and rp not in write_exceptions:
+            write_exceptions.append(rp)
+
+    # Engage write isolation only when the caller has signalled fs
+    # restriction is wanted (any of: output, writable_paths, target,
+    # restrict_reads). If none are set, the caller's intent matches
+    # Linux's Landlock-disabled profiles (`network-only`, `none`):
+    # network may still be policed but writes are unrestricted.
+    # Without this gate, the macOS path would always emit the write-
+    # deny clause even under `network-only`, diverging from Linux.
+    write_isolation_engaged = bool(
+        output or writable_paths or target or restrict_reads
+    )
+    if write_isolation_engaged:
+        if audit_mode:
+            # Audit mode: don't deny — allow writes anywhere AND emit
+            # a log entry for each. The write-allowlist exception
+            # becomes informational (operators see in audit records
+            # which paths the workload SHOULD have been allowed to
+            # touch under enforcement). Reasoning matches the Linux
+            # b3 layer: under audit, observe rather than block.
+            parts.append("(allow file-write* (with report))")
+        else:
+            # Enforcement: deny writes EXCEPT in the exception
+            # subpaths.
+            #
+            # SBPL semantics for multi-filter denies are OR (verified
+            # on macOS 26.4.1):
+            #   (deny X (require-not A) (require-not B))
+            #     ≡ deny X when (NOT A) OR (NOT B)
+            #     ≡ deny X UNLESS (A AND B)   ← intersection, not union
+            #
+            # We want UNION semantics ("allow if in A OR B"). Apple's
+            # canonical idiom is `(require-not (require-any ...))`:
+            #   (deny X (require-not (require-any A B)))
+            #     ≡ deny X UNLESS (A OR B)
+            # This matches Linux Landlock's writable_paths list
+            # behaviour. `require-any` is a multi-arg combinator —
+            # unlike `require-not` which is unary.
+            subpath_any = " ".join(
+                f"(subpath {_quote_sbpl(p)})" for p in write_exceptions
+            )
+            parts.append(
+                f"(deny file-write* (require-not (require-any "
+                f"{subpath_any})))"
+            )
+
+    # --- Filesystem read restriction (only when explicitly requested) ---
+    if restrict_reads:
+        # Mirror the Linux restrict_reads=True allowlist: system dirs
+        # always allowed (libc, ld.so, /etc); $HOME and bespoke paths
+        # only via readable_paths. We don't include /private/var/folders
+        # here — that's the per-call output dir, already covered by
+        # write_exceptions which DOES allow reads (file-write* implies
+        # file-read* under SBPL semantics for the same path).
+        SYSTEM_READ_DIRS = (
+            "/usr", "/System", "/Library/Frameworks",
+            "/private/etc", "/private/var/db/timezone",
+            # /bin and /sbin host real binaries on macOS — they are
+            # NOT symlinks to /usr/bin / /usr/sbin (unlike most modern
+            # Linux distros). PATH lookups commonly resolve to
+            # /bin/echo, /bin/sh, /bin/ls etc.; without these in the
+            # read allowlist, restrict_reads=True breaks every
+            # subprocess that runs a /bin or /sbin tool.
+            "/bin", "/sbin",
+        )
+        # /dev is NOT included wholesale — same posture as Linux
+        # (core/sandbox/context.py SYSTEM_READ_DIRS deliberately
+        # excludes /dev to keep /dev/shm out of scope; on macOS
+        # the equivalent is POSIX shm via shm_open which lives
+        # under /private/var/folders/.../C/shm and is similarly
+        # cross-process-readable for same-UID processes). Specific
+        # /dev files needed for normal program startup are granted
+        # individually below.
+        SYSTEM_READ_DEV_FILES = (
+            "/dev/null", "/dev/zero", "/dev/random", "/dev/urandom",
+            "/dev/full", "/dev/tty",
+            # /dev/dtracehelper is consulted by libsystem's malloc
+            # initialiser on some macOS versions; allowing it stops
+            # spurious deny-spam in audit mode.
+            "/dev/dtracehelper",
+        )
+        # The root directory `/` itself is needed by dyld during image
+        # loading — it opens `/` for read as part of path walk
+        # canonicalisation. `(subpath "/usr")` allows everything UNDER
+        # /usr but does NOT allow reading the parent root inode. Without
+        # this allow, every binary launched under restrict_reads=True
+        # SIGABRTs at dyld stage with an empty stderr (the kernel
+        # emits `deny(1) file-read-data /`). Apple's own open-source
+        # sandbox profiles use the same `(literal "/")` idiom for the
+        # same reason.
+        # Add `/` AND the curated /dev files as exact-path
+        # literals. `(subpath "/")` would defeat the restriction
+        # entirely; literal "/" allows ONLY the root inode (needed
+        # by dyld for path canonicalisation at image-load time).
+        # The /dev entries grant the small set of character devices
+        # tools genuinely need (null/zero/urandom/etc.) without
+        # opening up /dev/shm or /dev/io_uring-style surfaces.
+        SYSTEM_READ_LITERALS = ("/",) + SYSTEM_READ_DEV_FILES
+        read_exceptions: list = list(SYSTEM_READ_DIRS)
+        # Output + writable_paths are also readable by definition.
+        read_exceptions.extend(write_exceptions)
+        for p in (readable_paths or ()):
+            rp = _realpath_or_none(p)
+            if rp and rp not in read_exceptions:
+                read_exceptions.append(rp)
+        # Target is engagement-only on Linux but here we need to
+        # actually allow reads of it.
+        target_real = _realpath_or_none(target)
+        if target_real and target_real not in read_exceptions:
+            read_exceptions.append(target_real)
+        # Split file-read-metadata from file-read-data, matching
+        # Apple's own open-source SBPL profile pattern (used in
+        # WebKit, mDNSResponder, etc.):
+        #
+        #   * file-read-metadata is allowed UNIVERSALLY — stat,
+        #     readdir on any path, getattrlist, etc. Path
+        #     traversal needs metadata reads on every component
+        #     and dyld needs them at image load. Metadata is rarely
+        #     a secret.
+        #
+        #   * file-read-data (file content reads) is denied EXCEPT
+        #     in the narrow allowlist. This is the secret-protecting
+        #     layer — what we actually care about under
+        #     restrict_reads=True.
+        #
+        # Earlier code lumped both under (deny file-read*), which
+        # required a hack — `(literal "/")` allow so dyld didn't
+        # SIGABRT. That hack also allowed readdir("/") which leaks
+        # the top-level directory listing (/Users, /Volumes, etc).
+        # The split below keeps metadata permissive (no SIGABRT)
+        # while denying readdir-of-/ as a data read.
+        if not audit_mode:
+            parts.append("(allow file-read-metadata)")
+            data_allow_clauses = " ".join(
+                [f"(subpath {_quote_sbpl(p)})" for p in read_exceptions]
+                + [f"(literal {_quote_sbpl(p)})"
+                   for p in SYSTEM_READ_LITERALS]
+            )
+            parts.append(
+                f"(deny file-read-data (require-not (require-any "
+                f"{data_allow_clauses})))"
+            )
+        # Audit mode + restrict_reads: same idea as writes — log,
+        # don't block. Each unauthorized read attempt becomes a
+        # record in the audit summary. Keep file-read* (covers both
+        # data and metadata) so audit captures the full picture.
+        else:
+            parts.append("(allow file-read* (with report))")
+
+    # --- "Seccomp-equivalent" hardening ---
+    # Conservative defaults — stricter sets land under a future
+    # explicit "macos-strict" profile rather than the implicit "any
+    # non-None seccomp_profile means harden". See docstring.
+    #
+    # `debug` profile is deliberately EXCLUDED from the introspection
+    # denies. Linux's `--sandbox debug` is "full minus ptrace block"
+    # so gdb/rr can attach to the sandboxed target; on macOS the
+    # analogue is leaving process-info-* on `target others`
+    # unrestricted so lldb / dtrace / sample(1) can introspect the
+    # target. Both platforms now share the same intent: "debug
+    # profile = full enforcement EXCEPT keep debugger primitives
+    # functional".
+    # Allowlist (not denylist) the profile names that engage the
+    # introspection denies. Adding a future profile (e.g. "minimal")
+    # to PROFILES would otherwise SILENTLY engage the hardening
+    # because it'd be neither None nor "none" nor "debug". Pin the
+    # explicit set: only "full" engages introspection denies on
+    # macOS today. New profiles must opt in here.
+    _SECCOMP_PROFILES_HARDEN_INTROSPECTION = {"full"}
+    if seccomp_profile in _SECCOMP_PROFILES_HARDEN_INTROSPECTION:
+        # Block introspection of OTHER processes — closest analogue
+        # to Linux's seccomp-blocked ptrace under the "full" profile.
+        # `target others` so the sandboxed process can still introspect
+        # itself (legitimate things like reading /proc/self equivalents
+        # via libproc still work).
+        if audit_mode:
+            parts.append("(allow process-info* (with report))")
+        else:
+            parts.append("(deny process-info-pidinfo (target others))")
+            parts.append("(deny process-info-pidfdinfo (target others))")
+
+    # --- Verbose audit (Phase 2c — closest macOS analogue to Linux's
+    # SCMP_ACT_TRACE-everywhere strace-style audit). When audit_verbose
+    # is engaged alongside audit_mode, emit `(allow X (with report))`
+    # for additional SBPL action categories so seatbelt_audit's
+    # LogStreamer captures activity beyond just file writes.
+    #
+    # Category set is conservative — file-read-data captures
+    # interesting reads (file content) without the firehose of
+    # file-read-metadata (every stat/readdir). process-info-* is
+    # deliberately omitted for the same reason — too noisy under any
+    # real workload, no skip-budget on the macOS side yet. Operators
+    # who want everything can extend this list in seatbelt.py and
+    # accept the volume.
+    #
+    # Only emitted when audit_mode is also set — verbose without
+    # audit_mode is operator confusion (the Linux kwarg surface
+    # enforces the same constraint via context.py).
+    if audit_verbose and audit_mode:
+        # file-read-data already covered by restrict_reads+audit_mode
+        # branch above when restrict_reads=True; emit here for the
+        # restrict_reads=False case (verbose audit without read
+        # restriction). Idempotent re-emission is harmless — SBPL
+        # combines duplicate (allow ... (with report)) clauses.
+        parts.append("(allow file-read-data (with report))")
+        parts.append("(allow mach-lookup (with report))")
+        parts.append("(allow process-exec* (with report))")
+        parts.append("(allow process-fork (with report))")
+        parts.append("(allow signal (with report))")
+        # High-volume categories — safe to enable now that
+        # seatbelt_audit.LogStreamer routes records through
+        # core.sandbox.audit_budget.AuditBudget which enforces
+        # per-category caps (see DEFAULT_CATEGORY_CAPS) plus token-
+        # bucket refill and 1-in-N sampling. Without the budget
+        # these would
+        # flood the JSONL on any non-trivial workload (every
+        # stat/readdir, every pidinfo lookup, every kernel-info
+        # probe). Operators tuning sensitivity raise the per-cat
+        # cap rather than stripping these from the SBPL set.
+        parts.append("(allow file-read-metadata (with report))")
+        parts.append("(allow process-info* (with report))")
+        parts.append("(allow iokit-open (with report))")
+        parts.append("(allow sysctl-read (with report))")
+
+    # --- Network ---
+    # use_egress_proxy implies block_network (only the proxy port is
+    # reachable). Caller is responsible for setting HTTPS_PROXY in the
+    # child env; we just open the kernel-level network policy enough
+    # for the loopback proxy connection to work.
+    block = block_network or use_egress_proxy
+    if block:
+        parts.append("(deny network*)")
+        if use_egress_proxy and proxy_port:
+            parts.append(
+                f"(allow network-outbound "
+                f"(remote tcp4 \"localhost:{int(proxy_port)}\"))"
+            )
+            parts.append(
+                f"(allow network-outbound "
+                f"(remote tcp6 \"localhost:{int(proxy_port)}\"))"
+            )
+        for port in (allowed_tcp_ports or ()):
+            parts.append(
+                f"(allow network-outbound (remote tcp \"*:{int(port)}\"))"
+            )
+
+    return "\n".join(parts) + "\n"

--- a/core/sandbox/seatbelt_audit.py
+++ b/core/sandbox/seatbelt_audit.py
@@ -1,0 +1,337 @@
+"""macOS audit-mode log capture.
+
+When ``--audit`` is engaged on macOS, the SBPL profile uses
+``(allow file-write* (with report))`` — the write succeeds AND the
+kernel Sandbox.kext emits an entry to the unified log. This module
+streams those entries live via ``log stream``, parses them, and
+appends RAPTOR-format records to ``<run_dir>/.sandbox-denials.jsonl``
+— matching the JSONL schema produced by the Linux ptrace tracer so
+the existing ``summarize_and_write`` aggregation works unchanged.
+
+Spike-validated facts (see scripts/macos_sandbox_spike4.py):
+
+  * Sandbox kext entries have ``subsystem=""`` and ``category=""`` —
+    cannot filter on those.
+  * The reliable filter is ``senderImagePath ==
+    "/System/Library/Extensions/Sandbox.kext/Contents/MacOS/Sandbox"``.
+  * eventMessage format:
+        ``Sandbox: <ProcessName>(<PID>) <verdict> <action> <path>``
+    where verdict ∈ {allow, deny} and action is e.g. file-write-create,
+    file-read-data, network-outbound.
+
+Threading: the streamer runs as a daemon thread that reads
+``log stream`` ndjson output line-by-line. Daemon=True so it doesn't
+block process shutdown. ``stop()`` terminates the underlying
+subprocess.
+
+Per-call lifecycle: caller in _macos_spawn starts the streamer just
+before running the sandboxed workload and stops it after. The brief
+warm-up window is acceptable — sandbox events arrive within tens of
+milliseconds of the workload's syscall, well within the post-workload
+drain period.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from .seatbelt import SANDBOX_KEXT_SENDER
+
+logger = logging.getLogger(__name__)
+
+
+# Filename matches the Linux tracer convention so summarize_and_write
+# in summary.py picks it up unchanged.
+DENIALS_FILE = ".sandbox-denials.jsonl"
+
+
+# Skip-budget delegated to core.sandbox.audit_budget.AuditBudget,
+# which is shared with the Linux ptrace tracer so the two backends
+# stay in sync. See that module for the full mechanism (token-bucket
+# + per-category + per-PID + 1-in-N sampling + CLI override).
+from . import audit_budget as _audit_budget
+
+
+# Sandbox kext eventMessage format. Spike #4 confirmed:
+#   "Sandbox: <ProcessName>(<PID>) <verdict> <action> <path>"
+# verdict ∈ {allow, deny}; action is file-* / network-* / etc.
+_LOG_LINE_RE = re.compile(
+    r"Sandbox:\s+(\S+)\((\d+)\)\s+(allow|deny)\s+(\S+)\s+(.+)$"
+)
+
+
+# Map SBPL action prefixes to the RAPTOR sandbox-summary type taxonomy
+# (matches Linux tracer's _NAME_TO_TYPE mapping).
+def _action_to_type(action: str) -> str:
+    if action.startswith("file-write") or action.startswith("file-mknod"):
+        return "write"
+    if action.startswith("file-read"):
+        return "read"
+    if action.startswith("network"):
+        return "network"
+    # mach-lookup, iokit-open, sysctl-*, process-*, etc.
+    return "seccomp"  # closest analogue in the Linux taxonomy
+
+
+def parse_log_entry(entry: dict) -> Optional[dict]:
+    """Convert a `log stream` ndjson entry to a RAPTOR audit record.
+
+    Returns None if the entry isn't a recognisable Sandbox.kext
+    message (silently dropped — many kext entries pass through and
+    aren't meaningful audit events).
+    """
+    if entry.get("senderImagePath") != SANDBOX_KEXT_SENDER:
+        return None
+    msg = entry.get("eventMessage", "")
+    m = _LOG_LINE_RE.search(msg)
+    if not m:
+        return None
+    process_name, pid, verdict, action, path = m.groups()
+    return {
+        "ts": entry.get("timestamp") or _now_iso(),
+        "cmd": f"<sandbox audit: {action} {path}>",
+        "returncode": 0,
+        "type": _action_to_type(action),
+        "audit": True,
+        "verdict": verdict,           # allow | deny — present here, absent in Linux records
+        "syscall": action,            # field name matches Linux for compatibility
+        "path": path,
+        "target_pid": int(pid),
+        "process_name": process_name,
+    }
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class LogStreamer:
+    """Background log-stream subprocess feeding parsed audit records
+    into ``run_dir/.sandbox-denials.jsonl``.
+
+    Owned by ``_macos_spawn.run_sandboxed`` for the duration of one
+    sandboxed call. NOT a singleton — a fresh streamer per sandbox()
+    call, so concurrent sandboxes don't conflict on filtering /
+    routing of records. Slight overhead (one log-stream subprocess
+    per call) but each is cheap (~10MB resident, ~0 CPU when idle).
+    """
+
+    def __init__(self, run_dir: Path,
+                 budget: Optional["_audit_budget.AuditBudget"] = None):
+        self._run_dir = Path(run_dir)
+        self._proc: Optional[subprocess.Popen] = None
+        self._reader: Optional[threading.Thread] = None
+        self._stopped = threading.Event()
+        # Skip-budget — defaults to the CLI-aware factory so
+        # --audit-budget propagates without callers wiring it
+        # explicitly. Tests can pass a custom AuditBudget for
+        # deterministic clock + smaller caps.
+        self._budget = budget or _audit_budget.from_cli_state()
+        # Serialises _append_record() across the reader-thread
+        # writes and the parent-thread summary write at stop().
+        # O_APPEND atomicity guarantees no inter-line tearing at the
+        # kernel for sub-PIPE_BUF writes, but doesn't guarantee
+        # ORDERING between the two threads — the parent's summary
+        # could land before residual data records the reader is
+        # still draining. Lock makes the summary unambiguously the
+        # last write. AuditBudget itself is also single-writer
+        # (it's mutated only inside the held lock).
+        self._append_lock = threading.Lock()
+        # Lazily-opened directory fd for openat(). See
+        # _append_record_locked for the TOCTOU rationale.
+        self._dirfd: Optional[int] = None
+
+    def start(self) -> None:
+        """Spawn `log stream` filtered to sandbox kext events and
+        start the reader thread. Non-blocking; returns immediately
+        once the subprocess is launched."""
+        predicate = (
+            f'senderImagePath == "{SANDBOX_KEXT_SENDER}"'
+        )
+        self._proc = subprocess.Popen(
+            [
+                "/usr/bin/log", "stream",
+                "--predicate", predicate,
+                "--style", "ndjson",
+                "--info",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            # Buffering: line-buffered so we get records as they
+            # arrive rather than accumulating in a 4K pipe buffer.
+            bufsize=1,
+        )
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+
+    def _read_loop(self) -> None:
+        """Read ndjson lines from `log stream`, parse, and append
+        records to the JSONL. Robust to malformed lines (silently
+        skip)."""
+        try:
+            assert self._proc is not None
+            for raw_line in self._proc.stdout or ():
+                if self._stopped.is_set():
+                    break
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                record = parse_log_entry(entry)
+                if record is None:
+                    continue
+                # Defer all budget logic to AuditBudget.evaluate.
+                # Returns (KEEP|DROP, optional marker dict). Marker
+                # is appended FIRST so it lands in the JSONL right
+                # before the (or not, if dropped) original record —
+                # operators see the suppression in-line.
+                #
+                # Hold the append lock across budget.evaluate AND
+                # the marker/record appends so:
+                #   (a) summary_record() called from stop() on the
+                #       parent thread sees a consistent snapshot of
+                #       budget internals (no "dict changed size
+                #       during iteration").
+                #   (b) the marker lands in the JSONL immediately
+                #       before its associated record without another
+                #       writer slipping a record in between.
+                try:
+                    with self._append_lock:
+                        decision, marker = self._budget.evaluate(
+                            record["syscall"], record["target_pid"],
+                        )
+                        if marker is not None:
+                            self._append_record_locked(marker)
+                        if decision != _audit_budget.DROP:
+                            self._append_record_locked(record)
+                except OSError:
+                    # Best-effort. Don't crash the reader thread on
+                    # transient FS errors — a missed record is
+                    # acceptable, a dead reader thread is not.
+                    logger.debug("seatbelt audit append failed",
+                                 exc_info=True)
+        except Exception:
+            logger.debug("seatbelt audit reader thread crashed",
+                         exc_info=True)
+
+    def _append_record(self, record: dict) -> None:
+        """Append one record to the JSONL using the same O_NOFOLLOW
+        + O_APPEND atomicity dance as core.sandbox.summary.record_denial.
+        Each line is one JSON object; under PIPE_BUF (~4KB) the kernel
+        guarantees write atomicity against concurrent appenders. The
+        in-process lock serialises ORDERING between the reader thread
+        and the parent's summary write at stop()."""
+        with self._append_lock:
+            self._append_record_locked(record)
+
+    def _append_record_locked(self, record: dict) -> None:
+        """Real append logic. Called with self._append_lock held.
+
+        Uses an O_DIRECTORY|O_NOFOLLOW dirfd cached at first call
+        and an `openat(dirfd, DENIALS_FILE, ...)` for each append.
+        Without the dirfd, an attacker who can write to run_dir's
+        parent could swap run_dir with a symlink between
+        `mkdir(...)` and `open(...)` (TOCTOU) and redirect audit
+        records into a host file. The dirfd is opened once, before
+        any writes, and survives any later replacement of the
+        path-to-the-directory.
+        """
+        line = json.dumps(record, ensure_ascii=True, default=str) + "\n"
+        if self._dirfd is None:
+            # First call: materialise run_dir AND pin it as a dirfd.
+            self._run_dir.mkdir(parents=True, exist_ok=True)
+            self._dirfd = os.open(
+                str(self._run_dir),
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+            )
+        flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT | os.O_NOFOLLOW
+        fd = os.open(DENIALS_FILE, flags, mode=0o600,
+                     dir_fd=self._dirfd)
+        try:
+            os.write(fd, line.encode("utf-8"))
+        finally:
+            os.close(fd)
+
+    def stop(self, *, drain_timeout: float = 1.5) -> None:
+        """Stop the streamer. Gives `log stream` a brief window to
+        flush any in-flight records, then terminates.
+
+        Called by _macos_spawn after the workload exits. The drain
+        window matters: kernel → log subsystem → log stream pipeline
+        has visible latency (spike #4 measured ~1.5s for a cold
+        first event); without the drain we'd lose the tail-end
+        records of short workloads.
+        """
+        self._stopped.set()
+        if self._proc is not None:
+            # Give the reader a brief window to consume any buffered
+            # output before we kill the subprocess.
+            self._proc.terminate()
+            try:
+                self._proc.wait(timeout=drain_timeout)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+                try:
+                    self._proc.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    pass
+            # Reader thread is daemon — if it's still draining stdout,
+            # let it finish naturally; we don't block process exit on it.
+            if self._reader is not None and self._reader.is_alive():
+                self._reader.join(timeout=0.5)
+        # Final summary record. Always emitted regardless of proc
+        # state so operators see one of:
+        #   - 0 records, 0 drops → audit ran cleanly, nothing to log
+        #   - N records, 0 drops → audit ran, captured everything
+        #   - N records, K drops → audit ran, K events suppressed by cap
+        # The alternative (no summary on cold-start failure) makes
+        # "did audit run?" undecidable from the JSONL alone. Even
+        # the never-started case (no proc) emits a summary with
+        # zero counts — operators can distinguish it from
+        # "summary file missing entirely" (streamer never even
+        # constructed).
+        try:
+            # Hold the lock across summary_record + append so the
+            # snapshot read and the JSONL write are atomic with
+            # respect to any reader thread still draining.
+            with self._append_lock:
+                summary = self._budget.summary_record()
+                self._append_record_locked(summary)
+        except OSError:
+            logger.debug("seatbelt audit summary append failed",
+                         exc_info=True)
+        # Close the cached dirfd. Best-effort — fd leaks on
+        # daemon-thread paths are bounded by the per-process fd
+        # limit, but keeping process exit clean here avoids
+        # ResourceWarnings in test runs.
+        with self._append_lock:
+            if self._dirfd is not None:
+                try:
+                    os.close(self._dirfd)
+                except OSError:
+                    pass
+                self._dirfd = None
+
+
+def start_log_streamer(run_dir: Path) -> LogStreamer:
+    """Convenience: instantiate + start a LogStreamer.
+
+    Caller is responsible for calling ``.stop()`` after the
+    sandboxed workload exits. Use a try/finally to guarantee
+    cleanup (see _macos_spawn for the canonical pattern).
+    """
+    s = LogStreamer(run_dir)
+    s.start()
+    return s

--- a/core/sandbox/state.py
+++ b/core/sandbox/state.py
@@ -39,6 +39,11 @@ _libseccomp_cache = None
 # `--audit` to decide whether b2 (syscall audit via SCMP_ACT_TRACE)
 # and b3 (filesystem audit) can engage. Probed by core.sandbox.ptrace_probe.
 _ptrace_available_cache = None
+# macOS sandbox-exec cache: None = unprobed, True/False = probed.
+# True iff /usr/bin/sandbox-exec exists AND a smoke-test invocation
+# under (allow default) baseline succeeds. Set by check_seatbelt_
+# available() in probes.py. Linux hosts always cache False.
+_seatbelt_available_cache = None
 # User-supplied rlimit overrides from ~/.config/raptor/sandbox.json.
 _user_limits_cache = None
 # Resolved absolute paths to sandbox-setup binaries. We use absolute paths
@@ -66,6 +71,11 @@ _cli_sandbox_profile = None     # str profile name when --sandbox <name> passed
 # point argparse sets these, never env/config/repo content.
 _cli_sandbox_audit = False
 _cli_sandbox_audit_verbose = False
+# Operator override of the global audit-record cap (default 10000;
+# see core.sandbox.audit_budget.DEFAULT_GLOBAL_CAP). None = use the
+# default; positive integer = override. Per-category and per-PID
+# sub-caps scale proportionally inside AuditBudget.__init__.
+_cli_sandbox_audit_budget = None
 
 # Degradation warnings are logged once per process, not once per sandbox()
 # context — kernel capability doesn't change at runtime and scan loops

--- a/core/sandbox/tests/conftest.py
+++ b/core/sandbox/tests/conftest.py
@@ -37,6 +37,7 @@ def _sandbox_state_guard():
         # CLI overrides
         "_cli_sandbox_disabled", "_cli_sandbox_profile",
         "_cli_sandbox_audit", "_cli_sandbox_audit_verbose",
+        "_cli_sandbox_audit_budget",
         # Once-per-process warnings
         "_landlock_warned_unavailable", "_landlock_warned_abi_v4",
         "_landlock_warned_abi_v3", "_landlock_warned_abi_v2",
@@ -61,6 +62,12 @@ def _sandbox_state_guard():
         "_mount_ns_available_cache",
         "_libseccomp_cache", "_user_limits_cache",
         "_ptrace_available_cache",
+        # macOS sandbox-exec smoke-test result. Tests that mock
+        # check_seatbelt_available() without snapshotting would
+        # leak the mocked value into sibling tests on Linux hosts
+        # (where the cache otherwise stays at None and the function
+        # short-circuits to False on platform check).
+        "_seatbelt_available_cache",
         "_unshare_path_cache", "_prlimit_path_cache",
         "_mount_path_cache", "_mkdir_path_cache",
     ]

--- a/core/sandbox/tests/test_audit_budget.py
+++ b/core/sandbox/tests/test_audit_budget.py
@@ -1,0 +1,479 @@
+"""Tests for the unified AuditBudget shared by the Linux tracer
+and the macOS LogStreamer.
+
+These are pure-logic tests — no fork, no subprocess, no time.sleep.
+They use the AuditBudget's `clock` injection point to drive the
+token-bucket deterministically and run in milliseconds.
+"""
+
+from __future__ import annotations
+
+from core.sandbox import audit_budget
+
+
+# ---------------------------------------------------------------------
+# Categorisation
+# ---------------------------------------------------------------------
+
+def test_categorise_collapses_action_variants():
+    """File-write variants and mknod collapse together so a chatty
+    writer that mixes action names doesn't bypass the per-cat cap."""
+    cf = audit_budget._default_categorise
+    assert cf("file-write-create") == "file-write"
+    assert cf("file-write-data") == "file-write"
+    assert cf("file-write-mode") == "file-write"
+    assert cf("file-mknod") == "file-write"
+
+
+def test_categorise_distinguishes_metadata_from_data():
+    """file-read-metadata is split from file-read-data because
+    metadata reads (every stat/readdir) are 100x noisier than data
+    reads in typical workloads."""
+    cf = audit_budget._default_categorise
+    assert cf("file-read-metadata") == "file-read-metadata"
+    assert cf("file-read-data") == "file-read-data"
+    assert cf("file-read-xattr") == "file-read-data"
+
+
+def test_categorise_handles_linux_syscall_names():
+    """Same coarsening should apply to Linux syscall names so the
+    Linux tracer benefits from the same per-cat semantics."""
+    cf = audit_budget._default_categorise
+    assert cf("openat") == "file-read-metadata"
+    assert cf("write") == "file-write"
+    assert cf("read") == "file-read-data"
+    assert cf("connect") == "network"
+    assert cf("execve") == "process-exec"
+    assert cf("clone") == "process-fork"
+    assert cf("kill") == "signal"
+
+
+def test_categorise_unknown_action_returns_self():
+    """Unrecognised actions get their own category — they share
+    only the global cap, no per-cat sub-cap. Returning the action
+    name itself ensures _category_counts has a unique key."""
+    cf = audit_budget._default_categorise
+    assert cf("user-preference-write") == "user-preference-write"
+    assert cf("totally-made-up-action") == "totally-made-up-action"
+
+
+# ---------------------------------------------------------------------
+# Per-category cap
+# ---------------------------------------------------------------------
+
+class _FakeClock:
+    def __init__(self, t=0.0):
+        self.t = t
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, dt):
+        self.t += dt
+
+
+def test_per_category_cap_drops_excess_with_marker():
+    """Once a category bucket empties, further records of that
+    category are dropped. The first drop emits a marker; subsequent
+    drops are silent (operator already saw the warning)."""
+    clock = _FakeClock()
+    budget = audit_budget.AuditBudget(
+        category_caps={"process-info": 5},
+        # No refill — bucket once-empty stays empty.
+        refill_rates={"process-info": 0.0},
+        # No sampling — drops are clean.
+        sampling_rates={},
+        clock=clock,
+    )
+    decisions = []
+    markers = []
+    for _ in range(8):
+        d, m = budget.evaluate("process-info-pidinfo", pid=100)
+        decisions.append(d)
+        if m is not None:
+            markers.append(m)
+    # First 5 keep, last 3 drop.
+    assert decisions[:5] == [audit_budget.KEEP] * 5
+    assert decisions[5:] == [audit_budget.DROP] * 3
+    # Exactly one marker — on the first drop.
+    assert len(markers) == 1
+    assert markers[0]["type"] == "category_budget_exceeded"
+    assert markers[0]["category"] == "process-info"
+    assert markers[0]["cap"] == 5
+    # Bookkeeping
+    assert budget.total_records == 5
+    assert budget.dropped_by_category == {"process-info": 3}
+
+
+def test_per_category_caps_independent():
+    """A category at cap doesn't squeeze other categories out."""
+    clock = _FakeClock()
+    budget = audit_budget.AuditBudget(
+        category_caps={"process-info": 2, "mach-lookup": 5},
+        refill_rates={"process-info": 0.0, "mach-lookup": 0.0},
+        sampling_rates={},
+        clock=clock,
+    )
+    # Burn process-info, then push mach-lookup.
+    for _ in range(4):
+        budget.evaluate("process-info-pidinfo", pid=10)
+    for _ in range(5):
+        d, _ = budget.evaluate("mach-lookup", pid=10)
+        assert d == audit_budget.KEEP
+    assert budget.category_counts["process-info"] == 2
+    assert budget.category_counts["mach-lookup"] == 5
+
+
+# ---------------------------------------------------------------------
+# Token bucket refill
+# ---------------------------------------------------------------------
+
+def test_token_bucket_refills_over_time():
+    """A burst that empties the bucket can resume after the refill
+    rate has produced new tokens. Verifies the bucket is rate-
+    limited rather than hard-capped."""
+    clock = _FakeClock()
+    budget = audit_budget.AuditBudget(
+        category_caps={"network": 3},
+        refill_rates={"network": 1.0},   # 1/sec sustained
+        sampling_rates={},
+        clock=clock,
+    )
+    # Burst of 3 — bucket empties.
+    for _ in range(3):
+        d, _ = budget.evaluate("network-outbound", pid=1)
+        assert d == audit_budget.KEEP
+    # 4th immediate → drop.
+    d, m = budget.evaluate("network-outbound", pid=1)
+    assert d == audit_budget.DROP
+    assert m is not None  # first-drop marker
+    # Advance 2 seconds → 2 tokens regenerated → 2 more should pass.
+    clock.advance(2.0)
+    for _ in range(2):
+        d, _ = budget.evaluate("network-outbound", pid=1)
+        assert d == audit_budget.KEEP
+    # 3rd → drop again (bucket empty, no marker — already emitted).
+    d, m = budget.evaluate("network-outbound", pid=1)
+    assert d == audit_budget.DROP
+    assert m is None
+
+
+def test_token_bucket_capped_at_capacity():
+    """Long idle period doesn't accumulate tokens past capacity —
+    operators get burst-tolerance equal to the cap, not unbounded."""
+    clock = _FakeClock()
+    budget = audit_budget.AuditBudget(
+        category_caps={"network": 5},
+        refill_rates={"network": 1.0},
+        sampling_rates={},
+        clock=clock,
+    )
+    # Burn 1 token, then idle for an hour.
+    budget.evaluate("network-outbound", pid=1)
+    clock.advance(3600.0)
+    # Should have at most 5 tokens (capacity), so 5 evaluates pass
+    # and the 6th drops.
+    for _ in range(5):
+        d, _ = budget.evaluate("network-outbound", pid=1)
+        assert d == audit_budget.KEEP
+    d, _ = budget.evaluate("network-outbound", pid=1)
+    assert d == audit_budget.DROP
+
+
+# ---------------------------------------------------------------------
+# Per-PID cap
+# ---------------------------------------------------------------------
+
+def test_pid_cap_isolates_chatty_pid():
+    """One spamming subprocess can't squeeze sibling PIDs out."""
+    clock = _FakeClock()
+    budget = audit_budget.AuditBudget(
+        pid_cap=3,
+        category_caps={"file-write": 100},
+        refill_rates={"file-write": 0.0},
+        sampling_rates={},
+        clock=clock,
+    )
+    # PID 100 spams 5 events — only 3 keep.
+    decisions = []
+    markers = []
+    for _ in range(5):
+        d, m = budget.evaluate("file-write-data", pid=100)
+        decisions.append(d)
+        if m is not None:
+            markers.append(m)
+    assert decisions[:3] == [audit_budget.KEEP] * 3
+    assert decisions[3:] == [audit_budget.DROP] * 2
+    assert len(markers) == 1
+    assert markers[0]["type"] == "pid_budget_exceeded"
+    assert markers[0]["pid"] == 100
+    # PID 200 unaffected.
+    for _ in range(3):
+        d, _ = budget.evaluate("file-write-data", pid=200)
+        assert d == audit_budget.KEEP
+
+
+# ---------------------------------------------------------------------
+# Sampling
+# ---------------------------------------------------------------------
+
+def test_sampling_emits_one_in_n_after_cap():
+    """High-volume categories with a sampling rate get a trickle
+    even after the bucket empties — operators see "still happening"
+    rather than going completely dark."""
+    clock = _FakeClock()
+    budget = audit_budget.AuditBudget(
+        category_caps={"file-read-metadata": 2},
+        refill_rates={"file-read-metadata": 0.0},
+        sampling_rates={"file-read-metadata": 3},  # 1-in-3 after cap
+        clock=clock,
+    )
+    decisions = []
+    for _ in range(10):
+        d, _ = budget.evaluate("file-read-metadata", pid=1)
+        decisions.append(d)
+    # First 2 keep (in-bucket), then over cap with 1-in-3 sampling.
+    # Drops at index 2,3 then keep at 4 (3rd over-cap is sampled),
+    # drop 5,6, keep 7, drop 8,9.
+    assert decisions[0] == audit_budget.KEEP
+    assert decisions[1] == audit_budget.KEEP
+    # Pattern: D D K D D K D D for indices 2..9 (every 3rd over-cap kept).
+    over_cap = decisions[2:]
+    keeps_post = sum(1 for d in over_cap if d == audit_budget.KEEP)
+    # 8 over-cap events → 8/3 = 2 sampled.
+    assert keeps_post == 2
+
+
+def test_sampling_marker_advertises_sampling_rate():
+    """The marker that fires when sampling kicks in tells operators
+    explicitly what the post-cap rate is."""
+    clock = _FakeClock()
+    budget = audit_budget.AuditBudget(
+        category_caps={"iokit-open": 1},
+        refill_rates={"iokit-open": 0.0},
+        sampling_rates={"iokit-open": 7},
+        clock=clock,
+    )
+    budget.evaluate("iokit-open", pid=1)  # in-bucket
+    markers = []
+    for _ in range(7):
+        _, m = budget.evaluate("iokit-open", pid=1)
+        if m is not None:
+            markers.append(m)
+    assert len(markers) == 1
+    assert markers[0]["type"] == "category_budget_exceeded_sampling"
+    assert markers[0]["sampling_rate"] == 7
+
+
+# ---------------------------------------------------------------------
+# Global cap
+# ---------------------------------------------------------------------
+
+def test_global_cap_fires_when_categories_collectively_exhaust():
+    """No single category at cap — but collective volume across
+    many small categories trips the global ceiling. pid_cap pinned
+    high so the per-PID gate doesn't dominate (when global_cap is
+    overridden small, the proportional scale would make pid_cap=2,
+    which would mask the global-cap behaviour we're testing)."""
+    clock = _FakeClock()
+    budget = audit_budget.AuditBudget(
+        global_cap=5,
+        pid_cap=1000,  # don't let per-PID scale steal the show
+        # Inflate per-cat caps so the global ceiling is the binding
+        # constraint, not per-cat.
+        category_caps={"network": 100, "process-exec": 100},
+        refill_rates={"network": 0.0, "process-exec": 0.0},
+        sampling_rates={},
+        clock=clock,
+    )
+    decisions = []
+    for i in range(8):
+        cat = "network-outbound" if i % 2 == 0 else "execve"
+        d, _ = budget.evaluate(cat, pid=1)
+        decisions.append(d)
+    # 5 keep, 3 drop.
+    assert sum(1 for d in decisions if d == audit_budget.KEEP) == 5
+    assert sum(1 for d in decisions if d == audit_budget.DROP) == 3
+
+
+# ---------------------------------------------------------------------
+# CLI scaling
+# ---------------------------------------------------------------------
+
+def test_cli_global_override_scales_per_category_caps():
+    """When --audit-budget=N is set without per-category overrides,
+    per-cat caps must scale proportionally so the operator's intent
+    (more headroom overall) reaches the per-cat layer."""
+    default = audit_budget.AuditBudget()
+    larger = audit_budget.AuditBudget(global_cap=100000)  # 10x default
+    # Each per-cat cap should be ~10x.
+    for cat, default_cap in audit_budget.DEFAULT_CATEGORY_CAPS.items():
+        assert larger.category_caps[cat] == default_cap * 10, (
+            f"category {cat}: expected {default_cap*10}, "
+            f"got {larger.category_caps[cat]}"
+        )
+    # default unchanged.
+    for cat, default_cap in audit_budget.DEFAULT_CATEGORY_CAPS.items():
+        assert default.category_caps[cat] == default_cap
+
+
+def test_cli_global_override_scales_pid_cap_too():
+    larger = audit_budget.AuditBudget(global_cap=20000)  # 2x default
+    assert larger.pid_cap == audit_budget.DEFAULT_PID_CAP * 2
+
+
+def test_explicit_category_caps_override_scaling():
+    """Explicit per-cat overrides win over the proportional scale."""
+    b = audit_budget.AuditBudget(
+        global_cap=100000,
+        category_caps={"file-write": 42},
+    )
+    assert b.category_caps == {"file-write": 42}
+
+
+def test_from_cli_state_honours_state_field():
+    """from_cli_state reads state._cli_sandbox_audit_budget and
+    propagates it to AuditBudget. Tests both None (default) and an
+    explicit override."""
+    from core.sandbox import state
+    state._cli_sandbox_audit_budget = None
+    b = audit_budget.from_cli_state()
+    assert b.global_cap == audit_budget.DEFAULT_GLOBAL_CAP
+    state._cli_sandbox_audit_budget = 250
+    b = audit_budget.from_cli_state()
+    assert b.global_cap == 250
+    state._cli_sandbox_audit_budget = None  # cleanup (autouse fixture also resets)
+
+
+# ---------------------------------------------------------------------
+# Summary record
+# ---------------------------------------------------------------------
+
+def test_summary_record_includes_all_counts():
+    clock = _FakeClock()
+    budget = audit_budget.AuditBudget(
+        category_caps={"network": 100, "file-write": 100},
+        refill_rates={"network": 0.0, "file-write": 0.0},
+        sampling_rates={},
+        clock=clock,
+    )
+    for _ in range(3):
+        budget.evaluate("network-outbound", pid=1)
+    for _ in range(5):
+        budget.evaluate("file-write-data", pid=2)
+    s = budget.summary_record()
+    assert s["type"] == "audit_summary"
+    assert s["total_records"] == 8
+    assert s["category_counts"] == {"network": 3, "file-write": 5}
+    assert s["pid_counts"] == {1: 3, 2: 5}
+    assert s["dropped_by_category"] == {}
+
+
+def test_pop_global_cap_notice_one_shot():
+    """pop_global_cap_notice() returns True ONCE after the global
+    cap fires, then False forever. Used by callers (Linux tracer)
+    to emit a one-time stderr line."""
+    clock = _FakeClock()
+    budget = audit_budget.AuditBudget(
+        global_cap=2, pid_cap=1000,
+        category_caps={"network": 100},
+        refill_rates={"network": 0.0},
+        sampling_rates={},
+        clock=clock,
+    )
+    # Before any drops — no notice.
+    assert budget.pop_global_cap_notice() is False
+    # Two events fit, third drops on global cap.
+    for _ in range(3):
+        budget.evaluate("network-outbound", pid=1)
+    # First call returns True (notice owed).
+    assert budget.pop_global_cap_notice() is True
+    # Subsequent calls return False — caller already got the cue.
+    assert budget.pop_global_cap_notice() is False
+
+
+def test_pid_dict_lru_eviction_caps_memory():
+    """A target spawning many distinct PIDs must not balloon
+    _pid_counts unbounded. After _pid_dict_cap entries, oldest
+    are evicted."""
+    clock = _FakeClock()
+    budget = audit_budget.AuditBudget(
+        category_caps={"file-write": 10000},
+        refill_rates={"file-write": 0.0},
+        sampling_rates={},
+        clock=clock,
+    )
+    budget._pid_dict_cap = 5  # tighten for the test
+    for pid in range(20):
+        budget.evaluate("file-write-data", pid=pid)
+    # Only the 5 most-recent PIDs survive.
+    assert len(budget._pid_counts) == 5
+    assert set(budget._pid_counts) == {15, 16, 17, 18, 19}
+
+
+def test_global_cap_drop_refunds_category_token():
+    """When global cap (not category cap) drops a record, the
+    category token is refunded so the bucket isn't drained
+    spuriously. Without this, repeated global-cap drops would
+    permanently drain category buckets even though the actual
+    constraint is global."""
+    clock = _FakeClock()
+    budget = audit_budget.AuditBudget(
+        global_cap=2,
+        pid_cap=1000,
+        category_caps={"network": 5},
+        refill_rates={"network": 0.0},
+        sampling_rates={},
+        clock=clock,
+    )
+    # Burn the global cap with two records.
+    budget.evaluate("network-outbound", pid=1)
+    budget.evaluate("network-outbound", pid=1)
+    # Capture bucket state.
+    tokens_before, _ = budget._buckets["network"]  # 5 - 2 = 3
+    assert tokens_before == 3.0
+    # Drop one more — global cap refuses, category refund kicks in.
+    decision, _ = budget.evaluate("network-outbound", pid=1)
+    assert decision == audit_budget.DROP
+    tokens_after, _ = budget._buckets["network"]
+    # Bucket is unchanged: take consumed, then refund restored.
+    assert tokens_after == 3.0
+
+
+def test_sampling_marker_fires_on_first_drop():
+    """The sampling marker now emits on the FIRST over-cap drop,
+    not the Nth. Operators see the state-change cue immediately
+    instead of N silent drops first."""
+    clock = _FakeClock()
+    budget = audit_budget.AuditBudget(
+        category_caps={"file-read-metadata": 1},
+        refill_rates={"file-read-metadata": 0.0},
+        sampling_rates={"file-read-metadata": 5},
+        clock=clock,
+    )
+    # First event in-bucket — no marker.
+    _, m0 = budget.evaluate("file-read-metadata", pid=1)
+    assert m0 is None
+    # Second event over-cap — first drop, marker fires NOW.
+    _, m1 = budget.evaluate("file-read-metadata", pid=1)
+    assert m1 is not None
+    assert m1["type"] == "category_budget_exceeded_sampling"
+    # Third+ — no further markers (already emitted).
+    for _ in range(3):
+        _, m = budget.evaluate("file-read-metadata", pid=1)
+        assert m is None
+
+
+def test_summary_record_after_drops():
+    clock = _FakeClock()
+    budget = audit_budget.AuditBudget(
+        category_caps={"network": 2},
+        refill_rates={"network": 0.0},
+        sampling_rates={},
+        clock=clock,
+    )
+    for _ in range(5):
+        budget.evaluate("network-outbound", pid=1)
+    s = budget.summary_record()
+    assert s["total_records"] == 2
+    assert s["dropped_by_category"] == {"network": 3}

--- a/core/sandbox/tests/test_audit_cli_flags.py
+++ b/core/sandbox/tests/test_audit_cli_flags.py
@@ -116,6 +116,62 @@ class TestApplyCliArgsValidation:
         assert state._cli_sandbox_audit_verbose is True
 
 
+class TestAuditBudgetFlag:
+    """`--audit-budget=N` overrides the default global cap and
+    propagates into core.sandbox.audit_budget.from_cli_state()."""
+
+    def test_audit_budget_flag_recognised(self, parser):
+        args = parser.parse_args(
+            ["--sandbox", "full", "--audit", "--audit-budget", "250"])
+        assert args.audit_budget == 250
+
+    def test_audit_budget_default_is_none(self, parser):
+        args = parser.parse_args(["--sandbox", "full", "--audit"])
+        assert args.audit_budget is None
+
+    def test_audit_budget_propagates_to_state(self, parser):
+        args = parser.parse_args(
+            ["--sandbox", "full", "--audit", "--audit-budget", "500"])
+        cli_mod.apply_cli_args(args)
+        assert state._cli_sandbox_audit_budget == 500
+
+    def test_audit_budget_picked_up_by_from_cli_state(self, parser):
+        args = parser.parse_args(
+            ["--sandbox", "full", "--audit", "--audit-budget", "777"])
+        cli_mod.apply_cli_args(args)
+        from core.sandbox import audit_budget
+        b = audit_budget.from_cli_state()
+        assert b.global_cap == 777
+
+    def test_audit_budget_without_audit_rejected(self, parser):
+        args = parser.parse_args(["--audit-budget", "500"])
+        with pytest.raises(ValueError, match="--audit-budget requires --audit"):
+            cli_mod.apply_cli_args(args)
+
+    def test_audit_budget_zero_rejected(self, parser):
+        args = parser.parse_args(
+            ["--sandbox", "full", "--audit", "--audit-budget", "0"])
+        with pytest.raises(ValueError,
+                            match="--audit-budget must be a positive integer"):
+            cli_mod.apply_cli_args(args)
+
+    def test_audit_budget_negative_rejected(self, parser):
+        args = parser.parse_args(
+            ["--sandbox", "full", "--audit", "--audit-budget", "-1"])
+        with pytest.raises(ValueError,
+                            match="--audit-budget must be a positive integer"):
+            cli_mod.apply_cli_args(args)
+
+    def test_audit_budget_above_upper_clamp_rejected(self, parser):
+        """Operator typo (one extra zero) shouldn't be able to
+        produce a 2GB JSONL. Upper-clamp at 10M records."""
+        args = parser.parse_args(
+            ["--sandbox", "full", "--audit",
+             "--audit-budget", "100000000"])
+        with pytest.raises(ValueError, match="exceeds the upper clamp"):
+            cli_mod.apply_cli_args(args)
+
+
 class TestRunUntrustedForwardsAuditKwargs:
     """run_untrusted is a thin convenience wrapper around run() — it
     forwards **kwargs. Audit kwargs should propagate. Covers the

--- a/core/sandbox/tests/test_audit_filter.py
+++ b/core/sandbox/tests/test_audit_filter.py
@@ -20,6 +20,7 @@ import pytest
 from core.sandbox import probes
 from core.sandbox import ptrace_probe
 from core.sandbox import tracer as tracer_mod
+from core.sandbox import audit_budget
 
 
 pytestmark = pytest.mark.skipif(
@@ -893,7 +894,12 @@ class TestAuditConfigSchemaAgree:
         from core.sandbox import _spawn, tracer
 
         spawn_src = inspect.getsource(_spawn.run_sandboxed)
-        tracer_dispatch = inspect.getsource(tracer._handle_waitpid_event)
+        # Both the dispatch function (per-event filter logic) AND the
+        # trace() entry point (which reads one-shot config like the
+        # audit-budget cap at startup) must be considered — a key
+        # consumed in either is a contract the writer must honour.
+        tracer_dispatch = (inspect.getsource(tracer._handle_waitpid_event)
+                            + inspect.getsource(tracer.trace))
 
         # Extract keys written: pattern `"key":` inside audit_config dict.
         # Find audit_config = { ... } block specifically.
@@ -1225,16 +1231,19 @@ class TestFilterDispatchSeccomp:
             "allowed_tcp_ports": [],
         }
         traced = {1000}
-        rc, _ = tracer_mod._handle_waitpid_event(
+        budget = audit_budget.AuditBudget()
+        tracer_mod._handle_waitpid_event(
             1000, self._seccomp_event_status(),
             traced, 1000, self._make_arch_info(),
-            Path("/tmp"), 0, False,
+            Path("/tmp"), budget,
             audit_filter=audit_filter,
             **{k: v for k, v in helpers.items() if not k.startswith("_")},
         )
-        # Record dropped — count unchanged
-        assert rc == 0
+        # Record dropped by the audit filter (path matched the
+        # allowlist) BEFORE reaching the budget — write_record never
+        # called and budget.total_records stays at 0.
         assert helpers["_recorded"] == []
+        assert budget.total_records == 0
 
     def test_filtered_keeps_path_outside_allowlist(self):
         # /home/user/.ssh/id_rsa is NOT in the allowlist → recorded.
@@ -1246,19 +1255,21 @@ class TestFilterDispatchSeccomp:
             "allowed_tcp_ports": [],
         }
         traced = {1000}
-        rc, _ = tracer_mod._handle_waitpid_event(
+        budget = audit_budget.AuditBudget()
+        tracer_mod._handle_waitpid_event(
             1000, self._seccomp_event_status(),
             traced, 1000, self._make_arch_info(),
-            Path("/tmp"), 0, False,
+            Path("/tmp"), budget,
             audit_filter=audit_filter,
             **{k: v for k, v in helpers.items() if not k.startswith("_")},
         )
-        assert rc == 1
         assert len(helpers["_recorded"]) == 1
         assert helpers["_recorded"][0]["path"] == "/home/user/.ssh/id_rsa"
+        assert budget.total_records == 1
 
     def test_verbose_keeps_everything(self):
-        # Same allowlisted path, but verbose=True → still recorded.
+        # Same allowlisted path as test_filtered_drops_path_in_allowlist,
+        # but verbose=True → record kept (verbose disables filter).
         helpers = self._common_helpers(path_returned="/etc/hostname")
         audit_filter = {
             "verbose": True,
@@ -1267,27 +1278,37 @@ class TestFilterDispatchSeccomp:
             "allowed_tcp_ports": [],
         }
         traced = {1000}
-        rc, _ = tracer_mod._handle_waitpid_event(
+        budget = audit_budget.AuditBudget()
+        tracer_mod._handle_waitpid_event(
             1000, self._seccomp_event_status(),
             traced, 1000, self._make_arch_info(),
-            Path("/tmp"), 0, False,
+            Path("/tmp"), budget,
             audit_filter=audit_filter,
             **{k: v for k, v in helpers.items() if not k.startswith("_")},
         )
-        assert rc == 1
+        # Verbose mode bypasses the allowlist filter — the record IS
+        # written. write_record fake records into helpers["_recorded"].
+        assert len(helpers["_recorded"]) == 1, (
+            f"verbose=True should keep the record; got "
+            f"{helpers['_recorded']!r}"
+        )
+        assert budget.total_records == 1
 
     def test_no_filter_keeps_everything(self):
         # audit_filter=None → no filtering (legacy/default behaviour).
         helpers = self._common_helpers(path_returned="/etc/hostname")
         traced = {1000}
-        rc, _ = tracer_mod._handle_waitpid_event(
+        budget = audit_budget.AuditBudget()
+        tracer_mod._handle_waitpid_event(
             1000, self._seccomp_event_status(),
             traced, 1000, self._make_arch_info(),
-            Path("/tmp"), 0, False,
+            Path("/tmp"), budget,
             audit_filter=None,
             **{k: v for k, v in helpers.items() if not k.startswith("_")},
         )
-        assert rc == 1
+        # No filter → record kept regardless of path.
+        assert len(helpers["_recorded"]) == 1
+        assert budget.total_records == 1
 
 
 class TestEndToEndAuditVsAuditVerbose:

--- a/core/sandbox/tests/test_audit_integration.py
+++ b/core/sandbox/tests/test_audit_integration.py
@@ -203,8 +203,12 @@ class TestMaxRecordsCap:
 
     def test_tracer_and_summary_caps_match(self):
         # Both sides cap at 10000. Pin so a future divergence is
-        # caught.
-        from core.sandbox.tracer import _MAX_RECORDS_PER_RUN as t_cap
+        # caught. The tracer's cap moved into the shared
+        # core.sandbox.audit_budget module — the import target
+        # changed, the value did not.
+        from core.sandbox.audit_budget import (
+            DEFAULT_GLOBAL_CAP as t_cap,
+        )
         from core.sandbox.summary import (
             MAX_DENIALS_PER_RUN as s_cap,
         )

--- a/core/sandbox/tests/test_context_backend_dispatch.py
+++ b/core/sandbox/tests/test_context_backend_dispatch.py
@@ -1,0 +1,233 @@
+"""Cross-platform tests for the Linux/macOS backend dispatch in
+``core.sandbox.context``.
+
+These tests don't actually execute sandboxed processes; they patch
+``sys.platform`` and the spawn modules and assert the right backend
+is selected. The behavioural side (writes blocked, audit JSONL
+produced, etc.) is covered by test_macos_spawn.py and
+test_e2e_sandbox.py; this file is purely about the dispatch.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest import mock
+
+import pytest
+
+from core.sandbox import context, state
+
+
+@pytest.fixture
+def reset_caches():
+    """Make sure the platform / availability caches don't leak
+    between tests in this file."""
+    state._seatbelt_available_cache = None
+    state._mount_available_cache = None
+    state._mount_ns_available_cache = None
+    yield
+    state._seatbelt_available_cache = None
+    state._mount_available_cache = None
+    state._mount_ns_available_cache = None
+
+
+def test_check_seatbelt_available_returns_false_on_linux(reset_caches):
+    """Sanity: on a Linux dev box this MUST return False without
+    even attempting to invoke /usr/bin/sandbox-exec (which doesn't
+    exist there). The probe short-circuits on platform check."""
+    if sys.platform == "darwin":
+        pytest.skip("Linux-only sanity check")
+    assert context.check_seatbelt_available() is False
+
+
+def test_dispatch_picks_macos_backend_on_darwin(reset_caches):
+    """When sys.platform == "darwin" AND seatbelt is available, the
+    spawn dispatch must route through _macos_spawn.run_sandboxed,
+    NOT _spawn.run_sandboxed.
+
+    Patching strategy: ``from . import _macos_spawn as _macos_mod``
+    inside the function resolves via ``core.sandbox.__dict__`` once
+    the submodule is loaded — patching ``sys.modules`` doesn't reach
+    that attribute, so we patch ``run_sandboxed`` on the real
+    submodule object directly. Same trick for ``core.sandbox._spawn``.
+    """
+    from core.sandbox import _macos_spawn as macos_mod
+    from core.sandbox import _spawn as linux_mod
+
+    fake_macos_result = mock.MagicMock()
+    fake_macos_result.returncode = 0
+    fake_macos_result.stderr = b""
+    fake_macos_result.sandbox_info = {"backend": "macos-seatbelt"}
+
+    with mock.patch.object(sys, "platform", "darwin"), \
+         mock.patch.object(context, "check_seatbelt_available",
+                            return_value=True), \
+         mock.patch.object(context, "check_mount_available",
+                            return_value=False), \
+         mock.patch.object(context, "check_net_available",
+                            return_value=True), \
+         mock.patch.object(macos_mod, "run_sandboxed",
+                            return_value=fake_macos_result) as macos_run, \
+         mock.patch.object(linux_mod, "run_sandboxed",
+                            return_value=fake_macos_result) as linux_run:
+        from core.sandbox.context import sandbox
+        with sandbox(target="/tmp/some_target") as run:
+            run(["/usr/bin/true"], capture_output=True)
+
+    # macOS backend was called; Linux backend was NOT.
+    assert macos_run.called, (
+        "Darwin dispatch failed to route through _macos_spawn"
+    )
+    assert not linux_run.called, (
+        "Darwin dispatch incorrectly invoked Linux _spawn"
+    )
+
+
+def test_dispatch_picks_linux_backend_on_linux(reset_caches):
+    """Inverse: on Linux, the dispatch must use _spawn (or the
+    Landlock-only subprocess fallback), NEVER _macos_spawn."""
+    from core.sandbox import _macos_spawn as macos_mod
+    from core.sandbox import _spawn as linux_mod
+
+    fake_linux_result = mock.MagicMock()
+    fake_linux_result.returncode = 0
+    fake_linux_result.stderr = b""
+    fake_linux_result.sandbox_info = {"backend": "mount-ns"}
+
+    with mock.patch.object(sys, "platform", "linux"), \
+         mock.patch.object(context, "check_seatbelt_available",
+                            return_value=False), \
+         mock.patch.object(context, "check_mount_available",
+                            return_value=True), \
+         mock.patch.object(context, "check_net_available",
+                            return_value=True), \
+         mock.patch.object(macos_mod, "run_sandboxed") as macos_run, \
+         mock.patch.object(linux_mod, "run_sandboxed",
+                            return_value=fake_linux_result), \
+         mock.patch.object(linux_mod, "mount_ns_available",
+                            return_value=True):
+        from core.sandbox.context import sandbox
+        with sandbox(target="/tmp", output="/tmp") as run:
+            try:
+                run(["/usr/bin/true"], capture_output=True)
+            except Exception:
+                # The fake _spawn doesn't simulate the full chain
+                # perfectly; we only care about WHICH backend was
+                # invoked, not the result.
+                pass
+
+    assert not macos_run.called, (
+        "Linux dispatch incorrectly invoked _macos_spawn"
+    )
+
+
+def test_use_seatbelt_false_when_seatbelt_unavailable(reset_caches):
+    """Even on Darwin, if check_seatbelt_available() returns False
+    (sandbox-exec missing or smoke test failed), use_seatbelt must
+    be False — the dispatch then falls back to the bare subprocess
+    path with rlimits only."""
+    with mock.patch.object(sys, "platform", "darwin"), \
+         mock.patch.object(context, "check_seatbelt_available",
+                            return_value=False), \
+         mock.patch.object(context, "check_net_available",
+                            return_value=False):
+        # Sandbox unavailable entirely → no backend; subprocess.run
+        # path with rlimits only. Just verify no crash.
+        from core.sandbox.context import sandbox
+        with sandbox() as run:
+            with mock.patch("subprocess.run") as sub_run:
+                sub_run.return_value = mock.MagicMock(
+                    returncode=0, stderr=b"", stdout=b"",
+                    sandbox_info={},
+                )
+                run(["/usr/bin/true"])
+        assert sub_run.called
+
+
+def test_use_seatbelt_does_not_depend_on_check_net_available(reset_caches):
+    """Regression catch: an earlier dispatch wired use_sandbox to
+    check_net_available() (Linux unshare probe) AND THEN used the
+    result to gate use_seatbelt. On macOS check_net_available()
+    returns False (no unshare binary), so use_seatbelt was always
+    False even when sandbox-exec worked — silently degrading to
+    bare subprocess.run. The fix routes use_sandbox per-platform
+    via check_seatbelt_available() on Darwin. This test asserts
+    that with seatbelt available + net unavailable (the actual
+    macOS state), the seatbelt backend IS used."""
+    fake_macos = mock.MagicMock()
+    fake_macos_result = mock.MagicMock()
+    fake_macos_result.returncode = 0
+    fake_macos_result.stderr = b""
+    fake_macos_result.sandbox_info = {"backend": "macos-seatbelt"}
+
+    from core.sandbox import _macos_spawn as macos_mod
+    with mock.patch.object(sys, "platform", "darwin"), \
+         mock.patch.object(context, "check_seatbelt_available",
+                            return_value=True), \
+         mock.patch.object(context, "check_net_available",
+                            return_value=False), \
+         mock.patch.object(context, "check_mount_available",
+                            return_value=False), \
+         mock.patch.object(macos_mod, "run_sandboxed",
+                            return_value=fake_macos_result) as macos_run:
+        from core.sandbox.context import sandbox
+        with sandbox(target="/tmp/some_target") as run:
+            run(["/usr/bin/true"], capture_output=True)
+
+    assert macos_run.called, (
+        "seatbelt dispatch failed when check_net_available() returned "
+        "False — this is the actual state on every macOS host."
+    )
+
+
+def test_macos_does_not_resolve_unshare(reset_caches):
+    """Regression catch: even when use_seatbelt is engaged, an earlier
+    code path unconditionally built a Linux `unshare`-prefixed command
+    in the run() function (used only for the Landlock-only fallback).
+    The construction itself called _resolve_sandbox_binary("unshare")
+    which raises FileNotFoundError on macOS — crashing every sandbox
+    call that hits the dispatch with block_network/restrict_reads/
+    use_mount True (i.e. nearly every run_untrusted call). Fixed by
+    vetoing need_unshare when use_seatbelt is True."""
+    from core.sandbox import _macos_spawn as macos_mod
+    fake_macos_result = mock.MagicMock()
+    fake_macos_result.returncode = 0
+    fake_macos_result.stderr = b""
+    fake_macos_result.sandbox_info = {"backend": "macos-seatbelt"}
+
+    with mock.patch.object(sys, "platform", "darwin"), \
+         mock.patch.object(context, "check_seatbelt_available",
+                            return_value=True), \
+         mock.patch.object(context, "check_net_available",
+                            return_value=False), \
+         mock.patch.object(context, "check_mount_available",
+                            return_value=False), \
+         mock.patch.object(macos_mod, "run_sandboxed",
+                            return_value=fake_macos_result), \
+         mock.patch("core.sandbox.probes._resolve_sandbox_binary",
+                     side_effect=FileNotFoundError("unshare")):
+        from core.sandbox.context import sandbox
+        # block_network=True + restrict_reads=True is the typical
+        # run_untrusted path that previously crashed on macOS.
+        with sandbox(target="/tmp/x", output="/tmp/x",
+                      block_network=True, restrict_reads=True) as run:
+            run(["/usr/bin/true"], capture_output=True)
+    # If _resolve_sandbox_binary was called, the mock would have
+    # raised; the sandbox() call would have propagated. Reaching
+    # here means the seatbelt path correctly skipped the unshare
+    # construction.
+
+
+def test_audit_degrade_reason_macos_branch(reset_caches):
+    """The audit-degraded helper has a Darwin-specific branch that
+    fires when seatbelt is unavailable. Verify it produces a macOS-
+    sensible message rather than the Linux apparmor one."""
+    with mock.patch.object(sys, "platform", "darwin"), \
+         mock.patch.object(context, "check_seatbelt_available",
+                            return_value=False):
+        reason, instr = context._audit_degrade_reason(
+            None, None, None, None, {},
+        )
+        assert "sandbox-exec" in reason or "seatbelt" in reason.lower()
+        # Must NOT mention apparmor (Linux-specific).
+        assert "apparmor" not in reason.lower()

--- a/core/sandbox/tests/test_e2e_sandbox.py
+++ b/core/sandbox/tests/test_e2e_sandbox.py
@@ -6,6 +6,14 @@ Manual tests are documented in comments for the user to run.
 Run: python3 -m pytest core/sandbox/tests/test_e2e_sandbox.py -v
 """
 
+import sys as _sys
+import pytest as _pytest
+pytestmark = _pytest.mark.skipif(
+    _sys.platform != "linux",
+    reason="Linux-only sandbox internals (mount-ns / Landlock / seccomp / ptrace tracer / pid1 shim) — see core/sandbox/_macos_spawn.py for the macOS path",
+)
+
+
 import os
 import platform
 import subprocess

--- a/core/sandbox/tests/test_macos_spawn.py
+++ b/core/sandbox/tests/test_macos_spawn.py
@@ -1,0 +1,429 @@
+"""Darwin-only tests for ``core.sandbox._macos_spawn``.
+
+These tests invoke ``/usr/bin/sandbox-exec`` and assert behavioural
+outcomes (writes blocked, network blocked, audit JSONL produced).
+They skip cleanly on Linux so the CI suite stays green there; the
+macOS runner picks them up.
+
+Cross-platform smoke tests for the kwarg surface (signature parity
+with Linux _spawn) live alongside as plain unit tests so we catch
+breakage at every PR even before the macOS runner is wired up.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from core.sandbox import _macos_spawn
+
+darwin_only = pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="macOS-only — sandbox-exec is Apple-specific",
+)
+
+
+# --- Cross-platform sanity tests (signature parity, no exec) ----------
+
+def test_run_sandboxed_signature_matches_linux_spawn():
+    """Backend dispatch in context.py keys off platform and forwards
+    the SAME kwargs to whichever backend. Any kwarg present on
+    _spawn.run_sandboxed but absent on _macos_spawn.run_sandboxed
+    becomes an unexpected-keyword TypeError on macOS at runtime.
+    Inspect both signatures and assert _macos_spawn accepts every
+    Linux kwarg (extra Linux-only kwargs are accepted-and-ignored,
+    which the explicit `noqa: ARG001` annotations document)."""
+    import inspect
+    from core.sandbox import _spawn as linux_spawn
+    linux_params = set(
+        inspect.signature(linux_spawn.run_sandboxed).parameters.keys()
+    )
+    macos_params = set(
+        inspect.signature(_macos_spawn.run_sandboxed).parameters.keys()
+    )
+    missing = linux_params - macos_params
+    assert not missing, (
+        f"_macos_spawn.run_sandboxed missing kwargs from Linux "
+        f"_spawn.run_sandboxed: {missing}"
+    )
+
+
+def test_is_available_returns_bool():
+    """is_available is the cheap presence check; it must return a
+    bool regardless of platform (False on Linux, may be True or
+    False on macOS depending on whether sandbox-exec is installed)."""
+    assert isinstance(_macos_spawn.is_available(), bool)
+
+
+def test_is_available_false_on_non_darwin():
+    """On Linux, /usr/bin/sandbox-exec doesn't exist; is_available
+    must return False without raising."""
+    if sys.platform == "darwin":
+        pytest.skip("Darwin host — is_available may legitimately be True")
+    assert _macos_spawn.is_available() is False
+
+
+# --- Darwin-only behavioural tests ------------------------------------
+
+@darwin_only
+def test_smoke_test_invocation_succeeds(tmp_path):
+    """Most basic smoke test: run /usr/bin/true under the sandbox.
+    Confirms sandbox-exec invocation works AND our kwarg threading
+    doesn't break the simplest possible invocation."""
+    r = _macos_spawn.run_sandboxed(
+        ["/usr/bin/true"],
+        output=str(tmp_path),
+        capture_output=True,
+        timeout=10,
+    )
+    assert r.returncode == 0
+    assert r.sandbox_info["backend"] == "macos-seatbelt"
+
+
+@darwin_only
+def test_write_outside_output_blocked(tmp_path):
+    """Enforcement: write to a path OUTSIDE the writable allowlist
+    must fail (sandbox-exec returns the kernel sandbox error)."""
+    output = tmp_path / "out"
+    output.mkdir()
+    other = tmp_path / "other"
+    other.mkdir()
+    target_file = other / "should_not_exist"
+    py = (
+        f"import os\n"
+        f"try:\n"
+        f"    open({str(target_file)!r}, 'w').write('x')\n"
+        f"    print('LEAK')\n"
+        f"except OSError as e:\n"
+        f"    print('BLOCKED', e.errno)\n"
+    )
+    r = _macos_spawn.run_sandboxed(
+        ["/usr/bin/python3", "-c", py],
+        output=str(output),
+        capture_output=True, text=True, timeout=10,
+    )
+    # The process should still run successfully (returncode 0); the
+    # WRITE inside should fail. If sandbox-exec totally blocked exec
+    # we'd see rc != 0; that's a different bug.
+    assert r.returncode == 0
+    assert "BLOCKED" in r.stdout
+    assert "LEAK" not in r.stdout
+    assert not target_file.exists()
+
+
+@darwin_only
+def test_write_inside_output_allowed(tmp_path):
+    """Inverse of the above: writes INSIDE output= must succeed.
+    Catches over-restrictive profile generation."""
+    output = tmp_path / "out"
+    output.mkdir()
+    target_file = output / "allowed"
+    py = f"open({str(target_file)!r}, 'w').write('ok')"
+    r = _macos_spawn.run_sandboxed(
+        ["/usr/bin/python3", "-c", py],
+        output=str(output),
+        capture_output=True, text=True, timeout=10,
+    )
+    assert r.returncode == 0
+    assert target_file.exists()
+    assert target_file.read_text() == "ok"
+
+
+@darwin_only
+def test_write_to_private_tmp_allowed():
+    """The default exception list always includes /private/tmp so
+    standard temp-file APIs keep working. Regression catch: if we
+    drop /private/tmp from the default list, every tool that
+    writes to tempfile.mkstemp() breaks under our sandbox."""
+    py = (
+        "import tempfile\n"
+        "f = tempfile.mkstemp(prefix='macos_spawn_test_')[1]\n"
+        "open(f, 'w').write('ok')\n"
+        "import os; os.unlink(f)\n"
+        "print('OK')\n"
+    )
+    r = _macos_spawn.run_sandboxed(
+        ["/usr/bin/python3", "-c", py],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert r.returncode == 0
+    assert "OK" in r.stdout
+
+
+@darwin_only
+def test_block_network_actually_blocks(tmp_path):
+    """block_network=True must cause network connect to fail. Use a
+    non-routable address with a short timeout to keep the test fast
+    even if the deny doesn't engage."""
+    py = (
+        "import socket\n"
+        "s = socket.socket()\n"
+        "s.settimeout(2)\n"
+        "try:\n"
+        "    s.connect(('1.1.1.1', 443))\n"
+        "    print('LEAK')\n"
+        "except OSError as e:\n"
+        "    print('BLOCKED', e.errno)\n"
+    )
+    r = _macos_spawn.run_sandboxed(
+        ["/usr/bin/python3", "-c", py],
+        output=str(tmp_path),
+        block_network=True,
+        capture_output=True, text=True, timeout=10,
+    )
+    assert "BLOCKED" in r.stdout
+    assert "LEAK" not in r.stdout
+
+
+@darwin_only
+def test_audit_mode_writes_jsonl(tmp_path):
+    """End-to-end: with audit_mode=True the LogStreamer must
+    capture sandbox kext entries and append them as JSONL records
+    matching the Linux schema."""
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir()
+    output = tmp_path / "out"
+    output.mkdir()
+    # Trigger a write under audit mode. The (with report) clause
+    # makes it succeed AND log.
+    target_file = output / "audited"
+    py = f"open({str(target_file)!r}, 'w').write('x')"
+    r = _macos_spawn.run_sandboxed(
+        ["/usr/bin/python3", "-c", py],
+        output=str(output),
+        audit_mode=True,
+        audit_run_dir=str(audit_dir),
+        capture_output=True, text=True, timeout=15,
+    )
+    assert r.returncode == 0
+    # Allow the kernel→log→stream pipeline a moment to flush. Spike
+    # #4 measured ~1.5s end-to-end; the LogStreamer.stop() drain
+    # window covers most of this but in CI the wall-clock can stretch.
+    time.sleep(2.0)
+    jsonl_path = audit_dir / ".sandbox-denials.jsonl"
+    assert jsonl_path.exists(), (
+        "audit_mode=True did not produce .sandbox-denials.jsonl"
+    )
+    lines = jsonl_path.read_text().splitlines()
+    # We want at least one record about our write — be lenient
+    # about which one (the kernel may emit multiple file-* entries
+    # for one Python write).
+    parsed = [json.loads(l) for l in lines if l.strip()]
+    matching = [r for r in parsed if "audited" in r.get("path", "")]
+    assert matching, (
+        f"no audit record matched our test path; got {len(parsed)} "
+        f"records, paths={[r.get('path') for r in parsed]}"
+    )
+
+
+@darwin_only
+def test_fake_home_redirects_HOME(tmp_path):
+    """fake_home=True must override HOME inside the child. The
+    profile itself doesn't restrict HOME (env-side concern); the
+    test confirms the env override actually reached the child."""
+    output = tmp_path / "out"
+    output.mkdir()
+    py = "import os; print(os.environ.get('HOME'))"
+    r = _macos_spawn.run_sandboxed(
+        ["/usr/bin/python3", "-c", py],
+        output=str(output),
+        fake_home=True,
+        capture_output=True, text=True, timeout=10,
+    )
+    assert r.returncode == 0
+    expected = os.path.realpath(str(output / ".home"))
+    actual = os.path.realpath(r.stdout.strip())
+    assert actual == expected
+
+
+@darwin_only
+def test_rlimits_applied(tmp_path):
+    """Resource limits must apply via the preexec_fn pattern. Test
+    with a small max_file_mb (file size cap)."""
+    py = (
+        "import resource\n"
+        "soft, _ = resource.getrlimit(resource.RLIMIT_FSIZE)\n"
+        "print(soft)\n"
+    )
+    r = _macos_spawn.run_sandboxed(
+        ["/usr/bin/python3", "-c", py],
+        output=str(tmp_path),
+        limits={"max_file_mb": 10},
+        capture_output=True, text=True, timeout=10,
+    )
+    assert r.returncode == 0
+    soft = int(r.stdout.strip())
+    # 10 MB cap — let preexec set it; assert the child SEES the cap.
+    assert soft == 10 * 1024 * 1024
+
+
+@darwin_only
+def test_audit_verbose_records_extended_categories(tmp_path):
+    """End-to-end: with audit_verbose=True, the SBPL profile gets
+    `(allow X (with report))` for an extended set of categories
+    (file-read-data, mach-lookup, process-exec*, process-fork,
+    signal, file-read-metadata, process-info*, iokit-open,
+    sysctl-read). The LogStreamer must capture records from MORE
+    than just file-write events.
+
+    Mirror of the Linux test_spawn_audit.py pattern: run a real
+    sandboxed subprocess, then inspect the JSONL the streamer
+    appended. Asserts on category breadth, not exact counts (the
+    kernel→log pipeline timing varies)."""
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir()
+    output = tmp_path / "out"
+    output.mkdir()
+    # Workload that exercises several action categories: writes a
+    # file (file-write), reads a system file (file-read-data),
+    # opens IOKit-style resource info (mach-lookup), execs a child
+    # (process-exec / process-fork). Don't actually need the spawn
+    # to succeed — just need the SYSCALLS to fire so the kernel
+    # emits sandbox events.
+    target_file = output / "audited"
+    py = (
+        f"open({str(target_file)!r}, 'w').write('x')\n"
+        f"open('/etc/hostname', 'r').read()\n"
+        f"import subprocess; subprocess.run(['/bin/echo','hi'], "
+        f"capture_output=True)\n"
+    )
+    r = _macos_spawn.run_sandboxed(
+        ["/usr/bin/python3", "-c", py],
+        output=str(output),
+        audit_mode=True,
+        audit_verbose=True,
+        audit_run_dir=str(audit_dir),
+        capture_output=True, text=True, timeout=15,
+    )
+    assert r.returncode == 0, (
+        f"workload failed: stderr={r.stderr!r}"
+    )
+    # Allow kernel→log→stream pipeline to flush.
+    time.sleep(2.0)
+    jsonl_path = audit_dir / ".sandbox-denials.jsonl"
+    assert jsonl_path.exists(), (
+        "audit_verbose=True did not produce .sandbox-denials.jsonl"
+    )
+    records = [json.loads(l) for l in
+                jsonl_path.read_text().splitlines() if l.strip()]
+    # Filter out control-plane records (audit_summary, markers).
+    data = [r for r in records if "syscall" in r]
+    assert data, f"expected data records, got: {records!r}"
+    # Verbose audit MUST show categories beyond just file-write.
+    # We accept ANY non-write category (the workload triggers many,
+    # but exact set depends on macOS version + dyld behaviour).
+    types_seen = {r["type"] for r in data}
+    assert types_seen != {"write"}, (
+        f"audit_verbose only captured write events — extended "
+        f"category SBPL clauses didn't engage. Types: {types_seen}"
+    )
+
+
+@darwin_only
+def test_audit_summary_record_emitted(tmp_path):
+    """LogStreamer.stop() must always emit an audit_summary record
+    so the sandbox-summary aggregator can distinguish "audit ran
+    cleanly" from "audit dir empty because streamer never started"."""
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir()
+    output = tmp_path / "out"
+    output.mkdir()
+    target_file = output / "audited"
+    py = f"open({str(target_file)!r}, 'w').write('x')"
+    _macos_spawn.run_sandboxed(
+        ["/usr/bin/python3", "-c", py],
+        output=str(output),
+        audit_mode=True,
+        audit_run_dir=str(audit_dir),
+        capture_output=True, text=True, timeout=10,
+    )
+    time.sleep(1.0)
+    jsonl_path = audit_dir / ".sandbox-denials.jsonl"
+    records = [json.loads(l) for l in
+                jsonl_path.read_text().splitlines() if l.strip()]
+    summaries = [r for r in records if r.get("type") == "audit_summary"]
+    assert len(summaries) == 1, (
+        f"expected exactly one audit_summary record, got "
+        f"{len(summaries)}; all records: {records!r}"
+    )
+    s = summaries[0]
+    assert "total_records" in s
+    assert "category_counts" in s
+    assert "dropped_by_category" in s
+    assert "global_cap" in s
+
+
+@darwin_only
+def test_audit_budget_drops_when_cap_hit(tmp_path):
+    """End-to-end budget enforcement: pass a tiny global cap and
+    verify the JSONL contains a budget_exceeded marker. Uses the
+    LogStreamer's `budget` injection point so we don't need to
+    fiddle with CLI state for the test."""
+    from core.sandbox import audit_budget, seatbelt_audit
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir()
+    # Build an instance with a tight cap + no refill so the
+    # workload's first few file events are kept then everything
+    # else drops.
+    budget = audit_budget.AuditBudget(
+        global_cap=3,
+        pid_cap=1000,
+        category_caps={"file-write": 3, "file-read-data": 3},
+        refill_rates={"file-write": 0.0, "file-read-data": 0.0},
+        sampling_rates={},
+    )
+    streamer = seatbelt_audit.LogStreamer(audit_dir, budget=budget)
+    # Manually drive a few synthetic records through the budget +
+    # streamer's append path to verify the marker emits. (Full
+    # subprocess invocation also works but is harder to make
+    # deterministic given kernel timing.)
+    for i in range(8):
+        record = {
+            "ts": "2026-05-03T10:00:00+00:00",
+            "cmd": f"<sandbox audit: file-write-data /tmp/{i}>",
+            "type": "write", "audit": True, "verdict": "allow",
+            "syscall": "file-write-data", "path": f"/tmp/{i}",
+            "target_pid": 999, "process_name": "test",
+        }
+        decision, marker = budget.evaluate(
+            record["syscall"], record["target_pid"],
+        )
+        if marker is not None:
+            streamer._append_record(marker)
+        if decision == audit_budget.KEEP:
+            streamer._append_record(record)
+    streamer.stop()
+    records = [json.loads(l) for l in
+                (audit_dir / seatbelt_audit.DENIALS_FILE)
+                .read_text().splitlines() if l.strip()]
+    markers = [r for r in records
+                if r.get("type") in ("category_budget_exceeded",
+                                     "category_budget_exceeded_sampling")]
+    assert len(markers) == 1, (
+        f"expected 1 budget marker, got {len(markers)}; "
+        f"records: {records!r}"
+    )
+    summary = next(r for r in records if r.get("type") == "audit_summary")
+    assert summary["dropped_by_category"]["file-write"] == 5
+
+
+@darwin_only
+def test_seccomp_kwargs_silently_ignored(tmp_path):
+    """seccomp_profile= and seccomp_block_udp= are Linux-only;
+    accepted on macOS for signature parity but must NOT raise.
+    Catches accidental kwarg-rejection."""
+    r = _macos_spawn.run_sandboxed(
+        ["/usr/bin/true"],
+        output=str(tmp_path),
+        seccomp_profile="full",
+        seccomp_block_udp=True,
+        capture_output=True, timeout=10,
+    )
+    assert r.returncode == 0

--- a/core/sandbox/tests/test_pid1_shim.py
+++ b/core/sandbox/tests/test_pid1_shim.py
@@ -18,6 +18,14 @@ Contract tested:
   - stdout / stderr pass-through
 """
 
+import sys as _sys
+import pytest as _pytest
+pytestmark = _pytest.mark.skipif(
+    _sys.platform != "linux",
+    reason="Linux-only sandbox internals (mount-ns / Landlock / seccomp / ptrace tracer / pid1 shim) — see core/sandbox/_macos_spawn.py for the macOS path",
+)
+
+
 import os
 import signal
 import subprocess

--- a/core/sandbox/tests/test_ptrace_probe.py
+++ b/core/sandbox/tests/test_ptrace_probe.py
@@ -14,6 +14,14 @@ What we assert is correctness of the probe's behaviour given whatever
 the kernel reports.
 """
 
+import sys as _sys
+import pytest as _pytest
+pytestmark = _pytest.mark.skipif(
+    _sys.platform != "linux",
+    reason="Linux-only sandbox internals (mount-ns / Landlock / seccomp / ptrace tracer / pid1 shim) — see core/sandbox/_macos_spawn.py for the macOS path",
+)
+
+
 import logging
 import os
 

--- a/core/sandbox/tests/test_sandbox.py
+++ b/core/sandbox/tests/test_sandbox.py
@@ -2,10 +2,13 @@
 
 import os
 import subprocess
+import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
+
+import pytest
 
 from core.sandbox import (
     _check_blocked,
@@ -1411,6 +1414,13 @@ class TestCliProfile(unittest.TestCase):
         self.assertFalse(mod_state._cli_sandbox_disabled)
 
 
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="Landlock is Linux-only; macOS uses seatbelt and the dispatch "
+           "in context.py suppresses the Landlock-unavailable warning when "
+           "use_seatbelt is engaged. These tests assert on the warning text "
+           "of an entire layer that doesn't exist on Darwin.",
+)
 class TestLandlockDegradationWarnings(unittest.TestCase):
     """When Landlock can't enforce what the caller asked for, warn loudly."""
 

--- a/core/sandbox/tests/test_seatbelt.py
+++ b/core/sandbox/tests/test_seatbelt.py
@@ -1,0 +1,549 @@
+"""SBPL profile generation tests — cross-platform.
+
+These tests exercise ``core.sandbox.seatbelt.build_profile`` purely as
+string generation; they don't invoke ``sandbox-exec`` so they run on
+Linux too. The macOS-only end-to-end tests (which need the kernel
+Sandbox.kext to enforce the profile) live in test_macos_spawn.py.
+
+Coverage focus matches the spike-validated facts in seatbelt.py:
+  * `(allow default)` baseline (not deny-default)
+  * ``os.path.realpath()`` applied to write_exceptions paths
+  * ``(deny X (require-not (subpath Y)))`` deny-with-exception idiom
+  * Audit mode replaces deny with ``(allow X (with report))``
+  * Network deny + egress proxy port allowance
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+from core.sandbox import seatbelt
+
+
+def test_baseline_is_allow_default():
+    """Pure deny-default SIGABRTs modern macOS binaries before dyld can
+    load libSystem (spike #1 result rc=-6). We MUST emit allow-default
+    + targeted denies; regressing to deny-default would silently break
+    every sandboxed call on macOS."""
+    p = seatbelt.build_profile()
+    assert "(allow default)" in p
+    # Defensive: never accidentally emit a hard deny-default.
+    assert "(deny default)" not in p
+
+
+def test_version_pragma_first():
+    """SBPL requires (version 1) before any rule. Out-of-order or
+    missing version pragma rejects the profile."""
+    lines = seatbelt.build_profile().splitlines()
+    assert lines[0] == "(version 1)"
+
+
+def test_write_exceptions_use_realpath(tmp_path):
+    """Spike #3: SBPL (subpath ...) matches the canonical resolved
+    path. On macOS, /tmp resolves to /private/tmp via a symlink; if we
+    pass the symlink path, the write-allowlist exception silently
+    fails to match. tmp_path under pytest is typically already a
+    realpath, but this test asserts that whatever we pass IS the
+    realpath that ends up in the profile."""
+    output = str(tmp_path / "out")
+    os.makedirs(output, exist_ok=True)
+    p = seatbelt.build_profile(output=output)
+    expected = os.path.realpath(output)
+    assert f'(subpath "{expected}")' in p
+
+
+def test_write_exceptions_include_private_tmp(tmp_path):
+    """The /tmp default mirrors Linux Landlock's default /tmp in
+    writable_paths — many tools materialise temp files there. Spike
+    confirmed /private/tmp is the canonical realpath; emitting /tmp
+    directly would not match. Only emitted when write-isolation is
+    engaged (any of output/writable_paths/target/restrict_reads)."""
+    p = seatbelt.build_profile(output=str(tmp_path))
+    assert '(subpath "/private/tmp")' in p
+
+
+def test_writable_paths_appended():
+    """Caller-supplied writable_paths join the default exception
+    list (alongside output and /private/tmp)."""
+    extra = "/some/writable/dir"
+    p = seatbelt.build_profile(writable_paths=[extra])
+    assert f'(subpath "{extra}")' in p
+
+
+def test_writable_paths_dedup(tmp_path):
+    """A path passed in BOTH output= and writable_paths= must not
+    appear twice — duplicate (subpath ...) clauses parse fine but
+    needlessly bloat the profile and obscure the diff."""
+    output = str(tmp_path / "out")
+    os.makedirs(output, exist_ok=True)
+    p = seatbelt.build_profile(output=output, writable_paths=[output])
+    real = os.path.realpath(output)
+    assert p.count(f'(subpath "{real}")') == 1
+
+
+def test_enforcement_uses_require_not_idiom(tmp_path):
+    """Spike #2: plain ordering `(deny X)(allow X subpath)` doesn't
+    work — explicit deny outranks subsequent allow. The (deny X
+    (require-not Y)) clause is the canonical SBPL way to express
+    "deny X except where Y matches"."""
+    p = seatbelt.build_profile(output=str(tmp_path))
+    assert "(deny file-write* (require-not" in p
+
+
+def test_multi_path_uses_require_any_for_union_semantics(tmp_path):
+    """SBPL idioms tried + verified on macOS 26.4.1:
+
+      (a) (require-not (subpath A) (subpath B))
+            → sandbox-exec REJECTS: "too many arguments to require-
+              not". `require-not` is UNARY.
+      (b) (deny X (require-not A) (require-not B))
+            → parses but semantics are OR-on-the-deny:
+              ≡ deny X UNLESS (A AND B)  ← intersection
+              Wrong: writes inside A get denied unless they're ALSO
+              inside B.
+      (c) (deny X (require-not (require-any A B)))
+            → CORRECT: `require-any` is multi-arg, so the inner
+              expression is "A OR B"; require-not negates to NOT
+              (A OR B); deny when neither matches; allow if in
+              either A OR B. This is the Landlock-equivalent
+              "writable_paths is a union" semantic.
+
+    This test catches regressions back to (a) or (b) by asserting
+    structurally on the output."""
+    output = str(tmp_path / "out")
+    extra = str(tmp_path / "extra")
+    import os
+    os.makedirs(output, exist_ok=True)
+    os.makedirs(extra, exist_ok=True)
+    p = seatbelt.build_profile(output=output, writable_paths=[extra])
+    # Must use (require-not (require-any ...)) — exactly one
+    # require-any wrapping all the subpaths.
+    assert "(require-not (require-any " in p, (
+        f"expected (require-not (require-any ...)) idiom; got:\n{p}"
+    )
+    # Three exception paths: /private/tmp + output + extra → all
+    # three (subpath ...) must live inside ONE require-any clause.
+    import re
+    require_any_match = re.search(
+        r"\(require-any\s+((?:\(subpath [^)]+\)\s*)+)\)", p
+    )
+    assert require_any_match, "no (require-any (subpath ...) ...) found"
+    inside = require_any_match.group(1)
+    assert inside.count("(subpath ") == 3, (
+        f"expected 3 subpaths inside require-any, got: {inside}"
+    )
+    # Regression catch for form (b): we should NOT see multiple
+    # (require-not ...) clauses on the same deny (each holding one
+    # subpath) — that was the OR-semantics bug.
+    assert p.count("(require-not (subpath ") == 0, (
+        "found bare (require-not (subpath ...)) — the OR-semantics "
+        f"bug pattern. Profile:\n{p}"
+    )
+
+
+def test_audit_mode_replaces_deny_with_report():
+    """Spike #4: (allow file-write* (with report)) makes writes
+    succeed AND emit kernel sandbox log entries that LogStreamer
+    captures. In audit mode we MUST NOT emit a (deny file-write*) —
+    that would block writes despite "audit means observe". audit_mode
+    only triggers the replace when write-isolation would have engaged
+    (output= here engages it)."""
+    p = seatbelt.build_profile(audit_mode=True, output="/tmp/out")
+    assert "(allow file-write* (with report))" in p
+    assert "(deny file-write*" not in p
+
+
+def test_audit_mode_alone_omits_write_clause():
+    """audit_mode=True with no fs-isolation kwargs produces NO file-
+    write clause at all. The (allow default) baseline already permits
+    writes; replacing a non-existent deny is a no-op. Matches the
+    network-only-equivalent semantics where writes are unrestricted."""
+    p = seatbelt.build_profile(audit_mode=True)
+    assert "file-write*" not in p
+
+
+def test_audit_mode_does_not_emit_write_deny():
+    """Defensive: even with output= and writable_paths= set, audit
+    mode must NOT emit a deny clause — those args become
+    informational (operators see them in profile dumps; kernel
+    enforcement is replaced by reporting)."""
+    p = seatbelt.build_profile(
+        output="/tmp",
+        writable_paths=["/some/dir"],
+        audit_mode=True,
+    )
+    assert "(deny file-write*" not in p
+
+
+def test_block_network_emits_deny_network():
+    p = seatbelt.build_profile(block_network=True)
+    assert "(deny network*)" in p
+
+
+def test_no_block_network_omits_deny_network():
+    p = seatbelt.build_profile(block_network=False)
+    assert "(deny network*)" not in p
+
+
+def test_egress_proxy_implies_block_with_port_allow():
+    """use_egress_proxy=True is shorthand for "block all network
+    except the loopback proxy port". Profile must (a) deny network*
+    and (b) re-allow network-outbound to localhost:<proxy_port>."""
+    p = seatbelt.build_profile(use_egress_proxy=True, proxy_port=4567)
+    assert "(deny network*)" in p
+    assert "(allow network-outbound" in p
+    assert 'localhost:4567' in p
+
+
+def test_network_deny_then_allow_idiom_pinned():
+    """Pin the (deny network*) + (allow network-outbound ...)
+    pattern. Verified end-to-end on macOS 26.4.1 — the more-
+    specific allow overrides the broader deny for network rules
+    (different from file-* rules where explicit deny outranks any
+    subsequent allow). Apple's own SBPL profiles use this idiom.
+
+    A future refactor that "defensively" wraps network in a
+    `(deny network* (require-not (require-any ...)))` clause —
+    matching the file-write pattern — works equivalently but is
+    less idiomatic. Keep this test green to catch accidental
+    inversion (e.g., emitting the allow BEFORE the deny, which
+    DOES break — `(allow network-outbound)` followed by
+    `(deny network*)` blocks the proxy port)."""
+    p = seatbelt.build_profile(use_egress_proxy=True, proxy_port=4567)
+    lines = [l.strip() for l in p.splitlines() if l.strip()]
+    deny_idx = next(i for i, l in enumerate(lines)
+                    if l == "(deny network*)")
+    allow_idxs = [i for i, l in enumerate(lines)
+                   if l.startswith("(allow network-outbound")]
+    assert allow_idxs, "no allow-network-outbound clause emitted"
+    # The allow MUST come after the deny so the more-specific
+    # later rule wins. Inverting the order silently blocks the
+    # proxy port — caught by this assertion.
+    assert all(i > deny_idx for i in allow_idxs), (
+        f"allow-network-outbound clauses must follow (deny "
+        f"network*); deny at line {deny_idx}, allows at {allow_idxs}"
+    )
+
+
+def test_egress_proxy_emits_both_v4_and_v6():
+    """The HTTPS_PROXY env we set is hostname-based; depending on
+    resolver order (which we don't control inside the child) the
+    child may connect via tcp4 or tcp6. Both must be allowed."""
+    p = seatbelt.build_profile(use_egress_proxy=True, proxy_port=4567)
+    assert "tcp4" in p
+    assert "tcp6" in p
+
+
+def test_allowed_tcp_ports_emitted():
+    """Caller-supplied port allowlist (e.g. allowed_tcp_ports=[443])
+    becomes (allow network-outbound (remote tcp "*:443")) clauses."""
+    p = seatbelt.build_profile(
+        block_network=True,
+        allowed_tcp_ports=[443, 8443],
+    )
+    assert '"*:443"' in p
+    assert '"*:8443"' in p
+
+
+def test_restrict_reads_emits_deny_read_with_exceptions(tmp_path):
+    """restrict_reads=True mirrors the Linux read-allowlist behaviour
+    (Landlock's path_beneath denies reads outside the listed dirs).
+    Profile must emit:
+      1. `(allow file-read-metadata)` so path traversal works
+         everywhere (stat/readdir on any inode is permissive — just
+         metadata, not content).
+      2. `(deny file-read-data (require-not ...))` with the
+         system-dirs allowlist + output + readable_paths.
+    The split prevents readdir-of-/ leaking the top-level directory
+    listing (info leak) while keeping dyld + standard tools
+    functional."""
+    output = str(tmp_path / "out")
+    os.makedirs(output, exist_ok=True)
+    p = seatbelt.build_profile(
+        output=output,
+        restrict_reads=True,
+        readable_paths=["/opt/myapp"],
+    )
+    assert "(allow file-read-metadata)" in p
+    assert "(deny file-read-data (require-not" in p
+    assert '(subpath "/usr")' in p
+    assert '(subpath "/opt/myapp")' in p
+
+
+def test_restrict_reads_audit_mode_emits_allow_with_report():
+    """Audit mode + restrict_reads: log-don't-block, same idea as
+    writes. Each unauthorised read becomes an audit record."""
+    p = seatbelt.build_profile(restrict_reads=True, audit_mode=True)
+    assert "(allow file-read* (with report))" in p
+    assert "(deny file-read*" not in p
+
+
+def test_restrict_reads_off_omits_read_deny():
+    """Default (restrict_reads=False) must NOT emit any file-read*
+    clause — reads are unrestricted by the (allow default) baseline."""
+    p = seatbelt.build_profile()
+    assert "file-read*" not in p
+
+
+def test_quote_sbpl_escapes_quotes_and_backslashes():
+    """Defensive: a path containing " or \\ must be safely quoted so
+    it doesn't break the surrounding (subpath "...") expression. SBPL
+    uses backslash-escapes inside double-quoted strings."""
+    assert seatbelt._quote_sbpl('plain') == '"plain"'
+    assert seatbelt._quote_sbpl('with "quote"') == '"with \\"quote\\""'
+    assert seatbelt._quote_sbpl('with\\backslash') == '"with\\\\backslash"'
+
+
+def test_quote_sbpl_rejects_control_chars():
+    """SBPL injection guard: a path with newline / NUL / any control
+    character must be rejected, not naively escaped. SBPL parser is
+    whitespace-sensitive — `\\n` closes the s-expression and lets an
+    attacker-controlled path inject a fresh clause that overrides
+    the deny. Caught before the string ever reaches sandbox-exec."""
+    import pytest
+    with pytest.raises(ValueError, match="control character"):
+        seatbelt._quote_sbpl("/tmp/x\n(allow file-write*)")
+    with pytest.raises(ValueError, match="control character"):
+        seatbelt._quote_sbpl("/tmp/x\x00")
+    with pytest.raises(ValueError, match="control character"):
+        seatbelt._quote_sbpl("/tmp/x\t")
+    with pytest.raises(ValueError, match="control character"):
+        seatbelt._quote_sbpl("/tmp/x\r")
+
+
+def test_build_profile_rejects_path_with_newline():
+    """End-to-end: an attacker-controlled output= with embedded
+    newline must fail loudly, not silently produce an injected
+    profile. The build_profile entry funnels through _quote_sbpl
+    for every path-bearing clause."""
+    import pytest
+    with pytest.raises(ValueError, match="control character"):
+        seatbelt.build_profile(output="/tmp/x\n(allow file-write*)")
+    with pytest.raises(ValueError, match="control character"):
+        seatbelt.build_profile(writable_paths=["/tmp/x\nevil"])
+
+
+def test_realpath_or_none_handles_falsy():
+    assert seatbelt._realpath_or_none(None) is None
+    assert seatbelt._realpath_or_none("") is None
+
+
+def test_realpath_or_none_canonicalises_symlink(tmp_path):
+    """The whole point of _realpath_or_none — symlink targets are
+    resolved before SBPL emission."""
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real_dir)
+    resolved = seatbelt._realpath_or_none(str(link))
+    assert resolved == os.path.realpath(str(real_dir))
+
+
+def test_target_does_not_appear_in_write_exceptions(tmp_path):
+    """target= is a read-only engagement marker; it must NOT make
+    the path writable. (Reads are allowed by the allow-default
+    baseline — target's purpose is engagement signalling, not
+    permission grant.)"""
+    target = str(tmp_path / "target")
+    os.makedirs(target, exist_ok=True)
+    p = seatbelt.build_profile(target=target)
+    real = os.path.realpath(target)
+    # The deny clause's exception list must NOT include target.
+    # We check by extracting the require-not clause and confirming.
+    assert f'(subpath "{real}")' not in p
+
+
+def test_empty_inputs_produce_permissive_profile():
+    """No kwargs at all → no write-deny clause emitted. Matches the
+    Linux semantics for `--sandbox network-only` / `--sandbox none`
+    profiles where Landlock is disabled and writes are unrestricted.
+    Without this gate, the macOS path would over-restrict
+    network-only mode (writes blocked outside /private/tmp)."""
+    p = seatbelt.build_profile()
+    assert p.startswith("(version 1)\n(allow default)\n")
+    # No write isolation engaged → no file-write deny.
+    assert "file-write*" not in p
+
+
+def test_network_only_equivalent_omits_write_deny():
+    """Profile parity: Linux `--sandbox network-only` engages
+    block_network=True with use_landlock=False. The macOS equivalent
+    (block_network=True with no fs args) must NOT emit the file-write
+    deny — otherwise the macOS profile is strictly more restrictive
+    than its Linux namesake, breaking the operator's "network-only"
+    contract."""
+    p = seatbelt.build_profile(block_network=True)
+    assert "(deny network*)" in p
+    assert "file-write*" not in p
+
+
+def test_writable_paths_alone_engages_write_deny():
+    """Caller-supplied writable_paths is a positive signal that they
+    want fs isolation — engage the write-deny even without output=."""
+    p = seatbelt.build_profile(writable_paths=["/some/path"])
+    assert "(deny file-write*" in p
+    assert '(subpath "/some/path")' in p
+
+
+def test_restrict_reads_engages_write_deny_too():
+    """If a caller wants reads restricted, they almost certainly want
+    writes restricted too — otherwise the child can write a binary
+    then exec it, defeating the read-allowlist's secret-protection
+    purpose."""
+    p = seatbelt.build_profile(restrict_reads=True)
+    assert "(deny file-write*" in p
+
+
+def test_sandbox_kext_sender_constant():
+    """The senderImagePath constant is exported from seatbelt.py for
+    seatbelt_audit.py to import. Both modules must use the same
+    string — divergence would silently break audit log filtering."""
+    assert (seatbelt.SANDBOX_KEXT_SENDER ==
+            "/System/Library/Extensions/Sandbox.kext/Contents/MacOS/Sandbox")
+
+
+# --- seccomp_profile-equivalent SBPL hardening ------------------------
+
+def test_seccomp_profile_none_omits_process_info_deny():
+    """Default (no seccomp_profile) leaves the (allow default)
+    process introspection alone. Tools like ps, top, lldb that
+    introspect other processes must still work in this mode."""
+    p = seatbelt.build_profile()
+    assert "process-info" not in p
+
+
+def test_seccomp_profile_full_emits_process_info_deny():
+    """Linux's "full" seccomp blocks ptrace. Closest macOS analogue
+    is denying introspection of OTHER processes' pidinfo / pidfdinfo.
+    `(target others)` keeps self-introspection working."""
+    p = seatbelt.build_profile(seccomp_profile="full")
+    assert "(deny process-info-pidinfo (target others))" in p
+    assert "(deny process-info-pidfdinfo (target others))" in p
+
+
+def test_seccomp_profile_none_string_omits_deny():
+    """`seccomp_profile="none"` is the explicit "no syscall filter"
+    sentinel — must NOT engage the macOS hardening either."""
+    p = seatbelt.build_profile(seccomp_profile="none")
+    assert "process-info" not in p
+
+
+def test_seccomp_profile_with_audit_mode_uses_report():
+    """Under audit mode, process-info denies become (allow ...
+    (with report)) so introspection succeeds AND emits an audit
+    record — same observe-don't-block pattern as file writes."""
+    p = seatbelt.build_profile(seccomp_profile="full", audit_mode=True)
+    assert "(allow process-info* (with report))" in p
+    assert "(deny process-info" not in p
+
+
+def test_seccomp_profile_debug_omits_introspection_denies():
+    """Linux's `--sandbox debug` is "full minus ptrace block" so
+    gdb/rr can attach to the sandboxed target. The macOS analogue
+    must keep process-info-* on `target others` unrestricted so
+    lldb / sample / dtrace can introspect — same intent both
+    platforms. Regression catch: any earlier behaviour where
+    "debug" engaged the same hardening as "full" silently broke
+    the debugger UX on macOS."""
+    p = seatbelt.build_profile(seccomp_profile="debug")
+    assert "(deny process-info-pidinfo" not in p
+    assert "(deny process-info-pidfdinfo" not in p
+
+
+def test_seccomp_profile_full_distinct_from_debug():
+    """Pin the distinction: full engages introspection denies,
+    debug does not. If someone refactors and accidentally collapses
+    them, this test catches it."""
+    full = seatbelt.build_profile(seccomp_profile="full")
+    debug = seatbelt.build_profile(seccomp_profile="debug")
+    assert "(deny process-info-pidinfo" in full
+    assert "(deny process-info-pidinfo" not in debug
+
+
+# --- audit_verbose (Phase 2c) ------------------------------------------
+
+def test_audit_verbose_off_omits_extended_audit():
+    """Default (audit_mode=False, audit_verbose=False) → no extended
+    audit category clauses. Regression catch."""
+    p = seatbelt.build_profile()
+    assert "mach-lookup" not in p
+    assert "process-exec" not in p
+    assert "process-fork" not in p
+    assert "signal" not in p
+
+
+def test_audit_verbose_requires_audit_mode():
+    """audit_verbose alone (without audit_mode) is operator confusion
+    — same constraint Linux enforces. The build_profile silently
+    skips the verbose clauses if audit_mode is not also True."""
+    p = seatbelt.build_profile(audit_verbose=True)
+    assert "(allow file-read-data (with report))" not in p
+    assert "(allow mach-lookup (with report))" not in p
+
+
+def test_audit_verbose_with_audit_mode_emits_extended_set():
+    """audit_mode + audit_verbose → emit (allow X (with report)) for
+    each extended category. These ride alongside the file-write
+    (with report) from audit_mode."""
+    p = seatbelt.build_profile(audit_mode=True, audit_verbose=True,
+                                output="/tmp/x")
+    # audit_mode clause still present
+    assert "(allow file-write* (with report))" in p
+    # extended categories
+    assert "(allow file-read-data (with report))" in p
+    assert "(allow mach-lookup (with report))" in p
+    assert "(allow process-exec* (with report))" in p
+    assert "(allow process-fork (with report))" in p
+    assert "(allow signal (with report))" in p
+
+
+def test_restrict_reads_dev_is_narrow_not_wholesale():
+    """Parity with Linux: /dev is NOT allowlisted as a subpath.
+    Linux's restrict_reads default deliberately excludes /dev to
+    keep /dev/shm out of scope; on macOS the equivalent posix-shm
+    surface lives under /private/var/folders/.../C/shm. Wholesale
+    /dev read access exposes that surface to a sandboxed child.
+    Specific /dev character devices (null/zero/urandom/etc.) ARE
+    granted as literals."""
+    p = seatbelt.build_profile(restrict_reads=True, output="/tmp/x")
+    assert '(subpath "/dev")' not in p, (
+        "/dev should not be wholesale-allowlisted under "
+        "restrict_reads — narrow to specific files"
+    )
+    # The narrow allow-list should still let dyld + standard tools
+    # find the character devices they expect.
+    for needed in ("/dev/null", "/dev/urandom", "/dev/random",
+                    "/dev/tty"):
+        assert f'(literal "{needed}")' in p, (
+            f"missing expected /dev literal {needed!r}"
+        )
+
+
+def test_audit_verbose_includes_high_volume_categories():
+    """Once seatbelt_audit.LogStreamer enforces the per-category
+    skip-budget, high-volume categories (file-read-metadata,
+    process-info-*, iokit-open, sysctl-read) become safe to emit:
+    their JSONL contribution is bounded by AuditBudget's per-cat
+    caps + sampling (see core.sandbox.audit_budget.DEFAULT_*) and
+    operators see a budget_exceeded marker when the cap fires.
+    Regression catch for accidentally stripping the high-volume
+    categories back out."""
+    p = seatbelt.build_profile(audit_mode=True, audit_verbose=True,
+                                output="/tmp/x")
+    assert "(allow file-read-metadata (with report))" in p
+    assert "(allow process-info* (with report))" in p
+    assert "(allow iokit-open (with report))" in p
+    assert "(allow sysctl-read (with report))" in p
+
+
+def test_audit_verbose_compatible_with_restrict_reads():
+    """When restrict_reads=True + audit_mode=True, the
+    restrict-reads branch already emits (allow file-read* (with
+    report)). audit_verbose adds (allow file-read-data (with
+    report)) — both clauses can coexist in the profile (SBPL
+    handles duplicate (allow ... (with report)) cleanly)."""
+    p = seatbelt.build_profile(audit_mode=True, audit_verbose=True,
+                                restrict_reads=True, output="/tmp/x")
+    assert "(allow file-read* (with report))" in p
+    assert "(allow file-read-data (with report))" in p

--- a/core/sandbox/tests/test_seatbelt_audit_parse.py
+++ b/core/sandbox/tests/test_seatbelt_audit_parse.py
@@ -1,0 +1,245 @@
+"""macOS audit-log parser tests — cross-platform.
+
+These tests exercise ``core.sandbox.seatbelt_audit.parse_log_entry``
+and the JSONL-append behaviour of ``LogStreamer._append_record``
+without spawning ``log stream``. The Darwin-only end-to-end log
+capture lives in test_macos_e2e.py.
+
+Sample entries are reproduced from spike #4 output (run on macOS
+26.4.1 arm64) so the regex and field expectations are anchored to
+real kernel output, not invented.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from core.sandbox import seatbelt_audit
+from core.sandbox.seatbelt import SANDBOX_KEXT_SENDER
+
+
+# Real Sandbox.kext entry observed in spike #4 (formatting trimmed
+# to the fields we read). Spike #4 confirmed:
+#   subsystem="" category=""  ← cannot filter on these
+#   senderImagePath = SANDBOX_KEXT_SENDER  ← reliable filter
+#   eventMessage   = "Sandbox: <name>(<pid>) <verdict> <action> <path>"
+def _kext_entry(*, msg: str, ts: str = "2026-04-30 12:34:56.789012+0000"):
+    return {
+        "senderImagePath": SANDBOX_KEXT_SENDER,
+        "eventMessage": msg,
+        "timestamp": ts,
+        "subsystem": "",
+        "category": "",
+    }
+
+
+def test_parse_allow_file_write_create():
+    """Canonical (with report) entry: file-write-create allowed +
+    logged. Spike #4 verified this format."""
+    entry = _kext_entry(msg="Sandbox: Python(12345) allow file-write-create /private/tmp/x")
+    rec = seatbelt_audit.parse_log_entry(entry)
+    assert rec is not None
+    assert rec["verdict"] == "allow"
+    assert rec["syscall"] == "file-write-create"
+    assert rec["path"] == "/private/tmp/x"
+    assert rec["target_pid"] == 12345
+    assert rec["process_name"] == "Python"
+    assert rec["audit"] is True
+    assert rec["type"] == "write"
+
+
+def test_parse_deny_file_read_data():
+    entry = _kext_entry(msg="Sandbox: ls(99) deny file-read-data /etc/passwd")
+    rec = seatbelt_audit.parse_log_entry(entry)
+    assert rec is not None
+    assert rec["verdict"] == "deny"
+    assert rec["syscall"] == "file-read-data"
+    assert rec["type"] == "read"
+    assert rec["path"] == "/etc/passwd"
+
+
+def test_parse_network_outbound():
+    entry = _kext_entry(
+        msg="Sandbox: curl(2222) deny network-outbound /tmp/sock"
+    )
+    rec = seatbelt_audit.parse_log_entry(entry)
+    assert rec is not None
+    assert rec["type"] == "network"
+    assert rec["syscall"] == "network-outbound"
+
+
+def test_parse_action_to_type_mapping():
+    """The taxonomy must mirror Linux's _NAME_TO_TYPE so
+    summarize_and_write produces consistent buckets across
+    platforms."""
+    assert seatbelt_audit._action_to_type("file-write-create") == "write"
+    assert seatbelt_audit._action_to_type("file-write-data") == "write"
+    assert seatbelt_audit._action_to_type("file-mknod") == "write"
+    assert seatbelt_audit._action_to_type("file-read-data") == "read"
+    assert seatbelt_audit._action_to_type("file-read-metadata") == "read"
+    assert seatbelt_audit._action_to_type("network-outbound") == "network"
+    assert seatbelt_audit._action_to_type("network-inbound") == "network"
+    # Catch-all: mach/iokit/sysctl/process actions land in the closest
+    # Linux analogue ("seccomp" — that's the bucket Linux uses for
+    # syscall-class denials).
+    assert seatbelt_audit._action_to_type("mach-lookup") == "seccomp"
+    assert seatbelt_audit._action_to_type("iokit-open") == "seccomp"
+    assert seatbelt_audit._action_to_type("sysctl-read") == "seccomp"
+
+
+def test_parse_drops_non_kext_sender():
+    """Entries from other senders (e.g. com.apple.WindowServer) must
+    be silently dropped — we only care about Sandbox.kext output."""
+    entry = {
+        "senderImagePath": "/System/Library/Frameworks/Foo.framework/Foo",
+        "eventMessage": "Sandbox: ls(99) deny file-read-data /etc/passwd",
+    }
+    assert seatbelt_audit.parse_log_entry(entry) is None
+
+
+def test_parse_drops_unparseable_message():
+    """A kext entry whose eventMessage doesn't match the
+    Sandbox-format regex (other kext output, or a future format
+    change) must drop silently rather than crash."""
+    entry = _kext_entry(msg="Sandbox profile evaluated successfully")
+    assert seatbelt_audit.parse_log_entry(entry) is None
+
+
+def test_parse_drops_missing_eventmessage():
+    """Defensive: entries with no eventMessage at all must drop
+    cleanly — log stream occasionally emits skeletal entries."""
+    entry = {"senderImagePath": SANDBOX_KEXT_SENDER}
+    assert seatbelt_audit.parse_log_entry(entry) is None
+
+
+def test_parse_handles_path_with_spaces():
+    """File paths with spaces are common on macOS (~/Library/Application
+    Support/...). The regex's `(.+)$` greedy tail captures them
+    intact."""
+    entry = _kext_entry(
+        msg="Sandbox: foo(1) deny file-read-data /Users/Bob/Library/Application Support/x"
+    )
+    rec = seatbelt_audit.parse_log_entry(entry)
+    assert rec is not None
+    assert rec["path"] == "/Users/Bob/Library/Application Support/x"
+
+
+def test_parse_uses_entry_timestamp():
+    """The kernel-supplied timestamp is preserved when present —
+    important for ordering against host-side events. Falls back to
+    now() when absent (spike confirmed timestamps are usually
+    populated, but defensive)."""
+    entry = _kext_entry(
+        msg="Sandbox: foo(1) allow file-write-create /tmp/x",
+        ts="2026-04-30 12:00:00.000000+0000",
+    )
+    rec = seatbelt_audit.parse_log_entry(entry)
+    assert rec["ts"] == "2026-04-30 12:00:00.000000+0000"
+
+
+def test_parse_falls_back_to_now_when_no_timestamp():
+    entry = {
+        "senderImagePath": SANDBOX_KEXT_SENDER,
+        "eventMessage": "Sandbox: foo(1) allow file-write-create /tmp/x",
+    }
+    rec = seatbelt_audit.parse_log_entry(entry)
+    # Some ISO-format string is generated; we don't assert on the
+    # exact value but it must be present and roughly resemble ISO.
+    assert "T" in rec["ts"]
+    assert "+" in rec["ts"] or "Z" in rec["ts"]
+
+
+def test_log_streamer_appends_one_line_per_record(tmp_path):
+    """End-to-end JSONL append behaviour: each record is one JSON
+    object per line (matches Linux summary.record_denial format
+    exactly)."""
+    streamer = seatbelt_audit.LogStreamer(tmp_path)
+    rec1 = {"a": 1}
+    rec2 = {"b": 2}
+    streamer._append_record(rec1)
+    streamer._append_record(rec2)
+    path = tmp_path / seatbelt_audit.DENIALS_FILE
+    assert path.exists()
+    lines = path.read_text().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0]) == rec1
+    assert json.loads(lines[1]) == rec2
+
+
+def test_log_streamer_creates_run_dir(tmp_path):
+    """The streamer must materialise its own run_dir if absent —
+    mirrors Linux summary.record_denial behaviour."""
+    new_dir = tmp_path / "fresh"
+    assert not new_dir.exists()
+    streamer = seatbelt_audit.LogStreamer(new_dir)
+    streamer._append_record({"x": 1})
+    assert new_dir.exists()
+    assert (new_dir / seatbelt_audit.DENIALS_FILE).exists()
+
+
+# --- LogStreamer ↔ AuditBudget integration ----------------------------
+# Pure-budget mechanics live in test_audit_budget.py. The integration
+# tests below verify that LogStreamer wires its (parsed) records to
+# the budget AND emits a summary record on stop().
+
+def test_log_streamer_uses_injected_budget_for_summary(tmp_path):
+    """stop() must always emit an audit_summary record sourced from
+    the budget. Tests the wiring: inject a budget with known state,
+    call stop(), verify the JSONL contains the budget's summary."""
+    from core.sandbox import audit_budget
+    budget = audit_budget.AuditBudget()
+    # Bump the budget's internal counters via real evaluate calls
+    # (no clock games needed — we just want non-zero state).
+    budget.evaluate("file-write-data", pid=42)
+    budget.evaluate("file-write-data", pid=42)
+    budget.evaluate("network-outbound", pid=99)
+
+    streamer = seatbelt_audit.LogStreamer(tmp_path, budget=budget)
+    # No proc started — stop() should still flush the summary.
+    streamer.stop()
+
+    lines = (tmp_path / seatbelt_audit.DENIALS_FILE).read_text().splitlines()
+    summaries = [json.loads(l) for l in lines
+                  if json.loads(l).get("type") == "audit_summary"]
+    assert len(summaries) == 1
+    s = summaries[0]
+    assert s["total_records"] == 3
+    assert s["category_counts"] == {"file-write": 2, "network": 1}
+    # JSON round-trip stringifies int dict keys — match what
+    # operators actually read from the JSONL.
+    assert s["pid_counts"] == {"42": 2, "99": 1}
+
+
+def test_log_streamer_default_budget_is_cli_aware(tmp_path):
+    """LogStreamer with no explicit budget pulls one from
+    audit_budget.from_cli_state() — picks up --audit-budget."""
+    from core.sandbox import state, audit_budget
+    state._cli_sandbox_audit_budget = 250
+    try:
+        streamer = seatbelt_audit.LogStreamer(tmp_path)
+        assert streamer._budget.global_cap == 250
+    finally:
+        state._cli_sandbox_audit_budget = None
+
+
+def test_log_streamer_o_nofollow_blocks_symlink(tmp_path):
+    """Defence in depth: a sandboxed child with write access to
+    run_dir could pre-plant DENIALS_FILE as a symlink to a host
+    file. O_NOFOLLOW must reject the open with ELOOP rather than
+    follow the link and append to the host file."""
+    target = tmp_path / "target"
+    target.write_text("")
+    link = tmp_path / seatbelt_audit.DENIALS_FILE
+    link.symlink_to(target)
+    streamer = seatbelt_audit.LogStreamer(tmp_path)
+    try:
+        streamer._append_record({"x": 1})
+        # If we reach here, O_NOFOLLOW didn't engage — fail loudly.
+        assert False, "O_NOFOLLOW should have blocked the symlink"
+    except OSError as e:
+        # ELOOP on Linux, similar errno on macOS — either way, the
+        # symlink was refused.
+        assert e.errno in (40, 62), f"unexpected errno {e.errno}"
+    # The symlink target must remain empty (no leak).
+    assert target.read_text() == ""

--- a/core/sandbox/tests/test_seccomp_audit.py
+++ b/core/sandbox/tests/test_seccomp_audit.py
@@ -12,6 +12,14 @@ integration in this same commit; the end-to-end test there is the
 proof that the wiring works.
 """
 
+import sys as _sys
+import pytest as _pytest
+pytestmark = _pytest.mark.skipif(
+    _sys.platform != "linux",
+    reason="Linux-only sandbox internals (mount-ns / Landlock / seccomp / ptrace tracer / pid1 shim) — see core/sandbox/_macos_spawn.py for the macOS path",
+)
+
+
 import pytest
 
 from core.sandbox import seccomp

--- a/core/sandbox/tests/test_spawn_audit.py
+++ b/core/sandbox/tests/test_spawn_audit.py
@@ -15,6 +15,14 @@ unavailable).
 
 from __future__ import annotations
 
+import sys as _sys
+import pytest as _pytest
+pytestmark = _pytest.mark.skipif(
+    _sys.platform != "linux",
+    reason="Linux-only sandbox internals (mount-ns / Landlock / seccomp / ptrace tracer / pid1 shim) — see core/sandbox/_macos_spawn.py for the macOS path",
+)
+
+
 import json
 import os
 import platform
@@ -294,8 +302,10 @@ class TestAuditModeBasicFlow:
         records = [json.loads(line) for line in
                    jsonl.read_text().splitlines() if line]
         # Don't assert exact count (Python startup does many opens)
-        # but DO assert at least one openat with audit=True.
-        openats = [r for r in records if r["syscall"] == "openat"]
+        # but DO assert at least one openat with audit=True. Skip
+        # control-plane records (audit_summary, *_budget_exceeded
+        # markers) which don't have a `syscall` field.
+        openats = [r for r in records if r.get("syscall") == "openat"]
         assert len(openats) > 0, (
             f"expected at least one openat audit record, got: {records!r}"
         )
@@ -367,8 +377,11 @@ for _ in range(3):
             jsonl.read_text().splitlines() if line
         ]
         # Records should bear MULTIPLE distinct target_pids — proves
-        # TRACEFORK/CLONE auto-attached the children.
-        traced_pids = {r["target_pid"] for r in records}
+        # TRACEFORK/CLONE auto-attached the children. Skip
+        # control-plane records (audit_summary, *_budget_exceeded
+        # markers) which don't have a target_pid.
+        traced_pids = {r["target_pid"] for r in records
+                        if "target_pid" in r}
         # Without TRACEFORK only one PID would ever appear. We expect
         # at least the parent + one child (in practice, parent + 3
         # since python forked 3 children), but the assertion just
@@ -413,19 +426,7 @@ class TestAuditModeTracerDeath:
         # via a pipe so we know what to watch for.
 
         pipe_r, pipe_w = os.pipe()
-        # Suppress Python 3.12+ multi-threaded-fork DeprecationWarning.
-        # The seizer child does only os.pipe / os.fork / ptrace
-        # syscalls / os._exit — no Python objects, no GIL acquisition.
-        # Same fork-safety contract as production. The inner sleeper
-        # fork (line below) runs INSIDE the seizer child (single-
-        # threaded) so doesn't need the wrapper.
-        import warnings as _warnings
-        with _warnings.catch_warnings():
-            _warnings.filterwarnings(
-                "ignore", category=DeprecationWarning,
-                message=r".*fork.*may lead to deadlocks.*",
-            )
-            seizer_pid = os.fork()
+        seizer_pid = os.fork()
         if seizer_pid == 0:
             # === seizer ===
             os.close(pipe_r)
@@ -579,7 +580,7 @@ class TestSandboxAuditProfile:
         ]
         # At least one openat record for /etc/hostname (could also
         # appear for python startup paths).
-        openats = [r for r in records if r["syscall"] == "openat"]
+        openats = [r for r in records if r.get("syscall") == "openat"]
         assert len(openats) > 0
         for r in openats:
             assert r["audit"] is True

--- a/core/sandbox/tests/test_spawn_mount_ns.py
+++ b/core/sandbox/tests/test_spawn_mount_ns.py
@@ -13,6 +13,14 @@ developer manually flips the sysctl.
 
 from __future__ import annotations
 
+import sys as _sys
+import pytest as _pytest
+pytestmark = _pytest.mark.skipif(
+    _sys.platform != "linux",
+    reason="Linux-only sandbox internals (mount-ns / Landlock / seccomp / ptrace tracer / pid1 shim) — see core/sandbox/_macos_spawn.py for the macOS path",
+)
+
+
 import os
 import shutil
 import sys

--- a/core/sandbox/tests/test_tracer.py
+++ b/core/sandbox/tests/test_tracer.py
@@ -9,6 +9,14 @@ where the end-to-end test will live.
 
 from __future__ import annotations
 
+import sys as _sys
+import pytest as _pytest
+pytestmark = _pytest.mark.skipif(
+    _sys.platform != "linux",
+    reason="Linux-only sandbox internals (mount-ns / Landlock / seccomp / ptrace tracer / pid1 shim) — see core/sandbox/_macos_spawn.py for the macOS path",
+)
+
+
 import ctypes
 import json
 import os

--- a/core/sandbox/tests/test_tracer_event_loop.py
+++ b/core/sandbox/tests/test_tracer_event_loop.py
@@ -19,6 +19,14 @@ Status encoding cheatsheet (see man waitpid):
 
 from __future__ import annotations
 
+import sys as _sys
+import pytest as _pytest
+pytestmark = _pytest.mark.skipif(
+    _sys.platform != "linux",
+    reason="Linux-only sandbox internals (mount-ns / Landlock / seccomp / ptrace tracer / pid1 shim) — see core/sandbox/_macos_spawn.py for the macOS path",
+)
+
+
 import platform
 import signal
 import struct
@@ -117,12 +125,21 @@ def fake_helpers():
 
 
 def _dispatch(wpid, status, traced, target_pid, arch_info, helpers,
-              record_count=0, cap_warned=False, run_dir=Path("/tmp")):
+              budget=None, run_dir=Path("/tmp")):
     """Convenience wrapper to call _handle_waitpid_event with the
-    fake helpers from the fixture."""
-    return tracer._handle_waitpid_event(
+    fake helpers from the fixture.
+
+    Returns the budget so tests can assert on its state
+    (total_records, dropped_by_category, etc.). Constructs a fresh
+    budget per dispatch unless one is passed in for state-carrying
+    multi-event sequences.
+    """
+    from core.sandbox import audit_budget
+    if budget is None:
+        budget = audit_budget.AuditBudget()
+    tracer._handle_waitpid_event(
         wpid, status, traced, target_pid, arch_info,
-        run_dir, record_count, cap_warned,
+        run_dir, budget,
         ptrace_cont=helpers["ptrace_cont"],
         read_regs=helpers["read_regs"],
         decode_syscall=helpers["decode_syscall"],
@@ -130,6 +147,7 @@ def _dispatch(wpid, status, traced, target_pid, arch_info, helpers,
         get_event_msg=helpers["get_event_msg"],
         write_record=helpers["write_record"],
     )
+    return budget
 
 
 class TestExitedTracees:
@@ -138,7 +156,7 @@ class TestExitedTracees:
 
     def test_exited_tracee_removed_from_traced(self, arch_info, fake_helpers):
         traced = {1000, 1001, 1002}
-        rc, _ = _dispatch(
+        _dispatch(
             1001, _exit_status(0), traced, 1000, arch_info, fake_helpers,
         )
         assert traced == {1000, 1002}
@@ -172,12 +190,12 @@ class TestSeccompTraceEvent:
 
     def test_seccomp_event_writes_record(self, arch_info, fake_helpers):
         traced = {1000}
-        rc, cap = _dispatch(
+        budget = _dispatch(
             1000, _ptrace_event_status(tracer._PTRACE_EVENT_SECCOMP),
             traced, 1000, arch_info, fake_helpers,
         )
-        assert rc == 1, "record_count should increment"
-        assert cap is False
+        assert budget.total_records == 1, "budget should record one event"
+        assert not budget.dropped_by_category
         # write_record was called with openat
         records = fake_helpers["calls"]["write_record"]
         assert len(records) == 1
@@ -204,21 +222,28 @@ class TestSeccompTraceEvent:
         assert deref_calls[0] == (1000, 0xcafef00d)
 
     def test_record_cap_emits_one_warning(
-            self, arch_info, fake_helpers, monkeypatch, capfd):
-        # Lower the cap so the test runs fast.
-        monkeypatch.setattr(tracer, "_MAX_RECORDS_PER_RUN", 2)
+            self, arch_info, fake_helpers, tmp_path):
+        """Budget cap drops further records but still resumes the
+        tracee on every event. Uses a small AuditBudget for speed."""
+        from core.sandbox import audit_budget
+        # openat → file-read-metadata category. Cap that category at
+        # 2 with no refill so the third dispatch drops.
+        budget = audit_budget.AuditBudget(
+            category_caps={"file-read-metadata": 2},
+            refill_rates={"file-read-metadata": 0.0},
+            sampling_rates={},
+        )
         traced = {1000}
-        rc, cap = 0, False
         for _ in range(5):
-            rc, cap = _dispatch(
+            _dispatch(
                 1000, _ptrace_event_status(tracer._PTRACE_EVENT_SECCOMP),
                 traced, 1000, arch_info, fake_helpers,
-                record_count=rc, cap_warned=cap,
+                budget=budget, run_dir=tmp_path,
             )
         # 2 records persisted (cap), but ptrace_cont fired all 5 times.
         assert len(fake_helpers["calls"]["write_record"]) == 2
         assert len(fake_helpers["calls"]["ptrace_cont"]) == 5
-        assert cap is True
+        assert budget.dropped_by_category["file-read-metadata"] == 3
 
     def test_read_regs_failure_skips_record_but_resumes(
             self, arch_info):
@@ -230,17 +255,19 @@ class TestSeccompTraceEvent:
         def cont(pid, sig=0):
             calls.append((pid, sig))
             return True
+        from core.sandbox import audit_budget
+        budget = audit_budget.AuditBudget()
         traced = {1000}
-        rc, cap = tracer._handle_waitpid_event(
+        tracer._handle_waitpid_event(
             1000, _ptrace_event_status(tracer._PTRACE_EVENT_SECCOMP),
-            traced, 1000, arch_info, Path("/tmp"), 0, False,
+            traced, 1000, arch_info, Path("/tmp"), budget,
             read_regs=fail_read_regs, ptrace_cont=cont,
             decode_syscall=lambda *a: (0, [0]*6),
             read_tracee_string=lambda *a, **k: None,
             get_event_msg=lambda p: None,
             write_record=lambda *a, **k: True,
         )
-        assert rc == 0  # no record written
+        assert budget.total_records == 0  # no record written
         assert calls == [(1000, 0)]  # but tracee resumed
 
 
@@ -273,10 +300,12 @@ class TestNewTraceeEvents:
             calls.append((pid, sig))
             return True
 
+        from core.sandbox import audit_budget
+        budget = audit_budget.AuditBudget()
         traced = {1000}
         tracer._handle_waitpid_event(
             1000, _ptrace_event_status(tracer._PTRACE_EVENT_FORK),
-            traced, 1000, arch_info, Path("/tmp"), 0, False,
+            traced, 1000, arch_info, Path("/tmp"), budget,
             ptrace_cont=cont,
             read_regs=lambda *a: None,
             decode_syscall=lambda *a: (0, [0]*6),
@@ -377,10 +406,10 @@ class TestNonStoppedStatus:
         # by feeding a status that's not stopped/exited/signalled.
         traced = {1000}
         # 0xffff = WIFCONTINUED on Linux
-        rc, cap = _dispatch(
+        budget = _dispatch(
             1000, 0xffff, traced, 1000, arch_info, fake_helpers,
         )
         # No record, no resume, no set mutation
         assert traced == {1000}
-        assert rc == 0
+        assert budget.total_records == 0
         assert fake_helpers["calls"]["ptrace_cont"] == []

--- a/core/sandbox/tracer.py
+++ b/core/sandbox/tracer.py
@@ -103,6 +103,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from . import audit_budget
+
 logger = logging.getLogger(__name__)
 
 # ----- ptrace request constants (see <sys/ptrace.h>) -----
@@ -143,12 +145,11 @@ _NEW_TRACEE_EVENTS = frozenset((
     _PTRACE_EVENT_FORK, _PTRACE_EVENT_VFORK, _PTRACE_EVENT_CLONE,
 ))
 
-# Per-record cap on JSONL writes from the tracer. Mirrors
-# MAX_DENIALS_PER_RUN in summary.py — protects against a chatty target
-# that would otherwise generate gigabytes of audit records. Once the
-# cap is hit, further events are silently dropped (with a one-time
-# warning to the tracer's stderr).
-_MAX_RECORDS_PER_RUN = 10000
+# Per-record cap moved to core.sandbox.audit_budget.AuditBudget so
+# the macOS seatbelt LogStreamer and Linux ptrace tracer share one
+# budget mechanism. See audit_budget.DEFAULT_GLOBAL_CAP for the
+# default ceiling and AuditBudget for the token-bucket / per-cat /
+# per-PID / sampling refinements.
 
 # JSONL file lives in the run dir. Same name as record_denial uses so
 # both writers append to the same aggregation target.
@@ -977,6 +978,31 @@ def _write_record(run_dir: Path, syscall_name: str, syscall_nr: int,
         return False
 
 
+def _write_record_dict(run_dir: Path, record: dict) -> bool:
+    """Append a pre-built record dict to the run's JSONL file.
+
+    Used for AuditBudget markers and the end-of-run summary —
+    structures that don't fit the syscall-shaped _write_record
+    signature. Same O_NOFOLLOW + O_APPEND atomicity as
+    _write_record and core.sandbox.summary.record_denial.
+    """
+    try:
+        line = json.dumps(record, ensure_ascii=True, default=str) + "\n"
+        jsonl_path = run_dir / _DENIALS_FILENAME
+        jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(
+            str(jsonl_path),
+            os.O_WRONLY | os.O_APPEND | os.O_CREAT | os.O_NOFOLLOW,
+            0o600,
+        )
+        with os.fdopen(fd, "a", encoding="utf-8") as f:
+            f.write(line)
+        return True
+    except OSError as e:
+        logger.debug(f"tracer: write_record_dict failed: {e}")
+        return False
+
+
 # ----- Event loop -----
 
 def _signal_ready(sync_fd: Optional[int]) -> None:
@@ -1062,8 +1088,21 @@ def trace(target_pid: int, run_dir: Path,
     _signal_ready(sync_fd)
 
     syscall_table = arch_info["syscall_table"]
-    record_count = 0
-    cap_warned = False
+    # Audit budget — shared with macOS seatbelt LogStreamer via
+    # core.sandbox.audit_budget. Token-bucket + per-category +
+    # per-PID sub-caps + 1-in-N post-cap sampling; markers and
+    # final summary appear in the JSONL alongside data records
+    # (see audit_budget.AuditBudget docstring). The budget is read
+    # from `audit_filter["audit_budget"]` (passed in via the
+    # filter-config JSON _spawn.py wrote at parent-side spawn time)
+    # because the tracer subprocess has its own fresh state module
+    # and can't inherit the parent's --audit-budget override
+    # through state._cli_sandbox_audit_budget directly.
+    from . import audit_budget as _audit_budget_mod
+    _budget_override = (
+        audit_filter.get("audit_budget") if audit_filter else None
+    )
+    budget = _audit_budget_mod.AuditBudget(global_cap=_budget_override)
 
     # Set of currently-traced PIDs. Starts with the original target;
     # grows when fork/vfork/clone events fire (kernel auto-attaches
@@ -1098,12 +1137,21 @@ def trace(target_pid: int, run_dir: Path,
             logger.error(f"tracer: waitpid failed: {e}")
             return 4
 
-        record_count, cap_warned = _handle_waitpid_event(
+        _handle_waitpid_event(
             wpid, status, traced, target_pid, arch_info,
-            run_dir, record_count, cap_warned,
+            run_dir, budget,
             audit_filter=audit_filter,
         )
 
+    # End-of-run summary record so the sandbox-summary aggregator
+    # has total/dropped counts even when the run didn't hit any cap.
+    try:
+        _write_record_dict(run_dir, budget.summary_record())
+    except OSError:
+        # Best-effort. Don't crash the tracer on a transient FS
+        # error during summary append.
+        logger.debug("tracer: summary record append failed",
+                     exc_info=True)
     return 0
 
 
@@ -1111,7 +1159,7 @@ def _handle_waitpid_event(
     wpid: int, status: int,
     traced: set, target_pid: int,
     arch_info: dict, run_dir: Path,
-    record_count: int, cap_warned: bool,
+    budget: "audit_budget.AuditBudget",
     *,
     audit_filter: Optional[dict] = None,
     # Injection points so tests can substitute synthetic helpers
@@ -1125,8 +1173,8 @@ def _handle_waitpid_event(
     write_record=None,
     resolve_path=None,
     decode_sockaddr=None,
-) -> tuple:
-    """Handle one waitpid event. Returns (new_record_count, new_cap_warned).
+) -> None:
+    """Handle one waitpid event.
 
     Mutates `traced` in place: removes exited PIDs, adds new tracees
     on FORK/VFORK/CLONE events. The wait loop calls this once per
@@ -1165,10 +1213,10 @@ def _handle_waitpid_event(
         # This tracee exited; remove from set. Loop ends when
         # `traced` is empty (all tracees gone).
         traced.discard(wpid)
-        return record_count, cap_warned
+        return
 
     if not os.WIFSTOPPED(status):
-        return record_count, cap_warned
+        return
 
     sig = os.WSTOPSIG(status)
     # Ptrace event codes are encoded in the upper 16 bits of status
@@ -1177,123 +1225,142 @@ def _handle_waitpid_event(
 
     if event == _PTRACE_EVENT_SECCOMP:
         # SECCOMP_RET_TRACE event: read syscall, decide whether to log.
-        if record_count < _MAX_RECORDS_PER_RUN:
-            regs = read_regs(wpid, arch_info)
-            if regs is not None:
-                nr, args = decode_syscall(regs, arch_info)
-                name = syscall_table.get(nr, f"unknown_{nr}")
+        # Budget enforcement is moved INSIDE this branch and runs
+        # AFTER syscall identification — we need the syscall name to
+        # evaluate per-category caps. The legacy fixed-cap approach
+        # has been replaced by core.sandbox.audit_budget.AuditBudget
+        # (token-bucket + per-category + per-PID + sampling).
+        regs = read_regs(wpid, arch_info)
+        if regs is not None:
+            nr, args = decode_syscall(regs, arch_info)
+            name = syscall_table.get(nr, f"unknown_{nr}")
 
-                # Default: log every event (audit-verbose / no filter).
-                # The filter logic below short-circuits to drop legitimate
-                # events when audit_filter is configured for filtered
-                # mode (i.e., the `audit` profile).
-                should_log = True
-                path = None
-                path_idx = _path_arg_index(name)
-                if path_idx is not None:
-                    path = read_tracee_string(wpid, args[path_idx])
+            # Default: log every event (audit-verbose / no filter).
+            # The filter logic below short-circuits to drop legitimate
+            # events when audit_filter is configured for filtered
+            # mode (i.e., the `audit` profile).
+            should_log = True
+            path = None
+            path_idx = _path_arg_index(name)
+            if path_idx is not None:
+                path = read_tracee_string(wpid, args[path_idx])
 
-                if audit_filter is not None and not audit_filter.get("verbose"):
-                    # Filtered mode: drop events that would have been
-                    # ALLOWED under enforcement. The signal then becomes
-                    # "what would have been blocked" — the operator's
-                    # actual question.
-                    if name in ("openat", "open", "openat2"):
-                        # Resolve path argument to absolute, check
-                        # against Landlock-equivalent allowlist.
-                        if path is not None:
-                            # openat / openat2 dirfd lives at args[0];
-                            # for open(), there is no dirfd, treat as
-                            # AT_FDCWD.
-                            dirfd = (args[0] if name in ("openat", "openat2")
-                                     else _AT_FDCWD)
-                            # Treat dirfd as signed — kernel passes
-                            # AT_FDCWD as -100 which arrives as a
-                            # very large unsigned in our regs.
-                            if dirfd > 0x7fffffffffffffff:
-                                dirfd = dirfd - (1 << 64)
-                            abs_path = resolve_path(wpid, path, dirfd)
-                            # Flag location differs by syscall:
-                            #   open(path, flags, mode)            → args[1]
-                            #   openat(dirfd, path, flags, mode)   → args[2]
-                            #   openat2(dirfd, path, &how, size)   → deref args[2]
-                            #     `struct open_how` { __u64 flags; __u64 mode;
-                            #                        __u64 resolve; }
-                            #     so flags = first 8 bytes of *args[2].
-                            if name == "openat2":
-                                # Best-effort struct read. If process_vm_readv
-                                # fails (bad pointer, stale memory), default
-                                # to write_intent=True so we don't silently
-                                # miss writes — over-reporting reads is
-                                # acceptable, missing writes is not.
-                                how_bytes = _read_tracee_bytes(wpid, args[2], 8)
-                                if how_bytes is not None and len(how_bytes) == 8:
-                                    import struct as _struct
-                                    flags = _struct.unpack("<Q", how_bytes)[0]
-                                else:
-                                    flags = _O_WRONLY  # safe default
+            if audit_filter is not None and not audit_filter.get("verbose"):
+                # Filtered mode: drop events that would have been
+                # ALLOWED under enforcement. The signal then becomes
+                # "what would have been blocked" — the operator's
+                # actual question.
+                if name in ("openat", "open", "openat2"):
+                    # Resolve path argument to absolute, check
+                    # against Landlock-equivalent allowlist.
+                    if path is not None:
+                        # openat / openat2 dirfd lives at args[0];
+                        # for open(), there is no dirfd, treat as
+                        # AT_FDCWD.
+                        dirfd = (args[0] if name in ("openat", "openat2")
+                                 else _AT_FDCWD)
+                        # Treat dirfd as signed — kernel passes
+                        # AT_FDCWD as -100 which arrives as a
+                        # very large unsigned in our regs.
+                        if dirfd > 0x7fffffffffffffff:
+                            dirfd = dirfd - (1 << 64)
+                        abs_path = resolve_path(wpid, path, dirfd)
+                        # Flag location differs by syscall:
+                        #   open(path, flags, mode)            → args[1]
+                        #   openat(dirfd, path, flags, mode)   → args[2]
+                        #   openat2(dirfd, path, &how, size)   → deref args[2]
+                        #     `struct open_how` { __u64 flags; __u64 mode;
+                        #                        __u64 resolve; }
+                        #     so flags = first 8 bytes of *args[2].
+                        if name == "openat2":
+                            # Best-effort struct read. If process_vm_readv
+                            # fails (bad pointer, stale memory), default
+                            # to write_intent=True so we don't silently
+                            # miss writes — over-reporting reads is
+                            # acceptable, missing writes is not.
+                            how_bytes = _read_tracee_bytes(wpid, args[2], 8)
+                            if how_bytes is not None and len(how_bytes) == 8:
+                                import struct as _struct
+                                flags = _struct.unpack("<Q", how_bytes)[0]
                             else:
-                                flags_idx = 2 if name == "openat" else 1
-                                flags = args[flags_idx]
-                            write_intent = _is_write_intent(flags)
-                            # When read_allowlist is None, Landlock is
-                            # in restrict_reads=False mode (allows all
-                            # reads). Reads can never be would-blocked,
-                            # so we drop them unconditionally and only
-                            # filter writes against writable_paths.
-                            if (not write_intent
-                                    and audit_filter.get("read_allowlist") is None):
+                                flags = _O_WRONLY  # safe default
+                        else:
+                            flags_idx = 2 if name == "openat" else 1
+                            flags = args[flags_idx]
+                        write_intent = _is_write_intent(flags)
+                        # When read_allowlist is None, Landlock is
+                        # in restrict_reads=False mode (allows all
+                        # reads). Reads can never be would-blocked,
+                        # so we drop them unconditionally and only
+                        # filter writes against writable_paths.
+                        if (not write_intent
+                                and audit_filter.get("read_allowlist") is None):
+                            should_log = False
+                        else:
+                            # .get with [] default — defensive
+                            # against malformed/partial configs.
+                            # Empty list → _path_in_allowlist
+                            # always False → record kept.
+                            allowlist = (
+                                audit_filter.get("writable_paths") or []
+                                if write_intent
+                                else audit_filter.get("read_allowlist") or []
+                            )
+                            if _path_in_allowlist(abs_path, allowlist):
                                 should_log = False
                             else:
-                                # .get with [] default — defensive
-                                # against malformed/partial configs.
-                                # Empty list → _path_in_allowlist
-                                # always False → record kept.
-                                allowlist = (
-                                    audit_filter.get("writable_paths") or []
-                                    if write_intent
-                                    else audit_filter.get("read_allowlist") or []
-                                )
-                                if _path_in_allowlist(abs_path, allowlist):
-                                    should_log = False
-                                else:
-                                    # Useful surface form: replace
-                                    # `path` with the resolved
-                                    # absolute (relative paths in
-                                    # the raw record are ambiguous
-                                    # to operators).
-                                    path = abs_path
-                    elif name == "connect":
-                        # Decode sockaddr at args[1], length at args[2].
-                        # If destination port is in the allowed set,
-                        # drop. Otherwise log with decoded ip:port in
-                        # the path field for operator readability.
-                        sock = decode_sockaddr(wpid, args[1], args[2])
-                        if sock is not None:
-                            family, port, ip = sock
-                            allowed_ports = audit_filter.get(
-                                "allowed_tcp_ports", [])
-                            if port in allowed_ports:
-                                should_log = False
-                            else:
-                                path = f"{ip}:{port} ({family})"
-                    # For seccomp blocklist syscalls (ptrace, bpf, etc.)
-                    # we don't filter — they're rare and ALWAYS
-                    # would-be-blocked under enforcement, so the audit
-                    # signal is exactly what the operator wants.
+                                # Useful surface form: replace
+                                # `path` with the resolved
+                                # absolute (relative paths in
+                                # the raw record are ambiguous
+                                # to operators).
+                                path = abs_path
+                elif name == "connect":
+                    # Decode sockaddr at args[1], length at args[2].
+                    # If destination port is in the allowed set,
+                    # drop. Otherwise log with decoded ip:port in
+                    # the path field for operator readability.
+                    sock = decode_sockaddr(wpid, args[1], args[2])
+                    if sock is not None:
+                        family, port, ip = sock
+                        allowed_ports = audit_filter.get(
+                            "allowed_tcp_ports", [])
+                        if port in allowed_ports:
+                            should_log = False
+                        else:
+                            path = f"{ip}:{port} ({family})"
+                # For seccomp blocklist syscalls (ptrace, bpf, etc.)
+                # we don't filter — they're rare and ALWAYS
+                # would-be-blocked under enforcement, so the audit
+                # signal is exactly what the operator wants.
 
-                if should_log and write_record(
-                        run_dir, name, nr, args, wpid, path=path):
-                    record_count += 1
-        elif not cap_warned:
-            os.write(2, (
-                f"RAPTOR tracer: hit per-run record cap "
-                f"({_MAX_RECORDS_PER_RUN}); dropping further events\n"
-            ).encode("ascii", errors="replace"))
-            cap_warned = True
+            if should_log:
+                decision, marker = budget.evaluate(name, wpid)
+                if marker is not None:
+                    _write_record_dict(run_dir, marker)
+                if decision == audit_budget.KEEP:
+                    write_record(run_dir, name, nr, args, wpid,
+                                 path=path)
+                # First-time global-cap exhaustion: emit a one-time
+                # stderr line. Restores the operator-visible cue
+                # the legacy tracer printed ("hit per-run record
+                # cap ..."). Per-category and per-PID drops show
+                # up as in-band JSONL markers AND in audit_summary
+                # at end-of-run, so they don't need stderr noise;
+                # only the global cap (which truncates audit
+                # entirely) gets the stderr ping.
+                if budget.pop_global_cap_notice():
+                    os.write(2, (
+                        f"RAPTOR tracer: audit-record global cap "
+                        f"({budget.global_cap}) reached; further "
+                        f"events dropped (sub-caps still apply; "
+                        f"sampling continues for high-volume "
+                        f"categories). End-of-run audit_summary "
+                        f"record has totals.\n"
+                    ).encode("ascii", errors="replace"))
         # Continue regardless — audit mode allows the syscall.
         ptrace_cont(wpid, 0)
-        return record_count, cap_warned
+        return
 
     if event in _NEW_TRACEE_EVENTS:
         # fork/vfork/clone — the tracee created a new process or
@@ -1306,12 +1373,12 @@ def _handle_waitpid_event(
         if new_pid is not None and new_pid > 0:
             traced.add(new_pid)
         ptrace_cont(wpid, 0)
-        return record_count, cap_warned
+        return
 
     if event == _PTRACE_EVENT_EXIT:
         # Tracee is about to exit; let it.
         ptrace_cont(wpid, 0)
-        return record_count, cap_warned
+        return
 
     # SIGSTOP from a newly-auto-attached tracee: kernel paused the
     # new child as part of TRACEFORK/CLONE delivery. Resume it
@@ -1330,7 +1397,7 @@ def _handle_waitpid_event(
         ptrace_cont(wpid, 0)
     else:
         ptrace_cont(wpid, sig if sig != signal.SIGTRAP else 0)
-    return record_count, cap_warned
+    return
 
 
 def _cli_main(argv: Optional[list] = None) -> int:

--- a/core/startup/init.py
+++ b/core/startup/init.py
@@ -304,53 +304,70 @@ def check_env(unavailable_features: set) -> tuple[list, list]:
     if not os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
         warnings.append("/oss-forensics unavailable — BigQuery not configured")
 
-    # Subprocess sandboxing. Namespaces and Landlock are independent — a
-    # system without user namespaces (e.g. restricted containers) can
-    # still have Landlock, which protects the filesystem side. Report
-    # whatever is actually available rather than an all-or-nothing flag.
+    # Subprocess sandboxing. Layers reported per-platform:
+    #   Linux: net + mount + landlock + seccomp (any combination — see
+    #     core/sandbox/__init__.py module docstring)
+    #   macOS: seatbelt (single integrated layer via sandbox-exec / SBPL)
+    # Probing is a one-shot subprocess (cached); we report whatever is
+    # actually available rather than an all-or-nothing flag.
     try:
-        from core.sandbox import (
-            check_net_available, check_mount_available, check_landlock_available,
-            check_seccomp_available,
-        )
-        net_ok = check_net_available()
-        mount_ok = check_mount_available() if net_ok else False
-        landlock_ok = check_landlock_available()
-        seccomp_ok = check_seccomp_available()
-        features = []
-        if net_ok:
-            features.append("net")
-        if mount_ok:
-            features.append("mount")
-        if landlock_ok:
-            features.append("landlock")
-        if seccomp_ok:
-            features.append("seccomp")
-        if features:
-            parts.append(f"sandbox ✓ ({'+'.join(features)})")
-            # Partial-sandbox warnings — name what's missing so users can
-            # decide whether the gap matters for their use case. (The
-            # banner's feature list already shows what IS active.)
-            if not net_ok:
+        if sys.platform == "darwin":
+            from core.sandbox import check_seatbelt_available
+            seatbelt_ok = check_seatbelt_available()
+            if seatbelt_ok:
+                parts.append("sandbox ✓ (seatbelt)")
+            else:
+                parts.append("sandbox ✗")
                 warnings.append(
-                    "Sandbox network isolation missing — user namespaces "
-                    "not supported on this kernel. Subprocesses can still "
-                    "reach the network unless the caller passes "
-                    "allowed_tcp_ports to sandbox()."
-                )
-            elif not landlock_ok:
-                warnings.append(
-                    "Sandbox Landlock filesystem restriction missing — "
-                    "kernel does not support Landlock (needs 5.13+). "
-                    "Network isolation still active; writes outside the "
-                    "output dir are NOT restricted."
+                    "Subprocess sandboxing unavailable — sandbox-exec "
+                    "smoke test failed. Verify Command Line Tools are "
+                    "installed and "
+                    "`sandbox-exec -p '(version 1)(allow default)' "
+                    "/usr/bin/true` succeeds on this host."
                 )
         else:
-            parts.append("sandbox ✗")
-            warnings.append(
-                "Subprocess sandboxing unavailable — neither user "
-                "namespaces nor Landlock are supported on this kernel"
+            from core.sandbox import (
+                check_net_available, check_mount_available,
+                check_landlock_available, check_seccomp_available,
             )
+            net_ok = check_net_available()
+            mount_ok = check_mount_available() if net_ok else False
+            landlock_ok = check_landlock_available()
+            seccomp_ok = check_seccomp_available()
+            features = []
+            if net_ok:
+                features.append("net")
+            if mount_ok:
+                features.append("mount")
+            if landlock_ok:
+                features.append("landlock")
+            if seccomp_ok:
+                features.append("seccomp")
+            if features:
+                parts.append(f"sandbox ✓ ({'+'.join(features)})")
+                # Partial-sandbox warnings — name what's missing so users
+                # can decide whether the gap matters for their use case.
+                # (The banner's feature list already shows what IS active.)
+                if not net_ok:
+                    warnings.append(
+                        "Sandbox network isolation missing — user "
+                        "namespaces not supported on this kernel. "
+                        "Subprocesses can still reach the network unless "
+                        "the caller passes allowed_tcp_ports to sandbox()."
+                    )
+                elif not landlock_ok:
+                    warnings.append(
+                        "Sandbox Landlock filesystem restriction missing "
+                        "— kernel does not support Landlock (needs "
+                        "5.13+). Network isolation still active; writes "
+                        "outside the output dir are NOT restricted."
+                    )
+            else:
+                parts.append("sandbox ✗")
+                warnings.append(
+                    "Subprocess sandboxing unavailable — neither user "
+                    "namespaces nor Landlock are supported on this kernel"
+                )
     except Exception:
         # Never let a sandbox-probe bug kill startup, but leave a trail
         # at DEBUG so the bug is findable instead of invisible.

--- a/core/startup/tests/test_check_env_macos.py
+++ b/core/startup/tests/test_check_env_macos.py
@@ -1,0 +1,73 @@
+"""Tests for the macOS branch of core.startup.init.check_env().
+
+Verifies that the startup banner correctly probes the seatbelt
+backend on Darwin and produces an actionable warning when
+sandbox-exec is unavailable. Cross-platform — patches sys.platform
+so it runs on the Linux CI dev box too.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest import mock
+
+import pytest
+
+from core.startup import init as startup_init
+
+
+@pytest.fixture
+def reset_seatbelt_cache():
+    """check_seatbelt_available() caches its result process-wide;
+    tests here mock different return values so we must clear the
+    cache to avoid one test's mock leaking into another."""
+    from core.sandbox import state
+    state._seatbelt_available_cache = None
+    yield
+    state._seatbelt_available_cache = None
+
+
+def test_check_env_macos_seatbelt_available(reset_seatbelt_cache):
+    """When seatbelt smoke test passes, the banner shows
+    'sandbox ✓ (seatbelt)' and emits no sandbox warning."""
+    with mock.patch.object(sys, "platform", "darwin"), \
+         mock.patch("core.sandbox.check_seatbelt_available",
+                     return_value=True):
+        parts, warnings = startup_init.check_env(set())
+
+    sandbox_parts = [p for p in parts if "sandbox" in p]
+    assert sandbox_parts == ["sandbox ✓ (seatbelt)"]
+    sandbox_warnings = [w for w in warnings if "sandbox" in w.lower()]
+    assert sandbox_warnings == []
+
+
+def test_check_env_macos_seatbelt_unavailable(reset_seatbelt_cache):
+    """When seatbelt smoke test fails, the banner shows 'sandbox ✗'
+    and emits a macOS-specific warning naming the diagnostic
+    command operators can run."""
+    with mock.patch.object(sys, "platform", "darwin"), \
+         mock.patch("core.sandbox.check_seatbelt_available",
+                     return_value=False):
+        parts, warnings = startup_init.check_env(set())
+
+    sandbox_parts = [p for p in parts if "sandbox" in p]
+    assert sandbox_parts == ["sandbox ✗"]
+    sandbox_warnings = [w for w in warnings if "sandbox" in w.lower()]
+    assert any("sandbox-exec" in w for w in sandbox_warnings), (
+        f"expected sandbox-exec diagnostic, got {sandbox_warnings!r}"
+    )
+
+
+def test_check_env_linux_unchanged(reset_seatbelt_cache):
+    """Linux branch must remain its existing behaviour — never
+    invoke check_seatbelt_available, only the Linux-layer probes.
+    Regression catch for accidentally calling the macOS branch on
+    Linux."""
+    if sys.platform == "darwin":
+        pytest.skip("Linux-only sanity check")
+    with mock.patch("core.sandbox.check_seatbelt_available") as seatbelt_probe:
+        startup_init.check_env(set())
+    # Linux branch must NOT touch the seatbelt probe.
+    assert not seatbelt_probe.called, (
+        "Linux check_env unexpectedly called check_seatbelt_available"
+    )

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -220,16 +220,18 @@ not wall-clock time.
 Use audit mode for diagnosis, not routine work. Drop `--audit` for
 production scans (the profile alone runs at full speed).
 
-**Disk usage cap.** Both filtered and verbose modes are capped at
-`_MAX_RECORDS_PER_RUN = 10000` records per run (mirrors the
-non-tracer `record_denial` cap in `core/sandbox/summary.py`). Per
-record is bounded by `MAX_CMD_LEN = 2048` bytes after truncation —
-upper bound on the JSONL is ≈ 20 MB. On hitting the cap, the tracer
-emits `RAPTOR tracer: hit per-run record cap (10000); dropping
-further events` to stderr ONCE, then silently drops further events.
-This protects `/tmp` from runaway fuzz workloads but means a long
-verbose run loses tail-end signal — bias towards filtered mode for
-multi-hour workloads.
+**Disk usage cap.** Both filtered and verbose modes are routed
+through `core.sandbox.audit_budget.AuditBudget` (default global
+cap 10000, mirrors `core/sandbox/summary.py`'s `MAX_DENIALS_PER_RUN`).
+Per record is bounded by `MAX_CMD_LEN = 2048` bytes after
+truncation — upper bound on the JSONL is ≈ 20 MB. The budget also
+enforces per-category sub-caps (file-write 3000, file-read-data
+2000, etc.) and per-PID caps (5000) so one chatty source can't
+squeeze out the others. Operators see `category_budget_exceeded`
+and `pid_budget_exceeded` markers in the JSONL when caps fire, and
+an `audit_summary` record at end-of-run with totals. Override the
+global cap via `--audit-budget=N` (sub-caps scale proportionally).
+See the "Audit budget" section below for the full mechanism.
 
 **Anti-debug surface (acknowledged, acceptable).** Code in an
 audited sandbox can detect tracing via `/proc/self/status`'s
@@ -747,21 +749,159 @@ pins the bit values against `/usr/include/linux/landlock.h`.
 
 ```
 core/sandbox/
-├── __init__.py     # public API + threat-model docstring
-├── context.py      # sandbox(), run(), run_trusted(), run_untrusted()
-├── profiles.py     # named profile definitions
-├── cli.py          # --sandbox / --no-sandbox argparse integration
-├── probes.py       # per-layer availability detection
-├── _spawn.py       # fork+newuidmap+pivot_root+Landlock+seccomp spawn path
-├── mount_ns.py     # ctypes mount() / pivot_root() for the _spawn path
-├── mount.py        # legacy shell-script mount builder (kept for tests)
-├── landlock.py     # Landlock ABI + rule construction + self-test
-├── seccomp.py      # seccomp-bpf syscall filters
-├── preexec.py      # preexec_fn composition (PR_SET_NO_NEW_PRIVS etc.)
-├── proxy.py        # HTTPS-CONNECT egress proxy
-├── observe.py      # sandbox_info attachment, SIGSYS decoding
-└── state.py        # singletons and per-process cached state
+├── __init__.py        # public API + threat-model docstring
+├── context.py         # sandbox(), run(), run_trusted(), run_untrusted()
+├── profiles.py        # named profile definitions
+├── cli.py             # --sandbox / --no-sandbox argparse integration
+├── probes.py          # per-layer availability detection
+├── _spawn.py          # Linux: fork+newuidmap+pivot_root+Landlock+seccomp
+├── mount_ns.py        # Linux: ctypes mount() / pivot_root() for _spawn
+├── mount.py           # Linux: legacy shell-script mount builder
+├── landlock.py        # Linux: Landlock ABI + rule construction
+├── seccomp.py         # Linux: seccomp-bpf syscall filters
+├── preexec.py         # POSIX: preexec_fn composition (rlimits)
+├── proxy.py           # cross-platform: HTTPS-CONNECT egress proxy
+├── observe.py         # cross-platform: sandbox_info attachment
+├── state.py           # cross-platform: singletons + cached state
+├── _macos_spawn.py    # macOS: sandbox-exec wrapper
+├── seatbelt.py        # macOS: SBPL profile generator
+└── seatbelt_audit.py  # macOS: `log stream` capture + JSONL append
 ```
 
 See the module docstring in `core/sandbox/__init__.py` for the current
 threat-model statement — what the sandbox does and does not protect against.
+
+## macOS backend
+
+On Darwin, the sandbox routes through `core.sandbox._macos_spawn`
+instead of the Linux `_spawn.run_sandboxed()`. The kwarg surface is
+identical — callers don't need to switch on platform — but the
+underlying mechanism is `sandbox-exec(1)` + the kernel `Sandbox.kext`
+applying an SBPL (Sandbox Profile Language) profile.
+
+### What works the same
+
+- `sandbox()`, `run()`, `run_trusted()`, `run_untrusted()` — same
+  context-manager + helper surface.
+- `block_network=True`, `allowed_tcp_ports=`, `use_egress_proxy=`,
+  `proxy_hosts=` — translated to SBPL `(deny network*)` / `(allow
+  network-outbound (remote tcp ...))` / loopback proxy port allow.
+- `target=`, `output=`, `writable_paths=` — translated to SBPL
+  `(deny file-write* (require-not (subpath ...)))`. Paths are
+  realpath-canonicalised because SBPL's `(subpath ...)` matches the
+  canonical resolved path (macOS has pervasive symlinks like `/var
+  → /private/var`).
+- `restrict_reads=True`, `readable_paths=` — translated to SBPL
+  `(deny file-read* (require-not ...))` with the same system-dirs
+  allowlist (`/usr`, `/System`, `/Library/Frameworks`, `/private/etc`,
+  `/dev`).
+- `fake_home=True` — env-side; sets `HOME` and `XDG_*_HOME` to the
+  per-sandbox `{output}/.home/`. Same env-mutation as Linux.
+- `audit=True` / `--audit` CLI flag — replaces the file-write deny
+  with `(allow file-write* (with report))`. The kernel emits a
+  Sandbox.kext log entry for each write; `seatbelt_audit.LogStreamer`
+  reads `log stream` ndjson output, parses with the spike-validated
+  regex, and appends records to `<run>/.sandbox-denials.jsonl`
+  matching the Linux ptrace-tracer schema. `summarize_and_write`
+  works unchanged.
+- `limits=` — POSIX setrlimit via the same preexec_fn pattern.
+- Sandbox-summary aggregation (`summarize_and_write`,
+  `record_audit_degraded`, `proxy-events.jsonl`) — identical
+  cross-platform.
+
+### What's different (platform limits)
+
+| Linux feature                | macOS status   | Why / mitigation                                               |
+| ---------------------------- | -------------- | -------------------------------------------------------------- |
+| PID namespace                | ⚠ absent       | No unprivileged equivalent on macOS. Host PIDs visible.        |
+| Mount namespace + pivot_root | ⚠ absent       | `restrict_reads=True` is the substitute (read-deny via SBPL).  |
+| `RLIMIT_NPROC` per-namespace | weaker         | macOS rlimit is per-UID host-wide. Lower the limit on Darwin.  |
+| `seccomp_profile=full`       | partial        | Mapped to `(deny process-info* (target others))` — coarse.     |
+| `audit_verbose` (per-syscall)| partial        | SBPL `(allow X (with report))` for an extended category set    |
+|                              |                | (file-read*, mach-lookup, process-exec*, process-fork, signal, |
+|                              |                | iokit-open, sysctl-read, process-info*). Coarser than seccomp's|
+|                              |                | per-syscall trace and no argv, but operationally similar.      |
+| `--audit-budget=N`           | full           | Same `audit_budget.AuditBudget` module on both backends —      |
+|                              |                | token-bucket + per-category + per-PID + 1-in-N sampling.       |
+| `map_root` (UID re-mapping)  | ⚠ absent       | macOS sandbox-exec keeps caller UID.                           |
+| `--sandbox debug` (lldb)     | full           | Same intent as Linux: full enforcement EXCEPT keep debugger    |
+|                              |                | introspection unrestricted. macOS skips the process-info-*     |
+|                              |                | denies under debug so lldb / sample / dtrace can attach.       |
+
+### macOS-specific operator notes
+
+- **First-run cost**: `check_seatbelt_available()` invokes
+  `sandbox-exec` with a minimal `(allow default)` profile against
+  `/usr/bin/true` once per process to verify the kernel sandbox is
+  functional. ~50ms.
+- **No `(deny default)`**: pure deny-default profiles SIGABRT modern
+  macOS binaries before dyld can load libSystem (spike-validated).
+  We always use `(allow default)` + targeted denies.
+- **Default exception list**: `/private/tmp` is always added to the
+  write-allowlist exception so standard `tempfile.mkstemp()` works.
+  This matches Linux's default `/tmp` writable.
+- **Audit log latency**: kernel → log subsystem → `log stream`
+  pipeline has ~tens-of-ms latency for steady-state and ~1.5s for a
+  cold first event. `LogStreamer.stop(drain_timeout=1.5)` accounts
+  for this; very short workloads may drop the last record.
+
+### Audit budget (cross-platform)
+
+Both backends route audit-record decisions through one shared module
+(`core.sandbox.audit_budget.AuditBudget`). The budget composes four
+mechanisms:
+
+1. **Global cap** — `--audit-budget=N` (default 10000). Hard ceiling
+   on records per run.
+2. **Per-category sub-cap** — file-read-metadata (500), file-write
+   (3000), mach-lookup (1000), etc. Stops one chatty category from
+   squeezing important low-volume categories out of the global pool.
+3. **Per-PID sub-cap** — default 5000. One spamming subprocess can't
+   dominate the JSONL.
+4. **Token-bucket refill** — burst capacity = cap, sustained rate =
+   refill rate. Long-running workloads at low steady-state never trip.
+5. **1-in-N post-cap sampling** — high-volume categories
+   (file-read-metadata, file-read-data, process-info, iokit-open,
+   sysctl-read) keep emitting a trickle even after their bucket
+   empties so operators see "still happening".
+
+Markers and a final summary record appear in the JSONL alongside
+data records — operators see `category_budget_exceeded`,
+`pid_budget_exceeded`, `category_budget_exceeded_sampling`, and
+`audit_summary` types in the same file.
+
+CLI:
+
+```bash
+raptor scan target/  --sandbox full --audit                    # default 10000
+raptor scan target/  --sandbox full --audit --audit-budget 100 # quick diag
+raptor scan target/  --sandbox full --audit --audit-verbose --audit-budget 50000  # long run
+```
+
+The defaults in `core.sandbox.audit_budget.DEFAULT_*` are tuned as
+starting heuristics for typical `/scan` and `/agentic` workloads.
+After first deployment, measure real workload distributions and
+re-tune if entire categories disappear into the dropped bucket
+(too tight) or the JSONL still bloats (too lax).
+
+### Backend selection
+
+`core/sandbox/context.py` dispatches at the spawn-eligibility check:
+
+```
+if sys.platform == "darwin":
+    use_seatbelt = use_sandbox and check_seatbelt_available()
+else:
+    use_mount = use_sandbox and ... and check_mount_available()
+```
+
+`spawn_eligible` triggers either backend; the post-run aggregation
+(proxy events, `_check_blocked` engagement booleans, sandbox-summary
+JSONL) is platform-independent.
+
+### Spike scripts
+
+Phase 0 design spikes are in `scripts/macos_sandbox_spike{1,2,3,4}.py`
+— each validates one assumption used by `seatbelt.py` /
+`seatbelt_audit.py`. Re-run them on a new macOS major version to
+confirm the SBPL idioms haven't drifted.


### PR DESCRIPTION
sandbox-exec / Seatbelt Profile Language backend that gives macOS users parity with the Linux Landlock+seccomp+mount-ns sandbox (subject to inherent platform limits documented in docs/sandbox.md). Includes audit-mode log-stream capture, audit_verbose extended SBPL categories, --audit-budget CLI override shared by both backends, and --sandbox debug support for lldb/dtrace.