### PR TITLE
feat(agentic): operator UX retrofit — --verbose + per-model failure attribution

### DIFF
--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -812,6 +812,7 @@ def orchestrate(
         "findings_dispatched": len(findings),
         "findings_analysed": sum(1 for r in per_finding_results if "error" not in r),
         "findings_failed": sum(1 for r in per_finding_results if "error" in r),
+        "failed_by_model": _per_model_failure_summary(analysis_results),
         "structural_groups": len(groups),
         "cross_family_checked": cross_family_checked,
         "cross_family_disputes": cross_family_disputes,
@@ -1028,6 +1029,33 @@ def _build_aggregation_payload(
         "unique_insights": (correlation or {}).get("unique_insights", [])[:20],
         "findings": findings,
     }
+
+
+def _per_model_failure_summary(
+    analysis_results: List[Dict],
+) -> Dict[str, Dict[str, Any]]:
+    """Aggregate per-model failures from a flat analysis_results list.
+
+    /agentic dispatches analysis as (model × finding) work items. When
+    a model fails on a finding, the result has an ``"error"`` key plus
+    ``analysed_by`` identifying the model. Operators currently see only
+    a flat ``findings_failed`` count — they can't tell whether one
+    model failed on every finding or every model failed on one finding.
+
+    Returns ``{model_name: {count: N, first_error: "..."}}``. Empty
+    when no errors. ``first_error`` truncated to 200 chars to avoid
+    bloating the JSON report.
+    """
+    by_model: Dict[str, Dict[str, Any]] = {}
+    for r in analysis_results:
+        if not isinstance(r, dict) or "error" not in r:
+            continue
+        model = r.get("analysed_by") or "?"
+        entry = by_model.setdefault(model, {"count": 0, "first_error": None})
+        entry["count"] += 1
+        if entry["first_error"] is None:
+            entry["first_error"] = str(r["error"])[:200]
+    return by_model
 
 
 def _detect_multi_model_collapse(

--- a/packages/llm_analysis/tests/test_per_model_failure_summary.py
+++ b/packages/llm_analysis/tests/test_per_model_failure_summary.py
@@ -1,0 +1,98 @@
+"""Tests for _per_model_failure_summary — operator-visibility helper
+that surfaces which model failed on which finding(s)."""
+
+from __future__ import annotations
+
+from packages.llm_analysis.orchestrator import _per_model_failure_summary
+
+
+class TestEmptyAndNoErrors:
+    def test_empty_input(self):
+        assert _per_model_failure_summary([]) == {}
+
+    def test_all_successes(self):
+        results = [
+            {"finding_id": "f1", "analysed_by": "pro", "is_exploitable": True},
+            {"finding_id": "f2", "analysed_by": "flash", "is_exploitable": False},
+        ]
+        assert _per_model_failure_summary(results) == {}
+
+
+class TestSingleModelErrors:
+    def test_one_error_one_model(self):
+        results = [
+            {"finding_id": "f1", "analysed_by": "pro", "error": "rate limit"},
+        ]
+        out = _per_model_failure_summary(results)
+        assert out == {"pro": {"count": 1, "first_error": "rate limit"}}
+
+    def test_multiple_errors_same_model(self):
+        results = [
+            {"finding_id": "f1", "analysed_by": "pro", "error": "first error"},
+            {"finding_id": "f2", "analysed_by": "pro", "error": "second error"},
+            {"finding_id": "f3", "analysed_by": "pro", "error": "third error"},
+        ]
+        out = _per_model_failure_summary(results)
+        assert out == {"pro": {"count": 3, "first_error": "first error"}}
+
+
+class TestMultiModelErrors:
+    def test_per_model_attribution(self):
+        results = [
+            {"finding_id": "f1", "analysed_by": "pro", "error": "pro fail 1"},
+            {"finding_id": "f1", "analysed_by": "flash", "error": "flash fail 1"},
+            {"finding_id": "f2", "analysed_by": "pro", "error": "pro fail 2"},
+        ]
+        out = _per_model_failure_summary(results)
+        assert out == {
+            "pro": {"count": 2, "first_error": "pro fail 1"},
+            "flash": {"count": 1, "first_error": "flash fail 1"},
+        }
+
+
+class TestMixedSuccessFailure:
+    def test_only_failures_aggregated(self):
+        results = [
+            {"finding_id": "f1", "analysed_by": "pro", "is_exploitable": True},
+            {"finding_id": "f2", "analysed_by": "pro", "error": "fail"},
+            {"finding_id": "f3", "analysed_by": "flash", "is_exploitable": False},
+        ]
+        out = _per_model_failure_summary(results)
+        assert out == {"pro": {"count": 1, "first_error": "fail"}}
+
+
+class TestEdgeCases:
+    def test_missing_analysed_by_grouped_under_question_mark(self):
+        # Result with no analysed_by — group under "?" so operator
+        # at least sees something failed unattributable.
+        results = [
+            {"finding_id": "f1", "error": "early failure"},
+        ]
+        out = _per_model_failure_summary(results)
+        assert out == {"?": {"count": 1, "first_error": "early failure"}}
+
+    def test_empty_analysed_by_grouped_under_question_mark(self):
+        results = [
+            {"finding_id": "f1", "analysed_by": "", "error": "x"},
+        ]
+        out = _per_model_failure_summary(results)
+        assert out == {"?": {"count": 1, "first_error": "x"}}
+
+    def test_long_error_truncated(self):
+        long_err = "x" * 500
+        results = [{"analysed_by": "pro", "error": long_err}]
+        out = _per_model_failure_summary(results)
+        assert len(out["pro"]["first_error"]) == 200
+
+    def test_non_string_error_coerced_to_str(self):
+        results = [{"analysed_by": "pro", "error": {"code": 401, "msg": "auth"}}]
+        out = _per_model_failure_summary(results)
+        # str() of dict is fine; what matters is no crash
+        assert out["pro"]["count"] == 1
+        assert "401" in out["pro"]["first_error"]
+
+    def test_non_dict_entries_skipped(self):
+        # Defensive: malformed entries shouldn't crash
+        results = ["garbage", None, {"analysed_by": "pro", "error": "real"}]
+        out = _per_model_failure_summary(results)  # type: ignore[arg-type]
+        assert out == {"pro": {"count": 1, "first_error": "real"}}

--- a/packages/llm_analysis/tests/test_verbose_flag.py
+++ b/packages/llm_analysis/tests/test_verbose_flag.py
@@ -1,0 +1,70 @@
+"""Test for /agentic --verbose flag — bumps existing console
+StreamHandlers from INFO to DEBUG so per-LLM-call detail surfaces.
+
+The wiring lives at the top of raptor_agentic.py:main; we test the
+side effect (handler-level mutation) rather than driving full main().
+
+Note: logging.getLogger() handlers persist across pytest collection,
+so we test that the wiring snippet correctly mutates *whatever*
+StreamHandlers it finds, rather than asserting specific handler counts.
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+def _apply_verbose_wiring(log) -> None:
+    """Mirror the snippet at raptor_agentic.py:main when --verbose."""
+    for h in log.logger.handlers:
+        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler):
+            h.setLevel(logging.DEBUG)
+
+
+class TestVerboseWiring:
+    def test_verbose_bumps_console_streamhandlers_to_debug(self):
+        from core.logging import get_logger
+        log = get_logger()
+
+        # Force any console StreamHandlers back to INFO so we can see
+        # the wiring flip them.
+        for h in log.logger.handlers:
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler):
+                h.setLevel(logging.INFO)
+
+        _apply_verbose_wiring(log)
+
+        stream_handlers = [
+            h for h in log.logger.handlers
+            if isinstance(h, logging.StreamHandler)
+            and not isinstance(h, logging.FileHandler)
+        ]
+        assert stream_handlers, "expected at least one console StreamHandler"
+        for h in stream_handlers:
+            assert h.level == logging.DEBUG
+
+    def test_verbose_does_not_affect_file_handler(self):
+        from core.logging import get_logger
+        log = get_logger()
+        file_handlers = [
+            h for h in log.logger.handlers
+            if isinstance(h, logging.FileHandler)
+        ]
+        if not file_handlers:
+            # In some test envs no file handler is attached; nothing to assert.
+            return
+        before_levels = [h.level for h in file_handlers]
+
+        _apply_verbose_wiring(log)
+
+        after_levels = [h.level for h in file_handlers]
+        assert before_levels == after_levels
+
+    def test_verbose_idempotent(self):
+        from core.logging import get_logger
+        log = get_logger()
+        _apply_verbose_wiring(log)
+        _apply_verbose_wiring(log)  # second call is a no-op
+        for h in log.logger.handlers:
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler):
+                assert h.level == logging.DEBUG

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -218,6 +218,11 @@ Examples:
                         help="Run /validate on exploitable/high-confidence findings after analysis")
     parser.add_argument("--sequential", action="store_true",
                        help="Sequential analysis in Phase 3 instead of parallel Phase 4 orchestration")
+    parser.add_argument("--verbose", action="store_true",
+                       help="Drop console log level from INFO to DEBUG. "
+                            "Surfaces per-LLM-call detail (cache hits, retries, "
+                            "per-call cost/duration). Useful for debugging "
+                            "multi-model dispatches or schema validation failures.")
 
     parser.add_argument(
         "--accept-weakened-defenses",
@@ -296,6 +301,16 @@ Examples:
     add_cli_args(parser)
     args = parser.parse_args()
     apply_cli_args(args, parser=parser)
+
+    # --verbose: drop the existing console StreamHandler from INFO to
+    # DEBUG so per-LLM-call detail (cache hits, retries, per-call
+    # cost/duration) becomes visible. Doesn't change the file handler
+    # (already DEBUG) — only what the operator sees on stderr.
+    if getattr(args, "verbose", False):
+        import logging
+        for h in logger.logger.handlers:
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler):
+                h.setLevel(logging.DEBUG)
 
     # Propagate --trust-repo via a module-level flag in cc_trust so every
     # in-process trust check (this module, build_detector, ...) agrees.
@@ -1113,6 +1128,18 @@ Examples:
         if failed_count > 0:
             parts.append(f"{failed_count} failed")
         print(f"   ⚠️  {', '.join(parts)}")
+        # Per-model failure breakdown — operator can see which model
+        # failed and why (first error truncated to 200 chars).
+        if orchestration_result:
+            failed_by_model = (
+                orchestration_result.get("orchestration", {})
+                .get("failed_by_model", {})
+            )
+            for model, info in sorted(failed_by_model.items()):
+                first_err = info.get("first_error") or ""
+                err_snippet = (first_err[:120] + "...") if len(first_err) > 120 else first_err
+                print(f"     {model}: {info.get('count', 0)} error{'s' if info.get('count') != 1 else ''}"
+                      + (f" — {err_snippet}" if err_snippet else ""))
     if true_positives > 0 or false_positives > 0:
         print(f"   True positives: {true_positives}")
         if false_positives > 0:


### PR DESCRIPTION
Two operator-visibility improvements for /agentic that pair with the multi-model substrate landed in #302/#310.

--verbose flag (raptor_agentic.py): drops the existing console StreamHandler from INFO to DEBUG so per-LLM-call detail (cache hits, retries, per-call cost/duration) becomes visible without touching the file handler. Useful for debugging multi-model dispatch or schema validation failures.

Per-model failure attribution: orchestrator now exposes failed_by_model = {model: {count, first_error}} alongside the existing flat findings_failed count. /agentic's summary prints a per-model breakdown so operators can tell whether one model failed on every finding or every model failed on one finding — previously invisible.

14 tests added (11 for the helper, 3 for the verbose wiring). Existing 5895 tests still pass.