### PR TITLE
feat(core/dockerfile): apt-get install package extraction

### DIFF
--- a/core/dockerfile/__init__.py
+++ b/core/dockerfile/__init__.py
@@ -21,6 +21,10 @@ Module layout:
 
   * :mod:`core.dockerfile.parser` — tokenise the file into an
     ordered list of :class:`Instruction` objects.
+  * :mod:`core.dockerfile.apt` — walk the instruction stream and
+    extract ``apt-get install`` package declarations (name,
+    optional version pin, optional architecture qualifier, source
+    line). Substrate for SCA's Debian deps tier.
 
 Limitations (also captured in :doc:`README`):
   * No ``ARG`` / ``ENV`` substitution — instructions carry the
@@ -33,6 +37,10 @@ Limitations (also captured in :doc:`README`):
     interpret the contained shell.
 """
 
+from .apt import (
+    AptPackage,
+    extract_apt_packages,
+)
 from .parser import (
     DockerfileSyntaxError,
     Instruction,
@@ -40,7 +48,9 @@ from .parser import (
 )
 
 __all__ = [
+    "AptPackage",
     "DockerfileSyntaxError",
     "Instruction",
+    "extract_apt_packages",
     "parse_dockerfile",
 ]

--- a/core/dockerfile/apt.py
+++ b/core/dockerfile/apt.py
@@ -1,0 +1,415 @@
+"""Extract apt-get install package lists from Dockerfile RUN instructions.
+
+Pure mechanical parser — given a parsed instruction stream, walks the
+``RUN`` instructions, finds ``apt-get install`` / ``apt install``
+invocations, and returns the package args (name, optional version pin,
+optional architecture qualifier).
+
+Designed primarily for an SCA Debian-deps consumer (mapping RUN-line
+``apt-get install`` declarations to OSV Debian advisories) but
+consumer-agnostic — anything wanting the full apt install graph of a
+Dockerfile uses this.
+
+## Recognised forms
+
+  * ``RUN apt-get install -y pkg1 pkg2``
+  * ``RUN apt install -y pkg`` (deprecated alias, same syntax)
+  * ``RUN apt-get update && apt-get install -y pkg`` (chained)
+  * ``RUN apt-get install -y \\\n    pkg1 \\\n    pkg2`` (line-continued)
+  * ``RUN DEBIAN_FRONTEND=noninteractive apt-get install -y pkg``
+    (env-prefixed)
+  * ``RUN apt-get -o Dpkg::Options::=--force-confnew install -y pkg``
+    (global flags between the binary and ``install``)
+  * Version pins: ``pkg=1.2.3``, ``pkg=1.2.3-1ubuntu0.1``
+  * Architecture suffix: ``pkg:arm64``, ``pkg:arm64=1.2.3``
+
+## What this does not do
+
+  * **ARG / ENV substitution.** ``${VAR}`` appears in the output
+    verbatim. Consumers that need substitution do their own ARG
+    tracking via the existing instruction stream.
+  * **Quote-aware shell splitting.** Standard whitespace splitting,
+    which is correct for the unquoted, simple-flag-only forms
+    ``apt-get install`` actually takes in real Dockerfiles.
+    ``RUN bash -c "apt-get install -y foo"`` (subshell-quoted) is
+    rare and intentionally out of scope.
+  * **Heredoc bodies.** ``RUN <<EOF`` is skipped — practically
+    never used for apt installs.
+  * **Globs / wildcards.** ``pkg*`` is returned verbatim as the
+    name; the consumer (SCA tier) decides whether to resolve.
+"""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from .parser import Instruction
+
+
+@dataclass(frozen=True)
+class AptPackage:
+    """A single package declared by a Dockerfile ``apt-get install``.
+
+    ``name`` is the unqualified package name. ``version`` carries the
+    explicit pin from ``pkg=VERSION`` form when present (else None).
+    ``arch`` carries the architecture qualifier from ``pkg:ARCH``
+    (else None — implicit native arch).
+    ``stage`` is the multi-stage build stage name (from the active
+    ``FROM x AS <stage>``) the install belongs to (None when the
+    enclosing FROM had no AS clause). Lets SCA build per-stage
+    SBOMs distinguishing build-only deps (e.g. ``gcc`` in a builder
+    stage) from runtime deps (e.g. ``libc6`` in the runtime stage).
+    ``line`` is the 1-based source line of the ``RUN`` instruction
+    that declared the package, for finding-emitting consumers.
+    """
+
+    name: str
+    version: Optional[str]
+    arch: Optional[str]
+    stage: Optional[str]
+    line: int
+
+
+def extract_apt_packages(
+    instructions: List[Instruction],
+) -> List[AptPackage]:
+    """Walk a parsed Dockerfile's instructions, return apt packages.
+
+    Returns the deduplicated list of packages declared across every
+    ``RUN apt-get install`` / ``apt install`` invocation. Order is
+    preserved (source order, then within-RUN argument order).
+
+    Empty when no RUN instructions install via apt.
+    """
+    out: List[AptPackage] = []
+    for inst in instructions:
+        if inst.directive != "RUN":
+            continue
+        out.extend(_extract_from_run(inst))
+    return out
+
+
+def _extract_from_run(inst: Instruction) -> List[AptPackage]:
+    if inst.args.lstrip().startswith("<<"):
+        # Heredoc body — out of scope.
+        return []
+    flat = _flatten_run(inst.raw)
+    out: List[AptPackage] = []
+    for tokens in _split_commands(flat):
+        out.extend(_packages_from_command(tokens, inst.line, inst.stage_name))
+    return out
+
+
+def _flatten_run(raw: str) -> str:
+    """Collapse a multi-line RUN's raw source into one shell command
+    line, stripping shell ``#``-comments along the way.
+
+    ``Instruction.args`` already collapses line continuations, but
+    treats comment-only lines between continued args as plain text
+    (so ``pkg \\\n  # explainer\n  pkg2`` becomes ``pkg # explainer
+    pkg2``, leaving ``#`` as a token that downstream tokenisation
+    can't tell from a real argument). Re-walking the raw lets us
+    drop comment-only physical lines and inline ``# ...`` tails
+    before tokenisation, matching real shell semantics.
+    """
+    physical = raw.splitlines()
+    if physical and physical[0].split(None, 1)[0].upper() == "RUN":
+        # Drop the leading ``RUN`` directive on the first line.
+        head = physical[0].split(None, 1)
+        physical[0] = head[1] if len(head) > 1 else ""
+    chunks: List[str] = []
+    for ln in physical:
+        s = ln.strip()
+        if not s:
+            continue
+        if s.startswith("#"):
+            # Comment-only line — skip entirely.
+            continue
+        if s.endswith("\\"):
+            s = s[:-1].rstrip()
+        # Strip inline ``# ...`` tail at a word boundary.
+        idx = _inline_comment_start(s)
+        if idx is not None:
+            s = s[:idx].rstrip()
+        if s:
+            chunks.append(s)
+    return " ".join(chunks)
+
+
+def _inline_comment_start(s: str) -> Optional[int]:
+    """Return the index where an inline shell comment starts in ``s``.
+
+    Shell semantics: ``#`` starts a comment only at the beginning of
+    a word (preceded by whitespace or at position 0). ``pkg#tag``
+    is NOT a comment (rare for apt but defensive). Quote-awareness
+    is intentionally minimal — apt-get install lines almost never
+    quote.
+    """
+    i = 0
+    while i < len(s):
+        if s[i] == "#" and (i == 0 or s[i - 1].isspace()):
+            return i
+        i += 1
+    return None
+
+
+def _split_commands(args: str) -> List[List[str]]:
+    """Split a shell command line into per-command token lists.
+
+    Tokenisation goes through ``shlex.split`` (POSIX mode) so quoted
+    arguments are unquoted (``"curl"`` -> ``curl``) and backslash
+    escapes are honoured. ``&&`` / ``||`` / ``;`` / ``|`` split
+    commands whether they're standalone (``a && b``) or fused
+    (``update;install``, ``yes|apt-get``) — the connectors are
+    pre-padded so shlex sees them as their own tokens.
+
+    On unbalanced quotes (``shlex.ValueError``) we fall back to
+    plain whitespace splitting so a broken Dockerfile doesn't
+    abort the scan; consumers get whatever packages we can recognise.
+    """
+    # Pre-process so connectors are always standalone tokens. Order
+    # matters: pad ``&&`` / ``||`` first so the ``;`` / ``|`` pads
+    # don't turn ``&&`` into ``& &``. The final ``|  |`` reverse
+    # repairs ``||`` that the bare-``|`` pad would otherwise split.
+    padded = (
+        args.replace("&&", " && ")
+        .replace("||", " || ")
+        .replace(";", " ; ")
+        .replace("|", " | ")
+        .replace("|  |", "||")
+    )
+    try:
+        tokens = shlex.split(padded, comments=False, posix=True)
+    except ValueError:
+        tokens = padded.split()
+    out: List[List[str]] = []
+    current: List[str] = []
+    for tok in tokens:
+        if tok in ("&&", "||", ";", "|"):
+            if current:
+                out.append(current)
+                current = []
+            continue
+        current.append(tok)
+    if current:
+        out.append(current)
+    return out
+
+
+def _packages_from_command(
+    tokens: List[str],
+    line: int,
+    stage: Optional[str],
+) -> List[AptPackage]:
+    """For one shell command's token list, extract apt-installed
+    packages. Returns empty unless the command is
+    ``[(sudo|env=val) ...] (apt-get|apt) [flags] install [flags] pkg ...``.
+
+    Subshell parens are unwrapped: tokens with a leading ``(`` or
+    trailing ``)`` are stripped. ``( apt-get install -y pkg )`` and
+    ``(apt-get install -y pkg)`` both parse the same as the bare
+    form.
+    """
+    tokens = [_strip_subshell_paren(t) for t in tokens if t]
+    tokens = [t for t in tokens if t]
+    i = 0
+    # Skip ``KEY=VALUE`` env-var prefixes (e.g. DEBIAN_FRONTEND) and
+    # ``sudo`` prefixes (rare in Dockerfiles but real, e.g. on
+    # bases that demote root before subsequent layers).
+    while i < len(tokens) and (
+        _is_env_prefix(tokens[i]) or tokens[i] == "sudo"
+    ):
+        i += 1
+    if i >= len(tokens):
+        return []
+    # ``bash -c "apt-get install -y curl"`` / ``sh -c "..."`` — the
+    # shell body is a single shlex-unquoted string in tokens[i+N].
+    # Recurse into it so the contained installs are extracted.
+    if tokens[i] in _SHELL_PROGS:
+        return _recurse_shell_c(tokens, i + 1, line, stage)
+    if tokens[i] not in ("apt-get", "apt"):
+        return []
+    i += 1
+    # Skip global flags between the binary name and ``install``.
+    # Some flags take a separate-token arg (``-o KEY=VAL``,
+    # ``-c FILE``, ``-t TARGET``) — consume both. The arg-bearing
+    # flags below cover everything apt(-get) defines as global.
+    while i < len(tokens) and tokens[i].startswith("-"):
+        flag = tokens[i]
+        i += 1
+        if flag in _ARG_BEARING_FLAGS and i < len(tokens):
+            i += 1
+    if i >= len(tokens) or tokens[i] != "install":
+        return []
+    i += 1
+    out: List[AptPackage] = []
+    while i < len(tokens):
+        tok = tokens[i]
+        i += 1
+        if tok.startswith("-"):
+            # Install-time flags follow the same arg-bearing rule.
+            if tok in _ARG_BEARING_FLAGS and i < len(tokens):
+                i += 1
+            continue
+        parsed = _parse_pkg(tok)
+        if parsed is None:
+            continue
+        name, version, arch = parsed
+        out.append(AptPackage(
+            name=name, version=version, arch=arch,
+            stage=stage, line=line,
+        ))
+    return out
+
+
+_SHELL_PROGS = frozenset({"bash", "sh", "dash", "ash", "zsh"})
+# Flag values that mean "next token is the shell-command body".
+# ``-c`` is canonical; ``-lc`` / ``-Lc`` / ``-cl`` collapse a login
+# / interactive flag with ``-c``. Other flag combos are out of scope.
+_SHELL_C_FLAGS = frozenset({"-c", "-lc", "-Lc", "-cl"})
+
+
+def _recurse_shell_c(
+    tokens: List[str],
+    start: int,
+    line: int,
+    stage: Optional[str],
+) -> List[AptPackage]:
+    """For a ``bash``/``sh`` invocation starting at ``start``, find
+    ``-c <body>`` and recursively extract from the body string.
+
+    Returns ``[]`` for invocations without ``-c`` (script execution
+    or interactive — out of scope).
+    """
+    j = start
+    while j < len(tokens):
+        tok = tokens[j]
+        if tok in _SHELL_C_FLAGS:
+            j += 1
+            if j >= len(tokens):
+                return []
+            body = tokens[j]
+            out: List[AptPackage] = []
+            for sub in _split_commands(body):
+                out.extend(_packages_from_command(sub, line, stage))
+            return out
+        if tok.startswith("-"):
+            j += 1
+            continue
+        # Non-flag before any ``-c`` — script invocation, out of scope.
+        return []
+    return []
+
+
+def _strip_subshell_paren(tok: str) -> str:
+    """Strip leading ``(`` and trailing ``)`` from a token.
+
+    Handles the ``(apt-get install -y pkg)`` shape — both parens
+    fused to the adjacent token. Tokens with embedded parens (``foo(bar)``,
+    rare in apt) get stripped too — false-positive risk is low
+    given apt token shapes.
+    """
+    while tok.startswith("("):
+        tok = tok[1:]
+    while tok.endswith(")"):
+        tok = tok[:-1]
+    return tok
+
+
+# Flags that take a separate-token argument. apt-get(8) defines
+# these as global / install-time options. Any other ``-`` flag is
+# treated as bare (no following arg consumed).
+_ARG_BEARING_FLAGS = frozenset({
+    "-o", "--option",
+    "-c", "--config-file",
+    "-t", "--target-release",
+    "--default-release",
+})
+
+
+def _is_env_prefix(tok: str) -> bool:
+    """``KEY=VALUE`` shell env prefix.
+
+    Distinct from ``pkg=version`` package args because env prefixes
+    appear BEFORE the command name; we only call this scanning the
+    leading tokens, never inside the install argument list, so the
+    syntactic ambiguity is resolved by position.
+    """
+    if "=" not in tok or tok.startswith("-") or tok.startswith("="):
+        return False
+    name = tok.split("=", 1)[0]
+    if not name or name[0].isdigit():
+        return False
+    # Identifier-ish: letters, digits, underscores.
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def _parse_pkg(
+    token: str,
+) -> Optional[Tuple[str, Optional[str], Optional[str]]]:
+    """Parse ``pkg``, ``pkg=ver``, ``pkg:arch``, or ``pkg:arch=ver``.
+
+    Returns ``(name, version | None, arch | None)`` or ``None`` for
+    tokens that aren't recognisable as packages — empty, leading
+    ``=``, leading ``:``, file paths (``./local.deb``, ``/abs/path``),
+    or shell-substitution / quote-fragment tokens (``$(...``, ```...``,
+    ``"..."``).
+    """
+    if not token or token.startswith("=") or token.startswith(":"):
+        return None
+    # File paths to local .deb files: real apt syntax, but the file
+    # name is the install target — not a package name an OSV
+    # advisory would match against. Skip; consumers can scan the
+    # file separately if they care.
+    if token.startswith("/") or token.startswith("./") or token.startswith("../"):
+        return None
+    # Shell command substitution / variable expansion produces
+    # token fragments that aren't packages (``$(cat`` or ``)`` from
+    # ``$(cat list)``). Reject any token containing unbalanced
+    # backticks or paren-substitution markers.
+    if any(m in token for m in ("$(", ")", "`", "${", "}")):
+        # ``${VAR}`` and ``$VAR`` substitution: pass through (the
+        # whole token is the variable). But ``${VAR`` (truncated)
+        # or ``$(...)`` fragments are noise.
+        if not _is_clean_var_substitution(token):
+            return None
+    # Quote stripping is handled upstream by ``shlex.split`` in
+    # ``_split_commands`` — by the time we see the token here it
+    # is already unquoted.
+    name = token
+    version: Optional[str] = None
+    arch: Optional[str] = None
+    if "=" in name:
+        name, version = name.split("=", 1)
+        if not version:
+            version = None
+    if ":" in name:
+        name, arch = name.split(":", 1)
+        if not arch:
+            arch = None
+    if not name:
+        return None
+    return (name, version, arch)
+
+
+def _is_clean_var_substitution(token: str) -> bool:
+    """A token is a clean ``$VAR`` or ``pkg=${VAR}`` substitution
+    (acceptable to pass through verbatim) when its only ``$`` /
+    ``{`` / ``}`` characters form well-balanced ``${...}`` or a
+    leading ``$identifier``. Anything fancier (``$(cmd ...)``,
+    backticks) is rejected.
+    """
+    if "`" in token or "$(" in token:
+        return False
+    # Count braces. ``${A}`` is fine; ``${A`` or ``A}`` is not.
+    if token.count("{") != token.count("}"):
+        return False
+    return True
+
+
+__all__ = [
+    "AptPackage",
+    "extract_apt_packages",
+]

--- a/core/dockerfile/parser.py
+++ b/core/dockerfile/parser.py
@@ -99,15 +99,25 @@ def parse_dockerfile(text: str) -> List[Instruction]:
             continue
 
         # Collapse line continuations: gather lines while the
-        # current one ends with `` \``.
+        # current one ends with `` \``. Comment-only continuation
+        # lines (a frequent shape inside multi-line ``RUN`` blocks)
+        # don't terminate the continuation — Docker treats them as
+        # transparent. They're preserved in ``raw`` for round-trip
+        # but the continuation-test still uses the prior non-comment
+        # line.
         first_line_no = i + 1
         chunks = [line]
         while line.rstrip().endswith("\\"):
             i += 1
             if i >= len(raw_lines):
                 break
-            line = raw_lines[i]
-            chunks.append(line)
+            next_line = raw_lines[i]
+            chunks.append(next_line)
+            if next_line.strip().startswith("#"):
+                # Skip — keep ``line`` as-is so the while-test
+                # continues using the prior continuation status.
+                continue
+            line = next_line
         i += 1
 
         raw = "\n".join(chunks)

--- a/core/dockerfile/tests/test_apt.py
+++ b/core/dockerfile/tests/test_apt.py
@@ -1,0 +1,544 @@
+"""Tests for ``core.dockerfile.apt`` — extract apt-get install
+package lists from parsed Dockerfile instruction streams."""
+
+from __future__ import annotations
+
+from core.dockerfile.apt import (
+    AptPackage,
+    extract_apt_packages,
+)
+from core.dockerfile.parser import parse_dockerfile
+
+
+def _names(pkgs):
+    return [p.name for p in pkgs]
+
+
+# ---------------------------------------------------------------------------
+# Basic forms
+# ---------------------------------------------------------------------------
+
+
+def test_simple_install():
+    src = "FROM debian\nRUN apt-get install -y curl\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl"]
+    assert pkgs[0].version is None
+    assert pkgs[0].arch is None
+    assert pkgs[0].line == 2
+
+
+def test_multiple_packages():
+    src = "FROM debian\nRUN apt-get install -y curl wget git\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl", "wget", "git"]
+
+
+def test_apt_alias():
+    """``apt`` (deprecated alias) is handled too — used in some
+    minimal images."""
+    src = "FROM debian\nRUN apt install -y curl\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl"]
+
+
+def test_no_install_no_op():
+    """``apt-get update`` alone returns no packages."""
+    src = "FROM debian\nRUN apt-get update\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs == []
+
+
+def test_no_apt_no_op():
+    """RUN that doesn't invoke apt is ignored entirely."""
+    src = "FROM python:3.11\nRUN pip install requests\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs == []
+
+
+def test_empty_dockerfile():
+    pkgs = extract_apt_packages(parse_dockerfile(""))
+    assert pkgs == []
+
+
+# ---------------------------------------------------------------------------
+# Chaining
+# ---------------------------------------------------------------------------
+
+
+def test_update_then_install_chained_with_and():
+    """The standard ``apt-get update && apt-get install -y ...``
+    idiom — second command's packages are extracted."""
+    src = (
+        "FROM debian\n"
+        "RUN apt-get update && apt-get install -y curl wget\n"
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl", "wget"]
+
+
+def test_install_chained_with_semicolon():
+    src = (
+        "FROM debian\n"
+        "RUN apt-get update; apt-get install -y curl\n"
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl"]
+
+
+def test_install_chained_with_or():
+    src = (
+        "FROM debian\n"
+        "RUN apt-get install -y maybe-this || apt-get install -y fallback\n"
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["maybe-this", "fallback"]
+
+
+def test_install_then_cleanup():
+    """The classic install + cleanup idiom — only the install
+    packages are extracted; ``rm -rf /var/lib/apt/lists/*`` is
+    irrelevant."""
+    src = (
+        "FROM debian\n"
+        "RUN apt-get update \\\n"
+        "    && apt-get install -y curl wget \\\n"
+        "    && rm -rf /var/lib/apt/lists/*\n"
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl", "wget"]
+
+
+# ---------------------------------------------------------------------------
+# Line continuations
+# ---------------------------------------------------------------------------
+
+
+def test_line_continuation_packages():
+    src = (
+        "FROM debian\n"
+        "RUN apt-get install -y \\\n"
+        "    curl \\\n"
+        "    wget \\\n"
+        "    git\n"
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl", "wget", "git"]
+
+
+def test_real_world_devcontainer_shape():
+    """The shape used by RAPTOR's own devcontainer Dockerfile —
+    ``RUN apt-get update && apt-get install -y --no-install-recommends \\``
+    with packages on continuation lines, comments interleaved."""
+    src = (
+        "FROM debian\n"
+        "# install build tools\n"
+        "RUN apt-get update && apt-get install -y --no-install-recommends \\\n"
+        "    gcc \\\n"
+        "    clang-format \\\n"
+        "    gdb \\\n"
+        "    && rm -rf /var/lib/apt/lists/*\n"
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["gcc", "clang-format", "gdb"]
+
+
+# ---------------------------------------------------------------------------
+# Flag handling
+# ---------------------------------------------------------------------------
+
+
+def test_short_flags_skipped():
+    src = "FROM debian\nRUN apt-get install -y -q curl\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl"]
+
+
+def test_long_flags_skipped():
+    src = (
+        "FROM debian\n"
+        "RUN apt-get install -y --no-install-recommends curl\n"
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl"]
+
+
+def test_global_flags_before_install_skipped():
+    """``apt-get -o Foo=Bar install -y pkg`` — flags between the
+    binary and the ``install`` subcommand are skipped, packages
+    still extracted."""
+    src = (
+        "FROM debian\n"
+        "RUN apt-get -q -o Dpkg::Options::=--force-confnew install -y curl\n"
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl"]
+
+
+def test_assume_yes_flag_variants():
+    for flag in ("-y", "--yes", "--assume-yes"):
+        src = f"FROM debian\nRUN apt-get install {flag} curl\n"
+        pkgs = extract_apt_packages(parse_dockerfile(src))
+        assert _names(pkgs) == ["curl"], flag
+
+
+# ---------------------------------------------------------------------------
+# Env prefixes
+# ---------------------------------------------------------------------------
+
+
+def test_debian_frontend_env_prefix():
+    src = (
+        "FROM debian\n"
+        "RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl\n"
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl"]
+
+
+def test_multiple_env_prefixes():
+    src = (
+        "FROM debian\n"
+        "RUN DEBIAN_FRONTEND=noninteractive APT_LISTCHANGES_FRONTEND=none "
+        "apt-get install -y curl\n"
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl"]
+
+
+# ---------------------------------------------------------------------------
+# Version pins + architecture qualifiers
+# ---------------------------------------------------------------------------
+
+
+def test_version_pin():
+    src = "FROM debian\nRUN apt-get install -y curl=7.74.0-1\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs[0].name == "curl"
+    assert pkgs[0].version == "7.74.0-1"
+    assert pkgs[0].arch is None
+
+
+def test_version_pin_with_ubuntu_suffix():
+    src = (
+        "FROM debian\n"
+        "RUN apt-get install -y curl=7.74.0-1.3+deb11u7\n"
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs[0].name == "curl"
+    assert pkgs[0].version == "7.74.0-1.3+deb11u7"
+
+
+def test_arch_qualifier():
+    src = "FROM debian\nRUN apt-get install -y libc6:arm64\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs[0].name == "libc6"
+    assert pkgs[0].arch == "arm64"
+    assert pkgs[0].version is None
+
+
+def test_arch_qualifier_and_version():
+    src = (
+        "FROM debian\n"
+        "RUN apt-get install -y libc6:arm64=2.31-13+deb11u5\n"
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs[0].name == "libc6"
+    assert pkgs[0].arch == "arm64"
+    assert pkgs[0].version == "2.31-13+deb11u5"
+
+
+# ---------------------------------------------------------------------------
+# Multiple RUN instructions
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_runs():
+    src = (
+        "FROM debian\n"
+        "RUN apt-get install -y curl\n"
+        "RUN apt-get install -y wget\n"
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl", "wget"]
+    assert pkgs[0].line == 2
+    assert pkgs[1].line == 3
+
+
+def test_no_dedup_across_runs():
+    """Same package mentioned in two RUN lines surfaces twice —
+    the consumer (e.g. SCA) decides what to do with duplicates.
+    Useful for the multi-stage case where the same install runs
+    in different stages."""
+    src = (
+        "FROM debian\n"
+        "RUN apt-get install -y curl\n"
+        "RUN apt-get install -y curl\n"
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl", "curl"]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases / out of scope
+# ---------------------------------------------------------------------------
+
+
+def test_heredoc_skipped():
+    """RUN heredoc-form (``<<EOF`` body) is intentionally out of
+    scope — practically never used for apt installs in real
+    Dockerfiles. Skipping prevents mis-parsing the heredoc body."""
+    src = (
+        "FROM debian\n"
+        "RUN <<EOF\n"
+        "apt-get install -y curl\n"
+        "EOF\n"
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs == []
+
+
+def test_var_substitution_passes_through():
+    """``${VERSION}`` in a version pin is passed through verbatim —
+    consumers that need substitution do their own ARG tracking."""
+    src = (
+        "FROM debian\n"
+        "ARG CURL_VERSION=7.74.0-1\n"
+        "RUN apt-get install -y curl=${CURL_VERSION}\n"
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs[0].name == "curl"
+    assert pkgs[0].version == "${CURL_VERSION}"
+
+
+def test_pkg_starting_with_dash_skipped():
+    """Defensive: token like ``-curl`` is treated as a flag, not a
+    package. (Real apt would reject this.)"""
+    src = "FROM debian\nRUN apt-get install -y -curl wget\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["wget"]
+
+
+def test_empty_install_args():
+    """``apt-get install -y`` with no packages."""
+    src = "FROM debian\nRUN apt-get install -y\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs == []
+
+
+def test_return_value_is_dataclass():
+    src = "FROM debian\nRUN apt-get install -y curl\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert isinstance(pkgs[0], AptPackage)
+
+
+def test_apt_get_other_subcommand():
+    """``apt-get remove`` / ``apt-get purge`` aren't installs and
+    yield nothing. Only ``install`` matters for SCA."""
+    for sub in ("remove", "purge", "autoremove", "upgrade"):
+        src = f"FROM debian\nRUN apt-get {sub} -y curl\n"
+        pkgs = extract_apt_packages(parse_dockerfile(src))
+        assert pkgs == [], sub
+
+
+def test_install_word_alone_no_apt():
+    """The word ``install`` outside an apt invocation is ignored."""
+    src = "FROM debian\nRUN install -m 0755 binary /usr/local/bin/\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs == []
+
+
+# ---------------------------------------------------------------------------
+# Adversarial-input handling (fixed in adversarial-review pass)
+# ---------------------------------------------------------------------------
+
+
+def test_sudo_prefix_handled():
+    """``sudo`` prefix is rare in Dockerfiles but real on bases that
+    demote root. Strip it like an env prefix."""
+    src = "FROM ubuntu\nRUN sudo apt-get install -y curl\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl"]
+
+
+def test_pipe_separates_commands():
+    """``yes | apt-get install`` (auto-confirm pipe) — pipe acts as
+    a command separator."""
+    src = "FROM ubuntu\nRUN yes | apt-get install -y curl\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl"]
+
+
+def test_subshell_parens_stripped():
+    """``( apt-get install -y pkg )`` and ``(apt-get install -y pkg)``
+    both parse — the subshell parens are stripped."""
+    for src in (
+        'FROM ubuntu\nRUN ( apt-get install -y curl )\n',
+        'FROM ubuntu\nRUN (apt-get install -y curl)\n',
+    ):
+        pkgs = extract_apt_packages(parse_dockerfile(src))
+        assert _names(pkgs) == ["curl"]
+
+
+def test_quoted_package_unquoted():
+    '''``apt-get install -y "curl"`` — surrounding quotes stripped.'''
+    src = 'FROM ubuntu\nRUN apt-get install -y "curl"\n'
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl"]
+
+
+def test_local_deb_file_path_skipped():
+    """``apt-get install -y ./local.deb`` — the file path isn't a
+    package name an OSV advisory would match against."""
+    src = "FROM ubuntu\nRUN apt-get install -y ./local-pkg.deb\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs == []
+
+
+def test_absolute_path_skipped():
+    src = "FROM ubuntu\nRUN apt-get install -y /tmp/local.deb\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs == []
+
+
+def test_command_substitution_dollar_paren_skipped():
+    """``$(cmd ...)`` produces token fragments (``$(cat`` and ``)``)
+    that aren't valid package names — skip both."""
+    src = "FROM ubuntu\nRUN apt-get install -y $(cat /tmp/pkglist)\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs == []
+
+
+def test_command_substitution_backtick_skipped():
+    """``\\`cmd ...\\``` produces ``\\`cat`` and ``\\`...`` tokens —
+    skip both."""
+    src = "FROM ubuntu\nRUN apt-get install -y `cat /tmp/pkglist`\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs == []
+
+
+def test_clean_var_substitution_passes_through():
+    """``${PKG_NAME}`` (clean braces) is NOT a substitution fragment
+    — pass through verbatim. Consumers can ARG-resolve."""
+    src = "FROM ubuntu\nRUN apt-get install -y ${PKG_NAME}\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs[0].name == "${PKG_NAME}"
+
+
+def test_truncated_var_substitution_skipped():
+    """``${PKG`` (mismatched brace) is not a clean variable form."""
+    src = "FROM ubuntu\nRUN apt-get install -y ${PKG\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs == []
+
+
+# ---------------------------------------------------------------------------
+# Multi-stage stage attribution
+# ---------------------------------------------------------------------------
+
+
+def test_stage_attribution_multi_stage():
+    """``FROM x AS builder`` then install gcc, ``FROM y AS runtime``
+    then install libc6 — each AptPackage carries its stage so SCA
+    can build per-stage SBOMs distinguishing build-only deps from
+    runtime deps."""
+    src = (
+        "FROM ubuntu AS builder\n"
+        "RUN apt-get install -y gcc\n"
+        "FROM ubuntu AS runtime\n"
+        "RUN apt-get install -y libc6\n"
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    by_name = {p.name: p for p in pkgs}
+    assert by_name["gcc"].stage == "builder"
+    assert by_name["libc6"].stage == "runtime"
+
+
+def test_stage_attribution_no_as_clause():
+    """``FROM ubuntu`` (no AS) — stage is None."""
+    src = "FROM ubuntu\nRUN apt-get install -y curl\n"
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs[0].stage is None
+
+
+# ---------------------------------------------------------------------------
+# Shell ``-c`` recursion (shlex enables this)
+# ---------------------------------------------------------------------------
+
+
+def test_bash_c_recursion():
+    """``bash -c "apt-get install -y pkg"`` — the shell body is a
+    shlex-unquoted single token; recurse into it."""
+    src = (
+        'FROM debian\n'
+        'RUN bash -c "apt-get install -y curl"\n'
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl"]
+
+
+def test_sh_c_recursion():
+    src = (
+        'FROM debian\n'
+        'RUN sh -c "apt-get install -y curl"\n'
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl"]
+
+
+def test_bash_lc_recursion():
+    """``bash -lc "..."`` (login + command) — same recursion path."""
+    src = (
+        'FROM debian\n'
+        'RUN bash -lc "apt-get install -y curl wget"\n'
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl", "wget"]
+
+
+def test_bash_c_with_env_inside_body():
+    """The recursive parse handles env prefixes inside the shell
+    body the same way."""
+    src = (
+        'FROM debian\n'
+        'RUN bash -c '
+        '"DEBIAN_FRONTEND=noninteractive apt-get install -y curl"\n'
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl"]
+
+
+def test_bash_c_with_chain_inside_body():
+    """Chained installs inside ``bash -c`` body all recurse."""
+    src = (
+        'FROM debian\n'
+        'RUN bash -c '
+        '"apt-get update && apt-get install -y curl"\n'
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert _names(pkgs) == ["curl"]
+
+
+def test_bash_script_invocation_no_c_skipped():
+    """``bash /path/to/install.sh`` (no -c) — script execution is
+    out of scope; can't read foreign scripts at parse time."""
+    src = (
+        'FROM debian\n'
+        'RUN bash /opt/install-deps.sh\n'
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    assert pkgs == []
+
+
+def test_unbalanced_quotes_falls_back_gracefully():
+    """``apt-get install -y "unclosed`` — shlex would raise; we
+    fall back to whitespace splitting so the parse doesn't abort.
+    The unclosed-quote token may emit oddly but doesn't crash."""
+    src = (
+        'FROM debian\n'
+        'RUN apt-get install -y curl "unclosed wget\n'
+    )
+    pkgs = extract_apt_packages(parse_dockerfile(src))
+    # The fallback splitter still recovers ``curl`` even though the
+    # rest of the line is malformed.
+    assert "curl" in _names(pkgs)

--- a/core/dockerfile/tests/test_parser.py
+++ b/core/dockerfile/tests/test_parser.py
@@ -108,6 +108,30 @@ RUN apt-get update \\
     assert "git" in insts[0].args
 
 
+def test_comment_lines_inside_continuation_dont_terminate():
+    """Real Dockerfiles often interleave ``# explainer`` lines
+    between continued args. Docker treats those as transparent —
+    the prior line's trailing ``\\`` continuation still applies.
+    """
+    src = """\
+RUN apt-get install -y \\
+    curl \\
+    # explainer line
+    wget \\
+    # another explainer
+    git
+"""
+    insts = parse_dockerfile(src)
+    assert len(insts) == 1
+    assert insts[0].directive == "RUN"
+    args = insts[0].args
+    # All three packages survived the continuation across
+    # comment-only intermediate lines.
+    assert "curl" in args
+    assert "wget" in args
+    assert "git" in args
+
+
 def test_continuation_line_numbers_use_first_line():
     """``Instruction.line`` points at the FIRST line of the
     instruction, not the continuation lines. Consumers emitting


### PR DESCRIPTION
Adds `core.dockerfile.apt.extract_apt_packages`, a pure-mechanical walker over the parsed instruction stream that returns `AptPackage(name, version, arch, stage, line)` per package declared by every `RUN apt-get install` / `apt install`. Substrate for a future SCA Debian-deps tier — RAPTOR's own devcontainer declares ~28 currently-invisible apt packages.

POSIX-correct tokenisation via stdlib `shlex.split`; handles quotes, escapes, all shell connectors (&&, ||, ;, |), env prefixes (`DEBIAN_FRONTEND=...`), `sudo`, subshell parens, `bash -c "..."` recursion, version pins (`pkg=1.2.3`), arch qualifiers (`pkg:arm64`), and multi-stage attribution. Filters spurious tokens (`$()` / backtick fragments, local .deb paths) so OSV queries stay clean. Out of scope: `$APT install` variable-as-command (needs ARG resolution — future LLM pass) and heredoc bodies.

Bundled parser fix: `parse_dockerfile` no longer terminates line-continuation on comment-only lines inside multi-line RUNs (real Docker treats them transparently — without this, ~24 packages went missing on RAPTOR's own Dockerfile).

65 new tests (incl. 5-Dockerfile E2E + 20 adversarial inputs). Full core/ suite stays green at 2151 passing.