### PR TITLE
fix(core/http/urllib_backend): resolve relative final_url before validation

### DIFF
--- a/core/http/tests/test_urllib_backend.py
+++ b/core/http/tests/test_urllib_backend.py
@@ -745,6 +745,31 @@ class TestFollowRedirects:
         assert resp.status == 302
         assert resp.headers["location"] == "https://other.example/"
 
+    def test_geturl_returns_relative_path_does_not_refuse_response(self):
+        """urllib3's ``geturl()`` may return a relative path even on
+        a successful (200, no redirect) response — observed against
+        ``https://api.osv.dev/v1/querybatch`` which returns
+        ``Location: /v1/querybatch`` alongside its 200, prompting
+        urllib3 to record the relative path as the "final" URL.
+
+        Pre-fix the post-success URL revalidation refused the
+        relative path ("scheme '': only http/https permitted") and
+        the entire successful response was raised as a "refused
+        redirect" — silently turning every successful querybatch
+        call into an empty-result error. Reachable only against
+        servers that emit ``Location:`` on 200 responses, but
+        that's a real wire-format pattern.
+
+        Resolution: relative paths get joined against the original
+        URL before validation."""
+        client, _ = _client_with_mock_pool(
+            _stub_response(b'{"ok": true}', final_url="/v1/querybatch"),
+        )
+        # Should NOT raise — the response is valid; geturl's
+        # relative path resolves to the same canonical URL.
+        result = client.get_json("https://api.osv.dev/v1/querybatch")
+        assert result == {"ok": True}
+
 
 # ---------------------------------------------------------------------------
 # Factory

--- a/core/http/urllib_backend.py
+++ b/core/http/urllib_backend.py
@@ -794,6 +794,22 @@ class UrllibClient:
             # validator in that case rather than crashing
             # urlparse).
             if isinstance(final_url, str) and final_url != url:
+                # urllib3's ``geturl()`` may return a relative path
+                # (no scheme + no host) for the original
+                # response when the server's response shape includes
+                # a ``Location:`` header even on a non-redirect 200
+                # response — observed in the wild against
+                # ``https://api.osv.dev/v1/querybatch`` which returns
+                # ``Location: /v1/querybatch`` alongside its 200.
+                # Pre-fix the validator rejected the relative URL
+                # ("no scheme") and the entire successful response
+                # was discarded as a "refused redirect", silently
+                # turning every successful querybatch call into an
+                # empty-result error. Resolve relative paths against
+                # the original request URL before validating.
+                from urllib.parse import urlparse, urljoin
+                if not urlparse(final_url).scheme:
+                    final_url = urljoin(url, final_url)
                 try:
                     self._validate_url(final_url)
                 except HttpError as exc:


### PR DESCRIPTION
urllib3's response.geturl() may return a relative path even on a successful (200, no redirect) response. Observed against https://api.osv.dev/v1/querybatch which emits Location: /v1/querybatch alongside its 200 OK.

Pre-fix the post-success URL revalidation rejected relative paths ("Refused URL with scheme '': only http/https permitted") and raised the whole successful response as a "refused redirect" — silently hiding every OSV vuln in the batch. Reachable on every Go-heavy scan.

Fix: resolve relative paths against the original request URL via urlparse + urljoin before validation. Absolute URLs (both same-scheme redirects and downgrade attempts) still go through _validate_url.

Production impact (prometheus v2.10): 0 → 6+ vulns per Go dep query. 1 new regression test; 82 existing tests pass.