### PR TITLE
feat(iris): runtime CodeQL pack discovery for Tier 1 dataflow validation

### DIFF
--- a/packages/hypothesis_validation/adapters/codeql.py
+++ b/packages/hypothesis_validation/adapters/codeql.py
@@ -119,6 +119,117 @@ class CodeQLAdapter(ToolAdapter):
             languages=["c", "cpp", "java", "python", "javascript", "typescript", "go", "csharp", "ruby", "swift"],
         )
 
+    def run_prebuilt_query(
+        self,
+        query_path: Path,
+        target: Path,
+        *,
+        timeout: int = 300,
+        env: Optional[Dict[str, str]] = None,
+    ) -> ToolEvidence:
+        """Invoke an existing pack-resident .ql file directly.
+
+        Unlike `run`, no temp pack / qlpack.yml is materialised — the
+        prebuilt query already lives inside an installed pack so its
+        imports and dependencies are pre-resolved. We call
+        `codeql database analyze <db> <abs-ql-path>` and parse the SARIF.
+
+        `query_path` MUST be an absolute path to a `.ql` file produced
+        by `dataflow_query_builder.discover_prebuilt_query`. The path
+        is recorded as the `rule` field on the evidence so callers can
+        identify which prebuilt query handled the hypothesis (audit
+        trail, telemetry).
+
+        target / timeout / env behave the same as `run()`.
+        """
+        rule_label = str(query_path)
+        if not self._codeql_bin:
+            return ToolEvidence(
+                tool=self.name, rule=rule_label, success=False,
+                error="codeql CLI is not installed",
+            )
+        if not self._database_path:
+            return ToolEvidence(
+                tool=self.name, rule=rule_label, success=False,
+                error="no CodeQL database configured (set_database() first)",
+            )
+        if not self._database_path.exists():
+            return ToolEvidence(
+                tool=self.name, rule=rule_label, success=False,
+                error=f"CodeQL database not found: {self._database_path}",
+            )
+        if not query_path or not Path(query_path).is_file():
+            return ToolEvidence(
+                tool=self.name, rule=rule_label, success=False,
+                error=f"prebuilt query file not found: {query_path}",
+            )
+
+        if env is None:
+            from core.config import RaptorConfig
+            env = RaptorConfig.get_safe_env()
+
+        runner = (
+            make_sandbox_runner(target=self._database_path)
+            if self._sandbox else subprocess.run
+        )
+
+        try:
+            with TemporaryDirectory(prefix="codeql_prebuilt_") as tmp:
+                sarif_path = Path(tmp) / "result.sarif"
+                cmd = [
+                    self._codeql_bin,
+                    "database", "analyze",
+                    str(self._database_path),
+                    str(query_path),
+                    "--format=sarif-latest",
+                    f"--output={sarif_path}",
+                    "--no-rerun",
+                ]
+                try:
+                    proc = runner(
+                        cmd, capture_output=True, text=True,
+                        timeout=timeout, env=env,
+                    )
+                except subprocess.TimeoutExpired:
+                    return ToolEvidence(
+                        tool=self.name, rule=rule_label, success=False,
+                        error=f"codeql timeout after {timeout}s",
+                    )
+                except OSError as e:
+                    return ToolEvidence(
+                        tool=self.name, rule=rule_label, success=False,
+                        error=f"failed to invoke codeql: {e}",
+                    )
+
+                if proc.returncode != 0 or not sarif_path.exists():
+                    err = (proc.stderr or proc.stdout or "").strip()
+                    return ToolEvidence(
+                        tool=self.name, rule=rule_label, success=False,
+                        error=err[:500] or f"codeql returned {proc.returncode}",
+                    )
+
+                matches = _parse_sarif(sarif_path)
+        except OSError as e:
+            return ToolEvidence(
+                tool=self.name, rule=rule_label, success=False,
+                error=f"workspace setup failed: {e}",
+            )
+
+        n = len(matches)
+        files = sorted({m["file"] for m in matches if m.get("file")})
+        if n:
+            summary = f"{n} match{'es' if n != 1 else ''} in {len(files)} file{'s' if len(files) != 1 else ''}"
+        else:
+            summary = "no matches"
+
+        return ToolEvidence(
+            tool=self.name,
+            rule=rule_label,
+            success=True,
+            matches=matches,
+            summary=summary,
+        )
+
     def run(
         self,
         rule: str,

--- a/packages/llm_analysis/dataflow_query_builder.py
+++ b/packages/llm_analysis/dataflow_query_builder.py
@@ -2,13 +2,16 @@
 
 Three tiers, ordered by reliability:
 
-  Tier 1 — `build_prebuilt_query`: for known (language, CWE) pairs,
-    wraps a CodeQL pre-built Flow module (e.g. CommandInjectionFlow).
-    The LLM is not involved in QL generation; the wrapper imports the
-    professionally-written, pack-maintained config and reports paths.
-    Handles 70-80% of real Semgrep findings (CWE-78 / 79 / 89 / 22 etc.).
+  Tier 1 — `discover_prebuilt_query` + adapter.run_prebuilt_query:
+    discovers existing CodeQL queries indexed by `external/cwe/cwe-NNN`
+    tags under each installed `*-queries` pack. Invokes them by absolute
+    path. The LLM is not involved in QL generation; we just run the
+    professionally-written, pack-maintained `.ql` files. Handles 70-80%
+    of real Semgrep findings (CWE-78 / 79 / 89 / 22 etc.) for whatever
+    languages have packs installed.
 
-  Tier 2 — `build_template_query`: for unknown CWEs, assembles a full
+  Tier 2 — `build_template_query`: for CWEs with no prebuilt query, or
+    languages that lack a `*-queries` pack on the host, assembles a full
     query from a per-language template with placeholders. The LLM fills
     only the `isSource` and `isSink` predicate bodies — small surface,
     much smaller compile-error risk than full-query generation.
@@ -28,128 +31,190 @@ used the legacy `Configuration` class API, and got AST class names wrong
 (`IndexExpr` instead of `Subscript`). Constraining the LLM to predicate
 bodies — for which CodeQL's standard library exposes high-level helpers
 like `RemoteFlowSource` — sidesteps most of these failure modes.
+
+Discovery vs hardcoded map: an earlier draft maintained a hand-edited
+(language, CWE) → (import_path, flow_module) dict. Discovery replaces
+that — the CodeQL packs already organise queries by CWE under
+`Security/CWE-NNN/` and tag them with `@tags external/cwe/cwe-NNN`.
+The packs are the source of truth; hardcoding goes stale on every pack
+update. Discovery picks up new queries (and user-installed custom
+packs) automatically.
 """
 
+import functools
+import logging
 import re
-from typing import Dict, Optional, Tuple
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
 
 
-# Tier 1 ----------------------------------------------------------------------
+# Tier 1 — discovery ---------------------------------------------------------
 
-# Pre-built Flow modules from CodeQL's standard library packs.
-# Each entry maps (language, CWE) → (Customizations.qll path,
-# Flow module name). The path is what we `import`, the module name is
-# what we use for PathGraph / PathNode.
-#
-# These cover the most common CWEs flagged by Semgrep. Adding entries is
-# a one-line change — just confirm the pack actually ships the module
-# (look under `~/.codeql/packages/codeql/<lang>-all/*/semmle/<lang>/security/dataflow/`).
-_PREBUILT_FLOWS: Dict[Tuple[str, str], Tuple[str, str]] = {
-    # ---- Python (verified against installed codeql/python-all pack) ----
-    ("python", "CWE-78"):  ("semmle.python.security.dataflow.CommandInjectionQuery",       "CommandInjectionFlow"),
-    ("python", "CWE-77"):  ("semmle.python.security.dataflow.UnsafeShellCommandConstructionQuery", "UnsafeShellCommandConstructionFlow"),
-    ("python", "CWE-89"):  ("semmle.python.security.dataflow.SqlInjectionQuery",           "SqlInjectionFlow"),
-    ("python", "CWE-90"):  ("semmle.python.security.dataflow.LdapInjectionQuery",          "LdapInjectionFlow"),
-    ("python", "CWE-94"):  ("semmle.python.security.dataflow.CodeInjectionQuery",          "CodeInjectionFlow"),
-    ("python", "CWE-22"):  ("semmle.python.security.dataflow.PathInjectionQuery",          "PathInjectionFlow"),
-    ("python", "CWE-79"):  ("semmle.python.security.dataflow.ReflectedXssQuery",           "ReflectedXssFlow"),
-    ("python", "CWE-93"):  ("semmle.python.security.dataflow.HttpHeaderInjectionQuery",    "HttpHeaderInjectionFlow"),
-    ("python", "CWE-117"): ("semmle.python.security.dataflow.LogInjectionQuery",           "LogInjectionFlow"),
-    ("python", "CWE-209"): ("semmle.python.security.dataflow.StackTraceExposureQuery",     "StackTraceExposureFlow"),
-    ("python", "CWE-312"): ("semmle.python.security.dataflow.CleartextLoggingQuery",       "CleartextLoggingFlow"),
-    ("python", "CWE-313"): ("semmle.python.security.dataflow.CleartextStorageQuery",       "CleartextStorageFlow"),
-    ("python", "CWE-327"): ("semmle.python.security.dataflow.WeakSensitiveDataHashingQuery", "WeakSensitiveDataHashingFlow"),
-    ("python", "CWE-501"): ("semmle.python.security.dataflow.UrlRedirectQuery",            "UrlRedirectFlow"),
-    ("python", "CWE-502"): ("semmle.python.security.dataflow.UnsafeDeserializationQuery",  "UnsafeDeserializationFlow"),
-    ("python", "CWE-601"): ("semmle.python.security.dataflow.UrlRedirectQuery",            "UrlRedirectFlow"),
-    ("python", "CWE-611"): ("semmle.python.security.dataflow.XxeQuery",                    "XxeFlow"),
-    ("python", "CWE-643"): ("semmle.python.security.dataflow.XpathInjectionQuery",         "XpathInjectionFlow"),
-    ("python", "CWE-776"): ("semmle.python.security.dataflow.XmlBombQuery",                "XmlBombFlow"),
-    ("python", "CWE-918"): ("semmle.python.security.dataflow.ServerSideRequestForgeryQuery", "ServerSideRequestForgeryFlow"),
-    ("python", "CWE-943"): ("semmle.python.security.dataflow.NoSqlInjectionQuery",         "NoSqlInjectionFlow"),
-    ("python", "CWE-1004"): ("semmle.python.security.dataflow.CookieInjectionQuery",       "CookieInjectionFlow"),
-    ("python", "CWE-1333"): ("semmle.python.security.dataflow.PolynomialReDoSQuery",       "PolynomialReDoSFlow"),
-    ("python", "CWE-1336"): ("semmle.python.security.dataflow.TemplateInjectionQuery",     "TemplateInjectionFlow"),
+# Default pack search root. Mirrors the pack location CodeQL itself uses
+# for its bundled stdlib packs. The directory contains `<lang>-queries`
+# packs directly. Tests monkeypatch this constant to point at a fixture
+# tree.
+_DEFAULT_PACK_ROOT = Path.home() / ".codeql" / "packages" / "codeql"
 
-    # ---- Java ----
-    ("java", "CWE-78"):  ("semmle.code.java.security.CommandLineQuery",     "RemoteUserInputToArgumentToExecFlow"),
-    ("java", "CWE-89"):  ("semmle.code.java.security.SqlInjectionQuery",    "QueryInjectionFlow"),
-    ("java", "CWE-22"):  ("semmle.code.java.security.PathCreation",         "TaintedPathFlow"),
-    ("java", "CWE-79"):  ("semmle.code.java.security.XSS",                  "XssFlow"),
-    ("java", "CWE-502"): ("semmle.code.java.security.UnsafeDeserializationQuery", "UnsafeDeserializationFlow"),
+# Match `@tags external/cwe/cwe-NNN` (case-insensitive). The tag may sit on
+# its own line (continuation of a multi-line @tags block) or follow @tags
+# directly. Captures the numeric portion.
+_CWE_TAG_RE = re.compile(
+    r"\bexternal/cwe/cwe-(\d+)\b",
+    re.IGNORECASE,
+)
 
-    # ---- C / C++ ----
-    ("cpp", "CWE-78"):  ("semmle.code.cpp.security.CommandExecution",   "CommandExecutionFlow"),
-    ("cpp", "CWE-22"):  ("semmle.code.cpp.security.TaintedPath",        "TaintedPathFlow"),
-    ("cpp", "CWE-120"): ("semmle.code.cpp.security.BufferAccess",       "BufferAccessFlow"),
+# Match `@kind path-problem` to filter out non-dataflow queries.
+# Standalone `@kind problem` queries are useful for static checks
+# (e.g. "missing httpOnly flag") but don't track paths from source to
+# sink — they're not what IRIS is validating.
+_KIND_PATH_PROBLEM_RE = re.compile(
+    r"@kind\s+path-problem\b",
+    re.IGNORECASE,
+)
 
-    # ---- JavaScript / TypeScript ----
-    ("javascript", "CWE-79"):  ("semmle.javascript.security.dataflow.DomBasedXssQuery",     "DomBasedXss"),
-    ("javascript", "CWE-78"):  ("semmle.javascript.security.dataflow.CommandInjectionQuery", "CommandInjection"),
-    ("javascript", "CWE-89"):  ("semmle.javascript.security.dataflow.SqlInjectionQuery",     "SqlInjection"),
-    ("javascript", "CWE-22"):  ("semmle.javascript.security.dataflow.TaintedPathQuery",      "TaintedPath"),
+# Match `@id <ns>/<rest>` — used for stable identification of which
+# discovered query handled a particular finding (audit trail).
+_ID_RE = re.compile(r"@id\s+([\w.\-/]+)")
 
-    # ---- Go ----
-    ("go", "CWE-78"):  ("semmle.go.security.CommandInjectionQuery",   "CommandInjection"),
-    ("go", "CWE-89"):  ("semmle.go.security.SqlInjectionQuery",       "SqlInjection"),
-}
+# Bound how much of each .ql file we read when checking metadata. Real
+# headers fit in ~1 KB; reading more wastes IO on large dataflow query
+# bodies. 4 KB gives slack for queries with long descriptions.
+_METADATA_READ_BYTES = 4096
 
 
-def lookup_prebuilt_flow(language: str, cwe: str) -> Optional[Tuple[str, str]]:
-    """Return (import_path, flow_module_name) for known (language, CWE) pairs.
+def _pack_root() -> Path:
+    """Resolve the CodeQL package root."""
+    return _DEFAULT_PACK_ROOT
 
-    Both args are normalised to lowercase / uppercase respectively. Returns
-    None when the combination has no prebuilt mapping — caller falls back
-    to Tier 2 (template) or Tier 3 (LLM-generated free-form).
+
+def _read_metadata(ql_path: Path) -> Optional[str]:
+    """Return the first ~4KB of a .ql file as text, or None on read failure.
+
+    Comment-block parsing is naive on purpose: we just look for tag
+    matches anywhere in the head of the file. CodeQL's QLDoc format puts
+    metadata in the leading `/** ... */` block, so substring matches are
+    safe — there's no executable QL syntax in the comment block that would
+    spoof our patterns.
+    """
+    try:
+        with ql_path.open("rb") as f:
+            data = f.read(_METADATA_READ_BYTES)
+        return data.decode("utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _extract_cwes(metadata: str) -> List[str]:
+    """All CWE-NNN tags found in the metadata block (canonical form).
+
+    CodeQL packs zero-pad to three digits (`cwe-022`); the canonical
+    MITRE form has no leading zeros (`CWE-22`). Strip leading zeros so
+    the discovery dict uses the same key shape that callers pass in.
+    """
+    return [
+        f"CWE-{int(m.group(1))}"
+        for m in _CWE_TAG_RE.finditer(metadata)
+    ]
+
+
+def _is_path_problem(metadata: str) -> bool:
+    return bool(_KIND_PATH_PROBLEM_RE.search(metadata))
+
+
+def _query_id(metadata: str) -> Optional[str]:
+    m = _ID_RE.search(metadata)
+    return m.group(1) if m else None
+
+
+def _language_from_pack_dir(pack_dir: Path) -> Optional[str]:
+    """Extract language tag from a `<lang>-queries` directory name.
+
+    Examples: `python-queries` → "python", `cpp-queries` → "cpp".
+    Returns None for directories that don't fit the convention (library
+    packs like `python-all`, `dataflow`, etc.).
+    """
+    name = pack_dir.name
+    if not name.endswith("-queries"):
+        return None
+    return name[: -len("-queries")].lower()
+
+
+@functools.lru_cache(maxsize=1)
+def discover_prebuilt_queries() -> Dict[Tuple[str, str], Path]:
+    """Walk installed CodeQL query packs to build the (lang, CWE) → path map.
+
+    Scans `<pack_root>/<lang>-queries/<version>/Security/CWE-*/*.ql` and
+    reads each file's QLDoc header for `@kind path-problem` and
+    `external/cwe/cwe-NNN` tags. Returns a dict keyed by (language tag,
+    CWE-NNN string) with the absolute path of the .ql file.
+
+    Result is cached for the process lifetime via lru_cache. The scan
+    is cheap (~100ms for ~500 files) but still wasteful to repeat per
+    finding. Tests that need to bust the cache call
+    `discover_prebuilt_queries.cache_clear()`.
+
+    Multiple .ql files can share a (lang, CWE) key — e.g. both
+    `Security/CWE-078/CommandInjection.ql` and an extension query.
+    First-seen wins (sorted alphabetically), so behaviour is
+    deterministic. Operators with strong opinions about which query
+    handles a given CWE can set `CODEQL_HOME` to a curated install.
+    """
+    out: Dict[Tuple[str, str], Path] = {}
+    root = _pack_root()
+    if not root.is_dir():
+        logger.info("CodeQL pack root not found: %s", root)
+        return out
+
+    # Walk every <lang>-queries pack. Multiple versions may coexist —
+    # we take queries from all of them; a (lang, CWE) collision picks
+    # the alphabetically-first version which is a stable choice.
+    for pack_dir in sorted(root.iterdir()):
+        if not pack_dir.is_dir():
+            continue
+        language = _language_from_pack_dir(pack_dir)
+        if language is None:
+            continue
+
+        # Each pack contains one or more `<version>/` dirs — go one
+        # level deeper to find Security/CWE-* directories.
+        for version_dir in sorted(pack_dir.iterdir()):
+            if not version_dir.is_dir():
+                continue
+            security_dir = version_dir / "Security"
+            if not security_dir.is_dir():
+                continue
+            for ql_path in sorted(security_dir.rglob("*.ql")):
+                metadata = _read_metadata(ql_path)
+                if metadata is None or not _is_path_problem(metadata):
+                    continue
+                for cwe in _extract_cwes(metadata):
+                    key = (language, cwe)
+                    out.setdefault(key, ql_path)
+
+    if out:
+        logger.debug(
+            "discovered %d prebuilt CodeQL queries across %d languages",
+            len(out), len({k[0] for k in out}),
+        )
+    return out
+
+
+def discover_prebuilt_query(language: str, cwe: str) -> Optional[Path]:
+    """Look up a prebuilt path-problem query for (language, CWE).
+
+    Both args are normalised before lookup. Returns the absolute .ql
+    path, or None when no such query exists in the installed packs.
     """
     if not language or not cwe:
         return None
     key = (language.lower().strip(), cwe.upper().strip())
-    return _PREBUILT_FLOWS.get(key)
+    return discover_prebuilt_queries().get(key)
 
 
-def build_prebuilt_query(
-    *,
-    language: str,
-    flow_import: str,
-    flow_module: str,
-    query_id: str = "raptor/iris-validation",
-) -> str:
-    """Assemble a tiny wrapper query that uses a prebuilt Flow module.
-
-    The wrapper is purely mechanical — no LLM-generated content. All
-    the dataflow logic (sources, sinks, sanitizers, taint propagation
-    rules) lives inside the imported Flow module. We just import it
-    and ask for path results.
-
-    Returns the .ql text. Caller writes to a file inside a qlpack and
-    runs `codeql database analyze`.
-    """
-    lang_import = _LANGUAGE_HEADER.get(language.lower())
-    if lang_import is None:
-        raise ValueError(f"unsupported language for prebuilt query: {language}")
-
-    # Path-problem queries require @severity. Use 'error' since we're
-    # validating an existing finding's reachability — match found ⇒
-    # finding stands.
-    return f"""\
-/**
- * @name IRIS validation: {query_id}
- * @kind path-problem
- * @id {query_id}
- * @problem.severity error
- */
-{lang_import}
-import {flow_import}
-import {flow_module}::PathGraph
-
-from {flow_module}::PathNode source, {flow_module}::PathNode sink
-where {flow_module}::flowPath(source, sink)
-select sink.getNode(), source, sink, "IRIS-validated dataflow path"
-"""
-
-
-# Tier 2 ----------------------------------------------------------------------
+# Tier 2 — language templates ------------------------------------------------
 
 # Per-language taint-tracking templates. The LLM fills in two strings:
 # `source_predicate_body` and `sink_predicate_body`. Everything else
@@ -298,17 +363,6 @@ select sink.getNode(), source, sink, "IRIS dataflow path"
 }
 
 
-# Imports for the per-language top-level. Used by both Tier 1 wrapper and
-# anywhere we need just the `import <lang>` line.
-_LANGUAGE_HEADER: Dict[str, str] = {
-    "python":     "import python",
-    "java":       "import java",
-    "cpp":        "import cpp",
-    "javascript": "import javascript",
-    "go":         "import go",
-}
-
-
 def supported_languages_for_template() -> set:
     """Languages with a Tier 2 template available."""
     return set(_TAINT_TEMPLATES.keys())
@@ -349,9 +403,6 @@ def build_template_query(
     )
 
 
-# Tier 1+2 schema for LLM ----------------------------------------------------
-
-
 # Schema for the structured response when we ask the LLM for predicates only.
 # Used by the dataflow_validation runner when Tier 1 doesn't apply and we
 # fall through to Tier 2.
@@ -378,10 +429,10 @@ TEMPLATE_PREDICATE_SCHEMA = {
 
 # CWE inference --------------------------------------------------------------
 
-# Maps regex patterns over Semgrep rule IDs / rule_ids to CWE numbers.
-# Used when the finding's `cwe_id` field is empty — many Semgrep rules
-# don't tag CWE explicitly but their rule names are descriptive. Without
-# inference we lose the CWE → prebuilt query mapping for these findings.
+# Maps regex patterns over Semgrep rule IDs to CWE numbers. Used when the
+# finding's `cwe_id` field is empty — many Semgrep rules don't tag CWE
+# explicitly but their rule names are descriptive. Without inference we
+# lose the CWE → prebuilt query mapping for these findings.
 #
 # Order matters: more specific patterns first. The first match wins.
 _RULE_ID_TO_CWE: list = [
@@ -451,8 +502,8 @@ def infer_cwe_from_rule_id(rule_id: str) -> Optional[str]:
     Many Semgrep rules don't set the `cwe_id` field explicitly but have
     descriptive rule names like "raptor.injection.command-shell" or
     "python.lang.security.deserialization.pickle". Inferring from the
-    rule_id lets Tier 1's CWE → Flow map kick in for findings that
-    would otherwise fall through to Tier 2.
+    rule_id lets Tier 1's CWE → prebuilt-query map kick in for findings
+    that would otherwise fall through to Tier 2.
 
     Returns the first matching CWE-NNN string, or None when no pattern
     matches. Patterns are ordered from most specific to most general
@@ -468,8 +519,8 @@ def infer_cwe_from_rule_id(rule_id: str) -> Optional[str]:
 
 
 __all__ = [
-    "lookup_prebuilt_flow",
-    "build_prebuilt_query",
+    "discover_prebuilt_queries",
+    "discover_prebuilt_query",
     "build_template_query",
     "supported_languages_for_template",
     "TEMPLATE_PREDICATE_SCHEMA",

--- a/packages/llm_analysis/dataflow_validation.py
+++ b/packages/llm_analysis/dataflow_validation.py
@@ -33,10 +33,9 @@ from packages.hypothesis_validation.runner import validate
 from .dataflow_dispatch_client import DispatchClient
 from .dataflow_query_builder import (
     TEMPLATE_PREDICATE_SCHEMA,
-    build_prebuilt_query,
     build_template_query,
+    discover_prebuilt_query,
     infer_cwe_from_rule_id,
-    lookup_prebuilt_flow,
     supported_languages_for_template,
 )
 
@@ -651,7 +650,7 @@ def _validate_one_hypothesis(
     if not cwe:
         cwe = (infer_cwe_from_rule_id(finding.get("rule_id", "")) or "").upper().strip()
 
-    # ----- Tier 1: prebuilt Flow module -----
+    # ----- Tier 1: prebuilt pack-resident query -----
     # Fast confirmation lane. Returns confirmed when matches exist at the
     # finding's location. Returns inconclusive (NOT refuted) on no matches —
     # the prebuilt's source model may not cover the LLM's claimed source
@@ -659,16 +658,9 @@ def _validate_one_hypothesis(
     # Inconclusive at Tier 1 falls through to Tier 2 where the LLM can
     # customise predicates to test the specific claim.
     if language and cwe:
-        prebuilt = lookup_prebuilt_flow(language, cwe)
-        if prebuilt is not None:
-            flow_import, flow_module = prebuilt
-            rule = build_prebuilt_query(
-                language=language,
-                flow_import=flow_import,
-                flow_module=flow_module,
-                query_id=f"raptor/iris/{cwe.lower()}",
-            )
-            ev = adapter.run(rule, hypothesis.target)
+        prebuilt_path = discover_prebuilt_query(language, cwe)
+        if prebuilt_path is not None:
+            ev = adapter.run_prebuilt_query(prebuilt_path, hypothesis.target)
             verdict = _verdict_from_prebuilt(ev, finding)
             if verdict == "confirmed":
                 # Tier 1 confirmed the path exists at the finding's

--- a/packages/llm_analysis/tests/test_dataflow_query_builder.py
+++ b/packages/llm_analysis/tests/test_dataflow_query_builder.py
@@ -1,99 +1,213 @@
 """Tests for the mechanical CodeQL query builder (Tier 1 + Tier 2)."""
 
 import sys
+import textwrap
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
+from packages.llm_analysis import dataflow_query_builder as _dqb
 from packages.llm_analysis.dataflow_query_builder import (
     TEMPLATE_PREDICATE_SCHEMA,
-    build_prebuilt_query,
     build_template_query,
+    discover_prebuilt_queries,
+    discover_prebuilt_query,
     infer_cwe_from_rule_id,
-    lookup_prebuilt_flow,
     supported_languages_for_template,
 )
 
 
-# Tier 1 ---------------------------------------------------------------------
-
-class TestPrebuiltLookup:
-    def test_python_command_injection(self):
-        result = lookup_prebuilt_flow("python", "CWE-78")
-        assert result is not None
-        imp, mod = result
-        assert "CommandInjection" in imp
-        assert mod == "CommandInjectionFlow"
-
-    def test_python_sql_injection(self):
-        result = lookup_prebuilt_flow("python", "CWE-89")
-        assert result is not None
-        assert result[1] == "SqlInjectionFlow"
-
-    def test_java_command_injection(self):
-        result = lookup_prebuilt_flow("java", "CWE-78")
-        assert result is not None
-
-    def test_unknown_combination_returns_none(self):
-        assert lookup_prebuilt_flow("python", "CWE-9999") is None
-        assert lookup_prebuilt_flow("cobol", "CWE-78") is None
-
-    def test_case_insensitive_language(self):
-        assert lookup_prebuilt_flow("Python", "CWE-78") is not None
-        assert lookup_prebuilt_flow("PYTHON", "CWE-78") is not None
-
-    def test_case_insensitive_cwe(self):
-        assert lookup_prebuilt_flow("python", "cwe-78") is not None
-        assert lookup_prebuilt_flow("python", " CWE-78 ") is not None  # whitespace
-
-    def test_empty_inputs(self):
-        assert lookup_prebuilt_flow("", "CWE-78") is None
-        assert lookup_prebuilt_flow("python", "") is None
-        assert lookup_prebuilt_flow("", "") is None
-        assert lookup_prebuilt_flow(None, None) is None
+# Tier 1 — discovery ---------------------------------------------------------
 
 
-class TestBuildPrebuiltQuery:
-    def test_basic_python_query(self):
-        q = build_prebuilt_query(
-            language="python",
-            flow_import="semmle.python.security.dataflow.CommandInjectionQuery",
-            flow_module="CommandInjectionFlow",
+def _write_query(path: Path, *, kind: str, cwe_tag: str, qid: str = "raptor/test") -> None:
+    """Materialise a minimally-valid QLDoc-tagged .ql stub for discovery to find.
+
+    Discovery only reads the header; it never compiles the file. We just need
+    the @kind / @id / @tags external/cwe/cwe-NNN bits in the leading 4KB.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = textwrap.dedent(
+        f"""\
+        /**
+         * @name Test query
+         * @kind {kind}
+         * @id {qid}
+         * @tags security
+         *       {cwe_tag}
+         */
+        import python
+        """
+    )
+    path.write_text(body)
+
+
+def _build_pack_tree(root: Path, *, language: str, version: str = "1.0.0") -> Path:
+    """Mimic the on-disk layout of an installed CodeQL queries pack:
+    <root>/<lang>-queries/<version>/Security/CWE-NNN/*.ql
+    where <root> is the configured pack root.
+    """
+    sec = root / f"{language}-queries" / version / "Security"
+    sec.mkdir(parents=True, exist_ok=True)
+    return sec
+
+
+class TestDiscovery:
+    """`discover_prebuilt_queries` walks installed packs to map (lang, CWE) → path.
+
+    Tests build a fake pack tree under tmp_path, monkeypatch the module's
+    `_DEFAULT_PACK_ROOT` to point at it, and bust the lru_cache between
+    cases. Avoiding env vars per project convention.
+    """
+
+    def setup_method(self):
+        discover_prebuilt_queries.cache_clear()
+
+    def teardown_method(self):
+        discover_prebuilt_queries.cache_clear()
+
+    def test_finds_path_problem_query(self, tmp_path, monkeypatch):
+        sec = _build_pack_tree(tmp_path, language="python")
+        ql = sec / "CWE-078" / "CommandInjection.ql"
+        _write_query(ql, kind="path-problem",
+                     cwe_tag="external/cwe/cwe-78", qid="py/cmd-injection")
+
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        out = discover_prebuilt_queries()
+        assert ("python", "CWE-78") in out
+        assert out[("python", "CWE-78")] == ql
+
+    def test_skips_non_path_problem_queries(self, tmp_path, monkeypatch):
+        sec = _build_pack_tree(tmp_path, language="python")
+        ql = sec / "CWE-079" / "CookieFlag.ql"
+        # @kind problem (not path-problem) — useful as a static check, but
+        # dataflow validation isn't what it does.
+        _write_query(ql, kind="problem", cwe_tag="external/cwe/cwe-79")
+
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        out = discover_prebuilt_queries()
+        assert ("python", "CWE-79") not in out
+
+    def test_lookup_normalises_inputs(self, tmp_path, monkeypatch):
+        sec = _build_pack_tree(tmp_path, language="python")
+        _write_query(
+            sec / "CWE-089" / "SqlInjection.ql",
+            kind="path-problem",
+            cwe_tag="external/cwe/cwe-89",
         )
-        assert "import python" in q
-        assert "import semmle.python.security.dataflow.CommandInjectionQuery" in q
-        assert "import CommandInjectionFlow::PathGraph" in q
-        assert "from CommandInjectionFlow::PathNode source" in q
-        assert "where CommandInjectionFlow::flowPath" in q
-        assert "@kind path-problem" in q
-        assert "@problem.severity" in q  # required for path-problem queries
 
-    def test_query_id_embedded(self):
-        q = build_prebuilt_query(
-            language="python",
-            flow_import="...",
-            flow_module="X",
-            query_id="raptor/iris/CWE-78",
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        # Case-insensitive language and CWE; trims whitespace.
+        assert discover_prebuilt_query("Python", "cwe-89") is not None
+        assert discover_prebuilt_query("PYTHON", " CWE-89 ") is not None
+        assert discover_prebuilt_query("python", "CWE-89") is not None
+
+    def test_lookup_returns_none_for_unknown(self, tmp_path, monkeypatch):
+        # Empty pack tree.
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        assert discover_prebuilt_query("python", "CWE-9999") is None
+        assert discover_prebuilt_query("cobol", "CWE-78") is None
+
+    def test_lookup_empty_inputs(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        assert discover_prebuilt_query("", "CWE-78") is None
+        assert discover_prebuilt_query("python", "") is None
+        assert discover_prebuilt_query(None, None) is None
+
+    def test_finds_queries_across_languages(self, tmp_path, monkeypatch):
+        py_sec = _build_pack_tree(tmp_path, language="python")
+        java_sec = _build_pack_tree(tmp_path, language="java")
+        cpp_sec = _build_pack_tree(tmp_path, language="cpp")
+
+        _write_query(
+            py_sec / "CWE-078" / "CommandInjection.ql",
+            kind="path-problem", cwe_tag="external/cwe/cwe-78",
         )
-        assert "raptor/iris/CWE-78" in q
-
-    def test_unknown_language_raises(self):
-        import pytest
-        with pytest.raises(ValueError):
-            build_prebuilt_query(
-                language="cobol",
-                flow_import="...",
-                flow_module="X",
-            )
-
-    def test_includes_correct_lang_header(self):
-        q = build_prebuilt_query(
-            language="cpp",
-            flow_import="semmle.code.cpp.security.X",
-            flow_module="XFlow",
+        _write_query(
+            java_sec / "CWE-078" / "ExecTainted.ql",
+            kind="path-problem", cwe_tag="external/cwe/cwe-78",
         )
-        assert "import cpp" in q
-        assert "import python" not in q
+        _write_query(
+            cpp_sec / "CWE-078" / "ExecTainted.ql",
+            kind="path-problem", cwe_tag="external/cwe/cwe-78",
+        )
+
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        assert discover_prebuilt_query("python", "CWE-78") is not None
+        assert discover_prebuilt_query("java", "CWE-78") is not None
+        assert discover_prebuilt_query("cpp", "CWE-78") is not None
+
+    def test_first_seen_wins_on_collision(self, tmp_path, monkeypatch):
+        sec = _build_pack_tree(tmp_path, language="python")
+        # Two queries both tagged CWE-78. discover walks alphabetically so
+        # the lexicographically-first file wins, deterministically.
+        a = sec / "CWE-078" / "Aaa.ql"
+        b = sec / "CWE-078" / "Bbb.ql"
+        _write_query(a, kind="path-problem", cwe_tag="external/cwe/cwe-78")
+        _write_query(b, kind="path-problem", cwe_tag="external/cwe/cwe-78")
+
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        assert discover_prebuilt_query("python", "CWE-78") == a
+
+    def test_skips_non_queries_packs(self, tmp_path, monkeypatch):
+        # `python-all` is a library pack, not a queries pack. Discovery
+        # only looks at <lang>-queries dirs.
+        not_a_queries = tmp_path / "python-all" / "1.0.0" / "Security"
+        not_a_queries.mkdir(parents=True)
+        _write_query(
+            not_a_queries / "CWE-078" / "CommandInjection.ql",
+            kind="path-problem", cwe_tag="external/cwe/cwe-78",
+        )
+
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        assert discover_prebuilt_query("python", "CWE-78") is None
+
+    def test_missing_pack_root_is_handled(self, tmp_path, monkeypatch):
+        # Pack root points at a non-existent dir → empty result, no crash.
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path / "does-not-exist")
+        out = discover_prebuilt_queries()
+        assert out == {}
+
+    def test_zero_padded_cwe_tags_are_normalised(self, tmp_path, monkeypatch):
+        """Real CodeQL packs use zero-padded tags (`cwe-022`); RAPTOR
+        findings carry canonical CWE strings (`CWE-22`). Discovery must
+        strip leading zeros so the dict keys match what callers pass."""
+        sec = _build_pack_tree(tmp_path, language="python")
+        # Tag uses zero-padded form, as real packs do
+        ql = sec / "CWE-022" / "PathInjection.ql"
+        _write_query(ql, kind="path-problem",
+                     cwe_tag="external/cwe/cwe-022")
+
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        # Lookup with canonical (unpadded) form must hit the entry.
+        assert discover_prebuilt_query("python", "CWE-22") == ql
+        # The dict key itself is also canonical.
+        assert ("python", "CWE-22") in discover_prebuilt_queries()
+        assert ("python", "CWE-022") not in discover_prebuilt_queries()
+
+    def test_multiple_cwes_per_query(self, tmp_path, monkeypatch):
+        # Some queries tag multiple CWEs. Discovery indexes the query
+        # under each one — both lookups should find it.
+        sec = _build_pack_tree(tmp_path, language="python")
+        ql = sec / "CWE-078" / "MultiTagged.ql"
+        ql.parent.mkdir(parents=True, exist_ok=True)
+        ql.write_text(textwrap.dedent(
+            """\
+            /**
+             * @name Multi-tagged
+             * @kind path-problem
+             * @id raptor/multi
+             * @tags security
+             *       external/cwe/cwe-78
+             *       external/cwe/cwe-77
+             */
+            import python
+            """
+        ))
+
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        assert discover_prebuilt_query("python", "CWE-78") == ql
+        assert discover_prebuilt_query("python", "CWE-77") == ql
 
 
 # Tier 2 ---------------------------------------------------------------------
@@ -195,38 +309,6 @@ class TestSchemas:
         # Schema descriptions should help the LLM produce well-shaped predicates
         s = TEMPLATE_PREDICATE_SCHEMA["source_predicate_body"]
         assert "Example" in s or "example" in s
-
-
-class TestExpandedPrebuiltMap:
-    """Smoke tests for the expanded Python prebuilt map. Each entry should
-    resolve to a (import_path, flow_module) tuple and produce a syntactically
-    plausible wrapper query."""
-
-    PYTHON_CWES = [
-        "CWE-78", "CWE-77", "CWE-89", "CWE-90", "CWE-94", "CWE-22",
-        "CWE-79", "CWE-93", "CWE-117", "CWE-209", "CWE-312", "CWE-313",
-        "CWE-327", "CWE-501", "CWE-502", "CWE-601", "CWE-611", "CWE-643",
-        "CWE-776", "CWE-918", "CWE-943", "CWE-1004", "CWE-1333", "CWE-1336",
-    ]
-
-    def test_all_python_cwes_resolve(self):
-        for cwe in self.PYTHON_CWES:
-            result = lookup_prebuilt_flow("python", cwe)
-            assert result is not None, f"missing entry: python/{cwe}"
-            imp, mod = result
-            assert imp.startswith("semmle.python.security.dataflow.")
-            assert mod.endswith("Flow")
-
-    def test_each_python_cwe_builds_a_query(self):
-        for cwe in self.PYTHON_CWES:
-            imp, mod = lookup_prebuilt_flow("python", cwe)
-            q = build_prebuilt_query(
-                language="python", flow_import=imp, flow_module=mod,
-            )
-            assert "import python" in q
-            assert f"import {imp}" in q
-            assert f"import {mod}::PathGraph" in q
-            assert f"{mod}::flowPath(source, sink)" in q
 
 
 class TestCweInference:

--- a/packages/llm_analysis/tests/test_dataflow_validation.py
+++ b/packages/llm_analysis/tests/test_dataflow_validation.py
@@ -269,7 +269,15 @@ class TestDbFreshness:
 
 
 class TestTierSelection:
-    """Tier 1 → Tier 2 → fallback path through _validate_one_hypothesis."""
+    """Tier 1 → Tier 2 → fallback path through _validate_one_hypothesis.
+
+    Discovery is patched in every test so the suite is deterministic
+    regardless of which CodeQL packs (if any) are installed on the host.
+    Tier 1 invokes `adapter.run_prebuilt_query(path, target)`; Tier 2
+    invokes `adapter.run(rule_text, target)`.
+    """
+
+    _FAKE_PREBUILT = Path("/fake/pack/codeql/python-queries/1.0/Security/CWE-078/CommandInjection.ql")
 
     def _make_hyp_and_finding(self, *, cwe="CWE-78", file="x.py", line=10):
         from packages.hypothesis_validation import Hypothesis
@@ -284,10 +292,9 @@ class TestTierSelection:
         from packages.hypothesis_validation.adapters.base import ToolEvidence
         h, f = self._make_hyp_and_finding(cwe="CWE-78", file="x.py", line=10)
 
-        # Adapter returns a match at the finding's location → confirmed.
         adapter = MagicMock()
-        adapter.run.return_value = ToolEvidence(
-            tool="codeql", rule="...", success=True,
+        adapter.run_prebuilt_query.return_value = ToolEvidence(
+            tool="codeql", rule=str(self._FAKE_PREBUILT), success=True,
             matches=[{"file": "x.py", "line": 10,
                       "rule": "py/command-injection",
                       "message": "tainted to subprocess.call"}],
@@ -300,15 +307,20 @@ class TestTierSelection:
             "LLM was consulted for a prebuilt-CWE case"
         )
 
-        result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+        with patch(
+            "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
+            return_value=self._FAKE_PREBUILT,
+        ):
+            result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+
         assert tier == "prebuilt"
         assert result.verdict == "confirmed"
-        # The wrapper query is mechanical — verify the .ql passed to
-        # adapter.run imports the CommandInjectionFlow module rather
-        # than asking the LLM.
-        rule_arg = adapter.run.call_args.args[0]
-        assert "CommandInjectionFlow" in rule_arg
-        assert "import semmle.python.security.dataflow.CommandInjectionQuery" in rule_arg
+        # Tier 1 invokes run_prebuilt_query with the discovered Path —
+        # not run() with a generated rule string.
+        adapter.run_prebuilt_query.assert_called_once()
+        path_arg = adapter.run_prebuilt_query.call_args.args[0]
+        assert path_arg == self._FAKE_PREBUILT
+        adapter.run.assert_not_called()
 
     def test_prebuilt_no_match_at_location_falls_through_to_tier2(self):
         """Tier 1 inconclusive (matches elsewhere) → fall through to Tier 2
@@ -316,21 +328,19 @@ class TestTierSelection:
         from packages.hypothesis_validation.adapters.base import ToolEvidence
         h, f = self._make_hyp_and_finding(file="x.py", line=10)
 
-        # Tier 1 returns matches elsewhere → inconclusive
-        # Tier 2 returns no matches → refuted
-        adapter_evidences = [
-            ToolEvidence(
-                tool="codeql", rule="<prebuilt>", success=True,
-                matches=[{"file": "other_file.py", "line": 200}],
-                summary="1 match in 1 file",
-            ),
-            ToolEvidence(
-                tool="codeql", rule="<template>", success=True,
-                matches=[], summary="no matches",
-            ),
-        ]
         adapter = MagicMock()
-        adapter.run.side_effect = adapter_evidences
+        # Tier 1 → matches elsewhere → inconclusive
+        adapter.run_prebuilt_query.return_value = ToolEvidence(
+            tool="codeql", rule=str(self._FAKE_PREBUILT), success=True,
+            matches=[{"file": "other_file.py", "line": 200}],
+            summary="1 match in 1 file",
+        )
+        # Tier 2 → no matches → refuted
+        adapter.run.return_value = ToolEvidence(
+            tool="codeql", rule="<template>", success=True,
+            matches=[], summary="no matches",
+        )
+
         llm = MagicMock()
         llm.generate_structured.return_value = {
             "source_predicate_body": "n instanceof RemoteFlowSource",
@@ -338,11 +348,16 @@ class TestTierSelection:
             "expected_evidence": "...", "reasoning": "...",
         }
 
-        result, tier = _validate_one_hypothesis(h, f, adapter, llm)
-        # Fell through to Tier 2 which refuted
+        with patch(
+            "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
+            return_value=self._FAKE_PREBUILT,
+        ):
+            result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+
         assert tier == "template"
         assert result.verdict == "refuted"
-        assert adapter.run.call_count == 2  # Tier 1 + Tier 2
+        adapter.run_prebuilt_query.assert_called_once()
+        adapter.run.assert_called_once()
 
     def test_prebuilt_no_matches_falls_through_to_tier2(self):
         """Tier 1's source model may not cover the LLM's claim (e.g.
@@ -350,29 +365,34 @@ class TestTierSelection:
         is inconclusive, NOT refuted, and we try Tier 2."""
         from packages.hypothesis_validation.adapters.base import ToolEvidence
         h, f = self._make_hyp_and_finding()
-        adapter_evidences = [
-            ToolEvidence(
-                tool="codeql", rule="<prebuilt>", success=True,
-                matches=[], summary="no matches",
-            ),
-            ToolEvidence(
-                tool="codeql", rule="<template>", success=True,
-                matches=[{"file": "x.py", "line": 10}], summary="1 match",
-            ),
-        ]
+
         adapter = MagicMock()
-        adapter.run.side_effect = adapter_evidences
+        adapter.run_prebuilt_query.return_value = ToolEvidence(
+            tool="codeql", rule=str(self._FAKE_PREBUILT), success=True,
+            matches=[], summary="no matches",
+        )
+        adapter.run.return_value = ToolEvidence(
+            tool="codeql", rule="<template>", success=True,
+            matches=[{"file": "x.py", "line": 10}], summary="1 match",
+        )
         llm = MagicMock()
         llm.generate_structured.return_value = {
             "source_predicate_body": "n instanceof X",
             "sink_predicate_body": "exists(Call c)",
             "expected_evidence": "...", "reasoning": "...",
         }
-        result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+
+        with patch(
+            "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
+            return_value=self._FAKE_PREBUILT,
+        ):
+            result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+
         # Tier 2 confirmed via custom predicates that match the specific claim
         assert tier == "template"
         assert result.verdict == "confirmed"
-        assert adapter.run.call_count == 2
+        adapter.run_prebuilt_query.assert_called_once()
+        adapter.run.assert_called_once()
 
     def test_inferred_cwe_picks_tier1_when_finding_lacks_cwe_id(self):
         """Findings without explicit cwe_id should still hit Tier 1 when
@@ -385,20 +405,34 @@ class TestTierSelection:
              "rule_id": "raptor.injection.command-shell"}
 
         adapter = MagicMock()
-        adapter.run.return_value = ToolEvidence(
-            tool="codeql", rule="...", success=True,
+        adapter.run_prebuilt_query.return_value = ToolEvidence(
+            tool="codeql", rule=str(self._FAKE_PREBUILT), success=True,
             matches=[{"file": "x.py", "line": 10}],
             summary="1 match",
         )
         llm = MagicMock()
         llm.generate_structured.side_effect = AssertionError("LLM not needed")
 
-        result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+        # Patch discover_prebuilt_query to ASSERT it's called with the
+        # inferred CWE — this is the contract under test.
+        captured = {}
+
+        def fake_discover(language, cwe):
+            captured["lang"] = language
+            captured["cwe"] = cwe
+            return self._FAKE_PREBUILT
+
+        with patch(
+            "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
+            side_effect=fake_discover,
+        ):
+            result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+
         assert tier == "prebuilt"
         assert result.verdict == "confirmed"
-        # Verify the wrapper query is for CWE-78 (command injection)
-        rule_arg = adapter.run.call_args.args[0]
-        assert "CommandInjectionFlow" in rule_arg
+        # Verify the inference fed Tier 1 the correct CWE.
+        assert captured["cwe"] == "CWE-78"
+        assert captured["lang"] == "python"
 
     def test_unknown_cwe_falls_to_tier2_template(self):
         """No prebuilt → LLM generates predicates only → tier='template'."""
@@ -418,8 +452,15 @@ class TestTierSelection:
             "sink_predicate_body": "exists(Call c)",
             "expected_evidence": "...", "reasoning": "...",
         }
-        result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+
+        with patch(
+            "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
+            return_value=None,
+        ):
+            result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+
         assert tier == "template"
+        adapter.run_prebuilt_query.assert_not_called()
         # The query that ran must be the template-assembled one — check
         # what was passed to adapter.run, not what the mock returned.
         rule_arg = adapter.run.call_args.args[0]
@@ -458,7 +499,12 @@ class TestTierSelection:
         llm = MagicMock()
         llm.generate_structured.side_effect = llm_responses
 
-        result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+        with patch(
+            "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
+            return_value=None,
+        ):
+            result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+
         assert tier == "retry"
         assert result.verdict == "confirmed"
         assert adapter.run.call_count == 2  # initial + 1 retry
@@ -483,7 +529,11 @@ class TestTierSelection:
             "expected_evidence": "...", "reasoning": "...",
         }
 
-        result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+        with patch(
+            "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
+            return_value=None,
+        ):
+            result, tier = _validate_one_hypothesis(h, f, adapter, llm)
         # 1 initial + 2 retries = 3 attempts max
         assert adapter.run.call_count == 3
         assert result.verdict == "inconclusive"
@@ -505,7 +555,11 @@ class TestTierSelection:
             "expected_evidence": "...", "reasoning": "...",
         }
 
-        _validate_one_hypothesis(h, f, adapter, llm)
+        with patch(
+            "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
+            return_value=None,
+        ):
+            _validate_one_hypothesis(h, f, adapter, llm)
         # Only 1 attempt — no retry on non-compile errors
         assert adapter.run.call_count == 1
 
@@ -1130,7 +1184,7 @@ class TestValidateDataflowClaims:
         assert results_by_id["F1"]["dataflow_validation"]["recommends_downgrade"] is True
 
     def test_cache_hits_avoid_duplicate_llm_calls(self, tmp_path):
-        """Two findings with identical hypothesis share one tier1 + tier2 run."""
+        """Two findings with identical hypothesis share one validation run."""
         from packages.hypothesis_validation.adapters.base import ToolEvidence
         db = self._setup_db(tmp_path)
         results_by_id = {
@@ -1147,7 +1201,14 @@ class TestValidateDataflowClaims:
             "sink_predicate_body": "exists(Call c)",
             "expected_evidence": "...", "reasoning": "...",
         }
+        # Patch discover_prebuilt_query to skip Tier 1 — this test focuses
+        # on cache behaviour at the Tier 2 path. Tier 1 availability
+        # depends on host pack install state which would make the test
+        # non-deterministic in CI.
         with patch(
+            "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
+            return_value=None,
+        ), patch(
             "packages.hypothesis_validation.adapters.CodeQLAdapter.is_available",
             return_value=True,
         ), patch(
@@ -1166,8 +1227,8 @@ class TestValidateDataflowClaims:
                 repo_path=tmp_path,
                 llm_client=llm_client,
             )
-        # F1: 2 adapter calls (Tier 1 + Tier 2). F2: cache hit, 0 calls.
-        assert mock_run.call_count == 2
+        # F1: 1 Tier 2 call. F2: cache hit, 0 calls.
+        assert mock_run.call_count == 1
         assert m["n_validated"] == 1
         assert m["n_cache_hits"] == 1
         assert m["n_eligible"] == 2
@@ -1191,7 +1252,18 @@ class TestValidateDataflowClaims:
                          matches=[{"file": "b.c", "line": 2}],
                          summary="1 match"),
         ]
+        llm_client = MagicMock()
+        llm_client.generate_structured.return_value = {
+            "source_predicate_body": "n instanceof X",
+            "sink_predicate_body": "exists(Call c)",
+            "expected_evidence": "...", "reasoning": "...",
+        }
+        # Skip Tier 1 so the loop's adapter.run call sequence is
+        # deterministic regardless of host pack state.
         with patch(
+            "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
+            return_value=None,
+        ), patch(
             "packages.hypothesis_validation.adapters.CodeQLAdapter.is_available",
             return_value=True,
         ), patch(
@@ -1208,7 +1280,7 @@ class TestValidateDataflowClaims:
                 results_by_id=results_by_id,
                 codeql_db=db,
                 repo_path=tmp_path,
-                llm_client=MagicMock(),
+                llm_client=llm_client,
             )
             # F1 errored (not counted in n_validated), F2 ran
             assert m["n_validated"] == 1
@@ -1365,11 +1437,17 @@ class TestRunValidationPass:
         args = self._baseline_args(tmp_path)
         args["dispatch_mode"] = "cc_dispatch"
         args["findings"], args["results_by_id"] = self._make_finding()
+        # Force Tier 1 to fire with a synthetic discovery result so the
+        # test is deterministic regardless of host pack state.
+        fake_path = Path("/fake/pack/codeql/cpp-queries/1.0/Security/CWE-078/CmdInj.ql")
         with patch(
+            "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
+            return_value=fake_path,
+        ), patch(
             "packages.hypothesis_validation.adapters.CodeQLAdapter.is_available",
             return_value=True,
         ), patch(
-            "packages.hypothesis_validation.adapters.CodeQLAdapter.run",
+            "packages.hypothesis_validation.adapters.CodeQLAdapter.run_prebuilt_query",
             return_value=self._confirmed_evidence(),
         ) as mock_run:
             m = run_validation_pass(**args)


### PR DESCRIPTION
Replace the hardcoded _PREBUILT_FLOWS map (38 entries, mostly Python) with discover_prebuilt_queries() — a runtime walk of installed CodeQL packs that indexes any .ql file tagged `@kind path-problem` + `external/cwe/cwe-NNN` under <pack_root>/<lang>-queries/<version>/Security/. Tier 1 now invokes pack-resident queries directly via a new CodeQLAdapter.run_prebuilt_query method (no temp pack / qlpack.yml — imports are already resolved in the installed pack).

Discovery is process-cached (functools.lru_cache) and normalises zero-padded CWE tags (`cwe-022` → `CWE-22`) so the dict keys match the canonical form RAPTOR findings carry.

Empirical: 42 (python, CWE) entries discovered against python-queries 1.8.1 vs. the 24 we hand-maintained. Stays current automatically when operators install or update packs.