### PR TITLE
refactor(iris): extract dataflow_validation summary renderer; wire /analyze parity

### DIFF
--- a/core/reporting/dataflow_summary.py
+++ b/core/reporting/dataflow_summary.py
@@ -1,0 +1,152 @@
+"""Console renderer for the IRIS dataflow_validation summary block.
+
+Shared between `/agentic` (raptor_agentic.py) and `/analyze`
+(packages/llm_analysis/agent.py) so both surfaces show the same
+Tier 1/2/3/4 + path_conditions telemetry. Pre-extraction this
+lived inline in raptor_agentic.py only — operators running
+/analyze standalone after /scan didn't see whether IRIS validated
+findings, whether the LLM populated path_conditions, or whether
+Tier 4 SMT fired.
+
+The helper returns a list of pre-formatted lines (with leading
+indent baked in) rather than printing directly. Callers print
+them — easier to test, easier to splice into different output
+contexts (markdown report, log streamer, etc.).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def render_dataflow_validation_lines(
+    dv: Optional[Dict[str, Any]],
+    *,
+    indent: str = "   ",
+) -> List[str]:
+    """Render the IRIS dataflow validation summary as a list of lines.
+
+    Args:
+        dv: The dataflow_validation dict from the orchestration
+            result (typically `orchestration_result["dataflow_validation"]`
+            or `report["dataflow_validation"]`). May be None / empty;
+            both cases produce no output.
+        indent: Leading whitespace for each line. Default matches
+            raptor_agentic.py's existing report cadence ("   ").
+
+    Returns:
+        List of formatted strings ready to print. Empty list when
+        validation didn't run AND no skipped_reason was recorded
+        (caller should print nothing).
+
+    Output shape (when populated):
+        Dataflow validated: N (+M cache hits)
+          by tier: A Tier 1 (free), B Tier 2 (LLM), C Tier 3 (LLM retry)
+          Tier 4 SMT: X refuted, Y witness, Z disagreement
+          path_conditions populated: N (CWE-190=2, CWE-476=1)
+          downgrades: K flagged · applied: H hard, S soft (consensus override)
+
+    Or when explicitly skipped:
+        Dataflow validation skipped: <reason>
+
+    Or when validation never ran (no CodeQL DB, no findings, etc.):
+        (empty list)
+    """
+    if not dv:
+        return []
+
+    n_validated = dv.get("n_validated", 0)
+    n_cache_hits = dv.get("n_cache_hits", 0)
+    skipped_reason = dv.get("skipped_reason", "")
+
+    if not n_validated and not n_cache_hits:
+        # Validation didn't actually run on any finding. Surface the
+        # reason if one was recorded (operator can tell IRIS noticed
+        # but couldn't help — vs the silent "no findings to validate"
+        # case which is genuinely no signal).
+        if skipped_reason:
+            return [f"{indent}Dataflow validation skipped: {skipped_reason}"]
+        return []
+
+    out: List[str] = []
+
+    # Header line — matches the existing summary cadence
+    # ("Exploits generated: N", "Patches generated: N", …).
+    cache_suffix = (
+        f" (+{n_cache_hits} cache hit{'s' if n_cache_hits != 1 else ''})"
+        if n_cache_hits else ""
+    )
+    out.append(f"{indent}Dataflow validated: {n_validated}{cache_suffix}")
+
+    # Tier breakdown: Tier 1 is free CodeQL; Tier 2/3 burn LLM tokens;
+    # Tier 4 is free SMT (Z3 only) refining Tier 1/2/3 verdicts when
+    # the LLM extracted path_conditions. Worth showing the split so
+    # operators can tell whether --deep-validate is paying off.
+    n_tier1 = dv.get("n_tier1_prebuilt", 0)
+    n_tier2 = dv.get("n_tier2_template", 0)
+    n_tier3 = dv.get("n_tier3_retry", 0)
+    tier_parts: List[str] = []
+    if n_tier1:
+        tier_parts.append(f"{n_tier1} Tier 1 (free)")
+    if n_tier2:
+        tier_parts.append(f"{n_tier2} Tier 2 (LLM)")
+    if n_tier3:
+        tier_parts.append(f"{n_tier3} Tier 3 (LLM retry)")
+    if tier_parts:
+        out.append(f"{indent}  by tier: {', '.join(tier_parts)}")
+
+    # Tier 4 (SMT) sub-line — separate because outcomes are additive
+    # on top of Tier 1/2/3 (a finding's verdict may be confirmed-by-
+    # Tier-1 AND witness-attached-by-Tier-4) so mixing them into the
+    # per-tier counts would double-count.
+    n_smt_refuted = dv.get("n_tier4_smt_refuted", 0)
+    n_smt_witness = dv.get("n_tier4_smt_witness", 0)
+    n_smt_disagree = dv.get("n_tier4_smt_disagree", 0)
+    smt_parts: List[str] = []
+    if n_smt_refuted:
+        smt_parts.append(f"{n_smt_refuted} refuted")
+    if n_smt_witness:
+        smt_parts.append(f"{n_smt_witness} witness")
+    if n_smt_disagree:
+        smt_parts.append(f"{n_smt_disagree} disagreement")
+    if smt_parts:
+        out.append(f"{indent}  Tier 4 SMT: {', '.join(smt_parts)}")
+
+    # path_conditions population telemetry — answers "is the LLM
+    # actually emitting the SMT-checkable conditions the schema asks
+    # for?" Without this signal, a Tier 4 of all-zeros is ambiguous
+    # between "LLM never populates" and "LLM populates but everything
+    # resolves to no_check". Surface only when there's a non-zero
+    # count to report.
+    n_pc_pop = dv.get("n_path_conditions_populated", 0)
+    if n_pc_pop:
+        cwe_breakdown = dv.get("path_conditions_by_cwe", {}) or {}
+        if cwe_breakdown:
+            cwe_str = ", ".join(
+                f"{c}={n}"
+                for c, n in sorted(cwe_breakdown.items(), key=lambda kv: -kv[1])
+            )
+            out.append(
+                f"{indent}  path_conditions populated: {n_pc_pop} ({cwe_str})"
+            )
+        else:
+            out.append(f"{indent}  path_conditions populated: {n_pc_pop}")
+
+    # Downgrade outcome: distinguish "recommended" from "applied"
+    # (the latter is post-reconciliation with consensus/judge). Soft
+    # downgrades = recommendation overruled by consensus/judge.
+    n_recommended = dv.get("n_recommended_downgrades", 0)
+    n_hard = dv.get("n_applied_downgrades", 0)
+    n_soft = dv.get("n_soft_downgrades", 0)
+    if n_recommended:
+        outcome: List[str] = [f"{n_recommended} flagged"]
+        if n_hard or n_soft:
+            bits: List[str] = []
+            if n_hard:
+                bits.append(f"{n_hard} hard")
+            if n_soft:
+                bits.append(f"{n_soft} soft (consensus override)")
+            outcome.append(f"applied: {', '.join(bits)}")
+        out.append(f"{indent}  downgrades: {' · '.join(outcome)}")
+
+    return out

--- a/core/reporting/tests/test_dataflow_summary.py
+++ b/core/reporting/tests/test_dataflow_summary.py
@@ -1,0 +1,180 @@
+"""Tests for the IRIS dataflow_validation console renderer.
+
+Shared between /agentic and /analyze — pre-extraction this lived
+inline in raptor_agentic.py only, leaving /analyze operators
+unable to see Tier 4 / path_conditions telemetry. These tests
+pin both the populated and the no-op cases so neither surface
+silently regresses.
+"""
+
+from core.reporting.dataflow_summary import render_dataflow_validation_lines
+
+
+class TestRenderDataflowValidationLines:
+
+    def test_empty_dict_renders_nothing(self):
+        assert render_dataflow_validation_lines({}) == []
+
+    def test_none_renders_nothing(self):
+        """Caller may pass None when validation never ran (no
+        orchestration result, prep-only mode, etc.)."""
+        assert render_dataflow_validation_lines(None) == []
+
+    def test_no_validations_no_skip_reason_renders_nothing(self):
+        """Validation was set up but no finding entered the loop
+        (eligibility filter, etc.) — silent rather than printing
+        a misleading 'Dataflow validated: 0' line."""
+        dv = {"n_validated": 0, "n_cache_hits": 0, "skipped_reason": ""}
+        assert render_dataflow_validation_lines(dv) == []
+
+    def test_skipped_reason_surfaces_when_no_validation_ran(self):
+        """When the orchestrator set skipped_reason but no finding
+        was validated, surface the reason — operator can tell IRIS
+        noticed but couldn't help."""
+        dv = {"n_validated": 0, "skipped_reason": "no_database"}
+        out = render_dataflow_validation_lines(dv, indent="   ")
+        assert out == ["   Dataflow validation skipped: no_database"]
+
+    def test_simple_validation_run(self):
+        dv = {
+            "n_validated": 3,
+            "n_cache_hits": 0,
+        }
+        out = render_dataflow_validation_lines(dv, indent="   ")
+        # Only the header — no tier breakdown, no SMT, no
+        # path_conditions, no downgrades (all defaulted to 0).
+        assert out == ["   Dataflow validated: 3"]
+
+    def test_cache_hits_pluralised(self):
+        dv = {"n_validated": 1, "n_cache_hits": 1}
+        out = render_dataflow_validation_lines(dv)
+        assert "(+1 cache hit)" in out[0]
+        assert "hits)" not in out[0]
+
+        dv = {"n_validated": 1, "n_cache_hits": 5}
+        out = render_dataflow_validation_lines(dv)
+        assert "(+5 cache hits)" in out[0]
+
+    def test_tier_breakdown_only_lists_non_zero_tiers(self):
+        dv = {
+            "n_validated": 5,
+            "n_tier1_prebuilt": 2,
+            "n_tier2_template": 0,
+            "n_tier3_retry": 1,
+        }
+        out = render_dataflow_validation_lines(dv, indent="   ")
+        tier_line = [l for l in out if "by tier:" in l][0]
+        assert "2 Tier 1" in tier_line
+        assert "Tier 2" not in tier_line  # zero — omitted
+        assert "1 Tier 3" in tier_line
+
+    def test_tier_breakdown_omitted_when_all_zero(self):
+        dv = {
+            "n_validated": 1,
+            "n_tier1_prebuilt": 0,
+            "n_tier2_template": 0,
+            "n_tier3_retry": 0,
+        }
+        out = render_dataflow_validation_lines(dv)
+        assert not any("by tier:" in l for l in out)
+
+    def test_tier4_smt_subline_when_any_outcome_fired(self):
+        dv = {
+            "n_validated": 2,
+            "n_tier4_smt_witness": 1,
+            "n_tier4_smt_refuted": 1,
+        }
+        out = render_dataflow_validation_lines(dv)
+        smt_line = [l for l in out if "Tier 4 SMT:" in l][0]
+        assert "1 refuted" in smt_line
+        assert "1 witness" in smt_line
+        assert "disagreement" not in smt_line  # zero — omitted
+
+    def test_path_conditions_with_cwe_breakdown(self):
+        """Sorted by count descending — most common CWE first so
+        operators see the dominant pattern at a glance."""
+        dv = {
+            "n_validated": 5,
+            "n_path_conditions_populated": 4,
+            "path_conditions_by_cwe": {"CWE-190": 1, "CWE-476": 3},
+        }
+        out = render_dataflow_validation_lines(dv)
+        pc_line = [l for l in out if "path_conditions populated:" in l][0]
+        assert "4" in pc_line
+        # Sort: CWE-476 first (count 3), CWE-190 second (count 1).
+        idx_476 = pc_line.index("CWE-476")
+        idx_190 = pc_line.index("CWE-190")
+        assert idx_476 < idx_190, "CWE breakdown should be sorted by count desc"
+
+    def test_path_conditions_without_cwe_breakdown(self):
+        dv = {
+            "n_validated": 3,
+            "n_path_conditions_populated": 2,
+            "path_conditions_by_cwe": {},
+        }
+        out = render_dataflow_validation_lines(dv)
+        pc_line = [l for l in out if "path_conditions populated:" in l][0]
+        assert pc_line.endswith(": 2")  # no parenthetical breakdown
+
+    def test_downgrades_recommended_only(self):
+        dv = {
+            "n_validated": 3,
+            "n_recommended_downgrades": 2,
+        }
+        out = render_dataflow_validation_lines(dv)
+        dl = [l for l in out if "downgrades:" in l][0]
+        assert "2 flagged" in dl
+        assert "applied:" not in dl
+
+    def test_downgrades_recommended_and_applied(self):
+        dv = {
+            "n_validated": 5,
+            "n_recommended_downgrades": 3,
+            "n_applied_downgrades": 2,
+            "n_soft_downgrades": 1,
+        }
+        out = render_dataflow_validation_lines(dv)
+        dl = [l for l in out if "downgrades:" in l][0]
+        assert "3 flagged" in dl
+        assert "2 hard" in dl
+        assert "1 soft (consensus override)" in dl
+
+    def test_indent_zero_for_analyze_style(self):
+        """/analyze's report uses flat lines (no leading whitespace),
+        unlike /agentic which indents under the summary header."""
+        dv = {"n_validated": 1}
+        out = render_dataflow_validation_lines(dv, indent="")
+        assert out[0] == "Dataflow validated: 1"
+
+    def test_full_telemetry_renders_complete_block(self):
+        """End-to-end shape — what an operator sees on a real run
+        with all signals firing."""
+        dv = {
+            "n_validated": 5,
+            "n_cache_hits": 2,
+            "n_tier1_prebuilt": 3,
+            "n_tier2_template": 1,
+            "n_tier3_retry": 1,
+            "n_tier4_smt_refuted": 1,
+            "n_tier4_smt_witness": 2,
+            "n_tier4_smt_disagree": 0,
+            "n_path_conditions_populated": 3,
+            "path_conditions_by_cwe": {"CWE-190": 2, "CWE-476": 1},
+            "n_recommended_downgrades": 1,
+            "n_applied_downgrades": 1,
+            "n_soft_downgrades": 0,
+        }
+        out = render_dataflow_validation_lines(dv, indent="   ")
+        joined = "\n".join(out)
+        assert "Dataflow validated: 5" in joined
+        assert "(+2 cache hits)" in joined
+        assert "Tier 1 (free)" in joined
+        assert "Tier 2 (LLM)" in joined
+        assert "Tier 3 (LLM retry)" in joined
+        assert "1 refuted" in joined
+        assert "2 witness" in joined
+        assert "disagreement" not in joined
+        assert "path_conditions populated: 3" in joined
+        assert "CWE-190=2" in joined
+        assert "1 flagged" in joined
+        assert "1 hard" in joined

