### PR TITLE
fix(core/http): requests-API compat for OCI client (stream= kwarg + Respsonse shim

### DIFF
--- a/core/http/__init__.py
+++ b/core/http/__init__.py
@@ -104,6 +104,50 @@ class Response:
         except (UnicodeDecodeError, json.JSONDecodeError) as e:
             raise HttpError(f"Response is not valid JSON: {e}") from e
 
+    # ------------------------------------------------------------------
+    # ``requests``-compat shim
+    #
+    # Some consumers (notably ``core.oci.client``) were originally
+    # written against the ``requests.Response`` API. Adding aliases
+    # here lets them work against this Response dataclass without a
+    # rewrite. Native callers continue to use ``status`` / ``body``.
+    # ------------------------------------------------------------------
+
+    @property
+    def status_code(self) -> int:
+        """Alias for ``status`` — matches ``requests.Response``."""
+        return self.status
+
+    @property
+    def content(self) -> bytes:
+        """Alias for ``body`` — matches ``requests.Response``."""
+        return self.body
+
+    @property
+    def text(self) -> str:
+        """UTF-8 decoded body (errors=replace) — matches
+        ``requests.Response.text`` behaviour."""
+        return self.body.decode("utf-8", errors="replace")
+
+    def iter_content(self, chunk_size: int = 65536) -> Iterator[bytes]:
+        """Yield the body in ``chunk_size`` chunks.
+
+        The underlying urllib backend has already buffered the entire
+        body — we re-chunk it here to satisfy the consumer contract
+        without changing the buffering model. For genuinely streamed
+        downloads (where the body could be 100MB+ and shouldn't sit
+        in memory at all), use :meth:`HttpClient.stream_bytes`
+        instead.
+        """
+        body = self.body
+        for i in range(0, len(body), chunk_size):
+            yield body[i:i + chunk_size]
+
+    def close(self) -> None:
+        """No-op for the buffered backend; matches ``requests.Response``
+        which closes the underlying connection."""
+        pass
+
 
 class NotModified(HttpError):
     """Raised when a server returns 304 Not Modified.

--- a/core/http/tests/test_urllib_backend.py
+++ b/core/http/tests/test_urllib_backend.py
@@ -755,3 +755,83 @@ class TestDefaultClient:
     def test_no_hosts_returns_urllib(self):
         c = default_client()
         assert isinstance(c, UrllibClient)
+
+
+# ---------------------------------------------------------------------------
+# requests-API compatibility shim
+# ---------------------------------------------------------------------------
+
+class TestRequestsCompatShim:
+    """Consumers like ``core.oci.client`` were originally written
+    against the ``requests.Response`` API. The Response dataclass
+    exposes ``status_code`` / ``content`` / ``text`` / ``iter_content``
+    / ``close`` aliases so they work without a rewrite."""
+
+    def _resp(self, body=b"hello", status=200):
+        from core.http import Response
+        return Response(
+            status=status, headers={}, body=body, url="https://x/",
+        )
+
+    def test_status_code_aliases_status(self):
+        assert self._resp(status=404).status_code == 404
+
+    def test_content_aliases_body(self):
+        assert self._resp(body=b"abc").content == b"abc"
+
+    def test_text_decodes_utf8_with_replace(self):
+        # Invalid UTF-8 byte -> replacement char, not exception.
+        r = self._resp(body=b"hello \xff world")
+        assert "hello" in r.text and "world" in r.text
+
+    def test_iter_content_chunks(self):
+        r = self._resp(body=b"abcdefghij")
+        assert list(r.iter_content(chunk_size=3)) == [
+            b"abc", b"def", b"ghi", b"j",
+        ]
+
+    def test_iter_content_empty_body(self):
+        r = self._resp(body=b"")
+        assert list(r.iter_content()) == []
+
+    def test_close_is_noop(self):
+        # No-op for the buffered backend; doesn't raise.
+        self._resp().close()
+
+
+class TestStreamKwargAccepted:
+    """``UrllibClient.request`` accepts ``stream=`` as a no-op so
+    consumers written against ``requests.Session.request(stream=True)``
+    keep working. Buffering behaviour is unchanged."""
+
+    def test_request_accepts_stream_kwarg_via_inspect(self):
+        # Inspect the signature directly — no network needed. We
+        # only care that ``stream`` is an accepted parameter so the
+        # OCI client's ``request(method, url, stream=True)`` calls
+        # don't raise TypeError.
+        import inspect
+        sig = inspect.signature(UrllibClient.request)
+        assert "stream" in sig.parameters
+        assert sig.parameters["stream"].default is False
+
+    def test_request_stream_kwarg_doesnt_change_buffering(self, monkeypatch):
+        # The kwarg is accepted but ignored; buffering is unchanged.
+        # We verify by mocking ``_fetch`` and confirming both calls
+        # invoke it with identical arguments.
+        client = UrllibClient()
+        captured = []
+
+        def fake_fetch(*args, **kwargs):
+            captured.append(("call", args, kwargs))
+            from core.http import Response
+            return Response(
+                status=200, headers={}, body=b"ok", url=args[0],
+            )
+
+        monkeypatch.setattr(client, "_fetch", fake_fetch)
+        client.request("GET", "https://example.com/", stream=True)
+        client.request("GET", "https://example.com/", stream=False)
+        # Both calls reached _fetch with the same kwargs — stream=
+        # was stripped by request() before dispatch.
+        assert len(captured) == 2
+        assert captured[0] == captured[1]

--- a/core/http/urllib_backend.py
+++ b/core/http/urllib_backend.py
@@ -178,6 +178,7 @@ class UrllibClient:
         total_timeout: int = DEFAULT_TOTAL_TIMEOUT,
         retries: int = DEFAULT_RETRIES,
         follow_redirects: bool = True,
+        stream: bool = False,
     ) -> Response:
         """Low-level HTTP request — returns a full :class:`Response` object.
 
@@ -189,7 +190,15 @@ class UrllibClient:
         callers can pass them via this method — the convenience methods
         (``get_json``, ``post_json``, ``get_bytes``) only cover the
         most common shapes.
+
+        ``stream`` is accepted for ``requests``-API compatibility
+        (consumers like :mod:`core.oci.client` were written against
+        ``requests.Session.request(stream=True)``). The urllib
+        backend buffers the response body either way, so the
+        ``stream`` value is ignored. For true streaming downloads,
+        use :meth:`stream_bytes`.
         """
+        del stream                      # accepted for compat; no-op
         self._validate_url(url)
         merged = {"User-Agent": self._ua}
         if headers:


### PR DESCRIPTION
`core.oci.client` was originally written against `requests` (`stream=True`, `resp.status_code`, `resp.content`, `resp.text`, `resp.iter_content()`, `resp.close()`). Running it through the urllib backend raised:

    UrllibClient.request() got an unexpected keyword argument 'stream'

aborting every B9 Dockerfile-FROM manifest fetch silently — only a warning, no operator-visible reason that B9 returned no findings.

Two-part fix, no API rewrite:

  * `UrllibClient.request` accepts `stream=` as accept-and-ignore. The urllib backend buffers the body either way; for true streaming, callers continue to use `stream_bytes()`.
  * `core.http.Response` exposes `requests`-compat aliases: `status_code` -> `status`, `content` -> `body`, `text` -> `body.decode("utf-8", errors="replace")`, `iter_content(chunk_size=N)` -> re-chunks the buffered body, `close()` -> no-op.

Native callers continue to use `status` / `body`. Consumers written against `requests` get the alias surface for free.

8 new tests in `test_urllib_backend.py`. Full core.http suite at 86 passing.