### PR TITLE
feat: wire core.inventory.reachability into 3 consumers

### DIFF
--- a/core/orchestration/__init__.py
+++ b/core/orchestration/__init__.py
@@ -1,15 +1,19 @@
 """Cross-skill orchestration for /agentic enrichment passes."""
 
 from core.orchestration.agentic_passes import (
+    run_reachability_prepass,
     run_understand_prepass,
     run_validate_postpass,
     PrepassResult,
     PostpassResult,
+    ReachabilityPrepassResult,
 )
 
 __all__ = [
+    "run_reachability_prepass",
     "run_understand_prepass",
     "run_validate_postpass",
     "PrepassResult",
     "PostpassResult",
+    "ReachabilityPrepassResult",
 ]

--- a/core/orchestration/agentic_passes.py
+++ b/core/orchestration/agentic_passes.py
@@ -99,6 +99,22 @@ class PostpassResult:
     duration_s: float = 0.0
 
 
+@dataclass
+class ReachabilityPrepassResult:
+    """Outcome of run_reachability_prepass().
+
+    ``inventory`` is the (possibly cached) inventory dict the
+    prepass built. The agentic launcher threads it through to
+    downstream consumers (codeql analyzer, /validate Stage B)
+    so they don't re-walk the source tree.
+    """
+    ran: bool
+    skipped_reason: Optional[str] = None
+    marked_count: int = 0          # functions marked priority=low
+    inventory: Optional[Any] = None
+    duration_s: float = 0.0
+
+
 def run_understand_prepass(
     target: Path,
     agentic_out_dir: Path,
@@ -253,6 +269,14 @@ def _run_understand_prepass_unsafe(
         # analysis prompt — so --understand pays off in this run too, not just
         # any later /validate.
         enriched = _enrich_agentic_checklist(agentic_out_dir, context_map)
+
+        # NOTE: the reachability low-priority marking previously
+        # lived here (under the --understand-only branch) but is
+        # now hoisted to ``run_reachability_prepass`` so it fires
+        # regardless of whether --understand was passed.
+        # Operators not using --understand still get the dead-
+        # code priority signal in their checklist, which
+        # benefits the agentic LLM budget allocation.
 
         return PrepassResult(
             ran=True,
@@ -761,6 +785,127 @@ def _enrich_agentic_checklist(agentic_out_dir: Path, context_map_path: Path) -> 
     except Exception as e:
         logger.warning("checklist enrichment failed: %s", e)
         return False
+
+
+def _mark_unreachable_low_priority(
+    agentic_out_dir: Path, target: Path,
+) -> int:
+    """Mark dead-code functions as ``priority=low`` in the
+    agentic checklist.
+
+    Sibling of :func:`_enrich_agentic_checklist` — that pass
+    UPGRADES priority based on /understand context-map data;
+    this pass DOWNGRADES priority for functions not called
+    anywhere in non-test project source. The two are
+    complementary and run consecutively. Functions already
+    marked ``priority=high`` by context-map enrichment are
+    skipped (entry-point analysis trumps reachability).
+
+    Returns the count of functions marked low-priority. Best-
+    effort; failures logged at debug.
+    """
+    checklist_path = agentic_out_dir / "checklist.json"
+    if not checklist_path.exists():
+        return 0
+    try:
+        from core.json import load_json, save_json
+        from core.orchestration.reachability_enrichment import (
+            mark_unreachable_low_priority,
+        )
+        checklist = load_json(checklist_path)
+        if not isinstance(checklist, dict):
+            return 0
+        marked = mark_unreachable_low_priority(checklist, target)
+        if marked:
+            save_json(checklist_path, checklist)
+        return marked
+    except Exception:                               # noqa: BLE001
+        logger.debug(
+            "reachability low-priority enrichment failed",
+            exc_info=True,
+        )
+        return 0
+
+
+def run_reachability_prepass(
+    target: Path,
+    agentic_out_dir: Path,
+) -> "ReachabilityPrepassResult":
+    """Always-on companion to ``run_understand_prepass``.
+
+    Runs unconditionally (no --understand gating): builds the
+    inventory once, marks dead-code functions priority=low in
+    the agentic checklist, returns the inventory so downstream
+    consumers (codeql analyzer, /validate Stage B) can reuse it
+    without rebuilding.
+
+    The /agentic LLM analysis prompt already reads
+    ``priority`` / ``priority_reason`` per function and surfaces
+    them to the model — so the priority=low marking shifts the
+    analysis budget to live code regardless of whether the
+    operator passed --understand.
+
+    Best-effort: any failure (missing checklist, inventory build
+    error, malformed call_graph) is logged at debug; the
+    returned ``ReachabilityPrepassResult.ran`` is False with a
+    non-None ``skipped_reason``.
+    """
+    t0 = time.time()
+    checklist_path = agentic_out_dir / "checklist.json"
+    if not checklist_path.exists():
+        return ReachabilityPrepassResult(
+            ran=False,
+            skipped_reason="agentic checklist not yet built",
+            duration_s=time.time() - t0,
+        )
+
+    # Build the inventory once. Cached on the result so the
+    # agentic launcher can hand it to /validate + codeql.
+    try:
+        from core.inventory.builder import build_inventory
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            inventory = build_inventory(str(target), td)
+    except Exception as e:                          # noqa: BLE001
+        logger.debug(
+            "reachability prepass: inventory build failed (%s)", e,
+        )
+        return ReachabilityPrepassResult(
+            ran=False,
+            skipped_reason="inventory build failed",
+            duration_s=time.time() - t0,
+        )
+
+    try:
+        from core.orchestration.reachability_enrichment import (
+            mark_unreachable_low_priority,
+        )
+        checklist = load_json(checklist_path)
+        if not isinstance(checklist, dict):
+            return ReachabilityPrepassResult(
+                ran=False,
+                skipped_reason="checklist not a JSON object",
+                inventory=inventory,
+                duration_s=time.time() - t0,
+            )
+        marked = mark_unreachable_low_priority(
+            checklist, target, inventory=inventory,
+        )
+        if marked:
+            save_json(checklist_path, checklist)
+    except Exception:                               # noqa: BLE001
+        logger.debug(
+            "reachability prepass: enrichment failed",
+            exc_info=True,
+        )
+        marked = 0
+
+    return ReachabilityPrepassResult(
+        ran=True,
+        marked_count=marked,
+        inventory=inventory,
+        duration_s=time.time() - t0,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/core/orchestration/reachability_enrichment.py
+++ b/core/orchestration/reachability_enrichment.py
@@ -1,0 +1,155 @@
+"""Reachability-driven checklist enrichment for /agentic.
+
+Sibling of :func:`core.orchestration.understand_bridge.enrich_checklist`,
+which marks entry-points and sinks as ``priority=high`` based on
+the /understand context-map. This module marks dead-code
+functions (NOT_CALLED verdict from
+``core.inventory.reachability``) as ``priority=low`` so the
+/agentic LLM analysis spends its budget on functions that
+actually run.
+
+The two enrichers are complementary:
+
+  * ``enrich_checklist`` (understand_bridge): UPGRADES priority
+    based on context-map data (entry points, sinks, trust
+    boundaries).
+  * ``mark_unreachable_low_priority`` (this module): DOWNGRADES
+    priority for functions not reached from anywhere in non-test
+    project source.
+
+When both run, ``enrich_checklist`` should run FIRST so its
+``priority=high`` markers stand. This module skips functions
+already marked high-priority — the entry-point analysis trumps
+reachability (a function might be an externally-callable entry
+point that the project itself doesn't call internally; static
+reachability would say NOT_CALLED but the operator still cares).
+
+Mutates the checklist in place. Returns the count of functions
+marked low-priority, mainly for diagnostic logging.
+
+Best-effort: any failure (inventory build error, malformed
+checklist, missing call_graph data) is logged at debug and the
+checklist is returned unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def mark_unreachable_low_priority(
+    checklist: Dict[str, Any],
+    target_path: Path,
+    *,
+    inventory: Optional[Dict[str, Any]] = None,
+) -> int:
+    """Walk ``checklist["files"][*]["items"]`` and mark functions
+    that are provably dead (NOT_CALLED) as ``priority="low"``.
+
+    Skips functions already marked ``priority="high"`` —
+    upstream enrichment (from /understand context-map) takes
+    precedence. ``inventory`` may be passed in by the caller
+    (avoids a redundant tree walk when a sibling consumer
+    already built one).
+
+    Returns the count of functions marked low-priority.
+    """
+    if not isinstance(checklist, dict):
+        return 0
+    files = checklist.get("files")
+    if not isinstance(files, list):
+        return 0
+
+    if inventory is None:
+        try:
+            from core.inventory.builder import build_inventory
+            import tempfile
+            with tempfile.TemporaryDirectory() as td:
+                inventory = build_inventory(str(target_path), td)
+        except Exception as e:                      # noqa: BLE001
+            logger.debug(
+                "reachability_enrichment: inventory build failed (%s); "
+                "skipping low-priority pass", e,
+            )
+            return 0
+
+    try:
+        from core.inventory.reachability import (
+            Verdict, function_called,
+        )
+    except ImportError:
+        return 0
+
+    marked = 0
+    for file_info in files:
+        if not isinstance(file_info, dict):
+            continue
+        rel_path = file_info.get("path")
+        if not isinstance(rel_path, str) or not rel_path:
+            continue
+        module = _path_to_module(rel_path)
+        if not module:
+            continue
+
+        funcs = file_info.get("items")
+        if not isinstance(funcs, list):
+            funcs = file_info.get("functions")
+        if not isinstance(funcs, list):
+            continue
+
+        for func in funcs:
+            if not isinstance(func, dict):
+                continue
+            # Skip non-function items (globals, classes, macros).
+            kind = func.get("kind")
+            if kind and kind != "function":
+                continue
+            # Don't downgrade entries already marked high-priority
+            # by upstream context-map enrichment.
+            if func.get("priority") == "high":
+                continue
+            name = func.get("name")
+            if not isinstance(name, str) or not name:
+                continue
+
+            qualified = f"{module}.{name}"
+            try:
+                result = function_called(inventory, qualified)
+            except ValueError:
+                continue
+            if result.verdict != Verdict.NOT_CALLED:
+                continue
+
+            func["priority"] = "low"
+            func["priority_reason"] = "reachability:not_called"
+            marked += 1
+
+    if marked:
+        logger.info(
+            "reachability_enrichment: marked %d function(s) as "
+            "priority=low (not reached from non-test project source)",
+            marked,
+        )
+    return marked
+
+
+def _path_to_module(rel_path: str) -> Optional[str]:
+    """``packages/foo/bar.py`` → ``packages.foo.bar``. Same
+    convention used by the codeql / validate consumers."""
+    if not rel_path:
+        return None
+    from pathlib import PurePosixPath
+    p = PurePosixPath(rel_path.replace("\\", "/"))
+    if not p.suffix:
+        return None
+    parts = list(p.with_suffix("").parts)
+    if not parts:
+        return None
+    return ".".join(parts)
+
+
+__all__ = ["mark_unreachable_low_priority"]

--- a/core/orchestration/tests/test_reachability_consumer_wirings_e2e.py
+++ b/core/orchestration/tests/test_reachability_consumer_wirings_e2e.py
@@ -1,0 +1,436 @@
+"""End-to-end test for reachability consumer wirings.
+
+Exercises the full integration: a synthetic project tree, the
+/agentic prepass building an inventory, then all three consumers
+(codeql / /validate / /agentic enrichment) acting on the SAME
+inventory + checklist data without rebuilds.
+
+Pure-Python — no LLM calls, no real scanner subprocess. The
+expensive scanner stages are mocked; the reachability decisions
+that drive consumer behaviour are real.
+
+Architecture exercised:
+
+  1. Project tree: ``src/live.py`` (function called from main),
+     ``src/dead.py`` (function never called), ``src/main.py``
+     (entry).
+  2. ``run_reachability_prepass`` builds inventory, marks the
+     dead function priority=low in the checklist on disk.
+  3. Codeql analyzer constructed with ``reachability_inventory=``
+     pointing at the prepass's inventory. Analyzer's
+     ``_check_reachability`` returns "not_called" for findings
+     in the dead function and "called" for findings in the live
+     one — WITHOUT rebuilding the inventory.
+  4. /validate's ``demote_unreachable_paths`` invoked with the
+     SAME inventory (via ``inventory=`` kwarg). Attack paths
+     anchored to dead-code findings get proximity clamped and
+     blockers appended.
+  5. The /agentic checklist's priority markers are visible in
+     the on-disk JSON (the agentic LLM analysis prompt would
+     read these).
+
+Verifies:
+
+  * Prepass builds + persists priority markers to checklist.
+  * In-process inventory sharing actually works (no rebuilds in
+    sibling consumers when DI'd).
+  * Codeql short-circuits before the dataflow validator runs.
+  * /validate demotes the right paths.
+  * All three consumers' verdicts are CONSISTENT for the same
+    function (synthetic project shape verifies the resolver's
+    qualified-name construction matches).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_PROJECT = {
+    # Live function called from main via cross-file import.
+    "src/live.py": (
+        "def vulnerable_handler(query):\n"
+        "    cursor.execute(query)\n"           # the 'sink' — line 2
+    ),
+    # Dead function — defined but never called.
+    "src/dead.py": (
+        "def unused_handler(query):\n"
+        "    cursor.execute(query)\n"           # the 'sink' — line 2
+    ),
+    # main() lives in its own file; calls live via import.
+    "src/main.py": (
+        "from src.live import vulnerable_handler\n"
+        "def main():\n"
+        "    vulnerable_handler('SELECT 1')\n"
+    ),
+    # entry.py imports + calls main(). The resolver tracks
+    # cross-file calls via imports, so this anchors main as
+    # CALLED. Without this file, main would itself look dead
+    # (its only same-file caller is module-level, not via an
+    # import binding).
+    "src/entry.py": (
+        "from src.main import main\n"
+        "main()\n"
+    ),
+}
+
+
+def _write_project(tmp_path: Path) -> Path:
+    for rel, contents in _PROJECT.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(contents)
+    return tmp_path
+
+
+def _write_agentic_checklist(out_dir: Path) -> Path:
+    """Build a minimal agentic checklist mirroring what
+    ``libexec/raptor-build-checklist`` would emit. Function names
+    + paths must match the synthetic project so the resolver can
+    bind chains."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    data = {
+        "files": [
+            {
+                "path": "src/live.py",
+                "items": [{
+                    "name": "vulnerable_handler",
+                    "kind": "function",
+                    "line_start": 1,
+                    "line_end": 2,
+                }],
+            },
+            {
+                "path": "src/dead.py",
+                "items": [{
+                    "name": "unused_handler",
+                    "kind": "function",
+                    "line_start": 1,
+                    "line_end": 2,
+                }],
+            },
+            {
+                "path": "src/main.py",
+                "items": [{
+                    "name": "main",
+                    "kind": "function",
+                    "line_start": 2,
+                    "line_end": 3,
+                }],
+            },
+            {
+                "path": "src/entry.py",
+                "items": [],
+            },
+        ],
+    }
+    p = out_dir / "checklist.json"
+    p.write_text(json.dumps(data))
+    return p
+
+
+def test_full_pipeline_dead_code_deprioritised(tmp_path):
+    """End-to-end: prepass marks dead code → codeql skips dead-
+    code findings → /validate demotes dead-code attack paths.
+    All three consumers produce consistent verdicts for the same
+    underlying functions."""
+    target = _write_project(tmp_path)
+    agentic_out = tmp_path / "agentic-out"
+    _write_agentic_checklist(agentic_out)
+
+    # ----- Stage 1: prepass -----
+    from core.orchestration import run_reachability_prepass
+    prepass = run_reachability_prepass(target, agentic_out)
+    assert prepass.ran is True
+    assert prepass.marked_count == 1, (
+        "expected the dead function to be marked priority=low; "
+        f"got {prepass.marked_count}"
+    )
+    assert prepass.inventory is not None
+
+    # The on-disk checklist now carries the priority marker.
+    saved = json.loads((agentic_out / "checklist.json").read_text())
+    funcs_by_path = {
+        f["path"]: {it["name"]: it for it in f["items"]}
+        for f in saved["files"]
+    }
+    assert (
+        funcs_by_path["src/dead.py"]["unused_handler"]["priority"]
+        == "low"
+    )
+    assert (
+        funcs_by_path["src/dead.py"]["unused_handler"]
+        ["priority_reason"] == "reachability:not_called"
+    )
+    assert "priority" not in funcs_by_path["src/live.py"][
+        "vulnerable_handler"
+    ]
+
+    # ----- Stage 2: codeql consumer with shared inventory -----
+    from packages.codeql.autonomous_analyzer import (
+        AutonomousCodeQLAnalyzer,
+        CodeQLFinding,
+    )
+
+    # Construct analyzer with the prepass's inventory — no rebuild.
+    analyzer = AutonomousCodeQLAnalyzer(
+        llm_client=MagicMock(),
+        exploit_validator=MagicMock(),
+        reachability_inventory=prepass.inventory,
+    )
+    # Verify the analyzer is using the shared inventory, not a
+    # rebuild.
+    assert analyzer._reachability_inventory is prepass.inventory
+
+    dead_finding = CodeQLFinding(
+        rule_id="py/sql-injection",
+        rule_name="SQL injection",
+        message="Tainted data flows to a SQL query",
+        level="error",
+        file_path="src/dead.py",
+        start_line=2,
+        end_line=2,
+        snippet="cursor.execute(query)",
+    )
+    live_finding = CodeQLFinding(
+        rule_id="py/sql-injection",
+        rule_name="SQL injection",
+        message="Tainted data flows to a SQL query",
+        level="error",
+        file_path="src/live.py",
+        start_line=2,
+        end_line=2,
+        snippet="cursor.execute(query)",
+    )
+
+    assert analyzer._check_reachability(dead_finding, target) == "not_called"
+    assert analyzer._check_reachability(live_finding, target) == "called"
+
+    # Stage-2b: short-circuit observable in analyze_finding_autonomous.
+    analyzer.dataflow_validator = MagicMock()
+    analyzer.dataflow_validator.validate_finding.side_effect = (
+        AssertionError(
+            "dataflow validator should not have been invoked for "
+            "dead-code finding"
+        )
+    )
+    # Stub parse_sarif_finding so we don't need real SARIF.
+    analyzer.parse_sarif_finding = lambda r, run: dead_finding
+
+    result = analyzer.analyze_finding_autonomous(
+        sarif_result={}, sarif_run={},
+        repo_path=target, out_dir=tmp_path / "codeql-out",
+    )
+    assert result.skipped_reason == "reachability_not_called"
+    assert result.reachability_verdict == "not_called"
+
+    # ----- Stage 3: /validate consumer with shared inventory -----
+    from packages.exploitability_validation.reachability import (
+        demote_unreachable_paths,
+    )
+
+    findings = [
+        {
+            "id": "f-dead",
+            "file_path": "src/dead.py",
+            "start_line": 2,
+        },
+        {
+            "id": "f-live",
+            "file_path": "src/live.py",
+            "start_line": 2,
+        },
+    ]
+    attack_paths = [
+        {
+            "id": "p-dead",
+            "finding_id": "f-dead",
+            "proximity": 8,
+            "blockers": [],
+        },
+        {
+            "id": "p-live",
+            "finding_id": "f-live",
+            "proximity": 7,
+            "blockers": [],
+        },
+    ]
+
+    demoted = demote_unreachable_paths(
+        attack_paths, findings, target,
+        inventory=prepass.inventory,
+    )
+    assert demoted == 1
+
+    by_id = {p["id"]: p for p in attack_paths}
+    # Dead path demoted.
+    assert by_id["p-dead"]["proximity"] == 1
+    assert any(
+        "reachability:not_called" in b
+        for b in by_id["p-dead"]["blockers"]
+    )
+    # Live path untouched.
+    assert by_id["p-live"]["proximity"] == 7
+    assert by_id["p-live"]["blockers"] == []
+
+
+def test_inventory_genuinely_shared_across_consumers(tmp_path):
+    """The same inventory dict instance threads through all three
+    consumers. None of them rebuilds — the test would catch a
+    regression that accidentally lazy-builds despite a DI'd
+    inventory."""
+    target = _write_project(tmp_path)
+    agentic_out = tmp_path / "agentic-out"
+    _write_agentic_checklist(agentic_out)
+
+    from core.orchestration import run_reachability_prepass
+    prepass = run_reachability_prepass(target, agentic_out)
+    inv = prepass.inventory
+    assert inv is not None
+
+    # Identity check — the SAME dict instance flows through.
+    from packages.codeql.autonomous_analyzer import (
+        AutonomousCodeQLAnalyzer,
+    )
+    analyzer = AutonomousCodeQLAnalyzer(
+        llm_client=MagicMock(),
+        exploit_validator=MagicMock(),
+        reachability_inventory=inv,
+    )
+    assert analyzer._reachability_inventory is inv
+
+    # Mutate the prepass inventory; verify the codeql side sees
+    # the mutation (proves identity-sharing, not just
+    # equality-sharing).
+    sentinel = {"e2e_test": "tracked"}
+    inv["__sentinel__"] = sentinel
+    assert (
+        analyzer._reachability_inventory.get("__sentinel__")
+        is sentinel
+    )
+
+
+def test_codeql_loads_checklist_from_disk_when_no_inventory(tmp_path):
+    """Cross-process scenario: subprocess analyzer doesn't have
+    the parent's in-memory inventory but DOES have the parent's
+    on-disk checklist. ``reachability_checklist_path=`` lets it
+    skip the rebuild."""
+    target = _write_project(tmp_path)
+
+    # The /agentic prepass would have written a checklist with
+    # call-graph data via build_inventory. Simulate by running
+    # build_inventory ourselves.
+    from core.inventory.builder import build_inventory
+    shared_dir = tmp_path / "shared"
+    build_inventory(str(target), str(shared_dir))
+    checklist_path = shared_dir / "checklist.json"
+    assert checklist_path.exists()
+
+    from packages.codeql.autonomous_analyzer import (
+        AutonomousCodeQLAnalyzer,
+        CodeQLFinding,
+    )
+
+    analyzer = AutonomousCodeQLAnalyzer(
+        llm_client=MagicMock(),
+        exploit_validator=MagicMock(),
+        reachability_checklist_path=checklist_path,
+    )
+
+    dead_finding = CodeQLFinding(
+        rule_id="py/sql-injection",
+        rule_name="SQL injection",
+        message="x", level="error",
+        file_path="src/dead.py",
+        start_line=2, end_line=2,
+        snippet="cursor.execute(query)",
+    )
+    # Verdict from the loaded checklist.
+    assert (
+        analyzer._check_reachability(dead_finding, target)
+        == "not_called"
+    )
+    # Inventory cache was populated from the disk read, NOT
+    # rebuilt.
+    assert isinstance(analyzer._reachability_inventory, dict)
+    assert "files" in analyzer._reachability_inventory
+
+
+def test_uncertain_dispatch_blocks_demotion_consistently(tmp_path):
+    """Across all three consumers, an UNCERTAIN verdict (file
+    uses dynamic dispatch) does NOT trigger any demotion.
+    Conservative: don't trust NOT_CALLED claims when the static
+    analysis has gaps."""
+    # Project where dead.py's function WOULD be NOT_CALLED, but
+    # main.py uses getattr to dispatch — resolver returns
+    # UNCERTAIN. main.py still calls vulnerable_handler so live
+    # code stays live (and main() at module level so main itself
+    # is callable).
+    files = dict(_PROJECT)
+    files["src/main.py"] = (
+        "from src import dead\n"
+        "from src.live import vulnerable_handler\n"
+        "def main():\n"
+        "    fn = getattr(dead, 'unused_handler')\n"
+        "    fn('x')\n"
+        "    vulnerable_handler('SELECT 1')\n"
+        "main()\n"
+    )
+    target = tmp_path
+    for rel, contents in files.items():
+        p = target / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(contents)
+
+    agentic_out = tmp_path / "agentic-out"
+    _write_agentic_checklist(agentic_out)
+
+    from core.orchestration import run_reachability_prepass
+    prepass = run_reachability_prepass(target, agentic_out)
+    # Dynamic dispatch → uncertain → no functions marked.
+    assert prepass.marked_count == 0
+
+    from packages.codeql.autonomous_analyzer import (
+        AutonomousCodeQLAnalyzer, CodeQLFinding,
+    )
+    analyzer = AutonomousCodeQLAnalyzer(
+        llm_client=MagicMock(),
+        exploit_validator=MagicMock(),
+        reachability_inventory=prepass.inventory,
+    )
+    dead_finding = CodeQLFinding(
+        rule_id="x", rule_name="x", message="x", level="error",
+        file_path="src/dead.py", start_line=2, end_line=2,
+        snippet="x",
+    )
+    # Codeql's prefilter returns "uncertain" — analyzer DOES NOT
+    # short-circuit.
+    assert (
+        analyzer._check_reachability(dead_finding, target)
+        == "uncertain"
+    )
+
+    from packages.exploitability_validation.reachability import (
+        demote_unreachable_paths,
+    )
+    findings = [{
+        "id": "f-dead",
+        "file_path": "src/dead.py",
+        "start_line": 2,
+    }]
+    attack_paths = [{
+        "id": "p-dead",
+        "finding_id": "f-dead",
+        "proximity": 8,
+    }]
+    demoted = demote_unreachable_paths(
+        attack_paths, findings, target,
+        inventory=prepass.inventory,
+    )
+    assert demoted == 0
+    # Path proximity untouched.
+    assert attack_paths[0]["proximity"] == 8

--- a/core/orchestration/tests/test_reachability_enrichment.py
+++ b/core/orchestration/tests/test_reachability_enrichment.py
@@ -1,0 +1,205 @@
+"""Tests for ``core.orchestration.reachability_enrichment``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.orchestration.reachability_enrichment import (
+    _path_to_module,
+    mark_unreachable_low_priority,
+)
+
+
+def _project(tmp_path: Path, files: dict) -> Path:
+    """Drop ``files`` (path → contents) under tmp_path."""
+    for rel, contents in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(contents)
+    return tmp_path
+
+
+def _checklist(files_funcs: dict) -> dict:
+    """Build a minimal checklist with ``{rel_path: [{name, ...}, ...]}``."""
+    return {
+        "files": [
+            {"path": rel, "items": funcs}
+            for rel, funcs in files_funcs.items()
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Marking behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_marks_dead_function_low_priority(tmp_path):
+    """Function not called from anywhere → priority=low."""
+    target = _project(tmp_path, {
+        "src/vuln.py": (
+            "def dead(): pass\n"
+            "def alive(): pass\n"
+        ),
+        "src/main.py": (
+            "from src.vuln import alive\n"
+            "alive()\n"
+        ),
+    })
+    checklist = _checklist({
+        "src/vuln.py": [
+            {"name": "dead", "kind": "function"},
+            {"name": "alive", "kind": "function"},
+        ],
+    })
+    marked = mark_unreachable_low_priority(checklist, target)
+    assert marked == 1
+    funcs = {f["name"]: f for f in checklist["files"][0]["items"]}
+    assert funcs["dead"]["priority"] == "low"
+    assert funcs["dead"]["priority_reason"] == "reachability:not_called"
+    # alive function untouched.
+    assert "priority" not in funcs["alive"]
+
+
+def test_does_not_overwrite_high_priority(tmp_path):
+    """Function already marked priority=high (from context-map
+    enrichment) is left alone even if NOT_CALLED."""
+    target = _project(tmp_path, {
+        "src/vuln.py": "def entry_point(): pass\n",
+        "src/main.py": "x = 1\n",
+    })
+    checklist = _checklist({
+        "src/vuln.py": [{
+            "name": "entry_point",
+            "kind": "function",
+            "priority": "high",
+            "priority_reason": "entry_point",
+        }],
+    })
+    marked = mark_unreachable_low_priority(checklist, target)
+    assert marked == 0
+    func = checklist["files"][0]["items"][0]
+    assert func["priority"] == "high"
+    assert func["priority_reason"] == "entry_point"
+
+
+def test_skips_uncertain_dispatch(tmp_path):
+    """File using getattr → UNCERTAIN → no downgrade."""
+    target = _project(tmp_path, {
+        "src/vuln.py": "def affected(): pass\n",
+        "src/main.py": (
+            "from src import vuln\n"
+            "fn = getattr(vuln, 'affected')\n"
+            "fn()\n"
+        ),
+    })
+    checklist = _checklist({
+        "src/vuln.py": [{"name": "affected", "kind": "function"}],
+    })
+    marked = mark_unreachable_low_priority(checklist, target)
+    assert marked == 0
+    func = checklist["files"][0]["items"][0]
+    assert "priority" not in func
+
+
+def test_skips_globals_and_classes(tmp_path):
+    """Items with kind != "function" are skipped (only functions
+    have call-graph reachability semantics)."""
+    target = _project(tmp_path, {
+        "src/vuln.py": (
+            "x = 1\n"
+            "def f(): pass\n"
+        ),
+    })
+    checklist = _checklist({
+        "src/vuln.py": [
+            {"name": "x", "kind": "global"},
+            {"name": "f", "kind": "function"},
+        ],
+    })
+    marked = mark_unreachable_low_priority(checklist, target)
+    # f gets marked, x doesn't.
+    assert marked == 1
+    items = {it["name"]: it for it in checklist["files"][0]["items"]}
+    assert "priority" not in items["x"]
+    assert items["f"]["priority"] == "low"
+
+
+def test_handles_empty_checklist(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "pass\n"})
+    assert mark_unreachable_low_priority({}, target) == 0
+    assert mark_unreachable_low_priority({"files": []}, target) == 0
+
+
+def test_handles_malformed_inputs(tmp_path):
+    """Non-dict / non-list shapes degrade gracefully."""
+    assert mark_unreachable_low_priority(
+        "not a dict",  # type: ignore[arg-type]
+        tmp_path,
+    ) == 0
+    assert mark_unreachable_low_priority(
+        {"files": "not a list"}, tmp_path,
+    ) == 0
+    # Files entry not a dict.
+    assert mark_unreachable_low_priority(
+        {"files": ["not a dict"]}, tmp_path,
+    ) == 0
+
+
+def test_function_without_name_skipped(tmp_path):
+    target = _project(tmp_path, {"src/vuln.py": "def f(): pass\n"})
+    checklist = _checklist({
+        "src/vuln.py": [
+            {"kind": "function"},                   # no name
+            {"name": "", "kind": "function"},      # empty name
+            {"name": "f", "kind": "function"},
+        ],
+    })
+    marked = mark_unreachable_low_priority(checklist, target)
+    # Only ``f`` gets marked.
+    assert marked == 1
+
+
+def test_path_without_extension_skipped(tmp_path):
+    """File entry with a path that has no extension can't be
+    converted to a module — skipped."""
+    target = _project(tmp_path, {"src/x.py": "pass\n"})
+    checklist = {
+        "files": [
+            {"path": "Makefile", "items": [
+                {"name": "build", "kind": "function"},
+            ]},
+        ],
+    }
+    marked = mark_unreachable_low_priority(checklist, target)
+    assert marked == 0
+
+
+def test_inventory_passed_through(tmp_path):
+    """When the caller passes an inventory, no fresh build."""
+    target = _project(tmp_path, {
+        "src/vuln.py": "def dead(): pass\n",
+    })
+    checklist = _checklist({
+        "src/vuln.py": [{"name": "dead", "kind": "function"}],
+    })
+    # Build inventory ourselves.
+    from core.inventory.builder import build_inventory
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        inv = build_inventory(str(target), td)
+    marked = mark_unreachable_low_priority(
+        checklist, target, inventory=inv,
+    )
+    assert marked == 1
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_path_to_module():
+    assert _path_to_module("packages/foo/bar.py") == "packages.foo.bar"
+    assert _path_to_module("Makefile") is None
+    assert _path_to_module("") is None

--- a/core/orchestration/tests/test_reachability_prepass.py
+++ b/core/orchestration/tests/test_reachability_prepass.py
@@ -1,0 +1,159 @@
+"""Tests for ``run_reachability_prepass`` — the always-on
+companion to ``run_understand_prepass``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.orchestration.agentic_passes import (
+    ReachabilityPrepassResult,
+    run_reachability_prepass,
+)
+
+
+def _project(tmp_path: Path, files: dict) -> Path:
+    """Drop ``files`` (path → contents) under tmp_path."""
+    for rel, contents in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(contents)
+    return tmp_path
+
+
+def _write_checklist(out_dir: Path, files_funcs: dict) -> Path:
+    """Build a minimal checklist with the given file → functions
+    mapping. Returns the checklist path."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    data = {
+        "files": [
+            {"path": rel, "items": funcs}
+            for rel, funcs in files_funcs.items()
+        ],
+    }
+    p = out_dir / "checklist.json"
+    p.write_text(json.dumps(data))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Always-on prepass behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_runs_unconditionally_marks_dead_function(tmp_path):
+    """Prepass fires regardless of whether --understand is set,
+    marking dead-code functions priority=low."""
+    target = _project(tmp_path, {
+        "src/vuln.py": (
+            "def dead(): pass\n"
+            "def alive(): pass\n"
+        ),
+        "src/main.py": (
+            "from src.vuln import alive\nalive()\n"
+        ),
+    })
+    out_dir = tmp_path / "agentic-out"
+    _write_checklist(out_dir, {
+        "src/vuln.py": [
+            {"name": "dead", "kind": "function"},
+            {"name": "alive", "kind": "function"},
+        ],
+    })
+
+    result = run_reachability_prepass(target, out_dir)
+    assert isinstance(result, ReachabilityPrepassResult)
+    assert result.ran is True
+    assert result.marked_count == 1
+    assert result.inventory is not None
+    assert "files" in result.inventory
+
+    # Verify the checklist.json on disk got the priority marker.
+    saved = json.loads((out_dir / "checklist.json").read_text())
+    funcs = {f["name"]: f for f in saved["files"][0]["items"]}
+    assert funcs["dead"]["priority"] == "low"
+    assert "priority" not in funcs["alive"]
+
+
+def test_skipped_when_checklist_missing(tmp_path):
+    """No agentic checklist on disk → prepass returns ran=False."""
+    target = _project(tmp_path, {"src/x.py": "pass\n"})
+    out_dir = tmp_path / "agentic-out"
+    out_dir.mkdir()
+    # No checklist.json — simulates "agentic agent hasn't run yet".
+
+    result = run_reachability_prepass(target, out_dir)
+    assert result.ran is False
+    assert result.skipped_reason == "agentic checklist not yet built"
+
+
+def test_inventory_returned_for_downstream_use(tmp_path):
+    """The inventory built by the prepass is returned so the
+    agentic launcher can thread it to /validate / codeql / etc.
+    without rebuilding."""
+    target = _project(tmp_path, {
+        "src/x.py": "def f(): pass\n",
+    })
+    out_dir = tmp_path / "agentic-out"
+    _write_checklist(out_dir, {
+        "src/x.py": [{"name": "f", "kind": "function"}],
+    })
+
+    result = run_reachability_prepass(target, out_dir)
+    assert result.inventory is not None
+    # The inventory has the standard build_inventory shape.
+    assert "files" in result.inventory
+    paths = {f["path"] for f in result.inventory["files"]}
+    assert "src/x.py" in paths
+
+
+def test_no_marks_when_all_functions_alive(tmp_path):
+    """All functions are reachable from project source →
+    marked_count = 0, prepass ran successfully."""
+    target = _project(tmp_path, {
+        "src/x.py": "def a():\n    pass\n",
+        "src/y.py": "def b():\n    pass\n",
+        "src/main.py": (
+            "from src.x import a\n"
+            "from src.y import b\n"
+            "a()\n"
+            "b()\n"
+        ),
+    })
+    out_dir = tmp_path / "agentic-out"
+    _write_checklist(out_dir, {
+        "src/x.py": [{"name": "a", "kind": "function"}],
+        "src/y.py": [{"name": "b", "kind": "function"}],
+    })
+
+    result = run_reachability_prepass(target, out_dir)
+    assert result.ran is True
+    assert result.marked_count == 0
+
+
+def test_handles_malformed_checklist(tmp_path):
+    """Checklist.json present but corrupt → ran=False with a
+    diagnostic skipped_reason."""
+    target = _project(tmp_path, {"src/x.py": "pass\n"})
+    out_dir = tmp_path / "agentic-out"
+    out_dir.mkdir()
+    (out_dir / "checklist.json").write_text("not valid json")
+
+    result = run_reachability_prepass(target, out_dir)
+    # Either ran=False with a skipped reason OR ran=True with
+    # marked_count=0 — both are acceptable graceful degradations.
+    assert isinstance(result, ReachabilityPrepassResult)
+    if result.ran:
+        assert result.marked_count == 0
+    else:
+        assert result.skipped_reason
+
+
+def test_duration_recorded(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f(): pass\n"})
+    out_dir = tmp_path / "agentic-out"
+    _write_checklist(out_dir, {
+        "src/x.py": [{"name": "f", "kind": "function"}],
+    })
+    result = run_reachability_prepass(target, out_dir)
+    assert result.duration_s >= 0.0

--- a/packages/codeql/autonomous_analyzer.py
+++ b/packages/codeql/autonomous_analyzer.py
@@ -112,6 +112,17 @@ class AutonomousAnalysisResult:
     validation_result: Optional[Dict]
     refinement_iterations: int
     total_duration_seconds: float
+    # Reachability prefilter outcome — set when the inventory-based
+    # resolver was consulted before the expensive LLM stages.
+    # ``"called"`` / ``"not_called"`` / ``"uncertain"`` / None
+    # (when the prefilter couldn't determine, e.g. non-Python file
+    # or sink line not in any function).
+    reachability_verdict: Optional[str] = None
+    # Set to a non-None reason when the analyzer short-circuited
+    # without running deep analysis. Today the only value is
+    # ``"reachability_not_called"`` (sink function provably dead
+    # code); future iterations may add more.
+    skipped_reason: Optional[str] = None
 
 
 class AutonomousCodeQLAnalyzer:
@@ -131,7 +142,9 @@ class AutonomousCodeQLAnalyzer:
         llm_client,
         exploit_validator,
         multi_turn_analyzer=None,
-        enable_visualization=True
+        enable_visualization=True,
+        reachability_inventory=None,
+        reachability_checklist_path=None,
     ):
         """
         Initialize autonomous analyzer.
@@ -141,6 +154,18 @@ class AutonomousCodeQLAnalyzer:
             exploit_validator: ExploitValidator from packages/autonomous/exploit_validator.py
             multi_turn_analyzer: MultiTurnAnalyser from packages/autonomous/dialogue.py (optional)
             enable_visualization: Enable dataflow visualizations (default: True)
+            reachability_inventory: Pre-built inventory dict (from
+                ``core.inventory.builder.build_inventory``). When
+                provided, ``_check_reachability`` uses it directly
+                and skips the lazy build. Lets the caller share
+                an inventory across analyzer instances or with
+                sibling consumers in the same process.
+            reachability_checklist_path: Path to a serialised
+                ``checklist.json``. When provided AND
+                ``reachability_inventory`` is None, the prefilter
+                loads it instead of rebuilding. Lets a subprocess
+                analyzer reuse an inventory built by the parent
+                /agentic run, avoiding the per-process tree walk.
         """
         self.llm = llm_client
         self.validator = exploit_validator
@@ -148,6 +173,152 @@ class AutonomousCodeQLAnalyzer:
         self.dataflow_validator = DataflowValidator(llm_client)
         self.enable_visualization = enable_visualization
         self.logger = get_logger()
+        # Reachability prefilter inventory. Three states:
+        #   * dict — usable inventory (caller-provided OR lazy
+        #     build OR loaded-from-disk).
+        #   * None — uninitialised; first ``_check_reachability``
+        #     call attempts load/build.
+        #   * False — load AND build both failed earlier; don't
+        #     retry.
+        self._reachability_inventory: Any = reachability_inventory
+        self._reachability_checklist_path = reachability_checklist_path
+
+    def _check_reachability(
+        self, finding: CodeQLFinding, repo_path: Path,
+    ) -> Optional[str]:
+        """Best-effort prefilter: is the function containing this
+        finding's sink line reached from anywhere in the project?
+
+        Returns one of ``"called"`` / ``"not_called"`` /
+        ``"uncertain"`` / None (None = couldn't determine — non-
+        Python file, sink not in any function, inventory build
+        failed, etc.). The caller's policy is to short-circuit on
+        ``"not_called"`` and otherwise continue.
+
+        Cost: inventory build is paid once per analyzer instance
+        (cached); per-finding lookup is O(N_files + N_calls in
+        sink file) — sub-millisecond after the inventory is
+        loaded.
+        """
+        if self._reachability_inventory is False:
+            return None     # earlier load/build failed; don't retry
+        if self._reachability_inventory is None:
+            # First try loading from disk if a checklist path was
+            # supplied — caller's been told "an /agentic prepass
+            # already built this; don't redo the walk".
+            if self._reachability_checklist_path is not None:
+                try:
+                    from core.json import load_json
+                    loaded = load_json(self._reachability_checklist_path)
+                    if isinstance(loaded, dict) and loaded.get("files"):
+                        self._reachability_inventory = loaded
+                except Exception as e:               # noqa: BLE001
+                    self.logger.debug(
+                        "reachability prefilter: checklist load "
+                        "failed (%s); falling back to fresh build",
+                        e,
+                    )
+            if self._reachability_inventory is None:
+                try:
+                    from core.inventory.builder import build_inventory
+                    import tempfile
+                    with tempfile.TemporaryDirectory() as td:
+                        self._reachability_inventory = build_inventory(
+                            str(repo_path), td,
+                        )
+                except Exception as e:              # noqa: BLE001
+                    self.logger.debug(
+                        "reachability prefilter: inventory build "
+                        "failed: %s", e,
+                    )
+                    self._reachability_inventory = False
+                    return None
+
+        try:
+            from core.inventory.lookup import lookup_function
+            from core.inventory.reachability import (
+                Verdict, function_called,
+            )
+        except ImportError:
+            return None
+
+        # Find the function containing the sink line.
+        func_info = lookup_function(
+            self._reachability_inventory,
+            finding.file_path,
+            finding.start_line,
+            repo_root=str(repo_path),
+        )
+        if func_info is None:
+            return None
+        func_name = func_info.get("name")
+        if not isinstance(func_name, str) or not func_name:
+            return None
+
+        # Build the qualified name. For Python files we derive the
+        # module from the relative path; for other languages the
+        # resolver handles the dotted-chain matching directly off
+        # the inventory's call_graph data, but we still need a
+        # qualified name to query. ``<module>.<func>`` works for
+        # both — when the file isn't Python, the lookup just won't
+        # match and we get NOT_CALLED, which the caller treats
+        # conservatively (skip if the verdict is the answer; the
+        # None return from non-callable lookups falls through).
+        rel_path = self._relative_path(finding.file_path, repo_path)
+        if rel_path is None:
+            return None
+        module = self._path_to_module(rel_path)
+        if not module:
+            return None
+        qualified = f"{module}.{func_name}"
+
+        try:
+            result = function_called(
+                self._reachability_inventory, qualified,
+            )
+        except ValueError:
+            return None
+        return result.verdict.value
+
+    def _relative_path(
+        self, file_path: str, repo_path: Path,
+    ) -> Optional[str]:
+        """Normalise a finding's file path to a project-relative
+        path. SARIF emitters produce a mix of absolute, repo-
+        relative, and ``file://``-URI shapes — handle all three.
+        """
+        from pathlib import Path as _P
+        if file_path.startswith("file://"):
+            file_path = file_path[len("file://"):]
+        p = _P(file_path)
+        if p.is_absolute():
+            try:
+                return str(p.relative_to(repo_path.resolve()))
+            except ValueError:
+                return None
+        return file_path
+
+    def _path_to_module(self, rel_path: str) -> Optional[str]:
+        """``packages/foo/bar.py`` → ``packages.foo.bar``.
+
+        For non-Python files we strip the extension and replace
+        path separators with dots. The resolver's chain matching
+        is dotted-only, so this works for any language whose
+        call_graph data was produced by an extractor on the
+        inventory side."""
+        if not rel_path:
+            return None
+        from pathlib import PurePosixPath
+        p = PurePosixPath(rel_path.replace("\\", "/"))
+        if not p.suffix:
+            return None
+        # Drop the extension. Multiple-extension cases (.tar.gz)
+        # don't apply for source files; ``.py`` / ``.go`` /
+        # ``.js`` / ``.ts`` etc. are all single-suffix.
+        parts = list(p.with_suffix("").parts)
+        if not parts:
+            return None
+        return ".".join(parts)
 
     def parse_sarif_finding(self, result: Dict, run: Dict) -> CodeQLFinding:
         """
@@ -736,6 +907,39 @@ class AutonomousCodeQLAnalyzer:
         finding = self.parse_sarif_finding(sarif_result, sarif_run)
         self.logger.info(f"🤖 AUTONOMOUS ANALYSIS: {finding.rule_id}")
 
+        # Stage 1a: Reachability prefilter. The
+        # ``core.inventory.reachability`` resolver answers "is the
+        # function CONTAINING this sink reached from anywhere in
+        # the project?" When the answer is ``"not_called"`` the
+        # sink is in dead code — the multi-second LLM analyses
+        # that follow would be wasted, so short-circuit early.
+        # ``"uncertain"`` (e.g. dynamic dispatch in the file)
+        # falls through to the full analysis: we don't trust
+        # NOT_CALLED claims when the static analysis can't see
+        # everything. None means we couldn't determine (non-
+        # supported language, lookup miss) — also fall through.
+        reachability_verdict = self._check_reachability(
+            finding, repo_path,
+        )
+        if reachability_verdict == "not_called":
+            self.logger.info(
+                "⏭️  Sink function not called from project — "
+                "skipping expensive analysis",
+            )
+            return AutonomousAnalysisResult(
+                finding=finding,
+                analysis=None,
+                dataflow_validation=None,
+                exploitable=False,
+                exploit_code=None,
+                exploit_compiled=False,
+                validation_result=None,
+                refinement_iterations=0,
+                total_duration_seconds=time.time() - start_time,
+                reachability_verdict=reachability_verdict,
+                skipped_reason="reachability_not_called",
+            )
+
         # Stage 2: Read vulnerable code
         vulnerable_code = self.read_vulnerable_code(finding, repo_path)
 
@@ -778,7 +982,8 @@ class AutonomousCodeQLAnalyzer:
                     exploit_compiled=False,
                     validation_result=None,
                     refinement_iterations=0,
-                    total_duration_seconds=time.time() - start_time
+                    total_duration_seconds=time.time() - start_time,
+                    reachability_verdict=reachability_verdict,
                 )
 
         # Stage 4: Deep LLM analysis
@@ -800,7 +1005,8 @@ class AutonomousCodeQLAnalyzer:
                 exploit_compiled=False,
                 validation_result=None,
                 refinement_iterations=0,
-                total_duration_seconds=time.time() - start_time
+                total_duration_seconds=time.time() - start_time,
+                reachability_verdict=reachability_verdict,
             )
 
         # Stage 5: Check mitigations before exploit generation
@@ -826,7 +1032,8 @@ class AutonomousCodeQLAnalyzer:
                 exploit_compiled=False,
                 validation_result=None,
                 refinement_iterations=0,
-                total_duration_seconds=time.time() - start_time
+                total_duration_seconds=time.time() - start_time,
+                reachability_verdict=reachability_verdict,
             )
 
         # Stage 7: Validate and refine exploit
@@ -907,7 +1114,8 @@ class AutonomousCodeQLAnalyzer:
             exploit_compiled=exploit_compiled,
             validation_result=asdict(validation_result) if validation_result else None,
             refinement_iterations=refinement_count,
-            total_duration_seconds=time.time() - start_time
+            total_duration_seconds=time.time() - start_time,
+            reachability_verdict=reachability_verdict,
         )
 
 

--- a/packages/codeql/tests/test_reachability_prefilter.py
+++ b/packages/codeql/tests/test_reachability_prefilter.py
@@ -1,0 +1,352 @@
+"""Tests for the CodeQL autonomous analyzer's reachability
+prefilter — the inventory-based pre-check that short-circuits
+expensive LLM analysis when the sink function isn't called from
+anywhere in the project."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from packages.codeql.autonomous_analyzer import (
+    AutonomousCodeQLAnalyzer,
+    CodeQLFinding,
+)
+
+
+def _analyzer() -> AutonomousCodeQLAnalyzer:
+    """Construct an analyzer with mocked LLM + validator."""
+    return AutonomousCodeQLAnalyzer(
+        llm_client=MagicMock(),
+        exploit_validator=MagicMock(),
+        multi_turn_analyzer=None,
+        enable_visualization=False,
+    )
+
+
+def _finding(file_path: str, line: int = 10) -> CodeQLFinding:
+    return CodeQLFinding(
+        rule_id="py/sql-injection",
+        rule_name="SQL injection",
+        message="Tainted data flows to a SQL query",
+        level="error",
+        file_path=file_path,
+        start_line=line,
+        end_line=line,
+        snippet="cursor.execute(query)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _path_to_module helper
+# ---------------------------------------------------------------------------
+
+
+def test_path_to_module_simple():
+    a = _analyzer()
+    assert a._path_to_module("packages/foo/bar.py") == "packages.foo.bar"
+
+
+def test_path_to_module_handles_windows_separators():
+    a = _analyzer()
+    assert a._path_to_module(
+        "packages\\foo\\bar.py"
+    ) == "packages.foo.bar"
+
+
+def test_path_to_module_returns_none_without_extension():
+    a = _analyzer()
+    assert a._path_to_module("Makefile") is None
+
+
+def test_path_to_module_strips_extension():
+    a = _analyzer()
+    assert a._path_to_module("src/main.go") == "src.main"
+    assert a._path_to_module("src/main.js") == "src.main"
+
+
+def test_path_to_module_empty():
+    a = _analyzer()
+    assert a._path_to_module("") is None
+
+
+# ---------------------------------------------------------------------------
+# _check_reachability — end-to-end on a real source tree
+# ---------------------------------------------------------------------------
+
+
+def test_reachability_called_for_used_function(tmp_path):
+    """A function that's called from another function in the
+    project returns ``"called"``."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "vuln.py").write_text(
+        "def vulnerable(query):\n"
+        "    cursor.execute(query)\n"
+    )
+    (src / "main.py").write_text(
+        "from src.vuln import vulnerable\n"
+        "def main():\n"
+        "    vulnerable('SELECT 1')\n"
+    )
+    a = _analyzer()
+    finding = _finding("src/vuln.py", line=2)
+    verdict = a._check_reachability(finding, tmp_path)
+    assert verdict == "called"
+
+
+def test_reachability_not_called_for_dead_function(tmp_path):
+    """A function that nothing else calls — sink is in dead code."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "vuln.py").write_text(
+        "def dead_handler(query):\n"
+        "    cursor.execute(query)\n"
+        "\n"
+        "def other():\n"
+        "    pass\n"
+    )
+    (src / "main.py").write_text(
+        "from src.vuln import other\n"
+        "def main():\n"
+        "    other()\n"
+    )
+    a = _analyzer()
+    finding = _finding("src/vuln.py", line=2)
+    verdict = a._check_reachability(finding, tmp_path)
+    assert verdict == "not_called"
+
+
+def test_reachability_uncertain_with_dynamic_dispatch(tmp_path):
+    """A file using getattr to dispatch by name on a tail-matching
+    target → UNCERTAIN."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "vuln.py").write_text(
+        "def affected(query):\n"
+        "    cursor.execute(query)\n"
+    )
+    (src / "main.py").write_text(
+        "from src import vuln\n"
+        "def main():\n"
+        "    fn = getattr(vuln, 'affected')\n"
+        "    fn('SELECT 1')\n"
+    )
+    a = _analyzer()
+    finding = _finding("src/vuln.py", line=2)
+    verdict = a._check_reachability(finding, tmp_path)
+    assert verdict == "uncertain"
+
+
+def test_reachability_returns_none_for_unknown_file(tmp_path):
+    """Sink path doesn't exist in the inventory → can't determine."""
+    (tmp_path / "main.py").write_text("def f(): pass\n")
+    a = _analyzer()
+    finding = _finding("nonexistent/file.py", line=1)
+    verdict = a._check_reachability(finding, tmp_path)
+    assert verdict is None
+
+
+def test_reachability_returns_none_when_sink_outside_function(tmp_path):
+    """Sink line outside any function (module-level statement) →
+    no enclosing function to query → None."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "vuln.py").write_text(
+        "# line 1\n"
+        "x = 1\n"               # module-level, no enclosing function
+        "def f():\n"
+        "    pass\n"
+    )
+    a = _analyzer()
+    finding = _finding("src/vuln.py", line=2)
+    verdict = a._check_reachability(finding, tmp_path)
+    assert verdict is None
+
+
+def test_reachability_inventory_cache_reused(tmp_path):
+    """Two consecutive calls reuse the inventory build."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "f.py").write_text("def x(): pass\n")
+    a = _analyzer()
+    f1 = _finding("src/f.py", line=1)
+    a._check_reachability(f1, tmp_path)
+    inv_after_first = a._reachability_inventory
+    a._check_reachability(f1, tmp_path)
+    assert a._reachability_inventory is inv_after_first
+
+
+def test_reachability_failed_build_doesnt_retry(tmp_path):
+    """If inventory build fails once (e.g. inaccessible target),
+    subsequent calls return None without retrying."""
+    a = _analyzer()
+    # Force the cache to the "failed" sentinel.
+    a._reachability_inventory = False
+    finding = _finding("src/f.py", line=1)
+    assert a._check_reachability(finding, tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# DI'd inventory + checklist-from-disk (in-process / cross-process sharing)
+# ---------------------------------------------------------------------------
+
+
+def test_caller_provided_inventory_used_directly(tmp_path):
+    """Caller passes ``reachability_inventory=`` at construction
+    → no fresh build, used directly. Lets the agentic prepass
+    share its inventory with codeql in the same process."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "vuln.py").write_text("def dead(): pass\n")
+    (src / "main.py").write_text("x = 1\n")
+
+    from core.inventory.builder import build_inventory
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        inv = build_inventory(str(tmp_path), td)
+
+    a = AutonomousCodeQLAnalyzer(
+        llm_client=MagicMock(),
+        exploit_validator=MagicMock(),
+        reachability_inventory=inv,
+    )
+    assert a._reachability_inventory is inv
+
+    finding = _finding("src/vuln.py", line=1)
+    verdict = a._check_reachability(finding, tmp_path)
+    assert verdict == "not_called"
+
+
+def test_checklist_path_loaded_when_no_inventory(tmp_path):
+    """``reachability_checklist_path=`` provides a serialised
+    checklist. Loaded in lieu of building. Lets a subprocess
+    analyzer reuse the parent /agentic run's checklist."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "vuln.py").write_text("def dead(): pass\n")
+
+    from core.inventory.builder import build_inventory
+    out = tmp_path / "shared-out"
+    build_inventory(str(tmp_path), str(out))
+    checklist_path = out / "checklist.json"
+    assert checklist_path.exists()
+
+    a = AutonomousCodeQLAnalyzer(
+        llm_client=MagicMock(),
+        exploit_validator=MagicMock(),
+        reachability_checklist_path=checklist_path,
+    )
+    finding = _finding("src/vuln.py", line=1)
+    verdict = a._check_reachability(finding, tmp_path)
+    assert verdict == "not_called"
+
+
+def test_checklist_path_invalid_falls_back_to_build(tmp_path):
+    """Missing checklist path → falls back to fresh build."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "vuln.py").write_text("def dead(): pass\n")
+
+    a = AutonomousCodeQLAnalyzer(
+        llm_client=MagicMock(),
+        exploit_validator=MagicMock(),
+        reachability_checklist_path=tmp_path / "does-not-exist.json",
+    )
+    finding = _finding("src/vuln.py", line=1)
+    verdict = a._check_reachability(finding, tmp_path)
+    # Fresh build worked; verdict same.
+    assert verdict == "not_called"
+
+
+# ---------------------------------------------------------------------------
+# Short-circuit behaviour in analyze_finding_autonomous
+# ---------------------------------------------------------------------------
+
+
+def test_short_circuit_on_not_called(tmp_path, monkeypatch):
+    """When the prefilter returns ``"not_called"``,
+    analyze_finding_autonomous returns immediately — the
+    expensive dataflow validator + LLM stages are NOT invoked."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "vuln.py").write_text(
+        "def dead(q):\n"
+        "    cursor.execute(q)\n"
+        "\n"
+        "def other():\n"
+        "    pass\n"
+    )
+    (src / "main.py").write_text(
+        "from src.vuln import other\nother()\n"
+    )
+
+    a = _analyzer()
+    # Stub out the parser to skip SARIF shape parsing in this test.
+    canned = _finding("src/vuln.py", line=2)
+    monkeypatch.setattr(
+        a, "parse_sarif_finding", lambda r, run: canned,
+    )
+
+    # Replace the dataflow_validator with a mock so we can assert
+    # it was never called (short-circuit happened before stage 3).
+    a.dataflow_validator = MagicMock()
+    a.dataflow_validator.validate_finding.side_effect = AssertionError(
+        "dataflow validator was invoked despite short-circuit"
+    )
+
+    result = a.analyze_finding_autonomous(
+        sarif_result={}, sarif_run={},
+        repo_path=tmp_path, out_dir=tmp_path / "out",
+    )
+    assert result.skipped_reason == "reachability_not_called"
+    assert result.reachability_verdict == "not_called"
+    assert result.exploitable is False
+    # The dataflow validator must NOT have been invoked — its
+    # side_effect would have raised. The short-circuit fires
+    # before stage 3.
+    a.dataflow_validator.validate_finding.assert_not_called()
+
+
+def test_no_short_circuit_when_called(tmp_path, monkeypatch):
+    """When the prefilter returns ``"called"``, we proceed past
+    the early-exit. We don't run the FULL flow here (would need
+    extensive LLM mocking); just verify the reachability_verdict
+    is set and the early-return didn't fire."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "vuln.py").write_text(
+        "def vulnerable(q):\n"
+        "    cursor.execute(q)\n"
+    )
+    (src / "main.py").write_text(
+        "from src.vuln import vulnerable\nvulnerable('x')\n"
+    )
+
+    a = _analyzer()
+    canned = _finding("src/vuln.py", line=2)
+    monkeypatch.setattr(
+        a, "parse_sarif_finding", lambda r, run: canned,
+    )
+    # Stub read_vulnerable_code so we don't depend on actual file
+    # reading here.
+    monkeypatch.setattr(
+        a, "read_vulnerable_code", lambda f, p: "stub",
+    )
+    # Stub analyze_vulnerability to short-circuit before exploit.
+    fake_analysis = MagicMock(is_exploitable=False)
+    monkeypatch.setattr(
+        a, "analyze_vulnerability",
+        lambda *args, **kwargs: fake_analysis,
+    )
+    # The finding has no dataflow → skip dataflow stage.
+
+    result = a.analyze_finding_autonomous(
+        sarif_result={}, sarif_run={},
+        repo_path=tmp_path, out_dir=tmp_path / "out",
+    )
+    # Got past the early-exit (analysis was attempted).
+    assert result.skipped_reason is None
+    assert result.reachability_verdict == "called"

--- a/packages/exploitability_validation/orchestrator.py
+++ b/packages/exploitability_validation/orchestrator.py
@@ -697,6 +697,33 @@ class ValidationOrchestrator:
                     )
                     feas["attack_path_ref"] = None
 
