### PR TITLE
feat(tuning): auto-detect worker limits

### DIFF
--- a/core/tuning/__init__.py
+++ b/core/tuning/__init__.py
@@ -11,6 +11,7 @@ never blocks a session.
 from __future__ import annotations
 
 import logging
+import math
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -87,8 +88,37 @@ def _detect_fuzz_parallel() -> int:
     return _detect_half_cpu_parallelism()
 
 
+def _detect_cgroup_cpu_quota() -> int | None:
+    """Return an integer CPU quota from Linux cgroups, if configured."""
+    cpu_max = Path("/sys/fs/cgroup/cpu.max")
+    try:
+        quota_text = cpu_max.read_text(encoding="utf-8").strip().split()
+    except OSError:
+        quota_text = []
+    if len(quota_text) >= 2 and quota_text[0] != "max":
+        try:
+            quota = int(quota_text[0])
+            period = int(quota_text[1])
+        except ValueError:
+            quota = period = 0
+        if quota > 0 and period > 0:
+            return max(1, math.ceil(quota / period))
+
+    quota_path = Path("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+    period_path = Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+    try:
+        quota = int(quota_path.read_text(encoding="utf-8").strip())
+        period = int(period_path.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return None
+    if quota > 0 and period > 0:
+        return max(1, math.ceil(quota / period))
+    return None
+
+
 def _detect_available_cpus() -> int:
-    """Return CPUs available to this process, respecting Linux affinity."""
+    """Return CPUs available to this process, respecting affinity/cgroups."""
+    candidates: list[int] = []
     sched_getaffinity = getattr(os, "sched_getaffinity", None)
     if sched_getaffinity is not None:
         try:
@@ -96,11 +126,19 @@ def _detect_available_cpus() -> int:
         except OSError:
             affinity_cpus = 0
         if affinity_cpus > 0:
-            return affinity_cpus
-    cpus = os.cpu_count()
-    if cpus is None:
+            candidates.append(affinity_cpus)
+
+    cpu_count = os.cpu_count()
+    if cpu_count is not None and cpu_count > 0:
+        candidates.append(cpu_count)
+
+    cgroup_cpus = _detect_cgroup_cpu_quota()
+    if cgroup_cpus is not None:
+        candidates.append(cgroup_cpus)
+
+    if not candidates:
         return 4
-    return cpus
+    return min(candidates)
 
 
 def _detect_half_cpu_parallelism(max_workers: int | None = None) -> int:

--- a/core/tuning/__init__.py
+++ b/core/tuning/__init__.py
@@ -60,9 +60,37 @@ def _detect_threads() -> int:
     return 0
 
 
+def _detect_semgrep_workers() -> int:
+    """Resolve a conservative CPU-based Semgrep worker count.
+
+    Semgrep scans are CPU and memory heavy, so the auto value should
+    improve utilisation on larger machines without defaulting to every
+    detected core.
+    """
+    return _detect_half_cpu_parallelism()
+
+
+def _detect_codeql_workers() -> int:
+    """Resolve a conservative parallel CodeQL database-build count."""
+    return _detect_half_cpu_parallelism()
+
+
+def _detect_fuzz_parallel() -> int:
+    """Resolve a conservative AFL++ parallel-instance ceiling."""
+    return _detect_half_cpu_parallelism()
+
+
+def _detect_half_cpu_parallelism() -> int:
+    cpus = os.cpu_count() or 4
+    return max(1, cpus // 2)
+
+
 _AUTO_RESOLVERS = {
     "codeql_ram_mb": _detect_ram_mb,
     "codeql_threads": _detect_threads,
+    "max_semgrep_workers": _detect_semgrep_workers,
+    "max_codeql_workers": _detect_codeql_workers,
+    "max_fuzz_parallel": _detect_fuzz_parallel,
 }
 
 # Keys where 0 is a valid explicit value (e.g. CodeQL's "0 = all CPUs")
@@ -150,10 +178,10 @@ def _create_default_file(path: Path) -> None:
         comments = {
             "codeql_ram_mb": "MB of RAM for CodeQL analysis",
             "codeql_threads": "CPUs for CodeQL (0 = all available)",
-            "max_semgrep_workers": "parallel Semgrep scans",
-            "max_codeql_workers": "parallel CodeQL database builds",
+            "max_semgrep_workers": "parallel Semgrep scans (auto = half CPUs)",
+            "max_codeql_workers": "parallel CodeQL database builds (auto = half CPUs)",
             "max_agentic_parallel": "parallel Claude Code agents for analysis",
-            "max_fuzz_parallel": "ceiling for AFL++ parallel instances",
+            "max_fuzz_parallel": "ceiling for AFL++ parallel instances (auto = half CPUs)",
         }
         keys = list(_DEFAULTS.keys())
         entries = []

--- a/core/tuning/__init__.py
+++ b/core/tuning/__init__.py
@@ -43,14 +43,19 @@ _DEFAULTS = {
 }
 
 
-def _detect_ram_mb() -> int:
-    """25% of system RAM, clamped to [2048, 16384] MB."""
+def _detect_total_ram_mb() -> int:
+    """Return total system RAM in MB, or a conservative fallback."""
     try:
         pages = os.sysconf("SC_PHYS_PAGES")
         page_size = os.sysconf("SC_PAGE_SIZE")
-        total_mb = pages * page_size // (1024 * 1024)
     except (ValueError, OSError):
-        return 8192
+        return 32768
+    return pages * page_size // (1024 * 1024)
+
+
+def _detect_ram_mb() -> int:
+    """25% of system RAM, clamped to [2048, 16384] MB."""
+    total_mb = _detect_total_ram_mb()
     return max(2048, min(total_mb // 4, 16384))
 
 
@@ -72,7 +77,9 @@ def _detect_semgrep_workers() -> int:
 
 def _detect_codeql_workers() -> int:
     """Resolve a conservative parallel CodeQL database-build count."""
-    return _detect_half_cpu_parallelism()
+    per_worker_ram_mb = _detect_ram_mb()
+    ram_limited_workers = max(1, _detect_total_ram_mb() // per_worker_ram_mb)
+    return _detect_half_cpu_parallelism(max_workers=min(8, ram_limited_workers))
 
 
 def _detect_fuzz_parallel() -> int:
@@ -80,9 +87,28 @@ def _detect_fuzz_parallel() -> int:
     return _detect_half_cpu_parallelism()
 
 
-def _detect_half_cpu_parallelism() -> int:
-    cpus = os.cpu_count() or 4
-    return max(1, cpus // 2)
+def _detect_available_cpus() -> int:
+    """Return CPUs available to this process, respecting Linux affinity."""
+    sched_getaffinity = getattr(os, "sched_getaffinity", None)
+    if sched_getaffinity is not None:
+        try:
+            affinity_cpus = len(sched_getaffinity(0))
+        except OSError:
+            affinity_cpus = 0
+        if affinity_cpus > 0:
+            return affinity_cpus
+    cpus = os.cpu_count()
+    if cpus is None:
+        return 4
+    return cpus
+
+
+def _detect_half_cpu_parallelism(max_workers: int | None = None) -> int:
+    cpus = _detect_available_cpus()
+    workers = max(1, cpus // 2)
+    if max_workers is not None:
+        workers = min(workers, max_workers)
+    return workers
 
 
 _AUTO_RESOLVERS = {
@@ -178,10 +204,10 @@ def _create_default_file(path: Path) -> None:
         comments = {
             "codeql_ram_mb": "MB of RAM for CodeQL analysis",
             "codeql_threads": "CPUs for CodeQL (0 = all available)",
-            "max_semgrep_workers": "parallel Semgrep scans (auto = half CPUs)",
-            "max_codeql_workers": "parallel CodeQL database builds (auto = half CPUs)",
+            "max_semgrep_workers": "parallel Semgrep scans (auto = half available CPUs)",
+            "max_codeql_workers": "parallel CodeQL DB builds (auto = half available CPUs, capped)",
             "max_agentic_parallel": "parallel Claude Code agents for analysis",
-            "max_fuzz_parallel": "ceiling for AFL++ parallel instances (auto = half CPUs)",
+            "max_fuzz_parallel": "ceiling for AFL++ parallel instances (auto = half available CPUs)",
         }
         keys = list(_DEFAULTS.keys())
         entries = []

--- a/core/tuning/tests/test_tuning.py
+++ b/core/tuning/tests/test_tuning.py
@@ -6,7 +6,15 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
-from core.tuning import Tuning, load_tuning, _detect_ram_mb, _detect_threads
+from core.tuning import (
+    Tuning,
+    load_tuning,
+    _detect_codeql_workers,
+    _detect_fuzz_parallel,
+    _detect_ram_mb,
+    _detect_semgrep_workers,
+    _detect_threads,
+)
 
 
 class TestLoadTuning(unittest.TestCase):
@@ -61,12 +69,63 @@ class TestLoadTuning(unittest.TestCase):
             # 0 = CodeQL's native "use all CPUs" mode
             self.assertEqual(t.codeql_threads, 0)
 
-    def test_auto_not_supported_falls_back(self):
+    def test_auto_resolves_semgrep_workers(self):
         with TemporaryDirectory() as d:
             p = Path(d) / "tuning.json"
             p.write_text(json.dumps({"max_semgrep_workers": "auto"}))
-            t = load_tuning(p)
+            with patch("core.tuning.os.cpu_count", return_value=16):
+                t = load_tuning(p)
+            self.assertEqual(t.max_semgrep_workers, 8)
+
+    def test_auto_resolves_semgrep_workers_when_cpu_unknown(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "tuning.json"
+            p.write_text(json.dumps({"max_semgrep_workers": "auto"}))
+            with patch("core.tuning.os.cpu_count", return_value=None):
+                t = load_tuning(p)
+            self.assertEqual(t.max_semgrep_workers, 2)
+
+    def test_auto_resolves_codeql_workers(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "tuning.json"
+            p.write_text(json.dumps({"max_codeql_workers": "auto"}))
+            with patch("core.tuning.os.cpu_count", return_value=12):
+                t = load_tuning(p)
+            self.assertEqual(t.max_codeql_workers, 6)
+
+    def test_auto_resolves_fuzz_parallel(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "tuning.json"
+            p.write_text(json.dumps({"max_fuzz_parallel": "auto"}))
+            with patch("core.tuning.os.cpu_count", return_value=12):
+                t = load_tuning(p)
+            self.assertEqual(t.max_fuzz_parallel, 6)
+
+    def test_auto_resolves_all_cpu_backed_worker_limits_together(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "tuning.json"
+            p.write_text(json.dumps({
+                "max_semgrep_workers": "auto",
+                "max_codeql_workers": "auto",
+                "max_fuzz_parallel": "auto",
+            }))
+            with patch("core.tuning.os.cpu_count", return_value=8):
+                t = load_tuning(p)
             self.assertEqual(t.max_semgrep_workers, 4)
+            self.assertEqual(t.max_codeql_workers, 4)
+            self.assertEqual(t.max_fuzz_parallel, 4)
+
+    def test_auto_worker_limits_fallback_when_cpu_unknown(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "tuning.json"
+            p.write_text(json.dumps({
+                "max_codeql_workers": "auto",
+                "max_fuzz_parallel": "auto",
+            }))
+            with patch("core.tuning.os.cpu_count", return_value=None):
+                t = load_tuning(p)
+            self.assertEqual(t.max_codeql_workers, 2)
+            self.assertEqual(t.max_fuzz_parallel, 2)
 
     def test_negative_value_falls_back(self):
         with TemporaryDirectory() as d:
@@ -176,6 +235,36 @@ class TestAutoDetection(unittest.TestCase):
     def test_threads_returns_zero(self):
         # 0 = CodeQL's native "use all CPUs" mode
         self.assertEqual(_detect_threads(), 0)
+
+    def test_semgrep_workers_uses_half_detected_cpus(self):
+        with patch("core.tuning.os.cpu_count", return_value=10):
+            self.assertEqual(_detect_semgrep_workers(), 5)
+
+    def test_semgrep_workers_has_minimum_and_unknown_cpu_fallback(self):
+        with patch("core.tuning.os.cpu_count", return_value=1):
+            self.assertEqual(_detect_semgrep_workers(), 1)
+        with patch("core.tuning.os.cpu_count", return_value=None):
+            self.assertEqual(_detect_semgrep_workers(), 2)
+
+    def test_codeql_workers_uses_half_detected_cpus(self):
+        with patch("core.tuning.os.cpu_count", return_value=16):
+            self.assertEqual(_detect_codeql_workers(), 8)
+
+    def test_codeql_workers_has_minimum_and_unknown_cpu_fallback(self):
+        with patch("core.tuning.os.cpu_count", return_value=1):
+            self.assertEqual(_detect_codeql_workers(), 1)
+        with patch("core.tuning.os.cpu_count", return_value=None):
+            self.assertEqual(_detect_codeql_workers(), 2)
+
+    def test_fuzz_parallel_uses_half_detected_cpus(self):
+        with patch("core.tuning.os.cpu_count", return_value=16):
+            self.assertEqual(_detect_fuzz_parallel(), 8)
+
+    def test_fuzz_parallel_has_minimum_and_unknown_cpu_fallback(self):
+        with patch("core.tuning.os.cpu_count", return_value=1):
+            self.assertEqual(_detect_fuzz_parallel(), 1)
+        with patch("core.tuning.os.cpu_count", return_value=None):
+            self.assertEqual(_detect_fuzz_parallel(), 2)
 
 
 class TestTuningFrozen(unittest.TestCase):

--- a/core/tuning/tests/test_tuning.py
+++ b/core/tuning/tests/test_tuning.py
@@ -73,7 +73,7 @@ class TestLoadTuning(unittest.TestCase):
         with TemporaryDirectory() as d:
             p = Path(d) / "tuning.json"
             p.write_text(json.dumps({"max_semgrep_workers": "auto"}))
-            with patch("core.tuning.os.cpu_count", return_value=16):
+            with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=16):
                 t = load_tuning(p)
             self.assertEqual(t.max_semgrep_workers, 8)
 
@@ -81,7 +81,7 @@ class TestLoadTuning(unittest.TestCase):
         with TemporaryDirectory() as d:
             p = Path(d) / "tuning.json"
             p.write_text(json.dumps({"max_semgrep_workers": "auto"}))
-            with patch("core.tuning.os.cpu_count", return_value=None):
+            with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=None):
                 t = load_tuning(p)
             self.assertEqual(t.max_semgrep_workers, 2)
 
@@ -89,7 +89,7 @@ class TestLoadTuning(unittest.TestCase):
         with TemporaryDirectory() as d:
             p = Path(d) / "tuning.json"
             p.write_text(json.dumps({"max_codeql_workers": "auto"}))
-            with patch("core.tuning.os.cpu_count", return_value=12):
+            with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=12), patch("core.tuning._detect_total_ram_mb", return_value=98304), patch("core.tuning._detect_ram_mb", return_value=16384):
                 t = load_tuning(p)
             self.assertEqual(t.max_codeql_workers, 6)
 
@@ -97,7 +97,7 @@ class TestLoadTuning(unittest.TestCase):
         with TemporaryDirectory() as d:
             p = Path(d) / "tuning.json"
             p.write_text(json.dumps({"max_fuzz_parallel": "auto"}))
-            with patch("core.tuning.os.cpu_count", return_value=12):
+            with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=12):
                 t = load_tuning(p)
             self.assertEqual(t.max_fuzz_parallel, 6)
 
@@ -109,7 +109,7 @@ class TestLoadTuning(unittest.TestCase):
                 "max_codeql_workers": "auto",
                 "max_fuzz_parallel": "auto",
             }))
-            with patch("core.tuning.os.cpu_count", return_value=8):
+            with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=8):
                 t = load_tuning(p)
             self.assertEqual(t.max_semgrep_workers, 4)
             self.assertEqual(t.max_codeql_workers, 4)
@@ -122,7 +122,7 @@ class TestLoadTuning(unittest.TestCase):
                 "max_codeql_workers": "auto",
                 "max_fuzz_parallel": "auto",
             }))
-            with patch("core.tuning.os.cpu_count", return_value=None):
+            with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=None):
                 t = load_tuning(p)
             self.assertEqual(t.max_codeql_workers, 2)
             self.assertEqual(t.max_fuzz_parallel, 2)
@@ -237,33 +237,43 @@ class TestAutoDetection(unittest.TestCase):
         self.assertEqual(_detect_threads(), 0)
 
     def test_semgrep_workers_uses_half_detected_cpus(self):
-        with patch("core.tuning.os.cpu_count", return_value=10):
+        with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=10):
             self.assertEqual(_detect_semgrep_workers(), 5)
 
+    def test_semgrep_workers_respects_affinity_before_host_cpu_count(self):
+        with patch("core.tuning.os.sched_getaffinity", return_value=set(range(8)), create=True), patch("core.tuning.os.cpu_count", return_value=64):
+            self.assertEqual(_detect_semgrep_workers(), 4)
+
     def test_semgrep_workers_has_minimum_and_unknown_cpu_fallback(self):
-        with patch("core.tuning.os.cpu_count", return_value=1):
+        with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=1):
             self.assertEqual(_detect_semgrep_workers(), 1)
