### PR TITLE
chore(lint): declare re-exports via __all__ in 5 package hubs (DEEP-1c)

### DIFF
--- a/.claude/skills/oss-forensics/github-evidence-kit/src/collectors/archive.py
+++ b/.claude/skills/oss-forensics/github-evidence-kit/src/collectors/archive.py
@@ -4,7 +4,6 @@ GH Archive Collector.
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
 
 from ..clients.gharchive import GHArchiveClient
 from ..schema.common import EvidenceSource, VerificationInfo

--- a/.claude/skills/oss-forensics/github-evidence-kit/src/schema/common.py
+++ b/.claude/skills/oss-forensics/github-evidence-kit/src/schema/common.py
@@ -3,9 +3,7 @@ Common schema definitions for GitHub Evidence Kit.
 """
 from __future__ import annotations
 
-from datetime import datetime
 from enum import Enum
-from typing import Literal
 
 from pydantic import BaseModel, HttpUrl, model_validator
 

--- a/.claude/skills/oss-forensics/github-evidence-kit/src/schema/events.py
+++ b/.claude/skills/oss-forensics/github-evidence-kit/src/schema/events.py
@@ -9,7 +9,6 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 from .common import (
-    EvidenceSource,
     GitHubActor,
     GitHubRepository,
     IssueAction,

--- a/.claude/skills/oss-forensics/github-evidence-kit/tests/test_collectors_local.py
+++ b/.claude/skills/oss-forensics/github-evidence-kit/tests/test_collectors_local.py
@@ -1,7 +1,7 @@
 """
 Tests for LocalGitCollector.
 """
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 

--- a/.claude/skills/oss-forensics/github-evidence-kit/tests/test_integration.py
+++ b/.claude/skills/oss-forensics/github-evidence-kit/tests/test_integration.py
@@ -39,7 +39,7 @@ sys.path.insert(0, str(Path(__file__).parents[1]))
 from src.collectors.api import GitHubAPICollector
 from src.collectors.archive import GHArchiveCollector
 from src.collectors.local import LocalGitCollector
-from src.schema.common import EvidenceSource, IOCType
+from src.schema.common import EvidenceSource
 
 
 # Mark all tests in this module as integration tests

--- a/.devcontainer/test_devcontainer.py
+++ b/.devcontainer/test_devcontainer.py
@@ -100,7 +100,7 @@ def check_binary(name: str, version_flag: str = "--version") -> Tuple[bool, str,
         return True, f"Found at {path}", version
     except subprocess.TimeoutExpired:
         return True, f"Found at {path} (version check timed out)", None
-    except Exception as e:
+    except Exception:
         return True, f"Found at {path}", None
 
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -93,15 +93,22 @@ jobs:
           source $VENV_PATH/bin/activate
           uv pip install "$(grep -E '^ruff==' requirements-dev.txt)"
 
-      - name: Run ruff (F401, F811)
+      - name: Run ruff (F401, F811, F821, F841)
         run: |
           source $VENV_PATH/bin/activate
-          # Conservative starting rule set: unused-import + redefined-
-          # while-unused only. F821 + F841 manual fixes land in a
-          # follow-up PR (DEEP-1b); __init__.py __all__ declarations
-          # land in another follow-up (DEEP-1c). E501 (3,204 default-88
-          # violations) deferred until a separate evaluation of line-
-          # length policy. See notes/_judge/W14-E1-lint-ci-gate-design.md.
-          ruff check --select F401,F811 \
+          # Name-correctness rule set: F401 (unused-import),
+          # F811 (redefined-while-unused), F821 (undefined-name),
+          # F841 (unused-variable). E501 (3,204 default-88 violations)
+          # deferred until a separate evaluation of line-length policy.
+          # See notes/_judge/W14-E1-lint-ci-gate-design.md.
+          #
+          # NOTE: this branch's lint.yml SELECTS F401/F811/F821/F841 but
+          # F401 still has ~535 violations on this branch (the autofix
+          # lives on bug-fixes-W14-deep1a). This branch closes the 74
+          # F401 sites in the 5 `__init__.py` re-export hubs via
+          # explicit `__all__` declarations; the remaining ~535 are
+          # DEEP-1a's autofix territory. Once DEEP-1a + DEEP-1b merge,
+          # F401 will be 0 and this gate passes end-to-end.
+          ruff check --select F401,F811,F821,F841 \
             --output-format=github \
             .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,107 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  merge_group:
+  schedule:
+    # Daily catches lint regressions sneaked in via cherry-picks or
+    # ruff-version drifts that path-filtered PRs would miss.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: '3.12'
+  VENV_PATH: .venv
+
+permissions:
+  contents: read
+  # Needed by the pre_check job to query prior workflow runs at the
+  # current SHA via ``gh api repos/.../actions/runs``.
+  actions: read
+
+jobs:
+  # Same dedup pattern as tests.yml — skip a duplicate run of the same
+  # SHA. Inlined rather than refactored into a reusable composite so
+  # each workflow stays self-contained (raptor convention).
+  pre_check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      should_skip: ${{ steps.dup.outputs.should_skip }}
+    steps:
+      - id: dup
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          WORKFLOW: ${{ github.workflow }}
+          SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          should_skip=false
+          # Never dedup forced-full events: the operator triggered them
+          # deliberately (cron, manual dispatch) or the merge queue needs
+          # an authoritative pass.
+          if [[ "$EVENT" != "schedule" && "$EVENT" != "workflow_dispatch" \
+             && "$EVENT" != "merge_group" ]]; then
+            dup=$(gh api -X GET "repos/${REPO}/actions/runs" \
+                    -f "head_sha=${SHA}" -f "status=success" \
+                    --jq ".workflow_runs[] | select(.name==\"${WORKFLOW}\" and .id != ${RUN_ID}) | .id" \
+                  | head -n1 || true)
+            if [[ -n "${dup:-}" ]]; then
+              should_skip=true
+              echo "Skipping: prior successful run ${dup} already covered SHA ${SHA}"
+            fi
+          fi
+          echo "should_skip=${should_skip}" >> "$GITHUB_OUTPUT"
+
+  ruff:
+    needs: pre_check
+    if: needs.pre_check.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # was v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: "requirements*.txt"
+
+      - name: Install ruff
+        run: |
+          # Install only ruff (not full requirements-dev.txt) to keep
+          # this job fast and to avoid pulling pytest et al. just to
+          # lint. ruff is pinned to 0.15.12 in requirements-dev.txt —
+          # grep + uv pip install keeps a single source of truth.
+          uv venv $VENV_PATH
+          source $VENV_PATH/bin/activate
+          uv pip install "$(grep -E '^ruff==' requirements-dev.txt)"
+
+      - name: Run ruff (F401, F811)
+        run: |
+          source $VENV_PATH/bin/activate
+          # Conservative starting rule set: unused-import + redefined-
+          # while-unused only. F821 + F841 manual fixes land in a
+          # follow-up PR (DEEP-1b); __init__.py __all__ declarations
+          # land in another follow-up (DEEP-1c). E501 (3,204 default-88
+          # violations) deferred until a separate evaluation of line-
+          # length policy. See notes/_judge/W14-E1-lint-ci-gate-design.md.
+          ruff check --select F401,F811 \
+            --output-format=github \
+            .

--- a/core/annotations/tests/test_cli.py
+++ b/core/annotations/tests/test_cli.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/core/annotations/tests/test_locking.py
+++ b/core/annotations/tests/test_locking.py
@@ -11,7 +11,6 @@ process-level, and POSIX semantics are what we actually rely on.
 from __future__ import annotations
 
 import multiprocessing as mp
-import os
 import sys
 from pathlib import Path
 

--- a/core/annotations/tests/test_overwrite_modes.py
+++ b/core/annotations/tests/test_overwrite_modes.py
@@ -15,7 +15,6 @@ Plus the per-function source-line hash used by ``/annotate stale``:
 
 from __future__ import annotations
 
-from pathlib import Path
 
 import pytest
 

--- a/core/annotations/tests/test_storage.py
+++ b/core/annotations/tests/test_storage.py
@@ -14,7 +14,6 @@ Covers:
 
 from __future__ import annotations
 
-from pathlib import Path
 
 import pytest
 

--- a/core/annotations/tests/test_versioning.py
+++ b/core/annotations/tests/test_versioning.py
@@ -9,14 +9,11 @@ without updating the reader.
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 
-import pytest
 
 from core.annotations import (
     Annotation,
     annotation_path,
-    read_annotation,
     read_file_annotations,
     write_annotation,
 )

--- a/core/build/tests/test_toolchain.py
+++ b/core/build/tests/test_toolchain.py
@@ -8,7 +8,6 @@ installed.
 
 from __future__ import annotations
 
-import os
 import subprocess
 import unittest
 from unittest.mock import patch

--- a/core/build/toolchain.py
+++ b/core/build/toolchain.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 import logging
 import os
 import shutil
-from pathlib import Path
 from typing import Callable, Dict, Iterable, Optional
 
 logger = logging.getLogger(__name__)

--- a/core/config/tests/test_config.py
+++ b/core/config/tests/test_config.py
@@ -2,7 +2,6 @@
 
 import os
 import pytest
-from pathlib import Path
 from unittest.mock import patch
 
 # Pre-fix this file did:

--- a/core/coverage/record.py
+++ b/core/coverage/record.py
@@ -5,7 +5,6 @@ Built from the reads manifest (populated by the PostToolUse hook),
 Semgrep JSON output, CodeQL SARIF, and findings.json.
 """
 
-import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional

--- a/core/coverage/summary.py
+++ b/core/coverage/summary.py
@@ -5,7 +5,7 @@ coverage-*.json records. Supports single-run and project-wide aggregation.
 """
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from core.json import load_json
 from .record import load_records, write_record

--- a/core/coverage/summary.py
+++ b/core/coverage/summary.py
@@ -377,7 +377,6 @@ def format_detailed(summary: Dict[str, Any]) -> str:
         scanned_flags = []
         for abbrev, tool_name in tool_abbrevs:
             tool_key = tool_name.lower()
-            tool_info = tools.get(tool_key, {})
             # Check if this file was in the tool's examined list
             if pf.get(f"scanned_{tool_key}", False):
                 scanned_flags.append(abbrev)

--- a/core/coverage/tests/test_annotation_record.py
+++ b/core/coverage/tests/test_annotation_record.py
@@ -7,9 +7,7 @@ functions count as "examined" for coverage purposes.
 
 from __future__ import annotations
 
-from pathlib import Path
 
-import pytest
 
 from core.annotations import Annotation, write_annotation
 from core.coverage.record import build_from_annotations, load_records

--- a/core/coverage/tests/test_record.py
+++ b/core/coverage/tests/test_record.py
@@ -17,7 +17,6 @@ from core.coverage.record import (
     load_records,
     cleanup_manifest,
     READS_MANIFEST,
-    COVERAGE_RECORD_FILE,
 )
 from core.coverage.track_read import main as track_read_main
 

--- a/core/cve/kev.py
+++ b/core/cve/kev.py
@@ -20,7 +20,7 @@ KEV-listed flag on any CVE-tagged finding.
 from __future__ import annotations
 
 import logging
-from typing import Optional, Set
+from typing import Set
 
 from core.json import JsonCache
 from core.http import HttpClient, HttpError

--- a/core/cve/tests/test_epss.py
+++ b/core/cve/tests/test_epss.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
-import pytest
 
 from core.cve.epss import EPSS_URL, EpssClient
 from core.http import HttpError

--- a/core/cve/tests/test_kev.py
+++ b/core/cve/tests/test_kev.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
-import pytest
 
 from core.cve.kev import KEV_URL, KevClient
 from core.http import HttpError

--- a/core/dataflow/evidence_collector.py
+++ b/core/dataflow/evidence_collector.py
@@ -22,7 +22,7 @@ design is documented at ``~/design/dataflow-sanitizer-bypass.md``.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, Iterator, List, Optional, Tuple
+from typing import Dict, Iterator, Optional, Tuple
 
 from core.dataflow.finding import Finding
 from core.dataflow.llm_extractor import ExtractorFn, extract_from_files

--- a/core/dataflow/finding_diff.py
+++ b/core/dataflow/finding_diff.py
@@ -19,7 +19,7 @@ This module does NOT run CodeQL. PR2b-2 wires the subprocess.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Set, Tuple
 

--- a/core/dataflow/handlabel_seed.py
+++ b/core/dataflow/handlabel_seed.py
@@ -33,7 +33,6 @@ from core.dataflow.finding import Finding, Step
 from core.dataflow.label import (
     FP_DEAD_CODE,
     FP_FRAMEWORK_MITIGATION,
-    FP_MISSING_SANITIZER_MODEL,
     FP_TYPE_CONSTRAINT,
     GroundTruth,
     VERDICT_FALSE_POSITIVE,

--- a/core/dataflow/llm_extractor.py
+++ b/core/dataflow/llm_extractor.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
-from typing import Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 from core.dataflow.sanitizer_evidence import (
     PROVENANCE_LLM,

--- a/core/dataflow/owasp_corpus_generator.py
+++ b/core/dataflow/owasp_corpus_generator.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple
 
 from core.dataflow.adapters.codeql import from_sarif_result
-from core.dataflow.finding import Finding
+from core.dataflow.finding import Finding, Step
 from core.dataflow.label import (
     FP_MISSING_SANITIZER_MODEL,
     GroundTruth,

--- a/core/dataflow/sanitizer_evidence.py
+++ b/core/dataflow/sanitizer_evidence.py
@@ -37,8 +37,8 @@ required strings, ``confidence`` in ``[0, 1]``, ``source_line >= 1``,
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
-from typing import Any, Dict, FrozenSet, Iterable, List, Mapping, Optional, Tuple
+from dataclasses import dataclass
+from typing import Any, Dict, FrozenSet, Mapping, Tuple
 
 
 SCHEMA_VERSION = 1

--- a/core/dataflow/tests/test_adapters_codeql.py
+++ b/core/dataflow/tests/test_adapters_codeql.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List
 
 import pytest
 
-from core.dataflow import Finding, Step
+from core.dataflow import Step
 from core.dataflow.adapters.codeql import (
     PRODUCER,
     from_dataflow_path,

--- a/core/dataflow/tests/test_codeql_augmented_run.py
+++ b/core/dataflow/tests/test_codeql_augmented_run.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, List
+from typing import List
 
 import pytest
 

--- a/core/dataflow/tests/test_evidence_collector.py
+++ b/core/dataflow/tests/test_evidence_collector.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 from typing import List, Optional
 
-import pytest
 
 from core.dataflow import Finding, Step
 from core.dataflow.evidence_collector import (

--- a/core/dataflow/tests/test_evidence_renderer.py
+++ b/core/dataflow/tests/test_evidence_renderer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 from core.dataflow.evidence_renderer import render_evidence_for_prompt
 from core.dataflow.sanitizer_evidence import (

--- a/core/dataflow/tests/test_llm_bridge.py
+++ b/core/dataflow/tests/test_llm_bridge.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import json
-import pytest
 
 from core.dataflow.llm_bridge import (
     make_evidence_collector,

--- a/core/dataflow/tests/test_llm_extractor.py
+++ b/core/dataflow/tests/test_llm_extractor.py
@@ -20,7 +20,6 @@ from core.dataflow.sanitizer_evidence import (
     SCHEMA_VERSION,
     SEMANTICS_OTHER,
     SEMANTICS_SQL_ESCAPE,
-    CandidateValidator,
 )
 from core.security.prompt_envelope import PromptBundle
 

--- a/core/dataflow/tests/test_owasp_corpus_generator.py
+++ b/core/dataflow/tests/test_owasp_corpus_generator.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 
 from core.dataflow import (
     FP_MISSING_SANITIZER_MODEL,

--- a/core/dataflow/tests/test_path_annotator.py
+++ b/core/dataflow/tests/test_path_annotator.py
@@ -10,7 +10,6 @@ from core.dataflow.sanitizer_evidence import (
     PROVENANCE_LLM,
     SEMANTICS_AUTH_CHECK,
     SEMANTICS_SQL_ESCAPE,
-    SEMANTICS_URL_ALLOWLIST,
     CandidateValidator,
 )
 

--- a/core/dataflow/tests/test_sanitizer_evidence.py
+++ b/core/dataflow/tests/test_sanitizer_evidence.py
@@ -9,7 +9,6 @@ from core.dataflow.sanitizer_evidence import (
     PROVENANCE_LLM,
     SCHEMA_VERSION,
     SEMANTICS_AUTH_CHECK,
-    SEMANTICS_OTHER,
     SEMANTICS_SQL_ESCAPE,
     SEMANTICS_URL_ALLOWLIST,
     CandidateValidator,

--- a/core/dockerfile/tests/test_parser.py
+++ b/core/dockerfile/tests/test_parser.py
@@ -8,7 +8,6 @@ comments, unknown directives) plus a few real-world fixtures."""
 from __future__ import annotations
 
 from core.dockerfile.parser import (
-    Instruction,
     parse_dockerfile,
 )
 

--- a/core/git/clone.py
+++ b/core/git/clone.py
@@ -89,7 +89,7 @@ from ._proxy_hosts import proxy_hosts_for_git as _proxy_hosts_for_git
 # tuple (no operator override applied) so existing semantics hold;
 # new call sites should use ``_proxy_hosts_for_git()`` to pick up the
 # operator override config.
-from ._proxy_hosts import _DEFAULT_GIT_HOSTS as _PROXY_HOSTS
+from ._proxy_hosts import _DEFAULT_GIT_HOSTS as _PROXY_HOSTS  # noqa: F401
 
 
 def get_safe_git_env() -> Dict[str, str]:

--- a/core/git/tests/test_proxy_hosts.py
+++ b/core/git/tests/test_proxy_hosts.py
@@ -8,7 +8,6 @@ not binary-scoped).
 from __future__ import annotations
 
 import json
-from unittest import mock
 
 import pytest
 

--- a/core/hash/tests/test_hash.py
+++ b/core/hash/tests/test_hash.py
@@ -94,7 +94,6 @@ class TestSha256Tree:
         (tmp_path / "file2.txt").write_text("content2")
 
         hash_no_limit = sha256_tree(tmp_path, max_file_size=10**12)  # Effectively no limit
-        hash_with_limit = sha256_tree(tmp_path, max_file_size=100)
 
         # With no limit, all files included; with limit, might skip
         # Just verify no_limit produces a hash

--- a/core/hash/tests/test_hash.py
+++ b/core/hash/tests/test_hash.py
@@ -5,7 +5,6 @@ import os
 import platform
 import pytest
 import sys
-import tempfile
 from pathlib import Path
 
 # core/hash/tests/test_hash.py -> repo root

--- a/core/inventory/__init__.py
+++ b/core/inventory/__init__.py
@@ -45,6 +45,62 @@ from .lookup import lookup_function, normalise_path
 from .diff import compare_inventories
 from .coverage import update_coverage, get_coverage_stats, format_coverage_summary
 
+# Public re-export surface. Each name below is imported above purely
+# to make `from core.inventory import X` work for downstream callers
+# (build_inventory.py, packages/exploitability_validation, the
+# validation tests). Without `__all__`, ruff F401 flags them all as
+# "unused import"; with it, ruff recognises the re-export intent and
+# `from core.inventory import *` exposes exactly this list.
+# Order follows the import statements above (grouped by submodule)
+# rather than strict alphabetical, to keep the audit trail between
+# import-site and re-export-list trivial. `save_checklist` /
+# `get_items` are module-level functions defined below — included
+# here because they're part of the public surface too.
+__all__ = [
+    # .builder
+    "build_inventory",
+    # .languages
+    "LANGUAGE_MAP",
+    "detect_language",
+    # .exclusions
+    "DEFAULT_EXCLUDES",
+    "GENERATED_MARKERS",
+    "is_binary_file",
+    "is_generated_file",
+    "should_exclude",
+    "match_exclusion_reason",
+    # .extractors
+    "CodeItem",
+    "FunctionInfo",
+    "FunctionMetadata",
+    "KIND_FUNCTION",
+    "KIND_GLOBAL",
+    "KIND_MACRO",
+    "KIND_CLASS",
+    "extract_functions",
+    "extract_items",
+    "count_sloc",
+    "PythonExtractor",
+    "JavaScriptExtractor",
+    "CExtractor",
+    "JavaExtractor",
+    "GoExtractor",
+    "GenericExtractor",
+    "EXTRACTORS",
+    "_get_ts_languages",
+    # .lookup
+    "lookup_function",
+    "normalise_path",
+    # .diff
+    "compare_inventories",
+    # .coverage
+    "update_coverage",
+    "get_coverage_stats",
+    "format_coverage_summary",
+    # module-level functions defined below
+    "save_checklist",
+]
+
 
 def get_items(file_entry):
     """Read code items from a file entry. Handles both old and new format.

--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -16,17 +16,16 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
 from core.hash import sha256_bytes
-from core.json import load_json, save_json
+from core.json import load_json
 
 from .languages import LANGUAGE_MAP, detect_language
 from .exclusions import (
     DEFAULT_EXCLUDES,
     is_binary_file,
     is_generated_file,
-    should_exclude,
     match_exclusion_reason,
 )
-from .extractors import extract_functions, extract_items, count_sloc
+from .extractors import extract_items, count_sloc
 from .call_graph import (
     extract_call_graph_csharp,
     extract_call_graph_go,

--- a/core/inventory/call_graph.py
+++ b/core/inventory/call_graph.py
@@ -52,7 +52,7 @@ import ast
 import logging
 import warnings
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 logger = logging.getLogger(__name__)
 

--- a/core/inventory/extractors.py
+++ b/core/inventory/extractors.py
@@ -500,7 +500,7 @@ class GoExtractor:
         for i, line in enumerate(content.split('\n'), 1):
             match = re.match(self.PATTERN, line)
             if match:
-                receiver_name = match.group(1)  # e.g. "s"
+                # match.group(1) is the receiver variable name (e.g. "s"); unused
                 receiver_type = match.group(2)  # e.g. "*Server"
                 name = match.group(3)
                 class_name = receiver_type.lstrip("*") if receiver_type else None

--- a/core/inventory/fixture_detection.py
+++ b/core/inventory/fixture_detection.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 
 import os
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
 

--- a/core/inventory/tests/test_call_graph.py
+++ b/core/inventory/tests/test_call_graph.py
@@ -8,7 +8,6 @@ verdicts silently, so the data layer needs explicit coverage.
 from __future__ import annotations
 
 from core.inventory.call_graph import (
-    CallSite,
     FileCallGraph,
     INDIRECTION_DUNDER_IMPORT,
     INDIRECTION_GETATTR,

--- a/core/inventory/tests/test_call_graph_new_langs.py
+++ b/core/inventory/tests/test_call_graph_new_langs.py
@@ -12,7 +12,6 @@ import pytest
 
 from core.inventory.call_graph import (
     FileCallGraph,
-    INDIRECTION_DYNAMIC_IMPORT,
     INDIRECTION_EVAL,
     INDIRECTION_IMPORTLIB,
     INDIRECTION_REFLECT,

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -1,10 +1,8 @@
 """Tests for core.inventory — shared source inventory."""
 
 import json
-import os
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -27,9 +25,7 @@ from core.inventory import (
     is_binary_file,
     is_generated_file,
     match_exclusion_reason,
-    LANGUAGE_MAP,
     DEFAULT_EXCLUDES,
-    GENERATED_MARKERS,
     CodeItem,
     FunctionInfo,
     KIND_FUNCTION,

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -11,14 +11,9 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 from core.inventory.call_graph import (
-    INDIRECTION_DUNDER_IMPORT,
-    INDIRECTION_GETATTR,
-    INDIRECTION_IMPORTLIB,
-    INDIRECTION_WILDCARD_IMPORT,
     extract_call_graph_python,
 )
 from core.inventory.reachability import (
-    ReachabilityResult,
     Verdict,
     function_called,
 )

--- a/core/inventory/tests/test_reachability_adjacency.py
+++ b/core/inventory/tests/test_reachability_adjacency.py
@@ -31,11 +31,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-import pytest
 
 from core.inventory.call_graph import (
-    INDIRECTION_GETATTR,
-    INDIRECTION_WILDCARD_IMPORT,
     extract_call_graph_python,
 )
 from core.inventory.reachability import (

--- a/core/inventory/tests/test_reachability_closure.py
+++ b/core/inventory/tests/test_reachability_closure.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-import pytest
 
 from core.inventory.call_graph import extract_call_graph_python
 from core.inventory.reachability import (
@@ -503,7 +502,7 @@ def test_closure_paths_are_valid_edges():
     """Every adjacent pair in a closure path must correspond to an
     actual call edge in the index."""
     from core.inventory.reachability import (
-        _get_or_build_index, callers_of, callees_of,
+        callees_of,
     )
     inv = _inv(_file("src/a.py",
         "import json\n"

--- a/core/inventory/tests/test_reachability_evidence.py
+++ b/core/inventory/tests/test_reachability_evidence.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-import pytest
 
 from core.inventory.call_graph import extract_call_graph_python
 from core.inventory.reachability import (

--- a/core/inventory/tests/test_shared_checklist.py
+++ b/core/inventory/tests/test_shared_checklist.py
@@ -1,6 +1,5 @@
 """Tests for project-level shared checklist via symlinks."""
 
-import json
 import os
 import sys
 import unittest

--- a/core/json/cache.py
+++ b/core/json/cache.py
@@ -43,7 +43,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 from .utils import _reject_non_finite
 

--- a/core/llm/cc_adapter.py
+++ b/core/llm/cc_adapter.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Optional
 
 from core.security.redaction import redact_secrets

--- a/core/llm/cc_proxy_hosts.py
+++ b/core/llm/cc_proxy_hosts.py
@@ -49,7 +49,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional
 from urllib.parse import urlparse
 
 

--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -12,6 +12,7 @@ Manages multiple LLM providers with:
 
 import json
 import re
+import threading
 import time
 from pathlib import Path
 from typing import Dict, Optional, Any, Tuple
@@ -270,7 +271,6 @@ class LLMClient:
     """Unified LLM client with multi-provider support and fallback."""
 
     def __init__(self, config: Optional[LLMConfig] = None):
-        import threading
         self.config = config or LLMConfig()
         self.providers: Dict[str, LLMProvider] = {}
         self.total_cost = 0.0
@@ -453,7 +453,6 @@ class LLMClient:
         only held briefly to insert into the dict; the per-key lock
         itself is acquired by the caller for the duration of the
         check-call-save sequence."""
