### PR TITLE
ci: scope tests by changed paths and skip duplicate runs

### DIFF
--- a/.github/scripts/compute_filters.py
+++ b/.github/scripts/compute_filters.py
@@ -1,0 +1,197 @@
+"""Path-filter computation for the test-suite workflow.
+
+Replaces the third-party ``dorny/paths-filter`` action. Reads the set
+of changed files for the current event from ``$CHANGED_FILES_LIST``
+(one path per line) and writes ``<filter>=true|false`` lines to
+``$GITHUB_OUTPUT``. If ``$CHANGED_FILES_LIST`` is unset or points at a
+missing file, every filter is forced to ``true`` (safe fallback for
+events without a meaningful diff base).
+
+The ``FILTERS`` dict is the single source of truth for what each
+subsystem-scoped CI job depends on. ``.github/tests/test_filter_coverage.py``
+imports it directly to verify that every ``core.*`` / ``packages.*``
+import made by a subsystem's source is covered by the corresponding
+filter's globs.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+import sys
+from pathlib import Path
+
+
+FILTERS: dict[str, list[str]] = {
+    "python": [
+        "core/**",
+        "packages/**",
+        "libexec/tests/**",
+        ".github/tests/**",
+        "*.py",
+        "requirements*.txt",
+        "pyproject.toml",
+        ".github/workflows/tests.yml",
+    ],
+    "bash_surface": [
+        "raptor.py",
+        "libexec/**",
+        "core/**",
+        "packages/**",
+        "plugins/**",
+        "test/**",
+        "*.sh",
+        "**/*.sh",
+        "requirements*.txt",
+        "pyproject.toml",
+        ".github/workflows/tests.yml",
+        ".github/workflows/bash-test.yml",
+    ],
+    # Direct + transitive deps for sandbox (validated by
+    # .github/tests/test_filter_coverage.py).
+    "sandbox": [
+        "core/sandbox/**",
+        "core/security/**",
+        "core/config.py",
+        "core/run/**",
+        "libexec/raptor-run-sandboxed",
+        "libexec/raptor-pid1-shim",
+        "requirements*.txt",
+        ".github/workflows/tests.yml",
+    ],
+    # Direct + transitive deps for exploit_feasibility. Several core/
+    # modules are flat .py files (logging.py, config.py) so they are
+    # listed by name rather than as ``foo/**`` glob prefixes.
+    "exploit_feasibility": [
+        "packages/exploit_feasibility/**",
+        "packages/binary_analysis/**",
+        "packages/codeql/smt_path_validator.py",
+        "core/hash/**",
+        "core/json/**",
+        "core/logging.py",
+        "core/logging/**",
+        "core/config.py",
+        "core/orchestration/**",
+        "core/sandbox/**",
+        "core/smt_solver/**",
+        "requirements*.txt",
+        ".github/workflows/tests.yml",
+    ],
+    # CodeQL per-language scoping. Each matrix entry in codeql.yml
+    # gates on the corresponding filter, so a python-only PR skips the
+    # c-cpp and actions matrix entries (and vice versa).
+    "codeql_python": [
+        "**/*.py",
+        "requirements*.txt",
+        "pyproject.toml",
+        ".github/workflows/codeql.yml",
+        ".github/codeql/**",
+    ],
+    "codeql_cpp": [
+        "**/*.c",
+        "**/*.h",
+        "**/*.cpp",
+        "**/*.hpp",
+        "**/*.cc",
+        "**/*.hh",
+        ".github/workflows/codeql.yml",
+        ".github/codeql/**",
+    ],
+    "codeql_actions": [
+        ".github/workflows/**",
+        ".github/actions/**",
+        "action.yml",
+        "action.yaml",
+        ".github/codeql/**",
+    ],
+}
+
+
+def match_glob(path: str, pattern: str) -> bool:
+    """Approximate minimatch semantics for the patterns in ``FILTERS``.
+
+    Rules:
+      * ``foo/bar.py``  exact match
+      * ``foo/**``      recursive prefix (matches ``foo`` and ``foo/...``)
+      * ``**/X``        ``X`` at any depth, including top-level
+      * ``*.py``        single-segment match (no ``/`` in pattern → top-level)
+      * ``foo/*.py``    one segment after ``foo/``
+    """
+    if path == pattern:
+        return True
+
+    # Recursive prefix: ``foo/**`` matches ``foo`` and anything under it.
+    if pattern.endswith("/**"):
+        prefix = pattern[: -len("/**")]
+        return path == prefix or path.startswith(prefix + "/")
+
+    # ``**/X`` — match X at any depth.
+    if pattern.startswith("**/"):
+        suffix = pattern[len("**/") :]
+        # Try every path-suffix (including the full path) against the suffix.
+        parts = path.split("/")
+        for i in range(len(parts)):
+            if fnmatch.fnmatchcase("/".join(parts[i:]), suffix):
+                return True
+        return False
+
+    # No ``/`` in pattern → restrict to top-level files.
+    if "/" not in pattern:
+        return "/" not in path and fnmatch.fnmatchcase(path, pattern)
+
+    # Anything else: defer to fnmatch on the full path.
+    return fnmatch.fnmatchcase(path, pattern)
+
+
+def evaluate(changed_files: list[str] | None) -> dict[str, bool]:
+    """Return ``{filter_name: matched}`` for every filter in ``FILTERS``.
+
+    ``None`` signals "no diff base available" — every filter is forced
+    on so a CI mistake errs toward running tests.
+    """
+    if changed_files is None:
+        return {name: True for name in FILTERS}
+    out: dict[str, bool] = {}
+    for name, patterns in FILTERS.items():
+        out[name] = any(
+            match_glob(f, p) for f in changed_files for p in patterns
+        )
+    return out
+
+
+def _read_changed_files() -> list[str] | None:
+    list_path = os.environ.get("CHANGED_FILES_LIST")
+    if not list_path:
+        return None
+    p = Path(list_path)
+    if not p.is_file():
+        return None
+    return [
+        line.strip() for line in p.read_text().splitlines() if line.strip()
+    ]
+
+
+def main() -> int:
+    output = os.environ.get("GITHUB_OUTPUT")
+    if not output:
+        print("ERROR: GITHUB_OUTPUT not set", file=sys.stderr)
+        return 1
+
+    changed = _read_changed_files()
+    results = evaluate(changed)
+
+    with open(output, "a", encoding="utf-8") as fh:
+        for name, hit in results.items():
+            fh.write(f"{name}={'true' if hit else 'false'}\n")
+
+    if changed is None:
+        print("No diff base available — forcing all filters to true.")
+    else:
+        print(f"Changed files: {len(changed)}")
+        for name, hit in results.items():
+            print(f"  {name}: {hit}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/tests/test_filter_coverage.py
+++ b/.github/tests/test_filter_coverage.py
@@ -1,72 +1,39 @@
-"""Verify path-filter globs in tests.yml cover real import dependencies.
+"""Verify path-filter globs cover real import dependencies.
 
 Why this test exists
 --------------------
-``.github/workflows/tests.yml`` declares per-subsystem path filters
-(e.g. ``sandbox:``, ``exploit_feasibility:``) that scope which test
-jobs fire on a given PR. If a subsystem's source code gains an import
-to a module whose path is not covered by its filter glob, an
-indirect-breakage refactor in that path won't trigger the subsystem's
-tests on a normal PR — only on the weekly cron, up to 7 days late.
+``.github/scripts/compute_filters.py`` declares per-subsystem path
+filters in its ``FILTERS`` dict. If a subsystem's source code gains
+an import to a module whose path is not covered by its filter glob,
+an indirect-breakage refactor in that path won't trigger the
+subsystem's tests on a normal PR — only on the daily cron, up to a
+day late.
 
-This test parses the filter block, collects every ``core.*`` /
-``packages.*`` import made by the subsystem's source, resolves each
-import to a file path, and fails if any path is not covered by a
-glob in the corresponding filter.
+This test imports ``FILTERS`` directly, walks each subsystem's source
+tree, collects every ``core.*`` / ``packages.*`` import, resolves
+each to a file path, and fails if any path is not covered by a glob
+in the corresponding filter. The same ``match_glob`` helper used by
+the workflow does the matching, so the test and the runtime stay
+aligned automatically.
 """
 
 from __future__ import annotations
 
 import ast
-import fnmatch
-import re
+import sys
 import unittest
 from pathlib import Path
 
 
 REPO = Path(__file__).resolve().parents[2]
-TESTS_YML = REPO / ".github/workflows/tests.yml"
+sys.path.insert(0, str(REPO / ".github" / "scripts"))
+import compute_filters  # noqa: E402
 
-# (filter_name_in_tests_yml, package_dir_relative_to_repo)
+# (filter_name_in_FILTERS, package_dir_relative_to_repo)
 SUBSYSTEMS: list[tuple[str, str]] = [
     ("sandbox", "core/sandbox"),
     ("exploit_feasibility", "packages/exploit_feasibility"),
 ]
-
-
-def _parse_filter_globs(name: str) -> list[str]:
-    """Extract globs for the named filter from the dorny/paths-filter
-    block in tests.yml without depending on PyYAML.
-
-    The block looks like::
-
-        <name>:
-          - 'glob1'
-          - 'glob2'
-
-    nested under ``filters: |`` inside the ``changes`` job.
-    """
-    globs: list[str] = []
-    in_filter = False
-    filter_indent: int | None = None
-    item_re = re.compile(r"-\s*['\"]([^'\"]+)['\"]\s*$")
-    for line in TESTS_YML.read_text(encoding="utf-8").splitlines():
-        stripped = line.lstrip()
-        if not in_filter:
-            if stripped == f"{name}:":
-                in_filter = True
-                filter_indent = len(line) - len(stripped)
-            continue
-        if not stripped:
-            continue
-        cur_indent = len(line) - len(stripped)
-        assert filter_indent is not None
-        if cur_indent <= filter_indent:
-            break
-        m = item_re.match(stripped)
-        if m:
-            globs.append(m.group(1))
-    return globs
 
 
 def _collect_external_imports(pkg_dir: Path) -> set[str]:
@@ -105,30 +72,14 @@ def _module_to_path(module: str) -> Path | None:
     return None
 
 
-def _glob_covers(rel_path: Path, globs: list[str]) -> bool:
-    """Approximate dorny/paths-filter (minimatch) coverage."""
-    s = str(rel_path)
-    for g in globs:
-        if g.endswith("/**"):
-            prefix = g[: -len("/**")]
-            if s == prefix or s.startswith(prefix + "/"):
-                return True
-        elif "*" in g:
-            if fnmatch.fnmatch(s, g):
-                return True
-        elif s == g:
-            return True
-    return False
-
-
 class CIFilterCoverageTests(unittest.TestCase):
     """Every external import a subsystem makes must be covered by its
-    path-filter glob in tests.yml."""
+    path-filter glob in compute_filters.FILTERS."""
 
-    def test_tests_yml_exists(self):
+    def test_compute_filters_importable(self):
         self.assertTrue(
-            TESTS_YML.is_file(),
-            msg=f"workflow file missing: {TESTS_YML}",
+            hasattr(compute_filters, "FILTERS"),
+            msg="compute_filters.py is missing the FILTERS dict",
         )
 
     def test_each_subsystem_filter_covers_its_imports(self):
@@ -139,10 +90,10 @@ class CIFilterCoverageTests(unittest.TestCase):
                 pkg_dir.is_dir(),
                 msg=f"subsystem dir missing: {pkg_dir}",
             )
