### PR TITLE
feat(iris+exploit): SMT path-feasibility gate — /agentic Tier 4 + /ex…

### DIFF
--- a/core/llm/tests/test_response_validation.py
+++ b/core/llm/tests/test_response_validation.py
@@ -460,6 +460,12 @@ class TestValidateDataflowSchema:
             "cvss_estimate": 7.5,
             "false_positive": False,
             "false_positive_reason": "",
+            # SMT path-feasibility fields (added in PR #?). Optional and
+            # nullable; XSS is not a memory-corruption CWE so the LLM
+            # leaves them null. Including them here proves a "perfect"
+            # response with explicit nulls still scores 1.0.
+            "path_conditions": None,
+            "path_profile": None,
         }
         result = validate_structured_response(raw, DATAFLOW_VALIDATION_SCHEMA)
         assert result.quality == 1.0

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -866,6 +866,71 @@ class AutonomousSecurityAgentV2:
             logger.debug(f"Tier 1 gate: check raised: {e}")
             return "no_check"
 
+    def _smt_pre_flight(self, vuln: VulnerabilityContext) -> str:
+        """Free SMT path-feasibility check using the LLM-extracted
+        ``path_conditions`` / ``path_profile`` fields on this finding's
+        analysis. Same shape as ``_tier1_pre_flight`` but reads SMT
+        instead of CodeQL.
+
+        Returns one of "refuted" / "confirmed" / "no_check":
+
+          "refuted"   — SMT proved the conditions mutually exclusive;
+                        the dangerous path is unreachable. Caller
+                        should skip downstream LLM cost.
+          "confirmed" — SMT found a satisfying assignment. Path is
+                        reachable; falls through to exploit gen as
+                        before. (Witness model is also recorded in
+                        the analysis dict for downstream PoC seeding
+                        in a future PR.)
+          "no_check"  — no path_conditions on the analysis OR Z3 not
+                        installed OR conditions unparseable. Same
+                        meaning as the IRIS gate's no_check: caller
+                        proceeds without information.
+
+        Never raises — any failure mode returns "no_check" so the
+        exploit pipeline is never broken by SMT issues.
+        """
+        analysis = vuln.analysis or {}
+        # Same field-precedence as Tier 4 (`_tier4_smt_refine` in
+        # dataflow_validation.py): nested deep-validation block wins
+        # over top-level analysis.
+        nested = analysis.get("dataflow_validation") or {}
+        conditions = (
+            nested.get("path_conditions")
+            or analysis.get("path_conditions")
+            or []
+        )
+        if not conditions:
+            return "no_check"
+        profile = (
+            nested.get("path_profile")
+            or analysis.get("path_profile")
+            or "uint64"
+        ).strip().lower()
+
+        try:
+            from packages.exploit_feasibility.smt_path import validate_path
+        except ImportError as e:
+            logger.debug(f"SMT pre-flight: substrate unavailable: {e}")
+            return "no_check"
+
+        try:
+            smt = validate_path(conditions, profile=profile)
+        except Exception as e:
+            logger.debug(f"SMT pre-flight: check raised: {e}")
+            return "no_check"
+
+        if not smt.get("smt_available"):
+            return "no_check"
+
+        feasible = smt.get("feasible")
+        if feasible is False:
+            return "refuted"
+        if feasible is True:
+            return "confirmed"
+        # feasible is None — Z3 timed out / all conditions unparseable.
+        return "no_check"
+
     def generate_exploit(self, vuln: VulnerabilityContext) -> bool:
 
         if not vuln.exploitable:
@@ -889,6 +954,27 @@ class AutonomousSecurityAgentV2:
             vuln.analysis["exploit_skipped_reason"] = (
                 "iris_tier1_refuted: Tier 1 LocalFlowSource query "
                 "found no path; no LLM tokens spent"
+            )
+            return False
+
+        # SMT pre-flight gate — free Z3 check using the same
+        # `path_conditions` field that /agentic --validate-dataflow
+        # Tier 4 reads. Fires only when the per-finding analysis
+        # populated path_conditions (typically CWE-190/125/787/476/191).
+        # Refute on unsat → skip exploit gen for free. Mirrors the IRIS
+        # Tier 1 gate above; same fail-open semantics (any failure
+        # → no_check → fall through).
+        smt_gate = self._smt_pre_flight(vuln)
+        if smt_gate == "refuted":
+            logger.info(
+                f"⊘ Skipping exploit generation: SMT proved path "
+                f"conditions unsatisfiable for {vuln.rule_id} at "
+                f"{vuln.file_path}:{vuln.start_line}"
+            )
+            vuln.analysis = (vuln.analysis or {})
+            vuln.analysis["exploit_skipped_reason"] = (
+                "smt_unsat: path conditions are mutually exclusive; "
+                "the dangerous path is unreachable. No LLM tokens spent."
             )
             return False
 

