### PR TITLE
fix(core/sandbox): deterministic warm-up gate for seatbelt log streamer

### DIFF
--- a/core/sandbox/seatbelt_audit.py
+++ b/core/sandbox/seatbelt_audit.py
@@ -37,8 +37,10 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 import threading
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -65,12 +67,29 @@ DENIALS_FILE = ".sandbox-denials.jsonl"
 # values together against tracer._OBSERVE_FILENAME.
 OBSERVE_FILE = ".sandbox-observe.jsonl"
 
-# Wall-clock cap on `start()`'s wait for `log stream`'s first stdout
-# line. Empirically the banner arrives in 50-200ms; a generous cap keeps
-# the wait bounded if the OS log subsystem is wedged. Generous enough
-# that a healthy `log stream` startup never trips the cap, tight enough
-# that a slow path doesn't block the entire sandbox spawn.
-_FIRST_HEARTBEAT_TIMEOUT_S = 2.0
+# Wall-clock cap on the warm-up gate in `start()`. The gate spawns a
+# synthetic `sandbox-exec` workload and waits for `log stream` to emit
+# the resulting kext deny event — that's the deterministic signal that
+# attachment to the kernel log feed is live. The warm-up exits in
+# 50-200ms on a warm `log` daemon; cold-start (first invocation in a
+# shell) runs longer. 5s is generous enough that healthy systems never
+# trip it, tight enough that a wedged log subsystem doesn't block
+# sandbox spawn indefinitely.
+_WARM_UP_TIMEOUT_S = 5.0
+
+# SBPL profile for the warm-up workload. ``(deny default (with
+# report))`` denies every operation AND emits a kext audit event for
+# each denial. The first thing the kernel does after applying the
+# profile is the loader's image-read for the target binary — that
+# generates a deny event with the warm-up's PID, which is what we
+# wait for. The workload itself never runs (exec is denied), which
+# keeps the warm-up cheap and side-effect-free.
+_WARM_UP_SBPL = "(version 1)(deny default (with report))"
+
+# Path to the system sandbox-exec binary. Resolved via shutil.which at
+# call site so a non-standard PATH (operator override) works, falling
+# back to the canonical /usr/bin location that ships with macOS.
+_SANDBOX_EXEC_FALLBACK = "/usr/bin/sandbox-exec"
 
 
 # Skip-budget delegated to core.sandbox.audit_budget.AuditBudget,
@@ -201,14 +220,23 @@ class LogStreamer:
         self._dirfd: Optional[int] = None
 
     def start(self) -> None:
-        """Spawn `log stream` filtered to sandbox kext events and
-        start the reader thread. Blocks until `log stream` emits its
-        first line (usually the "Filtering the log data..." banner
-        on stdout) or up to ``_FIRST_HEARTBEAT_TIMEOUT_S`` seconds —
-        whichever comes first. Without this wait, the caller would
-        race the subprocess startup and lose events emitted by the
-        sandboxed workload during the ~50-200ms `log stream` needs
-        to attach to the kernel log feed."""
+        """Spawn `log stream` filtered to sandbox kext events, gate
+        on a synthetic warm-up workload to confirm attachment to the
+        kernel log feed, then start the reader thread.
+
+        The warm-up runs ``sandbox-exec`` against a deny-default SBPL
+        profile and waits until ``log stream`` emits a kext record
+        whose PID matches the warm-up child. This is the deterministic
+        signal that the kernel-side filter is live — without it, fast
+        workloads (e.g. ``claude --version`` finishing in tens of ms)
+        can complete before ``log stream`` attaches, producing zero
+        captured records on cold-start.
+
+        On hosts where ``sandbox-exec`` is missing (non-Darwin or
+        stripped installs) or the warm-up times out, falls back to a
+        best-effort proceed: the streamer is started anyway, callers
+        accept that early events may be missed. Logged at debug for
+        operator triage."""
         predicate = (
             f'senderImagePath == "{SANDBOX_KEXT_SENDER}"'
         )
