### PR TITLE
feat(d1): mechanical fixture-detection for /agentic + /validate

### DIFF
--- a/.claude/skills/exploitability-validation/stage-d-ruling.md
+++ b/.claude/skills/exploitability-validation/stage-d-ruling.md
@@ -64,7 +64,38 @@ Finding is part of:
 - [ ] Documentation code blocks
 - [ ] Commented-out code
 
+**Mechanical signal — read first:** the prep step writes
+``finding.likely_test_harness`` (one of ``true`` / ``false`` /
+``candidate``) and ``finding.harness_evidence`` per finding. The
+new field is path + reachability — it tells you whether the
+test/mock-flagged function is actually reachable from any
+production entry point.
+
+  * ``likely_test_harness == "true"`` — path matches AND no
+    production caller. Rule out with
+    ``disqualifier: "D-1"``.
+  * ``likely_test_harness == "false"`` — either not a test
+    path, OR a production caller exists. D-1 does NOT apply.
+  * ``likely_test_harness == "candidate"`` — path matches but
+    reachability is uncertain (indirection flags) or data
+    missing. Verify before applying D-1; lean toward keeping
+    the finding intact when in doubt — false-demoting a real
+    bug is the worse failure mode.
+
+The legacy ``test_code_flag`` (path-only) is still emitted for
+back-compat. Prefer ``likely_test_harness`` when present.
+
 **Note:** Distinguish between "test code" (unit tests, integration tests that verify functionality) and "test data" (sample inputs, fixtures, intentionally vulnerable code for security tool testing). Test DATA that contains real vulnerable patterns should NOT be excluded - it represents realistic attack surfaces.
+
+**Operator override:** if ``finding.manual_override == true``,
+preserve the prior ruling regardless of D-1 signals. Record your
+reasoning in ``manual_override_dialogue`` but do not flip the
+status. Cross-reference upstream exploitation-validator#1
+proposal 2 (CB-5 narrow) — this implements the "test-harness
+circularity" check at a more conservative threshold than
+upstream proposes (RAPTOR's reachability gate avoids the
+inversion problem of demoting test-adjacent code that
+production reaches).
 
 ---
 

