### PR TITLE
fix(core/security/envelope_probe): raise on dispatch failure under strict=True

### DIFF
--- a/core/llm/multi_model/dispatch.py
+++ b/core/llm/multi_model/dispatch.py
@@ -18,6 +18,7 @@ Pipeline:
 """
 
 import logging
+import time
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, Iterable, List, Optional, Sequence
@@ -34,6 +35,8 @@ from core.llm.multi_model.types import (
 )
 
 logger = logging.getLogger(__name__)
+
+_GATE_RETRY_SECONDS = 60.0
 
 
 def run_multi_model(
@@ -124,36 +127,51 @@ def run_multi_model(
             f"{type(correlation).__name__}. Adapter is buggy."
         )
 
-    # Local gate state — never mutate the external cost_gate. If gate
-    # raises, we disable budget checks for the rest of THIS run only.
-    gate_alive = [cost_gate is not None]
+    # Local gate state — never mutate the external cost_gate.
+    # Transient exceptions from budget_ratio() suspend gating for
+    # _GATE_RETRY_SECONDS, then re-probe automatically (circuit-breaker).
+    # Type-contract violations (non-float return) permanently disable
+    # gating for the run — a wrong return type is a code bug, not a
+    # network hiccup, and recovery would not help.
+    _gate_permanent_off = [cost_gate is None]
+    _gate_disabled_at: list = [None]  # None or monotonic timestamp of last transient fail
 
     def over_budget(cutoff_ratio: float) -> tuple[bool, Optional[float]]:
         """Return (skip, current_ratio). ratio is None when gating is off."""
-        if not gate_alive[0]:
+        if _gate_permanent_off[0]:
             return False, None
         if cutoff_ratio >= 1.0:
             return False, None
+        if _gate_disabled_at[0] is not None:
+            elapsed = time.monotonic() - _gate_disabled_at[0]
+            if elapsed < _GATE_RETRY_SECONDS:
+                return False, None
+            _gate_disabled_at[0] = None
+            logger.info(
+                "cost_gate: retrying budget_ratio() after %.0fs transient-failure cooldown",
+                elapsed,
+            )
         try:
             ratio = cost_gate.budget_ratio()  # type: ignore[union-attr]
         except Exception as exc:
             logger.warning(
                 f"cost_gate.budget_ratio() raised {type(exc).__name__}: {exc} — "
-                f"disabling cost gating for the rest of this run",
+                f"suspending cost gating for {_GATE_RETRY_SECONDS:.0f}s",
                 exc_info=True,
             )
-            gate_alive[0] = False
+            _gate_disabled_at[0] = time.monotonic()
             return False, None
         # Defensive: protocol says budget_ratio returns float, but
         # @runtime_checkable doesn't enforce return types. A non-numeric
         # value would crash the comparison below with a confusing error.
+        # Type-contract violation → permanent disable (not transient).
         if isinstance(ratio, bool) or not isinstance(ratio, (int, float)):
             logger.warning(
                 f"cost_gate.budget_ratio() returned {type(ratio).__name__} "
-                f"({ratio!r}), expected float — disabling cost gating "
-                f"for the rest of this run"
+                f"({ratio!r}), expected float — permanently disabling cost "
+                f"gating for the rest of this run"
             )
-            gate_alive[0] = False
+            _gate_permanent_off[0] = True
             return False, None
         return ratio >= cutoff_ratio, ratio
 

--- a/core/llm/tool_use/loop.py
+++ b/core/llm/tool_use/loop.py
@@ -525,7 +525,7 @@ class ToolUseLoop:
                 #   3. Emit ToolCallReturned with the RAW result.
                 #   4. Wrap (or refuse) for the message copy.
                 raw_content = result.content
-                pf = preflight(raw_content)
+                pf = preflight(raw_content, strict=True)
                 if pf.has_injection_indicators:
                     self._emit(ToolResultPreflight(
                         iteration=iteration,

--- a/core/sandbox/_macos_spawn.py
+++ b/core/sandbox/_macos_spawn.py
@@ -165,6 +165,7 @@ def run_sandboxed(cmd: List[str], *,
                   use_egress_proxy: bool = False,
                   proxy_port: Optional[int] = None,
                   fake_home: bool = False,
+                  strict_env: bool = False,
                   ) -> subprocess.CompletedProcess:
     """Run ``cmd`` under macOS sandbox-exec with an SBPL profile
     derived from the logical sandbox kwargs.
