### PR TITLE
fix(iris): cpp Tier 2/3 template — alias FlowSources to FS, drop redundant DataFlow import

### DIFF
--- a/packages/llm_analysis/dataflow_query_builder.py
+++ b/packages/llm_analysis/dataflow_query_builder.py
@@ -423,9 +423,25 @@ select sink.getNode(), source, sink, "IRIS dataflow path"
  * @problem.severity error
  */
 import cpp
-import semmle.code.cpp.dataflow.new.DataFlow
 import semmle.code.cpp.dataflow.new.TaintTracking
-import semmle.code.cpp.security.FlowSources
+import semmle.code.cpp.security.FlowSources as FS
+
+// Two cpp imports both expose `module DataFlow`:
+//   * `semmle.code.cpp.dataflow.new.DataFlow` (used by ConfigSig — pulled
+//     in transitively via TaintTracking above)
+//   * `semmle.code.cpp.ir.dataflow.DataFlow` (transitively imported by
+//     `semmle.code.cpp.security.FlowSources`)
+// Without the `as FS` alias the second leaks into top-level scope and the
+// `DataFlow::ConfigSig` reference below fails to compile with
+// "module DataFlow is ambiguous between: DataFlow::DataFlow,
+// DataFlow::DataFlow". Aliasing FlowSources scopes its DataFlow under
+// FS::DataFlow and leaves the new-style DataFlow as the unique top-level
+// `DataFlow`. Matches the canonical pattern in
+// /home/raptor/.local/codeql-queries/cpp/ql/src/Security/CWE/CWE-120/
+// UnboundedWrite.ql. LLM-generated source/sink bodies that need
+// FlowSources types must use the FS:: prefix (e.g. `n instanceof
+// FS::FlowSource`) — see the prompt instructions in
+// _ask_llm_for_predicates.
 
 module IrisConfig implements DataFlow::ConfigSig {{
   predicate isSource(DataFlow::Node n) {{

--- a/packages/llm_analysis/dataflow_validation.py
+++ b/packages/llm_analysis/dataflow_validation.py
@@ -1904,6 +1904,25 @@ def _ask_llm_for_predicates(
         "structure (imports, ConfigSig module, PathGraph, select clause) "
         "is provided mechanically — your output goes inside the braces."
     )
+    if language.lower() == "cpp":
+        # The cpp template aliases `semmle.code.cpp.security.FlowSources`
+        # to `FS` to avoid a `module DataFlow is ambiguous` compile error
+        # (see the comment block in dataflow_query_builder._TAINT_TEMPLATES
+        # ['cpp']). Any predicate body that references a FlowSources type
+        # MUST use the `FS::` prefix or it won't resolve. Examples:
+        # `n instanceof FS::FlowSource`, `n instanceof FS::RemoteFlowSource`.
+        prompt_parts.append(
+            "C/C++ specific: this query template aliases the FlowSources "
+            "import to `FS` — if you need to match attacker-controlled "
+            "input via a FlowSources class, use the `FS::` prefix (e.g. "
+            "`n instanceof FS::FlowSource` or `n instanceof FS::"
+            "RemoteFlowSource`). For most cpp memory-corruption findings "
+            "(CWE-120/125/787/190/476) the source is more naturally "
+            "expressed as `n.asExpr()` matching a specific argv / "
+            "parameter / external-input pattern — use that when "
+            "applicable. Without the `FS::` prefix, references to "
+            "FlowSource types will fail to resolve at compile time."
+        )
     if previous_error:
         prompt_parts.append(
             "Previous attempt failed to compile:\n"

--- a/packages/llm_analysis/tests/test_dataflow_query_builder.py
+++ b/packages/llm_analysis/tests/test_dataflow_query_builder.py
@@ -606,6 +606,74 @@ class TestBuildTemplateQuery:
         assert q is not None
         assert "import cpp" in q
 
+    def test_cpp_template_aliases_flowsources_to_avoid_dataflow_ambiguity(self):
+        """The cpp template MUST alias FlowSources to FS — otherwise its
+        transitive `semmle.code.cpp.ir.dataflow.DataFlow` collides with
+        the explicit `semmle.code.cpp.dataflow.new.DataFlow` (both
+        export module `DataFlow`) and codeql refuses to compile with
+        'module DataFlow is ambiguous between: DataFlow::DataFlow,
+        DataFlow::DataFlow'. Real failure observed on a /agentic run
+        2026-05-10 against /tmp/smt-tier4-test; fix matches canonical
+        pattern in shipped CWE-120 query."""
+        q = build_template_query(
+            language="cpp",
+            source_predicate_body="x",
+            sink_predicate_body="y",
+        )
+        assert q is not None
+        # The alias MUST be present — without it Tier 2/3 compile
+        # fails on every cpp finding.
+        assert "FlowSources as FS" in q, (
+            "cpp template lost its `FlowSources as FS` alias — "
+            "compile will fail with 'module DataFlow is ambiguous'"
+        )
+        # The redundant explicit DataFlow import should be absent —
+        # TaintTracking pulls it in. Keeping both worked fine
+        # historically (same module), but the canonical CWE-120 query
+        # omits it for cleanliness; assert here so a future drive-by
+        # re-add doesn't go unnoticed.
+        assert "import semmle.code.cpp.dataflow.new.DataFlow\n" not in q, (
+            "cpp template re-added the redundant explicit DataFlow "
+            "import; TaintTracking already pulls it in transitively"
+        )
+
+    def test_cpp_prompt_instructs_FS_prefix(self):
+        """Companion to the template change: the LLM prompt for cpp
+        predicates must mention the `FS::` prefix so the LLM doesn't
+        emit an unqualified `n instanceof FlowSource` that won't
+        resolve."""
+        # Inspect the prompt-building helper directly — this is the
+        # source of truth for what the LLM sees. Pass a dummy hypothesis
+        # and check the cpp branch fires.
+        from packages.llm_analysis.dataflow_validation import (
+            _ask_llm_for_predicates,
+        )
+        from packages.hypothesis_validation.hypothesis import Hypothesis
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        h = Hypothesis(
+            claim="dummy",
+            target=Path("/x.c"),
+        )
+        captured = {}
+
+        def fake_generate_structured(prompt, schema, system_prompt, task_type):
+            captured["prompt"] = prompt
+            return None  # short-circuit; we only care about the prompt
+
+        client = MagicMock()
+        client.generate_structured.side_effect = fake_generate_structured
+        _ask_llm_for_predicates(h, client, "cpp")
+        prompt = captured.get("prompt", "")
+        # The cpp-specific instruction MUST appear so the LLM uses the
+        # `FS::` prefix when referencing FlowSources types.
+        assert "FS::" in prompt, (
+            f"cpp prompt missing FS:: prefix instruction; LLM may emit "
+            f"unqualified FlowSource references that won't compile. "
+            f"Prompt: {prompt[:500]}"
+        )
+
     def test_unsupported_language_returns_none(self):
         q = build_template_query(
             language="cobol",


### PR DESCRIPTION
Real failure observed on /agentic --codeql --languages c run 2026-05-10 against /tmp/smt-tier4-test fixture. CWE-476 finding's Tier 2/3 LLM-generated query failed to compile with:

  ERROR: module DataFlow is ambiguous between:
    DataFlow::DataFlow,
    DataFlow::DataFlow

Both `DataFlow::DataFlow` paths resolve to identical-looking modules — the resolver doesn't say which two — but the cause is:

  * `import semmle.code.cpp.dataflow.new.TaintTracking` brings in `module DataFlow` from `semmle.code.cpp.dataflow.new.DataFlow` transitively (this is the new-style IR-based DataFlow used by ConfigSig)
  * `import semmle.code.cpp.security.FlowSources` brings in `module DataFlow` from `semmle.code.cpp.ir.dataflow.DataFlow` transitively (a DIFFERENT module also named DataFlow)

Both leak `DataFlow` into top-level scope; `DataFlow::ConfigSig` becomes ambiguous and the query refuses to compile. Failure blocks every cpp Tier 2/3 attempt — every CWE without a Tier 1 prebuilt for cpp ends up at `inconclusive` with this template- retry-exhausted error.

Two changes match the canonical pattern in the shipped CWE-120 query (/home/raptor/.local/codeql-queries/cpp/ql/src/Security/CWE/ CWE-120/UnboundedWrite.ql):

1. Alias FlowSources: `import ... FlowSources as FS`. The transitive `ir.dataflow.DataFlow` is now scoped under `FS::DataFlow` and stops shadowing the new-style top-level `DataFlow`.

2. Drop the explicit `import semmle.code.cpp.dataflow.new.DataFlow` — TaintTracking pulls it in transitively. Same module, same resolution; just removes a redundant import (matches CWE-120's imports list exactly).

LLM prompt update: when language=cpp, append a paragraph telling the LLM that FlowSources is aliased to `FS` and predicate bodies must use the `FS::` prefix when referencing FlowSources types (e.g. `n instanceof FS::FlowSource`). Without this the LLM would emit `n instanceof FlowSource` (per the schema example) and the query would fail with a different unresolved-name error after we fix the ambiguity.
Verified by direct codeql compile of a representative template- filled query (exit 0; "Done [1/1 comp 2m49s]") plus 1420-test regression sweep across llm_analysis + codeql + hypothesis_ validation. Two new unit tests pin the alias presence and the cpp-specific prompt instruction so a drive-by re-add of either defect is caught before it reaches a real run.

E2E validation on /tmp/smt-tier4-test fixture is the natural next step: with this fix, CWE-476's Tier 2/3 should compile and return a verdict (likely confirmed for the planted null deref), which would let Tier 4 SMT's witness branch fire and exercise the witness-PoC-seed wiring from #453 end-to-end for the first time.