### PR TITLE
core/upstream_latest: centralised latest-upstream-version lookup

### DIFF
--- a/core/oci/client.py
+++ b/core/oci/client.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, Iterator, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from core.http import HttpClient
 
@@ -166,6 +166,49 @@ class OciRegistryClient:
             content_type=content_type.split(";", 1)[0].strip(),
             digest=digest,
         )
+
+    def list_tags(
+        self, ref: ImageRef, *, per_page: int = 100,
+    ) -> List[str]:
+        """Return the tag list for ``ref.repository`` on its registry.
+
+        Hits ``GET /v2/<repo>/tags/list?n=<per_page>``. The OCI
+        Distribution Spec ``/tags/list`` endpoint returns
+        ``{"name": "<repo>", "tags": [...]}``. Only the first page
+        is fetched — the bumper's "what's the latest stable tag"
+        use case doesn't need exhaustive pagination, and most
+        registries cap responses around 100-1000 tags anyway. If a
+        future caller needs all tags, follow the ``Link`` header.
+
+        Raises :class:`RegistryError` on non-200 or malformed
+        response.
+        """
+        url = f"/v2/{ref.repository}/tags/list?n={per_page}"
+        resp = self._authed_request("GET", ref.registry, url)
+        if resp.status_code != 200:
+            raise RegistryError(
+                resp.status_code,
+                f"tags/list failed for {ref.repository} on "
+                f"{ref.registry}: {resp.text[:200]}",
+            )
+        try:
+            data = json.loads(resp.content)
+        except (ValueError, TypeError) as e:
+            raise RegistryError(
+                resp.status_code,
+                f"tags/list JSON parse failed for "
+                f"{ref.repository}: {e}",
+            )
+        tags = data.get("tags") if isinstance(data, dict) else None
+        if not isinstance(tags, list):
+            raise RegistryError(
+                resp.status_code,
+                f"tags/list response missing 'tags' array "
+                f"for {ref.repository}",
+            )
+        # Filter to non-empty strings — registries occasionally
+        # include nulls for in-progress pushes.
+        return [t for t in tags if isinstance(t, str) and t]
 
     def stream_blob(
         self, ref: ImageRef, digest: str,

--- a/core/oci/tests/test_client_list_tags.py
+++ b/core/oci/tests/test_client_list_tags.py
@@ -1,0 +1,136 @@
+"""Tests for ``OciRegistryClient.list_tags``.
+
+Covers the OCI Distribution Spec ``/v2/<repo>/tags/list`` endpoint
+wrapper. Auth handling (the 401-challenge-then-bearer-token
+exchange) is exercised end-to-end by ``test_manifest.py``-shaped
+tests; this file focuses on the tags-list-specific JSON shape,
+URL construction, and error paths."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Optional
+
+import pytest
+
+from core.oci.client import OciRegistryClient, RegistryError
+from core.oci.image_ref import parse_image_ref
+
+
+# ---------------------------------------------------------------------------
+# Minimal HTTP / Response stubs — track URLs hit, reply with
+# operator-supplied payloads.
+# ---------------------------------------------------------------------------
+
+class _StubResponse:
+    def __init__(self, status_code: int, body: bytes,
+                 headers: Optional[Dict[str, str]] = None):
+        self.status_code = status_code
+        self.content = body
+        self.text = body.decode("utf-8", errors="replace")
+        self.headers = headers or {}
+
+    def close(self):
+        pass
+
+
+class _StubHttp:
+    def __init__(self, responses: Dict[str, _StubResponse]):
+        self._responses = responses
+        self.calls: List[Dict] = []
+
+    def request(self, method: str, url: str, **kwargs):
+        self.calls.append({"method": method, "url": url,
+                           "headers": kwargs.get("headers") or {}})
+        if url not in self._responses:
+            return _StubResponse(404, b'{"errors": []}')
+        return self._responses[url]
+
+
+def _ok(body: dict) -> _StubResponse:
+    return _StubResponse(200, json.dumps(body).encode())
+
+
+# ---------------------------------------------------------------------------
+# list_tags
+# ---------------------------------------------------------------------------
+
+def test_list_tags_returns_tags_from_200_response() -> None:
+    """Happy path: registry returns the tags list, we return it."""
+    ref = parse_image_ref("docker.io/library/python:3.12")
+    http = _StubHttp({
+        "https://registry-1.docker.io/v2/library/python/tags/list?n=100":
+            _ok({"name": "library/python",
+                 "tags": ["3.11", "3.12", "3.12.0", "3.12.1"]}),
+    })
+    client = OciRegistryClient(http)
+    tags = client.list_tags(ref)
+    assert tags == ["3.11", "3.12", "3.12.0", "3.12.1"]
+
+
+def test_list_tags_passes_per_page() -> None:
+    """``per_page`` plumbs into the ``n=`` query param so callers
+    can scale up to "all the tags this registry has indexed"
+    without re-fetching paginated."""
+    ref = parse_image_ref("ghcr.io/anthropic/claude-code:latest")
+    http = _StubHttp({
+        "https://ghcr.io/v2/anthropic/claude-code/tags/list?n=500":
+            _ok({"name": "anthropic/claude-code", "tags": []}),
+    })
+    client = OciRegistryClient(http)
+    client.list_tags(ref, per_page=500)
+    assert "n=500" in http.calls[0]["url"]
+
+
+def test_list_tags_filters_non_string_entries() -> None:
+    """Registries occasionally include ``null`` for in-progress
+    pushes. Filter them out — they're not addressable tags."""
+    ref = parse_image_ref("docker.io/library/python:3.12")
+    http = _StubHttp({
+        "https://registry-1.docker.io/v2/library/python/tags/list?n=100":
+            _ok({"name": "library/python",
+                 "tags": ["3.12", None, "", "3.13"]}),
+    })
+    client = OciRegistryClient(http)
+    tags = client.list_tags(ref)
+    assert tags == ["3.12", "3.13"]
+
+
+def test_list_tags_non_200_raises_registry_error() -> None:
+    """5xx / 404 / etc. → ``RegistryError``. Caller decides
+    whether to fall back to a different surface or skip."""
+    ref = parse_image_ref("docker.io/library/no-such-image:1")
+    http = _StubHttp({
+        "https://registry-1.docker.io/v2/library/no-such-image/tags/list?n=100":
+            _StubResponse(404, b'{"errors":[{"code":"NAME_UNKNOWN"}]}'),
+    })
+    client = OciRegistryClient(http)
+    with pytest.raises(RegistryError) as exc_info:
+        client.list_tags(ref)
+    assert exc_info.value.status == 404
+
+
+def test_list_tags_malformed_json_raises() -> None:
+    """200 with non-JSON / shape regression → ``RegistryError``."""
+    ref = parse_image_ref("docker.io/library/python:3.12")
+    http = _StubHttp({
+        "https://registry-1.docker.io/v2/library/python/tags/list?n=100":
+            _StubResponse(200, b'not json'),
+    })
+    client = OciRegistryClient(http)
+    with pytest.raises(RegistryError):
+        client.list_tags(ref)
+
+
+def test_list_tags_missing_tags_field_raises() -> None:
+    """``{"name": "x"}`` without a ``tags`` array is a server
+    regression — surface as ``RegistryError`` instead of
+    returning ``[]`` silently (silent-skip would mask bugs)."""
+    ref = parse_image_ref("docker.io/library/python:3.12")
+    http = _StubHttp({
+        "https://registry-1.docker.io/v2/library/python/tags/list?n=100":
+            _ok({"name": "library/python"}),
+    })
+    client = OciRegistryClient(http)
+    with pytest.raises(RegistryError):
+        client.list_tags(ref)

--- a/core/upstream_latest/__init__.py
+++ b/core/upstream_latest/__init__.py
@@ -1,0 +1,37 @@
+"""Look up the latest stable version of an upstream package /
+release artefact.
+
+Centralised module so multiple call sites (current SCA bumper +
+future ``/agentic`` upstream-checks, ``cve-diff`` upstream
+resolution, etc.) don't each reinvent "fetch from GitHub
+releases, filter to stable semver, strip v prefix, cache for
+24h, respect rate limits".
+
+This commit ships :mod:`github_releases` (GitHub releases / tags
+endpoints + tag→SHA resolution). Subsequent commits add
+``oci_tags`` (OCI registry tag listings) and ``helm_index``
+(Helm repo index.yaml lookups).
+
+Why centralise: the patterns drift otherwise. Multiple
+copies of "is this tag stable-semver" leads to "is this *quite*
+stable-semver" variants that handle edge cases differently —
+one source of truth keeps the substrate honest.
+"""
+
+from core.upstream_latest.github_releases import (
+    GITHUB_API_BASE,
+    NoStableVersionsFound,
+    UpstreamLookupError,
+    latest_release,
+    latest_tag,
+    resolve_tag_to_sha,
+)
+
+__all__ = [
+    "GITHUB_API_BASE",
+    "NoStableVersionsFound",
+    "UpstreamLookupError",
+    "latest_release",
+    "latest_tag",
+    "resolve_tag_to_sha",
+]

--- a/core/upstream_latest/__init__.py
+++ b/core/upstream_latest/__init__.py
@@ -7,15 +7,18 @@ resolution, etc.) don't each reinvent "fetch from GitHub
 releases, filter to stable semver, strip v prefix, cache for
 24h, respect rate limits".
 
