### PR TITLE
fix(core/http+oci): make Docker Hub anonymous pulls work end-to-end

### DIFF
--- a/core/http/tests/test_urllib_backend.py
+++ b/core/http/tests/test_urllib_backend.py
@@ -835,3 +835,66 @@ class TestStreamKwargAccepted:
         # was stripped by request() before dispatch.
         assert len(captured) == 2
         assert captured[0] == captured[1]
+
+
+class TestRaiseOnStatus:
+    """``raise_on_status=False`` returns the Response on 4xx instead
+    of raising HttpError. Needed by the OCI client which inspects
+    401 responses for ``WWW-Authenticate`` to drive the bearer-
+    token exchange retry."""
+
+    def test_raise_on_status_default_true_raises_on_401(self):
+        client, _ = _client_with_mock_pool(
+            _stub_response(b"unauthorized", status=401, reason="Unauthorized"),
+        )
+        with pytest.raises(HttpError) as exc:
+            client.request("GET", "https://example.com/")
+        assert exc.value.status == 401
+
+    def test_raise_on_status_false_returns_401_response(self):
+        client, _ = _client_with_mock_pool(
+            _stub_response(
+                b"unauthorized", status=401, reason="Unauthorized",
+                extra_headers={"WWW-Authenticate": 'Bearer realm="x"'},
+            ),
+        )
+        resp = client.request(
+            "GET", "https://example.com/", raise_on_status=False,
+        )
+        assert resp.status == 401
+        # WWW-Authenticate (lowercased) reaches the caller — that's
+        # exactly what the OCI client needs for the auth dance.
+        assert "www-authenticate" in resp.headers
+        assert 'realm="x"' in resp.headers["www-authenticate"]
+
+    def test_raise_on_status_false_still_returns_2xx_normally(self):
+        client, _ = _client_with_mock_pool(
+            _stub_response(b'{"ok": true}'),
+        )
+        resp = client.request(
+            "GET", "https://example.com/", raise_on_status=False,
+        )
+        assert resp.status == 200
+        assert resp.body == b'{"ok": true}'
+
+    def test_raise_on_status_false_passes_through_to_fetch(
+        self, monkeypatch,
+    ):
+        """The kwarg is plumbed end-to-end: request -> _fetch ->
+        _fetch_once. Verify by mocking _fetch_once and asserting
+        it received the value."""
+        client = UrllibClient()
+        captured = {}
+
+        def fake_fetch_once(*args, **kwargs):
+            captured.update(kwargs)
+            from core.http import Response
+            return Response(
+                status=401, headers={}, body=b"", url=args[0],
+            )
+
+        monkeypatch.setattr(client, "_fetch_once", fake_fetch_once)
+        client.request(
+            "GET", "https://example.com/", raise_on_status=False,
+        )
+        assert captured.get("raise_on_status") is False

--- a/core/http/urllib_backend.py
+++ b/core/http/urllib_backend.py
@@ -179,6 +179,7 @@ class UrllibClient:
         retries: int = DEFAULT_RETRIES,
         follow_redirects: bool = True,
         stream: bool = False,
+        raise_on_status: bool = True,
     ) -> Response:
         """Low-level HTTP request — returns a full :class:`Response` object.
 
@@ -197,6 +198,17 @@ class UrllibClient:
         backend buffers the response body either way, so the
         ``stream`` value is ignored. For true streaming downloads,
         use :meth:`stream_bytes`.
+
+        ``raise_on_status`` (default True) raises ``HttpError`` on
+        4xx/5xx responses — the standard behaviour every consumer
+        relies on. Pass ``raise_on_status=False`` when you need to
+        inspect a 4xx response yourself (notably the OCI client's
+        401 → token-exchange retry path, where the WWW-Authenticate
+        header on the 401 IS the signal to act on, not a failure to
+        propagate). With ``raise_on_status=False`` the Response is
+        returned for any status; transient 5xx still triggers
+        backoff retry, but the final Response (whatever its status)
+        is handed back instead of raising.
         """
         del stream                      # accepted for compat; no-op
         self._validate_url(url)
@@ -209,6 +221,7 @@ class UrllibClient:
             total_timeout=total_timeout,
             retries=retries,
             follow_redirects=follow_redirects,
+            raise_on_status=raise_on_status,
         )
 
     def post_json(
@@ -401,6 +414,7 @@ class UrllibClient:
         total_timeout: int = DEFAULT_TOTAL_TIMEOUT,
         retries: int = DEFAULT_RETRIES,
         follow_redirects: bool = True,
+        raise_on_status: bool = True,
     ) -> Response:
         # Wall-clock deadline for the whole retry loop. Without this,
         # the full backoff schedule (~1h worst case) can dominate
