### PR TITLE
Fix dispatcher test

### DIFF
--- a/core/llm/dispatcher/tests/test_dispatcher.py
+++ b/core/llm/dispatcher/tests/test_dispatcher.py
@@ -666,7 +666,12 @@ class TestSubprocessE2E:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
-            stdout, stderr = proc.communicate(timeout=15)
+            # 30s, not 15s: this 1-deep Python subprocess (worker.py
+            # imports anthropic + core.llm) takes ~10-12s in isolation
+            # but can exceed 15s on a contended xdist runner. 30s
+            # matches the timeout used by the grandchild-relay sibling
+            # in core/llm/tests/test_dispatcher_integration.py.
+            stdout, stderr = proc.communicate(timeout=30)
             assert proc.returncode == 0, (
                 f"worker failed: rc={proc.returncode} "
                 f"stdout={stdout.decode()!r} stderr={stderr.decode()!r}"


### PR DESCRIPTION
The test spawns a Python subprocess that imports the anthropic SDK plus core.llm.dispatcher.client and makes a real HTTP call through the dispatcher UDS. In isolation it runs in ~10-12s on idle hardware, but the 15s timeout was tight enough to exceed under contention — flagged as flaky both sequentially and under xdist on CI.

30s matches the timeout already in place on the analogous grandchild-relay test in core/llm/tests/test_dispatcher_integration.py (commit 96081f3, "bump grandchild-relay subprocess timeout to 30s") which had the same root cause.