### PR TITLE
feat(smt): prefer_witness — drive Z3 to exploit-shape witnesses via Optimize

### DIFF
--- a/.claude/skills/exploitability-validation/stage-b-process.md
+++ b/.claude/skills/exploitability-validation/stage-b-process.md
@@ -149,7 +149,7 @@ libexec/raptor-smt-validate-path --profile uint32 \
 
 `--profile` matches the C type width: `uint32` for 32-bit unsigned wraparound (CWE-190 ALLOC pattern); `uint64` (default) for `size_t` / pointer arithmetic; `int32`/`int64` for signed paths.
 
-**Tip — finding the *exploit* witness, not the trivial one:** Z3 returns the smallest satisfying assignment by default, which is often `count=0`. Add a lower-bound condition that forces the dangerous range (e.g. `count > 0x10000000` for the ALLOC-overflow pattern); the witness then lands in the wraparound region.
+**Tip — finding the *exploit* witness, not the trivial one:** Z3 returns the smallest satisfying assignment by default, which is often `count=0`. Pass `--prefer-witness max:<var>` (or `min:<var>`) to drive the witness to an extremal value of the bug-driving variable. For the ALLOC-overflow pattern, `--prefer-witness max:count` produces a wraparound-region witness directly — no manual lower-bound condition needed.
 
 **Reading the verdict:**
 

--- a/.claude/skills/exploitability-validation/stage-e-feasibility.md
+++ b/.claude/skills/exploitability-validation/stage-e-feasibility.md
@@ -185,7 +185,7 @@ The script reads `attack-paths.json` itself, picks the matching trace, and appli
 - `path_conditions: []` (empty list) → script exits 0 with `feasible: true` and `reasoning: "no conditions ..."`. The path is unconditionally reachable from the entry; no re-extraction needed.
 - `path_conditions` non-empty → normal SMT verdict.
 
-**Tip — finding the *exploit* witness, not the trivial one:** Z3 returns the smallest satisfying assignment by default, which is often `count=0`, `length=0`, etc. — mathematically correct but not the bug. Add a lower-bound condition that forces the dangerous range. For the CWE-190 ALLOC pattern above, adding `'count > 0x10000000'` pushes Z3 into the wraparound region and yields a witness like `count=0x30000001, alloc_size=16` (the actual exploit input).
+**Tip — finding the *exploit* witness, not the trivial one:** Z3 returns the smallest satisfying assignment by default, which is often `count=0`, `length=0`, etc. — mathematically correct but not the bug. Use `--prefer-witness max:<var>` (or `min:<var>`) to push Z3 toward an extremal value of the variable driving the bug. For the CWE-190 ALLOC pattern above, `--prefer-witness max:count` yields a wraparound-region witness directly — no manual lower-bound conditions needed. The legacy form of adding `'count > 0x10000000'` still works and remains useful when constraining to a specific sub-range rather than pushing to the extreme.
 
 `--profile` matches the C type width in play. Common choices:
 

--- a/core/smt_solver/__init__.py
+++ b/core/smt_solver/__init__.py
@@ -46,7 +46,7 @@ from .rejection import (
     parse_literal_value,
     propagate,
 )
