### PR TITLE
packages/autonomous: source pre-scan to close gcc /etc/passwd exfil channel

### DIFF
--- a/packages/autonomous/exploit_validator.py
+++ b/packages/autonomous/exploit_validator.py
@@ -88,6 +88,23 @@ class ExploitValidator:
         """
         logger.info(f"Validating exploit: {exploit_name}")
 
+        # Source-level pre-scan rejects exfiltration shapes (absolute or
+        # traversing #include / #embed / __has_include / .incbin / #pragma
+        # GCC dependency) before they reach gcc. See
+        # packages/autonomous/poc_source_scan.py for the threat model.
+        from packages.autonomous.poc_source_scan import format_violations, scan
+        scan_violations = scan(exploit_code)
+        if scan_violations:
+            errors = format_violations(scan_violations)
+            for e in errors:
+                logger.warning(f"PoC source-scan rejection: {e}")
+            return ValidationResult(
+                success=False,
+                compilation_errors=errors,
+                runtime_errors=[],
+                warnings=[],
+            )
+
         # Write exploit to temporary file — sanitize name to prevent path traversal
         safe_name = Path(exploit_name).name.replace("..", "_") if exploit_name else "exploit"
         exploit_source = self.work_dir / f"{safe_name}.c"

--- a/packages/autonomous/poc_source_scan.py
+++ b/packages/autonomous/poc_source_scan.py
@@ -1,0 +1,140 @@
+"""Source-level pre-scan for LLM-generated PoC C/C++ before compilation.
+
+Why this exists:
+
+The LLM-generated PoC source flowing into ``ExploitValidator.validate_exploit``
+is attacker-influenceable via prompt injection in scanned-target metadata,
+finding descriptions, scanner output, etc. The anti-prompt-injection
+initiative (PR #273 and follow-ups) is the primary defence at the prompt
+side, but if a clever payload survives those layers and convinces the
+generator LLM to emit C with ``#include "/etc/passwd"`` or similar, gcc
+happily reads the file and leaks the first non-parseable line into stderr,
+which then flows back to the refiner LLM. A live probe confirmed the
+channel works today (see ``project_poc_source_analysis.md`` memory).
+
+This module is a narrowly-scoped second line of defence: a regex pre-pass
+that rejects exfiltration shapes in LLM-generated standalone PoCs. It is
+NOT a general C source validator — it only encodes the constraint
+"validate_exploit's PoCs don't need to read files outside their own
+work_dir or the standard system include path". Generic C compilation
+(libxml2 etc.) violates that constraint legitimately and would be wrongly
+rejected; that's outside the scope of this consumer.
+
+What we block:
+
+  - ``#include "/abs/path"`` and ``#include </abs/path>`` — direct exfil
+  - ``#include "../../traversing"`` — traversal escape from work_dir
+  - ``#embed "/abs"`` / ``#embed "../trav"`` — C23 file embedding
+  - ``__has_include(<abs>)`` / ``__has_include("../trav")`` — 1-bit oracle
+  - ``#pragma GCC dependency "/abs"`` / ``"../trav"`` — stat-based oracle
+  - ``.incbin "/abs"`` / ``.incbin "../trav"`` — assembler embed
+
+Angle-bracket includes of bare names (``<sys/socket.h>``) pass through:
+gcc resolves them via the toolchain include search path, not the source
+directory, so they aren't a traversal vector. ``#include "foo.h"`` and
+``#include "subdir/bar.h"`` also pass — same-dir or descending-only.
+
+What we don't try to do:
+
+  - Match obfuscated forms (macro-built paths, stringification tricks).
+    Belt-and-braces only: a determined attacker who has already bypassed
+    every prompt-injection defence is the threat model, and even then
+    most exfil shapes are caught by the obvious patterns.
+  - Block destructive runtime constructs (``system()``, ``unlink()``).
+    Those are policed at runtime by the sandbox layer, not at source.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SourceScanViolation:
+    """One pattern match. ``message`` is suitable for surfacing to the
+    refiner LLM as compilation-style feedback so it can iterate."""
+
+    directive: str  # "#include", "#embed", "__has_include", etc.
+    path: str       # the offending path string
+    reason: str     # "absolute path" or "directory traversal"
+    line_no: int    # 1-indexed source line
+
+
+# Each (directive_label, regex) extracts the path argument from a
+# preprocessor or assembler directive. Anchored to line start so we
+# don't match inside string literals or comments by accident — multi-line
+# block comments containing real ``#include`` directives are vanishingly
+# rare in PoC source and aren't worth a full C tokenizer.
+
+# Use ``[ \t]*`` rather than ``\s*`` for leading and intra-directive
+# whitespace: ``\s`` includes ``\n`` and lets the regex engine anchor a
+# match on a blank line preceding the directive, which throws the
+# reported line number off by however many blank lines came before.
+_DIRECTIVE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("#include",
+     re.compile(r'^[ \t]*#[ \t]*include[ \t]*[<"]([^>"]+)[>"]', re.MULTILINE)),
+    ("#embed",
+     re.compile(r'^[ \t]*#[ \t]*embed[ \t]*[<"]([^>"]+)[>"]', re.MULTILINE)),
+    ("#pragma GCC dependency",
+     re.compile(r'^[ \t]*#[ \t]*pragma[ \t]+GCC[ \t]+dependency[ \t]+"([^"]+)"', re.MULTILINE)),
+    ("__has_include",
+     re.compile(r'__has_include\s*\(\s*[<"]([^>"]+)[>"]\s*\)')),
+    # ``.incbin "..."`` appears inside ``__asm__("...")`` blocks where the
+    # C-string-escape ``\"`` survives into the source we scan. The
+    # non-greedy ``[^"]+?`` and trailing ``\\?`` together capture the path
+    # without a stray backslash artefact (else the LLM-facing message
+    # would read ``/etc/passwd\``).
+    (".incbin",
+     re.compile(r'\.incbin\s+\\?"([^"]+?)\\?"')),
+)
+
+
+def _classify(path: str) -> str | None:
+    """Return a violation reason for ``path``, or None if the path is OK.
+
+    Decision:
+      - absolute path (``/...`` or platform-equivalent) → block
+      - any segment is ``..`` → block
+      - else → allow
+    """
+    if path.startswith("/") or (len(path) >= 2 and path[1] == ":"):
+        # POSIX absolute, or Windows drive-letter absolute
+        return "absolute path"
+    # Normalise separators and split — mixed ``/`` and ``\`` both possible
+    # if a Windows-style path slipped through. We don't care which.
+    parts = re.split(r"[/\\]", path)
+    if any(p == ".." for p in parts):
+        return "directory traversal"
+    return None
+
+
+def scan(source: str) -> list[SourceScanViolation]:
+    """Return all violations found in ``source``. Empty list = OK to compile."""
+    violations: list[SourceScanViolation] = []
+    for directive, pattern in _DIRECTIVE_PATTERNS:
+        for m in pattern.finditer(source):
+            path = m.group(1)
+            reason = _classify(path)
+            if reason is None:
+                continue
+            line_no = source.count("\n", 0, m.start()) + 1
+            violations.append(SourceScanViolation(
+                directive=directive,
+                path=path,
+                reason=reason,
+                line_no=line_no,
+            ))
+    return violations
+
+
+def format_violations(violations: list[SourceScanViolation]) -> list[str]:
+    """Render violations as compilation-error-shaped strings the refiner
+    LLM can iterate against. Avoids exposing the security mechanism by
+    framing the rejection as a coding-style requirement."""
+    return [
+        f"line {v.line_no}: {v.directive} with {v.reason!s} "
+        f"(``{v.path}``) is not allowed; use a same-directory include or "
+        f"a standard ``<header>`` instead"
+        for v in violations
+    ]

