### PR TITLE
feat(iris): decode _anon_N witness placeholders to original expressions

### DIFF
--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -147,6 +147,15 @@ class PathSMTResult:
     same set in :class:`Rejection` form, naming *why* each was dropped
     (parser failure kind, solver timeout, ...) so consumers can retry,
     rephrase, or surface diagnostics.
+
+    ``anon_var_map`` records the mapping from each ``_anon_N``
+    placeholder allocated by ``_substitute_calls`` to the original
+    function-call subexpression it replaced (e.g.
+    ``{"_anon_0": "strlen(argv[1])"}``).  Downstream consumers
+    (``/exploit``'s witness PoC seed, report renderers) use this to
+    render meaningful labels — without it the witness model shows
+    only the opaque ``_anon_N`` names and the LLM can't connect the
+    concrete value back to anything actionable.
     """
     feasible: Optional[bool]
     satisfied: List[str]
@@ -156,6 +165,7 @@ class PathSMTResult:
     smt_available: bool
     reasoning: str
     unknown_reasons: List[Rejection] = field(default_factory=list)
+    anon_var_map: Dict[str, str] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -436,6 +446,7 @@ def make_anon_call_var(vars_: Dict[str, Any], *, profile: BVProfile) -> Any:
 
 def _substitute_calls(
     text: str, vars_: Dict[str, Any], *, profile: BVProfile,
+    anon_map: Optional[Dict[str, str]] = None,
 ) -> str:
     """Replace balanced ``<ident>(...)`` subterms with fresh free variables.
 
@@ -453,6 +464,15 @@ def _substitute_calls(
 
     Unbalanced parens (``strlen(x``) are left in place; the caller's
     parens-check still rejects them.
+
+    When ``anon_map`` is supplied, each new ``_anon_N`` allocated
+    here is recorded with the original substring it replaced
+    (``anon_map["_anon_0"] = "strlen(argv[1])"``).  Threaded through
+    ``_parse_condition`` and ``_classify_text_condition`` from
+    ``check_path_feasibility`` so the final ``PathSMTResult`` can
+    surface meaningful labels for the witness model.  None / omitted
+    preserves backwards compatibility — callers that don't care
+    (verb path, tests pre-dating this) still work unchanged.
     """
     counter = _next_anon_index(vars_)
     out: List[str] = []
@@ -473,6 +493,8 @@ def _substitute_calls(
                 placeholder = f'_anon_{counter}'
                 counter += 1
                 vars_[placeholder] = _mk_var(placeholder, profile.width)
+                if anon_map is not None:
+                    anon_map[placeholder] = text[i:j]
                 out.append(placeholder)
                 i = j
                 continue
@@ -485,6 +507,7 @@ def _substitute_calls(
 
 def _parse_condition(
     text: str, vars_: Dict[str, Any], *, profile: BVProfile,
+    anon_map: Optional[Dict[str, str]] = None,
 ) -> Union[Any, Rejection]:
     """Parse a single condition string into a Z3 boolean expression.
 
@@ -508,7 +531,9 @@ def _parse_condition(
     ``text`` (the original) is preserved for rejection messages so
     callers can match failures back to their input.
     """
-    t = _substitute_calls(_canonicalise(text), vars_, profile=profile)
+    t = _substitute_calls(
+        _canonicalise(text), vars_, profile=profile, anon_map=anon_map,
+    )
 
     # Early paren-balance scan.  ``_parse_expr`` would catch most imbalances
     # itself, but only conditions whose top-level matches the relational or
@@ -604,6 +629,7 @@ def _classify_text_condition(
     solver: Any,
     *,
     profile: BVProfile,
+    anon_map: Optional[Dict[str, str]] = None,
 ) -> Tuple[Optional[str], Optional[Tuple[str, Any]], Optional[Rejection]]:
     """Parse one text condition and classify it.
 
@@ -616,7 +642,7 @@ def _classify_text_condition(
     :func:`check_verb_feasibility` share the same parse-and-classify
     semantics.
     """
-    expr = _parse_condition(cond.text, vars_, profile=profile)
+    expr = _parse_condition(cond.text, vars_, profile=profile, anon_map=anon_map)
     if isinstance(expr, Rejection):
         _get_logger().debug(
             f"smt_path_validator: rejected {cond.text!r} ({expr.kind.value}: {expr.detail})"
@@ -647,6 +673,7 @@ def _solve_pending(
     unknown_reasons: List[Rejection],
     *,
     profile: BVProfile,
+    anon_map: Optional[Dict[str, str]] = None,
 ) -> PathSMTResult:
     """Run the solver over pending predicates and produce a verdict.
 
@@ -657,6 +684,10 @@ def _solve_pending(
     result.
     """
     mode = profile.describe()
+
+    # Default to empty dict so the field is always present on the
+    # PathSMTResult — downstream consumers never need to None-check.
+    _anon_map = anon_map or {}
 
     if not pending:
         if unknown:
@@ -669,6 +700,7 @@ def _solve_pending(
                     f"indeterminate ({mode}): {len(satisfied)} trivially satisfied, "
                     f"{len(unknown)} unparseable — LLM analysis required"
                 ),
+                anon_var_map=_anon_map,
             )
         return PathSMTResult(
             feasible=True,
@@ -676,6 +708,7 @@ def _solve_pending(
             unknown_reasons=[],
             model={}, smt_available=True,
             reasoning=f"all {len(satisfied)} condition(s) trivially satisfied ({mode})",
+            anon_var_map=_anon_map,
         )
 
     label_map = _track(solver, pending)
@@ -693,6 +726,7 @@ def _solve_pending(
                 + (f"; {len(satisfied)} trivially satisfied" if satisfied else "")
                 + (f"; {len(unknown)} unparsed" if unknown else "")
             ),
+            anon_var_map=_anon_map,
         )
 
     if result == z3.unsat:
@@ -707,6 +741,7 @@ def _solve_pending(
             unknown_reasons=unknown_reasons,
             model={}, smt_available=True,
             reasoning=reasoning,
+            anon_var_map=_anon_map,
         )
 
     # z3.unknown — timeout or outside decidable fragment.
@@ -732,6 +767,7 @@ def _solve_pending(
         unknown_reasons=unknown_reasons + pending_reasons,
         model={}, smt_available=True,
         reasoning=f"Z3 returned unknown ({mode}) — {detail}",
+        anon_var_map=_anon_map,
     )
 
 
@@ -875,6 +911,13 @@ def check_path_feasibility(
 
     vars_: Dict[str, Any] = {}
     solver = _new_solver()
+    # Per-check anon-var mapping. Populated by `_substitute_calls`
+    # as it allocates `_anon_N` placeholders for function-call
+    # subterms; threaded into the PathSMTResult so downstream
+    # consumers (witness PoC seed renderer) can show meaningful
+    # labels like `_anon_0 (= strlen(argv[1])) = 32` instead of
+    # bare `_anon_0 = 32`.
+    anon_map: Dict[str, str] = {}
 
     satisfied: List[str] = []
     unknown: List[str] = []
@@ -883,7 +926,7 @@ def check_path_feasibility(
 
     for cond in conditions:
         sat_display, pending_pair, rejection = _classify_text_condition(
-            cond, vars_, solver, profile=profile,
+            cond, vars_, solver, profile=profile, anon_map=anon_map,
         )
         if sat_display is not None:
             satisfied.append(sat_display)
@@ -895,5 +938,6 @@ def check_path_feasibility(
             pending.append(pending_pair)
 
     return _solve_pending(
-        pending, solver, satisfied, unknown, unknown_reasons, profile=profile,
+        pending, solver, satisfied, unknown, unknown_reasons,
+        profile=profile, anon_map=anon_map,
     )

--- a/packages/exploit_feasibility/smt_path.py
+++ b/packages/exploit_feasibility/smt_path.py
@@ -190,4 +190,12 @@ def validate_path(
             for r in smt_result.unknown_reasons
         ],
         "smt_available": smt_result.smt_available,
+        # Maps each `_anon_N` placeholder in `model` to the original
+        # function-call subexpression it stands for (e.g.
+        # `{"_anon_0": "strlen(argv[1])"}`). Empty when no
+        # function-call substitution happened (path conditions used
+        # only named locals). Downstream /exploit witness PoC seed
+        # renderer uses this to surface meaningful labels instead
+        # of opaque `_anon_N = V` lines.
+        "anon_var_map": dict(smt_result.anon_var_map),
     }

--- a/packages/llm_analysis/dataflow_validation.py
+++ b/packages/llm_analysis/dataflow_validation.py
@@ -1340,6 +1340,14 @@ def _tier4_smt_refine(
                 "model": dict(model),
                 "path_conditions": list(conditions),
                 "path_profile": profile_name,
+                # Map each `_anon_N` in the model to the original
+                # function-call subexpression Z3's parser substituted
+                # (e.g. `strlen(argv[1])`). Lets the /exploit prompt
+                # renderer show meaningful labels — without this the
+                # LLM sees `_anon_0 = 32` and can't connect that to
+                # anything actionable. Empty dict when no
+                # substitution happened (named-locals conditions).
+                "anon_var_map": dict(smt.get("anon_var_map") or {}),
             })
         refined = ValidationResult(
             verdict=result.verdict,

--- a/packages/llm_analysis/prompts/exploit.py
+++ b/packages/llm_analysis/prompts/exploit.py
@@ -48,6 +48,8 @@ If the user message includes EXPLOITATION CONSTRAINTS blocks listing chain break
 
 If the user message includes an SMT WITNESS block, the values listed there are guaranteed by the Z3 solver to make the program take the dangerous code path. Use them as your PoC's concrete inputs (argv values, struct fields, etc.) rather than reasoning out trigger values from scratch. The solver has already done that work.
 
+When the witness model uses an opaque placeholder name like `_anon_0` or `_anon_N`, the Z3 parser substituted it for a function-call subexpression that couldn't be encoded directly (e.g. `strlen(...)`, `sizeof(...)`, `getenv(...)`). The renderer usually decodes this for you in the form `_anon_0 (= strlen(argv[1])) = 32` — when the decoded form is shown, treat the value as the result of that expression (so `strlen(argv[1]) = 32` means "supply an argv[1] whose strlen is 32"). When only the bare `_anon_N = V` is shown (renderer couldn't disambiguate), look at the SMT WITNESS path conditions list in the same block to find the unique function-call expression — usually only one appears in the conditions, and that's what the placeholder stands for.
+
 Write complete, executable code as per the prime directives above. Make it realistic and practical, not just theoretical.
 The exploit should actually work against the vulnerable code, or system, shown above."""
 
@@ -77,12 +79,26 @@ def _format_smt_witness(witness: Dict[str, Any]) -> str:
     into the exploit prompt as a starter PoC saves the LLM from
     guessing concrete trigger values from scratch (the hardest part
     of integer-overflow / OOB / null-deref exploitation).
+
+    The `anon_var_map` field (when present) maps each opaque
+    `_anon_N` placeholder back to the original function-call
+    subexpression Z3's parser substituted (e.g.
+    `{"_anon_0": "strlen(argv[1])"}`). When that mapping is
+    available, render variables as
+    `_anon_0 (= strlen(argv[1])) = 32 (0x20)` so the LLM can
+    actually use the value — without the mapping the LLM only
+    sees `_anon_0 = 32` and has no way to connect that to a
+    real attacker-controllable input. (Pre-fix observation:
+    gemini-2.5-pro saw the witness, ignored it, and re-derived
+    trigger values from the path conditions because `_anon_0`
+    was meaningless context.)
     """
     model = witness.get("model") or {}
     if not model:
         return ""
     conditions = witness.get("path_conditions") or []
     profile = witness.get("path_profile") or "uint64"
+    anon_map = witness.get("anon_var_map") or {}
     parts: List[str] = [
         "Z3 verified the path conditions ARE satisfiable. The following "
         "concrete values make the program take the dangerous path — they "
@@ -96,12 +112,18 @@ def _format_smt_witness(witness: Dict[str, Any]) -> str:
         "Witness model (variable = value):",
     ]
     for var, val in sorted(model.items()):
+        # Decode `_anon_N` placeholders to the original function-call
+        # subexpression when the parser recorded the mapping. Show
+        # both names so the LLM can cross-reference with the path
+        # conditions block below if it needs to.
+        decoded = anon_map.get(var)
+        label = f"{var} (= {decoded})" if decoded else var
         # Render in both decimal and hex — exploit authors typically
         # need hex for memory layout reasoning, decimal for argv.
         if isinstance(val, int):
-            parts.append(f"  {var} = {val} (0x{val:x})")
+            parts.append(f"  {label} = {val} (0x{val:x})")
         else:
-            parts.append(f"  {var} = {val}")
+            parts.append(f"  {label} = {val}")
     if conditions:
         parts.append("")
         parts.append("Path conditions Z3 satisfied:")

--- a/packages/llm_analysis/tests/test_smt_witness_poc_seed.py
+++ b/packages/llm_analysis/tests/test_smt_witness_poc_seed.py
@@ -91,6 +91,64 @@ class TestFormatSmtWitness:
         out = _format_smt_witness({"model": {"name": "evil"}})
         assert "name = evil" in out
 
+    def test_anon_var_decoded_when_mapping_present(self):
+        """When anon_var_map records the substitution, the rendered
+        line shows BOTH the placeholder and the original expression
+        so the LLM can connect the value to a real input."""
+        out = _format_smt_witness({
+            "model": {"_anon_0": 32},
+            "path_conditions": ["strlen(argv[1]) >= 16"],
+            "path_profile": "uint64",
+            "anon_var_map": {"_anon_0": "strlen(argv[1])"},
+        })
+        # Decoded form must appear — without it, gemini sees `_anon_0
+        # = 32` and re-derives values from path_conditions instead of
+        # using the witness (observed pre-fix on /tmp/smt-witness-test
+        # 2026-05-10 — 0 occurrences of `32` in the generated PoC).
+        assert "_anon_0 (= strlen(argv[1])) = 32" in out
+
+    def test_anon_var_falls_back_to_bare_name_without_mapping(self):
+        """No mapping (anon_var_map missing or empty) — fall back to
+        the bare placeholder. Backwards-compatible with witnesses
+        produced before the parser annotation landed; also the case
+        for verb-path witnesses (smt_verbs.py allocates _anon_N too
+        but doesn't track an expression for it)."""
+        out = _format_smt_witness({
+            "model": {"_anon_0": 32},
+            "path_conditions": ["strlen(argv[1]) >= 16"],
+        })
+        assert "_anon_0 = 32" in out
+        assert "(= strlen" not in out  # no decoration
+
+    def test_named_local_unaffected_by_decoder(self):
+        """Variables with non-`_anon_` names are unchanged — the
+        decoder only kicks in for opaque placeholders."""
+        out = _format_smt_witness({
+            "model": {"count": 268435457},
+            "path_conditions": ["count > 0x10000000"],
+            "anon_var_map": {},  # explicitly empty
+        })
+        assert "count = 268435457" in out
+        assert "(= " not in out  # no spurious decoration
+
+    def test_partial_anon_mapping(self):
+        """Some _anon_N decoded, others not (e.g. parser captured one
+        but the second function-call hit a code path that didn't
+        record). Each is decoded independently."""
+        out = _format_smt_witness({
+            "model": {"_anon_0": 32, "_anon_1": 7},
+            "path_conditions": [
+                "strlen(argv[1]) >= 16",
+                "atoi(argv[2]) > 5",
+            ],
+            "anon_var_map": {"_anon_0": "strlen(argv[1])"},
+        })
+        assert "_anon_0 (= strlen(argv[1])) = 32" in out
+        assert "_anon_1 = 7" in out
+        # _anon_1 not decorated since it's not in the map
+        lines = [l for l in out.split("\n") if "_anon_1" in l]
+        assert all("(= " not in l for l in lines)
+
 
 # -- build_exploit_prompt_bundle integration -------------------------------
 
@@ -257,3 +315,76 @@ class TestTier4AttachesSmtWitness:
 
         assert outcome == "no_check"
         assert "smt_witness" not in analysis
+
+    def test_witness_includes_anon_var_map(self):
+        """The mapping recorded by the SMT parser flows through the
+        validate_path wrapper, _tier4_smt_refine, and lands on the
+        analysis dict's smt_witness field. End-to-end propagation
+        check — without it the renderer's anon-var decoding has
+        nothing to consume."""
+        from packages.llm_analysis.dataflow_validation import _tier4_smt_refine
+        from packages.hypothesis_validation.result import ValidationResult
+
+        analysis = {
+            "path_conditions": ["strlen(argv[1]) >= 16"],
+            "path_profile": "uint64",
+        }
+        finding = {"finding_id": "f1"}
+        confirmed = ValidationResult(verdict="confirmed", evidence=[], iterations=1)
+
+        with patch(
+            "packages.exploit_feasibility.smt_path.validate_path"
+        ) as mock_validate:
+            mock_validate.return_value = {
+                "feasible": True,
+                "smt_available": True,
+                "model": {"_anon_0": 32},
+                "reasoning": "satisfiable",
+                "satisfied": [],
+                "unsatisfied": [],
+                "unknown": [],
+                "unknown_reasons": [],
+                "anon_var_map": {"_anon_0": "strlen(argv[1])"},
+            }
+            _, outcome = _tier4_smt_refine(confirmed, finding, analysis)
+
+        assert outcome == "smt_witness"
+        sw = analysis["smt_witness"]
+        assert sw["anon_var_map"] == {"_anon_0": "strlen(argv[1])"}
+
+
+class TestSmtPathValidatorAnonMap:
+    """The bottom of the propagation chain: the parser must populate
+    PathSMTResult.anon_var_map for function-call substitutions. Tests
+    here pin the parser-side behaviour so the mapping is correct
+    when it bubbles up to /exploit."""
+
+    def _check(self, condition_text):
+        from packages.codeql.smt_path_validator import (
+            check_path_feasibility, PathCondition,
+        )
+        from core.smt_solver.config import BV_C_UINT64
+        return check_path_feasibility(
+            [PathCondition(text=condition_text, step_index=0)],
+            profile=BV_C_UINT64,
+        )
+
+    def test_function_call_substitution_recorded(self):
+        r = self._check("strlen(argv[1]) >= 16")
+        assert r.feasible is True
+        assert r.anon_var_map == {"_anon_0": "strlen(argv[1])"}
+
+    def test_named_local_no_substitution(self):
+        r = self._check("count > 268435456")
+        assert r.feasible is True
+        assert r.anon_var_map == {}
+
+    def test_two_distinct_calls_get_separate_anons(self):
+        """Two textually-identical calls should each get their own
+        placeholder (calls aren't assumed pure) — and both should
+        be recorded separately."""
+        r = self._check("strlen(input) > strlen(other)")
+        # _anon_0 → strlen(input), _anon_1 → strlen(other)
+        assert len(r.anon_var_map) == 2
+        assert r.anon_var_map["_anon_0"] == "strlen(input)"
+        assert r.anon_var_map["_anon_1"] == "strlen(other)"


### PR DESCRIPTION
Pre-fix, when the LLM emitted path conditions over function-call expressions (e.g. `strlen(argv[1]) >= 16`), Z3's parser substituted a fresh `_anon_0` bitvector — the witness model showed `_anon_0 = 32` and the LLM had no way to connect the value back to anything actionable. Verified on /tmp/smt-witness- test: witness branch fired, prompt block rendered, LLM saw `_anon_0 = 32`, ignored it.

Parser annotation: `_substitute_calls` in smt_path_validator.py now records each `_anon_N` → original-call-text mapping. Threaded through `_parse_condition` → `_classify_text_condition` → `_solve_pending`, surfaced on `PathSMTResult.anon_var_map`, propagated through `validate_path` and `_tier4_smt_refine` onto `analysis["smt_witness"]["anon_var_map"]`. The renderer in `prompts/exploit.py:_format_smt_witness` then shows `_anon_0 (= strlen(argv[1])) = 32 (0x20)` instead of bare `_anon_0 = 32 (0x20)`.

LLM hint as safety net: EXPLOIT_TASK_INSTRUCTIONS gets a paragraph explaining the convention — when the decoded form is shown, treat the value as the result of the named expression; when only the bare placeholder appears (parser couldn't disambiguate, e.g. nested calls), look at the path_conditions list to find the unique function-call expression.

Backwards compatible — all new params are
`Optional[Dict[str, str]] = None` and `anon_var_map` defaults to empty dict on PathSMTResult, so verb-path callers and pre-existing tests work unchanged.

Verified by 1979-test sweep plus 9 new pin-tests covering parser annotation + propagation + renderer decoding. E2E on /tmp/smt-witness-test confirms anon_var_map populated AND decoded label visible in the exploit prompt.

Caveat for this fixture: LLM still computed padding from the buffer-size analysis (24 + 8 + 1 = 33 bytes) rather than using witness value 32 directly. Correct behaviour for control-hijack BOFs — they need stack-layout-aware padding to reach the return address, which the witness can't capture. The witness will be directly actionable on CWE-476 (witness `p == NULL` IS the trigger) and CWE-190 (witness `count = N` IS the exact argv input); production validation needs a real CVE corpus where those CWEs have working Tier 1 prebuilts.