### PR TITLE
feat(sandbox): opt-in host-fingerprint sanitisation

### DIFF
--- a/core/sandbox/__init__.py
+++ b/core/sandbox/__init__.py
@@ -101,6 +101,78 @@ Fake HOME (fake_home=True):
   this, os.makedirs would resolve the symlink and create subdirs
   inside the attacker-chosen location outside `output`.
 
+Sanitised host fingerprint (sanitise_host_fingerprint=True):
+  Opt-in identity-surface masking. When engaged, the child sees
+  canonical "boring Debian 12 cloud VM on QEMU/KVM with Intel Xeon"
+  values for hostname (`localhost`), `/etc/os-release` (Debian 12
+  stub), `/etc/machine-id` (deterministic pseudo-random — looks
+  real, identical across operators), `/sys/class/dmi/id/*` (QEMU),
+  `/proc/cpuinfo` (canonical Xeon model + microcode + cache,
+  configurable processor count via cpu_count=N defaulting to 4),
+  `/proc/version` (trimmed to `Linux version <host-release>`), and
+  uname() nodename / domainname (via CLONE_NEWUTS + sethostname).
+  All hide-intent values — no "sandbox" / "raptor" / "Generic CPU"
+  / all-zero sentinels that anti-analysis-aware binaries can
+  trivially detect. Implemented in core/sandbox/fingerprint.py.
+
+  Preserved (capability surface, NOT identity):
+  - /proc/cpuinfo `flags` line — host-real. SMEP/SMAP detection in
+    packages/exploit_feasibility, SIMD dispatch in ASAN / glibc /
+    JITs, and pwntools all key off these.
+  - uname `release` and `machine` — host-real. exploit_feasibility's
+    `uname -r`, pwntools' context.arch, shellcode dispatch all
+    depend on the real values.
+  - /proc/sys/kernel/* (randomize_va_space, kptr_restrict,
+    yama/ptrace_scope) and /proc/sys/vm/mmap_min_addr — untouched.
+    exploit_feasibility's mitigation reads depend on accuracy.
+  - /proc/self/* (maps, exe, status, auxv) — untouched. ASAN, GDB,
+    pwntools context.aslr all depend on real values.
+
+  cpu_count=N (default 4 when sanitisation engaged) sets a
+  consistent N across /proc/cpuinfo blocks, /sys/devices/system/cpu/
+  {online,possible}, /proc/stat per-cpu lines, AND
+  sched_setaffinity (the kernel mask underlying os.cpu_count() /
+  sysconf(_SC_NPROCESSORS_ONLN) / Go GOMAXPROCS / Rust num_cpus).
+  Defaulting to 4 (typical cloud-VM size) rather than 1 avoids the
+  "exactly 1 CPU is an analysis sandbox" detection heuristic.
+
+  Soft-degrade with one-shot WARNING when prerequisites are missing
+  (Landlock-only mode, missing uidmap, apparmor_restrict_unpriv_
+  userns=1, macOS). `require_sanitisation=True` flips degradation
+  to hard-fail (RuntimeError at sandbox entry) for paranoid
+  callers. macOS has no functional equivalent — bind-mount and
+  UTS-namespace are Linux-only primitives, and most macOS host-
+  identity reads are sysctlbyname/IOKit-based (not file-based).
+
+  Residuals (documented; not addressed):
+  - CPUID asm bypass — direct cpuid execution reads real CPU.
+    Fix would need ptrace-based syscall rewriting + userspace
+    cpuid emulator (out of scope).
+  - AT_HWCAP auxiliary vector — kernel-supplied at exec; not
+    file-based. Side effect: glibc/Rust dispatch keeps working
+    even where flags-line is masked, but pure-asm fingerprinters
+    bypass our overlay.
+  - Vendor leakage via flags-line — Intel vs AMD distinguishable
+    by flag-set differences. Trade-off accepted for SIMD compat.
+  - /proc/meminfo, /sys/firmware/*, /dev/mem — host-real. UEFI/BIOS
+    + RAM size leakage. Out of v1 scope; meminfo masking deserves
+    its own audit (JVM heap auto-sizing, Postgres shared_buffers
+    consumers).
+  - /sys/class/dmi/id/{board_serial, product_uuid, chassis_*} —
+    only `sys_vendor` and `product_name` are bind-masked. Defended
+    by `restrict_reads=True`'s allowlist (DMI not on default
+    readable set); pass `restrict_reads=False` and the omitted
+    DMI identity files become host-real.
+  - sanitise_host_fingerprint=True with `target=None` AND
+    `output=None` produces partial coverage: UTS-ns + affinity
+    still apply (no mount-ns needed for those), but the file
+    overlays don't (mount-ns is skipped when neither target nor
+    output is set). Most callers pass at least one; pure
+    capability probes that don't would see this.
+
+  Default off everywhere; opt-in per caller. Once stable and
+  proven, `run_untrusted()` is a candidate to default-on.
+
 Log-output hygiene:
   RAPTOR logs attacker-influenced strings in several places (argv
   filenames from scanned repos, subprocess stderr / ASAN bug_type,
@@ -283,9 +355,15 @@ What the sandbox does NOT protect against:
   hostname-allowlisted outbound use `use_egress_proxy=True` which
   also blocks UDP via seccomp.
 - Host fingerprinting via /proc/version, /etc/os-release, /proc/cpuinfo,
-  /etc/machine-id, /sys/class/dmi/id/*. Tightening these would break
-  real PoCs (glibc CPU-feature detection, ASAN's /proc/self/maps,
-  dynamic linker's /etc/ld.so.cache). Accepted residual.
+  /etc/machine-id, /sys/class/dmi/id/* — accepted residual by default.
+  Opt-in masking via `sanitise_host_fingerprint=True`: presents a
+  canonical "Debian 12 cloud VM on QEMU/KVM with Intel Xeon" persona
+  while preserving capability surfaces (cpuinfo flags line, uname
+  release/machine, kernel mitigation sysctls). See the "Sanitised
+  host fingerprint" section above for the full surface list and
+  preserved-vs-masked policy. Two residuals remain even with the
+  flag on: CPUID asm reads bypass the file overlay; AT_HWCAP from
+  the kernel-supplied auxiliary vector at exec is not file-based.
 - Cross-PID-ns `/proc/<host_pid>/{cmdline,comm,status,stat}` —
   `/proc` stays host-shared under Landlock-only mode (no mount-ns);
   PID-ns isolation applies the kernel's ptrace-gated protection

--- a/core/sandbox/_macos_spawn.py
+++ b/core/sandbox/_macos_spawn.py
@@ -165,6 +165,17 @@ def run_sandboxed(cmd: List[str], *,
                   proxy_port: Optional[int] = None,
                   fake_home: bool = False,
                   strict_env: bool = False,
+                  # persona: host-fingerprint sanitisation is Linux-only
+                  # (bind-mount + UTS-ns + sched_setaffinity primitives).
+                  # macOS lacks unprivileged equivalents; most host-
+                  # identity reads there are sysctlbyname/IOKit-based,
+                  # not file-based, so file substitution wouldn't catch
+                  # them anyway. Accepted for signature parity and
+                  # silently ignored — context.py already gates on
+                  # fingerprint.is_supported() so the value reaches us
+                  # only as None when sanitisation was requested but
+                  # platform unsupported.
+                  persona=None,  # noqa: ARG001
                   ) -> subprocess.CompletedProcess:
     """Run ``cmd`` under macOS sandbox-exec with an SBPL profile
     derived from the logical sandbox kwargs.

--- a/core/sandbox/_spawn.py
+++ b/core/sandbox/_spawn.py
@@ -56,13 +56,19 @@ import sys
 import time
 import traceback
 from pathlib import Path
-from typing import Iterable, Optional, Sequence
+from typing import TYPE_CHECKING, Iterable, Optional, Sequence
 
 from . import state
 from ._fork_safe_warn import warn_post_fork
 from .landlock import _make_landlock_preexec
 from .mount_ns import setup_mount_ns
 from .seccomp import _make_seccomp_preexec
+
+if TYPE_CHECKING:
+    # Persona referenced by run_sandboxed's signature only; lazily
+    # imported in the child branch to keep module-load cost the same
+    # for callers that never engage fingerprint sanitisation.
+    from .fingerprint import Persona
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +78,7 @@ logger = logging.getLogger(__name__)
 # hardcoded copy. Requires Python 3.12+ (already enforced by the
 # os.unshare() call below, which was also new in 3.12).
 CLONE_NEWNS   = getattr(os, "CLONE_NEWNS",   0x00020000)
+CLONE_NEWUTS  = getattr(os, "CLONE_NEWUTS",  0x04000000)
 CLONE_NEWIPC  = getattr(os, "CLONE_NEWIPC",  0x08000000)
 CLONE_NEWUSER = getattr(os, "CLONE_NEWUSER", 0x10000000)
 CLONE_NEWPID  = getattr(os, "CLONE_NEWPID",  0x20000000)
@@ -359,6 +366,7 @@ def run_sandboxed(
     observe_nonce: Optional[str] = None,
     restrict_reads: bool = False,
     strict_env: bool = False,
+    persona: Optional["Persona"] = None,
 ) -> subprocess.CompletedProcess:
     """Run `cmd` inside a fully-isolated sandbox.
 
@@ -830,6 +838,12 @@ def run_sandboxed(
             ns_flags = CLONE_NEWUSER | CLONE_NEWNS | CLONE_NEWIPC
             if block_network:
                 ns_flags |= CLONE_NEWNET
+            if persona is not None:
+                # Fresh UTS namespace so sethostname/setdomainname only
+                # affect us, not the host. We have CAP_SYS_ADMIN in this
+                # UTS-ns post-newuidmap (we own it as ns-uid-0) — the
+                # actual sethostname call lives after step 7.
+                ns_flags |= CLONE_NEWUTS
             os.unshare(ns_flags)
 
             # Step 4.5 (audit mode): declare PR_SET_PTRACER_ANY so the
@@ -885,6 +899,27 @@ def run_sandboxed(
             # rlimits as early as possible so later setup is constrained.
             _set_rlimits(limits)
 
+            # Step 8.5 (fingerprint sanitisation): sethostname /
+            # setdomainname inside our fresh UTS namespace. Done before
+            # mount-ns so the persona's /etc/hostname (bind-mounted in
+            # step 9) and uname()'s nodename agree (gethostname() reads
+            # the UTS field, not /etc/hostname — both must be set
+            # consistently or a cross-check is a sandbox tell).
+            if persona is not None:
+                from .fingerprint import set_uts
+                try:
+                    set_uts(persona.hostname, persona.domainname)
+                except OSError as e:
+                    # Degrade silently — caller (context.py) already
+                    # gated on platform support; an unexpected runtime
+                    # failure here shouldn't take down the whole
+                    # sandbox, just leak hostname/domainname.
+                    warn_post_fork(
+                        b"sandbox: fingerprint set_uts failed (errno=%d)"
+                        b"; hostname/domainname remain host-real\n"
+                        % (e.errno or 0)
+                    )
+
             # Step 9: mount-ns pivot_root if target/output supplied.
             # readable_paths from the caller also get bind-mounted at
             # their original paths so they exist inside the pivoted
@@ -893,7 +928,31 @@ def run_sandboxed(
             if target or output:
                 setup_mount_ns(target, output,
                                extra_ro_paths=readable_paths,
-                               root_path=_root_dir)
+                               root_path=_root_dir,
+                               persona=persona)
+
+            # Step 9.5 (fingerprint sanitisation): pin sched_setaffinity
+            # to a mask of size persona.cpu_count. The persona's
+            # /proc/cpuinfo and /sys/devices/system/cpu/online already
+            # claim cpu_count processors; pinning the affinity mask to
+            # match means sched_getaffinity / os.cpu_count() /
+            # nproc / Go GOMAXPROCS / Rust num_cpus all agree with the
+            # cpuinfo view — no cross-check tell.
+            #
+            # Done AFTER mount_ns (no ordering dependency, but keeps the
+            # fingerprint-related calls grouped) and BEFORE Landlock
+            # (sched_setaffinity is allowed under seccomp/Landlock but
+            # grouping makes the audit trail clearer).
+            if persona is not None:
+                from .fingerprint import set_cpu_affinity
+                try:
+                    set_cpu_affinity(persona.cpu_count)
+                except (OSError, ValueError) as e:
+                    warn_post_fork(
+                        b"sandbox: fingerprint set_cpu_affinity failed "
+                        b"(errno=%d); affinity unchanged\n"
+                        % (getattr(e, "errno", 0) or 0)
+                    )
 
             # cwd — only now, after pivot_root. Match subprocess.run
             # semantics: if the caller specified a cwd that doesn't

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -13,6 +13,7 @@ import stat
 import subprocess
 import sys
 from contextlib import contextmanager
+from pathlib import Path
 from typing import List, Optional
 
 from . import landlock as _landlock
@@ -204,7 +205,10 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
             audit: bool = False, audit_verbose: bool = False,
             audit_run_dir: Optional[str] = None,
             observe: bool = False,
-            writable_paths: Optional[list] = None):
+            writable_paths: Optional[list] = None,
+            sanitise_host_fingerprint: bool = False,
+            cpu_count: Optional[int] = None,
+            require_sanitisation: bool = False):
     """Context manager for sandboxed subprocess execution.
 
     Each run() call inside the context runs the target command with the
@@ -806,6 +810,78 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                                seccomp_block_udp=seccomp_block_udp,
                                readable_paths=effective_read_paths)
 
+    # Host-fingerprint persona — opt-in. Built once per sandbox() context
+    # and reused across every run() call inside it. Cleanup happens in
+    # the finally block at the end of sandbox().
+    #
+    # Three failure modes, each with explicit behaviour so operators can
+    # see what's actually engaged:
+    #
+    #   1. is_supported() == False (macOS, etc.): persona stays None,
+    #      a one-shot WARNING tells the operator. require_sanitisation
+    #      raises RuntimeError instead.
+    #
+    #   2. mount-ns probe returns False (no uidmap, apparmor sysctl,
+    #      Landlock-only mode): persona stays None, one-shot WARNING.
+    #      require_sanitisation raises.
+    #
+    #   3. cpu_count > host's available CPUs: persona builds with the
+    #      requested count; set_cpu_affinity clamps at apply time and
+    #      logs INFO (the persona's cpuinfo still claims cpu_count,
+    #      creating a paranoid-cross-check tell — documented residual).
+    _persona = None
+    _persona_tmpdir = None
+    if sanitise_host_fingerprint:
+        from .fingerprint import build_persona, is_supported
+        from ._spawn import mount_ns_available
+        _fp_unsupported_reason = None
+        if not is_supported():
+            _fp_unsupported_reason = (
+                "platform unsupported (Linux required; macOS lacks "
+                "bind-mount + UTS-namespace primitives — run RAPTOR "
+                "in a Linux VM for untrusted-binary analysis)"
+            )
+        elif not mount_ns_available():
+            _fp_unsupported_reason = (
+                "mount-ns unavailable (needs `uidmap` package + "
+                "kernel.apparmor_restrict_unprivileged_userns=0); "
+                "see startup banner for the exact sysctl"
+            )
+        elif not (target or output):
+            # mount-ns engagement requires at least one of target/output
+            # — _spawn.run_sandboxed skips setup_mount_ns when both are
+            # falsy. Without mount-ns, the persona's file bind-mounts
+            # never apply; UTS + affinity would partially engage, which
+            # is a confusing half-state that lets the caller think they
+            # got sanitisation when they didn't.
+            _fp_unsupported_reason = (
+                "sandbox has no target/output set — mount-ns is skipped "
+                "in that case, so persona file overlays can't apply. "
+                "Pass at least one of target= or output= to engage "
+                "sanitisation"
+            )
+        if _fp_unsupported_reason:
+            msg = (
+                f"sanitise_host_fingerprint requested but {_fp_unsupported_reason}"
+            )
+            if require_sanitisation:
+                raise RuntimeError(msg + " (require_sanitisation=True)")
+            logger.warning("Sandbox: %s; identity surfaces will be host-real.", msg)
+        else:
+            import tempfile as _tf
+            _persona_tmpdir = _tf.mkdtemp(prefix="raptor-persona-")
+            _effective_cpu_count = cpu_count if cpu_count is not None else 4
+            _persona = build_persona(
+                Path(_persona_tmpdir), cpu_count=_effective_cpu_count,
+            )
+    elif cpu_count is not None:
+        # cpu_count without the master switch is a caller mistake — the
+        # CPU-mask change is part of the fingerprint persona, not an
+        # independent knob. Don't silently engage it.
+        logger.warning(
+            "Sandbox: cpu_count=%d ignored because sanitise_host_fingerprint=False",
+            cpu_count,
+        )
 
     # Cumulative proxy-event list spanning every run() call in this
     # sandbox() context. Per-run slices live on each result.sandbox_info;
@@ -1459,6 +1535,7 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                                            else None),
                             restrict_reads=restrict_reads,
                             strict_env=strict_env,
+                            persona=_persona,
                             # Default True here even though subprocess.run
                             # defaults to False — _spawn's historical
                             # behaviour was unconditional os.setsid() and
@@ -1996,6 +2073,22 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                     "this recurs.",
                     exc_info=True,
                 )
+        # Persona tmpdir lifecycle: created in build_persona above; the
+        # source files were bind-mounted into the sandbox children but
+        # bind sources can be unlinked after the bind is established —
+        # the kernel keeps the inode alive for the lifetime of the mount.
+        # Cleanup now is safe even mid-run (rare: with sandbox() used as
+        # a long-lived context wrapping many run() calls). For simplicity
+        # we only clean up at __exit__; the file count is small.
+        if _persona_tmpdir is not None:
+            import shutil as _shutil
+            try:
+                _shutil.rmtree(_persona_tmpdir, ignore_errors=True)
+            except Exception:
+                logger.debug(
+                    "persona tmpdir cleanup failed for %s",
+                    _persona_tmpdir, exc_info=True,
+                )
 
 
 # Convenience: standalone run function for one-off sandboxed commands
@@ -2012,6 +2105,9 @@ def run(cmd: List[str], block_network: bool = False, target: str = None,
         audit_run_dir: Optional[str] = None,
         observe: bool = False,
         writable_paths: Optional[list] = None,
+        sanitise_host_fingerprint: bool = False,
+        cpu_count: Optional[int] = None,
+        require_sanitisation: bool = False,
         **kwargs) -> subprocess.CompletedProcess:
     """Run a single command in a sandbox. Convenience wrapper.
 
@@ -2035,7 +2131,10 @@ def run(cmd: List[str], block_network: bool = False, target: str = None,
                  audit=audit, audit_verbose=audit_verbose,
                  audit_run_dir=audit_run_dir,
                  observe=observe,
-                 writable_paths=writable_paths) as _run:
+                 writable_paths=writable_paths,
+                 sanitise_host_fingerprint=sanitise_host_fingerprint,
+                 cpu_count=cpu_count,
+                 require_sanitisation=require_sanitisation) as _run:
         return _run(cmd, **kwargs)
 
 

--- a/core/sandbox/fingerprint.py
+++ b/core/sandbox/fingerprint.py
@@ -1,0 +1,508 @@
+"""Host-fingerprint sanitisation overlay for sandboxed children.
+
+Opt-in via `sandbox(..., sanitise_host_fingerprint=True)`. When engaged,
+the mount-ns child bind-mounts canonical files over the host's identity
+surfaces and the spawn machinery sets a canonical UTS namespace +
+sched_setaffinity mask:
+
+  /proc/cpuinfo                          → N blocks, host flags preserved
+  /proc/version                          → "Linux version <host-release>\\n"
+  /proc/cmdline                          → canonical stub
+  /proc/stat                             → aggregate + N per-cpu lines
+  /etc/os-release                        → Debian 12 stub
+  /etc/machine-id                        → deterministic-pseudo-random
+  /etc/hostname                          → "localhost"
+  /sys/class/dmi/id/sys_vendor           → "QEMU"
+  /sys/class/dmi/id/product_name         → "Standard PC (i440FX + PIIX, 1996)"
+  /sys/devices/system/cpu/online         → 0..N-1
+  /sys/devices/system/cpu/possible       → 0..N-1
+  uname() nodename                       → "localhost"
+  uname() domainname                     → "localdomain"
+  sched_getaffinity                      → bits 0..N-1
+
+Persona = "boring Debian 12 cloud VM on QEMU/KVM with Intel Xeon" —
+picked for hide-intent (most common Linux workload; doesn't tip off
+the sandbox). All sentinel-looking values that would identify us as
+analysis infrastructure ("sandbox" hostname, all-zero machine-id,
+"Generic x86_64 CPU" model) are deliberately avoided.
+
+What's PRESERVED from the host (capability surface, not identity):
+  - /proc/cpuinfo `flags` line (SMEP/SMAP detection in
+    packages/exploit_feasibility, SIMD dispatch, ASAN shadow-mem)
+  - uname() sysname (always "Linux"), release (kernel version for
+    exploit_feasibility's `uname -r`), machine (arch — shellcode
+    payload dispatch needs it)
+  - /proc/sys/kernel/{randomize_va_space, kptr_restrict,
+    yama/ptrace_scope}, /proc/sys/vm/mmap_min_addr (mitigation reads)
+  - /proc/self/* (maps, exe, status, auxv — ASAN, GDB, pwntools
+    context.aslr depend on real values)
+
+Residuals (documented; not addressed by this module):
+  - CPUID asm bypass — direct cpuid execution reads real CPU; fix
+    needs ptrace syscall rewriting + userspace emulator (out of scope).
+  - AT_HWCAP auxiliary vector — kernel-supplied at exec; not file-based.
+  - Vendor preservation via flags-line — Intel-vs-AMD distinguishable
+    via flag-set differences (e.g. AMD-specific flags). Trade-off for
+    SIMD compat.
+
+Platform support: Linux only. macOS lacks unprivileged bind-mount +
+UTS-namespace primitives, and most host-identity reads on macOS are
+syscall/IOKit-based (sysctlbyname, IORegistryEntry) — not file-based.
+`is_supported()` returns False on non-Linux; callers should soft-
+degrade with a one-shot WARNING (matching the pattern used by
+restrict_reads when Landlock is unavailable).
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util as _ctypes_util
+import hashlib
+import logging
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# === Persona constants ===
+
+# Hostname / domainname — applied via sethostname() / setdomainname()
+# inside the UTS namespace. Use the most universal default; "sandbox"
+# / "analyst" / "malware" are all known anti-analysis triggers.
+_HOSTNAME = "localhost"
+_DOMAINNAME = "localdomain"
+
+# /etc/machine-id: deterministic-pseudo-random per RAPTOR install.
+# Identical across runs from one install (cross-run determinism),
+# different across installs (defeats published-fingerprint attacks
+# where a malware author who knows RAPTOR can pre-compute a literal
+# hash to match against — the seed includes the install path which
+# is operator-specific).
+#
+# All-zeros (which we initially considered) is a known sandbox tell:
+# it indicates pre-systemd-machine-id-setup early boot or some
+# minimal containers, both unusual for "real" hosts. A literal
+# "sha256('raptor-sandbox-v1')" was the prior implementation but
+# being open-source it was a single grep away from a one-line bypass.
+def _derive_machine_id() -> str:
+    # Use RAPTOR_DIR (operator's install path) as the per-install
+    # entropy. Falls back to this module's directory if RAPTOR_DIR
+    # is unset — that path is also install-specific.
+    seed = os.environ.get("RAPTOR_DIR") or os.path.dirname(
+        os.path.abspath(__file__)
+    )
+    return hashlib.sha256(
+        b"raptor-fingerprint-v1\0" + seed.encode("utf-8", errors="replace")
+    ).hexdigest()[:32]
+
+
+_MACHINE_ID = _derive_machine_id()
+
+_OS_RELEASE = (
+    'PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"\n'
+    'NAME="Debian GNU/Linux"\n'
+    'VERSION_ID="12"\n'
+    'VERSION="12 (bookworm)"\n'
+    'VERSION_CODENAME=bookworm\n'
+    'ID=debian\n'
+    'HOME_URL="https://www.debian.org/"\n'
+    'SUPPORT_URL="https://www.debian.org/support"\n'
+    'BUG_REPORT_URL="https://bugs.debian.org/"\n'
+)
+
+# /proc/cmdline: generic VM-ish boot. Avoids known-VM markers like
+# console=ttyS0 (a QEMU/virt tell beyond just QEMU DMI).
+_CMDLINE = "BOOT_IMAGE=/boot/vmlinuz root=/dev/vda1 ro quiet\n"
+
+# DMI: canonical QEMU/KVM strings. Mirrors what a default-built QEMU
+# Standard PC presents — extremely common workload identity.
+_DMI_SYS_VENDOR = "QEMU\n"
+_DMI_PRODUCT_NAME = "Standard PC (i440FX + PIIX, 1996)\n"
+
+# /proc/cpuinfo block — per-processor. Per-CPU fields are templated
+# with the processor index and the global cpu_count. The `flags` field
+# is templated with the host's actual flags so capability dispatch
+# (SMEP/SMAP detection, SIMD, ASAN shadow-mem) keeps working.
+#
+# Identity triple = (family 6, model 85, stepping 7, microcode 0x5003901):
+# real values for Intel Xeon Silver 4214 (Skylake-X / Cascade Lake) —
+# one of the most common server SKUs on EC2/GCE/Azure. Picking ANY
+# real (family, model, stepping, microcode) tuple defeats the
+# `(f, m, s, mc) ∈ known_real_set` anti-analysis check; the family=6
+# model=1 stepping=0 microcode=0x0 combination we initially shipped
+# was the equivalent of a 1995 Pentium Pro on first boot — instantly
+# anomalous.
+#
+# `cpu MHz` and `bogomips` carry small deterministic offsets from the
+# round number rather than exact `2400.000` / `4800.00` — real CPUs
+# report `2399.9xx` / `4799.9xx` with sub-Hz jitter, and a "≡ 0 mod
+# 100" check is a soft tell that costs us nothing to defeat.
+_CPUINFO_TEMPLATE = """processor\t: {processor}
+vendor_id\t: GenuineIntel
+cpu family\t: 6
+model\t\t: 85
+model name\t: Intel(R) Xeon(R) Silver 4214 CPU @ 2.20GHz
+stepping\t: 7
+microcode\t: 0x5003901
+cpu MHz\t\t: 2199.998
+cache size\t: 16896 KB
+physical id\t: 0
+siblings\t: {cpu_count}
+core id\t\t: {processor}
+cpu cores\t: {cpu_count}
+apicid\t\t: {processor}
+initial apicid\t: {processor}
+fpu\t\t: yes
+fpu_exception\t: yes
+cpuid level\t: 22
+wp\t\t: yes
+flags\t\t: {flags}
+bugs\t\t:
+bogomips\t: 4399.99
+clflush size\t: 64
+cache_alignment\t: 64
+address sizes\t: 46 bits physical, 48 bits virtual
+power management:
+"""
+
+
+@dataclass(frozen=True)
+class Persona:
+    """A materialised host-fingerprint persona ready for bind-mounting.
+
+    `files`: absolute target path → temp source path. Each entry is
+    bind-mounted source→target by `apply_overlay()` inside the
+    mount-ns child.
+
+    `cpu_count`: number of logical CPUs the persona claims. The
+    cpuinfo file already contains the matching number of `processor`
+    blocks; this field is held separately so the spawn machinery can
+    pin sched_setaffinity to a matching mask (kept in sync = no
+    cross-check sandbox tell).
+
+    `hostname`, `domainname`: applied via sethostname() / setdomainname()
+    inside the UTS namespace by the spawn machinery — held separate from
+    `files` because the UTS-ns + syscall path is the only way to affect
+    uname() output. Bind-mounting /etc/hostname alone wouldn't change
+    what gethostname() returns.
+    """
+    files: dict[str, str]
+    cpu_count: int
+    hostname: str = _HOSTNAME
+    domainname: str = _DOMAINNAME
+
+
+def build_persona(tmpdir: Path, cpu_count: int) -> Persona:
+    """Materialise persona files under `tmpdir` and return the Persona.
+
+    cpu_count must be >= 1. The /proc/cpuinfo file will contain that
+    many `processor` blocks; the matching `sched_setaffinity` mask
+    is the caller's responsibility (see `set_cpu_affinity`).
+
+    Reads the host's /proc/cpuinfo `flags` line ONCE so all per-CPU
+    blocks share the same flag set. Host flags are preserved
+    deliberately: SIMD dispatch (ASAN, glibc, JITs) and SMEP/SMAP
+    feasibility detection in packages/exploit_feasibility key off
+    them. Empty string if host /proc/cpuinfo unreadable — handled
+    gracefully (tools fall back to default code paths).
+    """
+    if cpu_count < 1:
+        raise ValueError(f"cpu_count must be >= 1, got {cpu_count}")
+    tmpdir = Path(tmpdir)
+    tmpdir.mkdir(parents=True, exist_ok=True)
+
+    files: dict[str, str] = {}
+
+    # /proc/cpuinfo — N blocks separated by blank lines (kernel format).
+    flags = _read_host_cpu_flags()
+    blocks = [
+        _CPUINFO_TEMPLATE.format(
+            processor=i, cpu_count=cpu_count, flags=flags,
+        )
+        for i in range(cpu_count)
+    ]
+    files["/proc/cpuinfo"] = _write(tmpdir / "cpuinfo", "\n".join(blocks))
+
+    # /proc/version — trim host's version to "Linux version <release>".
+    files["/proc/version"] = _write(tmpdir / "version", _trim_proc_version())
+
+    # /proc/cmdline — canonical stub.
+    files["/proc/cmdline"] = _write(tmpdir / "cmdline", _CMDLINE)
+
+    # /etc/{os-release, machine-id, hostname}
+    files["/etc/os-release"] = _write(tmpdir / "os-release", _OS_RELEASE)
+    files["/etc/machine-id"] = _write(tmpdir / "machine-id", _MACHINE_ID + "\n")
+    files["/etc/hostname"] = _write(tmpdir / "hostname", _HOSTNAME + "\n")
+
+    # /sys/class/dmi/id/ — sys_vendor + product_name only.
+    # The omitted identity files (board_serial, product_uuid, etc.)
+    # remain host-real but are typically blocked by Landlock's
+    # restrict_reads allowlist (DMI dir isn't on the default list).
+    dmi_dir = tmpdir / "dmi"
+    dmi_dir.mkdir(exist_ok=True)
+    files["/sys/class/dmi/id/sys_vendor"] = _write(
+        dmi_dir / "sys_vendor", _DMI_SYS_VENDOR,
+    )
+    files["/sys/class/dmi/id/product_name"] = _write(
+        dmi_dir / "product_name", _DMI_PRODUCT_NAME,
+    )
+
+    # /sys/devices/system/cpu/{online,possible} — match cpu_count.
+    # Single-CPU systems write "0" (not "0-0") to match kernel format.
+    cpu_range = f"0-{cpu_count - 1}\n" if cpu_count > 1 else "0\n"
+    files["/sys/devices/system/cpu/online"] = _write(
+        tmpdir / "cpu_online", cpu_range,
+    )
+    files["/sys/devices/system/cpu/possible"] = _write(
+        tmpdir / "cpu_possible", cpu_range,
+    )
+
+    # /proc/{stat,uptime,loadavg} — internally consistent fake-uptime
+    # set. The earlier draft shipped /proc/stat with btime=1700000000
+    # and processes=1 while letting host /proc/uptime leak through —
+    # a malware cross-check seeing "system booted 2 years ago but has
+    # been up 4 hours" would flag immediately. Now all three derive
+    # from the same fake-uptime value: btime = now - uptime, uptime
+    # = the value, loadavg shows a plausible low-load system.
+    #
+    # Fake uptime is deterministic per RAPTOR install (same seed as
+    # _MACHINE_ID) so cross-run output is stable for one operator,
+    # but jitters across installs (defeats published-fingerprint).
+    # Range chosen to look like a multi-day-uptime production VM:
+    # ~3 days to ~30 days.
+    fake_uptime_s, fake_processes = _derive_uptime_and_processes()
+    btime = int(_now()) - fake_uptime_s
+
+    stat_lines = ["cpu  100 0 50 1000 0 0 0 0 0 0\n"]
+    for i in range(cpu_count):
+        stat_lines.append(f"cpu{i} 100 0 50 1000 0 0 0 0 0 0\n")
+    stat_lines.append(
+        f"intr 0\nctxt 0\nbtime {btime}\n"
+        f"processes {fake_processes}\nprocs_running 1\n"
+        f"procs_blocked 0\nsoftirq 0\n"
+    )
+    files["/proc/stat"] = _write(tmpdir / "stat", "".join(stat_lines))
+
+    # /proc/uptime — two floats: total uptime seconds + idle seconds.
+    # idle ≈ uptime * cpu_count (each CPU accumulates idle independently).
+    # Real systems report idle ≈ 0.97 * uptime * cpu_count on a low-load
+    # box; we pick 0.95 to leave a small "we've done some work" signal.
+    idle = int(fake_uptime_s * cpu_count * 0.95)
+    files["/proc/uptime"] = _write(
+        tmpdir / "uptime", f"{fake_uptime_s}.00 {idle}.00\n",
+    )
+
+    # /proc/loadavg — low-load values + a plausible "running/total
+    # tasks" pair + last-pid (matches `processes` in /proc/stat for
+    # internal consistency).
+    files["/proc/loadavg"] = _write(
+        tmpdir / "loadavg",
+        f"0.08 0.12 0.10 1/{fake_processes // 100} {fake_processes}\n",
+    )
+
+    return Persona(files=files, cpu_count=cpu_count)
+
+
+def _now() -> float:
+    """Wrapped for monkeypatching in tests."""
+    import time
+    return time.time()
+
+
+def _derive_uptime_and_processes() -> tuple[int, int]:
+    """Pick a fake uptime + processes counter, deterministic per
+    RAPTOR install. Uptime in [3 days, 30 days], processes in
+    [10000, 200000] — both plausible production-VM ranges.
+
+    Seed is the same as _MACHINE_ID so a single install consistently
+    presents the same uptime + processes across runs of the same
+    target. Different installs see different values (cross-operator
+    output drift, but local determinism).
+    """
+    seed = os.environ.get("RAPTOR_DIR") or os.path.dirname(
+        os.path.abspath(__file__)
+    )
+    h = hashlib.sha256(
+        b"raptor-fingerprint-uptime-v1\0" + seed.encode("utf-8", errors="replace")
+    ).digest()
+    # 3 days = 259200; 30 days = 2592000. Range = 2332800.
+    uptime = 259200 + (int.from_bytes(h[:4], "big") % 2332800)
+    # 10000 ≤ processes ≤ 210000
+    processes = 10000 + (int.from_bytes(h[4:8], "big") % 200000)
+    return uptime, processes
+
+
+def _write(path: Path, content: str) -> str:
+    """Helper: write content, return absolute path as str."""
+    path.write_text(content)
+    return str(path)
+
+
+def _read_host_cpu_flags() -> str:
+    """Return the host's /proc/cpuinfo `flags` line value (space-
+    separated flag names; no `flags\\t:` prefix).
+
+    Empty string on failure — handled gracefully by build_persona.
+    """
+    try:
+        with open("/proc/cpuinfo") as f:
+            for line in f:
+                if line.startswith("flags"):
+                    _, _, value = line.partition(":")
+                    return value.strip()
+    except OSError:
+        pass
+    return ""
+
+
+def _trim_proc_version() -> str:
+    """Return host /proc/version with build-host/compiler/timestamp
+    fingerprint stripped, preserving only `Linux version <release>`.
+
+    Example: "Linux version 6.8.0-49-generic (buildd@...) (gcc ...) #49-..."
+             becomes "Linux version 6.8.0-49-generic\\n"
+    """
+    try:
+        with open("/proc/version") as f:
+            raw = f.read().strip()
+    except OSError:
+        return "Linux version unknown\n"
+    m = re.match(r"^(Linux version \S+)", raw)
+    if not m:
+        return "Linux version unknown\n"
+    return m.group(1) + "\n"
+
+
+# === libc bindings ===
+# Python's os module exposes neither sethostname nor setdomainname
+# (only os.uname() for reading). Both syscalls require CAP_SYS_ADMIN
+# in the UTS namespace owner's user-ns — granted automatically inside
+# our user-ns (where we map to uid 0) PROVIDED CLONE_NEWUTS was
+# included in the unshare flags.
+
+_libc: ctypes.CDLL | None = None
+
+
+def _get_libc() -> ctypes.CDLL:
+    global _libc
+    if _libc is None:
+        _libc = ctypes.CDLL(_ctypes_util.find_library("c"), use_errno=True)
+    return _libc
+
+
+def set_uts(hostname: str, domainname: str) -> None:
+    """Set hostname + domainname in the current UTS namespace.
+
+    Must be called from inside the sandbox child AFTER
+    unshare(CLONE_NEWUTS|CLONE_NEWUSER) AND AFTER the parent's
+    newuidmap has run (we need uid 0 in the ns for CAP_SYS_ADMIN).
+
+    Raises OSError on failure. Caller decides whether to abort the
+    sandbox or degrade silently.
+    """
+    libc = _get_libc()
+    h = hostname.encode()
+    d = domainname.encode()
+    if libc.sethostname(h, len(h)) != 0:
+        err = ctypes.get_errno()
+        raise OSError(err, f"sethostname({hostname!r}): {os.strerror(err)}")
+    if libc.setdomainname(d, len(d)) != 0:
+        err = ctypes.get_errno()
+        raise OSError(err, f"setdomainname({domainname!r}): {os.strerror(err)}")
+
+
+def set_cpu_affinity(cpu_count: int) -> int:
+    """Pin the calling process to logical CPUs 0..cpu_count-1.
+
+    Returns the count actually applied (may be less than requested if
+    the host doesn't have that many CPUs available in the current
+    affinity set; we clamp rather than fail because the persona's
+    other CPU surfaces — /proc/cpuinfo blocks, /sys/cpu/online — can
+    still claim cpu_count without contradiction; the only cross-check
+    a paranoid binary could do is sched_getaffinity().popcount()
+    vs cpuinfo count, and clamping creates that one tell. Logged at
+    INFO so the operator knows the persona partially degraded.
+
+    Raises OSError only if sched_setaffinity fails for non-clamp
+    reasons (kernel error, EPERM in some namespace setups).
+    """
+    if cpu_count < 1:
+        raise ValueError(f"cpu_count must be >= 1, got {cpu_count}")
+    available = os.sched_getaffinity(0)
+    effective = min(cpu_count, len(available))
+    if effective < cpu_count:
+        logger.info(
+            "sanitise_host_fingerprint: cpu_count=%d requested but only "
+            "%d CPUs available in this affinity set; clamping. The persona's"
+            " /proc/cpuinfo will still report %d processors — a paranoid "
+            "binary cross-checking sched_getaffinity() popcount against "
+            "cpuinfo could detect the discrepancy.",
+            cpu_count, effective, cpu_count,
+        )
+    # Pick the lowest-numbered available CPUs so the mask is contiguous
+    # starting at 0, matching the persona's `/sys/cpu/online` range.
+    mask = set(sorted(available)[:effective])
+    os.sched_setaffinity(0, mask)
+    return effective
+
+
+def apply_overlay(persona: Persona, root_prefix: str = "") -> None:
+    """Bind-mount each persona file over its target path.
+
+    MUST be called inside the mount-ns child BEFORE pivot_root —
+    because the persona's source files live in the parent's /tmp,
+    which becomes inaccessible post-pivot (the fresh per-sandbox
+    tmpfs mounted at {root}/tmp shadows it).
+
+    The target path resolution is prefixed by `root_prefix` so the
+    caller can target `{root}/proc/cpuinfo` etc. while the sandbox
+    is still in its pre-pivot setup. After pivot_root, those binds
+    are visible at the un-prefixed path (`/proc/cpuinfo`) — same
+    mechanism as the /usr, /lib bind-mounts that setup_mount_ns
+    does earlier.
+
+    Must run AFTER setup_mount_ns has bind-mounted /proc, /etc, /sys
+    into {root} (otherwise the target paths don't exist), and BEFORE
+    Landlock install (kernel 6.15+ blocks mount topology changes
+    after landlock_restrict_self).
+
+    Failure handling: a single failing bind-mount logs at debug and
+    continues. Partial coverage is better than no coverage, and some
+    kernels/configs may not support bind-over for specific paths.
+    Tests assert per-file content visibility under a full setup.
+    """
+    # Use the same _mount wrapper as mount_ns.py to keep OSError
+    # semantics identical across the module boundary.
+    from .mount_ns import _mount, MS_BIND
+    for target, source in persona.files.items():
+        inside = f"{root_prefix}{target}"
+        if not os.path.exists(inside):
+            logger.debug(
+                "fingerprint: target %s does not exist; "
+                "skipping bind-mount", inside,
+            )
+            continue
+        try:
+            _mount(source, inside, None, MS_BIND)
+        except OSError as e:
+            logger.debug(
+                "fingerprint: bind %s → %s failed: %s",
+                source, inside, e,
+            )
+
+
+def is_supported() -> bool:
+    """Return True if the host platform can apply fingerprint sanitisation.
+
+    Linux only. macOS lacks unprivileged bind-mount + UTS namespace
+    primitives, and most host-identity reads there are syscall- or
+    IOKit-based (sysctlbyname, IORegistryEntry) — not file-based, so
+    file substitution wouldn't catch them. Recommended path for
+    untrusted-binary analysis on macOS: run RAPTOR in a Linux VM
+    (Virtualization.framework, since macOS 13).
+    """
+    return sys.platform == "linux"

--- a/core/sandbox/mount_ns.py
+++ b/core/sandbox/mount_ns.py
@@ -34,10 +34,17 @@ skipped — the per-ns mount already serves them.
 
 import ctypes
 import os
-from typing import Iterable, Optional
+from typing import TYPE_CHECKING, Iterable, Optional
 
 from ._fork_safe_warn import warn_post_fork
 from .exit_codes import SANDBOX_EXIT_MOUNT_NS_BIND_FAIL
+
+if TYPE_CHECKING:
+    # Avoid runtime circular import: fingerprint.apply_overlay imports
+    # _mount + MS_BIND from this module, so we keep the Persona
+    # annotation as a forward reference and import apply_overlay
+    # lazily inside setup_mount_ns when a persona is provided.
+    from .fingerprint import Persona
 
 # Linux mount(2) flag bits (from <linux/mount.h>). Values match the
 # kernel UAPI — do not "fix" without checking <sys/mount.h> on target.
@@ -163,13 +170,22 @@ def _shadows_per_ns(path: str) -> bool:
 
 def setup_mount_ns(target: Optional[str], output: Optional[str],
                    extra_ro_paths: Optional[Iterable[str]] = None,
-                   root_path: Optional[str] = None) -> None:
+                   root_path: Optional[str] = None,
+                   persona: Optional["Persona"] = None) -> None:
     """Establish pivot_root'd tmpfs sandbox root.
 
     Must be called AFTER the child has entered the new user-ns and acquired
     CAP_SYS_ADMIN (via the parent's newuidmap setup), and BEFORE
     landlock_restrict_self() — Landlock blocks mount operations on kernel
     6.15+.
+
+    `persona` (Optional[Persona]): when provided, after pivot_root completes
+    every persona.files[target] is bind-mounted over its target path
+    (/proc/cpuinfo, /etc/os-release, ...). Built by
+    `core.sandbox.fingerprint.build_persona()` when the caller passed
+    `sanitise_host_fingerprint=True`. Imported lazily to avoid a circular
+    import (fingerprint.apply_overlay imports _mount/MS_BIND from this
+    module).
     """
     # Absolutize target/output BEFORE any bind-mount work. A relative
     # path here produces a malformed bind-target like
@@ -366,6 +382,19 @@ def setup_mount_ns(target: Optional[str], output: Optional[str],
                 except OSError:
                     pass
                 os._exit(SANDBOX_EXIT_MOUNT_NS_BIND_FAIL)
+
+    # 8c. Host-fingerprint overlay (opt-in via sanitise_host_fingerprint).
+    # MUST happen BEFORE pivot_root — the persona's source files live
+    # in the parent's /tmp, which becomes inaccessible after pivot_root
+    # (the per-sandbox tmpfs at {root}/tmp shadows it). The overlay
+    # targets `{root}{target}` paths (e.g. `{root}/proc/cpuinfo`),
+    # which exist because /proc, /etc, /sys have already been bind-
+    # mounted into {root} in steps 5-6. After pivot_root, those binds
+    # are visible at the unprefixed path (`/proc/cpuinfo`) — same
+    # mechanism as the system-dir bind-mounts in step 4.
+    if persona is not None:
+        from .fingerprint import apply_overlay
+        apply_overlay(persona, root_prefix=root)
 
     # 9. pivot_root. put_old must be a directory INSIDE new_root.
     os.chdir(root)

--- a/core/sandbox/profiles.py
+++ b/core/sandbox/profiles.py
@@ -73,4 +73,8 @@ _SANDBOX_KWARGS = frozenset({
     # audit JSONL); passing it to inner run() would silently have no
     # effect — reject so the caller catches their mistake.
     "audit", "audit_verbose", "audit_run_dir",
+    # Fingerprint-sanitisation kwargs — sandbox-context-level because
+    # the persona is built once per context and reused across run()
+    # calls. Per-call override would silently no-op.
+    "sanitise_host_fingerprint", "cpu_count", "require_sanitisation",
 })

--- a/core/sandbox/tests/test_fingerprint.py
+++ b/core/sandbox/tests/test_fingerprint.py
@@ -1,0 +1,448 @@
+"""Unit tests for core.sandbox.fingerprint.
+
+Covers the pure-data parts: persona generation, file content shape,
+hide-intent invariants, cpu_count consistency, host-flag preservation.
+
+Tests that exercise the mount-ns / UTS-ns / sched_setaffinity wiring
+(which require fork + unshare + CAP_SYS_ADMIN) live in the integration
+test module (test_e2e_sandbox.py) and run against a real sandbox.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from core.sandbox.fingerprint import (
+    _HOSTNAME,
+    _DOMAINNAME,
+    _MACHINE_ID,
+    _OS_RELEASE,
+    _read_host_cpu_flags,
+    _trim_proc_version,
+    build_persona,
+    is_supported,
+    set_cpu_affinity,
+)
+
+
+# --- Constants / shape ---
+
+def test_machine_id_is_32_lowercase_hex():
+    """machine-id must look like a real /etc/machine-id (32 lowercase
+    hex, no dashes)."""
+    assert len(_MACHINE_ID) == 32, _MACHINE_ID
+    assert re.fullmatch(r"[0-9a-f]{32}", _MACHINE_ID), _MACHINE_ID
+
+
+def test_machine_id_is_not_all_zeros():
+    """All-zeros machine-id is a known sandbox tell (only seen during
+    pre-systemd-machine-id-setup early boot)."""
+    assert _MACHINE_ID != "0" * 32
+
+
+def test_machine_id_is_not_naive_published_hash():
+    """The first draft used hashlib.sha256(b'raptor-sandbox-v1') which
+    open-source publishes the exact bytes — any attacker can pre-
+    compute it and bypass with a literal-string match. Per-install
+    seed (RAPTOR_DIR or this module's path) defeats that."""
+    import hashlib as _hashlib
+    naive = _hashlib.sha256(b"raptor-sandbox-v1").hexdigest()[:32]
+    assert _MACHINE_ID != naive, (
+        "machine-id must NOT be the naive published-fingerprint hash; "
+        "current derivation should mix in install-path entropy"
+    )
+
+
+def test_hostname_is_localhost_not_sentinel():
+    """Hide-intent: hostname must avoid analysis-tool sentinels."""
+    assert _HOSTNAME == "localhost"
+    assert _DOMAINNAME == "localdomain"
+
+
+def test_os_release_does_not_mention_raptor_or_sandbox():
+    """Hide-intent invariant: nothing in persona names RAPTOR, sandbox,
+    analysis, malware, or analyst."""
+    lower = _OS_RELEASE.lower()
+    for tell in ("raptor", "sandbox", "analysis", "malware", "analyst"):
+        assert tell not in lower, (
+            f"hide-intent violation: os-release contains {tell!r}"
+        )
+
+
+def test_os_release_is_canonical_debian_12():
+    """Persona is "boring Debian 12 cloud VM"; os-release must reflect
+    that consistently."""
+    assert 'ID=debian' in _OS_RELEASE
+    assert 'VERSION_ID="12"' in _OS_RELEASE
+    assert 'bookworm' in _OS_RELEASE.lower()
+
+
+# --- build_persona input validation ---
+
+def test_build_persona_rejects_zero_cpu_count(tmp_path):
+    with pytest.raises(ValueError, match="cpu_count must be >= 1"):
+        build_persona(tmp_path, cpu_count=0)
+
+
+def test_build_persona_rejects_negative_cpu_count(tmp_path):
+    with pytest.raises(ValueError, match="cpu_count must be >= 1"):
+        build_persona(tmp_path, cpu_count=-1)
+
+
+# --- build_persona output shape ---
+
+def test_build_persona_creates_all_expected_targets(tmp_path):
+    persona = build_persona(tmp_path, cpu_count=4)
+    expected = {
+        "/proc/cpuinfo", "/proc/version", "/proc/cmdline", "/proc/stat",
+        "/proc/uptime", "/proc/loadavg",
+        "/etc/os-release", "/etc/machine-id", "/etc/hostname",
+        "/sys/class/dmi/id/sys_vendor",
+        "/sys/class/dmi/id/product_name",
+        "/sys/devices/system/cpu/online",
+        "/sys/devices/system/cpu/possible",
+    }
+    assert set(persona.files) == expected
+
+
+def test_build_persona_every_source_file_exists(tmp_path):
+    persona = build_persona(tmp_path, cpu_count=2)
+    for target, source in persona.files.items():
+        assert Path(source).is_file(), (
+            f"source for {target} does not exist: {source}"
+        )
+
+
+def test_persona_targets_are_absolute_paths(tmp_path):
+    """All target paths must be absolute — the mount-ns child bind-mounts
+    at literal paths and a relative target would silently fail."""
+    persona = build_persona(tmp_path, cpu_count=2)
+    for target in persona.files:
+        assert target.startswith("/"), (
+            f"persona target is not absolute: {target}"
+        )
+
+
+def test_persona_cpu_count_reflects_input(tmp_path):
+    persona = build_persona(tmp_path, cpu_count=8)
+    assert persona.cpu_count == 8
+
+
+def test_persona_carries_canonical_hostname(tmp_path):
+    persona = build_persona(tmp_path, cpu_count=1)
+    assert persona.hostname == "localhost"
+    assert persona.domainname == "localdomain"
+
+
+# --- /proc/cpuinfo content ---
+
+def test_cpuinfo_has_n_processor_blocks(tmp_path):
+    persona = build_persona(tmp_path, cpu_count=4)
+    content = Path(persona.files["/proc/cpuinfo"]).read_text()
+    blocks = re.findall(r"^processor\t: \d+$", content, re.MULTILINE)
+    assert len(blocks) == 4, content
+
+
+def test_cpuinfo_processor_indices_are_contiguous_from_zero(tmp_path):
+    persona = build_persona(tmp_path, cpu_count=3)
+    content = Path(persona.files["/proc/cpuinfo"]).read_text()
+    indices = [
+        int(m.group(1))
+        for m in re.finditer(r"^processor\t: (\d+)$", content, re.MULTILINE)
+    ]
+    assert indices == [0, 1, 2]
+
+
+def test_cpuinfo_single_cpu(tmp_path):
+    persona = build_persona(tmp_path, cpu_count=1)
+    content = Path(persona.files["/proc/cpuinfo"]).read_text()
+    indices = re.findall(r"^processor\t: (\d+)$", content, re.MULTILINE)
+    assert indices == ["0"]
+
+
+def test_cpuinfo_siblings_and_cores_match_cpu_count(tmp_path):
+    persona = build_persona(tmp_path, cpu_count=4)
+    content = Path(persona.files["/proc/cpuinfo"]).read_text()
+    # All `siblings` and `cpu cores` entries should report cpu_count.
+    siblings = re.findall(r"^siblings\t: (\d+)$", content, re.MULTILINE)
+    cores = re.findall(r"^cpu cores\t: (\d+)$", content, re.MULTILINE)
+    assert siblings == ["4"] * 4
+    assert cores == ["4"] * 4
+
+
+def test_cpuinfo_flags_preserved_from_host(tmp_path):
+    """flags line must equal the host's flags (capability preserved).
+    SMEP/SMAP/SIMD dispatch in packages/exploit_feasibility key off
+    these. Empty is acceptable only if host /proc/cpuinfo is unreadable
+    (non-Linux, restricted /proc) — in CI on Linux it should be non-empty.
+    """
+    host_flags = _read_host_cpu_flags()
+    persona = build_persona(tmp_path, cpu_count=1)
+    content = Path(persona.files["/proc/cpuinfo"]).read_text()
+    fake_flags_line = next(
+        l for l in content.splitlines() if l.startswith("flags")
+    )
+    _, _, fake_flags = fake_flags_line.partition(":")
+    assert fake_flags.strip() == host_flags
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="host /proc/cpuinfo only on Linux",
+)
+def test_host_flags_includes_sse_on_x86_linux():
+    """Sanity check that we're actually reading host flags on a normal
+    x86 Linux test host — catches a class of bug where the regex grabs
+    the wrong line."""
+    flags = _read_host_cpu_flags()
+    # Every x86 CPU since 2003 has 'sse'; this is just to confirm the
+    # parser is producing real content, not a smoke test of the CPU.
+    if "x86" in os.uname().machine:
+        assert "sse" in flags, f"flags read but no 'sse' present: {flags!r}"
+
+
+def test_cpuinfo_model_name_is_canonical_xeon(tmp_path):
+    """Model name must be plausible-real (hide-intent), not "Generic
+    x86_64 CPU" or other sentinel strings. Uses a real Xeon SKU
+    so a `(family, model, stepping) ∈ known_real_set` check doesn't
+    flag the persona."""
+    persona = build_persona(tmp_path, cpu_count=1)
+    content = Path(persona.files["/proc/cpuinfo"]).read_text()
+    assert "Intel(R) Xeon(R)" in content
+    for tell in ("Generic", "FAKE", "Sandbox", "Virtual CPU"):
+        assert tell not in content, (
+            f"hide-intent violation: cpuinfo contains {tell!r}"
+        )
+
+
+def test_cpuinfo_identity_triple_is_plausibly_real(tmp_path):
+    """family/model/stepping must NOT be the (6,1,0) Pentium-Pro-on-
+    first-boot signature we initially shipped. Any modern Xeon SKU
+    works; this test pins to the Skylake-X identity (family 6, model
+    85, stepping 7) we chose, so a refactor that drops to defaults
+    is caught at CI."""
+    persona = build_persona(tmp_path, cpu_count=1)
+    content = Path(persona.files["/proc/cpuinfo"]).read_text()
+    assert "cpu family\t: 6" in content
+    assert "model\t\t: 85" in content
+    assert "stepping\t: 7" in content
+
+
+def test_cpuinfo_microcode_is_plausible_revision(tmp_path):
+    """microcode revision must look like a real revision (non-zero
+    hex), not 0x0 (the "kernel has not loaded microcode yet" state
+    which is rare on production systems)."""
+    persona = build_persona(tmp_path, cpu_count=1)
+    content = Path(persona.files["/proc/cpuinfo"]).read_text()
+    micro_lines = [l for l in content.splitlines() if "microcode" in l]
+    assert micro_lines, "no microcode line in cpuinfo"
+    # All microcode values present, none all-zero, all valid hex.
+    for l in micro_lines:
+        value = l.partition(":")[2].strip()
+        assert value.startswith("0x"), l
+        assert int(value, 16) > 0, f"microcode is zero/empty: {l!r}"
+
+
+def test_cpuinfo_bogomips_is_not_round_hundred(tmp_path):
+    """bogomips with an exact 0.00 fractional part is a soft tell.
+    Real CPUs report values like 4799.95 / 4399.99 / etc."""
+    persona = build_persona(tmp_path, cpu_count=1)
+    content = Path(persona.files["/proc/cpuinfo"]).read_text()
+    bogo_lines = [l for l in content.splitlines() if l.startswith("bogomips")]
+    assert bogo_lines
+    for l in bogo_lines:
+        value = float(l.partition(":")[2].strip())
+        # Must be slightly off from a round hundred. 4800.00 → fail,
+        # 4399.99 → pass.
+        assert int(value * 100) % 100 != 0, (
+            f"bogomips is too round: {l!r}"
+        )
+
+
+def test_cpuinfo_bugs_line_is_empty(tmp_path):
+    """bugs line exposes mitigation posture (Meltdown/Spectre variants).
+    Must be empty value."""
+    persona = build_persona(tmp_path, cpu_count=1)
+    content = Path(persona.files["/proc/cpuinfo"]).read_text()
+    bugs_lines = [l for l in content.splitlines() if l.startswith("bugs")]
+    assert bugs_lines
+    for line in bugs_lines:
+        _, _, value = line.partition(":")
+        assert value.strip() == "", f"bugs line not empty: {line!r}"
+
+
+# --- /proc/version trim ---
+
+def test_trim_proc_version_regex_strips_suffix():
+    """Direct test of the trim against a synthetic kernel string —
+    avoids depending on the host's actual /proc/version."""
+    sample = (
+        "Linux version 6.8.0-49-generic (buildd@lcy02-amd64-072) "
+        "(gcc (Ubuntu 13.2.0-23ubuntu4) 13.2.0, GNU ld 2.42) "
+        "#49-Ubuntu SMP PREEMPT_DYNAMIC Wed Aug 28 16:33:25 UTC 2024"
+    )
+    m = re.match(r"^(Linux version \S+)", sample)
+    assert m is not None
+    assert m.group(1) == "Linux version 6.8.0-49-generic"
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="/proc/version only on Linux",
+)
+def test_trim_proc_version_against_host_strips_fingerprint():
+    """End-to-end: _trim_proc_version reads host /proc/version, returns
+    a single line starting with 'Linux version ' with no compiler /
+    build-host / timestamp tokens (those contain (, @, or #)."""
+    result = _trim_proc_version()
+    assert result.startswith("Linux version "), result
+    assert result.endswith("\n"), result
+    assert result.count("\n") == 1, result
+    body = result.rstrip("\n")
+    assert "(" not in body, f"compiler/buildhost not stripped: {body!r}"
+    assert "@" not in body, f"buildhost not stripped: {body!r}"
+    assert "#" not in body, f"build number not stripped: {body!r}"
+
+
+# --- /proc/cmdline ---
+
+def test_cmdline_is_canonical_vm_boot(tmp_path):
+    """cmdline must be generic-VM-ish: BOOT_IMAGE + root + ro + quiet.
+    Must NOT contain console=ttyS0 (a stronger virtualisation tell)."""
+    persona = build_persona(tmp_path, cpu_count=1)
+    content = Path(persona.files["/proc/cmdline"]).read_text()
+    assert "BOOT_IMAGE=" in content
+    assert "root=/dev/" in content
+    assert "console=ttyS0" not in content
+
+
+# --- /sys/devices/system/cpu/ ---
+
+def test_cpu_online_multi_cpu_uses_range(tmp_path):
+    persona = build_persona(tmp_path, cpu_count=4)
+    online = Path(persona.files["/sys/devices/system/cpu/online"]).read_text()
+    assert online.strip() == "0-3"
+
+
+def test_cpu_online_single_cpu_no_range(tmp_path):
+    """Single-CPU systems write just `0`, not `0-0` — matches kernel."""
+    persona = build_persona(tmp_path, cpu_count=1)
+    online = Path(persona.files["/sys/devices/system/cpu/online"]).read_text()
+    assert online.strip() == "0"
+
+
+def test_cpu_possible_matches_online(tmp_path):
+    """possible and online must agree — disagreement is a tell."""
+    persona = build_persona(tmp_path, cpu_count=2)
+    online = Path(persona.files["/sys/devices/system/cpu/online"]).read_text()
+    possible = Path(persona.files["/sys/devices/system/cpu/possible"]).read_text()
+    assert online == possible
+
+
+# --- /proc/stat ---
+
+def test_proc_stat_has_aggregate_plus_n_per_cpu_lines(tmp_path):
+    persona = build_persona(tmp_path, cpu_count=4)
+    stat = Path(persona.files["/proc/stat"]).read_text()
+    cpu_lines = [l for l in stat.splitlines() if l.startswith("cpu")]
+    # Expected: 1 aggregate "cpu " + 4 per-cpu lines "cpu0".."cpu3"
+    assert len(cpu_lines) == 5
+    assert cpu_lines[0].startswith("cpu ")
+    for i in range(4):
+        assert any(l.startswith(f"cpu{i} ") for l in cpu_lines)
+
+
+def test_proc_stat_includes_required_kernel_fields(tmp_path):
+    """Tools that parse /proc/stat (htop, monitoring) expect these
+    fields. Missing them can crash the parser."""
+    persona = build_persona(tmp_path, cpu_count=1)
+    stat = Path(persona.files["/proc/stat"]).read_text()
+    for field in ("intr ", "ctxt ", "btime ", "processes ", "softirq "):
+        assert field in stat, f"missing /proc/stat field: {field!r}"
+
+
+# --- DMI ---
+
+def test_dmi_sys_vendor_is_qemu(tmp_path):
+    """QEMU is plausible (most cloud workloads); avoids VirtualBox /
+    innotek / VMware sandbox tells."""
+    persona = build_persona(tmp_path, cpu_count=1)
+    sv = Path(persona.files["/sys/class/dmi/id/sys_vendor"]).read_text()
+    assert sv.strip() == "QEMU"
+
+
+def test_dmi_product_name_is_standard_pc(tmp_path):
+    persona = build_persona(tmp_path, cpu_count=1)
+    pn = Path(persona.files["/sys/class/dmi/id/product_name"]).read_text()
+    assert "Standard PC" in pn
+
+
+# --- sched_setaffinity ---
+
+def test_set_cpu_affinity_rejects_zero():
+    with pytest.raises(ValueError, match="cpu_count must be >= 1"):
+        set_cpu_affinity(0)
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="sched_setaffinity is Linux-only",
+)
+def test_set_cpu_affinity_pins_to_one_cpu_when_one_requested():
+    """Pin to CPU 0; sched_getaffinity should return exactly {0}.
+    Saves and restores the original mask so this test doesn't bleed
+    into siblings."""
+    original = os.sched_getaffinity(0)
+    try:
+        effective = set_cpu_affinity(1)
+        new = os.sched_getaffinity(0)
+        assert effective == 1
+        assert new == {0}
+    finally:
+        os.sched_setaffinity(0, original)
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux" or len(os.sched_getaffinity(0)) < 2,
+    reason="needs Linux + >= 2 available CPUs",
+)
+def test_set_cpu_affinity_pins_to_two_when_two_requested():
+    original = os.sched_getaffinity(0)
+    try:
+        effective = set_cpu_affinity(2)
+        new = os.sched_getaffinity(0)
+        assert effective == 2
+        # Mask should be contiguous from 0 to match persona's cpu_online range.
+        assert new == {0, 1}
+    finally:
+        os.sched_setaffinity(0, original)
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="sched_setaffinity is Linux-only",
+)
+def test_set_cpu_affinity_clamps_to_available(caplog):
+    """If cpu_count exceeds available CPUs, clamp and log INFO. Logged
+    so operators can see the persona partially degraded."""
+    import logging
+    original = os.sched_getaffinity(0)
+    try:
+        with caplog.at_level(logging.INFO, logger="core.sandbox.fingerprint"):
+            effective = set_cpu_affinity(len(original) + 1000)
+        assert effective == len(original)
+        assert any(
+            "clamping" in rec.message.lower() for rec in caplog.records
+        )
+    finally:
+        os.sched_setaffinity(0, original)
+
+
+# --- Platform support ---
+
+def test_is_supported_returns_true_on_linux():
+    if sys.platform == "linux":
+        assert is_supported() is True
+    else:
+        assert is_supported() is False

--- a/core/sandbox/tests/test_fingerprint_adversarial.py
+++ b/core/sandbox/tests/test_fingerprint_adversarial.py
@@ -1,0 +1,410 @@
+"""Adversarial end-to-end tests for host-fingerprint sanitisation.
+
+Each test runs a malware-style anti-analysis check INSIDE the sandbox
+and asserts the check concludes "I'm on a real Debian VM, not a
+sandbox." If any of these tests fails, an attacker writing roughly
+that check would detect RAPTOR's sandbox and refuse to execute its
+payload, defeating the analysis.
+
+Categories covered (drawn from public anti-analysis literature like
+Joe Sandbox / Cuckoo / Pafish / al-khaser):
+
+  - Hostname / domainname sentinel checks
+  - DMI vendor/product blacklist
+  - CPU identity triple lookup ((family, model, stepping) anomalies)
+  - machine-id well-known-bad list
+  - CPU count anomaly (==1 → sandbox heuristic)
+  - cpuinfo + sched_getaffinity cross-check
+  - cpuinfo + /sys/devices/system/cpu cross-check
+  - cpuinfo + /proc/stat cross-check (per-cpu line count)
+  - btime + uptime cross-check (must agree)
+  - os-release ID + dynamic linker cache (we don't claim Ubuntu and
+    then ship Debian's cache, etc.)
+  - Round-number checks on bogomips / MHz
+  - Published-fingerprint defence (machine-id NOT the trivial
+    sha256("raptor-sandbox-v1"))
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="adversarial fingerprint tests are Linux-only",
+)
+
+
+def _mount_ns_usable() -> bool:
+    if not shutil.which("newuidmap") or not shutil.which("newgidmap"):
+        return False
+    sysctl = Path("/proc/sys/kernel/apparmor_restrict_unprivileged_userns")
+    if sysctl.exists() and sysctl.read_text().strip() == "1":
+        return False
+    return True
+
+
+class TestAdversarialFingerprint(unittest.TestCase):
+    """Each test spawns a sandbox with sanitise_host_fingerprint=True
+    and runs an adversary's fingerprint check. The check exits 0 if
+    "looks like a real system", nonzero (with diagnostic on stderr) if
+    "this is a sandbox." We assert exit 0 — meaning the persona
+    successfully defeats that specific anti-analysis pattern."""
+
+    def setUp(self):
+        if not _mount_ns_usable():
+            self.skipTest(
+                "mount-ns unusable here (needs uidmap + sysctl=0)"
+            )
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.persona_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.persona_dir.cleanup)
+        from core.sandbox.fingerprint import build_persona
+        # cpu_count=4 (the production default) — exercises the multi-CPU
+        # path and the "not == 1" anti-analysis heuristic.
+        self.persona = build_persona(Path(self.persona_dir.name), cpu_count=4)
+
+    def _spawn_check(self, sh_script: str):
+        """Run an anti-analysis check script and return CompletedProcess."""
+        from core.sandbox._spawn import run_sandboxed
+        return run_sandboxed(
+            ["sh", "-c", sh_script],
+            target=self.tmp.name, output=self.tmp.name,
+            block_network=True,
+            nproc_limit=1024,
+            limits={"memory_mb": 0, "max_file_mb": 10240, "cpu_seconds": 300},
+            writable_paths=[self.tmp.name, "/tmp"],
+            readable_paths=None,
+            allowed_tcp_ports=None,
+            seccomp_profile=None,
+            seccomp_block_udp=False,
+            env=None, cwd=None, timeout=30,
+            capture_output=True, text=True,
+            persona=self.persona,
+        )
+
+    def _assert_undetected(self, script: str, message: str = ""):
+        r = self._spawn_check(script)
+        if r.returncode != 0:
+            self.fail(
+                f"sandbox DETECTED by anti-analysis check {message!r}: "
+                f"stdout={r.stdout!r} stderr={r.stderr!r} rc={r.returncode}"
+            )
+
+    # === Hostname checks (Pafish/al-khaser pattern) ===
+
+    def test_hostname_not_in_sandbox_blacklist(self):
+        script = textwrap.dedent("""
+            HN=$(hostname)
+            for bad in sandbox cuckoo malware analyst sample raptor; do
+                if echo "$HN" | grep -qi "$bad"; then
+                    echo "DETECTED hostname=$HN matches $bad" >&2
+                    exit 1
+                fi
+            done
+            exit 0
+        """)
+        self._assert_undetected(script, "hostname blacklist")
+
+    # === DMI vendor blacklist (most common anti-analysis check) ===
+
+    def test_dmi_vendor_not_virtualbox_or_vmware(self):
+        script = textwrap.dedent("""
+            V=$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || echo absent)
+            P=$(cat /sys/class/dmi/id/product_name 2>/dev/null || echo absent)
+            for bad in VirtualBox innotek "VMware" Parallels Xen Bochs; do
+                if echo "$V $P" | grep -q "$bad"; then
+                    echo "DETECTED DMI sys_vendor/product mentions $bad: $V / $P" >&2
+                    exit 1
+                fi
+            done
+            exit 0
+        """)
+        self._assert_undetected(script, "DMI vendor blacklist")
+
+    # === CPU identity triple sanity ===
+
+    def test_cpuinfo_identity_triple_is_known_real(self):
+        """A malware author maintains a small allowlist of (family,
+        model, stepping) tuples corresponding to real shipped CPUs.
+        Our persona must hit a known-real tuple."""
+        script = textwrap.dedent("""
+            FAMILY=$(awk -F: '/^cpu family/{print $2; exit}' /proc/cpuinfo | tr -d ' ')
+            MODEL=$(awk -F: '/^model[^ ]/{print $2; exit}' /proc/cpuinfo | tr -d ' ')
+            STEPPING=$(awk -F: '/^stepping/{print $2; exit}' /proc/cpuinfo | tr -d ' ')
+            TRIPLE="$FAMILY-$MODEL-$STEPPING"
+            # Real known-good Intel triples (Skylake-X / Cascade Lake /
+            # Ice Lake / various Coffee Lake server SKUs).
+            case "$TRIPLE" in
+                6-85-7|6-85-6|6-85-4|6-106-6|6-142-10|6-158-10|6-79-1|6-63-2|6-45-7)
+                    exit 0 ;;
+            esac
+            echo "DETECTED implausible (family,model,stepping)=$TRIPLE" >&2
+            exit 1
+        """)
+        self._assert_undetected(script, "CPU identity triple")
+
+    def test_cpuinfo_microcode_is_not_zero(self):
+        script = textwrap.dedent("""
+            MC=$(awk -F: '/^microcode/{print $2; exit}' /proc/cpuinfo | tr -d ' ')
+            if [ "$MC" = "0x0" ] || [ -z "$MC" ]; then
+                echo "DETECTED microcode is 0x0 / absent: $MC" >&2
+                exit 1
+            fi
+            exit 0
+        """)
+        self._assert_undetected(script, "microcode anomaly")
+
+    def test_cpuinfo_bogomips_not_exact_round_hundred(self):
+        script = textwrap.dedent("""
+            BOGO=$(awk -F: '/^bogomips/{print $2; exit}' /proc/cpuinfo | tr -d ' ')
+            # Strip the fractional part and check it's non-zero — real
+            # CPUs have sub-Hz jitter in their bogomips report.
+            FRAC=$(echo "$BOGO" | cut -d. -f2)
+            if [ "$FRAC" = "00" ]; then
+                echo "DETECTED suspiciously round bogomips $BOGO" >&2
+                exit 1
+            fi
+            exit 0
+        """)
+        self._assert_undetected(script, "bogomips precision")
+
+    # === machine-id checks ===
+
+    def test_machine_id_is_not_all_zeros(self):
+        script = textwrap.dedent("""
+            MID=$(cat /etc/machine-id)
+            if echo "$MID" | grep -qE '^0+$'; then
+                echo "DETECTED machine-id is all zeros: $MID" >&2
+                exit 1
+            fi
+            exit 0
+        """)
+        self._assert_undetected(script, "machine-id all zeros")
+
+    def test_machine_id_is_not_naive_published_hash(self):
+        """A malware author with our source code would pre-compute
+        sha256('raptor-sandbox-v1') and literal-match. Per-install
+        seeding defeats that — assert the literal naive value isn't
+        what we ship."""
+        import hashlib
+        naive = hashlib.sha256(b"raptor-sandbox-v1").hexdigest()[:32]
+        script = textwrap.dedent(f"""
+            MID=$(cat /etc/machine-id)
+            if [ "$MID" = "{naive}" ]; then
+                echo "DETECTED machine-id is the naive published-fingerprint hash" >&2
+                exit 1
+            fi
+            exit 0
+        """)
+        self._assert_undetected(script, "published-fingerprint machine-id")
+
+    # === CPU count heuristics ===
+
+    def test_cpu_count_is_at_least_two(self):
+        """Single-CPU systems are unusual for production workloads.
+        Persona default cpu_count=4 defeats `nproc == 1 → sandbox`."""
+        script = textwrap.dedent("""
+            N=$(nproc)
+            if [ "$N" -lt 2 ]; then
+                echo "DETECTED only $N CPU available" >&2
+                exit 1
+            fi
+            exit 0
+        """)
+        self._assert_undetected(script, "single-CPU heuristic")
+
+    def test_cpuinfo_count_matches_sched_getaffinity(self):
+        """Cross-check: cpuinfo blocks must equal sched_getaffinity
+        popcount. Disagreement reveals fakery."""
+        script = textwrap.dedent("""
+            CINFO=$(grep -c '^processor' /proc/cpuinfo)
+            AFF=$(python3 -c 'import os; print(len(os.sched_getaffinity(0)))')
+            if [ "$CINFO" != "$AFF" ]; then
+                echo "DETECTED cpuinfo=$CINFO != affinity=$AFF" >&2
+                exit 1
+            fi
+            exit 0
+        """)
+        self._assert_undetected(script, "cpuinfo vs affinity cross-check")
+
+    def test_cpuinfo_count_matches_sys_cpu_online(self):
+        script = textwrap.dedent("""
+            CINFO=$(grep -c '^processor' /proc/cpuinfo)
+            ONLINE=$(cat /sys/devices/system/cpu/online)
+            # Parse "0-3" → 4, "0" → 1, "0,2-3" → 3 (etc.)
+            COUNT=$(python3 -c '
+import sys
+s = sys.argv[1]
+total = 0
+for part in s.split(","):
+    if "-" in part:
+        a, b = part.split("-")
+        total += int(b) - int(a) + 1
+    else:
+        total += 1
+print(total)
+' "$ONLINE")
+            if [ "$CINFO" != "$COUNT" ]; then
+                echo "DETECTED cpuinfo=$CINFO != cpu/online=$COUNT" >&2
+                exit 1
+            fi
+            exit 0
+        """)
+        self._assert_undetected(script, "cpuinfo vs cpu/online cross-check")
+
+    def test_cpuinfo_count_matches_proc_stat(self):
+        """/proc/stat shows one cpu line per CPU. Mismatch reveals
+        the persona only patched cpuinfo and forgot about /proc/stat."""
+        script = textwrap.dedent("""
+            CINFO=$(grep -c '^processor' /proc/cpuinfo)
+            # cpu0, cpu1, cpu2, cpu3 — but NOT the aggregate "cpu " line.
+            STAT=$(awk '/^cpu[0-9]+ /' /proc/stat | wc -l)
+            if [ "$CINFO" != "$STAT" ]; then
+                echo "DETECTED cpuinfo=$CINFO != /proc/stat cpus=$STAT" >&2
+                exit 1
+            fi
+            exit 0
+        """)
+        self._assert_undetected(script, "cpuinfo vs /proc/stat cross-check")
+
+    # === Uptime / btime consistency ===
+
+    def test_uptime_btime_internally_consistent(self):
+        """uptime + btime should ≈ current time. A persona that fakes
+        btime but leaves uptime host-real (or vice versa) shows >>1hr
+        discrepancy — the original draft was 2+ years off."""
+        script = textwrap.dedent("""
+            UPTIME=$(awk '{print int($1)}' /proc/uptime)
+            BTIME=$(awk '/^btime/{print $2}' /proc/stat)
+            NOW=$(date +%s)
+            EXPECTED=$((NOW - UPTIME))
+            # btime should be within 60 seconds of (now - uptime). Real
+            # systems show a few seconds of skew due to clock drift; we
+            # allow 60s as a wide margin.
+            DIFF=$((BTIME - EXPECTED))
+            DIFF=${DIFF#-}  # absolute value
+            if [ "$DIFF" -gt 60 ]; then
+                echo "DETECTED btime=$BTIME vs now-uptime=$EXPECTED differ by $DIFF s" >&2
+                exit 1
+            fi
+            exit 0
+        """)
+        self._assert_undetected(script, "btime vs uptime cross-check")
+
+    def test_processes_counter_is_plausibly_large(self):
+        """/proc/stat `processes` is the cumulative fork count since
+        boot. `1` means only init ever forked — implausible for any
+        running system."""
+        script = textwrap.dedent("""
+            P=$(awk '/^processes/{print $2}' /proc/stat)
+            if [ "$P" -lt 100 ]; then
+                echo "DETECTED implausibly low process counter: $P" >&2
+                exit 1
+            fi
+            exit 0
+        """)
+        self._assert_undetected(script, "processes counter")
+
+    # === OS / distro consistency ===
+
+    def test_os_release_matches_apt_present(self):
+        """We claim Debian via /etc/os-release. apt/dpkg presence is
+        a soft cross-check — debian without dpkg is suspect. Our
+        sandbox bind-mounts /usr/bin RO from the HOST, so dpkg
+        availability depends on the operator's machine. Don't require
+        dpkg; instead, require that os-release's ID is in the
+        Debian-family allowlist (a real cross-check)."""
+        script = textwrap.dedent("""
+            . /etc/os-release
+            case "$ID" in
+                debian|ubuntu|raspbian|kali|mint|pop|elementary)
+                    exit 0 ;;
+            esac
+            echo "DETECTED os-release ID is implausible: $ID" >&2
+            exit 1
+        """)
+        self._assert_undetected(script, "os-release ID")
+
+    # === Domain / gethostname consistency ===
+
+    def test_etc_hostname_matches_gethostname(self):
+        """If /etc/hostname says foo but gethostname() says bar, it's
+        a sandbox tell (real init scripts keep them in sync). Our
+        persona binds /etc/hostname AND calls sethostname()."""
+        script = textwrap.dedent("""
+            FILE=$(cat /etc/hostname 2>/dev/null || echo absent)
+            SYS=$(hostname)
+            if [ "$FILE" != "$SYS" ]; then
+                echo "DETECTED /etc/hostname=$FILE vs hostname()=$SYS" >&2
+                exit 1
+            fi
+            exit 0
+        """)
+        self._assert_undetected(script, "hostname file vs syscall")
+
+    # === Capability surface preserved (regression guard) ===
+
+    def test_capability_surface_intact_smep(self):
+        """An exploit_feasibility-style check: does the cpuinfo flags
+        line still report SMEP/SMAP? If sanitisation accidentally
+        clobbered the flags line, kernel-exploit analysis breaks."""
+        script = textwrap.dedent("""
+            if grep -q '^flags.*smep' /proc/cpuinfo; then
+                exit 0
+            fi
+            # Older Atom / very old Xeon systems lack SMEP — that's
+            # not a sandbox tell. Tolerate by checking that SOME
+            # post-2010 flag is present (sse2 is the minimum).
+            if grep -q '^flags.*sse2' /proc/cpuinfo; then
+                exit 0
+            fi
+            echo "DETECTED cpuinfo flags line looks empty / not host-derived" >&2
+            exit 1
+        """)
+        self._assert_undetected(script, "capability surface SMEP")
+
+    def test_capability_surface_intact_aslr_sysctl(self):
+        """exploit_feasibility reads /proc/sys/kernel/randomize_va_space.
+        Sanitisation must NOT touch /proc/sys/."""
+        script = textwrap.dedent("""
+            V=$(cat /proc/sys/kernel/randomize_va_space 2>/dev/null)
+            # Must be 0, 1, or 2 (any kernel-valid value). Empty or
+            # missing means we accidentally masked this sysctl.
+            case "$V" in
+                0|1|2) exit 0 ;;
+            esac
+            echo "DETECTED sysctl randomize_va_space=$V (expected 0/1/2)" >&2
+            exit 1
+        """)
+        self._assert_undetected(script, "ASLR sysctl preserved")
+
+    def test_capability_surface_uname_release_real(self):
+        """exploit_feasibility runs `uname -r`. Must return the real
+        kernel release, not "6.0.0-generic" or other stub."""
+        script = textwrap.dedent("""
+            R=$(uname -r)
+            # The real kernel release on the host. We assert it's NON-
+            # generic (no exact match against a known stub string).
+            for stub in "6.0.0-generic" "unknown" "0.0.0" "5.0.0-generic"; do
+                if [ "$R" = "$stub" ]; then
+                    echo "DETECTED uname release looks stub'd: $R" >&2
+                    exit 1
+                fi
+            done
+            # Sanity: real kernel releases have a digit somewhere
+            if ! echo "$R" | grep -q '[0-9]'; then
+                echo "DETECTED kernel release has no digit: $R" >&2
+                exit 1
+            fi
+            exit 0
+        """)
+        self._assert_undetected(script, "uname -r preserved")

--- a/core/sandbox/tests/test_fingerprint_context.py
+++ b/core/sandbox/tests/test_fingerprint_context.py
@@ -1,0 +1,203 @@
+"""Tests for the context.py public-API integration of fingerprint
+sanitisation: opt-in kwarg threading, degradation behaviour,
+require_sanitisation hard-fail, per-call kwarg rejection.
+
+These tests do NOT exercise the full mount-ns spawn path (covered by
+test_fingerprint_e2e.py) — they focus on context.py's bookkeeping
+around the persona lifecycle and the public API surface.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import tempfile
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="fingerprint context tests target the Linux substrate",
+)
+
+
+def test_cpu_count_without_master_switch_logs_warning(caplog):
+    """Passing cpu_count without sanitise_host_fingerprint=True should
+    warn the caller — silently engaging the CPU mask without the rest
+    of the persona would be inconsistent and confusing."""
+    from core.sandbox import sandbox
+    with caplog.at_level(logging.WARNING, logger="core.sandbox"):
+        with tempfile.TemporaryDirectory() as tmp:
+            with sandbox(target=tmp, output=tmp, cpu_count=4):
+                pass
+    assert any(
+        "cpu_count=4 ignored" in rec.message for rec in caplog.records
+    ), [rec.message for rec in caplog.records]
+
+
+def test_sanitise_kwarg_rejected_on_inner_run():
+    """sanitise_host_fingerprint is sandbox-context-level. Passing it to
+    sandbox().run() must raise TypeError (same as block_network=, etc.).
+    """
+    from core.sandbox import sandbox
+    with tempfile.TemporaryDirectory() as tmp:
+        with sandbox(target=tmp, output=tmp) as run:
+            with pytest.raises(TypeError, match="sanitise_host_fingerprint"):
+                run(["true"], sanitise_host_fingerprint=True)
+
+
+def test_cpu_count_rejected_on_inner_run():
+    from core.sandbox import sandbox
+    with tempfile.TemporaryDirectory() as tmp:
+        with sandbox(target=tmp, output=tmp) as run:
+            with pytest.raises(TypeError, match="cpu_count"):
+                run(["true"], cpu_count=4)
+
+
+def test_require_sanitisation_rejected_on_inner_run():
+    from core.sandbox import sandbox
+    with tempfile.TemporaryDirectory() as tmp:
+        with sandbox(target=tmp, output=tmp) as run:
+            with pytest.raises(TypeError, match="require_sanitisation"):
+                run(["true"], require_sanitisation=True)
+
+
+def test_require_sanitisation_raises_when_unsupported(monkeypatch):
+    """If require_sanitisation=True and mount-ns is unavailable, the
+    sandbox() context must raise RuntimeError at entry. Operators who
+    explicitly require sanitisation prefer a hard fail over silent
+    degradation."""
+    from core.sandbox import sandbox
+    # Force mount_ns_available() to return False regardless of host.
+    import core.sandbox._spawn as _sp
+    monkeypatch.setattr(_sp, "mount_ns_available", lambda: False)
+    with tempfile.TemporaryDirectory() as tmp:
+        with pytest.raises(RuntimeError, match="require_sanitisation=True"):
+            with sandbox(target=tmp, output=tmp,
+                         sanitise_host_fingerprint=True,
+                         require_sanitisation=True):
+                pass
+
+
+def test_unsupported_soft_degrades_with_warning(monkeypatch, caplog):
+    """Without require_sanitisation, an unsupported environment should
+    log a WARNING but not raise — sandbox continues without the persona,
+    identity surfaces remain host-real."""
+    from core.sandbox import sandbox
+    import core.sandbox._spawn as _sp
+    monkeypatch.setattr(_sp, "mount_ns_available", lambda: False)
+    with caplog.at_level(logging.WARNING, logger="core.sandbox"):
+        with tempfile.TemporaryDirectory() as tmp:
+            with sandbox(target=tmp, output=tmp,
+                         sanitise_host_fingerprint=True) as _run:
+                pass
+    assert any(
+        "sanitise_host_fingerprint" in rec.message
+        and "host-real" in rec.message
+        for rec in caplog.records
+    ), [rec.message for rec in caplog.records]
+
+
+def test_sanitise_without_target_or_output_soft_degrades(monkeypatch, caplog):
+    """sandbox() with sanitise_host_fingerprint=True but neither
+    target nor output set: mount-ns gets skipped by _spawn (its gate
+    is `if target or output`), so file overlays can't apply. Must
+    soft-degrade with a clear warning rather than silently producing
+    half-coverage (UTS + affinity engage; file overlays don't)."""
+    from core.sandbox import sandbox
+    import core.sandbox._spawn as _sp
+    monkeypatch.setattr(_sp, "mount_ns_available", lambda: True)
+    with caplog.at_level(logging.WARNING, logger="core.sandbox"):
+        with sandbox(sanitise_host_fingerprint=True) as _run:
+            pass
+    assert any(
+        "no target/output" in rec.message for rec in caplog.records
+    ), [rec.message for rec in caplog.records]
+
+
+def test_sanitise_without_target_or_output_hard_fails_when_required(monkeypatch):
+    """require_sanitisation=True must hard-fail on the no-target/output
+    corner case too — not just on platform / mount-ns unavailability."""
+    from core.sandbox import sandbox
+    import core.sandbox._spawn as _sp
+    monkeypatch.setattr(_sp, "mount_ns_available", lambda: True)
+    with pytest.raises(RuntimeError, match="require_sanitisation=True"):
+        with sandbox(sanitise_host_fingerprint=True,
+                     require_sanitisation=True):
+            pass
+
+
+def test_top_level_run_forwards_kwargs_to_sandbox():
+    """The standalone run() must forward sanitise/cpu_count/require
+    kwargs through to its inner sandbox() — otherwise callers of
+    run(sanitise_host_fingerprint=True) get nothing. We can't easily
+    test the full sandbox-spawn path here (depends on host
+    capabilities); instead, drive require_sanitisation=True against
+    a forced-False mount-ns and assert run() propagates the
+    resulting RuntimeError."""
+    import tempfile as _tf
+    from core.sandbox import run as _run
+    with pytest.raises(RuntimeError, match="require_sanitisation=True"):
+        with _tf.TemporaryDirectory() as t:
+            # mount_ns will report unavailable -> hard-fail propagates
+            # from sandbox() through run()'s `with sandbox(...) as _r`.
+            # We don't monkeypatch mount_ns_available here so the test
+            # is portable across hosts.
+            from unittest.mock import patch
+            with patch("core.sandbox._spawn.mount_ns_available",
+                       return_value=False):
+                _run(["true"], target=t, output=t,
+                     sanitise_host_fingerprint=True,
+                     require_sanitisation=True)
+
+
+def test_persona_tmpdir_cleaned_up_on_exit(monkeypatch):
+    """The tmpdir created for persona files in sandbox() must be
+    removed on context exit. Catches a class of bug where a long-lived
+    parent process accumulates /tmp/raptor-persona-* over many runs."""
+    import os
+    from core.sandbox import sandbox
+
+    # Need mount_ns to be reported available for the persona to be built.
+    # On a CI host without uidmap this would otherwise short-circuit.
+    import core.sandbox._spawn as _sp
+    import core.sandbox.fingerprint as _fp
+    monkeypatch.setattr(_sp, "mount_ns_available", lambda: True)
+    monkeypatch.setattr(_fp, "is_supported", lambda: True)
+
+    seen_dirs = []
+    real_mkdtemp = tempfile.mkdtemp
+
+    def _track_mkdtemp(*args, **kw):
+        d = real_mkdtemp(*args, **kw)
+        # Capture both positional and keyword prefix forms — Python's
+        # own TemporaryDirectory calls mkdtemp(suffix, prefix, dir)
+        # positionally, so a kw-only matcher would miss it.
+        prefix = kw.get("prefix")
+        if prefix is None and len(args) >= 2:
+            prefix = args[1]
+        if prefix and str(prefix).startswith("raptor-persona-"):
+            seen_dirs.append(d)
+        return d
+
+    monkeypatch.setattr(tempfile, "mkdtemp", _track_mkdtemp)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            with sandbox(target=tmp, output=tmp,
+                         sanitise_host_fingerprint=True) as _run:
+                # We don't actually spawn — mount_ns_available was
+                # monkeypatched, so an actual run() would fall back to
+                # the Landlock-only path. We just verify the persona
+                # tmpdir got created.
+                assert len(seen_dirs) == 1, (
+                    f"expected one persona tmpdir, got {seen_dirs}"
+                )
+                assert os.path.isdir(seen_dirs[0]), seen_dirs[0]
+        finally:
+            pass
+    # After context exit, the tmpdir must be gone.
+    for d in seen_dirs:
+        assert not os.path.exists(d), (
+            f"persona tmpdir leaked: {d} still exists after sandbox exit"
+        )

--- a/core/sandbox/tests/test_fingerprint_e2e.py
+++ b/core/sandbox/tests/test_fingerprint_e2e.py
@@ -1,0 +1,222 @@
+"""End-to-end tests for host-fingerprint sanitisation.
+
+Exercises the full chain: caller passes persona → unshare(CLONE_NEWUTS)
+→ set_uts() → mount_ns with persona → apply_overlay → sched_setaffinity
+→ child execs and reads the masked surfaces.
+
+Skips gracefully where mount-ns isn't usable (missing uidmap,
+apparmor_restrict_unprivileged_userns=1) — same pattern as
+test_spawn_mount_ns.py.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="fingerprint sanitisation is Linux-only (mount-ns + UTS-ns)",
+)
+
+
+def _mount_ns_usable() -> bool:
+    if not shutil.which("newuidmap") or not shutil.which("newgidmap"):
+        return False
+    sysctl = Path("/proc/sys/kernel/apparmor_restrict_unprivileged_userns")
+    if sysctl.exists() and sysctl.read_text().strip() == "1":
+        return False
+    return True
+
+
+class TestFingerprintEndToEnd(unittest.TestCase):
+    """Full sandbox spawn with sanitise_host_fingerprint → child reads
+    masked files. Each test runs a small sh snippet inside the sandbox
+    and asserts the captured stdout matches the persona, not the host.
+    """
+
+    def setUp(self):
+        if not _mount_ns_usable():
+            self.skipTest(
+                "mount-ns unusable here (needs uidmap package + "
+                "kernel.apparmor_restrict_unprivileged_userns=0)"
+            )
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.persona_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.persona_dir.cleanup)
+        # cpu_count=2 keeps the persona small and avoids the single-CPU
+        # affinity-test footgun (sched_setaffinity to {0} is a no-op on
+        # already-pinned systems and doesn't exercise the multi-bit case).
+        from core.sandbox.fingerprint import build_persona
+        self.persona = build_persona(Path(self.persona_dir.name), cpu_count=2)
+
+    def _spawn(self, sh_argv: str):
+        from core.sandbox._spawn import run_sandboxed
+        return run_sandboxed(
+            ["sh", "-c", sh_argv],
+            target=self.tmp.name, output=self.tmp.name,
+            block_network=True,
+            nproc_limit=1024,
+            limits={"memory_mb": 0, "max_file_mb": 10240, "cpu_seconds": 300},
+            writable_paths=[self.tmp.name, "/tmp"],
+            readable_paths=None,
+            allowed_tcp_ports=None,
+            seccomp_profile=None,
+            seccomp_block_udp=False,
+            env=None, cwd=None, timeout=30,
+            capture_output=True, text=True,
+            persona=self.persona,
+        )
+
+    # --- /proc/cpuinfo ---
+
+    def test_cpuinfo_model_name_masked(self):
+        """Child sees the canonical Xeon string, not the host's real CPU."""
+        r = self._spawn("grep 'model name' /proc/cpuinfo | head -1")
+        self.assertEqual(r.returncode, 0, f"stderr: {r.stderr!r}")
+        self.assertIn("Intel(R) Xeon(R)", r.stdout)
+
+    def test_cpuinfo_identity_triple_is_real_xeon(self):
+        """family/model/stepping must match the real Skylake-X Xeon
+        identity, not the (6,1,0) Pentium-Pro signature."""
+        r = self._spawn(
+            "egrep '^(cpu family|model|stepping)' /proc/cpuinfo | sort -u"
+        )
+        self.assertEqual(r.returncode, 0, f"stderr: {r.stderr!r}")
+        out = r.stdout
+        self.assertIn("cpu family\t: 6", out)
+        self.assertIn("model\t\t: 85", out)
+        self.assertIn("stepping\t: 7", out)
+
+    def test_cpuinfo_processor_count_matches_persona(self):
+        """cpuinfo blocks N must equal persona.cpu_count (= 2 in setUp)."""
+        r = self._spawn("grep -c '^processor' /proc/cpuinfo")
+        self.assertEqual(r.returncode, 0, f"stderr: {r.stderr!r}")
+        self.assertEqual(r.stdout.strip(), "2")
+
+    def test_cpuinfo_flags_still_real(self):
+        """Capability surface preserved: child's cpuinfo flags include
+        a feature flag present on every modern x86 (sse2). The exact
+        flag set is host-derived, so this is a "non-empty" check."""
+        r = self._spawn("grep '^flags' /proc/cpuinfo | head -1")
+        self.assertEqual(r.returncode, 0, f"stderr: {r.stderr!r}")
+        # sse2 is mandatory in the x86_64 ABI; any Linux host running
+        # this test will have it. If we ever port to aarch64 / riscv64
+        # this assertion needs revisiting (different baseline flag).
+        if "x86" in os.uname().machine:
+            self.assertIn("sse2", r.stdout)
+
+    # --- /etc/hostname + uname() nodename ---
+
+    def test_etc_hostname_is_localhost(self):
+        r = self._spawn("cat /etc/hostname")
+        self.assertEqual(r.returncode, 0, f"stderr: {r.stderr!r}")
+        self.assertEqual(r.stdout.strip(), "localhost")
+
+    def test_gethostname_is_localhost(self):
+        """uname() nodename — what gethostname() syscall returns. Must
+        match /etc/hostname so a cross-check isn't a sandbox tell."""
+        r = self._spawn("hostname")
+        self.assertEqual(r.returncode, 0, f"stderr: {r.stderr!r}")
+        self.assertEqual(r.stdout.strip(), "localhost")
+
+    def test_uname_release_preserved_from_host(self):
+        """Capability surface: uname -r returns the real host kernel
+        release. exploit_feasibility's `uname -r` call depends on this."""
+        r = self._spawn("uname -r")
+        self.assertEqual(r.returncode, 0, f"stderr: {r.stderr!r}")
+        self.assertEqual(r.stdout.strip(), os.uname().release)
+
+    def test_uname_machine_preserved_from_host(self):
+        """Capability surface: uname -m returns the real arch. Shellcode
+        dispatch (pwntools context.arch) depends on this."""
+        r = self._spawn("uname -m")
+        self.assertEqual(r.returncode, 0, f"stderr: {r.stderr!r}")
+        self.assertEqual(r.stdout.strip(), os.uname().machine)
+
+    # --- /etc/{os-release,machine-id} ---
+
+    def test_os_release_is_debian_12(self):
+        r = self._spawn("cat /etc/os-release")
+        self.assertEqual(r.returncode, 0, f"stderr: {r.stderr!r}")
+        self.assertIn("ID=debian", r.stdout)
+        self.assertIn('VERSION_ID="12"', r.stdout)
+
+    def test_machine_id_is_deterministic_pseudo_random(self):
+        from core.sandbox.fingerprint import _MACHINE_ID
+        r = self._spawn("cat /etc/machine-id")
+        self.assertEqual(r.returncode, 0, f"stderr: {r.stderr!r}")
+        self.assertEqual(r.stdout.strip(), _MACHINE_ID)
+
+    # --- /proc/version trim ---
+
+    def test_proc_version_is_trimmed(self):
+        r = self._spawn("cat /proc/version")
+        self.assertEqual(r.returncode, 0, f"stderr: {r.stderr!r}")
+        line = r.stdout.strip()
+        self.assertTrue(line.startswith("Linux version "), line)
+        # No fingerprint markers — build-host / compiler / build number.
+        self.assertNotIn("(", line)
+        self.assertNotIn("@", line)
+        self.assertNotIn("#", line)
+
+    # --- /sys/devices/system/cpu ---
+
+    def test_cpu_online_matches_persona(self):
+        r = self._spawn("cat /sys/devices/system/cpu/online")
+        self.assertEqual(r.returncode, 0, f"stderr: {r.stderr!r}")
+        # persona has cpu_count=2 → expect "0-1"
+        self.assertEqual(r.stdout.strip(), "0-1")
+
+    def test_nproc_returns_persona_cpu_count(self):
+        """`nproc` reads sysconf(_SC_NPROCESSORS_ONLN) → sysfs cpu/online
+        (or affinity mask). Either path should give persona.cpu_count."""
+        r = self._spawn("nproc")
+        self.assertEqual(r.returncode, 0, f"stderr: {r.stderr!r}")
+        self.assertEqual(r.stdout.strip(), "2")
+
+    def test_sched_getaffinity_matches_persona(self):
+        """Python's os.sched_getaffinity reads the kernel affinity mask
+        set by sched_setaffinity in step 9.5. Must match cpu_count
+        bits — disagreement with cpuinfo would be a cross-check tell."""
+        r = self._spawn(
+            "python3 -c 'import os; print(sorted(os.sched_getaffinity(0)))'"
+        )
+        self.assertEqual(r.returncode, 0, f"stderr: {r.stderr!r}")
+        self.assertEqual(r.stdout.strip(), "[0, 1]")
+
+    # --- DMI ---
+
+    def test_dmi_sys_vendor_is_qemu(self):
+        r = self._spawn("cat /sys/class/dmi/id/sys_vendor 2>/dev/null || echo MISSING")
+        self.assertEqual(r.returncode, 0, f"stderr: {r.stderr!r}")
+        # Host may not have DMI at all (container, some VMs); the
+        # bind-mount apply_overlay skips missing targets silently.
+        # When DMI is present on host, our bind takes effect.
+        if "MISSING" not in r.stdout:
+            self.assertEqual(r.stdout.strip(), "QEMU")
+
+    # --- preservation: /proc/sys/kernel/* untouched ---
+
+    def test_sysctl_randomize_va_space_preserved(self):
+        """exploit_feasibility reads this sysctl to detect ASLR. Must
+        remain host-real; sanitisation only touches identity files."""
+        host = Path("/proc/sys/kernel/randomize_va_space").read_text().strip()
+        r = self._spawn("cat /proc/sys/kernel/randomize_va_space")
+        self.assertEqual(r.returncode, 0, f"stderr: {r.stderr!r}")
+        self.assertEqual(r.stdout.strip(), host)
+
+    def test_proc_self_status_pid_preserved(self):
+        """/proc/self/* is pid-ns-local but otherwise real. ASAN, GDB,
+        pwntools depend on it."""
+        r = self._spawn("grep '^Pid:' /proc/self/status")
+        self.assertEqual(r.returncode, 0, f"stderr: {r.stderr!r}")
+        # Inside the sandbox pid-ns the grandchild runs as PID 1.
+        self.assertIn("Pid:\t", r.stdout)


### PR DESCRIPTION
Adds `sanitise_host_fingerprint=True` to sandbox() / run() / run_untrusted(): masks identity surfaces inside the mount-ns child to a canonical "Debian 12 cloud VM on QEMU Xeon Silver 4214" persona, while preserving capability surfaces. Defends against anti-analysis-aware binaries that fingerprint the host before detonating, and reduces cross-operator analysis-output drift.

Masked: /proc/{cpuinfo, version, cmdline, stat, uptime, loadavg}, /etc/{os-release, machine-id, hostname}, /sys/class/dmi/id/{sys_ vendor, product_name}, /sys/devices/system/cpu/{online, possible}, UTS nodename/domainname, sched_setaffinity. machine-id is per- install (defeats published-fingerprint via open-source hash match). /proc/stat btime + uptime + loadavg derived from a single fake- uptime so cross-checks agree within seconds.

Preserved: /proc/cpuinfo flags line (SMEP/SMAP/SIMD), uname release/machine (exploit_feasibility, pwntools), /proc/sys/kernel/* mitigation reads, /proc/self/*.

API: sandbox(..., sanitise_host_fingerprint=True, cpu_count=4, require_sanitisation=False). Opt-in everywhere; default off. Soft-degrades on macOS / Landlock-only / no target+output; require_sanitisation flips to hard-fail.

Tests: +26 unit/e2e/context + 19-test adversarial battery acting as a Pafish/al-khaser-style anti-analysis check inside the sandbox. Sandbox suite 1016 pass / 16 skip, ruff clean.

Residuals (documented): CPUID asm + AT_HWCAP bypass, flags-line vendor leak, /proc/meminfo, omitted DMI identity files.