### PR TITLE
feat(core/ast): per-function structured view + C/C++ call_graph walkers

### DIFF
--- a/core/ast/__init__.py
+++ b/core/ast/__init__.py
@@ -1,0 +1,45 @@
+"""Structured per-function views built over the inventory substrate.
+
+The inventory (``core.inventory.extractors``, ``core.inventory.call_graph``)
+answers two file-/codebase-level questions:
+
+  * "What functions exist?" — ``extract_functions(filepath, language, content)``
+  * "What does this file call?" — ``extract_call_graph_<lang>(content)``
+
+``core.ast`` answers a third, per-function-level question:
+
+  * "What is the shape of *this one* function?" — its signature, the
+    calls it makes, where it returns, whether it embeds inline asm.
+
+The intended consumers are ``/understand --map`` (entry-point + sink
+records gain an ``ast_view`` block), ``/validate`` Stage B (path
+enumeration uses ``calls_made``), and ``/audit`` Phase A (per-function
+review).
+
+This package is a **composition layer**, not new parsing
+infrastructure. It reuses the per-language tree-sitter walkers already
+shipped in ``core.inventory``. The dependency direction reads oddly
+("AST view depends on inventory") because inventory's name is
+misleading — its per-language walkers are reusable substrate, not a
+higher-level domain concept. A future refactor may lift the walkers
+into ``core.treesitter.walkers`` and have both ``core.inventory`` and
+``core.ast`` consume them; that's deferred until a third consumer
+makes the duplication painful.
+
+Public surface:
+
+  * ``view(path, function, *, at_line=None, language=None) -> Optional[FunctionView]``
+  * ``FunctionView`` dataclass (re-exported from ``.model``)
+  * ``Return`` dataclass (re-exported from ``.model``)
+  * ``CallSite`` is re-used as-is from ``core.inventory.call_graph``;
+    no conversion layer.
+
+Language coverage (PR1): python, javascript, java, go, c, cpp.
+"""
+
+from __future__ import annotations
+
+from core.ast.model import FunctionView, Return
+from core.ast.view import view
+
+__all__ = ["view", "FunctionView", "Return"]

--- a/core/ast/model.py
+++ b/core/ast/model.py
@@ -1,0 +1,104 @@
+"""Dataclasses for the per-function AST view.
+
+Schema is frozen + JSON-serialisable so consumers (``/understand --map``,
+``/audit`` annotations) can persist the view alongside their own output
+without losing precision on round-trip.
+
+``CallSite`` (from ``core.inventory.call_graph``) is reused verbatim
+for the calls list — no conversion at the boundary. The field set
+(``line`` / ``chain`` / ``caller``) is already what an AST view of
+calls needs, and the future ``core.treesitter`` lift would move
+``CallSite`` to that substrate anyway.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Tuple
+
+# Re-exported so ``core.ast`` consumers don't have to know it lives in
+# inventory. When the future ``core.treesitter`` lift happens, this
+# import moves and ``core.ast`` callers are unaffected.
+from core.inventory.call_graph import CallSite  # noqa: F401  (re-export)
+
+
+SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class Return:
+    """One return statement in the function body.
+
+    ``value_text`` is the raw text between ``return`` and the
+    statement terminator, preserved verbatim — no AST parsing of the
+    return expression. Empty string for bare ``return`` statements.
+    The text is for human / LLM inspection; downstream consumers that
+    want structure parse it themselves.
+
+    Implicit returns (end of function in Python, void function falling
+    off the end in C) are NOT emitted — only explicit ``return``
+    statements. Callers that need "all exit points" should union
+    explicit returns with the function's end line themselves.
+    """
+
+    line: int
+    value_text: str  # empty for bare `return`
+
+
+@dataclass(frozen=True)
+class FunctionView:
+    """Structured view of one function.
+
+    The function is identified by ``(file, function, lines)``. When
+    multiple functions in one file share a name (e.g. methods of
+    different classes), the line range is the unambiguous identifier.
+
+    ``calls_made`` is a tuple of ``CallSite`` (re-used from
+    ``core.inventory.call_graph``). Each call records the callee's
+    attribute chain and the line; argument text is NOT preserved at
+    this revision (callers that need it should re-extract from
+    source). See module docstring for the reuse rationale.
+
+    ``has_inline_asm`` is true if the function body contains any
+    inline assembly construct in C/C++ (``asm``, ``__asm__``,
+    ``__asm``, with or without ``volatile``). The flag is for
+    consumers that want to deprioritise / specially-handle functions
+    that include opaque assembly; the actual asm text is not parsed.
+    For non-C/C++ languages the flag is always false.
+
+    ``language`` is the canonical language string used elsewhere in
+    RAPTOR (matches ``core.inventory.languages.LANGUAGE_MAP``
+    values).
+    """
+
+    function: str
+    file: str
+    language: str
+    lines: Tuple[int, int]  # (start, end), 1-indexed inclusive
+    signature: str
+    calls_made: Tuple[CallSite, ...]
+    returns: Tuple[Return, ...]
+    has_inline_asm: bool
+    schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise for JSON output (``/understand --map``, CLI)."""
+        return {
+            "function": self.function,
+            "file": self.file,
+            "language": self.language,
+            "lines": [self.lines[0], self.lines[1]],
+            "signature": self.signature,
+            "calls_made": [
+                {
+                    "line": c.line,
+                    "chain": list(c.chain),
+                    "caller": c.caller,
+                    "receiver_class": c.receiver_class,
+                }
+                for c in self.calls_made
+            ],
+            "returns": [{"line": r.line, "value_text": r.value_text} for r in self.returns],
+            "has_inline_asm": self.has_inline_asm,
+            "schema_version": self.schema_version,
+        }

--- a/core/ast/tests/fixtures/sample.c
+++ b/core/ast/tests/fixtures/sample.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include "internal.h"
+
+static int helper(int x) {
+    return x + 1;
+}
+
+int main(int argc, char **argv) {
+    asm volatile ("nop");
+    if (helper(argc) > 0) {
+        printf("positive");
+        return 0;
+    }
+    return 1;
+}

--- a/core/ast/tests/fixtures/sample.cpp
+++ b/core/ast/tests/fixtures/sample.cpp
@@ -1,0 +1,27 @@
+#include <iostream>
+
+class Widget {
+public:
+    void setup();
+    int run(int x);
+    ~Widget();
+private:
+    int counter_;
+};
+
+void Widget::setup() {
+    counter_ = 0;
+    helper();
+}
+
+int Widget::run(int x) {
+    this->setup();
+    if (x > 0) {
+        return x * 2;
+    }
+    return 0;
+}
+
+Widget::~Widget() {
+    cleanup();
+}

--- a/core/ast/tests/fixtures/sample.go
+++ b/core/ast/tests/fixtures/sample.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+func helper(x int) int {
+    return x + 1
+}
+
+func main() {
+    if helper(3) > 0 {
+        fmt.Println("ok")
+        return
+    }
+    fmt.Println("nope")
+}

--- a/core/ast/tests/fixtures/sample.py
+++ b/core/ast/tests/fixtures/sample.py
@@ -1,0 +1,23 @@
+# ruff: noqa: F821
+# Fixture file: deliberately references undefined names
+# (``compute_hash``, ``log_attempt``, ``constant_time_compare``)
+# so the view() tests have realistic call-site shapes without
+# pulling in real implementations.
+
+def check_password(user, pw):
+    """Check whether `pw` matches `user`'s hash."""
+    if user is None:
+        return -1
+    hashed = compute_hash(pw)
+    log_attempt(user)
+    if constant_time_compare(user.pw_hash, hashed):
+        return 0
+    return 1
+
+
+class Auth:
+    def login(self, user, pw):
+        return check_password(user, pw)
+
+    def logout(self, user):
+        pass

--- a/core/ast/tests/test_view.py
+++ b/core/ast/tests/test_view.py
@@ -24,6 +24,25 @@ from core.ast.model import SCHEMA_VERSION
 FIXTURES = Path(__file__).parent / "fixtures"
 
 
+def _has_grammar(module_name: str) -> bool:
+    """True iff the given tree-sitter grammar package is importable.
+
+    Tree-sitter grammars are optional dependencies in RAPTOR; the
+    walkers degrade to empty graphs without them. CI environments
+    that don't install the grammars must skip these tests rather
+    than fail with empty-result assertions."""
+    try:
+        __import__(module_name)
+        return True
+    except ImportError:
+        return False
+
+
+_HAS_TS_C = _has_grammar("tree_sitter_c")
+_HAS_TS_CPP = _has_grammar("tree_sitter_cpp")
+_HAS_TS_GO = _has_grammar("tree_sitter_go")
+
+
 # ---------------------------------------------------------------------------
 # Per-language end-to-end
 # ---------------------------------------------------------------------------
@@ -34,9 +53,14 @@ class TestC:
     bearing language for the /audit Phase A kernel CVE benchmark
     list, so the basic shape gets pinned here."""
 
-    pytestmark = pytest.mark.skipif(
-        not (FIXTURES / "sample.c").exists(), reason="fixture missing",
-    )
+    pytestmark = [
+        pytest.mark.skipif(
+            not (FIXTURES / "sample.c").exists(), reason="fixture missing",
+        ),
+        pytest.mark.skipif(
+            not _HAS_TS_C, reason="tree_sitter_c grammar not installed",
+        ),
+    ]
 
     def test_main_view(self):
         fv = view(FIXTURES / "sample.c", "main")
@@ -70,9 +94,14 @@ class TestCpp:
     ``run`` method exercises out-of-line definition + receiver_class
     tagging at once."""
 
-    pytestmark = pytest.mark.skipif(
-        not (FIXTURES / "sample.cpp").exists(), reason="fixture missing",
-    )
+    pytestmark = [
+        pytest.mark.skipif(
+            not (FIXTURES / "sample.cpp").exists(), reason="fixture missing",
+        ),
+        pytest.mark.skipif(
+            not _HAS_TS_CPP, reason="tree_sitter_cpp grammar not installed",
+        ),
+    ]
 
     def test_run_method_this_arrow(self):
         # Use --at-line equivalent because ``run`` might collide
@@ -159,22 +188,25 @@ class TestPython:
 
 
 class TestGo:
-    pytestmark = pytest.mark.skipif(
-        not (FIXTURES / "sample.go").exists(), reason="fixture missing",
-    )
+    pytestmark = [
+        pytest.mark.skipif(
+            not (FIXTURES / "sample.go").exists(), reason="fixture missing",
+        ),
+        pytest.mark.skipif(
+            not _HAS_TS_GO, reason="tree_sitter_go grammar not installed",
+        ),
+    ]
 
     def test_main_view(self):
         fv = view(FIXTURES / "sample.go", "main")
-        if fv is None:
-            pytest.skip("go grammar not installed")
+        assert fv is not None
         # fmt.Println called twice in main.
         println = [c for c in fv.calls_made if c.chain[-1] == "Println"]
         assert len(println) >= 1
 
     def test_go_no_inline_asm(self):
         fv = view(FIXTURES / "sample.go", "main")
-        if fv is None:
-            pytest.skip("go grammar not installed")
+        assert fv is not None
         assert fv.has_inline_asm is False
 
 
@@ -236,9 +268,14 @@ class TestEdgeCases:
 
 
 class TestSchema:
-    pytestmark = pytest.mark.skipif(
-        not (FIXTURES / "sample.c").exists(), reason="fixture missing",
-    )
+    pytestmark = [
+        pytest.mark.skipif(
+            not (FIXTURES / "sample.c").exists(), reason="fixture missing",
+        ),
+        pytest.mark.skipif(
+            not _HAS_TS_C, reason="tree_sitter_c grammar not installed",
+        ),
+    ]
 
     def test_to_dict_carries_full_schema(self):
         fv = view(FIXTURES / "sample.c", "main")

