### PR TITLE
feat(security): trust check for target-repo CodeQL pack config

### DIFF
--- a/core/security/codeql_trust.py
+++ b/core/security/codeql_trust.py
@@ -1,0 +1,470 @@
+"""
+core/security/codeql_trust.py
+
+Trust check for target-repo CodeQL pack files.
+
+Called before invoking ``codeql database create`` against an untrusted
+repo. Returns True if the caller should refuse to dispatch.
+
+**Distinct from cc_trust.** Claude Code config files
+(``.claude/settings.json``, ``.mcp.json``) go through ``cc_trust``;
+CodeQL pack files are loaded by the ``codeql`` binary itself during
+``codeql database create``, bypassing the CC trust path entirely.
+This module is the parallel check for the codeql side.
+
+Files inspected:
+    codeql-pack.yml         (recursive walk, capped)
+    qlpack.yml              (recursive walk, capped)
+    .github/codeql/codeql-config.yml
+
+Blocking fields in ``codeql-pack.yml`` / ``qlpack.yml``:
+    extractor:                     ANY value (codeql may exec this)
+    dependencies.<name>            non-canonical (not ``codeql/...``)
+    buildCommand                   subprocess invocation
+    setup / preCompileScript /
+    postCompileScript              subprocess invocation
+    structural: symlink, oversized, malformed → block
+
+Blocking fields in ``codeql-config.yml``:
+    packs.<lang>[]                 non-canonical pack reference
+    queries[].uses                 external repo / URL reference
+    manualBuildSteps / setup       subprocess invocation
+    structural: symlink, oversized, malformed → block
+
+Trust override: same module-flag pattern as cc_trust. ``--trust-repo``
+sets it once at entry-point argparse time; this module reads it via
+``check_repo_codeql_trust(trust_override=None)``. Deliberately NOT
+driven by an env var (target repos can inject env via the build
+system; trust must come from explicit operator intent).
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover — yaml is a hard dep elsewhere
+    yaml = None
+
+
+# ---------------------------------------------------------------------------
+# Process-wide trust override
+# ---------------------------------------------------------------------------
+
+_trust_override_set = False
+
+
+def set_trust_override(val: bool) -> None:
+    """Set process-wide trust override. Call once from each entry point
+    that parses ``--trust-repo``. Idempotent."""
+    global _trust_override_set
+    _trust_override_set = bool(val)
+
+
+# ---------------------------------------------------------------------------
+# Finding / FileScan dataclasses (parallel to cc_trust)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Finding:
+    """One labelled row in the per-file findings table."""
+    label: str
+    value: str
+    blocking: bool
+
+
+@dataclass
+class FileScan:
+    """Findings for one inspected file."""
+    path: Path
+    findings: List[Finding] = field(default_factory=list)
+
+    def has_blocking(self) -> bool:
+        return any(f.blocking for f in self.findings)
+
+
+# ---------------------------------------------------------------------------
+# Constants + helpers
+# ---------------------------------------------------------------------------
+
+# packages/codeql/.. — three levels up from this file.
+_RAPTOR_DIR = Path(__file__).resolve().parents[2]
+
+# 1 MiB cap on pack files. Real codeql-pack.yml files are <10 KiB; the
+# cap exists to bound the YAML parser's memory exposure.
+_MAX_CONFIG_BYTES = 1_048_576
+
+# Bound the recursive walk on pathological repos (vendored monorepos
+# with thousands of nested pack files). 200 hits + early break is
+# enough to catch any realistic pack layout while keeping the walk
+# bounded.
+_MAX_PACK_FILES = 200
+
+# U+2028/U+2029 line-separators slip past Cc/Cf categories but
+# render as newlines in terminals — strip them so output can't be
+# split by an attacker-supplied label.
+_EXTRA_STRIP = frozenset({" ", " "})
+
+# CodeQL's canonical (Microsoft-authored) pack namespace. Anything
+# outside this namespace is third-party and may carry custom
+# extractors / queries.
+_CANONICAL_PACK_PREFIX = "codeql/"
+
+
+def _safe(s: str) -> str:
+    """Strip Unicode control/format chars and line/paragraph separators.
+    Same defence as cc_trust._safe — see that docstring for the threat
+    model (ANSI escapes, Trojan Source bidi, zero-width chars)."""
+    return "".join(
+        c if c == "\t" or (
+            c not in _EXTRA_STRIP
+            and unicodedata.category(c) not in ("Cc", "Cf")
+        ) else "?"
+        for c in s
+    )
+
+
+def _truncate(s: str, limit: int = 80) -> str:
+    safe = _safe(s)
+    return safe[:limit] + "..." if len(safe) > limit else safe
+
+
+def _path_present(p: Path) -> bool:
+    try:
+        return p.is_symlink() or p.exists()
+    except OSError:
+        return False
+
+
+def _read_capped(path: Path) -> Optional[bytes]:
+    """Read up to ``_MAX_CONFIG_BYTES`` bytes. Returns None on
+    oversized, non-regular, or unreadable."""
+    try:
+        if not path.is_file():
+            return None
+        size = path.stat().st_size
+        if size > _MAX_CONFIG_BYTES:
+            return None
+        with open(path, "rb") as f:
+            return f.read(_MAX_CONFIG_BYTES + 1)
+    except OSError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Per-file scanners
+# ---------------------------------------------------------------------------
+
+
+def _scan_pack_file(path: Path) -> FileScan:
+    """Scan a ``codeql-pack.yml`` or ``qlpack.yml``."""
+    fs = FileScan(path=path)
+    raw = _read_capped(path)
+    if raw is None:
+        fs.findings.append(
+            Finding("oversized/unreadable", _truncate(str(path), 120), True)
+        )
+        return fs
+    if yaml is None:                                    # pragma: no cover
+        fs.findings.append(
+            Finding("yaml unavailable", "cannot inspect", True)
+        )
+        return fs
+    try:
+        doc = yaml.safe_load(raw)
+    except yaml.YAMLError as e:
+        fs.findings.append(
+            Finding("malformed YAML", _truncate(str(e), 120), True)
+        )
+        return fs
+    if not isinstance(doc, dict):
+        fs.findings.append(
+            Finding("non-dict YAML", _truncate(str(type(doc).__name__), 60), True)
+        )
+        return fs
+
+    # extractor: ANY value flags for review — codeql may exec this
+    # binary/script during DB build. The path is relative to the pack;
+    # an attacker-supplied repo could point it anywhere inside the
+    # source root.
+    if doc.get("extractor"):
+        fs.findings.append(
+            Finding("extractor", _truncate(str(doc["extractor"]), 120), True)
+        )
+
+    # dependencies: only the canonical ``codeql/`` namespace is allowed
+    # without manual review. Third-party packs may bring their own
+    # extractors / queries.
+    #
+    # Codeql's schema names a dict[name->version] but YAML is permissive
+    # and we've seen real packs in the wild use a flat list form
+    # (``dependencies: ['name@version', ...]``). Handle both — if the
+    # ``dependencies`` key is present at all and isn't an empty value,
+    # walk every entry. An attacker who can write the pack chooses the
+    # form, so we have to inspect both.
+    deps = doc.get("dependencies")
+    if isinstance(deps, dict):
+        dep_specs = [(str(n), str(v)) for n, v in deps.items()]
+    elif isinstance(deps, list):
+        dep_specs = [(str(item), "") for item in deps]
+    else:
+        dep_specs = []
+    for n, v in dep_specs:
+        if not n.startswith(_CANONICAL_PACK_PREFIX):
+            label = f"{n}: {v}" if v else n
+            fs.findings.append(
+                Finding("non-canonical dep", _truncate(label, 120), True)
+            )
+
+    # defaultSuiteFile: relative path to a query suite that codeql will
+    # compile + run by default. An attacker-controlled suite can pull
+    # in arbitrary queries (which then compile arbitrary QL — extension
+    # functions, file I/O via standard library, etc.). Path traversal
+    # via ``../`` could also reference suites outside the pack.
+    suite = doc.get("defaultSuiteFile")
+    if suite:
+        s = str(suite)
+        if ".." in s or s.startswith("/"):
+            fs.findings.append(
+                Finding("defaultSuiteFile (escapes pack)",
+                        _truncate(s, 120), True)
+            )
+
+    # buildCommand / setup hooks — pack-level subprocess invocation.
+    # These keys aren't part of the formal codeql-pack schema today,
+    # but conservative blocking guards against future schema growth
+    # AND against custom/forked codeql distributions.
+    for key in ("buildCommand", "setup",
+                "preCompileScript", "postCompileScript"):
+        if doc.get(key):
+            fs.findings.append(
+                Finding(key, _truncate(str(doc[key]), 120), True)
+            )
+
+    return fs
+
+
+def _scan_codeql_config(path: Path) -> FileScan:
+    """Scan a ``.github/codeql/codeql-config.yml``."""
+    fs = FileScan(path=path)
+    raw = _read_capped(path)
+    if raw is None:
+        fs.findings.append(
+            Finding("oversized/unreadable", _truncate(str(path), 120), True)
+        )
+        return fs
+    if yaml is None:                                    # pragma: no cover
+        fs.findings.append(
+            Finding("yaml unavailable", "cannot inspect", True)
+        )
+        return fs
+    try:
+        doc = yaml.safe_load(raw)
+    except yaml.YAMLError as e:
+        fs.findings.append(
+            Finding("malformed YAML", _truncate(str(e), 120), True)
+        )
+        return fs
+    if not isinstance(doc, dict):
+        fs.findings.append(
+            Finding("non-dict YAML", _truncate(str(type(doc).__name__), 60), True)
+        )
+        return fs
+
+    # packs: dict-by-language OR flat list of pack-spec strings.
+    # Canonical = ``codeql/<name>``; anything else is third-party.
+    packs = doc.get("packs")
+    if packs:
+        flat: List[str] = []
+        if isinstance(packs, dict):
+            for refs in packs.values():
+                if isinstance(refs, list):
+                    flat.extend(str(r) for r in refs if isinstance(r, str))
+        elif isinstance(packs, list):
+            flat = [str(r) for r in packs if isinstance(r, str)]
+        for ref in flat:
+            if not ref.startswith(_CANONICAL_PACK_PREFIX):
+                fs.findings.append(
+                    Finding("non-canonical pack", _truncate(ref, 120), True)
+                )
+
+    # queries: list of {uses: ...} OR string entries. External repo
+    # references (``owner/repo`` or URL) bring in arbitrary queries
+    # that can abuse extension functions during analysis.
+    queries = doc.get("queries")
+    if queries:
+        entries = queries if isinstance(queries, list) else [queries]
+        for e in entries:
+            if isinstance(e, dict):
+                uses = str(e.get("uses", ""))
+            else:
+                uses = str(e)
+            # External: any path containing ``/`` that isn't a relative
+            # local reference (``./`` or ``../``).
+            if "/" in uses and not uses.startswith(("./", "../")):
+                fs.findings.append(
+                    Finding("external queries", _truncate(uses, 120), True)
+                )
+
+    # manualBuildSteps / setup — subprocess invocation directives.
+    for key in ("manualBuildSteps", "setup"):
+        if doc.get(key):
+            fs.findings.append(
+                Finding(key, _truncate(str(doc[key]), 120), True)
+            )
+
+    # pack-cache: redirects codeql's pack download cache to a custom
+    # location. Used legitimately for offline / air-gapped builds, but
+    # an attacker-supplied repo could point it at a writable in-repo
+    # path pre-stocked with malicious pack content; codeql then
+    # "downloads" (i.e. reads) packs from there. Block any value —
+    # operator must opt in via --trust-repo if they need it.
+    if doc.get("pack-cache"):
+        fs.findings.append(
+            Finding("pack-cache", _truncate(str(doc["pack-cache"]), 120), True)
+        )
+
+    return fs
+
+
+# ---------------------------------------------------------------------------
+# Top-level scan + cache
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=64)
+def _scan_cached(resolved_path: str) -> Tuple[Tuple[FileScan, ...], bool]:
+    """Pure scan: returns (scans, any_blocking). Cached because
+    filesystem state for a given resolved path doesn't change within a
+    session. Side-effect-free so cache hits don't suppress operator-
+    visible warnings (rendered in the caller)."""
+    target = Path(resolved_path)
+    # Skip RAPTOR's own repo — RAPTOR ships codeql packs under
+    # packages/llm_analysis/codeql_packs/ that would always flag
+    # if scanned. Operator running RAPTOR against itself is
+    # implicitly trusted.
+    if target == _RAPTOR_DIR:
+        return ((), False)
+
+    # Walk for pack files. Skip dotted dirs (e.g. ``.git``,
+    # ``.claude/worktrees``) except ``.github`` which holds
+    # codeql-config.yml legitimately.
+    pack_files: List[Path] = []
+    try:
+        for name in ("codeql-pack.yml", "qlpack.yml"):
+            for p in target.rglob(name):
+                if len(pack_files) >= _MAX_PACK_FILES:
+                    break
+                rel_parts = p.relative_to(target).parts
+                if any(
+                    part.startswith(".") and part != ".github"
+                    for part in rel_parts[:-1]
+                ):
+                    continue
+                pack_files.append(p)
+            if len(pack_files) >= _MAX_PACK_FILES:
+                break
+    except OSError:
+        pass
+
+    config_path = target / ".github" / "codeql" / "codeql-config.yml"
+    if _path_present(config_path):
+        pack_files.append(config_path)
+
+    if not pack_files:
+        return ((), False)
+
+    scans: List[FileScan] = []
+    for path in pack_files:
+        if path.is_symlink():
+            fs = FileScan(path=path)
+            try:
+                tgt = str(path.readlink())
+            except OSError:
+                tgt = "<unreadable>"
+            fs.findings.append(Finding("symlink", _truncate(tgt, 120), True))
+            scans.append(fs)
+            continue
+        if path.name == "codeql-config.yml":
+            scanned = _scan_codeql_config(path)
+        else:
+            scanned = _scan_pack_file(path)
+        if scanned.findings:
+            scans.append(scanned)
+
+    any_blocking = any(s.has_blocking() for s in scans)
+    return (tuple(scans), any_blocking)
+
+
+def check_repo_codeql_trust(
+    repo_path: str,
+    trust_override: Optional[bool] = None,
+) -> bool:
+    """Check target repo for unsafe CodeQL pack config. Returns True if
+    DB creation should be refused.
+
+    ``trust_override``:
+        None   → read the module-level flag (set by ``set_trust_override``).
+                 Production default.
+        True   → force trust (warn but never block). Tests, callers with
+                 context the module flag doesn't capture.
+        False  → force strict. Tests, hard-enforcement code paths.
+    """
+    if not repo_path:
+        return False
+    try:
+        resolved = str(Path(repo_path).resolve())
+    except (ValueError, OSError):
+        return False
+    if trust_override is None:
+        trust_override = _trust_override_set
+    scans, any_blocking = _scan_cached(resolved)
+    if scans:
+        target = Path(resolved)
+        _render_scan_report(target, scans, any_blocking, trust_override)
+    return any_blocking and not trust_override
+
+
+def _render_scan_report(
+    target: Path,
+    scans: Tuple[FileScan, ...],
+    any_blocking: bool,
+    trust_override: bool,
+) -> None:
+    """Pure rendering — separated from ``_scan_cached`` so the cache
+    doesn't suppress operator warnings on re-invocation."""
+    safe_target = _safe(str(target))
+    if any_blocking:
+        if trust_override:
+            print(f"raptor: {safe_target} has dangerous CodeQL pack config "
+                  f"(trust override active):")
+        else:
+            print(f"raptor: {safe_target} has dangerous CodeQL pack config:")
+    else:
+        print(f"raptor: {safe_target} has CodeQL pack config:")
+
+    for fs in scans:
+        try:
+            rel = fs.path.relative_to(target)
+        except ValueError:
+            rel = fs.path
+        print(f"  {_safe(str(rel))}")
+        if not fs.findings:
+            continue
+        label_w = max(len(f.label) for f in fs.findings) + 2
+        for f in fs.findings:
+            print(f"    {f.label:<{label_w}}{f.value}")
+
+
+__all__ = [
+    "Finding",
+    "FileScan",
+    "check_repo_codeql_trust",
+    "set_trust_override",
+]