-            globs = _parse_filter_globs(filter_name)
+            globs = compute_filters.FILTERS.get(filter_name)
             self.assertTrue(
                 globs,
-                msg=f"filter `{filter_name}:` not found in {TESTS_YML}",
+                msg=f"filter `{filter_name}` not in compute_filters.FILTERS",
             )
 
             uncovered: list[tuple[str, Path]] = []
@@ -150,12 +101,14 @@ class CIFilterCoverageTests(unittest.TestCase):
                 path = _module_to_path(imp)
                 if path is None:
                     continue
-                if not _glob_covers(path, globs):
+                if not any(
+                    compute_filters.match_glob(str(path), g) for g in globs
+                ):
                     uncovered.append((imp, path))
 
             if uncovered:
                 problems.append(
-                    f"`{filter_name}:` filter does not cover imports made by"
+                    f"`{filter_name}` filter does not cover imports made by"
                     f" {pkg_rel}/:"
                 )
                 for imp, path in uncovered:
@@ -165,7 +118,7 @@ class CIFilterCoverageTests(unittest.TestCase):
             problems.append("")
             problems.append(
                 "Fix: add globs covering each path to the relevant filter"
-                " in .github/workflows/tests.yml, or narrow the import."
+                " in .github/scripts/compute_filters.py, or narrow the import."
             )
             self.fail("\n".join(problems))
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,26 +23,119 @@ on:
 
 jobs:
   # Skip the analyze job if a previous successful run already covered
