### PR TITLE
feat(packages/code_understanding): substrate consumers for hunt and trace

### DIFF
--- a/core/llm/tests/test_config_file.py
+++ b/core/llm/tests/test_config_file.py
@@ -17,6 +17,26 @@ from core.llm.config import (
 from core.llm.model_data import PROVIDER_DEFAULT_MODELS, MODEL_COSTS, MODEL_LIMITS
 
 
+@pytest.fixture(autouse=True)
+def _restore_thinking_model_cache():
+    """Snapshot core.llm.config's module-level cache before each test and
+    restore after. Many tests in this file deliberately poke
+    `_thinking_model_checked` / `_cached_thinking_model` to force a
+    re-evaluation against tmp_path config; without restore, the module
+    is left in an inconsistent state and later tests in the suite (e.g.
+    packages/llm_analysis/tests/test_dispatch.py::test_multi_model_flags)
+    re-read the real environment and pick up unintended fallbacks.
+    """
+    import core.llm.config as cfg
+    saved_checked = getattr(cfg, "_thinking_model_checked", None)
+    saved_cached = getattr(cfg, "_cached_thinking_model", None)
+    try:
+        yield
+    finally:
+        cfg._thinking_model_checked = saved_checked
+        cfg._cached_thinking_model = saved_cached
+
+
 class TestGetConfiguredModels:
     """Test config file reading with various formats."""
 

--- a/packages/code_understanding/__init__.py
+++ b/packages/code_understanding/__init__.py
@@ -1,0 +1,25 @@
+"""Code-understanding multi-model consumers (substrate of core.llm.multi_model).
+
+Public API:
+    hunt              — orchestrator for --hunt mode (set-style)
+    trace             — orchestrator for --trace mode (verdict-style)
+    VariantAdapter    — substrate adapter for hunt's set shape
+    TraceAdapter      — substrate adapter for trace's verdict shape
+
+PR2a: this package contains adapters + orchestrators only. The actual
+LLM dispatch (prompts, tool-use loop wiring, libexec entry points)
+lands in PR2b.
+"""
+
+from packages.code_understanding.adapters import TraceAdapter, VariantAdapter
+from packages.code_understanding.hunt import HuntDispatchFn, hunt
+from packages.code_understanding.trace import TraceDispatchFn, trace
+
+__all__ = [
+    "HuntDispatchFn",
+    "TraceAdapter",
+    "TraceDispatchFn",
+    "VariantAdapter",
+    "hunt",
+    "trace",
+]

--- a/packages/code_understanding/adapters.py
+++ b/packages/code_understanding/adapters.py
@@ -1,0 +1,142 @@
+"""Multi-model substrate adapters for /understand --hunt and --trace.
+
+These are the concrete consumer-side glue between /understand's two
+verdict/set-style modes and core.llm.multi_model. They define how
+variant items and trace verdicts are identified, merged, and correlated.
+
+PR2a scope: adapters only. PR2b will wire actual LLM dispatch using
+these adapters.
+"""
+
+from typing import Any, Dict, Hashable, Tuple
+
+from core.llm.multi_model import BaseSetAdapter, BaseVerdictAdapter
+
+
+# ---------------------------------------------------------------------------
+# /understand --hunt: set-style (each model returns a list of variants)
+# ---------------------------------------------------------------------------
+
+
+class VariantAdapter(BaseSetAdapter):
+    """Adapter for hunt-style variant findings.
+
+    Each model returns a list of dicts of the shape:
+        {
+          "file": "src/parser.c",
+          "line": 42,
+          "function": "parse_header",  # optional
+          "snippet": "strcpy(buf, untrusted)",  # optional, for context
+          "confidence": "high" | "medium" | "low",  # optional
+        }
+
+    Two finds at the same (file, line, function) are considered the same
+    variant — even if their snippets/confidence differ across models.
+    Function name is included in the dedup key because the same line
+    number can appear in different functions after refactors.
+
+    Note: BaseSetAdapter's default `extract_set_record` produces
+    `{"model": model_name, **item}` for each per-model record stored
+    under `multi_model_finds`. If your variant dicts include a `"model"`
+    field (e.g., a model-name annotation produced by the LLM), the
+    substrate-added `model` key takes precedence and overwrites it.
+    Override `extract_set_record` if you need to preserve a different
+    `model` field semantically.
+    """
+
+    def item_id(self, item: Dict[str, Any]) -> str:
+        # variants don't have a stable upstream id; synthesize from the
+        # canonical (file, line, function) so the same variant gets the
+        # same id regardless of which model contributed first.
+        file_path, line, function = self._canonical_parts(item)
+        if function:
+            return f"{file_path}:{line}:{function}"
+        return f"{file_path}:{line}"
+
+    def item_key(self, item: Dict[str, Any]) -> Hashable:
+        # Same canonicalization as item_id so two finds the substrate
+        # would unify (key) also produce the same id.
+        return self._canonical_parts(item)
+
+    @staticmethod
+    def _canonical_parts(item: Dict[str, Any]) -> Tuple[str, Any, str]:
+        """Normalize file path for cross-model comparison.
+
+        - Strip whitespace from file and function.
+        - Drop a leading "./" (NOT lstrip("./") — that strips any combination
+          of dots and slashes; we want only the literal "./" prefix).
+        - Don't lowercase: file paths are case-sensitive on Linux/macOS.
+        - Coerce `line` to int when possible so models returning "5"
+          (string) and 5 (int) don't get bucketed separately. Non-numeric
+          line values are preserved as-is and surface upstream.
+        """
+        file_path = (item.get("file") or "").strip().removeprefix("./")
+        function = (item.get("function") or "").strip()
+
+        line_raw = item.get("line")
+        if isinstance(line_raw, str):
+            stripped = line_raw.strip()
+            try:
+                line = int(stripped)
+            except ValueError:
+                # Non-numeric string: keep stripped form so trailing-whitespace
+                # variants don't bucket separately ("junk" and "junk " unify).
+                line = stripped
+        else:
+            line = line_raw
+
+        return (file_path, line, function)
+
+
+# ---------------------------------------------------------------------------
+# /understand --trace: verdict-style (each model returns a verdict per trace)
+# ---------------------------------------------------------------------------
+
+
+class TraceAdapter(BaseVerdictAdapter):
+    """Adapter for trace-style flow analysis.
+
+    Each model returns a list of dicts of the shape:
+        {
+          "trace_id": "EP-001-to-sink-3",
+          "verdict": "reachable" | "not_reachable" | "uncertain",
+          "confidence": "high" | "medium" | "low",
+          "steps": [...],   # optional
+          "reasoning": "...",  # short justification
+        }
+
+    select_primary defaults to BaseVerdictAdapter's prefer-positive
+    rule, mapped through normalize_verdict — so a "reachable" verdict
+    wins over "not_reachable" or "uncertain" when models disagree.
+    """
+
+    # Trace reasoning can include a step chain — slightly bigger budget
+    # than the default 600 chars, but still bounded.
+    REASONING_TRUNCATE: int = 1200
+
+    def item_id(self, item: Dict[str, Any]) -> str:
+        # Strip — models occasionally return surrounded-by-whitespace ids,
+        # which would otherwise count as a different trace from the
+        # original. Substrate's item_id contract requires non-empty str.
+        tid = item.get("trace_id")
+        if tid is None:
+            raise ValueError(
+                f"trace verdict dict missing required 'trace_id' field: "
+                f"{sorted(item.keys())}"
+            )
+        return tid.strip() if isinstance(tid, str) else tid
+
+    def normalize_verdict(self, item: Dict[str, Any]) -> str:
+        # Defensive: model output occasionally has type drift on enum
+        # fields. Non-string verdicts → "unknown" rather than AttributeError.
+        v = item.get("verdict")
+        if not isinstance(v, str):
+            return "unknown"
+        v = v.strip().lower()
+        if v == "reachable":
+            return "positive"
+        if v == "not_reachable":
+            return "negative"
+        if v == "uncertain":
+            return "inconclusive"
+        return "unknown"

--- a/packages/code_understanding/hunt.py
+++ b/packages/code_understanding/hunt.py
@@ -1,0 +1,92 @@
+"""Multi-model orchestrator for /understand --hunt.
+
+Runs N models in parallel against a hunt task, unions their variant
+findings, and optionally synthesizes them via an aggregator.
+
+The actual LLM call lives in `dispatch_fn` (consumer-supplied) — the
+orchestrator is dispatch-agnostic. PR2b will provide a default
+dispatch_fn that talks to the LLM SDK; for now, callers provide their
+own (which makes mock testing trivial).
+"""
+
+import logging
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+from core.llm.multi_model import (
+    Aggregator,
+    CostGate,
+    ModelHandle,
+    MultiModelResult,
+    Reviewer,
+    run_multi_model,
+)
+
+from packages.code_understanding.adapters import VariantAdapter
+
+logger = logging.getLogger(__name__)
+
+
+HuntDispatchFn = Callable[
+    [ModelHandle, str, str],     # (model, pattern, repo_path)
+    List[Dict[str, Any]],        # list of variant dicts
+]
+
+
+def hunt(
+    *,
+    pattern: str,
+    repo_path: str,
+    models: Iterable[ModelHandle],
+    dispatch_fn: HuntDispatchFn,
+    reviewers: Optional[Iterable[Reviewer]] = (),
+    aggregator: Optional[Aggregator] = None,
+    cost_gate: Optional[CostGate] = None,
+    max_parallel: int = 3,
+) -> MultiModelResult:
+    """Multi-model variant hunt.
+
+    Args:
+        pattern: The pattern to hunt — natural-language description, a
+            sample finding id, or a regex. Interpretation is dispatch_fn's
+            responsibility.
+        repo_path: Repository to search.
+        models: Sequence of ModelHandles. Substrate validates non-empty
+            and unique model_names.
+        dispatch_fn: Callable that takes a single model + pattern + repo
+            and returns its list of variant dicts. Each variant dict
+            should match VariantAdapter's expected shape (file, line,
+            function, ...).
+        reviewers: Optional review phase — runs after merge.
+        aggregator: Optional LLM synthesis — runs once over merged + correlated.
+        cost_gate: Optional budget gate. None disables gating.
+        max_parallel: Thread pool size.
+
+    Returns:
+        MultiModelResult with `items` = unioned variants annotated with
+        `found_by_models`, and `correlation` carrying recall signals.
+    """
+
+    if not isinstance(pattern, str) or not pattern.strip():
+        raise ValueError("pattern must be a non-empty string")
+    if not callable(dispatch_fn):
+        raise TypeError(
+            f"dispatch_fn must be callable; got {type(dispatch_fn).__name__}"
+        )
+    # Strip permanently so dispatch_fn doesn't have to handle leading/
+    # trailing whitespace from copy-paste mistakes.
+    pattern = pattern.strip()
+
+    def task(model: ModelHandle) -> List[Dict[str, Any]]:
+        # Substrate calls this once per model in parallel. dispatch_fn
+        # is the consumer-supplied actual-work; we just bind args.
+        return dispatch_fn(model, pattern, repo_path)
+
+    return run_multi_model(
+        task=task,
+        models=models,
+        adapter=VariantAdapter(),
+        reviewers=reviewers,
+        aggregator=aggregator,
+        cost_gate=cost_gate,
+        max_parallel=max_parallel,
+    )

--- a/packages/code_understanding/tests/test_adapters.py
+++ b/packages/code_understanding/tests/test_adapters.py
@@ -1,0 +1,350 @@
+"""Tests for VariantAdapter and TraceAdapter.
+
+The substrate-level adapter behaviour (merge / correlate semantics) is
+already exercised in core/llm/multi_model/tests. These tests verify the
+consumer-specific bits: item_id, item_key, normalize_verdict.
+"""
+
+import pytest
+
+from packages.code_understanding import TraceAdapter, VariantAdapter
+
+
+# ---------------------------------------------------------------------------
+# VariantAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestVariantAdapterItemId:
+    def test_id_includes_function_when_present(self):
+        adapter = VariantAdapter()
+        assert adapter.item_id({
+            "file": "src/parser.c", "line": 42, "function": "parse_header",
+        }) == "src/parser.c:42:parse_header"
+
+    def test_id_omits_function_when_absent(self):
+        adapter = VariantAdapter()
+        assert adapter.item_id({
+            "file": "src/parser.c", "line": 42,
+        }) == "src/parser.c:42"
+
+    def test_id_omits_function_when_empty(self):
+        adapter = VariantAdapter()
+        assert adapter.item_id({
+            "file": "src/parser.c", "line": 42, "function": "",
+        }) == "src/parser.c:42"
+
+
+class TestVariantAdapterItemKey:
+    def test_basic_key(self):
+        adapter = VariantAdapter()
+        assert adapter.item_key({
+            "file": "src/parser.c", "line": 42, "function": "f",
+        }) == ("src/parser.c", 42, "f")
+
+    def test_strips_leading_dot_slash(self):
+        # "./src/x.c" and "src/x.c" should produce equal keys
+        adapter = VariantAdapter()
+        a = adapter.item_key({"file": "./src/parser.c", "line": 42, "function": "f"})
+        b = adapter.item_key({"file": "src/parser.c", "line": 42, "function": "f"})
+        assert a == b
+
+    def test_strips_whitespace(self):
+        adapter = VariantAdapter()
+        a = adapter.item_key({"file": "  src/parser.c  ", "line": 42, "function": " f "})
+        b = adapter.item_key({"file": "src/parser.c", "line": 42, "function": "f"})
+        assert a == b
+
+    def test_does_not_lowercase(self):
+        # File paths are case-sensitive on Linux/macOS source trees;
+        # we must NOT collapse case.
+        adapter = VariantAdapter()
+        a = adapter.item_key({"file": "src/Parser.c", "line": 42, "function": ""})
+        b = adapter.item_key({"file": "src/parser.c", "line": 42, "function": ""})
+        assert a != b
+
+    def test_does_not_strip_extra_dots_at_start(self):
+        # Regression: previously used lstrip("./") which is a CHARACTER set,
+        # so leading dot sequences ("...weird.c") would get over-stripped.
+        # Now we use removeprefix("./") which only strips the literal prefix.
+        adapter = VariantAdapter()
+        # Three dots is unusual but should be preserved as-is
+        weird = adapter.item_key({"file": "...weird.c", "line": 1, "function": ""})
+        assert weird == ("...weird.c", 1, "")
+
+    def test_does_not_strip_dot_only_path(self):
+        adapter = VariantAdapter()
+        # ".file" is a hidden file name, not "./file"
+        result = adapter.item_key({"file": ".hidden", "line": 1, "function": ""})
+        assert result == (".hidden", 1, "")
+
+
+class TestVariantAdapterCanonicalIds:
+    """Regression: item_id and item_key must agree on canonicalization
+    so the same logical variant gets the same ID regardless of which
+    model contributed first."""
+
+    def test_id_normalizes_dot_slash_prefix(self):
+        adapter = VariantAdapter()
+        a = adapter.item_id({"file": "./src/x.c", "line": 5, "function": "f"})
+        b = adapter.item_id({"file": "src/x.c", "line": 5, "function": "f"})
+        assert a == b == "src/x.c:5:f"
+
+    def test_id_normalizes_whitespace(self):
+        adapter = VariantAdapter()
+        a = adapter.item_id({"file": "  src/x.c  ", "line": 5, "function": " f "})
+        b = adapter.item_id({"file": "src/x.c", "line": 5, "function": "f"})
+        assert a == b
+
+    def test_merged_item_has_canonical_id_regardless_of_first_model(self):
+        # Whether claude or zeta contributed first, item_id should be canonical.
+        adapter = VariantAdapter()
+        result_a_first = adapter.merge({
+            "alpha": [{"file": "./src/x.c", "line": 5, "function": "f"}],
+            "zeta":  [{"file": "src/x.c",   "line": 5, "function": "f"}],
+        })
+        result_z_first = adapter.merge({
+            "alpha": [{"file": "src/x.c",   "line": 5, "function": "f"}],
+            "zeta":  [{"file": "./src/x.c", "line": 5, "function": "f"}],
+        })
+        # IDs must be identical in both cases
+        assert adapter.item_id(result_a_first[0]) == adapter.item_id(result_z_first[0])
+
+
+class TestVariantAdapterLineCoercion:
+    """Models occasionally return numeric fields as strings; the adapter
+    should treat "5" and 5 as the same line."""
+
+    def test_string_line_unifies_with_int_line(self):
+        adapter = VariantAdapter()
+        result = adapter.merge({
+            "model-a": [{"file": "src/x.c", "line": 5, "function": "f"}],
+            "model-b": [{"file": "src/x.c", "line": "5", "function": "f"}],
+        })
+        # Same logical variant — should merge into one item
+        assert len(result) == 1
+        assert result[0]["found_by_models"] == ["model-a", "model-b"]
+
+    def test_string_line_with_whitespace_unifies(self):
+        adapter = VariantAdapter()
+        result = adapter.merge({
+            "model-a": [{"file": "src/x.c", "line": 5, "function": "f"}],
+            "model-b": [{"file": "src/x.c", "line": " 5 ", "function": "f"}],
+        })
+        assert len(result) == 1
+
+    def test_genuinely_different_lines_kept_separate(self):
+        adapter = VariantAdapter()
+        result = adapter.merge({
+            "model-a": [{"file": "src/x.c", "line": 5, "function": "f"}],
+            "model-b": [{"file": "src/x.c", "line": "10", "function": "f"}],
+        })
+        assert len(result) == 2
+
+    def test_non_numeric_line_string_preserved(self):
+        # Pathological case: model returned non-numeric line. Should
+        # surface as its own bucket rather than silently coercing to 0.
+        adapter = VariantAdapter()
+        result = adapter.merge({
+            "model-a": [{"file": "src/x.c", "line": "junk", "function": "f"}],
+        })
+        assert len(result) == 1
+        # The id is still derivable — the canonical line stays as the original junk string
+        assert "junk" in adapter.item_id(result[0])
+
+    def test_non_numeric_line_strips_whitespace_for_dedup(self):
+        # If two models return the SAME non-numeric line value but with
+        # different whitespace, they should still bucket together.
+        # Pre-fix: only the int-coercion path was stripped; the fallback
+        # path kept original whitespace, splitting the bucket.
+        adapter = VariantAdapter()
+        result = adapter.merge({
+            "model-a": [{"file": "src/x.c", "line": "junk", "function": "f"}],
+            "model-b": [{"file": "src/x.c", "line": "junk ", "function": "f"}],
+        })
+        assert len(result) == 1
+        assert result[0]["found_by_models"] == ["model-a", "model-b"]
+
+
+class TestVariantAdapterMerge:
+    def test_two_models_overlapping_finds(self):
+        adapter = VariantAdapter()
+        result = adapter.merge({
+            "claude": [
+                {"file": "src/x.c", "line": 5, "function": "f", "snippet": "claude saw"},
+            ],
+            "gemini": [
+                {"file": "src/x.c", "line": 5, "function": "f", "snippet": "gemini saw"},
+            ],
+        })
+        assert len(result) == 1
+        assert result[0]["found_by_models"] == ["claude", "gemini"]
+        # multi_model_finds preserves both views
+        assert "multi_model_finds" in result[0]
+        assert len(result[0]["multi_model_finds"]) == 2
+
+    def test_normalized_paths_unify_finds(self):
+        # claude returned "./src/x.c"; gemini returned "src/x.c".
+        # VariantAdapter's item_key normalizes ./ — they should unify.
+        adapter = VariantAdapter()
+        result = adapter.merge({
+            "claude": [{"file": "./src/x.c", "line": 5, "function": "f"}],
+            "gemini": [{"file": "src/x.c", "line": 5, "function": "f"}],
+        })
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# TraceAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestTraceAdapterItemId:
+    def test_uses_trace_id(self):
+        adapter = TraceAdapter()
+        assert adapter.item_id({"trace_id": "EP-001"}) == "EP-001"
+
+    def test_strips_trace_id_whitespace(self):
+        # Models occasionally return ids with surrounding whitespace.
+        # Strip so " EP-001 " and "EP-001" don't bucket separately.
+        adapter = TraceAdapter()
+        assert adapter.item_id({"trace_id": "  EP-001  "}) == "EP-001"
+
+    def test_whitespace_padded_trace_ids_unify_in_merge(self):
+        adapter = TraceAdapter()
+        result = adapter.merge({
+            "model-a": [{"trace_id": "EP-001", "verdict": "reachable"}],
+            "model-b": [{"trace_id": "  EP-001  ", "verdict": "reachable"}],
+        })
+        # Same trace, just whitespace differences
+        assert len(result) == 1
+
+    def test_missing_trace_id_raises_with_clear_message(self):
+        # Regression: previously raised KeyError, which misleads operators
+        # into thinking the adapter is buggy. Now we raise ValueError
+        # naming the actual problem (model returned malformed dict).
+        adapter = TraceAdapter()
+        with pytest.raises(ValueError, match="missing.*trace_id"):
+            adapter.item_id({"verdict": "reachable", "reasoning": "ok"})
+
+
+class TestTraceAdapterDefensiveVerdict:
+    """Model output occasionally has type drift; non-string verdict
+    values shouldn't crash with AttributeError."""
+
+    def test_int_verdict_is_unknown(self):
+        adapter = TraceAdapter()
+        # Pre-fix: `(42 or "").strip().lower()` raised AttributeError
+        assert adapter.normalize_verdict({"verdict": 42}) == "unknown"
+
+    def test_none_verdict_is_unknown(self):
+        adapter = TraceAdapter()
+        assert adapter.normalize_verdict({"verdict": None}) == "unknown"
+
+    def test_list_verdict_is_unknown(self):
+        adapter = TraceAdapter()
+        # Some LLMs return ["reachable"] instead of "reachable"
+        assert adapter.normalize_verdict({"verdict": ["reachable"]}) == "unknown"
+
+    def test_correlate_with_typedrift_doesnt_crash(self):
+        # End-to-end: a model returning a non-string verdict must not
+        # crash merge or correlate. The substrate drops "unknown"
+        # verdicts from agreement classification, so the remaining
+        # classifiable verdict (positive) wins → high.
+        adapter = TraceAdapter()
+        per_model = {
+            "model-a": [{"trace_id": "EP-001", "verdict": "reachable"}],
+            "model-b": [{"trace_id": "EP-001", "verdict": 42}],  # type drift
+        }
+        merged = adapter.merge(per_model)
+        c = adapter.correlate(merged, per_model)
+        # Doesn't crash; classifiable verdicts = {"positive"} → "high"
+        assert c["confidence_signals"]["EP-001"] == "high"
+
+
+class TestTraceAdapterNormalizeVerdict:
+    def test_reachable_is_positive(self):
+        adapter = TraceAdapter()
+        assert adapter.normalize_verdict({"verdict": "reachable"}) == "positive"
+
+    def test_not_reachable_is_negative(self):
+        adapter = TraceAdapter()
+        assert adapter.normalize_verdict({"verdict": "not_reachable"}) == "negative"
+
+    def test_uncertain_is_inconclusive(self):
+        adapter = TraceAdapter()
+        assert adapter.normalize_verdict({"verdict": "uncertain"}) == "inconclusive"
+
+    def test_unknown_string_is_unknown(self):
+        adapter = TraceAdapter()
+        assert adapter.normalize_verdict({"verdict": "weird"}) == "unknown"
+
+    def test_empty_is_unknown(self):
+        adapter = TraceAdapter()
+        assert adapter.normalize_verdict({}) == "unknown"
+
+    def test_case_and_whitespace_insensitive(self):
+        adapter = TraceAdapter()
+        assert adapter.normalize_verdict({"verdict": "  REACHABLE  "}) == "positive"
+
+
+class TestTraceAdapterMerge:
+    def test_prefer_positive_default(self):
+        # Default select_primary inherited from BaseVerdictAdapter:
+        # reachable wins over not_reachable.
+        adapter = TraceAdapter()
+        result = adapter.merge({
+            "claude": [{"trace_id": "EP-001", "verdict": "not_reachable"}],
+            "gemini": [{"trace_id": "EP-001", "verdict": "reachable"}],
+        })
+        assert len(result) == 1
+        assert result[0]["verdict"] == "reachable"
+        # multi_model_analyses attached when 2+ distinct models
+        assert "multi_model_analyses" in result[0]
+
+
+class TestTraceAdapterReasoningTruncation:
+    def test_reasoning_truncate_is_1200(self):
+        # Subclass overrides REASONING_TRUNCATE — verify it sticks
+        adapter = TraceAdapter()
+        long_reasoning = "x" * 2000
+        result = adapter.merge({
+            "claude": [{"trace_id": "EP-001", "verdict": "reachable",
+                        "reasoning": long_reasoning}],
+            "gemini": [{"trace_id": "EP-001", "verdict": "reachable"}],
+        })
+        analyses = result[0]["multi_model_analyses"]
+        claude_record = next(a for a in analyses if a["model"] == "claude")
+        assert len(claude_record["reasoning"]) == 1200
+
+
+class TestTraceAdapterCorrelate:
+    def test_disputed_when_reachable_vs_not_reachable(self):
+        adapter = TraceAdapter()
+        per_model = {
+            "claude": [{"trace_id": "EP-001", "verdict": "reachable"}],
+            "gemini": [{"trace_id": "EP-001", "verdict": "not_reachable"}],
+        }
+        merged = adapter.merge(per_model)
+        c = adapter.correlate(merged, per_model)
+        assert c["confidence_signals"]["EP-001"] == "disputed"
+
+    def test_high_when_all_reachable(self):
+        adapter = TraceAdapter()
+        per_model = {
+            "claude": [{"trace_id": "EP-001", "verdict": "reachable"}],
+            "gemini": [{"trace_id": "EP-001", "verdict": "reachable"}],
+        }
+        merged = adapter.merge(per_model)
+        c = adapter.correlate(merged, per_model)
+        assert c["confidence_signals"]["EP-001"] == "high"
+
+    def test_mixed_when_reachable_plus_uncertain(self):
+        adapter = TraceAdapter()
+        per_model = {
+            "claude": [{"trace_id": "EP-001", "verdict": "reachable"}],
+            "gemini": [{"trace_id": "EP-001", "verdict": "uncertain"}],
+        }
+        merged = adapter.merge(per_model)
+        c = adapter.correlate(merged, per_model)
+        assert c["confidence_signals"]["EP-001"] == "mixed"

--- a/packages/code_understanding/tests/test_hunt.py
+++ b/packages/code_understanding/tests/test_hunt.py
@@ -1,0 +1,245 @@
+"""Tests for hunt() orchestrator.
+
+Uses mock dispatch_fn — real LLM dispatch is PR2b's responsibility.
+"""
+
+from dataclasses import dataclass
+
+import pytest
+
+from packages.code_understanding import hunt
+
+
+@dataclass
+class FakeModel:
+    model_name: str
+
+
+# ---------------------------------------------------------------------------
+# Basic dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestHuntDispatch:
+    def test_calls_dispatch_for_each_model(self):
+        seen = []
+
+        def dispatch(model, pattern, repo_path):
+            seen.append((model.model_name, pattern, repo_path))
+            return [{"file": "x.c", "line": 1, "function": ""}]
+
+        hunt(
+            pattern="strcpy_misuse",
+            repo_path="/code",
+            models=[FakeModel("a"), FakeModel("b"), FakeModel("c")],
+            dispatch_fn=dispatch,
+        )
+
+        assert sorted(seen) == [
+            ("a", "strcpy_misuse", "/code"),
+            ("b", "strcpy_misuse", "/code"),
+            ("c", "strcpy_misuse", "/code"),
+        ]
+
+    def test_returns_unioned_variants(self):
+        per_model_finds = {
+            "a": [
+                {"file": "src/x.c", "line": 5, "function": "f"},
+                {"file": "src/x.c", "line": 9, "function": "g"},
+            ],
+            "b": [
+                {"file": "src/x.c", "line": 5, "function": "f"},
+                {"file": "src/y.c", "line": 1, "function": ""},
+            ],
+        }
+
+        def dispatch(model, pattern, repo_path):
+            return per_model_finds[model.model_name]
+
+        result = hunt(
+            pattern="any",
+            repo_path="/code",
+            models=[FakeModel("a"), FakeModel("b")],
+            dispatch_fn=dispatch,
+        )
+
+        # 3 distinct variants
+        ids = sorted(adapter_id(it) for it in result.items)
+        assert ids == ["src/x.c:5:f", "src/x.c:9:g", "src/y.c:1"]
+
+
+def adapter_id(item):
+    """Helper to derive id consistently with VariantAdapter."""
+    fn = item.get("function", "")
+    if fn:
+        return f"{item['file']}:{item['line']}:{fn}"
+    return f"{item['file']}:{item['line']}"
+
+
+# ---------------------------------------------------------------------------
+# Recall signals
+# ---------------------------------------------------------------------------
+
+
+class TestHuntRecallSignals:
+    def test_all_models_recall_when_all_find(self):
+        def dispatch(model, pattern, repo_path):
+            return [{"file": "src/x.c", "line": 5, "function": "f"}]
+
+        result = hunt(
+            pattern="any",
+            repo_path="/code",
+            models=[FakeModel("a"), FakeModel("b"), FakeModel("c")],
+            dispatch_fn=dispatch,
+        )
+
+        recall = result.correlation["recall_signals"]
+        assert recall["src/x.c:5:f"] == "all_models"
+
+    def test_minority_recall_when_only_one_finds(self):
+        def dispatch(model, pattern, repo_path):
+            if model.model_name == "a":
+                return [{"file": "src/x.c", "line": 5, "function": "f"}]
+            return []
+
+        result = hunt(
+            pattern="any",
+            repo_path="/code",
+            models=[FakeModel("a"), FakeModel("b"), FakeModel("c")],
+            dispatch_fn=dispatch,
+        )
+
+        recall = result.correlation["recall_signals"]
+        assert recall["src/x.c:5:f"] == "minority"
+
+
+# ---------------------------------------------------------------------------
+# Failure handling
+# ---------------------------------------------------------------------------
+
+
+class TestHuntFailures:
+    def test_failed_model_doesnt_kill_run(self):
+        def dispatch(model, pattern, repo_path):
+            if model.model_name == "broken":
+                raise RuntimeError("model fell over")
+            return [{"file": "src/x.c", "line": 1, "function": ""}]
+
+        result = hunt(
+            pattern="any",
+            repo_path="/code",
+            models=[FakeModel("good"), FakeModel("broken")],
+            dispatch_fn=dispatch,
+        )
+
+        assert result.failed_models == ["broken"]
+        # Survivor's finds are still in the merged result
+        assert any(
+            adapter_id(it) == "src/x.c:1" for it in result.items
+        )
+
+    def test_dispatch_returning_errors_filtered(self):
+        def dispatch(model, pattern, repo_path):
+            if model.model_name == "errored":
+                return [{"error": "model timed out"}]
+            return [{"file": "src/x.c", "line": 1, "function": ""}]
+
+        result = hunt(
+            pattern="any",
+            repo_path="/code",
+            models=[FakeModel("good"), FakeModel("errored")],
+            dispatch_fn=dispatch,
+        )
+
+        # Substrate filters errors before merge; "errored" is in failed_models
+        # because every result it returned was an error
+        assert result.failed_models == ["errored"]
+        # Real find still surfaces
+        ids = [adapter_id(it) for it in result.items]
+        assert "src/x.c:1" in ids
+
+
+class TestHuntInputValidation:
+    def test_empty_pattern_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            hunt(
+                pattern="",
+                repo_path="/code",
+                models=[FakeModel("a")],
+                dispatch_fn=lambda m, p, r: [],
+            )
+
+    def test_whitespace_only_pattern_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            hunt(
+                pattern="   ",
+                repo_path="/code",
+                models=[FakeModel("a")],
+                dispatch_fn=lambda m, p, r: [],
+            )
+
+    def test_non_callable_dispatch_raises(self):
+        with pytest.raises(TypeError, match="callable"):
+            hunt(
+                pattern="any",
+                repo_path="/code",
+                models=[FakeModel("a")],
+                dispatch_fn="not a function",  # type: ignore[arg-type]
+            )
+
+    def test_pattern_stripped_before_dispatch(self):
+        # Whitespace-padded patterns are common copy-paste errors.
+        # The validation pre-check used `pattern.strip()`; the dispatch
+        # call should see the stripped value, not the original.
+        seen = []
+
+        def dispatch(model, pattern, repo_path):
+            seen.append(pattern)
+            return []
+
+        hunt(
+            pattern="  strcpy_misuse  ",
+            repo_path="/code",
+            models=[FakeModel("a")],
+            dispatch_fn=dispatch,
+        )
+
+        assert seen == ["strcpy_misuse"]
+
+
+# ---------------------------------------------------------------------------
+# Aggregator integration
+# ---------------------------------------------------------------------------
+
+
+class TestHuntAggregator:
+    def test_aggregator_runs_with_recall_signals(self):
+        captured = {}
+
+        class CapturingAggregator:
+            cutoff_ratio = 1.0
+
+            def aggregate(self, items, correlation):
+                captured["correlation"] = correlation
+                captured["item_count"] = len(items)
+                return {"summary": f"{len(items)} variants found"}
+
+        per_model_finds = {
+            "a": [{"file": "src/x.c", "line": 5, "function": "f"}],
+            "b": [{"file": "src/x.c", "line": 5, "function": "f"}],
+        }
+
+        def dispatch(model, pattern, repo_path):
+            return per_model_finds[model.model_name]
+
+        result = hunt(
+            pattern="any",
+            repo_path="/code",
+            models=[FakeModel("a"), FakeModel("b")],
+            dispatch_fn=dispatch,
+            aggregator=CapturingAggregator(),
+        )
+
+        assert result.aggregation == {"summary": "1 variants found"}
+        assert "recall_signals" in captured["correlation"]
+        assert captured["item_count"] == 1

--- a/packages/code_understanding/tests/test_trace.py
+++ b/packages/code_understanding/tests/test_trace.py
@@ -1,0 +1,215 @@
+"""Tests for trace() orchestrator.
+
+Uses mock dispatch_fn — real LLM dispatch is PR2b's responsibility.
+"""
+
+from dataclasses import dataclass
+
+import pytest
+
+from packages.code_understanding import trace
+
+
+@dataclass
+class FakeModel:
+    model_name: str
+
+
+# ---------------------------------------------------------------------------
+# Basic dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestTraceDispatch:
+    def test_calls_dispatch_for_each_model(self):
+        seen = []
+
+        def dispatch(model, traces):
+            seen.append(model.model_name)
+            return [{"trace_id": t["trace_id"], "verdict": "reachable"}
+                    for t in traces]
+
+        trace(
+            traces=[{"trace_id": "EP-001"}],
+            repo_path="/code",
+            models=[FakeModel("a"), FakeModel("b")],
+            dispatch_fn=dispatch,
+        )
+
+        assert sorted(seen) == ["a", "b"]
+
+    def test_empty_traces_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            trace(
+                traces=[],
+                repo_path="/code",
+                models=[FakeModel("a")],
+                dispatch_fn=lambda m, t: [],
+            )
+
+    def test_non_callable_dispatch_raises(self):
+        with pytest.raises(TypeError, match="callable"):
+            trace(
+                traces=[{"trace_id": "EP-001"}],
+                repo_path="/code",
+                models=[FakeModel("a")],
+                dispatch_fn=None,  # type: ignore[arg-type]
+            )
+
+
+# ---------------------------------------------------------------------------
+# Verdict merging (prefer-positive default)
+# ---------------------------------------------------------------------------
+
+
+class TestTraceMerge:
+    def test_reachable_wins_over_not_reachable(self):
+        verdicts = {
+            "claude": [{"trace_id": "EP-001", "verdict": "not_reachable"}],
+            "gemini": [{"trace_id": "EP-001", "verdict": "reachable"}],
+        }
+
+        def dispatch(model, traces):
+            return verdicts[model.model_name]
+
+        result = trace(
+            traces=[{"trace_id": "EP-001"}],
+            repo_path="/code",
+            models=[FakeModel("claude"), FakeModel("gemini")],
+            dispatch_fn=dispatch,
+        )
+
+        assert result.items[0]["verdict"] == "reachable"
+
+    def test_disagreement_marked_as_disputed(self):
+        verdicts = {
+            "claude": [{"trace_id": "EP-001", "verdict": "reachable"}],
+            "gemini": [{"trace_id": "EP-001", "verdict": "not_reachable"}],
+        }
+
+        def dispatch(model, traces):
+            return verdicts[model.model_name]
+
+        result = trace(
+            traces=[{"trace_id": "EP-001"}],
+            repo_path="/code",
+            models=[FakeModel("claude"), FakeModel("gemini")],
+            dispatch_fn=dispatch,
+        )
+
+        assert result.correlation["confidence_signals"]["EP-001"] == "disputed"
+
+    def test_unanimous_reachable_is_high(self):
+        def dispatch(model, traces):
+            return [{"trace_id": t["trace_id"], "verdict": "reachable"}
+                    for t in traces]
+
+        result = trace(
+            traces=[{"trace_id": "EP-001"}, {"trace_id": "EP-002"}],
+            repo_path="/code",
+            models=[FakeModel("a"), FakeModel("b"), FakeModel("c")],
+            dispatch_fn=dispatch,
+        )
+
+        for trace_id in ("EP-001", "EP-002"):
+            assert result.correlation["confidence_signals"][trace_id] == "high"
+
+    def test_all_uncertain_is_high_inconclusive(self):
+        def dispatch(model, traces):
+            return [{"trace_id": t["trace_id"], "verdict": "uncertain"}
+                    for t in traces]
+
+        result = trace(
+            traces=[{"trace_id": "EP-001"}],
+            repo_path="/code",
+            models=[FakeModel("a"), FakeModel("b")],
+            dispatch_fn=dispatch,
+        )
+
+        assert result.correlation["confidence_signals"]["EP-001"] == "high-inconclusive"
+
+
+# ---------------------------------------------------------------------------
+# Failure handling
+# ---------------------------------------------------------------------------
+
+
+class TestTraceFailures:
+    def test_failed_model_doesnt_kill_run(self):
+        def dispatch(model, traces):
+            if model.model_name == "broken":
+                raise RuntimeError("nope")
+            return [{"trace_id": t["trace_id"], "verdict": "reachable"}
+                    for t in traces]
+
+        result = trace(
+            traces=[{"trace_id": "EP-001"}],
+            repo_path="/code",
+            models=[FakeModel("good"), FakeModel("broken")],
+            dispatch_fn=dispatch,
+        )
+
+        assert result.failed_models == ["broken"]
+        assert result.items[0]["verdict"] == "reachable"
+
+    def test_dispatch_partially_returning_errors(self):
+        def dispatch(model, traces):
+            return [{"error": "model timed out"} for _ in traces]
+
+        result = trace(
+            traces=[{"trace_id": "EP-001"}, {"trace_id": "EP-002"}],
+            repo_path="/code",
+            models=[FakeModel("a")],
+            dispatch_fn=dispatch,
+        )
+
+        # All of model a's verdicts were errors → failed
+        assert result.failed_models == ["a"]
+        # Nothing made it through to merged items
+        assert result.items == []
+
+
+# ---------------------------------------------------------------------------
+# Aggregator integration
+# ---------------------------------------------------------------------------
+
+
+class TestTraceAggregator:
+    def test_aggregator_sees_disputed_traces(self):
+        captured = {}
+
+        class DisputedCapturing:
+            cutoff_ratio = 1.0
+
+            def aggregate(self, items, correlation):
+                disputed = [
+                    tid for tid, sig in correlation["confidence_signals"].items()
+                    if sig == "disputed"
+                ]
+                captured["disputed"] = disputed
+                return {"disputed_count": len(disputed)}
+
+        verdicts = {
+            "claude": [
+                {"trace_id": "EP-001", "verdict": "reachable"},
+                {"trace_id": "EP-002", "verdict": "reachable"},  # unanimous
+            ],
+            "gemini": [
+                {"trace_id": "EP-001", "verdict": "not_reachable"},  # disputed
+                {"trace_id": "EP-002", "verdict": "reachable"},
+            ],
+        }
+
+        def dispatch(model, traces):
+            return verdicts[model.model_name]
+
+        result = trace(
+            traces=[{"trace_id": "EP-001"}, {"trace_id": "EP-002"}],
+            repo_path="/code",
+            models=[FakeModel("claude"), FakeModel("gemini")],
+            dispatch_fn=dispatch,
+            aggregator=DisputedCapturing(),
+        )
+
+        assert captured["disputed"] == ["EP-001"]
+        assert result.aggregation == {"disputed_count": 1}

--- a/packages/code_understanding/trace.py
+++ b/packages/code_understanding/trace.py
@@ -1,0 +1,97 @@
+"""Multi-model orchestrator for /understand --trace.
+
+Runs N models against a list of traces (entry-point flows), merges
+their per-trace verdicts via prefer-positive rules, and optionally
+synthesizes via an aggregator.
+
+The actual LLM call lives in `dispatch_fn` (consumer-supplied).
+PR2b will provide a default dispatch_fn; for now mocks work cleanly.
+"""
+
+import logging
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+from core.llm.multi_model import (
+    Aggregator,
+    CostGate,
+    ModelHandle,
+    MultiModelResult,
+    Reviewer,
+    run_multi_model,
+)
+
+from packages.code_understanding.adapters import TraceAdapter
+
+logger = logging.getLogger(__name__)
+
+
+TraceDispatchFn = Callable[
+    [ModelHandle, List[Dict[str, Any]]],  # (model, traces_to_classify)
+    List[Dict[str, Any]],                  # list of verdict dicts
+]
+# Asymmetry note: HuntDispatchFn takes (model, pattern, repo_path) while
+# TraceDispatchFn takes (model, traces). That's intentional — hunt has a
+# single pattern applied across the codebase, while trace has a list of
+# pre-built traces (each carrying its own entry/sink/steps). The
+# dispatch_fn signatures reflect what each mode actually needs, not a
+# shared shape.
+
+
+def trace(
+    *,
+    traces: List[Dict[str, Any]],
+    repo_path: str,
+    models: Iterable[ModelHandle],
+    dispatch_fn: TraceDispatchFn,
+    reviewers: Optional[Iterable[Reviewer]] = (),
+    aggregator: Optional[Aggregator] = None,
+    cost_gate: Optional[CostGate] = None,
+    max_parallel: int = 3,
+) -> MultiModelResult:
+    """Multi-model trace verdict.
+
+    Args:
+        traces: List of trace dicts to classify. Each must have at
+            least a `trace_id` field; other fields (entry, sink, steps)
+            are dispatch_fn's responsibility to interpret.
+        repo_path: Repository to analyse.
+        models: Sequence of ModelHandles.
+        dispatch_fn: Callable that takes a model + the trace list and
+            returns one verdict dict per trace. Each verdict dict must
+            include `trace_id` (matching the input) and `verdict`
+            (reachable | not_reachable | uncertain).
+        reviewers: Optional review phase — runs after merge.
+        aggregator: Optional LLM synthesis.
+        cost_gate: Optional budget gate.
+        max_parallel: Thread pool size.
+
+    Returns:
+        MultiModelResult with `items` = one merged trace per trace_id
+        (primary = prefer-positive winner) and `correlation` carrying
+        agreement signals (high / high-negative / disputed / mixed /
+        high-inconclusive / single_model).
+    """
+    if not traces:
+        raise ValueError("traces must be non-empty")
+    if not callable(dispatch_fn):
+        raise TypeError(
+            f"dispatch_fn must be callable; got {type(dispatch_fn).__name__}"
+        )
+
+    def task(model: ModelHandle) -> List[Dict[str, Any]]:
+        return dispatch_fn(model, traces)
+
+    # repo_path isn't needed by the substrate (the dispatch_fn closes
+    # over it via its own arguments), but we keep it on the signature
+    # for symmetry with hunt() and so a future PR2b dispatch can use it.
+    _ = repo_path
+
+    return run_multi_model(
+        task=task,
+        models=models,
+        adapter=TraceAdapter(),
+        reviewers=reviewers,
+        aggregator=aggregator,
+        cost_gate=cost_gate,
+        max_parallel=max_parallel,
+    )


### PR DESCRIPTION
Adapters and orchestrators for /understand --hunt (set-style) and --trace (verdict-style) on top of core.llm.multi_model. dispatch_fn is consumer-supplied; this PR ships the adapters + orchestrators only, mock-tested. Real LLM dispatch (prompts, tool-use loop wiring, libexec entry points) lands in PR2b.

Public API in packages/code_understanding/:
- hunt() — variant hunt orchestrator
- trace() — flow-trace orchestrator
- VariantAdapter — set-style substrate adapter
- TraceAdapter — verdict-style substrate adapter
- HuntDispatchFn, TraceDispatchFn — type aliases

Defensive against:
- LLM type drift (string-numeric line, non-string verdict)
- Whitespace-padded ids and pattern strings
- Path inconsistency (./src/x.c vs src/x.c)
- Bad dispatch_fn / pattern at entry

Also fixes a pre-existing test isolation bug in
core/llm/tests/test_config_file.py: 16 sites mutated module-level cache without restoring, causing test_dispatch.py::test_multi_model_flags to flake when the full suite ran. Added an autouse fixture that snapshots and restores the cache.

59 tests for code_understanding (4 adversarial review rounds); full repo suite 6038/6038 passing.