### PR TITLE
core/oci: follow Link-header pagination on /tags/list

### DIFF
--- a/core/oci/client.py
+++ b/core/oci/client.py
@@ -62,6 +62,33 @@ _MANIFEST_ACCEPT = ", ".join([
 ])
 
 
+def _parse_link_next(link_header: Optional[str]) -> Optional[str]:
+    """Pull the ``<url>`` of the ``rel="next"`` entry out of an
+    RFC-5988 ``Link:`` header. Returns None if no next link, or
+    the header is absent / malformed.
+
+    The OCI Distribution Spec lets registries paginate
+    ``/tags/list`` via this header; URLs may be relative (path
+    only) or absolute. We strip leading whitespace + the angle
+    brackets but otherwise pass the value through verbatim — the
+    HTTP client below treats both shapes.
+    """
+    if not link_header:
+        return None
+    # Header may carry multiple comma-separated link entries.
+    # Split on commas that aren't inside angle-brackets — RFC 5988
+    # lets the URL portion contain commas. Use a lenient parser:
+    # for each ``<...>; rel=next`` entry, return the URL.
+    import re
+    for part in link_header.split(","):
+        m = re.match(
+            r"\s*<([^>]+)>\s*;\s*rel\s*=\s*\"?next\"?", part,
+        )
+        if m:
+            return m.group(1).strip()
+    return None
+
+
 @dataclass
 class ManifestResponse:
     """A registry manifest fetch result.
@@ -169,46 +196,72 @@ class OciRegistryClient:
 
     def list_tags(
         self, ref: ImageRef, *, per_page: int = 100,
+        max_pages: int = 50,
     ) -> List[str]:
-        """Return the tag list for ``ref.repository`` on its registry.
+        """Return the full tag list for ``ref.repository`` on its
+        registry, following ``Link`` headers across pages.
 
         Hits ``GET /v2/<repo>/tags/list?n=<per_page>``. The OCI
         Distribution Spec ``/tags/list`` endpoint returns
-        ``{"name": "<repo>", "tags": [...]}``. Only the first page
-        is fetched — the bumper's "what's the latest stable tag"
-        use case doesn't need exhaustive pagination, and most
-        registries cap responses around 100-1000 tags anyway. If a
-        future caller needs all tags, follow the ``Link`` header.
+        ``{"name": "<repo>", "tags": [...]}`` and signals
+        pagination via an RFC-5988 ``Link: <url>; rel="next"``
+        response header.
+
+        Docker Hub's ordering quirk drives the need for pagination:
+        tags come back in repository-internal index order (often
+        alphabetic), so for a repo like ``ollama/ollama`` the
+        first 100 tags are the ``0.1.x`` line — never reaching the
+        actual ``0.21.x`` latest. Without pagination, ``latest_tag``
+        recommends a downgrade.
+
+        ``max_pages`` bounds the walk (default 50 — 5000 tags at
+        the default page size). Repos with more tags than that are
+        rare; the cap prevents an unbounded walk from a
+        misconfigured Link chain.
 
         Raises :class:`RegistryError` on non-200 or malformed
         response.
         """
