### PR TITLE
fix(scan): remove redundant per-pack semgrep files after merge

### DIFF
--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -502,6 +502,124 @@ def run_codeql(repo_path: Path, out_dir: Path, languages):
     return sarif_paths
 
 
+def _sarif_has_findings(sarif_path: Path) -> bool:
+    """Return True iff the SARIF file contains at least one result.
+
+    Failures (missing file, unparseable JSON) return False — callers treat
+    "unknown" the same as "empty" because the goal is opportunistic cleanup.
+    """
+    try:
+        data = json.loads(sarif_path.read_text())
+    except Exception:
+        return False
+    for run_obj in data.get("runs", []) or []:
+        if run_obj.get("results"):
+            return True
+    return False
+
+
+def cleanup_per_pack_artifacts(out_dir: Path) -> int:
+    """Remove redundant per-pack semgrep files after combined.sarif is written.
+
+    Per-pack files (semgrep_<suffix>.{exit,json,sarif,stderr.log}) are
+    intermediate: combined.sarif is the canonical post-merge artefact, and
+    scan_metrics.json captures the per-run accounting. Keep the minimum
+    needed for post-mortem of failed packs.
+
+    Cleanup rules (per pack):
+      - Always remove: .exit, .json, empty .stderr.log
+      - On exit==0: also remove .sarif
+      - On exit!=0: keep .exit, keep non-empty .stderr.log, keep .sarif if
+        it has findings; delete the .sarif if it is empty/zero-results
+        (still redundant — combined.sarif holds those results too)
+
+    Strict glob (semgrep_*.{exit,json,sarif,stderr.log}) and os.unlink
+    only — never follow symlinks or recurse.
+
+    Returns the number of files removed.
+    """
+    removed = 0
+    # Group by suffix using a strict glob set.
+    suffixes: set = set()
+    for ext in (".exit", ".json", ".sarif", ".stderr.log"):
+        for p in out_dir.glob(f"semgrep_*{ext}"):
+            # glob does not follow symlinks for matching, but the resolved
+            # entry might still be one — defend with is_symlink check.
+            if p.is_symlink() or not p.is_file():
+                continue
+            name = p.name[len("semgrep_"):-len(ext)]
+            if name:
+                suffixes.add(name)
+
+    for suffix in suffixes:
+        exit_file = out_dir / f"semgrep_{suffix}.exit"
+        json_file = out_dir / f"semgrep_{suffix}.json"
+        sarif_file = out_dir / f"semgrep_{suffix}.sarif"
+        stderr_file = out_dir / f"semgrep_{suffix}.stderr.log"
+
+        # Read exit code BEFORE any deletion.
+        exit_code: Optional[int]
+        try:
+            exit_code = int(exit_file.read_text().strip())
+        except Exception:
+            exit_code = None
+
+        success = exit_code == 0
+
+        # Always delete: .json (intermediate machine output)
+        for victim in (json_file,):
+            try:
+                if victim.is_file() and not victim.is_symlink():
+                    os.unlink(victim)
+                    removed += 1
+            except FileNotFoundError:
+                pass
+            except OSError as e:
+                logger.debug(f"cleanup: could not remove {victim}: {e}")
+
+        # Empty stderr — always delete
+        try:
+            if (stderr_file.is_file() and not stderr_file.is_symlink()
+                    and stderr_file.stat().st_size == 0):
+                os.unlink(stderr_file)
+                removed += 1
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            logger.debug(f"cleanup: could not stat/remove {stderr_file}: {e}")
+
+        if success:
+            # On success, .exit and .sarif are both redundant (combined.sarif
+            # is canonical and metrics record the success).
+            for victim in (exit_file, sarif_file):
+                try:
+                    if victim.is_file() and not victim.is_symlink():
+                        os.unlink(victim)
+                        removed += 1
+                except FileNotFoundError:
+                    pass
+                except OSError as e:
+                    logger.debug(f"cleanup: could not remove {victim}: {e}")
+        else:
+            # Failed pack: keep .exit. Keep .sarif only if it has findings;
+            # otherwise it is redundant noise (an empty {"runs":[]} stub).
+            if sarif_file.is_file() and not sarif_file.is_symlink():
+                if not _sarif_has_findings(sarif_file):
+                    try:
+                        os.unlink(sarif_file)
+                        removed += 1
+                    except OSError as e:
+                        logger.debug(
+                            f"cleanup: could not remove {sarif_file}: {e}"
+                        )
+
+    if removed:
+        logger.info(
+            f"Cleaned up {removed} redundant per-pack scan files in {out_dir}"
+        )
+    return removed
+
+
 def main():
     ap = argparse.ArgumentParser(description="RAPTOR Automated Code Security Agent with parallel scanning")
     ap.add_argument("--repo", required=True, help="Path or Git URL")
