### PR TITLE
feat(iris): non-default pack discovery + JS/Java/Go LocalFlowSource packs

### DIFF
--- a/packages/llm_analysis/codeql_packs/go-queries/Raptor/LocalFlowSource.qll
+++ b/packages/llm_analysis/codeql_packs/go-queries/Raptor/LocalFlowSource.qll
@@ -1,0 +1,33 @@
+/**
+ * Provides RAPTOR's `LocalFlowSource` for Go — a data-flow source
+ * class covering process-local user-controlled inputs that the stdlib
+ * `RemoteFlowSource` excludes.
+ *
+ * Selects stdlib `SourceNode` instances by threat-model category:
+ * `commandargs` (os.Args), `environment` (os.Getenv, godotenv,
+ * envconfig, gobuffalo/envy), `stdin` (os.Stdin reads), `file`
+ * (file reads of attacker-controlled paths). Includes `remote` so
+ * a single LocalFlowSource-based query covers both local and remote
+ * inputs — matches IRIS validation semantics where the LLM's claim
+ * might describe either kind.
+ *
+ * Mirrors the Python and Java patterns. SourceNode is abstract with
+ * an abstract `getThreatModel()`, so we extend `DataFlow::Node` and
+ * gate via `instanceof` cast plus the data-extension `sourceNode`
+ * predicate (covers YAML model entries that don't go through the
+ * SourceNode hierarchy).
+ */
+
+import go
+import semmle.go.security.FlowSources
+import semmle.go.dataflow.ExternalFlow
+
+class LocalFlowSource extends DataFlow::Node {
+  LocalFlowSource() {
+    this.(SourceNode).getThreatModel() =
+      ["remote", "commandargs", "environment", "stdin", "file"]
+    or
+    sourceNode(this,
+      ["remote", "commandargs", "environment", "stdin", "file"])
+  }
+}

--- a/packages/llm_analysis/codeql_packs/go-queries/Security/CWE-022/PathTraversalLocal.ql
+++ b/packages/llm_analysis/codeql_packs/go-queries/Security/CWE-022/PathTraversalLocal.ql
@@ -1,0 +1,34 @@
+/**
+ * @name IRIS LocalFlowSource: path traversal from local input
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id raptor/iris/go/tainted-path-local
+ * @tags security
+ *       external/cwe/cwe-22
+ *       external/cwe/cwe-23
+ *       external/cwe/cwe-36
+ */
+
+import go
+import semmle.go.dataflow.DataFlow
+import semmle.go.dataflow.TaintTracking
+import semmle.go.security.TaintedPathCustomizations
+import Raptor.LocalFlowSource
+
+private module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof LocalFlowSource }
+
+  predicate isSink(DataFlow::Node n) { n instanceof TaintedPath::Sink }
+
+  predicate isBarrier(DataFlow::Node n) { n instanceof TaintedPath::Sanitizer }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+import Flow::PathGraph
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "Local user input flows to a filesystem path."

--- a/packages/llm_analysis/codeql_packs/go-queries/Security/CWE-078/CommandInjectionLocal.ql
+++ b/packages/llm_analysis/codeql_packs/go-queries/Security/CWE-078/CommandInjectionLocal.ql
@@ -1,0 +1,31 @@
+/**
+ * @name IRIS LocalFlowSource: command injection from local input
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id raptor/iris/go/command-injection-local
+ * @tags security
+ *       external/cwe/cwe-78
+ *       external/cwe/cwe-88
+ */
+
+import go
+import semmle.go.dataflow.DataFlow
+import semmle.go.dataflow.TaintTracking
+import semmle.go.security.CommandInjectionCustomizations
+import Raptor.LocalFlowSource
+
+private module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof LocalFlowSource }
+
+  predicate isSink(DataFlow::Node n) { n instanceof CommandInjection::Sink }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+import Flow::PathGraph
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "Local user input flows to a command-execution sink."

--- a/packages/llm_analysis/codeql_packs/go-queries/Security/CWE-089/SqlInjectionLocal.ql
+++ b/packages/llm_analysis/codeql_packs/go-queries/Security/CWE-089/SqlInjectionLocal.ql
@@ -1,0 +1,30 @@
+/**
+ * @name IRIS LocalFlowSource: SQL injection from local input
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id raptor/iris/go/sql-injection-local
+ * @tags security
+ *       external/cwe/cwe-89
+ */
+
+import go
+import semmle.go.dataflow.DataFlow
+import semmle.go.dataflow.TaintTracking
+import semmle.go.security.SqlInjectionCustomizations
+import Raptor.LocalFlowSource
+
+private module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof LocalFlowSource }
+
+  predicate isSink(DataFlow::Node n) { n instanceof SqlInjection::Sink }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+import Flow::PathGraph
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "Local user input flows to a SQL query."

--- a/packages/llm_analysis/codeql_packs/go-queries/codeql-pack.lock.yml
+++ b/packages/llm_analysis/codeql_packs/go-queries/codeql-pack.lock.yml
@@ -1,0 +1,24 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/concepts:
+    version: 0.0.22
+  codeql/controlflow:
+    version: 2.0.32
+  codeql/dataflow:
+    version: 2.1.4
+  codeql/go-all:
+    version: 7.0.6
+  codeql/mad:
+    version: 1.0.48
+  codeql/ssa:
+    version: 2.0.24
+  codeql/threat-models:
+    version: 1.0.48
+  codeql/tutorial:
+    version: 1.0.48
+  codeql/typetracking:
+    version: 2.0.32
+  codeql/util:
+    version: 2.0.35
+compiled: false

