### PR TITLE
fix(tests): set scorecard_enabled=False in LLMConfig.__new__ fixtures

### DIFF
--- a/core/llm/tests/test_fast_model_routing.py
+++ b/core/llm/tests/test_fast_model_routing.py
@@ -135,6 +135,7 @@ def test_no_primary_model_no_population() -> None:
     cfg.cache_max_entries = None
     cfg.enable_cost_tracking = False
     cfg.max_cost_per_scan = 10.0
+    cfg.scorecard_enabled = False  # avoid latent class-default pollution if a future code path consults scorecard
     cfg.__post_init__()                       # should be a no-op
 
     assert cfg.specialized_models == {}

--- a/core/llm/tests/test_provider_preference.py
+++ b/core/llm/tests/test_provider_preference.py
@@ -336,6 +336,7 @@ def test_llmclient_primary_provider_raises_without_primary_model() -> None:
     cfg.cache_dir = Path("/tmp")
     cfg.enable_cost_tracking = False
     cfg.max_cost_per_scan = 10.0
+    cfg.scorecard_enabled = False  # avoid latent class-default pollution if a future code path consults scorecard
     client = LLMClient.__new__(LLMClient)
     client.config = cfg
     client.providers = {}

--- a/core/llm/tests/test_structured_response_cache.py
+++ b/core/llm/tests/test_structured_response_cache.py
@@ -83,6 +83,7 @@ def _client(
     cfg.cache_max_entries = cache_max_entries
     cfg.enable_cost_tracking = False
     cfg.max_cost_per_scan = 100.0
+    cfg.scorecard_enabled = False  # avoid latent class-default pollution if a future code path consults scorecard
 
     if enable_caching:
         cfg.cache_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Three test fixtures construct LLMConfig via __new__() to skip the real constructor's autodetection. They explicitly set most fields, but scorecard_enabled is left to fall through to the dataclass class-level default of True. None of the current tests exercise client.scorecard, so this is latent — but any future test reusing one of these fixtures to drive a scorecard-touching code path would silently:

  * write a sidecar to the class-default scorecard_path (out/llm_scorecard.json — repo pollution)
  * inherit the 5% shadow_rate that flaked test_short_circuit_skips_full_when_scorecard_trusts_cell on PR #341.

Same pattern as the codeql fixture fix; converts a stateful trap into "scorecard cannot fire here regardless of future code paths."