### PR TITLE
feat(core/llm/cwe_strategies): CWE-specialized review strategies

### DIFF
--- a/core/llm/cwe_strategies/__init__.py
+++ b/core/llm/cwe_strategies/__init__.py
@@ -1,0 +1,65 @@
+"""CWE-specialized review strategies for ``/audit`` Phase A.
+
+The general "look for bugs" prompt works for input-validation
+defects in straight-line code. Some bug classes need fundamentally
+different reasoning — race windows for concurrency, ownership for
+memory management, alias semantics for zero-copy paths. This
+package provides a small set of mechanically-picked **strategies**
+that prime the LLM's reasoning depth for the bug class at hand.
+
+Each strategy carries:
+
+  * Signals — function paths, header includes, function-name
+    keywords. The picker uses these to decide which strategies
+    apply to a given target function.
+  * Key questions — the prompts the LLM should be answering for
+    this bug class (not "is there a bug?" but "what does this
+    function trust?", "where does the lock window open?").
+  * Prompt addendum — prose appended to the base review prompt
+    for this strategy.
+  * Exemplars — 1-2 worked CVE examples per strategy showing the
+    vulnerable pattern + the reasoning that found it. Not the
+    patch, not the CVE description: the *reasoning*.
+
+Multiple strategies can apply at once. A network packet handler
+holding a lock gets both ``input_handling`` and ``concurrency``.
+Strategies are data, not code — adding one is writing a YAML file.
+
+Initial consumer:
+  * ``raptor_audit.py`` Phase A driver — picks strategies per
+    function, renders prompts, dispatches to ``LLMClient``.
+
+Companion design: ``~/design/audit.md``,
+"Adaptive review strategies" section.
+"""
+
+from __future__ import annotations
+
+from .loader import (
+    StrategyLoadError,
+    builtin_strategies_dir,
+    load_all,
+    load_strategy,
+)
+from .models import Exemplar, Signals, Strategy
+from .picker import GENERAL, pick_strategies
+from .prompts import (
+    DEFAULT_MAX_BYTES,
+    render_strategies,
+    render_strategy,
+)
+
+__all__ = [
+    "DEFAULT_MAX_BYTES",
+    "Exemplar",
+    "GENERAL",
+    "Signals",
+    "Strategy",
+    "StrategyLoadError",
+    "builtin_strategies_dir",
+    "load_all",
+    "load_strategy",
+    "pick_strategies",
+    "render_strategies",
+    "render_strategy",
+]

--- a/core/llm/cwe_strategies/loader.py
+++ b/core/llm/cwe_strategies/loader.py
@@ -1,0 +1,204 @@
+"""YAML loader for CWE-specialized strategies.
+
+Strategies are stored under ``core/llm/cwe_strategies/strategies/``
+as ``<name>.yml`` files. The format is intentionally narrow:
+
+    name: input_handling
+    description: Parsers, protocol handlers, network packet handling
+    signals:
+      paths: [net/, drivers/input/]
+      includes: [linux/skbuff.h]
+      function_keywords: [parse, decode]
+    key_questions:
+      - "What format/size assumptions does this code make?"
+      - "Are length fields validated before use?"
+    prompt_addendum: |
+      Focus on bounds checks and trust boundaries on incoming data.
+    exemplars:
+      - cve: CVE-2023-0179
+        title: nftables payload length confusion
+        pattern: |
+          Length field from packet trusted before bounds check.
+        why_buggy: |
+          Caller-controlled length used to size a copy without
+          validation against the available buffer.
+
+Unknown top-level keys are rejected — a typo in a strategy file
+should fail loudly, not silently disable a signal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+import yaml
+
+from .models import Exemplar, Signals, Strategy
+
+
+class StrategyLoadError(ValueError):
+    """Raised on malformed strategy YAML. Message identifies the
+    file + the problem so operators editing strategies see it."""
+
+
+_TOP_LEVEL_KEYS = {
+    "name", "description", "signals", "key_questions",
+    "prompt_addendum", "exemplars",
+}
+_SIGNAL_KEYS = {
+    "paths", "includes", "function_keywords",
+    "function_calls", "cwes",
+}
+_EXEMPLAR_KEYS = {"cve", "title", "pattern", "why_buggy"}
+
+
+def builtin_strategies_dir() -> Path:
+    """Directory containing the strategy YAMLs shipped with RAPTOR.
+
+    Operators wanting to customise can either edit these in place
+    or pass a different directory to ``load_all``.
+    """
+    return Path(__file__).resolve().parent / "strategies"
+
+
+def _check_keys(
+    where: str, data: Dict[str, Any], allowed: set,
+) -> None:
+    """Reject unknown keys with a clear message naming the file."""
+    if not isinstance(data, dict):
+        raise StrategyLoadError(f"{where}: expected mapping, got {type(data).__name__}")
+    extra = set(data) - allowed
+    if extra:
+        raise StrategyLoadError(
+            f"{where}: unknown keys {sorted(extra)}; allowed: {sorted(allowed)}"
+        )
+
+
+def _str_tuple(value: Any, where: str) -> Tuple[str, ...]:
+    """Coerce a YAML list-of-strings into a tuple. Empty / missing
+    values yield an empty tuple. Type errors raise."""
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise StrategyLoadError(
+            f"{where}: expected list of strings, got {type(value).__name__}"
+        )
+    out = []
+    for i, item in enumerate(value):
+        if not isinstance(item, str):
+            raise StrategyLoadError(
+                f"{where}[{i}]: expected string, got {type(item).__name__}"
+            )
+        out.append(item)
+    return tuple(out)
+
+
+def _load_signals(data: Any, where: str) -> Signals:
+    if data is None:
+        return Signals()
+    _check_keys(where, data, _SIGNAL_KEYS)
+    return Signals(
+        paths=_str_tuple(data.get("paths"), f"{where}.paths"),
+        includes=_str_tuple(data.get("includes"), f"{where}.includes"),
+        function_keywords=_str_tuple(
+            data.get("function_keywords"),
+            f"{where}.function_keywords",
+        ),
+        function_calls=_str_tuple(
+            data.get("function_calls"), f"{where}.function_calls",
+        ),
+        cwes=_str_tuple(data.get("cwes"), f"{where}.cwes"),
+    )
+
+
+def _load_exemplars(data: Any, where: str) -> Tuple[Exemplar, ...]:
+    if data is None:
+        return ()
+    if not isinstance(data, list):
+        raise StrategyLoadError(
+            f"{where}: expected list of exemplars, got {type(data).__name__}"
+        )
+    out: List[Exemplar] = []
+    for i, item in enumerate(data):
+        sub = f"{where}[{i}]"
+        _check_keys(sub, item, _EXEMPLAR_KEYS)
+        for required in ("cve", "title", "pattern", "why_buggy"):
+            if required not in item:
+                raise StrategyLoadError(
+                    f"{sub}: missing required field {required!r}"
+                )
+            if not isinstance(item[required], str):
+                raise StrategyLoadError(
+                    f"{sub}.{required}: expected string"
+                )
+        out.append(Exemplar(
+            cve=item["cve"],
+            title=item["title"],
+            pattern=item["pattern"],
+            why_buggy=item["why_buggy"],
+        ))
+    return tuple(out)
+
+
+def load_strategy(path: Path) -> Strategy:
+    """Load one strategy YAML. Raises StrategyLoadError on any
+    schema problem — operators editing files want loud failures."""
+    path = Path(path)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        raise StrategyLoadError(f"{path}: {e}") from e
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as e:
+        raise StrategyLoadError(f"{path}: invalid YAML: {e}") from e
+    if not isinstance(data, dict):
+        raise StrategyLoadError(
+            f"{path}: top-level must be a mapping"
+        )
+    _check_keys(str(path), data, _TOP_LEVEL_KEYS)
+    for required in ("name", "description"):
+        if required not in data:
+            raise StrategyLoadError(
+                f"{path}: missing required field {required!r}"
+            )
+        if not isinstance(data[required], str) or not data[required]:
+            raise StrategyLoadError(
+                f"{path}.{required}: expected non-empty string"
+            )
+    return Strategy(
+        name=data["name"],
+        description=data["description"],
+        signals=_load_signals(data.get("signals"), f"{path}.signals"),
+        key_questions=_str_tuple(
+            data.get("key_questions"), f"{path}.key_questions",
+        ),
+        prompt_addendum=str(data.get("prompt_addendum") or ""),
+        exemplars=_load_exemplars(
+            data.get("exemplars"), f"{path}.exemplars",
+        ),
+    )
+
+
+def load_all(directory: Path | None = None) -> List[Strategy]:
+    """Load every ``*.yml`` strategy in ``directory``.
+
+    Defaults to the bundled strategies dir. Files are loaded in
+    sorted order for stable output. Duplicate ``name`` fields raise
+    — every strategy must have a unique identifier.
+    """
+    directory = Path(directory) if directory is not None else builtin_strategies_dir()
+    if not directory.exists():
+        return []
+    strategies: List[Strategy] = []
+    seen_names: set = set()
+    for path in sorted(directory.glob("*.yml")):
+        s = load_strategy(path)
+        if s.name in seen_names:
+            raise StrategyLoadError(
+                f"{path}: duplicate strategy name {s.name!r}"
+            )
+        seen_names.add(s.name)
+        strategies.append(s)
+    return strategies

--- a/core/llm/cwe_strategies/models.py
+++ b/core/llm/cwe_strategies/models.py
@@ -1,0 +1,103 @@
+"""Dataclasses for CWE-specialized strategies.
+
+Frozen + JSON-friendly so /audit can persist its strategy choices
+alongside annotations and so picker tests have predictable equality.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Tuple
+
+
+@dataclass(frozen=True)
+class Signals:
+    """Mechanical heuristics for picking a strategy.
+
+    Each list is scored independently and the totals sum into a
+    single strategy score. Higher score = stronger pick.
+
+    Signals (best to weakest, generally):
+
+      * ``cwes`` — exact CWE identifiers attached to the target by
+        an upstream classifier (``/agentic`` finding, ``/understand``
+        sink type). Direct evidence of the bug class.
+      * ``function_calls`` — names of functions called by the
+        target. The strongest mechanical signal: a function that
+        calls ``mutex_lock`` IS concurrency-relevant regardless of
+        path, name, or includes.
+      * ``includes`` — header file names referenced by the target.
+        Strong signal for C/C++ (``linux/skbuff.h`` → input).
+      * ``paths`` — substrings of the target file's path. Broad
+        but cheap signal; specificity scoring rewards narrow
+        declarations like ``fs/splice.c`` over ``fs/``.
+      * ``function_keywords`` — tokens that should appear as
+        whole identifier components in the function name. Matched
+        with token semantics (split on ``_``/``-``), not raw
+        substring, so ``parse`` matches ``parse_packet`` but NOT
+        ``is_sparse_array``.
+
+    Matching is case-insensitive throughout.
+    """
+
+    paths: Tuple[str, ...] = ()  # path substrings (e.g. "net/", "crypto/")
+    includes: Tuple[str, ...] = ()  # header file names
+    function_keywords: Tuple[str, ...] = ()  # tokens in function name
+    function_calls: Tuple[str, ...] = ()  # function names called by target
+    cwes: Tuple[str, ...] = ()  # exact CWE ids (e.g. "CWE-78")
+
+
+@dataclass(frozen=True)
+class Exemplar:
+    """One worked CVE example illustrating the bug class.
+
+    Per the design doc: include the vulnerable code, what assumption
+    was violated, and the consequence. Not the patch, not the CVE
+    description — the reasoning that found it.
+    """
+
+    cve: str  # canonical id, e.g. "CVE-2023-0179"
+    title: str  # short human label
+    pattern: str  # the vulnerable structural pattern
+    why_buggy: str  # the assumption violation + consequence
+
+
+@dataclass(frozen=True)
+class Strategy:
+    """One CWE-specialized review strategy.
+
+    A strategy is data: its prompt addendum + exemplars are baked
+    into the YAML; the audit driver renders them into the per-
+    function prompt. ``name`` is the canonical identifier
+    (``input_handling`` etc.), used by /audit to log which
+    strategies fired for a given function.
+    """
+
+    name: str
+    description: str
+    signals: Signals = field(default_factory=Signals)
+    key_questions: Tuple[str, ...] = ()
+    prompt_addendum: str = ""
+    exemplars: Tuple[Exemplar, ...] = ()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "signals": {
+                "paths": list(self.signals.paths),
+                "includes": list(self.signals.includes),
+                "function_keywords": list(self.signals.function_keywords),
+                "function_calls": list(self.signals.function_calls),
+                "cwes": list(self.signals.cwes),
+            },
+            "key_questions": list(self.key_questions),
+            "prompt_addendum": self.prompt_addendum,
+            "exemplars": [
+                {
+                    "cve": e.cve, "title": e.title,
+                    "pattern": e.pattern, "why_buggy": e.why_buggy,
+                }
+                for e in self.exemplars
+            ],
+        }

