### PR TITLE
fix(core): PYTHONUSERBASE forwarding for pip-installed user tools

### DIFF
--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -633,7 +633,11 @@ class RaptorConfig:
         return RaptorConfig.MCP_JOB_DIR / job_id
 
     @staticmethod
-    def get_safe_env(*, preserve_proxy: bool = False) -> dict:
+    def get_safe_env(
+        *,
+        preserve_proxy: bool = False,
+        include_python_user_base: bool = False,
+    ) -> dict:
         """Return a sanitised copy of os.environ for subprocess use.
 
         Two-stage filter:
@@ -657,6 +661,18 @@ class RaptorConfig:
         an operator's HTTPS_PROXY setting. The dangerous-env-var
         strip still applies.
 
+        ``include_python_user_base=True`` (F102) re-admits the
+        ``PYTHONUSERBASE`` variable from the original os.environ
+        AFTER the dangerous-env-vars strip. Use only at scanner
+        invocation sites that legitimately depend on a
+        ``pip install --user`` tool (e.g. semgrep). The variable is
+        a real RCE vector via .pth files (see DANGEROUS_ENV_VARS
+        comment at PYTHONUSERBASE) and stays stripped by default;
+        but if the operator deliberately installed the scanner under
+        ``~/.local`` with a non-default ``PYTHONUSERBASE`` set, the
+        subprocess fails ``ModuleNotFoundError`` without this opt-in.
+        Mirrors the ``preserve_proxy`` opt-in pattern.
+
         Callers who need a specific extra var (JAVA_HOME for a Java tool,
         a custom CA bundle, etc.) should add it to the returned dict
         explicitly after calling get_safe_env(), or pass their own env=
@@ -674,6 +690,14 @@ class RaptorConfig:
         if not preserve_proxy:
             env = strip_env_vars(env, RaptorConfig.PROXY_ENV_VARS)
         env = strip_env_vars(env, RaptorConfig.DANGEROUS_ENV_VARS)
+        # F102: restore PYTHONUSERBASE AFTER the dangerous-var strip
+        # for callers that opted in (e.g. semgrep scanner spawn).
+        # Take the value verbatim from os.environ — do NOT invent
+        # one if the operator didn't set it.
+        if include_python_user_base:
+            _userbase = os.environ.get("PYTHONUSERBASE")
+            if _userbase is not None:
+                env["PYTHONUSERBASE"] = _userbase
         env["PYTHONUNBUFFERED"] = "1"
         return env
 

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -737,14 +737,31 @@ class RaptorConfig:
     )
 
     @staticmethod
-    def get_llm_env() -> dict:
+    def get_llm_env(
+        *,
+        include_python_user_base: bool = False,
+    ) -> dict:
         """Return get_safe_env() plus any LLM API keys present in the
         real environment.
 
         Use this for spawning RAPTOR's own analysis scripts that may call
         LLM providers.  Do NOT use for untrusted-code subprocesses.
