### PR TITLE
feat(codeql): proxy-hosts auto-calibrate

### DIFF
--- a/packages/codeql/codeql_proxy_hosts.py
+++ b/packages/codeql/codeql_proxy_hosts.py
@@ -1,0 +1,273 @@
+"""Sandbox policy for CodeQL pack-download sites — proxy-hosts
+allowlist and readable-paths set.
+
+Mirrors ``core/llm/cc_proxy_hosts`` for cc_dispatch. Resolution
+layers (priority high → low):
+
+  1. ``~/.config/raptor/codeql-proxy-hosts.json`` — operator
+     override for enterprise registries / corporate GitHub
+     installs (``ghe.<corp>.com``-style hosts that the hardcoded
+     fallback doesn't know about).
+  2. Calibrated SandboxProfile — when ``raptor-sandbox-calibrate``
+     has fingerprinted the resolved CodeQL binary + the env vars
+     that change its behaviour (``CODEQL_DIST``, ``CODEQL_HOME``,
+     ``XDG_CACHE_HOME``, ``GITHUB_TOKEN``), prefer the auto-
+     discovered values. The default ``codeql --version`` probe
+     captures filesystem reach reliably; proxy hostnames populate
+     only when a future probe variant exercises an actual ``pack
+     download`` against the operator's configured registry.
+     Empty values from the cache fall through to the next layer.
+  3. Default — the documented vanilla-CodeQL pack-download host
+     set: ``ghcr.io`` + the GitHub Container Registry redirect
+     chain. Same hardcoded list ``query_runner.py`` shipped with
+     for the past N releases, lifted into a function so it has
+     one definition and one place to extend.
+
+Threat model: same as ``cc_proxy_hosts``. Calibration is a
+portability/drift-detection tool, NOT a security feature. The
+egress proxy enforces deny-by-default regardless of what this
+module returns; if a future CodeQL version adds an essential
+endpoint, the proxy denies, ``codeql pack download`` errors out,
+and the operator updates the override config or upgrades RAPTOR.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+_OVERRIDE_CONFIG_PATH = (
+    Path.home() / ".config" / "raptor" / "codeql-proxy-hosts.json"
+)
+
+
+# Env vars that affect CodeQL's filesystem and registry resolution.
+# Used for the calibrate cache-key (``env_signature``) so the same
+# binary used with vs without ``CODEQL_DIST`` produces distinct
+# profiles. Operators on enterprise GHE installs typically set
+# at least ``GITHUB_TOKEN``; ``CODEQL_DIST`` / ``CODEQL_HOME``
+# redirect the cache + pack root.
+_CODEQL_ENV_KEYS: tuple[str, ...] = (
+    "CODEQL_DIST",
+    "CODEQL_HOME",
+    "XDG_CACHE_HOME",
+    "GITHUB_TOKEN",
+)
+
+
+# Default pack-download hostname allowlist. Same set
+# ``query_runner.py`` has shipped with — lifted here for
+# single-source-of-truth + extension via override / calibrate.
+_DEFAULT_PACK_DOWNLOAD_HOSTS: tuple[str, ...] = (
+    # CodeQL packs are published as OCI artefacts under ghcr.io.
+    "ghcr.io",
+    # GitHub-side download redirect (used when fetching tarballs).
+    "codeload.github.com",
+    # Object-storage backend that ghcr.io redirects fetches to.
+    "objects.githubusercontent.com",
+    # Container-image blob backend (used by `codeql pack download`).
+    "pkg-containers.githubusercontent.com",
+)
+
+
+# Per-process memoisation. Pack-download is bursty (multiple
+# missing packs in a single ``codeql analyze`` run trigger several
+# back-to-back ``pack download`` invocations); re-loading the
+# calibrated profile from disk on each is wasted effort.
+_CALIBRATED_CACHE: dict[str, "object"] = {}
+
+
+def _resolve_codeql_bin() -> Optional[str]:
+    """Locate the CodeQL CLI on PATH. Returns None when not found
+    (calibration disabled for that run; static fallback layers
+    still apply)."""
+    return shutil.which("codeql")
+
+
+def _calibrated_profile(codeql_bin: Optional[str] = None):
+    """Load (or trigger calibration of) a SandboxProfile for the
+    target CodeQL binary + env. Returns None when calibration is
+    unavailable (binary missing, observe-mode prerequisites
+    missing, exception during probe).
+
+    Args:
+        codeql_bin: explicit binary path. When None, falls back to
+            ``shutil.which("codeql")``. ``query_runner`` /
+            ``database_manager`` should pass the same binary path
+            they spawn so calibration fingerprints exactly that
+            install rather than "whatever happens to be on PATH"
+            (which can differ on multi-version setups, e.g. the
+            CodeQL bundle vs `gh ext install`-ed CLI).
+
+    Memoised per-process by binary path — same shape as
+    ``cc_proxy_hosts._calibrated_profile``.
+    """
+    if codeql_bin is None:
+        codeql_bin = _resolve_codeql_bin()
+    if codeql_bin is None:
+        return None
+    if codeql_bin in _CALIBRATED_CACHE:
+        return _CALIBRATED_CACHE[codeql_bin]
+
+    try:
+        from core.sandbox.calibrate import load_or_calibrate
+    except ImportError:
+        _CALIBRATED_CACHE[codeql_bin] = None
+        return None
+
+    try:
+        profile = load_or_calibrate(
+            codeql_bin,
+            probe_args=("--version",),
+            env_keys=_CODEQL_ENV_KEYS,
+            timeout=20,
+        )
+    except (FileNotFoundError, RuntimeError, OSError) as exc:
+        logger.debug(
+            "codeql_proxy_hosts: calibration of %s failed (%s); "
+            "falling back to static policy",
+            codeql_bin, exc,
+        )
+        _CALIBRATED_CACHE[codeql_bin] = None
+        return None
+
+    _CALIBRATED_CACHE[codeql_bin] = profile
+    return profile
+
+
+def _load_override_config() -> Optional[list[str]]:
+    """Load the operator's override list, or None if not configured.
+
+    Schema mirrors cc_proxy_hosts:
+        {"proxy_hosts": ["ghe.corp.example", "..."]}
+
+    Future fields can be added (commit history records schema
+    evolution). Unknown fields are tolerated.
+    """
+    if not _OVERRIDE_CONFIG_PATH.exists():
+        return None
+    try:
+        data = json.loads(
+            _OVERRIDE_CONFIG_PATH.read_text(encoding="utf-8"),
+        )
+    except (OSError, json.JSONDecodeError):
+        return None
+    hosts = data.get("proxy_hosts") if isinstance(data, dict) else None
+    if not isinstance(hosts, list):
+        return None
+    seen: set[str] = set()
+    result: list[str] = []
+    for h in hosts:
+        if isinstance(h, str) and h and h not in seen:
+            seen.add(h)
+            result.append(h)
+    return result or None
+
+
+def _calibrated_proxy_hosts(
+    codeql_bin: Optional[str] = None,
+) -> Optional[list[str]]:
+    """Calibrated layer of proxy_hosts_for_codeql's resolution
+    chain. Returns None when no profile exists OR proxy_hosts is
+    empty. Default ``codeql --version`` probe doesn't network, so
+    empty is the common case until a network-engaging probe variant
+    lands."""
+    profile = _calibrated_profile(codeql_bin)
+    if profile is None or not profile.proxy_hosts:
+        return None
+    return list(profile.proxy_hosts)
+
+
+def _calibrated_readable_paths(
+    codeql_bin: Optional[str] = None,
+) -> Optional[list[str]]:
+    """Calibrated layer of readable_paths_for_codeql's resolution
+    chain. Returns the union of paths_read + paths_stat — both
+    require Landlock read access (the kernel doesn't distinguish
+    open() from stat() at the path-permission layer)."""
+    profile = _calibrated_profile(codeql_bin)
+    if profile is None:
+        return None
+    union = list(dict.fromkeys(
+        list(profile.paths_read) + list(profile.paths_stat),
+    ))
+    if not union:
+        return None
+    return union
+
+
+def _default_readable_paths() -> list[str]:
+    """Documented CodeQL install layout fallback.
+
+    The CodeQL CLI's pack cache + config dirs. Operators with
+    non-default install locations (CODEQL_DIST set, custom
+    XDG_CACHE_HOME) should rely on calibration to pick up the
+    real layout — these defaults assume the vanilla GitHub
+    Action / `gh ext install codeql` shape.
+    """
+    home = Path.home()
+    return [
+        # Pack cache (created on first ``codeql pack download``).
+        str(home / ".codeql"),
+        # Some installs use the XDG layout.
+        str(home / ".cache" / "codeql"),
+        # Configuration.
+        str(home / ".config" / "codeql"),
+    ]
+
+
+def proxy_hosts_for_codeql(
+    codeql_bin: Optional[str] = None,
+) -> list[str]:
+    """Return the egress proxy hostname allowlist for a
+    ``codeql pack download`` invocation.
+
+    Args:
+        codeql_bin: explicit CodeQL CLI path. When provided,
+            calibration fingerprints exactly that binary; when
+            None, falls back to PATH lookup. Call sites should
+            pass the same value they'll spawn so the policy
+            matches.
+
+    Priority: override config > calibrated profile > default
+    GitHub Container Registry hosts.
+    """
+    override = _load_override_config()
+    if override is not None:
+        return override
+
+    calibrated = _calibrated_proxy_hosts(codeql_bin)
+    if calibrated is not None:
+        return calibrated
+
+    return list(_DEFAULT_PACK_DOWNLOAD_HOSTS)
+
+
+def readable_paths_for_codeql(
+    codeql_bin: Optional[str] = None,
+) -> list[str]:
+    """Return the Landlock readable-paths set for CodeQL.
+
+    Args:
+        codeql_bin: same semantics as ``proxy_hosts_for_codeql``.
+
+    Priority: calibrated profile > default install layout.
+    """
+    calibrated = _calibrated_readable_paths(codeql_bin)
+    if calibrated is not None:
+        return calibrated
+    return _default_readable_paths()
+
+
+def _reset_calibrate_cache_for_tests() -> None:
+    """Clear the per-process memo. Public so tests can isolate
+    runs without monkeypatching the dict directly."""
+    _CALIBRATED_CACHE.clear()

--- a/packages/codeql/query_runner.py
+++ b/packages/codeql/query_runner.py
@@ -381,16 +381,25 @@ class QueryRunner:
                     # cover the common transient failure modes.
                     import time as _time
                     dl = None
+                    from packages.codeql.codeql_proxy_hosts import (
+                        proxy_hosts_for_codeql,
+                    )
                     for attempt in range(3):
                         dl = sandbox_run(
                             [self.codeql_cli, "pack", "download", pack_name],
                             use_egress_proxy=True,
-                            proxy_hosts=[
-                                "ghcr.io",            # CodeQL packs hosted here
-                                "codeload.github.com",
-                                "objects.githubusercontent.com",
-                                "pkg-containers.githubusercontent.com",
-                            ],
+                            # Hostname allowlist auto-discovered from
+                            # the calibrated profile when present
+                            # (catches enterprise GHE redirect to
+                            # `ghe.<corp>.example`-style hosts);
+                            # falls back to the documented vanilla
+                            # GitHub Container Registry set otherwise.
+                            # Operator override at
+                            # ~/.config/raptor/codeql-proxy-hosts.json
+                            # short-circuits both.
+                            proxy_hosts=proxy_hosts_for_codeql(
+                                self.codeql_cli,
+                            ),
                             caller_label="codeql-pack-download",
                             target=str(codeql_cache),
                             output=str(codeql_cache),

--- a/packages/codeql/tests/test_codeql_proxy_hosts.py
+++ b/packages/codeql/tests/test_codeql_proxy_hosts.py
@@ -1,0 +1,417 @@
+"""Tests for ``packages.codeql.codeql_proxy_hosts``.
+
+The module resolves CodeQL pack-download sandbox policy via three
+layers (priority high → low):
+
+  1. ``~/.config/raptor/codeql-proxy-hosts.json`` override
+  2. Calibrated SandboxProfile (proxy_hosts AND readable_paths)
+  3. Default GitHub Container Registry hosts + documented install
+     layout
+
+Symmetric with ``core/llm/cc_proxy_hosts`` for cc_dispatch — same
+shape, same fallback behaviour, same memoisation contract.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from packages.codeql import codeql_proxy_hosts as mod
+from packages.codeql.codeql_proxy_hosts import (
+    proxy_hosts_for_codeql,
+    readable_paths_for_codeql,
+)
+
+
+def _hostname_in(hosts: list[str], target: str) -> bool:
+    """List-membership for exact hostnames.
+
+    Same shape as ``test_cc_proxy_hosts._hostname_in`` — sidesteps
+    CodeQL's ``py/incomplete-url-substring-sanitization`` query
+    which pattern-matches ``<host> in <var>`` even when ``<var>``
+    is a list[str] of hostnames rather than a URL.
+    """
+    return any(h == target for h in hosts)
+
+
+@pytest.fixture(autouse=True)
+def _reset_calibrate_memo():
+    """Per-process memo isolation. Autouse so cross-test pollution
+    can't leak a calibrated profile into a static-fallback test.
+    Mirrors the cc_proxy_hosts test layout."""
+    mod._reset_calibrate_cache_for_tests()
+    yield
+    mod._reset_calibrate_cache_for_tests()
+
+
+@pytest.fixture
+def isolated_env(monkeypatch):
+    """Strip every env var the calibrate cache key consults so
+    each test starts from a clean slate."""
+    for var in mod._CODEQL_ENV_KEYS:
+        monkeypatch.delenv(var, raising=False)
+    yield monkeypatch
+
+
+@pytest.fixture
+def no_override_config(monkeypatch, tmp_path):
+    """Point the override config path at an empty tmp dir so the
+    operator's real ``~/.config/raptor`` isn't read during tests."""
+    monkeypatch.setattr(
+        mod, "_OVERRIDE_CONFIG_PATH",
+        tmp_path / "codeql-proxy-hosts.json",
+    )
+
+
+@pytest.fixture
+def no_calibrate(monkeypatch):
+    """Force the calibrate layer to return None so static-fallback
+    tests don't accidentally trigger a real calibration probe of
+    /usr/bin/codeql on the dev box."""
+    monkeypatch.setattr(
+        mod, "_calibrated_profile",
+        lambda codeql_bin=None: None,
+    )
+
+
+def _fake_profile(*, paths_read=None, paths_stat=None,
+                  proxy_hosts=None):
+    """Construct a synthetic SandboxProfile for calibrate-path
+    tests without spawning. Mirrors the production shape from
+    ``core.sandbox.calibrate.calibrate_binary``."""
+    from core.sandbox.calibrate import SandboxProfile
+    return SandboxProfile(
+        binary_path="/fake/codeql",
+        binary_sha256="0" * 64,
+        env_signature="0" * 64,
+        captured_at="2026-05-09T00:00:00Z",
+        probe_args=["--version"],
+        paths_read=paths_read or [],
+        paths_written=[],
+        paths_stat=paths_stat or [],
+        proxy_hosts=proxy_hosts or [],
+        connect_targets=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default — no env, no override, no calibrate
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultProxyHosts:
+
+    def test_returns_documented_pack_download_hosts(
+        self, isolated_env, no_override_config, no_calibrate,
+    ):
+        hosts = proxy_hosts_for_codeql()
+        # Every host the historical hardcoded ``query_runner.py``
+        # list shipped with must be present — the migration is
+        # behaviour-preserving.
+        for required in (
+            "ghcr.io",
+            "codeload.github.com",
+            "objects.githubusercontent.com",
+            "pkg-containers.githubusercontent.com",
+        ):
+            assert _hostname_in(hosts, required), (
+                f"default proxy_hosts missing {required!r} — "
+                f"breaks codeql pack download out of the box"
+            )
+
+    def test_returns_a_fresh_list(
+        self, isolated_env, no_override_config, no_calibrate,
+    ):
+        # Caller-side mutation of the returned list must not leak
+        # back into the module-level default tuple.
+        hosts = proxy_hosts_for_codeql()
+        hosts.append("attacker.example")
+        hosts2 = proxy_hosts_for_codeql()
+        assert not _hostname_in(hosts2, "attacker.example"), (
+            "default-host fetcher must return a fresh list each "
+            "call, not share state with prior callers"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Calibrated layer
+# ---------------------------------------------------------------------------
+
+
+class TestCalibratedProxyHosts:
+
+    def test_calibrated_hosts_used_when_present(
+        self, isolated_env, no_override_config, monkeypatch,
+    ):
+        prof = _fake_profile(
+            proxy_hosts=["ghe.corp.example", "objects.ghe.corp.example"],
+        )
+        monkeypatch.setattr(
+            mod, "_calibrated_profile",
+            lambda codeql_bin=None: prof,
+        )
+        hosts = proxy_hosts_for_codeql()
+        # Calibrated values replace the hardcoded GHCR set —
+        # operator on enterprise GHE gets THEIR registry, not
+        # vanilla github.
+        assert hosts == ["ghe.corp.example", "objects.ghe.corp.example"]
+        # Vanilla ghcr.io is NOT in the result; calibration is
+        # authoritative when present.
+        assert not _hostname_in(hosts, "ghcr.io")
+
+    def test_empty_calibrated_falls_through_to_default(
+        self, isolated_env, no_override_config, monkeypatch,
+    ):
+        # ``codeql --version`` doesn't network → empty proxy_hosts
+        # in the cached profile. Resolution must fall through to
+        # the hardcoded default (NOT return [] which would deny
+        # every CONNECT and break pack download).
+        prof = _fake_profile(proxy_hosts=[])
+        monkeypatch.setattr(
+            mod, "_calibrated_profile",
+            lambda codeql_bin=None: prof,
+        )
+        hosts = proxy_hosts_for_codeql()
+        assert _hostname_in(hosts, "ghcr.io")
+
+    def test_no_profile_falls_through(
+        self, isolated_env, no_override_config, monkeypatch,
+    ):
+        monkeypatch.setattr(
+            mod, "_calibrated_profile",
+            lambda codeql_bin=None: None,
+        )
+        hosts = proxy_hosts_for_codeql()
+        assert _hostname_in(hosts, "ghcr.io")
+
+
+# ---------------------------------------------------------------------------
+# Override config
+# ---------------------------------------------------------------------------
+
+
+class TestOverrideConfig:
+
+    def test_override_supersedes_calibrate_and_default(
+        self, isolated_env, monkeypatch, tmp_path,
+    ):
+        config_path = tmp_path / "codeql-proxy-hosts.json"
+        config_path.write_text(json.dumps({
+            "proxy_hosts": ["ghe.corp.example"],
+        }))
+        monkeypatch.setattr(mod, "_OVERRIDE_CONFIG_PATH", config_path)
+
+        # Even with a calibrated profile in place, override wins.
+        prof = _fake_profile(proxy_hosts=["calibrated.example"])
+        monkeypatch.setattr(
+            mod, "_calibrated_profile",
+            lambda codeql_bin=None: prof,
+        )
+
+        assert proxy_hosts_for_codeql() == ["ghe.corp.example"]
+
+    def test_override_dedupes_and_strips_non_strings(
+        self, isolated_env, monkeypatch, tmp_path, no_calibrate,
+    ):
+        config_path = tmp_path / "codeql-proxy-hosts.json"
+        config_path.write_text(json.dumps({
+            "proxy_hosts": [
+                "a.example", 42, None, "b.example", "a.example",
+            ],
+        }))
+        monkeypatch.setattr(mod, "_OVERRIDE_CONFIG_PATH", config_path)
+        assert proxy_hosts_for_codeql() == ["a.example", "b.example"]
+
+    def test_empty_override_falls_back(
+        self, isolated_env, monkeypatch, tmp_path, no_calibrate,
+    ):
+        config_path = tmp_path / "codeql-proxy-hosts.json"
+        config_path.write_text(json.dumps({"proxy_hosts": []}))
+        monkeypatch.setattr(mod, "_OVERRIDE_CONFIG_PATH", config_path)
+        # Empty override is a misconfig — fall through rather than
+        # allowlisting nothing (which would deny every pack
+        # download). Same shape as cc_proxy_hosts.
+        hosts = proxy_hosts_for_codeql()
+        assert _hostname_in(hosts, "ghcr.io")
+
+    def test_malformed_override_falls_back(
+        self, isolated_env, monkeypatch, tmp_path, no_calibrate,
+    ):
+        config_path = tmp_path / "codeql-proxy-hosts.json"
+        config_path.write_text("not valid json{{")
+        monkeypatch.setattr(mod, "_OVERRIDE_CONFIG_PATH", config_path)
+        hosts = proxy_hosts_for_codeql()
+        assert _hostname_in(hosts, "ghcr.io")
+
+
+# ---------------------------------------------------------------------------
+# readable_paths_for_codeql
+# ---------------------------------------------------------------------------
+
+
+class TestReadablePathsForCodeQL:
+
+    def test_default_when_no_calibration(
+        self, isolated_env, no_override_config, no_calibrate,
+    ):
+        paths = readable_paths_for_codeql()
+        home = str(Path.home())
+        # The three documented install-layout dirs.
+        assert _hostname_in(paths, home + "/.codeql")
+        assert _hostname_in(paths, home + "/.cache/codeql")
+        assert _hostname_in(paths, home + "/.config/codeql")
+
+    def test_calibrated_paths_used_when_present(
+        self, isolated_env, no_override_config, monkeypatch,
+    ):
+        prof = _fake_profile(
+            paths_read=["/opt/codeql-2.21/codeql"],
+            paths_stat=["/etc/codeql/global.conf"],
+        )
+        monkeypatch.setattr(
+            mod, "_calibrated_profile",
+            lambda codeql_bin=None: prof,
+        )
+        paths = readable_paths_for_codeql()
+        assert _hostname_in(paths, "/opt/codeql-2.21/codeql")
+        assert _hostname_in(paths, "/etc/codeql/global.conf")
+        # Default paths are NOT present — calibration is
+        # authoritative when populated.
+        home = str(Path.home())
+        assert not _hostname_in(paths, home + "/.codeql")
+
+    def test_calibrated_paths_dedupe_across_read_and_stat(
+        self, isolated_env, no_override_config, monkeypatch,
+    ):
+        prof = _fake_profile(
+            paths_read=["/path/A", "/path/B"],
+            paths_stat=["/path/B", "/path/C"],
+        )
+        monkeypatch.setattr(
+            mod, "_calibrated_profile",
+            lambda codeql_bin=None: prof,
+        )
+        paths = readable_paths_for_codeql()
+        assert paths == ["/path/A", "/path/B", "/path/C"]
+
+
+# ---------------------------------------------------------------------------
+# _calibrated_profile failure modes
+# ---------------------------------------------------------------------------
+
+
+class TestCalibratedProfileFailureModes:
+    """Calibration is opt-in / advisory: every failure mode the
+    underlying probe can hit must degrade silently to the static
+    fallback rather than bubbling an exception to the caller."""
+
+    def test_no_codeql_on_path_returns_none(self, monkeypatch):
+        monkeypatch.setattr(
+            mod, "_resolve_codeql_bin", lambda: None,
+        )
+        assert mod._calibrated_profile() is None
+
+    def test_calibrate_raises_returns_none(self, monkeypatch):
+        monkeypatch.setattr(
+            mod, "_resolve_codeql_bin", lambda: "/fake/codeql",
+        )
+        import core.sandbox.calibrate as _cal
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("simulated probe failure")
+
+        monkeypatch.setattr(_cal, "load_or_calibrate", boom)
+        assert mod._calibrated_profile() is None
+
+    def test_calibrate_filenotfound_returns_none(self, monkeypatch):
+        # FileNotFoundError = binary deleted between which() and
+        # probe (race against codeql self-update).
+        monkeypatch.setattr(
+            mod, "_resolve_codeql_bin", lambda: "/fake/codeql",
+        )
+        import core.sandbox.calibrate as _cal
+
+        def boom(*args, **kwargs):
+            raise FileNotFoundError("/fake/codeql")
+
+        monkeypatch.setattr(_cal, "load_or_calibrate", boom)
+        assert mod._calibrated_profile() is None
+
+    def test_memoised_per_binary(self, monkeypatch):
+        """A second call for the same resolved binary path doesn't
+        re-spawn the calibrator — the per-process memo serves the
+        cached profile. ``codeql analyze`` paths can dispatch
+        several pack downloads in succession; per-call calibrate
+        cost would dwarf the actual download otherwise."""
+        monkeypatch.setattr(
+            mod, "_resolve_codeql_bin", lambda: "/fake/codeql",
+        )
+        import core.sandbox.calibrate as _cal
+        spawn_count = [0]
+
+        def counted_load(*args, **kwargs):
+            spawn_count[0] += 1
+            return _fake_profile(proxy_hosts=["ghcr.example"])
+
+        monkeypatch.setattr(_cal, "load_or_calibrate", counted_load)
+
+        mod._calibrated_profile()
+        mod._calibrated_profile()
+        mod._calibrated_profile()
+        assert spawn_count[0] == 1, (
+            f"memoisation broken: load_or_calibrate called "
+            f"{spawn_count[0]} times for one binary path"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Migration: query_runner.py routes pack-download proxy_hosts
+# through this module
+# ---------------------------------------------------------------------------
+
+
+class TestQueryRunnerMigrationWiring:
+    """The migration must route ``codeql pack download`` through
+    ``proxy_hosts_for_codeql``. Fail this test if a future change
+    re-introduces a hardcoded host list at the call site."""
+
+    def test_query_runner_imports_proxy_hosts_for_codeql(self):
+        # Source-level pin — the import statement is the contract.
+        # If a contributor removes the import (intending to revert
+        # to hardcoded), this test catches it before the rest of
+        # the suite races to find the resulting behaviour drift.
+        import inspect
+        from packages.codeql import query_runner
+
+        src = inspect.getsource(query_runner)
+        assert "proxy_hosts_for_codeql" in src, (
+            "query_runner.py must route proxy_hosts through "
+            "codeql_proxy_hosts.proxy_hosts_for_codeql; the "
+            "calibrate-aware policy is the load-bearing change"
+        )
+
+    def test_query_runner_no_longer_hardcodes_pack_hosts(self):
+        # Belt-and-braces: the historic hardcoded set should not
+        # appear as a literal list inside an unconditional
+        # ``proxy_hosts=[...]`` call site any more. Allow it as a
+        # default in codeql_proxy_hosts.py (where it's a single
+        # source of truth), but not inline at the call site.
+        import inspect
+        from packages.codeql import query_runner
+
+        src = inspect.getsource(query_runner)
+        # Search for the canonical hardcoded triple. If it appears
+        # AS A LITERAL LIST, the migration was reverted.
+        signature = (
+            '"ghcr.io",            # CodeQL packs hosted here'
+        )
+        assert signature not in src, (
+            "query_runner.py contains the pre-migration hardcoded "
+            "host list — the call site should use "
+            "proxy_hosts_for_codeql() instead"
+        )


### PR DESCRIPTION
packages/codeql/codeql_proxy_hosts.py: same shape as core/llm/cc_proxy_hosts. Three-tier resolution:
  1. ~/.config/raptor/codeql-proxy-hosts.json operator override
  2. calibrated SandboxProfile (env_keys: CODEQL_DIST, CODEQL_HOME, XDG_CACHE_HOME, GITHUB_TOKEN)
  3. default ghcr.io / codeload.github.com / objects+pkg- containers.githubusercontent.com (the hardcoded set query_runner.py shipped with).

readable_paths_for_codeql() companion: calibrated
paths_read+paths_stat union > ~/.codeql + ~/.cache/codeql + ~/.config/codeql defaults.

query_runner.py "codeql pack download" call site routes through proxy_hosts_for_codeql(self.codeql_cli) instead of the inline host list. Migration pin tests fail any future revert.

Closes the silent-failure gap on enterprise CodeQL installs where pack-download targets ghe.<corp>.example-style hosts that the vanilla allowlist doesn't know about.

Test results: 244 codeql tests passing (226 prior + 18 new), zero regressions.