### PR TITLE
feat(raptor): add raptor doctor command

### DIFF
--- a/bin/raptor
+++ b/bin/raptor
@@ -119,6 +119,20 @@ if [[ "${1:-}" == "project" ]]; then
     exec "$RAPTOR_DIR/libexec/raptor-project-manager" "$@"
 fi
 
+# Route doctor directly (no Claude needed) — the doctor is a status
+# report on local setup, and `raptor doctor` is precisely the
+# command an operator runs when claude itself is missing.
+# Export RAPTOR_DIR + _RAPTOR_TRUSTED here because the main path's
+# `export RAPTOR_DIR` (below) hasn't run yet; doctor needs them
+# in the python subprocess env.
+if [[ "${1:-}" == "doctor" ]]; then
+    shift
+    cd "$RAPTOR_DIR" || exit 1
+    export RAPTOR_DIR
+    export _RAPTOR_TRUSTED=1
+    exec python3 -m core.startup.doctor "$@"
+fi
+
 # Claude required for everything else
 if ! command -v claude >/dev/null 2>&1; then
     echo "raptor: claude not found. Install Claude Code:" >&2

--- a/core/startup/doctor.py
+++ b/core/startup/doctor.py
@@ -1,0 +1,252 @@
+"""``raptor doctor`` — on-demand status report.
+
+Runs the same checks the SessionStart banner runs (``check_tools``,
+``check_llm``, ``check_env``, ``check_lang``, ``check_active_project``
+in :mod:`core.startup.init`), but renders them for an operator who
+explicitly typed ``raptor doctor`` because something feels off.
+
+Differences from the banner:
+
+  * No logo, no quote, no banner-layout — failures first, then
+    warnings, then a one-line summary of what passed.
+  * Does NOT write ``.startup-output`` — the SessionStart hook owns
+    that file. Doctor only prints to stdout.
+  * Non-zero exit on real failure (``--strict`` also fails on
+    warnings) so CI / shell scripts can gate on a clean state.
+
+Deliberately NOT in scope:
+
+  * Install advice for missing binaries. RAPTOR's audience is
+    technical operators — saying ``apt install rr`` is patronising
+    and often wrong (rr is Linux-only, the operator may build from
+    source for newer kernels, etc.). Doctor reports what's missing
+    and which features degrade; the operator picks how to install.
+  * Performance benchmarks, network reachability beyond what
+    ``check_llm`` already does, test runs.
+
+The doctor-command concept was signposted earlier by:
+  * gadievron/raptor#57 (splinters-io) — first surfaced the
+    operator-facing self-check shape in an aborted Frida-
+    integration PR.
+  * gadievron/raptor#486 (hinotori-agent) — second proposal,
+    revisited the same idea.
+
+This implementation wraps the existing ``core.startup.init``
+checks rather than duplicate them, so a new check or tool added
+to ``RaptorConfig.TOOL_DEPS`` lights up in both banner and
+doctor without per-site updates.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Iterable, List, Optional, Tuple
+
+from core.security.log_sanitisation import escape_nonprintable
+
+
+_USAGE = (
+    "usage: raptor doctor [--strict] [--verbose]\n"
+    "  --strict     non-zero exit on warnings too (CI gate)\n"
+    "  --verbose    include passing checks in the output\n"
+)
+
+
+def _gather() -> Tuple[
+    List[Tuple[str, bool]],  # tool_results
+    List[str],               # tool_warnings
+    List[str],               # llm_lines
+    List[str],               # llm_warnings
+    List[str],               # env_parts
+    List[str],               # env_warnings
+    Optional[str],           # lang_line
+    Optional[str],           # project_line
+]:
+    """Run every check and return the same shape ``init.main`` builds.
+
+    Silences logging like ``init.main`` does — these checks are
+    noisy at WARNING level (LLM key validation, sandbox probes).
+    """
+    from .init import (
+        check_active_project, check_env, check_lang, check_llm,
+        check_tools,
+    )
+
+    logging.disable(logging.WARNING)
+    try:
+        tool_results, tool_warnings, unavailable = check_tools()
+        llm_lines, llm_warnings = check_llm()
+        env_parts, env_warnings = check_env(unavailable)
+        lang_line = check_lang()
+        project_line = check_active_project()
+    finally:
+        logging.disable(logging.NOTSET)
+
+    return (
+        tool_results, tool_warnings,
+        llm_lines, llm_warnings,
+        env_parts, env_warnings,
+        lang_line, project_line,
+    )
+
+
+def _render(
+    tool_results: Iterable[Tuple[str, bool]],
+    tool_warnings: Iterable[str],
+    llm_lines: Iterable[str],
+    llm_warnings: Iterable[str],
+    env_parts: Iterable[str],
+    env_warnings: Iterable[str],
+    lang_line: Optional[str],
+    project_line: Optional[str],
+    *,
+    verbose: bool,
+) -> Tuple[str, int, int]:
+    """Render the doctor output. Returns (text, n_failures, n_warnings).
+
+    Failure classification:
+      * ``check_env`` mixes pass/fail signals — entries containing
+        the ``✗`` glyph are failures. The rest are facts (``disk 16
+        GB free``) or passes (``out/ ✓``).
+      * Missing tools become warnings unless the tool is in a
+        required group (``check_tools`` already classifies
+        severity in ``tool_warnings``; we surface those as-is).
+      * Anything in a ``*_warnings`` list is a warning.
+    """
+    failures: List[str] = []
+    warnings: List[str] = []
+    passes: List[str] = []
+
+    # Tools — single line summary of present/missing, then individual
+    # warnings (which already carry severity).
+    missing = [name for name, ok in tool_results if not ok]
+    present = [name for name, ok in tool_results if ok]
+    if present:
+        passes.append(f"tools present: {', '.join(sorted(present))}")
+    if missing:
+        # The warnings list carries the feature-impact phrasing
+        # (``rr not found — /crash-analysis limited``) so we don't
+        # need to re-format from tool_results here. tool_warnings
+        # also carries group-level entries (e.g. "no scanner").
+        pass
+    for w in tool_warnings:
+        warnings.append(w)
+
+    # LLM — banner's ``check_llm`` is informational; entries describe
+    # which provider is configured. Warnings stand alone.
+    for line in llm_lines:
+        clean = line.strip()
+        if clean:
+            passes.append(clean)
+    for w in llm_warnings:
+        warnings.append(w)
+
+    # Env — mixed: ``out/ ✗`` is a failure, ``disk 16 GB free`` is a
+    # pass, ``RAPTOR_DIR not set …`` from the new check appears in
+    # env_warnings.
+    for part in env_parts:
+        clean = part.strip()
+        if not clean:
+            continue
+        if "✗" in clean:
+            failures.append(clean)
+        else:
+            passes.append(clean)
+    for w in env_warnings:
+        warnings.append(w)
+
+    # Language support — single informational line.
+    if lang_line:
+        passes.append(lang_line.strip())
+
+    # Active project — informational.
+    if project_line:
+        passes.append(project_line.strip())
+
+    out: List[str] = ["RAPTOR doctor", "============="]
+
+    # Defence in depth: although every current producer of these
+    # strings is RAPTOR-internal (check_tools, check_llm, check_env),
+    # a future producer could surface attacker-influenced text — a
+    # tool warning derived from subprocess stderr, an LLM-provider
+    # error string, a project name read from disk. Run every
+    # operator-visible line through ``escape_nonprintable`` so raw
+    # ESC bytes / C1 controls never reach the terminal.
+    if failures:
+        out.append("")
+        out.append("FAILURES:")
+        for f in failures:
+            out.append(f"  ✗ {escape_nonprintable(f)}")
+
+    if warnings:
+        out.append("")
+        out.append("WARNINGS:")
+        for w in warnings:
+            out.append(f"  ! {escape_nonprintable(w)}")
+
+    if verbose and passes:
+        out.append("")
+        out.append("PASSED:")
+        for p in passes:
+            out.append(f"  ✓ {escape_nonprintable(p)}")
+    elif passes and not failures and not warnings:
+        # Compact "all good" when there's nothing to act on.
+        out.append("")
+        out.append(f"All {len(passes)} check(s) passed. "
+                   "(--verbose for detail.)")
+
+    out.append("")
+    out.append(
+        f"Summary: {len(failures)} failure(s), "
+        f"{len(warnings)} warning(s), {len(passes)} passed."
+    )
+
+    return "\n".join(out), len(failures), len(warnings)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Run the doctor.
+
+    Exit codes:
+      * 0 — no failures (and no warnings under ``--strict``)
+      * 1 — at least one failure (or, under ``--strict``, any warning)
+      * 2 — usage error
+    """
+    argv = list(argv or [])
+    strict = False
+    verbose = False
+    while argv:
+        a = argv.pop(0)
+        if a == "--strict":
+            strict = True
+        elif a in ("--verbose", "-v"):
+            verbose = True
+        else:
+            print(_USAGE, file=sys.stderr)
+            return 2
+
+    try:
+        gathered = _gather()
+    except Exception as e:  # noqa: BLE001 — never crash a doctor
+        # Exception messages can be tainted (e.g. subprocess stderr
+        # rolled into a RuntimeError); escape before emitting.
+        safe_msg = escape_nonprintable(f"{type(e).__name__}: {e}")
+        print(
+            f"RAPTOR doctor\n=============\n\n"
+            f"FAILURES:\n  ✗ doctor internal error: {safe_msg}\n\n"
+            f"Summary: 1 failure(s), 0 warning(s), 0 passed.",
+        )
+        return 1
+
+    text, n_fail, n_warn = _render(*gathered, verbose=verbose)
+    print(text)
+    if n_fail:
+        return 1
+    if strict and n_warn:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))