-This commit ships :mod:`github_releases` (GitHub releases / tags
-endpoints + tag→SHA resolution). Subsequent commits add
-``oci_tags`` (OCI registry tag listings) and ``helm_index``
-(Helm repo index.yaml lookups).
+This package ships three registry kinds:
+  * :mod:`github_releases` — GitHub releases / tags endpoints
+    plus the ``resolve_tag_to_sha`` primitive
+  * :mod:`oci_tags` — OCI Distribution Spec tag listings
+    (Docker Hub / ghcr.io / etc.)
+  * :mod:`helm_index` — Helm repository index.yaml lookups
 
 Why centralise: the patterns drift otherwise. Multiple
 copies of "is this tag stable-semver" leads to "is this *quite*
 stable-semver" variants that handle edge cases differently —
-one source of truth keeps the substrate honest.
+one source of truth (see :mod:`_version_filter`) keeps the
+substrate honest.
 """
 
 from core.upstream_latest.github_releases import (
@@ -26,6 +29,11 @@ from core.upstream_latest.github_releases import (
     latest_tag,
     resolve_tag_to_sha,
 )
+from core.upstream_latest.helm_index import latest_chart_version
+from core.upstream_latest.oci_tags import (
+    latest_tag as latest_oci_tag,
+    list_all_tags as list_all_oci_tags,
+)
 
 __all__ = [
     "GITHUB_API_BASE",
@@ -34,4 +42,7 @@ __all__ = [
     "latest_release",
     "latest_tag",
     "resolve_tag_to_sha",
+    "latest_oci_tag",
+    "list_all_oci_tags",
+    "latest_chart_version",
 ]

--- a/core/upstream_latest/_version_filter.py
+++ b/core/upstream_latest/_version_filter.py
@@ -1,0 +1,60 @@
+"""Shared stable-semver filter for upstream-latest lookups.
+
+Both ``github_releases`` and ``oci_tags`` (and future modules
+like ``helm_index``) need the same logic: given a list of tag /
+version strings, pick the highest one that's stable-semver-
+shaped, rejecting pre-releases / dev shapes / non-version refs.
+
+Centralising means one source of truth for what counts as
+"stable" — adding a shape (e.g. NuGet 5-part) lands once and
+every registry kind benefits."""
+
+from __future__ import annotations
+
+import re
+from typing import List, Optional, Tuple
+
+# Stable-semver shapes we accept:
+#   * ``1``, ``1.2``, ``1.2.3``, ``1.2.3.4`` (1-4 part numeric)
+#   * Optional leading ``v`` (Go-style / GitHub tag convention)
+# Rejected:
+#   * Pre-release suffixes (``-rc.1``, ``-beta``, ``-alpha``)
+#   * PEP440 dev / pre shapes (``.dev0``, ``b1``, ``rc1`` inline)
+#   * Date-shaped tags (``2024-01-15``)
+#   * Branch / commit refs (``main``, ``deadbeef``)
+#   * Container variant suffixes (``3.12-bookworm``, ``3.12-slim``)
+_STABLE_RE = re.compile(
+    r"^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\.(\d+))?$"
+)
+
+
+def parse_stable(tag: str) -> Optional[Tuple[int, ...]]:
+    """Return the numeric tuple if ``tag`` is stable-semver, else None.
+
+    Tuple ordering matches lexical comparison: ``(1, 17, 21) >
+    (1, 17, 4)`` naturally gives the right answer across 1-4 part
+    versions because Python tuple comparison is element-wise.
+    """
+    match = _STABLE_RE.match(tag)
+    if match is None:
+        return None
+    return tuple(int(g) for g in match.groups() if g is not None)
+
+
+def highest_stable(tags: List[str]) -> Optional[str]:
+    """Return the highest stable-semver tag from ``tags``, or None
+    if no tag matches the stable shape.
+
+    Callers raise their own ``NoStableVersionsFound`` (or similar)
+    on None — keeps this function pure / testable without
+    exception coupling.
+    """
+    stable: List[Tuple[Tuple[int, ...], str]] = []
+    for tag in tags:
+        parts = parse_stable(tag)
+        if parts is None:
+            continue
+        stable.append((parts, tag))
+    if not stable:
+        return None
+    return max(stable)[1]

--- a/core/upstream_latest/github_releases.py
+++ b/core/upstream_latest/github_releases.py
@@ -1,0 +1,243 @@
+"""GitHub releases / tags upstream-latest lookup.
+
+Two entry points:
+
+* :func:`latest_release` — calls ``GET /repos/{owner}/{repo}/
+  releases/latest``. GitHub already filters this to the most
+  recent non-draft, non-pre-release release. Use this when the
+  upstream cuts proper GitHub releases (semgrep, codeql,
+  most CLI tools that ship via release assets).
+* :func:`latest_tag` — calls ``GET /repos/{owner}/{repo}/tags``,
+  filters to stable semver (rejecting ``-rc``, ``-beta``,
+  ``.dev0`` etc.), returns the highest. Use this when the
+  upstream tags releases but doesn't publish a ``releases/latest``
+  marker (claude-code, some quieter projects).
+
+Both functions take an injected ``HttpClient`` (so the egress
+allowlist and the project's circuit-breaker apply) and an
+optional ``JsonCache`` (24h TTL by default — the registry
+state changes slowly relative to a scan cadence).
+
+Adapted from https://github.com/gadievron/raptor/pull/467 by
+Natalie Somersall — her devcontainer auto-update workflow ships
+the same patterns inline; this module generalises them so other
+SCA consumers (bumper subcommand, GHA freshness scanner,
+cve-diff upstream resolver) share one implementation.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from core.http import HttpClient, HttpError
+from core.json import JsonCache
+
+from ._version_filter import highest_stable
+
+logger = logging.getLogger(__name__)
+
+GITHUB_API_BASE = "https://api.github.com"
+_DEFAULT_TTL_SECONDS = 24 * 3600
+
+
+class UpstreamLookupError(Exception):
+    """Raised when an upstream-latest lookup fails irrecoverably.
+
+    Distinct from ``HttpError`` so callers (the bumper) can
+    distinguish "GitHub returned 404 / 403 / 5xx" from "no usable
+    tag found in the response". The bumper treats both as
+    "skip this surface" — but logs them differently."""
+
+
+class NoStableVersionsFound(UpstreamLookupError):
+    """Raised when ``latest_tag`` finds no stable-semver tags in
+    the tag list. Either the project doesn't cut tags, OR every
+    tag is pre-release / non-semver shape. Caller should fall
+    back to ``latest_release`` (if applicable) or skip the bump.
+    """
+
+
+def latest_release(
+    repo: str,
+    *,
+    http: HttpClient,
+    cache: Optional[JsonCache] = None,
+    ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+    github_token: Optional[str] = None,
+) -> str:
+    """Return the ``tag_name`` of the latest stable GitHub release.
+
+    ``repo`` is the ``owner/name`` slug.  Returns the tag verbatim
+    (caller decides whether to strip a leading ``v``).
+
+    GitHub's ``releases/latest`` endpoint already filters drafts
+    + pre-releases, so we trust its choice and don't re-filter.
+    If the project doesn't cut proper releases, this returns
+    HTTP 404 — caller should fall back to ``latest_tag``.
+    """
+    url = f"{GITHUB_API_BASE}/repos/{repo}/releases/latest"
+    data = _fetch_cached_json(
+        url, http=http, cache=cache, ttl_seconds=ttl_seconds,
+        github_token=github_token,
+    )
+    if not isinstance(data, dict):
+        raise UpstreamLookupError(
+            f"GitHub /releases/latest for {repo} returned non-object"
+        )
+    tag = data.get("tag_name")
+    if not isinstance(tag, str) or not tag.strip():
+        raise UpstreamLookupError(
+            f"GitHub /releases/latest for {repo} missing tag_name"
+        )
+    return tag.strip()
+
+
+def resolve_tag_to_sha(
+    repo: str,
+    tag: str,
+    *,
+    http: HttpClient,
+    cache: Optional[JsonCache] = None,
+    ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+    github_token: Optional[str] = None,
+) -> str:
+    """Resolve a tag to its 40-char commit SHA.
+
+    Hits ``GET /repos/{repo}/git/refs/tags/{tag}``. The
+    response carries ``object.sha`` which is either:
+      * The commit SHA directly (lightweight tag), or
+      * A tag-object SHA (annotated tag) — in which case we
+        chase one more redirect via ``GET /repos/{repo}/git/
+        tags/{sha}`` to get the underlying commit SHA.
+
+    Caches the result per (repo, tag) — tag-to-SHA mappings
+    are typically stable once published (the SCA git_tag_drift
+    detector catches the rare cases where a tag is re-pointed).
+
+    Used by the bumper's SHA-pinned GHA-uses path (Phase 3.b.2)
+    to construct the target SHA when proposing a bump from
+    ``<sha-A>  # was v6`` to ``<sha-B>  # was v7``.
+    """
+    url = f"{GITHUB_API_BASE}/repos/{repo}/git/refs/tags/{tag}"
+    data = _fetch_cached_json(
+        url, http=http, cache=cache, ttl_seconds=ttl_seconds,
+        github_token=github_token,
+    )
+    if not isinstance(data, dict):
+        raise UpstreamLookupError(
+            f"GitHub /git/refs/tags/{tag} for {repo} returned non-object"
+        )
+    obj = data.get("object") or {}
+    sha = obj.get("sha")
+    obj_type = obj.get("type")
+    if not isinstance(sha, str) or len(sha) != 40:
+        raise UpstreamLookupError(
+            f"GitHub /git/refs/tags/{tag} for {repo} missing sha"
+        )
+    if obj_type == "tag":
+        # Annotated tag — chase the tag object to get the
+        # underlying commit SHA.
+        tag_url = f"{GITHUB_API_BASE}/repos/{repo}/git/tags/{sha}"
+        tag_data = _fetch_cached_json(
+            tag_url, http=http, cache=cache, ttl_seconds=ttl_seconds,
+            github_token=github_token,
+        )
+        if not isinstance(tag_data, dict):
+            raise UpstreamLookupError(
+                f"GitHub /git/tags/{sha} for {repo} returned non-object"
+            )
+        inner_obj = tag_data.get("object") or {}
+        inner_sha = inner_obj.get("sha")
+        if not isinstance(inner_sha, str) or len(inner_sha) != 40:
+            raise UpstreamLookupError(
+                f"GitHub /git/tags/{sha} for {repo} missing inner sha"
+            )
+        return inner_sha
+    return sha
+
+
+def latest_tag(
+    repo: str,
+    *,
+    http: HttpClient,
+    cache: Optional[JsonCache] = None,
+    ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+    github_token: Optional[str] = None,
+    per_page: int = 100,
+) -> str:
+    """Return the highest stable-semver tag in the repo.
+
+    Filters out pre-releases (``-rc.1``, ``-beta.2``, ``.dev0``)
+    so an auto-bumper never lands a pre-release into a pin.
+    Raises :class:`NoStableVersionsFound` if no tag matches the
+    stable-semver shape.
+
+    Use this when ``latest_release`` 404s (project doesn't ship
+    GitHub Releases, only tags).
+    """
+    url = (
+        f"{GITHUB_API_BASE}/repos/{repo}/tags?per_page={per_page}"
+    )
+    data = _fetch_cached_json(
+        url, http=http, cache=cache, ttl_seconds=ttl_seconds,
+        github_token=github_token,
+    )
+    if not isinstance(data, list):
+        raise UpstreamLookupError(
+            f"GitHub /tags for {repo} returned non-list"
+        )
+    names = [
+        entry["name"] for entry in data
+        if isinstance(entry, dict) and isinstance(entry.get("name"), str)
+    ]
+    winner = highest_stable(names)
+    if winner is None:
+        raise NoStableVersionsFound(
+            f"no stable-semver tags found for {repo}"
+        )
+    return winner
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+def _fetch_cached_json(
+    url: str,
+    *,
+    http: HttpClient,
+    cache: Optional[JsonCache],
+    ttl_seconds: int,
+    github_token: Optional[str],
+) -> Any:
+    """Cached GET-JSON wrapper.
+
+    Cache miss → live HTTP call → store in cache.  Cache hit →
+    return cached value without HTTP. Operators wanting to force
+    a refresh pass ``ttl_seconds=0``.
+    """
+    cache_key = f"upstream_latest:gh:{url}"
+    if cache is not None and ttl_seconds > 0:
+        cached = cache.get(cache_key, ttl_seconds=ttl_seconds)
+        if cached is not None:
+            return cached
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "raptor-sca",
+    }
+    if github_token:
+        headers["Authorization"] = f"Bearer {github_token}"
+    try:
+        data = http.get_json(url, headers=headers)
+    except HttpError as exc:
+        # Surface the original error with a more actionable wrapper
+        # (the caller cares "did this work" / "did it 404 / 403 /
+        # 5xx" — same fail-soft fallthrough either way).
+        raise UpstreamLookupError(
+            f"GitHub fetch failed for {url}: {exc}"
+        ) from exc
+    if cache is not None and ttl_seconds > 0:
+        cache.put(cache_key, data, ttl_seconds=ttl_seconds)
+    return data

