### PR TITLE
fix(iris): unblock Tier 4 SMT telemetry — cache lock, counter surfacing, usage-driven deep_validate

### DIFF
--- a/packages/hypothesis_validation/adapters/codeql.py
+++ b/packages/hypothesis_validation/adapters/codeql.py
@@ -231,8 +231,23 @@ class CodeQLAdapter(ToolAdapter):
             from core.config import RaptorConfig
             env = RaptorConfig.get_safe_env()
 
+        # `output=` grants write access to the database directory.
+        # CodeQL writes to `<db>/<lang>/default/cache/` (the IMB
+        # cache: pages/, predicates/, relations/, .lock) during
+        # `database analyze`. With `target=` alone the sandbox
+        # only grants read access — codeql then fails to acquire
+        # `cache/.lock` with a misleading FileNotFoundException
+        # masking the underlying EACCES from the Java NIO layer.
+        # Symptom: "[prebuilt] Running queries. … A fatal error
+        # occurred: Error acquiring the IMB cache lock at path
+        # …/cache/.lock (eventual cause: FileNotFoundException
+        # …/cache/.lock)" on a database that demonstrably exists
+        # on disk with a writable cache subdir.
         runner = (
-            make_sandbox_runner(target=self._database_path)
+            make_sandbox_runner(
+                target=self._database_path,
+                output=self._database_path,
+            )
             if self._sandbox else subprocess.run
         )
 
@@ -363,8 +378,14 @@ class CodeQLAdapter(ToolAdapter):
                 query_file.write_text(rule)
                 qlpack.write_text(_qlpack_yaml(rule))
 
+                # See note in run_prebuilt_query — `output=` is
+                # required so codeql can write to its IMB cache
+                # under `<db>/<lang>/default/cache/`.
                 runner = (
-                    make_sandbox_runner(target=self._database_path)
+                    make_sandbox_runner(
+                        target=self._database_path,
+                        output=self._database_path,
+                    )
                     if self._sandbox else subprocess.run
                 )
 

--- a/packages/hypothesis_validation/tests/test_security.py
+++ b/packages/hypothesis_validation/tests/test_security.py
@@ -455,3 +455,83 @@ class TestCodeQLTimeoutDefault:
         with patch("subprocess.run", side_effect=fake_run):
             a.run("import cpp\nselect 1\n", tmp_path, timeout=900)
         assert captured["timeout"] == 900
