### PR TITLE
feat(core/inventory): JavaScript / TypeScript call-graph extractor

### DIFF
--- a/core/inventory/REACHABILITY.md
+++ b/core/inventory/REACHABILITY.md
@@ -70,8 +70,9 @@ Why: `mock.patch("requests.get")` mentions a qualified name without calling it. 
 
 The resolver is a static AST walker. It cannot rule out, and so returns UNCERTAIN for:
 
-- **String dispatch**: `getattr(mod, "name")(...)`, `importlib.import_module(mod_name)`, `__import__(mod_name)`.
-- **Wildcard imports** when the source module's root matches the target's root.
+- **Python string dispatch**: `getattr(mod, "name")(...)`, `importlib.import_module(mod_name)`, `__import__(mod_name)`.
+- **JavaScript dynamic constructs**: `import(<var>)`, `require(<var>)`, `obj[<var>](...)` (bracket dispatch), `eval(...)`, `new Function(...)()`.
+- **Wildcard imports** (Python) when the source module's root matches the target's root.
 - **Decorator-driven dispatch**, plugin registries, runtime `setattr` injection.
 - **Method override on subclassed instances** (e.g. subclass `requests.Session`, override `get`). This is module-function reachability, not method-resolution-order reachability.
 - **Reflective dispatch via `eval` / `exec` / `pickle` / RPC**.
@@ -79,7 +80,14 @@ The resolver is a static AST walker. It cannot rule out, and so returns UNCERTAI
 
 ## Language support
 
-Python only at first cut. The resolver itself is language-agnostic — it operates on the `call_graph` field of each file record. Adding JavaScript / Go / Java is a matter of writing a `extract_call_graph_<lang>` function in `core/inventory/call_graph.py` that emits the same `FileCallGraph` dataclass and wiring it from `_process_single_file`.
+The resolver is language-agnostic — it operates on the `call_graph` field of each file record. Per-language extractors in `core/inventory/call_graph.py`:
+
+- **Python** (`extract_call_graph_python`) — uses stdlib `ast`. Always available.
+- **JavaScript / TypeScript** (`extract_call_graph_javascript`) — uses tree-sitter when `tree_sitter_javascript` is installed; gracefully empty otherwise. Handles ES-module imports (default + named + namespace + alias), CommonJS `require` (simple + destructured + alias), call sites with attribute chains, and the JS analogs of Python's indirection flags (`import(<var>)`, `require(<var>)`, `obj[<var>](...)`, `eval`, `new Function(...)()`).
+
+For npm consumers in particular, OSV advisories often ship `imports[].symbols` data — the SCA function-level reachability tier can match these against project source via the JS extractor, getting precise per-CVE function reachability for the npm ecosystem.
+
+Adding Go / Java is a matter of writing one more `extract_call_graph_<lang>` function emitting the same `FileCallGraph` dataclass and wiring it from `_process_single_file`.
 
 ## Performance
 

--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -23,7 +23,10 @@ from .exclusions import (
     match_exclusion_reason,
 )
 from .extractors import extract_functions, extract_items, count_sloc
-from .call_graph import extract_call_graph_python
+from .call_graph import (
+    extract_call_graph_javascript,
+    extract_call_graph_python,
+)
 from .diff import compare_inventories
 
 logger = logging.getLogger(__name__)
@@ -358,12 +361,18 @@ def _process_single_file(
             '_stat': file_stat,
             'items': [item.to_dict() for item in items],
         }
-        # Call-graph extraction is Python-only at first cut; the
-        # resolver in core.inventory.reachability is language-
-        # agnostic but the per-file walker is currently AST-based.
-        # Other languages get added when a consumer needs them.
+        # Call-graph extraction. The resolver in
+        # core.inventory.reachability is language-agnostic; per-file
+        # extractors emit the same FileCallGraph dataclass for
+        # whichever languages have a walker.
         if language == 'python':
             record['call_graph'] = extract_call_graph_python(content).to_dict()
+        elif language in ('javascript', 'typescript'):
+            # Tree-sitter-driven; gracefully empty when the grammar
+            # isn't installed.
+            record['call_graph'] = extract_call_graph_javascript(
+                content,
+            ).to_dict()
         return record
 
     except Exception as e:

--- a/core/inventory/call_graph.py
+++ b/core/inventory/call_graph.py
@@ -20,10 +20,11 @@ project?":
 
   * **Indirection flags** — set bits indicating the file does
     something the static analysis can't follow:
-      * ``getattr(mod, "name")(...)`` — name-by-string dispatch.
-      * ``importlib.import_module("x.y")`` — runtime import.
-      * ``from x import *`` — wildcard imports a name we can't
-        statically know.
+      * Python: ``getattr(mod, "name")``, ``importlib.import_module``,
+        ``__import__``, wildcard ``from x import *``.
+      * JavaScript / TypeScript: dynamic ``import(<var>)``,
+        ``require(<var>)``, bracket dispatch ``obj[<var>](...)``,
+        ``eval`` / ``new Function(...)``.
 
 Indirection flags are file-scoped (not per-call) because once any
 of them is present, every NOT_CALLED claim about that file becomes
@@ -32,13 +33,15 @@ uncertainty, but the resolver consumers (SCA reachability, codeql
 pre-filter) treat UNCERTAIN as "don't downgrade severity" anyway —
 finer granularity buys nothing.
 
-Pure-AST. We never ``import_module`` the target, never look at any
-filesystem outside the source tree. String-shape only.
+Pure-AST. We never import / require / eval the target, never look
+at any filesystem outside the source tree. String-shape only.
 
-This module is Python-only at first cut. JavaScript / Go / Java
-extension is straightforward — replace ``_PythonCallGraph`` with a
-language-specific AST walker that emits the same dataclasses. The
-resolver in :mod:`core.inventory.reachability` is language-agnostic.
+Languages today: Python (stdlib ``ast``) + JavaScript / TypeScript
+(tree-sitter when the grammar is installed; empty result
+otherwise). Adding Go / Java means writing one more
+``extract_call_graph_<lang>`` function emitting the same
+dataclasses; the resolver in :mod:`core.inventory.reachability` is
+language-agnostic.
 """
 
 from __future__ import annotations
@@ -58,6 +61,12 @@ INDIRECTION_GETATTR = "getattr"
 INDIRECTION_IMPORTLIB = "importlib"
 INDIRECTION_WILDCARD_IMPORT = "wildcard_import"
 INDIRECTION_DUNDER_IMPORT = "dunder_import"     # __import__("x.y")
+# JavaScript / TypeScript flags. The resolver's masking logic
+# treats them the same as the Python flags: any present →
+# UNCERTAIN for queries against names this file mentions.
+INDIRECTION_DYNAMIC_IMPORT = "dynamic_import"   # JS import(<var>) / require(<var>)
+INDIRECTION_BRACKET_DISPATCH = "bracket_dispatch"  # JS obj[<var>](...)
+INDIRECTION_EVAL = "eval"                        # JS eval / new Function
 
 
 @dataclass
@@ -275,12 +284,432 @@ def _attribute_chain(node: ast.AST) -> Optional[List[str]]:
     return None
 
 
+# ---------------------------------------------------------------------------
+# JavaScript / TypeScript
+# ---------------------------------------------------------------------------
+
+
+def extract_call_graph_javascript(content: str) -> FileCallGraph:
+    """Walk a JavaScript / TypeScript source string via tree-sitter
+    and return its :class:`FileCallGraph`.
+
+    Returns an empty graph when:
+
+      * tree-sitter or ``tree_sitter_javascript`` isn't installed
+        (the inventory builder degrades; resolver treats absence
+        as no-evidence)
+      * The file is unparseable
+
+    Captures both ES-module imports and CommonJS requires; both
+    populate the same ``imports`` map. Default imports
+    (``import x from 'foo'``) bind ``x`` to ``foo``; named imports
+    (``import { y } from 'foo'``) bind ``y`` to ``foo.y`` —
+    matching the Python ``from foo import y`` convention so the
+    resolver's chain semantics work unchanged.
+    """
+    try:
+        import tree_sitter_javascript as ts_js
+        from tree_sitter import Language, Parser
+    except ImportError:
+        logger.debug(
+            "call_graph: tree-sitter JavaScript grammar not "
+            "installed; returning empty graph",
+        )
+        return FileCallGraph()
+
+    try:
+        parser = Parser(Language(ts_js.language()))
+        tree = parser.parse(content.encode("utf-8", errors="replace"))
+    except Exception as e:                          # noqa: BLE001
+        logger.debug("call_graph: JS parse failed (%s)", e)
+        return FileCallGraph()
+
+    walker = _JsCallGraph()
+    walker.walk(tree.root_node)
+    return walker.graph
+
+
+class _JsCallGraph:
+    """Single-pass tree-sitter walk emitting imports + call sites
+    + indirection flags for one JS / TS file."""
+
+    # Node types per tree-sitter-javascript grammar (also used by
+    # tree-sitter-typescript via the same import path).
+    _CALL_NODE = "call_expression"
+    _IMPORT_NODE = "import_statement"
+    _MEMBER_NODE = "member_expression"
+    _SUBSCRIPT_NODE = "subscript_expression"
+    _IDENT_NODE = "identifier"
+    _PROP_IDENT_NODE = "property_identifier"
+    _STRING_NODE = "string"
+    _STRING_FRAG_NODE = "string_fragment"
+    _ARGS_NODE = "arguments"
+    _LEX_DECL_NODES = ("lexical_declaration", "variable_declaration")
+    _VAR_DECLARATOR_NODE = "variable_declarator"
+    _FUNC_NODES = (
+        "function_declaration", "function_expression",
+        "function", "arrow_function", "method_definition",
+        "generator_function_declaration", "generator_function",
+    )
+    _NEW_NODE = "new_expression"
+
+    def __init__(self) -> None:
+        self.graph = FileCallGraph()
+        self._enclosing: List[str] = []
+
+    def walk(self, node) -> None:
+        """Recursive descent. We push/pop the enclosing-function
+        stack on the way down/up so the ``CallSite.caller`` field
+        is the innermost NAMED enclosing function — anonymous
+        functions / arrows are walked-through without affecting
+        the caller attribution."""
+        if node.type in self._FUNC_NODES:
+            name = self._function_name(node)
+            if name is not None:
+                self._enclosing.append(name)
+                try:
+                    for child in node.children:
+                        self.walk(child)
+                finally:
+                    self._enclosing.pop()
+                return
+            # Anonymous function / arrow — descend without a frame
+            # so calls inside attribute to the outer named scope.
+
+        # Top-level shapes we care about. Calls come first because
+        # an import_statement can't contain a call (and we never
+        # want to emit imports as calls).
+        if node.type == self._IMPORT_NODE:
+            self._visit_import(node)
+            # Don't descend further; nothing useful inside.
+            return
+
+        if node.type in self._LEX_DECL_NODES:
+            self._visit_lex_decl(node)
+            # Continue descent so calls / functions inside (e.g.
+            # ``const x = foo()`` — the ``foo()`` call) are seen.
+
+        if node.type == self._CALL_NODE:
+            self._visit_call(node)
+            # Descend into args to capture nested calls.
+
+        for child in node.children:
+            self.walk(child)
+
+    # ------------------------------------------------------------------
+    # Imports
+    # ------------------------------------------------------------------
+
+    def _visit_import(self, node) -> None:
+        """``import x from 'foo'`` / ``import { y, z as zz } from 'foo'``
+        / ``import * as p from 'foo'`` / mixed forms."""
+        # First ``string`` child holds the module name.
+        module = self._import_module_name(node)
+        if not module:
+            return
+        clause = self._first_child_of_type(node, ("import_clause",))
+        if clause is None:
+            return
+        for c in clause.children:
+            if c.type == self._IDENT_NODE:
+                # Default import: ``import x from 'foo'`` → bind x
+                # to the whole module.
+                self.graph.imports[c.text.decode()] = module
+            elif c.type == "named_imports":
+                for spec in c.children:
+                    if spec.type != "import_specifier":
+                        continue
+                    self._add_named_import(spec, module)
+            elif c.type == "namespace_import":
+                # ``import * as p from 'foo'`` — last identifier is
+                # the bound name.
+                last_id = self._last_child_of_type(c, (self._IDENT_NODE,))
+                if last_id:
+                    self.graph.imports[last_id.text.decode()] = module
+
+    def _add_named_import(self, spec, module: str) -> None:
+        """``y`` → bind y to ``module.y``;
+        ``z as zz`` → bind zz to ``module.z``."""
+        ids = [c for c in spec.children if c.type == self._IDENT_NODE]
+        if not ids:
+            return
+        original = ids[0].text.decode()
+        bound = ids[-1].text.decode() if len(ids) > 1 else original
+        self.graph.imports[bound] = f"{module}.{original}"
+
+    def _visit_lex_decl(self, node) -> None:
+        """``const x = require('foo')`` / ``const { y } = require('foo')``."""
+        for declarator in node.children:
+            if declarator.type != self._VAR_DECLARATOR_NODE:
+                continue
+            value = self._declarator_value(declarator)
+            if value is None:
+                continue
+            module = self._require_module_name(value)
+            if module is None:
+                continue
+            target = declarator.children[0] if declarator.children else None
+            if target is None:
+                continue
+            if target.type == self._IDENT_NODE:
+                # ``const x = require('foo')`` → bind x to foo.
+                self.graph.imports[target.text.decode()] = module
+            elif target.type == "object_pattern":
+                # ``const { y, z: zz } = require('foo')`` —
+                # destructured names map to module.y / module.z.
+                for prop in target.children:
+                    if prop.type == "shorthand_property_identifier_pattern":
+                        nm = prop.text.decode()
+                        self.graph.imports[nm] = f"{module}.{nm}"
+                    elif prop.type == "pair_pattern":
+                        # ``z: zz`` — alias. Original is a
+                        # ``property_identifier`` (the key); alias
+                        # is an ``identifier`` (the binding).
+                        ids = [
+                            c for c in prop.children
+                            if c.type in (
+                                self._IDENT_NODE, self._PROP_IDENT_NODE,
+                            )
+                        ]
+                        if len(ids) == 2:
+                            orig = ids[0].text.decode()
+                            alias = ids[1].text.decode()
+                            self.graph.imports[alias] = f"{module}.{orig}"
+
+    # ------------------------------------------------------------------
+    # Calls + indirection
+    # ------------------------------------------------------------------
+
+    def _visit_call(self, node) -> None:
+        """Every ``call_expression``. Detect:
+
+          * Plain ``foo()`` and ``a.b.c()`` → recorded as CallSite.
+          * Dynamic ``import(x)`` → ``INDIRECTION_DYNAMIC_IMPORT``.
+          * ``require(<var>)`` → ``INDIRECTION_DYNAMIC_IMPORT``
+            (string-arg require is already handled in
+            ``_visit_lex_decl``).
+          * Bracket-dispatch ``obj[<var>](...)`` →
+            ``INDIRECTION_BRACKET_DISPATCH``.
+          * ``eval(...)``, ``new Function(...)()`` →
+            ``INDIRECTION_EVAL``.
+        """
+        callee = self._call_callee(node)
+        if callee is None:
+            return
+
+        # Dynamic ``import(...)`` — callee is the keyword.
+        if callee.type == "import":
+            self.graph.indirection.add(INDIRECTION_DYNAMIC_IMPORT)
+            return
+
+        # Subscript dispatch: ``obj[expr](...)``.
+        if callee.type == self._SUBSCRIPT_NODE:
+            self.graph.indirection.add(INDIRECTION_BRACKET_DISPATCH)
+            # Bracket with literal string ``obj["name"]()`` is the
+            # JS analog of Python's ``getattr(obj, "name")``.
+            # Capture the string for the resolver's
+            # ``getattr_targets`` mechanism.
+            literal = self._subscript_string_literal(callee)
+            if literal is not None:
+                self.graph.getattr_targets.add(literal)
+            return
+
+        # Bare-name and chain calls.
+        chain = self._callee_chain(callee)
+        if chain is None:
+            # ``new Function(...)()`` — outer call has a
+            # ``new_expression`` callee. Flag eval-style and skip.
+            if callee.type == self._NEW_NODE:
+                cls = self._first_child_of_type(callee, (self._IDENT_NODE,))
+                if cls is not None and cls.text.decode() == "Function":
+                    self.graph.indirection.add(INDIRECTION_EVAL)
+            return
+
+        # ``eval('...')`` — bare-name; also flag.
+        if chain == ["eval"]:
+            self.graph.indirection.add(INDIRECTION_EVAL)
+
+        # ``require(<non-string>)`` — chain `["require"]`. Already
+        # flagged for the bracket / dynamic case; here it's the
+        # variable-arg require pattern.
+        if chain == ["require"] and not self._call_first_arg_is_string(node):
+            self.graph.indirection.add(INDIRECTION_DYNAMIC_IMPORT)
+
+        caller = self._enclosing[-1] if self._enclosing else None
+        self.graph.calls.append(CallSite(
+            line=node.start_point[0] + 1,
+            chain=chain,
+            caller=caller,
+        ))
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _function_name(self, node) -> Optional[str]:
+        """Best-effort name extraction for a function-shape node.
+
+        ``function foo() {}`` → ``foo``.
+        ``method foo() {}``   → ``foo``.
+        ``() => {}`` and ``function() {}`` → None.
+
+        Arrow functions and anonymous function expressions don't
+        carry a name; their first identifier child is a parameter,
+        not the function name. Returning None for those collapses
+        ``caller`` to whatever frame is above (or None for
+        module-level), which matches operator intuition.
+        """
+        # Only ``function_declaration`` /
+        # ``generator_function_declaration`` / ``method_definition``
+        # carry a real name. Arrow functions, function expressions,
+        # and anonymous-function nodes don't — their first identifier
+        # is a parameter.
+        named_kinds = (
+            "function_declaration",
+            "generator_function_declaration",
+            "method_definition",
+        )
+        if node.type not in named_kinds:
+            return None
+        ident = self._first_child_of_type(
+            node, (self._IDENT_NODE, self._PROP_IDENT_NODE),
+        )
+        if ident is not None:
+            return ident.text.decode()
+        return None
+
+    def _call_callee(self, call_node):
+        """The first non-trivia child of a ``call_expression`` is
+        the callee. Skip anonymous nodes."""
+        for c in call_node.children:
+            if c.type == self._ARGS_NODE:
+                return None
+            if c.is_named:
+                return c
+        return None
+
+    def _callee_chain(self, callee) -> Optional[List[str]]:
+        """Convert a call's callee node into the dotted attribute
+        chain. Returns None for non-name callees (subscripts,
+        function returns, ``new_expression``, etc.)."""
+        if callee is None:
+            return None
+        if callee.type == self._IDENT_NODE:
+            return [callee.text.decode()]
+        if callee.type == self._MEMBER_NODE:
+            parts: List[str] = []
+            cur = callee
+            while cur is not None and cur.type == self._MEMBER_NODE:
+                prop = self._last_child_of_type(
+                    cur, (self._PROP_IDENT_NODE,),
+                )
+                if prop is None:
+                    return None
+                parts.append(prop.text.decode())
+                cur = cur.children[0] if cur.children else None
+            if cur is not None and cur.type == self._IDENT_NODE:
+                parts.append(cur.text.decode())
+                return list(reversed(parts))
+            return None
+        return None
+
+    def _call_first_arg_is_string(self, call_node) -> bool:
+        args = self._first_child_of_type(call_node, (self._ARGS_NODE,))
+        if args is None:
+            return False
+        for c in args.children:
+            if c.is_named:
+                return c.type == self._STRING_NODE
+        return False
+
+    def _subscript_string_literal(self, subscript_node) -> Optional[str]:
+        """``obj["name"]`` → ``"name"``. Returns None for
+        ``obj[var]``."""
+        # The subscript_expression children (named) are
+        # [object, index]. The index is the second named child.
+        named = [c for c in subscript_node.children if c.is_named]
+        if len(named) < 2:
+            return None
+        idx = named[1]
+        if idx.type != self._STRING_NODE:
+            return None
+        frag = self._first_child_of_type(idx, (self._STRING_FRAG_NODE,))
+        if frag is None:
+            return None
+        return frag.text.decode()
+
+    def _import_module_name(self, import_node) -> Optional[str]:
+        """First ``string`` child of an ``import_statement`` carries
+        the module path."""
+        s = self._first_child_of_type(import_node, (self._STRING_NODE,))
+        if s is None:
+            return None
+        frag = self._first_child_of_type(s, (self._STRING_FRAG_NODE,))
+        if frag is None:
+            return None
+        return frag.text.decode()
+
+    def _declarator_value(self, declarator):
+        """The value-expression child of a ``variable_declarator``
+        (``= <expr>``). Returns None when no initializer."""
+        named = [c for c in declarator.children if c.is_named]
+        # First named is the binding (identifier / object_pattern);
+        # last is the value (when present).
+        if len(named) < 2:
+            return None
+        return named[-1]
+
+    def _require_module_name(self, value_node) -> Optional[str]:
+        """Detect ``require('foo')`` and return ``'foo'``. Anything
+        else (including ``require(variable)``) → None."""
+        if value_node.type != self._CALL_NODE:
+            return None
+        callee = self._call_callee(value_node)
+        if (callee is None
+            or callee.type != self._IDENT_NODE
+            or callee.text.decode() != "require"):
+            return None
+        args = self._first_child_of_type(value_node, (self._ARGS_NODE,))
+        if args is None:
+            return None
+        for c in args.children:
+            if not c.is_named:
+                continue
+            if c.type != self._STRING_NODE:
+                # ``require(variable)`` — caller flags as dynamic.
+                return None
+            frag = self._first_child_of_type(c, (self._STRING_FRAG_NODE,))
+            if frag is not None:
+                return frag.text.decode()
+            return None
+        return None
+
+    @staticmethod
+    def _first_child_of_type(node, types):
+        for c in node.children:
+            if c.type in types:
+                return c
+        return None
+
+    @staticmethod
+    def _last_child_of_type(node, types):
+        last = None
+        for c in node.children:
+            if c.type in types:
+                last = c
+        return last
+
+
 __all__ = [
     "CallSite",
     "FileCallGraph",
+    "INDIRECTION_BRACKET_DISPATCH",
     "INDIRECTION_DUNDER_IMPORT",
+    "INDIRECTION_DYNAMIC_IMPORT",
+    "INDIRECTION_EVAL",
     "INDIRECTION_GETATTR",
     "INDIRECTION_IMPORTLIB",
     "INDIRECTION_WILDCARD_IMPORT",
+    "extract_call_graph_javascript",
     "extract_call_graph_python",
 ]

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -69,7 +69,10 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from .call_graph import (
+    INDIRECTION_BRACKET_DISPATCH,
     INDIRECTION_DUNDER_IMPORT,
+    INDIRECTION_DYNAMIC_IMPORT,
+    INDIRECTION_EVAL,
     INDIRECTION_GETATTR,
     INDIRECTION_IMPORTLIB,
     INDIRECTION_WILDCARD_IMPORT,
@@ -118,11 +121,17 @@ _TEST_FILE_PATTERN = re.compile(
 
 
 # Indirection flags that can mask a static "not called" claim.
+# Python flags first; JS flags second. The resolver doesn't
+# distinguish — any present flag → file is a confounder when it
+# also mentions the target tail name.
 _MASKING_FLAGS: Set[str] = {
     INDIRECTION_GETATTR,
     INDIRECTION_IMPORTLIB,
     INDIRECTION_DUNDER_IMPORT,
     INDIRECTION_WILDCARD_IMPORT,
+    INDIRECTION_BRACKET_DISPATCH,
+    INDIRECTION_DYNAMIC_IMPORT,
+    INDIRECTION_EVAL,
 }
 
 

--- a/core/inventory/tests/test_call_graph_javascript.py
+++ b/core/inventory/tests/test_call_graph_javascript.py
@@ -1,0 +1,330 @@
+"""Tests for :func:`core.inventory.call_graph.extract_call_graph_javascript`.
+
+The Python extractor's tests in ``test_call_graph.py`` cover the
+language-agnostic shape of ``FileCallGraph``; here we pin the
+JS-specific data shapes (ESM imports, CommonJS require,
+destructured require, dynamic import, bracket dispatch, eval).
+The resolver in :mod:`core.inventory.reachability` is unchanged —
+it just consumes the per-file dicts emitted by either extractor.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.inventory.call_graph import (
+    FileCallGraph,
+    INDIRECTION_BRACKET_DISPATCH,
+    INDIRECTION_DYNAMIC_IMPORT,
+    INDIRECTION_EVAL,
+    extract_call_graph_javascript,
+)
+
+
+pytest.importorskip("tree_sitter_javascript")
+
+
+# ---------------------------------------------------------------------------
+# Imports — ES modules
+# ---------------------------------------------------------------------------
+
+
+def test_default_import():
+    g = extract_call_graph_javascript("import lodash from 'lodash';\n")
+    assert g.imports == {"lodash": "lodash"}
+
+
+def test_named_import():
+    g = extract_call_graph_javascript(
+        "import { get, set } from 'lodash';\n",
+    )
+    assert g.imports == {"get": "lodash.get", "set": "lodash.set"}
+
+
+def test_named_import_with_alias():
+    g = extract_call_graph_javascript(
+        "import { get as g, set as s } from 'lodash';\n",
+    )
+    assert g.imports == {"g": "lodash.get", "s": "lodash.set"}
+
+
+def test_namespace_import():
+    g = extract_call_graph_javascript(
+        "import * as fp from 'lodash/fp';\n",
+    )
+    assert g.imports == {"fp": "lodash/fp"}
+
+
+def test_default_plus_named_import():
+    g = extract_call_graph_javascript(
+        "import lodash, { get } from 'lodash';\n",
+    )
+    assert g.imports == {"lodash": "lodash", "get": "lodash.get"}
+
+
+def test_relative_path_import():
+    """Relative import — module path stays as the literal string;
+    OSV won't match (it's project-internal), but the resolver
+    can still consume the data without crashing."""
+    g = extract_call_graph_javascript(
+        "import x from './local';\n",
+    )
+    assert g.imports == {"x": "./local"}
+
+
+# ---------------------------------------------------------------------------
+# Imports — CommonJS require
+# ---------------------------------------------------------------------------
+
+
+def test_simple_require():
+    g = extract_call_graph_javascript(
+        "const lodash = require('lodash');\n",
+    )
+    assert g.imports == {"lodash": "lodash"}
+
+
+def test_destructured_require():
+    g = extract_call_graph_javascript(
+        "const { get, set } = require('lodash');\n",
+    )
+    assert g.imports == {"get": "lodash.get", "set": "lodash.set"}
+
+
+def test_destructured_require_with_alias():
+    """``const { get: g } = require('lodash')`` — alias rename."""
+    g = extract_call_graph_javascript(
+        "const { get: g } = require('lodash');\n",
+    )
+    assert g.imports == {"g": "lodash.get"}
+
+
+def test_var_declaration_require():
+    """``var x = require(...)`` (legacy) works the same as ``const``."""
+    g = extract_call_graph_javascript(
+        "var lodash = require('lodash');\n",
+    )
+    assert g.imports == {"lodash": "lodash"}
+
+
+# ---------------------------------------------------------------------------
+# Calls
+# ---------------------------------------------------------------------------
+
+
+def test_attribute_chain_call():
+    g = extract_call_graph_javascript(
+        "import lodash from 'lodash';\nlodash.get(obj, 'k');\n",
+    )
+    assert any(c.chain == ["lodash", "get"] for c in g.calls)
+
+
+def test_bare_call():
+    g = extract_call_graph_javascript(
+        "import { get } from 'lodash';\nget(obj);\n",
+    )
+    assert any(c.chain == ["get"] for c in g.calls)
+
+
+def test_deep_attribute_chain():
+    g = extract_call_graph_javascript(
+        "import _ from 'lodash';\n_.fp.flow.compose(a, b);\n",
+    )
+    assert any(
+        c.chain == ["_", "fp", "flow", "compose"] for c in g.calls
+    )
+
+
+def test_module_level_call_caller_none():
+    g = extract_call_graph_javascript("foo();\n")
+    foo_calls = [c for c in g.calls if c.chain == ["foo"]]
+    assert foo_calls
+    assert foo_calls[0].caller is None
+
+
+def test_caller_attribution_named_function():
+    g = extract_call_graph_javascript(
+        "function outer() { foo(); }\n",
+    )
+    foo_calls = [c for c in g.calls if c.chain == ["foo"]]
+    assert foo_calls[0].caller == "outer"
+
+
+def test_arrow_does_not_break_caller_attribution():
+    """Calls inside an anonymous arrow inside a named function
+    attribute to the named function, not to the arrow."""
+    g = extract_call_graph_javascript(
+        "function outer() { arr.map(x => x.foo()); }\n",
+    )
+    foo_calls = [c for c in g.calls if c.chain == ["x", "foo"]]
+    assert foo_calls[0].caller == "outer"
+
+
+def test_method_definition_caller_attribution():
+    g = extract_call_graph_javascript(
+        "class C { meth() { foo(); } }\n",
+    )
+    foo_calls = [c for c in g.calls if c.chain == ["foo"]]
+    assert foo_calls[0].caller == "meth"
+
+
+# ---------------------------------------------------------------------------
+# Indirection flags
+# ---------------------------------------------------------------------------
+
+
+def test_dynamic_import_flagged():
+    g = extract_call_graph_javascript(
+        "import('./dynamic').then(m => m.foo());\n",
+    )
+    assert INDIRECTION_DYNAMIC_IMPORT in g.indirection
+
+
+def test_require_with_variable_arg_flagged():
+    """``require(variable)`` is dynamic — flag it."""
+    g = extract_call_graph_javascript(
+        "function f(name) { return require(name); }\n",
+    )
+    assert INDIRECTION_DYNAMIC_IMPORT in g.indirection
+
+
+def test_bracket_dispatch_flagged():
+    g = extract_call_graph_javascript(
+        "function f(name) { obj[name](); }\n",
+    )
+    assert INDIRECTION_BRACKET_DISPATCH in g.indirection
+
+
+def test_bracket_with_string_literal_captures_target():
+    """``obj["get"]()`` is the JS analog of Python's
+    ``getattr(obj, "get")()``. The literal ``"get"`` is captured
+    as a getattr_target so the resolver's tail-name detection
+    fires on queries about ``<lib>.get``."""
+    g = extract_call_graph_javascript(
+        "obj['someName']();\n",
+    )
+    assert "someName" in g.getattr_targets
+    assert INDIRECTION_BRACKET_DISPATCH in g.indirection
+
+
+def test_eval_flagged():
+    g = extract_call_graph_javascript("eval('alert(1)');\n")
+    assert INDIRECTION_EVAL in g.indirection
+
+
+def test_new_function_flagged():
+    """``new Function('return 1')()`` is the indirect-eval
+    pattern."""
+    g = extract_call_graph_javascript(
+        "new Function('return 1')();\n",
+    )
+    assert INDIRECTION_EVAL in g.indirection
+
+
+def test_normal_call_no_indirection():
+    g = extract_call_graph_javascript(
+        "import lodash from 'lodash';\nlodash.get(obj);\n",
+    )
+    assert g.indirection == set()
+
+
+# ---------------------------------------------------------------------------
+# Resilience
+# ---------------------------------------------------------------------------
+
+
+def test_syntax_error_returns_empty():
+    """Malformed JS shouldn't crash the inventory build. tree-
+    sitter is error-tolerant so it'll return SOMETHING — we just
+    need it to not blow up."""
+    g = extract_call_graph_javascript("function broken( {")
+    # Either FileCallGraph() or a partial extract — both
+    # acceptable. Crucial: no exception.
+    assert isinstance(g, FileCallGraph)
+
+
+def test_empty_file():
+    g = extract_call_graph_javascript("")
+    assert g == FileCallGraph()
+
+
+def test_round_trip_through_dict():
+    """Same shape as the Python extractor — round-trips cleanly."""
+    g = extract_call_graph_javascript(
+        "import lodash from 'lodash';\n"
+        "function f() { lodash.get(obj); obj['k'](); }\n",
+    )
+    d = g.to_dict()
+    g2 = FileCallGraph.from_dict(d)
+    assert g2.imports == g.imports
+    assert {tuple(c.chain) for c in g2.calls} == {
+        tuple(c.chain) for c in g.calls
+    }
+    assert g2.indirection == g.indirection
+    assert g2.getattr_targets == g.getattr_targets
+
+
+# ---------------------------------------------------------------------------
+# End-to-end with the resolver
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_called_against_js_data():
+    """The language-agnostic resolver consumes JS call_graph data
+    just like Python's. Synthesise an inventory entry from the JS
+    extractor and verify ``function_called`` returns CALLED for a
+    matching qualified name."""
+    from core.inventory.reachability import Verdict, function_called
+
+    cg = extract_call_graph_javascript(
+        "import lodash from 'lodash';\n"
+        "lodash.get(obj, 'k');\n"
+    ).to_dict()
+    inv = {
+        "files": [
+            {"path": "src/app.js", "language": "javascript",
+             "call_graph": cg},
+        ],
+    }
+    r = function_called(inv, "lodash.get")
+    assert r.verdict == Verdict.CALLED
+    assert r.evidence == (("src/app.js", 2),)
+
+
+def test_resolver_uncertain_on_eval():
+    """File uses eval AND mentions the target tail name (via a
+    bracket-string literal) → UNCERTAIN."""
+    from core.inventory.reachability import Verdict, function_called
+
+    cg = extract_call_graph_javascript(
+        "import lodash from 'lodash';\n"
+        "function f() {\n"
+        "    lodash['get'](obj);\n"
+        "}\n"
+    ).to_dict()
+    inv = {
+        "files": [
+            {"path": "src/app.js", "language": "javascript",
+             "call_graph": cg},
+        ],
+    }
+    r = function_called(inv, "lodash.get")
+    assert r.verdict == Verdict.UNCERTAIN
+
+
+def test_resolver_not_called_when_function_unused():
+    """JS file imports lodash but never calls .get."""
+    from core.inventory.reachability import Verdict, function_called
+
+    cg = extract_call_graph_javascript(
+        "import lodash from 'lodash';\n"
+        "lodash.set(obj, 'k', 1);\n"
+    ).to_dict()
+    inv = {
+        "files": [
+            {"path": "src/app.js", "language": "javascript",
+             "call_graph": cg},
+        ],
+    }
+    r = function_called(inv, "lodash.get")
+    assert r.verdict == Verdict.NOT_CALLED