-        import threading
         with self._key_locks_guard:
             lock = self._key_locks.get(cache_key)
             if lock is None:

--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -12,7 +12,6 @@ Manages multiple LLM providers with:
 
 import json
 import re
-import sys
 import time
 from pathlib import Path
 from typing import Dict, Optional, Any, Tuple

--- a/core/llm/config.py
+++ b/core/llm/config.py
@@ -11,11 +11,9 @@ Availability detection (SDK flags, Ollama, Claude Code) lives in detection.py.
 """
 
 import os
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-import json
 
 from core.logging import get_logger
 
@@ -25,8 +23,7 @@ from .model_data import (
     MODEL_COSTS, MODEL_LIMITS, PROVIDER_ENV_KEYS,
 )
 from .detection import (
-    OPENAI_SDK_AVAILABLE, ANTHROPIC_SDK_AVAILABLE,
-    LLMAvailability, detect_llm_availability,
+    OPENAI_SDK_AVAILABLE, detect_llm_availability,
     _get_available_ollama_models, _validate_ollama_url,
     _read_config_models,
 )
@@ -241,7 +238,6 @@ def _build_openai_compat_config(provider_name: str) -> Optional['ModelConfig']:
     # the resolver falls through to the next candidate (Ollama,
     # ClaudeCode) instead of detecting a usable API key, advertising
     # the model to the operator, then crashing the next LLM call.
-    from .detection import OPENAI_SDK_AVAILABLE
     if not OPENAI_SDK_AVAILABLE:
         logger.debug(
             "Skipping %s config: %s key present but openai SDK not "

--- a/core/llm/cwe_strategies/loader.py
+++ b/core/llm/cwe_strategies/loader.py
@@ -30,7 +30,7 @@ should fail loudly, not silently disable a signal.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import yaml
 

--- a/core/llm/cwe_strategies/models.py
+++ b/core/llm/cwe_strategies/models.py
@@ -7,7 +7,7 @@ alongside annotations and so picker tests have predictable equality.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Tuple
 
 
 @dataclass(frozen=True)

--- a/core/llm/cwe_strategies/tests/test_bundled_strategies.py
+++ b/core/llm/cwe_strategies/tests/test_bundled_strategies.py
@@ -55,7 +55,6 @@ class TestBundle:
 
     def test_no_unexpected_strategies(self, by_name):
         names = set(by_name)
-        unexpected = names - _EXPECTED_STRATEGIES
         # Allow extras in future without breaking; just flag for visibility.
         # Convert to a clear assertion the operator wants to see.
         assert names >= _EXPECTED_STRATEGIES

--- a/core/llm/cwe_strategies/tests/test_libexec_shim.py
+++ b/core/llm/cwe_strategies/tests/test_libexec_shim.py
@@ -13,7 +13,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]

--- a/core/llm/cwe_strategies/tests/test_picker.py
+++ b/core/llm/cwe_strategies/tests/test_picker.py
@@ -7,7 +7,6 @@ don't want this test file to need updates each time.
 
 from __future__ import annotations
 
-import pytest
 
 from core.llm.cwe_strategies import (
     Signals,

--- a/core/llm/cwe_strategies/tests/test_picker_tier1.py
+++ b/core/llm/cwe_strategies/tests/test_picker_tier1.py
@@ -10,7 +10,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 from core.llm.cwe_strategies import (
     Signals,

--- a/core/llm/cwe_strategies/tests/test_prompts.py
+++ b/core/llm/cwe_strategies/tests/test_prompts.py
@@ -8,7 +8,6 @@ content, content that looks like markdown injection).
 
 from __future__ import annotations
 
-import pytest
 
 from core.llm.cwe_strategies import (
     DEFAULT_MAX_BYTES,

--- a/core/llm/detection.py
+++ b/core/llm/detection.py
@@ -11,7 +11,6 @@ instead of ad-hoc env var or PATH checks.
 
 import os
 import shutil
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
@@ -25,19 +24,19 @@ logger = get_logger()
 
 # SDK availability flags — canonical source, imported by other modules
 try:
-    import openai as _openai_module
+    import openai as _openai_module  # noqa: F401 — availability probe
     OPENAI_SDK_AVAILABLE = True
 except ImportError:
     OPENAI_SDK_AVAILABLE = False
 
 try:
-    import anthropic as _anthropic_module
+    import anthropic as _anthropic_module  # noqa: F401 — availability probe
     ANTHROPIC_SDK_AVAILABLE = True
 except ImportError:
     ANTHROPIC_SDK_AVAILABLE = False
 
 try:
-    from google import genai as _genai_module
+    from google import genai as _genai_module  # noqa: F401 — availability probe
     GENAI_SDK_AVAILABLE = True
 except ImportError:
     GENAI_SDK_AVAILABLE = False
@@ -196,8 +195,6 @@ def _try_auto_migrate(old_config: Path, new_config: Path) -> bool:
     except ImportError:
         return False
 
-    import json
-    from .model_data import PROVIDER_ENV_KEYS
 
     # Allowlist of providers RAPTOR's downstream code can handle.
     # LiteLLM supports a much wider set (vertex_ai, bedrock, sagemaker,
@@ -371,7 +368,6 @@ def _read_config_models() -> list:
     Shared config file parsing — used by both detection and config modules.
     Returns a list of model dicts, or empty list on any error.
     """
-    import json
     try:
         from core.json import load_json_with_comments
 

--- a/core/llm/dispatcher/auth.py
+++ b/core/llm/dispatcher/auth.py
@@ -38,7 +38,7 @@ on a known upstream URL and route cleanly through the proxy.
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Callable
 
 

--- a/core/llm/dispatcher/server.py
+++ b/core/llm/dispatcher/server.py
@@ -32,7 +32,6 @@ bytes upstream.
 
 from __future__ import annotations
 
-import errno
 import http.server
 import json
 import logging
@@ -47,7 +46,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import IO, Optional
+from typing import Optional
 
 import httpx
 

--- a/core/llm/dispatcher/tests/test_dispatcher.py
+++ b/core/llm/dispatcher/tests/test_dispatcher.py
@@ -497,7 +497,7 @@ class TestRealAnthropicSDKThroughDispatcher:
         """Build the client via ``make_anthropic_client`` (the actual
         worker-side helper), call ``messages.create``, assert the SDK
         parsed the response and the dispatcher injected real creds."""
-        anthropic = pytest.importorskip("anthropic")
+        pytest.importorskip("anthropic")
         from core.llm.dispatcher.client import make_anthropic_client
 
         d, upstream = self._setup(fake_creds, tmp_path)
@@ -588,7 +588,7 @@ class TestSubprocessE2E:
     def test_subprocess_uses_dispatcher_with_no_keys_in_env(
         self, fake_creds, tmp_path
     ):
-        anthropic = pytest.importorskip("anthropic")
+        pytest.importorskip("anthropic")
         from core.llm.dispatcher.spawn import spawn_worker
 
         upstream = _CaptiveUpstream()

--- a/core/llm/dispatcher/tests/test_dispatcher.py
+++ b/core/llm/dispatcher/tests/test_dispatcher.py
@@ -14,18 +14,15 @@ import json
 import os
 import socket
 import stat
-import struct
 import sys
 import threading
 import time
-from pathlib import Path
 
 import httpx
 import pytest
 
 from core.llm.dispatcher.auth import CredentialStore
 from core.llm.dispatcher.server import (
-    AuditEvent,
     LLMDispatcher,
     _TOKEN_HEADER,
     _peer_uid,
@@ -328,7 +325,7 @@ class _CaptiveUpstream:
     send to the actual provider."""
 
     def __init__(self):
-        import http.server, threading
+        import http.server
 
         self.captured: dict = {}
         self_outer = self

--- a/core/llm/dispatcher/tests/test_lifecycle.py
+++ b/core/llm/dispatcher/tests/test_lifecycle.py
@@ -10,7 +10,6 @@ Confirms:
 
 from __future__ import annotations
 
-import os
 import pytest
 
 from core.llm.dispatcher.auth import CredentialStore

--- a/core/llm/dispatcher/tests/test_providers.py
+++ b/core/llm/dispatcher/tests/test_providers.py
@@ -9,7 +9,6 @@ dummy header is stripped.
 
 from __future__ import annotations
 
-import json
 import os
 import threading
 import http.server

--- a/core/llm/egress.py
+++ b/core/llm/egress.py
@@ -81,7 +81,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING, Iterable, Set
+from typing import TYPE_CHECKING, Set
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:

--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -14,8 +14,11 @@ import time
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from inspect import isclass
-from typing import Dict, Optional, Any, Tuple, Type, Union
+from typing import Dict, Optional, Any, Tuple, Type, Union, TYPE_CHECKING
 from dataclasses import dataclass
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
 
 from core.logging import get_logger
 from .config import ModelConfig

--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -9,16 +9,13 @@ JSON-in-prompt fallback for providers that lack native structured support.
 """
 
 import json
-import logging
 import os
-import sys
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from inspect import isclass
 from typing import Dict, Optional, Any, Tuple, Type, Union
 from dataclasses import dataclass
-from pathlib import Path
 
 from core.logging import get_logger
 from .config import ModelConfig
@@ -715,8 +712,7 @@ def _dict_schema_to_pydantic(schema: Union[Dict[str, Any], Type['BaseModel']]):
     Raises:
         ValueError: If schema is invalid or empty
     """
-    from pydantic import BaseModel, Field, create_model
-    from typing import get_type_hints
+    from pydantic import BaseModel, create_model
 
     # Check if already a Pydantic model class
     if isclass(schema) and issubclass(schema, BaseModel):

--- a/core/llm/scorecard/cli.py
+++ b/core/llm/scorecard/cli.py
@@ -21,7 +21,7 @@ import datetime as _dt
 import re
 import sys
 from pathlib import Path
-from typing import Iterable, List, Optional, Tuple
+from typing import List, Optional
 
 from .scorecard import (
     ALL_EVENT_TYPES,

--- a/core/llm/scorecard/judge.py
+++ b/core/llm/scorecard/judge.py
@@ -31,7 +31,7 @@ only — judge events do NOT shift the prefilter gate.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
 
 from .scorecard import EventType, ModelScorecard
 

--- a/core/llm/scorecard/scorecard.py
+++ b/core/llm/scorecard/scorecard.py
@@ -46,15 +46,14 @@ from __future__ import annotations
 
 import fcntl
 import math
-import os
 import random
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Iterator, List, Literal, Optional, Set, Tuple
+from typing import Dict, List, Literal, Optional, Set, Tuple
 
-from core.json import load_json, save_json
+from core.json import save_json
 from core.logging import get_logger
 
 logger = get_logger()

--- a/core/llm/scorecard/tests/test_cli.py
+++ b/core/llm/scorecard/tests/test_cli.py
@@ -13,7 +13,6 @@ import datetime as _dt
 import io
 import os
 import subprocess
-import sys
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from types import SimpleNamespace

--- a/core/llm/scorecard/tests/test_prefilter.py
+++ b/core/llm/scorecard/tests/test_prefilter.py
@@ -8,9 +8,7 @@ substrate's ``ModelScorecard`` is exercised separately.
 
 from __future__ import annotations
 
-from pathlib import Path
 
-import pytest
 
 from core.llm.scorecard import (
     EventType,
@@ -19,7 +17,6 @@ from core.llm.scorecard import (
     prefilter_decision,
     record_prefilter_outcome,
 )
-from core.llm.scorecard.scorecard import _wilson_upper_bound
 
 
 # ---------------------------------------------------------------------------

--- a/core/llm/scorecard/tests/test_scorecard.py
+++ b/core/llm/scorecard/tests/test_scorecard.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import json
 import multiprocessing
-import os
 import time
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
@@ -567,7 +566,6 @@ def _backdate_cell(sc, model: str, decision_class: str,
     GC sees the full set in one pass rather than firing per call.
     """
     from datetime import datetime, timezone
-    import time
     target = datetime.fromtimestamp(
         time.time() - days_ago * 86400, tz=timezone.utc,
     ).replace(microsecond=0).isoformat()
@@ -717,7 +715,6 @@ class TestAutoGc:
         # Backdate WITHOUT clearing last_gc_at this time so the
         # interval gate is the thing under test.
         from datetime import datetime, timezone
-        import time
         with sc2._with_lock() as data:
             old_iso = datetime.fromtimestamp(
                 time.time() - 200 * 86400, tz=timezone.utc,

--- a/core/llm/tests/test_cc_adapter.py
+++ b/core/llm/tests/test_cc_adapter.py
@@ -2,7 +2,6 @@
 
 import json
 
-import pytest
 
 from core.llm.cc_adapter import (
     CCDispatchConfig,

--- a/core/llm/tests/test_cc_proxy_hosts.py
+++ b/core/llm/tests/test_cc_proxy_hosts.py
@@ -13,9 +13,7 @@ The module resolves cc_dispatch sandbox policy via four layers
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/core/llm/tests/test_config_file.py
+++ b/core/llm/tests/test_config_file.py
@@ -276,7 +276,7 @@ class TestMigrationDetection:
 
 
 try:
-    import yaml
+    import yaml  # noqa: F401 — availability probe for the @skipif gate below
     HAS_PYYAML = True
 except ImportError:
     HAS_PYYAML = False

--- a/core/llm/tests/test_config_file.py
+++ b/core/llm/tests/test_config_file.py
@@ -5,7 +5,7 @@ import os
 import pytest
 import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 # packages/llm_analysis/tests/test_config_file.py -> repo root
 sys.path.insert(0, str(Path(__file__).parents[3]))

--- a/core/llm/tests/test_dispatcher_integration.py
+++ b/core/llm/tests/test_dispatcher_integration.py
@@ -17,7 +17,6 @@ import os
 import subprocess
 import sys
 import threading
-from pathlib import Path
 
 import httpx
 import pytest

--- a/core/llm/tests/test_egress.py
+++ b/core/llm/tests/test_egress.py
@@ -240,7 +240,6 @@ class TestEnableLLMEgress:
         Subsequent calls only union the allowlist."""
         cfg = _config(primary=_model(provider="anthropic"))
         egress.enable_llm_egress(cfg)
-        first_value = os.environ["HTTPS_PROXY"]
 
         # Mutate the env to detect a second overwrite if it happens.
         os.environ["HTTPS_PROXY"] = "http://sentinel:99"

--- a/core/llm/tests/test_llm_callbacks_providers.py
+++ b/core/llm/tests/test_llm_callbacks_providers.py
@@ -231,110 +231,24 @@ class TestCalculateCostSplit:
         actual_cost = provider._calculate_cost_split(0, 0)
         assert actual_cost == 0.0
 
-class TestThinkingModelFallback:
-    """Verify reasoning_content fallback for Ollama thinking models."""
-
-    def _make_ollama_provider(self):
-        """Create an OpenAICompatibleProvider configured for Ollama."""
-        mock_openai, cleanup = _ensure_mock_sdk(_providers_module, 'OpenAI')
-        with patch("core.llm.providers.OPENAI_SDK_AVAILABLE", True), \
-             patch("core.llm.providers.INSTRUCTOR_AVAILABLE", False):
-            from core.llm.providers import OpenAICompatibleProvider
-            config = ModelConfig(
-                provider="ollama", model_name="qwen3:8b",
-                api_base="http://localhost:11434/v1",
-            )
-            provider = OpenAICompatibleProvider(config)
-        return provider, mock_openai, cleanup
-
-    def test_reasoning_content_used_when_content_empty(self):
-        """Thinking models with empty content fall back to reasoning_content."""
-        provider, mock_openai, cleanup = self._make_ollama_provider()
-        try:
-            response = MagicMock()
-            response.choices = [MagicMock()]
-            response.choices[0].message.content = ""
-            response.choices[0].message.reasoning_content = "The answer is 42"
-            response.choices[0].message.refusal = None
-            response.choices[0].finish_reason = "stop"
-            response.usage = MagicMock()
-            response.usage.prompt_tokens = 50
-            response.usage.completion_tokens = 10
-            response.usage.completion_tokens_details = None
-            mock_openai.return_value.chat.completions.create.return_value = response
-
-            result = provider.generate("What is the answer?")
-            assert result.content == "The answer is 42"
-        finally:
-            cleanup()
-
-    def test_content_preferred_over_reasoning_content(self):
-        """When content is present, reasoning_content is not used."""
-        provider, mock_openai, cleanup = self._make_ollama_provider()
-        try:
-            response = MagicMock()
-            response.choices = [MagicMock()]
-            response.choices[0].message.content = "Normal response"
-            response.choices[0].message.reasoning_content = "Thinking process..."
-            response.choices[0].message.refusal = None
-            response.choices[0].finish_reason = "stop"
-            response.usage = MagicMock()
-            response.usage.prompt_tokens = 50
-            response.usage.completion_tokens = 10
-            response.usage.completion_tokens_details = None
-            mock_openai.return_value.chat.completions.create.return_value = response
-
-            result = provider.generate("test")
-            assert result.content == "Normal response"
-        finally:
-            cleanup()
-
-    def test_both_empty_returns_empty(self):
-        """When both content and reasoning_content are empty, returns empty."""
-        provider, mock_openai, cleanup = self._make_ollama_provider()
-        try:
-            response = MagicMock()
-            response.choices = [MagicMock()]
-            response.choices[0].message.content = ""
-            response.choices[0].message.reasoning_content = ""
-            response.choices[0].message.refusal = None
-            response.choices[0].finish_reason = "stop"
-            response.usage = MagicMock()
-            response.usage.prompt_tokens = 50
-            response.usage.completion_tokens = 0
-            response.usage.completion_tokens_details = None
-            mock_openai.return_value.chat.completions.create.return_value = response
-
-            result = provider.generate("test")
-            assert result.content == ""
-        finally:
-            cleanup()
-
-    def test_no_reasoning_content_attr(self):
-        """Models without reasoning_content attribute work normally."""
-        provider, mock_openai, cleanup = self._make_ollama_provider()
-        try:
-            response = MagicMock()
-            response.choices = [MagicMock()]
-            response.choices[0].message.content = "Normal response"
-            # No reasoning_content attribute
-            del response.choices[0].message.reasoning_content
-            response.choices[0].message.refusal = None
-            response.choices[0].finish_reason = "stop"
-            response.usage = MagicMock()
-            response.usage.prompt_tokens = 50
-            response.usage.completion_tokens = 10
-            response.usage.completion_tokens_details = None
-            mock_openai.return_value.chat.completions.create.return_value = response
-
-            result = provider.generate("test")
-            assert result.content == "Normal response"
-        finally:
-            cleanup()
+# NOTE: A duplicate ``TestThinkingModelFallback`` class previously
+# lived here. Python silently discarded it when the same-named class
+# at line ~334 was parsed at module scope (F811 hazard). The two defs
+# were near-identical (one comment line of difference); the
+# downstream copy is the one that actually ran and was being
+# maintained. Removed the upstream duplicate as part of W14-E1
+# DEEP-1b to make the F811 gate enforceable.
 
 
-class TestCalculateCostSplit:
-    """Verify _calculate_cost_split uses MODEL_COSTS for known models."""
+class TestModelCostsShape:
+    """Verify the MODEL_COSTS table itself has the right shape.
+
+    Was previously named ``TestCalculateCostSplit`` and silently
+    shadowed the earlier class of the same name at line 159 — Python
+    discards the first def when a second def at module scope shares the
+    name, so the 4 tests in the first class never ran. Renamed to its
+    actual purpose so both classes' tests now execute. See W14-E1
+    DEEP-1b narrative."""
 
     def test_all_model_costs_have_input_output(self):
         """Every entry in MODEL_COSTS has both 'input' and 'output' keys."""

--- a/core/llm/tests/test_ollama_warning.py
+++ b/core/llm/tests/test_ollama_warning.py
@@ -78,7 +78,7 @@ class TestOllamaWarning:
             api_base=RaptorConfig.OLLAMA_HOST
         )
 
-        client = LLMClient(config)
+        LLMClient(config)
 
         # Find Ollama warning
         ollama_warnings = [
@@ -121,7 +121,7 @@ class TestOllamaWarning:
             model_name="gpt-4o-mini"
         )
 
-        client = LLMClient(config)
+        LLMClient(config)
 
         # Check for Ollama warnings (should be none)
         ollama_warnings = [
@@ -184,7 +184,7 @@ class TestOllamaWarning:
             api_base=RaptorConfig.OLLAMA_HOST
         )
 
-        client = LLMClient(config)
+        LLMClient(config)
 
         # Find Ollama warning
         ollama_warnings = [

--- a/core/llm/tests/test_ollama_warning.py
+++ b/core/llm/tests/test_ollama_warning.py
@@ -4,7 +4,6 @@ import pytest
 import sys
 import os
 import logging
-from io import StringIO
 from pathlib import Path
 
 # Add parent directories to path for imports

--- a/core/llm/tests/test_provider_preference.py
+++ b/core/llm/tests/test_provider_preference.py
@@ -12,8 +12,6 @@ contract.
 
 from __future__ import annotations
 
-import os
-from unittest.mock import patch
 
 import pytest
 

--- a/core/llm/tests/test_response_validation.py
+++ b/core/llm/tests/test_response_validation.py
@@ -1,9 +1,7 @@
 """Tests for core.llm.response_validation — per-field LLM response validation."""
 
-import pytest
 
 from core.llm.response_validation import (
-    FieldResult,
     ValidatedResponse,
     attempt_quality_retry,
     validate_structured_response,
@@ -675,7 +673,6 @@ class TestAttemptQualityRetry:
         return llm
 
     def test_no_retry_when_quality_above_threshold(self):
-        from core.llm.response_validation import attempt_quality_retry, ValidatedResponse
         from unittest.mock import MagicMock
         validated = ValidatedResponse(
             data={"is_true_positive": True, "is_exploitable": True,
@@ -692,7 +689,6 @@ class TestAttemptQualityRetry:
     def test_no_retry_when_no_actionable_problems(self):
         """Below-threshold but no incomplete/coerced fields → no
         retry (no actionable corrective prompt to build)."""
-        from core.llm.response_validation import attempt_quality_retry, ValidatedResponse
         from unittest.mock import MagicMock
         validated = ValidatedResponse(
             data={}, quality=0.2, incomplete=[], coerced=[], fields={}, raw={},
@@ -706,7 +702,6 @@ class TestAttemptQualityRetry:
 
     def test_retry_used_when_better(self):
         """Retry response with higher quality replaces the original."""
-        from core.llm.response_validation import attempt_quality_retry, ValidatedResponse
         original = ValidatedResponse(
             data={"is_true_positive": True}, quality=0.3,
             incomplete=["reasoning", "vuln_type"], coerced=[], fields={}, raw={},
@@ -730,7 +725,6 @@ class TestAttemptQualityRetry:
 
     def test_retry_kept_original_when_not_better(self):
         """Retry returns equal-or-worse quality → keep original."""
-        from core.llm.response_validation import attempt_quality_retry, ValidatedResponse
         original = ValidatedResponse(
             data={"is_true_positive": True, "is_exploitable": True,
                   "reasoning": "x", "vuln_type": "sql_injection"},
@@ -748,7 +742,6 @@ class TestAttemptQualityRetry:
     def test_retry_swallows_llm_exception(self):
         """LLM raises on retry → fall back to original (production
         caller's existing low-quality warning still fires)."""
-        from core.llm.response_validation import attempt_quality_retry, ValidatedResponse
         from unittest.mock import MagicMock
         original = ValidatedResponse(
             data={}, quality=0.3, incomplete=["reasoning"], coerced=[],
@@ -763,7 +756,6 @@ class TestAttemptQualityRetry:
 
     def test_retry_handles_none_response(self):
         """LLM returns (None, None) → fall back to original."""
-        from core.llm.response_validation import attempt_quality_retry, ValidatedResponse
         from unittest.mock import MagicMock
         original = ValidatedResponse(
             data={}, quality=0.3, incomplete=["reasoning"], coerced=[],
@@ -779,7 +771,6 @@ class TestAttemptQualityRetry:
     def test_retry_forwards_system_prompt_and_task_type(self):
         """The retry call must carry the same system_prompt + task_type
         so the LLM has the same context as the original call."""
-        from core.llm.response_validation import attempt_quality_retry, ValidatedResponse
         from unittest.mock import MagicMock
         original = ValidatedResponse(
             data={}, quality=0.3, incomplete=["reasoning"], coerced=[],

--- a/core/llm/tests/test_structured_response_cache.py
+++ b/core/llm/tests/test_structured_response_cache.py
@@ -15,9 +15,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict, Tuple
-from unittest.mock import patch
 
-import pytest
 
 from core.llm.client import LLMClient
 from core.llm.config import LLMConfig, ModelConfig
@@ -421,7 +419,7 @@ def test_ttl_unset_keeps_entries_indefinitely(tmp_path: Path) -> None:
     """No TTL configured → an entry from epoch 0 still serves a hit.
     Defends the no-TTL path so operators aren't surprised by hidden
     expiry."""
-    import json, time
+    import json
     client = _client(tmp_path, cache_ttl_seconds=None)
     fake = _FakeProvider({"k": "v"})
     _install_provider(client, fake)

--- a/core/llm/tests/test_turn_track_usage_and_factory.py
+++ b/core/llm/tests/test_turn_track_usage_and_factory.py
@@ -154,7 +154,6 @@ def test_gemini_turn_tracks_via_delegated_generate() -> None:
 def test_claudecode_turn_tracks_via_delegated_generate(monkeypatch) -> None:
     """``ClaudeCodeLLMProvider.turn`` delegates to ``generate`` (no tools)
     or ``generate_structured`` (with tools); both call ``track_usage``."""
-    import json
     import subprocess
     from core.llm.providers import ClaudeCodeLLMProvider
     from core.llm.tool_use import Message, TextBlock, ToolDef

--- a/core/llm/tool_use/loop.py
+++ b/core/llm/tool_use/loop.py
@@ -73,7 +73,6 @@ from .types import (
     ToolResult,
     ToolResultPreflight,
     TurnCompleted,
-    TurnResponse,
     TurnStarted,
 )
 

--- a/core/llm/tool_use/tests/test_fallback.py
+++ b/core/llm/tool_use/tests/test_fallback.py
@@ -11,7 +11,6 @@ subprocess machinery.
 
 from __future__ import annotations
 
-import json
 from typing import Any, Dict, Optional, Tuple
 
 import pytest

--- a/core/llm/tool_use/tests/test_loop.py
+++ b/core/llm/tool_use/tests/test_loop.py
@@ -921,7 +921,7 @@ def test_xsource_blocks_hallucinated_discovered_field() -> None:
     ])
     events: list[LoopEvent] = []
     loop = ToolUseLoop(fp, [_discovered_tool()], events=events.append)
-    result = loop.run("Analyze CVE-2024-1234")
+    loop.run("Analyze CVE-2024-1234")
 
     blocked = [e for e in events if isinstance(e, ToolCallBlocked)]
     assert len(blocked) == 1
@@ -941,7 +941,7 @@ def test_xsource_passes_value_from_prompt() -> None:
     ])
     events: list[LoopEvent] = []
     loop = ToolUseLoop(fp, [_discovered_tool()], events=events.append)
-    result = loop.run("Check openssl/openssl for CVE-2024-1234")
+    loop.run("Check openssl/openssl for CVE-2024-1234")
 
     blocked = [e for e in events if isinstance(e, ToolCallBlocked)]
     assert len(blocked) == 0
@@ -968,7 +968,7 @@ def test_xsource_passes_value_from_prior_tool_output() -> None:
     loop = ToolUseLoop(
         fp, [source_tool, _discovered_tool()], events=events.append,
     )
-    result = loop.run("Analyze CVE-2024-1234")
+    loop.run("Analyze CVE-2024-1234")
 
     blocked = [e for e in events if isinstance(e, ToolCallBlocked)]
     assert len(blocked) == 0
@@ -993,7 +993,7 @@ def test_xsource_blocks_value_not_from_prior_output() -> None:
     loop = ToolUseLoop(
         fp, [source_tool, _discovered_tool()], events=events.append,
     )
-    result = loop.run("Analyze CVE-2024-1234")
+    loop.run("Analyze CVE-2024-1234")
 
     blocked = [e for e in events if isinstance(e, ToolCallBlocked)]
     assert len(blocked) == 1
@@ -1008,7 +1008,7 @@ def test_xsource_prompt_field_not_validated() -> None:
     ])
     events: list[LoopEvent] = []
     loop = ToolUseLoop(fp, [_prompt_tool()], events=events.append)
-    result = loop.run("go")
+    loop.run("go")
 
     blocked = [e for e in events if isinstance(e, ToolCallBlocked)]
     assert len(blocked) == 0
@@ -1022,7 +1022,7 @@ def test_xsource_no_annotations_means_no_validation() -> None:
     ])
     events: list[LoopEvent] = []
     loop = ToolUseLoop(fp, [_echo_tool()], events=events.append)