+        # Reachability demotion — for any attack path whose
+        # finding's enclosing function is provably dead code
+        # (NOT_CALLED verdict from the inventory's call-graph
+        # data), clamp ``proximity`` low and append a
+        # ``reachability:not_called`` blocker. Demotion rather
+        # than removal — entry function might be callable from
+        # outside the project (public API surface, plugin entry,
+        # framework callback). Operators retain the path data;
+        # it just sits at the bottom by proximity score.
+        try:
+            from .reachability import demote_unreachable_paths
+            demoted = demote_unreachable_paths(
+                self.state.attack_paths or [],
+                self.state.findings.get("findings", []),
+                Path(self.config.target_path),
+            )
+            if demoted:
+                # Attack paths were mutated in place; persist.
+                self.state.save_json(
+                    "attack-paths.json", self.state.attack_paths,
+                )
+        except Exception:                           # noqa: BLE001
+            logger.debug(
+                "Stage B: reachability demotion failed; report "
+                "produced without demotion pass", exc_info=True,
+            )
+
         # Update findings
         self.state.findings["stage"] = "B"
         self.state.findings["timestamp"] = datetime.now().isoformat()

--- a/packages/exploitability_validation/reachability.py
+++ b/packages/exploitability_validation/reachability.py
@@ -1,0 +1,238 @@
+"""Reachability-driven attack-path demotion.
+
+Consumer of the ``core.inventory.reachability`` substrate. After
+Stage B builds attack paths from findings + hypotheses, this
+module post-processes the path list: any path anchored to a
+finding whose enclosing function is provably dead code (NOT_CALLED
+verdict from the inventory's call-graph data) gets demoted —
+proximity clamped low + a ``reachability:not_called`` blocker
+appended.
+
+This complements the existing CodeQL reachability prefilter
+(``packages.codeql.autonomous_analyzer._check_reachability``).
+The CodeQL prefilter runs at SARIF-finding triage time and
+short-circuits the LLM analysis. The Stage B demotion runs later
+on the validated attack-path tree and ensures the report's
+proximity ordering doesn't bubble dead-code findings to the top
+just because they have populated attack paths.
+
+Demotion rather than removal — the entry function might be
+callable from outside the project (public API surface, plugin
+entry point, framework callback). Operators retain the path data
+in the report; it just sits at the bottom by proximity score.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# Cap for demoted paths' ``proximity`` field. The schema documents
+# 0-10 with 8 = "exploit path clear" and 5 = "primitive
+# confirmed". Clamping to 1 puts demoted paths firmly below
+# anything actively-validated; 0 would suggest "not started" which
+# misrepresents the LLM's actual analysis.
+_DEMOTED_PROXIMITY_CAP = 1
+
+
+def demote_unreachable_paths(
+    attack_paths: List[Dict[str, Any]],
+    findings: List[Dict[str, Any]],
+    target_path: Path,
+    *,
+    inventory: Optional[Dict[str, Any]] = None,
+) -> int:
+    """Walk ``attack_paths``, demote any whose entry function is
+    NOT_CALLED. Mutates the list in place. Returns the count of
+    demoted paths.
+
+    ``findings`` is the Stage B finding list — used to map
+    ``attack_path.finding_id`` → ``finding.location`` (file +
+    line). ``target_path`` is the project root for inventory
+    construction. ``inventory`` may be passed in by the caller
+    when it's already been built (e.g. by a sibling reachability
+    consumer); otherwise we build one over ``target_path``.
+
+    No-op when:
+      * attack_paths is empty
+      * no path can be linked to a finding-with-location
+      * the inventory build fails (graceful degradation —
+        operators get the report unchanged)
+      * the call_graph data isn't present (non-supported
+        language)
+
+    The function is a single best-effort pass; per-path errors are
+    logged at debug and the remaining paths still get processed.
+    """
+    if not attack_paths:
+        return 0
+
+    # Index findings by id for O(1) attack-path → finding lookup.
+    findings_by_id: Dict[str, Dict[str, Any]] = {
+        f.get("id"): f for f in findings
+        if isinstance(f, dict) and isinstance(f.get("id"), str)
+    }
+    if not findings_by_id:
+        return 0
+
+    if inventory is None:
+        try:
+            from core.inventory.builder import build_inventory
+            import tempfile
+            with tempfile.TemporaryDirectory() as td:
+                inventory = build_inventory(str(target_path), td)
+        except Exception as e:                      # noqa: BLE001
+            logger.debug(
+                "exploitability_validation.reachability: inventory "
+                "build failed (%s); skipping demotion pass", e,
+            )
+            return 0
+
+    try:
+        from core.inventory.lookup import lookup_function
+        from core.inventory.reachability import (
+            Verdict, function_called,
+        )
+    except ImportError:
+        return 0
+
+    demoted_count = 0
+    for path in attack_paths:
+        if not isinstance(path, dict):
+            continue
+        finding_id = path.get("finding_id") or path.get("finding")
+        if not isinstance(finding_id, str):
+            continue
+        finding = findings_by_id.get(finding_id)
+        if finding is None:
+            continue
+        location = _finding_location(finding)
+        if location is None:
+            continue
+        file_path, line = location
+
+        func_info = lookup_function(
+            inventory, file_path, line, repo_root=str(target_path),
+        )
+        if func_info is None:
+            continue
+        func_name = func_info.get("name")
+        if not isinstance(func_name, str) or not func_name:
+            continue
+
+        rel_path = _relative_path(file_path, target_path)
+        if rel_path is None:
+            continue
+        module = _path_to_module(rel_path)
+        if not module:
+            continue
+
+        try:
+            result = function_called(
+                inventory, f"{module}.{func_name}",
+            )
+        except ValueError:
+            continue
+
+        if result.verdict != Verdict.NOT_CALLED:
+            continue
+
+        # Demote: cap proximity, append blocker.
+        original_proximity = path.get("proximity")
+        if isinstance(original_proximity, int) and original_proximity > _DEMOTED_PROXIMITY_CAP:
+            path["proximity"] = _DEMOTED_PROXIMITY_CAP
+        elif not isinstance(original_proximity, int):
+            path["proximity"] = _DEMOTED_PROXIMITY_CAP
+        blockers = path.get("blockers")
+        if not isinstance(blockers, list):
+            blockers = []
+        blocker = (
+            f"reachability:not_called — entry function "
+            f"`{module}.{func_name}` is not called from any "
+            f"non-test project source"
+        )
+        if blocker not in blockers:
+            blockers.append(blocker)
+        path["blockers"] = blockers
+        demoted_count += 1
+
+    if demoted_count:
+        logger.info(
+            "exploitability_validation.reachability: demoted %d "
+            "attack path(s) anchored to dead-code findings",
+            demoted_count,
+        )
+    return demoted_count
+
+
+# ---------------------------------------------------------------------------
+# Helpers — same shape as the CodeQL prefilter to keep the two
+# consumers aligned. Duplicated rather than imported to keep the
+# /validate module independent of the codeql package.
+# ---------------------------------------------------------------------------
+
+
+def _finding_location(finding: Dict[str, Any]) -> Optional[tuple]:
+    """Pull ``(file_path, line)`` out of a finding's location data.
+
+    Findings vary in shape — some have flat ``file_path`` /
+    ``start_line``, others nest under ``location``. Try both."""
+    file_path = finding.get("file_path") or finding.get("file")
+    start_line = (
+        finding.get("start_line")
+        or finding.get("line")
+        or finding.get("line_start")
+    )
+    if file_path is None:
+        loc = finding.get("location") or {}
+        if isinstance(loc, dict):
+            file_path = loc.get("file") or loc.get("file_path")
+            start_line = (
+                start_line
+                or loc.get("line")
+                or loc.get("start_line")
+                or loc.get("line_start")
+            )
+    if not isinstance(file_path, str) or not file_path:
+        return None
+    if not isinstance(start_line, int) or start_line < 1:
+        return None
+    return file_path, start_line
+
+
+def _relative_path(
+    file_path: str, repo_path: Path,
+) -> Optional[str]:
+    """Same logic as the codeql prefilter's helper. Strip
+    ``file://`` URI prefix, normalise to project-relative."""
+    from pathlib import Path as _P
+    if file_path.startswith("file://"):
+        file_path = file_path[len("file://"):]
+    p = _P(file_path)
+    if p.is_absolute():
+        try:
+            return str(p.relative_to(repo_path.resolve()))
+        except ValueError:
+            return None
+    return file_path
+
+
+def _path_to_module(rel_path: str) -> Optional[str]:
+    """``packages/foo/bar.py`` → ``packages.foo.bar``."""
+    if not rel_path:
+        return None
+    from pathlib import PurePosixPath
+    p = PurePosixPath(rel_path.replace("\\", "/"))
+    if not p.suffix:
+        return None
+    parts = list(p.with_suffix("").parts)
+    if not parts:
+        return None
+    return ".".join(parts)
+
+
+__all__ = ["demote_unreachable_paths"]

