### PR TITLE
feat(iris): wire Tier 4 SMT witness as /exploit PoC seed

### DIFF
--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -1569,6 +1569,30 @@ def main() -> None:
     model_group.add_argument("--aggregate", metavar="MODEL",
                              help="Final synthesis model for multi-model results")
 
+    # IRIS Tier 2/3 deep-validate gate. Mirrors raptor_agentic.py.
+    # Without these flags /analyze can never reach Tier 4 SMT
+    # refinement on findings the orchestrator passed through —
+    # the auto-enable on path_conditions is the only path most
+    # operators take, so we want it here too.
+    ap.add_argument(
+        "--deep-validate",
+        action="store_true",
+        help="Force-enable Tier 2 / Tier 3 of IRIS validation for ALL "
+             "findings: when Tier 1 is inconclusive, ask the LLM to write "
+             "source+sink predicates and retry on compile errors. Costs "
+             "LLM tokens. Without this flag, Tier 2/3 auto-enables per-"
+             "finding when the LLM emits `path_conditions` (usage-driven "
+             "default); pass --no-deep-validate to disable even that auto-"
+             "enable path.",
+    )
+    ap.add_argument(
+        "--no-deep-validate",
+        action="store_true",
+        help="Hard kill-switch: disable Tier 2 / Tier 3 entirely, including "
+             "the default usage-driven auto-enable. Takes precedence over "
+             "--deep-validate.",
+    )
+
     args = ap.parse_args()
 
     if not args.sarif and not args.findings:
@@ -1646,6 +1670,8 @@ def main() -> None:
                     max_parallel=args.max_parallel,
                     max_findings=args.max_findings,
                     llm_config=llm_config,
+                    deep_validate=getattr(args, "deep_validate", False),
+                    deep_validate_disabled=getattr(args, "no_deep_validate", False),
                 )
                 if result:
                     return

--- a/packages/llm_analysis/dataflow_validation.py
+++ b/packages/llm_analysis/dataflow_validation.py
@@ -600,7 +600,17 @@ def validate_dataflow_claims(
         )
         if cond_present:
             metrics["n_path_conditions_populated"] += 1
-            cwe = (finding.get("cwe_id") or "").upper().strip() or "UNKNOWN"
+            # Prefer the LLM analysis result's cwe_id over the
+            # SARIF-derived finding's. The finding object often
+            # lacks cwe_id at the top level — Semgrep findings in
+            # particular only carry rule_id; the analysis call is
+            # what classifies the CWE. Without this fallback the
+            # by-cwe breakdown buckets everything under "UNKNOWN"
+            # which defeats the breakdown's purpose.
+            cwe = (
+                (finding.get("cwe_id") or "").strip()
+                or (analysis or {}).get("cwe_id", "").strip()
+            ).upper() or "UNKNOWN"
             metrics["path_conditions_by_cwe"][cwe] = (
                 metrics["path_conditions_by_cwe"].get(cwe, 0) + 1
             )

--- a/packages/llm_analysis/dataflow_validation.py
+++ b/packages/llm_analysis/dataflow_validation.py
@@ -1325,6 +1325,22 @@ def _tier4_smt_refine(
             "witness",
             f"SMT witness for path conditions: {model_str or '(no model)'}",
         )
