### PR TITLE
feat(iris): wire cwe_strategies substrate into dataflow validator prompt

### DIFF
--- a/packages/llm_analysis/dataflow_validation.py
+++ b/packages/llm_analysis/dataflow_validation.py
@@ -548,6 +548,62 @@ def validate_dataflow_claims(
 # Internals -------------------------------------------------------------------
 
 
+def _build_strategy_block(
+    *,
+    cwe: str,
+    file_path: str,
+    function: str,
+    finding: Dict,
+) -> str:
+    """Render CWE-strategy guidance for the IRIS validator prompt.
+
+    Returns a markdown block to append to ``trusted_parts``, or
+    empty string when the substrate is unavailable / picker raises.
+    Strategies are operator-curated trusted YAML, suitable for the
+    trusted (system-prompt-equivalent) part of the Hypothesis
+    context.
+
+    Best-effort: any error returns an empty string. The validator
+    runs unchanged on failure.
+    """
+    try:
+        from core.llm.cwe_strategies import (
+            pick_strategies, render_strategies,
+        )
+    except Exception:
+        return ""
+
+    candidate_cwes = [cwe] if cwe else []
+    # Inventory metadata may carry callees / includes — best-effort.
+    meta = finding.get("metadata") or {}
+    function_calls = meta.get("calls") or meta.get("callees") or ()
+    file_includes = meta.get("includes") or ()
+    try:
+        picked = pick_strategies(
+            file_path=file_path or "",
+            function_name=function or "",
+            file_includes=tuple(file_includes),
+            function_calls_made=tuple(function_calls),
+            candidate_cwes=tuple(candidate_cwes),
+            max_strategies=3,
+        )
+        if not picked:
+            return ""
+        rendered = render_strategies(picked)
+    except Exception:
+        return ""
+    return (
+        "## Bug-class lenses for this validation\n"
+        "\n"
+        "Apply the following strategy lenses' key questions and "
+        "worked CVE exemplars while reasoning about whether the "
+        "dataflow claim holds. The exemplars prime reasoning "
+        "depth — they are not patterns to match against.\n"
+        "\n"
+        f"{rendered}"
+    )
+
+
 def _build_hypothesis(finding: Dict, analysis: Dict, repo_path: Path):
     """Construct a Hypothesis from a Semgrep finding + LLM analysis.
 
@@ -582,6 +638,19 @@ def _build_hypothesis(finding: Dict, analysis: Dict, repo_path: Path):
     rule_id = finding.get("rule_id") or ""
     if rule_id:
         trusted_parts.append(f"Semgrep rule: {_sanitize_for_prompt(rule_id)}")
+
+    # CWE-specialised strategy lenses. The IRIS pack name encodes the
+    # CWE (e.g. ``Security/CWE-022/PathTraversalLocal.ql``) so we
+    # always have a strong signal here. Strategies prime reasoning
+    # depth for the bug class — particularly valuable for niche CWEs
+    # (CWE-022 path traversal, CWE-094 code injection, CWE-502
+    # deserialisation) where the validator has less training-data
+    # exposure than for SQL injection / XSS.
+    strategy_block = _build_strategy_block(
+        cwe=cwe, file_path=file_path, function=function, finding=finding,
+    )
+    if strategy_block:
+        trusted_parts.append(strategy_block)
 
     # Target-derived bits (LLM-rendered or directly from target source)
     # go inside an untrusted-block envelope.

--- a/packages/llm_analysis/tests/test_dataflow_validation.py
+++ b/packages/llm_analysis/tests/test_dataflow_validation.py
@@ -1541,11 +1541,14 @@ class TestBuildHypothesis:
         a = {"dataflow_summary": "claim", "reasoning": "x" * 10_000}
         h = _build_hypothesis(f, a, tmp_path)
         assert "…" in h.context
-        # Bounded: guidance block (now larger after CodeQL import-path
-        # specifics, ~2.5K chars) + 800-char reasoning excerpt + tags +
-        # trusted bits. 5000 is a comfortable upper bound that still
-        # catches an unbounded reasoning leak.
-        assert len(h.context) < 5000
+        # Bounded: guidance block (~2.5K) + CWE-strategy block
+        # (general always fires, ~1.2K when no specialised match) +
+        # 800-char reasoning excerpt + tags + trusted bits. 8000 is
+        # a comfortable upper bound that still catches an unbounded
+        # reasoning leak. (Bound bumped from 5000 when strategy
+        # lenses were wired into the validator prompt — strategy
+        # content is operator-curated trusted YAML.)
+        assert len(h.context) < 8000
 
     def test_truncates_long_dataflow_summary(self, tmp_path):
         f = {"file_path": "x", "start_line": 1}

--- a/packages/llm_analysis/tests/test_iris_strategy_adversarial.py
+++ b/packages/llm_analysis/tests/test_iris_strategy_adversarial.py
@@ -1,0 +1,271 @@
+"""Adversarial + E2E coverage for the cwe_strategies wire-in to
+IRIS's dataflow validator.
+
+Probes hostile inputs and verifies the rendered Hypothesis context
+is well-formed across realistic IRIS finding shapes. Covers the
+gaps left by ``test_iris_strategy_wiring.py`` (which focuses on
+happy-path picks).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from packages.llm_analysis.dataflow_validation import (
+    _build_hypothesis,
+    _build_strategy_block,
+)
+
+
+# ---------------------------------------------------------------------------
+# Hostile finding fields
+# ---------------------------------------------------------------------------
+
+
+class TestHostileFindingFields:
+    def test_newline_in_file_path_doesnt_corrupt_strategy_block(
+        self, tmp_path,
+    ):
+        """Pre-existing limitation: ``_sanitize_for_prompt`` neutralises
+        envelope-tag forgery, not arbitrary markdown headings — a
+        file_path with a newline-embedded ``## INJECTED`` heading does
+        echo into the trusted-parts ``Reported location:`` line. That's
+        not an issue this PR creates or fixes; the strategy block
+        itself is rendered from operator-curated YAML and isn't
+        affected by hostile file_path content. Pin: strategy block
+        content is intact regardless of what's elsewhere in the
+        context."""
+        finding = {
+            "file_path": "src/foo.py\n## INJECTED",
+            "start_line": 1, "rule_id": "x", "function": "f",
+            "cwe_id": "CWE-89",
+        }
+        h = _build_hypothesis(finding, {}, tmp_path)
+        # Strategy block fired and rendered cleanly.
+        assert "Bug-class lenses" in h.context
+        assert "## Strategy: input_handling" in h.context
+        # Strategy block itself doesn't contain the injection.
+        bug_pos = h.context.index("Bug-class lenses")
+        injected_pos = h.context.find("## INJECTED")
+        if injected_pos != -1:
+            # If present, it's BEFORE the strategy block (in the
+            # Reported-location line) — pre-existing leak path,
+            # not introduced by this PR.
+            assert injected_pos < bug_pos
+
+    def test_newline_in_function_name_no_fake_heading(self, tmp_path):
+        finding = {
+            "file_path": "src/x.py", "start_line": 1,
+            "rule_id": "x",
+            "function": "parse\n## INJECTED_HEADING",
+            "cwe_id": "CWE-89",
+        }
+        h = _build_hypothesis(finding, {}, tmp_path)
+        assert "## INJECTED_HEADING" not in h.context
+        # The legitimate ``parse`` token still pins input_handling.
+        assert "## Strategy: input_handling" in h.context
+
+    def test_huge_cwe_id_doesnt_blow_up_context(self, tmp_path):
+        finding = {
+            "file_path": "src/x.py", "start_line": 1,
+            "rule_id": "x", "function": "f",
+            "cwe_id": "CWE-" + "9" * 50_000,
+        }
+        h = _build_hypothesis(finding, {}, tmp_path)
+        # Picker treats it as no-match (no strategy declares such
+        # a CWE). Context bounded; no echo of the giant string.
+        assert "CWE-99999999999999" not in h.context
+        # Still under a reasonable size.
+        assert len(h.context) < 10_000
+
+    def test_hostile_metadata_calls_with_none_member(self, tmp_path):
+        """A None entry in metadata.calls list shouldn't crash the
+        picker — operator-supplied lists may be sloppy."""
+        finding = {
+            "file_path": "src/x.py", "start_line": 1,
+            "rule_id": "x", "function": "f",
+            "metadata": {"calls": ["mutex_lock", None, "kfree"]},
+        }
+        h = _build_hypothesis(finding, {}, tmp_path)
+        # No crash; whatever the picker filtered on still produces
+        # output. concurrency strategy fires on mutex_lock.
+        assert "## Strategy:" in h.context
+
+    def test_hostile_metadata_huge_calls_list(self, tmp_path):
+        """1000-entry calls list — picker scales, render_strategies
+        caps total output."""
+        finding = {
+            "file_path": "src/x.py", "start_line": 1,
+            "rule_id": "x", "function": "f",
+            "metadata": {
+                "calls": (
+                    ["mutex_lock"]
+                    + [f"noise_{i}" for i in range(1000)]
+                ),
+            },
+        }
+        h = _build_hypothesis(finding, {}, tmp_path)
+        # Concurrency fires (mutex_lock); context bounded.
+        assert "## Strategy: concurrency" in h.context
+        assert len(h.context) < 32_000
+
+
+# ---------------------------------------------------------------------------
+# CWE precedence (analysis vs finding)
+# ---------------------------------------------------------------------------
+
+
+class TestCwePrecedence:
+    def test_analysis_cwe_wins_over_finding_cwe(self, tmp_path):
+        """When both finding.cwe_id and analysis.cwe_id are set,
+        the LLM analysis's CWE is the more recent / specific
+        signal — it should drive strategy selection."""
+        finding = {
+            "file_path": "src/x.py", "start_line": 1,
+            "rule_id": "x", "function": "f",
+            "cwe_id": "CWE-89",  # SQL injection (input_handling)
+        }
+        analysis = {
+            # LLM refined to the structural cause.
+            "cwe_id": "CWE-416",  # use-after-free (memory_management)
+        }
+        h = _build_hypothesis(finding, analysis, tmp_path)
+        assert "## Strategy: memory_management" in h.context
+
+    def test_finding_cwe_used_when_analysis_has_none(self, tmp_path):
+        finding = {
+            "file_path": "src/x.py", "start_line": 1,
+            "rule_id": "x", "function": "f",
+            "cwe_id": "CWE-78",
+        }
+        analysis = {}  # no cwe_id
+        h = _build_hypothesis(finding, analysis, tmp_path)
+        assert "## Strategy: input_handling" in h.context
+
+
+# ---------------------------------------------------------------------------
+# Strategy block placement (trusted, not untrusted)
+# ---------------------------------------------------------------------------
+
+
+class TestStrategyPlacement:
+    def test_strategy_block_above_untrusted_envelope(self, tmp_path):
+        """Strategy guidance is operator-curated trusted content —
+        it must appear in the trusted region of the Hypothesis
+        context, BEFORE the untrusted_finding_context envelope."""
+        finding = {
+            "file_path": "src/x.py", "start_line": 1,
+            "rule_id": "x", "function": "f",
+            "cwe_id": "CWE-89",
+            "message": "scanner reflected message",
+        }
+        analysis = {"reasoning": "LLM reflected reasoning"}
+        h = _build_hypothesis(finding, analysis, tmp_path)
+        ctx = h.context
+        # Both blocks present.
+        bug_pos = ctx.find("Bug-class lenses")
+        envelope_pos = ctx.find("<untrusted_finding_context>")
+        assert bug_pos > 0
+        assert envelope_pos > 0
+        # Strategy block precedes the untrusted envelope.
+        assert bug_pos < envelope_pos
+
+
+# ---------------------------------------------------------------------------
+# E2E — realistic IRIS finding shapes producing distinct strategies
+# ---------------------------------------------------------------------------
+
+
+class TestE2EDistinctStrategies:
+    """Sanity check that the wire-in actually shapes output —
+    different CWEs produce demonstrably different validator
+    contexts."""
+
+    def test_path_traversal_finding(self, tmp_path):
+        """CWE-22 path-traversal IRIS pack scenario: the validator
+        gets input_handling lenses + CVE-2023-0179 exemplar."""
+        finding = {
+            "file_path": "src/api/upload.py",
+            "start_line": 87,
+            "rule_id": "py/path-injection",
+            "cwe_id": "CWE-22",
+            "function": "save_user_upload",
+            "message": "User-controlled path component in file open",
+        }
+        analysis = {
+            "cwe_id": "CWE-22",
+            "dataflow_summary": "request → safe_join → open",
+            "reasoning": "the path component is concatenated with user input",
+        }
+        h = _build_hypothesis(finding, analysis, tmp_path)
+        assert "## Strategy: input_handling" in h.context
+        assert "CVE-2023-0179" in h.context  # input_handling exemplar
+
+    def test_uaf_finding(self, tmp_path):
+        finding = {
+            "file_path": "src/buf.c", "start_line": 50,
+            "rule_id": "cpp/use-after-free", "cwe_id": "CWE-416",
+            "function": "release_buf",
+        }
+        analysis = {"cwe_id": "CWE-416"}
+        h = _build_hypothesis(finding, analysis, tmp_path)
+        assert "## Strategy: memory_management" in h.context
+        # memory_management exemplars include CVE-2024-1086 and
+        # CVE-2022-2588.
+        assert "CVE-2024-1086" in h.context or "CVE-2022-2588" in h.context
+
+    def test_path_traversal_vs_uaf_produce_different_content(self, tmp_path):
+        """Two findings with different CWEs must produce different
+        validator contexts — pin that the wiring actually shapes
+        output, not just adds a fixed boilerplate."""
+        f_path = {
+            "file_path": "src/x.py", "start_line": 1,
+            "rule_id": "x", "function": "f", "cwe_id": "CWE-22",
+        }
+        f_uaf = {
+            "file_path": "src/x.c", "start_line": 1,
+            "rule_id": "x", "function": "f", "cwe_id": "CWE-416",
+        }
+        h_path = _build_hypothesis(f_path, {"cwe_id": "CWE-22"}, tmp_path)
+        h_uaf = _build_hypothesis(f_uaf, {"cwe_id": "CWE-416"}, tmp_path)
+
+        assert "input_handling" in h_path.context
+        assert "memory_management" in h_uaf.context
+        # The two contexts are demonstrably distinct.
+        assert h_path.context != h_uaf.context
+
+
+# ---------------------------------------------------------------------------
+# Size bound across realistic flows
+# ---------------------------------------------------------------------------
+
+
+class TestSizeBounds:
+    def test_full_signal_stack_stays_bounded(self, tmp_path):
+        """Worst case: CWE pin + strong path + multiple callees +
+        long reasoning + scanner message. Total Hypothesis context
+        should still fit within prompt budget."""
+        finding = {
+            "file_path": "kernel/locking/rwsem.c",
+            "start_line": 287,
+            "rule_id": "cpp/use-after-free",
+            "cwe_id": "CWE-416",
+            "function": "rwsem_acquire_locked",
+            "message": "x" * 1000,  # bounded message
+            "metadata": {
+                "calls": ["mutex_lock", "kfree", "refcount_dec_and_test"],
+                "includes": ["linux/mutex.h", "linux/refcount.h"],
+            },
+        }
+        analysis = {
+            "cwe_id": "CWE-416",
+            "reasoning": "x" * 5000,  # bounded reasoning
+            "dataflow_summary": "y" * 1000,  # bounded summary
+        }
+        h = _build_hypothesis(finding, analysis, tmp_path)
+        # Even with multiple strategy matches + capped reasoning +
+        # bounded message + scanner content, total under 16KB.
+        assert len(h.context) < 16_000

--- a/packages/llm_analysis/tests/test_iris_strategy_wiring.py
+++ b/packages/llm_analysis/tests/test_iris_strategy_wiring.py
@@ -1,0 +1,215 @@
+"""Tests for the cwe_strategies wire-in into IRIS's validator prompt.
+
+The IRIS pack name encodes the CWE the query is for
+(``Security/CWE-022/PathTraversalLocal.ql`` etc.). When the
+validator builds a Hypothesis, the matching strategy's key
+questions and CVE exemplars get appended to the trusted context
+so the validator LLM has bug-class lenses for the validation
+decision.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from packages.llm_analysis.dataflow_validation import (
+    _build_hypothesis,
+    _build_strategy_block,
+)
+
+
+# ---------------------------------------------------------------------------
+# CWE → strategy in validator context
+# ---------------------------------------------------------------------------
+
+
+class TestCweTriggersStrategy:
+    def test_cwe_22_picks_input_handling_strategy(self, tmp_path):
+        finding = {
+            "file_path": "src/api/upload.py",
+            "start_line": 42,
+            "rule_id": "py/path-traversal",
+            "cwe_id": "CWE-22",
+            "function": "save_upload",
+        }
+        analysis = {
+            "dataflow_summary": "request → join → open",
+            "cwe_id": "CWE-22",
+        }
+        h = _build_hypothesis(finding, analysis, tmp_path)
+        # Strategy block present.
+        assert "Bug-class lenses" in h.context
+        # CWE-22 (path traversal) is in the input_handling strategy.
+        assert "## Strategy: input_handling" in h.context
+        # input_handling's CVE exemplar.
+        assert "CVE-2023-0179" in h.context
+
+    def test_cwe_416_picks_memory_management_strategy(self, tmp_path):
+        finding = {
+            "file_path": "src/buf.c",
+            "start_line": 10,
+            "rule_id": "cpp/use-after-free",
+            "cwe_id": "CWE-416",
+            "function": "release_buf",
+        }
+        analysis = {"cwe_id": "CWE-416"}
+        h = _build_hypothesis(finding, analysis, tmp_path)
+        assert "## Strategy: memory_management" in h.context
+
+    def test_cwe_362_picks_concurrency_strategy(self, tmp_path):
+        finding = {
+            "file_path": "kernel/locks.c",
+            "start_line": 1,
+            "rule_id": "cpp/race",
+            "cwe_id": "CWE-362",
+            "function": "rwsem_acquire",
+        }
+        analysis = {"cwe_id": "CWE-362"}
+        h = _build_hypothesis(finding, analysis, tmp_path)
+        assert "## Strategy: concurrency" in h.context
+
+
+# ---------------------------------------------------------------------------
+# Fall-through cases
+# ---------------------------------------------------------------------------
+
+
+class TestNoCweFallsThrough:
+    def test_finding_without_cwe_still_gets_general(self, tmp_path):
+        """No CWE on the finding — picker falls through to path /
+        function signals. ``general`` always pinned regardless."""
+        finding = {
+            "file_path": "src/x.py",
+            "start_line": 1,
+            "rule_id": "x",
+            "function": "f",
+        }
+        analysis = {}
+        h = _build_hypothesis(finding, analysis, tmp_path)
+        # General strategy always pinned.
+        assert "## Strategy: general" in h.context
+
+    def test_path_signal_fires_even_without_cwe(self, tmp_path):
+        finding = {
+            "file_path": "kernel/locking/rwsem.c",
+            "start_line": 1,
+            "rule_id": "x",
+            "function": "f",
+        }
+        analysis = {}
+        h = _build_hypothesis(finding, analysis, tmp_path)
+        # kernel/locking/ matches concurrency strategy's path.
+        assert "## Strategy: concurrency" in h.context
+
+
+# ---------------------------------------------------------------------------
+# Adversarial / robustness
+# ---------------------------------------------------------------------------
+
+
+class TestRobustness:
+    def test_substrate_import_failure_doesnt_break_validator(
+        self, tmp_path, monkeypatch,
+    ):
+        """If core/llm/cwe_strategies isn't importable, the
+        validator must still produce a usable Hypothesis."""
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "core.llm.cwe_strategies":
+                raise ImportError("substrate missing")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", fake_import):
+            finding = {
+                "file_path": "src/x.py", "start_line": 1,
+                "rule_id": "x", "function": "f", "cwe_id": "CWE-89",
+            }
+            h = _build_hypothesis(finding, {}, tmp_path)
+            # No crash, no strategy block, base context intact.
+            assert "Bug-class lenses" not in h.context
+            assert h.target == tmp_path
+
+    def test_picker_exception_doesnt_break_validator(self, tmp_path):
+        from packages.llm_analysis import dataflow_validation as mod
+
+        def boom(**kwargs):
+            raise RuntimeError("simulated picker failure")
+
+        with patch("core.llm.cwe_strategies.pick_strategies", boom):
+            finding = {
+                "file_path": "src/x.py", "start_line": 1,
+                "rule_id": "x", "function": "f", "cwe_id": "CWE-89",
+            }
+            h = _build_hypothesis(finding, {}, tmp_path)
+            assert "Bug-class lenses" not in h.context
+
+    def test_hostile_cwe_no_fake_heading_injected(self, tmp_path):
+        """Hostile CWE-id (newline + fake heading) must not corrupt
+        the rendered context. Picker treats as no-match — the raw
+        string never reaches output."""
+        finding = {
+            "file_path": "src/x.py", "start_line": 1,
+            "rule_id": "x", "function": "f",
+            "cwe_id": "CWE-89\n## INJECTED",
+        }
+        h = _build_hypothesis(finding, {}, tmp_path)
+        assert "## INJECTED" not in h.context
+
+
+# ---------------------------------------------------------------------------
+# _build_strategy_block direct unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestStrategyBlockDirect:
+    def test_returns_empty_when_substrate_missing(self):
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "core.llm.cwe_strategies":
+                raise ImportError("substrate missing")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", fake_import):
+            block = _build_strategy_block(
+                cwe="CWE-89", file_path="x", function="f", finding={},
+            )
+            assert block == ""
+
+    def test_returns_block_with_cwe_pin(self):
+        block = _build_strategy_block(
+            cwe="CWE-89", file_path="src/x.py",
+            function="check_credentials", finding={},
+        )
+        assert "## Strategy: input_handling" in block
+        assert "Bug-class lenses for this validation" in block
+
+    def test_picks_up_metadata_calls_and_includes(self):
+        finding = {
+            "metadata": {
+                "calls": ["mutex_lock"],
+                "includes": ["linux/mutex.h"],
+            }
+        }
+        block = _build_strategy_block(
+            cwe="", file_path="src/x.c", function="x",
+            finding=finding,
+        )
+        # mutex_lock callee + mutex.h include both pin concurrency.
+        assert "## Strategy: concurrency" in block
+
+    def test_fall_through_metadata_aliases(self):
+        """Some upstream finding shapes use ``callees`` instead of
+        ``calls`` — both should work."""
+        finding = {"metadata": {"callees": ["mutex_lock"]}}
+        block = _build_strategy_block(
+            cwe="", file_path="src/x.c", function="x",
+            finding=finding,
+        )
+        assert "## Strategy: concurrency" in block


### PR DESCRIPTION
Wires the cwe_strategies substrate (PR #392) into IRIS's dataflow validator. When the validator builds a Hypothesis for an IRIS finding, the matching strategy's key questions and CVE exemplars are appended to the trusted context so the validator LLM has bug-class lenses for the validation decision.

Reuse plan progress: PR ε of 9 (cwe_strategies → IRIS validator). checker_synthesis half is already covered by PR β's wire-in through /agentic's process_findings → analyze_vulnerability → checker_followup; IRIS findings flow that path automatically.

Surface area:
  * `_build_strategy_block` helper picks strategies from finding CWE / file path / function / metadata.calls + .includes.
  * Block is appended to trusted_parts (BEFORE the untrusted_finding_context envelope) so guidance is treated as operator content, not reflected target content.
  * Falls through silently on substrate ImportError or picker exception — validator continues to produce a usable Hypothesis.

24 new tests (12 wiring + 12 adversarial+E2E). Existing dataflow_validation context-size bound bumped 5000→8000 to accommodate the strategy block (general always fires, ~1.2KB).