### PR TITLE
feat(llm_analysis): migrate /agentic merge loop to FindingAdapter.extract_analysis_record

### DIFF
--- a/packages/llm_analysis/finding_adapter.py
+++ b/packages/llm_analysis/finding_adapter.py
@@ -43,6 +43,28 @@ class FindingAdapter(BaseVerdictAdapter):
         # negative. Preserve that rule here.
         return "positive" if item.get("is_exploitable") else "negative"
 
+    def extract_analysis_record(
+        self, result: Dict[str, Any], model_name: str,
+    ) -> Dict[str, Any]:
+        """Per-model record stored under ``multi_model_analyses``.
+
+        Matches /agentic's existing inline shape (preserved verbatim
+        from the manual loop in orchestrator.py): model + is_exploitable
+        + exploitability_score + ruling + full reasoning. Differs from
+        the substrate's default in two ways:
+        - includes ``ruling`` (free-form LLM verdict string) instead
+          of substrate's normalized ``verdict``;
+        - reasoning is NOT truncated (substrate truncates to 600 chars
+          by default).
+        """
+        return {
+            "model": model_name,
+            "is_exploitable": result.get("is_exploitable"),
+            "exploitability_score": result.get("exploitability_score"),
+            "ruling": result.get("ruling"),
+            "reasoning": result.get("reasoning", ""),
+        }
+
     def select_primary_with_error_fallback(
         self, model_results: List[Dict[str, Any]],
     ) -> Dict[str, Any]:

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -525,11 +525,9 @@ def orchestrate(
         else:
             primary = _finding_adapter.select_primary_with_error_fallback(model_results)
             primary["multi_model_analyses"] = [
-                {"model": r.get("analysed_by", "?"),
-                 "is_exploitable": r.get("is_exploitable"),
-                 "exploitability_score": r.get("exploitability_score"),
-                 "ruling": r.get("ruling"),
-                 "reasoning": r.get("reasoning", "")}
+                _finding_adapter.extract_analysis_record(
+                    r, r.get("analysed_by", "?"),
+                )
                 for r in model_results
             ]
         source = findings_by_id.get(fid, {})

--- a/packages/llm_analysis/tests/test_finding_adapter.py
+++ b/packages/llm_analysis/tests/test_finding_adapter.py
@@ -119,6 +119,65 @@ class TestSelectPrimaryBehaviour:
             adapter.select_primary([])
 
 
+class TestExtractAnalysisRecord:
+    """Override mirrors /agentic's existing inline shape from
+    orchestrator.py's manual multi_model_analyses construction:
+    model + is_exploitable + exploitability_score + ruling + reasoning
+    (untruncated)."""
+
+    def test_returns_agentic_shape(self):
+        adapter = FindingAdapter()
+        result = {
+            "is_exploitable": True,
+            "exploitability_score": 0.9,
+            "ruling": "exploitable",
+            "reasoning": "user input reaches sink",
+            # extra fields shouldn't leak into the record
+            "extra": "should not appear",
+        }
+        record = adapter.extract_analysis_record(result, "claude-opus-4-7")
+        assert record == {
+            "model": "claude-opus-4-7",
+            "is_exploitable": True,
+            "exploitability_score": 0.9,
+            "ruling": "exploitable",
+            "reasoning": "user input reaches sink",
+        }
+
+    def test_missing_fields_default_to_none_or_empty(self):
+        adapter = FindingAdapter()
+        record = adapter.extract_analysis_record({}, "m1")
+        assert record == {
+            "model": "m1",
+            "is_exploitable": None,
+            "exploitability_score": None,
+            "ruling": None,
+            "reasoning": "",
+        }
+
+    def test_reasoning_not_truncated(self):
+        # /agentic's legacy inline construction did NOT truncate reasoning.
+        # Substrate's BaseVerdictAdapter default truncates to 600 chars
+        # (REASONING_TRUNCATE). Our override preserves legacy untruncated.
+        adapter = FindingAdapter()
+        long_reasoning = "x" * 5000
+        record = adapter.extract_analysis_record(
+            {"reasoning": long_reasoning}, "m1",
+        )
+        assert record["reasoning"] == long_reasoning
+        assert len(record["reasoning"]) == 5000
+
+    def test_no_verdict_field(self):
+        # Substrate default includes "verdict" (normalize_verdict output).
+        # /agentic uses "ruling" instead; "verdict" should NOT appear.
+        adapter = FindingAdapter()
+        record = adapter.extract_analysis_record(
+            {"is_exploitable": True, "ruling": "exploitable"}, "m1",
+        )
+        assert "verdict" not in record
+        assert record["ruling"] == "exploitable"
+
+
 class TestSelectPrimaryWithErrorFallback:
     """Wrapper that mirrors legacy _select_primary_result's error
     handling. Errors filtered out; if every result is an error,


### PR DESCRIPTION
PR3 Option B-prime — second incremental step migrating /agentic onto the multi-model substrate. Replaces the inline dict-literal in the merge loop's multi_model_analyses construction with a call to ``FindingAdapter.extract_analysis_record``, an override that produces /agentic's existing entry shape exactly (model + is_exploitable + exploitability_score + ruling + reasoning, untruncated).

The override differs from the substrate's default ``BaseVerdictAdapter`` implementation in two ways:
- Includes ``ruling`` (free-form LLM verdict string) instead of substrate's normalized ``verdict``.
- Reasoning NOT truncated (substrate truncates to 600 chars by default via REASONING_TRUNCATE).

Both quirks preserved as a strict lift-and-shift; consumers that read ``multi_model_analyses`` continue to see the exact same entry shape.

E2E-validated: /agentic --model gemini-2.5-pro --model gemini-2.5-flash on a small target produced 3/3 multi-model-correlated findings with multi_model_analyses entries containing exactly {exploitability_score, is_exploitable, model, reasoning, ruling} — same shape as before. Reasoning preserved untruncated (entries up to 2446 chars).

4 new tests in test_finding_adapter.py covering agentic shape, missing-fields defaults, reasoning preservation, and verdict-field absence. Full repo suite (6413) green.