### PR TITLE
ci(tests): switch to uv + parallelise pre_check/changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,8 +75,6 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    needs: pre_check
-    if: needs.pre_check.outputs.should_skip != 'true'
     outputs:
       python: ${{ steps.filter.outputs.python }}
       bash_surface: ${{ steps.filter.outputs.bash_surface }}
@@ -166,12 +164,17 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: "requirements*.txt"
+
       - name: Create venv and install deps
         run: |
-          python -m venv $VENV_PATH
+          uv venv $VENV_PATH
           source $VENV_PATH/bin/activate
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          uv pip install -r requirements-dev.txt
 
       - name: Verify venv exists
         run: test -d "$VENV_PATH" || (echo "venv missing at $VENV_PATH" && exit 1)


### PR DESCRIPTION
Replace pip-based dep install in the deps job with uv (with built-in caching keyed off requirements*.txt). uv installs are typically 10-30x faster than pip, and the cache makes warm runs near-instant.

Drop the sequential pre_check -> changes ordering: the two jobs are independent (one is GH-API SHA dedup, the other is changed-file enumeration). Running them in parallel saves ~30s of wallclock per PR. The rare skip case (PR fast-forwarded -> main push at same SHA) runs `changes` once unnecessarily, which is acceptable.

All downstream test jobs continue to gate on
needs.pre_check.outputs.should_skip != 'true', so dedup still prevents the actual test work from running.

Estimated impact (per agent's analysis):
- Cold cache: deps drops from ~60–120s to ~10–20s (4–8× faster)
- Warm cache (uv enable-cache: true keyed on requirements*.txt): few seconds — 10–30× faster
- Parallelisation: ~30s wallclock saved per PR
- Combined critical path: ~120s → ~15–25s