-    result = loop.run("go")
+    loop.run("go")
 
     blocked = [e for e in events if isinstance(e, ToolCallBlocked)]
     assert len(blocked) == 0
@@ -1042,7 +1042,7 @@ def test_xsource_mixed_tool_blocks_only_discovered() -> None:
     ])
     events: list[LoopEvent] = []
     loop = ToolUseLoop(fp, [_mixed_tool()], events=events.append)
-    result = loop.run("Analyze CVE-2024-1234")
+    loop.run("Analyze CVE-2024-1234")
 
     blocked = [e for e in events if isinstance(e, ToolCallBlocked)]
     assert len(blocked) == 1
@@ -1070,7 +1070,7 @@ def test_xsource_known_values_grow_across_turns() -> None:
     ])
     events: list[LoopEvent] = []
     loop = ToolUseLoop(fp, [tool_a, tool_b], events=events.append)
-    result = loop.run("Analyze CVE-2024-1234")
+    loop.run("Analyze CVE-2024-1234")
 
     blocked = [e for e in events if isinstance(e, ToolCallBlocked)]
     assert len(blocked) == 0
@@ -1084,7 +1084,7 @@ def test_xsource_slash_split_matches_components() -> None:
     ])
     events: list[LoopEvent] = []
     loop = ToolUseLoop(fp, [_discovered_tool()], events=events.append)
-    result = loop.run("Check openssl/openssl")
+    loop.run("Check openssl/openssl")
 
     blocked = [e for e in events if isinstance(e, ToolCallBlocked)]
     assert len(blocked) == 0

--- a/core/llm/tool_use/tests/test_loop.py
+++ b/core/llm/tool_use/tests/test_loop.py
@@ -9,7 +9,6 @@ those concerns are tested in the provider-specific test files.
 from __future__ import annotations
 
 import time
-from collections.abc import Sequence
 from typing import Any
 
 import pytest
