### PR TITLE
perf(core): reachability fast-paths + http per-host circuit breaker

### DIFF
--- a/core/http/tests/test_urllib_backend.py
+++ b/core/http/tests/test_urllib_backend.py
@@ -20,7 +20,21 @@ from core.http import (
     SizeLimitExceeded,
     default_client,
 )
-from core.http.urllib_backend import UrllibClient
+from core.http.urllib_backend import (
+    UrllibClient, _HostCircuitBreaker,
+    reset_default_circuit_breaker,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_default_breaker():
+    """Fresh module-level breaker per test — earlier tests' 429/5xx
+    paths trip the singleton and would leak state into later tests
+    that share an UrllibClient without an explicit ``circuit_breaker``
+    kwarg."""
+    reset_default_circuit_breaker()
+    yield
+    reset_default_circuit_breaker()
 
 
 def _stub_response(body: bytes, *, status: int = 200,
@@ -923,3 +937,208 @@ class TestRaiseOnStatus:
             "GET", "https://example.com/", raise_on_status=False,
         )
         assert captured.get("raise_on_status") is False
+
+
+# ---------------------------------------------------------------------------
+# Host circuit breaker
+# ---------------------------------------------------------------------------
+
+
+class TestHostCircuitBreaker:
+    """Per-host fail-fast cooldown for repeated 429 / 5xx."""
+
+    def test_fresh_breaker_allows_requests(self):
+        cb = _HostCircuitBreaker()
+        is_open, _ = cb.is_open("example.com", 443)
+        assert is_open is False
+
+    def test_below_threshold_stays_closed(self):
+        cb = _HostCircuitBreaker(threshold=3, window=60.0, cooldown=120.0)
+        cb.record_failure("a.example", 443)
+        cb.record_failure("a.example", 443)  # 2 < threshold=3
+        is_open, _ = cb.is_open("a.example", 443)
+        assert is_open is False
+
+    def test_at_threshold_opens(self):
+        cb = _HostCircuitBreaker(threshold=2, window=60.0, cooldown=120.0)
+        transitioned1 = cb.record_failure("a.example", 443)
+        transitioned2 = cb.record_failure("a.example", 443)
+        # First failure shouldn't open; second crosses threshold.
+        assert transitioned1 is False
+        assert transitioned2 is True
+        is_open, remaining = cb.is_open("a.example", 443)
+        assert is_open is True
+        assert 0 < remaining <= 120.0
+
+    def test_per_host_isolation(self):
+        """One host opening must NOT block another host."""
+        cb = _HostCircuitBreaker(threshold=2, cooldown=120.0)
+        cb.record_failure("bad.example", 443)
+        cb.record_failure("bad.example", 443)
+        assert cb.is_open("bad.example", 443)[0] is True
+        assert cb.is_open("ok.example", 443)[0] is False
+
+    def test_per_port_isolation(self):
+        """Different ports on same host are independent circuits."""
+        cb = _HostCircuitBreaker(threshold=2, cooldown=120.0)
+        cb.record_failure("a.example", 443)
+        cb.record_failure("a.example", 443)
+        assert cb.is_open("a.example", 443)[0] is True
+        assert cb.is_open("a.example", 8080)[0] is False
+
+    def test_success_resets(self):
+        """A 200 must clear both the failure history and any open state."""
+        cb = _HostCircuitBreaker(threshold=2, cooldown=120.0)
+        cb.record_failure("a.example", 443)
+        cb.record_failure("a.example", 443)
+        assert cb.is_open("a.example", 443)[0] is True
+        cb.record_success("a.example", 443)
+        assert cb.is_open("a.example", 443)[0] is False
+        # Subsequent failures restart the count from 0 — one failure
+        # alone shouldn't reopen.
+        cb.record_failure("a.example", 443)
+        assert cb.is_open("a.example", 443)[0] is False
+
+    def test_old_failures_drop_out_of_window(self, monkeypatch):
+        """Failures older than ``window`` shouldn't count toward
+        the open threshold."""
+        import core.http.urllib_backend as ub
+        t = [1000.0]
+        monkeypatch.setattr(ub.time, "monotonic", lambda: t[0])
+        cb = _HostCircuitBreaker(threshold=2, window=60.0, cooldown=120.0)
+        cb.record_failure("a.example", 443)
+        t[0] = 1100.0  # +100s, past the 60s window
+        cb.record_failure("a.example", 443)
+        # Only the recent one counts → still 1 < 2 threshold.
+        assert cb.is_open("a.example", 443)[0] is False
+
+    def test_cooldown_elapses_closes_circuit(self, monkeypatch):
+        import core.http.urllib_backend as ub
+        t = [1000.0]
+        monkeypatch.setattr(ub.time, "monotonic", lambda: t[0])
+        cb = _HostCircuitBreaker(threshold=2, cooldown=120.0)
+        cb.record_failure("a.example", 443)
+        cb.record_failure("a.example", 443)
+        assert cb.is_open("a.example", 443)[0] is True
+        t[0] = 1200.0  # +200s, past cooldown
+        assert cb.is_open("a.example", 443)[0] is False
+
+    def test_case_insensitive_host_keying(self):
+        cb = _HostCircuitBreaker(threshold=2, cooldown=120.0)
+        cb.record_failure("Example.com", 443)
+        cb.record_failure("EXAMPLE.COM", 443)
+        # Should treat as same host → opens after 2.
+        assert cb.is_open("example.com", 443)[0] is True
+
+
+class TestUrllibClientCircuitBreakerWiring:
+    """The breaker fires from inside _fetch on real-shaped retries."""
+
+    def test_two_429s_then_third_request_fails_fast(self):
+        """After two 429s on host A, a third request to host A must
+        raise immediately without invoking the pool."""
+        cb = _HostCircuitBreaker(threshold=2, cooldown=120.0)
+        # 6 stub responses (one per backoff slot) — but the third
+        # request should fail fast before the pool is hit again.
+        r429 = _stub_response(b"", status=429, reason="Too Many Requests")
+        pool = MagicMock()
+        pool.request.return_value = r429
+        client = UrllibClient(_http=pool, circuit_breaker=cb)
+
+        # First request: 3 attempts (retries=2 + initial), every
+        # attempt returns 429, cumulative sleep is 1+2 = 3s under
+        # the default schedule. Each 429 records a failure → circuit
+        # opens at 2nd record. total_timeout=60 leaves plenty of
+        # headroom for the 3s of total backoff.
+        with pytest.raises(HttpError):
+            client.get_json(
+                "https://rate-limited.example.com/x",
+                total_timeout=60, retries=2,
+            )
+
+        is_open, _ = cb.is_open("rate-limited.example.com", 443)
+        assert is_open is True
+
+        # Second request to the same host: must NOT hit the pool.
+        pool.request.reset_mock()
+        with pytest.raises(HttpError, match="Circuit open"):
+            client.get_json(
+                "https://rate-limited.example.com/y",
+                total_timeout=10, retries=2,
+            )
+        assert pool.request.call_count == 0, (
+            "Circuit-open path must not invoke the urllib3 pool"
+        )
+
+    def test_other_host_still_succeeds_when_one_host_open(self):
+        """Per-host isolation through the wiring path."""
+        cb = _HostCircuitBreaker(threshold=2, cooldown=120.0)
+        # Pre-open the breaker for a-host:443 directly.
+        cb.record_failure("a-host.example.com", 443)
+        cb.record_failure("a-host.example.com", 443)
+
+        # b-host serves a clean 200.
+        ok = _stub_response(b'{"ok": 1}', status=200)
+        pool = MagicMock()
+        pool.request.return_value = ok
+        client = UrllibClient(_http=pool, circuit_breaker=cb)
+
+        # b-host succeeds.
+        result = client.get_json("https://b-host.example.com/")
+        assert result == {"ok": 1}
+        # a-host fast-fails.
+        with pytest.raises(HttpError, match="Circuit open"):
+            client.get_json("https://a-host.example.com/")
+
+    def test_success_clears_breaker_history(self):
+        """After a successful response, the host's failure count must
+        reset — a single subsequent failure shouldn't reopen."""
+        cb = _HostCircuitBreaker(threshold=2, cooldown=120.0)
+        ok = _stub_response(b'{"ok": 1}', status=200)
+        pool = MagicMock()
+        pool.request.return_value = ok
+        client = UrllibClient(_http=pool, circuit_breaker=cb)
+
+        # Pre-stage one failure (still under threshold), then a 2xx.
+        cb.record_failure("flaky.example.com", 443)
+        client.get_json("https://flaky.example.com/")
+        # The 2xx should have reset failure history; one new failure
+        # alone must not open.
+        cb.record_failure("flaky.example.com", 443)
+        assert cb.is_open("flaky.example.com", 443)[0] is False
+
+    def test_breaker_state_persists_across_default_clients(self):
+        """The fix for the ~90s-per-sample stress-sweep regression:
+        when callers don't pass an explicit ``circuit_breaker``,
+        the module-level singleton is used. State persists across
+        HttpClient instances within one process so sweep-style
+        callers don't have to re-trip the breaker on every fresh
+        client (each ~90s of retry budget burned per sample on a
+        rate-limited host)."""
+        # Two CONSECUTIVE clients, each constructed with no explicit
+        # breaker. They should share the singleton.
+        r429 = _stub_response(b"", status=429)
+        pool1 = MagicMock()
+        pool1.request.return_value = r429
+        client1 = UrllibClient(_http=pool1)
+
+        # Trip the breaker via client1.
+        with pytest.raises(HttpError):
+            client1.get_json(
+                "https://shared-host.example.com/x",
+                total_timeout=60, retries=2,
+            )
+
+        # Now build a fresh client. It MUST see the open circuit.
+        pool2 = MagicMock()
+        pool2.request.return_value = r429
+        client2 = UrllibClient(_http=pool2)
+
+        with pytest.raises(HttpError, match="Circuit open"):
+            client2.get_json(
+                "https://shared-host.example.com/y",
+                total_timeout=10, retries=2,
+            )
+        # Confirm pool2 was never invoked — the second client benefits
+        # from the first client's discovery without redoing the work.
+        assert pool2.request.call_count == 0

--- a/core/http/urllib_backend.py
+++ b/core/http/urllib_backend.py
@@ -32,8 +32,9 @@ import gzip
 import io
 import json
 import logging
+import threading
 import time
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 from urllib import parse as _urlparse
 
 import urllib3
@@ -136,6 +137,119 @@ def _new_pool_manager() -> urllib3.PoolManager:
     )
 
 
