### PR TITLE
feat(core/cve): EpssClient + KevClient — per-CVE signal layer

### DIFF
--- a/core/cve/__init__.py
+++ b/core/cve/__init__.py
@@ -1,0 +1,27 @@
+"""Per-CVE signal layer: EPSS, KEV.
+
+Shared substrate for any consumer that needs to enrich findings with
+CVE-keyed risk signals — SCA's vulnerable-dependency findings, but
+also ``/agentic`` ranking, ``/validate`` severity adjustment,
+``/exploit`` prioritisation, and SARIF / report badges. All clients
+take an injected :class:`core.http.HttpClient` and
+:class:`core.json.JsonCache` so consumers control the egress policy
+(allowlist via ``EgressClient``) and cache lifetime per their needs.
+
+The signal layer is deliberately scope-limited to PUBLIC CVE-keyed
+data. Corpus-backed signals (Exploit-DB, Metasploit, GitHub PoC
+indices) live elsewhere — they have data-distribution licensing
+constraints that don't fit a generic core utility. SCA's
+``exploit_evidence`` module bundles its calibration corpus and
+stays in ``packages/sca`` for that reason.
+
+OSV.dev is also out of scope here: ``packages/osv`` already
+provides the shared OSV client / parser / verdict types.
+``core/cve`` is for the per-CVE attribute layer (is this CVE in
+KEV? what's its EPSS score?), not for advisory aggregation.
+"""
+
+from core.cve.epss import EPSS_URL, EpssClient
+from core.cve.kev import KEV_URL, KevClient
+
+__all__ = ["EpssClient", "EPSS_URL", "KevClient", "KEV_URL"]

