### PR TITLE
feat(/validate): Stage C structural pre-check via Coccinelle

### DIFF
--- a/.claude/skills/exploitability-validation/stage-c-sanity.md
+++ b/.claude/skills/exploitability-validation/stage-c-sanity.md
@@ -30,6 +30,14 @@ libexec/raptor-validation-helper C "$OUTPUT_DIR"
 
 Findings where `checklist_verified` is false have already failed — investigate the path/line mismatch before proceeding with reasoning checks.
 
+For C/C++ targets, the prep script also annotates each finding with `cocci_prereqs` — mechanical structural facts (function-exists, function-has-callers) derived from the shipped `function_inventory.cocci` rule. Treat these as evidence supporting your sanity check:
+
+- `cocci_prereqs.checks.function_exists == false` → the function the finding names is NOT a real C function definition in the tree. Strong signal the LLM hallucinated a macro/typedef/forward-decl as a function. Investigate before passing.
+- `cocci_prereqs.checks.function_has_callers == false` (with `function_exists == true`) → orphan static helper or dead code. Cross-reference with the call chain in the finding's flow.
+- `cocci_prereqs.applicable == false` → the check didn't run (non-C file, spatch absent, or finding had no `function` field). No evidence either way.
+
+These facts are advisory — they DO NOT decide finding status. They flag cases worth investigating; your verbatim-code read is still the source of truth.
+
 ---
 
 ## Task

--- a/engine/coccinelle/prereqs/function_inventory.cocci
+++ b/engine/coccinelle/prereqs/function_inventory.cocci
@@ -1,0 +1,56 @@
+// function_inventory.cocci — emit two record kinds for the validation
+// Stage C structural pre-check:
+//   * "def:<name>" at every function definition
+//   * "call:<name>" at every call site that is NOT a definition
+//
+// The Python ``prereqs`` module derives:
+//   * function_exists(name): finding's claimed function is a real C
+//     function in the tree (not a macro the LLM hallucinated as one)
+//   * function_has_callers(name): function is called from somewhere
+//     other than itself (orphan-static-helper detection)
+//
+// The rule is intentionally narrow — defs and calls only. Anything
+// richer (taint, escape, scope shadowing) overlaps with CodeQL or
+// belongs in the LLM stages.
+
+@fdef@
+identifier f;
+position p;
+@@
+
+f@p(...)
+{
+  ...
+}
+
+@script:python@
+p << fdef.p;
+f << fdef.f;
+@@
+import json, sys
+for _p in p:
+    _m = {"file": _p.file, "line": int(_p.line),
+          "rule": "function_inventory",
+          "message": "def:" + str(f)}
+    sys.stderr.write("COCCIRESULT:" + json.dumps(_m) + "\n")
+
+// Match call sites whose position is NOT one of the definition
+// positions — otherwise ``f(...)`` in the def header would match
+// here too and inflate the caller count.
+@fcall@
+identifier g;
+position q != fdef.p;
+@@
+
+g@q(...)
+
+@script:python@
+q << fcall.q;
+g << fcall.g;
+@@
+import json, sys
+for _q in q:
+    _m = {"file": _q.file, "line": int(_q.line),
+          "rule": "function_inventory",
+          "message": "call:" + str(g)}
+    sys.stderr.write("COCCIRESULT:" + json.dumps(_m) + "\n")

--- a/libexec/raptor-validation-helper
+++ b/libexec/raptor-validation-helper
@@ -661,10 +661,73 @@ def prepare_C(workdir, target=None):
         else:
             finding["checklist_verified"] = True
 
+    # --- Cocci structural pre-check (C/C++ targets) ---
+    # Mechanical structural facts: function-exists, function-has-callers.
+    # Stage C reasoning consults these as evidence; finding status is
+    # NEVER overwritten here. Skips silently on non-C/C++ targets,
+    # missing spatch, or absent prereqs rules dir — no operator noise
+    # when prerequisites aren't met.
+    _run_cocci_prereqs(workdir, findings_data, target=target)
+
     _save_findings(workdir, findings_data)
     failed = sum(1 for f in findings_data["findings"] if f.get("checklist_verified") is False)
     print(f"Inventory check: {failed} failed, {len(findings_data['findings']) - failed} passed")
     _print_schema_hint("C")
