### PR TITLE
deps: exact-pin every runtime/dev/devcontainer/web dep

### DIFF
--- a/.devcontainer/requirements-all-optional.txt
+++ b/.devcontainer/requirements-all-optional.txt
@@ -5,12 +5,13 @@
 -r ../requirements.txt
 
 # All LLM provider SDKs
-openai>=1.0.0
-anthropic>=0.40.0
+openai==2.26.0
+anthropic==0.84.0
 
-# Enhanced visualization
-tabulate>=0.9.0
+# `tabulate` is already pinned in ../requirements.txt (pulled in via
+# the `-r` above); it used to be repeated here loosely. Removed to
+# avoid the duplicate-with-different-pin footgun.
 
 # Web scanning package
-beautifulsoup4>=4.12.0
-playwright>=1.40.0
+beautifulsoup4==4.14.3
+playwright==1.58.0

--- a/packages/web/requirements.txt
+++ b/packages/web/requirements.txt
@@ -1,5 +1,7 @@
 # Requirements specific to the `packages/web` module
 # These are installed by consumers of the web package or can be
 # installed in the devcontainer to enable web scanning/browser automation.
-beautifulsoup4>=4.12.0
-playwright>=1.40.0
+# Exact pins per the project's "no loose deps" policy — see
+# requirements.txt for the rationale.
+beautifulsoup4==4.14.3
+playwright==1.58.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,10 +4,10 @@
 -r requirements.txt
 
 # Linting
-ruff>=0.1.0
+ruff==0.15.12
 
 # Type checking
-mypy>=1.0.0
+mypy==2.0.0
 
 # Testing
 # pytest pinned exactly: the root pytest.ini uses ``--import-mode=importlib``

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,21 @@
 # RAPTOR Framework Requirements
 # Install with: pip3 install -r requirements.txt
 
-# Core dependencies
-requests>=2.31.0
+# Core dependencies. Exact pins per the project's "no loose deps"
+# policy — minor / patch upgrades come via dedicated PRs so any
+# breakage is bisectable. See requirements-dev.txt for the parallel
+# pinning rationale on pytest et al.
+requests==2.32.5
 # core.http.urllib_backend uses urllib3 directly for connection pooling
 # and to avoid the no_proxy bypass that stdlib urllib.request.ProxyHandler
 # silently performs. Already a transitive dep of `requests` but pinned
 # here too because we depend on it directly.
-urllib3>=2.0,<3.0
-pydantic>=2.9.2
-typer>=0.12
+urllib3==2.6.3
+pydantic==2.12.5
+typer==0.25.1
 
 # Structured output (works with both OpenAI and Anthropic SDKs)
-instructor>=1.0.0
+instructor==1.14.5
 
 # Optional: LLM provider SDKs (install for external LLM support)
 # pip install openai        # OpenAI, Gemini (via shim), Mistral, Ollama
@@ -23,7 +26,7 @@ instructor>=1.0.0
 # pip install tree-sitter tree-sitter-python tree-sitter-java tree-sitter-javascript tree-sitter-c tree-sitter-go
 
 # Optional: For enhanced dataflow visualization (recommended)
-tabulate>=0.9.0
+tabulate==0.10.0
 
 # Required for the /codeql workflow's pack-config trust check
 # (core/security/codeql_trust.py inspects target-repo codeql-pack.yml /


### PR DESCRIPTION
Per the project's "no loose deps" policy. All `>=` / `~=` / unconstrained version specs replaced with `==` against the latest stable that resolves cleanly under Python 3.12 (the CI baseline).

Future minor/patch upgrades come via dedicated PRs so any breakage is bisectable to a single dep bump rather than landing transitively via a transitive resolver decision.

* `requirements.txt` (6 deps pinned)
  - requests==2.32.5
  - urllib3==2.6.3
  - pydantic==2.12.5
  - typer==0.25.1
  - instructor==1.14.5
  - tabulate==0.10.0 (pyyaml==6.0.3 was already pinned)

* `requirements-dev.txt` (2 deps pinned)
  - ruff==0.15.12
  - mypy==2.0.0 (pytest et al + beautifulsoup4 + z3-solver already pinned)

* `.devcontainer/requirements-all-optional.txt` (4 deps pinned, 1 dropped)
  - openai==2.26.0
  - anthropic==0.84.0
  - beautifulsoup4==4.14.3
  - playwright==1.58.0
  - dropped redundant `tabulate>=0.9.0` (`-r ../requirements.txt` already pulls the pinned 0.10.0 — keeping the looser duplicate here was a foot-gun for resolver-mismatch surprises)

* `packages/web/requirements.txt` (2 deps pinned)
  - beautifulsoup4==4.14.3
  - playwright==1.58.0