### PR DESCRIPTION
Extends the function-level reachability substrate (PR-2, core/inventory.reachability) to JS / TS. The resolver itself is unchanged — it consumed FileCallGraph data language-agnostically already; this commit adds a tree-sitter-backed extractor that emits the same shape from JS / TS source.

For npm consumers in particular, OSV advisories regularly ship imports[].symbols data per affected version. The SCA function- level reachability tier can now match those symbols against project JS source the same way the Python tier already matches PyPI database_specific.affected_functions.

What the JS extractor captures:

* ES module imports — default / named / namespace / aliased / combined forms, plus relative paths
* CommonJS require — simple, destructured, alias (get: g), legacy var
* Call sites — every call_expression with a name-shaped callee, recorded as the dotted attribute chain. CallSite.caller is the innermost NAMED enclosing function — anonymous functions and arrows are walked through without breaking attribution
* Indirection flags (mirror Python set with JS-specific values, all in _MASKING_FLAGS): dynamic_import (import(<var>) / require(<var>)), bracket_dispatch (obj[<var>](...)), eval (eval / new Function(...)())
* Bracket-string literals captured into getattr_targets so the resolver's tail-name detection fires on queries against <lib>.<literal>

Wiring:

* core/inventory/builder.py routes language == 'javascript' / 'typescript' to extract_call_graph_javascript. The call_graph field rides on the same per-file record; consumers see JS reachability with no changes on their side
* core/inventory/reachability.py _MASKING_FLAGS extended to include the three JS flags
* REACHABILITY.md documents per-language extractor layout

Tests (30): ESM imports (6), CommonJS require (4), calls (7), indirection flags (6), resilience (3), end-to-end with the resolver (3). When tree_sitter_javascript isn't installed, the suite is skipped via pytest.importorskip rather than failing.

All 226 inventory tests pass (was 196; +30).