+
+
+def _run_cocci_prereqs(workdir, findings_data, target=None):
+    """Stage C structural pre-check via Coccinelle.
+
+    Runs the shipped function-inventory rule across the target ONCE
+    and annotates each finding with ``cocci_prereqs``. The Stage C
+    LLM consults these mechanical facts as evidence — they do not
+    decide finding status.
+
+    Skip cases (silent):
+      * target arg missing or path not a directory
+      * spatch absent / target has no C/C++ source / shipped rules
+        dir missing — handled by ``gather_prereqs`` itself
+    """
+    if not target:
+        return
+    target_path = Path(target)
+    if not target_path.is_dir():
+        return
+    try:
+        from packages.coccinelle.prereqs import (
+            evaluate_finding as _cocci_evaluate,
+            gather_prereqs as _cocci_gather,
+        )
+    except ImportError:
+        # packages/coccinelle absent (minimal install) — nothing to do.
+        return
+
+    facts = _cocci_gather(target_path)
+    if facts.is_skipped:
+        # The skip reason is informational; surface at debug volume
+        # only — operators expect silence when prerequisites aren't met.
+        return
+
+    flagged = 0
+    for finding in findings_data.get("findings", []):
+        if finding.get("status") == "disproven":
+            continue
+        result = _cocci_evaluate(finding, facts)
+        finding["cocci_prereqs"] = result
+        # Surface only the orphan-static-helper case at INFO volume.
+        # function_exists=False on libc symbols is normal noise; we
+        # don't want to print it for every finding referencing strlen.
+        if (result.get("applicable")
+                and result["checks"].get("function_exists") is True
+                and result["checks"].get("function_has_callers") is False):
+            flagged += 1
+            print(
+                f"  C-cocci WARN: {finding['id']} — function "
+                f"{result['details'].get('function')!r} has no callers "
+                f"in tree (orphan-static-helper or dead code)"
+            )
+    total = len(findings_data.get("findings", []))
+    print(f"Cocci structural pre-check: {flagged} orphan-fn warnings across {total} findings")
 
 
 # ---------------------------------------------------------------------------