--- a/core/inventory/fixture_detection.py
+++ b/core/inventory/fixture_detection.py
@@ -1,0 +1,335 @@
+"""Test-fixture-circularity detection for security findings.
+
+Implements the mechanical part of D-5 (test-harness circularity) per the
+``/audit`` design — see ``stage-d-ruling.md`` and upstream
+exploitation-validator#1 proposal 2 (CB-5 narrow case).
+
+A finding is considered "test-harness-derived" when:
+  1. its source file matches a test-fixture path pattern, AND
+  2. the function the finding lives in is NOT reachable from any
+     production entry point (i.e. only test code can drive it).
+
+Both halves are needed: a finding in ``tests/conftest.py`` that's
+ALSO callable from a production endpoint is a real bug (someone
+left a debug surface in prod). A finding outside ``tests/`` that's
+only reachable from test code is also a fixture-derived FP, but
+the path-pattern check is the cheap pre-filter — most fixture
+content lives in conventional paths.
+
+The reachability gate is delegated to
+:mod:`core.inventory.reachability`, which already has a
+``exclude_test_files=True`` mode that excludes calls *from* test
+files when answering "is this called?". A function with no
+non-test callers gets ``NOT_CALLED``.
+
+Verdict semantics:
+  * ``true`` — fixture-path matches AND reachability says NOT_CALLED.
+    The finding's preconditions originate in test code that can't
+    drive production. Stage D's [D-5] rubric will rule this out
+    with ``severity_demoted_to: INFORMATIONAL``.
+  * ``false`` — fixture-path doesn't match, OR reachability says
+    CALLED (a production caller exists). The finding is treated as
+    real; D-5 doesn't fire.
+  * ``candidate`` — fixture-path matches but reachability is
+    UNCERTAIN (indirection-flag in a plausibly-calling file) OR
+    the inventory lacks reachability data for this function. The
+    LLM must verify before D-5 fires.
+
+The verdict and supporting evidence are written to the finding so
+downstream consumers (Stage D's LLM, /agentic's pre-flight skip,
+the SARIF/report layer) all see the same signal.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# Path-pattern match. Matches the conventions
+# ``core.inventory.reachability._is_test_file`` already uses, plus a
+# wider net (JS / Ruby / Go conventions) and explicit fixture
+# directory names operators commonly use.
+#
+# Patterns are anchored to a path component boundary (``/`` or
+# start-of-string) so substring "test" inside a real production
+# path component (``test_runner.py`` is the binary, not a fixture
+# — same example) doesn't false-match. Component-anchored matches
+# are stricter than substring; this is the deliberate choice.
+_FIXTURE_PATH_PATTERNS: Tuple[Tuple[str, str], ...] = (
+    # Directory-anchored — the conventional containers.
+    (r"(^|/)tests?/", "tests directory"),
+    (r"(^|/)__tests__/", "JS __tests__ directory"),
+    (r"(^|/)spec/", "spec directory (Ruby/JS/etc.)"),
+    (r"(^|/)testdata/", "Go testdata directory"),
+    (r"(^|/)fixtures?/", "fixtures directory"),
+    # Filename-anchored — the conventional unit-test names.
+    (r"(^|/)test_[^/]+\.py$", "Python test_*.py"),
+    (r"(^|/)[^/]+_test\.py$", "Python *_test.py"),
+    (r"(^|/)conftest\.py$", "pytest conftest.py"),
+    (r"(^|/)[^/]+_test\.go$", "Go *_test.go"),
+    (r"(^|/)[^/]+\.test\.[jt]sx?$", "JS/TS *.test.{js,ts,jsx,tsx}"),
+    (r"(^|/)[^/]+\.spec\.[jt]sx?$", "JS/TS *.spec.{js,ts,jsx,tsx}"),
+    (r"(^|/)Test[A-Z][^/]*\.java$", "Java Test*.java"),
+    (r"(^|/)[^/]+Test\.java$", "Java *Test.java"),
+)
+
+_FIXTURE_PATH_RE = re.compile(
+    "|".join(p for p, _ in _FIXTURE_PATH_PATTERNS),
+)
+
+_PATTERN_LABELS: Dict[str, str] = {
+    p: label for p, label in _FIXTURE_PATH_PATTERNS
+}
+
+
+@dataclass(frozen=True)
+class HarnessEvidence:
+    """One piece of evidence supporting a fixture-detection verdict.
+
+    ``type`` is one of:
+      * ``fixture_path_match`` — path-pattern hit. ``path`` is the
+        finding's file; ``pattern`` is the matched-pattern label
+        (human-readable, not the regex itself).
+      * ``reachability_check`` — outcome of the reachability gate.
+        ``result`` is one of ``not_reachable_from_prod``,
+        ``reachable_from_prod``, ``data_missing``,
+        ``data_uncertain``. ``checked_against`` lists evidence
+        sites returned by ``function_called``.
+    """
+    type: str
+    path: str = ""
+    pattern: str = ""
+    result: str = ""
+    checked_against: Tuple[str, ...] = ()
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {"type": self.type}
+        if self.path:
+            d["path"] = self.path
+        if self.pattern:
+            d["pattern"] = self.pattern
+        if self.result:
+            d["result"] = self.result
+        if self.checked_against:
+            d["checked_against"] = list(self.checked_against)
+        return d
+
+
+@dataclass(frozen=True)
+class FixtureVerdict:
+    """Mechanical detection result for a single finding.
+
+    Consumers translate ``likely_test_harness`` to action:
+      * ``true``  — auto-eligible for D-5 demotion (LLM verifies in
+                    /validate; /agentic may skip the LLM analysis
+                    entirely with a deterministic synthetic result)
+      * ``false`` — D-5 does not apply; finding flows through
+                    normally
+      * ``candidate`` — LLM must verify before D-5 fires; never
+                       auto-demote
+    """
+    likely_test_harness: str  # "true" | "false" | "candidate"
+    evidence: Tuple[HarnessEvidence, ...] = ()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "likely_test_harness": self.likely_test_harness,
+            "harness_evidence": [e.to_dict() for e in self.evidence],
+        }
+
+
+def is_fixture_path(file_path: str) -> Tuple[bool, str]:
+    """Return ``(matched, label)`` for a path-pattern check.
+
+    ``label`` is the human-readable pattern name (e.g. "pytest
+    conftest.py"); empty when no match. Path is normalised to
+    forward slashes before matching so Windows separators don't
+    break the regex.
+    """
+    if not file_path:
+        return (False, "")
+    # Normalise BOTH separators — paths from a Windows operator
+    # arrive with ``\``; same path matched against this code on a
+    # Linux host needs explicit conversion (``os.sep`` alone is
+    # the host separator, not the path's separator).
+    normalised = file_path.replace("\\", "/")
+    for pattern, label in _FIXTURE_PATH_PATTERNS:
+        if re.search(pattern, normalised):
+            return (True, label)
+    return (False, "")
+
+
+def detect_fixture(
+    *,
+    file_path: str,
+    function: str,
+    inventory: Optional[Dict[str, Any]] = None,
+    qualified_name: Optional[str] = None,
+) -> FixtureVerdict:
+    """Mechanical fixture detection for a single finding.
+
+    Args:
+        file_path: repo-relative source file the finding is in.
+        function: name of the enclosing function (used to construct
+            the qualified name when ``qualified_name`` is None).
+        inventory: project inventory dict, as returned by
+            :func:`core.inventory.build_inventory`. When None, the
+            reachability gate is skipped — verdict is at most
+            ``candidate`` (path matched, reachability unknown).
+        qualified_name: dotted name to query against reachability
+            (e.g. ``"src.module.func"``). When None, fall back to
+            ``"<file-stem>.<function>"`` — coarse but sufficient
+            for the common case where the inventory's call-graph
+            entries match.
+
+    Returns:
+        :class:`FixtureVerdict` with verdict + evidence list.
+    """
+    evidence: List[HarnessEvidence] = []
+
+    matched, label = is_fixture_path(file_path)
+    if not matched:
+        # No fixture-path hit → finding is in production-shaped
+        # code. D-5 doesn't apply regardless of reachability.
+        return FixtureVerdict(likely_test_harness="false")
+
+    evidence.append(HarnessEvidence(
+        type="fixture_path_match",
+        path=file_path,
+        pattern=label,
+    ))
+
+    # Treat both ``None`` and empty/missing-files inventories the
+    # same — no data to gate on. The resolver itself happily
+    # returns NOT_CALLED for an empty inventory (no callers
+    # found), which would falsely flag every fixture-path finding
+    # as ``true`` and auto-demote it. Fall to ``candidate``
+    # whenever the inventory can't actually inform the gate.
+    if (
+        inventory is None
+        or not isinstance(inventory, dict)
+        or not inventory.get("files")
+    ):
+        evidence.append(HarnessEvidence(
+            type="reachability_check",
+            result="data_missing",
+        ))
+        return FixtureVerdict(
+            likely_test_harness="candidate",
+            evidence=tuple(evidence),
+        )
+
+    qname = qualified_name or _default_qualified_name(file_path, function)
+    if not qname or "." not in qname:
+        # Reachability resolver requires a dotted name. Fall back
+        # to candidate — path matched but we can't run the gate.
+        evidence.append(HarnessEvidence(
+            type="reachability_check",
+            result="data_missing",
+        ))
+        return FixtureVerdict(
+            likely_test_harness="candidate",
+            evidence=tuple(evidence),
+        )
+
+    try:
+        from core.inventory.reachability import (
+            Verdict,
+            function_called,
+        )
+    except Exception:
+        # Reachability substrate unavailable — fall through to
+        # candidate. Don't ever crash the consumer on import.
+        evidence.append(HarnessEvidence(
+            type="reachability_check",
+            result="data_missing",
+        ))
+        return FixtureVerdict(
+            likely_test_harness="candidate",
+            evidence=tuple(evidence),
+        )
+
+    try:
+        result = function_called(
+            inventory, qname, exclude_test_files=True,
+        )
+    except Exception:
+        # Bad inventory / qualified-name — don't crash, fall to
+        # candidate so the LLM can verify. Broad catch is
+        # deliberate: this helper is called from /agentic and
+        # /validate hot paths and must never propagate.
+        evidence.append(HarnessEvidence(
+            type="reachability_check",
+            result="data_missing",
+        ))
+        return FixtureVerdict(
+            likely_test_harness="candidate",
+            evidence=tuple(evidence),
+        )
+
+    if result.verdict == Verdict.CALLED:
+        # Reachable from prod — fixture path doesn't matter; the
+        # finding's call chain reaches non-test code. D-5 NOT
+        # eligible.
+        sites = tuple(
+            f"{path}:{line}" for path, line in result.evidence
+        )
+        evidence.append(HarnessEvidence(
+            type="reachability_check",
+            result="reachable_from_prod",
+            checked_against=sites[:5],  # cap evidence list size
+        ))
+        return FixtureVerdict(
+            likely_test_harness="false",
+            evidence=tuple(evidence),
+        )
+
+    if result.verdict == Verdict.NOT_CALLED:
+        # No production caller. Confirmed test-harness-only.
+        evidence.append(HarnessEvidence(
+            type="reachability_check",
+            result="not_reachable_from_prod",
+        ))
+        return FixtureVerdict(
+            likely_test_harness="true",
+            evidence=tuple(evidence),
+        )
+
+    # UNCERTAIN — indirection flags in plausibly-calling files.
+    # LLM must verify; never auto-demote on uncertainty.
+    indirection_sites = tuple(
+        f"{path} ({flag})"
+        for path, flag in result.uncertain_reasons[:5]
+    )
+    evidence.append(HarnessEvidence(
+        type="reachability_check",
+        result="data_uncertain",
+        checked_against=indirection_sites,
+    ))
+    return FixtureVerdict(
+        likely_test_harness="candidate",
+        evidence=tuple(evidence),
+    )
+
+
+def _default_qualified_name(file_path: str, function: str) -> str:
+    """Construct a fallback dotted name when consumers don't supply
+    one. ``src/foo/bar.py + run`` → ``src.foo.bar.run``. Crude —
+    consumers that have a richer module-path representation should
+    pass ``qualified_name`` directly."""
+    if not file_path or not function:
+        return ""
+    norm = file_path.replace(os.sep, "/")
+    # Strip extension; common Python / JS / Go cases. Other
+    # languages fall back to bare function name (rejected as
+    # too-coarse by the resolver).
+    for ext in (".py", ".js", ".ts", ".jsx", ".tsx", ".go", ".rb"):
+        if norm.endswith(ext):
+            norm = norm[: -len(ext)]
+            break
+    parts = [p for p in norm.split("/") if p]
+    parts.append(function)
+    return ".".join(parts)

--- a/core/inventory/tests/test_fixture_detection.py
+++ b/core/inventory/tests/test_fixture_detection.py
@@ -1,0 +1,327 @@
+"""Tests for ``core.inventory.fixture_detection``.
+
+Two halves:
+
+  * Path-pattern unit tests for ``is_fixture_path`` — exhaustive
+    across the conventional fixture path shapes per language /
+    framework.
+  * Integration tests for ``detect_fixture`` — exercise the full
+    path-match + reachability-gate flow with realistic inventory
+    fixtures, mocked reachability outcomes, and adversarial
+    inputs.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from core.inventory.fixture_detection import (
+    FixtureVerdict,
+    HarnessEvidence,
+    detect_fixture,
+    is_fixture_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# Path-pattern detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsFixturePath:
+    @pytest.mark.parametrize("path,expected_label", [
+        ("tests/conftest.py", "tests directory"),
+        ("tests/sub/test_foo.py", "tests directory"),
+        ("test/foo.go", "tests directory"),
+        ("src/__tests__/Foo.test.tsx", "JS __tests__ directory"),
+        ("spec/lib/foo_spec.rb", "spec directory (Ruby/JS/etc.)"),
+        ("internal/testdata/sample.txt", "Go testdata directory"),
+        ("tests/fixtures/users.json", "tests directory"),
+        ("fixtures/users.json", "fixtures directory"),
+        ("test_runner.py", "Python test_*.py"),
+        ("src/foo/test_bar.py", "Python test_*.py"),
+        ("src/foo/bar_test.py", "Python *_test.py"),
+        ("conftest.py", "pytest conftest.py"),
+        ("src/conftest.py", "pytest conftest.py"),
+        ("src/foo_test.go", "Go *_test.go"),
+        ("Foo.test.js", "JS/TS *.test.{js,ts,jsx,tsx}"),
+        ("Foo.test.ts", "JS/TS *.test.{js,ts,jsx,tsx}"),
+        ("Foo.spec.tsx", "JS/TS *.spec.{js,ts,jsx,tsx}"),
+        ("src/main/java/TestRunner.java", "Java Test*.java"),
+        ("src/main/java/RunnerTest.java", "Java *Test.java"),
+    ])
+    def test_matches_conventional_fixture_paths(self, path, expected_label):
+        matched, label = is_fixture_path(path)
+        assert matched, f"expected match for {path!r}"
+        assert label == expected_label
+
+    @pytest.mark.parametrize("path", [
+        "src/api/upload.py",
+        "src/db/query.py",
+        "src/auth/login.py",
+        "lib/util.go",
+        "internal/handler.go",  # internal/ is NOT testdata/
+        "src/main.rs",
+        "src/components/Button.tsx",
+        "main.py",
+        # Substring "test" inside a real word doesn't match — pattern
+        # is component-anchored.
+        "src/contestant.py",
+        "src/protest.go",
+    ])
+    def test_does_not_match_production_paths(self, path):
+        matched, label = is_fixture_path(path)
+        assert not matched, f"unexpected match for {path!r}"
+        assert label == ""
+
+    def test_empty_path_returns_no_match(self):
+        assert is_fixture_path("") == (False, "")
+
+    def test_windows_separators_normalised(self):
+        # Python OS-path separators get normalised to forward slash
+        # before matching — Windows paths shouldn't break detection.
+        matched, label = is_fixture_path("tests\\sub\\conftest.py")
+        assert matched
+        assert label == "tests directory"
+
+
+# ---------------------------------------------------------------------------
+# detect_fixture — full path + reachability gate
+# ---------------------------------------------------------------------------
+
+
+class TestDetectFixture:
+    def test_non_fixture_path_short_circuits_to_false(self):
+        v = detect_fixture(
+            file_path="src/api/upload.py", function="save",
+        )
+        assert v.likely_test_harness == "false"
+        assert v.evidence == ()
+
+    def test_fixture_path_no_inventory_yields_candidate(self):
+        v = detect_fixture(
+            file_path="tests/conftest.py", function="setup_user",
+        )
+        assert v.likely_test_harness == "candidate"
+        # Two evidence items: the path match and the
+        # reachability-data-missing tag.
+        assert len(v.evidence) == 2
+        assert v.evidence[0].type == "fixture_path_match"
+        assert v.evidence[1].type == "reachability_check"
+        assert v.evidence[1].result == "data_missing"
+
+    def test_fixture_path_with_called_verdict_yields_false(self):
+        # Path matches BUT reachability says CALLED — production
+        # caller exists, so D-5 must NOT fire.
+        from core.inventory.reachability import (
+            ReachabilityResult, Verdict,
+        )
+        with patch(
+            "core.inventory.reachability.function_called",
+            return_value=ReachabilityResult(
+                verdict=Verdict.CALLED,
+                evidence=(("src/api/main.py", 42),),
+            ),
+        ):
+            v = detect_fixture(
+                file_path="tests/conftest.py",
+                function="setup_user",
+                inventory={"files": [{"path": "src/x.py"}]},  # truthy; mocked anyway
+                qualified_name="tests.conftest.setup_user",
+            )
+        assert v.likely_test_harness == "false"
+        # Evidence preserved so operator can see WHY this wasn't
+        # demoted — the production caller location.
+        reach = next(
+            e for e in v.evidence if e.type == "reachability_check"
+        )
+        assert reach.result == "reachable_from_prod"
+        assert "src/api/main.py:42" in reach.checked_against
+
+    def test_fixture_path_with_not_called_verdict_yields_true(self):
+        from core.inventory.reachability import (
+            ReachabilityResult, Verdict,
+        )
+        with patch(
+            "core.inventory.reachability.function_called",
+            return_value=ReachabilityResult(verdict=Verdict.NOT_CALLED),
+        ):
+            v = detect_fixture(
+                file_path="tests/conftest.py",
+                function="setup_user",
+                inventory={"files": [{"path": "src/x.py"}]},
+                qualified_name="tests.conftest.setup_user",
+            )
+        assert v.likely_test_harness == "true"
+        reach = next(
+            e for e in v.evidence if e.type == "reachability_check"
+        )
+        assert reach.result == "not_reachable_from_prod"
+
+    def test_fixture_path_with_uncertain_yields_candidate(self):
+        from core.inventory.reachability import (
+            ReachabilityResult, Verdict,
+        )
+        with patch(
+            "core.inventory.reachability.function_called",
+            return_value=ReachabilityResult(
+                verdict=Verdict.UNCERTAIN,
+                uncertain_reasons=(("src/dynamic.py", "getattr"),),
+            ),
+        ):
+            v = detect_fixture(
+                file_path="tests/conftest.py",
+                function="setup_user",
+                inventory={"files": [{"path": "src/x.py"}]},
+                qualified_name="tests.conftest.setup_user",
+            )
+        assert v.likely_test_harness == "candidate"
+        reach = next(
+            e for e in v.evidence if e.type == "reachability_check"
+        )
+        assert reach.result == "data_uncertain"
+        assert any(
+            "getattr" in s for s in reach.checked_against
+        )
+
+    def test_function_called_raises_falls_through_to_candidate(self):
+        # Bad inventory / wrong shape → resolver raises. Helper
+        # must NOT crash; verdict falls to candidate so LLM can
+        # verify.
+        with patch(
+            "core.inventory.reachability.function_called",
+            side_effect=ValueError("bad qname"),
+        ):
+            v = detect_fixture(
+                file_path="tests/conftest.py",
+                function="setup_user",
+                inventory={"files": [{"path": "src/x.py"}]},
+                qualified_name="tests.conftest.setup_user",
+            )
+        assert v.likely_test_harness == "candidate"
+        reach = next(
+            e for e in v.evidence if e.type == "reachability_check"
+        )
+        assert reach.result == "data_missing"
+
+    def test_no_function_yields_candidate_after_path_match(self):
+        # Path matches, function missing → can't construct
+        # qualified name → can't run reachability gate → candidate.
+        v = detect_fixture(
+            file_path="tests/conftest.py", function="",
+            inventory={"files": [{"path": "src/x.py"}]},
+        )
+        assert v.likely_test_harness == "candidate"
+
+    def test_empty_inventory_files_yields_candidate(self):
+        # ``inventory={"files": []}`` would let the resolver return
+        # NOT_CALLED (no callers found because no files in the
+        # inventory), which would falsely mark every fixture-path
+        # finding as ``true``. Helper detects empty-inventory
+        # upstream and falls to ``candidate``.
+        v = detect_fixture(
+            file_path="tests/conftest.py", function="f",
+            inventory={"files": []},
+            qualified_name="tests.conftest.f",
+        )
+        assert v.likely_test_harness == "candidate"
+
+    def test_evidence_size_capped(self):
+        # Reachability returns 100 evidence sites — fixture
+        # detection caps the surface so on-disk evidence stays
+        # bounded.
+        from core.inventory.reachability import (
+            ReachabilityResult, Verdict,
+        )
+        many_sites = tuple(("src/f.py", i) for i in range(100))
+        with patch(
+            "core.inventory.reachability.function_called",
+            return_value=ReachabilityResult(
+                verdict=Verdict.CALLED, evidence=many_sites,
+            ),
+        ):
+            v = detect_fixture(
+                file_path="tests/conftest.py",
+                function="setup_user",
+                inventory={"files": [{"path": "src/x.py"}]},
+                qualified_name="tests.conftest.setup_user",
+            )
+        reach = next(
+            e for e in v.evidence if e.type == "reachability_check"
+        )
+        # Bounded to 5 to keep the on-disk size sane.
+        assert len(reach.checked_against) == 5
+
+
+class TestSerialisation:
+    def test_to_dict_round_trip_shape(self):
+        v = FixtureVerdict(
+            likely_test_harness="true",
+            evidence=(
+                HarnessEvidence(
+                    type="fixture_path_match",
+                    path="tests/conftest.py",
+                    pattern="pytest conftest.py",
+                ),
+                HarnessEvidence(
+                    type="reachability_check",
+                    result="not_reachable_from_prod",
+                ),
+            ),
+        )
+        d = v.to_dict()
+        assert d["likely_test_harness"] == "true"
+        assert len(d["harness_evidence"]) == 2
+        assert d["harness_evidence"][0]["type"] == "fixture_path_match"
+        assert d["harness_evidence"][0]["pattern"] == "pytest conftest.py"
+
+
+# ---------------------------------------------------------------------------
+# Adversarial — hostile / malformed inputs must not crash
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarial:
+    def test_path_traversal_in_file_path(self):
+        # Doesn't crash; the pattern detector treats traversal
+        # paths the same as any other — check still works on the
+        # normalised form.
+        v = detect_fixture(
+            file_path="../../etc/passwd", function="getpwent",
+        )
+        assert v.likely_test_harness == "false"
+
+    def test_extremely_long_path_does_not_blow_up(self):
+        long_path = "tests/" + ("x" * 50_000)
+        v = detect_fixture(file_path=long_path, function="f")
+        # Path matched; evidence carries the full path (caller
+        # decides whether to truncate).
+        assert v.likely_test_harness == "candidate"
+
+    def test_unicode_path(self):
+        v = detect_fixture(
+            file_path="tests/應用_test.py", function="f",
+        )
+        # Matches because "tests/" is anchored. Function present;
+        # no inventory; falls to candidate.
+        assert v.likely_test_harness == "candidate"
+
+    def test_null_byte_in_path(self):
+        # Path-pattern regex doesn't operate on null bytes
+        # specially; doesn't crash.
+        v = detect_fixture(
+            file_path="tests/conftest.py\x00evil", function="f",
+        )
+        assert v.likely_test_harness in ("candidate", "false")
+
+    def test_inventory_missing_files_key(self):
+        # Resolver expects ``inventory["files"]``. Malformed
+        # inventory raises; helper catches and falls to candidate.
+        v = detect_fixture(
+            file_path="tests/conftest.py", function="f",
+            inventory={},  # no "files" key
+            qualified_name="tests.conftest.f",
+        )
+        assert v.likely_test_harness == "candidate"

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -499,14 +499,24 @@ class TestCoverageStats:
 
 # ── CLI Script ──────────────────────────────────────────────────────
 
+_BUILD_INVENTORY_SCRIPT = (
+    Path(__file__).resolve().parents[3] / "build_inventory.py"
+)
+
+
 class TestCLIScript:
     def test_build_inventory_script(self, tmp_path):
+        # Anchor the script path to ``__file__`` rather than CWD so
+        # the test passes regardless of where pytest is invoked
+        # (per ``feedback-test-cwd-relative-paths``: pytest workers,
+        # IDE runners, and CI may all start with different cwds).
         src = tmp_path / "src"
         src.mkdir()
         (src / "app.py").write_text("def main(): pass\n")
 
         result = subprocess.run(
-            [sys.executable, "build_inventory.py", "--repo", str(src), "--out", str(tmp_path / "out")],
+            [sys.executable, str(_BUILD_INVENTORY_SCRIPT),
+             "--repo", str(src), "--out", str(tmp_path / "out")],
             capture_output=True, text=True, timeout=30,
         )
         assert result.returncode == 0
@@ -515,7 +525,8 @@ class TestCLIScript:
 
     def test_nonexistent_repo_fails(self, tmp_path):
         result = subprocess.run(
-            [sys.executable, "build_inventory.py", "--repo", "/nonexistent", "--out", str(tmp_path)],
+            [sys.executable, str(_BUILD_INVENTORY_SCRIPT),
+             "--repo", "/nonexistent", "--out", str(tmp_path)],
             capture_output=True, text=True, timeout=30,
         )
         assert result.returncode == 1

--- a/libexec/raptor-validation-helper
+++ b/libexec/raptor-validation-helper
@@ -708,14 +708,47 @@ def prepare_D(workdir, target=None):
                  if f.get("sanity_check", {}).get("passed") is False)
     print(f"Sanity check: {passed} passed, {failed} failed")
 
-    # --- Test/mock path filter ---
+    # --- Test/mock path filter (D-1) ---
+    # ``test_code_flag`` is the legacy path-only signal — fast,
+    # back-compat, but over-demotes when a real bug lives in test-
+    # adjacent code that production also reaches. The richer
+    # ``likely_test_harness`` (added 2026-05-10, see
+    # core/inventory/fixture_detection) layers a reachability
+    # gate on top, telling the LLM whether the path-flagged
+    # function is actually reachable from a production entry
+    # point. D-1's skill section reads the richer signal first;
+    # the simpler flag is kept for skills that haven't been
+    # updated.
+    inventory_path = Path(workdir) / "checklist.json"
+    inventory = load_json(inventory_path) if inventory_path.is_file() else None
+    try:
+        from core.inventory.fixture_detection import detect_fixture
+    except ImportError:
+        detect_fixture = None  # type: ignore[assignment]
+
     for finding in data.get("findings", []):
         if finding.get("status") == "disproven":
             continue
         fpath = finding.get("file", "")
         finding["test_code_flag"] = any(re.search(p, fpath) for p in TEST_PATTERNS)
+
+        if detect_fixture is not None:
+            verdict = detect_fixture(
+                file_path=fpath,
+                function=finding.get("function", ""),
+                inventory=inventory,
+            )
+            finding["likely_test_harness"] = verdict.likely_test_harness
+            finding["harness_evidence"] = [
+                e.to_dict() for e in verdict.evidence
+            ]
+
         if finding["test_code_flag"]:
-            print(f"  D0 FLAG: {finding['id']} in test/mock path: {fpath}")
+            label = finding.get("likely_test_harness", "?")
+            print(
+                f"  D-1 FLAG: {finding['id']} test path "
+                f"(likely_test_harness={label}): {fpath}"
+            )
 
     # --- Evidence card assembly ---
     for finding in data.get("findings", []):

--- a/packages/exploitability_validation/schemas.py
+++ b/packages/exploitability_validation/schemas.py
@@ -291,7 +291,37 @@ FINDING_SCHEMA = {
         },
         "dedup_flag": {"type": ["string", "null"], "description": "A1: potential duplicate indicator"},
         "checklist_verified": {"type": "boolean", "description": "C0: file+line found in inventory"},
-        "test_code_flag": {"type": "boolean", "description": "D0: file matches test/mock pattern"}
+        "test_code_flag": {"type": "boolean", "description": "D0: file matches test/mock pattern"},
+        "likely_test_harness": {
+            "type": "string",
+            "enum": ["true", "false", "candidate"],
+            "description": "D-1 enhanced: path + reachability gate. "
+                           "'true' = path matches AND function is not "
+                           "reachable from production entry points "
+                           "(D-1 should rule out). 'false' = no path "
+                           "match OR reachable from production. "
+                           "'candidate' = path matches but reachability "
+                           "uncertain or data missing — LLM verifies."
+        },
+        "harness_evidence": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": "Supporting evidence for likely_test_harness: "
+                           "fixture_path_match entries + reachability_check "
+                           "result. See core.inventory.fixture_detection."
+        },
+        "manual_override": {
+            "type": "boolean",
+            "description": "Operator-set: when true, Stage D's LLM and the "
+                           "IRIS Tier 1 gate must preserve any pre-existing "
+                           "ruling regardless of mechanical signals. Edits "
+                           "to this field survive across re-runs."
+        },
+        "manual_override_reason": {
+            "type": "string",
+            "description": "Operator-supplied rationale for manual_override "
+                           "(audit trail; rendered in reports)."
+        }
     }
 }
 