--- a/core/cve/epss.py
+++ b/core/cve/epss.py
@@ -1,0 +1,166 @@
+"""FIRST.org EPSS — exploit-prediction scores per CVE.
+
+EPSS publishes a daily probability that a CVE will be exploited in the
+wild within the next 30 days. We fetch scores per-CVE on demand and
+cache them for 24 hours.
+
+The endpoint accepts comma-separated CVE lists; we batch up to 100 IDs
+per request to keep URL length comfortable. Responses look like:
+
+    {
+      "data": [
+        {"cve": "CVE-2021-44228", "epss": "0.97559", "percentile": "0.99971"},
+        ...
+      ]
+    }
+
+EPSS coverage is incomplete — many advisories don't carry a CVE alias,
+and many CVEs have no EPSS score yet. ``score(cve)`` returns ``None`` in
+those cases; callers should treat ``None`` as "no signal", not "low risk".
+
+Originally written for ``packages/sca`` — lifted to ``core/cve`` so other
+consumers (``/agentic`` finding ranking, ``/validate`` Stage D severity,
+``/exploit`` prioritisation, SARIF report badges) can layer EPSS scores
+on top of any CVE-tagged finding without depending on SCA-specific code.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Iterable, List, Optional
+
+from core.json import JsonCache
+from core.http import HttpClient, HttpError
+
+logger = logging.getLogger(__name__)
+
+EPSS_URL = "https://api.first.org/data/v1/epss"
+_DEFAULT_TTL = 24 * 3600
+_BATCH_SIZE = 100
+
+
+class EpssClient:
+    """Per-CVE EPSS lookup with caching.
+
+    Caller-supplied ``HttpClient`` (so tests inject a stub) and
+    ``JsonCache`` (for the 24h per-CVE persistence). ``offline=True``
+    suppresses the network — fresh-cache hits still flow through;
+    everything else returns nothing.
+    """
+
+    def __init__(
+        self,
+        http: HttpClient,
+        cache: JsonCache,
+        *,
+        offline: bool = False,
+        ttl_seconds: int = _DEFAULT_TTL,
+    ) -> None:
+        self._http = http
+        self._cache = cache
+        self._offline = offline
+        self._ttl = ttl_seconds
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def scores(self, cves: Iterable[str]) -> Dict[str, float]:
+        """Return ``{cve: probability}`` for any IDs we can resolve.
+
+        Missing IDs (no EPSS coverage, network failure, etc.) are simply
+        absent from the dict. Callers should not assume completeness.
+        """
+        # Normalise + dedup.
+        clean = sorted({c.upper() for c in cves if isinstance(c, str) and c})
+        result: Dict[str, float] = {}
+        uncached: List[str] = []
+        for cve in clean:
+            cached = self._cache.get(self._key(cve), ttl_seconds=self._ttl)
+            if cached is None:
+                uncached.append(cve)
+                continue
+            score = _coerce_score(cached)
+            if score is not None:
+                result[cve] = score
+
+        if uncached and not self._offline:
+            for chunk in _chunked(uncached, _BATCH_SIZE):
+                fetched = self._fetch_chunk(chunk)
+                # Cache every requested CVE — even ones without coverage,
+                # using a sentinel so we don't refetch a known no-data row.
+                for cve in chunk:
+                    score = fetched.get(cve)
+                    self._cache.put(
+                        self._key(cve),
+                        score if score is not None else _NO_SCORE_SENTINEL,
+                        ttl_seconds=self._ttl,
+                    )
+                    if score is not None:
+                        result[cve] = score
+        return result
+
+    def score(self, cve: str) -> Optional[float]:
+        """Convenience: single-CVE lookup."""
+        return self.scores([cve]).get(cve.upper())
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _fetch_chunk(self, cves: List[str]) -> Dict[str, float]:
+        url = f"{EPSS_URL}?cve={','.join(cves)}"
+        try:
+            payload = self._http.get_json(url)
+        except HttpError as e:
+            logger.warning(
+                "core.cve.epss: chunk fetch failed (%s); leaving CVEs unresolved", e,
+            )
+            return {}
+        return _parse_response(payload)
+
+    @staticmethod
+    def _key(cve: str) -> str:
+        return f"epss/{cve}"
+
+
+# Marker stored when EPSS has no coverage for a CVE so we don't refetch.
+_NO_SCORE_SENTINEL = -1.0
+
+
+def _coerce_score(value: object) -> Optional[float]:
+    if isinstance(value, (int, float)):
+        if float(value) == _NO_SCORE_SENTINEL:
+            return None
+        return float(value)
+    return None
+
+
+def _parse_response(payload: object) -> Dict[str, float]:
+    if not isinstance(payload, dict):
+        return {}
+    data = payload.get("data")
+    if not isinstance(data, list):
+        return {}
+    out: Dict[str, float] = {}
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        cve = entry.get("cve")
+        score = entry.get("epss")
+        if not isinstance(cve, str):
+            continue
+        try:
+            score_f = float(score)            # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+        out[cve.upper()] = score_f
+    return out
+
+
+def _chunked(items: List[str], size: int):
+    for i in range(0, len(items), size):
+        yield items[i:i + size]
+
+
+__all__ = ["EpssClient", "EPSS_URL"]

--- a/core/cve/kev.py
+++ b/core/cve/kev.py
@@ -1,0 +1,120 @@
+"""CISA Known-Exploited Vulnerabilities (KEV) lookup.
+
+The full KEV catalog is one ~150 KB JSON document fetched from CISA. We
+download it once per run (24h cache), build an in-memory set of
+exploited CVE IDs, and answer ``contains(cve_id)`` in O(1).
+
+Failure modes:
+  * Network down + cold cache → ``KevClient.is_loaded()`` is False;
+    ``contains`` always returns False (degraded but harmless: KEV is a
+    bonus signal layered on top of any underlying CVE match).
+  * Stale cache + offline → load the cache anyway; the KEV list rarely
+    changes day-to-day.
+
+Originally written for ``packages/sca`` — lifted to ``core/cve`` so other
+consumers (``/agentic`` finding ranking, ``/validate`` Stage D severity,
+``/exploit`` prioritisation, SARIF report badges) can layer the
+KEV-listed flag on any CVE-tagged finding.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Set
+
+from core.json import JsonCache
+from core.http import HttpClient, HttpError
+
+logger = logging.getLogger(__name__)
+
+KEV_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+_DEFAULT_TTL = 24 * 3600
+_CACHE_KEY = "kev"
+
+
+class KevClient:
+    """In-memory KEV lookup; lazy-loads on first call.
+
+    Caller-supplied ``HttpClient`` (so tests inject a stub) and
+    ``JsonCache`` (for the 24h catalog persistence). ``offline=True``
+    suppresses the network — fresh-cache load still succeeds; cold
+    cache leaves ``contains`` returning False.
+    """
+
+    def __init__(
+        self,
+        http: HttpClient,
+        cache: JsonCache,
+        *,
+        offline: bool = False,
+        ttl_seconds: int = _DEFAULT_TTL,
+    ) -> None:
+        self._http = http
+        self._cache = cache
+        self._offline = offline
+        self._ttl = ttl_seconds
+        self._loaded = False
+        self._cve_set: Set[str] = set()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def contains(self, cve_id: str) -> bool:
+        """True if ``cve_id`` is in CISA's KEV list (case-insensitive)."""
+        if not cve_id:
+            return False
+        if not self._loaded:
+            self._load()
+        return cve_id.upper() in self._cve_set
+
+    def is_loaded(self) -> bool:
+        return self._loaded
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _load(self) -> None:
+        record = self._cache.get(_CACHE_KEY, ttl_seconds=self._ttl)
+        if record is None and not self._offline:
+            try:
+                record = self._http.get_json(KEV_URL)
+            except HttpError as e:
+                logger.warning("core.cve.kev: fetch failed (%s); KEV unavailable", e)
+                self._loaded = True
+                return
+            if isinstance(record, dict):
+                self._cache.put(_CACHE_KEY, record, ttl_seconds=self._ttl)
+        if record is None:
+            # Offline + cold cache.
+            self._loaded = True
+            return
+
+        self._cve_set = _extract_cves(record)
+        self._loaded = True
+
+
+def _extract_cves(record: object) -> Set[str]:
+    """Pull the CVE-id set from a KEV catalog payload.
+
+    Schema (relevant slice): ``{"vulnerabilities": [{"cveID": "CVE-..."},
+    ...]}``. Anything else is silently ignored; a corrupt feed yields an
+    empty set rather than a crash.
+    """
+    if not isinstance(record, dict):
+        return set()
+    vulns = record.get("vulnerabilities")
+    if not isinstance(vulns, list):
+        return set()
+    out: Set[str] = set()
+    for entry in vulns:
+        if not isinstance(entry, dict):
+            continue
+        cve = entry.get("cveID") or entry.get("cve_id")
+        if isinstance(cve, str) and cve:
+            out.add(cve.upper())
+    return out
+
+
+__all__ = ["KevClient", "KEV_URL"]

