### PR TITLE
feat(cve-diff): model-agnostic provider resolution

### DIFF
--- a/packages/cve_diff/cve_diff/agent/loop.py
+++ b/packages/cve_diff/cve_diff/agent/loop.py
@@ -317,14 +317,19 @@ class AgentLoop:
                         pass
 
         # ---- Create the provider ----
+        # Resolves the right provider for the model id (so
+        # ``--model gpt-5`` calls OpenAI, ``--model gemini-2.5-pro``
+        # calls Gemini, etc.) and picks the auth path: dispatcher
+        # route when RAPTOR_LLM_SOCKET is set, else env-direct, else
+        # Claude Code OAuth fallback for Anthropic models. See
+        # :mod:`cve_diff.llm.auth` for the resolution rules.
         try:
-            api_key = os.environ.get("ANTHROPIC_API_KEY")
-            if not api_key:
-                raise RuntimeError("ANTHROPIC_API_KEY not set")
+            from cve_diff.llm.auth import resolve_auth
+            decision = resolve_auth(config.model_id)
             model_config = ModelConfig(
-                provider="anthropic",
+                provider=decision.provider,
                 model_name=config.model_id,
-                api_key=api_key,
+                api_key=decision.api_key,
                 timeout=int(self.timeout_s),
             )
             provider = create_provider(model_config)
@@ -336,8 +341,14 @@ class AgentLoop:
             )
 
         # ---- Build provider-specific kwargs ----
+        # ``anthropic_task_budget_*`` are Anthropic-only beta flags
+        # (Claude's task-budget feature for prompt caching / cost
+        # control). Other providers don't support them; gating on
+        # the resolved provider keeps the kwargs from leaking onto
+        # OpenAI / Gemini / aggregator paths where they'd either be
+        # silently dropped or surface as confusing errors.
         provider_kw: dict[str, Any] = {}
-        if config.enable_task_budgets:
+        if config.enable_task_budgets and decision.provider == "anthropic":
             provider_kw["anthropic_task_budget_beta"] = True
             provider_kw["anthropic_task_budget_tokens"] = config.budget_tokens
 

--- a/packages/cve_diff/cve_diff/infra/api_status.py
+++ b/packages/cve_diff/cve_diff/infra/api_status.py
@@ -102,23 +102,32 @@ def api_key_status() -> list[tuple[ApiKeySpec, bool]]:
     return [(s, bool(os.environ.get(s.env_var))) for s in _KEYS]
 
 
-def llm_auth_status() -> tuple[bool, list[str], bool]:
+def llm_auth_status() -> tuple[bool, int, bool]:
     """Resolve the LLM-auth picture for startup-banner rendering.
 
-    Returns ``(any_auth, configured_env_vars, via_dispatcher)``.
-    ``configured_env_vars`` is the subset of
-    ``RaptorConfig.LLM_API_KEY_VARS`` that's currently set in env.
-    ``via_dispatcher`` reflects ``RAPTOR_LLM_SOCKET``.
+    Returns ``(any_auth, num_configured, via_dispatcher)``. We
+    deliberately project the configured-env-var list down to a
+    *count* before this function returns — the env-var names
+    themselves never flow into the rendering pipeline. CodeQL's
+    ``py/clear-text-logging-sensitive-data`` heuristic flags any
+    string from a list named ``LLM_API_KEY_VARS`` reaching a
+    print-call as a credential-leak suspicion, even when the
+    strings are env-var *names* rather than values. Returning a
+    count is the cheapest way to break the dataflow taint without
+    re-introducing a cve-diff-local enumeration of provider env
+    vars (the central :data:`core.config.RaptorConfig.LLM_API_KEY_VARS`
+    stays the only source of truth).
     """
     via_dispatcher = bool(os.environ.get("RAPTOR_LLM_SOCKET"))
-    configured = [v for v in _llm_provider_env_vars()
-                  if os.environ.get(v)]
+    num_configured = sum(
+        1 for v in _llm_provider_env_vars() if os.environ.get(v)
+    )
     # Claude Code OAuth fallback always authenticates Anthropic
     # models when the binary is on PATH; we treat that as
     # operator-facing "always available" rather than probing PATH
     # at startup.
-    any_auth = via_dispatcher or bool(configured) or True  # CC fallback
-    return any_auth, configured, via_dispatcher
+    any_auth = via_dispatcher or num_configured > 0 or True  # CC fallback
+    return any_auth, num_configured, via_dispatcher
 
 
 def render_startup_banner() -> str:
@@ -140,11 +149,15 @@ def render_startup_banner() -> str:
                 f"— {spec.when_missing}"
             )
 
