### PR TITLE
core/reporting: render-time XSS sanitisation for SARIF-sourced fields

### DIFF
--- a/core/reporting/findings.py
+++ b/core/reporting/findings.py
@@ -2,6 +2,14 @@
 
 Translates vulnerability findings into ReportSpec for rendering.
 Used by both /validate and /agentic pipelines.
+
+Untrusted fields — anything sourced from a finding dict, including
+SARIF text from external scanners (Semgrep, CodeQL, etc.) — pass
+through ``sanitise_string`` / ``sanitise_code`` before landing in
+the rendered output. Markdown allows raw HTML by default, so any
+unescaped ``<script>`` / ``<img onerror>`` in a finding field would
+execute when the report is opened in a browser-rendered viewer
+(GitHub preview, MkDocs, gitlab, etc). Single choke point: render-time.
 """
 
 from typing import Any, Dict, List, Optional, Tuple
@@ -9,6 +17,20 @@ from typing import Any, Dict, List, Optional, Tuple
 from core.security.prompt_output_sanitise import sanitise_code, sanitise_string
 from .formatting import get_display_status, title_case_type, truncate_path
 from .spec import ReportSpec, ReportSection
+
+
+def _sani(value: Any, *, max_chars: int = 200) -> str:
+    """Cast + sanitise an untrusted finding field for rendered output.
+
+    Returns ``"—"`` for None / empty so table cells stay tidy. All
+    SARIF-sourced strings go through here on their way into the
+    report — vuln_type, cwe_id, file path, function name, status,
+    severity, CVSS string, etc. Numeric callers can rely on the
+    str() cast.
+    """
+    if value is None or value == "":
+        return "—"
+    return sanitise_string(str(value), max_chars=max_chars)
 
 
 def build_findings_rows(findings: List[Dict[str, Any]], filename_only: bool = False) -> List[Tuple]:
@@ -22,17 +44,17 @@ def build_findings_rows(findings: List[Dict[str, Any]], filename_only: bool = Fa
     """
     rows = []
     for i, f in enumerate(findings, 1):
-        vtype = title_case_type(f.get("vuln_type", ""))
-        cwe = f.get("cwe_id") or "—"
+        vtype = sanitise_string(title_case_type(f.get("vuln_type", "")), max_chars=80)
+        cwe = _sani(f.get("cwe_id"), max_chars=20)
 
         fpath = f.get("file") or f.get("file_path") or ""
         if filename_only:
             fpath = fpath.rsplit("/", 1)[-1] if "/" in fpath else fpath
         fline = f.get("line") if f.get("line") is not None else f.get("start_line")
         loc = f"{fpath}:{fline}" if fline is not None else fpath
-        loc = truncate_path(loc) if loc else "—"
+        loc = sanitise_string(truncate_path(loc), max_chars=80) if loc else "—"
 
-        status = get_display_status(f)
+        status = sanitise_string(get_display_status(f), max_chars=40)
 
         severity = str(f.get("severity") or f.get("severity_assessment") or "").lower()
         if severity == "none":