--- a/core/cve/tests/test_epss.py
+++ b/core/cve/tests/test_epss.py
@@ -1,0 +1,250 @@
+"""Tests for ``core.cve.epss.EpssClient``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from core.cve.epss import EPSS_URL, EpssClient
+from core.http import HttpError
+from core.json import JsonCache
+
+
+class FakeHttp:
+    """Stub ``HttpClient`` that returns a canned payload (or raises)."""
+
+    def __init__(self, payload: Dict[str, Any] | None = None,
+                 error: Exception | None = None) -> None:
+        self.payload = payload
+        self.error = error
+        self.gets: list[str] = []
+
+    def post_json(self, *a, **k):
+        raise NotImplementedError
+
+    def get_json(self, url: str, timeout: int = 30) -> dict:
+        self.gets.append(url)
+        if self.error:
+            raise self.error
+        return self.payload or {}
+
+    def get_bytes(self, *a, **k):
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Basic lookup
+# ---------------------------------------------------------------------------
+
+
+class TestEpssBasic:
+    def test_basic_lookup(self, tmp_path: Path) -> None:
+        payload = {"data": [{"cve": "CVE-2021-44228", "epss": "0.97559"}]}
+        http = FakeHttp(payload=payload)
+        epss = EpssClient(http, JsonCache(root=tmp_path))
+        assert epss.scores(["CVE-2021-44228"]) == {"CVE-2021-44228": 0.97559}
+
+    def test_score_convenience(self, tmp_path: Path) -> None:
+        payload = {"data": [{"cve": "CVE-2021-44228", "epss": "0.97559"}]}
+        epss = EpssClient(
+            FakeHttp(payload=payload), JsonCache(root=tmp_path),
+        )
+        assert epss.score("CVE-2021-44228") == 0.97559
+
+    def test_missing_cve_omitted_from_result(self, tmp_path: Path) -> None:
+        payload = {"data": []}
+        epss = EpssClient(
+            FakeHttp(payload=payload), JsonCache(root=tmp_path),
+        )
+        assert epss.scores(["CVE-9999-99999"]) == {}
+
+    def test_dedup_normalises_case(self, tmp_path: Path) -> None:
+        payload = {"data": [{"cve": "CVE-2021-44228", "epss": "0.97"}]}
+        http = FakeHttp(payload=payload)
+        epss = EpssClient(http, JsonCache(root=tmp_path))
+        epss.scores(["CVE-2021-44228", "cve-2021-44228"])
+        # Only one CVE in the URL.
+        assert http.gets[0].count("CVE-2021-44228") == 1
+
+
+# ---------------------------------------------------------------------------
+# Caching
+# ---------------------------------------------------------------------------
+
+
+class TestEpssCaching:
+    def test_warm_cache_skips_network(self, tmp_path: Path) -> None:
+        cache = JsonCache(root=tmp_path)
+        payload = {"data": [{"cve": "CVE-2021-44228", "epss": "0.97559"}]}
+        EpssClient(FakeHttp(payload=payload), cache).scores(
+            ["CVE-2021-44228"],
+        )
+        http2 = FakeHttp(payload={})
+        epss2 = EpssClient(http2, cache)
+        assert epss2.scores(["CVE-2021-44228"]) == {
+            "CVE-2021-44228": 0.97559,
+        }
+        assert http2.gets == []
+
+    def test_no_score_sentinel_avoids_refetch(
+        self, tmp_path: Path,
+    ) -> None:
+        """A CVE the API has no data for is cached as a sentinel so
+        the next run doesn't refetch it."""
+        cache = JsonCache(root=tmp_path)
+        EpssClient(
+            FakeHttp(payload={"data": []}), cache,
+        ).scores(["CVE-X"])
+        http2 = FakeHttp(
+            payload={"data": [{"cve": "CVE-X", "epss": "0.5"}]},
+        )
+        epss2 = EpssClient(http2, cache)
+        # Sentinel is honoured: empty result, no network call.
+        assert epss2.scores(["CVE-X"]) == {}
+        assert http2.gets == []
+
+    def test_offline_cold_cache_returns_empty(
+        self, tmp_path: Path,
+    ) -> None:
+        http = FakeHttp(error=HttpError("should not be called"))
+        epss = EpssClient(
+            http, JsonCache(root=tmp_path), offline=True,
+        )
+        assert epss.scores(["CVE-2021-44228"]) == {}
+        assert http.gets == []
+
+
+# ---------------------------------------------------------------------------
+# Batching
+# ---------------------------------------------------------------------------
+
+
+class TestEpssBatching:
+    def test_batch_chunking_caps_url_length(
+        self, tmp_path: Path,
+    ) -> None:
+        payload = {"data": [
+            {"cve": f"CVE-2021-{i:05d}", "epss": "0.5"}
+            for i in range(150)
+        ]}
+        http = FakeHttp(payload=payload)
+        epss = EpssClient(http, JsonCache(root=tmp_path))
+        epss.scores([f"CVE-2021-{i:05d}" for i in range(150)])
+        # Default batch size is 100 → exactly 2 chunked GET calls.
+        assert len(http.gets) == 2
+
+    def test_each_chunk_uses_epss_url(self, tmp_path: Path) -> None:
+        payload = {"data": [
+            {"cve": f"CVE-2021-{i:05d}", "epss": "0.5"}
+            for i in range(50)
+        ]}
+        http = FakeHttp(payload=payload)
+        epss = EpssClient(http, JsonCache(root=tmp_path))
+        epss.scores([f"CVE-2021-{i:05d}" for i in range(50)])
+        assert http.gets[0].startswith(EPSS_URL)
+
+
+# ---------------------------------------------------------------------------
+# Error / malformed response handling
+# ---------------------------------------------------------------------------
+
+
+class TestEpssErrors:
+    def test_network_error_returns_empty(self, tmp_path: Path) -> None:
+        epss = EpssClient(
+            FakeHttp(error=HttpError("boom")),
+            JsonCache(root=tmp_path),
+        )
+        assert epss.scores(["CVE-2021-44228"]) == {}
+
+    def test_invalid_score_skipped(self, tmp_path: Path) -> None:
+        payload = {"data": [
+            {"cve": "CVE-A", "epss": "not-a-number"},
+            {"cve": "CVE-B", "epss": "0.5"},
+        ]}
+        epss = EpssClient(
+            FakeHttp(payload=payload), JsonCache(root=tmp_path),
+        )
+        assert epss.scores(["CVE-A", "CVE-B"]) == {"CVE-B": 0.5}
+
+    def test_non_dict_response_returns_empty(self, tmp_path: Path) -> None:
+        http = FakeHttp(payload="not a dict")  # type: ignore[arg-type]
+        epss = EpssClient(http, JsonCache(root=tmp_path))
+        assert epss.scores(["CVE-A"]) == {}
+
+    def test_non_list_data_returns_empty(self, tmp_path: Path) -> None:
+        http = FakeHttp(payload={"data": "not a list"})
+        epss = EpssClient(http, JsonCache(root=tmp_path))
+        assert epss.scores(["CVE-A"]) == {}
+
+    def test_non_dict_entries_skipped(self, tmp_path: Path) -> None:
+        payload = {"data": [
+            "string entry",
+            42,
+            None,
+            {"cve": "CVE-OK", "epss": "0.5"},
+        ]}
+        epss = EpssClient(
+            FakeHttp(payload=payload), JsonCache(root=tmp_path),
+        )
+        assert epss.scores(["CVE-OK"]) == {"CVE-OK": 0.5}
+
+    def test_non_string_cve_field_skipped(self, tmp_path: Path) -> None:
+        payload = {"data": [
+            {"cve": 12345, "epss": "0.9"},
+            {"cve": "CVE-OK", "epss": "0.5"},
+        ]}
+        epss = EpssClient(
+            FakeHttp(payload=payload), JsonCache(root=tmp_path),
+        )
+        assert epss.scores(["CVE-OK"]) == {"CVE-OK": 0.5}
+
+
+# ---------------------------------------------------------------------------
+# Hostile / adversarial inputs
+# ---------------------------------------------------------------------------
+
+
+class TestEpssAdversarial:
+    def test_empty_input_returns_empty(self, tmp_path: Path) -> None:
+        http = FakeHttp(payload={"data": []})
+        epss = EpssClient(http, JsonCache(root=tmp_path))
+        assert epss.scores([]) == {}
+        assert http.gets == []
+
+    def test_non_string_input_filtered(self, tmp_path: Path) -> None:
+        http = FakeHttp(payload={"data": []})
+        epss = EpssClient(http, JsonCache(root=tmp_path))
+        # ints / None / empty strings get filtered before the API call.
+        epss.scores([None, "", 0, "CVE-VALID"])  # type: ignore[list-item]
+        # One GET, one CVE in the URL.
+        assert len(http.gets) == 1
+        assert "CVE-VALID" in http.gets[0]
+        assert "None" not in http.gets[0]
+
+    def test_huge_cve_id_does_not_crash(self, tmp_path: Path) -> None:
+        # 100KB CVE id — gets uppercased + URL-included; doesn't blow
+        # up the client or the (mocked) HTTP layer.
+        big_cve = "CVE-" + "9" * 100_000
+        epss = EpssClient(
+            FakeHttp(payload={"data": []}), JsonCache(root=tmp_path),
+        )
+        # Doesn't raise.
+        result = epss.scores([big_cve])
+        assert result == {}
+
+    def test_mixed_case_cves_normalised_in_cache(
+        self, tmp_path: Path,
+    ) -> None:
+        cache = JsonCache(root=tmp_path)
+        EpssClient(
+            FakeHttp(payload={"data": [{"cve": "CVE-1", "epss": "0.5"}]}),
+            cache,
+        ).scores(["cve-1"])
+        # Cache hit on the upper-case key — second call no network.
+        http2 = FakeHttp(payload={})
+        epss2 = EpssClient(http2, cache)
+        assert epss2.scores(["CVE-1"]) == {"CVE-1": 0.5}
+        assert http2.gets == []

