### PR TITLE
feat(sandbox): wire host-fingerprint sanitisation into binary/fuzzing/codeql consumers

### DIFF
--- a/core/sandbox/fingerprint.py
+++ b/core/sandbox/fingerprint.py
@@ -68,6 +68,28 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
+# === Public sentinels ===
+
+# Sentinel for the `cpu_count` argument meaning "preserve the host's
+# actual CPU count" — build_persona resolves it from
+# len(os.sched_getaffinity(0)) at build time, and set_cpu_affinity
+# becomes a no-op (the existing host mask already matches).
+#
+# Use case: callers like `codeql database create` that engage a
+# target-repo parallel build (make -j$(nproc), mvn -T NC). Pinning
+# to the default cpu_count=4 on a 32-core CI host causes ~8x build
+# slowdown and pushes long builds past CODEQL_TIMEOUT.
+# HOST_CPU_COUNT preserves real parallelism while still masking
+# identity (model name, vendor, microcode, hostname, machine-id,
+# DMI, /proc/version, etc.).
+#
+# Caveat: leaks CPU count to the target (a 32-core operator is
+# distinguishable from a 4-core operator). Acceptable when the
+# caller's primary motivation is anti-analysis identity masking,
+# not full anti-fingerprint capability masking.
+HOST_CPU_COUNT = -1
+
+
 # === Persona constants ===
 
 # Hostname / domainname — applied via sethostname() / setdomainname()
@@ -199,9 +221,19 @@ class Persona:
 def build_persona(tmpdir: Path, cpu_count: int) -> Persona:
     """Materialise persona files under `tmpdir` and return the Persona.
 
-    cpu_count must be >= 1. The /proc/cpuinfo file will contain that
-    many `processor` blocks; the matching `sched_setaffinity` mask
-    is the caller's responsibility (see `set_cpu_affinity`).
+    cpu_count must be >= 1 OR the HOST_CPU_COUNT sentinel. When the
+    sentinel is passed, cpu_count is resolved to the host's actual
+    schedulable CPU count via len(os.sched_getaffinity(0)) — useful
+    for callers that engage target parallel builds (codeql database
+    create runs make/mvn/gradle, which need the real CPU count to
+    avoid build serialisation). set_cpu_affinity for that resolved
+    value is a no-op (matches the existing mask) so no CPU pin is
+    applied. The persona.cpu_count attribute reflects the resolved
+    integer either way.
+
+    The /proc/cpuinfo file will contain `cpu_count` `processor`
+    blocks; the matching `sched_setaffinity` mask is the caller's
+    responsibility (see `set_cpu_affinity`).
 
     Reads the host's /proc/cpuinfo `flags` line ONCE so all per-CPU
     blocks share the same flag set. Host flags are preserved
@@ -210,8 +242,12 @@ def build_persona(tmpdir: Path, cpu_count: int) -> Persona:
     them. Empty string if host /proc/cpuinfo unreadable — handled
     gracefully (tools fall back to default code paths).
     """
+    if cpu_count == HOST_CPU_COUNT:
+        cpu_count = len(os.sched_getaffinity(0))
     if cpu_count < 1:
-        raise ValueError(f"cpu_count must be >= 1, got {cpu_count}")
+        raise ValueError(
+            f"cpu_count must be >= 1 or HOST_CPU_COUNT, got {cpu_count}"
+        )
     tmpdir = Path(tmpdir)
     tmpdir.mkdir(parents=True, exist_ok=True)
 