--- a/packages/coccinelle/prereqs.py
+++ b/packages/coccinelle/prereqs.py
@@ -1,0 +1,201 @@
+"""Stage C structural pre-checks via Coccinelle.
+
+Runs a small set of cocci rules across the target ONCE, builds a
+``PrereqFacts`` map (function defs + call sites), then evaluates each
+finding against those facts. This is mechanical evidence the LLM
+reasoning at Stage C/D consults — it does NOT decide finding status
+on its own.
+
+Skip-silently semantics match the ``/scan`` cocci leg:
+  * spatch absent → no facts (skipped)
+  * target has no C/C++ source → no facts (skipped)
+  * shipped prereqs rules dir missing → no facts (skipped)
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from .runner import is_available as spatch_available
+from .runner import run_rules as spatch_run_rules
+
+
+# Re-exported for callers that want to skip prereqs on pure-Python /
+# pure-JS targets without re-implementing the heuristic. Same set as
+# the /scan cocci leg's ``_repo_has_c_cpp_source``.
+_C_CPP_EXTS: Tuple[str, ...] = (".c", ".h", ".cc", ".cpp", ".cxx", ".hpp", ".hh")
+
+
+def _shipped_prereqs_rules_dir() -> Optional[Path]:
+    """Resolve the in-tree shipped prereqs rules dir, or None if
+    missing (minimal install / packaging strip)."""
+    here = Path(__file__).resolve()
+    # packages/coccinelle/prereqs.py → repo root → engine/coccinelle/prereqs/
+    candidate = here.parents[2] / "engine" / "coccinelle" / "prereqs"
+    return candidate if candidate.is_dir() else None
+
+
+def _has_c_cpp_source(repo_path: Path, max_files: int = 200) -> bool:
+    """Bounded heuristic: any C/C++ source under ``repo_path``?"""
+    if not repo_path.is_dir():
+        return False
+    seen = 0
+    for entry in repo_path.rglob("*"):
+        if not entry.is_file():
+            continue
+        seen += 1
+        if entry.suffix.lower() in _C_CPP_EXTS:
+            return True
+        if seen >= max_files:
+            return False
+    return False
+
+
+@dataclass
+class PrereqFacts:
+    """Structural facts derived from the function-inventory rule.
+
+    ``defs``: function name → set of (file, line) where defined.
+    ``calls``: function name → set of (file, line) where called.
+
+    Both maps key on the bare function name as it appears in source.
+    Aliasing / renaming / pointer-call indirection is out of scope —
+    cocci only sees the syntactic form.
+    """
+
+    defs: Dict[str, Set[Tuple[str, int]]] = field(default_factory=dict)
+    calls: Dict[str, Set[Tuple[str, int]]] = field(default_factory=dict)
+    skipped_reason: Optional[str] = None
+
+    @property
+    def is_skipped(self) -> bool:
+        return self.skipped_reason is not None
+
+    def function_exists(self, name: str) -> bool:
+        return name in self.defs
+
+    def function_has_callers(self, name: str) -> bool:
+        return name in self.calls and len(self.calls[name]) > 0
+
+    def callers_of(self, name: str) -> List[Tuple[str, int]]:
+        return sorted(self.calls.get(name, set()))
+
+
+def gather_prereqs(
+    target: Path,
+    rules_dir: Optional[Path] = None,
+    timeout_per_rule: int = 300,
+) -> PrereqFacts:
+    """Run shipped prereq rules against ``target`` and build facts.
+
+    Returns ``PrereqFacts`` with ``skipped_reason`` set when the run
+    is skipped (caller treats this as "no structural evidence
+    available"; it is NOT an error).
+    """
+    target = Path(target)
+
+    if not spatch_available():
+        return PrereqFacts(skipped_reason="spatch_not_available")
+    if not _has_c_cpp_source(target):
+        return PrereqFacts(skipped_reason="no_c_cpp_source")
+
+    effective_rules_dir = rules_dir if rules_dir else _shipped_prereqs_rules_dir()
+    if effective_rules_dir is None:
+        return PrereqFacts(skipped_reason="rules_dir_missing")
+
+    results = spatch_run_rules(
+        target=target,
+        rules_dir=effective_rules_dir,
+        timeout_per_rule=timeout_per_rule,
+        no_includes=True,  # operator targets are untrusted
+    )
+
+    facts = PrereqFacts()
+    for r in results:
+        for m in r.matches:
+            msg = (m.message or "").strip()
+            if msg.startswith("def:"):
+                name = msg[4:].strip()
+                facts.defs.setdefault(name, set()).add((m.file, int(m.line)))
+            elif msg.startswith("call:"):
+                name = msg[5:].strip()
+                facts.calls.setdefault(name, set()).add((m.file, int(m.line)))
+            # Other message shapes (future rule additions) are
+            # ignored here — the consumer may grow checks; this
+            # gather pass stays neutral.
+    return facts
+
+
+def evaluate_finding(
+    finding: Dict[str, Any],
+    facts: PrereqFacts,
+) -> Dict[str, Any]:
+    """Per-finding mechanical evaluation against the prereq facts.
+
+    Returns a dict suitable for ``finding["cocci_prereqs"]``.
+
+    Output shape:
+      {
+        "applicable": bool,    # False when prereqs were skipped
+                               # OR finding's file isn't C/C++.
+        "checks": {
+          "function_exists": bool | null,
+          "function_has_callers": bool | null,
+        },
+        "details": {           # only populated when checks ran
+          "function": str,
+          "callers_count": int,
+        },
+        "skipped_reason": str | null,
+      }
+
+    Stage C reasoning consults this; Stage D may use it as evidence
+    in attack-tree disposition. Status of the finding is NEVER
+    overwritten here — these are facts, not verdicts.
+    """
+    out: Dict[str, Any] = {
+        "applicable": False,
+        "checks": {
+            "function_exists": None,
+            "function_has_callers": None,
+        },
+        "details": {},
+        "skipped_reason": None,
+    }
+
+    if facts.is_skipped:
+        out["skipped_reason"] = facts.skipped_reason
+        return out
+
+    func_name = (finding.get("function") or "").strip()
+    file_path = (finding.get("file") or "").strip()
+
+    # Bail when there's nothing to check or the file isn't C-family.
+    # Findings on .py / .js / .go are skipped (cocci is C-only).
+    if not func_name:
+        out["skipped_reason"] = "finding_missing_function"
+        return out
+    if file_path:
+        ext = os.path.splitext(file_path)[1].lower()
+        if ext and ext not in _C_CPP_EXTS:
+            out["skipped_reason"] = "non_c_cpp_file"
+            return out
+
+    out["applicable"] = True
+    exists = facts.function_exists(func_name)
+    has_callers = facts.function_has_callers(func_name) if exists else None
+
+    out["checks"]["function_exists"] = exists
+    # function_has_callers is only meaningful if the function exists.
+    # When the function isn't defined locally (e.g. libc symbol), we
+    # leave the caller check as null rather than asserting False.
+    out["checks"]["function_has_callers"] = has_callers
+
+    out["details"]["function"] = func_name
+    if exists:
+        out["details"]["callers_count"] = len(facts.calls.get(func_name, set()))
+
+    return out

--- a/packages/coccinelle/tests/test_prereqs.py
+++ b/packages/coccinelle/tests/test_prereqs.py
@@ -1,0 +1,295 @@
+"""Tests for ``packages.coccinelle.prereqs``.
+
+Unit coverage for the gather/evaluate split + 1 real-spatch E2E that
+runs the shipped ``function_inventory.cocci`` against a tiny C
+fixture and verifies the orphan-static-helper detection works
+end-to-end.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_RAPTOR_DIR = os.environ["RAPTOR_DIR"]
+if _RAPTOR_DIR not in sys.path:
+    sys.path.insert(0, _RAPTOR_DIR)
+
+from packages.coccinelle.models import SpatchMatch, SpatchResult
+from packages.coccinelle.prereqs import (
+    PrereqFacts,
+    evaluate_finding,
+    gather_prereqs,
+)
+
+
+# ---------------------------------------------------------------------
+# PrereqFacts data class
+# ---------------------------------------------------------------------
+
+
+def test_prereq_facts_default_is_not_skipped():
+    f = PrereqFacts()
+    assert f.is_skipped is False
+    assert f.function_exists("foo") is False
+    assert f.function_has_callers("foo") is False
+
+
+def test_prereq_facts_skipped_reason_marks_skipped():
+    f = PrereqFacts(skipped_reason="spatch_not_available")
+    assert f.is_skipped is True
+
+
+def test_prereq_facts_callers_of_returns_sorted():
+    f = PrereqFacts(
+        calls={"foo": {("b.c", 10), ("a.c", 1), ("a.c", 5)}},
+    )
+    assert f.callers_of("foo") == [("a.c", 1), ("a.c", 5), ("b.c", 10)]
+
+
+# ---------------------------------------------------------------------
+# gather_prereqs — skip paths
+# ---------------------------------------------------------------------
+
+
+def test_gather_prereqs_skips_when_spatch_missing(tmp_path):
+    (tmp_path / "x.c").write_text("\n")
+    with patch("packages.coccinelle.prereqs.spatch_available",
+               return_value=False):
+        facts = gather_prereqs(tmp_path)
+    assert facts.is_skipped is True
+    assert facts.skipped_reason == "spatch_not_available"
+
+
+def test_gather_prereqs_skips_when_no_c_source(tmp_path):
+    """Python-only target → skipped silently (cocci is C-only).
+
+    This is the same skip semantic as the /scan cocci leg — ensures
+    /validate prereqs don't mis-fire on Python/JS/Go projects."""
+    (tmp_path / "main.py").write_text("\n")
+    with patch("packages.coccinelle.prereqs.spatch_available",
+               return_value=True):
+        facts = gather_prereqs(tmp_path)
+    assert facts.skipped_reason == "no_c_cpp_source"
+
+
+def test_gather_prereqs_skips_when_rules_dir_missing(tmp_path):
+    """No shipped rules → skipped silently (minimal install /
+    packaging strip). Don't error; the consumer treats this as
+    "no structural evidence available"."""
+    (tmp_path / "x.c").write_text("\n")
+    with patch("packages.coccinelle.prereqs.spatch_available",
+               return_value=True), patch(
+        "packages.coccinelle.prereqs._shipped_prereqs_rules_dir",
+        return_value=None,
+    ):
+        facts = gather_prereqs(tmp_path)
+    assert facts.skipped_reason == "rules_dir_missing"
+
+
+# ---------------------------------------------------------------------
+# gather_prereqs — happy path (mocked spatch)
+# ---------------------------------------------------------------------
+
+
+def test_gather_prereqs_parses_def_and_call_messages(tmp_path):
+    """Cocci result shape: ``def:<name>`` and ``call:<name>``
+    messages → indexed into ``facts.defs`` and ``facts.calls``."""
+    (tmp_path / "x.c").write_text("\n")
+    rules_dir = tmp_path / "rules"; rules_dir.mkdir()
+
+    fake_results = [SpatchResult(
+        rule="function_inventory",
+        matches=[
+            SpatchMatch(file="src/a.c", line=10, message="def:helper"),
+            SpatchMatch(file="src/a.c", line=20, message="def:main"),
+            SpatchMatch(file="src/a.c", line=21, message="call:helper"),
+            SpatchMatch(file="src/a.c", line=22, message="call:printf"),
+        ],
+    )]
+
+    with patch("packages.coccinelle.prereqs.spatch_available",
+               return_value=True), patch(
+        "packages.coccinelle.prereqs.spatch_run_rules",
+        return_value=fake_results,
+    ):
+        facts = gather_prereqs(tmp_path, rules_dir=rules_dir)
+
+    assert facts.is_skipped is False
+    assert facts.function_exists("helper") is True
+    assert facts.function_exists("main") is True
+    assert facts.function_exists("printf") is False  # libc, not defined here
+    assert facts.function_has_callers("helper") is True
+    assert facts.function_has_callers("main") is False  # main is called by libc
+    assert facts.callers_of("helper") == [("src/a.c", 21)]
+
+
+def test_gather_prereqs_ignores_unknown_message_shapes(tmp_path):
+    """Future rule additions may emit other COCCIRESULT shapes;
+    the gather pass stays neutral and ignores them."""
+    (tmp_path / "x.c").write_text("\n")
+    rules_dir = tmp_path / "rules"; rules_dir.mkdir()
+
+    fake_results = [SpatchResult(
+        rule="function_inventory",
+        matches=[
+            SpatchMatch(file="x.c", line=1, message="def:f"),
+            SpatchMatch(file="x.c", line=2, message="future_kind:something"),
+            SpatchMatch(file="x.c", line=3, message=""),  # empty msg
+        ],
+    )]
+    with patch("packages.coccinelle.prereqs.spatch_available",
+               return_value=True), patch(
+        "packages.coccinelle.prereqs.spatch_run_rules",
+        return_value=fake_results,
+    ):
+        facts = gather_prereqs(tmp_path, rules_dir=rules_dir)
+    assert facts.function_exists("f") is True
+    # No spurious entries from the unknown / empty messages:
+    assert facts.calls == {}
+    assert list(facts.defs.keys()) == ["f"]
+
+
+# ---------------------------------------------------------------------
+# evaluate_finding — per-finding evidence shape
+# ---------------------------------------------------------------------
+
+
+def _facts(defs=None, calls=None):
+    f = PrereqFacts()
+    for name, locs in (defs or {}).items():
+        f.defs[name] = set(locs)
+    for name, locs in (calls or {}).items():
+        f.calls[name] = set(locs)
+    return f
+
+
+def test_evaluate_finding_returns_skipped_reason_when_facts_skipped():
+    facts = PrereqFacts(skipped_reason="spatch_not_available")
+    out = evaluate_finding({"function": "foo", "file": "a.c"}, facts)
+    assert out["applicable"] is False
+    assert out["skipped_reason"] == "spatch_not_available"
+
+
+def test_evaluate_finding_skips_when_finding_has_no_function():
+    """Findings without a ``function`` field can't be checked
+    structurally — gracefully skip rather than asserting."""
+    out = evaluate_finding({"file": "a.c"}, _facts())
+    assert out["applicable"] is False
+    assert out["skipped_reason"] == "finding_missing_function"
+
+
+def test_evaluate_finding_skips_for_non_c_cpp_files():
+    """Findings on Python / JS / Go files are skipped (cocci can't
+    see them). This is the per-finding mirror of the gather-time
+    target-language check."""
+    out = evaluate_finding(
+        {"function": "foo", "file": "src/auth.py"},
+        _facts(defs={"foo": [("a.c", 1)]}),
+    )
+    assert out["applicable"] is False
+    assert out["skipped_reason"] == "non_c_cpp_file"
+
+
+def test_evaluate_finding_function_exists_with_callers():
+    """Function defined and called somewhere → both checks True,
+    callers_count surfaces in details for downstream evidence."""
+    facts = _facts(
+        defs={"helper": [("a.c", 10)]},
+        calls={"helper": [("a.c", 20), ("b.c", 5)]},
+    )
+    out = evaluate_finding(
+        {"function": "helper", "file": "a.c"}, facts,
+    )
+    assert out["applicable"] is True
+    assert out["checks"]["function_exists"] is True
+    assert out["checks"]["function_has_callers"] is True
+    assert out["details"]["function"] == "helper"
+    assert out["details"]["callers_count"] == 2
+
+
+def test_evaluate_finding_orphan_static_helper():
+    """Function defined but never called → exists True, has_callers
+    False. This is the classic LLM-hallucinated-call-chain case."""
+    facts = _facts(
+        defs={"orphan": [("a.c", 10)]},
+        calls={},
+    )
+    out = evaluate_finding(
+        {"function": "orphan", "file": "a.c"}, facts,
+    )
+    assert out["checks"]["function_exists"] is True
+    assert out["checks"]["function_has_callers"] is False
+
+
+def test_evaluate_finding_function_not_defined_locally():
+    """Function isn't in the local tree (e.g. libc, header-only) →
+    function_exists False AND has_callers stays None (we can't
+    assert "no callers" for a function we don't see defined)."""
+    facts = _facts(
+        defs={"main": [("a.c", 1)]},
+        calls={"strlen": [("a.c", 5)]},
+    )
+    out = evaluate_finding(
+        {"function": "strlen", "file": "a.c"}, facts,
+    )
+    assert out["checks"]["function_exists"] is False
+    assert out["checks"]["function_has_callers"] is None
+    assert out["details"] == {"function": "strlen"}
+
+
+def test_evaluate_finding_files_with_no_extension_treated_as_c():
+    """Header-less or extensionless C source (e.g. driver code that
+    omits the .c suffix) — proceed as if C/C++ rather than skip,
+    since cocci will have scanned them. The empty extension fall-
+    through avoids a false "non_c_cpp_file" skip on these targets."""
+    out = evaluate_finding(
+        {"function": "foo", "file": "Makefile_target"},
+        _facts(defs={"foo": [("a.c", 1)]}),
+    )
+    assert out["applicable"] is True
+    assert out["checks"]["function_exists"] is True
+
+
+# ---------------------------------------------------------------------
+# Real-spatch E2E
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not shutil.which("spatch"),
+    reason="spatch not installed — skip real-spatch E2E",
+)
+def test_e2e_real_spatch_orphan_static_helper(tmp_path):
+    """End-to-end: real spatch runs the shipped ``function_inventory``
+    rule against a tiny C fixture; the prereqs module correctly
+    classifies an orphan static helper (defined, never called) and
+    a called static helper (both checks True). Pin against the
+    shipped rule corpus so corpus drift surfaces here."""
+    src = tmp_path / "main.c"
+    src.write_text(
+        "#include <stdio.h>\n"
+        "static int helper_called(int x) { return x + 1; }\n"
+        "static int helper_orphan(int y) { return y * 2; }\n"
+        "int main(void) {\n"
+        "    return helper_called(5);\n"
+        "}\n"
+    )
+
+    facts = gather_prereqs(tmp_path)
+    assert not facts.is_skipped, (
+        f"expected real spatch to produce facts; got skipped_reason="
+        f"{facts.skipped_reason!r}"
+    )
+    assert facts.function_exists("helper_called") is True
+    assert facts.function_exists("helper_orphan") is True
+    assert facts.function_has_callers("helper_called") is True
+    assert facts.function_has_callers("helper_orphan") is False, (
+        "helper_orphan has no caller in fixture — orphan-static-helper "
+        "detection broke (rule corpus drift?)"
+    )

