### PR TITLE
feat(iris): Tier 1 pre-flight gate before LLM deep dataflow validation

### DIFF
--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -658,45 +658,79 @@ class AutonomousSecurityAgentV2:
 
             # Deep dataflow validation for high-confidence findings
             if vuln.has_dataflow and vuln.exploitable:
-                logger.info("\n" + "─" * 70)
-                logger.info("🔍 Performing DEEP DATAFLOW VALIDATION...")
-                logger.info("─" * 70)
+                # IRIS Tier 1 pre-flight — same pattern as the
+                # `generate_exploit` gate below. A free CodeQL refutation
+                # short-circuits the LLM-backed deep validation entirely.
+                # Reuses the cached Tier 1 verdict if `validate_dataflow_claims`
+                # already ran (the /agentic --validate-dataflow path);
+                # otherwise discovers DBs lazily and runs Tier 1 against
+                # this finding. Inconclusive / confirmed / no_check fall
+                # through and the LLM call proceeds as before.
+                gate = self._tier1_pre_flight(vuln)
+                if gate == "refuted":
+                    logger.info(
+                        f"⚠️  IRIS Tier 1 refuted dataflow for "
+                        f"{vuln.rule_id} at "
+                        f"{vuln.file_path}:{vuln.start_line} — "
+                        f"skipping LLM deep validation"
+                    )
+                    vuln.exploitable = False
+                    vuln.exploitability_score = 0.0
+                    # Record the verdict in the same shape the LLM-backed
+                    # validation would, so downstream consumers (report
+                    # rendering, _tier1_pre_flight cache reuse from
+                    # `generate_exploit`) see a consistent dataflow_validation
+                    # record.
+                    analysis["dataflow_validation"] = {
+                        "verdict": "refuted",
+                        "tier": "iris_tier1",
+                        "false_positive": True,
+                        "false_positive_reason": (
+                            "iris_tier1_refuted: LocalFlowSource query "
+                            "found no path; LLM deep validation skipped"
+                        ),
+                        "is_exploitable": False,
+                    }
+                else:
+                    logger.info("\n" + "─" * 70)
+                    logger.info("🔍 Performing DEEP DATAFLOW VALIDATION...")
+                    logger.info("─" * 70)
 
-                validation = self.validate_dataflow(vuln)
+                    validation = self.validate_dataflow(vuln)
 
-                if validation:
-                    # Update exploitability based on validation
-                    if validation.get('false_positive'):
-                        logger.info(f"⚠️  Validation marked as FALSE POSITIVE:")
-                        logger.info(f"    Reason: {validation.get('false_positive_reason')}")
-                        vuln.exploitable = False
-                        vuln.exploitability_score = 0.0
-                    elif not validation.get('is_exploitable'):
-                        logger.info(f"⚠️  Validation determined NOT EXPLOITABLE:")
-                        logger.info(f"    Reason: {(validation.get('exploitability_reasoning') or '')[:150]}")
-                        vuln.exploitable = False
-                        # Same null-vs-missing distinction as the
-                        # log site above — explicit None from the
-                        # LLM crashes `None * 0.5`.
-                        _conf = validation.get('exploitability_confidence')
-                        if _conf is None:
-                            _conf = 0.0
-                        vuln.exploitability_score = _conf * 0.5
-                    else:
-                        # Validation confirms exploitability
-                        logger.info(f"✓ Validation confirms EXPLOITABLE")
-                        # Use validation confidence to refine score —
-                        # fall back to existing score if missing OR
-                        # explicit null (max(float, None) → TypeError).
-                        _conf = validation.get('exploitability_confidence')
-                        if _conf is None:
-                            _conf = vuln.exploitability_score
-                        vuln.exploitability_score = max(
-                            vuln.exploitability_score, _conf,
-                        )
+                    if validation:
+                        # Update exploitability based on validation
+                        if validation.get('false_positive'):
+                            logger.info(f"⚠️  Validation marked as FALSE POSITIVE:")
+                            logger.info(f"    Reason: {validation.get('false_positive_reason')}")
+                            vuln.exploitable = False
+                            vuln.exploitability_score = 0.0
+                        elif not validation.get('is_exploitable'):
+                            logger.info(f"⚠️  Validation determined NOT EXPLOITABLE:")
+                            logger.info(f"    Reason: {(validation.get('exploitability_reasoning') or '')[:150]}")
+                            vuln.exploitable = False
+                            # Same null-vs-missing distinction as the
+                            # log site above — explicit None from the
+                            # LLM crashes `None * 0.5`.
+                            _conf = validation.get('exploitability_confidence')
+                            if _conf is None:
+                                _conf = 0.0
+                            vuln.exploitability_score = _conf * 0.5
+                        else:
+                            # Validation confirms exploitability
+                            logger.info(f"✓ Validation confirms EXPLOITABLE")
+                            # Use validation confidence to refine score —
+                            # fall back to existing score if missing OR
+                            # explicit null (max(float, None) → TypeError).
+                            _conf = validation.get('exploitability_confidence')
+                            if _conf is None:
+                                _conf = vuln.exploitability_score
+                            vuln.exploitability_score = max(
+                                vuln.exploitability_score, _conf,
+                            )
 
