### PR TITLE
ci: run libexec wrapper tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,12 +74,19 @@ jobs:
       - name: Compile Python sources
         run: |
           source $VENV_PATH/bin/activate
-          python -m compileall -q core packages *.py
+          python -m compileall -q core packages libexec/tests *.py
 
       - name: Run unit tests
         run: |
           source $VENV_PATH/bin/activate
           pytest core packages
+
+      - name: Run libexec wrapper tests
+        run: |
+          source $VENV_PATH/bin/activate
+          # Keep this separate from `pytest core packages` to avoid pytest
+          # import-name collisions with other top-level tests packages.
+          pytest libexec/tests
 
   test-workflows:
     needs: deps


### PR DESCRIPTION
## Summary
- Add `libexec/tests` to the Python compile gate.
- Run the libexec wrapper pytest suite in CI.
- Keep the wrapper suite as a separate pytest step so it avoids import-name collisions with other top-level `tests` packages.

## Context
`main` already compiles `core packages *.py` and runs `pytest core packages`, which covers the earlier core/packages CI blind spot. This PR extends that coverage to the remaining libexec wrapper tests, which live outside both trees.

## Checks and improvements
I made multiple checks and small improvements before opening this PR. The main adjustment was keeping the `libexec/tests` run separate after confirming that combining it with `pytest core packages` can trigger pytest import-name collisions.

## Validation
- `python -m compileall -q core packages libexec/tests *.py`
- `pytest -q libexec/tests` — 12 passed
- `pytest --collect-only -q core packages` — 5579/5585 tests collected, 6 deselected
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tests.yml")'`
- `git diff --check`

