### PR TITLE
fix(orchestrator): CostTracker has no `total_cost_usd` — use `total_cost'

### DIFF
--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -840,7 +840,7 @@ def orchestrate(
         # Snapshot the cost tracker state BEFORE dispatch so we can
         # tell budget-skipped (no spend) from all-errored (spend
         # incurred but every call failed) afterwards.
-        _ct_before = cost_tracker.total_cost_usd if cost_tracker else 0.0
+        _ct_before = cost_tracker.total_cost if cost_tracker else 0.0
         dispatch_task(
             consensus_task, findings, dispatch_fn, role_resolution,
             results_by_id, cost_tracker, max_parallel,
@@ -872,7 +872,7 @@ def orchestrate(
             isinstance(r, dict) and r.get("consensus")
             for r in results_by_id.values()
         ):
-            _ct_after = cost_tracker.total_cost_usd if cost_tracker else 0.0
+            _ct_after = cost_tracker.total_cost if cost_tracker else 0.0
             if _ct_after > _ct_before:
                 consensus_all_errored = True
             else:


### PR DESCRIPTION
Two call sites in `orchestrate()` reference `cost_tracker.total_cost_usd` but the actual property is `total_cost` (defined at line 63 with `@property def total_cost(self) -> float`). Triggers AttributeError mid-orchestrate, crashing the agentic flow AFTER the analysis pass completes but BEFORE per-finding LLM output is persisted to disk — analysis comes back as `None` in `autonomous_analysis_report.json`, silently losing all the LLM work the operator paid for.

Surfaced when running `/agentic --validate-dataflow` on a real target.

File ".../packages/llm_analysis/orchestrator.py", line 843, in orchestrate
    _ct_before = cost_tracker.total_cost_usd if cost_tracker else 0.0
AttributeError: 'CostTracker' object has no attribute 'total_cost_usd'.
                Did you mean: 'total_cost'?

Two-line fix: lines 843 and 875 both use the wrong attribute name.

The misnamed attribute is `total_cost_usd` from a Claude Code envelope field (line 41 docstring); easy to confuse with the local `CostTracker.total_cost` property. Pre-fix tests didn't catch this because the consensus-skipped path is gated on `eligible AND not any(...consensus_result...)` which our existing test fixtures don't exercise — the crash only surfaces on real findings with consensus enabled (the default for single-model runs).