### PR TITLE
feat(validate): emit per-function annotations across stages A, B, D

### DIFF
--- a/libexec/raptor-validation-helper
+++ b/libexec/raptor-validation-helper
@@ -240,6 +240,20 @@ def _apply_stage_file(workdir, stage_letter):
         save_json(findings_path, container)
         print(f"  Merged stage-{stage_letter.lower()}.json: {applied} findings updated")
 
+    # Emit per-function annotations for stages that have a wired
+    # mapping (Stage A produces verdicts, Stage B refines with
+    # hypothesis + proximity). Best-effort — annotation failures
+    # never break the stage merge.
+    try:
+        from packages.exploitability_validation.annotation_emit import (
+            emit_stage_annotations,
+        )
+        n = emit_stage_annotations(Path(workdir), stage_letter)
+        if n > 0:
+            print(f"  Annotations emitted: {n} (per-function review trail)")
+    except Exception:
+        pass
+
     # Delete the stage file. Guard the unlink — pre-fix
     # `stage_path.unlink()` raised `FileNotFoundError` if the
     # file disappeared between the read above and here (rare

--- a/packages/exploitability_validation/annotation_emit.py
+++ b/packages/exploitability_validation/annotation_emit.py
@@ -1,0 +1,301 @@
+"""Per-function annotation emission for /validate stages.
+
+After each stage's structured output is merged into findings.json,
+walk the findings and emit/update annotations capturing what /validate
+learned about each function. Operator gets a per-function review trail
+that accumulates across runs alongside the existing findings.json.
+
+Stage handling (initial scope — A and B):
+
+  * Stage A — emit one annotation per finding with status derived
+    from ``stage_a_summary.status``:
+      - poc_success     → status=finding (exploitable confirmed)
+      - not_disproven   → status=suspicious (needs Stage B+)
+      - disproven       → status=clean (definitively safe)
+      - <missing>       → status=error
+    Body: candidate_reasoning + Stage A summary + ruling.
+
+  * Stage B — update annotation with hypothesis verdict and
+    proximity from ``stage_b_summary``:
+      - hypothesis_status=confirmed → status=finding
+      - hypothesis_status=disproven → status=clean
+      - hypothesis_status=testing  → keep prior status (no override)
+    Body: Stage A body + Stage B hypothesis + proximity + attack
+    path id.
+
+Stages C-F not yet wired — Stage D's ruling would be the natural
+final overwrite, but the stage outputs differ enough to deserve
+their own integration when Phase A driver work surfaces the need.
+
+All writes pass ``overwrite="respect-manual"`` so a manual operator
+note (``source=human``) is never clobbered. LLM-over-LLM writes
+proceed (later stages overwrite earlier — last-stage-wins is the
+intended semantic for /validate's progression).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Stage A: status mapping
+# ---------------------------------------------------------------------------
+
+
+_STAGE_A_STATUS_MAP = {
+    "poc_success": "finding",
+    "not_disproven": "suspicious",
+    "disproven": "clean",
+}
+
+
+def _stage_a_status(finding: Dict[str, Any]) -> str:
+    """Derive annotation status from a finding's Stage A summary.
+    Falls back to 'error' when the summary is missing or carries an
+    unknown status — surfaces the gap rather than silently mapping
+    to a wrong verdict."""
+    summary = finding.get("stage_a_summary") or {}
+    raw = summary.get("status", "")
+    return _STAGE_A_STATUS_MAP.get(raw, "error")
+
+
+def _stage_a_body(finding: Dict[str, Any]) -> str:
+    """Compose the annotation body from Stage A's findings record.
+    Captures candidate reasoning + verdict + disproof rationale."""
+    parts: List[str] = []
+    summary = finding.get("stage_a_summary") or {}
+
+    reasoning = (
+        summary.get("candidate_reasoning")
+        or finding.get("candidate_reasoning")
+    )
+    if reasoning:
+        parts.append(f"Stage A reasoning: {reasoning}")
+
+    confidence = summary.get("confidence")
+    if confidence:
+        parts.append(f"Confidence: {confidence}")
+
+    raw_status = summary.get("status") or finding.get("status")
+    if raw_status:
+        parts.append(f"Stage A status: {raw_status}")
+
+    # Disproof rationale, when applicable.
+    disproved = finding.get("disproved_because") or {}
+    if disproved:
+        bits = []
+        if disproved.get("conclusion"):
+            bits.append(f"Conclusion: {disproved['conclusion']}")
+        if disproved.get("investigated"):
+            bits.append(f"Investigated: {disproved['investigated']}")
+        if bits:
+            parts.append("Disproof rationale:\n  " + "\n  ".join(bits))
+
+    return "\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Stage B: hypothesis verdict + proximity
+# ---------------------------------------------------------------------------
+
+
+_STAGE_B_STATUS_MAP = {
+    "confirmed": "finding",
+    "disproven": "clean",
+    # "testing" / "uncertain" → keep prior status (no override)
+}
+
+
+def _stage_b_override_status(finding: Dict[str, Any]) -> Optional[str]:
+    """Return a status to override prior annotation, or None to keep
+    Stage A's status unchanged."""
+    summary = finding.get("stage_b_summary") or {}
+    raw = summary.get("hypothesis_status", "")
+    return _STAGE_B_STATUS_MAP.get(raw)
+
+
+def _stage_b_body(finding: Dict[str, Any]) -> str:
+    """Compose Stage B's body — extends Stage A with hypothesis +
+    proximity context."""
+    parts = [_stage_a_body(finding)]
+
+    summary = finding.get("stage_b_summary") or {}
+    if summary:
+        bits = []
+        h_status = summary.get("hypothesis_status")
+        if h_status:
+            bits.append(f"Hypothesis: {h_status}")
+        h_id = summary.get("hypothesis_id")
+        if h_id:
+            bits.append(f"Hypothesis id: {h_id}")
+        prox = summary.get("proximity")
+        if prox is not None:
+            bits.append(f"Proximity: {prox}/10")
+        ap_id = summary.get("attack_path_id")
+        if ap_id:
+            bits.append(f"Attack path: {ap_id}")
+        if bits:
+            parts.append("Stage B verdict:\n  " + "\n  ".join(bits))
+
+    return "\n\n".join(p for p in parts if p)
+
+
+# ---------------------------------------------------------------------------
+# Common metadata sanitisation + emission
+# ---------------------------------------------------------------------------
+
+
+def _sanitise_meta(value: Any) -> str:
+    """Coerce a metadata value to a safe single-line string. Mirrors
+    the sanitiser in /agentic and KNighter follow-up — strips
+    newlines, nulls, and HTML-comment delimiters."""
+    s = str(value)
+    s = s.replace("\n", " ").replace("\r", " ").replace("\x00", "")
+    s = s.replace("-->", "->").replace("<!--", "<!-")
+    return s.strip()
+
+
+def _build_metadata(
+    finding: Dict[str, Any], status: str, stage_letter: str,
+) -> Dict[str, str]:
+    """Assemble per-annotation metadata. Common fields across all
+    stages: source, status, stage, cwe, rule_id, vuln_type."""
+    metadata: Dict[str, str] = {
+        "source": "llm",
+        "status": status,
+        "stage": _sanitise_meta(stage_letter.upper()),
+        "tool": "validate",
+    }
+    cwe = finding.get("cwe_id")
+    if cwe:
+        metadata["cwe"] = _sanitise_meta(cwe)
+    rule_id = finding.get("rule_id")
+    if rule_id:
+        metadata["rule_id"] = _sanitise_meta(rule_id)
+    vt = finding.get("vuln_type")
+    if vt:
+        metadata["vuln_type"] = _sanitise_meta(vt)
+    fid = finding.get("id")
+    if fid:
+        metadata["finding_id"] = _sanitise_meta(fid)
+    # Stage B carries proximity score — surface it as a metadata
+    # tag so /annotate ls and downstream consumers can filter on it.
+    summary_b = finding.get("stage_b_summary") or {}
+    if summary_b.get("proximity") is not None:
+        metadata["proximity"] = _sanitise_meta(summary_b["proximity"])
+    return metadata
+
+
+def _emit_one(
+    finding: Dict[str, Any], stage_letter: str, base_dir: Path,
+) -> Optional[Path]:
+    """Build + write one annotation. Returns the path or None when
+    the finding lacks the fields required to land an annotation."""
+    file_path = finding.get("file") or finding.get("file_path")
+    function = finding.get("function")
+    if not file_path or not function:
+        return None
+
+    stage = stage_letter.upper()
+    if stage == "A":
+        status = _stage_a_status(finding)
+        body = _stage_a_body(finding)
+    elif stage == "B":
+        # Stage B may override Stage A's status. When the hypothesis
+        # is still "testing" we keep prior status — derive from
+        # stage_a_summary as the carry-forward.
+        override = _stage_b_override_status(finding)
+        status = override if override else _stage_a_status(finding)
+        body = _stage_b_body(finding)
+    else:
+        # Stages C-F not wired yet — short-circuit to keep the helper
+        # safe to call from any stage's prep.
+        return None
+
+    if not body:
+        # An empty body still produces a usable annotation (status +
+        # metadata carry the verdict), but a marker helps the
+        # operator skim.
+        body = (
+            f"Stage {stage} processed without prose evidence — "
+            f"see findings.json for structured detail."
+        )
+
+    metadata = _build_metadata(finding, status, stage)
+
+    from core.annotations import Annotation, write_annotation
+
+    try:
+        return write_annotation(
+            base_dir,
+            Annotation(
+                file=file_path,
+                function=function,
+                body=body,
+                metadata=metadata,
+            ),
+            overwrite="respect-manual",
+        )
+    except (ValueError, OSError) as e:
+        logger.debug(
+            f"validate.annotation_emit: write failed for "
+            f"{file_path}:{function}: {e}"
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def emit_stage_annotations(workdir: Path, stage_letter: str) -> int:
+    """Walk findings.json after a stage merge and emit/update an
+    annotation per finding. Returns count of annotations actually
+    written.
+
+    Best-effort throughout: malformed findings.json, missing fields,
+    or substrate failures all produce zero without raising — the
+    /validate pipeline must never break because annotations failed.
+
+    Stages A and B are wired today. Other stages return 0 (no-op);
+    safe to call from any stage's prep.
+    """
+    workdir = Path(workdir)
+    findings_path = workdir / "findings.json"
+    if not findings_path.exists():
+        return 0
+
+    try:
+        from core.json import load_json
+        container = load_json(findings_path)
+    except Exception:
+        return 0
+    if not isinstance(container, dict):
+        return 0
+
+    findings = container.get("findings")
+    if not isinstance(findings, list):
+        return 0
+
+    base_dir = workdir / "annotations"
+    written = 0
+    for finding in findings:
+        if not isinstance(finding, dict):
+            continue
+        try:
+            path = _emit_one(finding, stage_letter, base_dir)
+        except Exception:
+            logger.debug(
+                "validate.annotation_emit: per-finding emit failed",
+                exc_info=True,
+            )
+            continue
+        if path is not None:
+            written += 1
+    return written

--- a/packages/exploitability_validation/annotation_emit.py
+++ b/packages/exploitability_validation/annotation_emit.py
@@ -5,7 +5,7 @@ walk the findings and emit/update annotations capturing what /validate
 learned about each function. Operator gets a per-function review trail
 that accumulates across runs alongside the existing findings.json.
 
-Stage handling (initial scope — A and B):
+Stage handling (A, B, D):
 
   * Stage A — emit one annotation per finding with status derived
     from ``stage_a_summary.status``:
@@ -23,9 +23,21 @@ Stage handling (initial scope — A and B):
     Body: Stage A body + Stage B hypothesis + proximity + attack
     path id.
 
-Stages C-F not yet wired — Stage D's ruling would be the natural
-final overwrite, but the stage outputs differ enough to deserve
-their own integration when Phase A driver work surfaces the need.
+  * Stage D — final ruling, supersedes A and B verdicts:
+      - ruling.status=confirmed / exploitable → status=finding
+      - ruling.status=ruled_out               → status=clean
+    Body: Stage B body + Stage D ruling + disqualifier + reason +
+    CVSS vector. This is the canonical operator-facing verdict;
+    downstream consumers (/exploit, /patch) treat Stage D's
+    ruling as authoritative.
+
+Stages C, E, F not wired:
+  * C (sanity check) — feeds into Stage D's ruling, no separate
+    annotation update needed.
+  * E (SMT feasibility) — refines Stage D's verdict but rare;
+    operator runs /annotate edit if it matters.
+  * F (final review) — typically no new verdict info.
+The emission function returns 0 cleanly for these stages.
 
 All writes pass ``overwrite="respect-manual"`` so a manual operator
 note (``source=human``) is never clobbered. LLM-over-LLM writes
@@ -146,6 +158,72 @@ def _stage_b_body(finding: Dict[str, Any]) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Stage D: final ruling, supersedes A and B
+# ---------------------------------------------------------------------------
+
+
+_STAGE_D_STATUS_MAP = {
+    "confirmed": "finding",
+    "exploitable": "finding",
+    "ruled_out": "clean",
+}
+
+
+def _stage_d_status(finding: Dict[str, Any]) -> str:
+    """Derive annotation status from Stage D's ruling. Stage D's
+    output is the canonical final verdict — downstream consumers
+    treat this as authoritative.
+
+    Falls back to the Stage B-or-A status when the ruling is
+    missing or unmapped — mirror the upstream's progress, never
+    silently downgrade."""
+    ruling = finding.get("ruling") or {}
+    raw = ruling.get("status", "")
+    mapped = _STAGE_D_STATUS_MAP.get(raw)
+    if mapped:
+        return mapped
+    # No ruling yet, or unmapped value — fall back to whatever
+    # Stage B or Stage A had.
+    override_b = _stage_b_override_status(finding)
+    if override_b:
+        return override_b
+    return _stage_a_status(finding)
+
+
+def _stage_d_body(finding: Dict[str, Any]) -> str:
+    """Compose Stage D's body — extends Stage B with the ruling,
+    disqualifier, reason, and CVSS vector when present."""
+    parts = [_stage_b_body(finding)]
+
+    ruling = finding.get("ruling") or {}
+    summary = finding.get("stage_d_summary") or {}
+    if ruling or summary:
+        bits = []
+        rs = ruling.get("status") or summary.get("ruling")
+        if rs:
+            bits.append(f"Stage D ruling: {rs}")
+        disq = ruling.get("disqualifier") or summary.get("disqualifier")
+        if disq:
+            bits.append(f"Disqualifier: {disq}")
+        reason = ruling.get("reason")
+        if reason:
+            bits.append(f"Reason: {reason}")
+        cvss = (
+            finding.get("cvss_vector")
+            or summary.get("cvss_vector")
+        )
+        if cvss:
+            bits.append(f"CVSS: {cvss}")
+        synthesis = (ruling.get("evidence_synthesis") or {}).get("synthesis")
+        if synthesis:
+            bits.append(f"Evidence synthesis: {synthesis}")
+        if bits:
+            parts.append("Stage D verdict:\n  " + "\n  ".join(bits))
+
+    return "\n\n".join(p for p in parts if p)
+
+
+# ---------------------------------------------------------------------------
 # Common metadata sanitisation + emission
 # ---------------------------------------------------------------------------
 
@@ -188,6 +266,16 @@ def _build_metadata(
     summary_b = finding.get("stage_b_summary") or {}
     if summary_b.get("proximity") is not None:
         metadata["proximity"] = _sanitise_meta(summary_b["proximity"])
+    # Stage D carries the canonical final ruling + CVSS — surface
+    # both for filtering / reporting.
+    ruling = finding.get("ruling") or {}
+    summary_d = finding.get("stage_d_summary") or {}
+    rs = ruling.get("status") or summary_d.get("ruling")
+    if rs:
+        metadata["ruling"] = _sanitise_meta(rs)
+    cvss = finding.get("cvss_vector") or summary_d.get("cvss_vector")
+    if cvss:
+        metadata["cvss"] = _sanitise_meta(cvss)
     return metadata
 
 
@@ -212,9 +300,16 @@ def _emit_one(
         override = _stage_b_override_status(finding)
         status = override if override else _stage_a_status(finding)
         body = _stage_b_body(finding)
+    elif stage == "D":
+        # Stage D's ruling supersedes A and B verdicts. When the
+        # ruling is missing or unmapped, fall through to Stage B
+        # then Stage A so the annotation always reflects the
+        # latest signal we have.
+        status = _stage_d_status(finding)
+        body = _stage_d_body(finding)
     else:
-        # Stages C-F not wired yet — short-circuit to keep the helper
-        # safe to call from any stage's prep.
+        # Stages C, E, F not wired — short-circuit to keep the
+        # emission function safe to call from any stage's merge.
         return None
 
     if not body:
@@ -263,8 +358,8 @@ def emit_stage_annotations(workdir: Path, stage_letter: str) -> int:
     or substrate failures all produce zero without raising — the
     /validate pipeline must never break because annotations failed.
 
-    Stages A and B are wired today. Other stages return 0 (no-op);
-    safe to call from any stage's prep.
+    Stages A, B, D are wired. C/E/F return 0 (no-op) — safe to
+    call from any stage's prep.
     """
     workdir = Path(workdir)
     findings_path = workdir / "findings.json"

--- a/packages/exploitability_validation/tests/test_annotation_emit.py
+++ b/packages/exploitability_validation/tests/test_annotation_emit.py
@@ -357,13 +357,13 @@ class TestEdgeCases:
         _write_findings(tmp_path, [f])
         assert emit_stage_annotations(tmp_path, "A") == 0
 
-    def test_unknown_stage_returns_zero(self, tmp_path):
+    def test_unwired_stages_return_zero(self, tmp_path):
         _write_findings(tmp_path, [_basic_finding()])
-        # Stages C-F not yet wired — no-op.
+        # Stages C, E, F not wired — no-op.
         assert emit_stage_annotations(tmp_path, "C") == 0
-        assert emit_stage_annotations(tmp_path, "D") == 0
         assert emit_stage_annotations(tmp_path, "E") == 0
         assert emit_stage_annotations(tmp_path, "F") == 0
+        # Stage D IS wired — verified separately in TestStageDRuling.
 
     def test_multiple_findings_each_get_annotation(self, tmp_path):
         _write_findings(tmp_path, [
@@ -396,6 +396,184 @@ class TestEdgeCases:
         n = emit_stage_annotations(tmp_path, "A")
         # Two valid findings → two annotations; two skipped.
         assert n == 2
+
+
+# ---------------------------------------------------------------------------
+# Stage D ruling
+# ---------------------------------------------------------------------------
+
+
+class TestStageDRuling:
+    """Stage D's ruling is the canonical final verdict — supersedes
+    Stage A and Stage B verdicts. ``confirmed`` / ``exploitable``
+    map to ``finding``; ``ruled_out`` maps to ``clean``."""
+
+    def test_confirmed_ruling_maps_to_finding(self, tmp_path):
+        f = _basic_finding(stage_a_status="not_disproven")
+        f["ruling"] = {"status": "confirmed",
+                        "evidence_synthesis": {
+                            "synthesis": "all checks passed; PoC works"
+                        }}
+        f["stage_d_summary"] = {"ruling": "confirmed"}
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "D")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann.metadata["status"] == "finding"
+        assert ann.metadata["stage"] == "D"
+        assert ann.metadata["ruling"] == "confirmed"
+        assert "Stage D ruling: confirmed" in ann.body
+        assert "all checks passed" in ann.body
+
+    def test_exploitable_ruling_maps_to_finding(self, tmp_path):
+        f = _basic_finding(stage_a_status="poc_success")
+        f["ruling"] = {"status": "exploitable"}
+        f["stage_d_summary"] = {"ruling": "exploitable"}
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "D")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann.metadata["status"] == "finding"
+        assert ann.metadata["ruling"] == "exploitable"
+
+    def test_ruled_out_overrides_to_clean(self, tmp_path):
+        """Stage D's ruled_out wins even when Stage A had
+        not_disproven and Stage B never ran."""
+        f = _basic_finding(stage_a_status="not_disproven")
+        f["ruling"] = {
+            "status": "ruled_out",
+            "disqualifier": "D-1",
+            "reason": "code is in test/fixtures/, not production",
+        }
+        f["stage_d_summary"] = {
+            "ruling": "ruled_out",
+            "disqualifier": "D-1",
+        }
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "D")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        # Stage A's not_disproven is overridden by D's ruled_out.
+        assert ann.metadata["status"] == "clean"
+        assert ann.metadata["ruling"] == "ruled_out"
+        # Disqualifier surfaced for filtering.
+        assert "Disqualifier: D-1" in ann.body
+        assert "test/fixtures" in ann.body
+
+    def test_d_ruling_overrides_b_confirmed(self, tmp_path):
+        """If Stage B confirmed but Stage D rules out (e.g. test
+        code disqualifier), Stage D wins."""
+        f = _basic_finding(stage_a_status="not_disproven")
+        f["stage_b_summary"] = {
+            "hypothesis_status": "confirmed", "proximity": 9,
+        }
+        f["ruling"] = {
+            "status": "ruled_out", "disqualifier": "D-1",
+            "reason": "test code",
+        }
+        f["stage_d_summary"] = {"ruling": "ruled_out"}
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "D")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann.metadata["status"] == "clean"
+
+    def test_missing_ruling_falls_back_to_b_or_a(self, tmp_path):
+        """No Stage D ruling yet — fall back to Stage B (or Stage A)
+        so the annotation reflects the latest signal."""
+        f = _basic_finding(stage_a_status="not_disproven")
+        f["stage_b_summary"] = {"hypothesis_status": "confirmed"}
+        # No "ruling" key, no "stage_d_summary".
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "D")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        # Stage B's confirmed wins.
+        assert ann.metadata["status"] == "finding"
+
+    def test_unknown_ruling_falls_back(self, tmp_path):
+        """A future / unrecognised ruling value falls through —
+        never silently sets status='error'."""
+        f = _basic_finding(stage_a_status="not_disproven")
+        f["ruling"] = {"status": "future_ruling_value"}
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "D")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        # Falls back to Stage A's not_disproven → suspicious.
+        assert ann.metadata["status"] == "suspicious"
+
+    def test_cvss_vector_in_metadata_and_body(self, tmp_path):
+        f = _basic_finding(stage_a_status="not_disproven")
+        f["ruling"] = {"status": "confirmed"}
+        f["cvss_vector"] = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "D")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann.metadata["cvss"] == (
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        )
+        assert "CVSS:" in ann.body
+
+    def test_a_to_b_to_d_progression(self, tmp_path):
+        """Realistic full progression: Stage A flags, Stage B
+        confirms hypothesis, Stage D rules confirmed."""
+        f = _basic_finding(stage_a_status="not_disproven")
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "A")
+        ann_a = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann_a.metadata["status"] == "suspicious"
+        assert ann_a.metadata["stage"] == "A"
+
+        # Stage B confirms.
+        f["stage_b_summary"] = {
+            "hypothesis_status": "confirmed", "proximity": 9,
+        }
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "B")
+        ann_b = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann_b.metadata["status"] == "finding"
+        assert ann_b.metadata["stage"] == "B"
+        assert ann_b.metadata["proximity"] == "9"
+
+        # Stage D rules confirmed.
+        f["ruling"] = {"status": "confirmed"}
+        f["cvss_vector"] = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "D")
+        ann_d = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann_d.metadata["status"] == "finding"
+        assert ann_d.metadata["stage"] == "D"
+        assert ann_d.metadata["ruling"] == "confirmed"
+        assert ann_d.metadata["cvss"].startswith("CVSS:3.1")
+        # All three stages' info accumulates in the body.
+        assert "Stage A reasoning" in ann_d.body
+        assert "Stage B verdict" in ann_d.body
+        assert "Stage D verdict" in ann_d.body
 
 
 # ---------------------------------------------------------------------------

--- a/packages/exploitability_validation/tests/test_annotation_emit.py
+++ b/packages/exploitability_validation/tests/test_annotation_emit.py
@@ -1,0 +1,429 @@
+"""Tests for ``packages.exploitability_validation.annotation_emit``.
+
+Builds realistic findings.json fixtures and verifies the per-stage
+annotation emission produces the right shapes — status mapping,
+metadata fields, body content, last-stage-wins semantics across
+A→B, respect-manual preservation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from core.annotations import (
+    Annotation, iter_all_annotations, read_annotation, write_annotation,
+)
+from packages.exploitability_validation.annotation_emit import (
+    emit_stage_annotations,
+)
+
+
+def _write_findings(workdir: Path, findings: list, stage: str = "A"):
+    workdir.mkdir(parents=True, exist_ok=True)
+    container = {
+        "stage": stage,
+        "target_path": "/tmp/fake-target",
+        "findings": findings,
+    }
+    (workdir / "findings.json").write_text(json.dumps(container))
+
+
+def _basic_finding(
+    fid="FIND-001",
+    file="src/auth/login.py",
+    function="check_credentials",
+    cwe="CWE-89",
+    rule_id="py/sql-injection",
+    vuln_type="sql_injection",
+    stage_a_status="not_disproven",
+    stage_a_confidence="medium",
+    candidate_reasoning="tainted query string into cursor.execute",
+    **extras,
+) -> Dict[str, Any]:
+    f = {
+        "id": fid,
+        "file": file,
+        "function": function,
+        "line": 42,
+        "cwe_id": cwe,
+        "rule_id": rule_id,
+        "vuln_type": vuln_type,
+        "candidate_reasoning": candidate_reasoning,
+        "stage_a_summary": {
+            "status": stage_a_status,
+            "confidence": stage_a_confidence,
+            "candidate_reasoning": candidate_reasoning,
+        },
+    }
+    f.update(extras)
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Stage A status mapping
+# ---------------------------------------------------------------------------
+
+
+class TestStageAStatusMapping:
+    def test_poc_success_maps_to_finding(self, tmp_path):
+        _write_findings(tmp_path, [
+            _basic_finding(stage_a_status="poc_success"),
+        ])
+        n = emit_stage_annotations(tmp_path, "A")
+        assert n == 1
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann.metadata["status"] == "finding"
+
+    def test_not_disproven_maps_to_suspicious(self, tmp_path):
+        _write_findings(tmp_path, [
+            _basic_finding(stage_a_status="not_disproven"),
+        ])
+        emit_stage_annotations(tmp_path, "A")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann.metadata["status"] == "suspicious"
+
+    def test_disproven_maps_to_clean(self, tmp_path):
+        _write_findings(tmp_path, [
+            _basic_finding(stage_a_status="disproven"),
+        ])
+        emit_stage_annotations(tmp_path, "A")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann.metadata["status"] == "clean"
+
+    def test_unknown_status_maps_to_error(self, tmp_path):
+        _write_findings(tmp_path, [
+            _basic_finding(stage_a_status="frobnicated"),
+        ])
+        emit_stage_annotations(tmp_path, "A")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann.metadata["status"] == "error"
+
+    def test_missing_summary_maps_to_error(self, tmp_path):
+        # Construct a finding without stage_a_summary.
+        f = _basic_finding()
+        f.pop("stage_a_summary")
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "A")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann.metadata["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Stage A metadata + body
+# ---------------------------------------------------------------------------
+
+
+class TestStageAMetadataAndBody:
+    def test_metadata_contains_finding_context(self, tmp_path):
+        _write_findings(tmp_path, [
+            _basic_finding(stage_a_status="not_disproven"),
+        ])
+        emit_stage_annotations(tmp_path, "A")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann.metadata["source"] == "llm"
+        assert ann.metadata["tool"] == "validate"
+        assert ann.metadata["stage"] == "A"
+        assert ann.metadata["cwe"] == "CWE-89"
+        assert ann.metadata["rule_id"] == "py/sql-injection"
+        assert ann.metadata["vuln_type"] == "sql_injection"
+        assert ann.metadata["finding_id"] == "FIND-001"
+
+    def test_body_includes_candidate_reasoning(self, tmp_path):
+        _write_findings(tmp_path, [
+            _basic_finding(
+                stage_a_status="not_disproven",
+                candidate_reasoning="user input flows to db.execute",
+            ),
+        ])
+        emit_stage_annotations(tmp_path, "A")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert "user input flows to db.execute" in ann.body
+        assert "Confidence: medium" in ann.body
+
+    def test_disproof_rationale_included_when_disproven(self, tmp_path):
+        f = _basic_finding(stage_a_status="disproven")
+        f["disproved_because"] = {
+            "investigated": "tested 8 input vectors against the regex",
+            "conclusion": "regex covers all attack inputs",
+            "would_reconsider_if": "regex is changed",
+        }
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "A")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert "Disproof rationale" in ann.body
+        assert "regex covers all attack inputs" in ann.body
+
+
+# ---------------------------------------------------------------------------
+# Stage B updates
+# ---------------------------------------------------------------------------
+
+
+class TestStageBUpdates:
+    def test_confirmed_hypothesis_overrides_stage_a_to_finding(self, tmp_path):
+        f = _basic_finding(stage_a_status="not_disproven")
+        f["stage_b_summary"] = {
+            "hypothesis_id": "H-1",
+            "hypothesis_status": "confirmed",
+            "proximity": 8,
+            "attack_path_id": "AP-001",
+        }
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "B")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        # Stage B's confirmed hypothesis upgrades suspicious → finding.
+        assert ann.metadata["status"] == "finding"
+        assert ann.metadata["stage"] == "B"
+        # Stage B body extends Stage A's.
+        assert "Stage A reasoning" in ann.body
+        assert "Stage B verdict" in ann.body
+        assert "Hypothesis: confirmed" in ann.body
+        assert "Proximity: 8/10" in ann.body
+        # Proximity surfaces in metadata for filtering.
+        assert ann.metadata["proximity"] == "8"
+
+    def test_disproven_hypothesis_overrides_to_clean(self, tmp_path):
+        f = _basic_finding(stage_a_status="not_disproven")
+        f["stage_b_summary"] = {
+            "hypothesis_id": "H-1",
+            "hypothesis_status": "disproven",
+            "proximity": 1,
+        }
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "B")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        # Disproven downgrades to clean.
+        assert ann.metadata["status"] == "clean"
+
+    def test_testing_hypothesis_keeps_stage_a_status(self, tmp_path):
+        f = _basic_finding(stage_a_status="not_disproven")
+        f["stage_b_summary"] = {
+            "hypothesis_status": "testing",
+            "proximity": 4,
+        }
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "B")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        # Still suspicious — Stage A's status preserved.
+        assert ann.metadata["status"] == "suspicious"
+
+    def test_stage_b_without_summary_keeps_stage_a(self, tmp_path):
+        f = _basic_finding(stage_a_status="not_disproven")
+        # No stage_b_summary at all.
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "B")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann.metadata["status"] == "suspicious"
+
+
+# ---------------------------------------------------------------------------
+# A→B progression — sequential calls
+# ---------------------------------------------------------------------------
+
+
+class TestSequentialStages:
+    def test_a_then_b_progression(self, tmp_path):
+        """Realistic flow: emit Stage A first, then Stage B updates
+        the same finding's annotation."""
+        f = _basic_finding(stage_a_status="not_disproven")
+        _write_findings(tmp_path, [f])
+        n_a = emit_stage_annotations(tmp_path, "A")
+        assert n_a == 1
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann.metadata["status"] == "suspicious"
+        assert ann.metadata["stage"] == "A"
+
+        # Stage B fills in hypothesis verdict.
+        f["stage_b_summary"] = {
+            "hypothesis_id": "H-1",
+            "hypothesis_status": "confirmed",
+            "proximity": 9,
+        }
+        _write_findings(tmp_path, [f])
+        n_b = emit_stage_annotations(tmp_path, "B")
+        assert n_b == 1
+        ann2 = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        # Stage B's verdict overwrites Stage A's annotation.
+        assert ann2.metadata["status"] == "finding"
+        assert ann2.metadata["stage"] == "B"
+        assert ann2.metadata["proximity"] == "9"
+
+
+# ---------------------------------------------------------------------------
+# Respect-manual preservation
+# ---------------------------------------------------------------------------
+
+
+class TestRespectManual:
+    def test_operator_annotation_preserved_through_validate(self, tmp_path):
+        """Operator's prior manual review note must survive a
+        /validate Stage A emission."""
+        write_annotation(
+            tmp_path / "annotations",
+            Annotation(
+                file="src/auth/login.py", function="check_credentials",
+                body="Reviewed by alice — false positive after manual audit",
+                metadata={"source": "human", "status": "clean"},
+            ),
+        )
+        _write_findings(tmp_path, [
+            _basic_finding(stage_a_status="not_disproven"),
+        ])
+        n = emit_stage_annotations(tmp_path, "A")
+        # respect-manual blocked the write.
+        assert n == 0
+        # Operator's content intact.
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann.metadata["source"] == "human"
+        assert "alice" in ann.body
+
+
+# ---------------------------------------------------------------------------
+# Edge cases / robustness
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_no_findings_json_returns_zero(self, tmp_path):
+        assert emit_stage_annotations(tmp_path, "A") == 0
+
+    def test_invalid_findings_json_returns_zero(self, tmp_path):
+        (tmp_path / "findings.json").write_text("{ not valid json")
+        # load_json swallows JSONDecodeError; helper returns 0.
+        assert emit_stage_annotations(tmp_path, "A") == 0
+
+    def test_findings_not_a_list_returns_zero(self, tmp_path):
+        (tmp_path / "findings.json").write_text(
+            json.dumps({"findings": "not a list"})
+        )
+        assert emit_stage_annotations(tmp_path, "A") == 0
+
+    def test_finding_without_function_skipped(self, tmp_path):
+        f = _basic_finding(function="")
+        _write_findings(tmp_path, [f])
+        assert emit_stage_annotations(tmp_path, "A") == 0
+
+    def test_finding_without_file_skipped(self, tmp_path):
+        f = _basic_finding(file="")
+        _write_findings(tmp_path, [f])
+        assert emit_stage_annotations(tmp_path, "A") == 0
+
+    def test_unknown_stage_returns_zero(self, tmp_path):
+        _write_findings(tmp_path, [_basic_finding()])
+        # Stages C-F not yet wired — no-op.
+        assert emit_stage_annotations(tmp_path, "C") == 0
+        assert emit_stage_annotations(tmp_path, "D") == 0
+        assert emit_stage_annotations(tmp_path, "E") == 0
+        assert emit_stage_annotations(tmp_path, "F") == 0
+
+    def test_multiple_findings_each_get_annotation(self, tmp_path):
+        _write_findings(tmp_path, [
+            _basic_finding(fid="FIND-001",
+                            function="check_credentials"),
+            _basic_finding(fid="FIND-002",
+                            function="other_login",
+                            file="src/auth/other.py"),
+            _basic_finding(fid="FIND-003",
+                            function="admin_action",
+                            file="src/admin/actions.py"),
+        ])
+        assert emit_stage_annotations(tmp_path, "A") == 3
+        anns = list(iter_all_annotations(tmp_path / "annotations"))
+        assert len(anns) == 3
+
+    def test_non_dict_finding_skipped(self, tmp_path):
+        """A malformed entry that isn't a dict shouldn't crash the
+        whole pass."""
+        (tmp_path / "findings.json").write_text(json.dumps({
+            "findings": [
+                _basic_finding(),
+                "not a dict",  # malformed
+                {"id": "FIND-X"},  # incomplete
+                _basic_finding(fid="FIND-002",
+                                function="other",
+                                file="src/other.py"),
+            ],
+        }))
+        n = emit_stage_annotations(tmp_path, "A")
+        # Two valid findings → two annotations; two skipped.
+        assert n == 2
+
+
+# ---------------------------------------------------------------------------
+# Adversarial — hostile metadata in finding fields
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarial:
+    def test_hostile_cwe_sanitised(self, tmp_path):
+        _write_findings(tmp_path, [
+            _basic_finding(cwe="CWE-89-->\n## evil"),
+        ])
+        emit_stage_annotations(tmp_path, "A")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert "-->" not in ann.metadata["cwe"]
+        assert "\n" not in ann.metadata["cwe"]
+
+    def test_hostile_finding_id_sanitised(self, tmp_path):
+        _write_findings(tmp_path, [
+            _basic_finding(fid="FIND-001\n## evil\x00"),
+        ])
+        emit_stage_annotations(tmp_path, "A")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert "\n" not in ann.metadata["finding_id"]
+        assert "\x00" not in ann.metadata["finding_id"]

