### PR TITLE
feat(sandbox): observe-mode under Landlock-only

### DIFF
--- a/core/sandbox/_landlock_audit.py
+++ b/core/sandbox/_landlock_audit.py
@@ -1,0 +1,617 @@
+"""Landlock-only spawn variant with audit/observe tracer support.
+
+The mount-ns spawn path (``_spawn.run_sandboxed``) is the load-bearing
+audit/observe entry on hosts where unprivileged user-ns + mount-ns
+are available. On Ubuntu 24.04+ with the AppArmor default
+``apparmor_restrict_unprivileged_userns=1``, mount-ns is blocked and
+the sandbox falls back to a Landlock-only ``subprocess.run`` —
+which previously had NO tracer-fork machinery, so observe mode
+silently degraded.
+
+This module adds the missing piece: a focused spawn function that
+
+  * does NOT touch namespaces (mount/user/pid/net) — Landlock plus
+    seccomp do all of the per-call isolation;
+  * forks a ``core.sandbox.tracer`` subprocess in parallel with the
+    target child, mirroring the sync-pipe handshake from _spawn;
+  * passes the same audit-config tempfile so observe records carry
+    the per-run nonce + observe-stamp the parser validates.
+
+Implementation note: uses ``os.fork()`` directly (not
+``subprocess.Popen``) for the target child. ``Popen`` blocks until
+the child execs successfully, but our preexec must wait on a sync
+pipe BEFORE exec — Popen would deadlock the parent. The manual
+fork mirrors ``_spawn.run_sandboxed``'s pattern; the post-fork
+contract is the same (no Python objects, no GIL, ctypes-only
+syscalls until execvpe).
+
+Threat-model note: callers running on Landlock-only hosts already
+trade away namespace-level isolation (no PID-ns visibility hiding,
+no mount-ns filesystem hiding, no user-ns capability remapping).
+This module does not regress that posture; it specifically only
+restores AUDIT/OBSERVE signal that was missing. The Linux
+``THREAT_MODEL.md`` Landlock-only-mode warning applies unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+# Default tracer-ready timeout. The tracer's PTRACE_SEIZE +
+# SETOPTIONS dance is microseconds on a healthy host; allow 5s
+# to absorb pathological scheduler stalls (CI under heavy load).
+_TRACER_READY_TIMEOUT_S = 5.0
+
+# Linux prctl(2) constants for PR_SET_PTRACER. Not in stdlib;
+# duplicated here from the kernel headers.
+_PR_SET_PTRACER = 0x59616d61
+_PR_SET_PTRACER_ANY = 0xFFFFFFFFFFFFFFFF  # cast of (-1) to unsigned long
+
+
+def _set_ptracer_any_in_child() -> None:
+    """``prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY)`` so a sibling
+    tracer can attach under Yama scope 1.
+
+    Linux's Yama LSM in scope 1 mode (default on Ubuntu / Debian /
+    Fedora) only permits PTRACE_SEIZE on descendants of the tracer
+    process. The audit tracer is a sibling here (both target and
+    tracer are children of the parent), so the target must
+    explicitly opt in to being traced by ``any`` process. Same
+    approach the mount-ns spawn uses inside its preexec.
+
+    Failures are best-effort silent: on hosts without Yama (older
+    kernels, some containers) prctl returns EINVAL and ptrace
+    works without this opt-in. If Yama IS the gate, the tracer's
+    SEIZE will fail and the parent's diagnostic fires there.
+    """
+    import ctypes
+    libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    libc.prctl.argtypes = [
+        ctypes.c_int, ctypes.c_ulong, ctypes.c_ulong,
+        ctypes.c_ulong, ctypes.c_ulong,
+    ]
+    libc.prctl.restype = ctypes.c_int
+    libc.prctl(_PR_SET_PTRACER, _PR_SET_PTRACER_ANY, 0, 0, 0)
+
+
+def _build_audit_config(
+    *,
+    audit_verbose: bool,
+    observe_mode: bool,
+    observe_nonce: Optional[str],
+    writable_paths: Iterable[str],
+    readable_paths: Optional[Iterable[str]],
+    allowed_tcp_ports: Optional[Iterable[int]],
+    output: Optional[str],
+    target: Optional[str],
+    restrict_reads: bool,
+) -> dict:
+    """Construct the audit_config dict the tracer reads at startup.
+
+    Mirrors the dict built in ``_spawn.run_sandboxed`` so the tracer
+    sees the same shape regardless of which spawn path engaged it.
+    Pinning is enforced by ``test_audit_filter.TestAuditConfigSchemaAgree``
+    in the existing test suite.
+    """
+    from . import state as _state
+    import os.path as _osp
+
+    _writable: list = []
+    for p in (writable_paths or ()):
+        _writable.append(_osp.abspath(p))
+    _writable.append("/tmp")
+    if output:
+        _writable.append(_osp.abspath(output))
+
+    _system_ro = (
+        "/usr", "/lib", "/lib64", "/bin", "/sbin",
+        "/etc", "/proc", "/sys",
+    )
+    _read_allow = list(_writable)
+    for p in (readable_paths or ()):
+        _read_allow.append(_osp.abspath(p))
+    for p in _system_ro:
+        _read_allow.append(p)
+    if target:
+        _read_allow.append(_osp.abspath(target))
+
+    return {
+        "verbose": bool(audit_verbose),
+        "writable_paths": _writable,
+        "read_allowlist": (_read_allow if restrict_reads else None),
+        "allowed_tcp_ports": list(allowed_tcp_ports)
+            if allowed_tcp_ports else [],
+        "audit_budget": getattr(
+            _state, "_cli_sandbox_audit_budget", None,
+        ),
+        "observe_mode": bool(observe_mode),
+        "observe_nonce": observe_nonce,
+    }
+
+
+def _write_audit_config(audit_config: dict) -> str:
+    """Persist the audit-config dict to /tmp; return path.
+
+    Tempfile lives outside any sandbox view (random suffix in /tmp;
+    targets see /tmp via the system_ro list but cannot guess the
+    suffix). The nonce inside is therefore not readable by the
+    target, defeating spoofs by record-content forgery.
+    """
+    fd, path = tempfile.mkstemp(
+        prefix="raptor-audit-cfg-", suffix=".json",
+    )
+    serialised = json.dumps(audit_config).encode("utf-8")
+    try:
+        written = 0
+        while written < len(serialised):
+            n = os.write(fd, serialised[written:])
+            if n <= 0:
+                raise OSError(
+                    "audit-config write returned 0 bytes — "
+                    "filesystem full or read-only"
+                )
+            written += n
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+    return path
+
+
+def _close_safely(fd: int) -> None:
+    """Close an fd, ignoring already-closed / -1 / EBADF cases."""
+    if fd is None or fd < 0:
+        return
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+
+
+def _kill_and_reap(pid: int, timeout_s: float = 2.0) -> None:
+    """Kill (TERM → KILL) and reap a child. Idempotent."""
+    import time
+    try:
+        os.kill(pid, 15)
+    except ProcessLookupError:
+        return
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            done, _ = os.waitpid(pid, os.WNOHANG)
+        except (ChildProcessError, OSError):
+            return
+        if done != 0:
+            return
+        time.sleep(0.02)
+    try:
+        os.kill(pid, 9)
+    except ProcessLookupError:
+        return
+    try:
+        os.waitpid(pid, 0)
+    except (ChildProcessError, OSError):
+        pass
+
+
+def _read_to_eof(fd: int, max_bytes: int = 16 * 1024 * 1024) -> bytes:
+    """Read from `fd` until EOF or `max_bytes`; returns the bytes.
+
+    Bounded so a runaway child can't OOM the parent. Cap is
+    generous (16 MiB) for most workloads; over-cap callers should
+    use stdin/stdout passthrough (capture_output=False).
+    """
+    chunks: List[bytes] = []
+    total = 0
+    while total < max_bytes:
+        try:
+            chunk = os.read(fd, 65536)
+        except OSError:
+            break
+        if not chunk:
+            break
+        chunks.append(chunk)
+        total += len(chunk)
+    return b"".join(chunks)
+
+
+def run_landlock_audit(
+    cmd: List[str],
+    *,
+    audit_run_dir: str,
+    audit_verbose: bool = False,
+    observe_mode: bool = False,
+    observe_nonce: Optional[str] = None,
+    writable_paths: Optional[Iterable[str]] = None,
+    readable_paths: Optional[Iterable[str]] = None,
+    allowed_tcp_ports: Optional[Iterable[int]] = None,
+    target: Optional[str] = None,
+    output: Optional[str] = None,
+    restrict_reads: bool = False,
+    landlock_preexec=None,
+    seccomp_preexec=None,
+    rlimit_preexec=None,
+    env: Optional[dict] = None,
+    cwd: Optional[str] = None,
+    timeout: Optional[float] = None,
+    capture_output: bool = True,
+    text: bool = True,
+    stdin=None,
+    start_new_session: bool = True,
+) -> subprocess.CompletedProcess:
+    """Spawn ``cmd`` under Landlock + seccomp + ptrace tracer, no
+    namespaces.
+
+    Used when the host doesn't support unprivileged user-ns/mount-ns
+    (Ubuntu 24.04+ default with AppArmor) but Landlock + ptrace +
+    libseccomp work. Restores observe-mode signal that the bare
+    ``subprocess.run`` fallback couldn't capture.
+
+    Synchronisation: target child blocks on a sync pipe until the
+    parent confirms the tracer has SEIZE'd it. Without this gate,
+    the target's first traced syscall would fire SCMP_ACT_TRACE
+    with no tracer attached → kernel SIGSYS-kills the process.
+
+    Returns a CompletedProcess shaped to match subprocess.run's
+    return value.
+    """
+    if not audit_run_dir:
+        raise ValueError(
+            "run_landlock_audit requires audit_run_dir= so the "
+            "tracer has a place to write the JSONL"
+        )
+
+    audit_config = _build_audit_config(
+        audit_verbose=audit_verbose,
+        observe_mode=observe_mode,
+        observe_nonce=observe_nonce,
+        writable_paths=writable_paths or (),
+        readable_paths=readable_paths,
+        allowed_tcp_ports=allowed_tcp_ports,
+        output=output,
+        target=target,
+        restrict_reads=restrict_reads,
+    )
+    config_path = _write_audit_config(audit_config)
+
+    # Sync pipes:
+    #   p_go: parent → target ("tracer attached, proceed")
+    #   t_ready: tracer → parent ("I'm attached")
+    p_go_r, p_go_w = os.pipe()
+    t_ready_r, t_ready_w = os.pipe()
+    # The tracer subprocess inherits t_ready_w via execvpe →
+    # mark inheritable (PEP 446 sets O_CLOEXEC by default).
+    os.set_inheritable(t_ready_w, True)
+
+    # Capture pipes (only when capture_output=True).
+    if capture_output:
+        out_r, out_w = os.pipe()
+        err_r, err_w = os.pipe()
+    else:
+        out_r = out_w = err_r = err_w = -1
+
+    target_pid = -1
+    tracer_pid = -1
+    parent_owned_fds = [
+        p_go_r, p_go_w, t_ready_r, t_ready_w,
+        out_r, out_w, err_r, err_w,
+    ]
+
+    def _cleanup_fds() -> None:
+        for fd in parent_owned_fds:
+            _close_safely(fd)
+
+    try:
+        # ----- Fork the target -----
+        import warnings
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", category=DeprecationWarning,
+                message=r".*fork.*may lead to deadlocks.*",
+            )
+            target_pid = os.fork()
+
+        if target_pid == 0:
+            # ============== TARGET CHILD ==============
+            # Close the pipe ends we don't use; keep p_go_r (we
+            # read from it) and the capture write ends.
+            _close_safely(p_go_w)
+            _close_safely(t_ready_r)
+            _close_safely(t_ready_w)
+            if capture_output:
+                _close_safely(out_r)
+                _close_safely(err_r)
+                try:
+                    os.dup2(out_w, 1)
+                    os.dup2(err_w, 2)
+                finally:
+                    _close_safely(out_w)
+                    _close_safely(err_w)
+            # stdin: caller-supplied or /dev/null. Same shape as
+            # _spawn for parity (no PIPE on this path; that's a
+            # caller-side construct that wouldn't survive exec).
+            _use_devnull = (
+                stdin is None
+                or stdin == subprocess.DEVNULL
+                or stdin == subprocess.PIPE
+            )
+            if _use_devnull:
+                try:
+                    devnull = os.open("/dev/null", os.O_RDONLY)
+                    os.dup2(devnull, 0)
+                    os.close(devnull)
+                except OSError:
+                    pass
+            else:
+                try:
+                    stdin_fd = (stdin if isinstance(stdin, int)
+                                else stdin.fileno())
+                    os.dup2(stdin_fd, 0)
+                    if stdin_fd != 0:
+                        _close_safely(stdin_fd)
+                except (AttributeError, OSError):
+                    try:
+                        devnull = os.open("/dev/null", os.O_RDONLY)
+                        os.dup2(devnull, 0)
+                        os.close(devnull)
+                    except OSError:
+                        pass
+
+            if start_new_session:
+                try:
+                    os.setsid()
+                except OSError:
+                    pass
+
+            # cwd
+            if cwd is not None:
+                try:
+                    os.chdir(cwd)
+                except OSError:
+                    os._exit(126)
+
+            # rlimits + ptracer-any
+            try:
+                if rlimit_preexec is not None:
+                    rlimit_preexec()
+                _set_ptracer_any_in_child()
+
+                # Block until parent says tracer is attached.
+                byte = os.read(p_go_r, 1)
+                _close_safely(p_go_r)
+                if byte != b"G":
+                    os._exit(125)
+
+                # Apply Landlock then seccomp(audit). Ordering:
+                # Landlock first (filesystem isolation in place),
+                # then seccomp with TRACE action — every traced
+                # syscall now hits the (already-attached) tracer.
+                if landlock_preexec is not None:
+                    landlock_preexec()
+                if seccomp_preexec is not None:
+                    seccomp_preexec()
+
+                # Exec target. env=None → inherit parent's; env={} →
+                # empty env. subprocess.run uses None-sentinel for
+                # inherit; we honour the same.
+                if env is None:
+                    os.execvp(cmd[0], list(cmd))
+                else:
+                    os.execvpe(cmd[0], list(cmd), env)
+            except FileNotFoundError:
+                os._exit(127)
+            except PermissionError:
+                os._exit(126)
+            except Exception:
+                os._exit(125)
+
+        # ============== PARENT after target fork ==============
+        # Close the read end of go-pipe and capture-write ends —
+        # the target owns them now.
+        _close_safely(p_go_r); p_go_r = -1
+        if capture_output:
+            _close_safely(out_w); out_w = -1
+            _close_safely(err_w); err_w = -1
+
+        # ----- Fork the tracer -----
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", category=DeprecationWarning,
+                message=r".*fork.*may lead to deadlocks.*",
+            )
+            tracer_pid = os.fork()
+
+        if tracer_pid == 0:
+            # ============== TRACER CHILD ==============
+            # Close every inherited fd except stdio + t_ready_w.
+            try:
+                import resource as _resource
+                soft, _hard = _resource.getrlimit(_resource.RLIMIT_NOFILE)
+                upper = min(soft, 65536)
+                # Two ranges around t_ready_w.
+                if 3 <= t_ready_w < upper:
+                    os.closerange(3, t_ready_w)
+                    os.closerange(t_ready_w + 1, upper)
+                else:
+                    os.closerange(3, upper)
+                raptor_dir = os.environ.get("RAPTOR_DIR")
+                if raptor_dir is None:
+                    raptor_dir = str(
+                        Path(__file__).resolve().parent.parent.parent
+                    )
+                tracer_env = {
+                    "PYTHONPATH": raptor_dir,
+                    "PATH": "/usr/bin:/bin",
+                }
+                tracer_argv = [
+                    sys.executable, "-m", "core.sandbox.tracer",
+                    str(target_pid), str(audit_run_dir),
+                    str(t_ready_w), config_path,
+                ]
+                os.execvpe(sys.executable, tracer_argv, tracer_env)
+            except FileNotFoundError:
+                os._exit(127)
+            except PermissionError:
+                os._exit(126)
+            except Exception:
+                os._exit(125)
+
+        # ============== PARENT after tracer fork ==============
+        # Parent doesn't keep the tracer's signalling write end;
+        # without closing it the read below would never see EOF
+        # if the tracer dies before signalling.
+        _close_safely(t_ready_w); t_ready_w = -1
+
+        # Wait for tracer to signal ready (or die).
+        ready = b""
+        try:
+            ready = os.read(t_ready_r, 1)
+        finally:
+            _close_safely(t_ready_r); t_ready_r = -1
+        if not ready:
+            # Tracer failed before signalling. Reap it for diag,
+            # kill the still-blocked target, raise.
+            tracer_status = None
+            try:
+                _, tracer_status = os.waitpid(tracer_pid, 0)
+                tracer_pid = -1
+            except (ChildProcessError, OSError):
+                pass
+            try:
+                _kill_and_reap(target_pid)
+                target_pid = -1
+            except Exception:
+                pass
+            rc_hint = ""
+            if (tracer_status is not None
+                    and os.WIFEXITED(tracer_status)):
+                rc_hint = (
+                    f" (tracer exit code "
+                    f"{os.WEXITSTATUS(tracer_status)})"
+                )
+            raise RuntimeError(
+                f"audit-mode tracer failed to attach to sandboxed "
+                f"child{rc_hint} — likely PTRACE_SEIZE rejected "
+                f"(Yama scope, container cap-drop, AppArmor)"
+            )
+
+        # Tracer attached. Tell the target it can proceed.
+        try:
+            os.write(p_go_w, b"G")
+        finally:
+            _close_safely(p_go_w); p_go_w = -1
+
+        # Drain stdio capture pipes while waiting for target exit.
+        # Simple sequential read since we don't expect huge stderr
+        # interleaved with stdout in the cc_profile / probe use
+        # cases. If a downstream consumer ever pumps GBs through
+        # stdout, switch to selectors.
+        stdout_bytes = stderr_bytes = b""
+        if capture_output:
+            try:
+                stdout_bytes = _read_to_eof(out_r)
+            finally:
+                _close_safely(out_r); out_r = -1
+            try:
+                stderr_bytes = _read_to_eof(err_r)
+            finally:
+                _close_safely(err_r); err_r = -1
+
+        # waitpid the target.
+        target_rc = -1
+        if timeout is not None:
+            import time
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                try:
+                    done, status = os.waitpid(target_pid, os.WNOHANG)
+                except (ChildProcessError, OSError):
+                    target_rc = -1
+                    break
+                if done != 0:
+                    if os.WIFEXITED(status):
+                        target_rc = os.WEXITSTATUS(status)
+                    elif os.WIFSIGNALED(status):
+                        target_rc = -os.WTERMSIG(status)
+                    target_pid = -1
+                    break
+                time.sleep(0.02)
+            else:
+                # Timed out — kill, then re-wait, then raise.
+                _kill_and_reap(target_pid)
+                target_pid = -1
+                # Tracer is PTRACE_O_EXITKILL'd — should die soon.
+                if tracer_pid > 0:
+                    _kill_and_reap(tracer_pid)
+                    tracer_pid = -1
+                raise subprocess.TimeoutExpired(
+                    cmd=list(cmd), timeout=timeout,
+                    output=stdout_bytes if text is False else (
+                        stdout_bytes.decode(errors="replace")
+                    ),
+                    stderr=stderr_bytes if text is False else (
+                        stderr_bytes.decode(errors="replace")
+                    ),
+                )
+        else:
+            try:
+                _, status = os.waitpid(target_pid, 0)
+                target_pid = -1
+                if os.WIFEXITED(status):
+                    target_rc = os.WEXITSTATUS(status)
+                elif os.WIFSIGNALED(status):
+                    target_rc = -os.WTERMSIG(status)
+            except (ChildProcessError, OSError):
+                pass
+
+        # Reap the tracer (PTRACE_O_EXITKILL means it exits when
+        # the target's pid leaves; should be fast).
+        if tracer_pid > 0:
+            try:
+                os.waitpid(tracer_pid, 0)
+                tracer_pid = -1
+            except (ChildProcessError, OSError):
+                pass
+
+        # Marshal output to the requested type.
+        if text:
+            stdout_out = stdout_bytes.decode(errors="replace")
+            stderr_out = stderr_bytes.decode(errors="replace")
+        else:
+            stdout_out = stdout_bytes
+            stderr_out = stderr_bytes
+
+        return subprocess.CompletedProcess(
+            args=list(cmd),
+            returncode=target_rc,
+            stdout=stdout_out if capture_output else None,
+            stderr=stderr_out if capture_output else None,
+        )
+    finally:
+        _cleanup_fds()
+        if target_pid > 0:
+            try:
+                _kill_and_reap(target_pid)
+            except Exception:
+                pass
+        if tracer_pid > 0:
+            try:
+                _kill_and_reap(tracer_pid)
+            except Exception:
+                pass
+        try:
+            os.unlink(config_path)
+        except OSError:
+            pass

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -1264,7 +1264,30 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
         # line ~620 ("case 2: CLI flag + internal helper without
         # output"). Firing the degradation warning for those calls is
         # noise.
+        # Probe whether the Landlock-only audit helper can engage on
+        # this host. When True, the spawn dispatch will route through
+        # ``_landlock_audit.run_landlock_audit`` instead of bare
+        # ``subprocess.run``, restoring observe signal. Suppress the
+        # degrade marker / warning in that case — audit IS engaging,
+        # just via a different mechanism. Probed eagerly here so the
+        # marker decision and the eventual dispatch agree on whether
+        # this run is "audit-degraded" or not.
+        _landlock_audit_eligible = False
         if nonlocal_audit_mode and not spawn_eligible:
+            try:
+                from .ptrace_probe import (
+                    check_ptrace_available as _la_pre_ptp,
+                )
+                from .seccomp import (
+                    check_seccomp_available as _la_pre_sca,
+                )
+                _landlock_audit_eligible = bool(
+                    _la_pre_sca() and _la_pre_ptp() and seccomp_profile
+                )
+            except ImportError:
+                _landlock_audit_eligible = False
+        if (nonlocal_audit_mode and not spawn_eligible
+                and not _landlock_audit_eligible):
             # Distinguish the actual root cause. PR #265 added two new
             # failure paths (B fallback, cache hit) — those provide
             # their own _b_fallback_reason; otherwise fall through to
@@ -1578,7 +1601,114 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                         _spawn_err,
                     )
             if not used_spawn:
-                result = subprocess.run(full_cmd, **kwargs)
+                # Audit/observe in Landlock-only mode: the bare
+                # subprocess.run path has no tracer-fork machinery,
+                # so audit silently degraded pre-PR. _landlock_audit
+                # restores observe signal here by forking a tracer
+                # subprocess in parallel with the target child.
+                # Engaged only when the operator asked for audit
+                # AND we have the prerequisites (libseccomp + ptrace);
+                # any failure path falls back cleanly to the bare
+                # subprocess.run below. mount-ns absent is acceptable
+                # — Landlock + seccomp + ptrace are sufficient for
+                # observe semantics; the THREAT_MODEL.md
+                # Landlock-only-mode warning still applies.
+                _audit_landlock_engaged = False
+                if nonlocal_audit_mode:
+                    try:
+                        from .ptrace_probe import (
+                            check_ptrace_available as _la_ptrace_check,
+                        )
+                        from .seccomp import (
+                            check_seccomp_available as _la_seccomp_check,
+                            _make_seccomp_preexec as _la_make_seccomp,
+                        )
+                        from .landlock import (
+                            _make_landlock_preexec as _la_make_landlock,
+                        )
+                        from . import _landlock_audit as _la
+                        if (_la_seccomp_check()
+                                and _la_ptrace_check()):
+                            # Build the rlimit-only preexec (no
+                            # Landlock — we install it separately
+                            # post-sync), the Landlock preexec, and
+                            # the seccomp preexec with audit_mode=True.
+                            _rlimit_only = _make_preexec_fn(
+                                effective_limits,
+                                writable_paths=None,
+                                readable_paths=None,
+                                allowed_tcp_ports=None,
+                            )
+                            _wp = list(writable_paths or [])
+                            if "/tmp" not in _wp:
+                                _wp.append("/tmp")
+                            _ll_preexec = _la_make_landlock(
+                                _wp,
+                                list(allowed_tcp_ports)
+                                    if allowed_tcp_ports else None,
+                                readable_paths=(
+                                    list(effective_read_paths)
+                                    if effective_read_paths else None
+                                ),
+                            )
+                            _sc_preexec = _la_make_seccomp(
+                                seccomp_profile,
+                                block_udp=seccomp_block_udp,
+                                audit_mode=True,
+                                observe_mode=bool(observe and nonlocal_audit_mode),
+                            ) if seccomp_profile else None
+                            _audit_run_dir_la = (
+                                audit_run_dir or output
+                            )
+                            try:
+                                result = _la.run_landlock_audit(
+                                    full_cmd,
+                                    audit_run_dir=str(_audit_run_dir_la),
+                                    audit_verbose=audit_verbose_active,
+                                    observe_mode=bool(observe and nonlocal_audit_mode),
+                                    observe_nonce=(
+                                        nonlocal_observe_nonce
+                                        if observe and nonlocal_audit_mode
+                                        else None
+                                    ),
+                                    writable_paths=writable_paths or [],
+                                    readable_paths=effective_read_paths or [],
+                                    allowed_tcp_ports=(
+                                        list(allowed_tcp_ports)
+                                        if allowed_tcp_ports else None
+                                    ),
+                                    target=target, output=output,
+                                    restrict_reads=restrict_reads,
+                                    landlock_preexec=_ll_preexec,
+                                    seccomp_preexec=_sc_preexec,
+                                    rlimit_preexec=_rlimit_only,
+                                    env=kwargs.get("env"),
+                                    cwd=kwargs.get("cwd"),
+                                    timeout=kwargs.get("timeout"),
+                                    capture_output=kwargs.get(
+                                        "capture_output", False),
+                                    text=kwargs.get("text", False),
+                                    stdin=kwargs.get("stdin"),
+                                    start_new_session=kwargs.get(
+                                        "start_new_session", True),
+                                )
+                                _audit_landlock_engaged = True
+                            except (RuntimeError, OSError) as _la_err:
+                                # Tracer fork failed — fall through
+                                # to plain subprocess.run. Operator
+                                # gets the existing degrade marker.
+                                logger.warning(
+                                    "Sandbox: Landlock-only audit "
+                                    "tracer failed (%s); falling back "
+                                    "to non-audit subprocess.run",
+                                    _la_err,
+                                )
+                    except ImportError:
+                        # Sandbox helpers missing — let the bare
+                        # path run.
+                        pass
+                if not _audit_landlock_engaged:
+                    result = subprocess.run(full_cmd, **kwargs)
         finally:
             events = (
                 proxy_instance.unregister_sandbox(proxy_token)
@@ -1618,9 +1748,16 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
         # to surface None and let the operator notice their probe
         # didn't engage. The sandbox-audit-degraded.json marker
         # explains why.
+        # Either the spawn-path engaged the tracer (mount-ns spawn
+        # OR macOS seatbelt) OR the Landlock-only audit helper did.
+        # Stamp the nonce in either case so the operator can pass
+        # it to parse_observe_log() for spoof-resistant parsing.
+        _audit_engaged_anywhere = (
+            spawn_eligible or _audit_landlock_engaged
+        )
         if (nonlocal_observe_nonce is not None
                 and nonlocal_audit_mode
-                and spawn_eligible):
+                and _audit_engaged_anywhere):
             result.sandbox_info["observe_nonce"] = nonlocal_observe_nonce
         else:
             result.sandbox_info["observe_nonce"] = None

--- a/core/sandbox/tests/test_observe_cli.py
+++ b/core/sandbox/tests/test_observe_cli.py
@@ -338,24 +338,14 @@ class TestE2EShim:
         if not shim.exists():
             pytest.skip(f"shim not present at {shim}")
 
-        # Skip if observe-mode prerequisites aren't met on this
-        # host. Mount-ns is the load-bearing one for Linux observe
-        # — without it the spawn falls back to the Landlock-only
-        # subprocess path which has no tracer-fork machinery, so
-        # observe degrades silently and the shim exits 70.
-        # GitHub-Actions Ubuntu 24.04+ runners ship with
-        # ``kernel.apparmor_restrict_unprivileged_userns=1`` set,
-        # which trips this skip — extending observe into the
-        # Landlock-only path is a separate (architectural) follow-up.
+        # Observe works under either path:
+        #   * mount-ns spawn (when available)
+        #   * Landlock-only audit fallback (Ubuntu 24.04+ default
+        #     where unprivileged user-ns is blocked by AppArmor)
+        # The Landlock-only path was added in PR-θ; mount-ns is no
+        # longer a hard prereq for observe.
         from core.sandbox.seccomp import check_seccomp_available
         from core.sandbox.ptrace_probe import check_ptrace_available
-        from core.sandbox.probes import (
-            check_net_available, check_mount_available,
-        )
-        if not check_net_available():
-            pytest.skip("user namespaces unavailable")
-        if not check_mount_available():
-            pytest.skip("mount-ns unavailable (apparmor_restrict_unprivileged_userns=1)")
         if not check_seccomp_available():
             pytest.skip("libseccomp unavailable")
         if not check_ptrace_available():
@@ -381,14 +371,9 @@ class TestE2EShim:
 
         from core.sandbox.seccomp import check_seccomp_available
         from core.sandbox.ptrace_probe import check_ptrace_available
-        from core.sandbox.probes import (
-            check_net_available, check_mount_available,
-        )
-        if not (check_net_available()
-                and check_mount_available()
-                and check_seccomp_available()
+        if not (check_seccomp_available()
                 and check_ptrace_available()):
-            pytest.skip("observe-mode prerequisites unavailable (mount-ns / libseccomp / ptrace)")
+            pytest.skip("observe-mode prerequisites unavailable (libseccomp / ptrace)")
 
         env = {**os.environ, "_RAPTOR_TRUSTED": "1"}
         result = subprocess.run(

--- a/core/sandbox/tests/test_observe_namespaces.py
+++ b/core/sandbox/tests/test_observe_namespaces.py
@@ -63,49 +63,42 @@ def _prereqs_met() -> tuple[bool, str]:
 class TestObserveUnderLandlockOnly(unittest.TestCase):
     """When mount-ns isn't available (Ubuntu 24.04+ default with
     ``apparmor_restrict_unprivileged_userns=1``), the sandbox falls
