### PR TITLE
feat(checker_synthesis): KNighter checker synthesis primitive

### DIFF
--- a/packages/checker_synthesis/__init__.py
+++ b/packages/checker_synthesis/__init__.py
@@ -1,0 +1,55 @@
+"""KNighter-style checker synthesis (SOSP 2025).
+
+Turn a single confirmed bug into a Semgrep or Coccinelle rule, run
+it across the codebase, surface variant matches. The thing that
+makes ``/audit`` Phase A find more than per-function review alone.
+
+Pipeline:
+
+  1. ``propose``    — LLM gets a confirmed bug (function source +
+                      reasoning + CWE) and outputs a candidate rule.
+  2. ``validate``   — Run the rule against the seed function's file
+                      alone. The rule must match the original bug
+                      (positive control). If not, one refinement
+                      retry; then give up.
+  3. ``run``        — Execute the rule across the repo. Collect
+                      matches with line numbers.
+  4. ``triage``     — Optional LLM pass per match: variant /
+                      false_positive / uncertain. Bounded by
+                      ``max_triage_calls``.
+
+Engine choice is automatic from file language:
+  * Coccinelle for C source (``.c`` / ``.h``) — the precise tool
+    for kernel-style patches and missing-checks bugs.
+  * Semgrep for everything else (Python, Java, Go, JavaScript, etc.).
+
+Initial consumers:
+  * ``/audit`` Phase A — every confirmed hypothesis triggers
+    a checker-synthesis attempt; surfaced variants get re-reviewed.
+  * Standalone via ``libexec/raptor-synthesise-checker`` for
+    testing rules manually before /audit ships.
+"""
+
+from __future__ import annotations
+
+from .languages import detect_engine, supported_engines
+from .models import (
+    CheckerSynthesisResult,
+    Match,
+    MatchTriage,
+    SeedBug,
+    SynthesisedRule,
+)
+from .synthesise import LLMCallable, synthesise_and_run
+
+__all__ = [
+    "CheckerSynthesisResult",
+    "LLMCallable",
+    "Match",
+    "MatchTriage",
+    "SeedBug",
+    "SynthesisedRule",
+    "detect_engine",
+    "supported_engines",
+    "synthesise_and_run",
+]

--- a/packages/checker_synthesis/languages.py
+++ b/packages/checker_synthesis/languages.py
@@ -1,0 +1,70 @@
+"""Engine selection for KNighter checker synthesis.
+
+Coccinelle is the right tool for C source — its semantic-patch
+language captures kernel-style invariant violations (missing
+checks, leaked locks, missed bounds tests) with surgical precision
+that Semgrep's structural matching can't match.
+
+Semgrep handles every other language we currently support
+(Python, Java, Go, JavaScript, TypeScript, Ruby, Rust, etc.).
+
+Files we can't classify (binary blobs, unrecognised extensions)
+return ``None`` — caller should skip rather than guess.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Set
+
+
+# C source / header — Coccinelle's home turf.
+_COCCINELLE_EXTS: Set[str] = {".c", ".h"}
+
+# Languages Semgrep handles. Not exhaustive — Semgrep supports more —
+# but covers everything RAPTOR's inventory extractors currently know
+# about. Unknown extensions fall through to None so the caller can
+# skip rather than synthesise a rule that has nowhere to run.
+_SEMGREP_EXTS: Set[str] = {
+    ".py", ".pyi",
+    ".java",
+    ".go",
+    ".js", ".jsx", ".mjs", ".cjs",
+    ".ts", ".tsx",
+    ".rb",
+    ".rs",
+    ".php",
+    ".cs",
+    ".kt", ".kts",
+    ".scala",
+    ".swift",
+    ".lua",
+    ".ex", ".exs",
+    # C++: Coccinelle's C++ support is weak; route to Semgrep,
+    # which handles C++ better via tree-sitter.
+    ".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx", ".c++",
+}
+
+
+def detect_engine(file_path: str) -> Optional[str]:
+    """Pick the synthesis engine for a source file.
+
+    Returns ``"coccinelle"`` for C/C++ headers + sources, ``"semgrep"``
+    for everything else we support, or ``None`` for files we don't
+    recognise (binary, unknown extension, no extension).
+    """
+    if not file_path:
+        return None
+    suffix = Path(file_path).suffix.lower()
+    if not suffix:
+        return None
+    if suffix in _COCCINELLE_EXTS:
+        return "coccinelle"
+    if suffix in _SEMGREP_EXTS:
+        return "semgrep"
+    return None
+
+
+def supported_engines() -> tuple[str, ...]:
+    """The engines this package can synthesise rules for."""
+    return ("semgrep", "coccinelle")

--- a/packages/checker_synthesis/models.py
+++ b/packages/checker_synthesis/models.py
@@ -1,0 +1,146 @@
+"""Dataclasses for the checker-synthesis pipeline.
+
+Kept simple and serialisable so ``/audit`` can persist
+synthesis attempts as JSON alongside its annotations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+# Synthesis verdict for an individual cross-codebase match. Mirrors
+# the annotation status enum where it makes sense, but adds
+# ``uncertain`` for cases the LLM can't classify confidently.
+TRIAGE_STATUSES = ("variant", "false_positive", "uncertain", "skipped")
+
+
+@dataclass(frozen=True)
+class SeedBug:
+    """The confirmed bug that seeds a synthesis attempt.
+
+    ``reasoning`` is the LLM's prose from the original analysis —
+    what makes this code buggy, the assumption being violated, the
+    operation that's unsafe. The synthesis prompt uses it to derive
+    the rule's structural pattern.
+    """
+
+    file: str  # repo-relative path
+    function: str
+    line_start: int
+    line_end: int
+    cwe: str
+    reasoning: str
+    snippet: str = ""  # function source text; populated when available
+
+
+@dataclass(frozen=True)
+class SynthesisedRule:
+    """One LLM-proposed checker rule.
+
+    ``engine`` is ``"semgrep"`` or ``"coccinelle"``. The rule body
+    is the verbatim text the LLM produced. ``rule_id`` is a stable
+    identifier used in filenames + log lines; derived from the seed
+    bug's location + a sequence number.
+    """
+
+    engine: str
+    rule_id: str
+    body: str
+    rationale: str = ""  # LLM's explanation of what the rule looks for
+
+
+@dataclass(frozen=True)
+class Match:
+    """One cross-codebase hit from running a synthesised rule."""
+
+    file: str  # repo-relative
+    line: int
+    snippet: str = ""  # the matched code fragment, when the engine provides it
+    metavars: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class MatchTriage:
+    """Per-match LLM verdict from the optional triage pass."""
+
+    match: Match
+    status: str  # one of TRIAGE_STATUSES
+    reasoning: str = ""
+
+
+@dataclass
+class CheckerSynthesisResult:
+    """Top-level output of ``synthesise_and_run``.
+
+    Fields:
+      * ``seed`` — the input bug that seeded the run.
+      * ``rule`` — the LLM's final proposed rule, or None if synthesis
+        failed entirely (positive control never satisfied, syntax
+        error, LLM unavailable).
+      * ``rule_path`` — where ``rule.body`` was written on disk.
+      * ``positive_control`` — did the rule match the seed bug? Always
+        True for results where ``rule`` is not None (we retry / give
+        up before returning a bad rule).
+      * ``matches`` — cross-codebase matches found by the rule.
+      * ``triage`` — optional LLM verdicts per match, in match order.
+      * ``capped`` — True when the match count exceeded
+        ``max_matches`` and the result was truncated.
+      * ``errors`` — best-effort log of failures along the way (rule
+        synthesis errors, run errors, triage failures).
+    """
+
+    seed: SeedBug
+    rule: Optional[SynthesisedRule] = None
+    rule_path: Optional[Path] = None
+    positive_control: bool = False
+    matches: List[Match] = field(default_factory=list)
+    triage: List[MatchTriage] = field(default_factory=list)
+    capped: bool = False
+    errors: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """JSON-serialisable view for persistence next to annotations."""
+        return {
+            "seed": {
+                "file": self.seed.file,
+                "function": self.seed.function,
+                "line_start": self.seed.line_start,
+                "line_end": self.seed.line_end,
+                "cwe": self.seed.cwe,
+                "reasoning": self.seed.reasoning,
+            },
+            "rule": (
+                None if self.rule is None
+                else {
+                    "engine": self.rule.engine,
+                    "rule_id": self.rule.rule_id,
+                    "body": self.rule.body,
+                    "rationale": self.rule.rationale,
+                }
+            ),
+            "rule_path": str(self.rule_path) if self.rule_path else None,
+            "positive_control": self.positive_control,
+            "matches": [
+                {
+                    "file": m.file, "line": m.line,
+                    "snippet": m.snippet, "metavars": dict(m.metavars),
+                }
+                for m in self.matches
+            ],
+            "triage": [
+                {
+                    "match": {
+                        "file": t.match.file, "line": t.match.line,
+                        "snippet": t.match.snippet,
+                    },
+                    "status": t.status,
+                    "reasoning": t.reasoning,
+                }
+                for t in self.triage
+            ],
+            "capped": self.capped,
+            "errors": list(self.errors),
+        }

