### PR TITLE
feat(core/progress): expose last-stage side-channel for exception attribution

### DIFF
--- a/core/progress/__init__.py
+++ b/core/progress/__init__.py
@@ -10,6 +10,29 @@ from datetime import datetime
 from typing import Optional
 
 
+# Module-level "last stage that ran" — readable by out-of-band
+# exception handlers via :func:`last_stage_name`. See the
+# ``HackerProgressBar`` docstring for the design rationale.
+_LAST_STAGE_NAME: Optional[str] = None
+
+
+def last_stage_name() -> Optional[str]:
+    """The most-recent stage name that any active or recent
+    ``HackerProgressBar`` started, or ``None`` if no bar has
+    started a stage in this process.
+
+    Used by top-level exception handlers to attribute failures
+    to the pipeline phase that was active when the error occurred:
+    "raptor-sca: error during osv" beats the un-attributed
+    "raptor-sca: unrecoverable error".
+
+    The value persists past ``done()`` / ``end()`` so handlers can
+    still show context for failures that occurred between stages
+    (e.g. while writing an artefact between two ``stage()`` calls).
+    """
+    return _LAST_STAGE_NAME
+
+
 def _stderr_supports_unicode() -> bool:
     """Probe whether stderr can encode the unicode block characters
     used by the spinner / status decorations.
@@ -207,6 +230,21 @@ class HackerProgressBar:
     that's the simpler operations >15s case. ``HackerProgressBar``
     is for pipelines with N discrete phases the operator wants
     to see resolve one by one.
+
+    Side-channel last-stage tracking
+    -------------------------------
+    On every ``stage()`` call the bar updates a module-level
+    ``_LAST_STAGE_NAME`` so out-of-band exception handlers can
+    surface "which phase was running when this died" without
+    threading the bar through every call site. The CLI's outer
+    ``except`` reads it via :func:`last_stage_name` to print
+    "raptor-sca: unrecoverable error during osv (...)" instead
+    of the opaque pre-fix "unrecoverable error during run".
+
+    The variable persists past ``done()`` / ``end()`` so the
+    handler still has context if the failure occurred between
+    stages (e.g. during an artefact write that isn't itself a
+    stage).
     """
 
     _BLOCK_FULL = "▓" if _UNICODE_OK else "#"
@@ -286,6 +324,10 @@ class HackerProgressBar:
         self._stage_start = time.time()
         self._stage_detail = ""
         self._last_redraw = 0.0
+        # Update module-level side-channel for out-of-band exception
+        # handlers (see ``last_stage_name``).
+        global _LAST_STAGE_NAME
+        _LAST_STAGE_NAME = name
         self._render()
 
     def tick(self, done: Optional[int] = None,

--- a/core/progress/tests/test_progress.py
+++ b/core/progress/tests/test_progress.py
@@ -243,5 +243,47 @@ class HackerProgressBarTickThrottlingTest(unittest.TestCase):
             self.assertEqual(bar._stage_done, 3)
 
 
+class HackerProgressBarLastStageSideChannelTest(unittest.TestCase):
+    """Module-level ``last_stage_name()`` lets out-of-band exception
+    handlers report which pipeline phase was active when an error
+    occurred — without threading the bar through every call site."""
+
+    def test_stage_call_updates_last_stage_name(self) -> None:
+        from core.progress import last_stage_name
+        buf = io.StringIO()
+        with HackerProgressBar(disabled=True, stream=buf) as bar:
+            bar.stage("discovery")
+            self.assertEqual(last_stage_name(), "discovery")
+            bar.stage("osv")
+            self.assertEqual(last_stage_name(), "osv")
+
+    def test_last_stage_persists_after_done(self) -> None:
+        """The last-stage value survives ``done()`` / ``end()``
+        so handlers can still attribute failures that happen
+        between stages (e.g. while writing artefacts after the
+        pipeline body returns)."""
+        from core.progress import last_stage_name
+        buf = io.StringIO()
+        with HackerProgressBar(disabled=True, stream=buf) as bar:
+            bar.stage("emit")
+            bar.done(summary="ok")
+            bar.end(summary="all done")
+        # End ran; the name should still be retrievable for an
+        # exception that fires post-end.
+        self.assertEqual(last_stage_name(), "emit")
+
+    def test_silent_bar_still_updates_last_stage(self) -> None:
+        """Even when output is suppressed (``--no-progress``),
+        the side-channel must still update — operators using
+        ``--no-progress`` benefit *more* from a phase-attributed
+        error message because they have no rolling stage line to
+        glance at."""
+        from core.progress import last_stage_name
+        buf = io.StringIO()
+        with HackerProgressBar(disabled=True, stream=buf) as bar:
+            bar.stage("reach")
+        self.assertEqual(last_stage_name(), "reach")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds ``core.progress.last_stage_name()`` — returns the name of the most-recent ``HackerProgressBar.stage()`` invocation in this process, or ``None`` if no bar has started a stage.

The value is updated by every ``stage()`` call and persists past ``done()`` / ``end()``. Out-of-band exception handlers can read it without threading the bar through every call site:

  try:
      run_pipeline()
  except Exception:
      stage = core.progress.last_stage_name()
      logger.exception(f"unrecoverable error during {stage}")

Used by raptor-sca to attribute pipeline failures ("error during osv" vs the opaque pre-fix "unrecoverable error during run"), but the mechanism is generic — any consumer of HackerProgressBar gets it for free.

3 new tests in core/progress/tests/test_progress.py cover the stage-call update path, persistence past done()/end(), and that silent-mode bars (--no-progress) still update the side-channel (operators using --no-progress benefit MORE from a phase-attributed error because they have no rolling stage line to glance at).