### PR TITLE
feat(core/inventory): function-level reachability resolver

### DIFF
--- a/core/inventory/REACHABILITY.md
+++ b/core/inventory/REACHABILITY.md
@@ -1,0 +1,86 @@
+# Function-level reachability
+
+`core/inventory/reachability.py` answers: **is qualified function `X.Y.Z` actually called from this project?**
+
+It runs against the inventory artefact built by `core.inventory.build_inventory` and returns one of three verdicts: `CALLED`, `NOT_CALLED`, or `UNCERTAIN`.
+
+## When to use this
+
+- **SCA**: when an OSV advisory carries `database_specific.affected_functions`, downgrade reachability for findings whose affected functions are `NOT_CALLED`.
+- **CodeQL pre-filter**: skip building a full CodeQL DB when the candidate sink isn't called from any project file.
+- **/validate Stage B**: deprioritise attack paths whose entry function is `NOT_CALLED`.
+- **/agentic triage**: deprioritise findings on un-called code.
+
+## When NOT to use this
+
+If you need transitively-reachable analysis (call-graph closure), method-resolution-order awareness (subclass override tracking), or cross-package re-export following — use CodeQL. This resolver is sub-second; CodeQL is ~30s for the DB build but exhaustive. Different tool for a different job.
+
+## Quickstart
+
+```python
+from core.inventory.builder import build_inventory
+from core.inventory.reachability import function_called, Verdict
+
+inventory = build_inventory("/path/to/project", "/tmp/inventory-out")
+result = function_called(inventory, "requests.utils.extract_zipped_paths")
+
+if result.verdict == Verdict.NOT_CALLED:
+    print("safe to downgrade")
+elif result.verdict == Verdict.CALLED:
+    for path, line in result.evidence:
+        print(f"called from {path}:{line}")
+elif result.verdict == Verdict.UNCERTAIN:
+    for path, reason in result.uncertain_reasons:
+        print(f"can't be sure: {path} uses {reason}")
+```
+
+## Verdict semantics
+
+| Verdict | Meaning |
+|---|---|
+| `CALLED` | At least one call site demonstrably resolves to the queried qualified name via its file's import map. |
+| `NOT_CALLED` | No call site resolves AND no file with a tail-name candidate uses indirection that could mask such a call. |
+| `UNCERTAIN` | No demonstrable call, but at least one file uses indirection (`getattr` with literal string, `importlib.import_module`, `__import__`, wildcard import) that could plausibly call the function. |
+
+Consumers should treat `UNCERTAIN` as **"do not downgrade severity"** — false confidence in non-reachability is the worst outcome for security work.
+
+## How resolution works
+
+For a query like `requests.utils.extract_zipped_paths`:
+
+1. Walk every Python file in the inventory.
+2. For each call site, ask: does this call's chain (e.g. `["ezp"]` or `["requests", "utils", "extract_zipped_paths"]`) resolve to the target?
+   - **Bare name (`["ezp"]`)**: lookup `imports["ezp"]` and require exact match against the full qualified name.
+   - **Attribute chain (`["x", "y", "z"]`)**: resolve the head via the import map, concatenate with the middle parts, require the result equals `target_module.target_func`.
+3. If the file has no demonstrable call but mentions the target tail name (in a chain tail, an import tail, OR a `getattr(..., "tail")` literal), treat any masking-flag (`getattr`, `importlib`, `__import__`) as a confounder.
+4. Wildcard imports (`from x import *`) only count as confounders when `x`'s root module matches the target's root module — `from json import *` doesn't taint queries about `requests.get`.
+5. Test files are skipped by default (configurable via `exclude_test_files=False`).
+
+## Test-file exclusion
+
+By default, files matching these patterns don't count as evidence-for:
+
+- `tests/**` and `test/**`
+- `test_*.py` and `*_test.py`
+- `conftest.py`
+
+Why: `mock.patch("requests.get")` mentions a qualified name without calling it. Counting test-file usage as `CALLED` would keep severities pinned high purely because the project has good test coverage.
+
+## What's UNCERTAIN by design (documented, not "fix later")
+
+The resolver is a static AST walker. It cannot rule out, and so returns UNCERTAIN for:
+
+- **String dispatch**: `getattr(mod, "name")(...)`, `importlib.import_module(mod_name)`, `__import__(mod_name)`.
+- **Wildcard imports** when the source module's root matches the target's root.
+- **Decorator-driven dispatch**, plugin registries, runtime `setattr` injection.
+- **Method override on subclassed instances** (e.g. subclass `requests.Session`, override `get`). This is module-function reachability, not method-resolution-order reachability.
+- **Reflective dispatch via `eval` / `exec` / `pickle` / RPC**.
+- **Cross-package re-exports** the resolver hasn't been told about. A package that re-exports `requests.utils.extract_zipped_paths` as `mypkg.helpers.ezp` won't be matched on the `mypkg.helpers.ezp` qualified name unless the inventory captures the re-export.
+
+## Language support
+
+Python only at first cut. The resolver itself is language-agnostic — it operates on the `call_graph` field of each file record. Adding JavaScript / Go / Java is a matter of writing a `extract_call_graph_<lang>` function in `core/inventory/call_graph.py` that emits the same `FileCallGraph` dataclass and wiring it from `_process_single_file`.
+
+## Performance
+
+The data is captured as part of the existing inventory build (single AST walk per file alongside the function/class extractor). Resolver lookups are O(N_calls + N_imports) per file, dominated by dict lookups. For a ~1000-file project, a single `function_called(...)` query is sub-millisecond after the inventory's already loaded.

--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -23,6 +23,7 @@ from .exclusions import (
     match_exclusion_reason,
 )
 from .extractors import extract_functions, extract_items, count_sloc
+from .call_graph import extract_call_graph_python
 from .diff import compare_inventories
 
 logger = logging.getLogger(__name__)