--- a/core/upstream_latest/helm_index.py
+++ b/core/upstream_latest/helm_index.py
@@ -1,0 +1,168 @@
+"""Helm repository index upstream-latest lookup.
+
+A Helm chart's ``Chart.yaml`` ``dependencies:`` block points at
+chart repos by URL:
+
+    dependencies:
+      - name: postgresql
+        version: 13.4.4
+        repository: https://charts.bitnami.com/bitnami
+
+To find the latest stable version of ``postgresql`` in that
+repo, we GET ``<repository>/index.yaml`` — a YAML map of chart
+names → ordered list of versions:
+
+    apiVersion: v1
+    entries:
+      postgresql:
+        - version: 13.4.4
+          created: "2026-01-15T..."
+          digest: sha256:...
+        - version: 13.4.3
+        ...
+
+This module fetches that index (cached 24h), filters to
+stable-semver, and returns the highest.
+
+Same uniform interface as ``github_releases`` /
+``oci_tags`` — injected ``HttpClient`` + optional
+``JsonCache`` — so the bumper's orchestrator handles all
+three registries uniformly."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional
+
+from core.http import HttpClient, HttpError
+from core.json import JsonCache
+
+from ._version_filter import highest_stable
+from .github_releases import (
+    NoStableVersionsFound,
+    UpstreamLookupError,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TTL_SECONDS = 24 * 3600
+
+
+def latest_chart_version(
+    repository: str,
+    chart_name: str,
+    *,
+    http: HttpClient,
+    cache: Optional[JsonCache] = None,
+    ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+) -> str:
+    """Return the highest stable-semver version of ``chart_name``
+    in the Helm repo at ``repository``.
+
+    ``repository`` is the base URL — we append ``/index.yaml``
+    (or accept a URL already pointing at the index file).
+    ``chart_name`` is the entry key in ``index.yaml``'s ``entries``
+    map.
+
+    Raises:
+      * :class:`UpstreamLookupError` — fetch failed, malformed
+        YAML, or chart name not in the index.
+      * :class:`NoStableVersionsFound` — chart exists in the index
+        but no version matches the stable-semver shape.
+    """
+    index = _fetch_index_cached(
+        repository, http=http, cache=cache, ttl_seconds=ttl_seconds,
+    )
+    entries = index.get("entries") if isinstance(index, dict) else None
+    if not isinstance(entries, dict):
+        raise UpstreamLookupError(
+            f"Helm index at {repository} missing entries map"
+        )
+    versions = entries.get(chart_name)
+    if not isinstance(versions, list):
+        raise UpstreamLookupError(
+            f"Helm index at {repository} has no entry for "
+            f"chart {chart_name!r}"
+        )
+    raw_versions: List[str] = []
+    for entry in versions:
+        if not isinstance(entry, dict):
+            continue
+        v = entry.get("version")
+        if isinstance(v, str) and v.strip():
+            raw_versions.append(v.strip())
+    if not raw_versions:
+        raise UpstreamLookupError(
+            f"Helm index entry {chart_name!r} at {repository} "
+            f"has no version field"
+        )
+    winner = highest_stable(raw_versions)
+    if winner is None:
+        raise NoStableVersionsFound(
+            f"no stable-semver versions of {chart_name} in "
+            f"{repository}"
+        )
+    return winner
+
+
+def _fetch_index_cached(
+    repository: str,
+    *,
+    http: HttpClient,
+    cache: Optional[JsonCache],
+    ttl_seconds: int,
+) -> Any:
+    """Fetch + cache the index.yaml as a parsed dict.
+
+    Cache key keyed on the normalized index URL — if two charts
+    in the same repo are queried in the same run, the second
+    one is a cache hit (no second HTTP call).
+    """
+    url = _normalize_index_url(repository)
+    cache_key = f"upstream_latest:helm:{url}"
+    if cache is not None and ttl_seconds > 0:
+        cached = cache.get(cache_key, ttl_seconds=ttl_seconds)
+        if cached is not None:
+            return cached
+    try:
+        raw = http.get_bytes(url)
+    except HttpError as exc:
+        raise UpstreamLookupError(
+            f"Helm index fetch failed for {url}: {exc}"
+        ) from exc
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise UpstreamLookupError(
+            f"Helm index at {url} not UTF-8: {exc}"
+        ) from exc
+    try:
+        import yaml          # type: ignore[import-untyped]
+    except ImportError as exc:
+        raise UpstreamLookupError(
+            f"PyYAML not installed; cannot parse Helm index"
+        ) from exc
+    try:
+        # ``CSafeLoader`` is faster + immune to the same arbitrary-
+        # code-execution path that ``Loader`` exposes via Python
+        # tags. Fall back to ``SafeLoader`` when libyaml not
+        # built; both are safe.
+        loader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+        data = yaml.load(text, Loader=loader)   # noqa: S506
+    except yaml.YAMLError as exc:
+        raise UpstreamLookupError(
+            f"Helm index at {url} not parseable YAML: {exc}"
+        ) from exc
+    if cache is not None and ttl_seconds > 0:
+        cache.put(cache_key, data, ttl_seconds=ttl_seconds)
+    return data
+
+
+def _normalize_index_url(repository: str) -> str:
+    """Append ``/index.yaml`` if the URL doesn't already end with
+    it. Tolerate trailing slashes — many Chart.yaml entries write
+    ``https://charts.example.com`` without the trailing slash."""
+    repository = repository.rstrip("/")
+    if repository.endswith(".yaml") or repository.endswith(".yml"):
+        return repository
+    return f"{repository}/index.yaml"

