### PR TITLE
feat(validate): Stage B skill — SMT as verification primitive in hypothesis loop

### DIFF
--- a/.claude/skills/exploitability-validation/stage-b-process.md
+++ b/.claude/skills/exploitability-validation/stage-b-process.md
@@ -85,6 +85,15 @@ Track how close to successful exploitation. Ask: "How close did I come?" Log ans
 
 **Same bug class in different locations must score the same unless there's a specific difference in reachability or constraints. State the reason for any score difference.**
 
+**SMT-derived PROXIMITY rules** (apply when [B-3.1.5] produced a verdict):
+
+| SMT verdict | PROXIMITY effect |
+|---|---|
+| `feasible: false` (path conditions mutually exclusive) | Cap at **1**. The dangerous path is unreachable as theorised — move the hypothesis to disproven.json with the unsat core as `why_wrong`. Sound even when `_anon_N` placeholders appear in the unsat core. |
+| `feasible: true` with all-named-local witness model | Floor at **6**. Z3 found concrete trigger values; the source→sink path IS reachable. Remaining work is the exploit primitive. Use the witness model as the PoC input candidate. |
+| `feasible: true` with `_anon_N` in model | Soft signal only — may inform PROXIMITY upward but does NOT floor at 6. The free-variable fallback over-approximates in the SAT direction; the actual path may be infeasible if the function calls are pure and the same call appears multiple times. See [B-3.1.5] for the asymmetry. |
+| `feasible: null` (Z3 unavailable / conditions unparseable / timeout) | No PROXIMITY effect. Continue with LLM reasoning alone. |
+
 ---
 
 ## [B-2.5] Fast Path (mechanical — done by prep script)
@@ -114,14 +123,56 @@ The output lists 1–3 strategies (general + specialised bug-class lenses) with 
 **[B-3.1] Input Verification**
 Verify that suspected findings actually process user input (not just hardcoded values), and there is a proven flow from input to vulnerable code.
 
