### PR TITLE
feat(iris): LocalFlowSource for CLI / env / stdin Tier 1 coverage

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -59,6 +59,21 @@ class RaptorConfig:
     CODEQL_QUERIES_DIR = ENGINE_DIR / "codeql" / "queries"
     CODEQL_SUITES_DIR = ENGINE_DIR / "codeql" / "suites"
 
+    # Additional CodeQL pack roots searched by IRIS Tier 1 discovery
+    # alongside the default `~/.codeql/packages/codeql/` location. Each
+    # entry is a directory containing one or more `<lang>-queries/`
+    # subdirectories matching the standard CodeQL pack layout. Listed
+    # roots take precedence over the default on (lang, CWE) collisions
+    # so RAPTOR-shipped packs can override stdlib queries.
+    #
+    # Default includes the in-repo raptor-python-queries pack so
+    # LocalFlowSource-based queries (covering CLI sources like sys.argv
+    # that the stdlib RemoteFlowSource model excludes) are picked up
+    # without operator configuration.
+    EXTRA_CODEQL_PACK_ROOTS: List[Path] = [
+        REPO_ROOT / "packages" / "llm_analysis" / "codeql_packs",
+    ]
+
     # Timeout Configuration (seconds)
     DEFAULT_TIMEOUT = 1800          # 30 minutes
     SEMGREP_TIMEOUT = 900            # 15 minutes (scan over local rule dirs)

--- a/packages/hypothesis_validation/adapters/codeql.py
+++ b/packages/hypothesis_validation/adapters/codeql.py
@@ -18,14 +18,77 @@ this pattern.
 """
 
 import json
+import logging
 import shutil
 import subprocess
 import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 
 from .base import ToolAdapter, ToolCapability, ToolEvidence, make_sandbox_runner
+
+logger = logging.getLogger(__name__)
+
+
+# Process-scoped cache of pack dirs we've already attempted to install.
+# Pack-install is idempotent and fast on subsequent calls (just reads the
+# lockfile), but skipping the subprocess entirely is cheaper.
+_INSTALLED_PACK_DIRS: Set[Path] = set()
+
+
+def _find_pack_dir(query_path: Path) -> Optional[Path]:
+    """Walk up from a .ql file looking for the containing pack's qlpack.yml.
+
+    Bounds the walk to a few levels — pack layouts are
+    `<pack>/Security/CWE-NNN/file.ql` (3 up) or
+    `<pack>/<version>/Security/CWE-NNN/file.ql` (4 up).
+    """
+    for parent in query_path.resolve().parents[:5]:
+        if (parent / "qlpack.yml").is_file():
+            return parent
+    return None
+
+
+def _ensure_pack_installed(
+    query_path: Path,
+    codeql_bin: str,
+    runner,
+    env: Dict[str, str],
+) -> None:
+    """Run `codeql pack install` on the query's containing pack if needed.
+
+    Skipped when:
+      - The query lives outside any qlpack.yml-owning directory
+      - The pack already has a `codeql-pack.lock.yml` (already installed)
+      - We've already attempted install for this pack in this process
+
+    Failures are logged but do not raise — the subsequent
+    `codeql database analyze` call surfaces a clearer error if the
+    install was actually required.
+    """
+    pack_dir = _find_pack_dir(Path(query_path))
+    if pack_dir is None:
+        return
+    if pack_dir in _INSTALLED_PACK_DIRS:
+        return
+    _INSTALLED_PACK_DIRS.add(pack_dir)
+
+    if (pack_dir / "codeql-pack.lock.yml").is_file():
+        # Already installed — pack-install would be a no-op.
+        return
+
+    try:
+        runner(
+            [codeql_bin, "pack", "install", str(pack_dir)],
+            capture_output=True, text=True,
+            timeout=180, env=env,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        logger.warning(
+            "codeql pack install on %s failed: %s — analyze may fail with a clearer error",
+            pack_dir, e,
+        )
 
 
 _SYNTAX_EXAMPLE = """\
@@ -172,6 +235,15 @@ class CodeQLAdapter(ToolAdapter):
             make_sandbox_runner(target=self._database_path)
             if self._sandbox else subprocess.run
         )
