### PR TITLE
feat(core/llm/dispatcher): aggregator + ecosystem provider rules

### DIFF
--- a/core/llm/dispatcher/auth.py
+++ b/core/llm/dispatcher/auth.py
@@ -9,6 +9,30 @@ Only providers RAPTOR actively dispatches to are supported here. If
 ``api_key`` is None at request time, the dispatcher rejects with
 ``503 Service Unavailable: provider not configured`` so the worker's
 SDK surfaces a clear error rather than a mysterious 401 from upstream.
+
+Out of scope for the proxy-based dispatcher (Phase C-β):
+
+  * **AWS Bedrock** — uses sigv4 request signing. The signing
+    happens inside the AWS SDK over the request body, in worker
+    process address space (where the keys must live to sign).
+    The proxy can't transparently re-sign without a custom Bedrock
+    client shim that sends unsigned requests for the dispatcher to
+    sign with the parent's keys + per-model-family request shapes.
+    Until that ships, ``AWS_*`` env vars stay flowing through to
+    workers; operators wanting Bedrock isolation should rely on
+    AWS-native short-lived credentials (EC2/EKS instance roles,
+    SSO cache) which obviate the env-var question.
+
+  * **GCP Vertex AI** — uses OAuth refresh from a service-account
+    JSON file (``GOOGLE_APPLICATION_CREDENTIALS``). The dispatcher
+    would need ``google-auth`` integration to refresh the bearer
+    token at request time. Deferred to a focused follow-up; until
+    then ``GOOGLE_APPLICATION_CREDENTIALS`` flows through env to
+    workers and the SDK does its own OAuth exchange.
+
+The remaining providers in ``LLM_API_KEY_VARS`` (the three OG
+providers + the Phase C-β aggregators below) are all bearer-auth
+on a known upstream URL and route cleanly through the proxy.
 """
 
 from __future__ import annotations
@@ -69,9 +93,28 @@ class CredentialStore:
         # Read each provider's key into private state. Store is
         # mutable so tests can inject fakes without touching env.
         self._keys: dict[str, str | None] = {
-            "anthropic": _read_env("ANTHROPIC_API_KEY"),
-            "openai":    _read_env("OPENAI_API_KEY"),
-            "gemini":    _read_env("GEMINI_API_KEY") or _read_env("GOOGLE_API_KEY"),
+            "anthropic":  _read_env("ANTHROPIC_API_KEY"),
+            "openai":     _read_env("OPENAI_API_KEY"),
+            "gemini":     _read_env("GEMINI_API_KEY") or _read_env("GOOGLE_API_KEY"),
+            # OpenAI-compatible aggregators + ecosystem providers.
+            # Same Bearer-auth shape; different upstream URLs.
+            "mistral":    _read_env("MISTRAL_API_KEY"),
+            "groq":       _read_env("GROQ_API_KEY"),
+            "together":   _read_env("TOGETHER_API_KEY"),
+            "openrouter": _read_env("OPENROUTER_API_KEY"),
+            "fireworks":  _read_env("FIREWORKS_API_KEY"),
+            "deepinfra":  _read_env("DEEPINFRA_API_KEY"),
+            "perplexity": _read_env("PERPLEXITY_API_KEY"),
+            "cohere":     _read_env("COHERE_API_KEY"),
+            # Replicate — uses ``Token <key>`` prefix, not ``Bearer``.
+            "replicate":  _read_env("REPLICATE_API_TOKEN"),
+            # Azure OpenAI — operator-configured endpoint URL +
+            # api-key header. Endpoint read once at startup; if
+            # absent the rule's upstream is a sentinel that produces
+            # 503 at request time (consistent with other unconfigured
+            # providers).
+            "azure_openai":           _read_env("AZURE_OPENAI_API_KEY"),
+            "azure_openai_endpoint":  _read_env("AZURE_OPENAI_ENDPOINT"),
         }
 
     def get(self, provider: str) -> str | None:
@@ -118,6 +161,43 @@ def build_rules(creds: CredentialStore) -> dict[str, ProviderRule]:
         # the header so the dispatcher injects it that way.
         return {"x-goog-api-key": key}
 
+    # Bearer-auth aggregators — closure factory keeps each header
+    # injector tight (just reads the matching credential). All use
+    # the OpenAI-style ``Authorization: Bearer <key>`` shape.
+    def _bearer_headers(provider_key: str):
+        def _impl() -> dict[str, str]:
+            key = creds.get(provider_key)
+            if not key:
+                return {}
+            return {"Authorization": f"Bearer {key}"}
+        return _impl
+
+    def _replicate_headers() -> dict[str, str]:
+        # Replicate uses ``Token <key>`` (not Bearer). One-off rather
+        # than parameterising the factory above for clarity.
+        key = creds.get("replicate")
+        if not key:
+            return {}
+        return {"Authorization": f"Token {key}"}
+
+    def _azure_openai_headers() -> dict[str, str]:
+        # Azure OpenAI uses ``api-key`` header (not Bearer). Endpoint
+        # is operator-configured per Azure deployment; the
+        # ``upstream_base_url`` for this rule is filled from
+        # ``AZURE_OPENAI_ENDPOINT`` at build time. When the operator
+        # didn't set the endpoint, the rule's upstream is the
+        # sentinel below and the dispatcher rejects with 503
+        # ``provider not configured`` — same UX as missing key.
+        key = creds.get("azure_openai")
+        if not key:
+            return {}
+        return {"api-key": key}
+
+    azure_endpoint = (
+        creds.get("azure_openai_endpoint")
+        or "https://azure-openai-not-configured.invalid"
+    )
+
     return {
         "anthropic": ProviderRule(
             name="anthropic",
@@ -133,5 +213,68 @@ def build_rules(creds: CredentialStore) -> dict[str, ProviderRule]:
             name="gemini",
             upstream_base_url="https://generativelanguage.googleapis.com",
             inject_headers=_gemini_headers,
+        ),
+        "mistral": ProviderRule(
+            name="mistral",
+            upstream_base_url="https://api.mistral.ai",
+            inject_headers=_bearer_headers("mistral"),
+        ),
+        "groq": ProviderRule(
+            name="groq",
+            upstream_base_url="https://api.groq.com",
+            inject_headers=_bearer_headers("groq"),
+        ),
+        "together": ProviderRule(
+            name="together",
+            upstream_base_url="https://api.together.xyz",
+            inject_headers=_bearer_headers("together"),
+        ),
+        "openrouter": ProviderRule(
+            name="openrouter",
+            # OpenRouter's API is rooted at ``/api/v1`` rather than the
+            # bare host; SDKs typically configure ``base_url=https://
+            # openrouter.ai/api/v1``. Forward to the bare host — the
+            # SDK's path component (``/api/v1/chat/completions`` etc.)
+            # is preserved end-to-end through the dispatcher.
+            upstream_base_url="https://openrouter.ai",
+            inject_headers=_bearer_headers("openrouter"),
+        ),
+        "fireworks": ProviderRule(
+            name="fireworks",
+            upstream_base_url="https://api.fireworks.ai",
+            inject_headers=_bearer_headers("fireworks"),
+        ),
+        "deepinfra": ProviderRule(
+            name="deepinfra",
+            upstream_base_url="https://api.deepinfra.com",
+            inject_headers=_bearer_headers("deepinfra"),
+        ),
+        "perplexity": ProviderRule(
+            name="perplexity",
+            upstream_base_url="https://api.perplexity.ai",
+            inject_headers=_bearer_headers("perplexity"),
+        ),
+        "cohere": ProviderRule(
+            name="cohere",
+            upstream_base_url="https://api.cohere.ai",
+            inject_headers=_bearer_headers("cohere"),
+        ),
+        "replicate": ProviderRule(
+            name="replicate",
+            upstream_base_url="https://api.replicate.com",
+            inject_headers=_replicate_headers,
+        ),
+        "azure_openai": ProviderRule(
+            name="azure_openai",
+            upstream_base_url=azure_endpoint,
+            inject_headers=_azure_openai_headers,
+            # Azure echoes the api-key in some error responses;
+            # strip ``api-key`` from worker requests on top of the
+            # default Bearer/x-api-key set so the dispatcher's
+            # injected value isn't shadowed.
+            strip_request_headers=(
+                "authorization", "x-api-key", "x-goog-api-key",
+                "api-key", "openai-organization",
+            ),
         ),
     }

--- a/core/llm/dispatcher/server.py
+++ b/core/llm/dispatcher/server.py
@@ -397,9 +397,22 @@ def _short(token: str) -> str:
 
 
 _PROVIDER_FROM_PATH_PREFIX = {
-    "/anthropic/": "anthropic",
-    "/openai/":    "openai",
-    "/gemini/":    "gemini",
+    "/anthropic/":    "anthropic",
+    "/openai/":       "openai",
+    "/gemini/":       "gemini",
+    # OpenAI-compatible aggregators + ecosystem providers added in
+    # Phase C-β. Each routes by the same prefix shape; the rule's
+    # ``upstream_base_url`` decides where the request actually goes.
+    "/mistral/":      "mistral",
+    "/groq/":         "groq",
+    "/together/":     "together",
+    "/openrouter/":   "openrouter",
+    "/fireworks/":    "fireworks",
+    "/deepinfra/":    "deepinfra",
+    "/perplexity/":   "perplexity",
+    "/cohere/":       "cohere",
+    "/replicate/":    "replicate",
+    "/azure_openai/": "azure_openai",
 }
 
 

--- a/core/llm/dispatcher/tests/test_providers.py
+++ b/core/llm/dispatcher/tests/test_providers.py
@@ -28,6 +28,21 @@ def all_providers_creds():
         "anthropic": "anthropic-real-NOT-LEAKED",
         "openai":    "sk-openai-real-NOT-LEAKED",
         "gemini":    "AIza-gemini-real-NOT-LEAKED",
+        # Phase C-β aggregators + ecosystem providers. Distinct
+        # values so a header-injection bug that swaps providers
+        # (e.g. mistral key landing on groq path) shows up
+        # immediately in the upstream-captured headers.
+        "mistral":     "mistral-real-NOT-LEAKED",
+        "groq":        "gsk-groq-real-NOT-LEAKED",
+        "together":    "together-real-NOT-LEAKED",
+        "openrouter":  "sk-or-real-NOT-LEAKED",
+        "fireworks":   "fw-fireworks-real-NOT-LEAKED",
+        "deepinfra":   "deepinfra-real-NOT-LEAKED",
+        "perplexity":  "pplx-perplexity-real-NOT-LEAKED",
+        "cohere":      "cohere-real-NOT-LEAKED",
+        "replicate":   "r8-replicate-real-NOT-LEAKED",
+        "azure_openai":          "azure-real-NOT-LEAKED",
+        "azure_openai_endpoint": "https://example-azure.invalid",
     }
     return creds
 
@@ -215,3 +230,232 @@ class TestUnknownProviderPath:
             assert "unknown" in r.text.lower()
         finally:
             d.shutdown()
+
+
+# ---------------------------------------------------------------------
+# Phase C-β: 8 OpenAI-compatible aggregators (Bearer auth) +
+# Replicate (Token auth) + Azure OpenAI (api-key + operator-set
+# endpoint). Each gets the same shape of test:
+#   1. Captive upstream stands in for the real provider.
+#   2. POST through the dispatcher with a dummy auth header.
+#   3. Assert the upstream got the real key in the right header,
+#      the dummy was stripped, and the path was forwarded as-is.
+# ---------------------------------------------------------------------
+
+
+# Bearer-auth providers — 8 OpenAI-compatible aggregators all use
+# ``Authorization: Bearer <key>``. Parameterised so a future provider
+# with the same shape adds one row, not a whole new class.
+_BEARER_PROVIDERS = [
+    # (provider name, path tail, expected creds key, dummy header)
+    ("mistral",    "v1/chat/completions",    "mistral-real-NOT-LEAKED"),
+    ("groq",       "openai/v1/chat/completions", "gsk-groq-real-NOT-LEAKED"),
+    ("together",   "v1/chat/completions",    "together-real-NOT-LEAKED"),
+    ("openrouter", "api/v1/chat/completions", "sk-or-real-NOT-LEAKED"),
+    ("fireworks",  "inference/v1/chat/completions", "fw-fireworks-real-NOT-LEAKED"),
+    ("deepinfra",  "v1/openai/chat/completions", "deepinfra-real-NOT-LEAKED"),
+    ("perplexity", "chat/completions",       "pplx-perplexity-real-NOT-LEAKED"),
+    ("cohere",     "v1/chat",                "cohere-real-NOT-LEAKED"),
+]
+
+
+@pytest.mark.parametrize("provider,path_tail,expected_key", _BEARER_PROVIDERS)
+def test_bearer_provider_authorization_injected(
+    all_providers_creds, tmp_path, provider, path_tail, expected_key,
+):
+    """Bearer-auth aggregator: ``Authorization: Bearer <real>`` lands
+    upstream; worker's dummy ``Authorization`` is stripped."""
+    upstream = _CaptiveUpstream()
+    d = _setup_with_provider_redirected(
+        all_providers_creds, tmp_path, provider, upstream.base_url,
+    )
+    try:
+        _, fd = d.allocate_worker(label=f"{provider}-test")
+        token = os.read(fd, 64).decode().strip(); os.close(fd)
+        _post_via_dispatcher(
+            d, token, f"http://_/{provider}/{path_tail}",
+            b'{"model":"x","messages":[]}',
+            {"Authorization": "Bearer dummy-stripped"},
+        )
+        sent = {k.lower(): v for k, v in upstream.captured["headers"].items()}
+        assert sent.get("authorization") == f"Bearer {expected_key}", (
+            f"{provider}: expected real key in Authorization, got "
+            f"{sent.get('authorization')!r}"
+        )
+        assert sent.get("authorization") != "Bearer dummy-stripped"
+        # Path forwarded verbatim under the path_tail.
+        assert upstream.captured["path"] == f"/{path_tail}"
+        assert "x-raptor-token" not in sent
+    finally:
+        upstream.shutdown()
+        d.shutdown()
+
+
+class TestReplicateProvider:
+
+    def test_token_prefix_injected_dummy_stripped(
+        self, all_providers_creds, tmp_path,
+    ):
+        """Replicate uses ``Authorization: Token <key>`` (not Bearer).
+        Dispatcher rule encodes that prefix; verify the upstream
+        sees ``Token`` not ``Bearer``."""
+        upstream = _CaptiveUpstream()
+        d = _setup_with_provider_redirected(
+            all_providers_creds, tmp_path, "replicate", upstream.base_url,
+        )
+        try:
+            _, fd = d.allocate_worker(label="replicate-test")
+            token = os.read(fd, 64).decode().strip(); os.close(fd)
+            _post_via_dispatcher(
+                d, token, "http://_/replicate/v1/predictions",
+                b'{"version":"x","input":{}}',
+                {"Authorization": "Token dummy-stripped"},
+            )
+            sent = {k.lower(): v for k, v in upstream.captured["headers"].items()}
+            assert sent.get("authorization") == "Token r8-replicate-real-NOT-LEAKED"
+            assert sent.get("authorization") != "Token dummy-stripped"
+            # Crucially, NOT a Bearer prefix:
+            assert not sent.get("authorization", "").startswith("Bearer ")
+            assert upstream.captured["path"] == "/v1/predictions"
+        finally:
+            upstream.shutdown()
+            d.shutdown()
+
+
+class TestAzureOpenAIProvider:
+
+    def test_api_key_header_injected_dummy_stripped(
+        self, all_providers_creds, tmp_path,
+    ):
+        """Azure OpenAI uses ``api-key`` header (not Authorization).
+        Worker's dummy ``api-key`` is stripped; dispatcher injects
+        the real one."""
+        upstream = _CaptiveUpstream()
+        d = _setup_with_provider_redirected(
+            all_providers_creds, tmp_path, "azure_openai", upstream.base_url,
+        )
+        try:
+            _, fd = d.allocate_worker(label="azure-test")
+            token = os.read(fd, 64).decode().strip(); os.close(fd)
+            _post_via_dispatcher(
+                d, token,
+                "http://_/azure_openai/openai/deployments/gpt-5/chat/completions"
+                "?api-version=2024-02-15-preview",
+                b'{"messages":[]}',
+                {"api-key": "dummy-stripped"},
+            )
+            sent = {k.lower(): v for k, v in upstream.captured["headers"].items()}
+            assert sent.get("api-key") == "azure-real-NOT-LEAKED"
+            assert sent.get("api-key") != "dummy-stripped"
+            # No Bearer auth — Azure doesn't use it.
+            assert "authorization" not in sent
+        finally:
+            upstream.shutdown()
+            d.shutdown()
+
+
+class TestAzureOpenAIWithoutEndpoint:
+
+    def test_unconfigured_endpoint_uses_invalid_sentinel(self, tmp_path):
+        """When ``AZURE_OPENAI_ENDPOINT`` is unset, the rule's
+        upstream is the documented sentinel — operator gets a
+        connect-failure rather than the dispatcher silently routing
+        somewhere unexpected."""
+        from core.llm.dispatcher.auth import build_rules
+        creds = CredentialStore.__new__(CredentialStore)
+        creds._keys = {
+            "azure_openai": "key-but-no-endpoint",
+            "azure_openai_endpoint": None,
+        }
+        rules = build_rules(creds)
+        assert rules["azure_openai"].upstream_base_url == (
+            "https://azure-openai-not-configured.invalid"
+        )
+
+
+class TestNewProvidersUnconfiguredKeyReturns503:
+    """Every aggregator must surface a clean 503 when its key is
+    unset — same UX as the original three. Pinned per provider so
+    a future build_rules edit that drops a 503 path gets caught."""
+
+    @pytest.mark.parametrize(
+        "provider,path",
+        [
+            ("mistral",      "/mistral/v1/chat/completions"),
+            ("groq",         "/groq/openai/v1/chat/completions"),
+            ("together",     "/together/v1/chat/completions"),
+            ("openrouter",   "/openrouter/api/v1/chat/completions"),
+            ("fireworks",    "/fireworks/inference/v1/chat/completions"),
+            ("deepinfra",    "/deepinfra/v1/openai/chat/completions"),
+            ("perplexity",   "/perplexity/chat/completions"),
+            ("cohere",       "/cohere/v1/chat"),
+            ("replicate",    "/replicate/v1/predictions"),
+            ("azure_openai", "/azure_openai/openai/deployments/x/chat/completions"),
+        ],
+    )
+    def test_unconfigured_provider_returns_503(self, tmp_path, provider, path):
+        creds = CredentialStore.__new__(CredentialStore)
+        # All keys absent — every provider should 503.
+        creds._keys = {p: None for p in [
+            "anthropic", "openai", "gemini",
+            "mistral", "groq", "together", "openrouter",
+            "fireworks", "deepinfra", "perplexity",
+            "cohere", "replicate",
+            "azure_openai", "azure_openai_endpoint",
+        ]}
+        d = LLMDispatcher(
+            run_id=f"unconf-{provider}", creds=creds,
+            audit_path=tmp_path / "audit.jsonl",
+            token_ttl_s=60, token_budget=5,
+        )
+        try:
+            _, fd = d.allocate_worker(label="unconf-test")
+            token = os.read(fd, 64).decode().strip(); os.close(fd)
+            r = _post_via_dispatcher(d, token, f"http://_{path}", b'{}', {})
+            assert r.status_code == 503, (
+                f"{provider}: expected 503 with key unset, got "
+                f"{r.status_code} {r.text!r}"
+            )
+            assert provider in r.text
+        finally:
+            d.shutdown()
+
+
+class TestCredentialStoreReadsAggregatorEnvs:
+    """Real CredentialStore() — verify every aggregator key is
+    read at init time and the env vars are erased afterwards."""
+
+    def test_all_new_keys_read_then_erased(self, monkeypatch):
+        env_to_set = {
+            "MISTRAL_API_KEY":    "mistral-test",
+            "GROQ_API_KEY":       "groq-test",
+            "TOGETHER_API_KEY":   "together-test",
+            "OPENROUTER_API_KEY": "openrouter-test",
+            "FIREWORKS_API_KEY":  "fireworks-test",
+            "DEEPINFRA_API_KEY":  "deepinfra-test",
+            "PERPLEXITY_API_KEY": "perplexity-test",
+            "COHERE_API_KEY":     "cohere-test",
+            "REPLICATE_API_TOKEN": "replicate-test",
+            "AZURE_OPENAI_API_KEY": "azure-test",
+            "AZURE_OPENAI_ENDPOINT": "https://example-azure.invalid",
+        }
+        for k, v in env_to_set.items():
+            monkeypatch.setenv(k, v)
+        creds = CredentialStore()
+        # Each key landed in the store under the expected name.
+        assert creds.get("mistral") == "mistral-test"
+        assert creds.get("groq") == "groq-test"
+        assert creds.get("together") == "together-test"
+        assert creds.get("openrouter") == "openrouter-test"
+        assert creds.get("fireworks") == "fireworks-test"
+        assert creds.get("deepinfra") == "deepinfra-test"
+        assert creds.get("perplexity") == "perplexity-test"
+        assert creds.get("cohere") == "cohere-test"
+        assert creds.get("replicate") == "replicate-test"
+        assert creds.get("azure_openai") == "azure-test"
+        assert creds.get("azure_openai_endpoint") == "https://example-azure.invalid"
+        # Each env var was erased from os.environ as part of read.
+        for k in env_to_set:
+            assert os.environ.get(k) is None, (
+                f"{k} not erased from environ — leak surface"
+            )