-                    # Store validation in analysis
-                    analysis['dataflow_validation'] = validation
+                        # Store validation in analysis
+                        analysis['dataflow_validation'] = validation
 
             # Save detailed analysis
             analysis_file = self.out_dir / "analysis" / f"{vuln.finding_id}.json"

--- a/packages/llm_analysis/tests/test_iris_reuse.py
+++ b/packages/llm_analysis/tests/test_iris_reuse.py
@@ -335,6 +335,145 @@ class TestExploitGenGate:
         mock_gate.assert_not_called()
 
 
+# ----- /analyze (validate_dataflow) Tier 1 gate ------------------------
+
+
+class TestValidateDataflowGate:
+    """`agent.analyze_vulnerability` skips the LLM-backed
+    `validate_dataflow` deep-validation call when Tier 1 returns
+    `refuted`. Same shape as the `generate_exploit` gate: free CodeQL
+    refutation short-circuits an expensive LLM call. Affects /analyze,
+    /agentic without --validate-dataflow, /patch.
+    """
+
+    def _make_vuln(self):
+        v = MagicMock()
+        v.exploitable = True
+        v.has_dataflow = True
+        v.rule_id = "py/command-injection"
+        v.file_path = "src/x.py"
+        v.start_line = 10
+        v.end_line = 12
+        v.level = "error"
+        v.message = "command injection"
+        v.full_code = "subprocess.run(sys.argv[1])"
+        v.surrounding_context = ""
+        v.dataflow_source = {"code": "sys.argv", "file": "src/x.py", "line": 1}
+        v.dataflow_sink = {"code": "subprocess.run", "file": "src/x.py", "line": 10}
+        v.dataflow_steps = []
+        v.sanitizers_found = []
+        v.repo_path = Path("/repo")
+        v.finding = {
+            "finding_id": "F1", "tool": "semgrep",
+            "rule_id": "raptor.injection.command-shell",
+            "file_path": "src/x.py", "start_line": 10, "cwe_id": "CWE-78",
+        }
+        v.finding_id = "F1"
+        v.analysis = None
+        v.read_vulnerable_code = MagicMock(return_value=True)
+        v.extract_dataflow = MagicMock(return_value=True)
+        return v
+
+    def _agent(self, tmp_path):
+        from packages.llm_analysis.agent import AutonomousSecurityAgentV2
+        return AutonomousSecurityAgentV2(
+            repo_path=tmp_path / "repo",
+            out_dir=tmp_path / "out",
+            prep_only=True,
+        )
+
+    def _llm_analysis_response(self, is_exploitable=True):
+        """Stand-in for the LLM analysis dict the schema validator
+        would produce on success."""
+        return {
+            "is_exploitable": is_exploitable,
+            "exploitability_score": 0.8,
+            "severity_assessment": "high",
+            "reasoning": "stub",
+        }
+
+    def test_refuted_skips_validate_dataflow(self, tmp_path):
+        agent = self._agent(tmp_path)
+        v = self._make_vuln()
+        analysis = self._llm_analysis_response(is_exploitable=True)
+
+        # Wire the LLM chain so analyze_vulnerability reaches the gate
+        # with vuln.exploitable=True and vuln.has_dataflow=True.
+        agent.llm = MagicMock()
+        agent.llm.generate_structured.return_value = (analysis, None)
+
+        with patch(
+            "core.llm.response_validation.validate_structured_response",
+        ) as mock_validate, patch.object(
+            agent, "_tier1_pre_flight", return_value="refuted",
+        ), patch.object(
+            agent, "validate_dataflow",
+        ) as mock_validate_df:
+            mock_validate.return_value = MagicMock(
+                data=analysis, quality=1.0, incomplete=False,
+            )
+            agent.analyze_vulnerability(v)
+
+        # The expensive LLM call must NOT have fired
+        mock_validate_df.assert_not_called()
+        # Finding marked unexploitable, with the refute marker in the
+        # dataflow_validation record so `_tier1_pre_flight` cache reuse
+        # works in the subsequent generate_exploit step.
+        assert v.exploitable is False
+        assert v.exploitability_score == 0.0
+        assert v.analysis["dataflow_validation"]["verdict"] == "refuted"
+        assert "iris_tier1_refuted" in (
+            v.analysis["dataflow_validation"]["false_positive_reason"] or ""
+        )
+
+    def test_inconclusive_proceeds_to_validate_dataflow(self, tmp_path):
+        agent = self._agent(tmp_path)
+        v = self._make_vuln()
+        analysis = self._llm_analysis_response(is_exploitable=True)
+
+        agent.llm = MagicMock()
+        agent.llm.generate_structured.return_value = (analysis, None)
+
+        with patch(
+            "core.llm.response_validation.validate_structured_response",
+        ) as mock_validate, patch.object(
+            agent, "_tier1_pre_flight", return_value="inconclusive",
+        ), patch.object(
+            agent, "validate_dataflow", return_value={"is_exploitable": True},
+        ) as mock_validate_df:
+            mock_validate.return_value = MagicMock(
+                data=analysis, quality=1.0, incomplete=False,
+            )
+            agent.analyze_vulnerability(v)
+
+        # Inconclusive does NOT block the LLM validation
+        mock_validate_df.assert_called_once()
+
+    def test_no_check_proceeds_to_validate_dataflow(self, tmp_path):
+        """`no_check` (no DB, no query, etc.) means the gate couldn't
+        run. Caller must NOT be gated — same as pre-PR-G+ behaviour."""
+        agent = self._agent(tmp_path)
+        v = self._make_vuln()
+        analysis = self._llm_analysis_response(is_exploitable=True)
+
+        agent.llm = MagicMock()
+        agent.llm.generate_structured.return_value = (analysis, None)
+
+        with patch(
+            "core.llm.response_validation.validate_structured_response",
+        ) as mock_validate, patch.object(
+            agent, "_tier1_pre_flight", return_value="no_check",
+        ), patch.object(
+            agent, "validate_dataflow", return_value={"is_exploitable": True},
+        ) as mock_validate_df:
+            mock_validate.return_value = MagicMock(
+                data=analysis, quality=1.0, incomplete=False,
+            )
+            agent.analyze_vulnerability(v)
+
+        mock_validate_df.assert_called_once()
+
+
 # ----- /codeql analyze_iris_packs --------------------------------------
 
 