--- a/core/startup/init.py
+++ b/core/startup/init.py
@@ -326,6 +326,70 @@ def check_env(unavailable_features: set) -> tuple[list, list]:
     if os.getuid() == 0:
         warnings.append("Running as root is strongly discouraged — RAPTOR executes untrusted build commands, compiles PoCs, and runs fuzzing targets")
 
+    # Python version. RAPTOR requires 3.10+: ``packages/
+    # exploitability_validation/schemas.py`` (and other sites)
+    # uses PEP 604 union syntax (``str | None``) at function-
+    # definition time without ``from __future__ import
+    # annotations``, so the module fails to import on 3.9 with
+    # a confusing ``TypeError: unsupported operand type(s) for |``.
+    # Surface the version mismatch early so the operator sees
+    # "wrong Python" instead of a deep import trace.
+    import platform
+    py_version_str = platform.python_version()
+    if sys.version_info < (3, 10):
+        parts.append(f"Python {py_version_str} ✗")
+        warnings.append(
+            f"Python {py_version_str} at {sys.executable} — RAPTOR "
+            f"requires Python 3.10+. PEP 604 union syntax used in "
+            f"packages/exploitability_validation/schemas.py fails "
+            f"to import on older versions."
+        )
+    else:
+        parts.append(f"Python {py_version_str} ✓")
+
+    # RAPTOR_DIR — defensive check for the "operator bypassed the
+    # wrapper" path. ``bin/raptor`` / ``libexec/*`` scripts set this
+    # automatically; ``CLAUDE_ENV_FILE`` propagates it into claude-
+    # spawned Bash tool calls. Only unset when someone runs
+    # ``python3 raptor.py …`` (or imports core/ modules) from a
+    # bare shell. Specific value computed from REPO_ROOT so the
+    # operator can copy-paste the right export line.
+    raptor_dir = os.environ.get("RAPTOR_DIR")
+    if not raptor_dir:
+        warnings.append(
+            f"RAPTOR_DIR not set in this process; expected "
+            f"{REPO_ROOT} based on checkout location. Affects "
+            f"direct ``python3 raptor.py …`` invocations only — "
+            f"bin/raptor and claude sessions set it automatically."
+        )
+    else:
+        resolved = Path(raptor_dir).resolve()
+        if not resolved.is_dir():
+            warnings.append(
+                f"RAPTOR_DIR={raptor_dir!r} does not resolve to a "
+                f"directory"
+            )
+        else:
+            missing = [
+                d for d in ("core", "packages", "libexec", "bin")
+                if not (resolved / d).is_dir()
+            ]
+            if missing:
+                warnings.append(
+                    f"RAPTOR_DIR={raptor_dir!r} is missing expected "
+                    f"directories: {', '.join(missing)}"
+                )
+
+    # No check on .claude/raptor.env or .claude/settings.json
+    # despite both being part of the SessionStart hook chain.
+    # Failure modes for either file missing are: operator wiped
+    # it (wilful — operator knows), hook script broken (RAPTOR
+    # ship-side bug, doctor advice doesn't help), claude using
+    # a different project's settings (operator-config; doctor
+    # advice doesn't help). None are both common-enough-to-
+    # design-for AND actionable-via-doctor-output. Dropping
+    # avoids noise without missing real signal.
+
     out_dir = RaptorConfig.get_out_dir()
     out_ok = out_dir.exists() and os.access(out_dir, os.W_OK)
     parts.append("out/ ✓" if out_ok else "out/ ✗")

