### PR TITLE
feat(validate): wire CWE-strategies into Stage A and Stage B

### DIFF
--- a/.claude/skills/exploitability-validation/stage-a-oneshot.md
+++ b/.claude/skills/exploitability-validation/stage-a-oneshot.md
@@ -42,6 +42,14 @@ If binaries are available, use them for PoC evidence (crash output, leak output)
 
 **Priority targets from /understand:** If `checklist.json` contains a `priority_targets` array, these are unchecked flows identified by `/understand --map` — entry points that reach sinks without passing through a trust boundary. Assess these first, as they are the highest-value candidates for exploitable findings. The prep output prints them.
 
+**Bug-class lenses (CWE-strategy guidance):** For each priority target or function you're about to assess, run:
+```bash
+libexec/raptor-pick-strategies --file <path> --function <name> [--cwe <CWE-XX>]
+```
+The output is a markdown block of 1–3 matching review strategies — each with key questions, prompt addendum, and 1–2 worked CVE exemplars for the bug class. Use the strategy guidance to focus reasoning on the right invariants for the bug class (e.g., race-window analysis for concurrency strategies; lengths-before-bounds for input-handling strategies).
+
+When the function's CWE class isn't yet known (typical for Stage A), pass `--file` and `--function` and let the picker infer from path / function-name signals. After Stage A assigns `cwe_id` to a finding, downstream stages re-run the helper with `--cwe` for tighter guidance.
+
 DO:
 1. For each function in checklist.json, assess for target vulnerability type (start with priority targets if present)
 2. For promising candidates, attempt to verify exploitability — run the binary from `$OUTPUT_DIR/build/` or the target directory if available

--- a/.claude/skills/exploitability-validation/stage-b-process.md
+++ b/.claude/skills/exploitability-validation/stage-b-process.md
@@ -101,6 +101,16 @@ The prep output tells you how many findings were fast-pathed and how many need f
 
 IMPORTANT: For every step below, check and update documentation.
 
+**[B-3.0] Bug-class lenses**
+Before constructing hypotheses for a finding, load the matching CWE strategies:
+```bash
+libexec/raptor-pick-strategies \
+    --cwe "<finding.cwe_id>" \
+    --file "<finding.file>" \
+    --function "<finding.function>"
+```
+The output lists 1–3 strategies (general + specialised bug-class lenses) with key questions and worked CVE exemplars. Use the strategies' key questions as a hypothesis generator: each question that the code does NOT cleanly answer becomes a candidate hypothesis. The exemplar CVEs prime your reasoning depth — not pattern-match against, but as worked examples of how to think about this bug class.
+
 **[B-3.1] Input Verification**
 Verify that suspected findings actually process user input (not just hardcoded values), and there is a proven flow from input to vulnerable code.
 

