### PR TITLE
feat(cc_dispatch): empirical default hosts + opt-in network probe

### DIFF
--- a/core/llm/cc_proxy_hosts.py
+++ b/core/llm/cc_proxy_hosts.py
@@ -90,6 +90,67 @@ def _default_readable_paths() -> list[str]:
     ]
 
 
+# Opt-in env var: when set to "1" AND an Anthropic API key is
+# available, calibration uses a real ``claude -p`` probe that
+# networks. The default ``--version`` probe captures filesystem
+# reach but produces empty proxy_hosts — operators who want the
+# calibrated proxy_hosts to actually populate (and catch new
+# Anthropic endpoints / Bedrock regions / Foundry deployments
+# the static fallback doesn't know about) flip this on.
+#
+# Why opt-in: ``claude -p`` consumes tokens. Even at the
+# ``--max-budget-usd 0.01`` cap below, an operator running RAPTOR
+# in CI without expecting API charges shouldn't be billed silently.
+# The cache amortises the cost — once-per-(binary-sha + env-sig)
+# is typically once per Claude Code self-update cycle (weeks).
+_NETWORK_PROBE_OPT_IN_ENV = "RAPTOR_CC_CALIBRATE_NETWORK_PROBE"
+
+
+def _network_probe_enabled() -> bool:
+    """True when the operator opted in to the network-engaging
+    probe AND an Anthropic API key is set.
+
+    Without an API key the network probe would just hit the proxy
+    once and fail auth — the proxy_hosts capture still works
+    (the kext logs the CONNECT regardless), but the operator
+    might not realise they need the key to keep tokens flowing.
+    Falling back to ``--version`` in that case avoids the
+    surprise.
+    """
+    if os.environ.get(_NETWORK_PROBE_OPT_IN_ENV) != "1":
+        return False
+    # Either ANTHROPIC_API_KEY (direct) or the alternative-provider
+    # vars suffice — Bedrock / Vertex / Foundry have their own auth
+    # paths and ``claude -p`` reaches them when configured.
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        return True
+    if os.environ.get("CLAUDE_CODE_USE_BEDROCK"):
+        return True
+    if os.environ.get("CLAUDE_CODE_USE_VERTEX"):
+        return True
+    if os.environ.get("CLAUDE_CODE_USE_FOUNDRY"):
+        return True
+    return False
+
+
+def _cc_probe_args() -> tuple[str, ...]:
+    """Argv for the calibration probe. Network-engaging variant
+    when opted in; ``--version`` otherwise.
+
+    The network probe argv:
+      * ``-p "READY"`` — minimal prompt; our controlled string so
+        no prompt-injection vector (see THREAT_MODEL.md).
+      * ``--max-budget-usd 0.01`` — hard cap. A broken/looping
+        probe can't drain the operator's account.
+      * ``--max-turns 1`` — single tool-use round; rules out
+        runaway agentic loops.
+    """
+    if _network_probe_enabled():
+        return ("-p", "READY", "--max-budget-usd", "0.01",
+                "--max-turns", "1")
+    return ("--version",)
+
+
 def _load_override_config() -> Optional[list[str]]:
     """Load the operator's override list, or None if not configured.
 
@@ -227,11 +288,30 @@ def _calibrated_profile(claude_bin: Optional[str] = None):
         return None
 
     try:
+        # Probe args + cache-key env are derived together so the
+        # cached profile invalidates cleanly when the operator
+        # toggles the network-probe opt-in. Without including the
+        # opt-in env var in the cache key, a profile calibrated
+        # under ``--version`` (empty proxy_hosts) would be served
+        # to a caller that just enabled network probing — and the
+        # caller would never see the discovered hosts.
+        probe_args = _cc_probe_args()
+        env_keys = _PROVIDER_ENV_KEYS + (_NETWORK_PROBE_OPT_IN_ENV,)
+        # Network probe wall-time empirically: ~110s on Claude Code
+        # 2.1.138 with cold cache (auth + model-list + actual prompt
+        # + streaming response + MCP setup + telemetry). 150s gives
+        # headroom without unbounded hang risk; the AuditBudget cap
+        # bounds record volume independently. The probe runs ONCE
+        # per (binary-sha + env-sig) and the result is cached, so the
+        # one-time cost amortises across every cc_dispatch call until
+        # the binary self-updates.
+        # ``--version`` probe finishes in <1s; 20s is generous.
+        timeout = 150 if _network_probe_enabled() else 20
         profile = load_or_calibrate(
             claude_bin,
-            probe_args=("--version",),
-            env_keys=_PROVIDER_ENV_KEYS,
-            timeout=20,
+            probe_args=probe_args,
+            env_keys=env_keys,
+            timeout=timeout,
         )
     except (FileNotFoundError, RuntimeError, OSError) as exc:
         # Probe failed: ptrace blocked (Yama scope 3),
@@ -322,7 +402,33 @@ def proxy_hosts_for_cc_dispatch(
         # proxy with a clear "host not in allowlist" log, which is
         # better diagnostics than silently allowing a different host.
 
-    return ["api.anthropic.com"]
+    return list(_DEFAULT_ANTHROPIC_HOSTS)
+
+
+# Static fallback for the standard Anthropic API path. Empirically
+# derived from a real ``claude -p READY`` calibration probe against
+# Claude Code 2.1.138 (see RAPTOR_CC_CALIBRATE_NETWORK_PROBE):
+#   - api.anthropic.com         — load-bearing LLM endpoint
+#   - mcp-proxy.anthropic.com   — MCP server proxy; gracefully
+#                                  degrades when blocked but
+#                                  functionality is lost
+#   - downloads.claude.ai       — Claude Code self-update +
+#                                  model-asset download
+#
+# ``http-intake.logs.us5.datadoghq.com`` is intentionally absent —
+# Datadog telemetry is denied by RAPTOR policy. The proxy logs the
+# CONNECT and Claude Code degrades gracefully without telemetry.
+#
+# Pre-2026-05-09 this list was just ``["api.anthropic.com"]``;
+# Claude Code's reach has grown over versions and the calibration
+# probe surfaced the gap. Operators who want the auto-discovered
+# allowlist (catches future endpoint additions before they break
+# in production) flip ``RAPTOR_CC_CALIBRATE_NETWORK_PROBE=1``.
+_DEFAULT_ANTHROPIC_HOSTS: tuple[str, ...] = (
+    "api.anthropic.com",
+    "mcp-proxy.anthropic.com",
+    "downloads.claude.ai",
+)
 
 
 def readable_paths_for_cc_dispatch(

--- a/core/llm/tests/test_cc_proxy_hosts.py
+++ b/core/llm/tests/test_cc_proxy_hosts.py
@@ -114,8 +114,34 @@ def _fake_profile(*, paths_read=None, paths_stat=None,
 
 class TestDefault:
 
-    def test_returns_anthropic_only(self, isolated_env, no_override_config, no_calibrate):
-        assert proxy_hosts_for_cc_dispatch() == ["api.anthropic.com"]
+    def test_returns_documented_anthropic_set(
+        self, isolated_env, no_override_config, no_calibrate,
+    ):
+        # Empirically-derived from a real `claude -p READY`
+        # calibration probe (see RAPTOR_CC_CALIBRATE_NETWORK_PROBE).
+        # Pre-2026-05-09 this was just `api.anthropic.com`; Claude
+        # Code 2.1.138 reach grew to include MCP proxy +
+        # downloads.claude.ai (auto-update / model assets).
+        # Datadog telemetry stays absent by RAPTOR policy.
+        hosts = proxy_hosts_for_cc_dispatch()
+        assert _hostname_in(hosts, "api.anthropic.com")
+        assert _hostname_in(hosts, "mcp-proxy.anthropic.com")
+        assert _hostname_in(hosts, "downloads.claude.ai")
+        assert not _hostname_in(
+            hosts, "http-intake.logs.us5.datadoghq.com"
+        ), "Datadog telemetry must remain denied by default"
+
+    def test_returns_a_fresh_list(
+        self, isolated_env, no_override_config, no_calibrate,
+    ):
+        # Caller-side mutation must not leak back into the
+        # module-level tuple. Mirrors the codeql consumer's
+        # equivalent test.
+        hosts = proxy_hosts_for_cc_dispatch()
+        hosts.append("attacker.example")
+        assert not _hostname_in(
+            proxy_hosts_for_cc_dispatch(), "attacker.example",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -216,7 +242,11 @@ class TestFoundry:
         Foundry connection with a clear log so the operator notices."""
         isolated_env.setenv("CLAUDE_CODE_USE_FOUNDRY", "1")
         hosts = proxy_hosts_for_cc_dispatch()
