### PR TITLE
feat: add raptor doctor self-check

### DIFF
--- a/bin/raptor
+++ b/bin/raptor
@@ -82,6 +82,7 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
 
 Usage: raptor [options] [target]
        raptor project <subcommand> [args]
+       raptor doctor
 
 Arguments:
   target             Path or URL to scan (optional)
@@ -117,6 +118,13 @@ if [[ "${1:-}" == "project" ]]; then
     shift
     cd "$RAPTOR_DIR" || exit 1
     exec "$RAPTOR_DIR/libexec/raptor-project-manager" "$@"
+fi
+
+# Route doctor directly (no Claude needed)
+if [[ "${1:-}" == "doctor" ]]; then
+    shift
+    cd "$RAPTOR_DIR" || exit 1
+    exec python3 "$RAPTOR_DIR/raptor.py" doctor "$@"
 fi
 
 # Claude required for everything else

--- a/core/doctor.py
+++ b/core/doctor.py
@@ -1,0 +1,139 @@
+"""Environment self-checks for RAPTOR operators.
+
+The doctor command is intentionally lightweight: it checks local prerequisites
+and filesystem assumptions without contacting external services or reading any
+secrets.  It is safe to run before an analysis session to explain likely setup
+problems in one place instead of failing later inside a scanner wrapper.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import platform
+import shutil
+import sys
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class DoctorCheck:
+    """One doctor check result."""
+
+    name: str
+    status: str
+    detail: str
+
+
+_REQUIRED_DIRS = ("core", "packages", "libexec", "bin")
+_OPTIONAL_TOOLS = (
+    ("claude", "Claude Code launcher"),
+    ("semgrep", "static-analysis scans"),
+    ("codeql", "CodeQL scans"),
+    ("afl-fuzz", "binary fuzzing"),
+)
+
+
+def _status_line(check: DoctorCheck) -> str:
+    marker = {"pass": "✓", "warn": "!", "fail": "✗"}.get(check.status, "?")
+    return f"{marker} {check.status.upper():4} {check.name}: {check.detail}"
+
+
+def _repo_root(explicit_root: Path | None = None) -> Path:
+    return (explicit_root or Path(__file__).resolve().parents[1]).resolve()
+
+
+def _check_python() -> DoctorCheck:
+    version = sys.version_info
+    detail = f"Python {platform.python_version()} at {sys.executable}"
+    if version < (3, 10):
+        return DoctorCheck("python", "fail", f"{detail}; RAPTOR expects Python >= 3.10")
+    return DoctorCheck("python", "pass", detail)
+
+
+def _check_repo_layout(root: Path) -> DoctorCheck:
+    missing = [name for name in _REQUIRED_DIRS if not (root / name).is_dir()]
+    if missing:
+        return DoctorCheck("repo_layout", "fail", f"missing required directories: {', '.join(missing)}")
+    return DoctorCheck("repo_layout", "pass", f"found RAPTOR checkout at {root}")
+
+
+def _check_writable(path: Path, name: str) -> DoctorCheck:
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        probe = path / ".raptor-doctor-write-test"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink()
+    except OSError as exc:
+        return DoctorCheck(name, "fail", f"not writable: {path} ({exc})")
+    return DoctorCheck(name, "pass", f"writable: {path}")
+
+
+def _check_tool(binary: str, purpose: str) -> DoctorCheck:
+    resolved = shutil.which(binary)
+    if resolved:
+        return DoctorCheck(f"tool:{binary}", "pass", f"{purpose}: {resolved}")
+    return DoctorCheck(f"tool:{binary}", "warn", f"not found; needed for {purpose}")
+
+
+def _check_dangerous_env() -> DoctorCheck:
+    dangerous = sorted(
+        name for name in ("PYTHONPATH", "LD_PRELOAD", "LD_LIBRARY_PATH", "DYLD_INSERT_LIBRARIES")
+        if os.environ.get(name)
+    )
+    if dangerous:
+        return DoctorCheck(
+            "environment",
+            "warn",
+            "potentially process-influencing env vars are set: " + ", ".join(dangerous),
+        )
+    return DoctorCheck("environment", "pass", "no common process-influencing env vars detected")
+
+
+def collect_checks(root: Path | None = None) -> list[DoctorCheck]:
+    """Collect RAPTOR doctor checks.
+
+    ``root`` is injectable for tests; callers normally omit it so the checkout
+    is inferred from this module's location.
+    """
+
+    repo_root = _repo_root(root)
+    checks: list[DoctorCheck] = [
+        _check_python(),
+        _check_repo_layout(repo_root),
+        _check_writable(repo_root / "out", "output_dir"),
+        _check_writable(repo_root / ".raptor" / "tmp", "state_tmp"),
+        _check_dangerous_env(),
+    ]
+    checks.extend(_check_tool(binary, purpose) for binary, purpose in _OPTIONAL_TOOLS)
+    return checks
+
+
+def render_checks(checks: Iterable[DoctorCheck]) -> str:
+    """Render checks as human-readable terminal output."""
+
+    check_list = list(checks)
+    lines = ["RAPTOR doctor", "============="]
+    lines.extend(_status_line(check) for check in check_list)
+    failures = sum(1 for check in check_list if check.status == "fail")
+    warnings = sum(1 for check in check_list if check.status == "warn")
+    lines.append("")
+    lines.append(f"Summary: {failures} failure(s), {warnings} warning(s)")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the doctor command."""
+
+    argv = argv or []
+    if argv:
+        print("usage: raptor doctor", file=sys.stderr)
+        return 2
+    checks = collect_checks()
+    print(render_checks(checks))
+    return 1 if any(check.status == "fail" for check in checks) else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))