+class _HostCircuitBreaker:
+    """Per-(host, port) rate-limit circuit breaker.
+
+    After ``threshold`` 429/5xx events from the same host within
+    ``window`` seconds, the circuit opens — subsequent requests
+    for that host fail-fast for ``cooldown`` seconds instead of
+    retrying through the full backoff schedule (1+2+5+15+60+300 =
+    383s per request).
+
+    Why this exists: anonymous Docker Hub pulls hit a hard rate
+    limit (100 / 6h per IP) that no amount of in-process backoff
+    can recover from. With 8 worker threads each retrying every
+    rate-limited fetch through the full schedule, a multi-image
+    project (istio: 87 unique image refs) can spend 5-7 minutes
+    burning sleep cycles for fetches that are guaranteed to fail.
+    The circuit breaker bounds that to ``cooldown`` seconds total
+    instead of ``unique_failed_fetches × 383s``.
+
+    Successful responses to the host clear both the failure
+    history and the open-state, so a host that recovers (e.g.
+    rate-limit window resets) is immediately tried again.
+
+    Thread-safe: SCA's OCI fetcher uses an 8-worker ThreadPool
+    against a shared HttpClient, so concurrent record_failure /
+    is_open calls from different threads must serialise.
+    """
+
+    def __init__(
+        self, *,
+        threshold: int = 2,
+        window: float = 60.0,
+        cooldown: float = 120.0,
+    ) -> None:
+        self._threshold = threshold
+        self._window = window
+        self._cooldown = cooldown
+        self._failures: Dict[Tuple[str, int], List[float]] = {}
+        self._open_until: Dict[Tuple[str, int], float] = {}
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def _key(host: str, port: int) -> Tuple[str, int]:
+        return (host.lower(), port)
+
+    def is_open(self, host: str, port: int) -> Tuple[bool, float]:
+        """Return ``(is_open, seconds_remaining)``. When ``is_open``
+        is True the caller should raise without making the request."""
+        key = self._key(host, port)
+        with self._lock:
+            now = time.monotonic()
+            until = self._open_until.get(key, 0.0)
+            if now < until:
+                return True, until - now
+            # Cooldown elapsed — drop the open-state record so a
+            # successful retry fully resets to closed.
+            if until:
+                self._open_until.pop(key, None)
+            return False, 0.0
+
+    def record_failure(self, host: str, port: int) -> bool:
+        """Record a 429/5xx for the host. Returns True iff the
+        circuit transitioned to open as a result of this call.
+
+        Returning the transition lets the caller emit a single
+        log line rather than one per blocked attempt downstream.
+        """
+        key = self._key(host, port)
+        with self._lock:
+            now = time.monotonic()
+            failures = self._failures.setdefault(key, [])
+            failures[:] = [t for t in failures if now - t < self._window]
+            failures.append(now)
+            if len(failures) >= self._threshold:
+                was_open = (now < self._open_until.get(key, 0.0))
+                self._open_until[key] = now + self._cooldown
+                return not was_open
+            return False
+
+    def record_success(self, host: str, port: int) -> None:
+        """Reset state for the host on a 2xx response."""
+        key = self._key(host, port)
+        with self._lock:
+            self._failures.pop(key, None)
+            self._open_until.pop(key, None)
+
+
+# Module-level singleton circuit breaker — shared across all
+# UrllibClient (and subclass) instances created without an explicit
+# breaker. Lazy-initialised so module import doesn't pay the cost
+# when nobody constructs a default client. Tests that need state
+# isolation pass a fresh ``_HostCircuitBreaker()`` via the
+# ``circuit_breaker`` kwarg.
+_DEFAULT_CIRCUIT_BREAKER: Optional["_HostCircuitBreaker"] = None
+_DEFAULT_CIRCUIT_BREAKER_LOCK = threading.Lock()
+
+
+def _default_circuit_breaker() -> "_HostCircuitBreaker":
+    global _DEFAULT_CIRCUIT_BREAKER
+    if _DEFAULT_CIRCUIT_BREAKER is None:
+        with _DEFAULT_CIRCUIT_BREAKER_LOCK:
+            if _DEFAULT_CIRCUIT_BREAKER is None:
+                _DEFAULT_CIRCUIT_BREAKER = _HostCircuitBreaker()
+    return _DEFAULT_CIRCUIT_BREAKER
+
+
+def reset_default_circuit_breaker() -> None:
+    """Reset module-level breaker state — for tests + long-running
+    daemons that want a clean slate without restarting the process."""
+    global _DEFAULT_CIRCUIT_BREAKER
+    with _DEFAULT_CIRCUIT_BREAKER_LOCK:
+        _DEFAULT_CIRCUIT_BREAKER = None
+
+
 class UrllibClient:
     """urllib3-backed HttpClient (was stdlib urllib pre-pooling refactor).
 
@@ -157,11 +271,26 @@ class UrllibClient:
         self,
         user_agent: str = DEFAULT_USER_AGENT,
         _http: Optional[urllib3.PoolManager] = None,
+        *,
+        circuit_breaker: Optional[_HostCircuitBreaker] = None,
     ) -> None:
         self._ua = user_agent
         # Subclass / test hook. Lazy default avoids spinning up a pool
         # manager (and its certifi load) when the client is never used.
         self._http = _http or _new_pool_manager()
+        # Per-host rate-limit circuit breaker. Defaults to a module-
+        # level singleton so state persists ACROSS HttpClient
+        # instances within one process — important for sweep-style
+        # callers (calibration corpus collect, stress test) that
+        # construct a fresh client per sample. Without sharing,
+        # docker.io's rate-limit window stays exhausted (it's
+        # IP-scoped on their side) while each per-sample breaker
+        # has to re-trip from scratch, burning ~90s of retry budget
+        # per sample. Tests pass a fresh breaker explicitly via the
+        # kwarg to keep state isolated.
+        if circuit_breaker is None:
+            circuit_breaker = _default_circuit_breaker()
+        self._circuit_breaker = circuit_breaker
 
     def _validate_url(self, url: str) -> _urlparse.SplitResult:
         """Reject URLs that don't match (allowed-scheme)://host/...
