### PR TITLE
ci: scope tests by changed paths and skip duplicate runs

### DIFF
--- a/.github/tests/test_filter_coverage.py
+++ b/.github/tests/test_filter_coverage.py
@@ -1,0 +1,174 @@
+"""Verify path-filter globs in tests.yml cover real import dependencies.
+
+Why this test exists
+--------------------
+``.github/workflows/tests.yml`` declares per-subsystem path filters
+(e.g. ``sandbox:``, ``exploit_feasibility:``) that scope which test
+jobs fire on a given PR. If a subsystem's source code gains an import
+to a module whose path is not covered by its filter glob, an
+indirect-breakage refactor in that path won't trigger the subsystem's
+tests on a normal PR — only on the weekly cron, up to 7 days late.
+
+This test parses the filter block, collects every ``core.*`` /
+``packages.*`` import made by the subsystem's source, resolves each
+import to a file path, and fails if any path is not covered by a
+glob in the corresponding filter.
+"""
+
+from __future__ import annotations
+
+import ast
+import fnmatch
+import re
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+TESTS_YML = REPO / ".github/workflows/tests.yml"
+
+# (filter_name_in_tests_yml, package_dir_relative_to_repo)
+SUBSYSTEMS: list[tuple[str, str]] = [
+    ("sandbox", "core/sandbox"),
+    ("exploit_feasibility", "packages/exploit_feasibility"),
+]
+
+
+def _parse_filter_globs(name: str) -> list[str]:
+    """Extract globs for the named filter from the dorny/paths-filter
+    block in tests.yml without depending on PyYAML.
+
+    The block looks like::
+
+        <name>:
+          - 'glob1'
+          - 'glob2'
+
+    nested under ``filters: |`` inside the ``changes`` job.
+    """
+    globs: list[str] = []
+    in_filter = False
+    filter_indent: int | None = None
+    item_re = re.compile(r"-\s*['\"]([^'\"]+)['\"]\s*$")
+    for line in TESTS_YML.read_text(encoding="utf-8").splitlines():
+        stripped = line.lstrip()
+        if not in_filter:
+            if stripped == f"{name}:":
+                in_filter = True
+                filter_indent = len(line) - len(stripped)
+            continue
+        if not stripped:
+            continue
+        cur_indent = len(line) - len(stripped)
+        assert filter_indent is not None
+        if cur_indent <= filter_indent:
+            break
+        m = item_re.match(stripped)
+        if m:
+            globs.append(m.group(1))
+    return globs
+
+
+def _collect_external_imports(pkg_dir: Path) -> set[str]:
+    """Imported ``core.*`` / ``packages.*`` modules outside pkg_dir."""
+    pkg_module = ".".join(pkg_dir.relative_to(REPO).parts)
+    imports: set[str] = set()
+    for py in pkg_dir.rglob("*.py"):
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            mods: list[str] = []
+            if isinstance(node, ast.ImportFrom) and node.module:
+                mods.append(node.module)
+            elif isinstance(node, ast.Import):
+                mods.extend(alias.name for alias in node.names)
+            for m in mods:
+                if not m.startswith(("core.", "packages.")):
+                    continue
+                if m == pkg_module or m.startswith(pkg_module + "."):
+                    continue
+                imports.add(m)
+    return imports
+
+
+def _module_to_path(module: str) -> Path | None:
+    """Resolve a dotted module to a repo-relative path, or None."""
+    rel = module.replace(".", "/")
+    f = REPO / (rel + ".py")
+    if f.is_file():
+        return f.relative_to(REPO)
+    init = REPO / rel / "__init__.py"
+    if init.is_file():
+        return (REPO / rel).relative_to(REPO)
+    return None
+
+
+def _glob_covers(rel_path: Path, globs: list[str]) -> bool:
+    """Approximate dorny/paths-filter (minimatch) coverage."""
+    s = str(rel_path)
+    for g in globs:
+        if g.endswith("/**"):
+            prefix = g[: -len("/**")]
+            if s == prefix or s.startswith(prefix + "/"):
+                return True
+        elif "*" in g:
+            if fnmatch.fnmatch(s, g):
+                return True
+        elif s == g:
+            return True
+    return False
+
+
+class CIFilterCoverageTests(unittest.TestCase):
+    """Every external import a subsystem makes must be covered by its
+    path-filter glob in tests.yml."""
+
+    def test_tests_yml_exists(self):
+        self.assertTrue(
+            TESTS_YML.is_file(),
+            msg=f"workflow file missing: {TESTS_YML}",
+        )
+
+    def test_each_subsystem_filter_covers_its_imports(self):
+        problems: list[str] = []
+        for filter_name, pkg_rel in SUBSYSTEMS:
+            pkg_dir = REPO / pkg_rel
+            self.assertTrue(
+                pkg_dir.is_dir(),
+                msg=f"subsystem dir missing: {pkg_dir}",
+            )
+            globs = _parse_filter_globs(filter_name)
+            self.assertTrue(
+                globs,
+                msg=f"filter `{filter_name}:` not found in {TESTS_YML}",
+            )
+
+            uncovered: list[tuple[str, Path]] = []
+            for imp in sorted(_collect_external_imports(pkg_dir)):
+                path = _module_to_path(imp)
+                if path is None:
+                    continue
+                if not _glob_covers(path, globs):
+                    uncovered.append((imp, path))
+
+            if uncovered:
+                problems.append(
+                    f"`{filter_name}:` filter does not cover imports made by"
+                    f" {pkg_rel}/:"
+                )
+                for imp, path in uncovered:
+                    problems.append(f"  {imp}  ->  {path}")
+
+        if problems:
+            problems.append("")
+            problems.append(
+                "Fix: add globs covering each path to the relevant filter"
+                " in .github/workflows/tests.yml, or narrow the import."
+            )
+            self.fail("\n".join(problems))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,11 +16,33 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
   schedule:
     - cron: '34 2 * * 5'