--- a/packages/llm_analysis/codeql_packs/go-queries/qlpack.yml
+++ b/packages/llm_analysis/codeql_packs/go-queries/qlpack.yml
@@ -1,0 +1,13 @@
+---
+# RAPTOR-shipped CodeQL pack for Go: companion queries that complement
+# the stdlib `codeql/go-queries` pack with sources beyond
+# `RemoteFlowSource`. Mirrors the Python pack — selects stdlib
+# threat-model sources tagged `commandargs` (os.Args), `environment`
+# (os.Getenv, godotenv, envconfig), `stdin` (os.Stdin), and `file`
+# (file reads of attacker-controlled paths).
+library: false
+name: raptor/go-queries
+version: 0.0.1
+dependencies:
+  codeql/go-all: "*"
+extractor: go

--- a/packages/llm_analysis/codeql_packs/java-queries/Raptor/LocalFlowSource.qll
+++ b/packages/llm_analysis/codeql_packs/java-queries/Raptor/LocalFlowSource.qll
@@ -1,0 +1,46 @@
+/**
+ * Provides RAPTOR's `LocalFlowSource` for Java — a data-flow source
+ * class covering process-local user-controlled inputs that the stdlib
+ * `RemoteFlowSource` excludes.
+ *
+ * Selects existing stdlib `SourceNode` subclasses by threat-model
+ * category: `commandargs` (main args[]), `environment` (System.getenv,
+ * System.getProperty), `stdin` (System.in / Scanner), `file` (file
+ * reads of attacker-controlled paths), and Java's broader `local`
+ * category. Includes `remote` so a single LocalFlowSource-based
+ * query covers both local and remote inputs.
+ *
+ * Mirrors the design of packages/llm_analysis/codeql_packs/python-queries/
+ * Raptor/LocalFlowSource.qll. Adding a category here is the only
+ * change needed to widen IRIS Tier 1's source coverage in Java.
+ */
+
+import java
+import semmle.code.java.dataflow.DataFlow
+import semmle.code.java.dataflow.FlowSources
+import semmle.code.java.dataflow.ExternalFlow
+
+/**
+ * Implementation note: extending `SourceNode` directly fails to
+ * compile because `SourceNode.getThreatModel()` is abstract and we
+ * have nothing meaningful to override it with — we want to *filter*
+ * existing sources, not declare a new one. We therefore extend
+ * `DataFlow::Node` and gate on the threat-model selection via an
+ * `instanceof` cast.
+ *
+ * `sourceNode(this, kind)` covers data-extension model entries that
+ * register sources via the YAML model files (e.g. `argv` /
+ * `environment` annotations on framework APIs) without going through
+ * the Java SourceNode hierarchy. This keeps coverage comprehensive
+ * even when stdlib YAML models tag sources outside the SourceNode
+ * class system.
+ */
+class LocalFlowSource extends DataFlow::Node {
+  LocalFlowSource() {
+    this.(SourceNode).getThreatModel() =
+      ["remote", "local", "commandargs", "environment", "stdin", "file"]
+    or
+    sourceNode(this,
+      ["remote", "local", "commandargs", "environment", "stdin", "file"])
+  }
+}

--- a/packages/llm_analysis/codeql_packs/java-queries/Security/CWE-022/PathTraversalLocal.ql
+++ b/packages/llm_analysis/codeql_packs/java-queries/Security/CWE-022/PathTraversalLocal.ql
@@ -1,0 +1,35 @@
+/**
+ * @name IRIS LocalFlowSource: path traversal from local input
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id raptor/iris/java/tainted-path-local
+ * @tags security
+ *       external/cwe/cwe-22
+ *       external/cwe/cwe-23
+ *       external/cwe/cwe-36
+ */
+
+import java
+import semmle.code.java.dataflow.DataFlow
+import semmle.code.java.dataflow.TaintTracking
+import semmle.code.java.security.TaintedPathQuery
+import semmle.code.java.security.PathSanitizer
+import Raptor.LocalFlowSource
+
+private module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof LocalFlowSource }
+
+  predicate isSink(DataFlow::Node n) { n instanceof TaintedPathSink }
+
+  predicate isBarrier(DataFlow::Node n) { n instanceof PathInjectionSanitizer }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+import Flow::PathGraph
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "Local user input flows to a filesystem path."

--- a/packages/llm_analysis/codeql_packs/java-queries/Security/CWE-078/CommandInjectionLocal.ql
+++ b/packages/llm_analysis/codeql_packs/java-queries/Security/CWE-078/CommandInjectionLocal.ql
@@ -1,0 +1,38 @@
+/**
+ * @name IRIS LocalFlowSource: command injection from local input
+ * @description Reuses the stdlib Java CommandInjection sink and
+ *              sanitiser models with RAPTOR's `LocalFlowSource` so
+ *              args[]- / System.getenv- / stdin-driven flows that the
+ *              stock `ActiveThreatModelSource` configuration excludes
+ *              are caught.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id raptor/iris/java/command-injection-local
+ * @tags security
+ *       external/cwe/cwe-78
+ *       external/cwe/cwe-88
+ */
+
+import java
+import semmle.code.java.dataflow.DataFlow
+import semmle.code.java.dataflow.TaintTracking
+import semmle.code.java.security.CommandLineQuery
+import Raptor.LocalFlowSource
+
+private module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof LocalFlowSource }
+
+  predicate isSink(DataFlow::Node n) { n instanceof CommandInjectionSink }
+
+  predicate isBarrier(DataFlow::Node n) { n instanceof CommandInjectionSanitizer }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+import Flow::PathGraph
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "Local user input flows to a command-execution sink."

