### PR TITLE
feat: action-oriented correlate output + CC dispatch model tracking (#302 follow-up)

### DIFF
--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -760,7 +760,7 @@ def _print_diff(result):
 
 
 def _do_correlate(project, json_out=False):
-    """Cross-run finding correlation."""
+    """Cross-run finding correlation — action-oriented output."""
     import json
     from .correlate import correlate_project
 
@@ -772,38 +772,85 @@ def _do_correlate(project, json_out=False):
         return
 
     print(f"Project: {project.name}")
-    print(f"  Runs: {summary['runs']}")
-    print(f"  Unique findings: {summary['total_unique_findings']}")
-    print(f"  Persistent (2+ runs): {summary['persistent_findings']}")
-    if summary["tools_used"]:
-        print(f"  Tools: {', '.join(summary['tools_used'])}")
+    parts = [f"Runs: {summary['runs']}", f"Findings: {summary['total_unique_findings']}"]
+    if summary["disagreements"]:
+        parts.append(f"Disagreements: {summary['disagreements']}")
+    if summary["new_findings"]:
+        parts.append(f"New: {summary['new_findings']}")
+    if summary["potentially_resolved"]:
+        parts.append(f"Resolved?: {summary['potentially_resolved']}")
+    print(f"  {' | '.join(parts)}")
 
+    # --- Actions (primary output) ---
+    actions = result["actions"]
+    if actions:
+        _SIGILS = {
+            "disagreement": "[!]",
+            "new_finding": "[+]",
+            "resolved": "[~]",
+            "tool_gap": "[>]",
+        }
+        print(f"\n  Actions ({len(actions)})")
+        print(f"  {'─' * 60}")
+        for a in actions[:10]:
+            sigil = _SIGILS.get(a["category"], "[?]")
+            label = a["category"].upper().replace("_", " ")
+            print(f"  {sigil} {label}  {a['summary']}")
+            detail = a.get("detail", {})
+            if a["category"] == "disagreement":
+                for v in detail.get("verdicts", []):
+                    m = f" ({v['model']})" if v.get("model") else ""
+                    print(f"      {v['run']}: {v['status']}{m}")
+            elif a["category"] == "resolved":
+                absent = detail.get("absent_from", [])
+                if absent:
+                    print(f"      absent from: {', '.join(absent)}")
+        if len(actions) > 10:
+            print(f"  ... and {len(actions) - 10} more (use --json for full list)")
+    else:
+        print("\n  No actions — findings are consistent across runs.")
+
+    # --- Suggested next runs ---
+    suggested = result.get("tool_gaps", {}).get("suggested_next_runs", [])
+    if suggested:
+        print(f"\n  Next steps:")
+        for cmd in suggested:
+            print(f"    → {cmd}")
+
+    # --- Persistent findings (compact) ---
     persistent = result["persistent_findings"]
     if persistent:
-        print(f"\nPersistent findings:")
-        for pf in persistent[:20]:
-            loc = f"{pf['file']}:{pf['line']}" if pf.get("file") else "?"
-            vtype = pf.get("vuln_type", "")
-            status = pf.get("status", "")
-            runs = pf["runs_seen"]
-            print(f"  {loc:<40s}  {vtype:<20s}  {status:<16s}  {runs} runs")
-        if len(persistent) > 20:
-            print(f"  ... and {len(persistent) - 20} more")
+        display = persistent[:10]
+        rows = []
+        for pf in display:
+            models = ", ".join(pf.get("models", [])) or "—"
+            rows.append((
+                f"{pf['file']}:{pf['line']}" if pf.get("file") else "?",
+                pf.get("vuln_type", ""),
+                pf.get("status", ""),
+                f"{pf['runs_seen']} runs",
+                models,
+            ))
+        headers = ("Location", "Type", "Status", "Seen", "Models")
+        widths = [len(h) for h in headers]
+        for row in rows:
+            for i, cell in enumerate(row):
+                widths[i] = max(widths[i], len(cell))
+        fmt = (f"  {{:<{widths[0]}s}}  {{:<{widths[1]}s}}  {{:<{widths[2]}s}}"
+               f"  {{:>{widths[3]}s}}  {{:<{widths[4]}s}}")
+        print(f"\n  Persistent ({len(persistent)}):")
+        print(fmt.format(*headers))
+        print(f"  {'-' * widths[0]}  {'-' * widths[1]}  {'-' * widths[2]}  {'-' * widths[3]}  {'-' * widths[4]}")
+        for row in rows:
+            print(fmt.format(*row))
+        if len(persistent) > 10:
+            print(f"  ... and {len(persistent) - 10} more")
 
-    trends = result["trends"]
-    if trends:
-        print(f"\nTrends ({len(trends)} findings with history):")
-        for label, history in list(trends.items())[:10]:
-            statuses = " → ".join(h["status"] or "?" for h in history)
-            print(f"  {label}: {statuses}")
-        if len(trends) > 10:
-            print(f"  ... and {len(trends) - 10} more")
-
+    # --- Tool coverage (one line) ---
     tool_cov = result["tool_coverage"]
     if tool_cov:
-        print(f"\nTool coverage:")
-        for tool, files in tool_cov.items():
-            print(f"  {tool}: {len(files)} files")
+        cov_parts = [f"{tool}: {len(files)}" for tool, files in tool_cov.items()]
+        print(f"\n  Coverage: {', '.join(cov_parts)} files")
 
 
 def _do_clean(project, keep, dry_run, yes):

--- a/core/project/correlate.py
+++ b/core/project/correlate.py
@@ -1,8 +1,10 @@
 """Cross-run correlation for /project correlate.
 
 Aggregates findings and tool coverage across all runs in a project to
-produce: persistent findings, tool coverage matrix, gaps, and trends.
-Pure Python, no LLM calls.
+produce: disagreements, new/resolved findings, tool gaps, persistent
+findings, and trends. Pure Python, no LLM calls.
+
+Output is action-oriented: every section answers "what should I look at next?"
 """
 
 from collections import defaultdict
@@ -14,25 +16,77 @@ from core.run import load_run_metadata
 
 from .findings_utils import dedup_key, load_findings_from_dir
 
+# --- Status normalization ---
+
+POSITIVE_VERDICTS = frozenset({
+    "exploitable", "confirmed", "confirmed_unverified",
+    "confirmed_constrained", "confirmed_blocked", "poc_success",
+    "validated",
+})
+
+NEGATIVE_VERDICTS = frozenset({
+    "ruled_out", "disproven", "false_positive",
+    "test_code", "dead_code", "mitigated", "unreachable",
+})
+
+INCONCLUSIVE_VERDICTS = frozenset({
+    "not_disproven",
+})
+
+SCAN_COMMAND_TYPES = frozenset({"scan", "codeql"})
+LLM_COMMAND_TYPES = frozenset({"agentic", "validate"})
+
+
+def normalize_verdict(status: str) -> str:
+    s = (status or "").strip().lower()
+    if s in POSITIVE_VERDICTS:
+        return "positive"
+    if s in NEGATIVE_VERDICTS:
+        return "negative"
+    if s in INCONCLUSIVE_VERDICTS:
+        return "inconclusive"
+    return "unknown"
+
+
+def get_finding_status(finding: Dict) -> str:
+    if "is_true_positive" in finding or "is_exploitable" in finding:
+        if finding.get("is_true_positive") is False:
+            return "false_positive"
+        if finding.get("is_exploitable"):
+            return "exploitable"
+        if finding.get("is_true_positive"):
+            return "confirmed"
+    return finding.get("final_status") or finding.get("status") or ""
+
+
+# --- Main entry point ---
 
 def correlate_project(project) -> Dict[str, Any]:
     """Correlate findings and coverage across all runs in a project.
 
-    Returns:
-        persistent_findings: findings appearing in 2+ runs
-        tool_coverage: {tool: [files...]} across all runs
-        gaps: files in target not covered by any run
-        trends: {finding_key: [{run, status, score}]}
-        summary: counts
+    Returns an action-oriented result: disagreements first, then new/resolved
+    findings, tool gaps, and finally the existing persistent/trends/coverage.
     """
     run_dirs = project.get_run_dirs(sweep=False)
     if not run_dirs:
         return _empty_result()
 
+    run_models = {d.name: _get_run_model(d) for d in run_dirs}
+    run_types = _get_run_types(run_dirs)
     findings_by_run = _load_all_findings(run_dirs)
-    persistent = _find_persistent(findings_by_run)
-    trends = _build_trends(findings_by_run, run_dirs)
+
+    # Existing
+    persistent = _find_persistent(findings_by_run, run_models)
+    trends = _build_trends(findings_by_run, run_dirs, run_models)
     tool_coverage = _build_tool_coverage(run_dirs)
+
+    # New actionable analyses
+    disagreements = _find_disagreements(findings_by_run, run_models)
+    new_resolved = _find_new_and_resolved(findings_by_run, run_dirs, run_types)
+    tool_gaps = _build_tool_gaps(run_dirs, findings_by_run, run_types)
+    actions = _build_action_list(
+        disagreements, new_resolved, tool_gaps, persistent,
+    )
 
     n_persistent = len(persistent)
     n_total_unique = len({
@@ -40,24 +94,40 @@ def correlate_project(project) -> Dict[str, Any]:
         for findings in findings_by_run.values()
         for f in findings
     })
-    n_runs = len(run_dirs)
-    tools_used = sorted(tool_coverage.keys())
 
     return {
+        "actions": actions,
+        "disagreements": disagreements,
+        "new_findings": new_resolved["new_findings"],
+        "potentially_resolved": new_resolved["potentially_resolved"],
+        "tool_gaps": tool_gaps,
         "persistent_findings": persistent,
         "tool_coverage": tool_coverage,
         "trends": trends,
         "summary": {
-            "runs": n_runs,
+            "runs": len(run_dirs),
             "total_unique_findings": n_total_unique,
             "persistent_findings": n_persistent,
-            "tools_used": tools_used,
+            "tools_used": sorted(tool_coverage.keys()),
+            "disagreements": len(disagreements),
+            "new_findings": len(new_resolved["new_findings"]),
+            "potentially_resolved": len(new_resolved["potentially_resolved"]),
         },
     }
 
 
 def _empty_result() -> Dict[str, Any]:
     return {
+        "actions": [],
+        "disagreements": [],
+        "new_findings": [],
+        "potentially_resolved": [],
+        "tool_gaps": {
+            "scanned_not_validated": [],
+            "validated_not_scanned": [],
+            "missing_command_types": [],
+            "suggested_next_runs": [],
+        },
         "persistent_findings": [],
         "tool_coverage": {},
         "trends": {},
@@ -66,34 +136,373 @@ def _empty_result() -> Dict[str, Any]:
             "total_unique_findings": 0,
             "persistent_findings": 0,
             "tools_used": [],
+            "disagreements": 0,
+            "new_findings": 0,
+            "potentially_resolved": 0,
         },
     }
