### PR TITLE
fix(core): env-leak prevention (PYTHONUSERBASE forwarding) + opt-in strict envelope-probe (3 commits)

### DIFF
--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -633,7 +633,11 @@ class RaptorConfig:
         return RaptorConfig.MCP_JOB_DIR / job_id
 
     @staticmethod
-    def get_safe_env(*, preserve_proxy: bool = False) -> dict:
+    def get_safe_env(
+        *,
+        preserve_proxy: bool = False,
+        include_python_user_base: bool = False,
+    ) -> dict:
         """Return a sanitised copy of os.environ for subprocess use.
 
         Two-stage filter:
@@ -657,6 +661,18 @@ class RaptorConfig:
         an operator's HTTPS_PROXY setting. The dangerous-env-var
         strip still applies.
 
+        ``include_python_user_base=True`` (F102) re-admits the
+        ``PYTHONUSERBASE`` variable from the original os.environ
+        AFTER the dangerous-env-vars strip. Use only at scanner
+        invocation sites that legitimately depend on a
+        ``pip install --user`` tool (e.g. semgrep). The variable is
+        a real RCE vector via .pth files (see DANGEROUS_ENV_VARS
+        comment at PYTHONUSERBASE) and stays stripped by default;
+        but if the operator deliberately installed the scanner under
+        ``~/.local`` with a non-default ``PYTHONUSERBASE`` set, the
+        subprocess fails ``ModuleNotFoundError`` without this opt-in.
+        Mirrors the ``preserve_proxy`` opt-in pattern.
+
         Callers who need a specific extra var (JAVA_HOME for a Java tool,
         a custom CA bundle, etc.) should add it to the returned dict
         explicitly after calling get_safe_env(), or pass their own env=
@@ -674,6 +690,14 @@ class RaptorConfig:
         if not preserve_proxy:
             env = strip_env_vars(env, RaptorConfig.PROXY_ENV_VARS)
         env = strip_env_vars(env, RaptorConfig.DANGEROUS_ENV_VARS)
+        # F102: restore PYTHONUSERBASE AFTER the dangerous-var strip
+        # for callers that opted in (e.g. semgrep scanner spawn).
+        # Take the value verbatim from os.environ — do NOT invent
+        # one if the operator didn't set it.
+        if include_python_user_base:
+            _userbase = os.environ.get("PYTHONUSERBASE")
+            if _userbase is not None:
+                env["PYTHONUSERBASE"] = _userbase
         env["PYTHONUNBUFFERED"] = "1"
         return env
 

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -737,14 +737,31 @@ class RaptorConfig:
     )
 
     @staticmethod
-    def get_llm_env() -> dict:
+    def get_llm_env(
+        *,
+        include_python_user_base: bool = False,
+    ) -> dict:
         """Return get_safe_env() plus any LLM API keys present in the
         real environment.
 
         Use this for spawning RAPTOR's own analysis scripts that may call
         LLM providers.  Do NOT use for untrusted-code subprocesses.