+
+        # Lazy pack-install: in-repo packs (under EXTRA_CODEQL_PACK_ROOTS)
+        # ship a qlpack.yml but no codeql-pack.lock.yml in fresh checkouts.
+        # Without the lockfile codeql can't resolve the pack's
+        # dependencies (codeql/python-all etc.) when invoking via
+        # absolute query path. Standard installed packs (under
+        # ~/.codeql/packages/codeql/) always have lockfiles already,
+        # so this is a no-op for them.
+        _ensure_pack_installed(query_path, self._codeql_bin, runner, env)
 
         try:
             with TemporaryDirectory(prefix="codeql_prebuilt_") as tmp:

--- a/packages/llm_analysis/codeql_packs/python-queries/Raptor/LocalFlowSource.qll
+++ b/packages/llm_analysis/codeql_packs/python-queries/Raptor/LocalFlowSource.qll
@@ -1,0 +1,44 @@
+/**
+ * Provides RAPTOR's `LocalFlowSource` — a data-flow source class
+ * covering CLI / process-local user-controlled inputs that CodeQL's
+ * stdlib `RemoteFlowSource` intentionally excludes.
+ *
+ * Used by IRIS Tier 1 dataflow validation when the LLM's claim
+ * involves an attacker-controlled value reaching a sensitive sink
+ * via:
+ *   - `sys.argv` / `sys.orig_argv`               (commandargs)
+ *   - `os.environ`, `os.getenv`, `os.environb`   (environment)
+ *   - `sys.stdin.read*`, `input()`, `raw_input`  (stdin)
+ *   - file reads of attacker-controlled paths    (file)
+ *
+ * Implementation note: rather than re-modelling each API, we leverage
+ * CodeQL's existing `ThreatModelSource` infrastructure. The stdlib
+ * already models all the relevant APIs and tags them with threat-model
+ * categories; this class just selects the subset that maps to local /
+ * process-boundary inputs. See:
+ *   ~/.codeql/packages/codeql/threat-models/.../threat-model-grouping.model.yml
+ *
+ * Includes `remote` as well, so a query using `LocalFlowSource` covers
+ * BOTH local and remote inputs without needing two parallel queries —
+ * matches IRIS validation semantics where the LLM's claim might
+ * describe either kind of input.
+ */
+
+import python
+import semmle.python.dataflow.new.DataFlow
+import semmle.python.Concepts
+
+/**
+ * A data-flow source representing process-local user input
+ * (CLI args, env vars, stdin, file contents) plus remote sources.
+ *
+ * Subtype selectors mirror the threat-model categories in the CodeQL
+ * threat-models pack. Adding a category here is the only change needed
+ * to widen IRIS Tier 1's source coverage.
+ */
+class LocalFlowSource extends ThreatModelSource {
+  LocalFlowSource() {
+    this.getThreatModel() =
+      ["remote", "commandargs", "environment", "stdin", "file"]
+  }
+}

