### PR TITLE
feat(iris): SMT codebase gap items A2 + A4

### DIFF
--- a/.claude/skills/code-understanding/map.md
+++ b/.claude/skills/code-understanding/map.md
@@ -139,6 +139,23 @@ Produce a brief summary covering:
       "notes": "Query string built via f-string at line 87"
     }
   ],
+```
+
+For memory-corruption / arithmetic / bounds sinks (CWE-119/120/121/122/125/787/190/191/476), optionally include SMT-checkable path conditions on the sink_detail. The bridge propagates them into attack-paths.json so /validate Stage B's SMT pre-flight ([B-3.1.5]) doesn't have to re-extract from source. Skip for sinks where SMT doesn't apply (XSS/SQLi/cmdi etc — Z3 can't reason about strings the way string-sanitizer-bypass needs):
+
+```json
+{
+  "sink_details": [
+    {
+      "id": "SINK-002",
+      "type": "buffer_write",
+      "operation": "strcpy(buf, argv[1])",
+      "file": "src/util.c",
+      "line": 42,
+      "path_conditions": ["strlen(argv[1]) >= 16"],
+      "path_profile": "uint64"
+    }
+  ],
   "boundary_details": [
     {
       "id": "TB-001",

--- a/core/orchestration/tests/test_understand_bridge.py
+++ b/core/orchestration/tests/test_understand_bridge.py
@@ -826,6 +826,73 @@ class TestPathConditionsForwarding:
 # normalize_context_map
 # ---------------------------------------------------------------------------
 
+class TestUncheckedFlowPathConditionsImport:
+    """A4: /understand --map's sink_details may carry optional
+    `path_conditions` / `path_profile` for memory-corruption /
+    arithmetic / bounds sinks. The bridge propagates each such
+    unchecked_flow as an attack-paths.json entry so Stage B's SMT
+    pre-flight ([B-3.1.5]) finds the conditions ready-made instead
+    of re-extracting from source."""
+
+    def _build_context_map(self, sink_extras=None):
+        """Build a context_map with one unchecked_flow + sink_detail.
+        `sink_extras` overrides on the sink_detail (e.g. add
+        path_conditions / path_profile)."""
+        cm = copy.deepcopy(MINIMAL_CONTEXT_MAP)
+        if sink_extras:
+            cm["sink_details"][0].update(sink_extras)
+        return cm
+
+    def _import_and_get_paths(self, tmp_path, sink_extras=None):
+        understand_dir = tmp_path / "understand"
+        validate_dir = tmp_path / "validate"
+        understand_dir.mkdir()
+        validate_dir.mkdir()
+        _write_json(
+            understand_dir / "context-map.json",
+            self._build_context_map(sink_extras),
+        )
+        load_understand_context(understand_dir, validate_dir)
+        paths_path = validate_dir / "attack-paths.json"
+        if not paths_path.exists():
+            return []
+        return json.loads(paths_path.read_text())
+
+    def test_no_conditions_no_attack_path(self, tmp_path):
+        """sink_detail without path_conditions → no attack-paths
+        entry. The existing priority_targets path covers this case
+        without polluting attack-paths.json."""
+        paths = self._import_and_get_paths(tmp_path)
+        # No path_conditions on the sink, no path-with-source=map
+        assert not any(p.get("source") == "understand:map" for p in paths)
+
+    def test_with_conditions_emits_attack_path(self, tmp_path):
+        """sink_detail with path_conditions → attack-paths entry
+        carrying the conditions + understand:map source label."""
+        paths = self._import_and_get_paths(tmp_path, sink_extras={
+            "path_conditions": ["strlen(argv[1]) >= 16"],
+            "path_profile": "uint64",
+        })
+        map_paths = [p for p in paths if p.get("source") == "understand:map"]
+        assert len(map_paths) == 1
+        entry = map_paths[0]
+        assert entry["path_conditions"] == ["strlen(argv[1]) >= 16"]
+        assert entry["path_profile"] == "uint64"
+
+    def test_malformed_conditions_dropped(self, tmp_path):
+        """Same validation as the trace path: malformed path_conditions
+        (not a list) drop the field rather than poison downstream."""
+        paths = self._import_and_get_paths(tmp_path, sink_extras={
+            "path_conditions": "not a list",
+        })
+        # Either no entry written (no valid conditions) or entry
+        # without path_conditions — both are acceptable, the key
+        # is malformed data doesn't propagate
+        for p in paths:
+            if p.get("source") == "understand:map":
+                assert "path_conditions" not in p
+
+
 class TestNormalizeContextMap:
     def _checklist(self, files):
         return {"target_path": "/repo", "files": files}

--- a/core/orchestration/understand_bridge.py
+++ b/core/orchestration/understand_bridge.py
@@ -443,6 +443,20 @@ def load_understand_context(
     trace_stats = _import_flow_traces(understand_dir, validate_dir, stale_files)
     summary["flow_traces"] = trace_stats
 
+    # --- Import unchecked_flows with SMT path_conditions ---
+    # /understand --map's sink_details can carry optional
+    # `path_conditions` / `path_profile` for memory-corruption /
+    # arithmetic / bounds sinks. Forward each such unchecked_flow
+    # as an attack-paths.json entry so /validate Stage B's SMT
+    # pre-flight finds the conditions ready-made (saves the LLM
+    # re-extracting from source). Sinks without path_conditions
+    # are skipped — the existing priority_targets path covers
+    # them for non-SMT consumers.
+    map_smt_stats = _import_unchecked_flow_conditions(
+        context_map, validate_dir,
+    )
+    summary["map_smt_paths"] = map_smt_stats
+
     logger.info(
         "understand_bridge: loaded context map from %s — "
         "%d sources, %d sinks, %d trust boundaries, %d unchecked flows, "
@@ -1343,6 +1357,88 @@ def _import_flow_traces(
         save_json(paths_path, existing_paths)
 
     return {"count": len(trace_files), "imported_as_paths": imported, "skipped_stale": skipped_stale}
+
+
+def _import_unchecked_flow_conditions(
+    context_map: Dict[str, Any],
+    validate_dir: Path,
+) -> Dict[str, Any]:
+    """Import path_conditions from sink_details into attack-paths.json.
+
+    Walks `unchecked_flows`; for each flow whose referenced sink_detail
+    has `path_conditions` set, writes an attack-paths.json entry
+    carrying those conditions (+ optional `path_profile`). /validate
+    Stage B's SMT pre-flight then finds them ready-made instead of
+    re-extracting from source.
+
+    Skips flows whose sink_detail has no path_conditions — those stay
+    in priority_targets (existing path) without polluting attack-paths.
+
+    Returns {"count": <total>, "imported_as_paths": <with_conditions>,
+    "skipped_no_conditions": <without>}.
+    """
+    flows = _list_at(context_map, "unchecked_flows")
+    if not flows:
+        return {"count": 0, "imported_as_paths": 0, "skipped_no_conditions": 0}
+
+    _, sink_by_id = _index_entries_by_id(context_map)
+
+    paths_path = validate_dir / "attack-paths.json"
+    existing_paths: List[Dict[str, Any]] = []
+    if paths_path.exists():
+        loaded = load_json(paths_path)
+        if isinstance(loaded, list):
+            existing_paths = loaded
+    existing_ids = {p.get("id") for p in existing_paths if p.get("id")}
+
+    imported = 0
+    skipped = 0
+    for i, flow in enumerate(flows):
+        if not isinstance(flow, dict):
+            continue
+        sink_id = flow.get("sink")
+        sink = sink_by_id.get(sink_id) if isinstance(sink_id, str) else None
+        if not sink:
+            skipped += 1
+            continue
+        pc = _validate_path_conditions(
+            sink.get("path_conditions"), f"sink_detail:{sink_id}",
+        )
+        if pc is None:
+            skipped += 1
+            continue
+        path_id = f"map-flow-{i:03d}"
+        if path_id in existing_ids:
+            continue
+        entry: Dict[str, Any] = {
+            "id": path_id,
+            "name": f"Imported from /understand --map: {flow.get('entry_point')} → {sink_id}",
+            "finding": "",
+            "steps": [],
+            "proximity": 0,
+            "blockers": [],
+            "status": "uncertain",
+            "source": "understand:map",
+            "imported_at": datetime.now(timezone.utc).isoformat(),
+            "path_conditions": pc,
+        }
+        pp = _validate_path_profile(
+            sink.get("path_profile"), f"sink_detail:{sink_id}",
+        )
+        if pp is not None:
+            entry["path_profile"] = pp
+        existing_paths.append(entry)
+        existing_ids.add(path_id)
+        imported += 1
+
+    if imported > 0:
+        save_json(paths_path, existing_paths)
+
+    return {
+        "count": len(flows),
+        "imported_as_paths": imported,
+        "skipped_no_conditions": skipped,
+    }
 
 
 def _trace_to_attack_path(trace: Dict[str, Any], trace_file: Path) -> Dict[str, Any]:

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -1765,4 +1765,48 @@ def _structural_grouping(results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     for ref, fids_set in ref_to_fids.items():
         _add_group("shared_dataflow_ref", ref, list(fids_set))
 
+    # Group by shared SMT witness model. When two findings have
+    # identical witness models (same variable=value assignment that
+    # satisfies their path conditions), Z3 has effectively said
+    # "the SAME concrete attacker input drives both findings". That
+    # makes the pair a single attack vector rather than two
+    # independent bugs — operator should test them together. The
+    # fingerprint is a sorted-tuple of (variable, integer-value)
+    # pairs derived from `smt_witness.model`. Skip witnesses where
+    # ALL keys are `_anon_*` placeholders — those are over-
+    # approximating (Z3 picked the smallest BV satisfying the
+    # condition, not a meaningful attacker input), so the "shared
+    # witness" signal becomes spurious. Anon vars with concrete
+    # decoded names (via anon_var_map) DO count as named because
+    # the witness then describes a real attacker-visible quantity
+    # (e.g. strlen(argv[1])=32).
+    by_witness: Dict[Tuple, List[str]] = {}
+    for fid, r in findings_by_id.items():
+        witness = r.get("smt_witness") or {}
+        model = witness.get("model") or {}
+        if not model:
+            continue
+        anon_map = witness.get("anon_var_map") or {}
+        # Skip when EVERY model key is an undecoded _anon_N — pure
+        # opaque-placeholder witnesses don't describe a real shared
+        # attacker input.
+        if model and all(
+            k.startswith("_anon_") and k not in anon_map
+            for k in model
+        ):
+            continue
+        fingerprint = tuple(sorted(
+            (k, v if not isinstance(v, int) else int(v))
+            for k, v in model.items()
+        ))
+        by_witness.setdefault(fingerprint, []).append(fid)
+    for fingerprint, fids in by_witness.items():
+        # Render the fingerprint as a comma-separated `var=val`
+        # string for the criterion_value field; truncate to keep
+        # report lines readable.
+        rendered = ", ".join(f"{k}={v}" for k, v in fingerprint)
+        if len(rendered) > 80:
+            rendered = rendered[:77] + "..."
+        _add_group("smt_shared_witness", rendered, fids)
+
     return groups

--- a/packages/llm_analysis/tests/test_orchestrator.py
+++ b/packages/llm_analysis/tests/test_orchestrator.py
@@ -612,6 +612,89 @@ class TestStructuralGrouping:
         groups = _structural_grouping(results)
         assert len(groups) == 0
 
+    def test_smt_shared_witness_groups_findings_with_same_model(self):
+        """Two findings whose Tier 4 SMT witness has the same
+        variable=value model end up in the same `smt_shared_witness`
+        group. Z3 has effectively said the same concrete attacker
+        input triggers both — single attack vector, operator should
+        test them together."""
+        results = [
+            {"finding_id": "f-001", "file_path": "a.c", "rule_id": "r1",
+             "smt_witness": {
+                 "model": {"count": 268435456, "total": 0},
+                 "anon_var_map": {},
+             }},
+            {"finding_id": "f-002", "file_path": "b.c", "rule_id": "r2",
+             "smt_witness": {
+                 "model": {"count": 268435456, "total": 0},
+                 "anon_var_map": {},
+             }},
+        ]
+        groups = _structural_grouping(results)
+        witness_groups = [g for g in groups if g["criterion"] == "smt_shared_witness"]
+        assert len(witness_groups) == 1
+        assert set(witness_groups[0]["finding_ids"]) == {"f-001", "f-002"}
+        # criterion_value must be human-readable (not just `tuple(...)`)
+        assert "count=268435456" in witness_groups[0]["criterion_value"]
+
+    def test_smt_shared_witness_skips_pure_anon_models(self):
+        """Two findings with the SAME `_anon_N` model but NO
+        anon_var_map decoder are NOT grouped — pure-opaque
+        witnesses are Z3 picking the smallest BV that satisfies the
+        condition (not a meaningful shared attacker input). Pre-
+        check that the spurious grouping doesn't fire."""
+        results = [
+            {"finding_id": "f-001", "file_path": "a.c", "rule_id": "r1",
+             "smt_witness": {
+                 "model": {"_anon_0": 32},
+                 "anon_var_map": {},  # NO decoding
+             }},
+            {"finding_id": "f-002", "file_path": "b.c", "rule_id": "r2",
+             "smt_witness": {
+                 "model": {"_anon_0": 32},
+                 "anon_var_map": {},
+             }},
+        ]
+        groups = _structural_grouping(results)
+        assert not any(g["criterion"] == "smt_shared_witness" for g in groups), (
+            "Pure-opaque _anon_N witness should not produce a shared-witness "
+            "group — the value is Z3's choice, not a real attacker input"
+        )
+
+    def test_smt_shared_witness_groups_decoded_anon_models(self):
+        """When the SAME `_anon_N` value DOES have a decoder
+        (anon_var_map), the witness describes a real attacker-
+        visible quantity (e.g. strlen(argv[1])=32). Group them."""
+        results = [
+            {"finding_id": "f-001", "file_path": "a.c", "rule_id": "r1",
+             "smt_witness": {
+                 "model": {"_anon_0": 32},
+                 "anon_var_map": {"_anon_0": "strlen(argv[1])"},
+             }},
+            {"finding_id": "f-002", "file_path": "b.c", "rule_id": "r2",
+             "smt_witness": {
+                 "model": {"_anon_0": 32},
+                 "anon_var_map": {"_anon_0": "strlen(argv[1])"},
+             }},
+        ]
+        groups = _structural_grouping(results)
+        witness_groups = [g for g in groups if g["criterion"] == "smt_shared_witness"]
+        assert len(witness_groups) == 1
+        assert set(witness_groups[0]["finding_ids"]) == {"f-001", "f-002"}
+
+    def test_smt_no_witness_no_group(self):
+        """No smt_witness field, or empty model, contributes no
+        grouping signal."""
+        results = [
+            {"finding_id": "f-001", "file_path": "a.c"},
+            {"finding_id": "f-002", "file_path": "b.c",
+             "smt_witness": {"model": {}}},
+            {"finding_id": "f-003", "file_path": "c.c",
+             "smt_witness": {}},
+        ]
+        groups = _structural_grouping(results)
+        assert not any(g["criterion"] == "smt_shared_witness" for g in groups)
+
     def test_shared_dataflow_source(self):
         results = [
             {"finding_id": "f-001", "file_path": "a.py", "rule_id": "sqli",


### PR DESCRIPTION
Two non-overlapping items from the 2026-05-10 codebase gap audit (`project_smt_codebase_gaps.md`), both surfaced as "fair game, no upstream coordination" and shippable within the per-item ≤100 LOC budget. Drive-by adjacent: C3 closed in memory as "not a gap" — see project_smt_codebase_gaps notes.

A2: Group analysis SMT-shared-witness grouping

Extends `_structural_grouping` in `orchestrator.py` to add a new `smt_shared_witness` group criterion. Findings with identical Tier 4 SMT witness models (same `{var: value}` model satisfying their `path_conditions`) group together — Z3 has effectively said "the same concrete attacker input triggers both findings", making the pair a single attack vector worth testing together rather than two independent bugs.

Fingerprint is a sorted tuple of `(variable, integer-value)` pairs from `analysis.smt_witness.model`. Rendered as `var1=N, var2=M, ...` in `criterion_value` (truncated to 80 chars).

Skip rule: when EVERY model key is an undecoded `_anon_N` placeholder, don't group — Z3 picked the smallest BV satisfying the condition, not a meaningful shared attacker input. DECODED anon vars (via `anon_var_map`, e.g.
`_anon_0 → strlen(argv[1])`) DO count — they describe a real attacker-visible quantity shared across findings.

Empty model / missing `smt_witness` / pure-opaque witness all contribute no grouping signal.
4 new pin-tests in `TestStructuralGrouping` cover the four cases (grouped named-locals, skipped opaque, grouped decoded-anon, no-signal absent).

A4: /understand --map carries path_conditions to /validate

Lets `/understand --map` sink_details optionally emit SMT-checkable `path_conditions` / `path_profile` for memory- corruption / arithmetic / bounds sinks (CWE-119/120/121/122/ 125/787/190/191/476). The bridge forwards each unchecked_flow whose sink_detail carries conditions as a new attack-paths.json entry tagged `source: understand:map`. /validate Stage B's SMT pre-flight ([B-3.1.5]) then finds them ready-made instead of re-extracting from source.

Three changes:

1. `.claude/skills/code-understanding/map.md` gains optional `path_conditions` + `path_profile` fields on the sink_detail schema. Skill prose explains when to populate (memory- corruption CWEs) and when to skip (XSS / SQLi / cmdi — Z3 can't reason about strings).

2. `core/orchestration/understand_bridge.py` gets a new `_import_unchecked_flow_conditions(context_map, validate_dir)` called alongside `_import_flow_traces` in `load_understand_context`. Walks unchecked_flows; for each whose referenced sink_detail has path_conditions, writes an attack-paths.json entry with the conditions + optional profile. Skips flows without conditions (priority_targets path still covers them for non-SMT consumers, without polluting attack-paths.json).

3. Reuses existing `_validate_path_conditions` / `_validate_path_profile` helpers — malformed values are dropped with a logged warning rather than poisoning downstream Stage B.

3 new pin-tests in `TestUncheckedFlowPathConditionsImport` cover: no-conditions → no attack-paths entry,
conditions-present → entry with `source: understand:map`, malformed-conditions dropped.

Adversarial review (8-point checklist) clean for both items: no argv injection, no path-resolution issues, no signature break, no metric-dict-consumer break, no error-path leaks, no hostile-input vectors beyond the existing trust model.

E2E for A4: synthesised context-map.json with two
unchecked_flows (one with path_conditions, one without) → `load_understand_context` → attack-paths.json correctly contains 1 entry (`source: understand:map`, conditions + profile preserved); summary reports
`{count: 2, imported_as_paths: 1, skipped_no_conditions: 1}`.