### PR TITLE
feat(iris): default Tier 1 on, --deep-validate gates Tier 2/3

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,21 @@
+# CodeQL configuration for GitHub code scanning.
+#
+# Test fixtures under packages/**/tests/fixtures/ are intentionally
+# vulnerable — they exist to validate RAPTOR's own dataflow validation
+# pipeline and exploit-feasibility analyses. Scanning them produces
+# alerts that look real but are by-design honeypots, drowning out
+# signal from actual code.
+#
+# Loaded automatically by GitHub's default CodeQL setup when present
+# at this path.
+name: RAPTOR CodeQL config
+
+paths-ignore:
+  # IRIS Tier 1 dataflow-validation fixtures (intentionally vulnerable
+  # Flask + sys.argv command-injection patterns; CodeQL flags them
+  # because they ARE vulnerable, by design).
+  - packages/llm_analysis/tests/fixtures/iris_e2e/**
+  # Generic test-fixture exclusion for any other deliberately-bad
+  # samples a future test adds.
+  - "**/tests/fixtures/**"
+  - "**/test_fixtures/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+# Replaces GitHub's default CodeQL setup (which doesn't honour
+# in-repo configs) with an advanced workflow that points at
+# .github/codeql/codeql-config.yml. The config excludes intentionally-
+# vulnerable test fixtures (e.g. tests/fixtures/iris_e2e/) which
+# would otherwise generate persistent alerts for code that exists to
+# validate RAPTOR's own dataflow analyses.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly run picks up new query versions even when there's no
+    # PR/push activity.
+    - cron: "27 4 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/packages/llm_analysis/dataflow_validation.py
+++ b/packages/llm_analysis/dataflow_validation.py
@@ -337,6 +337,7 @@ def validate_dataflow_claims(
     cost_tracker: Optional[Any] = None,
     budget_threshold: float = DEFAULT_BUDGET_THRESHOLD,
     progress_callback: Optional[Callable[[str], None]] = None,
+    deep_validate: bool = False,
 ) -> Dict[str, Any]:
     """Validate LLM dataflow claims via hypothesis_validation + CodeQL.
 
@@ -495,6 +496,7 @@ def validate_dataflow_claims(
         try:
             result, tier_used = _validate_one_hypothesis(
                 hypothesis, finding, adapter, llm_client,
+                deep_validate=deep_validate,
             )
         except Exception as e:  # never let a single validation crash the loop
             logger.warning(
@@ -629,14 +631,25 @@ def _validate_one_hypothesis(
     finding: Dict,
     adapter: Any,
     llm_client: Any,
+    *,
+    deep_validate: bool = False,
 ) -> "tuple[ValidationResult, str]":
     """Run a hypothesis through Tier 1 → Tier 2 → Tier 3 in order.
 
+    Args:
+        deep_validate: When False (default), Tier 2/3 LLM-backed predicate
+            generation is skipped — Tier 1's verdict is returned even if
+            inconclusive. Tier 1 is free (just CodeQL); Tier 2/3 burns
+            LLM tokens. Operators opt in via `--deep-validate` to spend
+            tokens trying to refute Tier 1-inconclusive findings.
+
     Returns (ValidationResult, tier_label). Tier label is one of:
