### PR TITLE
feat(scorecard): auto-GC retention for stale cells

### DIFF
--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -418,10 +418,25 @@ class LLMClient:
             return None
         if self._scorecard is None:
             from .scorecard import ModelScorecard
+            # Operator's currently-configured models. Auto-GC
+            # preserves cells for these regardless of last_seen_at
+            # age — an operator who steps away for a quarter and
+            # comes back shouldn't lose Wilson-bound calibration
+            # data on models still listed in their config. Only
+            # cells for *deprecated* models age out. Includes
+            # primary + every fallback so multi-tier configs are
+            # fully covered.
+            keep_models: set[str] = set()
+            if self.config.primary_model is not None:
+                keep_models.add(self.config.primary_model.model_name)
+            for fb in (self.config.fallback_models or []):
+                if fb is not None:
+                    keep_models.add(fb.model_name)
             self._scorecard = ModelScorecard(
                 self.config.scorecard_path,
                 retain_samples=self.config.scorecard_retain_samples,
                 shadow_rate=self.config.scorecard_shadow_rate,
+                keep_models=keep_models or None,
             )
         return self._scorecard
 

--- a/core/llm/scorecard/scorecard.py
+++ b/core/llm/scorecard/scorecard.py
@@ -52,7 +52,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Iterator, List, Literal, Optional, Tuple
+from typing import Dict, Iterator, List, Literal, Optional, Set, Tuple
 
 from core.json import load_json, save_json
 from core.logging import get_logger
@@ -73,6 +73,32 @@ DEFAULT_MISS_RATE_CEILING = 0.05
 # and more reasoning text on disk (privacy concern). 5 is plenty
 # for the operator to scan a representative spread of failures.
 MAX_DISAGREEMENT_SAMPLES = 5
+
+
+# ---- auto-GC retention ---------------------------------------------------
+# The scorecard JSON grows as new (model, decision_class) pairs accumulate.
+# Per-cell content is bounded (samples capped at MAX_DISAGREEMENT_SAMPLES),
+# but cell count is not — operators that scan many distinct rule_ids over
+# many model upgrades collect dead-weight cells indefinitely. Without auto-
+# GC, the file grows linearly with operator history.
+#
+# Manual retention already exists via ``scorecard reset --older-than-days``;
+# this layer fires the same logic automatically at most once per interval
+# under the existing flock so concurrent processes don't all GC at once.
+
+# Retention horizon — cells whose last_seen_at is older than this are
+# dropped. 90 days is long enough that quarterly model upgrades and
+# seasonal scan patterns don't lose data; operators wanting tighter or
+# looser retention pass ``auto_gc_after_days`` to ``ModelScorecard``.
+# Pass ``None`` (or 0) to disable auto-GC entirely (manual reset still
+# works).
+DEFAULT_AUTO_GC_AFTER_DAYS = 90
+
+# Don't run the cell-walk more than once per this many seconds — operator
+# workloads often have many writes in a burst, and re-walking thousands of
+# cells each time is wasted effort. 24h is granular enough that a stale
+# cell at the cutoff stays at most one extra day.
+_AUTO_GC_INTERVAL_SECONDS = 86400
 
 
 class EventType:
@@ -245,6 +271,9 @@ class ModelScorecard:
         retain_samples: bool = True,
         miss_rate_ceiling: float = DEFAULT_MISS_RATE_CEILING,
         shadow_rate: float = 0.0,
