### PR TITLE
docs(core): W36.B strict-mode controls — close the documentation gaps

### DIFF
--- a/core/llm/multi_model/dispatch.py
+++ b/core/llm/multi_model/dispatch.py
@@ -15,6 +15,30 @@ Pipeline:
     8. Aggregator runs once over (merged, correlation), if configured.
     9. Cost gating: each reviewer/aggregator's cutoff_ratio is checked
        against cost_gate.budget_ratio() before invocation.
+
+Cost-gate failure semantics (W36.B / F090):
+
+  - **Transient failure** (``budget_ratio()`` raises an exception):
+    gating is *suspended* for ``_GATE_RETRY_SECONDS`` (60s by default)
+    then re-probed automatically. Subsequent invocations during the
+    cooldown skip the gate (return ``False, None``). Recovery is
+    announced via:
+
+        logger.info("cost_gate: retrying budget_ratio() after %.0fs "
+                    "transient-failure cooldown", ...)
+
+    Operators monitoring cost-gate health should grep run logs for
+    this string to detect cost-gate flapping.
+
+  - **Permanent failure** (``budget_ratio()`` returns a non-numeric
+    value — type-contract violation): gating is disabled for the rest
+    of the run with a single ``logger.warning`` at the moment of
+    disable. A wrong return type is a code bug, not a network
+    hiccup, so automatic retry would not help.
+
+  Transient exceptions are recoverable (network glitch, transient DB
+  error in a backing CostGate impl); type-contract violations are
+  not. The distinction lives at ``over_budget()`` below.
 """
 
 import logging

--- a/core/sandbox/__init__.py
+++ b/core/sandbox/__init__.py
@@ -366,6 +366,47 @@ Startup banner shows which layers are available:
   sandbox ✓ (landlock)            — container without user namespaces
   sandbox ✗                       — no isolation available
 
+W36.B strict-mode controls (added W36.B, fully landed by W36.K.3):
+Four opt-in mechanisms turn previously-fail-OPEN security paths into
+fail-CLOSED contracts. All default-off — existing callers see no
+behaviour change. Operators wanting a hardened posture opt in.
+
+  - ``run_untrusted(strict_env=True)`` — default ON for this helper
+    (the security-sensitive entry point). Strips
+    ``RaptorConfig.DANGEROUS_ENV_VARS`` (LD_PRELOAD, AWS_*, GH_TOKEN,
+    etc.) from caller-supplied ``env=`` dicts even when the caller
+    didn't go through ``get_safe_env()``. The lower-level
+    ``sandbox()`` accepts ``strict_env=`` too; default off there.
+    Both Linux (``_spawn``) and macOS (``_macos_spawn``) backends
+    apply the strip as defense-in-depth.
+
+  - ``EgressProxy(audit_enforce=True)`` / env var
+    ``RAPTOR_PROXY_AUDIT_ENFORCE`` set to ``"1"`` / ``"true"`` /
+    ``"yes"`` / ``"on"`` (case-insensitive, whitespace-stripped) —
+    switches gate 1 (hostname allowlist) in audit mode from
+    log-and-allow to log-AND-deny. Default off preserves the
+    documented audit-permissive semantics for operators still
+    building their allowlist.
+
+  - ``probe_envelope_compatibility(strict=True)`` (core/security) —
+    raises ``RuntimeError`` instead of returning a failed
+    ``ProbeResult`` when the LLM cannot honour the defense envelope.
+    Covers BOTH failure paths uniformly: ``dispatch_fn`` raising,
+    AND the post-evaluate ``compatible=False`` branch. Used by the
+    orchestrator to refuse to silently downgrade defenses.
+
+  - ``preflight(strict=True)`` (core/security) — raises
+    ``RuntimeError`` when the injection-pattern corpus is empty at
+    call time. Default fail-open (returns ``confidence_haircut=1.0``)
+    is preserved by ``strict=False``; strict mode surfaces the
+    misconfiguration the operator wouldn't otherwise notice.
+
+The cost-gating circuit-breaker in
+``core/llm/multi_model/dispatch.py`` (F090) shipped alongside these
+under the same W36.B umbrella but is not operator-tunable — see that
+module's docstring for the transient-vs-permanent disable semantics
+and the "cost_gate: retrying budget_ratio()" recovery log signal.
+
 Sandboxing by tool type:
 - PoC execution, LLM-generated code: `run_untrusted()` — full sandbox
   with restrict_reads=True + fake_home=True by default.

--- a/core/sandbox/proxy.py
+++ b/core/sandbox/proxy.py
@@ -393,8 +393,14 @@ class EgressProxy:
         # Default False preserves the documented audit-permissive semantics
         # (gate 1 audit mode is for diagnosis while building an allowlist;
         # once the allowlist is mature, operators can set audit_enforce=True
-        # or RAPTOR_PROXY_AUDIT_ENFORCE=1 to harden gate 1). Gate 2 is
-        # always enforcing regardless of this flag.
+        # or set the RAPTOR_PROXY_AUDIT_ENFORCE env var to one of the
+        # accepted truthy spellings — case-insensitive, whitespace-stripped:
+        #     "1" / "true" / "yes" / "on"
+        # Any other value (including "0" / "false" / "no" / "off" / "" /
+        # the unset variable) leaves audit-mode in its default log-only
+        # behaviour. The env-var parse lives at the `get_proxy()` read
+        # below; this kwarg accepts the already-parsed bool.
+        # Gate 2 is always enforcing regardless of this flag.
         self._audit_enforce = audit_enforce
         # Ref-count for concurrent acquire/release. Each audit-mode
         # sandbox via use_egress_proxy=True acquires on entry, releases

--- a/core/security/envelope_probe.py
+++ b/core/security/envelope_probe.py
@@ -190,9 +190,24 @@ def probe_envelope_compatibility(
     Returns a ProbeResult with .compatible indicating whether the model
     handled the envelope correctly.
 
-    When ``strict=True``, an incompatible probe result raises
-    ``RuntimeError`` instead of returning the failed ProbeResult, so
-    callers that do not check ``.compatible`` cannot silently continue.
+    When ``strict=True``, raises ``RuntimeError`` instead of returning a
+    failed ``ProbeResult``, so callers that do not check ``.compatible``
+    cannot silently continue. The strict contract applies UNIFORMLY to
+    both failure paths inside this function:
+
+    1. ``dispatch_fn(...)`` itself raises (e.g. ``TimeoutError``,
+       connection-refused, transient HTTP 5xx) — the underlying
+       exception is chained via ``raise ... from e`` so callers
+       introspecting the cause still see the original error.
+    2. ``dispatch_fn`` returns successfully but the response fails
+       envelope evaluation (probe canary leaked, tag forgery
+       detected, etc.) — raises with the evaluator's error message.
+
+    The original ``strict=True`` landed (W36.B / F058) covering only
+    path 2; path 1's coverage closed in W36.K.3 / F058-gap. A
+    ``strict=True`` caller can now treat the absence of an exception
+    as "envelope confirmed compatible" without separately checking
+    ``.compatible``.
     """
     system, user, nonce = build_canary_prompt(profile)
     model_name = getattr(analysis_model, "model_name", None) or str(analysis_model)

