### PR TITLE
feat(security): route in-process LLM SDK calls + remote SAGE through …

### DIFF
--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -272,6 +272,26 @@ class LLMClient:
         # the parent dir, so we defer until needed.
         self._scorecard = None
 
+        # Route in-process LLM SDK calls through the in-process
+        # egress proxy (matches what cc_dispatch.py already does for
+        # the CC subprocess). Idempotent across multiple LLMClient
+        # constructions in the same process; no-op on Ollama-only or
+        # autodetect-empty configs. See core/llm/egress.py for the
+        # full rationale (chokepoint, hostname allowlist, corporate
+        # proxy chain, subprocess-env separation).
+        from .egress import enable_llm_egress
+        try:
+            enable_llm_egress(self.config)
+        except Exception as e:                          # noqa: BLE001
+            # Fail open: a proxy bring-up failure must not block LLM
+            # calls entirely. Log and continue with direct egress.
+            # Operator who needs the chokepoint will see the warning.
+            logger.warning(
+                "LLM egress proxy bring-up failed (%s) — falling back "
+                "to direct outbound. Allowlist enforcement disabled "
+                "for this run.", e,
+            )
+
         # HEALTH CHECK: Warn if no API keys configured
         from .detection import detect_llm_availability
         availability = detect_llm_availability()