+  workflow_dispatch:
 
 jobs:
+  # Skip the analyze job if a previous successful run already covered
+  # this exact tree, or if the change touches only docs / .claude / etc.
+  # We use job-level `if:` (rather than top-level `paths-ignore:`) so that
+  # skipped runs still report as "Skipped = success" to branch protection,
+  # rather than never starting and blocking required-check enforcement.
+  pre_check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: same_content_newer
+          skip_after_successful_duplicate: 'true'
+          paths_ignore: '["**/*.md", "**/.gitignore", ".claude/**"]'
+
   analyze:
+    needs: pre_check
+    if: needs.pre_check.outputs.should_skip != 'true'
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     # - https://gh.io/recommended-hardware-resources-for-running-codeql

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,13 @@ on:
     branches: [ main ]
   push:
     branches: [ main ]
+  merge_group:
+  schedule:
+    # Daily full-suite run catches indirect breakage a path filter
+    # would miss (e.g. scanner.py refactor breaks sandbox API contract
+    # without touching core/sandbox/). Daily rather than weekly given
+    # the codebase's churn rate.
+    - cron: '0 6 * * *'
   workflow_dispatch:
 
 concurrency:
@@ -19,7 +26,111 @@ permissions:
     contents: read
 
 jobs:
+  # Skip the whole workflow if a previous successful run already covered
+  # this exact tree (e.g. PR run passed, then merged to main with no
+  # intervening changes — the post-merge push run is redundant).
+  pre_check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: same_content_newer
+          skip_after_successful_duplicate: 'true'
+          paths_ignore: '["**/*.md", "**/.gitignore", ".claude/**"]'
+
+  # Detect which subsystems the change touches so we can scope tests.
+  # On schedule/workflow_dispatch/merge_group, downstream jobs bypass
+  # this filter and run unconditionally (see `force_full` outputs).
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    needs: pre_check
+    if: needs.pre_check.outputs.should_skip != 'true'
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+      bash_surface: ${{ steps.filter.outputs.bash_surface }}
+      sandbox: ${{ steps.filter.outputs.sandbox }}
+      exploit_feasibility: ${{ steps.filter.outputs.exploit_feasibility }}
+      force_full: ${{ steps.force.outputs.force_full }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: force
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" \
+             || "${{ github.event_name }}" == "workflow_dispatch" \
+             || "${{ github.event_name }}" == "merge_group" ]]; then
+            echo "force_full=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "force_full=false" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            python:
+              - 'core/**'
+              - 'packages/**'
+              - 'libexec/tests/**'
+              - '.github/tests/**'
+              - '*.py'
+              - 'requirements*.txt'
+              - 'pyproject.toml'
+              - '.github/workflows/tests.yml'
+            bash_surface:
+              - 'raptor.py'
+              - 'libexec/**'
+              - 'core/**'
+              - 'packages/**'
+              - 'plugins/**'
+              - 'test/**'
+              - '**.sh'
+              - 'requirements*.txt'
+              - 'pyproject.toml'
+              - '.github/workflows/tests.yml'
+              - '.github/workflows/bash-test.yml'
+            # Direct + transitive deps for sandbox (validated by
+            # .github/tests/test_filter_coverage.py).
+            sandbox:
+              - 'core/sandbox/**'
+              - 'core/security/**'
+              - 'core/config.py'
+              - 'core/run/**'
+              - 'libexec/raptor-run-sandboxed'
+              - 'libexec/raptor-pid1-shim'
+              - 'requirements*.txt'
+              - '.github/workflows/tests.yml'
+            # Direct + transitive deps for exploit_feasibility. Note that
+            # several core/ modules are flat files (logging.py, config.py)
+            # so we list them by name rather than as glob prefixes — the
+            # path-filter test enforces this.
+            exploit_feasibility:
+              - 'packages/exploit_feasibility/**'
+              - 'packages/binary_analysis/**'
+              - 'packages/codeql/smt_path_validator.py'
+              - 'core/hash/**'
+              - 'core/json/**'
+              - 'core/logging.py'
+              - 'core/logging/**'
+              - 'core/config.py'
+              - 'core/orchestration/**'
+              - 'core/sandbox/**'
+              - 'core/smt_solver/**'
+              - 'requirements*.txt'
+              - '.github/workflows/tests.yml'
+
   deps:
+    needs: [pre_check, changes]
+    if: |
+      needs.pre_check.outputs.should_skip != 'true' &&
+      (needs.changes.outputs.force_full == 'true' ||
+       needs.changes.outputs.python == 'true' ||
+       needs.changes.outputs.bash_surface == 'true' ||
+       needs.changes.outputs.sandbox == 'true' ||
+       needs.changes.outputs.exploit_feasibility == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -49,10 +160,16 @@ jobs:
           include-hidden-files: true
           retention-days: 1
 
-  python-unit-tests:
+  # Fast tier: everything under core/ and packages/ except the two
+  # heavyweight subdirs that get their own jobs (sandbox, exploit_feasibility).
+  python-unit-tests-fast:
+    needs: [pre_check, changes, deps]
+    if: |
+      needs.pre_check.outputs.should_skip != 'true' &&
+      (needs.changes.outputs.force_full == 'true' ||
+       needs.changes.outputs.python == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs: deps
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -76,10 +193,12 @@ jobs:
           source $VENV_PATH/bin/activate
           python -m compileall -q core packages libexec/tests *.py
 
-      - name: Run unit tests
+      - name: Run unit tests (fast tier)
         run: |
           source $VENV_PATH/bin/activate
-          pytest core packages
+          pytest core packages \
+            --ignore=core/sandbox/tests \
+            --ignore=packages/exploit_feasibility/tests
 
       - name: Run libexec wrapper tests
         run: |
@@ -88,36 +207,130 @@ jobs:
           # import-name collisions with other top-level tests packages.
           pytest libexec/tests
 
+      - name: Run CI lint tests
+        run: |
+          source $VENV_PATH/bin/activate
+          # Validates path-filter globs in this workflow cover the actual
+          # import dependencies of subsystem-scoped test jobs. Same
+          # collision-avoidance reasoning as libexec/tests above.
+          pytest .github/tests
+
+  # Sandbox tier: ~251 heavyweight tests doing real namespace/mount/seccomp
+  # work. Gated on sandbox-related path changes only.
+  python-unit-tests-sandbox:
+    needs: [pre_check, changes, deps]
+    if: |
+      needs.pre_check.outputs.should_skip != 'true' &&
+      (needs.changes.outputs.force_full == 'true' ||
+       needs.changes.outputs.sandbox == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Download venv artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: venv-${{ github.run_id }}
+          path: ${{ env.VENV_PATH }}
+
+      - name: Restore venv permissions
+        run: chmod +x $VENV_PATH/bin/*
+
+      - name: Run sandbox tests
+        run: |
+          source $VENV_PATH/bin/activate
+          pytest core/sandbox/tests
+
+  # Exploit-feasibility integration tier: 11 × ~15 s tests calling
+  # analyze_binary against real binaries. Gated on the relevant packages.
+  python-unit-tests-exploit-feasibility:
+    needs: [pre_check, changes, deps]
+    if: |
+      needs.pre_check.outputs.should_skip != 'true' &&
+      (needs.changes.outputs.force_full == 'true' ||
+       needs.changes.outputs.exploit_feasibility == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Download venv artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: venv-${{ github.run_id }}
+          path: ${{ env.VENV_PATH }}
+
+      - name: Restore venv permissions
+        run: chmod +x $VENV_PATH/bin/*
+
+      - name: Run exploit_feasibility integration tests
+        run: |
+          source $VENV_PATH/bin/activate
+          pytest packages/exploit_feasibility/tests
+
   test-workflows:
-    needs: deps
+    needs: [pre_check, changes, deps]
+    if: |
+      needs.pre_check.outputs.should_skip != 'true' &&
+      (needs.changes.outputs.force_full == 'true' ||
+       needs.changes.outputs.bash_surface == 'true')
     uses: ./.github/workflows/bash-test.yml
     with:
       test_script: test_workflows.sh
       venv_artifact_name: venv-${{ github.run_id }}
 
   test-fast:
-    needs: deps
+    needs: [pre_check, changes, deps]
+    if: |
+      needs.pre_check.outputs.should_skip != 'true' &&
+      (needs.changes.outputs.force_full == 'true' ||
+       needs.changes.outputs.bash_surface == 'true')
     uses: ./.github/workflows/bash-test.yml
     with:
       test_script: real_tests_fast.sh
       venv_artifact_name: venv-${{ github.run_id }}
 
   test-real:
-    needs: deps
+    needs: [pre_check, changes, deps]
+    if: |
+      needs.pre_check.outputs.should_skip != 'true' &&
+      (needs.changes.outputs.force_full == 'true' ||
+       needs.changes.outputs.bash_surface == 'true')
     uses: ./.github/workflows/bash-test.yml
     with:
       test_script: real_tests.sh
       venv_artifact_name: venv-${{ github.run_id }}
 
   test-comprehensive:
-    needs: deps
+    needs: [pre_check, changes, deps]
+    if: |
+      needs.pre_check.outputs.should_skip != 'true' &&
+      (needs.changes.outputs.force_full == 'true' ||
+       needs.changes.outputs.bash_surface == 'true')
     uses: ./.github/workflows/bash-test.yml
     with:
       test_script: comprehensive_test.sh
       venv_artifact_name: venv-${{ github.run_id }}
 
   test-integration:
-    needs: deps
+    needs: [pre_check, changes, deps]
+    if: |
+      needs.pre_check.outputs.should_skip != 'true' &&
+      (needs.changes.outputs.force_full == 'true' ||
+       needs.changes.outputs.bash_surface == 'true')
     uses: ./.github/workflows/bash-test.yml
     with:
       test_script: integration_tests.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -246,7 +246,11 @@ jobs:
       - name: Run sandbox tests
         run: |
           source $VENV_PATH/bin/activate
-          pytest core/sandbox/tests
+          # `python -m pytest` (rather than bare `pytest`) puts the repo
+          # root on sys.path so `from core.security.redaction import ...`
+          # in sandbox sources resolves. Bare pytest only works when
+          # `core` is included in the args (e.g. `pytest core packages`).
+          python -m pytest core/sandbox/tests
 
   # Exploit-feasibility integration tier: 11 × ~15 s tests calling
   # analyze_binary against real binaries. Gated on the relevant packages.
@@ -279,7 +283,9 @@ jobs:
       - name: Run exploit_feasibility integration tests
         run: |
           source $VENV_PATH/bin/activate
-          pytest packages/exploit_feasibility/tests
+          # See sandbox tests above for why `python -m pytest` is needed
+          # rather than bare `pytest`.
+          python -m pytest packages/exploit_feasibility/tests
 
   test-workflows:
     needs: [pre_check, changes, deps]


### PR DESCRIPTION
Per-PR CI ran the full ~2-minute suite on every change and re-ran on the post-merge push, regardless of what was touched.

tests.yml:
- Add a `pre_check` job using fkirc/skip-duplicate-actions that short-circuits the workflow when an earlier successful run already covered this exact tree (the PR-then-merge double-run case).
- Add a `changes` job (dorny/paths-filter) emitting `python`, `bash_surface`, `sandbox`, and `exploit_feasibility` outputs; every test job is gated on its relevant filter plus a `force_full` output that fires on schedule/dispatch/merge_group.
- Split `python-unit-tests` into three tiers:
    * fast — pytest core packages, excluding the two heavy subdirs
    * sandbox — pytest core/sandbox/tests, gated on sandbox surface (~251 namespace/mount/seccomp tests)
    * exploit_feasibility — pytest packages/exploit_feasibility/tests, gated on the package's real upstream dependency surface (~11 × 15s integration tests)
- Add `merge_group` and a daily 06:00 UTC `schedule` cron — the cron is the safety net for indirect breakage a path filter would miss (e.g. a refactor breaks an API contract without touching the tests that exercise it). Daily rather than weekly given the codebase's churn rate.
- Skip the `deps` venv build when no test job will run.

codeql.yml:
- Apply the same `pre_check` gating so post-merge runs and unchanged- tree re-runs don't redo expensive c-cpp / python / actions analysis.
- Add `merge_group` and `workflow_dispatch` triggers.
- Use job-level `if:` rather than top-level `paths-ignore:` so skipped jobs report as Skipped (success) to branch protection rather than never starting and stalling required-check enforcement.

.github/tests/test_filter_coverage.py:
- New structural test that AST-parses every .py file under each subsystem (sandbox, exploit_feasibility), collects core.* / packages.* imports, resolves them to file paths, and fails if any path isn't covered by a glob in the corresponding filter.
- Without this, the path-filter globs can silently go stale as imports drift, causing indirect-breakage detection to slip back to the daily cron. Caught real gaps when first run (core.config, core.run.metadata, core.logging.py-as-flat-file, core.orchestration).
- Lives in .github/tests/ (no __init__.py) and runs in a dedicated pytest step in python-unit-tests-fast — same collision-avoidance pattern as libexec/tests/.

Skipped jobs report as success under branch protection, so existing required-check rules compose with this change.