### PR TITLE
Function reachability

### DIFF
--- a/core/inventory/call_graph.py
+++ b/core/inventory/call_graph.py
@@ -106,6 +106,17 @@ class FileCallGraph:
     calls: List[CallSite] = field(default_factory=list)
     indirection: Set[str] = field(default_factory=set)
     getattr_targets: Set[str] = field(default_factory=set)
+    # Relative imports (Python ``from . import x`` /
+    # ``from ..pkg import y``). Stored as
+    # ``(level, module_or_empty, name, asname_or_None)`` quads. Not
+    # resolved at extraction time — the package root depends on the
+    # file's location in the inventory tree, which the per-file
+    # extractor doesn't know. The resolver in
+    # :mod:`core.inventory.reachability` consumes these to model
+    # ``__init__.py`` re-exports.
+    relative_imports: List[Tuple[int, str, str, Optional[str]]] = field(
+        default_factory=list,
+    )
 
     def to_dict(self) -> dict:
         return {
@@ -117,10 +128,12 @@ class FileCallGraph:
             ],
             "indirection": sorted(self.indirection),
             "getattr_targets": sorted(self.getattr_targets),
+            "relative_imports": [list(ri) for ri in self.relative_imports],
         }
 
     @classmethod
     def from_dict(cls, d: dict) -> "FileCallGraph":
+        rel = d.get("relative_imports") or []
         return cls(
             imports=dict(d.get("imports") or {}),
             calls=[
@@ -133,6 +146,11 @@ class FileCallGraph:
             ],
             indirection=set(d.get("indirection") or []),
             getattr_targets=set(d.get("getattr_targets") or []),
+            relative_imports=[
+                (int(r[0]), str(r[1] or ""), str(r[2] or ""),
+                 r[3] if len(r) > 3 else None)
+                for r in rel if isinstance(r, (list, tuple)) and len(r) >= 3
+            ],
         )
 
 
