### PR TITLE
feat(smt): input hardening — char + condition-count caps

### DIFF
--- a/core/smt_solver/rejection.py
+++ b/core/smt_solver/rejection.py
@@ -114,6 +114,23 @@ class RejectionKind(str, Enum):
     """Z3 returned ``unknown`` for some other reason (incomplete tactic,
     construct outside the decidable bitvector fragment)."""
 
+    INPUT_TOO_LONG = "input_too_long"
+    """A single condition string exceeded the configured character cap.
+    Pre-parse bound on input size — defends the parser combinator against
+    pathological inputs whose runtime is linear in length but whose total
+    length is unboundedly large (e.g. a 1 MB string of operators).  The
+    cap lives in the encoder (``smt_path_validator._MAX_CONDITION_CHARS``)
+    so it can be tuned per call site if a real-target condition ever
+    legitimately exceeds it."""
+
+    TOO_MANY_CONDITIONS = "too_many_conditions"
+    """The caller passed more conditions to ``check_path_feasibility``
+    than the configured per-call cap.  Pre-parse bound on call shape —
+    real findings have 1-10 conditions; tens of thousands is a signal of
+    malformed upstream extraction or amplification.  The whole call
+    degrades to ``feasible=None``; the rejection appears once in
+    ``unknown_reasons``."""
+
 
 # RejectionKinds that no encoder emits any more but that we've kept in
 # the enum for back-compat with downstream consumers that match on the