--- a/core/sandbox/tests/test_consumer_sanitisation.py
+++ b/core/sandbox/tests/test_consumer_sanitisation.py
@@ -1,0 +1,111 @@
+"""Static checks confirming each consumer wired in PR2 carries
+`sanitise_host_fingerprint=True` at every sandbox.run call site that
+executes target-supplied or attacker-influenced code.
+
+Dynamic invocation tests would re-prove what
+test_fingerprint_e2e.py already covers (the persona's effect inside
+the spawned child). What we need here is a regression guard that
+the wiring stays in place across refactors — a static source check
+is precisely the right granularity.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+# (file, minimum number of sites expected, optional descriptor)
+PR2_CONSUMERS = [
+    ("packages/binary_analysis/debugger.py", 2,
+     "GDB under sandbox(profile=debug): two paths (with/without "
+     "input file)"),
+    ("packages/binary_analysis/crash_analyser.py", 4,
+     "GDB analysis + LLDB analysis + LLDB fallback + plain binary "
+     "replay against ASAN-built target"),
+    ("packages/fuzzing/afl_runner.py", 1,
+     "afl-showmap coverage compute on harness + input"),
+    ("packages/codeql/database_manager.py", 1,
+     "codeql database create — runs target-supplied build commands "
+     "during autobuild (paired with cpu_count=HOST_CPU_COUNT to "
+     "preserve build parallelism)"),
+]
+
+
+@pytest.mark.parametrize("rel,min_sites,descriptor", PR2_CONSUMERS)
+def test_consumer_passes_sanitise_host_fingerprint(rel, min_sites, descriptor):
+    """Every site in the file that calls `_sandbox_run(...)` /
+    `sandbox_run(...)` / `sandbox.run(...)` AND looks like it
+    executes target-derived content must include
+    `sanitise_host_fingerprint=True` within the call.
+
+    We use a coarse static check (count kwargs in the file) rather
+    than parsing the AST: the source files are stable enough that
+    counting occurrences of the literal kwarg is sufficient, and
+    the comment hints in each file make the intent clear to a
+    human reviewer."""
+    f = REPO_ROOT / rel
+    assert f.is_file(), f"missing consumer file: {f}"
+    text = f.read_text()
+    sites = len(re.findall(
+        r"sanitise_host_fingerprint\s*=\s*True", text,
+    ))
+    assert sites >= min_sites, (
+        f"{rel}: expected at least {min_sites} "
+        f"`sanitise_host_fingerprint=True` site(s) ({descriptor}); "
+        f"found {sites}. A refactor likely dropped one."
+    )
+
+
+def test_query_runner_does_NOT_sanitise():
+    """packages/codeql/query_runner.py runs `codeql analyze` against
+    a pre-built database — it doesn't exec target code, so adding
+    sanitisation there would be pure overhead. Assert it stays
+    un-sanitised so a well-meaning copy-paste doesn't introduce
+    unnecessary mount-ns engagement."""
+    f = REPO_ROOT / "packages/codeql/query_runner.py"
+    text = f.read_text()
+    assert "sanitise_host_fingerprint=True" not in text, (
+        "query_runner.py must NOT pass sanitise_host_fingerprint — "
+        "it analyses pre-built CodeQL databases, doesn't run target "
+        "code, and the mount-ns engagement would be wasted overhead. "
+        "If you have a reason to sanitise there, update this test."
+    )
+
+
+def test_build_detector_target_repo_sites_unchanged():
+    """packages/codeql/build_detector.py has two sandbox.run sites:
+    one runs an LLM-emitted Python script for build-system detection
+    (doesn't exec target binaries directly), one runs Claude Code.
+    Neither needs sanitisation today. Pinned here so adding
+    sanitisation later is a deliberate change, not accidental."""
+    f = REPO_ROOT / "packages/codeql/build_detector.py"
+    text = f.read_text()
+    assert "sanitise_host_fingerprint=True" not in text, (
+        "build_detector.py started sanitising — confirm this is "
+        "intended and update this test if so"
+    )
+
+
+def test_codeql_database_manager_uses_host_cpu_count():
+    """packages/codeql/database_manager.py wires sanitisation PAIRED
+    with cpu_count=HOST_CPU_COUNT so the target repo's parallel build
+    (make -j$(nproc), mvn -T NC, gradle --parallel) keeps real
+    parallelism. Default cpu_count=4 would serialise builds to 4
+    threads and push them past CODEQL_TIMEOUT on multi-core hosts."""
+    f = REPO_ROOT / "packages/codeql/database_manager.py"
+    text = f.read_text()
+    assert "sanitise_host_fingerprint=True" in text, (
+        "database_manager.py must sanitise — it runs the target "
+        "repo's build commands"
+    )
+    assert "cpu_count=HOST_CPU_COUNT" in text, (
+        "database_manager.py must use cpu_count=HOST_CPU_COUNT — "
+        "the default cpu_count=4 would serialise parallel builds and "
+        "push long codeql builds past CODEQL_TIMEOUT"
+    )

--- a/core/sandbox/tests/test_consumer_sanitisation_e2e.py
+++ b/core/sandbox/tests/test_consumer_sanitisation_e2e.py
@@ -1,0 +1,298 @@
+"""End-to-end adversarial tests for PR2 consumer wiring.
+
+For each consumer flipped in PR2, this module reconstructs the EXACT
+sandbox kwarg combination the consumer uses, spawns a real sandbox
+with those kwargs against a trivial target (`cat /etc/hostname` /
+`hostname` / `cat /proc/cpuinfo`), and asserts the child sees the
+persona — i.e. sanitise_host_fingerprint=True actually engages mount-ns,
+binds the persona, and reaches the child.
+
+This catches the class of bug where the static-grep check
+(test_consumer_sanitisation.py) passes but the kwarg is dropped
+somewhere along context.py → _spawn.py → setup_mount_ns. PR1's
+test_fingerprint_e2e.py proved the general path works; this proves
+each consumer's SPECIFIC kwarg combination works (block_network
+interaction, profile=debug interaction, readable_paths interaction).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="consumer e2e tests are Linux-only (mount-ns required)",
+)
+
+
+def _mount_ns_usable() -> bool:
+    if not shutil.which("newuidmap") or not shutil.which("newgidmap"):
+        return False
+    sysctl = Path("/proc/sys/kernel/apparmor_restrict_unprivileged_userns")
+    if sysctl.exists() and sysctl.read_text().strip() == "1":
+        return False
+    return True
+
+
+class _ConsumerE2EBase(unittest.TestCase):
+    """Shared setup: tmpdir for target/output, mount-ns gate."""
+
+    def setUp(self):
+        if not _mount_ns_usable():
+            self.skipTest(
+                "mount-ns unusable (needs uidmap + sysctl=0)"
+            )
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def _assert_persona_engaged(self, result, extra_msg=""):
+        """Persona engaged iff /etc/hostname inside the sandbox reads
+        'localhost' (the persona value), not the operator's real
+        hostname."""
+        self.assertEqual(
+            result.returncode, 0,
+            f"sandbox call failed; stderr={result.stderr!r} {extra_msg}",
+        )
+        self.assertEqual(
+            result.stdout.strip(), "localhost",
+            f"persona did NOT engage — child saw real hostname "
+            f"{result.stdout.strip()!r} {extra_msg}",
+        )
+
+
+class TestDebuggerKwargCombo(_ConsumerE2EBase):
+    """Replicates debugger.py:135/144 — sandbox with profile=debug +
+    target+output + sanitise_host_fingerprint=True. profile=debug
+    permits ptrace; sanitisation must still engage."""
+
+    def test_persona_engages_under_profile_debug(self):
+        from core.sandbox import run as sandbox_run
+        result = sandbox_run(
+            ["cat", "/etc/hostname"],
+            profile="debug",
+            target=self.tmp.name, output=self.tmp.name,
+            capture_output=True, text=True, timeout=15,
+            sanitise_host_fingerprint=True,
+        )
+        self._assert_persona_engaged(result)
+
+    def test_uname_release_still_real_under_profile_debug(self):
+        """Capability surface preserved even under profile=debug —
+        regression guard for an exploit_feasibility consumer that
+        runs under the same kwarg combo."""
+        from core.sandbox import run as sandbox_run
+        result = sandbox_run(
+            ["uname", "-r"],
+            profile="debug",
+            target=self.tmp.name, output=self.tmp.name,
+            capture_output=True, text=True, timeout=15,
+            sanitise_host_fingerprint=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), os.uname().release)
+
+
+class TestCrashAnalyserKwargCombo(_ConsumerE2EBase):
+    """Replicates crash_analyser.py — three combos: (1) profile=debug
+    for GDB/LLDB, (2) block_network=True for plain ASAN replay."""
+
+    def test_persona_under_profile_debug_with_stdin(self):
+        """GDB/LLDB sites pass stdin=<input_file>. Combine that with
+        profile=debug + target+output + sanitise."""
+        from core.sandbox import run as sandbox_run
+        input_file = Path(self.tmp.name) / "fake-input"
+        input_file.write_bytes(b"A" * 16)
+        with open(input_file, "rb") as fh:
+            result = sandbox_run(
+                ["cat", "/etc/hostname"],
+                profile="debug",
+                target=self.tmp.name, output=self.tmp.name,
+                stdin=fh,
+                capture_output=True, text=True, timeout=15,
+                sanitise_host_fingerprint=True,
+            )
+        self._assert_persona_engaged(result, "(profile=debug + stdin)")
+
+    def test_persona_under_block_network(self):
+        """Plain `run_binary` path: block_network=True + target+output
+        + sanitise. No profile=debug, no ptrace."""
+        from core.sandbox import run as sandbox_run
+        result = sandbox_run(
+            ["cat", "/etc/hostname"],
+            block_network=True,
+            target=self.tmp.name, output=self.tmp.name,
+            capture_output=True, text=True, timeout=15,
+            sanitise_host_fingerprint=True,
+        )
+        self._assert_persona_engaged(result, "(block_network=True)")
+
+
+class TestAflRunnerKwargCombo(_ConsumerE2EBase):
+    """Replicates afl_runner.py:709 — block_network + readable_paths +
+    target+output + sanitise_host_fingerprint."""
+
+    def test_persona_with_readable_paths(self):
+        from core.sandbox import run as sandbox_run
+        # readable_paths is the kwarg that afl-showmap passes (paths
+        # to allow reads from in addition to the system + target +
+        # output defaults). An empty list exercises the kwarg surface
+        # without needing real harness paths.
+        result = sandbox_run(
+            ["cat", "/etc/hostname"],
+            block_network=True,
+            target=self.tmp.name, output=self.tmp.name,
+            readable_paths=[],
+            capture_output=True, text=True, timeout=15,
+            sanitise_host_fingerprint=True,
+        )
+        self._assert_persona_engaged(result, "(readable_paths + block_network)")
+
+
+class TestPersonaConsistencyAcrossConsumers(_ConsumerE2EBase):
+    """The same persona must produce the same hostname / machine-id /
+    cpu_count across consumer kwarg combos — otherwise two consumers
+    of the same persona could produce inconsistent fingerprints."""
+
+    def test_machine_id_identical_across_combos(self):
+        from core.sandbox import run as sandbox_run
+        def _machine_id(**kwargs):
+            r = sandbox_run(
+                ["cat", "/etc/machine-id"],
+                target=self.tmp.name, output=self.tmp.name,
+                capture_output=True, text=True, timeout=15,
+                sanitise_host_fingerprint=True,
+                **kwargs,
+            )
+            assert r.returncode == 0, r.stderr
+            return r.stdout.strip()
+        debug_mid = _machine_id(profile="debug")
+        block_mid = _machine_id(block_network=True)
+        self.assertEqual(
+            debug_mid, block_mid,
+            "machine-id must be persona-derived (deterministic per "
+            "RAPTOR install) — not dependent on the sandbox profile",
+        )
+
+    def test_cpu_count_consistent_across_combos(self):
+        from core.sandbox import run as sandbox_run
+        def _nproc(**kwargs):
+            r = sandbox_run(
+                ["nproc"],
+                target=self.tmp.name, output=self.tmp.name,
+                capture_output=True, text=True, timeout=15,
+                sanitise_host_fingerprint=True,
+                **kwargs,
+            )
+            assert r.returncode == 0, r.stderr
+            return r.stdout.strip()
+        debug_n = _nproc(profile="debug")
+        block_n = _nproc(block_network=True)
+        # Default cpu_count=4 when sanitise is on.
+        self.assertEqual(debug_n, "4")
+        self.assertEqual(block_n, "4")
+
+
+class TestCodeqlKwargCombo(_ConsumerE2EBase):
+    """Replicates database_manager.py:790 — block_network +
+    sanitise_host_fingerprint + cpu_count=HOST_CPU_COUNT. Must mask
+    identity surfaces while preserving real CPU count + affinity
+    (otherwise codeql autobuild's `make -j$(nproc)` serialises)."""
+
+    def test_persona_engages_with_host_cpu_count(self):
+        from core.sandbox import run as sandbox_run
+        from core.sandbox.fingerprint import HOST_CPU_COUNT
+        result = sandbox_run(
+            ["cat", "/etc/hostname"],
+            block_network=True,
+            target=self.tmp.name, output=self.tmp.name,
+            capture_output=True, text=True, timeout=15,
+            sanitise_host_fingerprint=True,
+            cpu_count=HOST_CPU_COUNT,
+        )
+        self._assert_persona_engaged(result, "(codeql kwarg combo)")
+
+    def test_host_cpu_count_preserves_real_parallelism(self):
+        """With HOST_CPU_COUNT, nproc inside the sandbox must equal
+        the host's schedulable CPU count — not the default 4. Proves
+        the parallelism-preservation property that motivated this
+        sentinel."""
+        from core.sandbox import run as sandbox_run
+        from core.sandbox.fingerprint import HOST_CPU_COUNT
+        expected = str(len(os.sched_getaffinity(0)))
+        result = sandbox_run(
+            ["nproc"],
+            block_network=True,
+            target=self.tmp.name, output=self.tmp.name,
+            capture_output=True, text=True, timeout=15,
+            sanitise_host_fingerprint=True,
+            cpu_count=HOST_CPU_COUNT,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout.strip(), expected,
+            f"HOST_CPU_COUNT must preserve real nproc; "
+            f"expected {expected}, got {result.stdout.strip()!r}",
+        )
+
+    def test_host_cpu_count_still_masks_machine_id(self):
+        """Identity surfaces must STILL be masked even when CPU count
+        is preserved — operator-machine-id leak is the original
+        threat we're defending against."""
+        from core.sandbox import run as sandbox_run
+        from core.sandbox.fingerprint import HOST_CPU_COUNT, _MACHINE_ID
+        result = sandbox_run(
+            ["cat", "/etc/machine-id"],
+            block_network=True,
+            target=self.tmp.name, output=self.tmp.name,
+            capture_output=True, text=True, timeout=15,
+            sanitise_host_fingerprint=True,
+            cpu_count=HOST_CPU_COUNT,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), _MACHINE_ID)
+
+
+class TestProfileDebugDoesNotBreakPtrace(_ConsumerE2EBase):
+    """The debugger/crash_analyser sites use profile=debug specifically
+    so ptrace works (seccomp ptrace block is lifted). Sanitisation
+    must NOT engage seccomp blocks that would re-break ptrace.
+    Concrete test: spawn a child that ptraces itself and reads
+    /proc/self/syscall — succeeds iff ptrace is permitted."""
+
+    def test_strace_self_under_sanitise_plus_debug(self):
+        # We don't require strace to be installed; instead spawn a
+        # python child that calls PR_SET_PTRACER and ptrace(0, ...)
+        # — operations that only succeed if ptrace seccomp block
+        # is lifted (which profile=debug does).
+        from core.sandbox import run as sandbox_run
+        if not shutil.which("python3"):
+            self.skipTest("python3 not in PATH")
+        py_script = (
+            "import ctypes, os, sys;"
+            " libc = ctypes.CDLL('libc.so.6', use_errno=True);"
+            # PR_SET_PTRACER_ANY = -1; arg2 is the PID allowed to
+            # trace us. We aren't actually tracing — this just
+            # verifies the syscall isn't seccomp-blocked.
+            " r = libc.prctl(0x59616d61, -1, 0, 0, 0);"
+            " sys.exit(0 if r == 0 else 1)"
+        )
+        result = sandbox_run(
+            ["python3", "-c", py_script],
+            profile="debug",
+            target=self.tmp.name, output=self.tmp.name,
+            capture_output=True, text=True, timeout=15,
+            sanitise_host_fingerprint=True,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            f"PR_SET_PTRACER failed under sanitise+debug — "
+            f"sanitisation may be silently engaging extra seccomp blocks. "
+            f"stderr={result.stderr!r}",
+        )