--- a/packages/llm_analysis/codeql_packs/python-queries/Security/CWE-022/PathTraversalLocal.ql
+++ b/packages/llm_analysis/codeql_packs/python-queries/Security/CWE-022/PathTraversalLocal.ql
@@ -1,0 +1,41 @@
+/**
+ * @name IRIS LocalFlowSource: path traversal from local input
+ * @description Reuses the stdlib PathInjection sink and sanitiser
+ *              models with RAPTOR's `LocalFlowSource` to catch
+ *              CLI / env / stdin-driven path traversal that the
+ *              stdlib RemoteFlowSource-based query misses.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id raptor/iris/python/path-injection-local
+ * @tags security
+ *       external/cwe/cwe-22
+ *       external/cwe/cwe-23
+ *       external/cwe/cwe-36
+ */
+
+import python
+import semmle.python.dataflow.new.DataFlow
+import semmle.python.dataflow.new.TaintTracking
+import semmle.python.security.dataflow.PathInjectionCustomizations
+import Raptor.LocalFlowSource
+
+private module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof LocalFlowSource }
+
+  predicate isSink(DataFlow::Node n) { n instanceof PathInjection::Sink }
+
+  predicate isBarrier(DataFlow::Node n) { n instanceof PathInjection::Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+import Flow::PathGraph
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "Local user input from $@ flows to a filesystem path.",
+  source.getNode(), source.getNode().toString()

--- a/packages/llm_analysis/codeql_packs/python-queries/Security/CWE-078/CommandInjectionLocal.ql
+++ b/packages/llm_analysis/codeql_packs/python-queries/Security/CWE-078/CommandInjectionLocal.ql
@@ -1,0 +1,40 @@
+/**
+ * @name IRIS LocalFlowSource: command injection from local input
+ * @description Reuses the stdlib CommandInjection sink and sanitiser
+ *              models, but pairs them with RAPTOR's `LocalFlowSource`
+ *              so CLI- / env- / stdin-driven flows that the stdlib's
+ *              `RemoteFlowSource`-based query misses are caught.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id raptor/iris/python/command-injection-local
+ * @tags security
+ *       external/cwe/cwe-78
+ *       external/cwe/cwe-88
+ */
+
+import python
+import semmle.python.dataflow.new.DataFlow
+import semmle.python.dataflow.new.TaintTracking
+import semmle.python.security.dataflow.CommandInjectionCustomizations
+import Raptor.LocalFlowSource
+
+private module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof LocalFlowSource }
+
+  predicate isSink(DataFlow::Node n) { n instanceof CommandInjection::Sink }
+
+  predicate isBarrier(DataFlow::Node n) { n instanceof CommandInjection::Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+import Flow::PathGraph
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "Local user input from $@ flows to a command-execution sink.",
+  source.getNode(), source.getNode().toString()

--- a/packages/llm_analysis/codeql_packs/python-queries/Security/CWE-089/SqlInjectionLocal.ql
+++ b/packages/llm_analysis/codeql_packs/python-queries/Security/CWE-089/SqlInjectionLocal.ql
@@ -1,0 +1,39 @@
+/**
+ * @name IRIS LocalFlowSource: SQL injection from local input
+ * @description Reuses the stdlib SqlInjection sink and sanitiser
+ *              models with RAPTOR's `LocalFlowSource` to catch
+ *              CLI / env / stdin-driven SQL injection that the
+ *              stdlib RemoteFlowSource-based query misses.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id raptor/iris/python/sql-injection-local
+ * @tags security
+ *       external/cwe/cwe-89
+ */
+
+import python
+import semmle.python.dataflow.new.DataFlow
+import semmle.python.dataflow.new.TaintTracking
+import semmle.python.security.dataflow.SqlInjectionCustomizations
+import Raptor.LocalFlowSource
+
+private module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof LocalFlowSource }
+
+  predicate isSink(DataFlow::Node n) { n instanceof SqlInjection::Sink }
+
+  predicate isBarrier(DataFlow::Node n) { n instanceof SqlInjection::Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+import Flow::PathGraph
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "Local user input from $@ flows to a SQL query.",
+  source.getNode(), source.getNode().toString()

--- a/packages/llm_analysis/codeql_packs/python-queries/Security/CWE-094/CodeInjectionLocal.ql
+++ b/packages/llm_analysis/codeql_packs/python-queries/Security/CWE-094/CodeInjectionLocal.ql
@@ -1,0 +1,42 @@
+/**
+ * @name IRIS LocalFlowSource: code injection from local input
+ * @description Reuses the stdlib CodeInjection sink and sanitiser
+ *              models with RAPTOR's `LocalFlowSource` to catch
+ *              CLI / env / stdin-driven `eval` / `exec` / `compile`
+ *              flows that the stdlib RemoteFlowSource-based query
+ *              misses.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id raptor/iris/python/code-injection-local
+ * @tags security
+ *       external/cwe/cwe-94
+ *       external/cwe/cwe-95
+ *       external/cwe/cwe-116
+ */
+
+import python
+import semmle.python.dataflow.new.DataFlow
+import semmle.python.dataflow.new.TaintTracking
+import semmle.python.security.dataflow.CodeInjectionCustomizations
+import Raptor.LocalFlowSource
+
+private module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof LocalFlowSource }
+
+  predicate isSink(DataFlow::Node n) { n instanceof CodeInjection::Sink }
+
+  predicate isBarrier(DataFlow::Node n) { n instanceof CodeInjection::Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+import Flow::PathGraph
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "Local user input from $@ flows to a code-execution sink.",
+  source.getNode(), source.getNode().toString()

--- a/packages/llm_analysis/codeql_packs/python-queries/Security/CWE-502/UnsafeDeserializationLocal.ql
+++ b/packages/llm_analysis/codeql_packs/python-queries/Security/CWE-502/UnsafeDeserializationLocal.ql
@@ -1,0 +1,40 @@
+/**
+ * @name IRIS LocalFlowSource: unsafe deserialization from local input
+ * @description Reuses the stdlib UnsafeDeserialization sink and
+ *              sanitiser models with RAPTOR's `LocalFlowSource` to
+ *              catch CLI / env / stdin / file-driven deserialization
+ *              flows that the stdlib RemoteFlowSource-based query
+ *              misses (e.g. `pickle.loads(open(argv[1]).read())`).
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id raptor/iris/python/unsafe-deserialization-local
+ * @tags security
+ *       external/cwe/cwe-502
+ */
+
+import python
+import semmle.python.dataflow.new.DataFlow
+import semmle.python.dataflow.new.TaintTracking
+import semmle.python.security.dataflow.UnsafeDeserializationCustomizations
+import Raptor.LocalFlowSource
+
+private module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof LocalFlowSource }
+
+  predicate isSink(DataFlow::Node n) { n instanceof UnsafeDeserialization::Sink }
+
+  predicate isBarrier(DataFlow::Node n) { n instanceof UnsafeDeserialization::Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+import Flow::PathGraph
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "Local user input from $@ is deserialized.",
+  source.getNode(), source.getNode().toString()

--- a/packages/llm_analysis/codeql_packs/python-queries/codeql-pack.lock.yml
+++ b/packages/llm_analysis/codeql_packs/python-queries/codeql-pack.lock.yml
@@ -1,0 +1,30 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/concepts:
+    version: 0.0.22
+  codeql/controlflow:
+    version: 2.0.32
+  codeql/dataflow:
+    version: 2.1.4
+  codeql/mad:
+    version: 1.0.48
+  codeql/python-all:
+    version: 7.0.5
+  codeql/regex:
+    version: 1.0.48
+  codeql/ssa:
+    version: 2.0.24
+  codeql/threat-models:
+    version: 1.0.48
+  codeql/tutorial:
+    version: 1.0.48
+  codeql/typetracking:
+    version: 2.0.32
+  codeql/util:
+    version: 2.0.35
+  codeql/xml:
+    version: 1.0.48
+  codeql/yaml:
+    version: 1.0.48
+compiled: false

--- a/packages/llm_analysis/codeql_packs/python-queries/qlpack.yml
+++ b/packages/llm_analysis/codeql_packs/python-queries/qlpack.yml
@@ -1,0 +1,19 @@
+---
+# RAPTOR-shipped CodeQL pack: companion queries that complement the
+# stdlib `codeql/python-queries` pack with sources beyond the
+# `RemoteFlowSource` model — specifically `commandargs`, `environment`,
+# `stdin`, and `file` threat models. Used by IRIS Tier 1 dataflow
+# validation when a Semgrep finding's claim involves a CLI / env /
+# stdin source that the stdlib `RemoteFlowSource`-based queries miss.
+#
+# Discovery picks this pack up via RaptorConfig.EXTRA_CODEQL_PACK_ROOTS;
+# pack name is distinct from the stdlib's so no resolution collision.
+# Layout is flat (no version dir) since the pack ships in the RAPTOR
+# repo and isn't separately versioned — pack discovery's flat-layout
+# branch handles this case.
+library: false
+name: raptor/python-queries
+version: 0.0.1
+dependencies:
+  codeql/python-all: "*"
+extractor: python

--- a/packages/llm_analysis/dataflow_query_builder.py
+++ b/packages/llm_analysis/dataflow_query_builder.py
@@ -85,9 +85,27 @@ _ID_RE = re.compile(r"@id\s+([\w.\-/]+)")
 _METADATA_READ_BYTES = 4096
 
 
-def _pack_root() -> Path:
-    """Resolve the CodeQL package root."""
-    return _DEFAULT_PACK_ROOT
+def _pack_roots() -> List[Path]:
+    """Resolve all CodeQL pack roots in priority order.
+
+    Returns extras (from RaptorConfig.EXTRA_CODEQL_PACK_ROOTS) first,
+    then the default. First-seen-wins semantics in the walk mean
+    extras override the default on (lang, CWE) collisions — RAPTOR-
+    shipped packs (e.g. raptor-python-queries with LocalFlowSource
+    coverage) take precedence over the bundled stdlib queries.
+
+    Config import is deferred so this module stays import-safe in
+    contexts (tests, scripts) where core.config may not be fully
+    initialised. Tests can also monkeypatch _DEFAULT_PACK_ROOT
+    directly to point at fixtures.
+    """
+    extras: List[Path] = []
+    try:
+        from core.config import RaptorConfig
+        extras = list(RaptorConfig.EXTRA_CODEQL_PACK_ROOTS or [])
+    except ImportError:
+        pass
+    return extras + [_DEFAULT_PACK_ROOT]
 
 
 def _read_metadata(ql_path: Path) -> Optional[str]:
@@ -157,42 +175,52 @@ def discover_prebuilt_queries() -> Dict[Tuple[str, str], Path]:
     `discover_prebuilt_queries.cache_clear()`.
 
     Multiple .ql files can share a (lang, CWE) key — e.g. both
-    `Security/CWE-078/CommandInjection.ql` and an extension query.
-    First-seen wins (sorted alphabetically), so behaviour is
-    deterministic. Operators with strong opinions about which query
-    handles a given CWE can set `CODEQL_HOME` to a curated install.
+    `Security/CWE-078/CommandInjection.ql` and an extension query, or
+    a RAPTOR override and the stdlib version. First-seen wins, with
+    extras (RaptorConfig.EXTRA_CODEQL_PACK_ROOTS) walked before the
+    default root so RAPTOR-shipped packs win on collisions. Within a
+    single root, iteration is alphabetical for determinism.
     """
     out: Dict[Tuple[str, str], Path] = {}
-    root = _pack_root()
-    if not root.is_dir():
-        logger.info("CodeQL pack root not found: %s", root)
-        return out
-
-    # Walk every <lang>-queries pack. Multiple versions may coexist —
-    # we take queries from all of them; a (lang, CWE) collision picks
-    # the alphabetically-first version which is a stable choice.
-    for pack_dir in sorted(root.iterdir()):
-        if not pack_dir.is_dir():
-            continue
-        language = _language_from_pack_dir(pack_dir)
-        if language is None:
+    for root in _pack_roots():
+        if not root.is_dir():
+            logger.debug("CodeQL pack root not found: %s", root)
             continue
 
-        # Each pack contains one or more `<version>/` dirs — go one
-        # level deeper to find Security/CWE-* directories.
-        for version_dir in sorted(pack_dir.iterdir()):
-            if not version_dir.is_dir():
+        # Walk every <lang>-queries pack. The pack may have a single
+        # version dir (`<root>/<lang>-queries/<version>/Security/...`)
+        # or be laid out flat (`<root>/<lang>-queries/Security/...`)
+        # for in-repo packs that don't ship versioned. Both shapes
+        # are recognised.
+        for pack_dir in sorted(root.iterdir()):
+            if not pack_dir.is_dir():
                 continue
-            security_dir = version_dir / "Security"
-            if not security_dir.is_dir():
+            language = _language_from_pack_dir(pack_dir)
+            if language is None:
                 continue
-            for ql_path in sorted(security_dir.rglob("*.ql")):
-                metadata = _read_metadata(ql_path)
-                if metadata is None or not _is_path_problem(metadata):
-                    continue
-                for cwe in _extract_cwes(metadata):
-                    key = (language, cwe)
-                    out.setdefault(key, ql_path)
+
+            search_dirs: List[Path] = []
+            flat_security = pack_dir / "Security"
+            if flat_security.is_dir():
+                # Flat: <root>/<lang>-queries/Security/...
+                search_dirs.append(flat_security)
+            else:
+                # Versioned: <root>/<lang>-queries/<version>/Security/...
+                for version_dir in sorted(pack_dir.iterdir()):
+                    if not version_dir.is_dir():
+                        continue
+                    security_dir = version_dir / "Security"
+                    if security_dir.is_dir():
+                        search_dirs.append(security_dir)
+
+            for security_dir in search_dirs:
+                for ql_path in sorted(security_dir.rglob("*.ql")):
+                    metadata = _read_metadata(ql_path)
+                    if metadata is None or not _is_path_problem(metadata):
+                        continue
+                    for cwe in _extract_cwes(metadata):
+                        key = (language, cwe)
+                        out.setdefault(key, ql_path)
 
     if out:
         logger.debug(

--- a/packages/llm_analysis/tests/fixtures/iris_e2e/src/cli_command_injection.py
+++ b/packages/llm_analysis/tests/fixtures/iris_e2e/src/cli_command_injection.py
@@ -1,0 +1,26 @@
+"""CLI-driven command injection: sys.argv → subprocess.call(shell=True).
+
+Tests RAPTOR's LocalFlowSource coverage. The stdlib
+`RemoteFlowSource`-based CodeQL query (CommandInjection.ql) does NOT
+flag this — its source model is scoped to network inputs (HTTP, RPC,
+etc.) and excludes process-local sources like sys.argv.
+
+The RAPTOR-shipped CommandInjectionLocal.ql query (using
+`LocalFlowSource`) DOES flag this, providing IRIS Tier 1 confirmation
+for CLI-driven command-injection findings that would otherwise have
+to fall through to Tier 2's LLM-customised predicates.
+"""
+
+import subprocess
+import sys
+
+
+def main() -> int:
+    # sys.argv[1] is attacker-controlled when this script runs setuid /
+    # is called from a wrapper that takes user input.
+    target = sys.argv[1]
+    return subprocess.call(f"ping -c1 {target}", shell=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/llm_analysis/tests/test_dataflow_query_builder.py
+++ b/packages/llm_analysis/tests/test_dataflow_query_builder.py
@@ -56,8 +56,10 @@ class TestDiscovery:
     """`discover_prebuilt_queries` walks installed packs to map (lang, CWE) → path.
 
     Tests build a fake pack tree under tmp_path, monkeypatch the module's
-    `_DEFAULT_PACK_ROOT` to point at it, and bust the lru_cache between
-    cases. Avoiding env vars per project convention.
+    `_DEFAULT_PACK_ROOT` to point at it, AND clear
+    RaptorConfig.EXTRA_CODEQL_PACK_ROOTS so the in-repo
+    raptor-python-queries pack (a real production extras root) doesn't
+    leak into the test's view. Avoiding env vars per project convention.
     """
 
     def setup_method(self):
@@ -66,13 +68,19 @@ class TestDiscovery:
     def teardown_method(self):
         discover_prebuilt_queries.cache_clear()
 
+    def _isolate_default_root(self, monkeypatch, tmp_path):
+        """Point discovery at tmp_path only — no in-repo extras leak."""
+        from core.config import RaptorConfig
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [])
+
     def test_finds_path_problem_query(self, tmp_path, monkeypatch):
         sec = _build_pack_tree(tmp_path, language="python")
         ql = sec / "CWE-078" / "CommandInjection.ql"
         _write_query(ql, kind="path-problem",
                      cwe_tag="external/cwe/cwe-78", qid="py/cmd-injection")
 
-        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        self._isolate_default_root(monkeypatch, tmp_path)
         out = discover_prebuilt_queries()
         assert ("python", "CWE-78") in out
         assert out[("python", "CWE-78")] == ql
@@ -84,7 +92,7 @@ class TestDiscovery:
         # dataflow validation isn't what it does.
         _write_query(ql, kind="problem", cwe_tag="external/cwe/cwe-79")
 
-        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        self._isolate_default_root(monkeypatch, tmp_path)
         out = discover_prebuilt_queries()
         assert ("python", "CWE-79") not in out
 
@@ -96,7 +104,7 @@ class TestDiscovery:
             cwe_tag="external/cwe/cwe-89",
         )
 
-        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        self._isolate_default_root(monkeypatch, tmp_path)
         # Case-insensitive language and CWE; trims whitespace.
         assert discover_prebuilt_query("Python", "cwe-89") is not None
         assert discover_prebuilt_query("PYTHON", " CWE-89 ") is not None
@@ -104,12 +112,12 @@ class TestDiscovery:
 
     def test_lookup_returns_none_for_unknown(self, tmp_path, monkeypatch):
         # Empty pack tree.
-        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        self._isolate_default_root(monkeypatch, tmp_path)
         assert discover_prebuilt_query("python", "CWE-9999") is None
         assert discover_prebuilt_query("cobol", "CWE-78") is None
 
     def test_lookup_empty_inputs(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        self._isolate_default_root(monkeypatch, tmp_path)
         assert discover_prebuilt_query("", "CWE-78") is None
         assert discover_prebuilt_query("python", "") is None
         assert discover_prebuilt_query(None, None) is None
@@ -132,7 +140,7 @@ class TestDiscovery:
             kind="path-problem", cwe_tag="external/cwe/cwe-78",
         )
 
-        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        self._isolate_default_root(monkeypatch, tmp_path)
         assert discover_prebuilt_query("python", "CWE-78") is not None
         assert discover_prebuilt_query("java", "CWE-78") is not None
         assert discover_prebuilt_query("cpp", "CWE-78") is not None
@@ -146,7 +154,7 @@ class TestDiscovery:
         _write_query(a, kind="path-problem", cwe_tag="external/cwe/cwe-78")
         _write_query(b, kind="path-problem", cwe_tag="external/cwe/cwe-78")
 
-        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        self._isolate_default_root(monkeypatch, tmp_path)
         assert discover_prebuilt_query("python", "CWE-78") == a
 
     def test_skips_non_queries_packs(self, tmp_path, monkeypatch):
@@ -159,12 +167,14 @@ class TestDiscovery:
             kind="path-problem", cwe_tag="external/cwe/cwe-78",
         )
 
-        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        self._isolate_default_root(monkeypatch, tmp_path)
         assert discover_prebuilt_query("python", "CWE-78") is None
 
     def test_missing_pack_root_is_handled(self, tmp_path, monkeypatch):
         # Pack root points at a non-existent dir → empty result, no crash.
+        from core.config import RaptorConfig
         monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path / "does-not-exist")
+        monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [])
         out = discover_prebuilt_queries()
         assert out == {}
 
@@ -178,7 +188,7 @@ class TestDiscovery:
         _write_query(ql, kind="path-problem",
                      cwe_tag="external/cwe/cwe-022")
 
-        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        self._isolate_default_root(monkeypatch, tmp_path)
         # Lookup with canonical (unpadded) form must hit the entry.
         assert discover_prebuilt_query("python", "CWE-22") == ql
         # The dict key itself is also canonical.
@@ -205,9 +215,119 @@ class TestDiscovery:
             """
         ))
 