@@ -434,6 +448,7 @@ class UrllibClient:
                     url, method=method, timeout=timeout, max_bytes=max_bytes,
                     body=body, headers=headers,
                     follow_redirects=follow_redirects,
+                    raise_on_status=raise_on_status,
                 )
             except HttpError as e:
                 # Retry only on transient status codes (429, 5xx).
@@ -535,6 +550,7 @@ class UrllibClient:
         body: Optional[bytes],
         headers: Dict[str, str],
         follow_redirects: bool = True,
+        raise_on_status: bool = True,
     ) -> Response:
         # urllib3.Timeout(total=N) caps both connect and read; matches
         # the per-call semantics our public API exposes.
@@ -580,12 +596,13 @@ class UrllibClient:
                         resp.headers.get("Retry-After"),
                     ),
                 )
-            # Treat 4xx/5xx as HttpError. The exception is non-retryable
-            # for 4xx (we don't loop on auth/validation errors) and
-            # retried by _fetch for 5xx via the is_transient check.
-            # 3xx-with-follow_redirects=False reaches here too — surface
-            # the Location header in the exception for caller inspection.
-            if resp.status >= 400:
+            # Treat 4xx/5xx as HttpError unless caller opted out via
+            # ``raise_on_status=False`` (e.g. OCI client's 401 →
+            # token-exchange retry needs to inspect WWW-Authenticate
+            # on the 401 response). When opting out we still bound
+            # the body read by max_bytes — a 4xx response can carry
+            # an arbitrary body.
+            if resp.status >= 400 and raise_on_status:
                 # Drain enough body for the error message — bounded.
                 snippet = resp.read(512, decode_content=True) or b""
                 reason = resp.reason or "?"

--- a/core/oci/client.py
+++ b/core/oci/client.py
@@ -214,20 +214,28 @@ class OciRegistryClient:
         headers: Optional[Dict[str, str]] = None,
         stream: bool = False,
     ):
-        """Issue ``METHOD https://<registry><url_path>`` with the
-        appropriate auth header. On 401, parse the
-        ``WWW-Authenticate`` challenge, exchange for a bearer token
-        (cached), and retry once. Subsequent failures bubble up as
-        :class:`RegistryError`."""
-        full_url = f"https://{registry}{url_path}"
+        """Issue ``METHOD https://<api-endpoint><url_path>`` with the
+        appropriate auth header. The API endpoint is resolved via
+        :func:`api_endpoint_for` — for most registries this is just
+        ``registry`` itself, but Docker Hub canonical ``docker.io``
+        rewrites to ``registry-1.docker.io`` (the v2 API endpoint).
+        On 401, parse the ``WWW-Authenticate`` challenge, exchange
+        for a bearer token (cached), and retry once. Subsequent
+        failures bubble up as :class:`RegistryError`."""
+        from .registry_hosts import api_endpoint_for
+        full_url = f"https://{api_endpoint_for(registry)}{url_path}"
         req_headers = dict(headers) if headers else {}
         # First attempt with whatever auth is already cached for
         # this registry's most-recent (realm, service, scope) tuple.
         # Cache is keyed by the challenge triple, so we don't have
         # one yet — make the unauthenticated attempt first to
         # discover the realm.
+        # raise_on_status=False so the 401-with-WWW-Authenticate
+        # challenge reaches the retry path below instead of being
+        # converted to an exception by the backend.
         resp = self.http.request(
             method, full_url, headers=req_headers, stream=stream,
+            raise_on_status=False,
         )
         if resp.status_code != 401:
             return resp
@@ -291,11 +299,18 @@ class OciRegistryClient:
         if cached is not None:
             return cached
 
-        params: Dict[str, str] = {}
+        # Encode service+scope into the URL ourselves — the
+        # core.http backend doesn't support requests-style ``params=``.
+        from urllib.parse import urlencode
+        qs_pairs = []
         if service:
-            params["service"] = service
+            qs_pairs.append(("service", service))
         if scope:
-            params["scope"] = scope
+            qs_pairs.append(("scope", scope))
+        token_url = realm
+        if qs_pairs:
+            sep = "&" if "?" in realm else "?"
+            token_url = f"{realm}{sep}{urlencode(qs_pairs)}"
 
         headers: Dict[str, str] = {}
         creds = self._lookup(registry)