--- a/core/sandbox/tests/test_fingerprint.py
+++ b/core/sandbox/tests/test_fingerprint.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 
 from core.sandbox.fingerprint import (
+    HOST_CPU_COUNT,
     _HOSTNAME,
     _DOMAINNAME,
     _MACHINE_ID,
@@ -28,6 +29,49 @@ from core.sandbox.fingerprint import (
     is_supported,
     set_cpu_affinity,
 )
+
+
+# --- HOST_CPU_COUNT sentinel ---
+
+def test_host_cpu_count_sentinel_resolves_to_host(tmp_path):
+    """build_persona(cpu_count=HOST_CPU_COUNT) must resolve to the
+    host's actual schedulable CPU count via os.sched_getaffinity(0).
+    Persona.cpu_count is the resolved int, not the sentinel."""
+    expected = len(os.sched_getaffinity(0))
+    persona = build_persona(tmp_path, cpu_count=HOST_CPU_COUNT)
+    assert persona.cpu_count == expected, (
+        f"sentinel resolved to {persona.cpu_count}, expected {expected}"
+    )
+
+
+def test_host_cpu_count_sentinel_yields_n_cpuinfo_blocks(tmp_path):
+    """With the sentinel, /proc/cpuinfo claims as many processors as
+    the host has available — preserves capability surface for callers
+    that need real parallelism (codeql, parallel builds)."""
+    expected = len(os.sched_getaffinity(0))
+    build_persona(tmp_path, cpu_count=HOST_CPU_COUNT)
+    content = (tmp_path / "cpuinfo").read_text()
+    indices = [
+        m for m in content.splitlines() if m.startswith("processor\t:")
+    ]
+    assert len(indices) == expected
+
+
+def test_host_cpu_count_sentinel_value_is_negative():
+    """Sentinel must be < 1 so existing ValueError paths don't
+    accidentally accept it. Using -1 (conventional "unset" / "not
+    applicable")."""
+    assert HOST_CPU_COUNT < 1
+    assert HOST_CPU_COUNT != 0  # 0 might be confused with "no CPUs"
+
+
+def test_build_persona_still_rejects_invalid_negative(tmp_path):
+    """Any negative value OTHER than HOST_CPU_COUNT must still raise."""
+    import pytest as _pytest
+    # Pick a negative that isn't the sentinel.
+    bad = HOST_CPU_COUNT - 1
+    with _pytest.raises(ValueError, match="cpu_count must be >= 1"):
+        build_persona(tmp_path, cpu_count=bad)
 
 
 # --- Constants / shape ---
@@ -90,8 +134,10 @@ def test_build_persona_rejects_zero_cpu_count(tmp_path):
 
 
 def test_build_persona_rejects_negative_cpu_count(tmp_path):
+    # -1 is the HOST_CPU_COUNT sentinel (covered separately). Pick a
+    # negative that isn't a sentinel.
     with pytest.raises(ValueError, match="cpu_count must be >= 1"):
-        build_persona(tmp_path, cpu_count=-1)
+        build_persona(tmp_path, cpu_count=-2)
 
 
 # --- build_persona output shape ---

--- a/packages/binary_analysis/crash_analyser.py
+++ b/packages/binary_analysis/crash_analyser.py
@@ -538,6 +538,7 @@ class CrashAnalyser:
                     capture_output=True,
                     text=True,
                     timeout=30,
+                    sanitise_host_fingerprint=True,
                 )
         finally:
             # Clean up command file