--- a/core/llm/cwe_strategies/picker.py
+++ b/core/llm/cwe_strategies/picker.py
@@ -1,0 +1,248 @@
+"""Mechanical strategy picking from function signals.
+
+Given a target function (file path, name, includes, calls made, and
+known CWEs), score every loaded strategy and return the top N.
+The ``general`` strategy is always included by default — it's the
+trust/assumption baseline that fits everything; specialised
+strategies layer on top.
+
+Scoring is **specificity-weighted**: each match contributes
+``len(matched_token)`` points. ``fs/splice.c`` (12 chars) outscores
+``fs/`` (3 chars) for the same file path; this prevents a narrow,
+purpose-built signal from being drowned by broad ones declared on
+multiple strategies.
+
+Five signal dimensions, in roughly descending strength:
+
+  1. ``cwes`` — exact CWE id from upstream classifier. Direct
+     evidence: if /agentic already classified the finding as CWE-78,
+     ``input_handling`` should win automatically.
+  2. ``function_calls`` — token-equality match against names of
+     functions the target calls. The strongest mechanical signal
+     — a function calling ``mutex_lock`` IS concurrency-relevant
+     regardless of path or name.
+  3. ``includes`` — substring match on the function's headers.
+  4. ``paths`` — substring match on the file path.
+  5. ``function_keywords`` — token match against components of the
+     function name. Token semantics (split on ``_``/``-``) prevent
+     ``parse`` from matching ``is_sparse_array``.
+
+Matching is case-insensitive throughout. Only ``cwes`` and
+``function_calls`` use exact-token equality; ``includes`` and
+``paths`` use substring matching because operators write fragments
+(``fs/``, ``linux/skbuff.h``) that are meant to match prefixes.
+
+Caller's job: pass the function context they have. ``/audit``
+Phase A's driver fills these from inventory metadata + tree-sitter
+call graph + any /agentic-emitted finding CWEs.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List, Tuple
+
+from .loader import load_all
+from .models import Strategy
+
+# Sentinel name for the always-on default strategy.
+GENERAL = "general"
+
+# Identifier-component splitter: any run of non-word characters.
+# ``parse_packet-locked`` → {"parse", "packet", "locked"}.
+_TOKEN_SPLIT = re.compile(r"[^a-zA-Z0-9]+")
+
+
+def _tokenise(name: str) -> set[str]:
+    """Split an identifier into lowercase token components.
+
+    ``parse_packet`` → {"parse", "packet"}. Empty string + empty
+    components are dropped so trailing ``_`` in a keyword (operator
+    convention for "matches as a prefix") doesn't pollute the set.
+    """
+    if not name:
+        return set()
+    return {t.lower() for t in _TOKEN_SPLIT.split(name) if t}
+
+
+def _path_score(file_path: str, paths: Iterable[str]) -> int:
+    """Substring match (case-insensitive). Specificity-weighted.
+
+    Path fragments (``fs/``, ``kernel/locking/``) are designed to
+    match as prefixes / mid-path substrings, so substring match is
+    correct here despite token semantics being applied to keyword
+    fields.
+    """
+    if not file_path:
+        return 0
+    fp = file_path.lower()
+    return sum(len(p) for p in paths if p and p.lower() in fp)
+
+
+def _include_score(file_includes: Iterable[str], includes: Iterable[str]) -> int:
+    """Exact include-name match (case-insensitive). Specificity-weighted."""
+    targets = {i.lower() for i in file_includes if i}
+    return sum(len(i) for i in includes if i and i.lower() in targets)
+
+
+def _keyword_score(function_name: str, keywords: Iterable[str]) -> int:
+    """Token-equality match against function-name components.
+
+    ``parse`` matches ``parse_packet`` (token "parse" present) but
+    NOT ``is_sparse_array`` (no standalone "parse" component). This
+    is the bulk of the false-positive reduction over substring
+    matching. Trailing ``_``/``-`` on operator-written keywords is
+    stripped because it's a convention for "matches as a prefix" —
+    that semantic is built into tokenisation already.
+    """
+    tokens = _tokenise(function_name)
+    if not tokens:
+        return 0
+    score = 0
+    for k in keywords:
+        if not k:
+            continue
+        # Strip trailing separator chars; tokens never carry them.
+        kl = k.lower().rstrip("_-")
+        if not kl:
+            continue
+        if kl in tokens:
+            score += len(kl)
+    return score
+
+
+def _call_score(
+    function_calls_made: Iterable[str], strategy_calls: Iterable[str],
+) -> int:
+    """Exact-name match (case-insensitive) against the function's
+    callees. Specificity-weighted by callee name length."""
+    callees = {c.lower() for c in function_calls_made if c}
+    if not callees:
+        return 0
+    return sum(len(c) for c in strategy_calls if c and c.lower() in callees)
+
+
+def _cwe_score(
+    candidate_cwes: Iterable[str], strategy_cwes: Iterable[str],
+) -> int:
+    """Exact CWE-id match. Heavy-weighted: a CWE hit is direct
+    evidence and dominates fragmentary signal stacks.
+
+    Each match contributes 100 points. Typical aggregate
+    path+include+keyword scores sit around 20-50 chars; a CWE pin
+    reliably outranks them. This is intentional — when an upstream
+    classifier (a /agentic finding, a /understand sink type) tells
+    us the bug class, we should weight that ahead of inferred
+    heuristics."""
+    have = {c.lower() for c in candidate_cwes if c}
+    if not have:
+        return 0
+    return 100 * sum(1 for c in strategy_cwes if c and c.lower() in have)
+
+
+def _score_strategy(
+    strategy: Strategy,
+    *,
+    file_path: str,
+    function_name: str,
+    file_includes: Iterable[str],
+    function_calls_made: Iterable[str],
+    candidate_cwes: Iterable[str],
+) -> int:
+    """Combined score across all five signal dimensions."""
+    s = strategy.signals
+    return (
+        _path_score(file_path, s.paths)
+        + _include_score(file_includes, s.includes)
+        + _keyword_score(function_name, s.function_keywords)
+        + _call_score(function_calls_made, s.function_calls)
+        + _cwe_score(candidate_cwes, s.cwes)
+    )
+
+
+def pick_strategies(
+    *,
+    file_path: str,
+    function_name: str = "",
+    file_includes: Iterable[str] = (),
+    function_calls_made: Iterable[str] = (),
+    candidate_cwes: Iterable[str] = (),
+    strategies: Iterable[Strategy] | None = None,
+    max_strategies: int = 3,
+    always_include_general: bool = True,
+) -> List[Strategy]:
+    """Pick the highest-signal-scoring strategies for a function.
+
+    Args:
+        file_path: repo-relative path of the source file under
+            review (used for path signals).
+        function_name: identifier of the function under review
+            (used for keyword signals).
+        file_includes: header includes seen in the source file
+            (used for include signals). May be empty when the
+            inventory doesn't track includes for the language.
+        strategies: optional pre-loaded strategy list. Defaults to
+            ``load_all()`` for the bundled strategies dir.
+        max_strategies: maximum number of strategies to return
+            (default 3). The general strategy counts toward this
+            cap when ``always_include_general`` is True.
+        always_include_general: if True, the ``general`` strategy
+            is always included in the result regardless of score.
+
+    Returns:
+        List of strategies sorted by score descending, with
+        alphabetical tiebreaker. ``general`` (if included by the
+        always-on flag and present in ``strategies``) is the first
+        element of the result regardless of score so callers can
+        rely on its position.
+    """
+    if max_strategies <= 0:
+        return []
+
+    pool: List[Strategy] = list(strategies) if strategies is not None else load_all()
+    if not pool:
+        return []
+
+    # Score each strategy.
+    scored: List[Tuple[Strategy, int]] = [
+        (
+            s,
+            _score_strategy(
+                s,
+                file_path=file_path,
+                function_name=function_name,
+                file_includes=file_includes,
+                function_calls_made=function_calls_made,
+                candidate_cwes=candidate_cwes,
+            ),
+        )
+        for s in pool
+    ]
+
+    # Identify the general strategy if present.
+    general = next((s for s in pool if s.name == GENERAL), None)
+
+    # Filter zero-score strategies (general handled separately).
+    nonzero = [
+        (s, score) for (s, score) in scored
+        if score > 0 and s.name != GENERAL
+    ]
+    # Sort by score desc, then name asc for stable tiebreaking.
+    nonzero.sort(key=lambda item: (-item[1], item[0].name))
+
+    out: List[Strategy] = []
+    if always_include_general and general is not None:
+        out.append(general)
+
+    # Fill remaining slots with non-general matches.
+    remaining = max_strategies - len(out)
+    for s, _score in nonzero[:remaining]:
+        out.append(s)
+
+    # When general is NOT pinned, allow it to compete on score 0
+    # only if there's room and nothing else scored.
+    if not always_include_general and general is not None:
+        if not out and len(out) < max_strategies:
+            out.append(general)
+
+    return out

--- a/core/llm/cwe_strategies/prompts.py
+++ b/core/llm/cwe_strategies/prompts.py
@@ -1,0 +1,161 @@
+"""Prompt rendering for CWE-specialised strategies.
+
+The picker chooses strategies; this module turns them into prompt
+text for the LLM. /audit's driver composes:
+
+    [system prompt — base review instructions]
+    [function context — source, callers, callees, etc.]
+    [render_strategies(picked) — strategy blocks from this module]
+    [task instructions]
+
+Two rendering primitives:
+
+  * ``render_strategy(strategy)`` — single strategy as a markdown
+    section. Skips empty fields cleanly so a minimal strategy
+    (just name + description) produces just the header + intro.
+
+  * ``render_strategies(strategies, max_bytes=None)`` — concatenates
+    multiple strategy blocks with section breaks. Optionally caps
+    total UTF-8 bytes; when exceeded, exemplars are dropped first,
+    then questions, then later-strategy content. Caller gets a
+    truncation marker so the LLM knows the prompt was clipped.
+
+The rendered output is plain markdown. No escaping is done on
+strategy content — strategies are operator-curated YAML, trusted
+input from this module's perspective. (Loader-level validation
+already rejected the most pathological structural inputs.)
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+
+from .models import Exemplar, Strategy
+
+
+# Default soft cap on rendered output. Picked-strategies × addenda +
+# questions + exemplars typically sit under 8KB; the cap protects
+# against pathological cases (long strategy chains, oversized
+# exemplars) without bothering normal callers.
+DEFAULT_MAX_BYTES = 16_384
+
+_TRUNCATION_MARKER = "\n\n_(strategy block truncated to fit prompt budget)_\n"
+
+
+def _render_exemplar(e: Exemplar) -> str:
+    parts = [f"**{e.cve} — {e.title}**", ""]
+    if e.pattern:
+        parts += ["Vulnerable pattern:", e.pattern.rstrip(), ""]
+    if e.why_buggy:
+        parts += ["Why it's a bug:", e.why_buggy.rstrip(), ""]
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def render_strategy(
+    strategy: Strategy, *, include_exemplars: bool = True,
+    include_questions: bool = True,
+) -> str:
+    """Render one strategy as a markdown section.
+
+    ``include_exemplars`` and ``include_questions`` let the
+    truncation logic in ``render_strategies`` drop sub-sections
+    progressively when the budget is tight.
+    """
+    parts: List[str] = []
+    parts.append(f"## Strategy: {strategy.name}")
+    if strategy.description:
+        # Description may already be multi-line from YAML | block.
+        parts.append("")
+        parts.append(strategy.description.rstrip())
+
+    if include_questions and strategy.key_questions:
+        parts.append("")
+        parts.append("### Key questions")
+        for q in strategy.key_questions:
+            parts.append(f"- {q}")
+
+    if strategy.prompt_addendum:
+        parts.append("")
+        parts.append("### Approach")
+        parts.append(strategy.prompt_addendum.rstrip())
+
+    if include_exemplars and strategy.exemplars:
+        parts.append("")
+        parts.append("### Worked examples")
+        for e in strategy.exemplars:
+            parts.append("")
+            parts.append(_render_exemplar(e).rstrip())
+
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def _byte_len(text: str) -> int:
+    return len(text.encode("utf-8"))
+
+
+def render_strategies(
+    strategies: Iterable[Strategy],
+    *,
+    max_bytes: Optional[int] = DEFAULT_MAX_BYTES,
+) -> str:
+    """Render multiple strategies as a single markdown block.
+
+    When ``max_bytes`` is set and the full rendering exceeds it,
+    progressively drop content in this order:
+
+      1. Exemplars from the last-listed strategies (lower priority)
+      2. Exemplars from all strategies
+      3. Key questions from the last-listed strategies
+      4. Key questions from all strategies
+      5. Drop later strategies entirely
+
+    A ``_(strategy block truncated...)_`` marker is appended when
+    truncation occurs so the LLM sees the budget was tight.
+    """
+    pool = list(strategies)
+    if not pool:
+        return ""
+
+    # Try full render first — most calls fit.
+    full = "\n\n".join(render_strategy(s) for s in pool)
+    if max_bytes is None or _byte_len(full) <= max_bytes:
+        return full
+
+    # Tier 1: drop exemplars from later strategies first.
+    for keep_exemplars_through in range(len(pool) - 1, -1, -1):
+        candidate = "\n\n".join(
+            render_strategy(s, include_exemplars=(i <= keep_exemplars_through))
+            for i, s in enumerate(pool)
+        ) + _TRUNCATION_MARKER
+        if _byte_len(candidate) <= max_bytes:
+            return candidate
+
+    # Tier 2: also drop questions from later strategies.
+    for keep_questions_through in range(len(pool) - 1, -1, -1):
+        candidate = "\n\n".join(
+            render_strategy(
+                s,
+                include_exemplars=False,
+                include_questions=(i <= keep_questions_through),
+            )
+            for i, s in enumerate(pool)
+        ) + _TRUNCATION_MARKER
+        if _byte_len(candidate) <= max_bytes:
+            return candidate
+
+    # Tier 3: drop later strategies entirely.
+    for n in range(len(pool), 0, -1):
+        candidate = "\n\n".join(
+            render_strategy(
+                s, include_exemplars=False, include_questions=False,
+            )
+            for s in pool[:n]
+        ) + _TRUNCATION_MARKER
+        if _byte_len(candidate) <= max_bytes:
+            return candidate
+
+    # Last resort: just the first strategy's name + description, no
+    # frills. The caller's budget is unrealistically tight, but the
+    # function still produces something parseable.
+    s = pool[0]
+    return f"## Strategy: {s.name}\n\n{s.description.rstrip()}\n" + _TRUNCATION_MARKER