+
+        ``include_python_user_base=True`` (F102b) forwards the opt-in
+        to the underlying ``get_safe_env()`` so PYTHONUSERBASE is
+        preserved on the returned env. Use at canonical-operator
+        spawn sites (``raptor.py:_run_script``) whose child script
+        in turn opts into the F102 restoration (e.g.
+        ``raptor_agentic.py``'s semgrep spawn at line 757). Without
+        this forwarding, the parent strips PYTHONUSERBASE before the
+        child can restore it, and the F102 fix is orphaned for
+        ``python raptor.py <mode>`` invocations. Mirrors the existing
+        ``include_python_user_base`` opt-in on ``get_safe_env`` —
+        same default-False, opt-in pattern as ``preserve_proxy``.
         """
-        env = RaptorConfig.get_safe_env()
+        env = RaptorConfig.get_safe_env(
+            include_python_user_base=include_python_user_base,
+        )
         for var in RaptorConfig.LLM_API_KEY_VARS:
             val = os.environ.get(var)
             if val:

--- a/core/config/tests/test_config.py
+++ b/core/config/tests/test_config.py
@@ -231,3 +231,74 @@ class TestEnsureDirectories:
             RaptorConfig.ensure_directories()  # must not raise
 
 
+class TestGetSafeEnvIncludePythonUserBase:
+    """F102 — opt-in restoration of PYTHONUSERBASE for scanners that
+    depend on ``pip install --user`` tools (semgrep, etc.).
+
+    Default behaviour: PYTHONUSERBASE is in DANGEROUS_ENV_VARS and
+    must remain stripped (it's a real RCE vector via .pth files —
+    see core/config/__init__.py line 396-400).
+
+    With ``include_python_user_base=True``, scanner sites that
+    legitimately invoke a pip-installed user tool can re-admit the
+    variable so the tool finds its site-packages. The same kwarg
+    pattern as ``preserve_proxy``.
+
+    Without this opt-in, an operator who installed semgrep with
+    ``pip install --user`` and set ``PYTHONUSERBASE`` outside the
+    default sees ``ModuleNotFoundError: No module named 'semgrep'``
+    when RAPTOR spawns the scanner subprocess — verified in
+    W6/W9 PoC.
+    """
+
+    def test_default_strips_pythonuserbase(self):
+        """Backward-compat regression guard: default behaviour
+        unchanged. PYTHONUSERBASE still removed."""
+        with patch.dict(os.environ, {"PYTHONUSERBASE": "/home/user/.local"}):
+            env = RaptorConfig.get_safe_env()
+            assert "PYTHONUSERBASE" not in env
+
+    def test_include_python_user_base_keeps_pythonuserbase(self):
+        """Opt-in: when caller passes
+        ``include_python_user_base=True``, the var flows through."""
+        with patch.dict(os.environ, {"PYTHONUSERBASE": "/home/user/.local"}):
+            env = RaptorConfig.get_safe_env(include_python_user_base=True)
+            assert env.get("PYTHONUSERBASE") == "/home/user/.local"
+
+    def test_include_python_user_base_no_op_when_not_set(self):
+        """If the original env has no PYTHONUSERBASE, opt-in must
+        not invent one."""
+        # Build an env without PYTHONUSERBASE
+        scrubbed = {k: v for k, v in os.environ.items() if k != "PYTHONUSERBASE"}
+        with patch.dict(os.environ, scrubbed, clear=True):
+            env = RaptorConfig.get_safe_env(include_python_user_base=True)
+            assert "PYTHONUSERBASE" not in env
+
+    def test_include_python_user_base_does_not_re_admit_other_dangerous_vars(self):
+        """Opt-in is targeted — every OTHER dangerous var must still
+        be stripped. Regression guard against an over-broad opt-in
+        that accidentally lifts the whole blocklist."""
+        injected = {var: f"malicious_{var}" for var in RaptorConfig.DANGEROUS_ENV_VARS}
+        with patch.dict(os.environ, injected):
+            env = RaptorConfig.get_safe_env(include_python_user_base=True)
+            # PYTHONUSERBASE is the ONLY var the opt-in re-admits.
+            for var in RaptorConfig.DANGEROUS_ENV_VARS:
+                if var == "PYTHONUSERBASE":
+                    assert env.get(var) == "malicious_PYTHONUSERBASE"
+                else:
+                    assert var not in env, f"{var} should still be stripped"
+
+    def test_include_python_user_base_combines_with_preserve_proxy(self):
+        """Combining both kwargs is legal — neither flag rejects
+        the other. (Whether ``preserve_proxy`` actually re-admits
+        proxy vars depends on the allowlist; out of scope here.
+        This test only guards against an accidental kwarg-collision
+        regression in the function signature.)"""
+        injected = {"PYTHONUSERBASE": "/home/user/.local"}
+        with patch.dict(os.environ, injected):
+            env = RaptorConfig.get_safe_env(
+                preserve_proxy=True, include_python_user_base=True,
+            )
+            assert env.get("PYTHONUSERBASE") == "/home/user/.local"
+
+

--- a/core/config/tests/test_config.py
+++ b/core/config/tests/test_config.py
@@ -302,3 +302,72 @@ class TestGetSafeEnvIncludePythonUserBase:
             assert env.get("PYTHONUSERBASE") == "/home/user/.local"
 
 
+class TestGetLlmEnvIncludePythonUserBase:
+    """F102b — ``get_llm_env()`` must forward
+    ``include_python_user_base`` to ``get_safe_env()``.
+
+    Without this forwarding, ``python raptor.py agentic`` (the
+    canonical operator entry point at ``raptor.py:313,317``) calls
+    ``get_llm_env()`` which strips PYTHONUSERBASE before the
+    ``raptor_agentic.py:757`` opt-in can restore it for the semgrep
+    spawn — the F102 fix is orphaned on this path.
+
+    Default (False) must keep the existing strip behaviour;
+    opt-in (True) must preserve the var. Mirrors the existing
+    ``preserve_proxy`` opt-in pattern on the underlying
+    ``get_safe_env``. Sibling test class:
+    ``TestGetSafeEnvIncludePythonUserBase``.
+    """
+
+    def test_default_strips_pythonuserbase(self):
+        """Backward-compat regression guard: default ``get_llm_env()``
+        still strips PYTHONUSERBASE (security contract unchanged)."""
+        with patch.dict(os.environ, {"PYTHONUSERBASE": "/home/user/.local"}):
+            env = RaptorConfig.get_llm_env()
+            assert "PYTHONUSERBASE" not in env
+
+    def test_include_python_user_base_keeps_pythonuserbase(self):
+        """F102b: when caller passes
+        ``include_python_user_base=True``, the var flows through to
+        the returned env so the canonical operator path
+        (``raptor.py:313,317``) can preserve it for the agentic
+        subprocess that wires it into the semgrep spawn."""
+        with patch.dict(os.environ, {"PYTHONUSERBASE": "/home/user/.local"}):
+            env = RaptorConfig.get_llm_env(include_python_user_base=True)
+            assert env.get("PYTHONUSERBASE") == "/home/user/.local"
+
+    def test_include_python_user_base_no_op_when_not_set(self):
+        """If the original env has no PYTHONUSERBASE, opt-in must
+        not invent one."""
+        scrubbed = {k: v for k, v in os.environ.items() if k != "PYTHONUSERBASE"}
+        with patch.dict(os.environ, scrubbed, clear=True):
+            env = RaptorConfig.get_llm_env(include_python_user_base=True)
+            assert "PYTHONUSERBASE" not in env
+
+    def test_include_python_user_base_does_not_re_admit_other_dangerous_vars(self):
+        """Opt-in is targeted — the LLM-env opt-in must not lift the
+        wider DANGEROUS_ENV_VARS blocklist (regression guard against
+        an over-broad forwarding implementation)."""
+        injected = {var: f"malicious_{var}" for var in RaptorConfig.DANGEROUS_ENV_VARS}
+        with patch.dict(os.environ, injected):
+            env = RaptorConfig.get_llm_env(include_python_user_base=True)
+            for var in RaptorConfig.DANGEROUS_ENV_VARS:
+                if var == "PYTHONUSERBASE":
+                    assert env.get(var) == "malicious_PYTHONUSERBASE"
+                else:
+                    assert var not in env, f"{var} should still be stripped"
+
+    def test_include_python_user_base_preserves_llm_api_key_passthrough(self):
+        """Combining the opt-in with the LLM-key passthrough must
+        not break either contract: API keys still flow, PYTHONUSERBASE
+        is preserved."""
+        injected = {
+            "PYTHONUSERBASE": "/home/user/.local",
+            "ANTHROPIC_API_KEY": "sk-ant-test-f102b",
+        }
+        with patch.dict(os.environ, injected):
+            env = RaptorConfig.get_llm_env(include_python_user_base=True)
+            assert env.get("PYTHONUSERBASE") == "/home/user/.local"
+            assert env.get("ANTHROPIC_API_KEY") == "sk-ant-test-f102b"
+
+

--- a/raptor.py
+++ b/raptor.py
@@ -311,11 +311,26 @@ def _run_script(script_path: Path, args: list) -> int:
                 dispatcher,
                 cmd=cmd,
                 label=script_path.name,
-                env=RaptorConfig.get_llm_env(),
+                # F102b: preserve PYTHONUSERBASE for the child
+                # ``raptor_<mode>.py`` subprocess so its own opt-in
+                # at ``get_safe_env(include_python_user_base=True)``
+                # (e.g. ``raptor_agentic.py:757`` semgrep spawn)
+                # has the value to restore. Without this flag the
+                # parent strips PYTHONUSERBASE here, leaving the
+                # child's restoration a no-op for the canonical
+                # operator path. See W14-E3 §F102b.
+                env=RaptorConfig.get_llm_env(include_python_user_base=True),
             )
             return proc.wait()
         # Fallback: pre-Phase-B behaviour, env-direct.
-        result = subprocess.run(cmd, env=RaptorConfig.get_llm_env())
+        # F102b: same opt-in as the dispatcher path above — the
+        # canonical operator entry point must preserve
+        # PYTHONUSERBASE for the spawned ``raptor_<mode>.py``
+        # subprocess. See comment at the spawn_worker call site.
+        result = subprocess.run(
+            cmd,
+            env=RaptorConfig.get_llm_env(include_python_user_base=True),
+        )
         return result.returncode
     except KeyboardInterrupt:
         print("\n\nInterrupted by user")

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -747,7 +747,14 @@ Examples:
         semgrep_proc = subprocess.Popen(
             semgrep_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
             bufsize=1,  # Line-buffered, see main-Popen comment.
-            env=RaptorConfig.get_safe_env(),
+            # F102: semgrep is typically installed via
+            # ``pip install --user``; without PYTHONUSERBASE flowing
+            # through, an operator with a non-default user-base sees
+            # ``ModuleNotFoundError: No module named 'semgrep'`` here.
+            # PYTHONUSERBASE remains stripped by default (it is a real
+            # RCE vector via .pth files); the opt-in restores it only
+            # for this scanner spawn.
+            env=RaptorConfig.get_safe_env(include_python_user_base=True),
             start_new_session=True,  # See main-Popen comment.
         )
 


### PR DESCRIPTION
  Cherry-picked from @gadievron's PR #512 onto current main. The original PR had a third commit (`c976086`) adding strict-mode to `probe_envelope_compatibility`, but that work has since landed via #499 / #505 / #521 — only the two `PYTHONUSERBASE` commits remained non-redundant.
  
  ## Commits
  
  | SHA | Subject |
  |---|---|
  | 4f9bfeb | fix(core/config): opt-in get_safe_env(include_python_user_base=True) for pip-installed user tools |
  | 46418a4 | fix(raptor): forward include_python_user_base through get_llm_env to canonical operator path |
  
  Both authored by @gadievron, applied cleanly to current main via cherry-pick. Authorship preserved.
  
  ## Why
  
  `get_safe_env()` strips `PYTHONUSERBASE` unconditionally — but pip-installed user tools (e.g. Semgrep installed via `pip install --user semgrep`) need it to find their entry points. Opt-in  `include_python_user_base=True` re-admits it after the dangerous-var strip, preserving the strip-by-default contract for untrusted contexts.                                                                     
   
  The opt-in is threaded through:                                                                                                                                                                                  
  - `RaptorConfig.get_safe_env(include_python_user_base=False)` — the canonical safe-env producer
  - `get_llm_env(include_python_user_base=False)` — the LLM-process variant that forwards to `get_safe_env`                                                                                                        
  - `raptor.py` — main launcher passes `include_python_user_base=True` for mode-script subprocesses                                                                                                                
  - `raptor_agentic.py` — Semgrep subprocess opts in to avoid ModuleNotFoundError under user-pip installs                                                                                                          
                                                                                                                                                                                                                   
  Replaces #512 (which had a merge conflict with the W36.B strict-mode work that landed in parallel via #499 / #505 / #521).                                                                                       
                                                                                                                                                                                                                   
  ## Test plan                                                  
                                                                                                                                                                                                                   
  - `pytest core/config/ -q` → 34 passed locally on Linux; 2 pre-existing failures on macOS (`test_rejects_system_paths[/etc]`) are unrelated to this PR — `/etc` resolves to `/private/etc` on Darwin and the system-path rejection list doesn't include `/private/`-prefixed canonical paths. Not introduced by this change; visible against `upstream/main` as well.                                                         
  - CI runs on Linux where all tests pass.
                                                                                                                                                                                                                   
  Closes #512.                                                  