-    back to a Landlock-only ``subprocess.run`` path that does NOT
-    fork a tracer. Observe currently CANNOT engage in that path
-    because the tracer-fork machinery is wired through
-    ``_spawn.run_sandboxed`` (the mount-ns spawn entry).
+    back to a Landlock-only path. Observe IS supported there via
+    ``core.sandbox._landlock_audit.run_landlock_audit``, which
+    forks a tracer subprocess in parallel with the target without
+    needing a namespace setup.
 
-    This is a documented limitation — observe degrades gracefully
-    rather than failing loudly. The well-defined contract:
+    This test forces mount-ns "unavailable" via mocks so the
+    Landlock-only audit path engages on hosts where mount-ns is
+    actually present. The contract:
 
       * the spawned command still runs and returns its real exit code;
-      * a ``sandbox-audit-degraded.json`` marker lands in the run dir
-        explaining why audit didn't engage and how to fix;
-      * ``result.sandbox_info["observe_nonce"]`` is None to signal
-        "no provenance proof — observe didn't engage";
-      * no ``.sandbox-observe.jsonl`` is produced.
-
-    Full closure (extending the Landlock-only path with tracer-fork
-    support so cc_profile calibration works on Ubuntu 24.04+) is a
-    separate architectural follow-up; tracked outside this PR.
-
-    This test pins the documented degrade contract so a regression
-    that turned the silent degrade into a crash, or that re-enabled
-    observe under Landlock-only without testing it end-to-end, gets
-    caught."""
+      * ``result.sandbox_info["observe_nonce"]`` is populated;
+      * ``.sandbox-observe.jsonl`` is produced with observe records;
+      * NO ``sandbox-audit-degraded.json`` marker (audit IS engaging,
+        just via the Landlock-only path).
+    """
 
     def setUp(self):
         ok, reason = _prereqs_met()
         if not ok:
             self.skipTest(reason)
 