+
+        ``include_python_user_base=True`` (F102b) forwards the opt-in
+        to the underlying ``get_safe_env()`` so PYTHONUSERBASE is
+        preserved on the returned env. Use at canonical-operator
+        spawn sites (``raptor.py:_run_script``) whose child script
+        in turn opts into the F102 restoration (e.g.
+        ``raptor_agentic.py``'s semgrep spawn at line 757). Without
+        this forwarding, the parent strips PYTHONUSERBASE before the
+        child can restore it, and the F102 fix is orphaned for
+        ``python raptor.py <mode>`` invocations. Mirrors the existing
+        ``include_python_user_base`` opt-in on ``get_safe_env`` —
+        same default-False, opt-in pattern as ``preserve_proxy``.
         """
-        env = RaptorConfig.get_safe_env()
+        env = RaptorConfig.get_safe_env(
+            include_python_user_base=include_python_user_base,
+        )
         for var in RaptorConfig.LLM_API_KEY_VARS:
             val = os.environ.get(var)
             if val:

--- a/core/config/tests/test_config.py
+++ b/core/config/tests/test_config.py
@@ -231,3 +231,74 @@ class TestEnsureDirectories:
             RaptorConfig.ensure_directories()  # must not raise
 
 
+class TestGetSafeEnvIncludePythonUserBase:
+    """F102 — opt-in restoration of PYTHONUSERBASE for scanners that
+    depend on ``pip install --user`` tools (semgrep, etc.).
+
+    Default behaviour: PYTHONUSERBASE is in DANGEROUS_ENV_VARS and
+    must remain stripped (it's a real RCE vector via .pth files —
+    see core/config/__init__.py line 396-400).
+
+    With ``include_python_user_base=True``, scanner sites that
+    legitimately invoke a pip-installed user tool can re-admit the
+    variable so the tool finds its site-packages. The same kwarg
+    pattern as ``preserve_proxy``.
+
+    Without this opt-in, an operator who installed semgrep with
+    ``pip install --user`` and set ``PYTHONUSERBASE`` outside the
+    default sees ``ModuleNotFoundError: No module named 'semgrep'``
+    when RAPTOR spawns the scanner subprocess — verified in
+    W6/W9 PoC.
+    """
+
+    def test_default_strips_pythonuserbase(self):
+        """Backward-compat regression guard: default behaviour
+        unchanged. PYTHONUSERBASE still removed."""
+        with patch.dict(os.environ, {"PYTHONUSERBASE": "/home/user/.local"}):
+            env = RaptorConfig.get_safe_env()
+            assert "PYTHONUSERBASE" not in env
+
+    def test_include_python_user_base_keeps_pythonuserbase(self):
+        """Opt-in: when caller passes
+        ``include_python_user_base=True``, the var flows through."""
+        with patch.dict(os.environ, {"PYTHONUSERBASE": "/home/user/.local"}):
+            env = RaptorConfig.get_safe_env(include_python_user_base=True)
+            assert env.get("PYTHONUSERBASE") == "/home/user/.local"
+
+    def test_include_python_user_base_no_op_when_not_set(self):
+        """If the original env has no PYTHONUSERBASE, opt-in must
+        not invent one."""
+        # Build an env without PYTHONUSERBASE
+        scrubbed = {k: v for k, v in os.environ.items() if k != "PYTHONUSERBASE"}
+        with patch.dict(os.environ, scrubbed, clear=True):
+            env = RaptorConfig.get_safe_env(include_python_user_base=True)
+            assert "PYTHONUSERBASE" not in env
+
+    def test_include_python_user_base_does_not_re_admit_other_dangerous_vars(self):
+        """Opt-in is targeted — every OTHER dangerous var must still
+        be stripped. Regression guard against an over-broad opt-in
+        that accidentally lifts the whole blocklist."""
+        injected = {var: f"malicious_{var}" for var in RaptorConfig.DANGEROUS_ENV_VARS}
+        with patch.dict(os.environ, injected):
+            env = RaptorConfig.get_safe_env(include_python_user_base=True)
+            # PYTHONUSERBASE is the ONLY var the opt-in re-admits.
+            for var in RaptorConfig.DANGEROUS_ENV_VARS:
+                if var == "PYTHONUSERBASE":
+                    assert env.get(var) == "malicious_PYTHONUSERBASE"
+                else:
+                    assert var not in env, f"{var} should still be stripped"
+
+    def test_include_python_user_base_combines_with_preserve_proxy(self):
+        """Combining both kwargs is legal — neither flag rejects
+        the other. (Whether ``preserve_proxy`` actually re-admits
+        proxy vars depends on the allowlist; out of scope here.
+        This test only guards against an accidental kwarg-collision
+        regression in the function signature.)"""
+        injected = {"PYTHONUSERBASE": "/home/user/.local"}
+        with patch.dict(os.environ, injected):
+            env = RaptorConfig.get_safe_env(
+                preserve_proxy=True, include_python_user_base=True,
+            )
+            assert env.get("PYTHONUSERBASE") == "/home/user/.local"
+
+

--- a/core/config/tests/test_config.py
+++ b/core/config/tests/test_config.py
@@ -302,3 +302,72 @@ class TestGetSafeEnvIncludePythonUserBase:
             assert env.get("PYTHONUSERBASE") == "/home/user/.local"
 
 
+class TestGetLlmEnvIncludePythonUserBase:
+    """F102b — ``get_llm_env()`` must forward
+    ``include_python_user_base`` to ``get_safe_env()``.
+
+    Without this forwarding, ``python raptor.py agentic`` (the
+    canonical operator entry point at ``raptor.py:313,317``) calls
+    ``get_llm_env()`` which strips PYTHONUSERBASE before the
+    ``raptor_agentic.py:757`` opt-in can restore it for the semgrep
+    spawn — the F102 fix is orphaned on this path.
+
+    Default (False) must keep the existing strip behaviour;
+    opt-in (True) must preserve the var. Mirrors the existing
+    ``preserve_proxy`` opt-in pattern on the underlying
+    ``get_safe_env``. Sibling test class:
+    ``TestGetSafeEnvIncludePythonUserBase``.
+    """
+
+    def test_default_strips_pythonuserbase(self):
+        """Backward-compat regression guard: default ``get_llm_env()``
+        still strips PYTHONUSERBASE (security contract unchanged)."""
+        with patch.dict(os.environ, {"PYTHONUSERBASE": "/home/user/.local"}):
+            env = RaptorConfig.get_llm_env()
+            assert "PYTHONUSERBASE" not in env
+
+    def test_include_python_user_base_keeps_pythonuserbase(self):
+        """F102b: when caller passes
+        ``include_python_user_base=True``, the var flows through to
+        the returned env so the canonical operator path
+        (``raptor.py:313,317``) can preserve it for the agentic
+        subprocess that wires it into the semgrep spawn."""
+        with patch.dict(os.environ, {"PYTHONUSERBASE": "/home/user/.local"}):
+            env = RaptorConfig.get_llm_env(include_python_user_base=True)
+            assert env.get("PYTHONUSERBASE") == "/home/user/.local"
+
+    def test_include_python_user_base_no_op_when_not_set(self):
+        """If the original env has no PYTHONUSERBASE, opt-in must
+        not invent one."""
+        scrubbed = {k: v for k, v in os.environ.items() if k != "PYTHONUSERBASE"}
+        with patch.dict(os.environ, scrubbed, clear=True):
+            env = RaptorConfig.get_llm_env(include_python_user_base=True)
+            assert "PYTHONUSERBASE" not in env
+
+    def test_include_python_user_base_does_not_re_admit_other_dangerous_vars(self):
+        """Opt-in is targeted — the LLM-env opt-in must not lift the
+        wider DANGEROUS_ENV_VARS blocklist (regression guard against
+        an over-broad forwarding implementation)."""
+        injected = {var: f"malicious_{var}" for var in RaptorConfig.DANGEROUS_ENV_VARS}
+        with patch.dict(os.environ, injected):
+            env = RaptorConfig.get_llm_env(include_python_user_base=True)
+            for var in RaptorConfig.DANGEROUS_ENV_VARS:
+                if var == "PYTHONUSERBASE":
+                    assert env.get(var) == "malicious_PYTHONUSERBASE"
+                else:
+                    assert var not in env, f"{var} should still be stripped"
+
+    def test_include_python_user_base_preserves_llm_api_key_passthrough(self):
+        """Combining the opt-in with the LLM-key passthrough must
+        not break either contract: API keys still flow, PYTHONUSERBASE
+        is preserved."""
+        injected = {
+            "PYTHONUSERBASE": "/home/user/.local",
+            "ANTHROPIC_API_KEY": "sk-ant-test-f102b",
+        }
+        with patch.dict(os.environ, injected):
+            env = RaptorConfig.get_llm_env(include_python_user_base=True)
+            assert env.get("PYTHONUSERBASE") == "/home/user/.local"
+            assert env.get("ANTHROPIC_API_KEY") == "sk-ant-test-f102b"
+
+

--- a/core/security/envelope_probe.py
+++ b/core/security/envelope_probe.py
@@ -49,6 +49,19 @@ _CANARY_RULE_ID = "CWE-120"
 _CANARY_FILE = "canary_probe.c"
 
 
+class ProbeContentError(RuntimeError):
+    """Raised in strict mode when the probe dispatch yields empty /
+    refusal content or the underlying dispatch raises.
+
+    Default (non-strict) mode preserves the legacy
+    ``ProbeResult(compatible=False)`` return — see F058 in
+    ``notes/_logs/bugs-fixes-log-BF2.md``. Strict-mode callers
+    catch this to distinguish "ambiguous transient failure" from
+    "definitively incompatible verdict" and avoid silently falling
+    back to PASSTHROUGH (defences off) on a transient blip.
+    """
+
+
 @dataclass(frozen=True)
 class ProbeResult:
     compatible: bool
@@ -168,6 +181,8 @@ def probe_envelope_compatibility(
     analysis_model: Any,
     profile: ModelDefenseProfile,
     dispatch_fn,
+    *,
+    strict: bool = False,
 ) -> ProbeResult:
     """Send a canary probe through the dispatch path.
 
@@ -187,6 +202,19 @@ def probe_envelope_compatibility(
 
     Returns a ProbeResult with .compatible indicating whether the model
     handled the envelope correctly.
+
+    ``strict`` (default ``False``, F058): when ``True``, raise
+    :class:`ProbeContentError` on the ambiguous-transient paths —
+    dispatch raised, OR dispatch returned empty / whitespace-only
+    content. The legacy non-strict default returns
+    ``ProbeResult(compatible=False)`` for those cases; callers that
+    treat ``compatible=False`` as "fall back to PASSTHROUGH" then
+    silently disable the envelope defences when the model simply
+    glitched. Strict callers see the distinction and can surface to
+    the operator (or retry) rather than weakening defences blind.
+    A model that produces *valid JSON with the wrong verdict* is a
+    definitive incompatibility signal and is NOT escalated by strict
+    mode — those still return ``compatible=False``.
     """
     system, user, nonce = build_canary_prompt(profile)
     model_name = getattr(analysis_model, "model_name", None) or str(analysis_model)
@@ -194,13 +222,34 @@ def probe_envelope_compatibility(
     try:
         result = dispatch_fn(user, None, system, 0.0, analysis_model)
         raw = ""
+        # ``content_was_empty`` distinguishes "model produced an
+        # empty/whitespace response" from "result envelope had no
+        # content field". The legacy line 226 collapsed both via
+        # ``... or json.dumps(result.result)`` — for F058 strict
+        # mode we need to detect "actually empty content" before
+        # that fallback masks it as a non-empty JSON dump.
+        content_was_empty = False
         if hasattr(result, "result") and isinstance(result.result, dict):
-            raw = result.result.get("content", "") or json.dumps(result.result)
+            _content = result.result.get("content", "")
+            if isinstance(_content, str) and not _content.strip():
+                content_was_empty = True
+            raw = _content or json.dumps(result.result)
         elif hasattr(result, "result"):
             raw = str(result.result)
+            if not raw.strip():
+                content_was_empty = True
         else:
             raw = str(result)
+            if not raw.strip():
+                content_was_empty = True
     except Exception as e:
+        if strict:
+            raise ProbeContentError(
+                f"Envelope probe dispatch raised for {model_name} "
+                f"(profile: {profile.name}): {e}. Strict mode refuses "
+                f"to silently fall back to PASSTHROUGH on an ambiguous "
+                f"transient failure."
+            ) from e
         return ProbeResult(
             compatible=False,
             valid_json=False,
@@ -208,6 +257,19 @@ def probe_envelope_compatibility(
             nonce_leaked=False,
             raw_response="",
             error=f"Dispatch failed: {e}",
+        )
+
+    # F058 strict-mode: empty / whitespace-only content is
+    # genuinely ambiguous (transient overload, refusal filter,
+    # network blip) and should NOT be silently treated as
+    # "model is incompatible with the envelope, downgrade to
+    # PASSTHROUGH". Escalate so the caller surfaces it.
+    if strict and content_was_empty:
+        raise ProbeContentError(
+            f"Envelope probe got empty / whitespace-only response from "
+            f"{model_name} (profile: {profile.name}). Strict mode refuses "
+            f"to silently fall back to PASSTHROUGH on an ambiguous "
+            f"transient failure."
         )
 
     probe_result = evaluate_probe_response(raw, nonce)

--- a/core/security/tests/test_envelope_probe.py
+++ b/core/security/tests/test_envelope_probe.py
@@ -356,3 +356,97 @@ class TestProbeIsAttackerProof:
         result = probe_envelope_compatibility("test-model", CONSERVATIVE, dispatch)
         assert result.compatible
         # The probe doesn't touch the target repo at all
+
+
+# ============================================================
+# 6. F058 — strict=True raises on empty/refusal content
+# ============================================================
+#
+# In default (non-strict) mode the probe returns
+# ``ProbeResult(compatible=False)`` when the model returns an empty
+# response or a refusal. Callers that interpret ``compatible=False``
+# as "fall back to PASSTHROUGH" silently disable the envelope
+# defences in that case — see ``packages/llm_analysis/orchestrator``
+# where ``--accept-weakened-defenses`` flips a failed probe straight
+# to ``profile = PASSTHROUGH``. An empty response is genuinely
+# ambiguous: the model may be transiently overloaded, the prompt may
+# have tripped a refusal filter, or the network may have flaked —
+# none of those signal "this model can't honour the envelope".
+#
+# ``strict=True`` is an opt-in fail-CLOSED conversion: raise
+# :class:`ProbeContentError` on empty/refusal/dispatch-raised paths so
+# the caller can distinguish "ambiguous transient" from "definitely
+# incompatible verdict" and surface to the operator instead of
+# silently weakening defences.
+
+class TestProbeStrictMode:
+    """F058 — strict=True raises on empty/refusal content.
+
+    Default (non-strict) behaviour preserved — existing callers see
+    no change. Opt-in strict mode lets fail-CLOSED callers surface
+    ambiguous transient failures as errors instead of treating them
+    as "model is incompatible, switch to PASSTHROUGH".
+    """
+
+    def test_strict_raises_on_empty_content(self):
+        from core.security.envelope_probe import ProbeContentError
+        dispatch = _make_dispatch_fn(raw_text="")
+        with pytest.raises(ProbeContentError):
+            probe_envelope_compatibility(
+                "phi-3", CONSERVATIVE, dispatch, strict=True,
+            )
+
+    def test_strict_raises_on_whitespace_content(self):
+        from core.security.envelope_probe import ProbeContentError
+        dispatch = _make_dispatch_fn(raw_text="   \n\t  ")
+        with pytest.raises(ProbeContentError):
+            probe_envelope_compatibility(
+                "phi-3", CONSERVATIVE, dispatch, strict=True,
+            )
+
+    def test_strict_raises_on_dispatch_exception(self):
+        from core.security.envelope_probe import ProbeContentError
+        dispatch = _make_dispatch_fn(raise_error=RuntimeError("network blip"))
+        with pytest.raises(ProbeContentError):
+            probe_envelope_compatibility(
+                "phi-3", CONSERVATIVE, dispatch, strict=True,
+            )
+
+    def test_strict_does_not_raise_on_compatible_response(self):
+        """A real compatible response must NOT raise even in strict
+        mode — strict only escalates ambiguous-empty paths, it does
+        not re-classify the successful case."""
+        dispatch = _make_dispatch_fn(response_json={
+            "is_vulnerable": True,
+            "vulnerability_type": "buffer_overflow",
+            "confidence": 0.9,
+        })
+        result = probe_envelope_compatibility(
+            "gpt-5", CONSERVATIVE, dispatch, strict=True,
+        )
+        assert result.compatible
+
+    def test_strict_does_not_raise_on_wrong_verdict(self):
+        """A model that produces valid JSON but the wrong verdict is
+        a definitive incompatibility signal (not transient/ambiguous)
+        — strict still returns ``compatible=False`` for that case."""
+        dispatch = _make_dispatch_fn(response_json={
+            "is_vulnerable": False,
+            "vulnerability_type": "none",
+            "confidence": 0.1,
+        })
+        result = probe_envelope_compatibility(
+            "mistral-7b", CONSERVATIVE, dispatch, strict=True,
+        )
+        assert not result.compatible
+        assert "buffer overflow" in result.error.lower()
+
+    def test_default_mode_preserves_legacy_behaviour(self):
+        """Without ``strict=True`` the probe must still return
+        ``compatible=False`` on empty content — backward-compat for
+        existing orchestrator callers."""
+        dispatch = _make_dispatch_fn(raw_text="")
+        result = probe_envelope_compatibility("phi-3", CONSERVATIVE, dispatch)
+        assert not result.compatible
+        assert result.error is not None
+

--- a/raptor.py
+++ b/raptor.py
@@ -310,11 +310,26 @@ def _run_script(script_path: Path, args: list) -> int:
                 dispatcher,
                 cmd=cmd,
                 label=script_path.name,
-                env=RaptorConfig.get_llm_env(),
+                # F102b: preserve PYTHONUSERBASE for the child
+                # ``raptor_<mode>.py`` subprocess so its own opt-in
+                # at ``get_safe_env(include_python_user_base=True)``
+                # (e.g. ``raptor_agentic.py:757`` semgrep spawn)
+                # has the value to restore. Without this flag the
+                # parent strips PYTHONUSERBASE here, leaving the
+                # child's restoration a no-op for the canonical
+                # operator path. See W14-E3 §F102b.
+                env=RaptorConfig.get_llm_env(include_python_user_base=True),
             )
             return proc.wait()
         # Fallback: pre-Phase-B behaviour, env-direct.
-        result = subprocess.run(cmd, env=RaptorConfig.get_llm_env())
+        # F102b: same opt-in as the dispatcher path above — the
+        # canonical operator entry point must preserve
+        # PYTHONUSERBASE for the spawned ``raptor_<mode>.py``
+        # subprocess. See comment at the spawn_worker call site.
+        result = subprocess.run(
+            cmd,
+            env=RaptorConfig.get_llm_env(include_python_user_base=True),
+        )
         return result.returncode
     except KeyboardInterrupt:
         print("\n\nInterrupted by user")

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -747,7 +747,14 @@ Examples:
         semgrep_proc = subprocess.Popen(
             semgrep_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
             bufsize=1,  # Line-buffered, see main-Popen comment.
-            env=RaptorConfig.get_safe_env(),
+            # F102: semgrep is typically installed via
+            # ``pip install --user``; without PYTHONUSERBASE flowing
+            # through, an operator with a non-default user-base sees
+            # ``ModuleNotFoundError: No module named 'semgrep'`` here.
+            # PYTHONUSERBASE remains stripped by default (it is a real
+            # RCE vector via .pth files); the opt-in restores it only
+            # for this scanner spawn.
+            env=RaptorConfig.get_safe_env(include_python_user_base=True),
             start_new_session=True,  # See main-Popen comment.
         )
 


### PR DESCRIPTION
## Summary

3 defect-class fixes around LLM environment handling + envelope-probe strictness.

### Commits

| SHA | Subject |
|---|---|
| c976086 | `fix(core/security/envelope_probe): opt-in strict mode escalates ambiguous probe failures` |
| 4f9bfeb | `fix(core/config): opt-in get_safe_env(include_python_user_base=True) for pip-installed user tools` |
| 46418a4 | `fix(raptor): forward include_python_user_base through get_llm_env to canonical operator path` |

### Why these are defects

- `c976086`: ambiguous probe failures were being silently swallowed; opt-in `strict=True` now escalates them so callers can fail-CLOSED.
- `4f9bfeb` + `46418a4`: `get_safe_env()` previously dropped `PYTHONUSERBASE` unconditionally, which broke pip-installed user tools when invoked from RAPTOR's sandbox. The 2 commits add an opt-in pathway to preserve it without weakening the default strip-behavior for untrusted contexts.

## Conflict status

`git merge-tree origin/main bug-fixes-W12-c3` → **0 conflict markers** vs current `origin/main` (83657ea).

## Staleness

Branch last touched 2026-05-13. `origin/main` has advanced ~95+ commits since the baseline. Merge-tree clean; CI rerun via PR automation will confirm.

## Classification

- **Class**: DEFECT × 3
- All 3 commits use `fix:` prefix correctly per Conventional Commits.

## Test plan

- [ ] Existing dispatcher/spawn tests pass
- [ ] Envelope-probe strict-mode test asserts the new escalation path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive subprocess environment sanitization and envelope-probe behavior; changes are opt-in but could affect scanner/tool execution paths and failure handling if misused.
> 
> **Overview**
> **Improves subprocess env handling for pip-installed tools:** `RaptorConfig.get_safe_env()` gains an opt-in `include_python_user_base` flag that re-admits `PYTHONUSERBASE` *after* dangerous-var stripping, and `get_llm_env()` forwards the same opt-in.
> 
> **Wires the opt-in through the canonical launch path:** `raptor.py` now spawns mode scripts with `get_llm_env(include_python_user_base=True)`, and `raptor_agentic.py` opts in for the Semgrep subprocess to avoid `ModuleNotFoundError` when Semgrep is installed via `pip --user`.
> 
> **Adds fail-closed option to envelope probing:** `probe_envelope_compatibility(..., strict=True)` now raises `ProbeContentError` on dispatch exceptions or empty/whitespace responses (instead of silently returning `compatible=False`), with targeted unit tests added for both the env and strict-probe behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46418a45e19b9392e147ba831c26984bb39aa7b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->