### PR TITLE
feat(understand): emit per-function annotations from hunt variants

### DIFF
--- a/packages/code_understanding/annotation_synth.py
+++ b/packages/code_understanding/annotation_synth.py
@@ -393,6 +393,112 @@ def _emit_trace_steps(
 
 
 # ---------------------------------------------------------------------------
+# variants.json: per-variant annotations from /understand --hunt
+# ---------------------------------------------------------------------------
+
+
+# Map hunt's taint_status / status fields to our annotation status enum.
+# Confirmed-tainted / not_disproven variants are findings worth chasing.
+# Unlikely-tainted / false_positive are still flagged so the operator
+# sees them — "suspicious" rather than dropped silently.
+_TAINT_TO_STATUS = {
+    "confirmed_tainted": "finding",
+    "likely_tainted": "finding",
+    "unlikely_tainted": "suspicious",
+    "false_positive": "suspicious",
+}
+_STATUS_TO_STATUS = {
+    "not_disproven": "finding",
+    "poc_success": "finding",
+    "disproven": "suspicious",
+    "false_positive": "suspicious",
+}
+
+
+def _variant_annotation_status(variant: Dict[str, Any]) -> str:
+    """Decide the annotation status for a hunt variant.
+
+    Prefers ``taint_status`` (hunt's primary signal) over ``status``
+    (the validation-flow lifecycle field, often absent on raw hunt
+    output). Defaults to ``suspicious`` so a variant the LLM emitted
+    without status fields is still surfaced for operator review.
+    """
+    taint = variant.get("taint_status")
+    if isinstance(taint, str) and taint in _TAINT_TO_STATUS:
+        return _TAINT_TO_STATUS[taint]
+    status = variant.get("status")
+    if isinstance(status, str) and status in _STATUS_TO_STATUS:
+        return _STATUS_TO_STATUS[status]
+    return "suspicious"
+
+
+def _emit_variants(
+    variants_data: Dict[str, Any],
+    base_dir: Path, checklist: Dict[str, Any], repo_root: Path,
+    counts: SynthCounts,
+) -> None:
+    for variant in _safe_list_of_dicts(variants_data, "variants"):
+        file_path = variant.get("file")
+        line = variant.get("line")
+        func = _resolve(checklist, file_path, line, repo_root)
+        if not func or not func.get("name"):
+            counts.skipped_no_function += 1
+            continue
+        body_lines: List[str] = []
+        if variant.get("vuln_type"):
+            body_lines.append(f"Variant ({variant['vuln_type']})")
+        if variant.get("matched_code"):
+            body_lines.append(
+                f"Matched code: `{variant['matched_code']}`"
+            )
+        proof = variant.get("proof")
+        if isinstance(proof, dict):
+            if proof.get("vulnerable_code"):
+                body_lines.append(
+                    f"Vulnerable code: `{proof['vulnerable_code']}`"
+                )
+            if proof.get("source"):
+                body_lines.append(f"Source: {proof['source']}")
+            if proof.get("sink"):
+                body_lines.append(f"Sink: {proof['sink']}")
+        elif variant.get("taint_source"):
+            body_lines.append(f"Taint source: {variant['taint_source']}")
+        eps = variant.get("entry_points") or []
+        if isinstance(eps, list) and eps:
+            body_lines.append(
+                f"Entry points: {', '.join(str(e) for e in eps)}"
+            )
+        if variant.get("auth_required") is not None:
+            body_lines.append(f"Auth required: {variant['auth_required']}")
+        if variant.get("notes"):
+            body_lines.append(f"Notes: {variant['notes']}")
+        metadata = {
+            "source": "llm",
+            "status": _variant_annotation_status(variant),
+        }
+        if variant.get("id"):
+            metadata["variant_id"] = _safe_meta(variant["id"])
+        if variant.get("vuln_type"):
+            metadata["vuln_type"] = _safe_meta(variant["vuln_type"])
+        if variant.get("confidence"):
+            metadata["confidence"] = _safe_meta(variant["confidence"])
+        if variant.get("taint_status"):
+            metadata["taint_status"] = _safe_meta(variant["taint_status"])
+        if variant.get("root_cause_group"):
+            metadata["root_cause_group"] = _safe_meta(
+                variant["root_cause_group"],
+            )
+        if variant.get("priority") is not None:
+            metadata["priority"] = _safe_meta(variant["priority"])
+        metadata.update(_hash_metadata(repo_root, file_path, func))
+        ann = Annotation(
+            file=file_path, function=func["name"],
+            body="\n\n".join(body_lines), metadata=metadata,
+        )
+        _write(base_dir, ann, counts, "variant")
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
@@ -430,6 +536,12 @@ def synthesise_from_understand_output(
         _emit_sinks(cmap, base_dir, checklist, repo_root, counts)
         _emit_trust_boundaries(cmap, base_dir, checklist, repo_root, counts)
         _emit_unchecked_flows(cmap, base_dir, checklist, repo_root, counts)
+
+    variants_data = _load_json(output_dir / "variants.json")
+    if variants_data:
+        _emit_variants(
+            variants_data, base_dir, checklist, repo_root, counts,
+        )
 
     for trace_path in sorted(output_dir.glob("flow-trace-*.json")):
         trace = _load_json(trace_path)

--- a/packages/code_understanding/tests/test_annotation_synth.py
+++ b/packages/code_understanding/tests/test_annotation_synth.py
@@ -300,6 +300,413 @@ class TestFlowTrace:
 
 
 # ---------------------------------------------------------------------------
+# variants.json (hunt output)
+# ---------------------------------------------------------------------------
+
+
+def _make_variants(out: Path, variants: list) -> None:
+    payload = {"variants": variants}
+    (out / "variants.json").write_text(json.dumps(payload))
+
+
+class TestHuntVariants:
+    """Annotations synthesised from /understand --hunt output —
+    each variant becomes a per-function annotation on the source
+    file where it was found."""
+
+    def test_emits_finding_for_confirmed_tainted(self, understand_run):
+        repo, out = understand_run
+        _make_variants(out, [{
+            "id": "VAR-001",
+            "file": "src/db/query.py",
+            "function": "run_query",
+            "line": 90,
+            "vuln_type": "sqli",
+            "status": "not_disproven",
+            "confidence": "high",
+            "matched_code": "cursor.execute(f'... {s}')",
+            "taint_source": "request.json at routes/query.py:34",
+            "taint_status": "confirmed_tainted",
+            "root_cause_group": "RCG-001",
+            "priority": 1,
+            "notes": "Direct interpolation",
+        }])
+        counts = synthesise_from_understand_output(out)
+        assert counts.emitted >= 1
+        ann = read_annotation(
+            out / "annotations", "src/db/query.py", "run_query",
+        )
+        assert ann is not None
+        assert ann.metadata["status"] == "finding"
+        assert ann.metadata["variant_id"] == "VAR-001"
+        assert ann.metadata["vuln_type"] == "sqli"
+        assert ann.metadata["confidence"] == "high"
+        assert ann.metadata["root_cause_group"] == "RCG-001"
+        assert ann.metadata["priority"] == "1"
+        assert ann.metadata["taint_status"] == "confirmed_tainted"
+        assert ann.metadata.get("hash"), "hash should be stamped"
+
+    def test_emits_suspicious_for_false_positive_taint(
+        self, understand_run,
+    ):
+        repo, out = understand_run
+        _make_variants(out, [{
+            "id": "VAR-002",
+            "file": "src/db/query.py",
+            "function": "run_query",
+            "line": 90,
+            "taint_status": "false_positive",
+            "notes": "Sanitiser was missed by structural search",
+        }])
+        synthesise_from_understand_output(out)
+        ann = read_annotation(
+            out / "annotations", "src/db/query.py", "run_query",
+        )
+        assert ann is not None
+        assert ann.metadata["status"] == "suspicious"
+
+    def test_emits_suspicious_for_unlikely_tainted(self, understand_run):
+        repo, out = understand_run
+        _make_variants(out, [{
+            "id": "VAR-003",
+            "file": "src/db/query.py",
+            "function": "run_query",
+            "line": 90,
+            "taint_status": "unlikely_tainted",
+        }])
+        synthesise_from_understand_output(out)
+        ann = read_annotation(
+            out / "annotations", "src/db/query.py", "run_query",
+        )
+        assert ann.metadata["status"] == "suspicious"
+
+    def test_taint_status_wins_over_status_field(self, understand_run):
+        # taint_status="confirmed_tainted" + status="disproven" → finding,
+        # because hunt's taint_status is the primary signal.
+        repo, out = understand_run
+        _make_variants(out, [{
+            "id": "VAR-004",
+            "file": "src/db/query.py",
+            "function": "run_query",
+            "line": 90,
+            "taint_status": "confirmed_tainted",
+            "status": "disproven",
+        }])
+        synthesise_from_understand_output(out)
+        ann = read_annotation(
+            out / "annotations", "src/db/query.py", "run_query",
+        )
+        assert ann.metadata["status"] == "finding"
+
+    def test_unknown_taint_status_defaults_suspicious(self, understand_run):
+        repo, out = understand_run
+        _make_variants(out, [{
+            "id": "VAR-005",
+            "file": "src/db/query.py",
+            "function": "run_query",
+            "line": 90,
+            "taint_status": "weird_value",
+        }])
+        synthesise_from_understand_output(out)
+        ann = read_annotation(
+            out / "annotations", "src/db/query.py", "run_query",
+        )
+        assert ann.metadata["status"] == "suspicious"
+
+    def test_variant_without_status_fields_defaults_suspicious(
+        self, understand_run,
+    ):
+        repo, out = understand_run
+        _make_variants(out, [{
+            "id": "VAR-006",
+            "file": "src/db/query.py",
+            "function": "run_query",
+            "line": 90,
+        }])
+        synthesise_from_understand_output(out)
+        ann = read_annotation(
+            out / "annotations", "src/db/query.py", "run_query",
+        )
+        assert ann.metadata["status"] == "suspicious"
+
+    def test_body_includes_proof_dict_fields(self, understand_run):
+        repo, out = understand_run
+        _make_variants(out, [{
+            "id": "VAR-007",
+            "file": "src/db/query.py",
+            "function": "run_query",
+            "line": 90,
+            "vuln_type": "sqli",
+            "proof": {
+                "vulnerable_code": "cursor.execute(f'... {x}')",
+                "source": "request.json at /api/v2/query",
+                "sink": "psycopg2.cursor.execute",
+            },
+            "entry_points": ["POST /api/v2/query"],
+            "auth_required": False,
+        }])
+        synthesise_from_understand_output(out)
+        ann = read_annotation(
+            out / "annotations", "src/db/query.py", "run_query",
+        )
+        assert "Variant (sqli)" in ann.body
+        assert "Vulnerable code:" in ann.body
+        assert "request.json at /api/v2/query" in ann.body
+        assert "psycopg2.cursor.execute" in ann.body
+        assert "POST /api/v2/query" in ann.body
+        assert "Auth required: False" in ann.body
+
+    def test_body_falls_back_to_taint_source_without_proof_dict(
+        self, understand_run,
+    ):
+        repo, out = understand_run
+        _make_variants(out, [{
+            "id": "VAR-008",
+            "file": "src/db/query.py",
+            "function": "run_query",
+            "line": 90,
+            "taint_source": "request.json at routes/query.py:34",
+        }])
+        synthesise_from_understand_output(out)
+        ann = read_annotation(
+            out / "annotations", "src/db/query.py", "run_query",
+        )
+        assert "Taint source: request.json at routes/query.py:34" in ann.body
+
+    def test_multiple_variants_in_same_file_overwrite_within_pass(
+        self, understand_run,
+    ):
+        # Two variants on the same (file, function) — the second
+        # overwrites the first (last writer wins, both LLM-source).
+        # Pin: at least one variant annotation present and counted.
+        repo, out = understand_run
+        _make_variants(out, [
+            {"id": "VAR-A", "file": "src/db/query.py",
+             "function": "run_query", "line": 90,
+             "taint_status": "confirmed_tainted"},
+            {"id": "VAR-B", "file": "src/db/query.py",
+             "function": "run_query", "line": 90,
+             "taint_status": "likely_tainted"},
+        ])
+        counts = synthesise_from_understand_output(out)
+        assert counts.sources.get("variant", 0) >= 2
+        ann = read_annotation(
+            out / "annotations", "src/db/query.py", "run_query",
+        )
+        # Last variant wrote VAR-B.
+        assert ann.metadata["variant_id"] == "VAR-B"
+
+    def test_variant_skipped_when_no_inventory_match(self, understand_run):
+        repo, out = understand_run
+        _make_variants(out, [{
+            "id": "VAR-X",
+            "file": "src/not_in_inventory.py",
+            "function": "f",
+            "line": 1,
+        }])
+        counts = synthesise_from_understand_output(out)
+        assert counts.skipped_no_function >= 1
+        assert counts.sources.get("variant", 0) == 0
+
+    def test_variant_skipped_when_file_or_line_missing(self, understand_run):
+        repo, out = understand_run
+        _make_variants(out, [
+            {"id": "V1", "function": "f"},  # no file/line
+            {"id": "V2", "file": "src/db/query.py"},  # no line
+            {"id": "V3", "line": 90},  # no file
+        ])
+        counts = synthesise_from_understand_output(out)
+        assert counts.sources.get("variant", 0) == 0
+
+
+class TestHuntVariantsE2E:
+    """End-to-end: variants integrate cleanly with the existing
+    context-map / flow-trace post-processor, contribute to the
+    coverage record, and flow through the libexec shim."""
+
+    def test_variants_alongside_context_map_and_flow_trace(
+        self, understand_run,
+    ):
+        """Full /understand run with context-map + flow-trace +
+        variants. Each pass writes annotations; pin the per-kind
+        emission counts so a future change that accidentally drops
+        one pipeline pass is caught."""
+        repo, out = understand_run
+        _make_context_map(out)
+        _make_flow_trace(out)
+        _make_variants(out, [
+            {"id": "VAR-001",
+             "file": "src/routes/query.py", "function": "admin_bulk",
+             "line": 42, "vuln_type": "sqli",
+             "taint_status": "confirmed_tainted",
+             "matched_code": "run_query(req.json)"},
+        ])
+        counts = synthesise_from_understand_output(out)
+        # Each pipeline pass contributed at least one annotation —
+        # variants didn't disrupt the existing flow.
+        assert counts.sources.get("entry_point", 0) >= 1
+        assert counts.sources.get("sink", 0) >= 1
+        assert counts.sources.get("variant", 0) == 1
+        # Verify the variant landed on admin_bulk.
+        ann = read_annotation(
+            out / "annotations",
+            "src/routes/query.py", "admin_bulk",
+        )
+        assert ann is not None
+        assert ann.metadata.get("variant_id") == "VAR-001"
+
+    def test_variants_contribute_to_coverage_record(self, understand_run):
+        """Coverage-annotations.json should include variant-only
+        functions so ``raptor-coverage-summary`` picks them up as
+        reviewed alongside entry-points and sinks."""
+        repo, out = understand_run
+        _make_variants(out, [{
+            "id": "VAR-COV",
+            "file": "src/db/query.py",
+            "function": "run_query",
+            "line": 90,
+            "taint_status": "confirmed_tainted",
+        }])
+        counts = synthesise_from_understand_output(out)
+        assert counts.emitted >= 1
+        record_path = out / "coverage-annotations.json"
+        assert record_path.exists(), (
+            "coverage-annotations.json must be written when variants emit"
+        )
+        record = json.loads(record_path.read_text())
+        assert record["tool"] == "annotations"
+        # The variant-annotated function shows up in the record.
+        funcs = record["functions_analysed"]
+        assert any(
+            f.get("file") == "src/db/query.py"
+            and f.get("function") == "run_query"
+            for f in funcs
+        )
+
+    def test_libexec_shim_processes_variants(self, understand_run):
+        """End-to-end through the libexec shim: variants.json gets
+        picked up, emission counted, by_kind summary mentions
+        variant. Mirrors TestShim::test_full_run shape."""
+        repo, out = understand_run
+        _make_variants(out, [{
+            "id": "VAR-SHIM",
+            "file": "src/db/query.py",
+            "function": "run_query",
+            "line": 90,
+            "taint_status": "confirmed_tainted",
+        }])
+        env = dict(os.environ)
+        env["_RAPTOR_TRUSTED"] = "1"
+        r = subprocess.run(
+            [sys.executable, str(SHIM), str(out)],
+            env=env, capture_output=True, text=True,
+        )
+        assert r.returncode == 0, r.stderr
+        assert "emitted=" in r.stdout
+        assert "variant" in r.stdout
+
+
+class TestHuntVariantsAdversarial:
+    """Hostile / malformed variants.json — synth must not crash and
+    must not pollute on-disk annotation files."""
+
+    def test_no_variants_json_is_silent(self, understand_run):
+        repo, out = understand_run
+        # No variants.json; cmap absent too. Counts stay zero, no crash.
+        counts = synthesise_from_understand_output(out)
+        assert counts.emitted == 0
+        assert counts.errors == 0
+
+    def test_corrupt_variants_json_does_not_crash(self, understand_run):
+        repo, out = understand_run
+        (out / "variants.json").write_text("{ not valid json")
+        counts = synthesise_from_understand_output(out)
+        # Bad JSON → load returns None → silently skipped.
+        assert counts.errors == 0
+        assert counts.sources.get("variant", 0) == 0
+
+    def test_variants_field_not_a_list_silently_skipped(
+        self, understand_run,
+    ):
+        repo, out = understand_run
+        (out / "variants.json").write_text(
+            json.dumps({"variants": "not a list"}),
+        )
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        assert counts.sources.get("variant", 0) == 0
+
+    def test_non_dict_variant_entries_are_dropped(self, understand_run):
+        repo, out = understand_run
+        (out / "variants.json").write_text(json.dumps({
+            "variants": [
+                "string entry",
+                42,
+                None,
+                {"id": "VAR-OK", "file": "src/db/query.py",
+                 "function": "run_query", "line": 90,
+                 "taint_status": "confirmed_tainted"},
+            ],
+        }))
+        counts = synthesise_from_understand_output(out)
+        # Only the dict entry should have been written.
+        assert counts.sources.get("variant", 0) == 1
+
+    def test_hostile_chars_in_metadata_sanitised(self, understand_run):
+        # Newlines, NUL, and HTML-comment delimiters in metadata
+        # values would corrupt the on-disk frontmatter format.
+        # ``_safe_meta`` strips them.
+        repo, out = understand_run
+        _make_variants(out, [{
+            "id": "VAR-EVIL\n## INJECTED",
+            "file": "src/db/query.py",
+            "function": "run_query",
+            "line": 90,
+            "vuln_type": "type\x00with\nnull",
+            "root_cause_group": "rcg<!--evil-->stop",
+            "taint_status": "confirmed_tainted",
+        }])
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        ann = read_annotation(
+            out / "annotations", "src/db/query.py", "run_query",
+        )
+        assert ann is not None
+        # Newlines and nulls stripped.
+        assert "\n" not in ann.metadata["variant_id"]
+        assert "\x00" not in ann.metadata["vuln_type"]
+        # HTML-comment delimiters defanged so on-disk frontmatter is
+        # safe to round-trip.
+        assert "<!--" not in ann.metadata["root_cause_group"]
+        assert "-->" not in ann.metadata["root_cause_group"]
+
+    def test_respect_manual_blocks_overwrite(self, understand_run):
+        # A manual annotation already exists on (file, function);
+        # the variants pass must not overwrite it.
+        repo, out = understand_run
+        base = out / "annotations"
+        write_annotation(base, Annotation(
+            file="src/db/query.py", function="run_query",
+            body="Reviewed manually — false positive",
+            metadata={"source": "human", "status": "clean"},
+        ))
+        _make_variants(out, [{
+            "id": "VAR-LATE",
+            "file": "src/db/query.py",
+            "function": "run_query",
+            "line": 90,
+            "taint_status": "confirmed_tainted",
+        }])
+        counts = synthesise_from_understand_output(out)
+        assert counts.skipped_manual_blocked >= 1
+        ann = read_annotation(
+            base, "src/db/query.py", "run_query",
+        )
+        assert ann.metadata["source"] == "human"
+        assert ann.metadata["status"] == "clean"
+
+
+# ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------
 

--- a/packages/code_understanding/tests/test_annotation_synth_adversarial.py
+++ b/packages/code_understanding/tests/test_annotation_synth_adversarial.py
@@ -388,3 +388,207 @@ class TestStructuralSurprises:
         counts = synthesise_from_understand_output(out)
         assert counts.errors == 0
         assert counts.emitted == 0
+
+
+# ---------------------------------------------------------------------------
+# Hunt variants — hostile / surprising input shapes
+# ---------------------------------------------------------------------------
+
+
+def _write_variants(out: Path, variants: list) -> None:
+    (out / "variants.json").write_text(json.dumps({"variants": variants}))
+
+
+class TestHuntVariantsHostile:
+    """Hostile / surprising variant content. ``_emit_variants`` must
+    not crash, must not corrupt on-disk annotation format, and must
+    bound resource use."""
+
+    def test_500_variant_stress(self, fixture):
+        """Wide variant batch — picker / writer must scale linearly
+        without blowing up. All 500 collide on the same (file,
+        function), so last-writer-wins; pin counts.sources tracks
+        all attempts."""
+        repo, out = fixture
+        _write_variants(out, [{
+            "id": f"VAR-{i:03d}",
+            "file": "src/app.py", "function": "login", "line": 1,
+            "taint_status": "confirmed_tainted",
+        } for i in range(500)])
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        assert counts.sources.get("variant", 0) == 500
+
+    def test_unicode_in_path_and_function_skipped_cleanly(self, fixture):
+        """File path / function name with non-ASCII letters. The
+        inventory has no matching entry → variant skipped to
+        ``skipped_no_function``, no crash from non-ASCII handling."""
+        repo, out = fixture
+        _write_variants(out, [{
+            "id": "VAR-Ω",
+            "file": "src/応用.py",
+            "function": "處理",
+            "line": 1,
+            "taint_status": "confirmed_tainted",
+        }])
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        assert counts.skipped_no_function >= 1
+
+    def test_control_bytes_in_body_fields(self, fixture):
+        """NUL / bell / ESC inside body-bound fields (matched_code,
+        notes, taint_source). Body is markdown — unlike metadata it
+        isn't ``_safe_meta``-sanitised, but the underlying annotation
+        substrate must not crash on these characters."""
+        repo, out = fixture
+        _write_variants(out, [{
+            "id": "VAR-CTRL",
+            "file": "src/app.py", "function": "login", "line": 1,
+            "taint_status": "confirmed_tainted",
+            "matched_code": "func(\x00x\x07y\x1bz)",
+            "notes": "trailing\x00null",
+            "taint_source": "src/x.py:1\x00with control",
+        }])
+        counts = synthesise_from_understand_output(out)
+        # Either the annotation substrate accepts and round-trips
+        # the body, OR rejects it with a counted error. Either is
+        # acceptable; what's NOT acceptable is an uncaught exception.
+        assert counts.errors + counts.sources.get("variant", 0) >= 1
+
+    def test_proof_field_as_string_not_dict(self, fixture):
+        """Producer emits ``proof`` as a plain string instead of the
+        documented dict. ``_emit_variants`` falls back to taint_source
+        as the body source — variant still annotated."""
+        repo, out = fixture
+        _write_variants(out, [{
+            "id": "VAR-PSTR",
+            "file": "src/app.py", "function": "login", "line": 1,
+            "taint_status": "confirmed_tainted",
+            "proof": "raw prose proof, not a dict",
+            "taint_source": "src/router.py:5",
+        }])
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        assert counts.sources.get("variant", 0) == 1
+        ann = read_annotation(
+            out / "annotations", "src/app.py", "login",
+        )
+        assert ann is not None
+        # Fallback to taint_source picked up.
+        assert "Taint source: src/router.py:5" in ann.body
+
+    def test_proof_field_as_list_not_dict(self, fixture):
+        """``proof: ["item1", "item2"]`` — handler does
+        ``isinstance(proof, dict)``, so a list silently falls
+        through. Pin the contract."""
+        repo, out = fixture
+        _write_variants(out, [{
+            "id": "VAR-PLIST",
+            "file": "src/app.py", "function": "login", "line": 1,
+            "taint_status": "confirmed_tainted",
+            "proof": ["a", "b", "c"],
+        }])
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        assert counts.sources.get("variant", 0) == 1
+
+    def test_deeply_nested_proof_dict(self, fixture):
+        """20-level-deep ``proof`` dict — handler only reads three
+        documented keys (vulnerable_code / source / sink) so depth
+        is irrelevant; pin no recursion / no crash."""
+        repo, out = fixture
+        deep = {"vulnerable_code": "x"}
+        for _ in range(20):
+            deep = {"wrap": deep}
+        _write_variants(out, [{
+            "id": "VAR-DEEP",
+            "file": "src/app.py", "function": "login", "line": 1,
+            "taint_status": "confirmed_tainted",
+            "proof": deep,
+        }])
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        assert counts.sources.get("variant", 0) == 1
+
+    def test_empty_body_variant_still_emits(self, fixture):
+        """All body-building fields missing → empty body. Annotation
+        substrate accepts empty bodies (status carried in metadata
+        alone), so this should still emit one annotation."""
+        repo, out = fixture
+        _write_variants(out, [{
+            "id": "VAR-EMPTY",
+            "file": "src/app.py", "function": "login", "line": 1,
+            "taint_status": "confirmed_tainted",
+            # No matched_code / proof / taint_source / notes.
+        }])
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        assert counts.sources.get("variant", 0) == 1
+        ann = read_annotation(
+            out / "annotations", "src/app.py", "login",
+        )
+        assert ann is not None
+        assert ann.body == ""
+        assert ann.metadata["status"] == "finding"
+
+    def test_path_traversal_in_variant_file_field(self, fixture):
+        """``file: "../../etc/passwd"`` — would-be path traversal.
+        Inventory lookup returns no match → variant skipped to
+        ``skipped_no_function``. The annotation substrate's path-
+        traversal defence is the second line; pin that we don't
+        even reach it because the inventory miss filters first."""
+        repo, out = fixture
+        _write_variants(out, [{
+            "id": "VAR-TRAV",
+            "file": "../../etc/passwd",
+            "function": "anything",
+            "line": 1,
+            "taint_status": "confirmed_tainted",
+        }])
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        assert counts.skipped_no_function >= 1
+        # No annotation file written under the base dir.
+        assert not any(
+            (out / "annotations").rglob("*.md")
+        )
+
+    def test_html_comment_close_in_vuln_type_metadata(self, fixture):
+        """``vuln_type`` lands in metadata; ``_safe_meta`` must
+        defang ``-->`` so the on-disk frontmatter
+        ``<!-- meta: vuln_type=... -->`` doesn't terminate early."""
+        repo, out = fixture
+        _write_variants(out, [{
+            "id": "VAR-HTML",
+            "file": "src/app.py", "function": "login", "line": 1,
+            "taint_status": "confirmed_tainted",
+            "vuln_type": "x-->y",
+        }])
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        ann = read_annotation(
+            out / "annotations", "src/app.py", "login",
+        )
+        assert ann is not None
+        assert "-->" not in ann.metadata["vuln_type"]
+
+    def test_newlines_in_metadata_field_sanitised(self, fixture):
+        """``confidence`` / ``priority`` with newline → metadata
+        substrate would reject; ``_safe_meta`` strips them so the
+        write succeeds."""
+        repo, out = fixture
+        _write_variants(out, [{
+            "id": "VAR-NL",
+            "file": "src/app.py", "function": "login", "line": 1,
+            "taint_status": "confirmed_tainted",
+            "confidence": "high\nrating",
+            "priority": "1\n2",
+        }])
+        counts = synthesise_from_understand_output(out)
+        assert counts.errors == 0
+        ann = read_annotation(
+            out / "annotations", "src/app.py", "login",
+        )
+        assert ann is not None
+        assert "\n" not in ann.metadata["confidence"]
+        assert "\n" not in ann.metadata["priority"]


### PR DESCRIPTION
Extends synthesise_from_understand_output to walk variants.json (the /understand --hunt output) and emit one annotation per variant on the (file, function) where it was found. Mirrors the existing context-map / flow-trace passes that already cover --map and --trace; closes the gap that left hunt's variants invisible to raptor-coverage-summary and the /annotate lifecycle.

Reuse plan: PR θ of 9 (annotations → /understand --hunt).

Surface area:
  * _emit_variants() walks variants[], resolves each (file, line) to an inventory function via _resolve, builds a body from vuln_type / matched_code / proof / taint_source / entry_points / auth_required / notes, and stamps metadata with variant_id / vuln_type / confidence / taint_status / root_cause_group / priority.
  * Status mapping: taint_status is the primary signal (confirmed_ tainted / likely_tainted → finding; unlikely_tainted / false_positive → suspicious). Falls through to status field (not_disproven → finding; disproven / false_positive → suspicious). Defaults to suspicious if neither field present.
  * Honours overwrite="respect-manual" — operator notes survive.
  * proof may be a dict, string, list, or absent — handler tolerates all shapes.
  * Wired into synthesise_from_understand_output between context-map and flow-trace so the existing last-writer-wins convention for trace steps is preserved.

Tests (30 new, 33 if including bundled adversarial):
  * 11 wiring tests (TestHuntVariants): finding/suspicious mapping, taint_status precedence, body field coverage, multi-variant last-writer-wins, skip on inventory miss.
  * 6 hostile-input tests (TestHuntVariantsAdversarial): corrupt JSON, non-list variants[], non-dict entries, hostile metadata chars, respect-manual.
  * 3 end-to-end tests (TestHuntVariantsE2E): variants alongside context-map + flow-trace, coverage-record contribution, libexec shim subprocess.
  * 10 adversarial tests (TestHuntVariantsHostile): 500-variant stress, unicode paths, control bytes in body, proof as string/ list/20-deep dict, empty body, path traversal in file field, HTML-comment-close in metadata, newlines in metadata.

446 tests pass across packages/code_understanding/tests/ + core/annotations/tests/.