### PR TITLE
feat(diagram): render forward_reachable per entry point

### DIFF
--- a/packages/diagram/context_map.py
+++ b/packages/diagram/context_map.py
@@ -144,3 +144,128 @@ def generate_from_file(path: Path) -> str:
     if data is None:
         raise ValueError(f"Failed to load {path}")
     return generate(data)
+
+
+# ---------------------------------------------------------------------------
+# Forward-reachable diagrams (one per entry point)
+# ---------------------------------------------------------------------------
+#
+# /understand --map's MAP-5b step attaches a ``forward_reachable``
+# field to each entry point (substrate-derived call closure):
+#
+#     {"host": "...", "internal_count": N, "external_count": M,
+#      "internal_names": [...], "external_names": [...],
+#      "truncated": bool}
+#
+# Rendering this in the same flowchart as entry-points / trust-
+# boundaries / sinks would explode visual complexity (10+ nodes
+# per entry × N entries). Instead we emit ONE small flowchart
+# per entry, called "Forward Reachability per Entry Point" in
+# diagrams.md.
+
+
+def generate_forward_reachable_blocks(
+    data: dict[str, Any],
+) -> list[tuple[str, str]]:
+    """Return ``(title, mermaid_diagram)`` tuples — one per entry
+    point that carries ``forward_reachable``. Empty list when no
+    entry has the field (the renderer skips the section in that
+    case).
+    """
+    out: list[tuple[str, str]] = []
+    for ep in data.get("entry_points") or []:
+        if not isinstance(ep, dict):
+            continue
+        fr = ep.get("forward_reachable")
+        if not isinstance(fr, dict):
+            continue
+        diagram = _render_one_entry_forward(ep, fr)
+        if not diagram:
+            continue
+        ep_id = ep.get("id", "EP-?")
+        host = fr.get("host", "?")
+        title = f"{ep_id}: {host}"
+        out.append((title, diagram))
+    return out
+
+
+def _render_one_entry_forward(ep: dict[str, Any], fr: dict[str, Any]) -> str:
+    """Render one entry's forward closure as a top-down flowchart.
+
+    Layout: host at top, internal callees branching down (green),
+    external dep calls branching down (purple). A truncation
+    note attaches via dashed edge when the closure walk hit
+    max_depth.
+    """
+    lines = ["flowchart TD"]
+    host = fr.get("host", "?")
+    host_id = "HOST"
+    lines.append("")
+    lines.append("    %% Host (entry point's enclosing function)")
+    lines.append(f'    {host_id}["{_sanitize(host)}"]')
+
+    internal_names = list(fr.get("internal_names") or [])
+    external_names = list(fr.get("external_names") or [])
+    int_count = fr.get("internal_count", len(internal_names))
+    ext_count = fr.get("external_count", len(external_names))
+
+    # Internal nodes
+    if internal_names:
+        lines.append("")
+        lines.append("    %% Internal callees (project functions)")
+    int_ids: list[str] = []
+    for i, name in enumerate(internal_names):
+        nid = f"INT{i:03d}"
+        int_ids.append(nid)
+        lines.append(f'    {nid}["{_sanitize(name)}"]')
+        lines.append(f"    {host_id} --> {nid}")
+
+    # External nodes — parallelogram shape, distinct from
+    # internal rectangles. Same shape the existing context-map
+    # diagram uses for sinks; reads as "exits the project".
+    if external_names:
+        lines.append("")
+        lines.append("    %% External dep calls")
+    ext_ids: list[str] = []
+    for i, name in enumerate(external_names):
+        nid = f"EXT{i:03d}"
+        ext_ids.append(nid)
+        lines.append(f'    {nid}[/"{_sanitize(name)}"\\]')
+        lines.append(f"    {host_id} --> {nid}")
+
+    # Truncation note — closure walk hit max_depth, the listed
+    # nodes are partial.
+    if fr.get("truncated"):
+        lines.append("")
+        lines.append("    %% Closure walk hit max_depth — partial enumeration")
+        lines.append('    TRUNC["… (max_depth reached)"]')
+        lines.append(f"    {host_id} -. truncated .-> TRUNC")
+
+    # Cap-disclosure comment when the rendered list is shorter
+    # than the count (substrate caps internal_names /
+    # external_names at 10 each by default).
+    if int_count > len(internal_names) or ext_count > len(external_names):
+        lines.append("")
+        lines.append(
+            f"    %% Showing {len(internal_names)}/{int_count} internal, "
+            f"{len(external_names)}/{ext_count} external"
+        )
+
+    # Style classes
+    lines.append("")
+    lines.append("    classDef host fill:#dbeafe,stroke:#3b82f6,color:#1e3a5f")
+    lines.append("    classDef int fill:#dcfce7,stroke:#16a34a,color:#14532d")
+    lines.append("    classDef ext fill:#f3e8ff,stroke:#9333ea,color:#581c87")
+    lines.append(f"    class {host_id} host")
+    if int_ids:
+        lines.append(f"    class {','.join(int_ids)} int")
+    if ext_ids:
+        lines.append(f"    class {','.join(ext_ids)} ext")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "generate",
+    "generate_forward_reachable_blocks",
+    "generate_from_file",
+]