--- a/core/security/tests/test_codeql_trust.py
+++ b/core/security/tests/test_codeql_trust.py
@@ -1,0 +1,409 @@
+"""Tests for ``core.security.codeql_trust``.
+
+Mirrors the structure of ``test_cc_trust.py``:
+  - cache reset + trust-override reset autouse fixtures
+  - per-class grouping by source-file shape (no config / pack only /
+    config only / both / structural pathologies)
+  - asserts both the verdict and the printed output (operator visibility)
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# packages/cve_diff/tests/... — we ensure the repo root is on sys.path so
+# tests can run when invoked from a sub-directory pytest.
+try:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+except IndexError:                                     # pragma: no cover
+    pass
+
+from core.security.codeql_trust import (
+    check_repo_codeql_trust,
+    set_trust_override,
+    _scan_cached,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_trust_cache():
+    """Fresh cache per test so prints happen deterministically."""
+    _scan_cached.cache_clear()
+    yield
+    _scan_cached.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_trust_override():
+    """Reset the module-level trust flag between tests."""
+    set_trust_override(False)
+    yield
+    set_trust_override(False)
+
+
+_check = check_repo_codeql_trust
+
+
+# ---------------------------------------------------------------------------
+# No config — silent pass
+# ---------------------------------------------------------------------------
+
+
+class TestNoConfig:
+    def test_empty_dir_returns_false_silent(self, tmp_path, capsys):
+        assert _check(str(tmp_path)) is False
+        assert capsys.readouterr().out == ""
+
+    def test_empty_repo_path_short_circuits(self, tmp_path):
+        """``Path("").resolve()`` would yield CWD — guard skips."""
+        assert _check("") is False
+
+    def test_nonexistent_path(self, tmp_path):
+        assert _check(str(tmp_path / "does-not-exist")) is False
+
+
+# ---------------------------------------------------------------------------
+# codeql-pack.yml / qlpack.yml scanning
+# ---------------------------------------------------------------------------
+
+
+class TestPackFile:
+    def test_canonical_only_silent(self, tmp_path, capsys):
+        """Pure ``codeql/...`` deps are the canonical case — informative
+        only, never blocking. Also no extractor / hooks."""
+        (tmp_path / "qlpack.yml").write_text(
+            "name: my/pack\n"
+            "version: 0.0.1\n"
+            "dependencies:\n"
+            "  codeql/python-all: '*'\n"
+        )
+        assert _check(str(tmp_path)) is False
+        # No findings → no print
+        assert capsys.readouterr().out == ""
+
+    def test_extractor_blocks(self, tmp_path, capsys):
+        (tmp_path / "codeql-pack.yml").write_text(
+            "name: attacker/evil\n"
+            "extractor: ./build/evil-binary\n"
+        )
+        assert _check(str(tmp_path)) is True
+        out = capsys.readouterr().out
+        assert "extractor" in out
+        assert "evil-binary" in out
+
+    def test_non_canonical_dependency_blocks(self, tmp_path, capsys):
+        (tmp_path / "qlpack.yml").write_text(
+            "name: my/pack\n"
+            "dependencies:\n"
+            "  evilcorp/exploits: '*'\n"
+            "  codeql/python-all: '*'\n"
+        )
+        assert _check(str(tmp_path)) is True
+        out = capsys.readouterr().out
+        assert "non-canonical dep" in out
+        assert "evilcorp/exploits" in out
+        # Canonical dep should NOT trigger a finding line of its own.
+        assert "codeql/python-all" not in out.split("non-canonical dep")[1]
+
+    def test_build_command_blocks(self, tmp_path, capsys):
+        (tmp_path / "qlpack.yml").write_text(
+            "name: my/pack\n"
+            "buildCommand: rm -rf /\n"
+        )
+        assert _check(str(tmp_path)) is True
+        assert "buildCommand" in capsys.readouterr().out
+
+    def test_pre_compile_script_blocks(self, tmp_path, capsys):
+        (tmp_path / "qlpack.yml").write_text(
+            "name: my/pack\n"
+            "preCompileScript: ./setup.sh\n"
+        )
+        assert _check(str(tmp_path)) is True
+        assert "preCompileScript" in capsys.readouterr().out
+
+    def test_dependencies_as_list_blocks(self, tmp_path, capsys):
+        """Adversarial: YAML is permissive enough that ``dependencies``
+        could be expressed as a flat list rather than the documented
+        dict form. The check must inspect both shapes — earlier the
+        dict-only ``isinstance`` guard let list-form deps slip past."""
+        (tmp_path / "qlpack.yml").write_text(
+            "name: x\n"
+            "dependencies:\n"
+            "  - evilcorp/exploit\n"
+            "  - codeql/python-all\n"
+        )
+        assert _check(str(tmp_path)) is True
+        out = capsys.readouterr().out
+        assert "non-canonical dep" in out
+        assert "evilcorp/exploit" in out
+
+    def test_default_suite_file_traversal_blocks(self, tmp_path, capsys):
+        """Adversarial: ``defaultSuiteFile`` with ``../`` or absolute
+        path escapes the pack and references operator-side files."""
+        (tmp_path / "qlpack.yml").write_text(
+            "name: x\n"
+            "defaultSuiteFile: ../../etc/passwd\n"
+        )
+        assert _check(str(tmp_path)) is True
+        assert "defaultSuiteFile" in capsys.readouterr().out
+
+    def test_default_suite_file_local_silent(self, tmp_path, capsys):
+        """Pack-relative defaultSuiteFile is the canonical case — no
+        traversal, no flag."""
+        (tmp_path / "qlpack.yml").write_text(
+            "name: x\n"
+            "defaultSuiteFile: my-suite.qls\n"
+        )
+        assert _check(str(tmp_path)) is False
+        assert capsys.readouterr().out == ""
+
+    def test_extractor_falsy_silent(self, tmp_path, capsys):
+        """``extractor: null`` and ``extractor: ""`` aren't real
+        extractor declarations — no flag."""
+        (tmp_path / "qlpack.yml").write_text(
+            "name: x\n"
+            "extractor: null\n"
+        )
+        assert _check(str(tmp_path)) is False
+        assert capsys.readouterr().out == ""
+
+    def test_malformed_yaml_blocks(self, tmp_path, capsys):
+        (tmp_path / "qlpack.yml").write_text("name: [broken yaml\n  unbalanced")
+        assert _check(str(tmp_path)) is True
+        assert "malformed YAML" in capsys.readouterr().out
+
+    def test_non_dict_root_blocks(self, tmp_path, capsys):
+        (tmp_path / "qlpack.yml").write_text("- just\n- a\n- list\n")
+        assert _check(str(tmp_path)) is True
+        assert "non-dict YAML" in capsys.readouterr().out
+
+    def test_walks_nested_dirs(self, tmp_path, capsys):
+        """codeql walks the source root for pack files; we must too."""
+        nested = tmp_path / "deeply" / "nested" / "subdir"
+        nested.mkdir(parents=True)
+        (nested / "qlpack.yml").write_text(
+            "name: my/pack\n"
+            "extractor: ./hidden\n"
+        )
+        assert _check(str(tmp_path)) is True
+        assert "extractor" in capsys.readouterr().out
+
+    def test_skips_dotted_dirs(self, tmp_path, capsys):
+        """``.git`` / ``.claude/worktrees`` shouldn't be walked — their
+        contents aren't part of the pack codeql will load."""
+        hidden = tmp_path / ".claude" / "worktrees" / "x"
+        hidden.mkdir(parents=True)
+        (hidden / "qlpack.yml").write_text(
+            "name: my/pack\n"
+            "extractor: ./evil\n"
+        )
+        assert _check(str(tmp_path)) is False
+        assert capsys.readouterr().out == ""
+
+    def test_scans_dot_github(self, tmp_path, capsys):
+        """``.github`` IS walked because that's where codeql-config.yml
+        legitimately lives."""
+        gh = tmp_path / ".github" / "codeql"
+        gh.mkdir(parents=True)
+        (gh / "codeql-config.yml").write_text(
+            "name: x\n"
+            "manualBuildSteps:\n"
+            "  - 'sh evil.sh'\n"
+        )
+        assert _check(str(tmp_path)) is True
+        assert "manualBuildSteps" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# .github/codeql/codeql-config.yml scanning
+# ---------------------------------------------------------------------------
+
+
+class TestCodeqlConfig:
+    def _write_config(self, tmp_path: Path, body: str) -> None:
+        gh = tmp_path / ".github" / "codeql"
+        gh.mkdir(parents=True)
+        (gh / "codeql-config.yml").write_text(body)
+
+    def test_canonical_packs_only_silent(self, tmp_path, capsys):
+        self._write_config(tmp_path,
+            "name: ok\n"
+            "packs:\n"
+            "  python:\n"
+            "    - codeql/python-queries\n"
+        )
+        assert _check(str(tmp_path)) is False
+        assert capsys.readouterr().out == ""
+
+    def test_non_canonical_pack_blocks(self, tmp_path, capsys):
+        self._write_config(tmp_path,
+            "name: x\n"
+            "packs:\n"
+            "  python:\n"
+            "    - evilcorp/all\n"
+            "    - codeql/python-queries\n"
+        )
+        assert _check(str(tmp_path)) is True
+        out = capsys.readouterr().out
+        assert "non-canonical pack" in out
+        assert "evilcorp/all" in out
+
+    def test_external_query_blocks(self, tmp_path, capsys):
+        self._write_config(tmp_path,
+            "name: x\n"
+            "queries:\n"
+            "  - uses: evilcorp/queries/main\n"
+        )
+        assert _check(str(tmp_path)) is True
+        assert "external queries" in capsys.readouterr().out
+
+    def test_relative_local_query_silent(self, tmp_path, capsys):
+        self._write_config(tmp_path,
+            "name: x\n"
+            "queries:\n"
+            "  - uses: ./local-suite.qls\n"
+        )
+        assert _check(str(tmp_path)) is False
+        assert capsys.readouterr().out == ""
+
+    def test_manual_build_steps_blocks(self, tmp_path, capsys):
+        self._write_config(tmp_path,
+            "name: x\n"
+            "manualBuildSteps:\n"
+            "  - 'sh evil.sh'\n"
+        )
+        assert _check(str(tmp_path)) is True
+        assert "manualBuildSteps" in capsys.readouterr().out
+
+    def test_flat_packs_list(self, tmp_path, capsys):
+        self._write_config(tmp_path,
+            "name: x\n"
+            "packs:\n"
+            "  - evilcorp/all\n"
+        )
+        assert _check(str(tmp_path)) is True
+        assert "non-canonical pack" in capsys.readouterr().out
+
+    def test_pack_cache_blocks(self, tmp_path, capsys):
+        """Adversarial: ``pack-cache`` redirects codeql's pack download
+        cache. A malicious target could point it at a pre-stocked
+        in-repo directory so codeql 'downloads' attacker-supplied
+        packs from there."""
+        self._write_config(tmp_path,
+            "name: x\n"
+            "pack-cache: /attacker/cache\n"
+        )
+        assert _check(str(tmp_path)) is True
+        assert "pack-cache" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Structural pathologies (oversize, symlink, RAPTOR self-scan)
+# ---------------------------------------------------------------------------
+
+
+class TestStructural:
+    def test_symlink_pack_file_blocks(self, tmp_path, capsys):
+        target = tmp_path / "real.yml"
+        target.write_text("name: real/pack\n")
+        link = tmp_path / "qlpack.yml"
+        link.symlink_to(target)
+        assert _check(str(tmp_path)) is True
+        assert "symlink" in capsys.readouterr().out
+
+    def test_oversized_pack_file_blocks(self, tmp_path, capsys):
+        # 2 MiB pack file — beyond the 1 MiB cap.
+        big = "name: x\n" + ("# pad\n" * 350_000)
+        (tmp_path / "qlpack.yml").write_text(big)
+        assert _check(str(tmp_path)) is True
+        assert "oversized" in capsys.readouterr().out
+
+    def test_raptor_self_scan_short_circuits(self, capsys):
+        """Operator running RAPTOR against RAPTOR itself isn't an
+        attack — RAPTOR ships its own codeql packs under
+        packages/llm_analysis/codeql_packs/."""
+        raptor_dir = Path(__file__).resolve().parents[2]
+        # parents[2] = core/security/.. = repo root? actually parents[2]
+        # of test file = core/, parents[3] = repo root. The module's
+        # _RAPTOR_DIR = parents[2] of the module file (core/security/
+        # codeql_trust.py), which is the repo root. Use the same.
+        from core.security.codeql_trust import _RAPTOR_DIR
+        assert _check(str(_RAPTOR_DIR)) is False
+        assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# Trust override
+# ---------------------------------------------------------------------------
+
+
+class TestTrustOverride:
+    def test_module_flag_unblocks(self, tmp_path, capsys):
+        (tmp_path / "qlpack.yml").write_text(
+            "name: x\nextractor: ./evil\n"
+        )
+        # First confirm without override blocks.
+        assert _check(str(tmp_path)) is True
+        _scan_cached.cache_clear()  # so the warning re-renders below
+        capsys.readouterr()  # drop output
+        # Set override and confirm pass + override-active warning.
+        set_trust_override(True)
+        assert _check(str(tmp_path)) is False
+        out = capsys.readouterr().out
+        assert "trust override active" in out
+        assert "extractor" in out
+
+    def test_explicit_arg_overrides_module_flag(self, tmp_path, capsys):
+        (tmp_path / "qlpack.yml").write_text(
+            "name: x\nextractor: ./evil\n"
+        )
+        set_trust_override(True)
+        # Explicit False forces strict regardless of module flag.
+        assert _check(str(tmp_path), trust_override=False) is True
+
+    def test_override_when_no_findings_no_warning(self, tmp_path, capsys):
+        (tmp_path / "qlpack.yml").write_text("name: my/pack\n")
+        set_trust_override(True)
+        assert _check(str(tmp_path)) is False
+        # Empty pack file produces no findings → nothing printed even
+        # with override active.
+        assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# Combined + display sanity
+# ---------------------------------------------------------------------------
+
+
+class TestCombined:
+    def test_pack_plus_config_both_reported(self, tmp_path, capsys):
+        (tmp_path / "qlpack.yml").write_text(
+            "name: x\nextractor: ./bad\n"
+        )
+        gh = tmp_path / ".github" / "codeql"
+        gh.mkdir(parents=True)
+        (gh / "codeql-config.yml").write_text(
+            "name: y\npacks:\n  - evil/pack\n"
+        )
+        assert _check(str(tmp_path)) is True
+        out = capsys.readouterr().out
+        assert "extractor" in out
+        assert "non-canonical pack" in out
+        assert "qlpack.yml" in out
+        assert "codeql-config.yml" in out
+
+    def test_findings_use_safe_truncation(self, tmp_path, capsys):
+        """Long extractor values must be truncated; control chars stripped."""
+        long_extractor = "./" + "evil" * 100  # 402 chars
+        (tmp_path / "qlpack.yml").write_text(
+            f"name: x\nextractor: '{long_extractor}'\n"
+        )
+        _check(str(tmp_path))
+        out = capsys.readouterr().out
+        # Truncated to ~120 chars + "..."
+        assert "..." in out
+        # Doesn't dump the full 400+ chars
+        assert long_extractor not in out

