### PR TITLE
feat(substrate-adj): substrate adjustments

### DIFF
--- a/core/coverage/record.py
+++ b/core/coverage/record.py
@@ -229,7 +229,11 @@ def build_from_findings(findings_path: Path, reads_manifest_path: Path = None,
     return record
 
 
-def build_from_annotations(annotations_dir: Path) -> Optional[Dict[str, Any]]:
+def build_from_annotations(
+    annotations_dir: Path,
+    *,
+    tool_name: str = "annotations",
+) -> Optional[Dict[str, Any]]:
     """Build a coverage record from a tree of annotation .md files.
 
     Every annotated function counts as "examined" for coverage purposes:
@@ -241,10 +245,22 @@ def build_from_annotations(annotations_dir: Path) -> Optional[Dict[str, Any]]:
     Args:
         annotations_dir: Directory containing the annotation tree
             (typically ``<run_output_dir>/annotations``).
+        tool_name: ``tool`` field for the resulting record. Defaults
+            to ``"annotations"`` for back-compat with /agentic and
+            /understand consumers; ``/audit`` passes ``"audit"`` so
+            its records land as ``coverage-audit.json`` and are
+            distinguishable from generic annotation-derived
+            coverage.
 
     Returns:
         Coverage record dict, or None if the directory doesn't exist
         or contains no annotations.
+
+    Per-function entries include ``status`` and ``hash`` when those
+    fields are present in the annotation's metadata — ``/audit``
+    populates both at write time, so the resulting record carries
+    the verdict and source-line hash inline. Readers that don't
+    expect these fields ignore unknown keys.
     """
     annotations_dir = Path(annotations_dir)
     if not annotations_dir.exists():
@@ -265,17 +281,26 @@ def build_from_annotations(annotations_dir: Path) -> Optional[Dict[str, Any]]:
         if key in seen:
             continue
         seen.add(key)
-        functions.append({"file": ann.file, "function": ann.function})
+        entry: Dict[str, str] = {"file": ann.file, "function": ann.function}
+        # Include verdict + source-line hash inline when the
+        # annotation metadata carries them. /audit's status enum
+        # (clean / suspicious / finding / error) flows straight
+        # through; staleness detection downstream uses the hash.
         st = ann.metadata.get("status")
         if st:
+            entry["status"] = st
             statuses[st] = statuses.get(st, 0) + 1
+        h = ann.metadata.get("hash")
+        if h:
+            entry["hash"] = h
+        functions.append(entry)
         src = ann.metadata.get("source")
         if src:
             sources[src] = sources.get(src, 0) + 1
     if not files and not functions:
         return None
     return {
-        "tool": "annotations",
+        "tool": tool_name,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "files_examined": sorted(files),
         "functions_analysed": functions,

--- a/core/coverage/tests/test_annotation_record.py
+++ b/core/coverage/tests/test_annotation_record.py
@@ -32,10 +32,61 @@ class TestBuildFromAnnotations:
         assert record is not None
         assert record["tool"] == "annotations"
         assert record["files_examined"] == ["src/auth.py"]
-        assert record["functions_analysed"] == [
-            {"file": "src/auth.py", "function": "check_pw"}
-        ]
+        # The function entry has at minimum file + function. Status
+        # and hash are populated when the annotation metadata carries
+        # them — pinned in the per-function-metadata test below.
+        assert len(record["functions_analysed"]) == 1
+        entry = record["functions_analysed"][0]
+        assert entry["file"] == "src/auth.py"
+        assert entry["function"] == "check_pw"
         assert "timestamp" in record
+
+    def test_per_function_status_and_hash_inlined(self, tmp_path):
+        """Annotation metadata's ``status`` and ``hash`` flow into
+        each function entry — /audit's coverage-audit.json schema
+        wants these inline so consumers see verdict + freshness
+        without re-reading annotations."""
+        write_annotation(tmp_path, Annotation(
+            file="src/x.py", function="suspicious_fn",
+            metadata={
+                "status": "suspicious",
+                "hash": "abc123def456",
+                "source": "llm",
+            },
+        ))
+        record = build_from_annotations(tmp_path)
+        entry = record["functions_analysed"][0]
+        assert entry["status"] == "suspicious"
+        assert entry["hash"] == "abc123def456"
+
+    def test_status_and_hash_omitted_when_absent(self, tmp_path):
+        write_annotation(tmp_path, Annotation(
+            file="src/x.py", function="bare_fn",
+            metadata={"source": "human"},  # no status, no hash
+        ))
+        record = build_from_annotations(tmp_path)
+        entry = record["functions_analysed"][0]
+        assert "status" not in entry
+        assert "hash" not in entry
+
+    def test_tool_name_override(self, tmp_path):
+        """``/audit`` passes ``tool_name="audit"`` so its records
+        land as ``coverage-audit.json``, distinct from /agentic and
+        /understand's annotation-derived ``coverage-annotations.json``."""
+        write_annotation(tmp_path, Annotation(
+            file="src/x.py", function="f",
+            metadata={"status": "clean"},
+        ))
+        record = build_from_annotations(tmp_path, tool_name="audit")
+        assert record["tool"] == "audit"
+
+    def test_default_tool_name_is_annotations(self, tmp_path):
+        write_annotation(tmp_path, Annotation(
+            file="src/x.py", function="f",
+            metadata={"status": "clean"},
+        ))
+        record = build_from_annotations(tmp_path)
+        assert record["tool"] == "annotations"
 
     def test_aggregates_status_and_source_counts(self, tmp_path):
         for fn, status, source in [

--- a/core/llm/cwe_strategies/strategies/memory_aliasing.yml
+++ b/core/llm/cwe_strategies/strategies/memory_aliasing.yml
@@ -103,3 +103,45 @@ exemplars:
       locally true but globally violated. No race needed; a
       straight-line syscall sequence corrupts arbitrary readable
       files in the cache.
+
+  - cve: CVE-2026-43284
+    title: DirtyFrag (xfrm-ESP) — page-cache page reaches sk_buff frag, treated
+      as writable scratch
+    pattern: |
+      The xfrm-ESP transmit path obtains pages via the splice /
+      sendmsg path, which can hand back page-cache pages. Those
+      pages are placed into a ``struct sk_buff`` ``frag`` and the
+      ESP transform writes ICV / scratch bytes through the frag.
+      The networking-stack ``sk_buff`` is the wrong semantic
+      container for an immutable page-cache page — it's used as
+      scratch by every layer it passes through.
+    why_buggy: |
+      Two subsystems with different ownership models converge on
+      one piece of memory. The page-cache layer's contract
+      ("this page is shared and immutable for non-writers") and
+      the networking layer's contract ("frag pages are scratch I
+      own") are both locally consistent. The bug is the bridge:
+      ``sendmsg`` of file pages produces a frag whose contents
+      will be overwritten by xfrm-ESP. Same shape as CopyFail,
+      different subsystem — networking + page cache instead of
+      crypto + page cache.
+
+  - cve: CVE-2026-43500
+    title: DirtyFrag (AF_RXRPC) — same page-cache → sk_buff frag pattern in a
+      different protocol
+    pattern: |
+      AF_RXRPC's send path takes pages provided via splice or
+      sendmsg, places them into ``sk_buff`` frags, and lets the
+      RxRPC packet-construction code write through those frags.
+      Same as the xfrm-ESP case: page-cache pages that callers
+      assumed were read-only are mutated by the networking-stack
+      packet builder.
+    why_buggy: |
+      One bug pattern, two independent subsystems. The
+      generalisation lesson is the point: any networking path
+      that accepts caller-supplied pages and treats the resulting
+      frags as writable scratch is suspect. A Mode-2 checker
+      synthesised from CVE-2026-43284 should fire on this code
+      automatically; the bug class is "page-cache pages flow
+      into a downstream subsystem's writable buffer", not "this
+      specific protocol's send path".

--- a/packages/checker_synthesis/__init__.py
+++ b/packages/checker_synthesis/__init__.py
@@ -40,7 +40,11 @@ from .models import (
     SeedBug,
     SynthesisedRule,
 )
-from .synthesise import LLMCallable, synthesise_and_run
+from .synthesise import (
+    LLMCallable,
+    synthesise_and_run,
+    synthesise_with_refinement,
+)
 
 __all__ = [
     "CheckerSynthesisResult",
@@ -52,4 +56,5 @@ __all__ = [
     "detect_engine",
     "supported_engines",
     "synthesise_and_run",
+    "synthesise_with_refinement",
 ]

--- a/packages/checker_synthesis/prompts.py
+++ b/packages/checker_synthesis/prompts.py
@@ -84,7 +84,9 @@ SYNTHESIS_SCHEMA: Dict[str, Any] = {
 
 
 def build_synthesis_prompt(
-    seed: SeedBug, engine: str, retry_feedback: str = "",
+    seed: SeedBug, engine: str,
+    retry_feedback: str = "",
+    prior_fps: "Iterable[Match]" = (),
 ) -> str:
     """Compose the synthesis prompt body.
 
@@ -92,6 +94,12 @@ def build_synthesis_prompt(
     failure mode of the previous attempt (e.g. "rule did not match
     the seed function" or "rule produced invalid YAML") so the LLM
     can refine rather than regenerate from scratch.
+
+    ``prior_fps`` is non-empty during the iterative FP-elimination
+    loop — it carries matches from previous iterations that
+    triage classified as false positives. The synthesis prompt
+    appends them as negative examples so the next rule tightens
+    away from those locations while still hitting the seed bug.
     """
     parts = [
         f"BUG TO REPLICATE AS A CHECKER ({engine})",
@@ -133,6 +141,29 @@ def build_synthesis_prompt(
             retry_feedback,
             "Refine the rule, don't regenerate from scratch.",
         ]
+    fps = list(prior_fps) if prior_fps else []
+    if fps:
+        parts += [
+            "",
+            "PRIOR FALSE POSITIVES — earlier rules matched the "
+            "following locations that triage classified as NOT the "
+            "same bug. Refine your rule to AVOID matching these "
+            "while still hitting the seed at the lines above:",
+        ]
+        # Cap the per-prompt FP context to avoid context blow-up.
+        # 8 examples × ~200 chars each ≈ 1.6KB — enough signal,
+        # bounded cost.
+        for fp in fps[:8]:
+            line = f"  - {fp.file}:{fp.line}"
+            if fp.snippet:
+                # Trim the snippet so context stays bounded.
+                snip = " ".join(fp.snippet.split())[:160]
+                line += f"\n      {snip}"
+            parts.append(line)
+        if len(fps) > 8:
+            parts.append(
+                f"  ... ({len(fps) - 8} more false positives elided)"
+            )
     return "\n".join(parts)
 
 

--- a/packages/checker_synthesis/synthesise.py
+++ b/packages/checker_synthesis/synthesise.py
@@ -249,10 +249,15 @@ def _run_engine(
 def _propose_rule(
     seed: SeedBug, engine: str, attempt: int, llm: LLMCallable,
     retry_feedback: str = "",
+    prior_fps: Tuple[Match, ...] = (),
 ) -> Tuple[Optional[SynthesisedRule], Optional[str]]:
     """Single LLM round-trip producing one candidate rule.
     Returns ``(rule, error)``; exactly one is set."""
-    prompt = build_synthesis_prompt(seed, engine, retry_feedback=retry_feedback)
+    prompt = build_synthesis_prompt(
+        seed, engine,
+        retry_feedback=retry_feedback,
+        prior_fps=prior_fps,
+    )
     try:
         data = llm(prompt, SYNTHESIS_SCHEMA, SYNTHESIS_SYSTEM)
     except Exception as e:
@@ -358,6 +363,7 @@ def synthesise_and_run(
     max_matches: int = 50,
     triage_each: bool = False,
     max_triage_calls: int = 50,
+    prior_fps: Tuple[Match, ...] = (),
 ) -> CheckerSynthesisResult:
     """End-to-end: propose → validate → run → optionally triage.
 
@@ -375,6 +381,11 @@ def synthesise_and_run(
         triage_each: when True, every match gets an LLM verdict.
             Off by default — costs N×LLM calls per synthesis.
         max_triage_calls: hard ceiling on triage LLM calls.
+        prior_fps: matches from earlier iterations of an FP-elimination
+            loop, classified as false positives by triage. The
+            synthesis prompt appends them as negative examples. Empty
+            for single-shot synthesis; populated by
+            ``synthesise_with_refinement``.
     """
     repo_root = Path(repo_root).resolve()
     out_dir = Path(out_dir)
@@ -398,7 +409,10 @@ def synthesise_and_run(
     rule_path: Optional[Path] = None
 
     for attempt in range(max_retries + 1):
-        rule, err = _propose_rule(seed, engine, attempt, llm, feedback)
+        rule, err = _propose_rule(
+            seed, engine, attempt, llm, feedback,
+            prior_fps=tuple(prior_fps),
+        )
         if err:
             result.errors.append(f"attempt {attempt}: {err}")
             rule = None
@@ -459,3 +473,153 @@ def synthesise_and_run(
         result.errors.extend(t_errors)
 
     return result
+
+
+# ---------------------------------------------------------------------------
+# Iterative FP-elimination wrapper (Phase A Mode 2)
+# ---------------------------------------------------------------------------
+
+
+def _fp_rate(result: CheckerSynthesisResult) -> Optional[float]:
+    """Fraction of triaged matches classified as false positive.
+
+    Returns None when the rate can't be computed (no triage,
+    everything skipped). Excludes ``skipped`` from the denominator
+    — those are budget-truncated, not classified.
+    """
+    triaged = [t for t in result.triage if t.status != "skipped"]
+    if not triaged:
+        return None
+    fps = [t for t in triaged if t.status == "false_positive"]
+    return len(fps) / len(triaged)
+
+
+def synthesise_with_refinement(
+    seed: SeedBug,
+    repo_root: Path,
+    out_dir: Path,
+    llm: LLMCallable,
+    *,
+    max_iterations: int = 5,
+    max_acceptable_fp_rate: float = 0.2,
+    max_matches: int = 50,
+    max_triage_calls: int = 50,
+) -> CheckerSynthesisResult:
+    """Iterative checker synthesis with FP-elimination.
+
+    The KNighter pipeline that ``synthesise_and_run`` implements has
+    a single shot at the rule. The /audit design (2026-05-08) and
+    KNighter's own paper observe that 5–10 iterations of FP-driven
+    refinement typically converge a noisy rule to a tight one. This
+    wrapper provides that loop.
+
+    Each iteration:
+
+      1. Run ``synthesise_and_run`` with ``triage_each=True``,
+         passing the accumulated FPs from prior iterations as
+         negative examples.
+      2. Compute FP rate from the triage verdicts.
+      3. If FP rate ≤ ``max_acceptable_fp_rate``: converged, return
+         the current result.
+      4. Otherwise, append this iteration's FPs to the running list
+         and try again.
+
+    Convergence rules:
+      * Always returns the iteration with the LOWEST FP rate. If
+        no iteration beat the threshold, the best-so-far still
+        wins over the worst.
+      * If positive control fails on an iteration (no rule produced),
+        it doesn't count toward the best-so-far — just bumps to the
+        next iteration with the existing FP context.
+      * If we exhaust ``max_iterations`` without improvement, the
+        best-so-far is returned with an error log entry naming
+        the situation.
+      * If triage couldn't run at all (e.g. zero matches), there's
+        nothing to learn from; return immediately after iteration 1.
+
+    The first iteration is identical to a vanilla
+    ``synthesise_and_run(triage_each=True)`` call. Operators who
+    don't want refinement should call ``synthesise_and_run`` directly.
+    """
+    if max_iterations <= 0:
+        return CheckerSynthesisResult(
+            seed=seed,
+            errors=["max_iterations must be > 0"],
+        )
+
+    prior_fps: List[Match] = []
+    best: Optional[CheckerSynthesisResult] = None
+    best_rate: Optional[float] = None
+
+    for iteration in range(max_iterations):
+        result = synthesise_and_run(
+            seed, repo_root, out_dir, llm,
+            max_matches=max_matches,
+            triage_each=True,
+            max_triage_calls=max_triage_calls,
+            prior_fps=tuple(prior_fps),
+        )
+
+        # If synthesis failed entirely, bump to next iteration.
+        # The accumulated FP context from prior rounds carries
+        # forward — maybe a different rule will land this round.
+        if result.rule is None:
+            result.errors.append(
+                f"iteration {iteration}: no rule produced"
+            )
+            if best is None:
+                best = result  # at least surface SOMETHING
+            continue
+
+        rate = _fp_rate(result)
+        if rate is None:
+            # Triage didn't run — no signal to refine on. Take this
+            # result and stop; refinement can't help without verdicts.
+            result.errors.append(
+                f"iteration {iteration}: no triage verdicts; "
+                f"refinement loop has nothing to learn"
+            )
+            return result
+
+        # Track best-so-far by rate (lower is better).
+        if best_rate is None or rate < best_rate:
+            best = result
+            best_rate = rate
+
+        if rate <= max_acceptable_fp_rate:
+            # Converged.
+            return result
+
+        # Accumulate FPs for the next prompt. Cap to keep prompt
+        # size bounded across iterations — the prompt builder also
+        # caps to 8 in the prompt itself.
+        new_fps = [t.match for t in result.triage
+                   if t.status == "false_positive"]
+        # Avoid duplicate locations (dedup by file:line).
+        seen = {(m.file, m.line) for m in prior_fps}
+        for m in new_fps:
+            key = (m.file, m.line)
+            if key in seen:
+                continue
+            prior_fps.append(m)
+            seen.add(key)
+
+    # Exhausted without converging — return best-so-far with a note.
+    if best is None:
+        return CheckerSynthesisResult(
+            seed=seed,
+            errors=["refinement: no result across all iterations"],
+        )
+    if best_rate is None:
+        # No iteration ever produced a triageable rule.
+        best.errors.append(
+            f"refinement: did not converge in {max_iterations} "
+            f"iterations (no rule reached triage)"
+        )
+    else:
+        best.errors.append(
+            f"refinement: did not converge in {max_iterations} "
+            f"iterations (best fp_rate={best_rate:.2f} > threshold "
+            f"{max_acceptable_fp_rate:.2f})"
+        )
+    return best

--- a/packages/checker_synthesis/tests/test_refinement.py
+++ b/packages/checker_synthesis/tests/test_refinement.py
@@ -1,0 +1,357 @@
+"""Tests for ``synthesise_with_refinement`` — iterative FP-elimination.
+
+Each iteration runs the full synthesis pipeline; the wrapper carries
+forward false-positive matches as negative examples in subsequent
+prompts. Convergence: triage FP rate ≤ threshold.
+
+Stub LLM + stub engine adapters keep tests deterministic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from packages.checker_synthesis import (
+    Match,
+    SeedBug,
+    SynthesisedRule,
+    synthesise_with_refinement,
+)
+from packages.checker_synthesis import synthesise as synth_mod
+
+
+def _seed(tmp_path: Path) -> SeedBug:
+    src_dir = tmp_path / "src"
+    src_dir.mkdir(exist_ok=True)
+    (src_dir / "auth.py").write_text(
+        "def login(req):\n    return cursor.execute(f'x={req.q}')\n"
+    )
+    return SeedBug(
+        file="src/auth.py", function="login",
+        line_start=1, line_end=2,
+        cwe="CWE-89", reasoning="tainted f-string into execute",
+    )
+
+
+def _stub_llm(responses):
+    queue = list(responses)
+
+    def llm(prompt, schema, system_prompt):
+        if not queue:
+            raise AssertionError("stub LLM out of responses")
+        item = queue.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+    llm._queue = queue
+    return llm
+
+
+def _stub_engines_per_iteration(monkeypatch, iterations):
+    """``iterations`` is a list of (probe_matches, scan_matches) per
+    iteration. Each ``synthesise_and_run`` call consumes one entry's
+    pair (positive control + codebase scan)."""
+    state = {"iter": 0, "call_in_iter": 0}
+
+    def fake_run(rule, rule_path, target):
+        i = state["iter"]
+        c = state["call_in_iter"]
+        if i >= len(iterations):
+            return [], []
+        probe, scan = iterations[i]
+        if c == 0:
+            # Positive control on seed file.
+            state["call_in_iter"] = 1
+            return list(probe), []
+        # Codebase scan; advance to next iteration.
+        state["iter"] += 1
+        state["call_in_iter"] = 0
+        return list(scan), []
+
+    monkeypatch.setattr(synth_mod, "_run_engine", fake_run)
+
+
+# ---------------------------------------------------------------------------
+# Convergence behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestConvergence:
+    def test_converges_when_fp_rate_below_threshold(self, tmp_path, monkeypatch):
+        """First iteration's triage shows 1 variant + 0 FPs → fp_rate=0.0,
+        below default 0.2 threshold → converged on iteration 1."""
+        seed = _seed(tmp_path)
+        seed_match = Match(file="src/auth.py", line=2)
+        variant = Match(file="src/admin.py", line=42)
+        _stub_engines_per_iteration(monkeypatch, [
+            ([seed_match], [seed_match, variant]),
+        ])
+        llm = _stub_llm([
+            # Iteration 1 synthesis
+            {"rule_body": "rules: tight", "rationale": "x"},
+            # Iteration 1 triage (one variant)
+            {"status": "variant", "reasoning": "same shape"},
+        ])
+        result = synthesise_with_refinement(
+            seed, tmp_path, tmp_path / "out", llm,
+            max_iterations=5,
+        )
+        assert result.rule is not None
+        assert result.positive_control is True
+        assert len(result.matches) == 1
+
+    def test_iterates_when_fp_rate_above_threshold(self, tmp_path, monkeypatch):
+        """First iteration: 1 variant + 4 FPs (rate 0.8). Second
+        iteration: 1 variant + 0 FPs (rate 0.0). Converges on
+        iteration 2."""
+        seed = _seed(tmp_path)
+        seed_m = Match(file="src/auth.py", line=2)
+        variant = Match(file="src/admin.py", line=42)
+        fps = [Match(file=f"src/fp{i}.py", line=1) for i in range(4)]
+        _stub_engines_per_iteration(monkeypatch, [
+            # Iteration 1: noisy rule
+            ([seed_m], [seed_m, variant, *fps]),
+            # Iteration 2: tight rule (FPs gone)
+            ([seed_m], [seed_m, variant]),
+        ])
+        llm = _stub_llm([
+            # Iter 1 synthesis
+            {"rule_body": "rules: noisy", "rationale": "loose"},
+            # Iter 1 triage: 1 variant, 4 FPs
+            {"status": "variant", "reasoning": "tp"},
+            {"status": "false_positive", "reasoning": "fp1"},
+            {"status": "false_positive", "reasoning": "fp2"},
+            {"status": "false_positive", "reasoning": "fp3"},
+            {"status": "false_positive", "reasoning": "fp4"},
+            # Iter 2 synthesis (FP context appended)
+            {"rule_body": "rules: tight", "rationale": "refined"},
+            # Iter 2 triage: 1 variant, 0 FPs → converged
+            {"status": "variant", "reasoning": "tp"},
+        ])
+        result = synthesise_with_refinement(
+            seed, tmp_path, tmp_path / "out", llm,
+            max_iterations=5,
+        )
+        # Final result is the converged (iter 2) one — only 1 variant.
+        assert len(result.matches) == 1
+        # Convergence message NOT logged (we did converge).
+        assert not any("did not converge" in e for e in result.errors)
+
+    def test_returns_best_result_when_no_iteration_converges(
+        self, tmp_path, monkeypatch,
+    ):
+        """All iterations have FP rate above threshold; wrapper
+        returns the best (lowest-rate) one and logs the no-converge."""
+        seed = _seed(tmp_path)
+        seed_m = Match(file="src/auth.py", line=2)
+        # 3 iterations, each produces 1 variant + N FPs
+        _stub_engines_per_iteration(monkeypatch, [
+            # Iter 1: 1 variant + 5 FPs (rate 5/6 ≈ 0.83)
+            ([seed_m], [seed_m, Match(file="src/v.py", line=1)]
+                + [Match(file=f"src/fp1_{i}.py", line=1)
+                   for i in range(5)]),
+            # Iter 2: 1 variant + 2 FPs (rate 2/3 ≈ 0.67) ← best
+            ([seed_m], [seed_m, Match(file="src/v.py", line=1)]
+                + [Match(file=f"src/fp2_{i}.py", line=1)
+                   for i in range(2)]),
+            # Iter 3: 1 variant + 4 FPs (rate 0.8)
+            ([seed_m], [seed_m, Match(file="src/v.py", line=1)]
+                + [Match(file=f"src/fp3_{i}.py", line=1)
+                   for i in range(4)]),
+        ])
+        # 3 syntheses + (6 + 3 + 5) triages = 17 LLM calls
+        responses = []
+        for i in range(3):
+            responses.append({"rule_body": f"rules: r{i}",
+                              "rationale": f"iter{i}"})
+            n_triage = [6, 3, 5][i]
+            responses.append({"status": "variant", "reasoning": "tp"})
+            for _ in range(n_triage - 1):
+                responses.append(
+                    {"status": "false_positive", "reasoning": "fp"}
+                )
+        llm = _stub_llm(responses)
+        result = synthesise_with_refinement(
+            seed, tmp_path, tmp_path / "out", llm,
+            max_iterations=3,
+            max_acceptable_fp_rate=0.1,  # tighter than any iteration
+        )
+        # The wrapper returned a result, and explicitly logged the
+        # no-convergence case.
+        assert result.rule is not None
+        assert any("did not converge" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# FP context propagation
+# ---------------------------------------------------------------------------
+
+
+class TestFpContextPropagation:
+    def test_synthesis_prompt_includes_prior_fps_on_iter_2(
+        self, tmp_path, monkeypatch,
+    ):
+        """The second iteration's synthesis prompt should mention
+        the false positives the first iteration found."""
+        seed = _seed(tmp_path)
+        seed_m = Match(file="src/auth.py", line=2)
+        fp1 = Match(file="src/sparse.py", line=10,
+                    snippet="db.exec_some_other_thing()")
+        # Iter 1: produces FP. Iter 2: clean.
+        _stub_engines_per_iteration(monkeypatch, [
+            ([seed_m], [seed_m, fp1]),
+            ([seed_m], [seed_m]),
+        ])
+
+        # Capture prompts the LLM sees.
+        captured_prompts: List[str] = []
+
+        def llm(prompt, schema, system_prompt):
+            captured_prompts.append(prompt)
+            # Iteration 1 synthesis → loose rule, then triage 1 FP.
+            # Iteration 2 synthesis → tight rule, then no triage
+            # needed (no extra matches).
+            if len(captured_prompts) == 1:
+                return {"rule_body": "rules: r1", "rationale": "loose"}
+            if len(captured_prompts) == 2:
+                # Triage of fp1
+                return {"status": "false_positive",
+                        "reasoning": "different sink"}
+            if len(captured_prompts) == 3:
+                # Iter 2 synthesis — should see FP context.
+                return {"rule_body": "rules: r2",
+                        "rationale": "tightened"}
+            raise AssertionError("unexpected extra LLM call")
+
+        result = synthesise_with_refinement(
+            seed, tmp_path, tmp_path / "out", llm,
+            max_iterations=3,
+        )
+        # Iter 2's synthesis prompt (index 2, 0-indexed) should
+        # include the FP feedback section.
+        assert "PRIOR FALSE POSITIVES" in captured_prompts[2]
+        assert "src/sparse.py:10" in captured_prompts[2]
+        # Iter 1's synthesis prompt should NOT have FP context (no
+        # prior iterations).
+        assert "PRIOR FALSE POSITIVES" not in captured_prompts[0]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_max_iterations_zero_returns_error(self, tmp_path):
+        seed = _seed(tmp_path)
+        llm = _stub_llm([])
+        result = synthesise_with_refinement(
+            seed, tmp_path, tmp_path / "out", llm,
+            max_iterations=0,
+        )
+        assert result.rule is None
+        assert any("max_iterations" in e for e in result.errors)
+
+    def test_no_triage_verdicts_returns_immediately(
+        self, tmp_path, monkeypatch,
+    ):
+        """If a synthesis produces zero matches (and therefore zero
+        triage verdicts), refinement has nothing to learn from. Return
+        the result without iterating."""
+        seed = _seed(tmp_path)
+        seed_m = Match(file="src/auth.py", line=2)
+        _stub_engines_per_iteration(monkeypatch, [
+            # Probe matches seed (positive control passes), but
+            # codebase scan finds only the seed (no variants).
+            ([seed_m], [seed_m]),
+        ])
+        llm = _stub_llm([
+            {"rule_body": "rules: tight", "rationale": "x"},
+            # No triage calls expected — zero variants.
+        ])
+        result = synthesise_with_refinement(
+            seed, tmp_path, tmp_path / "out", llm,
+            max_iterations=5,
+        )
+        # Returned cleanly after iter 1.
+        assert result.rule is not None
+        assert any("nothing to learn" in e for e in result.errors)
+
+    def test_synthesis_failure_in_iter_1_returns_with_errors(
+        self, tmp_path, monkeypatch,
+    ):
+        """If the first iteration's positive control fails on both
+        the initial attempt and the retry, no rule is produced.
+        Wrapper should still return — not crash, not loop forever."""
+        seed = _seed(tmp_path)
+        # Probe never matches.
+        _stub_engines_per_iteration(monkeypatch, [
+            ([], []),
+            ([], []),
+            ([], []),
+        ])
+        llm = _stub_llm([
+            # Iter 1: 2 synthesis attempts (max_retries=1), both miss.
+            {"rule_body": "rules: bad1", "rationale": "x"},
+            {"rule_body": "rules: bad2", "rationale": "y"},
+            # Iter 2: 2 more attempts, also miss.
+            {"rule_body": "rules: bad3", "rationale": "x"},
+            {"rule_body": "rules: bad4", "rationale": "y"},
+            # Iter 3: 2 more.
+            {"rule_body": "rules: bad5", "rationale": "x"},
+            {"rule_body": "rules: bad6", "rationale": "y"},
+        ])
+        result = synthesise_with_refinement(
+            seed, tmp_path, tmp_path / "out", llm,
+            max_iterations=3,
+        )
+        # No rule, but no crash.
+        assert result.rule is None
+        assert any("no rule produced" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# FP dedup across iterations
+# ---------------------------------------------------------------------------
+
+
+class TestFpDedup:
+    def test_duplicate_fp_locations_not_double_counted(
+        self, tmp_path, monkeypatch,
+    ):
+        """The same (file, line) showing up as FP in iter 1 and iter 2
+        should appear once in the accumulated context."""
+        seed = _seed(tmp_path)
+        seed_m = Match(file="src/auth.py", line=2)
+        repeated_fp = Match(file="src/repeat.py", line=10)
+        _stub_engines_per_iteration(monkeypatch, [
+            ([seed_m], [seed_m, repeated_fp]),
+            ([seed_m], [seed_m, repeated_fp]),
+            ([seed_m], [seed_m]),
+        ])
+        captured: List[str] = []
+
+        def llm(prompt, schema, system_prompt):
+            captured.append(prompt)
+            if "rule_body" in schema.get("required", []):
+                return {"rule_body": "rules: r", "rationale": "x"}
+            return {"status": "false_positive", "reasoning": "fp"}
+
+        result = synthesise_with_refinement(
+            seed, tmp_path, tmp_path / "out", llm,
+            max_iterations=3,
+        )
+        # Iter 3 synthesis prompt should reference the FP only once,
+        # not twice. Find iter 3's synthesis prompt: it's the one
+        # following the second triage.
+        synthesis_prompts = [p for p in captured if "PRIOR FALSE" in p]
+        # Both iter 2 and iter 3 should include FP context.
+        for p in synthesis_prompts:
+            count = p.count("src/repeat.py:10")
+            assert count == 1, (
+                f"FP location should appear exactly once per prompt; "
+                f"saw {count} occurrences"
+            )


### PR DESCRIPTION
Four small substrate alignments. None block any consumer; each addresses a real seam between the existing primitives.

1. DirtyFrag exemplars on the memory_aliasing strategy.

   Adds CVE-2026-43284 (xfrm-ESP) + CVE-2026-43500 (AF_RXRPC) alongside the existing CVE-2022-0847 (Dirty Pipe) and CVE-2026-31431 (CopyFail). Two CVEs, one bug class, two independent subsystems — the exemplar set now demonstrates that the page-cache-into-writable-buffer pattern generalises beyond crypto/algif into networking paths.

2. ``build_from_annotations(annotations_dir, *, tool_name=...)`` parameter.

   Default stays ``"annotations"`` for back-compat with /agentic and /understand. Callers wanting a distinct coverage record tool name (e.g. ``"audit"``) pass it explicitly. Per-function ``status`` and ``hash`` are now inlined into ``functions_analysed`` entries when the annotation metadata carries them; readers that don't expect those fields ignore them.

3. ``synthesise_with_refinement`` — iterative FP-elimination loop.

   The KNighter pattern's followup: after the initial synthesis, triage classifies matches; if FP rate is too high, re-synthesise with FPs as negative examples; repeat until convergence or budget exhausted. KNighter's paper observes 5–10 iterations typically converge a noisy rule.

   API: result = synthesise_with_refinement( seed, repo_root, out_dir, llm, max_iterations=5, max_acceptable_fp_rate=0.2, )

   Convergence rules: best-so-far always returned even on non-converge (with explicit error log), iterations that fail synthesis don't break the loop, no-triage-verdicts case short-circuits because there's nothing to refine on, FP locations deduped across iterations.

   Real bug caught during test pass: format string blew up when best_rate stayed None (no iteration ever produced a triageable rule). Fixed with explicit None handling.

4. ``checked_by`` — already in place.

   Verified ``core.inventory.coverage.update_coverage()`` exists with carry-forward support. Callers can pass any ``source_label`` to mark functions reviewed; no substrate change needed.

8 new refinement tests (convergence, non-convergence, FP context propagation, FP dedup, edge cases including max_iterations=0 and all-iterations-fail) + 4 new coverage-record tests (per-function status/hash, tool_name override, default back-compat, status/hash omitted when absent).