-  # this exact tree, or if the change touches only docs / .claude / etc.
-  # We use job-level `if:` (rather than top-level `paths-ignore:`) so that
-  # skipped runs still report as "Skipped = success" to branch protection,
-  # rather than never starting and blocking required-check enforcement.
+  # this exact commit SHA. Same homebrew dedup pattern as tests.yml.
+  # Uses job-level ``if:`` rather than top-level ``paths-ignore:`` so
+  # skipped jobs report as Skipped (= success) to branch protection
+  # rather than never starting and stalling required-check enforcement.
   pre_check:
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    permissions:
+      actions: read
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_skip: ${{ steps.dup.outputs.should_skip }}
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          concurrent_skipping: same_content_newer
-          skip_after_successful_duplicate: 'true'
-          paths_ignore: '["**/*.md", "**/.gitignore", ".claude/**"]'
+      - id: dup
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          WORKFLOW: ${{ github.workflow }}
+          SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          should_skip=false
+          if [[ "$EVENT" != "schedule" && "$EVENT" != "workflow_dispatch" \
+             && "$EVENT" != "merge_group" ]]; then
+            dup=$(gh api -X GET "repos/${REPO}/actions/runs" \
+                    -f "head_sha=${SHA}" -f "status=success" \
+                    --jq ".workflow_runs[] | select(.name==\"${WORKFLOW}\" and .id != ${RUN_ID}) | .id" \
+                  | head -n1 || true)
+            if [[ -n "${dup:-}" ]]; then
+              should_skip=true
+              echo "Skipping: prior successful run ${dup} already covered SHA ${SHA}"
+            fi
+          fi
+          echo "should_skip=${should_skip}" >> "$GITHUB_OUTPUT"
 
