### PR TITLE
feat(validate): emit annotations from IRIS Tier 1 refutations

### DIFF
--- a/packages/exploitability_validation/annotation_emit.py
+++ b/packages/exploitability_validation/annotation_emit.py
@@ -394,3 +394,125 @@ def emit_stage_annotations(workdir: Path, stage_letter: str) -> int:
         if path is not None:
             written += 1
     return written
+
+
+# ---------------------------------------------------------------------------
+# IRIS Tier 1 gate refutation annotations
+# ---------------------------------------------------------------------------
+
+
+_IRIS_TIER1_REFUTATION_BODY = (
+    "Refuted by IRIS Tier 1 LocalFlowSource query.\n\n"
+    "The CodeQL query found no path from any tracked source "
+    "(commandargs / environment / stdin / file / remote) to the "
+    "claimed sink under the broad source model. The reported flow "
+    "does not exist in the current code."
+)
+
+
+def _emit_iris_tier1_one(
+    finding: Dict[str, Any], base_dir: Path,
+) -> Optional[Path]:
+    """Build + write one IRIS Tier 1 refutation annotation. Returns
+    the path or None when the finding lacks the fields required to
+    land an annotation (file / function) or the substrate write
+    failed."""
+    file_path = finding.get("file") or finding.get("file_path")
+    function = finding.get("function")
+    if not file_path or not function:
+        return None
+
+    body_parts: List[str] = [_IRIS_TIER1_REFUTATION_BODY]
+    # Surface the original claim so the operator can retrace why this
+    # finding was filed in the first place.
+    claim = (
+        finding.get("description")
+        or finding.get("title")
+        or finding.get("message")
+    )
+    if claim:
+        body_parts.append(f"Original claim: {claim}")
+    body = "\n\n".join(body_parts)
+
+    metadata: Dict[str, str] = {
+        "source": "llm",
+        "status": "clean",
+        "stage": "IRIS_TIER1",
+        "tool": "validate",
+        "iris_verdict": "refuted",
+    }
+    cwe = finding.get("cwe_id")
+    if cwe:
+        metadata["cwe"] = _sanitise_meta(cwe)
+    rule_id = finding.get("rule_id")
+    if rule_id:
+        metadata["rule_id"] = _sanitise_meta(rule_id)
+    vt = finding.get("vuln_type")
+    if vt:
+        metadata["vuln_type"] = _sanitise_meta(vt)
+    fid = finding.get("id")
+    if fid:
+        metadata["finding_id"] = _sanitise_meta(fid)
+
+    from core.annotations import Annotation, write_annotation
+
+    try:
+        return write_annotation(
+            base_dir,
+            Annotation(
+                file=file_path,
+                function=function,
+                body=body,
+                metadata=metadata,
+            ),
+            overwrite="respect-manual",
+        )
+    except (ValueError, OSError) as e:
+        logger.debug(
+            f"validate.annotation_emit: IRIS Tier 1 write failed for "
+            f"{file_path}:{function}: {e}"
+        )
+        return None
+
+
+def emit_iris_tier1_annotations(
+    workdir: Path, refuted_findings: List[Dict[str, Any]],
+) -> int:
+    """Emit one ``status=clean`` annotation per IRIS-refuted finding.
+
+    Called from the orchestrator's IRIS Tier 1 gate (between Stage A
+    and Stage B) when the LocalFlowSource query finds no path from
+    any tracked source to the claimed sink. The Stage A annotation
+    (typically ``status=suspicious``) is overwritten with the
+    refutation verdict so the operator's per-function review trail
+    reflects the negative result.
+
+    Best-effort throughout — malformed findings, substrate failures,
+    or annotation-write rejections all produce zero or skip
+    individual entries without raising. The /validate IRIS gate
+    must never fail because annotations failed.
+
+    Returns count of annotations actually written. Zero when the
+    list is empty, every entry malformed, or every write blocked
+    by ``respect-manual``.
+    """
+    if not refuted_findings:
+        return 0
+    workdir = Path(workdir)
+    base_dir = workdir / "annotations"
+    written = 0
+    for finding in refuted_findings:
+        if not isinstance(finding, dict):
+            continue
+        try:
+            path = _emit_iris_tier1_one(finding, base_dir)
+        except Exception:
+            logger.debug(
+                "validate.annotation_emit: IRIS Tier 1 per-finding "
+                "emit failed",
+                exc_info=True,
+            )
+            continue
+        if path is not None:
+            written += 1
+    return written

