### PR TITLE
chore(scripts): add explicit sys.path bootstrap to entry-point scripts

### DIFF
--- a/build_inventory.py
+++ b/build_inventory.py
@@ -10,6 +10,11 @@ Usage:
 
 import argparse
 import sys
+from pathlib import Path
+
+# build_inventory.py -> repo root. Belt + braces against subprocess
+# invocation under a sandboxed env that strips PYTHONPATH.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from core.inventory import build_inventory, format_coverage_summary
 

--- a/engine/semgrep/tools/sarif_merge.py
+++ b/engine/semgrep/tools/sarif_merge.py
@@ -5,6 +5,11 @@ Simple SARIF merger - combines multiple SARIF files into one.
 import sys
 from pathlib import Path
 
+# engine/semgrep/tools/sarif_merge.py -> repo root (4 levels up).
+# Needed when this is invoked as a subprocess under a sandboxed env
+# that strips PYTHONPATH and doesn't allowlist RAPTOR_DIR.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
 from core.json import save_json
 
 

--- a/generate_diagram.py
+++ b/generate_diagram.py
@@ -15,6 +15,10 @@ import argparse
 import sys
 from pathlib import Path
 
+# generate_diagram.py -> repo root. Belt + braces against subprocess
+# invocation under a sandboxed env that strips PYTHONPATH.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(

--- a/raptor.py
+++ b/raptor.py
@@ -42,6 +42,13 @@ import subprocess
 import sys
 from pathlib import Path
 
+# raptor.py -> repo root.
+# Belt + braces against subprocess invocation under a sandboxed env
+# that strips PYTHONPATH; today's "script-dir on sys.path[0]" default
+# happens to land on the repo root because we live here, but explicit
+# is safer than implicit.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
 from core.run.output import get_output_dir, TargetMismatchError
 from core.run.metadata import start_run, complete_run, fail_run
 from core.run.safe_io import safe_run_mkdir


### PR DESCRIPTION
Belt + braces against subprocess invocation under a sandboxed env that strips PYTHONPATH and doesn't allowlist RAPTOR_DIR — the same failure mode that left engine/semgrep/tools/sarif_merge.py unable to import core.* until this commit. Today raptor.py, build_inventory.py and generate_diagram.py all happen to work because Python puts the script's own dir on sys.path[0] and they live at repo root, but explicit is safer than implicit and protects future callers that move or re-host any of them.

sarif_merge.py also gets the bootstrap so it remains usable as a standalone tool.