### PR TITLE
fix(pytest): switch to importlib mode + pythonpath to fix tests namespace collision

### DIFF
--- a/packages/codeql/tests/test_scorecard_wiring.py
+++ b/packages/codeql/tests/test_scorecard_wiring.py
@@ -92,6 +92,11 @@ def _build_llm(tmp_path) -> "object":
     cfg.scorecard_path = tmp_path / "scorecard.json"
     cfg.scorecard_enabled = True
     cfg.scorecard_retain_samples = True
+    # Deterministic short-circuit assertions: the dataclass default
+    # for shadow_rate is 0.05, which would flake the
+    # ``short_circuit_skips_full`` test ~5% of the time when the random
+    # roll lands under threshold.
+    cfg.scorecard_shadow_rate = 0.0
 
     client = LLMClient.__new__(LLMClient)
     client.config = cfg

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,12 +6,16 @@
 # config from rootdir up. Per-package ``[tool.pytest.ini_options]``
 # sections only apply when their package is run standalone.
 #
-# Currently this file does two things:
+# This file does three things:
 #   1. Registers the ``integration`` marker so live-network tests
 #      (cve_diff's ``TestOSVLive``, ``TestNVDLive``, etc.) don't
 #      emit ``UnknownMarkWarning`` during collection.
 #   2. Deselects integration tests by default. Opt in with
 #      ``pytest -m integration`` (drops the negation).
+#   3. Skips RAPTOR's analysis output trees (``out/``, ``.out/``) and
+#      the per-target work areas spawned under ``.claude/worktrees/``
+#      so transient PoC ``test_*.py`` files inside scanned repos aren't
+#      collected.
 #
 # Other packages can extend ``markers`` as they grow their own
 # conventions. Shared raptor-wide pytest config goes here too.
@@ -19,4 +23,12 @@
 markers =
     integration: tests that hit live network — deselected by default
 
-addopts = -m "not integration"
+addopts = -m "not integration" --import-mode=importlib
+
+# Ensure each package's source root is importable without requiring an
+# editable install. Mirrors pytest's prepend-mode behaviour for the
+# subset of packages that have non-test runtime imports
+# (``from cve_diff.X import Y`` etc.) referenced from tests.
+pythonpath = packages/cve_diff packages/diagram packages/exploit_feasibility
+
+norecursedirs = out .out .claude .git build dist *.egg .tox .venv venv node_modules

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,9 +10,13 @@ ruff>=0.1.0
 mypy>=1.0.0
 
 # Testing
-pytest>=7.0.0
-pytest-cov>=4.0.0
-gcovr>=5.1
+# pytest pinned exactly: the root pytest.ini uses ``--import-mode=importlib``
+# and ``pythonpath`` (pytest 7+ features) to fix a ``tests`` namespace
+# collision between packages that all carry ``tests/__init__.py``. Pinning
+# avoids surprise regressions from collection-mode changes between minors.
+pytest==9.0.2
+pytest-cov==7.0.0
+gcovr==8.4
 
 # test for Z3 solver
 z3-solver==4.16.0.0


### PR DESCRIPTION
Two related fixes for whole-repo pytest collection failures.

importlib mode + pythonpath: ~25 packages carry tests/__init__.py under different paths, so pytest's default prepend mode loads each package's tests/ as the bare `tests` module. First package wins, leaving cve_diff's collection (which has a real subpackage layout tests.unit / tests.integration) to fail with `ModuleNotFoundError: No module named 'tests.unit'` whenever another package's tests/ loads first. importlib mode + an explicit pythonpath for the three packages that genuinely need their source on sys.path (cve_diff, diagram, exploit_feasibility — all use relative imports in test files) fixes both whole-repo and CI-style (`pytest core packages`) invocations.

norecursedirs: skip RAPTOR's analysis output trees (out, .out, .claude, build/dist) so transient PoC `test_*.py` files written into scanned repos by /agentic and friends aren't collected.

Pin pytest==9.0.2 (plus pytest-cov==7.0.0, gcovr==8.4) so the collection-mode change is reproducible across local/CI envs.

5217 tests pass, 3 skipped, 6 deselected (integration tests, gated correctly).