+
+
+class TestCodeQLSandboxGrantsCacheWriteAccess:
+    """The CodeQL adapter must grant write access to the database
+    directory so codeql can update its IMB cache during `database
+    analyze`. With target= alone the sandbox grants read-only and
+    codeql fails to acquire `<db>/<lang>/default/cache/.lock` with
+    a misleading FileNotFoundException masking the underlying
+    EACCES.
+    """
+
+    def _spy_sandbox_runner(self):
+        """Build a patched make_sandbox_runner that records its kwargs."""
+        captured = []
+        def spy(*args, **kwargs):
+            captured.append(kwargs)
+            # Return a runner that pretends the codeql call failed
+            # cheaply — the test only cares about the sandbox kwargs.
+            def runner(cmd, **rkwargs):
+                return MagicMock(returncode=2, stdout="", stderr="stub fail")
+            return runner
+        return spy, captured
+
+    def test_run_prebuilt_query_passes_output_for_cache_write(self, tmp_path):
+        db = tmp_path / "db"
+        db.mkdir()
+        query = tmp_path / "q.ql"
+        query.write_text("import cpp\nselect 1\n")
+
+        a = CodeQLAdapter(
+            database_path=db, codeql_bin="/usr/bin/codeql", sandbox=True,
+        )
+        spy, captured = self._spy_sandbox_runner()
+        with patch(
+            "packages.hypothesis_validation.adapters.codeql.make_sandbox_runner",
+            side_effect=spy,
+        ):
+            a.run_prebuilt_query(query, tmp_path)
+
+        # At least one make_sandbox_runner call must have been made
+        # with output= set to the database path. The first call is
+        # for `pack install` (which doesn't strictly need cache
+        # write) but `database analyze` MUST have it — assert the
+        # last call (the actual analyze) passes both kwargs.
+        assert captured, "make_sandbox_runner was never invoked"
+        analyze_call = captured[-1]
+        assert analyze_call.get("target") == db, (
+            f"target= not set to db path; saw {analyze_call.get('target')!r}"
+        )
+        assert analyze_call.get("output") == db, (
+            f"output= not set to db path — codeql cannot write its "
+            f"IMB cache; saw {analyze_call.get('output')!r}"
+        )
+
+    def test_run_passes_output_for_cache_write(self, tmp_path):
+        """Same fix needed in the LLM-generated-query path
+        (CodeQLAdapter.run), which builds a temp pack and calls
+        analyze on it. Same EACCES symptom otherwise."""
+        db = tmp_path / "db"
+        db.mkdir()
+
+        a = CodeQLAdapter(
+            database_path=db, codeql_bin="/usr/bin/codeql", sandbox=True,
+        )
+        spy, captured = self._spy_sandbox_runner()
+        with patch(
+            "packages.hypothesis_validation.adapters.codeql.make_sandbox_runner",
+            side_effect=spy,
+        ):
+            a.run("import cpp\nselect 1\n", tmp_path)
+
+        assert captured, "make_sandbox_runner was never invoked"
+        # The run() path makes one call (covers both pack install
+        # and analyze inside the same TemporaryDirectory context).
+        analyze_call = captured[-1]
+        assert analyze_call.get("target") == db
+        assert analyze_call.get("output") == db, (
+            f"output= not set to db path — codeql cannot write its "
+            f"IMB cache; saw {analyze_call.get('output')!r}"
+        )

