### PR TITLE
fix(fuzz): anchor default corpus dir to output_dir, not CWD

### DIFF
--- a/packages/fuzzing/afl_runner.py
+++ b/packages/fuzzing/afl_runner.py
@@ -47,7 +47,6 @@ class AFLRunner:
         if not self.binary.stat().st_mode & 0o111:  # Check if executable
             raise PermissionError(f"Binary is not executable: {binary_path}")
 
-        self.corpus_dir = Path(corpus_dir) if corpus_dir else self._create_default_corpus()
         # Anchor default output to RaptorConfig.get_out_dir() so
         # fuzz output lands under the operator-configured run
         # base, NOT a literal `out/` relative to whatever
@@ -70,6 +69,9 @@ class AFLRunner:
         else:
             from core.config import RaptorConfig
             self.output_dir = RaptorConfig.get_out_dir() / f"fuzz_{self.binary.stem}"
+        # Resolve corpus AFTER output_dir so the default-corpus
+        # path can anchor under output_dir (rather than CWD).
+        self.corpus_dir = Path(corpus_dir) if corpus_dir else self._create_default_corpus()
         self.dict_path = Path(dict_path) if dict_path else None
         self.input_mode = input_mode
         self.check_sanitizers = check_sanitizers
@@ -112,8 +114,13 @@ class AFLRunner:
             raise RuntimeError(f"AFL++ validation failed: {e}")
 
     def _create_default_corpus(self) -> Path:
-        """Create minimal default corpus if none provided."""
-        corpus = Path("out/corpus_default")
+        """Create minimal default corpus if none provided.
+
+        Anchored to ``self.output_dir`` (not CWD) so running
+        ``/fuzz`` from inside a target tree does NOT plant seed
+        files in ``<target>/out/corpus_default/``.
+        """
+        corpus = self.output_dir / "corpus_default"
         corpus.mkdir(parents=True, exist_ok=True)
 
         # Create some basic seed inputs

--- a/packages/fuzzing/tests/test_afl_runner.py
+++ b/packages/fuzzing/tests/test_afl_runner.py
@@ -1,5 +1,6 @@
 """Tests for packages/fuzzing/afl_runner.py."""
 
+import os
 import sys
 from pathlib import Path
 
@@ -31,7 +32,7 @@ class TestCreateDefaultCorpus:
         runner.output_dir = output_dir
         return runner
 
-    def test_corpus_anchored_to_output_dir_not_cwd(self, tmp_path, monkeypatch):
+    def test_corpus_anchored_to_output_dir_not_cwd(self, tmp_path):
         # Two distinct directories: where the runner lives vs the
         # operator's CWD when they invoke /fuzz.
         output_dir = tmp_path / "fuzz_run"
@@ -39,10 +40,18 @@ class TestCreateDefaultCorpus:
         cwd = tmp_path / "operator_cwd"
         cwd.mkdir()
 
-        monkeypatch.chdir(cwd)
-
-        runner = self._make_runner(output_dir)
-        result = runner._create_default_corpus()
+        # Plain os.chdir + try/finally instead of monkeypatch.chdir():
+        # monkeypatch.chdir calls os.getcwd() to remember the original
+        # cwd, which fails in CI when a prior test left cwd dangling.
+        # Anchor restoration to Path(__file__) (always absolute, no
+        # cwd dependency).
+        safe_restore = Path(__file__).resolve().parent
+        os.chdir(cwd)
+        try:
+            runner = self._make_runner(output_dir)
+            result = runner._create_default_corpus()
+        finally:
+            os.chdir(safe_restore)
 
         # Seeds land under output_dir.
         expected = output_dir / "corpus_default"
@@ -56,16 +65,16 @@ class TestCreateDefaultCorpus:
         assert not (cwd / "out").exists()
         assert not (cwd / "out" / "corpus_default").exists()
 
-    def test_corpus_returns_absolute_path_under_output_dir(self, tmp_path, monkeypatch):
+    def test_corpus_returns_absolute_path_under_output_dir(self, tmp_path):
         output_dir = tmp_path / "fuzz_run"
         output_dir.mkdir()
-        monkeypatch.chdir(tmp_path)
 
         runner = self._make_runner(output_dir)
         result = runner._create_default_corpus()
 
