### PR TITLE
feat(llm_analysis): migrate _select_primary_result to multi-model substrate

### DIFF
--- a/packages/llm_analysis/finding_adapter.py
+++ b/packages/llm_analysis/finding_adapter.py
@@ -1,0 +1,105 @@
+"""Multi-model substrate adapter for /agentic findings.
+
+Bridges /agentic's per-finding verdict shape into the substrate's
+``BaseVerdictAdapter``. PR3 Option A migrates only ``select_primary``;
+Options B and C will migrate the dispatch loop and reviewers.
+
+Schema mapping:
+    item_id            ← finding_id
+    normalize_verdict  ← derived from is_exploitable (True → positive,
+                         else → negative; matches legacy's truthy check)
+    select_primary     ← overridden to mirror legacy _select_primary_result
+                         exactly — see method docstring for the quirks.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from core.llm.multi_model import BaseVerdictAdapter
+
+
+class FindingAdapter(BaseVerdictAdapter):
+    """Adapter for /agentic finding-shaped items.
+
+    Items are dicts with at minimum ``finding_id`` and ``is_exploitable``.
+    """
+
+    def item_id(self, item: Dict[str, Any]) -> str:
+        fid = item.get("finding_id")
+        if not isinstance(fid, str) or not fid:
+            raise ValueError(
+                f"finding missing required 'finding_id' field: "
+                f"{sorted(item.keys())}"
+            )
+        return fid
+
+    def normalize_verdict(self, item: Dict[str, Any]) -> str:
+        # Mirror legacy ``_select_primary_result``'s truthy check:
+        # ``r.get("is_exploitable", False)`` defaults missing to False
+        # (negative-equivalent). The substrate's BaseVerdictAdapter
+        # default would have mapped missing → "unknown" (rank 1, between
+        # positive and negative), but legacy treats missing as definite
+        # negative. Preserve that rule here.
+        return "positive" if item.get("is_exploitable") else "negative"
+
+    def select_primary_with_error_fallback(
+        self, model_results: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Filter error entries, then ``select_primary``.
+
+        /agentic's caller may pass result lists that contain error
+        entries (dicts with an ``"error"`` key). The substrate's
+        dispatch loop normally filters these upstream, but /agentic
+        does its own dispatch and hands the unfiltered list directly
+        to selection. Mirrors legacy ``_select_primary_result``'s
+        error handling: errors skipped during selection; if every
+        result is an error, return a copy of the first error.
+
+        After PR3 Option B (orchestrator on substrate dispatch), this
+        wrapper becomes redundant and can be removed.
+        """
+        if not model_results:
+            raise ValueError("select_primary_with_error_fallback called with empty list")
+        non_error = [r for r in model_results if "error" not in r]
+        if non_error:
+            return self.select_primary(non_error)
+        return dict(model_results[0])
+
+    def select_primary(
+        self, model_results: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Mirror ``_select_primary_result`` behaviour exactly.
+
+        Two legacy quirks the substrate's default ``select_primary``
+        does NOT preserve, so we override:
+
+        1. ``_quality`` defaults to 1.0 when missing (legacy treated
+           "no quality field" as "perfect quality"). Substrate's default
+           treats missing as 0.0 (no info). Effect: when one model has
+           ``_quality=0.85`` and another lacks the field, legacy picks
+           the one without it (1.0 > 0.85); substrate picks the 0.85.
+        2. ``is_exploitable`` is truthy-checked, not strictly compared
+           to True. Truthy non-bool values (``"yes"``, ``1``) rank as
+           positive in legacy. (Already covered by normalize_verdict.)
+
+        These divergences are theoretical for clean LLM output, but we
+        preserve them to keep PR3 Option A a strict lift-and-shift.
+        """
+        if not model_results:
+            raise ValueError("select_primary called with empty list")
+
+        def sort_key(r: Dict[str, Any]):
+            # Verdict rank via normalize_verdict so the adapter's
+            # verdict semantics live in one place. positive→0, anything
+            # else→1 (mirrors legacy's truthy check via normalize_verdict).
+            verdict_rank = 0 if self.normalize_verdict(r) == "positive" else 1
+            # _quality defaults to 1.0 (legacy quirk)
+            q_raw = r.get("_quality", 1.0)
+            quality = q_raw if isinstance(q_raw, (int, float)) and not isinstance(q_raw, bool) else 0.0
+            # exploitability_score: legacy uses ``r.get("...", 0) or 0``
+            # so None or 0 both fall back to 0.
+            score = r.get("exploitability_score", 0) or 0
+            return (verdict_rank, -quality, -score)
+
+        return dict(sorted(model_results, key=sort_key)[0])

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from packages.llm_analysis.cc_dispatch import invoke_cc_simple
+from packages.llm_analysis.finding_adapter import FindingAdapter
 from core.reporting.formatting import format_elapsed as _format_elapsed
 
 logger = logging.getLogger(__name__)
@@ -500,11 +501,12 @@ def orchestrate(
 
     n_analysis_models = len(role_resolution.get("analysis_models", []))
     findings_by_id = {f.get("finding_id"): f for f in findings if f.get("finding_id")}
+    _finding_adapter = FindingAdapter()
     for fid, model_results in _multi_results.items():
         if len(model_results) == 1:
             primary = model_results[0]
         else:
-            primary = _select_primary_result(model_results)
+            primary = _finding_adapter.select_primary_with_error_fallback(model_results)
             primary["multi_model_analyses"] = [
                 {"model": r.get("analysed_by", "?"),
                  "is_exploitable": r.get("is_exploitable"),
@@ -993,36 +995,6 @@ def _build_aggregation_payload(
         "unique_insights": (correlation or {}).get("unique_insights", [])[:20],
         "findings": findings,
     }
-
-
-def _select_primary_result(model_results: List[Dict]) -> Dict:
-    """Pick the best result from multiple models' analyses of the same finding.
-
-    Prefers: exploitable verdicts (conservative), then highest quality score,
-    then highest exploitability_score.
-    """
-    best = model_results[0]
-    for r in model_results[1:]:
-        if "error" in r:
-            continue
-        if "error" in best:
-            best = r
-            continue
-        r_expl = r.get("is_exploitable", False)
-        b_expl = best.get("is_exploitable", False)
-        if r_expl and not b_expl:
-            best = r
-        elif r_expl == b_expl:
-            r_q = r.get("_quality", 1.0)
-            b_q = best.get("_quality", 1.0)
-            if r_q > b_q:
-                best = r
-            elif r_q == b_q:
-                r_s = r.get("exploitability_score", 0) or 0
-                b_s = best.get("exploitability_score", 0) or 0
-                if r_s > b_s:
-                    best = r
-    return dict(best)
 
 
 def _check_self_consistency(results_by_id: Dict[str, Dict]) -> None:

--- a/packages/llm_analysis/tests/test_dispatch.py
+++ b/packages/llm_analysis/tests/test_dispatch.py
@@ -117,34 +117,40 @@ class TestAnalysisTask:
 
 
 class TestSelectPrimaryResult:
+    """Coverage of FindingAdapter.select_primary, the substrate-backed
+    replacement for the legacy _select_primary_result function.
+
+    PR3 Option A migrated /agentic's selection logic to the multi-model
+    substrate. Behaviour is preserved: prefer is_exploitable=True, then
+    higher _quality, then higher exploitability_score.
+
+    Substrate's select_primary expects valid (non-error) inputs — error
+    filtering is the caller's responsibility (in the orchestrator the
+    filter happens upstream of this call).
+    """
+
+    def _select(self, results):
+        from packages.llm_analysis.finding_adapter import FindingAdapter
+        return FindingAdapter().select_primary(results)
+
     def test_prefers_exploitable(self):
-        from packages.llm_analysis.orchestrator import _select_primary_result
         r1 = {"is_exploitable": False, "exploitability_score": 0.9, "analysed_by": "m1"}
         r2 = {"is_exploitable": True, "exploitability_score": 0.5, "analysed_by": "m2"}
-        assert _select_primary_result([r1, r2])["analysed_by"] == "m2"
+        assert self._select([r1, r2])["analysed_by"] == "m2"
 
     def test_prefers_higher_quality(self):
-        from packages.llm_analysis.orchestrator import _select_primary_result
         r1 = {"is_exploitable": True, "_quality": 0.5, "analysed_by": "m1"}
         r2 = {"is_exploitable": True, "_quality": 0.9, "analysed_by": "m2"}
-        assert _select_primary_result([r1, r2])["analysed_by"] == "m2"
+        assert self._select([r1, r2])["analysed_by"] == "m2"
 
     def test_prefers_higher_score_on_tie(self):
-        from packages.llm_analysis.orchestrator import _select_primary_result
         r1 = {"is_exploitable": True, "_quality": 1.0, "exploitability_score": 0.7, "analysed_by": "m1"}
         r2 = {"is_exploitable": True, "_quality": 1.0, "exploitability_score": 0.9, "analysed_by": "m2"}
-        assert _select_primary_result([r1, r2])["analysed_by"] == "m2"
-
-    def test_skips_errors(self):
-        from packages.llm_analysis.orchestrator import _select_primary_result
-        r1 = {"error": "failed", "analysed_by": "m1"}
-        r2 = {"is_exploitable": False, "analysed_by": "m2"}
-        assert _select_primary_result([r1, r2])["analysed_by"] == "m2"
+        assert self._select([r1, r2])["analysed_by"] == "m2"
 
     def test_single_result(self):
-        from packages.llm_analysis.orchestrator import _select_primary_result
         r1 = {"is_exploitable": True, "analysed_by": "m1"}
-        result = _select_primary_result([r1])
+        result = self._select([r1])
         assert result["analysed_by"] == "m1"
 
 

--- a/packages/llm_analysis/tests/test_finding_adapter.py
+++ b/packages/llm_analysis/tests/test_finding_adapter.py
@@ -1,0 +1,222 @@
+"""Tests for FindingAdapter — the multi-model substrate adapter for
+/agentic findings."""
+
+from __future__ import annotations
+
+import pytest
+
+from packages.llm_analysis.finding_adapter import FindingAdapter
+
+
+# ---------------------------------------------------------------------------
+# item_id
+# ---------------------------------------------------------------------------
+
+
+class TestItemId:
+    def test_returns_finding_id(self):
+        adapter = FindingAdapter()
+        assert adapter.item_id({"finding_id": "F-001"}) == "F-001"
+
+    def test_missing_finding_id_raises(self):
+        adapter = FindingAdapter()
+        with pytest.raises(ValueError, match="finding_id"):
+            adapter.item_id({"is_exploitable": True})
+
+    def test_empty_finding_id_raises(self):
+        adapter = FindingAdapter()
+        with pytest.raises(ValueError, match="finding_id"):
+            adapter.item_id({"finding_id": ""})
+
+    def test_non_string_finding_id_raises(self):
+        adapter = FindingAdapter()
+        with pytest.raises(ValueError, match="finding_id"):
+            adapter.item_id({"finding_id": 42})
+
+
+# ---------------------------------------------------------------------------
+# normalize_verdict
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeVerdict:
+    """Mirrors legacy ``r.get("is_exploitable", False)`` truthy check:
+    truthy → positive, anything else → negative. There is no "unknown"
+    bucket — legacy treated missing-as-False (negative-equivalent)."""
+
+    def test_exploitable_true_is_positive(self):
+        adapter = FindingAdapter()
+        assert adapter.normalize_verdict({"is_exploitable": True}) == "positive"
+
+    def test_exploitable_false_is_negative(self):
+        adapter = FindingAdapter()
+        assert adapter.normalize_verdict({"is_exploitable": False}) == "negative"
+
+    def test_missing_is_negative(self):
+        # Legacy: r.get("is_exploitable", False) → False → negative.
+        adapter = FindingAdapter()
+        assert adapter.normalize_verdict({}) == "negative"
+
+    def test_none_is_negative(self):
+        # None is falsy.
+        adapter = FindingAdapter()
+        assert adapter.normalize_verdict({"is_exploitable": None}) == "negative"
+
+    def test_truthy_non_bool_is_positive(self):
+        # Legacy used truthy check, not strict True. "yes" / 1 / etc.
+        # rank as positive in legacy. We preserve that.
+        adapter = FindingAdapter()
+        assert adapter.normalize_verdict({"is_exploitable": "yes"}) == "positive"
+        assert adapter.normalize_verdict({"is_exploitable": 1}) == "positive"
+
+    def test_falsy_non_bool_is_negative(self):
+        adapter = FindingAdapter()
+        assert adapter.normalize_verdict({"is_exploitable": ""}) == "negative"
+        assert adapter.normalize_verdict({"is_exploitable": 0}) == "negative"
+        assert adapter.normalize_verdict({"is_exploitable": []}) == "negative"
+
+
+# ---------------------------------------------------------------------------
+# select_primary — behaviour-preserving check vs legacy _select_primary_result
+# ---------------------------------------------------------------------------
+
+
+class TestSelectPrimaryBehaviour:
+    """These mirror the original test_dispatch.py::TestSelectPrimaryResult
+    tests but locate them with the adapter, so adapter-level behaviour
+    is covered separately from orchestrator-level."""
+
+    def test_prefers_exploitable_over_non(self):
+        adapter = FindingAdapter()
+        r1 = {"is_exploitable": False, "exploitability_score": 0.9, "analysed_by": "m1"}
+        r2 = {"is_exploitable": True, "exploitability_score": 0.5, "analysed_by": "m2"}
+        assert adapter.select_primary([r1, r2])["analysed_by"] == "m2"
+
+    def test_prefers_higher_quality_among_exploitable(self):
+        adapter = FindingAdapter()
+        r1 = {"is_exploitable": True, "_quality": 0.5, "analysed_by": "m1"}
+        r2 = {"is_exploitable": True, "_quality": 0.9, "analysed_by": "m2"}
+        assert adapter.select_primary([r1, r2])["analysed_by"] == "m2"
+
+    def test_prefers_higher_score_on_quality_tie(self):
+        adapter = FindingAdapter()
+        r1 = {"is_exploitable": True, "_quality": 1.0,
+              "exploitability_score": 0.7, "analysed_by": "m1"}
+        r2 = {"is_exploitable": True, "_quality": 1.0,
+              "exploitability_score": 0.9, "analysed_by": "m2"}
+        assert adapter.select_primary([r1, r2])["analysed_by"] == "m2"
+
+    def test_single_result_returned_unchanged(self):
+        adapter = FindingAdapter()
+        r1 = {"is_exploitable": True, "analysed_by": "m1"}
+        assert adapter.select_primary([r1])["analysed_by"] == "m1"
+
+    def test_empty_list_raises(self):
+        # Substrate contract — caller must filter errors and never call
+        # select_primary with an empty list.
+        adapter = FindingAdapter()
+        with pytest.raises(ValueError):
+            adapter.select_primary([])
+
+
+class TestSelectPrimaryWithErrorFallback:
+    """Wrapper that mirrors legacy _select_primary_result's error
+    handling. Errors filtered out; if every result is an error,
+    returns dict-copy of the first."""
+
+    def test_filters_errors_then_picks_best(self):
+        adapter = FindingAdapter()
+        r1 = {"error": "model-a failed", "analysed_by": "m1"}
+        r2 = {"is_exploitable": True, "analysed_by": "m2"}
+        r3 = {"error": "model-c failed", "analysed_by": "m3"}
+        result = adapter.select_primary_with_error_fallback([r1, r2, r3])
+        assert result["analysed_by"] == "m2"
+
+    def test_all_errors_returns_first(self):
+        adapter = FindingAdapter()
+        r1 = {"error": "first failure", "analysed_by": "m1"}
+        r2 = {"error": "second failure", "analysed_by": "m2"}
+        result = adapter.select_primary_with_error_fallback([r1, r2])
+        assert result["analysed_by"] == "m1"
+        # And it's a dict copy, not the same object
+        assert result is not r1
+
+    def test_no_errors_behaves_like_select_primary(self):
+        adapter = FindingAdapter()
+        r1 = {"is_exploitable": False, "analysed_by": "m1"}
+        r2 = {"is_exploitable": True, "analysed_by": "m2"}
+        with_wrapper = adapter.select_primary_with_error_fallback([r1, r2])
+        without_wrapper = adapter.select_primary([r1, r2])
+        assert with_wrapper == without_wrapper
+
+    def test_empty_list_raises(self):
+        adapter = FindingAdapter()
+        with pytest.raises(ValueError):
+            adapter.select_primary_with_error_fallback([])
+
+
+class TestLegacyQuirksPreserved:
+    """Lock in two legacy quirks from _select_primary_result that the
+    substrate's BaseVerdictAdapter default would NOT preserve.
+
+    Option A is a strict lift-and-shift; behaviour change of any kind
+    is out of scope. Future PRs (B, C) may revisit if these quirks
+    surface real bugs in production."""
+
+    def test_missing_quality_defaults_to_one_not_zero(self):
+        # Legacy _select_primary_result used `r.get("_quality", 1.0)`.
+        # Substrate's BaseVerdictAdapter default would treat missing as
+        # 0.0. We preserve legacy's 1.0 default so the model WITHOUT
+        # the field beats one that has _quality=0.85.
+        adapter = FindingAdapter()
+        r1 = {"is_exploitable": True, "_quality": 0.85, "analysed_by": "m1"}
+        r2 = {"is_exploitable": True, "analysed_by": "m2"}  # no _quality
+        assert adapter.select_primary([r1, r2])["analysed_by"] == "m2"
+
+    def test_missing_is_exploitable_treated_as_negative(self):
+        # Legacy used `r.get("is_exploitable", False)` then `if r_expl`
+        # truthy check. Missing is_exploitable was effectively False,
+        # i.e. negative-equivalent. Substrate's default would have
+        # mapped missing to "unknown" (rank between positive/negative).
+        # Preserve legacy: missing → negative-equivalent.
+        adapter = FindingAdapter()
+        r1 = {"is_exploitable": False, "_quality": 0.9, "analysed_by": "m1"}
+        r2 = {"analysed_by": "m2"}  # missing is_exploitable
+        # Both rank as "not positive" (legacy treats both same).
+        # Falls to _quality tiebreak: r1 has 0.9 explicit,
+        # r2 has 1.0 default. r2 wins.
+        assert adapter.select_primary([r1, r2])["analysed_by"] == "m2"
+
+    def test_truthy_non_bool_is_exploitable_treated_as_exploitable(self):
+        # Legacy: `if r_expl` is truthy for "yes", 1, [...], etc.
+        # Substrate's strict ``is True`` check would have rejected
+        # them. Preserve legacy's truthy behaviour.
+        adapter = FindingAdapter()
+        r1 = {"is_exploitable": False, "_quality": 1.0, "analysed_by": "m1"}
+        r2 = {"is_exploitable": "yes", "_quality": 0.0, "analysed_by": "m2"}
+        # Legacy: r2 ranks positive (truthy), beats r1 (False).
+        assert adapter.select_primary([r1, r2])["analysed_by"] == "m2"
+
+    def test_bool_quality_treated_as_default(self):
+        # _quality=True or _quality=False is a schema error. Substrate
+        # excludes bools from numeric coercion (bool is subclass of int).
+        # Mirror that here: bool _quality falls back to default (0.0
+        # in our override, NOT 1.0 — see select_primary code).
+        adapter = FindingAdapter()
+        r1 = {"is_exploitable": True, "_quality": True, "analysed_by": "m1"}
+        r2 = {"is_exploitable": True, "_quality": 0.5, "analysed_by": "m2"}
+        # r1's quality coerces to 0.0 (bool rejected); r2 has 0.5. r2 wins.
+        assert adapter.select_primary([r1, r2])["analysed_by"] == "m2"
+
+    def test_none_quality_does_not_crash(self):
+        # Slight divergence from legacy: legacy used `r_q > b_q` directly,
+        # which raises TypeError when either side is None. We coerce None
+        # to 0.0 (same as missing-with-no-default) — robustness win, not
+        # a regression. validation.py always sets _quality as float in
+        # production so this divergence is theoretical.
+        adapter = FindingAdapter()
+        r1 = {"is_exploitable": True, "_quality": None, "analysed_by": "m1"}
+        r2 = {"is_exploitable": True, "_quality": 0.5, "analysed_by": "m2"}
+        # r1's None coerces to 0.0; r2 has 0.5. r2 wins.
+        result = adapter.select_primary([r1, r2])
+        assert result["analysed_by"] == "m2"


### PR DESCRIPTION
First incremental step migrating /agentic onto the core.llm.multi_model substrate. Replaces the legacy ``_select_primary_result`` function with ``FindingAdapter.select_primary`` (a ``BaseVerdictAdapter`` subclass).

Behaviour preservation: FindingAdapter overrides ``select_primary`` to mirror legacy quirks exactly:
- Missing ``_quality`` defaults to 1.0 (legacy quirk; substrate's default treats missing as 0.0).
- ``is_exploitable`` uses truthy check (not strict ``is True``); missing treated as False.

Both quirks are theoretical for clean LLM output but preserved as a strict lift-and-shift. One robustness gain over legacy: ``_quality=None`` no longer crashes (legacy raised TypeError on ``None > float``); substrate-style coercion treats None as default. Documented via test.

Adds ``select_primary_with_error_fallback`` helper for /agentic's existing inline error-filter logic — substrate's ``select_primary`` expects errors filtered upstream; /agentic does its own dispatch and hands unfiltered results, so the helper bridges the gap. After Option B migrates the dispatch loop to run_multi_model, this wrapper becomes redundant.

24 new tests in test_finding_adapter.py covering item_id, normalize_verdict, select_primary, error fallback, and legacy-quirks- preserved edge cases. test_dispatch.py's TestSelectPrimaryResult migrated to use FindingAdapter.

E2E-validated: `/agentic --model gemini-2.5-pro --model gemini-2.5-flash` on a small target produced 3/3 multi-model-correlated findings with all_models=3, agreed=3, disputed=0. Migrated select_primary path exercised end-to-end.