### PR TITLE
refactor(core/project/schema): demote validate_project + validate_run_metadata to private (0 prod callers)

### DIFF
--- a/core/project/schema.py
+++ b/core/project/schema.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Tuple
 VALID_RUN_STATUSES = {"running", "completed", "failed", "cancelled"}
 
 
-def validate_project(data: Dict[str, Any]) -> Tuple[bool, List[str]]:
+def _validate_project(data: Dict[str, Any]) -> Tuple[bool, List[str]]:
     """Validate a project.json dict. Returns (valid, errors)."""
     errors = []
 
@@ -47,7 +47,7 @@ def validate_project(data: Dict[str, Any]) -> Tuple[bool, List[str]]:
     return len(errors) == 0, errors
 
 
-def validate_run_metadata(data: Dict[str, Any]) -> Tuple[bool, List[str]]:
+def _validate_run_metadata(data: Dict[str, Any]) -> Tuple[bool, List[str]]:
     """Validate a .raptor-run.json dict. Returns (valid, errors)."""
     errors = []
 

--- a/core/project/tests/test_schema.py
+++ b/core/project/tests/test_schema.py
@@ -2,7 +2,11 @@
 
 import unittest
 
-from core.project.schema import validate_project, validate_run_metadata, VALID_RUN_STATUSES
+from core.project.schema import (
+    _validate_project as validate_project,
+    _validate_run_metadata as validate_run_metadata,
+    VALID_RUN_STATUSES,
+)
 
 
 class TestValidateProject(unittest.TestCase):


### PR DESCRIPTION
## Summary

`core/project/schema.py` exported `validate_project` and `validate_run_metadata` as public functions (no leading underscore), but neither has any production callers — both are only referenced from the sibling test file `core/project/tests/test_schema.py`. The public spelling implied a stable cross-module API that does not exist.

This PR renames them to `_validate_project` and `_validate_run_metadata` so the spelling matches actual usage. The test file imports them under the original names via `_validate_project as validate_project` so test bodies stay unchanged.

**Behavioral change**: none. This is visibility/naming hygiene only.

## Classification

- **Class**: HYGIENE (Conventional Commits `refactor:`)
- Not a defect, not a smell, not a security issue. Initially mis-classified locally as `fix:` (K-class semantic drift per work-audit); subject prefix amended to `refactor:` before push.

## Test plan

- [ ] CI green on `core/project/tests/test_schema.py`
- [ ] Confirm zero production callers (already verified locally via grep over `core/` and `packages/`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk rename-only change that demotes `validate_project`/`validate_run_metadata` to private helpers; main risk is breaking any external callers that weren’t caught by tests/grep.
> 
> **Overview**
> **Demotes schema validation APIs to private helpers.** `core/project/schema.py` renames `validate_project` and `validate_run_metadata` to `_validate_project` and `_validate_run_metadata` to reflect non-public usage.
> 
> Tests are updated to import the new private names while aliasing them back to the old local identifiers, keeping test code and behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36efd24066b59de18d7a24169e048f90392211d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->