--- a/packages/checker_synthesis/prompts.py
+++ b/packages/checker_synthesis/prompts.py
@@ -1,0 +1,207 @@
+"""Prompt templates for checker synthesis + match triage.
+
+Two LLM tasks live here:
+
+  * ``synthesis`` — given a confirmed bug, produce a checker rule.
+  * ``triage``    — given a candidate match from running that rule,
+                    classify it as variant / false_positive / uncertain.
+
+Both produce structured JSON responses validated against schemas
+defined in this module. The schemas double as in-prompt
+documentation — the LLM sees them, so the output shape is explicit.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .models import SeedBug, SynthesisedRule, Match
+
+
+# Cap on ``seed.snippet`` going into the synthesis prompt. A huge
+# snippet doesn't help the LLM derive a structural pattern — the
+# function's shape, sources/sinks, and missing checks are what
+# matter — and bloats prompt cost. Mirrors the constant in
+# ``synthesise.py`` so both sites stay in sync.
+_SEED_SNIPPET_MAX_BYTES = 8_192
+
+
+def _truncate_snippet(snippet: str) -> str:
+    """Cap ``snippet`` at ``_SEED_SNIPPET_MAX_BYTES`` UTF-8 bytes.
+    When truncated, append a marker so the LLM knows it's incomplete."""
+    encoded = snippet.encode("utf-8")
+    if len(encoded) <= _SEED_SNIPPET_MAX_BYTES:
+        return snippet
+    truncated = encoded[:_SEED_SNIPPET_MAX_BYTES].decode(
+        "utf-8", errors="ignore",
+    )
+    return truncated + "\n... (snippet truncated)"
+
+
+# ---------------------------------------------------------------------------
+# Synthesis
+# ---------------------------------------------------------------------------
+
+
+SYNTHESIS_SYSTEM = (
+    "You are a security analyst translating a confirmed code-level bug "
+    "into a static analysis rule. The rule must:\n"
+    "  1. Match the original bug's pattern (positive control).\n"
+    "  2. Be tight enough that running it across the codebase surfaces "
+    "VARIANTS of the same bug class — not every superficially similar "
+    "construct.\n"
+    "  3. Be syntactically valid for the chosen engine (Semgrep YAML "
+    "or Coccinelle .cocci).\n\n"
+    "Avoid rules that match every call to a common API (e.g. every "
+    "``subprocess.run``). Match the structural shape that makes the "
+    "ORIGINAL bug unsafe — typically the absence of a check, the use "
+    "of a tainted value at a sink, or a missing cleanup."
+)
+
+
+SYNTHESIS_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "required": ["rule_body", "rationale"],
+    "properties": {
+        "rule_body": {
+            "type": "string",
+            "description": (
+                "The complete rule text — Semgrep YAML or Coccinelle "
+                ".cocci syntax depending on engine. Must be valid as "
+                "written (no placeholders, no '...' literals as code)."
+            ),
+        },
+        "rationale": {
+            "type": "string",
+            "description": (
+                "One paragraph explaining what structural pattern this "
+                "rule captures and why a variant matching this rule is "
+                "likely to be the same bug class."
+            ),
+        },
+    },
+}
+
+
+def build_synthesis_prompt(
+    seed: SeedBug, engine: str, retry_feedback: str = "",
+) -> str:
+    """Compose the synthesis prompt body.
+
+    ``retry_feedback`` is non-empty on a retry — it carries the
+    failure mode of the previous attempt (e.g. "rule did not match
+    the seed function" or "rule produced invalid YAML") so the LLM
+    can refine rather than regenerate from scratch.
+    """
+    parts = [
+        f"BUG TO REPLICATE AS A CHECKER ({engine})",
+        "",
+        f"File:     {seed.file}",
+        f"Function: {seed.function}",
+        f"Lines:    {seed.line_start}–{seed.line_end}",
+        f"CWE:      {seed.cwe}",
+        "",
+        "Reasoning from the original analysis:",
+        seed.reasoning.strip() or "(no reasoning provided)",
+    ]
+    if seed.snippet:
+        parts += [
+            "",
+            "Source of the buggy function:",
+            "```",
+            _truncate_snippet(seed.snippet).rstrip(),
+            "```",
+        ]
+    parts += [
+        "",
+        "TASK:",
+        f"Output a {engine} rule that:",
+        "  1. Matches the original bug at the lines above.",
+        "  2. Captures the structural shape, not the exact text — so "
+        "running it across the codebase finds variants that share the "
+        "same flaw.",
+        "  3. Is tight enough to avoid mass false positives. If your "
+        "first instinct is a single ``pattern: foo(...)`` that would "
+        "match every call to ``foo``, refine it.",
+        "",
+        "Respond with JSON: {\"rule_body\": \"...\", \"rationale\": \"...\"}.",
+    ]
+    if retry_feedback:
+        parts += [
+            "",
+            "RETRY — the previous attempt failed:",
+            retry_feedback,
+            "Refine the rule, don't regenerate from scratch.",
+        ]
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Triage
+# ---------------------------------------------------------------------------
+
+
+TRIAGE_SYSTEM = (
+    "You are evaluating whether a candidate match is the same bug "
+    "class as the seed bug, or a false positive of the synthesised "
+    "rule. Be strict: 'variant' requires the same underlying flaw, "
+    "not just superficial syntactic similarity. When the snippet "
+    "lacks context to decide confidently, return 'uncertain' rather "
+    "than guessing."
+)
+
+
+TRIAGE_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "required": ["status", "reasoning"],
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["variant", "false_positive", "uncertain"],
+        },
+        "reasoning": {
+            "type": "string",
+            "description": "One short paragraph justifying the verdict.",
+        },
+    },
+}
+
+
+def build_triage_prompt(
+    seed: SeedBug, rule: SynthesisedRule, match: Match,
+) -> str:
+    """Compose the triage prompt for one candidate match."""
+    parts = [
+        f"SEED BUG (the confirmed instance, used as ground truth):",
+        f"  File:     {seed.file}",
+        f"  Function: {seed.function}",
+        f"  Lines:    {seed.line_start}–{seed.line_end}",
+        f"  CWE:      {seed.cwe}",
+        f"  Reasoning: {seed.reasoning.strip() or '(none)'}",
+        "",
+        f"SYNTHESISED RULE ({rule.engine}, id={rule.rule_id}):",
+        f"  Rationale: {rule.rationale or '(none)'}",
+        "",
+        "CANDIDATE MATCH (rule fired here, same bug or false positive?):",
+        f"  File: {match.file}",
+        f"  Line: {match.line}",
+    ]
+    if match.snippet:
+        parts += [
+            "  Snippet:",
+            "  ```",
+            "  " + match.snippet.rstrip().replace("\n", "\n  "),
+            "  ```",
+        ]
+    parts += [
+        "",
+        "TASK: classify this match.",
+        "  * variant         — same underlying flaw as the seed bug.",
+        "  * false_positive  — the rule matched but the code is safe.",
+        "  * uncertain       — not enough context to decide.",
+        "",
+        "Respond with JSON: "
+        "{\"status\": \"variant|false_positive|uncertain\", "
+        "\"reasoning\": \"...\"}.",
+    ]
+    return "\n".join(parts)