@@ -241,6 +242,10 @@ def run_sandboxed(cmd: List[str], *,
     #    so the child sees no dotfiles. Pre-populate the dir empty.
     if env is not None:
         child_env = dict(env)
+        if strict_env:
+            from core.config import RaptorConfig
+            _dangerous = set(RaptorConfig.DANGEROUS_ENV_VARS)
+            child_env = {k: v for k, v in child_env.items() if k not in _dangerous}
     else:
         from core.config import RaptorConfig
         child_env = RaptorConfig.get_safe_env()

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -898,6 +898,7 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
         # blocklist is belt-and-braces on the os.environ →
         # get_safe_env path (see core/config.py); the caller path
         # is "you know what you're doing".
+        strict_env = kwargs.pop("strict_env", False)
         if kwargs.get("env") is None:
             kwargs.pop("env", None)  # drop any explicit None
             kwargs["env"] = RaptorConfig.get_safe_env()
@@ -907,6 +908,16 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                 f"{' '.join(cmd[:_CMD_DISPLAY_MAX_ARGS]) or cmd!r} "
                 f"— get_safe_env() not applied; caller env passed through."
             )
+            if strict_env:
+                _dangerous = set(RaptorConfig.DANGEROUS_ENV_VARS)
+                _stripped = [k for k in kwargs["env"] if k in _dangerous]
+                if _stripped:
+                    kwargs["env"] = {k: v for k, v in kwargs["env"].items()
+                                     if k not in _dangerous}
+                    logger.info(
+                        f"Sandbox: strict_env=True — stripped DANGEROUS_ENV_VARS "
+                        f"from caller env: {sorted(_stripped)}"
+                    )
 
         # Egress-proxy env injection — overlays AFTER get_safe_env() so
         # the proxy vars aren't stripped by the PROXY_ENV_VARS blocklist
@@ -1385,6 +1396,7 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                     fake_home=fake_home,
                     map_root=map_root,
                     start_new_session=kwargs.get("start_new_session", True),
+                    strict_env=strict_env,
                 )
                 used_spawn = True
             elif spawn_eligible:
@@ -2154,6 +2166,7 @@ def run_untrusted(cmd: List[str], *, target: str = None, output: str = None,
                restrict_reads=restrict_reads,
                readable_paths=readable_paths,
                fake_home=fake_home,
+               strict_env=True,
                **kwargs)
 
 

--- a/core/sandbox/proxy.py
+++ b/core/sandbox/proxy.py
@@ -366,7 +366,8 @@ class EgressProxy:
                  buffer_size: int = _DEFAULT_BUFFER_SIZE,
                  upstream_proxy: Optional[str] = None,
                  no_proxy: Optional[str] = None,
-                 audit_log_only: bool = False):
+                 audit_log_only: bool = False,
+                 audit_enforce: bool = False):
         self._hosts_lock = threading.Lock()
         self._allowed_hosts: Set[str] = {h.lower() for h in allowed_hosts}
         # When True, gate 1 (hostname allowlist) emits a `would_deny_host`
@@ -387,6 +388,14 @@ class EgressProxy:
         # counting; concurrent mixed-profile sandbox correctness depends
         # on it.
         self._audit_log_only = audit_log_only
+        # When True, gate 1 in audit mode switches from log-and-allow to
+        # log-and-deny — the allowlist is enforced even in audit mode.
+        # Default False preserves the documented audit-permissive semantics
+        # (gate 1 audit mode is for diagnosis while building an allowlist;
+        # once the allowlist is mature, operators can set audit_enforce=True
+        # or RAPTOR_PROXY_AUDIT_ENFORCE=1 to harden gate 1). Gate 2 is
+        # always enforcing regardless of this flag.
+        self._audit_enforce = audit_enforce
         # Ref-count for concurrent acquire/release. Each audit-mode
         # sandbox via use_egress_proxy=True acquires on entry, releases
         # on exit. Gate 1 is in audit-log mode iff count > 0. Without