--- a/packages/llm_analysis/codeql_packs/java-queries/Security/CWE-089/SqlInjectionLocal.ql
+++ b/packages/llm_analysis/codeql_packs/java-queries/Security/CWE-089/SqlInjectionLocal.ql
@@ -1,0 +1,33 @@
+/**
+ * @name IRIS LocalFlowSource: SQL injection from local input
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id raptor/iris/java/sql-injection-local
+ * @tags security
+ *       external/cwe/cwe-89
+ */
+
+import java
+import semmle.code.java.dataflow.DataFlow
+import semmle.code.java.dataflow.TaintTracking
+import semmle.code.java.security.QueryInjection
+import semmle.code.java.security.Sanitizers
+import Raptor.LocalFlowSource
+
+private module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof LocalFlowSource }
+
+  predicate isSink(DataFlow::Node n) { n instanceof QueryInjectionSink }
+
+  predicate isBarrier(DataFlow::Node n) { n instanceof SimpleTypeSanitizer }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+import Flow::PathGraph
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "Local user input flows to a SQL query."

--- a/packages/llm_analysis/codeql_packs/java-queries/Security/CWE-502/UnsafeDeserializationLocal.ql
+++ b/packages/llm_analysis/codeql_packs/java-queries/Security/CWE-502/UnsafeDeserializationLocal.ql
@@ -1,0 +1,30 @@
+/**
+ * @name IRIS LocalFlowSource: unsafe deserialization from local input
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id raptor/iris/java/unsafe-deserialization-local
+ * @tags security
+ *       external/cwe/cwe-502
+ */
+
+import java
+import semmle.code.java.dataflow.DataFlow
+import semmle.code.java.dataflow.TaintTracking
+import semmle.code.java.security.UnsafeDeserializationQuery
+import Raptor.LocalFlowSource
+
+private module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof LocalFlowSource }
+
+  predicate isSink(DataFlow::Node n) { n instanceof UnsafeDeserializationSink }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+import Flow::PathGraph
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "Local user input is deserialized."

--- a/packages/llm_analysis/codeql_packs/java-queries/codeql-pack.lock.yml
+++ b/packages/llm_analysis/codeql_packs/java-queries/codeql-pack.lock.yml
@@ -1,0 +1,32 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/controlflow:
+    version: 2.0.32
+  codeql/dataflow:
+    version: 2.1.4
+  codeql/java-all:
+    version: 9.0.4
+  codeql/mad:
+    version: 1.0.48
+  codeql/quantum:
+    version: 0.0.26
+  codeql/rangeanalysis:
+    version: 1.0.48
+  codeql/regex:
+    version: 1.0.48
+  codeql/ssa:
+    version: 2.0.24
+  codeql/threat-models:
+    version: 1.0.48
+  codeql/tutorial:
+    version: 1.0.48
+  codeql/typeflow:
+    version: 1.0.48
+  codeql/typetracking:
+    version: 2.0.32
+  codeql/util:
+    version: 2.0.35
+  codeql/xml:
+    version: 1.0.48
+compiled: false

--- a/packages/llm_analysis/codeql_packs/java-queries/qlpack.yml
+++ b/packages/llm_analysis/codeql_packs/java-queries/qlpack.yml
@@ -1,0 +1,15 @@
+---
+# RAPTOR-shipped CodeQL pack for Java: companion queries that
+# complement the stdlib `codeql/java-queries` pack with sources
+# beyond `RemoteFlowSource`. Mirrors the Python pack — selects
+# stdlib threat-model sources tagged `commandargs` (main args[]),
+# `environment` (System.getenv, getProperty), `stdin`
+# (System.in / Scanner reads), `file` (file reads of attacker-
+# controlled paths), and `local` (Java's broader local-tag covering
+# things not specifically categorised).
+library: false
+name: raptor/java-queries
+version: 0.0.1
+dependencies:
+  codeql/java-all: "*"
+extractor: java

--- a/packages/llm_analysis/codeql_packs/javascript-queries/Raptor/LocalFlowSource.qll
+++ b/packages/llm_analysis/codeql_packs/javascript-queries/Raptor/LocalFlowSource.qll
@@ -1,0 +1,26 @@
+/**
+ * Provides RAPTOR's `LocalFlowSource` for JavaScript / TypeScript —
+ * a data-flow source class covering CLI / process-local user-controlled
+ * inputs that the stdlib `RemoteFlowSource` excludes.
+ *
+ * Selects existing stdlib threat-model sources tagged `commandargs`
+ * (process.argv, yargs, optimist, commander), `environment`
+ * (process.env reads), `stdin` (process.stdin reads), and `file`
+ * (file reads of attacker-controlled paths). Includes `remote` so a
+ * single LocalFlowSource-based query covers BOTH local and remote
+ * inputs — matches IRIS validation semantics where the LLM's claim
+ * might describe either kind.
+ *
+ * Mirrors the design of packages/llm_analysis/codeql_packs/python-queries/
+ * Raptor/LocalFlowSource.qll. Adding a category here is the only change
+ * needed to widen IRIS Tier 1's source coverage in JS.
+ */
+
+import javascript
+
+class LocalFlowSource extends ThreatModelSource {
+  LocalFlowSource() {
+    this.getThreatModel() =
+      ["remote", "commandargs", "environment", "stdin", "file"]
+  }
+}

--- a/packages/llm_analysis/codeql_packs/javascript-queries/Security/CWE-022/PathTraversalLocal.ql
+++ b/packages/llm_analysis/codeql_packs/javascript-queries/Security/CWE-022/PathTraversalLocal.ql
@@ -1,0 +1,34 @@
+/**
+ * @name IRIS LocalFlowSource: path traversal from local input
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id raptor/iris/javascript/tainted-path-local
+ * @tags security
+ *       external/cwe/cwe-22
+ *       external/cwe/cwe-23
+ *       external/cwe/cwe-36
+ */
+
+import javascript
+import semmle.javascript.dataflow.DataFlow
+import semmle.javascript.dataflow.TaintTracking
+import semmle.javascript.security.dataflow.TaintedPathCustomizations
+import Raptor.LocalFlowSource
+
+private module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof LocalFlowSource }
+
+  predicate isSink(DataFlow::Node n) { n instanceof TaintedPath::Sink }
+
+  predicate isBarrier(DataFlow::Node n) { n instanceof TaintedPath::Sanitizer }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+import Flow::PathGraph
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "Local user input flows to a filesystem path."