+        auto_gc_after_days: Optional[int] = DEFAULT_AUTO_GC_AFTER_DAYS,
+        auto_gc_interval_seconds: float = _AUTO_GC_INTERVAL_SECONDS,
+        keep_models: Optional[Set[str]] = None,
         rng=None,
     ):
         """``shadow_rate`` is the probability (0-1) that a call to a
@@ -268,6 +297,20 @@ class ModelScorecard:
         self.retain_samples = retain_samples
         self.miss_rate_ceiling = miss_rate_ceiling
         self.shadow_rate = shadow_rate
+        self.auto_gc_after_days = auto_gc_after_days
+        self.auto_gc_interval_seconds = auto_gc_interval_seconds
+        # Cells whose ``model`` is in ``keep_models`` are protected
+        # from auto-GC regardless of last_seen_at age. Intent: an
+        # operator who configures a model in models.json but takes
+        # a quarter off shouldn't lose Wilson-bound calibration
+        # data when they return. ``LLMClient`` populates this from
+        # the operator's primary + fallback model names; CLI /
+        # tests that don't pass it get unprotected behaviour
+        # (manual ``reset --model X`` still works to retire a
+        # specific model). Frozen ``set`` for cheap lookups.
+        self.keep_models: Set[str] = (
+            set(keep_models) if keep_models else set()
+        )
         self._rng = rng if rng is not None else random.random
 
     # ----- public API -----
@@ -632,6 +675,11 @@ class ModelScorecard:
         def __exit__(self, exc_type, exc, tb):
             try:
                 if exc_type is None and self.write:
+                    # Run auto-GC inside the write lock so concurrent
+                    # processes serialise and at most one walks per
+                    # configured interval. See
+                    # ``ModelScorecard._maybe_auto_gc``.
+                    self.scorecard._maybe_auto_gc(self.data)
                     # Atomic write via save_json (tempfile + rename).
                     # We're under flock on the sibling ``.lock``
                     # file, which stays stable across this rename;
@@ -649,6 +697,106 @@ class ModelScorecard:
 
     def _with_lock(self, *, write: bool = True) -> "_LockCtx":
         return ModelScorecard._LockCtx(self, write=write)
+
+    # ----- auto-GC -----
+
+    def _maybe_auto_gc(self, data: Dict) -> None:
+        """Drop stale cells if retention has elapsed since the last
+        sweep. Caller MUST hold the write lock.
+
+        Behaviour:
+
+        * No-op when ``self.auto_gc_after_days`` is ``None`` or
+          ``<= 0`` (operator opted out).
+        * Reads ``data["last_gc_at"]`` to gate the cell-walk on the
+          configured interval — at most one process per interval
+          actually walks. Concurrent processes serialise on the
+          flock and see the updated ``last_gc_at`` on their next
+          turn, so they no-op.
+        * Cell-walk drops every ``(model, decision_class)`` cell
+          whose ``last_seen_at`` predates the retention cutoff,
+          UNLESS its ``model`` is in :attr:`keep_models` — those
+          are operator-active models we don't want to silently
+          purge while the operator is on holiday.
+        * Logs a summary line at INFO when any cells were dropped:
+          per-model count + total events purged. Operators wanting
+          historical data pipe logs (the JSON intentionally keeps
+          no archive — see ``project_semantic_entropy`` memory).
+        """
+        days = self.auto_gc_after_days
+        if days is None or days <= 0:
+            return
+
+        now = time.time()
+        last_gc_iso = data.get("last_gc_at") or ""
+        if last_gc_iso:
+            try:
+                last_gc_ts = datetime.fromisoformat(
+                    last_gc_iso,
+                ).timestamp()
+            except ValueError:
+                # Hand-edited / corrupt — treat as never-run.
+                last_gc_ts = 0.0
+        else:
+            last_gc_ts = 0.0
+        if now - last_gc_ts < self.auto_gc_interval_seconds:
+            return
+
+        cutoff_ts = now - days * 86400
+        cutoff_iso = datetime.fromtimestamp(
+            cutoff_ts, tz=timezone.utc,
+        ).replace(microsecond=0).isoformat()
+
+        # Per-model summary for the log line. Only models whose cells
+        # actually got dropped end up in the dict — protected models
+        # never appear here even if they would otherwise have been
+        # GC candidates.
+        per_model_counts: Dict[str, int] = {}
+        events_correct = 0
+        events_incorrect = 0
+        models = data.get("models") or {}
+        for m_key in list(models.keys()):
+            if m_key in self.keep_models:
+                # Operator-active model — preserve all its cells.
+                continue
+            by_dc = models[m_key]
+            for dc_key in list(by_dc.keys()):
+                cell = by_dc[dc_key]
+                seen = cell.get("last_seen_at", "")
+                if seen and seen < cutoff_iso:
+                    # Tally before deletion so the log line is
+                    # informative without a separate scan.
+                    for et_counts in (cell.get("events") or {}).values():
+                        events_correct += int(
+                            et_counts.get("correct", 0))
+                        events_incorrect += int(
+                            et_counts.get("incorrect", 0))
+                    del by_dc[dc_key]
+                    per_model_counts[m_key] = (
+                        per_model_counts.get(m_key, 0) + 1)
+            if not by_dc:
+                del models[m_key]
+
+        data["last_gc_at"] = datetime.fromtimestamp(
+            now, tz=timezone.utc,
+        ).replace(microsecond=0).isoformat()
+
+        total_dropped = sum(per_model_counts.values())
+        if total_dropped:
+            per_model_str = ", ".join(
+                f"{m}: {n}" for m, n in sorted(per_model_counts.items())
+            )
+            # RaptorLogger takes a single pre-formatted message string,
+            # not %-style positional args. Build the message here so
+            # the log line stays one greppable line.
+            logger.info(
+                f"scorecard auto-GC: dropped {total_dropped} cells "
+                f"across {len(per_model_counts)} deprecated model(s) "
+                f"({per_model_str}); totals: "
+                f"{events_correct + events_incorrect} events purged "
+                f"({events_correct} correct, {events_incorrect} "
+                "incorrect)"
+            )
 
 
 __all__ = [

--- a/core/llm/scorecard/tests/test_scorecard.py
+++ b/core/llm/scorecard/tests/test_scorecard.py
@@ -545,3 +545,313 @@ def test_shadow_rate_invalid_value_rejected(tmp_path):
         ModelScorecard(tmp_path / "sc.json", shadow_rate=5.0)
     with pytest.raises(ValueError, match="shadow_rate"):
         ModelScorecard(tmp_path / "sc.json", shadow_rate=-0.1)
+
+
+# ---------------------------------------------------------------------------
+# Auto-GC retention
+# ---------------------------------------------------------------------------
+
+
+def _backdate_cell(sc, model: str, decision_class: str,
+                   *, days_ago: int) -> None:
+    """Helper: rewrite a cell's last_seen_at to be ``days_ago`` days
+    in the past. Lets tests stage stale data without having to wait
+    or stub time.time() for the read path. Acquires the same write
+    lock the public API uses, so the rewrite is consistent with the
+    persistence layer.
+
+    Note: this helper's own write counts as a GC trigger when the
+    scorecard's auto_gc_interval_seconds is 0. To stage MULTIPLE
+    stale cells before letting GC run, call ``_arm_gc(sc)`` after
+    all backdates and then perform a single write — that ensures
+    GC sees the full set in one pass rather than firing per call.
+    """
+    from datetime import datetime, timezone
+    import time
+    target = datetime.fromtimestamp(
+        time.time() - days_ago * 86400, tz=timezone.utc,
+    ).replace(microsecond=0).isoformat()
+    with sc._with_lock() as data:
+        data["models"][model][decision_class]["last_seen_at"] = target
+
+
+def _arm_gc(sc) -> None:
+    """Helper: clear ``last_gc_at`` so the next write triggers an
+    auto-GC pass. Use after staging multiple stale cells via
+    ``_backdate_cell`` to fire GC in one batch rather than per-cell."""
+    with sc._with_lock() as data:
+        data.pop("last_gc_at", None)
+
+
+class TestAutoGc:
+    def test_disabled_when_auto_gc_after_days_none(self, tmp_path):
+        # Default would be 90 days; pass None to opt out.
+        sc = ModelScorecard(
+            tmp_path / "sc.json", shadow_rate=0.0,
+            auto_gc_after_days=None,
+        )
+        sc.record_event(
+            "x:y", "m", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        _backdate_cell(sc, "m", "x:y", days_ago=400)
+        # Trigger another write; opt-out means no GC happens.
+        sc.record_event(
+            "x:y", "m2", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        assert sc.get_stat("x:y", "m") is not None
+
+    def test_disabled_when_auto_gc_after_days_zero(self, tmp_path):
+        sc = ModelScorecard(
+            tmp_path / "sc.json", shadow_rate=0.0,
+            auto_gc_after_days=0,
+        )
+        sc.record_event(
+            "x:y", "m", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        _backdate_cell(sc, "m", "x:y", days_ago=400)
+        sc.record_event(
+            "x:y", "m2", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        assert sc.get_stat("x:y", "m") is not None
+
+    def test_drops_stale_cell(self, tmp_path):
+        sc = ModelScorecard(
+            tmp_path / "sc.json", shadow_rate=0.0,
+            auto_gc_after_days=90,
+            auto_gc_interval_seconds=0.0,
+        )
+        sc.record_event(
+            "x:y", "old-model", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        _backdate_cell(sc, "old-model", "x:y", days_ago=120)
+        # Next write triggers GC; ``old-model`` is past the cutoff
+        # and not in keep_models, so its cell should be dropped.
+        sc.record_event(
+            "x:y", "fresh", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        assert sc.get_stat("x:y", "old-model") is None
+        assert sc.get_stat("x:y", "fresh") is not None
+
+    def test_preserves_fresh_cell(self, tmp_path):
+        sc = ModelScorecard(
+            tmp_path / "sc.json", shadow_rate=0.0,
+            auto_gc_after_days=90,
+            auto_gc_interval_seconds=0.0,
+        )
+        sc.record_event(
+            "x:y", "recent", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        _backdate_cell(sc, "recent", "x:y", days_ago=30)  # well within
+        sc.record_event(
+            "x:y", "another", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        # Fresh-ish cell survives — it's only 30d old.
+        assert sc.get_stat("x:y", "recent") is not None
+
+    def test_keep_models_protects_stale_cell(self, tmp_path):
+        # Operator configured ``in-use`` 4 months ago but is back
+        # scanning today. The cell would otherwise be GC'd; the
+        # ``keep_models`` set protects it.
+        sc = ModelScorecard(
+            tmp_path / "sc.json", shadow_rate=0.0,
+            auto_gc_after_days=90,
+            auto_gc_interval_seconds=0.0,
+            keep_models={"in-use"},
+        )
+        sc.record_event(
+            "x:y", "in-use", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        _backdate_cell(sc, "in-use", "x:y", days_ago=120)
+        sc.record_event(
+            "x:y", "fresh", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        # Stale but protected — survives. The Wilson-bound calibration
+        # data the operator built up over previous quarters is intact.
+        assert sc.get_stat("x:y", "in-use") is not None
+
+    def test_keep_models_does_not_protect_unrelated_models(self, tmp_path):
+        # Listing one model in keep_models doesn't rescue cells for
+        # other deprecated models.
+        sc = ModelScorecard(
+            tmp_path / "sc.json", shadow_rate=0.0,
+            auto_gc_after_days=90,
+            auto_gc_interval_seconds=0.0,
+            keep_models={"in-use"},
+        )
+        sc.record_event(
+            "x:y", "deprecated", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        _backdate_cell(sc, "deprecated", "x:y", days_ago=120)
+        sc.record_event(
+            "x:y", "in-use", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        assert sc.get_stat("x:y", "deprecated") is None
+
+    def test_interval_gates_walk(self, tmp_path):
+        # Run 1 with interval=0 → GC fires.
+        # Run 2 with default interval (24h) immediately after → no walk.
+        sc = ModelScorecard(
+            tmp_path / "sc.json", shadow_rate=0.0,
+            auto_gc_after_days=90,
+            auto_gc_interval_seconds=0.0,
+        )
+        sc.record_event(
+            "x:y", "old", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        _backdate_cell(sc, "old", "x:y", days_ago=120)
+        sc.record_event(  # triggers first GC; old dropped
+            "x:y", "fresh", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        assert sc.get_stat("x:y", "old") is None
+
+        # New scorecard handle on the same file with the production
+        # interval. Stage another stale cell. GC must NOT fire because
+        # last_gc_at was just stamped.
+        sc2 = ModelScorecard(
+            tmp_path / "sc.json", shadow_rate=0.0,
+            auto_gc_after_days=90,
+        )  # default 24h interval
+        sc2.record_event(
+            "x:y", "old2", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        # Backdate WITHOUT clearing last_gc_at this time so the
+        # interval gate is the thing under test.
+        from datetime import datetime, timezone
+        import time
+        with sc2._with_lock() as data:
+            old_iso = datetime.fromtimestamp(
+                time.time() - 200 * 86400, tz=timezone.utc,
+            ).replace(microsecond=0).isoformat()
+            data["models"]["old2"]["x:y"]["last_seen_at"] = old_iso
+
+        sc2.record_event(
+            "x:y", "fresh2", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        # Should still be present — interval gate suppressed the walk.
+        assert sc2.get_stat("x:y", "old2") is not None
+
+    def test_logs_summary_on_drop(self, tmp_path, caplog):
+        # Stage two stale cells under auto_gc_after_days=None so
+        # the seeding writes don't fire GC themselves. Then
+        # construct a fresh handle with the production retention
+        # to trigger the single GC pass we care about logging.
+        seed = ModelScorecard(
+            tmp_path / "sc.json", shadow_rate=0.0,
+            auto_gc_after_days=None,
+        )
+        seed.record_event(
+            "x:y", "deprecated-a", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        seed.record_event(
+            "x:y", "deprecated-b", EventType.CHEAP_SHORT_CIRCUIT, "incorrect",
+        )
+        _backdate_cell(seed, "deprecated-a", "x:y", days_ago=200)
+        _backdate_cell(seed, "deprecated-b", "x:y", days_ago=200)
+
+        sc = ModelScorecard(
+            tmp_path / "sc.json", shadow_rate=0.0,
+            auto_gc_after_days=90,
+            auto_gc_interval_seconds=0.0,
+        )
+
+        # RaptorLogger uses a "raptor" logger with propagate=False,
+        # so caplog (which hooks root by default) doesn't see its
+        # records. Attach a captor handler directly to the "raptor"
+        # logger for the duration of the test.
+        import logging
+        captured: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):  # noqa: D401
+                captured.append(record)
+
+        raptor_logger = logging.getLogger("raptor")
+        captor = _Capture(level=logging.INFO)
+        raptor_logger.addHandler(captor)
+        try:
+            sc.record_event(
+                "x:y", "fresh", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+            )
+        finally:
+            raptor_logger.removeHandler(captor)
+
+        # Summary line carries the per-model breakdown + outcome
+        # tallies. Operators wanting historical data grep this line.
+        summary = next(
+            (r.getMessage() for r in captured
+             if "auto-GC" in r.getMessage()), None,
+        )
+        assert summary is not None, [r.getMessage() for r in captured]
+        assert "deprecated-a: 1" in summary
+        assert "deprecated-b: 1" in summary
+        # Outcomes summed across both deprecated cells: 1 correct + 1 incorrect.
+        assert "1 correct" in summary
+        assert "1 incorrect" in summary
+
+    def test_no_log_when_nothing_dropped(self, tmp_path):
+        # Interval has elapsed but no cells are stale → walk runs
+        # silently (no INFO line). Operators don't get spammed when
+        # the scorecard is healthy.
+        sc = ModelScorecard(
+            tmp_path / "sc.json", shadow_rate=0.0,
+            auto_gc_after_days=90,
+            auto_gc_interval_seconds=0.0,
+        )
+        sc.record_event(
+            "x:y", "fresh", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+
+        # Same handler-attachment dance as test_logs_summary_on_drop
+        # — caplog can't see records on the propagate=False raptor
+        # logger.
+        import logging
+        captured: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):  # noqa: D401
+                captured.append(record)
+
+        raptor_logger = logging.getLogger("raptor")
+        captor = _Capture(level=logging.INFO)
+        raptor_logger.addHandler(captor)
+        try:
+            sc.record_event(
+                "x:y", "fresh-2", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+            )
+        finally:
+            raptor_logger.removeHandler(captor)
+        assert not any(
+            "auto-GC" in r.getMessage() for r in captured
+        )
+
+    def test_removes_empty_model_dict(self, tmp_path):
+        # When all of a model's cells are GC'd, the model entry
+        # itself goes too — keeps the JSON tidy.
+        sc = ModelScorecard(
+            tmp_path / "sc.json", shadow_rate=0.0,
+            auto_gc_after_days=90,
+            auto_gc_interval_seconds=0.0,
+        )
+        sc.record_event(
+            "x:y", "deprecated", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        _backdate_cell(sc, "deprecated", "x:y", days_ago=200)
+        sc.record_event(
+            "x:y", "fresh", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        with sc._with_lock(write=False) as data:
+            assert "deprecated" not in (data.get("models") or {})
+
+    def test_last_gc_at_persists(self, tmp_path):
+        sc = ModelScorecard(
+            tmp_path / "sc.json", shadow_rate=0.0,
+            auto_gc_after_days=90,
+            auto_gc_interval_seconds=0.0,
+        )
+        sc.record_event(
+            "x:y", "m", EventType.CHEAP_SHORT_CIRCUIT, "correct",
+        )
+        with sc._with_lock(write=False) as data:
+            assert data.get("last_gc_at"), (
+                "last_gc_at must be stamped after first auto-GC pass"
+            )


### PR DESCRIPTION
Adversarial-review #16 from PR #431. The scorecard JSON grows unbounded as new (model, decision_class) pairs accumulate over operator history. Per-cell content is bounded
(MAX_DISAGREEMENT_SAMPLES=5) but cell count is not. Manual retention exists via `scorecard reset --older-than-days N`; operators forget to run it.

Adds automatic GC inside the existing flock-protected write path:

* `auto_gc_after_days` (default 90) — cells whose `last_seen_at` is older are dropped. Pass None or 0 to disable.
* `auto_gc_interval_seconds` (default 86400) — gates the cell-walk to at most once per interval via `data["last_gc_at"]`. Concurrent processes serialise on the existing flock and at most one walks.
* `keep_models` — set of model names protected from auto-GC regardless of age. Operator-active models (configured in models.json but not scanned recently) keep their Wilson-bound calibration data. `LLMClient` populates this from the operator's primary + fallback model names automatically. Manual `reset --model X` still works to retire a specific model.
* INFO log line per GC pass with per-model breakdown + correct/ incorrect totals. Operators wanting historical data grep logs (the JSON intentionally keeps no archive — keeps schema simple and prevents the unbounded-growth problem in a different field).

Cells dropped: deprecated models (no longer in keep_models, last_seen_at past cutoff) and stale decision_classes (rule_ids the operator no longer scans).

Tests: 11 new in test_scorecard.py:TestAutoGc covering disabled- state, drops-stale, preserves-fresh, keep_models protection, keep_models doesn't over-protect, interval gates the walk, summary log on drop, no-spam when nothing dropped, empty model dict cleanup, last_gc_at persistence.