-        url = f"/v2/{ref.repository}/tags/list?n={per_page}"
-        resp = self._authed_request("GET", ref.registry, url)
-        if resp.status_code != 200:
-            raise RegistryError(
-                resp.status_code,
-                f"tags/list failed for {ref.repository} on "
-                f"{ref.registry}: {resp.text[:200]}",
+        all_tags: List[str] = []
+        next_url: Optional[str] = (
+            f"/v2/{ref.repository}/tags/list?n={per_page}"
+        )
+        for _ in range(max_pages):
+            if next_url is None:
+                break
+            resp = self._authed_request("GET", ref.registry, next_url)
+            if resp.status_code != 200:
+                raise RegistryError(
+                    resp.status_code,
+                    f"tags/list failed for {ref.repository} on "
+                    f"{ref.registry}: {resp.text[:200]}",
+                )
+            try:
+                data = json.loads(resp.content)
+            except (ValueError, TypeError) as e:
+                raise RegistryError(
+                    resp.status_code,
+                    f"tags/list JSON parse failed for "
+                    f"{ref.repository}: {e}",
+                )
+            tags = data.get("tags") if isinstance(data, dict) else None
+            if not isinstance(tags, list):
+                raise RegistryError(
+                    resp.status_code,
+                    f"tags/list response missing 'tags' array "
+                    f"for {ref.repository}",
+                )
+            # Filter to non-empty strings — registries occasionally
+            # include nulls for in-progress pushes.
+            all_tags.extend(t for t in tags if isinstance(t, str) and t)
+
+            # Follow ``Link: <url>; rel="next"`` if present. The
+            # URL is relative to the registry root, but some
+            # registries return absolute URLs — normalise.
+            next_url = _parse_link_next(
+                resp.headers.get("Link") or resp.headers.get("link"),
             )
-        try:
-            data = json.loads(resp.content)
-        except (ValueError, TypeError) as e:
-            raise RegistryError(
-                resp.status_code,
-                f"tags/list JSON parse failed for "
-                f"{ref.repository}: {e}",
-            )
-        tags = data.get("tags") if isinstance(data, dict) else None
-        if not isinstance(tags, list):
-            raise RegistryError(
-                resp.status_code,
-                f"tags/list response missing 'tags' array "
-                f"for {ref.repository}",
-            )
-        # Filter to non-empty strings — registries occasionally
-        # include nulls for in-progress pushes.
-        return [t for t in tags if isinstance(t, str) and t]
+        return all_tags
 
     def stream_blob(
         self, ref: ImageRef, digest: str,

--- a/core/oci/tests/test_client_list_tags.py
+++ b/core/oci/tests/test_client_list_tags.py
@@ -134,3 +134,79 @@ def test_list_tags_missing_tags_field_raises() -> None:
     client = OciRegistryClient(http)
     with pytest.raises(RegistryError):
         client.list_tags(ref)
+
+
+# ---------------------------------------------------------------------------
+# Link-header pagination — the ollama bug fix
+# ---------------------------------------------------------------------------
+
+def test_list_tags_follows_link_next_header() -> None:
+    """The bug this fixes: Docker Hub returns ``ollama/ollama``
+    tags in repository-internal index order (alphabetic-ish).
+    The first page is the ``0.1.x`` line; ``0.21.x`` lives on a
+    later page. Without Link-header pagination, ``latest_tag``
+    recommended a downgrade (0.21.0 → 0.1.45).
+    """
+    ref = parse_image_ref("docker.io/ollama/ollama:0.21.0")
+    page1 = _StubResponse(200, _ok_body({
+        "name": "ollama/ollama",
+        "tags": ["0.1.42", "0.1.43", "0.1.44", "0.1.45"],
+    }), headers={
+        "Link": '</v2/ollama/ollama/tags/list?n=100&last=0.1.45>; rel="next"',
+    })
+    page2 = _StubResponse(200, _ok_body({
+        "name": "ollama/ollama",
+        "tags": ["0.20.0", "0.21.0", "0.22.0"],
+    }))
+    http = _StubHttp({
+        "https://registry-1.docker.io/v2/ollama/ollama/tags/list?n=100": page1,
+        "https://registry-1.docker.io/v2/ollama/ollama/tags/list?n=100&last=0.1.45":
+            page2,
+    })
+    client = OciRegistryClient(http)
+    tags = client.list_tags(ref)
+    assert "0.21.0" in tags
+    assert "0.1.45" in tags
+    assert len(tags) == 7
+
+
+def test_list_tags_no_link_header_returns_single_page() -> None:
+    """No ``Link: rel=next`` → just one page. (Existing
+    behaviour preserved; this isn't a breaking change.)"""
+    ref = parse_image_ref("docker.io/library/python:3.12")
+    http = _StubHttp({
+        "https://registry-1.docker.io/v2/library/python/tags/list?n=100":
+            _ok({"name": "library/python",
+                 "tags": ["3.11", "3.12"]}),
+    })
+    client = OciRegistryClient(http)
+    assert client.list_tags(ref) == ["3.11", "3.12"]
+
+
+def test_list_tags_pagination_bounded_by_max_pages() -> None:
+    """A pathological infinite ``Link`` chain would never
+    terminate. ``max_pages`` (default 50) caps the walk so
+    misconfigured registries don't hang the bumper."""
+    # Build a Link header that points BACK to the same URL — a
+    # registry bug we should be defensive against.
+    bad_resp = _StubResponse(200, _ok_body({
+        "name": "ouroboros/loop",
+        "tags": ["a"],
+    }), headers={
+        "Link": '</v2/ouroboros/loop/tags/list?n=100>; rel="next"',
+    })
+    ref = parse_image_ref("docker.io/ouroboros/loop:a")
+    http = _StubHttp({
+        "https://registry-1.docker.io/v2/ouroboros/loop/tags/list?n=100":
+            bad_resp,
+    })
+    client = OciRegistryClient(http)
+    tags = client.list_tags(ref, max_pages=3)
+    # 3 pages × 1 tag each = 3 entries; doesn't loop forever.
+    assert len(tags) == 3
+
+
+# Helper for byte-encoding test bodies inline.
+def _ok_body(payload: dict) -> bytes:
+    import json as _json
+    return _json.dumps(payload).encode()


### PR DESCRIPTION
Docker Hub returns tags in repository-internal index order (often alphabetic), and OciRegistryClient.list_tags() was only fetching the first 100. For ollama/ollama that meant the client never saw past the 0.1.x line — the actual 0.21.x+ tags live on later pages.

- list_tags() now follows RFC-5988 Link: <url>; rel="next" headers
- Walk capped at max_pages=50 (5000 tags at default page size) to defend against pathological cycle-shaped Link chains
- New _parse_link_next() helper handles whitespace + quoted-rel tolerance