--- a/core/upstream_latest/oci_tags.py
+++ b/core/upstream_latest/oci_tags.py
@@ -1,0 +1,156 @@
+"""OCI registry tag-listing upstream-latest lookup.
+
+Given an image reference (``docker.io/library/python:3.12``,
+``ghcr.io/anthropic/claude-code:latest``, etc.), return the
+highest stable-semver tag available for that repository on its
+registry.
+
+Two entry points:
+
+* :func:`latest_tag` — list tags via OCI Distribution Spec
+  ``/v2/<repo>/tags/list``, filter to stable-semver, pick the
+  highest. Use when the image upstream tags releases with
+  numeric semver shapes (``3.12.1``, ``v1.2.3``, etc.).
+* :func:`list_all_tags` — return the unfiltered list (rarely
+  needed; exposed for diagnostic / future-detector use).
+
+Why not just trust the ``latest`` tag: ``latest`` is a moving
+alias that the publisher can re-point at any time. Auto-bumping
+to ``latest`` is the renovate/dependabot anti-pattern this whole
+substrate is designed to avoid. We pin to specific stable-semver
+tags instead.
+
+Out-of-scope shapes silently filter out (filter lives in
+``_version_filter``):
+
+  * Variant tags (``3.12-bookworm``, ``3.12-slim``)
+  * Date tags (``2024-01-15``)
+  * Branch / commit refs (``main``, ``deadbeef``)
+  * Pre-releases / dev shapes
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from core.http import HttpClient
+from core.json import JsonCache
+from core.oci.client import OciRegistryClient, RegistryError
+from core.oci.image_ref import ImageRef, parse_image_ref
+
+from ._version_filter import highest_stable
+from .github_releases import (
+    NoStableVersionsFound,
+    UpstreamLookupError,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TTL_SECONDS = 24 * 3600
+
+
+def latest_tag(
+    image_ref: str,
+    *,
+    http: HttpClient,
+    cache: Optional[JsonCache] = None,
+    ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+    client: Optional[OciRegistryClient] = None,
+    per_page: int = 100,
+) -> str:
+    """Return the highest stable-semver tag for the OCI image.
+
+    ``image_ref`` is a Docker / OCI reference string —
+    ``docker.io/library/python``, ``ghcr.io/anthropic/claude-code``,
+    or short-form ``python`` (which expands to
+    ``docker.io/library/python``). Tag / digest portions are
+    ignored; we're looking at the whole repository's tag list.
+
+    Caller can pass an existing ``OciRegistryClient`` (for
+    credential-lookup overrides / token reuse across calls).
+    Without one, a fresh client is constructed from ``http``.
+
+    Raises:
+
+    * :class:`NoStableVersionsFound` — no tag in the repo's tag
+      list matches the stable-semver shape (caller should fall
+      back to e.g. GitHub releases or skip the bump).
+    * :class:`UpstreamLookupError` — registry returned a non-200
+      / shape-regression / network failure.
+    """
+    tags = _list_tags_cached(
+        image_ref, http=http, cache=cache, ttl_seconds=ttl_seconds,
+        client=client, per_page=per_page,
+    )
+    winner = highest_stable(tags)
+    if winner is None:
+        raise NoStableVersionsFound(
+            f"no stable-semver tags found for {image_ref}"
+        )
+    return winner
+
+
+def list_all_tags(
+    image_ref: str,
+    *,
+    http: HttpClient,
+    cache: Optional[JsonCache] = None,
+    ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+    client: Optional[OciRegistryClient] = None,
+    per_page: int = 100,
+) -> List[str]:
+    """Return the full tag list, unfiltered.
+
+    Useful for diagnostic / future-detector use cases (e.g. "list
+    every patch on the current minor"). The bumper's auto-bump
+    path uses :func:`latest_tag` instead — it doesn't want to see
+    pre-release / variant tags.
+    """
+    return list(_list_tags_cached(
+        image_ref, http=http, cache=cache, ttl_seconds=ttl_seconds,
+        client=client, per_page=per_page,
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+def _list_tags_cached(
+    image_ref: str,
+    *,
+    http: HttpClient,
+    cache: Optional[JsonCache],
+    ttl_seconds: int,
+    client: Optional[OciRegistryClient],
+    per_page: int,
+) -> List[str]:
+    """Cached wrapper around ``OciRegistryClient.list_tags``.
+
+    Cache key includes the parsed registry + repository (not the
+    tag — the tags-list endpoint is registry-wide for a repo
+    regardless of what tag the caller asked about).
+    """
+    ref = parse_image_ref(image_ref)
+    cache_key = (
+        f"upstream_latest:oci:{ref.registry}/{ref.repository}"
+        f":n={per_page}"
+    )
+    if cache is not None and ttl_seconds > 0:
+        cached = cache.get(cache_key, ttl_seconds=ttl_seconds)
+        if cached is not None and isinstance(cached, list):
+            return cached
+    registry_client = client or OciRegistryClient(http=http)
+    try:
+        tags = registry_client.list_tags(ref, per_page=per_page)
+    except RegistryError as exc:
+        raise UpstreamLookupError(
+            f"OCI tag list failed for {image_ref}: {exc}"
+        ) from exc
+    if cache is not None and ttl_seconds > 0:
+        cache.put(cache_key, tags, ttl_seconds=ttl_seconds)
+    return tags
+
+
+__all__ = ["latest_tag", "list_all_tags"]

--- a/core/upstream_latest/tests/test_github_releases.py
+++ b/core/upstream_latest/tests/test_github_releases.py
@@ -1,0 +1,314 @@
+"""Tests for ``core.upstream_latest.github_releases``."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from core.http import HttpError
+from core.upstream_latest.github_releases import (
+    NoStableVersionsFound,
+    UpstreamLookupError,
+    latest_release,
+    latest_tag,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stub HttpClient — records every URL hit + headers, replies with
+# operator-supplied payloads.
+# ---------------------------------------------------------------------------
+
+class _StubHttp:
+    def __init__(self, urls: Dict[str, Any], *,
+                 raise_on: Optional[str] = None,
+                 raise_with: Optional[Exception] = None):
+        self._urls = urls
+        self._raise_on = raise_on
+        self._raise_with = raise_with or HttpError("stub error")
+        self.calls: List[Dict[str, Any]] = []
+
+    def get_json(self, url: str, **kwargs):
+        self.calls.append({"url": url, "headers": kwargs.get("headers", {})})
+        if self._raise_on and self._raise_on in url:
+            raise self._raise_with
+        if url not in self._urls:
+            raise HttpError(f"stub: no payload for {url}")
+        return self._urls[url]
+
+
+class _StubCache:
+    def __init__(self):
+        self.store: Dict[str, Any] = {}
+        self.gets: List[str] = []
+        self.puts: List[str] = []
+
+    def get(self, key: str, *, ttl_seconds: int):
+        self.gets.append(key)
+        return self.store.get(key)
+
+    def put(self, key: str, value: Any, *, ttl_seconds: int):
+        self.puts.append(key)
+        self.store[key] = value
+
+
+# ---------------------------------------------------------------------------
+# latest_release
+# ---------------------------------------------------------------------------
+
+def test_latest_release_returns_tag_name() -> None:
+    """GitHub's ``releases/latest`` already filters drafts and
+    pre-releases, so trust its choice and return ``tag_name``
+    verbatim."""
+    http = _StubHttp({
+        "https://api.github.com/repos/semgrep/semgrep/releases/latest":
+            {"tag_name": "v1.119.0", "name": "1.119.0"},
+    })
+    assert latest_release("semgrep/semgrep", http=http) == "v1.119.0"
+
+
+def test_latest_release_passes_github_api_headers() -> None:
+    """GitHub's API wants the ``vnd.github+json`` Accept header
+    and the X-GitHub-Api-Version pin for predictable response
+    shapes. Pre-fix some quieter projects would 200-with-empty
+    bodies when the header was wrong."""
+    http = _StubHttp({
+        "https://api.github.com/repos/owner/repo/releases/latest":
+            {"tag_name": "v1.0"},
+    })
+    latest_release("owner/repo", http=http)
+    headers = http.calls[0]["headers"]
+    assert headers["Accept"] == "application/vnd.github+json"
+    assert headers["X-GitHub-Api-Version"] == "2022-11-28"
+
+
+def test_latest_release_includes_bearer_token_when_supplied() -> None:
+    """``github_token`` plumbs into the Authorization header for
+    higher rate limits + access to private repos."""
+    http = _StubHttp({
+        "https://api.github.com/repos/owner/repo/releases/latest":
+            {"tag_name": "v1.0"},
+    })
+    latest_release("owner/repo", http=http, github_token="secret")
+    assert http.calls[0]["headers"]["Authorization"] == "Bearer secret"
+
+
+def test_latest_release_no_token_no_auth_header() -> None:
+    """No token → no Authorization header (unauth at 60/hr is
+    fine for individual operator runs)."""
+    http = _StubHttp({
+        "https://api.github.com/repos/owner/repo/releases/latest":
+            {"tag_name": "v1.0"},
+    })
+    latest_release("owner/repo", http=http)
+    assert "Authorization" not in http.calls[0]["headers"]
+
+
+def test_latest_release_http_error_wraps_to_upstream_lookup_error() -> None:
+    """HTTP-layer failures (404 / 403 / 5xx) wrap into
+    ``UpstreamLookupError`` so callers don't need to import
+    ``HttpError`` for the fail-soft fallthrough path."""
+    http = _StubHttp({}, raise_on="releases/latest",
+                      raise_with=HttpError("404"))
+    with pytest.raises(UpstreamLookupError) as exc_info:
+        latest_release("owner/repo", http=http)
+    assert "404" in str(exc_info.value)
+
+
+def test_latest_release_missing_tag_name_raises() -> None:
+    """If the response is JSON but missing ``tag_name``, that's
+    a server-shape regression — surface as
+    ``UpstreamLookupError`` rather than returning empty."""
+    http = _StubHttp({
+        "https://api.github.com/repos/owner/repo/releases/latest":
+            {"name": "no tag_name field"},
+    })
+    with pytest.raises(UpstreamLookupError):
+        latest_release("owner/repo", http=http)
+
+
+# ---------------------------------------------------------------------------
+# latest_tag
+# ---------------------------------------------------------------------------
+
+def test_latest_tag_picks_highest_stable_semver() -> None:
+    """Among the tags, pick the highest stable-semver version.
+    The classic case: a repo with ``v1.0.0`` / ``v1.5.0`` /
+    ``v2.0.0`` should return ``v2.0.0``."""
+    http = _StubHttp({
+        "https://api.github.com/repos/owner/repo/tags?per_page=100": [
+            {"name": "v1.0.0"},
+            {"name": "v2.0.0"},
+            {"name": "v1.5.0"},
+        ],
+    })
+    assert latest_tag("owner/repo", http=http) == "v2.0.0"
+
+
+def test_latest_tag_filters_pre_releases() -> None:
+    """Reject ``-rc``, ``-beta``, ``.dev0``, ``-alpha`` shapes —
+    an auto-bumper must never land a pre-release in a pin. The
+    only operator-acceptable bump is to a stable tag."""
+    http = _StubHttp({
+        "https://api.github.com/repos/owner/repo/tags?per_page=100": [
+            {"name": "v2.0.0-rc.1"},     # pre-release — skip
+            {"name": "v2.0.0-beta.2"},    # pre-release — skip
+            {"name": "v2.0.0.dev0"},      # PEP440 dev — skip
+            {"name": "v2.0.0-alpha"},     # pre-release — skip
+            {"name": "v1.5.0"},           # stable — winner
+        ],
+    })
+    assert latest_tag("owner/repo", http=http) == "v1.5.0"
+
+
+def test_latest_tag_no_stable_raises() -> None:
+    """If EVERY tag is pre-release / non-semver-shape, raise
+    ``NoStableVersionsFound`` so the bumper can fall back or
+    skip the surface."""
+    http = _StubHttp({
+        "https://api.github.com/repos/owner/repo/tags?per_page=100": [
+            {"name": "v1.0.0-rc.1"},
+            {"name": "v0.9.0-beta"},
+            {"name": "main"},
+        ],
+    })
+    with pytest.raises(NoStableVersionsFound):
+        latest_tag("owner/repo", http=http)
+
+
+def test_latest_tag_handles_four_part_versions() -> None:
+    """NuGet-style ``1.2.3.4`` four-part versions. The regex
+    accepts 1-4 parts so a project that ships ``1.0.0.1`` →
+    ``1.0.0.2`` bumps works."""
+    http = _StubHttp({
+        "https://api.github.com/repos/owner/repo/tags?per_page=100": [
+            {"name": "1.0.0.1"},
+            {"name": "1.0.0.5"},
+            {"name": "1.0.0.3"},
+        ],
+    })
+    assert latest_tag("owner/repo", http=http) == "1.0.0.5"
+
+
+def test_latest_tag_skips_non_semver_branches() -> None:
+    """Branches / non-version refs that happen to be tagged
+    (``main``, ``release-foo``, ``hash-deadbeef``) are silently
+    skipped."""
+    http = _StubHttp({
+        "https://api.github.com/repos/owner/repo/tags?per_page=100": [
+            {"name": "main"},
+            {"name": "release-2026-01"},
+            {"name": "v1.2.3"},
+        ],
+    })
+    assert latest_tag("owner/repo", http=http) == "v1.2.3"
+
+
+# ---------------------------------------------------------------------------
+# Cache integration
+# ---------------------------------------------------------------------------
+
+def test_cache_miss_fetches_and_stores() -> None:
+    """First call cache-misses → live HTTP → put into cache."""
+    cache = _StubCache()
+    http = _StubHttp({
+        "https://api.github.com/repos/owner/repo/releases/latest":
+            {"tag_name": "v1.0"},
+    })
+    latest_release("owner/repo", http=http, cache=cache)
+    assert len(http.calls) == 1
+    assert len(cache.puts) == 1
+
+
+def test_cache_hit_skips_http() -> None:
+    """Second call within TTL cache-hits → no HTTP call."""
+    cache = _StubCache()
+    http = _StubHttp({
+        "https://api.github.com/repos/owner/repo/releases/latest":
+            {"tag_name": "v1.0"},
+    })
+    latest_release("owner/repo", http=http, cache=cache)
+    latest_release("owner/repo", http=http, cache=cache)
+    # Two cache lookups, but only one HTTP call.
+    assert len(cache.gets) == 2
+    assert len(http.calls) == 1
+
+
+def test_cache_disabled_via_ttl_zero() -> None:
+    """``ttl_seconds=0`` forces a refresh (operator override
+    for "I just want the latest")."""
+    cache = _StubCache()
+    http = _StubHttp({
+        "https://api.github.com/repos/owner/repo/releases/latest":
+            {"tag_name": "v1.0"},
+    })
+    latest_release("owner/repo", http=http, cache=cache, ttl_seconds=0)
+    latest_release("owner/repo", http=http, cache=cache, ttl_seconds=0)
+    assert len(http.calls) == 2
+
+
+def test_cache_optional() -> None:
+    """No cache passed → still works, just no caching layer."""
+    http = _StubHttp({
+        "https://api.github.com/repos/owner/repo/releases/latest":
+            {"tag_name": "v1.0"},
+    })
+    assert latest_release("owner/repo", http=http) == "v1.0"
+
+
+# ---------------------------------------------------------------------------
+# resolve_tag_to_sha (Phase 3.b.2)
+# ---------------------------------------------------------------------------
+
+from core.upstream_latest.github_releases import resolve_tag_to_sha
+
+
+def test_resolve_tag_lightweight_returns_commit_sha() -> None:
+    """Lightweight tag (object.type == 'commit') — the
+    ``object.sha`` IS the commit SHA. One API call, no
+    annotated-tag chase needed."""
+    http = _StubHttp({
+        "https://api.github.com/repos/actions/checkout/git/refs/tags/v4":
+            {"object": {
+                "type": "commit",
+                "sha": "abcdef0123456789abcdef0123456789abcdef01",
+            }},
+    })
+    sha = resolve_tag_to_sha("actions/checkout", "v4", http=http)
+    assert sha == "abcdef0123456789abcdef0123456789abcdef01"
+
+
+def test_resolve_tag_annotated_chases_to_commit_sha() -> None:
+    """Annotated tag (object.type == 'tag') — the first
+    response's ``object.sha`` is a TAG OBJECT, not a commit.
+    Chase one more API call to get the underlying commit SHA."""
+    tag_obj_sha = "1111111111111111111111111111111111111111"
+    commit_sha = "2222222222222222222222222222222222222222"
+    http = _StubHttp({
+        "https://api.github.com/repos/actions/checkout/git/refs/tags/v4":
+            {"object": {"type": "tag", "sha": tag_obj_sha}},
+        f"https://api.github.com/repos/actions/checkout/git/tags/{tag_obj_sha}":
+            {"object": {"type": "commit", "sha": commit_sha}},
+    })
+    sha = resolve_tag_to_sha("actions/checkout", "v4", http=http)
+    # Resolved to the underlying commit SHA, not the tag-object SHA.
+    assert sha == commit_sha
+
+
+def test_resolve_tag_missing_returns_upstream_error() -> None:
+    """Non-existent tag → 404 → ``UpstreamLookupError``."""
+    http = _StubHttp({}, raise_on="refs/tags/", raise_with=HttpError("404"))
+    with pytest.raises(UpstreamLookupError):
+        resolve_tag_to_sha("actions/checkout", "v99", http=http)
+
+
+def test_resolve_tag_malformed_object_raises() -> None:
+    """200 with malformed ``object`` shape → UpstreamLookupError
+    (rather than silently returning an invalid SHA)."""
+    http = _StubHttp({
+        "https://api.github.com/repos/x/y/git/refs/tags/v1":
+            {"object": {"type": "commit", "sha": "too-short"}},
+    })
+    with pytest.raises(UpstreamLookupError):
+        resolve_tag_to_sha("x/y", "v1", http=http)

--- a/core/upstream_latest/tests/test_helm_index.py
+++ b/core/upstream_latest/tests/test_helm_index.py
@@ -1,0 +1,166 @@
+"""Tests for ``core.upstream_latest.helm_index``."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from core.http import HttpError
+from core.upstream_latest.github_releases import (
+    NoStableVersionsFound,
+    UpstreamLookupError,
+)
+from core.upstream_latest.helm_index import latest_chart_version
+
+
+# Skip everything if PyYAML isn't available — same fallback as
+# the production code.
+yaml = pytest.importorskip("yaml")
+
+
+class _StubHttp:
+    def __init__(self, payloads: Dict[str, bytes]):
+        self._payloads = payloads
+
+    def get_bytes(self, url: str, **kw):
+        if url in self._payloads:
+            return self._payloads[url]
+        raise HttpError(f"stub: no payload for {url}")
+
+
+def _idx(*, entries: Dict[str, List[Dict[str, Any]]]) -> bytes:
+    return yaml.safe_dump(
+        {"apiVersion": "v1", "entries": entries}
+    ).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+def test_latest_chart_version_picks_highest_stable() -> None:
+    """Multiple versions in the index → highest stable wins."""
+    http = _StubHttp({
+        "https://charts.example.com/index.yaml":
+            _idx(entries={
+                "postgresql": [
+                    {"version": "13.4.4"},
+                    {"version": "13.4.3"},
+                    {"version": "14.0.0"},
+                ],
+            }),
+    })
+    assert latest_chart_version(
+        "https://charts.example.com", "postgresql", http=http,
+    ) == "14.0.0"
+
+
+def test_latest_chart_version_filters_pre_releases() -> None:
+    """Pre-release / variant shapes skipped via the shared
+    ``_version_filter``."""
+    http = _StubHttp({
+        "https://charts.example.com/index.yaml":
+            _idx(entries={
+                "redis": [
+                    {"version": "7.0.0-rc.1"},     # pre-release
+                    {"version": "7.0.0-beta.1"},    # pre-release
+                    {"version": "6.2.0"},           # stable winner
+                ],
+            }),
+    })
+    assert latest_chart_version(
+        "https://charts.example.com", "redis", http=http,
+    ) == "6.2.0"
+
+
+def test_repo_url_trailing_slash_tolerated() -> None:
+    """Many Chart.yaml entries write the URL with a trailing
+    slash. Normalize correctly."""
+    http = _StubHttp({
+        "https://charts.example.com/index.yaml":
+            _idx(entries={"foo": [{"version": "1.0.0"}]}),
+    })
+    assert latest_chart_version(
+        "https://charts.example.com/",     # trailing /
+        "foo", http=http,
+    ) == "1.0.0"
+
+
+def test_full_index_url_accepted_as_is() -> None:
+    """When the operator already wrote
+    ``https://example.com/index.yaml``, don't double-suffix it."""
+    http = _StubHttp({
+        "https://example.com/index.yaml":
+            _idx(entries={"x": [{"version": "1.0"}]}),
+    })
+    assert latest_chart_version(
+        "https://example.com/index.yaml", "x", http=http,
+    ) == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+def test_chart_not_in_entries_raises() -> None:
+    """Index doesn't list the chart name → ``UpstreamLookupError``.
+    Caller decides whether to skip or fallback."""
+    http = _StubHttp({
+        "https://charts.example.com/index.yaml":
+            _idx(entries={"other-chart": [{"version": "1.0.0"}]}),
+    })
+    with pytest.raises(UpstreamLookupError) as exc_info:
+        latest_chart_version(
+            "https://charts.example.com", "missing-chart", http=http,
+        )
+    assert "missing-chart" in str(exc_info.value)
+
+
+def test_all_versions_pre_release_raises() -> None:
+    """Chart exists but every version is pre-release →
+    ``NoStableVersionsFound``."""
+    http = _StubHttp({
+        "https://charts.example.com/index.yaml":
+            _idx(entries={
+                "x": [
+                    {"version": "1.0.0-rc.1"},
+                    {"version": "1.0.0-beta.1"},
+                ],
+            }),
+    })
+    with pytest.raises(NoStableVersionsFound):
+        latest_chart_version(
+            "https://charts.example.com", "x", http=http,
+        )
+
+
+def test_http_failure_wraps_to_upstream_lookup_error() -> None:
+    """Network failure → ``UpstreamLookupError`` (consistent with
+    ``github_releases`` + ``oci_tags`` shape)."""
+    http = _StubHttp({})  # nothing → HttpError on get_bytes
+    with pytest.raises(UpstreamLookupError):
+        latest_chart_version(
+            "https://offline.example.com", "x", http=http,
+        )
+
+
+def test_malformed_yaml_raises() -> None:
+    """Index returned non-YAML bytes → ``UpstreamLookupError``."""
+    http = _StubHttp({
+        "https://example.com/index.yaml":
+            b"this: is: not: valid: yaml: : :",
+    })
+    with pytest.raises(UpstreamLookupError):
+        latest_chart_version("https://example.com", "x", http=http)
+
+
+def test_chart_entry_without_version_field_raises() -> None:
+    """Entry exists but no version key → ``UpstreamLookupError``."""
+    http = _StubHttp({
+        "https://example.com/index.yaml":
+            _idx(entries={"x": [{"name": "x", "digest": "sha"}]}),
+    })
+    with pytest.raises(UpstreamLookupError) as exc_info:
+        latest_chart_version("https://example.com", "x", http=http)
+    assert "version" in str(exc_info.value)

--- a/core/upstream_latest/tests/test_oci_tags.py
+++ b/core/upstream_latest/tests/test_oci_tags.py
@@ -1,0 +1,197 @@
+"""Tests for ``core.upstream_latest.oci_tags``.
+
+Auth handling is exercised end-to-end by
+``core/oci/tests/test_client_list_tags.py``; this file focuses
+on the upstream-latest semantics (stable-semver filtering,
+cache integration, fallback behaviour)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from core.oci.client import OciRegistryClient
+from core.upstream_latest.github_releases import (
+    NoStableVersionsFound,
+    UpstreamLookupError,
+)
+from core.upstream_latest.oci_tags import latest_tag, list_all_tags
+
+
+class _Resp:
+    def __init__(self, status: int, body: bytes,
+                 headers: Optional[Dict[str, str]] = None):
+        self.status_code = status
+        self.content = body
+        self.text = body.decode("utf-8", errors="replace")
+        self.headers = headers or {}
+
+    def close(self):
+        pass
+
+
+class _StubHttp:
+    def __init__(self, responses: Dict[str, _Resp]):
+        self._responses = responses
+        self.calls: List[Dict] = []
+
+    def request(self, method, url, **kw):
+        self.calls.append({"method": method, "url": url})
+        if url in self._responses:
+            return self._responses[url]
+        return _Resp(404, b'{"errors":[]}')
+
+
+def _tags_response(tags: List[str]) -> _Resp:
+    return _Resp(
+        200,
+        json.dumps({"name": "ignored", "tags": tags}).encode(),
+    )
+
+
+class _StubCache:
+    def __init__(self):
+        self.store: Dict[str, Any] = {}
+        self.put_count = 0
+
+    def get(self, key: str, *, ttl_seconds: int):
+        return self.store.get(key)
+
+    def put(self, key: str, value: Any, *, ttl_seconds: int):
+        self.put_count += 1
+        self.store[key] = value
+
+
+# ---------------------------------------------------------------------------
+# latest_tag
+# ---------------------------------------------------------------------------
+
+def test_latest_tag_picks_highest_stable_oci_tag() -> None:
+    """Among a Python image's tags, pick the highest stable
+    numeric tag. Tags like ``3.12-bookworm`` (variant) and
+    ``latest`` (alias) are correctly rejected by the
+    stable-semver filter."""
+    http = _StubHttp({
+        "https://registry-1.docker.io/v2/library/python/tags/list?n=100":
+            _tags_response([
+                "3.11", "3.12", "3.12.1", "3.13.0",
+                "3.12-bookworm", "3.12-slim",        # variants — skip
+                "latest", "main",                      # aliases — skip
+            ]),
+    })
+    assert latest_tag("docker.io/library/python", http=http) == "3.13.0"
+
+
+def test_latest_tag_no_stable_raises() -> None:
+    """An image whose entire tag list is variant / alias / date
+    shapes raises ``NoStableVersionsFound``."""
+    http = _StubHttp({
+        "https://ghcr.io/v2/foo/bar/tags/list?n=100":
+            _tags_response([
+                "main", "latest", "stable",
+                "2024-01-15", "deadbeef",
+                "3.12-alpine",
+            ]),
+    })
+    with pytest.raises(NoStableVersionsFound):
+        latest_tag("ghcr.io/foo/bar", http=http)
+
+
+def test_latest_tag_registry_error_wraps_to_upstream_lookup_error() -> None:
+    """Registry-layer failures (404 / 5xx / auth issues) wrap into
+    ``UpstreamLookupError`` so the bumper's fail-soft fallthrough
+    doesn't need to import ``RegistryError`` from core.oci."""
+    http = _StubHttp({})        # everything → 404
+    with pytest.raises(UpstreamLookupError):
+        latest_tag("docker.io/library/no-such-image", http=http)
+
+
+def test_latest_tag_short_form_image_resolves() -> None:
+    """Short-form ``python`` expands to ``docker.io/library/python``
+    via ``parse_image_ref``. Verifies we don't crash on a bare
+    name."""
+    http = _StubHttp({
+        "https://registry-1.docker.io/v2/library/python/tags/list?n=100":
+            _tags_response(["3.13.0"]),
+    })
+    assert latest_tag("python", http=http) == "3.13.0"
+
+
+def test_latest_tag_ghcr_short_form() -> None:
+    """ghcr.io repos use ``ghcr.io/<owner>/<repo>`` form."""
+    http = _StubHttp({
+        "https://ghcr.io/v2/anthropic/claude-code/tags/list?n=100":
+            _tags_response(["2.1.138", "2.2.0", "v3.0.0"]),
+    })
+    assert latest_tag(
+        "ghcr.io/anthropic/claude-code", http=http,
+    ) == "v3.0.0"
+
+
+# ---------------------------------------------------------------------------
+# list_all_tags
+# ---------------------------------------------------------------------------
+
+def test_list_all_tags_returns_unfiltered() -> None:
+    """``list_all_tags`` returns the full tag list including
+    variants / aliases. Used for diagnostic / future-detector
+    work, not for auto-bump."""
+    http = _StubHttp({
+        "https://registry-1.docker.io/v2/library/python/tags/list?n=100":
+            _tags_response(["3.12", "3.12-bookworm", "latest"]),
+    })
+    tags = list_all_tags("docker.io/library/python", http=http)
+    assert tags == ["3.12", "3.12-bookworm", "latest"]
+
+
+# ---------------------------------------------------------------------------
+# Cache integration
+# ---------------------------------------------------------------------------
+
+def test_cache_hit_skips_http() -> None:
+    """Second call within TTL → no HTTP."""
+    cache = _StubCache()
+    http = _StubHttp({
+        "https://registry-1.docker.io/v2/library/python/tags/list?n=100":
+            _tags_response(["3.13.0"]),
+    })
+    latest_tag("docker.io/library/python", http=http, cache=cache)
+    latest_tag("docker.io/library/python", http=http, cache=cache)
+    # One HTTP call, two cache lookups.
+    assert len(http.calls) == 1
+
+
+def test_cache_key_includes_repo_and_per_page() -> None:
+    """Different per_page should not collide in cache (different
+    response shapes possible if the registry caps differently)."""
+    cache = _StubCache()
+    http = _StubHttp({
+        "https://registry-1.docker.io/v2/library/python/tags/list?n=100":
+            _tags_response(["3.13.0"]),
+        "https://registry-1.docker.io/v2/library/python/tags/list?n=500":
+            _tags_response(["3.13.0", "3.14.0"]),
+    })
+    latest_tag("docker.io/library/python", http=http, cache=cache,
+                per_page=100)
+    latest_tag("docker.io/library/python", http=http, cache=cache,
+                per_page=500)
+    # Both must hit the registry — separate cache entries.
+    assert len(http.calls) == 2
+
+
+def test_cache_ttl_zero_forces_refresh() -> None:
+    """``ttl_seconds=0`` skips both read AND write — operator
+    override for "I want the absolute latest right now"."""
+    cache = _StubCache()
+    http = _StubHttp({
+        "https://registry-1.docker.io/v2/library/python/tags/list?n=100":
+            _tags_response(["3.13.0"]),
+    })
+    latest_tag("docker.io/library/python", http=http, cache=cache,
+                ttl_seconds=0)
+    latest_tag("docker.io/library/python", http=http, cache=cache,
+                ttl_seconds=0)
+    assert len(http.calls) == 2
+    assert cache.put_count == 0

--- a/core/upstream_latest/tests/test_version_filter.py
+++ b/core/upstream_latest/tests/test_version_filter.py
@@ -1,0 +1,100 @@
+"""Tests for the shared stable-semver filter.
+
+Centralised here so a change to the regex / tuple-comparison
+logic gets one test surface that covers every upstream-latest
+caller (github_releases, oci_tags, future helm_index, etc.)
+without duplicating shape tests in each module."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.upstream_latest._version_filter import (
+    highest_stable,
+    parse_stable,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_stable: shape recognition
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("tag", [
+    "1.2.3",
+    "v1.2.3",
+    "0.0.1",
+    "1.0",
+    "1",
+    "1.2.3.4",        # 4-part NuGet assembly version
+    "v0.0.0",
+])
+def test_parse_stable_accepts_stable_shapes(tag: str) -> None:
+    """Stable shapes (1-4 part numeric, optional v-prefix) parse."""
+    assert parse_stable(tag) is not None
+
+
+@pytest.mark.parametrize("tag", [
+    "1.2.3-rc.1",     # semver pre-release
+    "v1.2.3-beta.2",   # semver pre-release
+    "1.2.3.dev0",      # PEP440 dev
+    "20.8b1",          # PEP440 beta inline
+    "20.8rc1",         # PEP440 rc inline
+    "1.2.3-alpha",     # generic pre-release
+    "1.2.3+build.5",   # semver build metadata
+    "main",            # branch ref
+    "latest",          # alias
+    "stable",          # alias
+    "2024-01-15",      # date tag
+    "3.12-bookworm",   # OCI variant
+    "3.12-slim",       # OCI variant
+    "release-2026-01", # named release ref
+    "deadbeef",        # commit hash
+    "",                # empty
+])
+def test_parse_stable_rejects_non_stable_shapes(tag: str) -> None:
+    """Pre-release / variant / branch / non-version shapes
+    must NOT parse — an auto-bumper landing any of these in a
+    pin would be a regression."""
+    assert parse_stable(tag) is None
+
+
+def test_parse_stable_returns_tuple() -> None:
+    """The tuple is used for max(); element-wise comparison gives
+    the right ordering across part-count differences."""
+    assert parse_stable("1.2.3") == (1, 2, 3)
+    assert parse_stable("v0.0.1") == (0, 0, 1)
+    assert parse_stable("1.2.3.4") == (1, 2, 3, 4)
+    assert parse_stable("1") == (1,)
+
+
+# ---------------------------------------------------------------------------
+# highest_stable: comparison + selection
+# ---------------------------------------------------------------------------
+
+def test_highest_stable_picks_largest() -> None:
+    """Numeric ordering — (2, 0, 0) > (1, 5, 0) > (1, 0, 0)."""
+    assert highest_stable(["v1.0.0", "v2.0.0", "v1.5.0"]) == "v2.0.0"
+
+
+def test_highest_stable_strips_non_stable_before_comparing() -> None:
+    """A pre-release with a HIGHER numeric prefix is still
+    rejected; the highest STABLE wins."""
+    tags = ["v1.0.0", "v3.0.0-rc.1", "v2.0.0"]
+    # v3.0.0-rc.1 is pre-release; v2.0.0 wins among stables.
+    assert highest_stable(tags) == "v2.0.0"
+
+
+def test_highest_stable_handles_mixed_part_counts() -> None:
+    """A 4-part version vs 3-part version — element-wise tuple
+    compare gives (1, 0, 0, 1) > (1, 0, 0) naturally."""
+    tags = ["1.0.0", "1.0.0.1"]
+    assert highest_stable(tags) == "1.0.0.1"
+
+
+def test_highest_stable_none_when_nothing_stable() -> None:
+    """No stable shapes → None (callers raise their own error)."""
+    assert highest_stable(["main", "latest", "v1.0-rc"]) is None
+
+
+def test_highest_stable_empty_list() -> None:
+    assert highest_stable([]) is None


### PR DESCRIPTION
# Summary

- Centralizes "what's the latest stable release of $thing" into one package so cve-diff, agentic upstream checks, and the (in-flight) SCA bumper stop reinventing the same dance with three slightly different definitions of "stable" drifting between them.
- One regex (`parse_stable` / `highest_stable` in `_version_filter.py`) decides "is this tag a stable release" across every registry kind. Adding a fourth registry later doesn't get to invent its own answer.
- `HttpClient` + `JsonCache` injected throughout, so consumers control egress policy (proxied / sandboxed) and cache locality.

## Commits

Two commits — clean split so the second is easy to skim:

### 1. GitHub releases + tag + tag-to-sha resolver
- Adapted from @nsomersall's PR #467 (endpoint shape, tag-stripping, cache-key logic)
- Rebuilt onto the shared filter + injected substrate
- Falls through `/releases/latest` → tags-list when the latest release name is non-semver (e.g. `codeql-bundle-v2.25.4`)
- `resolve_tag_to_sha` primitive included for GHA-uses commit-SHA pinning
- Credit in `Co-Authored-By`

### 2. OCI tag listing + Helm index resolver
- `oci_tags.py` (Distribution Spec `/v2/<repo>/tags/list` with Link-header pagination, via new `OciRegistryClient.list_tags`)
- `helm_index.py` (Helm repository `index.yaml` + `CSafeLoader` parse)
