### PR TITLE
feat(validate): cross-process checklist hand-off from /agentic

### DIFF
--- a/core/orchestration/agentic_passes.py
+++ b/core/orchestration/agentic_passes.py
@@ -411,6 +411,33 @@ def _run_validate_postpass_unsafe(
         save_json(selection_file,
                   convert_agentic_to_validate(selected, str(target)))
 
+        # Drop a pointer to the parent /agentic checklist so /validate's
+        # Stage 0 can reuse it instead of rebuilding the inventory from
+        # scratch. The reachability prepass already built one; pointing
+        # at it saves a full source-tree walk + AST parse (~30-60s on
+        # typical large repos). /validate's Stage 0 reads
+        # ``parent-checklist-pointer.json`` and falls through to a fresh
+        # build when the pointer is missing / stale / mistargeted /
+        # outside the expected root.
+        #
+        # ``expected_root_dir`` is the agentic_out_dir; /validate
+        # rejects pointers whose ``checklist_path`` resolves outside
+        # this root (defense against a buggy or malicious pointer
+        # pointing at arbitrary file paths). Same defensive principle
+        # as the /understand bridge's path validation. The mtime-based
+        # TTL on the validate side rejects checklists older than 1h
+        # (stale source drift).
+        agentic_checklist = agentic_out_dir / "checklist.json"
+        if agentic_checklist.is_file():
+            save_json(
+                validate_dir / "parent-checklist-pointer.json",
+                {
+                    "checklist_path": str(agentic_checklist.resolve()),
+                    "expected_target_path": str(target),
+                    "expected_root_dir": str(agentic_out_dir.resolve()),
+                },
+            )
+
         prompt = _build_validate_prompt(target, agentic_out_dir, validate_dir,
                                         analysis_report, selection_file, len(selected))
 

--- a/core/orchestration/tests/test_validate_checklist_handoff_e2e.py
+++ b/core/orchestration/tests/test_validate_checklist_handoff_e2e.py
@@ -1,0 +1,302 @@
+"""End-to-end test for the cross-process checklist hand-off.
+
+Pure-Python E2E: synthetic project + real ``build_inventory`` for
+the parent checklist + real ``ValidationOrchestrator._run_stage_0``
+for reuse + real demotion. The agentic launcher's subprocess
+dispatch is mocked but the pointer write is exercised directly.
+
+Verifies:
+
+  1. The agentic launcher writes a structurally-valid pointer
+     into validate_dir before the subprocess kicks off.
+  2. The pointer's fields match what the orchestrator expects
+     (path / target / root).
+  3. The orchestrator's Stage 0 reuses the pointed-at checklist
+     instead of calling ``build_inventory`` (verified by
+     ``patch`` raising on any build_inventory call).
+  4. Stage B's demotion call uses the reused inventory.
+  5. The full chain produces consistent verdicts for live + dead
+     functions.
+
+Pre-existing test-isolation flakes in the broader suite reproduce
+without these changes — this test runs cleanly on its own.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+
+def _write_synthetic_project(tmp_path: Path) -> Path:
+    """Project with both live (called from main) and dead
+    (defined but unused) functions."""
+    files = {
+        "src/live.py": (
+            "def live_fn(query):\n"
+            "    cursor.execute(query)\n"
+        ),
+        "src/dead.py": (
+            "def dead_fn(query):\n"
+            "    cursor.execute(query)\n"
+        ),
+        "src/main.py": (
+            "from src.live import live_fn\n"
+            "def main():\n"
+            "    live_fn('SELECT 1')\n"
+        ),
+        "src/entry.py": (
+            "from src.main import main\n"
+            "main()\n"
+        ),
+    }
+    for rel, contents in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(contents)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Launcher-side: pointer write
+# ---------------------------------------------------------------------------
+
+
+def test_agentic_launcher_writes_pointer_into_validate_dir(tmp_path):
+    """``_run_validate_postpass_unsafe`` writes the pointer file
+    with the expected fields before kicking off the subprocess.
+    Mocks subprocess and lifecycle; exercises the real pointer-
+    write path."""
+    target = _write_synthetic_project(tmp_path)
+    agentic_out = tmp_path / "agentic-out"
+    agentic_out.mkdir()
+    # Build a checklist at agentic_out/checklist.json so the
+    # launcher has something to point at.
+    from core.inventory import build_inventory
+    build_inventory(str(target), str(agentic_out))
+    assert (agentic_out / "checklist.json").is_file()
+
+    # Write a minimal valid analysis report so selection finds
+    # something. The selector reads ``results`` (not
+    # ``findings``) per the report's canonical schema.
+    analysis_report = agentic_out / "analysis-report.json"
+    analysis_report.write_text(json.dumps({
+        "results": [{
+            "id": "f1",
+            "vuln_type": "sql-injection",
+            "is_exploitable": True,
+            "confidence": "high",
+            "file": "src/dead.py",
+            "line": 2,
+        }],
+    }))
+
+    # Mock the subprocess so we observe what's in validate_dir
+    # at dispatch time. The mock's side_effect inspects the dir
+    # and stores the pointer contents for the test to assert on.
+    captured = {}
+
+    def _capture_dispatch(*args, **kwargs):
+        # The validate_dir is somewhere under raptor's out/. Find
+        # it via the captured target/output args. The sandbox_run
+        # call has output= pointing at validate_dir.
+        output_path = Path(kwargs.get("output", ""))
+        pointer_path = output_path / "parent-checklist-pointer.json"
+        if pointer_path.is_file():
+            captured["pointer"] = json.loads(pointer_path.read_text())
+            captured["validate_dir"] = output_path
+        # Return a fake successful CompletedProcess.
+        rc_mock = MagicMock()
+        rc_mock.returncode = 0
+        return rc_mock
+
+    # Mock just enough to bypass the LLM dispatch; the rest of
+    # the flow stays real. Patch ``shutil.which`` so claude
+    # appears to exist.
+    from core.orchestration import agentic_passes
+    with patch("core.orchestration.agentic_passes.sandbox_run",
+               side_effect=_capture_dispatch), \
+         patch("core.orchestration.agentic_passes.shutil.which",
+               return_value="/usr/bin/fake-claude"), \
+         patch("core.security.rule_of_two."
+               "require_interactive_for_agentic_pass"):
+        result = agentic_passes.run_validate_postpass(
+            target=target,
+            agentic_out_dir=agentic_out,
+            analysis_report=analysis_report,
+        )
+
+    if "pointer" not in captured:
+        # Test relies on the launcher reaching the dispatch
+        # stage. If lifecycle setup or any earlier check
+        # short-circuited, surface that for diagnostic.
+        raise AssertionError(
+            "subprocess was never dispatched — launcher "
+            "short-circuited before pointer-write. result="
+            f"{result}"
+        )
+
+    # Pointer carries all three documented fields.
+    pointer = captured["pointer"]
+    assert "checklist_path" in pointer
+    assert "expected_target_path" in pointer
+    assert "expected_root_dir" in pointer
+    # And they match what the orchestrator expects.
+    assert (
+        Path(pointer["checklist_path"])
+        == (agentic_out / "checklist.json").resolve()
+    )
+    assert (
+        Path(pointer["expected_target_path"]).resolve()
+        == target.resolve()
+    )
+    assert (
+        Path(pointer["expected_root_dir"]).resolve()
+        == agentic_out.resolve()
+    )
+
+
+# ---------------------------------------------------------------------------
+# E2E: launcher pointer write → orchestrator Stage 0 reuse → Stage B demote
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_pointer_drives_full_reuse_and_demotion(tmp_path):
+    """End-to-end: pointer written by the launcher's logic
+    drives /validate's Stage 0 to reuse, Stage B's demotion to
+    use the reused inventory, and produces the right verdict.
+
+    No subprocess hop — we wire the launcher's pointer-write
+    output directly into the orchestrator's input. This
+    exercises the data contract between the two halves on the
+    same inventory."""
+    target = _write_synthetic_project(tmp_path)
+
+    # Stage 1: simulate the launcher's pointer write.
+    agentic_out = tmp_path / "agentic-out"
+    agentic_out.mkdir()
+    from core.inventory import build_inventory
+    build_inventory(str(target), str(agentic_out))
+    parent_checklist = agentic_out / "checklist.json"
+
+    validate_workdir = tmp_path / "validate-out"
+    validate_workdir.mkdir()
+    pointer_path = validate_workdir / "parent-checklist-pointer.json"
+    pointer_path.write_text(json.dumps({
+        "checklist_path": str(parent_checklist.resolve()),
+        "expected_target_path": str(target),
+        "expected_root_dir": str(agentic_out.resolve()),
+    }))
+
+    # Stage 2: orchestrator's Stage 0 — must reuse, not build.
+    from packages.exploitability_validation.orchestrator import (
+        PipelineConfig,
+        ValidationOrchestrator,
+    )
+    config = PipelineConfig(
+        target_path=str(target),
+        workdir=str(validate_workdir),
+        vuln_type="sql-injection",
+    )
+    orchestrator = ValidationOrchestrator(config)
+
+    with patch(
+        "core.inventory.build_inventory",
+        side_effect=AssertionError(
+            "build_inventory must not be called — pointer should "
+            "have driven reuse"
+        ),
+    ):
+        orchestrator._run_stage_0()
+
+    # The reused checklist persisted to validate's own dir.
+    assert (validate_workdir / "checklist.json").is_file()
+    assert orchestrator.state.checklist is not None
+    file_paths = {
+        f["path"] for f in orchestrator.state.checklist["files"]
+    }
+    assert "src/dead.py" in file_paths
+    assert "src/live.py" in file_paths
+
+    # Stage 3: Stage B reuses the loaded inventory for demotion.
+    # Set up minimum state for Stage B.
+    orchestrator.state.findings = {
+        "stage": "A",
+        "findings": [
+            {
+                "id": "f-dead",
+                "status": "not_disproven",
+                "vuln_type": "sql-injection",
+                "file_path": "src/dead.py",
+                "start_line": 2,
+            },
+            {
+                "id": "f-live",
+                "status": "not_disproven",
+                "vuln_type": "sql-injection",
+                "file_path": "src/live.py",
+                "start_line": 2,
+            },
+        ],
+    }
+    orchestrator.state.attack_paths = [
+        {
+            "id": "p-dead",
+            "finding_id": "f-dead",
+            "proximity": 8,
+            "blockers": [],
+        },
+        {
+            "id": "p-live",
+            "finding_id": "f-live",
+            "proximity": 8,
+            "blockers": [],
+        },
+    ]
+    # Persist Stage B's input artefacts to disk — Stage B
+    # reloads them from disk and overwrites state if a file is
+    # missing (the orchestrator's resume-from-disk pattern).
+    orchestrator.state.save_json(
+        "attack-paths.json", orchestrator.state.attack_paths,
+    )
+    orchestrator.state.attack_surface = {"sources": [], "sinks": []}
+    orchestrator.state.save_json(
+        "attack-surface.json", orchestrator.state.attack_surface,
+    )
+    orchestrator.state.hypotheses = []
+    orchestrator.state.save_json(
+        "hypotheses.json", orchestrator.state.hypotheses,
+    )
+    orchestrator.state.disproven = []
+    orchestrator.state.save_json(
+        "disproven.json", orchestrator.state.disproven,
+    )
+    orchestrator.state.attack_tree = {"root": "x", "nodes": []}
+    orchestrator.state.save_json(
+        "attack-tree.json", orchestrator.state.attack_tree,
+    )
+
+    # The Stage B demotion must use state.checklist (reused) and
+    # NOT call build_inventory.
+    with patch(
+        "core.inventory.build_inventory",
+        side_effect=AssertionError(
+            "Stage B demotion built a fresh inventory despite "
+            "state.checklist being set"
+        ),
+    ):
+        orchestrator._run_stage_b()
+
+    # Demotion fired correctly: dead path has proximity=1 and
+    # the reachability blocker.
+    paths_by_id = {p["id"]: p for p in orchestrator.state.attack_paths}
+    assert paths_by_id["p-dead"]["proximity"] == 1
+    assert any(
+        "reachability:not_called" in b
+        for b in paths_by_id["p-dead"]["blockers"]
+    )
+    # Live path untouched.
+    assert paths_by_id["p-live"]["proximity"] == 8
+    assert paths_by_id["p-live"]["blockers"] == []

--- a/packages/exploitability_validation/orchestrator.py
+++ b/packages/exploitability_validation/orchestrator.py
@@ -560,7 +560,29 @@ class ValidationOrchestrator:
         return result
 
     def _run_stage_0(self) -> List[str]:
-        """Stage 0: Inventory - Build checklist of functions."""
+        """Stage 0: Inventory - Build checklist of functions.
+
+        When invoked from the agentic launcher's
+        ``run_validate_postpass``, the parent process's already-
+        built checklist (from ``run_reachability_prepass``) is
+        pointed at via ``parent-checklist-pointer.json`` in the
+        run dir. We reuse that instead of paying for another
+        full source-tree walk + AST parse — typical large repos
+        save 30-60s here, which dominates Stage 0 cost.
+        """
+        # Check for parent-process checklist pointer first.
+        reused = self._try_reuse_parent_checklist()
+        if reused is not None:
+            self.state.checklist = reused
+            path = self.state.save_json("checklist.json", reused)
+            total_files = reused.get("total_files", "?")
+            total_functions = reused.get("total_functions", "?")
+            logger.info(
+                f"Stage 0 reused parent checklist: "
+                f"{total_files} files, {total_functions} functions",
+            )
+            return [path]
+
         from core.inventory import build_inventory
 
         checklist = build_inventory(
@@ -574,6 +596,131 @@ class ValidationOrchestrator:
 
         logger.info(f"Stage 0 complete: {checklist['total_files']} files, {checklist['total_functions']} functions")
         return [path]
+
+    # Pointer-driven checklist reuse expires this many seconds
+    # after the parent checklist was last modified. The intended
+    # use case (agentic → /validate within the same run) takes
+    # seconds; a stale rerun against an existing agentic-out-dir
+    # might happen days later with source drifted underneath.
+    # 1 hour is generous for the live case, conservative for
+    # drift.
+    _PARENT_CHECKLIST_TTL_SECONDS = 3600
+
+    def _try_reuse_parent_checklist(self) -> Optional[Dict[str, Any]]:
+        """Look for a ``parent-checklist-pointer.json`` written by
+        a parent /agentic run. The pointer file's
+        ``checklist_path`` field points at the parent's
+        already-built checklist on disk; load it instead of
+        rebuilding.
+
+        Returns the loaded checklist dict on success; None on any
+        validation failure (graceful fallback to fresh build).
+
+        Validation gates:
+
+        1. Pointer file exists, is valid JSON, is a dict.
+        2. ``checklist_path`` field is a non-empty string.
+        3. ``expected_target_path`` (when present) resolves to
+           the same path as the run's ``target_path``.
+        4. ``expected_root_dir`` (when present) is a real
+           ancestor of ``checklist_path`` — defends against
+           a malicious or buggy pointer that points outside the
+           agentic run dir.
+        5. Checklist file's mtime is within
+           ``_PARENT_CHECKLIST_TTL_SECONDS``. Source drift over
+           a longer window invalidates the call-graph data;
+           rebuild rather than emit stale reachability verdicts.
+        6. Loaded data is a dict with a ``files`` list (basic
+           shape check).
+        """
+        pointer_path = (
+            Path(self.config.workdir) / "parent-checklist-pointer.json"
+        )
+        if not pointer_path.is_file():
+            return None
+        try:
+            pointer = self.state.load_json("parent-checklist-pointer.json")
+        except Exception:                           # noqa: BLE001
+            return None
+        if not isinstance(pointer, dict):
+            return None
+        checklist_path = pointer.get("checklist_path")
+        if not isinstance(checklist_path, str) or not checklist_path:
+            return None
+        try:
+            cp = Path(checklist_path).resolve()
+        except OSError:
+            return None
+        if not cp.is_file():
+            logger.debug(
+                "parent checklist pointer references missing file %s; "
+                "falling back to fresh build", cp,
+            )
+            return None
+        # Path-traversal hardening: when the pointer carries an
+        # ``expected_root_dir``, ``checklist_path`` must resolve
+        # underneath it. Defends against malicious / buggy
+        # pointers that try to point at /etc/passwd or other
+        # off-tree files. Optional — when absent (e.g. tests),
+        # the gate is skipped.
+        expected_root = pointer.get("expected_root_dir")
+        if isinstance(expected_root, str) and expected_root:
+            try:
+                root = Path(expected_root).resolve()
+                cp.relative_to(root)
+            except (OSError, ValueError):
+                logger.debug(
+                    "parent checklist pointer references file %s "
+                    "outside expected_root_dir %s; falling back to "
+                    "fresh build", cp, expected_root,
+                )
+                return None
+        # Target-path freshness: the pointer optionally carries
+        # ``expected_target_path``. Mismatch → checklist was
+        # built against a different repo; must rebuild.
+        expected = pointer.get("expected_target_path")
+        if isinstance(expected, str) and expected:
+            try:
+                if (
+                    Path(expected).resolve()
+                    != Path(self.config.target_path).resolve()
+                ):
+                    logger.debug(
+                        "parent checklist pointer references different "
+                        "target (%s vs %s); falling back to fresh build",
+                        expected, self.config.target_path,
+                    )
+                    return None
+            except OSError:
+                return None
+        # mtime-based TTL: stale rerun protection. The pointer
+        # mechanism is designed for back-to-back agentic →
+        # /validate flows (seconds apart). When the checklist is
+        # older than the TTL, source has likely drifted and the
+        # call-graph data could be wrong.
+        try:
+            import time
+            mtime = cp.stat().st_mtime
+            age_s = time.time() - mtime
+            if age_s > self._PARENT_CHECKLIST_TTL_SECONDS:
+                logger.debug(
+                    "parent checklist %s is %.0fs old (TTL %ds); "
+                    "falling back to fresh build",
+                    cp, age_s, self._PARENT_CHECKLIST_TTL_SECONDS,
+                )
+                return None
+        except OSError:
+            return None
+        try:
+            from core.json import load_json as _load_json
+            checklist = _load_json(cp)
+        except Exception:                           # noqa: BLE001
+            return None
+        if not isinstance(checklist, dict):
+            return None
+        if not isinstance(checklist.get("files"), list):
+            return None
+        return checklist
 
     def _run_stage_a(self) -> List[str]:
         """Stage A: One-Shot - Quick exploitability check."""
@@ -708,10 +855,17 @@ class ValidationOrchestrator:
         # it just sits at the bottom by proximity score.
         try:
             from .reachability import demote_unreachable_paths
+            # Reuse Stage 0's already-built inventory (or one
+            # loaded from a parent-process pointer; see Stage 0)
+            # rather than rebuilding. The checklist on
+            # ``self.state`` carries the same call_graph data
+            # ``demote_unreachable_paths`` would produce by
+            # building afresh.
             demoted = demote_unreachable_paths(
                 self.state.attack_paths or [],
                 self.state.findings.get("findings", []),
                 Path(self.config.target_path),
+                inventory=self.state.checklist,
             )
             if demoted:
                 # Attack paths were mutated in place; persist.

--- a/packages/exploitability_validation/tests/test_parent_checklist_pointer.py
+++ b/packages/exploitability_validation/tests/test_parent_checklist_pointer.py
@@ -1,0 +1,363 @@
+"""Tests for the parent-checklist-pointer mechanism — /validate's
+Stage 0 reuses the parent /agentic run's already-built checklist
+instead of rebuilding."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+
+def _make_orchestrator(tmp_path: Path):
+    """Construct a ValidationOrchestrator bound to a workdir
+    inside ``tmp_path``."""
+    from packages.exploitability_validation.orchestrator import (
+        PipelineConfig,
+        ValidationOrchestrator,
+    )
+    workdir = tmp_path / "validate-out"
+    workdir.mkdir()
+    target = tmp_path / "target"
+    target.mkdir()
+    config = PipelineConfig(
+        target_path=str(target),
+        workdir=str(workdir),
+        vuln_type="generic",
+    )
+    return ValidationOrchestrator(config), target, workdir
+
+
+def _write_pointer(workdir: Path, **fields) -> None:
+    (workdir / "parent-checklist-pointer.json").write_text(
+        json.dumps(fields)
+    )
+
+
+def _write_checklist(path: Path, files=None, **kwargs) -> None:
+    """Write a minimal but valid build_inventory-shaped checklist."""
+    data = {
+        "generated_at": "2026-05-07T00:00:00+00:00",
+        "target_path": kwargs.get("target_path", "/some/target"),
+        "total_files": 1,
+        "total_functions": 1,
+        "total_items": 1,
+        "files": files or [
+            {
+                "path": "src/x.py",
+                "language": "python",
+                "items": [{
+                    "name": "f", "kind": "function",
+                    "line_start": 1, "line_end": 1,
+                }],
+                "call_graph": {
+                    "imports": {}, "calls": [],
+                    "indirection": [], "getattr_targets": [],
+                },
+            },
+        ],
+    }
+    path.write_text(json.dumps(data))
+
+
+# ---------------------------------------------------------------------------
+# Pointer-driven reuse
+# ---------------------------------------------------------------------------
+
+
+def test_reuses_parent_checklist_when_pointer_present(tmp_path):
+    """Pointer file points at a valid checklist → Stage 0 loads
+    it instead of rebuilding."""
+    orchestrator, target, workdir = _make_orchestrator(tmp_path)
+
+    parent_checklist = tmp_path / "parent" / "checklist.json"
+    parent_checklist.parent.mkdir()
+    _write_checklist(parent_checklist, target_path=str(target))
+
+    _write_pointer(
+        workdir,
+        checklist_path=str(parent_checklist),
+        expected_target_path=str(target),
+    )
+
+    reused = orchestrator._try_reuse_parent_checklist()
+    assert reused is not None
+    assert "files" in reused
+    assert reused["files"][0]["path"] == "src/x.py"
+
+
+def test_returns_none_when_no_pointer(tmp_path):
+    """No pointer file → return None → Stage 0 falls back to
+    fresh build."""
+    orchestrator, _, _ = _make_orchestrator(tmp_path)
+    assert orchestrator._try_reuse_parent_checklist() is None
+
+
+def test_returns_none_when_pointer_malformed(tmp_path):
+    """Pointer file isn't valid JSON / isn't a dict → return None."""
+    orchestrator, _, workdir = _make_orchestrator(tmp_path)
+    (workdir / "parent-checklist-pointer.json").write_text(
+        "not json"
+    )
+    assert orchestrator._try_reuse_parent_checklist() is None
+
+
+def test_returns_none_when_checklist_path_missing(tmp_path):
+    """Pointer file present but ``checklist_path`` field absent
+    or wrong type → None."""
+    orchestrator, _, workdir = _make_orchestrator(tmp_path)
+    _write_pointer(workdir, expected_target_path="/some/target")
+    assert orchestrator._try_reuse_parent_checklist() is None
+
+
+def test_returns_none_when_referenced_file_missing(tmp_path):
+    """Pointer points at a file that doesn't exist → None."""
+    orchestrator, _, workdir = _make_orchestrator(tmp_path)
+    _write_pointer(
+        workdir,
+        checklist_path="/does/not/exist.json",
+    )
+    assert orchestrator._try_reuse_parent_checklist() is None
+
+
+def test_returns_none_when_referenced_file_malformed(tmp_path):
+    """Pointer points at a file that's not a valid checklist —
+    falls back to fresh build."""
+    orchestrator, _, workdir = _make_orchestrator(tmp_path)
+    bad = tmp_path / "bad-checklist.json"
+    bad.write_text(json.dumps({"not": "a checklist"}))
+    _write_pointer(workdir, checklist_path=str(bad))
+    assert orchestrator._try_reuse_parent_checklist() is None
+
+
+def test_freshness_check_rejects_different_target(tmp_path):
+    """Pointer's ``expected_target_path`` doesn't match this
+    run's target → don't reuse (the checklist was built against
+    a different repo)."""
+    orchestrator, _target, workdir = _make_orchestrator(tmp_path)
+    parent_checklist = tmp_path / "parent" / "checklist.json"
+    parent_checklist.parent.mkdir()
+    _write_checklist(parent_checklist)
+    _write_pointer(
+        workdir,
+        checklist_path=str(parent_checklist),
+        expected_target_path="/totally/different/target",
+    )
+    assert orchestrator._try_reuse_parent_checklist() is None
+
+
+def test_freshness_field_optional(tmp_path):
+    """When ``expected_target_path`` is absent, no check is
+    performed — reuse proceeds."""
+    orchestrator, target, workdir = _make_orchestrator(tmp_path)
+    parent_checklist = tmp_path / "parent" / "checklist.json"
+    parent_checklist.parent.mkdir()
+    _write_checklist(parent_checklist)
+    _write_pointer(workdir, checklist_path=str(parent_checklist))
+    reused = orchestrator._try_reuse_parent_checklist()
+    assert reused is not None
+
+
+# ---------------------------------------------------------------------------
+# TTL freshness gate
+# ---------------------------------------------------------------------------
+
+
+def test_stale_checklist_rejected_by_ttl(tmp_path):
+    """A checklist older than the TTL → don't reuse. Stale rerun
+    days later gets fresh build automatically."""
+    import os
+    orchestrator, target, workdir = _make_orchestrator(tmp_path)
+    parent_checklist = tmp_path / "parent" / "checklist.json"
+    parent_checklist.parent.mkdir()
+    _write_checklist(parent_checklist)
+    # Backdate the file by 2 hours (TTL is 1h).
+    old_time = parent_checklist.stat().st_mtime - 7200
+    os.utime(parent_checklist, (old_time, old_time))
+    _write_pointer(workdir, checklist_path=str(parent_checklist))
+    assert orchestrator._try_reuse_parent_checklist() is None
+
+
+def test_fresh_checklist_passes_ttl(tmp_path):
+    """A checklist within the TTL window is accepted."""
+    orchestrator, target, workdir = _make_orchestrator(tmp_path)
+    parent_checklist = tmp_path / "parent" / "checklist.json"
+    parent_checklist.parent.mkdir()
+    _write_checklist(parent_checklist)
+    # Default mtime = now, well within TTL.
+    _write_pointer(workdir, checklist_path=str(parent_checklist))
+    assert orchestrator._try_reuse_parent_checklist() is not None
+
+
+# ---------------------------------------------------------------------------
+# Path-traversal hardening (expected_root_dir)
+# ---------------------------------------------------------------------------
+
+
+def test_pointer_outside_expected_root_rejected(tmp_path):
+    """Pointer's ``checklist_path`` resolves OUTSIDE
+    ``expected_root_dir`` → reject. Defense-in-depth against a
+    malicious or buggy pointer pointing at off-tree files."""
+    orchestrator, target, workdir = _make_orchestrator(tmp_path)
+    # Outside-the-root checklist file.
+    outside = tmp_path / "outside" / "checklist.json"
+    outside.parent.mkdir()
+    _write_checklist(outside)
+    # expected_root_dir set to a different directory.
+    inside_root = tmp_path / "agentic-out"
+    inside_root.mkdir()
+    _write_pointer(
+        workdir,
+        checklist_path=str(outside),
+        expected_root_dir=str(inside_root),
+    )
+    assert orchestrator._try_reuse_parent_checklist() is None
+
+
+def test_pointer_inside_expected_root_accepted(tmp_path):
+    """Pointer's ``checklist_path`` resolves INSIDE
+    ``expected_root_dir`` → accepted."""
+    orchestrator, target, workdir = _make_orchestrator(tmp_path)
+    inside_root = tmp_path / "agentic-out"
+    inside_root.mkdir()
+    parent_checklist = inside_root / "checklist.json"
+    _write_checklist(parent_checklist)
+    _write_pointer(
+        workdir,
+        checklist_path=str(parent_checklist),
+        expected_root_dir=str(inside_root),
+    )
+    assert orchestrator._try_reuse_parent_checklist() is not None
+
+
+def test_expected_root_dir_field_optional(tmp_path):
+    """When ``expected_root_dir`` absent, no traversal check is
+    performed (back-compat for old pointers / tests)."""
+    orchestrator, target, workdir = _make_orchestrator(tmp_path)
+    parent_checklist = tmp_path / "parent" / "checklist.json"
+    parent_checklist.parent.mkdir()
+    _write_checklist(parent_checklist)
+    _write_pointer(workdir, checklist_path=str(parent_checklist))
+    assert orchestrator._try_reuse_parent_checklist() is not None
+
+
+# ---------------------------------------------------------------------------
+# Stage 0 integration
+# ---------------------------------------------------------------------------
+
+
+def test_stage_0_skips_build_inventory_when_pointer_valid(tmp_path):
+    """End-to-end: when the pointer is present and valid, Stage 0
+    does NOT call ``core.inventory.build_inventory``."""
+    orchestrator, target, workdir = _make_orchestrator(tmp_path)
+    parent_checklist = tmp_path / "parent" / "checklist.json"
+    parent_checklist.parent.mkdir()
+    _write_checklist(parent_checklist, target_path=str(target))
+    _write_pointer(
+        workdir,
+        checklist_path=str(parent_checklist),
+        expected_target_path=str(target),
+    )
+
+    from unittest.mock import patch
+    with patch(
+        "core.inventory.build_inventory",
+        side_effect=AssertionError(
+            "build_inventory must not be called when pointer is "
+            "valid — parent checklist should have been reused"
+        ),
+    ):
+        paths = orchestrator._run_stage_0()
+    # The reused checklist gets persisted to validate's own
+    # checklist.json so subsequent stages can load it.
+    assert (workdir / "checklist.json").is_file()
+    assert orchestrator.state.checklist is not None
+    assert orchestrator.state.checklist["files"][0]["path"] == "src/x.py"
+
+
+def test_stage_0_falls_back_to_build_when_pointer_invalid(tmp_path):
+    """When the pointer references a missing file, Stage 0 falls
+    back to ``build_inventory``."""
+    orchestrator, target, workdir = _make_orchestrator(tmp_path)
+    _write_pointer(
+        workdir,
+        checklist_path="/does/not/exist.json",
+    )
+
+    fake_inv = {"total_files": 0, "total_functions": 0, "files": []}
+    from unittest.mock import patch
+    with patch(
+        "core.inventory.build_inventory",
+        return_value=fake_inv,
+    ) as mock_build:
+        orchestrator._run_stage_0()
+    mock_build.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Stage B integration — demote_unreachable_paths uses state.checklist
+# ---------------------------------------------------------------------------
+
+
+def test_stage_b_passes_state_checklist_to_demotion(tmp_path):
+    """Stage B's demotion call should reuse ``state.checklist``
+    (built by Stage 0) instead of having
+    ``demote_unreachable_paths`` build a fresh inventory."""
+    from packages.exploitability_validation.orchestrator import (
+        PipelineConfig, PipelineState, ValidationOrchestrator,
+    )
+    orchestrator, target, workdir = _make_orchestrator(tmp_path)
+
+    # Set up the state Stage B needs.
+    orchestrator.state.checklist = {
+        "total_files": 1, "files": [
+            {
+                "path": "src/x.py",
+                "items": [{
+                    "name": "f", "kind": "function",
+                    "line_start": 1, "line_end": 1,
+                }],
+                "call_graph": {
+                    "imports": {}, "calls": [],
+                    "indirection": [], "getattr_targets": [],
+                },
+            },
+        ],
+    }
+    orchestrator.state.findings = {
+        "stage": "A",
+        "findings": [{
+            "id": "f1",
+            "status": "not_disproven",
+            "file_path": "src/x.py",
+            "start_line": 1,
+        }],
+    }
+    orchestrator.state.attack_paths = [{
+        "id": "p1",
+        "finding_id": "f1",
+        "proximity": 8,
+    }]
+    orchestrator.state.attack_surface = {"sources": [], "sinks": []}
+    orchestrator.state.hypotheses = []
+    orchestrator.state.disproven = []
+
+    # Capture what gets passed to demote_unreachable_paths.
+    captured = {}
+    from unittest.mock import patch
+
+    def _capture(attack_paths, findings, target_path, *, inventory=None):
+        captured["inventory"] = inventory
+        return 0
+
+    with patch(
+        "packages.exploitability_validation.reachability."
+        "demote_unreachable_paths",
+        side_effect=_capture,
+    ):
+        orchestrator._run_stage_b()
+
+    # The orchestrator should have passed state.checklist as the
+    # inventory kwarg.
+    assert captured["inventory"] is orchestrator.state.checklist


### PR DESCRIPTION
Closes the cross-process inventory-sharing gap noted in #363.

Stage 0 reads parent-checklist-pointer.json (written by the agentic launcher when invoking /validate as a subprocess) and reuses the parent's already-built checklist instead of rebuilding. Stage B reuses the same checklist via state passthrough.

Validation gates on the pointer:
* expected_target_path — repo identity match
* expected_root_dir — checklist_path must resolve under it (path-traversal hardening)
* mtime TTL (1h) — rejects checklists beyond freshness window for stale rerun protection

Combined: previously 3× inventory builds per agentic-with-validate run (prepass + Stage 0 + demotion); now 1× build, all stages reuse it. Saves 30-60s on typical large repos.

Adversarial review surfaced + fixed three real issues (content drift, path traversal, test gap).

18 tests covering pointer reuse, fallback paths, freshness + TTL, path-traversal hardening, launcher pointer-write, and a real cross-side E2E (launcher write → Stage 0 reuse → Stage B demotion against synthetic project).