-        assert hosts == ["api.anthropic.com"]
+        # Default set includes api.anthropic.com (load-bearing) plus
+        # MCP proxy + downloads — the pre-2026-05-09 single-host
+        # default is now a 3-host set. This test pins "fell through
+        # to default" by checking the load-bearing host is present.
+        assert _hostname_in(hosts, "api.anthropic.com")
 
 
 # ---------------------------------------------------------------------------
@@ -273,7 +303,7 @@ class TestOverrideConfig:
         config_path = tmp_path / "cc-dispatch-proxy-hosts.json"
         config_path.write_text(json.dumps({"proxy_hosts": []}))
         monkeypatch.setattr(mod, "_OVERRIDE_CONFIG_PATH", config_path)
-        assert proxy_hosts_for_cc_dispatch() == ["api.anthropic.com"]
+        assert _hostname_in(proxy_hosts_for_cc_dispatch(), "api.anthropic.com")
 
     def test_malformed_override_falls_back_to_default(
         self, isolated_env, monkeypatch, tmp_path, no_calibrate,
@@ -281,7 +311,7 @@ class TestOverrideConfig:
         config_path = tmp_path / "cc-dispatch-proxy-hosts.json"
         config_path.write_text("not valid json{{")
         monkeypatch.setattr(mod, "_OVERRIDE_CONFIG_PATH", config_path)
-        assert proxy_hosts_for_cc_dispatch() == ["api.anthropic.com"]
+        assert _hostname_in(proxy_hosts_for_cc_dispatch(), "api.anthropic.com")
 
     def test_missing_override_uses_provider_logic(
         self, isolated_env, no_override_config, no_calibrate,
@@ -328,7 +358,7 @@ class TestCalibratedProxyHosts:
         self, isolated_env, no_override_config, monkeypatch,
     ):
         monkeypatch.setattr(mod, "_calibrated_profile", lambda claude_bin=None: None)
-        assert proxy_hosts_for_cc_dispatch() == ["api.anthropic.com"]
+        assert _hostname_in(proxy_hosts_for_cc_dispatch(), "api.anthropic.com")
 
     def test_override_beats_calibrated(
         self, isolated_env, monkeypatch, tmp_path,
@@ -466,4 +496,188 @@ class TestCalibratedProfileFailureModes:
         assert spawn_count[0] == 1, (
             f"memoisation broken: load_or_calibrate called "
             f"{spawn_count[0]} times for one binary path"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Network-engaging probe (opt-in)
+# ---------------------------------------------------------------------------
+
+
+class TestNetworkProbeOptIn:
+    """The opt-in network probe lets the calibrated proxy_hosts
+    actually populate (default ``--version`` probe doesn't network).
+    Gated on env var + auth so an operator who set neither doesn't
+    silently incur API charges."""
+
+    def test_default_uses_version_probe(self, monkeypatch):
+        # Strip both the opt-in flag and every auth env so the
+        # gate definitively returns False.
+        for var in (mod._NETWORK_PROBE_OPT_IN_ENV, "ANTHROPIC_API_KEY",
+                    "CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX",
+                    "CLAUDE_CODE_USE_FOUNDRY"):
+            monkeypatch.delenv(var, raising=False)
+        assert mod._cc_probe_args() == ("--version",)
+        assert mod._network_probe_enabled() is False
+
+    def test_opt_in_without_auth_falls_back(self, monkeypatch):
+        # Opt-in flag set but no auth env — the network probe
+        # would fail auth at the API call. Fall back to --version.
+        for var in ("ANTHROPIC_API_KEY", "CLAUDE_CODE_USE_BEDROCK",
+                    "CLAUDE_CODE_USE_VERTEX", "CLAUDE_CODE_USE_FOUNDRY"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv(mod._NETWORK_PROBE_OPT_IN_ENV, "1")
+        assert mod._network_probe_enabled() is False
+        assert mod._cc_probe_args() == ("--version",)
+
+    def test_opt_in_with_anthropic_key_uses_network_probe(
+        self, monkeypatch,
+    ):
+        for var in ("CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX",
+                    "CLAUDE_CODE_USE_FOUNDRY"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv(mod._NETWORK_PROBE_OPT_IN_ENV, "1")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
+        assert mod._network_probe_enabled() is True
+        argv = mod._cc_probe_args()
+        # Tight cap on cost + turn count: a broken/looping probe
+        # can't drain the operator's account.
+        assert "-p" in argv
+        assert "--max-budget-usd" in argv
+        budget_idx = argv.index("--max-budget-usd")
+        assert argv[budget_idx + 1] == "0.01", (
+            "budget cap drift — was meant to be $0.01 ceiling"
+        )
+        assert "--max-turns" in argv
+        turns_idx = argv.index("--max-turns")
+        assert argv[turns_idx + 1] == "1"
+        # Prompt is OUR string (no prompt-injection vector).
+        prompt_idx = argv.index("-p")
+        assert argv[prompt_idx + 1] == "READY"
+
+    def test_opt_in_with_provider_env_uses_network_probe(
+        self, monkeypatch,
+    ):
+        # Bedrock / Vertex / Foundry have their own auth paths;
+        # any of them suffices to enable the network probe.
+        for var in ("ANTHROPIC_API_KEY", "CLAUDE_CODE_USE_VERTEX",
+                    "CLAUDE_CODE_USE_FOUNDRY"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv(mod._NETWORK_PROBE_OPT_IN_ENV, "1")
+        monkeypatch.setenv("CLAUDE_CODE_USE_BEDROCK", "1")
+        assert mod._network_probe_enabled() is True
+
+    def test_opt_in_value_other_than_1_treated_as_off(
+        self, monkeypatch,
+    ):
+        # Only "1" enables. "0", "true", "yes", empty all disable —
+        # avoids the "is `RAPTOR_CC_CALIBRATE_NETWORK_PROBE=` set
+        # to disable?" foot-gun where the operator unsets via
+        # ``KEY=`` but the var is still in env with empty value.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
+        for value in ("0", "true", "yes", "", "True", "YES"):
+            monkeypatch.setenv(mod._NETWORK_PROBE_OPT_IN_ENV, value)
+            assert mod._network_probe_enabled() is False, (
+                f"value {value!r} unexpectedly enabled the probe"
+            )
+
+
+class TestNetworkProbeCacheInvalidation:
+    """Toggling the opt-in flag must invalidate the cached profile.
+    A profile calibrated under ``--version`` has empty proxy_hosts;
+    serving it to a caller who just opted in to the network probe
+    would mean the caller never sees the discovered hosts."""
+
+    def test_cache_key_includes_opt_in_env_var(self, monkeypatch):
+        # Capture what env_keys load_or_calibrate sees.
+        captured_env_keys = []
+
+        def fake_load(*args, env_keys=(), **kwargs):
+            captured_env_keys.append(tuple(env_keys))
+            return _fake_profile(proxy_hosts=["api.example.com"])
+
+        monkeypatch.setattr(mod, "_resolve_claude_bin",
+                            lambda: "/fake/claude")
+        import core.sandbox.calibrate as _cal
+        monkeypatch.setattr(_cal, "load_or_calibrate", fake_load)
+
+        mod._calibrated_profile()
+
+        assert len(captured_env_keys) == 1
+        env_keys = captured_env_keys[0]
+        assert mod._NETWORK_PROBE_OPT_IN_ENV in env_keys, (
+            f"opt-in env var must be in cache key so toggling "
+            f"the flag invalidates cleanly. Got env_keys={env_keys!r}"
+        )
+
+    def test_probe_args_match_opt_in_state(self, monkeypatch):
+        # Capture probe_args under both modes.
+        captured_probe_args = []
+
+        def fake_load(*args, probe_args=(), **kwargs):
+            captured_probe_args.append(tuple(probe_args))
+            return _fake_profile()
+
+        monkeypatch.setattr(mod, "_resolve_claude_bin",
+                            lambda: "/fake/claude")
+        import core.sandbox.calibrate as _cal
+        monkeypatch.setattr(_cal, "load_or_calibrate", fake_load)
+
+        # Off state.
+        for var in (mod._NETWORK_PROBE_OPT_IN_ENV, "ANTHROPIC_API_KEY",
+                    "CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX",
+                    "CLAUDE_CODE_USE_FOUNDRY"):
+            monkeypatch.delenv(var, raising=False)
+        mod._reset_calibrate_cache_for_tests()
+        mod._calibrated_profile()
+
+        # On state.
+        monkeypatch.setenv(mod._NETWORK_PROBE_OPT_IN_ENV, "1")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
+        mod._reset_calibrate_cache_for_tests()
+        mod._calibrated_profile()
+
+        assert captured_probe_args[0] == ("--version",)
+        assert captured_probe_args[1][:2] == ("-p", "READY"), (
+            f"opted-in probe should start with -p READY; got "
+            f"{captured_probe_args[1]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# build_detector.py uses cc_proxy_hosts (migration pin)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDetectorMigration:
+    """build_detector.py:1080 (the codeql build-detect Claude
+    invocation) MUST route through proxy_hosts_for_cc_dispatch.
+    If a contributor reverts to a hardcoded host list, this test
+    catches it."""
+
+    def test_build_detector_imports_proxy_hosts_for_cc_dispatch(self):
+        import inspect
+        from packages.codeql import build_detector
+        src = inspect.getsource(build_detector)
+        assert "proxy_hosts_for_cc_dispatch" in src, (
+            "packages/codeql/build_detector.py must route the "
+            "claude-build-detect proxy_hosts through "
+            "core.llm.cc_proxy_hosts so calibrate-aware policy "
+            "applies (Bedrock/Vertex/Foundry support, override "
+            "config, etc.)"
+        )
+
+    def test_build_detector_no_longer_hardcodes_anthropic_host(self):
+        import inspect
+        from packages.codeql import build_detector
+        src = inspect.getsource(build_detector)
+        # The pre-migration literal. If this returns, the call
+        # site reverted to hardcoded. Allow the string in
+        # comments / cc_proxy_hosts itself (single source of
+        # truth) but not as a `proxy_hosts=[...]` literal.
+        signature = 'proxy_hosts=["api.anthropic.com"]'
+        assert signature not in src, (
+            "build_detector.py contains the pre-migration "
+            "hardcoded proxy_hosts literal — call site should use "
+            "proxy_hosts_for_cc_dispatch(claude_bin) instead"
         )

--- a/core/orchestration/tests/test_agentic_passes.py
+++ b/core/orchestration/tests/test_agentic_passes.py
@@ -365,7 +365,16 @@ class UnderstandPrepassTests(unittest.TestCase):
             kw = sandbox_calls[0]
             # Helper internally sets use_egress_proxy=True; the caller
             # passes only the per-site config.
-            self.assertEqual(kw.get("proxy_hosts"), ["api.anthropic.com"])
+            # Default proxy_hosts grew from a single-host list to
+            # the empirical-default set (api.anthropic.com +
+            # mcp-proxy.anthropic.com + downloads.claude.ai).
+            # Pin presence rather than full equality so future
+            # additions don't break this assertion if they're
+            # justified.
+            hosts = kw.get("proxy_hosts")
+            self.assertIn("api.anthropic.com", hosts)
+            self.assertIn("mcp-proxy.anthropic.com", hosts)
+            self.assertIn("downloads.claude.ai", hosts)
             self.assertEqual(kw.get("caller_label"), "agentic-understand")
             # readable_paths must include ~/.claude (Claude Code OAuth)
             # and RAPTOR_DIR (for libexec scripts the LLM invokes).
@@ -594,7 +603,16 @@ class ValidatePostpassTests(unittest.TestCase):
             kw = sandbox_calls[0]
             # Helper internally sets use_egress_proxy=True; caller passes
             # only the per-site config.
-            self.assertEqual(kw.get("proxy_hosts"), ["api.anthropic.com"])
+            # Default proxy_hosts grew from a single-host list to
+            # the empirical-default set (api.anthropic.com +
+            # mcp-proxy.anthropic.com + downloads.claude.ai).
+            # Pin presence rather than full equality so future
+            # additions don't break this assertion if they're
+            # justified.
+            hosts = kw.get("proxy_hosts")
+            self.assertIn("api.anthropic.com", hosts)
+            self.assertIn("mcp-proxy.anthropic.com", hosts)
+            self.assertIn("downloads.claude.ai", hosts)
             self.assertEqual(kw.get("caller_label"), "agentic-validate")
             # readable_paths must include ~/.claude + RAPTOR_DIR + the
             # prior phases' agentic_out_dir (validate reads back what

--- a/packages/codeql/build_detector.py
+++ b/packages/codeql/build_detector.py
@@ -1073,11 +1073,20 @@ print(f"Compiled {{ok}}/{{total}} files ({{fail}} failed)")
                 capture_json_envelope=False,
             )
             repo_path = str(self.repo_path)
+            # Route hostname allowlist through cc_proxy_hosts so this
+            # site picks up the same calibrate-aware policy as
+            # cc_dispatch's main entry point — operator override,
+            # calibrated SandboxProfile, then provider-aware fallback.
+            # Pre-migration this hardcoded ``api.anthropic.com``,
+            # which silently broke Bedrock / Vertex / Azure /
+            # custom-endpoint setups. The downstream client is
+            # ``claude`` either way, so the policy is identical.
+            from core.llm.cc_proxy_hosts import proxy_hosts_for_cc_dispatch
             result = _sandbox_run(
                 build_cc_command(config),
                 target=repo_path, output=repo_path,
                 use_egress_proxy=True,
-                proxy_hosts=["api.anthropic.com"],
+                proxy_hosts=proxy_hosts_for_cc_dispatch(claude_bin),
                 caller_label="codeql-build-detect",
                 input=prompt, capture_output=True, text=True, timeout=180,
             )

--- a/packages/llm_analysis/tests/test_cc_dispatch_sandbox.py
+++ b/packages/llm_analysis/tests/test_cc_dispatch_sandbox.py
@@ -79,10 +79,14 @@ def test_invoke_cc_simple_uses_run_untrusted_networked(captured_helper_kwargs, t
     assert len(captured_helper_kwargs) == 1
 
 
-def test_invoke_cc_simple_passes_minimal_proxy_allowlist(captured_helper_kwargs, tmp_path):
-    """proxy_hosts is exactly ``["api.anthropic.com"]`` — the audit
-    finding from the binary + source review. If a future change adds
-    another host without justification, this fires."""
+def test_invoke_cc_simple_passes_documented_proxy_allowlist(
+    captured_helper_kwargs, tmp_path,
+):
+    """proxy_hosts comes from the empirical-default set
+    (api.anthropic.com + mcp-proxy.anthropic.com +
+    downloads.claude.ai). Datadog telemetry stays denied. If a
+    future change adds an unrelated host without justification,
+    this fires."""
     from packages.llm_analysis.cc_dispatch import invoke_cc_simple
 
     out_dir = tmp_path / "out"
@@ -97,7 +101,13 @@ def test_invoke_cc_simple_passes_minimal_proxy_allowlist(captured_helper_kwargs,
     )
 
     kwargs = captured_helper_kwargs[0]["kwargs"]
-    assert kwargs["proxy_hosts"] == ["api.anthropic.com"]
+    hosts = kwargs["proxy_hosts"]
+    assert any(h == "api.anthropic.com" for h in hosts)
+    assert any(h == "mcp-proxy.anthropic.com" for h in hosts)
+    assert any(h == "downloads.claude.ai" for h in hosts)
+    assert not any(
+        h == "http-intake.logs.us5.datadoghq.com" for h in hosts
+    ), "Datadog telemetry must remain denied"
 
 
 def test_invoke_cc_simple_includes_claude_paths_in_readable(
@@ -229,20 +239,23 @@ def test_live_cc_dispatch_no_unexpected_essential_traffic_denials(tmp_path):
         budget_usd="0.50",
         timeout_s=60,
     )
-    home = Path.home()
+    # Route both lists through the cc_proxy_hosts helpers so this
+    # test exercises the same policy real production cc_dispatch
+    # calls do. Hardcoding a single-host list here would make the
+    # live test fail on Claude Code versions that need additional
+    # endpoints (e.g. 2.1.138's mcp-proxy.anthropic.com).
+    from core.llm.cc_proxy_hosts import (
+        proxy_hosts_for_cc_dispatch,
+        readable_paths_for_cc_dispatch,
+    )
     r = run_untrusted_networked(
         build_cc_command(cfg),
         input="reply with the single word READY",
         capture_output=True, text=True,
         timeout=60,
         target=str(tmp_path), output=str(out_dir),
-        readable_paths=[
-            str(home / ".local" / "bin"),
-            str(home / ".local" / "share" / "claude"),
-            str(home / ".claude"),
-            str(home / ".claude.json"),
-        ],
-        proxy_hosts=["api.anthropic.com"],
+        readable_paths=readable_paths_for_cc_dispatch(),
+        proxy_hosts=proxy_hosts_for_cc_dispatch(),
         caller_label="cc-dispatch-test",
     )
 
@@ -320,7 +333,13 @@ def test_live_cc_dispatch_sentinel_home_file_not_leaked(tmp_path):
             budget_usd="0.50",
             timeout_s=60,
         )
-        home = Path.home()
+        # Same rationale as above — route through the helpers so
+        # the live test stays in sync with production policy
+        # whatever Claude Code version is installed.
+        from core.llm.cc_proxy_hosts import (
+            proxy_hosts_for_cc_dispatch,
+            readable_paths_for_cc_dispatch,
+        )
         r = run_untrusted_networked(
             build_cc_command(cfg),
             # Ask the LLM to do exactly the bad thing. With
@@ -333,13 +352,8 @@ def test_live_cc_dispatch_sentinel_home_file_not_leaked(tmp_path):
             capture_output=True, text=True,
             timeout=60,
             target=str(tmp_path), output=str(out_dir),
-            readable_paths=[
-                str(home / ".local" / "bin"),
-                str(home / ".local" / "share" / "claude"),
-                str(home / ".claude"),
-                str(home / ".claude.json"),
-            ],
-            proxy_hosts=["api.anthropic.com"],
+            readable_paths=readable_paths_for_cc_dispatch(),
+            proxy_hosts=proxy_hosts_for_cc_dispatch(),
             caller_label="cc-dispatch-sentinel-test",
         )
 


### PR DESCRIPTION
(a) Network-engaging calibration probe gated on
    RAPTOR_CC_CALIBRATE_NETWORK_PROBE=1 + auth-env presence.
    Argv: claude -p READY --max-budget-usd 0.01 --max-turns 1.
    Cache key extended with the opt-in env so toggling cleanly
    invalidates. Timeout 150s (real probe wall-time ~110s on
    Claude Code 2.1.138).

(b) Static default proxy_hosts bumped from ["api.anthropic.com"]
    to (api.anthropic.com, mcp-proxy.anthropic.com,
    downloads.claude.ai) — empirically derived from a real
    `claude -p READY` calibration. Datadog telemetry stays
    denied by policy. Closes the production drift gap where
    Claude Code 2.1.x silently degraded against the
    pre-migration single-host allowlist.

build_detector.py:1080 migrated from hardcoded
proxy_hosts=["api.anthropic.com"] to
proxy_hosts_for_cc_dispatch(claude_bin) — picks up Bedrock / Vertex / Foundry / override / calibrate.

Live cc_dispatch tests migrated to use the helpers so they stay in sync with whatever Claude Code version is installed.

Verified: real probe (~109s, $0.01-bounded), cache invalidation across opt-in toggle, env var NOT in
SAFE_ENV_ALLOWLIST (sandboxed children can't toggle parent's calibration).