### PR TITLE
feat(core/llm): fast-model routing infrastructure

### DIFF
--- a/core/llm/config.py
+++ b/core/llm/config.py
@@ -21,7 +21,7 @@ from core.logging import get_logger
 
 # Re-export from submodules for backward compatibility
 from .model_data import (
-    PROVIDER_ENDPOINTS, PROVIDER_DEFAULT_MODELS,
+    PROVIDER_ENDPOINTS, PROVIDER_DEFAULT_MODELS, PROVIDER_FAST_MODELS,
     MODEL_COSTS, MODEL_LIMITS, PROVIDER_ENV_KEYS,
 )
 from .detection import (
@@ -471,6 +471,48 @@ def _model_config_from_entry(entry: Dict) -> 'ModelConfig':
     )
 
 
+def _build_fast_model_for(primary: 'ModelConfig') -> Optional['ModelConfig']:
+    """Construct a same-provider fast/cheap-tier ModelConfig given the
+    operator's primary. Returns ``None`` when the primary's provider
+    has no fast-model mapping (Ollama, Claude Code) — in that case we
+    leave ``specialized_models`` alone and the operator can configure
+    explicitly.
+
+    Reuses the primary's API key and api_base because the fast model
+    sits on the same provider endpoint and authenticates with the
+    same credential. Pulls cost / context limits from the model_data
+    catalog so the same lookup tables drive both flagship and fast
+    tiers — a future model addition only needs catalog entries, not
+    plumbing changes here.
+    """
+    fast_name = PROVIDER_FAST_MODELS.get(primary.provider)
+    if not fast_name:
+        return None
+
+    limits = MODEL_LIMITS.get(fast_name, {})
+    costs = MODEL_COSTS.get(fast_name, {})
+    cost_per_1k = (costs.get("input", 0.0) + costs.get("output", 0.0)) / 2
+
+    return ModelConfig(
+        provider=primary.provider,
+        model_name=fast_name,
+        api_key=primary.api_key,
+        api_base=PROVIDER_ENDPOINTS.get(primary.provider) or primary.api_base,
+        # Fast-tier work (verdicts, classification) is short-output by
+        # design — no need to inherit the primary's max_tokens, which
+        # may be sized for code-generation. Use the catalog default,
+        # which is already provider-appropriate for the small model.
+        max_tokens=limits.get("max_output", 4096),
+        max_context=limits.get("max_context", 32000),
+        timeout=primary.timeout,
+        # Lower temperature than the primary's default — the workloads
+        # routed here (yes/no, classify) don't benefit from sampling
+        # variance and are more deterministic at lower temperature.
+        temperature=0.0,
+        cost_per_1k_tokens=cost_per_1k,
+    )
+
+
 def _get_default_fallback_models() -> List['ModelConfig']:
     """
     Get default fallback models based on primary model tier.
@@ -815,6 +857,29 @@ class LLMConfig:
     cache_max_entries: Optional[int] = None
     enable_cost_tracking: bool = True
     max_cost_per_scan: float = 10.0  # USD
+
+    def __post_init__(self) -> None:
+        """Seed ``specialized_models`` with same-provider fast-tier
+        defaults for routing-light task types (binary verdicts,
+        classification). Operator-set entries are preserved — we only
+        fill slots the operator hasn't claimed.
+
+        Skips silently when:
+          * no primary model is available (no provider to map from);
+          * the primary's provider has no entry in
+            ``PROVIDER_FAST_MODELS`` (Ollama, Claude Code) — those
+            providers don't have a meaningful "smaller, cheaper"
+            sibling within the family that we can pick automatically.
+        """
+        from .task_types import FAST_TIER_TASKS
+
+        if self.primary_model is None:
+            return
+        fast_config = _build_fast_model_for(self.primary_model)
+        if fast_config is None:
+            return
+        for task in FAST_TIER_TASKS:
+            self.specialized_models.setdefault(task, fast_config)
 
     def to_file(self, config_path: Path) -> None:
         """Save a MINIMAL snapshot of this configuration to JSON.