-  analyze:
+  # Per-language path scoping — the analyze matrix gates each entry on
+  # its corresponding filter so a python-only PR skips the c-cpp and
+  # actions matrix entries, etc. Reuses tests.yml's compute_filters.py
+  # for filter logic so both workflows stay in sync.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
     needs: pre_check
     if: needs.pre_check.outputs.should_skip != 'true'
+    permissions:
+      contents: read
+    outputs:
+      codeql_python: ${{ steps.filter.outputs.codeql_python }}
+      codeql_cpp: ${{ steps.filter.outputs.codeql_cpp }}
+      codeql_actions: ${{ steps.filter.outputs.codeql_actions }}
+      force_full: ${{ steps.force.outputs.force_full }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: force
+        env:
+          EVENT: ${{ github.event_name }}
+        run: |
+          if [[ "$EVENT" == "schedule" || "$EVENT" == "workflow_dispatch" \
+             || "$EVENT" == "merge_group" ]]; then
+            echo "force_full=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "force_full=false" >> "$GITHUB_OUTPUT"
+          fi
+      - id: changed_files
+        if: steps.force.outputs.force_full == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+        run: |
+          set -euo pipefail
+          out=/tmp/changed_files.txt
+          : > "$out"
+          case "$EVENT" in
+            pull_request|pull_request_target)
+              gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+                --jq '.[].filename' >> "$out"
+              ;;
+            push)
+              if [[ "$BEFORE" == "0000000000000000000000000000000000000000" ]]; then
+                rm -f "$out"
+              else
+                gh api --paginate "repos/${REPO}/compare/${BEFORE}...${AFTER}" \
+                  --jq '.files[].filename' >> "$out"
+              fi
+              ;;
+            *)
+              rm -f "$out"
+              ;;
+          esac
+          if [[ -f "$out" ]]; then
+            echo "list=$out" >> "$GITHUB_OUTPUT"
+          fi
+      - id: filter
+        env:
+          CHANGED_FILES_LIST: ${{ steps.changed_files.outputs.list }}
+        run: |
+          python3 .github/scripts/compute_filters.py
+
+  analyze:
+    needs: [pre_check, changes]
+    if: |
+      needs.pre_check.outputs.should_skip != 'true' &&
+      (
+        needs.changes.outputs.force_full == 'true' ||
+        (matrix.language == 'actions' && needs.changes.outputs.codeql_actions == 'true') ||
+        (matrix.language == 'c-cpp' && needs.changes.outputs.codeql_cpp == 'true') ||
+        (matrix.language == 'python' && needs.changes.outputs.codeql_python == 'true')
+      )
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     # - https://gh.io/recommended-hardware-resources-for-running-codeql

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,9 @@ on:
   merge_group:
   schedule:
     # Daily full-suite run catches indirect breakage a path filter
