### PR TITLE
core/llm: route Provider construction through dispatcher when present

### DIFF
--- a/core/llm/detection.py
+++ b/core/llm/detection.py
@@ -469,11 +469,23 @@ def detect_llm_availability() -> LLMAvailability:
 
     has_cloud_keys = has_anthropic or has_openai or has_gemini or has_mistral
 
+    # Phase B credential-isolation: a worker spawned via the
+    # dispatcher has ``RAPTOR_LLM_SOCKET`` set but no API keys in
+    # env (post-Phase-C this is the steady state). The dispatcher
+    # itself was constructed in the parent against the parent's
+    # keys, so external-LLM access is in fact available via the
+    # UDS — count it as ``external_llm`` for downstream gating
+    # (Phase 4 orchestration in raptor_agentic.py, the ``--prep-only``
+    # decision in agent.py, etc.). Without this, Phase C would
+    # silently degrade ``--sequential`` runs to ClaudeCodeProvider /
+    # manual-review even though the operator configured an API key.
+    has_dispatcher_route = bool(os.getenv("RAPTOR_LLM_SOCKET"))
+
     # Check config file for models with valid keys (no import from config.py
     # needed — just check if any model entry has an API key, either inline
     # or via env var for its provider)
     has_config_file = False
-    if not has_cloud_keys:
+    if not has_cloud_keys and not has_dispatcher_route:
         has_config_file = _config_has_keyed_models()
 
     # Check Ollama reachability (requires OpenAI SDK for API calls)
@@ -484,7 +496,9 @@ def detect_llm_availability() -> LLMAvailability:
     claude_on_path = shutil.which("claude") is not None
     claude_code = in_claude_code or claude_on_path
 