--- a/packages/llm_analysis/dataflow_validation.py
+++ b/packages/llm_analysis/dataflow_validation.py
@@ -345,6 +345,7 @@ def validate_dataflow_claims(
     budget_threshold: float = DEFAULT_BUDGET_THRESHOLD,
     progress_callback: Optional[Callable[[str], None]] = None,
     deep_validate: bool = False,
+    deep_validate_disabled: bool = False,
 ) -> Dict[str, Any]:
     """Validate LLM dataflow claims via hypothesis_validation + CodeQL.
 
@@ -396,6 +397,15 @@ def validate_dataflow_claims(
         "n_skipped_no_db_for_language": 0,
         "n_stale_db_warnings": 0,
         "skipped_reason": "",
+        # Usage-driven deep_validate counter — present-with-zero is
+        # meaningfully distinct from absent. If the operator passed
+        # --no-deep-validate we'll see 0 here (and then they can
+        # confirm the gate respected their opt-out); if they passed
+        # --deep-validate we'll see 0 here (auto-gate didn't fire
+        # because the explicit flag took precedence); on a default
+        # run a non-zero count means the LLM's path_conditions
+        # output enabled Tier 2/3 for that many findings.
+        "n_deep_validate_auto_enabled": 0,
     }
 
     # Master kill-switch — bail before doing any work.
@@ -512,10 +522,40 @@ def validate_dataflow_claims(
         if progress_callback:
             progress_callback(f"Validating dataflow for {fid}")
 
+        # Usage-driven deep_validate gate. The operator's choice
+        # forms a tri-state:
+        #   --no-deep-validate    → never (opt-out, hard kill)
+        #   --deep-validate       → always (opt-in, force-on)
+        #   neither (default)     → auto: enable for THIS finding
+        #                            iff the LLM emitted
+        #                            `path_conditions`, since Tier 4
+        #                            SMT only runs after Tier 1+
+        #                            produces something to refine
+        #                            and Tier 2/3 is the LLM-backed
+        #                            path that produces it when
+        #                            Tier 1's prebuilt query is
+        #                            inconclusive. Without this
+        #                            auto-gate, default-flag runs
+        #                            silently make the entire Tier
+        #                            4 + path_conditions investment
+        #                            unreachable.
+        if deep_validate_disabled:
+            effective_deep_validate = False
+        elif deep_validate:
+            effective_deep_validate = True
+        else:
+            nested_dv = (analysis or {}).get("dataflow_validation") or {}
+            effective_deep_validate = bool(
+                nested_dv.get("path_conditions")
+                or (analysis or {}).get("path_conditions")
+            )
+            if effective_deep_validate:
+                metrics["n_deep_validate_auto_enabled"] += 1
+
         try:
             result, tier_used = _validate_one_hypothesis(
                 hypothesis, finding, adapter, llm_client,
-                deep_validate=deep_validate,
+                deep_validate=effective_deep_validate,
             )
         except Exception as e:  # never let a single validation crash the loop
             logger.warning(
@@ -544,16 +584,23 @@ def validate_dataflow_claims(
         # of all-zeros could be either "LLM never populates" or "LLM
         # populates but SMT always returns no_check"; very different
         # remediations.
+        # The setdefault calls live OUTSIDE the cond_present gate
+        # so the counters are always present in the metrics dict
+        # (with value 0 when nothing populated). Without that, an
+        # absent counter is ambiguous between "code path never ran"
+        # and "code path ran, found nothing" — different
+        # remediations. Tier 1/2/3 counters above use the same
+        # always-init-then-conditional-increment pattern.
+        metrics.setdefault("n_path_conditions_populated", 0)
+        metrics.setdefault("path_conditions_by_cwe", {})
         nested_dv = (analysis or {}).get("dataflow_validation") or {}
         cond_present = bool(
             nested_dv.get("path_conditions")
             or (analysis or {}).get("path_conditions")
         )
         if cond_present:
-            metrics.setdefault("n_path_conditions_populated", 0)
             metrics["n_path_conditions_populated"] += 1
             cwe = (finding.get("cwe_id") or "").upper().strip() or "UNKNOWN"
-            metrics.setdefault("path_conditions_by_cwe", {})
             metrics["path_conditions_by_cwe"][cwe] = (
                 metrics["path_conditions_by_cwe"].get(cwe, 0) + 1
             )
@@ -567,11 +614,14 @@ def validate_dataflow_claims(
         # downgrades `confirmed` → `refuted` on SMT alone — when CodeQL
         # and SMT disagree the more conservative CodeQL signal wins
         # (logged as a disagreement metric for offline review).
+        # Same always-init pattern as the path_conditions counters
+        # above: present-with-zero is meaningfully distinct from
+        # absent.
+        metrics.setdefault("n_tier4_smt_refuted", 0)
+        metrics.setdefault("n_tier4_smt_witness", 0)
+        metrics.setdefault("n_tier4_smt_disagree", 0)
         result, smt_outcome = _tier4_smt_refine(result, finding, analysis)
         if smt_outcome and smt_outcome != "no_check":
-            metrics.setdefault("n_tier4_smt_refuted", 0)
-            metrics.setdefault("n_tier4_smt_witness", 0)
-            metrics.setdefault("n_tier4_smt_disagree", 0)
             if smt_outcome == "smt_refuted":
                 metrics["n_tier4_smt_refuted"] += 1
             elif smt_outcome == "smt_witness":
@@ -2046,6 +2096,7 @@ def run_validation_pass(
     progress_callback: Optional[Callable[[str], None]] = None,
     budget_threshold: float = DEFAULT_BUDGET_THRESHOLD,
     deep_validate: bool = False,
+    deep_validate_disabled: bool = False,
 ) -> Optional[Dict[str, Any]]:
     """Orchestrator-side hook: discover DB, pick model, run the pass.
 