--- a/packages/autonomous/tests/test_poc_source_scan.py
+++ b/packages/autonomous/tests/test_poc_source_scan.py
@@ -1,0 +1,407 @@
+"""Tests for the LLM-PoC source pre-scanner.
+
+The scanner runs in ``ExploitValidator.validate_exploit`` before gcc is
+invoked. Its job is to reject exfiltration-shaped directives (absolute
+or traversing ``#include`` / ``#embed`` / ``__has_include`` / ``.incbin``
+/ ``#pragma GCC dependency``) in LLM-generated PoCs without rejecting
+the directives a real PoC actually needs (system headers, same-dir or
+descending-only quoted includes).
+"""
+
+from __future__ import annotations
+
+from packages.autonomous.poc_source_scan import (
+    SourceScanViolation,
+    format_violations,
+    scan,
+)
+
+
+# ---------------------------------------------------------------------------
+# Allow: directives a real PoC legitimately uses
+# ---------------------------------------------------------------------------
+
+def test_standard_angle_include_allowed():
+    assert scan("#include <stdio.h>\nint main(){}") == []
+
+
+def test_subdir_angle_include_allowed():
+    assert scan("#include <sys/socket.h>\nint main(){}") == []
+
+
+def test_same_dir_quoted_include_allowed():
+    assert scan('#include "helper.h"\nint main(){}') == []
+
+
+def test_descending_subdir_include_allowed():
+    assert scan('#include "subdir/util.h"\nint main(){}') == []
+
+
+def test_has_include_relative_subheader_allowed():
+    src = '#if __has_include("opt.h")\n#include "opt.h"\n#endif'
+    assert scan(src) == []
+
+
+def test_empty_source_allowed():
+    assert scan("") == []
+
+
+def test_full_minimal_poc_allowed():
+    src = """\
+#include <stdio.h>
+#include <string.h>
+#include "local.h"
+int main() {
+    char buf[64];
+    strcpy(buf, "hello");
+    printf("%s\\n", buf);
+    return 0;
+}
+"""
+    assert scan(src) == []
+
+
+# ---------------------------------------------------------------------------
+# Block: absolute paths (POSIX + Windows drive-letter)
+# ---------------------------------------------------------------------------
+
+def test_absolute_quoted_include_blocked():
+    src = '#include "/etc/passwd"\nint main(){}'
+    v = scan(src)
+    assert len(v) == 1
+    assert v[0].directive == "#include"
+    assert v[0].path == "/etc/passwd"
+    assert v[0].reason == "absolute path"
+    assert v[0].line_no == 1
+
+
+def test_absolute_angle_include_blocked():
+    src = '#include </etc/shadow>\nint main(){}'
+    v = scan(src)
+    assert len(v) == 1
+    assert v[0].path == "/etc/shadow"
+    assert v[0].reason == "absolute path"
+
+
+def test_windows_drive_letter_path_blocked():
+    src = '#include "C:/Windows/System32/config/SAM"\nint main(){}'
+    v = scan(src)
+    assert len(v) == 1
+    assert v[0].reason == "absolute path"
+
+
+# ---------------------------------------------------------------------------
+# Block: directory traversal
+# ---------------------------------------------------------------------------
+
+def test_traversing_quoted_include_blocked():
+    src = '#include "../../../etc/passwd"\nint main(){}'
+    v = scan(src)
+    assert len(v) == 1
+    assert v[0].reason == "directory traversal"
+
+
+def test_traversing_angle_include_blocked():
+    src = '#include <../../../etc/passwd>\nint main(){}'
+    v = scan(src)
+    assert len(v) == 1
+    assert v[0].reason == "directory traversal"
+
+
+def test_traversal_segment_in_middle_blocked():
+    src = '#include "subdir/../../../etc/passwd"\nint main(){}'
+    v = scan(src)
+    assert len(v) == 1
+    assert v[0].reason == "directory traversal"
+
+
+def test_windows_backslash_traversal_blocked():
+    src = '#include "..\\..\\etc\\passwd"\nint main(){}'
+    v = scan(src)
+    assert len(v) == 1
+    assert v[0].reason == "directory traversal"
+
+
+# ---------------------------------------------------------------------------
+# Block: other directive shapes that share the threat
+# ---------------------------------------------------------------------------
+
+def test_embed_absolute_blocked():
+    src = 'const char d[] = {\n#embed "/etc/passwd"\n};'
+    v = scan(src)
+    assert len(v) == 1
+    assert v[0].directive == "#embed"
+
+
+def test_embed_traversing_blocked():
+    src = 'const char d[] = {\n#embed "../../../etc/passwd"\n};'
+    v = scan(src)
+    assert len(v) == 1
+    assert v[0].reason == "directory traversal"
+
+
+def test_pragma_gcc_dependency_absolute_blocked():
+    src = '#pragma GCC dependency "/etc/passwd"\nint main(){}'
+    v = scan(src)
+    assert len(v) == 1
+    assert v[0].directive == "#pragma GCC dependency"
+
+
+def test_has_include_absolute_oracle_blocked():
+    """The bandwidth-1 oracle the live probe confirmed."""
+    src = """\
+#if __has_include(</etc/passwd>)
+#error "PROBE_HIT"
+#endif
+int main(){}
+"""
+    v = scan(src)
+    assert len(v) == 1
+    assert v[0].directive == "__has_include"
+    assert v[0].path == "/etc/passwd"
+
+
+def test_has_include_traversing_oracle_blocked():
+    src = '#if __has_include("../../../etc/passwd")\n#endif\nint main(){}'
+    v = scan(src)
+    assert len(v) == 1
+    assert v[0].reason == "directory traversal"
+
+
+def test_incbin_absolute_blocked():
+    src = '__asm__(".incbin \\"/etc/passwd\\"");\nint main(){}'
+    v = scan(src)
+    assert len(v) == 1
+    assert v[0].directive == ".incbin"
+
+
+def test_incbin_traversing_blocked():
+    src = '__asm__(".incbin \\"../../../etc/passwd\\"");\nint main(){}'
+    v = scan(src)
+    assert len(v) == 1
+    assert v[0].reason == "directory traversal"
+
+
+# ---------------------------------------------------------------------------
+# Multiple violations + line numbers + formatting
+# ---------------------------------------------------------------------------
+
+def test_multiple_violations_all_reported():
+    src = """\
+#include "/etc/passwd"
+#include "../../etc/shadow"
+#include <stdio.h>
+#pragma GCC dependency "/proc/version"
+"""
+    v = scan(src)
+    assert len(v) == 3
+    paths = sorted(x.path for x in v)
+    assert paths == ["../../etc/shadow", "/etc/passwd", "/proc/version"]
+
+
+def test_violation_line_numbers_correct():
+    src = "// header\n\n\n#include \"/etc/passwd\"\nint main(){}"
+    v = scan(src)
+    assert v[0].line_no == 4
+
+
+def test_format_violations_includes_path_and_reason():
+    src = '#include "/etc/passwd"'
+    v = scan(src)
+    formatted = format_violations(v)
+    assert len(formatted) == 1
+    assert "/etc/passwd" in formatted[0]
+    assert "absolute path" in formatted[0]
+    # Should not say "blocked" or "security" — frames as a coding-style
+    # constraint to the refiner LLM rather than advertising the gate.
+    assert "security" not in formatted[0].lower()
+
+
+# ---------------------------------------------------------------------------
+# Whitespace / formatting variants the regex must tolerate
+# ---------------------------------------------------------------------------
+
+def test_indented_directive_blocked():
+    src = '   #include "/etc/passwd"\nint main(){}'
+    v = scan(src)
+    assert len(v) == 1
+
+
+def test_extra_spaces_inside_directive_blocked():
+    src = '#  include "/etc/passwd"\nint main(){}'
+    v = scan(src)
+    assert len(v) == 1
+
+
+def test_has_include_with_whitespace_blocked():
+    src = '#if __has_include  (  </etc/passwd>  )\n#endif'
+    v = scan(src)
+    assert len(v) == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration with ExploitValidator
+# ---------------------------------------------------------------------------
+
+def test_validate_exploit_rejects_absolute_include(tmp_path):
+    """End-to-end: malicious source goes into validate_exploit, the
+    pre-scan rejects it before gcc is ever called."""
+    from packages.autonomous.exploit_validator import ExploitValidator
+    v = ExploitValidator(work_dir=tmp_path)
+    result = v.validate_exploit('#include "/etc/passwd"\nint main(){}', "exfil")
+    assert result.success is False
+    assert result.compilation_errors
+    assert "/etc/passwd" in result.compilation_errors[0]
+    # No binary produced
+    assert result.exploit_path is None
+
+
+def test_validate_exploit_passes_clean_source(tmp_path):
+    """Sanity: a benign PoC isn't blocked by the pre-scan. We can't
+    assert successful compilation without a working gcc on the test host
+    (CI may not have one); the assertion is only that the pre-scan
+    didn't reject — gcc-result is whatever it is."""
+    import shutil
+    if shutil.which("gcc") is None:
+        import pytest
+        pytest.skip("gcc not available in test environment")
+    from packages.autonomous.exploit_validator import ExploitValidator
+    v = ExploitValidator(work_dir=tmp_path)
+    result = v.validate_exploit(
+        "#include <stdio.h>\nint main(){return 0;}",
+        "clean",
+    )
+    # Source-scan rejection produces "absolute path" / "directory traversal"
+    # in the error list. A real compile failure produces gcc errors. Confirm
+    # we don't see the source-scan rejection shape.
+    for err in result.compilation_errors:
+        assert "absolute path" not in err
+        assert "directory traversal" not in err
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: full call site (validate_and_refine) with the live exfil
+# payloads that the original probe confirmed leak file contents into stderr
+# ---------------------------------------------------------------------------
+
+class _MockRefiner:
+    """Stand-in for ``MultiTurnAnalyser`` so the validate_and_refine
+    iteration loop can be exercised without a real LLM call. Records
+    the errors handed to it on each refinement turn so the test can
+    assert that no file content is being relayed to the model."""
+
+    def __init__(self, refined_code: str):
+        self.refined_code = refined_code
+        self.refinements_seen: list[list[str]] = []
+
+    def refine_exploit_iteratively(self, *, exploit_code, crash_context,
+                                    validation_errors, **_kwargs):
+        self.refinements_seen.append(list(validation_errors))
+        return self.refined_code
+
+
+# All seven payloads the live probe (/tmp/poc_exfil_probe.py) confirmed
+# leak first-line content of the read target into gcc's stderr (or, for
+# the silent-success ones, embed the content into the output binary).
+_EXFIL_PAYLOADS = {
+    "abs_include":         '#include "/etc/passwd"\nint main(){}',
+    "angle_abs_include":   '#include </etc/passwd>\nint main(){}',
+    "traversing_include":  '#include "../../../../etc/passwd"\nint main(){}',
+    "has_include_oracle":  '#if __has_include(</etc/passwd>)\n#error H\n#endif\nint main(){}',
+    "incbin_asm":          '__asm__(".incbin \\"/etc/passwd\\"");\nint main(){}',
+    "embed_directive":     'const char d[] = {\n#embed "/etc/passwd"\n};\nint main(){}',
+    "pragma_dependency":   '#pragma GCC dependency "/etc/passwd"\nint main(){}',
+}
+
+
+def test_e2e_all_known_exfil_shapes_blocked_before_gcc(tmp_path):
+    """The full set of payloads the live probe confirmed work today.
+    For each: drive ``validate_exploit`` end-to-end and verify (a) the
+    call returns failure, (b) the error message is the source-scan
+    framing (not gcc stderr), (c) NO known-content fragment from
+    ``/etc/passwd`` (specifically the well-known ``root:`` prefix that
+    gcc echoes back when it parses the file as C) appears anywhere in
+    the returned errors. This is the regression-grade check that the
+    verified leak is closed at this call site."""
+    from packages.autonomous.exploit_validator import ExploitValidator
+
+    for name, source in _EXFIL_PAYLOADS.items():
+        v = ExploitValidator(work_dir=tmp_path)
+        result = v.validate_exploit(source, name)
+        assert result.success is False, f"{name}: expected rejection, got success"
+        assert result.compilation_errors, f"{name}: expected error message"
+        # Source-scan framing — proves we rejected pre-gcc, not at compile
+        joined = " ".join(result.compilation_errors)
+        assert ("absolute path" in joined or "directory traversal" in joined), \
+            f"{name}: expected source-scan rejection shape, got: {joined!r}"
+        # No file-content artefact. ``root:`` is the first token of every
+        # /etc/passwd file gcc would have read in a successful exfil.
+        assert "root:" not in joined, \
+            f"{name}: file content leaked into rejection message: {joined!r}"
+        # No binary produced
+        assert result.exploit_path is None, f"{name}: unexpected binary"
+
+
+def test_e2e_validate_and_refine_loop_handles_source_scan_rejection(tmp_path):
+    """Exercise the iterative-refinement loop: malicious PoC enters
+    iter 1, source-scan blocks, refiner is asked to fix, returns a
+    clean PoC, iter 2 succeeds. The errors fed to the refiner must be
+    the source-scan messages — never gcc stderr that could carry
+    leaked file content."""
+    import shutil
+    if shutil.which("gcc") is None:
+        import pytest
+        pytest.skip("gcc not available in test environment")
+    from packages.autonomous.exploit_validator import ExploitValidator
+
+    malicious = '#include "/etc/passwd"\nint main(){}'
+    clean = '#include <stdio.h>\nint main(){return 0;}'
+
+    v = ExploitValidator(work_dir=tmp_path)
+    refiner = _MockRefiner(refined_code=clean)
+
+    success, final_code, _path = v.validate_and_refine(
+        exploit_code=malicious,
+        exploit_name="e2e_refine",
+        crash_context=None,
+        multi_turn_analyser=refiner,
+        max_iterations=3,
+    )
+
+    assert success is True
+    assert final_code == clean
+    # Refiner was consulted exactly once (iter-1 rejected → refine →
+    # iter-2 compiled clean → loop exits).
+    assert len(refiner.refinements_seen) == 1
+    iter1_errors = refiner.refinements_seen[0]
+    # Errors carry the source-scan framing
+    assert any("absolute path" in e for e in iter1_errors)
+    # And do NOT leak file content
+    for e in iter1_errors:
+        assert "root:" not in e
+
+
+def test_e2e_no_gcc_invocation_when_source_scan_rejects(monkeypatch, tmp_path):
+    """Strongest signal: confirm the sandbox/gcc subprocess is NEVER
+    reached when the source-scan rejects. Substitutes ``sandbox.run``
+    for a probe that would fail loudly if it were called."""
+    from packages.autonomous.exploit_validator import ExploitValidator
+    import core.sandbox
+
+    sandbox_called = {"hit": False}
+
+    def _explode(*args, **kwargs):
+        sandbox_called["hit"] = True
+        raise AssertionError("sandbox.run should not be reached for blocked PoCs")
+
+    monkeypatch.setattr(core.sandbox, "run", _explode)
+    # Some import sites bind ``run`` directly — patch the namespace
+    # too so the validator's local lookup is intercepted.
+    import core.sandbox.context
+    monkeypatch.setattr(core.sandbox.context, "run", _explode)
+
+    v = ExploitValidator(work_dir=tmp_path)
+    for name, source in _EXFIL_PAYLOADS.items():
+        result = v.validate_exploit(source, name)
+        assert result.success is False
+    assert sandbox_called["hit"] is False