--- a/packages/codeql/database_manager.py
+++ b/packages/codeql/database_manager.py
@@ -494,6 +494,29 @@ class DatabaseManager:
         logger.info(f"Creating CodeQL database for {language}")
         logger.info(f"{'=' * 70}")
 
+        # Trust check: target-repo codeql-pack.yml / qlpack.yml /
+        # codeql-config.yml can declare custom extractors, build hooks
+        # and external pack dependencies that codeql exec's during
+        # `database create`. Refuse on findings unless --trust-repo
+        # has been parsed at the entry point. Distinct surface from
+        # the cc_trust check (which guards .claude/settings.json).
+        from core.security.codeql_trust import check_repo_codeql_trust
+        if check_repo_codeql_trust(str(repo_path)):
+            return DatabaseResult(
+                success=False,
+                language=language,
+                database_path=None,
+                metadata=None,
+                errors=[
+                    "target repo has unsafe CodeQL pack config — refusing "
+                    "to invoke `codeql database create`. Re-run with "
+                    "--trust-repo to override after auditing the printed "
+                    "findings."
+                ],
+                duration_seconds=time.time() - start_time,
+                cached=False,
+            )
+
         # Check for cached database
         if not force:
             cached_db = self.get_cached_database(repo_path, language)

--- a/packages/codeql/tests/test_codeql_trust_integration.py
+++ b/packages/codeql/tests/test_codeql_trust_integration.py
@@ -1,0 +1,120 @@
+"""Integration: ``DatabaseManager.create_database`` honours the
+codeql trust check before invoking the codeql CLI.
+
+We don't actually build a database — that needs codeql + a build
+toolchain on the test host. We just stand up a target dir with an
+unsafe pack file and confirm:
+
+  * Without ``--trust-repo`` the call returns a failed
+    ``DatabaseResult`` whose error mentions ``--trust-repo``.
+  * The codeql CLI subprocess is NOT invoked (the trust gate
+    fires before the cache check and before the subprocess).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+try:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+except IndexError:                                      # pragma: no cover
+    pass
+
+from core.security.codeql_trust import _scan_cached, set_trust_override
+from packages.codeql.database_manager import DatabaseManager
+
+
+@pytest.fixture(autouse=True)
+def _clear_trust_state():
+    _scan_cached.cache_clear()
+    set_trust_override(False)
+    yield
+    _scan_cached.cache_clear()
+    set_trust_override(False)
+
+
+def _unsafe_target(tmp_path: Path) -> Path:
+    """A repo carrying a pack file with a custom extractor."""
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "qlpack.yml").write_text(
+        "name: attacker/evil\n"
+        "extractor: ./build/evil-binary\n"
+    )
+    return target
+
+
+def _safe_target(tmp_path: Path) -> Path:
+    """A repo with no codeql config at all."""
+    target = tmp_path / "target"
+    target.mkdir()
+    return target
+
+
+def _dm(tmp_path: Path) -> DatabaseManager:
+    """Fresh DatabaseManager pinned at the test's tmp_path."""
+    return DatabaseManager(
+        codeql_cli="codeql",
+        db_root=tmp_path / "dbs",
+    )
+
+
+def test_unsafe_target_refused_without_trust_repo(tmp_path):
+    target = _unsafe_target(tmp_path)
+    dm = _dm(tmp_path)
+
+    result = dm.create_database(target, "python")
+
+    assert result.success is False
+    assert result.database_path is None
+    # The error string steers the operator at the right escape hatch.
+    assert any("--trust-repo" in e for e in result.errors)
+    # And the codeql CLI specifically wasn't invoked — metadata-related
+    # subprocess calls (e.g. git rev-parse for repo-hash) happen later
+    # in the flow, after the trust gate fires.
+    assert "codeql" not in " ".join(result.errors).lower() or \
+        "unsafe CodeQL pack" in " ".join(result.errors)
+
+
+def test_unsafe_target_proceeds_with_trust_override(tmp_path):
+    """``set_trust_override(True)`` must let create_database past the
+    gate; we can't easily complete the full subprocess flow but the
+    early-refuse error MUST not fire."""
+    target = _unsafe_target(tmp_path)
+    set_trust_override(True)
+    dm = _dm(tmp_path)
+
+    # Mock get_cached_database to short-circuit so we don't need to
+    # actually build. Returning a fake path means create_database
+    # returns success without subprocess work.
+    fake_db = tmp_path / "fake-db"
+    fake_db.mkdir()
+    with patch.object(dm, "get_cached_database", return_value=fake_db), \
+         patch.object(dm, "load_metadata", return_value=None):
+        result = dm.create_database(target, "python")
+
+    # Trust gate didn't refuse — the cached-DB short-circuit returned
+    # success; the unsafe-pack-config error must NOT be in errors.
+    assert not any("unsafe CodeQL pack config" in e for e in result.errors)
+    assert result.success is True
+
+
+def test_safe_target_does_not_short_circuit_at_trust_gate(tmp_path):
+    """A target with no pack files must NOT be refused by the trust
+    check. (It might still fail later for build reasons; the trust
+    gate should pass cleanly.)"""
+    target = _safe_target(tmp_path)
+    dm = _dm(tmp_path)
+
+    fake_db = tmp_path / "fake-db"
+    fake_db.mkdir()
+    with patch.object(dm, "get_cached_database", return_value=fake_db), \
+         patch.object(dm, "load_metadata", return_value=None):
+        result = dm.create_database(target, "python")
+
+    # Trust gate didn't fire — cached path returned success.
+    assert result.success is True

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -300,10 +300,10 @@ Examples:
     parser.add_argument(
         "--trust-repo",
         action="store_true",
-        help="Trust the target repo's config and skip safety checks. Currently "
-             "covers the Claude Code config check in core/security/cc_trust.py "
-             "(credential helpers, hooks, dangerous env vars, stdio MCP servers). "
-             "Future trust checks read the same signal.",
+        help="Trust the target repo's config and skip safety checks. Covers the "
+             "Claude Code config check (core/security/cc_trust.py) AND the "
+             "CodeQL pack/config check (core/security/codeql_trust.py). New "
+             "trust checks read the same signal.",
     )
 
     from core.sandbox import add_cli_args, apply_cli_args
