### PR TITLE
perf(sandbox/proxy): DNS cache, happy-eyeballs, snapshot fan-out

### DIFF
--- a/core/sandbox/proxy.py
+++ b/core/sandbox/proxy.py
@@ -76,7 +76,14 @@ import logging
 import socket
 import threading
 import time
-from typing import Iterable, List, Optional, Set
+from typing import Iterable, List, Optional, Set, Tuple
+
+# Module-top so the import doesn't run on every CONNECT — the proxy
+# tunnel handler used to do `from core.security.log_sanitisation
+# import has_nonprintable` inline on the hot path. Cached after the
+# first call but still a dict lookup + module attribute access per
+# request.
+from core.security.log_sanitisation import has_nonprintable
 
 logger = logging.getLogger(__name__)
 
@@ -84,8 +91,30 @@ logger = logging.getLogger(__name__)
 # constructor kwargs but the defaults are deliberately conservative.
 _DEFAULT_IDLE_TIMEOUT = 300.0        # seconds of silence before forced close
 _DEFAULT_TOTAL_TIMEOUT = 3600.0      # absolute cap on a single tunnel
-_DEFAULT_MAX_TUNNELS = 64            # concurrent CONNECT tunnels
+# Concurrent CONNECT tunnels. 64 was the original conservative default
+# but bursty resolvers (npm install with its parallel HTTP agent +
+# keep-alive lingering) can push past it on transitively-deep manifests,
+# get refused, and stall the scan past timeout. 256 keeps the
+# resource-exhaustion ceiling tight while leaving headroom for the
+# bursts we observed in the SCA stress harness (2026-05-09).
+_DEFAULT_MAX_TUNNELS = 256
 _DEFAULT_BUFFER_SIZE = 64 * 1024     # relay buffer per direction
+
+# DNS cache TTL. Holds (expires_at, addrinfo_list) per (host, port,
+# socktype) key. 60s is a balance: short enough that a legit DNS
+# rotation propagates within a normal scan run, long enough that the
+# typical npm/pip-style burst (dozens of CONNECTs to one registry host
+# in seconds) only pays the resolver cost once. Gate 2 (resolved-IP
+# block) still runs against the cached IP on every CONNECT, so a
+# DNS-rebinding attack window doesn't widen.
+_DNS_CACHE_TTL = 60.0
+
+# Happy-eyeballs per-attempt budget. RFC 8305 recommends 250ms
+# before kicking off the next address family's attempt. We keep that
+# default — it matches the broad assumption Linux/macOS/Windows
+# stacks already use, so behaviour stays predictable for operators
+# who are used to OS-level happy-eyeballs.
+_HAPPY_EYEBALLS_DELAY = 0.25
 
 # Canonical filename for the per-run proxy events JSONL. Written by
 # context.py (post-sandbox flush of unregister_sandbox events). Defined
@@ -271,6 +300,33 @@ def _host_in_no_proxy(host: str, patterns: list) -> bool:
     return False
 
 