--- a/packages/checker_synthesis/synthesise.py
+++ b/packages/checker_synthesis/synthesise.py
@@ -1,0 +1,461 @@
+"""Orchestration for KNighter checker synthesis.
+
+Public API: ``synthesise_and_run(seed, repo_root, out_dir, llm,
+**opts)`` returns a ``CheckerSynthesisResult`` documenting every
+stage of the pipeline.
+
+The LLM dependency is injected as a Protocol so tests can stub
+without mocking the ``core.llm`` machinery. Production callers
+pass an adapter around ``LLMClient.generate_structured``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+import tempfile
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Protocol, Tuple
+
+from .languages import detect_engine
+from .models import (
+    CheckerSynthesisResult,
+    Match,
+    MatchTriage,
+    SeedBug,
+    SynthesisedRule,
+)
+from .prompts import (
+    SYNTHESIS_SCHEMA,
+    SYNTHESIS_SYSTEM,
+    TRIAGE_SCHEMA,
+    TRIAGE_SYSTEM,
+    build_synthesis_prompt,
+    build_triage_prompt,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Hard upper bound on rule body size. An LLM that emits a 100KB
+# YAML "rule" is misbehaving; refuse rather than feed it to the
+# scanner. KNighter's published rules sit in the 0.5–4KB range.
+_RULE_BODY_MAX_BYTES = 32_768
+
+# Per-line ceiling on the rule body. A single multi-megabyte line
+# can hang downstream YAML / spatch parsers without tripping the
+# byte cap immediately. Real rule lines are short.
+_RULE_BODY_MAX_LINE = 4_096
+
+# Maximum size for ``seed.snippet`` plumbed into the LLM prompt.
+# A 1MB snippet doesn't help synthesis — the LLM only needs the
+# function's structural shape — and bloats prompt cost / context.
+_SEED_SNIPPET_MAX_BYTES = 8_192
+
+# Threshold above which the codebase scan triggers a "rule too
+# loose" warning. The match cap still applies after this; the
+# warning just tells operators (and /audit) the synthesised rule
+# may need refinement before downstream triage.
+_RULE_TOO_LOOSE_THRESHOLD = 200
+
+
+def _validate_seed_path(file_path: str) -> Optional[str]:
+    """Reject seed file paths that could escape ``repo_root`` or
+    that would refer to an absolute location. Mirrors the defence
+    in ``core.annotations`` — caller-supplied path that we then
+    join with ``repo_root`` to read source.
+
+    Returns an error string on rejection, or None if OK.
+    """
+    if not file_path:
+        return "seed.file must be non-empty"
+    if any(c in file_path for c in "\n\r\x00"):
+        return "seed.file must not contain newline / null characters"
+    p = Path(file_path)
+    if p.is_absolute():
+        return f"seed.file must be relative: {file_path!r}"
+    if any(part == ".." for part in p.parts):
+        return f"seed.file may not contain '..' segments: {file_path!r}"
+    return None
+
+
+def _validate_rule_body(body: str) -> Optional[str]:
+    """Reject rule bodies with control chars or oversized lines.
+    Returns an error string on rejection, or None if OK."""
+    if "\x00" in body:
+        return "rule body contains null byte"
+    for i, line in enumerate(body.split("\n"), 1):
+        if len(line) > _RULE_BODY_MAX_LINE:
+            return (
+                f"rule body line {i} exceeds {_RULE_BODY_MAX_LINE} chars "
+                f"({len(line)})"
+            )
+    return None
+
+
+class LLMCallable(Protocol):
+    """Minimal LLM interface for the synthesis loop.
+
+    Production: wraps ``LLMClient.generate_structured``. Tests:
+    a stub that returns canned dicts.
+
+    Returns the parsed structured response, or None when the LLM
+    cannot satisfy the schema. Raises on transport / auth failure.
+    """
+
+    def __call__(
+        self, prompt: str, schema: Dict[str, Any], system_prompt: str,
+    ) -> Optional[Dict[str, Any]]:
+        ...
+
+
+def _slugify(value: str) -> str:
+    """File-safe slug for rule_id construction."""
+    s = re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("_.")
+    return s or "x"
+
+
+def _make_rule_id(seed: SeedBug, attempt: int) -> str:
+    """Stable rule_id used for filenames + log lines."""
+    return (
+        f"{_slugify(seed.file)}.{_slugify(seed.function)}."
+        f"{_slugify(seed.cwe)}.{attempt}"
+    )
+
+
+def _rule_extension(engine: str) -> str:
+    return ".yml" if engine == "semgrep" else ".cocci"
+
+
+def _write_rule(
+    out_dir: Path, rule: SynthesisedRule,
+) -> Path:
+    """Atomic rule write — mirrors the annotations pattern.
+
+    Concurrent synthesises on the same seed (e.g. an /audit driver
+    parallel-fanning hypothesis tests) could each write the same
+    ``rule_id`` filename. Without atomicity, a reader between the
+    two writes sees partial content; with it, they see one or the
+    other intact.
+    """
+    rules_dir = out_dir / "checkers"
+    rules_dir.mkdir(parents=True, exist_ok=True)
+    path = rules_dir / f"{rule.rule_id}{_rule_extension(rule.engine)}"
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8",
+        dir=rules_dir, prefix=".rule-", suffix=".tmp",
+        delete=False,
+    )
+    try:
+        tmp.write(rule.body)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp.close()
+        os.replace(tmp.name, path)
+    except Exception:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+        raise
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Engine adapters — kept thin so tests can stub them.
+# ---------------------------------------------------------------------------
+
+
+def _run_semgrep(
+    rule_path: Path, target: Path,
+) -> Tuple[List[Match], List[str]]:
+    """Run a Semgrep rule against ``target`` (file or directory).
+    Returns ``(matches, errors)``.
+
+    The runner returns ``SemgrepFinding`` dataclasses (not dicts) —
+    access via attributes. ``file`` is normalised to a path relative
+    to ``target`` when it's under it, otherwise kept as-is.
+    """
+    from packages.semgrep.runner import run_rule
+    result = run_rule(target, str(rule_path))
+    matches: List[Match] = []
+    target_resolved = target.resolve()
+    for f in result.findings or []:
+        # SemgrepFinding has attribute access — file, line, etc.
+        path = getattr(f, "file", "") or ""
+        line = int(getattr(f, "line", 0) or 0)
+        message = getattr(f, "message", "") or ""
+        # Normalise to repo-relative when possible.
+        rel = path
+        try:
+            p = Path(path)
+            if p.is_absolute():
+                rel = str(p.relative_to(target_resolved))
+        except (ValueError, OSError):
+            rel = path
+        matches.append(Match(file=rel, line=line,
+                             snippet=str(message)[:500]))
+    errors: List[str] = list(result.errors or [])
+    return matches, errors
+
+
+def _run_coccinelle(
+    rule_path: Path, target: Path,
+) -> Tuple[List[Match], List[str]]:
+    from packages.coccinelle.runner import run_rule
+    result = run_rule(target, rule_path)
+    matches: List[Match] = []
+    for m in getattr(result, "matches", []) or []:
+        # SpatchMatch shape — access defensively.
+        path = getattr(m, "file", "") or getattr(m, "path", "") or ""
+        line = getattr(m, "line", 0) or 0
+        snippet = getattr(m, "snippet", "") or ""
+        try:
+            rel = str(Path(path).relative_to(target.resolve())) \
+                if Path(path).is_absolute() else path
+        except ValueError:
+            rel = path
+        matches.append(Match(file=rel, line=int(line),
+                             snippet=str(snippet)[:500]))
+    errors = list(getattr(result, "errors", []) or [])
+    return matches, errors
+
+
+def _run_engine(
+    rule: SynthesisedRule, rule_path: Path, target: Path,
+) -> Tuple[List[Match], List[str]]:
+    """Dispatch to engine adapter, swallowing any unexpected
+    exception (ImportError if scanner package not installed,
+    runtime errors from the runner) into the returned ``errors``
+    list. Synthesis failures must never crash the caller."""
+    try:
+        if rule.engine == "semgrep":
+            return _run_semgrep(rule_path, target)
+        if rule.engine == "coccinelle":
+            return _run_coccinelle(rule_path, target)
+        return [], [f"unsupported engine: {rule.engine!r}"]
+    except Exception as e:
+        return [], [f"{rule.engine} adapter error: {e}"]
+
+
+# ---------------------------------------------------------------------------
+# Synthesis steps
+# ---------------------------------------------------------------------------
+
+
+def _propose_rule(
+    seed: SeedBug, engine: str, attempt: int, llm: LLMCallable,
+    retry_feedback: str = "",
+) -> Tuple[Optional[SynthesisedRule], Optional[str]]:
+    """Single LLM round-trip producing one candidate rule.
+    Returns ``(rule, error)``; exactly one is set."""
+    prompt = build_synthesis_prompt(seed, engine, retry_feedback=retry_feedback)
+    try:
+        data = llm(prompt, SYNTHESIS_SCHEMA, SYNTHESIS_SYSTEM)
+    except Exception as e:
+        return None, f"llm error: {e}"
+    if not isinstance(data, dict):
+        return None, "llm returned non-dict response"
+    body = data.get("rule_body")
+    rationale = data.get("rationale", "") or ""
+    if not isinstance(body, str) or not body.strip():
+        return None, "llm response missing 'rule_body'"
+    if len(body.encode("utf-8")) > _RULE_BODY_MAX_BYTES:
+        return None, (
+            f"rule body too large "
+            f"({len(body)} chars > {_RULE_BODY_MAX_BYTES})"
+        )
+    body_err = _validate_rule_body(body)
+    if body_err:
+        return None, body_err
+    return SynthesisedRule(
+        engine=engine,
+        rule_id=_make_rule_id(seed, attempt),
+        body=body,
+        rationale=rationale,
+    ), None
+
+
+def _positive_control(
+    seed: SeedBug, rule_path: Path, repo_root: Path, engine: str,
+) -> Tuple[bool, List[str]]:
+    """Run rule on the seed's source file alone; require at least
+    one match within the seed's line range."""
+    seed_file = repo_root / seed.file
+    if not seed_file.exists():
+        return False, [f"seed file not found: {seed_file}"]
+    rule = SynthesisedRule(engine=engine, rule_id="probe", body="")
+    matches, errors = _run_engine(rule, rule_path, seed_file)
+    for m in matches:
+        if seed.line_start <= m.line <= seed.line_end:
+            return True, errors
+    return False, errors
+
+
+def _is_seed_match(seed: SeedBug, m: Match) -> bool:
+    """Identify a match that IS the seed bug (so we can drop it
+    from the variant list)."""
+    if Path(m.file).name != Path(seed.file).name:
+        return False
+    return seed.line_start <= m.line <= seed.line_end
+
+
+def _triage(
+    seed: SeedBug, rule: SynthesisedRule, matches: List[Match],
+    llm: LLMCallable, max_calls: int,
+) -> Tuple[List[MatchTriage], List[str]]:
+    """LLM-classify each match. Bounded by ``max_calls`` to cap cost.
+    Matches beyond the budget are recorded with ``status='skipped'``.
+    """
+    out: List[MatchTriage] = []
+    errors: List[str] = []
+    for i, m in enumerate(matches):
+        if i >= max_calls:
+            out.append(MatchTriage(
+                match=m, status="skipped",
+                reasoning=f"triage budget exhausted after {max_calls} calls",
+            ))
+            continue
+        prompt = build_triage_prompt(seed, rule, m)
+        try:
+            data = llm(prompt, TRIAGE_SCHEMA, TRIAGE_SYSTEM)
+        except Exception as e:
+            errors.append(f"triage llm error for {m.file}:{m.line}: {e}")
+            out.append(MatchTriage(
+                match=m, status="uncertain",
+                reasoning=f"triage failed: {e}",
+            ))
+            continue
+        if not isinstance(data, dict):
+            out.append(MatchTriage(
+                match=m, status="uncertain",
+                reasoning="triage response was not a dict",
+            ))
+            continue
+        status = str(data.get("status", "uncertain"))
+        if status not in ("variant", "false_positive", "uncertain"):
+            status = "uncertain"
+        reasoning = str(data.get("reasoning", "") or "")
+        out.append(MatchTriage(match=m, status=status, reasoning=reasoning))
+    return out, errors
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def synthesise_and_run(
+    seed: SeedBug,
+    repo_root: Path,
+    out_dir: Path,
+    llm: LLMCallable,
+    *,
+    max_retries: int = 1,
+    max_matches: int = 50,
+    triage_each: bool = False,
+    max_triage_calls: int = 50,
+) -> CheckerSynthesisResult:
+    """End-to-end: propose → validate → run → optionally triage.
+
+    Args:
+        seed: confirmed bug to synthesise around.
+        repo_root: root the rule is run against (codebase scan).
+        out_dir: where ``checkers/<rule_id>.{yml,cocci}`` is written.
+        llm: callable matching ``LLMCallable`` Protocol.
+        max_retries: how many times to refine if positive control
+            fails (1 = one refinement attempt). Reasonable default;
+            higher rarely helps.
+        max_matches: variant matches beyond this are dropped and
+            ``capped=True`` is set. Protects against rules so loose
+            they swamp downstream consumers.
+        triage_each: when True, every match gets an LLM verdict.
+            Off by default — costs N×LLM calls per synthesis.
+        max_triage_calls: hard ceiling on triage LLM calls.
+    """
+    repo_root = Path(repo_root).resolve()
+    out_dir = Path(out_dir)
+
+    # Defence-in-depth: reject seed paths that could escape repo_root
+    # before any filesystem touch.
+    path_err = _validate_seed_path(seed.file)
+    if path_err:
+        return CheckerSynthesisResult(seed=seed, errors=[path_err])
+
+    engine = detect_engine(seed.file)
+    if engine is None:
+        return CheckerSynthesisResult(
+            seed=seed,
+            errors=[f"no engine for file extension of {seed.file!r}"],
+        )
+
+    result = CheckerSynthesisResult(seed=seed)
+    feedback = ""
+    rule: Optional[SynthesisedRule] = None
+    rule_path: Optional[Path] = None
+
+    for attempt in range(max_retries + 1):
+        rule, err = _propose_rule(seed, engine, attempt, llm, feedback)
+        if err:
+            result.errors.append(f"attempt {attempt}: {err}")
+            rule = None
+            if attempt >= max_retries:
+                return result
+            feedback = err
+            continue
+
+        rule_path = _write_rule(out_dir, rule)
+        ok, run_errors = _positive_control(seed, rule_path, repo_root, engine)
+        result.errors.extend(f"attempt {attempt}: {e}" for e in run_errors)
+        if ok:
+            break
+        # Positive control failed — retry if we still have budget.
+        result.errors.append(
+            f"attempt {attempt}: rule did not match seed at "
+            f"{seed.file}:{seed.line_start}-{seed.line_end}"
+        )
+        feedback = (
+            f"Previous rule did not match the seed bug at lines "
+            f"{seed.line_start}-{seed.line_end} of {seed.file}. "
+            f"Refine the pattern so it captures the original."
+        )
+        rule = None
+        rule_path = None
+
+    if rule is None or rule_path is None:
+        return result
+
+    result.rule = rule
+    result.rule_path = rule_path
+    result.positive_control = True
+
+    # Codebase scan.
+    matches, run_errors = _run_engine(rule, rule_path, repo_root)
+    result.errors.extend(run_errors)
+    # Drop the seed itself from the variant list.
+    variants = [m for m in matches if not _is_seed_match(seed, m)]
+    pre_cap = len(variants)
+    if pre_cap > max_matches:
+        variants = variants[:max_matches]
+        result.capped = True
+    if pre_cap >= _RULE_TOO_LOOSE_THRESHOLD:
+        # Way more matches than a typical bug class produces — the
+        # synthesised rule is almost certainly too loose. Surface
+        # this so /audit can decide whether to refine, retry with
+        # a different prompt, or surface to the operator.
+        result.errors.append(
+            f"rule appears too loose: {pre_cap} variant matches "
+            f"(threshold {_RULE_TOO_LOOSE_THRESHOLD}); refine "
+            f"the synthesis prompt before triaging"
+        )
+    result.matches = variants
+
+    if triage_each and variants:
+        triage, t_errors = _triage(seed, rule, variants, llm, max_triage_calls)
+        result.triage = triage
+        result.errors.extend(t_errors)
+
+    return result