@@ -321,10 +321,14 @@ Examples:
             if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler):
                 h.setLevel(logging.DEBUG)
 
-    # Propagate --trust-repo via a module-level flag in cc_trust so every
-    # in-process trust check (this module, build_detector, ...) agrees.
+    # Propagate --trust-repo to every target-repo trust check so each
+    # in-process consumer (cc_trust, codeql_trust, build_detector, ...)
+    # agrees on the operator's intent. New checks added here must keep
+    # this list in sync.
     if getattr(args, "trust_repo", False):
         set_trust_override(True)
+        from core.security.codeql_trust import set_trust_override as _ql_set
+        _ql_set(True)
 
     if not args.repo:
         parser.error("--repo is required (or launch via `raptor` from the target directory)")

--- a/raptor_codeql.py
+++ b/raptor_codeql.py
@@ -281,15 +281,21 @@ Examples:
     parser.add_argument("--no-visualizations", action="store_true", help="Disable dataflow visualizations")
     parser.add_argument("--trust-repo", action="store_true",
                         help="Trust the target repo's config and skip safety checks "
-                             "(core/security/cc_trust.py).")
+                             "(.claude/settings*.json, .mcp.json, codeql-pack.yml, "
+                             "qlpack.yml, .github/codeql/codeql-config.yml).")
 
     from core.sandbox import add_cli_args, apply_cli_args
     add_cli_args(parser)
     args = parser.parse_args()
     apply_cli_args(args, parser=parser)
     if getattr(args, "trust_repo", False):