-      "prebuilt"  — Tier 1 succeeded with a CodeQL stdlib Flow module
-      "template"  — Tier 2 succeeded with LLM-filled template (no retry needed)
-      "retry"     — Tier 3 succeeded after >=1 retry
-      "fallback"  — fell through to legacy generic validate() (last resort)
+      "prebuilt"               — Tier 1 produced a definitive verdict
+      "prebuilt-inconclusive"  — Tier 1 inconclusive, deep_validate=False
+                                 (no Tier 2 attempted)
+      "template"               — Tier 2 succeeded with LLM-filled template
+      "retry"                  — Tier 3 succeeded after >=1 retry
+      "fallback"               — fell through to legacy generic validate()
 
     The tier label is metric-only; the verdict is unchanged regardless.
     """
@@ -675,11 +688,31 @@ def _validate_one_hypothesis(
             if verdict in ("confirmed", "refuted"):
                 # Tier 1 produced a definitive answer. Done.
                 return _wrap_result(ev, verdict, tier="prebuilt"), "prebuilt"
-            # Otherwise (inconclusive), fall through to Tier 2 for a
-            # chance at refutation via LLM-customised predicates.
+            # Otherwise (inconclusive). When deep_validate=False, stop
+            # here and return the inconclusive Tier 1 result. The user
+            # didn't authorise spending LLM tokens on Tier 2 refinement;
+            # Tier 1's free signal is what they asked for.
+            if not deep_validate:
+                return (
+                    _wrap_result(ev, "inconclusive", tier="prebuilt"),
+                    "prebuilt-inconclusive",
+                )
+            # deep_validate=True: fall through to Tier 2 for a chance at
+            # refutation via LLM-customised predicates.
 
     # ----- Tier 2 + 3: language template + LLM-filled predicates +
     #                    compile-error retry -----
+    # Skip when deep_validate=False — Tier 2/3 are LLM-backed and the
+    # operator hasn't opted in to spending tokens.
+    if not deep_validate:
+        return (
+            ValidationResult(
+                verdict="inconclusive", evidence=[], iterations=0,
+                reasoning="deep_validate=False — Tier 2/3 skipped",
+            ),
+            "skipped-deep",
+        )
+
     if language and language in supported_languages_for_template():
         result, succeeded, retries = _try_template_with_retry(
             hypothesis, finding, adapter, llm_client, language,
@@ -1190,20 +1223,26 @@ def run_validation_pass(
     cross_family_resolver: Optional[Callable] = None,
     progress_callback: Optional[Callable[[str], None]] = None,
     budget_threshold: float = DEFAULT_BUDGET_THRESHOLD,
+    deep_validate: bool = False,
 ) -> Optional[Dict[str, Any]]:
     """Orchestrator-side hook: discover DB, pick model, run the pass.
 
-    Wraps the three steps the orchestrator needs to do for every
-    `--validate-dataflow` run:
+    Tier 1 (free, CodeQL-only) runs whenever a database is available.
+    Tier 2/3 (LLM-backed predicate generation) is gated on
+    `deep_validate=True` — operators opt in via `--deep-validate`.
 
-      1. Decide whether dispatch mode supports validation. We accept
-         external_llm, cc_dispatch, and cc_fallback. Anything else
+    Steps:
+
+      1. Decide whether dispatch mode supports validation. Accepts
+         external_llm, cc_dispatch, cc_fallback. Anything else
          (no-LLM mode, etc.) → return None.
       2. Discover a CodeQL database under `out_dir/codeql/`. None means
          no database was built this run; return None and log.
-      3. Pick the validation model. When the resolver is provided AND
-         we're in external_llm mode AND it returns a cross-family
-         option, prefer that. Otherwise fall back to `analysis_model`.
+      3. Pick the validation model (only consulted if deep_validate
+         opts the run into Tier 2/3). When `cross_family_resolver` is
+         provided AND we're in external_llm mode AND it returns a
+         cross-family option, prefer that. Otherwise fall back to
+         `analysis_model`.
       4. Build a DispatchClient and call `validate_dataflow_claims`.
 
     Returns the metrics dict from `validate_dataflow_claims`, or None