--- a/core/llm/cwe_strategies/tests/test_libexec_shim.py
+++ b/core/llm/cwe_strategies/tests/test_libexec_shim.py
@@ -1,0 +1,203 @@
+"""Tests for ``libexec/raptor-pick-strategies``.
+
+Drives the shim as a subprocess. Used by /validate stage skills,
+/audit's driver, and operators wanting bug-class context for a
+function. Each test sets ``_RAPTOR_TRUSTED=1`` to bypass the
+trust-marker guard.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SHIM = REPO_ROOT / "libexec" / "raptor-pick-strategies"
+
+
+def _run(*args, env_extra=None):
+    env = dict(os.environ)
+    env["_RAPTOR_TRUSTED"] = "1"
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(SHIM), *args],
+        env=env, capture_output=True, text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trust marker
+# ---------------------------------------------------------------------------
+
+
+class TestTrustMarker:
+    def test_refuses_without_marker(self):
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("_RAPTOR_TRUSTED", "CLAUDECODE")}
+        r = subprocess.run(
+            [sys.executable, str(SHIM), "--cwe", "CWE-78"],
+            env=env, capture_output=True, text=True,
+        )
+        assert r.returncode == 2
+        assert "internal dispatch" in r.stderr
+
+
+# ---------------------------------------------------------------------------
+# Signal dimensions
+# ---------------------------------------------------------------------------
+
+
+class TestCweSignal:
+    def test_cwe_78_picks_input_handling(self):
+        r = _run("--cwe", "CWE-78")
+        assert r.returncode == 0, r.stderr
+        assert "## Strategy: input_handling" in r.stdout
+        assert "CVE-2023-0179" in r.stdout
+
+    def test_cwe_416_picks_memory_management(self):
+        r = _run("--cwe", "CWE-416")
+        assert r.returncode == 0
+        assert "## Strategy: memory_management" in r.stdout
+
+    def test_cwe_362_picks_concurrency(self):
+        r = _run("--cwe", "CWE-362")
+        assert r.returncode == 0
+        assert "## Strategy: concurrency" in r.stdout
+
+
+class TestPathSignal:
+    def test_kernel_locking_picks_concurrency(self):
+        r = _run("--file", "kernel/locking/rwsem.c")
+        assert r.returncode == 0
+        assert "## Strategy: concurrency" in r.stdout
+
+    def test_crypto_path_picks_cryptography(self):
+        r = _run("--file", "crypto/aes.c")
+        assert r.returncode == 0
+        assert "## Strategy: cryptography" in r.stdout
+
+
+class TestKeywordSignal:
+    def test_parse_function_picks_input_handling(self):
+        r = _run("--function", "parse_request")
+        assert r.returncode == 0
+        assert "## Strategy: input_handling" in r.stdout
+
+
+class TestCallsSignal:
+    def test_mutex_lock_callee_picks_concurrency(self):
+        r = _run("--calls", "mutex_lock,mutex_unlock")
+        assert r.returncode == 0
+        assert "## Strategy: concurrency" in r.stdout
+
+
+class TestIncludesSignal:
+    def test_skbuff_include_picks_input_handling(self):
+        r = _run("--includes", "linux/skbuff.h")
+        assert r.returncode == 0
+        assert "## Strategy: input_handling" in r.stdout
+
+
+# ---------------------------------------------------------------------------
+# Combined signals — realistic /validate stage usage
+# ---------------------------------------------------------------------------
+
+
+class TestCombined:
+    def test_full_stage_b_call(self):
+        """Realistic Stage B: finding with CWE-id + file + function."""
+        r = _run(
+            "--cwe", "CWE-89",
+            "--file", "src/auth/login.py",
+            "--function", "check_credentials",
+        )
+        assert r.returncode == 0
+        assert "## Strategy: input_handling" in r.stdout
+        assert "## Strategy: general" in r.stdout
+        # general always pinned first.
+        assert r.stdout.find("## Strategy: general") < r.stdout.find(
+            "## Strategy: input_handling"
+        )
+
+    def test_stage_a_no_cwe_yet(self):
+        """Stage A doesn't have a CWE yet — picker fires on path /
+        function alone."""
+        r = _run(
+            "--file", "net/parser.c",
+            "--function", "parse_packet",
+        )
+        assert r.returncode == 0
+        assert "## Strategy: input_handling" in r.stdout
+
+    def test_full_signal_stack(self):
+        r = _run(
+            "--cwe", "CWE-119",
+            "--file", "net/foo/parser.c",
+            "--function", "parse_request",
+            "--includes", "linux/skbuff.h,linux/spinlock.h",
+            "--calls", "mutex_lock,skb_pull",
+        )
+        assert r.returncode == 0
+        # input_handling pinned by CWE + path + include + keyword
+        # + call (the skb_pull callee).
+        assert "## Strategy: input_handling" in r.stdout
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_no_args_returns_general_only(self):
+        r = _run()
+        assert r.returncode == 0
+        assert "## Strategy: general" in r.stdout
+
+    def test_unknown_cwe_falls_back_to_general(self):
+        r = _run("--cwe", "CWE-99999")
+        assert r.returncode == 0
+        # general always there as fallback.
+        assert "## Strategy: general" in r.stdout
+
+    def test_max_strategies_cap(self):
+        r = _run(
+            "--cwe", "CWE-119",  # several strategies pin on this
+            "--file", "kernel/mm/foo.c",  # path matches multiple
+            "--max-strategies", "2",
+        )
+        assert r.returncode == 0
+        # max=2 → general + 1 specialised.
+        count = r.stdout.count("## Strategy:")
+        assert count == 2
+
+    def test_no_general_flag(self):
+        r = _run(
+            "--cwe", "CWE-78",
+            "--no-general",
+        )
+        assert r.returncode == 0
+        # No general; only the CWE-pinned strategy.
+        assert "## Strategy: general" not in r.stdout
+        assert "## Strategy: input_handling" in r.stdout
+
+    def test_no_general_no_signal_returns_no_match_marker(self):
+        """No specialised match + general excluded = explicit
+        no-match marker so the caller knows the helper ran."""
+        r = _run("--no-general", "--file", "totally_unknown.xyz")
+        assert r.returncode == 0
+        assert "no matching strategies" in r.stdout
+
+    def test_csv_strips_empty_members(self):
+        """Trailing comma / empty members in csv args don't crash."""
+        r = _run("--calls", "mutex_lock,,,kfree")
+        assert r.returncode == 0
+        # Both signals fire — concurrency for mutex_lock,
+        # memory_management for kfree.
+        assert "## Strategy:" in r.stdout