@@ -1050,25 +1059,29 @@ class EgressProxy:
             # consistent with the count value at the snapshot moment.
             with self._audit_lock:
                 _audit_now = self._audit_log_only
+                _enforce_now = self._audit_enforce
             if _audit_now:
-                # Audit mode: record the would-deny but proceed with the
-                # CONNECT. Use a distinct event result so consumers can
-                # tell audit-would-deny apart from real-deny in the same
-                # proxy-events.jsonl. The audit event captures intent;
-                # the later "allowed" event captures the actual outcome
-                # (so a single CONNECT in audit mode produces TWO event
-                # records — one would-deny, one allowed).
+                # Audit mode: record the would-deny event. When
+                # audit_enforce=False (default), fall through to allow —
+                # the allowlist is advisory while operators build it.
+                # When audit_enforce=True (RAPTOR_PROXY_AUDIT_ENFORCE=1),
+                # deny even in audit mode: log-AND-deny semantics.
+                _action = "denying" if _enforce_now else "allowing"
                 logger.warning(
                     f"egress proxy: AUDIT would-deny {host}:{port} — "
-                    f"not in allowlist (audit mode: allowing)"
+                    f"not in allowlist (audit mode: {_action})"
                 )
                 audit_event = {**event, "result": "would_deny_host",
                                "reason": "host not in allowlist (audit mode)",
-                               "duration": time.monotonic() - t_start}
+                               "duration": time.monotonic() - t_start,
+                               "audit_enforce": _enforce_now}
                 self._record(audit_event)
                 _record_proxy_denial(host, port, None,
                                      "host_not_in_allowlist")
-                # Fall through to the connect path.
+                if _enforce_now:
+                    await self._write_error(writer, 403, "Forbidden")
+                    return
+                # Fall through to the connect path (audit_enforce=False).
             else:
                 logger.warning(
                     f"egress proxy: DENY {host}:{port} — not in allowlist"
@@ -1415,9 +1428,13 @@ def get_proxy(allowed_hosts: Iterable[str]) -> EgressProxy:
                         or _os.environ.get("https_proxy"))
             no_proxy = (_os.environ.get("NO_PROXY")
                         or _os.environ.get("no_proxy"))