--- a/packages/exploitability_validation/orchestrator.py
+++ b/packages/exploitability_validation/orchestrator.py
@@ -771,6 +771,7 @@ class ValidationOrchestrator:
         )
 
         n_refuted = 0
+        refuted_findings: List[Dict[str, Any]] = []
         for finding in not_disproven:
             try:
                 verdict = tier1_check_finding(
@@ -799,6 +800,7 @@ class ValidationOrchestrator:
                 ),
                 "lesson": "iris_tier1_refuted",
             })
+            refuted_findings.append(finding)
             n_refuted += 1
 
         if n_refuted:
@@ -814,6 +816,22 @@ class ValidationOrchestrator:
                 f"{len(not_disproven)} not_disproven finding(s); "
                 "Stage B will skip them"
             )
+            # Mirror the refutation into per-function annotations so
+            # the operator's review trail flips from "suspicious"
+            # (Stage A's typical verdict) to "clean" with the IRIS
+            # refutation reason. Best-effort: a failure here must not
+            # break the gate.
+            try:
+                from packages.exploitability_validation.annotation_emit import (
+                    emit_iris_tier1_annotations,
+                )
+                emit_iris_tier1_annotations(
+                    Path(self.config.workdir), refuted_findings,
+                )
+            except Exception as e:
+                logger.debug(
+                    "IRIS Tier 1 gate: annotation emit failed: %s", e,
+                )
 
     def _run_stage_b(self) -> List[str]:
         """Stage B: Process - Systematic analysis with attack trees."""

--- a/packages/exploitability_validation/tests/test_annotation_emit.py
+++ b/packages/exploitability_validation/tests/test_annotation_emit.py
@@ -18,6 +18,7 @@ from core.annotations import (
     Annotation, iter_all_annotations, read_annotation, write_annotation,
 )
 from packages.exploitability_validation.annotation_emit import (
+    emit_iris_tier1_annotations,
     emit_stage_annotations,
 )
 
@@ -605,3 +606,686 @@ class TestAdversarial:
         )
         assert "\n" not in ann.metadata["finding_id"]
         assert "\x00" not in ann.metadata["finding_id"]
