### PR TITLE
Add Actions workflow to update dependencies inside devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -66,7 +66,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # SEMGREP (static-analysis, scan, raptor-scan, agentic commands)
 # ============================================================================
 
-RUN pip install --no-cache-dir semgrep==1.161.0
+ARG SEMGREP_VERSION=1.162.0
+RUN pip install --no-cache-dir semgrep==${SEMGREP_VERSION}
 
 # ============================================================================
 # RR DEBUGGER (rr-debugger skill, crash-analysis agents)
@@ -133,12 +134,13 @@ RUN apt-get update \
 # Capture-then-execute the nodesource setup script so a curl failure isn't
 # silently swallowed by the pipeline (curl | bash ignores curl's exit status).
 # Node 22 is the current LTS; Node 20 went EOL April 2026.
+ARG CLAUDE_CODE_VERSION=2.1.138
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x -o /tmp/nodesource_setup.sh \
     && bash /tmp/nodesource_setup.sh \
     && rm /tmp/nodesource_setup.sh \
     && apt-get install -y --no-install-recommends nodejs \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
-    && npm install -g @anthropic-ai/claude-code@2.1.119
+    && npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 
 # ============================================================================
 # JS PACKAGE MANAGERS (yarn replaced apt source removed above)

--- a/.github/scripts/update_devcontainer.py
+++ b/.github/scripts/update_devcontainer.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+"""
+This script updates the dependencies inside the container files.
+
+Sources:
+  SEMGREP_VERSION     - https://github.com/semgrep/semgrep/releases (GitHub releases, pip install)
+  CODEQL_VERSION      - https://github.com/github/codeql-cli-binaries/releases (GitHub releases)
+  CLAUDE_CODE_VERSION - https://github.com/anthropics/claude-code/tags (GitHub tags, npm install)
+"""
+
+import json
+import re
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+DOCKERFILES = [
+    ".devcontainer/Dockerfile",
+]
+
+# Matches a stable semver tag, optionally v-prefixed (e.g. "v1.2.3" or "1.2.3").
+# Pre-releases like "v1.2.3-rc.1" deliberately don't match — never auto-bump to one.
+SEMVER_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+
+
+def _fetch(url: str) -> bytes:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "devcontainer-updater",
+        },
+    )
+    with urllib.request.urlopen(req) as resp:
+        return resp.read()
+
+
+def _github_latest_release(repo: str) -> str:
+    """Return tag_name of the latest GitHub *release* for a repo (e.g. 'v2.25.3')."""
+    data = json.loads(
+        _fetch(f"https://api.github.com/repos/{repo}/releases/latest"))
+    return data["tag_name"]
+
+
+def _github_latest_tag(repo: str) -> str:
+    """Return the highest stable-semver *tag* for a repo (e.g. 'v2.1.138').
+
+    Use this when the project doesn't cut GitHub releases (or they lag the tags).
+    Pre-release tags are filtered out so an alpha/rc never lands in a Dockerfile pin.
+    """
+    data = json.loads(
+        _fetch(f"https://api.github.com/repos/{repo}/tags?per_page=100"))
+    versions: list[tuple[tuple[int, int, int], str]] = []
+    for entry in data:
+        name = entry["name"]
+        m = SEMVER_RE.match(name)
+        if m is None:
+            continue
+        versions.append((tuple(int(g) for g in m.groups()), name))
+    if not versions:
+        raise RuntimeError(f"No stable semver tags found for {repo}")
+    return max(versions)[1]
+
+
+def get_latest_versions() -> dict[str, str]:
+    """Fetch and return the latest version string for each tracked ARG.
+
+    All three ARGs are stored as bare semver in the Dockerfile, so the leading
+    'v' is stripped from every source.
+    """
+    return {
+        "SEMGREP_VERSION": _github_latest_release("semgrep/semgrep").lstrip("v"),
+        "CODEQL_VERSION": _github_latest_release("github/codeql-cli-binaries").lstrip("v"),
+        "CLAUDE_CODE_VERSION": _github_latest_tag("anthropics/claude-code").lstrip("v"),
+    }
+
+
+def update_dockerfile(path: Path, latest: dict[str, str]) -> list[tuple[str, str, str]]:
+    """
+    Rewrite ARG version lines in a single Dockerfile.
+
+    Only updates ARGs that are already present in the file; never adds new ones.
+    Returns a list of (arg_name, old_version, new_version) for each change made.
+    """
+    content = path.read_text()
+    changes: list[tuple[str, str, str]] = []
+
+    for arg, new_version in latest.items():
+        pattern = re.compile(rf"^(ARG {arg}=)(\S+)", re.MULTILINE)
+        match = pattern.search(content)
+        if match is None:
+            continue  # ARG not present in this file — skip
+        old_version = match.group(2)
+        if old_version == new_version:
+            continue  # already up to date
+        content = pattern.sub(rf"\g<1>{new_version}", content)
+        changes.append((arg, old_version, new_version))
+
+    if changes:
+        path.write_text(content)
+
+    return changes
+
+
+def main() -> None:
+    print("Fetching latest versions...")
+    latest = get_latest_versions()
+    for arg, version in latest.items():
+        print(f"  {arg}: {version}")
+
+    print()
+    any_changes = False
+
+    for rel_path in DOCKERFILES:
+        path = REPO_ROOT / rel_path
+        if not path.exists():
+            print(f"  SKIP {rel_path} (file not found)")
+            continue
+
+        changes = update_dockerfile(path, latest)
+        if changes:
+            any_changes = True
+            for arg, old, new in changes:
+                print(f"  {rel_path}: {arg}  {old} -> {new}")
+        else:
+            print(f"  {rel_path}: up to date")
+
+    print()
+    if any_changes:
+        print(
+            "Dockerfiles updated. Open a pull request and assign review to @some-natalie."
+        )
+    else:
+        print("All dependencies are up to date. Close this issue.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/update_devcontainer.yml
+++ b/.github/workflows/update_devcontainer.yml
@@ -1,0 +1,55 @@
+name: Update devcontainer's dependencies
+
+on:
+  schedule:
+    - cron: "0 0 * * 0" # every Sunday at midnight UTC
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to create a new branch with updates
+      pull-requests: write # to create a PR with the updates
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Update container dependencies
+        run: python3 .github/scripts/update_devcontainer.py
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set date
+        run: |
+          echo "DATE=$(date -u +"%Y-%m-%d")" >> "$GITHUB_ENV"
+
+      - name: Commit and push branch
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b automation/update-image-deps-${{ env.DATE }}
+          git add .devcontainer/
+          git commit -m "chore: bump image dependencies"
+          git push --force-with-lease origin automation/update-image-deps-${{ env.DATE }}
+
+      - name: Create PR with GH CLI
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --title "chore: bump devcontainer dependencies" \
+            --body "This PR updates the devcontainer's image dependencies (semgrep, codeql, claude-code) to their latest versions." \
+            --base main \
+            --head automation/update-image-deps-${{ env.DATE }} \
+            --label "dependencies"


### PR DESCRIPTION
This PR adds a Python script and GitHub Actions workflow to update the hard-coded dependencies inside of `.devcontainer/Dockerfile` by opening a PR like a janky Dependabot.  I use scripts like this to reduce toil on maintaining pinned deps.

⚠️ In order for this to work, you'll need to allow Actions to open PRs under "settings -> actions -> general" and scroll down to the checkbox toggle for it.  This can increase the blast radius of a supply chain attack w/i Actions, but it seems like everything's squared away on pinning these too. :)