### PR TITLE
feat(scorecard): wire all four reserved producer event types

### DIFF
--- a/core/llm/scorecard/cli.py
+++ b/core/llm/scorecard/cli.py
@@ -311,6 +311,7 @@ def _render_samples(stat: DecisionClassStats) -> str:
         lines.append(f"## Sample {i} — {sample.get('ts', '?')} ({sample.get('event_type', '?')})")
         cheap_r = sample.get("this_reasoning", "")
         full_r = sample.get("other_reasoning", "")
+        note = sample.get("note", "")
         if cheap_r:
             lines.append("**Cheap (clear_fp):**")
             lines.append(cheap_r)
@@ -318,6 +319,12 @@ def _render_samples(stat: DecisionClassStats) -> str:
         if full_r:
             lines.append("**Full (overruled):**")
             lines.append(full_r)
+            lines.append("")
+        if note:
+            # Operator-feedback shape: a single ``note`` field rather
+            # than the cheap-vs-full disagreement pair.
+            lines.append("**Operator note:**")
+            lines.append(note)
             lines.append("")
     return "\n".join(lines)
 
@@ -411,6 +418,144 @@ def cmd_reset(args: argparse.Namespace) -> int:
         all_=args.all,
     )
     print(f"Deleted {n} cell(s).", file=sys.stderr)