@@ -188,16 +206,22 @@ class _PythonCallGraph(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-        # ``from x.y import z``         → {"z": "x.y.z"}
-        # ``from x.y import z as q``    → {"q": "x.y.z"}
+        # ``from x.y import z``         → imports {"z": "x.y.z"}
+        # ``from x.y import z as q``    → imports {"q": "x.y.z"}
         # ``from x import *``           → flag wildcard, no map entry
-        # ``from . import z``           → relative; skip (we don't
-        #                                  resolve package roots here)
+        # ``from . import z``           → relative_imports entry; the
+        #                                  resolver in reachability.py
+        #                                  resolves the package root
+        #                                  from the file's path
         module = node.module or ""
         if node.level and node.level > 0:
-            # Relative import — without the package root we can't
-            # resolve to a qualified name. Don't record; let downstream
-            # treat as out-of-scope.
+            for alias in node.names:
+                if alias.name == "*":
+                    self.graph.indirection.add(INDIRECTION_WILDCARD_IMPORT)
+                    continue
+                self.graph.relative_imports.append(
+                    (node.level, module, alias.name, alias.asname),
+                )
             self.generic_visit(node)
             return
         for alias in node.names:

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -64,9 +64,9 @@ from __future__ import annotations
 import logging
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, FrozenSet, Iterable, List, Optional, Set, Tuple, Union
 
 from .call_graph import (
     INDIRECTION_BRACKET_DISPATCH,
@@ -324,8 +324,673 @@ def _is_test_file(path: str) -> bool:
     return bool(_TEST_FILE_PATTERN.search(norm))
 
 
+# ---------------------------------------------------------------------------
+# Adjacency primitives — 1-hop callers / callees
+# ---------------------------------------------------------------------------
+#
+# ``function_called`` (above) answers "is some call site in the project
+# resolved to ``X``?" — a *forward 1-hop* query specialised for external
+# targets. Consumers like ``/audit`` need a richer set of primitives:
+# given a project-internal function, who calls it and what does it call?
+# Given a CVE-affected dep function, walk back to find every caller chain
+# in the project.
+#
+# The primitives below are language-agnostic and operate on the same
+# inventory shape ``function_called`` consumes. They share a per-
+# inventory adjacency index built lazily on first query and memoised
+# weakly so batch queries (every function in the project) amortise.
+#
+# **Node identity.** A node in the call graph is one of:
+#
+#   * :class:`InternalFunction` — a project-defined function. Identity:
+#     ``(file_path, name, line)``. The line disambiguates same-name
+#     overloads / nested defs / methods of different classes that
+#     happen to share a name.
+#
+#   * :class:`ExternalFunction` — a dotted dep-name resolved via the
+#     containing file's import map. Identity: ``qualified_name``.
+#
+# **Method-call policy.** When a call site's chain is rooted in a name
+# that *isn't* in the file's import map — e.g. ``self.foo()``,
+# ``obj.foo()`` — we can't know which class's ``foo`` was invoked. Two
+# directions, two policies:
+#
+#   * **Caller direction (``callers_of``)**: over-inclusive. We add the
+#     enclosing function as a candidate caller of every project
+#     ``foo`` we know of. False positives in caller lists show up as
+#     visible noise; missing a real caller can lead a downstream
+#     consumer to demote a real vulnerability. Bias toward inclusion.
+#
+#   * **Callee direction (``callees_of``)**: under-inclusive +
+#     UNCERTAIN flag. We don't enumerate every possible ``foo`` in the
+#     project as a callee; instead we record an indirection-style
+#     uncertainty entry on the result. ``/audit``'s context slice
+#     would otherwise be flooded with non-callees.
+#
+# The asymmetry is deliberate. Documented; not "fix later".
+
+
+@dataclass(frozen=True)
+class InternalFunction:
+    """A project-defined function. Identity: ``(file_path, name, line)``.
+
+    ``line`` is the function's ``line_start`` from the inventory's item
+    record. Disambiguates two functions with the same name in the same
+    file (nested defs, methods of different classes inside one module).
+    """
+
+    file_path: str
+    name: str
+    line: int
+
+    def __str__(self) -> str:
+        return f"{self.file_path}:{self.name}@{self.line}"
+
+
+@dataclass(frozen=True)
+class ExternalFunction:
+    """A dep-defined function referenced by qualified name."""
+
+    qualified_name: str
+
+    def __str__(self) -> str:
+        return self.qualified_name
+
+
+FunctionId = Union[InternalFunction, ExternalFunction]
+
+
+@dataclass(frozen=True)
+class CallersResult:
+    """1-hop callers of a queried target.
+
+    ``definitive`` lists internal functions whose call sites
+    statically resolve to the target via the import map.
+
+    ``uncertain`` lists internal functions that *might* call the
+    target — typically because their enclosing file has masking
+    indirection flags (``getattr`` / wildcard import) AND mentions
+    the target's tail name. Consumers SHOULD NOT downgrade severity
+    based on an empty ``definitive`` if ``uncertain`` is non-empty.
+
+    ``method_match_overinclusive`` lists internal functions whose
+    enclosing function has a call chain rooted in an unresolved
+    name (``self.foo()``, ``obj.foo()``) where ``foo`` matches the
+    target's tail. These are over-inclusive matches per the
+    documented method-call policy.
+    """
+
+    definitive: Tuple[InternalFunction, ...] = ()
+    uncertain: Tuple[InternalFunction, ...] = ()
+    method_match_overinclusive: Tuple[InternalFunction, ...] = ()
+
+    @property
+    def all_callers(self) -> Tuple[InternalFunction, ...]:
+        """Union of definitive + uncertain + over-inclusive method
+        matches, deduplicated, in stable order. Useful when the
+        consumer just wants "everyone who might call this"."""
+        seen: Set[InternalFunction] = set()
+        out: List[InternalFunction] = []
+        for group in (self.definitive, self.uncertain,
+                      self.method_match_overinclusive):
+            for c in group:
+                if c not in seen:
+                    seen.add(c)
+                    out.append(c)
+        return tuple(out)
+
+
+@dataclass(frozen=True)
+class CalleesResult:
+    """1-hop callees of a queried internal source.
+
+    ``definitive`` lists callees the source's call sites statically
+    resolve to — a mix of :class:`InternalFunction` (project-internal
+    edges) and :class:`ExternalFunction` (dep-call edges).
+
+    ``uncertain`` lists qualified-name strings the source *mentions*
+    but for which the source's file has masking indirection. The
+    string form (rather than ``ExternalFunction``) reflects that we
+    don't know whether these are real callees.
+
+    ``has_method_dispatch`` is True iff the source contains call
+    chains rooted in unresolved names (``self.foo()`` etc.); the
+    actual callees can't be enumerated and consumers should treat
+    the source's internal callee set as incomplete.
+    """
+
+    definitive: Tuple[FunctionId, ...] = ()
+    uncertain: Tuple[str, ...] = ()
+    has_method_dispatch: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Adjacency index — internal substrate
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _AdjacencyIndex:
+    """Per-inventory derived call-graph indices.
+
+    Built once per ``inventory`` dict (memoised on object identity)
+    on first query, then reused. All maps are keyed by frozen,
+    hashable :class:`FunctionId` instances so consumers can dedup /
+    set-intersect cheaply.
+
+    Fields:
+
+    * ``forward[src] -> {callees}`` — mixed Internal+External nodes
+      reachable in 1 hop from ``src`` (which is always Internal).
+    * ``reverse[dst] -> {callers}`` — Internal callers of ``dst``,
+      where ``dst`` may be Internal or External.
+    * ``uncertain_callers[dst] -> {callers}`` — internal functions
+      flagged uncertain for ``dst`` (file has masking indirection +
+      mentions the target tail).
+    * ``method_match[tail] -> {callers}`` — internal functions whose
+      bodies contain unresolved ``...foo()`` chains where the tail
+      is ``foo``. Used to fill in ``method_match_overinclusive`` on
+      lookup against any internal target named ``foo``.
+    * ``uncertain_callees[src] -> {qualified_or_local_strings}`` —
+      see :class:`CalleesResult`.
+    * ``has_method_dispatch[src]`` — True iff ``src``'s body uses
+      unresolved-head method calls.
+    * ``definitions[(file_path, name)] -> {InternalFunction, ...}``
+      — every project-defined function indexed by its file+name
+      tuple. Multiple entries means name overloading within one
+      file (same-name nested defs). Used by callers_of when the
+      target is Internal: we need to find every InternalFunction
+      whose body has a call resolving to the target.
+    """
+
+    forward: Dict[InternalFunction, Set[FunctionId]] = field(default_factory=dict)
+    reverse: Dict[FunctionId, Set[InternalFunction]] = field(default_factory=dict)
+    # Uncertain callers are stashed by *target tail name*, not target
+    # FunctionId, because the same file-level masking flag taints
+    # every internal function in that file as a possible caller for
+    # any target the file mentions by tail. callers_of() looks up by
+    # the target's tail when assembling its result.
+    uncertain_callers_by_tail: Dict[str, Set[Tuple[InternalFunction, str]]] = (
+        field(default_factory=dict)
+    )
+    method_match: Dict[str, Set[InternalFunction]] = field(default_factory=dict)
+    uncertain_callees: Dict[InternalFunction, Set[str]] = field(default_factory=dict)
+    has_method_dispatch: Dict[InternalFunction, bool] = field(default_factory=dict)
+    definitions: Dict[Tuple[str, str], Set[InternalFunction]] = (
+        field(default_factory=dict)
+    )
+    # ``qualified_name -> InternalFunction`` for project-defined
+    # functions reachable via cross-package import. Used by
+    # callers_of() to follow ExternalFunction → InternalFunction
+    # aliasing at lookup time (the index already canonicalises
+    # forward edges; this map preserves the reverse lookup).
+    qualified_to_internal: Dict[str, InternalFunction] = (
+        field(default_factory=dict)
+    )
+    # Set of file paths classified as test files (cached).
+    test_paths: FrozenSet[str] = frozenset()
+
+
+# Memoisation: keyed on ``id(inventory)``. Cache entries hold a
+# strong reference to BOTH the inventory dict AND its index, so:
+#
+#   * The inventory can't be GC'd while the entry lives, which means
+#     ``id(inventory)`` cannot be reused for a different dict — the
+#     classic "stale id-keyed cache returns the wrong index" bug.
+#
+#   * On lookup we still verify ``cache[id(inv)][0] is inv`` as a
+#     belt-and-braces guard against eviction-then-reuse races.
+#
+# Bound: ``_CACHE_MAX_ENTRIES``. When full, drop the oldest entry
+# (insertion order; ``dict`` preserves it). 64 inventories is a
+# generous ceiling — typical workflows have at most one "active"
+# inventory plus the occasional historical comparison.
+_INDEX_CACHE: Dict[int, Tuple[Dict[str, Any], "_AdjacencyIndex"]] = {}
+_CACHE_MAX_ENTRIES = 64
+
+
+def _get_or_build_index(
+    inventory: Dict[str, Any],
+    *,
+    exclude_test_files: bool,
+) -> _AdjacencyIndex:
+    """Return the memoised adjacency index for ``inventory``.
+
+    Test-file exclusion is part of the cache key implicitly: we always
+    build the index over the FULL inventory and let the public API
+    filter results, so ``exclude_test_files`` doesn't change which
+    nodes / edges exist.
+    """
+    inv_id = id(inventory)
+    cached = _INDEX_CACHE.get(inv_id)
+    if cached is not None:
+        cached_inv, cached_idx = cached
+        # Identity check: id() reuse can't happen while the cache
+        # holds the dict, but a paranoid check costs nothing.
+        if cached_inv is inventory:
+            return cached_idx
+        # Stale slot — collision after eviction. Drop and rebuild.
+        _INDEX_CACHE.pop(inv_id, None)
+
+    idx = _AdjacencyIndex()
+    test_paths: Set[str] = set()
+
+    # Pass 1: gather every project-defined function as an
+    # InternalFunction and seed `definitions`.
+    for file_record in inventory.get("files", []):
+        path = file_record.get("path") or ""
+        if _is_test_file(path):
+            test_paths.add(path)
+        for item in file_record.get("items", []) or []:
+            if not isinstance(item, dict):
+                continue
+            if item.get("kind") not in (None, "function"):
+                # KIND_FUNCTION is the default; skip globals / macros / classes.
+                continue
+            name = item.get("name") or ""
+            if not name:
+                continue
+            line = int(item.get("line_start") or 0)
+            fn = InternalFunction(file_path=path, name=name, line=line)
+            idx.definitions.setdefault((path, name), set()).add(fn)
+
+    idx.test_paths = frozenset(test_paths)
+
+    # Pass 1.5: build a qualified-name → InternalFunction map so that
+    # external edges resolving to project-defined physical functions
+    # get rewritten into internal edges in pass 2.
+    #
+    # Without this, consumers asking ``callers_of(InternalFunction(F))``
+    # miss every caller that reaches ``F`` via a cross-file
+    # ``from pkg.mod import F`` import — those resolve through the
+    # file's import map to ``ExternalFunction("pkg.mod.F")``, which is
+    # a different graph node than the InternalFunction. The two are
+    # the same physical function; the substrate canonicalises on the
+    # InternalFunction.
+    #
+    # Heuristic: derive candidate dotted forms from each file path:
+    #   * ``a/b/c.py`` → ``a.b.c``
+    #   * ``a/b/__init__.py`` → ``a.b``
+    #   * ``src/a/b/c.py`` → also ``a.b.c`` (src-layout)
+    #
+    # Limitations (documented; consumer should be aware):
+    #   * Cross-package re-exports (``pkg/__init__.py`` does
+    #     ``from .helpers import foo``) — callers via ``pkg.foo`` are
+    #     NOT aliased to the def in ``pkg/helpers.py``. Same gap as
+    #     ``function_called``'s re-export documentation.
+    #   * Non-Python files: file-path-to-module heuristic doesn't run;
+    #     no internal aliasing for JS/Go/Java/etc.
+    for (file_path, fn_name), fns in idx.definitions.items():
+        # Pick the lowest-line def as canonical — typically the
+        # module-level one, which is the only one externally
+        # importable. Same-name nested defs aren't reachable from
+        # outside; we don't disambiguate further.
+        canonical = min(fns, key=lambda f: f.line)
+        for candidate in _candidate_qualified_names(file_path, fn_name):
+            idx.qualified_to_internal.setdefault(candidate, canonical)
+    qualified_to_internal = idx.qualified_to_internal
+
+    # Pass 2: walk every call site, resolve to a callee FunctionId
+    # (Internal or External), record forward + reverse edges.
+    for file_record in inventory.get("files", []):
+        path = file_record.get("path") or ""
+        cg = file_record.get("call_graph")
+        if not cg:
+            continue
+        imports: Dict[str, str] = cg.get("imports") or {}
+        flags: Set[str] = set(cg.get("indirection") or [])
+        getattr_targets: Set[str] = set(cg.get("getattr_targets") or [])
+        non_wildcard_masking = (flags & _MASKING_FLAGS) - {
+            INDIRECTION_WILDCARD_IMPORT,
+        }
+        has_wildcard = INDIRECTION_WILDCARD_IMPORT in flags
+
+        for call in cg.get("calls") or []:
+            chain: List[str] = list(call.get("chain") or [])
+            if not chain:
+                continue
+            line = int(call.get("line", 0) or 0)
+            caller_name: Optional[str] = call.get("caller")
+            caller_node = _resolve_caller(idx, path, caller_name, line)
+            if caller_node is None:
+                # Module-level call OR enclosing function not in the
+                # inventory's items (rare; could happen for code
+                # extracted from a file the items pass skipped).
+                # Edges from "module level" aren't useful for the
+                # primitives we expose; drop them.
+                continue
+
+            callee = _resolve_callee_chain(chain, imports)
+            if callee is not None:
+                # Canonicalise: if this external qualified name
+                # actually resolves to a project-defined function,
+                # use the InternalFunction node. Otherwise the
+                # callers_of(InternalFunction) lookup misses every
+                # caller reaching it via cross-package import.
+                aliased = qualified_to_internal.get(callee.qualified_name)
+                if aliased is not None:
+                    callee = aliased
+                idx.forward.setdefault(caller_node, set()).add(callee)
+                idx.reverse.setdefault(callee, set()).add(caller_node)
+                continue
+
+            # Couldn't resolve via import map. Two sub-cases:
+            #   (a) chain head is unbound — likely a method call
+            #       (``self.foo()`` / ``obj.foo()``). Tail name is
+            #       useful for the over-inclusive method-match index.
+            #   (b) chain is a single unbound name (``foo()`` where
+            #       ``foo`` is defined locally). Could be a call to
+            #       a peer function in the same file.
+            tail = chain[-1]
+            if len(chain) == 1:
+                # Sub-case (b): bare-name call. If this file defines
+                # a function with that name, record an internal edge.
+                local_defs = idx.definitions.get((path, tail))
+                if local_defs:
+                    for d in local_defs:
+                        idx.forward.setdefault(caller_node, set()).add(d)
+                        idx.reverse.setdefault(d, set()).add(caller_node)
+                    continue
+                # Local name not defined in this file — likely a
+                # builtin (open, len, ...) or a wildcard-imported
+                # name. Record nothing definitive; method-match
+                # index doesn't apply (no head-attr).
+                if has_wildcard:
+                    idx.uncertain_callees.setdefault(caller_node, set()).add(
+                        f"*.{tail}",
+                    )
+                continue
+
+            # Sub-case (a): unresolved attribute chain. Index for
+            # method-match over-inclusive caller lookup.
+            idx.method_match.setdefault(tail, set()).add(caller_node)
+            idx.has_method_dispatch[caller_node] = True
+            # And surface it on the source's callee set as
+            # uncertain-string so callees_of can flag it.
+            idx.uncertain_callees.setdefault(caller_node, set()).add(
+                ".".join(chain),
+            )
+
+        # Indirection flags on the file → every internal function
+        # defined IN this file inherits "uncertain caller" status
+        # for any target the file mentions by tail. We record this
+        # at file level: the keys we care about are tail names that
+        # appear in (a) call chains tail-side, (b) getattr_targets,
+        # (c) imports' tail components.
+        if non_wildcard_masking or has_wildcard:
+            file_internal_fns = [
+                fn for (p, _name), fns in idx.definitions.items()
+                if p == path for fn in fns
+            ]
+            mentioned_tails: Set[str] = set(getattr_targets)
+            for call in cg.get("calls") or []:
+                chain = list(call.get("chain") or [])
+                if chain:
+                    mentioned_tails.add(chain[-1])
+            for qualified in imports.values():
+                if not qualified:
+                    continue
+                mentioned_tails.add(qualified.rsplit(".", 1)[-1])
+            for tail in mentioned_tails:
+                for fn in file_internal_fns:
+                    # We don't know the *target* yet — that's keyed
+                    # on the lookup. Stash the (caller, tail, flag)
+                    # tuple under tail so callers_of can pick it
+                    # up.
+                    flag_label = (
+                        sorted(non_wildcard_masking)[0]
+                        if non_wildcard_masking
+                        else INDIRECTION_WILDCARD_IMPORT
+                    )
+                    idx.uncertain_callers_by_tail.setdefault(
+                        tail, set(),
+                    ).add((fn, flag_label))
+
+    _INDEX_CACHE[inv_id] = (inventory, idx)
+    if len(_INDEX_CACHE) > _CACHE_MAX_ENTRIES:
+        # Drop the oldest entry. dict preserves insertion order.
+        oldest = next(iter(_INDEX_CACHE))
+        _INDEX_CACHE.pop(oldest, None)
+    return idx
+
+
+def _resolve_caller(
+    idx: _AdjacencyIndex,
+    file_path: str,
+    caller_name: Optional[str],
+    call_line: int,
+) -> Optional[InternalFunction]:
+    """Map ``caller_name`` (lexical enclosing fn-name in ``file_path``)
+    to its :class:`InternalFunction` definition record.
+
+    When multiple definitions share the same ``(file_path, name)``
+    (rare: same-name nested defs), pick the one whose ``line`` is
+    the largest value ≤ ``call_line``. That's the lexically
+    innermost match. Falls through to the first def if heuristics
+    fail.
+    """
+    if not caller_name:
+        return None
+    candidates = idx.definitions.get((file_path, caller_name))
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return next(iter(candidates))
+    # Pick the def with greatest line ≤ call_line.
+    eligible = [c for c in candidates if c.line <= call_line]
+    if eligible:
+        return max(eligible, key=lambda c: c.line)
+    return min(candidates, key=lambda c: c.line)
+
+
+def _candidate_qualified_names(file_path: str, fn_name: str) -> List[str]:
+    """Heuristic: derive plausible Python qualified names for an
+    InternalFunction defined at ``(file_path, fn_name)``.
+
+    Returns at most a handful of candidates (typically 1-2). Used by
+    the index builder to canonicalise external callee edges that
+    actually resolve to project-defined functions.
+
+    Non-Python files: returns empty list. Other-language internal
+    aliasing isn't modelled.
+    """
+    if not (file_path.endswith(".py") or file_path.endswith(".pyi")):
+        return []
+    base = file_path
+    for suffix in (".pyi", ".py"):
+        if base.endswith(suffix):
+            base = base[: -len(suffix)]
+            break
+    if base.endswith("/__init__"):
+        base = base[: -len("/__init__")]
+    candidates: List[str] = []
+    if base:
+        candidates.append(f"{base.replace('/', '.')}.{fn_name}")
+    # ``src/`` layout: ``src/mypkg/foo.py`` is imported as
+    # ``mypkg.foo``, not ``src.mypkg.foo``. Generate both candidates.
+    if base.startswith("src/"):
+        stripped = base[len("src/"):]
+        if stripped:
+            candidates.append(f"{stripped.replace('/', '.')}.{fn_name}")
+    return candidates
+
+
+def _resolve_callee_chain(
+    chain: List[str],
+    imports: Dict[str, str],
+) -> Optional[ExternalFunction]:
+    """Map a call chain to an :class:`ExternalFunction` via the file's
+    import map. Returns None if the chain head isn't in the import
+    map.
+
+    Note: this never returns :class:`InternalFunction` — internal
+    edges via local bare-name calls are handled by the caller (the
+    fall-through path in ``_get_or_build_index`` looks up
+    ``definitions[(path, tail)]``).
+    """
+    if not chain:
+        return None
+    if len(chain) == 1:
+        bound = imports.get(chain[0])
+        if bound is None:
+            return None
+        return ExternalFunction(qualified_name=bound)
+    head = chain[0]
+    bound = imports.get(head)
+    if bound is None:
+        return None
+    middle = ".".join(chain[1:-1])
+    if middle:
+        qualified = f"{bound}.{middle}.{chain[-1]}"
+    else:
+        qualified = f"{bound}.{chain[-1]}"
+    return ExternalFunction(qualified_name=qualified)
+
+
+# ---------------------------------------------------------------------------
+# Public API: callers_of / callees_of
+# ---------------------------------------------------------------------------
+
+
+def callers_of(
+    inventory: Dict[str, Any],
+    target: FunctionId,
+    *,
+    exclude_test_files: bool = True,
+) -> CallersResult:
+    """Return 1-hop callers of ``target``.
+
+    ``target`` may be :class:`InternalFunction` (a project-defined
+    function — find every internal caller) or :class:`ExternalFunction`
+    (a dep-defined function — find every internal caller, same
+    semantics as ``function_called`` but returning structured caller
+    identities rather than evidence pairs).
+
+    Test-file callers are filtered when ``exclude_test_files`` is
+    True (the default; matches existing ``function_called``
+    behaviour).
+    """
+    idx = _get_or_build_index(
+        inventory, exclude_test_files=exclude_test_files,
+    )
+
+    # Aliasing: if the caller passes ``ExternalFunction("pkg.mod.fn")``
+    # but ``pkg.mod.fn`` is a project-defined function, follow the
+    # alias so we return the same callers as
+    # ``callers_of(InternalFunction(...))``. The index canonicalises
+    # forward edges to InternalFunction, so without this lookup the
+    # External form would silently return 0.
+    if isinstance(target, ExternalFunction):
+        aliased = idx.qualified_to_internal.get(target.qualified_name)
+        if aliased is not None:
+            target = aliased
+
+    definitive_set: Set[InternalFunction] = set(
+        idx.reverse.get(target, set())
+    )
+
+    # Uncertain: file-level masking flags on the caller's file +
+    # target tail mention. Indexed by tail (see _AdjacencyIndex).
+    target_tail = (
+        target.name if isinstance(target, InternalFunction)
+        else target.qualified_name.rsplit(".", 1)[-1]
+    )
+    uncertain_pairs = idx.uncertain_callers_by_tail.get(target_tail, set())
+    # Drop callers that are already definitive — uncertain only
+    # matters when there's NO definitive evidence in that file. But
+    # uncertain is per-fn, not per-file, so we filter by fn.
+    uncertain_set: Set[InternalFunction] = {
+        fn for (fn, _flag) in uncertain_pairs
+        if fn not in definitive_set
+    }
+
+    # Method-match overinclusive: only meaningful when target is
+    # internal (we're saying "any unresolved-head ...foo() chain
+    # might call this target named foo"). For external targets,
+    # method-match doesn't apply.
+    method_match_set: Set[InternalFunction] = set()
+    if isinstance(target, InternalFunction):
+        candidates = idx.method_match.get(target.name, set())
+        method_match_set = candidates - definitive_set - uncertain_set
+
+    if exclude_test_files:
+        definitive_set = {fn for fn in definitive_set
+                          if fn.file_path not in idx.test_paths}
+        uncertain_set = {fn for fn in uncertain_set
+                         if fn.file_path not in idx.test_paths}
+        method_match_set = {fn for fn in method_match_set
+                            if fn.file_path not in idx.test_paths}
+
+    return CallersResult(
+        definitive=tuple(_sorted_internal(definitive_set)),
+        uncertain=tuple(_sorted_internal(uncertain_set)),
+        method_match_overinclusive=tuple(_sorted_internal(method_match_set)),
+    )
+
+
+def callees_of(
+    inventory: Dict[str, Any],
+    source: InternalFunction,
+    *,
+    exclude_test_files: bool = True,
+) -> CalleesResult:
+    """Return 1-hop callees of ``source``.
+
+    ``source`` must be :class:`InternalFunction` (the question
+    "what does ``X`` call?" only makes sense when we have a
+    project-internal function whose body we've parsed).
+
+    Result mixes :class:`InternalFunction` (calls to peer project
+    functions) and :class:`ExternalFunction` (calls to dep
+    functions), reflecting that consumers like ``/audit`` want both
+    in their context slice.
+    """
+    idx = _get_or_build_index(
+        inventory, exclude_test_files=exclude_test_files,
+    )
+
+    definitive_set: Set[FunctionId] = set(idx.forward.get(source, set()))
+    uncertain: Set[str] = set(idx.uncertain_callees.get(source, set()))
+    has_method_dispatch = bool(idx.has_method_dispatch.get(source, False))
+
+    if exclude_test_files:
+        definitive_set = {
+            c for c in definitive_set
+            if not (isinstance(c, InternalFunction)
+                    and c.file_path in idx.test_paths)
+        }
+
+    return CalleesResult(
+        definitive=tuple(_sorted_callees(definitive_set)),
+        uncertain=tuple(sorted(uncertain)),
+        has_method_dispatch=has_method_dispatch,
+    )
+
+
+def _sorted_internal(s: Iterable[InternalFunction]) -> List[InternalFunction]:
+    """Stable order: by file path, then name, then line."""
+    return sorted(s, key=lambda fn: (fn.file_path, fn.name, fn.line))
+
+
+def _sorted_callees(s: Iterable[FunctionId]) -> List[FunctionId]:
+    """Stable order: Internal first (by path/name/line), External
+    second (by qualified_name)."""
+    internals = [c for c in s if isinstance(c, InternalFunction)]
+    externals = [c for c in s if isinstance(c, ExternalFunction)]
+    internals.sort(key=lambda fn: (fn.file_path, fn.name, fn.line))
+    externals.sort(key=lambda fn: fn.qualified_name)
+    return list(internals) + list(externals)
+
+
 __all__ = [
+    "CallersResult",
+    "CalleesResult",
+    "ExternalFunction",
+    "FunctionId",
+    "InternalFunction",
     "ReachabilityResult",
     "Verdict",
+    "callees_of",
+    "callers_of",
     "function_called",
 ]

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -527,6 +527,15 @@ class _AdjacencyIndex:
     qualified_to_internal: Dict[str, InternalFunction] = (
         field(default_factory=dict)
     )
+    # ``(src, dst) -> sorted tuple of line numbers`` recording every
+    # call site where ``src`` calls ``dst``. ``forward`` is dedup'd
+    # by edge; ``call_lines`` preserves multiplicity for evidence
+    # rendering ("X calls Y at lines 12, 27, 45"). Lines are 1-based
+    # source-file lines from the call_graph extractor; 0 when the
+    # extractor couldn't attribute a line.
+    call_lines: Dict[
+        Tuple[InternalFunction, FunctionId], Tuple[int, ...],
+    ] = field(default_factory=dict)
     # Set of file paths classified as test files (cached).
     test_paths: FrozenSet[str] = frozenset()
 
@@ -614,10 +623,6 @@ def _get_or_build_index(
     #   * ``src/a/b/c.py`` → also ``a.b.c`` (src-layout)
     #
     # Limitations (documented; consumer should be aware):
-    #   * Cross-package re-exports (``pkg/__init__.py`` does
-    #     ``from .helpers import foo``) — callers via ``pkg.foo`` are
-    #     NOT aliased to the def in ``pkg/helpers.py``. Same gap as
-    #     ``function_called``'s re-export documentation.
     #   * Non-Python files: file-path-to-module heuristic doesn't run;
     #     no internal aliasing for JS/Go/Java/etc.
     for (file_path, fn_name), fns in idx.definitions.items():
@@ -628,6 +633,40 @@ def _get_or_build_index(
         canonical = min(fns, key=lambda f: f.line)
         for candidate in _candidate_qualified_names(file_path, fn_name):
             idx.qualified_to_internal.setdefault(candidate, canonical)
+
+    # Pass 1.6: ``__init__.py`` re-export aliasing.
+    # ``pkg/__init__.py`` doing ``from .helpers import foo`` makes
+    # ``pkg.foo`` an alias for ``pkg.helpers.foo``. Without this pass,
+    # consumers reaching the function via ``from pkg import foo`` end
+    # up with an ``ExternalFunction("pkg.foo")`` edge that doesn't
+    # canonicalise — mirror image of the cross-package gap PR-A's
+    # heuristic closed.
+    #
+    # We resolve relative imports ourselves (the call_graph extractor
+    # records ``(level, module, name, asname)`` quads but doesn't
+    # resolve them — package roots come from file paths, which the
+    # per-file extractor doesn't know).
+    #
+    # Repeat the alias-discovery pass until fixed-point so that
+    # transitive re-exports (``pkg/__init__.py`` re-exports from
+    # ``pkg/sub/__init__.py`` which re-exports from ``pkg/sub/impl.py``)
+    # all collapse to the same canonical InternalFunction. Bounded
+    # by a small iteration count — re-export chains in real codebases
+    # are at most 3-4 deep.
+    idx._inventory_for_reexport_pass = inventory  # type: ignore[attr-defined]
+    try:
+        for _ in range(8):
+            added = _apply_reexport_aliases(idx)
+            if not added:
+                break
+    finally:
+        # Don't keep a strong ref to the inventory on the index past
+        # build time — the cache layer manages inventory lifetime.
+        try:
+            del idx._inventory_for_reexport_pass        # type: ignore[attr-defined]
+        except AttributeError:
+            pass
+
     qualified_to_internal = idx.qualified_to_internal
 
     # Pass 2: walk every call site, resolve to a callee FunctionId
@@ -672,6 +711,7 @@ def _get_or_build_index(
                     callee = aliased
                 idx.forward.setdefault(caller_node, set()).add(callee)
                 idx.reverse.setdefault(callee, set()).add(caller_node)
+                _record_call_line(idx, caller_node, callee, line)
                 continue
 
             # Couldn't resolve via import map. Two sub-cases:
@@ -690,6 +730,7 @@ def _get_or_build_index(
                     for d in local_defs:
                         idx.forward.setdefault(caller_node, set()).add(d)
                         idx.reverse.setdefault(d, set()).add(caller_node)
+                        _record_call_line(idx, caller_node, d, line)
                     continue
                 # Local name not defined in this file — likely a
                 # builtin (open, len, ...) or a wildcard-imported
@@ -781,6 +822,144 @@ def _resolve_caller(
     if eligible:
         return max(eligible, key=lambda c: c.line)
     return min(candidates, key=lambda c: c.line)
+
+
+def _record_call_line(
+    idx: _AdjacencyIndex,
+    caller: InternalFunction,
+    callee: FunctionId,
+    line: int,
+) -> None:
+    """Append ``line`` to ``idx.call_lines[(caller, callee)]``,
+    keeping the tuple sorted with no duplicates.
+
+    Forward / reverse edges are deduplicated; this side-index keeps
+    multiplicity for evidence rendering ("X calls Y at lines …").
+    """
+    key = (caller, callee)
+    existing = idx.call_lines.get(key, ())
+    if line in existing:
+        return
+    merged = existing + (line,)
+    idx.call_lines[key] = tuple(sorted(merged))
+
+
+def _apply_reexport_aliases(idx: _AdjacencyIndex) -> int:
+    """One iteration of ``__init__.py`` re-export alias discovery.
+
+    Walks every ``__init__.py`` in the inventory's call-graph data,
+    resolves each relative import to a fully-qualified source, and
+    when that source is in ``qualified_to_internal``, registers the
+    re-exported alias as another entry pointing at the same
+    InternalFunction. Returns the number of new aliases added so the
+    caller can iterate to fixed-point (transitive re-exports).
+
+    The re-export pass needs the call_graph data, which lives on
+    ``file_record["call_graph"]`` not on the ``_AdjacencyIndex`` —
+    we receive the index because that's what we mutate, but reading
+    the data requires the inventory. We stash the inventory on the
+    index temporarily during build so this helper can find it.
+    """
+    inv = getattr(idx, "_inventory_for_reexport_pass", None)
+    if inv is None:
+        return 0
+    added = 0
+    for file_record in inv.get("files", []):
+        path = file_record.get("path") or ""
+        if not (path.endswith("/__init__.py") or path == "__init__.py"):
+            continue
+        cg = file_record.get("call_graph")
+        if not cg:
+            continue
+        rel_imports = cg.get("relative_imports") or []
+        abs_imports = cg.get("imports") or {}
+        if not rel_imports and not abs_imports:
+            continue
+        # Package this __init__.py defines (path → dotted form).
+        if path == "__init__.py":
+            pkg_path = ""
+        else:
+            pkg_path = path[: -len("/__init__.py")]
+        pkg_dotted_candidates: List[str] = []
+        if pkg_path:
+            pkg_dotted_candidates.append(pkg_path.replace("/", "."))
+            if pkg_path.startswith("src/"):
+                stripped = pkg_path[len("src/"):]
+                if stripped:
+                    pkg_dotted_candidates.append(stripped.replace("/", "."))
+        else:
+            pkg_dotted_candidates.append("")
+        for ri in rel_imports:
+            if not isinstance(ri, (list, tuple)) or len(ri) < 3:
+                continue
+            level = int(ri[0])
+            module = str(ri[1] or "")
+            name = str(ri[2] or "")
+            asname = ri[3] if len(ri) > 3 else None
+            if level <= 0 or not name:
+                continue
+            for pkg_dotted in pkg_dotted_candidates:
+                # Walk up ``level - 1`` package levels from the
+                # file's package. Level 1 means current package.
+                parts = pkg_dotted.split(".") if pkg_dotted else []
+                ascend = level - 1
+                if ascend > len(parts):
+                    # ``from ..`` from a top-level package — skip;
+                    # there's no further ancestor.
+                    continue
+                ancestor = ".".join(
+                    parts[: len(parts) - ascend] if ascend > 0 else parts
+                )
+                # Compose the source qualified name: ancestor + module
+                if module:
+                    source_module = (
+                        f"{ancestor}.{module}" if ancestor else module
+                    )
+                else:
+                    source_module = ancestor
+                if not source_module:
+                    continue
+                source_full = f"{source_module}.{name}"
+                target_internal = idx.qualified_to_internal.get(source_full)
+                if target_internal is None:
+                    continue
+                alias_name = asname or name
+                alias_full = (
+                    f"{pkg_dotted}.{alias_name}" if pkg_dotted
+                    else alias_name
+                )
+                if alias_full not in idx.qualified_to_internal:
+                    idx.qualified_to_internal[alias_full] = target_internal
+                    added += 1
+        # Absolute-import re-exports: ``core/__init__.py`` doing
+        # ``from core.config import RaptorConfig`` makes
+        # ``core.RaptorConfig`` available to callers via ``from core
+        # import RaptorConfig``. Walk this file's imports map and
+        # treat each entry as a potential re-export from this package.
+        # (The local-name → qualified-name map is exactly what we
+        # need: local_name is the alias-as-seen-from-outside, and
+        # qualified is the source we look up in qualified_to_internal.)
+        for local_name, qualified in abs_imports.items():
+            if not qualified:
+                continue
+            target_internal = idx.qualified_to_internal.get(qualified)
+            if target_internal is None:
+                continue
+            for pkg_dotted in pkg_dotted_candidates:
+                alias_full = (
+                    f"{pkg_dotted}.{local_name}" if pkg_dotted
+                    else local_name
+                )
+                if alias_full == qualified:
+                    # Trivial self-alias — qualified is already in
+                    # the map under itself. Skip (would be a no-op
+                    # but for the ``added`` counter, which would
+                    # let us re-process every iteration).
+                    continue
+                if alias_full not in idx.qualified_to_internal:
+                    idx.qualified_to_internal[alias_full] = target_internal
+                    added += 1
+    return added
 
 
 def _candidate_qualified_names(file_path: str, fn_name: str) -> List[str]:
@@ -965,6 +1144,33 @@ def callees_of(
         uncertain=tuple(sorted(uncertain)),
         has_method_dispatch=has_method_dispatch,
     )
+
+
+def call_lines_of(
+    inventory: Dict[str, Any],
+    caller: InternalFunction,
+    callee: FunctionId,
+) -> Tuple[int, ...]:
+    """Source lines where ``caller`` calls ``callee``.
+
+    Returns the sorted, dedup'd tuple of 1-based line numbers
+    recorded at index-build time, or ``()`` when no edge exists.
+    Useful for evidence rendering (``"X calls Y at lines 12, 27,
+    45"``) where ``callees_of`` only tells you the edge exists.
+
+    For ``callee`` aliasing: an ``ExternalFunction`` whose
+    qualified name resolves to a project-internal function is
+    canonicalised to that ``InternalFunction`` (matches
+    ``callers_of`` / closure semantics). A consumer holding the
+    ``ExternalFunction`` form gets the same line numbers as one
+    holding the ``InternalFunction`` form.
+    """
+    idx = _get_or_build_index(inventory, exclude_test_files=False)
+    if isinstance(callee, ExternalFunction):
+        aliased = idx.qualified_to_internal.get(callee.qualified_name)
+        if aliased is not None:
+            callee = aliased
+    return idx.call_lines.get((caller, callee), ())
 
 
 def _sorted_internal(s: Iterable[InternalFunction]) -> List[InternalFunction]:
@@ -1268,6 +1474,79 @@ def shortest_path(
     return None
 
 
+def all_paths(
+    inventory: Dict[str, Any],
+    source: InternalFunction,
+    target: FunctionId,
+    *,
+    max_paths: int = 10,
+    max_depth: int = 50,
+    exclude_test_files: bool = False,
+) -> Tuple[Tuple[FunctionId, ...], ...]:
+    """All simple call chains ``source`` → ``target``, sorted by
+    length (shortest first), bounded by ``max_paths`` and
+    ``max_depth``.
+
+    Useful for evidence diversity when ``shortest_path``'s pick
+    isn't the chain a consumer wants — e.g. /validate sees the
+    LLM proposed a different chain and wants to confirm there are
+    multiple valid evidence paths to choose between.
+
+    "Simple": no node repeats within a single path. Cycles are
+    handled via the per-path visited set rather than a global one,
+    so multiple distinct paths through a shared intermediate are
+    discoverable.
+
+    Cost: bounded DFS, worst case O(b^max_depth) where b is the
+    branching factor. Real codebases are sparse; ``max_depth``
+    bounds the runaway. Returns early on hitting ``max_paths``.
+
+    External targets follow the qualified-name → Internal alias
+    (matches ``shortest_path`` / closure semantics).
+    """
+    idx = _get_or_build_index(
+        inventory, exclude_test_files=exclude_test_files,
+    )
+    if isinstance(target, ExternalFunction):
+        aliased = idx.qualified_to_internal.get(target.qualified_name)
+        if aliased is not None:
+            target = aliased
+    if source == target:
+        return ((source,),)
+
+    found: List[Tuple[FunctionId, ...]] = []
+
+    def _dfs(node: FunctionId, path: Tuple[FunctionId, ...],
+              visited: Set[FunctionId]) -> None:
+        if len(found) >= max_paths:
+            return
+        if len(path) > max_depth:
+            return
+        if not isinstance(node, InternalFunction):
+            return
+        for callee in idx.forward.get(node, set()):
+            if callee in visited:
+                continue
+            if exclude_test_files and isinstance(callee, InternalFunction) \
+                    and callee.file_path in idx.test_paths:
+                continue
+            new_path = path + (callee,)
+            if callee == target:
+                found.append(new_path)
+                if len(found) >= max_paths:
+                    return
+                continue
+            visited.add(callee)
+            _dfs(callee, new_path, visited)
+            visited.discard(callee)
+            if len(found) >= max_paths:
+                return
+
+    _dfs(source, (source,), {source})
+    found.sort(key=len)
+    return tuple(found[:max_paths])
+
+
 def _closure_sort_key(fn: FunctionId) -> Tuple:
     """Stable order across mixed Internal+External: Internal first by
     (path, name, line); External after by qualified_name. Use a
@@ -1286,6 +1565,8 @@ __all__ = [
     "InternalFunction",
     "ReachabilityResult",
     "Verdict",
+    "all_paths",
+    "call_lines_of",
     "callees_of",
     "callers_of",
     "forward_closure",

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -982,9 +982,305 @@ def _sorted_callees(s: Iterable[FunctionId]) -> List[FunctionId]:
     return list(internals) + list(externals)
 
 
+# ---------------------------------------------------------------------------
+# Closure primitives — transitive reverse / forward / shortest-path
+# ---------------------------------------------------------------------------
+#
+# 1-hop adjacency (``callers_of`` / ``callees_of``) answers "who DIRECTLY
+# calls X?" The closure primitives below answer the transitive question:
+# given a target, which project functions can reach it through ANY chain
+# of internal calls? Or symmetrically: from a set of entry points, what's
+# the full forward-reachable set?
+#
+# All three primitives walk the same definitive call-graph edges captured
+# by the adjacency index in pass 2. **Uncertain edges are NOT walked.**
+# A consumer wanting "could-possibly-reach" coverage should drill into
+# the boundary using ``callers_of`` / ``callees_of`` directly to inspect
+# the 1-hop uncertain neighbours; closure semantics are "demonstrably
+# reachable".
+#
+# This split is deliberate: the SCA / audit consumer that wants to demote
+# severity for unreachable code wants to be conservative — empty closure
+# under definitive-only walk, plus a non-empty 1-hop uncertain frontier,
+# means "we don't know" and severity should NOT be demoted. The two
+# halves of the answer come from separate primitives.
+#
+# **Termination at External nodes.** Forward closure expands
+# InternalFunction nodes only — ``ExternalFunction`` is recorded in the
+# closure when reached but its callees are unknown to the index (it's
+# a dep). Reverse closure has no analogous distinction: every caller of
+# anything is by definition an Internal project function (we don't
+# index how the project's deps call each other).
+#
+# **Cycles.** Visited-set BFS handles cycles trivially. We don't surface
+# strongly-connected-component structure — consumers that need it can
+# layer it on top of a closure result.
+
+
+@dataclass(frozen=True)
+class ClosureResult:
+    """Result of a transitive closure walk.
+
+    ``nodes`` is the set of project functions reachable from the seed
+    (forward) or that can reach the target (reverse), excluding the
+    seed/target itself, in stable order.
+
+    ``paths`` maps each reached node to a representative shortest call
+    chain. For ``forward_closure``, the chain runs entry → ... → node.
+    For ``reverse_closure``, the chain runs node → ... → target.
+    Useful for evidence rendering — a /validate consumer showing "this
+    sink is reachable from the HTTP entry via this chain" wants the
+    chain itself, not just the membership.
+
+    ``truncated`` is True iff the BFS hit ``max_depth`` on at least one
+    path. The closure is still useful (everything in ``nodes`` IS
+    reachable) but may be incomplete; consumers who care can re-run
+    with a higher ``max_depth``.
+    """
+
+    nodes: Tuple[FunctionId, ...] = ()
+    paths: Dict[FunctionId, Tuple[FunctionId, ...]] = field(
+        default_factory=dict,
+    )
+    truncated: bool = False
+
+
+def reverse_closure(
+    inventory: Dict[str, Any],
+    target: FunctionId,
+    *,
+    max_depth: int = 50,
+    exclude_test_files: bool = True,
+) -> ClosureResult:
+    """Project functions that can transitively reach ``target``.
+
+    BFS up the reverse-adjacency graph starting at ``target``. The
+    closure includes only :class:`InternalFunction` nodes — Externals
+    can't be callers in our model. The seed (``target``) is excluded
+    from the result.
+
+    ``target`` may be Internal or External. If External, the
+    qualified-name-to-internal alias is followed (same semantics as
+    ``callers_of``).
+
+    ``max_depth`` bounds the BFS depth. ``exclude_test_files``
+    filters test-file callers out of the result; the BFS itself
+    walks them so paths through tests reach internal seed functions
+    correctly.
+    """
+    from collections import deque
+
+    idx = _get_or_build_index(
+        inventory, exclude_test_files=exclude_test_files,
+    )
+    if isinstance(target, ExternalFunction):
+        aliased = idx.qualified_to_internal.get(target.qualified_name)
+        if aliased is not None:
+            target = aliased
+
+    paths: Dict[FunctionId, Tuple[FunctionId, ...]] = {target: (target,)}
+    queue: "deque[Tuple[FunctionId, int]]" = deque([(target, 0)])
+    truncated = False
+    while queue:
+        node, depth = queue.popleft()
+        if depth >= max_depth:
+            truncated = True
+            continue
+        for caller in idx.reverse.get(node, set()):
+            if caller in paths:
+                continue
+            # Don't traverse test-file functions when filtering them
+            # out — otherwise a non-test function reachable ONLY via
+            # a test caller ends up in the closure with a path that
+            # crosses test code, surprising the consumer. Symmetric
+            # with shortest_path's behaviour.
+            if exclude_test_files and isinstance(caller, InternalFunction) \
+                    and caller.file_path in idx.test_paths:
+                continue
+            paths[caller] = (caller,) + paths[node]
+            queue.append((caller, depth + 1))
+
+    nodes_list: List[FunctionId] = []
+    out_paths: Dict[FunctionId, Tuple[FunctionId, ...]] = {}
+    for n, p in paths.items():
+        if n == target:
+            continue
+        nodes_list.append(n)
+        out_paths[n] = p
+    nodes_list.sort(key=_closure_sort_key)
+    return ClosureResult(
+        nodes=tuple(nodes_list),
+        paths=out_paths,
+        truncated=truncated,
+    )
+
+
+def forward_closure(
+    inventory: Dict[str, Any],
+    entries: Iterable[InternalFunction],
+    *,
+    max_depth: int = 50,
+    exclude_test_files: bool = True,
+) -> ClosureResult:
+    """Functions transitively callable from any of ``entries``.
+
+    BFS down the forward-adjacency graph, seeding from every entry
+    in ``entries``. The closure includes both :class:`InternalFunction`
+    (project edges) and :class:`ExternalFunction` (dep calls) nodes
+    — the distinction matters for /validate Stage F asking "does the
+    chain reach this sink?" where the sink can be either form.
+
+    External nodes are TERMINAL: we record them but don't expand.
+    The substrate doesn't know an external dep's callees, only that
+    it was called.
+
+    ``entries`` is excluded from the result. Test-file results are
+    filtered when ``exclude_test_files`` is True.
+    """
+    from collections import deque
+
+    idx = _get_or_build_index(
+        inventory, exclude_test_files=exclude_test_files,
+    )
+
+    entry_set: Set[FunctionId] = set(entries)
+    paths: Dict[FunctionId, Tuple[FunctionId, ...]] = {}
+    queue: "deque[Tuple[FunctionId, int]]" = deque()
+    for entry in entry_set:
+        if entry not in paths:
+            paths[entry] = (entry,)
+            queue.append((entry, 0))
+
+    truncated = False
+    while queue:
+        node, depth = queue.popleft()
+        if depth >= max_depth:
+            truncated = True
+            continue
+        if not isinstance(node, InternalFunction):
+            # External — terminal. We have no internal definition,
+            # so no outgoing edges to expand.
+            continue
+        for callee in idx.forward.get(node, set()):
+            if callee in paths:
+                continue
+            # Don't traverse through test-file functions when
+            # excluding them — symmetric with reverse_closure /
+            # shortest_path. Reachability through tests isn't
+            # production reachability.
+            if exclude_test_files and isinstance(callee, InternalFunction) \
+                    and callee.file_path in idx.test_paths:
+                continue
+            paths[callee] = paths[node] + (callee,)
+            queue.append((callee, depth + 1))
+
+    nodes_list: List[FunctionId] = []
+    out_paths: Dict[FunctionId, Tuple[FunctionId, ...]] = {}
+    for n, p in paths.items():
+        if n in entry_set:
+            continue
+        nodes_list.append(n)
+        out_paths[n] = p
+    nodes_list.sort(key=_closure_sort_key)
+    return ClosureResult(
+        nodes=tuple(nodes_list),
+        paths=out_paths,
+        truncated=truncated,
+    )
+
+
+def shortest_path(
+    inventory: Dict[str, Any],
+    source: InternalFunction,
+    target: FunctionId,
+    *,
+    max_depth: int = 50,
+    exclude_test_files: bool = False,
+) -> Optional[Tuple[FunctionId, ...]]:
+    """Shortest call chain ``source`` → ``target``, or None.
+
+    BFS forward from ``source`` with early-exit on hitting
+    ``target``. Returns the chain inclusive of both endpoints, or
+    ``None`` if ``target`` is not reachable within ``max_depth``
+    hops. ``source == target`` returns ``(source,)``.
+
+    ``target`` may be Internal or External. External targets have
+    their qualified-name-to-internal alias followed (matches
+    callers_of / reverse_closure semantics).
+
+    ``exclude_test_files`` defaults to False here — when /validate
+    renders an evidence path, it usually wants the genuine chain
+    even if it crosses a test helper. Consumers that want the
+    audit-style filter pass ``exclude_test_files=True`` explicitly;
+    in that mode, the BFS rejects paths whose intermediate hops
+    cross a test file (endpoints are the consumer's responsibility).
+    """
+    from collections import deque
+
+    idx = _get_or_build_index(
+        inventory, exclude_test_files=exclude_test_files,
+    )
+    if isinstance(target, ExternalFunction):
+        aliased = idx.qualified_to_internal.get(target.qualified_name)
+        if aliased is not None:
+            target = aliased
+    if source == target:
+        return (source,)
+
+    visited: Dict[FunctionId, Tuple[FunctionId, ...]] = {source: (source,)}
+    queue: "deque[Tuple[FunctionId, int]]" = deque([(source, 0)])
+    while queue:
+        node, depth = queue.popleft()
+        if depth >= max_depth:
+            continue
+        if not isinstance(node, InternalFunction):
+            continue
+        for callee in idx.forward.get(node, set()):
+            if callee in visited:
+                continue
+            chain = visited[node] + (callee,)
+            if callee == target:
+                if exclude_test_files:
+                    intermediate_in_test = any(
+                        isinstance(s, InternalFunction)
+                        and s.file_path in idx.test_paths
+                        for s in chain[1:-1]
+                    )
+                    if intermediate_in_test:
+                        # Reject this chain as evidence — but don't
+                        # mark target visited (a different chain
+                        # via a non-test path may still reach it).
+                        # Don't enqueue target either: it has no
+                        # outgoing edges we'd want to walk.
+                        continue
+                return chain
+            # Same logic for intermediates: paths whose body crosses
+            # a test-file function shouldn't be propagated further
+            # under exclude_test_files=True. Otherwise we explore
+            # them and only filter at the endpoint, which can prune
+            # a clean sibling path that happened to be discovered
+            # through the same intermediate.
+            if exclude_test_files and isinstance(callee, InternalFunction) \
+                    and callee.file_path in idx.test_paths:
+                continue
+            visited[callee] = chain
+            queue.append((callee, depth + 1))
+    return None
+
+
+def _closure_sort_key(fn: FunctionId) -> Tuple:
+    """Stable order across mixed Internal+External: Internal first by
+    (path, name, line); External after by qualified_name. Use a
+    tuple-with-discriminant so heterogeneous comparison works."""
+    if isinstance(fn, InternalFunction):
+        return (0, fn.file_path, fn.name, fn.line, "")
+    return (1, "", "", 0, fn.qualified_name)
+
+
 __all__ = [
     "CallersResult",
     "CalleesResult",
+    "ClosureResult",
     "ExternalFunction",
     "FunctionId",
     "InternalFunction",
@@ -992,5 +1288,8 @@ __all__ = [
     "Verdict",
     "callees_of",
     "callers_of",
+    "forward_closure",
     "function_called",
+    "reverse_closure",
+    "shortest_path",
 ]

--- a/core/inventory/tests/test_reachability_adjacency.py
+++ b/core/inventory/tests/test_reachability_adjacency.py
@@ -43,6 +43,7 @@ from core.inventory.reachability import (
     CallersResult,
     ExternalFunction,
     InternalFunction,
+    call_lines_of,
     callees_of,
     callers_of,
 )
@@ -646,3 +647,287 @@ def test_cache_lru_eviction():
         r._CACHE_MAX_ENTRIES = saved_max
         r._INDEX_CACHE.clear()
         r._INDEX_CACHE.update(saved_cache)
+
+
+# ---------------------------------------------------------------------------
+# __init__.py re-export aliasing — extends the cross-package canonicalisation
+# above to handle ``pkg/__init__.py`` that re-exports from submodules,
+# both via relative (``from .helpers import foo``) and absolute (``from
+# pkg.helpers import foo``) import forms.
+# ---------------------------------------------------------------------------
+
+
+def test_reexport_basic():
+    """``pkg/__init__.py`` does ``from .helpers import foo`` and
+    ``app.py`` does ``from pkg import foo; foo()``. The caller must
+    resolve to the def in ``pkg/helpers.py``."""
+    inv = _inv(
+        _file("pkg/__init__.py",
+            "from .helpers import foo\n",
+            items=[],
+        ),
+        _file("pkg/helpers.py",
+            "def foo():\n"
+            "    pass\n"
+        ),
+        _file("app.py",
+            "from pkg import foo\n"
+            "def main():\n"
+            "    foo()\n"
+        ),
+    )
+    target = InternalFunction("pkg/helpers.py", "foo", 1)
+    r = callers_of(inv, target)
+    assert r.definitive == (InternalFunction("app.py", "main", 2),)
+
+
+def test_reexport_with_alias():
+    """``from .helpers import foo as bar`` — alias name must be the
+    one consumers can call by."""
+    inv = _inv(
+        _file("pkg/__init__.py",
+            "from .helpers import foo as bar\n",
+            items=[],
+        ),
+        _file("pkg/helpers.py",
+            "def foo():\n"
+            "    pass\n"
+        ),
+        _file("app.py",
+            "from pkg import bar\n"
+            "def main():\n"
+            "    bar()\n"
+        ),
+    )
+    target = InternalFunction("pkg/helpers.py", "foo", 1)
+    r = callers_of(inv, target)
+    assert r.definitive == (InternalFunction("app.py", "main", 2),)
+
+
+def test_reexport_transitive():
+    """``pkg/__init__.py`` re-exports from ``pkg/sub/__init__.py``
+    which re-exports from ``pkg/sub/impl.py``. Three-level chain;
+    fixed-point iteration must collapse them all to the same def."""
+    inv = _inv(
+        _file("pkg/__init__.py",
+            "from .sub import foo\n",
+            items=[],
+        ),
+        _file("pkg/sub/__init__.py",
+            "from .impl import foo\n",
+            items=[],
+        ),
+        _file("pkg/sub/impl.py",
+            "def foo():\n"
+            "    pass\n"
+        ),
+        _file("app.py",
+            "from pkg import foo\n"
+            "def main():\n"
+            "    foo()\n"
+        ),
+    )
+    target = InternalFunction("pkg/sub/impl.py", "foo", 1)
+    r = callers_of(inv, target)
+    assert InternalFunction("app.py", "main", 2) in r.definitive
+
+
+def test_reexport_via_double_dot():
+    """``pkg/sub/__init__.py`` does ``from ..other import x``,
+    making ``pkg.sub.x`` an alias for ``pkg.other.x``."""
+    inv = _inv(
+        _file("pkg/__init__.py", "", items=[]),
+        _file("pkg/sub/__init__.py",
+            "from ..other import x\n",
+            items=[],
+        ),
+        _file("pkg/other.py",
+            "def x():\n"
+            "    pass\n"
+        ),
+        _file("app.py",
+            "from pkg.sub import x\n"
+            "def main():\n"
+            "    x()\n"
+        ),
+    )
+    target = InternalFunction("pkg/other.py", "x", 1)
+    r = callers_of(inv, target)
+    assert InternalFunction("app.py", "main", 2) in r.definitive
+
+
+def test_reexport_doesnt_steal_unrelated():
+    """``pkg/__init__.py`` re-exporting ``foo`` shouldn't make
+    ``pkg.bar`` resolve to anything — there's no ``bar`` re-export."""
+    inv = _inv(
+        _file("pkg/__init__.py",
+            "from .helpers import foo\n",
+            items=[],
+        ),
+        _file("pkg/helpers.py",
+            "def foo():\n"
+            "    pass\n"
+            "def bar():\n"
+            "    pass\n"
+        ),
+        _file("app.py",
+            "from pkg import bar\n"
+            "def main():\n"
+            "    bar()\n"
+        ),
+    )
+    target = InternalFunction("pkg/helpers.py", "bar", 3)
+    r = callers_of(inv, target)
+    assert r.definitive == ()
+
+
+def test_reexport_src_layout():
+    """``src/mypkg/__init__.py`` re-exports from
+    ``src/mypkg/helpers.py``. Caller does ``from mypkg import foo``."""
+    inv = _inv(
+        _file("src/mypkg/__init__.py",
+            "from .helpers import foo\n",
+            items=[],
+        ),
+        _file("src/mypkg/helpers.py",
+            "def foo():\n"
+            "    pass\n"
+        ),
+        _file("app.py",
+            "from mypkg import foo\n"
+            "def main():\n"
+            "    foo()\n"
+        ),
+    )
+    target = InternalFunction("src/mypkg/helpers.py", "foo", 1)
+    r = callers_of(inv, target)
+    assert InternalFunction("app.py", "main", 2) in r.definitive
+
+
+def test_reexport_absolute_import():
+    """``core/__init__.py`` does ``from core.config import RaptorConfig``
+    (absolute import, not ``.config``). RAPTOR's actual
+    ``core/__init__.py`` uses this style."""
+    inv = _inv(
+        _file("core/__init__.py",
+            "from core.config import RaptorConfig\n",
+            items=[],
+        ),
+        _file("core/config.py",
+            "def RaptorConfig():\n"
+            "    pass\n"
+        ),
+        _file("app.py",
+            "from core import RaptorConfig\n"
+            "def main():\n"
+            "    RaptorConfig()\n"
+        ),
+    )
+    target = InternalFunction("core/config.py", "RaptorConfig", 1)
+    r = callers_of(inv, target)
+    assert InternalFunction("app.py", "main", 2) in r.definitive
+
+
+def test_reexport_target_not_in_project_unchanged():
+    """``from .nonexistent import foo`` where the source isn't a
+    project module — no alias should be created."""
+    inv = _inv(
+        _file("pkg/__init__.py",
+            "from .nonexistent import foo\n",
+            items=[],
+        ),
+        _file("app.py",
+            "from pkg import foo\n"
+            "def main():\n"
+            "    foo()\n"
+        ),
+    )
+    from core.inventory.reachability import _get_or_build_index
+    idx = _get_or_build_index(inv, exclude_test_files=False)
+    assert "pkg.foo" not in idx.qualified_to_internal
+
+
+# ---------------------------------------------------------------------------
+# call_lines_of — preserves multiplicity past the dedup'd forward / reverse
+# adjacency. Useful for evidence rendering ("X calls Y at lines …").
+# ---------------------------------------------------------------------------
+
+
+def test_call_lines_of_records_every_call_site():
+    inv = _inv(_file("src/a.py",
+        "def helper():\n"
+        "    pass\n"
+        "def main():\n"
+        "    helper()\n"
+        "    x = 1\n"
+        "    helper()\n"
+        "    y = 2\n"
+        "    helper()\n"
+    ))
+    main = InternalFunction("src/a.py", "main", 3)
+    helper = InternalFunction("src/a.py", "helper", 1)
+    assert call_lines_of(inv, main, helper) == (4, 6, 8)
+
+
+def test_call_lines_of_external_callee():
+    inv = _inv(_file("src/a.py",
+        "import requests\n"
+        "def f():\n"
+        "    requests.get('/')\n"
+        "    requests.get('/x')\n"
+    ))
+    f = InternalFunction("src/a.py", "f", 2)
+    assert call_lines_of(inv, f, ExternalFunction("requests.get")) == (3, 4)
+
+
+def test_call_lines_of_returns_empty_when_no_edge():
+    inv = _inv(_file("src/a.py",
+        "def a():\n"
+        "    pass\n"
+        "def b():\n"
+        "    pass\n"
+    ))
+    a = InternalFunction("src/a.py", "a", 1)
+    b = InternalFunction("src/a.py", "b", 3)
+    assert call_lines_of(inv, a, b) == ()
+
+
+def test_call_lines_of_internal_alias_target():
+    """A consumer holding ``ExternalFunction("pkg.helpers.foo")``
+    should get the same line numbers as one holding the
+    ``InternalFunction`` form — same alias semantics as
+    ``callers_of``."""
+    inv = _inv(
+        _file("pkg/helpers.py",
+            "def foo():\n"
+            "    pass\n"
+        ),
+        _file("app.py",
+            "from pkg.helpers import foo\n"
+            "def main():\n"
+            "    foo()\n"
+            "    foo()\n"
+        ),
+    )
+    main = InternalFunction("app.py", "main", 2)
+    foo = InternalFunction("pkg/helpers.py", "foo", 1)
+    via_internal = call_lines_of(inv, main, foo)
+    via_external = call_lines_of(
+        inv, main, ExternalFunction("pkg.helpers.foo"))
+    assert via_internal == via_external == (3, 4)
+
+
+def test_call_lines_dedups_same_line():
+    """The recorder is idempotent: repeated calls with the same
+    (line, edge) don't introduce duplicates."""
+    from core.inventory.reachability import (
+        _AdjacencyIndex, _record_call_line,
+    )
+    idx = _AdjacencyIndex()
+    fn = InternalFunction("a.py", "x", 1)
+    callee = ExternalFunction("os.path.join")
+    _record_call_line(idx, fn, callee, 5)
+    _record_call_line(idx, fn, callee, 5)
+    _record_call_line(idx, fn, callee, 7)
+    _record_call_line(idx, fn, callee, 3)
+    assert idx.call_lines[(fn, callee)] == (3, 5, 7)

--- a/core/inventory/tests/test_reachability_adjacency.py
+++ b/core/inventory/tests/test_reachability_adjacency.py
@@ -1,0 +1,648 @@
+"""Tests for the 1-hop adjacency primitives in
+:mod:`core.inventory.reachability` — ``callers_of`` and
+``callees_of``.
+
+These exercise the resolver against synthetic inventory dicts that
+mirror the shape :func:`core.inventory.builder.build_inventory`
+produces: each file has ``items`` (function definitions with name +
+line_start) AND ``call_graph`` (imports, calls with caller name,
+indirection flags).
+
+Built-in policy points pinned by the tests below:
+
+  * Project-internal call edges (``foo()`` → local def of ``foo``)
+    appear in ``definitive``.
+  * Cross-package call edges (``mod.fn()`` → ``ExternalFunction``)
+    appear in ``definitive``.
+  * Method-dispatch chains (``self.foo()``, ``obj.foo()``) appear
+    in ``method_match_overinclusive`` for any project-internal
+    target named ``foo``, and in the source's
+    ``CalleesResult.uncertain`` + ``has_method_dispatch=True``.
+  * File-level masking flags (``getattr`` / ``importlib`` /
+    wildcard import) flag every internal function in that file
+    as an uncertain caller of any tail-name the file mentions.
+  * Test files (``tests/``, ``test_*.py``, ``*_test.py``,
+    ``conftest.py``) are filtered out by default.
+  * The adjacency index is memoised per-inventory so back-to-back
+    queries don't rebuild.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from core.inventory.call_graph import (
+    INDIRECTION_GETATTR,
+    INDIRECTION_WILDCARD_IMPORT,
+    extract_call_graph_python,
+)
+from core.inventory.reachability import (
+    CalleesResult,
+    CallersResult,
+    ExternalFunction,
+    InternalFunction,
+    callees_of,
+    callers_of,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _file(path: str, source: str, *, items: List[Dict[str, Any]] = None,
+          ) -> Dict[str, Any]:
+    """Build one file record. Auto-derives items from the AST if not
+    supplied — convenient for most tests where the function defs in
+    the source are exactly what we want indexed."""
+    cg = extract_call_graph_python(source).to_dict()
+    if items is None:
+        items = _derive_items(source)
+    return {
+        "path": path,
+        "language": "python",
+        "items": items,
+        "call_graph": cg,
+    }
+
+
+def _derive_items(source: str) -> List[Dict[str, Any]]:
+    """Walk the source with stdlib ast and pull out top-level + nested
+    function defs. Mirrors what extract_items would do for the test's
+    purposes."""
+    import ast
+    out: List[Dict[str, Any]] = []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            out.append({
+                "name": node.name,
+                "kind": "function",
+                "line_start": node.lineno,
+                "line_end": getattr(node, "end_lineno", None),
+            })
+    return out
+
+
+def _inv(*files: Dict[str, Any]) -> Dict[str, Any]:
+    return {"files": list(files)}
+
+
+# ---------------------------------------------------------------------------
+# callers_of — external target (the SCA / codeql case)
+# ---------------------------------------------------------------------------
+
+
+def test_external_callers_definitive_via_attribute_chain():
+    inv = _inv(_file("src/a.py",
+        "import requests\n"
+        "def fetch():\n"
+        "    requests.get('/')\n"
+    ))
+    r = callers_of(inv, ExternalFunction("requests.get"))
+    assert r.definitive == (InternalFunction("src/a.py", "fetch", 2),)
+    assert r.uncertain == ()
+    assert r.method_match_overinclusive == ()
+
+
+def test_external_callers_definitive_via_aliased_import():
+    inv = _inv(_file("src/a.py",
+        "from requests.utils import extract_zipped_paths as ezp\n"
+        "def unzip():\n"
+        "    ezp('/')\n"
+    ))
+    r = callers_of(inv, ExternalFunction(
+        "requests.utils.extract_zipped_paths"))
+    assert r.definitive == (InternalFunction("src/a.py", "unzip", 2),)
+
+
+def test_external_callers_multiple_callers_sorted():
+    inv = _inv(
+        _file("src/b.py", "import requests\ndef b1():\n    requests.get('/')\n"),
+        _file("src/a.py", "import requests\ndef a1():\n    requests.get('/')\n"),
+    )
+    r = callers_of(inv, ExternalFunction("requests.get"))
+    # Stable sort by (file_path, name, line).
+    assert r.definitive == (
+        InternalFunction("src/a.py", "a1", 2),
+        InternalFunction("src/b.py", "b1", 2),
+    )
+
+
+def test_external_callers_no_callers():
+    inv = _inv(_file("src/a.py",
+        "import json\n"
+        "def f():\n"
+        "    json.dumps({})\n"
+    ))
+    r = callers_of(inv, ExternalFunction("requests.get"))
+    assert r.definitive == ()
+    assert r.uncertain == ()
+
+
+# ---------------------------------------------------------------------------
+# callers_of — internal target
+# ---------------------------------------------------------------------------
+
+
+def test_internal_callers_via_local_bare_call():
+    """`foo()` referring to a peer function defined in the same file."""
+    inv = _inv(_file("src/a.py",
+        "def helper():\n"
+        "    pass\n"
+        "def main():\n"
+        "    helper()\n"
+    ))
+    target = InternalFunction("src/a.py", "helper", 1)
+    r = callers_of(inv, target)
+    assert r.definitive == (InternalFunction("src/a.py", "main", 3),)
+
+
+def test_internal_callers_method_match_overinclusive():
+    """``self.foo()`` is over-inclusive: any project function with
+    body containing an unresolved-head ``...foo()`` is listed under
+    ``method_match_overinclusive`` for every project-internal target
+    named ``foo``."""
+    inv = _inv(
+        _file("src/a.py",
+            "class A:\n"
+            "    def foo(self):\n"
+            "        pass\n"
+            "    def main(self):\n"
+            "        self.foo()\n"
+        ),
+        _file("src/b.py",
+            "class B:\n"
+            "    def foo(self):\n"
+            "        pass\n"
+        ),
+    )
+    target_a = InternalFunction("src/a.py", "foo", 2)
+    target_b = InternalFunction("src/b.py", "foo", 2)
+    r_a = callers_of(inv, target_a)
+    r_b = callers_of(inv, target_b)
+    main_fn = InternalFunction("src/a.py", "main", 4)
+    # `main` shows up over-inclusively for both targets.
+    assert main_fn in r_a.method_match_overinclusive
+    assert main_fn in r_b.method_match_overinclusive
+    # And NOT in either's definitive — we don't know which `foo`
+    # `self.foo()` resolved to.
+    assert main_fn not in r_a.definitive
+    assert main_fn not in r_b.definitive
+
+
+def test_internal_callers_method_match_skipped_for_external_target():
+    """Method-match over-inclusive is only meaningful for internal
+    targets (``the project's foo``). For ``requests.get`` we don't
+    want every ``self.get()`` showing up."""
+    inv = _inv(_file("src/a.py",
+        "class A:\n"
+        "    def main(self):\n"
+        "        self.get('/')\n"
+    ))
+    r = callers_of(inv, ExternalFunction("requests.get"))
+    assert r.method_match_overinclusive == ()
+
+
+# ---------------------------------------------------------------------------
+# callers_of — uncertain via masking flags
+# ---------------------------------------------------------------------------
+
+
+def test_uncertain_when_file_uses_getattr_and_mentions_target_tail():
+    inv = _inv(_file("src/a.py",
+        "import requests\n"
+        "def hidden():\n"
+        "    f = getattr(requests, 'get')\n"
+        "    f('/')\n"
+    ))
+    r = callers_of(inv, ExternalFunction("requests.get"))
+    # No definitive call (getattr indirection); uncertain because
+    # the file uses getattr AND mentions the tail 'get'.
+    assert r.definitive == ()
+    assert InternalFunction("src/a.py", "hidden", 2) in r.uncertain
+
+
+def test_uncertain_does_not_overlap_definitive():
+    """If a function has a definitive call AND its file uses getattr
+    on the same target, only the definitive entry should appear."""
+    inv = _inv(_file("src/a.py",
+        "import requests\n"
+        "def fetch():\n"
+        "    requests.get('/')\n"
+        "    f = getattr(requests, 'get')\n"
+    ))
+    r = callers_of(inv, ExternalFunction("requests.get"))
+    fetch_fn = InternalFunction("src/a.py", "fetch", 2)
+    assert fetch_fn in r.definitive
+    assert fetch_fn not in r.uncertain
+
+
+# ---------------------------------------------------------------------------
+# callees_of
+# ---------------------------------------------------------------------------
+
+
+def test_callees_internal_and_external_mixed():
+    inv = _inv(_file("src/a.py",
+        "import requests\n"
+        "def helper():\n"
+        "    pass\n"
+        "def main():\n"
+        "    helper()\n"
+        "    requests.get('/')\n"
+    ))
+    src = InternalFunction("src/a.py", "main", 4)
+    r = callees_of(inv, src)
+    assert InternalFunction("src/a.py", "helper", 2) in r.definitive
+    assert ExternalFunction("requests.get") in r.definitive
+    assert r.uncertain == ()
+    assert r.has_method_dispatch is False
+
+
+def test_callees_method_dispatch_marks_uncertain_and_flag():
+    inv = _inv(_file("src/a.py",
+        "class A:\n"
+        "    def main(self):\n"
+        "        self.foo()\n"
+        "        self.bar.baz()\n"
+    ))
+    src = InternalFunction("src/a.py", "main", 2)
+    r = callees_of(inv, src)
+    assert r.has_method_dispatch is True
+    # Both unresolved chains landed in uncertain (string form).
+    assert "self.foo" in r.uncertain
+    assert "self.bar.baz" in r.uncertain
+    # Definitive may be empty — neither call resolved via imports.
+    assert r.definitive == ()
+
+
+def test_callees_returns_empty_for_unknown_source():
+    inv = _inv(_file("src/a.py", "def f():\n    pass\n"))
+    bogus = InternalFunction("nope.py", "missing", 1)
+    r = callees_of(inv, bogus)
+    assert r == CalleesResult()
+
+
+# ---------------------------------------------------------------------------
+# Test-file exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_test_file_caller_excluded_by_default():
+    inv = _inv(
+        _file("src/a.py",
+            "def helper():\n"
+            "    pass\n"
+        ),
+        _file("tests/test_a.py",
+            "from src.a import helper\n"
+            "def test_h():\n"
+            "    helper()\n",
+            items=[{"name": "test_h", "kind": "function",
+                    "line_start": 2, "line_end": 3}],
+        ),
+    )
+    target = InternalFunction("src/a.py", "helper", 1)
+    r = callers_of(inv, target)
+    # The test file's `test_h` would be a caller via wildcard, but
+    # the file isn't a true cross-import we can resolve from the
+    # local def. Either way, exclude_test_files=True means the test
+    # file shouldn't contribute.
+    for c in r.definitive + r.uncertain + r.method_match_overinclusive:
+        assert not c.file_path.startswith("tests/"), c
+
+
+def test_test_file_caller_included_when_opt_out():
+    """``exclude_test_files=False`` lets test-file callers through."""
+    inv = _inv(_file("tests/test_x.py",
+        "import requests\n"
+        "def test_get():\n"
+        "    requests.get('/')\n"
+    ))
+    r_excl = callers_of(inv, ExternalFunction("requests.get"))
+    r_incl = callers_of(inv, ExternalFunction("requests.get"),
+                        exclude_test_files=False)
+    assert r_excl.definitive == ()
+    assert r_incl.definitive == (
+        InternalFunction("tests/test_x.py", "test_get", 2),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Caller-resolution edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_module_level_calls_dropped():
+    """Calls outside any function don't have a useful caller node."""
+    inv = _inv(_file("src/a.py",
+        "import requests\n"
+        "requests.get('/')\n"      # module-level call, caller=None
+    ))
+    r = callers_of(inv, ExternalFunction("requests.get"))
+    assert r.definitive == ()
+
+
+def test_same_name_nested_def_picks_innermost_by_line():
+    """When two functions share name in one file (outer + nested
+    redefining), the call's caller-name resolves to the lexically
+    innermost one — the def with greatest line_start ≤ call_line."""
+    src = (
+        "def helper():\n"          # line 1
+        "    def helper():\n"      # line 2 — nested redefinition
+        "        import requests\n"
+        "        requests.get('/')\n"  # line 4 — caller is inner
+        "    return helper\n"
+    )
+    inv = _inv(_file("src/a.py", src))
+    r = callers_of(inv, ExternalFunction("requests.get"))
+    # The inner helper (line 2) should be the caller.
+    callers = r.definitive
+    assert any(c.line == 2 for c in callers)
+
+
+# ---------------------------------------------------------------------------
+# Memoisation
+# ---------------------------------------------------------------------------
+
+
+def test_index_memoised_across_queries():
+    """Two queries against the same inventory dict should not rebuild
+    the index. We verify by mocking the build pass and checking
+    invocation count."""
+    from core.inventory import reachability as r
+
+    inv = _inv(_file("src/a.py",
+        "import requests\n"
+        "def f():\n"
+        "    requests.get('/')\n"
+    ))
+
+    # Drop any cached entry for this exact inventory id.
+    r._INDEX_CACHE.pop(id(inv), None)
+
+    build_calls = {"n": 0}
+    real_build = r._get_or_build_index
+
+    def _spy(inv_arg, *, exclude_test_files):
+        # Detect a "miss" by checking the cache before delegating.
+        if id(inv_arg) not in r._INDEX_CACHE:
+            build_calls["n"] += 1
+        return real_build(inv_arg, exclude_test_files=exclude_test_files)
+
+    r._get_or_build_index = _spy        # type: ignore[assignment]
+    try:
+        callers_of(inv, ExternalFunction("requests.get"))
+        callers_of(inv, ExternalFunction("requests.get"))
+        callers_of(inv, ExternalFunction("requests.get"))
+    finally:
+        r._get_or_build_index = real_build  # type: ignore[assignment]
+
+    assert build_calls["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# CallersResult.all_callers convenience
+# ---------------------------------------------------------------------------
+
+
+def test_all_callers_dedups_and_orders():
+    """Each caller should appear at most once across all groups in the
+    union view, in (definitive, uncertain, method_match) priority."""
+    a = InternalFunction("src/a.py", "fn", 1)
+    b = InternalFunction("src/b.py", "fn", 1)
+    c = InternalFunction("src/c.py", "fn", 1)
+    res = CallersResult(
+        definitive=(a,),
+        uncertain=(a, b),
+        method_match_overinclusive=(c,),
+    )
+    assert res.all_callers == (a, b, c)
+
+
+# ---------------------------------------------------------------------------
+# FunctionId rendering
+# ---------------------------------------------------------------------------
+
+
+def test_internal_function_str_renders_path_name_line():
+    fn = InternalFunction("src/auth.py", "verify_token", 42)
+    assert str(fn) == "src/auth.py:verify_token@42"
+
+
+def test_external_function_str_is_qualified_name():
+    fn = ExternalFunction("requests.utils.extract_zipped_paths")
+    assert str(fn) == "requests.utils.extract_zipped_paths"
+
+
+def test_internal_functions_with_same_identity_are_equal():
+    """Frozen dataclass equality + hashable for set/dict use."""
+    a = InternalFunction("src/x.py", "f", 1)
+    b = InternalFunction("src/x.py", "f", 1)
+    assert a == b
+    assert hash(a) == hash(b)
+    assert {a, b} == {a}
+
+
+def test_internal_function_line_disambiguates():
+    a = InternalFunction("src/x.py", "f", 1)
+    b = InternalFunction("src/x.py", "f", 5)
+    assert a != b
+    assert {a, b} != {a}
+
+
+# ---------------------------------------------------------------------------
+# Cross-package import canonicalisation
+# ---------------------------------------------------------------------------
+
+
+def test_cross_package_import_call_resolves_to_internal():
+    """``from pkg.mod import fn; fn()`` should land in
+    ``callers_of(InternalFunction(pkg/mod.py, fn, ...))`` —
+    not just under ``ExternalFunction("pkg.mod.fn")``.
+
+    Pre-fix the substrate kept those as separate graph nodes, so a
+    consumer holding the InternalFunction def saw 0 callers despite
+    the function being demonstrably called from another file."""
+    inv = _inv(
+        _file("pkg/helpers.py",
+            "def fn():\n"
+            "    pass\n"
+        ),
+        _file("app.py",
+            "from pkg.helpers import fn\n"
+            "def main():\n"
+            "    fn()\n"
+        ),
+    )
+    target = InternalFunction("pkg/helpers.py", "fn", 1)
+    r = callers_of(inv, target)
+    assert r.definitive == (InternalFunction("app.py", "main", 2),)
+
+
+def test_external_form_returns_same_callers_when_aliased():
+    """Querying by the External qualified name should produce the
+    same answer as querying by the InternalFunction def — they're
+    the same physical function."""
+    inv = _inv(
+        _file("pkg/helpers.py",
+            "def fn():\n"
+            "    pass\n"
+        ),
+        _file("app.py",
+            "from pkg.helpers import fn\n"
+            "def main():\n"
+            "    fn()\n"
+        ),
+    )
+    via_internal = callers_of(inv, InternalFunction("pkg/helpers.py", "fn", 1))
+    via_external = callers_of(inv, ExternalFunction("pkg.helpers.fn"))
+    assert via_internal == via_external
+
+
+def test_attribute_call_to_project_internal_canonicalises():
+    """``import pkg.helpers; pkg.helpers.fn()`` (attribute chain
+    rather than ``from`` import) should also canonicalise."""
+    inv = _inv(
+        _file("pkg/helpers.py",
+            "def fn():\n"
+            "    pass\n"
+        ),
+        _file("app.py",
+            "import pkg.helpers\n"
+            "def main():\n"
+            "    pkg.helpers.fn()\n"
+        ),
+    )
+    target = InternalFunction("pkg/helpers.py", "fn", 1)
+    r = callers_of(inv, target)
+    assert r.definitive == (InternalFunction("app.py", "main", 2),)
+
+
+def test_init_py_module_resolves_to_package_dotted_name():
+    """``pkg/__init__.py`` corresponds to module ``pkg``, not
+    ``pkg.__init__``. The candidate-name heuristic must strip
+    ``__init__``."""
+    inv = _inv(
+        _file("pkg/__init__.py",
+            "def fn():\n"
+            "    pass\n"
+        ),
+        _file("app.py",
+            "from pkg import fn\n"
+            "def main():\n"
+            "    fn()\n"
+        ),
+    )
+    target = InternalFunction("pkg/__init__.py", "fn", 1)
+    r = callers_of(inv, target)
+    assert r.definitive == (InternalFunction("app.py", "main", 2),)
+
+
+def test_src_layout_alias():
+    """``src/mypkg/foo.py`` is imported as ``mypkg.foo``, not
+    ``src.mypkg.foo`` — the candidate-name helper handles the
+    standard src-layout."""
+    inv = _inv(
+        _file("src/mypkg/foo.py",
+            "def fn():\n"
+            "    pass\n"
+        ),
+        _file("app.py",
+            "from mypkg.foo import fn\n"
+            "def main():\n"
+            "    fn()\n"
+        ),
+    )
+    target = InternalFunction("src/mypkg/foo.py", "fn", 1)
+    r = callers_of(inv, target)
+    assert r.definitive == (InternalFunction("app.py", "main", 2),)
+
+
+def test_external_qualified_name_not_a_project_alias_unchanged():
+    """``requests.get`` doesn't resolve to anything project-internal;
+    callers_of should behave exactly like before for that case."""
+    inv = _inv(_file("src/a.py",
+        "import requests\n"
+        "def fetch():\n"
+        "    requests.get('/')\n"
+    ))
+    r = callers_of(inv, ExternalFunction("requests.get"))
+    assert r.definitive == (InternalFunction("src/a.py", "fetch", 2),)
+
+
+# ---------------------------------------------------------------------------
+# Cache safety: id() reuse guard + LRU eviction
+# ---------------------------------------------------------------------------
+
+
+def test_cache_identity_check_rejects_collision():
+    """Even if id(new_inv) collides with a stale cached id, the
+    identity check rejects the stale entry and rebuilds. We force
+    the collision deterministically by hand-poking the cache."""
+    from core.inventory import reachability as r
+
+    inv_a = _inv(_file("src/a.py",
+        "import requests\n"
+        "def f():\n"
+        "    requests.get('/')\n"
+    ))
+    callers_of(inv_a, ExternalFunction("requests.get"))
+    a_id = id(inv_a)
+    cached_a = r._INDEX_CACHE[a_id]
+    # Hand-poke a stale entry under a different id() — same shape
+    # the bug would produce when GC reuses an address.
+    inv_b = _inv(_file("src/b.py",
+        "import flask\n"
+        "def g():\n"
+        "    flask.run('/')\n"
+    ))
+    b_id = id(inv_b)
+    # Replace cache[b_id] with the OTHER inventory's entry — this
+    # simulates the post-eviction id-reuse race.
+    r._INDEX_CACHE[b_id] = cached_a
+    # Query inv_b. The identity check should detect the stale
+    # entry, drop it, and rebuild from inv_b's own data.
+    result = callers_of(inv_b, ExternalFunction("flask.run"))
+    assert result.definitive == (
+        InternalFunction("src/b.py", "g", 2),
+    )
+
+
+def test_cache_lru_eviction():
+    """Once the cache exceeds _CACHE_MAX_ENTRIES, the oldest entry
+    drops out. Bound by insertion order."""
+    from core.inventory import reachability as r
+
+    saved_max = r._CACHE_MAX_ENTRIES
+    r._CACHE_MAX_ENTRIES = 4
+    saved_cache = dict(r._INDEX_CACHE)
+    r._INDEX_CACHE.clear()
+    try:
+        invs = [
+            _inv(_file(f"src/m{i}.py",
+                "import requests\n"
+                f"def f{i}():\n"
+                "    requests.get('/')\n"
+            ))
+            for i in range(6)
+        ]
+        for inv in invs:
+            callers_of(inv, ExternalFunction("requests.get"))
+        # First two inventories should have been evicted; last 4 cached.
+        cached_ids = set(r._INDEX_CACHE.keys())
+        assert id(invs[0]) not in cached_ids
+        assert id(invs[1]) not in cached_ids
+        for inv in invs[2:]:
+            assert id(inv) in cached_ids
+    finally:
+        r._CACHE_MAX_ENTRIES = saved_max
+        r._INDEX_CACHE.clear()
+        r._INDEX_CACHE.update(saved_cache)

--- a/core/inventory/tests/test_reachability_closure.py
+++ b/core/inventory/tests/test_reachability_closure.py
@@ -1,0 +1,611 @@
+"""Tests for the transitive closure primitives in
+:mod:`core.inventory.reachability`:
+``reverse_closure``, ``forward_closure``, ``shortest_path``.
+
+The fixture helpers here intentionally mirror those in
+``test_reachability_adjacency.py`` so the closure tests can share
+the same mental model. Each test pins one design decision:
+
+  * Closure walks DEFINITIVE edges only — uncertain 1-hop edges
+    are visible via ``callers_of`` / ``callees_of`` and are NOT
+    surfaced by closure semantics.
+  * External nodes are TERMINAL in forward closure (recorded but
+    not expanded).
+  * Cycles are handled via the visited set; no infinite loop.
+  * ``max_depth`` bounds the BFS; results may be ``truncated``.
+  * Same External-to-Internal aliasing as the 1-hop primitives.
+  * Stable result ordering across heterogeneous Internal+External
+    node types (Internal first by path+name+line, External after
+    by qualified_name).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from core.inventory.call_graph import extract_call_graph_python
+from core.inventory.reachability import (
+    ClosureResult,
+    ExternalFunction,
+    InternalFunction,
+    forward_closure,
+    reverse_closure,
+    shortest_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers (duplicated from adjacency tests intentionally — keeps
+# the closure suite readable in isolation)
+# ---------------------------------------------------------------------------
+
+
+def _file(path: str, source: str, *,
+          items: List[Dict[str, Any]] = None) -> Dict[str, Any]:
+    cg = extract_call_graph_python(source).to_dict()
+    if items is None:
+        items = _derive_items(source)
+    return {
+        "path": path, "language": "python",
+        "items": items, "call_graph": cg,
+    }
+
+
+def _derive_items(source: str) -> List[Dict[str, Any]]:
+    import ast
+    out: List[Dict[str, Any]] = []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            out.append({
+                "name": node.name, "kind": "function",
+                "line_start": node.lineno,
+                "line_end": getattr(node, "end_lineno", None),
+            })
+    return out
+
+
+def _inv(*files: Dict[str, Any]) -> Dict[str, Any]:
+    return {"files": list(files)}
+
+
+# ---------------------------------------------------------------------------
+# reverse_closure
+# ---------------------------------------------------------------------------
+
+
+def test_reverse_closure_chain():
+    """A → B → target. reverse_closure(target) returns {A, B}."""
+    inv = _inv(_file("src/a.py",
+        "def target():\n"        # line 1
+        "    pass\n"
+        "def b():\n"              # line 3
+        "    target()\n"
+        "def a():\n"              # line 5
+        "    b()\n"
+    ))
+    target = InternalFunction("src/a.py", "target", 1)
+    r = reverse_closure(inv, target)
+    a = InternalFunction("src/a.py", "a", 5)
+    b = InternalFunction("src/a.py", "b", 3)
+    assert set(r.nodes) == {a, b}
+    # Path for `a` should be a → b → target (3 hops).
+    assert r.paths[a] == (a, b, target)
+    assert r.paths[b] == (b, target)
+    assert r.truncated is False
+
+
+def test_reverse_closure_target_excluded_from_result():
+    """The seed target itself is never in the result, even though
+    it's the root of the BFS."""
+    inv = _inv(_file("src/a.py",
+        "def target():\n"
+        "    pass\n"
+        "def caller():\n"
+        "    target()\n"
+    ))
+    target = InternalFunction("src/a.py", "target", 1)
+    r = reverse_closure(inv, target)
+    assert target not in r.nodes
+
+
+def test_reverse_closure_empty_when_unreachable():
+    """A function with no callers anywhere has an empty reverse
+    closure."""
+    inv = _inv(_file("src/a.py",
+        "def lonely():\n"
+        "    pass\n"
+    ))
+    target = InternalFunction("src/a.py", "lonely", 1)
+    r = reverse_closure(inv, target)
+    assert r.nodes == ()
+    assert r.paths == {}
+    assert r.truncated is False
+
+
+def test_reverse_closure_external_target_aliases_to_internal():
+    """``ExternalFunction("pkg.mod.fn")`` aliasing to a project
+    InternalFunction yields the same closure as the Internal form."""
+    inv = _inv(
+        _file("pkg/helpers.py",
+            "def fn():\n"
+            "    pass\n"
+        ),
+        _file("app.py",
+            "from pkg.helpers import fn\n"
+            "def b():\n"
+            "    fn()\n"
+            "def a():\n"
+            "    b()\n"
+        ),
+    )
+    via_int = reverse_closure(
+        inv, InternalFunction("pkg/helpers.py", "fn", 1))
+    via_ext = reverse_closure(
+        inv, ExternalFunction("pkg.helpers.fn"))
+    assert set(via_int.nodes) == set(via_ext.nodes)
+
+
+def test_reverse_closure_external_target_unaliased_returns_callers():
+    """``requests.get`` doesn't alias to anything internal — the
+    closure is just every direct caller (since External nodes have
+    no further reverse-edges to follow)."""
+    inv = _inv(_file("src/a.py",
+        "import requests\n"
+        "def fetch():\n"
+        "    requests.get('/')\n"
+        "def main():\n"
+        "    fetch()\n"
+    ))
+    r = reverse_closure(inv, ExternalFunction("requests.get"))
+    fetch = InternalFunction("src/a.py", "fetch", 2)
+    main = InternalFunction("src/a.py", "main", 4)
+    assert set(r.nodes) == {fetch, main}
+
+
+def test_reverse_closure_handles_cycles():
+    """A → B → A → target (recursion in the call chain). BFS must
+    terminate — the visited set prevents revisiting."""
+    inv = _inv(_file("src/a.py",
+        "def target():\n"          # 1
+        "    pass\n"
+        "def a():\n"                # 3
+        "    b()\n"
+        "def b():\n"                # 5
+        "    a()\n"
+        "    target()\n"
+    ))
+    target = InternalFunction("src/a.py", "target", 1)
+    r = reverse_closure(inv, target)
+    assert {fn.name for fn in r.nodes} == {"a", "b"}
+
+
+def test_reverse_closure_max_depth_bound():
+    """``max_depth`` bounds the BFS. Truncated flag is set."""
+    # Chain: f0 → f1 → f2 → ... → f10 → target
+    src_lines = ["def target():", "    pass"]
+    for i in range(10):
+        src_lines.append(f"def f{i}():")
+        if i == 0:
+            src_lines.append("    target()")
+        else:
+            src_lines.append(f"    f{i - 1}()")
+    inv = _inv(_file("src/a.py", "\n".join(src_lines) + "\n"))
+
+    target = InternalFunction("src/a.py", "target", 1)
+    r3 = reverse_closure(inv, target, max_depth=3)
+    # f0 → target = 1 hop; f1 → f0 → target = 2; f2 = 3; f3 = 4 (out)
+    assert {fn.name for fn in r3.nodes} == {"f0", "f1", "f2"}
+    assert r3.truncated is True
+    # Higher depth picks up the rest.
+    r_full = reverse_closure(inv, target, max_depth=50)
+    assert {fn.name for fn in r_full.nodes} == {f"f{i}" for i in range(10)}
+    assert r_full.truncated is False
+
+
+def test_reverse_closure_excludes_test_file_callers_by_default():
+    """Test-file callers are filtered from the result, but the BFS
+    still walks them (so a chain test → app → target still surfaces
+    `app` but drops `test`)."""
+    inv = _inv(
+        _file("src/a.py",
+            "def target():\n"
+            "    pass\n"
+            "def app():\n"
+            "    target()\n"
+        ),
+        _file("tests/test_a.py",
+            "from src.a import app\n"
+            "def test_app():\n"
+            "    app()\n",
+            items=[{"name": "test_app", "kind": "function",
+                    "line_start": 2, "line_end": 3}],
+        ),
+    )
+    r = reverse_closure(inv, InternalFunction("src/a.py", "target", 1))
+    assert all(not n.file_path.startswith("tests/") for n in r.nodes
+               if isinstance(n, InternalFunction))
+
+
+# ---------------------------------------------------------------------------
+# forward_closure
+# ---------------------------------------------------------------------------
+
+
+def test_forward_closure_chain():
+    """entry → A → B → ext_call. forward_closure({entry}) returns
+    {A, B, ExternalFunction(ext)}."""
+    inv = _inv(_file("src/a.py",
+        "import json\n"
+        "def b():\n"               # line 2
+        "    json.dumps({})\n"
+        "def a():\n"                # line 4
+        "    b()\n"
+        "def entry():\n"            # line 6
+        "    a()\n"
+    ))
+    entry = InternalFunction("src/a.py", "entry", 6)
+    r = forward_closure(inv, [entry])
+    a = InternalFunction("src/a.py", "a", 4)
+    b = InternalFunction("src/a.py", "b", 2)
+    json_dumps = ExternalFunction("json.dumps")
+    assert set(r.nodes) == {a, b, json_dumps}
+
+
+def test_forward_closure_external_terminal():
+    """External nodes are recorded but not expanded — even if the
+    External name happens to coincide with a project-internal name,
+    the substrate doesn't expand foreign code."""
+    inv = _inv(_file("src/a.py",
+        "import requests\n"
+        "def main():\n"
+        "    requests.get('/')\n"
+    ))
+    main = InternalFunction("src/a.py", "main", 2)
+    r = forward_closure(inv, [main])
+    assert ExternalFunction("requests.get") in r.nodes
+    # No phantom expansion — we don't have requests' internals.
+    assert len(r.nodes) == 1
+
+
+def test_forward_closure_multi_entry():
+    """Closure unions across all entries."""
+    inv = _inv(_file("src/a.py",
+        "def a():\n"        # 1
+        "    pass\n"
+        "def b():\n"         # 3
+        "    pass\n"
+        "def entry1():\n"    # 5
+        "    a()\n"
+        "def entry2():\n"    # 7
+        "    b()\n"
+    ))
+    e1 = InternalFunction("src/a.py", "entry1", 5)
+    e2 = InternalFunction("src/a.py", "entry2", 7)
+    r = forward_closure(inv, [e1, e2])
+    a = InternalFunction("src/a.py", "a", 1)
+    b = InternalFunction("src/a.py", "b", 3)
+    assert set(r.nodes) == {a, b}
+
+
+def test_forward_closure_entries_excluded_from_result():
+    inv = _inv(_file("src/a.py",
+        "def helper():\n"
+        "    pass\n"
+        "def entry():\n"
+        "    helper()\n"
+    ))
+    entry = InternalFunction("src/a.py", "entry", 3)
+    r = forward_closure(inv, [entry])
+    assert entry not in r.nodes
+
+
+def test_forward_closure_max_depth():
+    # Chain entry → f0 → f1 → ... → f5
+    src_lines = ["def entry():", "    f0()"]
+    for i in range(5):
+        src_lines.append(f"def f{i}():")
+        if i == 4:
+            src_lines.append("    pass")
+        else:
+            src_lines.append(f"    f{i + 1}()")
+    inv = _inv(_file("src/a.py", "\n".join(src_lines) + "\n"))
+    entry = InternalFunction("src/a.py", "entry", 1)
+    r = forward_closure(inv, [entry], max_depth=2)
+    # entry has depth 0; f0 depth 1; f1 depth 2; f2 NOT visited (would
+    # be depth 3 — past max_depth).
+    assert {fn.name for fn in r.nodes if isinstance(fn, InternalFunction)} \
+        == {"f0", "f1"}
+    assert r.truncated is True
+
+
+def test_forward_closure_handles_cycles():
+    inv = _inv(_file("src/a.py",
+        "def a():\n"
+        "    b()\n"
+        "def b():\n"
+        "    a()\n"
+        "def entry():\n"
+        "    a()\n"
+    ))
+    entry = InternalFunction("src/a.py", "entry", 5)
+    r = forward_closure(inv, [entry])
+    # Should terminate. Both a + b in result.
+    names = {fn.name for fn in r.nodes if isinstance(fn, InternalFunction)}
+    assert names == {"a", "b"}
+
+
+def test_forward_closure_empty_entries():
+    inv = _inv(_file("src/a.py", "def f():\n    pass\n"))
+    r = forward_closure(inv, [])
+    assert r == ClosureResult()
+
+
+# ---------------------------------------------------------------------------
+# shortest_path
+# ---------------------------------------------------------------------------
+
+
+def test_shortest_path_simple():
+    inv = _inv(_file("src/a.py",
+        "def target():\n"
+        "    pass\n"
+        "def a():\n"
+        "    target()\n"
+    ))
+    a = InternalFunction("src/a.py", "a", 3)
+    target = InternalFunction("src/a.py", "target", 1)
+    p = shortest_path(inv, a, target)
+    assert p == (a, target)
+
+
+def test_shortest_path_picks_shorter_chain():
+    """When two chains exist, the shorter one wins."""
+    inv = _inv(_file("src/a.py",
+        "def target():\n"          # 1
+        "    pass\n"
+        "def short():\n"           # 3 — direct
+        "    target()\n"
+        "def long():\n"            # 5 — indirect
+        "    short()\n"
+        "def entry():\n"           # 7
+        "    target()\n"           # direct, 1 hop
+        "    long()\n"             # also reaches via 3 hops
+    ))
+    entry = InternalFunction("src/a.py", "entry", 7)
+    target = InternalFunction("src/a.py", "target", 1)
+    p = shortest_path(inv, entry, target)
+    assert p == (entry, target)
+
+
+def test_shortest_path_returns_none_when_unreachable():
+    inv = _inv(_file("src/a.py",
+        "def isolated():\n"
+        "    pass\n"
+        "def standalone():\n"
+        "    pass\n"
+    ))
+    src = InternalFunction("src/a.py", "standalone", 3)
+    dst = InternalFunction("src/a.py", "isolated", 1)
+    assert shortest_path(inv, src, dst) is None
+
+
+def test_shortest_path_source_equals_target():
+    inv = _inv(_file("src/a.py", "def f():\n    pass\n"))
+    f = InternalFunction("src/a.py", "f", 1)
+    assert shortest_path(inv, f, f) == (f,)
+
+
+def test_shortest_path_max_depth_bound():
+    """Long chain truncated by max_depth → returns None."""
+    src_lines = ["def f0():", "    f1()"]
+    for i in range(1, 5):
+        src_lines.append(f"def f{i}():")
+        if i == 4:
+            src_lines.append("    pass")
+        else:
+            src_lines.append(f"    f{i + 1}()")
+    inv = _inv(_file("src/a.py", "\n".join(src_lines) + "\n"))
+    src = InternalFunction("src/a.py", "f0", 1)
+    dst = InternalFunction("src/a.py", "f4", 9)
+    assert shortest_path(inv, src, dst, max_depth=2) is None
+    p = shortest_path(inv, src, dst, max_depth=10)
+    assert p is not None and len(p) == 5
+
+
+def test_shortest_path_to_external_target():
+    inv = _inv(_file("src/a.py",
+        "import requests\n"
+        "def fetch():\n"
+        "    requests.get('/')\n"
+    ))
+    fetch = InternalFunction("src/a.py", "fetch", 2)
+    p = shortest_path(inv, fetch, ExternalFunction("requests.get"))
+    assert p == (fetch, ExternalFunction("requests.get"))
+
+
+def test_shortest_path_external_target_aliases_to_internal():
+    """When an external qualified name aliases to a project-internal
+    function, shortest_path follows the alias — same semantics as
+    callers_of."""
+    inv = _inv(
+        _file("pkg/helpers.py",
+            "def fn():\n"
+            "    pass\n"
+        ),
+        _file("app.py",
+            "from pkg.helpers import fn\n"
+            "def main():\n"
+            "    fn()\n"
+        ),
+    )
+    main = InternalFunction("app.py", "main", 2)
+    p = shortest_path(inv, main, ExternalFunction("pkg.helpers.fn"))
+    expected = InternalFunction("pkg/helpers.py", "fn", 1)
+    assert p == (main, expected)
+
+
+def test_shortest_path_exclude_test_files_filters_intermediates():
+    """When ``exclude_test_files=True``, paths whose intermediate
+    hops cross test-file functions are rejected; the BFS continues
+    looking for a non-test path."""
+    inv = _inv(
+        _file("src/a.py",
+            "def target():\n"          # 1
+            "    pass\n"
+            "def app():\n"              # 3
+            "    target()\n"
+        ),
+        _file("tests/helpers.py",
+            "from src.a import target\n"
+            "def via_test():\n"
+            "    target()\n",
+            items=[{"name": "via_test", "kind": "function",
+                    "line_start": 2, "line_end": 3}],
+        ),
+        _file("src/entry.py",
+            "from tests.helpers import via_test\n"
+            "from src.a import app\n"
+            "def entry():\n"
+            "    via_test()\n"          # path 1: entry → via_test → target
+            "    app()\n"                # path 2: entry → app → target
+        ),
+    )
+    entry = InternalFunction("src/entry.py", "entry", 3)
+    target = InternalFunction("src/a.py", "target", 1)
+    # Without filter: BFS picks up the test-helper path (3 hops same
+    # length as app path; insertion order may vary, but BOTH are
+    # acceptable answers).
+    p_default = shortest_path(inv, entry, target)
+    assert p_default is not None
+    # With filter: must pick the non-test chain.
+    p_filtered = shortest_path(inv, entry, target, exclude_test_files=True)
+    assert p_filtered is not None
+    assert all(
+        not (isinstance(s, InternalFunction)
+             and s.file_path.startswith("tests/"))
+        for s in p_filtered[1:-1]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Path validity invariant
+# ---------------------------------------------------------------------------
+
+
+def test_closure_paths_are_valid_edges():
+    """Every adjacent pair in a closure path must correspond to an
+    actual call edge in the index."""
+    from core.inventory.reachability import (
+        _get_or_build_index, callers_of, callees_of,
+    )
+    inv = _inv(_file("src/a.py",
+        "import json\n"
+        "def leaf():\n"
+        "    json.dumps({})\n"
+        "def mid():\n"
+        "    leaf()\n"
+        "def entry():\n"
+        "    mid()\n"
+    ))
+
+    entry = InternalFunction("src/a.py", "entry", 5)
+    fc = forward_closure(inv, [entry])
+    for node, path in fc.paths.items():
+        assert path[0] == entry
+        assert path[-1] == node
+        for i in range(len(path) - 1):
+            src, dst = path[i], path[i + 1]
+            assert isinstance(src, InternalFunction), \
+                f"source step in path is External: {src}"
+            cees = callees_of(inv, src).definitive
+            assert dst in cees, \
+                f"step {src} → {dst} not in source's callees: {cees}"
+
+
+# ---------------------------------------------------------------------------
+# ClosureResult shape
+# ---------------------------------------------------------------------------
+
+
+def test_closure_result_default_is_empty():
+    r = ClosureResult()
+    assert r.nodes == ()
+    assert r.paths == {}
+    assert r.truncated is False
+
+
+# ---------------------------------------------------------------------------
+# Test-file traversal semantics: closures must NOT walk through test
+# functions when exclude_test_files=True. Otherwise a non-test function
+# reachable only via a test-file caller ends up in the closure with a
+# path that crosses test code — surprising and inconsistent with
+# shortest_path.
+# ---------------------------------------------------------------------------
+
+
+def test_reverse_closure_does_not_walk_through_test_files():
+    """target is called by a test helper, which is itself called by
+    a non-test function. With exclude_test_files=True, the non-test
+    function should NOT appear in the closure — its only path
+    crosses a test file, and we don't treat that as reachability."""
+    inv = _inv(
+        _file("src/a.py",
+            "def target():\n"
+            "    pass\n"
+        ),
+        _file("tests/helpers.py",
+            "from src.a import target\n"
+            "def via_test():\n"
+            "    target()\n",
+            items=[{"name": "via_test", "kind": "function",
+                    "line_start": 2, "line_end": 3}],
+        ),
+        _file("src/upstream.py",
+            "from tests.helpers import via_test\n"
+            "def upstream():\n"
+            "    via_test()\n"
+        ),
+    )
+    target = InternalFunction("src/a.py", "target", 1)
+    r = reverse_closure(inv, target)
+    upstream = InternalFunction("src/upstream.py", "upstream", 2)
+    # via_test is a test function — filtered.
+    # upstream's only path to target crosses via_test — also filtered.
+    assert upstream not in r.nodes
+
+
+def test_forward_closure_does_not_walk_through_test_files():
+    """Symmetric: entry → test_helper → real_target should NOT put
+    real_target in the closure when exclude_test_files=True."""
+    inv = _inv(
+        _file("src/real.py",
+            "def real_target():\n"
+            "    pass\n"
+        ),
+        _file("tests/helpers.py",
+            "from src.real import real_target\n"
+            "def test_helper():\n"
+            "    real_target()\n",
+            items=[{"name": "test_helper", "kind": "function",
+                    "line_start": 2, "line_end": 3}],
+        ),
+        _file("src/entry.py",
+            "from tests.helpers import test_helper\n"
+            "def entry():\n"
+            "    test_helper()\n"
+        ),
+    )
+    entry = InternalFunction("src/entry.py", "entry", 2)
+    r = forward_closure(inv, [entry])
+    # test_helper filtered as test file.
+    # real_target's only path crosses test_helper — also filtered.
+    assert all(
+        not (isinstance(n, InternalFunction) and n.name == "real_target")
+        for n in r.nodes
+    )

--- a/core/inventory/tests/test_reachability_closure.py
+++ b/core/inventory/tests/test_reachability_closure.py
@@ -30,6 +30,7 @@ from core.inventory.reachability import (
     ClosureResult,
     ExternalFunction,
     InternalFunction,
+    all_paths,
     forward_closure,
     reverse_closure,
     shortest_path,
@@ -609,3 +610,202 @@ def test_forward_closure_does_not_walk_through_test_files():
         not (isinstance(n, InternalFunction) and n.name == "real_target")
         for n in r.nodes
     )
+
+
+# ---------------------------------------------------------------------------
+# all_paths — k-shortest simple paths (no node repeats per chain).
+# Companion to shortest_path when consumers want evidence diversity.
+# ---------------------------------------------------------------------------
+
+
+def test_all_paths_single_chain():
+    inv = _inv(_file("src/a.py",
+        "def target():\n"
+        "    pass\n"
+        "def b():\n"
+        "    target()\n"
+        "def a():\n"
+        "    b()\n"
+    ))
+    a = InternalFunction("src/a.py", "a", 5)
+    target = InternalFunction("src/a.py", "target", 1)
+    paths = all_paths(inv, a, target)
+    assert len(paths) == 1
+    assert paths[0] == (a, InternalFunction("src/a.py", "b", 3), target)
+
+
+def test_all_paths_finds_multiple():
+    """entry has two paths to target: direct and via mid."""
+    inv = _inv(_file("src/a.py",
+        "def target():\n"
+        "    pass\n"
+        "def mid():\n"
+        "    target()\n"
+        "def entry():\n"
+        "    target()\n"
+        "    mid()\n"
+    ))
+    entry = InternalFunction("src/a.py", "entry", 5)
+    target = InternalFunction("src/a.py", "target", 1)
+    paths = all_paths(inv, entry, target)
+    assert len(paths) == 2
+    # Sorted by length: direct first.
+    assert paths[0] == (entry, target)
+    assert paths[1] == (entry, InternalFunction("src/a.py", "mid", 3),
+                        target)
+
+
+def test_all_paths_handles_cycles_no_repeated_node():
+    """A cycle shouldn't cause infinite recursion or duplicate paths.
+    Simple-path constraint: no node repeats in a single chain."""
+    inv = _inv(_file("src/a.py",
+        "def target():\n"
+        "    pass\n"
+        "def a():\n"
+        "    b()\n"
+        "    target()\n"
+        "def b():\n"
+        "    a()\n"
+    ))
+    a = InternalFunction("src/a.py", "a", 3)
+    target = InternalFunction("src/a.py", "target", 1)
+    paths = all_paths(inv, a, target)
+    assert any(p == (a, target) for p in paths)
+    for p in paths:
+        assert len(set(p)) == len(p), p
+
+
+def test_all_paths_max_paths_bound():
+    """Many distinct paths exist; max_paths caps the result."""
+    src_lines = ["def target():", "    pass"]
+    for n in "abcde":
+        src_lines.append(f"def {n}():")
+        src_lines.append("    target()")
+    src_lines.append("def entry():")
+    for n in "abcde":
+        src_lines.append(f"    {n}()")
+    src_lines.append("    target()")
+    inv = _inv(_file("src/a.py", "\n".join(src_lines) + "\n"))
+    entry = next(InternalFunction("src/a.py", "entry", item["line_start"])
+                 for f in inv["files"]
+                 for item in f.get("items", [])
+                 if item.get("name") == "entry")
+    target = InternalFunction("src/a.py", "target", 1)
+    all_p = all_paths(inv, entry, target, max_paths=10)
+    assert len(all_p) == 6     # direct + 5 via single intermediate
+    capped = all_paths(inv, entry, target, max_paths=2)
+    assert len(capped) == 2
+
+
+def test_all_paths_max_depth_bound():
+    src_lines = ["def f0():", "    f1()"]
+    for i in range(1, 5):
+        src_lines.append(f"def f{i}():")
+        if i == 4:
+            src_lines.append("    pass")
+        else:
+            src_lines.append(f"    f{i + 1}()")
+    inv = _inv(_file("src/a.py", "\n".join(src_lines) + "\n"))
+    src = InternalFunction("src/a.py", "f0", 1)
+    dst = InternalFunction("src/a.py", "f4", 9)
+    deep = all_paths(inv, src, dst, max_depth=10)
+    assert len(deep) == 1
+    shallow = all_paths(inv, src, dst, max_depth=2)
+    assert shallow == ()
+
+
+def test_all_paths_unreachable_returns_empty():
+    inv = _inv(_file("src/a.py",
+        "def isolated():\n"
+        "    pass\n"
+        "def standalone():\n"
+        "    pass\n"
+    ))
+    src = InternalFunction("src/a.py", "standalone", 3)
+    dst = InternalFunction("src/a.py", "isolated", 1)
+    assert all_paths(inv, src, dst) == ()
+
+
+def test_all_paths_source_equals_target():
+    inv = _inv(_file("src/a.py", "def f():\n    pass\n"))
+    f = InternalFunction("src/a.py", "f", 1)
+    assert all_paths(inv, f, f) == ((f,),)
+
+
+def test_all_paths_external_target_alias():
+    """External target aliasing to a project InternalFunction yields
+    paths to the InternalFunction (matches shortest_path / closure
+    semantics)."""
+    inv = _inv(
+        _file("pkg/helpers.py",
+            "def fn():\n"
+            "    pass\n"
+        ),
+        _file("app.py",
+            "from pkg.helpers import fn\n"
+            "def main():\n"
+            "    fn()\n"
+        ),
+    )
+    main = InternalFunction("app.py", "main", 2)
+    paths = all_paths(inv, main, ExternalFunction("pkg.helpers.fn"))
+    expected = InternalFunction("pkg/helpers.py", "fn", 1)
+    assert paths == ((main, expected),)
+
+
+def test_all_paths_excludes_test_files_when_requested():
+    inv = _inv(
+        _file("src/a.py",
+            "def target():\n"
+            "    pass\n"
+            "def app():\n"
+            "    target()\n"
+        ),
+        _file("tests/helpers.py",
+            "from src.a import target\n"
+            "def via_test():\n"
+            "    target()\n",
+            items=[{"name": "via_test", "kind": "function",
+                    "line_start": 2, "line_end": 3}],
+        ),
+        _file("src/entry.py",
+            "from tests.helpers import via_test\n"
+            "from src.a import app\n"
+            "def entry():\n"
+            "    via_test()\n"
+            "    app()\n"
+        ),
+    )
+    entry = InternalFunction("src/entry.py", "entry", 3)
+    target = InternalFunction("src/a.py", "target", 1)
+    p_default = all_paths(inv, entry, target)
+    assert len(p_default) == 2
+    p_filtered = all_paths(inv, entry, target, exclude_test_files=True)
+    assert len(p_filtered) == 1
+    assert all(
+        not (isinstance(s, InternalFunction)
+             and s.file_path.startswith("tests/"))
+        for s in p_filtered[0]
+    )
+
+
+def test_all_paths_sorted_by_length():
+    inv = _inv(_file("src/a.py",
+        "def target():\n"
+        "    pass\n"
+        "def m():\n"
+        "    target()\n"
+        "def n():\n"
+        "    target()\n"
+        "def via_m():\n"
+        "    m()\n"
+        "def entry():\n"
+        "    m()\n"
+        "    n()\n"
+        "    via_m()\n"
+    ))
+    entry = InternalFunction("src/a.py", "entry", 9)
+    target = InternalFunction("src/a.py", "target", 1)
+    paths = all_paths(inv, entry, target)
+    lengths = [len(p) for p in paths]
+    assert lengths == sorted(lengths)


### PR DESCRIPTION
Reachability primitives substrate                                                                                                                                                                                
                                                            
Adds a function-level reachability layer to core.inventory: language-agnostic primitives for "who calls X", "what does X delegate to", and "is X transitively reachable from Y". Builds on the per-file call_graph data the inventory already captures; the existing function_called helper is unchanged.                                                                                                                                                                                             
