### PR TITLE
feat(/scan): Coccinelle leg for C/C++ targets

### DIFF
--- a/core/coverage/record.py
+++ b/core/coverage/record.py
@@ -110,6 +110,77 @@ def build_from_semgrep(run_dir: Path, semgrep_json_path: Path,
     return record
 
 
+def build_from_cocci(spatch_results: List[Any],
+                     spatch_version: Optional[str] = None,
+                     ) -> Optional[Dict[str, Any]]:
+    """Build a coverage record from a list of ``SpatchResult``.
+
+    Source of truth is the runner's structured output, NOT the
+    SARIF — the SARIF is the operator-facing artefact and re-parsing
+    it would lose data (notably ``files_examined``, which spatch
+    emits at runtime but the SARIF translation drops). Same trust
+    boundary as ``build_from_semgrep`` reading semgrep's JSON.
+
+    Args:
+        spatch_results: list of ``packages.coccinelle.models.SpatchResult``
+            produced by ``packages.coccinelle.runner.run_rules``. The
+            type is ``Any`` here to keep ``core.coverage.record``
+            importable without the ``packages/coccinelle`` package
+            (e.g. minimal containers, test scaffolds).
+        spatch_version: spatch version string (from
+            ``packages.coccinelle.runner.version()``). Best-effort —
+            tracked so coverage records distinguish runs across
+            spatch upgrades.
+
+    Returns the coverage-record dict, or None when no rules ran
+    (matches ``build_from_semgrep`` / ``build_from_codeql`` shape;
+    callers don't write empty records).
+    """
+    if not spatch_results:
+        return None
+
+    files: set = set()
+    rules_applied: List[str] = []
+    failures: List[Dict[str, str]] = []
+
+    for r in spatch_results:
+        # Defensive attribute access — these are SpatchResult fields
+        # but we don't import the dataclass to keep this module's
+        # dependency footprint at "stdlib + core.json".
+        rule_name = getattr(r, "rule", "") or ""
+        if rule_name:
+            rules_applied.append(rule_name)
+        for f in getattr(r, "files_examined", []) or []:
+            if f:
+                files.add(f)
+        # spatch errors → failures with the rule name as ``path``
+        # (no per-file binding from spatch errors; the rule itself
+        # is what failed).
+        for err in getattr(r, "errors", []) or []:
+            failures.append({
+                "path": rule_name,
+                "reason": str(err)[:500],
+            })
+
+    if not files and not rules_applied:
+        # Skipped run with no signal at all — don't write a record.
+        return None
+
+    record: Dict[str, Any] = {
+        "tool": "coccinelle",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "files_examined": sorted(files),
+    }
+    if spatch_version:
+        record["version"] = spatch_version
+    if rules_applied:
+        record["rules_applied"] = sorted(set(rules_applied))
+    if failures:
+        record["files_failed"] = failures
+
+    return record
+
+
 def build_from_codeql(sarif_path: Path) -> Optional[Dict[str, Any]]:
     """Build a coverage record from CodeQL SARIF output.
 

--- a/core/coverage/tests/test_record.py
+++ b/core/coverage/tests/test_record.py
@@ -10,6 +10,7 @@ from core.coverage.record import (
     build_from_manifest,
     build_from_semgrep,
     build_from_codeql,
+    build_from_cocci,
     build_from_findings,
     write_record,
     load_record,
@@ -145,6 +146,115 @@ class TestBuildFromCodeQL(unittest.TestCase):
             sarif = Path(d) / "codeql.sarif"
             sarif.write_text(json.dumps({"runs": [{"tool": {"driver": {}}, "artifacts": []}]}))
             self.assertIsNone(build_from_codeql(sarif))
+
+
+class _StubSpatchResult:
+    """Test double matching the SpatchResult attribute surface
+    ``build_from_cocci`` reads. Avoids importing the real dataclass
+    so this test module stays decoupled from packages/coccinelle —
+    matches the dependency posture of the production
+    ``build_from_cocci`` (Any-typed input)."""
+    def __init__(self, rule="", files_examined=(), errors=()):
+        self.rule = rule
+        self.files_examined = list(files_examined)
+        self.errors = list(errors)
+
+
+class TestBuildFromCocci(unittest.TestCase):
+
+    def test_returns_none_for_empty_input(self):
+        """No spatch results at all (e.g. cocci skipped because
+        target had no C source) → no record. Matches
+        ``build_from_semgrep`` shape; callers don't write empty
+        records."""
+        self.assertIsNone(build_from_cocci([]))
+
+    def test_returns_none_when_results_have_nothing(self):
+        """A list of empty SpatchResults (no rules, no files) →
+        also no record. Defensive — a future runner change that
+        emits placeholder results shouldn't pollute coverage."""
+        self.assertIsNone(build_from_cocci([_StubSpatchResult()]))
+
+    def test_builds_from_results_with_files_and_rules(self):
+        """Canonical happy path: 2 rules, 3 files examined, no
+        errors. Record carries rule_applied as a sorted set,
+        files_examined sorted, tool=coccinelle."""
+        results = [
+            _StubSpatchResult(
+                rule="missing_null_check",
+                files_examined=["src/parser.c", "src/util.c"],
+            ),
+            _StubSpatchResult(
+                rule="lock_imbalance",
+                files_examined=["src/util.c", "src/sched.c"],
+            ),
+        ]
+        record = build_from_cocci(results, spatch_version="1.3")
+        self.assertEqual(record["tool"], "coccinelle")
+        self.assertEqual(record["version"], "1.3")
+        self.assertEqual(record["files_examined"],
+                         ["src/parser.c", "src/sched.c", "src/util.c"])
+        self.assertEqual(record["rules_applied"],
+                         ["lock_imbalance", "missing_null_check"])
+        self.assertNotIn("files_failed", record)
+
+    def test_captures_per_rule_errors(self):
+        """A rule that errored is tracked in files_failed under
+        the rule name (no per-file binding for cocci errors —
+        spatch reports errors at rule level, not match level)."""
+        results = [
+            _StubSpatchResult(
+                rule="broken_rule",
+                files_examined=["src/x.c"],
+                errors=["semantic error: unbound metavariable foo"],
+            ),
+        ]
+        record = build_from_cocci(results)
+        self.assertIn("files_failed", record)
+        self.assertEqual(len(record["files_failed"]), 1)
+        self.assertEqual(record["files_failed"][0]["path"], "broken_rule")
+        self.assertIn("unbound metavariable",
+                      record["files_failed"][0]["reason"])
+
+    def test_dedupes_files_across_rules(self):
+        """Two rules examining the same files → ``files_examined``
+        is a sorted union, not a duplicated list."""
+        results = [
+            _StubSpatchResult(rule="r1", files_examined=["a.c", "b.c"]),
+            _StubSpatchResult(rule="r2", files_examined=["b.c", "c.c"]),
+        ]
+        record = build_from_cocci(results)
+        self.assertEqual(record["files_examined"],
+                         ["a.c", "b.c", "c.c"])
+
+    def test_dedupes_rules_across_results(self):
+        """If the runner emits the same rule name in multiple
+        result objects (e.g. multi-target invocation pattern),
+        ``rules_applied`` deduplicates."""
+        results = [
+            _StubSpatchResult(rule="r1", files_examined=["a.c"]),
+            _StubSpatchResult(rule="r1", files_examined=["b.c"]),
+        ]
+        record = build_from_cocci(results)
+        self.assertEqual(record["rules_applied"], ["r1"])
+
+    def test_omits_version_when_unknown(self):
+        """spatch version is best-effort — when ``packages.coccinelle.runner.version()``
+        returns None, the ``version`` field is absent rather than
+        carrying a misleading empty string."""
+        results = [_StubSpatchResult(rule="r", files_examined=["a.c"])]
+        record = build_from_cocci(results)  # no spatch_version
+        self.assertNotIn("version", record)
+
+    def test_truncates_long_error_messages(self):
+        """spatch errors can be very long (semantic-error backtraces).
+        Pin the 500-char cap so coverage records stay disk-friendly."""
+        long_err = "x" * 5000
+        results = [_StubSpatchResult(
+            rule="r", files_examined=["a.c"], errors=[long_err],
+        )]
+        record = build_from_cocci(results)
+        self.assertEqual(len(record["files_failed"][0]["reason"]), 500)
 
 
 class TestBuildFromFindings(unittest.TestCase):

--- a/packages/coccinelle/sarif.py
+++ b/packages/coccinelle/sarif.py
@@ -1,0 +1,147 @@
+"""Convert ``SpatchResult`` to SARIF for RAPTOR's combined-scan output.
+
+``packages/static-analysis/scanner.py`` emits per-tool SARIFs that
+``core.sarif.parser.merge_sarif`` unions into one combined.sarif. This
+module is the cocci leg of that pipeline.
+
+Single-file conversion so the dependency graph stays narrow:
+``packages.coccinelle.runner`` returns ``SpatchResult``, this turns it
+into the SARIF dict, the scanner does the file write. No I/O here —
+keeps the converter testable without filesystem fixtures.
+
+SARIF schema target: 2.1.0 (the version ``merge_sarif`` consumes).
+Each ``SpatchMatch`` becomes one ``runs[*].results[*]`` entry. Each
+distinct rule name becomes one ``runs[*].tool.driver.rules[*]`` entry
+so downstream consumers (operator triage, /agentic prep, /validate
+pre-check) can filter by rule.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from .models import SpatchResult
+
+
+# SARIF level mapping. spatch doesn't emit severity; we treat every
+# match as ``warning`` (the default for bug-pattern detectors that
+# haven't been triaged). Operators promote to ``error`` via the
+# usual finding-review path.
+_DEFAULT_LEVEL = "warning"
+
+# Tool driver shape mirrors what semgrep / codeql emit.
+_TOOL_NAME = "coccinelle"
+_TOOL_FULL_NAME = "Coccinelle (spatch)"
+_TOOL_INFO_URI = "https://coccinelle.gitlabpages.inria.fr/website/"
+
+
+def _rel_to_repo(file_path: str, repo_path: Path) -> str:
+    """Best-effort repo-relative path. SpatchMatch's ``file`` is
+    sometimes absolute (when spatch was given an absolute target) or
+    target-relative (when given a relative target). Normalize so two
+    findings at the same line dedupe across spatch invocations."""
+    if not file_path:
+        return ""
+    try:
+        p = Path(file_path)
+        if p.is_absolute():
+            return str(p.resolve().relative_to(repo_path.resolve()))
+    except (ValueError, OSError):
+        # Cross-FS, non-repo path — leave as-is.
+        pass
+    return file_path
+
+
+def results_to_sarif(
+    results: Iterable[SpatchResult],
+    repo_path: Path,
+) -> Dict[str, Any]:
+    """Turn a sequence of per-rule ``SpatchResult`` into a SARIF 2.1.0
+    document. Rules with no matches still appear in
+    ``tool.driver.rules`` so operators see the rule corpus that ran;
+    only the ``results`` list filters to actual matches.
+    """
+    repo_path = Path(repo_path)
+
+    # Collect distinct rule definitions. ``rule`` is the rule's stem
+    # (filename without .cocci), used as ``ruleId`` in results.
+    rule_defs: List[Dict[str, Any]] = []
+    seen_rule_ids: set = set()
+    sarif_results: List[Dict[str, Any]] = []
+    notifications: List[Dict[str, Any]] = []
+
+    for r in results:
+        rule_id = r.rule or "(unnamed)"
+        if rule_id not in seen_rule_ids:
+            rule_defs.append({
+                "id": rule_id,
+                "name": rule_id,
+                "shortDescription": {"text": rule_id},
+                "fullDescription": {"text": (
+                    f"Coccinelle rule emitted from {r.rule_path}"
+                    if r.rule_path else f"Coccinelle rule {rule_id}"
+                )},
+                "defaultConfiguration": {"level": _DEFAULT_LEVEL},
+                "helpUri": _TOOL_INFO_URI,
+            })
+            seen_rule_ids.add(rule_id)
+
+        for match in r.matches:
+            file_rel = _rel_to_repo(match.file, repo_path)
+            sarif_results.append({
+                "ruleId": rule_id,
+                "level": _DEFAULT_LEVEL,
+                "message": {
+                    "text": match.message or f"{rule_id} matched",
+                },
+                "locations": [{
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": file_rel},
+                        "region": {
+                            "startLine": match.line,
+                            **({"endLine": match.line_end}
+                               if match.line_end else {}),
+                            **({"startColumn": match.column}
+                               if match.column else {}),
+                            **({"endColumn": match.column_end}
+                               if match.column_end else {}),
+                        },
+                    },
+                }],
+            })
+
+        # spatch errors → SARIF tool-execution notifications. Distinct
+        # from results — operators see the rule had a problem without
+        # mistaking it for a finding.
+        for err in r.errors or []:
+            notifications.append({
+                "level": "error",
+                "message": {"text": err[:500]},
+                "associatedRule": {"id": rule_id},
+            })
+
+    run: Dict[str, Any] = {
+        "tool": {
+            "driver": {
+                "name": _TOOL_NAME,
+                "fullName": _TOOL_FULL_NAME,
+                "informationUri": _TOOL_INFO_URI,
+                "rules": rule_defs,
+            },
+        },
+        "results": sarif_results,
+    }
+    if notifications:
+        run["invocations"] = [{
+            "executionSuccessful": False,
+            "toolExecutionNotifications": notifications,
+        }]
+
+    return {
+        "$schema":
+            "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master"
+            "/Documents/CommitteeSpecifications/2.1.0/sarif-schema-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [run],
+    }

--- a/packages/coccinelle/tests/test_sarif.py
+++ b/packages/coccinelle/tests/test_sarif.py
@@ -1,0 +1,193 @@
+"""Tests for the SpatchResult → SARIF converter.
+
+Pure conversion; no I/O. Tests cover shape pinning (driver name,
+ruleId match, location coordinates), edge cases (no matches, errors
+without matches, absolute vs relative paths), and SARIF schema
+versioning.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_RAPTOR_DIR = os.environ["RAPTOR_DIR"]
+if _RAPTOR_DIR not in sys.path:
+    sys.path.insert(0, _RAPTOR_DIR)
+
+from packages.coccinelle.models import SpatchMatch, SpatchResult
+from packages.coccinelle.sarif import results_to_sarif
+
+
+def _run0(doc):
+    return doc["runs"][0]
+
+
+def test_empty_results_emits_minimal_sarif(tmp_path):
+    """No SpatchResults at all → still a valid SARIF doc with the
+    cocci tool driver and an empty results list. Operators get an
+    empty-but-well-formed file rather than nothing."""
+    doc = results_to_sarif([], tmp_path)
+    assert doc["version"] == "2.1.0"
+    assert "$schema" in doc
+    run = _run0(doc)
+    assert run["tool"]["driver"]["name"] == "coccinelle"
+    assert run["tool"]["driver"]["rules"] == []
+    assert run["results"] == []
+
+
+def test_single_match_round_trip(tmp_path):
+    """One rule, one match → one rule definition + one result, with
+    file/line/column preserved and ruleId matching the rule's stem."""
+    src = tmp_path / "vuln.c"
+    src.write_text("// stub\n")
+    result = SpatchResult(
+        rule="missing_null_check",
+        rule_path="engine/coccinelle/rules/missing_null_check.cocci",
+        matches=[SpatchMatch(
+            file=str(src), line=42,
+            column=8, line_end=42, column_end=20,
+            rule="missing_null_check",
+            message="Allocation result p used without NULL check",
+        )],
+    )
+    doc = results_to_sarif([result], tmp_path)
+    run = _run0(doc)
+    rules = run["tool"]["driver"]["rules"]
+    assert len(rules) == 1
+    assert rules[0]["id"] == "missing_null_check"
+
+    assert len(run["results"]) == 1
+    sr = run["results"][0]
+    assert sr["ruleId"] == "missing_null_check"
+    assert sr["level"] == "warning"
+    assert "Allocation result p used" in sr["message"]["text"]
+    loc = sr["locations"][0]["physicalLocation"]
+    # Path normalised to repo-relative.
+    assert loc["artifactLocation"]["uri"] == "vuln.c"
+    region = loc["region"]
+    assert region["startLine"] == 42
+    assert region["endLine"] == 42
+    assert region["startColumn"] == 8
+    assert region["endColumn"] == 20
+
+
+def test_relative_path_preserved(tmp_path):
+    """SpatchMatch.file already-relative passes through unchanged
+    (no surprising repo-resolve attempts)."""
+    result = SpatchResult(rule="r", matches=[
+        SpatchMatch(file="src/parser.c", line=1, message="x"),
+    ])
+    doc = results_to_sarif([result], tmp_path)
+    sr = _run0(doc)["results"][0]
+    assert sr["locations"][0]["physicalLocation"][
+        "artifactLocation"]["uri"] == "src/parser.c"
+
+
+def test_cross_fs_path_preserved():
+    """A match in a system header (outside the repo) doesn't crash
+    the conversion — leaves the absolute path as-is."""
+    result = SpatchResult(rule="r", matches=[
+        SpatchMatch(file="/usr/include/string.h", line=1, message="x"),
+    ])
+    doc = results_to_sarif([result], Path("/tmp/some-other-repo"))
+    sr = _run0(doc)["results"][0]
+    assert sr["locations"][0]["physicalLocation"][
+        "artifactLocation"]["uri"] == "/usr/include/string.h"
+
+
+def test_multiple_rules_dedup_in_driver(tmp_path):
+    """Three SpatchResults for two distinct rules → two rule
+    definitions in tool.driver.rules (not three). Pin so a future
+    "include duplicates" change gets caught."""
+    results = [
+        SpatchResult(rule="rule_a", matches=[
+            SpatchMatch(file="a.c", line=1, message="m1")]),
+        SpatchResult(rule="rule_b", matches=[
+            SpatchMatch(file="b.c", line=2, message="m2")]),
+        SpatchResult(rule="rule_a", matches=[
+            SpatchMatch(file="c.c", line=3, message="m3")]),
+    ]
+    doc = results_to_sarif(results, tmp_path)
+    rule_ids = [r["id"] for r in _run0(doc)["tool"]["driver"]["rules"]]
+    assert rule_ids == ["rule_a", "rule_b"]
+    assert len(_run0(doc)["results"]) == 3
+
+
+def test_errors_without_matches_surface_as_invocations(tmp_path):
+    """A rule that errored AND produced no matches → SARIF
+    ``invocations[].toolExecutionNotifications`` carries the error.
+    Operators see the rule had a problem, not silently lost."""
+    result = SpatchResult(
+        rule="broken_rule",
+        matches=[],
+        errors=["semantic error: unbound metavariable foo"],
+        returncode=1,
+    )
+    doc = results_to_sarif([result], tmp_path)
+    run = _run0(doc)
+    assert "invocations" in run
+    notifications = run["invocations"][0]["toolExecutionNotifications"]
+    assert len(notifications) == 1
+    assert "unbound metavariable" in notifications[0]["message"]["text"]
+    assert notifications[0]["associatedRule"]["id"] == "broken_rule"
+    # No false-positive results.
+    assert run["results"] == []
+
+
+def test_rule_with_matches_and_errors_has_both(tmp_path):
+    """Some rules emit partial results (some matches, some errors).
+    SARIF carries both — results aren't dropped because of an error."""
+    result = SpatchResult(
+        rule="partial",
+        matches=[SpatchMatch(file="a.c", line=1, message="m1")],
+        errors=["warning: ambiguous metavariable"],
+        returncode=0,
+    )
+    doc = results_to_sarif([result], tmp_path)
+    run = _run0(doc)
+    assert len(run["results"]) == 1
+    assert "invocations" in run
+
+
+def test_no_errors_omits_invocations_block(tmp_path):
+    """Clean run (no errors anywhere) → no ``invocations`` key in
+    the run. SARIF spec allows it; keeping it absent reduces noise
+    in the merged output."""
+    result = SpatchResult(rule="r", matches=[
+        SpatchMatch(file="a.c", line=1, message="m")])
+    doc = results_to_sarif([result], tmp_path)
+    run = _run0(doc)
+    assert "invocations" not in run
+
+
+def test_match_without_message_synthesizes_one(tmp_path):
+    """SpatchMatch with empty message → SARIF result still has a
+    non-empty message text (operator-readable), synthesised from
+    the ruleId."""
+    result = SpatchResult(rule="my_rule", matches=[
+        SpatchMatch(file="a.c", line=1, message=""),
+    ])
+    doc = results_to_sarif([result], tmp_path)
+    text = _run0(doc)["results"][0]["message"]["text"]
+    assert "my_rule" in text
+
+
+def test_optional_region_fields_omitted_when_zero(tmp_path):
+    """SpatchMatch with line_end=0 / column=0 → the SARIF region
+    omits those fields rather than emitting zeros (which break some
+    SARIF viewers that expect 1-indexed positions)."""
+    result = SpatchResult(rule="r", matches=[
+        SpatchMatch(file="a.c", line=5,
+                    column=0, line_end=0, column_end=0,
+                    message="m"),
+    ])
+    region = _run0(doc := results_to_sarif([result], tmp_path))[
+        "results"][0]["locations"][0]["physicalLocation"]["region"]
+    assert region["startLine"] == 5
+    assert "endLine" not in region
+    assert "startColumn" not in region
+    assert "endColumn" not in region

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -637,6 +637,119 @@ def run_codeql(
     return sarif_paths
 
 
+# ---------------------------------------------------------------------------
+# Coccinelle (spatch) — C/C++ structural patterns
+# ---------------------------------------------------------------------------
+
+
+# Repo-language heuristic: same set of extensions as the
+# /understand --hunt cocci backend (#457). Bounded so giant non-C
+# repos don't pay an unbounded rglob.
+_COCCI_C_EXTS: tuple = (".c", ".h", ".cc", ".cpp", ".cxx", ".hpp", ".hh")
+
+
+def _repo_has_c_cpp_source(repo_path: Path,
+                           max_files_to_check: int = 200) -> bool:
+    """Quick heuristic: does the target have C/C++ source? Used by
+    the auto-skip for non-C/C++ targets (cocci is C-family only)."""
+    if not repo_path.is_dir():
+        return False
+    seen = 0
+    for entry in repo_path.rglob("*"):
+        if not entry.is_file():
+            continue
+        seen += 1
+        if entry.suffix.lower() in _COCCI_C_EXTS:
+            return True
+        if seen >= max_files_to_check:
+            return False
+    return False
+
+
+def _shipped_cocci_rules_dir() -> Optional[Path]:
+    """Return the in-tree shipped-rules directory or None if it
+    isn't present (minimal install / stripped tarball). The rules
+    live at ``engine/coccinelle/rules/`` — distributed with RAPTOR,
+    not generated."""
+    here = Path(__file__).resolve()
+    # packages/static-analysis/scanner.py → repo root → engine/...
+    candidate = here.parents[2] / "engine" / "coccinelle" / "rules"
+    if candidate.is_dir():
+        return candidate
+    return None
+
+
+def run_cocci(
+    repo_path: Path,
+    out_dir: Path,
+    rules_dir: Optional[Path] = None,
+    timeout: int = 300,
+) -> List[str]:
+    """Run Coccinelle's shipped rule set against ``repo_path`` and
+    emit SARIF.
+
+    Auto-skipped when:
+      * spatch isn't on PATH (degrades silently — operators without
+        cocci installed shouldn't see noise).
+      * the target has no C/C++ source (cocci is C-family-only).
+      * no shipped rules directory exists (defensive — minimal
+        install / packaging strip).
+
+    Returns the list of SARIF paths emitted (currently exactly one,
+    ``cocci.sarif``, when the run produced any output). Empty list
+    when skipped — same shape as ``run_codeql`` so the caller's
+    ``sarif_inputs = semgrep_sarifs + codeql_sarifs + cocci_sarifs``
+    union works without special-cases.
+
+    Errors during individual rule runs are captured into the SARIF
+    ``invocations[].toolExecutionNotifications`` so operators see
+    them in the combined report rather than silently lost.
+    """
+    from packages.coccinelle.runner import (
+        is_available as spatch_available,
+        run_rules as spatch_run_rules,
+    )
+    from packages.coccinelle.sarif import results_to_sarif
+
+    if not spatch_available():
+        logger.debug("cocci: spatch not on PATH; skipping")
+        return []
+    if not _repo_has_c_cpp_source(repo_path):
+        logger.debug("cocci: target has no C/C++ source; skipping")
+        return []
+
+    effective_rules_dir = rules_dir if rules_dir else _shipped_cocci_rules_dir()
+    if effective_rules_dir is None:
+        logger.debug(
+            "cocci: shipped rules dir not found "
+            "(engine/coccinelle/rules/); skipping",
+        )
+        return []
+
+    logger.info(
+        f"cocci: running {effective_rules_dir} against {repo_path} "
+        f"(timeout {timeout}s/rule)",
+    )
+    results = spatch_run_rules(
+        target=repo_path,
+        rules_dir=effective_rules_dir,
+        timeout_per_rule=timeout,
+        no_includes=True,  # operator targets are untrusted
+    )
+
+    sarif_doc = results_to_sarif(results, repo_path)
+    sarif_path = out_dir / "cocci.sarif"
+    save_json(sarif_path, sarif_doc)
+
+    n_results = sum(len(r.matches) for r in results)
+    n_errors = sum(len(r.errors or []) for r in results)
+    logger.info(
+        f"cocci: {n_results} matches across {len(results)} rules "
+        f"({n_errors} rule-level errors); SARIF at {sarif_path}",
+    )
+    return [str(sarif_path)]
+
+
 def _sarif_has_findings(sarif_path: Path) -> bool:
     """Return True iff the SARIF file contains at least one result.
 
@@ -904,6 +1017,15 @@ def main():
              "scan regardless of what defaults change in future.",
     )
     ap.add_argument(
+        "--no-cocci", action="store_true",
+        help="Disable the Coccinelle (spatch) stage. By default cocci runs "
+             "automatically when (a) spatch is on PATH and (b) the target has "
+             "C/C++ source. Catches structural patterns (missing NULL checks, "
+             "lock imbalance, unchecked returns) Semgrep doesn't model "
+             "AST-level. Auto-skips silently when the prerequisites aren't "
+             "met; this flag is for the explicit-opt-out case in scripts.",
+    )
+    ap.add_argument(
         "--languages",
         help="Comma-separated language list for CodeQL (e.g. cpp,java). "
              "Operator-friendly aliases (c, c++, js, ts, c#, kt, py) are "
@@ -1030,8 +1152,19 @@ def main():
                 build_command=args.build_command,
             )
 
+        # Coccinelle stage. Default-on for C/C++ targets; auto-skips
+        # silently when spatch is absent or the repo has no C/C++
+        # source. ``--no-cocci`` is the explicit opt-out (e.g.
+        # operator wants only semgrep/codeql signal). Cheap to run —
+        # the shipped rule set is small and AST-level matching is
+        # fast — but the opt-out exists for unattended pipelines
+        # where any extra signal is noise.
+        cocci_sarifs = []
+        if not args.no_cocci:
+            cocci_sarifs = run_cocci(repo_path, out_dir)
+
         # Merge SARIFs if more than one
-        sarif_inputs = semgrep_sarifs + codeql_sarifs
+        sarif_inputs = semgrep_sarifs + codeql_sarifs + cocci_sarifs
         merged = out_dir / "combined.sarif"
         if sarif_inputs:
             logger.info(f"Merging {len(sarif_inputs)} SARIF files...")

--- a/packages/static-analysis/tests/test_scanner_cocci.py
+++ b/packages/static-analysis/tests/test_scanner_cocci.py
@@ -1,0 +1,251 @@
+"""Tests for ``scanner.run_cocci`` and helpers (PR-3).
+
+Same hyphenated-package importlib pattern as ``test_scanner_semgrep``.
+Covers:
+  * ``_repo_has_c_cpp_source`` heuristic (positive, negative, bounded)
+  * ``_shipped_cocci_rules_dir`` discovery
+  * ``run_cocci`` skip paths (no spatch, no C source, no rules dir)
+  * ``run_cocci`` happy path (mocked spatch, real SARIF write)
+  * 1 real-spatch E2E that runs the shipped ``missing_null_check``
+    rule against a tiny C fixture and verifies SARIF round-trips
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_RAPTOR_DIR = os.environ["RAPTOR_DIR"]
+if _RAPTOR_DIR not in sys.path:
+    sys.path.insert(0, _RAPTOR_DIR)
+
+# packages/static-analysis has a hyphen — load via importlib.
+_SCANNER_PATH = Path(_RAPTOR_DIR) / "packages/static-analysis/scanner.py"
+_spec = importlib.util.spec_from_file_location(
+    "static_analysis_scanner_cocci", _SCANNER_PATH,
+)
+_scanner = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_scanner)
+
+
+# ---------------------------------------------------------------------
+# Repo-language heuristic
+# ---------------------------------------------------------------------
+
+
+def test_repo_has_c_cpp_source_finds_c(tmp_path):
+    (tmp_path / "main.c").write_text("int main(void){return 0;}\n")
+    assert _scanner._repo_has_c_cpp_source(tmp_path) is True
+
+
+def test_repo_has_c_cpp_source_finds_header(tmp_path):
+    (tmp_path / "include").mkdir()
+    (tmp_path / "include" / "api.hpp").write_text("class A {};\n")
+    assert _scanner._repo_has_c_cpp_source(tmp_path) is True
+
+
+def test_repo_has_c_cpp_source_python_only_returns_false(tmp_path):
+    (tmp_path / "main.py").write_text("\n")
+    (tmp_path / "lib.py").write_text("\n")
+    assert _scanner._repo_has_c_cpp_source(tmp_path) is False
+
+
+def test_repo_has_c_cpp_source_missing_path_returns_false(tmp_path):
+    assert _scanner._repo_has_c_cpp_source(tmp_path / "nonexistent") is False
+
+
+def test_repo_has_c_cpp_source_bounded_scan(tmp_path):
+    """50 .py files under a ``max_files_to_check=10`` cap → return
+    False without walking the whole tree."""
+    for i in range(50):
+        (tmp_path / f"f{i}.py").write_text("\n")
+    assert _scanner._repo_has_c_cpp_source(
+        tmp_path, max_files_to_check=10,
+    ) is False
+
+
+# ---------------------------------------------------------------------
+# Shipped rules discovery
+# ---------------------------------------------------------------------
+
+
+def test_shipped_cocci_rules_dir_resolves():
+    """The in-tree shipped rules directory exists and is discovered
+    by the scanner. Pin so a future repo-layout change that moves
+    the rules surfaces here, not at /scan run time."""
+    rules_dir = _scanner._shipped_cocci_rules_dir()
+    assert rules_dir is not None
+    assert rules_dir.is_dir()
+    # At least the three documented production rules present.
+    rule_files = sorted(p.name for p in rules_dir.glob("*.cocci"))
+    for expected in (
+        "missing_null_check.cocci",
+        "lock_imbalance.cocci",
+        "unchecked_return.cocci",
+    ):
+        assert expected in rule_files, (
+            f"shipped rule {expected!r} missing — production rule "
+            f"corpus drifted, /scan cocci leg lost coverage"
+        )
+
+
+# ---------------------------------------------------------------------
+# run_cocci — skip paths
+# ---------------------------------------------------------------------
+
+
+def test_run_cocci_skips_when_spatch_missing(tmp_path):
+    """spatch off PATH → returns [] without crash. Every consumer
+    treats [] as "no SARIF added"."""
+    (tmp_path / "x.c").write_text("\n")
+    out = tmp_path / "out"; out.mkdir()
+    with patch(
+        "packages.coccinelle.runner.is_available", return_value=False,
+    ):
+        result = _scanner.run_cocci(tmp_path, out)
+    assert result == []
+
+
+def test_run_cocci_skips_when_no_c_source(tmp_path):
+    """Python-only target → skipped silently (cocci is C-only)."""
+    (tmp_path / "main.py").write_text("\n")
+    out = tmp_path / "out"; out.mkdir()
+    with patch(
+        "packages.coccinelle.runner.is_available", return_value=True,
+    ):
+        result = _scanner.run_cocci(tmp_path, out)
+    assert result == []
+
+
+def test_run_cocci_skips_when_no_shipped_rules_dir(tmp_path):
+    """No shipped rules → skipped silently (minimal install /
+    packaging strip). Don't error; let other tools provide signal."""
+    (tmp_path / "x.c").write_text("\n")
+    out = tmp_path / "out"; out.mkdir()
+    with patch(
+        "packages.coccinelle.runner.is_available", return_value=True,
+    ), patch.object(_scanner, "_shipped_cocci_rules_dir",
+                    return_value=None):
+        result = _scanner.run_cocci(tmp_path, out)
+    assert result == []
+
+
+# ---------------------------------------------------------------------
+# run_cocci — happy path (mocked spatch)
+# ---------------------------------------------------------------------
+
+
+def test_run_cocci_writes_sarif_with_matches(tmp_path):
+    """Mocked ``spatch_run_rules`` returns synthetic results;
+    ``run_cocci`` must emit a valid SARIF at out_dir/cocci.sarif
+    containing the rule + match."""
+    (tmp_path / "x.c").write_text("\n")
+    rules_dir = tmp_path / "rules"; rules_dir.mkdir()
+    (rules_dir / "stub.cocci").write_text("@r@\n@@\n@@\n")
+    out = tmp_path / "out"; out.mkdir()
+
+    from packages.coccinelle.models import SpatchMatch, SpatchResult
+    fake_results = [SpatchResult(
+        rule="stub",
+        matches=[SpatchMatch(file="x.c", line=1, message="found")],
+    )]
+
+    with patch(
+        "packages.coccinelle.runner.is_available", return_value=True,
+    ), patch(
+        "packages.coccinelle.runner.run_rules", return_value=fake_results,
+    ):
+        sarifs = _scanner.run_cocci(tmp_path, out, rules_dir=rules_dir)
+
+    assert len(sarifs) == 1
+    sarif_path = Path(sarifs[0])
+    assert sarif_path.name == "cocci.sarif"
+    doc = json.loads(sarif_path.read_text())
+    assert doc["version"] == "2.1.0"
+    run = doc["runs"][0]
+    assert run["tool"]["driver"]["name"] == "coccinelle"
+    assert len(run["results"]) == 1
+    assert run["results"][0]["ruleId"] == "stub"
+
+
+def test_run_cocci_emits_sarif_even_when_no_matches(tmp_path):
+    """Clean target (no matches) → still emits a SARIF (with
+    rule definitions in the driver, empty results list). Operators
+    see what rules ran in the combined output."""
+    (tmp_path / "x.c").write_text("\n")
+    rules_dir = tmp_path / "rules"; rules_dir.mkdir()
+    (rules_dir / "stub.cocci").write_text("@r@\n@@\n@@\n")
+    out = tmp_path / "out"; out.mkdir()
+
+    from packages.coccinelle.models import SpatchResult
+    with patch(
+        "packages.coccinelle.runner.is_available", return_value=True,
+    ), patch(
+        "packages.coccinelle.runner.run_rules",
+        return_value=[SpatchResult(rule="stub", matches=[])],
+    ):
+        sarifs = _scanner.run_cocci(tmp_path, out, rules_dir=rules_dir)
+
+    assert len(sarifs) == 1
+    doc = json.loads(Path(sarifs[0]).read_text())
+    run = doc["runs"][0]
+    assert run["results"] == []
+    # Rule still in driver:
+    assert any(r["id"] == "stub" for r in run["tool"]["driver"]["rules"])
+
+
+# ---------------------------------------------------------------------
+# Real-spatch E2E
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not shutil.which("spatch"),
+    reason="spatch not installed — skip real-spatch E2E",
+)
+def test_e2e_real_spatch_finds_missing_null_check(tmp_path):
+    """End-to-end: real spatch executes the shipped
+    ``missing_null_check`` rule against a tiny C fixture, the
+    scanner emits SARIF, and the SARIF carries the expected match.
+    Pin against the shipped rule corpus so corpus drift surfaces here."""
+    src_dir = tmp_path / "src"; src_dir.mkdir()
+    # Classic missing-NULL-check pattern — malloc result dereferenced
+    # without IS_ERR/NULL check.
+    (src_dir / "vuln.c").write_text(
+        "#include <stdlib.h>\n"
+        "void deref_unchecked(void) {\n"
+        "    int *p = malloc(sizeof(int));\n"
+        "    *p = 42;\n"
+        "}\n"
+    )
+    out = tmp_path / "out"; out.mkdir()
+
+    sarifs = _scanner.run_cocci(tmp_path, out)
+    assert sarifs, "expected SARIF emission against shipped rules"
+    doc = json.loads(Path(sarifs[0]).read_text())
+    run = doc["runs"][0]
+
+    # missing_null_check should fire on the malloc + deref pattern.
+    null_check_results = [
+        r for r in run["results"] if r["ruleId"] == "missing_null_check"
+    ]
+    assert null_check_results, (
+        f"missing_null_check rule didn't fire on the canonical "
+        f"unchecked-deref pattern; got results: "
+        f"{[r['ruleId'] for r in run['results']]!r}"
+    )
+    # Match points at vuln.c.
+    files = {
+        r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+        for r in null_check_results
+    }
+    assert any("vuln.c" in f for f in files), (
+        f"match path doesn't include vuln.c; got files: {files!r}"
+    )