@@ -617,6 +618,7 @@ class CrashAnalyser:
                         capture_output=True,
                         text=True,
                         timeout=60,  # Increased timeout
+                        sanitise_host_fingerprint=True,
                     )
             except subprocess.TimeoutExpired:
                 logger.warning("LLDB analysis timed out - trying fallback approach")
@@ -701,6 +703,7 @@ class CrashAnalyser:
                     capture_output=True,
                     text=True,
                     timeout=30,
+                    sanitise_host_fingerprint=True,
                 )
             return result.stdout
         except subprocess.TimeoutExpired:
@@ -1490,6 +1493,7 @@ class CrashAnalyser:
                     capture_output=True,
                     text=True,
                     timeout=30,
+                    sanitise_host_fingerprint=True,
                     # Use get_safe_env() as the base, NOT os.environ.
                     # Pre-fix `{**os.environ, "ASAN_OPTIONS": ...}`
                     # passed the operator's full env (LLM API keys,

--- a/packages/binary_analysis/debugger.py
+++ b/packages/binary_analysis/debugger.py
@@ -139,6 +139,7 @@ class GDBDebugger:
                         capture_output=True,
                         text=True,
                         timeout=timeout,
+                        sanitise_host_fingerprint=True,
                     )
             else:
                 result = _sandbox_run(
@@ -147,6 +148,7 @@ class GDBDebugger:
                     capture_output=True,
                     text=True,
                     timeout=timeout,
+                    sanitise_host_fingerprint=True,
                 )
 
             return result.stdout

