### PR TITLE
core/inventory: Go convention-aware bare-import binding

### DIFF
--- a/core/inventory/call_graph.py
+++ b/core/inventory/call_graph.py
@@ -737,6 +737,60 @@ class _JsCallGraph:
 INDIRECTION_REFLECT = "reflect"
 
 
+def _go_bare_binding_names(path: str) -> List[str]:
+    """Binding names a bare Go ``import "<path>"`` makes available.
+
+    Go's nominal rule is "the last path segment is the package
+    identifier", but two well-known conventions make that wrong
+    often enough to bite SCA's function-level reachability on
+    real-world Go code:
+
+      * **Versioned modules.** ``github.com/foo/bar/v2`` is a Go-
+        modules path-versioning convention. The package name is
+        almost always ``bar`` (the pre-version segment), not ``v2``
+        — callers write ``bar.SomeFunc(...)``. Bare-last-segment
+        binding misses every call to such a package.
+      * **Hyphenated dir names.** Go identifiers can't contain
+        hyphens, so a package at ``github.com/foo/bar-utils``
+        declares its package name without the hyphen (usually
+        ``barutils``, sometimes a shorter form). Bare-last-segment
+        gives ``"bar-utils"`` which no real Go call site uses.
+
+    Both conventions are common — versioned modules grow with
+    every major release post-2019; hyphenated dirs hit any
+    multi-word package name. Adding the convention-aware aliases
+    converts MISSED call edges into resolved ones without false
+    positives (the aliases coexist with the literal last-segment
+    binding; the resolver only matches what's actually called).
+
+    Returns a list (LAST segment first, then aliases). Caller
+    binds in order without overwriting existing entries — first
+    import wins, matching Go's compile-time duplicate-name rule.
+    """
+    names: List[str] = []
+    last = path.rsplit("/", 1)[-1]
+    if not last:
+        return names
+
+    names.append(last)
+
+    # Versioned module suffix: also bind the pre-version segment.
+    if last.startswith("v") and len(last) > 1 and last[1:].isdigit():
+        stripped = path.rsplit("/", 1)[0]
+        if stripped:
+            pre_v_last = stripped.rsplit("/", 1)[-1]
+            if pre_v_last:
+                names.append(pre_v_last)
+                if "-" in pre_v_last:
+                    names.append(pre_v_last.replace("-", ""))
+
+    # Hyphenated last segment: also bind a hyphen-collapsed form.
+    if "-" in last:
+        names.append(last.replace("-", ""))
+
+    return names
+
+
 def extract_call_graph_go(content: str) -> FileCallGraph:
     """Walk a Go source string via tree-sitter and return its
     :class:`FileCallGraph`.
@@ -908,10 +962,13 @@ class _GoCallGraph:
                 self.graph.imports[binding.text.decode()] = path
                 return
 
-        # Bare import: bind the LAST segment of the path.
-        last_segment = path.rsplit("/", 1)[-1]
-        if last_segment:
-            self.graph.imports[last_segment] = path
+        # Bare import: bind the LAST segment plus convention-aware
+        # aliases (versioned modules / hyphenated dirs). Don't
+        # overwrite existing bindings — Go's "first import wins"
+        # semantics handle real collisions via explicit aliasing.
+        for name in _go_bare_binding_names(path):
+            if name and name not in self.graph.imports:
+                self.graph.imports[name] = path
 
     def _import_path(self, spec) -> Optional[str]:
         """Pull the string literal out of an import_spec."""

--- a/core/inventory/tests/test_call_graph_go.py
+++ b/core/inventory/tests/test_call_graph_go.py
@@ -44,6 +44,132 @@ def test_aliased_import():
     assert g.imports == {"str": "strings"}
 
 
+def test_versioned_module_binds_pre_v_segment():
+    """``import "github.com/foo/bar/v2"`` is a Go-modules
+    path-versioning convention. The package name is almost
+    always ``bar`` (callers write ``bar.X(...)``). Bind
+    BOTH ``v2`` (literal last segment) and ``bar`` (pre-version
+    segment) so the resolver finds calls under either name."""
+    g = extract_call_graph_go(
+        'package x\nimport "github.com/foo/bar/v2"\n'
+    )
+    assert g.imports == {
+        "v2": "github.com/foo/bar/v2",
+        "bar": "github.com/foo/bar/v2",
+    }
+
+
+def test_versioned_module_v3():
+    """Same convention for /v3, /v10, …"""
+    g = extract_call_graph_go(
+        'package x\nimport "github.com/foo/bar/v10"\n'
+    )
+    assert g.imports == {
+        "v10": "github.com/foo/bar/v10",
+        "bar": "github.com/foo/bar/v10",
+    }
+
+
+def test_hyphenated_dir_binds_collapsed():
+    """``github.com/foo/bar-utils`` — Go identifiers can't have
+    hyphens, so the package name strips them. Bind both the
+    literal last segment (harmless; not a legal Go identifier
+    so won't collide with real call sites) and a collapsed
+    form ``barutils``."""
+    g = extract_call_graph_go(
+        'package x\nimport "github.com/foo/bar-utils"\n'
+    )
+    assert g.imports == {
+        "bar-utils": "github.com/foo/bar-utils",
+        "barutils": "github.com/foo/bar-utils",
+    }
+
+
+def test_versioned_and_hyphenated_combo():
+    """Pre-version segment is itself hyphenated."""
+    g = extract_call_graph_go(
+        'package x\nimport "github.com/foo/my-pkg/v2"\n'
+    )
+    assert g.imports == {
+        "v2": "github.com/foo/my-pkg/v2",
+        "my-pkg": "github.com/foo/my-pkg/v2",
+        "mypkg": "github.com/foo/my-pkg/v2",
+    }
+
+
+def test_versioned_alias_takes_priority():
+    """Explicit alias still wins — alias goes in via the
+    PKG_IDENT_NODE branch BEFORE we hit the bare-binding code."""
+    g = extract_call_graph_go(
+        'package x\nimport b2 "github.com/foo/bar/v2"\n'
+    )
+    # Alias produces the only binding; convention-aware aliases
+    # only fire for bare imports (no explicit operator choice).
+    assert g.imports == {"b2": "github.com/foo/bar/v2"}
+
+
+def test_bare_binding_doesnt_overwrite():
+    """If two bare imports would alias to the same name, first
+    wins (matching Go's compile-time 'duplicate package name'
+    semantics — operator must have handled the collision via
+    an alias in real code)."""
+    g = extract_call_graph_go(
+        'package x\n'
+        'import (\n'
+        '\t"foo/bar"\n'
+        '\t"baz/bar/v2"\n'
+        ')\n'
+    )
+    # ``foo/bar`` binds ``bar`` first; ``baz/bar/v2`` would also
+    # want ``bar`` via the pre-v alias — refused, kept the first.
+    # ``v2`` from the second import still binds (no collision).
+    assert g.imports["bar"] == "foo/bar"
+    assert g.imports["v2"] == "baz/bar/v2"
+
+
+def test_resolver_matches_versioned_import_call():
+    """End-to-end: a call to ``bar.SomeFunc()`` in a file that
+    imports ``github.com/foo/bar/v2`` resolves to the qualified
+    name ``github.com/foo/bar/v2.SomeFunc``. Without this
+    heuristic, the call would resolve to nothing (``bar`` not in
+    imports map → unresolved)."""
+    from core.inventory.reachability import Verdict, function_called
+
+    cg = extract_call_graph_go(
+        'package x\n'
+        'import "github.com/foo/bar/v2"\n'
+        'func handler() { bar.SomeFunc() }\n'
+    ).to_dict()
+    inv = {
+        "files": [
+            {"path": "src/handler.go", "language": "go",
+             "call_graph": cg},
+        ],
+    }
+    r = function_called(inv, "github.com/foo/bar/v2.SomeFunc")
+    assert r.verdict == Verdict.CALLED
+
+
+def test_resolver_matches_hyphenated_import_call():
+    """End-to-end: call to ``barutils.X()`` in a file importing
+    ``github.com/foo/bar-utils`` resolves to ``bar-utils.X``."""
+    from core.inventory.reachability import Verdict, function_called
+
+    cg = extract_call_graph_go(
+        'package x\n'
+        'import "github.com/foo/bar-utils"\n'
+        'func handler() { barutils.Helper() }\n'
+    ).to_dict()
+    inv = {
+        "files": [
+            {"path": "src/handler.go", "language": "go",
+             "call_graph": cg},
+        ],
+    }
+    r = function_called(inv, "github.com/foo/bar-utils.Helper")
+    assert r.verdict == Verdict.CALLED
+
+
 def test_block_form_imports():
     g = extract_call_graph_go(
         "package x\n"


### PR DESCRIPTION
Function-level reachability on Go projects silently misses call edges when the package name diverges from the path's last segment. Two well-known conventions trigger this in real-world code:

- **Versioned modules.** `github.com/foo/bar/v2` — the Go-modules path-versioning convention. The package name is almost always `bar` (callers write `bar.X(...)`); the `v2` suffix is a path-only artefact. Bare-last-segment binding gives `"v2"` which no call site uses.
- **Hyphenated dir names.** `github.com/foo/bar-utils` — Go identifiers can't contain hyphens, so packages with hyphenated dirs declare their name without (`barutils`). Bare-last-segment gives `"bar-utils"` which no call site uses either.

Both conventions are common — versioned modules grow with every major release post-2019, hyphens hit any multi-word dir name. The miss is silent: reachability returns `NOT_CALLED` for calls that *do* exist, which in security-sensitive use (SCA risk ranking) would downgrade real findings.

- New `_go_bare_binding_names(path)` helper returns `[last_segment, …convention_aliases]`
- `_handle_import_spec` registers all aliases for bare imports
- Aliases never overwrite existing bindings — matches Go's compile-time "first import wins" rule when an operator hasn't disambiguated with an explicit alias
- The literal last-segment binding is preserved, so existing behaviour is a strict subset of the new behaviour (no FPs, only newly-resolved call edges)

Java has a similar issue (wildcard imports, class-context tracking) but is structurally different and a separate effort — not addressed here.