+            audit_enforce = bool(
+                _os.environ.get("RAPTOR_PROXY_AUDIT_ENFORCE", "")
+            )
             _instance = EgressProxy(allowed_hosts,
                                     upstream_proxy=upstream,
-                                    no_proxy=no_proxy)
+                                    no_proxy=no_proxy,
+                                    audit_enforce=audit_enforce)
             atexit.register(_instance.stop)
             if upstream:
                 logger.info(

--- a/core/security/envelope_probe.py
+++ b/core/security/envelope_probe.py
@@ -207,6 +207,19 @@ def probe_envelope_compatibility(
         else:
             raw = str(result)
     except Exception as e:
+        # F058 strict-contract gap: under strict=True the caller's
+        # contract is "envelope-probe failure raises so silent fallback
+        # cannot happen." The post-evaluate path (below) already raises
+        # when probe_result.compatible is False; the dispatch-failure
+        # path used to early-return a compatible=False ProbeResult,
+        # leaving strict=True callers with the SAME failed-but-non-
+        # raising outcome they were trying to opt out of. Honour the
+        # contract uniformly here.
+        if strict:
+            raise RuntimeError(
+                f"Envelope probe dispatch failed for {model_name} "
+                f"(profile: {profile.name}): {e}"
+            ) from e
         return ProbeResult(
             compatible=False,
             valid_json=False,

--- a/core/security/envelope_probe.py
+++ b/core/security/envelope_probe.py
@@ -168,6 +168,8 @@ def probe_envelope_compatibility(
     analysis_model: Any,
     profile: ModelDefenseProfile,
     dispatch_fn,
+    *,
+    strict: bool = False,
 ) -> ProbeResult:
     """Send a canary probe through the dispatch path.
 
@@ -187,6 +189,10 @@ def probe_envelope_compatibility(
 
     Returns a ProbeResult with .compatible indicating whether the model
     handled the envelope correctly.
+
+    When ``strict=True``, an incompatible probe result raises
+    ``RuntimeError`` instead of returning the failed ProbeResult, so
+    callers that do not check ``.compatible`` cannot silently continue.
     """
     system, user, nonce = build_canary_prompt(profile)
     model_name = getattr(analysis_model, "model_name", None) or str(analysis_model)
@@ -226,5 +232,10 @@ def probe_envelope_compatibility(
             "applies.",
             model_name, profile.name, probe_result.error,
         )
+        if strict:
+            raise RuntimeError(
+                f"Envelope probe failed for {model_name} (profile: {profile.name}): "
+                f"{probe_result.error}"
+            )
 
     return probe_result

--- a/core/security/prompt_input_preflight.py
+++ b/core/security/prompt_input_preflight.py
@@ -121,6 +121,7 @@ def preflight(
     content: str,
     *,
     corpora: tuple[str, ...] | None = None,
+    strict: bool = False,
 ) -> PreflightResult:
     """Scan content for known injection-pattern indicators.
 
@@ -140,7 +141,20 @@ def preflight(
     iterated over zero patterns and returned the no-hit haircut — a
     fail-open misconfiguration the operator wouldn't see in normal logs.
     Failing fast surfaces the typo at the call site instead.
+
+    When ``strict=True``, raises ``RuntimeError`` if ``_PATTERNS`` is empty
+    (corpus directory missing or all files rejected at load time). Default
+    ``strict=False`` preserves the documented fail-open policy — an empty
+    corpus returns ``confidence_haircut=1.0`` rather than zeroing all
+    downstream confidence scores.
     """
+    if strict and not _PATTERNS:
+        raise RuntimeError(
+            f"preflight: strict=True but no corpora loaded from "
+            f"{_PATTERNS_DIR!r}; a missing or empty corpus directory "
+            f"would silently return confidence_haircut=1.0 (fail-open). "
+            f"Fix the corpus path or pass strict=False to allow fail-open."
+        )
     if corpora is not None:
         loaded = set(_PATTERNS)
         unknown = [c for c in corpora if c not in loaded]

--- a/core/security/tests/test_envelope_probe.py
+++ b/core/security/tests/test_envelope_probe.py
@@ -222,6 +222,45 @@ class TestProbeEnvelopeCompatibility:
         assert not result.compatible
         assert "timed out" in result.error
 
+    def test_strict_true_raises_on_dispatch_failure(self):
+        """F058 strict-contract gap (W36.J.2):
+
+        Under strict=True the existing post-evaluate path already
+        raised RuntimeError when probe_result.compatible was False.
+        But the dispatch-exception path used to early-return a
+        compatible=False ProbeResult, so a strict=True caller that
+        had registered the dispatch exception would NOT see the
+        documented "strict raises on failure" contract — exactly
+        the silent-fallback the kwarg was added to prevent.
+
+        After the fix, the dispatch-exception path raises uniformly
+        under strict=True. The original exception is chained via
+        `raise ... from e` so callers can introspect the root cause.
+        """
+        import pytest
+
+        dispatch = _make_dispatch_fn(
+            raise_error=RuntimeError("connection refused"),
+        )
+        with pytest.raises(RuntimeError, match="dispatch failed"):
+            probe_envelope_compatibility(
+                "phi-3", CONSERVATIVE, dispatch, strict=True,
+            )
+
+    def test_strict_false_default_still_returns_failed_result(self):
+        """Backward-compat: with strict=False (the default),
+        dispatch failures still return a failed ProbeResult so
+        existing callers (orchestrator.py:558 + any future caller
+        that opts out of strict) keep their current behaviour."""
+        dispatch = _make_dispatch_fn(
+            raise_error=RuntimeError("connection refused"),
+        )
+        result = probe_envelope_compatibility(
+            "phi-3", CONSERVATIVE, dispatch,
+        )
+        assert not result.compatible
+        assert "connection refused" in result.error
+
     def test_passes_analysis_model_object_to_dispatch_fn(self):
         """The probe must forward its ``analysis_model`` argument
         unchanged to dispatch_fn. Production dispatch_fn (in

--- a/packages/llm_analysis/dispatch.py
+++ b/packages/llm_analysis/dispatch.py
@@ -354,7 +354,7 @@ def dispatch_task(
                     iid = task.get_item_id(it)
                     with _nonces_lock:
                         _nonces[(iid, _model_key(m))] = nonce
-                pf = preflight(prompt, corpora=_DISPATCH_CORPORA)
+                pf = preflight(prompt, corpora=_DISPATCH_CORPORA, strict=True)
                 defense_telemetry.record_preflight(hit=pf.has_injection_indicators)
                 schema = task.get_schema(it)
                 return dispatch_fn(prompt, schema, system_prompt, task.temperature, m)

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -555,9 +555,15 @@ def orchestrate(
         for _probe_model in _models_to_probe:
             _pname = _probe_model.model_name if hasattr(_probe_model, "model_name") else str(_probe_model)
             _pprofile = get_profile_for(_pname)
-            probe_result = probe_envelope_compatibility(
-                _probe_model, _pprofile, dispatch_fn,
-            )
+            try:
+                probe_result = probe_envelope_compatibility(
+                    _probe_model, _pprofile, dispatch_fn, strict=True,
+                )
+            except RuntimeError as _probe_err:
+                defense_telemetry.set_probe_result(_pname, False)
+                _probe_failed = True
+                _failed_probe_models.append((_pname, str(_probe_err)))
+                continue
             defense_telemetry.set_probe_result(_pname, probe_result.compatible)
             if not probe_result.compatible:
                 _probe_failed = True


### PR DESCRIPTION
## Summary

**STACKED** on `bug-fixes-W36-B-strict-mode` (PR #499). When B merges, this PR's base auto-rebases to main.

F058 strict-contract gap closure. The `strict=True` kwarg landed in W36.B with the documented contract "callers that do not check `.compatible` cannot silently continue." But the implementation only honored that contract on ONE failure path — the post-evaluate branch at line ~234 that raises `RuntimeError` when `probe_result.compatible` is False.

The OTHER failure path — the `except Exception` clause at lines 209-216 catching exceptions from `dispatch_fn()` — early-returned a `compatible=False` `ProbeResult` unconditionally, regardless of `strict`. A `strict=True` caller registering the dispatch exception would see the SAME failed-but-non-raising outcome the kwarg was added to prevent.

Adds `if strict: raise RuntimeError(...) from e` at the head of the except clause, before the early return. Chains the original exception so callers introspecting the cause see the underlying TimeoutError / connection-refused / etc. Backward compat preserved with `strict=False`.

## Test plan

- 2 new tests: `test_strict_true_raises_on_dispatch_failure` + `test_strict_false_default_still_returns_failed_result`
- Envelope-probe suite: 27 → 29 passed

## Verdict

DEFECT (documented contract not honored uniformly). Bounded impact — sole production caller (`orchestrator.py:558`) handles both modes correctly. Value is closing the contract for future strict-mode callers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes failure semantics in a security probe so `strict=True` now raises on dispatch exceptions; any strict-mode callers relying on non-raising ProbeResults could now error out. Default (`strict=False`) behavior is preserved and covered by new tests.
> 
> **Overview**
> Closes a strict-mode contract gap in `probe_envelope_compatibility`: when `dispatch_fn` raises, `strict=True` now *also* raises a `RuntimeError` (chaining the original exception) instead of returning an incompatible `ProbeResult`.
> 
> Adds tests to ensure dispatch failures raise under `strict=True` while the default `strict=False` continues to return a failed `ProbeResult` for backward compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ead5452f6fc7118ea9c75563c32e7cc9f5a23b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->