### PR TITLE
fix(llm): prevent multi-model dispatch from collapsing into single-model

### DIFF
--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -602,6 +602,13 @@ class LLMClient:
             task_type: Task type for model selection
             **kwargs: Additional generation parameters
                 model_config: Optional ModelConfig to override default model selection
+                exclude_fallback_to: Optional set[str] of model names that
+                    should NOT be selected as fallback targets, even if
+                    configured globally as fallbacks. Used by multi-model
+                    dispatch to prevent silent fallback into another active
+                    model in the dispatch set (which would create duplicate
+                    analysed_by entries in the model panel). Cross-family
+                    fallbacks not in the set still work normally.
 
         Returns:
             LLMResponse with generated content
@@ -617,6 +624,14 @@ class LLMClient:
 
         # Get appropriate model for task (priority: explicit model_config > task_type > primary)
         model_config = kwargs.pop('model_config', None)
+        # exclude_fallback_to: optional set[str] of model names that should
+        # NOT be fallback targets even if configured globally. Used by
+        # multi-model dispatch to prevent a primary's failure from silently
+        # falling back into another model that's already in the active
+        # dispatch set — which would create a duplicate (the same model
+        # showing up under two slots in the model panel). Pop here so the
+        # value doesn't propagate to providers via **kwargs.
+        exclude_fallback_to: Optional[set] = kwargs.pop('exclude_fallback_to', None)
         if not model_config:
             if task_type:
                 model_config = self.config.get_model_for_task(task_type)
@@ -703,6 +718,10 @@ class LLMClient:
                     if is_local_primary == is_local_fallback:
                         # Skip if same as primary (already trying it)
                         if fallback.model_name != model_config.model_name:
+                            # Skip if caller marked this name as already-active
+                            # in a parallel dispatch (multi-model duplicate guard).
+                            if exclude_fallback_to and fallback.model_name in exclude_fallback_to:
+                                continue
                             models_to_try.append(fallback)
 
             last_error = None
@@ -806,6 +825,9 @@ class LLMClient:
             task_type: Task type for model selection
             **kwargs: Additional generation parameters
                 model_config: Optional ModelConfig to override default model selection
+                exclude_fallback_to: Optional set[str] of model names that
+                    should NOT be selected as fallback targets. Same
+                    semantics as ``generate``.
 
         Returns:
             StructuredResponse with result dict, raw content, cost, and metadata.
@@ -822,6 +844,8 @@ class LLMClient:
 
         # Get appropriate model (priority: explicit model_config > task_type > primary)
         model_config = kwargs.pop('model_config', None)
+        # See ``generate`` for the rationale on exclude_fallback_to.
+        exclude_fallback_to: Optional[set] = kwargs.pop('exclude_fallback_to', None)
         if not model_config:
             if task_type:
                 model_config = self.config.get_model_for_task(task_type)
@@ -903,6 +927,9 @@ class LLMClient:
                     is_local_fallback = fallback.provider.lower() == "ollama"
                     if is_local_primary == is_local_fallback:
                         if fallback.model_name != model_config.model_name:
+                            # Multi-model duplicate guard — see ``generate``.
+                            if exclude_fallback_to and fallback.model_name in exclude_fallback_to:
+                                continue
                             models_to_try.append(fallback)
 
             last_error = None