+        # Attach a structured witness record so downstream consumers
+        # (/exploit's prompt builder) can read it without parsing the
+        # reasoning string. The same model is also in `evidence` for
+        # report rendering, but a typed field is much easier to use
+        # as a PoC seed: the LLM gets concrete values that already
+        # satisfy the dangerous-path conditions and can amplify them
+        # rather than guess from scratch. Pre-fix the witness model
+        # was buried in a free-text evidence summary that /exploit's
+        # prompt builder dumped verbatim — useful for audit but not
+        # for steering exploit generation.
+        if model:
+            (analysis or {}).setdefault("smt_witness", {}).update({
+                "model": dict(model),
+                "path_conditions": list(conditions),
+                "path_profile": profile_name,
+            })
         refined = ValidationResult(
             verdict=result.verdict,
             evidence=list(result.evidence) + [ev],

--- a/packages/llm_analysis/prompts/exploit.py
+++ b/packages/llm_analysis/prompts/exploit.py
@@ -46,6 +46,8 @@ Create a WORKING proof-of-concept exploit that:
 
 If the user message includes EXPLOITATION CONSTRAINTS blocks listing chain breaks (techniques verified not to work) or what-would-help notes, respect them: do not attempt blocked techniques; favour the suggested viable approaches.
 
+If the user message includes an SMT WITNESS block, the values listed there are guaranteed by the Z3 solver to make the program take the dangerous code path. Use them as your PoC's concrete inputs (argv values, struct fields, etc.) rather than reasoning out trigger values from scratch. The solver has already done that work.
+
 Write complete, executable code as per the prime directives above. Make it realistic and practical, not just theoretical.
 The exploit should actually work against the vulnerable code, or system, shown above."""
 
@@ -60,6 +62,50 @@ def _format_feasibility_constraints(feasibility: Dict[str, Any]) -> str:
     if what_would_help:
         parts.append("Viable approaches to consider:")
         parts.extend(f"  - {wh}" for wh in what_would_help)
+    return "\n".join(parts)
+
+
+def _format_smt_witness(witness: Dict[str, Any]) -> str:
+    """Render a Tier 4 SMT witness as a PoC seed for the exploit prompt.
+
+    The Tier 4 SMT pipeline (packages/llm_analysis/dataflow_validation.py)
+    runs Z3 against the LLM's emitted `path_conditions` after Tier 1+
+    confirms a finding. When SMT proves the conditions are jointly
+    satisfiable, the satisfying assignment (a `{var: int}` model) is
+    attached to `analysis["smt_witness"]`. Z3 has GUARANTEED these
+    values make the program take the dangerous path — feeding them
+    into the exploit prompt as a starter PoC saves the LLM from
+    guessing concrete trigger values from scratch (the hardest part
+    of integer-overflow / OOB / null-deref exploitation).
+    """
+    model = witness.get("model") or {}
+    if not model:
+        return ""
+    conditions = witness.get("path_conditions") or []
+    profile = witness.get("path_profile") or "uint64"
+    parts: List[str] = [
+        "Z3 verified the path conditions ARE satisfiable. The following "
+        "concrete values make the program take the dangerous path — they "
+        "are guaranteed correct by the solver, not LLM-guessed. Use them "
+        "as your PoC's starting input; you should not need to derive trigger "
+        "values from first principles.",
+        "",
+        f"Bitvector profile: {profile} (matches the path_profile the "
+        "analysis claimed)",
+        "",
+        "Witness model (variable = value):",
+    ]
+    for var, val in sorted(model.items()):
+        # Render in both decimal and hex — exploit authors typically
+        # need hex for memory layout reasoning, decimal for argv.
+        if isinstance(val, int):
+            parts.append(f"  {var} = {val} (0x{val:x})")
+        else:
+            parts.append(f"  {var} = {val}")
+    if conditions:
+        parts.append("")
+        parts.append("Path conditions Z3 satisfied:")
+        parts.extend(f"  - {c}" for c in conditions)
     return "\n".join(parts)
 
 
@@ -98,6 +144,26 @@ def build_exploit_prompt_bundle(
                 content=constraints_text,
                 kind="exploitation-constraints",
                 origin=f"feasibility:{rule_id}",
+            ))
+
+    # Tier 4 SMT witness model (PR-following): when Z3 has GUARANTEED
+    # the dangerous path is reachable, surface the satisfying
+    # assignment as a dedicated block so the LLM can use the concrete
+    # values as a PoC starter rather than reasoning out trigger inputs
+    # from scratch. The witness lives at `analysis["smt_witness"]`
+    # (attached by Tier 4 in dataflow_validation._tier4_smt_refine);
+    # absent on findings without a sat outcome (i.e. all CWEs the LLM
+    # didn't populate path_conditions for, plus refuted findings —
+    # /exploit's pre-flight gate stops those before reaching us
+    # anyway).
+    smt_witness = (analysis or {}).get("smt_witness") if analysis else None
+    if smt_witness:
+        witness_text = _format_smt_witness(smt_witness)
+        if witness_text:
+            blocks.append(UntrustedBlock(
+                content=witness_text,
+                kind="smt-witness",
+                origin=f"smt:{rule_id}",
             ))
 
     if code:

--- a/packages/llm_analysis/prompts/schemas.py
+++ b/packages/llm_analysis/prompts/schemas.py
@@ -26,6 +26,40 @@ ANALYSIS_SCHEMA = {
     "dataflow_summary": "string - concise source->sanitizer->sink chain",
     "remediation": "string - what to fix and how",
     "false_positive_reason": "string or null - reason when ruling is false_positive",
+    # SMT path-feasibility hooks. Lives in ANALYSIS_SCHEMA (not
+    # DATAFLOW_SCHEMA_FIELDS) because the conditions are LOCAL to
+    # the dangerous statement for memory-corruption CWEs — the LLM
+    # can extract them from a `count * sizeof(record)` expression
+    # without needing CodeQL dataflow context. Pre-fix these were
+    # gated behind has_dataflow=True, which created a circular
+    # bootstrap: the auto-deep-validate gate needs path_conditions,
+    # but path_conditions only got asked for when CodeQL had
+    # already given a dataflow. Now always in scope; null is the
+    # correct value for non-applicable CWEs.
+    "path_conditions": (
+        "list of strings or null - SMT-checkable branch conditions on the "
+        "dangerous path. Each entry is a single predicate the parser "
+        "accepts: e.g. 'count > 0x10000000', 'alloc_size == count * 16', "
+        "'index >= buffer_size', 'ptr == NULL'. "
+        "REQUIRED for memory-corruption CWEs (their analysis is not "
+        "complete without it): CWE-119/120/121/122 (buffer overflow — "
+        "supply the size-vs-bound predicate), CWE-125/787 (out-of-bounds "
+        "read/write — supply the index-vs-bound predicate, e.g. 'idx >= "
+        "buffer_size'), CWE-190 (integer overflow — supply the wraparound "
+        "predicate, e.g. 'count * size > UINT32_MAX'), CWE-191 (integer "
+        "underflow), CWE-476 (null deref — supply 'ptr == NULL'). For ANY "
+        "OTHER CWE (XSS, SQLi, command injection, auth bypass, etc.), the "
+        "correct value is null. Downstream Z3 refutes findings whose "
+        "conditions are unsatisfiable and seeds /exploit PoCs from witness "
+        "models — populating this field on the listed CWEs measurably "
+        "improves verdict precision."
+    ),
+    "path_profile": (
+        "string or null - bitvector profile for SMT encoding. One of: "
+        "'uint64' (default — sizes/offsets/counts), 'uint32' (CWE-190 "
+        "wraparound), 'int32' / 'int64' (signed integer paths). REQUIRED "
+        "when path_conditions is non-empty; null otherwise."
+    ),
 }
 
 # Additional fields when dataflow is available
@@ -34,27 +68,8 @@ DATAFLOW_SCHEMA_FIELDS = {
     "sanitizers_effective": "boolean - are sanitizers in the path effective?",
     "sanitizer_bypass_technique": "string - how to bypass sanitizers, or empty if effective",
     "dataflow_exploitable": "boolean - is the complete dataflow path exploitable?",
-    # SMT path-feasibility hooks (populated only for memory-corruption /
-    # arithmetic / bounds CWEs: 190, 125, 787, 476, 191). When present
-    # the orchestrator's Tier 4 gate uses Z3 to refute findings whose
-    # path conditions are unsatisfiable and to attach a witness model
-    # to confirmed findings (used downstream by /exploit as a PoC seed).
-    # Empty / missing → Tier 4 no-ops; nothing requires these fields.
-    "path_conditions": (
-        "list of strings or null - SMT-checkable branch conditions on the "
-        "dangerous path. Each entry is a single predicate the parser "
-        "accepts: e.g. 'count > 0x10000000', 'alloc_size == count * 16', "
-        "'index >= buffer_size', 'ptr == NULL'. Populate ONLY for memory-"
-        "corruption / arithmetic / bounds / null-deref CWEs (190, 125, 787, "
-        "476, 191); use null or empty list otherwise — the field is "
-        "optional and absence does not dock response quality."
-    ),
-    "path_profile": (
-        "string or null - bitvector profile for SMT encoding. One of: "
-        "'uint64' (default — sizes/offsets/counts), 'uint32' (CWE-190 "
-        "wraparound), 'int32' / 'int64' (signed integer paths). Only "
-        "meaningful when path_conditions is non-empty; null otherwise."
-    ),
+    # path_conditions / path_profile moved to ANALYSIS_SCHEMA above
+    # so they're always in scope (not gated on has_dataflow=True).
 }
 
 # Schema for deep dataflow validation — used by agent.py's validate_dataflow
@@ -83,14 +98,19 @@ DATAFLOW_VALIDATION_SCHEMA = {
     # produced them.
     "path_conditions": (
         "list of strings or null - SMT-checkable branch conditions on the "
-        "dangerous path. Populate for memory-corruption / arithmetic / "
-        "bounds / null-deref CWEs (190, 125, 787, 476, 191); null or "
-        "empty list otherwise — optional, absence does not dock quality."
+        "dangerous path. REQUIRED for CWE-190 (integer overflow — supply "
+        "wraparound predicate), CWE-125/787 (out-of-bounds — supply index-"
+        "vs-bound predicate), CWE-476 (null deref — supply 'ptr == NULL'), "
+        "CWE-191 (underflow). For ANY OTHER CWE, the correct value is null. "
+        "Examples: 'count > 0x10000000', 'alloc_size == count * 16', "
+        "'idx >= buffer_size', 'ptr == NULL'. Z3 uses these to refute "
+        "infeasible findings and to seed /exploit PoCs from witness models."
     ),
     "path_profile": (
-        "string or null - bitvector profile: uint64 (default), uint32 "
-        "(wraparound), int32, int64. Only meaningful with non-empty "
-        "path_conditions; null otherwise."
+        "string or null - bitvector profile: 'uint64' (default — sizes/"
+        "offsets/counts), 'uint32' (CWE-190 wraparound), 'int32' / 'int64' "
+        "(signed paths). REQUIRED when path_conditions is non-empty; null "
+        "otherwise."
     ),
 }
 

--- a/packages/llm_analysis/tests/test_smt_witness_poc_seed.py
+++ b/packages/llm_analysis/tests/test_smt_witness_poc_seed.py
@@ -1,0 +1,259 @@
+"""Tests for SMT witness → /exploit PoC seed wiring.
+
+Tier 4 SMT (packages/llm_analysis/dataflow_validation.py) attaches a
+satisfying assignment to `analysis["smt_witness"]` when Z3 proves the
+LLM-emitted path conditions are jointly satisfiable. The /exploit
+prompt builder reads that field and surfaces it to the exploit-gen
+LLM as a starter PoC — concrete trigger values that are guaranteed
+to make the program take the dangerous code path, so the LLM doesn't
+have to derive them from first principles (the hardest part of
+integer-overflow / OOB / null-deref exploitation).
+
+These tests cover the wiring at both ends:
+  1. _tier4_smt_refine attaches a structured `smt_witness` field
+     when the SMT outcome is sat (witness branch).
+  2. build_exploit_prompt_bundle includes a dedicated `smt-witness`
+     UntrustedBlock when the field is present, omits when absent.
+  3. The block content is a parseable PoC seed (concrete values in
+     decimal AND hex).
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from packages.llm_analysis.prompts.exploit import (
+    _format_smt_witness,
+    build_exploit_prompt_bundle,
+)
+
+
+# -- _format_smt_witness ----------------------------------------------------
+
+class TestFormatSmtWitness:
+    """Witness rendering — concrete-value PoC seed for the LLM."""
+
+    def test_empty_model_returns_empty_string(self):
+        """Witness with no model is meaningless; render to empty so
+        the caller can omit the block entirely."""
+        assert _format_smt_witness({}) == ""
+        assert _format_smt_witness({"model": {}}) == ""
+
+    def test_model_renders_decimal_and_hex(self):
+        """Exploit authors need hex for memory-layout reasoning;
+        decimal for argv. Render both so the LLM doesn't have to
+        convert."""
+        out = _format_smt_witness({
+            "model": {"count": 268435457},
+            "path_conditions": ["count * 40 > 4294967295"],
+            "path_profile": "uint32",
+        })
+        assert "count = 268435457" in out
+        assert "0x10000001" in out  # hex form
+
+    def test_includes_path_profile_for_context(self):
+        out = _format_smt_witness({
+            "model": {"x": 1},
+            "path_profile": "uint32",
+        })
+        assert "uint32" in out
+
+    def test_includes_path_conditions_for_context(self):
+        out = _format_smt_witness({
+            "model": {"x": 1},
+            "path_conditions": ["x > 0"],
+        })
+        assert "x > 0" in out
+
+    def test_emphasises_solver_guarantee(self):
+        """The whole point of the witness is "Z3 has done this work
+        for you, don't redo it." The framing must be unambiguous."""
+        out = _format_smt_witness({
+            "model": {"x": 1},
+            "path_conditions": ["x > 0"],
+        })
+        # Must convey that the values are solver-verified, not
+        # LLM-guessed. Look for any of: "guaranteed", "verified",
+        # "solver", "Z3" — at least one must appear.
+        assert any(w in out.lower() for w in ("guarantee", "verified", "solver", "z3")), (
+            f"witness block should make it clear values are solver-verified; "
+            f"got: {out[:200]}"
+        )
+
+    def test_non_int_value_renders_unchanged(self):
+        """Defensive: if the model has a non-int (shouldn't happen
+        but Z3 model values can be arbitrary), don't crash on the
+        hex-format step."""
+        out = _format_smt_witness({"model": {"name": "evil"}})
+        assert "name = evil" in out
+
+
+# -- build_exploit_prompt_bundle integration -------------------------------
+
+class TestExploitPromptBundleSmtWitness:
+    """The exploit prompt builder must surface the witness as a
+    dedicated UntrustedBlock when present."""
+
+    def _bundle_text(self, **kwargs):
+        """Build the bundle and return all message text concatenated.
+        PromptBundle has `messages` (tuple of MessagePart with role +
+        content); we don't care about role-splitting for these
+        assertions."""
+        bundle = build_exploit_prompt_bundle(
+            rule_id="r1",
+            file_path="/x.c",
+            start_line=42,
+            level="warning",
+            **kwargs,
+        )
+        return "\n".join(m.content for m in bundle.messages)
+
+    def test_witness_renders_when_attached(self):
+        analysis = {
+            "is_exploitable": True,
+            "smt_witness": {
+                "model": {"count": 268435457},
+                "path_conditions": ["count * 40 > 4294967295"],
+                "path_profile": "uint32",
+            },
+        }
+        text = self._bundle_text(analysis=analysis)
+        # Should contain the witness's concrete value (decimal) and
+        # the rendered hex.
+        assert "268435457" in text
+        assert "0x10000001" in text
+        assert "uint32" in text
+
+    def test_no_witness_block_when_absent(self):
+        """No `smt_witness` field on the analysis ⇒ no smt-witness
+        block in the prompt. Matches feasibility/etc behaviour."""
+        analysis = {"is_exploitable": True}
+        text = self._bundle_text(analysis=analysis)
+        # The kind label "smt-witness" appears in block headers
+        # only when the block is present.
+        assert "smt-witness" not in text.lower()
+
+    def test_empty_witness_block_when_model_empty(self):
+        """smt_witness present but model empty ⇒ no block (the
+        formatter returns empty, the caller skips)."""
+        analysis = {
+            "is_exploitable": True,
+            "smt_witness": {"model": {}},
+        }
+        text = self._bundle_text(analysis=analysis)
+        assert "smt-witness" not in text.lower()
+
+    def test_witness_block_paired_with_existing_blocks(self):
+        """Witness block should coexist with feasibility + code +
+        analysis blocks; don't crowd them out."""
+        analysis = {
+            "is_exploitable": True,
+            "smt_witness": {"model": {"x": 42}},
+        }
+        feasibility = {"chain_breaks": ["ASLR enabled"]}
+        text = self._bundle_text(
+            analysis=analysis,
+            code="int main() { return 0; }",
+            feasibility=feasibility,
+        )
+        # All four blocks present.
+        assert "x = 42" in text  # witness
+        assert "ASLR enabled" in text  # feasibility
+        assert "int main()" in text  # code
+        assert "is_exploitable" in text  # analysis
+
+
+# -- Tier 4 attachment side -----------------------------------------------
+
+class TestTier4AttachesSmtWitness:
+    """_tier4_smt_refine must mutate the analysis dict to carry the
+    structured witness when SMT outcome is sat (witness branch)."""
+
+    def test_witness_branch_attaches_smt_witness_to_analysis(self):
+        """Sat path conditions on a confirmed verdict → analysis
+        dict gains an smt_witness field with model + path_conditions
+        + path_profile."""
+        from packages.llm_analysis.dataflow_validation import _tier4_smt_refine
+        from packages.hypothesis_validation.result import ValidationResult
+
+        analysis = {
+            "path_conditions": ["x > 0"],
+            "path_profile": "uint32",
+        }
+        finding = {"finding_id": "f1"}
+        confirmed = ValidationResult(verdict="confirmed", evidence=[], iterations=1)
+
+        # Mock validate_path to return a sat result with a model.
+        with patch(
+            "packages.exploit_feasibility.smt_path.validate_path"
+        ) as mock_validate:
+            mock_validate.return_value = {
+                "feasible": True,
+                "smt_available": True,
+                "model": {"x": 7},
+                "reasoning": "satisfiable",
+                "satisfied": [],
+                "unsatisfied": [],
+                "unknown": [],
+                "unknown_reasons": [],
+            }
+            refined, outcome = _tier4_smt_refine(confirmed, finding, analysis)
+
+        assert outcome == "smt_witness"
+        # The structured witness MUST be on analysis (not just in
+        # the reasoning string).
+        assert "smt_witness" in analysis
+        assert analysis["smt_witness"]["model"] == {"x": 7}
+        assert analysis["smt_witness"]["path_conditions"] == ["x > 0"]
+        assert analysis["smt_witness"]["path_profile"] == "uint32"
+
+    def test_refuted_branch_does_not_attach_witness(self):
+        """Unsat conditions ⇒ no witness; analysis must be untouched
+        on this axis (don't leak stale data from a prior call)."""
+        from packages.llm_analysis.dataflow_validation import _tier4_smt_refine
+        from packages.hypothesis_validation.result import ValidationResult
+
+        analysis = {
+            "path_conditions": ["x > 0", "x < 0"],  # mutually exclusive
+            "path_profile": "uint32",
+        }
+        finding = {"finding_id": "f1"}
+        inconclusive = ValidationResult(
+            verdict="inconclusive", evidence=[], iterations=1,
+        )
+
+        with patch(
+            "packages.exploit_feasibility.smt_path.validate_path"
+        ) as mock_validate:
+            mock_validate.return_value = {
+                "feasible": False,
+                "smt_available": True,
+                "model": {},
+                "reasoning": "unsatisfiable",
+                "satisfied": [],
+                "unsatisfied": ["x > 0", "x < 0"],
+                "unknown": [],
+                "unknown_reasons": [],
+            }
+            _, outcome = _tier4_smt_refine(inconclusive, finding, analysis)
+
+        assert outcome == "smt_refuted"
+        assert "smt_witness" not in analysis
+
+    def test_no_check_branch_does_not_attach_witness(self):
+        """No path_conditions ⇒ no SMT call ⇒ no witness."""
+        from packages.llm_analysis.dataflow_validation import _tier4_smt_refine
+        from packages.hypothesis_validation.result import ValidationResult
+
+        analysis = {}  # no path_conditions
+        finding = {"finding_id": "f1"}
+        confirmed = ValidationResult(verdict="confirmed", evidence=[], iterations=1)
+
+        _, outcome = _tier4_smt_refine(confirmed, finding, analysis)
+
+        assert outcome == "no_check"
+        assert "smt_witness" not in analysis

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -12,6 +12,7 @@ import argparse
 import json
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -577,28 +578,52 @@ def run_codeql(
         cmd.extend(["--build-command", build_command])
 
     logger.info(f"Delegating CodeQL stage to {agent_script.name}")
+    # subprocess.run + timeout SIGKILLs the immediate child only,
+    # leaving the agent's codeql grandchildren as orphans holding
+    # cache locks + gigabytes of memory until they finish. This
+    # path is NOT sandboxed (the agent does its own sandboxing of
+    # the codeql calls), so namespace teardown isn't doing the
+    # cleanup for us. Use Popen with start_new_session so the
+    # agent becomes its own process group leader, then killpg on
+    # timeout to flatten the whole tree. Sandboxed call sites
+    # (adapters/codeql.py via make_sandbox_runner) don't need
+    # this — their immediate child IS the namespace, and killing
+    # the namespace kills everything inside.
+    proc = None
     try:
-        proc = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=3600,
+        proc = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            text=True, start_new_session=True,
         )
-    except subprocess.TimeoutExpired:
-        logger.warning("codeql agent timed out after 3600s; skipping")
-        return []
+        try:
+            stdout, stderr = proc.communicate(timeout=3600)
+            returncode = proc.returncode
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                pass
+            logger.warning("codeql agent timed out after 3600s; skipping")
+            return []
     except OSError as e:
         logger.warning(f"failed to invoke codeql agent: {e}")
         return []
 
-    if proc.returncode != 0:
+    if returncode != 0:
         # Surface the agent's stderr tail so the operator can see
         # WHY the run failed — language detection miscount, build
         # synthesis failure, trust-check rejection. Same truncation
         # rationale as before — codeql error output can run
         # thousands of lines.
-        stderr_tail = (proc.stderr or proc.stdout or "").strip()
+        stderr_tail = (stderr or stdout or "").strip()
         if len(stderr_tail) > 2000:
             stderr_tail = "..." + stderr_tail[-2000:]
         logger.warning(
-            f"codeql agent exited rc={proc.returncode}. "
+            f"codeql agent exited rc={returncode}. "
             f"Last stderr: {stderr_tail or '<empty>'}"
         )
         # Don't return early — the agent may have produced partial

--- a/packages/static-analysis/tests/test_scanner.py
+++ b/packages/static-analysis/tests/test_scanner.py
@@ -29,6 +29,18 @@ run_codeql = _scanner_mod.run_codeql
 # operator-supplied flags through to the agent's argv.
 # ---------------------------------------------------------------------------
 
+def _fake_popen(returncode=0, stdout="", stderr="", communicate_side_effect=None):
+    """Build a MagicMock that quacks like subprocess.Popen."""
+    fake = MagicMock()
+    fake.pid = 12345
+    fake.returncode = returncode
+    if communicate_side_effect is not None:
+        fake.communicate.side_effect = communicate_side_effect
+    else:
+        fake.communicate.return_value = (stdout, stderr)
+    return fake
+
+
 class TestRunCodeqlDelegation:
 
     def test_returns_empty_when_codeql_not_installed(self, tmp_path):
@@ -43,10 +55,8 @@ class TestRunCodeqlDelegation:
         if the agent never wrote one)."""
         out_dir = tmp_path / "codeql_out"
         with patch("shutil.which", return_value="/usr/bin/codeql"), \
-             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
-            mock_proc.return_value = MagicMock(
-                returncode=1, stdout="", stderr="agent failed",
-            )
+             patch.object(_scanner_mod.subprocess, "Popen") as mock_proc:
+            mock_proc.return_value = _fake_popen(returncode=1, stderr="agent failed")
             run_codeql(tmp_path, out_dir, ["python"])
         assert out_dir.exists()
 
@@ -55,11 +65,11 @@ class TestRunCodeqlDelegation:
         packages/codeql/agent.py with --repo and --out."""
         out_dir = tmp_path / "out"
         with patch("shutil.which", return_value="/usr/bin/codeql"), \