--- a/core/tests/test_doctor.py
+++ b/core/tests/test_doctor.py
@@ -1,0 +1,71 @@
+"""Unit tests for the RAPTOR doctor command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+from core.doctor import DoctorCheck, collect_checks, main, render_checks
+
+
+def _minimal_repo(root: Path) -> None:
+    for dirname in ("core", "packages", "libexec", "bin"):
+        (root / dirname).mkdir(parents=True)
+
+
+def test_collect_checks_reports_layout_and_writable_dirs(tmp_path: Path):
+    _minimal_repo(tmp_path)
+
+    checks = collect_checks(tmp_path)
+    by_name = {check.name: check for check in checks}
+
+    assert by_name["repo_layout"].status == "pass"
+    assert by_name["output_dir"].status == "pass"
+    assert by_name["state_tmp"].status == "pass"
+    assert (tmp_path / "out").is_dir()
+    assert (tmp_path / ".raptor" / "tmp").is_dir()
+
+
+def test_collect_checks_fails_when_repo_layout_is_missing(tmp_path: Path):
+    checks = collect_checks(tmp_path)
+    by_name = {check.name: check for check in checks}
+
+    assert by_name["repo_layout"].status == "fail"
+    assert "missing required directories" in by_name["repo_layout"].detail
+
+
+def test_render_checks_includes_summary():
+    output = render_checks(
+        [
+            DoctorCheck("python", "pass", "ok"),
+            DoctorCheck("tool:semgrep", "warn", "not found"),
+            DoctorCheck("repo_layout", "fail", "missing"),
+        ]
+    )
+
+    assert "RAPTOR doctor" in output
+    assert "PASS python: ok" in output
+    assert "WARN tool:semgrep: not found" in output
+    assert "FAIL repo_layout: missing" in output
+    assert "Summary: 1 failure(s), 1 warning(s)" in output
+
+
+def test_main_rejects_unexpected_args(capsys):
+    rc = main(["--json"])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "usage: raptor doctor" in captured.err
+
+
+def test_main_exits_zero_without_failures(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "core.doctor.collect_checks",
+        lambda: [DoctorCheck("python", "pass", sys.version.split()[0])],
+    )
+
+    rc = main([])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "RAPTOR doctor" in captured.out

--- a/raptor.py
+++ b/raptor.py
@@ -18,6 +18,7 @@ Available Modes:
     web         - Web application security testing
     agentic     - Full autonomous workflow
     codeql      - CodeQL-only analysis
+    doctor      - Local environment self-check
     help        - Show detailed help for a specific mode
 
 Examples:
@@ -247,7 +248,8 @@ def _get_or_start_dispatcher():
         return _active_dispatcher
     try:
         from core.llm.dispatcher.server import LLMDispatcher
-        import uuid, atexit
+        import atexit
+        import uuid
         _active_dispatcher = LLMDispatcher(run_id=f"raptor-{uuid.uuid4().hex[:8]}")
         atexit.register(_active_dispatcher.shutdown)
         return _active_dispatcher
@@ -445,8 +447,17 @@ def mode_llm_analysis(args: list) -> int:
     return _run_script(llm_script, args)
 
 
+def mode_doctor(args: list) -> int:
+    """Run local environment self-checks."""
+    from core.doctor import main as doctor_main
+
+    return doctor_main(args)
+
+
 def show_mode_help(mode: str) -> None:
     """Show detailed help for a specific mode."""
+    from core.config import RaptorConfig
+
     script_root = Path(__file__).parent
     
     mode_scripts = {
@@ -502,6 +513,7 @@ Available Modes:
   agentic     - Full autonomous workflow (Semgrep + CodeQL + LLM analysis)
   codeql      - CodeQL-only analysis
   analyze     - LLM-powered vulnerability analysis (requires SARIF input)
+  doctor      - Local environment self-check
 
 Examples:
   # Full autonomous workflow
@@ -521,6 +533,9 @@ Examples:
 
   # LLM analysis of existing SARIF
   python3 raptor.py analyze --repo /path/to/code --sarif findings.sarif
+
+  # Check local environment and optional tools
+  python3 raptor.py doctor
 
 Sandbox isolation (available on all modes):
   --sandbox {full,debug,network-only,none}
@@ -597,6 +612,7 @@ def main():
         'agentic': mode_agentic,
         'codeql': mode_codeql,
         'analyze': mode_llm_analysis,
+        'doctor': mode_doctor,
     }
     
     if mode not in mode_handlers:


### PR DESCRIPTION
## Summary
- add a `raptor doctor` self-check command for setup diagnostics
- route `./bin/raptor doctor` without requiring Claude Code first
- cover the doctor checks with focused unit tests

## Why
This gives new and returning RAPTOR users a quick way to identify common local setup issues before running heavier scans. The output is intentionally actionable and copy-paste friendly.

## Validation
- `python3 -m ruff check core/doctor.py core/tests/test_doctor.py raptor.py`
- `python3 -m pytest -q core/tests/test_doctor.py core/security/tests/test_log_sanitisation.py`
- `python3 raptor.py doctor`
- `./bin/raptor doctor`
