### PR TITLE
feat(iris): surface dataflow-validation metrics in /agentic summary + report

### DIFF
--- a/packages/llm_analysis/tests/test_agentic_dv_reporting.py
+++ b/packages/llm_analysis/tests/test_agentic_dv_reporting.py
@@ -1,0 +1,168 @@
+"""Tests for the IRIS dataflow-validation surfacing in raptor_agentic.
+
+The section builder is a private helper in raptor_agentic.py. It reads
+from the `dataflow_validation` block that the orchestrator writes into
+the merged report (see orchestrator.py: `merged["dataflow_validation"]
+= {**validation_metrics, n_applied_downgrades, n_soft_downgrades}`).
+
+Goal: catch regressions in either direction —
+  - section builder formatting (unit test on the helper)
+  - the dict shape produced by the orchestrator (the keys we read here
+    have to actually be there)
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_agentic_module():
+    """Import raptor_agentic without invoking its CLI entry point.
+
+    The module lives at the repo root, not in a package. We bring it in
+    via importlib so this test doesn't depend on the test runner's CWD
+    or sys.path shape.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    spec = importlib.util.spec_from_file_location(
+        "raptor_agentic_for_tests", repo_root / "raptor_agentic.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _full_metrics(**overrides):
+    """Realistic shape of `merged["dataflow_validation"]` produced by the
+    orchestrator. Tests override individual fields rather than building
+    from scratch so missing-key regressions surface in the section
+    builder rather than the test fixture.
+    """
+    base = {
+        "n_eligible": 4,
+        "n_validated": 3,
+        "n_cache_hits": 0,
+        "n_errors": 0,
+        "n_skipped_no_db_for_language": 0,
+        "n_stale_db_warnings": 0,
+        "n_tier1_prebuilt": 2,
+        "n_tier2_template": 1,
+        "n_tier3_retry": 0,
+        "n_recommended_downgrades": 1,
+        "n_applied_downgrades": 1,
+        "n_soft_downgrades": 0,
+        "skipped_reason": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_section_renders_full_metrics_block():
+    mod = _load_agentic_module()
+    section = mod._build_dataflow_validation_report_section(_full_metrics())
+    assert section.title == "IRIS Dataflow Validation"
+    body = section.content
+    assert "Eligible findings: **4**" in body
+    assert "validated: **3**" in body
+    assert "Tier 1 (free, prebuilt query): 2" in body
+    assert "Tier 2 (LLM-customised predicates): 1" in body
+    # Tier 3 = 0 → omitted from the breakdown
+    assert "Tier 3" not in body
+    assert "Recommended (validation refuted claim): 1" in body
+    assert "Applied hard (no consensus override): 1" in body
+
+
+def test_skipped_reason_short_circuits_other_fields():
+    """When the orchestrator records `skipped_reason`, the rest of the
+    block is irrelevant — just surface the reason."""
+    mod = _load_agentic_module()
+    section = mod._build_dataflow_validation_report_section({
+        "skipped_reason": "no_database",
+    })
+    assert "no_database" in section.content
+    # No tier breakdown when skipped
+    assert "Tier 1" not in section.content
+    assert "Eligible" not in section.content
+
+
+def test_cache_hits_surface_in_header():
+    mod = _load_agentic_module()
+    section = mod._build_dataflow_validation_report_section(
+        _full_metrics(n_cache_hits=2)
+    )
+    assert "+2 cache hits" in section.content
+
+
+def test_cache_hit_singular_grammar():
+    mod = _load_agentic_module()
+    section = mod._build_dataflow_validation_report_section(
+        _full_metrics(n_cache_hits=1)
+    )
+    assert "+1 cache hit)" in section.content
+    # No bare 'hits' (plural) for a count of 1
+    assert "+1 cache hits" not in section.content
+
+
+def test_soft_downgrade_surfaces_consensus_override_explanation():
+    mod = _load_agentic_module()
+    section = mod._build_dataflow_validation_report_section(
+        _full_metrics(
+            n_recommended_downgrades=2,
+            n_applied_downgrades=1,
+            n_soft_downgrades=1,
+        )
+    )
+    assert "Applied soft" in section.content
+    assert "consensus" in section.content.lower()
+
+
+def test_recommendation_with_no_application_notes_skipped_reconciliation():
+    """If validation recommended downgrades but reconciliation didn't
+    apply any (consensus + judge agreed with original), the section
+    explicitly notes that, so operators don't read 'recommended: 1' as
+    'silently dropped'."""
+    mod = _load_agentic_module()
+    section = mod._build_dataflow_validation_report_section(
+        _full_metrics(
+            n_recommended_downgrades=2,
+            n_applied_downgrades=0,
+            n_soft_downgrades=0,
+        )
+    )
+    assert "Recommended" in section.content
+    assert "not applied" in section.content
+
+
+def test_errors_and_skips_surface_when_present():
+    mod = _load_agentic_module()
+    section = mod._build_dataflow_validation_report_section(
+        _full_metrics(
+            n_errors=2,
+            n_skipped_no_db_for_language=3,
+            n_stale_db_warnings=1,
+        )
+    )
+    assert "Errors:** 2" in section.content
+    assert "Skipped (no CodeQL DB for finding's language):** 3" in section.content
+    assert "Stale-DB warnings:** 1" in section.content
+
+
+def test_no_tier_breakdown_when_all_zero():
+    """If no tier ran (e.g. all eligible findings were cache hits),
+    don't emit an empty 'By tier:' block."""
+    mod = _load_agentic_module()
+    section = mod._build_dataflow_validation_report_section(
+        _full_metrics(
+            n_validated=0, n_cache_hits=4,
+            n_tier1_prebuilt=0, n_tier2_template=0, n_tier3_retry=0,
+            n_recommended_downgrades=0, n_applied_downgrades=0,
+        )
+    )
+    # Header still renders (cache hits matter)
+    assert "+4 cache hits" in section.content
+    # No empty tier block
+    assert "By tier:" not in section.content
+    # No empty downgrade block
+    assert "Downgrades:" not in section.content

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -1169,8 +1169,59 @@ Examples:
         print(f"   Exploits generated: {exploits_count}")
     if patches_count > 0:
         print(f"   Patches generated: {patches_count}")
-    if (args.codeql or args.codeql_only) and analysis.get('dataflow_validated', 0) > 0:
-        print(f"   Dataflow paths validated: {analysis.get('dataflow_validated', 0)}")
+    # IRIS Tier 1 / 2 / 3 dataflow validation surfacing. The full
+    # metrics block lives at orchestration_result["dataflow_validation"]
+    # (n_eligible, n_validated, n_tier1_prebuilt, n_tier2_template,
+    # n_tier3_retry, n_recommended_downgrades, n_applied_downgrades,
+    # n_soft_downgrades, n_skipped_no_db_for_language, …). Surface a
+    # short structured summary so operators see what IRIS did without
+    # needing to dig into orchestrated_report.json. Suppressed when
+    # validation didn't run (no CodeQL DB, --no-validate-dataflow).
+    dv = (orchestration_result or {}).get("dataflow_validation") or {}
+    n_validated = dv.get("n_validated", 0)
+    n_cache_hits = dv.get("n_cache_hits", 0)
+    if dv and (n_validated or n_cache_hits):
+        n_tier1 = dv.get("n_tier1_prebuilt", 0)
+        n_tier2 = dv.get("n_tier2_template", 0)
+        n_tier3 = dv.get("n_tier3_retry", 0)
+        n_recommended = dv.get("n_recommended_downgrades", 0)
+        n_hard = dv.get("n_applied_downgrades", 0)
+        n_soft = dv.get("n_soft_downgrades", 0)
+        # Header line matches the existing summary cadence
+        # ("Exploits generated: N", "Patches generated: N", …).
+        print(f"   Dataflow validated: {n_validated}"
+              + (f" (+{n_cache_hits} cache hit{'s' if n_cache_hits != 1 else ''})"
+                 if n_cache_hits else ""))
+        # Tier breakdown: Tier 1 is free CodeQL; Tier 2/3 burn LLM
+        # tokens. Worth showing the split so operators can tell whether
+        # --deep-validate is paying off.
+        tier_parts = []
+        if n_tier1:
+            tier_parts.append(f"{n_tier1} Tier 1 (free)")
+        if n_tier2:
+            tier_parts.append(f"{n_tier2} Tier 2 (LLM)")
+        if n_tier3:
+            tier_parts.append(f"{n_tier3} Tier 3 (LLM retry)")
+        if tier_parts:
+            print(f"     by tier: {', '.join(tier_parts)}")
+        # Downgrade outcome: distinguish "recommended" from "applied"
+        # (the latter is post-reconciliation with consensus/judge).
+        # Soft downgrades = recommendation overruled by consensus/judge.
+        if n_recommended:
+            outcome = []
+            outcome.append(f"{n_recommended} flagged")
+            if n_hard or n_soft:
+                bits = []
+                if n_hard:
+                    bits.append(f"{n_hard} hard")
+                if n_soft:
+                    bits.append(f"{n_soft} soft (consensus override)")
+                outcome.append(f"applied: {', '.join(bits)}")
+            print(f"     downgrades: {' · '.join(outcome)}")
+    elif dv.get("skipped_reason"):
+        # Validation was attempted but skipped — surface the reason so
+        # operators know IRIS noticed but couldn't help.
+        print(f"   Dataflow validation skipped: {dv['skipped_reason']}")
     aggregation = orchestration_result.get("aggregation", {}) if orchestration_result else {}
     if aggregation:
         summary = str(aggregation.get("summary") or "").strip()
@@ -1359,6 +1410,9 @@ Examples:
     extra_sections = []
     if aggregation:
         extra_sections.append(_build_aggregation_report_section(aggregation))
+    dv = (orchestration_result or {}).get("dataflow_validation") or {}
+    if dv and (dv.get("n_validated") or dv.get("n_cache_hits") or dv.get("skipped_reason")):
+        extra_sections.append(_build_dataflow_validation_report_section(dv))
 
     spec = build_findings_spec(
         analysed_results,
@@ -1474,6 +1528,90 @@ def _build_aggregation_report_section(aggregation):
     return ReportSection(
         title="Aggregate Synthesis",
         content="\n".join(lines) if lines else "Aggregate synthesis was requested, but the model returned no reportable fields.",
+    )
+
+
+def _build_dataflow_validation_report_section(dv):
+    """Render IRIS dataflow-validation metrics for the agentic report.
+
+    Surfaces the same Tier 1 / Tier 2 / 3 + downgrade breakdown that
+    the console summary shows, plus a couple of fields useful for
+    post-hoc review (skipped reasons, stale-DB warnings) that aren't
+    worth taking up a console line for.
+    """
+    from core.reporting import ReportSection
+
+    skipped = dv.get("skipped_reason") or ""
+    if skipped:
+        return ReportSection(
+            title="IRIS Dataflow Validation",
+            content=f"Validation was attempted but skipped: `{skipped}`.",
+        )
+
+    n_eligible = dv.get("n_eligible", 0)
+    n_validated = dv.get("n_validated", 0)
+    n_cache_hits = dv.get("n_cache_hits", 0)
+    n_errors = dv.get("n_errors", 0)
+    n_skip_no_db = dv.get("n_skipped_no_db_for_language", 0)
+    n_stale_warnings = dv.get("n_stale_db_warnings", 0)
+    n_tier1 = dv.get("n_tier1_prebuilt", 0)
+    n_tier2 = dv.get("n_tier2_template", 0)
+    n_tier3 = dv.get("n_tier3_retry", 0)
+    n_recommended = dv.get("n_recommended_downgrades", 0)
+    n_hard = dv.get("n_applied_downgrades", 0)
+    n_soft = dv.get("n_soft_downgrades", 0)
+
+    lines = []
+    lines.append(
+        f"Eligible findings: **{n_eligible}** · "
+        f"validated: **{n_validated}**"
+        + (f" (+{n_cache_hits} cache hit{'s' if n_cache_hits != 1 else ''})"
+           if n_cache_hits else "")
+    )
+    if n_tier1 or n_tier2 or n_tier3:
+        lines.append("")
+        lines.append("**By tier:**")
+        # Tier 1 is mechanical / free (CodeQL only — pre-built or
+        # in-repo LocalFlowSource queries). Tier 2 and 3 burn LLM
+        # tokens; only run when `--deep-validate` is set.
+        if n_tier1:
+            lines.append(f"- Tier 1 (free, prebuilt query): {n_tier1}")
+        if n_tier2:
+            lines.append(f"- Tier 2 (LLM-customised predicates): {n_tier2}")
+        if n_tier3:
+            lines.append(f"- Tier 3 (LLM compile-error retry): {n_tier3}")
+    if n_recommended:
+        lines.append("")
+        lines.append("**Downgrades:**")
+        lines.append(f"- Recommended (validation refuted claim): {n_recommended}")
+        if n_hard:
+            lines.append(f"- Applied hard (no consensus override): {n_hard}")
+        if n_soft:
+            lines.append(
+                f"- Applied soft (kept exploitable, lowered confidence — "
+                f"consensus or judge agreed with original analysis): {n_soft}"
+            )
+        if not (n_hard or n_soft):
+            lines.append(
+                "- *Note:* recommendations were not applied — "
+                "reconciliation may have been skipped or all overruled."
+            )
+    if n_errors:
+        lines.append("")
+        lines.append(f"**Errors:** {n_errors} validation(s) failed (loop did not crash).")
+    if n_skip_no_db:
+        lines.append(
+            f"**Skipped (no CodeQL DB for finding's language):** {n_skip_no_db}"
+        )
+    if n_stale_warnings:
+        lines.append(
+            f"**Stale-DB warnings:** {n_stale_warnings} — DB mtime predates "
+            "recent source changes; results may not reflect current code."
+        )
+
+    return ReportSection(
+        title="IRIS Dataflow Validation",
+        content="\n".join(lines),
     )
 
 


### PR DESCRIPTION
IRIS has been silently doing real work since PR-A — Tier 1 confirms / refutes via discovered CodeQL queries, reconciliation applies hard / soft downgrades after consensus — but the only operator-visible output was a one-line "Dataflow paths validated: N" with no tier breakdown, no downgrade outcome, and nothing at all when N happened to be zero.

Replaces that line with a structured block reading from the orchestrator's existing `dataflow_validation` block:

  Dataflow validated: 3 (+1 cache hit)
    by tier: 2 Tier 1 (free), 1 Tier 2 (LLM)
    downgrades: 1 flagged · applied: 1 hard

Adds a parallel `agentic-report.md` section with the same data plus less-common signals (errors, no-DB-skip, stale-DB warnings) not worth a console line. Skipped runs surface their reason ("no_database", "budget_exhausted") so operators see IRIS noticed but couldn't help, rather than the previous silent no-op.

Same UX shape as #348's fast-tier-savings line: read counters the orchestrator already emits, render post-run, no new collection plumbing.

8 new tests exercising the common shapes of
`merged["dataflow_validation"]`: full block, skip reason, cache hits (singular vs plural grammar), soft-vs-hard downgrades, all-zero tier breakdown, recommendations-not-applied note. 882 IRIS tests green.