### PR TITLE
fix(core/sandbox): surface 3 silent setrlimit failures via warn_post_fork

### DIFF
--- a/core/sandbox/_fork_safe_warn.py
+++ b/core/sandbox/_fork_safe_warn.py
@@ -1,0 +1,43 @@
+"""Fork-safe degraded-mode warning helper.
+
+`logging` is fork-unsafe (module-level locks can deadlock if a parent
+thread held a logging lock at fork time). `os.write(2, ...)` is
+async-signal-safe and lock-free — the only safe way to surface a
+degraded-isolation event from inside `preexec_fn` or the post-fork
+half of sandbox setup.
+
+Use this helper from any post-fork code that wants to surface a
+degraded-isolation event WITHOUT aborting the child. For fail-CLOSED
+sites (e.g. landlock.py:595-617 prctl / restrict_self / generic
+Exception), continue to use the direct `os.write(2, ...) + os._exit(126)`
+convention — those paths must not depend on this helper.
+
+Prefix convention: `RAPTOR: ` matches the in-tree style already used at
+core/sandbox/landlock.py:449,453,499,571,587 / seccomp.py / _spawn.py /
+ptrace_probe.py. Operators monitoring sandbox stderr can grep for a
+single prefix across all degraded-mode signals.
+"""
+
+import os
+
+_PREFIX = b"RAPTOR: "
+
+
+def warn_post_fork(message: bytes) -> None:
+    """Emit a fork-safe degraded-mode warning to stderr.
+
+    `message` must be `bytes` (already encoded; no f-strings). The
+    `RAPTOR: ` prefix is prepended automatically unless `message`
+    already starts with it. The caller should include a trailing
+    `\\n` in `message`.
+
+    Errors are swallowed — stderr may be closed/redirected in a
+    sandboxed child; the alternative is letting preexec_fn raise,
+    which is worse than a silent fail for a defense-in-depth signal.
+    """
+    if not message.startswith(_PREFIX):
+        message = _PREFIX + message
+    try:
+        os.write(2, message)
+    except OSError:
+        pass

--- a/core/sandbox/_macos_spawn.py
+++ b/core/sandbox/_macos_spawn.py
@@ -100,6 +100,7 @@ from pathlib import Path
 from typing import Iterable, List, Optional
 
 from . import seatbelt
+from ._fork_safe_warn import warn_post_fork
 from .preexec import _make_preexec_fn
 
 logger = logging.getLogger(__name__)