--- a/packages/checker_synthesis/tests/test_adversarial.py
+++ b/packages/checker_synthesis/tests/test_adversarial.py
@@ -1,0 +1,451 @@
+"""Adversarial tests for ``synthesise_and_run``.
+
+Inputs that a malicious upstream (compromised LLM, poisoned seed
+data from a prior /agentic run, hostile repository layout) could
+plausibly hand the synthesis loop. Each must reject cleanly without
+filesystem damage or pipeline crash.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from packages.checker_synthesis import (
+    Match,
+    SeedBug,
+    synthesise_and_run,
+)
+from packages.checker_synthesis import synthesise as synth_mod
+
+
+def _stub_llm(responses):
+    queue = list(responses)
+
+    def llm(prompt, schema, system_prompt):
+        if not queue:
+            raise AssertionError("stub LLM out of responses")
+        item = queue.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+    return llm
+
+
+def _stub_engines(monkeypatch, *, seed_matches, repo_matches):
+    calls = {"n": 0}
+
+    def fake_run(rule, rule_path, target):
+        n = calls["n"]
+        calls["n"] += 1
+        if n == 0:
+            return list(seed_matches), []
+        return list(repo_matches), []
+
+    monkeypatch.setattr(synth_mod, "_run_engine", fake_run)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Path-traversal defence on seed.file
+# ---------------------------------------------------------------------------
+
+
+class TestSeedPathDefence:
+    @pytest.mark.parametrize("bad_path", [
+        "../etc/passwd",
+        "../../../../etc/shadow",
+        "ok/../etc/passwd",
+        "/etc/passwd",
+        "/absolute/path.py",
+    ])
+    def test_traversal_or_absolute_rejected(self, tmp_path, bad_path):
+        seed = SeedBug(
+            file=bad_path, function="evil",
+            line_start=1, line_end=2,
+            cwe="CWE-?", reasoning="r",
+        )
+        # Stub LLM should never get called.
+        llm = _stub_llm([])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        assert result.rule is None
+        assert any(
+            "..'" in e or "must not contain" in e or "must be relative" in e
+            for e in result.errors
+        ), f"expected rejection error, got: {result.errors}"
+
+    def test_newline_in_path_rejected(self, tmp_path):
+        seed = SeedBug(
+            file="src/foo\n.py", function="f",
+            line_start=1, line_end=2,
+            cwe="CWE-?", reasoning="r",
+        )
+        llm = _stub_llm([])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        assert result.rule is None
+        assert any("newline" in e for e in result.errors)
+
+    def test_null_in_path_rejected(self, tmp_path):
+        seed = SeedBug(
+            file="src/foo\x00.py", function="f",
+            line_start=1, line_end=2,
+            cwe="CWE-?", reasoning="r",
+        )
+        llm = _stub_llm([])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        assert result.rule is None
+
+    def test_empty_path_rejected(self, tmp_path):
+        seed = SeedBug(
+            file="", function="f",
+            line_start=1, line_end=2,
+            cwe="CWE-?", reasoning="r",
+        )
+        llm = _stub_llm([])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        assert result.rule is None
+        assert any("non-empty" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# Rule-body validation
+# ---------------------------------------------------------------------------
+
+
+def _seed(tmp_path: Path) -> SeedBug:
+    src_dir = tmp_path / "src"
+    src_dir.mkdir(exist_ok=True)
+    (src_dir / "auth.py").write_text(
+        "def login(req):\n    return cursor.execute(f'x={req.q}')\n"
+    )
+    return SeedBug(
+        file="src/auth.py", function="login",
+        line_start=1, line_end=2,
+        cwe="CWE-89", reasoning="tainted f-string into execute",
+    )
+
+
+class TestRuleBodyValidation:
+    def test_null_byte_in_rule_body_rejected(self, tmp_path, monkeypatch):
+        seed = _seed(tmp_path)
+        _stub_engines(monkeypatch, seed_matches=[], repo_matches=[])
+        llm = _stub_llm([
+            {"rule_body": "rules:\n  - id: x\x00", "rationale": "ok"},
+            {"rule_body": "rules:\n  - id: y\x00", "rationale": "ok"},
+        ])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        assert result.rule is None
+        assert any("null byte" in e for e in result.errors)
+
+    def test_oversized_line_rejected(self, tmp_path, monkeypatch):
+        """Single huge line slips under the byte cap but should
+        still be rejected — engines parse line-by-line."""
+        seed = _seed(tmp_path)
+        _stub_engines(monkeypatch, seed_matches=[], repo_matches=[])
+        # 5000-char single line, total still under 32KB.
+        big_line = "rules:\n  - id: " + ("a" * 5000)
+        llm = _stub_llm([
+            {"rule_body": big_line, "rationale": "ok"},
+            {"rule_body": big_line, "rationale": "ok"},
+        ])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        assert result.rule is None
+        assert any("exceeds" in e for e in result.errors)
+
+    def test_lots_of_short_lines_accepted(self, tmp_path, monkeypatch):
+        """1000 lines × 50 chars = 50KB total but under the per-line
+        cap. Total-byte cap should bite first."""
+        seed = _seed(tmp_path)
+        _stub_engines(
+            monkeypatch,
+            seed_matches=[Match(file="src/auth.py", line=1)],
+            repo_matches=[Match(file="src/auth.py", line=1)],
+        )
+        body = "\n".join(["x" * 50 for _ in range(1000)])  # 50KB
+        llm = _stub_llm([
+            {"rule_body": body, "rationale": "ok"},
+            {"rule_body": body, "rationale": "ok"},
+        ])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        # Total-byte cap fires first.
+        assert result.rule is None
+        assert any("too large" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# Real-engine integration (only when semgrep is on PATH)
+# ---------------------------------------------------------------------------
+
+
+_SEMGREP = shutil.which("semgrep")
+
+
+# ---------------------------------------------------------------------------
+# Atomic rule write
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicRuleWrite:
+    def test_no_tempfile_left_behind(self, tmp_path, monkeypatch):
+        seed = _seed(tmp_path)
+        seed_match = Match(file="src/auth.py", line=2)
+        _stub_engines(
+            monkeypatch,
+            seed_matches=[seed_match],
+            repo_matches=[seed_match],
+        )
+        llm = _stub_llm([
+            {"rule_body": "rules: ...", "rationale": "x"},
+        ])
+        synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        # Tempfile pattern: ``.rule-*.tmp`` in checkers/.
+        leftovers = list((tmp_path / "out" / "checkers").glob(".rule-*.tmp"))
+        assert leftovers == []
+
+    def test_concurrent_writes_no_partial_content(self, tmp_path, monkeypatch):
+        """Two synthesise_and_run calls back-to-back with the same
+        seed produce the same rule_id (attempt 0). The atomic
+        rename means the final on-disk content is one of the two
+        rule bodies, not a partial mix."""
+        seed = _seed(tmp_path)
+        seed_match = Match(file="src/auth.py", line=2)
+        _stub_engines(
+            monkeypatch,
+            seed_matches=[seed_match],
+            repo_matches=[seed_match],
+        )
+        # First write.
+        llm = _stub_llm([
+            {"rule_body": "rules: A_VERSION", "rationale": "first"},
+        ])
+        r1 = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        # Reset engine call count — second write also runs probe.
+        # Plant fresh stub.
+        _stub_engines(
+            monkeypatch,
+            seed_matches=[seed_match],
+            repo_matches=[seed_match],
+        )
+        llm2 = _stub_llm([
+            {"rule_body": "rules: B_VERSION", "rationale": "second"},
+        ])
+        r2 = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm2)
+        text = r2.rule_path.read_text()
+        # Final content is the second write — exactly, no mixing.
+        assert text == "rules: B_VERSION"
+
+
+# ---------------------------------------------------------------------------
+# Snippet truncation
+# ---------------------------------------------------------------------------
+
+
+class TestSnippetTruncation:
+    def test_huge_snippet_truncated_in_prompt(self, tmp_path, monkeypatch):
+        from packages.checker_synthesis.prompts import build_synthesis_prompt
+        seed = SeedBug(
+            file="src/foo.py", function="f",
+            line_start=1, line_end=2,
+            cwe="CWE-?", reasoning="r",
+            snippet="x " * 100_000,  # ~200KB
+        )
+        prompt = build_synthesis_prompt(seed, "semgrep")
+        # Prompt body should be much smaller than the raw snippet.
+        assert len(prompt.encode("utf-8")) < 50_000
+        assert "(snippet truncated)" in prompt
+
+    def test_short_snippet_passes_through(self, tmp_path):
+        from packages.checker_synthesis.prompts import build_synthesis_prompt
+        seed = SeedBug(
+            file="src/foo.py", function="f",
+            line_start=1, line_end=2,
+            cwe="CWE-?", reasoning="r",
+            snippet="def f():\n    pass\n",
+        )
+        prompt = build_synthesis_prompt(seed, "semgrep")
+        assert "def f():" in prompt
+        assert "(snippet truncated)" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# Engine exception swallowing
+# ---------------------------------------------------------------------------
+
+
+class TestEngineExceptionSwallow:
+    def test_engine_import_error_logged(self, tmp_path, monkeypatch):
+        """If the underlying scanner package raises (e.g. binary
+        missing, transport error), synthesise_and_run must swallow
+        and log to ``errors`` rather than crash the caller."""
+        seed = _seed(tmp_path)
+        # Patch _run_semgrep at the module level to simulate an
+        # adapter exception path.
+        from packages.checker_synthesis import synthesise as synth_mod
+
+        def boom(rule_path, target):
+            raise ImportError("semgrep package not installed")
+
+        monkeypatch.setattr(synth_mod, "_run_semgrep", boom)
+
+        llm = _stub_llm([
+            {"rule_body": "rules: ...", "rationale": "x"},
+            {"rule_body": "rules: ...", "rationale": "y"},
+        ])
+        # Should not raise. Returns a result with errors logged.
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        assert result.rule is None
+        assert any("semgrep adapter error" in e for e in result.errors)
+
+    def test_engine_runtime_error_logged(self, tmp_path, monkeypatch):
+        seed = _seed(tmp_path)
+        from packages.checker_synthesis import synthesise as synth_mod
+
+        def boom(rule_path, target):
+            raise RuntimeError("transport failure")
+
+        monkeypatch.setattr(synth_mod, "_run_semgrep", boom)
+        llm = _stub_llm([
+            {"rule_body": "rules: ...", "rationale": "x"},
+            {"rule_body": "rules: ...", "rationale": "y"},
+        ])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        assert result.rule is None
+        assert any("transport failure" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# Rule-too-loose warning
+# ---------------------------------------------------------------------------
+
+
+class TestRuleTooLooseWarning:
+    def test_warning_at_threshold(self, tmp_path, monkeypatch):
+        seed = _seed(tmp_path)
+        seed_match = Match(file="src/auth.py", line=2)
+        # 250 variants — past the 200 threshold.
+        variants = [
+            Match(file=f"src/v{i:03d}.py", line=1)
+            for i in range(250)
+        ]
+        _stub_engines(
+            monkeypatch,
+            seed_matches=[seed_match],
+            repo_matches=[seed_match, *variants],
+        )
+        llm = _stub_llm([
+            {"rule_body": "rules: ...", "rationale": "loose"},
+        ])
+        result = synthesise_and_run(
+            seed, tmp_path, tmp_path / "out", llm,
+            max_matches=50,
+        )
+        # Match cap kicked in.
+        assert result.capped is True
+        assert len(result.matches) == 50
+        # Warning emitted.
+        assert any("too loose" in e for e in result.errors)
+
+    def test_no_warning_under_threshold(self, tmp_path, monkeypatch):
+        seed = _seed(tmp_path)
+        seed_match = Match(file="src/auth.py", line=2)
+        # Only 10 variants — well under the threshold and the cap.
+        variants = [
+            Match(file=f"src/v{i}.py", line=1) for i in range(10)
+        ]
+        _stub_engines(
+            monkeypatch,
+            seed_matches=[seed_match],
+            repo_matches=[seed_match, *variants],
+        )
+        llm = _stub_llm([
+            {"rule_body": "rules: ...", "rationale": "tight"},
+        ])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        assert result.capped is False
+        assert not any("too loose" in e for e in result.errors)
+
+
+@pytest.mark.skipif(_SEMGREP is None, reason="semgrep not on PATH")
+class TestRealSemgrepIntegration:
+    """Drive the actual semgrep adapter end-to-end. Catches shape
+    drift between our adapter (``_run_semgrep``) and what
+    ``packages.semgrep.runner.run_rule`` actually returns."""
+
+    def test_real_semgrep_finds_planted_match(self, tmp_path):
+        # Plant a target with a clear pattern.
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "vuln.py").write_text(
+            "import subprocess\n"
+            "def run_cmd(user_input):\n"
+            "    subprocess.call(user_input, shell=True)\n"
+            "\n"
+            "def run_other(user_input):\n"
+            "    subprocess.call(user_input, shell=True)\n"
+        )
+        seed = SeedBug(
+            file="src/vuln.py", function="run_cmd",
+            line_start=2, line_end=3,
+            cwe="CWE-78",
+            reasoning="subprocess.call with shell=True and user input",
+        )
+
+        # LLM emits a real, valid Semgrep rule that matches both calls.
+        rule_yaml = (
+            "rules:\n"
+            "  - id: subprocess-shell-true\n"
+            "    pattern: subprocess.call(..., shell=True)\n"
+            "    message: subprocess shell=True\n"
+            "    severity: WARNING\n"
+            "    languages: [python]\n"
+        )
+        llm = _stub_llm([
+            {"rule_body": rule_yaml, "rationale": "shell=True is unsafe"},
+        ])
+
+        result = synthesise_and_run(
+            seed, tmp_path, tmp_path / "out", llm,
+        )
+        # Positive control passes — the real semgrep matched the seed.
+        assert result.positive_control is True, (
+            f"positive control failed; errors: {result.errors}"
+        )
+        # The other ``run_other`` call shows up as a variant.
+        variant_files = [m.file for m in result.matches]
+        assert any("vuln.py" in f for f in variant_files), (
+            f"no variant match found; matches: {result.matches}, "
+            f"errors: {result.errors}"
+        )
+        # Rule file written and on disk.
+        assert result.rule_path.exists()
+        assert "subprocess-shell-true" in result.rule_path.read_text()
+
+    def test_real_semgrep_invalid_rule_records_error(self, tmp_path):
+        """A syntactically-broken YAML rule should fail positive
+        control without exploding."""
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "f.py").write_text(
+            "def f(x):\n    eval(x)\n"
+        )
+        seed = SeedBug(
+            file="src/f.py", function="f",
+            line_start=1, line_end=2,
+            cwe="CWE-94", reasoning="eval of user input",
+        )
+        bad_yaml = "rules: [this is not valid"
+        llm = _stub_llm([
+            {"rule_body": bad_yaml, "rationale": "broken"},
+            {"rule_body": bad_yaml, "rationale": "still broken"},
+        ])
+        result = synthesise_and_run(
+            seed, tmp_path, tmp_path / "out", llm,
+        )
+        # Positive control failed; rule is None.
+        assert result.rule is None
+        assert result.positive_control is False
+        # At least one attempt-error logged (semgrep would emit a
+        # parse error or simply fail to match).
+        assert len(result.errors) >= 1

--- a/packages/checker_synthesis/tests/test_languages.py
+++ b/packages/checker_synthesis/tests/test_languages.py
@@ -1,0 +1,52 @@
+"""Tests for engine detection."""
+
+from __future__ import annotations
+
+import pytest
+
+from packages.checker_synthesis import detect_engine, supported_engines
+
+
+class TestDetectEngine:
+    @pytest.mark.parametrize("path", [
+        "src/foo.c",
+        "include/bar.h",
+        "drivers/net/dev.c",
+        "kernel/sched.c",
+    ])
+    def test_c_picks_coccinelle(self, path):
+        assert detect_engine(path) == "coccinelle"
+
+    @pytest.mark.parametrize("path,expected", [
+        ("src/foo.py", "semgrep"),
+        ("src/Foo.java", "semgrep"),
+        ("cmd/main.go", "semgrep"),
+        ("src/app.js", "semgrep"),
+        ("src/app.ts", "semgrep"),
+        ("src/app.tsx", "semgrep"),
+        ("lib/a.rb", "semgrep"),
+        ("src/main.rs", "semgrep"),
+        ("src/PHPFile.php", "semgrep"),
+    ])
+    def test_other_languages_pick_semgrep(self, path, expected):
+        assert detect_engine(path) == expected
+
+    @pytest.mark.parametrize("path", [
+        "Makefile",          # no extension
+        "README",
+        "docs/notes.txt",    # plain text
+        "data.bin",          # binary
+        "image.png",
+        "",                   # empty
+    ])
+    def test_unknown_returns_none(self, path):
+        assert detect_engine(path) is None
+
+    def test_case_insensitive_extension(self):
+        assert detect_engine("src/Foo.PY") == "semgrep"
+        assert detect_engine("src/Foo.C") == "coccinelle"
+
+
+class TestSupportedEngines:
+    def test_returns_tuple(self):
+        assert supported_engines() == ("semgrep", "coccinelle")

--- a/packages/checker_synthesis/tests/test_models.py
+++ b/packages/checker_synthesis/tests/test_models.py
@@ -1,0 +1,103 @@
+"""Tests for ``packages.checker_synthesis.models``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from packages.checker_synthesis import (
+    CheckerSynthesisResult,
+    Match,
+    MatchTriage,
+    SeedBug,
+    SynthesisedRule,
+)
+
+
+class TestSeedBug:
+    def test_minimal_construction(self):
+        s = SeedBug(
+            file="src/foo.py",
+            function="login",
+            line_start=10,
+            line_end=20,
+            cwe="CWE-89",
+            reasoning="Tainted query string reaches cursor.execute",
+        )
+        assert s.file == "src/foo.py"
+        assert s.snippet == ""  # default empty
+
+    def test_frozen(self):
+        s = SeedBug(
+            file="x", function="f", line_start=1, line_end=2,
+            cwe="CWE-78", reasoning="r",
+        )
+        with pytest.raises(Exception):
+            s.file = "y"
+
+
+class TestSynthesisedRule:
+    def test_construction(self):
+        r = SynthesisedRule(
+            engine="semgrep", rule_id="auth.login.cwe-89.0",
+            body="rules:\n  - id: tainted-query\n    patterns: ...",
+            rationale="Pattern catches f-string SQL with user input",
+        )
+        assert r.engine == "semgrep"
+        assert r.rule_id == "auth.login.cwe-89.0"
+
+
+class TestCheckerSynthesisResult:
+    def _seed(self):
+        return SeedBug(
+            file="src/foo.py", function="login",
+            line_start=10, line_end=20,
+            cwe="CWE-89", reasoning="r",
+        )
+
+    def test_default_failure_state(self):
+        r = CheckerSynthesisResult(seed=self._seed())
+        assert r.rule is None
+        assert r.matches == []
+        assert r.triage == []
+        assert r.capped is False
+        assert r.errors == []
+        assert r.positive_control is False
+
+    def test_to_dict_round_trip_no_rule(self):
+        r = CheckerSynthesisResult(
+            seed=self._seed(),
+            errors=["LLM unavailable"],
+        )
+        d = r.to_dict()
+        assert d["rule"] is None
+        assert d["matches"] == []
+        assert d["errors"] == ["LLM unavailable"]
+        # JSON-serialisable.
+        assert json.dumps(d)
+
+    def test_to_dict_with_rule_and_matches(self, tmp_path):
+        rule = SynthesisedRule(
+            engine="semgrep", rule_id="x.0", body="rules: ...",
+        )
+        m = Match(file="src/bar.py", line=5, snippet="db.execute(q)")
+        t = MatchTriage(
+            match=m, status="variant",
+            reasoning="Same pattern, different file",
+        )
+        r = CheckerSynthesisResult(
+            seed=self._seed(),
+            rule=rule,
+            rule_path=tmp_path / "x.yml",
+            positive_control=True,
+            matches=[m],
+            triage=[t],
+        )
+        d = r.to_dict()
+        assert d["rule"]["engine"] == "semgrep"
+        assert d["matches"][0]["file"] == "src/bar.py"
+        assert d["triage"][0]["status"] == "variant"
+        assert d["positive_control"] is True
+        assert json.dumps(d)