--- a/packages/exploitability_validation/tests/test_annotation_emit_adversarial.py
+++ b/packages/exploitability_validation/tests/test_annotation_emit_adversarial.py
@@ -1,0 +1,420 @@
+"""Adversarial + E2E coverage for /validate's annotation emission.
+
+Probes inputs a faulty / compromised upstream could plausibly hand
+the stage-merge annotation step. Plus an end-to-end run through
+``libexec/raptor-validation-helper`` to verify the wire-up actually
+fires after a stage merge.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from core.annotations import (
+    Annotation, iter_all_annotations, read_annotation,
+)
+from packages.exploitability_validation.annotation_emit import (
+    emit_stage_annotations,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HELPER = REPO_ROOT / "libexec" / "raptor-validation-helper"
+
+
+def _basic_finding(**overrides) -> Dict[str, Any]:
+    f = {
+        "id": "FIND-001",
+        "file": "src/auth/login.py",
+        "function": "check_credentials",
+        "line": 42,
+        "cwe_id": "CWE-89",
+        "rule_id": "py/sql-injection",
+        "vuln_type": "sql_injection",
+        "candidate_reasoning": "tainted query string into cursor.execute",
+        "stage_a_summary": {
+            "status": "not_disproven",
+            "confidence": "medium",
+            "candidate_reasoning": "tainted query string into cursor.execute",
+        },
+    }
+    f.update(overrides)
+    return f
+
+
+def _write_findings(workdir: Path, findings: list, stage="A"):
+    workdir.mkdir(parents=True, exist_ok=True)
+    (workdir / "findings.json").write_text(json.dumps({
+        "stage": stage, "target_path": "/tmp/fake", "findings": findings,
+    }))
+
+
+# ---------------------------------------------------------------------------
+# Adversarial body content
+# ---------------------------------------------------------------------------
+
+
+class TestHostileBody:
+    def test_fake_heading_in_candidate_reasoning(self, tmp_path):
+        """``candidate_reasoning`` flows into the annotation body.
+        A reasoning string containing ``\\n## evil_function`` could,
+        on a later read of the .md, mis-parse as a separate section
+        — known substrate limitation pinned in test_storage.py.
+
+        Pin: the IMMEDIATE write succeeds, no crash, the section
+        we wrote is recoverable. Anything stronger needs the
+        substrate to gain code-fence awareness or markdown-escape
+        the body."""
+        f = _basic_finding(
+            stage_a_summary={
+                "status": "not_disproven",
+                "confidence": "medium",
+                "candidate_reasoning": (
+                    "main path looks clean BUT\n"
+                    "## evil_function\n"
+                    "more reasoning"
+                ),
+            },
+        )
+        _write_findings(tmp_path, [f])
+        n = emit_stage_annotations(tmp_path, "A")
+        assert n == 1
+        # Direct read by name still works.
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann is not None
+        assert ann.metadata["status"] == "suspicious"
+
+    def test_html_comment_in_disproof_does_not_corrupt_metadata(
+        self, tmp_path,
+    ):
+        """``disproved_because`` flows into BODY (not metadata) so
+        ``-->`` content there can't corrupt the metadata HTML
+        comment. Pin that the write succeeds and metadata is
+        intact."""
+        f = _basic_finding(
+            stage_a_summary={"status": "disproven", "confidence": "high"},
+        )
+        f["disproved_because"] = {
+            "investigated": "tested 5 inputs",
+            "conclusion": "regex covers all -->evil<!-- patterns",
+            "would_reconsider_if": "regex changes",
+        }
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "A")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        # Metadata still parseable.
+        assert ann.metadata["status"] == "clean"
+        # Body preserves operator's prose verbatim.
+        assert "regex covers all" in ann.body
+
+    def test_huge_candidate_reasoning_preserved(self, tmp_path):
+        """Stage A's reasoning could be 100KB if the LLM is verbose.
+        Annotation body is free-form prose — no truncation, no
+        crash. The substrate writes whatever it's given."""
+        big = "x " * 50_000  # ~100KB
+        f = _basic_finding(
+            stage_a_summary={
+                "status": "not_disproven",
+                "confidence": "medium",
+                "candidate_reasoning": big,
+            },
+        )
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "A")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert len(ann.body) >= 100_000
+
+
+# ---------------------------------------------------------------------------
+# Multiple findings sharing source files
+# ---------------------------------------------------------------------------
+
+
+class TestSameFileMultipleFindings:
+    def test_two_findings_one_file_two_sections(self, tmp_path):
+        """Two findings in the same source file but different
+        functions land as two ``## function_name`` sections in
+        the same .md file."""
+        _write_findings(tmp_path, [
+            _basic_finding(
+                fid="FIND-001",
+                **{"id": "FIND-001"},
+            ),
+            _basic_finding(
+                **{
+                    "id": "FIND-002",
+                    "function": "logout",
+                    "stage_a_summary": {
+                        "status": "disproven",
+                        "confidence": "high",
+                        "candidate_reasoning": "no taint reaches sink",
+                    },
+                },
+            ),
+        ])
+        n = emit_stage_annotations(tmp_path, "A")
+        assert n == 2
+        # Both functions show up in the same .md.
+        md = (tmp_path / "annotations" / "src" / "auth" / "login.py.md")
+        assert md.exists()
+        text = md.read_text()
+        assert "## check_credentials" in text
+        assert "## logout" in text
+        # Different statuses preserved.
+        ann1 = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        ann2 = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "logout",
+        )
+        assert ann1.metadata["status"] == "suspicious"
+        assert ann2.metadata["status"] == "clean"
+
+
+# ---------------------------------------------------------------------------
+# E2E — drive libexec/raptor-validation-helper
+# ---------------------------------------------------------------------------
+
+
+def _run_helper(*args, env_extra=None):
+    env = dict(os.environ)
+    env["_RAPTOR_TRUSTED"] = "1"
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(HELPER), *args],
+        env=env, capture_output=True, text=True, timeout=60,
+    )
+
+
+def _plant_minimal_run(workdir):
+    """Set up a workdir with the lifecycle marker + a minimal
+    checklist.json (required by prepare_A)."""
+    workdir.mkdir(parents=True, exist_ok=True)
+    (workdir / ".raptor-run.json").write_text("{}")
+    (workdir / "checklist.json").write_text(json.dumps({
+        "total_files": 1,
+        "total_items": 1,
+        "total_sloc": 100,
+        "files": [
+            {"path": "src/auth/login.py",
+             "items": [{"name": "check_credentials"}]}
+        ],
+    }))
+
+
+class TestHelperE2E:
+    """End-to-end tests through ``libexec/raptor-validation-helper``.
+
+    Helper convention: stage X's output (``stage-X.json``) is
+    merged into findings.json at the START of stage X+1's prep,
+    not at the end of stage X. So to exercise the Stage A merge +
+    annotation emit, drive the helper at Stage B.
+    """
+
+    def test_stage_a_merge_emits_annotations(self, tmp_path):
+        """Drop stage-a.json, run helper at Stage B (which calls
+        _apply_stage_file("A") as its first step), verify
+        findings.json built and annotations emitted."""
+        workdir = tmp_path / "validate-run"
+        _plant_minimal_run(workdir)
+
+        stage_a_data = {
+            "stage": "A",
+            "target_path": "/tmp/fake-target",
+            "findings": [
+                {
+                    "id": "FIND-001",
+                    "file": "src/auth/login.py",
+                    "function": "check_credentials",
+                    "line": 42,
+                    "cwe_id": "CWE-89",
+                    "rule_id": "py/sql-injection",
+                    "vuln_type": "sql_injection",
+                    "stage_a_summary": {
+                        "status": "not_disproven",
+                        "confidence": "medium",
+                        "candidate_reasoning": (
+                            "user input via request.args reaches "
+                            "cursor.execute through f-string"
+                        ),
+                    },
+                },
+                {
+                    "id": "FIND-002",
+                    "file": "src/admin/users.py",
+                    "function": "delete_user",
+                    "line": 87,
+                    "cwe_id": "CWE-352",
+                    "rule_id": "py/csrf",
+                    "vuln_type": "csrf",
+                    "stage_a_summary": {
+                        "status": "poc_success",
+                        "confidence": "high",
+                        "candidate_reasoning": (
+                            "no CSRF token check on delete endpoint"
+                        ),
+                    },
+                },
+            ],
+        }
+        (workdir / "stage-a.json").write_text(json.dumps(stage_a_data))
+
+        # Run helper at Stage B — the merge of stage-a.json + the
+        # annotation emit happen as Stage B's first prep step.
+        r = _run_helper("B", str(workdir))
+        assert r.returncode == 0, (
+            f"helper failed:\nstdout={r.stdout}\nstderr={r.stderr}"
+        )
+
+        # findings.json built from stage-a.json.
+        findings_path = workdir / "findings.json"
+        assert findings_path.exists()
+        container = json.loads(findings_path.read_text())
+        assert len(container["findings"]) == 2
+
+        # Annotations emitted.
+        anns = list(iter_all_annotations(workdir / "annotations"))
+        assert len(anns) == 2
+        names = sorted(a.function for a in anns)
+        assert names == ["check_credentials", "delete_user"]
+
+        # Status mapping flowed through correctly.
+        check = read_annotation(
+            workdir / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert check.metadata["status"] == "suspicious"
+        assert check.metadata["tool"] == "validate"
+        assert check.metadata["stage"] == "A"
+
+        delete = read_annotation(
+            workdir / "annotations",
+            "src/admin/users.py", "delete_user",
+        )
+        assert delete.metadata["status"] == "finding"
+
+        # Helper output mentions the annotation count.
+        assert "Annotations emitted: 2" in r.stdout
+
+    def test_stage_b_merge_updates_annotations(self, tmp_path):
+        """Drop both stage-a.json (so Stage B's prep can merge it)
+        AND stage-b.json (so Stage C's prep merges it), then run
+        helper at Stage B and Stage C. After Stage C's prep, the
+        Stage B annotation update should be live."""
+        workdir = tmp_path / "validate-run"
+        _plant_minimal_run(workdir)
+
+        # Plant Stage A so Stage B's prep can build findings.json.
+        stage_a = {
+            "stage": "A",
+            "target_path": "/tmp/fake-target",
+            "findings": [{
+                "id": "FIND-001",
+                "file": "src/auth/login.py",
+                "function": "check_credentials",
+                "line": 42,
+                "cwe_id": "CWE-89",
+                "vuln_type": "sql_injection",
+                "stage_a_summary": {
+                    "status": "not_disproven",
+                    "confidence": "medium",
+                    "candidate_reasoning": "tainted query",
+                },
+            }],
+        }
+        (workdir / "stage-a.json").write_text(json.dumps(stage_a))
+        r = _run_helper("B", str(workdir))
+        assert r.returncode == 0, r.stderr
+
+        # Sanity: Stage A annotation now exists, suspicious.
+        ann = read_annotation(
+            workdir / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann is not None, "Stage A merge should have emitted annotation"
+        assert ann.metadata["status"] == "suspicious"
+        assert ann.metadata["stage"] == "A"
+
+        # Plant Stage B's output. Running helper at Stage C will
+        # merge stage-b.json + emit Stage B annotations.
+        stage_b = {
+            "stage": "B",
+            "updates": {
+                "FIND-001": {
+                    "stage_b_summary": {
+                        "hypothesis_id": "H-1",
+                        "hypothesis_status": "confirmed",
+                        "proximity": 9,
+                        "attack_path_id": "AP-001",
+                    }
+                }
+            },
+        }
+        (workdir / "stage-b.json").write_text(json.dumps(stage_b))
+        r = _run_helper("C", str(workdir))
+        # Stage C may have its own prep issues unrelated to the
+        # merge — accept non-zero exit as long as the merge step
+        # completed (which is what runs first).
+        # The annotation update is the artefact we verify.
+        ann2 = read_annotation(
+            workdir / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann2.metadata["status"] == "finding"
+        assert ann2.metadata["stage"] == "B"
+        assert ann2.metadata["proximity"] == "9"
+        assert "Hypothesis: confirmed" in ann2.body
+        assert "Proximity: 9/10" in ann2.body
+
+    def test_apply_stage_file_invokes_emit_for_unknown_stage(
+        self, tmp_path,
+    ):
+        """Stages C-F are no-ops for annotation emission. The
+        annotation_emit module's emit_stage_annotations returns 0
+        for those stages — the helper's wire-in calls the same
+        function but produces no output. Pin the emission call's
+        no-op contract by exercising it directly (avoids prepare_C's
+        own separate issues with empty workdirs)."""
+        # Pre-existing Stage A annotation.
+        _write_findings(tmp_path, [_basic_finding()])
+        emit_stage_annotations(tmp_path, "A")
+        ann_before = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann_before.metadata["stage"] == "A"
+
+        # Add stage_c_summary to the finding (mimics the merge that
+        # would happen for Stage C). The merge wire-in calls
+        # emit_stage_annotations with "C" — should be a no-op.
+        f = _basic_finding()
+        f["stage_c_summary"] = {"sanity_passed": True}
+        _write_findings(tmp_path, [f])
+        n = emit_stage_annotations(tmp_path, "C")
+        assert n == 0  # Stage C is not wired.
+
+        # Stage A's annotation untouched.
+        ann_after = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann_after.metadata["stage"] == "A"

--- a/packages/exploitability_validation/tests/test_annotation_emit_adversarial.py
+++ b/packages/exploitability_validation/tests/test_annotation_emit_adversarial.py
@@ -385,6 +385,118 @@ class TestHelperE2E:
         assert "Hypothesis: confirmed" in ann2.body
         assert "Proximity: 9/10" in ann2.body
 
+    def test_stage_d_ruling_supersedes_b_via_helper(self, tmp_path):
+        """Drive helper through A → B → D. Final annotation should
+        carry Stage D's ruling (overriding Stage B's verdict if
+        they differ). Pin the canonical-final-verdict semantic."""
+        workdir = tmp_path / "validate-run"
+        _plant_minimal_run(workdir)
+
+        # Stage A.
+        (workdir / "stage-a.json").write_text(json.dumps({
+            "stage": "A", "target_path": "/tmp/fake",
+            "findings": [{
+                "id": "FIND-001",
+                "file": "src/auth/login.py",
+                "function": "check_credentials",
+                "line": 42, "cwe_id": "CWE-89",
+                "vuln_type": "sql_injection",
+                "stage_a_summary": {
+                    "status": "not_disproven",
+                    "confidence": "medium",
+                    "candidate_reasoning": "tainted query",
+                },
+            }],
+        }))
+        r = _run_helper("B", str(workdir))
+        assert r.returncode == 0
+
+        # Stage B confirms hypothesis (would map to status=finding).
+        (workdir / "stage-b.json").write_text(json.dumps({
+            "stage": "B",
+            "updates": {
+                "FIND-001": {
+                    "stage_b_summary": {
+                        "hypothesis_status": "confirmed",
+                        "proximity": 8,
+                    }
+                }
+            },
+        }))
+        # Run Stage C — merges Stage B's output + emits Stage B
+        # annotations. Stage C's own prep may have unrelated issues,
+        # but the merge happens first and is what we're testing.
+        _run_helper("C", str(workdir))
+        ann_b = read_annotation(
+            workdir / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann_b.metadata["status"] == "finding"
+        assert ann_b.metadata["stage"] == "B"
+
+        # Stage D rules ruled_out (e.g. test code) — should override
+        # Stage B's finding back down to clean.
+        (workdir / "stage-d.json").write_text(json.dumps({
+            "stage": "D",
+            "updates": {
+                "FIND-001": {
+                    "ruling": {
+                        "status": "ruled_out",
+                        "disqualifier": "D-1",
+                        "reason": "code is in test fixtures",
+                    },
+                    "stage_d_summary": {
+                        "ruling": "ruled_out",
+                        "disqualifier": "D-1",
+                    },
+                    "status": "ruled_out",
+                }
+            },
+        }))
+        # Stage E merges Stage D's output.
+        _run_helper("E", str(workdir))
+        ann_d = read_annotation(
+            workdir / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        # Stage D's ruled_out wins.
+        assert ann_d.metadata["status"] == "clean"
+        assert ann_d.metadata["stage"] == "D"
+        assert ann_d.metadata["ruling"] == "ruled_out"
+        assert "D-1" in ann_d.body
+        assert "test fixtures" in ann_d.body
+
+    def test_hostile_ruling_status_falls_back_safely(self, tmp_path):
+        """A future/unmapped ruling value mustn't silently mark a
+        confirmed-by-B finding as error — the picker falls through
+        to Stage B/A. Pin the safety net."""
+        f = _basic_finding(stage_a_status="not_disproven")
+        f["stage_b_summary"] = {"hypothesis_status": "confirmed"}
+        f["ruling"] = {"status": "frobnicated"}
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "D")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        # Falls back to Stage B's confirmed → finding.
+        assert ann.metadata["status"] == "finding"
+
+    def test_hostile_cvss_vector_sanitised(self, tmp_path):
+        """CVSS strings are operator-controlled output; sanitise
+        before they hit annotation metadata."""
+        f = _basic_finding(stage_a_status="not_disproven")
+        f["ruling"] = {"status": "confirmed"}
+        f["cvss_vector"] = "CVSS:3.1/AV:N\n## evil-->payload"
+        _write_findings(tmp_path, [f])
+        emit_stage_annotations(tmp_path, "D")
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert "\n" not in ann.metadata["cvss"]
+        assert "-->" not in ann.metadata["cvss"]
+
     def test_apply_stage_file_invokes_emit_for_unknown_stage(
         self, tmp_path,
     ):


### PR DESCRIPTION
Fourth reuse of the annotations substrate. /validate previously produced findings.json + per-stage working docs but no per-function annotations — operators tracking review state across runs had to reconcile structured outputs themselves. This wires annotation emission into the stage-merge step so each finding produces an annotation that progresses with the verdict from each stage.

Module: packages/exploitability_validation/annotation_emit.py.
Wired into libexec/raptor-validation-helper after each _apply_stage_file. Best-effort throughout — annotation failures never break the /validate pipeline.

**Stage A → emit one annotation per finding:**
- poc_success → status=finding (exploitable confirmed)
- not_disproven → status=suspicious (needs Stage B+)
- disproven → status=clean (definitively safe)
- unknown/missing → status=error

Body: candidate_reasoning + Stage A summary + disproof rationale.
Metadata: source=llm, tool=validate, stage=A, cwe, rule_id, vuln_type, finding_id.

**Stage B → update annotation with hypothesis verdict + proximity:**
- hypothesis_status=confirmed → status=finding
- hypothesis_status=disproven → status=clean
- hypothesis_status=testing/uncertain → keep prior status

Body extends Stage A's with hypothesis block (id, status, proximity, attack-path id). Metadata gains `proximity` (filterable via /annotate ls).

**Stage D → final ruling, supersedes A and B:**
- ruling.status=confirmed/exploitable → status=finding
- ruling.status=ruled_out → status=clean

Fall-through: missing/unmapped ruling falls back to Stage B then Stage A — never silently downgrades to error.
Body extends with Stage D block (ruling, disqualifier D-0..D-4, reason, CVSS vector, evidence_synthesis.synthesis).
Metadata gains `ruling` and `cvss` keys.

Stages C, E, F not wired by design: C feeds D's ruling, E refines D rarely, F is procedural. Emission function returns 0 for them so the helper can call it from any stage's prep without conditional plumbing.

Helper-merge convention pinned in tests: stage X's output merges at the START of stage X+1's prep (not at the end of X). Annotation emit fires alongside that merge. Tests follow this convention so future readers don't have to discover it.

**Defences:**
- respect-manual preserves operator-written annotations across all stages (source=human never clobbered)
- Metadata sanitiser strips newlines / nulls / HTML-comment delimiters from cwe / rule_id / vuln_type / finding_id / ruling / cvss
- Hostile body content (fake ## heading injection in candidate_reasoning, -->/<!-- in disproof rationale) doesn't crash the write — known substrate limitation pinned (same as /agentic and KNighter follow-up)
- Hostile ruling status falls back to prior stage rather than silently emitting an error verdict
- 100KB candidate_reasoning preserved verdict-faithfully

**E2E proven via real libexec/raptor-validation-helper invocation:**
- Drop stage-a.json, run helper at Stage B → findings.json built, Stage A annotations land
- Drop stage-b.json, run helper at Stage C → annotations upgraded with Stage B verdict
- Drop stage-d.json with ruled_out, run helper at Stage E → Stage B's confirmed flipped to clean per Stage D ruling

42 tests cover: 5+4+8 status mappings (A direct + missing summary, B direct + carry-forward, D direct + B/A fall-throughs + unknown); metadata + body content per stage; full A→B→D progression preserves all three stages' info in the body and ends at the canonical ruling; respect-manual preservation; 8 edge cases (missing files, invalid JSON, non-list, missing function/file, non-dict entries, multi-finding, unwired stages); 5 adversarial (hostile metadata sanitised, hostile ruling falls back, hostile CVSS sanitised, fake-heading body limitation pinned, HTML-comment in body doesn't corrupt metadata); 4 helper-E2E (Stage A merge, Stage B merge, Stage D ruling supersedes B, unwired-stage no-op contract).

Substrate dependency: core/annotations (PR #393).