@@ -304,10 +305,11 @@ def run_sandboxed(cmd: List[str], *,
             except (ValueError, OSError):
                 # Best-effort. Some macOS versions cap NPROC via
                 # different sysctls and setrlimit may EPERM the
-                # call when NPROC > kern.maxproc/UID. Don't crash
-                # the launch on it; the rlimit failure is a
-                # documented soft posture.
-                pass
+                # call when NPROC > kern.maxproc/UID. The module
+                # docstring already documents this as soft posture;
+                # emit a fork-safe warning so operators can observe
+                # when the documented-soft bound becomes a silent no-op.
+                warn_post_fork(b"RAPTOR: _macos_spawn RLIMIT_NPROC setrlimit failed -- documented soft posture became silent no-op\n")
     else:
         preexec = base_preexec
 

--- a/core/sandbox/_spawn.py
+++ b/core/sandbox/_spawn.py
@@ -157,21 +157,31 @@ def _set_rlimits(limits: dict) -> None:
     designed to run before mount ops / Landlock / seccomp."""
     import resource
     from .preexec import _DEFAULT_LIMITS
+    from ._fork_safe_warn import warn_post_fork
     mem = limits.get("memory_mb", _DEFAULT_LIMITS["memory_mb"])
     file_mb = limits.get("max_file_mb", _DEFAULT_LIMITS["max_file_mb"])
     cpu = limits.get("cpu_seconds", _DEFAULT_LIMITS["cpu_seconds"])
     mem_bytes = mem * 1024 * 1024
     file_bytes = file_mb * 1024 * 1024
-    try:
-        if mem > 0:
+    if mem > 0:
+        try:
             resource.setrlimit(resource.RLIMIT_AS, (mem_bytes, mem_bytes))
-        if file_mb > 0:
+        except (ValueError, OSError):
+            warn_post_fork(b"RAPTOR: _set_rlimits RLIMIT_AS setrlimit failed -- memory cap not applied\n")
+    if file_mb > 0:
+        try:
             resource.setrlimit(resource.RLIMIT_FSIZE, (file_bytes, file_bytes))
-        if cpu > 0:
+        except (ValueError, OSError):
+            warn_post_fork(b"RAPTOR: _set_rlimits RLIMIT_FSIZE setrlimit failed -- file-size cap not applied\n")
+    if cpu > 0:
+        try:
             resource.setrlimit(resource.RLIMIT_CPU, (cpu, cpu + 1))
+        except (ValueError, OSError):
+            warn_post_fork(b"RAPTOR: _set_rlimits RLIMIT_CPU setrlimit failed -- cpu cap not applied\n")
+    try:
         resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
     except (ValueError, OSError):
-        pass
+        warn_post_fork(b"RAPTOR: _set_rlimits RLIMIT_CORE setrlimit failed -- coredump suppression relies on kernel core_pattern\n")
 
 
 def _kill_and_reap(pid: int) -> None:

--- a/core/sandbox/_spawn.py
+++ b/core/sandbox/_spawn.py
@@ -900,11 +900,12 @@ def run_sandboxed(
                 # bounded fork count via RLIMIT_NPROC (prlimit).
                 if nproc_limit and nproc_limit > 0:
                     import resource
+                    from ._fork_safe_warn import warn_post_fork
                     try:
                         resource.setrlimit(resource.RLIMIT_NPROC,
                                            (nproc_limit, nproc_limit))
                     except (ValueError, OSError):
-                        pass
+                        warn_post_fork(b"RAPTOR: _spawn grandchild RLIMIT_NPROC setrlimit failed -- fork-bomb bound not applied\n")
                 try:
                     os.execvpe(cmd[0], list(cmd), exec_env)
                 except FileNotFoundError:

--- a/core/sandbox/tests/test_fork_safe_warn.py
+++ b/core/sandbox/tests/test_fork_safe_warn.py
@@ -1,0 +1,65 @@
+"""Tests for fork-safe degraded-mode warning helper."""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+
+def test_writes_prefixed_message_to_stderr(capfd):
+    from core.sandbox._fork_safe_warn import warn_post_fork
+
+    warn_post_fork(b"RAPTOR: unit_test\n")
+    captured = capfd.readouterr()
+    assert "RAPTOR: unit_test" in captured.err
+
+
+def test_auto_prepends_prefix_when_missing(capfd):
+    from core.sandbox._fork_safe_warn import warn_post_fork
+
+    warn_post_fork(b"bare_event\n")
+    captured = capfd.readouterr()
+    assert "RAPTOR: bare_event" in captured.err
+
+
+def test_silent_when_fd2_closed():
+    script = textwrap.dedent(
+        """
+        import os, sys
+        sys.path.insert(0, os.environ["RAPTOR_DIR"])
+        from core.sandbox._fork_safe_warn import warn_post_fork
+        os.close(2)
+        warn_post_fork(b"should_not_raise\\n")
+        print("OK")
+        """
+    )
+    env = {**os.environ, "RAPTOR_DIR": os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", ".."))}
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, env=env,
+    )
+    assert result.returncode == 0
+    assert "OK" in result.stdout
+
+
+def test_callable_from_preexec_fn():
+    script = textwrap.dedent(
+        """
+        import os, sys
+        sys.path.insert(0, os.environ["RAPTOR_DIR"])
+        from core.sandbox._fork_safe_warn import warn_post_fork
+        import subprocess
+        subprocess.run(
+            ["true"],
+            preexec_fn=lambda: warn_post_fork(b"RAPTOR: preexec_test\\n"),
+            check=True,
+        )
+        """
+    )
+    env = {**os.environ, "RAPTOR_DIR": os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", ".."))}
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, env=env,
+    )
+    assert result.returncode == 0
+    assert "RAPTOR: preexec_test" in result.stderr


### PR DESCRIPTION
## Summary

Surfaces 3 silent `setrlimit()` failures via fork-safe `warn_post_fork()`:

- `_set_rlimits()` shared `try/except OSError` previously aborted remaining setrlimit calls silently after first failure — restructured to per-call try/except
- `_set_rlimits()` macOS grandchild RLIMIT_NPROC silent-fail — now warned
- `_macos_spawn.py:298-310` macOS RLIMIT_NPROC silent-fail — now warned

Pre-fix: an operator using `--audit-budget=512M` could have RLIMIT_AS silently fail (e.g., kernel too small) and the run would continue with no rlimit applied; only the FIRST exception in the shared try would terminate the rest.

## Test plan

Touches `core/sandbox/{_macos_spawn,_spawn}.py`. Sandbox suite passes (`pytest core/sandbox/tests/ --ignore=test_macos_spawn.py --ignore=test_seatbelt_observe.py`). 2 worker claims were REFUTED via verifier (setsid POSIX-benign; PR_SET_PTRACER downstream raises RuntimeError).

## Notes

Verdict per W34 rubric: VISIBILITY (silent-degrade → operator-observable). Closes 3 sites; 2 prior worker claims refuted with citations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only add fork-safe stderr warnings and adjust exception handling around `setrlimit` without altering sandbox enforcement behavior beyond improved observability.
> 
> **Overview**
> Adds a new fork-safe warning helper (`core/sandbox/_fork_safe_warn.py`) that emits prefixed degraded-mode messages via `os.write(2, ...)` for use in post-fork / `preexec_fn` code.
> 
> Updates Linux and macOS sandbox spawn paths to **stop silently swallowing `setrlimit()` failures**: `_spawn._set_rlimits()` now handles each rlimit independently and warns on failures (AS/FSIZE/CPU/CORE), and both `_spawn` (grandchild `RLIMIT_NPROC`) and `_macos_spawn` (preexec `RLIMIT_NPROC`) emit warnings when NPROC limits can’t be applied.
> 
> Adds tests (`test_fork_safe_warn.py`) covering prefixing behavior, safety when stderr is closed, and usability from a `preexec_fn`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dea5a8d0fbfac6d60302873f57b8f63819440654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->