--- a/packages/diagram/renderer.py
+++ b/packages/diagram/renderer.py
@@ -70,6 +70,36 @@ def render_directory(out_dir: Path, target: Optional[str] = None) -> str:
             diagram = context_map.generate(data)
             body = f"_Source: `{fname}`_\n\n```mermaid\n{diagram}\n```"
             sections.append(_section(title, body))
+            # Per-entry forward-reachable diagrams (substrate-derived
+            # call closure from /understand --map's MAP-5b step).
+            # Only fires for context-map.json today; attack-surface.json
+            # uses a different shape but the helper safely returns []
+            # when no entry has forward_reachable.
+            try:
+                fr_blocks = context_map.generate_forward_reachable_blocks(
+                    data,
+                )
+            except Exception as exc:
+                fr_blocks = []
+                sections.append(_section(
+                    f"{title} — Forward Reachability",
+                    f"> Could not render forward-reachable blocks: {exc}",
+                ))
+            if fr_blocks:
+                sub_sections: list[str] = []
+                for sub_title, sub_diagram in fr_blocks:
+                    sub_sections.append(_section(
+                        sub_title,
+                        f"```mermaid\n{sub_diagram}\n```",
+                        level=3,
+                    ))
+                sections.append(_section(
+                    f"{title} — Forward Reachability per Entry Point",
+                    "_Source: `" + fname + "` (`forward_reachable` "
+                    "field per entry, populated by "
+                    "`raptor-enrich-context-map-callgraph`)_\n\n"
+                    + "\n".join(sub_sections),
+                ))
         except Exception as exc:
             sections.append(_section(title, f"> Could not render `{fname}`: {exc}"))
 

--- a/packages/diagram/tests/test_diagram.py
+++ b/packages/diagram/tests/test_diagram.py
@@ -392,6 +392,197 @@ class TestContextMap:
 
 
 # ---------------------------------------------------------------------------