@@ -226,18 +254,19 @@ class LogStreamer:
             # arrive rather than accumulating in a 4K pipe buffer.
             bufsize=1,
         )
-        # Drain the first line synchronously so we know `log stream`
-        # is attached. The banner is the first thing it emits before
-        # any actual records, so this consumes a line that the reader
-        # thread doesn't need to see. Hand the banner-consumed
-        # subprocess to the reader thread; subsequent reads in the
-        # loop will be the genuine sandbox records.
         try:
-            self._await_first_heartbeat()
+            attached = self._warm_up_until_attached()
+            if not attached:
+                logger.debug(
+                    "seatbelt audit: warm-up gate did not see kext events "
+                    "from synthetic workload within %ss; proceeding in "
+                    "best-effort mode (early records from the real "
+                    "workload may be missed)",
+                    _WARM_UP_TIMEOUT_S,
+                )
         except BaseException:
-            # If the heartbeat probe fails (subprocess died, timeout),
-            # tear down the subprocess so the caller doesn't have a
-            # zombie `log stream` running with nobody reading from it.
+            # Warm-up itself raised: tear down `log stream` so caller
+            # doesn't leak a zombie subprocess with nobody reading it.
             try:
                 self._proc.terminate()
             except OSError:
@@ -246,25 +275,110 @@ class LogStreamer:
         self._reader = threading.Thread(target=self._read_loop, daemon=True)
         self._reader.start()
 
-    def _await_first_heartbeat(self) -> None:
-        """Block until the `log stream` subprocess emits its first
-        line OR the heartbeat timeout elapses. Best-effort — we don't
-        fail the streamer if the banner doesn't arrive (some `log`
-        builds emit no banner on stdout, only on stderr which we
-        DEVNULL); we cap the wait so caller isn't blocked indefinitely."""
+    def _warm_up_until_attached(self) -> bool:
+        """Spawn a synthetic ``sandbox-exec`` workload and drain
+        ``log stream`` stdout until we see a kext record from that
+        workload's PID. Returns True when attachment is confirmed,
+        False when the timeout elapsed without a matching record.
+
+        The warm-up exits on its own (the deny-default profile blocks
+        the loader's image read, so ``sandbox-exec`` returns non-zero
+        in <50ms). We never read its output — the kernel emits the
+        kext event regardless, and that's all we need.
+
+        Records consumed during the warm-up gate are intentionally
+        discarded: they belong to the warm-up's own PID or to other
+        unrelated sandboxed processes running on the host, not to
+        the real workload. The reader thread starts fresh after
+        return, so caller-relevant events flow through ``_read_loop``
+        as designed.
+        """
         import selectors as _selectors