--- a/core/llm/egress.py
+++ b/core/llm/egress.py
@@ -1,0 +1,264 @@
+"""Route in-process LLM SDK calls (anthropic, openai, google-genai)
+through RAPTOR's existing in-process egress proxy.
+
+Why this exists
+---------------
+``packages/llm_analysis/cc_dispatch.py`` already routes the Claude Code
+subprocess through the in-process proxy (``use_egress_proxy=True,
+proxy_hosts=["api.anthropic.com"]``). The OTHER LLM consumers — direct
+in-process SDK calls used by /agentic external-LLM dispatch, /codeql's
+autonomous_analyzer, etc. — have historically gone direct, with no
+chokepoint to enforce hostname allowlist or surface egress for audit.
+
+This module closes that gap by setting ``HTTPS_PROXY`` in the parent
+process env to point at the same in-process proxy CC already uses.
+``httpx``-based SDKs (anthropic, openai, google-genai all use httpx
+under the hood) honour the env var and route accordingly.
+
+Hostname allowlist comes from ``LLMConfig`` itself — the operator's own
+configured ``api_base`` per ``ModelConfig`` is the authoritative
+source. Operators who route through LiteLLM proxy / corporate gateway
+/ vLLM by setting ``api_base`` automatically get that hostname
+allowlisted; defaults from :data:`PROVIDER_ENDPOINTS` cover the
+unconfigured case.
+
+No TLS interception
+-------------------
+The in-process proxy is a CONNECT-tunnel proxy: it sees host:port for
+allowlist enforcement and audit logging, but never decrypts the
+TLS body. So no CA injection is needed; SDK trust-store behaviour is
+unchanged. Cert pinning is irrelevant. (TLS-intercepting MITM is the
+separately-tracked /web feature.)
+
+Subprocess interaction
+----------------------
+``RaptorConfig.get_safe_env()`` strips ``HTTPS_PROXY`` from subprocess
+envs as a defence against env-injection attacks (a malicious target
+repo's ``.claude/settings.json`` could otherwise redirect a CodeQL
+build subprocess to an attacker proxy). That stripping is at a
+DIFFERENT layer from this module — we set ``HTTPS_PROXY`` in the
+parent process for the in-process LLM SDKs; subprocess builds do not
+inherit it. The two co-exist cleanly.
+
+Corporate-proxy chaining
+------------------------
+If the operator has ``HTTPS_PROXY=http://corp:8080`` set when RAPTOR
+launches, the in-process proxy reads it at first-construction time and
+chains through it for upstream connections. We MUST call
+``get_proxy()`` BEFORE overwriting ``HTTPS_PROXY`` — otherwise the
+proxy reads its own pointer and loops. Order is enforced in
+:func:`enable_llm_egress`.
+
+Process-wide effect on non-LLM HTTP callers
+-------------------------------------------
+Setting ``HTTPS_PROXY`` in ``os.environ`` affects every ``httpx`` /
+``requests`` caller in the same process, not just the LLM SDKs we
+intend to gate. Audit performed 2026-05-07:
+
+  * ``core.startup.init._test_key`` — hits the LLM provider hosts
+    (api.anthropic.com, api.openai.com, api.mistral.ai, ...). All in
+    the allowlist (they're the configured providers). Tunneled
+    through the chokepoint cleanly.
+  * ``core.llm.detection.detect_llm_availability`` (Ollama) — hits
+    ``localhost:11434``. Bypassed via the ``NO_PROXY`` augmentation
+    so this still works.
+  * ``core.sage.client`` (httpx.get on the configured SAGE URL) —
+    default ``http://localhost:8090`` is bypassed via ``NO_PROXY``.
+    For remote SAGE URLs, ``SageClient.__init__`` calls
+    ``get_proxy([sage_host])`` to add the host to the in-process
+    proxy's allowlist, so SAGE's health check + SDK calls flow
+    through the same chokepoint cleanly.
+  * ``packages.cve_diff`` — uses its own ``ResilientLLMClient`` that
+    calls ``create_provider`` directly, never constructing
+    ``LLMClient``, so this module's ``enable_llm_egress`` never
+    fires for cve-diff. cve-diff retains direct egress.
+  * ``core.git.clone`` — git runs as a sandboxed subprocess with
+    its own sanitised env (``RaptorConfig.get_git_env()``); parent
+    HTTPS_PROXY is not inherited.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Iterable, Set
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from .config import LLMConfig
+
+logger = logging.getLogger(__name__)
+
+
+# Static fallback for providers that bypass ``api_base`` because their
+# native SDK hardcodes the base URL (Anthropic). Other providers go
+# through ``PROVIDER_ENDPOINTS`` in :mod:`core.llm.model_data`.
+_KNOWN_DEFAULTS = {
+    "anthropic": "https://api.anthropic.com",
+}
+
+
+# Local-loop hosts that must NOT route through the chokepoint — Ollama
+# / vLLM / LiteLLM-on-localhost loop back through the proxy and break
+# its allowlist semantics for non-loopback callers.
+_LOCAL_BYPASS = ("localhost", "127.0.0.1")
+
+
+# Idempotency: once enabled in this process, repeated calls are no-ops
+# beyond union-ing the allowlist on the singleton proxy. Tracks the
+# port we set in HTTPS_PROXY so we don't re-overwrite an
+# operator-supplied value.
+_enabled = False
+
+
+def derive_allowlist(config: "LLMConfig") -> Set[str]:
+    """Walk ``config`` and extract the set of hostnames the in-process
+    proxy must allow.
+
+    For each ModelConfig (primary, fallbacks, specialized), pick the
+    hostname from its ``api_base`` if set, else ``PROVIDER_ENDPOINTS``,
+    else ``_KNOWN_DEFAULTS``. Returns ``set[str]`` of hostnames (host
+    only, no scheme/port/path).
+
+    Empty when no models are configured (e.g. CC-prep-only run, or
+    autodetect found no provider). Caller treats empty as "don't
+    bother enabling egress" — it's a no-op from the proxy's
+    perspective.
+    """
+    from .model_data import PROVIDER_ENDPOINTS
+
+    candidates: list = []
+    if config.primary_model is not None:
+        candidates.append(config.primary_model)
+    candidates.extend(config.fallback_models or [])
+    if config.specialized_models:
+        candidates.extend(config.specialized_models.values())
+
+    hosts: Set[str] = set()
+    for model in candidates:
+        if model is None:
+            continue
+        # Per-model api_base wins; otherwise fall back to provider
+        # default. PROVIDER_ENDPOINTS first (what the SDK actually
+        # uses), _KNOWN_DEFAULTS for native-SDK Anthropic which
+        # bypasses api_base entirely.
+        url = (
+            getattr(model, "api_base", None)
+            or PROVIDER_ENDPOINTS.get(getattr(model, "provider", None))
+            or _KNOWN_DEFAULTS.get(getattr(model, "provider", None))
+        )
+        if not url:
+            continue
+        host = _hostname_of(url)
+        if host:
+            hosts.add(host)
+    return hosts
+
+
+def _hostname_of(url: str) -> str:
+    """Extract the bare hostname (no port, no scheme, no path) from
+    a URL. Returns empty string on parse failure."""
+    try:
+        parsed = urlparse(url)
+    except (ValueError, TypeError):
+        return ""
+    # urlparse leaves ``hostname`` lowercased and port-stripped, which
+    # is what allowlist comparison wants.
+    return parsed.hostname or ""
+
+
+def _is_loopback(host: str) -> bool:
+    return host.lower() in _LOCAL_BYPASS
+
+
+def _augment_no_proxy(existing: str) -> str:
+    """Return a NO_PROXY value that includes ``localhost`` and
+    ``127.0.0.1`` UNION-ed with whatever the operator already set.
+    Order-preserving (operator entries first); de-duplicated."""
+    parts = [p.strip() for p in (existing or "").split(",") if p.strip()]
+    seen = {p.lower() for p in parts}
+    for entry in _LOCAL_BYPASS:
+        if entry.lower() not in seen:
+            parts.append(entry)
+            seen.add(entry.lower())
+    return ",".join(parts)
+
+
+def enable_llm_egress(config: "LLMConfig") -> None:
+    """Wire LLM SDK calls through the in-process proxy.
+
+    Idempotent: safe to call once per ``LLMClient`` instantiation; the
+    first call brings up the proxy and mutates env, subsequent calls
+    only union the allowlist.
+
+    Order-critical: ``get_proxy()`` is invoked BEFORE we overwrite
+    ``HTTPS_PROXY`` so the proxy reads operator-supplied upstream
+    chain (corporate proxy autodetect) at first-construction time,
+    not our self-pointer.
+
+    No-op when ``config`` resolves to an empty allowlist (e.g. no
+    models configured) — saves the proxy bring-up cost and avoids
+    surprising env mutation in CC-only or autodetect-empty modes.
+    """
+    global _enabled
+
+    allowlist = derive_allowlist(config)
+    # Drop loopback hosts from the proxy allowlist — they bypass the
+    # proxy entirely via NO_PROXY (set below). Adding them to the
+    # allowlist would let an attacker register a localhost service
+    # and have it reachable via the chokepoint, defeating the
+    # isolation the chokepoint exists to provide.
+    remote_hosts = {h for h in allowlist if not _is_loopback(h)}
+
+    if not remote_hosts:
+        # Nothing to chokepoint — Ollama-only, autodetect-empty, or
+        # CC-only setups. Skip silently.
+        return
+
+    # Step 1: bring up / extend the in-process proxy. MUST happen
+    # before we mutate HTTPS_PROXY so upstream-chain autodetect sees
+    # the operator's value (if any), not our self-pointer.
+    from core.sandbox.proxy import get_proxy
+    proxy = get_proxy(list(remote_hosts))
+
+    # Step 2: only mutate env on the first call. Subsequent
+    # LLMClient constructors just union the allowlist via get_proxy
+    # above; HTTPS_PROXY is already pointing where we want.
+    if _enabled:
+        return
+
+    # Step 3: point HTTPS_PROXY at our in-process proxy so httpx-based
+    # SDKs route through it. Honour http (not https) — the in-process
+    # proxy is plain-HTTP-on-loopback (CONNECT to upstream is what
+    # carries the TLS).
+    os.environ["HTTPS_PROXY"] = f"http://127.0.0.1:{proxy.port}"
+    os.environ["https_proxy"] = os.environ["HTTPS_PROXY"]
+
+    # Step 4: ensure local-loop hosts (Ollama, vLLM-localhost,
+    # LiteLLM-localhost) bypass the chokepoint. Union with whatever
+    # the operator already had so corporate ``NO_PROXY=internal.corp``
+    # is preserved.
+    existing = os.environ.get("NO_PROXY") or os.environ.get("no_proxy") or ""
+    new_no_proxy = _augment_no_proxy(existing)
+    os.environ["NO_PROXY"] = new_no_proxy
+    os.environ["no_proxy"] = new_no_proxy
+
+    _enabled = True
+    logger.debug(
+        "LLM egress enabled: HTTPS_PROXY=127.0.0.1:%d, allowlist=%s",
+        proxy.port, sorted(remote_hosts),
+    )
+
+
+def _reset_for_tests() -> None:
+    """Test-only helper: reset the module-level idempotency flag.
+    Does NOT clear env vars or the singleton proxy — those are
+    process-wide concerns the test fixture handles separately."""
+    global _enabled
+    _enabled = False
+
+
+__all__ = [
+    "derive_allowlist",
+    "enable_llm_egress",
+]

--- a/core/llm/tests/conftest.py
+++ b/core/llm/tests/conftest.py
@@ -1,0 +1,38 @@
+"""Per-directory test infra for ``core.llm`` tests.
+
+Reset env vars + module state that ``core.llm.egress.enable_llm_egress``
+mutates as a side effect of ``LLMClient.__init__``. Without this, any
+test in this directory that constructs a real ``LLMClient`` (e.g.
+``test_exclude_fallback``, ``test_ollama_warning``) leaks
+``HTTPS_PROXY=127.0.0.1:<port>`` into ``os.environ``, which subsequent
+tests in the pytest session pick up — notably
+``core/sandbox/tests/test_e2e_sandbox::test_allowed_host_succeeds``,
+where the in-process proxy reads it as a (now-dead) upstream chain
+target and the test's curl call fails with exit 56.
+
+Direct ``os.environ`` mutations bypass ``monkeypatch``'s auto-cleanup,
+so we pop them explicitly here.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+_PROXY_VARS = ("HTTPS_PROXY", "https_proxy", "NO_PROXY", "no_proxy")
+
+
+@pytest.fixture(autouse=True)
+def _reset_llm_egress_state():
+    """Reset egress module flag + clear proxy env vars before AND
+    after every test in this directory."""
+    from core.llm import egress
+    egress._reset_for_tests()
+    for var in _PROXY_VARS:
+        os.environ.pop(var, None)
+    yield
+    egress._reset_for_tests()
+    for var in _PROXY_VARS:
+        os.environ.pop(var, None)

