### PR TITLE
feat(agentic): KNighter follow-up — synthesise checker per confirmed finding

### DIFF
--- a/core/security/prompt_envelope_audit.py
+++ b/core/security/prompt_envelope_audit.py
@@ -234,7 +234,7 @@ _ALLOWLIST: Tuple[AllowlistEntry, ...] = (
     ),
     # ----- packages/llm_analysis/agent.py -----
     AllowlistEntry(
-        file="packages/llm_analysis/agent.py", line=967,
+        file="packages/llm_analysis/agent.py", line=973,
         attr="rule_id",
         audit_note=(
             "patch_content_formatted is markdown saved to disk for "
@@ -243,22 +243,22 @@ _ALLOWLIST: Tuple[AllowlistEntry, ...] = (
         ),
     ),
     AllowlistEntry(
-        file="packages/llm_analysis/agent.py", line=969,
+        file="packages/llm_analysis/agent.py", line=975,
         attr="file_path",
         audit_note="markdown for disk (operator review file), not LLM prompt",
     ),
     AllowlistEntry(
-        file="packages/llm_analysis/agent.py", line=970,
+        file="packages/llm_analysis/agent.py", line=976,
         attr="start_line",
         audit_note="markdown for disk, not LLM prompt",
     ),
     AllowlistEntry(
-        file="packages/llm_analysis/agent.py", line=970,
+        file="packages/llm_analysis/agent.py", line=976,
         attr="end_line",
         audit_note="markdown for disk, not LLM prompt",
     ),
     AllowlistEntry(
-        file="packages/llm_analysis/agent.py", line=971,
+        file="packages/llm_analysis/agent.py", line=977,
         attr="level",
         audit_note="markdown for disk, not LLM prompt",
     ),

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -347,10 +347,16 @@ def convert_validated_to_agent_format(data: dict) -> List[Dict[str, Any]]:
 
 class AutonomousSecurityAgentV2:
     def __init__(self, repo_path: Path, out_dir: Path, llm_config: Optional[LLMConfig] = None,
-                 prep_only: bool = False):
+                 prep_only: bool = False,
+                 synthesise_checkers: bool = True):
         self.repo_path = repo_path
         self.out_dir = out_dir
         self.out_dir.mkdir(parents=True, exist_ok=True)
+        # KNighter follow-up: synthesise a checker rule for every
+        # confirmed exploitable finding and emit suspicious annotations
+        # for variants found across the codebase. Default on; opt out
+        # via ``--no-checker-synthesis`` for cost-sensitive runs.
+        self.synthesise_checkers = synthesise_checkers
 
         # Detect LLM availability and choose provider
         availability = detect_llm_availability()
@@ -1144,6 +1150,7 @@ class AutonomousSecurityAgentV2:
         dataflow_validated = 0
         false_positives_found = 0
         annotations_emitted = 0
+        variant_annotations = 0
         idx = 0  # Initialize idx to prevent UnboundLocalError when unique_findings is empty
 
         is_prep = isinstance(self.llm, ClaudeCodeProvider)
@@ -1212,6 +1219,33 @@ class AutonomousSecurityAgentV2:
                         # 3. Generate patch using LLM (only for exploitable)
                         if self.generate_patch(vuln):
                             patches_generated += 1
+
+                        # 4. KNighter follow-up: synthesise a checker
+                        # rule for the confirmed pattern, run across
+                        # the codebase, emit suspicious annotations
+                        # for variant matches. One bug → N candidate
+                        # variants. Best-effort — failures don't break
+                        # the analysis loop.
+                        if (
+                            emit_annotations
+                            and getattr(self, "synthesise_checkers", True)
+                        ):
+                            try:
+                                from packages.llm_analysis.checker_followup import (
+                                    emit_variant_annotations_for_finding,
+                                )
+                                n_variants = emit_variant_annotations_for_finding(
+                                    vuln,
+                                    out_dir=self.out_dir,
+                                    checklist=checklist,
+                                    repo_root=self.repo_path,
+                                    llm_client=self.llm,
+                                )
+                                variant_annotations += n_variants
+                            except Exception:
+                                logger.debug(
+                                    "checker followup error", exc_info=True,
+                                )
                     else:
                         logger.debug(f"⊘ Skipping patch generation (not exploitable)")
 
@@ -1249,6 +1283,7 @@ class AutonomousSecurityAgentV2:
             "dataflow_validated": dataflow_validated,
             "false_positives_caught": false_positives_found,
             "annotations_emitted": annotations_emitted,
+            "variant_annotations": variant_annotations,
             "execution_time": execution_time,
             "llm_stats": llm_stats,
             "results": results,
@@ -1286,6 +1321,11 @@ class AutonomousSecurityAgentV2:
                 logger.info(
                     f"✓ Annotations emitted: {annotations_emitted} "
                     f"(in {self.out_dir / 'annotations'})"
+                )
+            if variant_annotations > 0:
+                logger.info(
+                    f"✓ Checker-synthesised variants: {variant_annotations} "
+                    f"(suspicious annotations from KNighter follow-up)"
                 )
             logger.info(f"")
             if dataflow_validated > 0:
@@ -1353,6 +1393,15 @@ def main() -> None:
         help="Skip per-finding annotation emission and the "
              "annotation-derived coverage record",
     )
+    ap.add_argument(
+        "--no-checker-synthesis",
+        action="store_true",
+        help="Skip the KNighter follow-up: don't synthesise a "
+             "checker rule per confirmed finding, don't emit "
+             "variant annotations. Use to cut LLM cost on confirmed "
+             "exploitable findings — at the price of losing variant "
+             "discovery.",
+    )
     ap.add_argument("--prep-only", action="store_true",
                     help="Skip LLM analysis; produce structured findings for external orchestration")
     ap.add_argument("--max-parallel", type=int, default=3, help="Max parallel dispatch threads")
@@ -1400,7 +1449,11 @@ def main() -> None:
 
     # When role flags are present, force prep-only then hand off to orchestrator
     prep_only = args.prep_only or _has_role_flags
-    agent = AutonomousSecurityAgentV2(repo_path, out_dir, prep_only=prep_only)
+    agent = AutonomousSecurityAgentV2(
+        repo_path, out_dir,
+        prep_only=prep_only,
+        synthesise_checkers=not args.no_checker_synthesis,
+    )
 
     # Load checklist for metadata lookup
     checklist = None