--- a/core/llm/cwe_strategies/strategies/auth_privilege.yml
+++ b/core/llm/cwe_strategies/strategies/auth_privilege.yml
@@ -1,0 +1,82 @@
+name: auth_privilege
+description: |
+  Permission checks, capability checks, namespace boundaries,
+  ACLs. The bug class: a privileged operation runs with
+  insufficient (or stale) authorisation context, or a check that
+  appears to enforce a boundary actually misses an edge case.
+
+signals:
+  paths:
+    - security/
+    - kernel/cred.c
+    - kernel/capability.c
+    - kernel/user_namespace.c
+    - fs/namespace.c
+    - net/socket.c
+  includes:
+    - linux/capability.h
+    - linux/cred.h
+    - linux/security.h
+  function_keywords:
+    - capable
+    - permission
+    - authoriz
+    - privilege
+  function_calls:
+    - capable
+    - ns_capable
+    - capable_setid
+    - inode_permission
+    - file_permission
+    - generic_permission
+    - security_capable
+    - cred_alive
+    - override_creds
+    - revert_creds
+  cwes:
+    - CWE-20    # improper input validation (often gated by auth)
+    - CWE-269   # improper privilege management
+    - CWE-285   # improper authorization
+    - CWE-287   # improper authentication
+    - CWE-358   # improperly implemented standard
+    - CWE-732   # incorrect permissions
+    - CWE-862   # missing authorization
+    - CWE-863   # incorrect authorization
+
+key_questions:
+  - "Which privilege check gates this operation? Could the operation execute on a path where the check was skipped, or where the check returned 'allowed' for the wrong reason?"
+  - "For namespace-scoped privileges: does the check use ``ns_capable`` (correct) or ``capable`` (likely incorrect for unprivileged user namespaces)?"
+  - "Between check and use, can credentials change — process re-exec, SUID transition, fd inheritance — invalidating the prior decision?"
+  - "On error paths, is partial state visible to a less-privileged subsequent caller? Is sensitive data zeroed before being made reachable?"
+
+prompt_addendum: |
+  Imagine an unprivileged user with the most permissive
+  configuration available to them — for kernel code, this often
+  means inside a user namespace they created themselves. Walk
+  the privileged operation's call chain and look for any check
+  that grants based on a capability that's actually held INSIDE
+  the user namespace, even though the operation reaches resources
+  OUTSIDE it. The classic bug: ``capable(CAP_SYS_ADMIN)`` returns
+  true for a user with admin in their own namespace, but the
+  kernel object being modified is not namespace-scoped. The
+  unprivileged user reaches a privileged side effect.
+
+exemplars:
+  - cve: CVE-2022-0185
+    title: fs_context heap overflow via legacy filesystem mount in user_ns
+    pattern: |
+      A length is computed from a string formatted with attacker-
+      controlled keys/values, but the size validation uses the
+      pre-format length rather than the post-format length. The
+      operation runs because the user has CAP_SYS_ADMIN inside
+      their own user namespace.
+    why_buggy: |
+      The privilege check granted admin-equivalent access for an
+      operation that the namespace boundary should have prevented:
+      mount-related code paths that interact with non-namespaced
+      kernel state. The privilege check passed locally for the
+      wrong reason — a CAP_SYS_ADMIN check that's intended to
+      protect the kernel's mount table treated namespace-scoped
+      capability as equivalent to root capability for this code
+      path. The heap overflow itself is the consequence; the
+      auth bypass is what made it reachable.

--- a/core/llm/cwe_strategies/strategies/concurrency.yml
+++ b/core/llm/cwe_strategies/strategies/concurrency.yml
@@ -1,0 +1,89 @@
+name: concurrency
+description: |
+  Code that takes / drops locks, reads or writes refcounted
+  objects, or enters / exits RCU read-side critical sections.
+  The bug class: a window between two mutually-dependent operations
+  where another thread can intervene and invalidate the function's
+  assumptions.
+
+signals:
+  paths:
+    - kernel/locking/
+    - mm/
+    - fs/
+    - kernel/rcu/
+    - kernel/sched/
+    - kernel/futex/
+  includes:
+    - linux/mutex.h
+    - linux/spinlock.h
+    - linux/rwsem.h
+    - linux/rcupdate.h
+    - linux/refcount.h
+  function_keywords:
+    - lock
+    - unlock
+    - acquire
+    - release
+    - rcu
+    - refcount
+  function_calls:
+    - mutex_lock
+    - mutex_unlock
+    - spin_lock
+    - spin_unlock
+    - read_lock
+    - write_lock
+    - rcu_read_lock
+    - rcu_read_unlock
+    - rcu_dereference
+    - synchronize_rcu
+    - refcount_inc
+    - refcount_dec
+    - refcount_dec_and_test
+    - atomic_inc
+    - atomic_dec
+  cwes:
+    - CWE-362   # race condition / TOCTOU
+    - CWE-364   # signal handler race
+    - CWE-366   # race within thread
+    - CWE-367   # TOCTOU
+    - CWE-414   # missing lock check
+    - CWE-415   # double free (often racy)
+    - CWE-416   # use-after-free (often racy)
+    - CWE-667   # improper locking
+    - CWE-833   # deadlock
+
+key_questions:
+  - "Where is each lock acquired and released? Is there any function call BETWEEN acquire and release that could drop the lock?"
+  - "If the function drops a lock and reacquires it, what state could change in the window? What invariants are checked AFTER the reacquire — and against pre-drop or post-drop state?"
+  - "For refcounted objects: is every increment paired with exactly one decrement on every path (including error paths)?"
+  - "Are RCU read-side critical sections kept short and side-effect-free? Is freed memory ever accessed without an rcu_dereference + read lock?"
+
+prompt_addendum: |
+  Read this function imagining ANOTHER thread is watching every
+  load and store, free to call into the same function or related
+  ones at the worst possible moment. For every memory access,
+  ask: what guarantees this hasn't been freed / overwritten /
+  unmapped between the previous check and this use? For every
+  lock pair, ask: what is the LARGEST possible delta to global
+  state across the locked region — and is the post-region code
+  prepared for that delta? Lock windows that drop and reacquire
+  are the highest-yield place to look — bugs there are usually
+  TOCTOU on a scale of microseconds to seconds.
+
+exemplars:
+  - cve: CVE-2022-2602
+    title: io_uring / Unix GC use-after-free via dropped lock
+    pattern: |
+      The io_uring submission path drops a socket reference lock,
+      runs scheduling work, then re-checks state without
+      verifying the socket itself wasn't freed by a parallel
+      Unix garbage collection that ran while the lock was down.
+    why_buggy: |
+      Between lock_drop() and lock_reacquire(), the garbage
+      collector for AF_UNIX sockets could observe a refcount of
+      zero (the only ref-holder had already dropped) and free
+      the socket. The post-reacquire code dereferenced the now-
+      freed pointer. The fix added the missing reference grab
+      across the entire window, not just on entry.

--- a/core/llm/cwe_strategies/strategies/cryptography.yml
+++ b/core/llm/cwe_strategies/strategies/cryptography.yml
@@ -1,0 +1,89 @@
+name: cryptography
+description: |
+  Cryptographic primitives, protocol implementations, key
+  management. The bug classes: timing side channels, padding /
+  format oracles, weak randomness, key-lifecycle errors, mode-
+  of-operation misuse, and constant-time-violation patterns.
+
+signals:
+  paths:
+    - crypto/
+    - lib/crypto/
+    - net/tls/
+    - drivers/crypto/
+  includes:
+    - linux/crypto.h
+    - crypto/aes.h
+    - crypto/hash.h
+    - crypto/skcipher.h
+  function_keywords:
+    - encrypt
+    - decrypt
+    - sign
+    - verify
+    - hash
+    - hmac
+    - cipher
+    - constant
+  function_calls:
+    - crypto_memneq
+    - constant_time_memcmp
+    - memcmp
+    - crypto_alloc_skcipher
+    - crypto_alloc_aead
+    - crypto_alloc_shash
+    - crypto_aead_encrypt
+    - crypto_aead_decrypt
+    - skcipher_walk_first
+    - shash_update
+    - get_random_bytes
+  cwes:
+    - CWE-200   # information exposure
+    - CWE-203   # observable discrepancy
+    - CWE-208   # observable timing discrepancy
+    - CWE-310   # cryptographic issues (legacy)
+    - CWE-326   # inadequate encryption strength
+    - CWE-327   # use of broken or risky crypto
+    - CWE-328   # weak hash
+    - CWE-330   # use of insufficiently random values
+    - CWE-340   # generation of predictable numbers
+    - CWE-916   # use of password hash with insufficient effort
+
+key_questions:
+  - "Does this code make any decision (branch, table lookup, early exit) on data derived from a secret? If so, the timing of that decision leaks the secret bit-by-bit."
+  - "When verifying a tag / MAC / signature, does the comparison run for the FULL length unconditionally, or does it short-circuit on first mismatch?"
+  - "Is the cryptographic primitive being used in the right mode? (ECB for bulk data; CBC without authentication; nonce reuse with stream ciphers; etc.)"
+  - "When an operation fails (verification, decryption), does the error path leak more information than the success path — error message texts, length of returned data, presence vs absence of side effects?"
+
+prompt_addendum: |
+  Cryptographic code requires constant-time discipline that's
+  often violated by ostensibly "obvious" optimisations: early
+  exit on mismatch in ``memcmp``, table lookups indexed by secret
+  bytes, branching on whether decryption succeeded. Look for
+  any control-flow OR data-flow that depends on a secret. For
+  every comparison of secrets, confirm it uses a constant-time
+  helper (``crypto_memneq``, ``CRYPTO_memcmp``) — never a plain
+  ``memcmp`` or ``==``. For every modular arithmetic operation,
+  ask whether the implementation pre-computes blinding values to
+  hide the secret operand's bit pattern from cache-timing
+  observers.
+
+exemplars:
+  - cve: CVE-2016-2107
+    title: OpenSSL AES-NI CBC padding oracle
+    pattern: |
+      The decryption path computes the MAC over the padded
+      plaintext and the ciphertext separately, leaving a timing
+      difference between "MAC verification failed because padding
+      was structurally wrong" and "MAC verification failed because
+      of a content mismatch". An attacker observing the timing of
+      many attempts reconstructs the plaintext byte by byte.
+    why_buggy: |
+      The two failure modes leave through different code paths
+      with measurably different durations. A constant-time
+      implementation would compute through to the same
+      operation count regardless of where verification first
+      failed. The attacker sends crafted ciphertexts and times
+      the response — millions of queries reveal the secret.
+      Lesson: even when the algorithm itself is sound, leaking
+      the WHY of a verification failure is enough to break it.