-             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
-            mock_proc.return_value = MagicMock(returncode=0, stdout="", stderr="")
+             patch.object(_scanner_mod.subprocess, "Popen") as mock_proc:
+            mock_proc.return_value = _fake_popen()
             run_codeql(tmp_path, out_dir, languages=None)
 
-        assert mock_proc.called, "subprocess.run was not called"
+        assert mock_proc.called, "subprocess.Popen was not called"
         cmd = mock_proc.call_args.args[0]
         assert cmd[0] == sys.executable
         # Agent script path component.
@@ -69,11 +79,28 @@ class TestRunCodeqlDelegation:
         assert "--repo" in cmd and str(tmp_path) in cmd
         assert "--out" in cmd and str(out_dir) in cmd
 
+    def test_popen_uses_new_session_for_orphan_cleanup(self, tmp_path):
+        """Without start_new_session=True, SIGKILL on the agent
+        leaves codeql grandchildren as orphans holding cache locks
+        + memory until they finish. The unification PR's bare
+        subprocess.run had this bug; the Popen migration fixes it.
+        """
+        with patch("shutil.which", return_value="/usr/bin/codeql"), \
+             patch.object(_scanner_mod.subprocess, "Popen") as mock_proc:
+            mock_proc.return_value = _fake_popen()
+            run_codeql(tmp_path, tmp_path / "out", languages=None)
+
+        kwargs = mock_proc.call_args.kwargs
+        assert kwargs.get("start_new_session") is True, (
+            f"Popen must be invoked with start_new_session=True for "
+            f"orphan-process cleanup; saw {kwargs}"
+        )
+
     def test_languages_forwarded_as_csv(self, tmp_path):
         """An explicit language list flows through as --languages a,b."""
         with patch("shutil.which", return_value="/usr/bin/codeql"), \