+
+
+# ---------------------------------------------------------------------------
+# IRIS Tier 1 gate refutations
+# ---------------------------------------------------------------------------
+
+
+class TestIrisTier1Refutations:
+    """``emit_iris_tier1_annotations`` is called from the IRIS Tier 1
+    gate (between Stage A and Stage B). Each refuted finding gets a
+    ``status=clean`` annotation overwriting Stage A's
+    ``status=suspicious``."""
+
+    def test_refuted_finding_emits_clean_annotation(self, tmp_path):
+        finding = _basic_finding(fid="F-1", stage_a_status="not_disproven")
+        finding["description"] = "Path traversal in upload"
+        n = emit_iris_tier1_annotations(tmp_path, [finding])
+        assert n == 1
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann.metadata["status"] == "clean"
+        assert ann.metadata["iris_verdict"] == "refuted"
+        assert ann.metadata["stage"] == "IRIS_TIER1"
+        assert ann.metadata["tool"] == "validate"
+        assert ann.metadata["finding_id"] == "F-1"
+        assert ann.metadata["cwe"] == "CWE-89"
+        assert ann.metadata["rule_id"] == "py/sql-injection"
+
+    def test_body_includes_refutation_reason(self, tmp_path):
+        finding = _basic_finding(fid="F-2")
+        finding["description"] = "SQL injection in login flow"
+        emit_iris_tier1_annotations(tmp_path, [finding])
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert "Refuted by IRIS Tier 1" in ann.body
+        assert "tracked source" in ann.body
+        assert "SQL injection in login flow" in ann.body
+
+    def test_body_falls_back_to_title_or_message(self, tmp_path):
+        # No description, but title.
+        f1 = _basic_finding(fid="F-3")
+        f1["title"] = "title-text"
+        emit_iris_tier1_annotations(tmp_path, [f1])
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert "title-text" in ann.body
+
+    def test_body_omits_claim_line_when_no_claim_text(self, tmp_path):
+        # No description / title / message — the body should still
+        # render with the canonical refutation reason.
+        finding = _basic_finding(fid="F-4")
+        emit_iris_tier1_annotations(tmp_path, [finding])
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert "Refuted by IRIS Tier 1" in ann.body
+        assert "Original claim:" not in ann.body
+
+    def test_finding_without_file_or_function_is_skipped(self, tmp_path):
+        finding = _basic_finding(fid="F-5")
+        del finding["file"]
+        n = emit_iris_tier1_annotations(tmp_path, [finding])
+        assert n == 0
+
+    def test_empty_list_returns_zero_no_dir_created(self, tmp_path):
+        n = emit_iris_tier1_annotations(tmp_path, [])
+        assert n == 0
+        assert not (tmp_path / "annotations").exists()
+
+    def test_respect_manual_blocks_overwrite(self, tmp_path):
+        # Operator wrote a manual note first.
+        write_annotation(tmp_path / "annotations", Annotation(
+            file="src/auth/login.py", function="check_credentials",
+            body="Reviewed manually — exploit confirmed",
+            metadata={"source": "human", "status": "finding"},
+        ))
+        finding = _basic_finding(fid="F-6")
+        n = emit_iris_tier1_annotations(tmp_path, [finding])
+        assert n == 0
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann.metadata["source"] == "human"
+        assert ann.metadata["status"] == "finding"
+
+    def test_stage_a_then_iris_refutation_overwrites_to_clean(
+        self, tmp_path,
+    ):
+        # Stage A wrote ``status=suspicious``; IRIS refutation must
+        # overwrite to ``status=clean``. Mirrors the in-pipeline
+        # ordering: A → IRIS Tier 1 → B.
+        _write_findings(tmp_path, [_basic_finding(
+            fid="F-7", stage_a_status="not_disproven",
+        )])
+        emit_stage_annotations(tmp_path, "A")
+        ann_a = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann_a.metadata["status"] == "suspicious"
+
+        # Then IRIS gate refutes it.
+        finding = _basic_finding(fid="F-7")
+        finding["description"] = "Path traversal"
+        emit_iris_tier1_annotations(tmp_path, [finding])
+        ann_after = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann_after.metadata["status"] == "clean"
+        assert ann_after.metadata["iris_verdict"] == "refuted"
+
+    def test_multiple_refutations_each_get_own_annotation(self, tmp_path):
+        f1 = _basic_finding(fid="F-A", file="src/a.py", function="fa")
+        f2 = _basic_finding(fid="F-B", file="src/b.py", function="fb")
+        f3 = _basic_finding(fid="F-C", file="src/c.py", function="fc")
+        n = emit_iris_tier1_annotations(tmp_path, [f1, f2, f3])
+        assert n == 3
+        for path, func in [
+            ("src/a.py", "fa"), ("src/b.py", "fb"), ("src/c.py", "fc"),
+        ]:
+            ann = read_annotation(tmp_path / "annotations", path, func)
+            assert ann.metadata["status"] == "clean"
+
+    def test_non_dict_entries_silently_skipped(self, tmp_path):
+        f1 = _basic_finding(fid="F-OK")
+        n = emit_iris_tier1_annotations(
+            tmp_path, [None, "string", 42, ["list"], f1],
+        )
+        # Only the valid dict was emitted.
+        assert n == 1
+
+
+# ---------------------------------------------------------------------------
+# IRIS Tier 1 — adversarial / hostile inputs
+# ---------------------------------------------------------------------------
+
+
+class TestIrisTier1Adversarial:
+    def test_hostile_chars_in_metadata_fields_sanitised(self, tmp_path):
+        finding = _basic_finding(
+            fid="F-EVIL\n## INJECTED",
+            cwe="CWE-89-->",
+            rule_id="rule\x00with\nnull",
+        )
+        emit_iris_tier1_annotations(tmp_path, [finding])
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        # Newlines / nulls / HTML-comment delimiters all defanged
+        # by ``_sanitise_meta``.
+        for key in ("finding_id", "cwe", "rule_id"):
+            v = ann.metadata.get(key, "")
+            assert "\n" not in v
+            assert "\x00" not in v
+            assert "-->" not in v
+
+    def test_hostile_description_in_body_does_not_crash(self, tmp_path):
+        finding = _basic_finding(fid="F-DESC")
+        # Body is markdown — no _sanitise_meta. Substrate must
+        # still accept it without crashing.
+        finding["description"] = (
+            "Claim with newlines\nand <!-- HTML comment --> and "
+            "\x00 null bytes"
+        )
+        n = emit_iris_tier1_annotations(tmp_path, [finding])
+        # Either accepted (n==1) or silently rejected by substrate
+        # (n==0); never crashes.
+        assert n in (0, 1)
+
+    def test_huge_refuted_findings_list_scales_linearly(self, tmp_path):
+        findings = [
+            _basic_finding(fid=f"F-{i:03d}",
+                           file=f"src/m_{i}.py",
+                           function=f"f_{i}")
+            for i in range(200)
+        ]
+        n = emit_iris_tier1_annotations(tmp_path, findings)
+        assert n == 200
+
+    def test_substrate_write_failure_swallowed(self, tmp_path, monkeypatch):
+        # Force write_annotation to raise — emit must catch and
+        # return zero rather than propagate.
+        from core import annotations as ann_mod
+
+        def boom(*args, **kwargs):
+            raise OSError("simulated disk full")
+
+        monkeypatch.setattr(ann_mod, "write_annotation", boom)
+        # Re-import to pick up the patched function inside the
+        # emit_iris_tier1_one's local import.
+        finding = _basic_finding(fid="F-DOOM")
+        n = emit_iris_tier1_annotations(tmp_path, [finding])
+        assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# IRIS Tier 1 — E2E through the orchestrator
+# ---------------------------------------------------------------------------
+
+
+class TestIrisTier1OrchestratorE2E:
+    """Drive ``_iris_tier1_gate`` end-to-end with mocks for the IRIS
+    check + CodeQL DB discovery so the gate's annotation-emission
+    wire-up is exercised at the layer that actually calls it."""
+
+    def _setup(self, tmp_path):
+        from packages.exploitability_validation.orchestrator import (
+            PipelineConfig, ValidationOrchestrator,
+        )
+        # Minimal repo + workdir.
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "src").mkdir()
+        (repo / "src" / "auth.py").write_text(
+            "def login(req):\n    return req\n"
+        )
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+
+        finding = _basic_finding(
+            fid="F-IRIS", file="src/auth.py", function="login",
+            stage_a_status="not_disproven",
+        )
+        # Top-level status is what the gate filters on (vs.
+        # stage_a_summary.status which is what annotation_emit reads).
+        finding["status"] = "not_disproven"
+        finding["description"] = "Path traversal in login"
+        # Full Stage A findings.json so the gate has data to read.
+        (workdir / "findings.json").write_text(json.dumps({
+            "stage": "A",
+            "target_path": str(repo),
+            "findings": [finding],
+        }))
+
+        config = PipelineConfig(
+            target_path=str(repo),
+            workdir=str(workdir),
+            vuln_type="sqli",
+        )
+        orch = ValidationOrchestrator(config)
+        # State.findings populated for the gate.
+        orch.state.findings = json.loads(
+            (workdir / "findings.json").read_text(),
+        )
+        return orch, workdir
+
+    def test_gate_writes_annotation_when_iris_refutes(
+        self, tmp_path, monkeypatch,
+    ):
+        orch, workdir = self._setup(tmp_path)
+
+        # Mock the IRIS imports so the gate believes it has DBs and
+        # runs the (mocked) Tier 1 check that returns ``refuted``.
+        from packages.llm_analysis import dataflow_validation as dv
+
+        monkeypatch.setattr(
+            dv, "discover_codeql_databases",
+            lambda d: {"python": Path("/fake/db")},
+        )
+        monkeypatch.setattr(
+            dv, "tier1_check_finding",
+            lambda f, dbs, target_path=None: "refuted",
+        )
+
+        orch._iris_tier1_gate()
+
+        # Annotation written under the workdir's annotations/.
+        ann = read_annotation(
+            workdir / "annotations", "src/auth.py", "login",
+        )
+        assert ann is not None
+        assert ann.metadata["status"] == "clean"
+        assert ann.metadata["iris_verdict"] == "refuted"
+        assert ann.metadata["finding_id"] == "F-IRIS"
+        assert "Refuted by IRIS Tier 1" in ann.body
+        assert "Path traversal in login" in ann.body
+        # Finding's status was also flipped.
+        flipped = orch.state.findings["findings"][0]
+        assert flipped["status"] == "disproven"
+
+    def test_gate_no_annotation_when_iris_does_not_refute(
+        self, tmp_path, monkeypatch,
+    ):
+        orch, workdir = self._setup(tmp_path)
+        from packages.llm_analysis import dataflow_validation as dv
+
+        monkeypatch.setattr(
+            dv, "discover_codeql_databases",
+            lambda d: {"python": Path("/fake/db")},
+        )
+        # IRIS finds a path → finding stays not_disproven.
+        monkeypatch.setattr(
+            dv, "tier1_check_finding",
+            lambda f, dbs, target_path=None: "uncertain",
+        )
+
+        orch._iris_tier1_gate()
+        # No refutation → no annotation written.
+        assert not (workdir / "annotations").exists()
+
+    def test_gate_annotation_failure_does_not_break_refutation(
+        self, tmp_path, monkeypatch,
+    ):
+        # The annotation emit is best-effort — if it raises, the gate
+        # must still complete the refutation (findings.json updated,
+        # disproven.json updated).
+        orch, workdir = self._setup(tmp_path)
+        from packages.llm_analysis import dataflow_validation as dv
+        from packages.exploitability_validation import annotation_emit as ae
+
+        monkeypatch.setattr(
+            dv, "discover_codeql_databases",
+            lambda d: {"python": Path("/fake/db")},
+        )
+        monkeypatch.setattr(
+            dv, "tier1_check_finding",
+            lambda f, dbs, target_path=None: "refuted",
+        )
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("simulated annotation failure")
+
+        monkeypatch.setattr(ae, "emit_iris_tier1_annotations", boom)
+
+        # Must not raise.
+        orch._iris_tier1_gate()
+        # Refutation persisted.
+        flipped = orch.state.findings["findings"][0]
+        assert flipped["status"] == "disproven"
+
+
+# ---------------------------------------------------------------------------
+# IRIS Tier 1 — extended adversarial / E2E
+# ---------------------------------------------------------------------------
+
+
+class TestIrisTier1ExtendedAdversarial:
+    """Hostile / surprising content beyond the basic adversarial pass."""
+
+    def test_path_traversal_in_finding_file_blocked(self, tmp_path):
+        """``file: "../../etc/passwd"`` — annotation substrate's path-
+        traversal defence must reject the write. Helper catches the
+        ValueError and returns 0; no file written."""
+        finding = _basic_finding(
+            fid="F-TRAV", file="../../etc/passwd",
+        )
+        n = emit_iris_tier1_annotations(tmp_path, [finding])
+        assert n == 0
+        # No annotation file landed under the workdir base.
+        ann_dir = tmp_path / "annotations"
+        if ann_dir.exists():
+            assert not list(ann_dir.rglob("*.md"))
+
+    def test_unicode_in_finding_fields(self, tmp_path):
+        """Non-ASCII letters in finding fields — function-name
+        substrate accepts unicode word chars, so this should land
+        cleanly. CWE / rule_id metadata also passes through."""
+        finding = _basic_finding(
+            fid="F-Ω", file="src/應用.py", function="處理_request",
+            cwe="CWE-22",
+        )
+        finding["description"] = "路径穿越 — path traversal"
+        n = emit_iris_tier1_annotations(tmp_path, [finding])
+        # Either accepted or rejected by substrate; never crashes.
+        assert n in (0, 1)
+
+    def test_500_finding_stress(self, tmp_path):
+        """Wide refutation batch — emit scales linearly without
+        memory blowup. Each landing on a distinct (file, function)
+        so no collision noise."""
+        findings = [
+            _basic_finding(
+                fid=f"F-{i:03d}",
+                file=f"src/m_{i}.py",
+                function=f"f_{i}",
+            )
+            for i in range(500)
+        ]
+        n = emit_iris_tier1_annotations(tmp_path, findings)
+        assert n == 500
+
+    def test_lowercase_cwe_metadata_preserved_verbatim(self, tmp_path):
+        """``cwe_id: "cwe-22"`` (lowercase) — ``_sanitise_meta``
+        strips control bytes / HTML-comment delimiters but does
+        NOT case-normalise. Pin verbatim preservation so future
+        consumers can rely on the original casing."""
+        finding = _basic_finding(fid="F-LC", cwe="cwe-22")
+        emit_iris_tier1_annotations(tmp_path, [finding])
+        ann = read_annotation(
+            tmp_path / "annotations",
+            "src/auth/login.py", "check_credentials",
+        )
+        assert ann.metadata["cwe"] == "cwe-22"
+
+    def test_partial_batch_write_failure_continues(
+        self, tmp_path, monkeypatch,
+    ):
+        """One bad write in the middle of a batch must not abort the
+        rest — emit returns the count of successful writes."""
+        from core import annotations as ann_mod
+        original = ann_mod.write_annotation
+        call_count = {"n": 0}
+
+        def flaky(*args, **kwargs):
+            call_count["n"] += 1
+            # Fail the second write only.
+            if call_count["n"] == 2:
+                raise OSError("simulated mid-batch failure")
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(ann_mod, "write_annotation", flaky)
+
+        findings = [
+            _basic_finding(fid="F-1", file="src/a.py", function="fa"),
+            _basic_finding(fid="F-2", file="src/b.py", function="fb"),
+            _basic_finding(fid="F-3", file="src/c.py", function="fc"),
+        ]
+        n = emit_iris_tier1_annotations(tmp_path, findings)
+        # Two of three succeed; the failed one is silently swallowed.
+        assert n == 2
+
+
+class TestIrisTier1ExtendedE2E:
+    """End-to-end paths beyond the basic gate happy path."""
+
+    def _setup(self, tmp_path):
+        from packages.exploitability_validation.orchestrator import (
+            PipelineConfig, ValidationOrchestrator,
+        )
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "src").mkdir()
+        (repo / "src" / "auth.py").write_text(
+            "def login(req):\n    return req\n"
+        )
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+
+        finding = _basic_finding(
+            fid="F-IRIS", file="src/auth.py", function="login",
+            stage_a_status="not_disproven",
+        )
+        finding["status"] = "not_disproven"
+        finding["description"] = "Path traversal in login"
+        (workdir / "findings.json").write_text(json.dumps({
+            "stage": "A",
+            "target_path": str(repo),
+            "findings": [finding],
+        }))
+
+        config = PipelineConfig(
+            target_path=str(repo),
+            workdir=str(workdir),
+            vuln_type="sqli",
+        )
+        orch = ValidationOrchestrator(config)
+        orch.state.findings = json.loads(
+            (workdir / "findings.json").read_text(),
+        )
+        return orch, workdir
+
+    def test_stage_a_then_iris_lifecycle(self, tmp_path, monkeypatch):
+        """Full chronologically-correct flow: Stage A annotation
+        emits ``status=suspicious``; IRIS Tier 1 refutes it; final
+        annotation reflects ``status=clean`` with the IRIS reason.
+        Operator's per-function review trail tells the right story
+        without manual re-reading of findings.json."""
+        orch, workdir = self._setup(tmp_path)
+
+        # Stage A emit first.
+        n_a = emit_stage_annotations(workdir, "A")
+        assert n_a == 1
+        ann_a = read_annotation(
+            workdir / "annotations", "src/auth.py", "login",
+        )
+        assert ann_a.metadata["status"] == "suspicious"
+        assert ann_a.metadata["stage"] == "A"
+
+        # IRIS Tier 1 gate runs.
+        from packages.llm_analysis import dataflow_validation as dv
+        monkeypatch.setattr(
+            dv, "discover_codeql_databases",
+            lambda d: {"python": Path("/fake/db")},
+        )
+        monkeypatch.setattr(
+            dv, "tier1_check_finding",
+            lambda f, dbs, target_path=None: "refuted",
+        )
+        orch._iris_tier1_gate()
+
+        ann_after = read_annotation(
+            workdir / "annotations", "src/auth.py", "login",
+        )
+        assert ann_after.metadata["status"] == "clean"
+        assert ann_after.metadata["stage"] == "IRIS_TIER1"
+        assert ann_after.metadata["iris_verdict"] == "refuted"
+        # Stage A's CWE / rule_id carry through.
+        assert ann_after.metadata["cwe"] == "CWE-89"
+        assert ann_after.metadata["rule_id"] == "py/sql-injection"
+
+    def test_gate_with_no_codeql_dbs_early_returns_no_emit(
+        self, tmp_path, monkeypatch,
+    ):
+        """When ``discover_codeql_databases`` returns nothing for any
+        candidate dir, the gate short-circuits before reaching
+        ``tier1_check_finding`` or the emit. Annotations dir must
+        not exist."""
+        orch, workdir = self._setup(tmp_path)
+        from packages.llm_analysis import dataflow_validation as dv
+
+        monkeypatch.setattr(
+            dv, "discover_codeql_databases",
+            lambda d: {},
+        )
+        # tier1_check_finding must NOT be called — set a sentinel
+        # that would fail the test if reached.
+        monkeypatch.setattr(
+            dv, "tier1_check_finding",
+            lambda *a, **kw: pytest.fail(
+                "tier1_check_finding called when no DBs discovered",
+            ),
+        )
+
+        orch._iris_tier1_gate()
+        assert not (workdir / "annotations").exists()
+
+    def test_disproven_json_wrapped_shape_preserved_with_emit(
+        self, tmp_path, monkeypatch,
+    ):
+        """Pre-existing disproven.json with ``{"disproven": [...]}``
+        wrapped shape — gate appends to the list AND emits
+        annotations; the wrapped shape is preserved on disk."""
+        orch, workdir = self._setup(tmp_path)
+        # Pre-existing wrapped disproven.json.
+        (workdir / "disproven.json").write_text(json.dumps({
+            "disproven": [{"finding": "F-PRIOR",
+                           "why_wrong": "earlier refutation"}],
+        }))
+
+        from packages.llm_analysis import dataflow_validation as dv
+        monkeypatch.setattr(
+            dv, "discover_codeql_databases",
+            lambda d: {"python": Path("/fake/db")},
+        )
+        monkeypatch.setattr(
+            dv, "tier1_check_finding",
+            lambda f, dbs, target_path=None: "refuted",
+        )
+        orch._iris_tier1_gate()
+
+        # Disproven.json kept its wrapped shape.
+        disproven = json.loads(
+            (workdir / "disproven.json").read_text(),
+        )
+        assert isinstance(disproven, dict)
+        assert "disproven" in disproven
+        ids = [d["finding"] for d in disproven["disproven"]]
+        assert "F-PRIOR" in ids
+        assert "F-IRIS" in ids
+        # Annotation also written.
+        ann = read_annotation(
+            workdir / "annotations", "src/auth.py", "login",
+        )
+        assert ann.metadata["status"] == "clean"
+
+    def test_disproven_json_unwrapped_shape_preserved_with_emit(
+        self, tmp_path, monkeypatch,
+    ):
+        """Pre-existing disproven.json with bare ``[...]`` list shape
+        — gate appends + emits; bare-list shape preserved on disk."""
+        orch, workdir = self._setup(tmp_path)
+        (workdir / "disproven.json").write_text(json.dumps([
+            {"finding": "F-PRIOR", "why_wrong": "earlier refutation"},
+        ]))
+
+        from packages.llm_analysis import dataflow_validation as dv
+        monkeypatch.setattr(
+            dv, "discover_codeql_databases",
+            lambda d: {"python": Path("/fake/db")},
+        )
+        monkeypatch.setattr(
+            dv, "tier1_check_finding",
+            lambda f, dbs, target_path=None: "refuted",
+        )
+        orch._iris_tier1_gate()
+
+        disproven = json.loads(
+            (workdir / "disproven.json").read_text(),
+        )
+        assert isinstance(disproven, list)
+        ids = [d["finding"] for d in disproven]
+        assert "F-PRIOR" in ids and "F-IRIS" in ids
+        # Annotation also written.
+        ann = read_annotation(
+            workdir / "annotations", "src/auth.py", "login",
+        )
+        assert ann.metadata["status"] == "clean"
+
+    def test_unexpected_tier1_verdict_string_no_emit(
+        self, tmp_path, monkeypatch,
+    ):
+        """``tier1_check_finding`` returns an unrecognised verdict
+        like ``"refute"`` (typo) — gate treats anything other than
+        ``"refuted"`` as not-refuted; no status flip, no annotation."""
+        orch, workdir = self._setup(tmp_path)
+        from packages.llm_analysis import dataflow_validation as dv
+
+        monkeypatch.setattr(
+            dv, "discover_codeql_databases",
+            lambda d: {"python": Path("/fake/db")},
+        )
+        monkeypatch.setattr(
+            dv, "tier1_check_finding",
+            lambda f, dbs, target_path=None: "refute",  # typo
+        )
+        orch._iris_tier1_gate()
+        # No annotations dir created.
+        assert not (workdir / "annotations").exists()
+        # Finding's status remains not_disproven.
+        assert orch.state.findings["findings"][0]["status"] == "not_disproven"
+
+    def test_stage_b_emit_after_iris_overwrites_clean_pin(
+        self, tmp_path, monkeypatch,
+    ):
+        """Pin current behaviour: if Stage B emit runs against the
+        IRIS-refuted finding (it shouldn't, since the gate flips
+        status to ``disproven`` and Stage B's loop filters those
+        out — but if a future change broke that filter), Stage B
+        emit's ``stage=B`` would clobber ``stage=IRIS_TIER1``. The
+        IRIS reason in body would also be replaced.
+
+        Pin: the gate's filter is the ONLY thing keeping Stage B
+        from regressing the IRIS verdict; any future refactor must
+        preserve that filter."""
+        orch, workdir = self._setup(tmp_path)
+        from packages.llm_analysis import dataflow_validation as dv
+
+        monkeypatch.setattr(
+            dv, "discover_codeql_databases",
+            lambda d: {"python": Path("/fake/db")},
+        )
+        monkeypatch.setattr(
+            dv, "tier1_check_finding",
+            lambda f, dbs, target_path=None: "refuted",
+        )
+        orch._iris_tier1_gate()
+        ann_iris = read_annotation(
+            workdir / "annotations", "src/auth.py", "login",
+        )
+        assert ann_iris.metadata["stage"] == "IRIS_TIER1"
+
+        # Now manually re-run Stage B emit on the same finding —
+        # this is what the gate's filter is supposed to prevent.
+        # Synthesise a finding with stage_b_summary so the Stage B
+        # path actually overrides.
+        f = json.loads((workdir / "findings.json").read_text())
+        f["findings"][0]["status"] = "not_disproven"  # un-flip
+        f["findings"][0]["stage_b_summary"] = {
+            "hypothesis_status": "disproven",
+        }
+        (workdir / "findings.json").write_text(json.dumps(f))
+        emit_stage_annotations(workdir, "B")
+
+        ann_after_b = read_annotation(
+            workdir / "annotations", "src/auth.py", "login",
+        )
+        # Stage B's stage tag wins. This is the regression risk
+        # this test pins.
+        assert ann_after_b.metadata["stage"] == "B"
+        # IRIS verdict metadata is gone — body no longer mentions
+        # the refutation reason.
+        assert "iris_verdict" not in ann_after_b.metadata
+        assert "Refuted by IRIS Tier 1" not in ann_after_b.body