-    # LLM auth — model-agnostic; show every configured env var plus
-    # the dispatcher route. Operator with no provider key + no
+    # LLM auth — model-agnostic; show count of configured env vars
+    # + the dispatcher route. Operator with no provider key + no
     # dispatcher still has the Claude Code OAuth fallback for
     # Anthropic models, so the worst-case is "limited to claude-*".
-    _, configured_vars, via_dispatcher = llm_auth_status()
+    # Operators wanting to know which specific provider env vars
+    # are set can run ``env | grep _API_KEY`` — we deliberately
+    # don't enumerate names here (see ``llm_auth_status`` docstring
+    # for the CodeQL false-positive rationale).
+    _, n_configured, via_dispatcher = llm_auth_status()
     lines.append("LLM auth:")
     if via_dispatcher:
         lines.append(
@@ -152,11 +165,11 @@ def render_startup_banner() -> str:
             "(RAPTOR_LLM_SOCKET set — provider keys handled by "
             "dispatcher, not in worker env)"
         )
-    if configured_vars:
+    if n_configured > 0:
         lines.append(
-            f"  ✓ provider env vars set: {', '.join(configured_vars)}"
+            f"  ✓ {n_configured} LLM provider env var(s) set"
         )
-    if not via_dispatcher and not configured_vars:
+    if not via_dispatcher and n_configured == 0:
         lines.append(
             "  — no LLM provider env var and no dispatcher; cve-diff "
             "will fall back to Claude Code OAuth for Anthropic models. "

--- a/packages/cve_diff/cve_diff/infra/api_status.py
+++ b/packages/cve_diff/cve_diff/infra/api_status.py
@@ -44,11 +44,6 @@ class ApiKeySpec:
 
 _KEYS: tuple[ApiKeySpec, ...] = (
     ApiKeySpec(
-        name="Anthropic",
-        env_var="ANTHROPIC_API_KEY",
-        when_missing="agent runs will fail at first LLM call",
-    ),
-    ApiKeySpec(
         name="GitHub",
         env_var="GITHUB_TOKEN",
         when_missing="GitHub API limited to 60 req/h (vs 5000/h authed) — bench will hit 429s",
@@ -60,6 +55,25 @@ _KEYS: tuple[ApiKeySpec, ...] = (
         optional=True,
     ),
 )
+
+
+# LLM-auth status is rendered separately because cve-diff is now
+# model-agnostic. We read the canonical env-var list from
+# ``core.config.RaptorConfig.LLM_API_KEY_VARS`` so adding a new
+# provider upstream automatically shows up in cve-diff's banner.
+def _llm_provider_env_vars() -> tuple[str, ...]:
+    """Pull the LLM-provider env-var list from the central config.
+
+    Lazy/import-at-call-time so we don't fail to load
+    ``api_status`` when ``core.config`` happens to be importable
+    only in certain test scaffolds. On any failure, fall through
+    to an empty list (banner just shows "no env vars configured").
+    """
+    try:
+        from core.config import RaptorConfig
+        return tuple(RaptorConfig.LLM_API_KEY_VARS)
+    except Exception:
+        return ()
 
 
 def record_rate_limit(service: str, status: int) -> None:
@@ -88,19 +102,67 @@ def api_key_status() -> list[tuple[ApiKeySpec, bool]]:
     return [(s, bool(os.environ.get(s.env_var))) for s in _KEYS]
 
 
+def llm_auth_status() -> tuple[bool, list[str], bool]:
+    """Resolve the LLM-auth picture for startup-banner rendering.
+
+    Returns ``(any_auth, configured_env_vars, via_dispatcher)``.
+    ``configured_env_vars`` is the subset of
+    ``RaptorConfig.LLM_API_KEY_VARS`` that's currently set in env.
+    ``via_dispatcher`` reflects ``RAPTOR_LLM_SOCKET``.
+    """
+    via_dispatcher = bool(os.environ.get("RAPTOR_LLM_SOCKET"))
+    configured = [v for v in _llm_provider_env_vars()
+                  if os.environ.get(v)]
+    # Claude Code OAuth fallback always authenticates Anthropic
+    # models when the binary is on PATH; we treat that as
+    # operator-facing "always available" rather than probing PATH
+    # at startup.
+    any_auth = via_dispatcher or bool(configured) or True  # CC fallback
+    return any_auth, configured, via_dispatcher
+
+
 def render_startup_banner() -> str:
     """Multi-line banner for the start of a `run` or `bench`.
 
-    Lists each API key as set / missing with a hint when missing. Always
-    rendered (this addresses the user's "always, as part of the system"
-    request — the cost is a few lines of stderr at startup)."""
+    Lists each API key as set / missing with a hint when missing.
+    LLM auth is reported separately because cve-diff is model-
+    agnostic: any of the supported providers (or the credential-
+    isolation dispatcher, or Claude Code OAuth) is a valid auth
+    path. Always rendered."""
     lines = ["API keys:"]
     for spec, present in api_key_status():
         if present:
             lines.append(f"  ✓ {spec.name:<10} ({spec.env_var}) set")
         else:
             tag = "—" if spec.optional else "✗"
-            lines.append(f"  {tag} {spec.name:<10} ({spec.env_var}) NOT set — {spec.when_missing}")
+            lines.append(
+                f"  {tag} {spec.name:<10} ({spec.env_var}) NOT set "
+                f"— {spec.when_missing}"
+            )
+
+    # LLM auth — model-agnostic; show every configured env var plus
+    # the dispatcher route. Operator with no provider key + no
+    # dispatcher still has the Claude Code OAuth fallback for
+    # Anthropic models, so the worst-case is "limited to claude-*".
+    _, configured_vars, via_dispatcher = llm_auth_status()
+    lines.append("LLM auth:")
+    if via_dispatcher:
+        lines.append(
+            "  ✓ credential-isolation dispatcher "
+            "(RAPTOR_LLM_SOCKET set — provider keys handled by "
+            "dispatcher, not in worker env)"
+        )
+    if configured_vars:
+        lines.append(
+            f"  ✓ provider env vars set: {', '.join(configured_vars)}"
+        )
+    if not via_dispatcher and not configured_vars:
+        lines.append(
+            "  — no LLM provider env var and no dispatcher; cve-diff "
+            "will fall back to Claude Code OAuth for Anthropic models. "
+            "Set ANTHROPIC_API_KEY (cheapest), GEMINI_API_KEY, or any "
+            "supported provider key to use --model with that family."
+        )
     return "\n".join(lines)
 
 

--- a/packages/cve_diff/cve_diff/infra/service_health.py
+++ b/packages/cve_diff/cve_diff/infra/service_health.py
@@ -82,11 +82,40 @@ def _health_model() -> str:
 
 
 def probe_anthropic() -> HealthResult:
-    """Anthropic: 1-token message to prove reachability."""
+    """Anthropic: 1-token message to prove reachability.
+
+    Skips when no auth is available — accepts either ``ANTHROPIC_API_KEY``
+    or the dispatcher route (``RAPTOR_LLM_SOCKET`` set) as a valid
+    auth path, matching the resolution in :mod:`cve_diff.llm.auth`.
+    Other providers (Gemini, OpenAI, ...) are not probed here yet —
+    when an operator runs cve-diff with ``--model gemini-2.5-pro``
+    and no Anthropic auth, the agent loop's resolver picks Gemini
+    cleanly; this health probe is informational, not gating.
+    """
     api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    via_dispatcher = bool(os.environ.get("RAPTOR_LLM_SOCKET"))
+    if not api_key and not via_dispatcher:
+        # Phrasing keeps the historical "ANTHROPIC_API_KEY not set"
+        # substring so existing test fixtures + scripts grepping for
+        # it still match; the credential-isolation hint is appended
+        # so operators with a dispatcher know the alternative.
+        return HealthResult(
+            "Anthropic API", False, 0,
+            detail=(
+                "ANTHROPIC_API_KEY not set (or run with "
+                "RAPTOR_LLM_SOCKET for credential-isolation dispatcher)"
+            ),
+        )
     if not api_key:
-        return HealthResult("Anthropic API", False, 0,
-                            detail="ANTHROPIC_API_KEY not set")
+        # Dispatcher route — the API call would succeed via
+        # dispatcher-injected headers, but we can't probe upstream
+        # from this layer without setting up an httpx UDS client.
+        # Surface as healthy + dispatcher-noted so operators see
+        # auth is wired up.
+        return HealthResult(
+            "Anthropic API", True, 0,
+            detail="auth via credential-isolation dispatcher",
+        )
     start = time.monotonic()
     body = json.dumps({"model": _health_model(), "max_tokens": 1,
                        "messages": [{"role": "user", "content": "x"}]}).encode()

--- a/packages/cve_diff/cve_diff/llm/auth.py
+++ b/packages/cve_diff/cve_diff/llm/auth.py
@@ -1,0 +1,68 @@
+"""Provider resolution + Claude Code OAuth fallback for cve-diff.
+
+cve-diff is model-agnostic: ``--model gpt-5`` calls OpenAI,
+``--model gemini-2.5-pro`` calls Gemini, etc. Provider resolution
+delegates to :func:`core.security.llm_family.provider_of`.
+
+Auth resolution delegates to :mod:`core.llm.providers` — the provider
+class checks ``RAPTOR_LLM_SOCKET`` and routes via the credential-
+isolation dispatcher when set, else lets the SDK read its own env
+var. cve-diff doesn't need to enumerate provider env vars; the
+central LLM config (:data:`core.config.RaptorConfig.LLM_API_KEY_VARS`)
+does that already.
+
+cve-diff's only special case: when the operator wants an Anthropic
+model but has neither ``ANTHROPIC_API_KEY`` nor the dispatcher,
+fall through to ``provider="claudecode"`` so Claude Code's OAuth
+auth handles the call (historical cve-diff behaviour: cheap-by-
+default Anthropic preference). Other providers don't have this
+fallback — passing ``--model gpt-5`` with no OpenAI auth surfaces
+a clear SDK error.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class AuthDecision:
+    """Resolution result for a model id.
+
+    ``provider`` is what the caller should pass to ``ModelConfig``.
+    ``api_key`` is left as ``None`` so the provider's SDK reads
+    its own env var directly (``ANTHROPIC_API_KEY`` etc.) or the
+    dispatcher route in :mod:`core.llm.providers` handles auth.
+    """
+    provider: str
+    api_key: Optional[str] = None
+    via_dispatcher: bool = False
+
+
+def resolve_auth(model_id: str) -> AuthDecision:
+    """Resolve provider from model id, with the Claude Code OAuth
+    fallback for Anthropic models when no other auth is available."""
+    # Lazy import — keep this module importable in minimal envs.
+    from core.security.llm_family import provider_of
+
+    provider = provider_of(model_id) or "anthropic"
+    via_dispatcher = bool(os.environ.get("RAPTOR_LLM_SOCKET"))
+
+    # Claude Code OAuth fallback for Anthropic-family models when
+    # neither dispatcher nor ANTHROPIC_API_KEY is available.
+    # Historical cve-diff behaviour preserved (operator without an
+    # Anthropic key but with Claude Code installed gets free
+    # Anthropic-routed analysis).
+    if (provider == "anthropic"
+            and not via_dispatcher
+            and not os.environ.get("ANTHROPIC_API_KEY")):
+        return AuthDecision(provider="claudecode")
+
+    # Everything else: hand off to ``core.llm.providers``. Pass
+    # ``api_key=None`` so the SDK / dispatcher route picks it up
+    # without cve-diff needing to enumerate provider env vars.
+    # If neither auth path is set, the SDK construction surfaces
+    # a clean error at first use.
+    return AuthDecision(provider=provider, via_dispatcher=via_dispatcher)

--- a/packages/cve_diff/cve_diff/llm/client.py
+++ b/packages/cve_diff/cve_diff/llm/client.py
@@ -50,18 +50,19 @@ class CostBudgetExceeded(RuntimeError):
 def _provider_for_model(model_id: str, timeout_s: float) -> LLMProvider:
     """Build a provider from a model id string.
 
-    Uses Anthropic when ANTHROPIC_API_KEY is set; falls through to other
-    providers via the standard ``create_provider`` factory.
+    Resolves provider from the model id — so ``--model gpt-5`` actually
+    calls OpenAI, ``--model gemini-2.5-pro`` calls Gemini, etc. Auth
+    layers are: ``RAPTOR_LLM_SOCKET`` (dispatcher route) → provider's
+    env var → Claude Code OAuth fallback for Anthropic models. See
+    :mod:`cve_diff.llm.auth` for the full resolution rules.
     """
-    provider_name = "anthropic"
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
-        provider_name = "claudecode"
-        api_key = None
+    from .auth import resolve_auth
+
+    decision = resolve_auth(model_id)
     config = ModelConfig(
-        provider=provider_name,
+        provider=decision.provider,
         model_name=model_id,
-        api_key=api_key,
+        api_key=decision.api_key,
         timeout=int(timeout_s),
     )
     return create_provider(config)

--- a/packages/cve_diff/tests/unit/agent/test_loop.py
+++ b/packages/cve_diff/tests/unit/agent/test_loop.py
@@ -143,10 +143,28 @@ def _submit_call(
 # ---------- tests -----------
 
 def test_client_init_failure_surrenders(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When provider construction raises (e.g. SDK rejects the
+    config, dispatcher unreachable, etc.) the agent surrenders
+    with reason="client_init_failed" rather than crashing.
+
+    Previously this test simply dropped ``ANTHROPIC_API_KEY``, but
+    after cve-diff went model-agnostic the resolver falls through
+    to Claude Code OAuth for Anthropic models — which doesn't
+    surrender at init, it tries to spawn ``claude``. We now mock
+    ``create_provider`` to raise, which exercises the surrender
+    code path directly without depending on env shape."""
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("RAPTOR_LLM_SOCKET", raising=False)
+    monkeypatch.setattr(
+        "cve_diff.agent.loop.create_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            RuntimeError("simulated SDK init failure"),
+        ),
+    )
     result = AgentLoop().run(_cfg(), AgentContext(cve_id="CVE-X"))
     assert isinstance(result, AgentSurrender)
     assert result.reason == "client_init_failed"
+    assert "simulated SDK init failure" in result.detail
 
 
 def test_immediate_submit_rescued(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/cve_diff/tests/unit/infra/test_api_status.py
+++ b/packages/cve_diff/tests/unit/infra/test_api_status.py
@@ -86,24 +86,58 @@ def test_reset_clears_events() -> None:
 
 
 def test_api_key_status_present_and_missing(monkeypatch) -> None:
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    """Non-LLM API keys (GitHub, NVD) are still tracked here.
+    LLM-provider env vars moved out of ``api_key_status`` after
+    cve-diff went model-agnostic — they're rendered by
+    ``llm_auth_status`` which iterates over the central
+    ``RaptorConfig.LLM_API_KEY_VARS`` list."""
     monkeypatch.setenv("GITHUB_TOKEN", "t")
     monkeypatch.delenv("NVD_API_KEY", raising=False)
 
     keys = {spec.name: present for spec, present in api_status.api_key_status()}
-    assert keys["Anthropic"] is True
     assert keys["GitHub"] is True
     assert keys["NVD"] is False
+    # Anthropic / OpenAI / etc. are no longer tracked here:
+    assert "Anthropic" not in keys
+
+
+def test_llm_auth_status_reflects_central_env_var_list(monkeypatch) -> None:
+    """``llm_auth_status`` reads the LLM-provider env-var list from
+    ``RaptorConfig.LLM_API_KEY_VARS`` (single source of truth) — no
+    cve-diff-local enumeration. Setting any provider's env var shows
+    up; setting RAPTOR_LLM_SOCKET also surfaces."""
+    # Clear all LLM provider env vars to start from a known state.
+    from core.config import RaptorConfig
+    for var in RaptorConfig.LLM_API_KEY_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv("RAPTOR_LLM_SOCKET", raising=False)
+
+    monkeypatch.setenv("GEMINI_API_KEY", "g")
+    monkeypatch.setenv("MISTRAL_API_KEY", "m")
+    _, configured, via_dispatcher = api_status.llm_auth_status()
+    assert "GEMINI_API_KEY" in configured
+    assert "MISTRAL_API_KEY" in configured
+    assert via_dispatcher is False
+
+    monkeypatch.setenv("RAPTOR_LLM_SOCKET", "/tmp/fake.sock")
+    _, _, via_dispatcher = api_status.llm_auth_status()
+    assert via_dispatcher is True
 
 
 def test_startup_banner_shows_set_and_missing(monkeypatch) -> None:
+    """LLM auth is now rendered in its own ``LLM auth:`` section
+    rather than inline in ``API keys:``. Anthropic-via-env shows up
+    as a configured provider env var; GitHub/NVD render as before."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("NVD_API_KEY", raising=False)
+    monkeypatch.delenv("RAPTOR_LLM_SOCKET", raising=False)
 
     banner = api_status.render_startup_banner()
     assert "API keys:" in banner
-    assert "Anthropic" in banner and "set" in banner
+    # Anthropic is now in the LLM-auth section (env-var name).
+    assert "LLM auth:" in banner
+    assert "ANTHROPIC_API_KEY" in banner
     # NVD is optional → "—" tag, not "✗"
     assert "✗ GitHub" in banner
     assert "— NVD" in banner or "NVD       (NVD_API_KEY) NOT set" in banner

--- a/packages/cve_diff/tests/unit/infra/test_api_status.py
+++ b/packages/cve_diff/tests/unit/infra/test_api_status.py
@@ -104,9 +104,9 @@ def test_api_key_status_present_and_missing(monkeypatch) -> None:
 def test_llm_auth_status_reflects_central_env_var_list(monkeypatch) -> None:
     """``llm_auth_status`` reads the LLM-provider env-var list from
     ``RaptorConfig.LLM_API_KEY_VARS`` (single source of truth) — no
-    cve-diff-local enumeration. Setting any provider's env var shows
-    up; setting RAPTOR_LLM_SOCKET also surfaces."""
-    # Clear all LLM provider env vars to start from a known state.
+    cve-diff-local enumeration. Result is a *count* of configured
+    vars, not their names — see ``llm_auth_status`` docstring for
+    the CodeQL-false-positive rationale."""
     from core.config import RaptorConfig
     for var in RaptorConfig.LLM_API_KEY_VARS:
         monkeypatch.delenv(var, raising=False)
@@ -114,9 +114,8 @@ def test_llm_auth_status_reflects_central_env_var_list(monkeypatch) -> None:
 
     monkeypatch.setenv("GEMINI_API_KEY", "g")
     monkeypatch.setenv("MISTRAL_API_KEY", "m")
-    _, configured, via_dispatcher = api_status.llm_auth_status()
-    assert "GEMINI_API_KEY" in configured
-    assert "MISTRAL_API_KEY" in configured
+    _, n_configured, via_dispatcher = api_status.llm_auth_status()
+    assert n_configured == 2
     assert via_dispatcher is False
 
     monkeypatch.setenv("RAPTOR_LLM_SOCKET", "/tmp/fake.sock")
@@ -124,10 +123,31 @@ def test_llm_auth_status_reflects_central_env_var_list(monkeypatch) -> None:
     assert via_dispatcher is True
 
 
+def test_banner_does_not_leak_provider_env_var_names(monkeypatch) -> None:
+    """The banner must not name specific LLM-provider env vars.
+    CodeQL flags ``LLM_API_KEY_VARS`` strings flowing into print
+    as a clear-text-credential leak (false positive — the strings
+    are env-var *names*, not values), and the count-only design is
+    cheaper than arguing with the heuristic. Pin so a future
+    "helpful" PR doesn't put them back into the output."""
+    from core.config import RaptorConfig
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    monkeypatch.delenv("RAPTOR_LLM_SOCKET", raising=False)
+    banner = api_status.render_startup_banner()
+    # No provider env-var name appears verbatim:
+    for var in RaptorConfig.LLM_API_KEY_VARS:
+        assert var not in banner, (
+            f"banner leaks provider env-var name {var!r} — "
+            f"CodeQL will flag this as clear-text credential "
+            f"logging. Use the count-only output."
+        )
+
+
 def test_startup_banner_shows_set_and_missing(monkeypatch) -> None:
-    """LLM auth is now rendered in its own ``LLM auth:`` section
-    rather than inline in ``API keys:``. Anthropic-via-env shows up
-    as a configured provider env var; GitHub/NVD render as before."""
+    """LLM auth is rendered in its own ``LLM auth:`` section as a
+    count of configured providers (see ``llm_auth_status``).
+    GitHub/NVD render with their full names as before."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("NVD_API_KEY", raising=False)
@@ -135,9 +155,10 @@ def test_startup_banner_shows_set_and_missing(monkeypatch) -> None:
 
     banner = api_status.render_startup_banner()
     assert "API keys:" in banner
-    # Anthropic is now in the LLM-auth section (env-var name).
+    # LLM auth section present with a count, no specific env var
+    # name (CodeQL-false-positive defuse):
     assert "LLM auth:" in banner
-    assert "ANTHROPIC_API_KEY" in banner
+    assert "1 LLM provider env var" in banner
     # NVD is optional → "—" tag, not "✗"
     assert "✗ GitHub" in banner
     assert "— NVD" in banner or "NVD       (NVD_API_KEY) NOT set" in banner

--- a/packages/cve_diff/tests/unit/llm/test_auth.py
+++ b/packages/cve_diff/tests/unit/llm/test_auth.py
@@ -1,0 +1,220 @@
+"""Tests for cve-diff's model→provider→auth resolver.
+
+Covers:
+  * model-id → provider routing for every supported family
+  * RAPTOR_LLM_SOCKET takes precedence (dispatcher route)
+  * env-var direct auth (any provider's env var lets the SDK
+    pick it up without cve-diff naming the var)
+  * Claude Code OAuth fallback for Anthropic models when no
+    other auth is available
+  * Non-Anthropic models never get the CC fallback
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from cve_diff.llm.auth import AuthDecision, resolve_auth
+
+
+@pytest.fixture(autouse=True)
+def _clean_llm_env(monkeypatch):
+    """Strip every LLM-provider env var + RAPTOR_LLM_SOCKET so each
+    test starts from a known state. Pulls the canonical list from
+    central config — no cve-diff-local enumeration."""
+    from core.config import RaptorConfig
+    for var in RaptorConfig.LLM_API_KEY_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv("RAPTOR_LLM_SOCKET", raising=False)
+
+
+# ---------------------------------------------------------------------
+# Provider resolution from model id
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model_id,expected_provider",
+    [
+        ("claude-opus-4-7",         "claudecode"),  # CC fallback (no key)
+        ("claude-sonnet-4-6",       "claudecode"),
+        ("claude-haiku-4-5",        "claudecode"),
+    ],
+)
+def test_anthropic_models_fall_back_to_claudecode_without_auth(
+    model_id, expected_provider,
+):
+    """Anthropic-family models with no env key + no dispatcher fall
+    through to Claude Code OAuth — historical cve-diff behaviour
+    preserved."""
+    decision = resolve_auth(model_id)
+    assert decision.provider == expected_provider
+    assert decision.api_key is None
+    assert decision.via_dispatcher is False
+
+
+@pytest.mark.parametrize(
+    "model_id,expected_provider",
+    [
+        ("claude-opus-4-7",      "anthropic"),
+        ("gpt-5",                "openai"),
+        ("gemini-2.5-pro",       "gemini"),
+        ("mistral-large-latest", "mistral"),
+    ],
+)
+def test_provider_from_model_id_with_anthropic_key(
+    monkeypatch, model_id, expected_provider,
+):
+    """When ``ANTHROPIC_API_KEY`` is set, Anthropic models route to
+    ``anthropic``. Other-family models still resolve to their own
+    provider — cve-diff is model-agnostic. ``api_key`` stays None
+    because cve-diff defers to the SDK to read its own env var
+    (matches the central LLM-config pattern; cve-diff doesn't
+    enumerate provider env vars itself)."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "real-anthropic")
+    decision = resolve_auth(model_id)
+    assert decision.provider == expected_provider
+    assert decision.api_key is None
+    assert decision.via_dispatcher is False
+
+
+@pytest.mark.parametrize(
+    "env_var,model_id,expected_provider",
+    [
+        ("OPENAI_API_KEY",  "gpt-5",                "openai"),
+        ("GEMINI_API_KEY",  "gemini-2.5-pro",       "gemini"),
+        ("MISTRAL_API_KEY", "mistral-large-latest", "mistral"),
+    ],
+)
+def test_other_providers_resolve_with_their_env_var(
+    monkeypatch, env_var, model_id, expected_provider,
+):
+    """Setting any non-Anthropic provider's env var lets cve-diff
+    use that provider for matching models — no Anthropic key
+    required, no Claude Code fallback. Operator with only Gemini
+    can run cve-diff.
+
+    Aggregator-prefixed models (``groq/...``, ``openrouter/...``)
+    are deliberately not tested here — ``provider_of`` peels the
+    aggregator prefix to find the underlying *family* (e.g.
+    ``groq/llama-3.3-70b`` → ``ollama``/meta, not ``groq``), which
+    is correct for cross-family safety but means routing to the
+    aggregator API requires a separate aggregator-aware resolver.
+    Pre-existing issue independent of this refactor; tracked
+    separately."""
+    monkeypatch.setenv(env_var, "real-key")
+    decision = resolve_auth(model_id)
+    assert decision.provider == expected_provider
+    assert decision.via_dispatcher is False
+
+
+# ---------------------------------------------------------------------
+# Dispatcher route
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model_id,expected_provider",
+    [
+        ("claude-opus-4-7",      "anthropic"),
+        ("gpt-5",                "openai"),
+        ("gemini-2.5-pro",       "gemini"),
+        ("mistral-large-latest", "mistral"),
+    ],
+)
+def test_dispatcher_socket_overrides_other_paths(
+    monkeypatch, model_id, expected_provider,
+):
+    """``RAPTOR_LLM_SOCKET`` set → dispatcher route wins over both
+    env-direct and Claude Code fallback. The dispatcher's
+    ``CredentialStore`` handles auth; cve-diff doesn't see keys."""
+    monkeypatch.setenv("RAPTOR_LLM_SOCKET", "/tmp/fake.sock")
+    # Even WITH Anthropic key set, dispatcher route still wins:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "would-be-direct")
+    decision = resolve_auth(model_id)
+    assert decision.via_dispatcher is True
+    assert decision.provider == expected_provider
+    # ``api_key`` is None — provider's dispatcher branch uses
+    # the dispatcher's CredentialStore, not the value in env.
+    assert decision.api_key is None
+
+
+def test_dispatcher_skips_claudecode_fallback_for_anthropic():
+    """Dispatcher route is a real auth path; Anthropic-with-dispatcher
+    must NOT fall through to claudecode (which would dispatch via
+    Claude Code OAuth instead of Anthropic API)."""
+    os.environ["RAPTOR_LLM_SOCKET"] = "/tmp/fake.sock"
+    try:
+        decision = resolve_auth("claude-opus-4-7")
+        assert decision.provider == "anthropic"
+        assert decision.via_dispatcher is True
+    finally:
+        os.environ.pop("RAPTOR_LLM_SOCKET", None)
+
+
+# ---------------------------------------------------------------------
+# Negative cases
+# ---------------------------------------------------------------------
+
+
+def test_non_anthropic_model_no_auth_does_not_fall_to_claudecode():
+    """An OpenAI / Gemini / Mistral model with no key + no dispatcher
+    must NOT silently re-route to Claude Code (operator passed
+    ``--model gpt-5``; falling to claudecode would silently use
+    Claude instead). The decision is handed to ``core.llm.providers``
+    which surfaces a clear SDK error at first call."""
+    # No env var set, no dispatcher.
+    decision = resolve_auth("gpt-5")
+    assert decision.provider == "openai"
+    assert decision.api_key is None
+    assert decision.via_dispatcher is False
+    # The "ok"-style boolean isn't on AuthDecision anymore — cve-diff
+    # always hands off to providers.py and lets the SDK raise.
+    # This test exists to pin that we don't quietly fall back.
+
+
+def test_unknown_model_id_defaults_to_anthropic():
+    """Provider resolver returns "" for unknown model ids; cve-diff
+    falls back to Anthropic for the historical default-cheap
+    behaviour. Important: a typo'd model name shouldn't crash hard;
+    it should land somewhere sensible."""
+    decision = resolve_auth("not-a-real-model-name-12345")
+    # Falls to claudecode because no Anthropic key + no dispatcher.
+    assert decision.provider == "claudecode"
+
+
+# ---------------------------------------------------------------------
+# Module-shape pin
+# ---------------------------------------------------------------------
+
+
+def test_auth_module_does_not_enumerate_provider_env_vars():
+    """cve-diff's auth resolver must not maintain its own list of
+    LLM-provider env vars — that list belongs in
+    ``core.config.RaptorConfig.LLM_API_KEY_VARS`` (single source of
+    truth). The resolver looks at exactly two env vars:
+    ``ANTHROPIC_API_KEY`` (for the CC fallback decision) and
+    ``RAPTOR_LLM_SOCKET`` (for dispatcher routing). Pin this so a
+    future change that adds a new provider doesn't accidentally
+    grow a parallel list here."""
+    import inspect
+    from cve_diff.llm import auth
+    src = inspect.getsource(auth)
+    # The only API-key env var name allowed in the source: Anthropic
+    # (for the CC fallback). Other provider env vars must NOT appear.
+    forbidden = [
+        "OPENAI_API_KEY", "GEMINI_API_KEY", "MISTRAL_API_KEY",
+        "GROQ_API_KEY", "TOGETHER_API_KEY", "OPENROUTER_API_KEY",
+        "FIREWORKS_API_KEY", "DEEPINFRA_API_KEY",
+        "PERPLEXITY_API_KEY", "COHERE_API_KEY",
+        "REPLICATE_API_TOKEN", "AZURE_OPENAI_API_KEY",
+    ]
+    leaked = [v for v in forbidden if v in src]
+    assert not leaked, (
+        f"cve_diff/llm/auth.py enumerates provider env vars: "
+        f"{leaked}. The central LLM config "
+        f"(RaptorConfig.LLM_API_KEY_VARS) should be the only place "
+        f"that lists them."
+    )


### PR DESCRIPTION
cve-diff's CLI accepted --model but agent/loop.py and llm/client.py hardcoded provider="anthropic" and demanded ANTHROPIC_API_KEY regardless of model. So `cve-diff --model gpt-5` either crashed or sent the model id to the Anthropic SDK.

Add cve_diff/llm/auth.py — resolves provider from model id via core.security.llm_family.provider_of, defers auth to core.llm.providers (dispatcher route via RAPTOR_LLM_SOCKET, else SDK reads its own env var). Claude Code OAuth fallback preserved for Anthropic-family models with no other auth.

Refactored 4 sites: llm/client.py, agent/loop.py, infra/api_status.py (LLM auth section now reads RaptorConfig.LLM_API_KEY_VARS — single source of truth, no cve-diff-local enumeration), and infra/service_health.py (accepts dispatcher route).

cve-diff now works with only GEMINI_API_KEY / MISTRAL_API_KEY / any supported provider key — no Anthropic key required.

18 new tests + 12/12 E2E provider-construction proofs across every path (Anthropic / OpenAI / Gemini / Mistral / Claude Code fallback / dispatcher route). Pin test prevents auth.py from re-acquiring a provider-env-var list. 652 cve-diff unit tests pass; no regressions.

Prerequisite for credential-isolation Phase C activation.