--- a/packages/exploitability_validation/schemas.py
+++ b/packages/exploitability_validation/schemas.py
@@ -291,6 +291,16 @@ FINDING_SCHEMA = {
         },
         "dedup_flag": {"type": ["string", "null"], "description": "A1: potential duplicate indicator"},
         "checklist_verified": {"type": "boolean", "description": "C0: file+line found in inventory"},
+        "cocci_prereqs": {
+            "type": "object",
+            "description": "Stage C structural pre-check via Coccinelle "
+                           "(C/C++ targets only). Mechanical facts: "
+                           "function_exists, function_has_callers. "
+                           "Stage C/D LLM consults as evidence; finding "
+                           "status is NEVER overwritten by these checks. "
+                           "Skipped (applicable=false) on non-C/C++ "
+                           "files, missing spatch, or absent rules dir."
+        },
         "test_code_flag": {"type": "boolean", "description": "D0: file matches test/mock pattern"},
         "likely_test_harness": {
             "type": "string",

--- a/packages/exploitability_validation/tests/test_prepare_c_cocci_prereqs.py
+++ b/packages/exploitability_validation/tests/test_prepare_c_cocci_prereqs.py
@@ -1,0 +1,218 @@
+"""Tests for the Cocci structural pre-check hook in
+``raptor-validation-helper:prepare_C``.
+
+The hook annotates each finding with ``cocci_prereqs`` (mechanical
+structural facts: function-exists, function-has-callers). Stage C
+LLM consults these as evidence; finding status is NEVER overwritten.
+
+Coverage:
+  * Hook is a silent no-op when the target arg is missing.
+  * Hook is a silent no-op when the target dir doesn't exist.
+  * Hook gracefully returns when packages.coccinelle import fails
+    (minimal install / packaging strip).
+  * Hook is a silent no-op when ``gather_prereqs`` reports skipped.
+  * Happy path: each finding gets ``cocci_prereqs``; orphan-static-
+    helper case prints a WARN line for that finding.
+  * Disproven findings are skipped (don't waste cycles annotating
+    findings already off the table).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _load_helper():
+    """Load ``libexec/raptor-validation-helper`` as a module so we
+    can call its private ``_run_cocci_prereqs`` directly."""
+    script = Path(__file__).resolve().parents[3] / "libexec" / "raptor-validation-helper"
+    spec = importlib.util.spec_from_file_location(
+        "raptor_validation_helper",
+        script,
+        submodule_search_locations=[],
+    )
+    if spec is None:
+        mod = types.ModuleType("raptor_validation_helper")
+        mod.__file__ = str(script)
+        code = compile(script.read_text(), str(script), "exec")
+        exec(code, mod.__dict__)
+        return mod
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_helper = _load_helper()
+
+
+def _findings(*ids):
+    return {
+        "findings": [
+            {
+                "id": fid,
+                "file": "src/a.c",
+                "line": 10,
+                "function": fname,
+                "status": "not_disproven",
+            }
+            for fid, fname in ids
+        ],
+    }
+
+
+# ---------------------------------------------------------------------
+# Skip paths — should be silent no-ops
+# ---------------------------------------------------------------------
+
+
+def test_run_cocci_prereqs_no_target_is_silent(capsys):
+    data = _findings(("F1", "foo"))
+    _helper._run_cocci_prereqs(workdir=None, findings_data=data, target=None)
+    assert "cocci_prereqs" not in data["findings"][0]
+    assert capsys.readouterr().out == ""
+
+
+def test_run_cocci_prereqs_target_not_dir_is_silent(tmp_path, capsys):
+    data = _findings(("F1", "foo"))
+    nonexistent = tmp_path / "no-such-dir"
+    _helper._run_cocci_prereqs(
+        workdir=tmp_path, findings_data=data, target=nonexistent,
+    )
+    assert "cocci_prereqs" not in data["findings"][0]
+    assert capsys.readouterr().out == ""
+
+
+def test_run_cocci_prereqs_skipped_facts_are_silent(tmp_path, capsys):
+    """``gather_prereqs`` returns a skipped PrereqFacts (e.g. spatch
+    absent) — the hook annotates nothing and prints nothing.
+    Operators expect silence when prerequisites aren't met."""
+    from packages.coccinelle.prereqs import PrereqFacts
+
+    data = _findings(("F1", "foo"))
+    skipped = PrereqFacts(skipped_reason="spatch_not_available")
+    with patch(
+        "packages.coccinelle.prereqs.gather_prereqs",
+        return_value=skipped,
+    ):
+        _helper._run_cocci_prereqs(
+            workdir=tmp_path, findings_data=data, target=tmp_path,
+        )
+    assert "cocci_prereqs" not in data["findings"][0]
+    assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------
+# Happy path — annotations + WARN print
+# ---------------------------------------------------------------------
+
+
+def test_run_cocci_prereqs_annotates_each_finding(tmp_path, capsys):
+    """Two findings, both C/C++ files. ``gather_prereqs`` returns
+    facts with one orphan helper. Both findings get
+    ``cocci_prereqs``; the orphan one triggers a WARN print."""
+    from packages.coccinelle.prereqs import PrereqFacts
+
+    facts = PrereqFacts(
+        defs={
+            "called_helper": {("src/a.c", 10)},
+            "orphan_helper": {("src/a.c", 20)},
+        },
+        calls={"called_helper": {("src/a.c", 30)}},
+    )
+    data = {
+        "findings": [
+            {
+                "id": "F1", "file": "src/a.c", "line": 10,
+                "function": "called_helper", "status": "not_disproven",
+            },
+            {
+                "id": "F2", "file": "src/a.c", "line": 20,
+                "function": "orphan_helper", "status": "not_disproven",
+            },
+        ],
+    }
+    with patch(
+        "packages.coccinelle.prereqs.gather_prereqs",
+        return_value=facts,
+    ):
+        _helper._run_cocci_prereqs(
+            workdir=tmp_path, findings_data=data, target=tmp_path,
+        )
+
+    f1 = data["findings"][0]
+    f2 = data["findings"][1]
+    assert f1["cocci_prereqs"]["applicable"] is True
+    assert f1["cocci_prereqs"]["checks"]["function_exists"] is True
+    assert f1["cocci_prereqs"]["checks"]["function_has_callers"] is True
+    assert f2["cocci_prereqs"]["applicable"] is True
+    assert f2["cocci_prereqs"]["checks"]["function_exists"] is True
+    assert f2["cocci_prereqs"]["checks"]["function_has_callers"] is False
+
+    out = capsys.readouterr().out
+    # Only the orphan triggers a WARN line:
+    assert "F2" in out
+    assert "orphan_helper" in out
+    assert "F1" not in out
+
+
+def test_run_cocci_prereqs_skips_disproven_findings(tmp_path):
+    """Findings with ``status=='disproven'`` are off the table —
+    don't waste cycles annotating them and don't risk shifting
+    Stage D's read of a disproven finding via cocci evidence."""
+    from packages.coccinelle.prereqs import PrereqFacts
+
+    facts = PrereqFacts(
+        defs={"orphan": {("src/a.c", 5)}},
+        calls={},
+    )
+    data = {
+        "findings": [
+            {
+                "id": "F1", "file": "src/a.c", "line": 5,
+                "function": "orphan", "status": "disproven",
+            },
+        ],
+    }
+    with patch(
+        "packages.coccinelle.prereqs.gather_prereqs",
+        return_value=facts,
+    ):
+        _helper._run_cocci_prereqs(
+            workdir=tmp_path, findings_data=data, target=tmp_path,
+        )
+    assert "cocci_prereqs" not in data["findings"][0]
+
+
+def test_run_cocci_prereqs_handles_missing_package_import(
+    tmp_path, capsys, monkeypatch,
+):
+    """If ``packages.coccinelle.prereqs`` can't be imported (minimal
+    install / packaging strip), the hook degrades silently. Pin the
+    contract so a future ``packages/coccinelle`` rename or extraction
+    surfaces here."""
+    # Force the import inside the hook to raise. We have to break it
+    # by uninstalling the module from sys.modules AND blocking the
+    # re-import via a meta_path finder.
+    monkeypatch.delitem(sys.modules, "packages.coccinelle.prereqs",
+                        raising=False)
+
+    class _Block:
+        def find_spec(self, name, path=None, target=None):
+            if name == "packages.coccinelle.prereqs":
+                raise ImportError("simulated minimal install")
+            return None
+
+    block = _Block()
+    monkeypatch.setattr("sys.meta_path",
+                        [block] + list(sys.meta_path))
+
+    data = _findings(("F1", "foo"))
+    _helper._run_cocci_prereqs(
+        workdir=tmp_path, findings_data=data, target=tmp_path,
+    )
+    assert "cocci_prereqs" not in data["findings"][0]
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
PR-4 (final) of the cocci utilization arc — wires the shipped function-inventory rule into Stage C's mechanical prep pass. Each C/C++ finding now carries `cocci_prereqs.checks.{function_exists, function_has_callers}` as deterministic evidence the Stage C LLM consults alongside its verbatim-code read.

Skip-silently semantics match the /scan cocci leg: missing spatch, non-C/C++ target, or absent rules dir → no annotation, no operator noise. Disproven findings are skipped (don't shift Stage D's read of a finding already off the table).

Single rule (`engine/coccinelle/prereqs/function_inventory.cocci`) emits `def:<name>` and `call:<name>` records. The Python prereqs module derives function-exists + function-has-callers from one spatch invocation across the whole target — O(1) per-finding lookup.

Captures two LLM-hallucination patterns inventory check misses:
  * function named in finding isn't a real C definition (macro / typedef / forward-decl)
  * orphan static helper — defined but never called, so the finding's claimed call chain is fabricated

Stage C verdict is NEVER overwritten — these are facts, not rulings. LLM still owns the sanity-check pass/fail.

Tests: 22 (16 prereqs unit + real-spatch E2E + 6 helper-hook
integration). Full validation suite: 524 passed.