### PR TITLE
feat: tighten aggregate role schema, filter hallucinated IDs, doc clarity (#310 follow-up)

### DIFF
--- a/.claude/commands/agentic.md
+++ b/.claude/commands/agentic.md
@@ -98,7 +98,7 @@ By default, the primary model is auto-detected from `~/.config/raptor/models.jso
 | `--model MODEL` (repeatable) | Analysis | Each model independently analyses every finding. Multiple = multi-model correlation. |
 | `--consensus MODEL` | Blind second opinion | Re-analyses each finding independently (doesn't see the primary verdict). Majority vote decides the final ruling. Auto-skipped with 3+ `--model`. |
 | `--judge MODEL` | Non-blind review | Sees the primary analysis reasoning and critiques it. Flags missed attack paths, flawed logic, or inconsistent verdicts. |
-| `--aggregate MODEL` | Final synthesis | Aggregates the multi-model results into `aggregation.json` and the final `agentic-report.md`. Requires at least two `--model` values. |
+| `--aggregate MODEL` | Final synthesis (optional) | LLM-written narrative summary on top of the deterministic correlation. Adds top findings, disputed findings, and recommended next actions to `aggregation.json` and the final `agentic-report.md`. Without it, you still get the correlation results. Requires at least two `--model` values. |
 
 ```
 # Single model

--- a/README.md
+++ b/README.md
@@ -208,12 +208,13 @@ Model roles let you assign different models to different tasks:
 | `analysis` | Validates and analyses each finding (Stages A-D) |
 | `code` | Writes exploit PoCs and patch code |
 | `consensus` | Second-opinion vote on true positives |
-| `aggregate` | Synthesizes multi-model results into `aggregation.json` and the final `agentic-report.md` |
+| `aggregate` | Optional. LLM-written narrative synthesis on top of the deterministic multi-model correlation, written to `aggregation.json` and the final `agentic-report.md` |
 | `fallback` | Used if the primary model fails or hits rate limits |
 
 If no roles are set, the first model in the list handles everything. For multi-model
-source-code analysis, configure at least two `analysis` models and one `aggregate`
-model, or pass them at runtime:
+source-code analysis, configure two or more `analysis` models — you'll get the
+deterministic correlation by default. The `aggregate` role is optional and adds an
+LLM-written summary on top:
 
 ```bash
 python3 raptor.py agentic --repo /code \

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -599,6 +599,7 @@ def orchestrate(
                 if "error" not in r:
                     aggregation = {k: v for k, v in r.items()
                                    if not k.startswith("_") and k != "finding_id"}
+                    _drop_hallucinated_finding_ids(aggregation, results_by_id)
                     break
 
     # Exploit/patch generation — after final verdict
@@ -821,6 +822,33 @@ def _auto_detect_cross_family_checker(primary_family: str) -> Optional[Any]:
             )
             return ModelConfig(provider=provider, model_name=model_name)
     return None
+
+
+def _drop_hallucinated_finding_ids(
+    aggregation: Dict[str, Any],
+    results_by_id: Dict[str, Dict],
+) -> None:
+    """Remove items whose finding_id doesn't match a real finding.
+
+    The aggregate model occasionally invents finding IDs. We filter rather
+    than fail so partial output is still useful.
+    """
+    valid_ids = set(results_by_id.keys())
+    for key in ("highest_confidence_findings", "disputed_findings"):
+        items = aggregation.get(key)
+        if not isinstance(items, list):
+            continue
+        kept = [
+            it for it in items
+            if isinstance(it, dict) and it.get("finding_id") in valid_ids
+        ]
+        dropped = len(items) - len(kept)
+        if dropped:
+            logger.info(
+                f"Aggregate: dropped {dropped} item{'s' if dropped != 1 else ''} "
+                f"with unknown finding_id from {key}"
+            )
+        aggregation[key] = kept
 
 
 def _build_aggregation_payload(

--- a/packages/llm_analysis/tasks.py
+++ b/packages/llm_analysis/tasks.py
@@ -433,7 +433,7 @@ class AggregationTask(DispatchTask):
     name = "aggregate"
     model_role = "aggregate"
     temperature = 0.2
-    budget_cutoff = 0.80
+    budget_cutoff = 0.95
 
     _SYSTEM_TEXT = (
         "You are the final security-analysis aggregator for a multi-model "
@@ -511,8 +511,14 @@ class AggregationTask(DispatchTask):
                         "type": "object",
                         "properties": {
                             "finding_id": {"type": "string"},
-                            "verdict": {"type": "string"},
-                            "confidence": {"type": "string"},
+                            "verdict": {
+                                "type": "string",
+                                "enum": ["exploitable", "not_exploitable", "uncertain"],
+                            },
+                            "confidence": {
+                                "type": "string",
+                                "enum": ["high", "medium", "low"],
+                            },
                             "reason": {"type": "string"},
                         },
                         "required": ["finding_id", "verdict", "confidence", "reason"],

--- a/packages/llm_analysis/tests/test_dispatch.py
+++ b/packages/llm_analysis/tests/test_dispatch.py
@@ -782,6 +782,64 @@ class TestAggregationTask:
         task = AggregationTask()
         assert task.get_item_id({}) == "aggregate"
 
+    def test_schema_constrains_verdict_and_confidence(self):
+        task = AggregationTask()
+        schema = task.get_schema({})
+        finding_props = schema["properties"]["highest_confidence_findings"]["items"]["properties"]
+        assert finding_props["verdict"]["enum"] == ["exploitable", "not_exploitable", "uncertain"]
+        assert finding_props["confidence"]["enum"] == ["high", "medium", "low"]
+
+
+class TestDropHallucinatedFindingIds:
+    def test_drops_unknown_ids(self):
+        from packages.llm_analysis.orchestrator import _drop_hallucinated_finding_ids
+        aggregation = {
+            "highest_confidence_findings": [
+                {"finding_id": "real-1", "verdict": "exploitable",
+                 "confidence": "high", "reason": "ok"},
+                {"finding_id": "ghost", "verdict": "exploitable",
+                 "confidence": "high", "reason": "made up"},
+            ],
+            "disputed_findings": [
+                {"finding_id": "real-2", "disagreement": "x", "resolution_needed": "y"},
+                {"finding_id": "phantom", "disagreement": "x", "resolution_needed": "y"},
+            ],
+        }
+        results_by_id = {"real-1": {}, "real-2": {}}
+        _drop_hallucinated_finding_ids(aggregation, results_by_id)
+        assert [f["finding_id"] for f in aggregation["highest_confidence_findings"]] == ["real-1"]
+        assert [f["finding_id"] for f in aggregation["disputed_findings"]] == ["real-2"]
+
+    def test_keeps_all_when_all_real(self):
+        from packages.llm_analysis.orchestrator import _drop_hallucinated_finding_ids
+        aggregation = {
+            "highest_confidence_findings": [
+                {"finding_id": "a", "verdict": "exploitable",
+                 "confidence": "high", "reason": "ok"},
+            ],
+        }
+        _drop_hallucinated_finding_ids(aggregation, {"a": {}})
+        assert len(aggregation["highest_confidence_findings"]) == 1
+
+    def test_handles_missing_lists(self):
+        from packages.llm_analysis.orchestrator import _drop_hallucinated_finding_ids
+        aggregation = {"summary": "ok"}
+        _drop_hallucinated_finding_ids(aggregation, {})
+        assert aggregation == {"summary": "ok"}
+
+    def test_handles_non_dict_items(self):
+        from packages.llm_analysis.orchestrator import _drop_hallucinated_finding_ids
+        aggregation = {
+            "highest_confidence_findings": [
+                "not-a-dict",
+                {"finding_id": "real", "verdict": "exploitable",
+                 "confidence": "high", "reason": "ok"},
+            ],
+        }
+        _drop_hallucinated_finding_ids(aggregation, {"real": {}})
+        assert len(aggregation["highest_confidence_findings"]) == 1
+        assert aggregation["highest_confidence_findings"][0]["finding_id"] == "real"
+
 
 class TestJudgeEdgeCases:
     def test_finalize_no_judge_results_for_finding(self):

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -257,9 +257,11 @@ Examples:
     model_group.add_argument(
         "--aggregate",
         metavar="MODEL",
-        help="Final synthesis model — aggregates multi-model analysis results "
-             "into a downstream triage artifact. Requires at least two "
-             "--model values.",
+        help="Optional. LLM-written synthesis on top of the deterministic "
+             "multi-model correlation. Adds a narrative summary, top findings, "
+             "and recommended next actions to the report. Requires at least "
+             "two --model values; without --aggregate you still get the "
+             "correlation results.",
     )
     parser.add_argument(
         "--trust-repo",


### PR DESCRIPTION
- Schema: verdict/confidence now have explicit enums (no more free-form strings)
- Filter aggregate-returned finding_ids that don't match real findings before render
- Bump budget_cutoff 0.80 → 0.95 so aggregate (last task) actually runs
- Docs: --aggregate is optional; deterministic correlation works without it