--- a/core/startup/tests/test_check_env_session.py
+++ b/core/startup/tests/test_check_env_session.py
@@ -1,0 +1,191 @@
+"""Tests for the session-context-aware additions to
+``core.startup.init.check_env``:
+
+  * Python version floor (3.10+, enforced by
+    PEP 604 syntax in schemas.py without
+    ``from __future__ import annotations``).
+  * RAPTOR_DIR defensive check.
+
+Both are visible to the banner AND the doctor (single source of
+truth — banner picks them up automatically).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from core.startup import init as startup_init
+
+
+@pytest.fixture
+def fake_repo(tmp_path, monkeypatch):
+    """Build a minimal fake repo at tmp_path and re-point
+    ``startup_init.REPO_ROOT`` at it for the duration of the test."""
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / "core").mkdir()
+    (tmp_path / "packages").mkdir()
+    (tmp_path / "libexec").mkdir()
+    (tmp_path / "bin").mkdir()
+    monkeypatch.setattr(startup_init, "REPO_ROOT", tmp_path)
+    return tmp_path
+
+
+def _run_check_env(monkeypatch):
+    """Invoke check_env with the noisy sandbox / disk side checks
+    stubbed out. We're testing only the new session-context branch.
+    """
+    # Sandbox probes shell out; disk reads statvfs. Both are
+    # noisy and orthogonal to the env-file check — patch them
+    # away so the test stays focused.
+    monkeypatch.setattr("os.statvfs", lambda _: type(
+        "S", (), {"f_bavail": 10**9, "f_frsize": 4096}
+    )())
+    return startup_init.check_env(set())
+
+
+# ---------------------------------------------------------------------------
+# RAPTOR_DIR check
+# ---------------------------------------------------------------------------
+
+
+class TestRaptorDirCheck:
+    def test_unset_warns_with_computed_value(
+        self, fake_repo, monkeypatch,
+    ):
+        monkeypatch.delenv("RAPTOR_DIR", raising=False)
+        _, warnings = _run_check_env(monkeypatch)
+        match = [w for w in warnings if "RAPTOR_DIR not set" in w]
+        assert match, f"no RAPTOR_DIR warning in: {warnings}"
+        assert str(fake_repo) in match[0]
+
+    def test_set_to_non_directory_warns(
+        self, fake_repo, monkeypatch, tmp_path,
+    ):
+        bogus = tmp_path / "does-not-exist"
+        monkeypatch.setenv("RAPTOR_DIR", str(bogus))
+        _, warnings = _run_check_env(monkeypatch)
+        match = [w for w in warnings if "does not resolve" in w]
+        assert match, f"no path-resolution warning in: {warnings}"
+
+    def test_set_to_non_raptor_dir_warns(
+        self, fake_repo, monkeypatch, tmp_path,
+    ):
+        # tmp_path lacks the layout.
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        monkeypatch.setenv("RAPTOR_DIR", str(empty))
+        _, warnings = _run_check_env(monkeypatch)
+        match = [w for w in warnings if "missing expected directories" in w]
+        assert match, f"no layout warning in: {warnings}"
+
+    def test_set_correctly_no_warning(self, fake_repo, monkeypatch):
+        monkeypatch.setenv("RAPTOR_DIR", str(fake_repo))
+        _, warnings = _run_check_env(monkeypatch)
+        assert not any(
+            "RAPTOR_DIR" in w and "not set" in w for w in warnings
+        )
+
+
+# ---------------------------------------------------------------------------
+# No .claude/raptor.env or .claude/settings.json checks
+# ---------------------------------------------------------------------------
+
+
+class TestPythonVersionCheck:
+    """The check pings a real failure mode: ``packages/
+    exploitability_validation/schemas.py`` uses ``str | None``
+    at function-definition time without ``__future__``, so
+    importing the module on 3.9 raises ``TypeError``. We want
+    the operator to see the version mismatch BEFORE that import
+    trace."""
+
+    def test_runs_on_current_python_records_version(
+        self, fake_repo, monkeypatch,
+    ):
+        # No version mock — we're running on a real Python.
+        # Whatever version it is, the version should appear as a
+        # part with the appropriate glyph.
+        parts, warnings = _run_check_env(monkeypatch)
+        version_parts = [p for p in parts if p.startswith("Python ")]
+        assert version_parts, f"no python version in parts: {parts}"
+
+    def test_old_python_emits_failure_glyph_and_warning(
+        self, fake_repo, monkeypatch,
+    ):
+        # Force version_info < 3.10. NamedTuple-style replacement
+        # so sys.version_info comparisons still work.
+        from collections import namedtuple
+        VI = namedtuple(
+            "VI", "major minor micro releaselevel serial",
+        )
+        monkeypatch.setattr("sys.version_info", VI(3, 9, 18, "final", 0))
+        # platform.python_version() reads from sys.version, not
+        # version_info — patch its return so the message is
+        # internally consistent.
+        monkeypatch.setattr(
+            "platform.python_version", lambda: "3.9.18",
+        )
+        parts, warnings = _run_check_env(monkeypatch)
+        version_parts = [p for p in parts if p.startswith("Python ")]
+        # Failure glyph ⇒ doctor classifies as failure.
+        assert any("✗" in p for p in version_parts), version_parts
+        # Warning carries the reason (PEP 604 / schemas.py) so
+        # operator knows WHY 3.10 is required.
+        match = [
+            w for w in warnings
+            if "Python 3.9.18" in w and "3.10+" in w
+        ]
+        assert match, warnings
+        assert "PEP 604" in match[0]
+        assert "schemas.py" in match[0]
+
+    def test_current_python_emits_pass_glyph(
+        self, fake_repo, monkeypatch,
+    ):
+        parts, warnings = _run_check_env(monkeypatch)
+        version_parts = [p for p in parts if p.startswith("Python ")]
+        assert version_parts
+        # On any 3.10+ host (which CI is), the part carries ✓.
+        assert any("✓" in p for p in version_parts), version_parts
+        # No Python-related warning.
+        assert not any(
+            "Python" in w and "3.10+" in w for w in warnings
+        )
+
+
+class TestNoClaudeFileChecks:
+    """Pin that ``check_env`` does NOT warn about ``.claude/raptor.env``
+    or ``.claude/settings.json`` either inside or outside a claude
+    session. Both checks were considered and dropped — failure
+    modes for either file missing are not actionable via doctor
+    advice (operator damage / RAPTOR ship-side bug / claude
+    misconfig)."""
+
+    def test_no_raptor_env_warning_inside_claude_session(
+        self, fake_repo, monkeypatch,
+    ):
+        monkeypatch.setenv("CLAUDECODE", "1")
+        _, warnings = _run_check_env(monkeypatch)
+        assert not any("raptor.env" in w for w in warnings), warnings
+
+    def test_no_raptor_env_warning_outside_claude_session(
+        self, fake_repo, monkeypatch,
+    ):
+        monkeypatch.delenv("CLAUDECODE", raising=False)
+        _, warnings = _run_check_env(monkeypatch)
+        assert not any("raptor.env" in w for w in warnings), warnings
+
+    def test_no_settings_json_warning(self, fake_repo, monkeypatch):
+        # No .claude/settings.json. CLAUDECODE both set and unset.
+        for v in ("1", None):
+            if v is None:
+                monkeypatch.delenv("CLAUDECODE", raising=False)
+            else:
+                monkeypatch.setenv("CLAUDECODE", v)
+            _, warnings = _run_check_env(monkeypatch)
+            assert not any(
+                "settings.json" in w for w in warnings
+            ), f"with CLAUDECODE={v}: {warnings}"

--- a/core/startup/tests/test_doctor.py
+++ b/core/startup/tests/test_doctor.py
@@ -1,0 +1,382 @@
+"""Tests for ``core.startup.doctor``.
+
+Exercises the renderer + main entry point with mocked ``init.check_*``
+returns. The check functions themselves have their own tests
+(``test_check_env_macos.py``, etc.); doctor's surface is the
+mapping from check-function output → failure/warning/pass
+classification + exit code.
+"""
+
+from __future__ import annotations
+
+from typing import List
+from unittest.mock import patch
+
+import pytest
+
+from core.startup import doctor
+from core.startup.doctor import _render, main
+
+
+def _gather_stub(
+    *,
+    tool_results=(),
+    tool_warnings=(),
+    llm_lines=(),
+    llm_warnings=(),
+    env_parts=(),
+    env_warnings=(),
+    lang_line=None,
+    project_line=None,
+):
+    """Build a _gather()-shaped tuple for tests."""
+    return (
+        list(tool_results), list(tool_warnings),
+        list(llm_lines), list(llm_warnings),
+        list(env_parts), list(env_warnings),
+        lang_line, project_line,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Classification — what's a failure, what's a warning, what's a pass
+# ---------------------------------------------------------------------------
+
+
+class TestRenderClassification:
+    def test_env_cross_glyph_is_failure(self):
+        text, n_fail, n_warn = _render(
+            *_gather_stub(env_parts=["out/ ✗", "disk 16 GB free"]),
+            verbose=False,
+        )
+        assert n_fail == 1
+        assert n_warn == 0
+        assert "FAILURES:" in text
+        assert "✗ out/ ✗" in text
+        # The fact line is a pass.
+        assert "disk 16 GB free" not in text.split("FAILURES:")[1].split("\n\n")[0]
+
+    def test_tool_warnings_are_warnings(self):
+        text, n_fail, n_warn = _render(
+            *_gather_stub(
+                tool_results=[("semgrep", True), ("rr", False)],
+                tool_warnings=["/crash-analysis limited — rr not found"],
+            ),
+            verbose=False,
+        )
+        assert n_fail == 0
+        assert n_warn == 1
+        assert "WARNINGS:" in text
+        assert "rr not found" in text
+
+    def test_llm_warnings_are_warnings(self):
+        text, n_fail, n_warn = _render(
+            *_gather_stub(llm_warnings=["No API keys configured"]),
+            verbose=False,
+        )
+        assert n_warn == 1
+
+    def test_env_warnings_are_warnings(self):
+        text, n_fail, n_warn = _render(
+            *_gather_stub(env_warnings=["RAPTOR_DIR not set"]),
+            verbose=False,
+        )
+        assert n_warn == 1
+
+    def test_pass_lines_default_summarised(self):
+        text, n_fail, n_warn = _render(
+            *_gather_stub(
+                tool_results=[("semgrep", True), ("codeql", True)],
+                env_parts=["out/ ✓"],
+                lang_line="tree-sitter ✓ (python)",
+            ),
+            verbose=False,
+        )
+        assert n_fail == 0
+        assert n_warn == 0
+        # All-good path emits the compact summary line.
+        assert "All " in text and "check(s) passed" in text
+        # Individual pass lines NOT in default output.
+        assert "PASSED:" not in text
+
+    def test_pass_lines_shown_with_verbose(self):
+        text, n_fail, n_warn = _render(
+            *_gather_stub(
+                tool_results=[("semgrep", True)],
+                env_parts=["out/ ✓"],
+            ),
+            verbose=True,
+        )
+        assert "PASSED:" in text
+        assert "tools present: semgrep" in text
+        assert "out/ ✓" in text
+
+    def test_summary_line_always_present(self):
+        text, _, _ = _render(*_gather_stub(), verbose=False)
+        assert "Summary:" in text
+        assert "0 failure(s)" in text
+
+
+# ---------------------------------------------------------------------------
+# Exit codes
+# ---------------------------------------------------------------------------
+
+
+class TestMainExitCodes:
+    def test_clean_run_returns_zero(self, capsys, monkeypatch):
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(tool_results=[("semgrep", True)]),
+        )
+        rc = main([])
+        assert rc == 0
+
+    def test_any_failure_returns_one(self, capsys, monkeypatch):
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(env_parts=["out/ ✗"]),
+        )
+        rc = main([])
+        assert rc == 1
+
+    def test_warnings_alone_do_not_fail(self, capsys, monkeypatch):
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(env_warnings=["RAPTOR_DIR not set"]),
+        )
+        rc = main([])
+        assert rc == 0
+
+    def test_strict_fails_on_warnings(self, capsys, monkeypatch):
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(env_warnings=["RAPTOR_DIR not set"]),
+        )
+        rc = main(["--strict"])
+        assert rc == 1
+
+    def test_strict_passes_on_clean(self, capsys, monkeypatch):
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(tool_results=[("semgrep", True)]),
+        )
+        rc = main(["--strict"])
+        assert rc == 0
+
+    def test_verbose_does_not_change_exit_code(self, capsys, monkeypatch):
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(env_parts=["out/ ✗"]),
+        )
+        rc = main(["--verbose"])
+        assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Usage / argument handling
+# ---------------------------------------------------------------------------
+
+
+class TestUsage:
+    def test_unknown_flag_returns_two(self, capsys):
+        rc = main(["--json"])
+        captured = capsys.readouterr()
+        assert rc == 2
+        assert "usage: raptor doctor" in captured.err
+
+    def test_strict_and_verbose_combinable(self, capsys, monkeypatch):
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(env_warnings=["x"]),
+        )
+        rc = main(["--strict", "--verbose"])
+        assert rc == 1
+
+    def test_short_verbose_flag(self, capsys, monkeypatch):
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(tool_results=[("x", True)]),
+        )
+        rc = main(["-v"])
+        assert rc == 0
+        # Short flag triggers verbose rendering.
+        out = capsys.readouterr().out
+        assert "PASSED:" in out
+
+
+# ---------------------------------------------------------------------------
+# Internal-error safety
+# ---------------------------------------------------------------------------
+
+
+class TestInternalSafety:
+    def test_gather_exception_renders_as_failure(
+        self, capsys, monkeypatch,
+    ):
+        def boom():
+            raise RuntimeError("simulated check explosion")
+        monkeypatch.setattr(doctor, "_gather", boom)
+        rc = main([])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "doctor internal error" in out
+        assert "simulated check explosion" in out
+
+
+# ---------------------------------------------------------------------------
+# Output shape — failures-first, no banner content
+# ---------------------------------------------------------------------------
+
+
+class TestOutputShape:
+    def test_no_logo_no_quote(self, capsys, monkeypatch):
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(tool_results=[("semgrep", True)]),
+        )
+        main([])
+        out = capsys.readouterr().out
+        # Banner artifacts should be absent.
+        assert "raptor:~$" not in out  # no quote prompt
+        assert "╔═" not in out  # no logo box
+        assert "Get them bugs" not in out
+
+    def test_failures_appear_before_warnings(
+        self, capsys, monkeypatch,
+    ):
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(
+                env_parts=["out/ ✗"],
+                env_warnings=["disk getting low"],
+            ),
+        )
+        main([])
+        out = capsys.readouterr().out
+        fail_idx = out.index("FAILURES:")
+        warn_idx = out.index("WARNINGS:")
+        assert fail_idx < warn_idx
+
+    def test_specific_paths_present_in_env_warnings(
+        self, capsys, monkeypatch,
+    ):
+        """Doctor output names the specific path / value when the check
+        knows it — operator saves a lookup. Pin that the warning text
+        flows through to stdout unchanged."""
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(
+                env_warnings=[
+                    "RAPTOR_DIR not set in this process; "
+                    "expected /home/op/raptor based on checkout "
+                    "location.",
+                ],
+            ),
+        )
+        main([])
+        out = capsys.readouterr().out
+        assert "/home/op/raptor" in out
+
+
+# ---------------------------------------------------------------------------
+# ANSI / control-byte defence
+# ---------------------------------------------------------------------------
+
+
+class TestNonprintableEscaping:
+    """Every operator-visible string from upstream checks must pass
+    through ``escape_nonprintable`` before reaching stdout. No current
+    producer of doctor input emits ANSI, but defence in depth keeps a
+    future change (e.g. tool warning sourced from subprocess stderr,
+    project name read from disk) from delivering a terminal-escape
+    injection."""
+
+    _EVIL = "\x1b[31mEVIL\x1b[0m"
+    _EVIL_ESCAPED = "\\x1b[31mEVIL\\x1b[0m"
+
+    def test_ansi_in_tool_warning_is_escaped(
+        self, capsys, monkeypatch,
+    ):
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(
+                tool_warnings=[f"/agentic limited — {self._EVIL} fake-tool"],
+            ),
+        )
+        main([])
+        out = capsys.readouterr().out
+        assert "\x1b" not in out
+        assert self._EVIL_ESCAPED in out
+
+    def test_ansi_in_llm_warning_is_escaped(
+        self, capsys, monkeypatch,
+    ):
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(
+                llm_warnings=[f"provider error: {self._EVIL}"],
+            ),
+        )
+        main([])
+        out = capsys.readouterr().out
+        assert "\x1b" not in out
+
+    def test_ansi_in_env_failure_is_escaped(
+        self, capsys, monkeypatch,
+    ):
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(
+                env_parts=[f"out/ ✗ {self._EVIL}"],
+            ),
+        )
+        main([])
+        out = capsys.readouterr().out
+        assert "\x1b" not in out
+        # The ✗ glyph (a printable Unicode codepoint) survives;
+        # only the ESC bytes get rewritten.
+        assert "✗" in out
+
+    def test_ansi_in_pass_lines_is_escaped_under_verbose(
+        self, capsys, monkeypatch,
+    ):
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(
+                env_parts=[f"out/ ✓ {self._EVIL}"],
+            ),
+        )
+        main(["--verbose"])
+        out = capsys.readouterr().out
+        assert "\x1b" not in out
+
+    def test_ansi_in_internal_error_is_escaped(
+        self, capsys, monkeypatch,
+    ):
+        def boom():
+            raise RuntimeError(f"taint {self._EVIL} in message")
+        monkeypatch.setattr(doctor, "_gather", boom)
+        rc = main([])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "\x1b" not in out
+        assert "doctor internal error" in out
+
+    def test_printable_glyphs_survive(self, capsys, monkeypatch):
+        """The escaping pass keeps ✗ ✓ ! and Unicode letters — only
+        non-printable bytes get rewritten. Pin so a tightening of
+        ``escape_nonprintable`` doesn't accidentally mangle the
+        doctor's status glyphs."""
+        monkeypatch.setattr(
+            doctor, "_gather",
+            lambda: _gather_stub(
+                env_parts=["out/ ✗"],
+                tool_warnings=["rr not found — /crash-analysis limited"],
+            ),
+        )
+        main([])
+        out = capsys.readouterr().out
+        assert "✗" in out
+        assert "!" in out
+        # Em-dash (a printable Unicode codepoint) must survive.
+        assert "—" in out

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1086,7 +1086,7 @@ We think it useful to include such costings, just so people understand how much 
 ## Dependencies
 
 ### Core Dependencies (Required by All)