--- a/packages/llm_analysis/codeql_packs/javascript-queries/Security/CWE-078/CommandInjectionLocal.ql
+++ b/packages/llm_analysis/codeql_packs/javascript-queries/Security/CWE-078/CommandInjectionLocal.ql
@@ -1,0 +1,37 @@
+/**
+ * @name IRIS LocalFlowSource: command injection from local input
+ * @description Reuses the stdlib JS CommandInjection sink and sanitiser
+ *              models with RAPTOR's `LocalFlowSource` so CLI / env /
+ *              stdin-driven flows the stock `ActiveThreatModelSource`
+ *              configuration excludes are caught.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id raptor/iris/javascript/command-injection-local
+ * @tags security
+ *       external/cwe/cwe-78
+ *       external/cwe/cwe-88
+ */
+
+import javascript
+import semmle.javascript.dataflow.DataFlow
+import semmle.javascript.dataflow.TaintTracking
+import semmle.javascript.security.dataflow.CommandInjectionCustomizations
+import Raptor.LocalFlowSource
+
+private module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof LocalFlowSource }
+
+  predicate isSink(DataFlow::Node n) { n instanceof CommandInjection::Sink }
+
+  predicate isBarrier(DataFlow::Node n) { n instanceof CommandInjection::Sanitizer }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+import Flow::PathGraph
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "Local user input flows to a command-execution sink."

--- a/packages/llm_analysis/codeql_packs/javascript-queries/Security/CWE-094/CodeInjectionLocal.ql
+++ b/packages/llm_analysis/codeql_packs/javascript-queries/Security/CWE-094/CodeInjectionLocal.ql
@@ -1,0 +1,34 @@
+/**
+ * @name IRIS LocalFlowSource: code injection from local input
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id raptor/iris/javascript/code-injection-local
+ * @tags security
+ *       external/cwe/cwe-94
+ *       external/cwe/cwe-95
+ *       external/cwe/cwe-116
+ */
+
+import javascript
+import semmle.javascript.dataflow.DataFlow
+import semmle.javascript.dataflow.TaintTracking
+import semmle.javascript.security.dataflow.CodeInjectionCustomizations
+import Raptor.LocalFlowSource
+
+private module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof LocalFlowSource }
+
+  predicate isSink(DataFlow::Node n) { n instanceof CodeInjection::Sink }
+
+  predicate isBarrier(DataFlow::Node n) { n instanceof CodeInjection::Sanitizer }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+import Flow::PathGraph
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "Local user input flows to a code-execution sink (eval / Function / vm.run)."

--- a/packages/llm_analysis/codeql_packs/javascript-queries/codeql-pack.lock.yml
+++ b/packages/llm_analysis/codeql_packs/javascript-queries/codeql-pack.lock.yml
@@ -1,0 +1,30 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/concepts:
+    version: 0.0.22
+  codeql/controlflow:
+    version: 2.0.32
+  codeql/dataflow:
+    version: 2.1.4
+  codeql/javascript-all:
+    version: 2.6.28
+  codeql/mad:
+    version: 1.0.48
+  codeql/regex:
+    version: 1.0.48
+  codeql/ssa:
+    version: 2.0.24
+  codeql/threat-models:
+    version: 1.0.48
+  codeql/tutorial:
+    version: 1.0.48
+  codeql/typetracking:
+    version: 2.0.32
+  codeql/util:
+    version: 2.0.35
+  codeql/xml:
+    version: 1.0.48
+  codeql/yaml:
+    version: 1.0.48
+compiled: false

--- a/packages/llm_analysis/codeql_packs/javascript-queries/qlpack.yml
+++ b/packages/llm_analysis/codeql_packs/javascript-queries/qlpack.yml
@@ -1,0 +1,14 @@
+---
+# RAPTOR-shipped CodeQL pack for JavaScript / TypeScript: companion
+# queries that complement the stdlib `codeql/javascript-queries` pack
+# with sources beyond `RemoteFlowSource`. See the Python pack at
+# packages/llm_analysis/codeql_packs/python-queries/ for the design
+# rationale; the JS pack mirrors that pattern, selecting stdlib
+# threat-model sources tagged `commandargs` (process.argv, yargs,
+# optimist), `environment` (process.env), `stdin`, and `file`.
+library: false
+name: raptor/javascript-queries
+version: 0.0.1
+dependencies:
+  codeql/javascript-all: "*"
+extractor: javascript

