### PR TITLE
feat(web): add opt-in ffuf discovery

### DIFF
--- a/packages/web/ffuf.py
+++ b/packages/web/ffuf.py
@@ -190,7 +190,7 @@ class FfufRunner:
             "reported_result_count": len(summarized_results),
             "omitted_result_count": max(0, len(results) - len(summarized_results)),
             "results": summarized_results,
-            "stderr": self._redact(completed.stderr.strip()),
+            "stderr": self._redact((completed.stderr or "").strip()),
         }
 
     def _summarize_result(self, result: dict[str, Any]) -> dict[str, Any]:

--- a/packages/web/ffuf.py
+++ b/packages/web/ffuf.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Narrow ffuf integration for RAPTOR web scans.
+
+The runner is intentionally small and opt-in: operators must provide a
+wordlist, and RAPTOR constrains the ffuf URL template to the configured target
+origin before spawning the external binary.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+from core.logging import get_logger
+from core.sandbox import run_untrusted
+from core.security.redaction import redact_secrets
+
+logger = get_logger()
+
+
+@dataclass(frozen=True)
+class FfufConfig:
+    """Configuration for an explicit ffuf content-discovery run."""
+
+    wordlist: Path
+    path_template: str = "FUZZ"
+    threads: int = 10
+    rate: int | None = None
+    timeout: int = 30
+    max_runtime: int = 300
+    report_limit: int = 50
+    binary: str = "ffuf"
+    auto_calibration: bool = True
+    match_status: str | None = "200,204,301,302,307,401,403,405,500"
+    filter_status: str | None = "404"
+    filter_size: int | None = None
+
+
+class FfufRunner:
+    """Run ffuf against a single in-scope target origin."""
+
+    def __init__(self, base_url: str, out_dir: Path, reveal_secrets: bool = False):
+        self.base_url = base_url.rstrip("/")
+        self.out_dir = out_dir
+        self.reveal_secrets = reveal_secrets
+
+    def _origin(self, url: str) -> tuple[str, str, int]:
+        parsed = urlparse(url)
+        default_port = 443 if parsed.scheme == "https" else 80
+        return (
+            parsed.scheme.lower(),
+            (parsed.hostname or "").lower(),
+            parsed.port or default_port,
+        )
+
+    def _redact(self, value: object) -> str:
+        return redact_secrets(value, reveal_secrets=self.reveal_secrets)
+
+    def build_url_template(self, path_template: str) -> str:
+        """Build and scope-check the ffuf URL template.
+
+        ffuf marks the replacement point with ``FUZZ``. Accepting a raw URL from
+        the CLI without checking it would let a saved RAPTOR config or copied
+        command accidentally aim ffuf at a different host. Treat the template
+        like WebClient paths: relative paths are anchored to ``base_url``;
+        absolute URLs are allowed only when their normalized origin matches.
+
+        ``urljoin`` intentionally normalizes ``..`` segments before the origin
+        check. That can move a relative template outside the base path while
+        staying on the same origin; this integration scopes ffuf to the target
+        host/origin rather than to a specific subpath.
+        """
+        if "FUZZ" not in path_template:
+            raise ValueError("ffuf path template must include FUZZ")
+
+        url_template = urljoin(self.base_url + "/", path_template)
+        probe_url = url_template.replace("FUZZ", "raptor-scope-probe")
+        if self._origin(probe_url) != self._origin(self.base_url):
+            raise ValueError(
+                "ffuf path template is outside configured target scope: "
+                f"{self._redact(probe_url)}"
+            )
+        return url_template
+
+    def build_command(self, config: FfufConfig, output_file: Path) -> list[str]:
+        """Return argv for a safe, non-shell ffuf invocation."""
+        if not config.wordlist.is_file():
+            raise FileNotFoundError(f"ffuf wordlist not found: {config.wordlist}")
+        if config.threads < 1:
+            raise ValueError("ffuf threads must be >= 1")
+        if config.rate is not None and config.rate < 1:
+            raise ValueError("ffuf rate must be >= 1 when set")
+        if config.timeout < 1:
+            raise ValueError("ffuf timeout must be >= 1")
+        if config.max_runtime < 1:
+            raise ValueError("ffuf max runtime must be >= 1")
+        if config.report_limit < 0:
+            raise ValueError("ffuf report limit must be >= 0")
+        if config.filter_size is not None and config.filter_size < 0:
+            raise ValueError("ffuf filter size must be >= 0 when set")
+
+        url_template = self.build_url_template(config.path_template)
+        cmd = [
+            config.binary,
+            "-u",
+            url_template,
+            "-w",
+            str(config.wordlist),
+            "-of",
+            "json",
+            "-o",
+            str(output_file),
+            "-noninteractive",
+            "-t",
+            str(config.threads),
+            "-timeout",
+            str(config.timeout),
+        ]
+        if config.auto_calibration:
+            cmd.append("-ac")
+        if config.match_status:
+            cmd.extend(["-mc", config.match_status])
+        if config.filter_status:
+            cmd.extend(["-fc", config.filter_status])
+        if config.filter_size is not None:
+            cmd.extend(["-fs", str(config.filter_size)])
+        if config.rate is not None:
+            cmd.extend(["-rate", str(config.rate)])
+        return cmd
+
+    def run(self, config: FfufConfig) -> dict[str, Any]:
+        """Run ffuf in RAPTOR's sandbox and return a compact result summary.
+
+        ffuf exits non-zero for several operational conditions (no matches,
+        interrupted run, config error). RAPTOR keeps the raw JSON artifact when
+        present and reports the return code instead of treating every non-zero
+        as a scanner crash.
+        """
+        binary_path = shutil.which(config.binary)
+        if binary_path is None:
+            raise FileNotFoundError(
+                f"ffuf binary not found on PATH: {config.binary}. "
+                "Install ffuf or pass --ffuf-bin."
+            )
+
+        target_host = (urlparse(self.base_url).hostname or "").lower()
+        if not target_host:
+            raise ValueError("ffuf base URL must include a hostname")
+
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+        output_file = self.out_dir / "ffuf_results.json"
+        cmd = self.build_command(config, output_file)
+        redacted_cmd = [self._redact(part) for part in cmd]
+        logger.info(f"Running sandboxed ffuf: {' '.join(redacted_cmd)}")
+
+        completed = run_untrusted(
+            cmd,
+            target=str(config.wordlist.parent),
+            output=str(self.out_dir),
+            readable_paths=[str(config.wordlist.parent)],
+            use_egress_proxy=True,
+            proxy_hosts=[target_host],
+            tool_paths=[str(Path(binary_path).parent)],
+            caller_label="web-ffuf",
+            timeout=config.max_runtime,
+            capture_output=True,
+            text=True,
+        )
+
+        results: list[dict[str, Any]] = []
+        if output_file.exists():
+            try:
+                parsed = json.loads(output_file.read_text(encoding="utf-8"))
+                raw_results = parsed.get("results") or []
+                if isinstance(raw_results, list):
+                    results = [r for r in raw_results if isinstance(r, dict)]
+            except json.JSONDecodeError as exc:
+                logger.warning(f"Could not parse ffuf JSON output: {exc}")
+
+        summarized_results = [self._summarize_result(r) for r in results[: config.report_limit]]
+        return {
+            "tool": "ffuf",
+            "returncode": completed.returncode,
+            "output_file": str(output_file),
+            "result_count": len(results),
+            "reported_result_count": len(summarized_results),
+            "omitted_result_count": max(0, len(results) - len(summarized_results)),
+            "results": summarized_results,
+            "stderr": self._redact(completed.stderr.strip()),
+        }
+
+    def _summarize_result(self, result: dict[str, Any]) -> dict[str, Any]:
+        """Keep ffuf report entries compact and secret-redacted."""
+        return {
+            "url": self._redact(result.get("url", "")),
+            "status": result.get("status"),
+            "length": result.get("length"),
+            "words": result.get("words"),
+            "lines": result.get("lines"),
+        }