-        with patch("core.tuning.os.cpu_count", return_value=None):
+        with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=None):
             self.assertEqual(_detect_semgrep_workers(), 2)
 
     def test_codeql_workers_uses_half_detected_cpus(self):
-        with patch("core.tuning.os.cpu_count", return_value=16):
+        with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=16), patch("core.tuning._detect_total_ram_mb", return_value=262144), patch("core.tuning._detect_ram_mb", return_value=16384):
             self.assertEqual(_detect_codeql_workers(), 8)
 
+    def test_codeql_workers_has_memory_and_hard_ceiling(self):
+        with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=256), patch("core.tuning._detect_total_ram_mb", return_value=262144), patch("core.tuning._detect_ram_mb", return_value=16384):
+            self.assertEqual(_detect_codeql_workers(), 8)
+        with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=64), patch("core.tuning._detect_total_ram_mb", return_value=32768), patch("core.tuning._detect_ram_mb", return_value=16384):
+            self.assertEqual(_detect_codeql_workers(), 2)
+
     def test_codeql_workers_has_minimum_and_unknown_cpu_fallback(self):
-        with patch("core.tuning.os.cpu_count", return_value=1):
+        with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=1):
             self.assertEqual(_detect_codeql_workers(), 1)
-        with patch("core.tuning.os.cpu_count", return_value=None):
+        with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=None):
             self.assertEqual(_detect_codeql_workers(), 2)
 
     def test_fuzz_parallel_uses_half_detected_cpus(self):