--- a/packages/llm_analysis/dataflow_query_builder.py
+++ b/packages/llm_analysis/dataflow_query_builder.py
@@ -42,8 +42,11 @@ packs) automatically.
 """
 
 import functools
+import json
 import logging
 import re
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -106,6 +109,71 @@ def _pack_roots() -> List[Path]:
     except ImportError:
         pass
     return extras + [_DEFAULT_PACK_ROOT]
+
+
+_RESOLVE_TIMEOUT_SECS = 30
+# Match `codeql/<lang>-queries` (canonical published-pack naming).
+# `<lang>` covers letters, digits, hyphens — no slashes.
+_QUERIES_PACK_NAME_RE = re.compile(r"^codeql/([A-Za-z0-9-]+)-queries$")
+
+
+def _resolved_pack_pointers() -> Dict[str, Path]:
+    """Ask the `codeql` CLI for the canonical install paths of all
+    published query packs. Returns {language: pack_path} for the
+    `codeql/<lang>-queries` namespace; non-queries packs (libs,
+    examples, tests) are filtered out.
+
+    Used as a secondary discovery source so operators who installed
+    CodeQL via the upstream queries-checkout (for example
+    `~/.local/codeql-queries/`) get IRIS Tier 1 coverage too — the
+    layout there does not match `<DEFAULT_PACK_ROOT>/<lang>-queries/`,
+    so the original walk would otherwise miss it.
+
+    Failure modes handled silently: codeql not on PATH, CLI errors,
+    parse errors, or timeout. The hardcoded `_DEFAULT_PACK_ROOT` walk
+    runs regardless of this helper's success.
+
+    Sandbox-safe: `codeql resolve qlpacks` is a metadata read against
+    the binary's own pack-cache. No target-repo or network access.
+    """
+    binary = shutil.which("codeql")
+    if not binary:
+        return {}
+    try:
+        proc = subprocess.run(
+            [binary, "resolve", "qlpacks", "--format=json"],
+            capture_output=True, text=True,
+            timeout=_RESOLVE_TIMEOUT_SECS,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        logger.debug("codeql resolve qlpacks failed: %s", e)
+        return {}
+    if proc.returncode != 0:
+        logger.debug(
+            "codeql resolve qlpacks returned %d: %s",
+            proc.returncode, (proc.stderr or "").strip()[:200],
+        )
+        return {}
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        logger.debug("codeql resolve qlpacks JSON parse failed: %s", e)
+        return {}
+
+    out: Dict[str, Path] = {}
+    for pack_name, paths in (data or {}).items():
+        m = _QUERIES_PACK_NAME_RE.match(pack_name)
+        if not m or not paths:
+            continue
+        lang = m.group(1).lower()
+        # `paths` is a list — published packs typically have one entry.
+        # Take the first that exists on disk.
+        for p in paths:
+            path = Path(p)
+            if path.is_dir():
+                out[lang] = path
+                break
+    return out
 
 
 def _read_metadata(ql_path: Path) -> Optional[str]:
@@ -182,45 +250,84 @@ def discover_prebuilt_queries() -> Dict[Tuple[str, str], Path]:
     single root, iteration is alphabetical for determinism.
     """
     out: Dict[Tuple[str, str], Path] = {}
-    for root in _pack_roots():
+
+    # Build the priority-ordered list of (language, pack_dir) pairs:
+    #   1. Extras roots (RaptorConfig.EXTRA_CODEQL_PACK_ROOTS) — RAPTOR-
+    #      shipped packs win on collisions.
+    #   2. `codeql resolve qlpacks` — direct pointers from the operator's
+    #      installed packs, including non-default install layouts like
+    #      the upstream codeql-queries checkout.
+    #   3. _DEFAULT_PACK_ROOT iter — the canonical
+    #      `~/.codeql/packages/codeql/` install. May overlap with (2);
+    #      `seen_dirs` dedupes by resolved absolute path.
+    seen_dirs: set = set()
+    pack_dirs: List[Tuple[str, Path]] = []
+
+    def _add_pack_dir(language: str, pack_dir: Path) -> None:
+        try:
+            resolved = pack_dir.resolve()
+        except (OSError, RuntimeError):
+            return
+        if resolved in seen_dirs:
+            return
+        seen_dirs.add(resolved)
+        pack_dirs.append((language, pack_dir))
+
+    # (1) Extras roots — iterate children
+    for root in _pack_roots()[:-1]:  # all but the default (handled in (3))
         if not root.is_dir():
             logger.debug("CodeQL pack root not found: %s", root)
             continue
-
-        # Walk every <lang>-queries pack. The pack may have a single
-        # version dir (`<root>/<lang>-queries/<version>/Security/...`)
-        # or be laid out flat (`<root>/<lang>-queries/Security/...`)
-        # for in-repo packs that don't ship versioned. Both shapes
-        # are recognised.
-        for pack_dir in sorted(root.iterdir()):
-            if not pack_dir.is_dir():
+        for child in sorted(root.iterdir()):
+            if not child.is_dir():
                 continue
-            language = _language_from_pack_dir(pack_dir)
-            if language is None:
+            lang = _language_from_pack_dir(child)
+            if lang:
+                _add_pack_dir(lang, child)
+
+    # (2) `codeql resolve qlpacks` — direct language→path pointers
+    for lang, path in _resolved_pack_pointers().items():
+        _add_pack_dir(lang, path)
+
+    # (3) _DEFAULT_PACK_ROOT — canonical install layout
+    default_root = _pack_roots()[-1]
+    if default_root.is_dir():
+        for child in sorted(default_root.iterdir()):
+            if not child.is_dir():
                 continue
+            lang = _language_from_pack_dir(child)
+            if lang:
+                _add_pack_dir(lang, child)
+    else:
+        logger.debug("CodeQL default pack root not found: %s", default_root)
 
-            search_dirs: List[Path] = []
-            flat_security = pack_dir / "Security"
-            if flat_security.is_dir():
-                # Flat: <root>/<lang>-queries/Security/...
-                search_dirs.append(flat_security)
-            else:
-                # Versioned: <root>/<lang>-queries/<version>/Security/...
-                for version_dir in sorted(pack_dir.iterdir()):
-                    if not version_dir.is_dir():
-                        continue
-                    security_dir = version_dir / "Security"
-                    if security_dir.is_dir():
-                        search_dirs.append(security_dir)
+    # Walk each pack dir. Layout variants supported:
+    #   Flat:        <pack>/Security/...                 (in-repo packs)
+    #   Versioned:   <pack>/<version>/Security/...       (canonical install)
+    #   Nested-CWE:  <pack>/Security/CWE/CWE-NNN/*.ql    (upstream queries
+    #                                                    checkout — handled
+    #                                                    by rglob below)
+    for language, pack_dir in pack_dirs:
+        search_dirs: List[Path] = []
+        flat_security = pack_dir / "Security"
+        if flat_security.is_dir():
+            search_dirs.append(flat_security)
+        else:
+            for version_dir in sorted(pack_dir.iterdir()):
+                if not version_dir.is_dir():
+                    continue
+                security_dir = version_dir / "Security"
+                if security_dir.is_dir():
+                    search_dirs.append(security_dir)
 