+    return 0
+
+
+def cmd_tool_evidence(args: argparse.Namespace) -> int:
+    """Walk an /agentic ``orchestrated_report.json`` + a /validate
+    ``validation_report.json``, joining on ``finding_id``, and record
+    one ``TOOL_EVIDENCE`` event per finding the validator concluded
+    on. Skips findings the validator marked inconclusive.
+
+    Operator-driven back-propagation: run after a /validate completes
+    to update the scorecard with downstream-validation truth signal.
+    """
+    import json as _json
+    from .tool_evidence import record_tool_evidence_outcomes
+
+    try:
+        analysis = _json.loads(Path(args.analysis).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as e:
+        print(f"error: cannot read analysis report {args.analysis!r}: {e}",
+              file=sys.stderr)
+        return 2
+    try:
+        validation = _json.loads(Path(args.validation).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as e:
+        print(f"error: cannot read validation report {args.validation!r}: {e}",
+              file=sys.stderr)
+        return 2
+
+    # Build {finding_id: validation_verdict} from the validation report.
+    # Tolerate multiple possible shapes — both a flat ``findings`` list
+    # and a nested ``results`` array.
+    val_by_id: dict = {}
+    val_findings = validation.get("findings") or validation.get("results") or []
+    for vf in val_findings:
+        fid = vf.get("finding_id")
+        if not fid:
+            continue
+        verdict = vf.get("is_exploitable")
+        if verdict is None:
+            # inconclusive — skip
+            continue
+        val_by_id[fid] = bool(verdict)
+
+    # Walk analysis records; emit one evidence record per finding the
+    # validator concluded on. Skip records missing the model — without
+    # an attributable model, a recorded event lands on a "?"-keyed
+    # cell that no producer ever revisits and that would silently
+    # accumulate noise.
+    records = []
+    skipped_no_model = 0
+    analysis_records = analysis.get("results") or []
+    for r in analysis_records:
+        fid = r.get("finding_id")
+        if not fid or fid not in val_by_id:
+            continue
+        model = r.get("analysed_by")
+        if not model:
+            skipped_no_model += 1
+            continue
+        records.append({
+            "model": model,
+            "rule_id": r.get("rule_id") or "unknown",
+            "analysis_verdict": bool(r.get("is_exploitable", False)),
+            "validation_verdict": val_by_id[fid],
+            "finding_id": fid,
+            "analysis_reasoning": r.get("reasoning") or "",
+        })
+
+    sc = ModelScorecard(args.path)
+    n = record_tool_evidence_outcomes(
+        sc, records=records,
+        decision_class_prefix=args.prefix,
+    )
+    print(
+        f"Recorded {n} tool_evidence event(s) "
+        f"from {len(records)} joined finding(s).",
+        file=sys.stderr,
+    )
+    if skipped_no_model:
+        print(
+            f"  notice: {skipped_no_model} analysis record(s) skipped "
+            "(no analysed_by field — can't attribute to a model)",
+            file=sys.stderr,
+        )
+    print(
+        "  reminder: re-running this command on the same reports "
+        "double-records. Track external state (commit hash, run id) "
+        "if invoking from automation.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def cmd_mark(args: argparse.Namespace) -> int:
+    """Record an explicit operator-feedback event on a (model,
+    decision_class) cell. Operator override of automated signals —
+    the operator inspected an output and is asserting whether the
+    model got it right or wrong. Increments the
+    ``operator_feedback`` event counter; the cell's auto-policy
+    surface still runs over the cheap-short-circuit math (per the
+    SHORT_CIRCUIT gate's design). The operator can read this
+    surface back through ``list``, ``compare``, or ``samples`` to
+    track whether their own feedback aligns with the model's
+    track record.
+    """
+    from .scorecard import EventType, ModelScorecard
+    sc = ModelScorecard(args.path)
+    # Soft notice when the targeted cell didn't pre-exist — catches
+    # decision_class / --model typos that would otherwise silently
+    # create a fresh cell that no producer ever touches again. Doesn't
+    # block (the operator may legitimately be marking a brand-new
+    # finding before any cheap-tier history has accumulated).
+    pre_existing = sc.get_stat(args.decision_class, args.model) is not None
+    sample = None
+    if args.note:
+        # Single-line operator note attached to the disagreement-
+        # samples log on incorrect outcomes. Bounded by
+        # ``record_event``'s caps + retain_samples gate.
+        sample = {"note": args.note}
+    sc.record_event(
+        decision_class=args.decision_class,
+        model=args.model,
+        event_type=EventType.OPERATOR_FEEDBACK,
+        outcome=args.outcome,
+        sample=sample,
+    )
+    print(
+        f"Recorded operator_feedback {args.outcome!r} on "
+        f"{args.decision_class} for {args.model}.",
+        file=sys.stderr,
+    )
+    if not pre_existing:
+        print(
+            f"  notice: {args.decision_class!r} on {args.model!r} had "
+            "no prior events — created a new cell. Double-check the "
+            "decision_class + --model spelling if this looks like a typo.",
+            file=sys.stderr,
+        )
     return 0
 
 
@@ -534,6 +679,70 @@ def _build_parser() -> argparse.ArgumentParser:
         help="delete every cell",
     )
     p_rst.set_defaults(handler=cmd_reset)
+
+    # mark — operator-feedback producer.
+    p_mark = sub.add_parser(
+        "mark",
+        help=(
+            "record an explicit operator-feedback event on a cell "
+            "(operator inspected a model's output and is asserting "
+            "whether it got it right). Bumps the operator_feedback "
+            "counter; visible via list/compare/samples."
+        ),
+    )
+    p_mark.add_argument(
+        "decision_class",
+        help="decision class — usually 'codeql:<rule_id>' or "
+             "'agentic:<rule_id>'",
+    )
+    p_mark.add_argument(
+        "outcome", choices=("correct", "incorrect"),
+        help="operator's verdict on the model's output for this cell",
+    )
+    p_mark.add_argument(
+        "--model", required=True,
+        help="model_name the verdict is being recorded against",
+    )
+    p_mark.add_argument(
+        "--note",
+        help=(
+            "short operator note attached to the disagreement-samples "
+            "log (only retained on outcome=incorrect, per the "
+            "scorecard's existing retain_samples policy). Avoid "
+            "including any code under analysis."
+        ),
+    )
+    p_mark.set_defaults(handler=cmd_mark)
+
+    # tool-evidence — automated back-propagation from /validate.
+    p_te = sub.add_parser(
+        "tool-evidence",
+        help=(
+            "back-propagate /validate outcomes onto the scorecard. "
+            "Joins an /agentic orchestrated_report.json with a "
+            "/validate validation_report.json by finding_id and "
+            "records one TOOL_EVIDENCE event per finding the "
+            "validator concluded on (skips inconclusive)."
+        ),
+    )
+    p_te.add_argument(
+        "--analysis", required=True, type=Path,
+        help="path to /agentic's orchestrated_report.json",
+    )
+    p_te.add_argument(
+        "--validation", required=True, type=Path,
+        help="path to /validate's validation_report.json",
+    )
+    p_te.add_argument(
+        "--prefix", default="agentic",
+        help=(
+            "decision_class prefix (default: 'agentic'). Use "
+            "'codeql' when validating /codeql findings so cells "
+            "land under codeql:<rule_id> matching the prefilter "
+            "producer's existing convention."
+        ),
+    )
+    p_te.set_defaults(handler=cmd_tool_evidence)
 
     return p
 

--- a/core/llm/scorecard/consensus.py
+++ b/core/llm/scorecard/consensus.py
@@ -1,0 +1,190 @@
+"""Producer wiring for ``EventType.MULTI_MODEL_CONSENSUS``.
+
+When /agentic dispatches multiple analysis models on the same finding,
+post-dispatch correlation tags each finding as ``"high"`` (everyone
+agreed exploitable), ``"high-negative"`` (everyone agreed not),
+or ``"disputed"`` (split). For disputed findings, this producer
+records:
+
+  * each minority model → ``incorrect``
+  * each majority model → ``correct``
+
+against the ``(model, decision_class)`` cell, where decision_class is
+``agentic:<rule_id>``. Agreed findings produce no signal — they're
+useful for downstream confidence math but don't tell us which models
+drift from panel consensus over time.
+
+Ties (e.g. 1-vs-1 in a 2-model panel) are skipped: there's no clear
+majority and arbitrarily declaring one model wrong would inject noise
+into the cell. The cheap-tier ``CHEAP_SHORT_CIRCUIT`` counter is
+untouched — this producer feeds its own event slot only and never
+shifts the auto-policy gate.
+
+Sister producers in the same family:
+
+  * ``core.llm.scorecard.prefilter`` — ``CHEAP_SHORT_CIRCUIT`` (the
+    fast-tier prefilter producer; landed first; drives the
+    auto-policy gate).
+  * ``core.llm.scorecard.judge`` — ``JUDGE_REVIEW`` (judge model
+    overruling primary; landed alongside this).
+  * ``core.llm.scorecard.tool_evidence`` — ``TOOL_EVIDENCE``
+    (downstream validation back-propagation).
+
+These all use the same ``record_event`` substrate API + same
+decision_class shape (``<consumer>:<rule_id>``). Naming and
+policy-isolation conventions live here so future producers added to
+the family stay in lock-step.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from .scorecard import EventType, ModelScorecard
+
+logger = logging.getLogger(__name__)
+
+
+_MAX_REASONING_CHARS = 500
+
+
+def record_consensus_outcomes(
+    scorecard: Optional[ModelScorecard],
+    *,
+    correlation: Dict[str, Any],
+    results_by_id: Dict[str, Dict],
+    per_finding_results: Optional[Dict[str, Any]] = None,
+    decision_class_prefix: str = "agentic",
+) -> int:
+    """Walk a correlation result; record one
+    ``MULTI_MODEL_CONSENSUS`` event per (model, finding) pair on
+    disputed findings.
+
+    Returns the number of events written.
+
+    No-op when ``scorecard`` is ``None`` (operator opted out via
+    ``scorecard_enabled=False`` or the consumer didn't have a
+    scorecard available). No-op when ``correlation`` is empty
+    (single-model run).
+
+    ``per_finding_results`` (optional): mapping ``{finding_id: [
+    per-model result dict, ...]}`` from the orchestrator's
+    per-model dispatch. When supplied, the producer captures each
+    minority model's OWN reasoning into the disagreement-samples
+    log (rather than the primary's, which is misleading attribution).
+    Passing ``None`` skips per-model reasoning capture — the cell
+    still gets the correct/incorrect counter bumps, just no sample
+    text. Decoupled from ``results_by_id`` to avoid mutating the
+    primary records the orchestrator later serialises into
+    ``orchestrated_report.json``.
+
+    The ``decision_class_prefix`` follows the existing convention —
+    ``"agentic"`` for /agentic-dispatched findings, matching the
+    prefilter producer's ``agentic:<rule_id>`` cell shape so consensus
+    and prefilter signals share the same cell.
+
+    Failure path: any per-event ``record_event`` exception is logged
+    at debug level and swallowed; one bad event must not abort the
+    whole batch and must never block the calling orchestrator's
+    flow. Operators who care will see the per-event log line.
+    """
+    if scorecard is None or not correlation:
+        return 0
+    matrix = correlation.get("agreement_matrix") or {}
+    confidence = correlation.get("confidence_signals") or {}
+    if not matrix:
+        return 0
+
+    n_recorded = 0
+    for fid, per_model in matrix.items():
+        if confidence.get(fid) != "disputed":
+            continue
+
+        verdicts: Dict[str, bool] = {}
+        for model, mr in per_model.items():
+            v = mr.get("is_exploitable")
+            if v is None:
+                # Result missing the verdict (handler error / schema
+                # failure); can't classify against majority, skip
+                # this model for this finding.
+                continue
+            verdicts[str(model)] = bool(v)
+        if len(verdicts) < 2:
+            # Need at least two models with verdicts to define a
+            # majority direction. ``confidence == "disputed"`` should
+            # imply this but be defensive against dirty inputs.
+            continue
+
+        exploitable_count = sum(1 for v in verdicts.values() if v)
+        non_exploitable_count = len(verdicts) - exploitable_count
+        if exploitable_count == 0 or non_exploitable_count == 0:
+            # Defensive: if everyone with a verdict agrees, the
+            # finding shouldn't be tagged disputed. Skip to avoid
+            # recording noise.
+            continue
+        if exploitable_count == non_exploitable_count:
+            # No clear majority — typically a 1-vs-1 split in a
+            # 2-model panel. Recording would arbitrarily declare one
+            # model "incorrect" against the other; skip rather than
+            # inject noise.
+            continue
+
+        majority_says_exploitable = exploitable_count > non_exploitable_count
+
+        result = results_by_id.get(fid) or {}
+        rule_id = str(result.get("rule_id") or "unknown")
+        decision_class = f"{decision_class_prefix}:{rule_id}"
+
+        # Look up this finding's per-model result list (when the
+        # caller supplied one) so we can attribute reasoning to the
+        # actual minority model rather than mis-attributing the
+        # primary's reasoning to a dissenter.
+        this_finding_per_model = (
+            (per_finding_results or {}).get(fid) or []
+        )
+
+        for model, verdict in verdicts.items():
+            with_majority = (verdict == majority_says_exploitable)
+            outcome = "correct" if with_majority else "incorrect"
+            sample = None
+            if outcome == "incorrect":
+                # Capture the minority model's OWN reasoning. If we
+                # can't find it in ``per_finding_results`` (caller
+                # didn't supply, or the per-model record is missing),
+                # skip the sample rather than fall back to the
+                # primary's reasoning — that would mis-attribute the
+                # majority's text to the dissenter.
+                this_model_result = next(
+                    (r for r in this_finding_per_model
+                     if str(r.get("analysed_by") or r.get("model") or "") == model),
+                    None,
+                )
+                if this_model_result is not None:
+                    reasoning = str(this_model_result.get("reasoning") or "")
+                    sample = {
+                        "this_reasoning": reasoning[:_MAX_REASONING_CHARS],
+                        "other_reasoning": (
+                            f"majority of {len(verdicts)} models voted "
+                            f"{'exploitable' if majority_says_exploitable else 'not exploitable'}"
+                        ),
+                    }
+            try:
+                scorecard.record_event(
+                    decision_class=decision_class,
+                    model=model,
+                    event_type=EventType.MULTI_MODEL_CONSENSUS,
+                    outcome=outcome,
+                    sample=sample,
+                )
+                n_recorded += 1
+            except Exception as e:                       # noqa: BLE001
+                logger.debug(
+                    "record_consensus_outcomes: failed to record %s/%s "
+                    "on %s: %s",
+                    model, decision_class, fid, e,
+                )
+    return n_recorded
+
+
+__all__ = ["record_consensus_outcomes"]

--- a/core/llm/scorecard/judge.py
+++ b/core/llm/scorecard/judge.py
@@ -1,0 +1,166 @@
+"""Producer wiring for ``EventType.JUDGE_REVIEW``.
+
+When /agentic dispatches a judge panel (``--judge <model>``,
+``--judge <m1> <m2>`` etc.) over the primary's analysis, the
+``JudgeTask`` finalises a final verdict by majority vote across
+(primary + judges). Disputes — where one or more participants
+disagreed — are this producer's signal:
+
+  * Primary's vote != final → primary's model gets ``incorrect``.
+  * Primary's vote == final → primary's model gets ``correct``.
+  * Each judge's vote vs final → same.
+
+Single-judge mode is INTENTIONALLY SKIPPED. There the ``JudgeTask``
+keeps the primary's verdict (``final = primary_exploitable``) and
+just flags the dispute for operator review — there's no automated
+truth signal worth recording. Multi-judge mode is where the panel
+collectively overrules and the producer can attribute correctness.
+
+Agreed findings produce no signal — every model voted the same way
+so the cell would just bump uniformly without distinguishing models.
+Same skip pattern as ``record_consensus_outcomes``.
+
+Cells are keyed by ``agentic:<rule_id>``, shared with the
+multi-model-consensus and prefilter producers; different event
+slots (``JUDGE_REVIEW`` vs ``MULTI_MODEL_CONSENSUS`` vs
+``CHEAP_SHORT_CIRCUIT``) keep their counters isolated. The
+auto-policy gate's Wilson math runs over the cheap-tier slot
+only — judge events do NOT shift the prefilter gate.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from .scorecard import EventType, ModelScorecard
+
+logger = logging.getLogger(__name__)
+
+
+_MAX_REASONING_CHARS = 500
+
+
+def record_judge_outcomes(
+    scorecard: Optional[ModelScorecard],
+    *,
+    results_by_id: Dict[str, Dict],
+    primary_verdicts_before_judge: Dict[str, bool],
+    decision_class_prefix: str = "agentic",
+) -> int:
+    """Walk results that ran through ``JudgeTask``; record one
+    ``JUDGE_REVIEW`` event per (model, finding) for disputed
+    multi-judge findings.
+
+    ``primary_verdicts_before_judge`` is a snapshot of each finding's
+    primary verdict captured BEFORE ``JudgeTask`` ran — JudgeTask
+    overwrites ``primary["is_exploitable"]`` with the final majority
+    verdict, so we need the snapshot to know which way primary
+    originally voted.
+
+    Returns count of events written. No-op on ``scorecard=None``.
+    """
+    if scorecard is None or not results_by_id:
+        return 0
+
+    n_recorded = 0
+    for fid, result in results_by_id.items():
+        if not isinstance(result, dict) or "error" in result:
+            continue
+        if result.get("judge") != "disputed":
+            continue
+
+        judge_analyses = result.get("judge_analyses") or []
+        if len(judge_analyses) < 2:
+            # Single-judge disputes don't yield a panel-majority
+            # signal — JudgeTask keeps the primary's verdict in that
+            # case and only flags the dispute for operator review.
+            # Recording a "primary correct, judge incorrect" event
+            # would be wrong — the dispute is real, the resolution
+            # isn't operator-trusted.
+            continue
+
+        if fid not in primary_verdicts_before_judge:
+            # Defensive — caller didn't snapshot this finding. Skip
+            # rather than mis-attribute against the now-overwritten
+            # primary verdict.
+            continue
+
+        rule_id = str(result.get("rule_id") or "unknown")
+        decision_class = f"{decision_class_prefix}:{rule_id}"
+        final_verdict = bool(result.get("is_exploitable"))
+        primary_model = str(result.get("analysed_by") or "?")
+        primary_vote = bool(primary_verdicts_before_judge[fid])
+
+        # Primary's outcome
+        primary_correct = (primary_vote == final_verdict)
+        _record_one(
+            scorecard,
+            decision_class=decision_class,
+            model=primary_model,
+            outcome="correct" if primary_correct else "incorrect",
+            sample_reasoning=(
+                None if primary_correct
+                else str(result.get("reasoning") or "")
+            ),
+            other_summary=(
+                f"panel of {len(judge_analyses)} judge(s) voted "
+                f"{'exploitable' if final_verdict else 'not exploitable'}"
+            ),
+        )
+        n_recorded += 1
+
+        # Each judge's outcome
+        for ja in judge_analyses:
+            judge_model = str(ja.get("model") or "?")
+            judge_vote = bool(ja.get("is_exploitable"))
+            judge_correct = (judge_vote == final_verdict)
+            _record_one(
+                scorecard,
+                decision_class=decision_class,
+                model=judge_model,
+                outcome="correct" if judge_correct else "incorrect",
+                sample_reasoning=(
+                    None if judge_correct
+                    else str(ja.get("reasoning") or "")
+                ),
+                other_summary=(
+                    f"panel majority voted "
+                    f"{'exploitable' if final_verdict else 'not exploitable'}"
+                ),
+            )
+            n_recorded += 1
+    return n_recorded
+
+
+def _record_one(
+    scorecard: ModelScorecard,
+    *,
+    decision_class: str,
+    model: str,
+    outcome: str,
+    sample_reasoning: Optional[str],
+    other_summary: str,
+) -> None:
+    sample = None
+    if outcome == "incorrect" and sample_reasoning is not None:
+        sample = {
+            "this_reasoning": sample_reasoning[:_MAX_REASONING_CHARS],
+            "other_reasoning": other_summary,
+        }
+    try:
+        scorecard.record_event(
+            decision_class=decision_class,
+            model=model,
+            event_type=EventType.JUDGE_REVIEW,
+            outcome=outcome,
+            sample=sample,
+        )
+    except Exception as e:                              # noqa: BLE001
+        logger.debug(
+            "record_judge_outcomes: failed to record %s/%s: %s",
+            model, decision_class, e,
+        )
+
+
+__all__ = ["record_judge_outcomes"]

--- a/core/llm/scorecard/tests/test_cli.py
+++ b/core/llm/scorecard/tests/test_cli.py
@@ -82,6 +82,7 @@ def _make_args(**kwargs):
         model_a=None, model_b=None,
         decision_class=None, model=None, as_=None,
         older_than_days=None, all=False,
+        outcome=None, note=None,
     )
     base.update(kwargs)
     return SimpleNamespace(**base)
@@ -301,6 +302,161 @@ def test_reset_all(seeded_scorecard):
     _capture(cli_mod.cmd_reset, args)
     sc = ModelScorecard(seeded_scorecard)
     assert sc.get_stats() == []
+
+
+# ---------------------------------------------------------------------------
+# mark — operator_feedback producer
+# ---------------------------------------------------------------------------
+
+
+def test_mark_correct_records_operator_feedback(seeded_scorecard):
+    args = _make_args(
+        path=seeded_scorecard,
+        decision_class="codeql:py/sql-injection",
+        model="claude-haiku-4-5",
+        outcome="correct",
+    )
+    rc, _, err = _capture(cli_mod.cmd_mark, args)
+    assert rc == 0
+    assert "operator_feedback 'correct'" in err
+    sc = ModelScorecard(seeded_scorecard)
+    stat = sc.get_stat("codeql:py/sql-injection", "claude-haiku-4-5")
+    from core.llm.scorecard.scorecard import EventType
+    assert stat.events[EventType.OPERATOR_FEEDBACK].correct == 1
+    assert stat.events[EventType.OPERATOR_FEEDBACK].incorrect == 0
+
+
+def test_mark_incorrect_records_and_attaches_note(seeded_scorecard):
+    args = _make_args(
+        path=seeded_scorecard,
+        decision_class="codeql:py/sql-injection",
+        model="claude-haiku-4-5",
+        outcome="incorrect",
+        note="Verified false positive — sanitiser was applied upstream.",
+    )
+    rc, _, _ = _capture(cli_mod.cmd_mark, args)
+    assert rc == 0
+    sc = ModelScorecard(seeded_scorecard)
+    stat = sc.get_stat("codeql:py/sql-injection", "claude-haiku-4-5")
+    from core.llm.scorecard.scorecard import EventType
+    assert stat.events[EventType.OPERATOR_FEEDBACK].incorrect == 1
+    # Note attached to the disagreement-samples log on incorrect.
+    notes = [s.get("note") for s in stat.disagreement_samples
+             if s.get("event_type") == EventType.OPERATOR_FEEDBACK]
+    assert "sanitiser was applied upstream" in (notes[0] or "")
+
+
+def test_mark_correct_with_note_does_not_attach_note(seeded_scorecard):
+    """retain_samples policy: notes only kept on incorrect outcomes
+    (mirrors the cheap/full producer's behaviour). Correct + note is
+    accepted but the note doesn't accumulate — keeps the cell from
+    becoming an operator notebook."""
+    args = _make_args(
+        path=seeded_scorecard,
+        decision_class="codeql:py/sql-injection",
+        model="claude-haiku-4-5",
+        outcome="correct",
+        note="great catch",
+    )
+    _capture(cli_mod.cmd_mark, args)
+    sc = ModelScorecard(seeded_scorecard)
+    stat = sc.get_stat("codeql:py/sql-injection", "claude-haiku-4-5")
+    correct_notes = [s for s in stat.disagreement_samples
+                     if s.get("note") == "great catch"]
+    assert correct_notes == []
+
+
+def test_mark_creates_cell_when_absent(seeded_scorecard):
+    """The cell may not yet exist (operator marking a finding before
+    the model has any cheap-tier history). ``record_event`` creates
+    it on demand."""
+    args = _make_args(
+        path=seeded_scorecard,
+        decision_class="codeql:py/never-seen",
+        model="brand-new-model",
+        outcome="correct",
+    )
+    _capture(cli_mod.cmd_mark, args)
+    sc = ModelScorecard(seeded_scorecard)
+    stat = sc.get_stat("codeql:py/never-seen", "brand-new-model")
+    from core.llm.scorecard.scorecard import EventType
+    assert stat.events[EventType.OPERATOR_FEEDBACK].correct == 1
+
+
+def test_mark_does_not_pollute_cheap_short_circuit_counters(seeded_scorecard):
+    """Operator feedback is its own counter; the prefilter gate's
+    Wilson math runs over CHEAP_SHORT_CIRCUIT only. Marking does
+    NOT shift the auto-policy decision."""
+    sc = ModelScorecard(seeded_scorecard)
+    from core.llm.scorecard.scorecard import EventType
+    before = sc.get_stat("codeql:py/sql-injection", "claude-haiku-4-5")
+    before_cheap = (
+        before.events[EventType.CHEAP_SHORT_CIRCUIT].correct,
+        before.events[EventType.CHEAP_SHORT_CIRCUIT].incorrect,
+    )
+    args = _make_args(
+        path=seeded_scorecard,
+        decision_class="codeql:py/sql-injection",
+        model="claude-haiku-4-5",
+        outcome="incorrect",
+    )
+    _capture(cli_mod.cmd_mark, args)
+    after = sc.get_stat("codeql:py/sql-injection", "claude-haiku-4-5")
+    after_cheap = (
+        after.events[EventType.CHEAP_SHORT_CIRCUIT].correct,
+        after.events[EventType.CHEAP_SHORT_CIRCUIT].incorrect,
+    )
+    assert before_cheap == after_cheap
+
+
+def test_mark_emits_typo_notice_on_new_cell(seeded_scorecard):
+    """Adversarial: catch decision_class / --model typos that would
+    silently create a fresh cell no producer touches. Soft notice
+    rather than refusal — operator may legitimately be marking a
+    brand-new finding."""
+    args = _make_args(
+        path=seeded_scorecard,
+        decision_class="codeql:py/typo-class",  # no prior events
+        model="brand-new-model",
+        outcome="correct",
+    )
+    rc, _, err = _capture(cli_mod.cmd_mark, args)
+    assert rc == 0
+    assert "no prior events" in err
+    assert "typo" in err
+
+
+def test_mark_no_notice_on_existing_cell(seeded_scorecard):
+    """Marking a cell with prior history → no typo notice (it's
+    clearly the right cell). Reduces operator-friction on the
+    expected case."""
+    # seeded_scorecard already has codeql:py/sql-injection on
+    # claude-haiku-4-5 with cheap-tier history.
+    args = _make_args(
+        path=seeded_scorecard,
+        decision_class="codeql:py/sql-injection",
+        model="claude-haiku-4-5",
+        outcome="correct",
+    )
+    rc, _, err = _capture(cli_mod.cmd_mark, args)
+    assert rc == 0
+    assert "no prior events" not in err
+
+
+def test_mark_invalid_outcome_rejected(seeded_scorecard):
+    """``outcome`` must be ``correct`` or ``incorrect`` —
+    ``record_event`` raises on anything else. The argparse ``choices=``
+    layer is the first defence; this test pins the substrate-side
+    validation that catches direct API misuse."""
+    import pytest
+    args = _make_args(
+        path=seeded_scorecard,
+        decision_class="codeql:py/sql-injection",
+        model="claude-haiku-4-5",
+        outcome="maybe",
+    )
+    with pytest.raises(ValueError, match="outcome must be"):
+        _capture(cli_mod.cmd_mark, args)
 
 
 # ---------------------------------------------------------------------------

--- a/core/llm/scorecard/tests/test_consensus.py
+++ b/core/llm/scorecard/tests/test_consensus.py
@@ -1,0 +1,381 @@
+"""Tests for ``core.llm.scorecard.consensus.record_consensus_outcomes``.
+
+Pins the producer's contract:
+  * Disputed findings produce one event per (model, finding) pair
+    — minority gets ``incorrect``, majority gets ``correct``.
+  * Agreed findings produce no events (no useful signal).
+  * Ties (1-vs-1, 2-vs-2) skipped — no clear majority.
+  * Decision class shape: ``agentic:<rule_id>``.
+  * Cheap-tier counters untouched (this producer feeds its own slot).
+  * No-op on ``scorecard=None`` or empty correlation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.llm.scorecard.consensus import record_consensus_outcomes
+from core.llm.scorecard.scorecard import EventType, ModelScorecard
+
+
+@pytest.fixture
+def scorecard(tmp_path: Path) -> ModelScorecard:
+    return ModelScorecard(tmp_path / "sc.json", shadow_rate=0.0)
+
+
+def _correlation(*, matrix, confidence):
+    return {
+        "agreement_matrix": matrix,
+        "confidence_signals": confidence,
+    }
+
+
+def _stat(sc: ModelScorecard, dc: str, model: str, ev: str):
+    s = sc.get_stat(dc, model)
+    if s is None:
+        return (0, 0)
+    return s.events[ev].correct, s.events[ev].incorrect
+
+
+# ---------------------------------------------------------------------------
+# No-op paths
+# ---------------------------------------------------------------------------
+
+
+class TestNoOp:
+    def test_none_scorecard(self):
+        n = record_consensus_outcomes(
+            None,
+            correlation={"agreement_matrix": {}, "confidence_signals": {}},
+            results_by_id={},
+        )
+        assert n == 0
+
+    def test_empty_correlation(self, scorecard):
+        n = record_consensus_outcomes(
+            scorecard, correlation={}, results_by_id={},
+        )
+        assert n == 0
+
+    def test_empty_matrix(self, scorecard):
+        n = record_consensus_outcomes(
+            scorecard,
+            correlation=_correlation(matrix={}, confidence={}),
+            results_by_id={},
+        )
+        assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# Disputed findings → events recorded
+# ---------------------------------------------------------------------------
+
+
+class TestDisputedFindings:
+    def test_2v1_minority_incorrect_majority_correct(self, scorecard):
+        """3-model panel, 2 say exploitable, 1 dissents.
+        Majority (2) → correct; minority (1) → incorrect."""
+        matrix = {
+            "f1": {
+                "pro":   {"is_exploitable": True},
+                "opus":  {"is_exploitable": True},
+                "flash": {"is_exploitable": False},
+            },
+        }
+        confidence = {"f1": "disputed"}
+        results = {"f1": {"rule_id": "py/sql-injection", "reasoning": "..."}}
+
+        n = record_consensus_outcomes(
+            scorecard,
+            correlation=_correlation(matrix=matrix, confidence=confidence),
+            results_by_id=results,
+        )
+        assert n == 3
+
+        dc = "agentic:py/sql-injection"
+        assert _stat(scorecard, dc, "pro",   EventType.MULTI_MODEL_CONSENSUS) == (1, 0)
+        assert _stat(scorecard, dc, "opus",  EventType.MULTI_MODEL_CONSENSUS) == (1, 0)
+        assert _stat(scorecard, dc, "flash", EventType.MULTI_MODEL_CONSENSUS) == (0, 1)
+
+    def test_1v2_minority_incorrect_majority_correct(self, scorecard):
+        """Symmetric case: 2 say not-exploitable, 1 dissents (says exploitable)."""
+        matrix = {
+            "f1": {
+                "pro":   {"is_exploitable": False},
+                "opus":  {"is_exploitable": False},
+                "flash": {"is_exploitable": True},
+            },
+        }
+        confidence = {"f1": "disputed"}
+        results = {"f1": {"rule_id": "py/sql-injection"}}
+
+        record_consensus_outcomes(
+            scorecard,
+            correlation=_correlation(matrix=matrix, confidence=confidence),
+            results_by_id=results,
+        )
+        dc = "agentic:py/sql-injection"
+        assert _stat(scorecard, dc, "pro",   EventType.MULTI_MODEL_CONSENSUS) == (1, 0)
+        assert _stat(scorecard, dc, "opus",  EventType.MULTI_MODEL_CONSENSUS) == (1, 0)
+        assert _stat(scorecard, dc, "flash", EventType.MULTI_MODEL_CONSENSUS) == (0, 1)
+
+    def test_minority_reasoning_captured_as_sample(self, scorecard):
+        """Minority's own reasoning attached to the disagreement-
+        samples log when ``per_finding_results`` is supplied."""
+        matrix = {
+            "f1": {
+                "pro":   {"is_exploitable": True},
+                "opus":  {"is_exploitable": True},
+                "flash": {"is_exploitable": False},
+            },
+        }
+        confidence = {"f1": "disputed"}
+        results = {"f1": {"rule_id": "py/sql-injection"}}
+        per_finding_results = {"f1": [
+            {"analysed_by": "pro", "reasoning": "pro: clearly tainted"},
+            {"analysed_by": "opus", "reasoning": "opus: tainted"},
+            {"analysed_by": "flash", "reasoning": "flash: input is hardcoded"},
+        ]}
+
+        record_consensus_outcomes(
+            scorecard,
+            correlation=_correlation(matrix=matrix, confidence=confidence),
+            results_by_id=results,
+            per_finding_results=per_finding_results,
+        )
+        s = scorecard.get_stat("agentic:py/sql-injection", "flash")
+        flash_samples = [
+            samp for samp in s.disagreement_samples
+            if samp.get("event_type") == EventType.MULTI_MODEL_CONSENSUS
+        ]
+        assert len(flash_samples) == 1
+        assert "input is hardcoded" in flash_samples[0]["this_reasoning"]
+        assert "majority" in flash_samples[0]["other_reasoning"]
+
+    def test_minority_no_sample_when_per_finding_results_missing(self, scorecard):
+        """Adversarial: caller didn't supply per_finding_results.
+        Producer skips the sample rather than mis-attribute the
+        primary's reasoning to the dissenter. Counters still bump."""
+        matrix = {
+            "f1": {
+                "pro":   {"is_exploitable": True},
+                "opus":  {"is_exploitable": True},
+                "flash": {"is_exploitable": False},
+            },
+        }
+        confidence = {"f1": "disputed"}
+        results = {"f1": {
+            "rule_id": "py/sql-injection",
+            "reasoning": "primary's reasoning — must NOT be attributed to flash",
+        }}
+        record_consensus_outcomes(
+            scorecard,
+            correlation=_correlation(matrix=matrix, confidence=confidence),
+            results_by_id=results,
+            per_finding_results=None,
+        )
+        s = scorecard.get_stat("agentic:py/sql-injection", "flash")
+        # Counter bumped (the dissent is recorded).
+        assert s.events[EventType.MULTI_MODEL_CONSENSUS].incorrect == 1
+        # But no sample — would have mis-attributed the primary's
+        # text to flash, which is misleading.
+        flash_samples = [
+            samp for samp in s.disagreement_samples
+            if samp.get("event_type") == EventType.MULTI_MODEL_CONSENSUS
+        ]
+        assert flash_samples == []
+
+
+# ---------------------------------------------------------------------------
+# Skip paths — no events when signal isn't useful
+# ---------------------------------------------------------------------------
+
+
+class TestSkipPaths:
+    def test_agreed_findings_skipped(self, scorecard):
+        """All models agreed → no event recorded. Avoids bumping
+        every model's counter on every agreed finding (noise)."""
+        matrix = {
+            "f1": {
+                "pro":   {"is_exploitable": True},
+                "opus":  {"is_exploitable": True},
+                "flash": {"is_exploitable": True},
+            },
+        }
+        confidence = {"f1": "high"}
+        results = {"f1": {"rule_id": "py/x"}}
+
+        n = record_consensus_outcomes(
+            scorecard,
+            correlation=_correlation(matrix=matrix, confidence=confidence),
+            results_by_id=results,
+        )
+        assert n == 0
+
+    def test_tie_1v1_skipped(self, scorecard):
+        """1-vs-1 split in a 2-model panel → no clear majority. Skip
+        rather than arbitrarily declare one model wrong."""
+        matrix = {
+            "f1": {
+                "pro":   {"is_exploitable": True},
+                "flash": {"is_exploitable": False},
+            },
+        }
+        # Note: with 1==1 the existing correlation labels this
+        # "disputed" too; we skip downstream of that signal.
+        confidence = {"f1": "disputed"}
+        results = {"f1": {"rule_id": "py/x"}}
+
+        n = record_consensus_outcomes(
+            scorecard,
+            correlation=_correlation(matrix=matrix, confidence=confidence),
+            results_by_id=results,
+        )
+        assert n == 0
+
+    def test_tie_2v2_skipped(self, scorecard):
+        matrix = {
+            "f1": {
+                "a": {"is_exploitable": True},
+                "b": {"is_exploitable": True},
+                "c": {"is_exploitable": False},
+                "d": {"is_exploitable": False},
+            },
+        }
+        confidence = {"f1": "disputed"}
+        results = {"f1": {"rule_id": "py/x"}}
+
+        n = record_consensus_outcomes(
+            scorecard,
+            correlation=_correlation(matrix=matrix, confidence=confidence),
+            results_by_id=results,
+        )
+        assert n == 0
+
+    def test_missing_verdict_excludes_model(self, scorecard):
+        """A model with ``is_exploitable=None`` (handler error / schema
+        failure) doesn't have a vote — exclude it from the majority
+        calculation rather than counting it as either."""
+        matrix = {
+            "f1": {
+                "pro":   {"is_exploitable": True},
+                "opus":  {"is_exploitable": True},
+                "flash": {"is_exploitable": False},
+                "broken": {"is_exploitable": None},  # model errored
+            },
+        }
+        confidence = {"f1": "disputed"}
+        results = {"f1": {"rule_id": "py/x"}}
+
+        n = record_consensus_outcomes(
+            scorecard,
+            correlation=_correlation(matrix=matrix, confidence=confidence),
+            results_by_id=results,
+        )
+        # 3 events: pro+opus correct, flash incorrect. broken: no event.
+        assert n == 3
+        assert scorecard.get_stat("agentic:py/x", "broken") is None
+
+    def test_under_two_voters_skipped(self, scorecard):
+        """If only one model has a verdict (others all errored),
+        there's nothing to compare against — skip."""
+        matrix = {
+            "f1": {
+                "pro":   {"is_exploitable": True},
+                "broken1": {"is_exploitable": None},
+                "broken2": {"is_exploitable": None},
+            },
+        }
+        confidence = {"f1": "disputed"}
+        results = {"f1": {"rule_id": "py/x"}}
+
+        n = record_consensus_outcomes(
+            scorecard,
+            correlation=_correlation(matrix=matrix, confidence=confidence),
+            results_by_id=results,
+        )
+        assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# Decision-class shape + isolation from gate
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionClass:
+    def test_decision_class_uses_agentic_prefix(self, scorecard):
+        matrix = {
+            "f1": {
+                "pro":   {"is_exploitable": True},
+                "opus":  {"is_exploitable": True},
+                "flash": {"is_exploitable": False},
+            },
+        }
+        confidence = {"f1": "disputed"}
+        results = {"f1": {"rule_id": "java/path-traversal"}}
+
+        record_consensus_outcomes(
+            scorecard,
+            correlation=_correlation(matrix=matrix, confidence=confidence),
+            results_by_id=results,
+        )
+        # Cell exists under agentic:java/path-traversal, NOT bare
+        # rule_id and NOT codeql:.
+        all_classes = {s.decision_class for s in scorecard.get_stats()}
+        assert "agentic:java/path-traversal" in all_classes
+        assert "java/path-traversal" not in all_classes
+        assert "codeql:java/path-traversal" not in all_classes
+
+    def test_unknown_rule_id_substituted(self, scorecard):
+        matrix = {
+            "f1": {
+                "pro":   {"is_exploitable": True},
+                "opus":  {"is_exploitable": True},
+                "flash": {"is_exploitable": False},
+            },
+        }
+        confidence = {"f1": "disputed"}
+        # Result missing rule_id — producer falls back to "unknown"
+        # rather than crashing.
+        results = {"f1": {}}
+        record_consensus_outcomes(
+            scorecard,
+            correlation=_correlation(matrix=matrix, confidence=confidence),
+            results_by_id=results,
+        )
+        all_classes = {s.decision_class for s in scorecard.get_stats()}
+        assert "agentic:unknown" in all_classes
+
+
+class TestIsolationFromGate:
+    def test_does_not_pollute_cheap_short_circuit(self, scorecard):
+        """The auto-policy gate's Wilson math runs over
+        CHEAP_SHORT_CIRCUIT only. Recording MULTI_MODEL_CONSENSUS
+        events MUST NOT bump that counter — otherwise consensus
+        signals would silently shift the prefilter gate's behaviour."""
+        # Pre-seed cheap-tier with confident-trust state.
+        for _ in range(20):
+            scorecard.record_event(
+                "agentic:py/x", "flash",
+                EventType.CHEAP_SHORT_CIRCUIT, "correct",
+            )
+        before = _stat(scorecard, "agentic:py/x", "flash",
+                       EventType.CHEAP_SHORT_CIRCUIT)
+
+        matrix = {"f1": {
+            "pro":   {"is_exploitable": True},
+            "opus":  {"is_exploitable": True},
+            "flash": {"is_exploitable": False},
+        }}
+        confidence = {"f1": "disputed"}
+        results = {"f1": {"rule_id": "py/x"}}
+        record_consensus_outcomes(
+            scorecard,
+            correlation=_correlation(matrix=matrix, confidence=confidence),
+            results_by_id=results,
+        )
+        after = _stat(scorecard, "agentic:py/x", "flash",
+                      EventType.CHEAP_SHORT_CIRCUIT)
+        assert before == after  # cheap-tier counter unchanged

--- a/core/llm/scorecard/tests/test_judge.py
+++ b/core/llm/scorecard/tests/test_judge.py
@@ -1,0 +1,276 @@
+"""Tests for ``core.llm.scorecard.judge.record_judge_outcomes``.
+
+Pins the producer's contract:
+  * Multi-judge disputes record one event per (model, finding):
+    primary's vote vs final, each judge's vote vs final.
+  * Single-judge disputes skipped (no panel-majority truth signal).
+  * Agreed findings skipped.
+  * Decision class shape ``agentic:<rule_id>``.
+  * Cheap-tier counters untouched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.llm.scorecard.judge import record_judge_outcomes
+from core.llm.scorecard.scorecard import EventType, ModelScorecard
+
+
+@pytest.fixture
+def scorecard(tmp_path: Path) -> ModelScorecard:
+    return ModelScorecard(tmp_path / "sc.json", shadow_rate=0.0)
+
+
+def _stat(sc: ModelScorecard, dc: str, model: str, ev: str):
+    s = sc.get_stat(dc, model)
+    if s is None:
+        return (0, 0)
+    return s.events[ev].correct, s.events[ev].incorrect
+
+
+# ---------------------------------------------------------------------------
+# No-op paths
+# ---------------------------------------------------------------------------
+
+
+class TestNoOp:
+    def test_none_scorecard(self):
+        n = record_judge_outcomes(
+            None,
+            results_by_id={},
+            primary_verdicts_before_judge={},
+        )
+        assert n == 0
+
+    def test_empty_results(self, scorecard):
+        n = record_judge_outcomes(
+            scorecard,
+            results_by_id={},
+            primary_verdicts_before_judge={},
+        )
+        assert n == 0
+
+    def test_skips_findings_without_judge_field(self, scorecard):
+        results = {"f1": {"rule_id": "py/x", "is_exploitable": True}}
+        n = record_judge_outcomes(
+            scorecard,
+            results_by_id=results,
+            primary_verdicts_before_judge={"f1": True},
+        )
+        assert n == 0
+
+    def test_skips_error_results(self, scorecard):
+        results = {"f1": {"error": "timeout", "judge": "disputed"}}
+        n = record_judge_outcomes(
+            scorecard,
+            results_by_id=results,
+            primary_verdicts_before_judge={"f1": True},
+        )
+        assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# Multi-judge disputes — events recorded
+# ---------------------------------------------------------------------------
+
+
+class TestMultiJudgeDispute:
+    def test_panel_overrules_primary(self, scorecard):
+        """Primary said exploitable; 2 judges said not. Final is
+        not-exploitable. Primary → incorrect; judges → correct."""
+        results = {"f1": {
+            "rule_id": "py/sql-injection",
+            "judge": "disputed",
+            "is_exploitable": False,                    # final
+            "analysed_by": "claude-opus",
+            "reasoning": "primary thought tainted",
+            "judge_analyses": [
+                {"model": "gpt-4", "is_exploitable": False,
+                 "reasoning": "actually constant"},
+                {"model": "gemini", "is_exploitable": False,
+                 "reasoning": "validated input"},
+            ],
+        }}
+        n = record_judge_outcomes(
+            scorecard,
+            results_by_id=results,
+            primary_verdicts_before_judge={"f1": True},  # primary said True
+        )
+        assert n == 3
+        dc = "agentic:py/sql-injection"
+        assert _stat(scorecard, dc, "claude-opus", EventType.JUDGE_REVIEW) == (0, 1)
+        assert _stat(scorecard, dc, "gpt-4",       EventType.JUDGE_REVIEW) == (1, 0)
+        assert _stat(scorecard, dc, "gemini",      EventType.JUDGE_REVIEW) == (1, 0)
+
+    def test_panel_kept_primary(self, scorecard):
+        """Primary said exploitable; 1 judge dissented but the other
+        agreed. With 3 voters (primary + 2 judges) and 2-vs-1
+        in-favour, final stays exploitable. Primary → correct;
+        agreeing judge → correct; dissenting judge → incorrect."""
+        results = {"f1": {
+            "rule_id": "py/sql-injection",
+            "judge": "disputed",
+            "is_exploitable": True,                     # final
+            "analysed_by": "claude-opus",
+            "judge_analyses": [
+                {"model": "gpt-4",  "is_exploitable": True},
+                {"model": "gemini", "is_exploitable": False,
+                 "reasoning": "thought it was sanitised"},
+            ],
+        }}
+        n = record_judge_outcomes(
+            scorecard,
+            results_by_id=results,
+            primary_verdicts_before_judge={"f1": True},
+        )
+        assert n == 3
+        dc = "agentic:py/sql-injection"
+        assert _stat(scorecard, dc, "claude-opus", EventType.JUDGE_REVIEW) == (1, 0)
+        assert _stat(scorecard, dc, "gpt-4",       EventType.JUDGE_REVIEW) == (1, 0)
+        assert _stat(scorecard, dc, "gemini",      EventType.JUDGE_REVIEW) == (0, 1)
+
+    def test_minority_reasoning_captured(self, scorecard):
+        """Dissenter's reasoning attached to disagreement-samples log."""
+        results = {"f1": {
+            "rule_id": "py/sql-injection",
+            "judge": "disputed",
+            "is_exploitable": False,
+            "analysed_by": "claude-opus",
+            "reasoning": "primary: clearly tainted via request.GET",
+            "judge_analyses": [
+                {"model": "gpt-4", "is_exploitable": False, "reasoning": "ok"},
+                {"model": "gemini", "is_exploitable": False, "reasoning": "ok"},
+            ],
+        }}
+        record_judge_outcomes(
+            scorecard,
+            results_by_id=results,
+            primary_verdicts_before_judge={"f1": True},
+        )
+        s = scorecard.get_stat("agentic:py/sql-injection", "claude-opus")
+        samples = [
+            samp for samp in s.disagreement_samples
+            if samp.get("event_type") == EventType.JUDGE_REVIEW
+        ]
+        assert len(samples) == 1
+        assert "tainted via request.GET" in samples[0]["this_reasoning"]
+
+
+# ---------------------------------------------------------------------------
+# Single-judge disputes — INTENTIONALLY skipped
+# ---------------------------------------------------------------------------
+
+
+class TestSingleJudgeSkipped:
+    def test_single_judge_dispute_records_nothing(self, scorecard):
+        """``JudgeTask.finalize`` keeps primary's verdict when there's
+        only one judge — there's no panel-majority truth signal and
+        recording would arbitrarily flag one side. Skip cleanly."""
+        results = {"f1": {
+            "rule_id": "py/sql-injection",
+            "judge": "disputed",
+            "is_exploitable": True,                     # primary kept
+            "analysed_by": "claude-opus",
+            "judge_analyses": [
+                {"model": "gpt-4", "is_exploitable": False,
+                 "reasoning": "single-judge dissent"},
+            ],
+        }}
+        n = record_judge_outcomes(
+            scorecard,
+            results_by_id=results,
+            primary_verdicts_before_judge={"f1": True},
+        )
+        assert n == 0
+        # No events for either model.
+        assert scorecard.get_stat("agentic:py/sql-injection", "claude-opus") is None
+        assert scorecard.get_stat("agentic:py/sql-injection", "gpt-4") is None
+
+
+# ---------------------------------------------------------------------------
+# Agreed cases — skipped (no useful signal)
+# ---------------------------------------------------------------------------
+
+
+class TestAgreedSkipped:
+    def test_agreed_no_events(self, scorecard):
+        results = {"f1": {
+            "rule_id": "py/sql-injection",
+            "judge": "agreed",
+            "is_exploitable": True,
+            "analysed_by": "claude-opus",
+            "judge_analyses": [
+                {"model": "gpt-4", "is_exploitable": True},
+                {"model": "gemini", "is_exploitable": True},
+            ],
+        }}
+        n = record_judge_outcomes(
+            scorecard,
+            results_by_id=results,
+            primary_verdicts_before_judge={"f1": True},
+        )
+        assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# Decision-class shape + isolation
+# ---------------------------------------------------------------------------
+
+
+class TestIsolationFromGate:
+    def test_does_not_pollute_cheap_short_circuit(self, scorecard):
+        # Pre-seed cheap-tier counter.
+        for _ in range(20):
+            scorecard.record_event(
+                "agentic:py/sql-injection", "claude-opus",
+                EventType.CHEAP_SHORT_CIRCUIT, "correct",
+            )
+        before = _stat(scorecard, "agentic:py/sql-injection", "claude-opus",
+                       EventType.CHEAP_SHORT_CIRCUIT)
+
+        results = {"f1": {
+            "rule_id": "py/sql-injection",
+            "judge": "disputed",
+            "is_exploitable": False,
+            "analysed_by": "claude-opus",
+            "judge_analyses": [
+                {"model": "gpt-4", "is_exploitable": False},
+                {"model": "gemini", "is_exploitable": False},
+            ],
+        }}
+        record_judge_outcomes(
+            scorecard,
+            results_by_id=results,
+            primary_verdicts_before_judge={"f1": True},
+        )
+        after = _stat(scorecard, "agentic:py/sql-injection", "claude-opus",
+                      EventType.CHEAP_SHORT_CIRCUIT)
+        assert before == after
+
+
+class TestMissingSnapshot:
+    def test_skips_when_primary_snapshot_missing(self, scorecard):
+        """Defensive: if the caller didn't snapshot primary's verdict
+        before judge ran, the producer can't know which way primary
+        originally voted (JudgeTask overwrote it). Skip rather than
+        mis-attribute."""
+        results = {"f1": {
+            "rule_id": "py/sql-injection",
+            "judge": "disputed",
+            "is_exploitable": False,
+            "analysed_by": "claude-opus",
+            "judge_analyses": [
+                {"model": "gpt-4", "is_exploitable": False},
+                {"model": "gemini", "is_exploitable": False},
+            ],
+        }}
+        # Empty snapshot.
+        n = record_judge_outcomes(
+            scorecard,
+            results_by_id=results,
+            primary_verdicts_before_judge={},
+        )
+        assert n == 0

--- a/core/llm/scorecard/tests/test_tool_evidence.py
+++ b/core/llm/scorecard/tests/test_tool_evidence.py
@@ -1,0 +1,357 @@
+"""Tests for the tool-evidence producer.
+
+Covers the single-record primitive
+(``record_tool_evidence_outcome``), the bulk variant, and the CLI
+``tool-evidence`` subcommand that joins orchestrated + validation
+reports.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from core.llm.scorecard import cli as cli_mod
+from core.llm.scorecard.scorecard import EventType, ModelScorecard
+from core.llm.scorecard.tool_evidence import (
+    record_tool_evidence_outcome,
+    record_tool_evidence_outcomes,
+)
+
+
+@pytest.fixture
+def scorecard(tmp_path: Path) -> ModelScorecard:
+    return ModelScorecard(tmp_path / "sc.json", shadow_rate=0.0)
+
+
+def _stat(sc: ModelScorecard, dc: str, model: str, ev: str = EventType.TOOL_EVIDENCE):
+    s = sc.get_stat(dc, model)
+    if s is None:
+        return (0, 0)
+    return s.events[ev].correct, s.events[ev].incorrect
+
+
+# ---------------------------------------------------------------------------
+# Single-record primitive
+# ---------------------------------------------------------------------------
+
+
+class TestSingleRecord:
+    def test_agree_records_correct(self, scorecard):
+        ok = record_tool_evidence_outcome(
+            scorecard,
+            model="claude-opus", rule_id="py/sql-injection",
+            analysis_verdict=True, validation_verdict=True,
+        )
+        assert ok is True
+        assert _stat(scorecard, "agentic:py/sql-injection", "claude-opus") == (1, 0)
+
+    def test_disagree_records_incorrect(self, scorecard):
+        ok = record_tool_evidence_outcome(
+            scorecard,
+            model="claude-opus", rule_id="py/sql-injection",
+            analysis_verdict=True, validation_verdict=False,
+        )
+        assert ok is True
+        assert _stat(scorecard, "agentic:py/sql-injection", "claude-opus") == (0, 1)
+
+    def test_inconclusive_skipped(self, scorecard):
+        ok = record_tool_evidence_outcome(
+            scorecard,
+            model="claude-opus", rule_id="py/sql-injection",
+            analysis_verdict=True, validation_verdict=None,
+        )
+        assert ok is False
+        assert scorecard.get_stat("agentic:py/sql-injection", "claude-opus") is None
+
+    def test_none_scorecard_no_op(self):
+        ok = record_tool_evidence_outcome(
+            None,
+            model="m", rule_id="r",
+            analysis_verdict=True, validation_verdict=True,
+        )
+        assert ok is False
+
+    def test_missing_model_skipped(self, scorecard):
+        ok = record_tool_evidence_outcome(
+            scorecard,
+            model="", rule_id="py/x",
+            analysis_verdict=True, validation_verdict=False,
+        )
+        assert ok is False
+
+    def test_missing_rule_id_skipped(self, scorecard):
+        ok = record_tool_evidence_outcome(
+            scorecard,
+            model="m", rule_id="",
+            analysis_verdict=True, validation_verdict=False,
+        )
+        assert ok is False
+
+    def test_finding_id_appears_in_sample(self, scorecard):
+        record_tool_evidence_outcome(
+            scorecard,
+            model="claude-opus", rule_id="py/sql-injection",
+            analysis_verdict=True, validation_verdict=False,
+            finding_id="f-001",
+            analysis_reasoning="model said tainted via request.GET",
+        )
+        s = scorecard.get_stat("agentic:py/sql-injection", "claude-opus")
+        samples = [
+            samp for samp in s.disagreement_samples
+            if samp.get("event_type") == EventType.TOOL_EVIDENCE
+        ]
+        assert len(samples) == 1
+        assert "request.GET" in samples[0]["this_reasoning"]
+        assert "f-001" in samples[0]["other_reasoning"]
+        assert "not exploitable" in samples[0]["other_reasoning"]
+
+
+# ---------------------------------------------------------------------------
+# Bulk variant
+# ---------------------------------------------------------------------------
+
+
+class TestBulkRecord:
+    def test_writes_one_per_record(self, scorecard):
+        records = [
+            {"model": "opus", "rule_id": "py/sql-injection",
+             "analysis_verdict": True, "validation_verdict": True},
+            {"model": "opus", "rule_id": "py/path-traversal",
+             "analysis_verdict": True, "validation_verdict": False},
+            {"model": "haiku", "rule_id": "py/sql-injection",
+             "analysis_verdict": False, "validation_verdict": False},
+        ]
+        n = record_tool_evidence_outcomes(scorecard, records=records)
+        assert n == 3
+        assert _stat(scorecard, "agentic:py/sql-injection", "opus") == (1, 0)
+        assert _stat(scorecard, "agentic:py/path-traversal", "opus") == (0, 1)
+        assert _stat(scorecard, "agentic:py/sql-injection", "haiku") == (1, 0)
+
+    def test_inconclusive_records_skipped(self, scorecard):
+        records = [
+            {"model": "opus", "rule_id": "py/x",
+             "analysis_verdict": True, "validation_verdict": None},
+            {"model": "opus", "rule_id": "py/x",
+             "analysis_verdict": True, "validation_verdict": True},
+        ]
+        n = record_tool_evidence_outcomes(scorecard, records=records)
+        assert n == 1
+        assert _stat(scorecard, "agentic:py/x", "opus") == (1, 0)
+
+    def test_malformed_records_skipped_not_aborting(self, scorecard):
+        records = [
+            "garbage",
+            None,
+            {"model": "opus", "rule_id": "py/x",
+             "analysis_verdict": True, "validation_verdict": True},
+        ]
+        n = record_tool_evidence_outcomes(scorecard, records=records)  # type: ignore[arg-type]
+        assert n == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI tool-evidence subcommand: join orchestrated + validation reports
+# ---------------------------------------------------------------------------
+
+
+def _capture(handler, args):
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = handler(args)
+    return rc, out.getvalue(), err.getvalue()
+
+
+class TestCLIToolEvidence:
+    def test_joins_reports_and_records(self, tmp_path):
+        analysis_path = tmp_path / "orchestrated.json"
+        validation_path = tmp_path / "validation.json"
+        sc_path = tmp_path / "sc.json"
+
+        analysis_path.write_text(json.dumps({
+            "results": [
+                {"finding_id": "f1", "rule_id": "py/sql-injection",
+                 "analysed_by": "claude-opus", "is_exploitable": True,
+                 "reasoning": "tainted"},
+                {"finding_id": "f2", "rule_id": "py/path-traversal",
+                 "analysed_by": "claude-opus", "is_exploitable": True},
+                # f3 absent from validation → skip
+                {"finding_id": "f3", "rule_id": "py/x",
+                 "analysed_by": "claude-opus", "is_exploitable": True},
+            ],
+        }))
+        validation_path.write_text(json.dumps({
+            "findings": [
+                {"finding_id": "f1", "is_exploitable": True},
+                {"finding_id": "f2", "is_exploitable": False},
+                # f4 unknown to analysis → skip
+                {"finding_id": "f4", "is_exploitable": True},
+                # f5 inconclusive → skip
+                {"finding_id": "f5", "is_exploitable": None},
+            ],
+        }))
+
+        args = SimpleNamespace(
+            path=sc_path,
+            analysis=analysis_path,
+            validation=validation_path,
+            prefix="agentic",
+        )
+        rc, _, err = _capture(cli_mod.cmd_tool_evidence, args)
+        assert rc == 0
+        assert "tool_evidence event(s)" in err
+        sc = ModelScorecard(sc_path)
+        # f1: agreed → correct
+        assert _stat(sc, "agentic:py/sql-injection", "claude-opus") == (1, 0)
+        # f2: disagreed → incorrect
+        assert _stat(sc, "agentic:py/path-traversal", "claude-opus") == (0, 1)
+        # f3 / f4 / f5: skipped (no join / inconclusive)
+        assert sc.get_stat("agentic:py/x", "claude-opus") is None
+
+    def test_missing_analysis_file_returns_error(self, tmp_path):
+        args = SimpleNamespace(
+            path=tmp_path / "sc.json",
+            analysis=tmp_path / "missing.json",
+            validation=tmp_path / "validation.json",
+            prefix="agentic",
+        )
+        # Validation file also missing — but analysis fail is checked
+        # first; either way the command returns non-zero.
+        rc, _, err = _capture(cli_mod.cmd_tool_evidence, args)
+        assert rc == 2
+        assert "cannot read" in err
+
+    def test_malformed_json_returns_error(self, tmp_path):
+        analysis_path = tmp_path / "orchestrated.json"
+        validation_path = tmp_path / "validation.json"
+        analysis_path.write_text("{not json")
+        validation_path.write_text("{}")
+        args = SimpleNamespace(
+            path=tmp_path / "sc.json",
+            analysis=analysis_path,
+            validation=validation_path,
+            prefix="agentic",
+        )
+        rc, _, err = _capture(cli_mod.cmd_tool_evidence, args)
+        assert rc == 2
+
+    def test_skips_records_without_analysed_by(self, tmp_path):
+        """Adversarial: an analysis record missing ``analysed_by``
+        would otherwise get a fake ``"?"`` model and silently land
+        on a no-one's cell. Skip + emit a notice instead."""
+        analysis_path = tmp_path / "orchestrated.json"
+        validation_path = tmp_path / "validation.json"
+        sc_path = tmp_path / "sc.json"
+        analysis_path.write_text(json.dumps({
+            "results": [
+                {"finding_id": "f1", "rule_id": "py/x",
+                 "is_exploitable": True},  # no analysed_by
+                {"finding_id": "f2", "rule_id": "py/x",
+                 "analysed_by": "claude-opus", "is_exploitable": True},
+            ],
+        }))
+        validation_path.write_text(json.dumps({
+            "findings": [
+                {"finding_id": "f1", "is_exploitable": True},
+                {"finding_id": "f2", "is_exploitable": False},
+            ],
+        }))
+        args = SimpleNamespace(
+            path=sc_path, analysis=analysis_path, validation=validation_path,
+            prefix="agentic",
+        )
+        rc, _, err = _capture(cli_mod.cmd_tool_evidence, args)
+        assert rc == 0
+        assert "skipped" in err
+        sc = ModelScorecard(sc_path)
+        # Only f2 recorded.
+        assert _stat(sc, "agentic:py/x", "claude-opus") == (0, 1)
+        # No "?"-keyed cell.
+        assert sc.get_stat("agentic:py/x", "?") is None
+
+    def test_prefix_flag_routes_to_codeql_namespace(self, tmp_path):
+        """``--prefix codeql`` routes events to ``codeql:<rule_id>``
+        cells matching the existing prefilter producer's convention
+        for /codeql consumers."""
+        analysis_path = tmp_path / "orchestrated.json"
+        validation_path = tmp_path / "validation.json"
+        sc_path = tmp_path / "sc.json"
+        analysis_path.write_text(json.dumps({
+            "results": [
+                {"finding_id": "f1", "rule_id": "py/sql-injection",
+                 "analysed_by": "claude-opus", "is_exploitable": True},
+            ],
+        }))
+        validation_path.write_text(json.dumps({
+            "findings": [{"finding_id": "f1", "is_exploitable": True}],
+        }))
+        args = SimpleNamespace(
+            path=sc_path, analysis=analysis_path, validation=validation_path,
+            prefix="codeql",
+        )
+        rc, _, _ = _capture(cli_mod.cmd_tool_evidence, args)
+        assert rc == 0
+        sc = ModelScorecard(sc_path)
+        # Cell under codeql:..., not agentic:...
+        assert _stat(sc, "codeql:py/sql-injection", "claude-opus") == (1, 0)
+        assert sc.get_stat("agentic:py/sql-injection", "claude-opus") is None
+
+    def test_idempotency_reminder_in_output(self, tmp_path):
+        """Operator should see the 'don't double-run' contract every
+        time. Documented in stderr rather than tracked as state."""
+        analysis_path = tmp_path / "orchestrated.json"
+        validation_path = tmp_path / "validation.json"
+        sc_path = tmp_path / "sc.json"
+        analysis_path.write_text(json.dumps({"results": []}))
+        validation_path.write_text(json.dumps({"findings": []}))
+        args = SimpleNamespace(
+            path=sc_path, analysis=analysis_path, validation=validation_path,
+            prefix="agentic",
+        )
+        _, _, err = _capture(cli_mod.cmd_tool_evidence, args)
+        assert "double-records" in err
+
+    def test_isolation_from_cheap_short_circuit(self, tmp_path):
+        """tool-evidence events go to TOOL_EVIDENCE slot only;
+        cheap-tier counters that drive the auto-policy gate are
+        untouched."""
+        sc_path = tmp_path / "sc.json"
+        sc = ModelScorecard(sc_path, shadow_rate=0.0)
+        for _ in range(20):
+            sc.record_event(
+                "agentic:py/x", "claude-opus",
+                EventType.CHEAP_SHORT_CIRCUIT, "correct",
+            )
+        before = sc.get_stat("agentic:py/x", "claude-opus").events[
+            EventType.CHEAP_SHORT_CIRCUIT
+        ]
+
+        analysis_path = tmp_path / "orchestrated.json"
+        validation_path = tmp_path / "validation.json"
+        analysis_path.write_text(json.dumps({
+            "results": [
+                {"finding_id": "f1", "rule_id": "py/x",
+                 "analysed_by": "claude-opus", "is_exploitable": True},
+            ],
+        }))
+        validation_path.write_text(json.dumps({
+            "findings": [
+                {"finding_id": "f1", "is_exploitable": False},
+            ],
+        }))
+        args = SimpleNamespace(
+            path=sc_path,
+            analysis=analysis_path,
+            validation=validation_path,
+            prefix="agentic",
+        )
+        _capture(cli_mod.cmd_tool_evidence, args)
+        after = sc.get_stat("agentic:py/x", "claude-opus").events[
+            EventType.CHEAP_SHORT_CIRCUIT
+        ]
+        assert (before.correct, before.incorrect) == (after.correct, after.incorrect)

--- a/core/llm/scorecard/tool_evidence.py
+++ b/core/llm/scorecard/tool_evidence.py
@@ -1,0 +1,151 @@
+"""Producer wiring for ``EventType.TOOL_EVIDENCE``.
+
+Back-propagates downstream-validation outcomes onto the (model,
+decision_class) cells of the models that emitted the original
+analysis verdicts. Specifically:
+
+  * /agentic produces an analysis verdict for finding F:
+    ``(model, rule_id, is_exploitable)``.
+  * /validate runs Stages 0-F on F and concludes
+    ``(is_exploitable=True|False|None)``. Stage F is the exploit
+    attempt — strongest signal in the pipeline.
+  * If both verdicts agree → model gets ``correct``; if they
+    disagree → ``incorrect``; ``None`` (inconclusive) → no signal.
+
+Decoupled from /validate's internals: the producer accepts plain
+records (analysis-side dict + validation-side bool) so the consumer
+shape can evolve without touching the substrate. Two entry points:
+
+  * :func:`record_tool_evidence_outcome` — single-record primitive,
+    the testable atom.
+  * :func:`record_tool_evidence_outcomes` — bulk variant that walks
+    aligned records.
+
+The CLI ``mark`` command is the operator-driven analogue
+(``OPERATOR_FEEDBACK``); this producer is the automated analogue
+(``TOOL_EVIDENCE``). Both write into different event slots so the
+auto-policy gate (Wilson over ``CHEAP_SHORT_CIRCUIT``) is unaffected.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Iterable, Optional
+
+from .scorecard import EventType, ModelScorecard
+
+logger = logging.getLogger(__name__)
+
+
+_MAX_REASONING_CHARS = 500
+
+
+def record_tool_evidence_outcome(
+    scorecard: Optional[ModelScorecard],
+    *,
+    model: str,
+    rule_id: str,
+    analysis_verdict: bool,
+    validation_verdict: Optional[bool],
+    finding_id: Optional[str] = None,
+    analysis_reasoning: Optional[str] = None,
+    decision_class_prefix: str = "agentic",
+) -> bool:
+    """Record one ``TOOL_EVIDENCE`` event when downstream validation
+    confirms or refutes a model's analysis verdict.
+
+    Returns True if an event was recorded, False otherwise (skip
+    cases: scorecard None, validation_verdict None, missing model).
+
+    ``analysis_verdict`` is the model's ``is_exploitable`` from
+    /agentic (or any consumer with a verdict). ``validation_verdict``
+    is the downstream pipeline's conclusion — bool when concrete,
+    ``None`` when inconclusive (no signal, skip).
+
+    ``finding_id`` is recorded into the disagreement-samples log on
+    incorrect outcomes so an operator inspecting the cell can trace
+    back to the specific finding that contradicted the model's
+    verdict.
+    """
+    if scorecard is None or validation_verdict is None:
+        return False
+    if not model or not rule_id:
+        return False
+    decision_class = f"{decision_class_prefix}:{rule_id}"
+    is_correct = (bool(analysis_verdict) == bool(validation_verdict))
+    sample = None
+    if not is_correct:
+        sample = {
+            "this_reasoning": (analysis_reasoning or "")[:_MAX_REASONING_CHARS],
+            "other_reasoning": (
+                f"validation pipeline concluded "
+                f"{'exploitable' if validation_verdict else 'not exploitable'}"
+                + (f" on finding {finding_id}" if finding_id else "")
+            ),
+        }
+    try:
+        scorecard.record_event(
+            decision_class=decision_class,
+            model=str(model),
+            event_type=EventType.TOOL_EVIDENCE,
+            outcome="correct" if is_correct else "incorrect",
+            sample=sample,
+        )
+        return True
+    except Exception as e:                              # noqa: BLE001
+        logger.debug(
+            "record_tool_evidence_outcome: %s/%s failed: %s",
+            model, decision_class, e,
+        )
+        return False
+
+
+def record_tool_evidence_outcomes(
+    scorecard: Optional[ModelScorecard],
+    *,
+    records: Iterable[Dict[str, Any]],
+    decision_class_prefix: str = "agentic",
+) -> int:
+    """Bulk variant. Each record is a dict with keys:
+
+      * ``model`` (str, required)
+      * ``rule_id`` (str, required)
+      * ``analysis_verdict`` (bool, required)
+      * ``validation_verdict`` (bool|None, required — None skips)
+      * ``finding_id`` (str, optional — for sample log)
+      * ``analysis_reasoning`` (str, optional — for sample log on
+        incorrect outcomes)
+
+    Returns the count of events written. Records missing required
+    fields are skipped (logged at debug); one bad record never aborts
+    the batch.
+    """
+    if scorecard is None:
+        return 0
+    n = 0
+    for rec in records:
+        if not isinstance(rec, dict):
+            continue
+        try:
+            ok = record_tool_evidence_outcome(
+                scorecard,
+                model=str(rec.get("model") or ""),
+                rule_id=str(rec.get("rule_id") or ""),
+                analysis_verdict=bool(rec.get("analysis_verdict")),
+                validation_verdict=rec.get("validation_verdict"),
+                finding_id=rec.get("finding_id"),
+                analysis_reasoning=rec.get("analysis_reasoning"),
+                decision_class_prefix=decision_class_prefix,
+            )
+        except Exception as e:                          # noqa: BLE001
+            logger.debug("record_tool_evidence_outcomes: bad record %r: %s", rec, e)
+            continue
+        if ok:
+            n += 1
+    return n
+
+
+__all__ = [
+    "record_tool_evidence_outcome",
+    "record_tool_evidence_outcomes",
+]

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -728,11 +728,39 @@ def orchestrate(
     # Judge review (if configured) — sees primary reasoning, critiques it
     judge_models = role_resolution.get("judge_models", [])
     if judge_models:
+        # Snapshot primary verdicts BEFORE JudgeTask runs — its
+        # finalize() overwrites ``primary["is_exploitable"]`` with
+        # the panel-majority verdict. The JUDGE_REVIEW producer
+        # below needs the original to know which way primary voted.
+        primary_verdicts_before_judge: Dict[str, bool] = {}
+        for fid, r in results_by_id.items():
+            if isinstance(r, dict) and "error" not in r:
+                primary_verdicts_before_judge[fid] = bool(
+                    r.get("is_exploitable", False)
+                )
         dispatch_task(
             JudgeTask(results_by_id=results_by_id, profile=profile),
             findings, dispatch_fn, role_resolution,
             results_by_id, cost_tracker, max_parallel,
         )
+
+        # Record JUDGE_REVIEW scorecard events for multi-judge
+        # disputes. Single-judge disputes are skipped (the JudgeTask
+        # keeps primary's verdict in that mode — no panel-majority
+        # signal to attribute). Agreed findings skipped (no useful
+        # per-model signal).
+        if client is not None:
+            sc = getattr(client, "scorecard", None)
+            if sc is not None:
+                from core.llm.scorecard.judge import record_judge_outcomes
+                try:
+                    record_judge_outcomes(
+                        sc,
+                        results_by_id=results_by_id,
+                        primary_verdicts_before_judge=primary_verdicts_before_judge,
+                    )
+                except Exception as e:                  # noqa: BLE001
+                    logger.debug("judge producer failed: %s", e)
 
     # Multi-model correlation (pure Python, no LLM)
     correlation = None
@@ -749,6 +777,37 @@ def orchestrate(
         n_disputed = corr_summary.get("disputed", 0)
         if n_corr:
             print(f"\n  Correlation: {n_corr} findings — {n_agreed} agreed, {n_disputed} disputed")
+
+        # Record MULTI_MODEL_CONSENSUS scorecard events for disputed
+        # findings: minority models → incorrect, majority → correct.
+        # Agreed findings produce no signal (every model gets the
+        # same bump → noise). Ties are skipped (no clear majority).
+        # Per-cell auto-policy unaffected — this populates its own
+        # event slot, distinct from the cheap-tier prefilter
+        # counters that drive the gate.
+        if client is not None:
+            sc = getattr(client, "scorecard", None)
+            if sc is not None:
+                # Pass ``_multi_results`` directly so the producer can
+                # attribute each minority model's reasoning to the
+                # right model. Decoupled from results_by_id to avoid
+                # mutating records that get serialised into
+                # orchestrated_report.json.
+                from core.llm.scorecard.consensus import (
+                    record_consensus_outcomes,
+                )
+                try:
+                    record_consensus_outcomes(
+                        sc,
+                        correlation=correlation,
+                        results_by_id=results_by_id,
+                        per_finding_results=_multi_results,
+                    )
+                except Exception as e:                  # noqa: BLE001
+                    # Never let scorecard wiring abort orchestration.
+                    logger.debug(
+                        "consensus producer failed: %s", e,
+                    )
 
     # Final LLM aggregation over independent analysis outputs. This is distinct
     # from consensus/judge: it produces a downstream artifact instead of


### PR DESCRIPTION
The scorecard schema has reserved MULTI_MODEL_CONSENSUS, JUDGE_REVIEW, TOOL_EVIDENCE, and OPERATOR_FEEDBACK since landing but only CHEAP_SHORT_CIRCUIT had a producer wired. This lands the remaining four. All write into their own event slots so the auto-policy gate (Wilson over CHEAP_SHORT_CIRCUIT) is unaffected. Decision-class shape ``agentic:<rule_id>`` (configurable to ``codeql:`` for /codeql consumers) so all producers share the same cell.

* OPERATOR_FEEDBACK — ``raptor-llm-scorecard mark`` CLI. Soft notice on cells with no prior history catches typos. Notes attached on incorrect outcomes only.

* MULTI_MODEL_CONSENSUS — orchestrator hook on correlation. Disputed findings: minority → incorrect, majority → correct. Agreed + ties skipped. Per-finding per-model results passed directly to the producer rather than mutated onto results_by_id (avoids leaking _per_model_results into orchestrated_report.json).

* JUDGE_REVIEW — orchestrator hook around judge dispatch. Snapshots primary verdicts before JudgeTask overwrites them. Multi-judge disputes only: each model's vote vs panel majority. Single-judge intentionally skipped (no panel-majority truth signal).

* TOOL_EVIDENCE — ``raptor-llm-scorecard tool-evidence`` CLI joins /agentic + /validate reports. Agreement → correct, disagreement → incorrect, inconclusive → skipped. ``--prefix`` flag for /codeql consumers. Records missing analysed_by skipped with notice. Reminder printed each run — re-running double-records.

Adversarial pass also fixed: P2 sample reasoning attribution (skip sample when per-finding-results unsupplied rather than fall back to primary's text); P2 state pollution; P4 ``"?"``-model cells.

52 new tests; full preflight (2541) passes.