### PR TITLE
feat(core/run): symlink-safe run-dir creation at trust-boundary entry points

### DIFF
--- a/core/run/safe_io.py
+++ b/core/run/safe_io.py
@@ -1,0 +1,104 @@
+"""Symlink-safe run-dir creation for raptor outputs.
+
+The standard run-dir naming pattern in :func:`core.run.output.unique_run_suffix`
+is ``timestamp + PID``, predictable to a co-resident local attacker. Combined
+with the codebase's prevalent ``Path.mkdir(exist_ok=True)`` pattern, that gives
+a TOCTOU window where an attacker can pre-create the predicted path as a
+symlink and redirect raptor's writes to a chosen target.
+
+This module's :func:`safe_run_mkdir` closes that window:
+
+  - :func:`os.mkdir` (not ``Path.mkdir``) creates the dir atomically with the
+    requested mode. ``Path.mkdir`` calls ``os.mkdir`` underneath, but using the
+    raw call here makes the umask-vs-mode interaction explicit.
+  - On :class:`FileExistsError`, :func:`os.lstat` reads the path metadata
+    without following symlinks. We refuse if the path is anything other than a
+    real directory owned by the current user, or if it is world-writable.
+
+Group-writable existing dirs (e.g. mode ``0o775`` from default umask ``0o002``
+on systemd-style "user private group" setups) are accepted with a logged
+warning rather than refused. The default-umask shape would otherwise refuse
+on every existing dir during upgrade.
+
+The check guards the *final* path component only; symlinks higher in the path
+resolve normally. An attacker who can manipulate parent directories has access
+beyond what this module is intended to defend against.
+
+Threat model assumptions:
+  - Single-tenant or low-trust-multi-tenant analysis box
+  - Attacker can read ``/proc`` to enumerate PIDs and predict the next one
+  - Attacker has write access under the parent of the run-dir-to-be
+  - Attacker does NOT share the user's UID
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from typing import Union
+
+from core.logging import get_logger
+
+logger = get_logger()
+
+
+class UnsafeRunDirError(PermissionError):
+    """Raised when an output dir cannot be created or used safely."""
+
+
+def safe_run_mkdir(path: Union[Path, str]) -> None:
+    """Create *path* if absent, or accept it if already present and safe.
+
+    Behaviour:
+      - If *path* does not exist: created via :func:`os.mkdir` with mode
+        ``0o700``. Any umask in effect can only mask away owner bits, which
+        ``0o700`` already lacks beyond the owner triplet — so the resulting
+        mode is always ``0o700`` regardless of the caller's umask.
+      - If *path* exists as a real directory owned by the current user and
+        not world-writable: accepted (no chmod, no chown).
+      - Group-writable existing dirs: accepted with a warning logged.
+      - Anything else (symlink, regular file, foreign UID, world-writable):
+        :class:`UnsafeRunDirError` raised.
+
+    The function is idempotent for safe pre-existing dirs. It does NOT create
+    intermediate parents — callers should ensure the parent exists, or use
+    :func:`pathlib.Path.parent.mkdir` separately for parents that are not
+    raptor-controlled run-dirs.
+    """
+    path = Path(path)
+
+    try:
+        os.mkdir(path, mode=0o700)
+        return
+    except FileExistsError:
+        pass
+
+    st = os.lstat(path)
+
+    if not stat.S_ISDIR(st.st_mode):
+        raise UnsafeRunDirError(
+            f"refusing non-directory output path: {path} "
+            f"(may be a symlink or regular file)"
+        )
+
+    euid = os.geteuid()
+    if st.st_uid != euid:
+        raise UnsafeRunDirError(
+            f"output dir not owned by current user "
+            f"(uid {st.st_uid} ≠ {euid}): {path}"
+        )
+
+    if st.st_mode & 0o002:
+        raise UnsafeRunDirError(
+            f"output dir is world-writable "
+            f"(mode {oct(st.st_mode & 0o777)}): {path} "
+            f"— chmod o-w to use, or move the dir"
+        )
+
+    if st.st_mode & 0o020:
+        logger.warning(
+            f"output dir is group-writable "
+            f"(mode {oct(st.st_mode & 0o777)}, gid {st.st_gid}): {path} "
+            f"— attacker injection possible if group has untrusted members"
+        )

--- a/core/run/tests/test_safe_io.py
+++ b/core/run/tests/test_safe_io.py
@@ -1,0 +1,158 @@
+"""Tests for core.run.safe_io.safe_run_mkdir."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from core.run.safe_io import safe_run_mkdir, UnsafeRunDirError
+
+
+# ── Fresh-create behaviour ───────────────────────────────────────────────
+
+
+def test_fresh_create_sets_mode_0700(tmp_path):
+    p = tmp_path / "fresh"
+    safe_run_mkdir(p)
+    assert p.is_dir()
+    assert (p.stat().st_mode & 0o777) == 0o700
+
+
+def test_fresh_create_default_mode_unaffected_by_loose_umask(tmp_path):
+    """Default mode 0o700 has no group/world bits, so no umask value can
+    relax it to something more permissive. Verifies the security invariant
+    that fresh-created dirs are always owner-only."""
+    old = os.umask(0o000)
+    try:
+        p = tmp_path / "fresh"
+        safe_run_mkdir(p)
+        assert (p.stat().st_mode & 0o777) == 0o700
+    finally:
+        os.umask(old)
+
+
+def test_str_path_accepted(tmp_path):
+    p = tmp_path / "fresh"
+    safe_run_mkdir(str(p))
+    assert p.is_dir()
+
+
+def test_symlinked_parent_allowed(tmp_path):
+    """Symlinks higher in the path are not refused — by design.
+
+    Defending against parent-chain manipulation is out of scope: an
+    attacker who can manipulate parent directories has capabilities
+    well beyond what this helper is intended to defend against, and
+    parent-chain refusal would break legitimate FHS / mount-symlink
+    layouts (e.g. ``/home`` → ``/data/home``)."""
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real)
+    p = link / "child"
+    safe_run_mkdir(p)
+    assert p.is_dir()
+
+
+# ── Pre-existing safe dirs accepted ──────────────────────────────────────
+
+
+def test_existing_owner_only_dir_accepted(tmp_path):
+    p = tmp_path / "a"
+    p.mkdir(mode=0o700)
+    safe_run_mkdir(p)
+
+
+def test_idempotent(tmp_path):
+    p = tmp_path / "a"
+    safe_run_mkdir(p)
+    safe_run_mkdir(p)
+
+
+def test_world_readable_dir_allowed(tmp_path):
+    """0o755 (default umask 0o022) is read-only by other users, so not
+    an injection vector — accept without warning. Chmod after mkdir to
+    pin the mode regardless of the test runner's umask."""
+    p = tmp_path / "a"
+    p.mkdir()
+    p.chmod(0o755)
+    safe_run_mkdir(p)
+
+
+def test_group_writable_warns_but_allowed(tmp_path, monkeypatch):
+    """0o775 (default umask 0o002 + private user group) is the most common
+    real-world existing run-dir mode. Warn but accept.
+
+    The warning's content is asserted by patching the module logger:
+    :class:`RaptorLogger` is a singleton with ``propagate=False`` and a
+    StreamHandler bound to a pre-pytest stderr, so caplog/capfd cannot
+    observe its output."""
+    p = tmp_path / "a"
+    p.mkdir()
+    p.chmod(0o775)
+
+    captured: list[str] = []
+    from core.run import safe_io as mod
+    monkeypatch.setattr(mod.logger, "warning", lambda msg, **_: captured.append(msg))
+
+    safe_run_mkdir(p)
+
+    assert captured, "expected a warning to be logged"
+    assert "group-writable" in captured[0].lower()
+
+
+# ── Refusals ─────────────────────────────────────────────────────────────
+
+
+def test_world_writable_refused(tmp_path):
+    p = tmp_path / "a"
+    p.mkdir()
+    p.chmod(0o777)
+    with pytest.raises(UnsafeRunDirError, match="world-writable"):
+        safe_run_mkdir(p)
+
+
+def test_symlink_to_dir_refused(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(target)
+    with pytest.raises(UnsafeRunDirError, match="non-directory"):
+        safe_run_mkdir(link)
+
+
+def test_symlink_to_file_refused(tmp_path):
+    target = tmp_path / "target.txt"
+    target.write_text("x")
+    link = tmp_path / "link"
+    link.symlink_to(target)
+    with pytest.raises(UnsafeRunDirError, match="non-directory"):
+        safe_run_mkdir(link)
+
+
+def test_dangling_symlink_refused(tmp_path):
+    link = tmp_path / "link"
+    link.symlink_to(tmp_path / "nonexistent")
+    with pytest.raises(UnsafeRunDirError, match="non-directory"):
+        safe_run_mkdir(link)
+
+
+def test_regular_file_refused(tmp_path):
+    p = tmp_path / "file"
+    p.write_text("x")
+    with pytest.raises(UnsafeRunDirError, match="non-directory"):
+        safe_run_mkdir(p)
+
+
+def test_foreign_uid_refused(tmp_path, monkeypatch):
+    """Existing dir owned by a different UID must be refused.
+
+    Simulated via geteuid monkeypatch — actually chowning would require
+    CAP_CHOWN which test environments don't have."""
+    p = tmp_path / "a"
+    p.mkdir(mode=0o700)
+    real_uid = os.lstat(p).st_uid
+    monkeypatch.setattr(os, "geteuid", lambda: real_uid + 1)
+    with pytest.raises(UnsafeRunDirError, match="not owned by current user"):
+        safe_run_mkdir(p)

--- a/packages/codeql/agent.py
+++ b/packages/codeql/agent.py
@@ -25,6 +25,7 @@ from core.json import save_json
 
 from core.config import RaptorConfig
 from core.logging import get_logger
+from core.run.safe_io import safe_run_mkdir
 from packages.codeql.language_detector import LanguageDetector, LanguageInfo
 from packages.codeql.build_detector import BuildDetector, BuildSystem
 from packages.codeql.database_manager import DatabaseManager, DatabaseResult
@@ -145,7 +146,8 @@ class CodeQLAgent:
             repo_name = self.repo_path.name
             self.out_dir = RaptorConfig.BASE_OUT_DIR / f"codeql_{repo_name}_{unique_run_suffix('_')}"
 
-        self.out_dir.mkdir(parents=True, exist_ok=True)
+        self.out_dir.parent.mkdir(parents=True, exist_ok=True)
+        safe_run_mkdir(self.out_dir)
 
         # Initialize components
         self.language_detector = LanguageDetector(self.repo_path)

--- a/packages/sca/agent.py
+++ b/packages/sca/agent.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from typing import List, Optional, Sequence
 
 from core.json import load_json, save_json
+from core.run.safe_io import safe_run_mkdir
 
 logger = logging.getLogger(__name__)
 
@@ -221,7 +222,8 @@ def main():
         out['files'].append(entry)
 
     out_dir = get_out_dir()
-    out_dir.mkdir(parents=True, exist_ok=True)
+    out_dir.parent.mkdir(parents=True, exist_ok=True)
+    safe_run_mkdir(out_dir)
     save_json(out_dir / 'sca.json', out)
     print(json.dumps({'status': 'ok', 'files_found': len(out['files'])}))
 

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -27,6 +27,7 @@ sys.path.insert(0, str(Path(__file__).parents[2]))
 from core.json import save_json
 from core.config import RaptorConfig
 from core.run.output import unique_run_suffix
+from core.run.safe_io import safe_run_mkdir
 from core.logging import get_logger
 from core.git import clone_repository
 from core.sarif.parser import generate_scan_metrics, validate_sarif
@@ -546,7 +547,8 @@ def main():
             repo_name = repo_path.name
             # Collision-prevention via unique_run_suffix — see core/run/output.py.
             out_dir = RaptorConfig.get_out_dir() / f"scan_{repo_name}_{unique_run_suffix('_')}"
-        out_dir.mkdir(parents=True, exist_ok=True)
+        out_dir.parent.mkdir(parents=True, exist_ok=True)
+        safe_run_mkdir(out_dir)
 
         # Make record_denial calls (proxy events, generic Landlock
         # denials) write to THIS subprocess's out_dir. Without this,

--- a/packages/web/scanner.py
+++ b/packages/web/scanner.py
@@ -17,6 +17,7 @@ from core.json import save_json
 
 from core.logging import get_logger
 from core.llm.providers import LLMProvider
+from core.run.safe_io import safe_run_mkdir
 from packages.web.client import WebClient
 from packages.web.crawler import WebCrawler
 from packages.web.fuzzer import WebFuzzer
@@ -134,7 +135,8 @@ Examples:
         timestamp = int(time.time())
         out_dir = RaptorConfig.get_out_dir() / f"web_scan_{timestamp}"
 
-    out_dir.mkdir(parents=True, exist_ok=True)
+    out_dir.parent.mkdir(parents=True, exist_ok=True)
+    safe_run_mkdir(out_dir)
 
     print("\n" + "=" * 70)
     print("RAPTOR WEB APPLICATION SECURITY SCANNER")

--- a/raptor.py
+++ b/raptor.py
@@ -44,6 +44,7 @@ from pathlib import Path
 
 from core.run.output import get_output_dir, TargetMismatchError
 from core.run.metadata import start_run, complete_run, fail_run
+from core.run.safe_io import safe_run_mkdir
 
 
 def _extract_target(args: list) -> str | None:
@@ -69,6 +70,14 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
     except TargetMismatchError as e:
         print(f"✗ {e}", file=sys.stderr)
         return 1
+
+    # Trust-boundary mkdir: refuses if the predictable run-dir name has been
+    # pre-positioned as a symlink, owned by another user, or world-writable.
+    # Subprocesses re-verify on their side (defence in depth) but the parent
+    # is the first writer and has to gate too — start_run below would
+    # otherwise create .raptor-run.json along an attacker symlink.
+    out_dir.parent.mkdir(parents=True, exist_ok=True)
+    safe_run_mkdir(out_dir)
 
     start_run(out_dir, command, target=target)
 

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -28,6 +28,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 from core.json import load_json, save_json
 from core.config import RaptorConfig
 from core.logging import get_logger
+from core.run.safe_io import safe_run_mkdir
 from core.security.cc_trust import check_repo_claude_trust, set_trust_override
 
 logger = get_logger()
@@ -401,7 +402,11 @@ Examples:
     repo_name = repo_path.name  # Define repo_name for logging
     from core.run import get_output_dir
     out_dir = get_output_dir("agentic", target_name=repo_name, explicit_out=args.out if args.out else None)
-    out_dir.mkdir(parents=True, exist_ok=True)
+    # Parent (RAPTOR_DIR/out/, project dir, or --out target's parent) is
+    # raptor-controlled — plain mkdir is fine. The leaf is the predictable
+    # timestamp+PID name and gets the symlink/UID/world-write check.
+    out_dir.parent.mkdir(parents=True, exist_ok=True)
+    safe_run_mkdir(out_dir)
 
     try:
         from core.run import start_run

--- a/raptor_fuzzing.py
+++ b/raptor_fuzzing.py
@@ -26,6 +26,7 @@ from core.json import save_json
 
 from core.config import RaptorConfig
 from core.logging import get_logger
+from core.run.safe_io import safe_run_mkdir
 from packages.fuzzing import AFLRunner, CrashCollector, CorpusManager
 from packages.binary_analysis import CrashAnalyser
 from packages.llm_analysis.crash_agent import CrashAnalysisAgent
@@ -71,7 +72,8 @@ def main() -> None:
 
     corpus_dir = Path(args.corpus) if args.corpus else None
     out_dir = Path(args.out) if args.out else Path(f"out/fuzz_{binary_path.stem}_{int(time.time())}")
-    out_dir.mkdir(parents=True, exist_ok=True)
+    out_dir.parent.mkdir(parents=True, exist_ok=True)
+    safe_run_mkdir(out_dir)
 
     logger.info("=" * 70)
     logger.info("RAPTOR FUZZING WORKFLOW STARTED")


### PR DESCRIPTION
The standard run-dir naming pattern (timestamp+PID, see core/run/output.py: unique_run_suffix) is predictable to a co-resident local attacker. Combined with the prevalent Path.mkdir(exist_ok=True) pattern, this gave a TOCTOU window where an attacker could pre-create the predicted path as a symlink and redirect raptor's writes to a chosen target.

Adds core/run/safe_io.safe_run_mkdir which:
  - creates fresh dirs atomically with mode 0o700 (umask-immune)
  - lstats existing paths and refuses non-directories (catches symlinks)
  - refuses dirs owned by another user
  - refuses world-writable dirs
  - warns on group-writable dirs (common with default umask 0o002 on user-private-group setups, so refusal would break upgrades)

Retrofits the 7 trust-boundary entry points where raptor first writes to a predictable run-dir name. Subprocess sites that mkdir paths under an already-verified parent are left for a follow-up defense-in-depth PR.

The check guards the final path component only; symlinks higher in the path resolve normally (FHS layouts and mount-symlinks would otherwise break).