### PR TITLE
fix(core/sandbox/context): defensive strict_env=True wire + forbidden-kwargs guard

### DIFF
--- a/core/sandbox/_macos_spawn.py
+++ b/core/sandbox/_macos_spawn.py
@@ -165,6 +165,7 @@ def run_sandboxed(cmd: List[str], *,
                   use_egress_proxy: bool = False,
                   proxy_port: Optional[int] = None,
                   fake_home: bool = False,
+                  strict_env: bool = False,
                   ) -> subprocess.CompletedProcess:
     """Run ``cmd`` under macOS sandbox-exec with an SBPL profile
     derived from the logical sandbox kwargs.
@@ -241,6 +242,10 @@ def run_sandboxed(cmd: List[str], *,
     #    so the child sees no dotfiles. Pre-populate the dir empty.
     if env is not None:
         child_env = dict(env)
+        if strict_env:
+            from core.config import RaptorConfig
+            _dangerous = set(RaptorConfig.DANGEROUS_ENV_VARS)
+            child_env = {k: v for k, v in child_env.items() if k not in _dangerous}
     else:
         from core.config import RaptorConfig
         child_env = RaptorConfig.get_safe_env()

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -898,6 +898,7 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
         # blocklist is belt-and-braces on the os.environ →
         # get_safe_env path (see core/config.py); the caller path
         # is "you know what you're doing".
+        strict_env = kwargs.pop("strict_env", False)
         if kwargs.get("env") is None:
             kwargs.pop("env", None)  # drop any explicit None
             kwargs["env"] = RaptorConfig.get_safe_env()
@@ -907,6 +908,16 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                 f"{' '.join(cmd[:_CMD_DISPLAY_MAX_ARGS]) or cmd!r} "
                 f"— get_safe_env() not applied; caller env passed through."
             )
+            if strict_env:
+                _dangerous = set(RaptorConfig.DANGEROUS_ENV_VARS)
+                _stripped = [k for k in kwargs["env"] if k in _dangerous]
+                if _stripped:
+                    kwargs["env"] = {k: v for k, v in kwargs["env"].items()
+                                     if k not in _dangerous}
+                    logger.info(
+                        f"Sandbox: strict_env=True — stripped DANGEROUS_ENV_VARS "
+                        f"from caller env: {sorted(_stripped)}"
+                    )
 
         # Egress-proxy env injection — overlays AFTER get_safe_env() so
         # the proxy vars aren't stripped by the PROXY_ENV_VARS blocklist
@@ -1385,6 +1396,7 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                     fake_home=fake_home,
                     map_root=map_root,
                     start_new_session=kwargs.get("start_new_session", True),
+                    strict_env=strict_env,
                 )
                 used_spawn = True
             elif spawn_eligible:
@@ -2154,6 +2166,7 @@ def run_untrusted(cmd: List[str], *, target: str = None, output: str = None,
                restrict_reads=restrict_reads,
                readable_paths=readable_paths,
                fake_home=fake_home,
+               strict_env=True,
                **kwargs)
 
 

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -2249,5 +2249,6 @@ def run_untrusted_networked(
         use_egress_proxy=True,
         proxy_hosts=list(proxy_hosts),
         allowed_tcp_ports=[443],
+        strict_env=True,
         **kwargs,
     )

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -2129,12 +2129,13 @@ def run_untrusted(cmd: List[str], *, target: str = None, output: str = None,
             "dir and/or a writable output dir."
         )
     # Guard against silent misuse — the contract fixes these.
-    for forbidden in ("block_network", "allowed_tcp_ports"):
+    for forbidden in ("block_network", "allowed_tcp_ports", "strict_env"):
         if forbidden in kwargs:
             raise TypeError(
                 f"run_untrusted() does not accept {forbidden}= — it always "
-                f"runs with block_network=True and no TCP allowlist. Use "
-                f"sandbox() directly for varied network policy."
+                f"runs with block_network=True, no TCP allowlist, and "
+                f"strict_env=True env-stripping. Use sandbox() directly "
+                f"for varied network or env policy."
             )
     # Default stdin to DEVNULL for untrusted code. If the parent's stdin
     # is the operator's TTY (common for interactive RAPTOR use) and the
@@ -2227,12 +2228,13 @@ def run_untrusted_networked(
             "the egress allowlist is mandatory; callers wanting unrestricted "
             "network should use sandbox() directly."
         )
-    for forbidden in ("block_network", "allowed_tcp_ports", "use_egress_proxy"):
+    for forbidden in ("block_network", "allowed_tcp_ports", "use_egress_proxy", "strict_env"):
         if forbidden in kwargs:
             raise TypeError(
                 f"run_untrusted_networked() does not accept {forbidden}= — "
                 f"the network policy is fixed to egress-proxy-only on port "
-                f"443. Use sandbox() directly for varied network policy."
+                f"443 and strict_env=True env-stripping is mandatory. Use "
+                f"sandbox() directly for varied network or env policy."
             )
     if "stdin" not in kwargs and "input" not in kwargs:
         kwargs["stdin"] = subprocess.DEVNULL

--- a/core/sandbox/tests/test_run_untrusted_networked_strict_env.py
+++ b/core/sandbox/tests/test_run_untrusted_networked_strict_env.py
@@ -6,6 +6,8 @@ from caller-supplied env= dicts, leaving a contract gap for future
 cc_dispatch-style migrations that build env from semi-trusted sources.
 """
 
+import pytest
+
 from core.sandbox import context as _ctx
 
 
@@ -46,3 +48,33 @@ def test_run_untrusted_networked_forwards_strict_env(monkeypatch):
     assert captured["kwargs"].get("use_egress_proxy") is True
     assert captured["kwargs"].get("allowed_tcp_ports") == [443]
     assert captured["kwargs"].get("proxy_hosts") == ["api.example.com"]