-            for security_dir in search_dirs:
-                for ql_path in sorted(security_dir.rglob("*.ql")):
-                    metadata = _read_metadata(ql_path)
-                    if metadata is None or not _is_path_problem(metadata):
-                        continue
-                    for cwe in _extract_cwes(metadata):
-                        key = (language, cwe)
-                        out.setdefault(key, ql_path)
+        for security_dir in search_dirs:
+            for ql_path in sorted(security_dir.rglob("*.ql")):
+                metadata = _read_metadata(ql_path)
+                if metadata is None or not _is_path_problem(metadata):
+                    continue
+                for cwe in _extract_cwes(metadata):
+                    key = (language, cwe)
+                    out.setdefault(key, ql_path)
 
     if out:
         logger.debug(

--- a/packages/llm_analysis/tests/fixtures/iris_e2e_multilang/README.md
+++ b/packages/llm_analysis/tests/fixtures/iris_e2e_multilang/README.md
@@ -1,0 +1,72 @@
+# IRIS multi-language LocalFlowSource fixtures
+
+Minimal CLI-driven command-injection samples for JS, Java, Go, and C —
+one file per language showing `argv[N] → exec(...)` with no
+sanitisation. Used to validate that IRIS Tier 1 discovers and runs the
+right `.ql` query for each language and that the discovered query
+catches the local (non-network) input flow.
+
+## Files
+
+- `js/cmd_inj.js`   — `process.argv[2]` flows to `child_process.exec`
+- `java/CmdInj.java` — `args[0]`         flows to `Runtime.getRuntime().exec`
+- `go/cmd_inj.go`   — `os.Args[1]`       flows to `os/exec.Command`
+- `c/cmd_inj.c`     — `argv[1]`          flows to `system()`
+
+## Why these flows would otherwise be missed
+
+CodeQL's stdlib CWE-78 queries for JS, Java, and Go default to
+`ActiveThreatModelSource` / `RemoteFlowSource` — network inputs only.
+CLI arguments fall outside that source model unless the operator has
+explicitly enabled the `commandargs` threat model (which the standard
+code-scanning configuration does not).
+
+The RAPTOR-shipped LocalFlowSource packs at
+`packages/llm_analysis/codeql_packs/<lang>-queries/` widen the source
+selection to include `commandargs` / `environment` / `stdin` / `file`
+threat-model categories alongside `remote`, so a single Tier 1 query
+covers both kinds of input.
+
+C is intentionally different: the stdlib `ExecTainted.ql` already uses
+the parent `FlowSource` class (the union of remote + local), so no
+RAPTOR pack is required — the gap was operator install layout, not
+source-model coverage. Discovery's `codeql resolve qlpacks` pointer
+fallback closes that gap.
+
+## Reproduction (manual)
+
+```bash
+# Build a CodeQL DB per language
+codeql database create /tmp/iris-js   --language=javascript --source-root=js   --overwrite
+codeql database create /tmp/iris-java --language=java       --source-root=java --command="javac CmdInj.java" --overwrite
+codeql database create /tmp/iris-go   --language=go         --source-root=go   --overwrite
+codeql database create /tmp/iris-c    --language=cpp        --source-root=c    --command="gcc -c cmd_inj.c -o /tmp/cmd_inj.o" --overwrite
+
+# Run RAPTOR's Tier 1 discovery + invocation
+python3 - <<'PY'
+from pathlib import Path
+from packages.llm_analysis.dataflow_query_builder import discover_prebuilt_query
+from packages.hypothesis_validation.adapters.codeql import CodeQLAdapter
+
+for lang, db in [
+    ("javascript", "/tmp/iris-js"),
+    ("java",       "/tmp/iris-java"),
+    ("go",         "/tmp/iris-go"),
+    ("cpp",        "/tmp/iris-c"),
+]:
+    ql = discover_prebuilt_query(lang, "CWE-78")
+    adapter = CodeQLAdapter(database_path=Path(db), sandbox=False)
+    ev = adapter.run_prebuilt_query(ql, Path("."), timeout=240)
+    print(lang, "→", len(ev.matches), "match(es)")
+PY
+```
+
+Expected: 1 match per language, all confirmed.
+
+## Reproducible CI use
+
+CI does NOT run real CodeQL against these fixtures (DB build + analysis
+is minutes of wallclock per language). The unit tests in
+`tests/test_dataflow_query_builder.py` mock discovery and verify the
+walk logic. This README documents the manual real-CodeQL smoke that
+proved the wiring works end-to-end on real installations.

--- a/packages/llm_analysis/tests/fixtures/iris_e2e_multilang/c/cmd_inj.c
+++ b/packages/llm_analysis/tests/fixtures/iris_e2e_multilang/c/cmd_inj.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+    if (argc < 2) return 1;
+    char buf[256];
+    snprintf(buf, sizeof(buf), "ping -c1 %s", argv[1]);
+    return system(buf);
+}

--- a/packages/llm_analysis/tests/fixtures/iris_e2e_multilang/go/cmd_inj.go
+++ b/packages/llm_analysis/tests/fixtures/iris_e2e_multilang/go/cmd_inj.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+)
+
+func main() {
+	target := os.Args[1]
+	exec.Command("sh", "-c", "ping -c1 "+target).Run()
+}

--- a/packages/llm_analysis/tests/fixtures/iris_e2e_multilang/go/go.mod
+++ b/packages/llm_analysis/tests/fixtures/iris_e2e_multilang/go/go.mod
@@ -1,0 +1,3 @@
+module example.com/cmdinj
+
+go 1.20