### PR DESCRIPTION
`agent.analyze_vulnerability` calls `validate_dataflow` (an LLM-backed deep validation) for every finding with `has_dataflow and exploitable`. Until now that LLM call fired even when IRIS Tier 1 had already refuted the dataflow claim — wasted tokens, same bug Tier 1 was designed to catch elsewhere.

Adds the same `_tier1_pre_flight` gate that `generate_exploit` already uses (PR #349). When Tier 1 returns "refuted":
  - Skip the LLM `validate_dataflow` call entirely
  - Mark the finding as not exploitable
  - Record a `dataflow_validation` block with the iris_tier1_refuted marker, in the same shape the LLM-backed validation would produce. Downstream consumers (report rendering, the cache reuse in `_tier1_pre_flight` from the subsequent `generate_exploit` call) see a consistent record either way.

Inconclusive / confirmed / no_check fall through and the LLM call proceeds as before — same fail-open semantics as the exploit-gen gate.

Affects:
  - /analyze (runs `agent.py` directly on existing SARIF)
  - /agentic without --validate-dataflow (the orchestrator's `validate_dataflow_claims` doesn't fire, but per-finding LLM `validate_dataflow` still does)
  - /patch (runs through agentic)

Cost saved per refuted finding: one ANALYSE-class LLM call, typically the largest single LLM cost per finding in the analysis phase.

Tests: TestValidateDataflowGate (3 tests) — refuted skips the LLM call and writes the iris_tier1_refuted record; inconclusive and no_check proceed to the LLM call as before.