### PR TITLE
refactor(scan): unify CodeQL backend — delegate /scan --codeql to packages/codeql/agent.py

### DIFF
--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -509,88 +509,106 @@ def semgrep_scan_sequential(
     return sarif_paths
 
 
-# This is a WIP CodeQL runner; assumes codeql CLI is installed and query packs are available
-# Expect this to change
-def run_codeql(repo_path: Path, out_dir: Path, languages):
+def run_codeql(
+    repo_path: Path,
+    out_dir: Path,
+    languages: Optional[List[str]] = None,
+    build_command: Optional[str] = None,
+) -> List[str]:
+    """Delegate CodeQL analysis to packages/codeql/agent.py.
+
+    Pre-unification this module shipped its own ~80-LOC WIP CodeQL
+    runner alongside the proper one in `packages/codeql/`. The two
+    diverged: the in-tree runner had no auto-detection (operator
+    had to hard-code the language list), no build-system detection
+    or synthesis (compiled C/C++ projects without a Makefile got
+    silent extraction failures), no content-addressed DB cache, no
+    target-repo trust check, no language alias normalisation
+    (PR #448), and a hard-coded query-dir path that broke if the
+    operator wasn't standing in repo root. The packages/codeql/
+    runner has all of those.
+
+    The two paths converge here: scanner.py invokes the proper
+    agent as a subprocess (mirroring how raptor_agentic.py runs it
+    at line 743). Output naming is identical — the agent writes
+    `codeql_<lang>.sarif` per detected language under `out_dir`,
+    matching the previous in-tree runner's convention so downstream
+    consumers (SARIF merge, coverage records) are unchanged.
+
+    Args:
+        repo_path: Repository to scan.
+        out_dir: Directory for SARIF + report outputs.
+        languages: Explicit language list. None ⇒ auto-detect
+            (recommended; the agent picks up everything in the
+            repo and skips empty languages, vs the pre-unification
+            "always create cpp/java/python/go DBs whether the repo
+            has those files or not" approach).
+        build_command: Optional CodeQL build command override
+            (e.g. for compiled languages with non-standard layouts).
+
+    Returns:
+        List of absolute SARIF paths the agent wrote. Empty on any
+        failure (logged); never raises.
+    """
     out_dir.mkdir(parents=True, exist_ok=True)
     if shutil.which("codeql") is None:
+        logger.warning("codeql CLI not on PATH; skipping CodeQL stage")
         return []
-    sarif_paths = []
-    for lang in languages:
-        db = out_dir / f"codeql-db-{lang}"
-        sarif = out_dir / f"codeql_{lang}.sarif"
-        # Database. `--threads=0` lets codeql auto-detect a sane
-        # parallelism level (uses all available CPUs). Pre-fix
-        # codeql defaulted to single-threaded extraction on
-        # large repos — extraction time scaled linearly with
-        # repo size and exhausted the analyser's 1800s timeout
-        # on monorepos that should have completed in 5-10
-        # minutes with auto-parallelism.
-        rc, so, se = run(
-            ["codeql", "database", "create", str(db),
-             "--language", lang, "--source-root", str(repo_path),
-             "--threads=0"],
-            timeout=1800,
+
+    # repo root → packages/codeql/agent.py. scanner.py lives at
+    # packages/static-analysis/scanner.py so parents[2] is repo root.
+    script_root = Path(__file__).resolve().parents[2]
+    agent_script = script_root / "packages" / "codeql" / "agent.py"
+    if not agent_script.exists():
+        logger.warning(
+            f"codeql agent script missing at {agent_script}; skipping CodeQL stage"
         )
-        if rc != 0:
-            # Pre-fix this branch silently `continue`d on DB-create
-            # failure, leaving the operator with no idea why the
-            # SARIF list was short. The most common DB-create
-            # failures (missing build deps for compiled langs,
-            # source-root containing forbidden chars, codeql wheel
-            # version mismatch) produce diagnostic stderr that is
-            # actionable — but not visible.
-            #
-            # Truncate stderr to keep the log readable; codeql
-            # error output can run thousands of lines on
-            # extraction failures.
-            stderr_tail = (se or "").strip()
-            if len(stderr_tail) > 2000:
-                stderr_tail = "..." + stderr_tail[-2000:]
-            # `RaptorLogger.warning(message, **kwargs)` accepts ONLY
-            # a single message arg (no printf-style varargs like
-            # stdlib `logging.Logger.warning`). Pre-fix the call
-            # passed positional substitution args and raised
-            # `TypeError: warning() takes 2 positional arguments
-            # but 5 were given`. Pre-format via f-string.
-            _stderr_disp = stderr_tail or "<empty>"
-            logger.warning(
-                f"codeql database create failed for language {lang} "
-                f"(rc={rc}). Last stderr: {_stderr_disp}"
-            )
-            continue
-        # Queries — same `--threads=0` for parallel query
-        # execution. Quiet codeql query suites (cpp / java)
-        # have hundreds of queries; serial execution wastes
-        # 80%+ of CPU time on machines with multiple cores.
-        # Resolve the query directory via RaptorConfig instead of
-        # the bare relative path "codeql-queries". Pre-fix
-        # `Path("codeql-queries") / lang` was relative to the
-        # CALLER'S CWD, so:
-        #   * Operators running from /tmp / their home / a
-        #     subdirectory got `query_dir.exists() == False` and
-        #     the queries silently skipped (sarif_paths stayed
-        #     empty, no findings reported even though the DB was
-        #     built).
-        #   * The actual queries live under
-        #     `engine/codeql/queries/` (RaptorConfig.CODEQL_QUERIES_DIR).
-        # Use the canonical config path; falls back to the relative
-        # form if for some reason CODEQL_QUERIES_DIR isn't set.
-        try:
-            from core.config import RaptorConfig as _RC
-            query_dir = _RC.CODEQL_QUERIES_DIR / lang
-        except (ImportError, AttributeError):
-            query_dir = Path("codeql-queries") / lang
-        if not query_dir.exists():
-            continue
-        rc, so, se = run(
-            ["codeql", "query", "run", str(query_dir),
-             "--database", str(db), "--output", str(sarif),
-             "--threads=0"],
-            timeout=1800,
+        return []
+
+    cmd = [
+        sys.executable,
+        str(agent_script),
+        "--repo", str(repo_path),
+        "--out", str(out_dir),
+    ]
+    if languages:
+        cmd.extend(["--languages", ",".join(languages)])
+    if build_command:
+        cmd.extend(["--build-command", build_command])
+
+    logger.info(f"Delegating CodeQL stage to {agent_script.name}")
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=3600,
         )
-        if rc == 0 and sarif.exists():
-            sarif_paths.append(str(sarif))
+    except subprocess.TimeoutExpired:
+        logger.warning("codeql agent timed out after 3600s; skipping")
+        return []
+    except OSError as e:
+        logger.warning(f"failed to invoke codeql agent: {e}")
+        return []
+
+    if proc.returncode != 0:
+        # Surface the agent's stderr tail so the operator can see
+        # WHY the run failed — language detection miscount, build
+        # synthesis failure, trust-check rejection. Same truncation
+        # rationale as before — codeql error output can run
+        # thousands of lines.
+        stderr_tail = (proc.stderr or proc.stdout or "").strip()
+        if len(stderr_tail) > 2000:
+            stderr_tail = "..." + stderr_tail[-2000:]
+        logger.warning(
+            f"codeql agent exited rc={proc.returncode}. "
+            f"Last stderr: {stderr_tail or '<empty>'}"
+        )
+        # Don't return early — the agent may have produced partial
+        # SARIFs (one language succeeded, another failed). Glob and
+        # return whatever's there.
+
+    # Glob for the agent's SARIF outputs. Naming matches the old
+    # in-tree runner so downstream code (SARIF merge, coverage
+    # records, _classify_artifact) needs no changes.
+    sarif_paths = sorted(str(p) for p in out_dir.glob("codeql_*.sarif"))
     return sarif_paths
 
 
@@ -847,7 +865,31 @@ def main():
         dest="policy_groups",
         help="Comma-separated list of rule group names (e.g. crypto,secrets,injection,auth,all)",
     )
-    ap.add_argument("--codeql", action="store_true", help="Run CodeQL stage if available")
+    ap.add_argument(
+        "--codeql", action="store_true",
+        help="Run CodeQL stage. Delegates to packages/codeql/agent.py — the "
+             "same engine /codeql uses (auto-language-detection, build "
+             "synthesis, content-addressed DB cache, trust check). Off by "
+             "default to keep /scan fast; use --no-codeql to assert opt-out.",
+    )
+    ap.add_argument(
+        "--no-codeql", action="store_true",
+        help="Explicitly disable the CodeQL stage. Takes precedence over "
+             "--codeql. Useful in scripts that want a guaranteed Semgrep-only "
+             "scan regardless of what defaults change in future.",
+    )
+    ap.add_argument(
+        "--languages",
+        help="Comma-separated language list for CodeQL (e.g. cpp,java). "
+             "Operator-friendly aliases (c, c++, js, ts, c#, kt, py) are "
+             "normalised. Default: auto-detect, which only creates DBs for "
+             "languages actually present in the repo.",
+    )
+    ap.add_argument(
+        "--build-command",
+        help="Override CodeQL's build command for compiled languages. "
+             "Forwarded to packages/codeql/agent.py --build-command.",
+    )
     ap.add_argument("--keep", action="store_true", help="Keep temp working directory")
     ap.add_argument("--sequential", action="store_true", help="Disable parallel scanning (for debugging)")
     ap.add_argument("--out", default=None, help="Output directory (from lifecycle). Overrides auto-generated path.")
@@ -947,11 +989,21 @@ def main():
         else:
             semgrep_sarifs = semgrep_scan_parallel(repo_path, rules_dirs, out_dir)
 
-        # CodeQL stage (optional)
+        # CodeQL stage (optional). --no-codeql takes precedence —
+        # script-friendly so a default-flip from "off" to "on" can
+        # be opted out of without code changes.
         codeql_sarifs = []
-        if args.codeql:
-            # Basic language guess; you can make this dynamic later
-            codeql_sarifs = run_codeql(repo_path, out_dir, languages=["cpp", "java", "python", "go"])
+        run_codeql_stage = args.codeql and not args.no_codeql
+        if run_codeql_stage:
+            languages = (
+                [s.strip() for s in args.languages.split(",") if s.strip()]
+                if args.languages else None  # None ⇒ agent auto-detects
+            )
+            codeql_sarifs = run_codeql(
+                repo_path, out_dir,
+                languages=languages,
+                build_command=args.build_command,
+            )
 
         # Merge SARIFs if more than one
         sarif_inputs = semgrep_sarifs + codeql_sarifs

--- a/packages/static-analysis/tests/test_scanner.py
+++ b/packages/static-analysis/tests/test_scanner.py
@@ -20,47 +20,151 @@ run_codeql = _scanner_mod.run_codeql
 
 
 # ---------------------------------------------------------------------------
-# run_codeql()
+# run_codeql() — post-unification: delegates to packages/codeql/agent.py
+# Pre-unification this module shipped its own ~80-LOC WIP CodeQL runner.
+# The proper one in packages/codeql/agent.py has auto-detect, build
+# synthesis, content-addressed cache, trust check, language alias
+# normalisation. Tests below assert the delegation contract: subprocess
+# invocation of the agent, SARIF discovery from out_dir, plumbing of
+# operator-supplied flags through to the agent's argv.
 # ---------------------------------------------------------------------------
 
-class TestRunCodeql:
+class TestRunCodeqlDelegation:
 
-    def test_returns_empty_list_when_codeql_not_installed(self, tmp_path):
+    def test_returns_empty_when_codeql_not_installed(self, tmp_path):
+        """No codeql CLI on PATH → bail before invoking agent."""
         with patch("shutil.which", return_value=None):
             result = run_codeql(tmp_path, tmp_path / "out", ["python"])
         assert result == []
 
-    @patch("shutil.which", return_value="/usr/bin/codeql")
-    @patch.object(_scanner_mod, "run")
-    def test_creates_output_dir(self, mock_run, mock_which, tmp_path):
-        mock_run.return_value = (1, "", "db create failed")
+    def test_creates_output_dir(self, tmp_path):
+        """out_dir is created up-front (matches pre-unification
+        contract — downstream consumers may glob for SARIFs even
+        if the agent never wrote one)."""
         out_dir = tmp_path / "codeql_out"
-        run_codeql(tmp_path, out_dir, ["python"])
+        with patch("shutil.which", return_value="/usr/bin/codeql"), \
+             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
+            mock_proc.return_value = MagicMock(
+                returncode=1, stdout="", stderr="agent failed",
+            )
+            run_codeql(tmp_path, out_dir, ["python"])
         assert out_dir.exists()
 
-    @patch("shutil.which", return_value="/usr/bin/codeql")
-    @patch.object(_scanner_mod, "run")
-    def test_skips_language_if_db_create_fails(self, mock_run, mock_which, tmp_path):
-        mock_run.return_value = (1, "", "database create error")
-        result = run_codeql(tmp_path, tmp_path / "out", ["python", "java"])
+    def test_invokes_agent_subprocess_with_repo_and_out(self, tmp_path):
+        """The unification contract: subprocess invocation of
+        packages/codeql/agent.py with --repo and --out."""
+        out_dir = tmp_path / "out"
+        with patch("shutil.which", return_value="/usr/bin/codeql"), \
+             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
+            mock_proc.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            run_codeql(tmp_path, out_dir, languages=None)
+
+        assert mock_proc.called, "subprocess.run was not called"
+        cmd = mock_proc.call_args.args[0]
+        assert cmd[0] == sys.executable
+        # Agent script path component.
+        assert any("packages/codeql/agent.py" in part for part in cmd), \
+            f"agent.py not in cmd: {cmd}"
+        # --repo and --out present and pointing at the right dirs.
+        assert "--repo" in cmd and str(tmp_path) in cmd
+        assert "--out" in cmd and str(out_dir) in cmd
+
+    def test_languages_forwarded_as_csv(self, tmp_path):
+        """An explicit language list flows through as --languages a,b."""
+        with patch("shutil.which", return_value="/usr/bin/codeql"), \
+             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
+            mock_proc.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            run_codeql(tmp_path, tmp_path / "out", languages=["cpp", "java"])
+
+        cmd = mock_proc.call_args.args[0]
+        assert "--languages" in cmd
+        idx = cmd.index("--languages")
+        assert cmd[idx + 1] == "cpp,java"
+
+    def test_no_languages_arg_when_none(self, tmp_path):
+        """languages=None ⇒ no --languages flag passed; the agent
+        auto-detects. This is the recommended default — the agent
+        skips empty languages, vs the pre-unification 'always make
+        cpp/java/python/go DBs' behaviour."""
+        with patch("shutil.which", return_value="/usr/bin/codeql"), \
+             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
+            mock_proc.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            run_codeql(tmp_path, tmp_path / "out", languages=None)
+
+        cmd = mock_proc.call_args.args[0]
+        assert "--languages" not in cmd
+
+    def test_build_command_forwarded(self, tmp_path):
+        """build_command flows through as --build-command for the
+        agent's CodeQL DB creation."""
+        with patch("shutil.which", return_value="/usr/bin/codeql"), \
+             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
+            mock_proc.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            run_codeql(
+                tmp_path, tmp_path / "out",
+                languages=["cpp"], build_command="make -j4",
+            )
+
+        cmd = mock_proc.call_args.args[0]
+        assert "--build-command" in cmd
+        idx = cmd.index("--build-command")
+        assert cmd[idx + 1] == "make -j4"
+
+    def test_returns_globbed_sarif_paths(self, tmp_path):
+        """After the agent runs, scanner globs out_dir for
+        codeql_*.sarif. Naming matches pre-unification convention."""
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        # Simulate the agent having written two language SARIFs.
+        (out_dir / "codeql_cpp.sarif").write_text("{}")
+        (out_dir / "codeql_python.sarif").write_text("{}")
+        # And a non-matching file we must NOT pick up.
+        (out_dir / "scan_metrics.json").write_text("{}")
+
+        with patch("shutil.which", return_value="/usr/bin/codeql"), \
+             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
+            mock_proc.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            result = run_codeql(tmp_path, out_dir, languages=None)
+
+        assert sorted(result) == sorted([
+            str(out_dir / "codeql_cpp.sarif"),
+            str(out_dir / "codeql_python.sarif"),
+        ])
+
+    def test_partial_success_returns_what_agent_wrote(self, tmp_path):
+        """Agent rc != 0 doesn't void the SARIFs that DID land.
+        One language extraction failing shouldn't drop the
+        successful one's findings."""
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        (out_dir / "codeql_python.sarif").write_text("{}")
+
+        with patch("shutil.which", return_value="/usr/bin/codeql"), \
+             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
+            mock_proc.return_value = MagicMock(
+                returncode=1, stdout="", stderr="cpp build failed",
+            )
+            result = run_codeql(tmp_path, out_dir, languages=["python", "cpp"])
+
+        assert result == [str(out_dir / "codeql_python.sarif")]
+
+    def test_subprocess_timeout_returns_empty(self, tmp_path):
+        """Agent timeout: log and return empty rather than raise.
+        Matches the no-raise contract scanner.py expects from
+        every stage."""
+        import subprocess
+        with patch("shutil.which", return_value="/usr/bin/codeql"), \
+             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
+            mock_proc.side_effect = subprocess.TimeoutExpired(cmd="codeql", timeout=3600)
+            result = run_codeql(tmp_path, tmp_path / "out", languages=None)
         assert result == []
 
-    @patch("shutil.which", return_value="/usr/bin/codeql")
-    @patch.object(_scanner_mod, "run")
-    def test_uses_list_based_args(self, mock_run, mock_which, tmp_path):
-        """run() must be called with list args, never shell strings."""
-        mock_run.return_value = (1, "", "")
-        run_codeql(tmp_path, tmp_path / "out", ["python"])
-        for c in mock_run.call_args_list:
-            cmd_arg = c.args[0] if c.args else c.kwargs.get("cmd", [])
-            assert isinstance(cmd_arg, list), "Command must be a list (no shell injection)"
-
-    @patch("shutil.which", return_value="/usr/bin/codeql")
-    @patch.object(_scanner_mod, "run")
-    def test_empty_languages_returns_empty(self, mock_run, mock_which, tmp_path):
-        result = run_codeql(tmp_path, tmp_path / "out", [])
+    def test_subprocess_oserror_returns_empty(self, tmp_path):
+        with patch("shutil.which", return_value="/usr/bin/codeql"), \
+             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
+            mock_proc.side_effect = OSError("ENOEXEC")
+            result = run_codeql(tmp_path, tmp_path / "out", languages=None)
         assert result == []
-        mock_run.assert_not_called()
 
 
 _compute_python_tool_paths = _scanner_mod._compute_python_tool_paths


### PR DESCRIPTION
Pre-unification this module shipped its own ~80-LOC WIP CodeQL runner (`scanner.py:run_codeql`, marked "expect this to change") alongside the proper one in `packages/codeql/agent.py`. The two diverged badly:

The in-tree WIP runner had:
  * No language auto-detection — operator had to hard-code the list (and scanner.py just hard-coded ["cpp", "java", "python", "go"], creating empty DBs for absent languages and skipping languages that were present)
  * No build system detection or synthesis — compiled C/C++ projects without a Makefile got silent extraction failures
  * No content-addressed DB cache — every run re-extracted from scratch
  * No target-repo trust check (codeql-pack.yml RCE pre-extraction)
  * No language alias normalisation — `--languages c` → silent no-op, the bug fixed by PR #448 in the agent.py path
  * Hard-coded query-dir path that broke if the operator wasn't standing in repo root

The packages/codeql/agent.py path has all of those.

Replace `run_codeql` body with a subprocess invocation of packages/codeql/agent.py, mirroring how raptor_agentic.py runs it at line 743. SARIF naming convention (`codeql_<lang>.sarif`) is identical so downstream consumers (SARIF merge,
build_from_codeql coverage records, _classify_artifact) need no changes.

Default-flag changes:
  * Drop the hard-coded ["cpp", "java", "python", "go"] guess — `languages=None` now means "let the agent auto-detect", which skips empty languages and uses the small-target retry from PR #448.
  * Add `--languages` flag for explicit override (matches /codeql
    + /agentic).
  * Add `--build-command` flag for compiled-language overrides.
  * Add `--no-codeql` symmetric opt-out (matches the `--deep-validate` / `--no-deep-validate` pattern). Takes precedence over `--codeql` so scripts can guarantee a Semgrep-only run regardless of future default-flips.

`--codeql` remains opt-in (off by default). Operators expect /scan to be the fast Semgrep tier; making CodeQL default would change the contract and add minutes-to-hours to every scan. With this unification, the "should it be default" question becomes a real choice in a future PR (was previously "you'd be defaulting to broken code").

Verified end-to-end on /tmp/smt-tier4-test fixture: `packages/static-analysis/scanner.py --repo /tmp/smt-tier4-test --codeql --languages c` produces codeql_cpp.sarif (the alias normalisation, build synthesis, and content-addressed cache all fire correctly), Semgrep semgrep_*.sarif, combined.sarif (merged), and coverage-codeql.json — all the downstream consumers see the artifacts they expect.