### PR TITLE
Reachability consumer wirings: validate / agentic / understand

### DIFF
--- a/.claude/skills/code-understanding/map.md
+++ b/.claude/skills/code-understanding/map.md
@@ -186,6 +186,23 @@ When you can, include the function `name` directly on each entry_point and
 sink_detail you emit — it helps the normaliser skip backfill and is
 clearer for human reviewers.
 
+**[MAP-5b] Enrich entry points with forward-reachable closures**
+
+After normalisation, run the call-graph enricher. Uses the inventory to
+attach a `forward_reachable` field to each entry point, listing the
+internal functions and external dep calls transitively reachable from
+the entry's host function.
+
+```bash
+libexec/raptor-enrich-context-map-callgraph "$WORKDIR"
+```
+
+The enriched context-map.json carries machine-derived "this entry
+reaches N internal + M external" data alongside the LLM's narrative —
+useful for `/diagram` rendering and downstream consumers (audit
+prioritisation, validate Stage F). Idempotent. Skip if
+`$WORKDIR/checklist.json` doesn't exist or doesn't carry `target_path`.
+
 **[MAP-6] Record Coverage**
 
 After writing `context-map.json`, update the inventory with which functions you examined.

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -1556,6 +1556,117 @@ def _closure_sort_key(fn: FunctionId) -> Tuple:
     return (1, "", "", 0, fn.qualified_name)
 
 