--- a/core/llm/tests/test_exclude_fallback.py
+++ b/core/llm/tests/test_exclude_fallback.py
@@ -1,0 +1,281 @@
+"""Tests for ``exclude_fallback_to`` — multi-model duplicate guard.
+
+When a primary model fails and the client silently falls back, the
+fallback target may already be one of the OTHER active models in a
+multi-model dispatch. That collapses the model panel to duplicates.
+
+These tests verify the kwarg correctly filters fallbacks WITHOUT
+breaking the existing fallback path for single-model callers.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.llm.client import LLMClient
+from core.llm.config import LLMConfig, ModelConfig
+
+
+def _model(provider: str, name: str, *, key: str = "test-key", role: str = None) -> ModelConfig:
+    return ModelConfig(
+        provider=provider, model_name=name, api_key=key, role=role,
+    )
+
+
+def _config(primary: ModelConfig, fallbacks: list) -> LLMConfig:
+    # Disable disk caching so tests don't hit stale cached responses
+    # from prior runs in the worktree's out/llm_cache/ directory.
+    return LLMConfig(
+        primary_model=primary, fallback_models=fallbacks,
+        enable_caching=False,
+    )
+
+
+class _FailingResponse:
+    """Stand-in for an LLMResponse the test never reads — provider raises before this matters."""
+
+
+class _FakeProvider:
+    """Provider stub.
+
+    Tracks which model was actually called via ``calls`` list. ``raise_for``
+    is a set of model names that should raise (simulating provider failure).
+    """
+
+    def __init__(self, calls: list, raise_for: set):
+        self.calls = calls
+        self.raise_for = raise_for
+
+    def generate(self, prompt, system_prompt=None, **kwargs):
+        # The model name is captured via the surrounding LLMClient logic
+        # — we record via a closure in the test fixture below.
+        raise NotImplementedError  # patched per-test
+
+
+@pytest.fixture
+def calls_log():
+    return []
+
+
+def _patched_get_provider(calls_log: list, fail_for: set, succeed_responses: dict):
+    """Build a `_get_provider` replacement that records calls and returns
+    a provider whose `generate` either raises (if model in fail_for) or
+    returns a canned response (from succeed_responses)."""
+
+    def make_provider(model_config: ModelConfig):
+        prov = MagicMock()
+
+        def _generate(prompt, system_prompt=None, **kwargs):
+            calls_log.append(model_config.model_name)
+            if model_config.model_name in fail_for:
+                raise RuntimeError(f"simulated failure for {model_config.model_name}")
+            return succeed_responses[model_config.model_name]
+
+        prov.generate.side_effect = _generate
+        return prov
+
+    return make_provider
+
+
+def _response(model_name: str, content: str = "ok"):
+    """Minimal LLMResponse-shaped mock."""
+    r = MagicMock()
+    r.content = content
+    r.model = model_name
+    r.provider = "anthropic"  # any string
+    r.tokens_used = 100
+    r.cost = 0.0
+    r.duration = 0.1
+    r.input_tokens = 50
+    r.output_tokens = 50
+    r.thinking_tokens = 0
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Default behaviour (without exclude_fallback_to) — preserve existing
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultFallback:
+    def test_falls_back_when_primary_fails(self, calls_log):
+        """Without exclude_fallback_to, primary failure → tries fallbacks."""
+        pro = _model("anthropic", "pro")
+        flash = _model("anthropic", "flash", role="fallback")
+        config = _config(pro, [flash])
+        client = LLMClient(config)
+
+        with patch.object(
+            client, "_get_provider",
+            side_effect=_patched_get_provider(
+                calls_log, fail_for={"pro"},
+                succeed_responses={"flash": _response("flash")},
+            ),
+        ):
+            result = client.generate("test prompt", model_config=pro)
+
+        assert calls_log == ["pro", "flash"]
+        assert result.model == "flash"
+
+
+# ---------------------------------------------------------------------------
+# exclude_fallback_to behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestExcludeFallbackTo:
+    def test_blocks_named_fallback(self, calls_log):
+        """exclude_fallback_to={"flash"} prevents fallback to flash."""
+        pro = _model("anthropic", "pro")
+        flash = _model("anthropic", "flash", role="fallback")
+        haiku = _model("anthropic", "haiku", role="fallback")
+        config = _config(pro, [flash, haiku])
+        client = LLMClient(config)
+
+        with patch.object(
+            client, "_get_provider",
+            side_effect=_patched_get_provider(
+                calls_log, fail_for={"pro"},
+                succeed_responses={"haiku": _response("haiku")},
+            ),
+        ):
+            result = client.generate(
+                "test", model_config=pro, exclude_fallback_to={"flash"},
+            )
+
+        # pro tried (and failed), flash skipped, haiku tried (succeeded)
+        assert "flash" not in calls_log
+        assert calls_log == ["pro", "haiku"]
+        assert result.model == "haiku"
+
+    def test_empty_exclude_set_acts_like_default(self, calls_log):
+        """exclude_fallback_to=set() doesn't prevent any fallback."""
+        pro = _model("anthropic", "pro")
+        flash = _model("anthropic", "flash", role="fallback")
+        config = _config(pro, [flash])
+        client = LLMClient(config)
+
+        with patch.object(
+            client, "_get_provider",
+            side_effect=_patched_get_provider(
+                calls_log, fail_for={"pro"},
+                succeed_responses={"flash": _response("flash")},
+            ),
+        ):
+            client.generate("test", model_config=pro, exclude_fallback_to=set())
+        assert calls_log == ["pro", "flash"]
+
+    def test_excluding_all_fallbacks_propagates_primary_failure(
+        self, calls_log,
+    ):
+        """If every fallback is excluded and primary fails, error surfaces."""
+        pro = _model("anthropic", "pro")
+        flash = _model("anthropic", "flash", role="fallback")
+        config = _config(pro, [flash])
+        client = LLMClient(config)
+
+        with patch.object(
+            client, "_get_provider",
+            side_effect=_patched_get_provider(
+                calls_log, fail_for={"pro"},
+                succeed_responses={},
+            ),
+        ):
+            with pytest.raises(RuntimeError):
+                client.generate(
+                    "test", model_config=pro,
+                    exclude_fallback_to={"flash"},
+                )
+        assert calls_log == ["pro"]
+
+    def test_primary_success_skips_exclude_logic(self, calls_log):
+        """When primary succeeds, exclude_fallback_to is never consulted."""
+        pro = _model("anthropic", "pro")
+        flash = _model("anthropic", "flash", role="fallback")
+        config = _config(pro, [flash])
+        client = LLMClient(config)
+
+        with patch.object(
+            client, "_get_provider",
+            side_effect=_patched_get_provider(
+                calls_log, fail_for=set(),
+                succeed_responses={"pro": _response("pro")},
+            ),
+        ):
+            result = client.generate(
+                "test", model_config=pro, exclude_fallback_to={"flash"},
+            )
+        assert calls_log == ["pro"]
+        assert result.model == "pro"
+
+    def test_does_not_propagate_to_provider(self):
+        """exclude_fallback_to must be popped from kwargs before reaching
+        the provider (which doesn't expect it)."""
+        pro = _model("anthropic", "pro")
+        config = _config(pro, [])
+        client = LLMClient(config)
+
+        captured_kwargs = {}
+
+        def make_provider(model_config):
+            prov = MagicMock()
+
+            def _generate(prompt, system_prompt=None, **kwargs):
+                captured_kwargs.update(kwargs)
+                return _response("pro")
+
+            prov.generate.side_effect = _generate
+            return prov
+
+        with patch.object(client, "_get_provider", side_effect=make_provider):
+            client.generate(
+                "test", model_config=pro,
+                exclude_fallback_to={"flash", "haiku"},
+            )
+
+        assert "exclude_fallback_to" not in captured_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Same surface on generate_structured
+# ---------------------------------------------------------------------------
+
+
+class TestExcludeFallbackToStructured:
+    def test_blocks_named_fallback_in_structured(self, calls_log):
+        """generate_structured respects exclude_fallback_to identically."""
+        pro = _model("anthropic", "pro")
+        flash = _model("anthropic", "flash", role="fallback")
+        haiku = _model("anthropic", "haiku", role="fallback")
+        config = _config(pro, [flash, haiku])
+        client = LLMClient(config)
+
+        def make_provider(model_config):
+            prov = MagicMock()
+            # Real numbers so cost-delta arithmetic and `:.4f` formatting
+            # downstream don't trip on MagicMock attributes.
+            prov.total_cost = 0.0
+            prov.total_tokens = 0
+
+            def _gs(prompt, schema, system_prompt=None, **kwargs):
+                calls_log.append(model_config.model_name)
+                if model_config.model_name == "pro":
+                    raise RuntimeError("primary fail")
+                # client.py:970 unpacks `result_tuple` as 2-tuple
+                # (result_dict, raw). Match that shape.
+                return ({"verdict": "ok"}, "{}")
+
+            prov.generate_structured.side_effect = _gs
+            return prov
+
+        with patch.object(client, "_get_provider", side_effect=make_provider):
+            result = client.generate_structured(
+                "test", schema={"type": "object"},
+                model_config=pro, exclude_fallback_to={"flash"},
+            )
+
+        assert "flash" not in calls_log
+        assert calls_log == ["pro", "haiku"]
+        assert result.model == "haiku"

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -20,7 +20,7 @@ import shutil
 import threading
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from packages.llm_analysis.cc_dispatch import invoke_cc_simple
 from packages.llm_analysis.finding_adapter import FindingAdapter