--- a/core/cve/tests/test_kev.py
+++ b/core/cve/tests/test_kev.py
@@ -1,0 +1,200 @@
+"""Tests for ``core.cve.kev.KevClient``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from core.cve.kev import KEV_URL, KevClient
+from core.http import HttpError
+from core.json import JsonCache
+
+
+class FakeHttp:
+    """Stub ``HttpClient`` that returns a canned payload (or raises)."""
+
+    def __init__(self, payload: Dict[str, Any] | None = None,
+                 error: Exception | None = None) -> None:
+        self.payload = payload
+        self.error = error
+        self.gets: list[str] = []
+
+    def post_json(self, *a, **k):
+        raise NotImplementedError
+
+    def get_json(self, url: str, timeout: int = 30) -> dict:
+        self.gets.append(url)
+        if self.error:
+            raise self.error
+        return self.payload or {}
+
+    def get_bytes(self, *a, **k):
+        raise NotImplementedError
+
+
+_PAYLOAD = {
+    "vulnerabilities": [
+        {"cveID": "CVE-2021-44228", "vendorProject": "Apache"},
+        {"cveID": "CVE-2017-5638"},
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Basic lookup
+# ---------------------------------------------------------------------------
+
+
+class TestKevBasic:
+    def test_contains_known_cve(self, tmp_path: Path) -> None:
+        http = FakeHttp(payload=_PAYLOAD)
+        kev = KevClient(http, JsonCache(root=tmp_path))
+        assert kev.contains("CVE-2021-44228") is True
+        assert kev.contains("cve-2021-44228") is True   # case-insensitive
+        assert kev.contains("CVE-9999-99999") is False
+
+    def test_contains_loads_lazily(self, tmp_path: Path) -> None:
+        http = FakeHttp(payload=_PAYLOAD)
+        kev = KevClient(http, JsonCache(root=tmp_path))
+        assert kev.is_loaded() is False
+        assert http.gets == []
+        kev.contains("CVE-2021-44228")
+        assert kev.is_loaded() is True
+        assert http.gets == [KEV_URL]
+
+    def test_alternate_cve_id_field(self, tmp_path: Path) -> None:
+        # Older snapshots use ``cve_id`` instead of ``cveID``.
+        payload = {"vulnerabilities": [{"cve_id": "CVE-2020-0001"}]}
+        kev = KevClient(
+            FakeHttp(payload=payload), JsonCache(root=tmp_path),
+        )
+        assert kev.contains("CVE-2020-0001") is True
+
+
+# ---------------------------------------------------------------------------
+# Caching
+# ---------------------------------------------------------------------------
+
+
+class TestKevCaching:
+    def test_warm_cache_skips_network(self, tmp_path: Path) -> None:
+        cache = JsonCache(root=tmp_path)
+        http1 = FakeHttp(payload=_PAYLOAD)
+        KevClient(http1, cache).contains("CVE-2021-44228")
+        http2 = FakeHttp(payload={})    # would fail to find anything
+        kev2 = KevClient(http2, cache)
+        assert kev2.contains("CVE-2021-44228") is True
+        assert http2.gets == []
+
+    def test_offline_cold_cache_returns_false(
+        self, tmp_path: Path,
+    ) -> None:
+        http = FakeHttp(error=HttpError("should not be called"))
+        kev = KevClient(
+            http, JsonCache(root=tmp_path), offline=True,
+        )
+        assert kev.contains("CVE-2021-44228") is False
+        assert http.gets == []
+
+
+# ---------------------------------------------------------------------------
+# Error / malformed handling
+# ---------------------------------------------------------------------------
+
+
+class TestKevErrors:
+    def test_network_error_degrades_gracefully(
+        self, tmp_path: Path,
+    ) -> None:
+        http = FakeHttp(error=HttpError("offline"))
+        kev = KevClient(http, JsonCache(root=tmp_path))
+        assert kev.contains("CVE-2021-44228") is False
+        assert kev.is_loaded() is True
+
+    def test_malformed_payload_yields_empty_set(
+        self, tmp_path: Path,
+    ) -> None:
+        http = FakeHttp(payload={"unexpected": "shape"})
+        kev = KevClient(http, JsonCache(root=tmp_path))
+        assert kev.contains("CVE-2021-44228") is False
+        assert kev.is_loaded() is True
+
+    def test_non_dict_response_yields_empty_set(
+        self, tmp_path: Path,
+    ) -> None:
+        http = FakeHttp(payload="not a dict")  # type: ignore[arg-type]
+        kev = KevClient(http, JsonCache(root=tmp_path))
+        assert kev.contains("CVE-2021-44228") is False
+
+    def test_non_list_vulnerabilities_yields_empty_set(
+        self, tmp_path: Path,
+    ) -> None:
+        http = FakeHttp(payload={"vulnerabilities": "not a list"})
+        kev = KevClient(http, JsonCache(root=tmp_path))
+        assert kev.contains("CVE-2021-44228") is False
+
+    def test_non_dict_entries_skipped(self, tmp_path: Path) -> None:
+        payload = {"vulnerabilities": [
+            "string entry",
+            42,
+            None,
+            {"cveID": "CVE-OK"},
+        ]}
+        kev = KevClient(
+            FakeHttp(payload=payload), JsonCache(root=tmp_path),
+        )
+        assert kev.contains("CVE-OK") is True
+
+    def test_non_string_cve_id_skipped(self, tmp_path: Path) -> None:
+        payload = {"vulnerabilities": [
+            {"cveID": 12345},
+            {"cveID": "CVE-OK"},
+        ]}
+        kev = KevClient(
+            FakeHttp(payload=payload), JsonCache(root=tmp_path),
+        )
+        assert kev.contains("CVE-OK") is True
+
+
+# ---------------------------------------------------------------------------
+# Hostile / adversarial inputs
+# ---------------------------------------------------------------------------
+
+
+class TestKevAdversarial:
+    def test_empty_id_returns_false(self, tmp_path: Path) -> None:
+        kev = KevClient(
+            FakeHttp(payload=_PAYLOAD), JsonCache(root=tmp_path),
+        )
+        assert kev.contains("") is False
+        # No network fetch when the input is empty.
+        assert kev.is_loaded() is False
+
+    def test_huge_cve_id_does_not_crash(self, tmp_path: Path) -> None:
+        big_cve = "CVE-" + "9" * 100_000
+        kev = KevClient(
+            FakeHttp(payload=_PAYLOAD), JsonCache(root=tmp_path),
+        )
+        # Lazy-load fires; doesn't crash; not in payload.
+        assert kev.contains(big_cve) is False
+
+    def test_payload_with_huge_vuln_list(self, tmp_path: Path) -> None:
+        # 10K entries — set construction is O(N), no quadratic
+        # behaviour.
+        payload = {"vulnerabilities": [
+            {"cveID": f"CVE-2020-{i:05d}"} for i in range(10_000)
+        ]}
+        http = FakeHttp(payload=payload)
+        kev = KevClient(http, JsonCache(root=tmp_path))
+        assert kev.contains("CVE-2020-00000") is True
+        assert kev.contains("CVE-2020-09999") is True
+        assert kev.contains("CVE-2020-10000") is False
+
+    def test_unicode_cve_id_does_not_crash(self, tmp_path: Path) -> None:
+        kev = KevClient(
+            FakeHttp(payload=_PAYLOAD), JsonCache(root=tmp_path),
+        )
+        # Unicode lookup — not in the catalog; doesn't crash.
+        assert kev.contains("CVE-2020-Ω") is False


### PR DESCRIPTION
Lifts the EPSS and KEV clients out of feat/sca's
``packages/sca/`` into a shared core utility so any consumer needing per-CVE risk signals can use them without depending on SCA's vulnerable-dependency-finding flow.

Use cases enabled (each is its own follow-up wiring PR):
  * /agentic finding ranking — EPSS percentile per CVE-tagged finding
  * /validate Stage D severity — bump for KEV-listed CVEs
  * /exploit prioritisation — operator-facing rank by EPSS+KEV
  * SARIF / report — EPSS percentile + KEV badge per finding

Substrate ported from feat/sca:
  * core/cve/epss.py  — EpssClient: FIRST.org per-CVE batch lookup, 24h cache, 100-per-batch chunking, no-data sentinel, offline mode.
  * core/cve/kev.py   — KevClient: CISA catalog, 24h cache,
                         O(1) contains check, lazy-load on
                         first call.
  * core/cve/__init__.py — re-exports + scope docstring.

Both clients take an injected ``HttpClient`` (so consumers control egress policy via ``EgressClient``) and ``JsonCache`` (so consumers control cache lifetime). Network failures and malformed responses degrade gracefully — empty result, never exception.

Tests (34): basic lookup, caching, batching, network/malformed errors, hostile inputs (huge IDs, non-string CVE fields, non-dict payloads, 10K-entry catalogs). All ported from feat/sca's existing test coverage with adversarial additions.

4696 tests pass under CI-equivalent invocation across core/.