--- a/packages/llm_analysis/tests/fixtures/iris_e2e_multilang/java/CmdInj.java
+++ b/packages/llm_analysis/tests/fixtures/iris_e2e_multilang/java/CmdInj.java
@@ -1,0 +1,5 @@
+public class CmdInj {
+    public static void main(String[] args) throws Exception {
+        Runtime.getRuntime().exec("ping -c1 " + args[0]);
+    }
+}

--- a/packages/llm_analysis/tests/fixtures/iris_e2e_multilang/js/cmd_inj.js
+++ b/packages/llm_analysis/tests/fixtures/iris_e2e_multilang/js/cmd_inj.js
@@ -1,0 +1,3 @@
+const { exec } = require('child_process');
+const target = process.argv[2];
+exec(`ping -c1 ${target}`);

--- a/packages/llm_analysis/tests/test_dataflow_query_builder.py
+++ b/packages/llm_analysis/tests/test_dataflow_query_builder.py
@@ -69,10 +69,12 @@ class TestDiscovery:
         discover_prebuilt_queries.cache_clear()
 
     def _isolate_default_root(self, monkeypatch, tmp_path):
-        """Point discovery at tmp_path only — no in-repo extras leak."""
+        """Point discovery at tmp_path only — no in-repo extras leak,
+        no real `codeql resolve qlpacks` output leaks either."""
         from core.config import RaptorConfig
         monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path)
         monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [])
+        monkeypatch.setattr(_dqb, "_resolved_pack_pointers", lambda: {})
 
     def test_finds_path_problem_query(self, tmp_path, monkeypatch):
         sec = _build_pack_tree(tmp_path, language="python")
@@ -175,6 +177,7 @@ class TestDiscovery:
         from core.config import RaptorConfig
         monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path / "does-not-exist")
         monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [])
+        monkeypatch.setattr(_dqb, "_resolved_pack_pointers", lambda: {})
         out = discover_prebuilt_queries()
         assert out == {}
 
@@ -252,6 +255,7 @@ class TestMultiRoot:
                      cwe_tag="external/cwe/cwe-78", qid="extras/cwe-78")
 
         monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", default_root)
+        monkeypatch.setattr(_dqb, "_resolved_pack_pointers", lambda: {})
         monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [extras_root])
 
         assert discover_prebuilt_query("python", "CWE-78") == extras_ql
@@ -273,6 +277,7 @@ class TestMultiRoot:
                      kind="path-problem", cwe_tag="external/cwe/cwe-94")
 
         monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", default_root)
+        monkeypatch.setattr(_dqb, "_resolved_pack_pointers", lambda: {})
         monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [extras_root])
 
         assert discover_prebuilt_query("python", "CWE-22") is not None
@@ -289,6 +294,7 @@ class TestMultiRoot:
                      kind="path-problem", cwe_tag="external/cwe/cwe-78")
 
         monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", default_root)
+        monkeypatch.setattr(_dqb, "_resolved_pack_pointers", lambda: {})
         monkeypatch.setattr(
             RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS",
             [tmp_path / "does-not-exist"],
@@ -311,6 +317,7 @@ class TestMultiRoot:
                      cwe_tag="external/cwe/cwe-502")
 
         monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path / "no-default")
+        monkeypatch.setattr(_dqb, "_resolved_pack_pointers", lambda: {})
         monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [extras_root])
 
         assert discover_prebuilt_query("python", "CWE-502") == ql
@@ -328,6 +335,125 @@ class TestMultiRoot:
         assert "raptor-python-queries" in str(path) or \
                "codeql_packs/python-queries" in str(path), \
                f"expected in-repo pack to win, got {path}"
