### PR TITLE
feat(codeql): surface fast-tier scorecard savings in /codeql summary

### DIFF
--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -250,6 +250,12 @@ class LLMClient:
         self.total_cost = 0.0
         self.request_count = 0
         self.task_type_costs: Dict[str, float] = {}  # task_type → cumulative cost
+        # Number of full ANALYSE calls avoided because the scorecard
+        # trusted the cheap-tier verdict and the consumer short-
+        # circuited. Bumped by consumers via ``record_short_circuit``;
+        # surfaced in /codeql's summary so the scorecard's effect on
+        # cost shows up as a concrete line.
+        self.short_circuits = 0
         self._stats_lock = threading.RLock()
         # Per-cache-key locks. Two threads issuing the same cache key
         # serialise on its lock so only one calls the provider; the
@@ -371,6 +377,14 @@ class LLMClient:
                 shadow_rate=self.config.scorecard_shadow_rate,
             )
         return self._scorecard
+
+    def record_short_circuit(self) -> None:
+        """Bump the avoided-full-call counter. Called by consumers
+        (codeql's autonomous_analyzer and dataflow_validator) right
+        after they take the scorecard-trusted short-circuit path so
+        the saving shows up in the run summary."""
+        with self._stats_lock:
+            self.short_circuits += 1
 
     def _key_lock(self, cache_key: str) -> "threading.Lock":
         """Return (creating if needed) a per-key lock used to dedupe

--- a/packages/codeql/autonomous_analyzer.py
+++ b/packages/codeql/autonomous_analyzer.py
@@ -428,6 +428,7 @@ class AutonomousCodeQLAnalyzer:
                 f"skipping full analysis (cheap verdict trusted by "
                 f"scorecard)"
             )
+            self.llm.record_short_circuit()
             return self._short_circuit_fp_result(cheap_reasoning)
 
         system = (

--- a/packages/codeql/dataflow_validator.py
+++ b/packages/codeql/dataflow_validator.py
@@ -546,6 +546,7 @@ class DataflowValidator:
                 f"skipping full validation (cheap verdict trusted by "
                 f"scorecard)"
             )
+            self.llm.record_short_circuit()
             return self._short_circuit_fp_dataflow_result(cheap_reasoning)
 
         # Path is sat or indeterminate — run full LLM analysis.

--- a/packages/codeql/tests/test_scorecard_wiring.py
+++ b/packages/codeql/tests/test_scorecard_wiring.py
@@ -104,6 +104,7 @@ def _build_llm(tmp_path) -> "object":
     client.total_cost = 0.0
     client.request_count = 0
     client.task_type_costs = {}
+    client.short_circuits = 0
     client._stats_lock = threading.RLock()
     client._key_locks = {}
     client._key_locks_guard = threading.Lock()
@@ -270,6 +271,32 @@ def test_short_circuit_skips_full_when_scorecard_trusts_cell(llm):
     # And the result reflects the cheap reasoning.
     assert result.is_true_positive is False
     assert "constant 'admin'" in result.reasoning
+    # Substrate counter bumped so /codeql can surface the saving.
+    assert client.short_circuits == 1
+
+
+def test_short_circuits_counter_starts_at_zero_when_full_runs(llm):
+    """No short-circuit → counter stays at zero. Guards against
+    consumers accidentally bumping on the fall-through path."""
+    client, prov = llm
+    analyzer = _make_analyzer(client)
+
+    def responder(prompt, schema, system_prompt):
+        if _is_cheap_call(schema):
+            return ({"verdict": "needs_analysis",
+                     "reasoning": "uncertain"}, "raw")
+        return ({
+            "is_true_positive": True, "is_exploitable": True,
+            "exploitability_score": 0.5, "severity_assessment": "medium",
+            "reasoning": "tainted", "attack_scenario": "",
+            "prerequisites": [], "impact": "?", "cvss_estimate": 5.0,
+            "mitigation": "fix",
+        }, "raw")
+    prov.responder = responder
+
+    analyzer.analyze_vulnerability(_finding(), "code")
+
+    assert client.short_circuits == 0
 
 
 def test_cheap_says_needs_analysis_does_not_record_event(llm):

--- a/raptor_codeql.py
+++ b/raptor_codeql.py
@@ -210,12 +210,14 @@ def run_autonomous_workflow(args):
                 logger.error(f"Analysis failed: {e}", exc_info=True)
 
     # Save autonomous analysis summary
+    short_circuits = getattr(llm_client, "short_circuits", 0)
     summary = {
         "total_findings": scan_result.total_findings,
         "analyzed": total_analyzed,
         "exploitable": total_exploitable,
         "exploits_generated": total_exploits_generated,
         "exploits_compiled": total_exploits_compiled,
+        "fast_tier_short_circuits": short_circuits,
         "scan_result": scan_result.to_dict(),
     }
 
@@ -233,6 +235,8 @@ def run_autonomous_workflow(args):
     print(f"Exploitable: {total_exploitable}")
     print(f"Exploits generated: {total_exploits_generated}")
     print(f"Exploits compiled: {total_exploits_compiled}")
+    if short_circuits > 0:
+        print(f"Fast-tier saved: {short_circuits} full ANALYSE call{'s' if short_circuits != 1 else ''}")
     print(f"\nOutput: {agent.out_dir}")
     print(f"  Scan results: {len(scan_result.sarif_files)} SARIF files")
     print(f"  Autonomous analysis: autonomous/")


### PR DESCRIPTION
The scorecard prefilter has been silently saving full ANALYSE calls on the codeql path since the substrate landed — but operators had no visible signal that it was actually firing. /scorecard CLI shows trust state, not behaviour.

Adds an LLMClient.short_circuits counter, bumped by the two existing prefilter consumers (AutonomousCodeQLAnalyzer.analyze_vulnerability and DataflowValidator.validate_dataflow_path) when the scorecard's SHORT_CIRCUIT decision is taken. /codeql's summary surfaces the count under the existing AUTONOMOUS ANALYSIS SUMMARY block ("Fast-tier saved: N full ANALYSE calls") and persists it as
fast_tier_short_circuits in autonomous_summary.json for downstream consumers.

Producer wiring is /codeql-only today (the substrate-level prefilter has no producer in /agentic's llm_analysis path); surfacing in /agentic is a separate follow-up requiring either prefilter wiring in agent.py or count propagation across the subprocess boundary.

7 codeql scorecard-wiring tests pass (2 new). 982 codeql + core/llm tests pass overall.