--- a/packages/llm_analysis/dataflow_validation.py
+++ b/packages/llm_analysis/dataflow_validation.py
@@ -536,6 +536,27 @@ def validate_dataflow_claims(
         elif tier_used == "retry":
             metrics["n_tier3_retry"] += 1
 
+        # ----- Tier 4: SMT path-feasibility refinement -----
+        # Reads `path_conditions` + `path_profile` from the LLM analysis
+        # (added in this PR's schema extension). Conservative refinement:
+        # may upgrade `inconclusive` → `refuted` when SMT proves the
+        # conditions are unsatisfiable, and may attach a witness model
+        # to `confirmed` for downstream consumers (/exploit). NEVER
+        # downgrades `confirmed` → `refuted` on SMT alone — when CodeQL
+        # and SMT disagree the more conservative CodeQL signal wins
+        # (logged as a disagreement metric for offline review).
+        result, smt_outcome = _tier4_smt_refine(result, finding, analysis)
+        if smt_outcome and smt_outcome != "no_check":
+            metrics.setdefault("n_tier4_smt_refuted", 0)
+            metrics.setdefault("n_tier4_smt_witness", 0)
+            metrics.setdefault("n_tier4_smt_disagree", 0)
+            if smt_outcome == "smt_refuted":
+                metrics["n_tier4_smt_refuted"] += 1
+            elif smt_outcome == "smt_witness":
+                metrics["n_tier4_smt_witness"] += 1
+            elif smt_outcome == "smt_disagree":
+                metrics["n_tier4_smt_disagree"] += 1
+
         cache[cache_key] = result
         metrics["n_validated"] += 1
         _attach_result(analysis, result)
@@ -1091,6 +1112,151 @@ def _is_compile_error(error_text: str) -> bool:
     if not error_text:
         return False
     return any(marker in error_text for marker in _COMPILE_ERROR_MARKERS)
+
+
+def _tier4_smt_refine(
+    result: "ValidationResult",
+    finding: Dict,
+    analysis: Dict,
+) -> "tuple[ValidationResult, str]":
+    """Tier 4: SMT path-feasibility refinement on a Tier 1/2/3 result.
+
+    Reads the LLM's `path_conditions` and `path_profile` (added in
+    PR-G+ schema extension) from either:
+      * `analysis['dataflow_validation']` (deep-validation output), or
+      * `analysis` (top-level analysis output).
+
+    Conservative refinement rules:
+      * `inconclusive` + SMT proves unsat → `refuted` (with unsat-core
+        as evidence)
+      * `confirmed` + SMT proves sat → keep `confirmed`, attach witness
+        model as additional evidence (downstream /exploit uses this as
+        a PoC seed)
+      * `confirmed` + SMT proves unsat → DISAGREEMENT — keep `confirmed`
+        (CodeQL-found path is the conservative signal), log + count as
+        disagreement metric for offline review
+      * Anything else → no change
+
+    Returns (possibly-refined ValidationResult, outcome label).
+    Outcome label is one of: "no_check", "smt_unavailable", "smt_error",
+    "smt_no_change", "smt_refuted", "smt_witness", "smt_disagree".
+
+    Never raises — failure modes (Z3 missing, conditions unparseable,
+    parser exception) all fall through to "no_check" / "smt_unavailable"
+    / "smt_error" so production callers stay unaffected.
+    """
+    dataflow_validation = (analysis or {}).get("dataflow_validation") or {}
+    conditions = (
+        dataflow_validation.get("path_conditions")
+        or (analysis or {}).get("path_conditions")
+        or []
+    )
+    if not conditions:
+        return result, "no_check"
+    profile_name = (
+        dataflow_validation.get("path_profile")
+        or (analysis or {}).get("path_profile")
+        or "uint64"
+    ).strip().lower()
+
+    try:
+        from packages.exploit_feasibility.smt_path import validate_path
+    except ImportError as e:
+        logger.debug("Tier 4 SMT: substrate unavailable: %s", e)
+        return result, "smt_unavailable"
+
+    try:
+        smt = validate_path(conditions, profile=profile_name)
+    except (ValueError, TypeError) as e:
+        # Bad profile name / malformed condition — treat as no signal
+        # rather than crashing the whole tier loop.
+        logger.debug("Tier 4 SMT: input rejected: %s", e)
+        return result, "smt_error"
+    except Exception as e:
+        logger.debug("Tier 4 SMT: check raised: %s", e)
+        return result, "smt_error"
+
+    if not smt.get("smt_available"):
+        return result, "smt_unavailable"
+
+    # Build a one-line evidence record describing the SMT outcome.
+    # Goes onto the existing ValidationResult.evidence list so the
+    # report renderer + /exploit downstream can see why the verdict
+    # was refined.
+    def _smt_evidence(label: str, summary: str) -> Evidence:
+        return Evidence(
+            tool="smt",
+            rule="path-feasibility",
+            summary=summary,
+            matches=[],
+            success=True,
+            error=None,
+        )
+
+    feasible = smt.get("feasible")
+    unsat_list = smt.get("unsatisfied") or []
+    model = smt.get("model") or {}
+
+    # Decision matrix.
+    if feasible is False:
+        unsat = ", ".join(unsat_list) or "(no specific core)"
+        if result.verdict == "inconclusive":
+            ev = _smt_evidence(
+                "refuted",
+                f"SMT proved path conditions unsatisfiable; conflict: {unsat}",
+            )
+            refined = ValidationResult(
+                verdict="refuted",
+                evidence=list(result.evidence) + [ev],
+                iterations=result.iterations,
+                reasoning=(
+                    (result.reasoning or "") +
+                    "\n[smt] inconclusive → refuted: unsat path conditions"
+                ),
+            )
+            return refined, "smt_refuted"
+        if result.verdict == "confirmed":
+            # SMT-CodeQL disagreement. Keep CodeQL's signal (conservative)
+            # but record the divergence.
+            logger.warning(
+                "Tier 4 SMT-CodeQL disagreement on %s: CodeQL confirmed but "
+                "SMT proves path conditions unsat (conflict: %s). Keeping "
+                "CodeQL verdict.",
+                finding.get("finding_id") or finding.get("file_path"),
+                unsat,
+            )
+            ev = _smt_evidence(
+                "disagreement",
+                f"SMT-CodeQL disagreement: SMT unsat (conflict: {unsat})",
+            )
+            refined = ValidationResult(
+                verdict=result.verdict,
+                evidence=list(result.evidence) + [ev],
+                iterations=result.iterations,
+                reasoning=result.reasoning,
+            )
+            return refined, "smt_disagree"
+
+    if feasible is True and result.verdict == "confirmed":
+        model_str = ", ".join(f"{k}={v}" for k, v in model.items())
+        ev = _smt_evidence(
+            "witness",
+            f"SMT witness for path conditions: {model_str or '(no model)'}",
+        )
+        refined = ValidationResult(
+            verdict=result.verdict,
+            evidence=list(result.evidence) + [ev],
+            iterations=result.iterations,
+            reasoning=(
+                (result.reasoning or "") +
+                f"\n[smt] confirmed + witness: {model_str}"
+            ),
+        )
+        return refined, "smt_witness"
+
+    # feasible is None (Z3 unavailable / conditions unparseable)
+    # or no actionable change. Leave the verdict alone.
+    return result, "smt_no_change"
 
 
 def _wrap_result(

--- a/packages/llm_analysis/prompts/schemas.py
+++ b/packages/llm_analysis/prompts/schemas.py
@@ -34,6 +34,27 @@ DATAFLOW_SCHEMA_FIELDS = {
     "sanitizers_effective": "boolean - are sanitizers in the path effective?",
     "sanitizer_bypass_technique": "string - how to bypass sanitizers, or empty if effective",
     "dataflow_exploitable": "boolean - is the complete dataflow path exploitable?",
+    # SMT path-feasibility hooks (populated only for memory-corruption /
+    # arithmetic / bounds CWEs: 190, 125, 787, 476, 191). When present
+    # the orchestrator's Tier 4 gate uses Z3 to refute findings whose
+    # path conditions are unsatisfiable and to attach a witness model
+    # to confirmed findings (used downstream by /exploit as a PoC seed).
+    # Empty / missing → Tier 4 no-ops; nothing requires these fields.
+    "path_conditions": (
+        "list of strings or null - SMT-checkable branch conditions on the "
+        "dangerous path. Each entry is a single predicate the parser "
+        "accepts: e.g. 'count > 0x10000000', 'alloc_size == count * 16', "
+        "'index >= buffer_size', 'ptr == NULL'. Populate ONLY for memory-"
+        "corruption / arithmetic / bounds / null-deref CWEs (190, 125, 787, "
+        "476, 191); use null or empty list otherwise — the field is "
+        "optional and absence does not dock response quality."
+    ),
+    "path_profile": (
+        "string or null - bitvector profile for SMT encoding. One of: "
+        "'uint64' (default — sizes/offsets/counts), 'uint32' (CWE-190 "
+        "wraparound), 'int32' / 'int64' (signed integer paths). Only "
+        "meaningful when path_conditions is non-empty; null otherwise."
+    ),
 }
 
 # Schema for deep dataflow validation — used by agent.py's validate_dataflow
@@ -56,6 +77,21 @@ DATAFLOW_VALIDATION_SCHEMA = {
     "cvss_estimate": "float (0.0-10.0) - severity score",
     "false_positive": "boolean - is this a false positive?",
     "false_positive_reason": "string - why it's false positive, or empty",
+    # SMT path-feasibility hooks — see DATAFLOW_SCHEMA_FIELDS for the
+    # full description. Same semantics; carried in the deep-validation
+    # output too so the Tier 4 gate sees them whichever LLM call
+    # produced them.
+    "path_conditions": (
+        "list of strings or null - SMT-checkable branch conditions on the "
+        "dangerous path. Populate for memory-corruption / arithmetic / "
+        "bounds / null-deref CWEs (190, 125, 787, 476, 191); null or "
+        "empty list otherwise — optional, absence does not dock quality."
+    ),
+    "path_profile": (
+        "string or null - bitvector profile: uint64 (default), uint32 "
+        "(wraparound), int32, int64. Only meaningful with non-empty "
+        "path_conditions; null otherwise."
+    ),
 }
 
 # JSON Schema for CC sub-agent structured output (claude -p --json-schema).

--- a/packages/llm_analysis/tests/test_agentic_dv_reporting.py
+++ b/packages/llm_analysis/tests/test_agentic_dv_reporting.py
@@ -166,3 +166,47 @@ def test_no_tier_breakdown_when_all_zero():
     assert "By tier:" not in section.content
     # No empty downgrade block
     assert "Downgrades:" not in section.content
+
+
+def test_tier4_smt_block_renders_when_outcomes_present():
+    """Tier 4 SMT outcomes (refuted / witness / disagreement) get
+    their own sub-block in the report — additive on top of the
+    Tier 1/2/3 verdict."""
+    mod = _load_agentic_module()
+    section = mod._build_dataflow_validation_report_section(
+        _full_metrics(
+            n_tier4_smt_refuted=2,
+            n_tier4_smt_witness=3,
+            n_tier4_smt_disagree=1,
+        )
+    )
+    body = section.content
+    assert "Tier 4 SMT path-feasibility refinement" in body
+    assert "Refuted (inconclusive → refuted on unsat conditions): 2" in body
+    assert "Witness attached to confirmed" in body
+    assert "3" in body  # witness count
+    assert "SMT-CodeQL disagreement" in body
+
+
+def test_tier4_smt_block_omitted_when_no_outcomes():
+    """When all Tier 4 counts are zero, no Tier 4 block at all —
+    avoids noise on runs where no findings carried path_conditions."""
+    mod = _load_agentic_module()
+    section = mod._build_dataflow_validation_report_section(_full_metrics())
+    body = section.content
+    assert "Tier 4 SMT" not in body
+
+
+def test_tier4_smt_block_partial_outcomes_only_shows_present_ones():
+    """Each Tier 4 outcome line is independently gated — a run with
+    only witnesses (no refutations / disagreements) shows just the
+    witness line."""
+    mod = _load_agentic_module()
+    section = mod._build_dataflow_validation_report_section(
+        _full_metrics(n_tier4_smt_witness=5)
+    )
+    body = section.content
+    assert "Tier 4 SMT" in body
+    assert "Witness attached" in body
+    assert "Refuted" not in body  # the standalone Tier 4 'Refuted' line
+    assert "disagreement" not in body

--- a/packages/llm_analysis/tests/test_dataflow_validation.py
+++ b/packages/llm_analysis/tests/test_dataflow_validation.py
@@ -2863,3 +2863,145 @@ class TestSourceRuleLabelHostile:
         assert "</untrusted_finding_context>" not in h.context
         # Legitimate prefix still present.
         assert "rule-X" in h.context
+
+
+class TestTier4SmtRefine:
+    """Tier 4 SMT path-feasibility refinement on Tier 1/2/3 verdicts.
+
+    Conservative refinement: may convert ``inconclusive`` → ``refuted``
+    on unsat conditions, attaches witness model to ``confirmed`` on
+    sat. Never downgrades ``confirmed`` → ``refuted`` on SMT alone
+    (CodeQL's signal wins on disagreement, with a warning logged).
+    """
+
+    def _result(self, verdict):
+        from packages.hypothesis_validation.result import ValidationResult
+        return ValidationResult(
+            verdict=verdict, evidence=[], iterations=1,
+            reasoning=f"[prebuilt] CodeQL produced {verdict}",
+        )
+
+    def test_no_path_conditions_no_check(self):
+        from packages.llm_analysis.dataflow_validation import _tier4_smt_refine
+        r, outcome = _tier4_smt_refine(
+            self._result("confirmed"), {"finding_id": "f"}, {},
+        )
+        assert outcome == "no_check"
+        assert r.verdict == "confirmed"
+
+    def test_inconclusive_plus_unsat_promotes_to_refuted(self):
+        from packages.llm_analysis.dataflow_validation import _tier4_smt_refine
+        analysis = {
+            "path_conditions": ["x > 100", "x < 5"],
+            "path_profile": "uint64",
+        }
+        r, outcome = _tier4_smt_refine(
+            self._result("inconclusive"), {"finding_id": "f"}, analysis,
+        )
+        assert outcome == "smt_refuted"
+        assert r.verdict == "refuted"
+        # SMT evidence appended to the trail.
+        assert any(ev.tool == "smt" for ev in r.evidence)
+
+    def test_confirmed_plus_unsat_keeps_confirmed_with_disagreement_log(self):
+        from packages.llm_analysis.dataflow_validation import _tier4_smt_refine
+        analysis = {
+            "path_conditions": ["x > 100", "x < 5"],
+            "path_profile": "uint64",
+        }
+        r, outcome = _tier4_smt_refine(
+            self._result("confirmed"), {"finding_id": "f"}, analysis,
+        )
+        assert outcome == "smt_disagree"
+        # Conservative: CodeQL wins; verdict unchanged.
+        assert r.verdict == "confirmed"
+        # Disagreement still recorded in evidence trail for offline review.
+        assert any(ev.tool == "smt" for ev in r.evidence)
+
+    def test_confirmed_plus_sat_attaches_witness(self):
+        from packages.llm_analysis.dataflow_validation import _tier4_smt_refine
+        analysis = {
+            "path_conditions": ["x > 10", "x < 100"],
+            "path_profile": "uint64",
+        }
+        r, outcome = _tier4_smt_refine(
+            self._result("confirmed"), {"finding_id": "f"}, analysis,
+        )
+        assert outcome == "smt_witness"
+        assert r.verdict == "confirmed"
+        # Witness model lands as a new Evidence record.
+        smt_ev = [ev for ev in r.evidence if ev.tool == "smt"]
+        assert len(smt_ev) == 1
+        assert "witness" in (smt_ev[0].summary or "").lower()
+
+    def test_inconclusive_plus_sat_no_change(self):
+        """SMT-sat alone shouldn't UPGRADE inconclusive — CodeQL never
+        confirmed it. Stay inconclusive."""
+        from packages.llm_analysis.dataflow_validation import _tier4_smt_refine
+        analysis = {
+            "path_conditions": ["x > 10", "x < 100"],
+            "path_profile": "uint64",
+        }
+        r, outcome = _tier4_smt_refine(
+            self._result("inconclusive"), {"finding_id": "f"}, analysis,
+        )
+        assert outcome == "smt_no_change"
+        assert r.verdict == "inconclusive"
+
+    def test_nested_dataflow_validation_path_conditions(self):
+        """Conditions can live under analysis['dataflow_validation']
+        (deep-validation output) instead of top-level analysis."""
+        from packages.llm_analysis.dataflow_validation import _tier4_smt_refine
+        analysis = {
+            "dataflow_validation": {
+                "path_conditions": ["y > 0", "y < 10"],
+                "path_profile": "uint32",
+            },
+        }
+        r, outcome = _tier4_smt_refine(
+            self._result("confirmed"), {"finding_id": "f"}, analysis,
+        )
+        assert outcome == "smt_witness"
+
+    def test_bad_profile_falls_through_as_smt_error(self):
+        """Malformed profile name shouldn't crash the tier loop."""
+        from packages.llm_analysis.dataflow_validation import _tier4_smt_refine
+        analysis = {
+            "path_conditions": ["x > 1"],
+            "path_profile": "not_a_real_profile",
+        }
+        r, outcome = _tier4_smt_refine(
+            self._result("confirmed"), {"finding_id": "f"}, analysis,
+        )
+        assert outcome == "smt_error"
+        # Verdict unchanged on error.
+        assert r.verdict == "confirmed"
+
+    def test_smt_unavailable_falls_through(self):
+        """When validate_path's substrate isn't importable, fall through
+        to smt_unavailable — verdict unchanged."""
+        from packages.llm_analysis import dataflow_validation as mod
+        from unittest.mock import patch
+        analysis = {"path_conditions": ["x > 1"]}
+        with patch.dict("sys.modules", {"packages.exploit_feasibility.smt_path": None}):
+            r, outcome = mod._tier4_smt_refine(
+                self._result("confirmed"), {"finding_id": "f"}, analysis,
+            )
+        assert outcome == "smt_unavailable"
+        assert r.verdict == "confirmed"
+
+    def test_unparseable_conditions_no_change(self):
+        """Conditions the parser can't encode → smt.feasible is None →
+        verdict unchanged (no_change)."""
+        from packages.llm_analysis.dataflow_validation import _tier4_smt_refine
+        analysis = {
+            "path_conditions": ["arr[0] == 5"],  # subscript not supported
+            "path_profile": "uint64",
+        }
+        r, outcome = _tier4_smt_refine(
+            self._result("confirmed"), {"finding_id": "f"}, analysis,
+        )
+        # Either smt_no_change (if Z3 decided) or smt_unavailable / no_check;
+        # what matters is the verdict isn't changed.
+        assert r.verdict == "confirmed"
+        assert outcome in ("smt_no_change", "smt_unavailable", "no_check")

--- a/packages/llm_analysis/tests/test_iris_reuse.py
+++ b/packages/llm_analysis/tests/test_iris_reuse.py
@@ -335,6 +335,140 @@ class TestExploitGenGate:
         mock_gate.assert_not_called()
 
 
+class TestSmtPreFlight:
+    """SMT pre-flight gate runs after IRIS Tier 1 and before LLM
+    exploit generation. Reads `path_conditions` (added in this PR's
+    schema extension) from `vuln.analysis` and refutes when the
+    conditions are unsatisfiable.
+
+    Same fail-open semantics as IRIS: any failure (no conditions,
+    Z3 unavailable, parser rejection) → "no_check" → caller proceeds
+    as if the gate hadn't been there.
+    """
+
+    def _make_vuln_with_conditions(self, conditions, profile="uint64",
+                                    nested=False):
+        v = MagicMock()
+        v.exploitable = True
+        v.rule_id = "py/integer-overflow"
+        v.file_path = "src/x.py"
+        v.start_line = 10
+        v.finding = {
+            "finding_id": "F1", "tool": "semgrep",
+            "rule_id": "raptor.arith.overflow",
+            "file_path": "src/x.py", "start_line": 10, "cwe_id": "CWE-190",
+        }
+        if nested:
+            v.analysis = {"dataflow_validation": {
+                "path_conditions": conditions, "path_profile": profile,
+            }}
+        else:
+            v.analysis = {
+                "path_conditions": conditions, "path_profile": profile,
+            }
+        return v
+
+    def _agent(self, tmp_path):
+        from packages.llm_analysis.agent import AutonomousSecurityAgentV2
+        return AutonomousSecurityAgentV2(
+            repo_path=tmp_path / "repo",
+            out_dir=tmp_path / "out",
+            prep_only=True,
+        )
+
+    def test_unsat_conditions_refuted(self, tmp_path):
+        agent = self._agent(tmp_path)
+        v = self._make_vuln_with_conditions(["x > 100", "x < 5"])
+        assert agent._smt_pre_flight(v) == "refuted"
+
+    def test_sat_conditions_confirmed(self, tmp_path):
+        agent = self._agent(tmp_path)
+        v = self._make_vuln_with_conditions(["x > 10", "x < 100"])
+        assert agent._smt_pre_flight(v) == "confirmed"
+
+    def test_no_conditions_no_check(self, tmp_path):
+        """Findings without path_conditions → no_check (gate doesn't
+        opine, caller proceeds)."""
+        agent = self._agent(tmp_path)
+        v = MagicMock(); v.analysis = {}
+        assert agent._smt_pre_flight(v) == "no_check"
+
+    def test_nested_dataflow_validation_block(self, tmp_path):
+        """path_conditions can live under analysis['dataflow_validation']
+        (deep-validation output) instead of top-level analysis."""
+        agent = self._agent(tmp_path)
+        v = self._make_vuln_with_conditions(["x > 100", "x < 5"], nested=True)
+        assert agent._smt_pre_flight(v) == "refuted"
+
+    def test_unparseable_conditions_no_check(self, tmp_path):
+        """Conditions the SMT parser can't encode → feasible=None →
+        gate returns no_check (don't block, don't endorse)."""
+        agent = self._agent(tmp_path)
+        v = self._make_vuln_with_conditions(["arr[0] == 5"])  # subscript NS
+        assert agent._smt_pre_flight(v) == "no_check"
+
+    def test_bad_profile_no_check(self, tmp_path):
+        """Bad profile name shouldn't crash the exploit pipeline —
+        fall through to no_check."""
+        agent = self._agent(tmp_path)
+        v = self._make_vuln_with_conditions(["x > 1"], profile="bogus")
+        assert agent._smt_pre_flight(v) == "no_check"
+
+    def test_smt_unavailable_no_check(self, tmp_path):
+        """When the SMT substrate isn't importable, no_check (silent
+        fallthrough) — exploit gen continues blind."""
+        from packages.llm_analysis import agent as agent_mod
+        v = self._make_vuln_with_conditions(["x > 1"])
+        with patch.dict("sys.modules",
+                        {"packages.exploit_feasibility.smt_path": None}):
+            agent = self._agent(tmp_path)
+            assert agent._smt_pre_flight(v) == "no_check"
+
+    def test_refuted_skips_exploit_gen_with_smt_marker(self, tmp_path):
+        """End-to-end: SMT-refuted → generate_exploit returns False
+        and records the smt_unsat marker (distinct from iris_tier1_refuted)
+        so downstream telemetry can count which gate fired."""
+        agent = self._agent(tmp_path)
+        v = self._make_vuln_with_conditions(["x > 100", "x < 5"])
+        # IRIS gate must NOT be the one that refutes
+        with patch.object(agent, "_tier1_pre_flight", return_value="no_check"):
+            ok = agent.generate_exploit(v)
+        assert ok is False
+        marker = (v.analysis or {}).get("exploit_skipped_reason") or ""
+        assert "smt_unsat" in marker
+        assert "iris_tier1_refuted" not in marker
+
+    def test_iris_refuted_short_circuits_smt_gate(self, tmp_path):
+        """IRIS gate runs FIRST. If IRIS refutes, SMT gate must not
+        even be consulted (avoids unnecessary work)."""
+        agent = self._agent(tmp_path)
+        v = self._make_vuln_with_conditions(["x > 100", "x < 5"])
+        with patch.object(agent, "_tier1_pre_flight", return_value="refuted"), \
+             patch.object(agent, "_smt_pre_flight") as mock_smt:
+            ok = agent.generate_exploit(v)
+        assert ok is False
+        mock_smt.assert_not_called()
+        marker = (v.analysis or {}).get("exploit_skipped_reason") or ""
+        assert "iris_tier1_refuted" in marker
+
+    def test_sat_conditions_proceed_to_exploit_gen(self, tmp_path):
+        """Confirmed by SMT → falls through to exploit gen as normal."""
+        agent = self._agent(tmp_path)
+        v = self._make_vuln_with_conditions(["x > 10", "x < 100"])
+        with patch.object(agent, "_tier1_pre_flight", return_value="no_check"), \
+             patch("packages.llm_analysis.prompts.exploit.build_exploit_prompt_bundle") as mock_bundle:
+            mock_bundle.return_value = MagicMock(messages=[
+                MagicMock(role="system", content="sys"),
+                MagicMock(role="user", content="user"),
+            ])
+            agent.llm = MagicMock()
+            agent.llm.generate.return_value = None
+            agent.generate_exploit(v)
+        # No skip marker — gate did NOT block
+        marker = (v.analysis or {}).get("exploit_skipped_reason") or ""
+        assert "smt_unsat" not in marker
+
+
 # ----- /analyze (validate_dataflow) Tier 1 gate ------------------------
 
 

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -1367,6 +1367,9 @@ Examples:
         n_tier1 = dv.get("n_tier1_prebuilt", 0)
         n_tier2 = dv.get("n_tier2_template", 0)
         n_tier3 = dv.get("n_tier3_retry", 0)
+        n_smt_refuted = dv.get("n_tier4_smt_refuted", 0)
+        n_smt_witness = dv.get("n_tier4_smt_witness", 0)
+        n_smt_disagree = dv.get("n_tier4_smt_disagree", 0)
         n_recommended = dv.get("n_recommended_downgrades", 0)
         n_hard = dv.get("n_applied_downgrades", 0)
         n_soft = dv.get("n_soft_downgrades", 0)
@@ -1376,7 +1379,9 @@ Examples:
               + (f" (+{n_cache_hits} cache hit{'s' if n_cache_hits != 1 else ''})"
                  if n_cache_hits else ""))
         # Tier breakdown: Tier 1 is free CodeQL; Tier 2/3 burn LLM
-        # tokens. Worth showing the split so operators can tell whether
+        # tokens; Tier 4 is free SMT (Z3 only) refining Tier 1/2/3
+        # verdicts when the LLM extracted path_conditions. Worth
+        # showing the split so operators can tell whether
         # --deep-validate is paying off.
         tier_parts = []
         if n_tier1:
@@ -1387,6 +1392,19 @@ Examples:
             tier_parts.append(f"{n_tier3} Tier 3 (LLM retry)")
         if tier_parts:
             print(f"     by tier: {', '.join(tier_parts)}")
+        # Tier 4 (SMT) sub-line — separate because outcomes are
+        # additive on top of Tier 1/2/3 (a finding's verdict may be
+        # confirmed-by-Tier-1 AND witness-attached-by-Tier-4) so
+        # mixing them into the per-tier counts would double-count.
+        smt_parts = []
+        if n_smt_refuted:
+            smt_parts.append(f"{n_smt_refuted} refuted")
+        if n_smt_witness:
+            smt_parts.append(f"{n_smt_witness} witness")
+        if n_smt_disagree:
+            smt_parts.append(f"{n_smt_disagree} disagreement")
+        if smt_parts:
+            print(f"     Tier 4 SMT: {', '.join(smt_parts)}")
         # Downgrade outcome: distinguish "recommended" from "applied"
         # (the latter is post-reconciliation with consensus/judge).
         # Soft downgrades = recommendation overruled by consensus/judge.
@@ -1750,6 +1768,9 @@ def _build_dataflow_validation_report_section(dv):
     n_tier1 = dv.get("n_tier1_prebuilt", 0)
     n_tier2 = dv.get("n_tier2_template", 0)
     n_tier3 = dv.get("n_tier3_retry", 0)
+    n_smt_refuted = dv.get("n_tier4_smt_refuted", 0)
+    n_smt_witness = dv.get("n_tier4_smt_witness", 0)
+    n_smt_disagree = dv.get("n_tier4_smt_disagree", 0)
     n_recommended = dv.get("n_recommended_downgrades", 0)
     n_hard = dv.get("n_applied_downgrades", 0)
     n_soft = dv.get("n_soft_downgrades", 0)
@@ -1773,6 +1794,28 @@ def _build_dataflow_validation_report_section(dv):
             lines.append(f"- Tier 2 (LLM-customised predicates): {n_tier2}")
         if n_tier3:
             lines.append(f"- Tier 3 (LLM compile-error retry): {n_tier3}")
+    if n_smt_refuted or n_smt_witness or n_smt_disagree:
+        lines.append("")
+        lines.append("**Tier 4 SMT path-feasibility refinement:**")
+        # Tier 4 outcomes are additive on top of the Tier 1/2/3
+        # verdict. Listed separately because a single finding can
+        # have a confirmed-by-Tier-1 verdict AND a witness-attached-
+        # by-Tier-4 outcome — they aren't exclusive.
+        if n_smt_refuted:
+            lines.append(
+                f"- Refuted (inconclusive → refuted on unsat conditions): "
+                f"{n_smt_refuted}"
+            )
+        if n_smt_witness:
+            lines.append(
+                f"- Witness attached to confirmed (concrete attacker-input "
+                f"values, usable as PoC seed): {n_smt_witness}"
+            )
+        if n_smt_disagree:
+            lines.append(
+                f"- SMT-CodeQL disagreement (kept CodeQL signal — see "
+                f"warning logs): {n_smt_disagree}"
+            )
     if n_recommended:
         lines.append("")
         lines.append("**Downgrades:**")


### PR DESCRIPTION
…ploit pre-flight

The SMT substrate (`core.smt_solver`, `packages.exploit_feasibility.smt_path`, `packages.codeql.smt_path_validator`) had zero in-tree consumers — only LLM-driven invocation via libexec shims. This PR plumbs it into two related gates that share one new schema field.

Two new optional + nullable fields on `DATAFLOW_SCHEMA_FIELDS` and `DATAFLOW_VALIDATION_SCHEMA`:
* `path_conditions: list of strings or null` — SMT-checkable branch conditions; LLM populates for memory-corruption / arith / bounds / null-deref CWEs (190, 125, 787, 476, 191).
* `path_profile: string or null` — bitvector profile (uint64 default, uint32 for wraparound, int32 / int64 for signed).

Nullable so absence doesn't dock response quality.

`_tier4_smt_refine()` runs after Tier 1/2/3 verdict. Conservative:
* `inconclusive` + unsat → `refuted`
* `confirmed` + sat → keep, attach witness Evidence (PoC seed)
* `confirmed` + unsat → DISAGREEMENT, keep CodeQL signal, log
* anything else → no change

New metrics `n_tier4_smt_{refuted,witness,disagree}` surfaced in the `/agentic` console summary and `agentic-report.md`.

`_smt_pre_flight()` mirrors `_tier1_pre_flight`. Reads the same `path_conditions` and refutes on unsat → skip the ANALYSE-class LLM exploit-gen call. Skip marker `smt_unsat` distinguishes from `iris_tier1_refuted`. IRIS gate runs first, so SMT is never consulted on already-IRIS-refuted findings.

22 new (9 Tier 4 + 3 reporting + 10 pre-flight). 943 pass across `packages/llm_analysis/tests/`. Both gates fail-open on every failure mode (no conditions / Z3 missing / parser rejection / exception) → `no_check` → caller proceeds unaffected.

Zero LLM tokens (Z3 only), <100ms per finding-with-conditions. Findings without conditions return `no_check` with no work — the common case. Saves one ANALYSE-class call (Tier 4) plus one PoC-class call (exploit gate) per refuted finding.