+
+
+# --- Helpers ---
+
+def _get_run_model(run_dir: Path) -> str:
+    """Extract the analysis model name for a run."""
+    orch = load_json(run_dir / "orchestrated_report.json")
+    if orch and isinstance(orch, dict):
+        o = orch.get("orchestration", {})
+        models = o.get("analysis_models", [])
+        if models:
+            return ", ".join(models)
+        m = o.get("analysis_model")
+        if m:
+            return m
+    meta = load_run_metadata(run_dir)
+    if meta:
+        extra = meta.get("extra", {})
+        models = extra.get("analysis_models", [])
+        if models:
+            return ", ".join(models)
+        m = extra.get("analysis_model")
+        if m:
+            return m
+    return ""
+
+
+def _get_run_types(run_dirs: List[Path]) -> Dict[str, str]:
+    """Map run dir name -> command type (scan, agentic, validate, etc.)."""
+    result = {}
+    for d in run_dirs:
+        meta = load_run_metadata(d)
+        result[d.name] = (meta or {}).get("command", "unknown")
+    return result
 
 
 def _load_all_findings(
     run_dirs: List[Path],
 ) -> Dict[str, List[Dict[str, Any]]]:
-    """Load findings from each run dir, keyed by run dir name."""
+    """Load findings from each run dir, keyed by run dir name.
+
+    Prefers orchestrated_report.json results (which have analysed_by and
+    multi_model_analyses) over plain findings.json.
+    """
     result = {}
     for d in run_dirs:
+        orch = load_json(d / "orchestrated_report.json")
+        if orch and isinstance(orch, dict):
+            findings = orch.get("results", [])
+            if findings:
+                result[d.name] = findings
+                continue
         findings = load_findings_from_dir(d)
         if findings:
             result[d.name] = findings
     return result
 
 
+# --- Disagreement detection ---
+
+def _find_disagreements(
+    findings_by_run: Dict[str, List[Dict]],
+    run_models: Dict[str, str],
+) -> List[Dict[str, Any]]:
+    """Find findings where runs disagree on verdict (positive vs negative)."""
+    key_to_verdicts: Dict[tuple, List[Dict]] = defaultdict(list)
+    key_to_finding: Dict[tuple, Dict] = {}
+
+    for run_name, findings in findings_by_run.items():
+        for f in findings:
+            k = dedup_key(f)
+            key_to_finding[k] = f
+            status = get_finding_status(f)
+            if not status:
+                continue
+            verdict = normalize_verdict(status)
+            if verdict == "unknown":
+                continue
+            model = f.get("analysed_by") or run_models.get(run_name, "")
+            key_to_verdicts[k].append({
+                "run": run_name,
+                "status": status,
+                "verdict": verdict,
+                "model": model,
+                "score": f.get("exploitability_score")
+                         or f.get("cvss_score_estimate"),
+            })
+
+    disagreements = []
+    for k, verdicts in key_to_verdicts.items():
+        verdict_set = {v["verdict"] for v in verdicts}
+        if "positive" in verdict_set and "negative" in verdict_set:
+            dtype = "positive_vs_negative"
+        elif "positive" in verdict_set and "inconclusive" in verdict_set:
+            dtype = "positive_vs_inconclusive"
+        else:
+            continue
+
+        f = key_to_finding[k]
+        scores = [v["score"] for v in verdicts if v["score"]]
+        disagreements.append({
+            "file": f.get("file", ""),
+            "function": f.get("function", ""),
+            "line": f.get("line", 0),
+            "vuln_type": f.get("vuln_type", ""),
+            "verdicts": verdicts,
+            "disagreement_type": dtype,
+            "max_score": max(scores) if scores else 0,
+        })
+
+    disagreements.sort(key=lambda d: (
+        0 if d["disagreement_type"] == "positive_vs_negative" else 1,
+        -(d["max_score"] or 0),
+    ))
+    return disagreements
+
+
+# --- New / resolved detection ---
+
+def _find_new_and_resolved(
+    findings_by_run: Dict[str, List[Dict]],
+    run_dirs: List[Path],
+    run_types: Dict[str, str],
+) -> Dict[str, List[Dict]]:
+    """Detect findings that appeared or disappeared across runs.
+
+    Only compares runs of the same command type — a finding in scan-001
+    but absent from validate-001 is expected, not "resolved."
+    """
+    run_order = [d.name for d in run_dirs]
+
+    key_to_runs_by_type: Dict[tuple, Dict[str, List[str]]] = defaultdict(
+        lambda: defaultdict(list),
+    )
+    key_to_finding: Dict[tuple, Dict] = {}
+
+    for run_name, findings in findings_by_run.items():
+        cmd_type = run_types.get(run_name, "unknown")
+        for f in findings:
+            k = dedup_key(f)
+            key_to_runs_by_type[k][cmd_type].append(run_name)
+            key_to_finding[k] = f
+
+    new_findings = []
+    potentially_resolved = []
+
+    for k, type_runs in key_to_runs_by_type.items():
+        f = key_to_finding[k]
+        for cmd_type, runs in type_runs.items():
+            typed_order = [r for r in run_order if run_types.get(r) == cmd_type]
+            if len(typed_order) < 2:
+                continue
+
+            earliest = typed_order[0]
+            latest = typed_order[-1]
+
+            first_run = min(runs, key=lambda r: (
+                run_order.index(r) if r in run_order else 999
+            ))
+            if first_run != earliest:
+                status = get_finding_status(f)
+                new_findings.append({
+                    "file": f.get("file", ""),
+                    "function": f.get("function", ""),
+                    "line": f.get("line", 0),
+                    "vuln_type": f.get("vuln_type", ""),
+                    "status": status,
+                    "verdict": normalize_verdict(status),
+                    "first_seen_run": first_run,
+                    "command_type": cmd_type,
+                })
+
+            if latest not in runs:
+                last_run = max(runs, key=lambda r: (
+                    run_order.index(r) if r in run_order else 0
+                ))
+                absent = [
+                    r for r in typed_order
+                    if r not in runs
+                    and run_order.index(r) > run_order.index(last_run)
+                ]
+                potentially_resolved.append({
+                    "file": f.get("file", ""),
+                    "function": f.get("function", ""),
+                    "line": f.get("line", 0),
+                    "vuln_type": f.get("vuln_type", ""),
+                    "last_seen_run": last_run,
+                    "absent_from": absent,
+                    "command_type": cmd_type,
+                })
+
+    new_findings.sort(key=lambda n: (
+        0 if n["verdict"] == "positive" else 1,
+    ))
+    return {"new_findings": new_findings, "potentially_resolved": potentially_resolved}
+
+
+# --- Tool gap analysis ---
+
+def _build_tool_gaps(
+    run_dirs: List[Path],
+    findings_by_run: Dict[str, List[Dict]],
+    run_types: Dict[str, str],
+) -> Dict[str, Any]:
+    """Identify coverage gaps between scan tools and LLM analysis."""
+    scan_files: Dict[str, set] = defaultdict(set)
+    llm_files: Dict[str, set] = defaultdict(set)
+
+    for run_name, findings in findings_by_run.items():
+        cmd = run_types.get(run_name, "unknown")
+        for f in findings:
+            fp = f.get("file", "")
+            if not fp:
+                continue
+            k = dedup_key(f)
+            if cmd in SCAN_COMMAND_TYPES:
+                scan_files[fp].add(k)
+            elif cmd in LLM_COMMAND_TYPES:
+                llm_files[fp].add(k)
+
+    scanned_not_validated = []
+    for fp in sorted(scan_files.keys() - llm_files.keys()):
+        n = len(scan_files[fp])
+        scanned_not_validated.append({
+            "file": fp,
+            "finding_count": n,
+        })
+
+    validated_not_scanned = sorted(llm_files.keys() - scan_files.keys())
+
+    types_present = set(run_types.values())
+    missing = []
+    if not types_present & SCAN_COMMAND_TYPES:
+        missing.append("scan")
+    if not types_present & LLM_COMMAND_TYPES:
+        missing.append("validate")
+
+    suggested = []
+    if scanned_not_validated:
+        n = sum(item["finding_count"] for item in scanned_not_validated)
+        suggested.append(
+            f"raptor validate  # {n} unvalidated scan finding"
+            f"{'s' if n != 1 else ''}"
+        )
+    if validated_not_scanned:
+        suggested.append(
+            f"raptor scan  # {len(validated_not_scanned)} file"
+            f"{'s' if len(validated_not_scanned) != 1 else ''}"
+            f" with LLM findings but no static analysis"
+        )
+    for cmd in missing:
+        suggested.append(f"raptor {cmd}  # no {cmd} runs found")
+
+    return {
+        "scanned_not_validated": scanned_not_validated,
+        "validated_not_scanned": [{"file": fp} for fp in validated_not_scanned],
+        "missing_command_types": missing,
+        "suggested_next_runs": suggested,
+    }
+
+
+# --- Action list ---
+
+def _build_action_list(
+    disagreements: List[Dict],
+    new_resolved: Dict[str, List[Dict]],
+    tool_gaps: Dict[str, Any],
+    persistent: List[Dict],
+) -> List[Dict[str, Any]]:
+    """Synthesize all analyses into a single prioritised action list."""
+    actions: List[Dict[str, Any]] = []
+
+    for d in disagreements:
+        pos = [v for v in d["verdicts"] if v["verdict"] == "positive"]
+        neg = [v for v in d["verdicts"] if v["verdict"] == "negative"]
+        inc = [v for v in d["verdicts"] if v["verdict"] == "inconclusive"]
+        if d["disagreement_type"] == "positive_vs_negative":
+            summary = (
+                f"{d['file']}:{d['line']} ({d['vuln_type']}) — "
+                f"{len(pos)} positive vs {len(neg)} negative verdict"
+                f"{'s' if len(neg) != 1 else ''}"
+            )
+            priority = 1
+        else:
+            summary = (
+                f"{d['file']}:{d['line']} ({d['vuln_type']}) — "
+                f"{len(pos)} positive vs {len(inc)} inconclusive"
+            )
+            priority = 4
+        actions.append({
+            "priority": priority,
+            "category": "disagreement",
+            "summary": summary,
+            "detail": d,
+        })
+
+    for nf in new_resolved.get("new_findings", []):
+        actions.append({
+            "priority": 2 if nf["verdict"] == "positive" else 6,
+            "category": "new_finding",
+            "summary": (
+                f"{nf['file']}:{nf['line']} ({nf['vuln_type']}) — "
+                f"new in {nf['first_seen_run']}"
+            ),
+            "detail": nf,
+        })
+
+    for gap in tool_gaps.get("scanned_not_validated", []):
+        actions.append({
+            "priority": 3,
+            "category": "tool_gap",
+            "summary": (
+                f"{gap['file']} — {gap['finding_count']} scan finding"
+                f"{'s' if gap['finding_count'] != 1 else ''}"
+                f" never LLM-validated"
+            ),
+            "detail": gap,
+        })
+
+    for r in new_resolved.get("potentially_resolved", []):
+        actions.append({
+            "priority": 5,
+            "category": "resolved",
+            "summary": (
+                f"{r['file']}:{r['line']} ({r['vuln_type']}) — "
+                f"absent from latest {r['command_type']} run"
+            ),
+            "detail": r,
+        })
+
+    for cmd in tool_gaps.get("missing_command_types", []):
+        actions.append({
+            "priority": 7,
+            "category": "tool_gap",
+            "summary": f"No {cmd} runs found",
+            "command": f"raptor {cmd}",
+            "detail": {"missing": cmd},
+        })
+
+    actions.sort(key=lambda a: a["priority"])
+    return actions
+
+
+# --- Existing analyses (persistent, trends, coverage) ---
+
 def _find_persistent(
     findings_by_run: Dict[str, List[Dict]],
+    run_models: Dict[str, str],
 ) -> List[Dict[str, Any]]:
     """Find findings that appear across 2+ runs."""
     key_to_runs: Dict[tuple, List[str]] = defaultdict(list)
     key_to_finding: Dict[tuple, Dict] = {}
