### PR TITLE
fix(scorecard): promote producer-error logs DEBUG → WARNING

### DIFF
--- a/core/llm/scorecard/consensus.py
+++ b/core/llm/scorecard/consensus.py
@@ -179,7 +179,16 @@ def record_consensus_outcomes(
                 )
                 n_recorded += 1
             except Exception as e:                       # noqa: BLE001
-                logger.debug(
+                # WARNING (not DEBUG): operators rarely run with
+                # DEBUG enabled in production, so a regressed
+                # producer would have been invisible. Per-event
+                # failures here are real signal — the scorecard
+                # write path failed for an attributable
+                # (model, decision_class, finding) cell. If this
+                # logs frequently in practice, the underlying issue
+                # (lock contention, disk full, schema corruption)
+                # warrants attention regardless of log volume.
+                logger.warning(
                     "record_consensus_outcomes: failed to record %s/%s "
                     "on %s: %s",
                     model, decision_class, fid, e,

--- a/core/llm/scorecard/judge.py
+++ b/core/llm/scorecard/judge.py
@@ -157,7 +157,8 @@ def _record_one(
             sample=sample,
         )
     except Exception as e:                              # noqa: BLE001
-        logger.debug(
+        # WARNING (not DEBUG): see consensus.py for rationale.
+        logger.warning(
             "record_judge_outcomes: failed to record %s/%s: %s",
             model, decision_class, e,
         )

--- a/core/llm/scorecard/reasoning_divergence.py
+++ b/core/llm/scorecard/reasoning_divergence.py
@@ -171,7 +171,8 @@ def record_reasoning_divergence(
                 )
                 n_recorded += 1
             except Exception as e:                       # noqa: BLE001
-                logger.debug(
+                # WARNING (not DEBUG): see consensus.py for rationale.
+                logger.warning(
                     "record_reasoning_divergence: failed to record "
                     "%s/%s on %s: %s",
                     model, decision_class, fid, e,

--- a/core/llm/scorecard/tests/test_consensus.py
+++ b/core/llm/scorecard/tests/test_consensus.py
@@ -379,3 +379,49 @@ class TestIsolationFromGate:
         after = _stat(scorecard, "agentic:py/x", "flash",
                       EventType.CHEAP_SHORT_CIRCUIT)
         assert before == after  # cheap-tier counter unchanged
+
+
+class TestProducerErrorVisibility:
+    """Pin that producer failures emit at WARNING, not DEBUG.
+
+    Operators rarely run with DEBUG enabled in production. A
+    regressed producer logging at DEBUG was effectively silent.
+    Promoted family-wide so failures surface in default logs.
+    Captured in the ``project_semantic_entropy`` memory under v1.3.
+    """
+
+    def test_per_event_failure_logs_at_warning(
+        self, scorecard, caplog, monkeypatch,
+    ):
+        # Force record_event to raise so we exercise the except path.
+        def _boom(*args, **kwargs):
+            raise RuntimeError("simulated record_event failure")
+        monkeypatch.setattr(scorecard, "record_event", _boom)
+
+        matrix = {"f1": {
+            "pro":   {"is_exploitable": True},
+            "opus":  {"is_exploitable": True},
+            "flash": {"is_exploitable": False},
+        }}
+        confidence = {"f1": "disputed"}
+        results = {"f1": {"rule_id": "py/x"}}
+
+        import logging
+        with caplog.at_level(logging.WARNING,
+                             logger="core.llm.scorecard.consensus"):
+            record_consensus_outcomes(
+                scorecard,
+                correlation=_correlation(
+                    matrix=matrix, confidence=confidence),
+                results_by_id=results,
+            )
+
+        warnings = [
+            r for r in caplog.records
+            if r.levelname == "WARNING"
+            and "record_consensus_outcomes" in r.getMessage()
+        ]
+        assert warnings, (
+            "expected WARNING log on per-event failure; got "
+            f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
+        )

--- a/core/llm/scorecard/tool_evidence.py
+++ b/core/llm/scorecard/tool_evidence.py
@@ -93,7 +93,8 @@ def record_tool_evidence_outcome(
         )
         return True
     except Exception as e:                              # noqa: BLE001
-        logger.debug(
+        # WARNING (not DEBUG): see consensus.py for rationale.
+        logger.warning(
             "record_tool_evidence_outcome: %s/%s failed: %s",
             model, decision_class, e,
         )
@@ -138,7 +139,13 @@ def record_tool_evidence_outcomes(
                 decision_class_prefix=decision_class_prefix,
             )
         except Exception as e:                          # noqa: BLE001
-            logger.debug("record_tool_evidence_outcomes: bad record %r: %s", rec, e)
+            # WARNING: a malformed record is a real signal — caller
+            # gave us shape we can't process. See consensus.py for
+            # the broader rationale on the family-wide promotion.
+            logger.warning(
+                "record_tool_evidence_outcomes: bad record %r: %s",
+                rec, e,
+            )
             continue
         if ok:
             n += 1

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -901,7 +901,10 @@ def orchestrate(
                         primary_verdicts_before_judge=primary_verdicts_before_judge,
                     )
                 except Exception as e:                  # noqa: BLE001
-                    logger.debug("judge producer failed: %s", e)
+                    # WARNING (not DEBUG): family-wide convention.
+                    # See core/llm/scorecard/consensus.py for the
+                    # rationale on operator-visible producer failures.
+                    logger.warning("judge producer failed: %s", e)
 
     # Multi-model correlation (pure Python, no LLM)
     correlation = None
@@ -958,8 +961,10 @@ def orchestrate(
                         per_finding_results=_multi_results,
                     )
                 except Exception as e:                  # noqa: BLE001
-                    # Never let scorecard wiring abort orchestration.
-                    logger.debug(
+                    # Never let scorecard wiring abort orchestration —
+                    # but log at WARNING so operators see regressions
+                    # without needing DEBUG enabled.
+                    logger.warning(
                         "consensus producer failed: %s", e,
                     )
                 # Sister producer covering the agreed-verdict case
@@ -977,7 +982,8 @@ def orchestrate(
                         per_finding_results=_multi_results,
                     )
                 except Exception as e:                  # noqa: BLE001
-                    logger.debug(
+                    # WARNING (not DEBUG): see consensus producer above.
+                    logger.warning(
                         "reasoning_divergence producer failed: %s", e,
                     )
 


### PR DESCRIPTION
Pre-PR-#431 family pattern: all 5 scorecard producers (consensus, judge, tool_evidence, reasoning_divergence, plus prefilter via its broader except path) caught record_event exceptions and logged at DEBUG. Operators rarely run with DEBUG enabled, so a regressed producer was effectively silent — adv review #12 of PR #431.

Promotes 8 sites from logger.debug to logger.warning:
- 5 inside producers (per-event failure paths)
- 3 in orchestrator (whole-producer-call wrappers)

Prefilter intentionally left alone: its callers in packages/codeql/{autonomous_analyzer,dataflow_validator}.py already wrap in broader try/except logging at ERROR.

New TestProducerErrorVisibility class in test_consensus.py pins the contract — monkeypatches record_event to raise, asserts WARNING is emitted. The pattern is mirror-able for the other producers if/when they accumulate their own coverage.

Silent-fail behaviour preserved: producers still don't propagate. Operators see the warning, orchestration completes.