@@ -303,7 +318,8 @@ class OciRegistryClient:
             headers["Authorization"] = f"Basic {creds.to_basic_header()}"
 
         resp = self.http.request(
-            "GET", realm, params=params, headers=headers,
+            "GET", token_url, headers=headers,
+            raise_on_status=False,
         )
         if resp.status_code != 200:
             raise RegistryError(

--- a/core/oci/registry_hosts.py
+++ b/core/oci/registry_hosts.py
@@ -146,4 +146,25 @@ def _aws_ecr_hosts(registry: str) -> List[str]:
     ]
 
 
-__all__ = ["registry_hosts_for"]
+def api_endpoint_for(registry: str) -> str:
+    """Return the actual HTTPS hostname to send registry-API requests to.
+
+    For most registries this is the canonical name itself
+    (``ghcr.io`` -> ``ghcr.io``). Docker Hub is the notable
+    exception: the canonical name ``docker.io`` is a brand /
+    namespace identifier, but the v2 API lives at
+    ``registry-1.docker.io``. Connecting to ``docker.io`` directly
+    returns 301-to-marketing-page or fails, depending on the path.
+
+    Used by :class:`core.oci.client.RegistryClient` when building
+    request URLs. Pairs with :func:`registry_hosts_for` which
+    returns the same hostnames for sandbox-allowlist purposes —
+    the proxy must permit whatever the client actually CONNECTs to,
+    not the canonical name.
+    """
+    if registry == "docker.io":
+        return "registry-1.docker.io"
+    return registry
+
+
+__all__ = ["api_endpoint_for", "registry_hosts_for"]

--- a/core/oci/tests/test_registry_hosts.py
+++ b/core/oci/tests/test_registry_hosts.py
@@ -163,3 +163,30 @@ def test_dedup_preserves_order():
     """No duplicates in the output, original order preserved."""
     hosts = registry_hosts_for("python:3.11")
     assert len(hosts) == len(set(hosts))
+
+
+# ---------------------------------------------------------------------------
+# api_endpoint_for — canonical-name → API-host resolution for HTTP requests
+# ---------------------------------------------------------------------------
+
+def test_api_endpoint_for_docker_hub_routes_to_registry_1():
+    """Docker Hub canonical ``docker.io`` is a brand identifier;
+    the v2 API actually lives at ``registry-1.docker.io``."""
+    from core.oci.registry_hosts import api_endpoint_for
+    assert api_endpoint_for("docker.io") == "registry-1.docker.io"
+
+
+def test_api_endpoint_for_ghcr_passthrough():
+    from core.oci.registry_hosts import api_endpoint_for
+    assert api_endpoint_for("ghcr.io") == "ghcr.io"
+
+
+def test_api_endpoint_for_self_hosted_passthrough():
+    from core.oci.registry_hosts import api_endpoint_for
+    assert api_endpoint_for("registry.corp.example") \
+        == "registry.corp.example"
+
+
+def test_api_endpoint_for_quay_passthrough():
+    from core.oci.registry_hosts import api_endpoint_for
+    assert api_endpoint_for("quay.io") == "quay.io"


### PR DESCRIPTION
Three contained fixes that together let the OCI client complete the anonymous-bearer-token dance against Docker Hub (and any registry that requires it):

1. **`raise_on_status=` on UrllibClient.request()** — the OCI client's 401-retry path needs to inspect WWW-Authenticate on the 401 response, but the urllib backend raised HttpError on every 4xx before the client could see it. New default-True kwarg lets callers opt out (OCI client passes `raise_on_status=False`).

2. **`api_endpoint_for()` — Docker Hub URL routing.** ImageRef registry for Docker Hub is `docker.io` (the brand name), but the v2 API lives at `registry-1.docker.io`. The OCI client was building URLs as `https://docker.io/v2/...` which the egress proxy refused. New helper in `core.oci.registry_hosts` maps canonical -> API host; only rewrites Docker Hub today, every other registry passes through.

3. **Token-exchange URL encoding.** `_exchange_token` was passing `params=` to `self.http.request(...)` — a `requests.Session` convention not in `core.http.HttpClient`. Now encodes service+scope into the URL via `urllib.parse.urlencode`.

E2E: `OciRegistryClient(UrllibClient()).resolve_digest( parse_image_ref("library/alpine:latest"))` now returns the digest.

8 new tests (4 raise_on_status + 4 api_endpoint_for). core.http + core.oci suite at 187 passing.