--- a/packages/codeql/database_manager.py
+++ b/packages/codeql/database_manager.py
@@ -787,6 +787,7 @@ class DatabaseManager:
         # Execute database creation in sandbox (network blocked — packs pre-fetched)
         try:
             from core.sandbox import run as sandbox_run
+            from core.sandbox.fingerprint import HOST_CPU_COUNT
             result = sandbox_run(
                 cmd,
                 block_network=True,
@@ -802,6 +803,19 @@ class DatabaseManager:
                 capture_output=True,
                 text=True,
                 timeout=RaptorConfig.CODEQL_TIMEOUT,
+                # `codeql database create` invokes the target repo's
+                # autobuild / --command build, which is where target-
+                # supplied build scripts execute. Sanitise identity
+                # surfaces so anti-analysis-aware build tooling can't
+                # detect the analysis environment.
+                #
+                # cpu_count=HOST_CPU_COUNT preserves real parallelism
+                # for Make/Maven/Gradle — the default cpu_count=4 would
+                # serialise to 4 threads regardless of host count and
+                # cause ~8x build slowdown on 32-core CI hosts,
+                # pushing long builds past CODEQL_TIMEOUT.
+                sanitise_host_fingerprint=True,
+                cpu_count=HOST_CPU_COUNT,
             )
 
             success = result.returncode == 0

