### PR TITLE
refactor(core/inventory): demote get_items to _get_items (0 prod callers, semantic-collision pair with W14-deep1c)

### DIFF
--- a/core/inventory/__init__.py
+++ b/core/inventory/__init__.py
@@ -5,7 +5,7 @@ globals, macros, classes), SHA-256 checksumming, SLOC counting, and
 cumulative coverage tracking.
 
 Usage:
-    from core.inventory import build_inventory, get_coverage_stats, get_items
+    from core.inventory import build_inventory, get_coverage_stats
 
     inventory = build_inventory("/path/to/repo", "/path/to/output")
     stats = get_coverage_stats(inventory)
@@ -46,7 +46,7 @@ from .diff import compare_inventories
 from .coverage import update_coverage, get_coverage_stats, format_coverage_summary
 
 
-def get_items(file_entry):
+def _get_items(file_entry):
     """Read code items from a file entry. Handles both old and new format.
 
     Old format: file_entry["functions"] (list of function dicts)

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -22,7 +22,7 @@ from core.inventory import (
     extract_functions,
     extract_items,
     count_sloc,
-    get_items,
+    _get_items as get_items,
     should_exclude,
     is_binary_file,
     is_generated_file,


### PR DESCRIPTION
## Summary

`core/inventory.__init__` exported `get_items()` as part of its documented public API (module docstring "Usage" example included it alongside `build_inventory` and `get_coverage_stats`), but the function has zero production callers across `core/` and `packages/`. The only callers are in `core/inventory/tests/test_inventory.py`.

This PR renames `core.inventory.get_items` → `core.inventory._get_items` so the spelling matches actual usage, and removes `get_items` from the module docstring's public-API example. The test file imports it under the original name via `_get_items as get_items` so test bodies are unchanged.

**Note on the two unrelated `_get_items` symbols**: `core/inventory/coverage.py` and `core/inventory/builder.py` each define a local `_get_items` that reads `file_info` dicts. Those are unrelated to this public-API `get_items` (which takes `file_entry` dicts). No name collision in scope.

**Behavioral change**: none. Visibility/naming hygiene only.

## Classification

- **Class**: HYGIENE (Conventional Commits `refactor:`)
- Not a defect, not a smell, not a security issue. Initially mis-classified locally as `fix:` (K-class semantic drift); subject prefix amended to `refactor:` before push.

## Test plan

- [ ] CI green on `core/inventory/tests/test_inventory.py`
- [ ] Confirm zero production callers (verified locally via grep)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only renames/hides a helper and updates imports/documentation; runtime behavior is unchanged. Main risk is breaking external consumers that imported `get_items` directly (though no in-repo prod callers were found).
> 
> **Overview**
> Removes `get_items` from the documented/public `core.inventory` API by renaming it to `_get_items` and updating the module docstring usage example accordingly.
> 
> Updates the test suite to import `_get_items` under the old name (`_get_items as get_items`) so existing test bodies remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eee705b9658e33637b281bc1c5958baae173c654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->