@@ -41,9 +63,10 @@ def build_findings_rows(findings: List[Dict[str, Any]], filename_only: bool = Fa
             severity = severity.title()
         else:
             severity = "—"
+        severity = sanitise_string(severity, max_chars=20)
 
         cvss = f.get("cvss_score_estimate")
-        cvss_str = str(cvss) if cvss is not None else "—"
+        cvss_str = sanitise_string(str(cvss), max_chars=10) if cvss is not None else "—"
 
         rows.append((str(i), vtype, cwe, loc, status, severity, cvss_str))
 
@@ -115,11 +138,15 @@ def findings_summary_line(counts: Dict[str, int], vuln_count: Optional[int] = No
 
 def build_finding_detail(finding: Dict[str, Any], index: int) -> ReportSection:
     """Build a per-finding detail section."""
-    fid = finding.get("id") or finding.get("finding_id") or f"FIND-{index:04d}"
-    vtype = title_case_type(finding.get("vuln_type", "unknown"))
+    fid = sanitise_string(
+        str(finding.get("id") or finding.get("finding_id") or f"FIND-{index:04d}"),
+        max_chars=80,
+    )
+    vtype = sanitise_string(title_case_type(finding.get("vuln_type", "unknown")), max_chars=80)
     fpath = finding.get("file") or finding.get("file_path") or "unknown"
     fline = finding.get("line") if finding.get("line") is not None else finding.get("start_line")
     loc = f"{fpath}:{fline}" if fline is not None else fpath
+    loc = sanitise_string(loc, max_chars=200)
 
     title = f"{fid} — {vtype} in `{loc}`"
 
@@ -130,31 +157,32 @@ def build_finding_detail(finding: Dict[str, Any], index: int) -> ReportSection:
 
     func = finding.get("function")
     if func:
-        lines.append(f"| Function | `{func}` |")
+        lines.append(f"| Function | `{sanitise_string(str(func), max_chars=120)}` |")
 
     code = finding.get("proof", {}).get("vulnerable_code") if isinstance(finding.get("proof"), dict) else None
     code = code or finding.get("code") or ""
     if code:
-        code_line = code.strip().split("\n")[0][:100].replace("|", "\\|")
+        code_line = code.strip().split("\n")[0][:100]
+        code_line = sanitise_string(code_line, max_chars=120).replace("|", "\\|")
         lines.append(f"| Code | `{code_line}` |")
 
-    lines.append(f"| Final Status | {get_display_status(finding)} |")
+    lines.append(f"| Final Status | {sanitise_string(get_display_status(finding), max_chars=40)} |")
 
     cwe = finding.get("cwe_id")
     if cwe:
-        lines.append(f"| CWE | {cwe} |")
+        lines.append(f"| CWE | {sanitise_string(str(cwe), max_chars=20)} |")
 
     cvss = finding.get("cvss_score_estimate")
     cvss_vec = finding.get("cvss_vector")
     if cvss is not None:
-        cvss_str = str(cvss)
+        cvss_str = sanitise_string(str(cvss), max_chars=10)
         if cvss_vec:
-            cvss_str += f" (`{cvss_vec}`)"
+            cvss_str += f" (`{sanitise_string(str(cvss_vec), max_chars=80)}`)"
         lines.append(f"| CVSS | {cvss_str} |")
 
     confidence = finding.get("confidence")
     if confidence:
-        lines.append(f"| Confidence | {str(confidence).title()} |")
+        lines.append(f"| Confidence | {sanitise_string(str(confidence).title(), max_chars=40)} |")
 
     lines.append("")
 

--- a/core/reporting/tests/test_findings.py
+++ b/core/reporting/tests/test_findings.py
@@ -198,10 +198,14 @@ class TestFindingDetailSanitisation(unittest.TestCase):
         self.assertNotIn("# Injected Heading", section.content)
         self.assertIn("Injected Heading", section.content)
 
-    def test_patch_code_preserves_hash_include(self):
+    def test_patch_code_html_escapes_hash_include(self):
+        """``<`` and ``>`` HTML-escape inside the fenced patch block —
+        renders correctly when the markdown is converted to HTML, and
+        prevents XSS if the fence ever breaks."""
         finding = {**SAMPLE_FINDINGS[0], "patch_code": "#include <stdio.h>\nint main() {}"}
         section = build_finding_detail(finding, 1)
-        self.assertIn("#include <stdio.h>", section.content)
+        self.assertIn("#include &lt;stdio.h&gt;", section.content)
+        self.assertNotIn("#include <stdio.h>", section.content)
 
     def test_ansi_in_patch_code_escaped(self):
         finding = {**SAMPLE_FINDINGS[0], "patch_code": "int x\x1b[31m = 0;"}
@@ -226,6 +230,90 @@ class TestFindingDetailSanitisation(unittest.TestCase):
         section = build_finding_detail(finding, 1)
         self.assertIn("…", section.content)
         self.assertLess(len(section.content), 5000)
+
+
+class TestSarifSourcedFieldXss(unittest.TestCase):
+    """SARIF-sourced fields (vuln_type, file, function, code, etc.) are
+    attacker-controlled when scanning untrusted repos. Confirm they
+    HTML-escape on the way into the rendered markdown so embedded
+    ``<script>`` / ``<img onerror>`` can't execute when the report is
+    opened in a browser-rendered viewer."""
+
+    XSS_PAYLOAD = '<script>alert(1)</script>'
+    IMG_PAYLOAD = '<img src=x onerror="alert(1)">'
+
+    def _assertNoRawXss(self, content: str, payload: str = None):
+        """Raw XSS payload must not appear in rendered content."""
+        payload = payload or self.XSS_PAYLOAD
+        self.assertNotIn(payload, content)
+        self.assertNotIn("<script>", content)
+
+    def _assertEscaped(self, content: str):
+        """Escaped form of XSS payload must appear (proof the value was rendered)."""
+        self.assertIn("&lt;", content)
+
+    def test_xss_in_function_name_escaped(self):
+        finding = {**SAMPLE_FINDINGS[0], "function": self.XSS_PAYLOAD}
+        section = build_finding_detail(finding, 1)
+        self._assertNoRawXss(section.content)
+        self._assertEscaped(section.content)
+
+    def test_xss_in_file_path_escaped_in_title(self):
+        finding = {**SAMPLE_FINDINGS[0], "file": f"src/{self.XSS_PAYLOAD}.c"}
+        section = build_finding_detail(finding, 1)
+        # File path appears in the section title, not the table body
+        self._assertNoRawXss(section.title)
+        self._assertEscaped(section.title)
+
+    def test_xss_in_code_snippet_escaped(self):
+        finding = {**SAMPLE_FINDINGS[0], "code": self.IMG_PAYLOAD}
+        section = build_finding_detail(finding, 1)
+        self._assertNoRawXss(section.content, self.IMG_PAYLOAD)
+        self._assertEscaped(section.content)
+
+    def test_xss_in_cwe_id_escaped(self):
+        finding = {**SAMPLE_FINDINGS[0], "cwe_id": self.XSS_PAYLOAD}
+        section = build_finding_detail(finding, 1)
+        self._assertNoRawXss(section.content)
+        self._assertEscaped(section.content)
+
+    def test_xss_in_vuln_type_escaped_in_row(self):
+        finding = {**SAMPLE_FINDINGS[0], "vuln_type": self.XSS_PAYLOAD}
+        rows = build_findings_rows([finding])
+        joined = " ".join(str(c) for c in rows[0])
+        self._assertNoRawXss(joined)
+        self._assertEscaped(joined)
+
+    def test_xss_in_finding_id_escaped(self):
+        # Override both id keys so the XSS payload actually lands in the title
+        finding = {**SAMPLE_FINDINGS[0], "id": self.XSS_PAYLOAD, "finding_id": self.XSS_PAYLOAD}
+        section = build_finding_detail(finding, 1)
+        self._assertNoRawXss(section.title)
+        self._assertEscaped(section.title)
+
+    def test_xss_in_cvss_vector_escaped(self):
+        finding = {**SAMPLE_FINDINGS[0],
+                   "cvss_score_estimate": 8.4,
+                   "cvss_vector": self.XSS_PAYLOAD}
+        section = build_finding_detail(finding, 1)
+        self._assertNoRawXss(section.content)
+        self._assertEscaped(section.content)
+
+    def test_full_spec_render_with_xss_safe(self):
+        """End-to-end: build the full spec, render to markdown,
+        confirm the rendered markdown is XSS-clean."""
+        finding = {
+            **SAMPLE_FINDINGS[0],
+            "vuln_type": self.XSS_PAYLOAD,
+            "file": f"src/{self.XSS_PAYLOAD}.c",
+            "function": self.XSS_PAYLOAD,
+            "cwe_id": self.XSS_PAYLOAD,
+            "code": self.IMG_PAYLOAD,
+        }
+        spec = build_findings_spec([finding], title="Test")
+        report = render_report(spec)
+        self.assertNotIn("<script>", report)
+        self.assertNotIn(self.IMG_PAYLOAD, report)
 
 
 class TestBuildFindingsSpec(unittest.TestCase):

--- a/core/security/prompt_output_sanitise.py
+++ b/core/security/prompt_output_sanitise.py
@@ -1,20 +1,32 @@
-"""Post-processing for LLM-returned strings before they reach reports / UI.
+"""Post-processing for untrusted strings before they reach reports / UI.
 
 Pairs with prompt_envelope at the input side: where the envelope quarantines
 input from being treated as instructions by the model, this module
-quarantines model output from rendering surprises (terminal-injection,
-markdown auto-render) when the operator views findings.
+quarantines untrusted output (LLM-returned strings, SARIF-sourced finding
+fields from external scanners) from rendering surprises — terminal
+injection, markdown auto-render, HTML/XSS — when the operator views
+the rendered report.
 
-Pipeline:
+Pipeline (sanitise_string):
   1. defang line-leading markdown control chars (`*_# at line start) on
      real newline boundaries — keeps prose readable mid-string while
      disabling block-level rendering
   2. escape ANSI / BIDI / control bytes (preserves `\\n`, `\\t` so multi-line
      prose still renders as paragraphs in reports)
-  3. length-cap at max_chars with a single Unicode ellipsis (…)
+  3. HTML-escape <, >, &, ", ' so embedded ``<script>`` / ``<img onerror>``
+     can't execute when the markdown is rendered to HTML (GitHub preview,
+     MkDocs, browser-rendered docs). Markdown allows raw HTML by default
+     so this is essential, not optional.
+  4. length-cap at max_chars with a single Unicode ellipsis (…)
+
+For ``sanitise_code`` the line-leading defang is skipped (code legitimately
+contains ``#include``, ``*ptr``, ``__attribute__``); the remaining steps
+apply. Fenced ``` blocks isolate HTML rendering in well-behaved markdown
+viewers, but a payload containing ``` could break out of the fence — the
+HTML escape is defence-in-depth for that case.
 
 Note: the /tmp/llm.md spec listed escape→strip→cap. We deviate to strip→
-escape→cap because `core.security.log_sanitisation.escape_nonprintable`
+escape→html→cap because `core.security.log_sanitisation.escape_nonprintable`
 treats `\\n` as non-printable and would convert it to `\\x0a`, which both
 breaks the multi-line strip and prevents reports from showing line breaks.
 The spec's *intent* (multi-line markdown defanged, ANSI/BIDI killed,
@@ -23,6 +35,7 @@ natural prose preserved) is preserved; only the literal order changed.
 
 from __future__ import annotations
 
+import html
 import re
 
 from core.security.log_sanitisation import escape_nonprintable
@@ -33,29 +46,40 @@ _LINE_LEAD_MD_RE = re.compile(r'(?m)^([ \t]*)([`*_#]+)')
 _ELLIPSIS = '…'
 
 
-def sanitise_string(s: str, *, max_chars: int = 500) -> str:
-    """Defang an LLM-returned string for safe rendering in reports / UI.
+def sanitise_string(s: str, *, max_chars: int = 500, html_escape: bool = True) -> str:
+    """Defang an untrusted string for safe rendering in reports / UI.
 
-    `max_chars` is the post-escape length cap; the suffix ellipsis counts
-    toward the cap (returned string is at most `max_chars` characters).
+    ``max_chars`` is the post-escape length cap; the suffix ellipsis counts
+    toward the cap (returned string is at most ``max_chars`` characters).
+
+    ``html_escape`` (default True) HTML-escapes ``<``, ``>``, ``&``, ``"``,
+    ``'`` so the output can't form active tags when rendered to HTML.
+    Disable only for callers writing into a context that already isolates
+    HTML (e.g. inside an attribute value that's being template-escaped
+    elsewhere) — virtually all report-rendering callers want it on.
     """
     s = _LINE_LEAD_MD_RE.sub(lambda m: m.group(1), s)
     s = escape_nonprintable(s, preserve_newlines=True)
+    if html_escape:
+        s = html.escape(s, quote=True)
     if len(s) > max_chars:
         s = s[: max_chars - 1] + _ELLIPSIS
     return s
 
 
-def sanitise_code(s: str, *, max_chars: int = 10_000) -> str:
-    """Escape control chars in LLM-returned code for fenced-block rendering.
+def sanitise_code(s: str, *, max_chars: int = 10_000, html_escape: bool = True) -> str:
+    """Defang an untrusted code snippet for fenced-block rendering.
 
     Unlike sanitise_string, does NOT strip markdown control chars — code
     contains ``#include``, ``*ptr``, ``__attribute__`` legitimately.
-    Fenced code blocks (` ``` `) already isolate markdown rendering; the
-    remaining threat is ANSI/BIDI/control-byte injection via terminal
-    emulators (``cat report.md``).
+    Fenced code blocks (` ``` `) isolate markdown rendering in well-behaved
+    viewers; the HTML escape is defence-in-depth against fence-break
+    attacks (a payload containing ``` could close the fence and emit raw
+    HTML that the renderer would then process).
     """
     s = escape_nonprintable(s, preserve_newlines=True)
+    if html_escape:
+        s = html.escape(s, quote=True)
     if len(s) > max_chars:
         s = s[: max_chars - 1] + _ELLIPSIS
     return s

--- a/core/security/tests/test_e2e_defense_layers.py
+++ b/core/security/tests/test_e2e_defense_layers.py
@@ -745,3 +745,130 @@ class TestFullStackIntegration:
         adjusted = llm_confidence * pre.confidence_haircut
         assert adjusted == pytest.approx(0.45)
         assert pre.has_injection_indicators is True
+
+
+# ---------------------------------------------------------------------------
+# End-to-end SARIF → markdown report → rendered HTML XSS test
+# ---------------------------------------------------------------------------
+
+class TestSarifReportPipelineXssE2E:
+    """Full pipeline E2E: a malicious SARIF file lands on disk, gets parsed
+    by ``parse_sarif_findings``, fed into ``build_findings_spec``, rendered
+    to markdown by ``render_report``, and (when markdown-it is available)
+    rendered to HTML. At every stage, embedded XSS payloads must remain
+    inert: no raw ``<script>`` / event-handler attributes survive.
+
+    Single choke point is render-time sanitisation in
+    ``core/reporting/findings.py``; this test confirms that choke point is
+    positioned correctly relative to the SARIF ingestion path that real
+    scanners (Semgrep, CodeQL, custom queries) feed into the report
+    pipeline.
+    """
+
+    XSS_SCRIPT = "<script>alert(1)</script>"
+    XSS_IMG = '<img src=x onerror="alert(1)">'
+    XSS_SVG = "<svg onload=alert(1)>"
+
+    def _malicious_sarif(self) -> dict:
+        """Synthesise a SARIF file with XSS payloads in every text field a
+        SARIF parser walks: ruleId, message.text, location uri, region
+        snippet, and the rule definition's text fields."""
+        return {
+            "version": "2.1.0",
+            "runs": [{
+                "tool": {
+                    "driver": {
+                        "name": f"semgrep-{self.XSS_SCRIPT}",
+                        "rules": [{
+                            "id": f"rule-{self.XSS_SCRIPT}",
+                            "shortDescription": {"text": f"Short {self.XSS_IMG}"},
+                            "fullDescription": {"text": f"Full {self.XSS_SVG}"},
+                            "properties": {"tags": ["external/cwe/cwe-79"]},
+                        }],
+                    },
+                },
+                "results": [{
+                    "ruleId": f"rule-{self.XSS_SCRIPT}",
+                    "message": {"text": f"Vuln found {self.XSS_IMG}"},
+                    "locations": [{
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": f"src/{self.XSS_SCRIPT}.c"},
+                            "region": {
+                                "startLine": 42,
+                                "endLine": 42,
+                                "snippet": {"text": f"strcpy(dst, {self.XSS_IMG});"},
+                            },
+                        },
+                    }],
+                }],
+            }],
+        }
+
+    def test_parse_then_render_no_raw_script(self, tmp_path):
+        """Write malicious SARIF to disk, parse + render through the full
+        pipeline, assert the markdown contains no executable HTML."""
+        import json
+        from core.reporting.findings import build_findings_spec
+        from core.reporting.renderer import render_report
+        from core.sarif.parser import parse_sarif_findings
+
+        sarif_path = tmp_path / "malicious.sarif"
+        sarif_path.write_text(json.dumps(self._malicious_sarif()), encoding="utf-8")
+
+        findings = parse_sarif_findings(sarif_path)
+        assert findings, "SARIF parser should have returned at least one finding"
+
+        # Map SARIF fields onto the keys the renderer expects (parse_sarif_findings
+        # produces 'message' / 'snippet' / 'file'; reporting expects 'vuln_type' / 'code'
+        # for some sites — copy across so we exercise both paths).
+        for f in findings:
+            f.setdefault("vuln_type", f.get("rule_id", ""))
+            f.setdefault("code", f.get("snippet", ""))
+
+        spec = build_findings_spec(findings, title="E2E XSS Test")
+        report_md = render_report(spec)
+
+        for payload in (self.XSS_SCRIPT, self.XSS_IMG, self.XSS_SVG):
+            assert payload not in report_md, f"Raw payload survived render: {payload!r}"
+
+        # Confirm the values reached the report (not silently dropped) — without
+        # this the test could pass vacuously if a field were never read.
+        assert "&lt;script&gt;" in report_md or "&lt;img" in report_md or "&lt;svg" in report_md
+
+        # No naked HTML opener can form a tag
+        assert "<script" not in report_md.lower()
+        assert "<img " not in report_md.lower()
+        assert "<svg" not in report_md.lower()
+
+    def test_parse_then_render_then_html_no_active_tags(self, tmp_path):
+        """Render the markdown to HTML via markdown-it (with raw HTML
+        explicitly enabled, mirroring GitHub preview's permissive default)
+        and confirm no active tags survive — the strongest E2E signal we
+        can produce without a headless browser."""
+        markdown_it = pytest.importorskip("markdown_it")
+
+        import json
+        from core.reporting.findings import build_findings_spec
+        from core.reporting.renderer import render_report
+        from core.sarif.parser import parse_sarif_findings
+
+        sarif_path = tmp_path / "malicious.sarif"
+        sarif_path.write_text(json.dumps(self._malicious_sarif()), encoding="utf-8")
+
+        findings = parse_sarif_findings(sarif_path)
+        for f in findings:
+            f.setdefault("vuln_type", f.get("rule_id", ""))
+            f.setdefault("code", f.get("snippet", ""))
+
+        spec = build_findings_spec(findings, title="E2E XSS Test")
+        report_md = render_report(spec)
+
+        md = markdown_it.MarkdownIt("commonmark", {"html": True}).enable("table")
+        html_out = md.render(report_md)
+
+        for needle in ("<script", "<img src=x", "<svg", "onerror=\"alert", "onload=alert"):
+            assert needle not in html_out.lower(), (
+                f"Active XSS form {needle!r} survived markdown→HTML render"
+            )
+
+        assert "&lt;" in html_out

--- a/core/security/tests/test_prompt_output_sanitise.py
+++ b/core/security/tests/test_prompt_output_sanitise.py
@@ -83,8 +83,14 @@ def test_pipeline_order_escape_then_strip_then_cap():
 
 # --- sanitise_code ---
 
-def test_code_preserves_hash_include():
-    assert sanitise_code("#include <stdio.h>") == "#include <stdio.h>"
+def test_code_html_escapes_hash_include():
+    """``<`` and ``>`` get HTML-escaped — render correctly inside ``` fences."""
+    assert sanitise_code("#include <stdio.h>") == "#include &lt;stdio.h&gt;"
+
+
+def test_code_html_escape_off_preserves_hash_include():
+    """Opt-out for callers that don't want HTML escape."""
+    assert sanitise_code("#include <stdio.h>", html_escape=False) == "#include <stdio.h>"
 
 
 def test_code_preserves_pointer_deref():
@@ -115,3 +121,66 @@ def test_code_caps_length():
 def test_code_default_cap_is_generous():
     s = sanitise_code("x" * 5000)
     assert len(s) == 5000
+
+
+# --- HTML / XSS ---
+
+def test_string_html_escapes_script_tag():
+    s = sanitise_string("<script>alert(1)</script>")
+    assert "<script>" not in s
+    assert "&lt;script&gt;" in s
+
+
+def test_string_html_escapes_img_onerror():
+    s = sanitise_string('<img src=x onerror="alert(1)">')
+    assert "<img" not in s
+    assert "onerror=" in s  # text content, not active attribute
+    assert "&lt;img" in s
+    assert "&quot;" in s
+
+
+def test_string_html_escapes_ampersand():
+    s = sanitise_string("a & b")
+    assert s == "a &amp; b"
+
+
+def test_string_html_escapes_single_quote():
+    s = sanitise_string("it's fine")
+    assert "&#x27;" in s
+
+
+def test_string_html_escape_off_preserves_tags():
+    s = sanitise_string("<b>bold</b>", html_escape=False)
+    assert s == "<b>bold</b>"
+
+
+def test_string_double_escape_does_not_compound():
+    """Render path runs once. Verify a single pass produces canonical form."""
+    s = sanitise_string("&amp;")
+    # Already-escaped input gets re-escaped (cannot distinguish from raw).
+    # Render-once invariant in callers prevents this in practice.
+    assert s == "&amp;amp;"
+
+
+def test_code_html_escapes_script_in_fence_break_payload():
+    """Fence-break attack: payload contains ``` then HTML.
+
+    The HTML is still escaped — even if a buggy renderer ends the fence,
+    no active tags can form.
+    """
+    payload = "x\n```\n<script>alert(1)</script>"
+    s = sanitise_code(payload)
+    assert "<script>" not in s
+    assert "&lt;script&gt;" in s
+
+
+def test_string_html_escape_preserves_newlines():
+    s = sanitise_string("line1\nline2")
+    assert "\n" in s
+
+
+def test_string_pipeline_strip_then_html_escape():
+    """Line-leading defang runs before HTML escape so ``# &lt;hi&gt;`` works."""
+    s = sanitise_string("# <hi>")
+    # # stripped, then < > escaped
+    assert s == " &lt;hi&gt;"

--- a/packages/diagram/attack_paths.py
+++ b/packages/diagram/attack_paths.py
@@ -110,10 +110,10 @@ def generate(data: list[dict[str, Any]]) -> str:
 
     sections = []
     for i, path_data in enumerate(data):
-        path_id = path_data.get("id", f"PATH-{i+1}")
-        name = path_data.get("name", path_id)
+        path_id = _sanitize(path_data.get("id", f"PATH-{i+1}"))
+        name = _sanitize(path_data.get("name", path_id))
         proximity = path_data.get("proximity") or 0
-        status = path_data.get("status", "uncertain")
+        status = _sanitize(path_data.get("status", "uncertain"))
         sections.append(f"#### {path_id}: {name} (Proximity {proximity}/10, {status})\n")
         sections.append("```mermaid")
         sections.append(generate_single(path_data, i))

--- a/packages/diagram/flow_trace.py
+++ b/packages/diagram/flow_trace.py
@@ -78,7 +78,7 @@ def generate(data: dict[str, Any]) -> str:
 
 
     if not steps:
-        return f"flowchart TD\n    EMPTY[\"No steps in {trace_id}\"]"
+        return f"flowchart TD\n    EMPTY[\"No steps in {_sanitize(trace_id)}\"]"
 
     lines = ["flowchart TD"]
     lines.append(f'    TITLE["{name}"]')

--- a/packages/diagram/tests/test_diagram.py
+++ b/packages/diagram/tests/test_diagram.py
@@ -428,6 +428,13 @@ class TestFlowTrace:
         out = gen_flow_trace({"id": "T1", "name": "empty", "steps": []})
         assert "No steps" in out
 
+    def test_empty_steps_xss_in_trace_id_sanitised(self):
+        """trace_id is read from input data and lands in the EMPTY label —
+        confirm it can't break out of the mermaid quoted string."""
+        out = gen_flow_trace({"id": '<script>alert(1)</script>', "steps": []})
+        assert "<script>" not in out
+        assert "&lt;script&gt;" in out
+
     def test_step_chain_edges(self):
         out = gen_flow_trace(FLOW_TRACE_DATA)
         assert "S1 --> S2" in out
@@ -758,6 +765,19 @@ class TestAttackPaths:
     def test_empty_list(self):
         out = gen_attack_paths([])
         assert "No attack paths" in out
+
+    def test_xss_in_path_heading_sanitised(self):
+        """``path_id`` / ``name`` / ``status`` land in a markdown ``####`` heading
+        that's rendered to HTML — confirm raw ``<script>`` cannot survive."""
+        payload = "<script>alert(1)</script>"
+        out = gen_attack_paths([{
+            "id": payload,
+            "name": payload,
+            "status": payload,
+            "steps": [],
+        }])
+        assert "<script>" not in out
+        assert "&lt;script&gt;" in out
 
     def test_single_path_step_chain(self):
         out = generate_single(ATTACK_PATHS_DATA[0], 0)


### PR DESCRIPTION
SARIF text fields from external scanners (Semgrep, CodeQL, custom queries) flow through findings.json into validation-report.md and adjacent reports. An attacker controlling a scanned repository can plant <script> / <img onerror> / <svg onload> in result.message.text, artifactLocation.uri, region.snippet.text, or rule metadata; markdown allows raw HTML by default, so the payload executes when the report is opened in any browser-rendered viewer (GitHub preview, MkDocs, gitlab) or piped through a markdown renderer.

Render-time choke point in core/reporting/findings.py: every SARIF-sourced finding field (vuln_type, cwe_id, file path, function, code snippet, status, severity, CVSS string + vector, finding ID, confidence) now passes through sanitise_string before landing in the ReportSpec. Single layer, no double-encoding.

sanitise_string / sanitise_code grow an html.escape pass (default on, opt-out via html_escape=False). Adds defence-in-depth for sanitise_code against fence-break attacks: even if a payload containing ``` exits the fenced block, no active tags can form in the now-out-of-fence content.

Two latent bypasses fixed in the diagram package:
  - flow_trace.py: trace_id was unsanitised in the empty-steps EMPTY label fallback.
  - attack_paths.py: path_id, name, status were unsanitised in the markdown #### heading rendered above each path's mermaid block.

Existing infrastructure preserved:
  - packages/diagram/sanitize.py keeps its mermaid-specific semantics (quote collapse, syntax-breaker handling, label vs ID separation). The two layers serve different render contexts and were not forced into a shared helper.
  - core/security/log_sanitisation.escape_nonprintable continues as the inner layer for terminal injection.
  - HTML escape via html.escape from stdlib — no new module.

E2E coverage: TestSarifReportPipelineXssE2E in test_e2e_defense_layers.py writes a malicious SARIF file to disk, parses it via parse_sarif_findings, renders the full ReportSpec to markdown, and (when markdown-it is available) renders that markdown to HTML with raw-HTML explicitly enabled — mirroring GitHub preview's permissive default — confirming no active tags survive any stage. 790/790 focused tests pass; 5596 + 619 cve_diff green across the broader suite.