-    # would miss (e.g. scanner.py refactor breaks sandbox API contract
-    # without touching core/sandbox/). Daily rather than weekly given
-    # the codebase's churn rate.
+    # would miss (e.g. a refactor breaks an API contract without
+    # touching the tests that exercise it). Daily rather than weekly
+    # given the codebase's churn rate.
     - cron: '0 6 * * *'
   workflow_dispatch:
 
@@ -23,28 +23,55 @@ env:
   VENV_PATH: .venv
 
 permissions:
-    contents: read
+  contents: read
+  # Needed by the pre_check job to query prior workflow runs at the
+  # current SHA via ``gh api repos/.../actions/runs``.
+  actions: read
 
 jobs:
-  # Skip the whole workflow if a previous successful run already covered
-  # this exact tree (e.g. PR run passed, then merged to main with no
-  # intervening changes — the post-merge push run is redundant).
+  # Skip the workflow if a previous successful run of this same workflow
+  # already passed at the exact same commit SHA — catches the
+  # "PR fast-forward-merged → main push reruns the same SHA" case and
+  # explicit re-runs. Doc-only / .claude-only PRs are skipped naturally
+  # by the per-job path-filter gate in `changes`, not here.
   pre_check:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_skip: ${{ steps.dup.outputs.should_skip }}
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          concurrent_skipping: same_content_newer
-          skip_after_successful_duplicate: 'true'
-          paths_ignore: '["**/*.md", "**/.gitignore", ".claude/**"]'
+      - id: dup
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          WORKFLOW: ${{ github.workflow }}
+          SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          should_skip=false
+          # Never dedup forced-full events: the operator triggered them
+          # deliberately (cron, manual dispatch) or the merge queue needs
+          # an authoritative pass.
+          if [[ "$EVENT" != "schedule" && "$EVENT" != "workflow_dispatch" \
+             && "$EVENT" != "merge_group" ]]; then
+            dup=$(gh api -X GET "repos/${REPO}/actions/runs" \
+                    -f "head_sha=${SHA}" -f "status=success" \
+                    --jq ".workflow_runs[] | select(.name==\"${WORKFLOW}\" and .id != ${RUN_ID}) | .id" \
+                  | head -n1 || true)
+            if [[ -n "${dup:-}" ]]; then
+              should_skip=true
+              echo "Skipping: prior successful run ${dup} already covered SHA ${SHA}"
+            fi
+          fi
+          echo "should_skip=${should_skip}" >> "$GITHUB_OUTPUT"
 
