### PR TITLE
refactor(core/sandbox): plumb strict_env through Linux _spawn for parity

### DIFF
--- a/core/sandbox/_spawn.py
+++ b/core/sandbox/_spawn.py
@@ -358,6 +358,7 @@ def run_sandboxed(
     observe_mode: bool = False,
     observe_nonce: Optional[str] = None,
     restrict_reads: bool = False,
+    strict_env: bool = False,
 ) -> subprocess.CompletedProcess:
     """Run `cmd` inside a fully-isolated sandbox.
 
@@ -943,6 +944,20 @@ def run_sandboxed(
                 # Grandchild runs as PID 1 in the new pid-ns.
                 if env is not None:
                     exec_env = env
+                    # Defense-in-depth: context.py:run() already strips
+                    # DANGEROUS_ENV_VARS from the caller env when
+                    # strict_env=True, so this re-strip is a no-op on
+                    # the standard call path. The kwarg lives here for
+                    # parity with _macos_spawn.run_sandboxed and to
+                    # protect direct callers of this function that
+                    # bypass the run() wrapper (tests, future helpers).
+                    if strict_env:
+                        from core.config import RaptorConfig
+                        _dangerous = set(RaptorConfig.DANGEROUS_ENV_VARS)
+                        exec_env = {
+                            k: v for k, v in exec_env.items()
+                            if k not in _dangerous
+                        }
                 else:
                     exec_env = os.environ.copy()
                 # bounded fork count via RLIMIT_NPROC (prlimit).

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -1458,6 +1458,7 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                                            if observe and nonlocal_audit_mode
                                            else None),
                             restrict_reads=restrict_reads,
+                            strict_env=strict_env,
                             # Default True here even though subprocess.run
                             # defaults to False — _spawn's historical
                             # behaviour was unconditional os.setsid() and


### PR DESCRIPTION
Follow-up to PR #503. Closes the Linux/macOS asymmetry observation: the macOS backend (`_macos_spawn.run_sandboxed`) accepts `strict_env` and strips `DANGEROUS_ENV_VARS` from caller-supplied env as defense-in-depth; the Linux backend (`_spawn.run_sandboxed`) does not.

Functionally a no-op on the standard call path — `context.py:run()` already strips before invoking either spawn backend. The Linux strip is redundant when reached through `run()`. But the kwarg parity matters for two cases:

1. Future direct callers of `_spawn.run_sandboxed` that bypass `run()` (tests, alternative wrappers) get the same defense-in- depth the macOS backend already offers.
2. A future reader looking at the two backends side-by-side sees matching signatures rather than "why does only macOS have this?".

Change is three pieces:

- `_spawn.run_sandboxed`: new `strict_env: bool = False` kwarg.
- `_spawn.run_sandboxed` grandchild env-dispatch: when `strict_env=True` and `env is not None`, filter out `RaptorConfig.DANGEROUS_ENV_VARS` before `execvpe`.
- `context.py` Linux spawn call site: pass `strict_env=strict_env`, matching the macOS site already does at line 1399.

Tests: 875 sandbox tests pass. No new tests added — the change is structural parity (no-op on standard path); #503's tests already cover the helper-to-`run()` wire that supplies `strict_env`.