--- a/core/llm/cwe_strategies/strategies/general.yml
+++ b/core/llm/cwe_strategies/strategies/general.yml
@@ -1,0 +1,53 @@
+name: general
+description: |
+  Default strategy for all code under review. Trust + assumption
+  reasoning that applies regardless of bug class — when no other
+  strategy fits, this one always does.
+
+signals:
+  # General has no specialised signals — it's the default fallback.
+  # When other strategies match better, those win; general stays
+  # included by the picker's always-on flag.
+  cwes: []
+
+key_questions:
+  - "What does this function trust about its inputs and the surrounding state?"
+  - "What invariants must callers maintain? Where are they checked?"
+  - "What happens when each assumption is violated — does the function still behave safely?"
+  - "On error paths, are resources released and partial state cleaned up?"
+
+prompt_addendum: |
+  Read the function with an attacker who controls everything the
+  function does not explicitly validate. For each parameter, ask
+  what the function does if the value is unexpected (negative
+  length, NULL pointer, oversized buffer, malformed string, the
+  same value as another parameter that's supposed to be different).
+  Trace what happens on the EARLY-RETURN paths as carefully as on
+  the success path — bugs often live in cleanup gaps.
+
+exemplars:
+  - cve: CVE-2022-0995
+    title: watch_queue missing bounds check
+    pattern: |
+      The function indexes into a fixed-size array using a value
+      derived from a syscall argument without first validating
+      that the index falls within the array.
+    why_buggy: |
+      Caller-supplied integer is used as an array index. The
+      function assumes the caller passes only valid indices, but
+      the caller is unprivileged userspace and can pass anything.
+      Out-of-bounds write corrupts adjacent kernel state.
+
+  - cve: CVE-2022-1016
+    title: nf_tables information leak from uninitialised stack
+    pattern: |
+      A struct on the stack is partially initialised (some fields
+      assigned, others left untouched) and then copied to userspace
+      as the response to a syscall.
+    why_buggy: |
+      The function trusts that ``memset`` or per-field assignment
+      covers every byte of the struct. Compiler padding between
+      fields, or a new field added without updating the
+      initialisation, leaves uninitialised stack bytes that get
+      copied out — leaking whatever the previous stack frame
+      contained.

--- a/core/llm/cwe_strategies/strategies/input_handling.yml
+++ b/core/llm/cwe_strategies/strategies/input_handling.yml
@@ -1,0 +1,78 @@
+name: input_handling
+description: |
+  Parsers, protocol handlers, and any code that reads structured
+  data supplied by an attacker. The signature pattern: a length /
+  type / offset field is consumed before being validated against
+  the actual buffer or table size.
+
+signals:
+  paths:
+    - net/
+    - drivers/input/
+    - drivers/usb/
+    - drivers/net/
+    - fs/
+    - sound/
+  includes:
+    - linux/skbuff.h
+    - linux/netlink.h
+    - linux/usb.h
+  function_keywords:
+    - parse
+    - decode
+    - deserialize
+    - unmarshal
+    - load
+  function_calls:
+    - copy_from_user
+    - get_user
+    - skb_pull
+    - skb_push
+    - skb_copy_bits
+    - nla_get_u32
+    - nla_get_u64
+    - kmemdup_array
+  cwes:
+    - CWE-20    # improper input validation
+    - CWE-78    # OS command injection
+    - CWE-79    # XSS
+    - CWE-89    # SQL injection
+    - CWE-119   # buffer bounds
+    - CWE-120   # classic buffer overflow
+    - CWE-125   # out-of-bounds read
+    - CWE-787   # out-of-bounds write
+    - CWE-22    # path traversal
+    - CWE-94    # code injection
+
+key_questions:
+  - "What format does this code assume the input has? Does it ever check before consuming?"
+  - "Are length / size / count / offset fields validated against the actual buffer size BEFORE being used?"
+  - "If a length field claims more bytes than available, what happens — out-of-bounds read, integer overflow on the length, infinite loop?"
+  - "Are integer fields checked for negative / zero / overflow values that would cause downstream calculations to wrap?"
+
+prompt_addendum: |
+  Treat every byte of the input as adversary-controlled. For each
+  field the code reads, ask: what's the largest value that gets
+  through? what's the smallest? does the code handle both extremes?
+  Pay particular attention to length-prefixed fields where the
+  length is read from the buffer — these are nearly always the
+  source of CVEs in protocol handlers. Walk the function with
+  inputs that lie about their size: a length field saying 1MB when
+  only 64 bytes are available, or claiming 0 bytes after a header
+  the code already advanced past.
+
+exemplars:
+  - cve: CVE-2023-0179
+    title: nf_tables payload length confusion
+    pattern: |
+      A length field from a netlink payload is used to size a
+      memory copy without first checking that the field's claimed
+      length fits within the actual netlink message buffer. The
+      copy reads past the end of attacker-controlled memory.
+    why_buggy: |
+      The function trusts the length field to be honest. The
+      caller is unprivileged userspace via a netlink socket — it
+      can claim any length. Validation that ``claimed_len <=
+      remaining_buffer_bytes`` was missing on the path the
+      attacker exercised. Result: out-of-bounds read of kernel
+      memory, leakable through a subsequent write to userspace.

--- a/core/llm/cwe_strategies/strategies/memory_aliasing.yml
+++ b/core/llm/cwe_strategies/strategies/memory_aliasing.yml
@@ -1,0 +1,105 @@
+name: memory_aliasing
+description: |
+  Code that creates aliases between two memory regions — same
+  physical pages mapped or referenced from two paths. The bug
+  class: one path treats the alias as read-only or as having
+  one set of ownership semantics; another path writes through
+  the alias or assumes different semantics. The bracket spans
+  Dirty COW (race-induced) to CopyFail (race-free in-place
+  optimisation).
+
+signals:
+  paths:
+    - mm/
+    - fs/splice.c
+    - fs/pipe.c
+    - fs/iomap/
+    - crypto/algif_aead.c
+    - lib/iov_iter.c
+  includes:
+    - linux/splice.h
+    - linux/pipe_fs_i.h
+    - linux/iov_iter.h
+  function_keywords:
+    - splice
+    - alias
+    - inplace
+  function_calls:
+    - splice_to_pipe
+    - generic_splice_sendpage
+    - sg_chain
+    - sg_init_table
+    - iov_iter_init
+    - iov_iter_pipe
+    - copy_page_to_iter
+    - get_pages
+    - get_user_pages
+    - copy_page
+  cwes:
+    # Aliasing-specific patterns. Generic buffer-bounds CWEs
+    # (CWE-119, CWE-787) belong with memory_management; including
+    # them here would make this strategy a magnet for every
+    # corruption finding, drowning the genuine alias signal.
+    - CWE-362   # race condition (Dirty COW)
+    - CWE-668   # exposure of resource to wrong sphere
+
+key_questions:
+  - "Does this code set up an aliasing relationship between two regions — same pages, overlapping scatterlists, shared page-cache entries?"
+  - "Who provided the source pages? Are they writable from the source's perspective, or only readable? Does this code write to them?"
+  - "If another subsystem holds a reference to the same pages (page cache, swap cache, file mapping), can it observe writes made through the alias?"
+  - "Are there assumptions like 'this page is private to me' that would break if the page is actually shared? What enforces privacy — a copy-on-write check, a flag bit, or just convention?"
+
+prompt_addendum: |
+  Aliasing bugs are subtle because each code path is locally
+  correct under its own assumptions. The bug emerges from the
+  intersection — the source path expects 'read-only', the destination
+  path produces 'write through'. Walk the function looking for
+  any operation that creates an alias: a scatterlist whose source
+  pages came from another subsystem, an iov_iter that transmutes
+  read iovecs into write iovecs, an in-place transform that swaps
+  destination and source. For each alias, name BOTH endpoints
+  and ask: does each endpoint's code know the other endpoint
+  exists, and does each endpoint enforce its own assumptions on
+  the shared memory?
+
+exemplars:
+  - cve: CVE-2022-0847
+    title: Dirty Pipe — pipe buffer flag persistence enables write to read-only
+      page-cache pages
+    pattern: |
+      A page splice'd from a read-only file into a pipe buffer
+      retains the ``PIPE_BUF_FLAG_CAN_MERGE`` flag from a previous
+      writer. When a subsequent ``write(pipe)`` reuses the same
+      pipe buffer slot, the kernel believes the destination page
+      is mergeable / writable and writes the new data directly
+      into the page-cache page that backs the read-only file.
+    why_buggy: |
+      The pipe buffer's flag was not cleared when the splice path
+      reused a buffer struct. The splice path treated the buffer
+      as 'read-only source'; the write path treated it as
+      'writable destination', because the flag from a prior write
+      operation persisted. Two paths, two assumptions, one
+      shared piece of state — the bug is that the state didn't
+      reset when the role changed.
+
+  - cve: CVE-2026-31431
+    title: CopyFail — algif_aead in-place authencesn aliases splice'd page-cache
+      pages
+    pattern: |
+      The algif_aead receive path reuses splice'd input pages as
+      the output scatterlist for in-place transformation. The
+      authencesn algorithm writes scratch / authentication-tag
+      bytes into the scatterlist as part of normal operation.
+      Because the splice'd pages came directly from the page
+      cache (not a private copy), the writes corrupt the file's
+      cached contents.
+    why_buggy: |
+      The optimisation aliases the source and destination
+      scatterlists for performance. It assumed the source is
+      private to algif_aead. It isn't — splice gives back
+      page-cache references, and the cache is shared with every
+      other reader of the same file. The crypto path's
+      assumption ('this is my buffer, I can write to it') is
+      locally true but globally violated. No race needed; a
+      straight-line syscall sequence corrupts arbitrary readable
+      files in the cache.

--- a/core/llm/cwe_strategies/strategies/memory_management.yml
+++ b/core/llm/cwe_strategies/strategies/memory_management.yml
@@ -1,0 +1,106 @@
+name: memory_management
+description: |
+  Code that allocates, frees, or reference-counts heap objects.
+  The bug classes: asymmetric refcounting (extra free, missing
+  free, double free), dangling pointers after object removal,
+  memory leaks on error paths, use-after-free across function
+  boundaries.
+
+signals:
+  paths:
+    - mm/
+    - mm/slab/
+    - kernel/cred.c
+    - kernel/exit.c
+  includes:
+    - linux/slab.h
+    - linux/refcount.h
+    - linux/kref.h
+    - linux/percpu-refcount.h
+  function_keywords:
+    - alloc
+    - free
+    - destroy
+    - put
+    - ref
+    - unref
+    - refcount
+    - kref
+  function_calls:
+    - kmalloc
+    - kzalloc
+    - kfree
+    - kvfree
+    - vmalloc
+    - vfree
+    - kmem_cache_alloc
+    - kmem_cache_free
+    - kref_get
+    - kref_put
+    - refcount_inc
+    - refcount_dec
+    - refcount_dec_and_test
+    - put_device
+    - get_device
+  cwes:
+    - CWE-119   # buffer bounds
+    - CWE-401   # missing release after lifecycle
+    - CWE-415   # double free
+    - CWE-416   # use-after-free
+    - CWE-476   # NULL pointer dereference
+    - CWE-590   # free of memory not on heap
+    - CWE-672   # use after expiration
+    - CWE-762   # mismatched free
+    - CWE-770   # allocation without limits
+
+key_questions:
+  - "For every successful allocation, is there exactly one matching free on EVERY return path — including error paths and early returns?"
+  - "If this function takes a reference, is the reference released by the same function on errors, or transferred to the caller? Is the contract documented or enforceable?"
+  - "When an object is removed from a global structure (list, hash, tree), is every path that holds a stored pointer to it either notified or invalidated?"
+  - "For shared mutable state: is there any sequence — concurrent or sequential — that could free an object while a pointer to it is still in active use elsewhere?"
+
+prompt_addendum: |
+  Trace ownership symbolically: who 'owns' each pointer on entry,
+  what's the ownership state on each exit path, and are those
+  states consistent with the function's contract. Asymmetry is
+  the bug — one path frees, another doesn't, and the caller
+  assumes one or the other. For refcount-managed objects, count
+  the increments and decrements on every code path; they MUST
+  balance. Pay close attention to error-handling cleanup: most
+  refcount bugs live in ``goto err_*`` ladders where the order of
+  ``put`` calls relative to the failed step is wrong.
+
+exemplars:
+  - cve: CVE-2024-1086
+    title: nf_tables verdict mismatch double-free
+    pattern: |
+      The verdict path of an nft expression frees an object on
+      one side and a different verdict path frees the same object
+      on the other side. A specific sequence of netlink commands
+      causes both paths to fire in order, producing a double-free
+      of the original object plus a use-after-free on the second
+      free's allocator metadata.
+    why_buggy: |
+      Each verdict path is locally correct: it frees what its
+      branch allocated. But the two paths can both fire on the
+      same object across separate netfilter table mutations.
+      The bug is that the ownership model — which verdict 'owns'
+      the cleanup — was implicit and could be made ambiguous from
+      userspace. Real fix: explicit ownership tracking, not just
+      adding a NULL check.
+
+  - cve: CVE-2022-2588
+    title: cls_route filter dangling pointer after hash removal
+    pattern: |
+      A cls_route filter is removed from a hash table on one path
+      while another path still holds a pointer to it. The remove
+      operation only unlinks the filter; it does not invalidate
+      any other paths' caches of the now-detached pointer. A
+      subsequent operation dereferences the dangling pointer.
+    why_buggy: |
+      The function removes the filter from the visible structure
+      but doesn't synchronise with concurrent readers. Removal
+      should be a two-phase operation: detach (visible to new
+      lookups), then synchronise (drain in-flight operations
+      holding cached pointers), then free. Skipping the
+      synchronisation step leaves dangling references.

--- a/core/llm/cwe_strategies/tests/test_bundled_strategies.py
+++ b/core/llm/cwe_strategies/tests/test_bundled_strategies.py
@@ -1,0 +1,216 @@
+"""Coverage for the 7 bundled strategies.
+
+Verifies every shipped strategy:
+  * Loads cleanly via the strict schema.
+  * Has at least one CVE exemplar (the design-doc principle).
+  * Is reachable through the picker via realistic signals.
+
+These tests are the canary: if a strategy YAML breaks during edits,
+or if a renamed file silently disappears from the bundled dir, this
+test surfaces it immediately.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.llm.cwe_strategies import (
+    Strategy,
+    load_all,
+    pick_strategies,
+)
+
+
+_EXPECTED_STRATEGIES = {
+    "general",
+    "input_handling",
+    "concurrency",
+    "memory_management",
+    "auth_privilege",
+    "cryptography",
+    "memory_aliasing",
+}
+
+
+@pytest.fixture(scope="module")
+def all_strategies():
+    return load_all()
+
+
+@pytest.fixture(scope="module")
+def by_name(all_strategies):
+    return {s.name: s for s in all_strategies}
+
+
+# ---------------------------------------------------------------------------
+# Bundle completeness
+# ---------------------------------------------------------------------------
+
+
+class TestBundle:
+    def test_all_seven_present(self, by_name):
+        names = set(by_name)
+        missing = _EXPECTED_STRATEGIES - names
+        assert not missing, f"missing bundled strategies: {sorted(missing)}"
+
+    def test_no_unexpected_strategies(self, by_name):
+        names = set(by_name)
+        unexpected = names - _EXPECTED_STRATEGIES
+        # Allow extras in future without breaking; just flag for visibility.
+        # Convert to a clear assertion the operator wants to see.
+        assert names >= _EXPECTED_STRATEGIES
+
+    @pytest.mark.parametrize("name", sorted(_EXPECTED_STRATEGIES))
+    def test_each_loads(self, by_name, name):
+        s = by_name.get(name)
+        assert isinstance(s, Strategy), f"{name} did not load"
+        assert s.description, f"{name} has empty description"
+        assert s.key_questions, f"{name} has no key_questions"
+        assert s.prompt_addendum, f"{name} has empty prompt_addendum"
+
+    @pytest.mark.parametrize("name", sorted(_EXPECTED_STRATEGIES))
+    def test_each_has_at_least_one_exemplar(self, by_name, name):
+        # ``general`` has 2; the rest have at least 1.
+        s = by_name[name]
+        assert len(s.exemplars) >= 1, (
+            f"{name} has no CVE exemplars — design doc requires 1-2 per strategy"
+        )
+
+    @pytest.mark.parametrize("name", sorted(_EXPECTED_STRATEGIES - {"general"}))
+    def test_specialised_strategies_have_signals(self, by_name, name):
+        """Every strategy except ``general`` should have at least one
+        signal — otherwise the picker can never select it."""
+        s = by_name[name]
+        sig = s.signals
+        has_any = sig.paths or sig.includes or sig.function_keywords
+        assert has_any, (
+            f"{name} has no signals — picker can't reach it. "
+            f"Add at least one path / include / function_keyword."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Picker reachability — each specialised strategy must fire on at
+# least one realistic signal combination.
+# ---------------------------------------------------------------------------
+
+
+class TestPickerReachability:
+    """If a strategy can never be picked, it adds noise to the bundle
+    without contributing. These tests pin a representative trigger
+    for each one — adapt if the signals are tuned later."""
+
+    def _get(self, by_name, name):
+        return by_name[name]
+
+    def test_input_handling_via_path(self, by_name):
+        out = pick_strategies(
+            file_path="net/netfilter/nf_tables_api.c",
+            function_name="nft_payload_eval",
+        )
+        assert "input_handling" in {s.name for s in out}
+
+    def test_input_handling_via_keyword(self, by_name):
+        out = pick_strategies(
+            file_path="src/random.c",
+            function_name="parse_request",
+        )
+        assert "input_handling" in {s.name for s in out}
+
+    def test_concurrency_via_path(self, by_name):
+        out = pick_strategies(
+            file_path="kernel/locking/rwsem.c",
+            function_name="x",
+        )
+        assert "concurrency" in {s.name for s in out}
+
+    def test_concurrency_via_include(self, by_name):
+        out = pick_strategies(
+            file_path="src/foo.c",
+            function_name="x",
+            file_includes=["linux/mutex.h"],
+        )
+        assert "concurrency" in {s.name for s in out}
+
+    def test_memory_management_via_keyword(self, by_name):
+        out = pick_strategies(
+            file_path="src/foo.c",
+            function_name="kref_put_obj",
+        )
+        assert "memory_management" in {s.name for s in out}
+
+    def test_auth_privilege_via_path(self, by_name):
+        out = pick_strategies(
+            file_path="security/commoncap.c",
+            function_name="x",
+        )
+        assert "auth_privilege" in {s.name for s in out}
+
+    def test_auth_privilege_via_keyword(self, by_name):
+        out = pick_strategies(
+            file_path="src/foo.c",
+            function_name="ns_capable_or_die",
+        )
+        assert "auth_privilege" in {s.name for s in out}
+
+    def test_cryptography_via_path(self, by_name):
+        out = pick_strategies(
+            file_path="crypto/aes.c",
+            function_name="x",
+        )
+        assert "cryptography" in {s.name for s in out}
+
+    def test_cryptography_via_keyword(self, by_name):
+        out = pick_strategies(
+            file_path="src/foo.c",
+            function_name="hmac_verify",
+        )
+        assert "cryptography" in {s.name for s in out}
+
+    def test_memory_aliasing_via_path(self, by_name):
+        out = pick_strategies(
+            file_path="fs/splice.c",
+            function_name="x",
+        )
+        assert "memory_aliasing" in {s.name for s in out}
+
+    def test_memory_aliasing_via_keyword(self, by_name):
+        out = pick_strategies(
+            file_path="src/foo.c",
+            function_name="splice_pages",
+        )
+        assert "memory_aliasing" in {s.name for s in out}
+
+
+# ---------------------------------------------------------------------------
+# Multi-strategy picks — realistic combinations
+# ---------------------------------------------------------------------------
+
+
+class TestMultiStrategyPicks:
+    def test_network_packet_handler_under_lock(self):
+        """Network handler holding a lock should match input_handling
+        + concurrency, plus general."""
+        out = pick_strategies(
+            file_path="net/foo.c",
+            function_name="parse_packet_locked",
+            file_includes=["linux/skbuff.h", "linux/spinlock.h"],
+            max_strategies=3,
+        )
+        names = {s.name for s in out}
+        assert "general" in names
+        assert "input_handling" in names
+        assert "concurrency" in names
+
+    def test_crypto_under_aliasing(self):
+        out = pick_strategies(
+            file_path="crypto/algif_aead.c",
+            function_name="aead_recvmsg_locked_splice",
+            max_strategies=4,
+        )
+        names = {s.name for s in out}
+        # Path matches both crypto/ AND has 'splice' keyword for aliasing
+        # AND lock_ keyword for concurrency.
+        assert "general" in names
+        assert "cryptography" in names
+        assert "memory_aliasing" in names

--- a/core/llm/cwe_strategies/tests/test_loader.py
+++ b/core/llm/cwe_strategies/tests/test_loader.py
@@ -1,0 +1,265 @@
+"""Tests for the strategy YAML loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.llm.cwe_strategies import (
+    Strategy,
+    StrategyLoadError,
+    builtin_strategies_dir,
+    load_all,
+    load_strategy,
+)
+
+
+# ---------------------------------------------------------------------------
+# Real bundled strategies
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinStrategies:
+    def test_dir_exists_and_loads(self):
+        d = builtin_strategies_dir()
+        assert d.is_dir(), f"strategies dir missing: {d}"
+        strategies = load_all()
+        assert len(strategies) >= 1
+        # Sanity: every loaded entry is a Strategy.
+        assert all(isinstance(s, Strategy) for s in strategies)
+
+    def test_general_strategy_present(self):
+        strategies = load_all()
+        names = {s.name for s in strategies}
+        assert "general" in names
+
+    def test_loaded_strategies_have_required_shape(self):
+        for s in load_all():
+            assert s.name
+            assert s.description
+            # No empty key_questions for shipped strategies.
+            assert s.key_questions, f"{s.name} has no key_questions"
+
+
+# ---------------------------------------------------------------------------
+# Loading from disk — round-trip + schema enforcement
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, content: str, name: str = "x.yml") -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+class TestLoadStrategySchema:
+    def test_minimal_valid(self, tmp_path):
+        p = _write(tmp_path, """
+name: minimal
+description: A minimal valid strategy
+""")
+        s = load_strategy(p)
+        assert s.name == "minimal"
+        assert s.description == "A minimal valid strategy"
+        assert s.signals.paths == ()
+        assert s.key_questions == ()
+        assert s.exemplars == ()
+
+    def test_full_round_trip(self, tmp_path):
+        p = _write(tmp_path, """
+name: input_handling
+description: Parsers, network protocol handlers
+signals:
+  paths: [net/, drivers/input/]
+  includes: [linux/skbuff.h]
+  function_keywords: [parse, decode]
+key_questions:
+  - "What format assumptions does this make?"
+  - "Are length fields validated?"
+prompt_addendum: |
+  Focus on bounds checks.
+exemplars:
+  - cve: CVE-2023-0179
+    title: nftables length confusion
+    pattern: |
+      Length field trusted before bounds check.
+    why_buggy: |
+      Caller-controlled length used to size copy.
+""")
+        s = load_strategy(p)
+        assert s.name == "input_handling"
+        assert s.signals.paths == ("net/", "drivers/input/")
+        assert s.signals.includes == ("linux/skbuff.h",)
+        assert s.signals.function_keywords == ("parse", "decode")
+        assert len(s.key_questions) == 2
+        assert "bounds checks" in s.prompt_addendum
+        assert len(s.exemplars) == 1
+        assert s.exemplars[0].cve == "CVE-2023-0179"
+
+    def test_to_dict_round_trip(self, tmp_path):
+        import json
+        p = _write(tmp_path, """
+name: x
+description: y
+signals:
+  paths: [a/]
+key_questions:
+  - "q1?"
+exemplars:
+  - cve: CVE-1
+    title: t
+    pattern: p
+    why_buggy: w
+""")
+        s = load_strategy(p)
+        d = s.to_dict()
+        assert json.dumps(d)  # serialisable
+        assert d["signals"]["paths"] == ["a/"]
+        assert d["exemplars"][0]["cve"] == "CVE-1"
+
+
+# ---------------------------------------------------------------------------
+# Adversarial — malformed strategy files
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarialSchema:
+    def test_missing_name_rejected(self, tmp_path):
+        p = _write(tmp_path, "description: no name\n")
+        with pytest.raises(StrategyLoadError, match="name"):
+            load_strategy(p)
+
+    def test_missing_description_rejected(self, tmp_path):
+        p = _write(tmp_path, "name: x\n")
+        with pytest.raises(StrategyLoadError, match="description"):
+            load_strategy(p)
+
+    def test_unknown_top_level_key_rejected(self, tmp_path):
+        p = _write(tmp_path, """
+name: x
+description: y
+typo_field: oops
+""")
+        with pytest.raises(StrategyLoadError, match="unknown"):
+            load_strategy(p)
+
+    def test_unknown_signals_key_rejected(self, tmp_path):
+        p = _write(tmp_path, """
+name: x
+description: y
+signals:
+  paths: [a/]
+  pahts: [b/]   # typo
+""")
+        with pytest.raises(StrategyLoadError, match="unknown"):
+            load_strategy(p)
+
+    def test_unknown_exemplar_key_rejected(self, tmp_path):
+        p = _write(tmp_path, """
+name: x
+description: y
+exemplars:
+  - cve: CVE-1
+    title: t
+    pattern: p
+    why_buggy: w
+    note: extra   # not allowed
+""")
+        with pytest.raises(StrategyLoadError, match="unknown"):
+            load_strategy(p)
+
+    def test_signals_not_a_list_rejected(self, tmp_path):
+        p = _write(tmp_path, """
+name: x
+description: y
+signals:
+  paths: not_a_list
+""")
+        with pytest.raises(StrategyLoadError, match="list of strings"):
+            load_strategy(p)
+
+    def test_signals_list_with_non_string_rejected(self, tmp_path):
+        p = _write(tmp_path, """
+name: x
+description: y
+signals:
+  paths: [42, "ok/"]
+""")
+        with pytest.raises(StrategyLoadError, match="expected string"):
+            load_strategy(p)
+
+    def test_exemplar_missing_field_rejected(self, tmp_path):
+        p = _write(tmp_path, """
+name: x
+description: y
+exemplars:
+  - cve: CVE-1
+    title: t
+    pattern: p
+""")
+        with pytest.raises(StrategyLoadError, match="missing required field 'why_buggy'"):
+            load_strategy(p)
+
+    def test_invalid_yaml_rejected(self, tmp_path):
+        p = _write(tmp_path, "name: x\ndescription: [unclosed\n")
+        with pytest.raises(StrategyLoadError, match="invalid YAML"):
+            load_strategy(p)
+
+    def test_top_level_not_mapping_rejected(self, tmp_path):
+        p = _write(tmp_path, "- just a list\n")
+        with pytest.raises(StrategyLoadError, match="must be a mapping"):
+            load_strategy(p)
+
+    def test_empty_name_rejected(self, tmp_path):
+        p = _write(tmp_path, """
+name: ""
+description: y
+""")
+        with pytest.raises(StrategyLoadError, match="non-empty string"):
+            load_strategy(p)
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(StrategyLoadError):
+            load_strategy(tmp_path / "nope.yml")
+
+
+# ---------------------------------------------------------------------------
+# load_all behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAll:
+    def test_empty_dir_yields_empty_list(self, tmp_path):
+        assert load_all(tmp_path) == []
+
+    def test_missing_dir_yields_empty_list(self, tmp_path):
+        assert load_all(tmp_path / "nope") == []
+
+    def test_loads_all_yml_files(self, tmp_path):
+        _write(tmp_path, "name: a\ndescription: A\n", "a.yml")
+        _write(tmp_path, "name: b\ndescription: B\n", "b.yml")
+        out = load_all(tmp_path)
+        assert {s.name for s in out} == {"a", "b"}
+
+    def test_duplicate_names_rejected(self, tmp_path):
+        _write(tmp_path, "name: dup\ndescription: A\n", "a.yml")
+        _write(tmp_path, "name: dup\ndescription: B\n", "b.yml")
+        with pytest.raises(StrategyLoadError, match="duplicate"):
+            load_all(tmp_path)
+
+    def test_non_yml_files_ignored(self, tmp_path):
+        _write(tmp_path, "name: a\ndescription: A\n", "a.yml")
+        (tmp_path / "README.md").write_text("# notes")
+        (tmp_path / "draft.yaml").write_text("name: draft")  # .yaml not .yml
+        out = load_all(tmp_path)
+        assert len(out) == 1
+        assert out[0].name == "a"
+
+    def test_sorted_load_order(self, tmp_path):
+        _write(tmp_path, "name: zeta\ndescription: Z\n", "zzz.yml")
+        _write(tmp_path, "name: alpha\ndescription: A\n", "aaa.yml")
+        _write(tmp_path, "name: middle\ndescription: M\n", "mmm.yml")
+        names = [s.name for s in load_all(tmp_path)]
+        # File order is alphabetical (aaa.yml, mmm.yml, zzz.yml).
+        assert names == ["alpha", "middle", "zeta"]