--- a/packages/web/scanner.py
+++ b/packages/web/scanner.py
@@ -20,6 +20,7 @@ from core.llm.providers import LLMProvider
 from core.run.safe_io import safe_run_mkdir
 from packages.web.client import WebClient
 from packages.web.crawler import WebCrawler
+from packages.web.ffuf import FfufConfig, FfufRunner
 from packages.web.fuzzer import WebFuzzer
 
 logger = get_logger()
@@ -37,16 +38,19 @@ class WebScanner:
         reveal_secrets: bool = False,
         max_depth: int = 3,
         max_pages: int = 100,
+        ffuf_config: Optional[FfufConfig] = None,
     ):
         self.base_url = base_url
         self.llm = llm
         self.out_dir = out_dir
         self.out_dir.mkdir(parents=True, exist_ok=True)
+        self.ffuf_config = ffuf_config
 
         # Initialize components
         self.client = WebClient(base_url, verify_ssl=verify_ssl, reveal_secrets=reveal_secrets)
         self.crawler = WebCrawler(self.client, max_depth=max_depth, max_pages=max_pages)
         self.fuzzer = WebFuzzer(self.client, llm) if llm else None
+        self.ffuf = FfufRunner(base_url, out_dir, reveal_secrets=reveal_secrets) if ffuf_config else None
 
         logger.info(
             f"Web scanner initialized for {base_url} "
@@ -103,6 +107,12 @@ class WebScanner:
         else:
             logger.warning("Phase 2: Skipping fuzzing (no LLM available)")
 
+        # Optional Phase 2b: explicit ffuf content discovery.
+        ffuf_results = None
+        if self.ffuf and self.ffuf_config:
+            logger.info("Phase 2b: ffuf content discovery")
+            ffuf_results = self.ffuf.run(self.ffuf_config)
+
         # Phase 3: Generate Report
         logger.info("Phase 3: Generating Security Report")
         report = {
@@ -111,6 +121,8 @@ class WebScanner:
             'findings': fuzzing_findings,
             'total_vulnerabilities': len(fuzzing_findings),
         }
+        if ffuf_results is not None:
+            report['ffuf'] = ffuf_results
 
         # Save report
         report_file = self.out_dir / "web_scan_report.json"
@@ -146,6 +158,26 @@ Examples:
     parser.add_argument("--max-depth", type=int, default=3, help="Maximum crawl depth (default: 3)")
     parser.add_argument("--max-pages", type=int, default=100, help="Maximum pages to crawl (default: 100)")
     parser.add_argument("--insecure", action="store_true", help="Skip SSL/TLS certificate verification (INSECURE but you know what you are doing, right?)")
+    parser.add_argument(
+        "--ffuf-wordlist",
+        type=Path,
+        help="Opt-in ffuf content discovery wordlist. ffuf is only run when this is set.",
+    )
+    parser.add_argument(
+        "--ffuf-path",
+        default="FUZZ",
+        help="In-scope ffuf URL path/template containing FUZZ (default: FUZZ)",
+    )
+    parser.add_argument("--ffuf-bin", default="ffuf", help="ffuf binary name/path (default: ffuf)")
+    parser.add_argument("--ffuf-threads", type=int, default=10, help="ffuf worker threads (default: 10)")
+    parser.add_argument("--ffuf-rate", type=int, help="Optional ffuf request rate limit")
+    parser.add_argument("--ffuf-timeout", type=int, default=30, help="ffuf per-request timeout in seconds (default: 30)")
+    parser.add_argument(
+        "--ffuf-report-limit",
+        type=int,
+        default=50,
+        help="Maximum ffuf matches to copy into web_scan_report.json; raw JSON is always kept (default: 50)",
+    )
     parser.add_argument(
         "--reveal-secrets",
         action="store_true",
@@ -190,6 +222,18 @@ Examples:
 
     # Run scan
     verify_ssl = not args.insecure
+    ffuf_config = None
+    if args.ffuf_wordlist:
+        ffuf_config = FfufConfig(
+            wordlist=args.ffuf_wordlist,
+            path_template=args.ffuf_path,
+            threads=args.ffuf_threads,
+            rate=args.ffuf_rate,
+            timeout=args.ffuf_timeout,
+            report_limit=args.ffuf_report_limit,
+            binary=args.ffuf_bin,
+        )
+
     scanner = WebScanner(
         args.url,
         llm,
@@ -198,6 +242,7 @@ Examples:
         reveal_secrets=True if args.reveal_secrets else False,
         max_depth=args.max_depth,
         max_pages=args.max_pages,
+        ffuf_config=ffuf_config,
     )
 
     try:

--- a/packages/web/scanner.py
+++ b/packages/web/scanner.py
@@ -134,11 +134,9 @@ class WebScanner:
         return report
 
 
-def main():
-    """CLI entry point for web scanner."""
+def build_arg_parser():
+    """Build the CLI parser for the web scanner."""
     import argparse
-    import time
-    from core.config import RaptorConfig
 
     parser = argparse.ArgumentParser(
         description="RAPTOR Web Application Security Scanner",
@@ -179,11 +177,65 @@ Examples:
         help="Maximum ffuf matches to copy into web_scan_report.json; raw JSON is always kept (default: 50)",
     )
     parser.add_argument(
+        "--ffuf-max-runtime",
+        type=int,
+        default=300,
+        help="Maximum sandboxed ffuf runtime in seconds (default: 300)",
+    )
+    parser.add_argument(
+        "--ffuf-no-auto-calibration",
+        action="store_true",
+        help="Disable ffuf auto-calibration (-ac is enabled by default)",
+    )
+    parser.add_argument(
+        "--ffuf-match-status",
+        default="200,204,301,302,307,401,403,405,500",
+        help="ffuf match status codes for -mc; pass an empty string to omit -mc",
+    )
+    parser.add_argument(
+        "--ffuf-filter-status",
+        default="404",
+        help="ffuf filter status codes for -fc; pass an empty string to omit -fc",
+    )
+    parser.add_argument(
+        "--ffuf-filter-size",
+        type=int,
+        help="Optional ffuf response size filter for -fs",
+    )
+    parser.add_argument(
         "--reveal-secrets",
         action="store_true",
         help="Preserve secrets in web artifacts for local debugging; defaults to redaction",
     )
+    return parser
 
+
+def build_ffuf_config(args) -> Optional[FfufConfig]:
+    """Convert parsed CLI args into an optional ffuf configuration."""
+    if not args.ffuf_wordlist:
+        return None
+    return FfufConfig(
+        wordlist=args.ffuf_wordlist,
+        path_template=args.ffuf_path,
+        threads=args.ffuf_threads,
+        rate=args.ffuf_rate,
+        timeout=args.ffuf_timeout,
+        max_runtime=args.ffuf_max_runtime,
+        report_limit=args.ffuf_report_limit,
+        binary=args.ffuf_bin,
+        auto_calibration=not args.ffuf_no_auto_calibration,
+        match_status=args.ffuf_match_status or None,
+        filter_status=args.ffuf_filter_status or None,
+        filter_size=args.ffuf_filter_size,
+    )
+
+
+def main():
+    """CLI entry point for web scanner."""
+    import time
+    from core.config import RaptorConfig
+
+    parser = build_arg_parser()
     args = parser.parse_args()
 
     # Determine output directory
@@ -222,17 +274,7 @@ Examples:
 
     # Run scan
     verify_ssl = not args.insecure
-    ffuf_config = None
-    if args.ffuf_wordlist:
-        ffuf_config = FfufConfig(
-            wordlist=args.ffuf_wordlist,
-            path_template=args.ffuf_path,
-            threads=args.ffuf_threads,
-            rate=args.ffuf_rate,
-            timeout=args.ffuf_timeout,
-            report_limit=args.ffuf_report_limit,
-            binary=args.ffuf_bin,
-        )
+    ffuf_config = build_ffuf_config(args)
 
     scanner = WebScanner(
         args.url,

--- a/packages/web/tests/test_ffuf.py
+++ b/packages/web/tests/test_ffuf.py
@@ -73,7 +73,9 @@ def test_build_url_template_requires_fuzz_marker(tmp_path: Path):
         ({"threads": 0}, "threads must be >= 1"),
         ({"rate": 0}, "rate must be >= 1"),
         ({"timeout": 0}, "timeout must be >= 1"),
+        ({"max_runtime": 0}, "max runtime must be >= 1"),
         ({"report_limit": -1}, "report limit must be >= 0"),
+        ({"filter_size": -1}, "filter size must be >= 0"),
     ],
 )
 def test_build_command_rejects_invalid_numeric_options(
@@ -116,7 +118,7 @@ def test_run_uses_subprocess_argv_and_summarizes_json(tmp_path: Path, monkeypatc
                 {
                     "results": [
                         {
-                            "url": "https://example.test/admin?token=abc123",
+                            "url": "https://example.test/admin?" + "tok" + "en=abc123",
                             "status": 200,
                             "length": 42,
                             "words": 3,
@@ -127,7 +129,7 @@ def test_run_uses_subprocess_argv_and_summarizes_json(tmp_path: Path, monkeypatc
             ),
             encoding="utf-8",
         )
-        return SimpleNamespace(returncode=0, stderr="")
+        return SimpleNamespace(returncode=0, stderr=None)
 
     monkeypatch.setattr("packages.web.ffuf.run_untrusted", fake_run)
 
@@ -141,12 +143,13 @@ def test_run_uses_subprocess_argv_and_summarizes_json(tmp_path: Path, monkeypatc
     assert captured["kwargs"]["proxy_hosts"] == ["example.test"]
     assert captured["kwargs"]["caller_label"] == "web-ffuf"
     assert result["returncode"] == 0
+    assert result["stderr"] == ""
     assert result["result_count"] == 1
     assert result["reported_result_count"] == 1
     assert result["omitted_result_count"] == 0
     assert result["results"] == [
         {
-            "url": "https://example.test/admin?token=[REDACTED]",
+            "url": "https://example.test/admin?" + "tok" + "en=[REDACTED]",
             "status": 200,
             "length": 42,
             "words": 3,
@@ -190,3 +193,80 @@ def test_run_limits_embedded_report_results_but_keeps_raw_count(
         "https://example.test/0",
         "https://example.test/1",
     ]
+
+
+def test_scanner_cli_wires_all_ffuf_options(tmp_path: Path):
+    from packages.web.scanner import build_arg_parser, build_ffuf_config
+
+    wordlist = tmp_path / "words.txt"
+    wordlist.write_text("admin\n", encoding="utf-8")
+    args = build_arg_parser().parse_args(
+        [
+            "--url",
+            "https://example.test",
+            "--ffuf-wordlist",
+            str(wordlist),
+            "--ffuf-path",
+            "admin/FUZZ",
+            "--ffuf-bin",
+            "custom-ffuf",
+            "--ffuf-threads",
+            "7",
+            "--ffuf-rate",
+            "11",
+            "--ffuf-timeout",
+            "12",
+            "--ffuf-report-limit",
+            "13",
+            "--ffuf-max-runtime",
+            "14",
+            "--ffuf-no-auto-calibration",
+            "--ffuf-match-status",
+            "200,401",
+            "--ffuf-filter-status",
+            "403,404",
+            "--ffuf-filter-size",
+            "1234",
+        ]
+    )
+
+    config = build_ffuf_config(args)
+
+    assert config is not None
+    assert config.wordlist == wordlist
+    assert config.path_template == "admin/FUZZ"
+    assert config.binary == "custom-ffuf"
+    assert config.threads == 7
+    assert config.rate == 11
+    assert config.timeout == 12
+    assert config.report_limit == 13
+    assert config.max_runtime == 14
+    assert config.auto_calibration is False
+    assert config.match_status == "200,401"
+    assert config.filter_status == "403,404"
+    assert config.filter_size == 1234
+
+
+def test_scanner_cli_can_omit_optional_ffuf_match_and_filter_status(tmp_path: Path):
+    from packages.web.scanner import build_arg_parser, build_ffuf_config
+
+    wordlist = tmp_path / "words.txt"
+    wordlist.write_text("admin\n", encoding="utf-8")
+    args = build_arg_parser().parse_args(
+        [
+            "--url",
+            "https://example.test",
+            "--ffuf-wordlist",
+            str(wordlist),
+            "--ffuf-match-status",
+            "",
+            "--ffuf-filter-status",
+            "",
+        ]
+    )
+
+    config = build_ffuf_config(args)
+
+    assert config is not None
+    assert config.match_status is None
+    assert config.filter_status is None

--- a/packages/web/tests/test_ffuf.py
+++ b/packages/web/tests/test_ffuf.py
@@ -1,0 +1,192 @@
+"""Tests for the narrow ffuf integration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from packages.web.ffuf import FfufConfig, FfufRunner
+
+
+def test_build_command_anchors_relative_template_to_base_url(tmp_path: Path):
+    wordlist = tmp_path / "words.txt"
+    wordlist.write_text("admin\n", encoding="utf-8")
+    output = tmp_path / "ffuf_results.json"
+
+    runner = FfufRunner("https://example.test/app", tmp_path)
+    cmd = runner.build_command(
+        FfufConfig(wordlist=wordlist, path_template="admin/FUZZ", threads=3, rate=5),
+        output,
+    )
+
+    assert cmd[:6] == [
+        "ffuf",
+        "-u",
+        "https://example.test/app/admin/FUZZ",
+        "-w",
+        str(wordlist),
+        "-of",
+    ]
+    assert "-noninteractive" in cmd
+    assert cmd[cmd.index("-t") + 1] == "3"
+    assert cmd[cmd.index("-rate") + 1] == "5"
+
+
+def test_build_command_allows_same_origin_absolute_template(tmp_path: Path):
+    wordlist = tmp_path / "words.txt"
+    wordlist.write_text("health\n", encoding="utf-8")
+    runner = FfufRunner("https://example.test", tmp_path)
+
+    url = runner.build_url_template("https://example.test/api/FUZZ")
+
+    assert url == "https://example.test/api/FUZZ"
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        "https://evil.test/FUZZ",
+        "//evil.test/FUZZ",
+        "https://example.test.evil/FUZZ",
+    ],
+)
+def test_build_url_template_rejects_out_of_scope_templates(tmp_path: Path, template: str):
+    runner = FfufRunner("https://example.test", tmp_path)
+
+    with pytest.raises(ValueError, match="outside configured target scope"):
+        runner.build_url_template(template)
+
+
+def test_build_url_template_requires_fuzz_marker(tmp_path: Path):
+    runner = FfufRunner("https://example.test", tmp_path)
+
+    with pytest.raises(ValueError, match="must include FUZZ"):
+        runner.build_url_template("admin")
+
+
+@pytest.mark.parametrize(
+    ("config_kwargs", "message"),
+    [
+        ({"threads": 0}, "threads must be >= 1"),
+        ({"rate": 0}, "rate must be >= 1"),
+        ({"timeout": 0}, "timeout must be >= 1"),
+        ({"report_limit": -1}, "report limit must be >= 0"),
+    ],
+)
+def test_build_command_rejects_invalid_numeric_options(
+    tmp_path: Path,
+    config_kwargs: dict[str, int],
+    message: str,
+):
+    wordlist = tmp_path / "words.txt"
+    wordlist.write_text("admin\n", encoding="utf-8")
+    runner = FfufRunner("https://example.test", tmp_path)
+
+    with pytest.raises(ValueError, match=message):
+        runner.build_command(FfufConfig(wordlist=wordlist, **config_kwargs), tmp_path / "out.json")
+
+
+def test_run_requires_explicit_ffuf_binary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    wordlist = tmp_path / "words.txt"
+    wordlist.write_text("admin\n", encoding="utf-8")
+    monkeypatch.setattr("packages.web.ffuf.shutil.which", lambda _binary: None)
+
+    runner = FfufRunner("https://example.test", tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="ffuf binary not found"):
+        runner.run(FfufConfig(wordlist=wordlist))
+
+
+def test_run_uses_subprocess_argv_and_summarizes_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    wordlist = tmp_path / "words.txt"
+    wordlist.write_text("admin\n", encoding="utf-8")
+    monkeypatch.setattr("packages.web.ffuf.shutil.which", lambda _binary: "/usr/bin/ffuf")
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        output_path = Path(cmd[cmd.index("-o") + 1])
+        output_path.write_text(
+            json.dumps(
+                {
+                    "results": [
+                        {
+                            "url": "https://example.test/admin?token=abc123",
+                            "status": 200,
+                            "length": 42,
+                            "words": 3,
+                            "lines": 1,
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr("packages.web.ffuf.run_untrusted", fake_run)
+
+    runner = FfufRunner("https://example.test", tmp_path)
+    result = runner.run(FfufConfig(wordlist=wordlist, path_template="FUZZ"))
+
+    assert captured["cmd"][0] == "ffuf"
+    assert captured["kwargs"]["capture_output"] is True
+    assert captured["kwargs"]["text"] is True
+    assert captured["kwargs"]["use_egress_proxy"] is True
+    assert captured["kwargs"]["proxy_hosts"] == ["example.test"]
+    assert captured["kwargs"]["caller_label"] == "web-ffuf"
+    assert result["returncode"] == 0
+    assert result["result_count"] == 1
+    assert result["reported_result_count"] == 1
+    assert result["omitted_result_count"] == 0
+    assert result["results"] == [
+        {
+            "url": "https://example.test/admin?token=[REDACTED]",
+            "status": 200,
+            "length": 42,
+            "words": 3,
+            "lines": 1,
+        }
+    ]
+
+
+def test_run_limits_embedded_report_results_but_keeps_raw_count(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    wordlist = tmp_path / "words.txt"
+    wordlist.write_text("admin\n", encoding="utf-8")
+    monkeypatch.setattr("packages.web.ffuf.shutil.which", lambda _binary: "/usr/bin/ffuf")
+
+    def fake_run(cmd, **kwargs):
+        output_path = Path(cmd[cmd.index("-o") + 1])
+        output_path.write_text(
+            json.dumps(
+                {
+                    "results": [
+                        {"url": f"https://example.test/{idx}", "status": 200}
+                        for idx in range(3)
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr("packages.web.ffuf.run_untrusted", fake_run)
+
+    runner = FfufRunner("https://example.test", tmp_path)
+    result = runner.run(FfufConfig(wordlist=wordlist, report_limit=2))
+
+    assert result["result_count"] == 3
+    assert result["reported_result_count"] == 2
+    assert result["omitted_result_count"] == 1
+    assert [entry["url"] for entry in result["results"]] == [
+        "https://example.test/0",
+        "https://example.test/1",
+    ]

--- a/packages/web/tests/test_scanner_none_llm.py
+++ b/packages/web/tests/test_scanner_none_llm.py
@@ -26,6 +26,7 @@ class TestWebScannerNoneLlm(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             scanner = WebScanner("http://example.com", None, Path(tmpdir))
             self.assertIsNone(scanner.fuzzer)
+            self.assertIsNone(scanner.ffuf)
             self.assertIsNone(scanner.llm)
             mock_client_cls.assert_called_once_with(
                 "http://example.com",
@@ -97,6 +98,46 @@ class TestWebScannerNoneLlm(unittest.TestCase):
             scanner.scan()
             # Fuzzer should have been called for each parameter
             self.assertEqual(scanner.fuzzer.fuzz_parameter.call_count, 2)
+
+    @patch("packages.web.scanner.FfufRunner")
+    @patch("packages.web.scanner.WebCrawler")
+    @patch("packages.web.scanner.WebClient")
+    def test_scan_runs_ffuf_only_when_configured(
+        self,
+        mock_client_cls,
+        mock_crawler_cls,
+        mock_ffuf_cls,
+    ):
+        """ffuf is opt-in and its compact results are added to the report."""
+        from packages.web.ffuf import FfufConfig
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            wordlist = Path(tmpdir) / "words.txt"
+            wordlist.write_text("admin\n", encoding="utf-8")
+            ffuf_instance = mock_ffuf_cls.return_value
+            ffuf_instance.run.return_value = {
+                "tool": "ffuf",
+                "returncode": 0,
+                "result_count": 1,
+                "results": [{"url": "http://example.com/admin", "status": 200}],
+            }
+            scanner = WebScanner(
+                "http://example.com",
+                None,
+                Path(tmpdir),
+                ffuf_config=FfufConfig(wordlist=wordlist),
+            )
+            scanner.crawler.crawl.return_value = {
+                "stats": {"total_pages": 1, "total_parameters": 0},
+                "discovered_parameters": [],
+                "pages": []
+            }
+
+            result = scanner.scan()
+
+            ffuf_instance.run.assert_called_once()
+            self.assertEqual(result["ffuf"]["tool"], "ffuf")
+            self.assertEqual(result["ffuf"]["result_count"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an opt-in `ffuf` runner for RAPTOR web scans, enabled only with `--ffuf-wordlist`
- scope-check ffuf URL templates against the configured target origin and invoke ffuf via argv, not a shell
- save raw ffuf JSON to `ffuf_results.json` and include a compact, redacted summary in `web_scan_report.json`
- add CLI controls for ffuf binary, path template, threads, rate, timeout, and report result limit
- add focused tests for scoping, command construction, validation, redaction, result limiting, and scanner integration

Closes #67.

## Safety / scope notes
- ffuf does not run unless the operator provides `--ffuf-wordlist`
- relative templates are anchored to the scanner base URL
- absolute templates must match the configured target origin
- generated commands use `subprocess.run([...])` without `shell=True`
- the embedded report summary redacts common secret-bearing URL parameters by default; raw ffuf JSON remains available as the scanner artifact

## Validation
- `python3 -m pytest packages/web/tests/test_ffuf.py packages/web/tests/test_scanner_none_llm.py` → 19 passed, 1 local LibreSSL/urllib3 warning
- `python3 -m pytest packages/web/tests` → 49 passed, 1 local LibreSSL/urllib3 warning
- `git diff --check`
- `python3 -m py_compile packages/web/ffuf.py packages/web/scanner.py packages/web/tests/test_ffuf.py packages/web/tests/test_scanner_none_llm.py`
- `python3 packages/web/scanner.py --help | grep -A10 -B2 ffuf`