-  # Detect which subsystems the change touches so we can scope tests.
-  # On schedule/workflow_dispatch/merge_group, downstream jobs bypass
-  # this filter and run unconditionally (see `force_full` outputs).
+  # Path-filter equivalent of dorny/paths-filter, implemented with the
+  # GitHub API for changed-file enumeration and a small in-tree Python
+  # script (``.github/scripts/compute_filters.py``) for glob matching.
+  # The script's FILTERS dict is the single source of truth, also
+  # imported by ``.github/tests/test_filter_coverage.py``.
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -58,69 +85,66 @@ jobs:
       force_full: ${{ steps.force.outputs.force_full }}
     steps:
       - uses: actions/checkout@v6
+
       - id: force
+        env:
+          EVENT: ${{ github.event_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "schedule" \
-             || "${{ github.event_name }}" == "workflow_dispatch" \
-             || "${{ github.event_name }}" == "merge_group" ]]; then
+          if [[ "$EVENT" == "schedule" || "$EVENT" == "workflow_dispatch" \
+             || "$EVENT" == "merge_group" ]]; then
             echo "force_full=true" >> "$GITHUB_OUTPUT"
           else
             echo "force_full=false" >> "$GITHUB_OUTPUT"
           fi
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            python:
-              - 'core/**'
-              - 'packages/**'
-              - 'libexec/tests/**'
-              - '.github/tests/**'
-              - '*.py'
-              - 'requirements*.txt'
-              - 'pyproject.toml'
-              - '.github/workflows/tests.yml'
-            bash_surface:
-              - 'raptor.py'
-              - 'libexec/**'
-              - 'core/**'
-              - 'packages/**'
-              - 'plugins/**'
-              - 'test/**'
-              - '**.sh'
-              - 'requirements*.txt'
-              - 'pyproject.toml'
-              - '.github/workflows/tests.yml'
-              - '.github/workflows/bash-test.yml'
-            # Direct + transitive deps for sandbox (validated by
-            # .github/tests/test_filter_coverage.py).
-            sandbox:
-              - 'core/sandbox/**'
-              - 'core/security/**'
-              - 'core/config.py'
-              - 'core/run/**'
-              - 'libexec/raptor-run-sandboxed'
-              - 'libexec/raptor-pid1-shim'
-              - 'requirements*.txt'
-              - '.github/workflows/tests.yml'
-            # Direct + transitive deps for exploit_feasibility. Note that
-            # several core/ modules are flat files (logging.py, config.py)
-            # so we list them by name rather than as glob prefixes — the
-            # path-filter test enforces this.
-            exploit_feasibility:
-              - 'packages/exploit_feasibility/**'
-              - 'packages/binary_analysis/**'
-              - 'packages/codeql/smt_path_validator.py'
-              - 'core/hash/**'
-              - 'core/json/**'
-              - 'core/logging.py'
-              - 'core/logging/**'
-              - 'core/config.py'
-              - 'core/orchestration/**'
-              - 'core/sandbox/**'
-              - 'core/smt_solver/**'
-              - 'requirements*.txt'
-              - '.github/workflows/tests.yml'
+
+      - id: changed_files
+        if: steps.force.outputs.force_full == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+        run: |
+          set -euo pipefail
+          out=/tmp/changed_files.txt
+          : > "$out"
+          case "$EVENT" in
+            pull_request|pull_request_target)
+              gh api --paginate \
+                "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+                --jq '.[].filename' >> "$out"
+              ;;
+            push)
+              if [[ "$BEFORE" == "0000000000000000000000000000000000000000" ]]; then
+                # First push to a new branch — no diff base. Fall through
+                # to the no-list path so compute_filters forces all true.
+                rm -f "$out"
+              else
+                gh api --paginate \
+                  "repos/${REPO}/compare/${BEFORE}...${AFTER}" \
+                  --jq '.files[].filename' >> "$out"
+              fi
+              ;;
+            *)
+              # Other event types reach this step only if force_full was
+              # false (shouldn't happen given the if: above). Treat as
+              # "unknown diff" → force all filters on.
+              rm -f "$out"
+              ;;
+          esac
+          if [[ -f "$out" ]]; then
+            echo "list=$out" >> "$GITHUB_OUTPUT"
+            echo "Changed files ($(wc -l < "$out")):"
+            cat "$out"
+          fi
+
+      - id: filter
+        env:
+          CHANGED_FILES_LIST: ${{ steps.changed_files.outputs.list }}
+        run: |
+          python3 .github/scripts/compute_filters.py
 
   deps:
     needs: [pre_check, changes]
