### PR TITLE
feat: multi-model analysis and correlation

### DIFF
--- a/.claude/commands/agentic.md
+++ b/.claude/commands/agentic.md
@@ -1,5 +1,5 @@
 ---
-description: Full autonomous security workflow — scan, dedup, prep, analyse, consensus, exploit, patch, group
+description: Full autonomous security workflow — scan, dedup, prep, analyse, consensus, judge, exploit, patch, group
 ---
 
 # /agentic - RAPTOR Full Autonomous Workflow
@@ -10,10 +10,11 @@ description: Full autonomous security workflow — scan, dedup, prep, analyse, c
 3. Prep findings (read code, extract dataflow)
 4. **Validate + analyse** each finding (exploitation-validator methodology, Stages A-D)
 5. **Self-review**: catch contradictions, retry low confidence (Stage F)
-6. **Consensus**: multi-model second opinion (if configured)
-7. **Generate exploit PoCs** for exploitable findings
-8. **Generate secure patches** for confirmed vulnerabilities
-9. **Cross-finding analysis** (structural grouping, shared root causes)
+6. **Consensus**: multi-model second opinion (if `--consensus`)
+7. **Judge**: non-blind review of primary reasoning (if `--judge`)
+8. **Generate exploit PoCs** for exploitable findings
+9. **Generate secure patches** for confirmed vulnerabilities
+10. **Cross-finding analysis** (structural grouping, shared root causes)
 
 Nothing will be applied to your code - only generated in the out/ directory.
 
@@ -51,8 +52,9 @@ Findings are dispatched for parallel analysis via one of two paths:
 - **External LLM configured**: dispatches via `generate_structured()` API calls
 - **Both available**: uses external LLM, falls back to Claude Code if it fails
 
-Model roles determine which model analyses (analysis), writes code (code), and
-provides second opinions (consensus).
+Model roles determine which model analyses (analysis), writes code (code),
+provides second opinions (consensus), and reviews reasoning (judge).
+See the "Multi-model analysis" section below.
 
 If **neither** is available, the pipeline produces prep-only output. In that case,
 **YOU (Claude Code) are the LLM** — the user may ask you to analyse the findings
@@ -71,13 +73,41 @@ finding's analysis prompt.
 The dispatch pipeline runs these tasks in sequence:
 
 1. **AnalysisTask** — Stages A-D per finding (validation + analysis in one call)
-2. **RetryTask** — Stage F: self-consistency check, retry contradictions + low confidence
-3. **ConsensusTask** — second model votes on true positives (if configured)
-4. **ExploitTask** — PoCs for final-verdict exploitable findings
-5. **PatchTask** — secure fixes for exploitable findings
-6. **GroupAnalysisTask** — cross-finding patterns (shared root cause, attack chaining)
+2. **CrossFamilyCheckTask** — re-check suspicious responses via a different model family
+3. **RetryTask** — Stage F: self-consistency check, retry contradictions + low confidence
+4. **ConsensusTask** — blind second model votes on true positives (if `--consensus`)
+5. **JudgeTask** — non-blind review of primary reasoning (if `--judge`)
+6. **Correlation** — multi-model agreement matrix + confidence signals (if 2+ `--model`)
+7. **ExploitTask** — PoCs for final-verdict exploitable findings
+8. **PatchTask** — secure fixes for exploitable findings
+9. **GroupAnalysisTask** — cross-finding patterns (shared root cause, attack chaining)
 
 Cost tracking is real-time with adaptive budget cutoff.