### PR DESCRIPTION
Phase C-β of the LLM credential-isolation arc. Extends the dispatcher with route rules for 10 additional LLM providers so their API keys can flow through the dispatcher instead of the worker process environ — preparing the ground for Phase C activation (drop env passthrough) without breaking workflows that depend on aggregator providers.

Providers added:

  Bearer-auth (Authorization: Bearer <key>) — 8 OpenAI-compatible
  aggregators + Mistral / Cohere ecosystem:
    * mistral      → api.mistral.ai
    * groq         → api.groq.com
    * together     → api.together.xyz
    * openrouter   → openrouter.ai
    * fireworks    → api.fireworks.ai
    * deepinfra    → api.deepinfra.com
    * perplexity   → api.perplexity.ai
    * cohere       → api.cohere.ai

  Other auth shapes:
    * replicate    → api.replicate.com (uses `Token <key>`, not Bearer)
    * azure_openai → operator-set AZURE_OPENAI_ENDPOINT (uses
                     `api-key` header; sentinel URL when endpoint
                     env var is unset, so the rule's 503 path stays
                     consistent with other unconfigured providers)

`CredentialStore.__init__` reads each new key once at startup then erases it from `os.environ` (verified by
test_all_new_keys_read_then_erased — pins zero leak surface across all 11 env vars including AZURE_OPENAI_ENDPOINT).

