### PR TITLE
feat(core/progress): add HackerProgressBar multi-stage display

### DIFF
--- a/core/progress/__init__.py
+++ b/core/progress/__init__.py
@@ -183,6 +183,226 @@ class HackerProgress:
         return False
 
 
+class HackerProgressBar:
+    """Multi-stage progress display for SCA-shaped pipelines.
+
+    Each stage gets a single self-rewriting line (cleared + reprinted
+    on each tick) showing the active stage name, an optional progress
+    bar, and a counter. When the stage completes, the line is
+    rewritten one final time to the stage's summary form and a
+    newline locks it in scrollback. The next ``stage()`` call begins
+    a fresh self-rewriting line below.
+
+    Finding-flash callouts (``flash()``) interleave: the active line
+    is cleared, the flash line is printed and locked, then the
+    active line is re-rendered below. The flash sticks in scrollback;
+    the active line continues advancing.
+
+    TTY-only by default (``disabled`` auto-set when stderr isn't a
+    TTY). Non-TTY path emits one start-line and one done-line per
+    stage with no redraws — friendly to pipes / CI logs / file
+    redirects.
+
+    Single-stage pipelines should use ``HackerProgress`` (above) —
+    that's the simpler operations >15s case. ``HackerProgressBar``
+    is for pipelines with N discrete phases the operator wants
+    to see resolve one by one.
+    """
+
+    _BLOCK_FULL = "▓" if _UNICODE_OK else "#"
+    _BLOCK_EMPTY = "░" if _UNICODE_OK else "."
+    _STAGE_GLYPH = "·"
+    _DONE_GLYPH = "✓" if _UNICODE_OK else "[OK]"
+    _FLASH_GLYPH = "↳" if _UNICODE_OK else "->"
+
+    def __init__(self, *, target: Optional[str] = None,
+                 disabled: Optional[bool] = None,
+                 stream=None,
+                 bar_width: int = 12):
+        self._stream = stream if stream is not None else sys.stderr
+        # Three modes:
+        #   "redraw"  — TTY: rewriting stage lines + flashes + ANSI
+        #   "oneline" — non-TTY: one finalised line per stage, no
+        #               ANSI, no flashes (CI logs / pipes / file
+        #               redirect)
+        #   "silent"  — operator opted out via disabled=True
+        if disabled is True:
+            self._mode = "silent"
+        elif disabled is False:
+            self._mode = "redraw"
+        else:
+            is_tty = getattr(self._stream, "isatty",
+                              lambda: False)()
+            self._mode = "redraw" if is_tty else "oneline"
+        # Back-compat: existing code paths read self._disabled to
+        # mean "anything but the rich redraw form" — both ``silent``
+        # and ``oneline`` skip ANSI / per-tick redraws / flashes.
+        # The fine-grained ``self._mode`` discriminates between
+        # them where it matters.
+        self._disabled = self._mode != "redraw"
+        self._target = str(target) if target is not None else None
+        self._bar_width = bar_width
+        # Per-stage state
+        self._stage: Optional[str] = None
+        self._stage_total: Optional[int] = None
+        self._stage_done: int = 0
+        self._stage_start: float = 0.0
+        self._stage_detail: str = ""
+        # Throttling — max ~10 Hz
+        self._last_redraw: float = 0.0
+        # Set when an active line is currently drawn and must be
+        # cleared before any new write to this stream.
+        self._line_active: bool = False
+        self._t0 = time.time()
+        # Header is emitted at construction so callers don't have to
+        # use ``with`` to get it — the SCA pipeline wires this in
+        # without re-indenting its 460-line body. The context-
+        # manager protocol still works for callers that want
+        # exception-safe finalisation. Suppressed in silent mode
+        # (operator opt-out) but emitted in oneline mode (CI logs
+        # benefit from the target prelude).
+        if self._mode != "silent" and self._target:
+            self._stream.write(f"sca > {self._target}\n")
+            self._stream.flush()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # Finalise any in-flight stage so the operator sees its
+        # detail rather than the bar.
+        if self._stage is not None:
+            self._finalise_stage(detail="interrupted"
+                                  if exc_type else self._stage_detail)
+        return False
+
+    def stage(self, name: str, total: Optional[int] = None) -> None:
+        """Begin a new stage. Finalises any prior in-flight stage."""
+        if self._stage is not None:
+            self._finalise_stage(detail=self._stage_detail)
+        self._stage = name
+        self._stage_total = total
+        self._stage_done = 0
+        self._stage_start = time.time()
+        self._stage_detail = ""
+        self._last_redraw = 0.0
+        self._render()
+
+    def tick(self, done: Optional[int] = None,
+             detail: str = "") -> None:
+        """Advance progress within the current stage. Throttled."""
+        if self._stage is None:
+            return
+        if done is not None:
+            self._stage_done = done
+        else:
+            self._stage_done += 1
+        if detail:
+            self._stage_detail = detail
+        if self._disabled:
+            return
+        now = time.time()
+        if now - self._last_redraw < 0.1:
+            return
+        self._last_redraw = now
+        self._render()
+
+    def flash(self, severity: str, message: str) -> None:
+        """Emit a callout above the active stage line."""
+        if self._disabled:
+            return
+        # Clear the active line, write the flash, leave a newline,
+        # then re-render the active stage line below.
+        self._clear_active_line()
+        sev = severity.upper()[:5]
+        self._stream.write(
+            f"      {self._FLASH_GLYPH} {sev:5s} {message}\n"
+        )
+        self._stream.flush()
+        self._render()
+
+    def done(self, summary: str = "") -> None:
+        """Finalise the current stage with a summary detail."""
+        if self._stage is None:
+            return
+        self._finalise_stage(detail=summary or self._stage_detail)
+
+    def end(self, summary: str = "") -> None:
+        """End all progress; print final summary footer."""
+        if self._stage is not None:
+            self._finalise_stage(detail=self._stage_detail)
+        if self._mode == "silent":
+            return
+        elapsed = time.time() - self._t0
+        mins = int(elapsed // 60)
+        secs = elapsed - mins * 60
+        elapsed_str = (f"{mins}m {secs:.0f}s" if mins
+                       else f"{secs:.1f}s")
+        self._stream.write(
+            f"  {self._DONE_GLYPH} done · {elapsed_str}"
+            + (f" · {summary}" if summary else "")
+            + "\n"
+        )
+        self._stream.flush()
+
+    # ----- internals -----
+
+    def _finalise_stage(self, *, detail: str) -> None:
+        if self._mode == "silent":
+            self._stage = None
+            return
+        if self._mode == "oneline":
+            # Non-TTY: emit a single line with the final detail.
+            self._stream.write(
+                f"  {self._STAGE_GLYPH} {self._stage:<12s} "
+                f"{detail or '...'}\n"
+            )
+            self._stream.flush()
+        else:
+            self._clear_active_line()
+            line = self._format_line(final=True, detail=detail)
+            self._stream.write(line + "\n")
+            self._stream.flush()
+        self._stage = None
+
+    def _render(self) -> None:
+        if self._disabled or self._stage is None:
+            return
+        self._clear_active_line()
+        self._stream.write(self._format_line(final=False))
+        self._stream.flush()
+        self._line_active = True
+
+    def _format_line(self, *, final: bool,
+                     detail: Optional[str] = None) -> str:
+        name = self._stage or ""
+        if final:
+            text = detail or "..."
+            return f"  {self._STAGE_GLYPH} {name:<12s} {text}"
+        if self._stage_total:
+            ratio = max(0.0, min(1.0, self._stage_done / self._stage_total))
+            filled = int(ratio * self._bar_width)
+            bar = (self._BLOCK_FULL * filled
+                   + self._BLOCK_EMPTY * (self._bar_width - filled))
+            return (
+                f"  {self._STAGE_GLYPH} {name:<12s} "
+                f"[{bar}] {self._stage_done}/{self._stage_total} "
+                f"({ratio*100:.0f}%)"
+                + (f" · {self._stage_detail}"
+                    if self._stage_detail else "")
+            )
+        # Indeterminate stage — just dots + detail.
+        return (
+            f"  {self._STAGE_GLYPH} {name:<12s} ..."
+            + (f" {self._stage_detail}" if self._stage_detail else "")
+        )
+
+    def _clear_active_line(self) -> None:
+        if self._line_active:
+            self._stream.write("\r\033[K")
+            self._line_active = False
+
+
 # Example usage:
 if __name__ == "__main__":
     # Test the progress counter

--- a/core/progress/tests/test_progress.py
+++ b/core/progress/tests/test_progress.py
@@ -6,7 +6,11 @@ import sys
 import unittest
 from unittest import mock
 
-from core.progress import HackerProgress, _stderr_supports_unicode
+from core.progress import (
+    HackerProgress,
+    HackerProgressBar,
+    _stderr_supports_unicode,
+)
 
 
 class CalculateETATest(unittest.TestCase):
@@ -72,6 +76,171 @@ class UnicodeProbeTest(unittest.TestCase):
         fake = mock.MagicMock(spec=[])  # No `encoding`.
         with mock.patch.object(sys, "stderr", fake):
             self.assertFalse(_stderr_supports_unicode())
+
+
+class _FakeTTY(io.StringIO):
+    """StringIO that claims to be a TTY for HackerProgressBar's
+    auto-disable detection."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+class HackerProgressBarTTYDetectionTest(unittest.TestCase):
+    def test_oneline_mode_when_stream_is_not_tty(self) -> None:
+        """Plain ``io.StringIO`` reports ``isatty()==False`` —
+        bar auto-selects ``oneline`` mode, emitting one line per
+        stage with no ANSI clear."""
+        buf = io.StringIO()
+        with HackerProgressBar(target="x", stream=buf) as bar:
+            bar.stage("discovery")
+            bar.tick()
+            bar.done(summary="3 manifests")
+        out = buf.getvalue()
+        self.assertNotIn("\x1b[", out)
+        self.assertIn("discovery", out)
+        self.assertIn("3 manifests", out)
+
+    def test_redraw_mode_when_stream_is_tty(self) -> None:
+        """TTY-shaped stream → bar enables redraw; ticks emit
+        ANSI clear sequences."""
+        buf = _FakeTTY()
+        with HackerProgressBar(target="x", stream=buf) as bar:
+            bar.stage("osv", total=10)
+            for i in range(11):
+                bar.tick(done=i)
+            bar.done(summary="0 vuln")
+        out = buf.getvalue()
+        self.assertIn("\x1b[", out)
+        self.assertIn("osv", out)
+
+
+class HackerProgressBarSilentModeTest(unittest.TestCase):
+    """``disabled=True`` (operator opt-out via ``--no-progress``)
+    must produce zero output. Distinct from non-TTY oneline mode
+    which still emits per-stage records suitable for CI logs."""
+
+    def test_disabled_true_emits_nothing(self) -> None:
+        buf = io.StringIO()
+        with HackerProgressBar(target="repo", disabled=True,
+                                stream=buf) as bar:
+            bar.stage("discovery")
+            bar.tick()
+            bar.flash("KEV", "CVE-2021-44228")
+            bar.done(summary="120 deps")
+            bar.stage("osv", total=10)
+            bar.tick(done=5)
+            bar.done(summary="14 vuln")
+            bar.end(summary="all good")
+        # Silent mode: not a single byte hits the stream.
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_disabled_true_suppresses_target_header(self) -> None:
+        """Even the ``sca > <target>`` prelude is suppressed when
+        the operator explicitly opts out."""
+        buf = io.StringIO()
+        bar = HackerProgressBar(target="repo", disabled=True,
+                                  stream=buf)
+        del bar
+        self.assertEqual(buf.getvalue(), "")
+
+
+class HackerProgressBarStageLifecycleTest(unittest.TestCase):
+    """Lifecycle behaviours — exercise the oneline (non-TTY auto)
+    path because it's deterministic to read back from a buffer."""
+
+    def test_oneline_emits_one_line_per_stage(self) -> None:
+        buf = io.StringIO()  # not a TTY → auto-selects oneline
+        with HackerProgressBar(target="repo", stream=buf) as bar:
+            bar.stage("discovery")
+            bar.done(summary="120 deps")
+            bar.stage("osv")
+            bar.done(summary="14 vuln")
+            bar.end(summary="all good")
+        lines = [l for l in buf.getvalue().splitlines() if l.strip()]
+        # Header + discovery + osv + done footer = 4 lines.
+        self.assertEqual(len(lines), 4)
+        self.assertIn("sca", lines[0])
+        self.assertIn("repo", lines[0])
+        self.assertIn("discovery", lines[1])
+        self.assertIn("120 deps", lines[1])
+        self.assertIn("osv", lines[2])
+        self.assertIn("14 vuln", lines[2])
+        self.assertIn("done", lines[3])
+        self.assertIn("all good", lines[3])
+
+    def test_stage_switch_finalises_prior_stage(self) -> None:
+        """Calling ``stage()`` twice without ``done()`` finalises
+        the previous one — operator never gets two stages
+        appearing simultaneously."""
+        buf = io.StringIO()
+        with HackerProgressBar(target=None, stream=buf) as bar:
+            bar.stage("discovery")
+            bar.stage("cascade")  # Implicit finalise of discovery.
+            bar.done(summary="ok")
+        out = buf.getvalue()
+        self.assertIn("discovery", out)
+        self.assertIn("cascade", out)
+
+    def test_exit_finalises_in_flight_stage(self) -> None:
+        """Context-manager exit cleans up an unfinished stage."""
+        buf = io.StringIO()
+        with HackerProgressBar(stream=buf) as bar:
+            bar.stage("reach")
+            bar.tick()
+            # No done() call — exit must still emit the line.
+        self.assertIn("reach", buf.getvalue())
+
+    def test_exit_with_exception_marks_stage_interrupted(self) -> None:
+        """If the body raises, the in-flight stage's final line
+        carries ``interrupted`` so the operator sees where it
+        died."""
+        buf = io.StringIO()
+        try:
+            with HackerProgressBar(stream=buf) as bar:
+                bar.stage("osv")
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+        self.assertIn("interrupted", buf.getvalue())
+
+
+class HackerProgressBarFlashTest(unittest.TestCase):
+    def test_flash_emitted_in_tty_mode(self) -> None:
+        buf = _FakeTTY()
+        with HackerProgressBar(disabled=False, stream=buf) as bar:
+            bar.stage("osv", total=100)
+            bar.tick(done=10)
+            bar.flash("KEV", "CVE-2021-44228 log4j-core@2.14.1")
+            bar.tick(done=20)
+            bar.done(summary="14 vuln")
+        out = buf.getvalue()
+        self.assertIn("KEV", out)
+        self.assertIn("CVE-2021-44228", out)
+
+    def test_flash_suppressed_in_oneline_mode(self) -> None:
+        """Non-TTY oneline mode suppresses flashes — they'd
+        interleave oddly with the per-stage one-line output and
+        ANSI-less CI logs already get the KEV count from the
+        stage detail."""
+        buf = io.StringIO()  # non-TTY → oneline
+        with HackerProgressBar(stream=buf) as bar:
+            bar.stage("osv")
+            bar.flash("KEV", "CVE-2021-44228")
+            bar.done(summary="ok")
+        self.assertNotIn("CVE-2021-44228", buf.getvalue())
+
+
+class HackerProgressBarTickThrottlingTest(unittest.TestCase):
+    def test_tick_advances_internal_counter_even_when_silent(self) -> None:
+        """Silent / oneline modes still count ticks for done()'s
+        summary, just don't render mid-stage."""
+        buf = io.StringIO()
+        with HackerProgressBar(disabled=True, stream=buf) as bar:
+            bar.stage("x", total=5)
+            for _ in range(3):
+                bar.tick()
+            self.assertEqual(bar._stage_done, 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a multi-stage progress class alongside the existing single-stage HackerProgress. Three-mode operation:
  - redraw   on TTY: rewriting stage line + KEV-style flashes + ANSI
  - oneline  on non-TTY auto: one finalised line per stage (CI logs)
  - silent   on disabled=True: zero output (operator opt-out)

Zero new deps, monochrome (no colour codes). Auto-disables on non-TTY stderr; explicit ``disabled=True`` is fully silent.

API: stage(name, total) / tick(done) / flash(severity, message) / done(summary) / end(summary). Context-manager protocol supports exception-safe finalisation.