--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -1794,6 +1794,17 @@ def main() -> None:
         print(f"Exploitable: {report['exploitable']}")
         print(f"Exploits generated: {report['exploits_generated']} (LLM-generated)")
         print(f"Patches generated: {report['patches_generated']} (LLM-generated)")
+        # IRIS Tier 1/2/3/4 + path_conditions telemetry — same
+        # surfacing /agentic uses (raptor_agentic.py). Renders only
+        # when validation actually ran on at least one finding;
+        # silent on prep-only / no-CodeQL-DB runs. Indent at zero
+        # because /analyze's report uses flat lines (no leading
+        # whitespace), unlike /agentic which uses "   " for the
+        # nested-under-summary cadence.
+        from core.reporting.dataflow_summary import render_dataflow_validation_lines
+        dv = (report or {}).get("dataflow_validation") or {}
+        for line in render_dataflow_validation_lines(dv, indent=""):
+            print(line)
         print(f"LLM cost: ${report['llm_stats']['total_cost']:.4f}")
         print(f"Output: {out_dir}")
         print("=" * 70)

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -1366,94 +1366,16 @@ Examples:
         print(f"   Exploits generated: {exploits_count}")
     if patches_count > 0:
         print(f"   Patches generated: {patches_count}")
-    # IRIS Tier 1 / 2 / 3 dataflow validation surfacing. The full
-    # metrics block lives at orchestration_result["dataflow_validation"]
-    # (n_eligible, n_validated, n_tier1_prebuilt, n_tier2_template,
-    # n_tier3_retry, n_recommended_downgrades, n_applied_downgrades,
-    # n_soft_downgrades, n_skipped_no_db_for_language, …). Surface a
-    # short structured summary so operators see what IRIS did without
-    # needing to dig into orchestrated_report.json. Suppressed when
-    # validation didn't run (no CodeQL DB, --no-validate-dataflow).
+    # IRIS Tier 1 / 2 / 3 / 4 + path_conditions telemetry surfacing.
+    # Helper lives in core/reporting/dataflow_summary.py so /analyze
+    # (packages/llm_analysis/agent.py) can render the same block —
+    # operators running /analyze standalone after /scan would
+    # otherwise miss whether IRIS validated findings, populated
+    # path_conditions, or fired SMT.
+    from core.reporting.dataflow_summary import render_dataflow_validation_lines
     dv = (orchestration_result or {}).get("dataflow_validation") or {}