Out of scope (documented in `auth.py` module docstring):

  * AWS Bedrock — sigv4 signing requires keys in the SDK process address space (signing covers the request body; the proxy can't transparently re-sign without a custom Bedrock-client shim per model family). AWS_* keys keep flowing through env until a future Phase C-γ ships the shim. Operators wanting Bedrock isolation today should use AWS-native short-lived credentials (EC2/EKS instance roles, SSO cache) which obviate the env-var question.

  * GCP Vertex AI — needs `google-auth` integration to refresh bearer tokens from the service-account JSON at request time. Deferred to a focused follow-up; GOOGLE_APPLICATION_CREDENTIALS keeps flowing through env until that lands.

22 new tests in `test_providers.py`:
  * 8 parameterised bearer-auth cases (one per provider) verify real key in Authorization, dummy stripped, path forwarded
  * Replicate-specific test pins the `Token` (not `Bearer`) prefix
  * Azure tests cover both endpoint-set and endpoint-unset paths
  * 10-case parameterised 503 test pins the unconfigured-key UX per provider
  * env-erasure test pins `os.environ` clean after CredentialStore()

53 dispatcher tests + 31 cross-cutting integration/preference tests all pass; no regressions in pre-existing 31 dispatcher tests.

Phase C activation is unchanged by this PR — `LLM_API_KEY_VARS` still flows aggregator keys through env. The next PR can selectively drop them now that the dispatcher route exists.