+
+        sandbox_exec = (
+            shutil.which("sandbox-exec") or _SANDBOX_EXEC_FALLBACK
+        )
+        if not Path(sandbox_exec).exists():
+            # Non-Darwin host or stripped install — no point spawning
+            # a missing binary. Best-effort fallback applies.
+            return False
+
+        try:
+            warm_up = subprocess.Popen(
+                [
+                    sandbox_exec, "-p", _WARM_UP_SBPL,
+                    "/usr/bin/true",
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except OSError:
+            return False
+
+        target_pid = warm_up.pid
+
         assert self._proc is not None
         if self._proc.stdout is None:
-            return
+            try:
+                warm_up.wait(timeout=1.0)
+            except subprocess.TimeoutExpired:
+                warm_up.terminate()
+            return False
+
         sel = _selectors.DefaultSelector()
         sel.register(self._proc.stdout, _selectors.EVENT_READ)
+        deadline = time.monotonic() + _WARM_UP_TIMEOUT_S
+        seen = False
         try:
-            events = sel.select(timeout=_FIRST_HEARTBEAT_TIMEOUT_S)
-            if events:
-                # Consume one line; if stdout closed, just return.
-                self._proc.stdout.readline()
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                events = sel.select(timeout=remaining)
+                if not events:
+                    break
+                line = self._proc.stdout.readline()
+                if not line:
+                    # `log stream` died — let caller handle in
+                    # best-effort fallback.
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                msg = entry.get("eventMessage", "")
+                m = _LOG_LINE_RE.search(msg)
+                if not m:
+                    continue
+                # Group 2 is the PID per `_LOG_LINE_RE`.
+                pid_str = m.group(2)
+                try:
+                    if int(pid_str) == target_pid:
+                        seen = True
+                        break
+                except ValueError:
+                    continue
         finally:
             sel.unregister(self._proc.stdout)
+            # Reap the warm-up child. With (deny default) the exec
+            # itself is denied, so sandbox-exec exits ~immediately
+            # with non-zero. Wait briefly; terminate as a safety net.
+            try:
+                warm_up.wait(timeout=1.0)
+            except subprocess.TimeoutExpired:
+                try:
+                    warm_up.terminate()
+                except OSError:
+                    pass
+                try:
+                    warm_up.wait(timeout=1.0)
+                except subprocess.TimeoutExpired:
+                    pass
+
+        return seen
 
     def _read_loop(self) -> None:
         """Read ndjson lines from `log stream`, parse, and append

--- a/core/sandbox/tests/test_seatbelt_audit_warmup.py
+++ b/core/sandbox/tests/test_seatbelt_audit_warmup.py
@@ -1,0 +1,338 @@
+"""Warm-up gate tests for ``LogStreamer.start()``.
+
+The warm-up gate spawns a synthetic ``sandbox-exec`` workload and
+drains ``log stream`` stdout until a kext record from that workload's
+PID appears — guaranteeing kernel-side filter attachment before the
+real workload runs.
+
+Cross-platform: tests mock ``subprocess.Popen`` for both ``log
+stream`` and ``sandbox-exec`` so they exercise the gate's logic
+without touching macOS-only binaries. Real Darwin end-to-end
+validation lives outside the unit suite.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import threading
+from unittest import mock
+
+import pytest
+
+from core.sandbox import seatbelt_audit
+from core.sandbox.seatbelt import SANDBOX_KEXT_SENDER
+
+
+def _kext_line(*, pid: int, name: str = "sandbox-exec",
+               action: str = "file-read-data",
+               path: str = "/usr/bin/true") -> bytes:
+    """Build one ndjson line that ``log stream`` would emit."""
+    entry = {
+        "senderImagePath": SANDBOX_KEXT_SENDER,
+        "eventMessage": f"Sandbox: {name}({pid}) deny {action} {path}",
+        "timestamp": "2026-05-09 12:00:00.000000+0000",
+        "subsystem": "",
+        "category": "",
+    }
+    return (json.dumps(entry) + "\n").encode("utf-8")
+
+
+class _FakeStdout:
+    """Pipe-like stdout backed by an injectable line list. Mirrors
+    just enough of a TextIO buffered stream that the warm-up gate's
+    selector + readline loop works without spawning subprocesses."""
+
+    def __init__(self, lines):
+        self._buf = io.BytesIO(b"".join(lines))
+        # selectors needs a real fd — back the BytesIO with a pipe.
+        import os
+        self._read_fd, self._write_fd = os.pipe()
+        os.write(self._write_fd, b"".join(lines))
+        os.close(self._write_fd)
+        self._reader = open(self._read_fd, "r", encoding="utf-8")
+
+    def fileno(self):
+        return self._reader.fileno()
+
+    def readline(self):
+        return self._reader.readline()
+
+    def close(self):
+        try:
+            self._reader.close()
+        except OSError:
+            pass
+
+
+class _FakeProc:
+    """Stand-in for the ``log stream`` Popen. Carries ``stdout`` and a
+    ``terminate``/``poll`` shape sufficient for the gate to manage it."""
+
+    def __init__(self, stdout):
+        self.stdout = stdout
+        self.terminated = False
+        self.pid = 99999
+
+    def terminate(self):
+        self.terminated = True
+
+    def poll(self):
+        return None
+
+
+class _FakeWarmUp:
+    """Stand-in for the ``sandbox-exec`` Popen — exits immediately,
+    just carries a synthetic PID for the gate to match against the
+    injected kext records."""
+
+    def __init__(self, pid: int):
+        self.pid = pid
+        self.terminated = False
+
+    def wait(self, timeout=None):
+        return 1  # `(deny default)` denies exec → non-zero
+
+    def terminate(self):
+        self.terminated = True
+
+
+def _make_streamer(tmp_path):
+    """Construct a LogStreamer wired to a tmp run_dir; tests assign
+    ``_proc`` directly to bypass the real Popen('/usr/bin/log')."""
+    return seatbelt_audit.LogStreamer(
+        run_dir=tmp_path, observe_mode=True, observe_nonce="warm-up-test",
+    )
+
+
+def test_warm_up_returns_true_when_target_pid_event_seen(tmp_path):
+    """Gate returns True as soon as a kext record matching the
+    warm-up's PID is parsed from log-stream stdout."""
+    target_pid = 4242
+    lines = [
+        _kext_line(pid=111),          # other sandboxed proc — skip
+        _kext_line(pid=target_pid),   # warm-up — matches
+        _kext_line(pid=222),          # would-be later event
+    ]
+    streamer = _make_streamer(tmp_path)
+    streamer._proc = _FakeProc(_FakeStdout(lines))
+
+    with mock.patch.object(
+        seatbelt_audit.subprocess, "Popen",
+        return_value=_FakeWarmUp(target_pid),
+    ), mock.patch.object(
+        seatbelt_audit.shutil, "which",
+        return_value="/usr/bin/sandbox-exec",
+    ), mock.patch.object(
+        seatbelt_audit.Path, "exists", return_value=True,
+    ):
+        result = streamer._warm_up_until_attached()
+
+    assert result is True
+
+
+def test_warm_up_returns_false_when_no_target_pid_event(tmp_path):
+    """If log-stream stdout never carries the warm-up's PID and the
+    timeout fires, the gate returns False so callers fall back to
+    best-effort mode."""
+    target_pid = 4242
+    # Only events from unrelated PIDs.
+    lines = [_kext_line(pid=111), _kext_line(pid=222)]
+    streamer = _make_streamer(tmp_path)
+    streamer._proc = _FakeProc(_FakeStdout(lines))
+
+    # Compress the timeout for a fast unit-test run.
+    with mock.patch.object(
+        seatbelt_audit, "_WARM_UP_TIMEOUT_S", 0.5,
+    ), mock.patch.object(
+        seatbelt_audit.subprocess, "Popen",
+        return_value=_FakeWarmUp(target_pid),
+    ), mock.patch.object(
+        seatbelt_audit.shutil, "which",
+        return_value="/usr/bin/sandbox-exec",
+    ), mock.patch.object(
+        seatbelt_audit.Path, "exists", return_value=True,
+    ):
+        result = streamer._warm_up_until_attached()
+
+    assert result is False
+
+
+def test_warm_up_returns_false_when_sandbox_exec_missing(tmp_path):
+    """Non-Darwin host (or stripped install) — gate skips cleanly."""
+    streamer = _make_streamer(tmp_path)
+    streamer._proc = _FakeProc(_FakeStdout([]))
+
+    with mock.patch.object(
+        seatbelt_audit.shutil, "which", return_value=None,
+    ), mock.patch.object(
+        seatbelt_audit.Path, "exists", return_value=False,
+    ):
+        result = streamer._warm_up_until_attached()
+
+    assert result is False
+
+
+def test_warm_up_returns_false_when_sandbox_exec_oserror(tmp_path):
+    """Popen('sandbox-exec') failing (binary present but unrunnable)
+    is also a clean fall-through, not a crash."""
+    streamer = _make_streamer(tmp_path)
+    streamer._proc = _FakeProc(_FakeStdout([]))
+
+    with mock.patch.object(
+        seatbelt_audit.subprocess, "Popen",
+        side_effect=OSError("denied"),
+    ), mock.patch.object(
+        seatbelt_audit.shutil, "which",
+        return_value="/usr/bin/sandbox-exec",
+    ), mock.patch.object(
+        seatbelt_audit.Path, "exists", return_value=True,
+    ):
+        result = streamer._warm_up_until_attached()
+
+    assert result is False
+
+
+def test_warm_up_invokes_sandbox_exec_with_deny_default_profile(tmp_path):
+    """The synthetic workload uses a deny-default SBPL profile so the
+    kext deny event fires deterministically. Pin the argv shape — if
+    a future change loosens the profile, we want the test to fail so
+    we re-validate the warm-up still emits an event."""
+    target_pid = 7000
+    lines = [_kext_line(pid=target_pid)]
+    streamer = _make_streamer(tmp_path)
+    streamer._proc = _FakeProc(_FakeStdout(lines))
+
+    captured: list = []
+
+    def _capture_popen(argv, **kwargs):
+        captured.append(argv)
+        return _FakeWarmUp(target_pid)
+
+    with mock.patch.object(
+        seatbelt_audit.subprocess, "Popen", side_effect=_capture_popen,
+    ), mock.patch.object(
+        seatbelt_audit.shutil, "which",
+        return_value="/usr/bin/sandbox-exec",
+    ), mock.patch.object(
+        seatbelt_audit.Path, "exists", return_value=True,
+    ):
+        streamer._warm_up_until_attached()
+
+    assert len(captured) == 1
+    argv = captured[0]
+    assert argv[0] == "/usr/bin/sandbox-exec"
+    assert argv[1] == "-p"
+    assert "deny default" in argv[2]
+    assert "with report" in argv[2]
+    assert argv[3] == "/usr/bin/true"
+
+
+def test_warm_up_skips_non_kext_entries(tmp_path):
+    """Non-Sandbox.kext entries (or malformed JSON / messages) are
+    ignored — the gate keeps reading until a real kext record from
+    the warm-up's PID arrives. Guards against false positives if the
+    predicate ever loosens upstream."""
+    target_pid = 8000
+    # Mix in: malformed JSON, non-kext entry (no eventMessage match),
+    # finally the real warm-up event.
+    bad_json = b"this is not json\n"
+    non_kext = json.dumps({
+        "senderImagePath": "/some/other/sender",
+        "eventMessage": f"Sandbox: foo({target_pid}) allow file-read /etc",
+    }).encode("utf-8") + b"\n"
+    lines = [
+        bad_json,
+        non_kext,  # would match PID but isn't really a kext entry —
+                   # though our parser only checks eventMessage shape,
+                   # so this DOES count. Use a clearly non-matching
+                   # entry instead.
+        _kext_line(pid=target_pid),
+    ]
+    # Replace non_kext with something whose eventMessage doesn't match
+    # the kext regex.
+    lines[1] = json.dumps({
+        "senderImagePath": SANDBOX_KEXT_SENDER,
+        "eventMessage": "Some other unrelated kext message",
+    }).encode("utf-8") + b"\n"
+
+    streamer = _make_streamer(tmp_path)
+    streamer._proc = _FakeProc(_FakeStdout(lines))
+
+    with mock.patch.object(
+        seatbelt_audit.subprocess, "Popen",
+        return_value=_FakeWarmUp(target_pid),
+    ), mock.patch.object(
+        seatbelt_audit.shutil, "which",
+        return_value="/usr/bin/sandbox-exec",
+    ), mock.patch.object(
+        seatbelt_audit.Path, "exists", return_value=True,
+    ):
+        result = streamer._warm_up_until_attached()
+
+    assert result is True
+
+
+def test_start_proceeds_in_best_effort_when_warm_up_times_out(tmp_path):
+    """End-to-end: when the warm-up reports False, ``start()`` still
+    starts the reader thread — best-effort fallback — rather than
+    raising. Operators get a debug log; sandboxing continues."""
+    streamer = _make_streamer(tmp_path)
+
+    # Stub `log stream` Popen with a fake that won't be drained.
+    fake_log_stream = _FakeProc(_FakeStdout([]))
+
+    def _popen_substitute(argv, **kwargs):
+        # Only the first Popen call is for `log stream`; treat
+        # subsequent ones as the warm-up.
+        if argv[0] == "/usr/bin/log":
+            return fake_log_stream
+        return _FakeWarmUp(pid=12345)
+
+    with mock.patch.object(
+        seatbelt_audit, "_WARM_UP_TIMEOUT_S", 0.2,
+    ), mock.patch.object(
+        seatbelt_audit.subprocess, "Popen", side_effect=_popen_substitute,
+    ), mock.patch.object(
+        seatbelt_audit.shutil, "which",
+        return_value="/usr/bin/sandbox-exec",
+    ), mock.patch.object(
+        seatbelt_audit.Path, "exists", return_value=True,
+    ):
+        streamer.start()
+
+    # Reader thread started despite warm-up returning False.
+    assert streamer._reader is not None
+    assert streamer._reader.is_alive() or streamer._reader.ident is not None
+    streamer._stopped.set()
+
+
+def test_warm_up_reaps_child_even_on_match(tmp_path):
+    """The synthetic workload must be reaped — leaking a zombie
+    sandbox-exec per LogStreamer would compound across runs."""
+    target_pid = 9000
+    lines = [_kext_line(pid=target_pid)]
+    streamer = _make_streamer(tmp_path)
+    streamer._proc = _FakeProc(_FakeStdout(lines))
+
+    warm_up = _FakeWarmUp(target_pid)
+    wait_called = []
+    orig_wait = warm_up.wait
+
+    def _track_wait(timeout=None):
+        wait_called.append(timeout)
+        return orig_wait(timeout)
+    warm_up.wait = _track_wait
+
+    with mock.patch.object(
+        seatbelt_audit.subprocess, "Popen", return_value=warm_up,
+    ), mock.patch.object(
+        seatbelt_audit.shutil, "which",
+        return_value="/usr/bin/sandbox-exec",
+    ), mock.patch.object(
+        seatbelt_audit.Path, "exists", return_value=True,
+    ):
+        streamer._warm_up_until_attached()
+
+    assert wait_called, "warm-up child was not reaped via wait()"


### PR DESCRIPTION
Replace best-effort `_await_first_heartbeat` (waited up to 2s for a stdout banner that `log stream` emits on stderr — DEVNULL'd — so the wait always timed out) with a synthetic-workload gate.

After spawning `log stream`, run `sandbox-exec -p '(deny default (with report))' /usr/bin/true` and drain log-stream stdout until a kext record from that workload's PID parses out. That's the deterministic signal the kernel-side filter is attached. Without this, fast workloads (e.g. `claude --version` finishing in tens of ms) can outrace `log stream`'s attachment on a cold `log` daemon and produce zero captured records — surfaced on macOS Tahoe 26.4.1 during cc_dispatch calibration smoke-testing.

Falls back to best-effort proceed when sandbox-exec is missing or the warm-up times out — operators on edge configurations still get a streamer, just without the attachment guarantee.

8 mock-level tests cover: match path, timeout path, missing sandbox-exec, OSError on Popen, argv shape pin, non-kext-entry filtering, start() best-effort fallback, and child reaping.

Validated on macOS Tahoe 26.4.1 arm64: pre-fix bundle reproduced the flake (3/3 attempts, 0 records); post-fix bundle captured paths_read=10 on attempt 1.