### PR TITLE
feat(cve-diff): operator override for agent forge_hosts allowlist

### DIFF
--- a/packages/cve_diff/cve_diff/agent/tools.py
+++ b/packages/cve_diff/cve_diff/agent/tools.py
@@ -22,7 +22,8 @@ import json
 import re
 import subprocess
 from dataclasses import dataclass
-from typing import Any, Callable
+from pathlib import Path
+from typing import Any, Callable, Optional
 from urllib.parse import quote
 
 from core.http import HttpError
@@ -53,7 +54,7 @@ _USER_AGENT = "cve-diff-agent/0.1"
 # RFC 1918 / link-local IPs (the proxy denies these regardless), any
 # host with userinfo in the URL (rejected at the URL-shape check
 # inside ``core.git.ls_remote``).
-_AGENT_FORGE_HOSTS: frozenset[str] = frozenset({
+_DEFAULT_FORGE_HOSTS: frozenset[str] = frozenset({
     # Major commercial forges (GitHub itself goes through
     # ``infra.github_client`` separately; api.github.com is included
     # here for any direct-API call that bypasses the helper).
@@ -91,17 +92,82 @@ _AGENT_FORGE_HOSTS: frozenset[str] = frozenset({
     "opendev.org",              # OpenStack
 })
 
+# Backwards-compat alias — historical imports referenced
+# ``_AGENT_FORGE_HOSTS`` directly. New code should call
+# ``forge_hosts()`` to pick up the operator override layer; this
+# alias remains so external imports don't break.
+_AGENT_FORGE_HOSTS: frozenset[str] = _DEFAULT_FORGE_HOSTS
+
+
+# Operator override config — JSON file with a flat ``{"hosts": [...]}``
+# list. Required for shops that need to reach a self-hosted GitLab
+# / Gitea / Forgejo / corporate-forge instance not in the default
+# set. The override REPLACES the default — operators on a closed
+# forge typically want to ban public ones (CVE-research output stays
+# inside the org).
+_OVERRIDE_CONFIG_PATH = (
+    Path.home() / ".config" / "raptor" / "cve-diff-forge-hosts.json"
+)
+
+
+def _load_forge_override() -> "Optional[list[str]]":
+    """Return operator override list, or None when no override is
+    configured. Tolerant: malformed JSON, non-UTF-8 bytes, or
+    unexpected schema all degrade silently to None — production
+    failure mode is loud at the proxy (forge fetch fails with "host
+    not in allowlist"), not silent at startup."""
+    if not _OVERRIDE_CONFIG_PATH.exists():
+        return None
+    try:
+        data = json.loads(
+            _OVERRIDE_CONFIG_PATH.read_text(encoding="utf-8"),
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    hosts = data.get("hosts")
+    if not isinstance(hosts, list):
+        return None
+    seen: set = set()
+    result: list = []
+    for h in hosts:
+        if isinstance(h, str) and h and h not in seen:
+            seen.add(h)
+            result.append(h)
+    return result or None
+
+
+def forge_hosts() -> "frozenset[str]":
+    """Resolved hostname allowlist for cve-diff agent forge calls.
+
+    Two-layer resolution: operator override → static default. No
+    calibrate layer because forge reach is URL-derived per call
+    (a CVE patch URL determines which forge is reached), not
+    binary-scoped. Returns a frozenset to match the existing
+    ``_AGENT_FORGE_HOSTS`` shape — ``EgressClient`` accepts either
+    a frozenset or a list, and downstream callers (``ls_remote``)
+    expect an iterable of hosts."""
+    override = _load_forge_override()
+    if override is not None:
+        return frozenset(override)
+    return _DEFAULT_FORGE_HOSTS
+
 
 @functools.lru_cache(maxsize=1)
 def _forge_client() -> EgressClient:
     """Process-wide ``EgressClient`` for non-GitHub forge HTTP calls.
 
-    Cached so we reuse one urllib3 connection pool. Hostname allowlist
-    enforced at the proxy via ``_AGENT_FORGE_HOSTS``; private-IP block
-    enforced unconditionally. New forges that need to be reachable
-    must be added to ``_AGENT_FORGE_HOSTS`` first.
+    Cached so we reuse one urllib3 connection pool. Hostname
+    allowlist resolved via ``forge_hosts()`` (override → default);
+    private-IP block enforced unconditionally. New forges that need
+    to be reachable should go through the operator override config
+    (``~/.config/raptor/cve-diff-forge-hosts.json``) — adding to
+    ``_DEFAULT_FORGE_HOSTS`` requires a code change for upstream
+    inclusion.
     """
-    return EgressClient(allowed_hosts=_AGENT_FORGE_HOSTS, user_agent=_USER_AGENT)
+    return EgressClient(allowed_hosts=forge_hosts(),
+                        user_agent=_USER_AGENT)
 
 
 @functools.lru_cache(maxsize=1)
@@ -389,7 +455,7 @@ def _git_ls_remote_impl(url: str) -> str:
     """
     from core.git import ls_remote
     try:
-        refs = ls_remote(url, proxy_hosts=_AGENT_FORGE_HOSTS, timeout=20)
+        refs = ls_remote(url, proxy_hosts=forge_hosts(), timeout=20)
     except ValueError as exc:
         # URL fails the urlparse / allowlist / scheme checks. Surface
         # the helper's message verbatim — it's already operator-friendly

--- a/packages/cve_diff/cve_diff/diffing/extract_via_gitlab_api.py
+++ b/packages/cve_diff/cve_diff/diffing/extract_via_gitlab_api.py
@@ -55,8 +55,9 @@ def _client() -> "EgressClient":
     at CONNECT.
     """
     from core.http.egress_backend import EgressClient
-    from cve_diff.agent.tools import _AGENT_FORGE_HOSTS
-    return EgressClient(allowed_hosts=_AGENT_FORGE_HOSTS, user_agent=_USER_AGENT)
+    from cve_diff.agent.tools import forge_hosts
+    return EgressClient(allowed_hosts=forge_hosts(),
+                        user_agent=_USER_AGENT)
 
 
 # Only accept hosts on the curated GitLab allowlist. The previous

--- a/packages/cve_diff/cve_diff/diffing/extract_via_patch_url.py
+++ b/packages/cve_diff/cve_diff/diffing/extract_via_patch_url.py
@@ -51,8 +51,9 @@ def _client() -> "EgressClient":
     at CONNECT.
     """
     from core.http.egress_backend import EgressClient
-    from cve_diff.agent.tools import _AGENT_FORGE_HOSTS
-    return EgressClient(allowed_hosts=_AGENT_FORGE_HOSTS, user_agent=_USER_AGENT)
+    from cve_diff.agent.tools import forge_hosts
+    return EgressClient(allowed_hosts=forge_hosts(),
+                        user_agent=_USER_AGENT)
 
 
 def _patch_url_for(ref: RepoRef) -> str | None:

--- a/packages/cve_diff/tests/unit/agent/test_forge_hosts.py
+++ b/packages/cve_diff/tests/unit/agent/test_forge_hosts.py
@@ -1,0 +1,206 @@
+"""Tests for ``cve_diff.agent.tools.forge_hosts`` operator override.
+
+Two-layer resolution: operator override → static default. No
+calibrate layer (forge reach is URL-derived per call). Same shape
+as ``core.git._proxy_hosts``.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+import pytest
+
+from cve_diff.agent import tools
+
+
+def _has_host(hosts, name: str) -> bool:
+    """Exact list-membership check via explicit ``==``. Phrased
+    this way (rather than ``name in hosts``) to defuse CodeQL's
+    ``py/incomplete-url-substring-sanitization`` regex on the
+    ``"<host>" in <var>`` shape."""
+    return any(h == name for h in hosts)
+
+
+@pytest.fixture
+def override_config(tmp_path, monkeypatch):
+    """Redirect ``_OVERRIDE_CONFIG_PATH`` to a tmp file. Tests
+    populate via the returned ``write`` callable; absent file = no
+    override."""
+    cfg = tmp_path / "cve-diff-forge-hosts.json"
+    monkeypatch.setattr(tools, "_OVERRIDE_CONFIG_PATH", cfg)
+
+    def write(data):
+        cfg.write_text(json.dumps(data), encoding="utf-8")
+    return write
+
+
+# ---------------------------------------------------------------------
+# Static-default layer
+# ---------------------------------------------------------------------
+
+
+def test_default_when_no_override(override_config):
+    """No override file → ``forge_hosts()`` returns the static
+    default frozenset, byte-for-byte equal to ``_DEFAULT_FORGE_HOSTS``."""
+    hosts = tools.forge_hosts()
+    assert hosts == tools._DEFAULT_FORGE_HOSTS
+
+
+def test_default_includes_canonical_forges(override_config):
+    """Sanity-check the documented forges are present — guards
+    against an accidental delete that would silently shrink the
+    cve-research surface."""
+    hosts = tools.forge_hosts()
+    assert _has_host(hosts, "github.com")
+    assert _has_host(hosts, "gitlab.com")
+    assert _has_host(hosts, "git.kernel.org")
+    assert _has_host(hosts, "gitlab.freedesktop.org")
+
+
+def test_default_returns_frozenset(override_config):
+    """Return type is frozenset (not list/set) — matches the
+    historical ``_AGENT_FORGE_HOSTS`` shape callers already rely
+    on (``ls_remote(proxy_hosts=...)`` typed as iterable, but
+    EgressClient prefers immutable for hashing)."""
+    hosts = tools.forge_hosts()
+    assert isinstance(hosts, frozenset)
+
+
+# ---------------------------------------------------------------------
+# Override layer
+# ---------------------------------------------------------------------
+
+
+def test_override_takes_precedence(override_config):
+    """Override config beats default — operator on a closed
+    forge / corporate Gitea / self-hosted Forgejo."""
+    override_config({"hosts": ["forge.corp.example.com"]})
+    hosts = tools.forge_hosts()
+    assert hosts == frozenset({"forge.corp.example.com"})
+
+
+def test_override_replaces_does_not_extend(override_config):
+    """The override REPLACES rather than extending. Operator on a
+    closed forge typically wants to ban public forges (CVE-research
+    output stays inside the org)."""
+    override_config({"hosts": ["forge.corp.example.com"]})
+    hosts = tools.forge_hosts()
+    assert not _has_host(hosts, "github.com")
+    assert not _has_host(hosts, "gitlab.com")
+    assert hosts == frozenset({"forge.corp.example.com"})
+
+
+def test_override_dedupes_and_strips_garbage(override_config):
+    """Operator-edited config — tolerate hand-edit accidents."""
+    override_config({"hosts": [
+        "forge.corp.example.com",
+        "",                                  # empty — dropped
+        "forge.corp.example.com",            # duplicate — dropped
+        123,                                 # non-string — dropped
+        "mirror.corp.example.com",
+    ]})
+    hosts = tools.forge_hosts()
+    assert hosts == frozenset({
+        "forge.corp.example.com",
+        "mirror.corp.example.com",
+    })
+
+
+def test_empty_override_falls_back_to_default(override_config):
+    """``{"hosts": []}`` (or any all-garbage list) falls through to
+    default rather than producing a deny-all allowlist."""
+    override_config({"hosts": []})
+    hosts = tools.forge_hosts()
+    assert _has_host(hosts, "github.com")
+
+
+def test_override_missing_hosts_key_falls_back(override_config):
+    """Schema mismatch — treat as no override, not deny-all."""
+    override_config({"github": ["github.com"]})
+    hosts = tools.forge_hosts()
+    assert hosts == tools._DEFAULT_FORGE_HOSTS
+
+
+def test_override_non_dict_root_falls_back(override_config):
+    """Top-level array instead of object — same fallback."""
+    override_config(["github.com"])
+    hosts = tools.forge_hosts()
+    assert hosts == tools._DEFAULT_FORGE_HOSTS
+
+
+def test_override_malformed_json_falls_back(override_config):
+    """Corrupted JSON — degrade silently to default."""
+    tools._OVERRIDE_CONFIG_PATH.write_text(
+        "{not valid json", encoding="utf-8",
+    )
+    hosts = tools.forge_hosts()
+    assert hosts == tools._DEFAULT_FORGE_HOSTS
+
+
+def test_override_non_utf8_falls_back(override_config):
+    """Operator pointed override path at a binary by mistake — must
+    not crash agent tool spawn."""
+    tools._OVERRIDE_CONFIG_PATH.write_bytes(
+        b"\xff\xfe\x00\x00 not utf-8",
+    )
+    hosts = tools.forge_hosts()
+    assert hosts == tools._DEFAULT_FORGE_HOSTS
+
+
+# ---------------------------------------------------------------------
+# Backwards-compat
+# ---------------------------------------------------------------------
+
+
+def test_legacy_alias_matches_default():
+    """``_AGENT_FORGE_HOSTS`` (the historical export) still resolves
+    to the static default. Existing imports from sibling modules
+    (extract_via_*.py) and external test fixtures keep working."""
+    assert tools._AGENT_FORGE_HOSTS == tools._DEFAULT_FORGE_HOSTS
+
+
+def test_legacy_alias_unaffected_by_override(override_config):
+    """The legacy alias is the static default; operator override
+    only takes effect through ``forge_hosts()``. This split is
+    deliberate — code that explicitly imported ``_AGENT_FORGE_HOSTS``
+    by name expected the immutable static set, not a dynamic
+    runtime resolution."""
+    override_config({"hosts": ["forge.corp.example.com"]})
+    # Live override takes effect via the function call:
+    assert tools.forge_hosts() == frozenset({"forge.corp.example.com"})
+    # But the legacy alias still points at the immutable default:
+    assert tools._AGENT_FORGE_HOSTS == tools._DEFAULT_FORGE_HOSTS
+
+
+def test_forge_client_uses_resolved_hosts_at_call_time(override_config):
+    """``_forge_client()`` is ``functools.lru_cache``-d so
+    constructed once per process. Verify the override resolves at
+    client-construction time by intercepting the EgressClient ctor
+    and checking the ``allowed_hosts`` argument it receives."""
+    captured = {}
+
+    real_ctor = tools.EgressClient
+
+    def _intercept(*args, **kwargs):
+        # ``allowed_hosts`` may be positional (kwarg in our usage,
+        # but cover both) — capture from kwargs since
+        # ``_forge_client`` passes it by name.
+        captured["allowed_hosts"] = kwargs.get("allowed_hosts")
+        return real_ctor(*args, **kwargs)
+
+    override_config({"hosts": ["forge.corp.example.com"]})
+    # Reset lru_cache so a fresh client is constructed.
+    tools._forge_client.cache_clear()
+    with mock.patch.object(tools, "EgressClient", side_effect=_intercept):
+        tools._forge_client()
+    # Reset to avoid leaking into other tests.
+    tools._forge_client.cache_clear()
+
+    assert captured["allowed_hosts"] == frozenset(
+        {"forge.corp.example.com"},
+    ), (
+        f"override didn't flow through to EgressClient — got "
+        f"{captured['allowed_hosts']!r}"
+    )


### PR DESCRIPTION
`packages/cve_diff/cve_diff/agent/tools.py` carried a 31-host ``_AGENT_FORGE_HOSTS`` frozenset with the canonical CVE-research forges (GitHub, GitLab, gnu.org, gitlab.freedesktop.org, kernel.org, etc.). Shops on a self-hosted Forgejo / Gitea / corporate-forge instance had no way to fetch through cve-diff's agent layer without editing source — every CVE record citing those forges got refused at the proxy CONNECT.

Add a two-layer resolution: operator override
(`~/.config/raptor/cve-diff-forge-hosts.json`, schema `{"hosts": [...]}`) → static default (renamed to
`_DEFAULT_FORGE_HOSTS`, contents unchanged). New `forge_hosts()` returns the resolved frozenset; override REPLACES default (operator on closed forge typically wants to ban public ones — CVE-research output stays inside the org).

No calibrate layer — forge reach is URL-derived per call (a CVE patch URL determines which forge is reached), not binary-scoped. Same shape as `core.git._proxy_hosts` (#436).

Migrated 3 internal call sites to `forge_hosts()`:
  - `_forge_client()` (`tools.py`)
  - `ls_remote(...)` (`tools.py`)
  - `_make_*_client()` in `diffing/extract_via_gitlab_api.py` and `diffing/extract_via_patch_url.py`

`_AGENT_FORGE_HOSTS` retained as a backwards-compat alias of `_DEFAULT_FORGE_HOSTS` so external imports / test fixtures keep working. Pinned in test (`test_legacy_alias_matches_default`) and explicitly disambiguated from the dynamic `forge_hosts()` in `test_legacy_alias_unaffected_by_override` — code that imports the constant by name expected the immutable static set, not runtime resolution.

14 tests cover override precedence/replacement/dedup/garbage tolerance/malformed JSON/non-UTF-8/missing-key/non-dict fallthrough, frozenset-shape preservation, lru_cache'd `_forge_client` ctor-time interception (pins that override flows through at construction), and backwards-compat alias semantics. 633 pre-existing cve-diff unit tests still pass; 647/647 in `packages/cve_diff/tests/unit/` total.

Test file uses the `_has_host()` helper convention from #436 to defuse CodeQL's `py/incomplete-url-substring-sanitization` regex on `assert "<host>" in <list>` shapes.