-             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
-            mock_proc.return_value = MagicMock(returncode=0, stdout="", stderr="")
+             patch.object(_scanner_mod.subprocess, "Popen") as mock_proc:
+            mock_proc.return_value = _fake_popen()
             run_codeql(tmp_path, tmp_path / "out", languages=["cpp", "java"])
 
         cmd = mock_proc.call_args.args[0]
@@ -87,8 +114,8 @@ class TestRunCodeqlDelegation:
         skips empty languages, vs the pre-unification 'always make
         cpp/java/python/go DBs' behaviour."""
         with patch("shutil.which", return_value="/usr/bin/codeql"), \
-             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
-            mock_proc.return_value = MagicMock(returncode=0, stdout="", stderr="")
+             patch.object(_scanner_mod.subprocess, "Popen") as mock_proc:
+            mock_proc.return_value = _fake_popen()
             run_codeql(tmp_path, tmp_path / "out", languages=None)
 
         cmd = mock_proc.call_args.args[0]
@@ -98,8 +125,8 @@ class TestRunCodeqlDelegation:
         """build_command flows through as --build-command for the
         agent's CodeQL DB creation."""
         with patch("shutil.which", return_value="/usr/bin/codeql"), \
-             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
-            mock_proc.return_value = MagicMock(returncode=0, stdout="", stderr="")
+             patch.object(_scanner_mod.subprocess, "Popen") as mock_proc:
+            mock_proc.return_value = _fake_popen()
             run_codeql(
                 tmp_path, tmp_path / "out",
                 languages=["cpp"], build_command="make -j4",
@@ -122,8 +149,8 @@ class TestRunCodeqlDelegation:
         (out_dir / "scan_metrics.json").write_text("{}")
 
         with patch("shutil.which", return_value="/usr/bin/codeql"), \
-             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
-            mock_proc.return_value = MagicMock(returncode=0, stdout="", stderr="")
+             patch.object(_scanner_mod.subprocess, "Popen") as mock_proc:
+            mock_proc.return_value = _fake_popen()
             result = run_codeql(tmp_path, out_dir, languages=None)
 
         assert sorted(result) == sorted([
@@ -140,29 +167,68 @@ class TestRunCodeqlDelegation:
         (out_dir / "codeql_python.sarif").write_text("{}")
 
         with patch("shutil.which", return_value="/usr/bin/codeql"), \
-             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
-            mock_proc.return_value = MagicMock(
-                returncode=1, stdout="", stderr="cpp build failed",
+             patch.object(_scanner_mod.subprocess, "Popen") as mock_proc:
+            mock_proc.return_value = _fake_popen(
+                returncode=1, stderr="cpp build failed",
             )
             result = run_codeql(tmp_path, out_dir, languages=["python", "cpp"])
 
         assert result == [str(out_dir / "codeql_python.sarif")]
 
-    def test_subprocess_timeout_returns_empty(self, tmp_path):
-        """Agent timeout: log and return empty rather than raise.
-        Matches the no-raise contract scanner.py expects from
-        every stage."""
+    def test_subprocess_timeout_killpgs_and_returns_empty(self, tmp_path):
+        """Agent timeout: SIGKILL the entire process group (so
+        codeql grandchildren die with the agent) and return empty
+        rather than raise. Matches the no-raise contract scanner
+        expects from every stage AND prevents orphan codeql holding
+        cache locks."""
         import subprocess
+        fake = _fake_popen(
+            communicate_side_effect=subprocess.TimeoutExpired(
+                cmd="codeql", timeout=3600,
+            ),
+        )
         with patch("shutil.which", return_value="/usr/bin/codeql"), \
-             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
-            mock_proc.side_effect = subprocess.TimeoutExpired(cmd="codeql", timeout=3600)
+             patch.object(_scanner_mod.subprocess, "Popen") as mock_popen, \
+             patch.object(_scanner_mod.os, "killpg") as mock_killpg, \
+             patch.object(_scanner_mod.os, "getpgid", return_value=12345):
+            mock_popen.return_value = fake
+            result = run_codeql(tmp_path, tmp_path / "out", languages=None)
+
+        assert result == []
+        # killpg must have been called with the agent's PGID +
+        # SIGKILL — anything less leaves codeql running.
+        assert mock_killpg.called, (
+            "killpg not invoked on TimeoutExpired — codeql will orphan"
+        )
+        args = mock_killpg.call_args.args
+        assert args[0] == 12345
+        assert args[1] == _scanner_mod.signal.SIGKILL
+
+    def test_killpg_swallows_processlookup_when_child_already_died(self, tmp_path):
+        """If the agent died on its own between communicate() and
+        our killpg, ProcessLookupError must not propagate as an
+        uncaught exception."""
+        import subprocess
+        fake = _fake_popen(
+            communicate_side_effect=subprocess.TimeoutExpired(
+                cmd="codeql", timeout=3600,
+            ),
+        )
+        with patch("shutil.which", return_value="/usr/bin/codeql"), \
+             patch.object(_scanner_mod.subprocess, "Popen") as mock_popen, \
+             patch.object(_scanner_mod.os, "killpg",
+                          side_effect=ProcessLookupError()), \
+             patch.object(_scanner_mod.os, "getpgid", return_value=12345):
+            mock_popen.return_value = fake
+            # Should not raise; should still return [].
             result = run_codeql(tmp_path, tmp_path / "out", languages=None)
         assert result == []
 
     def test_subprocess_oserror_returns_empty(self, tmp_path):
+        """Popen itself failing to spawn (ENOEXEC etc.) is caught."""
         with patch("shutil.which", return_value="/usr/bin/codeql"), \
-             patch.object(_scanner_mod.subprocess, "run") as mock_proc:
-            mock_proc.side_effect = OSError("ENOEXEC")
+             patch.object(_scanner_mod.subprocess, "Popen",
+                          side_effect=OSError("ENOEXEC")):
             result = run_codeql(tmp_path, tmp_path / "out", languages=None)
         assert result == []
 


### PR DESCRIPTION
  Closes the deferred follow-up from `project_smt_consumer_wirings` memory. Stacks on the predecessor that made the LLM actually populate path_conditions — now we feed Z3's witness model into /exploit as a starter PoC.

  - `_tier4_smt_refine` attaches a structured `analysis["smt_witness"] = {model, path_conditions, path_profile}` on confirmed+sat outcomes (previously the witness was buried in evidence-list free-text).
  - `prompts/exploit.build_exploit_prompt_bundle` reads it and surfaces a dedicated `smt-witness` UntrustedBlock — separate from the 10KB prior-analysis JSON dump where the LLM tended to miss it. Decimal AND hex per variable (exploit authors need hex for memory layout, decimal for argv).
  - `EXPLOIT_TASK_INSTRUCTIONS` adds one paragraph: SMT WITNESS values are solver-guaranteed; use them as concrete inputs instead of re-deriving from first principles.

  **Why:** integer-overflow / OOB / null-deref exploitation's hardest part is finding concrete trigger values that satisfy all branch conditions. Z3 decides this in polynomial time; the LLM has to grope. Handing over Z3's answer turns "guess the right count" into "count is 0x10000001, write a PoC passing that as argv[1]".