@@ -210,9 +234,9 @@ jobs:
       - name: Run CI lint tests
         run: |
           source $VENV_PATH/bin/activate
-          # Validates path-filter globs in this workflow cover the actual
-          # import dependencies of subsystem-scoped test jobs. Same
-          # collision-avoidance reasoning as libexec/tests above.
+          # Validates path-filter globs in compute_filters.py cover the
+          # actual import dependencies of subsystem-scoped test jobs.
+          # Same collision-avoidance reasoning as libexec/tests above.
           pytest .github/tests
 
   # Sandbox tier: ~251 heavyweight tests doing real namespace/mount/seccomp
@@ -253,7 +277,8 @@ jobs:
           python -m pytest core/sandbox/tests
 
   # Exploit-feasibility integration tier: 11 × ~15 s tests calling
-  # analyze_binary against real binaries. Gated on the relevant packages.
+  # analyze_binary against real binaries. Gated on the package's real
+  # upstream dependency surface.
   python-unit-tests-exploit-feasibility:
     needs: [pre_check, changes, deps]
     if: |


### PR DESCRIPTION
Replaces a flat ~2-minute test run on every push with per-subsystem path scoping plus dedup of post-merge re-runs.

tests.yml:
- New pre_check job uses `gh api .../actions/runs` to skip when a prior successful run already covered the current SHA.
- New changes job pulls the changed-files list via gh api and pipes it to compute_filters.py, emitting per-subsystem booleans.
- python-unit-tests split into fast / sandbox / exploit_feasibility tiers, each gated on the relevant filter (heavy subdirs no longer run on unrelated PRs).
- Subdir-scoped invocations use `python -m pytest` so repo root is on sys.path.
- Adds merge_group + daily 06:00 UTC cron as the indirect-breakage safety net.

codeql.yml:
- Same dedup pattern.
- Per-language scoping: python-only PRs skip c-cpp + actions; doc- only PRs skip everything; workflow-only PRs skip python + c-cpp.
- Job-level if: keeps skipped runs reporting as Skipped (success) to branch protection.

.github/scripts/compute_filters.py:
- Single source of truth for path-filter patterns. Replaces fkirc/skip-duplicate-actions (unmaintained, Node-20 deprecation) and dorny/paths-filter — both gone, no third-party action deps.

.github/tests/test_filter_coverage.py:
- Imports FILTERS + match_glob directly and fails if any subsystem's core.* / packages.* imports drift outside its filter globs. Caught real gaps when first run.