--- a/core/llm/cwe_strategies/tests/test_picker.py
+++ b/core/llm/cwe_strategies/tests/test_picker.py
@@ -1,0 +1,286 @@
+"""Tests for ``pick_strategies``.
+
+Synthetic strategies are used throughout so the tests don't depend
+on which strategies are bundled — commit 3 adds the rest, and we
+don't want this test file to need updates each time.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.llm.cwe_strategies import (
+    Signals,
+    Strategy,
+    pick_strategies,
+)
+
+
+def _strat(name, *, paths=(), includes=(), keywords=()):
+    return Strategy(
+        name=name,
+        description=f"{name} description",
+        signals=Signals(
+            paths=tuple(paths),
+            includes=tuple(includes),
+            function_keywords=tuple(keywords),
+        ),
+        key_questions=("q1?",),
+        prompt_addendum=f"{name} addendum",
+    )
+
+
+GENERAL_STRAT = _strat("general")
+INPUT_STRAT = _strat("input_handling",
+                     paths=("net/", "drivers/input/"),
+                     keywords=("parse", "decode"))
+CONCURRENCY_STRAT = _strat("concurrency",
+                            paths=("kernel/locking/", "mm/"),
+                            includes=("linux/mutex.h",),
+                            keywords=("lock", "unlock"))
+CRYPTO_STRAT = _strat("cryptography",
+                       paths=("crypto/",),
+                       keywords=("hash", "encrypt"))
+
+
+def _pool():
+    return [GENERAL_STRAT, INPUT_STRAT, CONCURRENCY_STRAT, CRYPTO_STRAT]
+
+
+# ---------------------------------------------------------------------------
+# Default behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestDefaults:
+    def test_general_always_first_when_no_match(self):
+        out = pick_strategies(
+            file_path="src/random.py",
+            function_name="do_thing",
+            strategies=_pool(),
+        )
+        assert len(out) == 1
+        assert out[0].name == "general"
+
+    def test_general_first_with_matches(self):
+        out = pick_strategies(
+            file_path="net/proto.c",
+            function_name="parse_packet",
+            strategies=_pool(),
+        )
+        # Should pick general + input_handling.
+        assert out[0].name == "general"
+        assert any(s.name == "input_handling" for s in out)
+
+    def test_max_strategies_cap(self):
+        out = pick_strategies(
+            file_path="net/crypto/lock.c",  # matches 3 strategies
+            function_name="parse_lock_hash",  # matches 3 keywords
+            strategies=_pool(),
+            max_strategies=2,
+        )
+        # General + best match = 2 entries.
+        assert len(out) == 2
+        assert out[0].name == "general"
+
+    def test_max_strategies_zero_returns_empty(self):
+        out = pick_strategies(
+            file_path="net/proto.c",
+            function_name="parse",
+            strategies=_pool(),
+            max_strategies=0,
+        )
+        assert out == []
+
+
+# ---------------------------------------------------------------------------
+# Signal scoring
+# ---------------------------------------------------------------------------
+
+
+class TestSignalScoring:
+    def test_path_match(self):
+        out = pick_strategies(
+            file_path="net/skbuff.c",
+            function_name="x",
+            strategies=_pool(),
+        )
+        assert "input_handling" in {s.name for s in out}
+
+    def test_keyword_match_in_function_name(self):
+        out = pick_strategies(
+            file_path="src/util.c",  # no path match
+            function_name="encrypt_buffer",
+            strategies=_pool(),
+        )
+        assert "cryptography" in {s.name for s in out}
+
+    def test_include_match(self):
+        out = pick_strategies(
+            file_path="src/random.c",
+            function_name="x",
+            file_includes=("linux/mutex.h",),
+            strategies=_pool(),
+        )
+        assert "concurrency" in {s.name for s in out}
+
+    def test_higher_score_ranks_higher(self):
+        # input_handling: 1 path match (net/) + 1 keyword (parse) = 2
+        # concurrency: 1 path match (mm/) only = 1
+        out = pick_strategies(
+            file_path="net/foo.c",  # input_handling: paths
+            function_name="parse_data",  # input_handling: keyword
+            strategies=_pool(),
+            max_strategies=3,
+        )
+        # general first, then input_handling (highest score).
+        assert out[0].name == "general"
+        # input_handling should appear before concurrency (no concurrency
+        # signal in this case, so concurrency wouldn't show at all).
+        assert out[1].name == "input_handling"
+
+    def test_zero_score_excluded(self):
+        out = pick_strategies(
+            file_path="src/totally_unrelated.py",
+            function_name="boring_helper",
+            strategies=_pool(),
+        )
+        # Only general (always-included), no zero-score strategies.
+        assert [s.name for s in out] == ["general"]
+
+    def test_case_insensitive_path(self):
+        out = pick_strategies(
+            file_path="NET/Proto.C",
+            function_name="x",
+            strategies=_pool(),
+        )
+        assert "input_handling" in {s.name for s in out}
+
+    def test_case_insensitive_keyword(self):
+        out = pick_strategies(
+            file_path="src/x.c",
+            function_name="ENCRYPT_DATA",
+            strategies=_pool(),
+        )
+        assert "cryptography" in {s.name for s in out}
+
+    def test_alphabetical_tiebreaker(self):
+        # Construct two strategies with same-length keywords so the
+        # specificity-weighted scoring genuinely ties.
+        a = _strat("aaa", keywords=("hash",))   # len 4
+        b = _strat("bbb", keywords=("lock",))   # len 4
+        out = pick_strategies(
+            file_path="src/x.c",
+            function_name="hash_lock",  # hits both, equal length
+            strategies=[a, b, GENERAL_STRAT],
+        )
+        # Both score 4; alphabetical ordering: aaa < bbb.
+        names = [s.name for s in out]
+        assert names == ["general", "aaa", "bbb"]
+
+    def test_specificity_outranks_breadth(self):
+        """Length-weighted scoring: a narrow path signal outscores
+        a broader one matching the same file."""
+        narrow = _strat("narrow", paths=("fs/splice.c",))   # len 12
+        broad = _strat("broad", paths=("fs/",))              # len 3
+        out = pick_strategies(
+            file_path="fs/splice.c",
+            function_name="x",
+            strategies=[narrow, broad],
+            always_include_general=False,
+        )
+        # Narrow's specificity wins.
+        assert out[0].name == "narrow"
+        assert out[1].name == "broad"
+
+
+# ---------------------------------------------------------------------------
+# always_include_general
+# ---------------------------------------------------------------------------
+
+
+class TestAlwaysIncludeGeneral:
+    def test_general_omitted_when_flag_off_and_other_matches(self):
+        out = pick_strategies(
+            file_path="net/x.c",
+            function_name="parse_data",
+            strategies=_pool(),
+            always_include_general=False,
+        )
+        # General should not appear; input_handling is the match.
+        assert "general" not in {s.name for s in out}
+        assert "input_handling" in {s.name for s in out}
+
+    def test_general_falls_through_when_flag_off_and_no_matches(self):
+        # No matches at all — picker should still return general so
+        # the caller never gets an empty list when general exists.
+        out = pick_strategies(
+            file_path="src/totally_unrelated.py",
+            function_name="boring",
+            strategies=_pool(),
+            always_include_general=False,
+        )
+        assert [s.name for s in out] == ["general"]
+
+    def test_no_general_in_pool_returns_only_matches(self):
+        # Pool without general — pick should only return scored matches.
+        pool = [INPUT_STRAT, CONCURRENCY_STRAT]
+        out = pick_strategies(
+            file_path="net/x.c",
+            function_name="parse_data",
+            strategies=pool,
+        )
+        assert "general" not in {s.name for s in out}
+        assert "input_handling" in {s.name for s in out}
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_strategy_pool_returns_empty(self):
+        assert pick_strategies(
+            file_path="x", function_name="y", strategies=[],
+        ) == []
+
+    def test_empty_file_path(self):
+        # No path signals can match without a path.
+        out = pick_strategies(
+            file_path="",
+            function_name="parse_data",
+            strategies=_pool(),
+        )
+        # Keyword-based match still fires.
+        assert "input_handling" in {s.name for s in out}
+
+    def test_empty_function_name(self):
+        out = pick_strategies(
+            file_path="net/x.c",
+            function_name="",
+            strategies=_pool(),
+        )
+        # Path match fires.
+        assert "input_handling" in {s.name for s in out}
+
+    def test_empty_includes_list(self):
+        out = pick_strategies(
+            file_path="src/x.c",
+            function_name="x",
+            file_includes=(),
+            strategies=_pool(),
+        )
+        # No matches; only general.
+        assert [s.name for s in out] == ["general"]
+
+    def test_default_pool_loads_bundled(self):
+        """When ``strategies`` is None, picker loads from the bundled
+        directory. Sanity check that this path works at all."""
+        out = pick_strategies(
+            file_path="net/x.c",
+            function_name="parse",
+        )
+        # Bundled dir currently has only general — but that's fine,
+        # picker just returns it.
+        assert any(s.name == "general" for s in out)

--- a/core/llm/cwe_strategies/tests/test_picker_tier1.py
+++ b/core/llm/cwe_strategies/tests/test_picker_tier1.py
@@ -1,0 +1,296 @@
+"""Tests for Tier-1 picker improvements:
+
+  * 1a — token-based keyword matching (no more `parse` matching
+    `is_sparse_array`).
+  * 1b — function_calls signal: strategies declare callees, picker
+    accepts ``function_calls_made``.
+  * 1c — cwes signal: strategies declare CWEs, picker accepts
+    ``candidate_cwes``; CWE matches are heavy-weighted.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.llm.cwe_strategies import (
+    Signals,
+    Strategy,
+    pick_strategies,
+)
+
+
+def _strat(name, *, paths=(), includes=(), keywords=(),
+           calls=(), cwes=()):
+    return Strategy(
+        name=name,
+        description=f"{name} description",
+        signals=Signals(
+            paths=tuple(paths),
+            includes=tuple(includes),
+            function_keywords=tuple(keywords),
+            function_calls=tuple(calls),
+            cwes=tuple(cwes),
+        ),
+        key_questions=("q?",),
+        prompt_addendum=f"{name} addendum",
+    )
+
+
+GENERAL_STRAT = _strat("general")
+
+
+# ---------------------------------------------------------------------------
+# Tier 1a — token-based keyword matching
+# ---------------------------------------------------------------------------
+
+
+class TestTokenKeywordMatching:
+    def test_token_match_in_function_name(self):
+        s = _strat("input", keywords=("parse",))
+        out = pick_strategies(
+            file_path="x", function_name="parse_packet",
+            strategies=[GENERAL_STRAT, s],
+        )
+        assert "input" in {x.name for x in out}
+
+    def test_no_substring_pollution(self):
+        """``parse`` keyword should NOT match ``is_sparse_array`` —
+        the previous substring-based picker did, leading to
+        false-positive strategy picks on unrelated functions."""
+        s = _strat("input", keywords=("parse",))
+        out = pick_strategies(
+            file_path="x", function_name="is_sparse_array",
+            strategies=[GENERAL_STRAT, s],
+        )
+        # Only general; input is not picked.
+        assert [x.name for x in out] == ["general"]
+
+    def test_compare_does_not_match_parse(self):
+        """``parse`` is NOT a substring of ``compare`` — included
+        for the historical lesson that substring matching seems
+        right but isn't, and to pin the fix."""
+        s = _strat("input", keywords=("parse",))
+        out = pick_strategies(
+            file_path="x", function_name="compare_buffers",
+            strategies=[GENERAL_STRAT, s],
+        )
+        assert [x.name for x in out] == ["general"]
+
+    def test_token_with_dash_separator(self):
+        s = _strat("input", keywords=("parse",))
+        out = pick_strategies(
+            file_path="x", function_name="parse-packet",
+            strategies=[GENERAL_STRAT, s],
+        )
+        assert "input" in {x.name for x in out}
+
+    def test_trailing_underscore_keyword_treated_as_token(self):
+        """``get_`` is a common operator convention: 'matches as a
+        prefix'. Token semantics + trailing-separator strip handles
+        this — ``get_`` keyword matches ``get_user``, ``get_size``
+        etc."""
+        s = _strat("memory", keywords=("get_",))
+        out = pick_strategies(
+            file_path="x", function_name="get_user_creds",
+            strategies=[GENERAL_STRAT, s],
+        )
+        assert "memory" in {x.name for x in out}
+
+    def test_keyword_in_middle_token(self):
+        s = _strat("memory", keywords=("kref",))
+        out = pick_strategies(
+            file_path="x", function_name="my_kref_helper",
+            strategies=[GENERAL_STRAT, s],
+        )
+        assert "memory" in {x.name for x in out}
+
+    def test_partial_token_no_match(self):
+        """``ref`` keyword should NOT match ``referer`` (token
+        ``referer`` doesn't equal ``ref``)."""
+        s = _strat("memory", keywords=("ref",))
+        out = pick_strategies(
+            file_path="x", function_name="set_referer_header",
+            strategies=[GENERAL_STRAT, s],
+        )
+        assert [x.name for x in out] == ["general"]
+
+
+# ---------------------------------------------------------------------------
+# Tier 1b — function_calls signal
+# ---------------------------------------------------------------------------
+
+
+class TestFunctionCallsSignal:
+    def test_call_match_picks_strategy(self):
+        s = _strat("concurrency", calls=("mutex_lock", "mutex_unlock"))
+        out = pick_strategies(
+            file_path="src/random.c",  # no path signal
+            function_name="do_thing",   # no keyword signal
+            function_calls_made=["mutex_lock", "kfree"],
+            strategies=[GENERAL_STRAT, s],
+        )
+        assert "concurrency" in {x.name for x in out}
+
+    def test_no_call_match_no_pick(self):
+        s = _strat("concurrency", calls=("mutex_lock",))
+        out = pick_strategies(
+            file_path="x", function_name="y",
+            function_calls_made=["printf", "memcpy"],
+            strategies=[GENERAL_STRAT, s],
+        )
+        assert [x.name for x in out] == ["general"]
+
+    def test_call_match_outscores_path_match(self):
+        """A function calling `mutex_lock` is a stronger
+        concurrency signal than living in ``net/``. Length-weighted
+        scoring on the ``mutex_lock`` (10 chars) vs ``net/`` (4)
+        should rank concurrency higher."""
+        net_strat = _strat("input", paths=("net/",))
+        conc_strat = _strat("concurrency", calls=("mutex_lock",))
+        out = pick_strategies(
+            file_path="net/x.c",
+            function_name="x",
+            function_calls_made=["mutex_lock"],
+            strategies=[GENERAL_STRAT, net_strat, conc_strat],
+        )
+        # general first, then concurrency (10) before input (4).
+        names = [s.name for s in out]
+        assert names == ["general", "concurrency", "input"]
+
+    def test_case_insensitive_call_match(self):
+        s = _strat("concurrency", calls=("Mutex_Lock",))
+        out = pick_strategies(
+            file_path="x", function_name="y",
+            function_calls_made=["mutex_lock"],
+            strategies=[GENERAL_STRAT, s],
+        )
+        assert "concurrency" in {x.name for x in out}
+
+
+# ---------------------------------------------------------------------------
+# Tier 1c — cwes signal
+# ---------------------------------------------------------------------------
+
+
+class TestCweSignal:
+    def test_cwe_match_picks_strategy(self):
+        s = _strat("input", cwes=("CWE-78", "CWE-89"))
+        out = pick_strategies(
+            file_path="x", function_name="y",
+            candidate_cwes=["CWE-78"],
+            strategies=[GENERAL_STRAT, s],
+        )
+        assert "input" in {x.name for x in out}
+
+    def test_cwe_match_outranks_other_signals(self):
+        """A CWE pin is direct evidence — should outrank a
+        fragmentary signal stack from other strategies."""
+        a = _strat("a", cwes=("CWE-78",))
+        b = _strat("b",
+                   paths=("very/long/path/to/match/strongly/",),
+                   keywords=("parse", "decode", "deserialize",
+                             "unmarshal"))
+        out = pick_strategies(
+            file_path="very/long/path/to/match/strongly/x.c",
+            function_name="parse_decode_deserialize_unmarshal",
+            candidate_cwes=["CWE-78"],
+            strategies=[GENERAL_STRAT, a, b],
+        )
+        # 'a' wins on CWE pin (50 pts) over 'b' even with
+        # accumulated path + keyword length.
+        names = [s.name for s in out]
+        assert names[1] == "a"
+
+    def test_no_cwes_no_match(self):
+        s = _strat("input", cwes=("CWE-78",))
+        out = pick_strategies(
+            file_path="x", function_name="y",
+            candidate_cwes=[],
+            strategies=[GENERAL_STRAT, s],
+        )
+        assert [x.name for x in out] == ["general"]
+
+    def test_case_insensitive_cwe_match(self):
+        s = _strat("input", cwes=("cwe-78",))
+        out = pick_strategies(
+            file_path="x", function_name="y",
+            candidate_cwes=["CWE-78"],
+            strategies=[GENERAL_STRAT, s],
+        )
+        assert "input" in {x.name for x in out}
+
+    def test_multiple_cwe_matches_compound(self):
+        """Two CWEs both matching → 100 pts. Stronger evidence
+        than one CWE."""
+        a = _strat("a", cwes=("CWE-78",))
+        b = _strat("b", cwes=("CWE-89", "CWE-90"))
+        out = pick_strategies(
+            file_path="x", function_name="y",
+            candidate_cwes=["CWE-89", "CWE-90"],
+            strategies=[GENERAL_STRAT, a, b],
+        )
+        # 'b' has 2 CWE matches (100 pts) vs 'a' with no match (0).
+        assert "b" in {s.name for s in out}
+        assert "a" not in {s.name for s in out}
+
+
+# ---------------------------------------------------------------------------
+# Combined — realistic /audit driver scenario
+# ---------------------------------------------------------------------------
+
+
+class TestRealistic:
+    def test_audit_driver_with_full_context(self):
+        """The likely shape of /audit Phase A's call: file path,
+        function name, includes from inventory, callees from
+        tree-sitter call graph, CWEs from /agentic finding (if any).
+
+        With max=4, both CWE-pinned strategies and the call/include-
+        matched ``concurrency`` get into the result set."""
+        out = pick_strategies(
+            file_path="net/foo/parser.c",
+            function_name="parse_request",
+            file_includes=["linux/skbuff.h", "linux/spinlock.h"],
+            function_calls_made=["spin_lock", "skb_pull"],
+            candidate_cwes=["CWE-119"],
+            max_strategies=4,
+        )
+        names = [s.name for s in out]
+        # general always first, then specialised.
+        assert names[0] == "general"
+        # input_handling fires on path + include + keyword + call +
+        # the CWE-119 pin (it's classified there too).
+        assert "input_handling" in names
+        # memory_management also pinned on CWE-119.
+        assert "memory_management" in names
+        # concurrency fires on include + call (no CWE pin).
+        assert "concurrency" in names
+
+    def test_audit_driver_max3_prefers_cwe_pinned(self):
+        """With max=3 and two CWE-pinned strategies, the picker
+        prefers the CWE-pinned ones over a non-CWE-pinned third
+        (concurrency loses despite having include + call signal).
+        This is correct: a CWE pin is direct evidence; aggregated
+        weak signals shouldn't outrank it."""
+        out = pick_strategies(
+            file_path="net/foo/parser.c",
+            function_name="parse_request",
+            file_includes=["linux/skbuff.h", "linux/spinlock.h"],
+            function_calls_made=["spin_lock", "skb_pull"],
+            candidate_cwes=["CWE-119"],
+            max_strategies=3,
+        )
+        names = [s.name for s in out]
+        assert names[0] == "general"
+        assert "input_handling" in names
+        assert "memory_management" in names
+        assert "concurrency" not in names
+
+    def test_tier1_doesnt_break_path_only_pick(self):
+        """A purely path-based pick (no calls, no CWEs) still works."""
+        out = pick_strategies(
+            file_path="kernel/locking/rwsem.c",
+            function_name="rwsem_acquire",
+            max_strategies=3,
+        )
+        assert "concurrency" in {s.name for s in out}