--- a/packages/exploitability_validation/tests/test_d1_fixture_cross_pipeline.py
+++ b/packages/exploitability_validation/tests/test_d1_fixture_cross_pipeline.py
@@ -1,0 +1,200 @@
+"""Cross-pipeline consistency for D-1 fixture-detection.
+
+Drives the /validate Stage D mechanical prep with a finding shape
+identical to one /agentic's pre-flight would consume, and pins
+that both pipelines reach the same ``likely_test_harness``
+verdict on the same input. Without this, /agentic and /validate
+could diverge silently — operator running both gets contradictory
+demotions.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HELPER_PATH = REPO_ROOT / "libexec" / "raptor-validation-helper"
+
+
+@pytest.fixture
+def helper_module():
+    os.environ.setdefault("_RAPTOR_TRUSTED", "1")
+    loader = SourceFileLoader("raptor_validation_helper", str(HELPER_PATH))
+    spec = importlib.util.spec_from_loader("raptor_validation_helper", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+def _make_workdir(tmp_path, finding):
+    findings_data = {
+        "stage": "C",
+        "target_path": "/repo",
+        "findings": [finding],
+    }
+    (tmp_path / "findings.json").write_text(json.dumps(findings_data))
+    checklist = {
+        "target_path": "/repo",
+        "files": [
+            {"path": "src/api.py",
+             "items": [{"name": "save_upload",
+                        "line_start": 1, "line_end": 2}]},
+            {"path": "tests/conftest.py",
+             "items": [{"name": "setup_user",
+                        "line_start": 1, "line_end": 2}]},
+        ],
+    }
+    (tmp_path / "checklist.json").write_text(json.dumps(checklist))
+    (tmp_path / "stage-c.json").write_text(json.dumps({
+        "stage": "C", "updates": {},
+    }))
+    return tmp_path
+
+
+def _stage_c_finding(file, function, fid, **extras):
+    f = {
+        "id": fid,
+        "file": file,
+        "function": function,
+        "line": 1,
+        "vuln_type": "path_traversal",
+        "status": "not_disproven",
+        "confidence": "medium",
+        "candidate_reasoning": "x",
+        "stage_a_summary": {"status": "not_disproven",
+                             "confidence": "medium"},
+        "stage_b_summary": {},
+        "stage_c_summary": {
+            "checks": {"file_exists": True, "code_verbatim": True,
+                       "flow_real": True, "reachable": True},
+        },
+        "sanity_check": {"passed": True},
+    }
+    f.update(extras)
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Cross-pipeline consistency
+# ---------------------------------------------------------------------------
+
+
+class TestCrossPipelineVerdictConsistency:
+    """The same (file, function, inventory) input must yield the same
+    ``likely_test_harness`` verdict whether processed by /agentic's
+    pre-flight or /validate's Stage D prep. Both pipelines call
+    ``core.inventory.fixture_detection.detect_fixture`` directly,
+    so consistency reduces to "same input → same call → same output"
+    — but pin it in case a future divergence creeps in via wrapper
+    differences."""
+
+    def test_fixture_finding_same_verdict_in_both_pipelines(
+        self, helper_module, tmp_path,
+    ):
+        finding = _stage_c_finding(
+            "tests/conftest.py", "setup_user", "F-FIX",
+        )
+        workdir = _make_workdir(tmp_path, finding)
+        # Run /validate's Stage D prep
+        helper_module.prepare_D(workdir)
+        validate_data = json.loads(
+            (workdir / "findings.json").read_text(),
+        )
+        validate_finding = next(
+            f for f in validate_data["findings"]
+            if f["id"] == "F-FIX"
+        )
+        validate_verdict = validate_finding.get("likely_test_harness")
+
+        # Run /agentic's pre-flight directly via the shared helper
+        from core.inventory.fixture_detection import detect_fixture
+        checklist = json.loads(
+            (workdir / "checklist.json").read_text(),
+        )
+        agentic_verdict = detect_fixture(
+            file_path="tests/conftest.py",
+            function="setup_user",
+            inventory=checklist,
+        ).likely_test_harness
+
+        # Same verdict.
+        assert validate_verdict == agentic_verdict, (
+            f"divergence: validate={validate_verdict!r}, "
+            f"agentic={agentic_verdict!r}"
+        )
+
+    def test_production_finding_same_verdict_in_both_pipelines(
+        self, helper_module, tmp_path,
+    ):
+        finding = _stage_c_finding(
+            "src/api.py", "save_upload", "F-PROD",
+        )
+        workdir = _make_workdir(tmp_path, finding)
+        helper_module.prepare_D(workdir)
+        validate_data = json.loads(
+            (workdir / "findings.json").read_text(),
+        )
+        validate_finding = next(
+            f for f in validate_data["findings"]
+            if f["id"] == "F-PROD"
+        )
+        validate_verdict = validate_finding.get("likely_test_harness")
+
+        from core.inventory.fixture_detection import detect_fixture
+        checklist = json.loads(
+            (workdir / "checklist.json").read_text(),
+        )
+        agentic_verdict = detect_fixture(
+            file_path="src/api.py",
+            function="save_upload",
+            inventory=checklist,
+        ).likely_test_harness
+
+        # Both pipelines see ``false`` — production path, no D-1
+        # demotion in either.
+        assert validate_verdict == agentic_verdict == "false"
+
+    def test_evidence_shape_consistent(
+        self, helper_module, tmp_path,
+    ):
+        """Both pipelines write ``harness_evidence`` as a list of
+        dicts with the same shape — fixture_path_match entries
+        carry ``path`` and ``pattern``; reachability_check entries
+        carry ``result`` and optionally ``checked_against``."""
+        finding = _stage_c_finding(
+            "tests/conftest.py", "setup_user", "F-EV",
+        )
+        workdir = _make_workdir(tmp_path, finding)
+        helper_module.prepare_D(workdir)
+        validate_data = json.loads(
+            (workdir / "findings.json").read_text(),
+        )
+        validate_finding = next(
+            f for f in validate_data["findings"]
+            if f["id"] == "F-EV"
+        )
+        validate_evidence = validate_finding.get(
+            "harness_evidence", [],
+        )
+
+        from core.inventory.fixture_detection import detect_fixture
+        checklist = json.loads(
+            (workdir / "checklist.json").read_text(),
+        )
+        agentic_verdict = detect_fixture(
+            file_path="tests/conftest.py",
+            function="setup_user",
+            inventory=checklist,
+        )
+        agentic_evidence = [e.to_dict() for e in agentic_verdict.evidence]
+
+        # Same shape — same number of entries, same types.
+        assert len(validate_evidence) == len(agentic_evidence)
+        for v_ev, a_ev in zip(validate_evidence, agentic_evidence):
+            assert v_ev["type"] == a_ev["type"]

--- a/packages/exploitability_validation/tests/test_d_prep_fixture_signal.py
+++ b/packages/exploitability_validation/tests/test_d_prep_fixture_signal.py
@@ -1,0 +1,181 @@
+"""Tests for the validation-helper Stage D prep — specifically the
+``likely_test_harness`` + ``harness_evidence`` fields it writes.
+
+The helper itself lives in ``libexec/raptor-validation-helper`` and
+is invoked as a subprocess by the operator. These tests exercise
+the prep logic by importing the module and calling ``prepare_D``
+directly with a synthetic workdir.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HELPER_PATH = REPO_ROOT / "libexec" / "raptor-validation-helper"
+
+
+@pytest.fixture
+def helper_module():
+    """Import the libexec helper as a module so we can call its
+    ``prepare_D`` function directly. The helper is a CLI script,
+    not normally importable; we load it via spec_from_file_location.
+    """
+    os.environ.setdefault("_RAPTOR_TRUSTED", "1")
+    # Helper has no .py suffix; force the SourceFileLoader so
+    # importlib doesn't reject it for filename-extension reasons.
+    from importlib.machinery import SourceFileLoader
+    loader = SourceFileLoader("raptor_validation_helper", str(HELPER_PATH))
+    spec = importlib.util.spec_from_loader("raptor_validation_helper", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def workdir(tmp_path):
+    """Build a minimal workdir with findings.json + checklist.json."""
+    findings = {
+        "stage": "C",
+        "target_path": "/repo",
+        "findings": [
+            # Test-fixture path, no production caller in checklist
+            {
+                "id": "F-FIXTURE",
+                "file": "tests/conftest.py",
+                "function": "setup_user",
+                "line": 10,
+                "vuln_type": "auth_bypass",
+                "status": "not_disproven",
+                "confidence": "medium",
+                "candidate_reasoning": "x",
+                "stage_a_summary": {"status": "not_disproven",
+                                     "confidence": "medium"},
+                "stage_b_summary": {},
+                "stage_c_summary": {
+                    "checks": {"file_exists": True,
+                               "code_verbatim": True,
+                               "flow_real": True,
+                               "reachable": True},
+                },
+                "sanity_check": {"passed": True},
+            },
+            # Production path, sanity passed
+            {
+                "id": "F-PROD",
+                "file": "src/api/upload.py",
+                "function": "save_user_upload",
+                "line": 42,
+                "vuln_type": "path_traversal",
+                "status": "not_disproven",
+                "confidence": "high",
+                "candidate_reasoning": "y",
+                "stage_a_summary": {"status": "not_disproven",
+                                     "confidence": "high"},
+                "stage_b_summary": {},
+                "stage_c_summary": {
+                    "checks": {"file_exists": True,
+                               "code_verbatim": True,
+                               "flow_real": True,
+                               "reachable": True},
+                },
+                "sanity_check": {"passed": True},
+            },
+        ],
+    }
+    (tmp_path / "findings.json").write_text(json.dumps(findings))
+
+    checklist = {
+        "target_path": "/repo",
+        "files": [
+            # Production file with no caller of setup_user — gives
+            # the resolver something to walk over without finding
+            # any reference to the test fixture.
+            {
+                "path": "src/api/upload.py",
+                "items": [{"name": "save_user_upload",
+                           "line_start": 42, "line_end": 50}],
+            },
+        ],
+    }
+    (tmp_path / "checklist.json").write_text(json.dumps(checklist))
+
+    # Stage C output expected by _apply_stage_file
+    (tmp_path / "stage-c.json").write_text(json.dumps({
+        "stage": "C", "updates": {},
+    }))
+
+    return tmp_path
+
+
+class TestPrepDWritesHarnessFields:
+    def test_fixture_finding_gets_harness_signal(
+        self, helper_module, workdir, capsys,
+    ):
+        helper_module.prepare_D(workdir)
+        data = json.loads((workdir / "findings.json").read_text())
+        fixture = next(
+            f for f in data["findings"] if f["id"] == "F-FIXTURE"
+        )
+        # test_code_flag set by legacy path-only check
+        assert fixture["test_code_flag"] is True
+        # New richer signal — fixture path + reachability gate
+        assert fixture["likely_test_harness"] in ("true", "candidate")
+        assert isinstance(fixture["harness_evidence"], list)
+        # First evidence is the path-pattern match
+        assert fixture["harness_evidence"][0]["type"] == "fixture_path_match"
+
+    def test_production_finding_gets_no_harness_match(
+        self, helper_module, workdir, capsys,
+    ):
+        helper_module.prepare_D(workdir)
+        data = json.loads((workdir / "findings.json").read_text())
+        prod = next(
+            f for f in data["findings"] if f["id"] == "F-PROD"
+        )
+        assert prod["test_code_flag"] is False
+        assert prod["likely_test_harness"] == "false"
+        # No evidence when path doesn't match — short-circuit.
+        assert prod["harness_evidence"] == []
+
+    def test_disproven_finding_skipped(
+        self, helper_module, workdir, capsys,
+    ):
+        # Mark F-FIXTURE as disproven; helper must skip and not
+        # emit harness fields.
+        data = json.loads((workdir / "findings.json").read_text())
+        data["findings"][0]["status"] = "disproven"
+        (workdir / "findings.json").write_text(json.dumps(data))
+
+        helper_module.prepare_D(workdir)
+        data2 = json.loads((workdir / "findings.json").read_text())
+        fixture = next(
+            f for f in data2["findings"] if f["id"] == "F-FIXTURE"
+        )
+        # No harness fields written for disproven findings.
+        assert "likely_test_harness" not in fixture
+
+    def test_missing_inventory_yields_candidate(
+        self, helper_module, workdir, capsys,
+    ):
+        # Remove checklist.json — helper should still run and
+        # produce ``candidate`` for path-flagged findings.
+        (workdir / "checklist.json").unlink()
+        helper_module.prepare_D(workdir)
+        data = json.loads((workdir / "findings.json").read_text())
+        fixture = next(
+            f for f in data["findings"] if f["id"] == "F-FIXTURE"
+        )
+        assert fixture["likely_test_harness"] == "candidate"
+        # Evidence shows the path match + data_missing reason
+        assert any(
+            e["type"] == "reachability_check"
+            and e["result"] == "data_missing"
+            for e in fixture["harness_evidence"]
+        )

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -1300,6 +1300,13 @@ class AutonomousSecurityAgentV2:
         false_positives_found = 0
         annotations_emitted = 0
         variant_annotations = 0
+        # D-1 fixture-detection pre-flight metrics. Counts of
+        # findings the pre-flight saw and how it ruled. Surfaced
+        # in the autonomous report so operators can see whether
+        # the pre-flight is firing usefully and how many LLM
+        # tokens it saved.
+        fixture_prep_outcomes = {"true": 0, "false": 0, "candidate": 0}
+        fixture_skipped_llm_calls = 0
         idx = 0  # Initialize idx to prevent UnboundLocalError when unique_findings is empty
 
         is_prep = isinstance(self.llm, ClaudeCodeProvider)
@@ -1343,6 +1350,96 @@ class AutonomousSecurityAgentV2:
                         finding["metadata"] = metadata
 
                 vuln = VulnerabilityContext(finding, self.repo_path)
+
+                # 0. Pre-flight: D-1 fixture-detection. When the
+                # finding sits in test code AND the function isn't
+                # reachable from any production entry point, the
+                # LLM verdict is essentially deterministic — skip
+                # the LLM call to save tokens and emit a clean
+                # annotation directly. Only the high-confidence
+                # ``true`` case skips; ``candidate`` (path matches
+                # but reachability uncertain) still runs the LLM
+                # so it can verify. ``manual_override`` operator
+                # flag bypasses pre-flight entirely.
+                #
+                # See core/inventory/fixture_detection for the
+                # path + reachability gate logic; mirrors the
+                # /validate Stage D [D-1] integration.
+                fixture_skipped_this = False
+                if checklist and not finding.get("manual_override"):
+                    try:
+                        from core.inventory.fixture_detection import (
+                            detect_fixture,
+                        )
+                        verdict = detect_fixture(
+                            file_path=(
+                                finding.get("file_path")
+                                or finding.get("file") or ""
+                            ),
+                            function=(
+                                finding.get("function")
+                                or (finding.get("metadata") or {}).get(
+                                    "function_name", ""
+                                )
+                            ),
+                            inventory=checklist,
+                        )
+                        finding["likely_test_harness"] = (
+                            verdict.likely_test_harness
+                        )
+                        finding["harness_evidence"] = [
+                            e.to_dict() for e in verdict.evidence
+                        ]
+                        fixture_prep_outcomes[
+                            verdict.likely_test_harness
+                        ] = (
+                            fixture_prep_outcomes.get(
+                                verdict.likely_test_harness, 0,
+                            ) + 1
+                        )
+                        if verdict.likely_test_harness == "true":
+                            # Synthesise a deterministic clean
+                            # analysis. _derive_status (in
+                            # annotation_emit) maps
+                            # is_true_positive=False to status=
+                            # clean automatically; the
+                            # ``fixture_demotion`` tag flags the
+                            # reason for the operator's review.
+                            vuln.analysis = {
+                                "is_true_positive": False,
+                                "is_exploitable": False,
+                                "reasoning": (
+                                    "Test-harness circularity: the "
+                                    "finding's enclosing function is "
+                                    "in test-fixture code and not "
+                                    "reachable from any production "
+                                    "entry point. See harness_evidence "
+                                    "for the path-pattern match and "
+                                    "reachability check that confirmed "
+                                    "this. To override, set "
+                                    "``manual_override: true`` on the "
+                                    "finding and re-run."
+                                ),
+                                "fixture_demotion": True,
+                                "harness_evidence": (
+                                    finding["harness_evidence"]
+                                ),
+                            }
+                            fixture_skipped_this = True
+                    except Exception as e:  # noqa: BLE001
+                        logger.debug(
+                            "fixture pre-flight failed on %s: %s",
+                            finding.get("finding_id") or finding.get("id"),
+                            e,
+                        )
+
+                if fixture_skipped_this:
+                    analyzed += 1
+                    fixture_skipped_llm_calls += 1
+                    if emit_annotations:
+                        if self._emit_finding_annotation(vuln, checklist):
+                            annotations_emitted += 1
+                    continue  # skip LLM analyze + exploit + patch
 
                 # 1. Autonomous analysis (LLM-powered, or prep-only)
                 if self.analyze_vulnerability(vuln):
@@ -1433,6 +1530,10 @@ class AutonomousSecurityAgentV2:
             "false_positives_caught": false_positives_found,
             "annotations_emitted": annotations_emitted,
             "variant_annotations": variant_annotations,
+            "fixture_detection_metrics": {
+                "prep_outcomes": fixture_prep_outcomes,
+                "skipped_llm_calls": fixture_skipped_llm_calls,
+            },
             "execution_time": execution_time,
             "llm_stats": llm_stats,
             "results": results,
@@ -1475,6 +1576,13 @@ class AutonomousSecurityAgentV2:
                 logger.info(
                     f"✓ Checker-synthesised variants: {variant_annotations} "
                     f"(suspicious annotations from KNighter follow-up)"
+                )
+            if fixture_skipped_llm_calls > 0:
+                logger.info(
+                    f"✓ Fixture-detection (D-1): "
+                    f"{fixture_skipped_llm_calls} LLM call(s) skipped "
+                    f"(test-harness circularity); prep outcomes "
+                    f"{fixture_prep_outcomes}"
                 )
             logger.info(f"")
             if dataflow_validated > 0:

--- a/packages/llm_analysis/tests/test_annotation_wiring.py
+++ b/packages/llm_analysis/tests/test_annotation_wiring.py
@@ -50,17 +50,34 @@ class TestProcessFindingsCallsTheMethod:
         assert "self._emit_finding_annotation(vuln, checklist)" in text
 
     def test_call_is_inside_analyze_vulnerability_branch(self):
-        """The call must be inside the ``if analyze_vulnerability``
-        block (post-analysis) — otherwise it fires on every iteration
-        regardless of whether analysis happened."""
+        """The post-LLM emit must be inside the
+        ``if analyze_vulnerability`` block (post-analysis) —
+        otherwise it fires on every iteration regardless of whether
+        analysis happened.
+
+        ``process_findings`` may also emit from a deterministic
+        pre-flight skip path (D-1 fixture-detection — finding sits
+        in test code with no production caller, LLM analysis
+        skipped to save tokens). That earlier emit is conditional
+        on ``fixture_skipped_this`` and lives inside its own
+        ``continue`` block, so it doesn't fire on every iteration.
+
+        Pin: there's a post-LLM emit immediately after the
+        ``analyze_vulnerability`` conditional (within ~500 chars).
+        """
         text = AGENT_PY.read_text(encoding="utf-8")
-        # Find the analyze_vulnerability check and the emit call.
         ana_idx = text.index("if self.analyze_vulnerability(vuln):")
-        emit_idx = text.index("self._emit_finding_annotation(vuln, checklist)")
-        # Emit must come after the conditional (within the block).
-        assert emit_idx > ana_idx
-        # And reasonably close — within ~500 chars (same indent block).
-        assert emit_idx - ana_idx < 500
+        # Find an emit call AFTER the analyze_vulnerability block.
+        # rindex to skip the pre-flight emit; index after ana_idx
+        # would be cleaner but rindex hardens against multiple
+        # post-LLM emit sites if any future refactor adds one.
+        post_text = text[ana_idx:]
+        emit_offset = post_text.index(
+            "self._emit_finding_annotation(vuln, checklist)"
+        )
+        # Emit within ~500 chars of the conditional (same indent
+        # block).
+        assert 0 < emit_offset < 500
 
 
 # ---------------------------------------------------------------------------

--- a/packages/llm_analysis/tests/test_d1_fixture_pipeline_e2e.py
+++ b/packages/llm_analysis/tests/test_d1_fixture_pipeline_e2e.py
@@ -1,0 +1,324 @@
+"""End-to-end tests for the D-1 fixture-detection wire-in across
+both pipelines.
+
+These tests drive the full process_findings flow with fixture-
+detection-eligible findings and assert:
+
+  * Pre-flight verdicts ride through to the synthetic
+    ``vuln.analysis``.
+  * The high-confidence ``true`` case skips ``analyze_vulnerability``
+    (no LLM call, no exploit/patch attempts).
+  * ``candidate`` and ``false`` outcomes don't skip — the LLM
+    pass runs normally.
+  * ``manual_override`` bypasses the pre-flight entirely.
+  * Telemetry counts in ``autonomous_analysis_report.json``
+    reflect the per-finding outcomes.
+  * Annotations emitted by the pre-flight skip path land with
+    ``status=clean`` (via the existing ``_derive_status`` mapping
+    on ``is_true_positive: false``).
+
+Cross-pipeline consistency is exercised by reusing the same
+finding shape against /validate's helper prep (separate test
+module already covers /validate-side correctness; this one
+focuses on /agentic).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from core.annotations import read_annotation
+from packages.llm_analysis.agent import (
+    AutonomousSecurityAgentV2,
+    VulnerabilityContext,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """Minimal repo with prod and test source files."""
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "tests").mkdir()
+    (repo / "src" / "api.py").write_text(
+        "def save_upload(req):\n    return open(req.path, 'wb')\n"
+    )
+    (repo / "tests" / "conftest.py").write_text(
+        "def setup_user(req):\n    return {'token': 'fake'}\n"
+    )
+    return repo
+
+
+@pytest.fixture
+def agent(tmp_path, repo):
+    """An agent in prep_only mode — no LLM dispatcher needed."""
+    out = tmp_path / "out"
+    return AutonomousSecurityAgentV2(
+        repo_path=repo, out_dir=out, prep_only=True,
+    )
+
+
+@pytest.fixture
+def checklist(repo):
+    """Realistic inventory: production file calls a function in src/api.py;
+    tests/conftest.py is also indexed but no production code calls
+    setup_user."""
+    return {
+        "target_path": str(repo),
+        "files": [
+            {
+                "path": "src/api.py",
+                "items": [{
+                    "name": "save_upload",
+                    "line_start": 1, "line_end": 2,
+                }],
+            },
+            {
+                "path": "tests/conftest.py",
+                "items": [{
+                    "name": "setup_user",
+                    "line_start": 1, "line_end": 2,
+                }],
+            },
+        ],
+    }
+
+
+def _finding(file_path, function, fid="F-1", **extras):
+    """Construct a SARIF-shaped finding for process_findings."""
+    f = {
+        "finding_id": fid,
+        "rule_id": "py/path-traversal",
+        "file": file_path,
+        "file_path": file_path,
+        "function": function,
+        "startLine": 1,
+        "endLine": 2,
+        "snippet": "open(req.path, 'wb')",
+        "message": "Path traversal in upload",
+        "level": "warning",
+        "cwe_id": "CWE-22",
+        "tool": "semgrep",
+        "has_dataflow": False,
+    }
+    f.update(extras)
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight skip — high-confidence ``true`` case
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightSkipsLLMOnTrueVerdict:
+    def test_fixture_finding_skips_analyze_vulnerability(
+        self, agent, checklist, repo, tmp_path,
+    ):
+        """A finding in tests/conftest.py with no production caller —
+        pre-flight returns ``true``, agent skips analyze_vulnerability,
+        synthesises a deterministic clean analysis, emits annotation."""
+        finding = _finding("tests/conftest.py", "setup_user", fid="F-FIX")
+        # findings.json input
+        findings_in = tmp_path / "findings_in.json"
+        findings_in.write_text(json.dumps([finding]))
+
+        # Mock parse_sarif_findings to return our finding without
+        # touching SARIF; mock analyze_vulnerability to ASSERT it
+        # isn't called.
+        with patch.object(
+            AutonomousSecurityAgentV2,
+            "_load_validated_findings",
+            return_value=[finding],
+        ), patch.object(
+            AutonomousSecurityAgentV2,
+            "analyze_vulnerability",
+        ) as mock_analyze:
+            mock_analyze.side_effect = AssertionError(
+                "analyze_vulnerability should NOT have been called",
+            )
+            report = agent.process_findings(
+                findings_path=str(findings_in),
+                max_findings=10,
+                checklist=checklist,
+                emit_annotations=True,
+            )
+
+        # Telemetry fields populated.
+        assert report["fixture_detection_metrics"]["skipped_llm_calls"] == 1
+        assert report["fixture_detection_metrics"]["prep_outcomes"][
+            "true"
+        ] == 1
+        # Annotation written with status=clean (via _derive_status
+        # on synthetic is_true_positive=False).
+        ann_dir = agent.out_dir / "annotations"
+        ann = read_annotation(ann_dir, "tests/conftest.py", "setup_user")
+        assert ann is not None
+        assert ann.metadata.get("status") == "clean"
+        # Body cites the harness reasoning.
+        assert "Test-harness circularity" in ann.body
+
+
+class TestPreflightDoesNotSkipOnFalseVerdict:
+    def test_production_finding_runs_llm(
+        self, agent, checklist, repo, tmp_path,
+    ):
+        """A finding in src/api.py — pre-flight returns ``false``,
+        analyze_vulnerability is called normally."""
+        finding = _finding("src/api.py", "save_upload", fid="F-PROD")
+        findings_in = tmp_path / "findings_in.json"
+        findings_in.write_text(json.dumps([finding]))
+
+        with patch.object(
+            AutonomousSecurityAgentV2,
+            "_load_validated_findings",
+            return_value=[finding],
+        ), patch.object(
+            AutonomousSecurityAgentV2,
+            "analyze_vulnerability",
+            return_value=False,  # LLM ran but ruled out
+        ) as mock_analyze:
+            report = agent.process_findings(
+                findings_path=str(findings_in),
+                max_findings=10,
+                checklist=checklist,
+                emit_annotations=False,
+            )
+
+        mock_analyze.assert_called_once()
+        assert report["fixture_detection_metrics"]["skipped_llm_calls"] == 0
+        assert report["fixture_detection_metrics"]["prep_outcomes"][
+            "false"
+        ] == 1
+
+
+class TestPreflightDoesNotSkipOnCandidateVerdict:
+    def test_candidate_verdict_runs_llm(
+        self, agent, repo, tmp_path,
+    ):
+        """A fixture-path finding without inventory — pre-flight
+        returns ``candidate``, LLM still runs (verifies the
+        uncertain case)."""
+        finding = _finding("tests/conftest.py", "setup_user", fid="F-CAND")
+        findings_in = tmp_path / "findings_in.json"
+        findings_in.write_text(json.dumps([finding]))
+
+        with patch.object(
+            AutonomousSecurityAgentV2,
+            "_load_validated_findings",
+            return_value=[finding],
+        ), patch.object(
+            AutonomousSecurityAgentV2,
+            "analyze_vulnerability",
+            return_value=False,
+        ) as mock_analyze:
+            # No checklist passed → fixture_detection falls to
+            # ``candidate``.
+            report = agent.process_findings(
+                findings_path=str(findings_in),
+                max_findings=10,
+                checklist=None,
+                emit_annotations=False,
+            )
+
+        # LLM was called (no skip on candidate).
+        # process_findings short-circuits the pre-flight when
+        # checklist=None, so prep_outcomes are all zero — the
+        # finding still flows through to analyze_vulnerability.
+        mock_analyze.assert_called_once()
+        assert report["fixture_detection_metrics"]["skipped_llm_calls"] == 0
+
+
+class TestManualOverrideBypassesPreflight:
+    def test_manual_override_skips_fixture_detection_entirely(
+        self, agent, checklist, repo, tmp_path,
+    ):
+        """manual_override=True on the finding bypasses the pre-
+        flight; the LLM analysis runs normally even when path +
+        reachability would have triggered ``true``."""
+        finding = _finding(
+            "tests/conftest.py", "setup_user",
+            fid="F-OVERRIDE",
+            manual_override=True,
+            manual_override_reason=(
+                "Operator: this fixture is also exposed via debug "
+                "endpoint in prod under DEBUG=1"
+            ),
+        )
+        findings_in = tmp_path / "findings_in.json"
+        findings_in.write_text(json.dumps([finding]))
+
+        with patch.object(
+            AutonomousSecurityAgentV2,
+            "_load_validated_findings",
+            return_value=[finding],
+        ), patch.object(
+            AutonomousSecurityAgentV2,
+            "analyze_vulnerability",
+            return_value=False,
+        ) as mock_analyze:
+            report = agent.process_findings(
+                findings_path=str(findings_in),
+                max_findings=10,
+                checklist=checklist,
+                emit_annotations=False,
+            )
+
+        mock_analyze.assert_called_once()
+        # Pre-flight did not record an outcome (it was bypassed).
+        assert report["fixture_detection_metrics"]["skipped_llm_calls"] == 0
+
+
+class TestMixedBatch:
+    def test_mixed_batch_telemetry(
+        self, agent, checklist, repo, tmp_path,
+    ):
+        """Three findings: fixture (skip), prod (run), fixture-with-
+        override (run). Telemetry should reflect each path."""
+        findings = [
+            _finding("tests/conftest.py", "setup_user", fid="F-FIX"),
+            _finding("src/api.py", "save_upload", fid="F-PROD"),
+            _finding(
+                "tests/conftest.py", "setup_user",
+                fid="F-OVERRIDE", manual_override=True,
+            ),
+        ]
+        findings_in = tmp_path / "findings_in.json"
+        findings_in.write_text(json.dumps(findings))
+
+        with patch.object(
+            AutonomousSecurityAgentV2,
+            "_load_validated_findings",
+            return_value=findings,
+        ), patch.object(
+            AutonomousSecurityAgentV2,
+            "analyze_vulnerability",
+            return_value=False,
+        ) as mock_analyze:
+            report = agent.process_findings(
+                findings_path=str(findings_in),
+                max_findings=10,
+                checklist=checklist,
+                emit_annotations=True,
+            )
+
+        # Two LLM calls (prod + override-bypass).
+        assert mock_analyze.call_count == 2
+        # One LLM-skip (the fixture finding).
+        assert report["fixture_detection_metrics"]["skipped_llm_calls"] == 1
+        # Pre-flight outcomes: F-FIX → true, F-PROD → false,
+        # F-OVERRIDE bypassed (no outcome recorded).
+        outcomes = report["fixture_detection_metrics"]["prep_outcomes"]
+        assert outcomes["true"] == 1
+        assert outcomes["false"] == 1
+        # F-OVERRIDE bypass means no outcome — counts stay at 0
+        # for candidate.
+        assert outcomes.get("candidate", 0) == 0


### PR DESCRIPTION
Implements upstream exploitation-validator#1 proposal 2 (CB-5 narrow case) — test-harness circularity — via shared substrate in core/inventory and per-pipeline integration. Path-pattern match + reachability-from-production gate; high-confidence fixture-only findings auto-demote.

Substrate (core/inventory/fixture_detection):
  * Path-pattern + reachability gate via existing core.inventory.reachability.function_called.
  * Empty/missing inventory → candidate (never auto-demote on absent data — the resolver returns NOT_CALLED for empty inventory which would be a silent FN).
  * Resolver exceptions caught; helper never propagates.
  * Reachability evidence list capped at 5 to bound on-disk size.

/validate Stage D integration:
  * libexec/raptor-validation-helper D writes likely_test_harness
    + harness_evidence per non-disproven finding.
  * stage-d-ruling.md [D-1] section reads the new fields first; biases conservative on `candidate`.
  * Schema gains likely_test_harness, harness_evidence, manual_override, manual_override_reason fields.

/agentic process_findings integration:
  * Pre-flight per finding before analyze_vulnerability.
  * `true` outcome + no manual_override → synthesise clean analysis, skip LLM call, emit annotation; saves tokens.
  * `candidate`/`false`/with-override → LLM runs normally, pre-flight signal still written for the LLM to read.
  * Telemetry: prep_outcomes counters + skipped_llm_calls.

Cross-pipeline: both pipelines call the shared substrate directly, so same input → same verdict. Cross-consistency test pins this against silent divergence.

Bonus fix: TestCLIScript anchored to __file__ instead of CWD (was failing on non-repo-root pytest invocations including some CI workers).

1814 tests pass across core/inventory + packages/llm_analysis
+ packages/exploitability_validation. Wide sweep clean.