-        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
+        self._isolate_default_root(monkeypatch, tmp_path)
         assert discover_prebuilt_query("python", "CWE-78") == ql
         assert discover_prebuilt_query("python", "CWE-77") == ql
+
+
+class TestMultiRoot:
+    """Discovery walks RaptorConfig.EXTRA_CODEQL_PACK_ROOTS before the
+    default. Extras win on (lang, CWE) collisions so RAPTOR-shipped
+    packs (LocalFlowSource etc.) override the bundled stdlib queries."""
+
+    def setup_method(self):
+        discover_prebuilt_queries.cache_clear()
+
+    def teardown_method(self):
+        discover_prebuilt_queries.cache_clear()
+
+    def test_extras_override_default_on_collision(self, tmp_path, monkeypatch):
+        """Same (lang, CWE) in both extras and default → extras wins."""
+        from core.config import RaptorConfig
+
+        # Default root: stdlib-shaped query for CWE-78
+        default_root = tmp_path / "default"
+        default_sec = default_root / "python-queries" / "1.0.0" / "Security"
+        default_sec.mkdir(parents=True)
+        default_ql = default_sec / "CWE-078" / "FromDefault.ql"
+        _write_query(default_ql, kind="path-problem",
+                     cwe_tag="external/cwe/cwe-78", qid="default/cwe-78")
+
+        # Extras root: same CWE, flat layout (in-repo packs ship flat).
+        extras_root = tmp_path / "extras"
+        extras_sec = extras_root / "python-queries" / "Security"
+        extras_sec.mkdir(parents=True)
+        extras_ql = extras_sec / "CWE-078" / "FromExtras.ql"
+        _write_query(extras_ql, kind="path-problem",
+                     cwe_tag="external/cwe/cwe-78", qid="extras/cwe-78")
+
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", default_root)
+        monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [extras_root])
+
+        assert discover_prebuilt_query("python", "CWE-78") == extras_ql
+
+    def test_extras_and_default_merge_distinct_cwes(self, tmp_path, monkeypatch):
+        """Extras and default contribute different CWEs — both surface."""
+        from core.config import RaptorConfig
+
+        default_root = tmp_path / "default"
+        default_sec = default_root / "python-queries" / "1.0.0" / "Security"
+        default_sec.mkdir(parents=True)
+        _write_query(default_sec / "CWE-022" / "PathInjection.ql",
+                     kind="path-problem", cwe_tag="external/cwe/cwe-22")
+
+        extras_root = tmp_path / "extras"
+        extras_sec = extras_root / "python-queries" / "Security"
+        extras_sec.mkdir(parents=True)
+        _write_query(extras_sec / "CWE-094" / "CodeInjection.ql",
+                     kind="path-problem", cwe_tag="external/cwe/cwe-94")
+
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", default_root)
+        monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [extras_root])
+
+        assert discover_prebuilt_query("python", "CWE-22") is not None
+        assert discover_prebuilt_query("python", "CWE-94") is not None
+
+    def test_missing_extras_root_tolerated(self, tmp_path, monkeypatch):
+        """A non-existent extras root must not crash discovery."""
+        from core.config import RaptorConfig
+
+        default_root = tmp_path / "default"
+        default_sec = default_root / "python-queries" / "1.0.0" / "Security"
+        default_sec.mkdir(parents=True)
+        _write_query(default_sec / "CWE-078" / "X.ql",
+                     kind="path-problem", cwe_tag="external/cwe/cwe-78")
+
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", default_root)
+        monkeypatch.setattr(
+            RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS",
+            [tmp_path / "does-not-exist"],
+        )
+
+        # Default root still resolves; missing extras silently skipped.
+        assert discover_prebuilt_query("python", "CWE-78") is not None
+
+    def test_flat_pack_layout_recognised(self, tmp_path, monkeypatch):
+        """In-repo packs use flat layout (<pack>/Security/...) without a
+        version dir. Discovery must recognise both layouts."""
+        from core.config import RaptorConfig
+
+        # Flat layout — used by raptor-python-queries
+        extras_root = tmp_path / "extras"
+        flat_sec = extras_root / "python-queries" / "Security"
+        flat_sec.mkdir(parents=True)
+        ql = flat_sec / "CWE-502" / "Deser.ql"
+        _write_query(ql, kind="path-problem",
+                     cwe_tag="external/cwe/cwe-502")
+
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path / "no-default")
+        monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [extras_root])
+
+        assert discover_prebuilt_query("python", "CWE-502") == ql
+
+    def test_in_repo_pack_discoverable_in_default_config(self):
+        """Smoke-test the production default: discovery actually picks up
+        the RAPTOR-shipped raptor-python-queries pack via the default
+        EXTRA_CODEQL_PACK_ROOTS without any monkeypatching."""
+        # No monkeypatch — use real RaptorConfig defaults
+        out = discover_prebuilt_queries()
+        # CWE-78 must resolve to the in-repo LocalFlowSource query
+        # (extras win over the stdlib CommandInjection.ql on collision).
+        path = discover_prebuilt_query("python", "CWE-78")
+        assert path is not None
+        assert "raptor-python-queries" in str(path) or \
+               "codeql_packs/python-queries" in str(path), \
+               f"expected in-repo pack to win, got {path}"
 
 
 # Tier 2 ---------------------------------------------------------------------


### PR DESCRIPTION
CodeQL's stdlib RemoteFlowSource model excludes process-local inputs (sys.argv, os.environ, sys.stdin), so IRIS Tier 1 misses CLI-driven findings and they fall through to Tier 2 LLM predicates.

Ships an in-repo CodeQL pack (`raptor/python-queries`) with a LocalFlowSource library selecting the stdlib threat-model sources tagged commandargs/environment/stdin/file/remote, plus 5 companion path-problem queries reusing the stdlib sink+sanitiser models for CWE-78/89/22/94/502.

Discovery walks RaptorConfig.EXTRA_CODEQL_PACK_ROOTS (new config- object knob, not an env var) before the default `~/.codeql/packages/` so RAPTOR-shipped queries override the stdlib on collisions. CodeQLAdapter.run_prebuilt_query gained a lazy `codeql pack install` step gated on codeql-pack.lock.yml. Discovery now recognises both versioned and flat pack layouts.

Empirical (real CodeQL on tests/fixtures/iris_e2e/):
  Stdlib RemoteFlowSource query: 2 matches (Flask only)
  LocalFlowSource query:         3 matches (Flask + sys.argv flow)

Tests: 846 green; new fixture cli_command_injection.py proves the gap is closed end-to-end.