+# context_map.generate_forward_reachable_blocks tests
+# ---------------------------------------------------------------------------
+
+
+class TestForwardReachableBlocks:
+    """Per-entry-point forward-reachable diagrams (substrate-derived
+    closures attached by /understand --map's MAP-5b step)."""
+
+    def _entry(self, fr=None, ep_id="EP-001",
+               file="src/r/q.py", line=34) -> dict:
+        ep = {"id": ep_id, "file": file, "line": line}
+        if fr is not None:
+            ep["forward_reachable"] = fr
+        return ep
+
+    def test_no_forward_reachable_returns_empty(self):
+        from packages.diagram.context_map import (
+            generate_forward_reachable_blocks,
+        )
+        data = {"entry_points": [self._entry()]}
+        assert generate_forward_reachable_blocks(data) == []
+
+    def test_renders_one_block_per_entry_with_field(self):
+        from packages.diagram.context_map import (
+            generate_forward_reachable_blocks,
+        )
+        fr = {
+            "host": "src/r/q.py:query_handler@34",
+            "internal_count": 2,
+            "external_count": 1,
+            "internal_names": [
+                "src/db.py:run_query@1",
+                "src/log.py:emit@5",
+            ],
+            "external_names": ["sqlite3.Cursor.execute"],
+            "truncated": False,
+        }
+        data = {"entry_points": [self._entry(fr=fr)]}
+        blocks = generate_forward_reachable_blocks(data)
+        assert len(blocks) == 1
+        title, diagram = blocks[0]
+        assert "EP-001" in title
+        assert "query_handler" in title
+        assert diagram.startswith("flowchart TD")
+        assert "query_handler" in diagram
+        assert "run_query" in diagram
+        assert "sqlite3.Cursor.execute" in diagram
+
+    def test_renders_internal_and_external_with_distinct_classes(self):
+        from packages.diagram.context_map import (
+            generate_forward_reachable_blocks,
+        )
+        fr = {
+            "host": "src/a.py:f@1",
+            "internal_count": 1, "external_count": 1,
+            "internal_names": ["src/b.py:g@1"],
+            "external_names": ["json.dumps"],
+            "truncated": False,
+        }
+        data = {"entry_points": [self._entry(fr=fr)]}
+        diagram = generate_forward_reachable_blocks(data)[0][1]
+        assert "classDef host" in diagram
+        assert "classDef int" in diagram
+        assert "classDef ext" in diagram
+        # Internal node is the rectangle shape; external uses the
+        # parallelogram shape ([/...\\]).
+        assert 'INT000["src/b.py:g@1"]' in diagram
+        assert 'EXT000[/"json.dumps"\\]' in diagram
+
+    def test_truncation_note_emitted_when_flag_set(self):
+        from packages.diagram.context_map import (
+            generate_forward_reachable_blocks,
+        )
+        fr = {
+            "host": "src/a.py:f@1",
+            "internal_count": 5, "external_count": 0,
+            "internal_names": ["src/b.py:g@1"],
+            "external_names": [],
+            "truncated": True,
+        }
+        diagram = generate_forward_reachable_blocks(
+            {"entry_points": [self._entry(fr=fr)]},
+        )[0][1]
+        assert "max_depth" in diagram
+        assert "TRUNC" in diagram
+        # Dashed edge syntax for the truncation note.
+        assert "-. truncated .->" in diagram
+
+    def test_cap_disclosure_when_count_exceeds_rendered(self):
+        from packages.diagram.context_map import (
+            generate_forward_reachable_blocks,
+        )
+        fr = {
+            "host": "src/a.py:f@1",
+            "internal_count": 50,    # full closure
+            "external_count": 20,
+            "internal_names": ["src/b.py:g1@1", "src/b.py:g2@1"],   # only 2
+            "external_names": ["json.dumps"],                        # only 1
+            "truncated": False,
+        }
+        diagram = generate_forward_reachable_blocks(
+            {"entry_points": [self._entry(fr=fr)]},
+        )[0][1]
+        assert "Showing 2/50 internal" in diagram
+        assert "1/20 external" in diagram
+
+    def test_skips_non_dict_entries(self):
+        """Defensive: entries that aren't dicts (malformed LLM
+        output) shouldn't crash the generator."""
+        from packages.diagram.context_map import (
+            generate_forward_reachable_blocks,
+        )
+        data = {"entry_points": [
+            "not-a-dict", 42, None,
+            self._entry(fr={
+                "host": "src/a.py:f@1",
+                "internal_count": 0, "external_count": 0,
+                "internal_names": [], "external_names": [],
+                "truncated": False,
+            }),
+        ]}
+        blocks = generate_forward_reachable_blocks(data)
+        assert len(blocks) == 1
+
+    def test_skips_entries_with_non_dict_forward_reachable(self):
+        from packages.diagram.context_map import (
+            generate_forward_reachable_blocks,
+        )
+        data = {"entry_points": [
+            self._entry(fr="not-a-dict"),
+            self._entry(fr=42),
+            self._entry(fr=None),
+        ]}
+        assert generate_forward_reachable_blocks(data) == []
+
+    def test_handles_missing_entry_points(self):
+        from packages.diagram.context_map import (
+            generate_forward_reachable_blocks,
+        )
+        assert generate_forward_reachable_blocks({}) == []
+        assert generate_forward_reachable_blocks(
+            {"entry_points": []},
+        ) == []
+
+    def test_multiple_entries_each_get_own_block(self):
+        from packages.diagram.context_map import (
+            generate_forward_reachable_blocks,
+        )
+        fr_a = {
+            "host": "a.py:f@1", "internal_count": 1, "external_count": 0,
+            "internal_names": ["b.py:g@1"], "external_names": [],
+            "truncated": False,
+        }
+        fr_b = {
+            "host": "x.py:y@1", "internal_count": 0, "external_count": 1,
+            "internal_names": [], "external_names": ["os.path.join"],
+            "truncated": False,
+        }
+        data = {"entry_points": [
+            self._entry(fr=fr_a, ep_id="EP-A"),
+            self._entry(fr=fr_b, ep_id="EP-B"),
+        ]}
+        blocks = generate_forward_reachable_blocks(data)
+        assert len(blocks) == 2
+        titles = [t for t, _ in blocks]
+        assert any("EP-A" in t for t in titles)
+        assert any("EP-B" in t for t in titles)
+
+    def test_html_special_chars_in_names_get_sanitised(self):
+        """Substrate-emitted identities can contain characters that
+        Mermaid would interpret as syntax. Names go through sanitize."""
+        from packages.diagram.context_map import (
+            generate_forward_reachable_blocks,
+        )
+        fr = {
+            "host": 'src/a.py:f"injected"@1',
+            "internal_count": 1, "external_count": 0,
+            "internal_names": ["src/b.py:g[evil]@1"],
+            "external_names": [],
+            "truncated": False,
+        }
+        diagram = generate_forward_reachable_blocks(
+            {"entry_points": [self._entry(fr=fr)]},
+        )[0][1]
+        # Sanitised — must not break the Mermaid parser.
+        assert 'flowchart TD' in diagram
+        # The host appears (with sanitisation applied).
+        assert "src/a.py" in diagram
+
+
+# ---------------------------------------------------------------------------
 # flow_trace tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
PR #395 added forward_reachable to each entry point in context-map.json (substrate-derived call closure). /diagram knew nothing about it; the data sat inert. This ties off that loop.

/diagram now emits one small Mermaid flowchart per entry that carries forward_reachable, under a "Forward Reachability per Entry Point" section in diagrams.md:

  - Host (entry's enclosing function) at top, blue
  - Internal callees as green rectangles
  - External dep calls as purple parallelograms
  - Dashed truncation note when the closure walk hit max_depth
  - Cap-disclosure comment when internal_count > rendered names

Kept as a separate section rather than folded into the existing EP→TB→SINK flowchart — bundling 10+ nodes per entry would explode visual complexity.

generate_forward_reachable_blocks(data) returns one (title, mermaid) tuple per entry with the field; empty list when none carry it (renderer skips the section).

10 new tests; diagram suite 98 passing. E2E verified via render_directory.