-        from core.security.cc_trust import set_trust_override
-        set_trust_override(True)
+        # Umbrella flag: every target-repo trust check honours the same
+        # operator-set override. New checks added here must keep this
+        # list in sync.
+        from core.security.cc_trust import set_trust_override as _cc_set
+        from core.security.codeql_trust import set_trust_override as _ql_set
+        _cc_set(True)
+        _ql_set(True)
 
     try:
         run_autonomous_workflow(args)

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,12 @@ instructor>=1.0.0
 # Optional: For enhanced dataflow visualization (recommended)
 tabulate>=0.9.0
 
+# Required for the /codeql workflow's pack-config trust check
+# (core/security/codeql_trust.py inspects target-repo codeql-pack.yml /
+# qlpack.yml / .github/codeql/codeql-config.yml). Without yaml the
+# check degrades to fail-safe block on any pack-bearing target.
+pyyaml==6.0.3
+
 # Optional: For SMT-based constraint analysis (one-gadget feasibility, etc.)
 # z3-solver==4.16.0.0
 


### PR DESCRIPTION
Distinct RCE surface from cc_trust: codeql-pack.yml, qlpack.yml, and .github/codeql/codeql-config.yml are loaded by the codeql binary itself during `codeql database create`, bypassing the .claude/settings.json trust path entirely. A malicious target repo can declare a custom extractor pointing at an in-repo binary, pull external pack dependencies that ship their own extractors, redirect pack-cache to an attacker-stocked path, escape the pack root via defaultSuiteFile traversal, or specify build/setup hooks that codeql exec's during DB build.