### PR DESCRIPTION
Closes the gap between Stage A's annotation emission (PR δ) and Stage B. IRIS Tier 1 runs between A and B, flipping ``not_disproven`` findings to ``disproven`` when the LocalFlowSource CodeQL query finds no path to the claimed sink. Pre-fix, that refutation only landed in findings.json / disproven.json; the per-function annotation written by Stage A (typically ``status=suspicious``) stayed stale until Stage B overwrote it later — and Stage B was deliberately skipped for IRIS-refuted findings, so the stale annotation was the operator's last visible state.

Now the IRIS gate emits one ``status=clean`` annotation per refuted finding, mirroring the stage_a/b/d pattern.

Reuse plan: PR ι of 9 (annotations → IRIS Tier 1 gate). Plan complete after this lands.

Surface area:
  * ``emit_iris_tier1_annotations(workdir, refuted_findings)`` in annotation_emit.py — public entry point. Walks the list, writes one annotation per dict entry via ``_emit_iris_tier1_one`` with status=clean, body referencing the canonical IRIS Tier 1 refutation reason (mirrors disproven.json's ``why_wrong`` text), and metadata source=llm + iris_verdict=refuted + stage=IRIS_TIER1 + tool=validate plus finding-derived fields (cwe / rule_id / vuln_type / finding_id).
  * Orchestrator wire-in: ``_iris_tier1_gate`` collects each refuted finding into a list during the existing refutation loop, then calls the emit helper after persisting findings.json / disproven.json. Wrapped in try/except so annotation failures never break the gate (best-effort convention shared with the rest of the /validate annotation pipeline).
  * Honours overwrite="respect-manual" — operator notes survive.