@@ -672,6 +790,16 @@ def main():
                 save_json(out_dir / "scan_metrics.json", metrics)
         except Exception as e:
             logger.debug(f"Coverage record write failed (non-fatal): {e}")
+
+        # Per-pack file cleanup. Runs AFTER combined.sarif and
+        # scan_metrics.json are finalised. The merged SARIF is canonical;
+        # per-pack semgrep_*.{exit,json,sarif,stderr.log} files are
+        # intermediate. Keep only what's useful for post-mortem of failed
+        # packs (exit code + non-empty stderr + sarif-with-findings).
+        try:
+            cleanup_per_pack_artifacts(out_dir)
+        except Exception as e:
+            logger.debug(f"Per-pack cleanup failed (non-fatal): {e}")
 
         # Verification plan
         verification = {

--- a/packages/static-analysis/tests/test_scanner_cleanup.py
+++ b/packages/static-analysis/tests/test_scanner_cleanup.py
@@ -1,0 +1,265 @@
+"""Tests for cleanup_per_pack_artifacts in packages/static-analysis/scanner.py.
+
+The cleanup runs after combined.sarif is written. It removes redundant
+per-pack semgrep_*.{exit,json,sarif,stderr.log} files while preserving
+diagnostic artefacts for failed packs.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# static-analysis has a hyphen — load via importlib (mirrors test_scanner.py).
+_SCANNER_PATH = Path(__file__).parent.parent / "scanner.py"
+_spec = importlib.util.spec_from_file_location(
+    "static_analysis_scanner_cleanup", _SCANNER_PATH
+)
+_scanner_mod = importlib.util.module_from_spec(_spec)
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+_spec.loader.exec_module(_scanner_mod)
+
+cleanup_per_pack_artifacts = _scanner_mod.cleanup_per_pack_artifacts
+_sarif_has_findings = _scanner_mod._sarif_has_findings
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+EMPTY_SARIF = json.dumps({"version": "2.1.0", "runs": [{"results": []}]})
+
+SARIF_WITH_FINDINGS = json.dumps({
+    "version": "2.1.0",
+    "runs": [
+        {
+            "results": [
+                {"ruleId": "R1", "message": {"text": "hello"}},
+            ]
+        }
+    ],
+})
+
+
+def _make_pack(out: Path, suffix: str, *, exit_code: int,
+               stderr: str = "", sarif: str = EMPTY_SARIF,
+               json_body: str = '{"results": []}') -> None:
+    (out / f"semgrep_{suffix}.exit").write_text(str(exit_code))
+    (out / f"semgrep_{suffix}.stderr.log").write_text(stderr)
+    (out / f"semgrep_{suffix}.sarif").write_text(sarif)
+    (out / f"semgrep_{suffix}.json").write_text(json_body)
+
+
+# --------------------------------------------------------------------------
+# _sarif_has_findings
+# --------------------------------------------------------------------------
+
+class TestSarifHasFindings:
+    def test_empty_sarif_returns_false(self, tmp_path):
+        p = tmp_path / "x.sarif"
+        p.write_text(EMPTY_SARIF)
+        assert _sarif_has_findings(p) is False
+
+    def test_sarif_with_results_returns_true(self, tmp_path):
+        p = tmp_path / "x.sarif"
+        p.write_text(SARIF_WITH_FINDINGS)
+        assert _sarif_has_findings(p) is True
+
+    def test_missing_file_returns_false(self, tmp_path):
+        assert _sarif_has_findings(tmp_path / "missing.sarif") is False
+
+    def test_invalid_json_returns_false(self, tmp_path):
+        p = tmp_path / "x.sarif"
+        p.write_text("not json {{{")
+        assert _sarif_has_findings(p) is False
+
+
+# --------------------------------------------------------------------------
+# cleanup_per_pack_artifacts
+# --------------------------------------------------------------------------
+
+class TestCleanupPerPackArtifacts:
+
+    def test_successful_pack_with_empty_stderr_strips_everything(self, tmp_path):
+        _make_pack(tmp_path, "category_auth", exit_code=0, stderr="")
+        cleanup_per_pack_artifacts(tmp_path)
+
+        for ext in (".exit", ".json", ".sarif", ".stderr.log"):
+            assert not (tmp_path / f"semgrep_category_auth{ext}").exists(), (
+                f"{ext} should be removed for successful pack with empty stderr"
+            )
+
+    def test_successful_pack_with_stderr_keeps_stderr_only(self, tmp_path):
+        _make_pack(
+            tmp_path, "p_security_audit",
+            exit_code=0, stderr="WARN: rule deprecation\n",
+        )
+        cleanup_per_pack_artifacts(tmp_path)
+
+        # Successful: .exit, .json, .sarif removed.
+        assert not (tmp_path / "semgrep_p_security_audit.exit").exists()
+        assert not (tmp_path / "semgrep_p_security_audit.json").exists()
+        assert not (tmp_path / "semgrep_p_security_audit.sarif").exists()
+        # Non-empty stderr: kept.
+        assert (tmp_path / "semgrep_p_security_audit.stderr.log").exists()
+
+    def test_failed_pack_with_empty_sarif_keeps_exit_and_stderr(self, tmp_path):
+        _make_pack(
+            tmp_path, "category_crypto",
+            exit_code=1, stderr="ERROR: rule parse failed\n",
+            sarif=EMPTY_SARIF,
+        )
+        cleanup_per_pack_artifacts(tmp_path)
+
+        # Always-removed files
+        assert not (tmp_path / "semgrep_category_crypto.json").exists()
+        # Failed pack diagnostics kept
+        assert (tmp_path / "semgrep_category_crypto.exit").exists()
+        assert (tmp_path / "semgrep_category_crypto.stderr.log").exists()
+        # Empty SARIF still removed (combined.sarif is canonical)
+        assert not (tmp_path / "semgrep_category_crypto.sarif").exists()
+
+    def test_failed_pack_with_findings_keeps_sarif(self, tmp_path):
+        _make_pack(
+            tmp_path, "category_injection",
+            exit_code=1, stderr="ERROR: partial completion\n",
+            sarif=SARIF_WITH_FINDINGS,
+        )
+        cleanup_per_pack_artifacts(tmp_path)
+
+        assert not (tmp_path / "semgrep_category_injection.json").exists()
+        # Diagnostics kept for the failed pack
+        assert (tmp_path / "semgrep_category_injection.exit").exists()
+        assert (tmp_path / "semgrep_category_injection.stderr.log").exists()
+        # SARIF retained because it has findings
+        assert (tmp_path / "semgrep_category_injection.sarif").exists()
+
+    def test_unparseable_exit_treated_as_failure(self, tmp_path):
+        # exit file with garbage means we don't know the outcome — treat as
+        # failure so we keep diagnostics rather than silently dropping them.
+        suffix = "category_garbled"
+        (tmp_path / f"semgrep_{suffix}.exit").write_text("\x00not-an-int\n")
+        (tmp_path / f"semgrep_{suffix}.stderr.log").write_text("oops\n")
+        (tmp_path / f"semgrep_{suffix}.sarif").write_text(EMPTY_SARIF)
+        (tmp_path / f"semgrep_{suffix}.json").write_text("{}")
+
+        cleanup_per_pack_artifacts(tmp_path)
+
+        assert not (tmp_path / f"semgrep_{suffix}.json").exists()
+        # exit kept (failure treatment)
+        assert (tmp_path / f"semgrep_{suffix}.exit").exists()
+        # non-empty stderr kept
+        assert (tmp_path / f"semgrep_{suffix}.stderr.log").exists()
+        # empty SARIF removed
+        assert not (tmp_path / f"semgrep_{suffix}.sarif").exists()
+
+    def test_unrelated_files_left_alone(self, tmp_path):
+        """Cleanup must only touch precisely-named per-pack files."""
+        # Unrelated artefacts that must survive.
+        keep = [
+            "combined.sarif",
+            "scan-manifest.json",
+            "scan_metrics.json",
+            "coverage-semgrep.json",
+            "verification.json",
+            "proxy-events.jsonl",
+            ".raptor-run.json",
+            "sarif_merge.stderr.log",  # not a per-pack file
+            "codeql_python.sarif",     # codeql, not semgrep
+            "semgrep.log",             # standalone, no <suffix>
+        ]
+        for name in keep:
+            (tmp_path / name).write_text("x")
+
+        # .semgrep_home/ subdirectory must be left intact.
+        sh = tmp_path / ".semgrep_home"
+        sh.mkdir()
+        (sh / "settings.yml").write_text("y")
+
+        # And one real successful pack to make sure cleanup runs.
+        _make_pack(tmp_path, "category_auth", exit_code=0, stderr="")
+
+        cleanup_per_pack_artifacts(tmp_path)
+
+        for name in keep:
+            assert (tmp_path / name).exists(), f"{name} must not be deleted"
+        assert (sh / "settings.yml").exists()
+
+        # The pack itself was cleaned.
+        assert not (tmp_path / "semgrep_category_auth.exit").exists()
+
+    def test_multiple_packs_mixed_outcomes(self, tmp_path):
+        # Pack A: success, empty stderr → fully removed
+        _make_pack(tmp_path, "category_auth", exit_code=0, stderr="")
+        # Pack B: success, non-empty stderr → only stderr kept
+        _make_pack(tmp_path, "category_logging", exit_code=0, stderr="warn\n")
+        # Pack C: failed, empty sarif → exit + stderr kept
+        _make_pack(
+            tmp_path, "category_secrets",
+            exit_code=2, stderr="boom\n", sarif=EMPTY_SARIF,
+        )
+        # Pack D: failed, sarif with findings → all diagnostics kept
+        _make_pack(
+            tmp_path, "p_default",
+            exit_code=1, stderr="partial\n", sarif=SARIF_WITH_FINDINGS,
+        )
+
+        removed = cleanup_per_pack_artifacts(tmp_path)
+        assert removed > 0
+
+        # Pack A — gone
+        for ext in (".exit", ".json", ".sarif", ".stderr.log"):
+            assert not (tmp_path / f"semgrep_category_auth{ext}").exists()
+
+        # Pack B — only stderr remains
+        assert not (tmp_path / "semgrep_category_logging.exit").exists()
+        assert not (tmp_path / "semgrep_category_logging.json").exists()
+        assert not (tmp_path / "semgrep_category_logging.sarif").exists()
+        assert (tmp_path / "semgrep_category_logging.stderr.log").exists()
+
+        # Pack C — exit + stderr remain
+        assert (tmp_path / "semgrep_category_secrets.exit").exists()
+        assert (tmp_path / "semgrep_category_secrets.stderr.log").exists()
+        assert not (tmp_path / "semgrep_category_secrets.json").exists()
+        assert not (tmp_path / "semgrep_category_secrets.sarif").exists()
+
+        # Pack D — exit + stderr + sarif (with findings) remain
+        assert (tmp_path / "semgrep_p_default.exit").exists()
+        assert (tmp_path / "semgrep_p_default.stderr.log").exists()
+        assert (tmp_path / "semgrep_p_default.sarif").exists()
+        assert not (tmp_path / "semgrep_p_default.json").exists()
+
+    def test_missing_per_pack_files_do_not_error(self, tmp_path):
+        # Only an .exit file — the other per-pack files were never written.
+        (tmp_path / "semgrep_category_partial.exit").write_text("0")
+        # Should run without raising.
+        cleanup_per_pack_artifacts(tmp_path)
+        assert not (tmp_path / "semgrep_category_partial.exit").exists()
+
+    def test_does_not_follow_symlinks(self, tmp_path):
+        # Set up a successful pack normally...
+        _make_pack(tmp_path, "category_real", exit_code=0, stderr="")
+        # ...and a symlink that masquerades as a per-pack file pointing at
+        # an unrelated file outside the patterns we want to delete.
+        sentinel = tmp_path / "outside_target.txt"
+        sentinel.write_text("important")
+        link = tmp_path / "semgrep_category_link.sarif"
+        try:
+            os.symlink(sentinel, link)
+        except OSError:
+            pytest.skip("symlinks not supported on this filesystem")
+
+        cleanup_per_pack_artifacts(tmp_path)
+
+        # The symlinked sarif must NOT have been removed (we skip symlinks).
+        assert link.is_symlink(), "symlink should be left intact"
+        # And the real target must be untouched.
+        assert sentinel.exists()
+        assert sentinel.read_text() == "important"
+
+    def test_empty_directory_is_noop(self, tmp_path):
+        removed = cleanup_per_pack_artifacts(tmp_path)
+        assert removed == 0


### PR DESCRIPTION
A scan with 16 rule packs left 70 files / 7.8 MB in the run dir; most were empty per-pack stubs that became dead weight once combined.sarif was written. Add cleanup_per_pack_artifacts() that runs after the merge and metrics are finalised.

Rules: always drop the per-pack .json (intermediate Semgrep machine output) and any zero-byte .stderr.log. On pack success drop .exit and .sarif too (combined.sarif is canonical). On failure keep .exit and non-empty .stderr.log; keep the pack's .sarif only if it actually has findings worth a post-mortem look. Strict glob, os.unlink, never follows symlinks, never errors on missing files.

E2E: scan of /tmp/vulns drops from 70 entries to 11 visible files.