+
+## Multi-model analysis
+
+By default, the primary model is auto-detected from `~/.config/raptor/models.json` or API key env vars (GEMINI_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY). Use `--model` to override.
+
+`--model` is repeatable. Multiple models each independently analyse every finding (Stages A-D), then results are correlated — agreement matrix, confidence signals, clusters, unique insights. With 3+ analysis models, `--consensus` is auto-skipped (redundant).
+
+| Flag | Role | What it does |
+|------|------|-------------|
+| `--model MODEL` (repeatable) | Analysis | Each model independently analyses every finding. Multiple = multi-model correlation. |
+| `--consensus MODEL` | Blind second opinion | Re-analyses each finding independently (doesn't see the primary verdict). Majority vote decides the final ruling. Auto-skipped with 3+ `--model`. |
+| `--judge MODEL` | Non-blind review | Sees the primary analysis reasoning and critiques it. Flags missed attack paths, flawed logic, or inconsistent verdicts. |
+
+```
+# Single model
+/agentic --model gemini-2.5-pro
+
+# Multi-model — each analyses independently, results correlated
+/agentic --model gemini-2.5-pro --model gpt-5 --model claude-opus-4-6
+
+# Single model + consensus + judge
+/agentic --model gemini-2.5-pro --consensus gpt-5.4 --judge claude-opus-4-6
+```
+
+Roles can also be set permanently in `models.json` instead of CLI flags.
 
 ## Report modes
 
@@ -102,8 +132,8 @@ read the code itself via the Read tool.
 
 **`"mode": "orchestrated"`** — Parallel analysis via external LLM or Claude Code
 sub-agents. Results include per-finding `analysed_by` (which model), `cost_usd`,
-`duration_seconds`, plus `cross_finding_groups` and optional `consensus` data.
-Present the results to the user.
+`duration_seconds`, plus `cross_finding_groups` and optional `consensus`,
+`judge` metadata. Present the results to the user.
 
 In all modes, findings are in the `results` array of the report. Orchestrated
 and full mode findings include `is_exploitable`, `reasoning`, `exploit_code`, and

--- a/.claude/commands/analyze.md
+++ b/.claude/commands/analyze.md
@@ -10,4 +10,21 @@ Execute: `python3 raptor.py analyze --repo <path> --sarif <sarif-file>`
 
 Use when you already have SARIF findings and want LLM analysis.
 
+## Multi-model support
+
+The same `--model`, `--consensus`, and `--judge` flags from `/agentic`
+work here. When any role flag is provided, `/analyze` preps findings
+then dispatches them through the parallel orchestrator:
+
+```
+# Analyze with a specific model
+python3 raptor.py analyze --repo /path --sarif findings.sarif --model gemini-2.5-pro
+
+# Add consensus + judge
+python3 raptor.py analyze --repo /path --sarif findings.sarif \
+  --model gemini-2.5-pro --consensus claude-opus-4-6 --judge gpt-5.4
+```
+
+Without role flags, `/analyze` runs the sequential single-model path as before.
+
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ VERY IMPORTANT: follow these steps in order.
 
 **Coverage:** When asked about coverage, run `libexec/raptor-coverage-summary` (no args = active project). Use `--detailed` for per-file table, `--gaps` for unreviewed functions. See `.claude/skills/coverage.md` for mark/unmark and the full API.
 
-**Note:** `/agentic` runs scan → dedup → prep → analysis (with validation methodology). Use `--sequential` to bypass parallel orchestration. Use `--understand` to pre-map the codebase before scanning, and `--validate` to run the full validation pipeline on exploitable findings afterwards. Both flags are opt-in.
+**Note:** `/agentic` runs scan → dedup → prep → analysis (with validation methodology). Use `--sequential` to bypass parallel orchestration. Use `--understand` to pre-map the codebase before scanning, and `--validate` to run the full validation pipeline on exploitable findings afterwards. Both flags are opt-in. Multi-model: `--model` is repeatable — multiple models each independently analyse every finding, then results are correlated; `--consensus` and `--judge` add optional review models.
 /crash-analysis - Autonomous crash root-cause analysis (see below)
 /oss-forensics - GitHub forensic investigation (see below)
 /create-skill - Save approaches (alpha)
@@ -45,6 +45,7 @@ Projects are opt-in named workspaces that corral analysis runs into a shared dir
 /project findings              # shows merged findings across runs
 /project coverage              # shows tool coverage summary
 /project report                # merged view across all runs
+/project correlate             # cross-run finding correlation
 /project clean --keep 3        # delete old runs
 /project none                  # clear active project
 ```

--- a/core/llm/config.py
+++ b/core/llm/config.py
@@ -554,7 +554,7 @@ def _get_default_fallback_models() -> List['ModelConfig']:
 # Model role resolution
 # ---------------------------------------------------------------------------
 
-VALID_ROLES = {"analysis", "code", "consensus", "fallback"}
+VALID_ROLES = {"analysis", "code", "consensus", "fallback", "judge"}
 
 
 def resolve_model_roles(
@@ -597,6 +597,7 @@ def resolve_model_roles(
             "analysis_model": all_models[0] if all_models else None,
             "code_model": all_models[0] if all_models else None,
             "consensus_models": [],
+            "judge_models": [],
             "fallback_models": all_models[1:] if len(all_models) > 1 else [],
         }
 
@@ -607,6 +608,7 @@ def resolve_model_roles(
     analysis = [m for m in all_models if m.role == "analysis"]
     code = [m for m in all_models if m.role == "code"]
     consensus = [m for m in all_models if m.role == "consensus"]
+    judge = [m for m in all_models if m.role == "judge"]
     fallbacks = [m for m in all_models if m.role == "fallback" or m.role is None]
 
     analysis_model = analysis[0] if analysis else (all_models[0] if all_models else None)
@@ -614,8 +616,10 @@ def resolve_model_roles(
 
     return {
         "analysis_model": analysis_model,
+        "analysis_models": analysis if analysis else ([all_models[0]] if all_models else []),
         "code_model": code_model,
         "consensus_models": consensus,
+        "judge_models": judge,
         "fallback_models": fallbacks,
     }
 
@@ -639,16 +643,18 @@ def _validate_model_roles(models: List['ModelConfig']) -> None:
     has_code = code_count > 0
     only_fallback = all(r == "fallback" for r in roles) if roles else False
 
+    has_judge = "judge" in roles
+
     if has_consensus and not has_analysis:
         raise ConfigError("Consensus models configured without an analysis model")
+
+    if has_judge and not has_analysis:
+        raise ConfigError("Judge models configured without an analysis model")
 
     if has_code and not has_analysis:
         raise ConfigError("Code model configured without an analysis model")
 
-    if analysis_count > 1:
-        raise ConfigError(
-            "Multiple models with role 'analysis'. Use 'consensus' for second opinions"
-        )
+    # Multiple analysis models is valid (multi-model mode)
 
     if code_count > 1:
         raise ConfigError(
@@ -661,17 +667,22 @@ def _validate_model_roles(models: List['ModelConfig']) -> None:
             "Set role to 'analysis' on at least one model."
         )
 
-    # Check for same model with two roles (by model_name + provider)
-    seen = {}
+    # Check for same model with two *incompatible* roles.
+    # analysis+consensus is the conflict (use consensus role instead).
+    # Same model for consensus+judge is fine — distinct tasks.
+    _CONFLICTING_PAIRS = {frozenset({"analysis", "consensus"})}
+    seen: dict[tuple[str, str], set[str]] = {}
     for m in models:
         if m.role:
             key = (m.provider, m.model_name)
-            if key in seen and seen[key] != m.role:
+            seen.setdefault(key, set()).add(m.role)
+    for key, model_roles in seen.items():
+        for pair in _CONFLICTING_PAIRS:
+            if pair <= model_roles:
                 raise ConfigError(
-                    f"Model {m.model_name} ({m.provider}) has conflicting roles: "
-                    f"'{seen[key]}' and '{m.role}'"
+                    f"Model {key[1]} ({key[0]}) has conflicting roles: "
+                    f"{sorted(pair)}"
                 )
-            seen[key] = m.role
 
 
 # ---------------------------------------------------------------------------

--- a/core/llm/tests/test_model_roles.py
+++ b/core/llm/tests/test_model_roles.py
@@ -80,11 +80,12 @@ class TestRoleValidation:
         with pytest.raises(ConfigError, match="without an analysis model"):
             resolve_model_roles(None, [m])
 
-    def test_multiple_analysis_raises(self):
+    def test_multiple_analysis_allowed(self):
         m1 = ModelConfig(provider="anthropic", model_name="opus", role="analysis")
         m2 = ModelConfig(provider="openai", model_name="gpt-5", role="analysis")
-        with pytest.raises(ConfigError, match="Multiple models"):
-            resolve_model_roles(m1, [m2])
+        result = resolve_model_roles(m1, [m2])
+        assert len(result["analysis_models"]) == 2
+        assert result["analysis_model"] == m1
 
     def test_fallback_only_raises(self):
         m = ModelConfig(provider="anthropic", model_name="opus", role="fallback")

--- a/core/llm/tests/test_turn_track_usage_and_factory.py
+++ b/core/llm/tests/test_turn_track_usage_and_factory.py
@@ -227,9 +227,8 @@ def test_factory_routes_keyless_anthropic_to_openai_compat() -> None:
         provider = create_provider(config)
 
     assert isinstance(provider, OpenAICompatibleProvider)
-    # base_url is what OpenAI client will hit. Trailing slash present
-    # because the OpenAI SDK normalises base_url.
-    assert "api.anthropic.com" in str(provider.client.base_url)
+    from urllib.parse import urlparse
+    assert urlparse(str(provider.client.base_url)).hostname == "api.anthropic.com"
     # API key threaded through correctly so requests authenticate.
     assert provider.client.api_key == "test-anthropic-key"
 

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -159,6 +159,13 @@ def main():
     p_clean.add_argument("--dry-run", action="store_true", help="Show what would be deleted")
     p_clean.add_argument("--yes", action="store_true", help="Skip confirmation")
 
+    # correlate
+    p_correlate = sub.add_parser("correlate", help="Cross-run finding correlation",
+                                 usage="raptor project correlate [<name>] [--json]", **_F)
+    p_correlate.add_argument("name", nargs="?", help="Project name")
+    p_correlate.add_argument("--json", dest="json_out", action="store_true",
+                             help="Output raw JSON instead of formatted table")
+
     # export
     p_export = sub.add_parser("export", help="Export project as zip",
                               usage="raptor project export <name> <path> [--force]", **_F)
@@ -392,6 +399,17 @@ def main():
         elif args.subcommand == "remove":
             mgr.remove_run(args.name, args.run, to_path=args.to)
             print(f"Removed '{args.run}' from project '{args.name}'")
+
+        elif args.subcommand == "correlate":
+            name = args.name or _get_active_project()
+            if not name:
+                print("No project specified.")
+                return
+            p = mgr.load(name)
+            if not p:
+                print(f"Project '{name}' not found.")
+                return
+            _do_correlate(p, json_out=args.json_out)
 
         elif args.subcommand == "diff":
             from .diff import diff_runs
@@ -739,6 +757,53 @@ def _print_diff(result):
         for c in result["changed"]:
             print(_yellow(f"  ~ {c['label']} ({c.get('status_before', '?')} → {c.get('status_after', '?')})"))
     print(f"Unchanged: {result['unchanged']}")
+
+
+def _do_correlate(project, json_out=False):
+    """Cross-run finding correlation."""
+    import json
+    from .correlate import correlate_project
+
+    result = correlate_project(project)
+    summary = result["summary"]
+
+    if json_out:
+        print(json.dumps(result, indent=2))
+        return
+
+    print(f"Project: {project.name}")
+    print(f"  Runs: {summary['runs']}")
+    print(f"  Unique findings: {summary['total_unique_findings']}")
+    print(f"  Persistent (2+ runs): {summary['persistent_findings']}")
+    if summary["tools_used"]:
+        print(f"  Tools: {', '.join(summary['tools_used'])}")
+
+    persistent = result["persistent_findings"]
+    if persistent:
+        print(f"\nPersistent findings:")
+        for pf in persistent[:20]:
+            loc = f"{pf['file']}:{pf['line']}" if pf.get("file") else "?"
+            vtype = pf.get("vuln_type", "")
+            status = pf.get("status", "")
+            runs = pf["runs_seen"]
+            print(f"  {loc:<40s}  {vtype:<20s}  {status:<16s}  {runs} runs")
+        if len(persistent) > 20:
+            print(f"  ... and {len(persistent) - 20} more")
+
+    trends = result["trends"]
+    if trends:
+        print(f"\nTrends ({len(trends)} findings with history):")
+        for label, history in list(trends.items())[:10]:
+            statuses = " → ".join(h["status"] or "?" for h in history)
+            print(f"  {label}: {statuses}")
+        if len(trends) > 10:
+            print(f"  ... and {len(trends) - 10} more")
+
+    tool_cov = result["tool_coverage"]
+    if tool_cov:
+        print(f"\nTool coverage:")
+        for tool, files in tool_cov.items():
+            print(f"  {tool}: {len(files)} files")
 
 
 def _do_clean(project, keep, dry_run, yes):

--- a/core/project/correlate.py
+++ b/core/project/correlate.py
@@ -1,0 +1,165 @@
+"""Cross-run correlation for /project correlate.
+
+Aggregates findings and tool coverage across all runs in a project to
+produce: persistent findings, tool coverage matrix, gaps, and trends.
+Pure Python, no LLM calls.
+"""
+
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from core.json import load_json
+from core.run import load_run_metadata
+
+from .findings_utils import dedup_key, load_findings_from_dir
+
+
+def correlate_project(project) -> Dict[str, Any]:
+    """Correlate findings and coverage across all runs in a project.
+
+    Returns:
+        persistent_findings: findings appearing in 2+ runs
+        tool_coverage: {tool: [files...]} across all runs
+        gaps: files in target not covered by any run
+        trends: {finding_key: [{run, status, score}]}
+        summary: counts
+    """
+    run_dirs = project.get_run_dirs(sweep=False)
+    if not run_dirs:
+        return _empty_result()
+
+    findings_by_run = _load_all_findings(run_dirs)
+    persistent = _find_persistent(findings_by_run)
+    trends = _build_trends(findings_by_run, run_dirs)
+    tool_coverage = _build_tool_coverage(run_dirs)
+
+    n_persistent = len(persistent)
+    n_total_unique = len({
+        dedup_key(f)
+        for findings in findings_by_run.values()
+        for f in findings
+    })
+    n_runs = len(run_dirs)
+    tools_used = sorted(tool_coverage.keys())
+
+    return {
+        "persistent_findings": persistent,
+        "tool_coverage": tool_coverage,
+        "trends": trends,
+        "summary": {
+            "runs": n_runs,
+            "total_unique_findings": n_total_unique,
+            "persistent_findings": n_persistent,
+            "tools_used": tools_used,
+        },
+    }
+
+
+def _empty_result() -> Dict[str, Any]:
+    return {
+        "persistent_findings": [],
+        "tool_coverage": {},
+        "trends": {},
+        "summary": {
+            "runs": 0,
+            "total_unique_findings": 0,
+            "persistent_findings": 0,
+            "tools_used": [],
+        },
+    }
+
+
+def _load_all_findings(
+    run_dirs: List[Path],
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Load findings from each run dir, keyed by run dir name."""
+    result = {}
+    for d in run_dirs:
+        findings = load_findings_from_dir(d)
+        if findings:
+            result[d.name] = findings
+    return result
+
+
+def _find_persistent(
+    findings_by_run: Dict[str, List[Dict]],
+) -> List[Dict[str, Any]]:
+    """Find findings that appear across 2+ runs."""
+    key_to_runs: Dict[tuple, List[str]] = defaultdict(list)
+    key_to_finding: Dict[tuple, Dict] = {}
+
+    for run_name, findings in findings_by_run.items():
+        for f in findings:
+            k = dedup_key(f)
+            key_to_runs[k].append(run_name)
+            key_to_finding[k] = f
+
+    persistent = []
+    for k, runs in sorted(key_to_runs.items(), key=lambda x: -len(x[1])):
+        if len(runs) < 2:
+            continue
+        f = key_to_finding[k]
+        persistent.append({
+            "file": f.get("file", ""),
+            "function": f.get("function", ""),
+            "line": f.get("line", 0),
+            "vuln_type": f.get("vuln_type", ""),
+            "status": f.get("final_status") or f.get("status", ""),
+            "runs_seen": len(runs),
+            "run_names": sorted(runs),
+        })
+
+    return persistent
+
+
+def _build_trends(
+    findings_by_run: Dict[str, List[Dict]],
+    run_dirs: List[Path],
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Track how each finding's status changed across runs.
+
+    Returns {finding_label: [{run, status, score}]} ordered by run time.
+    """
+    run_order = [d.name for d in run_dirs]
+
+    key_to_history: Dict[tuple, List[Dict]] = defaultdict(list)
+    for run_name, findings in findings_by_run.items():
+        for f in findings:
+            k = dedup_key(f)
+            key_to_history[k].append({
+                "run": run_name,
+                "status": f.get("final_status") or f.get("status", ""),
+                "score": f.get("exploitability_score") or f.get("cvss_score_estimate"),
+            })
+
+    # Only include findings seen in 2+ runs (single-run = no trend)
+    trends = {}
+    for k, history in key_to_history.items():
+        if len(history) < 2:
+            continue
+        history.sort(key=lambda h: run_order.index(h["run"]) if h["run"] in run_order else 999)
+        label = f"{k[0]}:{k[1]}:{k[2]}" if k[1] else f"{k[0]}:{k[2]}"
+        trends[label] = history
+
+    return trends
+
+
+def _build_tool_coverage(run_dirs: List[Path]) -> Dict[str, List[str]]:
+    """Build tool → files-covered mapping from run metadata.
+
+    Reads .raptor-run.json command field to determine which tool produced
+    each run, then collects files from findings.
+    """
+    tool_files: Dict[str, set] = defaultdict(set)
+
+    for d in run_dirs:
+        meta = load_run_metadata(d)
+        tool = (meta or {}).get("command", "unknown")
+        findings = load_findings_from_dir(d)
+        for f in findings:
+            fp = f.get("file", "")
+            if fp:
+                tool_files[tool].add(fp)
+
+    return {tool: sorted(files) for tool, files in sorted(tool_files.items())}

--- a/core/project/tests/test_correlate.py
+++ b/core/project/tests/test_correlate.py
@@ -1,0 +1,148 @@
+"""Tests for cross-run project correlation."""
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[3]))
+
+from core.project.correlate import (
+    correlate_project,
+    _find_persistent,
+    _build_trends,
+    _build_tool_coverage,
+)
+
+
+def _make_finding(file="app.py", function="handle", line=10,
+                  vuln_type="sqli", status="exploitable", score=0.9):
+    return {
+        "file": file,
+        "function": function,
+        "line": line,
+        "vuln_type": vuln_type,
+        "final_status": status,
+        "exploitability_score": score,
+    }
+
+
+def _write_run(tmp_path, name, findings, command="scan"):
+    """Create a fake run directory with findings.json and metadata."""
+    d = tmp_path / name
+    d.mkdir()
+    (d / "findings.json").write_text(json.dumps({"findings": findings}))
+    (d / ".raptor-run.json").write_text(json.dumps({
+        "version": 1, "command": command, "status": "completed",
+    }))
+    return d
+
+
+class TestFindPersistent:
+    def test_empty(self):
+        assert _find_persistent({}) == []
+
+    def test_single_run(self):
+        findings_by_run = {
+            "run-1": [_make_finding()],
+        }
+        assert _find_persistent(findings_by_run) == []
+
+    def test_same_finding_two_runs(self):
+        f = _make_finding()
+        findings_by_run = {
+            "run-1": [f],
+            "run-2": [f],
+        }
+        result = _find_persistent(findings_by_run)
+        assert len(result) == 1
+        assert result[0]["runs_seen"] == 2
+        assert result[0]["file"] == "app.py"
+
+    def test_different_findings(self):
+        findings_by_run = {
+            "run-1": [_make_finding(line=10)],
+            "run-2": [_make_finding(line=20)],
+        }
+        assert _find_persistent(findings_by_run) == []
+
+    def test_mixed(self):
+        shared = _make_finding(line=10)
+        unique = _make_finding(line=20)
+        findings_by_run = {
+            "run-1": [shared, unique],
+            "run-2": [shared],
+        }
+        result = _find_persistent(findings_by_run)
+        assert len(result) == 1
+        assert result[0]["line"] == 10
+
+
+class TestBuildTrends:
+    def test_empty(self):
+        assert _build_trends({}, []) == {}
+
+    def test_single_run_no_trend(self):
+        findings_by_run = {"run-1": [_make_finding()]}
+        assert _build_trends(findings_by_run, [Path("run-1")]) == {}
+
+    def test_status_progression(self):
+        f1 = _make_finding(status="not_disproven", score=0.5)
+        f2 = _make_finding(status="exploitable", score=0.9)
+        findings_by_run = {
+            "run-1": [f1],
+            "run-2": [f2],
+        }
+        dirs = [Path("run-1"), Path("run-2")]
+        trends = _build_trends(findings_by_run, dirs)
+        assert len(trends) == 1
+        label = list(trends.keys())[0]
+        history = trends[label]
+        assert history[0]["status"] == "not_disproven"
+        assert history[1]["status"] == "exploitable"
+
+
+class TestBuildToolCoverage:
+    def test_empty(self):
+        assert _build_tool_coverage([]) == {}
+
+    def test_from_runs(self, tmp_path):
+        d1 = _write_run(tmp_path, "scan-001", [
+            _make_finding(file="a.py"), _make_finding(file="b.py"),
+        ], command="scan")
+        d2 = _write_run(tmp_path, "agentic-001", [
+            _make_finding(file="b.py"), _make_finding(file="c.py"),
+        ], command="agentic")
+
+        result = _build_tool_coverage([d1, d2])
+        assert "scan" in result
+        assert "agentic" in result
+        assert "a.py" in result["scan"]
+        assert "b.py" in result["scan"]
+        assert "c.py" in result["agentic"]
+
+
+class TestCorrelateProject:
+    def test_no_runs(self):
+        project = MagicMock()
+        project.get_run_dirs.return_value = []
+        result = correlate_project(project)
+        assert result["summary"]["runs"] == 0
+
+    def test_full_correlation(self, tmp_path):
+        shared = _make_finding(file="shared.py", line=5)
+        d1 = _write_run(tmp_path, "scan-001", [shared, _make_finding(file="a.py", line=1)])
+        d2 = _write_run(tmp_path, "scan-002", [shared, _make_finding(file="b.py", line=2)])
+
+        project = MagicMock()
+        project.get_run_dirs.return_value = [d1, d2]
+
+        result = correlate_project(project)
+        assert result["summary"]["runs"] == 2
+        assert result["summary"]["persistent_findings"] == 1
+        assert result["summary"]["total_unique_findings"] == 3
+        assert len(result["persistent_findings"]) == 1
+        assert result["persistent_findings"][0]["file"] == "shared.py"

--- a/core/security/llm_family.py
+++ b/core/security/llm_family.py
@@ -49,6 +49,26 @@ _MODEL_STEMS: tuple[tuple[str, Family], ...] = (
 )
 
 
+_FAMILY_TO_PROVIDER: dict[Family, str] = {
+    "anthropic": "anthropic",
+    "openai": "openai",
+    "google": "gemini",
+    "meta": "ollama",
+    "mistral": "mistral",
+    "ollama": "ollama",
+}
+
+
+def provider_for_family(family: Family) -> str:
+    """Map a model family to its provider string (for ModelConfig)."""
+    return _FAMILY_TO_PROVIDER.get(family, "")
+
+
+def provider_of(model_id: str) -> str:
+    """Shorthand: model identifier → provider string."""
+    return provider_for_family(family_of(model_id))
+
+
 def family_of(model_id: str) -> Family:
     """Return the model family for a model identifier.
 

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -1095,11 +1095,30 @@ def main() -> None:
     ap.add_argument("--checklist", help="Inventory checklist.json for function metadata lookup")
     ap.add_argument("--prep-only", action="store_true",
                     help="Skip LLM analysis; produce structured findings for external orchestration")
+    ap.add_argument("--max-parallel", type=int, default=3, help="Max parallel dispatch threads")
+
+    model_group = ap.add_argument_group(
+        "multi-model analysis",
+        "When any of these flags are provided, findings are prepped then "
+        "dispatched through the parallel orchestrator with role support.",
+    )
+    model_group.add_argument("--model", metavar="MODEL", action="append", default=[],
+                             help="Analysis model (repeatable for multi-model)")
+    model_group.add_argument("--consensus", metavar="MODEL",
+                             help="Blind second opinion model")
+    model_group.add_argument("--judge", metavar="MODEL",
+                             help="Non-blind review model")
 
     args = ap.parse_args()
 
     if not args.sarif and not args.findings:
         ap.error("Either --sarif or --findings is required")
+
+    _has_role_flags = any([
+        getattr(args, "model", []),
+        getattr(args, "consensus", None),
+        getattr(args, "judge", None),
+    ])
 
     # Suggest --findings if validation artifacts exist nearby
     if args.sarif and not args.findings:
@@ -1116,8 +1135,9 @@ def main() -> None:
         # Collision-prevention via unique_run_suffix — see core/run/output.py.
         out_dir = RaptorConfig.get_out_dir() / f"autonomous_v2_{unique_run_suffix('_')}"
 
-    # Initialize agent with LLM
-    agent = AutonomousSecurityAgentV2(repo_path, out_dir, prep_only=args.prep_only)
+    # When role flags are present, force prep-only then hand off to orchestrator
+    prep_only = args.prep_only or _has_role_flags
+    agent = AutonomousSecurityAgentV2(repo_path, out_dir, prep_only=prep_only)
 
     # Load checklist for metadata lookup
     checklist = None
@@ -1136,6 +1156,32 @@ def main() -> None:
     else:
         report = agent.process_findings(sarif_paths=args.sarif, max_findings=args.max_findings,
                                         checklist=checklist)
+
+    # Orchestrated path: role flags → prep then parallel dispatch
+    if _has_role_flags and report.get("mode") == "prep_only":
+        prep_report_path = out_dir / "autonomous_analysis_report.json"
+        if prep_report_path.exists():
+            from packages.llm_analysis.orchestrator import (
+                build_llm_config_from_flags, orchestrate,
+            )
+            llm_config = build_llm_config_from_flags(
+                models=args.model or [],
+                consensus=args.consensus,
+                judge=args.judge,
+            )
+            if llm_config:
+                result = orchestrate(
+                    prep_report_path=prep_report_path,
+                    repo_path=repo_path,
+                    out_dir=out_dir,
+                    max_parallel=args.max_parallel,
+                    max_findings=args.max_findings,
+                    llm_config=llm_config,
+                )
+                if result:
+                    return
+        print("\n  Orchestration skipped — check model/API key configuration")
+        return
 
     if report.get('mode') != 'prep_only':
         print("\n" + "=" * 70)

--- a/packages/llm_analysis/correlation.py
+++ b/packages/llm_analysis/correlation.py
@@ -1,0 +1,137 @@
+"""Multi-model correlation engine.
+
+Pure-Python aggregation of per-model analysis results. Produces agreement
+matrix, clusters, unique insights, and confidence signals. No LLM calls.
+"""
+
+from typing import Any, Dict, List
+
+
+def correlate_results(results_by_id: Dict[str, Dict]) -> Dict[str, Any]:
+    """Correlate multi-model analysis results for all findings.
+
+    Only processes findings that have multi_model_analyses (i.e., were
+    analysed by multiple models). Single-model findings are skipped.
+
+    Returns a dict with:
+        agreement_matrix: {finding_id: {model: {verdict, score, ruling}}}
+        clusters: [{pattern, finding_ids, models_agreed}]
+        unique_insights: [{finding_id, model, insight}]
+        confidence_signals: {finding_id: "high"|"high-negative"|"disputed"}
+        summary: {agreed, disputed, total, models}
+    """
+    matrix: Dict[str, Dict[str, Dict]] = {}
+    confidence: Dict[str, str] = {}
+    unique: List[Dict] = []
+
+    models_seen: set[str] = set()
+
+    for fid, result in results_by_id.items():
+        analyses = result.get("multi_model_analyses")
+        if not analyses or len(analyses) < 2:
+            continue
+
+        per_model = {}
+        for a in analyses:
+            model = a.get("model", "?")
+            models_seen.add(model)
+            per_model[model] = {
+                "is_exploitable": a.get("is_exploitable"),
+                "exploitability_score": a.get("exploitability_score"),
+                "ruling": a.get("ruling"),
+            }
+        matrix[fid] = per_model
+
+        verdicts = [a.get("is_exploitable", False) for a in analyses]
+        all_agree = len(set(verdicts)) == 1
+
+        if all_agree and verdicts[0]:
+            confidence[fid] = "high"
+        elif all_agree and not verdicts[0]:
+            confidence[fid] = "high-negative"
+        else:
+            confidence[fid] = "disputed"
+
+            exploitable_models = [
+                a["model"] for a in analyses if a.get("is_exploitable")
+            ]
+            non_exploitable_models = [
+                a["model"] for a in analyses if not a.get("is_exploitable")
+            ]
+            minority = (exploitable_models if len(exploitable_models) < len(non_exploitable_models)
+                        else non_exploitable_models)
+            majority_verdict = len(exploitable_models) >= len(non_exploitable_models)
+            for model in minority:
+                reasoning = next(
+                    (a.get("reasoning", "") for a in analyses if a.get("model") == model),
+                    "",
+                )
+                unique.append({
+                    "finding_id": fid,
+                    "model": model,
+                    "verdict": not majority_verdict,
+                    "reasoning": reasoning[:200],
+                })
+
+    clusters = _build_clusters(matrix, results_by_id)
+
+    agreed = sum(1 for s in confidence.values() if s in ("high", "high-negative"))
+    disputed = sum(1 for s in confidence.values() if s == "disputed")
+
+    return {
+        "agreement_matrix": matrix,
+        "clusters": clusters,
+        "unique_insights": unique,
+        "confidence_signals": confidence,
+        "summary": {
+            "total_correlated": len(matrix),
+            "agreed": agreed,
+            "disputed": disputed,
+            "models": sorted(models_seen),
+        },
+    }
+
+
+def _build_clusters(
+    matrix: Dict[str, Dict[str, Dict]],
+    results_by_id: Dict[str, Dict],
+) -> List[Dict]:
+    """Group findings by agreement pattern.
+
+    Findings where the same set of models agree on the same verdict pattern
+    are clustered together.
+    """
+    pattern_groups: Dict[str, List[str]] = {}
+
+    for fid, per_model in matrix.items():
+        verdicts = tuple(
+            (model, v.get("is_exploitable", False))
+            for model, v in sorted(per_model.items())
+        )
+        pattern_key = str(verdicts)
+        pattern_groups.setdefault(pattern_key, []).append(fid)
+
+    clusters = []
+    for pattern_key, fids in pattern_groups.items():
+        if len(fids) < 2:
+            continue
+        sample_fid = fids[0]
+        per_model = matrix[sample_fid]
+        models_agreed = all(
+            v.get("is_exploitable") == list(per_model.values())[0].get("is_exploitable")
+            for v in per_model.values()
+        )
+        shared_rules = set()
+        for fid in fids:
+            rule = results_by_id.get(fid, {}).get("rule_id", "")
+            if rule:
+                shared_rules.add(rule)
+
+        clusters.append({
+            "finding_ids": sorted(fids),
+            "pattern": "unanimous" if models_agreed else "split",
+            "shared_rules": sorted(shared_rules),
+            "models_agreed": models_agreed,
+        })
+
+    return clusters

--- a/packages/llm_analysis/dispatch.py
+++ b/packages/llm_analysis/dispatch.py
@@ -186,6 +186,9 @@ def dispatch_task(
         model_name = models[0].model_name if models[0] else ""
         total_calls = len(selected) * len(models)
         if cost_tracker.should_skip_phase(total_calls, model_name, task.budget_cutoff, task.name):
+            print(f"\n  {task.name}: skipped ({len(selected)} items) — "
+                  f"budget > {int(task.budget_cutoff * 100)}%"
+                  f"; raise --max-cost to include")
             return []
 
     # Build work items: (model, item) pairs
@@ -309,8 +312,9 @@ def dispatch_task(
                     with _nonces_lock:
                         nonce = _nonces.pop(item_id, "")
                     if nonce:
+                        model_id = getattr(model, "model_name", str(model))
                         defense_telemetry.record_response(
-                            model_id=model,
+                            model_id=model_id,
                             profile_name=profile_name,
                             nonce=nonce,
                             raw_response=err_str,

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -134,6 +134,86 @@ class CostTracker:
             return summary
 
 
+def build_llm_config_from_flags(
+    *,
+    models: Optional[List[str]] = None,
+    consensus: Optional[str] = None,
+    judge: Optional[str] = None,
+    auto_detect: bool = True,
+) -> Optional[Any]:
+    """Build an LLMConfig from CLI flags, shared by /agentic and /analyze.
+
+    Args:
+        models: List of analysis model names. Single entry = one primary.
+            Multiple = multi-model mode (each independently analyses).
+        consensus: Blind second-opinion model name.
+        judge: Non-blind review model name.
+        auto_detect: Try env vars / models.json if no --model given.
+
+    Returns LLMConfig or None if no model could be resolved.
+    """
+    from core.llm.config import LLMConfig, _model_config_from_entry, _get_configured_models
+    from core.llm.model_data import PROVIDER_ENV_KEYS
+    from core.security.llm_family import provider_of
+
+    models = models or []
+    llm_config = None
+
+    def _resolve_model(name: str, role: str):
+        provider = provider_of(name)
+        entry: Dict[str, Any] = {"model": name, "provider": provider, "role": role}
+        for cfg_entry in _get_configured_models():
+            if cfg_entry.get("model") == name and cfg_entry.get("api_key"):
+                entry["api_key"] = cfg_entry["api_key"]
+                break
+        mc = _model_config_from_entry(entry)
+        if not mc.api_key:
+            env_key = PROVIDER_ENV_KEYS.get(provider, "???")
+            print(f"\n  Error: no API key for --model {name}")
+            print(f"  Set {env_key} or add the key to models.json")
+            return None
+        return mc
+
+    if models:
+        primary_mc = _resolve_model(models[0], "analysis")
+        if primary_mc:
+            llm_config = LLMConfig(primary_model=primary_mc)
+            for extra in models[1:]:
+                mc = _resolve_model(extra, "analysis")
+                if mc:
+                    llm_config.fallback_models.append(mc)
+    elif auto_detect:
+        try:
+            llm_config = LLMConfig()
+        except Exception:
+            pass
+
+    # Consensus is redundant with 3+ analysis models
+    n_analysis = len(models)
+    if n_analysis >= 3 and consensus:
+        print(f"\n  Note: --consensus skipped — {n_analysis} analysis models "
+              f"already provide independent opinions")
+        consensus = None
+
+    role_flags = [
+        ("consensus", consensus),
+        ("judge", judge),
+    ]
+    has_role_flags = any(m for _, m in role_flags)
+    if has_role_flags and not llm_config:
+        print("\n  Warning: --consensus/--judge require a primary analysis model")
+        print("  Use --model MODEL, configure models.json, or set an API key env var")
+    if llm_config and has_role_flags:
+        for role, model_name in role_flags:
+            if not model_name:
+                continue
+            mc = _resolve_model(model_name, role)
+            if mc:
+                llm_config.fallback_models.append(mc)
+
+    return llm_config
+
+
 def orchestrate(
     prep_report_path: Path,
     repo_path: Path,
@@ -209,7 +289,8 @@ def orchestrate(
     # Resolve model roles
     from core.llm.config import resolve_model_roles
     role_resolution = {"analysis_model": None, "code_model": None,
-                       "consensus_models": [], "fallback_models": []}
+                       "consensus_models": [], "judge_models": [],
+                       "fallback_models": []}
     if llm_config and llm_config.primary_model:
         role_resolution = resolve_model_roles(
             llm_config.primary_model,
@@ -222,18 +303,32 @@ def orchestrate(
 
     # Print dispatch info
     n_consensus = len(role_resolution.get("consensus_models", []))
+    n_judge = len(role_resolution.get("judge_models", []))
     analysis_model = role_resolution.get("analysis_model")
     analysis_model_name = analysis_model.model_name if analysis_model else ""
     is_cc_dispatch = not (llm_config and llm_config.primary_model)
-    model_label = analysis_model_name or ("Claude Code" if is_cc_dispatch else "unknown")
+    analysis_models_all = role_resolution.get("analysis_models", [])
+    n_analysis = len(analysis_models_all)
+    if n_analysis > 1:
+        model_label = ", ".join(m.model_name for m in analysis_models_all)
+    else:
+        model_label = analysis_model_name or ("Claude Code" if is_cc_dispatch else "unknown")
     n = len(findings)
-    print(f"\n  {n} finding{'s' if n != 1 else ''} → {model_label}"
-          + (f" + {n_consensus} consensus model{'s' if n_consensus != 1 else ''}" if n_consensus else ""))
+    extras = []
+    if n_analysis > 1:
+        extras.append(f"{n_analysis} models")
+    if n_consensus:
+        extras.append(f"{n_consensus} consensus")
+    if n_judge:
+        extras.append(f"{n_judge} judge")
+    extra_str = f" ({', '.join(extras)})" if extras else ""
+    print(f"\n  {n} finding{'s' if n != 1 else ''} → {model_label}{extra_str}")
 
     # --- Build dispatch callable ---
     from packages.llm_analysis.dispatch import dispatch_task, DispatchResult
     from packages.llm_analysis.tasks import (
-        AnalysisTask, ExploitTask, PatchTask, ConsensusTask, GroupAnalysisTask,
+        AnalysisTask, ExploitTask, PatchTask,
+        ConsensusTask, JudgeTask, GroupAnalysisTask,
         RetryTask, CrossFamilyCheckTask,
     )
     from core.security.prompt_defense_profiles import (
@@ -303,20 +398,25 @@ def orchestrate(
         dispatch_mode = "cc_dispatch"
 
     # --- Canary probe: verify model handles the defense envelope ---
+    # Multi-model: probe each analysis model; use strictest compatible profile.
     profile = CONSERVATIVE
-    if dispatch_fn and analysis_model_name:
-        profile = get_profile_for(analysis_model_name)
+    _models_to_probe = analysis_models_all if len(analysis_models_all) > 1 else (
+        [analysis_model] if analysis_model else []
+    )
+    _probe_failed = False
+    if dispatch_fn and _models_to_probe:
         from core.security.envelope_probe import probe_envelope_compatibility
-        # Pass the full ModelConfig: dispatch_fn forwards its 5th arg
-        # to ``client.generate_structured(model_config=...)`` which
-        # needs ``.max_context`` etc. The probe falls back to a
-        # ``str(analysis_model_name)`` label for telemetry on the CC
-        # dispatch path (where the arg is unused anyway).
-        probe_result = probe_envelope_compatibility(
-            analysis_model or analysis_model_name, profile, dispatch_fn,
-        )
-        defense_telemetry.set_probe_result(analysis_model_name, probe_result.compatible)
-        if not probe_result.compatible:
+        profile = get_profile_for(analysis_model_name)
+        for _probe_model in _models_to_probe:
+            _pname = _probe_model.model_name if hasattr(_probe_model, "model_name") else str(_probe_model)
+            probe_result = probe_envelope_compatibility(
+                _probe_model, get_profile_for(_pname), dispatch_fn,
+            )
+            defense_telemetry.set_probe_result(_pname, probe_result.compatible)
+            if not probe_result.compatible:
+                _probe_failed = True
+                break
+        if _probe_failed:
             if not accept_weakened_defenses:
                 print(f"\n  Envelope probe failed for {model_label}: {probe_result.error}")
                 print(f"  The model cannot honour the defense envelope — aborting.")
@@ -368,10 +468,29 @@ def orchestrate(
             )
 
     # Index results for downstream tasks
+    # Multi-model: multiple results per finding — pick best as primary,
+    # attach all per-model analyses for correlation.
+    _multi_results: Dict[str, List[Dict]] = {}
     for r in analysis_results:
         fid = r.get("finding_id")
         if fid:
-            results_by_id[fid] = r
+            _multi_results.setdefault(fid, []).append(r)
+
+    n_analysis_models = len(role_resolution.get("analysis_models", []))
+    for fid, model_results in _multi_results.items():
+        if len(model_results) == 1:
+            results_by_id[fid] = model_results[0]
+        else:
+            primary = _select_primary_result(model_results)
+            primary["multi_model_analyses"] = [
+                {"model": r.get("analysed_by", "?"),
+                 "is_exploitable": r.get("is_exploitable"),
+                 "exploitability_score": r.get("exploitability_score"),
+                 "ruling": r.get("ruling"),
+                 "reasoning": r.get("reasoning", "")}
+                for r in model_results
+            ]
+            results_by_id[fid] = primary
 
     # --- Pipeline flow (maps to exploitation-validator stages) ---
     # Stage E (binary feasibility) runs in Phase 0 if --binary provided.
@@ -425,6 +544,31 @@ def orchestrate(
         ):
             consensus_budget_skipped = True
 
+    # Judge review (if configured) — sees primary reasoning, critiques it
+    judge_models = role_resolution.get("judge_models", [])
+    if judge_models:
+        dispatch_task(
+            JudgeTask(results_by_id=results_by_id, profile=profile),
+            findings, dispatch_fn, role_resolution,
+            results_by_id, cost_tracker, max_parallel,
+        )
+
+    # Multi-model correlation (pure Python, no LLM)
+    correlation = None
+    if n_analysis_models > 1:
+        from packages.llm_analysis.correlation import correlate_results
+        correlation = correlate_results(results_by_id)
+        # Apply confidence signals back to individual results
+        for fid, signal in correlation.get("confidence_signals", {}).items():
+            if fid in results_by_id:
+                results_by_id[fid]["multi_model_confidence"] = signal
+        corr_summary = correlation.get("summary", {})
+        n_corr = corr_summary.get("total_correlated", 0)
+        n_agreed = corr_summary.get("agreed", 0)
+        n_disputed = corr_summary.get("disputed", 0)
+        if n_corr:
+            print(f"\n  Correlation: {n_corr} findings — {n_agreed} agreed, {n_disputed} disputed")
+
     # Exploit/patch generation — after final verdict
     # CC analysis may produce exploits/patches inline via schema. ExploitTask/PatchTask
     # only select findings that are exploitable AND missing exploit_code/patch_code,
@@ -468,11 +612,17 @@ def orchestrate(
     merged["cross_finding_groups"] = groups
     if group_analyses:
         merged["group_analyses"] = group_analyses
+    if correlation:
+        merged["correlation"] = correlation
 
     consensus_agreed = sum(1 for r in per_finding_results
                            if r.get("consensus") == "agreed")
     consensus_disputes = sum(1 for r in per_finding_results
                              if r.get("consensus") == "disputed")
+    judge_agreed = sum(1 for r in per_finding_results
+                       if r.get("judge") == "agreed")
+    judge_disputes = sum(1 for r in per_finding_results
+                         if r.get("judge") == "disputed")
     cross_family_checked = sum(1 for r in per_finding_results
                                if r.get("cross_family_check"))
     cross_family_disputes = sum(1 for r in per_finding_results
@@ -480,16 +630,22 @@ def orchestrate(
     retries = sum(1 for r in per_finding_results if r.get("retried"))
     low_confidence = sum(1 for r in per_finding_results if r.get("low_confidence"))
 
+    analysis_models_list = role_resolution.get("analysis_models", [])
     merged["orchestration"] = {
         "mode": dispatch_mode,
+        "multi_model": len(analysis_models_list) > 1,
         "analysis_model": (role_resolution.get("analysis_model").model_name
                           if role_resolution.get("analysis_model") else None),
+        "analysis_models": [m.model_name for m in analysis_models_list],
         "defense_profile": profile.name,
         "weakened_defenses": accept_weakened_defenses and profile.name == "passthrough",
         "consensus_models": [m.model_name for m in consensus_models],
         "consensus_agreed": consensus_agreed,
         "consensus_disputes": consensus_disputes,
         "consensus_budget_skipped": consensus_budget_skipped,
+        "judge_models": [m.model_name for m in judge_models],
+        "judge_agreed": judge_agreed,
+        "judge_disputes": judge_disputes,
         "findings_dispatched": len(findings),
         "findings_analysed": sum(1 for r in per_finding_results if "error" not in r),
         "findings_failed": sum(1 for r in per_finding_results if "error" in r),
@@ -499,6 +655,7 @@ def orchestrate(
         "low_confidence_retries": retries,
         "low_confidence_remaining": low_confidence,
         "group_analyses": len(group_analyses),
+        "correlation": correlation.get("summary") if correlation else None,
         "elapsed_seconds": round(elapsed, 1),
         "max_parallel": max_parallel,
         "cost": cost_tracker.get_summary(),
@@ -509,6 +666,8 @@ def orchestrate(
 
     out_dir.mkdir(parents=True, exist_ok=True)
     from core.json import save_json
+    if correlation:
+        save_json(out_dir / "correlation.json", correlation)
     out_path = out_dir / "orchestrated_report.json"
     save_json(out_path, merged)
     logger.info(f"Orchestrated report saved to {out_path}")
@@ -548,6 +707,13 @@ def orchestrate(
         print(f"  Consensus: {', '.join(cn_parts)}")
     elif consensus_budget_skipped:
         print(f"  Consensus: skipped (budget > {int(ConsensusTask.budget_cutoff * 100)}%)")
+    if judge_agreed or judge_disputes:
+        jg_parts = []
+        if judge_agreed:
+            jg_parts.append(f"{judge_agreed} agreed")
+        if judge_disputes:
+            jg_parts.append(f"{judge_disputes} disputed")
+        print(f"  Judge: {', '.join(jg_parts)}")
     if cross_family_checked:
         cf_parts = [f"{cross_family_checked} cross-family checked"]
         if cross_family_disputes:
@@ -611,6 +777,36 @@ def _auto_detect_cross_family_checker(primary_family: str) -> Optional[Any]:
             )
             return ModelConfig(provider=provider, model_name=model_name)
     return None
+
+
+def _select_primary_result(model_results: List[Dict]) -> Dict:
+    """Pick the best result from multiple models' analyses of the same finding.
+
+    Prefers: exploitable verdicts (conservative), then highest quality score,
+    then highest exploitability_score.
+    """
+    best = model_results[0]
+    for r in model_results[1:]:
+        if "error" in r:
+            continue
+        if "error" in best:
+            best = r
+            continue
+        r_expl = r.get("is_exploitable", False)
+        b_expl = best.get("is_exploitable", False)
+        if r_expl and not b_expl:
+            best = r
+        elif r_expl == b_expl:
+            r_q = r.get("_quality", 1.0)
+            b_q = best.get("_quality", 1.0)
+            if r_q > b_q:
+                best = r
+            elif r_q == b_q:
+                r_s = r.get("exploitability_score", 0) or 0
+                b_s = best.get("exploitability_score", 0) or 0
+                if r_s > b_s:
+                    best = r
+    return dict(best)
 
 
 def _check_self_consistency(results_by_id: Dict[str, Dict]) -> None:
@@ -797,3 +993,5 @@ def _structural_grouping(results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         _add_group("shared_dataflow_ref", ref, list(fids_set))
 
     return groups
+
+

--- a/packages/llm_analysis/prompts/__init__.py
+++ b/packages/llm_analysis/prompts/__init__.py
@@ -19,14 +19,18 @@ from .analysis import (
 from .exploit import (
     EXPLOIT_SYSTEM_PROMPT,
     EXPLOIT_TASK_INSTRUCTIONS,
+    SCA_EXPLOIT_TASK_INSTRUCTIONS,
     build_exploit_prompt_bundle,
     build_exploit_prompt_bundle_from_finding,
+    build_sca_exploit_prompt_bundle,
 )
 from .patch import (
     PATCH_SYSTEM_PROMPT,
     PATCH_TASK_INSTRUCTIONS,
+    SCA_PATCH_SYSTEM_PROMPT,
     build_patch_prompt_bundle,
     build_patch_prompt_bundle_from_finding,
+    build_sca_patch_prompt_bundle,
 )
 from .schemas import (
     ANALYSIS_SCHEMA,

--- a/packages/llm_analysis/prompts/exploit.py
+++ b/packages/llm_analysis/prompts/exploit.py
@@ -138,6 +138,8 @@ def build_exploit_prompt_bundle_from_finding(
     extra_blocks: tuple[UntrustedBlock, ...] = (),
 ) -> PromptBundle:
     """Bundle equivalent of ``build_exploit_prompt_from_finding``."""
+    if finding.get("rule_id", "").startswith("sca:"):
+        return build_sca_exploit_prompt_bundle(finding, profile=profile)
     return build_exploit_prompt_bundle(
         rule_id=finding.get("rule_id", "unknown"),
         file_path=finding.get("file_path", "unknown"),
@@ -149,4 +151,98 @@ def build_exploit_prompt_bundle_from_finding(
         feasibility=finding.get("feasibility"),
         profile=profile,
         extra_blocks=extra_blocks,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SCA-specific exploit PoC: demonstrate CVE reachability
+# ---------------------------------------------------------------------------
+
+SCA_EXPLOIT_TASK_INSTRUCTIONS = """\
+You are a security researcher demonstrating that a known CVE in a \
+third-party dependency is **reachable** through this project's actual \
+usage of that dependency.
+
+The user message contains:
+- The CVE identifier, advisory details, and affected package/version
+- The project's import/call sites that use the vulnerable dependency
+- The advisory description of the vulnerable function or behaviour
+
+**Your task:**
+Write a proof-of-concept that demonstrates:
+1. The project imports and uses the vulnerable dependency
+2. The vulnerable code path in the dependency is reachable from the \
+   project's actual call sites
+3. An attacker can trigger the vulnerability through the project's \
+   exposed entry points (API, CLI, file parsing, etc.)
+
+Focus on **reachability**, not full exploitation.  Show that untrusted \
+input flows through the project into the vulnerable dependency function.
+
+If the project only uses safe APIs from the dependency and the \
+vulnerable path is unreachable, say so explicitly.
+
+Write Python unless the project's language requires otherwise."""
+
+
+def build_sca_exploit_prompt_bundle(
+    finding: Dict[str, Any],
+    *,
+    profile: Optional[ModelDefenseProfile] = None,
+) -> PromptBundle:
+    """Build exploit prompt for an SCA finding (CVE reachability PoC)."""
+    profile = profile or CONSERVATIVE
+    system = EXPLOIT_SYSTEM_PROMPT + "\n\n" + SCA_EXPLOIT_TASK_INSTRUCTIONS
+
+    sca = finding.get("sca", {})
+    advisory = sca.get("advisory", {})
+    dep_name = sca.get("name", finding.get("rule_id", "unknown"))
+    dep_version = sca.get("version", "")
+    ecosystem = sca.get("ecosystem", "")
+    cve_id = advisory.get("aliases", [""])[0] if advisory.get("aliases") else advisory.get("id", "")
+
+    blocks: list[UntrustedBlock] = []
+
+    advisory_text = json.dumps({
+        "cve": cve_id,
+        "summary": advisory.get("summary", ""),
+        "severity": finding.get("level", ""),
+        "fixed_in": sca.get("fixed_version", ""),
+        "ecosystem": ecosystem,
+        "package": dep_name,
+        "version": dep_version,
+    }, indent=2)
+    blocks.append(UntrustedBlock(
+        content=advisory_text,
+        kind="sca-advisory",
+        origin=f"{ecosystem}/{dep_name}@{dep_version}",
+    ))
+
+    call_sites = sca.get("call_sites", "")
+    if call_sites:
+        blocks.append(UntrustedBlock(
+            content=call_sites if isinstance(call_sites, str) else json.dumps(call_sites),
+            kind="call-sites",
+            origin=f"project usage of {dep_name}",
+        ))
+
+    reachability = sca.get("reachability", "")
+    if reachability:
+        blocks.append(UntrustedBlock(
+            content=f"Reachability assessment: {reachability}",
+            kind="reachability",
+            origin="sca-reachability-analysis",
+        ))
+
+    slots = {
+        "cve_id": TaintedString(value=cve_id, trust="untrusted"),
+        "package": TaintedString(value=f"{ecosystem}/{dep_name}@{dep_version}", trust="untrusted"),
+        "rule_id": TaintedString(value=finding.get("rule_id", ""), trust="untrusted"),
+    }
+
+    return build_prompt(
+        system=system,
+        profile=profile,
+        untrusted_blocks=tuple(blocks),
+        slots=slots,
     )

--- a/packages/llm_analysis/prompts/patch.py
+++ b/packages/llm_analysis/prompts/patch.py
@@ -165,6 +165,8 @@ def build_patch_prompt_bundle_from_finding(
     extra_blocks: tuple[UntrustedBlock, ...] = (),
 ) -> PromptBundle:
     """Bundle equivalent of ``build_patch_prompt_from_finding``."""
+    if finding.get("rule_id", "").startswith("sca:"):
+        return build_sca_patch_prompt_bundle(finding, profile=profile)
     return build_patch_prompt_bundle(
         rule_id=finding.get("rule_id", "unknown"),
         file_path=finding.get("file_path", "unknown"),
@@ -178,4 +180,81 @@ def build_patch_prompt_bundle_from_finding(
         attack_path=attack_path,
         profile=profile,
         extra_blocks=extra_blocks,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SCA manifest-level patches: version bumps in dependency files
+# ---------------------------------------------------------------------------
+
+SCA_PATCH_SYSTEM_PROMPT = """\
+You are a software engineer writing a minimal, safe dependency upgrade \
+patch for a manifest file.
+
+Create a unified diff that bumps the vulnerable dependency to the fixed \
+version.  Preserve the manifest's existing formatting, comments, and \
+pin style.  If the manifest uses exact pins, produce an exact pin.  \
+If it uses range pins, produce the tightest range that includes the fix.
+
+Only change the one dependency — do not touch unrelated lines."""
+
+
+def build_sca_patch_prompt_bundle(
+    finding: Dict[str, Any],
+    *,
+    profile: Optional[ModelDefenseProfile] = None,
+) -> PromptBundle:
+    """Build a patch prompt for an SCA finding (manifest version bump)."""
+    profile = profile or CONSERVATIVE
+    system = SCA_PATCH_SYSTEM_PROMPT
+
+    sca = finding.get("sca", {})
+    dep_name = sca.get("name", "unknown")
+    dep_version = sca.get("version", "")
+    ecosystem = sca.get("ecosystem", "")
+    fixed_version = sca.get("fixed_version", "")
+    manifest_path = sca.get("declared_in", finding.get("file_path", ""))
+    advisory = sca.get("advisory", {})
+    cve_id = ""
+    if advisory.get("aliases"):
+        cve_id = advisory["aliases"][0]
+    elif advisory.get("id"):
+        cve_id = advisory["id"]
+
+    context = (
+        f"Dependency: {ecosystem}/{dep_name}\n"
+        f"Current version: {dep_version}\n"
+        f"Fixed version: {fixed_version}\n"
+        f"Manifest: {manifest_path}\n"
+        f"Advisory: {cve_id}\n"
+    )
+
+    blocks: list[UntrustedBlock] = [
+        UntrustedBlock(
+            content=context,
+            kind="sca-upgrade-context",
+            origin=f"{ecosystem}/{dep_name}",
+        ),
+    ]
+
+    manifest_content = finding.get("code", "")
+    if manifest_content:
+        blocks.append(UntrustedBlock(
+            content=manifest_content,
+            kind="manifest-content",
+            origin=str(manifest_path),
+        ))
+
+    slots = {
+        "package": TaintedString(value=f"{ecosystem}/{dep_name}", trust="untrusted"),
+        "from_version": TaintedString(value=dep_version, trust="untrusted"),
+        "to_version": TaintedString(value=fixed_version, trust="untrusted"),
+        "manifest": TaintedString(value=str(manifest_path), trust="untrusted"),
+    }
+
+    return build_prompt(
+        system=system,
+        profile=profile,
+        untrusted_blocks=tuple(blocks),
+        slots=slots,
     )

--- a/packages/llm_analysis/tasks.py
+++ b/packages/llm_analysis/tasks.py
@@ -67,6 +67,13 @@ class AnalysisTask(DispatchTask):
         self.profile = profile
         self._tls = threading.local()
 
+    def get_models(self, role_resolution):
+        models = role_resolution.get("analysis_models", [])
+        if models:
+            return models
+        model = role_resolution.get("analysis_model")
+        return [model] if model else []
+
     def build_prompt(self, finding):
         bundle = build_analysis_prompt_bundle_from_finding(finding, profile=self.profile)
         self._tls.nonce = bundle.nonce
@@ -99,14 +106,32 @@ class ExploitTask(DispatchTask):
     temperature = 0.8
     budget_cutoff = 0.85
 
+    _SCA_REACHABILITY_FOR_EXPLOIT = ("likely_called", "imported")
+
     def __init__(self, profile: ModelDefenseProfile = CONSERVATIVE):
         self.profile = profile
         self._tls = threading.local()
 
     def select_items(self, findings, prior_results):
-        return [f for f in findings
-                if prior_results.get(f.get("finding_id"), {}).get("is_exploitable")
-                and not prior_results.get(f.get("finding_id"), {}).get("exploit_code")]
+        selected = []
+        for f in findings:
+            fid = f.get("finding_id", "")
+            prior = prior_results.get(fid, {})
+            if prior.get("exploit_code"):
+                continue
+            if prior.get("is_exploitable"):
+                selected.append(f)
+                continue
+            # SCA findings: select if reachable or KEV-listed
+            if f.get("rule_id", "").startswith("sca:vulnerable_dependency"):
+                sca = f.get("sca", {})
+                reachability = sca.get("reachability", "")
+                in_kev = sca.get("in_kev", False)
+                if reachability in self._SCA_REACHABILITY_FOR_EXPLOIT:
+                    selected.append(f)
+                elif in_kev and reachability != "not_reachable":
+                    selected.append(f)
+        return selected
 
     def build_prompt(self, finding):
         bundle = build_exploit_prompt_bundle_from_finding(finding, profile=self.profile)
@@ -149,9 +174,21 @@ class PatchTask(DispatchTask):
         self._tls = threading.local()
 
     def select_items(self, findings, prior_results):
-        return [f for f in findings
-                if prior_results.get(f.get("finding_id"), {}).get("is_exploitable")
-                and not prior_results.get(f.get("finding_id"), {}).get("patch_code")]
+        selected = []
+        for f in findings:
+            fid = f.get("finding_id", "")
+            prior = prior_results.get(fid, {})
+            if prior.get("patch_code"):
+                continue
+            if prior.get("is_exploitable"):
+                selected.append(f)
+                continue
+            # SCA findings with a known fix version get a manifest patch
+            if f.get("rule_id", "").startswith("sca:vulnerable_dependency"):
+                sca = f.get("sca", {})
+                if sca.get("fixed_version"):
+                    selected.append(f)
+        return selected
 
     def build_prompt(self, finding):
         bundle = build_patch_prompt_bundle_from_finding(finding, profile=self.profile)
@@ -265,6 +302,125 @@ class ConsensusTask(DispatchTask):
                      "is_exploitable": ca.get("is_exploitable"),
                      "reasoning": ca.get("reasoning", "")}
                     for ca in consensus_analyses
+                ]
+
+        return results
+
+
+class JudgeTask(DispatchTask):
+    """Non-blind review: judge sees primary reasoning and critiques it."""
+
+    name = "judge"
+    model_role = "judge"
+    budget_cutoff = 0.75
+
+    _JUDGE_ADDENDUM = (
+        "\n\n**Judge review mode:** The user message contains a "
+        "'primary-analysis-reasoning' untrusted block with the primary "
+        "analyst's verdict and reasoning. Your job is to critique this "
+        "analysis:\n"
+        "1. Is the reasoning sound? Does it follow from the evidence?\n"
+        "2. Did the analyst miss attack paths, sanitizer bypasses, or preconditions?\n"
+        "3. Is the verdict (is_exploitable, ruling) consistent with the reasoning?\n"
+        "4. Provide your own independent verdict using the same schema.\n\n"
+        "If you agree with the primary analysis, say so explicitly. "
+        "If you disagree, explain what was missed or incorrect."
+    )
+
+    def __init__(self, results_by_id=None, profile: ModelDefenseProfile = CONSERVATIVE):
+        self.results_by_id = results_by_id or {}
+        self.profile = profile
+        self._tls = threading.local()
+
+    def get_models(self, role_resolution):
+        return role_resolution.get("judge_models", [])
+
+    def select_items(self, findings, prior_results):
+        selected = []
+        for f in findings:
+            fid = f.get("finding_id")
+            r = prior_results.get(fid, {"error": True})
+            if "error" in r:
+                continue
+            if not r.get("is_true_positive", True):
+                continue
+            if r.get("cross_family_agreed"):
+                continue
+            selected.append(f)
+        return selected
+
+    def build_prompt(self, finding):
+        from core.security.prompt_envelope import UntrustedBlock
+
+        fid = finding.get("finding_id")
+        primary = self.results_by_id.get(fid, {})
+        primary_reasoning = (primary.get("reasoning") or "")[:2000]
+        primary_verdict = primary.get("is_exploitable", "unknown")
+        primary_ruling = primary.get("ruling", "unknown")
+
+        extra_blocks = (
+            UntrustedBlock(
+                content=(
+                    f"Primary verdict: is_exploitable={primary_verdict}, "
+                    f"ruling={primary_ruling}\n\n{primary_reasoning}"
+                ),
+                kind="primary-analysis-reasoning",
+                origin=f"judge:{fid}",
+            ),
+        )
+
+        bundle = build_analysis_prompt_bundle_from_finding(
+            finding, profile=self.profile, extra_blocks=extra_blocks,
+        )
+        self._tls.nonce = bundle.nonce
+        return _user_message_from_bundle(bundle)
+
+    def get_last_nonce(self) -> str:
+        return getattr(self._tls, "nonce", "")
+
+    def get_profile_name(self) -> str:
+        return self.profile.name
+
+    def get_schema(self, finding):
+        return build_analysis_schema(has_dataflow=finding.get("has_dataflow", False))
+
+    def get_system_prompt(self):
+        return _analysis_system_text(self.profile) + self._JUDGE_ADDENDUM
+
+    def finalize(self, results, prior_results):
+        """Apply judge verdicts: preserve primary (single), majority (multi)."""
+        judge_by_finding: Dict[str, List[Dict]] = {}
+        for r in results:
+            fid = r.get("finding_id")
+            if fid and "error" not in r:
+                judge_by_finding.setdefault(fid, []).append(r)
+
+        for fid, primary in prior_results.items():
+            if isinstance(primary, dict) and "error" not in primary:
+                judge_analyses = judge_by_finding.get(fid, [])
+                if not judge_analyses:
+                    continue
+
+                primary_exploitable = primary.get("is_exploitable", False)
+                verdicts = [primary_exploitable]
+                for ja in judge_analyses:
+                    verdicts.append(ja.get("is_exploitable", False))
+
+                disputed = not all(v == verdicts[0] for v in verdicts)
+
+                n_judges = len(judge_analyses)
+                if n_judges == 1:
+                    final = primary_exploitable
+                else:
+                    final = sum(1 for v in verdicts if v) > len(verdicts) / 2
+
+                primary["judge"] = "disputed" if disputed else "agreed"
+                primary["is_exploitable"] = final
+                primary["judge_analyses"] = [
+                    {"model": ja.get("analysed_by", "?"),
+                     "is_exploitable": ja.get("is_exploitable"),
+                     "reasoning": ja.get("reasoning", "")}
+                    for ja in judge_analyses
                 ]
 
         return results

--- a/packages/llm_analysis/tests/test_correlation.py
+++ b/packages/llm_analysis/tests/test_correlation.py
@@ -1,0 +1,204 @@
+"""Tests for multi-model correlation engine."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[3]))
+
+from packages.llm_analysis.correlation import correlate_results, _build_clusters
+
+
+def _make_result(finding_id, analyses):
+    """Build a result dict with multi_model_analyses."""
+    return {
+        "finding_id": finding_id,
+        "rule_id": "sqli",
+        "multi_model_analyses": analyses,
+    }
+
+
+def _make_analysis(model, exploitable, score=0.8, ruling="validated"):
+    return {
+        "model": model,
+        "is_exploitable": exploitable,
+        "exploitability_score": score,
+        "ruling": ruling,
+        "reasoning": f"{model} says {'yes' if exploitable else 'no'}",
+    }
+
+
+class TestCorrelateResults:
+    def test_empty_input(self):
+        result = correlate_results({})
+        assert result["agreement_matrix"] == {}
+        assert result["clusters"] == []
+        assert result["unique_insights"] == []
+        assert result["confidence_signals"] == {}
+        assert result["summary"]["total_correlated"] == 0
+
+    def test_skips_single_model_findings(self):
+        results = {
+            "f-001": _make_result("f-001", [
+                _make_analysis("gemini", True),
+            ]),
+        }
+        result = correlate_results(results)
+        assert result["summary"]["total_correlated"] == 0
+
+    def test_skips_findings_without_analyses(self):
+        results = {
+            "f-001": {"finding_id": "f-001", "is_exploitable": True},
+        }
+        result = correlate_results(results)
+        assert result["summary"]["total_correlated"] == 0
+
+    def test_unanimous_exploitable(self):
+        results = {
+            "f-001": _make_result("f-001", [
+                _make_analysis("gemini", True),
+                _make_analysis("gpt-5", True),
+            ]),
+        }
+        result = correlate_results(results)
+        assert result["confidence_signals"]["f-001"] == "high"
+        assert result["summary"]["agreed"] == 1
+        assert result["summary"]["disputed"] == 0
+        assert result["summary"]["models"] == ["gemini", "gpt-5"]
+
+    def test_unanimous_not_exploitable(self):
+        results = {
+            "f-001": _make_result("f-001", [
+                _make_analysis("gemini", False),
+                _make_analysis("gpt-5", False),
+            ]),
+        }
+        result = correlate_results(results)
+        assert result["confidence_signals"]["f-001"] == "high-negative"
+        assert result["summary"]["agreed"] == 1
+
+    def test_disputed(self):
+        results = {
+            "f-001": _make_result("f-001", [
+                _make_analysis("gemini", True),
+                _make_analysis("gpt-5", False),
+            ]),
+        }
+        result = correlate_results(results)
+        assert result["confidence_signals"]["f-001"] == "disputed"
+        assert result["summary"]["disputed"] == 1
+
+    def test_disputed_unique_insights(self):
+        results = {
+            "f-001": _make_result("f-001", [
+                _make_analysis("gemini", True),
+                _make_analysis("gpt-5", False),
+                _make_analysis("claude", True),
+            ]),
+        }
+        result = correlate_results(results)
+        assert result["confidence_signals"]["f-001"] == "disputed"
+        # gpt-5 is the minority (1 not-exploitable vs 2 exploitable)
+        assert len(result["unique_insights"]) == 1
+        assert result["unique_insights"][0]["model"] == "gpt-5"
+        assert result["unique_insights"][0]["verdict"] is False
+
+    def test_agreement_matrix_structure(self):
+        results = {
+            "f-001": _make_result("f-001", [
+                _make_analysis("gemini", True, score=0.9),
+                _make_analysis("gpt-5", True, score=0.7),
+            ]),
+        }
+        result = correlate_results(results)
+        matrix = result["agreement_matrix"]
+        assert "f-001" in matrix
+        assert "gemini" in matrix["f-001"]
+        assert matrix["f-001"]["gemini"]["is_exploitable"] is True
+        assert matrix["f-001"]["gemini"]["exploitability_score"] == 0.9
+
+    def test_multiple_findings(self):
+        results = {
+            "f-001": _make_result("f-001", [
+                _make_analysis("gemini", True),
+                _make_analysis("gpt-5", True),
+            ]),
+            "f-002": _make_result("f-002", [
+                _make_analysis("gemini", False),
+                _make_analysis("gpt-5", True),
+            ]),
+        }
+        result = correlate_results(results)
+        assert result["summary"]["total_correlated"] == 2
+        assert result["summary"]["agreed"] == 1
+        assert result["summary"]["disputed"] == 1
+
+    def test_reasoning_truncated(self):
+        long_reasoning = "x" * 500
+        results = {
+            "f-001": _make_result("f-001", [
+                {"model": "gemini", "is_exploitable": True,
+                 "exploitability_score": 0.9, "ruling": "ok",
+                 "reasoning": long_reasoning},
+                {"model": "gpt-5", "is_exploitable": False,
+                 "exploitability_score": 0.2, "ruling": "no",
+                 "reasoning": "short"},
+            ]),
+        }
+        result = correlate_results(results)
+        for insight in result["unique_insights"]:
+            assert len(insight["reasoning"]) <= 200
+
+
+class TestBuildClusters:
+    def test_no_clusters_for_singletons(self):
+        matrix = {
+            "f-001": {"gemini": {"is_exploitable": True}},
+        }
+        clusters = _build_clusters(matrix, {})
+        assert clusters == []
+
+    def test_same_pattern_clusters(self):
+        matrix = {
+            "f-001": {"gemini": {"is_exploitable": True}, "gpt-5": {"is_exploitable": True}},
+            "f-002": {"gemini": {"is_exploitable": True}, "gpt-5": {"is_exploitable": True}},
+        }
+        results = {
+            "f-001": {"rule_id": "sqli"},
+            "f-002": {"rule_id": "sqli"},
+        }
+        clusters = _build_clusters(matrix, results)
+        assert len(clusters) == 1
+        assert clusters[0]["pattern"] == "unanimous"
+        assert clusters[0]["models_agreed"] is True
+        assert sorted(clusters[0]["finding_ids"]) == ["f-001", "f-002"]
+        assert "sqli" in clusters[0]["shared_rules"]
+
+    def test_different_patterns_no_cluster(self):
+        matrix = {
+            "f-001": {"gemini": {"is_exploitable": True}, "gpt-5": {"is_exploitable": True}},
+            "f-002": {"gemini": {"is_exploitable": True}, "gpt-5": {"is_exploitable": False}},
+        }
+        clusters = _build_clusters(matrix, {})
+        assert clusters == []
+
+    def test_split_pattern_cluster(self):
+        matrix = {
+            "f-001": {"gemini": {"is_exploitable": True}, "gpt-5": {"is_exploitable": False}},
+            "f-002": {"gemini": {"is_exploitable": True}, "gpt-5": {"is_exploitable": False}},
+        }
+        clusters = _build_clusters(matrix, {})
+        assert len(clusters) == 1
+        assert clusters[0]["pattern"] == "split"
+        assert clusters[0]["models_agreed"] is False
+
+    def test_multiple_clusters(self):
+        matrix = {
+            "f-001": {"gemini": {"is_exploitable": True}, "gpt-5": {"is_exploitable": True}},
+            "f-002": {"gemini": {"is_exploitable": True}, "gpt-5": {"is_exploitable": True}},
+            "f-003": {"gemini": {"is_exploitable": False}, "gpt-5": {"is_exploitable": False}},
+            "f-004": {"gemini": {"is_exploitable": False}, "gpt-5": {"is_exploitable": False}},
+        }
+        clusters = _build_clusters(matrix, {})
+        assert len(clusters) == 2

--- a/packages/llm_analysis/tests/test_dispatch.py
+++ b/packages/llm_analysis/tests/test_dispatch.py
@@ -14,8 +14,8 @@ from packages.llm_analysis.dispatch import (
     _classify_error,
 )
 from packages.llm_analysis.tasks import (
-    AnalysisTask, ExploitTask, PatchTask, ConsensusTask, GroupAnalysisTask,
-    RetryTask,
+    AnalysisTask, ExploitTask, PatchTask, ConsensusTask,
+    GroupAnalysisTask, JudgeTask, RetryTask,
 )
 from packages.llm_analysis.orchestrator import CostTracker
 
@@ -100,6 +100,52 @@ class TestAnalysisTask:
     def test_system_prompt(self):
         task = AnalysisTask()
         assert task.get_system_prompt() is not None
+
+
+    def test_get_models_returns_analysis_models_list(self):
+        task = AnalysisTask()
+        m1 = MagicMock()
+        m2 = MagicMock()
+        resolution = {"analysis_models": [m1, m2]}
+        assert task.get_models(resolution) == [m1, m2]
+
+    def test_get_models_fallback_to_singular(self):
+        task = AnalysisTask()
+        m1 = MagicMock()
+        resolution = {"analysis_model": m1}
+        assert task.get_models(resolution) == [m1]
+
+
+class TestSelectPrimaryResult:
+    def test_prefers_exploitable(self):
+        from packages.llm_analysis.orchestrator import _select_primary_result
+        r1 = {"is_exploitable": False, "exploitability_score": 0.9, "analysed_by": "m1"}
+        r2 = {"is_exploitable": True, "exploitability_score": 0.5, "analysed_by": "m2"}
+        assert _select_primary_result([r1, r2])["analysed_by"] == "m2"
+
+    def test_prefers_higher_quality(self):
+        from packages.llm_analysis.orchestrator import _select_primary_result
+        r1 = {"is_exploitable": True, "_quality": 0.5, "analysed_by": "m1"}
+        r2 = {"is_exploitable": True, "_quality": 0.9, "analysed_by": "m2"}
+        assert _select_primary_result([r1, r2])["analysed_by"] == "m2"
+
+    def test_prefers_higher_score_on_tie(self):
+        from packages.llm_analysis.orchestrator import _select_primary_result
+        r1 = {"is_exploitable": True, "_quality": 1.0, "exploitability_score": 0.7, "analysed_by": "m1"}
+        r2 = {"is_exploitable": True, "_quality": 1.0, "exploitability_score": 0.9, "analysed_by": "m2"}
+        assert _select_primary_result([r1, r2])["analysed_by"] == "m2"
+
+    def test_skips_errors(self):
+        from packages.llm_analysis.orchestrator import _select_primary_result
+        r1 = {"error": "failed", "analysed_by": "m1"}
+        r2 = {"is_exploitable": False, "analysed_by": "m2"}
+        assert _select_primary_result([r1, r2])["analysed_by"] == "m2"
+
+    def test_single_result(self):
+        from packages.llm_analysis.orchestrator import _select_primary_result
+        r1 = {"is_exploitable": True, "analysed_by": "m1"}
+        result = _select_primary_result([r1])
+        assert result["analysed_by"] == "m1"
 
 
 class TestExploitTask:
@@ -619,3 +665,423 @@ class TestClassifyError:
 
     def test_empty_string(self):
         assert _classify_error("") == "error"
+
+
+class TestJudgeTask:
+    def test_gets_judge_models(self):
+        task = JudgeTask()
+        m1 = MagicMock()
+        resolution = {"judge_models": [m1]}
+        assert task.get_models(resolution) == [m1]
+
+    def test_selects_same_as_consensus(self):
+        task = JudgeTask()
+        findings = [_make_finding("f-001"), _make_finding("f-002"), _make_finding("f-003")]
+        prior = {
+            "f-001": {"is_exploitable": True},
+            "f-002": {"error": "failed"},
+            "f-003": {"is_exploitable": True, "cross_family_agreed": True},
+        }
+        selected = task.select_items(findings, prior)
+        assert len(selected) == 1
+        assert selected[0]["finding_id"] == "f-001"
+
+    def test_finalize_single_judge_preserves_primary(self):
+        task = JudgeTask()
+        judge_results = [
+            {"finding_id": "f-001", "is_exploitable": True, "analysed_by": "gpt-5",
+             "reasoning": "looks exploitable"}
+        ]
+        prior = {"f-001": {"is_exploitable": False, "finding_id": "f-001"}}
+        task.finalize(judge_results, prior)
+        assert prior["f-001"]["is_exploitable"] is False
+        assert prior["f-001"]["judge"] == "disputed"
+
+    def test_finalize_single_judge_agreed(self):
+        task = JudgeTask()
+        judge_results = [
+            {"finding_id": "f-001", "is_exploitable": True, "analysed_by": "gpt-5",
+             "reasoning": "confirmed"}
+        ]
+        prior = {"f-001": {"is_exploitable": True, "finding_id": "f-001"}}
+        task.finalize(judge_results, prior)
+        assert prior["f-001"]["is_exploitable"] is True
+        assert prior["f-001"]["judge"] == "agreed"
+
+    def test_finalize_multi_judge_majority(self):
+        task = JudgeTask()
+        judge_results = [
+            {"finding_id": "f-001", "is_exploitable": False, "analysed_by": "gpt-5",
+             "reasoning": "no"},
+            {"finding_id": "f-001", "is_exploitable": False, "analysed_by": "mistral",
+             "reasoning": "no"},
+        ]
+        prior = {"f-001": {"is_exploitable": True, "finding_id": "f-001"}}
+        task.finalize(judge_results, prior)
+        assert prior["f-001"]["is_exploitable"] is False
+        assert prior["f-001"]["judge"] == "disputed"
+
+    def test_judge_analyses_in_output(self):
+        task = JudgeTask()
+        judge_results = [
+            {"finding_id": "f-001", "is_exploitable": True, "analysed_by": "gpt-5",
+             "reasoning": "judge reasoning text"}
+        ]
+        prior = {"f-001": {"is_exploitable": True, "finding_id": "f-001"}}
+        task.finalize(judge_results, prior)
+        analyses = prior["f-001"]["judge_analyses"]
+        assert len(analyses) == 1
+        assert analyses[0]["reasoning"] == "judge reasoning text"
+        assert analyses[0]["model"] == "gpt-5"
+
+    def test_budget_cutoff(self):
+        assert JudgeTask.budget_cutoff == 0.75
+
+    def test_builds_prompt_includes_primary_reasoning(self):
+        results_by_id = {
+            "f-001": {
+                "is_exploitable": True,
+                "ruling": "validated",
+                "reasoning": "SQL injection via user input",
+            }
+        }
+        task = JudgeTask(results_by_id=results_by_id)
+        finding = _make_finding("f-001")
+        prompt = task.build_prompt(finding)
+        assert "SQL injection via user input" in prompt
+        assert "is_exploitable=True" in prompt
+
+
+class TestJudgeEdgeCases:
+    def test_finalize_no_judge_results_for_finding(self):
+        """Findings without judge results should be untouched."""
+        task = JudgeTask()
+        prior = {"f-001": {"is_exploitable": True, "finding_id": "f-001"}}
+        task.finalize([], prior)
+        assert "judge" not in prior["f-001"]
+        assert prior["f-001"]["is_exploitable"] is True
+
+    def test_finalize_skips_error_results(self):
+        task = JudgeTask()
+        judge_results = [
+            {"finding_id": "f-001", "error": "model failed"}
+        ]
+        prior = {"f-001": {"is_exploitable": True, "finding_id": "f-001"}}
+        task.finalize(judge_results, prior)
+        assert "judge" not in prior["f-001"]
+
+    def test_finalize_skips_error_prior(self):
+        task = JudgeTask()
+        judge_results = [
+            {"finding_id": "f-001", "is_exploitable": True, "analysed_by": "gpt-5",
+             "reasoning": "yes"}
+        ]
+        prior = {"f-001": {"error": "analysis failed"}}
+        task.finalize(judge_results, prior)
+        assert "judge" not in prior["f-001"]
+
+    def test_select_skips_false_positives(self):
+        task = JudgeTask()
+        findings = [_make_finding("f-001")]
+        prior = {"f-001": {"is_exploitable": False, "is_true_positive": False}}
+        assert task.select_items(findings, prior) == []
+
+    def test_select_includes_true_positive_default(self):
+        """is_true_positive defaults to True when missing."""
+        task = JudgeTask()
+        findings = [_make_finding("f-001")]
+        prior = {"f-001": {"is_exploitable": True}}
+        assert len(task.select_items(findings, prior)) == 1
+
+
+class TestProviderOf:
+    def test_claude_maps_to_anthropic(self):
+        from core.security.llm_family import provider_of
+        assert provider_of("claude-opus-4-6") == "anthropic"
+
+    def test_gemini_maps_to_gemini(self):
+        from core.security.llm_family import provider_of
+        assert provider_of("gemini-2.5-pro") == "gemini"
+
+    def test_gpt_maps_to_openai(self):
+        from core.security.llm_family import provider_of
+        assert provider_of("gpt-5.4") == "openai"
+
+    def test_unknown_returns_empty(self):
+        from core.security.llm_family import provider_of
+        assert provider_of("some-random-model") == ""
+
+    def test_ollama_prefix(self):
+        from core.security.llm_family import provider_of
+        assert provider_of("ollama/llama-3") == "ollama"
+
+
+class TestConfigRoleValidation:
+    def test_judge_without_analysis_raises(self):
+        from core.llm.config import _validate_model_roles, ConfigError
+        m = MagicMock()
+        m.role = "judge"
+        m.model_name = "gpt-5"
+        with pytest.raises(ConfigError, match="Judge.*without.*analysis"):
+            _validate_model_roles([m])
+
+    def test_judge_with_analysis_ok(self):
+        from core.llm.config import _validate_model_roles
+        analysis = MagicMock(); analysis.role = "analysis"; analysis.model_name = "gemini"
+        judge = MagicMock(); judge.role = "judge"; judge.model_name = "gpt-5"
+        _validate_model_roles([analysis, judge])
+
+    def test_resolve_roles_includes_judge(self):
+        from core.llm.config import resolve_model_roles
+        analysis = MagicMock(); analysis.role = "analysis"; analysis.model_name = "gemini"
+        judge = MagicMock(); judge.role = "judge"; judge.model_name = "gpt-5"
+        result = resolve_model_roles(analysis, [judge])
+        assert result["judge_models"] == [judge]
+        assert result["analysis_model"] == analysis
+
+    def test_multiple_analysis_models_allowed(self):
+        from core.llm.config import _validate_model_roles
+        m1 = MagicMock(); m1.role = "analysis"; m1.model_name = "gemini"
+        m2 = MagicMock(); m2.role = "analysis"; m2.model_name = "gpt-5"
+        _validate_model_roles([m1, m2])
+
+    def test_resolve_roles_returns_analysis_models_list(self):
+        from core.llm.config import resolve_model_roles
+        m1 = MagicMock(); m1.role = "analysis"; m1.model_name = "gemini"
+        m2 = MagicMock(); m2.role = "analysis"; m2.model_name = "gpt-5"
+        result = resolve_model_roles(m1, [m2])
+        assert len(result["analysis_models"]) == 2
+        assert result["analysis_model"] == m1
+
+
+class TestBuildLLMConfigFromFlags:
+    def test_no_flags_no_autodetect_returns_none(self):
+        from packages.llm_analysis.orchestrator import build_llm_config_from_flags
+        assert build_llm_config_from_flags(auto_detect=False) is None
+
+    def test_unknown_model_no_key_returns_none(self):
+        from packages.llm_analysis.orchestrator import build_llm_config_from_flags
+        result = build_llm_config_from_flags(models=["no-such-model"], auto_detect=False)
+        assert result is None
+
+    def test_role_flags_without_primary_returns_none(self):
+        from packages.llm_analysis.orchestrator import build_llm_config_from_flags
+        result = build_llm_config_from_flags(
+            consensus="gpt-5", auto_detect=False,
+        )
+        assert result is None
+
+    @patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"})
+    def test_single_model_flag(self):
+        from packages.llm_analysis.orchestrator import build_llm_config_from_flags
+        result = build_llm_config_from_flags(
+            models=["gemini-2.5-pro"], auto_detect=False,
+        )
+        assert result is not None
+        assert result.primary_model.model_name == "gemini-2.5-pro"
+
+    @patch.dict("os.environ", {"GEMINI_API_KEY": "test-key", "ANTHROPIC_API_KEY": "test-key-2"})
+    def test_model_with_role_flags(self):
+        from packages.llm_analysis.orchestrator import build_llm_config_from_flags
+        result = build_llm_config_from_flags(
+            models=["gemini-2.5-pro"],
+            consensus="claude-sonnet-4-6",
+            auto_detect=False,
+        )
+        assert result is not None
+        consensus_models = [m for m in result.fallback_models if m.role == "consensus"]
+        assert len(consensus_models) == 1
+        assert consensus_models[0].model_name == "claude-sonnet-4-6"
+
+    @patch.dict("os.environ", {"GEMINI_API_KEY": "test-key", "OPENAI_API_KEY": "test-key-2"})
+    def test_multi_model_flags(self):
+        from packages.llm_analysis.orchestrator import build_llm_config_from_flags
+        result = build_llm_config_from_flags(
+            models=["gemini-2.5-pro", "gpt-5"],
+            auto_detect=False,
+        )
+        assert result is not None
+        assert result.primary_model.model_name == "gemini-2.5-pro"
+        analysis_models = [m for m in result.fallback_models if m.role == "analysis"]
+        assert len(analysis_models) == 1
+        assert analysis_models[0].model_name == "gpt-5"
+
+    @patch.dict("os.environ", {"GEMINI_API_KEY": "k1", "OPENAI_API_KEY": "k2", "ANTHROPIC_API_KEY": "k3"})
+    def test_three_models_skips_consensus(self, capsys):
+        from packages.llm_analysis.orchestrator import build_llm_config_from_flags
+        result = build_llm_config_from_flags(
+            models=["gemini-2.5-pro", "gpt-5", "claude-opus-4-6"],
+            consensus="mistral-large-latest",
+            auto_detect=False,
+        )
+        assert result is not None
+        consensus_models = [m for m in result.fallback_models if m.role == "consensus"]
+        assert len(consensus_models) == 0
+        captured = capsys.readouterr()
+        assert "skipped" in captured.out.lower()
+
+
+# -----------------------------------------------------------------------
+# SCA integration tests
+# -----------------------------------------------------------------------
+
+def _make_sca_finding(
+    finding_id,
+    *,
+    reachability="likely_called",
+    in_kev=False,
+    fixed_version="9.0.3",
+):
+    """Create a minimal SCA finding for task selection tests."""
+    return {
+        "finding_id": finding_id,
+        "rule_id": "sca:vulnerable_dependency",
+        "file_path": "requirements.txt",
+        "start_line": 5,
+        "end_line": 5,
+        "level": "warning",
+        "message": "Vulnerable dependency",
+        "code": 'pytest>=7.0.0',
+        "surrounding_context": "",
+        "sca": {
+            "ecosystem": "PyPI",
+            "name": "pytest",
+            "version": "7.0.0",
+            "fixed_version": fixed_version,
+            "reachability": reachability,
+            "in_kev": in_kev,
+            "declared_in": "requirements.txt",
+            "advisory": {
+                "id": "GHSA-6w46-j5rx-g56g",
+                "aliases": ["CVE-2025-71176"],
+                "summary": "pytest has vulnerable tmpdir handling",
+            },
+        },
+    }
+
+
+class TestExploitTaskSCA:
+    """ExploitTask selection of SCA findings for reachability PoC."""
+
+    def test_selects_sca_with_likely_called(self):
+        task = ExploitTask()
+        findings = [_make_sca_finding("sca-001", reachability="likely_called")]
+        selected = task.select_items(findings, {})
+        assert len(selected) == 1
+
+    def test_selects_sca_with_imported(self):
+        task = ExploitTask()
+        findings = [_make_sca_finding("sca-001", reachability="imported")]
+        selected = task.select_items(findings, {})
+        assert len(selected) == 1
+
+    def test_selects_sca_kev_with_non_reachable(self):
+        task = ExploitTask()
+        findings = [_make_sca_finding("sca-001", reachability="not_evaluated", in_kev=True)]
+        selected = task.select_items(findings, {})
+        assert len(selected) == 1
+
+    def test_skips_sca_kev_with_not_reachable(self):
+        task = ExploitTask()
+        findings = [_make_sca_finding("sca-001", reachability="not_reachable", in_kev=True)]
+        selected = task.select_items(findings, {})
+        assert len(selected) == 0
+
+    def test_skips_sca_without_reachability_or_kev(self):
+        task = ExploitTask()
+        findings = [_make_sca_finding("sca-001", reachability="not_evaluated", in_kev=False)]
+        selected = task.select_items(findings, {})
+        assert len(selected) == 0
+
+    def test_skips_sca_with_existing_exploit(self):
+        task = ExploitTask()
+        findings = [_make_sca_finding("sca-001")]
+        prior = {"sca-001": {"exploit_code": "# already"}}
+        selected = task.select_items(findings, prior)
+        assert len(selected) == 0
+
+    def test_mixes_source_and_sca_findings(self):
+        task = ExploitTask()
+        findings = [
+            _make_finding("src-001"),
+            _make_sca_finding("sca-001", reachability="likely_called"),
+        ]
+        prior = {"src-001": {"is_exploitable": True}}
+        selected = task.select_items(findings, prior)
+        assert len(selected) == 2
+
+
+class TestPatchTaskSCA:
+    """PatchTask selection of SCA findings for manifest patches."""
+
+    def test_selects_sca_with_fix_version(self):
+        task = PatchTask()
+        findings = [_make_sca_finding("sca-001", fixed_version="9.0.3")]
+        selected = task.select_items(findings, {})
+        assert len(selected) == 1
+
+    def test_skips_sca_without_fix_version(self):
+        task = PatchTask()
+        findings = [_make_sca_finding("sca-001", fixed_version="")]
+        selected = task.select_items(findings, {})
+        assert len(selected) == 0
+
+    def test_skips_sca_with_existing_patch(self):
+        task = PatchTask()
+        findings = [_make_sca_finding("sca-001")]
+        prior = {"sca-001": {"patch_code": "# already"}}
+        selected = task.select_items(findings, prior)
+        assert len(selected) == 0
+
+    def test_sca_hygiene_not_selected(self):
+        task = PatchTask()
+        finding = _make_sca_finding("sca-001")
+        finding["rule_id"] = "sca:hygiene:lockfile_missing"
+        selected = task.select_items([finding], {})
+        assert len(selected) == 0
+
+
+class TestScaExploitPrompt:
+    """SCA-specific exploit prompt builder."""
+
+    def test_builds_sca_prompt(self):
+        from packages.llm_analysis.prompts.exploit import (
+            build_exploit_prompt_bundle_from_finding,
+        )
+        finding = _make_sca_finding("sca-001")
+        bundle = build_exploit_prompt_bundle_from_finding(finding)
+        user_msg = next(m.content for m in bundle.messages if m.role == "user")
+        assert "CVE-2025-71176" in user_msg
+        assert "pytest" in user_msg
+
+    def test_routes_source_findings_normally(self):
+        from packages.llm_analysis.prompts.exploit import (
+            build_exploit_prompt_bundle_from_finding,
+        )
+        finding = _make_finding("src-001")
+        bundle = build_exploit_prompt_bundle_from_finding(finding)
+        user_msg = next(m.content for m in bundle.messages if m.role == "user")
+        assert "sqli" in user_msg
+
+
+class TestScaPatchPrompt:
+    """SCA-specific patch prompt builder."""
+
+    def test_builds_sca_patch_prompt(self):
+        from packages.llm_analysis.prompts.patch import (
+            build_patch_prompt_bundle_from_finding,
+        )
+        finding = _make_sca_finding("sca-001")
+        bundle = build_patch_prompt_bundle_from_finding(finding)
+        user_msg = next(m.content for m in bundle.messages if m.role == "user")
+        assert "9.0.3" in user_msg
+        assert "pytest" in user_msg
+
+    def test_routes_source_findings_normally(self):
+        from packages.llm_analysis.prompts.patch import (
+            build_patch_prompt_bundle_from_finding,
+        )
+        finding = _make_finding("src-001")
+        bundle = build_patch_prompt_bundle_from_finding(finding)
+        user_msg = next(m.content for m in bundle.messages if m.role == "user")
+        assert "sqli" in user_msg or "db.py" in user_msg

--- a/packages/sca/__init__.py
+++ b/packages/sca/__init__.py
@@ -1,1 +1,42 @@
-"""RAPTOR SCA Package - Software Composition Analysis."""
+"""RAPTOR SCA Package - Software Composition Analysis.
+
+Canonical host allowlist for /sca network egress.  Consumed by:
+
+  - ``packages.sca.agent`` when launching raptor-sca as a sandboxed
+    subprocess (``proxy_hosts=list(SCA_ALLOWED_HOSTS)``).
+  - ``raptor_agentic.py`` Phase 1b (same pattern).
+  - raptor-sca's own ``packages.sca.__init__.default_client()`` which
+    constructs an ``EgressClient`` with the same set.
+
+When a new registry or feed is added on the raptor-sca side, add the
+host here too so the sandbox permits the traffic.
+"""
+
+# The full set of hosts /sca needs to reach for vulnerability data and
+# registry metadata.  Mirrors the authoritative list in the raptor-sca
+# branch at ``packages/sca/__init__.py``.  Ordered by purpose.
+SCA_ALLOWED_HOSTS: tuple[str, ...] = (
+    # Vulnerability feeds
+    "api.osv.dev",
+    "osv-vulnerabilities.storage.googleapis.com",   # OSV offline-DB zip mirror
+    "www.cisa.gov",                                 # KEV feed
+    "api.first.org",                                # EPSS scores
+    # Registry metadata (harden / typosquat / supply-chain heuristics)
+    "pypi.org",
+    "registry.npmjs.org",
+    "crates.io",
+    "rubygems.org",
+    "proxy.golang.org",
+    "search.maven.org",
+    "repo.packagist.org",
+    "api.nuget.org",
+    "sources.debian.org",
+    "formulae.brew.sh",
+    # Source-archive downloads (version-diff review + wheel-metadata fallback)
+    "files.pythonhosted.org",                       # PyPI sdist/wheel archives
+    "static.crates.io",                             # Cargo crate tarballs
+    "sum.golang.org",                               # Go module checksums
+    "repo.maven.apache.org",                        # Maven/Gradle source jars
+    "repo1.maven.org",                              # Maven Central mirror
+    "api.github.com",                               # GHA ref→SHA resolution
+)

--- a/packages/sca/agent.py
+++ b/packages/sca/agent.py
@@ -1,48 +1,189 @@
 #!/usr/bin/env python3
-"""RAPTOR SCA Agent (safe)
-- Inspects common dependency files (pom.xml, build.gradle, package.json, requirements.txt)
-- Produces out/sca.json with discovered dependency files and a simple parse (list of deps)
-- Non-network: does not contact package registries
-"""
-import argparse, json, os, shutil, subprocess, sys, tempfile, time
-from pathlib import Path
-from core.json import load_json, save_json
-import xml.etree.ElementTree as ET
+"""Bridge between raptor and raptor-sca for agentic and sandboxed runs.
 
+Provides:
+
+  - :func:`_find_sca_agent` — discover the raptor-sca entry point.
+    Returns the resolved path to ``packages/sca/agent.py`` in the
+    raptor-sca tree, or ``None`` if raptor-sca is not installed.
+
+  - :func:`run_sca_subprocess` — launch raptor-sca as a sandboxed
+    subprocess with egress routed through the proxy.  The hostname
+    allowlist is :data:`packages.sca.SCA_ALLOWED_HOSTS`.
+
+Used by ``raptor_agentic.py`` Phase 1b::
+
+    from packages.sca.agent import _find_sca_agent, run_sca_subprocess
+    agent = _find_sca_agent()
+    if agent:
+        rc, stdout, stderr = run_sca_subprocess(agent, target, out, ...)
+
+And by the raptor-side ``packages/sca/__init__.py`` for the canonical
+host list (the old basic-scan functions are retained for backward compat
+with existing tests).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+from core.json import load_json, save_json
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# raptor-sca discovery
+# ---------------------------------------------------------------------------
+
+# Search order for the raptor-sca agent entry point. The worktree
+# location is the most common dev layout; the sibling directory covers
+# a standalone checkout.  Paths are relative to the raptor repo root.
+_SCA_AGENT_CANDIDATES = (
+    # git worktree at ../raptor-sca
+    Path(__file__).resolve().parents[2] / ".." / "raptor-sca" / "packages" / "sca" / "agent.py",  # noqa: E501
+    # same-repo feature branch (packages/sca/agent.py IS the agent)
+    # — when feat/sca merges to main, this file is replaced by the
+    #   full agent; until then, a marker file signals the real one.
+    Path(__file__).resolve().parents[2] / "packages" / "sca" / "_sca_agent_marker",
+)
+
+
+def _find_sca_agent() -> Optional[Path]:
+    """Discover the raptor-sca subprocess agent.
+
+    Returns the resolved path to the raptor-sca agent entry point, or
+    ``None`` when raptor-sca is not installed.  The agent is the
+    ``packages/sca/agent.py`` script in the raptor-sca tree — NOT this
+    file (which is the raptor-side bridge).
+    """
+    # Explicit override — useful for CI or custom layouts.
+    env_path = os.environ.get("RAPTOR_SCA_AGENT")
+    if env_path:
+        p = Path(env_path).resolve()
+        if p.is_file():
+            return p
+        logger.warning("RAPTOR_SCA_AGENT=%s does not exist — ignoring", env_path)
+
+    for candidate in _SCA_AGENT_CANDIDATES:
+        resolved = candidate.resolve()
+        if resolved.is_file() and resolved.name == "agent.py":
+            # Quick sanity: the real raptor-sca agent imports
+            # packages.sca.api, not core.json.  Check for the
+            # SCA_ALLOWED_HOSTS import to distinguish it from this file.
+            try:
+                text = resolved.read_text(encoding="utf-8")
+                if "from packages.sca import SCA_ALLOWED_HOSTS" in text:
+                    return resolved
+            except OSError:
+                pass
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Sandboxed subprocess launch
+# ---------------------------------------------------------------------------
+
+def run_sca_subprocess(
+    agent_path: Path,
+    target: Path,
+    output_dir: Path,
+    *,
+    sandbox_args: Sequence[str] = (),
+    env: Optional[dict] = None,
+    timeout: int = 600,
+) -> tuple:
+    """Run the raptor-sca agent as a sandboxed subprocess.
+
+    Uses :func:`core.sandbox.run` with ``use_egress_proxy=True`` so the
+    child's outbound HTTPS is funnelled through the in-process proxy
+    with :data:`packages.sca.SCA_ALLOWED_HOSTS` as the hostname
+    allowlist.  Landlock confines writes to ``output_dir``.
+
+    Returns ``(returncode, stdout, stderr)``.
+    """
+    from core.config import RaptorConfig
+    from core.sandbox import run as sandbox_run
+    from packages.sca import SCA_ALLOWED_HOSTS
+
+    cmd: list = [
+        sys.executable, str(agent_path),
+        "--repo", str(target),
+        "--out", str(output_dir),
+        *sandbox_args,
+    ]
+
+    result = sandbox_run(
+        cmd,
+        use_egress_proxy=True,
+        proxy_hosts=list(SCA_ALLOWED_HOSTS),
+        caller_label="sca-agent",
+        target=str(target),
+        output=str(output_dir),
+        env=env or RaptorConfig.get_safe_env(),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Legacy basic-scan functions (retained for backward compat with tests)
+# ---------------------------------------------------------------------------
 
 def get_out_dir() -> Path:
     base = os.environ.get("RAPTOR_OUT_DIR")
     return Path(base).resolve() if base else Path("out").resolve()
 
-def find_dependency_files(root: Path):
+
+def find_dependency_files(root: Path) -> List[Path]:
     candidates = []
-    for pat in ['pom.xml','build.gradle','package.json','requirements.txt','pyproject.toml']:
+    for pat in ['pom.xml', 'build.gradle', 'package.json',
+                'requirements.txt', 'pyproject.toml']:
         for p in root.rglob(pat):
             candidates.append(p)
     return candidates
+
 
 def parse_pom(p):
     try:
         tree = ET.parse(p)
         root = tree.getroot()
-        ns = {'m':'http://maven.apache.org/POM/4.0.0'}
+        ns = {'m': 'http://maven.apache.org/POM/4.0.0'}
         deps = []
         for d in root.findall('.//m:dependency', ns):
             g = d.find('m:groupId', ns)
             a = d.find('m:artifactId', ns)
             v = d.find('m:version', ns)
-            deps.append({'group': g.text if g is not None else None, 'artifact': a.text if a is not None else None, 'version': v.text if v is not None else None})
+            deps.append({
+                'group': g.text if g is not None else None,
+                'artifact': a.text if a is not None else None,
+                'version': v.text if v is not None else None,
+            })
         return deps
     except Exception as e:
         return {'error': str(e)}
+
 
 def parse_requirements(p):
     deps = []
     for ln in p.read_text().splitlines():
         ln = ln.strip()
-        if not ln or ln.startswith('#'): continue
+        if not ln or ln.startswith('#'):
+            continue
         deps.append(ln)
     return deps
+
 
 def parse_package_json(p):
     try:
@@ -50,19 +191,23 @@ def parse_package_json(p):
         if obj is None:
             return {'error': 'failed to parse JSON'}
         deps = obj.get('dependencies', {})
-        return [{'name':k,'version':v} for k,v in deps.items()]
+        return [{'name': k, 'version': v} for k, v in deps.items()]
     except Exception as e:
         return {'error': str(e)}
+
 
 def main():
     ap = argparse.ArgumentParser(description='RAPTOR SCA Agent')
     ap.add_argument('--repo', required=True)
     args = ap.parse_args()
     repo = Path(args.repo).resolve()
-    if not repo.exists(): 
+    if not repo.exists():
         raise SystemExit('repo not found')
 
-    out = {'files':[], 'timestamp': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}
+    out = {
+        'files': [],
+        'timestamp': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+    }
     for p in find_dependency_files(repo):
         entry = {'path': str(p)}
         if p.name == 'pom.xml':
@@ -78,7 +223,7 @@ def main():
     out_dir = get_out_dir()
     out_dir.mkdir(parents=True, exist_ok=True)
     save_json(out_dir / 'sca.json', out)
-    print(json.dumps({'status':'ok','files_found': len(out['files'])}))
+    print(json.dumps({'status': 'ok', 'files_found': len(out['files'])}))
 
 
 if __name__ == '__main__':

--- a/packages/sca/tests/test_sca_egress.py
+++ b/packages/sca/tests/test_sca_egress.py
@@ -1,0 +1,219 @@
+"""Tests for SCA egress allowlist integration.
+
+Verifies that:
+1. SCA_ALLOWED_HOSTS contains all required hosts.
+2. SCA_ALLOWED_HOSTS on the raptor side matches the raptor-sca side.
+3. _find_sca_agent discovers (or doesn't discover) the raptor-sca agent.
+4. run_sca_subprocess wires proxy_hosts correctly.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from packages.sca import SCA_ALLOWED_HOSTS
+from packages.sca.agent import _find_sca_agent, run_sca_subprocess
+
+
+# ---------------------------------------------------------------------------
+# SCA_ALLOWED_HOSTS completeness
+# ---------------------------------------------------------------------------
+
+class TestScaAllowedHosts:
+
+    def test_is_tuple(self):
+        """Immutable — accidental mutation is a security regression."""
+        assert isinstance(SCA_ALLOWED_HOSTS, tuple)
+
+    def test_not_empty(self):
+        assert len(SCA_ALLOWED_HOSTS) > 0
+
+    def test_contains_osv(self):
+        assert "api.osv.dev" in SCA_ALLOWED_HOSTS
+
+    def test_contains_kev(self):
+        assert "www.cisa.gov" in SCA_ALLOWED_HOSTS
+
+    def test_contains_epss(self):
+        assert "api.first.org" in SCA_ALLOWED_HOSTS
+
+    def test_contains_pypi_registry(self):
+        assert "pypi.org" in SCA_ALLOWED_HOSTS
+
+    def test_contains_npm_registry(self):
+        assert "registry.npmjs.org" in SCA_ALLOWED_HOSTS
+
+    def test_contains_crates_registry(self):
+        assert "crates.io" in SCA_ALLOWED_HOSTS
+
+    def test_contains_rubygems_registry(self):
+        assert "rubygems.org" in SCA_ALLOWED_HOSTS
+
+    def test_contains_golang_proxy(self):
+        assert "proxy.golang.org" in SCA_ALLOWED_HOSTS
+
+    def test_contains_nuget_registry(self):
+        assert "api.nuget.org" in SCA_ALLOWED_HOSTS
+
+    def test_contains_maven_registry(self):
+        assert "repo.maven.apache.org" in SCA_ALLOWED_HOSTS
+
+    def test_contains_packagist_registry(self):
+        assert "repo.packagist.org" in SCA_ALLOWED_HOSTS
+
+    def test_contains_pypi_archives(self):
+        """Source-archive downloads for version-diff review."""
+        assert "files.pythonhosted.org" in SCA_ALLOWED_HOSTS
+
+    def test_contains_github_api(self):
+        assert "api.github.com" in SCA_ALLOWED_HOSTS
+
+    def test_no_duplicates(self):
+        assert len(SCA_ALLOWED_HOSTS) == len(set(SCA_ALLOWED_HOSTS))
+
+    def test_all_lowercase(self):
+        """Proxy comparison is case-insensitive but the canonical form
+        should be lowercase for consistency."""
+        for host in SCA_ALLOWED_HOSTS:
+            assert host == host.lower(), f"{host} is not lowercase"
+
+
+# ---------------------------------------------------------------------------
+# Cross-repo parity
+# ---------------------------------------------------------------------------
+
+class TestCrossRepoParity:
+
+    @pytest.fixture()
+    def raptor_sca_init(self):
+        """Path to raptor-sca's packages/sca/__init__.py, if available."""
+        candidate = (Path(__file__).resolve().parents[3]
+                     / ".." / "raptor-sca" / "packages" / "sca" / "__init__.py")
+        if not candidate.resolve().is_file():
+            pytest.skip("raptor-sca not available at ../raptor-sca")
+        return candidate.resolve()
+
+    def test_hosts_match_raptor_sca(self, raptor_sca_init):
+        """Every host in raptor-sca's SCA_ALLOWED_HOSTS must appear in
+        the raptor-side copy. Extra hosts on the raptor side are OK
+        (forward-compat), but missing hosts mean the sandbox will block
+        SCA traffic."""
+        text = raptor_sca_init.read_text(encoding="utf-8")
+        # Extract the SCA_ALLOWED_HOSTS tuple literal from source.
+        # We isolate the block between "SCA_ALLOWED_HOSTS = (" and the
+        # closing ")" then extract quoted hostnames (must contain a dot
+        # to distinguish from non-host string literals).
+        import re
+        m = re.search(
+            r'SCA_ALLOWED_HOSTS\s*=\s*\((.*?)\)',
+            text, re.DOTALL,
+        )
+        assert m, "could not find SCA_ALLOWED_HOSTS in raptor-sca"
+        block = m.group(1)
+        hosts_in_sca = set(re.findall(r'"([a-z0-9][a-z0-9._-]*\.[a-z]{2,})"', block))
+        raptor_hosts = set(SCA_ALLOWED_HOSTS)
+        missing = hosts_in_sca - raptor_hosts
+        assert not missing, (
+            f"raptor-sca declares hosts not in raptor's SCA_ALLOWED_HOSTS: "
+            f"{sorted(missing)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _find_sca_agent
+# ---------------------------------------------------------------------------
+
+class TestFindScaAgent:
+
+    def test_returns_none_when_not_installed(self, tmp_path, monkeypatch):
+        """When no raptor-sca tree exists, returns None."""
+        monkeypatch.delenv("RAPTOR_SCA_AGENT", raising=False)
+        # _find_sca_agent searches relative to packages/sca/agent.py's
+        # parents; with no raptor-sca worktree it should return None.
+        result = _find_sca_agent()
+        # Either None (no raptor-sca) or a valid path (raptor-sca exists).
+        # Both are acceptable — the function must not crash.
+        assert result is None or result.is_file()
+
+    def test_env_override(self, tmp_path, monkeypatch):
+        """RAPTOR_SCA_AGENT env var overrides discovery."""
+        agent = tmp_path / "agent.py"
+        agent.write_text("from packages.sca import SCA_ALLOWED_HOSTS\n")
+        monkeypatch.setenv("RAPTOR_SCA_AGENT", str(agent))
+        result = _find_sca_agent()
+        assert result == agent
+
+    def test_env_override_nonexistent(self, tmp_path, monkeypatch):
+        """RAPTOR_SCA_AGENT pointing to a missing file returns None."""
+        monkeypatch.setenv("RAPTOR_SCA_AGENT", str(tmp_path / "nope.py"))
+        result = _find_sca_agent()
+        # Falls through to normal discovery (may find real agent or None).
+        # The env path itself is skipped.
+        assert result is None or result.is_file()
+
+
+# ---------------------------------------------------------------------------
+# run_sca_subprocess
+# ---------------------------------------------------------------------------
+
+class TestRunScaSubprocess:
+
+    def test_passes_proxy_hosts(self, tmp_path):
+        """Verify that run_sca_subprocess wires SCA_ALLOWED_HOSTS into
+        the sandbox call via proxy_hosts."""
+        agent = tmp_path / "agent.py"
+        agent.write_text("# stub")
+
+        captured_kwargs = {}
+
+        def fake_sandbox_run(cmd, **kwargs):
+            captured_kwargs.update(kwargs)
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = '{"status": "ok"}'
+            mock_result.stderr = ""
+            return mock_result
+
+        with patch("packages.sca.agent.sandbox_run", fake_sandbox_run, create=True):
+            # Patch the import inside run_sca_subprocess
+            with patch("core.sandbox.run", fake_sandbox_run):
+                rc, stdout, stderr = run_sca_subprocess(
+                    agent, tmp_path, tmp_path / "out",
+                )
+
+        assert captured_kwargs.get("use_egress_proxy") is True
+        proxy_hosts = captured_kwargs.get("proxy_hosts", [])
+        assert set(proxy_hosts) == set(SCA_ALLOWED_HOSTS)
+        assert captured_kwargs.get("caller_label") == "sca-agent"
+
+    def test_passes_sandbox_args(self, tmp_path):
+        """Extra --sandbox / --audit flags are forwarded to the command."""
+        agent = tmp_path / "agent.py"
+        agent.write_text("# stub")
+
+        captured_cmd = []
+
+        def fake_sandbox_run(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = "{}"
+            mock_result.stderr = ""
+            return mock_result
+
+        with patch("core.sandbox.run", fake_sandbox_run):
+            run_sca_subprocess(
+                agent, tmp_path, tmp_path / "out",
+                sandbox_args=["--sandbox", "full", "--audit"],
+            )
+
+        assert "--sandbox" in captured_cmd
+        assert "full" in captured_cmd
+        assert "--audit" in captured_cmd

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -154,6 +154,21 @@ Examples:
 
   # Focus validation on specific vulnerability type
   python3 raptor.py agentic --repo /path/to/code --vuln-type sql_injection
+
+  # Choose a specific analysis model (overrides models.json auto-detection)
+  python3 raptor.py agentic --repo /path/to/code --model gemini-2.5-pro
+
+  # Multi-model: N models independently analyse, results correlated
+  python3 raptor.py agentic --repo /path/to/code \\
+    --model gemini-2.5-pro --model gpt-5 --model claude-opus-4-6
+
+  # Single model + consensus second opinion
+  python3 raptor.py agentic --repo /path/to/code --model gemini-2.5-pro \\
+    --consensus claude-opus-4-6
+
+  # Single model + judge review
+  python3 raptor.py agentic --repo /path/to/code --model gemini-2.5-pro \\
+    --judge claude-opus-4-6
         """
     )
 
@@ -208,12 +223,32 @@ Examples:
              "base64) are disabled; model-independent floor still holds. "
              "Logged in run metadata and flagged in the final report.",
     )
-    parser.add_argument(
+    model_group = parser.add_argument_group(
+        "multi-model analysis",
+        "Choose which LLMs analyse findings. The primary model is auto-detected "
+        "from models.json / API key env vars unless --model overrides it. "
+        "Role models (consensus, judge) are optional additions.",
+    )
+    model_group.add_argument(
+        "--model",
+        metavar="MODEL",
+        action="append",
+        default=[],
+        help="Analysis model (repeatable). Single: --model gemini-2.5-pro. "
+             "Multi: --model gemini-2.5-pro --model gpt-5 — each independently "
+             "analyses every finding, then results are correlated.",
+    )
+    model_group.add_argument(
         "--consensus",
         metavar="MODEL",
-        help="Add a consensus model for second-opinion analysis "
-             "(e.g. --consensus gpt-5.4). Can also be set via "
-             "role: \"consensus\" in models.json.",
+        help="Blind second opinion — re-analyses each finding independently "
+             "without seeing the primary verdict. Majority vote decides.",
+    )
+    model_group.add_argument(
+        "--judge",
+        metavar="MODEL",
+        help="Non-blind review — sees and critiques the primary analysis "
+             "reasoning. Flags missed attack paths or flawed logic.",
     )
     parser.add_argument(
         "--trust-repo",
@@ -617,19 +652,80 @@ Examples:
                 for sarif in sarif_files:
                     all_sarif_files.append(Path(sarif))
 
-    # Check if we have any findings
+    # Check if we have any findings from source-code scanners.
+    # SCA may still contribute findings even when Semgrep/CodeQL found nothing,
+    # so we don't exit here — we proceed to the SCA phase first.
+    source_scan_empty = not all_sarif_files
+
+    # ========================================================================
+    # PHASE 1b: SOFTWARE COMPOSITION ANALYSIS
+    # ========================================================================
+    sca_metrics = {}
+    sca_out = out_dir / "sca"
+    try:
+        from packages.sca.agent import _find_sca_agent, run_sca_subprocess
+        sca_agent = _find_sca_agent()
+    except ImportError:
+        sca_agent = None
+
+    if sca_agent:
+        print("\n" + "=" * 70)
+        print("SOFTWARE COMPOSITION ANALYSIS")
+        print("=" * 70)
+        print("\n[*] Running SCA (dependencies, supply chain, reachability)...")
+        # Route via sandbox egress proxy so SCA's HTTP calls are
+        # hostname-allowlisted when --sandbox is active. The allowlist
+        # is SCA_ALLOWED_HOSTS (vuln feeds + registries + archives).
+        rc, sca_stdout, sca_stderr = run_sca_subprocess(
+            sca_agent,
+            original_repo_path,
+            sca_out,
+            sandbox_args=sandbox_passthrough,
+        )
+        if rc == 0:
+            sca_sarif = sca_out / "findings.sarif"
+            if sca_sarif.exists():
+                all_sarif_files.append(sca_sarif)
+            # Parse the one-line JSON summary from stdout
+            import json as _json
+            for line in reversed(sca_stdout.strip().splitlines()):
+                line = line.strip()
+                if line.startswith("{"):
+                    try:
+                        sca_metrics = _json.loads(line)
+                    except Exception:
+                        pass
+                    break
+            sca_findings_count = sca_metrics.get("vuln_findings", 0) + \
+                                 sca_metrics.get("supply_chain_findings", 0)
+            print(f"\n✓ SCA complete:")
+            print(f"  - Dependencies: {sca_metrics.get('deps_analysed', 0)}")
+            print(f"  - Vulnerability findings: {sca_metrics.get('vuln_findings', 0)}")
+            print(f"  - Supply chain findings: {sca_metrics.get('supply_chain_findings', 0)}")
+            print(f"  - Hygiene findings: {sca_metrics.get('hygiene_findings', 0)}")
+        else:
+            logger.warning(f"SCA failed (rc={rc}) — continuing without dep findings")
+            sca_findings_count = 0
+    else:
+        sca_findings_count = 0
+        if not source_scan_empty:
+            logger.info("raptor-sca not installed — skipping SCA phase")
+
     if not all_sarif_files:
         print("\n❌ No SARIF files generated from scanning")
         sys.exit(1)
 
     # Combine metrics
-    total_findings = semgrep_metrics.get('total_findings', 0) + codeql_metrics.get('total_findings', 0)
+    total_findings = (semgrep_metrics.get('total_findings', 0)
+                      + codeql_metrics.get('total_findings', 0)
+                      + sca_findings_count)
     scan_metrics = {
         'total_findings': total_findings,
         'total_files_scanned': semgrep_metrics.get('total_files_scanned', 0),
         'findings_by_severity': semgrep_metrics.get('findings_by_severity', {}),
         'semgrep': semgrep_metrics,
         'codeql': codeql_metrics,
+        'sca': sca_metrics,
     }
 
     sarif_files = all_sarif_files
@@ -639,6 +735,8 @@ Examples:
         print(f"  Semgrep: {semgrep_metrics.get('total_findings', 0)} findings")
     if codeql_metrics:
         print(f"  CodeQL: {codeql_metrics.get('total_findings', 0)} findings")
+    if sca_findings_count:
+        print(f"  SCA: {sca_findings_count} findings")
     print(f"SARIF files: {len(sarif_files)}")
 
     # ========================================================================
@@ -747,35 +845,16 @@ Examples:
         print("=" * 70)
 
         if analysis_report and analysis_report.exists():
-            # Build LLMConfig if external LLM is available
-            llm_config = None
-            if llm_env.external_llm:
-                from packages.llm_analysis import LLMConfig
-                llm_config = LLMConfig()
+            from packages.llm_analysis.orchestrator import (
+                build_llm_config_from_flags, orchestrate,
+            )
 
-            # --consensus flag: inject a consensus model
-            if args.consensus and llm_config:
-                from core.llm.config import _model_config_from_entry
-                from core.security.llm_family import family_of
-                _FAMILY_TO_PROVIDER = {
-                    "anthropic": "anthropic", "openai": "openai",
-                    "google": "gemini", "mistral": "mistral",
-                    "meta": "ollama", "ollama": "ollama",
-                }
-                provider = _FAMILY_TO_PROVIDER.get(
-                    family_of(args.consensus), "")
-                consensus_mc = _model_config_from_entry({
-                    "model": args.consensus,
-                    "provider": provider,
-                    "role": "consensus",
-                })
-                if consensus_mc.api_key:
-                    llm_config.fallback_models.append(consensus_mc)
-                else:
-                    print(f"\n  Warning: no API key found for consensus model {args.consensus}")
-                    print(f"  Set the provider's env var or add it to models.json")
-
-            from packages.llm_analysis.orchestrator import orchestrate
+            llm_config = build_llm_config_from_flags(
+                models=getattr(args, "model", []) or [],
+                consensus=getattr(args, "consensus", None),
+                judge=getattr(args, "judge", None),
+                auto_detect=llm_env.external_llm,
+            )
             orchestration_result = orchestrate(
                 prep_report_path=analysis_report,
                 repo_path=original_repo_path,
@@ -833,6 +912,7 @@ Examples:
         "tools_used": {
             "semgrep": not args.codeql_only,
             "codeql": args.codeql or args.codeql_only,
+            "sca": bool(sca_agent and sca_metrics),
         },
         "phases": {
             "scanning": {
@@ -1059,6 +1139,8 @@ Examples:
         print("   ✓ Scanned with CodeQL")
         if codeql_metrics.get('total_findings', 0) > 0:
             print("   ✓ Validated dataflow paths")
+    if sca_metrics:
+        print(f"   ✓ Analysed {sca_metrics.get('deps_analysed', 0)} dependencies (SCA)")
     if validation_result:
         print("   ✓ Deduplicated findings")
     print("   ✓ Analysed vulnerabilities")
@@ -1101,6 +1183,8 @@ Examples:
         via = None
 
     pipeline_parts = ["Scan"]
+    if sca_metrics:
+        pipeline_parts.append("SCA")
     if validation.get("completed"):
         pipeline_parts.append("Dedup")
     if analysed_count > 0:
@@ -1127,6 +1211,8 @@ Examples:
     codeql = scanning.get("codeql", {})
     if codeql.get("enabled"):
         extra_summary["CodeQL"] = codeql.get("findings", 0)
+    if sca_findings_count:
+        extra_summary["SCA"] = sca_findings_count
     if validation.get("completed"):
         extra_summary["After deduplication"] = validation.get("validated_findings", 0)
     if analysed_count > 0:


### PR DESCRIPTION
Thanks to Nicolas Krassas for the input

--model is repeatable: N models each independently analyse every finding via Cartesian product dispatch, then results are correlated. Includes judge role, SCA exploit/patch dispatch, /project correlate, and cross-run finding correlation.