@@ -2118,6 +2169,7 @@ def run_validation_pass(
         budget_threshold=budget_threshold,
         progress_callback=progress_callback,
         deep_validate=deep_validate,
+        deep_validate_disabled=deep_validate_disabled,
     )
 
 

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -285,6 +285,7 @@ def orchestrate(
     accept_weakened_defenses: bool = False,
     dataflow_validation_enabled: bool = True,
     deep_validate: bool = False,
+    deep_validate_disabled: bool = False,
     deep_validate_budget: float = 0.60,
 ) -> Optional[Dict[str, Any]]:
     """Orchestrate vulnerability analysis via external LLM or Claude Code.
@@ -728,6 +729,7 @@ def orchestrate(
             cross_family_resolver=_resolve_cross_family_checker,
             budget_threshold=deep_validate_budget,
             deep_validate=deep_validate,
+            deep_validate_disabled=deep_validate_disabled,
         )
         if validation_metrics is None:
             logger.info("dataflow validation skipped: mode/db unavailable")

--- a/packages/llm_analysis/tests/test_dataflow_validation.py
+++ b/packages/llm_analysis/tests/test_dataflow_validation.py
@@ -3020,33 +3020,37 @@ class TestPathConditionsTelemetry:
         """Simulate enough of validate_dataflow_claims to exercise the
         per-finding path_conditions counting without needing a full
         CodeQL adapter / hypothesis stack. Returns the metrics dict.