@@ -514,6 +643,28 @@ class UrllibClient:
         # truncated; a max() guards against negative values.
         max_attempts = max(1, min(retries + 1, len(_BACKOFF_SECONDS)))
         schedule = _BACKOFF_SECONDS[:max_attempts]
+
+        # Per-host circuit-breaker fast-fail. If we recently saw enough
+        # 429/5xx from this host to open the circuit, skip the request
+        # entirely — saves the full backoff schedule (~383s) on a host
+        # that's already known-bad-this-window. Most common case: Docker
+        # Hub anonymous-pull rate limit during a multi-image scan.
+        parsed_for_cb = _urlparse.urlsplit(url)
+        cb_host = (parsed_for_cb.hostname or "").lower()
+        cb_port = parsed_for_cb.port or (
+            443 if parsed_for_cb.scheme == "https" else 80
+        )
+        is_open, seconds_left = self._circuit_breaker.is_open(
+            cb_host, cb_port,
+        )
+        if is_open:
+            raise HttpError(
+                f"Circuit open for {cb_host}:{cb_port} "
+                f"(cooldown {seconds_left:.0f}s remaining); "
+                f"recent 429/5xx history. Skipping request to avoid "
+                f"retry-storm: {_safe_url_for_log(url)}",
+            )
+
         last_exc: Optional[Exception] = None
         for attempt, delay in enumerate(schedule):
             if time.monotonic() >= deadline:
@@ -530,12 +681,18 @@ class UrllibClient:
             # would burn the trailing 300s slot for no reason.
             is_last_attempt = attempt + 1 == len(schedule)
             try:
-                return self._fetch_once(
+                response = self._fetch_once(
                     url, method=method, timeout=timeout, max_bytes=max_bytes,
                     body=body, headers=headers,
                     follow_redirects=follow_redirects,
                     raise_on_status=raise_on_status,
                 )
+                # Successful response (or a 4xx-with-raise_on_status=False
+                # that we want to surface). Reset the host's circuit
+                # breaker — a successful fetch means the rate-limit
+                # window reset, the registry came back, etc.
+                self._circuit_breaker.record_success(cb_host, cb_port)
+                return response
             except HttpError as e:
                 # Retry only on transient status codes (429, 5xx).
                 # Everything else — non-retryable 4xx, SizeLimitExceeded
@@ -544,6 +701,18 @@ class UrllibClient:
                     e.status == 429
                     or (e.status is not None and 500 <= e.status < 600)
                 )
+                if is_transient:
+                    transitioned = self._circuit_breaker.record_failure(
+                        cb_host, cb_port,
+                    )
+                    if transitioned:
+                        logger.warning(
+                            "core.http: opening circuit breaker for "
+                            "%s:%d (recent 429/5xx threshold reached); "
+                            "subsequent requests will fail-fast for the "
+                            "cooldown window",
+                            cb_host, cb_port,
+                        )
                 if not is_transient:
                     raise
                 last_exc = e

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -172,6 +172,8 @@ def function_called(
     evidence: List[Tuple[str, int]] = []
     uncertain_reasons: List[Tuple[str, str]] = []
 
+    target_dot_func = f"{target_module}.{target_func}"
+    target_module_dot = target_module + "."
     for file_record in inventory.get("files", []):
         path = file_record.get("path") or ""
         if exclude_test_files and _is_test_file(path):
@@ -185,33 +187,34 @@ def function_called(
 
         getattr_targets = set(cg.get("getattr_targets") or [])
 
+        # Fast-path skip: when no import in this file binds to
+        # target_module (or its bare-name form), no call chain can
+        # resolve to target. The indirection branch below still runs
+        # because it depends only on target_func, not target_module.
+        # For Go's istio-scale inventory (~770 files × ~3000 deps),
+        # this drops _resolves_to invocations from 74M to ~hundreds —
+        # the main istio-1.4 scan-perf fix (cProfile flagged
+        # _resolves_to + its inner generator at >190s of 410s total).
+        target_in_imports = False
+        for bound in imports.values():
+            if (bound == target_module
+                    or bound == target_dot_func
+                    or bound.startswith(target_module_dot)):
+                target_in_imports = True
+                break
+
         file_has_evidence = False
-        for call in calls:
-            chain = call.get("chain") or []
-            if not chain:
-                continue
-            if _resolves_to(chain, imports, target_module, target_func):
-                file_has_evidence = True
-                evidence.append((path, int(call.get("line", 0) or 0)))
+        if target_in_imports:
+            for call in calls:
+                chain = call.get("chain") or []
+                if not chain:
+                    continue
+                if _resolves_to(chain, imports, target_module, target_func):
+                    file_has_evidence = True
+                    evidence.append((path, int(call.get("line", 0) or 0)))
 
         if file_has_evidence:
             continue
-
-        # Indirection is only a confounder when there's *some*
-        # signal that this file might be calling the target. A file
-        # that uses getattr but doesn't mention the target name in
-        # any form isn't suspect.
-        file_mentions_tail = (
-            target_func in getattr_targets
-            or any(
-                (c.get("chain") or [])[-1:] == [target_func]
-                for c in calls
-            )
-            or any(
-                qualified.split(".")[-1] == target_func
-                for qualified in imports.values()
-            )
-        )
 
         # getattr / importlib / __import__ flags taint a file IFF
         # the file mentions the target tail name (chain tail, import
@@ -221,9 +224,27 @@ def function_called(
         non_wildcard_flags = (flags & _MASKING_FLAGS) - {
             INDIRECTION_WILDCARD_IMPORT,
         }
-        if non_wildcard_flags and file_mentions_tail:
-            for flag in sorted(non_wildcard_flags):
-                uncertain_reasons.append((path, flag))
+
+        # Lazy-compute file_mentions_tail — required only by the
+        # non-wildcard indirection branch. Files without any non-
+        # wildcard masking flag (the common case at istio scale,
+        # ~770 files × ~3000 deps) skip the genexpr over ``calls``,
+        # which was the hot path after the imports-fast-path fix.
+        if non_wildcard_flags:
+            file_mentions_tail = (
+                target_func in getattr_targets
+                or any(
+                    (c.get("chain") or [])[-1:] == [target_func]
+                    for c in calls
+                )
+                or any(
+                    qualified.split(".")[-1] == target_func
+                    for qualified in imports.values()
+                )
+            )
+            if file_mentions_tail:
+                for flag in sorted(non_wildcard_flags):
+                    uncertain_reasons.append((path, flag))
 
         if INDIRECTION_WILDCARD_IMPORT in flags and (
             _wildcard_could_provide(imports, target_module, target_func)


### PR DESCRIPTION
Two independent perf fixes surfaced during a corpus-wide SCA stress investigation. Both are pure dead-code-elimination / fail-fast — no behaviour change for happy-path callers.        