--- a/core/llm/model_data.py
+++ b/core/llm/model_data.py
@@ -48,6 +48,35 @@ PROVIDER_DEFAULT_MODELS = {
     "mistral":   "mistral-large-latest",
 }
 
+# Fast/cheap-tier model per provider — used as the default for
+# routing-light task types (binary verdicts, classification, severity
+# triage) where a flagship model is overkill. Aim is "good enough"
+# quality at ~10× cost reduction and ~3× latency reduction vs the
+# flagship default.
+#
+# Cost-class ratio (input/output, per-1K, vs flagship default):
+#   Anthropic:  Opus  $0.005/$0.025  →  Haiku   $0.001/$0.005   (~5×)
+#   OpenAI:     5.4   $0.0025/$0.015 →  4o-mini $0.00015/$0.0006 (~25×)
+#   Gemini:     Pro   $0.00125/$0.01 →  Flash-L $0.0001/$0.0004  (~25×)
+#   Mistral:    Large $0.0005/$0.0015→  Small   $0.00015/$0.0006 (~3×)
+#
+# OpenAI mapping prefers ``gpt-4o-mini`` over the cheaper
+# ``gpt-5-nano`` because the 4o-mini has a longer track record for
+# structured-output reliability across third-party libraries (Instructor,
+# pydantic-ai). Switch to a 5.x mini when its structured-output story
+# stabilises in those libraries.
+#
+# Providers without a fast-model mapping (Ollama, Claude Code via
+# subprocess) are intentionally absent — for Ollama the operator picks
+# a small tagged model themselves; for Claude Code there's only one
+# "model".
+PROVIDER_FAST_MODELS = {
+    "anthropic": "claude-haiku-4-5",
+    "openai":    "gpt-4o-mini",
+    "gemini":    "gemini-2.5-flash-lite",
+    "mistral":   "mistral-small-latest",
+}
+
 # Per-1K-token costs (USD), split input/output.
 # Thinking/reasoning tokens are billed at the output rate on all providers.
 MODEL_COSTS = {

--- a/core/llm/task_types.py
+++ b/core/llm/task_types.py
@@ -1,0 +1,83 @@
+"""Canonical ``task_type`` names recognised by the LLM router.
+
+Pass one of these as ``task_type=`` to
+:meth:`~core.llm.client.LLMClient.generate` /
+:meth:`~core.llm.client.LLMClient.generate_structured` so the client
+can route the call to a model appropriate for the workload's shape
+rather than always going to the configured primary.
+
+Routing layers:
+  1. Explicit ``model_config=`` kwarg wins.
+  2. Otherwise ``LLMConfig.specialized_models[task_type]`` if set
+     (operators can override anything by populating this dict).
+  3. Otherwise ``LLMConfig.primary_model``.
+
+The fast tier (``FAST_TIER_TASKS``) is auto-populated at
+:class:`~core.llm.config.LLMConfig` construction time when the primary
+model's provider has a known fast-model mapping (see
+:data:`~core.llm.model_data.PROVIDER_FAST_MODELS`). Operators who set
+their own ``specialized_models`` entry for a fast-tier task keep that
+override.
+
+Adding a new task_type:
+  1. Add a constant on :class:`TaskType`.
+  2. Decide whether it routes fast or to the primary by default; if
+     fast, add it to ``FAST_TIER_TASKS``.
+  3. Document the workload shape in the constant's docstring so future
+     callers can pick the right one without reading the source.
+
+Why a constants class rather than enum:
+  ``task_type`` is a string everywhere it crosses an LLM-provider
+  boundary (logged, recorded in telemetry, used as a cost-attribution
+  key). Stringly-typed callers continue to work; the constants only
+  add type-safety for callers that adopt them.
+"""
+
+from __future__ import annotations
+
+
+class TaskType:
+    """Canonical task_type names. Use as ``task_type=TaskType.<X>``."""
+
+    # Yes/no, safe/risky/block, true-positive/false-positive — short
+    # categorical answers from a fixed set. Routes fast.
+    VERDICT_BINARY = "verdict_binary"
+
+    # Severity triage, label-from-set classification of a finding,
+    # CWE bucket selection. Routes fast.
+    CLASSIFY = "classify"
+
+    # Report condensation, multi-finding rollup. Quality matters but
+    # the input is dense and structured. Routes to primary by default
+    # — fast-tier models tend to drop nuance in summarisation.
+    SUMMARISE = "summarise"
+
+    # Default for analysis-shaped workloads: dataflow validation,
+    # vulnerability review, cross-finding correlation. Routes to
+    # primary.
+    ANALYSE = "analyse"
+
+    # PoC / exploit / patch generation. Routes to primary; the
+    # quality cost of routing fast here is too high.
+    GENERATE_CODE = "generate_code"
+
+    # Multi-turn tool-using orchestrators (cve-diff, agentic). Routes
+    # to primary. Fast models often misuse tools.
+    AGENT_LOOP = "agent_loop"
+
+    # Legacy: pre-existing task_type used in dataflow validation.
+    # Equivalent to ANALYSE; kept for backwards compatibility with
+    # call sites that haven't migrated yet.
+    AUDIT = "audit"
+
+
+# Task types that default to the provider's fast-tier model when the
+# primary's provider has a fast mapping. See module docstring for
+# how operators override.
+FAST_TIER_TASKS: frozenset[str] = frozenset({
+    TaskType.VERDICT_BINARY,
+    TaskType.CLASSIFY,
+})
+
+
+__all__ = ["TaskType", "FAST_TIER_TASKS"]

--- a/core/llm/tests/test_fast_model_routing.py
+++ b/core/llm/tests/test_fast_model_routing.py
@@ -1,0 +1,197 @@
+"""Tests for fast-tier task routing.
+
+Verifies that ``LLMConfig`` populates ``specialized_models`` for
+fast-tier task types from a same-provider fast model, and that
+``get_model_for_task`` routes correctly.
+
+The fast-tier convention is: if the configured primary's provider has
+an entry in :data:`PROVIDER_FAST_MODELS`, every task in
+``FAST_TIER_TASKS`` defaults to that fast model unless the operator
+has supplied their own entry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.llm.config import LLMConfig, ModelConfig
+from core.llm.model_data import (
+    PROVIDER_FAST_MODELS,
+    MODEL_COSTS,
+    MODEL_LIMITS,
+)
+from core.llm.task_types import FAST_TIER_TASKS, TaskType
+
+
+def _primary(provider: str, model_name: str = None) -> ModelConfig:
+    """Build a primary ModelConfig for tests. ``model_name`` defaults
+    to the provider's flagship default when omitted, mirroring real
+    auto-config behaviour."""
+    from core.llm.model_data import PROVIDER_DEFAULT_MODELS
+    name = model_name or PROVIDER_DEFAULT_MODELS[provider]
+    return ModelConfig(
+        provider=provider,
+        model_name=name,
+        max_context=200000,
+        api_key="sk-test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default population
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("provider", sorted(PROVIDER_FAST_MODELS.keys()))
+def test_fast_tier_populated_for_known_provider(provider: str) -> None:
+    """Every provider with a PROVIDER_FAST_MODELS entry must have its
+    fast model auto-installed for every fast-tier task. This is the
+    payoff: operators get fast-tier routing for free as long as their
+    primary is a recognised cloud provider."""
+    cfg = LLMConfig(primary_model=_primary(provider), fallback_models=[])
+    expected_fast_name = PROVIDER_FAST_MODELS[provider]
+    for task in FAST_TIER_TASKS:
+        m = cfg.get_model_for_task(task)
+        assert m is not None
+        assert m.provider == provider
+        assert m.model_name == expected_fast_name, (
+            f"task {task!r}: expected {expected_fast_name}, got {m.model_name}"
+        )
+
+
+def test_non_fast_tier_task_routes_to_primary() -> None:
+    """ANALYSE / GENERATE_CODE / etc. must NOT be silently downgraded
+    to the fast model. This guards against accidentally widening the
+    fast tier."""
+    cfg = LLMConfig(primary_model=_primary("anthropic"), fallback_models=[])
+    for task in (TaskType.ANALYSE, TaskType.SUMMARISE,
+                 TaskType.GENERATE_CODE, TaskType.AGENT_LOOP, TaskType.AUDIT):
+        m = cfg.get_model_for_task(task)
+        assert m.model_name == cfg.primary_model.model_name, (
+            f"task {task!r} unexpectedly routed away from primary"
+        )
+
+
+def test_unknown_task_type_routes_to_primary() -> None:
+    """Unrecognised task_type strings must fall through to primary —
+    callers passing typos or new names shouldn't get an exception or
+    silent fast-model downgrade."""
+    cfg = LLMConfig(primary_model=_primary("anthropic"), fallback_models=[])
+    m = cfg.get_model_for_task("totally_made_up_task_name")
+    assert m.model_name == cfg.primary_model.model_name
+
+
+# ---------------------------------------------------------------------------
+# Operator overrides
+# ---------------------------------------------------------------------------
+
+
+def test_operator_override_preserved() -> None:
+    """If the operator pre-populates ``specialized_models[<fast-task>]``
+    we must keep their entry intact — defaults only fill empty slots.
+    Without this, an operator setting a custom fast model for one
+    task would have it stomped at LLMConfig() construction time."""
+    custom = ModelConfig(
+        provider="anthropic",
+        model_name="claude-sonnet-4-6",
+        max_context=200000,
+        api_key="sk-custom",
+    )
+    cfg = LLMConfig(
+        primary_model=_primary("anthropic"),
+        fallback_models=[],
+        specialized_models={TaskType.VERDICT_BINARY: custom},
+    )
+    # Operator's choice survived for the task they set.
+    m = cfg.get_model_for_task(TaskType.VERDICT_BINARY)
+    assert m is custom
+
+    # Other fast-tier tasks (CLASSIFY) still got the default fill.
+    other = cfg.get_model_for_task(TaskType.CLASSIFY)
+    assert other.model_name == PROVIDER_FAST_MODELS["anthropic"]
+
+
+# ---------------------------------------------------------------------------
+# Provider edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_no_primary_model_no_population() -> None:
+    """When ``primary_model`` is None (no LLM provider configured)
+    population is a no-op rather than an exception. Mirrors how the
+    rest of LLMConfig degrades gracefully without a primary."""
+    cfg = LLMConfig.__new__(LLMConfig)
+    cfg.primary_model = None
+    cfg.fallback_models = []
+    cfg.specialized_models = {}
+    cfg.enable_fallback = False
+    cfg.max_retries = 1
+    cfg.retry_delay = 0.0
+    cfg.retry_delay_remote = 0.0
+    cfg.enable_caching = False
+    from pathlib import Path
+    cfg.cache_dir = Path("/tmp")
+    cfg.cache_ttl_seconds = None
+    cfg.cache_max_entries = None
+    cfg.enable_cost_tracking = False
+    cfg.max_cost_per_scan = 10.0
+    cfg.__post_init__()                       # should be a no-op
+
+    assert cfg.specialized_models == {}
+
+
+def test_unknown_provider_no_population() -> None:
+    """A provider absent from ``PROVIDER_FAST_MODELS`` (Ollama, Claude
+    Code subprocess, anything custom) must leave ``specialized_models``
+    untouched. Operators with these setups configure fast routing
+    manually."""
+    primary = ModelConfig(
+        provider="ollama",
+        model_name="llama3.2:3b",
+        max_context=128000,
+        api_key="",
+    )
+    cfg = LLMConfig(primary_model=primary, fallback_models=[])
+    assert cfg.specialized_models == {}
+
+
+# ---------------------------------------------------------------------------
+# Built ModelConfig sanity
+# ---------------------------------------------------------------------------
+
+
+def test_fast_model_inherits_provider_credentials() -> None:
+    """The auto-installed fast model uses the primary's API key —
+    same provider, same auth. Operators who configured one should
+    not need to configure the other."""
+    primary = _primary("anthropic")
+    primary.api_key = "sk-anthropic-test"
+    cfg = LLMConfig(primary_model=primary, fallback_models=[])
+    fast = cfg.get_model_for_task(TaskType.VERDICT_BINARY)
+    assert fast.api_key == "sk-anthropic-test"
+
+
+def test_fast_model_pulls_limits_and_costs_from_catalog() -> None:
+    """The auto-installed model reads its context window and cost
+    figures from the model_data catalog rather than inheriting the
+    primary's. Without this the cost-tracking math would credit the
+    fast model with the flagship's tariff."""
+    cfg = LLMConfig(primary_model=_primary("anthropic"), fallback_models=[])
+    fast = cfg.get_model_for_task(TaskType.VERDICT_BINARY)
+
+    expected_limits = MODEL_LIMITS["claude-haiku-4-5"]
+    expected_costs = MODEL_COSTS["claude-haiku-4-5"]
+    assert fast.max_context == expected_limits["max_context"]
+    assert fast.max_tokens == expected_limits["max_output"]
+
+    expected_avg = (expected_costs["input"] + expected_costs["output"]) / 2
+    assert fast.cost_per_1k_tokens == pytest.approx(expected_avg)
+
+
+def test_fast_model_temperature_zero() -> None:
+    """Verdict / classification workloads benefit from determinism;
+    the fast model is configured with temperature 0 even when the
+    primary defaults to 0.7."""
+    cfg = LLMConfig(primary_model=_primary("anthropic"), fallback_models=[])
+    fast = cfg.get_model_for_task(TaskType.VERDICT_BINARY)
+    assert fast.temperature == 0.0


### PR DESCRIPTION
Introduce a small task_type taxonomy and have LLMConfig auto-populate specialized_models[<fast-task>] with a same-provider fast/cheap-tier model. No call-site changes here — this is the substrate; the follow-up sweep adopts task_type at consumer call sites (SCA major-bump verdict, codeql FP/TP triage, etc.).

Convention (core/llm/task_types.py):

  TaskType.VERDICT_BINARY   yes/no, safe/risky/block, TP/FP        FAST
  TaskType.CLASSIFY         severity, label-from-set               FAST
  TaskType.SUMMARISE        report rollup                          primary
  TaskType.ANALYSE          dataflow / vuln review (default)       primary
  TaskType.GENERATE_CODE    PoC / exploit / patch                  primary
  TaskType.AGENT_LOOP       tool-using orchestrators               primary
  TaskType.AUDIT            legacy alias for ANALYSE               primary

Fast-model mapping (core/llm/model_data.py PROVIDER_FAST_MODELS):

  Anthropic → claude-haiku-4-5             (~5× cheaper than Opus)
  OpenAI    → gpt-4o-mini                  (~25× cheaper than 5.4)
  Gemini    → gemini-2.5-flash-lite        (~25× cheaper than Pro)
  Mistral   → mistral-small-latest         (~3× cheaper than Large)

OpenAI mapping prefers gpt-4o-mini over gpt-5-nano because 4o-mini has a longer track record for structured-output reliability across third-party libraries (Instructor, pydantic-ai). Switch when 5.x mini stabilises in those libraries.

Ollama and Claude Code (subprocess) are intentionally absent — those providers don't have a meaningful "smaller, cheaper" sibling we can pick automatically. Operators with those setups configure manually.

Routing layers (unchanged in shape, only the defaults shift):
  1. Explicit model_config= kwarg wins.
  2. Otherwise specialized_models[task_type] if set.
  3. Otherwise primary_model.

LLMConfig.__post_init__ uses setdefault so an operator who populates specialized_models[TaskType.VERDICT_BINARY] keeps their override — defaults only fill empty slots.

Fast-model ModelConfig:
  - Inherits provider + api_key + api_base from primary (same auth).
  - Pulls max_tokens / max_context / cost_per_1k from model_data catalog so cost-tracking math credits the fast tariff, not the flagship's.
  - temperature=0.0 since verdict / classification workloads don't benefit from sampling variance.

Tests (12): default population per provider; non-fast tasks route to primary; unknown task → primary; operator override preserved; no primary → no-op; unknown provider (Ollama) → no-op; credentials inherited; catalog limits/costs honoured; temperature=0.