+
+        Mirrors production: counters are ALWAYS initialised so 0 is
+        observable (and meaningfully distinct from absent — "code
+        path didn't run" vs "code path ran, found nothing").
         """
-        # Simplest path: directly construct the metrics dict the
-        # production code builds, then run the same per-finding
-        # accumulator the production loop runs.
-        from packages.llm_analysis import dataflow_validation as mod
         metrics = {}
         for fid, analysis in results_by_id.items():
             finding = {"finding_id": fid, "cwe_id": analysis.get("cwe_id", "")}
+            metrics.setdefault("n_path_conditions_populated", 0)
+            metrics.setdefault("path_conditions_by_cwe", {})
             nested_dv = (analysis or {}).get("dataflow_validation") or {}
             cond_present = bool(
                 nested_dv.get("path_conditions")
                 or (analysis or {}).get("path_conditions")
             )
             if cond_present:
-                metrics.setdefault("n_path_conditions_populated", 0)
                 metrics["n_path_conditions_populated"] += 1
                 cwe = (finding.get("cwe_id") or "").upper().strip() or "UNKNOWN"
-                metrics.setdefault("path_conditions_by_cwe", {})
                 metrics["path_conditions_by_cwe"][cwe] = (
                     metrics["path_conditions_by_cwe"].get(cwe, 0) + 1
                 )
         return metrics
 
-    def test_no_findings_with_conditions_no_telemetry(self):
+    def test_no_findings_with_conditions_zero_count(self):
         m = self._mock_orchestrator_loop({"f1": {"cwe_id": "CWE-79"}})
-        assert "n_path_conditions_populated" not in m
-        assert "path_conditions_by_cwe" not in m
+        # Counter present with value 0 — meaningfully distinct from
+        # absent. An "absent" counter would mean the code path never
+        # ran (operator can't tell the LLM is failing to populate vs
+        # validation never reached the per-finding loop).
+        assert m["n_path_conditions_populated"] == 0
+        assert m["path_conditions_by_cwe"] == {}
 
     def test_top_level_path_conditions_counted(self):
         m = self._mock_orchestrator_loop({
@@ -3072,7 +3076,8 @@ class TestPathConditionsTelemetry:
         m = self._mock_orchestrator_loop({
             "f1": {"cwe_id": "CWE-190", "path_conditions": []},
         })
-        assert "n_path_conditions_populated" not in m
+        assert m["n_path_conditions_populated"] == 0
+        assert m["path_conditions_by_cwe"] == {}
 
     def test_cwe_breakdown_aggregates(self):
         m = self._mock_orchestrator_loop({
@@ -3090,3 +3095,70 @@ class TestPathConditionsTelemetry:
         })
         assert m["n_path_conditions_populated"] == 1
         assert m["path_conditions_by_cwe"] == {"UNKNOWN": 1}
+
+
+class TestUsageDrivenDeepValidate:
+    """When neither --deep-validate nor --no-deep-validate is set,
+    Tier 2/3 auto-enables on the per-finding path_conditions signal.
+    Tri-state precedence: disabled > forced-on > auto."""
+
+    def _decide(self, *, analysis, deep_validate=False, deep_validate_disabled=False):
+        """Mirror the production decision logic."""
+        if deep_validate_disabled:
+            return False
+        if deep_validate:
+            return True
+        nested_dv = (analysis or {}).get("dataflow_validation") or {}
+        return bool(
+            nested_dv.get("path_conditions")
+            or (analysis or {}).get("path_conditions")
+        )
+
+    def test_disabled_overrides_forced_on(self):
+        """--no-deep-validate is the hard kill switch — wins even
+        against --deep-validate (operator's most-recent intent)."""
+        analysis = {"path_conditions": ["x > 1"]}
+        assert self._decide(
+            analysis=analysis,
+            deep_validate=True,
+            deep_validate_disabled=True,
+        ) is False
+
+    def test_forced_on_ignores_path_conditions(self):
+        """--deep-validate enables Tier 2/3 even when the LLM
+        didn't emit path_conditions."""
+        assert self._decide(
+            analysis={"cwe_id": "CWE-79"},
+            deep_validate=True,
+        ) is True
+
+    def test_auto_enables_when_path_conditions_present(self):
+        """The default-flags case: LLM emitted path_conditions →
+        auto-enable Tier 2/3 for THIS finding."""
+        assert self._decide(
+            analysis={"path_conditions": ["x > 1"]},
+        ) is True
+
+    def test_auto_enables_on_nested_path_conditions(self):
+        """Either top-level or nested-under-dataflow_validation
+        triggers auto-enable."""
+        assert self._decide(
+            analysis={
+                "dataflow_validation": {"path_conditions": ["i < n"]},
+            },
+        ) is True
+
+    def test_default_skips_when_no_path_conditions(self):
+        """Default-flags + no path_conditions → Tier 2/3 stays off
+        (the legacy behavior that prompted this work — tokens are
+        only spent when there's a reason)."""
+        assert self._decide(
+            analysis={"cwe_id": "CWE-79"},
+        ) is False
+
+    def test_empty_list_does_not_enable(self):
+        """`path_conditions: []` is "no applicable conditions" not
+        "extracted some" — auto-enable should NOT fire."""
+        assert self._decide(
+            analysis={"path_conditions": []},
+        ) is False

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -373,11 +373,24 @@ Examples:
     parser.add_argument(
         "--deep-validate",
         action="store_true",
-        help="Opt into Tier 2 / Tier 3 of IRIS validation: when Tier 1 is "
-             "inconclusive, ask the LLM to write source+sink predicates and "
-             "retry on compile errors. Costs LLM tokens; without this flag "
-             "Tier 1's free signal is the only validation. Implies dataflow "
-             "validation is enabled (see --no-validate-dataflow to opt out).",
+        help="Force-enable Tier 2 / Tier 3 of IRIS validation for ALL "
+             "findings: when Tier 1 is inconclusive, ask the LLM to write "
+             "source+sink predicates and retry on compile errors. Costs LLM "
+             "tokens. Implies dataflow validation is enabled (see "
+             "--no-validate-dataflow to opt out). Without this flag, Tier 2/3 "
+             "auto-enables per-finding when the LLM emits `path_conditions` "
+             "(usage-driven default — only spends tokens on findings the LLM "
+             "thinks it can SMT-check); pass --no-deep-validate to disable "
+             "even that auto-enable path.",
+    )
+    parser.add_argument(
+        "--no-deep-validate",
+        action="store_true",
+        help="Hard kill-switch: disable Tier 2 / Tier 3 entirely, including "
+             "the default usage-driven auto-enable on findings where the LLM "
+             "emitted `path_conditions`. Use when budget pressure is acute or "
+             "when bisecting whether deep-validate is responsible for a "
+             "verdict change. Takes precedence over --deep-validate.",
     )
     parser.add_argument(
         "--deep-validate-budget",
@@ -1116,6 +1129,7 @@ Examples:
                 accept_weakened_defenses=args.accept_weakened_defenses,
                 dataflow_validation_enabled=not getattr(args, "no_validate_dataflow", False),
                 deep_validate=getattr(args, "deep_validate", False),
+                deep_validate_disabled=getattr(args, "no_deep_validate", False),
                 deep_validate_budget=getattr(args, "deep_validate_budget", 0.60),
             )
         else:


### PR DESCRIPTION
Three independent fixes that all blocked the SMT path-feasibility substrate (PR #442 + #444) from producing useful signal on real runs. Surfaced together because the first real-target /agentic run after the CodeQL `--languages c` fix (#448) made it possible to exercise the path end-to-end.

1. Tier 1 IMB cache lock failure The CodeQL adapter sandboxed `database analyze` calls with `target=db_path` only — read access. CodeQL writes to its IMB cache under `<db>/<lang>/default/cache/` during query runs; without write access it fails to acquire `cache/.lock` with a misleading `FileNotFoundException` masking the underlying EACCES from the Java NIO layer. Symptom: every Tier 1 prebuilt query failed with "[prebuilt] Running queries. … A fatal error occurred: Error acquiring the IMB cache lock" on databases that demonstrably exist on disk with a writable cache subdir. Fix: pass `output=db_path` to make_sandbox_runner in both `run_prebuilt_query` and `run` (the LLM-generated-query path has the same bug).

2. Per-finding counters not surfacing `n_path_conditions_populated`, `path_conditions_by_cwe`, `n_tier4_smt_*` were initialised via `setdefault` gated behind the relevant condition (`if cond_present:` / `if smt_outcome != "no_check":`). Result: the keys never appeared in the metrics dict on runs where the LLM didn't populate path_conditions or SMT didn't fire — the common case. Operator couldn't distinguish "code path didn't run" from "code path ran, found nothing". Fix: lift the setdefaults out of their gates; the always-init pattern matches Tier 1/2/3 counters above. Adds `n_deep_validate_auto_enabled` to the top-level always-present init for the same observability reason.

3. Usage-driven deep_validate gate `deep_validate=False` (the default) skipped Tier 2/3 entirely on every finding — meaning Tier 4 SMT (which only runs after Tier 1+ produces something to refine) was unreachable on default-flag runs. The whole #442 + #444 investment paid off in zero observable telemetry. Tri-state replacement:
   - --no-deep-validate → never (hard kill, takes precedence)
   - --deep-validate    → always (force-on, all findings)
   - neither (default)  → auto: enable per-finding when the LLM
                          emitted `path_conditions` for THAT
                          finding. Spends LLM tokens only where
                          there's structured signal worth
                          expanding on.

Verified end-to-end on /tmp/smt-tier4-test fixture: Tier 1 now runs cleanly (was: every Tier 1 attempt errored), all counters present at 0, auto-gate respects the no-path_conditions case. The empirical observation the new telemetry surfaces on the test run — gemini-2.5-pro emits `path_conditions: null` even on textbook SMT-checkable bugs (CWE-190 wraparound, CWE-476 null deref) — is now the actionable next-step question (prompt strength, model choice, few-shot examples) rather than buried under broken infrastructure.