--- a/core/llm/tests/test_egress.py
+++ b/core/llm/tests/test_egress.py
@@ -31,17 +31,9 @@ from core.llm.config import LLMConfig, ModelConfig
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(autouse=True)
-def _reset_egress_state(monkeypatch):
-    """Reset module-level ``_enabled`` flag and any env vars we mutate
-    between tests so each test sees a deterministic starting state."""
-    egress._reset_for_tests()
-    monkeypatch.delenv("HTTPS_PROXY", raising=False)
-    monkeypatch.delenv("https_proxy", raising=False)
-    monkeypatch.delenv("NO_PROXY", raising=False)
-    monkeypatch.delenv("no_proxy", raising=False)
-    yield
-    egress._reset_for_tests()
+# Note: env-var cleanup + ``egress._enabled`` reset for every test in
+# this directory is handled by ``core/llm/tests/conftest.py``'s autouse
+# fixture. See that file for the test-pollution rationale.
 
 
 @pytest.fixture
@@ -100,7 +92,13 @@ class TestDeriveAllowlist:
 
     def test_openai_default_uses_provider_endpoints(self):
         cfg = _config(primary=_model(provider="openai"))
-        assert "api.openai.com" in egress.derive_allowlist(cfg)
+        # Use set equality / superset checks rather than ``in``
+        # against the returned set — CodeQL's
+        # py/incomplete-url-substring-sanitization rule false-positives
+        # on string-shaped LHS in ``in`` checks even when RHS is
+        # explicitly a set. ``issuperset`` makes the set semantics
+        # unambiguous.
+        assert egress.derive_allowlist(cfg).issuperset({"api.openai.com"})
 
     def test_operator_api_base_overrides_default(self):
         """Operator routes Anthropic via internal gateway: the
@@ -112,8 +110,8 @@ class TestDeriveAllowlist:
             api_base="https://gateway.internal.corp/anthropic/v1",
         ))
         hosts = egress.derive_allowlist(cfg)
-        assert "gateway.internal.corp" in hosts
-        assert "api.anthropic.com" not in hosts
+        assert hosts.issuperset({"gateway.internal.corp"})
+        assert hosts.isdisjoint({"api.anthropic.com"})
 
     def test_multi_provider_panel(self):
         """A multi-model dispatch with primary + fallback + specialized