-from .session import DEFAULT_TIMEOUT_MS, new_solver, scoped
+from .session import DEFAULT_TIMEOUT_MS, new_optimizer, new_solver, scoped
 from .witness import bv_to_int, format_vars, format_witness
 
 __all__ = [
@@ -81,6 +81,7 @@ __all__ = [
     # Session
     "DEFAULT_TIMEOUT_MS",
     "new_solver",
+    "new_optimizer",
     "scoped",
     # Unsat-core explanation
     "track",

--- a/core/smt_solver/session.py
+++ b/core/smt_solver/session.py
@@ -49,6 +49,32 @@ def new_solver(timeout_ms: int = DEFAULT_TIMEOUT_MS) -> Any:
     return s
 
 
+def new_optimizer(timeout_ms: int = DEFAULT_TIMEOUT_MS) -> Any:
+    """Return a fresh ``z3.Optimize()`` with the given timeout applied.
+
+    Same clamping behaviour as :func:`new_solver`.  Use when the caller
+    wants to drive the witness toward a maximal or minimal value of some
+    variable (typically to produce an *exploit* witness rather than the
+    trivial smallest-model assignment that ``z3.Solver`` returns by
+    default).  Add objectives via ``opt.maximize(var)`` /
+    ``opt.minimize(var)`` after construction.
+
+    ``z3.Optimize`` shares the ``add``/``check``/``model``/``push``/
+    ``pop``/``assert_and_track``/``unsat_core`` interface with
+    ``z3.Solver`` so existing helpers (the explain.py unsat-core
+    tracker, the scoped context-manager, the witness formatter) all
+    work without modification — verified empirically on the Z3 builds
+    we ship.
+    """
+    if timeout_ms < 1:
+        timeout_ms = 1
+    elif timeout_ms > _MAX_TIMEOUT_MS:
+        timeout_ms = _MAX_TIMEOUT_MS
+    o = z3.Optimize()
+    o.set("timeout", timeout_ms)
+    return o
+
+
 @contextmanager
 def scoped(solver: Any) -> Iterator[Any]:
     """Push an assertion scope on ``solver`` for the duration of the block.

--- a/libexec/raptor-smt-validate-path
+++ b/libexec/raptor-smt-validate-path
@@ -35,6 +35,12 @@ or the file/id can't be resolved.
   int32   32-bit signed (signed-overflow UB reasoning)
   uint16  int16  uint8  int8
 
+``--prefer-witness max:VAR`` (or ``min:VAR``) drives the satisfying
+witness toward an extreme value of ``VAR`` instead of Z3's default
+smallest-model behaviour.  Common case is CWE-190 wraparound — pass
+``--prefer-witness max:count`` so the witness lands in the wraparound
+region instead of the trivial ``count=0`` Z3 returns by default.
+
 Output: JSON to stdout with keys
 
   feasible        true | false | null
@@ -174,6 +180,19 @@ def main() -> int:
              "to ~2000 for CWE-190/191/476 to fail-fast on "
              "pathological encodings. Clamped to [1, 2**31-1].",
     )
+    p.add_argument(
+        "--prefer-witness",
+        default=None,
+        metavar="DIR:VAR",
+        help="Drive the satisfying witness toward an extreme value of "
+             "a named variable instead of Z3's default smallest-model "
+             "behaviour. Format: 'max:<var>' or 'min:<var>'. Common "
+             "use case: CWE-190 wraparound — pass 'max:count' so the "
+             "witness lands in the wraparound region instead of the "
+             "trivial 'count=0' Z3 returns by default. When <var> is "
+             "absent from the parsed conditions the objective is "
+             "silently skipped.",
+    )
     args = p.parse_args()
 
     # Mutually-exclusive input modes
@@ -208,6 +227,7 @@ def main() -> int:
     try:
         result = validate_path(
             conditions, profile=profile, timeout_ms=args.timeout_ms,
+            prefer_witness=args.prefer_witness,
         )
     except (TypeError, ValueError) as e:
         return _err(str(e))

--- a/packages/codeql/smt_path_validator.py
+++ b/packages/codeql/smt_path_validator.py
@@ -86,11 +86,14 @@ Other limitations (verdict still trustworthy, but with caveats):
     first-cut design; per-variable typing is the next step when a
     real case demands it.
   - **Z3 picks the smallest satisfying witness by default**, which is
-    often the trivial assignment (``x = 0``).  To find an *exploit*
-    witness, add a lower-bound condition that forces the dangerous
-    range (e.g. ``count > 0x10000000`` for CWE-190 wraparound at
-    uint32).  Will be addressed by Z3 Optimize integration in a
-    follow-up.
+    often the trivial assignment (``x = 0``).  To drive the witness
+    into the dangerous range, pass ``prefer_witness=("count", "max")``
+    (or the shim's ``--prefer-witness max:count``) and the encoder
+    swaps in a ``z3.Optimize`` backend with the corresponding
+    ``maximize`` objective.  Manual lower-bound hints (e.g.
+    ``count > 0x10000000``) still work and remain useful when the
+    caller wants to constrain the search to a specific subrange
+    rather than push to the extreme.
 
 Integration: packages/codeql/dataflow_validator.py :: DataflowValidator
 """
@@ -113,6 +116,7 @@ from core.smt_solver import (
     core_names as _core_names,
     mk_val as _mk_val,
     mk_var as _mk_var,
+    new_optimizer as _new_optimizer,
     new_solver as _new_solver,
     parse_literal_value as _parse_literal_value,
     propagate as _propagate,
@@ -752,6 +756,8 @@ def _solve_pending(
     *,
     profile: BVProfile,
     anon_map: Optional[Dict[str, str]] = None,
+    prefer_witness: Optional[Tuple[str, str]] = None,
+    vars_: Optional[Dict[str, Any]] = None,
 ) -> PathSMTResult:
     """Run the solver over pending predicates and produce a verdict.
 
@@ -760,8 +766,37 @@ def _solve_pending(
     each input as tautology/pending/unknown; this function turns the
     pending list into a sat/unsat/unknown verdict and packages the
     result.
+
+    When ``prefer_witness`` is set, ``solver`` is expected to be a
+    ``z3.Optimize`` instance (the caller is responsible for the
+    backend swap).  This function then adds the appropriate
+    ``maximize`` or ``minimize`` objective for the named variable.
+    ``vars_`` carries the parser's interned BitVec table so the
+    objective lookup uses the same variable instance the predicates
+    were built against — name collisions in z3's hash-cons would
+    otherwise produce an objective on a freshly-minted variable
+    decoupled from the path.
     """
     mode = profile.describe()
+
+    # Apply the witness-direction objective before solving.  Silently
+    # skip if the named variable doesn't appear in the parsed
+    # conditions — the caller can spot this by inspecting `model` to
+    # confirm the variable is present, and the unsat-core /
+    # smallest-model behaviour still produces a valid (just not
+    # extremal) witness.
+    if prefer_witness is not None and pending and vars_ is not None:
+        var_name, direction = prefer_witness
+        target = vars_.get(var_name)
+        if target is not None:
+            if direction == "max":
+                solver.maximize(target)
+            elif direction == "min":
+                solver.minimize(target)
+            # Any other direction value is silently ignored — the
+            # caller's API (validate_path / shim) is responsible for
+            # vetting; defensive ignore avoids partial-objective
+            # state if a stray string gets here.
 
     # Default to empty dict so the field is always present on the
     # PathSMTResult — downstream consumers never need to None-check.
@@ -948,6 +983,7 @@ def check_path_feasibility(
     *,
     profile: BVProfile = BV_C_UINT64,
     timeout_ms: Optional[int] = None,
+    prefer_witness: Optional[Tuple[str, str]] = None,
 ) -> PathSMTResult:
     """
     Check whether a set of path conditions are jointly satisfiable.
@@ -962,6 +998,20 @@ def check_path_feasibility(
                     rendering.  Defaults to BV_C_UINT64 (64-bit unsigned).
                     Use BV_C_UINT32 for CWE-190 32-bit wraparound paths;
                     BV_C_INT32 for signed-integer path conditions; etc.
+        prefer_witness: When set to ``(var_name, "max")`` or
+                    ``(var_name, "min")``, drive the satisfying witness
+                    toward an extreme value of ``var_name`` instead of
+                    Z3's default (smallest model).  Useful for CWE-190
+                    wraparound and similar bug classes where the
+                    *exploit* witness lives at the high end of a
+                    variable's domain — without ``prefer_witness`` Z3
+                    typically returns the trivial ``var=0`` model that
+                    technically satisfies the path but isn't a useful
+                    PoC seed.  When the named variable is absent from
+                    the parsed conditions (e.g. caller mistake or
+                    rejected via parser fall-through) the objective is
+                    silently skipped and the witness reverts to the
+                    default smallest-model behaviour.
 
     Returns:
         PathSMTResult.  feasible=None when Z3 is unavailable or every
@@ -1025,7 +1075,22 @@ def check_path_feasibility(
     # solving-cost profile (CWE-190 wraparound is fast; CWE-787
     # OOB with complex array indexing may need longer) can pass
     # a tuned value via _tier4_smt_refine or the libexec shims.
-    solver = _new_solver(timeout_ms) if timeout_ms is not None else _new_solver()
+    #
+    # When prefer_witness is set, swap z3.Solver for z3.Optimize so
+    # we can drive the witness toward a maximal/minimal value of a
+    # named variable.  Optimize shares the entire Solver interface
+    # (add/check/model/push/pop/assert_and_track/unsat_core) so the
+    # rest of the encoder is agnostic to which backend is in use.
+    if prefer_witness is not None:
+        solver = (
+            _new_optimizer(timeout_ms) if timeout_ms is not None
+            else _new_optimizer()
+        )
+    else:
+        solver = (
+            _new_solver(timeout_ms) if timeout_ms is not None
+            else _new_solver()
+        )
     # Per-check anon-var mapping. Populated by `_substitute_calls`
     # as it allocates `_anon_N` placeholders for function-call
     # subterms; threaded into the PathSMTResult so downstream
@@ -1055,4 +1120,5 @@ def check_path_feasibility(
     return _solve_pending(
         pending, solver, satisfied, unknown, unknown_reasons,
         profile=profile, anon_map=anon_map,
+        prefer_witness=prefer_witness, vars_=vars_,
     )

--- a/packages/codeql/tests/test_smt_path_validator.py
+++ b/packages/codeql/tests/test_smt_path_validator.py
@@ -1230,3 +1230,123 @@ class TestInputLimits:
         assert huge in r.unknown
         rej = next(x for x in r.unknown_reasons if x.text == huge)
         assert rej.kind is RejectionKind.INPUT_TOO_LONG
+
+
+# ---------------------------------------------------------------------------
+# check_path_feasibility — prefer_witness (Z3 Optimize integration)
+# ---------------------------------------------------------------------------
+
+class TestPreferWitness:
+    """Driving the witness toward extreme values via z3.Optimize.
+
+    Without ``prefer_witness`` Z3 returns the smallest model that
+    satisfies the conditions — typically the trivial ``x=0``
+    assignment.  With ``prefer_witness=("var", "max")`` (or ``"min"``)
+    the encoder swaps in ``z3.Optimize`` and adds a maximize / minimize
+    objective on the named variable, producing an *exploit*-shape
+    witness instead.
+    """
+
+    def _cwe190_conds(self):
+        # Canonical CWE-190 32-bit wraparound shape.  Without a witness
+        # hint Z3 returns ``count=0``; with ``max:count`` it lands in
+        # the wraparound region (count * 16 > 2^32 - 1).
+        return [
+            PathCondition("alloc_size == count * 16", step_index=0),
+            PathCondition("alloc_size < 0x8000", step_index=1),
+        ]
+
+    @_requires_z3
+    def test_default_returns_trivial_witness(self):
+        """Sanity baseline: without prefer_witness, CWE-190 conditions
+        produce the trivial count=0 witness."""
+        from core.smt_solver import BV_C_UINT32
+        r = check_path_feasibility(
+            self._cwe190_conds(), profile=BV_C_UINT32,
+        )
+        assert r.feasible is True
+        assert r.model.get("count") == 0
+
+    @_requires_z3
+    def test_max_drives_witness_into_wraparound_region(self):
+        """``max:count`` produces a witness where count * 16 exceeds
+        2^32 — confirming Z3 found a wraparound assignment."""
+        from core.smt_solver import BV_C_UINT32
+        r = check_path_feasibility(
+            self._cwe190_conds(), profile=BV_C_UINT32,
+            prefer_witness=("count", "max"),
+        )
+        assert r.feasible is True
+        count = r.model.get("count")
+        assert count is not None and count > 0, (
+            f"prefer_witness max:count should produce non-trivial count, got {count}"
+        )
+        # On uint32, count * 16 in C semantics wraps; the test confirms
+        # the witness lands in a region where unwrapped multiplication
+        # would exceed UINT32_MAX.
+        assert count * 16 > 0xFFFFFFFF, (
+            f"witness count={count} does not lie in the wraparound region"
+        )
+
+    @_requires_z3
+    def test_min_drives_witness_to_floor(self):
+        """``min:count`` with a lower-bound condition returns the
+        smallest count above the bound."""
+        from core.smt_solver import BV_C_UINT32
+        r = check_path_feasibility(
+            self._cwe190_conds() + [PathCondition("count > 1000", step_index=2)],
+            profile=BV_C_UINT32,
+            prefer_witness=("count", "min"),
+        )
+        assert r.feasible is True
+        # min above the floor of 1000 → 1001.
+        assert r.model.get("count") == 1001
+
+    @_requires_z3
+    def test_absent_variable_silent_skip(self):
+        """When the named variable doesn't appear in any condition the
+        objective is silently dropped and the witness reverts to the
+        default smallest-model behaviour.  No error — Z3 still returns
+        a valid (non-extremal) witness."""
+        from core.smt_solver import BV_C_UINT32
+        r = check_path_feasibility(
+            self._cwe190_conds(), profile=BV_C_UINT32,
+            prefer_witness=("bogusvar", "max"),
+        )
+        assert r.feasible is True
+        # Default trivial witness comes back (count=0); no exception
+        # raised for the missing variable.
+        assert r.model.get("count") == 0
+        assert "bogusvar" not in r.model
+
+    @_requires_z3
+    def test_unsat_still_unsat_in_witness_mode(self):
+        """An unsat path remains unsat regardless of witness direction
+        — the objective only affects which sat witness is chosen, not
+        whether one exists.  unsat-core info must still surface."""
+        from core.smt_solver import BV_C_UINT32
+        r = check_path_feasibility(
+            [PathCondition("x > 100", step_index=0),
+             PathCondition("x < 50", step_index=1)],
+            profile=BV_C_UINT32,
+            prefer_witness=("x", "max"),
+        )
+        assert r.feasible is False
+        # unsat-core info preserved across the Solver→Optimize swap.
+        assert "x > 100" in r.unsatisfied
+        assert "x < 50" in r.unsatisfied
+
+    @_requires_z3
+    def test_witness_mode_compatible_with_timeout(self):
+        """``timeout_ms`` is honoured by the Optimize backend the same
+        way it is by Solver — empty pending list short-circuits to
+        ``feasible=True`` without solver work, but the timeout config
+        threads through cleanly."""
+        from core.smt_solver import BV_C_UINT32
+        r = check_path_feasibility(
+            self._cwe190_conds(), profile=BV_C_UINT32,
+            prefer_witness=("count", "max"),
+            timeout_ms=10000,
+        )
+        assert r.feasible is True
+        assert r.model.get("count") is not None

--- a/packages/exploit_feasibility/smt_path.py
+++ b/packages/exploit_feasibility/smt_path.py
@@ -20,7 +20,7 @@ Z3 is an optional soft dependency.  When ``z3-solver`` is not installed,
 ``validate_path`` returns ``{"feasible": null, "smt_available": false,
 …}`` so the caller falls back to LLM reasoning unchanged.
 
-Example::
+Example — manual lower-bound to push Z3 into the wraparound region::
 
     from packages.exploit_feasibility.smt_path import validate_path
     import json
@@ -35,6 +35,18 @@ Example::
     print(json.dumps(result, indent=2))
     # → feasible: true, model: {count: 0x30000001, alloc_size: 16}
     #   a wraparound exploit witness
+
+Equivalent using ``prefer_witness`` (no manual bound needed)::
+
+    result = validate_path(
+        ["alloc_size == count * 16",
+         "alloc_size < 0x8000"],
+        profile="uint32",
+        prefer_witness="max:count",   # or ("count", "max")
+    )
+    # → feasible: true, model: {count: 0xf00007ff, alloc_size: 0x7ff0}
+    #   Z3 maximises `count` directly so the witness lands in the
+    #   wraparound region without any caller-supplied range hint
 """
 
 from __future__ import annotations
@@ -120,10 +132,56 @@ def _normalise_conditions(
     return out
 
 
+def _parse_prefer_witness(
+    spec: Union[str, "tuple[str, str]", None],
+) -> "tuple[str, str] | None":
+    """Normalise a prefer_witness spec.
+
+    Accepts either a ``(name, direction)`` tuple or a colon-separated
+    string ``"max:varname"`` / ``"min:varname"`` (the form the libexec
+    shim CLI parses out of a single ``--prefer-witness`` argument).
+
+    Returns ``None`` when input is ``None`` or empty.  Raises
+    ``ValueError`` on malformed input so the caller fails fast rather
+    than silently dropping the objective.
+    """
+    if spec is None or spec == "":
+        return None
+    if isinstance(spec, tuple):
+        if len(spec) != 2:
+            raise ValueError(
+                f"prefer_witness tuple must be (name, direction), got {spec!r}"
+            )
+        name, direction = spec
+    elif isinstance(spec, str):
+        if ":" not in spec:
+            raise ValueError(
+                f"prefer_witness string must be 'max:name' or 'min:name', "
+                f"got {spec!r}"
+            )
+        direction, _, name = spec.partition(":")
+    else:
+        raise TypeError(
+            f"prefer_witness must be tuple, str, or None — got "
+            f"{type(spec).__name__}"
+        )
+    direction = direction.strip().lower()
+    name = name.strip()
+    if direction not in ("max", "min"):
+        raise ValueError(
+            f"prefer_witness direction must be 'max' or 'min', "
+            f"got {direction!r}"
+        )
+    if not name:
+        raise ValueError("prefer_witness variable name must not be empty")
+    return (name, direction)
+
+
 def validate_path(
     conditions: Sequence[Union[str, Dict[str, Any]]],
     profile: Union[BVProfile, str] = "uint64",
     timeout_ms: "int | None" = None,
+    prefer_witness: Union[str, "tuple[str, str]", None] = None,
 ) -> Dict[str, Any]:
     """Check whether a set of path conditions are jointly satisfiable.
 
@@ -152,6 +210,20 @@ def validate_path(
             CWE-125/787/680 to ``10000`` (complex array-index
             expressions). Clamped to ``[1, 2**31-1]`` by
             ``core.smt_solver.session.new_solver``.
+        prefer_witness: Optional witness-direction hint.  Accepts
+            either a ``(var_name, "max" | "min")`` tuple, or a shim-
+            friendly string ``"max:var_name"`` / ``"min:var_name"``,
+            or ``None`` (default) for Z3's normal smallest-model
+            behaviour.  When set, Z3 drives the satisfying witness
+            toward an extreme value of the named variable — the
+            common use case is CWE-190 wraparound, where without a
+            hint Z3 returns the trivial ``count=0`` model that
+            technically satisfies the conditions but isn't a useful
+            PoC seed.  Asking for ``"max:count"`` instead pushes the
+            witness into the wraparound region.  When the named
+            variable doesn't appear in the parsed conditions the
+            objective is silently skipped (the model still returns
+            a valid, just non-extremal, witness).
 
     Returns:
         JSON-serialisable dict with keys:
@@ -180,8 +252,10 @@ def validate_path(
     """
     bv = _resolve_profile(profile)
     paths = _normalise_conditions(conditions)
+    objective = _parse_prefer_witness(prefer_witness)
     smt_result: PathSMTResult = check_path_feasibility(
         paths, profile=bv, timeout_ms=timeout_ms,
+        prefer_witness=objective,
     )
 
     return {

--- a/packages/exploit_feasibility/tests/test_smt_path.py
+++ b/packages/exploit_feasibility/tests/test_smt_path.py
@@ -25,6 +25,7 @@ from core.smt_solver import (
 )
 from packages.exploit_feasibility.smt_path import (
     _normalise_conditions,
+    _parse_prefer_witness,
     _resolve_profile,
     validate_path,
 )
@@ -573,3 +574,118 @@ class TestFromTrace:
             assert "32-bit unsigned" in v["reasoning"]
         finally:
             os.chmod(poisoned, stat.S_IRUSR | stat.S_IWUSR)
+
+
+_requires_z3 = pytest.mark.skipif(
+    not z3_available(), reason="z3-solver not installed",
+)
+
+
+# ---------------------------------------------------------------------------
+# _parse_prefer_witness — shim-friendly string + tuple parsing
+# ---------------------------------------------------------------------------
+
+class TestParsePreferWitness:
+    """The string parser is the shim's only entry point for the
+    witness-direction objective.  Bad input must raise (not silently
+    drop) so a malformed --prefer-witness flag doesn't leave the
+    caller thinking they got an extremal witness when they didn't."""
+
+    def test_none_passthrough(self):
+        assert _parse_prefer_witness(None) is None
+
+    def test_empty_string_treated_as_none(self):
+        # The shim normalises absent flags to ``None``, but defensive
+        # empty-string handling avoids a confusing "must be max or min"
+        # error on what looks like an absent flag.
+        assert _parse_prefer_witness("") is None
+
+    def test_max_string(self):
+        assert _parse_prefer_witness("max:count") == ("count", "max")
+
+    def test_min_string(self):
+        assert _parse_prefer_witness("min:idx") == ("idx", "min")
+
+    def test_direction_case_insensitive(self):
+        assert _parse_prefer_witness("MAX:count") == ("count", "max")
+        assert _parse_prefer_witness("Min:count") == ("count", "min")
+
+    def test_whitespace_trimmed(self):
+        assert _parse_prefer_witness(" max : count ") == ("count", "max")
+
+    def test_tuple_accepted_directly(self):
+        assert _parse_prefer_witness(("count", "max")) == ("count", "max")
+
+    def test_missing_colon_rejected(self):
+        with pytest.raises(ValueError, match="must be 'max:name' or 'min:name'"):
+            _parse_prefer_witness("count")
+
+    def test_bad_direction_rejected(self):
+        with pytest.raises(ValueError, match="direction must be 'max' or 'min'"):
+            _parse_prefer_witness("avg:count")
+
+    def test_empty_name_rejected(self):
+        with pytest.raises(ValueError, match="variable name must not be empty"):
+            _parse_prefer_witness("max:")
+
+    def test_bad_tuple_arity_rejected(self):
+        with pytest.raises(ValueError, match="must be \\(name, direction\\)"):
+            _parse_prefer_witness(("count",))  # type: ignore[arg-type]
+
+    def test_wrong_type_rejected(self):
+        with pytest.raises(TypeError):
+            _parse_prefer_witness(42)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# validate_path — prefer_witness end-to-end
+# ---------------------------------------------------------------------------
+
+class TestValidatePathPreferWitness:
+    """End-to-end via the public API the Stage E LLM and libexec
+    shim both use."""
+
+    @_requires_z3
+    def test_default_returns_trivial_witness(self):
+        r = validate_path(
+            ["alloc_size == count * 16", "alloc_size < 0x8000"],
+            profile="uint32",
+        )
+        assert r["feasible"] is True
+        assert r["model"].get("count") == 0
+
+    @_requires_z3
+    def test_max_drives_wraparound_witness(self):
+        r = validate_path(
+            ["alloc_size == count * 16", "alloc_size < 0x8000"],
+            profile="uint32",
+            prefer_witness="max:count",
+        )
+        assert r["feasible"] is True
+        count = r["model"].get("count")
+        assert count > 0
+        # uint32 wraparound region: count * 16 overflows 2^32.
+        assert count * 16 > 0xFFFFFFFF
+
+    @_requires_z3
+    def test_tuple_form_accepted(self):
+        # API accepts the tuple form too, mirroring the lower-level
+        # check_path_feasibility kwarg.
+        r = validate_path(
+            ["alloc_size == count * 16", "alloc_size < 0x8000"],
+            profile="uint32",
+            prefer_witness=("count", "max"),
+        )
+        assert r["feasible"] is True
+        assert r["model"].get("count") > 0
+
+    @_requires_z3
+    def test_malformed_spec_raises_through_public_api(self):
+        # Important: validate_path must NOT swallow the parse error.
+        # The shim catches it and surfaces to stderr — silent fallback
+        # would leave operators thinking they got an extremal witness.
+        with pytest.raises(ValueError):
+            validate_path(
+                ["x > 0"], profile="uint32",
+                prefer_witness="bogus_no_colon",
+            )


### PR DESCRIPTION
Adds an optional witness-direction hint to validate_path / check_path_feasibility. When set, the encoder swaps z3.Solver for z3.Optimize and adds a maximize/minimize objective on the named variable, producing an exploit-shape witness instead of Z3's default smallest-model assignment.

CWE-190 32-bit wraparound, before and after:

  conditions: "alloc_size == count * 16, alloc_size < 0x8000"

  default:                       count=0, alloc_size=0   (trivial)
  --prefer-witness max:count:    count=0xf00007ff        (wraparound)

The operator/LLM no longer has to manually add `count > 0x10000000` as a lower-bound just to get a useful witness.

Surface:
- new kwarg on `validate_path` and `check_path_feasibility` (accepts `("count", "max")` tuple or shim-friendly `"max:count"` string)
- new `--prefer-witness DIR:VAR` flag on the libexec shim — combines with --stdin, --from-trace, --timeout-ms
- Stage E + Stage B skill markdown updated to point the LLM at the flag; the manual lower-bound technique stays as a fallback for sub-range constraints

Absent variables silent-skip (graceful degradation); malformed specs raise ValueError rather than silently dropping the objective. prefer_witness defaults to None so existing callers see identical behaviour. unsat-core info preserved across the Solver→Optimize swap.