@@ -1256,6 +1295,7 @@ def run_validation_pass(
         cost_tracker=cost_tracker,
         budget_threshold=budget_threshold,
         progress_callback=progress_callback,
+        deep_validate=deep_validate,
     )
 
 

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -229,8 +229,9 @@ def orchestrate(
     llm_config: Optional[Any] = None,
     block_cc_dispatch: bool = False,
     accept_weakened_defenses: bool = False,
-    validate_dataflow: bool = False,
-    validation_budget_threshold: float = 0.60,
+    dataflow_validation_enabled: bool = True,
+    deep_validate: bool = False,
+    deep_validate_budget: float = 0.60,
 ) -> Optional[Dict[str, Any]]:
     """Orchestrate vulnerability analysis via external LLM or Claude Code.
 
@@ -567,7 +568,7 @@ def orchestrate(
     # For correlated-error reasons, the helper prefers a different model
     # family from the analysis model (cross-family) when one is available.
     validation_metrics: Optional[Dict[str, Any]] = None
-    if validate_dataflow:
+    if dataflow_validation_enabled:
         from packages.llm_analysis.dataflow_validation import run_validation_pass
         validation_metrics = run_validation_pass(
             findings=findings,
@@ -580,7 +581,8 @@ def orchestrate(
             dispatch_mode=dispatch_mode,
             cost_tracker=cost_tracker,
             cross_family_resolver=_resolve_cross_family_checker,
-            budget_threshold=validation_budget_threshold,
+            budget_threshold=deep_validate_budget,
+            deep_validate=deep_validate,
         )
         if validation_metrics is None:
             logger.info("dataflow validation skipped: mode/db unavailable")
@@ -742,7 +744,7 @@ def orchestrate(
     # across is_exploitable / cvss_score / severity.
     n_applied_downgrades = 0
     n_soft_downgrades = 0
-    if validate_dataflow:
+    if dataflow_validation_enabled:
         from packages.llm_analysis.dataflow_validation import (
             reconcile_dataflow_validation,
         )
@@ -761,7 +763,7 @@ def orchestrate(
     merged = _merge_results(report, per_finding_results,
                             no_exploits=no_exploits, no_patches=no_patches)
     merged["cross_finding_groups"] = groups
-    if validate_dataflow:
+    if dataflow_validation_enabled:
         merged["dataflow_validation"] = {
             **(validation_metrics or {}),
             "n_applied_downgrades": n_applied_downgrades,

--- a/packages/llm_analysis/tests/test_dataflow_validation.py
+++ b/packages/llm_analysis/tests/test_dataflow_validation.py
@@ -352,7 +352,9 @@ class TestTierSelection:
             "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
             return_value=self._FAKE_PREBUILT,
         ):
-            result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+            result, tier = _validate_one_hypothesis(
+                h, f, adapter, llm, deep_validate=True,
+            )
 
         assert tier == "template"
         assert result.verdict == "refuted"
@@ -386,7 +388,9 @@ class TestTierSelection:
             "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
             return_value=self._FAKE_PREBUILT,
         ):
-            result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+            result, tier = _validate_one_hypothesis(
+                h, f, adapter, llm, deep_validate=True,
+            )
 
         # Tier 2 confirmed via custom predicates that match the specific claim
         assert tier == "template"
@@ -497,7 +501,9 @@ class TestTierSelection:
             "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
             return_value=None,
         ):
-            result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+            result, tier = _validate_one_hypothesis(
+                h, f, adapter, llm, deep_validate=True,
+            )
 
         assert tier == "template"
         adapter.run_prebuilt_query.assert_not_called()
@@ -543,7 +549,9 @@ class TestTierSelection:
             "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
             return_value=None,
         ):
-            result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+            result, tier = _validate_one_hypothesis(
+                h, f, adapter, llm, deep_validate=True,
+            )
 
         assert tier == "retry"
         assert result.verdict == "confirmed"
@@ -573,7 +581,9 @@ class TestTierSelection:
             "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
             return_value=None,
         ):
-            result, tier = _validate_one_hypothesis(h, f, adapter, llm)
+            result, tier = _validate_one_hypothesis(
+                h, f, adapter, llm, deep_validate=True,
+            )
         # 1 initial + 2 retries = 3 attempts max
         assert adapter.run.call_count == 3
         assert result.verdict == "inconclusive"
@@ -599,7 +609,7 @@ class TestTierSelection:
             "packages.llm_analysis.dataflow_validation.discover_prebuilt_query",
             return_value=None,
         ):
-            _validate_one_hypothesis(h, f, adapter, llm)
+            _validate_one_hypothesis(h, f, adapter, llm, deep_validate=True)
         # Only 1 attempt — no retry on non-compile errors
         assert adapter.run.call_count == 1
 
@@ -1302,6 +1312,7 @@ class TestValidateDataflowClaims:
                 codeql_db=db,
                 repo_path=tmp_path,
                 llm_client=llm_client,
+                deep_validate=True,
             )
             assert m["n_validated"] == 1
             assert m["n_eligible"] == 1
@@ -1356,6 +1367,7 @@ class TestValidateDataflowClaims:
                 codeql_db=db,
                 repo_path=tmp_path,
                 llm_client=llm_client,
+                deep_validate=True,
             )
         # F1: 1 Tier 2 call. F2: cache hit, 0 calls.
         assert mock_run.call_count == 1
@@ -1411,6 +1423,7 @@ class TestValidateDataflowClaims:
                 codeql_db=db,
                 repo_path=tmp_path,
                 llm_client=llm_client,
+                deep_validate=True,
             )
             # F1 errored (not counted in n_validated), F2 ran
             assert m["n_validated"] == 1
@@ -1724,31 +1737,58 @@ class TestCrossFamilyResolution:
 
 
 class TestCLIFlag:
-    """--validate-dataflow CLI flag wiring."""
+    """CLI flag wiring after the rename: --no-validate-dataflow opts
+    OUT (default is on), --deep-validate opts INTO Tier 2/3 LLM tiers,
+    --deep-validate-budget caps Tier 2/3 LLM cost."""
 
-    def test_flag_default_is_false(self):
+    def test_no_validate_dataflow_flag_default_is_false(self):
         import argparse
-        # Reproduce the argparse setup minimally
         parser = argparse.ArgumentParser()
-        parser.add_argument("--validate-dataflow", action="store_true")
+        parser.add_argument("--no-validate-dataflow", action="store_true")
         args = parser.parse_args([])
-        assert args.validate_dataflow is False
+        assert args.no_validate_dataflow is False
 
-    def test_flag_when_set_is_true(self):
+    def test_no_validate_dataflow_flag_when_set_is_true(self):
         import argparse
         parser = argparse.ArgumentParser()
-        parser.add_argument("--validate-dataflow", action="store_true")
-        args = parser.parse_args(["--validate-dataflow"])
-        assert args.validate_dataflow is True
+        parser.add_argument("--no-validate-dataflow", action="store_true")
+        args = parser.parse_args(["--no-validate-dataflow"])
+        assert args.no_validate_dataflow is True
 
-    def test_orchestrate_signature_accepts_flag(self):
-        """orchestrate() must accept validate_dataflow=True without TypeError."""
+    def test_deep_validate_flag_default_is_false(self):
+        import argparse
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--deep-validate", action="store_true")
+        args = parser.parse_args([])
+        assert args.deep_validate is False
+
+    def test_deep_validate_flag_when_set_is_true(self):
+        import argparse
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--deep-validate", action="store_true")
+        args = parser.parse_args(["--deep-validate"])
+        assert args.deep_validate is True
+
+    def test_orchestrate_signature_accepts_new_flags(self):
+        """orchestrate() must accept the new flag shape without TypeError."""
         import inspect
         from packages.llm_analysis.orchestrator import orchestrate
         sig = inspect.signature(orchestrate)
-        assert "validate_dataflow" in sig.parameters
-        # Default should be False so existing callers are unaffected
-        assert sig.parameters["validate_dataflow"].default is False
+        assert "dataflow_validation_enabled" in sig.parameters
+        assert sig.parameters["dataflow_validation_enabled"].default is True
+        assert "deep_validate" in sig.parameters
+        assert sig.parameters["deep_validate"].default is False
+        assert "deep_validate_budget" in sig.parameters
+
+    def test_orchestrate_no_longer_accepts_old_flag(self):
+        """The pre-rename validate_dataflow / validation_budget_threshold
+        kwargs must not exist any more — callers should fail loudly when
+        passing them rather than silently disabling the new behaviour."""
+        import inspect
+        from packages.llm_analysis.orchestrator import orchestrate
+        sig = inspect.signature(orchestrate)
+        assert "validate_dataflow" not in sig.parameters
+        assert "validation_budget_threshold" not in sig.parameters
 
 
 class TestOrchestratorIntegration:

--- a/packages/llm_analysis/tests/test_e2e_iris.py
+++ b/packages/llm_analysis/tests/test_e2e_iris.py
@@ -226,6 +226,7 @@ class TestE2EIris:
                 role_resolution={},
                 dispatch_mode="external_llm",
                 cost_tracker=None,
+                deep_validate=True,
             )
 
         # Validation ran exactly once, confirmed
@@ -285,6 +286,7 @@ class TestE2EIris:
                 role_resolution={},
                 dispatch_mode="external_llm",
                 cost_tracker=None,
+                deep_validate=True,
             )
 
         # IRIS recommended a downgrade
@@ -361,6 +363,7 @@ class TestE2EIris:
                 role_resolution={},
                 dispatch_mode="external_llm",
                 cost_tracker=None,
+                deep_validate=True,
             )
 
         assert metrics["n_validated"] == 2
@@ -419,6 +422,7 @@ class TestE2EIris:
                 role_resolution={},
                 dispatch_mode="external_llm",
                 cost_tracker=None,
+                deep_validate=True,
             )
 
         recon = reconcile_dataflow_validation(results_by_id)

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -270,23 +270,32 @@ Examples:
              "correlation results.",
     )
     parser.add_argument(
-        "--validate-dataflow",
+        "--no-validate-dataflow",
         action="store_true",
-        help="IRIS-style validation: for Semgrep findings where the LLM "
-             "claimed a dataflow path, generate a CodeQL query and run it "
-             "against the project database. Refuted claims downgrade "
-             "is_exploitable; original verdicts preserved as "
-             "is_exploitable_pre_validation. Requires --codeql to have run. "
-             "Opt-in until FP-reduction rate is measured against real data.",
+        help="Disable IRIS-style dataflow validation entirely. By default, "
+             "Tier 1 (free, CodeQL-only — runs the pre-built RemoteFlowSource "
+             "and RAPTOR-shipped LocalFlowSource queries against the project "
+             "database) is on whenever --codeql produced a database. Pass this "
+             "flag to skip validation completely.",
     )
     parser.add_argument(
-        "--validation-budget",
+        "--deep-validate",
+        action="store_true",
+        help="Opt into Tier 2 / Tier 3 of IRIS validation: when Tier 1 is "
+             "inconclusive, ask the LLM to write source+sink predicates and "
+             "retry on compile errors. Costs LLM tokens; without this flag "
+             "Tier 1's free signal is the only validation. Implies dataflow "
+             "validation is enabled (see --no-validate-dataflow to opt out).",
+    )
+    parser.add_argument(
+        "--deep-validate-budget",
         type=float,
         default=0.60,
         metavar="FRACTION",
-        help="Fraction of LLM budget (0.0-1.0) above which dataflow "
-             "validation is skipped to leave room for downstream tasks "
-             "(consensus, exploit, patch). Default 0.60.",
+        help="Fraction of LLM budget (0.0-1.0) above which --deep-validate's "
+             "Tier 2 / 3 LLM calls are skipped to leave room for downstream "
+             "tasks (consensus, exploit, patch). Tier 1 has no LLM cost so "
+             "this budget never gates it. Default 0.60.",
     )
     parser.add_argument(
         "--trust-repo",
@@ -908,6 +917,9 @@ Examples:
                 aggregate=getattr(args, "aggregate", None),
                 auto_detect=llm_env.external_llm,
             )
+            # Dataflow validation is on by default when CodeQL ran;
+            # `--no-validate-dataflow` opts out entirely. `--deep-validate`
+            # opts into LLM-backed Tier 2/3 on top of the always-free Tier 1.
             orchestration_result = orchestrate(
                 prep_report_path=analysis_report,
                 repo_path=original_repo_path,
@@ -919,8 +931,9 @@ Examples:
                 llm_config=llm_config,
                 block_cc_dispatch=block_cc_dispatch,
                 accept_weakened_defenses=args.accept_weakened_defenses,
-                validate_dataflow=getattr(args, "validate_dataflow", False),
-                validation_budget_threshold=getattr(args, "validation_budget", 0.60),
+                dataflow_validation_enabled=not getattr(args, "no_validate_dataflow", False),
+                deep_validate=getattr(args, "deep_validate", False),
+                deep_validate_budget=getattr(args, "deep_validate_budget", 0.60),
             )
         else:
             print("\n  No analysis report from Phase 3 — skipping orchestration")


### PR DESCRIPTION
After PR-A (LocalFlowSource) and PR-B (no-match-as-refutation), Tier 1 is free CodeQL work and can both confirm and refute. Gating it behind `--validate-dataflow` was overly cautious. This PR splits the flag.

CLI:
  Removed:  --validate-dataflow, --validation-budget
  Added:    --no-validate-dataflow   full opt-out
            --deep-validate          opt into Tier 2/3 LLM tiers
            --deep-validate-budget   renames --validation-budget; gates
                                     Tier 2/3 only

Default: with --codeql, Tier 1 runs automatically; Tier 2/3 stays opt-in. orchestrator's validate_dataflow → dataflow_validation_enabled (default True) + deep_validate (default False).

_validate_one_hypothesis: when deep_validate=False and Tier 1 is inconclusive, return immediately. New tier labels prebuilt-inconclusive / skipped-deep so metrics distinguish "Tier 1 no signal" from "LLM-checked, still no signal".

Bonus (closes #76, #77): ships .github/codeql/codeql-config.yml + advanced workflow excluding tests/fixtures/** and test_fixtures/**. The iris_e2e fixtures are intentionally vulnerable test data.

869 IRIS tests green.