+**[B-3.1.5] SMT Pre-flight (memory-corruption / arithmetic / bounds CWEs)**
+
+Before constructing an attack path, ask Z3 whether the path conditions you've identified are jointly satisfiable. SMT is a decision procedure within its domain — when it says `feasible: false`, the path IS infeasible (sound even with `_anon_N` placeholders in the unsat core); when it says `feasible: true` with a named-local witness, you have concrete trigger values to use as the PoC seed instead of deriving them from first principles.
+
+**Applies to:** CWE-119/120/121/122 (buffer overflow), CWE-125/787 (out-of-bounds read/write), CWE-190 (integer overflow / wraparound), CWE-191 (integer underflow), CWE-476 (null deref), CWE-193 (off-by-one). Skip for everything else (XSS, SQLi, command injection, auth bypass — Z3 can't speak about those).
+
+**Choose your entry point** (same decision table as [E-3 SMT]):
+
+| Situation | Tool | Why first |
+|---|---|---|
+| The finding has an imported `/understand` flow trace with `path_conditions` (look in `attack-paths.json` for entries with `source: "understand:trace"` carrying that field) | `libexec/raptor-smt-validate-path --from-trace TRACE-ID --workdir "$OUTPUT_DIR"` | The trace's conditions were extracted alongside the dataflow walk with full source-code context — usually richer and more accurate than re-extracting from prose |
+| The source matches a named pattern: `count * size` or similar arithmetic-with-guard (CWE-190); `arr[index]` access (CWE-125 / CWE-787); pointer deref of a possibly-null pointer (CWE-476) | Named verb: `libexec/raptor-smt-check-overflow` / `-oob` / `-null-deref` | The verb's intrinsic predicate is right by construction (csem-built); you only have to extract operands and guards, not derive the encoding |
+| Anything else — bespoke path conditions, multi-stage taint, mixed bitmask/relational guards, or a pattern none of the verbs cover | `libexec/raptor-smt-validate-path` with free-form predicates | The general-purpose escape hatch; richer expressiveness at the cost of you constructing the predicate |
+
+Don't call multiple tools for the same finding — pick one and trust the verdict (or its caveats).
+
+**Free-form example:**
+```bash
+libexec/raptor-smt-validate-path --profile uint32 \
+  'count > 0x10000000' \
+  'alloc_size == count * 16' \
+  'alloc_size < 0x8000'
+```
+
+`--profile` matches the C type width: `uint32` for 32-bit unsigned wraparound (CWE-190 ALLOC pattern); `uint64` (default) for `size_t` / pointer arithmetic; `int32`/`int64` for signed paths.
+
+**Tip — finding the *exploit* witness, not the trivial one:** Z3 returns the smallest satisfying assignment by default, which is often `count=0`. Add a lower-bound condition that forces the dangerous range (e.g. `count > 0x10000000` for the ALLOC-overflow pattern); the witness then lands in the wraparound region.
+
+**Reading the verdict:**
+
+- `feasible: false` → path is infeasible. Move the hypothesis to disproven.json with the `unsatisfied` list as `why_wrong`. PROXIMITY caps at 1. **Skip [B-3.2] attack-path construction for this finding** — the path doesn't exist.
+- `feasible: true` → reachable. The `model` shows witness values (variables = concrete ints). When the model is all named locals, use them as the PoC input directly. PROXIMITY floors at 6. Continue to [B-3.2].
+  - **`_anon_N` decoder:** if the witness shows `_anon_0 (= strlen(argv[1])) = 32`, that's "supply an `argv[1]` whose strlen is 32" — the parser substituted the function-call expression and the renderer decoded it back. When only the bare placeholder appears, look at the path_conditions to find the unique function-call expression.
+  - **Soundness asymmetry:** model has only named locals → trustworthy concrete values. Model contains `_anon_N` → may over-approximate (treat as hint, not proof). If the function call is pure and appears more than once, re-issue with a helper variable forcing them equal.
+- `feasible: null` → Z3 unavailable, conditions unparseable, or timeout. Continue with [B-3.2] using your own reasoning.
+
+**Record in evidence:** add the SMT verdict to the hypothesis's `evidence_for` (sat) or `evidence_against` (unsat) array as a string like `"smt:refuted: count > 0x100 ⊥ count < 16"` or `"smt:witness: count=268435457, alloc_size=16 (uint32 wraparound)"`. The verdict satisfies GATE-4 (NO-HEDGING) for the conditions it covers and GATE-6 (PROOF) for the values it produced.
+
+**Conditions the parser rejects** (these land in `unknown` and the verdict will lean toward `null`): type casts, struct/pointer access, array indexing, pointer deref, unary NOT, XOR, division, modulo, ternary, non-call grouping parens. Stick to bare variables, integer/hex literals, `NULL`, and the operators `+ - * | & << >>` plus relational `< <= > >= == !=`.
+
+**Skip when:** the CWE isn't in the applicable list above; OR z3-solver isn't installed (the shim returns `null` quickly); OR the finding already carries an SMT verdict from /agentic's Tier 4 (don't redo work — look for `smt_witness` in the finding's analysis dict).
+
 **[B-3.2] Attack Path Construction**
-Construct an attack path and walk through it, trying to prove exploitability at every stage. Update attack-paths.json on every attempt.
+Construct an attack path and walk through it, trying to prove exploitability at every stage. Update attack-paths.json on every attempt. If [B-3.1.5] returned `feasible: true` with a witness model, use the witness values as the starting input — no need to derive trigger values from first principles.
 
 **[B-3.3] Path Exhaustion**
 Try different attack paths (completely new ones or new directions along each path) until you can't creatively come up with new directions and the attack tree is exhausted. Update attack-paths.json on every attempt.
 
 **[B-3.4] Verify Before Recording**
-Before writing a prediction result as confirmed or disproven, run the verification command (disassembly, grep, test execution) and include its output in the result field. A reference to a tool is not evidence — the output of the tool is.
+Before writing a prediction result as confirmed or disproven, run the verification command (disassembly, grep, test execution, SMT shim) and include its output in the result field. A reference to a tool is not evidence — the output of the tool is. For path-condition predictions on memory-corruption / arithmetic / bounds CWEs, the verification command IS [B-3.1.5]'s SMT call — its `feasible` verdict and `model` are the output that goes into `result`.
 
 **[B-3.5] PoC Development**
 For every finding that is not far-fetched, provide a full, end-to-end, step-by-step, harmless PoC exploit.

--- a/libexec/raptor-validation-helper
+++ b/libexec/raptor-validation-helper
@@ -1080,7 +1080,7 @@ def _bridge_understand_output(out_dir, checklist, target,
         detect stale files by comparing the understand run's hashes
         against current disk.
     """
-    from core.understand_bridge import (
+    from core.orchestration.understand_bridge import (
         find_understand_output, load_understand_context, enrich_checklist,
         _extract_hashes, _find_stale_files, _filter_context_map,
     )


### PR DESCRIPTION
Pre-fix Stage B's hypothesis loop had no SMT integration: only Stage E (memory corruption / binary feasibility) had explicit skill-bridge SMT calls. /agentic ran Tier 4 SMT post-hoc, but /validate operators in Stages A-D got nothing. Path conditions emerge naturally during Stage B's hypothesis formation (the "value-level predictions" the skill already requires); SMT verifies them deterministically; the verdict resolves what's currently a vibes-based PROXIMITY score into a checked one for the slice of CWEs Z3 can speak about.

Three skill-only changes in `stage-b-process.md`:

1. **[B-2] PROXIMITY** gains an SMT-derived rules table — refuted caps at 1, witness with named-locals floors at 6, witness with `_anon_N` is soft signal only (free-variable fallback over- approximates SAT), `null` no effect.

2. **New [B-3.1.5] SMT Pre-flight** between Input Verification and Attack Path Construction. Applies to memory-corruption / arithmetic / bounds CWEs. Lifts [E-3 SMT]'s decision table (which shim for which pattern) — same shim names, just earlier in the pipeline. Includes anon_var_map decoding (#458), parser-rejection list, profile-mismatch warning. When refuted, skip [B-3.2] (path doesn't exist); when witness'd, use the model as the [B-3.5] PoC seed.

3. **[B-3.4] Verify Before Recording** lists SMT shim alongside disassembly/grep/test-execution as evidence-producing tools.

Zero schema changes — verdicts land in existing `evidence_for` / `evidence_against` arrays as `"smt:refuted: ..."` / `"smt:witness: ..."` strings. Reuses substrate already shipped: `validate_path` API, named-verb shims, anon decoder, Stage E's prose.

Bundled drive-by: fixes a pre-existing ModuleNotFoundError in `libexec/raptor-validation-helper:1083` — the `core.understand_bridge` import wasn't updated when the module moved to
`core.orchestration.understand_bridge` in PR #231. Was blocking every Stage 0 invocation on origin/main; one-line fix.