--- a/packages/llm_analysis/checker_followup.py
+++ b/packages/llm_analysis/checker_followup.py
@@ -1,0 +1,279 @@
+"""KNighter follow-up after a confirmed /agentic finding.
+
+When ``analyze_vulnerability`` confirms a finding as exploitable, this
+module turns the bug into a Semgrep / Coccinelle rule via
+``packages.checker_synthesis``, runs it across the codebase, and emits
+``status=suspicious`` annotations for each variant match. One bug ⇒
+N variant annotations.
+
+Per the audit design doc (Mode 2): every confirmed hypothesis
+potentially yields a reusable checker. The variants surfaced here are
+candidate findings — operator triages them via ``/annotate`` review,
+the next ``/agentic`` run can re-analyse them with full context, and
+the synthesised rule itself is saved on disk for future ``/scan`` runs
+(KNighter's permanent-rule pattern).
+
+Best-effort: any exception is logged at DEBUG and swallowed so a
+synthesis failure cannot break the analysis loop. The caller's
+counter is bumped only when an annotation actually lands.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _llm_callable_from_client(llm_client) -> Optional[Any]:
+    """Adapt RAPTOR's ``LLMClient`` to checker_synthesis's
+    ``LLMCallable`` Protocol. Returns None when the client doesn't
+    expose ``generate_structured`` (e.g. ClaudeCodeProvider in
+    prep-only mode — checker synthesis can't run without an LLM)."""
+    if not hasattr(llm_client, "generate_structured"):
+        return None
+    from core.llm.task_types import TaskType
+
+    def _call(prompt, schema, system_prompt):
+        try:
+            data, _full = llm_client.generate_structured(
+                prompt=prompt,
+                schema=schema,
+                system_prompt=system_prompt,
+                task_type=TaskType.ANALYSE,
+            )
+            return data
+        except Exception as e:
+            logger.debug(f"checker_synthesis LLM call failed: {e}")
+            return None
+    return _call
+
+
+def _seed_from_vuln(vuln) -> Optional[Any]:
+    """Build a ``SeedBug`` from a confirmed-exploitable
+    ``VulnerabilityContext``. Returns None if the vuln lacks the
+    fields needed to seed synthesis (no file_path, no line range,
+    no resolved function name)."""
+    from packages.checker_synthesis import SeedBug
+
+    file_path = getattr(vuln, "file_path", "") or ""
+    start_line = getattr(vuln, "start_line", None)
+    end_line = getattr(vuln, "end_line", None) or start_line
+    if not file_path or not start_line or not end_line:
+        return None
+
+    # Function name: prefer inventory-resolved metadata, fall back
+    # to whatever the upstream finding adapter populated.
+    meta = getattr(vuln, "metadata", None) or {}
+    function_name = (
+        meta.get("name")
+        or getattr(vuln, "function_name", None)
+        or ""
+    )
+    if not function_name:
+        return None
+
+    cwe = getattr(vuln, "cwe_id", "") or ""
+    analysis = getattr(vuln, "analysis", None) or {}
+    reasoning = (
+        analysis.get("reasoning")
+        or analysis.get("explanation")
+        or getattr(vuln, "message", "")
+        or ""
+    )
+    snippet = getattr(vuln, "full_code", "") or ""
+
+    return SeedBug(
+        file=file_path,
+        function=function_name,
+        line_start=int(start_line),
+        line_end=int(end_line),
+        cwe=cwe,
+        reasoning=str(reasoning),
+        snippet=str(snippet),
+    )
+
+
+def _resolve_match_function(
+    match, checklist: Optional[Dict[str, Any]], repo_root: Path,
+) -> Optional[str]:
+    """Look up the function name covering ``match.file:match.line``.
+    Returns None when not resolvable — the variant annotation needs
+    a function name to land in the right .md section."""
+    if not checklist:
+        return None
+    if not match.file or not match.line:
+        return None
+    try:
+        from core.inventory.lookup import lookup_function
+        func = lookup_function(
+            checklist, match.file, int(match.line),
+            repo_root=str(repo_root),
+        )
+    except (ValueError, TypeError, OSError):
+        return None
+    if not func:
+        return None
+    return func.get("name") or None
+
+
+def _build_variant_body(seed, rule, match) -> str:
+    """Compose the prose body for a variant annotation."""
+    parts = [
+        f"Candidate variant of bug pattern from "
+        f"{seed.file}:{seed.line_start}-{seed.line_end} "
+        f"({seed.function}).",
+    ]
+    if rule.rationale:
+        parts.append(f"Pattern rationale: {rule.rationale.strip()}")
+    if seed.cwe:
+        parts.append(f"CWE: {seed.cwe}")
+    parts.append(
+        f"Surfaced by {rule.engine} rule ``{rule.rule_id}``. "
+        f"Triage with ``/annotate show`` or re-run ``/agentic`` to "
+        f"confirm or rule out."
+    )
+    if match.snippet:
+        parts.append(f"Match snippet:\n```\n{match.snippet.rstrip()}\n```")
+    return "\n\n".join(parts)
+
+
+def _sanitise_meta(value) -> str:
+    """Coerce metadata values to a safe single-line string. Mirrors
+    the sanitiser in ``annotation_emit`` — strips newlines / nulls /
+    HTML-comment delimiters that would corrupt the on-disk format."""
+    s = str(value)
+    s = s.replace("\n", " ").replace("\r", " ").replace("\x00", "")
+    s = s.replace("-->", "->").replace("<!--", "<!-")
+    return s.strip()
+
+
+def emit_variant_annotations_for_finding(
+    vuln,
+    *,
+    out_dir: Path,
+    checklist: Optional[Dict[str, Any]],
+    repo_root: Path,
+    llm_client,
+    max_matches: int = 10,
+    triage_each: bool = True,
+    max_triage_calls: int = 10,
+) -> int:
+    """For a confirmed exploitable finding, synthesise a checker
+    rule, run it across ``repo_root``, and emit ``suspicious``
+    annotations for every variant match.
+
+    Returns the count of annotations actually written. Skipped
+    silently when:
+
+      * Seed couldn't be built (missing file/line/function info)
+      * LLM client doesn't support ``generate_structured``
+      * Synthesis didn't produce a rule (positive control failed)
+      * No checklist (can't resolve match function names)
+
+    Best-effort throughout — any exception is logged and swallowed.
+    The caller's analysis loop must never crash because variant
+    hunting failed.
+    """
+    try:
+        seed = _seed_from_vuln(vuln)
+        if seed is None:
+            return 0
+
+        llm_callable = _llm_callable_from_client(llm_client)
+        if llm_callable is None:
+            return 0
+
+        from packages.checker_synthesis import synthesise_and_run
+        result = synthesise_and_run(
+            seed,
+            repo_root=repo_root,
+            out_dir=out_dir,
+            llm=llm_callable,
+            max_matches=max_matches,
+            triage_each=triage_each,
+            max_triage_calls=max_triage_calls,
+        )
+    except Exception:
+        logger.debug("checker_followup: synthesis failed", exc_info=True)
+        return 0
+
+    if result.rule is None or not result.matches:
+        return 0
+
+    return _emit_variants(
+        seed=seed,
+        result=result,
+        out_dir=out_dir,
+        checklist=checklist,
+        repo_root=repo_root,
+    )
+
+
+def _emit_variants(
+    *,
+    seed,
+    result,
+    out_dir: Path,
+    checklist: Optional[Dict[str, Any]],
+    repo_root: Path,
+) -> int:
+    """Walk synthesis matches → look up function names → write
+    annotations. Triage verdicts (when present) gate emission:
+    ``variant`` lands as ``suspicious``; ``false_positive`` and
+    ``skipped`` are dropped; ``uncertain`` lands as ``suspicious``
+    too (operator should look). Untriaged matches always land."""
+    from core.annotations import Annotation, write_annotation
+
+    triage_by_match = {
+        (t.match.file, t.match.line): t.status
+        for t in (result.triage or [])
+    }
+
+    written = 0
+    base_dir = out_dir / "annotations"
+
+    for m in result.matches:
+        triage_status = triage_by_match.get((m.file, m.line))
+        if triage_status in ("false_positive", "skipped"):
+            continue
+
+        function_name = _resolve_match_function(m, checklist, repo_root)
+        if not function_name:
+            continue
+
+        metadata: Dict[str, str] = {
+            "source": "llm",
+            "status": "suspicious",
+            "variant_of_file": _sanitise_meta(seed.file),
+            "variant_of_function": _sanitise_meta(seed.function),
+            "rule_id": _sanitise_meta(result.rule.rule_id),
+            "engine": _sanitise_meta(result.rule.engine),
+        }
+        if seed.cwe:
+            metadata["cwe"] = _sanitise_meta(seed.cwe)
+        if triage_status:
+            metadata["triage"] = _sanitise_meta(triage_status)
+
+        ann = Annotation(
+            file=m.file,
+            function=function_name,
+            body=_build_variant_body(seed, result.rule, m),
+            metadata=metadata,
+        )
+        try:
+            path = write_annotation(
+                base_dir, ann, overwrite="respect-manual",
+            )
+        except Exception:
+            logger.debug(
+                f"checker_followup: variant annotation write failed for "
+                f"{m.file}:{m.line}",
+                exc_info=True,
+            )
+            continue
+        if path is not None:
+            written += 1
+    return written

--- a/packages/llm_analysis/tests/test_checker_followup.py
+++ b/packages/llm_analysis/tests/test_checker_followup.py
@@ -1,0 +1,473 @@
+"""Tests for ``packages.llm_analysis.checker_followup``.
+
+Stubbed LLM + stubbed checker_synthesis so tests don't need an LLM
+provider or scanner binaries. The point is to verify the wiring:
+seed-from-vuln, function-name resolution, annotation emission,
+triage-aware filtering, and best-effort exception handling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from packages.llm_analysis.checker_followup import (
+    _build_variant_body,
+    _llm_callable_from_client,
+    _resolve_match_function,
+    _seed_from_vuln,
+    emit_variant_annotations_for_finding,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StubVuln:
+    file_path: str = "src/auth.py"
+    start_line: int = 10
+    end_line: int = 20
+    rule_id: str = "py/sql-injection"
+    cwe_id: str = "CWE-89"
+    tool: str = "codeql"
+    message: str = "tainted query"
+    full_code: str = "def login(req):\n    return cursor.execute(...)"
+    metadata: Optional[Dict[str, Any]] = None
+    analysis: Optional[Dict[str, Any]] = None
+
+
+class StubLLMClient:
+    """Minimal stub matching ``LLMClient.generate_structured`` signature."""
+
+    def __init__(self, responses=None):
+        self._responses = list(responses or [])
+
+    def generate_structured(self, *, prompt, schema, system_prompt, task_type):
+        if not self._responses:
+            return None, None
+        item = self._responses.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return item, None
+
+
+class _NoLLMClient:
+    """A client that doesn't expose ``generate_structured`` — e.g.
+    the prep-only ClaudeCodeProvider."""
+    pass
+
+
+def _checklist(file_path="src/v.py", name="variant_fn",
+               line_start=1, line_end=10):
+    return {
+        "files": [
+            {
+                "path": file_path,
+                "items": [
+                    {
+                        "name": name,
+                        "line_start": line_start,
+                        "line_end": line_end,
+                    }
+                ],
+            }
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSeedFromVuln:
+    def test_minimal_vuln_succeeds(self):
+        v = StubVuln(metadata={"name": "login"})
+        seed = _seed_from_vuln(v)
+        assert seed is not None
+        assert seed.file == "src/auth.py"
+        assert seed.function == "login"
+        assert seed.line_start == 10
+        assert seed.line_end == 20
+        assert seed.cwe == "CWE-89"
+
+    def test_no_function_name_returns_none(self):
+        v = StubVuln(metadata={})
+        assert _seed_from_vuln(v) is None
+
+    def test_no_file_path_returns_none(self):
+        v = StubVuln(file_path="", metadata={"name": "x"})
+        assert _seed_from_vuln(v) is None
+
+    def test_no_line_returns_none(self):
+        v = StubVuln(start_line=None, metadata={"name": "x"})  # type: ignore
+        assert _seed_from_vuln(v) is None
+
+    def test_uses_analysis_reasoning_when_present(self):
+        v = StubVuln(
+            metadata={"name": "login"},
+            analysis={"reasoning": "rich LLM reasoning here"},
+        )
+        seed = _seed_from_vuln(v)
+        assert "rich LLM reasoning" in seed.reasoning
+
+    def test_falls_back_to_message_when_no_reasoning(self):
+        v = StubVuln(metadata={"name": "login"}, message="scanner msg")
+        seed = _seed_from_vuln(v)
+        assert "scanner msg" in seed.reasoning
+
+
+class TestLLMCallableFromClient:
+    def test_returns_callable_for_real_client(self):
+        c = StubLLMClient(responses=[{"rule_body": "...", "rationale": "x"}])
+        callable = _llm_callable_from_client(c)
+        assert callable is not None
+        out = callable("p", {}, "s")
+        assert out == {"rule_body": "...", "rationale": "x"}
+
+    def test_returns_none_for_client_without_generate_structured(self):
+        c = _NoLLMClient()
+        assert _llm_callable_from_client(c) is None
+
+    def test_swallows_llm_exception(self):
+        c = StubLLMClient(responses=[RuntimeError("transport error")])
+        callable = _llm_callable_from_client(c)
+        # Returns None when the underlying client raises.
+        assert callable("p", {}, "s") is None
+
+
+class TestResolveMatchFunction:
+    def test_finds_function(self, tmp_path):
+        from packages.checker_synthesis import Match
+        m = Match(file="src/v.py", line=5)
+        ck = _checklist()
+        assert _resolve_match_function(m, ck, tmp_path) == "variant_fn"
+
+    def test_no_checklist_returns_none(self, tmp_path):
+        from packages.checker_synthesis import Match
+        m = Match(file="src/v.py", line=5)
+        assert _resolve_match_function(m, None, tmp_path) is None
+
+    def test_empty_file_returns_none(self, tmp_path):
+        from packages.checker_synthesis import Match
+        m = Match(file="", line=5)
+        assert _resolve_match_function(m, _checklist(), tmp_path) is None
+
+    def test_zero_line_returns_none(self, tmp_path):
+        from packages.checker_synthesis import Match
+        m = Match(file="src/v.py", line=0)
+        assert _resolve_match_function(m, _checklist(), tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# emit_variant_annotations_for_finding — full pipeline
+# ---------------------------------------------------------------------------
+
+
+def _patch_synth(monkeypatch, *, rule, matches, triage=()):
+    """Replace ``synthesise_and_run`` with a fixture that returns a
+    canned ``CheckerSynthesisResult``."""
+    from packages.checker_synthesis import (
+        CheckerSynthesisResult,
+        SynthesisedRule,
+    )
+    from packages.llm_analysis import checker_followup as mod
+
+    def _fake(*args, **kwargs):
+        return CheckerSynthesisResult(
+            seed=kwargs.get("seed") or args[0],
+            rule=rule,
+            matches=list(matches),
+            triage=list(triage),
+            positive_control=True,
+        )
+
+    # synthesise_and_run is imported lazily inside the function.
+    # Patch the symbol that the helper imports.
+    import packages.checker_synthesis as cs_mod
+    monkeypatch.setattr(cs_mod, "synthesise_and_run", _fake)
+
+
+class TestEmitVariantAnnotations:
+    def test_emits_one_annotation_per_match(self, tmp_path, monkeypatch):
+        from packages.checker_synthesis import Match, SynthesisedRule
+        from core.annotations import iter_all_annotations
+
+        v = StubVuln(metadata={"name": "login"})
+        rule = SynthesisedRule(
+            engine="semgrep", rule_id="auth.0", body="r",
+            rationale="catches f-string SQL into execute",
+        )
+        # Variant in another function in another file.
+        matches = [Match(file="src/v.py", line=5)]
+
+        # Plant the inventory entry that resolves the match's function.
+        ck = _checklist()
+        _patch_synth(monkeypatch, rule=rule, matches=matches)
+
+        n = emit_variant_annotations_for_finding(
+            v,
+            out_dir=tmp_path,
+            checklist=ck,
+            repo_root=tmp_path,
+            llm_client=StubLLMClient(),
+        )
+        assert n == 1
+
+        anns = list(iter_all_annotations(tmp_path / "annotations"))
+        assert len(anns) == 1
+        ann = anns[0]
+        assert ann.function == "variant_fn"
+        assert ann.metadata["status"] == "suspicious"
+        assert ann.metadata["source"] == "llm"
+        assert ann.metadata["variant_of_function"] == "login"
+        assert ann.metadata["variant_of_file"] == "src/auth.py"
+        assert ann.metadata["rule_id"] == "auth.0"
+        assert ann.metadata["engine"] == "semgrep"
+        assert ann.metadata["cwe"] == "CWE-89"
+        assert "Candidate variant" in ann.body
+
+    def test_triage_filters_false_positives(self, tmp_path, monkeypatch):
+        from packages.checker_synthesis import (
+            Match, MatchTriage, SynthesisedRule,
+        )
+        from core.annotations import iter_all_annotations
+
+        v = StubVuln(metadata={"name": "login"})
+        rule = SynthesisedRule(
+            engine="semgrep", rule_id="auth.0", body="r",
+        )
+        m_variant = Match(file="src/v.py", line=5)
+        m_fp = Match(file="src/v.py", line=15)
+        matches = [m_variant, m_fp]
+        triage = [
+            MatchTriage(match=m_variant, status="variant",
+                         reasoning="same shape"),
+            MatchTriage(match=m_fp, status="false_positive",
+                         reasoning="different sink"),
+        ]
+        ck = {
+            "files": [
+                {
+                    "path": "src/v.py",
+                    "items": [
+                        {"name": "variant_fn",
+                         "line_start": 1, "line_end": 10},
+                        {"name": "safe_fn",
+                         "line_start": 12, "line_end": 20},
+                    ],
+                }
+            ]
+        }
+        _patch_synth(monkeypatch, rule=rule,
+                     matches=matches, triage=triage)
+
+        n = emit_variant_annotations_for_finding(
+            v,
+            out_dir=tmp_path,
+            checklist=ck,
+            repo_root=tmp_path,
+            llm_client=StubLLMClient(),
+        )
+        # variant kept, false_positive dropped.
+        assert n == 1
+        anns = list(iter_all_annotations(tmp_path / "annotations"))
+        assert len(anns) == 1
+        assert anns[0].function == "variant_fn"
+
+    def test_triage_uncertain_kept(self, tmp_path, monkeypatch):
+        from packages.checker_synthesis import (
+            Match, MatchTriage, SynthesisedRule,
+        )
+        v = StubVuln(metadata={"name": "login"})
+        rule = SynthesisedRule(engine="semgrep", rule_id="x", body="r")
+        m = Match(file="src/v.py", line=5)
+        triage = [MatchTriage(match=m, status="uncertain", reasoning="?")]
+        _patch_synth(monkeypatch, rule=rule,
+                     matches=[m], triage=triage)
+        n = emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist=_checklist(),
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+        assert n == 1
+
+    def test_triage_skipped_dropped(self, tmp_path, monkeypatch):
+        from packages.checker_synthesis import (
+            Match, MatchTriage, SynthesisedRule,
+        )
+        v = StubVuln(metadata={"name": "login"})
+        rule = SynthesisedRule(engine="semgrep", rule_id="x", body="r")
+        m = Match(file="src/v.py", line=5)
+        triage = [MatchTriage(match=m, status="skipped", reasoning="budget")]
+        _patch_synth(monkeypatch, rule=rule,
+                     matches=[m], triage=triage)
+        n = emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist=_checklist(),
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+        assert n == 0
+
+    def test_returns_zero_when_no_seed(self, tmp_path):
+        v = StubVuln(metadata={})  # no function name
+        n = emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist=_checklist(),
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+        assert n == 0
+
+    def test_returns_zero_when_no_llm(self, tmp_path):
+        v = StubVuln(metadata={"name": "login"})
+        n = emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist=_checklist(),
+            repo_root=tmp_path, llm_client=_NoLLMClient(),
+        )
+        assert n == 0
+
+    def test_returns_zero_when_no_rule(self, tmp_path, monkeypatch):
+        v = StubVuln(metadata={"name": "login"})
+        _patch_synth(monkeypatch, rule=None, matches=[])
+        n = emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist=_checklist(),
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+        assert n == 0
+
+    def test_returns_zero_when_no_matches(self, tmp_path, monkeypatch):
+        from packages.checker_synthesis import SynthesisedRule
+        v = StubVuln(metadata={"name": "login"})
+        rule = SynthesisedRule(engine="semgrep", rule_id="x", body="r")
+        _patch_synth(monkeypatch, rule=rule, matches=[])
+        n = emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist=_checklist(),
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+        assert n == 0
+
+    def test_returns_zero_when_match_has_no_inventory_entry(
+        self, tmp_path, monkeypatch,
+    ):
+        """Match in a file that's not in the checklist — function name
+        unresolvable, annotation skipped silently."""
+        from packages.checker_synthesis import Match, SynthesisedRule
+        v = StubVuln(metadata={"name": "login"})
+        rule = SynthesisedRule(engine="semgrep", rule_id="x", body="r")
+        # Match in an unrelated file.
+        m = Match(file="src/not_in_inventory.py", line=5)
+        _patch_synth(monkeypatch, rule=rule, matches=[m])
+        n = emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist=_checklist(),
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+        assert n == 0
+
+    def test_synthesis_exception_swallowed(self, tmp_path, monkeypatch):
+        v = StubVuln(metadata={"name": "login"})
+        import packages.checker_synthesis as cs_mod
+
+        def boom(*a, **kw):
+            raise RuntimeError("simulated synth failure")
+
+        monkeypatch.setattr(cs_mod, "synthesise_and_run", boom)
+        # Must not raise.
+        n = emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist=_checklist(),
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+        assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# Adversarial: hostile inputs in the seed → annotation pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarial:
+    def test_hostile_seed_function_sanitised_in_metadata(
+        self, tmp_path, monkeypatch,
+    ):
+        """A vuln whose function name contains HTML-comment delimiters
+        would corrupt the on-disk metadata format if not sanitised. The
+        sanitiser strips ``-->`` from metadata values."""
+        from packages.checker_synthesis import Match, SynthesisedRule
+        v = StubVuln(metadata={"name": "login-->evil"})
+        rule = SynthesisedRule(engine="semgrep", rule_id="x", body="r")
+        _patch_synth(monkeypatch, rule=rule,
+                     matches=[Match(file="src/v.py", line=5)])
+        n = emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist=_checklist(),
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+        assert n == 1
+        from core.annotations import iter_all_annotations
+        ann = list(iter_all_annotations(tmp_path / "annotations"))[0]
+        # ``-->`` stripped from metadata value.
+        assert "-->" not in ann.metadata["variant_of_function"]
+
+    def test_hostile_rule_id_sanitised(self, tmp_path, monkeypatch):
+        from packages.checker_synthesis import Match, SynthesisedRule
+        v = StubVuln(metadata={"name": "login"})
+        rule = SynthesisedRule(
+            engine="semgrep",
+            rule_id="hostile\nrule\x00id",
+            body="r",
+        )
+        _patch_synth(monkeypatch, rule=rule,
+                     matches=[Match(file="src/v.py", line=5)])
+        n = emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist=_checklist(),
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+        assert n == 1
+        from core.annotations import iter_all_annotations
+        ann = list(iter_all_annotations(tmp_path / "annotations"))[0]
+        assert "\n" not in ann.metadata["rule_id"]
+        assert "\x00" not in ann.metadata["rule_id"]
+
+
+# ---------------------------------------------------------------------------
+# Body composition
+# ---------------------------------------------------------------------------
+
+
+class TestBuildVariantBody:
+    def test_includes_seed_location(self):
+        from packages.checker_synthesis import (
+            Match, SeedBug, SynthesisedRule,
+        )
+        seed = SeedBug(
+            file="src/auth.py", function="login",
+            line_start=10, line_end=20,
+            cwe="CWE-89", reasoning="r",
+        )
+        rule = SynthesisedRule(
+            engine="semgrep", rule_id="auth.0", body="...",
+            rationale="rationale here",
+        )
+        m = Match(file="src/v.py", line=5,
+                   snippet="cursor.execute(f'...')")
+        body = _build_variant_body(seed, rule, m)
+        assert "src/auth.py:10-20" in body
+        assert "login" in body
+        assert "rationale here" in body
+        assert "CWE-89" in body
+        assert "auth.0" in body
+        assert "cursor.execute" in body
+
+    def test_no_snippet_no_snippet_section(self):
+        from packages.checker_synthesis import (
+            Match, SeedBug, SynthesisedRule,
+        )
+        seed = SeedBug(
+            file="x", function="f", line_start=1, line_end=2,
+            cwe="", reasoning="",
+        )
+        rule = SynthesisedRule(engine="semgrep", rule_id="r", body="b")
+        m = Match(file="src/v.py", line=5)  # no snippet
+        body = _build_variant_body(seed, rule, m)
+        assert "Match snippet" not in body

--- a/packages/llm_analysis/tests/test_checker_followup_adversarial.py
+++ b/packages/llm_analysis/tests/test_checker_followup_adversarial.py
@@ -1,0 +1,441 @@
+"""Adversarial + E2E coverage for the KNighter follow-up wiring.
+
+Probes inputs a faulty / compromised upstream could hand the
+follow-up helper. Each case must produce a usable on-disk
+annotation tree without crash, prompt-format corruption, or
+unbounded growth.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from packages.llm_analysis.checker_followup import (
+    emit_variant_annotations_for_finding,
+)
+
+
+@dataclass
+class StubVuln:
+    file_path: str = "src/auth.py"
+    start_line: int = 10
+    end_line: int = 20
+    rule_id: str = "py/sql-injection"
+    cwe_id: str = "CWE-89"
+    tool: str = "codeql"
+    message: str = "tainted query"
+    full_code: str = "def login(req):\n    return cursor.execute(...)"
+    metadata: Optional[Dict[str, Any]] = None
+    analysis: Optional[Dict[str, Any]] = None
+
+
+class StubLLMClient:
+    def generate_structured(
+        self, *, prompt, schema, system_prompt, task_type,
+    ):
+        return None, None  # Doesn't matter; synth is patched.
+
+
+def _patch_synth(monkeypatch, *, rule, matches, triage=()):
+    from packages.checker_synthesis import CheckerSynthesisResult
+    import packages.checker_synthesis as cs_mod
+
+    def _fake(*args, **kwargs):
+        return CheckerSynthesisResult(
+            seed=kwargs.get("seed") or args[0],
+            rule=rule,
+            matches=list(matches),
+            triage=list(triage),
+            positive_control=True,
+        )
+    monkeypatch.setattr(cs_mod, "synthesise_and_run", _fake)
+
+
+def _multi_function_checklist(file_path, names_with_lines):
+    """Build a checklist where one source file has multiple functions."""
+    return {
+        "files": [
+            {
+                "path": file_path,
+                "items": [
+                    {"name": name, "line_start": s, "line_end": e}
+                    for name, s, e in names_with_lines
+                ],
+            }
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Hostile snippet content — pinned current substrate limitation
+# ---------------------------------------------------------------------------
+
+
+class TestHostileSnippet:
+    def test_snippet_with_double_hash_does_not_crash(
+        self, tmp_path, monkeypatch,
+    ):
+        """A match snippet containing ``\\n## fake_function`` could,
+        in principle, mis-parse on a later read because the
+        annotation file's section regex matches ``## name`` at
+        start-of-line. Code-fence-aware parsing is a known
+        substrate limitation. Pin: write succeeds, no crash; the
+        first round-trip read gets the data; later reads of the
+        same file may see the fake section. The test pins that
+        the IMMEDIATE write+read works — anything stronger is
+        out of scope for this layer."""
+        from packages.checker_synthesis import Match, SynthesisedRule
+        from core.annotations import iter_all_annotations
+
+        v = StubVuln(metadata={"name": "login"})
+        rule = SynthesisedRule(engine="semgrep", rule_id="x", body="r")
+        m = Match(
+            file="src/v.py",
+            line=5,
+            snippet="some_call(...)\n## evil_function\nmore_code",
+        )
+        ck = _multi_function_checklist(
+            "src/v.py", [("variant_fn", 1, 10)],
+        )
+        _patch_synth(monkeypatch, rule=rule, matches=[m])
+
+        n = emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist=ck,
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+        assert n == 1
+        # The .md file exists, was written without raising.
+        md = tmp_path / "annotations" / "src" / "v.py.md"
+        assert md.exists()
+
+
+# ---------------------------------------------------------------------------
+# Vuln-shape edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestVulnShapes:
+    def test_vuln_metadata_explicitly_none(self, tmp_path):
+        """``metadata = None`` (vs missing key vs empty dict). Helper
+        must not crash; falls through to no-seed (no function name)."""
+        v = StubVuln(metadata=None)
+        n = emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist={},
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+        assert n == 0
+
+    def test_vuln_with_no_metadata_attribute(self, tmp_path):
+        """Some upstream vuln shapes might not even define a
+        ``metadata`` attribute. Helper should ``getattr`` defensively."""
+        class Bare:
+            file_path = "src/x.py"
+            start_line = 1
+            end_line = 5
+            cwe_id = "CWE-89"
+            rule_id = "x"
+            tool = "y"
+            message = "z"
+            full_code = ""
+            analysis = None
+
+        n = emit_variant_annotations_for_finding(
+            Bare(), out_dir=tmp_path, checklist={},
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+        # No function name resolvable without metadata; skip.
+        assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# Variant relationships
+# ---------------------------------------------------------------------------
+
+
+class TestVariantRelationships:
+    def test_variant_in_same_file_different_function(
+        self, tmp_path, monkeypatch,
+    ):
+        """Seed: src/auth.py:login. Variant: src/auth.py:other_login.
+        Both should land in the SAME annotation .md file as separate
+        sections."""
+        from packages.checker_synthesis import Match, SynthesisedRule
+        from core.annotations import iter_all_annotations
+
+        v = StubVuln(metadata={"name": "login"})
+        rule = SynthesisedRule(engine="semgrep", rule_id="x", body="r")
+        # Variant in same file (auth.py) as the seed.
+        m = Match(file="src/auth.py", line=42)
+        ck = _multi_function_checklist(
+            "src/auth.py",
+            [("login", 10, 20), ("other_login", 35, 50)],
+        )
+        _patch_synth(monkeypatch, rule=rule, matches=[m])
+
+        n = emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist=ck,
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+        assert n == 1
+        # The annotation lands as a separate section in the .md.
+        anns = list(iter_all_annotations(tmp_path / "annotations"))
+        assert len(anns) == 1
+        assert anns[0].function == "other_login"
+
+    def test_seed_match_filtered_by_substrate(self, tmp_path, monkeypatch):
+        """The seed bug itself should NOT be re-emitted as a variant.
+        ``synthesise_and_run`` filters via ``_is_seed_match`` —
+        verify that path is hit when the synthesis result reflects
+        the substrate's filtering."""
+        from packages.checker_synthesis import Match, SynthesisedRule
+
+        v = StubVuln(metadata={"name": "login"})
+        rule = SynthesisedRule(engine="semgrep", rule_id="x", body="r")
+        # Empty matches list (substrate already filtered the seed).
+        _patch_synth(monkeypatch, rule=rule, matches=[])
+        n = emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist={},
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+        assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# Coexistence with prior annotations on the same function
+# ---------------------------------------------------------------------------
+
+
+class TestCoexistence:
+    def test_respect_manual_preserves_operator_note(
+        self, tmp_path, monkeypatch,
+    ):
+        """Operator wrote a manual annotation for src/v.py:variant_fn.
+        Then /agentic confirms a finding elsewhere, KNighter follow-up
+        finds variant_fn as a variant. The follow-up's annotation
+        write should be skipped (respect-manual), operator's note
+        intact."""
+        from core.annotations import (
+            Annotation, read_annotation, write_annotation,
+        )
+        from packages.checker_synthesis import Match, SynthesisedRule
+
+        # Operator's prior manual note.
+        write_annotation(
+            tmp_path / "annotations",
+            Annotation(
+                file="src/v.py", function="variant_fn",
+                body="reviewed by alice — clean, constant-time",
+                metadata={"source": "human", "status": "clean"},
+            ),
+        )
+
+        v = StubVuln(metadata={"name": "login"})
+        rule = SynthesisedRule(engine="semgrep", rule_id="x", body="r")
+        m = Match(file="src/v.py", line=5)
+        ck = _multi_function_checklist(
+            "src/v.py", [("variant_fn", 1, 10)],
+        )
+        _patch_synth(monkeypatch, rule=rule, matches=[m])
+
+        n = emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist=ck,
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+        # respect-manual blocked — count is 0.
+        assert n == 0
+        # Operator's content preserved.
+        ann = read_annotation(
+            tmp_path / "annotations", "src/v.py", "variant_fn",
+        )
+        assert ann.metadata["source"] == "human"
+        assert "alice" in ann.body
+
+    def test_double_emit_overwrites_llm_annotation(
+        self, tmp_path, monkeypatch,
+    ):
+        """Two consecutive runs on the same seed → second emit
+        overwrites the first cleanly (both source=llm). Pin the
+        last-writer-wins semantics for LLM-over-LLM case."""
+        from core.annotations import iter_all_annotations
+        from packages.checker_synthesis import Match, SynthesisedRule
+
+        v = StubVuln(metadata={"name": "login"})
+        rule1 = SynthesisedRule(engine="semgrep", rule_id="r1", body="r")
+        rule2 = SynthesisedRule(engine="semgrep", rule_id="r2", body="r")
+        m = Match(file="src/v.py", line=5)
+        ck = _multi_function_checklist(
+            "src/v.py", [("variant_fn", 1, 10)],
+        )
+        _patch_synth(monkeypatch, rule=rule1, matches=[m])
+        emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist=ck,
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+
+        # Second emit with a different rule_id — should overwrite.
+        _patch_synth(monkeypatch, rule=rule2, matches=[m])
+        emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist=ck,
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+
+        anns = list(iter_all_annotations(tmp_path / "annotations"))
+        assert len(anns) == 1
+        # Latest rule_id wins.
+        assert anns[0].metadata["rule_id"] == "r2"
+
+
+# ---------------------------------------------------------------------------
+# Body & telemetry bounds
+# ---------------------------------------------------------------------------
+
+
+class TestBodyAndTelemetryBounds:
+    def test_max_snippet_size_kept_bounded(self, tmp_path, monkeypatch):
+        """``Match.snippet`` is capped at 500 chars by the
+        checker_synthesis adapter. Verify the resulting annotation
+        body stays bounded — no runaway from a hostile scanner."""
+        from core.annotations import iter_all_annotations
+        from packages.checker_synthesis import Match, SynthesisedRule
+
+        v = StubVuln(metadata={"name": "login"})
+        rule = SynthesisedRule(engine="semgrep", rule_id="x", body="r",
+                                rationale="rationale")
+        # Snippet at the cap (500 chars).
+        m = Match(file="src/v.py", line=5, snippet="x" * 500)
+        ck = _multi_function_checklist(
+            "src/v.py", [("variant_fn", 1, 10)],
+        )
+        _patch_synth(monkeypatch, rule=rule, matches=[m])
+        emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist=ck,
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+        anns = list(iter_all_annotations(tmp_path / "annotations"))
+        # Body should be a few KB at most: prose + one 500-char snippet.
+        assert len(anns[0].body.encode("utf-8")) < 4_000
+
+
+# ---------------------------------------------------------------------------
+# E2E — multi-variant realistic scenario
+# ---------------------------------------------------------------------------
+
+
+class TestE2E:
+    def test_multi_variant_landing_on_disk(self, tmp_path, monkeypatch):
+        """Seed: SQL injection in login. KNighter follow-up surfaces
+        4 variants in 4 different files. Verify the on-disk
+        annotation tree mirrors the source tree, each .md has the
+        right section, metadata captures seed + rule + triage."""
+        from core.annotations import iter_all_annotations
+        from packages.checker_synthesis import (
+            Match, MatchTriage, SynthesisedRule,
+        )
+
+        v = StubVuln(
+            file_path="src/auth/login.py",
+            start_line=42, end_line=48,
+            rule_id="py/sql-injection",
+            cwe_id="CWE-89",
+            metadata={"name": "check_credentials"},
+            analysis={
+                "is_true_positive": True, "is_exploitable": True,
+                "reasoning": "tainted query string flows into execute",
+            },
+        )
+        rule = SynthesisedRule(
+            engine="semgrep",
+            rule_id="src_auth_login_py.check_credentials.CWE-89.0",
+            body="rules:\n  - id: tainted-execute\n    pattern: ...",
+            rationale=(
+                "f-string with user-controlled value passed directly "
+                "to cursor.execute"
+            ),
+        )
+        # 4 variants: 2 TPs, 1 FP, 1 uncertain.
+        v1 = Match(file="src/admin/users.py", line=87,
+                    snippet="cursor.execute(f'SELECT * FROM u WHERE id={uid}')")
+        v2 = Match(file="src/api/search.py", line=23,
+                    snippet="cursor.execute(f'... {q}')")
+        v3 = Match(file="src/log/audit.py", line=15,
+                    snippet="conn.exec_safe(...)")  # FP — different sink
+        v4 = Match(file="src/util/db.py", line=42,
+                    snippet="db.run(query)")  # uncertain
+        triage = [
+            MatchTriage(match=v1, status="variant",
+                         reasoning="same f-string-into-execute pattern"),
+            MatchTriage(match=v2, status="variant",
+                         reasoning="same shape"),
+            MatchTriage(match=v3, status="false_positive",
+                         reasoning="exec_safe uses parameterised query"),
+            MatchTriage(match=v4, status="uncertain",
+                         reasoning="db.run could be either"),
+        ]
+
+        # Build a checklist covering all 4 variant locations.
+        ck = {
+            "files": [
+                {"path": "src/admin/users.py",
+                 "items": [{"name": "list_users",
+                            "line_start": 80, "line_end": 100}]},
+                {"path": "src/api/search.py",
+                 "items": [{"name": "search_handler",
+                            "line_start": 20, "line_end": 30}]},
+                {"path": "src/log/audit.py",
+                 "items": [{"name": "log_event",
+                            "line_start": 10, "line_end": 25}]},
+                {"path": "src/util/db.py",
+                 "items": [{"name": "db_run",
+                            "line_start": 40, "line_end": 50}]},
+            ]
+        }
+        _patch_synth(monkeypatch, rule=rule, matches=[v1, v2, v3, v4],
+                     triage=triage)
+
+        n = emit_variant_annotations_for_finding(
+            v, out_dir=tmp_path, checklist=ck,
+            repo_root=tmp_path, llm_client=StubLLMClient(),
+        )
+        # 2 variants + 1 uncertain = 3 emitted; FP dropped.
+        assert n == 3
+
+        anns = list(iter_all_annotations(tmp_path / "annotations"))
+        names = sorted(a.function for a in anns)
+        assert names == ["db_run", "list_users", "search_handler"]
+
+        # Mirror source tree on disk.
+        for rel in ("src/admin/users.py.md", "src/api/search.py.md",
+                    "src/util/db.py.md"):
+            assert (tmp_path / "annotations" / rel).exists(), (
+                f"missing annotation file: {rel}"
+            )
+        # FP file NOT created.
+        assert not (
+            tmp_path / "annotations" / "src" / "log" / "audit.py.md"
+        ).exists()
+
+        # Per-annotation metadata captures the seed + rule + triage.
+        list_users = next(a for a in anns if a.function == "list_users")
+        assert list_users.metadata["status"] == "suspicious"
+        assert list_users.metadata["source"] == "llm"
+        assert list_users.metadata["variant_of_function"] == "check_credentials"
+        assert list_users.metadata["variant_of_file"] == "src/auth/login.py"
+        assert list_users.metadata["cwe"] == "CWE-89"
+        assert list_users.metadata["engine"] == "semgrep"
+        assert list_users.metadata["rule_id"] == (
+            "src_auth_login_py.check_credentials.CWE-89.0"
+        )
+        assert list_users.metadata["triage"] == "variant"
+
+        # Body has rationale + cwe + match snippet.
+        assert "f-string with user-controlled value" in list_users.body
+        assert "CWE-89" in list_users.body
+        assert "cursor.execute" in list_users.body
+
+        # Uncertain match has triage="uncertain" in metadata.
+        db_run = next(a for a in anns if a.function == "db_run")
+        assert db_run.metadata["triage"] == "uncertain"


### PR DESCRIPTION
Second reuse of the cwe_strategies/checker_synthesis substrate. After /agentic confirms a finding as exploitable, turn the bug into a Semgrep/Coccinelle rule, run it across the codebase, and emit ``status=suspicious`` annotations for each variant match. One bug → N candidate variants per the audit design's Mode 2.

Module: ``packages/llm_analysis/checker_followup.py``.

Pipeline: SeedBug from VulnerabilityContext → adapter wraps LLMClient as LLMCallable → ``synthesise_and_run`` with triage_each=True (default max_matches=10, max_triage_calls=10) → resolve match function names via inventory → write suspicious annotations with ``respect-manual`` (preserves operator notes).

Triage filtering: variant + uncertain → emit; false_positive + skipped → drop.

Wired into ``agent.py:process_findings`` after exploit + patch generation. Behind ``self.synthesise_checkers`` flag (default True). New CLI: ``--no-checker-synthesis`` opts out for cost-sensitive runs. Behind ``emit_annotations`` too — disabling annotations also disables variant emission.

Best-effort throughout: synthesis exceptions, LLM failures, missing client / checklist / function names all return zero without breaking the analysis loop.

Telemetry: ``variant_annotations`` counter in process_findings, ``variant_annotations`` in autonomous_analysis_report.json, "✓ Checker-synthesised variants: N" log line.

Defences: hostile metadata values (newlines, null bytes, HTML- comment delimiters) sanitised before they reach the on-disk format. Substrate handles seed-self filtering. respect-manual preserves operator annotations on variant functions.

36 new tests: 27 unit (seed construction, LLM-callable adapter, match resolution, full pipeline, triage filtering, all skip-paths, adversarial sanitisation, body composition) + 9 adversarial/E2E (hostile snippet, vuln shapes, variant relationships, respect- manual coexistence, double-emit, body bounds, full multi-variant E2E with mixed triage verdicts).

Bumps prompt-envelope-audit allowlist line numbers in agent.py from 967-971 to 973-977 — the +6-line constructor change shifted the patch-markdown interpolations.

1022 tests across all touched packages (llm_analysis, checker_synthesis, cwe_strategies, prompt_envelope_audit) green.