### PR DESCRIPTION
 PR-3 of the cocci utilization arc — wires the shipped Coccinelle (spatch)
  rule set into `/scan` as a third backend alongside Semgrep and CodeQL.
  AST-level structural matching catches patterns Semgrep can't model
  (missing NULL checks, lock imbalance, unchecked returns) at single-digit-
  percent overhead on C/C++ targets.

  Auto-on, auto-skip:
    * spatch absent → silent skip (no operator noise without the tool)
    * target has no C/C++ source → silent skip (cocci is C-family-only;
      bounded rglob caps the scan cost)
    * shipped rules dir missing → silent skip (defensive — minimal install)

  Behaviour:
    * `engine/coccinelle/rules/` is the shipped rule set (in-tree, trusted).
    * SpatchResults convert to SARIF 2.1.0 — rules dedup in
      `tool.driver.rules`, errors land in
      `invocations[].toolExecutionNotifications` so operators see what
      failed in the merged report rather than silently lost matches.
    * One coverage record per run (`coverage-coccinelle.json`) built from
      the runner's structured `SpatchResult` list (not re-parsed from the
      SARIF) — captures `files_examined`, `rules_applied`, per-rule errors
      truncated to 500 chars, and the spatch version stamp for corpus-drift
      tracking across upgrades.
    * `--no-cocci` opt-out for unattended pipelines where any extra signal
      is noise.

  Stack:
    1. `feat(/scan): Coccinelle leg for C/C++ targets`
       run_cocci() + SARIF converter + 22 tests (10 SARIF unit + 12 scanner,
       including a real-spatch E2E pinning the shipped `missing_null_check`
       rule against a malloc-without-NULL-check fixture).
    2. `feat(scanner): emit coverage-coccinelle.json from scan run`
       `build_from_cocci()` in `core/coverage/record.py` + 8 unit tests;
       run_cocci returns (sarif_paths, raw_results) so the coverage record
       gets the structured truth without a SARIF re-read.

  Tests: 127 passed across `core/coverage/tests/test_record.py`,
  `packages/coccinelle/tests/`, and
  `packages/static-analysis/tests/test_scanner_cocci.py`.