+# ---------------------------------------------------------------------------
+# Evidence-line helpers
+# ---------------------------------------------------------------------------
+#
+# Substrate consumers that walk evidence (``"path:line"`` pairs)
+# back to enclosing functions need a couple of small primitives.
+# These started life inside ``packages/sca/reachability/`` but every
+# consumer ends up needing them — /validate Stage F resolves
+# attack-path entry/sink to InternalFunctions; /agentic triage
+# resolves a finding's source line to its host for caller-summary
+# context; /understand --map renders host context for entry points.
+# Hoisted to share one implementation.
+
+
+def enclosing_function(
+    inventory: Dict[str, Any],
+    file_path: str,
+    line: int,
+) -> Optional[InternalFunction]:
+    """Return the project-internal function whose body contains
+    ``line`` in ``file_path``, or ``None`` if the line lives at
+    module scope (no enclosing def).
+
+    When two defs nest (``def outer(): ... def inner(): ...``)
+    and ``line`` falls in the inner body, the innermost match
+    wins — the def with the largest ``line_start`` ≤ ``line``
+    that also has ``line`` ≤ ``line_end`` (or no
+    ``line_end``).
+
+    Returns ``None`` for any of:
+      * file_path not in the inventory
+      * file has no items list
+      * line falls outside every function's range
+    """
+    file_record = _find_file_record(inventory, file_path)
+    if file_record is None:
+        return None
+    items = file_record.get("items") or []
+    if not isinstance(items, list):
+        return None
+
+    best: Optional[Dict[str, Any]] = None
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if item.get("kind") not in (None, "function"):
+            continue
+        line_start = item.get("line_start")
+        line_end = item.get("line_end")
+        if not isinstance(line_start, int) or line_start <= 0:
+            continue
+        if line_start > line:
+            continue
+        # When line_end is missing, treat the def's range as
+        # open-ended — pick the lexically last def that started
+        # before our line. Same line_start-greatest-match
+        # heuristic the substrate uses for nested-def
+        # disambiguation.
+        if isinstance(line_end, int) and line_end >= 0 and line_end < line:
+            continue
+        if best is None or item["line_start"] > best["line_start"]:
+            best = item
+
+    if best is None:
+        return None
+    name = best.get("name") or ""
+    if not name:
+        return None
+    return InternalFunction(
+        file_path=file_path,
+        name=name,
+        line=int(best["line_start"]),
+    )
+
+
+def parse_evidence_entry(entry: str) -> Tuple[Optional[str], int]:
+    """Split a ``"path:line"`` evidence string into ``(path, line)``.
+
+    Returns ``(None, 0)`` for malformed inputs. Handles paths
+    containing colons (``C:\\path`` on Windows, IPv6 fragments)
+    by ``rsplit``-ing on the LAST colon and requiring the suffix
+    to be a decimal int.
+    """
+    if not isinstance(entry, str) or ":" not in entry:
+        return None, 0
+    path, _, line_str = entry.rpartition(":")
+    if not path or not line_str:
+        return None, 0
+    try:
+        return path, int(line_str)
+    except ValueError:
+        return None, 0
+
+
+def _find_file_record(
+    inventory: Dict[str, Any],
+    path: str,
+) -> Optional[Dict[str, Any]]:
+    """Linear scan of the inventory's files for a path match.
+
+    Files lists are typically hundreds of entries; linear scan is
+    fast in practice (single-digit microseconds per query).
+    Consumers needing sub-millisecond latency across many queries
+    can pre-build a path→record map.
+    """
+    for file_record in inventory.get("files", []):
+        if file_record.get("path") == path:
+            return file_record
+    return None
+
+
 __all__ = [
     "CallersResult",
     "CalleesResult",
@@ -1569,8 +1680,10 @@ __all__ = [
     "call_lines_of",
     "callees_of",
     "callers_of",
+    "enclosing_function",
     "forward_closure",
     "function_called",
+    "parse_evidence_entry",
     "reverse_closure",
     "shortest_path",
 ]

--- a/core/inventory/tests/test_reachability_evidence.py
+++ b/core/inventory/tests/test_reachability_evidence.py
@@ -1,0 +1,192 @@
+"""Tests for the evidence-line helpers hoisted to
+:mod:`core.inventory.reachability`: ``enclosing_function`` and
+``parse_evidence_entry``.
+
+Both started in ``packages/sca/reachability/_host_reachability.py``;
+hoisted because /validate, /agentic, /understand all need the
+same primitives. These tests duplicate (intentionally) the SCA
+suite's coverage of ``enclosing_function`` so the substrate is
+self-tested at its own level.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from core.inventory.call_graph import extract_call_graph_python
+from core.inventory.reachability import (
+    InternalFunction,
+    enclosing_function,
+    parse_evidence_entry,
+)
+
+
+def _file(path: str, source: str) -> Dict[str, Any]:
+    import ast
+    cg = extract_call_graph_python(source).to_dict()
+    items: List[Dict[str, Any]] = []
+    try:
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                items.append({
+                    "name": node.name,
+                    "kind": "function",
+                    "line_start": node.lineno,
+                    "line_end": getattr(node, "end_lineno", None),
+                })
+    except SyntaxError:
+        pass
+    return {
+        "path": path, "language": "python",
+        "items": items, "call_graph": cg,
+    }
+
+
+def _inv(*files: Dict[str, Any]) -> Dict[str, Any]:
+    return {"files": list(files)}
+
+
+# ---------------------------------------------------------------------------
+# enclosing_function
+# ---------------------------------------------------------------------------
+
+
+def test_enclosing_function_simple():
+    inv = _inv(_file("src/a.py",
+        "def helper():\n"
+        "    pass\n"
+        "def main():\n"
+        "    helper()\n"
+    ))
+    assert enclosing_function(inv, "src/a.py", 4) == \
+        InternalFunction("src/a.py", "main", 3)
+
+
+def test_enclosing_function_nested_picks_innermost():
+    """Inner def's body resolves to inner; outer def's body
+    resolves to outer."""
+    inv = _inv(_file("src/a.py",
+        "def outer():\n"          # 1
+        "    def inner():\n"      # 2
+        "        x = 1\n"          # 3 — inside inner
+        "    inner()\n"            # 4 — inside outer (inner already closed)
+    ))
+    assert enclosing_function(inv, "src/a.py", 3) == \
+        InternalFunction("src/a.py", "inner", 2)
+    assert enclosing_function(inv, "src/a.py", 4) == \
+        InternalFunction("src/a.py", "outer", 1)
+
+
+def test_enclosing_function_module_level_returns_none():
+    inv = _inv(_file("src/a.py",
+        "x = 1\n"                  # 1 — module level
+        "def f():\n"                # 2
+        "    return x\n"            # 3 — inside f
+    ))
+    assert enclosing_function(inv, "src/a.py", 1) is None
+    assert enclosing_function(inv, "src/a.py", 3) == \
+        InternalFunction("src/a.py", "f", 2)
+
+
+def test_enclosing_function_unknown_path_returns_none():
+    inv = _inv(_file("src/a.py", "def f():\n    pass\n"))
+    assert enclosing_function(inv, "nope.py", 5) is None
+
+
+def test_enclosing_function_handles_missing_items():
+    """Defensive: file record without an items field should not
+    crash."""
+    inv = {"files": [{"path": "src/a.py", "language": "python"}]}
+    assert enclosing_function(inv, "src/a.py", 5) is None
+
+
+def test_enclosing_function_skips_non_function_items():
+    """Globals / classes / macros in the items list shouldn't
+    confuse the lookup — we skip everything that isn't kind='function'
+    (or kind missing, which defaults to function)."""
+    inv = {"files": [{
+        "path": "src/a.py",
+        "language": "python",
+        "items": [
+            {"name": "GLOBAL_VAR", "kind": "global",
+             "line_start": 1, "line_end": 1},
+            {"name": "f", "kind": "function",
+             "line_start": 2, "line_end": 5},
+        ],
+    }]}
+    assert enclosing_function(inv, "src/a.py", 3) == \
+        InternalFunction("src/a.py", "f", 2)
+
+
+def test_enclosing_function_skips_items_with_invalid_lines():
+    """An item with ``line_start <= 0`` shouldn't be matched."""
+    inv = {"files": [{
+        "path": "src/a.py",
+        "language": "python",
+        "items": [
+            {"name": "broken", "kind": "function",
+             "line_start": 0, "line_end": None},
+            {"name": "real", "kind": "function",
+             "line_start": 5, "line_end": 10},
+        ],
+    }]}
+    assert enclosing_function(inv, "src/a.py", 7) == \
+        InternalFunction("src/a.py", "real", 5)
+
+
+def test_enclosing_function_open_ended_when_line_end_missing():
+    """When ``line_end`` is missing, treat the range as
+    open-ended — last def started before our line wins."""
+    inv = {"files": [{
+        "path": "src/a.py",
+        "language": "python",
+        "items": [
+            {"name": "f", "kind": "function",
+             "line_start": 1, "line_end": None},
+            {"name": "g", "kind": "function",
+             "line_start": 5, "line_end": None},
+        ],
+    }]}
+    assert enclosing_function(inv, "src/a.py", 7) == \
+        InternalFunction("src/a.py", "g", 5)
+
+
+# ---------------------------------------------------------------------------
+# parse_evidence_entry
+# ---------------------------------------------------------------------------
+
+
+def test_parse_evidence_entry_simple():
+    assert parse_evidence_entry("src/a.py:42") == ("src/a.py", 42)
+
+
+def test_parse_evidence_entry_preserves_colons_in_path():
+    """Windows-style ``C:\\path:line`` should rsplit on the
+    LAST colon."""
+    assert parse_evidence_entry("C:\\src\\a.py:42") == \
+        ("C:\\src\\a.py", 42)
+
+
+def test_parse_evidence_entry_no_colon_returns_none():
+    assert parse_evidence_entry("just-a-string") == (None, 0)
+
+
+def test_parse_evidence_entry_non_int_line_returns_none():
+    assert parse_evidence_entry("src/a.py:notanumber") == (None, 0)
+
+
+def test_parse_evidence_entry_empty_path_returns_none():
+    assert parse_evidence_entry(":42") == (None, 0)
+
+
+def test_parse_evidence_entry_empty_line_returns_none():
+    assert parse_evidence_entry("src/a.py:") == (None, 0)
+
+
+def test_parse_evidence_entry_non_string_returns_none():
+    assert parse_evidence_entry(None) == (None, 0)
+    assert parse_evidence_entry(42) == (None, 0)
+    assert parse_evidence_entry(["src/a.py", 42]) == (None, 0)

--- a/core/orchestration/agentic_passes.py
+++ b/core/orchestration/agentic_passes.py
@@ -905,6 +905,7 @@ def run_reachability_prepass(
 
     try:
         from core.orchestration.reachability_enrichment import (
+            enrich_with_caller_context,
             mark_unreachable_low_priority,
         )
         checklist = load_json(checklist_path)
@@ -918,7 +919,17 @@ def run_reachability_prepass(
         marked = mark_unreachable_low_priority(
             checklist, target, inventory=inventory,
         )
-        if marked:
+        # Caller-context enrichment runs AFTER the dead-code
+        # marking so already-marked functions can be skipped
+        # cheaply (the LLM is going to deprioritise them
+        # regardless). Each surviving function gains
+        # caller_count_direct / _transitive / _uncertain plus
+        # direct_caller_names — the triage prompt reads these to
+        # judge blast radius alongside priority.
+        enriched_caller_ctx = enrich_with_caller_context(
+            checklist, target, inventory=inventory,
+        )
+        if marked or enriched_caller_ctx:
             save_json(checklist_path, checklist)
     except Exception:                               # noqa: BLE001
         logger.debug(

--- a/core/orchestration/context_map_callgraph.py
+++ b/core/orchestration/context_map_callgraph.py
@@ -1,0 +1,167 @@
+"""Substrate-derived call-graph enrichment for /understand --map.
+
+After ``/understand --map`` produces ``context-map.json`` (entry
+points + sinks + trust boundaries), and after the normaliser runs,
+this module enriches each entry point with the substrate's
+forward-closure: the set of functions transitively reachable from
+that entry. Operators reading the context map see machine-derived
+"this entry point reaches N internal + M external functions, here's
+the closure", which complements the LLM's narrative descriptions.
+
+The enrichment is idempotent and best-effort: missing checklist /
+inventory build failure / unresolved (file, line) entries leave
+the entry point unchanged.
+
+## Output shape
+
+Each entry point dict gains a ``forward_reachable`` field:
+
+    {
+        "id": "EP-001",
+        "file": "src/routes/query.py",
+        "line": 34,
+        ...,
+        "forward_reachable": {
+            "host": "src/routes/query.py:query_handler@34",
+            "internal_count": 12,
+            "external_count": 3,
+            "internal_names": ["src/db/query.py:run_query@89", ...],
+            "external_names": ["sqlite3.Cursor.execute", ...],
+            "truncated": false
+        }
+    }
+
+``internal_names`` / ``external_names`` are capped at
+``MAX_NAMES_PER_LIST = 10`` to keep context-map.json readable.
+``truncated`` flags when the closure walk hit ``max_depth`` —
+operators can re-run with a higher depth or read it as "deep call
+graph, partial enumeration".
+
+## Why not flow-trace?
+
+``/understand --trace`` produces ``flow-trace-*.json`` for
+specific source→sink chains the operator picked. This enrichment
+runs over EVERY entry point unconditionally, giving the next
+consumer (``/diagram``, the audit prioritiser) a uniform view
+without an operator picking traces.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+MAX_NAMES_PER_LIST = 10
+DEFAULT_MAX_DEPTH = 10
+
+
+def enrich_with_forward_reachable(
+    context_map: Dict[str, Any],
+    target_path: Path,
+    *,
+    inventory: Optional[Dict[str, Any]] = None,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    max_names_per_list: int = MAX_NAMES_PER_LIST,
+) -> int:
+    """Walk ``context_map["entry_points"]`` and attach a
+    ``forward_reachable`` field to each entry's host function.
+
+    ``inventory`` may be provided by the caller (avoids a redundant
+    inventory build when a sibling consumer already constructed
+    one). When omitted, builds one over ``target_path``.
+
+    Returns the count of entries enriched. Idempotent — re-running
+    overwrites prior enrichment with fresh data.
+    """
+    if not isinstance(context_map, dict):
+        return 0
+    entries = context_map.get("entry_points")
+    if not isinstance(entries, list) or not entries:
+        return 0
+
+    if inventory is None:
+        try:
+            from core.inventory.builder import build_inventory
+            import tempfile
+            with tempfile.TemporaryDirectory() as td:
+                inventory = build_inventory(str(target_path), td)
+        except Exception as e:                          # noqa: BLE001
+            logger.debug(
+                "context_map_callgraph: inventory build failed (%s); "
+                "skipping enrichment", e,
+            )
+            return 0
+
+    try:
+        from core.inventory.reachability import (
+            ExternalFunction,
+            InternalFunction,
+            enclosing_function,
+            forward_closure,
+        )
+    except ImportError:
+        return 0
+
+    enriched_count = 0
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        file_path = entry.get("file") or entry.get("file_path")
+        line = entry.get("line") or entry.get("line_start")
+        if not isinstance(file_path, str) or not file_path:
+            continue
+        if not isinstance(line, int) or line <= 0:
+            continue
+
+        host = enclosing_function(inventory, file_path, line)
+        if host is None:
+            # Module-level entry, or path/line not in inventory.
+            # Skip rather than emitting a placeholder — operators
+            # would mistake a populated-but-empty enrichment for
+            # "no callees" rather than "couldn't resolve host".
+            continue
+
+        try:
+            closure = forward_closure(
+                inventory, [host], max_depth=max_depth,
+            )
+        except Exception:                              # noqa: BLE001
+            continue
+
+        internal_names: list = []
+        external_names: list = []
+        for node in closure.nodes:
+            if isinstance(node, InternalFunction):
+                internal_names.append(str(node))
+            elif isinstance(node, ExternalFunction):
+                external_names.append(str(node))
+        internal_names.sort()
+        external_names.sort()
+
+        entry["forward_reachable"] = {
+            "host": str(host),
+            "internal_count": len(internal_names),
+            "external_count": len(external_names),
+            "internal_names": internal_names[:max_names_per_list],
+            "external_names": external_names[:max_names_per_list],
+            "truncated": closure.truncated,
+        }
+        enriched_count += 1
+
+    if enriched_count:
+        logger.info(
+            "context_map_callgraph: enriched %d entry point(s) with "
+            "forward-reachable closures", enriched_count,
+        )
+    return enriched_count
+
+
+__all__ = [
+    "DEFAULT_MAX_DEPTH",
+    "MAX_NAMES_PER_LIST",
+    "enrich_with_forward_reachable",
+]

--- a/core/orchestration/reachability_enrichment.py
+++ b/core/orchestration/reachability_enrichment.py
@@ -152,4 +152,134 @@ def _path_to_module(rel_path: str) -> Optional[str]:
     return ".".join(parts)
 
 
-__all__ = ["mark_unreachable_low_priority"]
+# ---------------------------------------------------------------------------
+# Caller-context enrichment — feed substrate-derived blast-radius data
+# into the /agentic triage LLM's per-function context.
+# ---------------------------------------------------------------------------
+
+
+def enrich_with_caller_context(
+    checklist: Dict[str, Any],
+    target_path: Path,
+    *,
+    inventory: Optional[Dict[str, Any]] = None,
+    max_direct_caller_names: int = 5,
+    max_depth: int = 20,
+) -> int:
+    """Walk ``checklist["files"][*]["items"]`` and attach
+    substrate-derived caller context to each function.
+
+    For each function, set:
+
+      * ``caller_count_direct`` — 1-hop callers (definitive +
+        uncertain + over-inclusive method match), via
+        ``callers_of``.
+      * ``caller_count_transitive`` — full reverse closure size.
+      * ``caller_count_uncertain`` — file-masking-flag uncertain
+        callers, surfaced separately because consumers may want
+        to discount them.
+      * ``direct_caller_names`` — first ``max_direct_caller_names``
+        ``"file:name"`` strings, sorted, for the LLM's display.
+
+    The /agentic triage prompt reads these alongside ``priority``
+    so the LLM can judge blast radius — a function called by 50
+    things has different stakes than one called by 1.
+
+    Skips functions already marked ``priority="low"`` by
+    ``mark_unreachable_low_priority`` — those are dead and the
+    LLM will deprioritise them regardless.
+
+    Returns the count of functions enriched.
+    """
+    if not isinstance(checklist, dict):
+        return 0
+    files = checklist.get("files")
+    if not isinstance(files, list):
+        return 0
+
+    if inventory is None:
+        try:
+            from core.inventory.builder import build_inventory
+            import tempfile
+            with tempfile.TemporaryDirectory() as td:
+                inventory = build_inventory(str(target_path), td)
+        except Exception as e:                          # noqa: BLE001
+            logger.debug(
+                "reachability_enrichment: inventory build failed (%s); "
+                "skipping caller-context pass", e,
+            )
+            return 0
+
+    try:
+        from core.inventory.reachability import (
+            InternalFunction,
+            callers_of,
+            reverse_closure,
+        )
+    except ImportError:
+        return 0
+
+    enriched = 0
+    for file_info in files:
+        if not isinstance(file_info, dict):
+            continue
+        rel_path = file_info.get("path")
+        if not isinstance(rel_path, str) or not rel_path:
+            continue
+
+        funcs = file_info.get("items")
+        if not isinstance(funcs, list):
+            funcs = file_info.get("functions")
+        if not isinstance(funcs, list):
+            continue
+
+        for func in funcs:
+            if not isinstance(func, dict):
+                continue
+            kind = func.get("kind")
+            if kind and kind != "function":
+                continue
+            # Already-dead functions don't need caller context —
+            # the LLM is going to deprioritise them anyway.
+            if func.get("priority") == "low":
+                continue
+            name = func.get("name")
+            if not isinstance(name, str) or not name:
+                continue
+            line_start = func.get("line_start")
+            if not isinstance(line_start, int) or line_start <= 0:
+                continue
+
+            target = InternalFunction(
+                file_path=rel_path, name=name, line=line_start,
+            )
+            try:
+                one_hop = callers_of(inventory, target)
+                closure = reverse_closure(
+                    inventory, target, max_depth=max_depth,
+                )
+            except Exception:                          # noqa: BLE001
+                continue
+
+            direct_callers = one_hop.all_callers
+            func["caller_count_direct"] = len(direct_callers)
+            func["caller_count_transitive"] = len(closure.nodes)
+            func["caller_count_uncertain"] = len(one_hop.uncertain)
+            sorted_names = sorted(str(c) for c in direct_callers)
+            func["direct_caller_names"] = (
+                sorted_names[:max_direct_caller_names]
+            )
+            enriched += 1
+
+    if enriched:
+        logger.info(
+            "reachability_enrichment: enriched %d function(s) with "
+            "caller-context fields", enriched,
+        )
+    return enriched
+
+
+__all__ = [
+    "enrich_with_caller_context",
+    "mark_unreachable_low_priority",
+]

--- a/core/orchestration/tests/test_context_map_callgraph.py
+++ b/core/orchestration/tests/test_context_map_callgraph.py
@@ -1,0 +1,218 @@
+"""Tests for ``core.orchestration.context_map_callgraph`` —
+forward-reachable closure enrichment for /understand --map's
+context-map.json output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.orchestration.context_map_callgraph import (
+    enrich_with_forward_reachable,
+)
+
+
+def _project(tmp_path: Path, files: dict) -> Path:
+    for rel, contents in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(contents)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_simple_entry_point(tmp_path):
+    """Entry point reaches an internal function and an external
+    dep — both surface in the forward_reachable field."""
+    target = _project(tmp_path, {
+        "src/routes/query.py": (
+            "import sqlite3\n"
+            "from src.db import run_query\n"
+            "def handle_query():\n"             # line 3
+            "    sqlite3.connect('x')\n"
+            "    return run_query('SELECT 1')\n"
+        ),
+        "src/db.py": (
+            "def run_query(sql):\n"
+            "    pass\n"
+        ),
+    })
+    cmap = {
+        "entry_points": [{
+            "id": "EP-001",
+            "file": "src/routes/query.py",
+            "line": 3,
+        }],
+    }
+    enriched = enrich_with_forward_reachable(cmap, target)
+    assert enriched == 1
+    fr = cmap["entry_points"][0]["forward_reachable"]
+    assert fr["host"] == "src/routes/query.py:handle_query@3"
+    assert fr["internal_count"] >= 1
+    assert any(
+        "run_query" in n for n in fr["internal_names"]
+    )
+    assert fr["external_count"] >= 1
+    assert any(
+        "sqlite3" in n for n in fr["external_names"]
+    )
+    assert fr["truncated"] is False
+
+
+def test_enrich_skips_entry_without_file_or_line(tmp_path):
+    target = _project(tmp_path, {"src/v.py": "def f(): pass\n"})
+    cmap = {
+        "entry_points": [
+            {"id": "EP-1", "file": "src/v.py"},          # no line
+            {"id": "EP-2", "line": 1},                     # no file
+            {"id": "EP-3", "file": "", "line": 5},         # empty file
+            {"id": "EP-4", "file": "src/v.py", "line": 0}, # invalid line
+        ],
+    }
+    enriched = enrich_with_forward_reachable(cmap, target)
+    assert enriched == 0
+    for ep in cmap["entry_points"]:
+        assert "forward_reachable" not in ep
+
+
+def test_enrich_skips_unresolvable_host(tmp_path):
+    """File not in the inventory → no host → skip silently."""
+    target = _project(tmp_path, {"src/real.py": "def f(): pass\n"})
+    cmap = {
+        "entry_points": [{
+            "id": "EP-1", "file": "src/missing.py", "line": 1,
+        }],
+    }
+    enriched = enrich_with_forward_reachable(cmap, target)
+    assert enriched == 0
+    assert "forward_reachable" not in cmap["entry_points"][0]
+
+
+def test_enrich_handles_module_level_lines(tmp_path):
+    """Line outside any function (module scope) → no host → skip."""
+    target = _project(tmp_path, {
+        "src/v.py": (
+            "import os\n"               # line 1, module scope
+            "def f():\n"
+            "    pass\n"
+        ),
+    })
+    cmap = {
+        "entry_points": [{
+            "id": "EP-1", "file": "src/v.py", "line": 1,
+        }],
+    }
+    enriched = enrich_with_forward_reachable(cmap, target)
+    assert enriched == 0
+
+
+# ---------------------------------------------------------------------------
+# Caps and bounds
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_caps_internal_names(tmp_path):
+    """When internal_count exceeds max_names_per_list, the names
+    list is capped but the count reflects the full closure."""
+    # entry → 12 internal helpers, each calling its own pass()
+    src = ["def entry():"]
+    for i in range(12):
+        src.append(f"    h{i}()")
+    for i in range(12):
+        src.append(f"def h{i}():")
+        src.append("    pass")
+    target = _project(tmp_path, {
+        "src/v.py": "\n".join(src) + "\n",
+    })
+    cmap = {
+        "entry_points": [{
+            "id": "EP-1", "file": "src/v.py", "line": 1,
+        }],
+    }
+    enriched = enrich_with_forward_reachable(
+        cmap, target, max_names_per_list=5,
+    )
+    assert enriched == 1
+    fr = cmap["entry_points"][0]["forward_reachable"]
+    assert fr["internal_count"] == 12
+    assert len(fr["internal_names"]) == 5
+
+
+def test_enrich_truncates_at_max_depth(tmp_path):
+    """A deep chain hits max_depth → truncated flag set."""
+    # f0 → f1 → f2 → f3 → ... → f9
+    src = ["def f0():", "    f1()"]
+    for i in range(1, 10):
+        src.append(f"def f{i}():")
+        if i == 9:
+            src.append("    pass")
+        else:
+            src.append(f"    f{i + 1}()")
+    target = _project(tmp_path, {
+        "src/v.py": "\n".join(src) + "\n",
+    })
+    cmap = {
+        "entry_points": [{
+            "id": "EP-1", "file": "src/v.py", "line": 1,
+        }],
+    }
+    enriched = enrich_with_forward_reachable(cmap, target, max_depth=3)
+    assert enriched == 1
+    fr = cmap["entry_points"][0]["forward_reachable"]
+    assert fr["truncated"] is True
+
+
+def test_enrich_idempotent(tmp_path):
+    """Running twice produces the same enrichment — second run
+    overwrites with fresh data."""
+    target = _project(tmp_path, {
+        "src/v.py": (
+            "def helper():\n"
+            "    pass\n"
+            "def entry():\n"
+            "    helper()\n"
+        ),
+    })
+    cmap = {
+        "entry_points": [{
+            "id": "EP-1", "file": "src/v.py", "line": 3,
+        }],
+    }
+    enrich_with_forward_reachable(cmap, target)
+    fr1 = dict(cmap["entry_points"][0]["forward_reachable"])
+    enrich_with_forward_reachable(cmap, target)
+    fr2 = cmap["entry_points"][0]["forward_reachable"]
+    assert fr1 == fr2
+
+
+# ---------------------------------------------------------------------------
+# Defensive
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_handles_empty_entry_points(tmp_path):
+    target = _project(tmp_path, {"src/v.py": "def f(): pass\n"})
+    assert enrich_with_forward_reachable({"entry_points": []}, target) == 0
+    assert enrich_with_forward_reachable({}, target) == 0
+    assert enrich_with_forward_reachable(
+        {"entry_points": "not-a-list"}, target,
+    ) == 0
+
+
+def test_enrich_handles_non_dict_entries(tmp_path):
+    target = _project(tmp_path, {"src/v.py": "def f(): pass\n"})
+    cmap = {
+        "entry_points": [
+            "string-not-dict",
+            42,
+            None,
+            {"id": "EP-1", "file": "src/v.py", "line": 1},
+        ],
+    }
+    # Should process the dict and skip the non-dicts without raising.
+    enrich_with_forward_reachable(cmap, target)
+    # The valid entry should be processed (even if no enrichment lands).
+    assert isinstance(cmap["entry_points"][3], dict)

--- a/core/orchestration/tests/test_reachability_enrichment.py
+++ b/core/orchestration/tests/test_reachability_enrichment.py
@@ -203,3 +203,190 @@ def test_path_to_module():
     assert _path_to_module("packages/foo/bar.py") == "packages.foo.bar"
     assert _path_to_module("Makefile") is None
     assert _path_to_module("") is None
+
+
+# ---------------------------------------------------------------------------
+# Caller-context enrichment
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_caller_context_attaches_counts(tmp_path):
+    """A function with two callers gains caller_count_direct=2,
+    caller_count_transitive>=2, and direct_caller_names lists
+    them."""
+    from core.orchestration.reachability_enrichment import (
+        enrich_with_caller_context,
+    )
+    target = _project(tmp_path, {
+        "src/vuln.py": (
+            "def affected():\n"             # line 1
+            "    pass\n"
+        ),
+        "src/main.py": (
+            "from src.vuln import affected\n"
+            "def use_a():\n"                 # caller 1
+            "    affected()\n"
+            "def use_b():\n"                 # caller 2
+            "    affected()\n"
+        ),
+    })
+    checklist = _checklist({
+        "src/vuln.py": [{
+            "name": "affected", "kind": "function",
+            "line_start": 1, "line_end": 2,
+        }],
+    })
+    enriched = enrich_with_caller_context(checklist, target)
+    assert enriched == 1
+    func = checklist["files"][0]["items"][0]
+    assert func["caller_count_direct"] == 2
+    assert func["caller_count_transitive"] >= 2
+    assert func["caller_count_uncertain"] == 0
+    assert len(func["direct_caller_names"]) == 2
+
+
+def test_enrich_caller_context_skips_low_priority(tmp_path):
+    """A function already marked priority=low (dead code) doesn't
+    need caller context — the LLM is going to deprioritise it
+    regardless. Skip to save the lookup."""
+    from core.orchestration.reachability_enrichment import (
+        enrich_with_caller_context,
+    )
+    target = _project(tmp_path, {
+        "src/vuln.py": "def dead(): pass\n",
+    })
+    checklist = _checklist({
+        "src/vuln.py": [{
+            "name": "dead", "kind": "function",
+            "line_start": 1, "line_end": 1,
+            "priority": "low",
+            "priority_reason": "reachability:not_called",
+        }],
+    })
+    enriched = enrich_with_caller_context(checklist, target)
+    assert enriched == 0
+    func = checklist["files"][0]["items"][0]
+    assert "caller_count_direct" not in func
+
+
+def test_enrich_caller_context_caps_caller_names(tmp_path):
+    """``direct_caller_names`` is capped at ``max_direct_caller_names``."""
+    from core.orchestration.reachability_enrichment import (
+        enrich_with_caller_context,
+    )
+    target = _project(tmp_path, {
+        "src/vuln.py": "def affected(): pass\n",
+        "src/main.py": (
+            "from src.vuln import affected\n"
+            "def c1(): affected()\n"
+            "def c2(): affected()\n"
+            "def c3(): affected()\n"
+            "def c4(): affected()\n"
+            "def c5(): affected()\n"
+            "def c6(): affected()\n"
+            "def c7(): affected()\n"
+        ),
+    })
+    checklist = _checklist({
+        "src/vuln.py": [{
+            "name": "affected", "kind": "function",
+            "line_start": 1, "line_end": 1,
+        }],
+    })
+    enriched = enrich_with_caller_context(
+        checklist, target, max_direct_caller_names=3,
+    )
+    assert enriched == 1
+    func = checklist["files"][0]["items"][0]
+    assert func["caller_count_direct"] == 7
+    assert len(func["direct_caller_names"]) == 3
+
+
+def test_enrich_caller_context_handles_no_callers(tmp_path):
+    """A function with no callers — counts are 0 but the function
+    is still enriched (consumer can read 0 to know "lonely")."""
+    from core.orchestration.reachability_enrichment import (
+        enrich_with_caller_context,
+    )
+    target = _project(tmp_path, {
+        "src/vuln.py": "def lonely(): pass\n",
+    })
+    checklist = _checklist({
+        "src/vuln.py": [{
+            "name": "lonely", "kind": "function",
+            "line_start": 1, "line_end": 1,
+        }],
+    })
+    enriched = enrich_with_caller_context(checklist, target)
+    assert enriched == 1
+    func = checklist["files"][0]["items"][0]
+    assert func["caller_count_direct"] == 0
+    assert func["caller_count_transitive"] == 0
+    assert func["direct_caller_names"] == []
+
+
+def test_enrich_caller_context_skips_non_function_items(tmp_path):
+    from core.orchestration.reachability_enrichment import (
+        enrich_with_caller_context,
+    )
+    target = _project(tmp_path, {
+        "src/v.py": "x = 1\n",
+    })
+    checklist = _checklist({
+        "src/v.py": [{
+            "name": "GLOBAL_VAR", "kind": "global",
+            "line_start": 1, "line_end": 1,
+        }],
+    })
+    enriched = enrich_with_caller_context(checklist, target)
+    assert enriched == 0
+    func = checklist["files"][0]["items"][0]
+    assert "caller_count_direct" not in func
+
+
+def test_enrich_caller_context_handles_missing_line_start(tmp_path):
+    """Defensive: a checklist item without line_start can't be
+    resolved to an InternalFunction — skip silently."""
+    from core.orchestration.reachability_enrichment import (
+        enrich_with_caller_context,
+    )
+    target = _project(tmp_path, {
+        "src/v.py": "def f(): pass\n",
+    })
+    checklist = _checklist({
+        "src/v.py": [{
+            "name": "f", "kind": "function",
+            # line_start missing
+        }],
+    })
+    enriched = enrich_with_caller_context(checklist, target)
+    assert enriched == 0
+
+
+def test_enrich_caller_context_uncertain_caller_counted_separately(
+    tmp_path,
+):
+    """A function called via getattr counts as an UNCERTAIN
+    caller — surfaced in caller_count_uncertain."""
+    from core.orchestration.reachability_enrichment import (
+        enrich_with_caller_context,
+    )
+    target = _project(tmp_path, {
+        "src/v.py": "def affected(q): pass\n",
+        "src/dyn.py": (
+            "from src import v\n"
+            "def dispatch():\n"
+            "    fn = getattr(v, 'affected')\n"
+            "    fn('x')\n"
+        ),
+    })
+    checklist = _checklist({
+        "src/v.py": [{
+            "name": "affected", "kind": "function",
+            "line_start": 1, "line_end": 1,
+        }],
+    })
+    enriched = enrich_with_caller_context(checklist, target)
+    assert enriched == 1
+    func = checklist["files"][0]["items"][0]
+    assert func["caller_count_uncertain"] >= 1

--- a/libexec/raptor-enrich-context-map-callgraph
+++ b/libexec/raptor-enrich-context-map-callgraph
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Enrich a context-map.json with substrate-derived forward-reachable
+closures per entry point. Runs after raptor-normalize-context-map.
+
+Usage: raptor-enrich-context-map-callgraph <understand_dir> [--max-depth N]
+
+Wraps core.orchestration.context_map_callgraph.enrich_with_forward_reachable
+for invocation from skill markdown. Adds a ``forward_reachable`` field
+to each entry point in context-map.json. Idempotent — safe to re-run.
+
+Best-effort: missing checklist / inventory build failure / unresolved
+host functions log warnings but never abort the run.
+"""
+import argparse
+import sys
+from pathlib import Path
+
+# ─── trust-marker check (do not import; inline by design) ───
+import os
+if not (os.environ.get("CLAUDECODE")
+        or os.environ.get("_RAPTOR_TRUSTED")):
+    sys.stderr.write(
+        f"{sys.argv[0]}: internal dispatch script.\n"
+        "  Run via 'bin/raptor' instead.\n"
+        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
+    )
+    sys.exit(2)
+# ─── end trust-marker check ─────────────────────────────────
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.json import load_json, save_json
+from core.orchestration.context_map_callgraph import (
+    DEFAULT_MAX_DEPTH,
+    enrich_with_forward_reachable,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="raptor-enrich-context-map-callgraph",
+        description=(
+            "Enrich context-map.json entry points with substrate-derived "
+            "forward-reachable closures."
+        ),
+    )
+    parser.add_argument("understand_dir", help="path to /understand run dir")
+    parser.add_argument(
+        "--max-depth", type=int, default=DEFAULT_MAX_DEPTH,
+        help=(
+            f"BFS depth bound for the closure walk "
+            f"(default: {DEFAULT_MAX_DEPTH})"
+        ),
+    )
+    args = parser.parse_args()
+
+    understand_dir = Path(args.understand_dir).resolve()
+    if not understand_dir.is_dir():
+        print(
+            f"raptor-enrich-context-map-callgraph: {understand_dir} is "
+            "not a directory", file=sys.stderr,
+        )
+        return 1
+
+    context_map_path = understand_dir / "context-map.json"
+    if not context_map_path.exists():
+        print(
+            f"raptor-enrich-context-map-callgraph: {context_map_path} "
+            "does not exist", file=sys.stderr,
+        )
+        return 1
+
+    context_map = load_json(context_map_path)
+    if not isinstance(context_map, dict):
+        print(
+            f"raptor-enrich-context-map-callgraph: {context_map_path} "
+            "is not a JSON object", file=sys.stderr,
+        )
+        return 1
+
+    checklist = load_json(understand_dir / "checklist.json") or {}
+    target_path = (
+        checklist.get("target_path") if isinstance(checklist, dict) else None
+    )
+    if not target_path:
+        print(
+            "raptor-enrich-context-map-callgraph: checklist missing "
+            "target_path; skipping enrichment", file=sys.stderr,
+        )
+        return 0
+
+    enriched = enrich_with_forward_reachable(
+        context_map, Path(target_path), max_depth=args.max_depth,
+    )
+    if enriched:
+        save_json(context_map_path, context_map)
+        print(
+            f"raptor-enrich-context-map-callgraph: enriched {enriched} "
+            f"entry point(s) in {context_map_path}"
+        )
+    else:
+        print(
+            "raptor-enrich-context-map-callgraph: no entries enriched "
+            "(no entry_points field, all hosts unresolvable, or inventory "
+            "build skipped)"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/exploitability_validation/orchestrator.py
+++ b/packages/exploitability_validation/orchestrator.py
@@ -928,7 +928,10 @@ class ValidationOrchestrator:
         # framework callback). Operators retain the path data;
         # it just sits at the bottom by proximity score.
         try:
-            from .reachability import demote_unreachable_paths
+            from .reachability import (
+                demote_unreachable_paths,
+                enrich_with_substrate_evidence,
+            )
             # Reuse Stage 0's already-built inventory (or one
             # loaded from a parent-process pointer; see Stage 0)
             # rather than rebuilding. The checklist on
@@ -941,7 +944,19 @@ class ValidationOrchestrator:
                 Path(self.config.target_path),
                 inventory=self.state.checklist,
             )
-            if demoted:
+            # Stage F path verification: every attack path whose
+            # sink is alive (not demoted) gets a substrate_evidence
+            # block — transitive caller count, shortest chain to
+            # the sink, uncertain-frontier size. Operators reading
+            # the report compare the LLM's narrative steps against
+            # the substrate's independent evidence.
+            enriched = enrich_with_substrate_evidence(
+                self.state.attack_paths or [],
+                self.state.findings.get("findings", []),
+                Path(self.config.target_path),
+                inventory=self.state.checklist,
+            )
+            if demoted or enriched:
                 # Attack paths were mutated in place; persist.
                 self.state.save_json(
                     "attack-paths.json", self.state.attack_paths,

--- a/packages/exploitability_validation/reachability.py
+++ b/packages/exploitability_validation/reachability.py
@@ -235,4 +235,167 @@ def _path_to_module(rel_path: str) -> Optional[str]:
     return ".".join(parts)
 
 
-__all__ = ["demote_unreachable_paths"]
+# ---------------------------------------------------------------------------
+# Substrate-evidence enrichment — Stage F path verification
+# ---------------------------------------------------------------------------
+#
+# ``demote_unreachable_paths`` (above) handles the "sink is dead"
+# case by clamping proximity. The complementary case — "sink is
+# alive" — gets richer treatment: we surface the substrate's own
+# view of how the sink is reachable, independent of the LLM's
+# narrative steps. Operators reading the report can compare:
+#
+#   1. The LLM-proposed chain in ``steps[]``.
+#   2. The substrate's shortest demonstrable caller chain in
+#      ``substrate_evidence.shortest_call_chain``.
+#
+# Mismatch = potential LLM hallucination. Match = independent
+# corroboration.
+
+
+def enrich_with_substrate_evidence(
+    attack_paths: List[Dict[str, Any]],
+    findings: List[Dict[str, Any]],
+    target_path: Path,
+    *,
+    inventory: Optional[Dict[str, Any]] = None,
+    max_depth: int = 20,
+) -> int:
+    """Walk ``attack_paths``, enrich any whose sink is alive with
+    substrate-derived evidence. Mutates the list in place. Returns
+    the count of enriched paths.
+
+    Each enriched path gains a ``substrate_evidence`` field:
+
+      * ``transitive_caller_count`` (int) — size of the sink's
+        reverse closure (project functions that can reach the
+        sink through any chain of internal calls).
+      * ``shortest_call_chain`` (list of str) — string-rendered
+        function identities ``"file_path:name"`` along the
+        shortest demonstrable chain TO the sink, or empty when
+        no internal caller exists.
+      * ``uncertain_caller_count`` (int) — number of 1-hop
+        callers with masking indirection (getattr / wildcard
+        import) that mention the sink's tail name.
+      * ``verified`` (bool) — True iff transitive_caller_count
+        >= 1 OR uncertain_caller_count >= 1. Operators can use
+        this as a binary "substrate has a story for this path".
+
+    No-op when:
+      * attack_paths is empty
+      * no path can be linked to a finding-with-location
+      * sink-host can't be resolved via the inventory's items
+      * the path was already demoted (skip enrichment to avoid
+        contradicting the demotion claim)
+
+    ``max_depth`` bounds the reverse_closure walk; 20 is generous
+    for most projects and keeps batch enrichment fast.
+    """
+    if not attack_paths:
+        return 0
+
+    findings_by_id: Dict[str, Dict[str, Any]] = {
+        f.get("id"): f for f in findings
+        if isinstance(f, dict) and isinstance(f.get("id"), str)
+    }
+    if not findings_by_id:
+        return 0
+
+    if inventory is None:
+        try:
+            from core.inventory.builder import build_inventory
+            import tempfile
+            with tempfile.TemporaryDirectory() as td:
+                inventory = build_inventory(str(target_path), td)
+        except Exception as e:                          # noqa: BLE001
+            logger.debug(
+                "exploitability_validation.reachability: inventory "
+                "build failed (%s); skipping enrichment pass", e,
+            )
+            return 0
+
+    try:
+        from core.inventory.reachability import (
+            callers_of,
+            enclosing_function,
+            reverse_closure,
+        )
+    except ImportError:
+        return 0
+
+    enriched_count = 0
+    for path in attack_paths:
+        if not isinstance(path, dict):
+            continue
+        # Skip already-demoted paths — enrichment would
+        # contradict the "dead code" claim demote_unreachable_paths
+        # made.
+        if _is_demoted(path):
+            continue
+        finding_id = path.get("finding_id") or path.get("finding")
+        if not isinstance(finding_id, str):
+            continue
+        finding = findings_by_id.get(finding_id)
+        if finding is None:
+            continue
+        location = _finding_location(finding)
+        if location is None:
+            continue
+        file_path, line = location
+
+        sink = enclosing_function(inventory, file_path, line)
+        if sink is None:
+            continue
+
+        # Substrate query: callers + transitive reverse closure.
+        one_hop = callers_of(inventory, sink)
+        closure = reverse_closure(inventory, sink, max_depth=max_depth)
+
+        shortest_chain: List[str] = []
+        if closure.paths:
+            # The closure stores per-caller shortest chains TO the
+            # sink. Pick the shortest length across all callers as
+            # the "representative" demonstration.
+            shortest = min(closure.paths.values(), key=len)
+            shortest_chain = [str(node) for node in shortest]
+
+        evidence = {
+            "transitive_caller_count": len(closure.nodes),
+            "shortest_call_chain": shortest_chain,
+            "uncertain_caller_count": len(one_hop.uncertain),
+            "verified": (
+                len(closure.nodes) >= 1
+                or len(one_hop.uncertain) >= 1
+            ),
+        }
+        if closure.truncated:
+            evidence["closure_truncated"] = True
+        path["substrate_evidence"] = evidence
+        enriched_count += 1
+
+    if enriched_count:
+        logger.info(
+            "exploitability_validation.reachability: enriched %d "
+            "attack path(s) with substrate evidence",
+            enriched_count,
+        )
+    return enriched_count
+
+
+def _is_demoted(path: Dict[str, Any]) -> bool:
+    """Detect whether ``demote_unreachable_paths`` already
+    demoted this path. Looks for the documented blocker prefix.
+    """
+    blockers = path.get("blockers") or []
+    if not isinstance(blockers, list):
+        return False
+    return any(
+        isinstance(b, str) and b.startswith("reachability:not_called")
+        for b in blockers
+    )
+
+
+__all__ = [
+    "demote_unreachable_paths",
+    "enrich_with_substrate_evidence",
+]

--- a/packages/exploitability_validation/schemas.py
+++ b/packages/exploitability_validation/schemas.py
@@ -426,7 +426,25 @@ ATTACK_PATH_SCHEMA = {
         "status": {"type": "string", "enum": ["confirmed", "uncertain", "blocked"]},
         "poc_attempted": {"type": "boolean"},
         "poc_result": {"type": "string"},
-        "attempted_at": {"type": "string"}
+        "attempted_at": {"type": "string"},
+        # Stage F path verification: substrate-derived evidence
+        # about how the sink is reached, independent of the LLM's
+        # narrative steps. Populated by
+        # ``enrich_with_substrate_evidence`` after Stage B.
+        "substrate_evidence": {
+            "type": "object",
+            "description": "Substrate-derived reachability evidence",
+            "properties": {
+                "transitive_caller_count": {"type": "integer"},
+                "shortest_call_chain": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "uncertain_caller_count": {"type": "integer"},
+                "verified": {"type": "boolean"},
+                "closure_truncated": {"type": "boolean"},
+            },
+        },
     }
 }
 

--- a/packages/exploitability_validation/tests/test_substrate_evidence.py
+++ b/packages/exploitability_validation/tests/test_substrate_evidence.py
@@ -1,0 +1,240 @@
+"""Tests for ``enrich_with_substrate_evidence`` — Stage F path
+verification.
+
+These exercise the enrichment pass against real on-disk projects
+(small fixtures built in tmp_path) so the inventory builder runs
+end-to-end. Each test pins one design decision:
+
+  * Live sink → enriched with reverse-closure stats + shortest
+    chain.
+  * Dead sink (already demoted by a prior pass) → skipped to
+    avoid contradicting the demotion claim.
+  * Sink not resolvable → skipped silently.
+  * Multiple paths in one batch → each enriched independently.
+  * Closure truncation flag surfaces when max_depth bites.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from packages.exploitability_validation.reachability import (
+    demote_unreachable_paths,
+    enrich_with_substrate_evidence,
+)
+
+
+# ---------------------------------------------------------------------------
+# Live-sink enrichment
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_live_sink_populates_evidence(tmp_path):
+    """Sink has callers → substrate_evidence shows count + chain."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "vuln.py").write_text(
+        "def vulnerable(query):\n"           # line 1
+        "    cursor.execute(query)\n"
+    )
+    (tmp_path / "src" / "main.py").write_text(
+        "from src.vuln import vulnerable\n"
+        "def app():\n"
+        "    vulnerable('x')\n"
+    )
+
+    findings = [{
+        "id": "f1",
+        "file_path": "src/vuln.py",
+        "start_line": 2,
+    }]
+    attack_paths = [{
+        "id": "p1",
+        "finding_id": "f1",
+        "proximity": 7,
+        "blockers": [],
+    }]
+
+    enriched = enrich_with_substrate_evidence(
+        attack_paths, findings, tmp_path,
+    )
+    assert enriched == 1
+    ev = attack_paths[0]["substrate_evidence"]
+    assert ev["transitive_caller_count"] >= 1
+    assert ev["verified"] is True
+    assert ev["uncertain_caller_count"] == 0
+    # The shortest chain ends at the sink.
+    chain = ev["shortest_call_chain"]
+    assert chain
+    assert chain[-1].endswith("vulnerable@1")
+
+
+def test_enrich_skips_demoted_paths(tmp_path):
+    """A path already marked as dead by ``demote_unreachable_paths``
+    should NOT be enriched — surfacing substrate evidence for
+    something we already said is dead is contradictory."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "vuln.py").write_text(
+        "def dead_handler(query):\n"
+        "    cursor.execute(query)\n"
+        "\n"
+        "def other():\n"
+        "    pass\n"
+    )
+    (tmp_path / "src" / "main.py").write_text(
+        "from src.vuln import other\n"
+        "other()\n"
+    )
+
+    findings = [{
+        "id": "f1",
+        "file_path": "src/vuln.py",
+        "start_line": 2,
+    }]
+    attack_paths = [{
+        "id": "p1",
+        "finding_id": "f1",
+        "proximity": 8,
+        "blockers": [],
+    }]
+
+    # First demote (sink is dead — no callers via static graph).
+    demote_unreachable_paths(attack_paths, findings, tmp_path)
+    assert any(
+        "reachability:not_called" in b
+        for b in attack_paths[0]["blockers"]
+    )
+    # Now try to enrich. Should skip.
+    enriched = enrich_with_substrate_evidence(
+        attack_paths, findings, tmp_path,
+    )
+    assert enriched == 0
+    assert "substrate_evidence" not in attack_paths[0]
+
+
+def test_enrich_skips_paths_without_finding_link(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "v.py").write_text("def f():\n    pass\n")
+    findings: list = []          # no findings → nothing to link
+    attack_paths = [{"id": "p1", "finding_id": "missing", "proximity": 5}]
+    enriched = enrich_with_substrate_evidence(
+        attack_paths, findings, tmp_path,
+    )
+    assert enriched == 0
+
+
+def test_enrich_skips_when_sink_not_in_inventory(tmp_path):
+    """Finding points at a file that isn't in the inventory."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "real.py").write_text("def f():\n    pass\n")
+    findings = [{
+        "id": "f1",
+        "file_path": "src/missing.py",
+        "start_line": 1,
+    }]
+    attack_paths = [{
+        "id": "p1", "finding_id": "f1", "proximity": 5,
+    }]
+    enriched = enrich_with_substrate_evidence(
+        attack_paths, findings, tmp_path,
+    )
+    assert enriched == 0
+
+
+# ---------------------------------------------------------------------------
+# Multi-path batches
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_handles_multiple_paths(tmp_path):
+    """Two paths, two findings, two sinks — both get enriched."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "v1.py").write_text(
+        "def sink1(q):\n    cursor.execute(q)\n"
+    )
+    (tmp_path / "src" / "v2.py").write_text(
+        "def sink2(q):\n    cursor.execute(q)\n"
+    )
+    (tmp_path / "src" / "app.py").write_text(
+        "from src.v1 import sink1\n"
+        "from src.v2 import sink2\n"
+        "def use1(): sink1('a')\n"
+        "def use2(): sink2('b')\n"
+    )
+    findings = [
+        {"id": "f1", "file_path": "src/v1.py", "start_line": 2},
+        {"id": "f2", "file_path": "src/v2.py", "start_line": 2},
+    ]
+    attack_paths = [
+        {"id": "p1", "finding_id": "f1", "proximity": 5},
+        {"id": "p2", "finding_id": "f2", "proximity": 5},
+    ]
+    enriched = enrich_with_substrate_evidence(
+        attack_paths, findings, tmp_path,
+    )
+    assert enriched == 2
+    for p in attack_paths:
+        assert p["substrate_evidence"]["verified"] is True
+
+
+def test_enrich_uncertain_callers_count(tmp_path):
+    """Sink has only uncertain callers (file uses getattr) →
+    transitive_caller_count is 0 but uncertain_caller_count is
+    nonzero, and verified is True (we don't distinguish definitive
+    vs uncertain at the verified-flag level)."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "v.py").write_text(
+        "def affected(q):\n"
+        "    cursor.execute(q)\n"
+    )
+    (tmp_path / "src" / "dyn.py").write_text(
+        "from src import v\n"
+        "def dispatch():\n"
+        "    fn = getattr(v, 'affected')\n"
+        "    fn('x')\n"
+    )
+    findings = [{
+        "id": "f1", "file_path": "src/v.py", "start_line": 2,
+    }]
+    attack_paths = [{
+        "id": "p1", "finding_id": "f1", "proximity": 5,
+    }]
+    enriched = enrich_with_substrate_evidence(
+        attack_paths, findings, tmp_path,
+    )
+    assert enriched == 1
+    ev = attack_paths[0]["substrate_evidence"]
+    # Uncertain caller exists; closure walks definitive only so
+    # transitive count may be 0.
+    assert ev["uncertain_caller_count"] >= 1
+    assert ev["verified"] is True
+
+
+# ---------------------------------------------------------------------------
+# No-ops
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_empty_attack_paths(tmp_path):
+    assert enrich_with_substrate_evidence([], [], tmp_path) == 0
+
+
+def test_enrich_empty_findings(tmp_path):
+    paths = [{"id": "p1", "finding_id": "x", "proximity": 5}]
+    assert enrich_with_substrate_evidence(paths, [], tmp_path) == 0
+
+
+def test_enrich_handles_non_dict_path_entries(tmp_path):
+    """Defensive: a malformed (non-dict) attack-path entry shouldn't
+    crash the pass."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "v.py").write_text("def f():\n    pass\n")
+    findings = [{"id": "f1", "file_path": "src/v.py", "start_line": 1}]
+    attack_paths = [
+        "this-is-not-a-dict",
+        {"id": "p1", "finding_id": "f1", "proximity": 5},
+    ]
+    # Should process the dict and skip the string without raising.
+    enriched = enrich_with_substrate_evidence(
+        attack_paths, findings, tmp_path,
+    )
+    assert enriched <= 1   # the def is private + uncalled, so likely 0


### PR DESCRIPTION
Three first-line substrate consumers + a small shared hoist.

  - hoist: enclosing_function(inventory, path, line) and parse_evidence_entry move from SCA-private into core.inventory.reachability. Every consumer walks evidence pairs back to hosts; one shared impl.

  - /validate Stage F: each Stage B attack path whose sink is alive gets substrate_evidence (transitive_caller_count, shortest_call_chain, uncertain_caller_count, verified). LLM narrative vs substrate chain → mismatch flags hallucination. Runs alongside demote_unreachable_paths; demoted paths skipped. Schema-additive.

  - /agentic triage: non-dead checklist functions gain caller_count_{direct,transitive,uncertain} + direct_caller_names (capped at 5). Triage LLM reads these alongside priority to judge blast radius. Runs after mark_unreachable_low_priority; reuses the prepass inventory.

  - /understand --map: each entry point in context-map.json gains forward_reachable (internal/external counts + capped name lists + truncated flag). New libexec raptor-enrich-context-map-callgraph mirrors the normaliser; skill markdown picks it up as [MAP-5b].

40 new tests across the four pieces; inventory + validate + orchestration suites 929 passing; no regressions on existing function_called consumers.