--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -203,6 +203,22 @@ _PRECEDENCE: Dict[str, int] = {
 # far more than any real C condition would ever need.
 _MAX_PAREN_DEPTH = 64
 
+# Maximum length in characters of a single condition string.  Defends the
+# parser against pathological inputs whose runtime is linear in length but
+# whose total length is unboundedly large (e.g. a 1 MB string of operators).
+# Real path-conditions extracted from source rarely exceed a few hundred
+# characters even with verbose chained predicates; 2048 is generously above
+# any observed legitimate input.  Companion bound to ``_MAX_PAREN_DEPTH``
+# (depth) — together they cap both axes of parser cost.
+_MAX_CONDITION_CHARS = 2048
+
+# Maximum number of conditions accepted in a single ``check_path_feasibility``
+# call.  Real findings carry 1-10 conditions; tens of thousands signals
+# malformed upstream extraction or amplification.  When exceeded the call
+# degrades to ``feasible=None`` so partial answers can't be misread as
+# authoritative.
+_MAX_CONDITIONS_PER_CALL = 64
+
 # Operator-shaped tokens we recognise but don't accept as binary operators
 # inside ``_parse_expr`` — they belong to the relational or bitmask layer
 # and reaching ``_parse_expr`` with one in operand-trailing position is a
@@ -570,6 +586,19 @@ def _parse_condition(
     ``text`` (the original) is preserved for rejection messages so
     callers can match failures back to their input.
     """
+    # Hard cap on input size before any parsing work runs.  Defends the
+    # parser combinator against pathological inputs whose total length is
+    # unboundedly large.  See ``_MAX_CONDITION_CHARS`` for the rationale
+    # and tuning guidance.
+    if len(text) > _MAX_CONDITION_CHARS:
+        return Rejection(
+            text, RejectionKind.INPUT_TOO_LONG,
+            f"condition length {len(text)} exceeds limit {_MAX_CONDITION_CHARS}",
+            hint=(
+                f"shorten or split the predicate so each condition is at "
+                f"most {_MAX_CONDITION_CHARS} characters"
+            ),
+        )
     t = _substitute_calls(
         _canonicalise(text), vars_, profile=profile, anon_map=anon_map,
     )
@@ -948,6 +977,37 @@ def check_path_feasibility(
             unknown_reasons=[],
             model={}, smt_available=False,
             reasoning="z3 not available — install z3-solver for path feasibility analysis",
+        )
+
+    # Hard cap on number of conditions per call.  Caller mistakes
+    # (malformed upstream extraction, accidental amplification) can
+    # flood the parser with tens of thousands of items.  Refuse the
+    # whole call cleanly so partial parser progress isn't misread as
+    # an authoritative feasibility verdict.
+    if len(conditions) > _MAX_CONDITIONS_PER_CALL:
+        cap_reason = Rejection(
+            text="",
+            kind=RejectionKind.TOO_MANY_CONDITIONS,
+            detail=(
+                f"{len(conditions)} conditions exceeds per-call cap "
+                f"{_MAX_CONDITIONS_PER_CALL}"
+            ),
+            hint=(
+                "split the path into smaller condition batches or "
+                "deduplicate before calling check_path_feasibility"
+            ),
+        )
+        return PathSMTResult(
+            feasible=None,
+            satisfied=[], unsatisfied=[],
+            unknown=[c.text for c in conditions],
+            unknown_reasons=[cap_reason],
+            model={}, smt_available=True,
+            reasoning=(
+                f"refused: {len(conditions)} conditions exceeds the per-call "
+                f"cap of {_MAX_CONDITIONS_PER_CALL} — caller should split or "
+                f"deduplicate before retrying"
+            ),
         )
 
     if not conditions:

--- a/packages/codeql/tests/test_smt_path_validator.py
+++ b/packages/codeql/tests/test_smt_path_validator.py
@@ -1091,3 +1091,142 @@ class TestParensGrouping:
         rej = next(x for x in r.unknown_reasons if x.text == f"{inner} > 0")
         assert rej.kind is RejectionKind.UNRECOGNIZED_FORM
         assert "depth" in rej.detail
+
+
+# ---------------------------------------------------------------------------
+# check_path_feasibility — input hardening caps
+# ---------------------------------------------------------------------------
+
+class TestInputLimits:
+    """Pre-parse caps on input size and call shape (C4 parser hardening).
+
+    These caps defend the parser against pathological inputs without
+    relying on Z3's per-call timeout — they fire before any solver work
+    runs, so even a malformed extraction or amplification attack costs
+    only the cap-check, not parser walk + Z3 round-trip.
+    """
+
+    @_requires_z3
+    def test_condition_length_within_cap_accepted(self):
+        """A condition just under ``_MAX_CONDITION_CHARS`` parses normally."""
+        from packages.codeql.smt_path_validator import _MAX_CONDITION_CHARS
+        # Build a condition of length _MAX_CONDITION_CHARS that the parser
+        # accepts: ``x + x + x + ... > 0``.  Each ``x + `` token is 4 chars.
+        prefix = "x + " * ((_MAX_CONDITION_CHARS - len("x > 0")) // 4)
+        cond = prefix + "x > 0"
+        assert len(cond) <= _MAX_CONDITION_CHARS
+        r = check_path_feasibility([PathCondition(cond, step_index=0)])
+        # Either feasible or rejected for non-length reasons — must NOT
+        # carry INPUT_TOO_LONG.
+        kinds = {rej.kind for rej in r.unknown_reasons}
+        assert RejectionKind.INPUT_TOO_LONG not in kinds
+
+    @_requires_z3
+    def test_condition_length_over_cap_rejected(self):
+        """A condition exceeding ``_MAX_CONDITION_CHARS`` is rejected with
+        ``INPUT_TOO_LONG`` before any parser work runs."""
+        from packages.codeql.smt_path_validator import _MAX_CONDITION_CHARS
+        huge = "x" + ("=" * _MAX_CONDITION_CHARS) + "y"
+        assert len(huge) > _MAX_CONDITION_CHARS
+        r = check_path_feasibility([PathCondition(huge, step_index=0)])
+        assert huge in r.unknown
+        rej = next(x for x in r.unknown_reasons if x.text == huge)
+        assert rej.kind is RejectionKind.INPUT_TOO_LONG
+        # Detail mentions the observed length and the cap.
+        assert str(len(huge)) in rej.detail
+        assert str(_MAX_CONDITION_CHARS) in rej.detail
+        # Hint guides the caller to a fix.
+        assert "shorten" in rej.hint or "split" in rej.hint
+
+    @_requires_z3
+    def test_condition_count_within_cap_accepted(self):
+        """A call with ``_MAX_CONDITIONS_PER_CALL`` items runs normally."""
+        from packages.codeql.smt_path_validator import _MAX_CONDITIONS_PER_CALL
+        # Use distinct variable names per condition so they trivially
+        # satisfy together — focus the test on the count check, not on
+        # condition semantics.
+        conds = [
+            PathCondition(f"x{i} > 0", step_index=i)
+            for i in range(_MAX_CONDITIONS_PER_CALL)
+        ]
+        r = check_path_feasibility(conds)
+        # Either feasible or rejected for non-count reasons — must NOT
+        # carry TOO_MANY_CONDITIONS.
+        kinds = {rej.kind for rej in r.unknown_reasons}
+        assert RejectionKind.TOO_MANY_CONDITIONS not in kinds
+
+    @_requires_z3
+    def test_condition_count_over_cap_refused(self):
+        """A call with more than ``_MAX_CONDITIONS_PER_CALL`` items refuses
+        the whole call with ``feasible=None`` and a single
+        ``TOO_MANY_CONDITIONS`` rejection."""
+        from packages.codeql.smt_path_validator import _MAX_CONDITIONS_PER_CALL
+        n = _MAX_CONDITIONS_PER_CALL + 1
+        conds = [
+            PathCondition(f"x{i} > 0", step_index=i) for i in range(n)
+        ]
+        r = check_path_feasibility(conds)
+        # Whole call refused — no partial verdict.
+        assert r.feasible is None
+        # Every input condition is in unknown (caller can match them back).
+        assert len(r.unknown) == n
+        # Exactly one TOO_MANY_CONDITIONS rejection — not one per condition,
+        # because the cap is a call-shape issue, not a per-condition issue.
+        too_many = [
+            rej for rej in r.unknown_reasons
+            if rej.kind is RejectionKind.TOO_MANY_CONDITIONS
+        ]
+        assert len(too_many) == 1
+        rej = too_many[0]
+        assert str(n) in rej.detail
+        assert str(_MAX_CONDITIONS_PER_CALL) in rej.detail
+        # Reasoning surfaces the cap so log readers understand the refusal.
+        assert "refused" in r.reasoning.lower()
+        assert str(_MAX_CONDITIONS_PER_CALL) in r.reasoning
+
+    @_requires_z3
+    def test_length_cap_fires_before_paren_depth(self):
+        """When BOTH limits would fire, INPUT_TOO_LONG should reach the
+        caller first — the length check runs at the very top of
+        _parse_condition, before any structural inspection.
+
+        This matters because the length check is cheap (one comparison)
+        while paren-depth detection runs the early-balance scan over the
+        whole input.  An adversarial input that's both very long AND has
+        deep nesting must short-circuit on length so the balance scan
+        never executes."""
+        from packages.codeql.smt_path_validator import (
+            _MAX_CONDITION_CHARS, _MAX_PAREN_DEPTH,
+        )
+        # Build a string that's BOTH over the char cap AND has deeper
+        # nesting than _MAX_PAREN_DEPTH.
+        inner = "x"
+        for _ in range(_MAX_PAREN_DEPTH + 1):
+            inner = f"({inner})"
+        # Pad with extra chars to exceed the char cap.
+        pad = "z" * (_MAX_CONDITION_CHARS + 10)
+        cond = f"{inner} == {pad}"
+        assert len(cond) > _MAX_CONDITION_CHARS
+        r = check_path_feasibility([PathCondition(cond, step_index=0)])
+        rej = next(x for x in r.unknown_reasons if x.text == cond)
+        # Length cap fires first.
+        assert rej.kind is RejectionKind.INPUT_TOO_LONG
+
+    @_requires_z3
+    def test_oversize_condition_among_normal_ones(self):
+        """One oversize condition is rejected without poisoning the rest
+        of the call — the other conditions still parse and contribute to
+        the joint feasibility verdict."""
+        from packages.codeql.smt_path_validator import _MAX_CONDITION_CHARS
+        huge = "y" + ("=" * _MAX_CONDITION_CHARS) + "0"
+        r = check_path_feasibility([
+            PathCondition("x > 0", step_index=0),
+            PathCondition(huge, step_index=1),
+            PathCondition("x < 100", step_index=2),
+        ])
+        # The two well-formed conditions are jointly satisfiable.
+        assert r.feasible is True
+        # The oversize one is rejected with INPUT_TOO_LONG.
+        assert huge in r.unknown
+        rej = next(x for x in r.unknown_reasons if x.text == huge)
+        assert rej.kind is RejectionKind.INPUT_TOO_LONG


### PR DESCRIPTION
Adds two pre-parse bounds on path-condition input shape, defending the SMT parser against pathological inputs without relying on Z3's per-call timeout. The caps fire before any solver work runs, so a malformed extraction or amplification attack costs only the cap-check itself.

What's bounded:
- `_MAX_CONDITION_CHARS = 2048`  — single condition string length
- `_MAX_CONDITIONS_PER_CALL = 64` — items per check_path_feasibility call

Companion to the existing `_MAX_PAREN_DEPTH = 64` (depth) so both axes of parser cost — width × depth — are now bounded.

Behavioural change for downstream callers:
- An oversize single condition becomes a per-condition rejection of kind INPUT_TOO_LONG (joins existing per-condition rejection flow; other conditions in the same call still parse normally).
- A call with >64 conditions degrades to feasible=None with a single TOO_MANY_CONDITIONS rejection in unknown_reasons. dataflow_validator's `feasible is False` early-return is not triggered, so callers still fall through to LLM analysis (we don't claim infeasibility just because we refused to solve).

Metric pickup: the n_smt_rejections_by_kind counter shipped in PR #475 sees the new kinds automatically since they flow through the existing unknown_reasons pipeline.

Background: process-level isolation of Z3 was considered but rejected. z3-solver is a C++ extension where in-process rlimits affect the whole Python interpreter, making true process isolation a substantially-larger refactor; and the threat that motivates it (untrusted input reaching path_conditions) has not actually materialised — conditions come from trusted LLM output today. Parser-side hardening is the cheapest correct move and is useful regardless: even trusted-LLM output can produce a malformed condition list that hangs Z3.

Tests: 6 new pin-tests in TestInputLimits — within-cap accepted, over-cap rejected, length-cap-fires-before-paren-depth, oversize- condition-doesn't-poison-the-call. E2E via libexec/raptor-smt-validate- path shim confirmed both kinds surface correctly through the JSON output. 1318-test regression sweep across core/smt_solver, packages/ codeql, packages/exploit_feasibility, packages/hypothesis_validation, and packages/llm_analysis dataflow tests — all green.