--- a/packages/fuzzing/afl_runner.py
+++ b/packages/fuzzing/afl_runner.py
@@ -718,6 +718,7 @@ class AFLRunner:
                 cwd=str(self.output_dir),
                 env=env,
                 timeout=300,
+                sanitise_host_fingerprint=True,
             )
 
             # Parse output for coverage info


### PR DESCRIPTION
PR2 of the host-fingerprint sanitisation arc — opts in the four consumers that already use core.sandbox.run and exec target-supplied or attacker-influenced code. Substrate from PR #525 plus one small substrate addition (HOST_CPU_COUNT sentinel) for codeql.

Wired:
- packages/binary_analysis/debugger.py (2 sites — GDB w/ and w/o input file, both under profile=debug)
- packages/binary_analysis/crash_analyser.py (4 sites — GDB + LLDB + LLDB fallback + ASAN-binary replay)
- packages/fuzzing/afl_runner.py (1 site — afl-showmap)
- packages/codeql/database_manager.py (1 site — `codeql database create`, paired with cpu_count=HOST_CPU_COUNT)

Substrate addition: HOST_CPU_COUNT sentinel on
core.sandbox.fingerprint. When passed as cpu_count, build_persona resolves to len(os.sched_getaffinity(0)) and set_cpu_affinity becomes a no-op. Identity surfaces stay masked; capability surface (real CPU count + sched_getaffinity) is preserved. Required because `codeql database create` invokes the target repo's autobuild (make -j$(nproc), mvn -T NC) — the default cpu_count=4 would serialise to 4 threads and push long builds past CODEQL_TIMEOUT on multi-core CI hosts. Other three consumers are single-input replay paths and keep the default cpu_count=4.

NOT wired (decisions pinned by test_consumer_sanitisation.py):
- packages/codeql/query_runner.py — analyses pre-built DBs, no target-code execution
- packages/codeql/build_detector.py — runs an LLM-emitted Python build-detector script + Claude Code, no direct target-binary execution

Adversarial e2e battery (test_consumer_sanitisation_e2e.py, 11 tests): each consumer's EXACT kwarg combination spawns a real sandbox against `cat /etc/hostname` and asserts the child sees the persona. Plus a profile=debug + sanitise + PR_SET_PTRACER regression test, cross-consumer machine-id/hostname consistency, and HOST_CPU_COUNT-specific tests proving nproc returns the host count while machine-id stays masked.

4 new unit tests on the sentinel (resolves to host, yields N cpuinfo blocks, < 1 invariant, other negatives still rejected). test_consumer_sanitisation.py guards both directions: 4 expected flips and 2 pinned non-flips, so accidental adds/removes require a deliberate test update.

Tests: 106 fingerprint + consumer-wiring + e2e pass (focused). 378 consumer packages still pass. Ruff F401/F811/F821/F841 clean.