### PR TITLE
fix(core/sandbox): TimeoutExpired falls through to static proxy_hosts

### DIFF
--- a/core/llm/cc_proxy_hosts.py
+++ b/core/llm/cc_proxy_hosts.py
@@ -47,6 +47,7 @@ import json
 import logging
 import os
 import shutil
+import subprocess
 from pathlib import Path
 from typing import Optional, Tuple
 from urllib.parse import urlparse
@@ -313,12 +314,14 @@ def _calibrated_profile(claude_bin: Optional[str] = None):
             env_keys=env_keys,
             timeout=timeout,
         )
-    except (FileNotFoundError, RuntimeError, OSError) as exc:
+    except (FileNotFoundError, RuntimeError, OSError,
+            subprocess.TimeoutExpired) as exc:
         # Probe failed: ptrace blocked (Yama scope 3),
-        # libseccomp absent on minimal containers, or the
-        # binary was deleted between which() and probe. Log at
-        # debug — calibration is opt-in / advisory, the static
-        # fallback stays in place.
+        # libseccomp absent on minimal containers, the binary was
+        # deleted between which() and probe, or the probe exceeded
+        # its per-mode timeout (20s for `--version`, 150s for
+        # `claude -p READY`). Log at debug — calibration is opt-in
+        # / advisory, the static fallback stays in place.
         logger.debug(
             "cc_proxy_hosts: calibration of %s failed (%s); "
             "falling back to static policy",

--- a/core/llm/tests/test_cc_proxy_hosts.py
+++ b/core/llm/tests/test_cc_proxy_hosts.py
@@ -477,6 +477,22 @@ class TestCalibratedProfileFailureModes:
         monkeypatch.setattr(_cal, "load_or_calibrate", boom)
         assert mod._calibrated_profile() is None
 
+    def test_calibrate_timeout_returns_none(self, monkeypatch):
+        # subprocess.TimeoutExpired from a sandboxed `claude --version`
+        # (or a network probe exceeding 150s) must not propagate to
+        # cc_dispatch — fall through to the static default like every
+        # other failure mode.
+        import subprocess as _subprocess
+        monkeypatch.setattr(mod, "_resolve_claude_bin",
+                            lambda: "/fake/claude")
+        import core.sandbox.calibrate as _cal
+        def boom(*args, **kwargs):
+            raise _subprocess.TimeoutExpired(
+                ["/fake/claude", "--version"], 20,
+            )
+        monkeypatch.setattr(_cal, "load_or_calibrate", boom)
+        assert mod._calibrated_profile() is None
+
     def test_memoised_per_binary(self, monkeypatch):
         """A second call for the same resolved binary path doesn't
         re-spawn the calibrator — the per-process memo serves the

--- a/packages/codeql/codeql_proxy_hosts.py
+++ b/packages/codeql/codeql_proxy_hosts.py
@@ -37,6 +37,7 @@ import json
 import logging
 import os
 import shutil
+import subprocess
 from pathlib import Path
 from typing import Optional
 
@@ -130,7 +131,12 @@ def _calibrated_profile(codeql_bin: Optional[str] = None):
             env_keys=_CODEQL_ENV_KEYS,
             timeout=20,
         )
-    except (FileNotFoundError, RuntimeError, OSError) as exc:
+    except (FileNotFoundError, RuntimeError, OSError,
+            subprocess.TimeoutExpired) as exc:
+        # TimeoutExpired: a sandboxed `codeql --version` exceeding
+        # 20s (rare but observable on cold systems / large CodeQL
+        # bundles) shouldn't break the resolver — fall through to
+        # the static default like every other failure mode.
         logger.debug(
             "codeql_proxy_hosts: calibration of %s failed (%s); "
             "falling back to static policy",

--- a/packages/codeql/tests/test_codeql_proxy_hosts.py
+++ b/packages/codeql/tests/test_codeql_proxy_hosts.py
@@ -342,6 +342,25 @@ class TestCalibratedProfileFailureModes:
         monkeypatch.setattr(_cal, "load_or_calibrate", boom)
         assert mod._calibrated_profile() is None
 
+    def test_calibrate_timeout_returns_none(self, monkeypatch):
+        # subprocess.TimeoutExpired = sandboxed `codeql --version`
+        # exceeded the 20s probe cap (rare but observable on cold
+        # systems / large CodeQL bundles). Must not propagate to
+        # query_runner — fall through to the static default.
+        import subprocess as _subprocess
+        monkeypatch.setattr(
+            mod, "_resolve_codeql_bin", lambda: "/fake/codeql",
+        )
+        import core.sandbox.calibrate as _cal
+
+        def boom(*args, **kwargs):
+            raise _subprocess.TimeoutExpired(
+                ["/fake/codeql", "--version"], 20,
+            )
+
+        monkeypatch.setattr(_cal, "load_or_calibrate", boom)
+        assert mod._calibrated_profile() is None
+
     def test_memoised_per_binary(self, monkeypatch):
         """A second call for the same resolved binary path doesn't
         re-spawn the calibrator — the per-process memo serves the


### PR DESCRIPTION
Both `cc_proxy_hosts._calibrated_profile` and
`codeql_proxy_hosts._calibrated_profile` caught only `(FileNotFoundError, RuntimeError, OSError)` from
`load_or_calibrate`. `subprocess.TimeoutExpired` — raised when a sandboxed `<bin> --version` exceeds the 20s probe cap — is none of those; it bubbled up to the consumer (cc_dispatch / query_runner) and crashed the resolver.

Surfaced empirically while writing the SCA-resolver consumers: a sandboxed `npm --version` on a slow host hit the timeout and the resolver died instead of falling through to the static default.

Add `subprocess.TimeoutExpired` to both except lists. Same behaviour as every other failure mode — log at debug, cache a None, return the static default. One unit test per module exercising the catch path with a real `subprocess.TimeoutExpired` instance.

No behaviour change on the success path; no regression in the 936 sandbox+proxy_hosts tests.