-    def test_observe_degrades_gracefully_when_mount_ns_unavailable(self):
+    def test_observe_engages_via_landlock_only_when_mount_ns_unavailable(self):
         from unittest.mock import patch
-        import json
         from core.sandbox import run as sandbox_run
-        from core.sandbox.observe_profile import OBSERVE_FILENAME
+        from core.sandbox.observe_profile import (
+            OBSERVE_FILENAME, parse_observe_log,
+        )
 
         with TemporaryDirectory() as d:
             run_dir = Path(d) / "observe-no-mount-ns"
             run_dir.mkdir()
 
             # Force the Landlock-only path — even if the test host
-            # has mount-ns available. We mock ``check_mount_available``
-            # too so the audit-degrade reason resolves to "mount-ns
-            # blocked by host" (the realistic Ubuntu 24.04+ case).
+            # has mount-ns available. We mock both probes (the
+            # spawn-side and context-side checks) so eligibility
+            # resolves the Ubuntu 24.04+ way.
             with patch("core.sandbox._spawn.mount_ns_available",
                        return_value=False), \
                  patch("core.sandbox.context.check_mount_available",
@@ -117,39 +110,45 @@ class TestObserveUnderLandlockOnly(unittest.TestCase):
                     capture_output=True, text=True, timeout=10,
                 )
 