+
+
+class TestResolvedPackPointers:
+    """`_resolved_pack_pointers()` shells out to `codeql resolve qlpacks`
+    so operators with non-default install layouts (e.g. the upstream
+    queries-checkout at `~/.local/codeql-queries/`) get IRIS Tier 1
+    coverage. Discovery merges these pointers with the default-root
+    walk."""
+
+    def setup_method(self):
+        discover_prebuilt_queries.cache_clear()
+
+    def teardown_method(self):
+        discover_prebuilt_queries.cache_clear()
+
+    def test_resolved_pointers_picked_up_by_discovery(self, tmp_path, monkeypatch):
+        """A pack at a non-default location is found via the resolved-
+        pointers fallback. Layout: `<pack_dir>/Security/CWE-NNN/*.ql`
+        (no `<lang>-queries/<version>/` wrapper)."""
+        from core.config import RaptorConfig
+
+        pack_dir = tmp_path / "alt-install" / "go" / "ql" / "src"
+        sec = pack_dir / "Security" / "CWE-078"
+        sec.mkdir(parents=True)
+        _write_query(sec / "CommandInjection.ql",
+                     kind="path-problem", cwe_tag="external/cwe/cwe-78")
+
+        # Default root and extras both empty; only the resolved pointer
+        # provides this pack.
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path / "no-default")
+        monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [])
+        monkeypatch.setattr(_dqb, "_resolved_pack_pointers",
+                            lambda: {"go": pack_dir})
+
+        assert discover_prebuilt_query("go", "CWE-78") is not None
+
+    def test_resolved_pointers_handle_nested_cwe_layout(self, tmp_path, monkeypatch):
+        """Upstream codeql-queries checkout uses
+        `Security/CWE/CWE-NNN/*.ql` — an extra `CWE/` intermediate dir.
+        rglob inside the walk handles this transparently."""
+        from core.config import RaptorConfig
+
+        pack_dir = tmp_path / "queries" / "cpp" / "ql" / "src"
+        nested = pack_dir / "Security" / "CWE" / "CWE-078"
+        nested.mkdir(parents=True)
+        _write_query(nested / "ExecTainted.ql",
+                     kind="path-problem", cwe_tag="external/cwe/cwe-78")
+
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path / "no-default")
+        monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [])
+        monkeypatch.setattr(_dqb, "_resolved_pack_pointers",
+                            lambda: {"cpp": pack_dir})
+
+        assert discover_prebuilt_query("cpp", "CWE-78") is not None
+
+    def test_extras_still_win_over_resolved(self, tmp_path, monkeypatch):
+        """Extras (RaptorConfig) take priority over both resolved
+        pointers and the default — RAPTOR-shipped LocalFlowSource packs
+        must override stdlib queries on collisions."""
+        from core.config import RaptorConfig
+
+        # Extras: in-repo override
+        extras_root = tmp_path / "extras"
+        extras_pack = extras_root / "python-queries" / "Security" / "CWE-078"
+        extras_pack.mkdir(parents=True)
+        extras_ql = extras_pack / "FromExtras.ql"
+        _write_query(extras_ql, kind="path-problem",
+                     cwe_tag="external/cwe/cwe-78")
+
+        # Resolved pointer: stdlib version
+        resolved_pack = tmp_path / "alt-install" / "python" / "ql" / "src"
+        resolved_sec = resolved_pack / "Security" / "CWE-078"
+        resolved_sec.mkdir(parents=True)
+        _write_query(resolved_sec / "FromResolved.ql",
+                     kind="path-problem", cwe_tag="external/cwe/cwe-78")
+
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path / "no-default")
+        monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [extras_root])
+        monkeypatch.setattr(_dqb, "_resolved_pack_pointers",
+                            lambda: {"python": resolved_pack})
+
+        assert discover_prebuilt_query("python", "CWE-78") == extras_ql
+
+    def test_codeql_unavailable_falls_back_silently(self, tmp_path, monkeypatch):
+        """When `codeql` isn't on PATH, _resolved_pack_pointers returns
+        {} and discovery proceeds with whatever the default + extras
+        walks find. No crash."""
+        from core.config import RaptorConfig
+        # Empty default, no extras, no resolved pointers — empty dict.
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", tmp_path / "no-default")
+        monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [])
+        monkeypatch.setattr(_dqb, "_resolved_pack_pointers", lambda: {})
+        out = discover_prebuilt_queries()
+        assert out == {}
+
+    def test_dedup_when_resolved_overlaps_default(self, tmp_path, monkeypatch):
+        """If resolve-qlpacks returns a path that's also under
+        _DEFAULT_PACK_ROOT, the walk dedupes by resolved absolute
+        path so we don't scan the same files twice."""
+        from core.config import RaptorConfig
+
+        # Default root contains a python-queries pack
+        default_root = tmp_path / "default"
+        pack_dir = default_root / "python-queries"
+        sec = pack_dir / "Security" / "CWE-078"
+        sec.mkdir(parents=True)
+        ql = sec / "X.ql"
+        _write_query(ql, kind="path-problem", cwe_tag="external/cwe/cwe-78")
+
+        monkeypatch.setattr(_dqb, "_DEFAULT_PACK_ROOT", default_root)
+        monkeypatch.setattr(RaptorConfig, "EXTRA_CODEQL_PACK_ROOTS", [])
+        # Resolved pointer points at the same pack
+        monkeypatch.setattr(_dqb, "_resolved_pack_pointers",
+                            lambda: {"python": pack_dir})
+
+        # Should still find exactly one entry, not crash on duplicate
+        # walk into the same Security tree.
+        out = discover_prebuilt_queries()
+        assert out.get(("python", "CWE-78")) == ql
 
 
 # Tier 2 ---------------------------------------------------------------------


### PR DESCRIPTION
Two changes that together extend IRIS Tier 1 coverage from Python-only to all six languages CodeQL knows about:

1) Pack discovery via `codeql resolve qlpacks`

`_resolved_pack_pointers()` shells out to `codeql resolve qlpacks --format=json` and merges `codeql/<lang>-queries` paths into the discovery walk. Catches operators whose CodeQL install puts queries outside `~/.codeql/packages/codeql/` — most commonly the upstream `codeql-queries` checkout where C/C++ stdlib queries live. Layout- tolerant (`Security/...`, `<version>/Security/...`, and `Security/CWE/CWE-NNN/`); deduped by resolved absolute path. Sandbox- safe (metadata read only). 257 (lang, CWE) entries discovered now across 6 languages, was 47 / 1.

2) JS / Java / Go LocalFlowSource packs

Same gap as Python had pre-PR-A: stdlib CWE-78/22/89/94/502 queries default to `ActiveThreatModelSource` / `RemoteFlowSource` (network only). CLI flows like `process.argv → exec`, `args[0] → Runtime.exec`, `os.Args → exec.Command` fall outside.

Ships RAPTOR-bundled packs at
`packages/llm_analysis/codeql_packs/{javascript,java,go}-queries/` following PR-A's pattern: `LocalFlowSource.qll` selecting threat-model sources tagged `commandargs / environment / stdin / file / remote`, paired with companion queries reusing stdlib sink + sanitiser models. Java / Go extend `DataFlow::Node` with an `instanceof SourceNode` cast (SourceNode's `getThreatModel()` is abstract there).

C++ does not get a pack: stdlib `ExecTainted.ql` already uses the parent `FlowSource` (remote + local union). Coverage was already comprehensive — change (1) is what unlocks it for C++.

Empirical (real CodeQL on minimal argv→exec fixtures, all 4 langs):
  javascript : in-repo → 1 match  cmd_inj.js
  java       : in-repo → 1 match  CmdInj.java
  go         : in-repo → 1 match  cmd_inj.go
  cpp        : stdlib  → 1 match  cmd_inj.c

874 IRIS tests green; 5 new tests cover resolve-qlpacks (resolved pointers, nested-CWE layout, extras priority, codeql-unavailable fallback, dedup). Fixtures at
`tests/fixtures/iris_e2e_multilang/` with a reproduction README; covered by the PR-C `**/tests/fixtures/**` codeql-config exclusion so no live alerts generated.