@@ -25,7 +24,6 @@ from core.llm.tool_use import (
     StopReason,
     TextBlock,
     ToolCall,
-    ToolCallDispatched,
     ToolCallReturned,
     ToolDef,
     TurnCompleted,

--- a/core/llm/tool_use/tests/test_tool_result_injection.py
+++ b/core/llm/tool_use/tests/test_tool_result_injection.py
@@ -13,10 +13,8 @@ See ``core/llm/tool_use/loop.py`` (dispatch hook) and
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence
 
 from core.llm.tool_use import (
-    Message,
     StopReason,
     TextBlock,
     ToolCall,
@@ -533,7 +531,6 @@ class TestXSourceExtraction:
         passes that SHA as a discovered field → must dispatch (in the
         allowlist), confirming the SHA was extracted from raw content
         and entered the known-values set."""
-        from core.llm.tool_use.types import LoopEvent
 
         # Tool 2 declares its ``sha`` input as discovered, so the loop
         # validates it against known_values before dispatch. If

--- a/core/llm/tool_use/tests/test_wire_converters.py
+++ b/core/llm/tool_use/tests/test_wire_converters.py
@@ -11,7 +11,6 @@ shapes end-to-end via fake clients.
 
 from __future__ import annotations
 
-import json
 
 import pytest
 

--- a/core/logging/__init__.py
+++ b/core/logging/__init__.py
@@ -10,7 +10,6 @@ import json
 import logging
 import sys
 import time
-from pathlib import Path
 from typing import Any, Dict, Optional
 
 from core.config import RaptorConfig

--- a/core/oci/client.py
+++ b/core/oci/client.py
@@ -35,7 +35,6 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple
 from core.http import HttpClient
 
 from .auth import (
-    BasicCredentials,
     lookup_credentials,
     parse_www_authenticate,
 )

--- a/core/oci/sbom.py
+++ b/core/oci/sbom.py
@@ -36,7 +36,6 @@ Limitations (also noted in :doc:`README`):
 
 from __future__ import annotations
 
-import io
 import logging
 import sqlite3
 import struct

--- a/core/oci/tests/test_auth.py
+++ b/core/oci/tests/test_auth.py
@@ -12,7 +12,6 @@ import base64
 import json
 from pathlib import Path
 
-import pytest
 
 from core.oci.auth import (
     BasicCredentials,

--- a/core/oci/tests/test_sbom.py
+++ b/core/oci/tests/test_sbom.py
@@ -13,7 +13,6 @@ import struct
 from pathlib import Path
 
 from core.oci.sbom import (
-    InstalledPackage,
     LAYER_FILE_PATHS,
     packages_from_layer_files,
     parse_apk_installed,

--- a/core/orchestration/agentic_passes.py
+++ b/core/orchestration/agentic_passes.py
@@ -42,7 +42,7 @@ import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from core.json import load_json, save_json
 from core.sandbox import run_untrusted_networked

--- a/core/orchestration/tests/test_agentic_passes.py
+++ b/core/orchestration/tests/test_agentic_passes.py
@@ -14,8 +14,6 @@ from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
 
 from core.orchestration.agentic_passes import (
-    PostpassResult,
-    PrepassResult,
     _enrich_agentic_checklist,
     _select_findings_for_validate,
     run_understand_prepass,
@@ -1022,7 +1020,6 @@ class AdversarialBugsTests(unittest.TestCase):
         # If the helper failed internally (e.g. couldn't write metadata),
         # we'd never know — the run dir stays in "running" state.
         from core.orchestration.agentic_passes import _complete_lifecycle
-        import logging
         with patch("core.orchestration.agentic_passes.subprocess.run",
                    return_value=_ok(returncode=1, stderr="permission denied")):
             with self.assertLogs(
@@ -1194,7 +1191,6 @@ class EnrichmentTests(unittest.TestCase):
         # Context map with 1 entry point against a checklist that has the
         # same logical file under a different path (absolute vs relative)
         # should fire the "0 marked despite N entry-points" warning.
-        import logging
         with TemporaryDirectory() as tmp:
             tmp = Path(tmp)
             (tmp / "checklist.json").write_text(json.dumps({

--- a/core/orchestration/tests/test_agentic_passes_integration.py
+++ b/core/orchestration/tests/test_agentic_passes_integration.py
@@ -17,8 +17,6 @@ from unittest.mock import MagicMock, patch
 from core.orchestration.agentic_passes import (
     run_understand_prepass,
     run_validate_postpass,
-    _RAPTOR_DIR,
-    _LIFECYCLE,
 )
 from core.orchestration.understand_bridge import find_understand_output, load_understand_context
 

--- a/core/orchestration/tests/test_reachability_consumer_wirings_e2e.py
+++ b/core/orchestration/tests/test_reachability_consumer_wirings_e2e.py
@@ -47,7 +47,6 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import pytest
 
 
 _PROJECT = {

--- a/core/orchestration/tests/test_understand_bridge.py
+++ b/core/orchestration/tests/test_understand_bridge.py
@@ -198,7 +198,7 @@ class TestFindUnderstandOutput:
         validate_dir = project_dir / "validate-20260403-120000"
         validate_dir.mkdir(parents=True)
 
-        old = _make_understand_dir(project_dir, "understand-20260401-120000")
+        _make_understand_dir(project_dir, "understand-20260401-120000")
         time.sleep(0.01)
         new = _make_understand_dir(project_dir, "understand-20260402-120000")
 

--- a/core/orchestration/tests/test_understand_bridge.py
+++ b/core/orchestration/tests/test_understand_bridge.py
@@ -8,7 +8,6 @@ import time
 import unittest.mock
 from pathlib import Path
 
-import pytest
 
 # core/orchestration/tests/ -> repo root
 sys.path.insert(0, str(Path(__file__).parents[3]))
@@ -435,7 +434,6 @@ class TestHashFreshness:
 
     def test_rank_returns_stale_set(self, tmp_path):
         """When best candidate has stale files, they are returned."""
-        import hashlib
         target = tmp_path / "target"
         target.mkdir()
         (target / "a.py").write_text("current")

--- a/core/orchestration/tests/test_validate_checklist_handoff_e2e.py
+++ b/core/orchestration/tests/test_validate_checklist_handoff_e2e.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
 

--- a/core/orchestration/understand_bridge.py
+++ b/core/orchestration/understand_bridge.py
@@ -1074,9 +1074,7 @@ def _filter_context_map(context_map: Dict[str, Any], stale_files: Set[str]) -> i
 
     # Filter unchecked_flows — references entry_points/sinks by ID, so
     # resolve IDs to files first, then drop flows touching stale files.
-    stale_ep_ids: Set[str] = set()
-    stale_sink_ids: Set[str] = set()
-
+    #
     # We need the original entry_points/sink_details to know which IDs
     # were removed. But we already filtered those lists above. Instead,
     # collect IDs from the entries we kept and drop flows referencing
@@ -1281,7 +1279,6 @@ def _import_flow_traces(
 
     paths_path = validate_dir / "attack-paths.json"
     existing_paths: List[Dict[str, Any]] = []
-    paths_was_malformed = False
     if paths_path.exists():
         loaded = load_json(paths_path)
         if isinstance(loaded, list):
@@ -1305,7 +1302,6 @@ def _import_flow_traces(
             # sibling so the operator can inspect / recover it,
             # and warn loudly. Then proceed as if paths_path didn't
             # exist (existing_paths stays []).
-            paths_was_malformed = True
             ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
             quarantine = paths_path.with_suffix(
                 paths_path.suffix + f".malformed-{ts}"

--- a/core/project/clean.py
+++ b/core/project/clean.py
@@ -3,7 +3,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 
 def plan_clean(project, keep=1) -> Dict[str, Any]:

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -1165,7 +1165,6 @@ def _do_clean(project, keep, dry_run, yes):
 def _do_merge(project, merge_type, yes):
     """Merge runs per command type."""
     import shutil
-    import time
     from datetime import datetime, timezone
     from .merge import merge_runs
     from core.json import save_json

--- a/core/project/correlate.py
+++ b/core/project/correlate.py
@@ -9,7 +9,7 @@ Output is action-oriented: every section answers "what should I look at next?"
 
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List
 
 from core.json import load_json
 from core.run import load_run_metadata

--- a/core/project/export.py
+++ b/core/project/export.py
@@ -404,9 +404,9 @@ def import_project(zip_path: Path, projects_dir: Path,
     notes = embedded_meta.get("notes", "") if embedded_meta else ""
     created = embedded_meta.get("created") if embedded_meta else None
 
-    project = mgr.create(project_name, target, description=description,
-                         output_dir=str(output_dir), resolve_target=False,
-                         created=created)
+    mgr.create(project_name, target, description=description,
+               output_dir=str(output_dir), resolve_target=False,
+               created=created)
     if notes:
         mgr.update_notes(project_name, notes)
 

--- a/core/project/tests/test_add.py
+++ b/core/project/tests/test_add.py
@@ -78,7 +78,6 @@ class TestAddDirectory(unittest.TestCase):
             run_dir.mkdir()
             (run_dir / "findings.json").write_text("[]")
 
-        runs_parent = Path(self.tmpdir.name)
         # Add all at once — they're in tmpdir alongside projects dir
         # Create a subdirectory with just the runs
         runs = Path(self.tmpdir.name) / "batch"

--- a/core/project/tests/test_add.py
+++ b/core/project/tests/test_add.py
@@ -1,12 +1,11 @@
 """Tests for project add and remove operations."""
 
-import json
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from core.project.project import ProjectManager
-from core.run import RUN_METADATA_FILE, start_run
+from core.run import RUN_METADATA_FILE
 
 
 class TestAddDirectory(unittest.TestCase):

--- a/core/project/tests/test_annotations_cmd.py
+++ b/core/project/tests/test_annotations_cmd.py
@@ -8,7 +8,6 @@ filtered listing.
 
 from __future__ import annotations
 
-import json
 import unittest
 from io import StringIO
 from pathlib import Path

--- a/core/project/tests/test_clean.py
+++ b/core/project/tests/test_clean.py
@@ -1,6 +1,5 @@
 """Tests for project clean — delete old runs, keep latest N."""
 
-import json
 import time
 import unittest
 from pathlib import Path

--- a/core/project/tests/test_cli.py
+++ b/core/project/tests/test_cli.py
@@ -1,7 +1,6 @@
 """Basic smoke tests for the project CLI."""
 
 import os
-import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/core/project/tests/test_cli.py
+++ b/core/project/tests/test_cli.py
@@ -20,7 +20,6 @@ class TestCLI(unittest.TestCase):
     def test_create(self):
         """Create subcommand creates a project file."""
         with TemporaryDirectory() as d:
-            projects_dir = Path(d) / "projects"
             output_dir = Path(d) / "output"
             with patch("core.project.cli.ProjectManager") as MockMgr:
                 instance = MockMgr.return_value

--- a/core/project/tests/test_correlate.py
+++ b/core/project/tests/test_correlate.py
@@ -7,10 +7,8 @@ from unittest import TestCase, mock
 
 from core.project.correlate import (
     INCONCLUSIVE_VERDICTS,
-    LLM_COMMAND_TYPES,
     NEGATIVE_VERDICTS,
     POSITIVE_VERDICTS,
-    SCAN_COMMAND_TYPES,
     correlate_project,
     get_finding_status,
     normalize_verdict,

--- a/core/project/tests/test_export.py
+++ b/core/project/tests/test_export.py
@@ -1,7 +1,5 @@
 """Tests for project export/import with security validation."""
 
-import json
-import os
 import unittest
 import zipfile
 from pathlib import Path

--- a/core/project/tests/test_project.py
+++ b/core/project/tests/test_project.py
@@ -77,7 +77,6 @@ class TestProject(unittest.TestCase):
         """sweep skips runs whose session PID is still alive."""
         from core.run.metadata import RUN_METADATA_FILE
         from core.json import load_json, save_json
-        from unittest.mock import patch
         import os
         with TemporaryDirectory() as d:
             run = Path(d) / "scan-20260401"

--- a/core/reporting/__init__.py
+++ b/core/reporting/__init__.py
@@ -24,3 +24,26 @@ from .findings import (
     findings_summary_line,
     findings_summary,
 )
+
+# Public re-export surface (see module docstring for layering).
+# Order matches the import groups above; both layers are intentionally
+# exposed through the same hub because callers don't care which layer
+# a helper lives in — they only care that it's `core.reporting`.
+__all__ = [
+    # Layer 1 — domain-agnostic report scaffolding
+    "ReportSpec",
+    "ReportSection",
+    "render_report",
+    "render_console_table",
+    "get_display_status",
+    "title_case_type",
+    "truncate_path",
+    "format_elapsed",
+    # Layer 2 — findings-aware helpers
+    "FINDINGS_COLUMNS",
+    "build_findings_spec",
+    "build_findings_rows",
+    "build_findings_summary",
+    "findings_summary_line",
+    "findings_summary",
+]

--- a/core/reporting/renderer.py
+++ b/core/reporting/renderer.py
@@ -2,7 +2,7 @@
 
 from typing import List, Tuple
 
-from .spec import ReportSpec, ReportSection
+from .spec import ReportSpec
 
 
 def render_report(spec: ReportSpec, separator: str = "---") -> str:

--- a/core/run/tests/test_lifecycle_hook.py
+++ b/core/run/tests/test_lifecycle_hook.py
@@ -2,7 +2,6 @@
 
 import importlib.machinery
 import importlib.util
-import json
 import os
 import subprocess
 import sys
@@ -14,7 +13,6 @@ from unittest.mock import patch
 from core.json import load_json, save_json
 from core.run.metadata import (
     RUN_METADATA_FILE, STATUS_RUNNING, STATUS_COMPLETED, STATUS_FAILED,
-    start_run,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[3]  # core/run/tests/ → raptor/

--- a/core/run/tests/test_output.py
+++ b/core/run/tests/test_output.py
@@ -1,7 +1,6 @@
 """Tests for output directory resolution."""
 
 import os
-import time
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/core/sage/scripts/seed_sage_knowledge.py
+++ b/core/sage/scripts/seed_sage_knowledge.py
@@ -46,7 +46,6 @@ def extract_primitives() -> list[dict]:
 
     from packages.exploit_feasibility.primitives import (
         get_primitive_definitions,
-        PrimitiveID,
         MitigationID,
     )
 

--- a/core/sage/tests/test_sage_memory.py
+++ b/core/sage/tests/test_sage_memory.py
@@ -4,7 +4,6 @@
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 
 class TestSageFuzzingMemoryInit(unittest.TestCase):

--- a/core/sage/tests/test_sage_memory.py
+++ b/core/sage/tests/test_sage_memory.py
@@ -31,7 +31,7 @@ class TestSageFuzzingMemoryInit(unittest.TestCase):
             mem_file = Path(tmpdir) / "subdir" / "memory.json"
             config = SageConfig(enabled=False)
 
-            memory = SageFuzzingMemory(memory_file=mem_file, sage_config=config)
+            SageFuzzingMemory(memory_file=mem_file, sage_config=config)
             self.assertTrue(mem_file.parent.exists())
 
 

--- a/core/sandbox/__init__.py
+++ b/core/sandbox/__init__.py
@@ -522,7 +522,16 @@ __all__ = [
     # Availability probes (exposed for the startup banner)
     "check_sandbox_available", "check_net_available",
     "check_mount_available", "check_landlock_available",
+    "check_seatbelt_available",
     "check_seccomp_available",
     # Named profiles
-    "PROFILES", "DEFAULT_PROFILE",
+    "PROFILES", "DEFAULT_PROFILE", "_SANDBOX_KWARGS",
+    # Private re-exports kept for backward compatibility — see the
+    # block comment above; tests + a few internal callers reach into
+    # these names directly so the public name stays stable.
+    "_get_landlock_abi",
+    "_BLOCKED_PATTERNS", "_check_blocked", "_interpret_result", "_path_within",
+    "OBSERVE_FILENAME", "ConnectTarget", "ObserveProfile", "parse_observe_log",
+    "_DEFAULT_LIMITS", "_load_user_limits", "_make_preexec_fn",
+    "_build_mount_script",
 ]

--- a/core/sandbox/_macos_spawn.py
+++ b/core/sandbox/_macos_spawn.py
@@ -94,8 +94,6 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
-import sys
-import threading
 from pathlib import Path
 from typing import Iterable, List, Optional
 

--- a/core/sandbox/calibrate.py
+++ b/core/sandbox/calibrate.py
@@ -49,7 +49,6 @@ import hashlib
 import json
 import logging
 import os
-import shutil
 import tempfile
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -246,7 +245,7 @@ def _spawn_probe(
     # unit tests via mocked spawn).
     from core.sandbox import run as sandbox_run
     from core.sandbox.observe_profile import (
-        OBSERVE_FILENAME, parse_observe_log,
+        parse_observe_log,
     )
 
     with tempfile.TemporaryDirectory(prefix="raptor-calibrate-") as scratch:

--- a/core/sandbox/calibrate_cli.py
+++ b/core/sandbox/calibrate_cli.py
@@ -28,7 +28,6 @@ modes:
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 from pathlib import Path
 from typing import Optional, Sequence

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -1502,7 +1502,6 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                             # — held for microseconds.
                             _resolved_cmd0 = (shutil.which(cmd[0])
                                               or cmd[0])
-                            import threading as _threading
                             with state._cache_lock:
                                 _first_seen = (
                                     _resolved_cmd0

--- a/core/sandbox/landlock.py
+++ b/core/sandbox/landlock.py
@@ -316,12 +316,15 @@ def _make_landlock_preexec(writable_paths: list, allowed_tcp_ports: list = None,
     # — reads were never restricted (READ_FILE was miscoded as EXECUTE)
     # and MAKE_SYM was never restricted (shifted off the end of the
     # write mask). Verified against the uapi header on kernel 6.x.
-    EXECUTE = 1 << 0
+    # EXECUTE, REMOVE_DIR, REMOVE_FILE retained as comments to document
+    # the bit positions even though we don't restrict them (see note
+    # below about unshare and importlib needing remove ops).
+    EXECUTE = 1 << 0  # noqa: F841 — kernel-ABI doc, not used
     WRITE_FILE = 1 << 1
     READ_FILE = 1 << 2
     READ_DIR = 1 << 3
-    REMOVE_DIR = 1 << 4
-    REMOVE_FILE = 1 << 5
+    REMOVE_DIR = 1 << 4  # noqa: F841 — kernel-ABI doc, not used
+    REMOVE_FILE = 1 << 5  # noqa: F841 — kernel-ABI doc, not used
     MAKE_CHAR = 1 << 6
     MAKE_DIR = 1 << 7
     MAKE_REG = 1 << 8

--- a/core/sandbox/observe_cli.py
+++ b/core/sandbox/observe_cli.py
@@ -35,10 +35,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 import tempfile
-from dataclasses import asdict
 from pathlib import Path
 from typing import Optional, Sequence
 

--- a/core/sandbox/observe_context_merge.py
+++ b/core/sandbox/observe_context_merge.py
@@ -35,7 +35,6 @@ Used by:
 from __future__ import annotations
 
 import datetime
-import os
 from copy import deepcopy
 from typing import Iterable, Optional
 

--- a/core/sandbox/tests/test_audit_cli_flags.py
+++ b/core/sandbox/tests/test_audit_cli_flags.py
@@ -249,7 +249,6 @@ class TestSandboxAuditKwarg:
     def test_audit_kwarg_engages_audit_mode(self, monkeypatch, tmp_path):
         # No CLI flag, but per-call audit=True. Should still engage.
         from core.sandbox import probes
-        from core.sandbox import ptrace_probe
         from core.sandbox import proxy as proxy_mod
         from core.sandbox.context import sandbox
 

--- a/core/sandbox/tests/test_audit_cli_flags.py
+++ b/core/sandbox/tests/test_audit_cli_flags.py
@@ -264,7 +264,7 @@ class TestSandboxAuditKwarg:
                 audit=True,
                 use_egress_proxy=True,
                 proxy_hosts=["api.example.com"],
-            ) as run:
+            ):
                 # Audit engaged via per-call kwarg → proxy acquired.
                 assert proxy_inst._audit_count == 1
             assert proxy_inst._audit_count == 0

--- a/core/sandbox/tests/test_audit_failure_modes.py
+++ b/core/sandbox/tests/test_audit_failure_modes.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 import json
 import os
 import platform
-import sys
-import time
 from pathlib import Path
 
 import pytest

--- a/core/sandbox/tests/test_audit_failure_modes.py
+++ b/core/sandbox/tests/test_audit_failure_modes.py
@@ -602,7 +602,7 @@ class TestAuditMissingOutputBehaviour:
         # Ref-count observation tests construct sandbox without
         # calling run() — must keep working.
         from core.sandbox.context import sandbox
-        with sandbox(audit=True) as run:
+        with sandbox(audit=True):
             pass
 
     def test_audit_kwarg_with_output_run_succeeds_validation(self, tmp_path):
@@ -853,10 +853,6 @@ class TestAuditAcquireOrdering:
             i for i, line in enumerate(lines)
             if line.strip() == "yield run"
         ]
-        try_lines = [
-            i for i, line in enumerate(lines)
-            if line.strip() == "try:"
-        ]
         finally_lines = [
             i for i, line in enumerate(lines)
             if line.strip() == "finally:"
@@ -1009,7 +1005,7 @@ class TestAuditWithExistingSandboxFlows:
                 audit=True, disabled=True,
                 use_egress_proxy=True,
                 proxy_hosts=["api.example.com"],
-            ) as run:
+            ):
                 # disabled=True wins; audit silently no-ops; no acquire.
                 assert proxy_inst._audit_count == 0, (
                     f"audit-mode wrongly engaged with disabled=True: "
@@ -1030,7 +1026,7 @@ class TestAuditWithExistingSandboxFlows:
                 audit=True, profile="none",
                 use_egress_proxy=True,
                 proxy_hosts=["api.example.com"],
-            ) as run:
+            ):
                 assert proxy_inst._audit_count == 0
             assert proxy_inst._audit_count == 0
         finally:
@@ -1046,7 +1042,7 @@ class TestAuditWithExistingSandboxFlows:
             proxy_inst = proxy_mod.get_proxy(["api.example.com"])
             assert proxy_inst._audit_count == 0
 
-            with sandbox(audit=True, use_egress_proxy=False) as run:
+            with sandbox(audit=True, use_egress_proxy=False):
                 # Proxy not engaged by THIS sandbox; count unchanged.
                 assert proxy_inst._audit_count == 0
 
@@ -1071,7 +1067,7 @@ class TestProxyAuditAcquireReleaseIntegration:
                 audit=True,
                 use_egress_proxy=True,
                 proxy_hosts=["api.example.com"],
-            ) as run:
+            ):
                 assert proxy_inst._audit_count == 1
                 assert proxy_inst._audit_log_only is True
 
@@ -1090,7 +1086,7 @@ class TestProxyAuditAcquireReleaseIntegration:
                     audit=True,
                     use_egress_proxy=True,
                     proxy_hosts=["api.example.com"],
-                ) as run:
+                ):
                     assert proxy_inst._audit_count == 1
                     raise RuntimeError("simulated workflow failure")
 

--- a/core/sandbox/tests/test_audit_filter.py
+++ b/core/sandbox/tests/test_audit_filter.py
@@ -9,11 +9,9 @@ count differs in the expected direction.
 
 from __future__ import annotations
 
-import json
 import os
 import platform
 from pathlib import Path
-from unittest import mock
 
 import pytest
 
@@ -382,7 +380,6 @@ class TestAtFdcwdValue:
     available (skip otherwise)."""
 
     def test_at_fdcwd_matches_uapi_header(self):
-        import os
         import re
         import pytest
         candidate_paths = [
@@ -570,7 +567,6 @@ class TestTracerArgvContract:
     def test_argv_count_matches_documented_usage(self):
         # Module docstring + _cli_main docstring both document the
         # CLI shape. Keep them in sync with the actual implementation.
-        import inspect
         from core.sandbox import tracer
 
         # _cli_main's argument count matches what the module
@@ -671,7 +667,6 @@ class TestConftestSnapshotMatchesState:
     }
 
     def test_every_state_var_is_snapshotted_or_excluded(self):
-        import inspect
         import re
         from core.sandbox import state
         # Pull the snapshot list literal from conftest source.
@@ -1117,7 +1112,6 @@ class TestDecodeSockaddr:
 
     def test_decode_af_inet(self):
         import ctypes
-        import socket
         # Build a sockaddr_in: family=2 (AF_INET), port=443, addr=1.2.3.4
         # struct sockaddr_in: family (2), port (2 BE), addr (4)
         buf = bytes([2, 0]) + (443).to_bytes(2, "big") + bytes([1, 2, 3, 4])

--- a/core/sandbox/tests/test_audit_propagation.py
+++ b/core/sandbox/tests/test_audit_propagation.py
@@ -25,10 +25,8 @@ Why source-grep over functional spawn:
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
-import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -106,7 +104,6 @@ class TestCodeqlAgentRegistersSandboxArgs:
         # Catches the case where someone removes the import but leaves
         # the rest of the wiring (the source-grep tests above would
         # still pass on a half-edit).
-        import importlib
         import sys
         agent_path = REPO_ROOT / "packages" / "codeql" / "agent.py"
         # Use subprocess to avoid main()'s sys.exit / global state.

--- a/core/sandbox/tests/test_calibrate.py
+++ b/core/sandbox/tests/test_calibrate.py
@@ -17,11 +17,8 @@ Three layers:
 
 from __future__ import annotations
 
-import json
-import os
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/core/sandbox/tests/test_calibrate_cli.py
+++ b/core/sandbox/tests/test_calibrate_cli.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import io
 import json
 import os
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/core/sandbox/tests/test_context_backend_dispatch.py
+++ b/core/sandbox/tests/test_context_backend_dispatch.py
@@ -154,7 +154,6 @@ def test_use_seatbelt_does_not_depend_on_check_net_available(reset_caches):
     via check_seatbelt_available() on Darwin. This test asserts
     that with seatbelt available + net unavailable (the actual
     macOS state), the seatbelt backend IS used."""
-    fake_macos = mock.MagicMock()
     fake_macos_result = mock.MagicMock()
     fake_macos_result.returncode = 0
     fake_macos_result.stderr = b""

--- a/core/sandbox/tests/test_e2e_sandbox.py
+++ b/core/sandbox/tests/test_e2e_sandbox.py
@@ -164,7 +164,7 @@ class TestE2ELandlockWriteBlocking(unittest.TestCase):
             # Create a symlink inside output pointing to /var/tmp
             evil_link = Path(output) / "escape"
             evil_link.symlink_to("/var/tmp")
-            result = sandbox_run(
+            sandbox_run(
                 ["sh", "-c", f"echo pwned > {output}/escape/raptor_test 2>&1"],
                 target=target, output=output,
                 capture_output=True, text=True, timeout=5,
@@ -182,7 +182,7 @@ class TestE2ELandlockWriteBlocking(unittest.TestCase):
         with TemporaryDirectory() as target, TemporaryDirectory() as output:
             victim = Path(output) / "source.txt"
             victim.write_text("hello")
-            result = sandbox_run(
+            sandbox_run(
                 ["sh", "-c", f"mv {output}/source.txt {sentinel} 2>&1"],
                 target=target, output=output,
                 capture_output=True, text=True, timeout=5,
@@ -346,7 +346,7 @@ class TestE2EResourceLimits(unittest.TestCase):
     def test_file_size_limit(self):
         """File size limit prevents large writes."""
         with TemporaryDirectory() as d:
-            result = sandbox_run(
+            sandbox_run(
                 ["python3", "-c",
                  f"f=open('{d}/big','wb'); f.write(b'A'*200*1024*1024); f.close()"],
                 block_network=True,

--- a/core/sandbox/tests/test_e2e_sandbox.py
+++ b/core/sandbox/tests/test_e2e_sandbox.py
@@ -15,7 +15,6 @@ pytestmark = _pytest.mark.skipif(
 
 
 import os
-import platform
 import subprocess
 import unittest
 from pathlib import Path
@@ -999,7 +998,7 @@ class TestE2EEgressProxy(unittest.TestCase):
         or cursor-movement to overwrite prior lines with forged "allowed"
         entries. The proxy rejects these at CONNECT-parse time.
         """
-        import socket as _socket, time as _time, threading
+        import socket as _socket
         from core.sandbox.proxy import get_proxy, _reset_for_tests
         try:
             _reset_for_tests()
@@ -1452,7 +1451,6 @@ class TestE2ELandlockReadRestriction(unittest.TestCase):
         (restrict_reads blocks them even by absolute path), and tools
         expanding `~` land inside the fake home.
         """
-        import os as _os
         from core.sandbox import run_untrusted
         restricted_file = Path.home() / ".raptor_fake_home_regression.txt"
         restricted_file.write_text("REAL-HOME-SECRET\n")
@@ -1493,7 +1491,6 @@ class TestE2ELandlockReadRestriction(unittest.TestCase):
     def test_fake_home_requires_output(self):
         """fake_home=True without output= is a config error — raise
         rather than silently skipping the feature."""
-        from core.sandbox import sandbox
         with self.assertRaises(ValueError) as cm:
             with sandbox(fake_home=True):
                 pass

--- a/core/sandbox/tests/test_macos_spawn.py
+++ b/core/sandbox/tests/test_macos_spawn.py
@@ -14,11 +14,8 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
 import sys
-import tempfile
 import time
-from pathlib import Path
 
 import pytest
 

--- a/core/sandbox/tests/test_observe_budget.py
+++ b/core/sandbox/tests/test_observe_budget.py
@@ -26,7 +26,6 @@ import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest.mock import patch
 
 import pytest
 

--- a/core/sandbox/tests/test_observe_cli.py
+++ b/core/sandbox/tests/test_observe_cli.py
@@ -75,7 +75,7 @@ class TestArgparse:
         # by saying observe log doesn't exist.
         with patch("core.sandbox.run", side_effect=fake_run), \
              patch("core.sandbox.parse_observe_log") as _parse:
-            rc = _cli_main(["--", "/usr/bin/true", "x"])
+            _cli_main(["--", "/usr/bin/true", "x"])
         # The spawn failed (no observe log), so rc is _SOFTWARE_EX.
         assert seen_cmd == [["/usr/bin/true", "x"]]
 

--- a/core/sandbox/tests/test_observe_cli.py
+++ b/core/sandbox/tests/test_observe_cli.py
@@ -14,14 +14,12 @@ import json
 import os
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from core.sandbox.observe_cli import (
-    _build_parser,
     _cli_main,
     _format_summary,
     _profile_to_json,
@@ -72,7 +70,6 @@ class TestArgparse:
 
         # Monkeypatch sandbox import path. Lazy-imported, so we patch
         # at the module level.
-        from core.sandbox import observe_cli as mod
         # Force the parser to consume "--" then the cmd.
         # We won't actually spawn — fake_run + abort via early return
         # by saying observe log doesn't exist.
@@ -176,7 +173,6 @@ class TestCliDispatch:
 
     def _run_with_stubs(self, argv, *, profile, return_code,
                         observe_log_exists=True):
-        from core.sandbox import observe_cli as mod
 
         class _Result:
             def __init__(self, rc): self.returncode = rc
@@ -271,7 +267,6 @@ class TestCliDispatch:
         every downstream `jq` invocation."""
         seen = {}
 
-        from core.sandbox import observe_cli as mod
 
         class _Result:
             def __init__(self): self.returncode = 0

--- a/core/sandbox/tests/test_observe_concurrency.py
+++ b/core/sandbox/tests/test_observe_concurrency.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import json
 import sys
-import threading
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/core/sandbox/tests/test_observe_context_merge.py
+++ b/core/sandbox/tests/test_observe_context_merge.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import json
 from copy import deepcopy
 
-import pytest
 
 from core.sandbox.observe_context_merge import (
     RUNTIME_OBSERVATION_KEY,

--- a/core/sandbox/tests/test_observe_namespaces.py
+++ b/core/sandbox/tests/test_observe_namespaces.py
@@ -22,7 +22,6 @@ All tests are Linux-only and skip when the relevant prerequisite
 
 from __future__ import annotations
 
-import os
 import sys
 import unittest
 from pathlib import Path
@@ -255,7 +254,6 @@ class TestObserveMultiProcess(unittest.TestCase):
 
     def test_child_processes_traced_too(self):
         from core.sandbox import run as sandbox_run
-        from core.sandbox.observe_profile import parse_observe_log
 
         # bash → /usr/bin/true && /usr/bin/cat </dev/null. cat opens
         # /dev/null; true opens nothing extra. Both load libc + ld.so

--- a/core/sandbox/tests/test_sandbox.py
+++ b/core/sandbox/tests/test_sandbox.py
@@ -1655,7 +1655,7 @@ class TestToolPathsKwarg(unittest.TestCase):
 
     def test_tool_paths_accepted_by_sandbox(self):
         from core.sandbox import sandbox
-        with sandbox(tool_paths=["/opt/foo/bin"]) as run:
+        with sandbox(tool_paths=["/opt/foo/bin"]):
             pass
 
     def test_tool_paths_accepted_by_top_level_run(self):

--- a/core/sandbox/tests/test_sandbox.py
+++ b/core/sandbox/tests/test_sandbox.py
@@ -29,7 +29,7 @@ class TestAvailabilityCheck(unittest.TestCase):
 
     def test_cached(self):
         """Second call returns same result without re-testing."""
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        from core.sandbox import state as mod_state
         mod_state._net_available_cache = None
         first = check_sandbox_available()
         second = check_sandbox_available()
@@ -44,7 +44,7 @@ class TestAvailabilityCheck(unittest.TestCase):
         exactly the system where PATH-hijack matters). check_net_available
         catches the exception and returns False.
         """
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        from core.sandbox import state as mod_state
         mod_state._net_available_cache = None
         mod_state._unshare_path_cache = None
         with patch("os.path.isfile", return_value=False):
@@ -998,7 +998,7 @@ class TestSanitizerStderrBytes(unittest.TestCase):
         stderr was bytes, losing all enforcement detection while
         _interpret_result (sibling call) still decoded correctly.
         """
-        import subprocess, tempfile
+        import tempfile
         from core.sandbox import sandbox
         # Use a sandbox with Landlock engaged and a write to a non-writable
         # path so Landlock produces "Permission denied" stderr in bytes.
@@ -1177,7 +1177,7 @@ class TestCacheLockReentrant(unittest.TestCase):
     """check_mount_available nests a call to check_net_available — must not deadlock."""
 
     def test_nested_check_does_not_deadlock(self):
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        from core.sandbox import state as mod_state
         mod_state._net_available_cache = None
         mod_state._mount_available_cache = None
         # Should return without hanging
@@ -1288,12 +1288,12 @@ class TestCliProfile(unittest.TestCase):
     """--sandbox <profile> / --no-sandbox CLI surface."""
 
     def setUp(self):
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        from core.sandbox import state as mod_state
         self._saved_disabled = mod_state._cli_sandbox_disabled
         self._saved_profile = mod_state._cli_sandbox_profile
 
     def tearDown(self):
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        from core.sandbox import state as mod_state
         mod_state._cli_sandbox_disabled = self._saved_disabled
         mod_state._cli_sandbox_profile = self._saved_profile
 
@@ -1305,7 +1305,7 @@ class TestCliProfile(unittest.TestCase):
     def test_set_cli_profile_none_also_disables(self):
         """profile='none' must set both _cli_sandbox_profile and _cli_sandbox_disabled
         so existing disabled-checks continue to work."""
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        from core.sandbox import state as mod_state
         from core.sandbox import set_cli_profile
         set_cli_profile("none")
         self.assertEqual(mod_state._cli_sandbox_profile, "none")
@@ -1313,7 +1313,7 @@ class TestCliProfile(unittest.TestCase):
 
     def test_set_cli_profile_switches_coherently(self):
         """Switching profile='none' → 'full' must un-stick the disabled flag."""
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        from core.sandbox import state as mod_state
         from core.sandbox import set_cli_profile
         set_cli_profile("none")
         self.assertTrue(mod_state._cli_sandbox_disabled)
@@ -1324,7 +1324,7 @@ class TestCliProfile(unittest.TestCase):
     def test_disable_from_cli_coherent_after_profile_full(self):
         """disable_from_cli() after set_cli_profile('full') must disable — it
         used to leave _cli_sandbox_profile='full' and silently win."""
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        from core.sandbox import state as mod_state
         from core.sandbox import set_cli_profile, disable_from_cli
         set_cli_profile("full")
         self.assertEqual(mod_state._cli_sandbox_profile, "full")
@@ -1381,7 +1381,7 @@ class TestCliProfile(unittest.TestCase):
     def test_apply_cli_args_no_sandbox_alone(self):
         """--no-sandbox sets BOTH flags coherently via shared _set_cli_state."""
         import argparse
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        from core.sandbox import state as mod_state
         from core.sandbox import add_cli_args, apply_cli_args
         parser = argparse.ArgumentParser()
         add_cli_args(parser)
@@ -1393,7 +1393,7 @@ class TestCliProfile(unittest.TestCase):
     def test_apply_cli_args_sandbox_network_only(self):
         """--sandbox network-only sets profile, does NOT set disabled."""
         import argparse
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        from core.sandbox import state as mod_state
         from core.sandbox import add_cli_args, apply_cli_args
         parser = argparse.ArgumentParser()
         add_cli_args(parser)
@@ -1404,7 +1404,7 @@ class TestCliProfile(unittest.TestCase):
 
     def test_apply_cli_args_noop_when_neither_flag(self):
         import argparse
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        from core.sandbox import state as mod_state
         from core.sandbox import add_cli_args, apply_cli_args
         parser = argparse.ArgumentParser()
         add_cli_args(parser)
@@ -1426,19 +1426,19 @@ class TestLandlockDegradationWarnings(unittest.TestCase):
 
     def setUp(self):
         # Reset the once-per-process warning flags so each test starts clean.
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        from core.sandbox import state as mod_state
         self._saved_unav = mod_state._landlock_warned_unavailable
         self._saved_abi = mod_state._landlock_warned_abi_v4
         mod_state._landlock_warned_unavailable = False
         mod_state._landlock_warned_abi_v4 = False
 
     def tearDown(self):
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        from core.sandbox import state as mod_state
         mod_state._landlock_warned_unavailable = self._saved_unav
         mod_state._landlock_warned_abi_v4 = self._saved_abi
 
     def test_warns_when_landlock_unavailable_but_target_set(self):
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        import core.sandbox as mod; 
         from unittest.mock import patch
         with TemporaryDirectory() as d:
             # Force check_landlock_available → False regardless of host kernel.
@@ -1452,7 +1452,7 @@ class TestLandlockDegradationWarnings(unittest.TestCase):
         self.assertTrue(any("Landlock is unavailable" in m for m in cm.output))
 
     def test_warns_when_tcp_allowlist_on_abi_lt_4(self):
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        import core.sandbox as mod; 
         from unittest.mock import patch
         # Simulate ABI v3 kernel: Landlock available for fs, not for net.
         with patch.object(mod.landlock, "check_landlock_available", return_value=True):
@@ -1465,7 +1465,7 @@ class TestLandlockDegradationWarnings(unittest.TestCase):
 
     def test_degradation_warning_throttled(self):
         """Opening many sandbox contexts on a degraded kernel warns ONCE."""
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        import core.sandbox as mod; 
         from unittest.mock import patch
         with TemporaryDirectory() as d:
             with patch.object(mod.landlock, "check_landlock_available", return_value=False), \
@@ -1481,7 +1481,7 @@ class TestLandlockDegradationWarnings(unittest.TestCase):
     def test_warns_on_old_landlock_abi_v2(self):
         """Pre-5.19 kernels lack REFER — rename-across-dirs isn't blocked.
         Operator should see a WARNING so the gap is visible."""
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        import core.sandbox as mod; 
         with patch.object(mod.landlock, "check_landlock_available", return_value=True):
             with patch.object(mod.landlock, "_get_landlock_abi", return_value=1):
                 with patch.object(mod.probes, "check_mount_available", return_value=False):
@@ -1495,7 +1495,7 @@ class TestLandlockDegradationWarnings(unittest.TestCase):
 
     def test_warns_on_old_landlock_abi_v3_only(self):
         """Pre-6.2 kernels lack TRUNCATE but have REFER (ABI 2)."""
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        import core.sandbox as mod; 
         with patch.object(mod.landlock, "check_landlock_available", return_value=True):
             with patch.object(mod.landlock, "_get_landlock_abi", return_value=2):
                 with patch.object(mod.probes, "check_mount_available", return_value=False):
@@ -1518,7 +1518,7 @@ class TestLandlockDegradationWarnings(unittest.TestCase):
 
     def test_no_warning_on_abi_v4_with_tcp_allowlist(self):
         """On ABI v4+, allowed_tcp_ports is enforceable — no degradation warning."""
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        import core.sandbox as mod; 
         from unittest.mock import patch
         with patch.object(mod.landlock, "check_landlock_available", return_value=True):
             with patch.object(mod.landlock, "_get_landlock_abi", return_value=4):
@@ -1537,19 +1537,19 @@ class TestCliProfileAuthoritative(unittest.TestCase):
     """CLI --sandbox must override library-level disabled=True."""
 
     def setUp(self):
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        from core.sandbox import state as mod_state
         self._saved_disabled = mod_state._cli_sandbox_disabled
         self._saved_profile = mod_state._cli_sandbox_profile
 
     def tearDown(self):
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        from core.sandbox import state as mod_state
         mod_state._cli_sandbox_disabled = self._saved_disabled
         mod_state._cli_sandbox_profile = self._saved_profile
 
     def test_cli_full_beats_library_disabled(self):
         """User passed --sandbox full; library code passes disabled=True.
         CLI must win — sandbox should actually run."""
-        import core.sandbox as mod; from core.sandbox import state as mod_state
+        from core.sandbox import state as mod_state
         from core.sandbox import set_cli_profile
         set_cli_profile("full")
         # With disabled=True + CLI='full', we expect CLI to override —

--- a/core/sandbox/tests/test_sandbox_attack_scenarios.py
+++ b/core/sandbox/tests/test_sandbox_attack_scenarios.py
@@ -11,7 +11,6 @@ import os
 import shutil
 import socket
 import subprocess
-import tempfile
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/core/sandbox/tests/test_sandbox_attack_scenarios.py
+++ b/core/sandbox/tests/test_sandbox_attack_scenarios.py
@@ -962,7 +962,7 @@ class TestProxyIsGlobalScreen(unittest.TestCase):
             output=self.tmp.name, caller_label="is-global-test",
         ) as run:
             # Any CONNECT through the proxy to localhost forces the is_global path
-            r = run(
+            run(
                 ["curl", "-s", "-o", "/dev/null", "--max-time", "2",
                  "https://localhost/"],
                 capture_output=True, text=True, timeout=8,

--- a/core/sandbox/tests/test_seatbelt.py
+++ b/core/sandbox/tests/test_seatbelt.py
@@ -16,7 +16,6 @@ Coverage focus matches the spike-validated facts in seatbelt.py:
 from __future__ import annotations
 
 import os
-import tempfile
 
 from core.sandbox import seatbelt
 

--- a/core/sandbox/tests/test_seatbelt_audit_parse.py
+++ b/core/sandbox/tests/test_seatbelt_audit_parse.py
@@ -13,7 +13,6 @@ real kernel output, not invented.
 from __future__ import annotations
 
 import json
-import os
 
 from core.sandbox import seatbelt_audit
 from core.sandbox.seatbelt import SANDBOX_KEXT_SENDER
@@ -214,7 +213,7 @@ def test_log_streamer_uses_injected_budget_for_summary(tmp_path):
 def test_log_streamer_default_budget_is_cli_aware(tmp_path):
     """LogStreamer with no explicit budget pulls one from
     audit_budget.from_cli_state() — picks up --audit-budget."""
-    from core.sandbox import state, audit_budget
+    from core.sandbox import state
     state._cli_sandbox_audit_budget = 250
     try:
         streamer = seatbelt_audit.LogStreamer(tmp_path)

--- a/core/sandbox/tests/test_seatbelt_audit_warmup.py
+++ b/core/sandbox/tests/test_seatbelt_audit_warmup.py
@@ -15,11 +15,8 @@ from __future__ import annotations
 
 import io
 import json
-import subprocess
-import threading
 from unittest import mock
 
-import pytest
 
 from core.sandbox import seatbelt_audit
 from core.sandbox.seatbelt import SANDBOX_KEXT_SENDER

--- a/core/sandbox/tests/test_seatbelt_observe.py
+++ b/core/sandbox/tests/test_seatbelt_observe.py
@@ -48,7 +48,6 @@ from __future__ import annotations
 
 import json
 import sys
-from pathlib import Path
 
 import pytest
 

--- a/core/sandbox/tests/test_spawn_audit.py
+++ b/core/sandbox/tests/test_spawn_audit.py
@@ -27,10 +27,7 @@ import json
 import os
 import platform
 import signal
-import subprocess
-import sys
 import time
-from pathlib import Path
 
 import pytest
 

--- a/core/sandbox/tests/test_spawn_mount_ns.py
+++ b/core/sandbox/tests/test_spawn_mount_ns.py
@@ -210,7 +210,6 @@ class TestRunSandboxedSmokeTest(unittest.TestCase):
         mount_ns_flake.md). Fix: per-run path tracking via
         monkey-patch.
         """
-        from core.sandbox import _spawn
         from core.sandbox._spawn import run_sandboxed
         captured_stubs = []
         # _spawn.run_sandboxed imports tempfile internally as _tempfile.

--- a/core/sandbox/tests/test_spawn_mount_ns.py
+++ b/core/sandbox/tests/test_spawn_mount_ns.py
@@ -213,8 +213,6 @@ class TestRunSandboxedSmokeTest(unittest.TestCase):
         from core.sandbox import _spawn
         from core.sandbox._spawn import run_sandboxed
         captured_stubs = []
-        original_mkdtemp = _spawn._tempfile.mkdtemp \
-            if hasattr(_spawn, '_tempfile') else None
         # _spawn.run_sandboxed imports tempfile internally as _tempfile.
         # Monkey-patch the module-level tempfile.mkdtemp to record the
         # stub path before passing through.

--- a/core/sandbox/tests/test_tracer.py
+++ b/core/sandbox/tests/test_tracer.py
@@ -25,7 +25,6 @@ import struct
 import subprocess
 import sys
 import time
-from pathlib import Path
 
 import pytest
 

--- a/core/sandbox/tests/test_tracer_event_loop.py
+++ b/core/sandbox/tests/test_tracer_event_loop.py
@@ -29,7 +29,6 @@ pytestmark = _pytest.mark.skipif(
 
 import platform
 import signal
-import struct
 from pathlib import Path
 
 import pytest

--- a/core/sandbox/tests/test_understand_probe_e2e.py
+++ b/core/sandbox/tests/test_understand_probe_e2e.py
@@ -59,7 +59,7 @@ class TestUnderstandProbeFlowE2E(unittest.TestCase):
     def test_full_probe_flow_correlates_entry_points(self):
         from core.sandbox import run as sandbox_run
         from core.sandbox.observe_profile import (
-            OBSERVE_FILENAME, parse_observe_log,
+            parse_observe_log,
         )
         from core.sandbox.observe_context_merge import (
             RUNTIME_OBSERVATION_KEY,

--- a/core/sandbox/tracer.py
+++ b/core/sandbox/tracer.py
@@ -1190,7 +1190,6 @@ def trace(target_pid: int, run_dir: Path,
 
     _signal_ready(sync_fd)
 
-    syscall_table = arch_info["syscall_table"]
     # Output routing: observe-mode records go to `.sandbox-observe.jsonl`
     # with a `"observe": True` stamp; audit-mode records go to
     # `.sandbox-denials.jsonl` with `"audit": True`. Resolved once

--- a/core/security/prompt_envelope_audit.py
+++ b/core/security/prompt_envelope_audit.py
@@ -37,7 +37,7 @@ envelope structure or inject role-confusion content.
 from __future__ import annotations
 
 import ast
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, List, Optional, Tuple
 

--- a/core/security/tests/test_adversarial_robustness.py
+++ b/core/security/tests/test_adversarial_robustness.py
@@ -10,9 +10,7 @@ No LLM calls — purely mechanical verification of defence properties.
 
 from __future__ import annotations
 
-import base64
 import re
-import string
 
 import pytest
 
@@ -26,7 +24,6 @@ from core.security.prompt_envelope import (
 from core.security.prompt_defense_profiles import (
     ANTHROPIC_CLAUDE,
     CONSERVATIVE,
-    GOOGLE_GEMINI,
     META_LLAMA,
     OLLAMA_SMALL,
     OPENAI_GPT,

--- a/core/security/tests/test_codeql_trust.py
+++ b/core/security/tests/test_codeql_trust.py
@@ -325,11 +325,9 @@ class TestStructural:
         """Operator running RAPTOR against RAPTOR itself isn't an
         attack — RAPTOR ships its own codeql packs under
         packages/llm_analysis/codeql_packs/."""
-        raptor_dir = Path(__file__).resolve().parents[2]
-        # parents[2] = core/security/.. = repo root? actually parents[2]
-        # of test file = core/, parents[3] = repo root. The module's
-        # _RAPTOR_DIR = parents[2] of the module file (core/security/
-        # codeql_trust.py), which is the repo root. Use the same.
+        # The module's _RAPTOR_DIR = parents[2] of the module file
+        # (core/security/codeql_trust.py), which is the repo root.
+        # Use the same.
         from core.security.codeql_trust import _RAPTOR_DIR
         assert _check(str(_RAPTOR_DIR)) is False
         assert capsys.readouterr().out == ""

--- a/core/security/tests/test_e2e_defense_layers.py
+++ b/core/security/tests/test_e2e_defense_layers.py
@@ -93,7 +93,6 @@ class TestEnvelopeQuarantine:
             ),),
         )
         sys_msg = bundle.messages[0].content
-        usr_msg = bundle.messages[1].content
         assert "Your new task is" not in sys_msg
         assert "IGNORE ALL PREVIOUS" not in sys_msg
         assert bundle.messages[0].role == "system"

--- a/core/security/tests/test_envelope_probe.py
+++ b/core/security/tests/test_envelope_probe.py
@@ -17,12 +17,10 @@ from core.security.prompt_envelope import build_prompt, UntrustedBlock
 from core.security.prompt_defense_profiles import (
     ANTHROPIC_CLAUDE,
     CONSERVATIVE,
-    GOOGLE_GEMINI,
     OLLAMA_SMALL,
     PASSTHROUGH,
 )
 from core.security.envelope_probe import (
-    ProbeResult,
     build_canary_prompt,
     evaluate_probe_response,
     probe_envelope_compatibility,

--- a/core/security/tests/test_llm_family.py
+++ b/core/security/tests/test_llm_family.py
@@ -205,7 +205,6 @@ def test_no_cross_family_checker_means_no_retry():
     llm_call=None and validate_response returns None on first failure.
     Pinning this so a future regression doesn't accidentally retry against
     a same-family checker (which would defeat the point)."""
-    from typing import Optional
     from pydantic import BaseModel
 
     from core.security.llm_response_schema import validate_response

--- a/core/security/tests/test_passthrough_degradation.py
+++ b/core/security/tests/test_passthrough_degradation.py
@@ -9,7 +9,6 @@ or base64 that confuse the model. Saves tokens, avoids confusion.
 
 from __future__ import annotations
 
-import re
 
 import pytest
 

--- a/core/security/tests/test_prompt_envelope.py
+++ b/core/security/tests/test_prompt_envelope.py
@@ -9,9 +9,7 @@ import re
 import pytest
 
 from core.security.prompt_envelope import (
-    MessagePart,
     ModelDefenseProfile,
-    PromptBundle,
     TaintedString,
     UntrustedBlock,
     build_prompt,
@@ -670,7 +668,6 @@ class TestPreflightWiring:
     def test_preflight_called_during_dispatch(self):
         """preflight() is imported and called in the dispatch loop."""
         import importlib
-        import packages.llm_analysis.dispatch as dispatch_mod
         source = importlib.util.find_spec("packages.llm_analysis.dispatch")
         text = open(source.origin).read()
         assert "from core.security.prompt_input_preflight import preflight" in text

--- a/core/security/tests/test_prompt_input_preflight.py
+++ b/core/security/tests/test_prompt_input_preflight.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from core.security.prompt_input_preflight import (
-    PreflightResult,
     loaded_corpora,
     preflight,
 )

--- a/core/security/tests/test_security_mitigations.py
+++ b/core/security/tests/test_security_mitigations.py
@@ -1,12 +1,10 @@
 """Tests for Claude Code settings-based attack mitigations."""
 
-import json
 import os
 import sys
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 
 # core/security/tests/test_security_mitigations.py -> repo root
 sys.path.insert(0, str(Path(__file__).parents[3]))
@@ -163,7 +161,6 @@ class TestRepoDefault:
 
     def test_env_var_used_as_default(self, tmp_path):
         """argparse picks up RAPTOR_CALLER_DIR when --repo not specified."""
-        import argparse
         with patch.dict(os.environ, {"RAPTOR_CALLER_DIR": str(tmp_path)}):
             default = os.environ.get("RAPTOR_CALLER_DIR")
             assert default == str(tmp_path)

--- a/core/smt_solver/tests/test_smt_solver.py
+++ b/core/smt_solver/tests/test_smt_solver.py
@@ -1,7 +1,6 @@
 """Tests for core.smt_solver — Z3 dependency management."""
 
 import sys
-import unittest.mock
 from pathlib import Path
 import pytest
 

--- a/core/smt_solver/witness.py
+++ b/core/smt_solver/witness.py
@@ -7,7 +7,7 @@ high-bit-set values as two's-complement negatives when ``signed=True``.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, Mapping, Optional, Union
+from typing import Any, Dict, Mapping, Union
 
 from .availability import z3
 

--- a/core/startup/tests/test_check_env_session.py
+++ b/core/startup/tests/test_check_env_session.py
@@ -12,8 +12,6 @@ truth — banner picks them up automatically).
 
 from __future__ import annotations
 
-from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/core/startup/tests/test_doctor.py
+++ b/core/startup/tests/test_doctor.py
@@ -9,10 +9,7 @@ classification + exit code.
 
 from __future__ import annotations
 
-from typing import List
-from unittest.mock import patch
 
-import pytest
 
 from core.startup import doctor
 from core.startup.doctor import _render, main

--- a/core/tar/safe_member.py
+++ b/core/tar/safe_member.py
@@ -42,9 +42,7 @@ from __future__ import annotations
 import logging
 import sys
 import tarfile
-from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/core/tar/tests/test_safe_member.py
+++ b/core/tar/tests/test_safe_member.py
@@ -8,10 +8,8 @@ doesn't silently relax the check.
 
 from __future__ import annotations
 
-import sys
 import tarfile
 
-import pytest
 
 from core.tar import (
     DEFAULT_MAX_MEMBER_BYTES,

--- a/core/upstream_latest/oci_tags.py
+++ b/core/upstream_latest/oci_tags.py
@@ -37,7 +37,7 @@ from typing import List, Optional
 from core.http import HttpClient
 from core.json import JsonCache
 from core.oci.client import OciRegistryClient, RegistryError
-from core.oci.image_ref import ImageRef, parse_image_ref
+from core.oci.image_ref import parse_image_ref
 
 from ._version_filter import highest_stable
 from .github_releases import (

--- a/core/upstream_latest/tests/test_helm_index.py
+++ b/core/upstream_latest/tests/test_helm_index.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import pytest
 

--- a/core/upstream_latest/tests/test_oci_tags.py
+++ b/core/upstream_latest/tests/test_oci_tags.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, List, Optional
 
 import pytest
 
-from core.oci.client import OciRegistryClient
 from core.upstream_latest.github_releases import (
     NoStableVersionsFound,
     UpstreamLookupError,

--- a/libexec/tests/test_raptor_agentic_wrapper.py
+++ b/libexec/tests/test_raptor_agentic_wrapper.py
@@ -2,7 +2,6 @@
 
 import os
 import subprocess
-import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/libexec/tests/test_raptor_normalize_context_map.py
+++ b/libexec/tests/test_raptor_normalize_context_map.py
@@ -3,7 +3,6 @@
 import json
 import os
 import subprocess
-import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/packages/autonomous/corpus_generator.py
+++ b/packages/autonomous/corpus_generator.py
@@ -9,7 +9,6 @@ Instead of hardcoded seeds, this module:
 - Learns which seed patterns lead to coverage/crashes
 """
 
-import json
 from core.sandbox import run_trusted as _run_trusted  # read-only tools only (strings)
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set

--- a/packages/autonomous/corpus_generator.py
+++ b/packages/autonomous/corpus_generator.py
@@ -184,8 +184,8 @@ class CorpusGenerator:
         corpus_dir.mkdir(parents=True, exist_ok=True)
         seeds_generated = 0
 
-        # Analyze binary first
-        analysis = self.analyze_binary()
+        # Analyze binary first (populates self.detected_commands etc as side effects)
+        self.analyze_binary()
 
         # 1. Generate basic seeds (always useful)
         logger.info("Generating basic seed corpus...")
@@ -421,7 +421,6 @@ class CorpusGenerator:
         logger.info("Optimizing corpus (removing redundant seeds)...")
 
         seeds = list(corpus_dir.glob("seed_*"))
-        initial_count = len(seeds)
 
         if not coverage_data:
             # Simple deduplication by content. Use hashlib.sha256

--- a/packages/autonomous/dialogue.py
+++ b/packages/autonomous/dialogue.py
@@ -109,17 +109,6 @@ class MultiTurnAnalyser:
         logger.info("MULTI-TURN CRASH ANALYSIS")
         logger.info("=" * 70)
 
-        context = DialogueContext(
-            goal="analyse crash deeply",
-            crash_info={
-                "signal": crash_context.signal,
-                "function": crash_context.function_name,
-                "stack_trace": crash_context.stack_trace,
-                "registers": crash_context.registers,
-            },
-            max_turns=max_turns,
-        )
-
         messages = []
         analysis_result = {
             "vulnerability_type": "unknown",
@@ -214,13 +203,6 @@ class MultiTurnAnalyser:
         logger.info("ITERATIVE EXPLOIT REFINEMENT")
         logger.info("=" * 70)
 
-        context = DialogueContext(
-            goal="refine exploit",
-            crash_info={"signal": crash_context.signal, "function": crash_context.function_name},
-            exploit_code=exploit_code,
-            validation_results={"errors": validation_errors},
-            max_turns=max_iterations,
-        )
 
         messages = []
         current_code = exploit_code

--- a/packages/autonomous/exploit_validator.py
+++ b/packages/autonomous/exploit_validator.py
@@ -11,7 +11,6 @@ This module enables RAPTOR to:
 
 import re
 import subprocess
-import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Tuple

--- a/packages/autonomous/memory.py
+++ b/packages/autonomous/memory.py
@@ -7,7 +7,7 @@ improve over time through persistent knowledge storage.
 """
 
 import time
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Any

--- a/packages/autonomous/planner.py
+++ b/packages/autonomous/planner.py
@@ -6,7 +6,6 @@ This module transforms RAPTOR from a fixed pipeline into an intelligent agent
 that makes decisions based on fuzzing state and learned knowledge.
 """
 
-import time
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path

--- a/packages/autonomous/tests/test_dialogue_envelope.py
+++ b/packages/autonomous/tests/test_dialogue_envelope.py
@@ -11,9 +11,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Optional
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-import pytest
 
 from core.security.prompt_envelope import PromptBundle
 

--- a/packages/autonomous/tests/test_poc_source_scan.py
+++ b/packages/autonomous/tests/test_poc_source_scan.py
@@ -11,7 +11,6 @@ descending-only quoted includes).
 from __future__ import annotations
 
 from packages.autonomous.poc_source_scan import (
-    SourceScanViolation,
     format_violations,
     scan,
 )

--- a/packages/binary_analysis/crash_analyser.py
+++ b/packages/binary_analysis/crash_analyser.py
@@ -14,7 +14,6 @@ from core.sandbox import run as _sandbox_run, run_trusted as _run_trusted
 # - GDB / LLDB: need ptrace → profile='debug' (keeps net/Landlock/most seccomp).
 # - ASAN binary: no ptrace needed → default full sandbox via _sandbox_run.
 # Each call site specifies target+output for Landlock engagement.
-import os
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/packages/binary_analysis/debugger.py
+++ b/packages/binary_analysis/debugger.py
@@ -82,7 +82,6 @@ class GDBDebugger:
         # leaks. Place the script next to the binary so it
         # inherits the binary's directory permissions, which
         # we control.
-        import tempfile
         # binary_dir resolves to the analyser's binary working
         # area — same dir we already pass to landlock as a
         # writable path (line 81 below).

--- a/packages/binary_analysis/tests/test_gdb_injection.py
+++ b/packages/binary_analysis/tests/test_gdb_injection.py
@@ -251,8 +251,6 @@ class TestDebuggerTempFile:
         """
         import subprocess as sp
 
-        script_paths = []
-
         # Verify cleanup behavior directly via filesystem
         # inspection — pre-fix this test had no assertions.
         # The script lands under `binary_dir` (per batch 836)

--- a/packages/binary_analysis/tests/test_gdb_injection.py
+++ b/packages/binary_analysis/tests/test_gdb_injection.py
@@ -1,7 +1,5 @@
 """Tests for debugger/crash_analyser security mitigations (CWE-78, CWE-59)."""
 
-import os
-import glob
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 

--- a/packages/checker_synthesis/prompts.py
+++ b/packages/checker_synthesis/prompts.py
@@ -13,7 +13,7 @@ documentation — the LLM sees them, so the output shape is explicit.
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 
 from .models import SeedBug, SynthesisedRule, Match
 

--- a/packages/checker_synthesis/synthesise.py
+++ b/packages/checker_synthesis/synthesise.py
@@ -14,9 +14,7 @@ from __future__ import annotations
 import logging
 import os
 import re
-import subprocess
 import tempfile
-from dataclasses import replace
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Protocol, Tuple
 

--- a/packages/checker_synthesis/tests/test_adversarial.py
+++ b/packages/checker_synthesis/tests/test_adversarial.py
@@ -220,7 +220,7 @@ class TestAtomicRuleWrite:
         llm = _stub_llm([
             {"rule_body": "rules: A_VERSION", "rationale": "first"},
         ])
-        r1 = synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
+        synthesise_and_run(seed, tmp_path, tmp_path / "out", llm)
         # Reset engine call count — second write also runs probe.
         # Plant fresh stub.
         _stub_engines(

--- a/packages/checker_synthesis/tests/test_models.py
+++ b/packages/checker_synthesis/tests/test_models.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 

--- a/packages/checker_synthesis/tests/test_refinement.py
+++ b/packages/checker_synthesis/tests/test_refinement.py
@@ -10,14 +10,12 @@ Stub LLM + stub engine adapters keep tests deterministic.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import List
 
-import pytest
 
 from packages.checker_synthesis import (
     Match,
     SeedBug,
-    SynthesisedRule,
     synthesise_with_refinement,
 )
 from packages.checker_synthesis import synthesise as synth_mod

--- a/packages/checker_synthesis/tests/test_refinement.py
+++ b/packages/checker_synthesis/tests/test_refinement.py
@@ -224,7 +224,7 @@ class TestFpContextPropagation:
                         "rationale": "tightened"}
             raise AssertionError("unexpected extra LLM call")
 
-        result = synthesise_with_refinement(
+        synthesise_with_refinement(
             seed, tmp_path, tmp_path / "out", llm,
             max_iterations=3,
         )
@@ -338,7 +338,7 @@ class TestFpDedup:
                 return {"rule_body": "rules: r", "rationale": "x"}
             return {"status": "false_positive", "reasoning": "fp"}
 
-        result = synthesise_with_refinement(
+        synthesise_with_refinement(
             seed, tmp_path, tmp_path / "out", llm,
             max_iterations=3,
         )

--- a/packages/checker_synthesis/tests/test_synthesise.py
+++ b/packages/checker_synthesis/tests/test_synthesise.py
@@ -8,14 +8,11 @@ semgrep / coccinelle binaries on the test runner.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional
 
-import pytest
 
 from packages.checker_synthesis import (
     Match,
     SeedBug,
-    SynthesisedRule,
     synthesise_and_run,
 )
 from packages.checker_synthesis import synthesise as synth_mod

--- a/packages/coccinelle/models.py
+++ b/packages/coccinelle/models.py
@@ -1,8 +1,7 @@
 """Data models for Coccinelle results."""
 
 from dataclasses import dataclass, field
-from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 
 @dataclass

--- a/packages/coccinelle/tests/test_prereqs.py
+++ b/packages/coccinelle/tests/test_prereqs.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import os
 import shutil
 import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest

--- a/packages/coccinelle/tests/test_sarif.py
+++ b/packages/coccinelle/tests/test_sarif.py
@@ -184,7 +184,7 @@ def test_optional_region_fields_omitted_when_zero(tmp_path):
                     column=0, line_end=0, column_end=0,
                     message="m"),
     ])
-    region = _run0(doc := results_to_sarif([result], tmp_path))[
+    region = _run0(results_to_sarif([result], tmp_path))[
         "results"][0]["locations"][0]["physicalLocation"]["region"]
     assert region["startLine"] == 5
     assert "endLine" not in region

--- a/packages/coccinelle/tests/test_sarif.py
+++ b/packages/coccinelle/tests/test_sarif.py
@@ -12,7 +12,6 @@ import os
 import sys
 from pathlib import Path
 
-import pytest
 
 _RAPTOR_DIR = os.environ["RAPTOR_DIR"]
 if _RAPTOR_DIR not in sys.path:

--- a/packages/code_understanding/dispatch/hunt_cocci_dispatch.py
+++ b/packages/code_understanding/dispatch/hunt_cocci_dispatch.py
@@ -42,7 +42,6 @@ from __future__ import annotations
 
 import logging
 import re
-import shutil
 import tempfile
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional

--- a/packages/code_understanding/tests/dispatch/test_hunt_cocci_dispatch.py
+++ b/packages/code_understanding/tests/dispatch/test_hunt_cocci_dispatch.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import os
 import sys
-from pathlib import Path
 from unittest import mock
 
 import pytest

--- a/packages/code_understanding/tests/dispatch/test_hunt_strategy_adversarial.py
+++ b/packages/code_understanding/tests/dispatch/test_hunt_strategy_adversarial.py
@@ -10,8 +10,7 @@ content, and helper purity.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Iterator, List
+from typing import List
 from unittest.mock import patch
 
 import pytest

--- a/packages/code_understanding/tests/dispatch/test_hunt_strategy_wiring.py
+++ b/packages/code_understanding/tests/dispatch/test_hunt_strategy_wiring.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
 
 from packages.code_understanding.dispatch.hunt_dispatch import (
     _build_hunt_strategy_block,

--- a/packages/code_understanding/tests/dispatch/test_trace_strategy_adversarial.py
+++ b/packages/code_understanding/tests/dispatch/test_trace_strategy_adversarial.py
@@ -9,7 +9,6 @@ trace content, and pin helper purity.
 
 from __future__ import annotations
 
-import json
 from typing import List
 from unittest.mock import patch
 

--- a/packages/code_understanding/tests/dispatch/test_trace_strategy_wiring.py
+++ b/packages/code_understanding/tests/dispatch/test_trace_strategy_wiring.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
 
 from packages.code_understanding.dispatch.trace_dispatch import (
     _build_strategy_block,

--- a/packages/code_understanding/tests/test_annotation_synth.py
+++ b/packages/code_understanding/tests/test_annotation_synth.py
@@ -259,7 +259,7 @@ class TestFlowTrace:
         repo, out = understand_run
         _make_context_map(out)
         _make_flow_trace(out)
-        counts = synthesise_from_understand_output(out)
+        synthesise_from_understand_output(out)
         # Step 1 → query_handler (already has entry_point); step 2 →
         # run_query (already has sink); step 3 is external library,
         # skipped.

--- a/packages/code_understanding/tests/test_annotation_synth.py
+++ b/packages/code_understanding/tests/test_annotation_synth.py
@@ -19,11 +19,9 @@ from core.annotations import (
     Annotation,
     iter_all_annotations,
     read_annotation,
-    read_file_annotations,
     write_annotation,
 )
 from packages.code_understanding.annotation_synth import (
-    SynthCounts,
     _parse_definition,
     synthesise_from_understand_output,
 )

--- a/packages/code_understanding/tests/test_annotation_synth_adversarial.py
+++ b/packages/code_understanding/tests/test_annotation_synth_adversarial.py
@@ -13,15 +13,12 @@ LLM upstream could plausibly produce.
 from __future__ import annotations
 
 import json
-import os
-import tempfile
 from pathlib import Path
 
 import pytest
 
 from core.annotations import iter_all_annotations, read_annotation
 from packages.code_understanding.annotation_synth import (
-    SynthCounts,
     synthesise_from_understand_output,
 )
 

--- a/packages/codeql/agent.py
+++ b/packages/codeql/agent.py
@@ -8,7 +8,6 @@ into a seamless automated pipeline.
 """
 
 import argparse
-import json
 import sys
 import time
 from dataclasses import dataclass, asdict

--- a/packages/codeql/autonomous_analyzer.py
+++ b/packages/codeql/autonomous_analyzer.py
@@ -235,9 +235,7 @@ class AutonomousCodeQLAnalyzer:
 
         try:
             from core.inventory.lookup import lookup_function
-            from core.inventory.reachability import (
-                Verdict, function_called,
-            )
+            from core.inventory.reachability import function_called
         except ImportError:
             return None
 

--- a/packages/codeql/autonomous_analyzer.py
+++ b/packages/codeql/autonomous_analyzer.py
@@ -14,7 +14,7 @@ import sys
 from dataclasses import dataclass, asdict
 
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 # Add parent directory to path for imports
 # packages/codeql/autonomous_analyzer.py -> repo root

--- a/packages/codeql/autonomous_analyzer.py
+++ b/packages/codeql/autonomous_analyzer.py
@@ -10,7 +10,6 @@ Fully autonomous analysis of CodeQL findings with:
 - Exploit validation and refinement
 """
 
-import json
 import sys
 from dataclasses import dataclass, asdict
 
@@ -620,7 +619,6 @@ class AutonomousCodeQLAnalyzer:
             prefilter_decision,
             record_prefilter_outcome,
         )
-        from core.llm.config import PROVIDER_FAST_MODELS
 
         decision_class = f"codeql:{finding.rule_id}"
         # Resolve the fast model name from the config — the cheap

--- a/packages/codeql/codeql_proxy_hosts.py
+++ b/packages/codeql/codeql_proxy_hosts.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import shutil
 import subprocess
 from pathlib import Path

--- a/packages/codeql/database_manager.py
+++ b/packages/codeql/database_manager.py
@@ -11,7 +11,6 @@ import hashlib
 import os
 import re
 import shutil
-import stat
 import subprocess
 
 import sys

--- a/packages/codeql/dataflow_validator.py
+++ b/packages/codeql/dataflow_validator.py
@@ -6,16 +6,14 @@ Validates CodeQL dataflow findings using LLM analysis to determine
 if dataflow paths are truly exploitable beyond theoretical detection.
 """
 
-import json
 import sys
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
 
 from core.smt_solver import BVProfile
 from packages.codeql.smt_path_validator import (
     PathCondition,
-    PathSMTResult,
     check_path_feasibility,
 )
 

--- a/packages/codeql/dataflow_visualizer.py
+++ b/packages/codeql/dataflow_visualizer.py
@@ -11,9 +11,8 @@ Creates visual representations of CodeQL dataflow paths in multiple formats:
 
 import json
 import sys
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List
 from html import escape
 
 # Add parent directory to path for imports
@@ -21,7 +20,7 @@ from html import escape
 sys.path.insert(0, str(Path(__file__).parents[2]))
 
 from core.logging import get_logger
-from packages.codeql.dataflow_validator import DataflowPath, DataflowStep
+from packages.codeql.dataflow_validator import DataflowPath
 
 logger = get_logger()
 

--- a/packages/codeql/query_runner.py
+++ b/packages/codeql/query_runner.py
@@ -6,12 +6,11 @@ Executes CodeQL queries and suites against databases,
 producing SARIF output for vulnerability analysis.
 """
 
-import json
 import subprocess
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
 

--- a/packages/codeql/query_runner.py
+++ b/packages/codeql/query_runner.py
@@ -12,7 +12,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 # Add parent directory to path for imports
 # packages/codeql/query_runner.py -> repo root

--- a/packages/codeql/test_database_manager_integration.py
+++ b/packages/codeql/test_database_manager_integration.py
@@ -20,7 +20,6 @@ import time
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-import pytest
 
 
 # Module-level worker — spawn pickles by name, so it must not be nested

--- a/packages/codeql/tests/test_build_synthesis.py
+++ b/packages/codeql/tests/test_build_synthesis.py
@@ -3,7 +3,6 @@
 import sys
 from pathlib import Path
 
-import pytest
 
 # packages/codeql/tests/test_build_synthesis.py -> repo root
 sys.path.insert(0, str(Path(__file__).parents[3]))

--- a/packages/codeql/tests/test_build_synthesis.py
+++ b/packages/codeql/tests/test_build_synthesis.py
@@ -117,21 +117,21 @@ class TestSynthesiseCpp:
     def test_uses_gpp_for_cpp_files(self, tmp_path):
         (tmp_path / "main.cpp").write_text("int main() {}")
         bd = BuildDetector(tmp_path)
-        result = bd.synthesise_build_command("cpp")
+        bd.synthesise_build_command("cpp")
         script = _find_script(tmp_path).read_text()
         assert "g++" in script
 
     def test_uses_gcc_for_c_files(self, tmp_path):
         (tmp_path / "main.c").write_text("int main() { return 0; }")
         bd = BuildDetector(tmp_path)
-        result = bd.synthesise_build_command("cpp")
+        bd.synthesise_build_command("cpp")
         script = _find_script(tmp_path).read_text()
         assert "'gcc'" in script
 
     def test_build_dir_is_temp(self, tmp_path):
         (tmp_path / "main.c").write_text("int main() { return 0; }")
         bd = BuildDetector(tmp_path)
-        result = bd.synthesise_build_command("cpp")
+        bd.synthesise_build_command("cpp")
         script = _find_script(tmp_path).read_text()
         assert ".raptor_build_" in script
 

--- a/packages/codeql/tests/test_codeql_proxy_hosts.py
+++ b/packages/codeql/tests/test_codeql_proxy_hosts.py
@@ -15,9 +15,7 @@ shape, same fallback behaviour, same memoisation contract.
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/packages/codeql/tests/test_envelope_migration.py
+++ b/packages/codeql/tests/test_envelope_migration.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import pytest
 
 from packages.codeql.autonomous_analyzer import (
     AutonomousCodeQLAnalyzer,

--- a/packages/codeql/tests/test_evidence_validator.py
+++ b/packages/codeql/tests/test_evidence_validator.py
@@ -14,7 +14,6 @@ from core.dataflow import Finding, Step
 from core.dataflow.validator import Validator, ValidatorVerdict
 from packages.codeql.dataflow_validator import (
     DataflowPath,
-    DataflowStep,
     DataflowValidation,
 )
 from packages.codeql.evidence_validator import (

--- a/packages/codeql/tests/test_iris_pack_killswitch.py
+++ b/packages/codeql/tests/test_iris_pack_killswitch.py
@@ -8,9 +8,7 @@ before any pack work happens. Symmetric to the kill-switch test in
 
 import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
 
-import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 

--- a/packages/codeql/tests/test_language_normalisation.py
+++ b/packages/codeql/tests/test_language_normalisation.py
@@ -122,7 +122,7 @@ class TestExplicitLanguagesNormalised:
         # database_manager returns empty so workflow exits cleanly
         agent.database_manager.create_databases_parallel.return_value = {}
 
-        result = agent.run_autonomous_analysis(languages=["c"])
+        agent.run_autonomous_analysis(languages=["c"])
 
         # The agent should have passed "cpp" (canonical) to the
         # detector chain, NEVER the raw "c" string.

--- a/packages/codeql/tests/test_language_normalisation.py
+++ b/packages/codeql/tests/test_language_normalisation.py
@@ -14,9 +14,8 @@ Both behaviours close ergonomic footguns in the CodeQL agent:
 
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-import pytest
 
 # packages/codeql/tests/test_language_normalisation.py -> repo root
 sys.path.insert(0, str(Path(__file__).parents[3]))

--- a/packages/codeql/tests/test_reachability_prefilter.py
+++ b/packages/codeql/tests/test_reachability_prefilter.py
@@ -5,10 +5,8 @@ anywhere in the project."""
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import MagicMock
 
-import pytest
 
 from packages.codeql.autonomous_analyzer import (
     AutonomousCodeQLAnalyzer,

--- a/packages/codeql/tests/test_scorecard_wiring.py
+++ b/packages/codeql/tests/test_scorecard_wiring.py
@@ -15,14 +15,12 @@ LLM client and verifies:
 from __future__ import annotations
 
 import threading
-from pathlib import Path
 from types import SimpleNamespace
-from typing import List, Tuple
 
 import pytest
 
 from core.llm.config import LLMConfig, ModelConfig
-from core.llm.scorecard import EventType, ModelScorecard, Policy
+from core.llm.scorecard import EventType, ModelScorecard
 from core.llm.task_types import TaskType
 from packages.codeql.autonomous_analyzer import (
     AutonomousCodeQLAnalyzer,

--- a/packages/codeql/tests/test_smt_path_validator.py
+++ b/packages/codeql/tests/test_smt_path_validator.py
@@ -2,7 +2,7 @@
 
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -12,7 +12,6 @@ sys.path.insert(0, str(Path(__file__).parents[3]))
 from core.smt_solver import RejectionKind, z3_available
 from packages.codeql.smt_path_validator import (
     PathCondition,
-    PathSMTResult,
     check_path_feasibility,
 )
 

--- a/packages/cve_diff/cve_diff/agent/loop.py
+++ b/packages/cve_diff/cve_diff/agent/loop.py
@@ -102,10 +102,6 @@ class AgentLoop:
     last_telemetry: dict[str, Any] | None = field(default=None, init=False, repr=False)
 
     def run(self, config: AgentConfig, ctx: AgentContext) -> AgentResult:
-        prompt_hash = hashlib.sha256(
-            (config.system_prompt + "\n" + config.user_message).encode("utf-8")
-        ).hexdigest()[:12]
-
         # ---- State tracked across the loop via closures ----
         tool_call_log: list[str] = []
         verified: list[tuple[str, str]] = []

--- a/packages/cve_diff/cve_diff/agent/loop.py
+++ b/packages/cve_diff/cve_diff/agent/loop.py
@@ -12,7 +12,6 @@ Dataclasses live in ``agent/types.py``; tools in ``agent/tools.py``.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import time

--- a/packages/cve_diff/cve_diff/agent/loop.py
+++ b/packages/cve_diff/cve_diff/agent/loop.py
@@ -30,7 +30,6 @@ from core.llm.tool_use.types import (
     ToolCallDispatched,
     ToolCallReturned,
     ToolDef,
-    ToolLoopResult,
     TurnCompleted,
 )
 

--- a/packages/cve_diff/cve_diff/diffing/extract_via_gitlab_api.py
+++ b/packages/cve_diff/cve_diff/diffing/extract_via_gitlab_api.py
@@ -20,10 +20,13 @@ from __future__ import annotations
 
 import functools
 import re
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 from urllib.parse import quote as _urlquote
 
 from core.http import HttpError
+
+if TYPE_CHECKING:
+    from core.http.egress_backend import EgressClient
 
 from cve_diff.core.exceptions import AnalysisError
 from cve_diff.core.models import CommitSha, DiffBundle, FileChange, RepoRef

--- a/packages/cve_diff/cve_diff/diffing/extract_via_gitlab_api.py
+++ b/packages/cve_diff/cve_diff/diffing/extract_via_gitlab_api.py
@@ -24,7 +24,6 @@ from typing import Optional
 from urllib.parse import quote as _urlquote
 
 from core.http import HttpError
-from core.http.urllib_backend import UrllibClient
 
 from cve_diff.core.exceptions import AnalysisError
 from cve_diff.core.models import CommitSha, DiffBundle, FileChange, RepoRef

--- a/packages/cve_diff/cve_diff/diffing/extract_via_patch_url.py
+++ b/packages/cve_diff/cve_diff/diffing/extract_via_patch_url.py
@@ -25,7 +25,6 @@ import functools
 import re
 
 from core.http import HttpError
-from core.http.urllib_backend import UrllibClient
 
 from cve_diff.core.models import CommitSha, DiffBundle, FileChange, RepoRef
 from cve_diff.core.path_classifier import is_test_path

--- a/packages/cve_diff/cve_diff/diffing/extract_via_patch_url.py
+++ b/packages/cve_diff/cve_diff/diffing/extract_via_patch_url.py
@@ -23,8 +23,12 @@ from __future__ import annotations
 
 import functools
 import re
+from typing import TYPE_CHECKING
 
 from core.http import HttpError
+
+if TYPE_CHECKING:
+    from core.http.egress_backend import EgressClient
 
 from cve_diff.core.models import CommitSha, DiffBundle, FileChange, RepoRef
 from cve_diff.core.path_classifier import is_test_path

--- a/packages/cve_diff/cve_diff/discovery/distro_cache.py
+++ b/packages/cve_diff/cve_diff/discovery/distro_cache.py
@@ -24,7 +24,6 @@ this module returns reference URLs untouched.
 from __future__ import annotations
 
 import functools
-import json
 import re
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field

--- a/packages/cve_diff/cve_diff/discovery/nvd.py
+++ b/packages/cve_diff/cve_diff/discovery/nvd.py
@@ -20,7 +20,6 @@ from typing import Any
 
 from packages.nvd import extract_patch_refs
 from packages.nvd.client import (
-    DEFAULT_CACHE_DIR,
     DEFAULT_TIMEOUT_S,
     NvdClient,
     _SENTINEL_USE_DEFAULT,

--- a/packages/cve_diff/cve_diff/infra/service_health.py
+++ b/packages/cve_diff/cve_diff/infra/service_health.py
@@ -120,7 +120,7 @@ def probe_anthropic() -> HealthResult:
     body = json.dumps({"model": _health_model(), "max_tokens": 1,
                        "messages": [{"role": "user", "content": "x"}]}).encode()
     try:
-        resp = _client().request(
+        _client().request(
             "POST", "https://api.anthropic.com/v1/messages",
             body=body,
             headers={

--- a/packages/cve_diff/cve_diff/llm/client.py
+++ b/packages/cve_diff/cve_diff/llm/client.py
@@ -15,8 +15,6 @@ preserves the public surface that the analyzer and agent loop depend on:
 
 from __future__ import annotations
 
-import os
-import sys
 import time
 from dataclasses import dataclass, field
 

--- a/packages/cve_diff/cve_diff/llm/client.py
+++ b/packages/cve_diff/cve_diff/llm/client.py
@@ -109,13 +109,11 @@ class ResilientLLMClient:
         # `backoff_factor` but the original implementation called
         # provider.generate exactly once. Wire them up for real.
         attempt = 0
-        last_exc: Exception | None = None
         while True:
             try:
                 resp = provider.generate(prompt, system_prompt=system, **kwargs)
                 break
             except Exception as exc:
-                last_exc = exc
                 if attempt >= self.max_retries:
                     raise LLMCallFailed(
                         f"LLM call ({model_id}) failed after "

--- a/packages/cve_diff/tests/unit/cli/test_main.py
+++ b/packages/cve_diff/tests/unit/cli/test_main.py
@@ -10,9 +10,7 @@ flag.").
 """
 from __future__ import annotations
 
-import json
 import subprocess
-from dataclasses import dataclass
 from pathlib import Path
 
 import pytest

--- a/packages/cve_diff/tests/unit/diffing/test_extract_via_gitlab_api.py
+++ b/packages/cve_diff/tests/unit/diffing/test_extract_via_gitlab_api.py
@@ -13,7 +13,6 @@ clone bundle.
 from __future__ import annotations
 
 import json as _json
-from typing import Any
 
 import pytest
 

--- a/packages/cve_diff/tests/unit/diffing/test_extract_via_patch_url.py
+++ b/packages/cve_diff/tests/unit/diffing/test_extract_via_patch_url.py
@@ -7,7 +7,6 @@ second-source coverage for cgit (kernel.org), which has no JSON API.
 """
 from __future__ import annotations
 
-import pytest
 
 from core.http import HttpError, Response
 from cve_diff.core.models import RepoRef

--- a/packages/cve_diff/tests/unit/discovery/test_nvd.py
+++ b/packages/cve_diff/tests/unit/discovery/test_nvd.py
@@ -7,7 +7,7 @@ HTTP round-trip is mocked at the ``_client()`` boundary.
 from __future__ import annotations
 
 import json as _json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 import pytest

--- a/packages/cve_diff/tests/unit/llm/test_auth.py
+++ b/packages/cve_diff/tests/unit/llm/test_auth.py
@@ -16,7 +16,7 @@ import os
 
 import pytest
 
-from cve_diff.llm.auth import AuthDecision, resolve_auth
+from cve_diff.llm.auth import resolve_auth
 
 
 @pytest.fixture(autouse=True)

--- a/packages/cve_diff/tests/unit/report/test_flow.py
+++ b/packages/cve_diff/tests/unit/report/test_flow.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 
 
 # ----- the helper under test -----

--- a/packages/cve_diff/tests/unit/test_diff_shape_dynamic.py
+++ b/packages/cve_diff/tests/unit/test_diff_shape_dynamic.py
@@ -125,7 +125,6 @@ class TestExtensionParsing:
         )
 
     def test_dotfile_no_extension(self) -> None:
-        payloads = {"x/y": {"Python": 100}}
         assert shape_dynamic._ext(".gitignore") == ""
 
     def test_extension_case_insensitive(self) -> None:

--- a/packages/cve_diff/tests/unit/test_pipeline.py
+++ b/packages/cve_diff/tests/unit/test_pipeline.py
@@ -534,7 +534,6 @@ def test_post_submit_retry_on_analysis_error_recovers(tmp_path):
     # check by patching it to fail-then-succeed.
     from cve_diff import pipeline as pipeline_mod
     shape_calls = {"n": 0}
-    real_check = pipeline_mod.check_diff_shape
 
     def flaky_check(shape: str):
         shape_calls["n"] += 1

--- a/packages/cve_diff/tests/unit/test_report_consensus.py
+++ b/packages/cve_diff/tests/unit/test_report_consensus.py
@@ -1,7 +1,6 @@
 """Tests for cve_diff/report/consensus.py — aggregation logic (2 methods)."""
 from __future__ import annotations
 
-import pytest
 
 from cve_diff.report.consensus import (
     ConsensusReport,

--- a/packages/cve_diff/tests/unit/test_url_re.py
+++ b/packages/cve_diff/tests/unit/test_url_re.py
@@ -1,7 +1,6 @@
 """Tests for core/url_patterns — slug + commit URL parsing."""
 from __future__ import annotations
 
-import pytest
 
 from core.url_patterns import (
     GITHUB_COMMIT_URL_RE,
@@ -9,7 +8,6 @@ from core.url_patterns import (
     is_github_url,
     is_gitlab_url,
     is_kernel_org_url,
-    normalize_slug,
 )
 
 

--- a/packages/diagram/renderer.py
+++ b/packages/diagram/renderer.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 from core.json import load_json as _load_json
 

--- a/packages/exploit_feasibility/analyzer.py
+++ b/packages/exploit_feasibility/analyzer.py
@@ -40,7 +40,6 @@ import os
 import re
 import subprocess
 from core.sandbox import run as _sandbox_run, run_trusted as _run_trusted
-from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple

--- a/packages/exploit_feasibility/api.py
+++ b/packages/exploit_feasibility/api.py
@@ -119,8 +119,7 @@ def analyze_binary(binary_path: str, output_dir: str = None,
             'rop_gadgets': {'pop_rdi': int, 'ret': int, ...},  # If extended
         }
     """
-    from .analyzer import FeasibilityAnalyzer, ExploitabilityVerdict
-    from .context import ExploitationConstraints
+    from .analyzer import FeasibilityAnalyzer
 
     binary_path = Path(binary_path) if binary_path else None
 
@@ -2254,7 +2253,7 @@ def what_if_mitigation_blocked(
             'summary': str
         }
     """
-    from .analyzer import create_dependency_graph, PrimitiveDependencyGraph
+    from .analyzer import create_dependency_graph
 
     # Create graph without the mitigation
     graph = create_dependency_graph()
@@ -2381,7 +2380,6 @@ def save_exploit_context(binary_path: str, output_dir: str = None, vuln_type: st
         >>> # After compaction, reload with:
         >>> ctx = load_exploit_context(ctx_file)
     """
-    import json
     from pathlib import Path
     from datetime import datetime
 

--- a/packages/exploit_feasibility/config.py
+++ b/packages/exploit_feasibility/config.py
@@ -7,7 +7,6 @@ and file-based configuration.
 """
 
 import os
-import json
 from core.json import load_json, save_json
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/packages/exploit_feasibility/constants.py
+++ b/packages/exploit_feasibility/constants.py
@@ -8,7 +8,6 @@ Centralizes magic numbers and thresholds with explanations.
 import subprocess
 from core.sandbox import run_trusted as _run_trusted  # read-only tools only (readelf)
 from dataclasses import dataclass
-from typing import Optional
 
 
 # =============================================================================

--- a/packages/exploit_feasibility/context.py
+++ b/packages/exploit_feasibility/context.py
@@ -22,7 +22,6 @@ Usage:
     ctx = report.context  # Access the underlying context
 """
 
-import json
 import os
 import subprocess
 from core.sandbox import run_trusted as _run_trusted  # read-only tools only (readelf, objdump, nm, strings, etc.)

--- a/packages/exploit_feasibility/finding_mapper.py
+++ b/packages/exploit_feasibility/finding_mapper.py
@@ -17,7 +17,7 @@ Usage:
     #   mapped[0].finding_id, mapped[0].verdict, mapped[0].exploitation_paths
 """
 
-from typing import Dict, List, Any, Optional, Union
+from typing import Dict, List, Optional
 
 from .models import FeasibilityAssessment, ExploitationPath
 

--- a/packages/exploit_feasibility/models.py
+++ b/packages/exploit_feasibility/models.py
@@ -6,7 +6,7 @@ providing documented fields, type safety, and proper defaults.
 """
 
 from dataclasses import dataclass, field, asdict
-from typing import List, Optional
+from typing import List
 
 
 @dataclass

--- a/packages/exploit_feasibility/schema.py
+++ b/packages/exploit_feasibility/schema.py
@@ -6,7 +6,6 @@ Provides validation for serialized ExploitContext and FeasibilityReport data.
 """
 
 from typing import Any, Dict, List, Tuple
-import json
 from core.json import load_json
 from .vuln_types import ExploitabilityVerdict
 

--- a/packages/exploit_feasibility/smt_verbs.py
+++ b/packages/exploit_feasibility/smt_verbs.py
@@ -55,7 +55,7 @@ reason about strings the way XSS / SQLi need.  See
 from __future__ import annotations
 
 import re
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Sequence, Union
 
 from core.smt_solver import (
     BVProfile,
@@ -69,7 +69,6 @@ from core.smt_solver.csem import (
     usub_underflows,
 )
 from packages.codeql.smt_path_validator import (
-    PathCondition,
     PathSMTResult,
     check_verb_feasibility,
     is_balanced_call,

--- a/packages/exploit_feasibility/tests/test_api_functions.py
+++ b/packages/exploit_feasibility/tests/test_api_functions.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Tests for API functions that were previously untested."""
 
-import pytest
 from unittest.mock import patch, MagicMock
 from ..api import (
     find_exploit_paths,

--- a/packages/exploit_feasibility/tests/test_api_functions.py
+++ b/packages/exploit_feasibility/tests/test_api_functions.py
@@ -310,7 +310,7 @@ class TestFindExploitPathsCaching:
         from ..analyzer import FeasibilityAnalyzer
         with patch.object(FeasibilityAnalyzer, '__init__', return_value=None) as mock_init:
             # Provide cached protections - analyzer should NOT be created
-            result = find_exploit_paths(
+            find_exploit_paths(
                 "format_string_vuln",
                 binary_protections={'full_relro': True, 'pie': True},
                 glibc_version='2.35'

--- a/packages/exploit_feasibility/tests/test_api_persistence.py
+++ b/packages/exploit_feasibility/tests/test_api_persistence.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 import pytest
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from ..api import (
     save_exploit_context,

--- a/packages/exploit_feasibility/tests/test_bugfixes.py
+++ b/packages/exploit_feasibility/tests/test_bugfixes.py
@@ -2,10 +2,7 @@
 """Tests for specific bugfixes in exploit_feasibility package."""
 
 import os
-import tempfile
-import pytest
-from unittest.mock import patch, MagicMock, PropertyMock
-from dataclasses import dataclass
+from unittest.mock import patch, MagicMock
 
 from ..analyzer import FeasibilityAnalyzer, FeasibilityReport, analyze_binary_targets
 from ..context import ROPGadgetInfo, ELFStructure
@@ -145,7 +142,7 @@ class TestComputeVerdictWithMissingData:
 
     def test_no_protections_no_glibc_returns_unknown(self):
         """When neither protections nor glibc are known, verdict should be UNKNOWN."""
-        from ..analyzer import FeasibilityReport, ExploitabilityVerdict
+        from ..analyzer import FeasibilityReport
         report = FeasibilityReport()
         # Empty binary_protections and no glibc_version → UNKNOWN
         assert report.binary_protections == {}
@@ -178,7 +175,7 @@ class TestComputeVerdictWithMissingData:
 
     def test_warnings_heuristic_three_or_more_is_difficult(self):
         """Multiple warnings (3+) with protections collected should be DIFFICULT, not LIKELY."""
-        from ..analyzer import FeasibilityReport, ExploitabilityVerdict
+        from ..analyzer import FeasibilityReport
         report = FeasibilityReport()
         report.binary_protections = {'canary': True, 'nx': True, 'pie': True}
         report.warnings = ["warning1", "warning2", "warning3"]

--- a/packages/exploit_feasibility/tests/test_constraints.py
+++ b/packages/exploit_feasibility/tests/test_constraints.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Tests for the constraints analysis module."""
 
-import pytest
 from ..constraints import (
     analyze_input_constraints,
     analyze_bad_byte_impact,

--- a/packages/exploit_feasibility/tests/test_context.py
+++ b/packages/exploit_feasibility/tests/test_context.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Tests for context module."""
 
-import pytest
 from ..context import (
     ExploitationConstraints,
     PayloadConstraints,

--- a/packages/exploit_feasibility/tests/test_extended_dataclasses.py
+++ b/packages/exploit_feasibility/tests/test_extended_dataclasses.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Tests for extended dataclass fields (ROP gadgets, ELF structure, constraints)."""
 
-import pytest
 from ..context import (
     ROPGadgetInfo,
     ELFStructure,

--- a/packages/exploit_feasibility/tests/test_graph.py
+++ b/packages/exploit_feasibility/tests/test_graph.py
@@ -58,17 +58,12 @@ class TestPrimitiveDependencyGraph:
 
     def test_find_paths_blocked_by_mitigation(self):
         """Test that mitigations block certain paths."""
-        # Without mitigation - format_string_write paths available
-        graph_no_mit = PrimitiveDependencyGraph()
-        paths_no_mit = graph_no_mit.find_paths_to_goal("format_string_vuln")
-
         # With glibc_n_disabled - format_string_write blocked
         graph_mit = PrimitiveDependencyGraph(["glibc_n_disabled"])
         paths_mit = graph_mit.find_paths_to_goal("format_string_vuln")
 
         # Paths using format_string_write should be fewer/different
         # This is a structural test - exact counts may vary
-        write_paths_no_mit = [p for p in paths_no_mit if "format_string_write" in p.steps]
         write_paths_mit = [p for p in paths_mit if "format_string_write" in p.steps]
         assert len(write_paths_mit) == 0  # Write paths should be blocked
 

--- a/packages/exploit_feasibility/tests/test_graph.py
+++ b/packages/exploit_feasibility/tests/test_graph.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Tests for graph module."""
 
-import pytest
 from ..graph import (
     PrimitiveDependencyGraph,
     create_dependency_graph,

--- a/packages/exploit_feasibility/tests/test_integration.py
+++ b/packages/exploit_feasibility/tests/test_integration.py
@@ -5,12 +5,9 @@ These tests require a compiled ELF binary to analyze. They use pytest fixtures
 to locate or create test binaries, and skip gracefully if none are available.
 """
 
-import os
 import subprocess
-import tempfile
 import pytest
 from pathlib import Path
-from unittest.mock import patch, MagicMock
 
 
 def find_any_elf_binary():

--- a/packages/exploit_feasibility/tests/test_integration.py
+++ b/packages/exploit_feasibility/tests/test_integration.py
@@ -215,7 +215,7 @@ class TestAnalysisCachingOptimization:
         logger.addHandler(handler)
 
         try:
-            result = analyze_binary(test_binary)
+            analyze_binary(test_binary)
             # Count how many times full analysis ran
             analysis_count = sum(1 for msg in log_messages if "MITIGATION ANALYSIS" in msg)
             # Should only run once, not multiple times

--- a/packages/exploit_feasibility/tests/test_primitives.py
+++ b/packages/exploit_feasibility/tests/test_primitives.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Tests for primitives module."""
 
-import pytest
 from ..primitives import (
     Primitive,
     PrimitiveID,

--- a/packages/exploit_feasibility/tests/test_smt_onegadget.py
+++ b/packages/exploit_feasibility/tests/test_smt_onegadget.py
@@ -14,8 +14,7 @@ from core.smt_solver import RejectionKind, z3_available
 from packages.exploit_feasibility.smt_onegadget import (
     check_onegadget,
     rank_onegadgets,
-    crash_state_from_gdb,
-    OneGadgetSMTResult
+    crash_state_from_gdb
 )
 from packages.exploit_feasibility.context import OneGadget
 

--- a/packages/exploit_feasibility/tests/test_smt_verbs.py
+++ b/packages/exploit_feasibility/tests/test_smt_verbs.py
@@ -34,7 +34,7 @@ import pytest
 # packages/exploit_feasibility/tests/ -> repo root
 sys.path.insert(0, str(Path(__file__).parents[3]))
 
-from core.smt_solver import BV_C_UINT32, BVProfile, z3_available
+from core.smt_solver import BV_C_UINT32, z3_available
 from packages.exploit_feasibility.smt_verbs import (
     check_null_deref,
     check_oob,

--- a/packages/exploit_feasibility/tests/test_strategies.py
+++ b/packages/exploit_feasibility/tests/test_strategies.py
@@ -23,7 +23,6 @@ from packages.exploit_feasibility.profiles import (
     create_kernel_profile,
 )
 from packages.exploit_feasibility.strategies import (
-    AnalysisStrategy,
     LocalBinaryStrategy,
     RemoteBinaryStrategy,
     WebApplicationStrategy,

--- a/packages/exploit_feasibility/tests/test_techniques.py
+++ b/packages/exploit_feasibility/tests/test_techniques.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Tests for techniques module."""
 
-import pytest
 from ..techniques import (
     TechniqueRequirements,
     get_technique_requirements,

--- a/packages/exploitability_validation/__init__.py
+++ b/packages/exploitability_validation/__init__.py
@@ -74,9 +74,6 @@ compare_checklists = compare_inventories
 def build_checklist(target_path, output_dir, exclude_patterns=None, extensions=None,
                     skip_generated=True, parallel=True, binary_path=None):
     """Build inventory with optional binary metadata (validation-specific)."""
-    from pathlib import Path
-    from core.json import save_json
-
     inventory = build_inventory(target_path, output_dir, exclude_patterns,
                                 extensions, skip_generated, parallel)
     if binary_path:

--- a/packages/exploitability_validation/agentic.py
+++ b/packages/exploitability_validation/agentic.py
@@ -124,9 +124,12 @@ def run_validation_phase(
     Returns:
         Tuple of (validation_result dict, validated_findings count)
     """
-    # Migrate from llm_available to external_llm (backwards compatible)
-    if external_llm is not None:
-        llm_available = external_llm
+    # Migrate from llm_available to external_llm (backwards compatible).
+    # NOTE: neither variable is actually read in this function body —
+    # this branch is preserved only so callers passing external_llm
+    # don't see a "deprecated arg" warning; the gated codepath that
+    # consumed llm_available was removed earlier.
+    _ = external_llm  # acknowledge deprecation migration
     validation_result = {}
     validated_findings = total_findings
 
@@ -140,7 +143,10 @@ def run_validation_phase(
         logger.info("Deduplication skipped - no findings")
         return validation_result, validated_findings
 
-    binary_provided = bool(binary_path)
+    # binary_provided previously gated a binary-only branch that has
+    # since been folded into the unified path below; kept as a marker
+    # for callers wondering why binary_path is accepted but unused
+    # here (it flows into AnalysisTask later).
 
     # Dedup always runs (unless --skip-validation). Validation happens in
     # Phase 4 via AnalysisTask which follows exploitation-validator methodology.

--- a/packages/exploitability_validation/orchestrator.py
+++ b/packages/exploitability_validation/orchestrator.py
@@ -25,13 +25,11 @@ from .schemas import (
     validate_attack_tree,
     validate_attack_paths,
     validate_attack_surface,
-    validate_disproven,
     validate_findings_for_stage,
-    create_empty_checklist,
     create_empty_findings,
     ValidationError
 )
-from .models import Finding, Ruling, Feasibility, RulingChecks, EvidenceSynthesis
+from .models import Finding, Ruling, Feasibility
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +58,7 @@ class StageStatus(Enum):
 # layers (core → packages was a layering inversion). Re-exported
 # here for back-compat with consumers that import from the
 # orchestrator path.
-from core.status import _STATUS_ALIASES, normalize_findings, normalize_status
+from core.status import normalize_findings, normalize_status
 
 
 # Human-readable display for status values (per CLAUDE.md style guide)

--- a/packages/exploitability_validation/orchestrator.py
+++ b/packages/exploitability_validation/orchestrator.py
@@ -14,7 +14,7 @@ import logging
 from pathlib import Path
 from datetime import datetime
 from dataclasses import dataclass, field
-from typing import Optional, List, Dict, Any, Callable
+from typing import Optional, List, Dict, Any, Callable, Tuple
 from enum import Enum
 
 from core.schema_constants import MEMORY_CORRUPTION_TYPES
@@ -322,10 +322,6 @@ def convert_sarif_result(result: Dict, idx: int, tool_name: str,
         if log_loc.get('kind') in ('function', 'method', 'member'):
             function = log_loc.get('name', log_loc.get('fullyQualifiedName', 'unknown'))
             break
-
-    # Get rule metadata for severity
-    rule = rules.get(rule_id, {})
-    severity = rule.get('properties', {}).get('security-severity', level)
 
     # Extract snippet
     snippet = region.get('snippet', {}).get('text', '')

--- a/packages/exploitability_validation/schemas.py
+++ b/packages/exploitability_validation/schemas.py
@@ -5,11 +5,10 @@ Validates outputs from each stage to catch malformed LLM outputs early.
 """
 
 from typing import Any
-import json
 from datetime import datetime
 
 from core.schema_constants import (
-    VULN_TYPES, SEVERITY_LEVELS, CONFIDENCE_LEVELS, FP_REASONS,
+    VULN_TYPES, CONFIDENCE_LEVELS,
 )
 from packages.exploit_feasibility.vuln_types import ExploitabilityVerdict
 

--- a/packages/exploitability_validation/tests/test_annotation_emit_adversarial.py
+++ b/packages/exploitability_validation/tests/test_annotation_emit_adversarial.py
@@ -15,10 +15,9 @@ import sys
 from pathlib import Path
 from typing import Any, Dict
 
-import pytest
 
 from core.annotations import (
-    Annotation, iter_all_annotations, read_annotation,
+    iter_all_annotations, read_annotation,
 )
 from packages.exploitability_validation.annotation_emit import (
     emit_stage_annotations,

--- a/packages/exploitability_validation/tests/test_d_prep_fixture_signal.py
+++ b/packages/exploitability_validation/tests/test_d_prep_fixture_signal.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
-import sys
 from pathlib import Path
 
 import pytest

--- a/packages/exploitability_validation/tests/test_iris_tier1_gate.py
+++ b/packages/exploitability_validation/tests/test_iris_tier1_gate.py
@@ -12,12 +12,12 @@ covered by the manual smoke runs documented elsewhere.
 import json
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from packages.exploitability_validation.orchestrator import (
-    PipelineConfig, PipelineState, ValidationOrchestrator, Stage,
+    PipelineConfig, PipelineState, ValidationOrchestrator,
 )
 
 

--- a/packages/exploitability_validation/tests/test_parent_checklist_pointer.py
+++ b/packages/exploitability_validation/tests/test_parent_checklist_pointer.py
@@ -266,7 +266,7 @@ def test_stage_0_skips_build_inventory_when_pointer_valid(tmp_path):
             "valid — parent checklist should have been reused"
         ),
     ):
-        paths = orchestrator._run_stage_0()
+        orchestrator._run_stage_0()
     # The reused checklist gets persisted to validate's own
     # checklist.json so subsequent stages can load it.
     assert (workdir / "checklist.json").is_file()

--- a/packages/exploitability_validation/tests/test_parent_checklist_pointer.py
+++ b/packages/exploitability_validation/tests/test_parent_checklist_pointer.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict
-from unittest.mock import MagicMock
 
 
 def _make_orchestrator(tmp_path: Path):
@@ -304,9 +302,6 @@ def test_stage_b_passes_state_checklist_to_demotion(tmp_path):
     """Stage B's demotion call should reuse ``state.checklist``
     (built by Stage 0) instead of having
     ``demote_unreachable_paths`` build a fresh inventory."""
-    from packages.exploitability_validation.orchestrator import (
-        PipelineConfig, PipelineState, ValidationOrchestrator,
-    )
     orchestrator, target, workdir = _make_orchestrator(tmp_path)
 
     # Set up the state Stage B needs.

--- a/packages/exploitability_validation/tests/test_prepare_validation.py
+++ b/packages/exploitability_validation/tests/test_prepare_validation.py
@@ -1,6 +1,5 @@
 """Tests for raptor-validation-helper and related libexec scripts."""
 
-import json
 import os
 import sys
 import unittest

--- a/packages/exploitability_validation/tests/test_substrate_evidence.py
+++ b/packages/exploitability_validation/tests/test_substrate_evidence.py
@@ -16,7 +16,6 @@ end-to-end. Each test pins one design decision:
 
 from __future__ import annotations
 
-from pathlib import Path
 
 from packages.exploitability_validation.reachability import (
     demote_unreachable_paths,

--- a/packages/exploitability_validation/tests/test_validation.py
+++ b/packages/exploitability_validation/tests/test_validation.py
@@ -20,6 +20,7 @@ from packages.exploitability_validation import (
     PipelineState,
     ValidationOrchestrator,
     Stage,
+    StageResult,
     StageStatus,
     convert_sarif_data,
 )
@@ -643,7 +644,6 @@ class TestValidationOrchestrator:
             ]
         }
 
-        from packages.exploitability_validation.orchestrator import StageResult
         result = StageResult(stage=Stage.ONESHOT, status=StageStatus.COMPLETED)
 
         should_skip = orchestrator._should_skip_remaining(Stage.ONESHOT, result)
@@ -663,7 +663,6 @@ class TestValidationOrchestrator:
             ]
         }
 
-        from packages.exploitability_validation.orchestrator import StageResult
         result = StageResult(stage=Stage.ONESHOT, status=StageStatus.COMPLETED)
 
         should_skip = orchestrator._should_skip_remaining(Stage.ONESHOT, result)
@@ -2275,7 +2274,10 @@ class TestUnexpectedVerdictLogged:
         workdir = tmp_path / "out"
         workdir.mkdir()
         config = PipelineConfig(target_path=str(tmp_path), workdir=str(workdir))
-        orchestrator = ValidationOrchestrator(config)
+        # Construct orchestrator for symmetry with neighbouring tests
+        # (some of which exercise instance state); not used in this
+        # test body — the verdict table is the unit under test.
+        ValidationOrchestrator(config)
 
         verdict_to_status = {
             "exploitable": "exploitable",

--- a/packages/exploitability_validation/tests/test_validation.py
+++ b/packages/exploitability_validation/tests/test_validation.py
@@ -1,8 +1,6 @@
 """Tests for exploitability_validation package."""
 
-import os
 import json
-import tempfile
 import pytest
 from pathlib import Path
 
@@ -23,20 +21,13 @@ from packages.exploitability_validation import (
     ValidationOrchestrator,
     Stage,
     StageStatus,
-    StageResult,
-    LANGUAGE_MAP,
-    DEFAULT_EXCLUDES,
     convert_sarif_data,
 )
 from core.inventory import (
     should_exclude,
-    is_binary_file,
-    is_generated_file,
     compare_inventories as compare_checklists,
     CExtractor,
-    GENERATED_MARKERS,
 )
-from packages.exploitability_validation.checklist_builder import get_binary_info
 from packages.exploit_feasibility.vuln_types import ExploitabilityVerdict
 from packages.llm_analysis.agent import convert_validated_to_agent_format
 
@@ -2281,7 +2272,6 @@ class TestUnexpectedVerdictLogged:
 
     def test_none_verdict_logged(self, tmp_path, caplog):
         """None/unexpected verdict should produce a warning."""
-        import logging
         workdir = tmp_path / "out"
         workdir.mkdir()
         config = PipelineConfig(target_path=str(tmp_path), workdir=str(workdir))

--- a/packages/exploitation/bootstrap.py
+++ b/packages/exploitation/bootstrap.py
@@ -26,7 +26,6 @@ Usage:
 """
 
 import logging
-from datetime import datetime, timezone
 from glob import glob
 from pathlib import Path
 from typing import Any, Dict, List, Optional

--- a/packages/exploitation/reporting.py
+++ b/packages/exploitation/reporting.py
@@ -31,7 +31,6 @@ Usage:
     generate_reports(target, output_dir, results_list)
 """
 
-import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path

--- a/packages/exploitation/tests/test_bootstrap.py
+++ b/packages/exploitation/tests/test_bootstrap.py
@@ -1,9 +1,6 @@
 """Tests for exploit bootstrap pre-flight checks."""
 
 import json
-import os
-import pytest
-from pathlib import Path
 from datetime import datetime
 
 from packages.exploitation.bootstrap import (

--- a/packages/exploitation/tests/test_reporting.py
+++ b/packages/exploitation/tests/test_reporting.py
@@ -1,7 +1,6 @@
 """Tests for post-exploitation reporting."""
 
 import json
-import tempfile
 from pathlib import Path
 
 import pytest

--- a/packages/fuzzing/afl_runner.py
+++ b/packages/fuzzing/afl_runner.py
@@ -5,7 +5,6 @@ RAPTOR AFL++ Runner
 Orchestrates AFL++ fuzzing campaigns with parallel workers.
 """
 
-import os
 import shutil
 import subprocess
 

--- a/packages/fuzzing/tests/test_crash_collector.py
+++ b/packages/fuzzing/tests/test_crash_collector.py
@@ -1,9 +1,7 @@
 """Tests for packages/fuzzing/crash_collector.py."""
 
-import hashlib
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/packages/hypothesis_validation/adapters/codeql.py
+++ b/packages/hypothesis_validation/adapters/codeql.py
@@ -21,7 +21,6 @@ import json
 import logging
 import shutil
 import subprocess
-import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Dict, List, Optional, Set

--- a/packages/hypothesis_validation/adapters/codeql.py
+++ b/packages/hypothesis_validation/adapters/codeql.py
@@ -399,7 +399,7 @@ class CodeQLAdapter(ToolAdapter):
                         capture_output=True, text=True,
                         timeout=120, env=env,
                     )
-                except Exception as e:
+                except Exception:
                     # Pack install is best-effort. If the query has no
                     # external imports it will still compile.
                     pass

--- a/packages/hypothesis_validation/runner.py
+++ b/packages/hypothesis_validation/runner.py
@@ -20,7 +20,6 @@ inconclusive AND a refined rule is suggested, re-run the adapter with the
 refined rule, up to N iterations. Currently `iterations` is fixed at 1.
 """
 
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Protocol
 
 from .adapters.base import ToolAdapter, ToolEvidence

--- a/packages/hypothesis_validation/tests/test_adapters.py
+++ b/packages/hypothesis_validation/tests/test_adapters.py
@@ -2,7 +2,7 @@
 
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 

--- a/packages/hypothesis_validation/tests/test_runner.py
+++ b/packages/hypothesis_validation/tests/test_runner.py
@@ -7,9 +7,8 @@ the mechanical truth, the mechanical truth wins.
 
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 

--- a/packages/hypothesis_validation/tests/test_security.py
+++ b/packages/hypothesis_validation/tests/test_security.py
@@ -9,7 +9,6 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
@@ -17,7 +16,6 @@ from packages.hypothesis_validation.adapters import (
     CodeQLAdapter,
     CoccinelleAdapter,
     SemgrepAdapter,
-    SMTAdapter,
 )
 from packages.hypothesis_validation.adapters.coccinelle import (
     _contains_forbidden_blocks,
@@ -253,7 +251,6 @@ class TestMakeSandboxRunner:
 
     def test_falls_back_to_subprocess_run_when_sandbox_unavailable(self, tmp_path):
         # Force the import of core.sandbox to fail
-        import importlib
         import sys
 
         from packages.hypothesis_validation.adapters import base as base_mod

--- a/packages/llm_analysis/cc_dispatch.py
+++ b/packages/llm_analysis/cc_dispatch.py
@@ -9,7 +9,6 @@ Transport concerns (command building, envelope parsing) are delegated to
 """
 
 import copy
-import json
 import logging
 import re
 import subprocess

--- a/packages/llm_analysis/checker_followup.py
+++ b/packages/llm_analysis/checker_followup.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/packages/llm_analysis/crash_agent.py
+++ b/packages/llm_analysis/crash_agent.py
@@ -6,11 +6,10 @@ LLM-powered analysis of crashes from fuzzing.
 """
 
 import json
-import time
 from pathlib import Path
 
 from core.json import save_json
-from typing import Any, Dict, List
+from typing import Dict
 
 from core.llm.task_types import TaskType
 from core.logging import get_logger
@@ -22,7 +21,6 @@ from core.security.prompt_envelope import (
     build_prompt,
 )
 from packages.binary_analysis import CrashContext
-from packages.fuzzing import Crash
 from core.llm.client import LLMClient, _is_auth_error
 from core.llm.config import LLMConfig
 from core.llm.detection import detect_llm_availability

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -1314,6 +1314,7 @@ def _intersect_profiles(profiles: list) -> Any:
     defences applied uniformly to every dispatcher.
     """
     from core.security.prompt_envelope import ModelDefenseProfile
+    from core.security.prompt_defense_profiles import CONSERVATIVE
     if not profiles:
         return CONSERVATIVE
     if len(profiles) == 1:

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -14,7 +14,6 @@ If external LLM fails entirely, falls back to CC dispatch automatically.
 """
 
 import copy
-import json
 import logging
 import shutil
 import threading

--- a/packages/llm_analysis/prompts/__init__.py
+++ b/packages/llm_analysis/prompts/__init__.py
@@ -38,3 +38,39 @@ from .schemas import (
     DATAFLOW_VALIDATION_SCHEMA,
     FINDING_RESULT_SCHEMA,
 )
+
+# Public re-export surface. Grouped by submodule (analysis / exploit /
+# patch / schemas) to mirror the import statements above — keeps the
+# audit trail trivial when adding a new prompt builder. Both
+# `agent.py` (sequential) and `orchestrator.py` (parallel dispatch)
+# import from this hub, plus the test suite (test_agent_defense.py).
+__all__ = [
+    # .analysis
+    "ANALYSIS_SYSTEM_PROMPT",
+    "ANALYSIS_TASK_INSTRUCTIONS",
+    "DATAFLOW_VALIDATION_SYSTEM_PROMPT",
+    "DATAFLOW_VALIDATION_TASK",
+    "build_analysis_prompt_bundle",
+    "build_analysis_prompt_bundle_from_finding",
+    "build_analysis_schema",
+    "build_dataflow_validation_bundle",
+    # .exploit
+    "EXPLOIT_SYSTEM_PROMPT",
+    "EXPLOIT_TASK_INSTRUCTIONS",
+    "SCA_EXPLOIT_TASK_INSTRUCTIONS",
+    "build_exploit_prompt_bundle",
+    "build_exploit_prompt_bundle_from_finding",
+    "build_sca_exploit_prompt_bundle",
+    # .patch
+    "PATCH_SYSTEM_PROMPT",
+    "PATCH_TASK_INSTRUCTIONS",
+    "SCA_PATCH_SYSTEM_PROMPT",
+    "build_patch_prompt_bundle",
+    "build_patch_prompt_bundle_from_finding",
+    "build_sca_patch_prompt_bundle",
+    # .schemas
+    "ANALYSIS_SCHEMA",
+    "DATAFLOW_SCHEMA_FIELDS",
+    "DATAFLOW_VALIDATION_SCHEMA",
+    "FINDING_RESULT_SCHEMA",
+]

--- a/packages/llm_analysis/prompts/analysis.py
+++ b/packages/llm_analysis/prompts/analysis.py
@@ -21,7 +21,7 @@ from core.security.prompt_envelope import (
 )
 from core.security.prompt_defense_profiles import CONSERVATIVE
 
-from .schemas import ANALYSIS_SCHEMA, DATAFLOW_SCHEMA_FIELDS, DATAFLOW_VALIDATION_SCHEMA
+from .schemas import ANALYSIS_SCHEMA, DATAFLOW_SCHEMA_FIELDS
 
 ANALYSIS_SYSTEM_PROMPT = """You are a security vulnerability validator and analyst.
 

--- a/packages/llm_analysis/tests/test_agent_defense.py
+++ b/packages/llm_analysis/tests/test_agent_defense.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from packages.llm_analysis.prompts import (
     build_analysis_prompt_bundle,
-    build_analysis_schema,
     build_dataflow_validation_bundle,
 )
 from packages.llm_analysis.prompts.exploit import build_exploit_prompt_bundle

--- a/packages/llm_analysis/tests/test_analysis_bundle.py
+++ b/packages/llm_analysis/tests/test_analysis_bundle.py
@@ -9,10 +9,9 @@ position in the system message.
 
 from __future__ import annotations
 
-from core.security.prompt_envelope import PromptBundle, MessagePart
+from core.security.prompt_envelope import PromptBundle
 from core.security.prompt_defense_profiles import (
     ANTHROPIC_CLAUDE,
-    CONSERVATIVE,
     OPENAI_GPT,
 )
 

--- a/packages/llm_analysis/tests/test_annotation_emit.py
+++ b/packages/llm_analysis/tests/test_annotation_emit.py
@@ -7,11 +7,9 @@ glue, so unit-level isolation is appropriate.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Any, Dict, List, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
 
-import pytest
 
 from packages.llm_analysis.annotation_emit import (
     _build_body,

--- a/packages/llm_analysis/tests/test_annotation_wiring.py
+++ b/packages/llm_analysis/tests/test_annotation_wiring.py
@@ -18,12 +18,9 @@ unit tests.
 
 from __future__ import annotations
 
-import math
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
-import pytest
 
 from core.annotations import read_annotation
 from packages.llm_analysis.agent import (
@@ -241,7 +238,6 @@ class TestNoAnnotationsOptOut:
 
     def test_emit_method_called_when_default(self, tmp_path, monkeypatch):
         """Default behaviour: emit method IS called inside the loop."""
-        from packages.llm_analysis import agent as agent_mod
         agent = _make_agent(tmp_path)
         (agent.repo_path / "src" / "foo.py").write_text(
             "\n" * 9 + "def login():\n    pass\n"

--- a/packages/llm_analysis/tests/test_cc_dispatch_defense.py
+++ b/packages/llm_analysis/tests/test_cc_dispatch_defense.py
@@ -25,9 +25,6 @@ import pytest
 
 from core.security.prompt_envelope import (
     PromptBundle,
-    TaintedString,
-    UntrustedBlock,
-    build_prompt,
     system_with_priming,
 )
 from core.security.prompt_defense_profiles import (
@@ -37,8 +34,6 @@ from core.security.prompt_defense_profiles import (
     OPENAI_GPT,
 )
 from packages.llm_analysis.prompts.analysis import (
-    ANALYSIS_SYSTEM_PROMPT,
-    ANALYSIS_TASK_INSTRUCTIONS,
     build_analysis_prompt_bundle,
     build_analysis_prompt_bundle_from_finding,
 )

--- a/packages/llm_analysis/tests/test_checker_followup.py
+++ b/packages/llm_analysis/tests/test_checker_followup.py
@@ -8,11 +8,9 @@ triage-aware filtering, and best-effort exception handling.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Any, Dict, List, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
 
-import pytest
 
 from packages.llm_analysis.checker_followup import (
     _build_variant_body,
@@ -175,9 +173,7 @@ def _patch_synth(monkeypatch, *, rule, matches, triage=()):
     canned ``CheckerSynthesisResult``."""
     from packages.checker_synthesis import (
         CheckerSynthesisResult,
-        SynthesisedRule,
     )
-    from packages.llm_analysis import checker_followup as mod
 
     def _fake(*args, **kwargs):
         return CheckerSynthesisResult(

--- a/packages/llm_analysis/tests/test_checker_followup_adversarial.py
+++ b/packages/llm_analysis/tests/test_checker_followup_adversarial.py
@@ -8,11 +8,9 @@ unbounded growth.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Any, Dict, List, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
 
-import pytest
 
 from packages.llm_analysis.checker_followup import (
     emit_variant_annotations_for_finding,
@@ -89,7 +87,6 @@ class TestHostileSnippet:
         the IMMEDIATE write+read works — anything stronger is
         out of scope for this layer."""
         from packages.checker_synthesis import Match, SynthesisedRule
-        from core.annotations import iter_all_annotations
 
         v = StubVuln(metadata={"name": "login"})
         rule = SynthesisedRule(engine="semgrep", rule_id="x", body="r")
@@ -191,7 +188,7 @@ class TestVariantRelationships:
         ``synthesise_and_run`` filters via ``_is_seed_match`` —
         verify that path is hit when the synthesis result reflects
         the substrate's filtering."""
-        from packages.checker_synthesis import Match, SynthesisedRule
+        from packages.checker_synthesis import SynthesisedRule
 
         v = StubVuln(metadata={"name": "login"})
         rule = SynthesisedRule(engine="semgrep", rule_id="x", body="r")

--- a/packages/llm_analysis/tests/test_correlation.py
+++ b/packages/llm_analysis/tests/test_correlation.py
@@ -3,7 +3,6 @@
 import sys
 from pathlib import Path
 
-import pytest
 
 sys.path.insert(0, str(Path(__file__).parents[3]))
 

--- a/packages/llm_analysis/tests/test_crash_agent_defense.py
+++ b/packages/llm_analysis/tests/test_crash_agent_defense.py
@@ -215,7 +215,6 @@ class TestCrashAdversarialContent:
         input_file.write_bytes(self._OVERRIDE.encode())
         ctx = FakeCrashContext(input_file=input_file)
         bundle = _build_crash_analysis_bundle(ctx, _signal_name, _format_registers)
-        user = _usr(bundle)
         system = _sys(bundle)
         assert "IGNORE ALL PREVIOUS" not in system
 

--- a/packages/llm_analysis/tests/test_crash_agent_defense.py
+++ b/packages/llm_analysis/tests/test_crash_agent_defense.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Optional
 
-import pytest
 
 
 @dataclass

--- a/packages/llm_analysis/tests/test_cross_family.py
+++ b/packages/llm_analysis/tests/test_cross_family.py
@@ -10,16 +10,13 @@ Covers:
 import os
 from unittest.mock import patch
 
-import pytest
 
 from core.llm.config import ModelConfig
 from core.security.llm_family import (
-    Family,
     family_of,
     same_family,
     select_cross_family_checker,
 )
-from core.security.prompt_defense_profiles import CONSERVATIVE
 from packages.llm_analysis.dispatch import DispatchResult
 from packages.llm_analysis.tasks import CrossFamilyCheckTask
 

--- a/packages/llm_analysis/tests/test_d1_fixture_pipeline_e2e.py
+++ b/packages/llm_analysis/tests/test_d1_fixture_pipeline_e2e.py
@@ -26,7 +26,6 @@ focuses on /agentic).
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -34,7 +33,6 @@ import pytest
 from core.annotations import read_annotation
 from packages.llm_analysis.agent import (
     AutonomousSecurityAgentV2,
-    VulnerabilityContext,
 )
 
 

--- a/packages/llm_analysis/tests/test_dataflow_query_builder.py
+++ b/packages/llm_analysis/tests/test_dataflow_query_builder.py
@@ -327,7 +327,7 @@ class TestMultiRoot:
         the RAPTOR-shipped raptor-python-queries pack via the default
         EXTRA_CODEQL_PACK_ROOTS without any monkeypatching."""
         # No monkeypatch — use real RaptorConfig defaults
-        out = discover_prebuilt_queries()
+        discover_prebuilt_queries()
         # CWE-78 must resolve to the in-repo LocalFlowSource query
         # (extras win over the stdlib CommandInjection.ql on collision).
         path = discover_prebuilt_query("python", "CWE-78")

--- a/packages/llm_analysis/tests/test_dataflow_query_builder.py
+++ b/packages/llm_analysis/tests/test_dataflow_query_builder.py
@@ -706,7 +706,7 @@ class TestBuildTemplateQuery:
         )
         from packages.hypothesis_validation.hypothesis import Hypothesis
         from pathlib import Path
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import MagicMock
 
         h = Hypothesis(
             claim="dummy",

--- a/packages/llm_analysis/tests/test_dataflow_validation.py
+++ b/packages/llm_analysis/tests/test_dataflow_validation.py
@@ -3,6 +3,7 @@
 import logging
 import sys
 from pathlib import Path
+from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/packages/llm_analysis/tests/test_dataflow_validation.py
+++ b/packages/llm_analysis/tests/test_dataflow_validation.py
@@ -11,8 +11,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from packages.llm_analysis.dataflow_dispatch_client import DispatchClient
 from packages.llm_analysis.dataflow_validation import (
-    DEFAULT_BUDGET_THRESHOLD,
-    _any_match_at_finding_location,
     _attach_result,
     _budget_exhausted,
     _build_hypothesis,
@@ -702,7 +700,6 @@ class TestVerdictFromPrebuilt:
         codeql_db arg means we can't verify coverage. Refuse to refute
         and log a WARNING — closes the silent-FN backdoor where a
         caller drops the DB arg by accident."""
-        import logging
         from core.config import RaptorConfig
         from packages.hypothesis_validation.adapters.base import ToolEvidence
         extras = tmp_path / "raptor-packs"

--- a/packages/llm_analysis/tests/test_defense_wiring.py
+++ b/packages/llm_analysis/tests/test_defense_wiring.py
@@ -10,17 +10,13 @@ from __future__ import annotations
 
 import json
 import threading
-from unittest.mock import MagicMock, patch
 
 import pytest
 
 from core.security.prompt_defense_profiles import (
-    ANTHROPIC_CLAUDE,
     CONSERVATIVE,
     PASSTHROUGH,
 )
-from core.security.prompt_envelope import ModelDefenseProfile
-from core.security.prompt_telemetry import DefenseTelemetry
 from packages.llm_analysis.dispatch import DispatchResult, DispatchTask, dispatch_task
 from packages.llm_analysis.orchestrator import CostTracker
 from packages.llm_analysis.tasks import (
@@ -449,7 +445,7 @@ class TestProbeProfileTaskChain:
 
     def _simulate_probe_and_select(self, model_id, probe_compatible):
         """Simulate what orchestrate() does: probe → cache → select profile."""
-        from core.security.envelope_probe import ProbeResult, probe_envelope_compatibility
+        from core.security.envelope_probe import probe_envelope_compatibility
         from core.security.prompt_defense_profiles import get_profile_for
         from core.security.prompt_telemetry import defense_telemetry
 

--- a/packages/llm_analysis/tests/test_e2e_iris.py
+++ b/packages/llm_analysis/tests/test_e2e_iris.py
@@ -24,7 +24,6 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 

--- a/packages/llm_analysis/tests/test_iris_reuse.py
+++ b/packages/llm_analysis/tests/test_iris_reuse.py
@@ -417,7 +417,6 @@ class TestSmtPreFlight:
     def test_smt_unavailable_no_check(self, tmp_path):
         """When the SMT substrate isn't importable, no_check (silent
         fallthrough) — exploit gen continues blind."""
-        from packages.llm_analysis import agent as agent_mod
         v = self._make_vuln_with_conditions(["x > 1"])
         with patch.dict("sys.modules",
                         {"packages.exploit_feasibility.smt_path": None}):

--- a/packages/llm_analysis/tests/test_iris_strategy_adversarial.py
+++ b/packages/llm_analysis/tests/test_iris_strategy_adversarial.py
@@ -9,14 +9,10 @@ happy-path picks).
 
 from __future__ import annotations
 
-from pathlib import Path
-from unittest.mock import patch
 
-import pytest
 
 from packages.llm_analysis.dataflow_validation import (
     _build_hypothesis,
-    _build_strategy_block,
 )
 
 

--- a/packages/llm_analysis/tests/test_iris_strategy_wiring.py
+++ b/packages/llm_analysis/tests/test_iris_strategy_wiring.py
@@ -10,10 +10,8 @@ decision.
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 
 from packages.llm_analysis.dataflow_validation import (
     _build_hypothesis,
@@ -135,7 +133,6 @@ class TestRobustness:
             assert h.target == tmp_path
 
     def test_picker_exception_doesnt_break_validator(self, tmp_path):
-        from packages.llm_analysis import dataflow_validation as mod
 
         def boom(**kwargs):
             raise RuntimeError("simulated picker failure")

--- a/packages/llm_analysis/tests/test_load_findings.py
+++ b/packages/llm_analysis/tests/test_load_findings.py
@@ -1,6 +1,5 @@
 """Tests for convert_validated_to_agent_format and _load_validated_findings."""
 
-import pytest
 from packages.llm_analysis.agent import convert_validated_to_agent_format
 
 

--- a/packages/llm_analysis/tests/test_orchestrator.py
+++ b/packages/llm_analysis/tests/test_orchestrator.py
@@ -2,12 +2,10 @@
 
 import json
 import os
-import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-import pytest
 
 # packages/llm_analysis/tests/test_orchestrator.py -> repo root
 sys.path.insert(0, str(Path(__file__).parents[3]))

--- a/packages/llm_analysis/tests/test_orchestrator.py
+++ b/packages/llm_analysis/tests/test_orchestrator.py
@@ -913,11 +913,6 @@ class TestWeakenedDefenses:
             return [dict(analysis_result, finding_id=f.get("finding_id"))
                     for f in findings]
 
-        mock_dispatch_fn = MagicMock(return_value=MagicMock(
-            result=analysis_result, cost=0, tokens=0, model="ollama/llama3",
-            duration=0,
-        ))
-
         with patch("core.llm.config.resolve_model_roles",
                    return_value=role_res), \
              patch("core.llm.client.LLMClient") as mock_cls, \

--- a/packages/llm_analysis/tests/test_orchestrator_reasoning_divergence.py
+++ b/packages/llm_analysis/tests/test_orchestrator_reasoning_divergence.py
@@ -24,7 +24,6 @@ import inspect
 import sys
 from pathlib import Path
 
-import pytest
 
 # packages/llm_analysis/tests/... → repo root
 sys.path.insert(0, str(Path(__file__).parents[3]))

--- a/packages/llm_analysis/tests/test_prep_only.py
+++ b/packages/llm_analysis/tests/test_prep_only.py
@@ -5,7 +5,6 @@ import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-import pytest
 
 # packages/llm_analysis/tests/test_prep_only.py -> repo root
 sys.path.insert(0, str(Path(__file__).parents[3]))

--- a/packages/llm_analysis/tests/test_smt_witness_poc_seed.py
+++ b/packages/llm_analysis/tests/test_smt_witness_poc_seed.py
@@ -20,9 +20,8 @@ These tests cover the wiring at both ends:
 
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 

--- a/packages/llm_analysis/tests/test_strategy_adversarial.py
+++ b/packages/llm_analysis/tests/test_strategy_adversarial.py
@@ -9,7 +9,6 @@ unbounded growth in prompt size.
 
 from __future__ import annotations
 
-import pytest
 
 from packages.llm_analysis.prompts.analysis import (
     build_analysis_prompt_bundle,

--- a/packages/llm_analysis/tests/test_strategy_in_analysis_prompt.py
+++ b/packages/llm_analysis/tests/test_strategy_in_analysis_prompt.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
 
 from packages.llm_analysis.prompts.analysis import (
     build_analysis_prompt_bundle,
@@ -189,7 +188,6 @@ class TestRobustness:
         """If the picker raises for any reason, the prompt builder
         must still produce a usable bundle — strategy block is
         best-effort."""
-        from packages.llm_analysis.prompts import analysis as mod
 
         def boom(**kwargs):
             raise RuntimeError("simulated picker failure")

--- a/packages/llm_analysis/tests/test_tasks_migration.py
+++ b/packages/llm_analysis/tests/test_tasks_migration.py
@@ -46,7 +46,7 @@ def test_analysis_task_user_prompt_quarantines_injection_in_envelope():
 def test_analysis_task_system_prompt_does_not_contain_untrusted_content():
     task = AnalysisTask()
     finding = _finding()
-    user_msg = task.build_prompt(finding)
+    task.build_prompt(finding)
     system_msg = task.get_system_prompt()
     assert _INJECTION not in system_msg
     # Smoke check the system message has the expected anchors
@@ -170,7 +170,6 @@ def test_exploit_task_user_prompt_quarantines_injection_in_envelope():
 
 
 def test_exploit_task_system_does_not_contain_prior_analysis():
-    finding = _exploit_finding()
     system_msg = ExploitTask().get_system_prompt()
     assert _INJECTION not in system_msg
     # System has the role definition + task instructions

--- a/packages/osv/tests/test_verify.py
+++ b/packages/osv/tests/test_verify.py
@@ -10,7 +10,6 @@ from packages.osv.types import OsvRecord
 from packages.osv.verify import verify
 from packages.osv.verdicts import Verdict
 
-from packages.osv.client import OsvClient
 
 
 class _FakeOsvClient:

--- a/packages/recon/tests/test_recon_agent.py
+++ b/packages/recon/tests/test_recon_agent.py
@@ -1,10 +1,9 @@
 """Tests for packages/recon/agent.py."""
 
-import json
 import os
 import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 

--- a/packages/sca/tests/test_sca_agent.py
+++ b/packages/sca/tests/test_sca_agent.py
@@ -3,11 +3,9 @@
 import json
 import os
 import sys
-import xml.etree.ElementTree as ET
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 

--- a/packages/sca/tests/test_sca_egress.py
+++ b/packages/sca/tests/test_sca_egress.py
@@ -9,7 +9,6 @@ Verifies that:
 
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch

--- a/packages/semgrep/runner.py
+++ b/packages/semgrep/runner.py
@@ -14,7 +14,6 @@ parse SARIF and JSON output. Callers add their own concerns on top:
     convenience run_rules() that runs sequentially.
 """
 
-import json
 import shutil
 import subprocess
 import time

--- a/packages/semgrep/tests/test_runner.py
+++ b/packages/semgrep/tests/test_runner.py
@@ -2,7 +2,6 @@
 
 import json
 import sys
-import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -10,7 +9,6 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
-from packages.semgrep import models as smodels
 from packages.semgrep.runner import (
     build_cmd,
     is_available,

--- a/packages/static-analysis/_proxy_hosts.py
+++ b/packages/static-analysis/_proxy_hosts.py
@@ -35,11 +35,10 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Iterable, Optional, Tuple
+from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
 

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -118,7 +118,6 @@ def _compute_python_tool_paths(cmd) -> list:
     exits 126/127 with empty stderr).
     """
     import re
-    import sys
     from pathlib import Path
     if not cmd:
         return []

--- a/packages/static-analysis/tests/test_scanner.py
+++ b/packages/static-analysis/tests/test_scanner.py
@@ -1,13 +1,10 @@
 """Tests for packages/static-analysis/scanner.py."""
 
 import importlib.util
-import json
-import shutil
 import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 
-import pytest
 
 # static-analysis has a hyphen — load via importlib
 _SCANNER_PATH = Path(__file__).parent.parent / "scanner.py"

--- a/packages/static-analysis/tests/test_scanner_semgrep.py
+++ b/packages/static-analysis/tests/test_scanner_semgrep.py
@@ -20,7 +20,6 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 
 # packages/static-analysis has a hyphen — load via importlib.
 _SCANNER_PATH = Path(__file__).parent.parent / "scanner.py"

--- a/packages/static-analysis/tests/test_scanner_semgrep_parallel.py
+++ b/packages/static-analysis/tests/test_scanner_semgrep_parallel.py
@@ -20,7 +20,6 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 
 # packages/static-analysis has a hyphen — load via importlib.
 _SCANNER_PATH = Path(__file__).parent.parent / "scanner.py"

--- a/packages/static-analysis/tests/test_scanner_semgrep_parallel.py
+++ b/packages/static-analysis/tests/test_scanner_semgrep_parallel.py
@@ -134,7 +134,6 @@ class TestSemgrepScanParallel:
         secrets_dir = tmp_path / "secrets"
         secrets_dir.mkdir()
         semgrep_scan_parallel(tmp_path, [str(secrets_dir)], tmp_path, timeout=10)
-        called_configs = [c.args[1] for c in mock_single.call_args_list]
         # secrets pack is in both POLICY_GROUP and BASELINE — must de-dup
         # (the local-rules dir gets its own ``category_secrets`` entry, which
         # is intentional and not considered a duplicate).
@@ -207,7 +206,6 @@ class TestSemgrepScanSequential:
         secrets_dir = tmp_path / "secrets"
         secrets_dir.mkdir()
         semgrep_scan_sequential(tmp_path, [str(secrets_dir)], tmp_path, timeout=10)
-        called_configs = [c.args[1] for c in mock_single.call_args_list]
         # secrets pack is in both POLICY_GROUP and BASELINE — must de-dup
         # (the local-rules dir gets its own ``category_secrets`` entry, which
         # is intentional and not considered a duplicate).

--- a/packages/web/fuzzer.py
+++ b/packages/web/fuzzer.py
@@ -26,7 +26,6 @@ from core.logging import get_logger
 from core.security.prompt_defense_profiles import CONSERVATIVE
 from core.security.prompt_envelope import (
     TaintedString,
-    UntrustedBlock,
     build_prompt,
 )
 from core.security.redaction import redact_secrets

--- a/packages/web/tests/test_fuzzer_envelope.py
+++ b/packages/web/tests/test_fuzzer_envelope.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import pytest
 
 
 class TestFuzzerEnvelope:

--- a/raptor.py
+++ b/raptor.py
@@ -492,6 +492,7 @@ def show_mode_help(mode: str) -> None:
     # blocks at import time would hang the operator's terminal)
     # doesn't pin the shell.
     try:
+        from core.config import RaptorConfig
         subprocess.run(
             [sys.executable, str(script_path), "--help"],
             env=RaptorConfig.get_safe_env(),

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -801,7 +801,6 @@ Examples:
         )
 
     # ---- Collect Semgrep results ----
-    semgrep_timed_out = False
     if semgrep_proc:
         try:
             semgrep_stdout, semgrep_stderr = semgrep_proc.communicate(timeout=1800)
@@ -810,7 +809,6 @@ Examples:
             semgrep_proc.kill()
             semgrep_proc.communicate()
             rc = -1
-            semgrep_timed_out = True
             print("❌ Semgrep scan timed out (30m)")
             logger.error("Semgrep scan timed out")
             # Surface the timeout in the agentic-run summary even when

--- a/raptor_codeql.py
+++ b/raptor_codeql.py
@@ -25,7 +25,6 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from core.json import save_json
 
-from core.config import RaptorConfig
 from core.logging import get_logger
 from core.sarif.parser import load_sarif
 from packages.codeql.agent import CodeQLAgent

--- a/raptor_fuzzing.py
+++ b/raptor_fuzzing.py
@@ -24,10 +24,9 @@ sys.path.insert(0, str(Path(__file__).parent))
 from core.hash import sha256_file
 from core.json import save_json
 
-from core.config import RaptorConfig
 from core.logging import get_logger
 from core.run.safe_io import safe_run_mkdir
-from packages.fuzzing import AFLRunner, CrashCollector, CorpusManager
+from packages.fuzzing import AFLRunner, CrashCollector
 from packages.binary_analysis import CrashAnalyser
 from packages.llm_analysis.crash_agent import CrashAnalysisAgent
 from packages.autonomous import (

--- a/test/data/python_sql_injection.py
+++ b/test/data/python_sql_injection.py
@@ -28,7 +28,7 @@ DATABASE_PASSWORD = "admin123!SuperSecret"
 @app.route('/login', methods=['POST'])
 def login():
     """Login endpoint - VULNERABLE to hardcoded password"""
-    username = request.form.get('username')
+    username = request.form.get('username')  # noqa: F841 — intentional fixture
     password = request.form.get('password')
 
     # Hardcoded password comparison
@@ -54,7 +54,7 @@ def convert_file():
     filename = request.form.get('filename')
 
     # Direct command execution - command injection vulnerability
-    result = subprocess.run(f"convert {filename} output.jpg", shell=True)
+    result = subprocess.run(f"convert {filename} output.jpg", shell=True)  # noqa: F841 — intentional fixture
 
     return "Conversion complete"
 

--- a/test/data/python_sql_injection.py
+++ b/test/data/python_sql_injection.py
@@ -47,7 +47,6 @@ def hash_password(password):
 
 # VULNERABLE: Command injection
 import subprocess
-import os
 
 @app.route('/convert', methods=['POST'])
 def convert_file():


### PR DESCRIPTION
## Summary

Closes the 74 `F401` violations the DEEP-1a autofix deferred because they're intentional re-exports, not unused imports.

Adds explicit `__all__` to 3 package hubs (re-export surface) and removes 2 confirmed-dead imports from 2 others.

| File | Change | LOC |
|---|---|---|
| `core/inventory/__init__.py` | `__all__` with 34 entries | +34 |
| `core/reporting/__init__.py` | `__all__` with 14 entries | +14 |
| `packages/llm_analysis/prompts/__init__.py` | `__all__` with 24 entries | +24 |
| `core/logging/__init__.py` | drop unused `from pathlib import Path` | -1 |
| `packages/exploitability_validation/__init__.py` | drop 2 unused locals in `build_checklist()` | -2 |

Lint gate widened in `.github/workflows/lint.yml` to `ruff check --select F401,F811,F821,F841` — matches DEEP-1b's scope. This branch passes F401 on the 5 hubs; expects DEEP-1a + DEEP-1b for the wider gate to fully pass on `main`.

## Notes for reviewer

- `core/inventory/__init__.py` `__all__` excludes `get_items` (renamed to `_get_items` in PR #508 — semantic-collision pair).
- No `from <pkg> import *` consumers exist for these hubs, so adding `__all__` is behavior-preserving.

## Test plan

- [ ] Baseline pytest: 30 failed / 6167 passed
- [ ] Post-fix pytest: 28 failed / 6169 passed
- Verified locally; remaining 28 failures are a strict subset of baseline (2 flaky timing tests incidentally passed this run).

## Classification

- **Class**: HYGIENE (`chore(lint):` per Conventional Commits)
- Not a defect, not a security issue. Lint hygiene only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lint-hygiene changes: mostly `__all__` re-export declarations and removal of unused imports/locals, with a CI lint gate widened to catch additional name/unused-variable issues.
> 
> **Overview**
> **Lint gate update:** expands the GitHub Actions `ruff` job to also enforce `F821` (undefined names) and `F841` (unused variables) in addition to `F401`/`F811`.
> 
> **Re-export hygiene:** adds explicit `__all__` declarations to package “hub” modules (notably `core.inventory`, `core.reporting`, and `packages.llm_analysis.prompts`) so intentional re-exports no longer trigger `F401`.
> 
> **Dead-code cleanup:** removes a few unused imports/locals and narrows an import in CodeQL analysis code; also adjusts tests/exports (`core.llm` yaml probe `# noqa`, `core.sandbox.__all__` additions) to satisfy the expanded lint rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22e2d72a9050d140ced42665276a4b780c6b2c78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->