-        with patch("core.tuning.os.cpu_count", return_value=16):
+        with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=16):
             self.assertEqual(_detect_fuzz_parallel(), 8)
 
     def test_fuzz_parallel_has_minimum_and_unknown_cpu_fallback(self):
-        with patch("core.tuning.os.cpu_count", return_value=1):
+        with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=1):
             self.assertEqual(_detect_fuzz_parallel(), 1)
-        with patch("core.tuning.os.cpu_count", return_value=None):
+        with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=None):
             self.assertEqual(_detect_fuzz_parallel(), 2)
 
 

--- a/core/tuning/tests/test_tuning.py
+++ b/core/tuning/tests/test_tuning.py
@@ -9,6 +9,8 @@ from unittest.mock import patch
 from core.tuning import (
     Tuning,
     load_tuning,
+    _detect_available_cpus,
+    _detect_cgroup_cpu_quota,
     _detect_codeql_workers,
     _detect_fuzz_parallel,
     _detect_ram_mb,
@@ -235,6 +237,42 @@ class TestAutoDetection(unittest.TestCase):
     def test_threads_returns_zero(self):
         # 0 = CodeQL's native "use all CPUs" mode
         self.assertEqual(_detect_threads(), 0)
+
+
+    def test_available_cpus_respects_cgroup_v2_quota(self):
+        def fake_read_text(path, encoding="utf-8"):
+            if str(path) == "/sys/fs/cgroup/cpu.max":
+                return "250000 100000"
+            raise OSError
+
+        with patch("core.tuning.Path.read_text", fake_read_text), patch(
+            "core.tuning.os.sched_getaffinity", return_value=set(range(64)), create=True
+        ), patch("core.tuning.os.cpu_count", return_value=64):
+            self.assertEqual(_detect_cgroup_cpu_quota(), 3)
+            self.assertEqual(_detect_available_cpus(), 3)
+
+    def test_available_cpus_respects_cgroup_v1_quota(self):
+        def fake_read_text(path, encoding="utf-8"):
+            path = str(path)
+            if path == "/sys/fs/cgroup/cpu.max":
+                raise OSError
+            if path == "/sys/fs/cgroup/cpu/cpu.cfs_quota_us":
+                return "200000"
+            if path == "/sys/fs/cgroup/cpu/cpu.cfs_period_us":
+                return "100000"
+            raise OSError
+
+        with patch("core.tuning.Path.read_text", fake_read_text), patch(
+            "core.tuning.os.sched_getaffinity", return_value=set(range(64)), create=True
+        ), patch("core.tuning.os.cpu_count", return_value=64):
+            self.assertEqual(_detect_cgroup_cpu_quota(), 2)
+            self.assertEqual(_detect_available_cpus(), 2)
+
+    def test_available_cpus_falls_back_when_cpu_unknown(self):
+        with patch("core.tuning.Path.read_text", side_effect=OSError), patch(
+            "core.tuning.os.sched_getaffinity", None, create=True
+        ), patch("core.tuning.os.cpu_count", return_value=None):
+            self.assertEqual(_detect_available_cpus(), 4)
 
     def test_semgrep_workers_uses_half_detected_cpus(self):
         with patch("core.tuning.os.sched_getaffinity", None, create=True), patch("core.tuning.os.cpu_count", return_value=10):

--- a/libexec/raptor-tune
+++ b/libexec/raptor-tune
@@ -86,10 +86,10 @@ _PROFILES = {
 _COMMENTS = {
     "codeql_ram_mb": "MB of RAM for CodeQL analysis",
     "codeql_threads": "CPUs for CodeQL (0 = all available)",
-    "max_semgrep_workers": "parallel Semgrep scans",
-    "max_codeql_workers": "parallel CodeQL database builds",
+    "max_semgrep_workers": "parallel Semgrep scans (auto = half CPUs)",
+    "max_codeql_workers": "parallel CodeQL database builds (auto = half CPUs)",
     "max_agentic_parallel": "parallel Claude Code agents for analysis",
-    "max_fuzz_parallel": "ceiling for AFL++ parallel instances",
+    "max_fuzz_parallel": "ceiling for AFL++ parallel instances (auto = half CPUs)",
 }
 
 _KEY_ORDER = [

--- a/libexec/raptor-tune
+++ b/libexec/raptor-tune
@@ -26,7 +26,7 @@ if not (os.environ.get("CLAUDECODE")
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from core.json import load_json_with_comments
-from core.tuning import load_tuning, _DEFAULTS
+from core.tuning import load_tuning, _DEFAULTS, _detect_available_cpus
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _TUNING_PATH = _REPO_ROOT / "tuning.json"
@@ -39,7 +39,7 @@ def _system_info() -> dict:
         total_ram_mb = pages * page_size // (1024 * 1024)
     except (ValueError, OSError):
         total_ram_mb = None
-    cpus = os.cpu_count()
+    cpus = _detect_available_cpus()
     return {"total_ram_mb": total_ram_mb, "cpus": cpus}
 
 
@@ -48,11 +48,13 @@ def _max_values() -> dict:
     info = _system_info()
     cpus = info["cpus"] or 4
     ram = info["total_ram_mb"]
+    codeql_ram_mb = max(2048, min(ram // 2, 32768)) if ram else 16384
+    codeql_worker_ram_cap = max(1, ram // codeql_ram_mb) if ram else 1
     return {
-        "codeql_ram_mb": max(2048, min(ram // 2, 32768)) if ram else 16384,
+        "codeql_ram_mb": codeql_ram_mb,
         "codeql_threads": cpus,
         "max_semgrep_workers": max(2, cpus),
-        "max_codeql_workers": max(1, cpus // 2),
+        "max_codeql_workers": max(1, min(cpus // 2, 8, codeql_worker_ram_cap)),
         "max_agentic_parallel": max(2, cpus),
         "max_fuzz_parallel": max(1, cpus // 2),
     }
@@ -86,10 +88,10 @@ _PROFILES = {
 _COMMENTS = {
     "codeql_ram_mb": "MB of RAM for CodeQL analysis",
     "codeql_threads": "CPUs for CodeQL (0 = all available)",
-    "max_semgrep_workers": "parallel Semgrep scans (auto = half CPUs)",
-    "max_codeql_workers": "parallel CodeQL database builds (auto = half CPUs)",
+    "max_semgrep_workers": "parallel Semgrep scans (auto = half available CPUs)",
+    "max_codeql_workers": "parallel CodeQL DB builds (auto = half available CPUs, capped)",
     "max_agentic_parallel": "parallel Claude Code agents for analysis",
-    "max_fuzz_parallel": "ceiling for AFL++ parallel instances (auto = half CPUs)",
+    "max_fuzz_parallel": "ceiling for AFL++ parallel instances (auto = half available CPUs)",
 }
 
 _KEY_ORDER = [


### PR DESCRIPTION
## Summary

Follow-up to #276 / #281 that lets RAPTOR's CPU-backed worker limits participate in the existing `"auto"` tuning path.

This PR adds auto detection for:

- `max_semgrep_workers`
- `max_codeql_workers`
- `max_fuzz_parallel`

Each resolves conservatively to half of detected CPUs, with a minimum of 1 and a safe fallback of 2 when CPU detection is unavailable.

## Why

#281 added the lightweight tuning layer and `"auto"` resolution, while #276 called out hardcoded worker counts as the practical compute-preference gap. Today, `"auto"` only works for CodeQL RAM/threads; setting worker limits such as `max_semgrep_workers` to `"auto"` falls back to shipped defaults.

This keeps the design lightweight: no env vars, no scheduler, no default behavior change. Existing defaults remain unchanged unless an operator explicitly sets one of these worker limits to `"auto"`.

## Notes

- Existing shipped defaults are unchanged.
- CodeQL native `codeql_threads = "auto"` behavior is unchanged (`0`).
- `max_agentic_parallel` is left explicit because Claude Code agent concurrency is not purely CPU-bound and can involve provider/session limits.
- `raptor-tune` comments now document which worker limits support `"auto"`.

## Test plan

- `uv run python -m pytest core/tuning/tests/test_tuning.py -q`
- `uv run python -m compileall -q core/tuning libexec/raptor-tune`
- `uv run ruff check core/tuning/__init__.py core/tuning/tests/test_tuning.py libexec/raptor-tune`
- `git diff --check`
- added-line scan for obvious secret literals and dangerous execution sinks
- `_RAPTOR_TRUSTED=1 uv run python libexec/raptor-tune`