-            # Contract 1: the spawned command exits cleanly.
+            # Contract 1: spawn succeeds.
             self.assertEqual(
                 result.returncode, 0,
-                f"true should exit 0 even when audit can't engage; "
+                f"true should exit 0; "
                 f"stderr={result.stderr!r}",
             )
 
-            # Contract 2: observe_nonce is None (audit didn't engage,
-            # so no provenance secret to surface).
-            self.assertIsNone(
-                result.sandbox_info.get("observe_nonce"),
-                "observe_nonce must be None when audit didn't engage",
+            # Contract 2: observe_nonce is populated — Landlock-only
+            # audit DID engage.
+            nonce = result.sandbox_info.get("observe_nonce")
+            self.assertIsNotNone(
+                nonce,
+                "observe_nonce must be populated when Landlock-only "
+                "audit engages",
             )
+            self.assertEqual(len(nonce), 32, "nonce is 128-bit hex")
 
-            # Contract 3: no observe log produced.
-            self.assertFalse(
-                (run_dir / OBSERVE_FILENAME).exists(),
-                "no JSONL should be written when observe degraded",
-            )
-
-            # Contract 4: a sandbox-audit-degraded.json marker
-            # explains the degrade. Operators inspecting an output
-            # dir can distinguish this from "audit ran, found
-            # nothing".
-            marker = run_dir / "sandbox-audit-degraded.json"
+            # Contract 3: observe log produced and parseable.
+            observe_log = run_dir / OBSERVE_FILENAME
             self.assertTrue(
-                marker.exists(),
-                f"degrade marker missing at {marker} — operator "
-                f"loses visibility into why audit didn't run",
+                observe_log.exists(),
+                f"observe log missing at {observe_log}",
             )
-            content = json.loads(marker.read_text())
-            self.assertIn("reason", content)
-            self.assertIn("mount-ns", content["reason"])
+            profile = parse_observe_log(
+                run_dir, expected_nonce=nonce,
+            )
+            self.assertGreater(
+                len(profile.paths_read) + len(profile.paths_stat),
+                0,
+                f"expected paths recorded; got profile={profile!r}",
+            )
+
+            # Contract 4: NO degrade marker (audit IS engaging).
+            marker = run_dir / "sandbox-audit-degraded.json"
+            self.assertFalse(
+                marker.exists(),
+                "Landlock-only audit engaged — no degrade marker "
+                "should land",
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/llm_analysis/tests/test_orchestrator.py
+++ b/packages/llm_analysis/tests/test_orchestrator.py
@@ -57,13 +57,23 @@ def _make_finding(finding_id, rule_id, file_path, start_line):
 def _make_cc_result(finding_id, exploitable=True, score=0.85):
     """Create a valid CC sub-agent result dict.
 
-    Fills every field weighted by ``core.llm.response_validation``'s
-    _FINDING_RESULT_WEIGHTS / _ANALYSIS_WEIGHTS tables so the
-    response's quality score lands above the 0.5 dispatch threshold.
-    Missing high-weight fields here previously trimmed the score to
-    ~0.48 → cc_dispatch flagged the response low-quality and
-    overrode is_exploitable to False, breaking the orchestrator's
-    exploitable-count assertion.
+    Two correctness contracts the validator + cc_dispatch enforce:
+
+    1. Every field weighted in ``core.llm.response_validation``'s
+       _FINDING_RESULT_WEIGHTS table needs a value (None is fine for
+       nullable fields). Missing high-weight fields drop the
+       quality score below 0.5 → cc_dispatch logs a low-quality
+       warning and may override is_exploitable.
+
+    2. Self-consistency: ``false_positive_reason`` MUST be None
+       when ``is_true_positive=True`` (a true positive is by
+       definition NOT a false positive). The validator at
+       packages.llm_analysis.validation flags otherwise.
+
+    This fixture sets is_true_positive=True regardless of
+    exploitability — a finding can be a true positive AND
+    not-exploitable (the bug is real but unreachable) — so
+    false_positive_reason stays None throughout.
     """
     return {
         "finding_id": finding_id,
@@ -88,7 +98,10 @@ def _make_cc_result(finding_id, exploitable=True, score=0.85):
             "input → query" if exploitable else None
         ),
         "remediation": "use parameterised queries" if exploitable else None,
-        "false_positive_reason": None if exploitable else "test fixture",
+        # ``is_true_positive=True`` above means this finding is NOT
+        # a false positive, so the reason field MUST be None — see
+        # contract (2) in the docstring.
+        "false_positive_reason": None,
         "impact": "data exfiltration" if exploitable else None,
         "prerequisites": (
             ["authenticated user"] if exploitable else None
@@ -99,7 +112,50 @@ def _make_cc_result(finding_id, exploitable=True, score=0.85):
 
 
 def _mock_subprocess_ok(results_by_call):
-    """Create a subprocess.run mock that returns results in order."""
+    """Create a subprocess.run mock that returns the right result
+    for each finding.
+
+    ``results_by_call`` may be either:
+
+    * a dict ``{finding_id: result_json}`` — preferred for parallel
+      dispatch, matched against the prompt the test passes via
+      ``input=`` kwarg;
+    * a list — legacy positional behaviour, returned in call order.
+
+    Parallel orchestration dispatches findings in non-deterministic
+    order; positional matching returns the WRONG result for the
+    wrong finding_id, the orchestrator then retries to correct, and
+    the retry mock returns clamped-to-last results which compounds
+    the mismatch. Dict-keyed matching is order-independent.
+    """
+    if isinstance(results_by_call, dict):
+        def mock_run_by_marker(cmd, **kwargs):
+            # Each dict key is a substring (e.g. file path) the
+            # caller picked because it appears in the prompt for
+            # exactly one finding. The build_analysis_prompt_bundle
+            # builder embeds rule_id / file_path / line info in the
+            # prompt, but NOT the synthetic ``finding_id`` the test
+            # uses for its own bookkeeping — match on something the
+            # prompt actually carries.
+            result = MagicMock()
+            result.returncode = 0
+            prompt = kwargs.get("input", "") or ""
+            chosen = None
+            for marker, payload in results_by_call.items():
+                if marker in prompt:
+                    chosen = payload
+                    break
+            if chosen is None:
+                # No marker matched — return the first entry so the
+                # orchestrator's retry logic still sees something
+                # parseable rather than crashing on empty stdout.
+                chosen = next(iter(results_by_call.values()))
+            result.stdout = chosen
+            result.stderr = ""
+            return result
+
+        return mock_run_by_marker
+
     call_count = [0]
 
     def mock_run(cmd, **kwargs):
@@ -196,10 +252,18 @@ class TestOrchestrate:
         report_path = tmp_path / "report.json"
         report_path.write_text(json.dumps(report))
 
-        cc_results = [
-            json.dumps(_make_cc_result("f-001", exploitable=True)),
-            json.dumps(_make_cc_result("f-002", exploitable=False, score=0.1)),
-        ]
+        # Dict-keyed mock so parallel dispatch returns the right
+        # result for each finding regardless of completion order.
+        # Keys must be substrings the analysis prompt embeds — the
+        # builder uses rule_id / file_path / line, NOT the synthetic
+        # finding_id this test assigns. ``db.py`` / ``template.js``
+        # are distinctive enough to identify each finding's prompt.
+        cc_results = {
+            "db.py": json.dumps(_make_cc_result("f-001", exploitable=True)),
+            "template.js": json.dumps(
+                _make_cc_result("f-002", exploitable=False, score=0.1)
+            ),
+        }
 
         with patch.dict(os.environ, {}, clear=True), \
              patch("packages.llm_analysis.orchestrator.shutil.which", return_value="/usr/bin/claude"), \

--- a/packages/llm_analysis/tests/test_orchestrator.py
+++ b/packages/llm_analysis/tests/test_orchestrator.py
@@ -55,17 +55,46 @@ def _make_finding(finding_id, rule_id, file_path, start_line):
 
 
 def _make_cc_result(finding_id, exploitable=True, score=0.85):
-    """Create a valid CC sub-agent result dict."""
+    """Create a valid CC sub-agent result dict.
+
+    Fills every field weighted by ``core.llm.response_validation``'s
+    _FINDING_RESULT_WEIGHTS / _ANALYSIS_WEIGHTS tables so the
+    response's quality score lands above the 0.5 dispatch threshold.
+    Missing high-weight fields here previously trimmed the score to
+    ~0.48 → cc_dispatch flagged the response low-quality and
+    overrode is_exploitable to False, breaking the orchestrator's
+    exploitable-count assertion.
+    """
     return {
         "finding_id": finding_id,
         "is_true_positive": True,
         "is_exploitable": exploitable,
         "exploitability_score": score,
+        "confidence": "high" if exploitable else "low",
         "severity_assessment": "high" if exploitable else "low",
+        "ruling": "exploitable" if exploitable else "not_exploitable",
         "reasoning": "Test reasoning",
         "attack_scenario": "Test scenario" if exploitable else None,
         "exploit_code": "# exploit" if exploitable else None,
         "patch_code": "# patch",
+        "cvss_vector": (
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+            if exploitable else None
+        ),
+        "cvss_score_estimate": 9.8 if exploitable else None,
+        "vuln_type": "sql_injection" if exploitable else None,
+        "cwe_id": "CWE-89" if exploitable else None,
+        "dataflow_summary": (
+            "input → query" if exploitable else None
+        ),
+        "remediation": "use parameterised queries" if exploitable else None,
+        "false_positive_reason": None if exploitable else "test fixture",
+        "impact": "data exfiltration" if exploitable else None,
+        "prerequisites": (
+            ["authenticated user"] if exploitable else None
+        ),
+        "tool": "test",
+        "rule_id": "test/rule",
     }
 
 


### PR DESCRIPTION
_landlock_audit forks tracer + target via os.fork() so the sync-pipe handshake works without subprocess.Popen's exec-wait deadlock. Restores observe signal on Ubuntu 24.04+ where unprivileged mount-ns is blocked by AppArmor; cc_profile calibration now works on those hosts. macOS network format validated empirically — kext path-string shape matches the existing parser regex.