-    external_llm = has_cloud_keys or has_config_file or has_ollama
+    external_llm = (
+        has_cloud_keys or has_config_file or has_ollama or has_dispatcher_route
+    )
 
     availability = LLMAvailability(
         external_llm=external_llm,

--- a/core/llm/dispatcher/__init__.py
+++ b/core/llm/dispatcher/__init__.py
@@ -27,6 +27,7 @@ from .client import (
     make_anthropic_client,
     make_gemini_base_url,
     make_openai_client,
+    relay_for_grandchild,
 )
 from .lifecycle import dispatcher_for_run, llm_dispatcher_in_run
 from .server import LLMDispatcher, AuditEvent
@@ -40,5 +41,6 @@ __all__ = [
     "make_anthropic_client",
     "make_gemini_base_url",
     "make_openai_client",
+    "relay_for_grandchild",
     "spawn_worker",
 ]

--- a/core/llm/dispatcher/client.py
+++ b/core/llm/dispatcher/client.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 import os
 from typing import Optional
 
+import threading
+
 import httpx
 
 
@@ -55,18 +57,50 @@ def read_token(fd: Optional[int] = None) -> str:
     return token
 
 
-def _make_httpx_client(socket_path: str, token: str) -> httpx.Client:
+# Token cache: ``read_token()`` consumes the FD on first read. When
+# multiple ``Provider`` instances share the same worker process — every
+# RAPTOR analysis script does this when the operator has multiple
+# providers configured — the second instance's call to ``read_token``
+# would fail because the FD is already closed. Cache the value at
+# process scope so all Provider constructors in the same worker share
+# one resolved token.
+_cached_token: Optional[str] = None
+_cache_lock = threading.Lock()
+
+
+def _get_or_read_token() -> str:
+    """Return the worker's token, reading once and caching for the
+    rest of the process lifetime."""
+    global _cached_token
+    if _cached_token is not None:
+        return _cached_token
+    with _cache_lock:
+        if _cached_token is not None:
+            return _cached_token
+        _cached_token = read_token()
+        return _cached_token
+
+
+def _make_httpx_client(
+    socket_path: str, token: str, *, timeout: Optional[float] = None,
+) -> httpx.Client:
     """Build the underlying ``httpx`` client.
 
     UDS transport directs all traffic to the dispatcher; the
     ``X-Raptor-Token`` header is attached to every request via the
     client's default headers.
+
+    ``timeout`` (seconds) sets the request timeout the SDK ends up
+    using; setting it on the SDK client AFTER construction is a
+    no-op for the underlying httpx, so it has to flow in through
+    here.
     """
     transport = httpx.HTTPTransport(uds=socket_path)
+    request_timeout = timeout if timeout is not None else 60.0
     return httpx.Client(
         transport=transport,
         headers={_TOKEN_HEADER: token},
-        timeout=httpx.Timeout(60.0, connect=5.0),
+        timeout=httpx.Timeout(request_timeout, connect=5.0),
     )
 
 
@@ -88,7 +122,7 @@ def _resolve_socket_and_token(
             )
         socket_path = env
     if token is None:
-        token = read_token()
+        token = _get_or_read_token()
     return socket_path, token
 
 
@@ -96,6 +130,7 @@ def make_anthropic_client(
     *,
     socket_path: Optional[str] = None,
     token: Optional[str] = None,
+    timeout: Optional[float] = None,
 ):
     """Return a stock ``anthropic.Anthropic`` client routed through
     the dispatcher.
@@ -103,6 +138,10 @@ def make_anthropic_client(
     Defaults read socket path from ``RAPTOR_LLM_SOCKET`` and the
     token from ``RAPTOR_LLM_TOKEN_FD``. Pass arguments explicitly
     only in tests.
+
+    ``timeout`` (seconds) flows through to the underlying httpx; the
+    SDK clients on the dispatcher path don't accept post-construction
+    timeout changes since their httpx instance is fixed at build time.
 
     The returned client behaves exactly like a normal Anthropic SDK
     client — workers call ``client.messages.create(...)`` etc. and
@@ -112,7 +151,7 @@ def make_anthropic_client(
     import anthropic   # imported lazily so the module loads without the SDK
 
     socket_path, token = _resolve_socket_and_token(socket_path, token)
-    http = _make_httpx_client(socket_path, token)
+    http = _make_httpx_client(socket_path, token, timeout=timeout)
     # ``api_key='dummy'`` because the SDK validates that *something*
     # was passed; the dispatcher strips it and injects the real key.
     # ``base_url`` directs requests to ``/anthropic/v1/...`` so the
@@ -128,18 +167,51 @@ def make_openai_client(
     *,
     socket_path: Optional[str] = None,
     token: Optional[str] = None,
+    timeout: Optional[float] = None,
 ):
     """Return a stock ``openai.OpenAI`` client routed through the
     dispatcher. Same shape as :func:`make_anthropic_client`."""
     import openai
 
     socket_path, token = _resolve_socket_and_token(socket_path, token)
-    http = _make_httpx_client(socket_path, token)
+    http = _make_httpx_client(socket_path, token, timeout=timeout)
     return openai.OpenAI(
         api_key="dummy-not-used",
         base_url="http://_/openai/v1",
         http_client=http,
     )
+
+
+def relay_for_grandchild() -> tuple[str, int]:
+    """Return ``(socket_path, token_fd)`` for a grandchild ``Popen``.
+
+    Use case: a worker script that's already authenticated to a
+    dispatcher (env has ``RAPTOR_LLM_SOCKET`` + ``RAPTOR_LLM_TOKEN_FD``)
+    needs to spawn its own subprocess that should share the same
+    LLM session — typical example is ``raptor_agentic.py`` spawning
+    ``packages/llm_analysis/agent.py`` in ``--sequential`` mode.
+
+    The grandchild gets:
+      - the same UDS path (same dispatcher) via env var
+      - the same token value, but in a fresh inheritable FD
+
+    Sharing the token value within a parent → child trust boundary
+    is fine: both processes are part of the same RAPTOR run, both
+    are equally trusted. The FD wrapper (rather than env-var token
+    passing) keeps the same property as the original ``spawn_worker``
+    chain — no other same-UID process can scrape the token via
+    ``/proc/N/environ``.
+
+    Caller is responsible for ``os.close(token_fd)`` after passing
+    it via ``Popen(pass_fds=...)``, mirroring the spawn_worker
+    contract.
+    """
+    socket_path, token = _resolve_socket_and_token(None, None)
+    read_fd, write_fd = os.pipe()
+    os.write(write_fd, token.encode())
+    os.close(write_fd)
+    os.set_inheritable(read_fd, True)
+    return socket_path, read_fd
 
 
 def make_gemini_base_url(*, socket_path: Optional[str] = None,

--- a/core/llm/dispatcher/server.py
+++ b/core/llm/dispatcher/server.py
@@ -14,10 +14,14 @@ Five security layers, in the order an attacker must defeat them:
       (NOT env var — same-UID processes can read ``/proc/N/environ``
       on Linux). Worker presents the token in the ``X-Raptor-Token``
       header on its first request.
-  L4. **Single-use connection tokens with per-token budget.** Token
-      authorises one connection; revoked when connection closes,
-      after ``request_budget`` requests, or after ``ttl_s`` seconds.
-      Replay after legitimate session ends fails.
+  L4. **Token bounded by request budget + TTL + explicit revocation.**
+      Token can establish multiple connections within its budget +
+      TTL — required so a worker process that spawns its own
+      grandchildren (relayed via :func:`relay_for_grandchild`) can
+      share the session without round-tripping the dispatcher for a
+      fresh token. Connections after ``request_budget`` requests or
+      ``ttl_s`` seconds are rejected; an explicit ``revoke`` flips
+      the record to terminal state.
   L5. **Audit log.** Every accept / reject / dispatch event lands
       in a JSONL log. Body content is intentionally never logged.
 
@@ -58,8 +62,13 @@ _logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-_TOKEN_DEFAULT_TTL_S = 60 * 60       # one hour
-_TOKEN_DEFAULT_BUDGET = 1000         # requests per worker run
+_TOKEN_DEFAULT_TTL_S = 8 * 60 * 60   # 8 hours — long-running /agentic
+                                     # and /validate runs on large
+                                     # codebases comfortably exceed
+                                     # the original 1-hour cap.
+_TOKEN_DEFAULT_BUDGET = 10_000       # requests per worker run — agentic
+                                     # workflows over many findings can
+                                     # easily clear 1k LLM calls.
 _TOKEN_HEADER = "X-Raptor-Token"
 
 
@@ -168,10 +177,32 @@ class LLMDispatcher:
         self._audit_path = audit_path
         self._audit_lock = threading.Lock()
 
+        # Init may fail past this point (bind error, thread start
+        # failure). On failure the tempdir would otherwise leak.
+        try:
+            self._init_server(run_id)
+        except Exception:
+            # Best-effort cleanup so /tmp/raptor-llm-* doesn't
+            # accumulate after init failures.
+            try:
+                self.socket_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            try:
+                self._sock_dir.rmdir()
+            except OSError:
+                pass
+            raise
+
+    def _init_server(self, run_id: str) -> None:
+        # The body below was inlined in __init__ pre-cleanup-fix; lifted
+        # here so the try/except wrapper can clean up the tempdir on
+        # any partial-init failure.
+
         # Pass dispatcher self into the request handler via the server.
         # http.server's HTTPServer accepts a ``RequestHandlerClass`` so
         # we close over the dispatcher in a per-instance handler.
-        dispatcher = self
+        dispatcher = self  # noqa: F841 — closed over by handler factory
 
         class _UnixThreadingHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
             address_family = socket.AF_UNIX

--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -10,6 +10,7 @@ JSON-in-prompt fallback for providers that lack native structured support.
 
 import json
 import logging
+import os
 import sys
 import time
 from abc import ABC, abstractmethod
@@ -741,11 +742,33 @@ class OpenAICompatibleProvider(LLMProvider):
                 "OpenAI SDK not installed. Run: pip install openai"
             )
 
-        self.client = OpenAI(
-            api_key=config.api_key or "unused",
-            base_url=config.api_base,
-            timeout=config.timeout,
+        # Dispatcher route only when (a) dispatcher session is set,
+        # (b) provider is OpenAI proper (not Ollama / vLLM / LM Studio),
+        # AND (c) ``api_base`` is None — i.e., default upstream is
+        # ``api.openai.com``. Operators routing through a custom
+        # OpenAI-compatible gateway (e.g. corporate proxy at
+        # ``my-corp-gw/v1``) keep their ``api_base`` and the
+        # dispatcher's hard-coded ``api.openai.com`` upstream would
+        # be the wrong destination — fall back to env-direct in
+        # that case.
+        use_dispatcher = (
+            os.environ.get("RAPTOR_LLM_SOCKET")
+            and config.provider == "openai"
+            and not config.api_base
         )
+        if use_dispatcher:
+            from core.llm.dispatcher.client import make_openai_client
+            self.client = make_openai_client(timeout=config.timeout)
+            logger.debug("OpenAICompatibleProvider: routing via credential-isolation dispatcher")
+        else:
+            self.client = OpenAI(
+                api_key=config.api_key or "unused",
+                base_url=config.api_base,
+                timeout=config.timeout,
+            )
+            logger.debug(
+                f"OpenAICompatibleProvider: direct SDK (no dispatcher) provider={config.provider}"
+            )
 
         self.instructor_client = None
         self._instructor_warned = False
@@ -1284,10 +1307,22 @@ class AnthropicProvider(LLMProvider):
                 "Anthropic SDK not installed. Run: pip install anthropic"
             )
 
-        self.client = anthropic.Anthropic(
-            api_key=config.api_key,
-            timeout=config.timeout,
-        )
+        # Phase B: route through the credential-isolation dispatcher when
+        # the worker has been spawned with one in place. Tie-breaker:
+        # ``RAPTOR_LLM_SOCKET`` wins over ``config.api_key`` so the
+        # dispatcher path actually gets exercised in opt-in workflows.
+        # The env-direct fallback stays in place until Phase C drops the
+        # API-key passthrough entirely.
+        if os.environ.get("RAPTOR_LLM_SOCKET"):
+            from core.llm.dispatcher.client import make_anthropic_client
+            self.client = make_anthropic_client(timeout=config.timeout)
+            logger.debug("AnthropicProvider: routing via credential-isolation dispatcher")
+        else:
+            self.client = anthropic.Anthropic(
+                api_key=config.api_key,
+                timeout=config.timeout,
+            )
+            logger.debug("AnthropicProvider: direct SDK (no dispatcher)")
 
         self.instructor_client = None
         self._instructor_warned = False
@@ -1843,7 +1878,25 @@ class GeminiProvider(LLMProvider):
     def client(self):
         """Per-thread client — google-genai is not guaranteed thread-safe."""
         if not hasattr(self._local, 'client'):
-            self._local.client = _genai_module.Client(api_key=self.config.api_key)
+            # Phase B: dispatcher-route when ``RAPTOR_LLM_SOCKET`` set.
+            # google-genai 1.70+ accepts a custom ``base_url`` and
+            # ``httpx_client`` via ``HttpOptions`` — :func:`make_gemini_base_url`
+            # returns the (base_url, http_client) pair the SDK needs.
+            if os.environ.get("RAPTOR_LLM_SOCKET"):
+                from core.llm.dispatcher.client import make_gemini_base_url
+                from google.genai.types import HttpOptions
+                base_url, http_client = make_gemini_base_url()
+                self._local.client = _genai_module.Client(
+                    api_key="dummy-not-used",
+                    http_options=HttpOptions(
+                        base_url=base_url,
+                        httpx_client=http_client,
+                    ),
+                )
+                logger.debug("GeminiProvider: routing via credential-isolation dispatcher")
+            else:
+                self._local.client = _genai_module.Client(api_key=self.config.api_key)
+                logger.debug("GeminiProvider: direct SDK (no dispatcher)")
         return self._local.client
 
     def generate(self, prompt: str, system_prompt: Optional[str] = None,

--- a/core/llm/tests/test_dispatcher_integration.py
+++ b/core/llm/tests/test_dispatcher_integration.py
@@ -1,0 +1,758 @@
+"""Phase B integration tests: ``core/llm/providers.py`` + dispatcher.
+
+Confirms each Provider's ``__init__`` takes the dispatcher route when
+``RAPTOR_LLM_SOCKET`` is set in the worker's env, and the env-direct
+fallback when it isn't. These prove the additive behaviour we relied
+on for "Phase B can't break anything until Phase C".
+
+The full subprocess-end-to-end is exercised in
+``test_e2e_credentials_isolation_through_providers`` below.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import httpx
+import pytest
+
+from core.llm.config import ModelConfig
+from core.llm.dispatcher.auth import CredentialStore, ProviderRule
+from core.llm.dispatcher.server import LLMDispatcher
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: dispatcher + captive upstream
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_creds():
+    creds = CredentialStore.__new__(CredentialStore)
+    creds._keys = {
+        "anthropic": "test-anthropic-secret",
+        "openai":    "test-openai-secret",
+        "gemini":    "test-gemini-secret",
+    }
+    return creds
+
+
+class _CaptiveUpstream:
+    def __init__(self, body: bytes = b'{"ok":true}'):
+        self.captured: dict = {}
+        self._body = body
+        outer = self
+
+        class _H(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *_a, **_kw): return
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", "0"))
+                body = self.rfile.read(length) if length else b""
+                outer.captured["headers"] = {k: v for k, v in self.headers.items()}
+                outer.captured["path"] = self.path
+                outer.captured["body"] = body
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(outer._body)))
+                self.end_headers()
+                self.wfile.write(outer._body)
+
+        self._server = http.server.HTTPServer(("127.0.0.1", 0), _H)
+        self.host, self.port = self._server.server_address
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def shutdown(self):
+        self._server.shutdown()
+        self._server.server_close()
+
+
+def _wired_dispatcher(creds, tmp_path, provider: str, upstream: _CaptiveUpstream):
+    """Build a dispatcher with the chosen provider's upstream rewritten
+    to the captive HTTP server. Returns the dispatcher."""
+    d = LLMDispatcher(
+        run_id=f"providers-{provider}",
+        creds=creds,
+        audit_path=tmp_path / "audit.jsonl",
+        token_ttl_s=3600, token_budget=100,
+    )
+    original = d._rules[provider]
+    d._rules[provider] = ProviderRule(
+        name=original.name,
+        upstream_base_url=upstream.base_url,
+        inject_headers=original.inject_headers,
+        strip_request_headers=original.strip_request_headers,
+    )
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher-route selection at provider __init__
+# ---------------------------------------------------------------------------
+
+
+class TestProviderRouteSelection:
+    """Each Provider's ``__init__`` must pick the dispatcher path
+    when ``RAPTOR_LLM_SOCKET`` is set, and the direct-SDK path
+    otherwise. Tested without making a real LLM call by inspecting
+    the constructed client's transport configuration."""
+
+    def test_anthropic_provider_uses_dispatcher_when_socket_set(
+        self, fake_creds, tmp_path, monkeypatch,
+    ):
+        upstream = _CaptiveUpstream()
+        d = _wired_dispatcher(fake_creds, tmp_path, "anthropic", upstream)
+        try:
+            _, fd = d.allocate_worker(label="ant-init")
+            monkeypatch.setenv("RAPTOR_LLM_SOCKET", str(d.socket_path))
+            monkeypatch.setenv("RAPTOR_LLM_TOKEN_FD", str(fd))
+
+            # Reset the worker-side token cache so this test sees the
+            # fresh FD instead of one from a previous test.
+            from core.llm.dispatcher import client as _client
+            _client._cached_token = None
+
+            from core.llm.providers import AnthropicProvider
+            cfg = ModelConfig(provider="anthropic", model_name="claude-3-haiku-20240307")
+            cfg.api_key = "should-not-be-used"
+            provider = AnthropicProvider(cfg)
+
+            # Dispatcher path constructs the client with a UDS transport;
+            # the SDK's underlying httpx instance carries that.
+            httpx_client = provider.client._client
+            transport = httpx_client._transport
+            assert isinstance(transport, httpx.HTTPTransport)
+            # The SDK's base_url on the dispatcher path is the dummy http://_/...
+            assert "http://_/anthropic" in str(provider.client.base_url)
+        finally:
+            upstream.shutdown()
+            d.shutdown()
+
+    def test_anthropic_provider_uses_direct_sdk_when_no_socket(
+        self, monkeypatch,
+    ):
+        monkeypatch.delenv("RAPTOR_LLM_SOCKET", raising=False)
+        from core.llm.providers import AnthropicProvider
+        cfg = ModelConfig(provider="anthropic", model_name="claude-3-haiku-20240307")
+        cfg.api_key = "test-key"
+        provider = AnthropicProvider(cfg)
+        # Direct path: base_url is the real anthropic endpoint, NOT
+        # the dispatcher's dummy host.
+        assert "http://_/" not in str(provider.client.base_url)
+
+    def test_openai_provider_uses_dispatcher_when_socket_set(
+        self, fake_creds, tmp_path, monkeypatch,
+    ):
+        upstream = _CaptiveUpstream()
+        d = _wired_dispatcher(fake_creds, tmp_path, "openai", upstream)
+        try:
+            _, fd = d.allocate_worker(label="oai-init")
+            monkeypatch.setenv("RAPTOR_LLM_SOCKET", str(d.socket_path))
+            monkeypatch.setenv("RAPTOR_LLM_TOKEN_FD", str(fd))
+            from core.llm.dispatcher import client as _client
+            _client._cached_token = None
+
+            from core.llm.providers import OpenAICompatibleProvider
+            cfg = ModelConfig(provider="openai", model_name="gpt-5")
+            cfg.api_key = "should-not-be-used"
+            provider = OpenAICompatibleProvider(cfg)
+            assert "http://_/openai" in str(provider.client.base_url)
+        finally:
+            upstream.shutdown()
+            d.shutdown()
+
+    def test_openai_compat_does_NOT_use_dispatcher_for_ollama(
+        self, fake_creds, tmp_path, monkeypatch,
+    ):
+        """Critical isolation: the OpenAI-compatible provider class
+        is shared with Ollama, vLLM, LM Studio, etc. Those have no
+        creds to isolate and a custom ``api_base``. Even with
+        ``RAPTOR_LLM_SOCKET`` set, the dispatcher path must NOT be
+        taken for ``provider != "openai"``."""
+        upstream = _CaptiveUpstream()
+        d = _wired_dispatcher(fake_creds, tmp_path, "openai", upstream)
+        try:
+            _, fd = d.allocate_worker(label="ollama-init")
+            monkeypatch.setenv("RAPTOR_LLM_SOCKET", str(d.socket_path))
+            monkeypatch.setenv("RAPTOR_LLM_TOKEN_FD", str(fd))
+            from core.llm.dispatcher import client as _client
+            _client._cached_token = None
+
+            from core.llm.providers import OpenAICompatibleProvider
+            cfg = ModelConfig(
+                provider="ollama",
+                model_name="llama3.1:8b",
+            )
+            cfg.api_key = "unused"
+            cfg.api_base = "http://localhost:11434/v1"
+            provider = OpenAICompatibleProvider(cfg)
+            # Direct path → base_url is the local Ollama endpoint
+            assert "http://_/" not in str(provider.client.base_url)
+            assert "11434" in str(provider.client.base_url)
+        finally:
+            upstream.shutdown()
+            d.shutdown()
+
+    def test_gemini_provider_uses_dispatcher_when_socket_set(
+        self, fake_creds, tmp_path, monkeypatch,
+    ):
+        pytest.importorskip("google.genai")
+        upstream = _CaptiveUpstream()
+        d = _wired_dispatcher(fake_creds, tmp_path, "gemini", upstream)
+        try:
+            _, fd = d.allocate_worker(label="gem-init")
+            monkeypatch.setenv("RAPTOR_LLM_SOCKET", str(d.socket_path))
+            monkeypatch.setenv("RAPTOR_LLM_TOKEN_FD", str(fd))
+            from core.llm.dispatcher import client as _client
+            _client._cached_token = None
+
+            from core.llm.providers import GeminiProvider
+            cfg = ModelConfig(provider="gemini", model_name="gemini-2.5-pro")
+            cfg.api_key = "should-not-be-used"
+            provider = GeminiProvider(cfg)
+            # Force lazy client construction
+            client = provider.client
+            # google-genai stores HttpOptions on _api_client.http_options
+            base_url = client._api_client._http_options.base_url
+            assert "http://_/gemini" in str(base_url)
+        finally:
+            upstream.shutdown()
+            d.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real subprocess, no API keys in env, real anthropic SDK
+# ---------------------------------------------------------------------------
+
+
+class TestGrandchildRelay:
+    """``raptor_agentic.py --sequential`` spawns
+    ``packages/llm_analysis/agent.py`` as a subprocess that itself
+    needs LLM access. Phase B's :func:`relay_for_grandchild` lets
+    the parent-script pass its already-authenticated session down
+    to the grandchild — same socket, same token, fresh inheritable
+    FD. After Phase C drops API keys from env, this is the only
+    way the grandchild can reach the LLM."""
+
+    def test_relay_for_grandchild_returns_inheritable_fd_with_token(
+        self, fake_creds, tmp_path, monkeypatch,
+    ):
+        d = LLMDispatcher(
+            run_id="relay-test", creds=fake_creds,
+            audit_path=tmp_path / "audit.jsonl",
+            token_ttl_s=60, token_budget=10,
+        )
+        try:
+            _, parent_fd = d.allocate_worker(label="parent")
+            monkeypatch.setenv("RAPTOR_LLM_SOCKET", str(d.socket_path))
+            monkeypatch.setenv("RAPTOR_LLM_TOKEN_FD", str(parent_fd))
+            from core.llm.dispatcher import client as _client
+            _client._cached_token = None
+
+            # Parent reads its own token via the cache (simulates
+            # what AnthropicProvider did at startup).
+            parent_token = _client._get_or_read_token()
+
+            # Now relay to a grandchild: get a fresh FD with the
+            # same token, ready for pass_fds=.
+            sock, child_fd = _client.relay_for_grandchild()
+            try:
+                assert sock == str(d.socket_path)
+                # FD is inheritable (so subprocess.Popen pass_fds works)
+                assert os.get_inheritable(child_fd)
+                # And carries the same token value
+                relayed_token = os.read(child_fd, 64).decode().strip()
+                assert relayed_token == parent_token
+            finally:
+                try:
+                    os.close(child_fd)
+                except OSError:
+                    pass
+        finally:
+            d.shutdown()
+
+    def test_grandchild_subprocess_uses_relayed_session(
+        self, fake_creds, tmp_path,
+    ):
+        """End-to-end: parent worker spawned with token; parent
+        relays to grandchild; grandchild makes an LLM call through
+        the dispatcher; captive upstream sees real key injected."""
+        anthropic_response = json.dumps({
+            "id": "msg_grandchild",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3-haiku-20240307",
+            "content": [{"type": "text", "text": "from grandchild"}],
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 4, "output_tokens": 3},
+        }).encode("utf-8")
+        upstream = _CaptiveUpstream(body=anthropic_response)
+        d = _wired_dispatcher(fake_creds, tmp_path, "anthropic", upstream)
+        try:
+            # Parent script: read inherited token, immediately relay
+            # to a grandchild that's spawned inline. Mimics what
+            # raptor_agentic.py does when it spawns agent.py with
+            # the relayed session.
+            parent_src = tmp_path / "parent_for_grandchild.py"
+            parent_src.write_text(
+                "import json, os, subprocess, sys\n"
+                "from core.llm.dispatcher.client import relay_for_grandchild\n"
+                "sock, child_fd = relay_for_grandchild()\n"
+                "child_env = {\n"
+                "    'PATH': os.environ.get('PATH', ''),\n"
+                "    'PYTHONPATH': os.environ.get('PYTHONPATH', ''),\n"
+                "    'RAPTOR_LLM_SOCKET': sock,\n"
+                "    'RAPTOR_LLM_TOKEN_FD': str(child_fd),\n"
+                "}\n"
+                "rc = subprocess.call(\n"
+                "    [sys.executable, sys.argv[1]],\n"
+                "    env=child_env, pass_fds=(child_fd,),\n"
+                ")\n"
+                "try:\n"
+                "    os.close(child_fd)\n"
+                "except OSError:\n"
+                "    pass\n"
+                "sys.exit(rc)\n",
+                encoding="utf-8",
+            )
+            grandchild_src = tmp_path / "grandchild.py"
+            grandchild_src.write_text(
+                "import json, os, sys\n"
+                "for k in os.environ:\n"
+                "    if 'API_KEY' in k or 'API_TOKEN' in k:\n"
+                "        sys.exit(f'leaked key in env: {k}')\n"
+                "from core.llm.config import ModelConfig\n"
+                "from core.llm.providers import AnthropicProvider\n"
+                "cfg = ModelConfig(provider='anthropic', model_name='claude-3-haiku-20240307')\n"
+                "cfg.api_key = 'dummy'\n"
+                "msg = AnthropicProvider(cfg).client.messages.create(\n"
+                "    model='claude-3-haiku-20240307',\n"
+                "    max_tokens=64,\n"
+                "    messages=[{'role':'user','content':'gc'}],\n"
+                ")\n"
+                "sys.stdout.write(json.dumps({'id': msg.id, 'text': msg.content[0].text}))\n",
+                encoding="utf-8",
+            )
+
+            from core.llm.dispatcher.spawn import spawn_worker
+            repo_root = os.path.dirname(os.path.dirname(os.path.dirname(
+                os.path.dirname(os.path.abspath(__file__))
+            )))
+            proc = spawn_worker(
+                d,
+                cmd=[sys.executable, str(parent_src), str(grandchild_src)],
+                label="parent-for-relay",
+                env={
+                    "PATH": os.environ.get("PATH", ""),
+                    "PYTHONPATH": repo_root,
+                },
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            stdout, stderr = proc.communicate(timeout=20)
+            assert proc.returncode == 0, (
+                f"parent+grandchild chain failed: rc={proc.returncode} "
+                f"stdout={stdout.decode()!r} stderr={stderr.decode()!r}"
+            )
+
+            # The grandchild's parsed response landed on stdout
+            payload = json.loads(stdout.decode())
+            assert payload["id"] == "msg_grandchild"
+            assert payload["text"] == "from grandchild"
+
+            # Real key was injected; dummy stripped; token not forwarded
+            sent = {k.lower(): v for k, v in upstream.captured["headers"].items()}
+            assert sent.get("x-api-key") == "test-anthropic-secret"
+            assert "x-raptor-token" not in sent
+        finally:
+            upstream.shutdown()
+            d.shutdown()
+
+
+@pytest.fixture
+def clear_detection_cache():
+    """``detect_llm_availability`` caches its result at module scope.
+    Tests that drive different cache values must clear it both before
+    and after they run, otherwise they pollute later tests in the
+    suite (observed: test_ollama_warning emits an extra "no LLM
+    available" warning when our test left a False-cache behind)."""
+    from core.llm import detection
+    detection._cached_llm_availability = None
+    try:
+        yield
+    finally:
+        detection._cached_llm_availability = None
+
+
+class TestPhaseBChainE2E:
+    """Adversarial-grade end-to-end: simulate the full raptor.py →
+    raptor_agentic.py → packages/llm_analysis/agent.py chain that
+    Phase B is supposed to enable post-Phase-C.
+
+    Three processes:
+      1. **outer-parent** (this test) — owns the dispatcher and the
+         only credentials. No API keys are ever written into a
+         child's environment.
+      2. **child** — like raptor_agentic.py: builds a real
+         ``AnthropicProvider`` to confirm the in-process LLM path
+         works, AND relays its session to a grandchild.
+      3. **grandchild** — like agent.py in --sequential mode: builds
+         its own ``AnthropicProvider`` and makes an LLM call.
+
+    Asserts the credential-isolation invariants hold across the
+    whole chain — not just the leaf — and that ``detect_llm_availability``
+    correctly reports ``external_llm=True`` in the grandchild despite
+    no API keys in env.
+    """
+
+    def test_full_chain_no_api_keys_anywhere(self, fake_creds, tmp_path):
+        # Skip if any required SDK is missing (CI containers vary)
+        pytest.importorskip("anthropic")
+
+        # Captive upstream that records every request hit
+        anthropic_response = json.dumps({
+            "id": "msg_chain",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3-haiku-20240307",
+            "content": [{"type": "text", "text": "chain works"}],
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 4, "output_tokens": 3},
+        }).encode("utf-8")
+
+        # Need to track which process made each request (parent vs
+        # grandchild) — capture all of them so we can count.
+        all_requests: list[dict] = []
+        body_holder = [anthropic_response]
+        outer_lock = threading.Lock()
+
+        class _Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *_a, **_kw): return
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", "0"))
+                body = self.rfile.read(length) if length else b""
+                with outer_lock:
+                    all_requests.append({
+                        "headers": {k: v for k, v in self.headers.items()},
+                        "path": self.path,
+                        "body": body,
+                    })
+                resp = body_holder[0]
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(resp)))
+                self.end_headers()
+                self.wfile.write(resp)
+
+        upstream_server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+        upstream_thread = threading.Thread(
+            target=upstream_server.serve_forever, daemon=True,
+        )
+        upstream_thread.start()
+        upstream_base = f"http://{upstream_server.server_address[0]}:{upstream_server.server_address[1]}"
+
+        d = LLMDispatcher(
+            run_id="chain-e2e", creds=fake_creds,
+            audit_path=tmp_path / "audit.jsonl",
+            token_ttl_s=120, token_budget=20,
+        )
+        original = d._rules["anthropic"]
+        d._rules["anthropic"] = ProviderRule(
+            name=original.name,
+            upstream_base_url=upstream_base,
+            inject_headers=original.inject_headers,
+            strip_request_headers=original.strip_request_headers,
+        )
+
+        try:
+            from core.llm.dispatcher.spawn import spawn_worker
+            repo_root = os.path.dirname(os.path.dirname(os.path.dirname(
+                os.path.dirname(os.path.abspath(__file__))
+            )))
+
+            # ---- grandchild: imports providers, makes LLM call ----
+            grandchild_src = tmp_path / "chain_grandchild.py"
+            grandchild_src.write_text(
+                "import json, os, sys\n"
+                # No API key may be in our env
+                "for k in os.environ:\n"
+                "    if 'API_KEY' in k or 'API_TOKEN' in k:\n"
+                "        sys.exit(f'GC: leaked key in env: {k}')\n"
+                # detect_llm_availability MUST return external_llm=True
+                # in the grandchild despite no keys, because dispatcher
+                # socket is set
+                "from core.llm.detection import detect_llm_availability, _cached_llm_availability\n"
+                "import core.llm.detection as _det\n"
+                "_det._cached_llm_availability = None\n"
+                "av = detect_llm_availability()\n"
+                "if not av.external_llm:\n"
+                "    sys.exit(f'GC: detect_llm_availability said external_llm=False')\n"
+                # Build a real AnthropicProvider, make a call
+                "from core.llm.config import ModelConfig\n"
+                "from core.llm.providers import AnthropicProvider\n"
+                "cfg = ModelConfig(provider='anthropic', model_name='claude-3-haiku-20240307')\n"
+                "cfg.api_key = 'gc-dummy'\n"
+                "msg = AnthropicProvider(cfg).client.messages.create(\n"
+                "    model='claude-3-haiku-20240307',\n"
+                "    max_tokens=64,\n"
+                "    messages=[{'role':'user','content':'gc'}],\n"
+                ")\n"
+                "sys.stdout.write(json.dumps({'who':'grandchild','id':msg.id,'text':msg.content[0].text}))\n",
+                encoding="utf-8",
+            )
+
+            # ---- child: builds Provider locally + relays to grandchild ----
+            child_src = tmp_path / "chain_child.py"
+            child_src.write_text(
+                "import json, os, subprocess, sys\n"
+                # No API keys here either
+                "for k in os.environ:\n"
+                "    if 'API_KEY' in k or 'API_TOKEN' in k:\n"
+                "        sys.exit(f'C: leaked key in env: {k}')\n"
+                # In-process LLM call (Phase 4 orchestration shape)
+                "from core.llm.config import ModelConfig\n"
+                "from core.llm.providers import AnthropicProvider\n"
+                "cfg = ModelConfig(provider='anthropic', model_name='claude-3-haiku-20240307')\n"
+                "cfg.api_key = 'c-dummy'\n"
+                "msg = AnthropicProvider(cfg).client.messages.create(\n"
+                "    model='claude-3-haiku-20240307',\n"
+                "    max_tokens=64,\n"
+                "    messages=[{'role':'user','content':'c'}],\n"
+                ")\n"
+                "sys.stderr.write(json.dumps({'who':'child','id':msg.id,'text':msg.content[0].text}) + '\\n')\n"
+                # Relay to grandchild — same socket, fresh FD with same token
+                "from core.llm.dispatcher.client import relay_for_grandchild\n"
+                "sock, child_fd = relay_for_grandchild()\n"
+                "gc_env = {\n"
+                "    'PATH': os.environ.get('PATH',''),\n"
+                "    'PYTHONPATH': os.environ.get('PYTHONPATH',''),\n"
+                "    'RAPTOR_LLM_SOCKET': sock,\n"
+                "    'RAPTOR_LLM_TOKEN_FD': str(child_fd),\n"
+                "}\n"
+                "rc = subprocess.call(\n"
+                "    [sys.executable, sys.argv[1]],\n"
+                "    env=gc_env, pass_fds=(child_fd,),\n"
+                ")\n"
+                "try: os.close(child_fd)\n"
+                "except OSError: pass\n"
+                "sys.exit(rc)\n",
+                encoding="utf-8",
+            )
+
+            # ---- spawn the child via the dispatcher (mimics _run_script) ----
+            proc = spawn_worker(
+                d,
+                cmd=[sys.executable, str(child_src), str(grandchild_src)],
+                label="chain-child",
+                env={
+                    "PATH": os.environ.get("PATH", ""),
+                    "PYTHONPATH": repo_root,
+                },
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            stdout, stderr = proc.communicate(timeout=30)
+            assert proc.returncode == 0, (
+                f"chain failed: rc={proc.returncode}\n"
+                f"stdout={stdout.decode()!r}\nstderr={stderr.decode()!r}"
+            )
+
+            # ---- grandchild's parsed response landed on stdout ----
+            gc_payload = json.loads(stdout.decode().strip())
+            assert gc_payload["who"] == "grandchild"
+            assert gc_payload["id"] == "msg_chain"
+            assert gc_payload["text"] == "chain works"
+
+            # Child's own response landed on stderr (we used stderr to
+            # not collide with the grandchild's stdout pass-through)
+            child_lines = [l for l in stderr.decode().splitlines()
+                           if l.startswith("{")]
+            assert len(child_lines) == 1, f"child output not found: {stderr.decode()!r}"
+            c_payload = json.loads(child_lines[0])
+            assert c_payload["who"] == "child"
+            assert c_payload["id"] == "msg_chain"
+
+            # ---- TWO upstream requests (one from child, one from grandchild) ----
+            assert len(all_requests) == 2, (
+                f"expected 2 upstream requests (child + grandchild), got {len(all_requests)}"
+            )
+
+            # ---- credential-isolation invariants on EVERY request ----
+            for i, req in enumerate(all_requests):
+                sent = {k.lower(): v for k, v in req["headers"].items()}
+                assert sent.get("x-api-key") == "test-anthropic-secret", (
+                    f"request {i}: real key not injected, got: {sent.get('x-api-key')!r}"
+                )
+                # Each child uses a different dummy api_key; both must
+                # have been stripped before the dispatcher forwarded
+                assert sent.get("x-api-key") not in ("c-dummy", "gc-dummy")
+                # Capability token must NEVER reach upstream
+                assert "x-raptor-token" not in sent, (
+                    f"request {i}: capability token leaked upstream"
+                )
+                # Anthropic-version header was injected by the rule
+                assert sent.get("anthropic-version") == "2023-06-01"
+
+            # ---- audit log captured the dispatch events ----
+            audit_lines = [
+                json.loads(l)
+                for l in (tmp_path / "audit.jsonl").read_text().splitlines()
+            ]
+            dispatched = [a for a in audit_lines if a["event"] == "request.dispatch"]
+            assert len(dispatched) == 2, (
+                f"expected 2 dispatch events in audit, got {len(dispatched)}"
+            )
+            # Both should reference the same worker_label (child) since
+            # we relayed the token (same token-id prefix). This proves
+            # the relay used the same token rather than minting a new
+            # one — important for the "α (relax single-use)" decision.
+            assert dispatched[0]["token_id"] == dispatched[1]["token_id"]
+            assert dispatched[0]["worker_label"] == dispatched[1]["worker_label"]
+        finally:
+            upstream_server.shutdown()
+            upstream_server.server_close()
+            d.shutdown()
+
+
+class TestDetectLLMAvailabilityRecognizesDispatcher:
+    """``detect_llm_availability`` is consulted by Phase 4 of
+    raptor_agentic.py and the prep-only decision in agent.py. After
+    Phase C, env has no API keys but ``RAPTOR_LLM_SOCKET`` is set;
+    this must still report ``external_llm=True`` so the LLM-using
+    branches don't silently degrade to ClaudeCodeProvider."""
+
+    def test_external_llm_true_when_dispatcher_socket_set(
+        self, monkeypatch, clear_detection_cache,
+    ):
+        from core.llm import detection
+        for k in (
+            "ANTHROPIC_API_KEY", "OPENAI_API_KEY",
+            "GEMINI_API_KEY", "MISTRAL_API_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("RAPTOR_LLM_SOCKET", "/tmp/whatever-not-used.sock")
+
+        result = detection.detect_llm_availability()
+        assert result.external_llm is True
+        assert result.llm_available is True
+
+    def test_external_llm_false_without_dispatcher_or_keys(
+        self, monkeypatch, clear_detection_cache,
+    ):
+        from core.llm import detection
+        for k in (
+            "ANTHROPIC_API_KEY", "OPENAI_API_KEY",
+            "GEMINI_API_KEY", "MISTRAL_API_KEY",
+            "RAPTOR_LLM_SOCKET",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        # Stub out ollama / config-file checks so this test is
+        # hermetic (no /etc/raptor/llm-models.toml dependency, no
+        # localhost:11434 reachability dependency).
+        monkeypatch.setattr(detection, "_config_has_keyed_models", lambda: False)
+        monkeypatch.setattr(detection, "_get_available_ollama_models", lambda: [])
+
+        result = detection.detect_llm_availability()
+        assert result.external_llm is False
+
+
+class TestEndToEndCredentialIsolationThroughProviders:
+    """The "we got Phase B right" signal: a subprocess instantiates
+    ``AnthropicProvider`` (the production path), no API key in env,
+    LLM call succeeds, and the captive upstream confirms the
+    dispatcher injected real creds.
+
+    Mirrors the existing dispatcher subprocess test but proves the
+    integration via the production provider class (``AnthropicProvider``
+    in ``core/llm/providers.py``) — i.e. the actual code RAPTOR analysis
+    scripts run."""
+
+    def test_subprocess_via_anthropic_provider_no_env_key(self, fake_creds, tmp_path):
+        anthropic_response = json.dumps({
+            "id": "msg_e2e_b",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3-haiku-20240307",
+            "content": [{"type": "text", "text": "phase B works"}],
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 4, "output_tokens": 3},
+        }).encode("utf-8")
+        upstream = _CaptiveUpstream(body=anthropic_response)
+        d = _wired_dispatcher(fake_creds, tmp_path, "anthropic", upstream)
+
+        try:
+            from core.llm.dispatcher.spawn import spawn_worker
+
+            # Worker imports core.llm.providers.AnthropicProvider, builds
+            # a ModelConfig, calls .generate() — exactly the production
+            # path. Worker fail-fasts if any LLM API key is in its env.
+            worker_src = tmp_path / "phase_b_worker.py"
+            worker_src.write_text(
+                "import json, os, sys\n"
+                "for k in os.environ:\n"
+                "    if 'API_KEY' in k or 'API_TOKEN' in k:\n"
+                "        sys.exit(f'leaked key in env: {k}')\n"
+                "from core.llm.config import ModelConfig\n"
+                "from core.llm.providers import AnthropicProvider\n"
+                "cfg = ModelConfig(provider='anthropic', model_name='claude-3-haiku-20240307')\n"
+                "cfg.api_key = 'dummy-not-used'\n"
+                "p = AnthropicProvider(cfg)\n"
+                "msg = p.client.messages.create(\n"
+                "    model='claude-3-haiku-20240307',\n"
+                "    max_tokens=64,\n"
+                "    messages=[{'role':'user','content':'hi'}],\n"
+                ")\n"
+                "sys.stdout.write(json.dumps({'id': msg.id, 'text': msg.content[0].text}))\n",
+                encoding="utf-8",
+            )
+
+            # Repo root: this file is at core/llm/tests/test_dispatcher_integration.py
+            # so four dirname() calls reach the repo root.
+            repo_root = os.path.dirname(os.path.dirname(os.path.dirname(
+                os.path.dirname(os.path.abspath(__file__))
+            )))
+            proc = spawn_worker(
+                d,
+                cmd=[sys.executable, str(worker_src)],
+                label="phase-b-e2e",
+                env={
+                    "PATH": os.environ.get("PATH", ""),
+                    "PYTHONPATH": repo_root,
+                },
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            stdout, stderr = proc.communicate(timeout=15)
+            assert proc.returncode == 0, (
+                f"worker failed: rc={proc.returncode} "
+                f"stdout={stdout.decode()!r} stderr={stderr.decode()!r}"
+            )
+
+            # SDK parsed the response from the captive upstream
+            payload = json.loads(stdout.decode())
+            assert payload["id"] == "msg_e2e_b"
+            assert payload["text"] == "phase B works"
+
+            # Real key injected on the wire; dummy stripped
+            sent = {k.lower(): v for k, v in upstream.captured["headers"].items()}
+            assert sent.get("x-api-key") == "test-anthropic-secret"
+            assert sent.get("x-api-key") != "dummy-not-used"
+            assert "x-raptor-token" not in sent
+        finally:
+            upstream.shutdown()
+            d.shutdown()

--- a/raptor.py
+++ b/raptor.py
@@ -196,21 +196,70 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
     return rc
 
 
+_active_dispatcher = None
+
+
+def _get_or_start_dispatcher():
+    """Lazy single dispatcher per ``raptor.py`` invocation.
+
+    Phase B credential-isolation: when this is called, the spawned
+    analysis script gets ``RAPTOR_LLM_SOCKET`` + a per-spawn token
+    via ``spawn_worker``, and ``core/llm/providers.py`` routes its
+    SDK calls through the dispatcher. API keys are still in env (for
+    fallback) until Phase C drops the passthrough.
+    """
+    global _active_dispatcher
+    if _active_dispatcher is not None:
+        return _active_dispatcher
+    try:
+        from core.llm.dispatcher.server import LLMDispatcher
+        import uuid, atexit
+        _active_dispatcher = LLMDispatcher(run_id=f"raptor-{uuid.uuid4().hex[:8]}")
+        atexit.register(_active_dispatcher.shutdown)
+        return _active_dispatcher
+    except Exception as exc:
+        # Failure to start the dispatcher must not break the run —
+        # fall through to the env-direct path. The credential leak
+        # channel stays open in this case but is no worse than today.
+        import logging
+        logging.getLogger(__name__).warning(
+            "credential-isolation dispatcher failed to start, falling back "
+            "to env-direct: %s", exc,
+        )
+        return None
+
+
 def _run_script(script_path: Path, args: list) -> int:
     """
     Run a RAPTOR script with given arguments.
-    
+
     Args:
         script_path: Path to the Python script to run
         args: Command-line arguments to pass to the script
-        
+
     Returns:
         Exit code from the script
     """
     cmd = [sys.executable, str(script_path)] + args
-    
+
     try:
         from core.config import RaptorConfig
+        # Phase B: opt the spawn into the credential-isolation
+        # dispatcher. Worker env still has API keys (fallback path
+        # exists until Phase C); ``RAPTOR_LLM_SOCKET`` and
+        # ``RAPTOR_LLM_TOKEN_FD`` direct the worker's SDK calls
+        # through the dispatcher when present.
+        dispatcher = _get_or_start_dispatcher()
+        if dispatcher is not None:
+            from core.llm.dispatcher.spawn import spawn_worker
+            proc = spawn_worker(
+                dispatcher,
+                cmd=cmd,
+                label=script_path.name,
+                env=RaptorConfig.get_llm_env(),
+            )
+            return proc.wait()
+        # Fallback: pre-Phase-B behaviour, env-direct.
         result = subprocess.run(cmd, env=RaptorConfig.get_llm_env())
         return result.returncode
     except KeyboardInterrupt:

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -75,6 +75,31 @@ def run_command_streaming(cmd: list, description: str) -> tuple[int, str, str]:
         finally:
             pipe.close()
 
+    # Phase B credential-isolation: when raptor_agentic.py was
+    # itself spawned with a dispatcher session (RAPTOR_LLM_SOCKET +
+    # RAPTOR_LLM_TOKEN_FD), relay the session to the grandchild so
+    # ``--sequential`` mode of ``packages/llm_analysis/agent.py`` can
+    # reach the LLM after Phase C drops API keys from the env. Same
+    # token value, fresh inheritable FD — see
+    # ``core.llm.dispatcher.client.relay_for_grandchild``.
+    child_env = RaptorConfig.get_safe_env()
+    child_pass_fds: list[int] = []
+    if os.environ.get("RAPTOR_LLM_SOCKET"):
+        try:
+            from core.llm.dispatcher.client import relay_for_grandchild
+            socket_path, token_fd = relay_for_grandchild()
+            child_env["RAPTOR_LLM_SOCKET"] = socket_path
+            child_env["RAPTOR_LLM_TOKEN_FD"] = str(token_fd)
+            child_pass_fds.append(token_fd)
+        except Exception as exc:
+            logger.warning(
+                f"credential-isolation relay to grandchild failed, "
+                f"falling back to env-direct: {exc}"
+            )
+            token_fd = None
+    else:
+        token_fd = None
+
     try:
         process = subprocess.Popen(
             cmd,
@@ -83,7 +108,8 @@ def run_command_streaming(cmd: list, description: str) -> tuple[int, str, str]:
             text=True,
             bufsize=1,  # Line buffered
             universal_newlines=True,
-            env=RaptorConfig.get_safe_env(),
+            env=child_env,
+            pass_fds=tuple(child_pass_fds),
             # Detach from parent's process group so operator
             # Ctrl-C in the parent doesn't propagate SIGINT
             # to the child via the controlling terminal. The
@@ -96,6 +122,13 @@ def run_command_streaming(cmd: list, description: str) -> tuple[int, str, str]:
             # message.
             start_new_session=True,
         )
+        # The child has inherited the FD; close our copy so the
+        # pipe's EOF tracks the child's lifetime, not ours.
+        if token_fd is not None:
+            try:
+                os.close(token_fd)
+            except OSError:
+                pass
 
         stdout_lines = []
         stderr_lines = []


### PR DESCRIPTION
When RAPTOR_LLM_SOCKET is set in a worker's env, AnthropicProvider / OpenAICompatibleProvider / GeminiProvider construct via the dispatcher (stock SDK + httpx UDS transport) instead of reading API keys from os.environ. When unset, behaviour is identical to today. Opt-in: raptor.py:_run_script lazy-starts a dispatcher and uses spawn_worker. get_llm_env() still ships keys — dual-channel until Phase C.

Grandchild support for raptor_agentic.py --sequential:
  - relay_for_grandchild() returns (socket_path, fresh_token_fd) for pass_fds. Same token, fresh FD — preserves no-token-in-env / no-token-in-argv across parent → child → grandchild.
  - detect_llm_availability counts RAPTOR_LLM_SOCKET as external_llm so post-C --sequential doesn't silently degrade to ClaudeCodeProvider.

Adversarial-review fixes:
  - OpenAICompatibleProvider with custom api_base (corp gateway) no longer silently re-routes to api.openai.com.
  - SDK timeout flows through make_*_client(timeout=...) instead of being assigned post-construction (was a no-op).
  - Default TTL 1h → 8h, budget 1k → 10k for long-running flows.
  - Init failure cleans up the temp socket dir.
  - Token cache so multiple Providers in one worker share the FD read.

Tests: 11 new in test_dispatcher_integration.py incl. chain E2E across three real subprocesses (parent + child + grandchild, no API keys anywhere, both make real Anthropic calls, audit confirms token-relay). 3638 core + 3425 packages tests pass.