@@ -128,9 +126,9 @@ class TestDeriveAllowlist:
             },
         )
         hosts = egress.derive_allowlist(cfg)
-        assert "api.anthropic.com" in hosts
-        assert "api.openai.com" in hosts
-        assert "api.mistral.ai" in hosts
+        assert hosts.issuperset(
+            {"api.anthropic.com", "api.openai.com", "api.mistral.ai"}
+        )
 
     def test_ollama_only_localhost(self):
         cfg = _config(primary=_model(
@@ -141,7 +139,7 @@ class TestDeriveAllowlist:
         # localhost SHOULD show up here — derive_allowlist is pure
         # discovery; the loopback bypass happens in enable_llm_egress.
         hosts = egress.derive_allowlist(cfg)
-        assert "localhost" in hosts
+        assert hosts.issuperset({"localhost"})
 
     def test_unknown_provider_no_endpoint(self):
         """A provider with no ``api_base`` and no entry in
@@ -162,7 +160,7 @@ class TestDeriveAllowlist:
         hosts = egress.derive_allowlist(cfg)
         # urlparse on "not a url" yields no hostname; we silently skip
         # this entry rather than substituting the default.
-        assert "api.anthropic.com" not in hosts
+        assert hosts.isdisjoint({"api.anthropic.com"})
 
     def test_api_base_with_port_extracts_host_only(self):
         cfg = _config(primary=_model(
@@ -188,29 +186,31 @@ class TestEnableLLMEgress:
     def test_appends_loopback_to_no_proxy(self, stub_proxy):
         cfg = _config(primary=_model(provider="anthropic"))
         egress.enable_llm_egress(cfg)
-        np = os.environ["NO_PROXY"]
-        assert "localhost" in np
-        assert "127.0.0.1" in np
+        # Parse NO_PROXY as a set so the assertion is set-membership
+        # rather than substring containment (CodeQL's URL-substring
+        # rule false-positives on the latter).
+        entries = {p.strip() for p in os.environ["NO_PROXY"].split(",")}
+        assert entries.issuperset({"localhost", "127.0.0.1"})
 
     def test_preserves_operator_no_proxy_entries(self, stub_proxy, monkeypatch):
         monkeypatch.setenv("NO_PROXY", "internal.corp,*.test")
         cfg = _config(primary=_model(provider="anthropic"))
         egress.enable_llm_egress(cfg)
         np = os.environ["NO_PROXY"]
-        assert "internal.corp" in np
-        assert "*.test" in np
-        assert "localhost" in np
+        entries = [p.strip() for p in np.split(",")]
+        assert set(entries).issuperset(
+            {"internal.corp", "*.test", "localhost"}
+        )
         # Order: operator entries first
-        parts = np.split(",")
-        assert parts.index("internal.corp") < parts.index("localhost")
+        assert entries.index("internal.corp") < entries.index("localhost")
 
     def test_no_double_localhost_when_already_present(self, stub_proxy, monkeypatch):
         monkeypatch.setenv("NO_PROXY", "localhost,internal.corp")
         cfg = _config(primary=_model(provider="anthropic"))
         egress.enable_llm_egress(cfg)
-        np = os.environ["NO_PROXY"]
+        entries = [p.strip() for p in os.environ["NO_PROXY"].split(",")]
         # Each entry exactly once
-        assert np.count("localhost") == 1
+        assert entries.count("localhost") == 1
 
     def test_empty_allowlist_no_op(self, stub_proxy, monkeypatch):
         """No models configured (autodetect-empty) → no env mutation,
@@ -257,8 +257,8 @@ class TestEnableLLMEgress:
         egress.enable_llm_egress(cfg1)
         egress.enable_llm_egress(cfg2)
         assert len(stub_proxy) == 2
-        assert "api.anthropic.com" in stub_proxy[0]
-        assert "api.openai.com" in stub_proxy[1]
+        assert set(stub_proxy[0]).issuperset({"api.anthropic.com"})
+        assert set(stub_proxy[1]).issuperset({"api.openai.com"})
 
     def test_proxy_brought_up_before_env_overwrite(self, monkeypatch):
         """Critical ordering: ``get_proxy`` must be called BEFORE we
@@ -310,9 +310,8 @@ class TestEnableLLMEgress:
         egress.enable_llm_egress(cfg)
         assert stub_proxy, "get_proxy should have been called"
         registered = set(stub_proxy[0])
-        assert "api.anthropic.com" in registered
-        assert "localhost" not in registered
-        assert "127.0.0.1" not in registered
+        assert registered.issuperset({"api.anthropic.com"})
+        assert registered.isdisjoint({"localhost", "127.0.0.1"})
 
 
 # ---------------------------------------------------------------------------

--- a/core/llm/tests/test_egress.py
+++ b/core/llm/tests/test_egress.py
@@ -1,0 +1,337 @@
+"""Tests for ``core.llm.egress`` — LLM SDK egress via in-process proxy.
+
+Two layers:
+  * ``derive_allowlist`` — pure function over LLMConfig shape. Easy to
+    test in isolation.
+  * ``enable_llm_egress`` — mutates env + spawns proxy singleton.
+    Tested with a stub proxy (avoids actually opening a port) plus
+    explicit env reset between tests so the global state doesn't
+    leak across the suite.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+try:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+except IndexError:                                      # pragma: no cover
+    pass
+
+from core.llm import egress
+from core.llm.config import LLMConfig, ModelConfig
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_egress_state(monkeypatch):
+    """Reset module-level ``_enabled`` flag and any env vars we mutate
+    between tests so each test sees a deterministic starting state."""
+    egress._reset_for_tests()
+    monkeypatch.delenv("HTTPS_PROXY", raising=False)
+    monkeypatch.delenv("https_proxy", raising=False)
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+    yield
+    egress._reset_for_tests()
+
+
+@pytest.fixture
+def stub_proxy(monkeypatch):
+    """Replace ``core.sandbox.proxy.get_proxy`` with a stub that
+    records the allowlist passed in and returns an object with a
+    fixed ``.port``. Avoids spinning up a real TCP listener for tests
+    that don't need it."""
+    seen_calls = []
+
+    class _StubProxy:
+        port = 51234
+
+    def stub_get_proxy(allowed_hosts):
+        seen_calls.append(list(allowed_hosts))
+        return _StubProxy()
+
+    import core.sandbox.proxy as proxy_mod
+    monkeypatch.setattr(proxy_mod, "get_proxy", stub_get_proxy)
+    yield seen_calls
+
+
+def _model(provider: str = "anthropic", model_name: str = "x",
+           api_base: str = None) -> ModelConfig:
+    return ModelConfig(
+        provider=provider,
+        model_name=model_name,
+        max_context=200000,
+        api_key="k",
+        api_base=api_base,
+    )
+
+
+def _config(primary=None, fallbacks=None, specialized=None) -> LLMConfig:
+    """Bypass autodetect — we craft the config explicitly."""
+    cfg = LLMConfig.__new__(LLMConfig)
+    cfg.primary_model = primary
+    cfg.fallback_models = fallbacks or []
+    cfg.specialized_models = specialized or {}
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# derive_allowlist — pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveAllowlist:
+    def test_empty_config_returns_empty(self):
+        cfg = _config()
+        assert egress.derive_allowlist(cfg) == set()
+
+    def test_anthropic_default_uses_known_default(self):
+        cfg = _config(primary=_model(provider="anthropic"))
+        assert egress.derive_allowlist(cfg) == {"api.anthropic.com"}
+
+    def test_openai_default_uses_provider_endpoints(self):
+        cfg = _config(primary=_model(provider="openai"))
+        assert "api.openai.com" in egress.derive_allowlist(cfg)
+
+    def test_operator_api_base_overrides_default(self):
+        """Operator routes Anthropic via internal gateway: the
+        operator's hostname lands in the allowlist; the
+        ``api.anthropic.com`` default does NOT (because the operator
+        explicitly didn't go there)."""
+        cfg = _config(primary=_model(
+            provider="anthropic",
+            api_base="https://gateway.internal.corp/anthropic/v1",
+        ))
+        hosts = egress.derive_allowlist(cfg)
+        assert "gateway.internal.corp" in hosts
+        assert "api.anthropic.com" not in hosts
+
+    def test_multi_provider_panel(self):
+        """A multi-model dispatch with primary + fallback + specialized
+        across providers contributes every distinct hostname."""
+        cfg = _config(
+            primary=_model(provider="anthropic"),
+            fallbacks=[_model(provider="openai", model_name="gpt-x")],
+            specialized={
+                "verdict_binary": _model(
+                    provider="mistral", model_name="mistral-fast",
+                ),
+            },
+        )
+        hosts = egress.derive_allowlist(cfg)
+        assert "api.anthropic.com" in hosts
+        assert "api.openai.com" in hosts
+        assert "api.mistral.ai" in hosts
+
+    def test_ollama_only_localhost(self):
+        cfg = _config(primary=_model(
+            provider="ollama",
+            model_name="llama3",
+            api_base="http://localhost:11434/v1",
+        ))
+        # localhost SHOULD show up here — derive_allowlist is pure
+        # discovery; the loopback bypass happens in enable_llm_egress.
+        hosts = egress.derive_allowlist(cfg)
+        assert "localhost" in hosts
+
+    def test_unknown_provider_no_endpoint(self):
+        """A provider with no ``api_base`` and no entry in
+        PROVIDER_ENDPOINTS / KNOWN_DEFAULTS contributes nothing —
+        rather than crashing the egress wiring."""
+        cfg = _config(primary=_model(
+            provider="totally-made-up", model_name="x",
+        ))
+        assert egress.derive_allowlist(cfg) == set()
+
+    def test_malformed_api_base_skipped(self):
+        cfg = _config(primary=_model(
+            provider="anthropic",
+            api_base="not a url",
+        ))
+        # Should not crash; falls back to the configured provider's
+        # default if api_base parses to no host.
+        hosts = egress.derive_allowlist(cfg)
+        # urlparse on "not a url" yields no hostname; we silently skip
+        # this entry rather than substituting the default.
+        assert "api.anthropic.com" not in hosts
+
+    def test_api_base_with_port_extracts_host_only(self):
+        cfg = _config(primary=_model(
+            provider="openai",
+            api_base="https://gateway.corp:8443/v1",
+        ))
+        # Hostname only, no port
+        assert egress.derive_allowlist(cfg) == {"gateway.corp"}
+
+
+# ---------------------------------------------------------------------------
+# enable_llm_egress — env mutation + idempotency tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnableLLMEgress:
+    def test_sets_https_proxy_env_var(self, stub_proxy):
+        cfg = _config(primary=_model(provider="anthropic"))
+        egress.enable_llm_egress(cfg)
+        assert os.environ["HTTPS_PROXY"] == "http://127.0.0.1:51234"
+        assert os.environ["https_proxy"] == "http://127.0.0.1:51234"
+
+    def test_appends_loopback_to_no_proxy(self, stub_proxy):
+        cfg = _config(primary=_model(provider="anthropic"))
+        egress.enable_llm_egress(cfg)
+        np = os.environ["NO_PROXY"]
+        assert "localhost" in np
+        assert "127.0.0.1" in np
+
+    def test_preserves_operator_no_proxy_entries(self, stub_proxy, monkeypatch):
+        monkeypatch.setenv("NO_PROXY", "internal.corp,*.test")
+        cfg = _config(primary=_model(provider="anthropic"))
+        egress.enable_llm_egress(cfg)
+        np = os.environ["NO_PROXY"]
+        assert "internal.corp" in np
+        assert "*.test" in np
+        assert "localhost" in np
+        # Order: operator entries first
+        parts = np.split(",")
+        assert parts.index("internal.corp") < parts.index("localhost")
+
+    def test_no_double_localhost_when_already_present(self, stub_proxy, monkeypatch):
+        monkeypatch.setenv("NO_PROXY", "localhost,internal.corp")
+        cfg = _config(primary=_model(provider="anthropic"))
+        egress.enable_llm_egress(cfg)
+        np = os.environ["NO_PROXY"]
+        # Each entry exactly once
+        assert np.count("localhost") == 1
+
+    def test_empty_allowlist_no_op(self, stub_proxy, monkeypatch):
+        """No models configured (autodetect-empty) → no env mutation,
+        no proxy bring-up. Operator who runs in CC-only or no-LLM
+        modes shouldn't see HTTPS_PROXY appear in their environment."""
+        cfg = _config()  # nothing configured
+        egress.enable_llm_egress(cfg)
+        assert "HTTPS_PROXY" not in os.environ
+        assert stub_proxy == []  # get_proxy not invoked
+
+    def test_ollama_only_no_op(self, stub_proxy):
+        """Ollama-only setups have a single localhost host — no remote
+        endpoints, so the chokepoint is meaningless. Skip the env
+        mutation entirely so the SDK talks direct to localhost."""
+        cfg = _config(primary=_model(
+            provider="ollama",
+            model_name="llama3",
+            api_base="http://localhost:11434/v1",
+        ))
+        egress.enable_llm_egress(cfg)
+        assert "HTTPS_PROXY" not in os.environ
+        assert stub_proxy == []
+
+    def test_idempotent_env_not_re_overwritten(self, stub_proxy):
+        """Two LLMClient constructions in the same process must not
+        re-overwrite HTTPS_PROXY (which by now points at our proxy).
+        Subsequent calls only union the allowlist."""
+        cfg = _config(primary=_model(provider="anthropic"))
+        egress.enable_llm_egress(cfg)
+        first_value = os.environ["HTTPS_PROXY"]
+
+        # Mutate the env to detect a second overwrite if it happens.
+        os.environ["HTTPS_PROXY"] = "http://sentinel:99"
+        egress.enable_llm_egress(cfg)
+        assert os.environ["HTTPS_PROXY"] == "http://sentinel:99", (
+            "second call should not overwrite HTTPS_PROXY"
+        )
+
+    def test_idempotent_unions_allowlist(self, stub_proxy):
+        """Second call with a wider config adds new hosts to the
+        existing in-process proxy via ``get_proxy``'s union semantics."""
+        cfg1 = _config(primary=_model(provider="anthropic"))
+        cfg2 = _config(primary=_model(provider="openai"))
+        egress.enable_llm_egress(cfg1)
+        egress.enable_llm_egress(cfg2)
+        assert len(stub_proxy) == 2
+        assert "api.anthropic.com" in stub_proxy[0]
+        assert "api.openai.com" in stub_proxy[1]
+
+    def test_proxy_brought_up_before_env_overwrite(self, monkeypatch):
+        """Critical ordering: ``get_proxy`` must be called BEFORE we
+        overwrite HTTPS_PROXY, so the proxy reads the operator's
+        upstream chain (corporate proxy autodetect) rather than its
+        own self-pointer.
+
+        Asserted by recording the value HTTPS_PROXY had at the moment
+        ``get_proxy`` was invoked."""
+        monkeypatch.setenv("HTTPS_PROXY", "http://corp:8080")
+
+        captured = {}
+
+        class _StubProxy:
+            port = 51234
+
+        def stub_get_proxy(allowed_hosts):
+            captured["env_at_call"] = os.environ.get("HTTPS_PROXY")
+            return _StubProxy()
+
+        import core.sandbox.proxy as proxy_mod
+        monkeypatch.setattr(proxy_mod, "get_proxy", stub_get_proxy)
+
+        cfg = _config(primary=_model(provider="anthropic"))
+        egress.enable_llm_egress(cfg)
+
+        assert captured["env_at_call"] == "http://corp:8080", (
+            "get_proxy must see the operator's HTTPS_PROXY for "
+            "upstream chain autodetect; saw "
+            f"{captured.get('env_at_call')!r} instead"
+        )
+        # And after the call, env is overwritten.
+        assert os.environ["HTTPS_PROXY"] == "http://127.0.0.1:51234"
+
+    def test_loopback_excluded_from_proxy_allowlist(self, stub_proxy):
+        """A multi-provider config that includes both remote hosts
+        AND localhost (e.g. Ollama fallback) must NOT register
+        localhost on the chokepoint allowlist — that would let an
+        attacker register a localhost service and reach it via the
+        chokepoint, defeating the isolation."""
+        cfg = _config(
+            primary=_model(provider="anthropic"),
+            fallbacks=[_model(
+                provider="ollama",
+                model_name="llama",
+                api_base="http://localhost:11434/v1",
+            )],
+        )
+        egress.enable_llm_egress(cfg)
+        assert stub_proxy, "get_proxy should have been called"
+        registered = set(stub_proxy[0])
+        assert "api.anthropic.com" in registered
+        assert "localhost" not in registered
+        assert "127.0.0.1" not in registered
+
+
+# ---------------------------------------------------------------------------
+# Subprocess-strip layer separation
+# ---------------------------------------------------------------------------
+
+
+class TestSubprocessStripStillWorks:
+    """The subprocess-env strip in get_safe_env() must continue to
+    remove HTTPS_PROXY even when we set it in the parent process —
+    they're at different layers and must not interfere."""
+
+    def test_get_safe_env_strips_https_proxy(self, stub_proxy):
+        from core.config import RaptorConfig
+
+        cfg = _config(primary=_model(provider="anthropic"))
+        egress.enable_llm_egress(cfg)
+        assert "HTTPS_PROXY" in os.environ  # Sanity: parent has it
+
+        env = RaptorConfig.get_safe_env()
+        assert "HTTPS_PROXY" not in env
+        assert "https_proxy" not in env

--- a/core/sage/client.py
+++ b/core/sage/client.py
@@ -63,6 +63,56 @@ class SageClient:
     def __init__(self, config: Optional[SageConfig] = None):
         self._config = config or SageConfig.from_env()
         self._client = None
+        self._register_with_egress_proxy()
+
+    def _register_with_egress_proxy(self) -> None:
+        """Register the configured SAGE host with the in-process egress
+        proxy's allowlist when LLM egress is active.
+
+        ``core.llm.egress.enable_llm_egress`` (called from
+        ``LLMClient.__init__``) brings up the in-process proxy and
+        registers LLM provider hostnames on its allowlist. SAGE's
+        host is NOT in that allowlist — without this registration the
+        SAGE health check + SDK calls go through the same proxy and
+        get refused with a 403.
+
+        We only act when:
+          * LLM egress is active (the egress module's own
+            ``_enabled`` flag is set, NOT a heuristic on
+            ``HTTPS_PROXY`` URL pattern — the latter would
+            false-positive on an operator running their own local
+            proxy on 127.0.0.1); and
+          * SAGE's URL is non-loopback (loopback is bypassed via
+            ``NO_PROXY``, no registration needed).
+
+        Failure to register is logged at debug level and falls
+        through to SAGE's graceful-degradation contract — never
+        raises."""
+        from urllib.parse import urlparse
+
+        try:
+            from core.llm.egress import _enabled as _llm_egress_enabled
+        except ImportError:
+            # Defensive — egress module always present in tree, but
+            # circular-import safety in pathological setups.
+            return
+        if not _llm_egress_enabled:
+            # LLM egress not active for this process — SAGE's httpx
+            # calls go direct, no chokepoint to coordinate with.
+            return
+        try:
+            host = urlparse(self._config.url).hostname or ""
+        except (TypeError, ValueError):
+            return
+        if not host or host in ("localhost", "127.0.0.1"):
+            return
+        try:
+            from core.sandbox.proxy import get_proxy
+            get_proxy([host])
+        except Exception as e:                          # noqa: BLE001
+            logger.debug(
+                f"Could not register SAGE host {host!r} with egress proxy: {e}"
+            )
 
     def is_available(self) -> bool:
         """

--- a/core/sage/tests/test_sage_client.py
+++ b/core/sage/tests/test_sage_client.py
@@ -198,5 +198,107 @@ class TestSageClientWithMock(unittest.TestCase):
             _restore_sdk(client_mod, snapshot)
 
 
+class TestSageClientEgressProxyRegistration(unittest.TestCase):
+    """SAGE registers its host with the in-process egress proxy when
+    LLM egress is active so its httpx calls aren't refused by the
+    chokepoint.
+
+    See ``core/sage/client.py:_register_with_egress_proxy`` and
+    ``core/llm/egress.py`` for the rationale."""
+
+    def setUp(self):
+        # Each test starts with the egress module's _enabled flag
+        # in a known state; restore on tearDown.
+        from core.llm import egress
+        self._egress_module = egress
+        self._egress_was_enabled = egress._enabled
+        egress._enabled = False
+
+    def tearDown(self):
+        self._egress_module._enabled = self._egress_was_enabled
+
+    def _set_egress_enabled(self, value: bool) -> None:
+        self._egress_module._enabled = value
+
+    def test_no_op_when_egress_not_active(self):
+        """LLM egress not enabled → don't touch the proxy singleton.
+        Avoids spinning up a chokepoint that nothing will route through
+        and prevents false-positive on operators running their own
+        local proxy on 127.0.0.1."""
+        from core.sage.config import SageConfig
+        from core.sage.client import SageClient
+
+        self._set_egress_enabled(False)
+        with patch("core.sandbox.proxy.get_proxy") as mock_get:
+            SageClient(SageConfig(enabled=True, url="http://sage.example.com:9090"))
+            mock_get.assert_not_called()
+
+    def test_no_op_for_localhost_url(self):
+        """Localhost SAGE bypasses the proxy via NO_PROXY — no
+        registration needed."""
+        from core.sage.config import SageConfig
+        from core.sage.client import SageClient
+
+        self._set_egress_enabled(True)
+        with patch("core.sandbox.proxy.get_proxy") as mock_get:
+            SageClient(SageConfig(enabled=True, url="http://localhost:8090"))
+            mock_get.assert_not_called()
+
+    def test_no_op_for_127_0_0_1_url(self):
+        from core.sage.config import SageConfig
+        from core.sage.client import SageClient
+
+        self._set_egress_enabled(True)
+        with patch("core.sandbox.proxy.get_proxy") as mock_get:
+            SageClient(SageConfig(enabled=True, url="http://127.0.0.1:8090"))
+            mock_get.assert_not_called()
+
+    def test_registers_remote_host_when_egress_active(self):
+        """Remote SAGE_URL + LLM egress active → register sage's
+        host on the proxy allowlist via UNION semantics."""
+        from core.sage.config import SageConfig
+        from core.sage.client import SageClient
+
+        self._set_egress_enabled(True)
+        with patch("core.sandbox.proxy.get_proxy") as mock_get:
+            SageClient(SageConfig(enabled=True, url="http://sage.example.com:9090"))
+            mock_get.assert_called_once()
+            # Hostname only, no scheme/port/path
+            args, _ = mock_get.call_args
+            assert args[0] == ["sage.example.com"]
+
+    def test_proxy_failure_swallowed(self):
+        """A failure in get_proxy must not propagate — SAGE has its
+        own graceful-degradation contract that should remain
+        unchanged by this wiring."""
+        from core.sage.config import SageConfig
+        from core.sage.client import SageClient
+
+        self._set_egress_enabled(True)
+        with patch("core.sandbox.proxy.get_proxy",
+                   side_effect=RuntimeError("port bind failed")):
+            # Must not raise.
+            SageClient(SageConfig(enabled=True, url="http://sage.example.com:9090"))
+
+    def test_no_op_when_operator_runs_their_own_local_proxy(self):
+        """Adversarial: operator runs e.g. mitmproxy at
+        ``127.0.0.1:8888`` and sets HTTPS_PROXY pointing at it. The
+        URL pattern alone matches our in-process proxy's pattern, so
+        a heuristic-on-HTTPS_PROXY check would false-positive and
+        register sage on a chokepoint that isn't ours. Using the
+        egress module's ``_enabled`` flag avoids that — the flag is
+        only set when ``enable_llm_egress`` actually ran."""
+        from core.sage.config import SageConfig
+        from core.sage.client import SageClient
+
+        # Operator's own proxy pattern in env, but our flag NOT set
+        # (LLM egress wasn't actually enabled this process).
+        self._set_egress_enabled(False)
+        with patch.dict("os.environ", {"HTTPS_PROXY": "http://127.0.0.1:8888"}):
+            with patch("core.sandbox.proxy.get_proxy") as mock_get:
+                SageClient(SageConfig(enabled=True, url="http://sage.example.com:9090"))
+                mock_get.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
…egress proxy

cc_dispatch.py already routes the CC subprocess through the in-process proxy with a hostname allowlist. In-process LLM SDK calls (anthropic, openai, google-genai) used by /agentic external-LLM dispatch and /codeql autonomous_analyzer haven't had the same chokepoint. This adds it.

New core/llm/egress.py:
  * derive_allowlist(config) — hostnames from LLMConfig (per-model api_base, else PROVIDER_ENDPOINTS, else KNOWN_DEFAULTS for native- SDK Anthropic). Operator-set api_base (LiteLLM, corporate gateway, vLLM) lands automatically.
  * enable_llm_egress(config) — get_proxy() first (so it reads the operator's HTTPS_PROXY for upstream-chain autodetect), then overwrites HTTPS_PROXY to point at our 127.0.0.1:<port>. Augments NO_PROXY with loopback bypass (UNION with operator entries). Idempotent. No-op on empty allowlist.

Wired at LLMClient.__init__; failure soft-falls-back to direct egress.

CONNECT-tunnel only — no TLS interception, no CA injection.

SAGE remote-URL support: SageClient._register_with_egress_proxy() adds sage's host to the proxy allowlist when LLM egress is active. Detection uses core.llm.egress._enabled flag (not an HTTPS_PROXY URL heuristic, which would false-positive on operator-run local proxies).

Audited other in-process http callers (_test_key, Ollama detection, cve_diff's ResilientLLMClient, git subprocess) — all safe.

37 new tests; 2368 broader preflight passes. E2E: real Gemini call routes via proxy; github.com (not in allowlist) refused with 403; remote SAGE_URL registered cleanly; subprocess HTTPS_PROXY strip still works.