+    key_to_models: Dict[tuple, set] = defaultdict(set)
 
     for run_name, findings in findings_by_run.items():
         for f in findings:
             k = dedup_key(f)
             key_to_runs[k].append(run_name)
             key_to_finding[k] = f
+            model = f.get("analysed_by") or run_models.get(run_name, "")
+            if model:
+                key_to_models[k].add(model)
 
     persistent = []
     for k, runs in sorted(key_to_runs.items(), key=lambda x: -len(x[1])):
@@ -108,6 +517,7 @@ def _find_persistent(
             "status": f.get("final_status") or f.get("status", ""),
             "runs_seen": len(runs),
             "run_names": sorted(runs),
+            "models": sorted(key_to_models.get(k, set())),
         })
 
     return persistent
@@ -116,10 +526,11 @@ def _find_persistent(
 def _build_trends(
     findings_by_run: Dict[str, List[Dict]],
     run_dirs: List[Path],
+    run_models: Dict[str, str],
 ) -> Dict[str, List[Dict[str, Any]]]:
     """Track how each finding's status changed across runs.
 
-    Returns {finding_label: [{run, status, score}]} ordered by run time.
+    Returns {finding_label: [{run, status, score, model}]} ordered by run time.
     """
     run_order = [d.name for d in run_dirs]
 
@@ -127,13 +538,14 @@ def _build_trends(
     for run_name, findings in findings_by_run.items():
         for f in findings:
             k = dedup_key(f)
+            model = f.get("analysed_by") or run_models.get(run_name, "")
             key_to_history[k].append({
                 "run": run_name,
                 "status": f.get("final_status") or f.get("status", ""),
                 "score": f.get("exploitability_score") or f.get("cvss_score_estimate"),
+                "model": model,
             })
 
-    # Only include findings seen in 2+ runs (single-run = no trend)
     trends = {}
     for k, history in key_to_history.items():
         if len(history) < 2:
@@ -146,11 +558,7 @@ def _build_trends(
 
 
 def _build_tool_coverage(run_dirs: List[Path]) -> Dict[str, List[str]]:
-    """Build tool → files-covered mapping from run metadata.
-
-    Reads .raptor-run.json command field to determine which tool produced
-    each run, then collects files from findings.
-    """
+    """Build tool -> files-covered mapping from run metadata."""
     tool_files: Dict[str, set] = defaultdict(set)
 
     for d in run_dirs:

--- a/core/project/tests/test_correlate.py
+++ b/core/project/tests/test_correlate.py
@@ -1,148 +1,453 @@
-"""Tests for cross-run project correlation."""
+"""Tests for core.project.correlate — action-oriented cross-run correlation."""
 
 import json
-import os
-import sys
+import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock
-
-import pytest
-
-sys.path.insert(0, str(Path(__file__).parents[3]))
+from unittest import TestCase, mock
 
 from core.project.correlate import (
+    INCONCLUSIVE_VERDICTS,
+    LLM_COMMAND_TYPES,
+    NEGATIVE_VERDICTS,
+    POSITIVE_VERDICTS,
+    SCAN_COMMAND_TYPES,
     correlate_project,
+    get_finding_status,
+    normalize_verdict,
+    _build_action_list,
+    _build_tool_gaps,
+    _find_disagreements,
+    _find_new_and_resolved,
     _find_persistent,
-    _build_trends,
-    _build_tool_coverage,
 )
 
 
-def _make_finding(file="app.py", function="handle", line=10,
-                  vuln_type="sqli", status="exploitable", score=0.9):
-    return {
-        "file": file,
-        "function": function,
-        "line": line,
-        "vuln_type": vuln_type,
-        "final_status": status,
-        "exploitability_score": score,
-    }
+# --- normalize_verdict ---
+
+class TestNormalizeVerdict(TestCase):
+    def test_positive_verdicts(self):
+        for v in POSITIVE_VERDICTS:
+            self.assertEqual(normalize_verdict(v), "positive", v)
+
+    def test_negative_verdicts(self):
+        for v in NEGATIVE_VERDICTS:
+            self.assertEqual(normalize_verdict(v), "negative", v)
+
+    def test_inconclusive_verdicts(self):
+        for v in INCONCLUSIVE_VERDICTS:
+            self.assertEqual(normalize_verdict(v), "inconclusive", v)
+
+    def test_unknown(self):
+        self.assertEqual(normalize_verdict("something_random"), "unknown")
+        self.assertEqual(normalize_verdict(""), "unknown")
+
+    def test_whitespace_and_case(self):
+        self.assertEqual(normalize_verdict("  Exploitable  "), "positive")
+        self.assertEqual(normalize_verdict("RULED_OUT"), "negative")
 
 
-def _write_run(tmp_path, name, findings, command="scan"):
-    """Create a fake run directory with findings.json and metadata."""
-    d = tmp_path / name
-    d.mkdir()
-    (d / "findings.json").write_text(json.dumps({"findings": findings}))
-    (d / ".raptor-run.json").write_text(json.dumps({
-        "version": 1, "command": command, "status": "completed",
-    }))
-    return d
+# --- get_finding_status ---
 
+class TestGetFindingStatus(TestCase):
+    def test_exploitable_boolean(self):
+        self.assertEqual(get_finding_status({"is_exploitable": True}), "exploitable")
 
-class TestFindPersistent:
+    def test_true_positive_false(self):
+        self.assertEqual(get_finding_status({"is_true_positive": False}), "false_positive")
+
+    def test_true_positive_true(self):
+        self.assertEqual(get_finding_status({"is_true_positive": True}), "confirmed")
+
+    def test_final_status_fallback(self):
+        self.assertEqual(get_finding_status({"final_status": "ruled_out"}), "ruled_out")
+
+    def test_status_fallback(self):
+        self.assertEqual(get_finding_status({"status": "not_disproven"}), "not_disproven")
+
     def test_empty(self):
-        assert _find_persistent({}) == []
+        self.assertEqual(get_finding_status({}), "")
 
-    def test_single_run(self):
-        findings_by_run = {
-            "run-1": [_make_finding()],
+
+# --- _find_disagreements ---
+
+def _make_finding(file="a.c", function="fn", line=1, vuln_type="bof", **kw):
+    return {"file": file, "function": function, "line": line, "vuln_type": vuln_type, **kw}
+
+
+class TestFindDisagreements(TestCase):
+    def test_no_disagreement_all_positive(self):
+        findings = {
+            "run-A": [_make_finding(final_status="exploitable")],
+            "run-B": [_make_finding(final_status="confirmed")],
         }
-        assert _find_persistent(findings_by_run) == []
+        result = _find_disagreements(findings, {})
+        self.assertEqual(result, [])
 
-    def test_same_finding_two_runs(self):
-        f = _make_finding()
-        findings_by_run = {
-            "run-1": [f],
-            "run-2": [f],
+    def test_positive_vs_negative(self):
+        findings = {
+            "run-A": [_make_finding(final_status="exploitable")],
+            "run-B": [_make_finding(final_status="ruled_out")],
         }
-        result = _find_persistent(findings_by_run)
-        assert len(result) == 1
-        assert result[0]["runs_seen"] == 2
-        assert result[0]["file"] == "app.py"
+        result = _find_disagreements(findings, {})
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["disagreement_type"], "positive_vs_negative")
 
-    def test_different_findings(self):
-        findings_by_run = {
-            "run-1": [_make_finding(line=10)],
-            "run-2": [_make_finding(line=20)],
+    def test_positive_vs_inconclusive(self):
+        findings = {
+            "run-A": [_make_finding(final_status="confirmed")],
+            "run-B": [_make_finding(final_status="not_disproven")],
         }
-        assert _find_persistent(findings_by_run) == []
+        result = _find_disagreements(findings, {})
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["disagreement_type"], "positive_vs_inconclusive")
 
-    def test_mixed(self):
-        shared = _make_finding(line=10)
-        unique = _make_finding(line=20)
-        findings_by_run = {
-            "run-1": [shared, unique],
-            "run-2": [shared],
+    def test_negative_vs_inconclusive_no_disagreement(self):
+        findings = {
+            "run-A": [_make_finding(final_status="ruled_out")],
+            "run-B": [_make_finding(final_status="not_disproven")],
         }
-        result = _find_persistent(findings_by_run)
-        assert len(result) == 1
-        assert result[0]["line"] == 10
+        self.assertEqual(_find_disagreements(findings, {}), [])
 
-
-class TestBuildTrends:
-    def test_empty(self):
-        assert _build_trends({}, []) == {}
-
-    def test_single_run_no_trend(self):
-        findings_by_run = {"run-1": [_make_finding()]}
-        assert _build_trends(findings_by_run, [Path("run-1")]) == {}
-
-    def test_status_progression(self):
-        f1 = _make_finding(status="not_disproven", score=0.5)
-        f2 = _make_finding(status="exploitable", score=0.9)
-        findings_by_run = {
-            "run-1": [f1],
-            "run-2": [f2],
+    def test_sorted_by_type_then_score(self):
+        findings = {
+            "run-A": [
+                _make_finding(file="x.c", final_status="exploitable", exploitability_score=9),
+                _make_finding(file="y.c", final_status="confirmed", exploitability_score=5),
+            ],
+            "run-B": [
+                _make_finding(file="x.c", final_status="ruled_out"),
+                _make_finding(file="y.c", final_status="not_disproven"),
+            ],
         }
-        dirs = [Path("run-1"), Path("run-2")]
-        trends = _build_trends(findings_by_run, dirs)
-        assert len(trends) == 1
-        label = list(trends.keys())[0]
-        history = trends[label]
-        assert history[0]["status"] == "not_disproven"
-        assert history[1]["status"] == "exploitable"
+        result = _find_disagreements(findings, {})
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["disagreement_type"], "positive_vs_negative")
+        self.assertEqual(result[1]["disagreement_type"], "positive_vs_inconclusive")
+
+    def test_model_from_run_models(self):
+        findings = {
+            "run-A": [_make_finding(final_status="exploitable")],
+            "run-B": [_make_finding(final_status="ruled_out")],
+        }
+        result = _find_disagreements(findings, {"run-A": "gpt-4o", "run-B": "claude-3-opus"})
+        verdicts = result[0]["verdicts"]
+        models = {v["model"] for v in verdicts}
+        self.assertIn("gpt-4o", models)
+        self.assertIn("claude-3-opus", models)
+
+    def test_model_from_analysed_by_field(self):
+        findings = {
+            "run-A": [_make_finding(final_status="exploitable", analysed_by="gpt-4o")],
+            "run-B": [_make_finding(final_status="ruled_out", analysed_by="claude")],
+        }
+        result = _find_disagreements(findings, {"run-A": "fallback", "run-B": "fallback"})
+        models = {v["model"] for v in result[0]["verdicts"]}
+        self.assertIn("gpt-4o", models)
+        self.assertIn("claude", models)
 
 
-class TestBuildToolCoverage:
-    def test_empty(self):
-        assert _build_tool_coverage([]) == {}
+# --- _find_new_and_resolved ---
 
-    def test_from_runs(self, tmp_path):
-        d1 = _write_run(tmp_path, "scan-001", [
-            _make_finding(file="a.py"), _make_finding(file="b.py"),
-        ], command="scan")
-        d2 = _write_run(tmp_path, "agentic-001", [
-            _make_finding(file="b.py"), _make_finding(file="c.py"),
-        ], command="agentic")
+class TestNewAndResolved(TestCase):
+    def _make_run_dirs(self, names):
+        d = tempfile.mkdtemp()
+        dirs = []
+        for n in names:
+            p = Path(d) / n
+            p.mkdir()
+            meta = {"command": "validate"}
+            (p / "run-metadata.json").write_text(json.dumps(meta))
+            dirs.append(p)
+        return dirs
 
-        result = _build_tool_coverage([d1, d2])
-        assert "scan" in result
-        assert "agentic" in result
-        assert "a.py" in result["scan"]
-        assert "b.py" in result["scan"]
-        assert "c.py" in result["agentic"]
+    def test_new_finding_detected(self):
+        dirs = self._make_run_dirs(["validate-001", "validate-002"])
+        findings = {
+            "validate-001": [],
+            "validate-002": [_make_finding(final_status="exploitable")],
+        }
+        types = {"validate-001": "validate", "validate-002": "validate"}
+        result = _find_new_and_resolved(findings, dirs, types)
+        self.assertEqual(len(result["new_findings"]), 1)
+        self.assertEqual(result["new_findings"][0]["first_seen_run"], "validate-002")
+
+    def test_resolved_finding_detected(self):
+        dirs = self._make_run_dirs(["validate-001", "validate-002"])
+        findings = {
+            "validate-001": [_make_finding(final_status="exploitable")],
+            "validate-002": [],
+        }
+        types = {"validate-001": "validate", "validate-002": "validate"}
+        result = _find_new_and_resolved(findings, dirs, types)
+        self.assertEqual(len(result["potentially_resolved"]), 1)
+
+    def test_cross_type_not_resolved(self):
+        dirs = self._make_run_dirs(["scan-001", "validate-001"])
+        findings = {
+            "scan-001": [_make_finding(final_status="exploitable")],
+            "validate-001": [],
+        }
+        types = {"scan-001": "scan", "validate-001": "validate"}
+        result = _find_new_and_resolved(findings, dirs, types)
+        self.assertEqual(len(result["potentially_resolved"]), 0)
+
+    def test_single_run_no_new_or_resolved(self):
+        dirs = self._make_run_dirs(["validate-001"])
+        findings = {
+            "validate-001": [_make_finding(final_status="exploitable")],
+        }
+        types = {"validate-001": "validate"}
+        result = _find_new_and_resolved(findings, dirs, types)
+        self.assertEqual(len(result["new_findings"]), 0)
+        self.assertEqual(len(result["potentially_resolved"]), 0)
+
+    def test_finding_in_all_runs_not_new(self):
+        dirs = self._make_run_dirs(["validate-001", "validate-002", "validate-003"])
+        f = _make_finding(final_status="exploitable")
+        findings = {
+            "validate-001": [f],
+            "validate-002": [f],
+            "validate-003": [f],
+        }
+        types = {"validate-001": "validate", "validate-002": "validate",
+                 "validate-003": "validate"}
+        result = _find_new_and_resolved(findings, dirs, types)
+        self.assertEqual(len(result["new_findings"]), 0)
+        self.assertEqual(len(result["potentially_resolved"]), 0)
 
 
-class TestCorrelateProject:
-    def test_no_runs(self):
-        project = MagicMock()
+# --- _build_tool_gaps ---
+
+class TestBuildToolGaps(TestCase):
+    def _make_run_dirs(self, names):
+        d = tempfile.mkdtemp()
+        dirs = []
+        for n in names:
+            p = Path(d) / n
+            p.mkdir()
+            dirs.append(p)
+        return dirs
+
+    def test_validated_not_scanned(self):
+        dirs = self._make_run_dirs(["validate-001"])
+        findings = {
+            "validate-001": [_make_finding(file="x.c", final_status="confirmed")],
+        }
+        types = {"validate-001": "validate"}
+        result = _build_tool_gaps(dirs, findings, types)
+        self.assertEqual(len(result["validated_not_scanned"]), 1)
+
+    def test_scanned_not_validated(self):
+        dirs = self._make_run_dirs(["scan-001"])
+        findings = {
+            "scan-001": [_make_finding(file="x.c", final_status="confirmed")],
+        }
+        types = {"scan-001": "scan"}
+        result = _build_tool_gaps(dirs, findings, types)
+        self.assertEqual(len(result["scanned_not_validated"]), 1)
+
+    def test_both_covered_no_gap(self):
+        dirs = self._make_run_dirs(["scan-001", "validate-001"])
+        findings = {
+            "scan-001": [_make_finding(file="x.c")],
+            "validate-001": [_make_finding(file="x.c")],
+        }
+        types = {"scan-001": "scan", "validate-001": "validate"}
+        result = _build_tool_gaps(dirs, findings, types)
+        self.assertEqual(result["scanned_not_validated"], [])
+        self.assertEqual(result["validated_not_scanned"], [])
+
+    def test_missing_scan_commands(self):
+        dirs = self._make_run_dirs(["validate-001"])
+        types = {"validate-001": "validate"}
+        result = _build_tool_gaps(dirs, {}, types)
+        self.assertIn("scan", result["missing_command_types"])
+
+    def test_missing_validate_commands(self):
+        dirs = self._make_run_dirs(["scan-001"])
+        types = {"scan-001": "scan"}
+        result = _build_tool_gaps(dirs, {}, types)
+        self.assertIn("validate", result["missing_command_types"])
+
+    def test_suggested_next_runs(self):
+        dirs = self._make_run_dirs(["validate-001"])
+        findings = {
+            "validate-001": [_make_finding(file="a.c"), _make_finding(file="b.c")],
+        }
+        types = {"validate-001": "validate"}
+        result = _build_tool_gaps(dirs, findings, types)
+        suggested = result["suggested_next_runs"]
+        self.assertTrue(any("raptor scan" in s for s in suggested))
+
+
+# --- _build_action_list ---
+
+class TestBuildActionList(TestCase):
+    def test_priority_ordering(self):
+        disagreements = [{
+            "file": "a.c", "line": 1, "vuln_type": "bof",
+            "verdicts": [
+                {"verdict": "positive", "run": "r1", "status": "exploitable", "model": "", "score": 9},
+                {"verdict": "negative", "run": "r2", "status": "ruled_out", "model": "", "score": None},
+            ],
+            "disagreement_type": "positive_vs_negative",
+            "max_score": 9,
+        }]
+        new_resolved = {
+            "new_findings": [{
+                "file": "b.c", "line": 5, "vuln_type": "xss",
+                "status": "exploitable", "verdict": "positive",
+                "first_seen_run": "r2", "command_type": "validate",
+            }],
+            "potentially_resolved": [],
+        }
+        tool_gaps = {
+            "scanned_not_validated": [{"file": "c.c", "finding_count": 2}],
+            "missing_command_types": [],
+            "suggested_next_runs": [],
+        }
+        persistent = []
+
+        actions = _build_action_list(disagreements, new_resolved, tool_gaps, persistent)
+        self.assertEqual(actions[0]["category"], "disagreement")
+        self.assertEqual(actions[0]["priority"], 1)
+        self.assertEqual(actions[1]["category"], "new_finding")
+        self.assertEqual(actions[1]["priority"], 2)
+        self.assertEqual(actions[2]["category"], "tool_gap")
+        self.assertEqual(actions[2]["priority"], 3)
+
+    def test_empty_input(self):
+        actions = _build_action_list(
+            [], {"new_findings": [], "potentially_resolved": []},
+            {"scanned_not_validated": [], "missing_command_types": []}, [],
+        )
+        self.assertEqual(actions, [])
+
+
+# --- _find_persistent ---
+
+class TestFindPersistent(TestCase):
+    def test_single_run_not_persistent(self):
+        findings = {
+            "run-A": [_make_finding(final_status="exploitable")],
+        }
+        self.assertEqual(_find_persistent(findings, {}), [])
+
+    def test_two_runs_persistent(self):
+        findings = {
+            "run-A": [_make_finding(final_status="exploitable")],
+            "run-B": [_make_finding(final_status="confirmed")],
+        }
+        result = _find_persistent(findings, {})
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["runs_seen"], 2)
+
+    def test_different_findings_not_persistent(self):
+        findings = {
+            "run-A": [_make_finding(file="a.c")],
+            "run-B": [_make_finding(file="b.c")],
+        }
+        result = _find_persistent(findings, {})
+        self.assertEqual(result, [])
+
+    def test_models_tracked(self):
+        findings = {
+            "run-A": [_make_finding(final_status="exploitable", analysed_by="gpt-4o")],
+            "run-B": [_make_finding(final_status="confirmed", analysed_by="claude")],
+        }
+        result = _find_persistent(findings, {})
+        self.assertEqual(len(result), 1)
+        self.assertIn("gpt-4o", result[0]["models"])
+        self.assertIn("claude", result[0]["models"])
+
+    def test_models_from_run_models(self):
+        findings = {
+            "run-A": [_make_finding(final_status="exploitable")],
+            "run-B": [_make_finding(final_status="confirmed")],
+        }
+        result = _find_persistent(findings, {"run-A": "model-a", "run-B": "model-b"})
+        self.assertEqual(len(result), 1)
+        self.assertIn("model-a", result[0]["models"])
+
+    def test_sorted_by_frequency(self):
+        findings = {
+            "run-A": [_make_finding(file="a.c"), _make_finding(file="b.c")],
+            "run-B": [_make_finding(file="a.c"), _make_finding(file="b.c")],
+            "run-C": [_make_finding(file="a.c")],
+        }
+        result = _find_persistent(findings, {})
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["runs_seen"], 3)
+        self.assertEqual(result[1]["runs_seen"], 2)
+
+    def test_status_from_latest_finding(self):
+        findings = {
+            "run-A": [_make_finding(final_status="not_disproven")],
+            "run-B": [_make_finding(final_status="exploitable")],
+        }
+        result = _find_persistent(findings, {})
+        self.assertEqual(len(result), 1)
+
+
+# --- correlate_project integration ---
+
+class TestCorrelateProject(TestCase):
+    def _make_project(self, run_specs):
+        """Create a mock project with given run specs.
+
+        run_specs: list of (run_name, command, findings_list)
+        """
+        base = Path(tempfile.mkdtemp())
+        runs_dir = base / "runs"
+        runs_dir.mkdir()
+
+        run_dirs = []
+        for name, command, findings in run_specs:
+            d = runs_dir / name
+            d.mkdir()
+            meta = {"command": command, "status": "complete"}
+            (d / "run-metadata.json").write_text(json.dumps(meta))
+            if findings:
+                report = {"mode": "prep_only", "results": findings}
+                (d / "findings.json").write_text(json.dumps(report))
+            run_dirs.append(d)
+
+        project = mock.MagicMock()
+        project.name = "test-project"
+        project.get_run_dirs.return_value = run_dirs
+        return project
+
+    def test_empty_project(self):
+        project = mock.MagicMock()
         project.get_run_dirs.return_value = []
         result = correlate_project(project)
-        assert result["summary"]["runs"] == 0
+        self.assertEqual(result["summary"]["runs"], 0)
 
-    def test_full_correlation(self, tmp_path):
-        shared = _make_finding(file="shared.py", line=5)
-        d1 = _write_run(tmp_path, "scan-001", [shared, _make_finding(file="a.py", line=1)])
-        d2 = _write_run(tmp_path, "scan-002", [shared, _make_finding(file="b.py", line=2)])
-
-        project = MagicMock()
-        project.get_run_dirs.return_value = [d1, d2]
-
+    def test_basic_integration(self):
+        f = _make_finding(final_status="exploitable")
+        project = self._make_project([
+            ("validate-001", "validate", [f]),
+            ("validate-002", "validate", [f]),
+        ])
         result = correlate_project(project)
-        assert result["summary"]["runs"] == 2
-        assert result["summary"]["persistent_findings"] == 1
-        assert result["summary"]["total_unique_findings"] == 3
-        assert len(result["persistent_findings"]) == 1
-        assert result["persistent_findings"][0]["file"] == "shared.py"
+        self.assertEqual(result["summary"]["runs"], 2)
+        self.assertGreater(len(result["persistent_findings"]), 0)
+
+    def test_disagreement_surfaces_in_actions(self):
+        project = self._make_project([
+            ("validate-001", "validate", [_make_finding(final_status="exploitable")]),
+            ("validate-002", "validate", [_make_finding(final_status="ruled_out")]),
+        ])
+        result = correlate_project(project)
+        self.assertGreater(result["summary"]["disagreements"], 0)
+        categories = [a["category"] for a in result["actions"]]
+        self.assertIn("disagreement", categories)
+
+    def test_tool_gap_surfaces_in_actions(self):
+        project = self._make_project([
+            ("validate-001", "validate",
+             [_make_finding(file="only_llm.c", final_status="confirmed")]),
+        ])
+        result = correlate_project(project)
+        suggested = result["tool_gaps"]["suggested_next_runs"]
+        self.assertTrue(any("scan" in s for s in suggested))

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -635,8 +635,10 @@ def orchestrate(
         "mode": dispatch_mode,
         "multi_model": len(analysis_models_list) > 1,
         "analysis_model": (role_resolution.get("analysis_model").model_name
-                          if role_resolution.get("analysis_model") else None),
-        "analysis_models": [m.model_name for m in analysis_models_list],
+                          if role_resolution.get("analysis_model")
+                          else ("Claude Code" if is_cc_dispatch else None)),
+        "analysis_models": ([m.model_name for m in analysis_models_list]
+                           or (["Claude Code"] if is_cc_dispatch else [])),
         "defense_profile": profile.name,
         "weakened_defenses": accept_weakened_defenses and profile.name == "passthrough",
         "consensus_models": [m.model_name for m in consensus_models],

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -1286,10 +1286,13 @@ Examples:
     # Mark run as completed
     try:
         from core.run import complete_run
+        orch_meta = (orchestration_result or {}).get("orchestration", {})
         complete_run(out_dir, extra={
             "findings_count": analysed_count,
             "exploitable_count": exploitable_count,
             "duration_seconds": round(workflow_duration, 1),
+            "analysis_model": orch_meta.get("analysis_model"),
+            "analysis_models": orch_meta.get("analysis_models", []),
         })
     except Exception as e:
         logger.debug(f"Run metadata: {e}")  # Optional — don't fail the pipeline


### PR DESCRIPTION
Redesign /project correlate to surface disagreements, new/resolved findings, and tool gaps instead of raw tables. Record analysis model in run metadata so correlate can attribute verdicts per-model.