+
+
+def test_run_untrusted_rejects_caller_strict_env():
+    """Caller passing strict_env= must get the clean guard message, not
+    a confusing "multiple values for keyword argument" TypeError.
+
+    run_untrusted() hardcodes strict_env=True; allowing the caller to
+    override would either bypass DANGEROUS_ENV_VARS stripping (silent
+    misuse) or collide with the wire (TypeError that doesn't name the
+    real problem). The forbidden-kwargs guard surfaces the misuse.
+    """
+    with pytest.raises(TypeError, match="strict_env"):
+        _ctx.run_untrusted(
+            ["echo", "ok"],
+            target="/tmp/raptor-target",
+            output="/tmp/raptor-output",
+            strict_env=False,
+        )
+
+
+def test_run_untrusted_networked_rejects_caller_strict_env():
+    """Same defensive parity for the networked variant."""
+    with pytest.raises(TypeError, match="strict_env"):
+        _ctx.run_untrusted_networked(
+            ["echo", "ok"],
+            target="/tmp/raptor-target",
+            output="/tmp/raptor-output",
+            proxy_hosts=["api.example.com"],
+            strict_env=False,
+        )

--- a/core/sandbox/tests/test_run_untrusted_networked_strict_env.py
+++ b/core/sandbox/tests/test_run_untrusted_networked_strict_env.py
@@ -1,0 +1,48 @@
+"""Verify that run_untrusted_networked() forwards strict_env=True to run().
+
+Defensive parity with the existing run_untrusted() wire (W36.B / F067).
+Without strict_env=True the helper would not strip DANGEROUS_ENV_VARS
+from caller-supplied env= dicts, leaving a contract gap for future
+cc_dispatch-style migrations that build env from semi-trusted sources.
+"""
+
+from core.sandbox import context as _ctx
+
+
+def test_run_untrusted_networked_forwards_strict_env(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+
+        # Return a sentinel so the caller's `return run(...)` is fine;
+        # no real subprocess is spawned.
+        class _Stub:
+            returncode = 0
+        return _Stub()
+
+    monkeypatch.setattr(_ctx, "run", fake_run)
+
+    _ctx.run_untrusted_networked(
+        ["echo", "ok"],
+        target="/tmp/raptor-target",
+        output="/tmp/raptor-output",
+        proxy_hosts=["api.example.com"],
+    )
+
+    # Defensive parity assertion: strict_env must be True regardless of
+    # any caller default. The helper is the security-sensitive entry
+    # point for hostname-allowlisted egress; callers must not have to
+    # remember to pass strict_env themselves.
+    assert captured["kwargs"].get("strict_env") is True, (
+        "run_untrusted_networked must forward strict_env=True to run(); "
+        f"saw kwargs.strict_env={captured['kwargs'].get('strict_env')!r}"
+    )
+
+    # Sanity: the other fixed-policy kwargs should also be set as the
+    # helper's docstring promises.
+    assert captured["kwargs"].get("block_network") is False
+    assert captured["kwargs"].get("use_egress_proxy") is True
+    assert captured["kwargs"].get("allowed_tcp_ports") == [443]
+    assert captured["kwargs"].get("proxy_hosts") == ["api.example.com"]


### PR DESCRIPTION
## Summary

Two changes in `core/sandbox/context.py`:

1. **Wire `strict_env=True` in `run_untrusted_networked()`** — defensive parity with `run_untrusted()` (which already hardcodes `strict_env=True` since W36.B / F067). Without this, a future `cc_dispatch`-style caller passing `env=os.environ.copy()` to `run_untrusted_networked()` would inherit the operator's `DANGEROUS_ENV_VARS` (LD_PRELOAD, etc.) instead of having them stripped. No current callers pass `env=`, so this is a defensive plug.

2. **Add `strict_env` to forbidden-kwargs guard** in both `run_untrusted()` and `run_untrusted_networked()`. Pre-fix, a caller passing `strict_env=False` (intending to opt out) would hit Python's confusing `TypeError: multiple values for keyword argument 'strict_env'` because the helpers hardcode it. Post-fix: clean `does not accept strict_env=` guard message matching the existing pattern for `block_network=` etc.

## Branch composition

Order: handler → wire → test → guard. The handler commit is a cherry-pick of W36.B's `fd19f33` so this branch is bisect-safe (every intermediate commit has both the handler and any wire that needs it).

## Test plan

- `test_run_untrusted_networked_strict_env.py` (NEW): 3 tests
  - Verifies wire forwards `strict_env=True` via `monkeypatch.setattr(core.sandbox.context.run, ...)`
  - Verifies `run_untrusted(strict_env=False)` raises clean `TypeError` with "strict_env"
  - Verifies `run_untrusted_networked(strict_env=False)` raises same
- Full sandbox suite: 451 passed, 408 skipped

## Notes

- Branch is independent of W36.B branch (cherry-pick brings W36.B's handler along; semantic equivalence). PR base is main.
- If W36.B PR (#499) merges first, GitHub will dedup the handler commit during rebase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox process-launch env handling for untrusted execution paths; mistakes could either over-strip needed vars or fail to strip dangerous ones, impacting security or tool compatibility.
> 
> **Overview**
> Ensures untrusted sandbox helpers always strip `RaptorConfig.DANGEROUS_ENV_VARS` even when callers pass a custom `env=` by introducing/propagating `strict_env` and wiring it through the macOS seatbelt backend.
> 
> `run_untrusted()` and `run_untrusted_networked()` now hard-require `strict_env=True` (and reject caller overrides with a clearer guard), and a new test verifies the networked helper forwards the flag and raises clean errors when misused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22b048a1cdcd1d05522c00d8034cdbb3bfbb7a30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->