### PR TITLE
fix(orchestrator): honor explicit --consensus on 3+ analysis models

### DIFF
--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -229,12 +229,18 @@ def build_llm_config_from_flags(
         except Exception:
             pass
 
-    # Consensus is redundant with 3+ analysis models
+    # Consensus auto-defaults are redundant with 3+ analysis models
+    # — the analysis models already provide independent opinions.
+    # Strip any auto-loaded consensus model from LLMConfig defaults
+    # (models.json / env-var picks). The operator's EXPLICIT
+    # --consensus flag is honored separately by the role-flag loop
+    # below; an explicit flag means the operator wants that specific
+    # model regardless of analysis-model count.
     n_analysis = len(models)
-    if n_analysis >= 3 and consensus:
-        print(f"\n  Note: --consensus skipped — {n_analysis} analysis models "
-              f"already provide independent opinions")
-        consensus = None
+    if n_analysis >= 3 and llm_config and llm_config.fallback_models:
+        llm_config.fallback_models = [
+            m for m in llm_config.fallback_models if m.role != "consensus"
+        ]
 
     role_flags = [
         ("consensus", consensus),
@@ -246,9 +252,19 @@ def build_llm_config_from_flags(
         print("\n  Warning: --consensus/--judge/--aggregate require a primary analysis model")
         print("  Use --model MODEL, configure models.json, or set an API key env var")
     if llm_config and has_role_flags:
+        # Explicit operator role-flag overrides any auto-loaded model
+        # for the same role. Without this strip, models.json /
+        # provider-env defaults stack alongside the operator's
+        # explicit pick (e.g. operator says `--consensus
+        # claude-sonnet-4-6` but the auto-loader has already pinned
+        # claude-haiku-4-5 as consensus → 2 consensus models in
+        # fallback, neither cleanly attributable to operator intent).
         for role, model_name in role_flags:
             if not model_name:
                 continue
+            llm_config.fallback_models = [
+                m for m in llm_config.fallback_models if m.role != role
+            ]
             mc = _resolve_model(model_name, role)
             if mc:
                 llm_config.fallback_models.append(mc)

--- a/packages/llm_analysis/tests/test_dispatch.py
+++ b/packages/llm_analysis/tests/test_dispatch.py
@@ -1125,7 +1125,34 @@ class TestBuildLLMConfigFromFlags:
         assert analysis_models[0].model_name == "gpt-5"
 
     @patch.dict("os.environ", {"GEMINI_API_KEY": "k1", "OPENAI_API_KEY": "k2", "ANTHROPIC_API_KEY": "k3"})
-    def test_three_models_skips_consensus(self, capsys):
+    def test_three_models_strips_auto_consensus(self):
+        """With 3+ analysis models and NO explicit --consensus flag,
+        any auto-loaded consensus model from LLMConfig defaults is
+        stripped — the analysis trio already provides independent
+        opinions, so the auto-default is pure cost.
+        """
+        from packages.llm_analysis.orchestrator import build_llm_config_from_flags
+        result = build_llm_config_from_flags(
+            models=["gemini-2.5-pro", "gpt-5", "claude-opus-4-6"],
+            auto_detect=False,
+        )
+        assert result is not None
+        consensus_models = [m for m in result.fallback_models if m.role == "consensus"]
+        assert len(consensus_models) == 0
+
+    @patch.dict("os.environ", {"GEMINI_API_KEY": "k1", "OPENAI_API_KEY": "k2", "ANTHROPIC_API_KEY": "k3", "MISTRAL_API_KEY": "k4"})
+    def test_three_models_with_explicit_consensus_is_honored(self):
+        """With 3+ analysis models AND an explicit --consensus, honor
+        the operator's choice. The consensus role has different prompt
+        semantics than analysis (review-this-verdict vs analyse-this-
+        finding) and the explicit flag is the operator's signal that
+        they want that specific second-opinion shape — distinct from
+        having three first-pass analyses.
+
+        Pre-fix behaviour silently dropped the explicit flag with a
+        "skipped" note; this test pins the new behaviour where the
+        explicit flag wins.
+        """
         from packages.llm_analysis.orchestrator import build_llm_config_from_flags
         result = build_llm_config_from_flags(
             models=["gemini-2.5-pro", "gpt-5", "claude-opus-4-6"],
@@ -1134,9 +1161,8 @@ class TestBuildLLMConfigFromFlags:
         )
         assert result is not None
         consensus_models = [m for m in result.fallback_models if m.role == "consensus"]
-        assert len(consensus_models) == 0
-        captured = capsys.readouterr()
-        assert "skipped" in captured.out.lower()
+        assert len(consensus_models) == 1
+        assert consensus_models[0].model_name == "mistral-large-latest"
 
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
Pre-fix, `build_llm_config_from_flags` silently dropped any explicit `--consensus` flag when the operator passed 3+ analysis models, with the note "consensus skipped — N analysis models already provide independent opinions". The intent was right (don't add a 4th LLM call when 3 first-pass analyses already exist) but the implementation conflated two distinct cases:

  * **Auto-loaded consensus** from LLMConfig defaults — redundant when 3+ analysis models cover the same ground. Stripping it saves a per-finding LLM call the operator never asked for.
  * **Explicit `--consensus <model>`** — the operator's deliberate signal that they want a specific second-opinion *with the consensus prompt shape* (review-this-verdict, not analyse-this-finding). Distinct from N first-pass opinions; silently dropping it is paternalistic.

This change splits the cases:

  * `n_analysis >= 3` AND no explicit consensus → strip auto-loaded consensus from `fallback_models` (saves the 4th call)
  * `n_analysis >= 3` AND explicit `--consensus X` → honor X (passes through the role-flag loop unchanged)
  * `n_analysis < 3` — unchanged behaviour

Also drops the "Note: --consensus skipped" print, since the only remaining skip case is the auto-loaded one which the operator never opted into and doesn't need to be informed about.

The role-flag loop was already strip-then-add for explicit role flags (preceding commit) so explicit consensus at any analysis-count cleanly replaces any auto-loaded same-role model.

* `test_three_models_strips_auto_consensus` — pins the no-explicit-flag path: auto-loaded consensus is stripped at N=3.
* `test_three_models_with_explicit_consensus_is_honored` (new) — pins the new behaviour: explicit `--consensus mistral-large-latest` with 3 analysis models produces 1 consensus model in fallback_models, and it's the operator's choice.
* The renamed `test_three_models_skips_consensus` was checking the old paternalistic path; replaced by the two above.

PRs that pass `--model A --model B --model C --consensus D` now get the 4th LLM call per finding, where pre-fix they would have silently dropped D. Cost increase is real (~25% per finding) but the operator opted in by typing the flag.