### PR TITLE
(feat)Annotate

### DIFF
--- a/.claude/commands/annotate.md
+++ b/.claude/commands/annotate.md
@@ -1,0 +1,143 @@
+---
+description: Add, list, edit, or remove per-function annotations attached to source files
+---
+
+# /annotate
+
+Per-function prose annotations stored as markdown mirroring the source tree.
+Annotations capture audit-style notes on individual functions: a manual
+"reviewed clean", a hypothesis-then-validate finding, a CWE label, or any
+free-form prose.
+
+Operator-driven adds default to ``metadata.source=human``, so subsequent
+LLM passes (`/agentic`, `/understand` post-processor) that pass
+``overwrite=respect-manual`` will not silently clobber operator notes.
+
+## Usage
+
+```
+/annotate add <file> <function> [options]
+/annotate ls [options]
+/annotate show <file> <function> [options]
+/annotate edit <file> <function> [options]
+/annotate rm <file> <function> [options]
+/annotate stale [options]
+```
+
+## Subcommands
+
+| Subcommand | What it does |
+|---|---|
+| `add <file> <function>` | Write or update an annotation |
+| `ls` | List annotations (filterable by file/status/source) |
+| `show <file> <function>` | Render one annotation |
+| `edit <file> <function>` | Open the source file's annotation .md in `$EDITOR` |
+| `rm <file> <function>` | Remove an annotation; cleans up empty .md files |
+| `stale` | List annotations whose stored source-line hash no longer matches |
+
+## Add options
+
+| Option | Purpose |
+|---|---|
+| `--status VALUE` | `clean` / `suspicious` / `finding` / `error` |
+| `--cwe CWE-XX` | CWE identifier |
+| `-m, --body TEXT` | Annotation prose |
+| `--body-file PATH` | Read body from file (`-` for stdin) |
+| `--lines N-M` | Source line range; computes `metadata.hash` for staleness |
+| `--target REPO_ROOT` | Where to find source for hash (default: cwd) |
+| `--meta KEY=VALUE` | Extra metadata (repeatable) |
+| `--source VALUE` | Defaults to `human`; set `llm` only for scripted adds |
+| `--overwrite MODE` | `all` (default) or `respect-manual` |
+
+## ls options
+
+| Option | Purpose |
+|---|---|
+| `--file PATH` | Show only annotations for one source file |
+| `--status VALUE` | Filter by `metadata.status` |
+| `--source VALUE` | Filter by `metadata.source` |
+
+## stale options
+
+| Option | Purpose |
+|---|---|
+| `--target REPO_ROOT` | Source-tree root for hash recomputation (default: cwd) |
+
+## Common option
+
+`--base PATH` — annotation base directory. Defaults to the active project's
+`<output_dir>/annotations`. Required if no project is active.
+
+## Examples
+
+```
+# Manual clean review
+/annotate add src/auth.py check_password \
+    --status clean -m "Reviewed: constant-time compare, no taint"
+
+# Manual finding with CWE + staleness hash
+/annotate add src/exec.py run_cmd \
+    --status finding --cwe CWE-78 \
+    --lines 42-58 --target ~/repos/myproj \
+    -m "Confirmed shell injection via subprocess(shell=True)"
+
+# Quick listing
+/annotate ls
+/annotate ls --status finding
+/annotate ls --source human
+
+# Inspect one record
+/annotate show src/auth.py check_password
+
+# Edit (opens .md in $EDITOR)
+/annotate edit src/auth.py check_password
+
+# Remove a record
+/annotate rm src/auth.py old_function
+
+# Find stale annotations after source edits
+/annotate stale --target ~/repos/myproj
+```
+
+## Execution
+
+Run via the Bash tool:
+
+```bash
+libexec/raptor-annotate <subcommand> [args]
+```
+
+For `add` calls invoked through this slash command, the operator's intent
+is implicit — keep the default `--source human`. Do **not** pass
+`--source llm` from `/annotate` unless the operator explicitly asks for
+scripted, non-human-attributable behaviour.
+
+## Output
+
+Output the result verbatim in a fenced code block. Do not summarise — the
+operator wants exact paths, exact metadata values, and exact bodies.
+
+## Base-dir resolution
+
+The CLI resolves the annotation base in this order:
+
+1. Explicit `--base PATH` argument
+2. Active project's `<output_dir>/annotations`
+3. Exit 2 with a hint to set `--base` or activate a project
+
+So when a project is active (`/project use foo`), `/annotate ls` "just
+works" without arguments.
+
+## Conventions
+
+- **`metadata.source=human`** marks a manual entry. LLM-driven callers
+  (e.g. `/agentic`'s annotation emitter) pass `overwrite=respect-manual`
+  so they will skip rather than overwrite a human-source record.
+- **`metadata.hash`**: a short sha256 prefix of the function's source
+  lines, captured at add time when `--lines N-M --target REPO_ROOT` is
+  provided. Used by `/annotate stale` to detect annotations whose source
+  has drifted.
+- **Function names**: top-level functions use bare names (`process`);
+  class methods use dotted form (`MyClass.process`).
+- **Path traversal**: `../etc/passwd` is rejected before any filesystem
+  access, regardless of `--base` value.

--- a/.claude/commands/annotate.md
+++ b/.claude/commands/annotate.md
@@ -56,6 +56,10 @@ LLM passes (`/agentic`, `/understand` post-processor) that pass
 | `--file PATH` | Show only annotations for one source file |
 | `--status VALUE` | Filter by `metadata.status` |
 | `--source VALUE` | Filter by `metadata.source` |
+| `--cwe CWE-XX` | Filter by `metadata.cwe` (exact match) |
+| `--rule-id PATTERN` | Filter by `metadata.rule_id` substring (e.g. `py/`) |
+| `--grep TEXT` | Case-insensitive substring search across body + metadata |
+| `--since 7d` | Annotation file mtime within window (`Nd`/`Nh`/`Nm`/`Ns`/`Nw`) |
 
 ## stale options
 

--- a/.claude/commands/project.md
+++ b/.claude/commands/project.md
@@ -22,6 +22,7 @@ Manage projects — named workspaces that corral analysis runs into one director
 | `status [<name>]` | Show project summary with run history |
 | `coverage [<name>] [--detailed]` | Show tool coverage summary (or per-file table) |
 | `findings [<name>] [--detailed]` | Show merged findings (or per-finding detail) |
+| `annotations [<name>] [--status S] [--source S] [--file PATH]` | List annotations across all runs (project-level overrides run-level) |
 | `none` | Clear the active project |
 | `use [<name>]` | Set active project (no arg = show current, `none` = clear) |
 | `delete <name> [--purge] [--yes]` | Remove project (--purge also deletes output) |

--- a/.claude/commands/project.md
+++ b/.claude/commands/project.md
@@ -22,7 +22,7 @@ Manage projects — named workspaces that corral analysis runs into one director
 | `status [<name>]` | Show project summary with run history |
 | `coverage [<name>] [--detailed]` | Show tool coverage summary (or per-file table) |
 | `findings [<name>] [--detailed]` | Show merged findings (or per-finding detail) |
-| `annotations [<name>] [--status S] [--source S] [--file PATH] [--cwe X] [--rule-id P] [--grep T]` | List annotations across all runs (project-level overrides run-level) |
+| `annotations [<name>] [--status S] [--source S] [--file PATH] [--cwe X] [--rule-id P] [--grep T] [--since 7d]` | List annotations across all runs (project-level overrides run-level) |
 | `annotations-diff <run-a> <run-b>` | Compare annotation state between two runs |
 | `none` | Clear the active project |
 | `use [<name>]` | Set active project (no arg = show current, `none` = clear) |

--- a/.claude/commands/project.md
+++ b/.claude/commands/project.md
@@ -22,7 +22,8 @@ Manage projects — named workspaces that corral analysis runs into one director
 | `status [<name>]` | Show project summary with run history |
 | `coverage [<name>] [--detailed]` | Show tool coverage summary (or per-file table) |
 | `findings [<name>] [--detailed]` | Show merged findings (or per-finding detail) |
-| `annotations [<name>] [--status S] [--source S] [--file PATH]` | List annotations across all runs (project-level overrides run-level) |
+| `annotations [<name>] [--status S] [--source S] [--file PATH] [--cwe X] [--rule-id P] [--grep T]` | List annotations across all runs (project-level overrides run-level) |
+| `annotations-diff <run-a> <run-b>` | Compare annotation state between two runs |
 | `none` | Clear the active project |
 | `use [<name>]` | Set active project (no arg = show current, `none` = clear) |
 | `delete <name> [--purge] [--yes]` | Remove project (--purge also deletes output) |

--- a/.claude/commands/understand.md
+++ b/.claude/commands/understand.md
@@ -88,6 +88,15 @@ libexec/raptor-coverage-summary "$OUTPUT_DIR" --mark-file "$OUTPUT_DIR/reviewed-
 libexec/raptor-render-diagrams "$OUTPUT_DIR"
 ```
 
+**Step 4.5: Synthesise per-function annotations** (for `--map` or `--trace`):
+```bash
+libexec/raptor-understand-annotate "$OUTPUT_DIR"
+```
+Reads `context-map.json` + any `flow-trace-*.json`, attaches per-function
+annotations under `$OUTPUT_DIR/annotations/` for entry points, sinks,
+trust boundaries, unchecked flows, and trace steps. Best-effort — exits
+0 with "nothing to synthesise" when no inputs are present.
+
 **Step 5: Complete the run:**
 ```bash
 libexec/raptor-run-lifecycle complete "$OUTPUT_DIR"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,36 @@ very much a WIP but it could be of use for those wanting to see relationships an
 
 ---
 
+## ANNOTATIONS
+
+The `/annotate` command attaches free-form prose to individual functions, stored as markdown mirroring the source tree. Operators write manual review notes; LLM passes (`/agentic`, `/understand`) emit per-function annotations automatically.
+
+**Storage:** `<base>/<source_path>.md` — one annotation file per source file, with `## function_name` sections, an HTML-comment metadata line, and a free-form prose body. The base directory defaults to the active project's `<output_dir>/annotations`.
+
+**Status enum:** `clean` (reviewed, no concern) / `suspicious` (real bug, not exploitable) / `finding` (exploitable) / `entry_point` / `sink` / `trust_boundary` / `flow_step` / `unchecked_flow` / `error`.
+
+**Source attribution:** Every annotation carries `metadata.source=human` or `metadata.source=llm`. LLM-driven writes pass `overwrite=respect-manual` so a manual operator note is never silently clobbered. Operators using `/annotate add` set `source=human` by default.
+
+**Staleness:** Annotations stamped with `--lines N-M` carry a `metadata.hash` short prefix of the function's source. `/annotate stale` re-computes and lists annotations whose source has drifted.
+
+**Where annotations come from:**
+- `/agentic` — emits one annotation per analysed finding under `<run_output_dir>/annotations/`. Status mapped from the LLM's `is_true_positive` × `is_exploitable`. Body is the LLM's `reasoning`.
+- `/understand --map` / `--trace` — post-processor synthesises annotations for entry points, sinks, trust boundaries, unchecked flows, and per-step trace records.
+- `/annotate add` — operator-driven manual entry.
+
+**Operator workflow:**
+```
+/annotate add src/auth.py check_pw --status clean -m "Constant-time compare, no taint"
+/annotate ls --status finding              # cross-run view in active project
+/annotate show src/auth.py check_pw
+/annotate edit src/auth.py check_pw        # opens .md in $EDITOR
+/annotate stale --target ~/repos/myproj    # source drifted since note written
+```
+
+**Substrate:** `core/annotations/` — atomic write via tempfile + rename, path-traversal defended (rejects `..` segments and absolute paths), function-name and metadata-value validation prevents on-disk format corruption.
+
+---
+
 ## PROGRESSIVE LOADING
 
 **When scan completes:** Load `tiers/analysis-guidance.md` (adversarial thinking)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ VERY IMPORTANT: follow these steps in order.
 /validate - Exploitability validation pipeline (see below)
 /understand - Code understanding: map attack surface, trace flows, hunt variants (see below)
 /diagram - Generate Mermaid visual maps from /understand or /validate output (see below)
+/annotate - Per-function prose annotations (manual or LLM-emitted) attached to source files
 
 **Coverage:** When asked about coverage, run `libexec/raptor-coverage-summary` (no args = active project). Use `--detailed` for per-file table, `--gaps` for unreviewed functions. See `.claude/skills/coverage.md` for mark/unmark and the full API.
 

--- a/core/annotations/__init__.py
+++ b/core/annotations/__init__.py
@@ -1,0 +1,61 @@
+"""Per-function prose annotations stored as markdown mirroring the
+source tree.
+
+An annotation is free-form prose written by the LLM or by a human
+operator, attached to one function in one source file. Annotations
+are markdown files at ``<base>/<source_path>.md`` containing
+``## <function>`` sections, each with an HTML-comment metadata line
+and a prose body.
+
+Initial consumers:
+  * ``/audit`` (Phase A) — captures hypothesis-then-validate evidence
+    per function.
+  * ``/understand`` — exploration notes during code-mapping.
+  * ``/agentic`` — false-positive triage prose, attached to the
+    function the LLM analysed.
+
+Why markdown not JSON:
+  * Operator-readable. A reviewer can ``cat`` an annotation file
+    and understand what was tested without parsing.
+  * Diff-friendly under git. Changes show as text diffs.
+  * Free-form body but structured metadata (frontmatter), so Python
+    can extract status/cwe while leaving prose untouched.
+
+Design constraints:
+  * One annotation file per source file. Avoids per-function file
+    explosion.
+  * Function name as section heading (``## name``). Class-scoped
+    methods qualified as ``ClassName.method_name``.
+  * HTML comment immediately under the heading carries machine-
+    readable metadata (``<!-- meta: status=clean cwe=CWE-78 -->``).
+  * Atomic write via tempfile + rename so concurrent operators
+    can't corrupt mid-write.
+  * Path-traversal defended: any ``..`` segment in a source path
+    raises before touching the filesystem.
+
+Companion design doc: ~/design/audit.md (sections "Annotations
+(markdown)", "Annotation location").
+"""
+
+from __future__ import annotations
+
+from .models import Annotation
+from .storage import (
+    annotation_path,
+    iter_all_annotations,
+    read_annotation,
+    read_file_annotations,
+    remove_annotation,
+    write_annotation,
+)
+
+
+__all__ = [
+    "Annotation",
+    "annotation_path",
+    "iter_all_annotations",
+    "read_annotation",
+    "read_file_annotations",
+    "remove_annotation",
+    "write_annotation",
+]

--- a/core/annotations/__init__.py
+++ b/core/annotations/__init__.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 from .models import Annotation
 from .storage import (
     annotation_path,
+    compute_function_hash,
     iter_all_annotations,
     read_annotation,
     read_file_annotations,
@@ -53,6 +54,7 @@ from .storage import (
 __all__ = [
     "Annotation",
     "annotation_path",
+    "compute_function_hash",
     "iter_all_annotations",
     "read_annotation",
     "read_file_annotations",

--- a/core/annotations/models.py
+++ b/core/annotations/models.py
@@ -1,0 +1,45 @@
+"""Annotation dataclass — the in-memory shape of one per-function
+record. See :mod:`core.annotations` for the on-disk format and
+storage rationale."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class Annotation:
+    """One function's annotation.
+
+    ``file``: source file path. Stored exactly as supplied; callers
+    use repo-relative paths consistently so the resulting markdown
+    layout mirrors the source tree.
+
+    ``function``: function identifier. Top-level functions: bare
+    name (``foo``). Class methods: dotted (``Klass.method``).
+    Operators / mangled names: caller's responsibility to choose
+    a stable string.
+
+    ``body``: free-form markdown prose. May be empty (a clean-status
+    annotation can carry just metadata). The body is preserved
+    verbatim across read-write round-trips.
+
+    ``metadata``: structured key=value pairs from the HTML-comment
+    frontmatter (``<!-- meta: status=clean cwe=CWE-78 -->``).
+    Conventional keys:
+      * ``status``: ``clean`` / ``suspicious`` / ``finding`` /
+        ``error`` (matches the audit coverage status enum)
+      * ``cwe``: e.g. ``CWE-78``
+      * ``hash``: source-line hash captured at annotation time, so
+        callers can detect stale annotations after the source has
+        edited.
+
+    Other keys are accepted; readers tolerate unknown keys to allow
+    consumer-specific extensions without schema migrations.
+    """
+
+    file: str
+    function: str
+    body: str = ""
+    metadata: Mapping[str, str] = field(default_factory=dict)

--- a/core/annotations/models.py
+++ b/core/annotations/models.py
@@ -31,9 +31,16 @@ class Annotation:
       * ``status``: ``clean`` / ``suspicious`` / ``finding`` /
         ``error`` (matches the audit coverage status enum)
       * ``cwe``: e.g. ``CWE-78``
-      * ``hash``: source-line hash captured at annotation time, so
-        callers can detect stale annotations after the source has
-        edited.
+      * ``source``: ``human`` / ``llm`` — who wrote the annotation.
+        ``write_annotation(..., overwrite="respect-manual")`` skips
+        writes whose existing record has ``source=human`` so LLM
+        passes never clobber operator notes. Operator-driven CLI
+        commands set ``source=human``; LLM-driven callers set
+        ``source=llm``.
+      * ``hash``: short sha256 prefix of the function's source lines,
+        captured at annotation time so callers can detect a stale
+        annotation when the source edits later. Use
+        ``core.annotations.compute_function_hash`` to populate.
 
     Other keys are accepted; readers tolerate unknown keys to allow
     consumer-specific extensions without schema migrations.

--- a/core/annotations/storage.py
+++ b/core/annotations/storage.py
@@ -1,0 +1,369 @@
+"""On-disk format + read/write for annotation markdown files.
+
+Layout: ``<base_dir>/<source_path>.md`` mirrors the source tree.
+For source file ``packages/foo/bar.py`` the annotation file is
+``<base_dir>/packages/foo/bar.py.md``.
+
+Format:
+
+    # packages/foo/bar.py
+
+    ## function_a
+    <!-- meta: status=suspicious cwe=CWE-78 -->
+
+    This function takes user input via ``sys.argv`` and passes it
+    to ``os.system`` without sanitisation. Confirmed via:
+      * semgrep rule ``raw-command`` matched at line 42
+
+    ## function_b
+    <!-- meta: status=clean -->
+
+    Pure, no side effects.
+
+The first ``# <source_file>`` heading is a label only — readers
+ignore it. Each ``## <name>`` heading starts a new function
+section; the immediately-following HTML comment carries metadata;
+the rest until the next ``##`` (or EOF) is the prose body.
+
+Atomic write: each save writes to a sibling tempfile and renames
+into place. Concurrent writers may race the rename; last-writer-wins
+is acceptable for the audit / annotation workflow (the operator
+adding manual notes shouldn't conflict with an LLM run).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .models import Annotation
+
+
+# Section heading regex. ``## name`` at start-of-line. Name captures
+# any non-newline up to end-of-line; we don't constrain to identifier
+# chars because operators, templated symbols, and qualified names all
+# need to be expressible.
+_SECTION_HEADING_RE = re.compile(r"^##[ \t]+(.+?)\s*$", re.MULTILINE)
+
+# Metadata HTML comment, anchored to immediately after a heading.
+# Format: ``<!-- meta: key=value key2=value2 -->``. Values may
+# contain spaces if quoted: ``key="value with spaces"``.
+_META_RE = re.compile(
+    r"^<!--\s*meta:\s*(.*?)\s*-->\s*$",
+    re.MULTILINE,
+)
+_META_KV_RE = re.compile(
+    # ``key="quoted value"`` or ``key=bareword`` (no spaces, no quotes)
+    r'(\w[-\w]*)=(?:"([^"]*)"|(\S+))'
+)
+
+
+def _validate_source_path(source_file: str) -> None:
+    """Reject paths that could escape ``base_dir`` via traversal.
+
+    Defense-in-depth: even though callers pass repo-relative paths,
+    a target-supplied identifier (e.g. a finding's ``file_path``
+    attribute pulled from scanner output) could contain ``..`` or
+    an absolute path. Refuse before any filesystem access.
+    """
+    if not source_file:
+        raise ValueError("source_file must be non-empty")
+    # Reject newlines / nulls / other control chars — would let an
+    # attacker forge file headings or break path semantics.
+    if any(c in source_file for c in "\n\r\x00"):
+        raise ValueError(
+            f"source_file may not contain newline / null characters: "
+            f"{source_file!r}"
+        )
+    # Reject absolute paths and ``..`` segments in any component.
+    p = Path(source_file)
+    if p.is_absolute():
+        raise ValueError(f"source_file must be relative: {source_file!r}")
+    parts = p.parts
+    if any(part == ".." for part in parts):
+        raise ValueError(
+            f"source_file may not contain '..' segments: {source_file!r}"
+        )
+
+
+def _validate_function_name(function: str) -> None:
+    """Reject function names that would corrupt the on-disk format.
+
+    Newlines / carriage returns let an attacker inject fake ``##``
+    section headings on subsequent lines (the parser then reads them
+    as separate functions). Reject before any rendering."""
+    if not function:
+        raise ValueError("function name must be non-empty")
+    if any(c in function for c in "\n\r\x00"):
+        raise ValueError(
+            f"function name may not contain newline / null characters: "
+            f"{function!r}"
+        )
+
+
+# Sequences that would corrupt the metadata HTML comment if present
+# in a value. ``-->`` closes the comment early; ``<!--`` would open
+# a nested comment that some parsers handle differently.
+_FORBIDDEN_META_VALUE_SUBSTRINGS = ("-->", "<!--")
+
+
+def _validate_metadata(metadata) -> None:
+    """Reject metadata key/value pairs that would corrupt the
+    HTML-comment frontmatter on disk."""
+    if metadata is None:
+        return
+    for k, v in dict(metadata).items():
+        if not isinstance(k, str) or not k:
+            raise ValueError(f"metadata key must be a non-empty string: {k!r}")
+        if any(c in k for c in "\n\r\x00=\"' "):
+            raise ValueError(
+                f"metadata key may not contain newline / quote / equals / "
+                f"space characters: {k!r}"
+            )
+        v_str = str(v)
+        if any(c in v_str for c in "\n\r\x00"):
+            raise ValueError(
+                f"metadata value for {k!r} may not contain newline / null "
+                f"characters: {v_str!r}"
+            )
+        for forbidden in _FORBIDDEN_META_VALUE_SUBSTRINGS:
+            if forbidden in v_str:
+                raise ValueError(
+                    f"metadata value for {k!r} may not contain {forbidden!r} "
+                    f"(would corrupt the on-disk HTML-comment format): "
+                    f"{v_str!r}"
+                )
+
+
+def annotation_path(base_dir: Path, source_file: str) -> Path:
+    """Resolve the annotation .md path for one source file. Doesn't
+    create the file; callers do."""
+    _validate_source_path(source_file)
+    return base_dir / (source_file + ".md")
+
+
+def _parse_meta(comment_body: str) -> Dict[str, str]:
+    """Parse ``key=value`` pairs from the inside of a meta comment.
+    Quoted values keep spaces; bare values are whitespace-delimited."""
+    out: Dict[str, str] = {}
+    for m in _META_KV_RE.finditer(comment_body):
+        key = m.group(1)
+        value = m.group(2) if m.group(2) is not None else m.group(3)
+        out[key] = value
+    return out
+
+
+def _format_meta(metadata: Dict[str, str]) -> str:
+    """Render ``metadata`` back to the comment's body string. Keys
+    sorted for stable output; values quoted only when they contain
+    spaces or quotes."""
+    parts: List[str] = []
+    for k in sorted(metadata):
+        v = str(metadata[k])
+        if (" " in v) or ('"' in v) or v == "":
+            v_escaped = v.replace('"', '\\"')
+            parts.append(f'{k}="{v_escaped}"')
+        else:
+            parts.append(f"{k}={v}")
+    return " ".join(parts)
+
+
+def _split_sections(text: str) -> List[tuple[str, int, int]]:
+    """Split a markdown body into ``(name, start_offset, end_offset)``
+    triples, one per ``## name`` heading. Offsets are byte positions
+    of the heading line (start) and start of next heading or EOF (end).
+    """
+    headings = list(_SECTION_HEADING_RE.finditer(text))
+    out: List[tuple[str, int, int]] = []
+    for i, m in enumerate(headings):
+        name = m.group(1).strip()
+        start = m.start()
+        end = headings[i + 1].start() if i + 1 < len(headings) else len(text)
+        out.append((name, start, end))
+    return out
+
+
+def _parse_section(
+    text: str, name: str, start: int, end: int,
+) -> tuple[Dict[str, str], str]:
+    """Parse one section: returns (metadata, body)."""
+    section = text[start:end]
+    # Drop the heading line.
+    nl = section.find("\n")
+    if nl == -1:
+        body = ""
+        meta_search = ""
+    else:
+        rest = section[nl + 1:]
+        meta_match = _META_RE.match(rest)
+        if meta_match:
+            meta_search = meta_match.group(1)
+            body = rest[meta_match.end():]
+        else:
+            meta_search = ""
+            body = rest
+    return _parse_meta(meta_search), body.strip("\n")
+
+
+def read_file_annotations(
+    base_dir: Path, source_file: str,
+) -> List[Annotation]:
+    """Read all annotations for one source file. Returns an empty
+    list if no annotation file exists for the source path."""
+    path = annotation_path(base_dir, source_file)
+    if not path.exists():
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        # Corrupt or unreadable annotation file — return empty rather
+        # than propagate. The caller can detect "no annotations" and
+        # decide what to do; crashing the reader on a single bad file
+        # would block iter_all_annotations across the whole tree.
+        return []
+    out: List[Annotation] = []
+    for name, start, end in _split_sections(text):
+        meta, body = _parse_section(text, name, start, end)
+        out.append(Annotation(
+            file=source_file,
+            function=name,
+            body=body,
+            metadata=meta,
+        ))
+    return out
+
+
+def read_annotation(
+    base_dir: Path, source_file: str, function: str,
+) -> Optional[Annotation]:
+    """Read one specific annotation. Returns None if absent."""
+    for ann in read_file_annotations(base_dir, source_file):
+        if ann.function == function:
+            return ann
+    return None
+
+
+def write_annotation(base_dir: Path, ann: Annotation) -> Path:
+    """Write or replace one function's annotation in its source
+    file's annotation .md. Returns the path written.
+
+    Atomic via tempfile + rename — concurrent readers see either the
+    pre-write or post-write content, never a partial rewrite.
+    Existing annotations for OTHER functions in the same file are
+    preserved.
+    """
+    _validate_function_name(ann.function)
+    _validate_metadata(ann.metadata)
+    path = annotation_path(base_dir, ann.file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing = read_file_annotations(base_dir, ann.file)
+    by_name = {a.function: a for a in existing}
+    by_name[ann.function] = ann
+    rendered = _render_file(ann.file, by_name.values())
+
+    # Atomic write — tempfile in same directory so rename is on
+    # the same filesystem (cross-fs rename isn't atomic).
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8",
+        dir=path.parent, prefix=".annotation-", suffix=".tmp",
+        delete=False,
+    )
+    try:
+        tmp.write(rendered)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp.close()
+        os.replace(tmp.name, path)
+    except Exception:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+        raise
+    return path
+
+
+def remove_annotation(
+    base_dir: Path, source_file: str, function: str,
+) -> bool:
+    """Remove one function's annotation. Returns True if a record was
+    actually removed; False if the function had no annotation.
+
+    Removes the file entirely when the last annotation is deleted —
+    keeps the annotation tree from accumulating empty .md files.
+    """
+    existing = read_file_annotations(base_dir, source_file)
+    if not any(a.function == function for a in existing):
+        return False
+    remaining = [a for a in existing if a.function != function]
+    path = annotation_path(base_dir, source_file)
+    if not remaining:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        return True
+    rendered = _render_file(source_file, remaining)
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8",
+        dir=path.parent, prefix=".annotation-", suffix=".tmp",
+        delete=False,
+    )
+    try:
+        tmp.write(rendered)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp.close()
+        os.replace(tmp.name, path)
+    except Exception:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+        raise
+    return True
+
+
+def iter_all_annotations(base_dir: Path) -> Iterator[Annotation]:
+    """Walk the annotation tree, yielding every annotation. Order is
+    filesystem-dependent — callers needing deterministic order
+    should collect into a list and sort."""
+    if not base_dir.exists():
+        return
+    for md in base_dir.rglob("*.md"):
+        # Recover the source path by stripping the .md suffix and
+        # the base_dir prefix.
+        try:
+            rel = md.relative_to(base_dir)
+        except ValueError:
+            continue
+        if rel.suffix != ".md":
+            continue
+        # rel.with_suffix("") drops the final .md, leaving e.g.
+        # "packages/foo/bar.py" for "packages/foo/bar.py.md".
+        source_file = str(rel.with_suffix(""))
+        yield from read_file_annotations(base_dir, source_file)
+
+
+def _render_file(source_file: str, anns) -> str:
+    """Render an annotation file from a sequence of Annotation
+    objects. Sections are sorted by function name for stable output
+    (diff-friendly under git)."""
+    sorted_anns = sorted(anns, key=lambda a: a.function)
+    lines: List[str] = []
+    lines.append(f"# {source_file}")
+    lines.append("")
+    for ann in sorted_anns:
+        lines.append(f"## {ann.function}")
+        if ann.metadata:
+            lines.append(f"<!-- meta: {_format_meta(dict(ann.metadata))} -->")
+        if ann.body:
+            lines.append("")
+            lines.append(ann.body)
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/core/annotations/storage.py
+++ b/core/annotations/storage.py
@@ -38,8 +38,15 @@ import os
 import re
 import tempfile
 from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Dict, List, Optional
+
+try:
+    import fcntl  # POSIX
+    _HAS_FCNTL = True
+except ImportError:  # pragma: no cover — only triggers on Windows
+    _HAS_FCNTL = False
 
 from .models import Annotation
 
@@ -178,6 +185,42 @@ def annotation_path(base_dir: Path, source_file: str) -> Path:
     create the file; callers do."""
     _validate_source_path(source_file)
     return base_dir / (source_file + ".md")
+
+
+@contextmanager
+def _file_lock(path: Path):
+    """Cross-process exclusive lock on the annotation file's read-
+    modify-write window.
+
+    Two operators (or LLM + operator) writing to the same source
+    file's annotations concurrently could otherwise lose data via
+    last-writer-wins on the read-modify-write cycle: both read state
+    A, both write back A+B1 / A+B2 → one of B1/B2 is dropped.
+
+    The lock target is a sibling ``.lock`` file in the parent dir.
+    Using a sibling rather than the .md itself avoids racing on the
+    .md's existence (atomic writes replace it) and avoids leaving
+    a lock fd on a file we just unlinked.
+
+    On non-POSIX (Windows): no-op. The substrate's typical deployment
+    is Linux/macOS dev or CI; Windows operators get last-writer-wins
+    semantics — same as before this commit, no regression.
+    """
+    if not _HAS_FCNTL:
+        yield
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    # Open with O_CREAT — creates if absent, doesn't truncate.
+    fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
 
 
 def _parse_meta(comment_body: str) -> Dict[str, str]:
@@ -327,38 +370,42 @@ def write_annotation(
     _validate_function_name(ann.function)
     _validate_metadata(ann.metadata)
 
-    if overwrite == "respect-manual":
-        prior = read_annotation(base_dir, ann.file, ann.function)
-        if prior is not None and prior.metadata.get("source") == "human":
-            return None
-
     path = annotation_path(base_dir, ann.file)
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    existing = read_file_annotations(base_dir, ann.file)
-    by_name = {a.function: a for a in existing}
-    by_name[ann.function] = ann
-    rendered = _render_file(ann.file, by_name.values())
+    # Cross-process lock around the read-modify-write cycle. Without
+    # it, two concurrent writers could each load state A, then write
+    # A+B1 and A+B2 — one B is dropped. The lock serialises them.
+    with _file_lock(path):
+        if overwrite == "respect-manual":
+            prior = read_annotation(base_dir, ann.file, ann.function)
+            if prior is not None and prior.metadata.get("source") == "human":
+                return None
 
-    # Atomic write — tempfile in same directory so rename is on
-    # the same filesystem (cross-fs rename isn't atomic).
-    tmp = tempfile.NamedTemporaryFile(
-        mode="w", encoding="utf-8",
-        dir=path.parent, prefix=".annotation-", suffix=".tmp",
-        delete=False,
-    )
-    try:
-        tmp.write(rendered)
-        tmp.flush()
-        os.fsync(tmp.fileno())
-        tmp.close()
-        os.replace(tmp.name, path)
-    except Exception:
+        existing = read_file_annotations(base_dir, ann.file)
+        by_name = {a.function: a for a in existing}
+        by_name[ann.function] = ann
+        rendered = _render_file(ann.file, by_name.values())
+
+        # Atomic write — tempfile in same directory so rename is on
+        # the same filesystem (cross-fs rename isn't atomic).
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8",
+            dir=path.parent, prefix=".annotation-", suffix=".tmp",
+            delete=False,
+        )
         try:
-            os.unlink(tmp.name)
-        except OSError:
-            pass
-        raise
+            tmp.write(rendered)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp.close()
+            os.replace(tmp.name, path)
+        except Exception:
+            try:
+                os.unlink(tmp.name)
+            except OSError:
+                pass
+            raise
     return path
 
 
@@ -371,35 +418,36 @@ def remove_annotation(
     Removes the file entirely when the last annotation is deleted —
     keeps the annotation tree from accumulating empty .md files.
     """
-    existing = read_file_annotations(base_dir, source_file)
-    if not any(a.function == function for a in existing):
-        return False
-    remaining = [a for a in existing if a.function != function]
     path = annotation_path(base_dir, source_file)
-    if not remaining:
+    with _file_lock(path):
+        existing = read_file_annotations(base_dir, source_file)
+        if not any(a.function == function for a in existing):
+            return False
+        remaining = [a for a in existing if a.function != function]
+        if not remaining:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            return True
+        rendered = _render_file(source_file, remaining)
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8",
+            dir=path.parent, prefix=".annotation-", suffix=".tmp",
+            delete=False,
+        )
         try:
-            path.unlink()
-        except OSError:
-            pass
-        return True
-    rendered = _render_file(source_file, remaining)
-    tmp = tempfile.NamedTemporaryFile(
-        mode="w", encoding="utf-8",
-        dir=path.parent, prefix=".annotation-", suffix=".tmp",
-        delete=False,
-    )
-    try:
-        tmp.write(rendered)
-        tmp.flush()
-        os.fsync(tmp.fileno())
-        tmp.close()
-        os.replace(tmp.name, path)
-    except Exception:
-        try:
-            os.unlink(tmp.name)
-        except OSError:
-            pass
-        raise
+            tmp.write(rendered)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp.close()
+            os.replace(tmp.name, path)
+        except Exception:
+            try:
+                os.unlink(tmp.name)
+            except OSError:
+                pass
+            raise
     return True
 
 

--- a/core/annotations/storage.py
+++ b/core/annotations/storage.py
@@ -43,6 +43,30 @@ from typing import Dict, List, Optional
 
 from .models import Annotation
 
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+# Current on-disk format version. Bumped when the format changes in
+# a way that older readers can't handle. The marker is emitted as the
+# first line of every annotation file so that future readers can
+# detect format drift and either upgrade-in-place or refuse to read.
+#
+# Versioning policy:
+#   * v1 is the initial format (markdown with ``## function`` sections
+#     and ``<!-- meta: ... -->`` HTML-comment frontmatter).
+#   * Files without the marker are treated as v1 (legacy files written
+#     before this commit; reader is permissive).
+#   * Files with a marker > CURRENT_VERSION trigger a warning but the
+#     reader still tries — better to surface a partial result than to
+#     silently drop data.
+CURRENT_VERSION = 1
+_VERSION_MARKER_RE = re.compile(
+    r"^<!--\s*annotations-version:\s*(\d+)\s*-->\s*$",
+    re.MULTILINE,
+)
+
 
 # Allowed values for ``write_annotation(overwrite=...)``. ``all``
 # matches the original behaviour. ``respect-manual`` refuses to
@@ -235,6 +259,21 @@ def read_file_annotations(
         # decide what to do; crashing the reader on a single bad file
         # would block iter_all_annotations across the whole tree.
         return []
+    # Detect format version. Files without a marker are legacy v1 —
+    # parse permissively. Files with a future version emit a warning
+    # but still try (partial-results-better-than-nothing).
+    version_match = _VERSION_MARKER_RE.search(text)
+    if version_match:
+        try:
+            version = int(version_match.group(1))
+        except ValueError:
+            version = CURRENT_VERSION
+        if version > CURRENT_VERSION:
+            logger.warning(
+                f"annotation file {path} declares version {version} "
+                f"(reader supports up to {CURRENT_VERSION}); "
+                f"attempting to parse anyway"
+            )
     out: List[Annotation] = []
     for name, start, end in _split_sections(text):
         meta, body = _parse_section(text, name, start, end)
@@ -425,6 +464,9 @@ def _render_file(source_file: str, anns) -> str:
     (diff-friendly under git)."""
     sorted_anns = sorted(anns, key=lambda a: a.function)
     lines: List[str] = []
+    # Format version marker — first line. Reader uses this to detect
+    # future format changes and warn rather than silently mis-parse.
+    lines.append(f"<!-- annotations-version: {CURRENT_VERSION} -->")
     lines.append(f"# {source_file}")
     lines.append("")
     for ann in sorted_anns:

--- a/core/annotations/storage.py
+++ b/core/annotations/storage.py
@@ -33,6 +33,7 @@ adding manual notes shouldn't conflict with an LLM run).
 
 from __future__ import annotations
 
+import hashlib
 import os
 import re
 import tempfile
@@ -41,6 +42,15 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from .models import Annotation
+
+
+# Allowed values for ``write_annotation(overwrite=...)``. ``all``
+# matches the original behaviour. ``respect-manual`` refuses to
+# overwrite an existing same-name annotation whose
+# ``metadata.source == "human"`` — used by LLM-driven callers
+# (``/agentic``, ``/understand`` post-processor) so a manual edit
+# is never silently clobbered.
+_OVERWRITE_MODES = ("all", "respect-manual")
 
 
 # Section heading regex. ``## name`` at start-of-line. Name captures
@@ -247,17 +257,42 @@ def read_annotation(
     return None
 
 
-def write_annotation(base_dir: Path, ann: Annotation) -> Path:
+def write_annotation(
+    base_dir: Path, ann: Annotation,
+    *, overwrite: str = "all",
+) -> Optional[Path]:
     """Write or replace one function's annotation in its source
-    file's annotation .md. Returns the path written.
+    file's annotation .md.
+
+    Returns the path written, or ``None`` if the write was refused
+    by the ``overwrite`` policy.
+
+    ``overwrite``:
+      * ``"all"`` (default) — always write, replacing any existing
+        same-name annotation. Existing annotations for OTHER
+        functions in the same file are still preserved.
+      * ``"respect-manual"`` — if an existing same-name annotation
+        carries ``metadata.source == "human"``, skip this write
+        (return ``None``). LLM-driven callers should pass this so
+        operator notes never get clobbered. LLM-over-LLM and
+        write-when-no-prior-record proceed normally.
 
     Atomic via tempfile + rename — concurrent readers see either the
     pre-write or post-write content, never a partial rewrite.
-    Existing annotations for OTHER functions in the same file are
-    preserved.
     """
+    if overwrite not in _OVERWRITE_MODES:
+        raise ValueError(
+            f"invalid overwrite mode {overwrite!r}; "
+            f"expected one of {_OVERWRITE_MODES}"
+        )
     _validate_function_name(ann.function)
     _validate_metadata(ann.metadata)
+
+    if overwrite == "respect-manual":
+        prior = read_annotation(base_dir, ann.file, ann.function)
+        if prior is not None and prior.metadata.get("source") == "human":
+            return None
+
     path = annotation_path(base_dir, ann.file)
     path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -348,6 +383,40 @@ def iter_all_annotations(base_dir: Path) -> Iterator[Annotation]:
         # "packages/foo/bar.py" for "packages/foo/bar.py.md".
         source_file = str(rel.with_suffix(""))
         yield from read_file_annotations(base_dir, source_file)
+
+
+def compute_function_hash(
+    source_path: Path, start_line: int, end_line: int,
+) -> str:
+    """Compute a stable short hash of a function's source lines for
+    staleness detection.
+
+    Returns the first 12 hex chars of sha256 over the slice. 12 chars
+    keeps the metadata line short while still being collision-resistant
+    for the use case (a few thousand annotations per project).
+
+    ``start_line`` and ``end_line`` are 1-indexed and inclusive on
+    both ends. If the file is unreadable or the range is empty,
+    returns ``""`` so callers can detect "no hash available" and
+    skip the staleness check.
+
+    Lines are read with ``errors="replace"`` so a stray non-UTF-8
+    byte in source doesn't crash the hash computation — the hash
+    is for change-detection, not cryptographic integrity.
+    """
+    if start_line <= 0 or end_line < start_line:
+        return ""
+    try:
+        text = source_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    lines = text.splitlines()
+    s = max(0, start_line - 1)
+    e = min(len(lines), end_line)
+    if s >= e:
+        return ""
+    snippet = "\n".join(lines[s:e])
+    return hashlib.sha256(snippet.encode("utf-8")).hexdigest()[:12]
 
 
 def _render_file(source_file: str, anns) -> str:

--- a/core/annotations/tests/test_cli.py
+++ b/core/annotations/tests/test_cli.py
@@ -1,0 +1,355 @@
+"""End-to-end tests for the ``libexec/raptor-annotate`` operator CLI.
+
+Drives the CLI as a subprocess. Each test sets ``_RAPTOR_TRUSTED=1``
+to bypass the trust-marker guard and passes ``--base`` so no project
+state is required.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CLI = REPO_ROOT / "libexec" / "raptor-annotate"
+
+
+def _run(*args, env=None, input_text=None):
+    """Run the CLI with --base resolved by caller in args."""
+    real_env = dict(os.environ)
+    real_env["_RAPTOR_TRUSTED"] = "1"
+    if env:
+        real_env.update(env)
+    result = subprocess.run(
+        [sys.executable, str(CLI), *args],
+        env=real_env,
+        capture_output=True,
+        text=True,
+        input=input_text,
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Trust marker
+# ---------------------------------------------------------------------------
+
+
+class TestTrustMarker:
+    def test_refuses_without_marker(self, tmp_path):
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("_RAPTOR_TRUSTED", "CLAUDECODE")}
+        result = subprocess.run(
+            [sys.executable, str(CLI), "ls", "--base", str(tmp_path)],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2
+        assert "internal dispatch" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# add
+# ---------------------------------------------------------------------------
+
+
+class TestAdd:
+    def test_basic_add(self, tmp_path):
+        r = _run("add", "src/foo.py", "process",
+                 "--base", str(tmp_path),
+                 "--status", "clean",
+                 "-m", "Reviewed, no taint")
+        assert r.returncode == 0, r.stderr
+        assert "wrote" in r.stdout
+        # Verify on disk.
+        ann_file = tmp_path / "src" / "foo.py.md"
+        assert ann_file.exists()
+        text = ann_file.read_text()
+        assert "## process" in text
+        assert "status=clean" in text
+        assert "source=human" in text  # default
+        assert "Reviewed, no taint" in text
+
+    def test_add_with_cwe_and_meta(self, tmp_path):
+        r = _run("add", "src/foo.py", "process",
+                 "--base", str(tmp_path),
+                 "--status", "finding",
+                 "--cwe", "CWE-78",
+                 "--meta", "reviewer=alice",
+                 "--meta", "ticket=BUG-42",
+                 "-m", "command injection via shell=True")
+        assert r.returncode == 0
+        text = (tmp_path / "src" / "foo.py.md").read_text()
+        assert "cwe=CWE-78" in text
+        assert "reviewer=alice" in text
+        assert "ticket=BUG-42" in text
+
+    def test_add_body_from_stdin(self, tmp_path):
+        r = _run("add", "src/foo.py", "process",
+                 "--base", str(tmp_path),
+                 "--status", "clean",
+                 "--body-file", "-",
+                 input_text="body from stdin\nmulti-line content\n")
+        assert r.returncode == 0
+        ann = (tmp_path / "src" / "foo.py.md").read_text()
+        assert "body from stdin" in ann
+        assert "multi-line content" in ann
+
+    def test_add_body_from_file(self, tmp_path):
+        body_file = tmp_path / "_body.txt"
+        body_file.write_text("imported prose\n")
+        r = _run("add", "src/foo.py", "process",
+                 "--base", str(tmp_path),
+                 "--status", "clean",
+                 "--body-file", str(body_file))
+        assert r.returncode == 0
+        assert "imported prose" in (tmp_path / "src" / "foo.py.md").read_text()
+
+    def test_add_with_hash(self, tmp_path):
+        # Set up a mock target repo with a real source file.
+        target = tmp_path / "repo"
+        target.mkdir()
+        (target / "src").mkdir()
+        (target / "src" / "foo.py").write_text(
+            "def process(x):\n    return os.system(x)\n"
+        )
+        ann_base = tmp_path / "anns"
+        r = _run("add", "src/foo.py", "process",
+                 "--base", str(ann_base),
+                 "--status", "finding",
+                 "--lines", "1-2",
+                 "--target", str(target),
+                 "-m", "shell injection")
+        assert r.returncode == 0, r.stderr
+        text = (ann_base / "src" / "foo.py.md").read_text()
+        assert "hash=" in text
+        assert "start_line=1" in text
+        assert "end_line=2" in text
+
+    def test_add_invalid_lines_format(self, tmp_path):
+        r = _run("add", "src/foo.py", "f",
+                 "--base", str(tmp_path),
+                 "--lines", "garbage",
+                 "-m", "x")
+        assert r.returncode == 2
+        assert "lines" in r.stderr
+
+    def test_add_invalid_meta(self, tmp_path):
+        r = _run("add", "src/foo.py", "f",
+                 "--base", str(tmp_path),
+                 "--meta", "no-equals-sign",
+                 "-m", "x")
+        assert r.returncode == 2
+
+    def test_add_respect_manual_skips_human(self, tmp_path):
+        # First write as human (default).
+        _run("add", "src/foo.py", "f",
+             "--base", str(tmp_path),
+             "-m", "manual note")
+        # Now LLM tries respect-manual — should skip.
+        r = _run("add", "src/foo.py", "f",
+                 "--base", str(tmp_path),
+                 "--source", "llm",
+                 "--overwrite", "respect-manual",
+                 "-m", "llm overwrite attempt")
+        # Skip is signalled with rc=1 and "skipped" in stderr.
+        assert r.returncode == 1
+        assert "skipped" in r.stderr
+        # Manual content still there.
+        text = (tmp_path / "src" / "foo.py.md").read_text()
+        assert "manual note" in text
+        assert "llm overwrite" not in text
+
+    def test_add_rejects_invalid_overwrite_mode(self, tmp_path):
+        r = _run("add", "src/foo.py", "f",
+                 "--base", str(tmp_path),
+                 "--overwrite", "bogus",
+                 "-m", "x")
+        # argparse rejects before reaching our validation.
+        assert r.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# ls
+# ---------------------------------------------------------------------------
+
+
+class TestLs:
+    def test_empty_says_so(self, tmp_path):
+        r = _run("ls", "--base", str(tmp_path))
+        assert r.returncode == 0
+        assert "(no annotations)" in r.stdout
+
+    def test_lists_added(self, tmp_path):
+        _run("add", "src/a.py", "f1", "--base", str(tmp_path),
+             "--status", "clean", "-m", "ok")
+        _run("add", "src/b.py", "f2", "--base", str(tmp_path),
+             "--status", "finding", "-m", "bad")
+        r = _run("ls", "--base", str(tmp_path))
+        assert r.returncode == 0
+        assert "src/a.py" in r.stdout
+        assert "src/b.py" in r.stdout
+
+    def test_filter_by_status(self, tmp_path):
+        _run("add", "src/a.py", "f1", "--base", str(tmp_path),
+             "--status", "clean", "-m", "ok")
+        _run("add", "src/b.py", "f2", "--base", str(tmp_path),
+             "--status", "finding", "-m", "bad")
+        r = _run("ls", "--base", str(tmp_path), "--status", "finding")
+        assert "src/b.py" in r.stdout
+        assert "src/a.py" not in r.stdout
+
+    def test_filter_by_source(self, tmp_path):
+        _run("add", "src/a.py", "f1", "--base", str(tmp_path),
+             "--source", "human", "-m", "manual")
+        _run("add", "src/b.py", "f2", "--base", str(tmp_path),
+             "--source", "llm", "-m", "auto")
+        r = _run("ls", "--base", str(tmp_path), "--source", "llm")
+        assert "src/b.py" in r.stdout
+        assert "src/a.py" not in r.stdout
+
+    def test_filter_by_file(self, tmp_path):
+        _run("add", "src/a.py", "f1", "--base", str(tmp_path),
+             "--status", "clean", "-m", "ok")
+        _run("add", "src/b.py", "f2", "--base", str(tmp_path),
+             "--status", "clean", "-m", "ok")
+        r = _run("ls", "--base", str(tmp_path), "--file", "src/a.py")
+        assert "src/a.py" in r.stdout
+        assert "src/b.py" not in r.stdout
+
+
+# ---------------------------------------------------------------------------
+# show
+# ---------------------------------------------------------------------------
+
+
+class TestShow:
+    def test_shows_existing(self, tmp_path):
+        _run("add", "src/a.py", "f1", "--base", str(tmp_path),
+             "--status", "clean", "-m", "the body content")
+        r = _run("show", "src/a.py", "f1", "--base", str(tmp_path))
+        assert r.returncode == 0
+        assert "## f1" in r.stdout
+        assert "status=clean" in r.stdout
+        assert "the body content" in r.stdout
+
+    def test_missing_returns_1(self, tmp_path):
+        r = _run("show", "src/nope.py", "x", "--base", str(tmp_path))
+        assert r.returncode == 1
+        assert "no annotation" in r.stderr
+
+
+# ---------------------------------------------------------------------------
+# rm
+# ---------------------------------------------------------------------------
+
+
+class TestRm:
+    def test_removes_existing(self, tmp_path):
+        _run("add", "src/a.py", "f1", "--base", str(tmp_path),
+             "--status", "clean", "-m", "x")
+        r = _run("rm", "src/a.py", "f1", "--base", str(tmp_path))
+        assert r.returncode == 0
+        assert "removed" in r.stdout
+
+    def test_remove_missing_returns_1(self, tmp_path):
+        r = _run("rm", "src/nope.py", "x", "--base", str(tmp_path))
+        assert r.returncode == 1
+
+
+# ---------------------------------------------------------------------------
+# edit
+# ---------------------------------------------------------------------------
+
+
+class TestEdit:
+    def test_edit_invokes_editor(self, tmp_path):
+        # Use ``true`` as a no-op editor — exits 0 without prompting.
+        env = {"EDITOR": "true"}
+        r = _run("edit", "src/a.py", "f1",
+                 "--base", str(tmp_path), env=env)
+        assert r.returncode == 0
+        # Placeholder file created.
+        assert (tmp_path / "src" / "a.py.md").exists()
+
+    def test_edit_propagates_editor_failure(self, tmp_path):
+        env = {"EDITOR": "false"}
+        r = _run("edit", "src/a.py", "f1",
+                 "--base", str(tmp_path), env=env)
+        assert r.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# stale
+# ---------------------------------------------------------------------------
+
+
+class TestStale:
+    def test_no_annotations(self, tmp_path):
+        r = _run("stale", "--base", str(tmp_path),
+                 "--target", str(tmp_path))
+        assert r.returncode == 0
+        assert "(no stale" in r.stdout
+
+    def test_detects_stale(self, tmp_path):
+        target = tmp_path / "repo"
+        target.mkdir()
+        (target / "src").mkdir()
+        src = target / "src" / "a.py"
+        src.write_text("def f():\n    return 1\n")
+        # Add annotation with hash from current source.
+        ann_base = tmp_path / "anns"
+        _run("add", "src/a.py", "f",
+             "--base", str(ann_base),
+             "--status", "clean",
+             "--lines", "1-2",
+             "--target", str(target),
+             "-m", "ok")
+        # Run stale check now — nothing stale.
+        r = _run("stale", "--base", str(ann_base),
+                 "--target", str(target))
+        assert r.returncode == 0
+        assert "(no stale" in r.stdout
+        # Edit source — hash changes — stale detected.
+        src.write_text("def f():\n    return 99\n")
+        r = _run("stale", "--base", str(ann_base),
+                 "--target", str(target))
+        assert r.returncode == 0
+        assert "src/a.py:f" in r.stdout
+        assert "stored=" in r.stdout
+        assert "current=" in r.stdout
+
+    def test_skips_annotations_without_hash(self, tmp_path):
+        # Add annotation without --lines (no hash captured).
+        _run("add", "src/a.py", "f", "--base", str(tmp_path),
+             "--status", "clean", "-m", "no hash")
+        r = _run("stale", "--base", str(tmp_path),
+                 "--target", str(tmp_path))
+        assert r.returncode == 0
+        assert "(no stale" in r.stdout
+
+
+# ---------------------------------------------------------------------------
+# Base resolution
+# ---------------------------------------------------------------------------
+
+
+class TestBaseResolution:
+    def test_explicit_base_used(self, tmp_path):
+        r = _run("ls", "--base", str(tmp_path))
+        assert r.returncode == 0
+
+    def test_no_base_no_project_errors(self, tmp_path):
+        # Run with no --base and a temp HOME so no real project exists.
+        # We can't easily fake "no active project" in a real repo with
+        # active-state, so instead point PROJECTS_DIR at an empty tmp dir
+        # via env. The real defence is integration-tested in the slash
+        # command harness; here, just ensure the explicit-base path works.
+        # Skip this assertion if a project is active in the dev env.
+        pass

--- a/core/annotations/tests/test_cli.py
+++ b/core/annotations/tests/test_cli.py
@@ -111,6 +111,107 @@ class TestAdd:
         assert r.returncode == 0
         assert "imported prose" in (tmp_path / "src" / "foo.py.md").read_text()
 
+    def test_auto_discovers_bounds_from_checklist_in_base_parent(
+        self, tmp_path,
+    ):
+        """When ``--lines`` is omitted, the CLI looks for a
+        checklist.json next to the base directory's parent."""
+        run_dir = tmp_path / "run"
+        ann_base = run_dir / "annotations"
+        run_dir.mkdir()
+        target = tmp_path / "repo"
+        target.mkdir()
+        (target / "src").mkdir()
+        (target / "src" / "foo.py").write_text(
+            "def f():\n    pass\n"
+        )
+        # Checklist sits next to the base dir's parent (i.e. in run_dir).
+        import json
+        (run_dir / "checklist.json").write_text(json.dumps({
+            "files": [{
+                "path": "src/foo.py",
+                "items": [{"name": "f", "line_start": 1, "line_end": 2}],
+            }],
+        }))
+        r = _run("add", "src/foo.py", "f",
+                 "--base", str(ann_base),
+                 "--status", "clean",
+                 "--target", str(target),
+                 "-m", "auto-discovered")
+        assert r.returncode == 0, r.stderr
+        text = (ann_base / "src" / "foo.py.md").read_text()
+        assert "hash=" in text
+        assert "start_line=1" in text
+        assert "end_line=2" in text
+
+    def test_auto_discovery_skipped_silently_no_checklist(self, tmp_path):
+        """No checklist anywhere → no hash, but the annotation
+        still lands. No warning printed (warnings are reserved for
+        explicit ``--lines`` failures)."""
+        r = _run("add", "src/foo.py", "f",
+                 "--base", str(tmp_path),
+                 "--status", "clean",
+                 "-m", "no hash possible")
+        assert r.returncode == 0
+        assert "warning" not in r.stderr
+        text = (tmp_path / "src" / "foo.py.md").read_text()
+        assert "hash=" not in text
+
+    def test_explicit_checklist_arg(self, tmp_path):
+        run_dir = tmp_path / "out"
+        run_dir.mkdir()
+        ann_base = run_dir / "annotations"
+        target = tmp_path / "repo"
+        target.mkdir()
+        (target / "src").mkdir()
+        (target / "src" / "foo.py").write_text("def f():\n    pass\n")
+        import json
+        ck = tmp_path / "custom-checklist.json"
+        ck.write_text(json.dumps({
+            "files": [{
+                "path": "src/foo.py",
+                "items": [{"name": "f", "line_start": 1, "line_end": 2}],
+            }],
+        }))
+        r = _run("add", "src/foo.py", "f",
+                 "--base", str(ann_base),
+                 "--checklist", str(ck),
+                 "--target", str(target),
+                 "-m", "from custom checklist")
+        assert r.returncode == 0
+        text = (ann_base / "src" / "foo.py.md").read_text()
+        assert "hash=" in text
+
+    def test_explicit_lines_overrides_checklist(self, tmp_path):
+        """If both --lines and --checklist could provide bounds,
+        --lines wins (operator's explicit intent)."""
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        ann_base = run_dir / "annotations"
+        target = tmp_path / "repo"
+        target.mkdir()
+        (target / "src").mkdir()
+        (target / "src" / "foo.py").write_text(
+            "def f():\n    return 1\n\ndef g():\n    return 2\n"
+        )
+        import json
+        (run_dir / "checklist.json").write_text(json.dumps({
+            "files": [{
+                "path": "src/foo.py",
+                "items": [{"name": "f", "line_start": 1, "line_end": 2}],
+            }],
+        }))
+        # Operator explicitly says lines 4-5 (the ``g`` body).
+        r = _run("add", "src/foo.py", "f",
+                 "--base", str(ann_base),
+                 "--lines", "4-5",
+                 "--target", str(target),
+                 "-m", "explicit override")
+        assert r.returncode == 0
+        text = (ann_base / "src" / "foo.py.md").read_text()
+        assert "start_line=4" in text
+        assert "end_line=5" in text
+
     def test_add_with_hash(self, tmp_path):
         # Set up a mock target repo with a real source file.
         target = tmp_path / "repo"

--- a/core/annotations/tests/test_cli.py
+++ b/core/annotations/tests/test_cli.py
@@ -315,6 +315,77 @@ class TestLs:
         assert "src/b.py" in r.stdout
         assert "src/a.py" not in r.stdout
 
+    def test_filter_by_cwe(self, tmp_path):
+        _run("add", "src/a.py", "f1", "--base", str(tmp_path),
+             "--status", "finding", "--cwe", "CWE-78", "-m", "x")
+        _run("add", "src/b.py", "f2", "--base", str(tmp_path),
+             "--status", "finding", "--cwe", "CWE-89", "-m", "x")
+        r = _run("ls", "--base", str(tmp_path), "--cwe", "CWE-78")
+        assert "src/a.py" in r.stdout
+        assert "src/b.py" not in r.stdout
+
+    def test_filter_by_rule_id_substring(self, tmp_path):
+        _run("add", "src/a.py", "f1", "--base", str(tmp_path),
+             "--meta", "rule_id=py/sql-injection", "-m", "x")
+        _run("add", "src/b.py", "f2", "--base", str(tmp_path),
+             "--meta", "rule_id=cpp/buffer-overflow", "-m", "x")
+        # Substring "py/" scopes to Python rules.
+        r = _run("ls", "--base", str(tmp_path), "--rule-id", "py/")
+        assert "src/a.py" in r.stdout
+        assert "src/b.py" not in r.stdout
+
+    def test_grep_body(self, tmp_path):
+        _run("add", "src/a.py", "f1", "--base", str(tmp_path),
+             "-m", "uses subprocess.call shell=True")
+        _run("add", "src/b.py", "f2", "--base", str(tmp_path),
+             "-m", "constant-time compare")
+        r = _run("ls", "--base", str(tmp_path), "--grep", "subprocess")
+        assert "src/a.py" in r.stdout
+        assert "src/b.py" not in r.stdout
+
+    def test_grep_case_insensitive(self, tmp_path):
+        _run("add", "src/a.py", "f1", "--base", str(tmp_path),
+             "-m", "Subprocess Call")
+        r = _run("ls", "--base", str(tmp_path), "--grep", "SUBPROCESS")
+        assert "src/a.py" in r.stdout
+
+    def test_grep_metadata_value(self, tmp_path):
+        _run("add", "src/a.py", "f1", "--base", str(tmp_path),
+             "--meta", "ticket=BUG-42", "-m", "x")
+        _run("add", "src/b.py", "f2", "--base", str(tmp_path),
+             "-m", "x")
+        r = _run("ls", "--base", str(tmp_path), "--grep", "BUG-42")
+        assert "src/a.py" in r.stdout
+        assert "src/b.py" not in r.stdout
+
+    def test_since_filter_all_recent(self, tmp_path):
+        _run("add", "src/a.py", "f1", "--base", str(tmp_path), "-m", "x")
+        # Just-written annotation falls inside any reasonable window.
+        r = _run("ls", "--base", str(tmp_path), "--since", "1h")
+        assert "src/a.py" in r.stdout
+
+    def test_since_filter_excludes_old(self, tmp_path):
+        import os, time
+        _run("add", "src/a.py", "f1", "--base", str(tmp_path), "-m", "x")
+        # Backdate the annotation file by 30 days.
+        ann_file = tmp_path / "src" / "a.py.md"
+        old_ts = time.time() - (30 * 86400)
+        os.utime(ann_file, (old_ts, old_ts))
+        r = _run("ls", "--base", str(tmp_path), "--since", "7d")
+        assert "src/a.py" not in r.stdout
+
+    def test_since_bad_value_errors(self, tmp_path):
+        _run("add", "src/a.py", "f1", "--base", str(tmp_path), "-m", "x")
+        r = _run("ls", "--base", str(tmp_path), "--since", "garbage")
+        assert r.returncode == 2
+        assert "since" in r.stderr.lower()
+
+    def test_since_supported_units(self, tmp_path):
+        _run("add", "src/a.py", "f1", "--base", str(tmp_path), "-m", "x")
+        for unit in ("60s", "5m", "1h", "1d", "1w"):
+            r = _run("ls", "--base", str(tmp_path), "--since", unit)
+            assert r.returncode == 0, f"{unit}: {r.stderr}"
+
     def test_filter_by_file(self, tmp_path):
         _run("add", "src/a.py", "f1", "--base", str(tmp_path),
              "--status", "clean", "-m", "ok")

--- a/core/annotations/tests/test_command_file.py
+++ b/core/annotations/tests/test_command_file.py
@@ -1,0 +1,117 @@
+"""Lint-style smoke tests for the ``/annotate`` slash command file.
+
+These don't exercise behaviour — they just verify the command file is
+syntactically intact, references the correct libexec script, and
+documents every subcommand the CLI implements. Catches accidental
+deletion / link rot when the CLI evolves.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+COMMAND_FILE = REPO_ROOT / ".claude" / "commands" / "annotate.md"
+CLI = REPO_ROOT / "libexec" / "raptor-annotate"
+CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+
+
+def _command_text():
+    return COMMAND_FILE.read_text(encoding="utf-8")
+
+
+class TestCommandFileExists:
+    def test_command_file_present(self):
+        assert COMMAND_FILE.exists(), (
+            f"slash command file missing: {COMMAND_FILE}"
+        )
+
+    def test_cli_target_exists_and_executable(self):
+        assert CLI.exists(), f"libexec target missing: {CLI}"
+        assert CLI.stat().st_mode & 0o100, (
+            f"libexec target not executable: {CLI}"
+        )
+
+
+class TestFrontMatter:
+    def test_has_frontmatter(self):
+        text = _command_text()
+        # YAML front matter must be the first thing.
+        assert text.startswith("---\n"), (
+            "command file must start with YAML front matter"
+        )
+        # And must close.
+        body_start = text.find("\n---\n", 4)
+        assert body_start > 0, "front matter must be closed with ---"
+
+    def test_has_description(self):
+        text = _command_text()
+        assert "description:" in text.split("\n---\n", 1)[0], (
+            "front matter needs a 'description:' field"
+        )
+
+
+class TestSubcommandsCovered:
+    """Every CLI subcommand should be documented in the slash command
+    file. Otherwise an operator types ``/annotate stale`` and Claude
+    has no idea that's a real subcommand."""
+
+    SUBCOMMANDS = ("add", "ls", "show", "edit", "rm", "stale")
+
+    @pytest.mark.parametrize("sub", SUBCOMMANDS)
+    def test_subcommand_documented(self, sub):
+        text = _command_text()
+        # Look for /annotate <sub> in usage block, or `<sub> ` (with
+        # trailing space or args) in the subcommands table.
+        assert (
+            f"/annotate {sub}" in text
+            or f"`{sub} " in text
+            or f"`{sub}`" in text
+        ), f"subcommand '{sub}' not documented in command file"
+
+
+class TestExecutionTarget:
+    def test_references_libexec_cli(self):
+        text = _command_text()
+        # The command file's Execution section must point Claude at
+        # the right libexec script.
+        assert "libexec/raptor-annotate" in text, (
+            "command file does not reference libexec/raptor-annotate"
+        )
+
+
+class TestClaudeMdEntry:
+    def test_command_listed_in_claude_md(self):
+        """Operators reading CLAUDE.md should see /annotate in the
+        commands list."""
+        text = CLAUDE_MD.read_text(encoding="utf-8")
+        assert "/annotate" in text, (
+            "CLAUDE.md COMMANDS section does not mention /annotate"
+        )
+
+
+class TestKeyConventions:
+    """Spot-check that the design conventions Claude needs to apply
+    are present in the doc — otherwise operators get inconsistent
+    behaviour across sessions."""
+
+    def test_documents_source_human_default(self):
+        text = _command_text()
+        assert "source=human" in text or "`source` " in text or "human" in text, (
+            "command file should document the source=human convention"
+        )
+
+    def test_documents_respect_manual(self):
+        text = _command_text()
+        assert "respect-manual" in text, (
+            "command file should document overwrite=respect-manual"
+        )
+
+    def test_documents_base_resolution_order(self):
+        text = _command_text()
+        # Operators need to know how --base resolves.
+        assert "--base" in text
+        assert "active project" in text.lower()

--- a/core/annotations/tests/test_locking.py
+++ b/core/annotations/tests/test_locking.py
@@ -1,0 +1,103 @@
+"""Tests for cross-process locking on annotation writes.
+
+Without the lock, two concurrent writers can lose each other's
+data via the read-modify-write race: both load state A, both write
+A+B1 / A+B2, one of B1/B2 is dropped. The lock serialises them.
+
+These tests fork real subprocesses (not threads) — fcntl.flock is
+process-level, and POSIX semantics are what we actually rely on.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _writer_proc(base_str: str, file: str, prefix: str, count: int):
+    """Worker: write ``count`` annotations to ``file`` with names
+    ``<prefix>_001`` ... ``<prefix>_NNN``."""
+    sys.path.insert(0, str(REPO_ROOT))
+    from core.annotations import Annotation, write_annotation
+    base = Path(base_str)
+    for i in range(count):
+        write_annotation(base, Annotation(
+            file=file,
+            function=f"{prefix}_{i:03d}",
+            body=f"body for {prefix}_{i:03d}",
+            metadata={"source": "llm", "status": "clean"},
+        ))
+
+
+class TestConcurrentWrites:
+    """Two processes hammer the same file. With locking, all writes
+    survive. Without it, ~half would be lost to the read-modify-write
+    race."""
+
+    def test_two_writers_no_data_loss(self, tmp_path):
+        base = tmp_path / "annotations"
+        # 50 annotations per writer, two writers — 100 total.
+        # Without locking this used to lose roughly half on real systems.
+        per_writer = 50
+        ctx = mp.get_context("fork")
+        p1 = ctx.Process(
+            target=_writer_proc,
+            args=(str(base), "src/concur.py", "alice", per_writer),
+        )
+        p2 = ctx.Process(
+            target=_writer_proc,
+            args=(str(base), "src/concur.py", "bob", per_writer),
+        )
+        p1.start()
+        p2.start()
+        p1.join(timeout=30)
+        p2.join(timeout=30)
+        assert p1.exitcode == 0, "writer 1 crashed"
+        assert p2.exitcode == 0, "writer 2 crashed"
+
+        from core.annotations import read_file_annotations
+        annotations = read_file_annotations(base, "src/concur.py")
+        names = {a.function for a in annotations}
+        # 100 unique names expected. Race-induced losses would mean
+        # we see fewer; the lock guarantees we see all.
+        expected = (
+            {f"alice_{i:03d}" for i in range(per_writer)}
+            | {f"bob_{i:03d}" for i in range(per_writer)}
+        )
+        missing = expected - names
+        assert not missing, (
+            f"{len(missing)} annotations lost to read-modify-write "
+            f"race — locking didn't serialise. Missing: "
+            f"{sorted(list(missing))[:5]}..."
+        )
+
+
+class TestLockFileCleanup:
+    """The .lock sibling file is left in place — this is OK and
+    expected. Pin the behaviour so a future "clean it up" change
+    doesn't introduce a race window between unlock and unlink."""
+
+    def test_lock_file_persists(self, tmp_path):
+        from core.annotations import Annotation, write_annotation
+        write_annotation(tmp_path, Annotation(
+            file="src/foo.py", function="f", body="x",
+        ))
+        # The .md.lock sibling is a normal file we just leave there.
+        # If we tried to unlink it after release, another process
+        # could acquire a lock on a since-deleted file and not see
+        # contention.
+        lock_path = tmp_path / "src" / "foo.py.md.lock"
+        # On POSIX it'll exist; on a hypothetical no-fcntl platform
+        # the test is skipped.
+        from core.annotations.storage import _HAS_FCNTL
+        if _HAS_FCNTL:
+            assert lock_path.exists()
+        else:
+            pytest.skip("fcntl unavailable; locking is a no-op")

--- a/core/annotations/tests/test_overwrite_modes.py
+++ b/core/annotations/tests/test_overwrite_modes.py
@@ -1,0 +1,279 @@
+"""Tests for overwrite-mode policies on ``write_annotation`` and
+the ``compute_function_hash`` staleness helper.
+
+These exercise the substrate features that protect operator-written
+annotations from being clobbered by LLM-driven re-runs:
+
+  * ``overwrite="all"`` (default) — current behaviour, always writes.
+  * ``overwrite="respect-manual"`` — skip if existing record has
+    ``metadata.source == "human"``.
+
+Plus the per-function source-line hash used by ``/annotate stale``:
+  * Stable across identical content, distinct across changed content.
+  * Tolerates missing files and non-UTF-8 bytes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.annotations import (
+    Annotation,
+    compute_function_hash,
+    read_annotation,
+    read_file_annotations,
+    write_annotation,
+)
+
+
+# ---------------------------------------------------------------------------
+# overwrite="all" (default)
+# ---------------------------------------------------------------------------
+
+
+class TestOverwriteAll:
+    def test_default_overwrites_human_source(self, tmp_path):
+        """Default mode does NOT inspect ``source`` — operator updating
+        their own note expects the new content to land."""
+        write_annotation(tmp_path, Annotation(
+            file="x.py", function="f", body="manual note",
+            metadata={"source": "human"},
+        ))
+        path = write_annotation(tmp_path, Annotation(
+            file="x.py", function="f", body="updated",
+            metadata={"source": "human"},
+        ))
+        assert path is not None
+        got = read_annotation(tmp_path, "x.py", "f")
+        assert got.body == "updated"
+
+    def test_default_overwrites_llm_source(self, tmp_path):
+        """LLM-over-LLM also fine in default mode — re-running
+        analysis updates the prose."""
+        write_annotation(tmp_path, Annotation(
+            file="x.py", function="f", body="first run",
+            metadata={"source": "llm"},
+        ))
+        write_annotation(tmp_path, Annotation(
+            file="x.py", function="f", body="second run",
+            metadata={"source": "llm"},
+        ))
+        got = read_annotation(tmp_path, "x.py", "f")
+        assert got.body == "second run"
+
+    def test_default_explicit_value_returns_path(self, tmp_path):
+        path = write_annotation(
+            tmp_path,
+            Annotation(file="x.py", function="f", body="x"),
+            overwrite="all",
+        )
+        assert path is not None
+        assert path.exists()
+
+
+# ---------------------------------------------------------------------------
+# overwrite="respect-manual"
+# ---------------------------------------------------------------------------
+
+
+class TestRespectManual:
+    def test_skips_when_existing_is_human(self, tmp_path):
+        """LLM pass must not clobber a manual annotation."""
+        write_annotation(tmp_path, Annotation(
+            file="x.py", function="f",
+            body="operator wrote this — important context",
+            metadata={"source": "human", "status": "finding"},
+        ))
+        result = write_annotation(
+            tmp_path,
+            Annotation(
+                file="x.py", function="f",
+                body="LLM ran later and tried to overwrite",
+                metadata={"source": "llm", "status": "clean"},
+            ),
+            overwrite="respect-manual",
+        )
+        assert result is None
+        # Manual content is intact.
+        got = read_annotation(tmp_path, "x.py", "f")
+        assert "operator wrote this" in got.body
+        assert got.metadata["status"] == "finding"
+
+    def test_writes_when_existing_is_llm(self, tmp_path):
+        """LLM-over-LLM proceeds — no operator content to protect."""
+        write_annotation(tmp_path, Annotation(
+            file="x.py", function="f", body="prior llm",
+            metadata={"source": "llm"},
+        ))
+        result = write_annotation(
+            tmp_path,
+            Annotation(
+                file="x.py", function="f", body="new llm",
+                metadata={"source": "llm"},
+            ),
+            overwrite="respect-manual",
+        )
+        assert result is not None
+        got = read_annotation(tmp_path, "x.py", "f")
+        assert got.body == "new llm"
+
+    def test_writes_when_no_existing(self, tmp_path):
+        """First-time write proceeds even in respect-manual mode."""
+        result = write_annotation(
+            tmp_path,
+            Annotation(
+                file="x.py", function="brand_new", body="first record",
+                metadata={"source": "llm"},
+            ),
+            overwrite="respect-manual",
+        )
+        assert result is not None
+
+    def test_writes_when_existing_has_no_source_metadata(self, tmp_path):
+        """Legacy annotations without ``source`` metadata aren't
+        protected — they predate the convention. Only an explicit
+        ``source=human`` triggers the skip."""
+        write_annotation(tmp_path, Annotation(
+            file="x.py", function="f", body="legacy", metadata={},
+        ))
+        result = write_annotation(
+            tmp_path,
+            Annotation(
+                file="x.py", function="f", body="new content",
+                metadata={"source": "llm"},
+            ),
+            overwrite="respect-manual",
+        )
+        assert result is not None
+        got = read_annotation(tmp_path, "x.py", "f")
+        assert got.body == "new content"
+
+    def test_skip_does_not_affect_siblings(self, tmp_path):
+        """Skipping one section's write must NOT touch other sections
+        in the same file."""
+        write_annotation(tmp_path, Annotation(
+            file="x.py", function="alpha",
+            body="manual alpha",
+            metadata={"source": "human"},
+        ))
+        write_annotation(tmp_path, Annotation(
+            file="x.py", function="beta",
+            body="llm beta",
+            metadata={"source": "llm"},
+        ))
+        # Try to overwrite alpha (should skip) and beta (should write)
+        # in respect-manual mode.
+        skipped = write_annotation(
+            tmp_path,
+            Annotation(
+                file="x.py", function="alpha", body="llm overwrite",
+                metadata={"source": "llm"},
+            ),
+            overwrite="respect-manual",
+        )
+        assert skipped is None
+        wrote = write_annotation(
+            tmp_path,
+            Annotation(
+                file="x.py", function="beta", body="llm beta v2",
+                metadata={"source": "llm"},
+            ),
+            overwrite="respect-manual",
+        )
+        assert wrote is not None
+        # Both annotations still in the file; alpha untouched, beta updated.
+        all_ = read_file_annotations(tmp_path, "x.py")
+        names = {a.function: a for a in all_}
+        assert names["alpha"].body == "manual alpha"
+        assert names["beta"].body == "llm beta v2"
+
+
+# ---------------------------------------------------------------------------
+# Invalid overwrite mode
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidOverwriteMode:
+    def test_rejects_unknown_mode(self, tmp_path):
+        with pytest.raises(ValueError, match="invalid overwrite mode"):
+            write_annotation(
+                tmp_path,
+                Annotation(file="x.py", function="f", body="x"),
+                overwrite="bogus",
+            )
+
+    def test_rejects_empty_string(self, tmp_path):
+        with pytest.raises(ValueError, match="invalid overwrite mode"):
+            write_annotation(
+                tmp_path,
+                Annotation(file="x.py", function="f", body="x"),
+                overwrite="",
+            )
+
+
+# ---------------------------------------------------------------------------
+# compute_function_hash
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFunctionHash:
+    def test_stable_across_calls(self, tmp_path):
+        src = tmp_path / "foo.py"
+        src.write_text("def f():\n    return 1\n\ndef g():\n    return 2\n")
+        h1 = compute_function_hash(src, 1, 2)
+        h2 = compute_function_hash(src, 1, 2)
+        assert h1 == h2
+        assert len(h1) == 12  # short prefix
+        assert all(c in "0123456789abcdef" for c in h1)
+
+    def test_different_for_different_lines(self, tmp_path):
+        src = tmp_path / "foo.py"
+        src.write_text("def f():\n    return 1\n\ndef g():\n    return 2\n")
+        h_f = compute_function_hash(src, 1, 2)
+        h_g = compute_function_hash(src, 4, 5)
+        assert h_f != h_g
+
+    def test_changes_when_content_changes(self, tmp_path):
+        src = tmp_path / "foo.py"
+        src.write_text("def f():\n    return 1\n")
+        h_before = compute_function_hash(src, 1, 2)
+        src.write_text("def f():\n    return 99\n")
+        h_after = compute_function_hash(src, 1, 2)
+        assert h_before != h_after
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert compute_function_hash(tmp_path / "nope.py", 1, 5) == ""
+
+    def test_non_utf8_bytes_tolerated(self, tmp_path):
+        """Non-UTF-8 source bytes shouldn't crash the hasher — the
+        hash is for change-detection, not crypto. errors="replace"
+        gives us a stable hash for whatever was on disk."""
+        src = tmp_path / "weird.py"
+        src.write_bytes(b"def f():\n    s = \"\xff\xfe\"\n")
+        h = compute_function_hash(src, 1, 2)
+        assert h != ""
+        assert len(h) == 12
+
+    def test_invalid_range_returns_empty(self, tmp_path):
+        src = tmp_path / "foo.py"
+        src.write_text("a\nb\nc\n")
+        # start_line <= 0
+        assert compute_function_hash(src, 0, 5) == ""
+        assert compute_function_hash(src, -1, 5) == ""
+        # end_line < start_line
+        assert compute_function_hash(src, 5, 1) == ""
+
+    def test_range_past_eof_clamps(self, tmp_path):
+        """Asking for lines past EOF doesn't crash — clamp to file
+        length and hash whatever's there."""
+        src = tmp_path / "foo.py"
+        src.write_text("only one line\n")
+        h = compute_function_hash(src, 1, 1000)
+        assert h != ""
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        src = tmp_path / "empty.py"
+        src.write_text("")
+        assert compute_function_hash(src, 1, 5) == ""

--- a/core/annotations/tests/test_storage.py
+++ b/core/annotations/tests/test_storage.py
@@ -1,0 +1,435 @@
+"""Tests for ``core.annotations`` storage layer.
+
+Covers:
+  * Read/write round-trip with body + metadata
+  * Multiple annotations per source file (preserves siblings)
+  * Update-in-place vs append for the same function
+  * Removal: cleans up empty files
+  * Path traversal defence (no .., no absolute paths)
+  * Atomic write (no partial files on simulated crash)
+  * Walk-the-tree iterator
+  * Format-stability: sorted sections, deterministic output
+  * Quoting: values with spaces and quotes round-trip cleanly
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.annotations import (
+    Annotation,
+    annotation_path,
+    iter_all_annotations,
+    read_annotation,
+    read_file_annotations,
+    remove_annotation,
+    write_annotation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Path resolution + validation
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotationPath:
+    def test_mirrors_source_tree_structure(self, tmp_path):
+        p = annotation_path(tmp_path, "packages/foo/bar.py")
+        assert p == tmp_path / "packages" / "foo" / "bar.py.md"
+
+    def test_top_level_file(self, tmp_path):
+        p = annotation_path(tmp_path, "main.py")
+        assert p == tmp_path / "main.py.md"
+
+    def test_rejects_traversal(self, tmp_path):
+        with pytest.raises(ValueError, match=r"\.\."):
+            annotation_path(tmp_path, "../etc/passwd")
+
+    def test_rejects_traversal_in_middle(self, tmp_path):
+        with pytest.raises(ValueError, match=r"\.\."):
+            annotation_path(tmp_path, "ok/../etc/passwd")
+
+    def test_rejects_absolute_path(self, tmp_path):
+        with pytest.raises(ValueError, match="relative"):
+            annotation_path(tmp_path, "/etc/passwd")
+
+    def test_rejects_empty(self, tmp_path):
+        with pytest.raises(ValueError, match="non-empty"):
+            annotation_path(tmp_path, "")
+
+
+# ---------------------------------------------------------------------------
+# Read / write round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_simple_body_only(self, tmp_path):
+        ann = Annotation(
+            file="src/foo.py",
+            function="bar",
+            body="This function returns 42.",
+        )
+        write_annotation(tmp_path, ann)
+        got = read_annotation(tmp_path, "src/foo.py", "bar")
+        assert got == ann
+
+    def test_with_metadata(self, tmp_path):
+        ann = Annotation(
+            file="src/foo.py", function="bar",
+            body="Suspicious — sys.argv → os.system",
+            metadata={"status": "suspicious", "cwe": "CWE-78"},
+        )
+        write_annotation(tmp_path, ann)
+        got = read_annotation(tmp_path, "src/foo.py", "bar")
+        assert got is not None
+        assert got.metadata["status"] == "suspicious"
+        assert got.metadata["cwe"] == "CWE-78"
+        assert "sys.argv" in got.body
+
+    def test_metadata_only_no_body(self, tmp_path):
+        """Common audit case: function reviewed clean, no prose."""
+        ann = Annotation(
+            file="src/foo.py", function="trivial_getter",
+            metadata={"status": "clean"},
+        )
+        write_annotation(tmp_path, ann)
+        got = read_annotation(tmp_path, "src/foo.py", "trivial_getter")
+        assert got.metadata["status"] == "clean"
+        assert got.body == ""
+
+    def test_qualified_method_name(self, tmp_path):
+        """Class methods qualified as ``Klass.method`` survive
+        round-trip."""
+        ann = Annotation(
+            file="src/foo.py", function="MyClass.do_thing",
+            body="ok",
+        )
+        write_annotation(tmp_path, ann)
+        got = read_annotation(tmp_path, "src/foo.py", "MyClass.do_thing")
+        assert got is not None
+
+    def test_returns_none_for_missing_function(self, tmp_path):
+        # File exists but function not annotated.
+        write_annotation(tmp_path, Annotation(
+            file="src/foo.py", function="bar", body="x",
+        ))
+        assert read_annotation(tmp_path, "src/foo.py", "missing") is None
+
+    def test_returns_none_for_missing_file(self, tmp_path):
+        assert read_annotation(tmp_path, "nope.py", "any") is None
+
+
+# ---------------------------------------------------------------------------
+# Multi-annotation files
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleAnnotations:
+    def test_siblings_preserved_on_write(self, tmp_path):
+        """Writing function B doesn't drop function A in the same
+        source file."""
+        write_annotation(tmp_path, Annotation(
+            file="src/foo.py", function="alpha", body="A body",
+        ))
+        write_annotation(tmp_path, Annotation(
+            file="src/foo.py", function="beta", body="B body",
+        ))
+        got = read_file_annotations(tmp_path, "src/foo.py")
+        names = {a.function for a in got}
+        assert names == {"alpha", "beta"}
+
+    def test_update_replaces_existing(self, tmp_path):
+        """Writing the same function name overwrites — not appends."""
+        write_annotation(tmp_path, Annotation(
+            file="src/foo.py", function="alpha", body="initial",
+        ))
+        write_annotation(tmp_path, Annotation(
+            file="src/foo.py", function="alpha", body="revised",
+            metadata={"status": "clean"},
+        ))
+        got = read_annotation(tmp_path, "src/foo.py", "alpha")
+        assert got.body == "revised"
+        assert got.metadata["status"] == "clean"
+        # Only one alpha section.
+        all_for_file = read_file_annotations(tmp_path, "src/foo.py")
+        assert sum(1 for a in all_for_file if a.function == "alpha") == 1
+
+    def test_sections_sorted_alphabetically(self, tmp_path):
+        """Diff stability: write order should not affect on-disk
+        order. Sections sorted by function name."""
+        for name in ("zebra", "alpha", "middle"):
+            write_annotation(tmp_path, Annotation(
+                file="src/foo.py", function=name, body=name,
+            ))
+        path = annotation_path(tmp_path, "src/foo.py")
+        text = path.read_text(encoding="utf-8")
+        # alpha appears before middle which appears before zebra.
+        a = text.index("## alpha")
+        m = text.index("## middle")
+        z = text.index("## zebra")
+        assert a < m < z
+
+
+# ---------------------------------------------------------------------------
+# Removal
+# ---------------------------------------------------------------------------
+
+
+class TestRemoval:
+    def test_remove_single_annotation_keeps_siblings(self, tmp_path):
+        write_annotation(tmp_path, Annotation(
+            file="src/foo.py", function="alpha", body="A",
+        ))
+        write_annotation(tmp_path, Annotation(
+            file="src/foo.py", function="beta", body="B",
+        ))
+        assert remove_annotation(tmp_path, "src/foo.py", "alpha") is True
+        remaining = read_file_annotations(tmp_path, "src/foo.py")
+        assert {a.function for a in remaining} == {"beta"}
+
+    def test_remove_last_annotation_deletes_file(self, tmp_path):
+        write_annotation(tmp_path, Annotation(
+            file="src/foo.py", function="alpha", body="A",
+        ))
+        path = annotation_path(tmp_path, "src/foo.py")
+        assert path.exists()
+        remove_annotation(tmp_path, "src/foo.py", "alpha")
+        assert not path.exists()
+
+    def test_remove_nonexistent_returns_false(self, tmp_path):
+        assert remove_annotation(tmp_path, "nope.py", "x") is False
+
+
+# ---------------------------------------------------------------------------
+# iter_all_annotations
+# ---------------------------------------------------------------------------
+
+
+class TestIterAll:
+    def test_walks_tree(self, tmp_path):
+        write_annotation(tmp_path, Annotation(
+            file="src/foo.py", function="a", body="A",
+        ))
+        write_annotation(tmp_path, Annotation(
+            file="src/foo.py", function="b", body="B",
+        ))
+        write_annotation(tmp_path, Annotation(
+            file="lib/util.py", function="c", body="C",
+        ))
+        write_annotation(tmp_path, Annotation(
+            file="deep/nested/bar.c", function="d", body="D",
+        ))
+
+        all_ = list(iter_all_annotations(tmp_path))
+        names = sorted(a.function for a in all_)
+        assert names == ["a", "b", "c", "d"]
+
+    def test_empty_tree_yields_nothing(self, tmp_path):
+        assert list(iter_all_annotations(tmp_path)) == []
+
+    def test_nonexistent_base_yields_nothing(self, tmp_path):
+        assert list(iter_all_annotations(tmp_path / "nope")) == []
+
+
+# ---------------------------------------------------------------------------
+# Edge-case formatting
+# ---------------------------------------------------------------------------
+
+
+class TestFormatting:
+    def test_metadata_value_with_spaces_quoted(self, tmp_path):
+        ann = Annotation(
+            file="x.py", function="f",
+            metadata={"reviewer": "Alice Smith"},
+        )
+        write_annotation(tmp_path, ann)
+        text = annotation_path(tmp_path, "x.py").read_text()
+        assert 'reviewer="Alice Smith"' in text
+        # Round-trip preserves the value.
+        got = read_annotation(tmp_path, "x.py", "f")
+        assert got.metadata["reviewer"] == "Alice Smith"
+
+    def test_metadata_value_with_quotes_escaped(self, tmp_path):
+        ann = Annotation(
+            file="x.py", function="f",
+            metadata={"note": 'has "quotes"'},
+        )
+        write_annotation(tmp_path, ann)
+        got = read_annotation(tmp_path, "x.py", "f")
+        # The value with embedded quotes round-trips at least partially —
+        # we don't promise full quote-fidelity (the format is line-based)
+        # but the read shouldn't crash.
+        assert got is not None
+
+    def test_body_with_markdown_headings(self, tmp_path):
+        """Body containing ``###`` headings (one level deeper than
+        section heading) should NOT be confused with a new section."""
+        body = "# Tier-1 heading inside body\n\n### subhead\n\nprose"
+        ann = Annotation(file="x.py", function="f", body=body)
+        write_annotation(tmp_path, ann)
+        got = read_annotation(tmp_path, "x.py", "f")
+        # The single-hash heading at body start would mis-parse if
+        # the regex were too loose. Exactly one record found.
+        all_ = read_file_annotations(tmp_path, "x.py")
+        assert len(all_) == 1
+        assert "subhead" in got.body
+
+    def test_body_with_double_hash_in_code_block(self, tmp_path):
+        """Markdown ``## name`` inside a fenced code block would
+        false-positive as a new section. Acceptable limitation —
+        the format expects ``## name`` only at section starts. We
+        document the limitation by pinning the current behaviour:
+        no crash, may split the section."""
+        body = "```\n## not_really_a_section\n```\nreal content"
+        ann = Annotation(file="x.py", function="f", body=body)
+        write_annotation(tmp_path, ann)
+        # Round-trip: we read whatever the regex sees. Pin that
+        # the original section's name + first line at minimum
+        # are recoverable.
+        all_ = read_file_annotations(tmp_path, "x.py")
+        assert any(a.function == "f" for a in all_)
+
+
+# ---------------------------------------------------------------------------
+# Atomic write (sanity)
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Adversarial: input that would corrupt the on-disk format
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarialInputs:
+    def test_rejects_function_name_with_newline(self, tmp_path):
+        """Newline in function name would let an attacker forge fake
+        ``## evil`` headings in subsequent lines."""
+        with pytest.raises(ValueError, match="newline"):
+            write_annotation(tmp_path, Annotation(
+                file="x.py", function="real\n## injected", body="x",
+            ))
+
+    def test_rejects_function_name_with_carriage_return(self, tmp_path):
+        with pytest.raises(ValueError, match="newline"):
+            write_annotation(tmp_path, Annotation(
+                file="x.py", function="real\r## injected", body="x",
+            ))
+
+    def test_rejects_function_name_with_null(self, tmp_path):
+        with pytest.raises(ValueError, match="newline"):
+            write_annotation(tmp_path, Annotation(
+                file="x.py", function="real\x00", body="x",
+            ))
+
+    def test_rejects_empty_function_name(self, tmp_path):
+        with pytest.raises(ValueError, match="non-empty"):
+            write_annotation(tmp_path, Annotation(
+                file="x.py", function="", body="x",
+            ))
+
+    def test_rejects_metadata_value_with_html_comment_close(self, tmp_path):
+        """``-->`` in a metadata value would close the comment early
+        on disk and cause the body content after to be re-parsed as
+        comment trailer."""
+        with pytest.raises(ValueError, match="-->"):
+            write_annotation(tmp_path, Annotation(
+                file="x.py", function="f",
+                metadata={"note": "value-->evil"},
+            ))
+
+    def test_rejects_metadata_value_with_html_comment_open(self, tmp_path):
+        with pytest.raises(ValueError, match="<!--"):
+            write_annotation(tmp_path, Annotation(
+                file="x.py", function="f",
+                metadata={"note": "value<!--evil"},
+            ))
+
+    def test_rejects_metadata_value_with_newline(self, tmp_path):
+        with pytest.raises(ValueError, match="newline"):
+            write_annotation(tmp_path, Annotation(
+                file="x.py", function="f",
+                metadata={"note": "line1\nline2"},
+            ))
+
+    def test_rejects_metadata_key_with_special_chars(self, tmp_path):
+        with pytest.raises(ValueError):
+            write_annotation(tmp_path, Annotation(
+                file="x.py", function="f",
+                metadata={"bad key": "v"},
+            ))
+
+    def test_rejects_source_path_with_newline(self, tmp_path):
+        with pytest.raises(ValueError, match="newline"):
+            annotation_path(tmp_path, "foo\nbar.py")
+
+    def test_rejects_source_path_with_null(self, tmp_path):
+        with pytest.raises(ValueError, match="newline"):
+            annotation_path(tmp_path, "foo\x00bar.py")
+
+    def test_legit_unicode_in_function_name_accepted(self, tmp_path):
+        """Defense should not over-reject — unicode identifiers are
+        valid in Python and many other languages."""
+        write_annotation(tmp_path, Annotation(
+            file="x.py", function="MyClass.做事",
+            body="ok",
+        ))
+        got = read_annotation(tmp_path, "x.py", "MyClass.做事")
+        assert got is not None
+
+    def test_legit_special_chars_in_body_preserved(self, tmp_path):
+        """Body is free-form prose — should preserve whatever the
+        operator wrote, including comment-like sequences (since
+        the body is not inside a comment)."""
+        body = "Saw <!-- comment --> in the input. Also `-->` at line 5."
+        ann = Annotation(file="x.py", function="f", body=body)
+        write_annotation(tmp_path, ann)
+        got = read_annotation(tmp_path, "x.py", "f")
+        assert "<!-- comment -->" in got.body
+        assert "`-->`" in got.body
+
+    def test_corrupt_utf8_does_not_crash_reader(self, tmp_path):
+        """If a file gets corrupted on disk, reader should not crash —
+        return empty rather than propagate UnicodeDecodeError."""
+        # Write a real annotation, then corrupt the file with bytes
+        # that aren't valid UTF-8.
+        write_annotation(tmp_path, Annotation(
+            file="x.py", function="f", body="ok",
+        ))
+        path = annotation_path(tmp_path, "x.py")
+        path.write_bytes(b"\xff\xfe garbage \xc3\x28 not utf-8")
+        # Reader should swallow and return empty, not propagate.
+        result = read_file_annotations(tmp_path, "x.py")
+        assert result == []
+        # iter_all_annotations should also tolerate it.
+        all_ = list(iter_all_annotations(tmp_path))
+        assert all_ == []
+
+
+class TestAtomicWrite:
+    def test_no_partial_file_on_concurrent_reader(self, tmp_path):
+        """Atomic-rename means a reader who opens the path between
+        two writes sees either the old content or the new — never
+        a half-written file. Pin by reading immediately after write."""
+        write_annotation(tmp_path, Annotation(
+            file="x.py", function="a", body="initial " * 1000,
+        ))
+        write_annotation(tmp_path, Annotation(
+            file="x.py", function="a", body="updated " * 1000,
+        ))
+        got = read_annotation(tmp_path, "x.py", "a")
+        # Body is exactly one of the two written values, not a mix.
+        assert got.body in (
+            ("initial " * 1000).rstrip(),
+            ("updated " * 1000).rstrip(),
+        )
+
+    def test_no_tempfile_left_behind_after_write(self, tmp_path):
+        write_annotation(tmp_path, Annotation(
+            file="x.py", function="a", body="ok",
+        ))
+        # No .annotation-*.tmp files left in the directory.
+        leftovers = list(tmp_path.glob("**/.annotation-*.tmp"))
+        assert leftovers == []

--- a/core/annotations/tests/test_versioning.py
+++ b/core/annotations/tests/test_versioning.py
@@ -1,0 +1,131 @@
+"""Tests for annotation file format versioning.
+
+Pin the marker shape, the legacy-no-marker behaviour, and the
+forward-compat warning path. These guards catch regressions if
+``CURRENT_VERSION`` is bumped or the marker pattern is changed
+without updating the reader.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from core.annotations import (
+    Annotation,
+    annotation_path,
+    read_annotation,
+    read_file_annotations,
+    write_annotation,
+)
+from core.annotations.storage import CURRENT_VERSION
+
+
+class TestVersionMarker:
+    def test_writes_emit_current_version_marker(self, tmp_path):
+        write_annotation(tmp_path, Annotation(
+            file="src/foo.py", function="login", body="x",
+        ))
+        text = annotation_path(tmp_path, "src/foo.py").read_text()
+        assert text.startswith(
+            f"<!-- annotations-version: {CURRENT_VERSION} -->"
+        )
+
+    def test_marker_is_first_line(self, tmp_path):
+        write_annotation(tmp_path, Annotation(
+            file="src/foo.py", function="f", body="x",
+        ))
+        first_line = annotation_path(
+            tmp_path, "src/foo.py",
+        ).read_text().splitlines()[0]
+        assert "annotations-version" in first_line
+
+
+class TestLegacyFilesAreReadable:
+    """Files written before the marker existed must still parse."""
+
+    def test_legacy_v1_format_no_marker(self, tmp_path):
+        path = tmp_path / "src" / "foo.py.md"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            "# src/foo.py\n\n"
+            "## login\n"
+            "<!-- meta: status=clean -->\n\n"
+            "Reviewed clean\n"
+        )
+        anns = read_file_annotations(tmp_path, "src/foo.py")
+        assert len(anns) == 1
+        assert anns[0].function == "login"
+        assert anns[0].metadata["status"] == "clean"
+
+    def test_legacy_round_trip_via_write(self, tmp_path):
+        """Read a legacy file, write a new annotation, file gets
+        upgraded to current format with marker."""
+        path = tmp_path / "src" / "foo.py.md"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            "# src/foo.py\n\n"
+            "## old_func\n"
+            "<!-- meta: status=clean -->\n\n"
+            "legacy entry\n"
+        )
+        # Add a new annotation — siblings preserved, marker added.
+        write_annotation(tmp_path, Annotation(
+            file="src/foo.py", function="new_func", body="new",
+            metadata={"status": "clean"},
+        ))
+        text = path.read_text()
+        # Marker now present.
+        assert "annotations-version: 1" in text
+        # Legacy entry preserved.
+        assert "legacy entry" in text
+
+
+class TestForwardCompatWarning:
+    """A future-version file should warn but still attempt to parse."""
+
+    def test_future_version_warns(self, tmp_path, caplog):
+        path = tmp_path / "src" / "foo.py.md"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            "<!-- annotations-version: 999 -->\n"
+            "# src/foo.py\n\n"
+            "## f\n"
+            "<!-- meta: status=clean -->\n\n"
+            "future-format prose\n"
+        )
+        with caplog.at_level(logging.WARNING, logger="core.annotations.storage"):
+            anns = read_file_annotations(tmp_path, "src/foo.py")
+        assert any("declares version 999" in r.message for r in caplog.records)
+        # Best-effort parse: our v1 parser found the section anyway.
+        assert len(anns) == 1
+        assert anns[0].function == "f"
+
+    def test_current_version_no_warning(self, tmp_path, caplog):
+        write_annotation(tmp_path, Annotation(
+            file="src/foo.py", function="f", body="x",
+        ))
+        with caplog.at_level(logging.WARNING, logger="core.annotations.storage"):
+            read_file_annotations(tmp_path, "src/foo.py")
+        # No warnings about version drift.
+        assert not any(
+            "declares version" in r.message for r in caplog.records
+        )
+
+    def test_malformed_version_string_falls_back(self, tmp_path):
+        """Non-numeric version → silently treated as current."""
+        path = tmp_path / "src" / "foo.py.md"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            "<!-- annotations-version: notanumber -->\n"
+            "# src/foo.py\n\n"
+            "## f\n"
+            "<!-- meta: status=clean -->\n\n"
+            "x\n"
+        )
+        # Marker regex requires \d+, so notanumber doesn't match —
+        # treated as no-marker (legacy v1).
+        anns = read_file_annotations(tmp_path, "src/foo.py")
+        assert len(anns) == 1

--- a/core/coverage/record.py
+++ b/core/coverage/record.py
@@ -229,6 +229,62 @@ def build_from_findings(findings_path: Path, reads_manifest_path: Path = None,
     return record
 
 
+def build_from_annotations(annotations_dir: Path) -> Optional[Dict[str, Any]]:
+    """Build a coverage record from a tree of annotation .md files.
+
+    Every annotated function counts as "examined" for coverage purposes:
+    operator manual review and LLM analysis both produce a finished
+    record about the function. ``status=clean`` annotations are the
+    cleanest signal but any annotation is sufficient evidence — the
+    function was looked at.
+
+    Args:
+        annotations_dir: Directory containing the annotation tree
+            (typically ``<run_output_dir>/annotations``).
+
+    Returns:
+        Coverage record dict, or None if the directory doesn't exist
+        or contains no annotations.
+    """
+    annotations_dir = Path(annotations_dir)
+    if not annotations_dir.exists():
+        return None
+    # Local import — avoid circular dependency with packages that
+    # use coverage records.
+    from core.annotations import iter_all_annotations
+
+    files = set()
+    functions: List[Dict[str, str]] = []
+    seen = set()
+    statuses: Dict[str, int] = {}
+    sources: Dict[str, int] = {}
+    for ann in iter_all_annotations(annotations_dir):
+        if ann.file:
+            files.add(ann.file)
+        key = (ann.file, ann.function)
+        if key in seen:
+            continue
+        seen.add(key)
+        functions.append({"file": ann.file, "function": ann.function})
+        st = ann.metadata.get("status")
+        if st:
+            statuses[st] = statuses.get(st, 0) + 1
+        src = ann.metadata.get("source")
+        if src:
+            sources[src] = sources.get(src, 0) + 1
+    if not files and not functions:
+        return None
+    return {
+        "tool": "annotations",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "files_examined": sorted(files),
+        "functions_analysed": functions,
+        # Annotation-specific extension (readers ignore unknown keys).
+        "annotation_statuses": statuses,
+        "annotation_sources": sources,
+    }
+
+
 def write_record(run_dir: Path, record: Dict[str, Any],
                  tool_name: str = None) -> Path:
     """Write a coverage record to the run directory.

--- a/core/coverage/tests/test_annotation_record.py
+++ b/core/coverage/tests/test_annotation_record.py
@@ -1,0 +1,107 @@
+"""Tests for ``core.coverage.record.build_from_annotations``.
+
+The builder converts an annotation tree into a coverage record
+that the existing summary computation can ingest. Annotated
+functions count as "examined" for coverage purposes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.annotations import Annotation, write_annotation
+from core.coverage.record import build_from_annotations, load_records
+
+
+class TestBuildFromAnnotations:
+    def test_returns_none_for_missing_dir(self, tmp_path):
+        assert build_from_annotations(tmp_path / "nope") is None
+
+    def test_returns_none_for_empty_dir(self, tmp_path):
+        # Directory exists but has no annotations.
+        assert build_from_annotations(tmp_path) is None
+
+    def test_basic_record_fields(self, tmp_path):
+        write_annotation(tmp_path, Annotation(
+            file="src/auth.py", function="check_pw",
+            body="ok", metadata={"status": "clean", "source": "human"},
+        ))
+        record = build_from_annotations(tmp_path)
+        assert record is not None
+        assert record["tool"] == "annotations"
+        assert record["files_examined"] == ["src/auth.py"]
+        assert record["functions_analysed"] == [
+            {"file": "src/auth.py", "function": "check_pw"}
+        ]
+        assert "timestamp" in record
+
+    def test_aggregates_status_and_source_counts(self, tmp_path):
+        for fn, status, source in [
+            ("a", "clean", "human"),
+            ("b", "clean", "llm"),
+            ("c", "finding", "llm"),
+            ("d", "suspicious", "llm"),
+        ]:
+            write_annotation(tmp_path, Annotation(
+                file="src/foo.py", function=fn, body="x",
+                metadata={"status": status, "source": source},
+            ))
+        record = build_from_annotations(tmp_path)
+        assert record["annotation_statuses"] == {
+            "clean": 2, "finding": 1, "suspicious": 1,
+        }
+        assert record["annotation_sources"] == {"human": 1, "llm": 3}
+
+    def test_dedupes_function_records(self, tmp_path):
+        """Multiple annotations on the same (file, function) pair —
+        the builder records the function once."""
+        # Write twice — second overwrites first in-place.
+        write_annotation(tmp_path, Annotation(
+            file="src/foo.py", function="login",
+            body="first", metadata={"source": "human"},
+        ))
+        write_annotation(tmp_path, Annotation(
+            file="src/foo.py", function="login",
+            body="second", metadata={"source": "llm"},
+        ))
+        record = build_from_annotations(tmp_path)
+        # Only one entry — same (file, function) collapses on disk.
+        assert len(record["functions_analysed"]) == 1
+
+    def test_walks_nested_tree(self, tmp_path):
+        write_annotation(tmp_path, Annotation(
+            file="src/a.py", function="f1", body="x",
+        ))
+        write_annotation(tmp_path, Annotation(
+            file="lib/util.py", function="f2", body="y",
+        ))
+        write_annotation(tmp_path, Annotation(
+            file="deep/nested/c.py", function="f3", body="z",
+        ))
+        record = build_from_annotations(tmp_path)
+        assert set(record["files_examined"]) == {
+            "src/a.py", "lib/util.py", "deep/nested/c.py",
+        }
+        assert len(record["functions_analysed"]) == 3
+
+
+class TestRoundTripWithLoadRecords:
+    """Once the record is written via ``write_record``, the standard
+    ``load_records`` reader must pick it up."""
+
+    def test_round_trip(self, tmp_path):
+        from core.coverage.record import write_record
+        ann_dir = tmp_path / "annotations"
+        write_annotation(ann_dir, Annotation(
+            file="src/foo.py", function="login",
+            body="x", metadata={"status": "clean", "source": "human"},
+        ))
+        record = build_from_annotations(ann_dir)
+        assert record is not None
+        write_record(tmp_path, record, tool_name="annotations")
+        # Now load_records picks it up alongside any other coverage
+        # records (none in this test).
+        records = load_records(tmp_path)
+        assert any(r.get("tool") == "annotations" for r in records)

--- a/core/coverage/tests/test_summary_with_annotations.py
+++ b/core/coverage/tests/test_summary_with_annotations.py
@@ -1,0 +1,140 @@
+"""End-to-end verification that ``compute_summary`` picks up the
+``coverage-annotations.json`` record written by ``/agentic`` and
+``/understand``.
+
+The standard ``load_records`` reader scans for ``coverage-*.json``
+files. The annotation builder writes one per run. This test pins
+that the wire-up actually flows: write annotations → coverage record
+emitted → compute_summary surfaces it as ``tools["annotations"]``.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from core.annotations import Annotation, write_annotation
+from core.coverage.record import build_from_annotations, write_record
+from core.coverage.summary import compute_summary
+
+
+class TestSummaryWithAnnotations(unittest.TestCase):
+    """Pins that the annotation tool name appears in the summary
+    output, with the right files_examined and functions_analysed."""
+
+    def _make_run_with_annotations(self, run_dir: Path):
+        """Create a run dir that mirrors what /agentic writes:
+        a checklist.json (inventory), an annotations tree, and a
+        coverage-annotations.json built from the tree."""
+        # Tiny inventory.
+        checklist = {
+            "target_path": str(run_dir),
+            "total_files": 1,
+            "total_items": 3,
+            "files": [
+                {
+                    "path": "src/foo.py",
+                    "sloc": 30,
+                    "items": [
+                        {"name": "alpha", "line_start": 1, "line_end": 10},
+                        {"name": "beta", "line_start": 11, "line_end": 20},
+                        {"name": "gamma", "line_start": 21, "line_end": 30},
+                    ],
+                }
+            ],
+        }
+        (run_dir / "checklist.json").write_text(json.dumps(checklist))
+
+        # Annotations on two of the three functions.
+        ann_dir = run_dir / "annotations"
+        write_annotation(ann_dir, Annotation(
+            file="src/foo.py", function="alpha",
+            body="reviewed clean",
+            metadata={"source": "human", "status": "clean"},
+        ))
+        write_annotation(ann_dir, Annotation(
+            file="src/foo.py", function="beta",
+            body="LLM finding",
+            metadata={"source": "llm", "status": "finding"},
+        ))
+
+        # Coverage record (matches what /agentic + /understand emit).
+        record = build_from_annotations(ann_dir)
+        assert record is not None
+        write_record(run_dir, record, tool_name="annotations")
+
+    def test_annotations_record_appears_in_summary(self):
+        with TemporaryDirectory() as d:
+            run_dir = Path(d)
+            self._make_run_with_annotations(run_dir)
+
+            summary = compute_summary(run_dir)
+            assert summary is not None
+            tools = summary["tools"]
+            assert "annotations" in tools, (
+                f"annotations tool missing from summary; "
+                f"got tools: {list(tools.keys())}"
+            )
+            ann_info = tools["annotations"]
+            assert ann_info["files_examined"] == 1
+            assert ann_info["functions_analysed"] == 2
+
+    def test_summary_records_annotation_status_breakdown(self):
+        """The builder stamps annotation_statuses + annotation_sources
+        on the record; verify they survive into the summary's tools
+        dict (readers tolerate unknown keys)."""
+        with TemporaryDirectory() as d:
+            run_dir = Path(d)
+            self._make_run_with_annotations(run_dir)
+
+            summary = compute_summary(run_dir)
+            ann_info = summary["tools"]["annotations"]
+            # Either present (if compute_summary preserves) or absent
+            # (if it filters to the schema fields it knows). Pin the
+            # current behaviour — whichever it is.
+            # If preserved, useful for `/project annotations` etc.
+            # We at minimum want files + functions present.
+            assert "files_examined" in ann_info
+            assert "functions_analysed" in ann_info
+
+    def test_unreviewed_unchanged_when_no_llm_record(self):
+        """Without an LLM record, the existing semantics keep
+        ``unreviewed_functions`` at total_items even when annotations
+        cover some functions. This is documented as conservative —
+        annotations don't currently reduce the LLM-scoped 'unreviewed'
+        count. If that ever changes, this test will surface the
+        semantic shift."""
+        with TemporaryDirectory() as d:
+            run_dir = Path(d)
+            self._make_run_with_annotations(run_dir)
+
+            summary = compute_summary(run_dir)
+            # 3 inventory items, no LLM coverage, 2 annotated.
+            # Current semantics: unreviewed_functions = total_items - llm
+            # = 3 - 0 = 3. (Annotations are out of band today.)
+            assert summary["unreviewed_functions"] == 3
+
+    def test_per_file_breakdown_includes_annotation_functions(self):
+        """The per-file breakdown DOES use the union of all tools'
+        functions_analysed — so annotated functions show up as
+        reviewed in per-file detail even though the top-level
+        unreviewed_functions stays LLM-scoped."""
+        with TemporaryDirectory() as d:
+            run_dir = Path(d)
+            self._make_run_with_annotations(run_dir)
+
+            summary = compute_summary(run_dir)
+            per_file = {pf["path"]: pf for pf in summary["per_file"]}
+            foo = per_file.get("src/foo.py")
+            assert foo is not None
+            # Annotations covered alpha + beta — per-file "reviewed"
+            # count reflects that.
+            assert foo["reviewed"] == 2
+            assert foo["total"] == 3
+            assert "gamma" in foo["unreviewed_functions"]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core/project/annotations_diff.py
+++ b/core/project/annotations_diff.py
@@ -1,0 +1,131 @@
+"""Annotation diff between two run directories.
+
+Mirrors the findings ``diff.py`` pattern: load annotations from each
+run's ``annotations/`` subdir, key by (file, function), classify
+into ``added`` / ``removed`` / ``changed`` / ``unchanged``.
+
+A pair is "changed" when the body or metadata.status differs between
+the two runs. Other metadata drift (e.g. updated rule_id, refreshed
+hash) doesn't count as semantically changed — operators care about
+the verdict, not the file checksum.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+from core.annotations import iter_all_annotations
+
+
+def _load_run(run_dir: Path) -> Dict[tuple, Dict[str, Any]]:
+    """Index a run's annotations by (file, function) → record dict."""
+    by_pair: Dict[tuple, Dict[str, Any]] = {}
+    ann_dir = run_dir / "annotations"
+    if not ann_dir.exists():
+        return by_pair
+    for ann in iter_all_annotations(ann_dir):
+        by_pair[(ann.file, ann.function)] = {
+            "file": ann.file,
+            "function": ann.function,
+            "body": ann.body,
+            "metadata": dict(ann.metadata),
+        }
+    return by_pair
+
+
+def _has_changed(a: Dict[str, Any], b: Dict[str, Any]) -> bool:
+    """Did the verdict-relevant content change between two records?"""
+    if a["body"] != b["body"]:
+        return True
+    if a["metadata"].get("status") != b["metadata"].get("status"):
+        return True
+    return False
+
+
+def diff_annotations(run_dir_a: Path, run_dir_b: Path) -> Dict[str, Any]:
+    """Compare annotation trees between two run dirs.
+
+    Returns a dict with four lists:
+      * ``added``     — present in B, absent in A.
+      * ``removed``   — present in A, absent in B.
+      * ``changed``   — present in both, body or status differ. Each
+                        entry has ``before`` + ``after`` records.
+      * ``unchanged`` — present in both, body and status match.
+    """
+    a_index = _load_run(Path(run_dir_a))
+    b_index = _load_run(Path(run_dir_b))
+
+    a_keys = set(a_index)
+    b_keys = set(b_index)
+
+    added = [b_index[k] for k in sorted(b_keys - a_keys)]
+    removed = [a_index[k] for k in sorted(a_keys - b_keys)]
+
+    changed: List[Dict[str, Any]] = []
+    unchanged: List[Dict[str, Any]] = []
+    for k in sorted(a_keys & b_keys):
+        before = a_index[k]
+        after = b_index[k]
+        if _has_changed(before, after):
+            changed.append({"before": before, "after": after})
+        else:
+            unchanged.append(after)
+
+    return {
+        "run_a": str(run_dir_a),
+        "run_b": str(run_dir_b),
+        "added": added,
+        "removed": removed,
+        "changed": changed,
+        "unchanged": unchanged,
+    }
+
+
+def format_diff(result: Dict[str, Any]) -> str:
+    """Render a diff result as text suitable for stdout."""
+    lines: List[str] = []
+    a, b = result["run_a"], result["run_b"]
+    lines.append(f"Annotations diff: {a} → {b}")
+    lines.append("")
+    counts = (
+        f"added={len(result['added'])} "
+        f"removed={len(result['removed'])} "
+        f"changed={len(result['changed'])} "
+        f"unchanged={len(result['unchanged'])}"
+    )
+    lines.append(counts)
+    if result["added"]:
+        lines.append("")
+        lines.append("Added:")
+        for r in result["added"]:
+            status = r["metadata"].get("status", "—")
+            source = r["metadata"].get("source", "—")
+            lines.append(
+                f"  + {r['file']}::{r['function']}  "
+                f"status={status}  source={source}"
+            )
+    if result["removed"]:
+        lines.append("")
+        lines.append("Removed:")
+        for r in result["removed"]:
+            status = r["metadata"].get("status", "—")
+            lines.append(f"  - {r['file']}::{r['function']}  status={status}")
+    if result["changed"]:
+        lines.append("")
+        lines.append("Changed:")
+        for ch in result["changed"]:
+            before, after = ch["before"], ch["after"]
+            old_status = before["metadata"].get("status", "—")
+            new_status = after["metadata"].get("status", "—")
+            if old_status != new_status:
+                lines.append(
+                    f"  ~ {after['file']}::{after['function']}  "
+                    f"status: {old_status} → {new_status}"
+                )
+            else:
+                lines.append(
+                    f"  ~ {after['file']}::{after['function']}  "
+                    f"(body changed; status={new_status})"
+                )
+    return "\n".join(lines) + "\n"

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -532,6 +532,8 @@ def main():
             if stats.get("findings_dir"):
                 print(f"  Findings directory: {stats['findings_dir']}")
             print(f"  Merged findings: {stats['findings']}")
+            if stats.get("annotations") is not None:
+                print(f"  Annotations: {stats['annotations']}")
 
         elif args.subcommand == "export":
             from .export import export_project

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -110,6 +110,19 @@ def main():
         "--file",
         help="Filter by source file path",
     )
+    p_anns.add_argument(
+        "--cwe",
+        help="Filter by metadata.cwe (exact match)",
+    )
+    p_anns.add_argument(
+        "--rule-id",
+        dest="rule_id",
+        help="Filter by metadata.rule_id (substring match)",
+    )
+    p_anns.add_argument(
+        "--grep",
+        help="Case-insensitive substring search across body + metadata",
+    )
 
     # delete
     p_delete = sub.add_parser("delete", help="Delete a project",
@@ -299,6 +312,9 @@ def main():
                 status_filter=args.status,
                 source_filter=args.source,
                 file_filter=args.file,
+                cwe_filter=args.cwe,
+                rule_id_filter=args.rule_id,
+                grep=args.grep,
             )
 
         elif args.subcommand == "use":
@@ -834,6 +850,7 @@ def _finding_label(f):
 
 def _print_annotations(
     project, status_filter=None, source_filter=None, file_filter=None,
+    cwe_filter=None, rule_id_filter=None, grep=None,
 ):
     """List annotations across all runs in the project.
 
@@ -875,6 +892,18 @@ def _print_annotations(
         anns = [a for a in anns if a.metadata.get("source") == source_filter]
     if file_filter:
         anns = [a for a in anns if a.file == file_filter]
+    if cwe_filter:
+        anns = [a for a in anns if a.metadata.get("cwe") == cwe_filter]
+    if rule_id_filter:
+        anns = [a for a in anns
+                if rule_id_filter in (a.metadata.get("rule_id") or "")]
+    if grep:
+        needle = grep.lower()
+        anns = [
+            a for a in anns
+            if needle in a.body.lower()
+            or any(needle in str(v).lower() for v in a.metadata.values())
+        ]
     anns.sort(key=lambda a: (a.file, a.function))
     if not anns:
         print("No annotations match the filter.")

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -89,6 +89,28 @@ def main():
     p_findings.add_argument("name", nargs="?", help="Project name")
     p_findings.add_argument("--detailed", action="store_true", help="Per-finding detail (reasoning, proof, PoC)")
 
+    # annotations
+    p_anns = sub.add_parser(
+        "annotations",
+        help="List annotations across all runs in the project",
+        usage="raptor project annotations [<name>] [--status S] "
+              "[--source S] [--file PATH]",
+        **_F,
+    )
+    p_anns.add_argument("name", nargs="?", help="Project name")
+    p_anns.add_argument(
+        "--status",
+        help="Filter by metadata.status (clean / suspicious / finding / etc.)",
+    )
+    p_anns.add_argument(
+        "--source",
+        help="Filter by metadata.source (human / llm)",
+    )
+    p_anns.add_argument(
+        "--file",
+        help="Filter by source file path",
+    )
+
     # delete
     p_delete = sub.add_parser("delete", help="Delete a project",
                               usage="raptor project delete <name> [--purge] [--yes]", **_F)
@@ -262,6 +284,22 @@ def main():
                 print(f"Project '{name}' not found.")
                 return
             _print_findings(p, detailed=args.detailed)
+
+        elif args.subcommand == "annotations":
+            name = args.name or _get_active_project()
+            if not name:
+                print("No project specified.")
+                return
+            p = mgr.load(name)
+            if not p:
+                print(f"Project '{name}' not found.")
+                return
+            _print_annotations(
+                p,
+                status_filter=args.status,
+                source_filter=args.source,
+                file_filter=args.file,
+            )
 
         elif args.subcommand == "use":
             if args.name is None:
@@ -790,6 +828,65 @@ def _print_findings(project, detailed=False):
 def _finding_label(f):
     """Location-based label for a finding."""
     return f"{f.get('file', '?')}:{f.get('function', '?')}:{f.get('line', '?')}"
+
+
+def _print_annotations(
+    project, status_filter=None, source_filter=None, file_filter=None,
+):
+    """List annotations across all runs in the project.
+
+    Walks every run dir's ``annotations/`` subdir plus the project's
+    own top-level ``annotations/`` dir (operator-driven manual notes
+    land there when the active project has no specific run scope).
+    Deduplicates on (file, function), keeping the most recent annotation
+    per pair (last-writer-wins by run mtime).
+    """
+    from core.annotations import iter_all_annotations
+
+    # Candidate annotation roots: one per run dir + the project root.
+    roots = []
+    for rd in project.get_run_dirs(sweep=False):
+        ann_dir = rd / "annotations"
+        if ann_dir.exists():
+            roots.append((rd.stat().st_mtime, ann_dir))
+    project_ann = Path(project.output_dir) / "annotations"
+    if project_ann.exists():
+        # Project-level annotations win over run-level (operator
+        # notes are higher-priority than LLM emissions).
+        roots.append((float("inf"), project_ann))
+    if not roots:
+        print("No annotations.")
+        return
+
+    # Sort by mtime (oldest first) so later writes overwrite earlier
+    # in the dedup map.
+    roots.sort(key=lambda r: r[0])
+    by_pair = {}  # (file, function) → Annotation
+    for _mtime, root in roots:
+        for ann in iter_all_annotations(root):
+            by_pair[(ann.file, ann.function)] = ann
+
+    anns = list(by_pair.values())
+    if status_filter:
+        anns = [a for a in anns if a.metadata.get("status") == status_filter]
+    if source_filter:
+        anns = [a for a in anns if a.metadata.get("source") == source_filter]
+    if file_filter:
+        anns = [a for a in anns if a.file == file_filter]
+    anns.sort(key=lambda a: (a.file, a.function))
+    if not anns:
+        print("No annotations match the filter.")
+        return
+
+    print(f"{len(anns)} annotation(s):")
+    file_w = max(len(a.file) for a in anns)
+    fn_w = max(len(a.function) for a in anns)
+    for a in anns:
+        status = a.metadata.get("status", "-")
+        source = a.metadata.get("source", "-")
+        snippet = " ".join(a.body.split())[:60]
+        print(f"  {a.file:<{file_w}}  {a.function:<{fn_w}}  "
+              f"{status:<14}  {source:<5}  {snippet}")
 
 
 def _print_diff(result):

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -172,6 +172,18 @@ def main():
                               usage="raptor project report [<name>]", **_F)
     p_report.add_argument("name", nargs="?", help="Project name")
 
+    # annotations-diff
+    p_anndiff = sub.add_parser(
+        "annotations-diff",
+        help="Compare annotations between two runs",
+        usage="raptor project annotations-diff <run-a> <run-b> "
+              "[--name <project>]",
+        **_F,
+    )
+    p_anndiff.add_argument("run_a", help="First run dir or run name")
+    p_anndiff.add_argument("run_b", help="Second run dir or run name")
+    p_anndiff.add_argument("--name", help="Project name (default: active)")
+
     # diff
     p_diff = sub.add_parser("diff", help="Compare findings between two runs",
                             usage="raptor project diff <name> <run1> <run2>", **_F)
@@ -532,6 +544,27 @@ def main():
             result = diff_runs(dir1, dir2)
             print(f"Diff: {args.run1} (baseline) → {args.run2}")
             _print_diff(result)
+
+        elif args.subcommand == "annotations-diff":
+            from .annotations_diff import diff_annotations, format_diff
+            name = args.name or _get_active_project()
+            if not name:
+                print("No project specified.")
+                return
+            p = mgr.load(name)
+            if not p:
+                print(f"Project '{name}' not found.")
+                return
+            dir1 = p.output_path / args.run_a
+            dir2 = p.output_path / args.run_b
+            if not dir1.exists():
+                print(f"Run not found: {args.run_a}")
+                return
+            if not dir2.exists():
+                print(f"Run not found: {args.run_b}")
+                return
+            result = diff_annotations(dir1, dir2)
+            print(format_diff(result), end="")
 
         elif args.subcommand == "report":
             name = args.name or _get_active_project()

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -123,6 +123,11 @@ def main():
         "--grep",
         help="Case-insensitive substring search across body + metadata",
     )
+    p_anns.add_argument(
+        "--since",
+        help="Annotation file mtime within window: ``7d`` / ``24h`` / "
+             "``30m`` / ``120s`` / ``1w``",
+    )
 
     # delete
     p_delete = sub.add_parser("delete", help="Delete a project",
@@ -327,6 +332,7 @@ def main():
                 cwe_filter=args.cwe,
                 rule_id_filter=args.rule_id,
                 grep=args.grep,
+                since=args.since,
             )
 
         elif args.subcommand == "use":
@@ -881,9 +887,29 @@ def _finding_label(f):
     return f"{f.get('file', '?')}:{f.get('function', '?')}:{f.get('line', '?')}"
 
 
+def _parse_since(spec: str):
+    """Parse a ``--since`` value (``7d`` / ``24h`` etc.) into a
+    cutoff timestamp. Returns None on bad input."""
+    import time
+    if not spec:
+        return None
+    spec = spec.strip().lower()
+    multipliers = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
+    if spec[-1] in multipliers:
+        try:
+            n = float(spec[:-1])
+        except ValueError:
+            return None
+        return time.time() - n * multipliers[spec[-1]]
+    try:
+        return time.time() - float(spec)
+    except ValueError:
+        return None
+
+
 def _print_annotations(
     project, status_filter=None, source_filter=None, file_filter=None,
-    cwe_filter=None, rule_id_filter=None, grep=None,
+    cwe_filter=None, rule_id_filter=None, grep=None, since=None,
 ):
     """List annotations across all runs in the project.
 
@@ -913,30 +939,55 @@ def _print_annotations(
     # Sort by mtime (oldest first) so later writes overwrite earlier
     # in the dedup map.
     roots.sort(key=lambda r: r[0])
-    by_pair = {}  # (file, function) → Annotation
+    # Track origin root per (file, function) so the --since filter
+    # can stat the right annotation .md file post-dedup.
+    by_pair = {}  # (file, function) → (Annotation, root)
     for _mtime, root in roots:
         for ann in iter_all_annotations(root):
-            by_pair[(ann.file, ann.function)] = ann
+            by_pair[(ann.file, ann.function)] = (ann, root)
 
-    anns = list(by_pair.values())
+    pairs = list(by_pair.values())
     if status_filter:
-        anns = [a for a in anns if a.metadata.get("status") == status_filter]
+        pairs = [(a, r) for (a, r) in pairs
+                 if a.metadata.get("status") == status_filter]
     if source_filter:
-        anns = [a for a in anns if a.metadata.get("source") == source_filter]
+        pairs = [(a, r) for (a, r) in pairs
+                 if a.metadata.get("source") == source_filter]
     if file_filter:
-        anns = [a for a in anns if a.file == file_filter]
+        pairs = [(a, r) for (a, r) in pairs if a.file == file_filter]
     if cwe_filter:
-        anns = [a for a in anns if a.metadata.get("cwe") == cwe_filter]
+        pairs = [(a, r) for (a, r) in pairs
+                 if a.metadata.get("cwe") == cwe_filter]
     if rule_id_filter:
-        anns = [a for a in anns
-                if rule_id_filter in (a.metadata.get("rule_id") or "")]
+        pairs = [(a, r) for (a, r) in pairs
+                 if rule_id_filter in (a.metadata.get("rule_id") or "")]
     if grep:
         needle = grep.lower()
-        anns = [
-            a for a in anns
-            if needle in a.body.lower()
-            or any(needle in str(v).lower() for v in a.metadata.values())
-        ]
+        def _matches(a):
+            if needle in a.body.lower():
+                return True
+            return any(
+                needle in str(v).lower() for v in a.metadata.values()
+            )
+        pairs = [(a, r) for (a, r) in pairs if _matches(a)]
+    if since:
+        cutoff = _parse_since(since)
+        if cutoff is None:
+            print(f"raptor: bad --since value {since!r}; expected "
+                  f"e.g. ``7d`` / ``24h`` / ``30m``")
+            return
+        from core.annotations import annotation_path
+        kept = []
+        for a, r in pairs:
+            try:
+                mtime = annotation_path(r, a.file).stat().st_mtime
+            except OSError:
+                continue
+            if mtime >= cutoff:
+                kept.append((a, r))
+        pairs = kept
+
+    anns = [a for a, _r in pairs]
     anns.sort(key=lambda a: (a.file, a.function))
     if not anns:
         print("No annotations match the filter.")

--- a/core/project/export.py
+++ b/core/project/export.py
@@ -55,6 +55,35 @@ def validate_zip_contents(zip_path: Path) -> Tuple[bool, List[str]]:
     return len(warnings) == 0, warnings
 
 
+def _is_transient_artefact(path: Path) -> bool:
+    """Per-process / per-machine files that shouldn't ship in a
+    portable export bundle.
+
+    Currently filters:
+      * ``*.lock`` — POSIX advisory lock files (e.g.
+        ``annotations/<src>.md.lock`` from
+        ``core.annotations.storage._file_lock``). They carry no
+        data — they're just stable file descriptors for
+        ``fcntl.flock``. A new importing process creates its own
+        lock file on first write; shipping the original is bundle
+        bloat and operator confusion.
+      * ``.annotation-*.tmp`` — orphaned tempfiles from
+        interrupted atomic writes. Should already be cleaned up
+        by the writer's ``except`` block, but this is belt-and-
+        braces.
+
+    Pre-existing exclusions are NOT widened by this commit — the
+    historical behaviour for ``.reads-manifest`` and
+    ``.raptor-run.json`` is preserved.
+    """
+    name = path.name
+    if name.endswith(".lock"):
+        return True
+    if name.startswith(".annotation-") and name.endswith(".tmp"):
+        return True
+    return False
+
+
 def export_project(project_output_dir: Path, dest_path: Path,
                    project_json_path: Path = None,
                    force: bool = False) -> Dict[str, str]:
@@ -87,12 +116,17 @@ def export_project(project_output_dir: Path, dest_path: Path,
     dest_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Build zip manually to skip symlinks (shutil.make_archive follows them)
+    # plus per-process / transient artefacts that shouldn't ship in a
+    # portable archive (POSIX advisory lock files, tempfile leftovers).
     with zipfile.ZipFile(dest_path, "w", zipfile.ZIP_DEFLATED) as zf:
         for item in project_output_dir.rglob("*"):
             if item.is_symlink():
                 logger.debug(f"Skipping symlink in export: {item}")
                 continue
             if item.is_file():
+                if _is_transient_artefact(item):
+                    logger.debug(f"Skipping transient artefact: {item}")
+                    continue
                 arcname = f"{project_output_dir.name}/{item.relative_to(project_output_dir)}"
                 zf.write(item, arcname)
         # Include project metadata if provided

--- a/core/project/report.py
+++ b/core/project/report.py
@@ -301,6 +301,98 @@ def export_findings_directory(
     }
 
 
+def gather_project_annotations(project) -> List[Dict[str, Any]]:
+    """Walk every run dir's ``annotations/`` subdir plus the project's
+    own top-level ``annotations/`` dir, dedup on (file, function),
+    project-level wins. Returns a list of dicts with ``file``,
+    ``function``, ``status``, ``source``, ``body``, ``metadata``.
+
+    Used by the project report (counts + annotations.md section)
+    and reused by ``raptor project annotations``-style consumers.
+    """
+    from core.annotations import iter_all_annotations
+
+    roots = []
+    for rd in project.get_run_dirs(sweep=False):
+        ann_dir = rd / "annotations"
+        if ann_dir.exists():
+            roots.append((rd.stat().st_mtime, ann_dir))
+    project_ann = project.output_path / "annotations"
+    if project_ann.exists():
+        roots.append((float("inf"), project_ann))
+
+    if not roots:
+        return []
+
+    roots.sort(key=lambda r: r[0])
+    by_pair = {}
+    for _mt, root in roots:
+        for ann in iter_all_annotations(root):
+            by_pair[(ann.file, ann.function)] = ann
+
+    out = []
+    for ann in by_pair.values():
+        out.append({
+            "file": ann.file,
+            "function": ann.function,
+            "status": ann.metadata.get("status"),
+            "source": ann.metadata.get("source"),
+            "body": ann.body,
+            "metadata": dict(ann.metadata),
+        })
+    out.sort(key=lambda r: (r["file"], r["function"]))
+    return out
+
+
+def render_annotations_markdown(records: List[Dict[str, Any]],
+                                project_name: str) -> str:
+    """Render the deduped project-level annotation list as markdown
+    suitable for ``annotations.md`` in the report dir."""
+    lines: List[str] = [f"# Annotations — {project_name}", ""]
+    if not records:
+        lines.append("_No annotations._")
+        return "\n".join(lines) + "\n"
+
+    # Status counts up top.
+    status_counts: Dict[str, int] = {}
+    source_counts: Dict[str, int] = {}
+    for r in records:
+        s = r.get("status") or "—"
+        src = r.get("source") or "—"
+        status_counts[s] = status_counts.get(s, 0) + 1
+        source_counts[src] = source_counts.get(src, 0) + 1
+
+    lines.append(f"_{len(records)} unique annotation(s) "
+                 f"(deduped, project-level wins)._")
+    lines.append("")
+    lines.append("**By status:** " + ", ".join(
+        f"{k}={v}" for k, v in sorted(status_counts.items())
+    ))
+    lines.append("")
+    lines.append("**By source:** " + ", ".join(
+        f"{k}={v}" for k, v in sorted(source_counts.items())
+    ))
+    lines.append("")
+    lines.append("## Per-function entries")
+    lines.append("")
+    for r in records:
+        # Header line: file:function (status, source)
+        title = f"### `{r['file']}` :: `{r['function']}`"
+        meta = []
+        if r["status"]:
+            meta.append(f"status=`{r['status']}`")
+        if r["source"]:
+            meta.append(f"source=`{r['source']}`")
+        lines.append(title)
+        if meta:
+            lines.append(" · ".join(meta))
+        if r["body"]:
+            lines.append("")
+            lines.append(r["body"])
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
 def generate_project_report(project) -> Dict[str, Any]:
     """Generate a merged report across all runs in _report/ directory.
 
@@ -314,7 +406,7 @@ def generate_project_report(project) -> Dict[str, Any]:
 
     run_dirs = project.get_run_dirs(sweep=True)
     if not run_dirs:
-        return {"findings": 0, "runs": 0}
+        return {"findings": 0, "runs": 0, "annotations": 0}
 
     # Merge findings
     merged = merge_findings(run_dirs)
@@ -325,11 +417,20 @@ def generate_project_report(project) -> Dict[str, Any]:
         project_name=project.name,
     )
 
+    # Aggregate annotations across runs + project-level overrides.
+    annotations = gather_project_annotations(project)
+    save_json(report_dir / "annotations.json", {"annotations": annotations})
+    annotations_md = render_annotations_markdown(annotations, project.name)
+    annotations_md_path = report_dir / "annotations.md"
+    annotations_md_path.write_text(annotations_md, encoding="utf-8")
+
     return {
         "findings": len(merged),
         "runs": len(run_dirs),
+        "annotations": len(annotations),
         "report_dir": str(report_dir),
         "findings_dir": findings_export["findings_dir"],
         "aggregate_markdown": findings_export["aggregate_markdown"],
         "finding_buckets": findings_export["counts"],
+        "annotations_markdown": str(annotations_md_path),
     }

--- a/core/project/tests/test_annotations_cmd.py
+++ b/core/project/tests/test_annotations_cmd.py
@@ -184,6 +184,43 @@ class TestPrintAnnotations(unittest.TestCase):
             assert "1 annotation(s)" in output
             assert " a " in output
 
+    def test_since_filter_recent(self):
+        """All freshly-written annotations are within a wide window."""
+        with TemporaryDirectory() as d:
+            project = _build_project(Path(d))
+            with patch("sys.stdout", new_callable=StringIO) as buf:
+                _print_annotations(project, since="7d")
+            output = buf.getvalue()
+            assert "2 annotation(s)" in output
+
+    def test_since_filter_excludes_old(self):
+        import os, time
+        with TemporaryDirectory() as d:
+            project = _build_project(Path(d))
+            # Backdate the run-level annotation file by 30 days.
+            for run in project._run_dirs:
+                for md in (run / "annotations").rglob("*.md"):
+                    old_ts = time.time() - (30 * 86400)
+                    os.utime(md, (old_ts, old_ts))
+            # Also backdate the project-level file.
+            for md in (Path(project.output_dir) / "annotations").rglob("*.md"):
+                old_ts = time.time() - (30 * 86400)
+                os.utime(md, (old_ts, old_ts))
+            with patch("sys.stdout", new_callable=StringIO) as buf:
+                _print_annotations(project, since="7d")
+            output = buf.getvalue()
+            # All annotations are now older than 7d → filter shows
+            # "no annotations match".
+            assert "No annotations match" in output
+
+    def test_since_bad_value_errors(self):
+        with TemporaryDirectory() as d:
+            project = _build_project(Path(d))
+            with patch("sys.stdout", new_callable=StringIO) as buf:
+                _print_annotations(project, since="garbage")
+            output = buf.getvalue()
+            assert "bad --since" in output
+
     def test_no_runs_no_project_annotations(self):
         with TemporaryDirectory() as d:
             project_root = Path(d) / "empty"

--- a/core/project/tests/test_annotations_cmd.py
+++ b/core/project/tests/test_annotations_cmd.py
@@ -1,0 +1,144 @@
+"""Tests for ``/project annotations`` subcommand.
+
+Builds a fake project with two run dirs each carrying annotations,
+plus the project's top-level annotations dir, and verifies the
+``annotations`` subcommand walks all three and prints a deduped /
+filtered listing.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from core.annotations import Annotation, write_annotation
+from core.project.cli import _print_annotations
+
+
+class _FakeProject:
+    """Minimal Project shim — only the attributes _print_annotations
+    actually touches."""
+
+    def __init__(self, output_dir: Path, run_dirs):
+        self.output_dir = str(output_dir)
+        self._run_dirs = run_dirs
+
+    def get_run_dirs(self, sweep=False):
+        return list(self._run_dirs)
+
+
+def _build_project(tmp_path: Path):
+    """Create: two run dirs each with annotations, plus project-level
+    annotations dir."""
+    project_root = tmp_path / "myproject"
+    project_root.mkdir()
+
+    run_a = project_root / "run-a"
+    run_a.mkdir()
+    (run_a / ".raptor-run.json").write_text("{}")  # marker
+    write_annotation(run_a / "annotations", Annotation(
+        file="src/foo.py", function="login",
+        body="LLM run-a body", metadata={
+            "source": "llm", "status": "finding", "cwe": "CWE-89",
+        },
+    ))
+
+    run_b = project_root / "run-b"
+    run_b.mkdir()
+    (run_b / ".raptor-run.json").write_text("{}")
+    write_annotation(run_b / "annotations", Annotation(
+        file="src/foo.py", function="logout",
+        body="LLM run-b body", metadata={
+            "source": "llm", "status": "clean",
+        },
+    ))
+
+    # Project-level (operator notes).
+    write_annotation(project_root / "annotations", Annotation(
+        file="src/foo.py", function="login",
+        body="Operator override: actually clean after manual review",
+        metadata={"source": "human", "status": "clean"},
+    ))
+
+    return _FakeProject(project_root, [run_a, run_b])
+
+
+class TestPrintAnnotations(unittest.TestCase):
+    def test_lists_all_unique_pairs(self):
+        with TemporaryDirectory() as d:
+            project = _build_project(Path(d))
+            with patch("sys.stdout", new_callable=StringIO) as buf:
+                _print_annotations(project)
+            output = buf.getvalue()
+            # Two unique (file, function) pairs: (foo.py, login) +
+            # (foo.py, logout). The login annotation from run-a is
+            # superseded by the project-level human one.
+            assert "2 annotation(s)" in output
+            assert "src/foo.py" in output
+            assert "login" in output
+            assert "logout" in output
+
+    def test_project_level_overrides_run_level(self):
+        with TemporaryDirectory() as d:
+            project = _build_project(Path(d))
+            with patch("sys.stdout", new_callable=StringIO) as buf:
+                _print_annotations(project)
+            output = buf.getvalue()
+            # The login row should show source=human (project-level),
+            # not source=llm (run-a).
+            login_line = [l for l in output.splitlines() if "login" in l][0]
+            assert "human" in login_line
+
+    def test_filter_by_status(self):
+        with TemporaryDirectory() as d:
+            project = _build_project(Path(d))
+            with patch("sys.stdout", new_callable=StringIO) as buf:
+                _print_annotations(project, status_filter="clean")
+            output = buf.getvalue()
+            # Both surviving rows are clean (logout=clean, login=clean
+            # after override).
+            assert "2 annotation(s)" in output
+            with patch("sys.stdout", new_callable=StringIO) as buf:
+                _print_annotations(project, status_filter="finding")
+            output = buf.getvalue()
+            # No finding rows survive the override.
+            assert "No annotations match" in output
+
+    def test_filter_by_source(self):
+        with TemporaryDirectory() as d:
+            project = _build_project(Path(d))
+            with patch("sys.stdout", new_callable=StringIO) as buf:
+                _print_annotations(project, source_filter="human")
+            output = buf.getvalue()
+            assert "1 annotation(s)" in output
+            assert "login" in output
+
+    def test_filter_by_file(self):
+        with TemporaryDirectory() as d:
+            project = _build_project(Path(d))
+            with patch("sys.stdout", new_callable=StringIO) as buf:
+                _print_annotations(project, file_filter="src/foo.py")
+            output = buf.getvalue()
+            assert "2 annotation(s)" in output
+            with patch("sys.stdout", new_callable=StringIO) as buf:
+                _print_annotations(project, file_filter="src/missing.py")
+            output = buf.getvalue()
+            assert "No annotations match" in output
+
+    def test_no_runs_no_project_annotations(self):
+        with TemporaryDirectory() as d:
+            project_root = Path(d) / "empty"
+            project_root.mkdir()
+            project = _FakeProject(project_root, [])
+            with patch("sys.stdout", new_callable=StringIO) as buf:
+                _print_annotations(project)
+            output = buf.getvalue()
+            assert "No annotations" in output
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core/project/tests/test_annotations_cmd.py
+++ b/core/project/tests/test_annotations_cmd.py
@@ -129,6 +129,61 @@ class TestPrintAnnotations(unittest.TestCase):
             output = buf.getvalue()
             assert "No annotations match" in output
 
+    def test_filter_by_cwe(self):
+        with TemporaryDirectory() as d:
+            project = _build_project(Path(d))
+            with patch("sys.stdout", new_callable=StringIO) as buf:
+                _print_annotations(project, cwe_filter="CWE-89")
+            output = buf.getvalue()
+            # Only run-a's login had CWE-89, but it's overridden by
+            # the project-level entry without a CWE — so no match.
+            assert "No annotations match" in output
+
+    def test_filter_by_rule_id_substring(self):
+        with TemporaryDirectory() as d:
+            out = Path(d) / "p"
+            out.mkdir()
+            run = out / "run-x"
+            run.mkdir()
+            write_annotation(run / "annotations", Annotation(
+                file="src/foo.py", function="a",
+                metadata={"source": "llm", "rule_id": "py/sql-injection"},
+            ))
+            write_annotation(run / "annotations", Annotation(
+                file="src/foo.py", function="b",
+                metadata={"source": "llm", "rule_id": "cpp/buffer-overflow"},
+            ))
+            project = _FakeProject(out, [run])
+            with patch("sys.stdout", new_callable=StringIO) as buf:
+                _print_annotations(project, rule_id_filter="py/")
+            output = buf.getvalue()
+            assert "1 annotation(s)" in output
+            assert "::a" in output or " a " in output  # function name
+            assert "::b" not in output
+
+    def test_grep(self):
+        with TemporaryDirectory() as d:
+            out = Path(d) / "p"
+            out.mkdir()
+            run = out / "run-x"
+            run.mkdir()
+            write_annotation(run / "annotations", Annotation(
+                file="src/foo.py", function="a",
+                body="uses subprocess.call shell=True",
+                metadata={"source": "llm"},
+            ))
+            write_annotation(run / "annotations", Annotation(
+                file="src/foo.py", function="b",
+                body="constant-time compare",
+                metadata={"source": "llm"},
+            ))
+            project = _FakeProject(out, [run])
+            with patch("sys.stdout", new_callable=StringIO) as buf:
+                _print_annotations(project, grep="subprocess")
+            output = buf.getvalue()
+            assert "1 annotation(s)" in output
+            assert " a " in output
+
     def test_no_runs_no_project_annotations(self):
         with TemporaryDirectory() as d:
             project_root = Path(d) / "empty"

--- a/core/project/tests/test_annotations_diff.py
+++ b/core/project/tests/test_annotations_diff.py
@@ -1,0 +1,160 @@
+"""Tests for ``core.project.annotations_diff``.
+
+Builds two run dirs with overlapping annotation sets and asserts
+the diff classifier puts each pair in the right bucket (added,
+removed, changed, unchanged).
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from core.annotations import Annotation, write_annotation
+from core.project.annotations_diff import (
+    diff_annotations,
+    format_diff,
+)
+
+
+class TestDiffAnnotations(unittest.TestCase):
+    def _setup_runs(self, tmp_path: Path):
+        run_a = tmp_path / "run-a"
+        run_b = tmp_path / "run-b"
+        run_a.mkdir()
+        run_b.mkdir()
+
+        # Same in both — unchanged.
+        for run in (run_a, run_b):
+            write_annotation(run / "annotations", Annotation(
+                file="src/foo.py", function="same",
+                body="identical body",
+                metadata={"source": "llm", "status": "clean"},
+            ))
+
+        # In A only — removed.
+        write_annotation(run_a / "annotations", Annotation(
+            file="src/foo.py", function="dropped",
+            body="x", metadata={"source": "llm", "status": "clean"},
+        ))
+
+        # In B only — added.
+        write_annotation(run_b / "annotations", Annotation(
+            file="src/foo.py", function="new",
+            body="y", metadata={"source": "llm", "status": "finding"},
+        ))
+
+        # In both, status changed — changed.
+        write_annotation(run_a / "annotations", Annotation(
+            file="src/foo.py", function="status_flip",
+            body="x", metadata={"source": "llm", "status": "finding"},
+        ))
+        write_annotation(run_b / "annotations", Annotation(
+            file="src/foo.py", function="status_flip",
+            body="x", metadata={"source": "llm", "status": "clean"},
+        ))
+
+        # In both, body changed — changed.
+        write_annotation(run_a / "annotations", Annotation(
+            file="src/foo.py", function="body_flip",
+            body="initial reasoning",
+            metadata={"source": "llm", "status": "clean"},
+        ))
+        write_annotation(run_b / "annotations", Annotation(
+            file="src/foo.py", function="body_flip",
+            body="updated reasoning after re-review",
+            metadata={"source": "llm", "status": "clean"},
+        ))
+
+        return run_a, run_b
+
+    def test_classification(self):
+        with TemporaryDirectory() as d:
+            run_a, run_b = self._setup_runs(Path(d))
+            result = diff_annotations(run_a, run_b)
+            assert len(result["added"]) == 1
+            assert result["added"][0]["function"] == "new"
+            assert len(result["removed"]) == 1
+            assert result["removed"][0]["function"] == "dropped"
+            assert len(result["changed"]) == 2
+            changed_names = {c["after"]["function"] for c in result["changed"]}
+            assert changed_names == {"status_flip", "body_flip"}
+            assert len(result["unchanged"]) == 1
+            assert result["unchanged"][0]["function"] == "same"
+
+    def test_irrelevant_metadata_drift_is_unchanged(self):
+        """Updating ``hash`` or ``rule_id`` doesn't count as changed
+        — operators care about body + status, not file checksums."""
+        with TemporaryDirectory() as d:
+            run_a = Path(d) / "a"; run_a.mkdir()
+            run_b = Path(d) / "b"; run_b.mkdir()
+            write_annotation(run_a / "annotations", Annotation(
+                file="src/x.py", function="f", body="same body",
+                metadata={"source": "llm", "status": "clean",
+                          "hash": "abc123"},
+            ))
+            write_annotation(run_b / "annotations", Annotation(
+                file="src/x.py", function="f", body="same body",
+                metadata={"source": "llm", "status": "clean",
+                          "hash": "def456"},  # different hash
+            ))
+            result = diff_annotations(run_a, run_b)
+            assert len(result["unchanged"]) == 1
+            assert len(result["changed"]) == 0
+
+    def test_empty_runs(self):
+        with TemporaryDirectory() as d:
+            run_a = Path(d) / "a"; run_a.mkdir()
+            run_b = Path(d) / "b"; run_b.mkdir()
+            result = diff_annotations(run_a, run_b)
+            assert result["added"] == []
+            assert result["removed"] == []
+            assert result["changed"] == []
+            assert result["unchanged"] == []
+
+    def test_no_annotations_subdir(self):
+        """Run dirs without ``annotations/`` subdirs treated as empty."""
+        with TemporaryDirectory() as d:
+            run_a = Path(d) / "a"; run_a.mkdir()
+            run_b = Path(d) / "b"; run_b.mkdir()
+            # No annotations/ in either.
+            result = diff_annotations(run_a, run_b)
+            assert all(len(result[k]) == 0
+                       for k in ("added", "removed", "changed", "unchanged"))
+
+
+class TestFormatDiff(unittest.TestCase):
+    def test_includes_counts(self):
+        with TemporaryDirectory() as d:
+            run_a = Path(d) / "a"; run_a.mkdir()
+            run_b = Path(d) / "b"; run_b.mkdir()
+            write_annotation(run_b / "annotations", Annotation(
+                file="src/x.py", function="new", body="x",
+                metadata={"source": "llm", "status": "finding"},
+            ))
+            result = diff_annotations(run_a, run_b)
+            text = format_diff(result)
+            assert "added=1" in text
+            assert "removed=0" in text
+            assert "+ src/x.py::new" in text
+
+    def test_status_change_rendered(self):
+        with TemporaryDirectory() as d:
+            run_a = Path(d) / "a"; run_a.mkdir()
+            run_b = Path(d) / "b"; run_b.mkdir()
+            write_annotation(run_a / "annotations", Annotation(
+                file="src/x.py", function="f", body="x",
+                metadata={"source": "llm", "status": "finding"},
+            ))
+            write_annotation(run_b / "annotations", Annotation(
+                file="src/x.py", function="f", body="x",
+                metadata={"source": "llm", "status": "clean"},
+            ))
+            result = diff_annotations(run_a, run_b)
+            text = format_diff(result)
+            assert "finding → clean" in text
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core/project/tests/test_export_annotations_roundtrip.py
+++ b/core/project/tests/test_export_annotations_roundtrip.py
@@ -177,14 +177,15 @@ class TestExportImportRoundTrip(unittest.TestCase):
                 )
 
     def test_lock_files_excluded_from_export(self):
-        """``.md.lock`` sibling files exist on disk but should NOT
-        be included in the export — they're per-process locking
-        primitives, not data."""
+        """``.md.lock`` sibling files exist on disk but MUST NOT
+        be included in the export — they're per-process advisory-
+        lock primitives, not data, and shipping them across machines
+        is bundle bloat + operator confusion."""
         with TemporaryDirectory() as d:
             d = Path(d)
             (d / "src").mkdir()
             src = _build_project_with_annotations(d / "src")
-            # Verify lock files exist before export.
+            # Verify lock files exist on disk before export.
             from core.annotations.storage import _HAS_FCNTL
             if _HAS_FCNTL:
                 lock_files = list(src.rglob("*.md.lock"))
@@ -201,24 +202,49 @@ class TestExportImportRoundTrip(unittest.TestCase):
             }))
             export_project(src, zip_path, project_json_path=project_json)
 
-            # Verify zip doesn't contain .md.lock entries.
             import zipfile
             with zipfile.ZipFile(zip_path) as zf:
-                # NOTE: this is currently a regression-pin test — if
-                # the export starts including lock files, this will
-                # fail and we'll know to filter them. Today, the export
-                # just zips everything in the dir.
-                lock_in_zip = [
-                    n for n in zf.namelist()
-                    if n.endswith(".md.lock")
-                ]
-            # If lock files are getting included, this surfaces it.
-            # NOT failing the test hard — the export today doesn't
-            # filter, so we accept the current state. Pin: at least
-            # data files survive.
+                names = zf.namelist()
+            lock_in_zip = [n for n in names if n.endswith(".lock")]
+            assert lock_in_zip == [], (
+                f"export must filter lock files; got {lock_in_zip}"
+            )
+            # Data files survive.
             assert any(
                 n.endswith(".md") and not n.endswith(".md.lock")
-                for n in zipfile.ZipFile(zip_path).namelist()
+                for n in names
+            )
+
+    def test_orphaned_tempfiles_excluded_from_export(self):
+        """``.annotation-*.tmp`` orphan tempfiles (e.g. from a writer
+        crashed mid-rename) shouldn't ship either. Pin the filter."""
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "src").mkdir()
+            src = _build_project_with_annotations(d / "src")
+            # Plant a fake orphan tempfile.
+            ann_dir = src / "annotations" / "src"
+            ann_dir.mkdir(parents=True, exist_ok=True)
+            fake_tmp = ann_dir / ".annotation-orphan-xyz.tmp"
+            fake_tmp.write_text("would-be tempfile leftover")
+            assert fake_tmp.exists()
+
+            zip_path = d / "myproj.zip"
+            project_json = d / "myproj.json"
+            project_json.write_text(json.dumps({
+                "name": "myproj",
+                "target": "/tmp/fake-target",
+                "output_dir": str(src),
+            }))
+            export_project(src, zip_path, project_json_path=project_json)
+
+            import zipfile
+            with zipfile.ZipFile(zip_path) as zf:
+                names = zf.namelist()
+            tmp_in_zip = [n for n in names
+                          if "/.annotation-" in n and n.endswith(".tmp")]
+            assert tmp_in_zip == [], (
+                f"export must filter orphan tempfiles; got {tmp_in_zip}"
             )
 
 

--- a/core/project/tests/test_export_annotations_roundtrip.py
+++ b/core/project/tests/test_export_annotations_roundtrip.py
@@ -1,0 +1,226 @@
+"""Round-trip verification: ``/project export`` then import preserves
+annotation tree fidelity.
+
+Annotations live under ``<project_output_dir>/annotations/`` and
+under each run's ``<run_dir>/annotations/``. Both should survive
+the zip round-trip exactly — same content, same metadata, same
+on-disk layout.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from core.annotations import (
+    Annotation,
+    iter_all_annotations,
+    write_annotation,
+)
+from core.project.export import export_project, import_project
+
+
+def _build_project_with_annotations(out_root: Path) -> Path:
+    """Create a project with annotations at both project-level and
+    inside two run dirs."""
+    project_out = out_root / "myproj"
+    project_out.mkdir()
+
+    # Project-level annotations (operator notes).
+    write_annotation(project_out / "annotations", Annotation(
+        file="src/auth.py", function="check_pw",
+        body="Operator: reviewed clean, constant-time compare.",
+        metadata={"source": "human", "status": "clean", "cwe": "—"},
+    ))
+    write_annotation(project_out / "annotations", Annotation(
+        file="src/auth.py", function="login",
+        body="Operator: deferred review, see ticket BUG-42.",
+        metadata={"source": "human", "status": "suspicious",
+                  "ticket": "BUG-42"},
+    ))
+
+    # Two run dirs, each with their own annotations.
+    for ts in ("20260507_120000", "20260508_120000"):
+        run_dir = project_out / ts
+        run_dir.mkdir()
+        (run_dir / ".raptor-run.json").write_text("{}")
+        write_annotation(run_dir / "annotations", Annotation(
+            file="src/auth.py", function=f"f_{ts}",
+            body=f"LLM analysis from run {ts}",
+            metadata={"source": "llm", "status": "finding",
+                      "rule_id": "py/sql-injection"},
+        ))
+
+    return project_out
+
+
+def _collect_records(annotation_root: Path) -> list:
+    """Read an annotation tree into a list of dict records sorted
+    by (file, function) for stable equality checks."""
+    out = []
+    for ann in iter_all_annotations(annotation_root):
+        out.append({
+            "file": ann.file,
+            "function": ann.function,
+            "body": ann.body,
+            "metadata": dict(ann.metadata),
+        })
+    return sorted(out, key=lambda r: (r["file"], r["function"]))
+
+
+class TestExportImportRoundTrip(unittest.TestCase):
+    def test_project_level_annotations_preserved(self):
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "src").mkdir()
+            src = _build_project_with_annotations(d / "src")
+
+            # Capture pre-export state.
+            before = _collect_records(src / "annotations")
+            assert len(before) == 2
+
+            # Export → import.
+            zip_path = d / "myproj.zip"
+            project_json = d / "myproj.json"
+            project_json.write_text(json.dumps({
+                "name": "myproj",
+                "target": "/tmp/fake-target",
+                "output_dir": str(src),
+            }))
+            export_project(src, zip_path, project_json_path=project_json)
+            assert zip_path.exists()
+
+            projects_dir = d / "projects"
+            output_base = d / "imported_out"
+            projects_dir.mkdir()
+            output_base.mkdir()
+            result = import_project(zip_path, projects_dir,
+                                    output_base=output_base)
+            imported_root = Path(result["output_dir"])
+
+            after = _collect_records(imported_root / "annotations")
+            assert after == before
+
+    def test_run_level_annotations_preserved(self):
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "src").mkdir()
+            src = _build_project_with_annotations(d / "src")
+
+            zip_path = d / "myproj.zip"
+            project_json = d / "myproj.json"
+            project_json.write_text(json.dumps({
+                "name": "myproj",
+                "target": "/tmp/fake-target",
+                "output_dir": str(src),
+            }))
+            export_project(src, zip_path, project_json_path=project_json)
+
+            projects_dir = d / "projects"
+            output_base = d / "imported_out"
+            projects_dir.mkdir()
+            output_base.mkdir()
+            result = import_project(zip_path, projects_dir,
+                                    output_base=output_base)
+            imported_root = Path(result["output_dir"])
+
+            # Each run dir's annotations should match.
+            for ts in ("20260507_120000", "20260508_120000"):
+                run_a_before = _collect_records(
+                    src / ts / "annotations"
+                )
+                run_a_after = _collect_records(
+                    imported_root / ts / "annotations"
+                )
+                assert run_a_after == run_a_before
+
+    def test_full_tree_byte_equal(self):
+        """Stronger check: the on-disk markdown content is byte-for-
+        byte equal (so the version marker, atomic-write artefacts,
+        and metadata formatting all survive)."""
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "src").mkdir()
+            src = _build_project_with_annotations(d / "src")
+            zip_path = d / "myproj.zip"
+            project_json = d / "myproj.json"
+            project_json.write_text(json.dumps({
+                "name": "myproj",
+                "target": "/tmp/fake-target",
+                "output_dir": str(src),
+            }))
+            export_project(src, zip_path, project_json_path=project_json)
+
+            projects_dir = d / "projects"
+            output_base = d / "imported_out"
+            projects_dir.mkdir()
+            output_base.mkdir()
+            result = import_project(zip_path, projects_dir,
+                                    output_base=output_base)
+            imported_root = Path(result["output_dir"])
+
+            # Gather all .md files in both trees.
+            def md_files(root):
+                return sorted(
+                    str(p.relative_to(root))
+                    for p in root.rglob("*.md")
+                )
+
+            assert md_files(src) == md_files(imported_root)
+            for rel in md_files(src):
+                src_bytes = (src / rel).read_bytes()
+                imp_bytes = (imported_root / rel).read_bytes()
+                assert src_bytes == imp_bytes, (
+                    f"{rel}: byte mismatch after round-trip"
+                )
+
+    def test_lock_files_excluded_from_export(self):
+        """``.md.lock`` sibling files exist on disk but should NOT
+        be included in the export — they're per-process locking
+        primitives, not data."""
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "src").mkdir()
+            src = _build_project_with_annotations(d / "src")
+            # Verify lock files exist before export.
+            from core.annotations.storage import _HAS_FCNTL
+            if _HAS_FCNTL:
+                lock_files = list(src.rglob("*.md.lock"))
+                assert len(lock_files) > 0, (
+                    "test setup: lock files should exist on POSIX"
+                )
+
+            zip_path = d / "myproj.zip"
+            project_json = d / "myproj.json"
+            project_json.write_text(json.dumps({
+                "name": "myproj",
+                "target": "/tmp/fake-target",
+                "output_dir": str(src),
+            }))
+            export_project(src, zip_path, project_json_path=project_json)
+
+            # Verify zip doesn't contain .md.lock entries.
+            import zipfile
+            with zipfile.ZipFile(zip_path) as zf:
+                # NOTE: this is currently a regression-pin test — if
+                # the export starts including lock files, this will
+                # fail and we'll know to filter them. Today, the export
+                # just zips everything in the dir.
+                lock_in_zip = [
+                    n for n in zf.namelist()
+                    if n.endswith(".md.lock")
+                ]
+            # If lock files are getting included, this surfaces it.
+            # NOT failing the test hard — the export today doesn't
+            # filter, so we accept the current state. Pin: at least
+            # data files survive.
+            assert any(
+                n.endswith(".md") and not n.endswith(".md.lock")
+                for n in zipfile.ZipFile(zip_path).namelist()
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core/project/tests/test_report_annotations.py
+++ b/core/project/tests/test_report_annotations.py
@@ -1,0 +1,129 @@
+"""Tests for annotation handling in ``generate_project_report``.
+
+Verifies the report includes annotation counts and writes
+``annotations.json`` + ``annotations.md`` next to the merged
+findings export.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from core.annotations import Annotation, write_annotation
+from core.project.report import (
+    gather_project_annotations,
+    generate_project_report,
+    render_annotations_markdown,
+)
+
+
+class _FakeProject:
+    def __init__(self, output_dir: Path, run_dirs, name="test"):
+        self.name = name
+        self.output_path = output_dir
+        self.output_dir = str(output_dir)
+        self._run_dirs = run_dirs
+
+    def get_run_dirs(self, sweep=False):
+        return list(self._run_dirs)
+
+
+def _build_project(tmp_path: Path):
+    out = tmp_path / "myproj"
+    out.mkdir()
+    run_a = out / "run-a"
+    run_a.mkdir()
+    write_annotation(run_a / "annotations", Annotation(
+        file="src/foo.py", function="login",
+        body="LLM run-a body",
+        metadata={"source": "llm", "status": "finding"},
+    ))
+    write_annotation(run_a / "annotations", Annotation(
+        file="src/foo.py", function="logout",
+        body="LLM run-a body 2",
+        metadata={"source": "llm", "status": "clean"},
+    ))
+    # Project-level operator override on login.
+    write_annotation(out / "annotations", Annotation(
+        file="src/foo.py", function="login",
+        body="Operator override",
+        metadata={"source": "human", "status": "clean"},
+    ))
+    return _FakeProject(out, [run_a])
+
+
+class TestGatherProjectAnnotations(unittest.TestCase):
+    def test_dedupes_with_project_priority(self):
+        with TemporaryDirectory() as d:
+            project = _build_project(Path(d))
+            recs = gather_project_annotations(project)
+            assert len(recs) == 2  # login + logout
+            login = next(r for r in recs if r["function"] == "login")
+            assert login["source"] == "human"  # project-level wins
+            assert "Operator override" in login["body"]
+
+    def test_no_annotations_returns_empty(self):
+        with TemporaryDirectory() as d:
+            out = Path(d) / "p"
+            out.mkdir()
+            project = _FakeProject(out, [])
+            assert gather_project_annotations(project) == []
+
+
+class TestRenderAnnotationsMarkdown(unittest.TestCase):
+    def test_empty_renders_no_annotations(self):
+        md = render_annotations_markdown([], "test")
+        assert "No annotations" in md
+
+    def test_includes_counts_and_per_function(self):
+        records = [
+            {"file": "a.py", "function": "f1",
+             "status": "clean", "source": "human",
+             "body": "ok", "metadata": {}},
+            {"file": "a.py", "function": "f2",
+             "status": "finding", "source": "llm",
+             "body": "bad", "metadata": {}},
+        ]
+        md = render_annotations_markdown(records, "myproj")
+        assert "Annotations — myproj" in md
+        assert "2 unique annotation(s)" in md
+        assert "clean=1" in md
+        assert "finding=1" in md
+        assert "human=1" in md
+        assert "llm=1" in md
+        assert "`a.py`" in md
+        assert "`f1`" in md
+        assert "`f2`" in md
+
+
+class TestGenerateProjectReport(unittest.TestCase):
+    def test_writes_annotations_json_and_md(self):
+        with TemporaryDirectory() as d:
+            project = _build_project(Path(d))
+            # Add a run marker so get_run_dirs returns it via sweep.
+            (project._run_dirs[0] / ".raptor-run.json").write_text("{}")
+            stats = generate_project_report(project)
+            assert stats["annotations"] == 2
+            report_dir = Path(stats["report_dir"])
+            assert (report_dir / "annotations.json").exists()
+            assert (report_dir / "annotations.md").exists()
+            data = json.loads((report_dir / "annotations.json").read_text())
+            assert len(data["annotations"]) == 2
+            md = (report_dir / "annotations.md").read_text()
+            assert "login" in md
+            assert "logout" in md
+
+    def test_no_runs_returns_zero_annotations(self):
+        with TemporaryDirectory() as d:
+            out = Path(d) / "empty"
+            out.mkdir()
+            project = _FakeProject(out, [])
+            stats = generate_project_report(project)
+            assert stats == {"findings": 0, "runs": 0, "annotations": 0}
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/libexec/raptor-annotate
+++ b/libexec/raptor-annotate
@@ -110,6 +110,54 @@ def _resolve_base(explicit: Optional[str]) -> Path:
     sys.exit(2)
 
 
+def _find_checklist(base_dir: Path, explicit: Optional[str]) -> Optional[Path]:
+    """Locate a checklist.json for inventory lookups.
+
+    Priority:
+      1. ``--checklist PATH`` if explicit.
+      2. ``<base_dir>/../checklist.json`` (works when ``base_dir`` is
+         a run dir's ``annotations`` subdir — most common case).
+      3. Walk up two more levels in case ``base_dir`` is nested deeper.
+    """
+    if explicit:
+        p = Path(explicit)
+        return p if p.exists() else None
+    candidate = base_dir.parent / "checklist.json"
+    if candidate.exists():
+        return candidate
+    # Two more levels up — generous but bounded.
+    candidate = base_dir.parent.parent / "checklist.json"
+    if candidate.exists():
+        return candidate
+    candidate = base_dir.parent.parent.parent / "checklist.json"
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def _lookup_bounds_by_name(
+    checklist_path: Path, file_path: str, function: str,
+) -> Optional[tuple[int, int]]:
+    """Look up ``(line_start, line_end)`` for ``function`` in
+    ``file_path`` from a checklist. Returns ``None`` if either is
+    missing or the function isn't in the inventory."""
+    try:
+        import json
+        data = json.loads(checklist_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    for file_entry in data.get("files", []):
+        if file_entry.get("path") != file_path:
+            continue
+        for item in file_entry.get("items", file_entry.get("functions", [])):
+            if item.get("name") == function:
+                ls = item.get("line_start")
+                le = item.get("line_end")
+                if ls and le:
+                    return int(ls), int(le)
+    return None
+
+
 def _read_body(opts: argparse.Namespace) -> str:
     """Body resolution: explicit ``-m`` wins, else --body-file (or
     stdin), else empty."""
@@ -156,12 +204,24 @@ def cmd_add(opts: argparse.Namespace) -> int:
     if opts.cwe:
         metadata["cwe"] = opts.cwe
     metadata.setdefault("source", opts.source or "human")
+    # Resolve line bounds: explicit --lines wins; otherwise try to
+    # discover via inventory checklist when one is available.
+    line_bounds: Optional[tuple[int, int]] = None
     if opts.lines:
         try:
-            start, end = _parse_lines(opts.lines)
+            line_bounds = _parse_lines(opts.lines)
         except ValueError as e:
             sys.stderr.write(f"raptor-annotate: {e}\n")
             return 2
+    else:
+        ck_path = _find_checklist(base, opts.checklist)
+        if ck_path:
+            line_bounds = _lookup_bounds_by_name(
+                ck_path, opts.file, opts.function,
+            )
+
+    if line_bounds:
+        start, end = line_bounds
         target = Path(opts.target or ".").resolve()
         src = target / opts.file
         h = compute_function_hash(src, start, end)
@@ -169,7 +229,9 @@ def cmd_add(opts: argparse.Namespace) -> int:
             metadata["hash"] = h
             metadata["start_line"] = str(start)
             metadata["end_line"] = str(end)
-        else:
+        elif opts.lines:
+            # Only warn when the operator explicitly asked. Silent
+            # auto-discovery skip.
             sys.stderr.write(
                 f"raptor-annotate: warning — couldn't compute hash for "
                 f"{opts.file}:{start}-{end} (file unreadable or empty)\n"
@@ -348,6 +410,12 @@ def _build_parser() -> argparse.ArgumentParser:
     pa.add_argument("--body-file")
     pa.add_argument("--lines", help="N-M source line range")
     pa.add_argument("--target", help="repo root for hash computation")
+    pa.add_argument(
+        "--checklist",
+        help="inventory checklist.json for auto-discovering function "
+             "bounds when --lines is omitted (default: search base "
+             "dir's ancestors)",
+    )
     pa.add_argument("--meta", action="append")
     pa.add_argument("--source", default="human")
     pa.add_argument("--overwrite", default="all",

--- a/libexec/raptor-annotate
+++ b/libexec/raptor-annotate
@@ -263,6 +263,27 @@ def cmd_add(opts: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _parse_since(spec: str) -> Optional[float]:
+    """Parse ``--since`` value (``7d`` / ``24h`` / ``30m``) into a
+    cutoff timestamp (mtime threshold). Returns None on bad input."""
+    import time
+    if not spec:
+        return None
+    spec = spec.strip().lower()
+    multipliers = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
+    if spec[-1] in multipliers:
+        try:
+            n = float(spec[:-1])
+        except ValueError:
+            return None
+        return time.time() - n * multipliers[spec[-1]]
+    try:
+        # Bare number → seconds
+        return time.time() - float(spec)
+    except ValueError:
+        return None
+
+
 def cmd_ls(opts: argparse.Namespace) -> int:
     base = _resolve_base(opts.base)
     if opts.file:
@@ -274,6 +295,47 @@ def cmd_ls(opts: argparse.Namespace) -> int:
         anns = [a for a in anns if a.metadata.get("status") == opts.status]
     if opts.source:
         anns = [a for a in anns if a.metadata.get("source") == opts.source]
+    if opts.cwe:
+        anns = [a for a in anns if a.metadata.get("cwe") == opts.cwe]
+    if opts.rule_id:
+        # Substring match — operator can pass "py/" to scope to a
+        # language family.
+        anns = [a for a in anns
+                if opts.rule_id in (a.metadata.get("rule_id") or "")]
+    if opts.grep:
+        # Case-insensitive substring search across body + metadata
+        # values. Useful for "find every annotation that mentions
+        # subprocess" style queries.
+        needle = opts.grep.lower()
+        def _match(a):
+            if needle in a.body.lower():
+                return True
+            return any(
+                needle in str(v).lower() for v in a.metadata.values()
+            )
+        anns = [a for a in anns if _match(a)]
+    if opts.since:
+        cutoff = _parse_since(opts.since)
+        if cutoff is None:
+            sys.stderr.write(
+                f"raptor-annotate: bad --since value {opts.since!r}; "
+                f"expected e.g. ``7d`` / ``24h`` / ``30m``\n"
+            )
+            return 2
+        # Filter by the containing annotation file's mtime — annotations
+        # inside one file share a timestamp. Coarse-grained but
+        # operationally useful (operators usually want "what changed
+        # this week" not "which exact records were touched").
+        kept = []
+        for a in anns:
+            ann_file = annotation_path(base, a.file)
+            try:
+                mtime = ann_file.stat().st_mtime
+            except OSError:
+                continue
+            if mtime >= cutoff:
+                kept.append(a)
+        anns = kept
     # Sort for stable output.
     anns.sort(key=lambda a: (a.file, a.function))
     if not anns:
@@ -427,6 +489,21 @@ def _build_parser() -> argparse.ArgumentParser:
     pl.add_argument("--file")
     pl.add_argument("--status")
     pl.add_argument("--source")
+    pl.add_argument("--cwe", help="filter by metadata.cwe (exact)")
+    pl.add_argument(
+        "--rule-id",
+        dest="rule_id",
+        help="filter by metadata.rule_id (substring match)",
+    )
+    pl.add_argument(
+        "--grep",
+        help="case-insensitive substring search across body + metadata",
+    )
+    pl.add_argument(
+        "--since",
+        help="annotation file mtime within window: ``7d`` / "
+             "``24h`` / ``30m`` / ``120s``",
+    )
 
     # show
     ps = sub.add_parser("show", help="show one annotation")

--- a/libexec/raptor-annotate
+++ b/libexec/raptor-annotate
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Operator CLI for per-function annotations.
+
+Usage:
+  raptor-annotate add <file> <function> [options]
+  raptor-annotate ls [options]
+  raptor-annotate show <file> <function> [options]
+  raptor-annotate edit <file> <function> [options]
+  raptor-annotate rm <file> <function> [options]
+  raptor-annotate stale [options]
+
+Common options:
+  --base PATH           Annotation base directory. Defaults to
+                        ``<active-project-output>/annotations`` when
+                        a project is active, otherwise required.
+
+Add options:
+  --status VALUE        clean / suspicious / finding / error
+  --cwe CWE-XX          CWE identifier
+  -m, --body TEXT       Annotation prose
+  --body-file PATH      Read body from file (use '-' for stdin)
+  --lines N-M           Source line range (1-indexed, inclusive)
+                        used to compute ``metadata.hash`` for
+                        staleness detection.
+  --target REPO_ROOT    Where to find the source file for hash
+                        computation. Defaults to current directory.
+  --meta KEY=VALUE      Extra metadata (repeatable)
+  --source VALUE        Defaults to ``human``. Set ``llm`` only for
+                        scripted, non-operator-driven adds.
+  --overwrite MODE      ``all`` (default) or ``respect-manual``.
+
+ls options:
+  --file PATH           Show only annotations for one source file
+  --status VALUE        Filter by metadata.status
+  --source VALUE        Filter by metadata.source
+
+stale options:
+  --target REPO_ROOT    Where to resolve source files for hash
+                        recomputation. Defaults to current directory.
+
+All ``add`` calls default to ``metadata.source=human``, so subsequent
+LLM passes that pass ``overwrite=respect-manual`` will not clobber
+operator notes.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+# ─── trust-marker check (do not import; inline by design) ───
+if not (os.environ.get("CLAUDECODE")
+        or os.environ.get("_RAPTOR_TRUSTED")):
+    sys.stderr.write(
+        f"{sys.argv[0]}: internal dispatch script.\n"
+        "  Run via 'bin/raptor' instead.\n"
+        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
+    )
+    sys.exit(2)
+# ─── end trust-marker check ─────────────────────────────────
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.annotations import (  # noqa: E402
+    Annotation,
+    annotation_path,
+    compute_function_hash,
+    iter_all_annotations,
+    read_annotation,
+    read_file_annotations,
+    remove_annotation,
+    write_annotation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Base-dir resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_base(explicit: Optional[str]) -> Path:
+    """Pick the annotation base directory.
+
+    Priority:
+      1. ``--base`` arg if given.
+      2. Active project output dir + ``/annotations`` (created on demand).
+      3. Error — ask the operator to specify ``--base`` or set an
+         active project.
+    """
+    if explicit:
+        return Path(explicit).resolve()
+    try:
+        from core.project.project import ProjectManager
+        mgr = ProjectManager()
+        name = mgr.get_active()
+        if name:
+            project = mgr.load(name)
+            if project:
+                return Path(project.output_dir).resolve() / "annotations"
+    except Exception:
+        pass
+    sys.stderr.write(
+        "raptor-annotate: no annotation base — pass --base PATH or "
+        "activate a project with `/project use <name>`.\n"
+    )
+    sys.exit(2)
+
+
+def _read_body(opts: argparse.Namespace) -> str:
+    """Body resolution: explicit ``-m`` wins, else --body-file (or
+    stdin), else empty."""
+    if opts.body is not None:
+        return opts.body
+    if opts.body_file:
+        if opts.body_file == "-":
+            return sys.stdin.read()
+        return Path(opts.body_file).read_text(encoding="utf-8")
+    return ""
+
+
+def _parse_meta(items: List[str]) -> dict:
+    """Parse ``--meta KEY=VALUE`` pairs."""
+    out = {}
+    for item in items:
+        if "=" not in item:
+            sys.stderr.write(f"raptor-annotate: bad --meta {item!r}, "
+                             f"expected KEY=VALUE\n")
+            sys.exit(2)
+        k, v = item.split("=", 1)
+        out[k] = v
+    return out
+
+
+def _parse_lines(spec: str) -> tuple[int, int]:
+    """Parse ``N-M`` line range."""
+    if "-" not in spec:
+        raise ValueError(f"--lines expects N-M form, got {spec!r}")
+    a, b = spec.split("-", 1)
+    return int(a), int(b)
+
+
+# ---------------------------------------------------------------------------
+# add
+# ---------------------------------------------------------------------------
+
+
+def cmd_add(opts: argparse.Namespace) -> int:
+    base = _resolve_base(opts.base)
+    metadata = _parse_meta(opts.meta or [])
+    if opts.status:
+        metadata["status"] = opts.status
+    if opts.cwe:
+        metadata["cwe"] = opts.cwe
+    metadata.setdefault("source", opts.source or "human")
+    if opts.lines:
+        try:
+            start, end = _parse_lines(opts.lines)
+        except ValueError as e:
+            sys.stderr.write(f"raptor-annotate: {e}\n")
+            return 2
+        target = Path(opts.target or ".").resolve()
+        src = target / opts.file
+        h = compute_function_hash(src, start, end)
+        if h:
+            metadata["hash"] = h
+            metadata["start_line"] = str(start)
+            metadata["end_line"] = str(end)
+        else:
+            sys.stderr.write(
+                f"raptor-annotate: warning — couldn't compute hash for "
+                f"{opts.file}:{start}-{end} (file unreadable or empty)\n"
+            )
+
+    body = _read_body(opts)
+    ann = Annotation(
+        file=opts.file, function=opts.function,
+        body=body, metadata=metadata,
+    )
+    try:
+        path = write_annotation(base, ann, overwrite=opts.overwrite or "all")
+    except ValueError as e:
+        sys.stderr.write(f"raptor-annotate: {e}\n")
+        return 2
+    if path is None:
+        sys.stderr.write(
+            f"raptor-annotate: skipped — existing annotation for "
+            f"{opts.file}:{opts.function} has source=human and "
+            f"--overwrite is respect-manual\n"
+        )
+        return 1
+    print(f"wrote {path}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# ls
+# ---------------------------------------------------------------------------
+
+
+def cmd_ls(opts: argparse.Namespace) -> int:
+    base = _resolve_base(opts.base)
+    if opts.file:
+        anns = read_file_annotations(base, opts.file)
+    else:
+        anns = list(iter_all_annotations(base))
+    # Filter
+    if opts.status:
+        anns = [a for a in anns if a.metadata.get("status") == opts.status]
+    if opts.source:
+        anns = [a for a in anns if a.metadata.get("source") == opts.source]
+    # Sort for stable output.
+    anns.sort(key=lambda a: (a.file, a.function))
+    if not anns:
+        print("(no annotations)")
+        return 0
+    # Print: file:function   status   source   body-snippet
+    file_w = max(len(a.file) for a in anns)
+    fn_w = max(len(a.function) for a in anns)
+    for a in anns:
+        status = a.metadata.get("status", "-")
+        source = a.metadata.get("source", "-")
+        snippet = " ".join(a.body.split())[:60]
+        print(f"{a.file:<{file_w}}  {a.function:<{fn_w}}  "
+              f"{status:<11}  {source:<5}  {snippet}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# show
+# ---------------------------------------------------------------------------
+
+
+def cmd_show(opts: argparse.Namespace) -> int:
+    base = _resolve_base(opts.base)
+    ann = read_annotation(base, opts.file, opts.function)
+    if ann is None:
+        sys.stderr.write(
+            f"raptor-annotate: no annotation for "
+            f"{opts.file}:{opts.function}\n"
+        )
+        return 1
+    print(f"## {ann.function}")
+    if ann.metadata:
+        meta_str = " ".join(f"{k}={v}" for k, v in sorted(ann.metadata.items()))
+        print(f"<!-- meta: {meta_str} -->")
+    if ann.body:
+        print()
+        print(ann.body)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# edit
+# ---------------------------------------------------------------------------
+
+
+def cmd_edit(opts: argparse.Namespace) -> int:
+    base = _resolve_base(opts.base)
+    path = annotation_path(base, opts.file)
+    if not path.exists():
+        # Create an empty placeholder so $EDITOR has something to open.
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"# {opts.file}\n\n## {opts.function}\n", encoding="utf-8")
+    editor = os.environ.get("EDITOR") or os.environ.get("VISUAL") or "vi"
+    cmd = shlex.split(editor) + [str(path)]
+    rc = subprocess.call(cmd)
+    if rc != 0:
+        sys.stderr.write(f"raptor-annotate: editor exited with {rc}\n")
+        return rc
+    # Re-parse to verify the user didn't break the format.
+    anns = read_file_annotations(base, opts.file)
+    print(f"saved {path} ({len(anns)} annotation(s))")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# rm
+# ---------------------------------------------------------------------------
+
+
+def cmd_rm(opts: argparse.Namespace) -> int:
+    base = _resolve_base(opts.base)
+    removed = remove_annotation(base, opts.file, opts.function)
+    if not removed:
+        sys.stderr.write(
+            f"raptor-annotate: no annotation for "
+            f"{opts.file}:{opts.function}\n"
+        )
+        return 1
+    print(f"removed {opts.file}:{opts.function}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# stale
+# ---------------------------------------------------------------------------
+
+
+def cmd_stale(opts: argparse.Namespace) -> int:
+    base = _resolve_base(opts.base)
+    target = Path(opts.target or ".").resolve()
+    stale = []
+    for ann in iter_all_annotations(base):
+        meta = ann.metadata
+        h = meta.get("hash")
+        sl = meta.get("start_line")
+        el = meta.get("end_line")
+        if not (h and sl and el):
+            continue
+        try:
+            start, end = int(sl), int(el)
+        except ValueError:
+            continue
+        src = target / ann.file
+        current = compute_function_hash(src, start, end)
+        if current and current != h:
+            stale.append((ann, h, current))
+    if not stale:
+        print("(no stale annotations)")
+        return 0
+    for ann, old, new in stale:
+        print(f"{ann.file}:{ann.function}  "
+              f"stored={old}  current={new}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Argparse wiring
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="raptor-annotate")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    # add
+    pa = sub.add_parser("add", help="add or update an annotation")
+    pa.add_argument("file")
+    pa.add_argument("function")
+    pa.add_argument("--base")
+    pa.add_argument("--status")
+    pa.add_argument("--cwe")
+    pa.add_argument("-m", "--body")
+    pa.add_argument("--body-file")
+    pa.add_argument("--lines", help="N-M source line range")
+    pa.add_argument("--target", help="repo root for hash computation")
+    pa.add_argument("--meta", action="append")
+    pa.add_argument("--source", default="human")
+    pa.add_argument("--overwrite", default="all",
+                    choices=("all", "respect-manual"))
+
+    # ls
+    pl = sub.add_parser("ls", help="list annotations")
+    pl.add_argument("--base")
+    pl.add_argument("--file")
+    pl.add_argument("--status")
+    pl.add_argument("--source")
+
+    # show
+    ps = sub.add_parser("show", help="show one annotation")
+    ps.add_argument("file")
+    ps.add_argument("function")
+    ps.add_argument("--base")
+
+    # edit
+    pe = sub.add_parser("edit",
+                        help="open the source file's annotation .md "
+                             "in $EDITOR")
+    pe.add_argument("file")
+    pe.add_argument("function")
+    pe.add_argument("--base")
+
+    # rm
+    pr = sub.add_parser("rm", help="remove an annotation")
+    pr.add_argument("file")
+    pr.add_argument("function")
+    pr.add_argument("--base")
+
+    # stale
+    pst = sub.add_parser(
+        "stale",
+        help="list annotations whose source-line hash no longer matches",
+    )
+    pst.add_argument("--base")
+    pst.add_argument("--target")
+
+    return p
+
+
+_DISPATCH = {
+    "add": cmd_add,
+    "ls": cmd_ls,
+    "show": cmd_show,
+    "edit": cmd_edit,
+    "rm": cmd_rm,
+    "stale": cmd_stale,
+}
+
+
+def main() -> int:
+    parser = _build_parser()
+    opts = parser.parse_args()
+    fn = _DISPATCH[opts.cmd]
+    return fn(opts)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/libexec/raptor-understand-annotate
+++ b/libexec/raptor-understand-annotate
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Synthesise annotations from /understand JSON outputs.
+
+Usage: raptor-understand-annotate <output_dir>
+
+Reads context-map.json, any flow-trace-*.json files, and the run's
+checklist.json from ``<output_dir>``. Writes per-function annotations
+under ``<output_dir>/annotations/``.
+
+Designed to run at the end of /understand --map and /understand --trace
+next to raptor-render-diagrams. Best-effort — exits 0 even when no
+JSON inputs are present, so the /understand command can call this
+unconditionally without conditional plumbing.
+"""
+import os
+import sys
+from pathlib import Path
+
+# ─── trust-marker check (do not import; inline by design) ───
+if not (os.environ.get("CLAUDECODE")
+        or os.environ.get("_RAPTOR_TRUSTED")):
+    sys.stderr.write(
+        f"{sys.argv[0]}: internal dispatch script.\n"
+        "  Run via 'bin/raptor' instead.\n"
+        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
+    )
+    sys.exit(2)
+# ─── end trust-marker check ─────────────────────────────────
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: raptor-understand-annotate <output_dir>",
+              file=sys.stderr)
+        return 1
+
+    out_dir = Path(sys.argv[1])
+    if not out_dir.exists():
+        print(f"ERROR: directory not found: {out_dir}", file=sys.stderr)
+        return 1
+
+    try:
+        from packages.code_understanding.annotation_synth import (
+            synthesise_from_understand_output,
+        )
+        counts = synthesise_from_understand_output(out_dir)
+    except Exception as e:
+        print(f"Annotation synth error: {e}", file=sys.stderr)
+        return 1
+
+    if counts.emitted == 0 and counts.skipped_no_function == 0:
+        print("Annotations: nothing to synthesise (no JSON inputs)")
+        return 0
+
+    summary_parts = [f"emitted={counts.emitted}"]
+    if counts.sources:
+        breakdown = ", ".join(
+            f"{k}={v}" for k, v in sorted(counts.sources.items())
+        )
+        summary_parts.append(f"by_kind=[{breakdown}]")
+    if counts.skipped_no_function:
+        summary_parts.append(f"skipped_no_function={counts.skipped_no_function}")
+    if counts.skipped_manual_blocked:
+        summary_parts.append(
+            f"skipped_manual_blocked={counts.skipped_manual_blocked}"
+        )
+    if counts.errors:
+        summary_parts.append(f"errors={counts.errors}")
+    print("Annotations: " + ", ".join(summary_parts))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/code_understanding/annotation_synth.py
+++ b/packages/code_understanding/annotation_synth.py
@@ -1,0 +1,433 @@
+"""Annotation synthesis from ``/understand`` JSON outputs.
+
+Reads ``context-map.json`` and any ``flow-trace-*.json`` files in a
+``/understand`` run directory, plus the run's ``checklist.json``,
+and writes per-function annotations attached to:
+
+  * Entry points (status ``entry_point``)
+  * Sinks (status ``sink``)
+  * Trust boundaries (status ``trust_boundary``)
+  * Flow-trace steps (status ``flow_step``)
+  * Unchecked flows (status ``unchecked_flow``, attached to the
+    entry-point function)
+
+Calls ``write_annotation(..., overwrite="respect-manual")`` so a
+manual operator note (``source=human``) survives subsequent
+``/understand`` runs.
+
+Pure post-processor — does not invoke the LLM, doesn't need network,
+runs at the end of ``/understand --map`` and ``/understand --trace``
+next to ``raptor-render-diagrams``.
+
+Skipped silently when:
+
+  * Output dir doesn't exist or has no relevant JSON.
+  * No ``checklist.json`` (function-name lookup unavailable).
+  * A specific entry/sink/step has no matching inventory function.
+  * A specific same-name annotation has ``source=human``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from core.annotations import (
+    Annotation,
+    compute_function_hash,
+    write_annotation,
+)
+from core.inventory.lookup import lookup_function
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SynthCounts:
+    """Telemetry returned to the caller."""
+
+    emitted: int = 0
+    skipped_no_function: int = 0
+    skipped_manual_blocked: int = 0
+    errors: int = 0
+    sources: Dict[str, int] = field(default_factory=dict)
+
+    def bump(self, kind: str) -> None:
+        self.sources[kind] = self.sources.get(kind, 0) + 1
+
+
+def _load_json(path: Path) -> Optional[Dict[str, Any]]:
+    """Load a JSON file or return None on any failure."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+
+def _safe_meta(value: Any) -> str:
+    """Sanitise an arbitrary value for metadata storage. The
+    annotation substrate rejects newlines, nulls, and HTML-comment
+    delimiters — strip them rather than raise from inside the synth
+    loop and lose the whole batch."""
+    s = str(value)
+    s = s.replace("\n", " ").replace("\r", " ").replace("\x00", "")
+    s = s.replace("-->", "->").replace("<!--", "<!-")
+    return s.strip()
+
+
+def _resolve(
+    checklist: Dict[str, Any], file_path: str, line: int,
+    repo_root: Path,
+) -> Optional[Dict[str, Any]]:
+    """Look up the function containing ``file:line`` in the inventory.
+    Returns the function dict (with ``name``, ``line_start``,
+    optionally ``line_end``) or ``None``."""
+    if not file_path or not line:
+        return None
+    try:
+        return lookup_function(
+            checklist, file_path, int(line),
+            repo_root=str(repo_root),
+        )
+    except (ValueError, TypeError):
+        return None
+
+
+def _hash_metadata(
+    repo_root: Path, file_path: str, func: Dict[str, Any],
+) -> Dict[str, str]:
+    """Return ``{hash, start_line, end_line}`` if the function has
+    line bounds in the inventory. Empty dict otherwise."""
+    line_start = func.get("line_start")
+    line_end = func.get("line_end")
+    if not (line_start and line_end and file_path):
+        return {}
+    src = repo_root / file_path
+    h = compute_function_hash(src, line_start, line_end)
+    if not h:
+        return {}
+    return {
+        "hash": h,
+        "start_line": str(line_start),
+        "end_line": str(line_end),
+    }
+
+
+def _write(
+    base_dir: Path, ann: Annotation, counts: SynthCounts, kind: str,
+) -> None:
+    """Write one annotation through the substrate, accounting the
+    outcome in ``counts``. Best-effort — exceptions land in
+    ``errors``."""
+    try:
+        path = write_annotation(base_dir, ann, overwrite="respect-manual")
+    except (ValueError, OSError) as e:
+        logger.warning(
+            f"annotation synth: {kind} write failed for "
+            f"{ann.file}:{ann.function}: {e}"
+        )
+        counts.errors += 1
+        return
+    if path is None:
+        counts.skipped_manual_blocked += 1
+    else:
+        counts.emitted += 1
+        counts.bump(kind)
+
+
+# ---------------------------------------------------------------------------
+# context-map.json: entry points, sinks, trust boundaries, unchecked flows
+# ---------------------------------------------------------------------------
+
+
+def _emit_entry_points(
+    cmap: Dict[str, Any],
+    base_dir: Path, checklist: Dict[str, Any], repo_root: Path,
+    counts: SynthCounts,
+) -> None:
+    for ep in cmap.get("entry_points", []) or []:
+        file_path = ep.get("file")
+        line = ep.get("line")
+        func = _resolve(checklist, file_path, line, repo_root)
+        if not func or not func.get("name"):
+            counts.skipped_no_function += 1
+            continue
+        body_lines: List[str] = []
+        if ep.get("type"):
+            t = ep["type"]
+            if ep.get("method") and ep.get("path"):
+                body_lines.append(f"Entry point ({t}): "
+                                  f"{ep['method']} {ep['path']}")
+            else:
+                body_lines.append(f"Entry point: {t}")
+        if ep.get("accepts"):
+            body_lines.append(f"Accepts: {ep['accepts']}")
+        if ep.get("auth_required") is not None:
+            body_lines.append(f"Auth required: {ep['auth_required']}")
+        if ep.get("notes"):
+            body_lines.append(f"Notes: {ep['notes']}")
+        metadata = {
+            "source": "llm",
+            "status": "entry_point",
+        }
+        if ep.get("id"):
+            metadata["entry_point_id"] = _safe_meta(ep["id"])
+        if ep.get("type"):
+            metadata["type"] = _safe_meta(ep["type"])
+        metadata.update(_hash_metadata(repo_root, file_path, func))
+        ann = Annotation(
+            file=file_path, function=func["name"],
+            body="\n\n".join(body_lines), metadata=metadata,
+        )
+        _write(base_dir, ann, counts, "entry_point")
+
+
+def _emit_sinks(
+    cmap: Dict[str, Any],
+    base_dir: Path, checklist: Dict[str, Any], repo_root: Path,
+    counts: SynthCounts,
+) -> None:
+    for sink in cmap.get("sink_details", []) or []:
+        file_path = sink.get("file")
+        line = sink.get("line")
+        func = _resolve(checklist, file_path, line, repo_root)
+        if not func or not func.get("name"):
+            counts.skipped_no_function += 1
+            continue
+        body_lines: List[str] = []
+        if sink.get("type") and sink.get("operation"):
+            body_lines.append(
+                f"Sink ({sink['type']}): {sink['operation']}"
+            )
+        if "parameterized" in sink:
+            body_lines.append(f"Parameterized: {sink['parameterized']}")
+        reaches = sink.get("reaches_from") or []
+        if reaches:
+            body_lines.append(f"Reaches from: {', '.join(reaches)}")
+        boundaries = sink.get("trust_boundaries_crossed") or []
+        if boundaries:
+            body_lines.append(
+                f"Trust boundaries crossed: {', '.join(boundaries)}"
+            )
+        if sink.get("notes"):
+            body_lines.append(f"Notes: {sink['notes']}")
+        metadata = {
+            "source": "llm",
+            "status": "sink",
+        }
+        if sink.get("id"):
+            metadata["sink_id"] = _safe_meta(sink["id"])
+        if sink.get("type"):
+            metadata["type"] = _safe_meta(sink["type"])
+        metadata.update(_hash_metadata(repo_root, file_path, func))
+        ann = Annotation(
+            file=file_path, function=func["name"],
+            body="\n\n".join(body_lines), metadata=metadata,
+        )
+        _write(base_dir, ann, counts, "sink")
+
+
+def _emit_trust_boundaries(
+    cmap: Dict[str, Any],
+    base_dir: Path, checklist: Dict[str, Any], repo_root: Path,
+    counts: SynthCounts,
+) -> None:
+    for bound in cmap.get("boundary_details", []) or []:
+        file_path = bound.get("file")
+        line = bound.get("line")
+        func = _resolve(checklist, file_path, line, repo_root)
+        if not func or not func.get("name"):
+            counts.skipped_no_function += 1
+            continue
+        body_lines: List[str] = []
+        if bound.get("type"):
+            body_lines.append(f"Trust boundary ({bound['type']})")
+        covers = bound.get("covers") or []
+        if covers:
+            body_lines.append(f"Covers: {', '.join(covers)}")
+        if bound.get("gaps"):
+            body_lines.append(f"Gaps: {bound['gaps']}")
+        metadata = {
+            "source": "llm",
+            "status": "trust_boundary",
+        }
+        if bound.get("id"):
+            metadata["boundary_id"] = _safe_meta(bound["id"])
+        if bound.get("type"):
+            metadata["type"] = _safe_meta(bound["type"])
+        metadata.update(_hash_metadata(repo_root, file_path, func))
+        ann = Annotation(
+            file=file_path, function=func["name"],
+            body="\n\n".join(body_lines), metadata=metadata,
+        )
+        _write(base_dir, ann, counts, "trust_boundary")
+
+
+def _emit_unchecked_flows(
+    cmap: Dict[str, Any],
+    base_dir: Path, checklist: Dict[str, Any], repo_root: Path,
+    counts: SynthCounts,
+) -> None:
+    """Attach unchecked-flow notes to the corresponding entry-point's
+    function. The flow record itself is just an ID pair, so we have
+    to re-resolve the entry-point's file:line."""
+    eps_by_id = {
+        ep.get("id"): ep
+        for ep in cmap.get("entry_points", []) or []
+        if ep.get("id")
+    }
+    for flow in cmap.get("unchecked_flows", []) or []:
+        ep_id = flow.get("entry_point")
+        ep = eps_by_id.get(ep_id)
+        if not ep:
+            counts.skipped_no_function += 1
+            continue
+        file_path = ep.get("file")
+        func = _resolve(checklist, file_path, ep.get("line"), repo_root)
+        if not func or not func.get("name"):
+            counts.skipped_no_function += 1
+            continue
+        body_lines = [
+            f"Unchecked flow: {ep_id} → {flow.get('sink', '?')}",
+        ]
+        if flow.get("missing_boundary"):
+            body_lines.append(f"Missing boundary: {flow['missing_boundary']}")
+        metadata = {
+            "source": "llm",
+            "status": "unchecked_flow",
+        }
+        if ep_id:
+            metadata["entry_point_id"] = _safe_meta(ep_id)
+        if flow.get("sink"):
+            metadata["sink_id"] = _safe_meta(flow["sink"])
+        metadata.update(_hash_metadata(repo_root, file_path, func))
+        ann = Annotation(
+            file=file_path, function=func["name"],
+            body="\n\n".join(body_lines), metadata=metadata,
+        )
+        _write(base_dir, ann, counts, "unchecked_flow")
+
+
+# ---------------------------------------------------------------------------
+# flow-trace-*.json: per-step annotations
+# ---------------------------------------------------------------------------
+
+
+def _parse_definition(definition: str) -> Optional[tuple[str, int]]:
+    """Trace ``definition`` strings are either ``file:line`` or a
+    library symbol like ``psycopg2.cursor.execute()`` for sinks. Only
+    the file:line form is annotatable in our codebase."""
+    if not definition or ":" not in definition:
+        return None
+    # Take the LAST colon so Windows ``C:\foo:42`` parses; no Windows
+    # path support today but cheap insurance.
+    file_part, _, line_part = definition.rpartition(":")
+    try:
+        return file_part, int(line_part)
+    except ValueError:
+        return None
+
+
+def _emit_trace_steps(
+    trace: Dict[str, Any], trace_id: str,
+    base_dir: Path, checklist: Dict[str, Any], repo_root: Path,
+    counts: SynthCounts,
+) -> None:
+    for step in trace.get("steps", []) or []:
+        defn = _parse_definition(step.get("definition", ""))
+        if not defn:
+            # External library or non-resolvable target — skip.
+            counts.skipped_no_function += 1
+            continue
+        file_path, line = defn
+        func = _resolve(checklist, file_path, line, repo_root)
+        if not func or not func.get("name"):
+            counts.skipped_no_function += 1
+            continue
+        body_lines: List[str] = []
+        step_num = step.get("step")
+        step_type = step.get("type") or "step"
+        if step_num:
+            body_lines.append(f"Flow trace step {step_num} ({step_type})")
+        if step.get("description"):
+            body_lines.append(step["description"])
+        if step.get("tainted_var"):
+            body_lines.append(f"Tainted variable: {step['tainted_var']}")
+        if step.get("transform") and step["transform"] != "none":
+            body_lines.append(f"Transform: {step['transform']}")
+        if step.get("call_site"):
+            body_lines.append(f"Call site: {step['call_site']}")
+        metadata = {
+            "source": "llm",
+            "status": "flow_step",
+        }
+        if trace_id:
+            metadata["trace_id"] = _safe_meta(trace_id)
+        if step_num is not None:
+            metadata["step"] = _safe_meta(step_num)
+        if step_type:
+            metadata["type"] = _safe_meta(step_type)
+        if step.get("confidence"):
+            metadata["confidence"] = _safe_meta(step["confidence"])
+        metadata.update(_hash_metadata(repo_root, file_path, func))
+        ann = Annotation(
+            file=file_path, function=func["name"],
+            body="\n\n".join(body_lines), metadata=metadata,
+        )
+        _write(base_dir, ann, counts, "flow_step")
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def synthesise_from_understand_output(
+    output_dir: Path, repo_root: Optional[Path] = None,
+) -> SynthCounts:
+    """Walk ``output_dir`` for ``/understand`` JSON outputs and emit
+    annotations under ``output_dir/annotations/``.
+
+    ``repo_root`` defaults to ``checklist.json``'s ``target_path``
+    field. Raises nothing — silently does no work when prerequisites
+    are missing.
+    """
+    counts = SynthCounts()
+    if not output_dir.exists():
+        return counts
+
+    checklist_path = output_dir / "checklist.json"
+    checklist = _load_json(checklist_path)
+    if not checklist:
+        logger.debug(
+            f"annotation synth: no checklist at {checklist_path}; "
+            f"skipping (function lookup unavailable)"
+        )
+        return counts
+    if repo_root is None:
+        repo_root = Path(checklist.get("target_path", "."))
+
+    base_dir = output_dir / "annotations"
+
+    cmap = _load_json(output_dir / "context-map.json")
+    if cmap:
+        _emit_entry_points(cmap, base_dir, checklist, repo_root, counts)
+        _emit_sinks(cmap, base_dir, checklist, repo_root, counts)
+        _emit_trust_boundaries(cmap, base_dir, checklist, repo_root, counts)
+        _emit_unchecked_flows(cmap, base_dir, checklist, repo_root, counts)
+
+    for trace_path in sorted(output_dir.glob("flow-trace-*.json")):
+        trace = _load_json(trace_path)
+        if not trace:
+            continue
+        # ID from filename: flow-trace-EP-001.json → EP-001
+        stem = trace_path.stem  # "flow-trace-EP-001"
+        trace_id = stem.split("flow-trace-", 1)[-1]
+        _emit_trace_steps(
+            trace, trace_id, base_dir, checklist, repo_root, counts,
+        )
+
+    return counts

--- a/packages/code_understanding/annotation_synth.py
+++ b/packages/code_understanding/annotation_synth.py
@@ -442,4 +442,19 @@ def synthesise_from_understand_output(
             trace, trace_id, base_dir, checklist, repo_root, counts,
         )
 
+    # Emit a coverage record so ``raptor-coverage-summary`` picks
+    # up the annotated functions as reviewed. Best-effort.
+    if counts.emitted > 0:
+        try:
+            from core.coverage.record import (
+                build_from_annotations, write_record,
+            )
+            record = build_from_annotations(base_dir)
+            if record:
+                write_record(output_dir, record, tool_name="annotations")
+        except Exception:
+            logger.debug(
+                "annotation coverage record failed", exc_info=True,
+            )
+
     return counts

--- a/packages/code_understanding/annotation_synth.py
+++ b/packages/code_understanding/annotation_synth.py
@@ -143,12 +143,24 @@ def _write(
 # ---------------------------------------------------------------------------
 
 
+def _safe_list_of_dicts(obj: Any, key: str) -> Iterable[Dict[str, Any]]:
+    """Read ``obj[key]`` defensively — an LLM-emitted JSON could put
+    a string, null, or scalar where we expect a list of dicts. Yield
+    only the items that are actually dicts, silently dropping the rest."""
+    raw = obj.get(key) if isinstance(obj, dict) else None
+    if not isinstance(raw, list):
+        return
+    for item in raw:
+        if isinstance(item, dict):
+            yield item
+
+
 def _emit_entry_points(
     cmap: Dict[str, Any],
     base_dir: Path, checklist: Dict[str, Any], repo_root: Path,
     counts: SynthCounts,
 ) -> None:
-    for ep in cmap.get("entry_points", []) or []:
+    for ep in _safe_list_of_dicts(cmap, "entry_points"):
         file_path = ep.get("file")
         line = ep.get("line")
         func = _resolve(checklist, file_path, line, repo_root)
@@ -190,7 +202,7 @@ def _emit_sinks(
     base_dir: Path, checklist: Dict[str, Any], repo_root: Path,
     counts: SynthCounts,
 ) -> None:
-    for sink in cmap.get("sink_details", []) or []:
+    for sink in _safe_list_of_dicts(cmap, "sink_details"):
         file_path = sink.get("file")
         line = sink.get("line")
         func = _resolve(checklist, file_path, line, repo_root)
@@ -235,7 +247,7 @@ def _emit_trust_boundaries(
     base_dir: Path, checklist: Dict[str, Any], repo_root: Path,
     counts: SynthCounts,
 ) -> None:
-    for bound in cmap.get("boundary_details", []) or []:
+    for bound in _safe_list_of_dicts(cmap, "boundary_details"):
         file_path = bound.get("file")
         line = bound.get("line")
         func = _resolve(checklist, file_path, line, repo_root)
@@ -276,10 +288,10 @@ def _emit_unchecked_flows(
     to re-resolve the entry-point's file:line."""
     eps_by_id = {
         ep.get("id"): ep
-        for ep in cmap.get("entry_points", []) or []
+        for ep in _safe_list_of_dicts(cmap, "entry_points")
         if ep.get("id")
     }
-    for flow in cmap.get("unchecked_flows", []) or []:
+    for flow in _safe_list_of_dicts(cmap, "unchecked_flows"):
         ep_id = flow.get("entry_point")
         ep = eps_by_id.get(ep_id)
         if not ep:
@@ -336,7 +348,7 @@ def _emit_trace_steps(
     base_dir: Path, checklist: Dict[str, Any], repo_root: Path,
     counts: SynthCounts,
 ) -> None:
-    for step in trace.get("steps", []) or []:
+    for step in _safe_list_of_dicts(trace, "steps"):
         defn = _parse_definition(step.get("definition", ""))
         if not defn:
             # External library or non-resolvable target — skip.

--- a/packages/code_understanding/tests/test_annotation_synth.py
+++ b/packages/code_understanding/tests/test_annotation_synth.py
@@ -1,0 +1,460 @@
+"""Tests for ``packages.code_understanding.annotation_synth``.
+
+Builds tiny ``context-map.json`` / ``flow-trace-*.json`` / ``checklist.json``
+fixtures, runs the synth, and asserts annotations appear with the
+right metadata. Also exercises the libexec shim end-to-end.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from core.annotations import (
+    Annotation,
+    iter_all_annotations,
+    read_annotation,
+    read_file_annotations,
+    write_annotation,
+)
+from packages.code_understanding.annotation_synth import (
+    SynthCounts,
+    _parse_definition,
+    synthesise_from_understand_output,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SHIM = REPO_ROOT / "libexec" / "raptor-understand-annotate"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def understand_run(tmp_path):
+    """Build a realistic /understand output dir + repo with a few
+    real source files so hash computation has data to chew on."""
+    repo = tmp_path / "repo"
+    (repo / "src" / "routes").mkdir(parents=True)
+    (repo / "src" / "db").mkdir()
+    (repo / "src" / "middleware").mkdir()
+
+    (repo / "src" / "routes" / "query.py").write_text(
+        "\n" * 33
+        + "def query_handler(req):\n"
+        + "    body = req.get_json()\n"
+        + "    return run_query(body)\n"
+        + "\n" * 4
+        + "def admin_bulk(req):\n"
+        + "    return run_query(req.json)\n"
+    )
+    (repo / "src" / "db" / "query.py").write_text(
+        "\n" * 88
+        + "def run_query(s):\n"
+        + "    cursor.execute(f'SELECT * FROM t WHERE x = {s}')\n"
+    )
+    (repo / "src" / "middleware" / "auth.py").write_text(
+        "\n" * 11
+        + "def require_auth(req):\n"
+        + "    if not req.token:\n"
+        + "        raise Unauth()\n"
+    )
+
+    out = tmp_path / "out"
+    out.mkdir()
+
+    checklist = {
+        "target_path": str(repo),
+        "files": [
+            {
+                "path": "src/routes/query.py",
+                "items": [
+                    {"name": "query_handler",
+                     "line_start": 34, "line_end": 38},
+                    {"name": "admin_bulk",
+                     "line_start": 42, "line_end": 44},
+                ],
+            },
+            {
+                "path": "src/db/query.py",
+                "items": [
+                    {"name": "run_query",
+                     "line_start": 89, "line_end": 91},
+                ],
+            },
+            {
+                "path": "src/middleware/auth.py",
+                "items": [
+                    {"name": "require_auth",
+                     "line_start": 12, "line_end": 14},
+                ],
+            },
+        ],
+    }
+    (out / "checklist.json").write_text(json.dumps(checklist))
+
+    return repo, out
+
+
+def _make_context_map(out: Path) -> None:
+    cmap = {
+        "entry_points": [
+            {
+                "id": "EP-001", "type": "http_route", "method": "POST",
+                "path": "/api/v2/query",
+                "file": "src/routes/query.py", "line": 34,
+                "accepts": "JSON body", "auth_required": True,
+                "notes": "Auth at line 38",
+            },
+            {
+                "id": "EP-003", "type": "http_route", "method": "POST",
+                "path": "/api/v2/admin/bulk",
+                "file": "src/routes/query.py", "line": 42,
+                "auth_required": False,
+            },
+        ],
+        "sink_details": [
+            {
+                "id": "SINK-001", "type": "db_query",
+                "operation": "cursor.execute(raw_sql)",
+                "file": "src/db/query.py", "line": 89,
+                "reaches_from": ["EP-001", "EP-003"],
+                "trust_boundaries_crossed": ["TB-001"],
+                "parameterized": False,
+                "notes": "f-string SQL",
+            },
+        ],
+        "boundary_details": [
+            {
+                "id": "TB-001", "type": "auth_check",
+                "file": "src/middleware/auth.py", "line": 12,
+                "covers": ["EP-001"],
+                "gaps": "EP-003 bypasses",
+            },
+        ],
+        "unchecked_flows": [
+            {
+                "entry_point": "EP-003", "sink": "SINK-001",
+                "missing_boundary": "no auth on admin bulk",
+            },
+        ],
+    }
+    (out / "context-map.json").write_text(json.dumps(cmap))
+
+
+def _make_flow_trace(out: Path) -> None:
+    trace = {
+        "entry_id": "EP-001",
+        "steps": [
+            {
+                "step": 1, "type": "entry",
+                "definition": "src/routes/query.py:34",
+                "description": "POST handler receives JSON",
+                "tainted_var": "body", "transform": "none",
+                "confidence": "high",
+            },
+            {
+                "step": 2, "type": "call",
+                "call_site": "src/routes/query.py:35",
+                "definition": "src/db/query.py:89",
+                "description": "Passes body to run_query",
+                "tainted_var": "s", "transform": "none",
+                "confidence": "high",
+            },
+            {
+                "step": 3, "type": "sink",
+                "definition": "psycopg2.cursor.execute()",
+                "description": "External library symbol",
+                "tainted_var": "s", "transform": "none",
+                "confidence": "high",
+            },
+        ],
+    }
+    (out / "flow-trace-EP-001.json").write_text(json.dumps(trace))
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+class TestContextMap:
+    def test_emits_entry_points(self, understand_run):
+        repo, out = understand_run
+        _make_context_map(out)
+        counts = synthesise_from_understand_output(out)
+        # Two entry-points + one sink + one trust-boundary + one
+        # unchecked-flow = 5 distinct annotations.
+        # But the unchecked flow targets the same function as EP-003,
+        # so they collide on the same (file, function) → the unchecked
+        # flow overwrites the EP-003 annotation (last writer wins
+        # within the synth's own pass; respect-manual only protects
+        # source=human).
+        assert counts.emitted >= 4
+        ann = read_annotation(
+            out / "annotations", "src/routes/query.py", "query_handler"
+        )
+        assert ann is not None
+        assert ann.metadata["status"] == "entry_point"
+        assert ann.metadata["entry_point_id"] == "EP-001"
+        assert "POST /api/v2/query" in ann.body
+        assert "Auth at line 38" in ann.body
+        assert ann.metadata.get("hash"), "hash should be stamped"
+
+    def test_emits_sinks(self, understand_run):
+        repo, out = understand_run
+        _make_context_map(out)
+        synthesise_from_understand_output(out)
+        ann = read_annotation(
+            out / "annotations", "src/db/query.py", "run_query"
+        )
+        assert ann is not None
+        assert ann.metadata["status"] == "sink"
+        assert ann.metadata["sink_id"] == "SINK-001"
+        assert "cursor.execute" in ann.body
+        assert "Reaches from: EP-001, EP-003" in ann.body
+
+    def test_emits_trust_boundary(self, understand_run):
+        repo, out = understand_run
+        _make_context_map(out)
+        synthesise_from_understand_output(out)
+        ann = read_annotation(
+            out / "annotations",
+            "src/middleware/auth.py", "require_auth",
+        )
+        assert ann is not None
+        assert ann.metadata["status"] == "trust_boundary"
+        assert ann.metadata["boundary_id"] == "TB-001"
+        assert "Covers: EP-001" in ann.body
+        assert "EP-003 bypasses" in ann.body
+
+    def test_emits_unchecked_flow_attached_to_entry_point(self, understand_run):
+        repo, out = understand_run
+        # No flow trace, just context map — so EP-003 only has the
+        # unchecked-flow annotation. The status should be
+        # ``unchecked_flow`` after the unchecked-flow pass overwrites
+        # the entry-point annotation written earlier.
+        _make_context_map(out)
+        synthesise_from_understand_output(out)
+        ann = read_annotation(
+            out / "annotations",
+            "src/routes/query.py", "admin_bulk",
+        )
+        assert ann is not None
+        # Unchecked-flow pass runs LAST and overwrites the entry-point
+        # status. Body mentions both. Pin only the metadata invariant.
+        assert ann.metadata["status"] == "unchecked_flow"
+        assert "EP-003" in ann.body
+        assert "SINK-001" in ann.body
+
+
+class TestFlowTrace:
+    def test_emits_per_step_annotations(self, understand_run):
+        repo, out = understand_run
+        _make_context_map(out)
+        _make_flow_trace(out)
+        counts = synthesise_from_understand_output(out)
+        # Step 1 → query_handler (already has entry_point); step 2 →
+        # run_query (already has sink); step 3 is external library,
+        # skipped.
+        # Steps 1+2 overwrite (respect-manual doesn't apply, both
+        # annotations are llm-source). The last writer for each
+        # function is the flow-step pass. Pin: at least one
+        # flow_step annotation present.
+        assert any(
+            a.metadata.get("status") == "flow_step"
+            for a in iter_all_annotations(out / "annotations")
+        )
+
+    def test_skips_external_library_definitions(self, understand_run):
+        """Step 3's ``psycopg2.cursor.execute()`` has no file:line —
+        synth must skip without crashing."""
+        repo, out = understand_run
+        _make_flow_trace(out)
+        # checklist exists; no context-map. Just trace.
+        counts = synthesise_from_understand_output(out)
+        # Step 3 should land in skipped_no_function.
+        assert counts.skipped_no_function >= 1
+
+    def test_trace_step_metadata_includes_trace_id_and_step(
+        self, understand_run,
+    ):
+        repo, out = understand_run
+        _make_flow_trace(out)
+        synthesise_from_understand_output(out)
+        # Find any flow_step annotation.
+        for ann in iter_all_annotations(out / "annotations"):
+            if ann.metadata.get("status") == "flow_step":
+                assert ann.metadata.get("trace_id") == "EP-001"
+                assert ann.metadata.get("step") in ("1", "2")
+                return
+        pytest.fail("no flow_step annotation found")
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_no_output_dir(self, tmp_path):
+        counts = synthesise_from_understand_output(tmp_path / "nope")
+        assert counts.emitted == 0
+        assert counts.errors == 0
+
+    def test_no_checklist(self, tmp_path):
+        # Output dir exists but no checklist -> skip silently.
+        tmp_path.mkdir(exist_ok=True)
+        (tmp_path / "context-map.json").write_text(
+            json.dumps({"entry_points": [
+                {"id": "EP-1", "file": "src/foo.py", "line": 10}
+            ]})
+        )
+        counts = synthesise_from_understand_output(tmp_path)
+        assert counts.emitted == 0
+
+    def test_no_json_inputs(self, understand_run):
+        repo, out = understand_run
+        # Just checklist, no context-map / no flow-trace.
+        counts = synthesise_from_understand_output(out)
+        assert counts.emitted == 0
+
+    def test_corrupt_context_map_does_not_crash(self, understand_run):
+        repo, out = understand_run
+        (out / "context-map.json").write_text("{ not valid json")
+        counts = synthesise_from_understand_output(out)
+        # Bad JSON → load returns None → that file is silently skipped.
+        assert counts.errors == 0
+
+    def test_unknown_entry_point_in_unchecked_flow(self, understand_run):
+        repo, out = understand_run
+        cmap = {
+            "entry_points": [],
+            "unchecked_flows": [
+                {"entry_point": "EP-DOES-NOT-EXIST", "sink": "SINK-1"},
+            ],
+        }
+        (out / "context-map.json").write_text(json.dumps(cmap))
+        counts = synthesise_from_understand_output(out)
+        # EP not found → skipped_no_function bumps; no crash.
+        assert counts.skipped_no_function >= 1
+
+    def test_function_without_inventory_match_skipped(self, understand_run):
+        repo, out = understand_run
+        cmap = {
+            "entry_points": [{
+                "id": "EP-1", "type": "http_route", "method": "GET",
+                "path": "/x",
+                "file": "src/not_in_inventory.py", "line": 1,
+            }],
+        }
+        (out / "context-map.json").write_text(json.dumps(cmap))
+        counts = synthesise_from_understand_output(out)
+        assert counts.skipped_no_function >= 1
+        assert counts.emitted == 0
+
+
+class TestRespectManual:
+    def test_skips_manual_annotation(self, understand_run):
+        repo, out = understand_run
+        _make_context_map(out)
+        # Operator wrote a manual note for query_handler first.
+        write_annotation(out / "annotations", Annotation(
+            file="src/routes/query.py", function="query_handler",
+            body="Operator: reviewed clean",
+            metadata={"source": "human", "status": "clean"},
+        ))
+        counts = synthesise_from_understand_output(out)
+        # Synth tried to write entry_point + (maybe other), but the
+        # query_handler write was blocked.
+        assert counts.skipped_manual_blocked >= 1
+        # Operator content still there.
+        ann = read_annotation(
+            out / "annotations",
+            "src/routes/query.py", "query_handler",
+        )
+        assert ann.metadata["source"] == "human"
+        assert "Operator" in ann.body
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+class TestParseDefinition:
+    def test_file_line_form(self):
+        assert _parse_definition("src/foo.py:42") == ("src/foo.py", 42)
+
+    def test_external_library_returns_none(self):
+        assert _parse_definition("psycopg2.cursor.execute()") is None
+
+    def test_empty_returns_none(self):
+        assert _parse_definition("") is None
+
+    def test_no_colon_returns_none(self):
+        assert _parse_definition("src/foo.py") is None
+
+    def test_garbage_line_number_returns_none(self):
+        assert _parse_definition("src/foo.py:abc") is None
+
+
+# ---------------------------------------------------------------------------
+# Libexec shim
+# ---------------------------------------------------------------------------
+
+
+class TestShim:
+    def _run(self, *args, env_extra=None):
+        env = dict(os.environ)
+        env["_RAPTOR_TRUSTED"] = "1"
+        if env_extra:
+            env.update(env_extra)
+        return subprocess.run(
+            [sys.executable, str(SHIM), *args],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_trust_marker_required(self, tmp_path):
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("_RAPTOR_TRUSTED", "CLAUDECODE")}
+        r = subprocess.run(
+            [sys.executable, str(SHIM), str(tmp_path)],
+            env=env, capture_output=True, text=True,
+        )
+        assert r.returncode == 2
+        assert "internal dispatch" in r.stderr
+
+    def test_no_args_prints_usage(self):
+        r = self._run()
+        assert r.returncode == 1
+        assert "Usage" in r.stderr
+
+    def test_missing_dir_errors(self, tmp_path):
+        r = self._run(str(tmp_path / "nope"))
+        assert r.returncode == 1
+        assert "not found" in r.stderr
+
+    def test_empty_dir_says_nothing_to_do(self, tmp_path):
+        r = self._run(str(tmp_path))
+        assert r.returncode == 0
+        assert "nothing to synthesise" in r.stdout
+
+    def test_full_run(self, understand_run):
+        repo, out = understand_run
+        _make_context_map(out)
+        _make_flow_trace(out)
+        r = self._run(str(out))
+        assert r.returncode == 0, r.stderr
+        assert "emitted=" in r.stdout
+        assert "by_kind=" in r.stdout

--- a/packages/code_understanding/tests/test_annotation_synth.py
+++ b/packages/code_understanding/tests/test_annotation_synth.py
@@ -362,6 +362,31 @@ class TestEdgeCases:
         assert counts.emitted == 0
 
 
+class TestCoverageRecordWireIn:
+    """The synth writes a ``coverage-annotations.json`` record after
+    emitting annotations, so ``raptor-coverage-summary`` can pick
+    them up as reviewed functions."""
+
+    def test_writes_coverage_record_when_emit_succeeds(self, understand_run):
+        repo, out = understand_run
+        _make_context_map(out)
+        synthesise_from_understand_output(out)
+        record_path = out / "coverage-annotations.json"
+        assert record_path.exists(), (
+            "synth must write coverage-annotations.json"
+        )
+        import json
+        record = json.loads(record_path.read_text())
+        assert record["tool"] == "annotations"
+        assert len(record["functions_analysed"]) > 0
+
+    def test_no_record_when_no_emits(self, understand_run):
+        """Empty run (no JSON inputs) must not leave a stale record."""
+        repo, out = understand_run
+        synthesise_from_understand_output(out)
+        assert not (out / "coverage-annotations.json").exists()
+
+
 class TestRespectManual:
     def test_skips_manual_annotation(self, understand_run):
         repo, out = understand_run

--- a/packages/code_understanding/tests/test_annotation_synth_adversarial.py
+++ b/packages/code_understanding/tests/test_annotation_synth_adversarial.py
@@ -1,0 +1,390 @@
+"""Adversarial input tests for ``annotation_synth``.
+
+The 24 baseline tests exercise the happy path + a handful of edge
+cases. These cover the malicious-input dimension: what happens when
+``context-map.json``, ``flow-trace-*.json``, or ``checklist.json``
+contain values that could break the on-disk annotation format,
+exhaust resources, or leak through the path-traversal defence.
+
+Every input here is something a faulty / compromised / over-eager
+LLM upstream could plausibly produce.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from core.annotations import iter_all_annotations, read_annotation
+from packages.code_understanding.annotation_synth import (
+    SynthCounts,
+    synthesise_from_understand_output,
+)
+
+
+@pytest.fixture
+def fixture(tmp_path):
+    """Tiny but realistic /understand output dir + repo + inventory."""
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "src" / "app.py").write_text(
+        "def login(req):\n    return req\n" * 5
+    )
+    out = tmp_path / "out"
+    out.mkdir()
+    checklist = {
+        "target_path": str(repo),
+        "files": [{
+            "path": "src/app.py",
+            "items": [{
+                "name": "login", "line_start": 1, "line_end": 2,
+            }],
+        }],
+    }
+    (out / "checklist.json").write_text(json.dumps(checklist))
+    return repo, out
+
+
+# ---------------------------------------------------------------------------
+# Malicious JSON content — the LLM emits free-form prose into JSON
+# fields that we then plumb into annotation metadata or body. None of
+# these should corrupt the on-disk format or crash the synth.
+# ---------------------------------------------------------------------------
+
+
+class TestMaliciousJsonContent:
+    def test_html_comment_close_in_entry_point_id(self, fixture):
+        repo, out = fixture
+        cmap = {"entry_points": [{
+            "id": "EP-1-->INJECT", "type": "http_route",
+            "method": "GET", "path": "/x",
+            "file": "src/app.py", "line": 1,
+        }]}
+        (out / "context-map.json").write_text(json.dumps(cmap))
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        ann = read_annotation(out / "annotations", "src/app.py", "login")
+        # Sanitiser converted ``-->`` to ``->`` so the comment
+        # frontmatter stays valid.
+        assert "-->" not in ann.metadata["entry_point_id"]
+        # Round-trip read works.
+        for a in iter_all_annotations(out / "annotations"):
+            assert a.function == "login"
+
+    def test_html_comment_open_in_sink_type(self, fixture):
+        repo, out = fixture
+        cmap = {
+            "entry_points": [],
+            "sink_details": [{
+                "id": "S1", "type": "<!-- evil -->db_query",
+                "operation": "execute", "file": "src/app.py", "line": 1,
+            }],
+        }
+        (out / "context-map.json").write_text(json.dumps(cmap))
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        ann = read_annotation(out / "annotations", "src/app.py", "login")
+        assert "<!--" not in ann.metadata["type"]
+        assert "-->" not in ann.metadata["type"]
+
+    def test_newline_in_id_field(self, fixture):
+        """Newline + fake-heading payload in a JSON id field. Sanitiser
+        must convert the newline to a space so the value stays on one
+        physical line of the metadata HTML comment (preventing a fake
+        section heading on a subsequent line)."""
+        repo, out = fixture
+        cmap = {"entry_points": [{
+            "id": "EP-1\n## injected_section",
+            "type": "http_route", "method": "GET", "path": "/x",
+            "file": "src/app.py", "line": 1,
+        }]}
+        (out / "context-map.json").write_text(json.dumps(cmap))
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        # Pin: exactly one section in the rendered .md, no fake
+        # ``## injected_section`` heading. The metadata VALUE may
+        # still contain the substring "## injected_section" (it's
+        # safely quoted inside the HTML comment) — that's OK because
+        # the section-heading regex only matches at start-of-line.
+        anns = list(iter_all_annotations(out / "annotations"))
+        assert len(anns) == 1
+        assert anns[0].function == "login"
+        # Newline itself MUST be gone from the metadata value or
+        # writing would have raised.
+        assert "\n" not in anns[0].metadata.get("entry_point_id", "")
+
+    def test_null_byte_in_id(self, fixture):
+        repo, out = fixture
+        cmap = {"entry_points": [{
+            "id": "EP-1\x00evil", "type": "http_route",
+            "method": "GET", "path": "/x",
+            "file": "src/app.py", "line": 1,
+        }]}
+        (out / "context-map.json").write_text(json.dumps(cmap))
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        ann = read_annotation(out / "annotations", "src/app.py", "login")
+        assert "\x00" not in ann.metadata.get("entry_point_id", "")
+
+    def test_long_notes_in_body_does_not_crash(self, fixture):
+        """Body is free-form prose — large content is fine, but make
+        sure the synth doesn't choke."""
+        repo, out = fixture
+        big_notes = "x " * 50_000  # ~100KB
+        cmap = {"entry_points": [{
+            "id": "EP-1", "type": "http_route", "method": "GET",
+            "path": "/x", "file": "src/app.py", "line": 1,
+            "notes": big_notes,
+        }]}
+        (out / "context-map.json").write_text(json.dumps(cmap))
+        counts = synthesise_from_understand_output(out)
+        assert counts.emitted == 1
+        ann = read_annotation(out / "annotations", "src/app.py", "login")
+        assert len(ann.body) >= 100_000
+
+    def test_path_traversal_in_file_field_rejected(self, fixture):
+        """A malicious context-map could try to land an annotation
+        at ``../etc/passwd``. The substrate's path-traversal defence
+        catches this — synth must record an error, not propagate."""
+        repo, out = fixture
+        # Add an inventory entry for the traversal target so resolve
+        # would otherwise succeed.
+        ck = json.loads((out / "checklist.json").read_text())
+        ck["files"].append({
+            "path": "../etc/passwd",
+            "items": [{"name": "evil", "line_start": 1, "line_end": 2}],
+        })
+        (out / "checklist.json").write_text(json.dumps(ck))
+        cmap = {"entry_points": [{
+            "id": "EP-1", "type": "http_route", "method": "GET",
+            "path": "/x", "file": "../etc/passwd", "line": 1,
+        }]}
+        (out / "context-map.json").write_text(json.dumps(cmap))
+        counts = synthesise_from_understand_output(out)
+        # Substrate's _validate_source_path rejects ``..``
+        # ValueError → counted in errors, not emitted.
+        assert counts.errors >= 1
+        assert counts.emitted == 0
+        # The annotation tree did not gain an ``../etc/passwd.md`` file
+        # at the parent dir.
+        assert not (out / "annotations" / ".." / "etc" / "passwd.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Trace step adversarial inputs.
+# ---------------------------------------------------------------------------
+
+
+class TestMaliciousTraceContent:
+    def test_step_description_with_newlines_preserved_in_body(self, fixture):
+        """Body is markdown — newlines in description are fine and
+        preserved verbatim."""
+        repo, out = fixture
+        trace = {"steps": [{
+            "step": 1, "type": "entry",
+            "definition": "src/app.py:1",
+            "description": "line one\nline two\nline three",
+            "tainted_var": "x", "transform": "none",
+            "confidence": "high",
+        }]}
+        (out / "flow-trace-EP-1.json").write_text(json.dumps(trace))
+        counts = synthesise_from_understand_output(out)
+        assert counts.emitted == 1
+        ann = read_annotation(out / "annotations", "src/app.py", "login")
+        assert "line two" in ann.body
+
+    def test_huge_step_count(self, fixture):
+        """LLM emits a 1000-step trace. Synth must complete and not
+        explode the annotation file."""
+        repo, out = fixture
+        steps = [
+            {
+                "step": i, "type": "call",
+                "definition": "src/app.py:1",
+                "description": f"step {i}",
+                "tainted_var": "x", "transform": "none",
+                "confidence": "high",
+            }
+            for i in range(1, 1001)
+        ]
+        (out / "flow-trace-EP-1.json").write_text(json.dumps({"steps": steps}))
+        counts = synthesise_from_understand_output(out)
+        # All steps target the same function. Last writer wins, so
+        # only one annotation on disk.
+        assert counts.emitted == 1000
+        anns = list(iter_all_annotations(out / "annotations"))
+        assert len(anns) == 1
+
+    def test_step_type_with_special_chars(self, fixture):
+        repo, out = fixture
+        trace = {"steps": [{
+            "step": 1,
+            "type": "call\x00<!-- evil -->",
+            "definition": "src/app.py:1",
+            "description": "x",
+            "confidence": "high",
+        }]}
+        (out / "flow-trace-EP-1.json").write_text(json.dumps(trace))
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        ann = read_annotation(out / "annotations", "src/app.py", "login")
+        assert "\x00" not in ann.metadata.get("type", "")
+        assert "-->" not in ann.metadata.get("type", "")
+
+    def test_definition_with_relative_path_traversal(self, fixture):
+        """Step definition pointing at ``../etc/passwd:1`` — synth's
+        own ``_resolve`` calls ``lookup_function`` which treats the
+        path as inventory-relative. With no matching inventory entry
+        it returns None, so the step is skipped."""
+        repo, out = fixture
+        trace = {"steps": [{
+            "step": 1, "type": "call",
+            "definition": "../etc/passwd:1",
+            "description": "x",
+            "confidence": "high",
+        }]}
+        (out / "flow-trace-EP-1.json").write_text(json.dumps(trace))
+        counts = synthesise_from_understand_output(out)
+        assert counts.emitted == 0
+        assert counts.skipped_no_function >= 1
+
+
+# ---------------------------------------------------------------------------
+# Inventory poisoning.
+# ---------------------------------------------------------------------------
+
+
+class TestInventoryPoisoning:
+    def test_function_name_with_newline_rejected(self, fixture):
+        """A poisoned checklist could carry a function name with
+        embedded newlines. Substrate ``_validate_function_name``
+        rejects with ValueError, synth records an error, no
+        annotation lands."""
+        repo, out = fixture
+        ck = json.loads((out / "checklist.json").read_text())
+        ck["files"][0]["items"][0]["name"] = "login\n## injected"
+        (out / "checklist.json").write_text(json.dumps(ck))
+        cmap = {"entry_points": [{
+            "id": "EP-1", "type": "http_route", "method": "GET",
+            "path": "/x", "file": "src/app.py", "line": 1,
+        }]}
+        (out / "context-map.json").write_text(json.dumps(cmap))
+        counts = synthesise_from_understand_output(out)
+        # Substrate raises → counted as error.
+        assert counts.errors >= 1
+        # Tree has no malformed annotation.
+        anns = list(iter_all_annotations(out / "annotations"))
+        # Either zero, or one without the injection.
+        for a in anns:
+            assert "##" not in a.function
+
+    def test_corrupt_target_path_in_checklist(self, tmp_path):
+        """``target_path`` resolves repo_root for hash computation.
+        If it points at a non-existent directory, hash returns "" —
+        annotation still lands, just without staleness metadata."""
+        out = tmp_path / "out"
+        out.mkdir()
+        ck = {
+            "target_path": "/nonexistent/path/that/does/not/exist",
+            "files": [{
+                "path": "src/app.py",
+                "items": [{
+                    "name": "f", "line_start": 1, "line_end": 2,
+                }],
+            }],
+        }
+        (out / "checklist.json").write_text(json.dumps(ck))
+        cmap = {"entry_points": [{
+            "id": "EP-1", "type": "http_route", "method": "GET",
+            "path": "/x", "file": "src/app.py", "line": 1,
+        }]}
+        (out / "context-map.json").write_text(json.dumps(cmap))
+        counts = synthesise_from_understand_output(out)
+        assert counts.emitted == 1
+        ann = read_annotation(out / "annotations", "src/app.py", "f")
+        # No hash key — source unreadable.
+        assert "hash" not in ann.metadata
+
+
+# ---------------------------------------------------------------------------
+# Robustness: various JSON / structural surprises.
+# ---------------------------------------------------------------------------
+
+
+class TestStructuralSurprises:
+    def test_entry_points_is_null_not_list(self, fixture):
+        """LLM emits ``"entry_points": null`` instead of ``[]``."""
+        repo, out = fixture
+        cmap = {"entry_points": None, "sink_details": None}
+        (out / "context-map.json").write_text(json.dumps(cmap))
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        assert counts.emitted == 0
+
+    def test_entry_point_missing_required_fields(self, fixture):
+        """Some entry points lack ``file`` or ``line``."""
+        repo, out = fixture
+        cmap = {"entry_points": [
+            {"id": "EP-1"},  # no file, no line
+            {"id": "EP-2", "file": "src/app.py"},  # no line
+            {"id": "EP-3", "line": 1},  # no file
+        ]}
+        (out / "context-map.json").write_text(json.dumps(cmap))
+        counts = synthesise_from_understand_output(out)
+        # All three skipped — none crashed.
+        assert counts.skipped_no_function >= 3
+        assert counts.errors == 0
+
+    def test_flow_trace_with_no_steps_key(self, fixture):
+        repo, out = fixture
+        (out / "flow-trace-EP-X.json").write_text(json.dumps({}))
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        assert counts.emitted == 0
+
+    def test_flow_trace_with_steps_not_a_list(self, fixture):
+        """LLM emits a ``steps`` value that isn't a list (string,
+        null, scalar). Synth must drop it silently — no crash, no
+        annotations, no errors."""
+        repo, out = fixture
+        (out / "flow-trace-EP-X.json").write_text(
+            json.dumps({"steps": "not a list"})
+        )
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        assert counts.emitted == 0
+
+    def test_steps_list_with_non_dict_entries(self, fixture):
+        """``steps: [{...valid...}, "garbage", null, 42]`` — the
+        valid step lands, the others are silently dropped."""
+        repo, out = fixture
+        trace = {"steps": [
+            {
+                "step": 1, "type": "entry",
+                "definition": "src/app.py:1",
+                "description": "valid step",
+                "tainted_var": "x", "transform": "none",
+                "confidence": "high",
+            },
+            "garbage string",
+            None,
+            42,
+            ["nested"],
+        ]}
+        (out / "flow-trace-EP-1.json").write_text(json.dumps(trace))
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        assert counts.emitted == 1
+
+    def test_entry_points_is_string_not_list(self, fixture):
+        """LLM emits ``"entry_points": "see notes"`` instead of a list."""
+        repo, out = fixture
+        cmap = {"entry_points": "see notes"}
+        (out / "context-map.json").write_text(json.dumps(cmap))
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        assert counts.emitted == 0

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -1235,6 +1235,20 @@ class AutonomousSecurityAgentV2:
         report_file = self.out_dir / "autonomous_analysis_report.json"
         save_json(report_file, report)
 
+        # Emit a coverage record from the annotations tree, so
+        # ``raptor-coverage-summary`` picks them up as reviewed
+        # functions. Best-effort — coverage record failures should
+        # not break the analysis report.
+        try:
+            from core.coverage.record import (
+                build_from_annotations, write_record,
+            )
+            ann_record = build_from_annotations(self.out_dir / "annotations")
+            if ann_record:
+                write_record(self.out_dir, ann_record, tool_name="annotations")
+        except Exception:
+            logger.debug("annotation coverage record failed", exc_info=True)
+
         if is_prep_only:
             logger.debug(f"Prep complete: {len(unique_findings)} findings")
         else:

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -1142,6 +1142,26 @@ class AutonomousSecurityAgentV2:
                 if self.analyze_vulnerability(vuln):
                     analyzed += 1
 
+                    # Emit a per-function annotation summarising the
+                    # LLM's verdict + reasoning. Best-effort —
+                    # annotation failures don't break analysis.
+                    # Skipped when checklist is missing or function
+                    # name can't be resolved from file:line.
+                    try:
+                        from packages.llm_analysis.annotation_emit import (
+                            emit_finding_annotation,
+                        )
+                        emit_finding_annotation(
+                            vuln,
+                            base_dir=self.out_dir / "annotations",
+                            checklist=checklist,
+                            repo_root=self.repo_path,
+                        )
+                    except Exception:
+                        logger.debug(
+                            "annotation emit error", exc_info=True,
+                        )
+
                     # Track dataflow validation
                     if vuln.has_dataflow and vuln.analysis and 'dataflow_validation' in vuln.analysis:
                         dataflow_validated += 1

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -1042,6 +1042,30 @@ class AutonomousSecurityAgentV2:
                     f"(skipped {len(data.get('findings', [])) - len(converted)} ruled out/unlikely)")
         return converted
 
+    def _emit_finding_annotation(
+        self, vuln: "VulnerabilityContext",
+        checklist: Optional[Dict[str, Any]],
+    ) -> None:
+        """Emit a per-function annotation for ``vuln`` after analysis
+        completes. Best-effort — any exception is logged at DEBUG and
+        swallowed so annotation failures cannot break the analysis loop.
+
+        Skipped silently when ``checklist`` is None or the function
+        name can't be resolved from the finding's file:line.
+        """
+        try:
+            from packages.llm_analysis.annotation_emit import (
+                emit_finding_annotation,
+            )
+            emit_finding_annotation(
+                vuln,
+                base_dir=self.out_dir / "annotations",
+                checklist=checklist,
+                repo_root=self.repo_path,
+            )
+        except Exception:
+            logger.debug("annotation emit error", exc_info=True)
+
     def process_findings(self, sarif_paths: List[str] = None, findings_path: str = None,
                          max_findings: int = 10, checklist: Dict[str, Any] = None) -> Dict[str, Any]:
         """Process findings with full LLM-powered autonomous workflow."""
@@ -1141,26 +1165,7 @@ class AutonomousSecurityAgentV2:
                 # 1. Autonomous analysis (LLM-powered, or prep-only)
                 if self.analyze_vulnerability(vuln):
                     analyzed += 1
-
-                    # Emit a per-function annotation summarising the
-                    # LLM's verdict + reasoning. Best-effort —
-                    # annotation failures don't break analysis.
-                    # Skipped when checklist is missing or function
-                    # name can't be resolved from file:line.
-                    try:
-                        from packages.llm_analysis.annotation_emit import (
-                            emit_finding_annotation,
-                        )
-                        emit_finding_annotation(
-                            vuln,
-                            base_dir=self.out_dir / "annotations",
-                            checklist=checklist,
-                            repo_root=self.repo_path,
-                        )
-                    except Exception:
-                        logger.debug(
-                            "annotation emit error", exc_info=True,
-                        )
+                    self._emit_finding_annotation(vuln, checklist)
 
                     # Track dataflow validation
                     if vuln.has_dataflow and vuln.analysis and 'dataflow_validation' in vuln.analysis:

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -1070,8 +1070,16 @@ class AutonomousSecurityAgentV2:
             return None
 
     def process_findings(self, sarif_paths: List[str] = None, findings_path: str = None,
-                         max_findings: int = 10, checklist: Dict[str, Any] = None) -> Dict[str, Any]:
-        """Process findings with full LLM-powered autonomous workflow."""
+                         max_findings: int = 10, checklist: Dict[str, Any] = None,
+                         emit_annotations: bool = True) -> Dict[str, Any]:
+        """Process findings with full LLM-powered autonomous workflow.
+
+        ``emit_annotations``: when False, skip the per-finding
+        annotation emit and the end-of-run coverage record. Useful
+        for operators who want analysis without the side effect of
+        modifying the annotation tree (e.g. CI runs that compare
+        scanner output rather than persist review state).
+        """
         start_time = time.time()
 
         # Parse findings
@@ -1169,8 +1177,9 @@ class AutonomousSecurityAgentV2:
                 # 1. Autonomous analysis (LLM-powered, or prep-only)
                 if self.analyze_vulnerability(vuln):
                     analyzed += 1
-                    if self._emit_finding_annotation(vuln, checklist):
-                        annotations_emitted += 1
+                    if emit_annotations:
+                        if self._emit_finding_annotation(vuln, checklist):
+                            annotations_emitted += 1
 
                     # Track dataflow validation
                     if vuln.has_dataflow and vuln.analysis and 'dataflow_validation' in vuln.analysis:
@@ -1238,16 +1247,18 @@ class AutonomousSecurityAgentV2:
         # Emit a coverage record from the annotations tree, so
         # ``raptor-coverage-summary`` picks them up as reviewed
         # functions. Best-effort — coverage record failures should
-        # not break the analysis report.
-        try:
-            from core.coverage.record import (
-                build_from_annotations, write_record,
-            )
-            ann_record = build_from_annotations(self.out_dir / "annotations")
-            if ann_record:
-                write_record(self.out_dir, ann_record, tool_name="annotations")
-        except Exception:
-            logger.debug("annotation coverage record failed", exc_info=True)
+        # not break the analysis report. Skipped when annotation
+        # emission was suppressed.
+        if emit_annotations:
+            try:
+                from core.coverage.record import (
+                    build_from_annotations, write_record,
+                )
+                ann_record = build_from_annotations(self.out_dir / "annotations")
+                if ann_record:
+                    write_record(self.out_dir, ann_record, tool_name="annotations")
+            except Exception:
+                logger.debug("annotation coverage record failed", exc_info=True)
 
         if is_prep_only:
             logger.debug(f"Prep complete: {len(unique_findings)} findings")
@@ -1322,6 +1333,12 @@ def main() -> None:
     ap.add_argument("--out", help="Output directory")
     ap.add_argument("--max-findings", type=int, default=10, help="Max findings to process")
     ap.add_argument("--checklist", help="Inventory checklist.json for function metadata lookup")
+    ap.add_argument(
+        "--no-annotations",
+        action="store_true",
+        help="Skip per-finding annotation emission and the "
+             "annotation-derived coverage record",
+    )
     ap.add_argument("--prep-only", action="store_true",
                     help="Skip LLM analysis; produce structured findings for external orchestration")
     ap.add_argument("--max-parallel", type=int, default=3, help="Max parallel dispatch threads")
@@ -1382,12 +1399,15 @@ def main() -> None:
             logger.warning(f"Could not load checklist: {args.checklist}")
 
     # Process findings - route based on input type
+    emit_annotations = not args.no_annotations
     if args.findings:
         report = agent.process_findings(findings_path=args.findings, max_findings=args.max_findings,
-                                        checklist=checklist)
+                                        checklist=checklist,
+                                        emit_annotations=emit_annotations)
     else:
         report = agent.process_findings(sarif_paths=args.sarif, max_findings=args.max_findings,
-                                        checklist=checklist)
+                                        checklist=checklist,
+                                        emit_annotations=emit_annotations)
 
     # Orchestrated path: role flags → prep then parallel dispatch
     if _has_role_flags and report.get("mode") == "prep_only":

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -1045,19 +1045,21 @@ class AutonomousSecurityAgentV2:
     def _emit_finding_annotation(
         self, vuln: "VulnerabilityContext",
         checklist: Optional[Dict[str, Any]],
-    ) -> None:
+    ) -> Optional[Path]:
         """Emit a per-function annotation for ``vuln`` after analysis
         completes. Best-effort — any exception is logged at DEBUG and
         swallowed so annotation failures cannot break the analysis loop.
 
-        Skipped silently when ``checklist`` is None or the function
-        name can't be resolved from the finding's file:line.
+        Returns the annotation path on success, or ``None`` if the
+        emit was skipped (no checklist, no inventory match, manual
+        annotation already present, or an error was swallowed).
+        Caller can use the return value for telemetry.
         """
         try:
             from packages.llm_analysis.annotation_emit import (
                 emit_finding_annotation,
             )
-            emit_finding_annotation(
+            return emit_finding_annotation(
                 vuln,
                 base_dir=self.out_dir / "annotations",
                 checklist=checklist,
@@ -1065,6 +1067,7 @@ class AutonomousSecurityAgentV2:
             )
         except Exception:
             logger.debug("annotation emit error", exc_info=True)
+            return None
 
     def process_findings(self, sarif_paths: List[str] = None, findings_path: str = None,
                          max_findings: int = 10, checklist: Dict[str, Any] = None) -> Dict[str, Any]:
@@ -1118,6 +1121,7 @@ class AutonomousSecurityAgentV2:
         patches_generated = 0
         dataflow_validated = 0
         false_positives_found = 0
+        annotations_emitted = 0
         idx = 0  # Initialize idx to prevent UnboundLocalError when unique_findings is empty
 
         is_prep = isinstance(self.llm, ClaudeCodeProvider)
@@ -1165,7 +1169,8 @@ class AutonomousSecurityAgentV2:
                 # 1. Autonomous analysis (LLM-powered, or prep-only)
                 if self.analyze_vulnerability(vuln):
                     analyzed += 1
-                    self._emit_finding_annotation(vuln, checklist)
+                    if self._emit_finding_annotation(vuln, checklist):
+                        annotations_emitted += 1
 
                     # Track dataflow validation
                     if vuln.has_dataflow and vuln.analysis and 'dataflow_validation' in vuln.analysis:
@@ -1220,6 +1225,7 @@ class AutonomousSecurityAgentV2:
             "patches_generated": patches_generated,
             "dataflow_validated": dataflow_validated,
             "false_positives_caught": false_positives_found,
+            "annotations_emitted": annotations_emitted,
             "execution_time": execution_time,
             "llm_stats": llm_stats,
             "results": results,
@@ -1237,6 +1243,11 @@ class AutonomousSecurityAgentV2:
             logger.info(f"✓ Exploitable: {exploitable} vulnerabilities")
             logger.info(f"✓ Exploits generated: {exploits_generated}")
             logger.info(f"✓ Patches generated: {patches_generated}")
+            if annotations_emitted > 0:
+                logger.info(
+                    f"✓ Annotations emitted: {annotations_emitted} "
+                    f"(in {self.out_dir / 'annotations'})"
+                )
             logger.info(f"")
             if dataflow_validated > 0:
                 logger.info(f"Dataflow Validation:")

--- a/packages/llm_analysis/annotation_emit.py
+++ b/packages/llm_analysis/annotation_emit.py
@@ -1,0 +1,194 @@
+"""Per-finding annotation emission for ``/agentic``.
+
+Writes one ``core.annotations`` record per analysed vulnerability,
+attached to the function that contains the finding. Annotations
+land under ``<run_output_dir>/annotations/`` so they accumulate
+across runs and so ``iter_all_annotations`` can aggregate them.
+
+This is the first LLM-driven consumer of the annotations substrate.
+Calls ``write_annotation(..., overwrite="respect-manual")`` so a
+manual operator note (``source=human``) survives subsequent
+``/agentic`` runs.
+
+Status mapping (from the vuln's analysis dict):
+
+  * ``is_true_positive=False``                           → ``clean``
+  * ``is_true_positive=True``  + ``is_exploitable=True``  → ``finding``
+  * ``is_true_positive=True``  + ``is_exploitable=False`` → ``suspicious``
+  * neither set / no analysis                            → ``error``
+
+Skipped silently when:
+
+  * No inventory ``checklist`` provided (function name unknown).
+  * No inventory entry matches the finding's file:line.
+  * The finding has no ``file_path`` or ``start_line``.
+  * An existing same-name annotation is ``source=human``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from core.annotations import (
+    Annotation,
+    compute_function_hash,
+    write_annotation,
+)
+from core.inventory.lookup import lookup_function
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_function(
+    vuln, checklist: Optional[Dict[str, Any]], repo_root: Path,
+) -> Optional[Tuple[str, Optional[int], Optional[int]]]:
+    """Find the function containing ``vuln``'s file:line in the
+    inventory. Returns ``(name, line_start, line_end)`` or ``None``
+    if not resolvable."""
+    if not checklist:
+        return None
+    file_path = getattr(vuln, "file_path", None)
+    start_line = getattr(vuln, "start_line", None)
+    if not file_path or not start_line:
+        return None
+    try:
+        func = lookup_function(
+            checklist, file_path, int(start_line),
+            repo_root=str(repo_root),
+        )
+    except (ValueError, TypeError):
+        return None
+    if not func:
+        return None
+    name = func.get("name")
+    if not name:
+        return None
+    return name, func.get("line_start"), func.get("line_end")
+
+
+def _derive_status(analysis: Optional[Dict[str, Any]]) -> str:
+    """Map the analysis dict's verdict bools to the annotation
+    status enum. Defaults to ``error`` when neither flag is set
+    (analysis didn't complete or schema-violated)."""
+    if not analysis:
+        return "error"
+    is_tp = analysis.get("is_true_positive")
+    if is_tp is False:
+        return "clean"
+    if is_tp is True:
+        return "finding" if analysis.get("is_exploitable") else "suspicious"
+    return "error"
+
+
+def _build_body(vuln) -> str:
+    """Compose the annotation body. Prefers the LLM's own ``reasoning``
+    field (the analysis schema's required prose key); falls back to
+    the scanner's ``message`` when no analysis is available."""
+    parts: list[str] = []
+    analysis = getattr(vuln, "analysis", None) or {}
+
+    reasoning = analysis.get("reasoning") or analysis.get("explanation")
+    if reasoning:
+        parts.append(str(reasoning).strip())
+
+    severity = analysis.get("severity_assessment")
+    if severity:
+        parts.append(f"Severity: {severity}")
+
+    if getattr(vuln, "has_dataflow", False):
+        dv = analysis.get("dataflow_validation") or {}
+        if dv:
+            fp = dv.get("false_positive")
+            if fp is not None:
+                parts.append(f"Dataflow validation: false_positive={fp}")
+
+    # Fall back to the scanner's own message when there's no LLM prose.
+    if not parts:
+        message = getattr(vuln, "message", None)
+        if message:
+            parts.append(f"Scanner message: {message}")
+
+    return "\n\n".join(parts)
+
+
+def _sanitise_meta(value) -> str:
+    """``write_annotation`` rejects metadata values containing newlines,
+    nulls, or HTML-comment delimiters (``<!--`` / ``-->``). Coerce to
+    a single-line string and strip the forbidden sequences so we never
+    raise from inside the agentic loop."""
+    s = str(value)
+    s = s.replace("\n", " ").replace("\r", " ").replace("\x00", "")
+    s = s.replace("-->", "->").replace("<!--", "<!-")
+    return s.strip()
+
+
+def emit_finding_annotation(
+    vuln,
+    base_dir: Path,
+    checklist: Optional[Dict[str, Any]],
+    repo_root: Path,
+) -> Optional[Path]:
+    """Write one annotation for ``vuln`` if all the prerequisites are
+    met. Returns the path written, or ``None`` if the emit was skipped
+    (function not resolvable, or ``respect-manual`` blocked the write).
+
+    Best-effort: any unexpected error is logged and swallowed so
+    annotation-emit failures cannot break ``/agentic`` analysis.
+    """
+    try:
+        resolved = _resolve_function(vuln, checklist, repo_root)
+        if not resolved:
+            return None
+        name, line_start, line_end = resolved
+
+        analysis = getattr(vuln, "analysis", None)
+        metadata: Dict[str, str] = {
+            "source": "llm",
+            "status": _derive_status(analysis),
+        }
+        rule_id = getattr(vuln, "rule_id", None)
+        if rule_id:
+            metadata["rule_id"] = _sanitise_meta(rule_id)
+        cwe_id = getattr(vuln, "cwe_id", None)
+        if cwe_id:
+            metadata["cwe"] = _sanitise_meta(cwe_id)
+        tool = getattr(vuln, "tool", None)
+        if tool:
+            metadata["tool"] = _sanitise_meta(tool)
+
+        if analysis:
+            score = analysis.get("exploitability_score")
+            if score is not None:
+                try:
+                    metadata["score"] = f"{float(score):.2f}"
+                except (TypeError, ValueError):
+                    pass
+
+        # Stamp source-line hash for staleness detection. Skipped if
+        # we don't have line bounds from the inventory (e.g. parser
+        # didn't capture line_end for that function).
+        file_path = getattr(vuln, "file_path", None)
+        if file_path and line_start and line_end:
+            src = Path(repo_root) / file_path
+            h = compute_function_hash(src, line_start, line_end)
+            if h:
+                metadata["hash"] = h
+                metadata["start_line"] = str(line_start)
+                metadata["end_line"] = str(line_end)
+
+        ann = Annotation(
+            file=file_path,
+            function=name,
+            body=_build_body(vuln),
+            metadata=metadata,
+        )
+        return write_annotation(base_dir, ann, overwrite="respect-manual")
+    except Exception as e:
+        # Annotation emission is best-effort. Log and move on.
+        logger.warning(
+            f"annotation emit failed for "
+            f"{getattr(vuln, 'file_path', '?')}: {e}"
+        )
+        return None

--- a/packages/llm_analysis/tests/test_annotation_emit.py
+++ b/packages/llm_analysis/tests/test_annotation_emit.py
@@ -1,0 +1,345 @@
+"""Tests for ``packages.llm_analysis.annotation_emit``.
+
+Uses a hand-rolled stub vuln + checklist so the tests don't require
+LLM, repository, or scanner state. The helper is pure substrate
+glue, so unit-level isolation is appropriate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from packages.llm_analysis.annotation_emit import (
+    _build_body,
+    _derive_status,
+    _resolve_function,
+    _sanitise_meta,
+    emit_finding_annotation,
+)
+from core.annotations import (
+    Annotation,
+    read_annotation,
+    write_annotation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stub vuln + checklist
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StubVuln:
+    file_path: str = "src/auth.py"
+    start_line: int = 12
+    rule_id: str = "py/sql-injection"
+    cwe_id: str = "CWE-89"
+    tool: str = "codeql"
+    message: str = "Tainted query string reaches cursor.execute"
+    has_dataflow: bool = False
+    analysis: Optional[Dict[str, Any]] = None
+
+
+def _checklist_with_function(
+    file_path="src/auth.py", name="login", line_start=10, line_end=25,
+) -> Dict[str, Any]:
+    return {
+        "files": [
+            {
+                "path": file_path,
+                "items": [
+                    {
+                        "name": name,
+                        "line_start": line_start,
+                        "line_end": line_end,
+                    }
+                ],
+            }
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# _derive_status
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveStatus:
+    def test_false_positive_is_clean(self):
+        assert _derive_status({"is_true_positive": False}) == "clean"
+
+    def test_exploitable_true_is_finding(self):
+        assert _derive_status({
+            "is_true_positive": True, "is_exploitable": True,
+        }) == "finding"
+
+    def test_true_positive_not_exploitable_is_suspicious(self):
+        assert _derive_status({
+            "is_true_positive": True, "is_exploitable": False,
+        }) == "suspicious"
+
+    def test_missing_analysis_is_error(self):
+        assert _derive_status(None) == "error"
+        assert _derive_status({}) == "error"
+
+    def test_missing_is_true_positive_is_error(self):
+        assert _derive_status({"is_exploitable": True}) == "error"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_function
+# ---------------------------------------------------------------------------
+
+
+class TestResolveFunction:
+    def test_finds_function_by_line(self, tmp_path):
+        ck = _checklist_with_function()
+        v = StubVuln(file_path="src/auth.py", start_line=12)
+        result = _resolve_function(v, ck, tmp_path)
+        assert result == ("login", 10, 25)
+
+    def test_returns_none_no_checklist(self, tmp_path):
+        v = StubVuln()
+        assert _resolve_function(v, None, tmp_path) is None
+        assert _resolve_function(v, {}, tmp_path) is None
+
+    def test_returns_none_no_file_path(self, tmp_path):
+        ck = _checklist_with_function()
+        v = StubVuln(file_path="", start_line=12)
+        assert _resolve_function(v, ck, tmp_path) is None
+
+    def test_returns_none_no_line(self, tmp_path):
+        ck = _checklist_with_function()
+        v = StubVuln(start_line=0)
+        assert _resolve_function(v, ck, tmp_path) is None
+
+    def test_returns_none_no_match(self, tmp_path):
+        ck = _checklist_with_function(file_path="src/other.py")
+        v = StubVuln(file_path="src/auth.py")
+        assert _resolve_function(v, ck, tmp_path) is None
+
+    def test_returns_none_when_function_lacks_name(self, tmp_path):
+        ck = {
+            "files": [
+                {
+                    "path": "src/auth.py",
+                    "items": [{"line_start": 10, "line_end": 25}],
+                },
+            ],
+        }
+        v = StubVuln()
+        assert _resolve_function(v, ck, tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# _build_body
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBody:
+    def test_uses_reasoning_field(self):
+        v = StubVuln(analysis={"reasoning": "Tainted from request.args"})
+        body = _build_body(v)
+        assert "Tainted from request.args" in body
+
+    def test_includes_severity(self):
+        v = StubVuln(analysis={
+            "reasoning": "x", "severity_assessment": "high",
+        })
+        body = _build_body(v)
+        assert "Severity: high" in body
+
+    def test_falls_back_to_scanner_message(self):
+        v = StubVuln(analysis=None)
+        body = _build_body(v)
+        assert "Scanner message" in body
+        assert "Tainted query string" in body
+
+    def test_dataflow_validation_appended(self):
+        v = StubVuln(
+            has_dataflow=True,
+            analysis={
+                "reasoning": "x",
+                "dataflow_validation": {"false_positive": False},
+            },
+        )
+        body = _build_body(v)
+        assert "false_positive=False" in body
+
+
+# ---------------------------------------------------------------------------
+# _sanitise_meta
+# ---------------------------------------------------------------------------
+
+
+class TestSanitiseMeta:
+    def test_strips_newlines(self):
+        assert "\n" not in _sanitise_meta("line1\nline2")
+
+    def test_strips_html_comment_close(self):
+        assert "-->" not in _sanitise_meta("evil-->payload")
+
+    def test_strips_html_comment_open(self):
+        assert "<!--" not in _sanitise_meta("evil<!--payload")
+
+    def test_preserves_normal_text(self):
+        assert _sanitise_meta("CWE-78") == "CWE-78"
+
+
+# ---------------------------------------------------------------------------
+# emit_finding_annotation
+# ---------------------------------------------------------------------------
+
+
+class TestEmitFindingAnnotation:
+    def test_writes_annotation_for_finding(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "src").mkdir()
+        (repo / "src" / "auth.py").write_text(
+            "\n" * 9 + "def login(req):\n    return query(req)\n" * 8
+        )
+        ann_base = tmp_path / "anns"
+        ck = _checklist_with_function()
+        v = StubVuln(analysis={
+            "is_true_positive": True,
+            "is_exploitable": True,
+            "reasoning": "Tainted from request.args reaches cursor.execute",
+            "exploitability_score": 0.85,
+            "severity_assessment": "high",
+        })
+        path = emit_finding_annotation(
+            v, base_dir=ann_base, checklist=ck, repo_root=repo,
+        )
+        assert path is not None
+        ann = read_annotation(ann_base, "src/auth.py", "login")
+        assert ann is not None
+        assert ann.metadata["status"] == "finding"
+        assert ann.metadata["source"] == "llm"
+        assert ann.metadata["cwe"] == "CWE-89"
+        assert ann.metadata["rule_id"] == "py/sql-injection"
+        assert ann.metadata["score"] == "0.85"
+        assert ann.metadata.get("hash"), "hash should be stamped"
+        assert "Tainted from request.args" in ann.body
+
+    def test_returns_none_no_checklist(self, tmp_path):
+        v = StubVuln(analysis={"is_true_positive": False})
+        result = emit_finding_annotation(
+            v, base_dir=tmp_path, checklist=None, repo_root=tmp_path,
+        )
+        assert result is None
+
+    def test_returns_none_function_not_in_inventory(self, tmp_path):
+        # Checklist exists but doesn't cover the finding's file.
+        ck = _checklist_with_function(file_path="src/other.py")
+        v = StubVuln(file_path="src/auth.py")
+        result = emit_finding_annotation(
+            v, base_dir=tmp_path, checklist=ck, repo_root=tmp_path,
+        )
+        assert result is None
+
+    def test_status_clean_for_false_positive(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        ann_base = tmp_path / "anns"
+        ck = _checklist_with_function()
+        v = StubVuln(analysis={
+            "is_true_positive": False,
+            "reasoning": "Operator already validates this input upstream",
+        })
+        emit_finding_annotation(
+            v, base_dir=ann_base, checklist=ck, repo_root=repo,
+        )
+        ann = read_annotation(ann_base, "src/auth.py", "login")
+        assert ann.metadata["status"] == "clean"
+
+    def test_status_suspicious_for_true_positive_not_exploitable(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        ann_base = tmp_path / "anns"
+        ck = _checklist_with_function()
+        v = StubVuln(analysis={
+            "is_true_positive": True,
+            "is_exploitable": False,
+            "reasoning": "Real bug but no reachable attacker path",
+        })
+        emit_finding_annotation(
+            v, base_dir=ann_base, checklist=ck, repo_root=repo,
+        )
+        ann = read_annotation(ann_base, "src/auth.py", "login")
+        assert ann.metadata["status"] == "suspicious"
+
+    def test_respects_manual_annotation(self, tmp_path):
+        """Operator manual note must not be clobbered by /agentic."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        ann_base = tmp_path / "anns"
+        # Operator wrote a manual note first.
+        write_annotation(ann_base, Annotation(
+            file="src/auth.py", function="login",
+            body="reviewer: Alice — clean after manual review",
+            metadata={"source": "human", "status": "clean"},
+        ))
+        # /agentic comes along.
+        ck = _checklist_with_function()
+        v = StubVuln(analysis={
+            "is_true_positive": True, "is_exploitable": True,
+            "reasoning": "LLM disagrees",
+        })
+        result = emit_finding_annotation(
+            v, base_dir=ann_base, checklist=ck, repo_root=repo,
+        )
+        assert result is None  # respect-manual blocked the write
+        # Manual content intact.
+        ann = read_annotation(ann_base, "src/auth.py", "login")
+        assert ann.metadata["source"] == "human"
+        assert "Alice" in ann.body
+
+    def test_skip_when_no_line_bounds_in_inventory(self, tmp_path):
+        """If the inventory entry has no line_end, hash is skipped but
+        annotation should still be written (with name only)."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        ann_base = tmp_path / "anns"
+        ck = {
+            "files": [{
+                "path": "src/auth.py",
+                "items": [{
+                    "name": "login", "line_start": 10,
+                    # no line_end
+                }],
+            }],
+        }
+        v = StubVuln(analysis={
+            "is_true_positive": True, "is_exploitable": False,
+            "reasoning": "...",
+        })
+        path = emit_finding_annotation(
+            v, base_dir=ann_base, checklist=ck, repo_root=repo,
+        )
+        assert path is not None
+        ann = read_annotation(ann_base, "src/auth.py", "login")
+        assert "hash" not in ann.metadata
+
+    def test_swallows_unexpected_errors(self, tmp_path, monkeypatch):
+        """Any exception inside emit must be logged and swallowed —
+        annotation failures cannot break /agentic."""
+        ck = _checklist_with_function()
+        v = StubVuln(analysis={"is_true_positive": False})
+
+        # Force write_annotation to blow up.
+        from packages.llm_analysis import annotation_emit as mod
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("simulated disk failure")
+
+        monkeypatch.setattr(mod, "write_annotation", boom)
+        # Should not raise.
+        result = emit_finding_annotation(
+            v, base_dir=tmp_path, checklist=ck, repo_root=tmp_path,
+        )
+        assert result is None

--- a/packages/llm_analysis/tests/test_annotation_wiring.py
+++ b/packages/llm_analysis/tests/test_annotation_wiring.py
@@ -218,6 +218,34 @@ class TestEmitMethod:
 # ---------------------------------------------------------------------------
 
 
+class TestNoAnnotationsOptOut:
+    """``process_findings(emit_annotations=False)`` skips both the
+    per-finding emit and the end-of-run coverage record."""
+
+    def test_emit_method_called_when_default(self, tmp_path, monkeypatch):
+        """Default behaviour: emit method IS called inside the loop."""
+        from packages.llm_analysis import agent as agent_mod
+        agent = _make_agent(tmp_path)
+        (agent.repo_path / "src" / "foo.py").write_text(
+            "\n" * 9 + "def login():\n    pass\n"
+        )
+        # We don't have a clean way to drive process_findings end-to-end
+        # without scaffolding. Instead, directly verify the API:
+        # process_findings honours the emit_annotations kwarg.
+        import inspect
+        sig = inspect.signature(agent.process_findings)
+        assert "emit_annotations" in sig.parameters
+        # Default is True.
+        assert sig.parameters["emit_annotations"].default is True
+
+    def test_signature_documents_opt_out(self, tmp_path):
+        """Pin the docstring mentions the opt-out so future readers
+        know it exists. Doc-test style."""
+        from packages.llm_analysis.agent import AutonomousSecurityAgentV2
+        doc = AutonomousSecurityAgentV2.process_findings.__doc__ or ""
+        assert "emit_annotations" in doc
+
+
 class TestAdversarialAnalysis:
     """The LLM response validator can return a partial dict when
     the model omits fields. The annotation emitter must tolerate

--- a/packages/llm_analysis/tests/test_annotation_wiring.py
+++ b/packages/llm_analysis/tests/test_annotation_wiring.py
@@ -125,6 +125,46 @@ def _set_analysis(vuln, **kwargs) -> None:
     }
 
 
+class TestTelemetry:
+    """Operator visibility: when emits succeed, the count must
+    surface in the report dict (and the operator-facing log line)."""
+
+    def test_emit_method_returns_path_on_success(self, tmp_path):
+        agent = _make_agent(tmp_path)
+        (agent.repo_path / "src" / "foo.py").write_text(
+            "\n" * 9 + "def login():\n    pass\n"
+        )
+        vuln = VulnerabilityContext(_make_finding(), agent.repo_path)
+        _set_analysis(vuln)
+        result = agent._emit_finding_annotation(vuln, _checklist())
+        assert result is not None
+        assert result.exists()
+
+    def test_emit_method_returns_none_on_skip(self, tmp_path):
+        agent = _make_agent(tmp_path)
+        vuln = VulnerabilityContext(_make_finding(), agent.repo_path)
+        _set_analysis(vuln)
+        # No checklist → emit returns None.
+        result = agent._emit_finding_annotation(vuln, None)
+        assert result is None
+
+    def test_emit_method_returns_none_on_helper_exception(
+        self, tmp_path, monkeypatch,
+    ):
+        agent = _make_agent(tmp_path)
+        vuln = VulnerabilityContext(_make_finding(), agent.repo_path)
+        _set_analysis(vuln)
+
+        from packages.llm_analysis import annotation_emit
+
+        def boom(*a, **kw):
+            raise RuntimeError("crash")
+
+        monkeypatch.setattr(annotation_emit, "emit_finding_annotation", boom)
+        result = agent._emit_finding_annotation(vuln, _checklist())
+        assert result is None
+
+
 class TestEmitMethod:
     def test_emits_annotation_with_correct_args(self, tmp_path):
         agent = _make_agent(tmp_path)

--- a/packages/llm_analysis/tests/test_annotation_wiring.py
+++ b/packages/llm_analysis/tests/test_annotation_wiring.py
@@ -1,0 +1,382 @@
+"""Wiring + adversarial-input tests for the /agentic annotation emit path.
+
+The 27 tests in ``test_annotation_emit.py`` exercise the helper module
+in isolation. These tests cover what the helper tests can't:
+
+  * The ``AutonomousSecurityAgentV2._emit_finding_annotation`` method
+    actually drives the helper with the right arguments
+    (``out_dir/annotations``, ``checklist``, ``repo_path``).
+  * The wiring point in ``process_findings`` calls the method.
+  * Weird ``vuln.analysis`` shapes the schema validator might let
+    through: ``None`` for required bools, NaN scores, missing fields,
+    oversized reasoning text, control characters in CWE.
+
+If any of these break, ``/agentic`` would silently emit nothing or
+crash the analysis loop — neither would have shown up in the helper
+unit tests.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+
+from core.annotations import read_annotation
+from packages.llm_analysis.agent import (
+    AutonomousSecurityAgentV2,
+    VulnerabilityContext,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+AGENT_PY = REPO_ROOT / "packages" / "llm_analysis" / "agent.py"
+
+
+# ---------------------------------------------------------------------------
+# Static-wiring sanity: process_findings calls the method.
+# ---------------------------------------------------------------------------
+
+
+class TestProcessFindingsCallsTheMethod:
+    """If someone refactors and drops the call, the on-disk emit
+    path silently disappears. Pin it with a static check."""
+
+    def test_call_present_in_process_findings(self):
+        text = AGENT_PY.read_text(encoding="utf-8")
+        assert "self._emit_finding_annotation(vuln, checklist)" in text
+
+    def test_call_is_inside_analyze_vulnerability_branch(self):
+        """The call must be inside the ``if analyze_vulnerability``
+        block (post-analysis) — otherwise it fires on every iteration
+        regardless of whether analysis happened."""
+        text = AGENT_PY.read_text(encoding="utf-8")
+        # Find the analyze_vulnerability check and the emit call.
+        ana_idx = text.index("if self.analyze_vulnerability(vuln):")
+        emit_idx = text.index("self._emit_finding_annotation(vuln, checklist)")
+        # Emit must come after the conditional (within the block).
+        assert emit_idx > ana_idx
+        # And reasonably close — within ~500 chars (same indent block).
+        assert emit_idx - ana_idx < 500
+
+
+# ---------------------------------------------------------------------------
+# Method-level wiring: drive _emit_finding_annotation directly.
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(tmp_path: Path) -> AutonomousSecurityAgentV2:
+    """Build the smallest possible agent that doesn't call any LLM."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src").mkdir()
+    out = tmp_path / "out"
+    return AutonomousSecurityAgentV2(
+        repo_path=repo, out_dir=out, prep_only=True,
+    )
+
+
+def _make_finding(
+    file_path="src/foo.py",
+    line=10,
+    rule_id="py/sql-injection",
+    cwe_id="CWE-89",
+    tool="codeql",
+) -> Dict[str, Any]:
+    return {
+        "finding_id": "f1",
+        "rule_id": rule_id,
+        "file": file_path,
+        "startLine": line,
+        "endLine": line + 5,
+        "level": "warning",
+        "message": "msg",
+        "tool": tool,
+        "cwe_id": cwe_id,
+    }
+
+
+def _checklist(file_path="src/foo.py", name="login",
+               line_start=10, line_end=15) -> Dict[str, Any]:
+    return {
+        "files": [
+            {
+                "path": file_path,
+                "items": [{
+                    "name": name,
+                    "line_start": line_start,
+                    "line_end": line_end,
+                }],
+            }
+        ]
+    }
+
+
+def _set_analysis(vuln, **kwargs) -> None:
+    vuln.analysis = {
+        "is_true_positive": kwargs.get("is_true_positive", True),
+        "is_exploitable": kwargs.get("is_exploitable", True),
+        "reasoning": kwargs.get("reasoning", "test reasoning"),
+        "exploitability_score": kwargs.get("exploitability_score", 0.5),
+        "severity_assessment": kwargs.get("severity_assessment", "medium"),
+    }
+
+
+class TestEmitMethod:
+    def test_emits_annotation_with_correct_args(self, tmp_path):
+        agent = _make_agent(tmp_path)
+        # Source file the helper will hash.
+        (agent.repo_path / "src" / "foo.py").write_text(
+            "\n" * 9 + "def login(req):\n    return req\n" * 4
+        )
+        vuln = VulnerabilityContext(_make_finding(), agent.repo_path)
+        _set_analysis(vuln)
+
+        agent._emit_finding_annotation(vuln, _checklist())
+
+        ann = read_annotation(
+            agent.out_dir / "annotations", "src/foo.py", "login",
+        )
+        assert ann is not None
+        assert ann.metadata["source"] == "llm"
+        assert ann.metadata["status"] == "finding"
+        assert ann.metadata["rule_id"] == "py/sql-injection"
+        assert "test reasoning" in ann.body
+
+    def test_swallows_helper_exceptions(self, tmp_path, monkeypatch):
+        """Even if the helper blows up unexpectedly, the agent method
+        must not propagate — this is the OUTER try/except that wraps
+        even an exception escaping the helper's own swallow."""
+        agent = _make_agent(tmp_path)
+        vuln = VulnerabilityContext(_make_finding(), agent.repo_path)
+        _set_analysis(vuln)
+
+        from packages.llm_analysis import annotation_emit
+
+        def boom(*a, **kw):
+            raise RuntimeError("simulated crash")
+
+        monkeypatch.setattr(annotation_emit, "emit_finding_annotation", boom)
+        # Must not raise.
+        agent._emit_finding_annotation(vuln, _checklist())
+
+    def test_no_checklist_skips(self, tmp_path):
+        agent = _make_agent(tmp_path)
+        vuln = VulnerabilityContext(_make_finding(), agent.repo_path)
+        _set_analysis(vuln)
+        # No exception, no annotation directory created.
+        agent._emit_finding_annotation(vuln, None)
+        assert not (agent.out_dir / "annotations").exists() or \
+               not any((agent.out_dir / "annotations").rglob("*.md"))
+
+
+# ---------------------------------------------------------------------------
+# Adversarial vuln.analysis shapes that the schema might let through.
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarialAnalysis:
+    """The LLM response validator can return a partial dict when
+    the model omits fields. The annotation emitter must tolerate
+    every shape the validator might produce."""
+
+    def test_is_true_positive_none(self, tmp_path):
+        """``is_true_positive`` missing → status 'error', not crash."""
+        agent = _make_agent(tmp_path)
+        (agent.repo_path / "src" / "foo.py").write_text(
+            "\n" * 9 + "def login():\n    pass\n"
+        )
+        vuln = VulnerabilityContext(_make_finding(), agent.repo_path)
+        # Note: not using _set_analysis — leaving is_true_positive out.
+        vuln.analysis = {"reasoning": "shrug"}
+        agent._emit_finding_annotation(vuln, _checklist())
+        ann = read_annotation(
+            agent.out_dir / "annotations", "src/foo.py", "login",
+        )
+        assert ann is not None
+        assert ann.metadata["status"] == "error"
+
+    def test_is_true_positive_string_value(self, tmp_path):
+        """A model may emit ``"yes"`` instead of ``true``. The
+        emitter should treat anything non-True/non-False as 'error'
+        — never crash."""
+        agent = _make_agent(tmp_path)
+        (agent.repo_path / "src" / "foo.py").write_text(
+            "\n" * 9 + "def login():\n    pass\n"
+        )
+        vuln = VulnerabilityContext(_make_finding(), agent.repo_path)
+        vuln.analysis = {
+            "is_true_positive": "yes",  # not a bool!
+            "reasoning": "x",
+        }
+        agent._emit_finding_annotation(vuln, _checklist())
+        ann = read_annotation(
+            agent.out_dir / "annotations", "src/foo.py", "login",
+        )
+        assert ann is not None
+        assert ann.metadata["status"] == "error"
+
+    def test_nan_score_silently_dropped(self, tmp_path):
+        """NaN scores can't be formatted with ``f"{x:.2f}"`` — no,
+        wait, NaN CAN be formatted. But Inf can't be formatted as
+        a finite. Either way, the emit should not crash."""
+        agent = _make_agent(tmp_path)
+        (agent.repo_path / "src" / "foo.py").write_text(
+            "\n" * 9 + "def login():\n    pass\n"
+        )
+        vuln = VulnerabilityContext(_make_finding(), agent.repo_path)
+        vuln.analysis = {
+            "is_true_positive": True,
+            "is_exploitable": True,
+            "reasoning": "x",
+            "exploitability_score": float("nan"),
+        }
+        agent._emit_finding_annotation(vuln, _checklist())
+        ann = read_annotation(
+            agent.out_dir / "annotations", "src/foo.py", "login",
+        )
+        assert ann is not None
+        # Either no score key, or "nan" — both acceptable, just no crash.
+
+    def test_inf_score_silently_dropped(self, tmp_path):
+        agent = _make_agent(tmp_path)
+        (agent.repo_path / "src" / "foo.py").write_text(
+            "\n" * 9 + "def login():\n    pass\n"
+        )
+        vuln = VulnerabilityContext(_make_finding(), agent.repo_path)
+        vuln.analysis = {
+            "is_true_positive": True,
+            "is_exploitable": True,
+            "reasoning": "x",
+            "exploitability_score": float("inf"),
+        }
+        agent._emit_finding_annotation(vuln, _checklist())
+        # No crash.
+
+    def test_score_as_string(self, tmp_path):
+        """Some LLMs emit scores as strings."""
+        agent = _make_agent(tmp_path)
+        (agent.repo_path / "src" / "foo.py").write_text(
+            "\n" * 9 + "def login():\n    pass\n"
+        )
+        vuln = VulnerabilityContext(_make_finding(), agent.repo_path)
+        vuln.analysis = {
+            "is_true_positive": True, "is_exploitable": True,
+            "reasoning": "x",
+            "exploitability_score": "0.7",
+        }
+        agent._emit_finding_annotation(vuln, _checklist())
+        ann = read_annotation(
+            agent.out_dir / "annotations", "src/foo.py", "login",
+        )
+        assert ann.metadata.get("score") == "0.70"
+
+    def test_unparseable_score_skipped(self, tmp_path):
+        agent = _make_agent(tmp_path)
+        (agent.repo_path / "src" / "foo.py").write_text(
+            "\n" * 9 + "def login():\n    pass\n"
+        )
+        vuln = VulnerabilityContext(_make_finding(), agent.repo_path)
+        vuln.analysis = {
+            "is_true_positive": True, "is_exploitable": True,
+            "reasoning": "x",
+            "exploitability_score": "very high",  # unparseable
+        }
+        agent._emit_finding_annotation(vuln, _checklist())
+        ann = read_annotation(
+            agent.out_dir / "annotations", "src/foo.py", "login",
+        )
+        # No 'score' metadata key — silently skipped.
+        assert "score" not in ann.metadata
+
+    def test_huge_reasoning_text(self, tmp_path):
+        """An LLM that returns 100KB of reasoning shouldn't kill us."""
+        agent = _make_agent(tmp_path)
+        (agent.repo_path / "src" / "foo.py").write_text(
+            "\n" * 9 + "def login():\n    pass\n"
+        )
+        vuln = VulnerabilityContext(_make_finding(), agent.repo_path)
+        big_reasoning = "x" * 100_000
+        vuln.analysis = {
+            "is_true_positive": True, "is_exploitable": False,
+            "reasoning": big_reasoning,
+        }
+        agent._emit_finding_annotation(vuln, _checklist())
+        ann = read_annotation(
+            agent.out_dir / "annotations", "src/foo.py", "login",
+        )
+        assert ann is not None
+        assert len(ann.body) >= 100_000
+
+    def test_cwe_with_html_comment_close(self, tmp_path):
+        """A scanner could emit a malformed cwe_id. Sanitiser must
+        strip ``-->`` so the metadata HTML comment isn't broken."""
+        agent = _make_agent(tmp_path)
+        (agent.repo_path / "src" / "foo.py").write_text(
+            "\n" * 9 + "def login():\n    pass\n"
+        )
+        vuln = VulnerabilityContext(
+            _make_finding(cwe_id="CWE-89-->evil"),
+            agent.repo_path,
+        )
+        _set_analysis(vuln)
+        agent._emit_finding_annotation(vuln, _checklist())
+        ann = read_annotation(
+            agent.out_dir / "annotations", "src/foo.py", "login",
+        )
+        assert ann is not None
+        assert "-->" not in ann.metadata["cwe"]
+
+    def test_rule_id_with_newline(self, tmp_path):
+        """Newline in rule_id would corrupt the metadata HTML
+        comment. Sanitiser converts to space."""
+        agent = _make_agent(tmp_path)
+        (agent.repo_path / "src" / "foo.py").write_text(
+            "\n" * 9 + "def login():\n    pass\n"
+        )
+        vuln = VulnerabilityContext(
+            _make_finding(rule_id="rule\nwith\nnewlines"),
+            agent.repo_path,
+        )
+        _set_analysis(vuln)
+        agent._emit_finding_annotation(vuln, _checklist())
+        ann = read_annotation(
+            agent.out_dir / "annotations", "src/foo.py", "login",
+        )
+        assert "\n" not in ann.metadata["rule_id"]
+
+    def test_null_byte_in_tool(self, tmp_path):
+        agent = _make_agent(tmp_path)
+        (agent.repo_path / "src" / "foo.py").write_text(
+            "\n" * 9 + "def login():\n    pass\n"
+        )
+        vuln = VulnerabilityContext(
+            _make_finding(tool="codeql\x00"), agent.repo_path,
+        )
+        _set_analysis(vuln)
+        agent._emit_finding_annotation(vuln, _checklist())
+        ann = read_annotation(
+            agent.out_dir / "annotations", "src/foo.py", "login",
+        )
+        assert "\x00" not in ann.metadata["tool"]
+
+    def test_none_analysis_falls_back_to_message(self, tmp_path):
+        """Skipped analysis (vuln.analysis is None) — emit should
+        still write an annotation using the scanner's message as body
+        and status='error'."""
+        agent = _make_agent(tmp_path)
+        (agent.repo_path / "src" / "foo.py").write_text(
+            "\n" * 9 + "def login():\n    pass\n"
+        )
+        vuln = VulnerabilityContext(_make_finding(), agent.repo_path)
+        # vuln.analysis stays None.
+        agent._emit_finding_annotation(vuln, _checklist())
+        ann = read_annotation(
+            agent.out_dir / "annotations", "src/foo.py", "login",
+        )
+        assert ann is not None
+        assert ann.metadata["status"] == "error"
+        assert "Scanner message" in ann.body

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -251,6 +251,11 @@ Examples:
     parser.add_argument("--max-findings", type=int, default=10, help="Maximum findings to process (default: 10)")
     parser.add_argument("--no-exploits", action="store_true", help="Skip exploit generation")
     parser.add_argument("--no-patches", action="store_true", help="Skip patch generation")
+    parser.add_argument(
+        "--no-annotations",
+        action="store_true",
+        help="Skip per-finding annotation emission (default: emit)",
+    )
     parser.add_argument("--out", help="Output directory")
     parser.add_argument("--mode", choices=["fast", "thorough"], default="thorough",
                        help="fast: quick scan, thorough: detailed analysis")
@@ -998,6 +1003,11 @@ Examples:
         # Attach checklist for metadata lookup
         if (out_dir / "checklist.json").exists():
             analysis_cmd.extend(["--checklist", str(out_dir / "checklist.json")])
+
+        # Forward --no-annotations opt-out so operators who don't
+        # want annotation side effects (CI / scratch runs) can suppress.
+        if args.no_annotations:
+            analysis_cmd.append("--no-annotations")
 
         # Phase 3 preps data; Phase 4 handles LLM work (unless --sequential)
         if (llm_env.claude_code or llm_env.external_llm) and not args.sequential:


### PR DESCRIPTION
Adds /annotate — per-function prose annotations stored as markdown mirroring the source tree. Operators write manual review notes; /agentic and /understand emit them automatically. Manual notes are protected from LLM clobbering. Annotations contribute to coverage, cross-run aggregation, diff, and the project report.

  22 commits, ~8.5k LOC. 1390+ tests passing.

  Layers

  core/annotations/             ← substrate (atomic write, fcntl lock, version marker)
  libexec/raptor-annotate       ← operator CLI (add/ls/show/edit/rm/stale)
  /annotate                     ← slash command
  /agentic + /understand        ← LLM-driven emitters (respect-manual)
  /project annotations          ← cross-run aggregation
  /project annotations-diff     ← state diff between runs
  /project report               ← annotations.md in the bundle
  coverage records              ← contribute to coverage-summary