--- a/packages/exploitability_validation/tests/test_reachability_demotion.py
+++ b/packages/exploitability_validation/tests/test_reachability_demotion.py
@@ -1,0 +1,285 @@
+"""Tests for the Stage B reachability-driven attack-path demotion."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from packages.exploitability_validation.reachability import (
+    _path_to_module,
+    _relative_path,
+    demote_unreachable_paths,
+)
+
+
+# ---------------------------------------------------------------------------
+# Demotion behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_demotes_path_anchored_to_dead_function(tmp_path):
+    """Finding's enclosing function is dead code → path proximity
+    clamped + blocker appended."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "vuln.py").write_text(
+        "def dead_handler(query):\n"
+        "    cursor.execute(query)\n"
+        "\n"
+        "def other():\n"
+        "    pass\n"
+    )
+    (tmp_path / "src" / "main.py").write_text(
+        "from src.vuln import other\n"
+        "other()\n"
+    )
+
+    findings = [{
+        "id": "f1",
+        "file_path": "src/vuln.py",
+        "start_line": 2,
+    }]
+    attack_paths = [{
+        "id": "p1",
+        "finding_id": "f1",
+        "proximity": 8,
+        "blockers": [],
+    }]
+
+    demoted = demote_unreachable_paths(
+        attack_paths, findings, tmp_path,
+    )
+    assert demoted == 1
+    assert attack_paths[0]["proximity"] == 1
+    assert any(
+        "reachability:not_called" in b
+        for b in attack_paths[0]["blockers"]
+    )
+
+
+def test_does_not_demote_called_function(tmp_path):
+    """Finding's enclosing function IS called → no demotion."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "vuln.py").write_text(
+        "def vulnerable(query):\n"
+        "    cursor.execute(query)\n"
+    )
+    (tmp_path / "src" / "main.py").write_text(
+        "from src.vuln import vulnerable\n"
+        "vulnerable('x')\n"
+    )
+
+    findings = [{
+        "id": "f1",
+        "file_path": "src/vuln.py",
+        "start_line": 2,
+    }]
+    attack_paths = [{
+        "id": "p1",
+        "finding_id": "f1",
+        "proximity": 7,
+        "blockers": [],
+    }]
+
+    demoted = demote_unreachable_paths(
+        attack_paths, findings, tmp_path,
+    )
+    assert demoted == 0
+    assert attack_paths[0]["proximity"] == 7
+    assert attack_paths[0]["blockers"] == []
+
+
+def test_does_not_demote_uncertain_dispatch(tmp_path):
+    """Function looks dead per static analysis but the file uses
+    getattr → UNCERTAIN → no demotion."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "vuln.py").write_text(
+        "def affected(q):\n"
+        "    cursor.execute(q)\n"
+    )
+    (tmp_path / "src" / "main.py").write_text(
+        "from src import vuln\n"
+        "fn = getattr(vuln, 'affected')\n"
+        "fn('x')\n"
+    )
+    findings = [{
+        "id": "f1",
+        "file_path": "src/vuln.py",
+        "start_line": 2,
+    }]
+    attack_paths = [{
+        "id": "p1",
+        "finding_id": "f1",
+        "proximity": 8,
+    }]
+    demoted = demote_unreachable_paths(
+        attack_paths, findings, tmp_path,
+    )
+    assert demoted == 0
+
+
+def test_handles_missing_finding_id(tmp_path):
+    """Path without finding_id → skipped silently."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "vuln.py").write_text("def f(): pass\n")
+
+    attack_paths = [{
+        "id": "p1",
+        "proximity": 5,
+    }]
+    demoted = demote_unreachable_paths(
+        attack_paths, [], tmp_path,
+    )
+    assert demoted == 0
+    assert attack_paths[0]["proximity"] == 5
+
+
+def test_handles_finding_id_missing_from_findings(tmp_path):
+    """Path's finding_id doesn't match any finding — skipped."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "vuln.py").write_text("def f(): pass\n")
+    findings = [{"id": "other", "file_path": "src/vuln.py", "start_line": 1}]
+    attack_paths = [{"id": "p1", "finding_id": "missing", "proximity": 5}]
+    demoted = demote_unreachable_paths(
+        attack_paths, findings, tmp_path,
+    )
+    assert demoted == 0
+
+
+def test_handles_finding_without_location(tmp_path):
+    """Finding without file_path/start_line → can't look up
+    function → no demotion."""
+    (tmp_path / "src").mkdir()
+    findings = [{"id": "f1"}]                       # no location
+    attack_paths = [{"id": "p1", "finding_id": "f1", "proximity": 8}]
+    demoted = demote_unreachable_paths(
+        attack_paths, findings, tmp_path,
+    )
+    assert demoted == 0
+
+
+def test_empty_inputs(tmp_path):
+    assert demote_unreachable_paths([], [], tmp_path) == 0
+
+
+def test_alternate_finding_field_alias(tmp_path):
+    """``attack_path["finding"]`` (instead of ``finding_id``) —
+    supported per ATTACK_PATH_SCHEMA which calls them aliases."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "vuln.py").write_text(
+        "def dead(): pass\n"
+        "def other(): pass\n"
+    )
+    (tmp_path / "src" / "main.py").write_text(
+        "from src.vuln import other\nother()\n"
+    )
+    findings = [{
+        "id": "f1",
+        "file_path": "src/vuln.py",
+        "start_line": 1,
+    }]
+    attack_paths = [{
+        "id": "p1",
+        "finding": "f1",                            # alias form
+        "proximity": 8,
+    }]
+    demoted = demote_unreachable_paths(
+        attack_paths, findings, tmp_path,
+    )
+    assert demoted == 1
+
+
+def test_multiple_paths_independently_processed(tmp_path):
+    """Two paths, one anchored to dead code, one to live code.
+    Only the dead one is demoted."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "vuln.py").write_text(
+        "def dead(): pass\n"
+        "def alive(): pass\n"
+    )
+    (tmp_path / "src" / "main.py").write_text(
+        "from src.vuln import alive\nalive()\n"
+    )
+    findings = [
+        {"id": "f1", "file_path": "src/vuln.py", "start_line": 1},
+        {"id": "f2", "file_path": "src/vuln.py", "start_line": 2},
+    ]
+    attack_paths = [
+        {"id": "p1", "finding_id": "f1", "proximity": 8},
+        {"id": "p2", "finding_id": "f2", "proximity": 7},
+    ]
+    demoted = demote_unreachable_paths(
+        attack_paths, findings, tmp_path,
+    )
+    assert demoted == 1
+    by_id = {p["id"]: p for p in attack_paths}
+    assert by_id["p1"]["proximity"] == 1
+    assert by_id["p2"]["proximity"] == 7
+
+
+def test_blocker_dedup(tmp_path):
+    """Re-running the demotion against an already-demoted path
+    doesn't append a duplicate blocker."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "vuln.py").write_text("def dead(): pass\n")
+    findings = [{"id": "f1", "file_path": "src/vuln.py", "start_line": 1}]
+    attack_paths = [{
+        "id": "p1",
+        "finding_id": "f1",
+        "proximity": 8,
+        "blockers": [],
+    }]
+    demote_unreachable_paths(attack_paths, findings, tmp_path)
+    blockers_after_first = list(attack_paths[0]["blockers"])
+    demote_unreachable_paths(attack_paths, findings, tmp_path)
+    # Blocker list should NOT have grown.
+    assert attack_paths[0]["blockers"] == blockers_after_first
+
+
+def test_existing_proximity_below_cap_unchanged(tmp_path):
+    """If the path's proximity is already below the demotion cap
+    (e.g. proximity=0), demotion still adds the blocker but
+    leaves proximity alone."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "vuln.py").write_text("def dead(): pass\n")
+    findings = [{"id": "f1", "file_path": "src/vuln.py", "start_line": 1}]
+    attack_paths = [{"id": "p1", "finding_id": "f1", "proximity": 0}]
+    demote_unreachable_paths(attack_paths, findings, tmp_path)
+    assert attack_paths[0]["proximity"] == 0
+    assert any(
+        "reachability:not_called" in b
+        for b in attack_paths[0].get("blockers", [])
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_relative_path_strips_file_uri():
+    assert _relative_path(
+        "file:///tmp/proj/src/x.py", Path("/tmp/proj"),
+    ) == "src/x.py"
+
+
+def test_relative_path_handles_absolute(tmp_path):
+    p = tmp_path / "src" / "x.py"
+    rel = _relative_path(str(p), tmp_path)
+    assert rel == "src/x.py"
+
+
+def test_relative_path_keeps_relative_as_is():
+    assert _relative_path("src/x.py", Path("/tmp/proj")) == "src/x.py"
+
+
+def test_relative_path_returns_none_when_outside_repo(tmp_path):
+    """Absolute path outside the repo can't be made relative."""
+    other = "/etc/passwd"
+    assert _relative_path(other, tmp_path) is None
+
+
+def test_path_to_module_simple():
+    assert _path_to_module("packages/foo/bar.py") == "packages.foo.bar"
+
+
+def test_path_to_module_no_extension_returns_none():
+    assert _path_to_module("Makefile") is None

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -564,6 +564,40 @@ Examples:
         else:
             logger.warning(f"Pre-pass skipped: {prepass_result.skipped_reason}")
 
+    # ========================================================================
+    # PRE-PASS: reachability — always-on companion to /understand.
+    # Marks dead-code functions priority=low in the agentic checklist using
+    # core.inventory.reachability. Runs regardless of --understand because
+    # the agentic LLM analysis prompt reads priority/priority_reason and
+    # benefits from the dead-code signal even without context-map upgrades.
+    # The returned inventory is threaded through to downstream consumers
+    # (codeql analyzer, /validate post-pass) so they don't re-walk the tree.
+    # ========================================================================
+    reachability_prepass_result = None
+    try:
+        from core.orchestration import run_reachability_prepass
+        reachability_prepass_result = run_reachability_prepass(
+            target=original_repo_path,
+            agentic_out_dir=out_dir,
+        )
+        if reachability_prepass_result.ran:
+            logger.info(
+                f"Reachability pre-pass marked "
+                f"{reachability_prepass_result.marked_count} dead-code "
+                f"function(s) priority=low "
+                f"(took {reachability_prepass_result.duration_s:.1f}s)"
+            )
+        else:
+            logger.debug(
+                "Reachability pre-pass skipped: "
+                f"{reachability_prepass_result.skipped_reason}"
+            )
+    except Exception:                               # noqa: BLE001
+        logger.warning(
+            "Reachability pre-pass failed; continuing without it",
+            exc_info=True,
+        )
+
     all_sarif_files = []
     semgrep_metrics = {}
     codeql_metrics = {}


### PR DESCRIPTION
Three independent consumers + an orchestration commit unifying how they share inventory across processes + an E2E test.

* codeql autonomous_analyzer (1) — short-circuit before LLM stages when sink's enclosing function is dead.
* /validate Stage B (2) — demote attack paths anchored to dead-code findings: proximity clamp + reachability blocker appended. Demotion not removal — entry might be externally callable.
* /agentic checklist (3) — sibling of the existing context-map upgrade enricher; marks priority=low for NOT_CALLED functions, skips ones already marked priority=high (entry-point analysis trumps reachability).
* orchestration (4) — extracts run_reachability_prepass to fire unconditionally (no --understand gating), exposes the built inventory on the result, threads it through codeql via new reachability_inventory + reachability_checklist_path kwargs. In-process consumers share the dict instance; subprocess consumers share via the on-disk checklist.
* E2E test (5+6) — pure-Python integration test against a synthetic project tree exercising prepass → all three consumers → identity-checked inventory sharing → checklist- from-disk fallback → UNCERTAIN-blocks-demotion consistency. Surfaced + documented one resolver limitation: same-file module-level calls don't bind through imports, so the resolver reads them as NOT_CALLED.

Verdict semantics consistent across all three consumers: NOT_CALLED → act, CALLED / UNCERTAIN / resolver-miss → no-op.

Tests: 50 new (14 codeql + 17 /validate + 10 /agentic + 9 orchestration). 931 total passing across core/orchestration + core/inventory + packages/codeql + packages/exploitability_ validation.