@@ -348,7 +349,7 @@ def _process_single_file(
         items = extract_items(str(filepath), language, content, _tree_cache=tree_cache)
         sloc = count_sloc(content, language, _tree=tree_cache.get("tree"))
 
-        return {
+        record: Dict[str, Any] = {
             'path': rel_path,
             'language': language,
             'lines': line_count,
@@ -357,6 +358,13 @@ def _process_single_file(
             '_stat': file_stat,
             'items': [item.to_dict() for item in items],
         }
+        # Call-graph extraction is Python-only at first cut; the
+        # resolver in core.inventory.reachability is language-
+        # agnostic but the per-file walker is currently AST-based.
+        # Other languages get added when a consumer needs them.
+        if language == 'python':
+            record['call_graph'] = extract_call_graph_python(content).to_dict()
+        return record
 
     except Exception as e:
         logger.warning(f"Failed to process {filepath}: {e}")

--- a/core/inventory/call_graph.py
+++ b/core/inventory/call_graph.py
@@ -1,0 +1,286 @@
+"""Per-file call-graph extraction.
+
+Companion to :mod:`core.inventory.extractors`, which captures
+function *definitions*. This module captures the data needed to
+answer "is qualified function ``X.Y.Z`` actually called from this
+project?":
+
+  * **Import map** — for each imported name available in the file's
+    namespace, the dotted target it resolves to. ``import requests``
+    → ``{"requests": "requests"}``. ``import os.path as p`` →
+    ``{"p": "os.path"}``. ``from requests.utils import
+    extract_zipped_paths as ezp`` → ``{"ezp":
+    "requests.utils.extract_zipped_paths"}``.
+
+  * **Call sites** — every call expression in the file, recorded as
+    the attribute chain of the callee (``foo.bar.baz()`` →
+    ``["foo", "bar", "baz"]``), plus the line and the enclosing
+    function name. We don't record arguments or the call's value;
+    the resolver only needs "did this name get called".
+
+  * **Indirection flags** — set bits indicating the file does
+    something the static analysis can't follow:
+      * ``getattr(mod, "name")(...)`` — name-by-string dispatch.
+      * ``importlib.import_module("x.y")`` — runtime import.
+      * ``from x import *`` — wildcard imports a name we can't
+        statically know.
+
+Indirection flags are file-scoped (not per-call) because once any
+of them is present, every NOT_CALLED claim about that file becomes
+UNCERTAIN. Tracking per-call would let the resolver narrow the
+uncertainty, but the resolver consumers (SCA reachability, codeql
+pre-filter) treat UNCERTAIN as "don't downgrade severity" anyway —
+finer granularity buys nothing.
+
+Pure-AST. We never ``import_module`` the target, never look at any
+filesystem outside the source tree. String-shape only.
+
+This module is Python-only at first cut. JavaScript / Go / Java
+extension is straightforward — replace ``_PythonCallGraph`` with a
+language-specific AST walker that emits the same dataclasses. The
+resolver in :mod:`core.inventory.reachability` is language-agnostic.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import warnings
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+
+# Indirection-flag values. Strings (not enum) so they round-trip
+# through JSON cleanly without a from_dict shim.
+INDIRECTION_GETATTR = "getattr"
+INDIRECTION_IMPORTLIB = "importlib"
+INDIRECTION_WILDCARD_IMPORT = "wildcard_import"
+INDIRECTION_DUNDER_IMPORT = "dunder_import"     # __import__("x.y")
+
+
+@dataclass
+class CallSite:
+    """One call expression in a file.
+
+    ``chain`` is the attribute chain of the callee. ``foo.bar.baz()``
+    → ``["foo", "bar", "baz"]``. Plain function call ``f()`` →
+    ``["f"]``. Calls with non-name callees (e.g. ``(lambda x: x)()``,
+    ``f()()``, ``arr[0]()``) are NOT emitted — we have no qualified
+    name to match against.
+
+    ``caller`` is the name of the lexically-enclosing function /
+    method, or ``None`` for module-level calls. The resolver doesn't
+    use this today, but it's cheap to capture and useful for future
+    "transitively reachable from entry-point X" queries.
+    """
+    line: int
+    chain: List[str]
+    caller: Optional[str] = None
+
+
+@dataclass
+class FileCallGraph:
+    """All call-graph data for one Python file.
+
+    ``getattr_targets`` records the literal string second-arguments
+    seen in ``getattr(obj, "name")(...)`` calls. The resolver uses
+    this to detect "the file is plausibly calling target_func via
+    string dispatch" — a file that contains
+    ``getattr(requests, 'get')`` is a confounder for queries about
+    ``requests.get`` even if no static call chain has tail ``get``.
+    """
+    imports: Dict[str, str] = field(default_factory=dict)
+    calls: List[CallSite] = field(default_factory=list)
+    indirection: Set[str] = field(default_factory=set)
+    getattr_targets: Set[str] = field(default_factory=set)
+
+    def to_dict(self) -> dict:
+        return {
+            "imports": dict(self.imports),
+            "calls": [
+                {"line": c.line, "chain": list(c.chain),
+                 "caller": c.caller}
+                for c in self.calls
+            ],
+            "indirection": sorted(self.indirection),
+            "getattr_targets": sorted(self.getattr_targets),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "FileCallGraph":
+        return cls(
+            imports=dict(d.get("imports") or {}),
+            calls=[
+                CallSite(
+                    line=int(c.get("line", 0)),
+                    chain=list(c.get("chain") or []),
+                    caller=c.get("caller"),
+                )
+                for c in (d.get("calls") or [])
+            ],
+            indirection=set(d.get("indirection") or []),
+            getattr_targets=set(d.get("getattr_targets") or []),
+        )
+
+
+def extract_call_graph_python(content: str) -> FileCallGraph:
+    """Walk a Python source string and return its
+    :class:`FileCallGraph`.
+
+    Returns an empty graph (no imports, no calls, no indirection)
+    on syntax errors — a malformed file shouldn't blow up the
+    inventory build, and the resolver treats "no data" as "no
+    evidence", which collapses to NOT_CALLED for the function in
+    question (correct: a file we can't parse can't demonstrably
+    call anything).
+    """
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", SyntaxWarning)
+            tree = ast.parse(content)
+    except SyntaxError as e:
+        logger.debug("call_graph: skip unparseable file (%s)", e)
+        return FileCallGraph()
+
+    walker = _PythonCallGraph()
+    walker.visit(tree)
+    return walker.graph
+
+
+class _PythonCallGraph(ast.NodeVisitor):
+    """Single-pass AST walk emitting imports + call sites + flags."""
+
+    def __init__(self) -> None:
+        self.graph = FileCallGraph()
+        # Stack of enclosing function names, top is innermost.
+        self._enclosing: List[str] = []
+
+    # ------------------------------------------------------------------
+    # Imports
+    # ------------------------------------------------------------------
+
+    def visit_Import(self, node: ast.Import) -> None:
+        # ``import x``                  → {"x": "x"}
+        # ``import x.y``                → {"x": "x"} (the binding is x,
+        #                                  not x.y — Python convention)
+        # ``import x.y as p``           → {"p": "x.y"}
+        for alias in node.names:
+            target = alias.name
+            if alias.asname is not None:
+                self.graph.imports[alias.asname] = target
+            else:
+                # Bound name is the first component.
+                first = target.split(".", 1)[0]
+                self.graph.imports[first] = first
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        # ``from x.y import z``         → {"z": "x.y.z"}
+        # ``from x.y import z as q``    → {"q": "x.y.z"}
+        # ``from x import *``           → flag wildcard, no map entry
+        # ``from . import z``           → relative; skip (we don't
+        #                                  resolve package roots here)
+        module = node.module or ""
+        if node.level and node.level > 0:
+            # Relative import — without the package root we can't
+            # resolve to a qualified name. Don't record; let downstream
+            # treat as out-of-scope.
+            self.generic_visit(node)
+            return
+        for alias in node.names:
+            if alias.name == "*":
+                self.graph.indirection.add(INDIRECTION_WILDCARD_IMPORT)
+                continue
+            local = alias.asname or alias.name
+            qualified = f"{module}.{alias.name}" if module else alias.name
+            self.graph.imports[local] = qualified
+        self.generic_visit(node)
+
+    # ------------------------------------------------------------------
+    # Function-scope tracking
+    # ------------------------------------------------------------------
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._enclosing.append(node.name)
+        try:
+            self.generic_visit(node)
+        finally:
+            self._enclosing.pop()
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._enclosing.append(node.name)
+        try:
+            self.generic_visit(node)
+        finally:
+            self._enclosing.pop()
+
+    # ------------------------------------------------------------------
+    # Calls + indirection
+    # ------------------------------------------------------------------
+
+    def visit_Call(self, node: ast.Call) -> None:
+        chain = _attribute_chain(node.func)
+        if chain is None:
+            # Non-name callee (lambda, subscript, returned function
+            # call, etc.) — nothing for the resolver to match.
+            self.generic_visit(node)
+            return
+
+        # Indirection: getattr(obj, "name")(...)
+        if (chain == ["getattr"] and len(node.args) >= 2
+                and isinstance(node.args[1], ast.Constant)
+                and isinstance(node.args[1].value, str)):
+            self.graph.indirection.add(INDIRECTION_GETATTR)
+            self.graph.getattr_targets.add(node.args[1].value)
+
+        # Indirection: importlib.import_module("x.y")
+        if chain == ["importlib", "import_module"]:
+            self.graph.indirection.add(INDIRECTION_IMPORTLIB)
+        if chain == ["import_module"]:
+            # ``from importlib import import_module`` then bare call.
+            qualified = self.graph.imports.get("import_module")
+            if qualified == "importlib.import_module":
+                self.graph.indirection.add(INDIRECTION_IMPORTLIB)
+
+        # Indirection: __import__("x.y")
+        if chain == ["__import__"]:
+            self.graph.indirection.add(INDIRECTION_DUNDER_IMPORT)
+
+        caller = self._enclosing[-1] if self._enclosing else None
+        self.graph.calls.append(CallSite(
+            line=getattr(node, "lineno", 0),
+            chain=chain,
+            caller=caller,
+        ))
+        self.generic_visit(node)
+
+
+def _attribute_chain(node: ast.AST) -> Optional[List[str]]:
+    """Convert ``foo.bar.baz`` into ``["foo", "bar", "baz"]``.
+
+    Returns ``None`` for non-name callees (function returns,
+    subscripts, lambdas, etc.) — those have no qualified name we
+    could resolve against an import map.
+    """
+    parts: List[str] = []
+    cur = node
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        parts.append(cur.id)
+        return list(reversed(parts))
+    return None
+
+
+__all__ = [
+    "CallSite",
+    "FileCallGraph",
+    "INDIRECTION_DUNDER_IMPORT",
+    "INDIRECTION_GETATTR",
+    "INDIRECTION_IMPORTLIB",
+    "INDIRECTION_WILDCARD_IMPORT",
+    "extract_call_graph_python",
+]

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -1,0 +1,320 @@
+"""Function-level reachability resolver.
+
+Answers "is qualified-function ``X.Y.Z`` actually called from this
+project?" using the call-graph data captured by
+:mod:`core.inventory.call_graph` and stored in the inventory
+artefact.
+
+The resolver is language-agnostic. The first-cut data producer
+(``call_graph.extract_call_graph_python``) is Python-only, so
+non-Python files contribute neither evidence-for nor evidence-
+against — they're skipped as "no data". Other-language consumers
+get added when a producer for that language ships.
+
+## Verdict semantics
+
+  * ``CALLED`` — at least one call site in non-test project code
+    demonstrably resolves to the queried qualified name via its
+    file's import map.
+  * ``NOT_CALLED`` — no call site resolves to the qualified name,
+    AND no file with a tail-name candidate has an indirection flag
+    (``getattr`` / ``importlib.import_module`` / ``__import__`` /
+    wildcard import) that could plausibly mask such a call.
+  * ``UNCERTAIN`` — no call site resolves, but at least one file
+    that could plausibly call this function uses indirection. We
+    refuse to claim NOT_CALLED in that case.
+
+Consumers translate UNCERTAIN to "do not downgrade severity" — it's
+the safe choice for security work, where false-confidence in
+non-reachability is the worst outcome.
+
+## Out of scope (UNCERTAIN by design — documented, not "fix
+later")
+
+  * Decorator-driven dispatch, plugin registries, dynamic
+    ``setattr`` injection.
+  * Method dispatch on subclassed instances (e.g. subclass
+    ``requests.Session``, override ``get``). This is *module-
+    function* reachability, not method-resolution-order
+    reachability.
+  * String-based reflective dispatch beyond ``getattr`` /
+    ``importlib`` / ``__import__`` (eval / exec / pickle / RPC).
+  * Cross-package re-exports the resolver hasn't been told about.
+    A package that re-exports ``requests.utils.extract_zipped_paths``
+    as ``mypkg.helpers.ezp`` won't be matched on the
+    ``mypkg.helpers.ezp`` qualified name unless the inventory
+    captures the re-export — and at first cut, it doesn't.
+
+If the consumer cares about any of those, CodeQL's call-graph
+queries are the right tool — at the cost of a ~30s DB build.
+This resolver is meant to be sub-second.
+
+## Test-file exclusion
+
+By default, files matching a test path pattern (``tests/``,
+``test_*.py``, ``*_test.py``, ``conftest.py``) are NOT counted as
+evidence-for. ``mock.patch("requests.get")`` mentions a qualified
+name without calling it; counting test-file uses as CALLED would
+keep severities pinned high purely because the project has good
+test coverage. Pass ``exclude_test_files=False`` to opt out.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from .call_graph import (
+    INDIRECTION_DUNDER_IMPORT,
+    INDIRECTION_GETATTR,
+    INDIRECTION_IMPORTLIB,
+    INDIRECTION_WILDCARD_IMPORT,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Verdict(str, Enum):
+    """Reachability verdict for a queried qualified name."""
+    CALLED = "called"
+    NOT_CALLED = "not_called"
+    UNCERTAIN = "uncertain"
+
+
+@dataclass(frozen=True)
+class ReachabilityResult:
+    """Verdict plus diagnostic detail.
+
+    ``evidence`` lists the (file_path, line) pairs that demonstrate
+    a CALLED verdict — empty for NOT_CALLED / UNCERTAIN. Consumers
+    can surface these to operators ("called from src/handler.py:42").
+
+    ``uncertain_reasons`` lists ``(file_path, indirection_flag)``
+    pairs that explain UNCERTAIN — e.g.
+    ``[("src/dynamic.py", "getattr")]`` says we couldn't rule out a
+    call because that file uses ``getattr``-by-name dispatch.
+    """
+    verdict: Verdict
+    evidence: Tuple[Tuple[str, int], ...] = ()
+    uncertain_reasons: Tuple[Tuple[str, str], ...] = ()
+
+
+# Test-file pattern. Matches paths that look like pytest /
+# unittest / nose conventions — covers ``tests/x.py``,
+# ``tests/sub/x.py``, ``test_x.py``, ``x_test.py``, ``conftest.py``,
+# and the conventional ``tests`` directory at any depth.
+_TEST_FILE_PATTERN = re.compile(
+    r"(^|/)("
+    r"tests?/.*|"
+    r"test_[^/]+\.py|"
+    r"[^/]+_test\.py|"
+    r"conftest\.py"
+    r")$"
+)
+
+
+# Indirection flags that can mask a static "not called" claim.
+_MASKING_FLAGS: Set[str] = {
+    INDIRECTION_GETATTR,
+    INDIRECTION_IMPORTLIB,
+    INDIRECTION_DUNDER_IMPORT,
+    INDIRECTION_WILDCARD_IMPORT,
+}
+
+
+def function_called(
+    inventory: Dict[str, Any],
+    qualified_name: str,
+    *,
+    exclude_test_files: bool = True,
+) -> ReachabilityResult:
+    """Determine whether ``qualified_name`` is called by the project
+    described by ``inventory``.
+
+    ``inventory`` is the dict shape emitted by
+    :func:`core.inventory.build_inventory` — has a top-level
+    ``files`` list, each entry potentially carrying a
+    ``call_graph`` field (Python files only at first cut).
+
+    ``qualified_name`` is dotted, e.g.
+    ``"requests.utils.extract_zipped_paths"``. Bare function name
+    (no dots) is treated as a top-level module function in an
+    unknown module — useful only for builtins (``"open"``) and
+    raises ``ValueError`` because the resolver can't validate
+    against an empty import-chain prefix.
+    """
+    if not qualified_name or "." not in qualified_name:
+        raise ValueError(
+            "qualified_name must be dotted (module.function); got "
+            f"{qualified_name!r}",
+        )
+
+    target_parts = qualified_name.split(".")
+    target_func = target_parts[-1]
+    target_module_parts = target_parts[:-1]
+    target_module = ".".join(target_module_parts)
+
+    evidence: List[Tuple[str, int]] = []
+    uncertain_reasons: List[Tuple[str, str]] = []
+
+    for file_record in inventory.get("files", []):
+        path = file_record.get("path") or ""
+        if exclude_test_files and _is_test_file(path):
+            continue
+        cg = file_record.get("call_graph")
+        if not cg:
+            continue
+        imports = cg.get("imports") or {}
+        calls = cg.get("calls") or []
+        flags = set(cg.get("indirection") or [])
+
+        getattr_targets = set(cg.get("getattr_targets") or [])
+
+        file_has_evidence = False
+        for call in calls:
+            chain = call.get("chain") or []
+            if not chain:
+                continue
+            if _resolves_to(chain, imports, target_module, target_func):
+                file_has_evidence = True
+                evidence.append((path, int(call.get("line", 0) or 0)))
+
+        if file_has_evidence:
+            continue
+
+        # Indirection is only a confounder when there's *some*
+        # signal that this file might be calling the target. A file
+        # that uses getattr but doesn't mention the target name in
+        # any form isn't suspect.
+        file_mentions_tail = (
+            target_func in getattr_targets
+            or any(
+                (c.get("chain") or [])[-1:] == [target_func]
+                for c in calls
+            )
+            or any(
+                qualified.split(".")[-1] == target_func
+                for qualified in imports.values()
+            )
+        )
+
+        # getattr / importlib / __import__ flags taint a file IFF
+        # the file mentions the target tail name (chain tail, import
+        # tail, or getattr literal). Wildcard imports are routed
+        # through _wildcard_could_provide because they only mask
+        # what their source module could plausibly export.
+        non_wildcard_flags = (flags & _MASKING_FLAGS) - {
+            INDIRECTION_WILDCARD_IMPORT,
+        }
+        if non_wildcard_flags and file_mentions_tail:
+            for flag in sorted(non_wildcard_flags):
+                uncertain_reasons.append((path, flag))
+
+        if INDIRECTION_WILDCARD_IMPORT in flags and (
+            _wildcard_could_provide(imports, target_module, target_func)
+        ):
+            uncertain_reasons.append((path, INDIRECTION_WILDCARD_IMPORT))
+
+    if evidence:
+        return ReachabilityResult(
+            verdict=Verdict.CALLED,
+            evidence=tuple(evidence),
+            uncertain_reasons=tuple(uncertain_reasons),
+        )
+    if uncertain_reasons:
+        return ReachabilityResult(
+            verdict=Verdict.UNCERTAIN,
+            uncertain_reasons=tuple(uncertain_reasons),
+        )
+    return ReachabilityResult(verdict=Verdict.NOT_CALLED)
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolves_to(
+    chain: List[str],
+    imports: Dict[str, str],
+    target_module: str,
+    target_func: str,
+) -> bool:
+    """Return True iff ``chain`` (in this file's namespace) refers to
+    ``target_module.target_func``.
+
+    Two main shapes:
+
+    1. Bare-name call: ``ezp(...)`` → ``chain == ["ezp"]``. Resolve
+       via ``imports[chain[0]]`` and require it equal the full
+       ``target_module.target_func``.
+    2. Attribute-chain call: ``requests.utils.foo(...)`` →
+       ``chain == ["requests", "utils", "foo"]``. Resolve the head
+       (``"requests"``) via the import map, then concatenate the
+       middle parts with the resolved head and require equality.
+    """
+    if len(chain) == 1:
+        # Bare-name call. Must be in the import map and resolve
+        # exactly to the full target.
+        bound = imports.get(chain[0])
+        if bound is None:
+            return False
+        return bound == f"{target_module}.{target_func}"
+
+    head = chain[0]
+    bound = imports.get(head)
+    if bound is None:
+        return False
+    middle = ".".join(chain[1:-1])
+    if middle:
+        resolved_module = f"{bound}.{middle}"
+    else:
+        resolved_module = bound
+    return resolved_module == target_module and chain[-1] == target_func
+
+
+def _wildcard_could_provide(
+    imports: Dict[str, str],
+    target_module: str,
+    target_func: str,
+) -> bool:
+    """Heuristic: does this file have any import map entry whose
+    qualified prefix matches ``target_module``?
+
+    Wildcard imports (``from x.y import *``) don't end up in the
+    import map at all, so we can't see whether they would have
+    bound ``target_func``. This is best-effort: if any other import
+    in this file targets the same module prefix as ``target_module``,
+    treat the wildcard as plausible cover. Avoids spamming
+    UNCERTAIN for a wildcard from a totally unrelated module.
+
+    Without this, a wildcard import of ``json.*`` would mask
+    NOT_CALLED claims about ``requests.utils.foo``, which is
+    nonsense.
+    """
+    # If any other recorded import in this file shares the target
+    # module's first component, treat the wildcard as plausible.
+    target_root = target_module.split(".", 1)[0]
+    for qualified in imports.values():
+        if qualified.split(".", 1)[0] == target_root:
+            return True
+    return False
+
+
+def _is_test_file(path: str) -> bool:
+    """Conventional test-file detection. Matches paths under any
+    ``tests/`` or ``test/`` directory, plus ``test_*.py``,
+    ``*_test.py``, ``conftest.py``."""
+    norm = path.replace(os.sep, "/")
+    return bool(_TEST_FILE_PATTERN.search(norm))
+
+
+__all__ = [
+    "ReachabilityResult",
+    "Verdict",
+    "function_called",
+]

--- a/core/inventory/tests/test_call_graph.py
+++ b/core/inventory/tests/test_call_graph.py
@@ -1,0 +1,227 @@
+"""Tests for :mod:`core.inventory.call_graph`.
+
+The call-graph extractor sits between the AST and the resolver.
+Tests pin the data shape — broken extraction breaks reachability
+verdicts silently, so the data layer needs explicit coverage.
+"""
+
+from __future__ import annotations
+
+from core.inventory.call_graph import (
+    CallSite,
+    FileCallGraph,
+    INDIRECTION_DUNDER_IMPORT,
+    INDIRECTION_GETATTR,
+    INDIRECTION_IMPORTLIB,
+    INDIRECTION_WILDCARD_IMPORT,
+    extract_call_graph_python,
+)
+
+
+# ---------------------------------------------------------------------------
+# Imports
+# ---------------------------------------------------------------------------
+
+
+def test_plain_import():
+    g = extract_call_graph_python("import os\n")
+    assert g.imports == {"os": "os"}
+
+
+def test_dotted_import_binds_first_component():
+    """``import os.path`` binds ``os`` (Python's import semantics);
+    later use is ``os.path.join``."""
+    g = extract_call_graph_python("import os.path\n")
+    assert g.imports == {"os": "os"}
+
+
+def test_aliased_import():
+    g = extract_call_graph_python("import os.path as p\n")
+    assert g.imports == {"p": "os.path"}
+
+
+def test_from_import():
+    g = extract_call_graph_python("from os.path import join\n")
+    assert g.imports == {"join": "os.path.join"}
+
+
+def test_from_import_aliased():
+    g = extract_call_graph_python("from os.path import join as j\n")
+    assert g.imports == {"j": "os.path.join"}
+
+
+def test_from_import_multiple():
+    g = extract_call_graph_python(
+        "from os.path import join, dirname, basename\n",
+    )
+    assert g.imports == {
+        "join": "os.path.join",
+        "dirname": "os.path.dirname",
+        "basename": "os.path.basename",
+    }
+
+
+def test_wildcard_import_flagged_not_mapped():
+    g = extract_call_graph_python("from os.path import *\n")
+    assert g.imports == {}
+    assert INDIRECTION_WILDCARD_IMPORT in g.indirection
+
+
+def test_relative_import_skipped():
+    """``from . import x`` isn't qualifiable without the package
+    root — skipped from the import map and from the resolver."""
+    g = extract_call_graph_python("from . import sibling\n")
+    assert g.imports == {}
+
+
+# ---------------------------------------------------------------------------
+# Calls
+# ---------------------------------------------------------------------------
+
+
+def test_bare_call_recorded():
+    g = extract_call_graph_python("from os.path import join\njoin('a', 'b')\n")
+    assert any(c.chain == ["join"] for c in g.calls)
+
+
+def test_attribute_chain_recorded():
+    g = extract_call_graph_python("import os.path\nos.path.join('a', 'b')\n")
+    assert any(c.chain == ["os", "path", "join"] for c in g.calls)
+
+
+def test_caller_function_tracked():
+    g = extract_call_graph_python(
+        "def outer():\n"
+        "    inner()\n"
+    )
+    inner = [c for c in g.calls if c.chain == ["inner"]]
+    assert len(inner) == 1
+    assert inner[0].caller == "outer"
+
+
+def test_caller_innermost_function_wins():
+    """Nested functions: the call's caller is the innermost
+    enclosing function."""
+    g = extract_call_graph_python(
+        "def outer():\n"
+        "    def inner():\n"
+        "        target()\n"
+        "    inner()\n"
+    )
+    target_call = [c for c in g.calls if c.chain == ["target"]]
+    assert target_call[0].caller == "inner"
+
+
+def test_module_level_call_has_no_caller():
+    g = extract_call_graph_python("foo()\n")
+    foo = [c for c in g.calls if c.chain == ["foo"]]
+    assert foo[0].caller is None
+
+
+def test_method_call_records_chain():
+    g = extract_call_graph_python(
+        "obj = something()\nobj.method()\n",
+    )
+    method_calls = [c for c in g.calls if c.chain == ["obj", "method"]]
+    assert len(method_calls) == 1
+
+
+def test_lambda_call_not_recorded():
+    """``(lambda x: x)()`` has no qualified callee — skipped."""
+    g = extract_call_graph_python("(lambda x: x)(1)\n")
+    # The wrapped lambda call itself shouldn't appear in the chain;
+    # there are no name-shaped callees here.
+    assert all(c.chain != [] for c in g.calls)
+
+
+def test_returned_function_call_not_recorded():
+    """``f()()`` — the outer call has no qualified name."""
+    g = extract_call_graph_python(
+        "def f():\n    return lambda: None\nf()()\n"
+    )
+    # Inner ``f()`` recorded, outer call (with Call as func) skipped.
+    assert any(c.chain == ["f"] for c in g.calls)
+
+
+def test_call_line_numbers():
+    g = extract_call_graph_python(
+        "import os\n"
+        "\n"
+        "os.getcwd()\n"
+    )
+    osg = [c for c in g.calls if c.chain == ["os", "getcwd"]]
+    assert osg[0].line == 3
+
+
+# ---------------------------------------------------------------------------
+# Indirection flags
+# ---------------------------------------------------------------------------
+
+
+def test_getattr_string_dispatch_flagged():
+    g = extract_call_graph_python(
+        "import os\n"
+        "getattr(os, 'getcwd')()\n"
+    )
+    assert INDIRECTION_GETATTR in g.indirection
+
+
+def test_getattr_with_non_constant_not_flagged():
+    """``getattr(obj, attr)`` with a variable second arg isn't the
+    string-dispatch pattern we care about."""
+    g = extract_call_graph_python(
+        "def f(obj, attr):\n"
+        "    getattr(obj, attr)()\n"
+    )
+    assert INDIRECTION_GETATTR not in g.indirection
+
+
+def test_importlib_import_module_flagged():
+    g = extract_call_graph_python(
+        "import importlib\n"
+        "importlib.import_module('os.path')\n"
+    )
+    assert INDIRECTION_IMPORTLIB in g.indirection
+
+
+def test_importlib_bare_import_module_flagged():
+    """``from importlib import import_module`` then bare call."""
+    g = extract_call_graph_python(
+        "from importlib import import_module\n"
+        "import_module('os.path')\n"
+    )
+    assert INDIRECTION_IMPORTLIB in g.indirection
+
+
+def test_dunder_import_flagged():
+    g = extract_call_graph_python("__import__('os.path')\n")
+    assert INDIRECTION_DUNDER_IMPORT in g.indirection
+
+
+# ---------------------------------------------------------------------------
+# Resilience
+# ---------------------------------------------------------------------------
+
+
+def test_syntax_error_returns_empty_graph():
+    """A malformed file shouldn't blow up the inventory build."""
+    g = extract_call_graph_python("def broken(:\n  pass")
+    assert g == FileCallGraph()
+
+
+def test_round_trip_through_dict():
+    """The extractor's output must round-trip cleanly through
+    JSON-shaped dicts so the inventory artefact stays loadable."""
+    g = extract_call_graph_python(
+        "import os.path as p\n"
+        "from sys import exit\n"
+        "p.join('a')\n"
+        "getattr(p, 'dirname')('/x')\n"
+    )
+    d = g.to_dict()
+    g2 = FileCallGraph.from_dict(d)
+    assert g2.imports == g.imports
+    assert {tuple(c.chain) for c in g2.calls} == {
+        tuple(c.chain) for c in g.calls
+    }
+    assert g2.indirection == g.indirection

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -1,0 +1,323 @@
+"""Tests for :mod:`core.inventory.reachability`.
+
+These exercise the resolver against synthetic inventory dicts. The
+goal is to pin all the import / call-site shapes that arise in
+real Python code so a SCA "this CVE function isn't reachable"
+verdict means what it claims.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from core.inventory.call_graph import (
+    INDIRECTION_DUNDER_IMPORT,
+    INDIRECTION_GETATTR,
+    INDIRECTION_IMPORTLIB,
+    INDIRECTION_WILDCARD_IMPORT,
+    extract_call_graph_python,
+)
+from core.inventory.reachability import (
+    ReachabilityResult,
+    Verdict,
+    function_called,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _inv(*files: tuple) -> Dict[str, Any]:
+    """Build a synthetic inventory from ``(path, source)`` pairs."""
+    out: List[Dict[str, Any]] = []
+    for path, source in files:
+        cg = extract_call_graph_python(source).to_dict()
+        out.append({
+            "path": path,
+            "language": "python",
+            "call_graph": cg,
+        })
+    return {"files": out}
+
+
+# ---------------------------------------------------------------------------
+# CALLED — direct-import shapes
+# ---------------------------------------------------------------------------
+
+
+def test_attribute_chain_call_resolves():
+    inv = _inv(("src/a.py", "import requests\nrequests.get('/')\n"))
+    r = function_called(inv, "requests.get")
+    assert r.verdict == Verdict.CALLED
+    assert r.evidence == (("src/a.py", 2),)
+
+
+def test_aliased_module_resolves():
+    inv = _inv((
+        "src/a.py",
+        "import requests.utils as ru\nru.extract_zipped_paths('/')\n",
+    ))
+    r = function_called(inv, "requests.utils.extract_zipped_paths")
+    assert r.verdict == Verdict.CALLED
+
+
+def test_from_import_aliased_resolves():
+    inv = _inv((
+        "src/a.py",
+        "from requests.utils import extract_zipped_paths as ezp\n"
+        "ezp('/')\n",
+    ))
+    r = function_called(inv, "requests.utils.extract_zipped_paths")
+    assert r.verdict == Verdict.CALLED
+
+
+def test_from_import_no_alias_resolves():
+    inv = _inv((
+        "src/a.py",
+        "from requests import get\nget('/')\n",
+    ))
+    r = function_called(inv, "requests.get")
+    assert r.verdict == Verdict.CALLED
+
+
+def test_dotted_module_attribute_chain_resolves():
+    """``from os import path; path.join(...)`` — aliased to a
+    sub-module."""
+    inv = _inv((
+        "src/a.py",
+        "from os import path\npath.join('a', 'b')\n",
+    ))
+    r = function_called(inv, "os.path.join")
+    assert r.verdict == Verdict.CALLED
+
+
+# ---------------------------------------------------------------------------
+# NOT_CALLED
+# ---------------------------------------------------------------------------
+
+
+def test_imported_but_never_called():
+    inv = _inv((
+        "src/a.py",
+        "import requests\nx = 1\n",
+    ))
+    r = function_called(inv, "requests.get")
+    assert r.verdict == Verdict.NOT_CALLED
+
+
+def test_calls_different_function_in_same_module():
+    inv = _inv((
+        "src/a.py",
+        "import requests\nrequests.post('/')\n",
+    ))
+    r = function_called(inv, "requests.get")
+    assert r.verdict == Verdict.NOT_CALLED
+
+
+def test_calls_same_tail_in_different_module():
+    """Local function ``get`` shadows the queried ``requests.get``;
+    chain doesn't resolve to the target."""
+    inv = _inv((
+        "src/a.py",
+        "def get():\n    return 1\nget()\n",
+    ))
+    r = function_called(inv, "requests.get")
+    assert r.verdict == Verdict.NOT_CALLED
+
+
+def test_empty_inventory():
+    r = function_called({"files": []}, "requests.get")
+    assert r.verdict == Verdict.NOT_CALLED
+
+
+# ---------------------------------------------------------------------------
+# UNCERTAIN — indirection masking
+# ---------------------------------------------------------------------------
+
+
+def test_getattr_with_tail_match_is_uncertain():
+    """A file that uses ``getattr`` AND has a call whose tail
+    matches the target function name → UNCERTAIN, because the
+    getattr could be the call."""
+    inv = _inv((
+        "src/a.py",
+        "import requests\n"
+        "def f():\n"
+        "    g = getattr(requests, 'get')\n"
+        "    g()\n"
+    ))
+    r = function_called(inv, "requests.get")
+    assert r.verdict == Verdict.UNCERTAIN
+    assert any(reason == "getattr" for _, reason in r.uncertain_reasons)
+
+
+def test_getattr_in_unrelated_file_doesnt_taint():
+    """File-A has no mention of the target tail name AND uses
+    getattr — NOT a confounder. File-B doesn't call the target →
+    NOT_CALLED."""
+    inv = _inv(
+        ("src/a.py", "x = getattr(object(), 'something_else')\n"),
+        ("src/b.py", "import requests\nrequests.post('/')\n"),
+    )
+    r = function_called(inv, "requests.get")
+    assert r.verdict == Verdict.NOT_CALLED
+
+
+def test_importlib_with_tail_match_is_uncertain():
+    inv = _inv((
+        "src/a.py",
+        "import importlib\n"
+        "def f():\n"
+        "    m = importlib.import_module('requests')\n"
+        "    m.get()\n"
+    ))
+    r = function_called(inv, "requests.get")
+    assert r.verdict == Verdict.UNCERTAIN
+
+
+def test_dunder_import_with_tail_match_is_uncertain():
+    inv = _inv((
+        "src/a.py",
+        "def f():\n"
+        "    m = __import__('requests')\n"
+        "    m.get()\n"
+    ))
+    r = function_called(inv, "requests.get")
+    assert r.verdict == Verdict.UNCERTAIN
+
+
+def test_wildcard_from_unrelated_module_doesnt_taint():
+    """``from json import *`` in a file with a `.get(...)` call
+    must not taint a query about ``requests.get``."""
+    inv = _inv((
+        "src/a.py",
+        "from json import *\n"
+        "x = 1\n"
+        "x.get('foo')\n"
+    ))
+    r = function_called(inv, "requests.get")
+    assert r.verdict == Verdict.NOT_CALLED
+
+
+def test_wildcard_from_same_root_module_is_uncertain():
+    """``from requests import *`` then bare ``get(...)`` — wildcard
+    plausibly bound ``get``. Conservative: UNCERTAIN."""
+    inv = _inv((
+        "src/a.py",
+        "import requests\n"
+        "from requests.utils import *\n"
+        "get('/')\n"
+    ))
+    r = function_called(inv, "requests.get")
+    assert r.verdict == Verdict.UNCERTAIN
+
+
+# ---------------------------------------------------------------------------
+# Test-file exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_test_file_excluded_by_default():
+    """Mock-style references in tests aren't real calls."""
+    inv = _inv((
+        "tests/test_thing.py",
+        "import requests\nrequests.get('/')\n",
+    ))
+    r = function_called(inv, "requests.get")
+    assert r.verdict == Verdict.NOT_CALLED
+
+
+def test_test_file_included_when_opted_in():
+    inv = _inv((
+        "tests/test_thing.py",
+        "import requests\nrequests.get('/')\n",
+    ))
+    r = function_called(inv, "requests.get", exclude_test_files=False)
+    assert r.verdict == Verdict.CALLED
+
+
+def test_conftest_excluded_by_default():
+    inv = _inv((
+        "conftest.py",
+        "import requests\nrequests.get('/')\n",
+    ))
+    r = function_called(inv, "requests.get")
+    assert r.verdict == Verdict.NOT_CALLED
+
+
+def test_test_suffix_filename_excluded_by_default():
+    inv = _inv((
+        "src/widget_test.py",
+        "import requests\nrequests.get('/')\n",
+    ))
+    r = function_called(inv, "requests.get")
+    assert r.verdict == Verdict.NOT_CALLED
+
+
+# ---------------------------------------------------------------------------
+# Multiple files
+# ---------------------------------------------------------------------------
+
+
+def test_evidence_lists_all_call_sites_across_files():
+    inv = _inv(
+        ("src/a.py", "import requests\nrequests.get('/')\n"),
+        ("src/b.py", "import requests\n\nrequests.get('/x')\n"),
+    )
+    r = function_called(inv, "requests.get")
+    assert r.verdict == Verdict.CALLED
+    assert set(r.evidence) == {("src/a.py", 2), ("src/b.py", 3)}
+
+
+def test_one_called_one_uncertain_returns_called():
+    """Hard evidence beats indirection. CALLED + UNCERTAIN → CALLED.
+    The uncertain reasons are still attached for transparency."""
+    inv = _inv(
+        ("src/a.py", "import requests\nrequests.get('/')\n"),
+        ("src/b.py",
+         "import requests\ndef f():\n    g = getattr(requests, 'get')\n    g()\n"),
+    )
+    r = function_called(inv, "requests.get")
+    assert r.verdict == Verdict.CALLED
+
+
+# ---------------------------------------------------------------------------
+# API surface
+# ---------------------------------------------------------------------------
+
+
+def test_bare_function_name_rejected():
+    """Querying ``"open"`` is meaningless without a module — the
+    resolver can't tell ``builtins.open`` from a local ``open``."""
+    import pytest
+    with pytest.raises(ValueError):
+        function_called({"files": []}, "open")
+
+
+def test_non_python_files_silently_skipped():
+    """Files without a ``call_graph`` field (e.g. JS, Go, C) are
+    no-evidence — they don't contribute either way."""
+    inv = {
+        "files": [
+            {"path": "src/a.js", "language": "javascript"},  # no call_graph
+            {"path": "src/b.py", "language": "python",
+             "call_graph": extract_call_graph_python(
+                 "import requests\nrequests.get('/')\n"
+             ).to_dict()},
+        ]
+    }
+    r = function_called(inv, "requests.get")
+    assert r.verdict == Verdict.CALLED
+
+
+def test_result_is_immutable():
+    """``ReachabilityResult`` is frozen — consumers can stash it
+    without defensive-copying."""
+    r = function_called({"files": []}, "requests.get")
+    import dataclasses
+    assert dataclasses.is_dataclass(r)
+    import pytest
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        r.verdict = Verdict.CALLED  # type: ignore[misc]


### PR DESCRIPTION
Substrate for "is qualified function X.Y.Z actually called from this project?" — sub-second pre-filter for SCA (downgrade CVEs whose affected functions aren't called), CodeQL (skip DB build for un-called sinks), /validate (deprioritise attack paths whose entry isn't called), /agentic (triage weighting).

Built rather than reaching for CodeQL because the perf goal is sub-second; CodeQL's call-graph queries are exhaustive but pay ~30s per DB build. Use the resolver as a pre-filter, fall through to CodeQL on UNCERTAIN.

* core/inventory/call_graph.py — per-Python-file AST walk emitting imports + call sites + indirection flags + getattr-literal targets.
* core/inventory/reachability.py — function_called(inventory, "x.y.z") -> CALLED / NOT_CALLED / UNCERTAIN. Test files excluded from CALLED evidence by default. UNCERTAIN routed through the file's indirection-flag set; wildcard imports only count as confounders when source module root matches target root.
* core/inventory/builder.py — Python files now carry a call_graph field on each inventory record.
* core/inventory/REACHABILITY.md — verdict semantics, what's UNCERTAIN-by-design, quickstart.
* 48 new tests; 196 total in core/inventory passing.