@@ -368,11 +368,27 @@ def orchestrate(
         from core.llm.client import LLMClient
         client = LLMClient(llm_config)
 
+        # Multi-model duplicate guard: when a primary model fails and
+        # the client silently falls back, the fallback target may
+        # already be one of the OTHER active analysis models — and the
+        # multi-model panel collapses to duplicate analysed_by entries
+        # (e.g. ``[pro, flash]`` becomes ``[flash, flash]`` if pro
+        # falls back to flash). Pass the names of all active analysis
+        # models to the client so it skips them as fallback targets
+        # for any one dispatch. Other fallback targets (cross-family
+        # resilience) still work normally.
+        _active_analysis_names = {
+            m.model_name for m in role_resolution.get("analysis_models", [])
+            if m and getattr(m, "model_name", None)
+        }
+
         def dispatch_fn(prompt, schema, system_prompt, temperature, model):
+            other_active = _active_analysis_names - {model.model_name}
             if schema:
                 response = client.generate_structured(
                     prompt=prompt, schema=schema, system_prompt=system_prompt,
                     model_config=model, temperature=temperature,
+                    exclude_fallback_to=other_active,
                 )
                 result = response.result
                 quality = 1.0
@@ -390,6 +406,7 @@ def orchestrate(
                 response = client.generate(
                     prompt=prompt, system_prompt=system_prompt,
                     model_config=model, temperature=temperature,
+                    exclude_fallback_to=other_active,
                 )
                 return DispatchResult(
                     result={"content": response.content}, cost=response.cost,
@@ -520,6 +537,24 @@ def orchestrate(
             if key not in primary and source.get(key) is not None:
                 primary[key] = source.get(key)
         results_by_id[fid] = primary
+
+    # Multi-model collapse detection. The exclude_fallback_to guard above
+    # prevents most cases where a primary's failure routes silently into
+    # another active analysis model. The corner case it doesn't catch:
+    # multiple primaries failing concurrently and converging on the same
+    # external fallback (e.g., both pro and flash falling back to haiku).
+    # Surface that here so operators don't silently get a single-model
+    # result labelled as multi-model.
+    if n_analysis_models > 1:
+        collapsed = _detect_multi_model_collapse(results_by_id, n_analysis_models)
+        if collapsed:
+            logger.warning(
+                f"Multi-model collapse: {len(collapsed)}/"
+                f"{len(results_by_id)} finding(s) had fewer than "
+                f"{n_analysis_models} distinct contributors. Likely caused "
+                f"by silent fallback during model failure. First few: "
+                f"{collapsed[:3]}"
+            )
 
     # --- IRIS-style dataflow validation (opt-in via --validate-dataflow) ---
     # For Semgrep findings where the LLM claimed a dataflow path but no
@@ -995,6 +1030,35 @@ def _build_aggregation_payload(
         "unique_insights": (correlation or {}).get("unique_insights", [])[:20],
         "findings": findings,
     }
+
+
+def _detect_multi_model_collapse(
+    results_by_id: Dict[str, Dict],
+    n_analysis_models: int,
+) -> List[Tuple[str, List[str]]]:
+    """Identify findings whose multi_model_analyses has fewer DISTINCT
+    contributors than the requested model count.
+
+    Returns a list of ``(finding_id, sorted_distinct_models)`` for each
+    such finding. Empty if every multi-model finding has the expected
+    number of contributors.
+
+    Helps operators spot silent-fallback failures where multiple primary
+    models converged on the same external fallback model.
+    """
+    collapsed: List[Tuple[str, List[str]]] = []
+    for fid, item in results_by_id.items():
+        analyses = item.get("multi_model_analyses")
+        if not isinstance(analyses, list) or not analyses:
+            continue
+        distinct = {
+            a.get("model") for a in analyses if isinstance(a, dict)
+        }
+        distinct.discard("?")
+        distinct.discard(None)
+        if len(distinct) < n_analysis_models:
+            collapsed.append((fid, sorted(distinct)))
+    return collapsed
 
 
 def _check_self_consistency(results_by_id: Dict[str, Dict]) -> None:

--- a/packages/llm_analysis/tests/test_multi_model_collapse.py
+++ b/packages/llm_analysis/tests/test_multi_model_collapse.py
@@ -1,0 +1,142 @@
+"""Tests for _detect_multi_model_collapse — orchestrator's secondary
+guard against silent-fallback collapsing the multi-model panel.
+
+The PRIMARY guard is ``exclude_fallback_to`` in the LLM client (see
+core/llm/tests/test_exclude_fallback.py). This detector catches the
+corner case the primary guard can't: independent fallback paths
+converging on the same external model.
+"""
+
+from __future__ import annotations
+
+from packages.llm_analysis.orchestrator import _detect_multi_model_collapse
+
+
+class TestDetectMultiModelCollapse:
+    def test_no_collapse_when_all_panels_have_n_distinct(self):
+        results = {
+            "f1": {
+                "multi_model_analyses": [
+                    {"model": "pro"},
+                    {"model": "flash"},
+                ],
+            },
+            "f2": {
+                "multi_model_analyses": [
+                    {"model": "pro"},
+                    {"model": "flash"},
+                ],
+            },
+        }
+        assert _detect_multi_model_collapse(results, n_analysis_models=2) == []
+
+    def test_detects_finding_with_duplicate_panel(self):
+        results = {
+            "f1": {
+                "multi_model_analyses": [
+                    {"model": "haiku"},
+                    {"model": "haiku"},  # duplicate — convergence
+                ],
+            },
+        }
+        collapsed = _detect_multi_model_collapse(results, n_analysis_models=2)
+        assert collapsed == [("f1", ["haiku"])]
+
+    def test_partial_collapse_some_findings_ok(self):
+        results = {
+            "f1": {
+                "multi_model_analyses": [
+                    {"model": "pro"},
+                    {"model": "flash"},
+                ],
+            },
+            "f2": {
+                "multi_model_analyses": [
+                    {"model": "haiku"},
+                    {"model": "haiku"},
+                ],
+            },
+            "f3": {
+                "multi_model_analyses": [
+                    {"model": "pro"},
+                    {"model": "flash"},
+                ],
+            },
+        }
+        collapsed = _detect_multi_model_collapse(results, n_analysis_models=2)
+        # Only f2 collapsed
+        assert len(collapsed) == 1
+        assert collapsed[0][0] == "f2"
+
+    def test_three_model_panel_with_two_distinct_contributors(self):
+        # 3 requested, 2 actual contributors (one model showed up twice)
+        results = {
+            "f1": {
+                "multi_model_analyses": [
+                    {"model": "pro"},
+                    {"model": "flash"},
+                    {"model": "flash"},  # convergence
+                ],
+            },
+        }
+        collapsed = _detect_multi_model_collapse(results, n_analysis_models=3)
+        assert collapsed == [("f1", ["flash", "pro"])]
+
+    def test_findings_without_multi_model_analyses_skipped(self):
+        # Single-model findings (no multi_model_analyses key) shouldn't
+        # be flagged as collapsed.
+        results = {
+            "f1": {"is_exploitable": True},  # no multi_model_analyses key
+            "f2": {
+                "multi_model_analyses": [
+                    {"model": "haiku"},
+                    {"model": "haiku"},
+                ],
+            },
+        }
+        collapsed = _detect_multi_model_collapse(results, n_analysis_models=2)
+        assert collapsed == [("f2", ["haiku"])]
+
+    def test_unknown_model_labels_excluded_from_distinct_count(self):
+        # ``?`` and None aren't real model identities — drop from counting
+        # so they don't artificially inflate the distinct contributor set.
+        results = {
+            "f1": {
+                "multi_model_analyses": [
+                    {"model": "?"},
+                    {"model": "haiku"},
+                    {"model": None},
+                ],
+            },
+        }
+        collapsed = _detect_multi_model_collapse(results, n_analysis_models=2)
+        # Only "haiku" is a real contributor; n=2 requested → collapsed
+        assert collapsed == [("f1", ["haiku"])]
+
+    def test_non_dict_analysis_entry_skipped(self):
+        # Defensive: malformed multi_model_analyses entries shouldn't
+        # crash the detector.
+        results = {
+            "f1": {
+                "multi_model_analyses": [
+                    "garbage",
+                    {"model": "haiku"},
+                    None,
+                ],
+            },
+        }
+        collapsed = _detect_multi_model_collapse(results, n_analysis_models=2)
+        # 1 valid contributor of 2 requested → collapsed
+        assert collapsed == [("f1", ["haiku"])]
+
+    def test_empty_results_returns_empty(self):
+        assert _detect_multi_model_collapse({}, n_analysis_models=2) == []
+
+    def test_non_list_multi_model_analyses_skipped(self):
+        # If multi_model_analyses got malformed (not a list), skip the
+        # finding rather than crash.
+        results = {
+            "f1": {"multi_model_analyses": "wrong shape"},
+            "f2": {"multi_model_analyses": {"oops": "dict"}},
+        }
+        assert _detect_multi_model_collapse(results, n_analysis_models=2) == []


### PR DESCRIPTION
When LLMClient.generate*'s primary fails, the client silently falls back to other configured models. In multi-model dispatch, that fallback can land on another model already in the active dispatch set — collapsing the model panel into duplicates without the operator noticing.

Two-layer defence:

1. New ``exclude_fallback_to: set[str]`` kwarg on ``LLMClient.generate`` and ``LLMClient.generate_structured``. When set, the named fallbacks are skipped during the fallback chain walk. Other fallbacks (cross-family resilience) still work normally. Single-model callers unaffected.

2. ``packages/llm_analysis/orchestrator.py`` builds the exclude set per-call from the active analysis_models (less the one being requested). Catches the common case where, e.g., active=[pro, flash] and pro silently falls back to flash.

3. Post-hoc detector ``_detect_multi_model_collapse`` runs after the merge loop and logs a WARNING when distinct contributors per finding < n_analysis_models. Catches the corner case the kwarg guard can't: concurrent primary failures converging on a shared external fallback (e.g. both pro and flash falling back to haiku).