+def _split_addrinfo_by_family(
+    addrinfo: list,
+) -> Tuple[list, list]:
+    """Partition an addrinfo list into (v6, v4) buckets, preserving
+    each bucket's internal order.
+
+    Happy-eyeballs (RFC 8305) prefers attempting IPv6 first because
+    when v6 works it usually has the better path; v4 is the fallback
+    if v6 stalls. Splitting by family lets the dialer race one
+    address from each bucket in parallel rather than walking the
+    full list serially with a 10s OS timeout per attempt — which is
+    what bites npm-style burst traffic when an upstream's first
+    addrinfo entry happens to be an IPv6 address the local link
+    can't reach.
+    """
+    v6, v4 = [], []
+    for entry in addrinfo:
+        family = entry[0]
+        if family == socket.AF_INET6:
+            v6.append(entry)
+        elif family == socket.AF_INET:
+            v4.append(entry)
+        # Other families (AF_UNIX etc) ignored — getaddrinfo with
+        # SOCK_STREAM on a hostname won't yield them in practice.
+    return v6, v4
+
+
 class EgressProxy:
     """HTTPS CONNECT proxy with hostname allowlist.
 
@@ -331,6 +387,14 @@ class EgressProxy:
         # matching a pattern bypasses the upstream and connects directly
         # (so internal services like git-server.corp remain reachable).
         self._no_proxy_patterns: list = _parse_no_proxy(no_proxy)
+        # Per-(host, port, socktype) DNS cache. Map key → (expires_at,
+        # addrinfo_list). Bursty resolvers (npm install, pip-compile)
+        # hit the same registry host dozens of times in seconds; without
+        # caching, each CONNECT pays a fresh getaddrinfo. The cache lives
+        # only on the proxy's event-loop thread so no lock is needed —
+        # asyncio is single-threaded and reads/writes serialise on the
+        # loop.
+        self._dns_cache: dict = {}
         # Event ring buffer for observability. Each entry is a dict:
         #   {"t": monotonic_seconds, "host": str, "port": int,
         #    "result": one of _PROXY_EVENT_RESULTS (see module-level
@@ -355,6 +419,22 @@ class EgressProxy:
         self._sandbox_labels: dict = {}
         self._next_token = 0
         self._buffer_lock = threading.Lock()
+        # Atomic snapshot of the buffer-list refs for the hot path.
+        # `_record` is called once per CONNECT and used to acquire
+        # `_buffer_lock` to iterate `_sandbox_buffers.values()`. Under
+        # bursty traffic that single lock serialises every recorder.
+        # The snapshot is a tuple — re-bound (atomic ref-write under
+        # CPython's GIL) by register/unregister inside the lock; the
+        # hot path reads the tuple ref without the lock and iterates
+        # to append. Race window: between snapshot read and append, a
+        # concurrent unregister may have popped a buffer; the append
+        # still lands on that orphaned list. The unregistered caller's
+        # returned events are a defensive copy taken at unregister
+        # time, so the late append is silently dropped from the
+        # caller's view — same end-state as the previous design where
+        # the late event would have been recorded into a buffer the
+        # caller had already left behind.
+        self._sandbox_buffers_snapshot: Tuple[list, ...] = ()
 
         # Synchronise startup: the thread runs the asyncio loop and signals
         # `_ready` once the server is bound and port is known. The calling
@@ -470,6 +550,9 @@ class EgressProxy:
             token = self._next_token
             self._sandbox_buffers[token] = []
             self._sandbox_labels[token] = caller_label
+            self._sandbox_buffers_snapshot = tuple(
+                self._sandbox_buffers.values()
+            )
             return token
 
     def unregister_sandbox(self, token: int) -> List[dict]:
@@ -491,10 +574,18 @@ class EgressProxy:
         with self._buffer_lock:
             events = self._sandbox_buffers.pop(token, [])
             label = self._sandbox_labels.pop(token, None)
-        # Copy + stamp outside the lock — `events` is no longer in
-        # `_sandbox_buffers` so _record won't touch it. Still, other
-        # tunnel handlers may be mutating the underlying dict
-        # references via `event.update(...)` — we copy defensively.
+            self._sandbox_buffers_snapshot = tuple(
+                self._sandbox_buffers.values()
+            )
+        # Copy + stamp outside the lock. The snapshot has been refreshed
+        # so _record's hot-path readers won't pick up this buffer
+        # anymore. A late append from a tunnel handler that already
+        # snapshotted the OLD tuple may still land on `events`, but
+        # since the iteration below is the only consumer that sees this
+        # list, the late append is silently dropped from the caller's
+        # returned view (CPython list iteration tolerates concurrent
+        # appends without raising). Caller's audit trail remains
+        # consistent with the snapshot-at-unregister-time semantics.
         if label is not None:
             return [{**e, "caller": label} for e in events]
         return [dict(e) for e in events]
@@ -514,10 +605,163 @@ class EgressProxy:
         No-op when no sandbox is registered (rare — means the proxy is
         processing a CONNECT that happened outside any register /
         unregister window, e.g. during proxy shutdown).
+
+        Lock-free hot path: reads `_sandbox_buffers_snapshot` (atomic
+        ref-read under the GIL) and iterates without acquiring
+        `_buffer_lock`. Append to a Python list is atomic per the GIL.
+        Under bursty traffic this avoids serialising every recorder on
+        a single mutex shared with register/unregister.
         """
