### PR TITLE
feat(iris): relax Tier 1 verdict to refute on no-match for in-repo packs

### DIFF
--- a/packages/llm_analysis/dataflow_validation.py
+++ b/packages/llm_analysis/dataflow_validation.py
@@ -651,20 +651,29 @@ def _validate_one_hypothesis(
         cwe = (infer_cwe_from_rule_id(finding.get("rule_id", "")) or "").upper().strip()
 
     # ----- Tier 1: prebuilt pack-resident query -----
-    # Fast confirmation lane. Returns confirmed when matches exist at the
-    # finding's location. Returns inconclusive (NOT refuted) on no matches —
-    # the prebuilt's source model may not cover the LLM's claimed source
-    # (e.g. RemoteFlowSource for HTTP misses sys.argv-driven CLIs).
-    # Inconclusive at Tier 1 falls through to Tier 2 where the LLM can
-    # customise predicates to test the specific claim.
+    # Confirmation lane. Behaviour depends on which pack the discovered
+    # query came from:
+    #
+    #   - Stdlib pack (~/.codeql/packages/codeql/python-queries/...):
+    #     RemoteFlowSource-only source model. No-match is inconclusive
+    #     because CLI / env / stdin sources fall outside the model.
+    #
+    #   - In-repo extras pack (RaptorConfig.EXTRA_CODEQL_PACK_ROOTS):
+    #     LocalFlowSource selects remote + commandargs + environment +
+    #     stdin + file. Source model is broad enough that no-match
+    #     becomes meaningful refutation.
+    #
+    # Either way a confirmed verdict (matches at finding location)
+    # short-circuits Tier 2. A refuted verdict (now possible from
+    # extras packs) does the same. Inconclusive falls through to Tier 2
+    # for a chance at refutation via LLM-customised predicates.
     if language and cwe:
         prebuilt_path = discover_prebuilt_query(language, cwe)
         if prebuilt_path is not None:
             ev = adapter.run_prebuilt_query(prebuilt_path, hypothesis.target)
-            verdict = _verdict_from_prebuilt(ev, finding)
-            if verdict == "confirmed":
-                # Tier 1 confirmed the path exists at the finding's
-                # location. Done — no need to run Tier 2.
+            verdict = _verdict_from_prebuilt(ev, finding, prebuilt_path)
+            if verdict in ("confirmed", "refuted"):
+                # Tier 1 produced a definitive answer. Done.
                 return _wrap_result(ev, verdict, tier="prebuilt"), "prebuilt"
             # Otherwise (inconclusive), fall through to Tier 2 for a
             # chance at refutation via LLM-customised predicates.
@@ -802,35 +811,72 @@ def _wrap_result(
 def _verdict_from_prebuilt(
     evidence: ToolEvidence,
     finding: Dict,
+    query_path: Optional[Path] = None,
 ) -> str:
     """Derive verdict from a prebuilt-query result.
 
-    Tier 1 is asymmetric: it confirms reliably, but cannot refute alone.
-
-    Why: prebuilt CodeQL queries (e.g. CommandInjectionFlow) have specific
-    source/sink models that may not cover every variant the LLM's
-    dataflow_summary describes. Python's `RemoteFlowSource`, for instance,
-    models *network* sources but NOT `sys.argv` — so a real CLI-driven
-    command injection produces "no matches" in the prebuilt query.
-    Treating that as refutation would downgrade true positives. Empirical:
-    real-LLM E2E with `sys.argv → subprocess.call(shell=True)` hit
-    exactly this case.
+    Asymmetry depends on which pack the query came from. Stdlib queries
+    use `RemoteFlowSource` only (network inputs); they cannot refute a
+    finding alone because the LLM's claim might involve a CLI / env /
+    stdin source that the model doesn't cover. In-repo extras packs
+    (`RaptorConfig.EXTRA_CODEQL_PACK_ROOTS`) ship `LocalFlowSource`
+    queries selecting remote + commandargs + environment + stdin + file
+    threat models — broad enough that a no-match result IS meaningful
+    refutation.
 
     Verdict logic:
       - tool failed → inconclusive
-      - matches present at finding location → confirmed (high-confidence)
-      - matches present elsewhere → inconclusive (query-narrow vs true-elsewhere)
-      - no matches at all → inconclusive (prebuilt's source model may
-        not cover the LLM's claimed source; refutation requires Tier 2's
-        LLM-customised predicates aligned with the specific claim)
+      - matches at finding location → confirmed
+      - matches elsewhere → inconclusive
+      - no matches, query from in-repo extras pack → refuted
+      - no matches, query from stdlib pack → inconclusive
+        (caller falls through to Tier 2 for LLM-customised refutation)
+
+    Empirical: pre-LocalFlowSource, a real CLI-driven command injection
+    using `sys.argv → subprocess.call(shell=True)` produced no matches
+    against the stdlib query, and treating that as refutation would
+    have downgraded a true positive. The relaxed branch only fires
+    when an in-repo query (which DOES cover sys.argv) returned no
+    matches — at which point refutation is justified.
     """
     if not evidence.success:
         return "inconclusive"
-    if not evidence.matches:
-        return "inconclusive"  # NOT refuted — see docstring
-    if _any_match_at_finding_location(evidence.matches, finding):
-        return "confirmed"
+    if evidence.matches:
+        if _any_match_at_finding_location(evidence.matches, finding):
+            return "confirmed"
+        return "inconclusive"
+    # No matches. Refutation is justified only when the query has broad
+    # source coverage — which only the in-repo extras packs do.
+    if query_path is not None and _query_is_in_extras_pack(query_path):
+        return "refuted"
     return "inconclusive"
+
+
+def _query_is_in_extras_pack(query_path: Path) -> bool:
+    """True when `query_path` lives under one of the configured extras
+    roots (i.e. an in-repo RAPTOR pack with LocalFlowSource coverage).
+
+    Handles both `Path.is_relative_to` (3.9+) and resolves to absolute
+    so a relative path argument doesn't accidentally fail the check.
+    """
+    try:
+        from core.config import RaptorConfig
+        extras = list(RaptorConfig.EXTRA_CODEQL_PACK_ROOTS or [])
+    except ImportError:
+        return False
+    if not extras:
+        return False
+    try:
+        target = Path(query_path).resolve()
+    except (OSError, RuntimeError):
+        return False
+    for root in extras:
+        try:
+            if target.is_relative_to(Path(root).resolve()):
+                return True
+        except (OSError, RuntimeError):
+            continue
+    return False
 
 
 def _verdict_from_template(

--- a/packages/llm_analysis/tests/test_dataflow_validation.py
+++ b/packages/llm_analysis/tests/test_dataflow_validation.py
@@ -394,6 +394,46 @@ class TestTierSelection:
         adapter.run_prebuilt_query.assert_called_once()
         adapter.run.assert_called_once()
 
+    def test_extras_pack_no_matches_refutes_at_tier1(self, tmp_path, monkeypatch):
+        """When discovery returns an in-repo (extras) query and CodeQL
+        finds zero matches, Tier 1 refutes immediately — no Tier 2
+        fallthrough, no LLM call. This is the key PR-B behaviour: the
+        broader LocalFlowSource model rules out CLI / env / stdin
+        variants the stdlib query would have missed."""
+        from core.config import RaptorConfig
+        from packages.hypothesis_validation.adapters.base import ToolEvidence
+        h, f = self._make_hyp_and_finding()
+
+        # Build a fake extras-rooted query path
+        extras = tmp_path / "extras"
+        ql = extras / "python-queries" / "Security" / "CWE-078" / "CmdInjLocal.ql"
+        ql.parent.mkdir(parents=True)
+        ql.write_text("// stub")
+        monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [extras])
+
+        adapter = MagicMock()
+        adapter.run_prebuilt_query.return_value = ToolEvidence(
+            tool="codeql", rule=str(ql), success=True,
+            matches=[], summary="no matches",
+        )
+
+        # LLM must NOT be called — refutation short-circuits Tier 2
+        llm = MagicMock()
+        llm.generate_structured.side_effect = AssertionError(
+            "LLM was consulted despite Tier 1 refutation"
+        )
+
+        with patch(
+            "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
+            return_value=ql,
+        ):
+            result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+
+        assert tier == "prebuilt"
+        assert result.verdict == "refuted"
+        adapter.run_prebuilt_query.assert_called_once()
+        adapter.run.assert_not_called()
+
     def test_inferred_cwe_picks_tier1_when_finding_lacks_cwe_id(self):
         """Findings without explicit cwe_id should still hit Tier 1 when
         the rule_id matches an inference pattern."""
@@ -571,14 +611,104 @@ class TestVerdictFromPrebuilt:
                           error="boom", matches=[])
         assert _verdict_from_prebuilt(ev, {"file_path": "x", "start_line": 1}) == "inconclusive"
 
-    def test_no_matches_inconclusive(self):
-        """Tier 1 cannot refute alone — its source model may not cover
-        the LLM's claim. No matches → inconclusive (caller falls through
-        to Tier 2 for refutation)."""
+    def test_no_matches_stdlib_path_inconclusive(self):
+        """Stdlib queries use RemoteFlowSource only; their source model
+        may not cover the LLM's claim. No matches → inconclusive (caller
+        falls through to Tier 2 for refutation)."""
         from packages.hypothesis_validation.adapters.base import ToolEvidence
         ev = ToolEvidence(tool="codeql", rule="r", success=True,
                           matches=[])
-        assert _verdict_from_prebuilt(ev, {"file_path": "x", "start_line": 1}) == "inconclusive"
+        # Stdlib path — falls outside any extras root
+        stdlib_path = Path("/home/me/.codeql/packages/codeql/python-queries/1.8.1/Security/CWE-078/CommandInjection.ql")
+        assert _verdict_from_prebuilt(
+            ev, {"file_path": "x", "start_line": 1}, stdlib_path,
+        ) == "inconclusive"
+
+    def test_no_matches_stdlib_path_inconclusive_no_path(self):
+        """Backwards-compat: callers that don't pass query_path get the
+        old asymmetric behaviour (no-match → inconclusive)."""
+        from packages.hypothesis_validation.adapters.base import ToolEvidence
+        ev = ToolEvidence(tool="codeql", rule="r", success=True, matches=[])
+        assert _verdict_from_prebuilt(
+            ev, {"file_path": "x", "start_line": 1},
+        ) == "inconclusive"
+
+    def test_no_matches_extras_path_refutes(self, tmp_path, monkeypatch):
+        """When the discovered query lives under an in-repo extras pack
+        (LocalFlowSource coverage), no-match IS a refutation signal —
+        the broader source model rules out CLI / env / stdin variants
+        that the stdlib query would miss."""
+        from core.config import RaptorConfig
+        from packages.hypothesis_validation.adapters.base import ToolEvidence
+        # Synthetic extras root with a query path under it
+        extras = tmp_path / "raptor-packs"
+        ql = extras / "python-queries" / "Security" / "CWE-078" / "CmdInj.ql"
+        ql.parent.mkdir(parents=True)
+        ql.write_text("// stub")
+
+        monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [extras])
+
+        ev = ToolEvidence(tool="codeql", rule=str(ql), success=True, matches=[])
+        assert _verdict_from_prebuilt(
+            ev, {"file_path": "x.py", "start_line": 1}, ql,
+        ) == "refuted"
+
+    def test_no_matches_extras_path_no_extras_configured(self, monkeypatch):
+        """If extras is empty, even a path that LOOKS like it's under
+        an extras root falls back to inconclusive — without a configured
+        root we can't verify the query's source model is broad enough."""
+        from core.config import RaptorConfig
+        from packages.hypothesis_validation.adapters.base import ToolEvidence
+        monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [])
+        ev = ToolEvidence(tool="codeql", rule="r", success=True, matches=[])
+        assert _verdict_from_prebuilt(
+            ev, {"file_path": "x", "start_line": 1},
+            Path("/some/path/that/is/not/an/extras/root.ql"),
+        ) == "inconclusive"
+
+    def test_extras_path_with_matches_at_location_still_confirms(
+        self, tmp_path, monkeypatch,
+    ):
+        """The extras-path branch only flips no-match → refuted. When
+        matches DO exist at the finding location, the verdict is still
+        confirmed regardless of which pack the query came from."""
+        from core.config import RaptorConfig
+        from packages.hypothesis_validation.adapters.base import ToolEvidence
+        extras = tmp_path / "raptor-packs"
+        ql = extras / "python-queries" / "Security" / "CWE-078" / "CmdInj.ql"
+        ql.parent.mkdir(parents=True)
+        ql.write_text("// stub")
+        monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [extras])
+
+        ev = ToolEvidence(
+            tool="codeql", rule=str(ql), success=True,
+            matches=[{"file": "x.py", "line": 10}],
+        )
+        assert _verdict_from_prebuilt(
+            ev, {"file_path": "x.py", "start_line": 10}, ql,
+        ) == "confirmed"
+
+    def test_extras_path_with_matches_elsewhere_inconclusive(
+        self, tmp_path, monkeypatch,
+    ):
+        """Matches exist somewhere but not at the finding's location →
+        inconclusive. The matches-elsewhere case is NOT refutation; the
+        query may have caught a sibling flow."""
+        from core.config import RaptorConfig
+        from packages.hypothesis_validation.adapters.base import ToolEvidence
+        extras = tmp_path / "raptor-packs"
+        ql = extras / "python-queries" / "Security" / "CWE-078" / "CmdInj.ql"
+        ql.parent.mkdir(parents=True)
+        ql.write_text("// stub")
+        monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [extras])
+
+        ev = ToolEvidence(
+            tool="codeql", rule=str(ql), success=True,
+            matches=[{"file": "other.py", "line": 99}],
+        )
+        assert _verdict_from_prebuilt(
+            ev, {"file_path": "x.py", "start_line": 10}, ql,
+        ) == "inconclusive"
 
     def test_match_at_location_confirms(self):
         from packages.hypothesis_validation.adapters.base import ToolEvidence


### PR DESCRIPTION
PR-A's LocalFlowSource library covers remote + commandargs + environment
+ stdin + file threat models — broad enough that no-match against an in-repo extras query is meaningful refutation. Stdlib RemoteFlowSource queries still need the asymmetric "no-match → inconclusive" treatment because their source model excludes CLI / env / stdin variants the LLM's claim might describe.

_verdict_from_prebuilt now takes the resolved query path and refutes on no-match when the path is under any RaptorConfig.EXTRA_CODEQL_PACK_ROOTS entry. Stdlib paths keep current behaviour. Tier 1 short-circuits on refuted as well as confirmed, saving a Tier 2 LLM call when the broader source model has already ruled the claim out.

Empirical (real CodeQL on tests/fixtures/iris_e2e/):
  Real Flask CWE-78 finding              → confirmed (unchanged)
  sys.argv → subprocess.call flow        → confirmed (unchanged from PR-A)
  Hypothetical SQL claim, no SQL in tree → refuted  (PR-B; was inconclusive)

7 new tests (6 verdict cases + 1 tier-selection case proving the LLM is not called on Tier 1 refutation). 852 IRIS tests green.