### PR DESCRIPTION
A live probe confirmed that LLM-generated PoC source flowing into ExploitValidator.validate_exploit() can exfiltrate file content via gcc when an attacker bypasses prompt-injection defences and gets the generator to emit C with #include "/etc/passwd" or its variants. gcc reads the target file, fails to parse it as C, and prints the offending source line into stderr — which then flows back to the refiner LLM via _parse_gcc_errors. Probe output for #include "/etc/passwd" included `1 | root:x:0:0:root:/root:/bin/bash` verbatim.

Add packages/autonomous/poc_source_scan.py: a regex pre-pass that rejects exfiltration shapes before gcc is invoked. Blocks absolute paths and `..` traversal segments in:
  - #include "..." / #include <...>
  - #embed "..."
  - __has_include(<...>) / __has_include("...")  — the 1-bit oracle
  - .incbin "..."  — assembler embed inside __asm__ blocks
  - #pragma GCC dependency "..."

Allow-list scope is "what an LLM-generated standalone PoC actually needs": same-directory or descending quoted includes, angle-bracket system headers (resolved by toolchain search path, not source traversal). Generic C compilation that legitimately uses parent-dir traversal is outside the scope of this consumer.

Wire into ExploitValidator.validate_exploit() ahead of the gcc subprocess call. On a hit, return ValidationResult(success=False, compilation_errors=[...]) with the violations framed as coding-style feedback so the refiner LLM iterates without being told there's a security gate.

E2E tests run all seven verified-leak payloads through validate_exploit and assert: rejection, source-scan framing in the errors, no `root:` content fragment anywhere in the returned messages, and (via monkeypatched sandbox.run) confirm gcc is never reached for blocked PoCs. validate_and_refine's iteration loop is exercised with a mock refiner: malicious in -> blocked -> refiner consulted with sanitised errors -> clean PoC -> compile success.

What this does NOT do, intentionally:

  - No toolchain probe + sandbox restrict_reads (Layer 0). Lands when a second tool->LLM consumer makes the abstraction worth designing.
  - No tool-output scrubber for the LLM-facing channel (Layer 3). Same justification — multiple consumers needed before designing.
  - No per-language plugin architecture. C/C++ is the only current consumer; pluggable detectors for Rust/Python/Go land when those languages enter the PoC pipeline.
  - No LLM-reviewer second opinion. Adds an LLM call per PoC for marginal gain over the mechanical blocklist; gated on measured miss-rate from the corpus before being worth the cost.

The threat is closed at the verified channel for the cost of ~140 LOC plus tests. 32 new tests + 1325 existing tests pass across autonomous + sandbox + security packages.