-- Python 3.9+
+- Python 3.10+ (PEP 604 union syntax used at function-definition time)
 - Standard library: pathlib, logging, json, subprocess, argparse
 
 ### Package-Specific Dependencies

--- a/raptor.py
+++ b/raptor.py
@@ -18,6 +18,7 @@ Available Modes:
     web         - Web application security testing
     agentic     - Full autonomous workflow
     codeql      - CodeQL-only analysis
+    doctor      - Status report for local setup (no claude needed)
     help        - Show detailed help for a specific mode
 
 Examples:
@@ -436,13 +437,24 @@ def mode_llm_analysis(args: list) -> int:
     """Run LLM-powered vulnerability analysis on existing SARIF files."""
     script_root = Path(__file__).parent
     llm_script = script_root / "packages/llm_analysis/agent.py"
-    
+
     if not llm_script.exists():
         print(f"✗ LLM analysis script not found: {llm_script}")
         return 1
-    
+
     print("\n[*] Running LLM-powered vulnerability analysis...\n")
     return _run_script(llm_script, args)
+
+
+def mode_doctor(args: list) -> int:
+    """Run the on-demand status report.
+
+    Wraps :mod:`core.startup.doctor` — see its docstring for the
+    contract (no logo, failures-first, non-zero exit on real
+    failure). All flags pass through to ``doctor.main``.
+    """
+    from core.startup.doctor import main as doctor_main
+    return doctor_main(args)
 
 
 def show_mode_help(mode: str) -> None:
@@ -502,6 +514,7 @@ Available Modes:
   agentic     - Full autonomous workflow (Semgrep + CodeQL + LLM analysis)
   codeql      - CodeQL-only analysis
   analyze     - LLM-powered vulnerability analysis (requires SARIF input)
+  doctor      - Status report for local setup (no claude needed)
 
 Examples:
   # Full autonomous workflow
@@ -597,6 +610,7 @@ def main():
         'agentic': mode_agentic,
         'codeql': mode_codeql,
         'analyze': mode_llm_analysis,
+        'doctor': mode_doctor,
     }
     
     if mode not in mode_handlers:


### PR DESCRIPTION
Status report on local RAPTOR setup, runnable without a live claude session. Wraps the existing ``core/startup/init.py`` checks (no duplicate check infrastructure) and renders them failures-first for an operator who typed ``raptor doctor`` because something feels off.

The doctor reports what's wrong, not how to fix it — RAPTOR's audience is technical operators who pick their own install path.

Also adds two checks to ``check_env`` (visible to banner AND doctor):
  * Python 3.10+ — PEP 604 syntax in schemas.py imports fail on 3.9 with a confusing TypeError; surface the version mismatch first.
  * RAPTOR_DIR — defensive check for bare ``python3 raptor.py`` use outside bin/raptor / libexec / claude SessionStart.

Operator-visible strings pass through ``escape_nonprintable`` as defence in depth against future ANSI / control-byte injection from tainted upstream sources (subprocess stderr, provider errors, etc.).

Supersedes #486 (hinotori-agent), revives the self-check shape from #57 (splinters-io, aborted Frida PR).

47 tests pass in ``core/startup/tests/``.

Closes #486
See also #57