-    n_validated = dv.get("n_validated", 0)
-    n_cache_hits = dv.get("n_cache_hits", 0)
-    if dv and (n_validated or n_cache_hits):
-        n_tier1 = dv.get("n_tier1_prebuilt", 0)
-        n_tier2 = dv.get("n_tier2_template", 0)
-        n_tier3 = dv.get("n_tier3_retry", 0)
-        n_smt_refuted = dv.get("n_tier4_smt_refuted", 0)
-        n_smt_witness = dv.get("n_tier4_smt_witness", 0)
-        n_smt_disagree = dv.get("n_tier4_smt_disagree", 0)
-        n_recommended = dv.get("n_recommended_downgrades", 0)
-        n_hard = dv.get("n_applied_downgrades", 0)
-        n_soft = dv.get("n_soft_downgrades", 0)
-        # Header line matches the existing summary cadence
-        # ("Exploits generated: N", "Patches generated: N", …).
-        print(f"   Dataflow validated: {n_validated}"
-              + (f" (+{n_cache_hits} cache hit{'s' if n_cache_hits != 1 else ''})"
-                 if n_cache_hits else ""))
-        # Tier breakdown: Tier 1 is free CodeQL; Tier 2/3 burn LLM
-        # tokens; Tier 4 is free SMT (Z3 only) refining Tier 1/2/3
-        # verdicts when the LLM extracted path_conditions. Worth
-        # showing the split so operators can tell whether
-        # --deep-validate is paying off.
-        tier_parts = []
-        if n_tier1:
-            tier_parts.append(f"{n_tier1} Tier 1 (free)")
-        if n_tier2:
-            tier_parts.append(f"{n_tier2} Tier 2 (LLM)")
-        if n_tier3:
-            tier_parts.append(f"{n_tier3} Tier 3 (LLM retry)")
-        if tier_parts:
-            print(f"     by tier: {', '.join(tier_parts)}")
-        # Tier 4 (SMT) sub-line — separate because outcomes are
-        # additive on top of Tier 1/2/3 (a finding's verdict may be
-        # confirmed-by-Tier-1 AND witness-attached-by-Tier-4) so
-        # mixing them into the per-tier counts would double-count.
-        smt_parts = []
-        if n_smt_refuted:
-            smt_parts.append(f"{n_smt_refuted} refuted")
-        if n_smt_witness:
-            smt_parts.append(f"{n_smt_witness} witness")
-        if n_smt_disagree:
-            smt_parts.append(f"{n_smt_disagree} disagreement")
-        if smt_parts:
-            print(f"     Tier 4 SMT: {', '.join(smt_parts)}")
-        # path_conditions population telemetry — answers "is the LLM
-        # actually emitting the SMT-checkable conditions the schema
-        # asks for?" Without this signal, a Tier 4 of all-zeros is
-        # ambiguous between "LLM never populates" and "LLM populates
-        # but everything resolves to no_check". Surface only when
-        # there's a non-zero count to report.
-        n_pc_pop = dv.get("n_path_conditions_populated", 0)
-        if n_pc_pop:
-            cwe_breakdown = dv.get("path_conditions_by_cwe", {})
-            if cwe_breakdown:
-                cwe_str = ", ".join(
-                    f"{c}={n}" for c, n in
-                    sorted(cwe_breakdown.items(), key=lambda kv: -kv[1])
-                )
-                print(f"     path_conditions populated: {n_pc_pop} ({cwe_str})")
-            else:
-                print(f"     path_conditions populated: {n_pc_pop}")
-        # Downgrade outcome: distinguish "recommended" from "applied"
-        # (the latter is post-reconciliation with consensus/judge).
-        # Soft downgrades = recommendation overruled by consensus/judge.
-        if n_recommended:
-            outcome = []
-            outcome.append(f"{n_recommended} flagged")
-            if n_hard or n_soft:
-                bits = []
-                if n_hard:
-                    bits.append(f"{n_hard} hard")
-                if n_soft:
-                    bits.append(f"{n_soft} soft (consensus override)")
-                outcome.append(f"applied: {', '.join(bits)}")
-            print(f"     downgrades: {' · '.join(outcome)}")
-    elif dv.get("skipped_reason"):
-        # Validation was attempted but skipped — surface the reason so
-        # operators know IRIS noticed but couldn't help.
-        print(f"   Dataflow validation skipped: {dv['skipped_reason']}")
+    for line in render_dataflow_validation_lines(dv, indent="   "):
+        print(line)
     aggregation = orchestration_result.get("aggregation", {}) if orchestration_result else {}
     if aggregation:
         summary = str(aggregation.get("summary") or "").strip()