--- a/core/security/prompt_input_preflight.py
+++ b/core/security/prompt_input_preflight.py
@@ -147,6 +147,14 @@ def preflight(
     ``strict=False`` preserves the documented fail-open policy — an empty
     corpus returns ``confidence_haircut=1.0`` rather than zeroing all
     downstream confidence scores.
+
+    The ``strict`` check evaluates ``_PATTERNS`` *at call time*, not at
+    module import time — so a corpus that loads asynchronously after
+    import (rare, but possible for callers that hot-reload pattern
+    files) still satisfies ``strict=True`` once populated. The check
+    fails only when ``_PATTERNS`` is still empty when this function is
+    invoked, which is the actual fail-open exposure window the kwarg
+    is designed to surface.
     """
     if strict and not _PATTERNS:
         raise RuntimeError(


### PR DESCRIPTION
Single-commit follow-up covering five doc / docstring tightenings across the three PRs that landed the W36.B strict-mode contracts (#499 base, #505 F058 gap-close, #506 F068 env-var parse).

1. `core/sandbox/proxy.py` — `_audit_enforce` comment now enumerates the truthy whitelist the env-var parser accepts (1/true/yes/on, case-insensitive, whitespace-stripped). Pre-merge the comment only cited "=1" as an example; post-#506 the whitelist IS the contract, so operators should be able to discover it without reading the parse code.

2. `core/security/envelope_probe.py` — `probe_envelope_compatibility` docstring now explicitly lists BOTH failure paths that `strict=True` covers: the `dispatch_fn` exception path (closed in #505) and the post-evaluate `compatible=False` path (landed in #499). Without this, a future caller might assume only one of the two is covered.

3. `core/security/prompt_input_preflight.py` — `preflight` docstring clarifies `strict=True` evaluates `_PATTERNS` at call time, not at module import time. Relevant for callers that hot-reload pattern corpora; defines the actual fail-open window the kwarg surfaces.

4. `core/llm/multi_model/dispatch.py` — module docstring adds a "Cost-gate failure semantics" section describing F090's transient (60s cooldown + auto-retry) vs permanent (type-contract violation) disable distinction and the operator-visible "cost_gate: retrying budget_ratio()" recovery log signal.

5. `core/sandbox/__init__.py` — new "W36.B strict-mode controls" doc block at the bottom of the module docstring centralising all four operator-tunable mechanisms (`run_untrusted(strict_env=)`, `EgressProxy(audit_enforce=)` + `RAPTOR_PROXY_AUDIT_ENFORCE` env var, `probe_envelope_compatibility(strict=)`, `preflight(strict=)`) with a cross-reference to the F090 cost-gate behaviour. Operators previously had to discover these piecemeal across four modules; the sandbox __init__ is the natural index because sandbox is the primary touchpoint for strict-env hardening.

No behaviour change — all five edits are docstring/comment-only. Tests: 1699 pass across core/sandbox/, core/security/, core/llm/multi_model/.