--- a/packages/checker_synthesis/tests/test_synthesise.py
+++ b/packages/checker_synthesis/tests/test_synthesise.py
@@ -1,0 +1,403 @@
+"""Tests for the ``synthesise_and_run`` orchestration.
+
+The LLM is stubbed (a callable returning canned dicts). The engine
+runners are stubbed via ``monkeypatch`` so tests don't require
+semgrep / coccinelle binaries on the test runner.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from packages.checker_synthesis import (
+    Match,
+    SeedBug,
+    SynthesisedRule,
+    synthesise_and_run,
+)
+from packages.checker_synthesis import synthesise as synth_mod
+
+
+def _seed(tmp_path: Path) -> SeedBug:
+    """Build a seed bug + plant the source file in tmp_path."""
+    src_dir = tmp_path / "src"
+    src_dir.mkdir(exist_ok=True)
+    (src_dir / "auth.py").write_text(
+        "def login(req):\n"
+        "    q = req.get('q')\n"
+        "    return cursor.execute(f'SELECT * FROM t WHERE x={q}')\n"
+    )
+    return SeedBug(
+        file="src/auth.py",
+        function="login",
+        line_start=1, line_end=3,
+        cwe="CWE-89",
+        reasoning="Tainted query string reaches cursor.execute via f-string",
+        snippet="def login(req): ...",
+    )
+
+
+def _stub_llm(responses):
+    """Return a callable that pops responses in order. Each entry
+    is either a dict (returned) or an Exception subclass instance
+    (raised) or None (returned as None)."""
+    queue = list(responses)
+
+    def llm(prompt, schema, system_prompt):
+        if not queue:
+            raise AssertionError("stub LLM out of responses")
+        item = queue.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+    llm._queue = queue  # noqa: SLF001 — for assertions
+    return llm
+
+
+def _stub_engines(monkeypatch, *, seed_matches, repo_matches, errors=None):
+    """Patch the semgrep + coccinelle adapters to return canned matches.
+
+    The first call (positive control on seed file) returns ``seed_matches``;
+    subsequent calls (codebase scan) return ``repo_matches``.
+    """
+    calls = {"n": 0}
+
+    def fake_run(rule, rule_path, target):
+        n = calls["n"]
+        calls["n"] += 1
+        if n == 0:
+            return list(seed_matches), list(errors or [])
+        return list(repo_matches), list(errors or [])
+
+    monkeypatch.setattr(synth_mod, "_run_engine", fake_run)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_first_attempt_succeeds_with_one_variant(self, tmp_path, monkeypatch):
+        seed = _seed(tmp_path)
+        out = tmp_path / "out"
+        # Seed match at line 3 (inside seed range), one variant elsewhere,
+        # plus the seed itself in the codebase scan (must be filtered out).
+        seed_match = Match(file="src/auth.py", line=3,
+                           snippet="cursor.execute(f'...')")
+        variant = Match(file="src/admin.py", line=42,
+                        snippet="db.exec(f'DROP {tbl}')")
+        _stub_engines(
+            monkeypatch,
+            seed_matches=[seed_match],
+            repo_matches=[seed_match, variant],
+        )
+
+        llm = _stub_llm([
+            {"rule_body": "rules:\n  - id: x\n    pattern: ...\n",
+             "rationale": "f-string into execute"},
+        ])
+        result = synthesise_and_run(seed, tmp_path, out, llm)
+
+        assert result.rule is not None
+        assert result.positive_control is True
+        # Seed itself filtered; only the variant remains.
+        assert len(result.matches) == 1
+        assert result.matches[0].file == "src/admin.py"
+        assert result.capped is False
+        # Rule was written to disk.
+        assert result.rule_path is not None
+        assert result.rule_path.exists()
+        assert result.rule_path.suffix == ".yml"
+        assert result.rule_path.read_text().startswith("rules:")
+
+    def test_coccinelle_engine_for_c_seed(self, tmp_path, monkeypatch):
+        # Plant a C source file as the seed.
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "drv.c").write_text(
+            "void f(struct s *p) {\n"
+            "    if (!p) return;\n"
+            "    p->x = 1;\n"
+            "}\n"
+        )
+        seed = SeedBug(
+            file="src/drv.c", function="f",
+            line_start=1, line_end=4,
+            cwe="CWE-476",
+            reasoning="missing null check before deref",
+        )
+        _stub_engines(
+            monkeypatch,
+            seed_matches=[Match(file="src/drv.c", line=2)],
+            repo_matches=[Match(file="src/drv.c", line=2)],
+        )
+        llm = _stub_llm([
+            {"rule_body": "@@ struct s *p; @@\n p->x", "rationale": "deref"},
+        ])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        assert result.rule.engine == "coccinelle"
+        assert result.rule_path.suffix == ".cocci"
+
+
+# ---------------------------------------------------------------------------
+# Retry / failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestRetry:
+    def test_retry_on_positive_control_miss(self, tmp_path, monkeypatch):
+        """First rule misses the seed; second matches. Retries once,
+        then succeeds."""
+        seed = _seed(tmp_path)
+        # Custom engine stub: first probe misses, third probe (after retry)
+        # hits, fourth call (codebase scan) returns one variant.
+        calls = {"n": 0}
+        seed_match = Match(file="src/auth.py", line=3)
+        variant = Match(file="src/admin.py", line=99)
+
+        def fake_run(rule, rule_path, target):
+            n = calls["n"]
+            calls["n"] += 1
+            # n=0: probe attempt 0 → no match (positive control fails)
+            # n=1: probe attempt 1 → match (positive control passes)
+            # n=2: codebase scan → seed + variant
+            if n == 0:
+                return [], []
+            if n == 1:
+                return [seed_match], []
+            return [seed_match, variant], []
+
+        monkeypatch.setattr(synth_mod, "_run_engine", fake_run)
+        llm = _stub_llm([
+            {"rule_body": "rules:\n  - id: bad", "rationale": "miss"},
+            {"rule_body": "rules:\n  - id: good", "rationale": "hit"},
+        ])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        assert result.positive_control is True
+        # Error log records the first failed attempt.
+        assert any("attempt 0" in e for e in result.errors)
+        assert len(result.matches) == 1
+
+    def test_give_up_after_retry_budget(self, tmp_path, monkeypatch):
+        """Both attempts miss positive control → no rule, no matches."""
+        seed = _seed(tmp_path)
+        _stub_engines(
+            monkeypatch,
+            seed_matches=[],   # always miss
+            repo_matches=[],
+        )
+        llm = _stub_llm([
+            {"rule_body": "rules: []", "rationale": "first"},
+            {"rule_body": "rules: []", "rationale": "second"},
+        ])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm,
+                                    max_retries=1)
+        assert result.rule is None
+        assert result.positive_control is False
+        # Two failure messages logged (attempt 0, attempt 1).
+        miss_errors = [e for e in result.errors if "did not match seed" in e]
+        assert len(miss_errors) == 2
+
+
+class TestLLMFailures:
+    def test_llm_returns_non_dict(self, tmp_path, monkeypatch):
+        seed = _seed(tmp_path)
+        _stub_engines(monkeypatch, seed_matches=[], repo_matches=[])
+        llm = _stub_llm(["not a dict", "also not a dict"])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        assert result.rule is None
+        assert any("non-dict" in e for e in result.errors)
+
+    def test_llm_missing_rule_body(self, tmp_path, monkeypatch):
+        seed = _seed(tmp_path)
+        _stub_engines(monkeypatch, seed_matches=[], repo_matches=[])
+        llm = _stub_llm([
+            {"rationale": "no rule_body field"},
+            {"rationale": "still none"},
+        ])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        assert result.rule is None
+        assert any("missing 'rule_body'" in e for e in result.errors)
+
+    def test_llm_raises_propagates_as_error(self, tmp_path, monkeypatch):
+        seed = _seed(tmp_path)
+        _stub_engines(monkeypatch, seed_matches=[], repo_matches=[])
+        llm = _stub_llm([RuntimeError("transport blew up")] * 2)
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        assert result.rule is None
+        assert any("transport blew up" in e for e in result.errors)
+
+    def test_oversized_rule_rejected(self, tmp_path, monkeypatch):
+        seed = _seed(tmp_path)
+        _stub_engines(monkeypatch, seed_matches=[], repo_matches=[])
+        big = "x" * 100_000
+        llm = _stub_llm([
+            {"rule_body": big, "rationale": "huge"},
+            {"rule_body": big, "rationale": "still huge"},
+        ])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        assert result.rule is None
+        assert any("too large" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# Engine selection
+# ---------------------------------------------------------------------------
+
+
+class TestEngineDetection:
+    def test_unsupported_extension_returns_early(self, tmp_path):
+        seed = SeedBug(
+            file="data/blob.bin", function="?",
+            line_start=1, line_end=10,
+            cwe="CWE-?", reasoning="r",
+        )
+        # No LLM call should be made; supply an empty stub.
+        llm = _stub_llm([])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        assert result.rule is None
+        assert any("no engine" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# Match cap
+# ---------------------------------------------------------------------------
+
+
+class TestMatchCap:
+    def test_caps_at_max_matches(self, tmp_path, monkeypatch):
+        seed = _seed(tmp_path)
+        seed_match = Match(file="src/auth.py", line=3)
+        variants = [
+            Match(file=f"src/v{i:03d}.py", line=10)
+            for i in range(100)
+        ]
+        _stub_engines(
+            monkeypatch,
+            seed_matches=[seed_match],
+            repo_matches=[seed_match, *variants],
+        )
+        llm = _stub_llm([
+            {"rule_body": "rules: [...]", "rationale": "x"},
+        ])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm,
+                                    max_matches=10)
+        assert result.capped is True
+        assert len(result.matches) == 10
+
+
+# ---------------------------------------------------------------------------
+# Triage
+# ---------------------------------------------------------------------------
+
+
+class TestTriage:
+    def test_triage_each_match(self, tmp_path, monkeypatch):
+        seed = _seed(tmp_path)
+        seed_match = Match(file="src/auth.py", line=3)
+        v1 = Match(file="src/a.py", line=10, snippet="db.exec(...)")
+        v2 = Match(file="src/b.py", line=20, snippet="db.exec(...)")
+        _stub_engines(
+            monkeypatch,
+            seed_matches=[seed_match],
+            repo_matches=[seed_match, v1, v2],
+        )
+        llm = _stub_llm([
+            {"rule_body": "rules: ...", "rationale": "x"},
+            {"status": "variant", "reasoning": "same shape"},
+            {"status": "false_positive", "reasoning": "different sink"},
+        ])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm,
+                                    triage_each=True)
+        assert len(result.triage) == 2
+        assert result.triage[0].status == "variant"
+        assert result.triage[1].status == "false_positive"
+
+    def test_triage_budget_marks_remainder_skipped(self, tmp_path, monkeypatch):
+        seed = _seed(tmp_path)
+        seed_match = Match(file="src/auth.py", line=3)
+        variants = [Match(file=f"src/v{i}.py", line=1) for i in range(5)]
+        _stub_engines(
+            monkeypatch,
+            seed_matches=[seed_match],
+            repo_matches=[seed_match, *variants],
+        )
+        llm = _stub_llm([
+            {"rule_body": "rules: ...", "rationale": "x"},
+            # Only 2 triage budget — remaining 3 should be skipped.
+            {"status": "variant", "reasoning": "1"},
+            {"status": "variant", "reasoning": "2"},
+        ])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm,
+                                    triage_each=True, max_triage_calls=2)
+        assert len(result.triage) == 5
+        statuses = [t.status for t in result.triage]
+        assert statuses.count("variant") == 2
+        assert statuses.count("skipped") == 3
+
+    def test_triage_invalid_status_falls_back_uncertain(self, tmp_path, monkeypatch):
+        seed = _seed(tmp_path)
+        seed_match = Match(file="src/auth.py", line=3)
+        v1 = Match(file="src/a.py", line=10)
+        _stub_engines(
+            monkeypatch,
+            seed_matches=[seed_match],
+            repo_matches=[seed_match, v1],
+        )
+        llm = _stub_llm([
+            {"rule_body": "rules: ...", "rationale": "x"},
+            {"status": "frobnicated", "reasoning": "garbage"},
+        ])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm,
+                                    triage_each=True)
+        assert result.triage[0].status == "uncertain"
+
+    def test_triage_llm_raises_marks_uncertain(self, tmp_path, monkeypatch):
+        seed = _seed(tmp_path)
+        seed_match = Match(file="src/auth.py", line=3)
+        v1 = Match(file="src/a.py", line=10)
+        _stub_engines(
+            monkeypatch,
+            seed_matches=[seed_match],
+            repo_matches=[seed_match, v1],
+        )
+        llm = _stub_llm([
+            {"rule_body": "rules: ...", "rationale": "x"},
+            RuntimeError("triage transport failure"),
+        ])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm,
+                                    triage_each=True)
+        assert result.triage[0].status == "uncertain"
+        assert "triage failed" in result.triage[0].reasoning
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSerialisation:
+    def test_to_dict_after_synthesis(self, tmp_path, monkeypatch):
+        seed = _seed(tmp_path)
+        seed_match = Match(file="src/auth.py", line=3)
+        variant = Match(file="src/admin.py", line=42)
+        _stub_engines(
+            monkeypatch,
+            seed_matches=[seed_match],
+            repo_matches=[seed_match, variant],
+        )
+        llm = _stub_llm([
+            {"rule_body": "rules: ...", "rationale": "x"},
+        ])
+        result = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        d = result.to_dict()
+        import json
+        assert json.dumps(d)
+        assert d["rule"]["engine"] == "semgrep"
+        assert d["positive_control"] is True
+        assert len(d["matches"]) == 1


### PR DESCRIPTION
Adds packages/checker_synthesis/ — turn one confirmed bug into a Semgrep or Coccinelle rule, run it across the codebase, surface variant matches. (KNighter, SOSP 2025).

Pipeline: propose → write rule (atomic) → positive control → codebase scan → optional triage. Coccinelle for C/.h, Semgrep for everything else (Python, Java, Go, JS/TS, Rust, PHP, C++, etc.).

LLM dependency injected as an LLMCallable Protocol so production wires LLMClient.generate_structured and tests stub freely.

Adversarial defences:
  * seed.file rejected on traversal / absolute / newline / null
  * Rule body: 32KB total cap, 4KB per line, no null bytes
  * Atomic write via tempfile + os.replace
  * seed.snippet capped at 8KB in prompts with truncation marker
  * Engine adapter exceptions swallowed into result.errors
  * Match cap (default 50) + rule-too-loose warning at 200
  * Retry budget: one refinement on positive-control miss
  * Triage exceptions per-match map to status="uncertain"

Real bug caught during integration: Semgrep adapter treated SemgrepFinding dataclass as dict. Fixed via attribute access. Stub-driven tests passed because they bypassed the parser; the real-engine test surfaced the drift.

63 tests (substrate / pipeline / adversarial / hardening) + E2E walkthrough verifying real Semgrep finds a planted variant, real Coccinelle parse errors are caught gracefully, traversal rejected without filesystem touch.