--- a/core/ast/tests/test_view.py
+++ b/core/ast/tests/test_view.py
@@ -1,0 +1,265 @@
+"""Tests for ``core.ast.view``.
+
+End-to-end coverage of the composition layer: each language fixture
+in ``./fixtures/`` is opened, ``view()`` is called for known
+functions, and the resulting :class:`FunctionView` is asserted
+against the expected shape.
+
+The per-language walker tests (``core/inventory/tests/test_call_graph_*``)
+pin the lower-level extraction. These tests pin the *composition*:
+that ``view()`` glues function discovery + calls + returns + asm
+correctly, handles edge cases (missing file / function / language),
+and emits a stable JSON-serialisable schema.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.ast import view
+from core.ast.model import SCHEMA_VERSION
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Per-language end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestC:
+    """C uses tree-sitter for calls + returns + asm. C is a load-
+    bearing language for the /audit Phase A kernel CVE benchmark
+    list, so the basic shape gets pinned here."""
+
+    pytestmark = pytest.mark.skipif(
+        not (FIXTURES / "sample.c").exists(), reason="fixture missing",
+    )
+
+    def test_main_view(self):
+        fv = view(FIXTURES / "sample.c", "main")
+        assert fv is not None
+        assert fv.function == "main"
+        assert fv.language == "c"
+        # Three calls: helper (line 10), printf (line 11). The asm
+        # statement is not a call. The conditional check on helper(argc)
+        # also counts.
+        call_chains = [c.chain for c in fv.calls_made]
+        assert ["helper"] in call_chains
+        assert ["printf"] in call_chains
+        # Two explicit returns.
+        return_lines = sorted(r.line for r in fv.returns)
+        assert len(return_lines) == 2
+        # Inline asm detected.
+        assert fv.has_inline_asm is True
+
+    def test_helper_view_no_asm(self):
+        fv = view(FIXTURES / "sample.c", "helper")
+        assert fv is not None
+        assert fv.has_inline_asm is False
+        assert len(fv.returns) == 1
+        assert fv.returns[0].value_text == "x + 1"
+        # No calls inside helper.
+        assert fv.calls_made == ()
+
+
+class TestCpp:
+    """C++ extends C with classes, qualified ids, ``this->``. The
+    ``run`` method exercises out-of-line definition + receiver_class
+    tagging at once."""
+
+    pytestmark = pytest.mark.skipif(
+        not (FIXTURES / "sample.cpp").exists(), reason="fixture missing",
+    )
+
+    def test_run_method_this_arrow(self):
+        # Use --at-line equivalent because ``run`` might collide
+        # with other names; in this fixture it's unique so name
+        # match suffices.
+        fv = view(FIXTURES / "sample.cpp", "run")
+        assert fv is not None
+        assert fv.language == "cpp"
+        # this->setup() inside run → receiver_class="Widget"
+        this_setup = [
+            c for c in fv.calls_made
+            if c.chain == ["this", "setup"]
+        ]
+        assert len(this_setup) == 1
+        assert this_setup[0].receiver_class == "Widget"
+        # Two explicit returns.
+        assert len(fv.returns) == 2
+
+    def test_setup_method_out_of_line(self):
+        fv = view(FIXTURES / "sample.cpp", "setup")
+        assert fv is not None
+        # ``helper()`` is a free function, not a Widget method →
+        # no receiver_class tag.
+        helper_calls = [
+            c for c in fv.calls_made if c.chain == ["helper"]
+        ]
+        assert len(helper_calls) == 1
+        assert helper_calls[0].receiver_class is None
+
+    def test_destructor_view(self):
+        """Out-of-line destructor (``Widget::~Widget()``) is
+        surfaced by inventory and the view() composition picks it up.
+
+        Originally pinned as a known-gap test (TreeSitterExtractor's
+        ``_get_name`` didn't handle qualified+destructor declarators
+        and the cpp branch used the C grammar). Fixed inline as part
+        of PR1 after adversarial review surfaced the broader
+        inline-method gap that shared the same root cause."""
+        fv = view(FIXTURES / "sample.cpp", "~Widget")
+        assert fv is not None
+        assert fv.function == "~Widget"
+        # cleanup() called inside destructor body
+        assert any(c.chain == ["cleanup"] for c in fv.calls_made)
+
+
+class TestPython:
+    """Python uses stdlib ``ast`` for both function discovery and
+    returns. Tests pin source-order return sorting and that the
+    composition flows through correctly despite the local
+    ``core.ast`` namespace collision with stdlib ``ast``."""
+
+    pytestmark = pytest.mark.skipif(
+        not (FIXTURES / "sample.py").exists(), reason="fixture missing",
+    )
+
+    def test_check_password_view(self):
+        fv = view(FIXTURES / "sample.py", "check_password")
+        assert fv is not None
+        assert fv.language == "python"
+        # All three function calls.
+        names = [".".join(c.chain) for c in fv.calls_made]
+        assert "compute_hash" in names
+        assert "log_attempt" in names
+        assert "constant_time_compare" in names
+        # Three explicit returns, in source order.
+        lines = [r.line for r in fv.returns]
+        assert lines == sorted(lines), (
+            "returns are not in source order — Python's ast.walk "
+            "doesn't guarantee order; _walk_returns_python must sort"
+        )
+
+    def test_method_inside_class(self):
+        fv = view(FIXTURES / "sample.py", "login")
+        assert fv is not None
+        # check_password call inside login.
+        assert any(
+            c.chain == ["check_password"] for c in fv.calls_made
+        )
+
+    def test_python_no_inline_asm(self):
+        fv = view(FIXTURES / "sample.py", "check_password")
+        assert fv is not None
+        assert fv.has_inline_asm is False
+
+
+class TestGo:
+    pytestmark = pytest.mark.skipif(
+        not (FIXTURES / "sample.go").exists(), reason="fixture missing",
+    )
+
+    def test_main_view(self):
+        fv = view(FIXTURES / "sample.go", "main")
+        if fv is None:
+            pytest.skip("go grammar not installed")
+        # fmt.Println called twice in main.
+        println = [c for c in fv.calls_made if c.chain[-1] == "Println"]
+        assert len(println) >= 1
+
+    def test_go_no_inline_asm(self):
+        fv = view(FIXTURES / "sample.go", "main")
+        if fv is None:
+            pytest.skip("go grammar not installed")
+        assert fv.has_inline_asm is False
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_missing_file_returns_none(self):
+        assert view(Path("/no/such/file.c"), "foo") is None
+
+    def test_unknown_extension_returns_none(self, tmp_path):
+        f = tmp_path / "unknown.xyz"
+        f.write_text("whatever")
+        assert view(f, "foo") is None
+
+    def test_function_not_found_returns_none(self, tmp_path):
+        f = tmp_path / "x.c"
+        f.write_text('int main(void) { return 0; }\n')
+        assert view(f, "nonexistent") is None
+        # Sanity check that the file/function are otherwise findable.
+        assert view(f, "main") is not None
+
+    def test_language_override(self, tmp_path):
+        # File with no extension: detect_language returns None,
+        # but with --language given, view() proceeds.
+        f = tmp_path / "noext"
+        f.write_text('int main(void) { return 0; }\n')
+        assert view(f, "main") is None  # detection fails
+        fv = view(f, "main", language="c")
+        assert fv is not None
+        assert fv.language == "c"
+
+    def test_at_line_disambiguates_collision(self, tmp_path):
+        # Two functions named __init__ — typical Python class methods.
+        f = tmp_path / "x.py"
+        f.write_text(
+            'class A:\n'
+            '    def __init__(self):\n'
+            '        self.a = 1\n'
+            'class B:\n'
+            '    def __init__(self):\n'
+            '        self.b = 2\n'
+        )
+        # Without --at-line, the first match wins (extractor order).
+        # With --at-line=5, we should hit B's __init__.
+        fv = view(f, "__init__", at_line=5)
+        # Should be B's __init__: line 5 inside its range.
+        assert fv is not None
+        # The disambiguation worked iff the view covers a range
+        # that includes line 5.
+        assert fv.lines[0] <= 5 <= fv.lines[1]
+
+
+# ---------------------------------------------------------------------------
+# Schema round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSchema:
+    pytestmark = pytest.mark.skipif(
+        not (FIXTURES / "sample.c").exists(), reason="fixture missing",
+    )
+
+    def test_to_dict_carries_full_schema(self):
+        fv = view(FIXTURES / "sample.c", "main")
+        d = fv.to_dict()
+        # Top-level keys.
+        assert set(d.keys()) >= {
+            "function", "file", "language", "lines", "signature",
+            "calls_made", "returns", "has_inline_asm", "schema_version",
+        }
+        assert d["schema_version"] == SCHEMA_VERSION
+        # Calls have receiver_class (None for C is fine).
+        for c in d["calls_made"]:
+            assert set(c.keys()) >= {"line", "chain", "caller", "receiver_class"}
+        # Returns have line + value_text.
+        for r in d["returns"]:
+            assert set(r.keys()) == {"line", "value_text"}
+
+    def test_to_dict_is_json_serialisable(self):
+        import json
+        fv = view(FIXTURES / "sample.c", "main")
+        # Round-trip through JSON — pin no non-serialisable types.
+        s = json.dumps(fv.to_dict())
+        d = json.loads(s)
+        assert d["function"] == "main"

--- a/core/ast/view.py
+++ b/core/ast/view.py
@@ -1,0 +1,371 @@
+"""Composition layer: build a :class:`FunctionView` over the inventory
+substrate.
+
+The public entry point :func:`view` is the only function callers should
+need. Everything else here is per-language helper plumbing.
+
+Implementation notes:
+
+  * Function discovery routes through
+    :func:`core.inventory.extractors.extract_functions`, which already
+    does language dispatch and tree-sitter/regex/Python-AST fallback.
+  * Calls extraction routes through the per-language
+    ``core.inventory.call_graph.extract_call_graph_<lang>``; the
+    dispatch table is local to this module. Languages absent from the
+    table return an empty calls list (the rest of the view still
+    works).
+  * Returns / inline-asm are extracted here per-language because they
+    aren't yet first-class in inventory. Per-language walkers stay
+    simple (~20-40 LOC each) and lazy-import their grammar so a
+    missing grammar package degrades cleanly to no returns / no asm
+    flag rather than crashing.
+
+Language coverage at this revision:
+
+  * Calls + returns + asm: C, C++ (asm is C/C++ only)
+  * Calls + returns: Python, JavaScript, Java, Go
+  * Calls only (inherited from inventory): Rust, Ruby, C#, PHP,
+    TypeScript (TS shares the JS walker)
+
+A function with ``line_end == None`` (extractor couldn't determine
+the end) skips line-range filtering for calls — the whole file's
+call graph would otherwise be empty for that function. Returns/asm
+also bail out cleanly when bounds aren't known.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+
+from core.ast.model import FunctionView, Return, SCHEMA_VERSION
+from core.inventory.call_graph import (
+    extract_call_graph_c,
+    extract_call_graph_cpp,
+    extract_call_graph_csharp,
+    extract_call_graph_go,
+    extract_call_graph_java,
+    extract_call_graph_javascript,
+    extract_call_graph_php,
+    extract_call_graph_python,
+    extract_call_graph_ruby,
+    extract_call_graph_rust,
+)
+from core.inventory.extractors import extract_functions
+from core.inventory.languages import detect_language
+
+
+# ---------------------------------------------------------------------------
+# Call-graph dispatch
+# ---------------------------------------------------------------------------
+#
+# Per-language ``extract_call_graph_<lang>`` indexed by the canonical
+# language string from ``core.inventory.languages.LANGUAGE_MAP``.
+# Languages not in this table aren't a hard error — they just produce
+# an empty ``calls_made`` tuple. Adding a new walker is a one-line
+# entry here.
+#
+# TypeScript maps to the JavaScript walker until tree-sitter-typescript
+# wiring lands — the JS walker accepts a subset of TS syntactically;
+# TS-specific constructs (type annotations, generics, decorators)
+# parse-fail or are ignored, but the call-extraction logic is sound
+# for the common JS-shaped subset.
+
+_CALL_GRAPH_DISPATCH: dict[str, Callable] = {
+    "python": extract_call_graph_python,
+    "javascript": extract_call_graph_javascript,
+    "typescript": extract_call_graph_javascript,
+    "java": extract_call_graph_java,
+    "go": extract_call_graph_go,
+    "c": extract_call_graph_c,
+    "cpp": extract_call_graph_cpp,
+    "rust": extract_call_graph_rust,
+    "ruby": extract_call_graph_ruby,
+    "csharp": extract_call_graph_csharp,
+    "php": extract_call_graph_php,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def view(
+    path: Path,
+    function: str,
+    *,
+    at_line: Optional[int] = None,
+    language: Optional[str] = None,
+) -> Optional[FunctionView]:
+    """Return a :class:`FunctionView` for ``function`` in ``path``.
+
+    Returns ``None`` when:
+      * The file can't be read.
+      * The language can't be detected from extension (pass
+        ``language=...`` to override).
+      * No function in the file matches ``function`` (and ``at_line``
+        when given).
+
+    When multiple functions in the file share the same name (e.g.
+    methods of different classes), pass ``at_line`` to disambiguate
+    — the first match whose line range contains ``at_line`` is
+    returned. Without ``at_line``, the first name match wins; for
+    files with name collisions this is deterministic (extractor
+    output order) but not necessarily the function the caller meant.
+    """
+    path = Path(path)
+    if language is None:
+        language = detect_language(str(path))
+        if language is None:
+            return None
+
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+    # Function discovery — inventory handles per-language dispatch.
+    functions = extract_functions(str(path), language, content)
+    matches = [f for f in functions if f.name == function]
+    if at_line is not None:
+        # Narrow to functions whose range encloses at_line. line_end
+        # may be None for extractors that don't compute it; treat
+        # missing end as "unknown" and require an exact start match.
+        narrowed = []
+        for fi in matches:
+            if fi.line_end is not None:
+                if fi.line_start <= at_line <= fi.line_end:
+                    narrowed.append(fi)
+            elif fi.line_start == at_line:
+                narrowed.append(fi)
+        matches = narrowed
+    if not matches:
+        return None
+    fi = matches[0]
+
+    # Calls — filter file-wide graph by the function's line range.
+    calls_made = _filter_calls(content, language, fi.line_start, fi.line_end)
+
+    # Returns + inline asm.
+    returns = _walk_returns(content, language, fi.line_start, fi.line_end)
+    has_asm = _has_inline_asm(content, language, fi.line_start, fi.line_end)
+
+    return FunctionView(
+        function=fi.name,
+        file=str(path),
+        language=language,
+        # If line_end is None, fall back to start so the tuple type
+        # stays valid; consumers should treat (n, n) as "unknown end"
+        # by checking against the source length. Better than tripping
+        # downstream assumptions about line_end being None.
+        lines=(fi.line_start, fi.line_end if fi.line_end is not None else fi.line_start),
+        signature=fi.signature or "",
+        calls_made=calls_made,
+        returns=returns,
+        has_inline_asm=has_asm,
+        schema_version=SCHEMA_VERSION,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Calls — line-range filter over the file-wide call graph
+# ---------------------------------------------------------------------------
+
+
+def _filter_calls(
+    content: str,
+    language: str,
+    line_start: int,
+    line_end: Optional[int],
+) -> Tuple:
+    """Return calls inside the function's line range. Empty tuple
+    when the language has no call-graph walker or the file is
+    unparseable for it."""
+    extractor = _CALL_GRAPH_DISPATCH.get(language)
+    if extractor is None:
+        return ()
+    try:
+        graph = extractor(content)
+    except Exception:                                       # noqa: BLE001
+        return ()
+    if line_end is None:
+        # No upper bound known; return every call (best-effort).
+        return tuple(graph.calls)
+    return tuple(
+        c for c in graph.calls
+        if line_start <= c.line <= line_end
+    )
+
+
+# ---------------------------------------------------------------------------
+# Returns
+# ---------------------------------------------------------------------------
+
+
+def _walk_returns(
+    content: str,
+    language: str,
+    line_start: int,
+    line_end: Optional[int],
+) -> Tuple[Return, ...]:
+    """Return all explicit ``return`` statements inside the function.
+
+    Implicit returns (end-of-function fall-through in C/Go, etc.) are
+    NOT emitted. Callers that want "all exit points" should union
+    these with ``lines[1]``.
+    """
+    if line_end is None:
+        return ()
+    if language == "python":
+        return _walk_returns_python(content, line_start, line_end)
+    # Tree-sitter languages: same shape across grammars — a
+    # ``return_statement`` node whose first named child (if any) is
+    # the returned expression. Lazy-import the grammar so a missing
+    # package degrades cleanly.
+    grammar = _ts_grammar_module(language)
+    if grammar is None:
+        return ()
+    return _walk_returns_ts(content, grammar, line_start, line_end)
+
+
+def _walk_returns_python(
+    content: str,
+    line_start: int,
+    line_end: int,
+) -> Tuple[Return, ...]:
+    """Use stdlib ``ast`` for Python — no third-party grammar needed."""
+    import ast as _stdlib_ast  # absolute import: shadowed by core.ast namespace
+    try:
+        tree = _stdlib_ast.parse(content)
+    except SyntaxError:
+        return ()
+    out: List[Return] = []
+    for node in _stdlib_ast.walk(tree):
+        if not isinstance(node, _stdlib_ast.Return):
+            continue
+        line = getattr(node, "lineno", 0)
+        if not (line_start <= line <= line_end):
+            continue
+        value_text = ""
+        if node.value is not None:
+            try:
+                value_text = _stdlib_ast.unparse(node.value)
+            except Exception:                               # noqa: BLE001
+                value_text = ""
+        out.append(Return(line=line, value_text=value_text))
+    # ast.walk's traversal order isn't source-order; sort by line so
+    # consumers get a stable, predictable sequence.
+    out.sort(key=lambda r: r.line)
+    return tuple(out)
+
+
+def _walk_returns_ts(
+    content: str,
+    grammar_module,
+    line_start: int,
+    line_end: int,
+) -> Tuple[Return, ...]:
+    """Generic tree-sitter ``return_statement`` walk.
+
+    The grammar's emitted node type is conventionally
+    ``return_statement`` in every grammar this dispatch hands out
+    (verified for c / cpp / javascript / java / go); if a future
+    grammar uses a different name, add it to the tuple below.
+    """
+    try:
+        from tree_sitter import Language, Parser
+        parser = Parser(Language(grammar_module.language()))
+        tree = parser.parse(content.encode("utf-8", errors="replace"))
+    except Exception:                                       # noqa: BLE001
+        return ()
+    out: List[Return] = []
+    return_types = ("return_statement",)
+
+    def visit(node) -> None:
+        # Cheap line-range prune: skip subtrees entirely outside
+        # [line_start, line_end].
+        n_start = node.start_point[0] + 1
+        n_end = node.end_point[0] + 1
+        if n_start > line_end or n_end < line_start:
+            return
+        if node.type in return_types:
+            line = n_start
+            if line_start <= line <= line_end:
+                value_text = ""
+                for c in node.children:
+                    if c.is_named:
+                        value_text = c.text.decode("utf-8", errors="replace")
+                        break
+                out.append(Return(line=line, value_text=value_text))
+            # Returns don't nest meaningfully; still descend so nested
+            # functions / lambdas inside return expressions are seen.
+        for c in node.children:
+            visit(c)
+
+    visit(tree.root_node)
+    return tuple(out)
+
+
+def _ts_grammar_module(language: str):
+    """Lazy-import the tree-sitter grammar for ``language``. Returns
+    None if the package isn't installed — the caller falls back to
+    "no returns" / "no asm" rather than crashing."""
+    try:
+        if language == "c":
+            import tree_sitter_c as m
+            return m
+        if language == "cpp":
+            import tree_sitter_cpp as m
+            return m
+        if language in ("javascript", "typescript"):
+            import tree_sitter_javascript as m
+            return m
+        if language == "java":
+            import tree_sitter_java as m
+            return m
+        if language == "go":
+            import tree_sitter_go as m
+            return m
+    except ImportError:
+        return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Inline asm (C/C++ only)
+# ---------------------------------------------------------------------------
+
+
+# Whole-word match for the three GNU-extension asm keywords. ``asm``
+# is contextual (only meaningful at statement position) — false
+# positives are theoretically possible if a function contains a
+# variable / type / macro literally named ``asm``, but C and C++
+# discourage that (``asm`` is a reserved word in C++ and a
+# conditional keyword in C since C99 via ``<iso646.h>``). For PR1
+# minimum the regex is the right precision/cost trade-off; a future
+# revision can switch to a tree-sitter ``gnu_asm_statement`` walk if
+# false positives surface in real corpora.
+_ASM_PATTERN = re.compile(
+    r"\b(__asm__|__asm|asm)\b\s*(?:volatile|goto)?\s*[(]",
+)
+
+
+def _has_inline_asm(
+    content: str,
+    language: str,
+    line_start: int,
+    line_end: Optional[int],
+) -> bool:
+    """True iff a GNU-extension inline-asm construct appears in the
+    function body. Non-C/C++ always False."""
+    if language not in ("c", "cpp"):
+        return False
+    if line_end is None:
+        return False
+    # Slice the function body by lines (1-indexed). String slicing
+    # is cheap relative to parsing the whole file again.
+    lines = content.splitlines()
+    body = "\n".join(lines[line_start - 1: line_end])
+    return bool(_ASM_PATTERN.search(body))

--- a/core/inventory/call_graph.py
+++ b/core/inventory/call_graph.py
@@ -2610,6 +2610,922 @@ class _PhpCallGraph:
         return None
 
 
+# ===========================================================================
+# C
+# ===========================================================================
+#
+# C semantics differ from the higher-level languages above:
+#
+#   * No module system. ``#include "foo.h"`` is preprocessor text
+#     substitution; there's no qualified-name space the linker
+#     exposes by file. ``imports`` records included headers as
+#     ``basename(header) -> header path`` so the resolver can
+#     match ``foo`` → ``foo.h`` at the call site.
+#
+#   * Function pointers are first-class. ``fp()`` where ``fp`` is a
+#     local variable is statically indistinguishable from a direct
+#     call without type-resolution. Walker emits the call with chain
+#     ``[<name>]`` and adds ``INDIRECTION_FN_POINTER`` to the
+#     indirection set. Resolver downstream can downweight matches.
+#
+#   * Macros that look like calls (``BUG_ON(...)``,
+#     ``container_of(...)``) appear as ``call_expression`` to
+#     tree-sitter — the preprocessor isn't run. The walker emits
+#     them as regular calls with the macro identifier as chain.
+#     Downstream consumers can disambiguate via the inventory's
+#     macro list.
+#
+#   * No classes, no namespaces (C++ handles those separately).
+
+INDIRECTION_FN_POINTER = "fn_pointer"  # C/C++ call through a fn pointer var
+
+
+def extract_call_graph_c(content: str) -> FileCallGraph:
+    """Walk a C source string via tree-sitter-c and return its
+    :class:`FileCallGraph`.
+
+    Returns an empty graph when ``tree_sitter_c`` isn't installed or
+    the file is unparseable.
+
+    Shapes captured:
+
+      * ``#include "x.h"`` / ``#include <x.h>`` → ``imports``: the
+        basename without extension maps to the full header path.
+        ``#include "subdir/x.h"`` records both ``x`` → ``subdir/x.h``.
+      * ``foo(...)`` → chain ``["foo"]``
+      * ``obj.foo(...)`` → chain ``["obj", "foo"]``
+        (struct field access via tree-sitter ``field_expression``)
+      * ``obj->foo(...)`` → chain ``["obj", "foo"]``
+        (pointer-to-struct field access; same node type)
+      * ``a.b.c(...)`` / ``a->b->c(...)`` → chain ``["a", "b", "c"]``
+      * ``(*fp)(...)`` → chain ``[<name>]`` + ``INDIRECTION_FN_POINTER``
+      * ``fp(...)`` where ``fp`` looks like a local variable —
+        statically indistinguishable from a direct call; emitted as a
+        regular call. Downstream consumers wanting to filter
+        function-pointer-likely callees should consult the inventory
+        for whether ``fp`` is a known function name.
+
+    Limitations (deliberate, not bugs):
+
+      * Macros that expand to call expressions are not seen as such —
+        the walker reads pre-preprocessor source. ``BUG_ON(x)`` is
+        emitted as a call to ``BUG_ON``; its expansion (``do { if
+        (x) { ... } } while (0)``) is invisible.
+      * Typedef'd function-pointer types aren't traced; only the
+        syntactic ``(*fp)(...)`` form is recognised as indirection.
+      * K&R-style function definitions are accepted by tree-sitter
+        but the declarator walk only handles ANSI prototypes for
+        signature/parameters extraction.
+    """
+    try:
+        import tree_sitter_c as ts_c
+        from tree_sitter import Language, Parser
+    except ImportError:
+        logger.debug(
+            "call_graph: tree-sitter C grammar not installed; "
+            "returning empty graph",
+        )
+        return FileCallGraph()
+
+    try:
+        parser = Parser(Language(ts_c.language()))
+        tree = parser.parse(content.encode("utf-8", errors="replace"))
+    except Exception as e:                              # noqa: BLE001
+        logger.debug("call_graph: C parse failed (%s)", e)
+        return FileCallGraph()
+
+    walker = _CCallGraph()
+    walker.walk(tree.root_node)
+    return walker.graph
+
+
+class _CCallGraph:
+    """Single-pass tree-sitter-c walk.
+
+    Maintains a stack of enclosing function names so each emitted
+    ``CallSite`` knows its lexical container. The stack is keyed by
+    function identifier; for static functions and externs the
+    identifier is sufficient because C's single global namespace per
+    translation unit means name + file is unique.
+    """
+
+    # Top-level constructs.
+    _FUNCTION_DEFINITION = "function_definition"
+    _PREPROC_INCLUDE = "preproc_include"
+
+    # Declarator wrapping.
+    _FUNCTION_DECLARATOR = "function_declarator"
+    _POINTER_DECLARATOR = "pointer_declarator"
+    _PARENTHESIZED_DECLARATOR = "parenthesized_declarator"
+
+    # Expressions.
+    _CALL_EXPRESSION = "call_expression"
+    _FIELD_EXPRESSION = "field_expression"
+    _POINTER_EXPRESSION = "pointer_expression"
+    _PARENTHESIZED_EXPRESSION = "parenthesized_expression"
+
+    # Leaf names.
+    _IDENTIFIER = "identifier"
+    _FIELD_IDENTIFIER = "field_identifier"
+
+    # Header strings.
+    _STRING_LITERAL = "string_literal"
+    _SYSTEM_LIB_STRING = "system_lib_string"
+    _STRING_CONTENT = "string_content"
+
+    def __init__(self) -> None:
+        self.graph = FileCallGraph()
+        # Stack of lexically-enclosing function names. ``None`` is
+        # never pushed — file-scope ``CallSite``s (initialisers) emit
+        # with ``caller=None``.
+        self._enclosing: List[str] = []
+
+    # ------------------------------------------------------------------
+    # Walk dispatch
+    # ------------------------------------------------------------------
+
+    def walk(self, node) -> None:
+        """Pre-order traversal. Function definitions push their name
+        before children are visited; pop on the way back up."""
+        t = node.type
+        if t == self._PREPROC_INCLUDE:
+            self._visit_include(node)
+            # Includes don't have function/call children worth walking.
+            return
+        if t == self._FUNCTION_DEFINITION:
+            name = self._function_name(node)
+            if name is not None:
+                self._enclosing.append(name)
+                try:
+                    for child in node.children:
+                        self.walk(child)
+                    return
+                finally:
+                    self._enclosing.pop()
+        if t == self._CALL_EXPRESSION:
+            self._visit_call(node)
+            # Fall through so nested calls inside the arg list are visited.
+        for child in node.children:
+            self.walk(child)
+
+    # ------------------------------------------------------------------
+    # Includes
+    # ------------------------------------------------------------------
+
+    def _visit_include(self, node) -> None:
+        # tree-sitter-c structure:
+        #   preproc_include "#include" (string_literal | system_lib_string)
+        for child in node.children:
+            if child.type == self._STRING_LITERAL:
+                # "foo/bar.h" → unwrap the string_content.
+                path = self._unwrap_string(child)
+                if path:
+                    self._record_include(path)
+            elif child.type == self._SYSTEM_LIB_STRING:
+                # <stdio.h> — the whole text including angle brackets.
+                raw = child.text.decode("utf-8", errors="replace").strip()
+                if raw.startswith("<") and raw.endswith(">"):
+                    path = raw[1:-1]
+                    if path:
+                        self._record_include(path)
+
+    def _record_include(self, path: str) -> None:
+        # basename without extension as the local binding name.
+        # ``net/dst.h`` → ``dst``; ``stdio.h`` → ``stdio``.
+        from os.path import basename, splitext
+        local = splitext(basename(path))[0]
+        if local:
+            self.graph.imports[local] = path
+
+    # ------------------------------------------------------------------
+    # Calls
+    # ------------------------------------------------------------------
+
+    def _visit_call(self, node) -> None:
+        # call_expression: function (argument_list)
+        # The "function" field is the first named child before
+        # argument_list.
+        callee_node = None
+        for c in node.children:
+            if c.type == "argument_list":
+                break
+            if c.is_named:
+                callee_node = c
+                break
+        if callee_node is None:
+            return
+
+        chain, is_fn_pointer = self._callee_chain(callee_node)
+        if chain is None:
+            return
+
+        if is_fn_pointer:
+            self.graph.indirection.add(INDIRECTION_FN_POINTER)
+
+        caller = self._enclosing[-1] if self._enclosing else None
+        self.graph.calls.append(CallSite(
+            line=node.start_point[0] + 1,  # tree-sitter is 0-indexed
+            chain=chain,
+            caller=caller,
+        ))
+
+    def _callee_chain(self, node) -> Tuple[Optional[List[str]], bool]:
+        """Resolve the callee expression to an attribute chain.
+
+        Returns (chain, is_fn_pointer). ``chain`` is None when the
+        callee shape isn't statically nameable (lambda result,
+        subscripted array, complex expression).
+        """
+        # Unwrap parenthesised expressions: ``(*fp)(...)`` parses as
+        # call_expression{parenthesized_expression{pointer_expression{
+        # identifier "fp"}}}.
+        if node.type == self._PARENTHESIZED_EXPRESSION:
+            inner = self._first_named_child(node)
+            if inner is None:
+                return None, False
+            chain, _ = self._callee_chain(inner)
+            # Anything inside parens that resolved to a chain is
+            # function-pointer-shaped if we unwrap a pointer_expression
+            # next.
+            return chain, chain is not None and inner.type == self._POINTER_EXPRESSION
+
+        if node.type == self._POINTER_EXPRESSION:
+            # ``*fp`` — the pointed-to is the operand.
+            inner = self._first_named_child(node)
+            if inner is None:
+                return None, False
+            chain, _ = self._callee_chain(inner)
+            return chain, chain is not None
+
+        if node.type == self._IDENTIFIER:
+            return [node.text.decode("utf-8", errors="replace")], False
+
+        if node.type == self._FIELD_EXPRESSION:
+            return self._field_chain(node), False
+
+        return None, False
+
+    def _field_chain(self, node) -> Optional[List[str]]:
+        """Resolve ``a.b.c`` / ``a->b->c`` / mixed → ``["a","b","c"]``."""
+        parts: List[str] = []
+        cur = node
+        # field_expression: argument . | -> field
+        while cur is not None and cur.type == self._FIELD_EXPRESSION:
+            field_node = None
+            for c in cur.children:
+                if c.type == self._FIELD_IDENTIFIER:
+                    field_node = c
+            if field_node is None:
+                return None
+            parts.append(field_node.text.decode("utf-8", errors="replace"))
+            # Operand is the first named child (the "argument" side).
+            operand = None
+            for c in cur.children:
+                if c.is_named and c.type != self._FIELD_IDENTIFIER:
+                    operand = c
+                    break
+            cur = operand
+        if cur is None:
+            return None
+        if cur.type == self._IDENTIFIER:
+            parts.append(cur.text.decode("utf-8", errors="replace"))
+            return list(reversed(parts))
+        # Other tail shapes (subscript, call result) aren't statically
+        # nameable; bail out.
+        return None
+
+    # ------------------------------------------------------------------
+    # Function name extraction
+    # ------------------------------------------------------------------
+
+    def _function_name(self, fn_def_node) -> Optional[str]:
+        """Find the function identifier inside a function_definition.
+
+        The declarator subtree may be wrapped:
+          * ``int foo(...)``           → function_declarator{identifier}
+          * ``int *foo(...)``          → pointer_declarator{
+                                            function_declarator{identifier}}
+          * ``int (*foo)(...)``        → function pointer typedef — NOT a
+                                            function definition; tree-sitter
+                                            parses this differently, so we
+                                            wouldn't be in this branch.
+        """
+        for c in fn_def_node.children:
+            if not c.is_named:
+                continue
+            if c.type == self._FUNCTION_DECLARATOR:
+                return self._declarator_name(c)
+            if c.type == self._POINTER_DECLARATOR:
+                inner = self._find_function_declarator(c)
+                if inner is not None:
+                    return self._declarator_name(inner)
+        return None
+
+    def _declarator_name(self, fn_declarator_node) -> Optional[str]:
+        # function_declarator first named child is the name (identifier)
+        # or another declarator that wraps the name.
+        for c in fn_declarator_node.children:
+            if not c.is_named:
+                continue
+            if c.type == self._IDENTIFIER:
+                return c.text.decode("utf-8", errors="replace")
+            if c.type == self._PARENTHESIZED_DECLARATOR:
+                inner = self._first_named_child(c)
+                if inner is not None and inner.type == self._IDENTIFIER:
+                    return inner.text.decode("utf-8", errors="replace")
+        return None
+
+    def _find_function_declarator(self, node):
+        """Recursively descend through pointer/parenthesized wrappers
+        to the inner function_declarator."""
+        for c in node.children:
+            if c.type == self._FUNCTION_DECLARATOR:
+                return c
+            if c.type in (self._POINTER_DECLARATOR, self._PARENTHESIZED_DECLARATOR):
+                inner = self._find_function_declarator(c)
+                if inner is not None:
+                    return inner
+        return None
+
+    # ------------------------------------------------------------------
+    # Small utilities
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _first_named_child(node):
+        for c in node.children:
+            if c.is_named:
+                return c
+        return None
+
+    @staticmethod
+    def _unwrap_string(string_node) -> Optional[str]:
+        """``"foo/bar.h"`` → ``foo/bar.h``."""
+        for c in string_node.children:
+            if c.type == "string_content":
+                return c.text.decode("utf-8", errors="replace")
+        # Fallback: strip outer quotes from the raw text.
+        raw = string_node.text.decode("utf-8", errors="replace")
+        if len(raw) >= 2 and raw[0] == '"' and raw[-1] == '"':
+            return raw[1:-1]
+        return None
+
+
+# ===========================================================================
+# C++
+# ===========================================================================
+#
+# C++ extends C with classes, namespaces, qualified identifiers,
+# destructors, templates. The walker subclasses ``_CCallGraph`` and
+# overrides the dispatch + the constructs C doesn't have:
+#
+#   * ``class_specifier`` / ``struct_specifier`` → ``ClassDef`` entry,
+#     class stack pushed for inline-method calls to acquire
+#     ``receiver_class``.
+#   * In-class method definitions populate ``ClassDef.methods``.
+#   * Out-of-line definitions (``int Foo::bar() {...}``) emit calls
+#     inside ``bar`` with ``receiver_class="Foo"`` even though the
+#     class body isn't lexically enclosing — the qualified declarator
+#     carries the class.
+#   * ``qualified_identifier`` (``Foo::bar``, ``std::cout``,
+#     ``ns::sub::fn``) → chain with ``::``-joined name components.
+#   * Inside a class body, a bare ``member()`` call is implicit-this;
+#     ``this->member()`` is the explicit form. Both tag the call
+#     with ``receiver_class`` = current class.
+#   * ``~Foo`` (destructor_name) → name ``~Foo``.
+#   * ``template_declaration`` wrappers are descended into; the
+#     template itself doesn't appear in the call graph.
+#   * Lambdas are opaque: the call expression they appear in is still
+#     emitted, but a lambda *call* (``[]{...}()``) returns no chain.
+
+def extract_call_graph_cpp(content: str) -> FileCallGraph:
+    """Walk a C++ source string via tree-sitter-cpp and return its
+    :class:`FileCallGraph`.
+
+    Returns an empty graph when ``tree_sitter_cpp`` isn't installed or
+    the file is unparseable.
+
+    Shapes captured (in addition to all C shapes — see
+    :func:`extract_call_graph_c`):
+
+      * ``Foo::bar(...)`` → chain ``["Foo", "bar"]``
+      * ``std::cout`` (used as a callee chain root) → chain
+        ``["std", "cout", ...]``
+      * ``namespace ns { void f() {...} }`` → ``f`` is recorded
+        bare; we do NOT prepend namespace to the function name
+        (the inventory's resolver matches on bare names today;
+        prepending would create a second namespace-resolution
+        problem for downstream).
+      * ``class Foo { void bar(); }`` → ``ClassDef(name="Foo",
+        methods=[("bar", line), ...])`` in
+        ``FileCallGraph.classes``.
+      * ``int Foo::bar() {...}`` (out-of-line) → ``bar`` is pushed
+        as the caller name (matches the C convention); calls inside
+        bar's body tagged with ``receiver_class="Foo"``.
+      * ``this->member()`` inside class body → chain ``["this",
+        "member"]`` + ``receiver_class`` = enclosing class.
+      * Bare ``member()`` inside class body → chain ``["member"]``;
+        treated as implicit-this only when the name is in the
+        current class's method list — otherwise emitted as a plain
+        call.
+
+    Out of scope at this revision:
+
+      * Template instantiation. ``vector<int>`` callees emit the
+        bare ``vector`` (the type-args are dropped). Method-template
+        calls are emitted with the bare method name.
+      * Operator overloading. ``a + b`` doesn't emit a call to
+        ``operator+`` even though it resolves to one.
+      * Implicit conversion / constructor calls. Only syntactic
+        calls are emitted.
+      * ``using namespace ns;`` doesn't fold ``ns::`` qualifiers off
+        of subsequent calls.
+    """
+    try:
+        import tree_sitter_cpp as ts_cpp
+        from tree_sitter import Language, Parser
+    except ImportError:
+        logger.debug(
+            "call_graph: tree-sitter C++ grammar not installed; "
+            "returning empty graph",
+        )
+        return FileCallGraph()
+
+    try:
+        parser = Parser(Language(ts_cpp.language()))
+        tree = parser.parse(content.encode("utf-8", errors="replace"))
+    except Exception as e:                              # noqa: BLE001
+        logger.debug("call_graph: C++ parse failed (%s)", e)
+        return FileCallGraph()
+
+    walker = _CppCallGraph()
+    walker.walk(tree.root_node)
+    return walker.graph
+
+
+class _CppCallGraph(_CCallGraph):
+    """C++ walker. Reuses C base for includes, field expressions,
+    pointer-call indirection, and ANSI declarator name extraction;
+    adds class/struct/namespace/qualified-id handling."""
+
+    # Class-body constructs.
+    _CLASS_SPECIFIER = "class_specifier"
+    _STRUCT_SPECIFIER = "struct_specifier"
+    _FIELD_DECLARATION_LIST = "field_declaration_list"
+    _BASE_CLASS_CLAUSE = "base_class_clause"
+    _NAMESPACE_DEFINITION = "namespace_definition"
+
+    # Qualified names.
+    _QUALIFIED_IDENTIFIER = "qualified_identifier"
+    _NAMESPACE_IDENTIFIER = "namespace_identifier"
+    _TEMPLATE_TYPE = "template_type"
+    _TEMPLATE_FUNCTION = "template_function"
+    _TEMPLATE_DECLARATION = "template_declaration"
+
+    # Special name shapes.
+    _DESTRUCTOR_NAME = "destructor_name"
+    _OPERATOR_NAME = "operator_name"
+    _TYPE_IDENTIFIER = "type_identifier"
+
+    # tree-sitter-cpp emits the keyword ``this`` as its own node type
+    # named literally ``"this"``. It appears as the operand inside
+    # ``field_expression`` for ``this->member`` / ``this.member``.
+    _THIS = "this"
+
+    # In-class method declaration: ``field_declaration`` wraps a
+    # ``function_declarator``. Tracking these populates
+    # ``ClassDef.methods`` even when the body lives out-of-line.
+    _FIELD_DECLARATION = "field_declaration"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._class_stack: List[ClassDef] = []
+
+    # ------------------------------------------------------------------
+    # Walk dispatch
+    # ------------------------------------------------------------------
+
+    def walk(self, node) -> None:
+        t = node.type
+        if t == self._PREPROC_INCLUDE:
+            self._visit_include(node)
+            return
+        if t in (self._CLASS_SPECIFIER, self._STRUCT_SPECIFIER):
+            self._visit_class_specifier(node)
+            return  # children are visited inside _visit_class_specifier
+        if t == self._FUNCTION_DEFINITION:
+            self._visit_function_definition(node)
+            return
+        if t == self._CALL_EXPRESSION:
+            self._visit_call(node)
+            # Fall through — nested calls in arg list still walked.
+        for child in node.children:
+            self.walk(child)
+
+    # ------------------------------------------------------------------
+    # Class / struct
+    # ------------------------------------------------------------------
+
+    def _visit_class_specifier(self, node) -> None:
+        name = self._class_name(node)
+        if name is None:
+            # Anonymous struct/class — skip class-stack tracking but
+            # still descend so inner calls aren't lost.
+            for c in node.children:
+                self.walk(c)
+            return
+        bases = self._extract_bases(node)
+        cdef = ClassDef(
+            name=name,
+            line=node.start_point[0] + 1,
+            bases=bases,
+            nested=bool(self._class_stack) or bool(self._enclosing),
+        )
+        # Pre-pass: collect method declarations from the class body
+        # before descending. This populates ``cdef.methods`` so that
+        # in-class call-receiver inference works on the very first
+        # call site visited; without this, the methods list would
+        # only fill as inline definitions get walked, leaving early
+        # calls untagged.
+        self._collect_method_declarations(node, cdef)
+        self.graph.classes.append(cdef)
+        self._class_stack.append(cdef)
+        try:
+            for child in node.children:
+                self.walk(child)
+        finally:
+            self._class_stack.pop()
+
+    def _collect_method_declarations(self, class_node, cdef: ClassDef) -> None:
+        """Scan a ``class_specifier`` / ``struct_specifier`` body for
+        method *declarations* (in addition to any inline definitions
+        already in the body). A method declaration is a
+        ``field_declaration`` that wraps a ``function_declarator``.
+
+        Out-of-line definitions don't appear here; the in-class
+        declaration is the load-bearing record for the method's
+        existence as far as receiver-class inference is concerned.
+        """
+        body = None
+        for c in class_node.children:
+            if c.type == self._FIELD_DECLARATION_LIST:
+                body = c
+                break
+        if body is None:
+            return
+        # Methods declared inside a class body come in two shapes:
+        #   * ``field_declaration`` — normal methods (have a return
+        #     type child + function_declarator child).
+        #   * ``declaration`` — destructors and constructors (no
+        #     return type, so the grammar doesn't fit the
+        #     ``field_declaration`` shape).
+        for member in body.children:
+            if member.type not in (self._FIELD_DECLARATION, "declaration"):
+                continue
+            for sub in member.children:
+                if sub.type == self._FUNCTION_DECLARATOR:
+                    name = self._declarator_name_cpp(sub)
+                    if name:
+                        cdef.methods.append(
+                            (name, member.start_point[0] + 1),
+                        )
+
+    def _class_name(self, node) -> Optional[str]:
+        # class_specifier: "class" type_identifier base_class_clause? body
+        for c in node.children:
+            if c.type == self._TYPE_IDENTIFIER:
+                return c.text.decode("utf-8", errors="replace")
+        return None
+
+    def _extract_bases(self, node) -> List[str]:
+        """Parse ``: public Foo, protected Bar`` into ``["Foo",
+        "Bar"]``. Access specifiers are dropped; only the type names
+        survive."""
+        bases: List[str] = []
+        for c in node.children:
+            if c.type != self._BASE_CLASS_CLAUSE:
+                continue
+            for sub in c.children:
+                if not sub.is_named:
+                    continue
+                if sub.type == self._TYPE_IDENTIFIER:
+                    bases.append(sub.text.decode("utf-8", errors="replace"))
+                elif sub.type == self._QUALIFIED_IDENTIFIER:
+                    parts = self._qualified_parts(sub)
+                    if parts:
+                        bases.append("::".join(parts))
+        return bases
+
+    # ------------------------------------------------------------------
+    # Function definitions
+    # ------------------------------------------------------------------
+
+    def _visit_function_definition(self, node) -> None:
+        name = self._function_name(node)
+        qualified_class = self._qualified_class_from_declarator(node)
+        if name is None:
+            # Couldn't resolve; still descend to catch nested calls.
+            for c in node.children:
+                self.walk(c)
+            return
+
+        # In-class inline method: record method on the current class.
+        if self._class_stack and qualified_class is None:
+            self._class_stack[-1].methods.append(
+                (name, node.start_point[0] + 1),
+            )
+
+        # Push enclosing function name. For out-of-line methods, also
+        # synthesise a transient ClassDef-like context so calls inside
+        # tag receiver_class correctly. The synthetic ClassDef
+        # inherits the *real* class's methods list (looked up by name
+        # from already-collected classes); without that inheritance,
+        # bare in-class call inference (e.g. ``setup()`` inside
+        # ``Widget::run``, where ``setup`` is a sibling method) can't
+        # fire because the synthetic's methods list would be empty.
+        # Forward references (out-of-line definition appears before
+        # the class declaration) degrade to empty-methods — a real
+        # but accepted gap; the lookup falls back to the body-walk
+        # collecting the class later in the file, which then helps
+        # any subsequent definitions.
+        synthetic_class: Optional[ClassDef] = None
+        if qualified_class is not None and not self._class_in_stack(qualified_class):
+            real = self._lookup_class(qualified_class)
+            if real is not None:
+                synthetic_class = ClassDef(
+                    name=qualified_class,
+                    line=real.line,
+                    bases=list(real.bases),
+                    methods=list(real.methods),
+                    nested=real.nested,
+                )
+            else:
+                synthetic_class = ClassDef(
+                    name=qualified_class, line=0, nested=False,
+                )
+            self._class_stack.append(synthetic_class)
+        self._enclosing.append(name)
+        try:
+            for c in node.children:
+                self.walk(c)
+        finally:
+            self._enclosing.pop()
+            if synthetic_class is not None:
+                # The synthetic class is the top of the stack iff no
+                # other class_specifier pushed during the body.
+                if (self._class_stack
+                        and self._class_stack[-1] is synthetic_class):
+                    self._class_stack.pop()
+
+    def _class_in_stack(self, name: str) -> bool:
+        return any(c.name == name for c in self._class_stack)
+
+    def _lookup_class(self, name: str) -> Optional[ClassDef]:
+        """Find a previously-recorded class by name. Returns None on
+        forward references (the class hasn't been visited yet)."""
+        for c in self.graph.classes:
+            if c.name == name:
+                return c
+        return None
+
+    def _function_name(self, fn_def_node) -> Optional[str]:
+        """C++ declarators can be qualified (``Foo::bar``), template-
+        parameterised, or destructors (``~Foo``). Walk through wrapping
+        declarators to find the innermost name."""
+        for c in fn_def_node.children:
+            if not c.is_named:
+                continue
+            if c.type == self._FUNCTION_DECLARATOR:
+                return self._declarator_name_cpp(c)
+            if c.type == self._POINTER_DECLARATOR:
+                inner = self._find_function_declarator(c)
+                if inner is not None:
+                    return self._declarator_name_cpp(inner)
+        return None
+
+    def _declarator_name_cpp(self, fn_declarator_node) -> Optional[str]:
+        """Like the C version but accepts qualified_identifier
+        (returns just the trailing name), destructor_name, and
+        operator_name."""
+        for c in fn_declarator_node.children:
+            if not c.is_named:
+                continue
+            if c.type == self._IDENTIFIER:
+                return c.text.decode("utf-8", errors="replace")
+            if c.type == self._FIELD_IDENTIFIER:
+                return c.text.decode("utf-8", errors="replace")
+            if c.type == self._QUALIFIED_IDENTIFIER:
+                parts = self._qualified_parts(c)
+                if parts:
+                    return parts[-1]
+            if c.type == self._DESTRUCTOR_NAME:
+                return c.text.decode("utf-8", errors="replace")
+            if c.type == self._OPERATOR_NAME:
+                return c.text.decode("utf-8", errors="replace")
+            if c.type == self._PARENTHESIZED_DECLARATOR:
+                inner = self._first_named_child(c)
+                if inner is not None:
+                    if inner.type == self._IDENTIFIER:
+                        return inner.text.decode("utf-8", errors="replace")
+                    if inner.type == self._QUALIFIED_IDENTIFIER:
+                        parts = self._qualified_parts(inner)
+                        if parts:
+                            return parts[-1]
+        return None
+
+    def _qualified_class_from_declarator(self, fn_def_node) -> Optional[str]:
+        """If the function's declarator is ``Foo::bar`` (out-of-line
+        method), return ``"Foo"``. Otherwise None."""
+        for c in fn_def_node.children:
+            if not c.is_named:
+                continue
+            if c.type == self._FUNCTION_DECLARATOR:
+                return self._qualified_class_from_fn_declarator(c)
+            if c.type == self._POINTER_DECLARATOR:
+                inner = self._find_function_declarator(c)
+                if inner is not None:
+                    return self._qualified_class_from_fn_declarator(inner)
+        return None
+
+    def _qualified_class_from_fn_declarator(self, fn_declarator_node) -> Optional[str]:
+        for c in fn_declarator_node.children:
+            if not c.is_named:
+                continue
+            if c.type == self._QUALIFIED_IDENTIFIER:
+                parts = self._qualified_parts(c)
+                if len(parts) >= 2:
+                    # ``A::B::method`` → out-of-line method of ``B``.
+                    return parts[-2]
+        return None
+
+    # ------------------------------------------------------------------
+    # Qualified-identifier parsing
+    # ------------------------------------------------------------------
+
+    def _qualified_parts(self, qualified_node) -> List[str]:
+        """``Foo::bar`` → ``["Foo", "bar"]``;
+        ``ns::sub::fn`` → ``["ns", "sub", "fn"]``.
+
+        Tree-sitter-cpp models this recursively: ``qualified_identifier``
+        has ``namespace_identifier`` + nested ``qualified_identifier``
+        or terminal ``identifier`` / ``destructor_name`` /
+        ``field_identifier`` / ``template_function``."""
+        parts: List[str] = []
+        cur = qualified_node
+        while cur is not None and cur.type == self._QUALIFIED_IDENTIFIER:
+            # Pre-order children: namespace_identifier, then nested.
+            head = None
+            tail = None
+            for c in cur.children:
+                if not c.is_named:
+                    continue
+                if head is None:
+                    head = c
+                else:
+                    tail = c
+                    break
+            if head is None:
+                return parts
+            parts.append(self._name_token(head))
+            cur = tail
+        if cur is None:
+            return [p for p in parts if p]
+        # Terminal at the right-hand side.
+        last = self._name_token(cur)
+        if last:
+            parts.append(last)
+        return [p for p in parts if p]
+
+    def _name_token(self, node) -> str:
+        """Extract a printable name from any of the leaf-name node
+        types tree-sitter-cpp uses inside qualified expressions."""
+        if node.type in (
+            self._IDENTIFIER, self._NAMESPACE_IDENTIFIER,
+            self._TYPE_IDENTIFIER, self._FIELD_IDENTIFIER,
+            self._DESTRUCTOR_NAME, self._OPERATOR_NAME,
+        ):
+            return node.text.decode("utf-8", errors="replace")
+        if node.type in (self._TEMPLATE_TYPE, self._TEMPLATE_FUNCTION):
+            # ``vector<int>`` / ``f<T>`` — emit the bare name; drop
+            # template args (out of scope this revision).
+            for c in node.children:
+                if not c.is_named:
+                    continue
+                if c.type in (self._IDENTIFIER, self._TYPE_IDENTIFIER):
+                    return c.text.decode("utf-8", errors="replace")
+            return ""
+        return ""
+
+    # ------------------------------------------------------------------
+    # Calls (override to set receiver_class + handle qualified callees)
+    # ------------------------------------------------------------------
+
+    def _callee_chain(self, node) -> Tuple[Optional[List[str]], bool]:
+        # Extension: qualified_identifier as a callee.
+        if node.type == self._QUALIFIED_IDENTIFIER:
+            parts = self._qualified_parts(node)
+            return (parts if parts else None), False
+        if node.type == self._FIELD_EXPRESSION:
+            # Override C base: field_expression in C++ may root on
+            # ``this`` (own node type) rather than an identifier.
+            return self._field_chain_cpp(node), False
+        return super()._callee_chain(node)
+
+    def _field_chain_cpp(self, node) -> Optional[List[str]]:
+        """C++ ``a.b.c`` / ``a->b->c`` / ``this->member`` resolution.
+
+        Same as the C base's ``_field_chain`` but accepts ``this`` as
+        a terminal (rendered as the literal string ``"this"`` in the
+        chain), and handles a qualified_identifier at the root
+        (``ns::var.field`` is legal C++)."""
+        parts: List[str] = []
+        cur = node
+        while cur is not None and cur.type == self._FIELD_EXPRESSION:
+            field_node = None
+            for c in cur.children:
+                if c.type == self._FIELD_IDENTIFIER:
+                    field_node = c
+            if field_node is None:
+                return None
+            parts.append(field_node.text.decode("utf-8", errors="replace"))
+            operand = None
+            for c in cur.children:
+                if c.is_named and c.type != self._FIELD_IDENTIFIER:
+                    operand = c
+                    break
+            cur = operand
+        if cur is None:
+            return None
+        if cur.type == self._IDENTIFIER:
+            parts.append(cur.text.decode("utf-8", errors="replace"))
+            return list(reversed(parts))
+        if cur.type == self._THIS:
+            parts.append("this")
+            return list(reversed(parts))
+        if cur.type == self._QUALIFIED_IDENTIFIER:
+            head = self._qualified_parts(cur)
+            if not head:
+                return None
+            return head + list(reversed(parts))
+        return None
+
+    def _visit_call(self, node) -> None:
+        callee_node = None
+        for c in node.children:
+            if c.type == "argument_list":
+                break
+            if c.is_named:
+                callee_node = c
+                break
+        if callee_node is None:
+            return
+
+        chain, is_fn_pointer = self._callee_chain(callee_node)
+        if chain is None:
+            return
+
+        if is_fn_pointer:
+            self.graph.indirection.add(INDIRECTION_FN_POINTER)
+
+        caller = self._enclosing[-1] if self._enclosing else None
+        receiver_class = self._infer_receiver_class(chain)
+
+        self.graph.calls.append(CallSite(
+            line=node.start_point[0] + 1,
+            chain=chain,
+            caller=caller,
+            receiver_class=receiver_class,
+        ))
+
+    def _infer_receiver_class(self, chain: List[str]) -> Optional[str]:
+        """Tag ``receiver_class`` when the callee shape pins it.
+
+        Rules (deliberately narrow to avoid wrong tags):
+          * ``this->member`` (chain == ["this", X]) → current class
+          * Inside class body, bare ``X()`` where X is in the
+            class's method list → current class
+          * Out-of-line methods (synthetic class on stack) — same
+            rules apply
+
+        We do NOT tag ``obj.method()`` calls (chain length >= 2 with
+        non-``this`` root) — the receiver type isn't statically
+        resolvable from this walk.
+        """
+        if not self._class_stack:
+            return None
+        top = self._class_stack[-1]
+        if top.nested:
+            # Mirrors Python walker's conservatism for nested classes.
+            return None
+        if len(chain) == 2 and chain[0] == "this":
+            return top.name
+        if len(chain) == 1:
+            method_names = {m[0] for m in top.methods}
+            if chain[0] in method_names:
+                return top.name
+        return None
+
+
 __all__ = [
     "CallSite",
     "FileCallGraph",
@@ -2617,10 +3533,13 @@ __all__ = [
     "INDIRECTION_DUNDER_IMPORT",
     "INDIRECTION_DYNAMIC_IMPORT",
     "INDIRECTION_EVAL",
+    "INDIRECTION_FN_POINTER",
     "INDIRECTION_GETATTR",
     "INDIRECTION_IMPORTLIB",
     "INDIRECTION_REFLECT",
     "INDIRECTION_WILDCARD_IMPORT",
+    "extract_call_graph_c",
+    "extract_call_graph_cpp",
     "extract_call_graph_csharp",
     "extract_call_graph_go",
     "extract_call_graph_java",

--- a/core/inventory/extractors.py
+++ b/core/inventory/extractors.py
@@ -561,8 +561,17 @@ def _ts_language(lang: str):
             import tree_sitter_java as ts
         elif lang in ("javascript", "typescript"):
             import tree_sitter_javascript as ts
-        elif lang in ("c", "cpp"):
+        elif lang == "c":
             import tree_sitter_c as ts
+        elif lang == "cpp":
+            # Pre-2026-05-16 this branch loaded ``tree_sitter_c``,
+            # which can't parse class / method / template / namespace
+            # / qualified-id shapes. Inline class methods and
+            # out-of-line destructors were silently dropped from
+            # ``extract_functions`` output. Using the cpp-specific
+            # grammar gives the extractor the right node types
+            # (``class_specifier``, ``destructor_name``, etc.).
+            import tree_sitter_cpp as ts
         elif lang == "go":
             import tree_sitter_go as ts
         else:
@@ -760,9 +769,49 @@ class TreeSitterExtractor:
             # C/C++: name is inside function_declarator
             if child.type == "function_declarator":
                 return self._get_name(child)
-            # Go: name is inside field_identifier for methods
+            # Go: name is inside field_identifier for methods.
+            # C++: same node type covers in-class method declarations
+            # (``void f();`` inside a class body has its name as
+            # field_identifier rather than identifier).
             if child.type == "field_identifier":
                 return child.text.decode()
+            # C++: out-of-line method definitions wrap the name in a
+            # ``qualified_identifier`` (``Foo::bar``); return the
+            # trailing component.
+            if child.type == "qualified_identifier":
+                # Walk to the rightmost name token. The grammar models
+                # nested qualified_identifier with a trailing
+                # identifier / field_identifier / destructor_name.
+                last_name = None
+                cur = child
+                while cur is not None:
+                    found_nested = False
+                    for c in cur.children:
+                        if c.type in ("identifier", "field_identifier"):
+                            last_name = c.text.decode()
+                        elif c.type == "destructor_name":
+                            last_name = c.text.decode()
+                        elif c.type == "qualified_identifier":
+                            cur = c
+                            found_nested = True
+                            break
+                    if not found_nested:
+                        break
+                if last_name:
+                    return last_name
+            # C++: destructor declaration / definition. ``~Foo()`` —
+            # the declarator's child is a ``destructor_name`` whose
+            # text includes the tilde.
+            if child.type == "destructor_name":
+                return child.text.decode()
+            # C/C++: pointer return types wrap the declarator in
+            # ``pointer_declarator``. Recurse to find the inner name.
+            # Same for parenthesized_declarator used in some
+            # complex C declarations.
+            if child.type in ("pointer_declarator", "parenthesized_declarator"):
+                inner = self._get_name(child)
+                if inner:
+                    return inner
         return None
 
     def _find_child(self, node, types: tuple):

--- a/core/inventory/tests/test_call_graph_c.py
+++ b/core/inventory/tests/test_call_graph_c.py
@@ -1,0 +1,278 @@
+"""Tests for ``extract_call_graph_c``.
+
+The walker is structural: tree-sitter parses the file, the
+``_CCallGraph`` visitor extracts includes, function definitions,
+calls, and a few indirection signals. Tests pin the shapes the
+caller (``core.ast.view``, the reachability resolver, and the
+audit pipeline) relies on.
+
+The whole walker degrades to an empty :class:`FileCallGraph` when
+``tree_sitter_c`` isn't available; one test pins that contract
+without actually uninstalling the grammar.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.inventory.call_graph import (
+    INDIRECTION_FN_POINTER,
+    extract_call_graph_c,
+)
+
+
+pytest.importorskip("tree_sitter_c")
+
+
+# ---------------------------------------------------------------------------
+# Includes → imports
+# ---------------------------------------------------------------------------
+
+
+class TestIncludes:
+    """``#include`` is the closest thing C has to an import. The
+    walker records the included header keyed by its basename so the
+    resolver can match ``foo`` → ``foo.h`` at call sites."""
+
+    def test_system_include_uses_basename(self):
+        g = extract_call_graph_c('#include <stdio.h>\n')
+        assert g.imports == {"stdio": "stdio.h"}
+
+    def test_quoted_include_uses_basename(self):
+        g = extract_call_graph_c('#include "foo.h"\n')
+        assert g.imports == {"foo": "foo.h"}
+
+    def test_nested_include_preserves_full_path(self):
+        g = extract_call_graph_c('#include "net/dst.h"\n')
+        # basename without extension becomes the binding name; full
+        # path preserved as the qualified target.
+        assert g.imports == {"dst": "net/dst.h"}
+
+    def test_multiple_includes_collected(self):
+        g = extract_call_graph_c(
+            '#include <stdio.h>\n'
+            '#include <stdlib.h>\n'
+            '#include "internal/list.h"\n'
+        )
+        assert g.imports == {
+            "stdio": "stdio.h",
+            "stdlib": "stdlib.h",
+            "list": "internal/list.h",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Function definitions → caller field on calls
+# ---------------------------------------------------------------------------
+
+
+class TestFunctionScope:
+    """Every call gets a ``caller`` of the lexically-enclosing
+    function's name (or None for file-scope initialisers)."""
+
+    def test_caller_is_enclosing_function(self):
+        g = extract_call_graph_c(
+            'int helper(int x) { return x + 1; }\n'
+            'int main(void) { helper(3); return 0; }\n'
+        )
+        calls_to_helper = [c for c in g.calls if c.chain == ["helper"]]
+        assert len(calls_to_helper) == 1
+        assert calls_to_helper[0].caller == "main"
+
+    def test_pointer_return_type_function_name(self):
+        # ``char *strdup(...) {}`` — the function declarator is
+        # wrapped in a pointer_declarator; the walker descends.
+        g = extract_call_graph_c(
+            'char *upper(char *s) { return s; }\n'
+            'void caller(void) { upper("x"); }\n'
+        )
+        calls = [c for c in g.calls if c.chain == ["upper"]]
+        assert len(calls) == 1
+        assert calls[0].caller == "caller"
+
+    def test_static_function(self):
+        g = extract_call_graph_c(
+            'static void inner(void) {}\n'
+            'void outer(void) { inner(); }\n'
+        )
+        assert any(
+            c.chain == ["inner"] and c.caller == "outer"
+            for c in g.calls
+        )
+
+    def test_file_scope_caller_is_none(self):
+        # File-scope initialiser calls have no enclosing function.
+        # Tree-sitter parses initialiser calls as call_expression
+        # in the declaration's initializer; they reach _visit_call
+        # with an empty _enclosing stack.
+        g = extract_call_graph_c(
+            'extern int seed(void);\n'
+            'int x = seed();\n'  # this call's caller should be None
+        )
+        seed_calls = [c for c in g.calls if c.chain == ["seed"]]
+        assert seed_calls, "file-scope initialiser call missing"
+        assert seed_calls[0].caller is None
+
+
+# ---------------------------------------------------------------------------
+# Field expressions
+# ---------------------------------------------------------------------------
+
+
+class TestFieldExpressions:
+    """``obj.method(...)`` and ``obj->method(...)`` chain through
+    field expressions; the walker resolves them to attribute chains."""
+
+    def test_dot_field(self):
+        g = extract_call_graph_c(
+            'void f(struct s o) { o.method(); }\n'
+        )
+        match = [c for c in g.calls if c.chain == ["o", "method"]]
+        assert len(match) == 1, g.calls
+
+    def test_arrow_field(self):
+        g = extract_call_graph_c(
+            'void f(struct s *o) { o->method(); }\n'
+        )
+        match = [c for c in g.calls if c.chain == ["o", "method"]]
+        assert len(match) == 1, g.calls
+
+    def test_chained_arrow(self):
+        g = extract_call_graph_c(
+            'void f(struct s *o) { o->a->b(); }\n'
+        )
+        match = [c for c in g.calls if c.chain == ["o", "a", "b"]]
+        assert len(match) == 1, g.calls
+
+    def test_mixed_dot_arrow(self):
+        g = extract_call_graph_c(
+            'void f(struct s *o) { o->a.b(); }\n'
+        )
+        match = [c for c in g.calls if c.chain == ["o", "a", "b"]]
+        assert len(match) == 1, g.calls
+
+
+# ---------------------------------------------------------------------------
+# Function-pointer calls → INDIRECTION_FN_POINTER
+# ---------------------------------------------------------------------------
+
+
+class TestFunctionPointers:
+    """``(*fp)(...)`` is the syntactic shape recognised as an
+    indirect call. Bare ``fp()`` is statically indistinguishable
+    from a direct call and emitted as such."""
+
+    def test_explicit_pointer_call_marks_indirection(self):
+        g = extract_call_graph_c(
+            'void f(int (*fp)(int)) { (*fp)(7); }\n'
+        )
+        assert INDIRECTION_FN_POINTER in g.indirection
+        # Chain still recorded.
+        assert any(c.chain == ["fp"] for c in g.calls)
+
+    def test_bare_pointer_call_no_indirection_flag(self):
+        # We can't tell ``fp(7)`` is indirect without type resolution.
+        # Walker emits it as a regular call; the indirection set
+        # stays clean.
+        g = extract_call_graph_c(
+            'void f(int (*fp)(int)) { fp(7); }\n'
+        )
+        assert INDIRECTION_FN_POINTER not in g.indirection
+        assert any(c.chain == ["fp"] for c in g.calls)
+
+
+# ---------------------------------------------------------------------------
+# Line numbers
+# ---------------------------------------------------------------------------
+
+
+class TestLineNumbers:
+    """Lines are 1-indexed (tree-sitter is 0-indexed; walker adds 1).
+    A drift here breaks ``core.ast.view``'s range filtering."""
+
+    def test_line_1_indexed(self):
+        # Line 1 is the include; line 2 is the function; the call
+        # is on line 3.
+        src = (
+            '#include <stdio.h>\n'      # 1
+            'int main(void) {\n'        # 2
+            '    printf("hi");\n'       # 3
+            '    return 0;\n'           # 4
+            '}\n'                        # 5
+        )
+        g = extract_call_graph_c(src)
+        printf = [c for c in g.calls if c.chain == ["printf"]]
+        assert len(printf) == 1
+        assert printf[0].line == 3
+
+
+# ---------------------------------------------------------------------------
+# Macros that look like calls
+# ---------------------------------------------------------------------------
+
+
+class TestMacroShapedCalls:
+    """Tree-sitter reads pre-preprocessor source. Macros like
+    ``BUG_ON(...)`` or ``container_of(...)`` parse as call
+    expressions; the walker emits them as regular calls with the
+    macro identifier as chain. Downstream consumers disambiguate via
+    the inventory's macro list."""
+
+    def test_macro_looking_call_is_emitted(self):
+        g = extract_call_graph_c(
+            '#define BUG_ON(x) do { if (x) panic(); } while (0)\n'
+            'void f(int n) { BUG_ON(n < 0); }\n'
+        )
+        bug_on = [c for c in g.calls if c.chain == ["BUG_ON"]]
+        # Don't pin caller for now — depends on whether the macro
+        # definition itself is parsed as a function_definition or as
+        # a preproc_def. The contract is "emit the call".
+        assert bug_on, g.calls
+
+
+# ---------------------------------------------------------------------------
+# Parse failures + missing grammar
+# ---------------------------------------------------------------------------
+
+
+class TestRobustness:
+    """Malformed input shouldn't crash the walker. The contract is
+    "return empty graph"."""
+
+    def test_empty_input(self):
+        g = extract_call_graph_c("")
+        assert g.imports == {} and g.calls == []
+
+    def test_random_garbage_is_partial_or_empty(self):
+        # Tree-sitter is error-tolerant — it'll parse what it can.
+        # The walker should never raise.
+        g = extract_call_graph_c("@@@ this is not C @@@\n")
+        # Empty or partial — either is acceptable.
+        assert isinstance(g.imports, dict)
+        assert isinstance(g.calls, list)
+
+
+# ---------------------------------------------------------------------------
+# Schema contract for downstream consumers
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaContract:
+    """Pin that the new walker populates the field set
+    ``core.ast.view`` and the reachability resolver expect, and
+    leaves Python-/Java-specific extras empty."""
+
+    def test_c_walker_leaves_python_fields_empty(self):
+        g = extract_call_graph_c(
+            'int main(void) { return 0; }\n'
+        )
+        assert g.classes == []
+        assert g.decorated_functions == []
+        assert g.relative_imports == []
+
+    def test_callsite_receiver_class_always_none_in_c(self):
+        # C has no classes — receiver_class is None for every call.
+        g = extract_call_graph_c(
+            'void f(void) { g(); h(); i(); }\n'
+        )
+        assert all(c.receiver_class is None for c in g.calls)

--- a/core/inventory/tests/test_call_graph_cpp.py
+++ b/core/inventory/tests/test_call_graph_cpp.py
@@ -1,0 +1,312 @@
+"""Tests for ``extract_call_graph_cpp``.
+
+The C++ walker subclasses the C base, so the C tests cover the
+shared shapes (includes, function pointers, field expressions).
+This file pins the C++-specific extensions:
+
+  * ``class_specifier`` / ``struct_specifier`` → ``ClassDef``
+  * Method declarations populate ``ClassDef.methods``
+  * ``qualified_identifier`` (``Foo::bar``, ``std::cout``)
+  * ``this->member`` → ``receiver_class`` tag
+  * Bare in-class call to a sibling method → ``receiver_class``
+  * Out-of-line definitions (``int Foo::bar() {...}``) push a
+    synthetic class so calls inside get the right receiver tag
+  * Destructors
+  * Bases with access specifiers
+  * Namespaces (transparent)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.inventory.call_graph import (
+    INDIRECTION_FN_POINTER,
+    extract_call_graph_cpp,
+)
+
+
+pytest.importorskip("tree_sitter_cpp")
+
+
+# ---------------------------------------------------------------------------
+# Classes — ClassDef entries
+# ---------------------------------------------------------------------------
+
+
+class TestClassDef:
+    def test_class_recorded(self):
+        g = extract_call_graph_cpp(
+            'class Widget { public: void f(); };\n'
+        )
+        assert len(g.classes) == 1
+        assert g.classes[0].name == "Widget"
+        assert g.classes[0].nested is False
+
+    def test_struct_recorded(self):
+        # struct_specifier should produce a ClassDef the same way
+        # class_specifier does — C++ semantics for structs match
+        # classes (modulo default access).
+        g = extract_call_graph_cpp(
+            'struct S { void f(); };\n'
+        )
+        names = [c.name for c in g.classes]
+        assert "S" in names, g.classes
+
+    def test_nested_class_marked_nested(self):
+        g = extract_call_graph_cpp(
+            'class Outer { class Inner { void f(); }; };\n'
+        )
+        inner = next(c for c in g.classes if c.name == "Inner")
+        outer = next(c for c in g.classes if c.name == "Outer")
+        assert outer.nested is False
+        assert inner.nested is True
+
+    def test_anonymous_struct_skipped_in_class_list(self):
+        # ``struct { int x; } var;`` has no type identifier. We
+        # don't record an anonymous ClassDef but still descend so
+        # any nested calls aren't lost.
+        g = extract_call_graph_cpp(
+            'struct { int x; } var;\n'
+            'void f() { use(var); }\n'
+        )
+        assert g.classes == []
+        # The call inside f is still picked up.
+        assert any(c.chain == ["use"] for c in g.calls)
+
+
+# ---------------------------------------------------------------------------
+# Method declarations → methods list
+# ---------------------------------------------------------------------------
+
+
+class TestMethods:
+    def test_declared_methods_listed(self):
+        g = extract_call_graph_cpp(
+            'class W {\n'
+            'public:\n'
+            '    void setup();\n'
+            '    int run(int x);\n'
+            '};\n'
+        )
+        w = g.classes[0]
+        names = [m[0] for m in w.methods]
+        assert "setup" in names
+        assert "run" in names
+
+    def test_destructor_listed(self):
+        # Destructors parse as ``declaration`` (no return type), not
+        # as ``field_declaration`` — pin that the walker handles
+        # both shapes.
+        g = extract_call_graph_cpp(
+            'class W { void f(); ~W(); };\n'
+        )
+        names = [m[0] for m in g.classes[0].methods]
+        assert "~W" in names, g.classes[0].methods
+
+    def test_method_line_recorded(self):
+        g = extract_call_graph_cpp(
+            'class W {\n'   # 1
+            '    void f();\n'  # 2
+            '};\n'             # 3
+        )
+        f = next(m for m in g.classes[0].methods if m[0] == "f")
+        assert f[1] == 2
+
+
+# ---------------------------------------------------------------------------
+# Base classes
+# ---------------------------------------------------------------------------
+
+
+class TestBases:
+    def test_single_base_no_access_specifier(self):
+        g = extract_call_graph_cpp(
+            'class D : Base { void f(); };\n'
+        )
+        assert g.classes[0].bases == ["Base"]
+
+    def test_multiple_bases_with_access_specifiers(self):
+        g = extract_call_graph_cpp(
+            'class D : public A, protected B { void f(); };\n'
+        )
+        assert g.classes[0].bases == ["A", "B"]
+
+    def test_qualified_base(self):
+        g = extract_call_graph_cpp(
+            'class D : public mixins::M { void f(); };\n'
+        )
+        assert g.classes[0].bases == ["mixins::M"]
+
+
+# ---------------------------------------------------------------------------
+# this->member — receiver_class tagging
+# ---------------------------------------------------------------------------
+
+
+class TestThisCall:
+    def test_this_arrow_member_in_inline_method(self):
+        g = extract_call_graph_cpp(
+            'class W {\n'
+            'public:\n'
+            '    void setup() {}\n'
+            '    void run() { this->setup(); }\n'
+            '};\n'
+        )
+        call = next(c for c in g.calls if c.chain == ["this", "setup"])
+        assert call.caller == "run"
+        assert call.receiver_class == "W"
+
+    def test_this_arrow_in_out_of_line_method(self):
+        g = extract_call_graph_cpp(
+            'class W { public: void setup(); void run(); };\n'
+            'void W::setup() {}\n'
+            'void W::run() { this->setup(); }\n'
+        )
+        call = next(c for c in g.calls if c.chain == ["this", "setup"])
+        assert call.caller == "run"
+        assert call.receiver_class == "W"
+
+
+# ---------------------------------------------------------------------------
+# Bare in-class call — receiver_class tagging
+# ---------------------------------------------------------------------------
+
+
+class TestBareInClassCall:
+    """A bare ``method()`` call from inside a class member function
+    refers to ``this->method()`` if ``method`` is a sibling member.
+    The walker tags receiver_class iff the bare name is in the
+    class's method list (collected in the pre-pass)."""
+
+    def test_bare_call_to_sibling_method(self):
+        g = extract_call_graph_cpp(
+            'class W {\n'
+            'public:\n'
+            '    void helper() {}\n'
+            '    void run() { helper(); }\n'
+            '};\n'
+        )
+        helper_calls = [c for c in g.calls if c.chain == ["helper"]]
+        # The relevant call site is inside W::run.
+        from_run = [c for c in helper_calls if c.caller == "run"]
+        assert from_run, helper_calls
+        assert from_run[0].receiver_class == "W"
+
+    def test_bare_call_to_free_function_no_receiver_tag(self):
+        g = extract_call_graph_cpp(
+            'void helper() {}\n'
+            'class W {\n'
+            'public:\n'
+            '    void run() { helper(); }\n'  # not a W method
+            '};\n'
+        )
+        helper_calls = [c for c in g.calls if c.chain == ["helper"]]
+        from_run = [c for c in helper_calls if c.caller == "run"]
+        assert from_run, helper_calls
+        # ``helper`` is a free function, not a W method → no tag.
+        assert from_run[0].receiver_class is None
+
+
+# ---------------------------------------------------------------------------
+# Qualified identifiers
+# ---------------------------------------------------------------------------
+
+
+class TestQualifiedIdentifier:
+    def test_two_level_qualified_call(self):
+        g = extract_call_graph_cpp(
+            'namespace ns { void f() {} }\n'
+            'void caller() { ns::f(); }\n'
+        )
+        # ns::f() → chain ["ns", "f"]
+        call = next(c for c in g.calls if c.chain == ["ns", "f"])
+        assert call.caller == "caller"
+
+    def test_three_level_qualified_call(self):
+        g = extract_call_graph_cpp(
+            'void caller() { a::b::c(); }\n'
+        )
+        assert any(c.chain == ["a", "b", "c"] for c in g.calls)
+
+    def test_std_namespace_call(self):
+        # ``std::sort(...)`` should chain as ["std", "sort"].
+        g = extract_call_graph_cpp(
+            '#include <algorithm>\n'
+            'void caller() { std::sort(nullptr, nullptr); }\n'
+        )
+        assert any(c.chain == ["std", "sort"] for c in g.calls)
+
+
+# ---------------------------------------------------------------------------
+# Out-of-line method definitions
+# ---------------------------------------------------------------------------
+
+
+class TestOutOfLineMethod:
+    def test_out_of_line_definition_caller_is_method_name(self):
+        # ``void W::run() {...}`` — the caller for inner calls is
+        # ``run``, NOT ``W::run``. This matches the C-side convention
+        # of caller = bare function name.
+        g = extract_call_graph_cpp(
+            'class W { public: void run(); };\n'
+            'void W::run() { helper(); }\n'
+        )
+        calls = [c for c in g.calls if c.chain == ["helper"]]
+        assert len(calls) == 1
+        assert calls[0].caller == "run"
+
+    def test_out_of_line_destructor_caller(self):
+        g = extract_call_graph_cpp(
+            'class W { public: ~W(); };\n'
+            'W::~W() { cleanup(); }\n'
+        )
+        calls = [c for c in g.calls if c.chain == ["cleanup"]]
+        assert len(calls) == 1
+        assert calls[0].caller == "~W"
+
+
+# ---------------------------------------------------------------------------
+# C base inheritance — make sure C-style constructs still work
+# ---------------------------------------------------------------------------
+
+
+class TestCInheritanceInCpp:
+    """The C++ walker subclasses the C base. Sanity-check that C-style
+    constructs still extract correctly when the file is parsed as
+    C++."""
+
+    def test_includes_still_work(self):
+        g = extract_call_graph_cpp(
+            '#include <iostream>\n#include "foo.h"\n'
+        )
+        assert g.imports == {"iostream": "iostream", "foo": "foo.h"}
+
+    def test_function_pointer_indirection(self):
+        g = extract_call_graph_cpp(
+            'void f(int (*fp)(int)) { (*fp)(7); }\n'
+        )
+        assert INDIRECTION_FN_POINTER in g.indirection
+
+    def test_arrow_field_access_in_function(self):
+        g = extract_call_graph_cpp(
+            'struct s { int x; };\n'
+            'void f(struct s *o) { o->x; }\n'
+        )
+        # No call site (just an expression statement) — sanity check
+        # that the walker doesn't crash.
+        assert isinstance(g.imports, dict)
+
+
+# ---------------------------------------------------------------------------
+# Schema fields for downstream consumers
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaContract:
+    def test_python_specific_fields_remain_empty(self):
+        g = extract_call_graph_cpp(
+            'class W { public: void f(); };\n'
+        )
+        assert g.decorated_functions == []
+        assert g.relative_imports == []

--- a/core/inventory/tests/test_extractors.py
+++ b/core/inventory/tests/test_extractors.py
@@ -265,3 +265,87 @@ class TestTreeSitter:
     def test_ts_languages_available(self):
         langs = _get_ts_languages()
         assert "python" in langs
+
+
+class TestCppTreeSitter:
+    """Pin the C++ extraction fixes landed alongside ``core.ast`` (PR
+    ``feat/core-ast``):
+
+      * ``_ts_language("cpp")`` now loads ``tree_sitter_cpp`` (was
+        loading ``tree_sitter_c``, which can't parse class / method
+        / template / namespace shapes).
+      * ``_get_name`` handles the C++ declarator shapes the cpp
+        grammar produces: ``qualified_identifier`` (out-of-line
+        methods), ``destructor_name`` (``~Foo``),
+        ``pointer_declarator`` / ``parenthesized_declarator`` wraps.
+
+    Direct extractor coverage (the ``core.ast`` view tests cover
+    this indirectly; pinning here makes the contract explicit at the
+    layer where it lives)."""
+
+    def test_inline_class_method_extracted(self):
+        # Previously emitted only the class name because the C
+        # grammar couldn't parse the class body. Now: the inline
+        # method ``m`` should be in the output.
+        src = "class A { public: void m() { foo(); } };\n"
+        funcs = extract_functions("t.cpp", "cpp", src)
+        names = [f.name for f in funcs]
+        assert "m" in names, names
+
+    def test_inline_class_methods_with_name_collision(self):
+        # Two classes, both with a method called ``m``. Both must
+        # appear as separate entries so callers can disambiguate by
+        # line range.
+        src = (
+            "class A { public: void m() {} };\n"
+            "class B { public: void m() {} };\n"
+        )
+        funcs = extract_functions("t.cpp", "cpp", src)
+        m_entries = [f for f in funcs if f.name == "m"]
+        assert len(m_entries) == 2
+        # The two ``m`` entries occupy different line ranges.
+        assert m_entries[0].line_start != m_entries[1].line_start
+
+    def test_out_of_line_method_keeps_bare_name(self):
+        # ``void W::setup() {...}`` — the function declarator's name
+        # is a qualified_identifier. _get_name walks to the trailing
+        # ``setup`` and returns the bare name (matches the C-side
+        # convention of caller-tracking by bare name).
+        src = (
+            "class W { public: void setup(); };\n"
+            "void W::setup() { helper(); }\n"
+        )
+        funcs = extract_functions("t.cpp", "cpp", src)
+        names = [f.name for f in funcs]
+        assert "setup" in names
+
+    def test_out_of_line_destructor_named_with_tilde(self):
+        # ``W::~W() {...}`` — destructor_name (`~W`) is the inner
+        # child of the qualified_identifier. _get_name returns the
+        # destructor name verbatim, including the tilde.
+        src = (
+            "class W { public: ~W(); };\n"
+            "W::~W() { cleanup(); }\n"
+        )
+        funcs = extract_functions("t.cpp", "cpp", src)
+        names = [f.name for f in funcs]
+        assert "~W" in names
+
+    def test_namespaced_function_definition(self):
+        # ``namespace ns { void f() {...} }`` — the function inside
+        # the namespace is extracted with its bare name. We don't
+        # qualify with the namespace (matches the inventory's
+        # name-resolution convention).
+        src = "namespace ns { void f() { helper(); } }\n"
+        funcs = extract_functions("t.cpp", "cpp", src)
+        names = [f.name for f in funcs]
+        assert "f" in names
+
+    def test_pointer_return_type_function_name(self):
+        # ``char *strdup(...) {...}`` — the declarator is wrapped in
+        # a pointer_declarator. _get_name recurses through and finds
+        # the inner name.
+        src = "char *upper(char *s) { return s; }\n"
+        funcs = extract_functions("t.cpp", "cpp", src)
+        names = [f.name for f in funcs]
+        assert "upper" in names

--- a/core/inventory/tests/test_extractors.py
+++ b/core/inventory/tests/test_extractors.py
@@ -267,6 +267,18 @@ class TestTreeSitter:
         assert "python" in langs
 
 
+def _has_tree_sitter_cpp() -> bool:
+    try:
+        import tree_sitter_cpp  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(
+    not _has_tree_sitter_cpp(),
+    reason="tree_sitter_cpp grammar not installed",
+)
 class TestCppTreeSitter:
     """Pin the C++ extraction fixes landed alongside ``core.ast`` (PR
     ``feat/core-ast``):

--- a/libexec/raptor-ast
+++ b/libexec/raptor-ast
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Structured per-function AST view.
+
+Usage:
+  raptor-ast --file <path> --function <name> [--at-line <n>] [--language <lang>] [--json|--text]
+
+Returns a structured view of one function (signature, calls made, returns,
+inline-asm flag). See ``core.ast`` package docstring for the full schema.
+
+Exit codes:
+  0   view emitted
+  1   function not found / file unreadable / language unknown
+  2   usage error
+
+Language coverage at this revision:
+  Calls + returns + asm:  c, cpp
+  Calls + returns:        python, javascript, java, go
+  Calls only:             rust, ruby, csharp, php, typescript
+
+The view is computed by ``core.ast.view`` — a composition over the
+inventory substrate. See the ``core/ast/`` package for the API.
+"""
+import sys
+from pathlib import Path
+
+# ─── trust-marker check (do not import; inline by design) ───
+import os
+if not (os.environ.get("CLAUDECODE")
+        or os.environ.get("_RAPTOR_TRUSTED")):
+    sys.stderr.write(
+        f"{sys.argv[0]}: internal dispatch script.\n"
+        "  Run via 'bin/raptor' instead.\n"
+        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
+    )
+    sys.exit(2)
+# ─── end trust-marker check ─────────────────────────────────
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import argparse
+import json
+
+from core.ast import view, FunctionView
+
+
+def _render_text(fv: FunctionView) -> str:
+    """Human-friendly rendering for operator inspection.
+
+    JSON is the default for machine consumers (``/understand``,
+    ``/audit``); --text is the alternate when an operator runs the
+    shim directly and wants to skim the structure.
+    """
+    out = [
+        f"function:  {fv.function}",
+        f"file:      {fv.file}",
+        f"language:  {fv.language}",
+        f"lines:     {fv.lines[0]}-{fv.lines[1]}",
+        f"signature: {fv.signature}",
+        f"inline asm: {'yes' if fv.has_inline_asm else 'no'}",
+    ]
+    if fv.calls_made:
+        out.append("")
+        out.append("calls made:")
+        for c in fv.calls_made:
+            chain = ".".join(c.chain) if c.chain else "?"
+            tag = f"  (in class: {c.receiver_class})" if c.receiver_class else ""
+            out.append(f"  L{c.line:<5}  {chain}{tag}")
+    else:
+        out.append("")
+        out.append("calls made: (none statically resolvable)")
+    if fv.returns:
+        out.append("")
+        out.append("returns:")
+        for r in fv.returns:
+            val = r.value_text if r.value_text else "(bare)"
+            out.append(f"  L{r.line:<5}  return {val}")
+    else:
+        out.append("")
+        out.append("returns: (none explicit)")
+    return "\n".join(out)
+
+
+def main(argv) -> int:
+    parser = argparse.ArgumentParser(
+        prog="raptor-ast",
+        description=(
+            "Structured per-function view (signature, calls, returns, "
+            "inline-asm flag). JSON by default; --text for operator "
+            "inspection."
+        ),
+    )
+    parser.add_argument(
+        "--file", required=True,
+        help="Path to the source file containing the function.",
+    )
+    parser.add_argument(
+        "--function", required=True,
+        help="Function name. Disambiguate name collisions with --at-line.",
+    )
+    parser.add_argument(
+        "--at-line", type=int, default=None,
+        help=(
+            "Line number that falls inside the desired function. Used "
+            "to disambiguate when multiple functions in the file share "
+            "the same name (e.g. methods on different classes)."
+        ),
+    )
+    parser.add_argument(
+        "--language", default=None,
+        help=(
+            "Override language detection (defaults to file-extension "
+            "lookup via core.inventory.languages.detect_language)."
+        ),
+    )
+    out_format = parser.add_mutually_exclusive_group()
+    out_format.add_argument(
+        "--json", dest="fmt", action="store_const", const="json",
+        help="Emit JSON (default).",
+    )
+    out_format.add_argument(
+        "--text", dest="fmt", action="store_const", const="text",
+        help="Emit human-readable text.",
+    )
+    parser.set_defaults(fmt="json")
+
+    args = parser.parse_args(argv)
+
+    fv = view(
+        Path(args.file),
+        args.function,
+        at_line=args.at_line,
+        language=args.language,
+    )
+    if fv is None:
+        sys.stderr.write(
+            f"raptor-ast: no view available for {args.function!r} in "
+            f"{args.file!r} "
+            f"(check that the file exists, the language is supported, "
+            f"and the function name + --at-line resolves to a known "
+            f"function)\n",
+        )
+        return 1
+
+    if args.fmt == "json":
+        print(json.dumps(fv.to_dict(), indent=2))
+    else:
+        print(_render_text(fv))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
`core/ast/view()` returns a `FunctionView` (signature, calls_made, returns, has_inline_asm) for one function in a file. Composition over `extract_functions` + `extract_call_graph_<lang>` — no duplicate per-language parsing.

Also adds two new call_graph walkers (`extract_call_graph_c`, `extract_call_graph_cpp`) + `INDIRECTION_FN_POINTER` constant. C++ extends C with classes / methods / `this->` / qualified ids / out-of-line definitions / destructors. Grammars degrade cleanly when not installed.

`libexec/raptor-ast` — CLI shim, `--json` / `--text`.

Adversarial review surfaced two pre-existing bugs in `core/inventory/extractors.py` (cpp branch loaded the C grammar; `_get_name` didn't handle qualified/destructor/pointer declarators); both fixed inline.

Language coverage:
  Calls + returns + asm:  c, cpp
  Calls + returns:        python, javascript, java, go
  Calls only:             rust, ruby, csharp, php, typescript

66 new tests; 4583 wider regression clean; 20-scenario adversarial clean; E2E verified on real Linux kernel `lib/string_helpers.c`.