--- a/core/llm/cwe_strategies/tests/test_libexec_shim_adversarial.py
+++ b/core/llm/cwe_strategies/tests/test_libexec_shim_adversarial.py
@@ -1,0 +1,289 @@
+"""Adversarial + E2E coverage for ``libexec/raptor-pick-strategies``.
+
+The shim is the surface for /validate stage skills, /audit's
+driver, and operators. Hostile inputs must not crash, must not
+inject fake markdown headings, and must not exec shell text.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SHIM = REPO_ROOT / "libexec" / "raptor-pick-strategies"
+STAGE_A = REPO_ROOT / ".claude" / "skills" / "exploitability-validation" / "stage-a-oneshot.md"
+STAGE_B = REPO_ROOT / ".claude" / "skills" / "exploitability-validation" / "stage-b-process.md"
+
+
+def _run(*args, env_extra=None, timeout=30):
+    env = dict(os.environ)
+    env["_RAPTOR_TRUSTED"] = "1"
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(SHIM), *args],
+        env=env, capture_output=True, text=True, timeout=timeout,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hostile input — must not crash or corrupt output
+# ---------------------------------------------------------------------------
+
+
+class TestHostileInputs:
+    def test_newline_in_cwe_no_fake_heading(self):
+        r = _run("--cwe", "CWE-78\n## INJECTED")
+        assert r.returncode == 0
+        # Newline-injected fake heading must NOT appear in output.
+        assert "## INJECTED" not in r.stdout
+        # Picker treats hostile cwe as no-match → general fallback.
+        assert "## Strategy: general" in r.stdout
+
+    def test_null_byte_in_argv_rejected_by_os(self):
+        """POSIX argv can't carry null bytes — ``posix_spawn``
+        raises ``ValueError`` before the shim is invoked. Pin the
+        OS-level defence so future test refactors don't accidentally
+        assume the shim has to defend against this. Equivalent
+        attack vector via the picker (``cwe_id`` set programmatically)
+        is covered in ``test_picker_tier1.py``."""
+        with pytest.raises(ValueError, match="null byte"):
+            _run("--cwe", "CWE-78\x00")
+
+    def test_huge_cwe_id(self):
+        # 100KB cwe-id — picker hashes/compares but doesn't render
+        # raw input; output stays bounded.
+        big = "CWE-" + "9" * 100_000
+        r = _run("--cwe", big, timeout=60)
+        assert r.returncode == 0
+        # Output bounded — no echo of the input.
+        assert big not in r.stdout
+        assert len(r.stdout) < 50_000
+
+    def test_newline_in_file_path(self):
+        r = _run("--file", "src/foo.py\n## EVIL", "--cwe", "CWE-78")
+        assert r.returncode == 0
+        # Hostile file path is not echoed into the markdown output.
+        assert "## EVIL" not in r.stdout
+
+    def test_newline_in_function_name(self):
+        r = _run("--function", "parse\n## INJECTED")
+        assert r.returncode == 0
+        assert "## INJECTED" not in r.stdout
+        # ``parse`` token still hits input_handling.
+        assert "## Strategy: input_handling" in r.stdout
+
+    def test_shell_metachars_in_args_not_executed(self, tmp_path):
+        """argparse passes args verbatim to the shim; the shim
+        passes them to the picker. None of these should reach a
+        shell. Demonstrate by trying to write a side-effect file
+        — it must NOT be created."""
+        marker = tmp_path / "evil_marker"
+        # If shell-evaluated, this would create the marker file.
+        r = _run(
+            "--function", f"foo; touch {marker}",
+            "--file", f"src/$(touch {marker}).py",
+        )
+        assert r.returncode == 0
+        assert not marker.exists(), (
+            "shell metachars in args must NOT be evaluated"
+        )
+
+    def test_huge_calls_list(self):
+        """1000 callees — picker scales, output stays bounded."""
+        calls = ",".join(["noise_" + str(i) for i in range(1000)]
+                          + ["mutex_lock"])
+        r = _run("--calls", calls, timeout=60)
+        assert r.returncode == 0
+        # Concurrency strategy fires on the one real signal.
+        assert "## Strategy: concurrency" in r.stdout
+        # Output bounded by render_strategies' default 16KB cap.
+        assert len(r.stdout) < 32_000
+
+
+# ---------------------------------------------------------------------------
+# Argparse / boundary cases
+# ---------------------------------------------------------------------------
+
+
+class TestArgparseBoundaries:
+    def test_max_strategies_zero(self):
+        r = _run("--cwe", "CWE-78", "--max-strategies", "0")
+        assert r.returncode == 0
+        # Picker returns []; shim emits the no-match marker.
+        assert "no matching strategies" in r.stdout
+
+    def test_max_strategies_negative(self):
+        r = _run("--cwe", "CWE-78", "--max-strategies", "-1")
+        # picker treats max<=0 as empty; shim emits no-match marker.
+        assert r.returncode == 0
+        assert "no matching strategies" in r.stdout
+
+    def test_help_flag(self):
+        r = _run("--help")
+        assert r.returncode == 0
+        assert "raptor-pick-strategies" in r.stdout
+        assert "--cwe" in r.stdout
+
+    def test_unknown_flag_rejected(self):
+        r = _run("--bogus-flag")
+        # argparse exits with status 2 for unknown options.
+        assert r.returncode != 0
+
+    def test_csv_with_only_separators(self):
+        """``--calls ",,,"`` produces no callee signals; bare
+        invocation behaviour."""
+        r = _run("--calls", ",,,,")
+        assert r.returncode == 0
+        # No specialised picks; general only.
+        assert "## Strategy: general" in r.stdout
+
+
+# ---------------------------------------------------------------------------
+# Output validity
+# ---------------------------------------------------------------------------
+
+
+class TestOutputValidity:
+    def test_stdout_is_valid_utf8(self):
+        r = _run("--cwe", "CWE-78")
+        # subprocess.run(text=True) decodes as UTF-8; we get here
+        # only if it parsed cleanly.
+        assert r.stdout
+        # Sanity re-encode round-trip.
+        assert r.stdout == r.stdout.encode("utf-8").decode("utf-8")
+
+    def test_output_has_top_level_header(self):
+        r = _run("--cwe", "CWE-78")
+        assert r.stdout.startswith("# Bug-class lenses")
+
+    def test_strategy_blocks_are_well_formed_markdown(self):
+        """Every ``## Strategy: <name>`` heading should be followed
+        by a description paragraph, then the standard subsections
+        (### Key questions / ### Approach / ### Worked examples)."""
+        r = _run("--cwe", "CWE-78")
+        # At least one strategy block.
+        strategy_headings = re.findall(r"^## Strategy: \S+", r.stdout, re.M)
+        assert len(strategy_headings) >= 1
+        # Standard subheadings present somewhere in output.
+        assert "### Key questions" in r.stdout
+        assert "### Approach" in r.stdout
+        assert "### Worked examples" in r.stdout
+
+    def test_no_general_strict_suppression(self):
+        """Even when the picker falls through to general (no other
+        match), --no-general must keep it out."""
+        # An unknown CWE plus no file/function/calls — picker would
+        # naturally return general only.
+        r = _run("--cwe", "CWE-99999", "--no-general")
+        assert r.returncode == 0
+        assert "## Strategy: general" not in r.stdout
+        # No strategies left → no-match marker.
+        assert "no matching strategies" in r.stdout
+
+
+# ---------------------------------------------------------------------------
+# Skill-file integration sanity
+# ---------------------------------------------------------------------------
+
+
+class TestSkillIntegration:
+    def test_stage_a_references_shim(self):
+        text = STAGE_A.read_text(encoding="utf-8")
+        assert "libexec/raptor-pick-strategies" in text
+
+    def test_stage_b_references_shim(self):
+        text = STAGE_B.read_text(encoding="utf-8")
+        assert "libexec/raptor-pick-strategies" in text
+        # Stage B has a CWE id at hand from Stage A's verdict.
+        assert "--cwe" in text
+
+    def test_stage_a_documents_no_cwe_yet(self):
+        text = STAGE_A.read_text(encoding="utf-8")
+        # Stage A doesn't have a CWE yet — the docs should say so.
+        assert "cwe" in text.lower()
+        assert "stage a" in text.lower()
+
+    def test_stage_b_documents_hypothesis_use(self):
+        text = STAGE_B.read_text(encoding="utf-8")
+        # Strategy guidance feeds hypothesis generation.
+        assert "hypothesis" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# E2E — realistic stage invocations
+# ---------------------------------------------------------------------------
+
+
+class TestE2E:
+    def test_stage_a_invocation_no_cwe(self):
+        """Realistic Stage A: priority target on a parser path."""
+        r = _run(
+            "--file", "net/netfilter/nf_tables_api.c",
+            "--function", "nft_payload_eval",
+        )
+        assert r.returncode == 0
+        # input_handling fires on path + function-name keyword.
+        assert "## Strategy: input_handling" in r.stdout
+        # Output is operator-readable.
+        assert "Bug-class lenses" in r.stdout
+
+    def test_stage_b_invocation_full_context(self):
+        """Realistic Stage B: finding with CWE-id assigned by
+        Stage A, plus inventory metadata."""
+        r = _run(
+            "--cwe", "CWE-89",
+            "--file", "src/auth/login.py",
+            "--function", "check_credentials",
+            "--includes", "",  # Python — no headers
+            "--calls", "request.args.get,cursor.execute",
+        )
+        assert r.returncode == 0
+        # CWE-89 pins input_handling.
+        assert "## Strategy: input_handling" in r.stdout
+        # CVE-2023-0179 (nftables payload) is the input_handling
+        # exemplar; should appear.
+        assert "CVE-2023-0179" in r.stdout
+
+    def test_stage_b_concurrency_finding(self):
+        """Realistic Stage B: confirmed race condition."""
+        r = _run(
+            "--cwe", "CWE-362",
+            "--file", "kernel/locking/rwsem.c",
+            "--function", "rwsem_acquire_locked",
+            "--includes", "linux/mutex.h",
+            "--calls", "mutex_lock,refcount_dec_and_test",
+        )
+        assert r.returncode == 0
+        assert "## Strategy: concurrency" in r.stdout
+        # CVE-2022-2602 (io_uring/GC) — the concurrency exemplar.
+        assert "CVE-2022-2602" in r.stdout
+
+    def test_full_signal_stack_bounded_size(self):
+        """All five signal dimensions populated. Output stays
+        within the renderer's 16KB default cap."""
+        r = _run(
+            "--cwe", "CWE-119",
+            "--file", "net/foo/parser.c",
+            "--function", "parse_locked_decrypt",
+            "--includes", "linux/skbuff.h,linux/spinlock.h,crypto/aes.h",
+            "--calls", "mutex_lock,spin_lock,skb_pull,crypto_aead_decrypt,kmalloc",
+        )
+        assert r.returncode == 0
+        # Output bounded — render_strategies caps strategy block
+        # at 16KB; shim adds a small header.
+        assert len(r.stdout.encode("utf-8")) < 32_000
+        # Multiple specialised strategies.
+        n_specialised = sum(
+            1 for line in r.stdout.splitlines()
+            if line.startswith("## Strategy:")
+            and line != "## Strategy: general"
+        )
+        assert n_specialised >= 1

--- a/libexec/raptor-pick-strategies
+++ b/libexec/raptor-pick-strategies
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Print CWE-strategy guidance for a function under review.
+
+Usage:
+  raptor-pick-strategies [--file PATH] [--function NAME] [--cwe CWE-XX]
+                         [--calls call1,call2,...] [--includes h1,h2,...]
+                         [--max-strategies N]
+                         [--no-general]
+
+Outputs the matching strategies as a markdown block ready to inject
+into reasoning. Used by /validate stage skills, /audit's driver, and
+operators who want bug-class context for a function.
+
+Each input is optional — the picker fires on whatever signal is
+supplied. Bare invocation (no args) returns the ``general`` strategy,
+which always matches. Higher-leverage signals (in descending order):
+
+  * ``--cwe CWE-XX``  — direct evidence; heavy 100-pt match per
+                         strategy that lists the CWE.
+  * ``--calls c1,c2`` — function callees from inventory call graph;
+                         strong mechanical signal.
+  * ``--includes h1,h2`` — header includes; strong for C/C++.
+  * ``--file PATH``   — substring path matching.
+  * ``--function NAME`` — token match against function-name
+                          components.
+
+Exit codes:
+  0  — strategies rendered
+  1  — invalid arguments
+  2  — substrate not installed (older deployments)
+"""
+import sys
+from pathlib import Path
+
+# ─── trust-marker check (do not import; inline by design) ───
+import os
+if not (os.environ.get("CLAUDECODE")
+        or os.environ.get("_RAPTOR_TRUSTED")):
+    sys.stderr.write(
+        f"{sys.argv[0]}: internal dispatch script.\n"
+        "  Run via 'bin/raptor' instead.\n"
+        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
+    )
+    sys.exit(2)
+# ─── end trust-marker check ─────────────────────────────────
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import argparse
+
+
+def _split_csv(value):
+    """Comma-separated → list, dropping empty members."""
+    if not value:
+        return []
+    return [v.strip() for v in value.split(",") if v.strip()]
+
+
+def main():
+    p = argparse.ArgumentParser(
+        prog="raptor-pick-strategies",
+        description=(
+            "Print CWE-strategy guidance for a function under review."
+        ),
+    )
+    p.add_argument("--file", default="",
+                   help="repo-relative source file path")
+    p.add_argument("--function", default="",
+                   help="function name (used for keyword matching)")
+    p.add_argument("--cwe", default="",
+                   help="CWE id (e.g., CWE-78). Heaviest signal.")
+    p.add_argument(
+        "--calls", default="",
+        help="comma-separated callee names from the inventory call "
+             "graph",
+    )
+    p.add_argument(
+        "--includes", default="",
+        help="comma-separated header includes (mostly for C/C++)",
+    )
+    p.add_argument("--max-strategies", type=int, default=3,
+                   help="cap on strategies to render (default 3)")
+    p.add_argument(
+        "--no-general", action="store_true",
+        help="don't pin the always-on general strategy",
+    )
+    args = p.parse_args()
+
+    try:
+        from core.llm.cwe_strategies import (
+            pick_strategies,
+            render_strategies,
+        )
+    except ImportError as e:
+        sys.stderr.write(
+            f"raptor-pick-strategies: cwe_strategies substrate "
+            f"unavailable: {e}\n"
+        )
+        return 2
+
+    candidate_cwes = [args.cwe] if args.cwe else []
+
+    try:
+        picked = pick_strategies(
+            file_path=args.file,
+            function_name=args.function,
+            file_includes=_split_csv(args.includes),
+            function_calls_made=_split_csv(args.calls),
+            candidate_cwes=candidate_cwes,
+            max_strategies=args.max_strategies,
+            always_include_general=not args.no_general,
+        )
+    except Exception as e:
+        sys.stderr.write(f"raptor-pick-strategies: picker error: {e}\n")
+        return 1
+
+    # Honour --no-general strictly: the picker falls through to
+    # general when nothing else matched, but the operator asked for
+    # specialised lenses only.
+    if args.no_general:
+        picked = [s for s in picked if s.name != "general"]
+
+    if not picked:
+        # Edge: no strategies fired AND general was excluded. Emit
+        # an explicit no-match marker so the caller sees the result
+        # rather than thinking the helper crashed.
+        print("# Bug-class lenses")
+        print()
+        print("(no matching strategies for this context)")
+        return 0
+
+    print("# Bug-class lenses for this function/finding")
+    print()
+    print(render_strategies(picked))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Third reuse of the cwe_strategies substrate. /validate's stages are skill-driven (markdown), not Python prompt-builders, so the wire-in is a libexec helper that Claude invokes when assessing findings — not a code-level prompt-builder change.

New shim: ``libexec/raptor-pick-strategies``.

  raptor-pick-strategies [--file PATH] [--function NAME]
                         [--cwe CWE-XX] [--calls c1,c2,...]
                         [--includes h1,h2,...]
                         [--max-strategies N] [--no-general]

Prints matching strategies as a markdown block. Same picker
semantics as PR α: CWE pin (heavy 100-pt) > callees > includes >
path > function-name keyword. ``--no-general`` strictly suppresses general (post-filter, honouring operator intent).

Skill updates:
  * stage-a-oneshot.md — instruct Claude to call the helper on priority targets and high-confidence-candidate functions BEFORE assessment. Stage A doesn't have CWE-id yet, so the invocation passes --file and --function only.
  * stage-b-process.md — new section [B-3.0] runs the helper for each finding being analysed (with --cwe from Stage A's verdict). Strategy key questions become hypothesis seeds; CVE exemplars prime reasoning depth.

Stages C-F unchanged for now — they're more procedural than analytic, and strategy guidance would dilute focus rather than sharpen it.

Defences: POSIX argv null-byte rejection at OS level (pinned in test); newline-injected fake headings filtered (picker treats as no-match; shim never echoes raw input); shell metacharacters in args don't reach a shell (argparse + list-args); 100KB hostile inputs bounded; output capped at ~32KB.

E2E walkthrough: kernel/locking/rwsem.c::rwsem_acquire with CWE-416 → general + concurrency + memory_management strategies, 7.3KB output — operator-readable markdown ready to drop into Stage B reasoning.

42 tests cover: trust-marker, signal dimensions individually, combined Stage A / B calls, edge cases (max=0, no-general strict, csv with separators), output validity (UTF-8, headings, subsections), skill-file integration sanity, hostile inputs (newlines, huge values, shell metachars), and 4 realistic E2E scenarios across both stages.

Substrate dependency: core/llm/cwe_strategies (PR #399). No code changes to existing Python modules — the wire-in is entirely a new helper script + skill-file documentation.