-        with self._buffer_lock:
-            for buf in self._sandbox_buffers.values():
-                buf.append(event)
+        for buf in self._sandbox_buffers_snapshot:
+            buf.append(event)
+
+    async def _cached_getaddrinfo(self, host: str, port: int) -> list:
+        """Resolve `host:port` with a TTL cache.
+
+        On the proxy event-loop thread; no lock needed (asyncio is
+        single-threaded and the cache dict is only touched from this
+        thread). Cache miss → call `loop.getaddrinfo` and stash the
+        result with `now + _DNS_CACHE_TTL` as expiry. Cache hit →
+        return the stored addrinfo list directly.
+
+        Cache is bounded by the natural diversity of (host, port)
+        pairs the sandboxed children touch — typically a handful of
+        registry hosts per scan. We do not LRU-evict; entries simply
+        expire by TTL. If a future workload generates an unbounded
+        host set, add a max-entries cap here.
+
+        Errors are NOT cached — getaddrinfo failures are usually
+        transient (DNS hiccup, brief network glitch) and caching
+        NXDOMAIN would amplify the outage's impact for as long as the
+        TTL.
+        """
+        key = (host, port)
+        now = time.monotonic()
+        cached = self._dns_cache.get(key)
+        if cached is not None and cached[0] > now:
+            return cached[1]
+        addrinfo = await asyncio.wait_for(
+            self._loop.getaddrinfo(host, port, type=socket.SOCK_STREAM),
+            timeout=10.0,
+        )
+        self._dns_cache[key] = (now + _DNS_CACHE_TTL, addrinfo)
+        return addrinfo
+
+    async def _happy_eyeballs_connect(
+        self, addrinfo: list, port: int,
+    ) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter, str]:
+        """RFC 8305 happy-eyeballs dial across an addrinfo list.
+
+        Returns ``(reader, writer, dialed_ip)`` for the first address
+        that connects. Cancels the loser. Falls back to the original
+        sequential walk if the addrinfo list has only one family
+        (no race needed).
+
+        Why this matters: the previous code did
+        ``asyncio.open_connection(host=addrinfo[0][4][0], ...)`` and
+        ate a 10s ``asyncio.wait_for`` per attempt. When a host's
+        first record is an IPv6 address the local link can't reach,
+        the entire CONNECT stalled 10s before failing. Under bursty
+        npm traffic that's a wallclock catastrophe. Happy-eyeballs
+        kicks off the v4 attempt 250ms after v6 starts; whichever
+        wins wins, and the loser is cancelled.
+
+        Gate-2 (resolved-IP block) is re-applied per attempt — a
+        DNS-poisoned response that returns one good and one bad IP
+        won't slip the bad one in via the race.
+        """
+        v6, v4 = _split_addrinfo_by_family(addrinfo)
+
+        # Single-family path: no race needed, just walk in order.
+        if not v6 or not v4:
+            ordered = v6 if v6 else v4
+            last_exc: Optional[Exception] = None
+            for entry in ordered:
+                family, socktype, proto, _, sockaddr = entry
+                ip = sockaddr[0]
+                if _ip_is_blocked(ip):
+                    last_exc = OSError(f"IP {ip} blocked by gate 2")
+                    continue
+                try:
+                    reader, writer = await asyncio.wait_for(
+                        asyncio.open_connection(host=ip, port=port,
+                                                 family=family),
+                        timeout=10.0,
+                    )
+                    return reader, writer, ip
+                except (OSError, asyncio.TimeoutError) as e:
+                    last_exc = e
+                    continue
+            raise last_exc if last_exc is not None else OSError(
+                "no addresses to dial"
+            )
+
+        # Dual-family: race v6 first, kick v4 _HAPPY_EYEBALLS_DELAY later.
+        # Take the first connector to succeed; cancel the other. Note
+        # we only race the FIRST address of each family — if both fail
+        # we then walk the rest serially as a single-family fallback.
+        # (Most upstream registries return one address per family, so
+        # the common case is exactly two attempts.)
+        async def _attempt(entry):
+            family, socktype, proto, _, sockaddr = entry
+            ip = sockaddr[0]
+            if _ip_is_blocked(ip):
+                raise OSError(f"IP {ip} blocked by gate 2")
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(host=ip, port=port,
+                                         family=family),
+                timeout=10.0,
+            )
+            return reader, writer, ip
+
+        v6_task = asyncio.ensure_future(_attempt(v6[0]))
+        v4_task: Optional[asyncio.Task] = None
+
+        try:
+            done, pending = await asyncio.wait(
+                {v6_task},
+                timeout=_HAPPY_EYEBALLS_DELAY,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            # If v6 finished within the delay (success OR failure), and
+            # it succeeded, take it. If it failed, race v4 directly.
+            if v6_task in done:
+                try:
+                    return v6_task.result()
+                except (OSError, asyncio.TimeoutError):
+                    return await _attempt(v4[0])
+            # v6 still pending after delay: kick off v4 in parallel.
+            v4_task = asyncio.ensure_future(_attempt(v4[0]))
+            done, pending = await asyncio.wait(
+                {v6_task, v4_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            # First to finish — if it succeeded, take it; if it failed,
+            # wait on the other.
+            for t in done:
+                try:
+                    result = t.result()
+                    # Cancel the loser.
+                    for p in pending:
+                        p.cancel()
+                    return result
+                except (OSError, asyncio.TimeoutError):
+                    pass
+            # Both done in this iteration with failures? Wait the rest.
+            for t in pending:
+                try:
+                    result = await t
+                    return result
+                except (OSError, asyncio.TimeoutError) as e:
+                    last = e
+            raise last
+        finally:
+            # Best-effort: ensure no task is left dangling. Tasks that
+            # already returned a result are no-op'd on cancel; in-flight
+            # tasks get torn down so we don't leak a half-open socket.
+            for t in (v6_task, v4_task):
+                if t is not None and not t.done():
+                    t.cancel()
 
     def stop(self) -> None:
         """Close the server and stop the event loop. Safe to call twice."""
@@ -703,8 +947,9 @@ class EgressProxy:
         # json.dumps escapes control chars, but the logger.warning/info
         # calls below interpolate the host into human-readable messages
         # that may reach a live terminal. See
-        # core.security.log_sanitisation.has_nonprintable.
-        from core.security.log_sanitisation import has_nonprintable
+        # core.security.log_sanitisation.has_nonprintable. Imported at
+        # module top to avoid a per-CONNECT dict-lookup + module-attr
+        # access on the hot path.
         if has_nonprintable(target):
             event.update(result="bad_request",
                          reason="non-printable characters in CONNECT target",
@@ -871,21 +1116,20 @@ class EgressProxy:
                     break
         else:
             # Direct path — resolve target, reject private/loopback IPs,
-            # open connection to resolved address.
+            # open connection via happy-eyeballs.
             try:
-                addrinfo = await asyncio.wait_for(
-                    self._loop.getaddrinfo(host, port, type=socket.SOCK_STREAM),
-                    timeout=10.0,
-                )
+                addrinfo = await self._cached_getaddrinfo(host, port)
             except asyncio.TimeoutError:
-                logger.warning(f"egress proxy: DNS timeout for {host}:{port}")
+                logger.warning("egress proxy: DNS timeout for %s:%s",
+                                host, port)
                 event.update(result="dns_failed", reason="DNS timeout",
                              duration=time.monotonic() - t_start)
                 self._record(event)
                 await self._write_error(writer, 504, "Gateway Timeout")
                 return
             except socket.gaierror as e:
-                logger.warning(f"egress proxy: DNS failure for {host}:{port}: {e}")
+                logger.warning("egress proxy: DNS failure for %s:%s: %s",
+                                host, port, e)
                 event.update(result="dns_failed", reason=f"DNS: {e}",
                              duration=time.monotonic() - t_start)
                 self._record(event)
@@ -900,8 +1144,13 @@ class EgressProxy:
                 return
 
             # Policy gate 2: reject resolved IPs that point to loopback /
-            # private / link-local. Stops a (hypothetical future) allowlisted
-            # hostname whose DNS now points to 127.x.
+            # private / link-local. The check runs against the FIRST
+            # candidate (and the happy-eyeballs dial below also re-runs
+            # gate 2 on each per-attempt connect) so a multi-A-record
+            # hostname where one record is private and another is public
+            # still gets caught. The "first record wins gate 2" semantic
+            # matches the original code; happy-eyeballs only changes
+            # which record we end up CONNECTING to, not which we VET.
             family, socktype, proto, _, sockaddr = addrinfo[0]
             resolved_ip = sockaddr[0]
             event["resolved_ip"] = resolved_ip
@@ -923,8 +1172,8 @@ class EgressProxy:
                 # audit promise is "every policy/safety event lands in
                 # the summary".)
                 logger.warning(
-                    f"egress proxy: DENY {host}:{port} — resolved to blocked "
-                    f"IP {resolved_ip}"
+                    "egress proxy: DENY %s:%s — resolved to blocked IP %s",
+                    host, port, resolved_ip,
                 )
                 event.update(result="denied_resolved_ip",
                              reason=f"resolved to blocked range: {resolved_ip}",
@@ -943,15 +1192,13 @@ class EgressProxy:
                 return
 
             try:
-                up_reader, up_writer = await asyncio.wait_for(
-                    asyncio.open_connection(host=resolved_ip, port=port,
-                                            family=family),
-                    timeout=10.0,
+                up_reader, up_writer, dialed_ip = (
+                    await self._happy_eyeballs_connect(addrinfo, port)
                 )
             except (OSError, asyncio.TimeoutError) as e:
                 logger.warning(
-                    f"egress proxy: upstream connect failed {host}:{port} "
-                    f"({resolved_ip}): {e}"
+                    "egress proxy: upstream connect failed %s:%s (%s): %s",
+                    host, port, resolved_ip, e,
                 )
                 event.update(result="upstream_failed",
                              reason=f"{e.__class__.__name__}: {e}",
@@ -959,6 +1206,11 @@ class EgressProxy:
                 self._record(event)
                 await self._write_error(writer, 502, "Bad Gateway")
                 return
+            # Update event with the IP we actually dialled (may differ
+            # from `resolved_ip` if happy-eyeballs preferred a v4
+            # address while the addrinfo's first record was v6).
+            if dialed_ip != resolved_ip:
+                event["resolved_ip"] = dialed_ip
 
         # Acknowledge tunnel established, then relay bytes both ways.
         writer.write(b"HTTP/1.1 200 Connection established\r\n\r\n")
@@ -969,9 +1221,13 @@ class EgressProxy:
         # NameError on every upstream-proxy CONNECT, crashing the tunnel
         # handler mid-request. Read through the event dict so both paths
         # produce a valid log line.
+        # Lazy %-style format so the string isn't built when INFO is
+        # below the logger threshold — every CONNECT used to pay the
+        # f-string formatting cost regardless of whether anything
+        # consumed the line.
         logger.info(
-            f"egress proxy: OPEN {host}:{port} -> "
-            f"{event.get('resolved_ip', '?')}"
+            "egress proxy: OPEN %s:%s -> %s",
+            host, port, event.get("resolved_ip", "?"),
         )
 
         # Record the event NOW (not at close) so short tunnels that
@@ -1029,8 +1285,8 @@ class EgressProxy:
                          bytes_c2u=total["c2u"], bytes_u2c=total["u2c"],
                          duration=time.monotonic() - t_start)
             logger.info(
-                f"egress proxy: CLOSE {host}:{port} "
-                f"(c2u={total['c2u']} u2c={total['u2c']})"
+                "egress proxy: CLOSE %s:%s (c2u=%s u2c=%s)",
+                host, port, total["c2u"], total["u2c"],
             )
 
     async def _relay(self, src: asyncio.StreamReader,

--- a/core/sandbox/tests/test_proxy_perf.py
+++ b/core/sandbox/tests/test_proxy_perf.py
@@ -1,0 +1,370 @@
+"""Tests for the egress-proxy performance fixes:
+
+  A. TTL'd DNS cache (skip getaddrinfo on repeat host).
+  B. Happy-eyeballs dialer (race v6 + v4 instead of serial walk).
+  C. Module-top has_nonprintable import + lazy log formatting (smoke).
+  D. Snapshot-based buffer fan-out (lock-free hot path; concurrent
+     register/unregister/_record exercise).
+
+Pure-Python tests — no subprocess, no real network. The dialer is
+exercised against ``EgressProxy`` instance methods with mocked
+``getaddrinfo`` and ``open_connection``; concurrency tests run on
+the proxy's own asyncio loop via ``loop.call_soon_threadsafe`` +
+``run_coroutine_threadsafe``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+from core.sandbox import proxy as proxy_mod
+
+
+@pytest.fixture
+def reset_proxy():
+    proxy_mod._reset_for_tests()
+    yield
+    proxy_mod._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# A — DNS cache
+# ---------------------------------------------------------------------------
+
+
+class TestDnsCache:
+
+    def test_cache_hit_skips_getaddrinfo(self, reset_proxy):
+        """Two resolutions of the same host within TTL → 1 call."""
+        proxy = proxy_mod.EgressProxy(allowed_hosts={"example.com"})
+        try:
+            calls = []
+
+            async def fake_gai(host, port, **kwargs):
+                calls.append((host, port))
+                return [(
+                    socket.AF_INET, socket.SOCK_STREAM, 0, "",
+                    ("93.184.216.34", port),
+                )]
+
+            async def driver():
+                with patch.object(proxy._loop, "getaddrinfo", fake_gai):
+                    a = await proxy._cached_getaddrinfo("example.com", 443)
+                    b = await proxy._cached_getaddrinfo("example.com", 443)
+                return a, b
+
+            a, b = asyncio.run_coroutine_threadsafe(
+                driver(), proxy._loop,
+            ).result(timeout=5)
+            assert a == b
+            assert calls == [("example.com", 443)], (
+                f"second lookup hit getaddrinfo: {calls}"
+            )
+        finally:
+            proxy.stop()
+
+    def test_cache_expires_after_ttl(self, reset_proxy):
+        """Past TTL → re-resolves."""
+        proxy = proxy_mod.EgressProxy(allowed_hosts={"example.com"})
+        try:
+            calls = []
+
+            async def fake_gai(host, port, **kwargs):
+                calls.append((host, port))
+                return [(
+                    socket.AF_INET, socket.SOCK_STREAM, 0, "",
+                    ("93.184.216.34", port),
+                )]
+
+            async def driver():
+                with patch.object(proxy._loop, "getaddrinfo", fake_gai):
+                    await proxy._cached_getaddrinfo("example.com", 443)
+                    # Force the cache entry to be expired by rewriting
+                    # its expiry timestamp.
+                    key = ("example.com", 443)
+                    expires, addrs = proxy._dns_cache[key]
+                    proxy._dns_cache[key] = (time.monotonic() - 1.0, addrs)
+                    await proxy._cached_getaddrinfo("example.com", 443)
+
+            asyncio.run_coroutine_threadsafe(
+                driver(), proxy._loop,
+            ).result(timeout=5)
+            assert len(calls) == 2, (
+                f"expired entry was not refreshed: {calls}"
+            )
+        finally:
+            proxy.stop()
+
+    def test_distinct_keys_cache_independently(self, reset_proxy):
+        """Different (host, port) keys do not share cache entries."""
+        proxy = proxy_mod.EgressProxy(allowed_hosts={"a.com", "b.com"})
+        try:
+            calls = []
+
+            async def fake_gai(host, port, **kwargs):
+                calls.append((host, port))
+                return [(
+                    socket.AF_INET, socket.SOCK_STREAM, 0, "",
+                    ("1.2.3.4", port),
+                )]
+
+            async def driver():
+                with patch.object(proxy._loop, "getaddrinfo", fake_gai):
+                    await proxy._cached_getaddrinfo("a.com", 443)
+                    await proxy._cached_getaddrinfo("b.com", 443)
+                    await proxy._cached_getaddrinfo("a.com", 80)
+
+            asyncio.run_coroutine_threadsafe(
+                driver(), proxy._loop,
+            ).result(timeout=5)
+            assert calls == [("a.com", 443), ("b.com", 443),
+                              ("a.com", 80)]
+        finally:
+            proxy.stop()
+
+
+# ---------------------------------------------------------------------------
+# B — Happy-eyeballs
+# ---------------------------------------------------------------------------
+
+
+class TestHappyEyeballs:
+
+    def _addrinfo(self, family, ip, port=443):
+        return (family, socket.SOCK_STREAM, 0, "", (ip, port))
+
+    def test_single_family_walks_in_order(self, reset_proxy):
+        """Only v4 records → no race, just walk in order."""
+        proxy = proxy_mod.EgressProxy(allowed_hosts={"example.com"})
+        try:
+            connect_calls = []
+
+            async def fake_open(host, port, family=None, **kwargs):
+                connect_calls.append(host)
+                return ("reader", "writer")
+
+            addrinfo = [
+                self._addrinfo(socket.AF_INET, "1.2.3.4"),
+                self._addrinfo(socket.AF_INET, "5.6.7.8"),
+            ]
+
+            async def driver():
+                with patch("asyncio.open_connection", fake_open):
+                    return await proxy._happy_eyeballs_connect(
+                        addrinfo, 443,
+                    )
+
+            r, w, ip = asyncio.run_coroutine_threadsafe(
+                driver(), proxy._loop,
+            ).result(timeout=5)
+            assert ip == "1.2.3.4"
+            assert connect_calls == ["1.2.3.4"]
+        finally:
+            proxy.stop()
+
+    def test_dual_family_v6_succeeds_first(self, reset_proxy):
+        """v6 wins the race → return v6 result; v4 cancelled."""
+        proxy = proxy_mod.EgressProxy(allowed_hosts={"example.com"})
+        try:
+
+            async def fake_open(host, port, family=None, **kwargs):
+                if family == socket.AF_INET6:
+                    return ("r6", "w6")
+                # v4 is slower
+                await asyncio.sleep(1.0)
+                return ("r4", "w4")
+
+            addrinfo = [
+                self._addrinfo(socket.AF_INET6, "2606:2800:220:1::"),
+                self._addrinfo(socket.AF_INET, "1.2.3.4"),
+            ]
+
+            async def driver():
+                with patch("asyncio.open_connection", fake_open):
+                    return await proxy._happy_eyeballs_connect(
+                        addrinfo, 443,
+                    )
+
+            r, w, ip = asyncio.run_coroutine_threadsafe(
+                driver(), proxy._loop,
+            ).result(timeout=5)
+            assert ip == "2606:2800:220:1::"
+        finally:
+            proxy.stop()
+
+    def test_dual_family_v6_stalls_v4_wins(self, reset_proxy):
+        """v6 stalls past the 250ms gate; v4 races and wins."""
+        proxy = proxy_mod.EgressProxy(allowed_hosts={"example.com"})
+        try:
+
+            async def fake_open(host, port, family=None, **kwargs):
+                if family == socket.AF_INET6:
+                    await asyncio.sleep(2.0)
+                    return ("r6", "w6")
+                # v4 fast
+                return ("r4", "w4")
+
+            addrinfo = [
+                self._addrinfo(socket.AF_INET6, "2606:2800:220:1::"),
+                self._addrinfo(socket.AF_INET, "1.2.3.4"),
+            ]
+
+            async def driver():
+                with patch("asyncio.open_connection", fake_open):
+                    return await proxy._happy_eyeballs_connect(
+                        addrinfo, 443,
+                    )
+
+            t0 = time.monotonic()
+            r, w, ip = asyncio.run_coroutine_threadsafe(
+                driver(), proxy._loop,
+            ).result(timeout=5)
+            elapsed = time.monotonic() - t0
+            assert ip == "1.2.3.4"
+            # Must be quick: v4 starts after the 250ms gate, then
+            # connects instantly.
+            assert elapsed < 1.0, (
+                f"happy-eyeballs took {elapsed:.2f}s — v6 stall not "
+                f"bypassed?"
+            )
+        finally:
+            proxy.stop()
+
+    def test_gate2_blocks_first_candidate_falls_through(
+        self, reset_proxy,
+    ):
+        """If gate-2 rejects the first candidate (private IP), the
+        dialer tries the next."""
+        proxy = proxy_mod.EgressProxy(allowed_hosts={"example.com"})
+        try:
+            connect_calls = []
+
+            async def fake_open(host, port, family=None, **kwargs):
+                connect_calls.append(host)
+                return ("r", "w")
+
+            # First v4 is loopback (gate-2 reject), second is public.
+            addrinfo = [
+                self._addrinfo(socket.AF_INET, "127.0.0.1"),
+                self._addrinfo(socket.AF_INET, "1.2.3.4"),
+            ]
+
+            async def driver():
+                with patch("asyncio.open_connection", fake_open):
+                    return await proxy._happy_eyeballs_connect(
+                        addrinfo, 443,
+                    )
+
+            r, w, ip = asyncio.run_coroutine_threadsafe(
+                driver(), proxy._loop,
+            ).result(timeout=5)
+            assert ip == "1.2.3.4"
+            assert connect_calls == ["1.2.3.4"], (
+                f"gate-2-blocked IP was dialled: {connect_calls}"
+            )
+        finally:
+            proxy.stop()
+
+
+# ---------------------------------------------------------------------------
+# D — Snapshot buffer fan-out
+# ---------------------------------------------------------------------------
+
+
+class TestBufferSnapshot:
+
+    def test_register_appends_to_snapshot(self, reset_proxy):
+        proxy = proxy_mod.EgressProxy(allowed_hosts={"x"})
+        try:
+            assert proxy._sandbox_buffers_snapshot == ()
+            t1 = proxy.register_sandbox(caller_label="a")
+            assert len(proxy._sandbox_buffers_snapshot) == 1
+            t2 = proxy.register_sandbox(caller_label="b")
+            assert len(proxy._sandbox_buffers_snapshot) == 2
+            proxy.unregister_sandbox(t1)
+            assert len(proxy._sandbox_buffers_snapshot) == 1
+            proxy.unregister_sandbox(t2)
+            assert proxy._sandbox_buffers_snapshot == ()
+        finally:
+            proxy.stop()
+
+    def test_record_fans_out_lock_free(self, reset_proxy):
+        """_record appends to every registered sandbox's buffer
+        without acquiring the buffer lock."""
+        proxy = proxy_mod.EgressProxy(allowed_hosts={"x"})
+        try:
+            t1 = proxy.register_sandbox()
+            t2 = proxy.register_sandbox()
+            event = {"host": "h", "port": 1, "result": "allowed"}
+            proxy._record(event)
+            ev1 = proxy.unregister_sandbox(t1)
+            ev2 = proxy.unregister_sandbox(t2)
+            assert len(ev1) == 1 and len(ev2) == 1
+            assert ev1[0]["host"] == "h"
+            assert ev2[0]["host"] == "h"
+        finally:
+            proxy.stop()
+
+    def test_concurrent_record_and_register(self, reset_proxy):
+        """Hammer _record from many threads concurrently with
+        register/unregister churn — must not raise (no dict-mutated-
+        during-iteration) and every event must land in at least one
+        buffer that was registered when the record happened."""
+        proxy = proxy_mod.EgressProxy(allowed_hosts={"x"})
+        try:
+            stop = threading.Event()
+            errors = []
+
+            def hammer_record():
+                try:
+                    while not stop.is_set():
+                        proxy._record({"host": "h", "port": 1,
+                                        "result": "allowed"})
+                except Exception as e:
+                    errors.append(e)
+
+            def hammer_register():
+                try:
+                    while not stop.is_set():
+                        t = proxy.register_sandbox()
+                        proxy.unregister_sandbox(t)
+                except Exception as e:
+                    errors.append(e)
+
+            ts = [threading.Thread(target=hammer_record) for _ in range(4)]
+            ts += [threading.Thread(target=hammer_register) for _ in range(2)]
+            for t in ts:
+                t.start()
+            time.sleep(0.5)
+            stop.set()
+            for t in ts:
+                t.join(timeout=5)
+            assert not errors, f"concurrent run raised: {errors}"
+        finally:
+            proxy.stop()
+
+
+# ---------------------------------------------------------------------------
+# C — module-top import + lazy log formatting (smoke)
+# ---------------------------------------------------------------------------
+
+
+class TestImportAndLogging:
+
+    def test_has_nonprintable_imported_at_module_top(self):
+        """The hot-path inline import is gone — the symbol resolves
+        from the proxy module's own namespace."""
+        # Direct module attribute lookup; if the inline import was
+        # still in _serve_tunnel and the module-top one was removed,
+        # this would AttributeError.
+        assert hasattr(proxy_mod, "has_nonprintable")
+        from core.security.log_sanitisation import (
+            has_nonprintable as canonical,
+        )
+        assert proxy_mod.has_nonprintable is canonical


### PR DESCRIPTION
Egress proxy added ~70s overhead per `npm install --dry-run` in the SCA stress harness (20s direct → >90s through sandbox). Four hot-path fixes:

A. TTL'd DNS cache (60s, per host:port). Bursty resolvers hit the same
   registry dozens of times per scan; each used to re-getaddrinfo.
   Gate-2 (resolved-IP block) still runs per CONNECT against the
   cached IP, so the rebinding defence is unchanged.

B. Happy-eyeballs dialer (RFC 8305). Old code took addrinfo[0] and
   ate a 10s timeout when the first record was an unreachable IPv6
   address. Now races v6+v4 with a 250ms gate; loser cancelled.
   Gate-2 re-applied per attempt.

C. Module-top `has_nonprintable` import + `%`-style lazy log formatting
   on OPEN/CLOSE/warning paths. Drops per-CONNECT dict lookups and
   below-threshold f-string formatting.

D. Snapshot-tuple buffer fan-out. `_record` no longer acquires the
   shared `_buffer_lock` — reads the snapshot tuple (atomic under
   GIL), appends to each list (atomic under GIL). Register/unregister
   rebuild the tuple inside the existing lock.

Also: `_DEFAULT_MAX_TUNNELS` 64 → 256 (cap was tripping under burst).

11 new tests in test_proxy_perf.py; existing 740-test sandbox suite unchanged.