### PR TITLE
fix(devcontainer): unblock ARM/aarch64 build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,9 +6,12 @@
 
 FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
 
-# The base image ships a stale yarn apt source without its GPG key,
-# which breaks apt-get update (NO_PUBKEY 62D54FD4003F6525).
-RUN rm -f /etc/apt/sources.list.d/yarn.list
+# The base image's `node` devcontainer-feature install path added a stale
+# yarn apt source (NO_PUBKEY 62D54FD4003F6525, breaks apt-get update) AND
+# the yarn 1.x package itself (/usr/bin/yarn). Remove both so the later
+# `npm install -g yarn` step doesn't collide on aarch64 builds.
+RUN rm -f /etc/apt/sources.list.d/yarn.list \
+    && (apt-get -y remove yarn || echo "yarn not installed - skipping removal")
 
 # ============================================================================
 # SYSTEM DEPENDENCIES
@@ -141,7 +144,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x -o /tmp/nodesource_setup.sh
     && npm install -g @anthropic-ai/claude-code@2.1.119
 
 # ============================================================================
-# JS PACKAGE MANAGERS (yarn replaced apt source removed above)
+# JS PACKAGE MANAGERS (npm-managed yarn — apt source + package removed above)
 # ============================================================================
 
 RUN npm install -g yarn pnpm
@@ -155,7 +158,7 @@ ENV GIT_TERMINAL_PROMPT=0
 ENV PYTHONUNBUFFERED=1
 # Ensure python can import repo packages when container runs
 # Adds repo root and `packages/` so `import core`, `import binary_analysis`, etc. work
-ENV PYTHONPATH="/workspaces/raptor:/workspaces/raptor/packages:${PYTHONPATH}"
+ENV PYTHONPATH="/workspaces/raptor:/workspaces/raptor/packages"
 
 # ============================================================================
 # WORKSPACE

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,4 +28,10 @@ gcovr==8.4
 beautifulsoup4==4.14.3
 
 # test for Z3 solver
-z3-solver==4.16.0.0
+# Capped at 4.15.4.0 until the devcontainer base image moves to trixie:
+# z3-solver 4.15.5+ ships only manylinux_2_38_aarch64 wheels (glibc 2.38+),
+# but mcr.microsoft.com/devcontainers/python:1-3.12-bookworm has glibc 2.36.
+# 4.15.4.0 uses manylinux_2_34_aarch64 (glibc 2.34) and installs cleanly on
+# both x86_64 and aarch64. Move forward when bookworm -> trixie (glibc 2.41).
+# Our z3 surface (BitVec + Bool only) is unaffected by post-4.15.4 changes.
+z3-solver==4.15.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ tabulate==0.10.0
 pyyaml==6.0.3
 
 # Optional: For SMT-based constraint analysis (one-gadget feasibility, etc.)
-# z3-solver==4.16.0.0
+# z3-solver==4.15.4.0  # see requirements-dev.txt for bookworm/aarch64 cap
 
 # Optional: For web scanning package
 # beautifulsoup4>=4.12.0


### PR DESCRIPTION
Three independent issues prevent the devcontainer from building on aarch64 hosts (ARM Macs, ARM CI runners). All hit at devcontainer build time on the existing bookworm base image; x86_64 was unaffected.

Reported by Terry Franklin, who also diagnosed all three root causes.

* requirements-dev.txt: cap z3-solver at 4.15.4.0. 4.15.5+ ship only manylinux_2_38_aarch64 wheels (glibc 2.38+) but mcr.microsoft.com/devcontainers/python:1-3.12-bookworm has glibc 2.36. 4.15.4.0 uses manylinux_2_34_aarch64 (glibc 2.34) and installs cleanly on both architectures. Move forward when the base image is bumped to trixie. Our z3 surface (BitVec + Bool only) is unaffected by the post-4.15.4 changes — those were string-theory soundness + arithmetic fixes (the latter already in 4.15.4).

* .devcontainer/Dockerfile: remove the apt-installed yarn 1.x package in addition to its stale apt source. The base image's `node` devcontainer-feature install path baked in yarn from the yarnpkg.com Debian repo. PR #226 removed the apt source file to fix `apt-get update` (expired GPG key NO_PUBKEY 62D54FD4003F6525) but left /usr/bin/yarn in place; the later `npm install -g yarn pnpm` then collides on aarch64. The `apt-get remove` is wrapped in `|| echo` so it stays idempotent if the base image drops yarn in future.

* .devcontainer/Dockerfile: drop the trailing `:${PYTHONPATH}` from the ENV PYTHONPATH line. PYTHONPATH is unset in the base image, so the append pattern emits a Docker UndefinedVar warning for no functional benefit.

requirements.txt's commented-out version reference updated for consistency with the requirements-dev.txt pin.