New core/security/codeql_trust.py mirrors cc_trust's shape:

  * check_repo_codeql_trust(repo_path) -> bool (True = block)
  * set_trust_override(bool) module-level flag
  * @lru_cache on the scan, side-effect-free; rendering separated so cache hits don't suppress operator warnings
  * Walks the source root for codeql-pack.yml / qlpack.yml (capped at 200 hits, depth-bounded by skipping dotted dirs except .github)
  * Plus the canonical .github/codeql/codeql-config.yml location

Blocking fields (any presence = refuse):
  * extractor: any value
  * dependencies: non-canonical entries — handles BOTH dict-form and list-form (yaml is permissive enough that an attacker chooses)
  * defaultSuiteFile with `..` or absolute path (escapes the pack)
  * buildCommand / setup / preCompileScript / postCompileScript
  * packs.<lang>[] non-canonical references
  * queries[].uses with external repo/URL refs
  * manualBuildSteps / setup in codeql-config.yml
  * pack-cache (redirects codeql's pack download cache)
  * Structural: symlink, oversized (>1 MiB), malformed YAML, non-dict

Wired into packages/codeql/database_manager.py:create_database() ahead of the cache check and the codeql CLI invocation; refuses with an error string that points the operator at --trust-repo.

--trust-repo on raptor_agentic.py and raptor_codeql.py is now an umbrella flag setting both cc_trust and codeql_trust module overrides. Help text updated.

Adversarial pass surfaced 3 bypasses (dependencies-as-list, defaultSuiteFile traversal, pack-cache redirect) — all closed with tests for each.

E2E verified against /tmp/codeql-trust-e2e (target with extractor + non-canonical deps): pass 1 (no flag) refused with operator-readable error and codeql binary never invoked; pass 2 (--trust-repo) showed "(trust override active)" annotation and proceeded.

35 trust-check tests + 2284 broader package suite all pass.