### PR DESCRIPTION
Pre-fix the IRIS Tier 1/2/3/4 + path_conditions telemetry block (~80 LOC) lived inline in raptor_agentic.py. Operators running /analyze standalone after /scan saw only "Analyzed: N / Exploitable: M / Exploits / Patches / Cost / Output" — no dataflow validation summary, no Tier breakdown, no SMT counters, no path_conditions visibility. Tracked as
project_analyze_smt_renderer_parity since #450 surfaced the gap.

Extract the inline block to core/reporting/dataflow_summary.py
(`render_dataflow_validation_lines(dv, indent="   ")`) returning
a list of formatted strings. raptor_agentic.py replaces its 80
lines with a 4-line call; packages/llm_analysis/agent.py's main()
report block adds the same 4 lines (with indent="" to match its
flat cadence). Both surfaces now show identical telemetry from
the same source of truth.

The helper preserves all existing behaviour:
  - Silent when validation didn't run AND no skipped_reason
  - "Dataflow validation skipped: <reason>" when explicitly skipped (no_database / etc.)
  - Header (n_validated + cache hits with correct singular/plural)
  - Tier 1/2/3 breakdown (only non-zero tiers shown)
  - Tier 4 SMT (refuted / witness / disagreement, only if any)
  - path_conditions populated with CWE breakdown (sorted desc)
  - Downgrades flagged + applied (hard / soft (consensus override))

15 pin-tests cover empty/none/zero/skipped/single-tier/multi-tier/ SMT/path_conditions-with-and-without-cwe/downgrades/full-block shapes plus indent-zero rendering for the /analyze surface. 1001-test sweep clean.

Verified via direct render: identical output between /agentic
(indent="   ") and /analyze (indent="") — only leading-whitespace
differs, matching each surface's existing report cadence.