--- a/core/llm/cwe_strategies/tests/test_prompts.py
+++ b/core/llm/cwe_strategies/tests/test_prompts.py
@@ -1,0 +1,329 @@
+"""Tests for ``render_strategy`` / ``render_strategies``.
+
+Pure-text rendering — no LLM dependency. Adversarial coverage
+focuses on the truncation cascade (drop exemplars → drop questions
+→ drop strategies) and on edge cases (empty fields, oversized
+content, content that looks like markdown injection).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.llm.cwe_strategies import (
+    DEFAULT_MAX_BYTES,
+    Exemplar,
+    Signals,
+    Strategy,
+    load_all,
+    pick_strategies,
+    render_strategies,
+    render_strategy,
+)
+
+
+def _ex(cve, title="t", pattern="p", why_buggy="w"):
+    return Exemplar(cve=cve, title=title, pattern=pattern, why_buggy=why_buggy)
+
+
+def _strat(name, *, desc="d", questions=("q?",), addendum="a", exemplars=()):
+    return Strategy(
+        name=name,
+        description=desc,
+        signals=Signals(),
+        key_questions=tuple(questions),
+        prompt_addendum=addendum,
+        exemplars=tuple(exemplars),
+    )
+
+
+# ---------------------------------------------------------------------------
+# render_strategy — single strategy
+# ---------------------------------------------------------------------------
+
+
+class TestRenderStrategy:
+    def test_full_render_includes_all_sections(self):
+        s = _strat(
+            "input_handling",
+            desc="Parsers and protocol handlers",
+            questions=("What does this trust?", "Are lengths checked?"),
+            addendum="Treat every byte as adversary-controlled.",
+            exemplars=[_ex("CVE-2023-0179", title="nftables")],
+        )
+        out = render_strategy(s)
+        assert "## Strategy: input_handling" in out
+        assert "Parsers and protocol handlers" in out
+        assert "### Key questions" in out
+        assert "- What does this trust?" in out
+        assert "### Approach" in out
+        assert "adversary-controlled" in out
+        assert "### Worked examples" in out
+        assert "CVE-2023-0179" in out
+
+    def test_minimal_strategy_renders_header_and_desc_only(self):
+        s = Strategy(name="x", description="just a description")
+        out = render_strategy(s)
+        assert "## Strategy: x" in out
+        assert "just a description" in out
+        # No empty section headers.
+        assert "### Key questions" not in out
+        assert "### Approach" not in out
+        assert "### Worked examples" not in out
+
+    def test_skip_exemplars_flag(self):
+        s = _strat("x", exemplars=[_ex("CVE-1")])
+        out = render_strategy(s, include_exemplars=False)
+        assert "### Worked examples" not in out
+        assert "CVE-1" not in out
+
+    def test_skip_questions_flag(self):
+        s = _strat("x", questions=("q1?", "q2?"))
+        out = render_strategy(s, include_questions=False)
+        assert "### Key questions" not in out
+        assert "q1?" not in out
+
+    def test_multiline_description_preserved(self):
+        s = Strategy(
+            name="x",
+            description="line one\nline two\nline three",
+        )
+        out = render_strategy(s)
+        assert "line one" in out
+        assert "line two" in out
+        assert "line three" in out
+
+    def test_multiple_exemplars_each_appear(self):
+        s = _strat("x", exemplars=[
+            _ex("CVE-1", title="first"),
+            _ex("CVE-2", title="second"),
+        ])
+        out = render_strategy(s)
+        assert "CVE-1" in out
+        assert "CVE-2" in out
+        assert "first" in out
+        assert "second" in out
+
+
+# ---------------------------------------------------------------------------
+# render_strategies — multiple strategies + truncation cascade
+# ---------------------------------------------------------------------------
+
+
+class TestRenderStrategiesBasic:
+    def test_empty_returns_empty(self):
+        assert render_strategies([]) == ""
+
+    def test_single_strategy(self):
+        out = render_strategies([_strat("x")])
+        assert "## Strategy: x" in out
+
+    def test_multiple_strategies_in_order(self):
+        out = render_strategies([_strat("a"), _strat("b"), _strat("c")])
+        a_pos = out.index("## Strategy: a")
+        b_pos = out.index("## Strategy: b")
+        c_pos = out.index("## Strategy: c")
+        assert a_pos < b_pos < c_pos
+
+
+class TestTruncationCascade:
+    def _big_strat(self, name, exemplar_text_size=500):
+        # Exemplars are the easiest signal to inflate.
+        # exemplar_text_size=500 → exemplar ~2KB, strategy ~2.5KB,
+        # strategy-without-exemplar ~0.5KB. Pick budgets in tests to
+        # fall between these landmarks to exercise the cascade tiers.
+        big = "x " * exemplar_text_size
+        return _strat(
+            name,
+            questions=("q?",),
+            addendum="addendum",
+            exemplars=[_ex(f"CVE-{name}-1", title="t",
+                           pattern=big, why_buggy=big)],
+        )
+
+    def test_no_cap_no_truncation(self):
+        s = [self._big_strat("a"), self._big_strat("b")]
+        out = render_strategies(s, max_bytes=None)
+        assert "truncated" not in out
+        assert "CVE-a-1" in out
+        assert "CVE-b-1" in out
+
+    def test_within_budget_no_truncation_marker(self):
+        s = [_strat("a"), _strat("b")]  # tiny strategies
+        out = render_strategies(s, max_bytes=DEFAULT_MAX_BYTES)
+        assert "truncated" not in out
+
+    def test_drops_later_strategy_exemplars_first(self):
+        """Tier 1 of the cascade: keep early strategies' exemplars,
+        drop late ones'.
+
+        Sizes: each exemplar ~2KB, strategy with exemplar ~2.5KB,
+        strategy without ~0.5KB. Budget 4000: full (5KB) fails,
+        a-keeps-b-drops (~3KB) fits.
+        """
+        s = [self._big_strat("a"), self._big_strat("b")]
+        out = render_strategies(s, max_bytes=4_000)
+        assert "truncated" in out
+        # a's exemplar should survive.
+        assert "CVE-a-1" in out
+        # b's exemplar dropped.
+        assert "CVE-b-1" not in out
+        # b's structure still present.
+        assert "## Strategy: b" in out
+
+    def test_drops_all_exemplars_when_too_tight(self):
+        s = [self._big_strat("a"), self._big_strat("b")]
+        # Budget 1500: even a-only-keeps-exemplar (~2.5KB) doesn't
+        # fit; cascade drops both.
+        out = render_strategies(s, max_bytes=1_500)
+        assert "truncated" in out
+        # Exemplars are gone.
+        assert "CVE-a-1" not in out
+        assert "CVE-b-1" not in out
+
+    def test_drops_questions_after_exemplars(self):
+        # All exemplars dropped; if still too big, drop questions.
+        big_q = "q? " * 1000
+        s = [
+            _strat("a", questions=(big_q, big_q),
+                   exemplars=[_ex("CVE-a-1", pattern="p", why_buggy="w")]),
+            _strat("b", questions=(big_q, big_q),
+                   exemplars=[_ex("CVE-b-1", pattern="p", why_buggy="w")]),
+        ]
+        out = render_strategies(s, max_bytes=2_500)
+        # Exemplars gone, last strategy's questions also gone.
+        assert "CVE-a-1" not in out
+        assert "CVE-b-1" not in out
+        assert "truncated" in out
+
+    def test_drops_strategies_when_too_tight(self):
+        """Tier 3: drop later strategies entirely when even
+        without exemplars/questions the budget is exceeded."""
+        big_addendum = "x " * 5_000
+        s = [
+            _strat("a", addendum=big_addendum),
+            _strat("b", addendum=big_addendum),
+            _strat("c", addendum=big_addendum),
+        ]
+        out = render_strategies(s, max_bytes=12_000)
+        # 'a' should survive; later ones may be dropped.
+        assert "## Strategy: a" in out
+        assert "truncated" in out
+
+    def test_extreme_tight_budget_returns_first_only(self):
+        big_desc = "x " * 5_000
+        s = [
+            _strat("a", desc=big_desc, addendum=big_desc),
+            _strat("b", desc=big_desc, addendum=big_desc),
+        ]
+        out = render_strategies(s, max_bytes=200)
+        # Only 'a' header + truncated description fits.
+        assert "## Strategy: a" in out
+        assert "## Strategy: b" not in out
+        assert "truncated" in out
+
+
+# ---------------------------------------------------------------------------
+# Adversarial — content that could confuse the rendered prompt
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarialContent:
+    def test_strategy_name_with_markdown(self):
+        """Strategy name showing up in a `## Strategy: <name>`
+        heading. If the name contains ``##`` or `\n`, it could
+        forge fake sections. Pin the current behaviour: rendered
+        verbatim. Caller responsibility — strategies are
+        operator-curated."""
+        s = _strat("evil\n## Forged: heading")
+        out = render_strategy(s)
+        # We don't escape — but the test pins what we DO produce
+        # so a future hardening change is visible.
+        assert "## Strategy: evil" in out
+
+    def test_empty_strategy_doesnt_crash(self):
+        s = Strategy(name="x", description="")
+        out = render_strategy(s)
+        # Just the heading, nothing else.
+        assert "## Strategy: x" in out
+
+    def test_unicode_content_preserved(self):
+        s = _strat(
+            "ünïcødé",
+            desc="émüläted",
+            exemplars=[_ex("CVE-1", title="日本語タイトル",
+                           pattern="código", why_buggy="τι")],
+        )
+        out = render_strategy(s)
+        assert "ünïcødé" in out
+        assert "日本語タイトル" in out
+        assert "código" in out
+
+    def test_huge_single_strategy(self):
+        """One strategy that on its own exceeds the budget. Renderer
+        falls all the way through to the 'first only, no frills'
+        last resort, no crash."""
+        big = "x" * 50_000
+        s = [_strat("a", desc=big, addendum=big,
+                     exemplars=[_ex("CVE-1", pattern=big, why_buggy=big)])]
+        out = render_strategies(s, max_bytes=1_000)
+        assert "truncated" in out
+
+
+# ---------------------------------------------------------------------------
+# E2E with bundled strategies
+# ---------------------------------------------------------------------------
+
+
+class TestE2EBundledStrategies:
+    def test_full_audit_driver_render(self):
+        """Realistic /audit Phase A scenario: pick strategies for a
+        function, render them. Verify the rendered prompt is
+        well-formed and contains the expected strategy content."""
+        picked = pick_strategies(
+            file_path="net/foo/parser.c",
+            function_name="parse_request",
+            file_includes=["linux/skbuff.h", "linux/spinlock.h"],
+            function_calls_made=["spin_lock", "skb_pull"],
+            candidate_cwes=["CWE-119"],
+            max_strategies=4,
+        )
+        assert len(picked) >= 3
+        out = render_strategies(picked)
+
+        # Every picked strategy's name appears as a section heading.
+        for s in picked:
+            assert f"## Strategy: {s.name}" in out
+
+        # Exemplars from picked strategies appear (at least one
+        # CVE per non-empty strategy).
+        for s in picked:
+            if s.exemplars:
+                first_cve = s.exemplars[0].cve
+                assert first_cve in out, f"missing exemplar {first_cve}"
+
+        # No truncation marker — bundled strategies should fit
+        # comfortably within the default budget.
+        assert "truncated" not in out
+
+        # Rendered output is sub-32KB (sanity check on signal
+        # density). At 3-4 strategies × 1-2 exemplars × ~500 chars
+        # we expect ~5-15KB.
+        assert len(out.encode("utf-8")) < 32_000
+
+    def test_three_strategies_under_default_budget(self):
+        """All bundled strategies, picked at max=3, fit under the
+        default 16KB budget."""
+        all_strats = load_all()
+        out = render_strategies(all_strats[:3])
+        assert "truncated" not in out
+        assert len(out.encode("utf-8")) <= DEFAULT_MAX_BYTES
+
+    def test_all_seven_bundled_might_truncate(self):
+        """All 7 strategies rendered together MAY exceed the default
+        budget. Pin behaviour: either fits, or truncates cleanly."""
+        all_strats = load_all()
+        out = render_strategies(all_strats)
+        # Either no truncation OR clean truncation marker.
+        if len(out.encode("utf-8")) >= DEFAULT_MAX_BYTES:
+            assert "truncated" in out


### PR DESCRIPTION
Third /audit Phase A pre-req after core/annotations (#393) and packages/checker_synthesis (#394). Strategies are YAML data — signals (paths, includes, function keywords, calls, CWEs), key questions, prompt addendum, 1-2 CVE exemplars per bug class.

Pipeline: signals → picker → strategies → render → prompt block.

Substrate:
  * models.py — Strategy/Signals/Exemplar dataclasses
  * loader.py — strict YAML schema with loud failures
  * picker.py — five-dimensional specificity-weighted scoring; CWE pins (100 pts each) dominate aggregated heuristics
  * prompts.py — three-tier truncation cascade (drop exemplars → questions → strategies)

Seven bundled strategies from the audit design doc: general, input_handling, concurrency, memory_management, auth_privilege, cryptography, memory_aliasing — each with worked CVE exemplars.

Picker improvements over naive substring matching:
  * Token-based keyword matching: ``parse`` matches ``parse_packet`` but NOT ``is_sparse_array``
  * function_calls signal: ``mutex_lock`` callee → concurrency, regardless of path
  * cwes signal: direct evidence from upstream classifier wins over inferred heuristics

Tier 2 (/understand --map integration) lives in /audit's driver, not in this substrate — driver fills picker inputs from context-map.json. Tier 3 (LLM-driven picking when mechanical signals are weak) is opt-in, added later if data shows it's needed.

Adversarial: token matching prevents substring false-positives (``parse``/``compare`` regression pin); CWE pruning stops memory_aliasing from being a magnet for every corruption finding; truncation cascade tested at every tier; markdown injection in strategy name pinned as caller-trusted.

E2E walkthrough exercises six realistic /audit scenarios — network parser+lock, /agentic CWE pin, crypto-with-aliasing, auth helper, no-signal fallback, tight-budget cascade.

122 tests across loader / picker / Tier-1 picker / bundled strategies / prompt rendering.

Standalone substrate; raptor_audit.py Phase A driver composes this with core/annotations + packages/checker_synthesis + packages/hypothesis_validation in subsequent work.