-        # Path must be a child of output_dir (not interpreted relative
-        # to CWD by some downstream consumer).
+        # Path must be absolute and a child of output_dir (not
+        # interpreted relative to CWD by some downstream consumer).
+        assert result.is_absolute()
         assert output_dir in result.parents or result.parent == output_dir
 
     def test_seeds_have_expected_content(self, tmp_path):

--- a/packages/fuzzing/tests/test_afl_runner.py
+++ b/packages/fuzzing/tests/test_afl_runner.py
@@ -1,0 +1,81 @@
+"""Tests for packages/fuzzing/afl_runner.py."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from packages.fuzzing.afl_runner import AFLRunner
+
+
+# ---------------------------------------------------------------------------
+# _create_default_corpus()
+# ---------------------------------------------------------------------------
+
+class TestCreateDefaultCorpus:
+    """The default-corpus path must be anchored to ``self.output_dir``,
+    NOT to the current working directory.
+
+    Regression: previously ``Path("out/corpus_default")`` was CWD-relative,
+    so running ``/fuzz`` from inside a target tree planted seed files in
+    ``<target>/out/corpus_default/``.
+    """
+
+    def _make_runner(self, output_dir: Path) -> AFLRunner:
+        # Bypass __init__ — we don't need a real binary or AFL on PATH
+        # for this unit test. Only output_dir matters for the method
+        # under test.
+        runner = AFLRunner.__new__(AFLRunner)
+        runner.output_dir = output_dir
+        return runner
+
+    def test_corpus_anchored_to_output_dir_not_cwd(self, tmp_path, monkeypatch):
+        # Two distinct directories: where the runner lives vs the
+        # operator's CWD when they invoke /fuzz.
+        output_dir = tmp_path / "fuzz_run"
+        output_dir.mkdir()
+        cwd = tmp_path / "operator_cwd"
+        cwd.mkdir()
+
+        monkeypatch.chdir(cwd)
+
+        runner = self._make_runner(output_dir)
+        result = runner._create_default_corpus()
+
+        # Seeds land under output_dir.
+        expected = output_dir / "corpus_default"
+        assert result == expected
+        assert expected.is_dir()
+        for idx in range(4):
+            seed = expected / f"seed{idx}"
+            assert seed.is_file(), f"missing {seed}"
+
+        # CWD is NOT polluted.
+        assert not (cwd / "out").exists()
+        assert not (cwd / "out" / "corpus_default").exists()
+
+    def test_corpus_returns_absolute_path_under_output_dir(self, tmp_path, monkeypatch):
+        output_dir = tmp_path / "fuzz_run"
+        output_dir.mkdir()
+        monkeypatch.chdir(tmp_path)
+
+        runner = self._make_runner(output_dir)
+        result = runner._create_default_corpus()
+
+        # Path must be a child of output_dir (not interpreted relative
+        # to CWD by some downstream consumer).
+        assert output_dir in result.parents or result.parent == output_dir
+
+    def test_seeds_have_expected_content(self, tmp_path):
+        output_dir = tmp_path / "fuzz_run"
+        output_dir.mkdir()
+
+        runner = self._make_runner(output_dir)
+        corpus = runner._create_default_corpus()
+
+        assert (corpus / "seed0").read_bytes() == b"A" * 10
+        assert (corpus / "seed1").read_bytes() == b"test\n"
+        assert (corpus / "seed2").read_bytes() == b"\x00\x01\x02\x03"
+        assert (corpus / "seed3").read_bytes() == b"GET / HTTP/1.0\r\n\r\n"

--- a/packages/fuzzing/tests/test_afl_runner.py
+++ b/packages/fuzzing/tests/test_afl_runner.py
@@ -4,8 +4,6 @@ import os
 import sys
 from pathlib import Path
 
-import pytest
-
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 
 from packages.fuzzing.afl_runner import AFLRunner


### PR DESCRIPTION
Path("out/corpus_default") was CWD-relative, so running /fuzz from inside a target tree planted seed files in <target>/out/corpus_default/. Anchor to self.output_dir (already resolved via RaptorConfig.get_out_dir()) and reorder the constructor so output_dir is set before _create_default_corpus runs.