### PR TITLE
feat(static-analysis): operator override for semgrep scanner proxy_hosts

### DIFF
--- a/packages/static-analysis/_proxy_hosts.py
+++ b/packages/static-analysis/_proxy_hosts.py
@@ -1,0 +1,195 @@
+"""Egress-proxy hostname allowlist for the semgrep scanner.
+
+Three-layer resolution: operator override → calibrated profile →
+static default. Same shape as ``core.llm.cc_proxy_hosts`` /
+``packages.codeql.codeql_proxy_hosts`` / ``packages.sca.resolvers._proxy_hosts``;
+semgrep fits the binary-scoped pattern because (a) it has a small
+fixed set of public registry endpoints, (b) those endpoints have
+evolved across versions (``api.semgrep.dev`` was added more
+recently than ``semgrep.dev``), and (c) operators on Semgrep
+Enterprise / self-hosted Semgrep AppSec Platform need a way to
+override without editing source.
+
+Resolution layers:
+
+  1. **Operator override** — ``~/.config/raptor/semgrep-proxy-hosts.json``
+     with a flat ``{"hosts": [...]}`` list. Required for shops on
+     Semgrep self-hosted / a corporate registry mirror.
+  2. **Calibrated profile** — ``raptor-sandbox-calibrate --bin
+     semgrep`` populates the profile cache. ``semgrep --version``
+     doesn't network, so calibrated ``proxy_hosts`` will be empty
+     and falls through to default; an operator running a
+     network-engaging probe (e.g. ``semgrep ci --dry-run`` against
+     a public registry pack) gets full host capture.
+  3. **Static default** — the four public Semgrep endpoints
+     (``semgrep.dev``, ``registry.semgrep.dev``, ``semgrep.app``,
+     ``api.semgrep.dev``).
+
+Empty calibrated values fall through to the next layer.
+
+The egress proxy enforces deny-by-default at runtime regardless of
+what this module returns.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Iterable, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+_OVERRIDE_CONFIG_PATH = (
+    Path.home() / ".config" / "raptor" / "semgrep-proxy-hosts.json"
+)
+
+
+# Static default — the public Semgrep endpoints scanner.py historically
+# hardcoded. Kept as a tuple so this module is a layered wrapper, not a
+# policy change at the bottom of the chain.
+_DEFAULT_SEMGREP_HOSTS: Tuple[str, ...] = (
+    "semgrep.dev",
+    "registry.semgrep.dev",
+    "semgrep.app",
+    "api.semgrep.dev",
+)
+
+
+# Env keys that discriminate the calibrate cache. ``SEMGREP_APP_TOKEN``
+# is the auth token for Semgrep Cloud Platform; an operator with one
+# token configured for org A and another for org B (rare but possible)
+# gets distinct cache entries. ``SEMGREP_RULES`` and
+# ``SEMGREP_RULES_CACHE`` shift the rule-fetch surface and
+# legitimately discriminate the binary's reach.
+_SEMGREP_ENV_KEYS: Tuple[str, ...] = (
+    "SEMGREP_APP_TOKEN",
+    "SEMGREP_RULES",
+    "SEMGREP_RULES_CACHE",
+)
+
+
+# Per-process memoisation. Calibration is sha-keyed on disk; without
+# this in-memory layer, every scanner-spawn in a /scan would stat the
+# cache file independently.
+_CALIBRATED_CACHE: "dict[str, Optional[object]]" = {}
+
+
+def _load_override() -> Optional[list[str]]:
+    """Return the operator override list, or None when no override
+    is configured. Tolerant: malformed JSON, non-UTF-8 bytes, or an
+    unexpected schema all degrade to None — production failure mode
+    is loud at the proxy (scanner subprocess fails with "host not
+    in allowlist"), not silent at startup."""
+    if not _OVERRIDE_CONFIG_PATH.exists():
+        return None
+    try:
+        data = json.loads(
+            _OVERRIDE_CONFIG_PATH.read_text(encoding="utf-8"),
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    hosts = data.get("hosts")
+    if not isinstance(hosts, list):
+        return None
+    seen: set = set()
+    result: list = []
+    for h in hosts:
+        if isinstance(h, str) and h and h not in seen:
+            seen.add(h)
+            result.append(h)
+    return result or None
+
+
+def _resolve_semgrep_bin() -> Optional[str]:
+    """Resolve ``semgrep`` to its absolute path via PATH. None when
+    not installed — calibration is impossible in that case so we
+    fall through to defaults."""
+    return shutil.which("semgrep")
+
+
+def _calibrated_profile():
+    """Load (or trigger calibration of) the SandboxProfile for the
+    semgrep binary. Returns None on any failure — calibration is
+    advisory; static layers carry the policy when it's unavailable.
+
+    Memoised per-process by resolved binary path.
+    """
+    bin_path = _resolve_semgrep_bin()
+    if bin_path is None:
+        return None
+    if bin_path in _CALIBRATED_CACHE:
+        return _CALIBRATED_CACHE[bin_path]
+
+    try:
+        from core.sandbox.calibrate import load_or_calibrate
+    except ImportError:
+        _CALIBRATED_CACHE[bin_path] = None
+        return None
+
+    try:
+        profile = load_or_calibrate(
+            bin_path,
+            probe_args=("--version",),
+            env_keys=_SEMGREP_ENV_KEYS,
+            timeout=20,
+        )
+    except (FileNotFoundError, RuntimeError, OSError,
+            subprocess.TimeoutExpired) as exc:
+        # ptrace blocked, libseccomp absent, binary deleted between
+        # which() and probe, or `semgrep --version` exceeded 20s
+        # under sandbox. Log at debug — calibration is advisory,
+        # static fallback stays in place.
+        logger.debug(
+            "semgrep proxy_hosts: calibration of %s failed (%s); "
+            "falling back to static policy",
+            bin_path, exc,
+        )
+        _CALIBRATED_CACHE[bin_path] = None
+        return None
+
+    _CALIBRATED_CACHE[bin_path] = profile
+    return profile
+
+
+def _calibrated_proxy_hosts() -> Optional[list[str]]:
+    """Calibrated layer — None when no profile exists OR the profile
+    carries an empty ``proxy_hosts`` list (the common case for
+    ``--version`` probes — they don't network)."""
+    profile = _calibrated_profile()
+    if profile is None or not getattr(profile, "proxy_hosts", None):
+        return None
+    return list(profile.proxy_hosts)
+
+
+def proxy_hosts_for_semgrep() -> list[str]:
+    """Egress-proxy hostname allowlist for the semgrep scanner
+    subprocess.
+
+    Three-layer resolution: operator override
+    (``~/.config/raptor/semgrep-proxy-hosts.json`` ``{"hosts": [...]}``)
+    → calibrated profile → static default. Returns a fresh list
+    each call.
+    """
+    override = _load_override()
+    if override is not None:
+        return override
+
+    calibrated = _calibrated_proxy_hosts()
+    if calibrated is not None:
+        return calibrated
+
+    return list(_DEFAULT_SEMGREP_HOSTS)
+
+
+def _reset_calibrate_cache_for_tests() -> None:
+    """Clear the per-process calibrate memo. Test-only — production
+    code never invalidates manually; the cache is sha-keyed and
+    re-loads on binary self-update via the sha mismatch check."""
+    _CALIBRATED_CACHE.clear()

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -282,14 +282,30 @@ def run_single_semgrep(
         # Engage Landlock via target + output. Writes pinned to out_dir
         # and /tmp. Reads Landlock-default-wide (semgrep is a
         # RAPTOR-chosen trusted tool, not attacker-controlled code).
-        # Network: route via the egress proxy with semgrep.dev on the
-        # allowlist — UDP blocked, hostname-allowlisted, resolved-IP-
-        # screened by the proxy's is_global check.
+        # Network: route via the egress proxy with the resolved
+        # allowlist — UDP blocked, hostname-allowlisted,
+        # resolved-IP-screened by the proxy's is_global check.
+        # Allowlist pulled from ._proxy_hosts (override → calibrate
+        # → static default) so operators on Semgrep self-hosted /
+        # corporate registry mirrors can override without source
+        # edits. See packages/static-analysis/_proxy_hosts.py.
+        #
+        # ``static-analysis`` is hyphenated → not importable as a
+        # Python package; scanner.py runs as ``__main__`` via
+        # subprocess. Load the helper via importlib at call time
+        # to match the existing convention (see tests under
+        # packages/static-analysis/tests/ for the same pattern).
+        import importlib.util as _importlib_util
+        _ph_path = Path(__file__).parent / "_proxy_hosts.py"
+        _ph_spec = _importlib_util.spec_from_file_location(
+            "static_analysis_proxy_hosts", _ph_path,
+        )
+        _ph = _importlib_util.module_from_spec(_ph_spec)
+        _ph_spec.loader.exec_module(_ph)
         rc, so, se = run(
             cmd, timeout=effective_timeout, env=clean_env,
             target=str(repo_path), output=str(out_dir),
-            proxy_hosts=["semgrep.dev", "registry.semgrep.dev",
-                         "semgrep.app", "api.semgrep.dev"],
+            proxy_hosts=_ph.proxy_hosts_for_semgrep(),
             caller_label="scanner-semgrep",
         )
 

--- a/packages/static-analysis/tests/test_proxy_hosts.py
+++ b/packages/static-analysis/tests/test_proxy_hosts.py
@@ -1,0 +1,321 @@
+"""Tests for ``packages.static_analysis._proxy_hosts``.
+
+Three-layer resolution: operator override → calibrated profile →
+static default. Same shape as the cc_dispatch / codeql / SCA
+consumers; tests cover one path per layer plus calibrate failure
+modes.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest import mock
+
+import pytest
+
+# Imported via the static-analysis package path (which exists as a
+# directory; underscore-resilient import).
+import importlib
+mod = importlib.import_module("packages.static-analysis._proxy_hosts")
+
+
+def _has_host(hosts: list, name: str) -> bool:
+    """Exact list-membership check via explicit ``==``. Phrased
+    this way (rather than ``name in hosts``) to defuse CodeQL's
+    ``py/incomplete-url-substring-sanitization`` regex, which
+    fires on the ``"<host>" in <var>`` shape regardless of
+    whether ``<var>`` is a list (this case — exact == match) or
+    a URL string (the substring-sanitization vulnerability the
+    rule actually targets)."""
+    return any(h == name for h in hosts)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    mod._reset_calibrate_cache_for_tests()
+    yield
+    mod._reset_calibrate_cache_for_tests()
+
+
+@pytest.fixture
+def override_config(tmp_path, monkeypatch):
+    cfg = tmp_path / "semgrep-proxy-hosts.json"
+    monkeypatch.setattr(mod, "_OVERRIDE_CONFIG_PATH", cfg)
+
+    def write(data):
+        cfg.write_text(json.dumps(data), encoding="utf-8")
+    return write
+
+
+# ---------------------------------------------------------------------
+# Static-default layer
+# ---------------------------------------------------------------------
+
+
+def test_default_when_no_override_no_calibration():
+    """Cold path: no override file, no resolvable binary → the
+    documented public-Semgrep set."""
+    with mock.patch.object(mod, "_resolve_semgrep_bin",
+                           return_value=None):
+        hosts = mod.proxy_hosts_for_semgrep()
+    assert hosts == [
+        "semgrep.dev", "registry.semgrep.dev",
+        "semgrep.app", "api.semgrep.dev",
+    ]
+
+
+def test_returns_fresh_list_each_call():
+    """Caller-mutation safety — scanner.py threads the list into a
+    sandbox call; a shared mutable would leak cross-call."""
+    with mock.patch.object(mod, "_resolve_semgrep_bin",
+                           return_value=None):
+        a = mod.proxy_hosts_for_semgrep()
+        b = mod.proxy_hosts_for_semgrep()
+    assert a == b
+    assert a is not b
+    a.append("mutation.example.com")
+    with mock.patch.object(mod, "_resolve_semgrep_bin",
+                           return_value=None):
+        c = mod.proxy_hosts_for_semgrep()
+    assert not _has_host(c, "mutation.example.com")
+
+
+# ---------------------------------------------------------------------
+# Override layer
+# ---------------------------------------------------------------------
+
+
+def test_override_takes_precedence(override_config):
+    """Override config beats default — operator on Semgrep
+    self-hosted / corporate registry mirror."""
+    override_config({"hosts": ["semgrep.corp.example.com"]})
+    hosts = mod.proxy_hosts_for_semgrep()
+    assert hosts == ["semgrep.corp.example.com"]
+
+
+def test_override_replaces_does_not_extend(override_config):
+    """The override REPLACES rather than extending — operator on
+    self-hosted typically wants to ban public Semgrep (no rule
+    leakage to public registry)."""
+    override_config({"hosts": ["semgrep.corp.example.com"]})
+    hosts = mod.proxy_hosts_for_semgrep()
+    assert not _has_host(hosts, "semgrep.dev")
+    assert hosts == ["semgrep.corp.example.com"]
+
+
+def test_override_dedupes_and_strips_garbage(override_config):
+    """Operator-edited config; tolerate hand-edit accidents."""
+    override_config({"hosts": [
+        "semgrep.corp.example.com",
+        "",                                  # empty — dropped
+        "semgrep.corp.example.com",          # duplicate — dropped
+        123,                                 # non-string — dropped
+        "mirror.corp.example.com",
+    ]})
+    hosts = mod.proxy_hosts_for_semgrep()
+    assert hosts == ["semgrep.corp.example.com",
+                     "mirror.corp.example.com"]
+
+
+def test_empty_override_falls_back_to_default(override_config):
+    """``{"hosts": []}`` falls through to default rather than
+    producing a deny-all allowlist."""
+    override_config({"hosts": []})
+    with mock.patch.object(mod, "_resolve_semgrep_bin",
+                           return_value=None):
+        hosts = mod.proxy_hosts_for_semgrep()
+    assert _has_host(hosts, "semgrep.dev")
+
+
+def test_override_missing_hosts_key_falls_back(override_config):
+    """Schema mismatch — treat as no override, not deny-all."""
+    override_config({"semgrep": ["semgrep.dev"]})
+    with mock.patch.object(mod, "_resolve_semgrep_bin",
+                           return_value=None):
+        hosts = mod.proxy_hosts_for_semgrep()
+    assert _has_host(hosts, "semgrep.dev")
+    assert len(hosts) == 4
+
+
+def test_override_malformed_json_falls_back(override_config):
+    """Corrupted JSON — degrade silently to default."""
+    mod._OVERRIDE_CONFIG_PATH.write_text(
+        "{not valid json", encoding="utf-8",
+    )
+    with mock.patch.object(mod, "_resolve_semgrep_bin",
+                           return_value=None):
+        hosts = mod.proxy_hosts_for_semgrep()
+    assert _has_host(hosts, "semgrep.dev")
+
+
+def test_override_non_utf8_falls_back(override_config):
+    """Operator pointed override path at a binary by mistake — must
+    not crash the scanner spawn."""
+    mod._OVERRIDE_CONFIG_PATH.write_bytes(
+        b"\xff\xfe\x00\x00 not utf-8",
+    )
+    with mock.patch.object(mod, "_resolve_semgrep_bin",
+                           return_value=None):
+        hosts = mod.proxy_hosts_for_semgrep()
+    assert _has_host(hosts, "semgrep.dev")
+
+
+# ---------------------------------------------------------------------
+# Calibrated layer
+# ---------------------------------------------------------------------
+
+
+def _profile(proxy_hosts):
+    """Stub object matching the SandboxProfile shape this module
+    reads (only ``proxy_hosts`` is consulted)."""
+    obj = mock.Mock()
+    obj.proxy_hosts = proxy_hosts
+    return obj
+
+
+def test_calibrated_proxy_hosts_used_when_populated():
+    """Operator ran a network-engaging probe → calibrated hosts win
+    over the static default."""
+    with mock.patch.object(mod, "_resolve_semgrep_bin",
+                           return_value="/fake/semgrep"), \
+         mock.patch.object(mod, "_calibrated_profile",
+                           return_value=_profile(
+                               ["semgrep.snapshot.example.com"])):
+        hosts = mod.proxy_hosts_for_semgrep()
+    assert hosts == ["semgrep.snapshot.example.com"]
+
+
+def test_calibrated_empty_proxy_hosts_falls_through_to_default():
+    """``--version`` calibration captures no network — falls through."""
+    with mock.patch.object(mod, "_resolve_semgrep_bin",
+                           return_value="/fake/semgrep"), \
+         mock.patch.object(mod, "_calibrated_profile",
+                           return_value=_profile([])):
+        hosts = mod.proxy_hosts_for_semgrep()
+    assert _has_host(hosts, "semgrep.dev")
+    assert len(hosts) == 4
+
+
+def test_calibrated_load_failure_falls_through_to_default():
+    """Calibration raising (RuntimeError, OSError, etc.) must NOT
+    propagate to the scanner — fall through cleanly."""
+    with mock.patch.object(mod, "_resolve_semgrep_bin",
+                           return_value="/fake/semgrep"), \
+         mock.patch(
+            "core.sandbox.calibrate.load_or_calibrate",
+            side_effect=RuntimeError("observe-mode unavailable"),
+         ):
+        hosts = mod.proxy_hosts_for_semgrep()
+    assert _has_host(hosts, "semgrep.dev")
+    assert len(hosts) == 4
+
+
+def test_calibrated_timeout_falls_through_to_default():
+    """``subprocess.TimeoutExpired`` from the calibration probe must
+    not crash the scanner. Empirically observed for some tools on
+    cold systems where ``--version`` exceeds 20s under sandbox."""
+    with mock.patch.object(mod, "_resolve_semgrep_bin",
+                           return_value="/fake/semgrep"), \
+         mock.patch(
+            "core.sandbox.calibrate.load_or_calibrate",
+            side_effect=subprocess.TimeoutExpired(
+                ["semgrep", "--version"], 20,
+            ),
+         ):
+        hosts = mod.proxy_hosts_for_semgrep()
+    assert _has_host(hosts, "semgrep.dev")
+
+
+def test_calibrated_filenotfound_falls_through_to_default():
+    """Binary deleted between which() and probe (semgrep
+    self-update race)."""
+    with mock.patch.object(mod, "_resolve_semgrep_bin",
+                           return_value="/fake/semgrep"), \
+         mock.patch(
+            "core.sandbox.calibrate.load_or_calibrate",
+            side_effect=FileNotFoundError("/fake/semgrep"),
+         ):
+        hosts = mod.proxy_hosts_for_semgrep()
+    assert _has_host(hosts, "semgrep.dev")
+
+
+def test_calibrate_per_process_memo_avoids_repeat_loads():
+    """Multiple scanner spawns during one /scan should hit the
+    in-memory memo, not re-stat the on-disk cache file each time."""
+    call_count = [0]
+
+    def _counting_load(*args, **kwargs):
+        call_count[0] += 1
+        return _profile([])
+
+    with mock.patch.object(mod, "_resolve_semgrep_bin",
+                           return_value="/fake/semgrep"), \
+         mock.patch(
+            "core.sandbox.calibrate.load_or_calibrate",
+            side_effect=_counting_load,
+         ):
+        for _ in range(5):
+            mod.proxy_hosts_for_semgrep()
+
+    assert call_count[0] == 1, (
+        f"expected 1 calibrate call across 5 invocations, "
+        f"got {call_count[0]} — memoisation broke"
+    )
+
+
+def test_calibration_includes_documented_env_keys():
+    """``SEMGREP_APP_TOKEN`` / ``SEMGREP_RULES`` /
+    ``SEMGREP_RULES_CACHE`` must be part of the calibrate cache key
+    so a binary used with two configs gets two distinct entries."""
+    captured = {}
+
+    def _capture_load(bin_path, **kwargs):
+        captured.update(kwargs)
+        return _profile([])
+
+    with mock.patch.object(mod, "_resolve_semgrep_bin",
+                           return_value="/fake/semgrep"), \
+         mock.patch(
+            "core.sandbox.calibrate.load_or_calibrate",
+            side_effect=_capture_load,
+         ):
+        mod.proxy_hosts_for_semgrep()
+
+    env_keys = tuple(captured.get("env_keys", ()))
+    assert "SEMGREP_APP_TOKEN" in env_keys
+    assert "SEMGREP_RULES" in env_keys
+    assert "SEMGREP_RULES_CACHE" in env_keys
+
+
+# ---------------------------------------------------------------------
+# scanner.py wiring
+# ---------------------------------------------------------------------
+
+
+def test_scanner_imports_proxy_hosts_for_semgrep():
+    """Scanner module imports the helper at the call site (deferred
+    import to avoid heavy load at module-import time)."""
+    scanner_path = (
+        __import__("pathlib").Path(__file__).resolve()
+        .parent.parent / "scanner.py"
+    )
+    text = scanner_path.read_text(encoding="utf-8")
+    assert "proxy_hosts_for_semgrep" in text
+
+
+def test_scanner_no_longer_hardcodes_semgrep_hosts():
+    """Migration pin — if a future change reverts the call site to
+    a hardcoded list, this test catches it."""
+    scanner_path = (
+        __import__("pathlib").Path(__file__).resolve()
+        .parent.parent / "scanner.py"
+    )
+    text = scanner_path.read_text(encoding="utf-8")
+    # The historical hardcoded list shape — looking for a literal
+    # tuple/list of the four hosts together.
+    assert 'proxy_hosts=["semgrep.dev", "registry.semgrep.dev"' \
+        not in text, (
+            "scanner.py reverted to hardcoded semgrep proxy_hosts; "
+            "should route through proxy_hosts_for_semgrep()"
+        )


### PR DESCRIPTION
`packages/static-analysis/scanner.py:291` hardcoded the four public Semgrep registry hosts (`semgrep.dev`, `registry.semgrep.dev`, `semgrep.app`, `api.semgrep.dev`) inline. Shops on Semgrep self-hosted / AppSec Platform / a corporate registry mirror had no way to scan through RAPTOR without editing source.

Add `packages/static-analysis/_proxy_hosts.py` with three-layer resolution: operator override (`~/.config/raptor/semgrep-proxy-hosts.json`, schema `{"hosts": [...]}`) → calibrated profile via `load_or_calibrate(semgrep, --version)` (cache-keyed on `SEMGREP_APP_TOKEN` / `SEMGREP_RULES` / `SEMGREP_RULES_CACHE`) → static default (the same four hosts as before). Override REPLACES default — operators on self-hosted typically want to ban public Semgrep (no rule leakage to public registry).

Same shape as `cc_proxy_hosts` (#416) / `codeql_proxy_hosts` (#418) / git/_proxy_hosts (#436) — semgrep fits the binary-scoped pattern because hosts are version-evolving (`api.semgrep.dev` was added more recently than `semgrep.dev`).

`packages/static-analysis` is hyphenated — `scanner.py` runs as `__main__` via subprocess so relative imports don't resolve. Helper loaded at call-time via `importlib.util.spec_from_file_location`, matching the existing test-file convention for the same package.

18 tests cover override precedence/replacement/dedup/garbage tolerance/malformed JSON/non-UTF-8/missing-key/non-dict fallthrough, calibrated populate/empty/RuntimeError/TimeoutExpired/FileNotFound fallthrough, per-process memo, env-key fingerprinting, and scanner.py call-site wiring (import + no-hardcoded-list pin). 73 pre-existing scanner tests still pass; 91/91 in `packages/static-analysis/tests/` total.

Test file uses the `_has_host()` helper convention from #436 to defuse CodeQL's `py/incomplete-url-substring-sanitization` regex on `assert "<host>" in <list>` shapes.