### PR TITLE
feat(orchestration): wire core/ast view into /understand --map

### DIFF
--- a/.claude/skills/code-understanding/map.md
+++ b/.claude/skills/code-understanding/map.md
@@ -220,6 +220,24 @@ useful for `/diagram` rendering and downstream consumers (audit
 prioritisation, validate Stage F). Idempotent. Skip if
 `$WORKDIR/checklist.json` doesn't exist or doesn't carry `target_path`.
 
+**[MAP-5c] Enrich entry points and sinks with per-function AST views**
+
+After normalisation, run the AST-view enricher. Uses the inventory to
+attach an `ast_view` field to each entry point and sink whose
+`(file, line)` resolves to an enclosing function: signature, calls
+made inside the body, explicit returns, inline-asm flag.
+
+```bash
+libexec/raptor-enrich-context-map-ast-view "$WORKDIR"
+```
+
+The enriched context-map.json carries machine-derived structure (what
+the function *is*) alongside the LLM's narrative (what the function
+*does*). Downstream consumers — `/audit` Phase A per-function review,
+`/validate` Stage B path enumeration, `/diagram` rendering — can read
+this without re-parsing source. Idempotent. Skip if
+`$WORKDIR/checklist.json` doesn't exist or doesn't carry `target_path`.
+
 **[MAP-6] Record Coverage**
 
 After writing `context-map.json`, update the inventory with which functions you examined.

--- a/core/orchestration/context_map_ast_view.py
+++ b/core/orchestration/context_map_ast_view.py
@@ -1,0 +1,186 @@
+"""Structured AST-view enrichment for /understand --map.
+
+After ``/understand --map`` produces ``context-map.json`` (entry
+points + sinks + trust boundaries) and the normaliser runs, this
+module attaches a per-function ``ast_view`` block to each entry
+point and sink. Operators reading the map see the LLM's narrative
+plus the machine-derived structural view (signature, calls made,
+returns, inline-asm flag) for the enclosing host function.
+
+This is the second consumer of ``core.ast.view`` after the
+libexec CLI shim — the substrate-then-wire-in pattern from
+``project_core_ast.md``. Downstream of this enrichment, ``/audit``
+Phase A consumes ``context-map.json`` through the standard
+understand-bridge channel and gets the AST view for free.
+
+## Output shape
+
+Each entry point and sink dict gains an ``ast_view`` field
+containing :func:`core.ast.view`'s ``FunctionView.to_dict()``
+output:
+
+    {
+        "id": "EP-001",
+        "file": "src/routes/query.py",
+        "line": 34,
+        ...,
+        "ast_view": {
+            "function": "handle_query",
+            "file": "src/routes/query.py",
+            "language": "python",
+            "lines": [34, 56],
+            "signature": "handle_query(request: Request) -> Response",
+            "calls_made": [
+                {"line": 38, "chain": ["execute_query"], ...},
+                ...
+            ],
+            "returns": [{"line": 55, "value_text": "response"}, ...],
+            "has_inline_asm": false,
+            "schema_version": 1
+        }
+    }
+
+The ``ast_view`` field is absent (rather than null) when:
+
+  * The entry's ``file``/``line`` doesn't resolve to a function
+    in the inventory (module-level entry, path missing from
+    inventory).
+  * ``core.ast.view`` returns None — file unreadable / language
+    unsupported / parser unavailable.
+
+Idempotent — re-running overwrites prior enrichment with fresh
+data. Best-effort: any individual entry's failure leaves that
+entry unchanged but doesn't abort the run.
+
+## Why both entry points and sinks?
+
+Audit prompts want shape for the function under review regardless
+of whether it's an attack surface or a destination. The
+callgraph enricher only walks entry points because forward-
+reachable closures originate at entries; ``ast_view`` is about
+the function itself, so it applies equally to sinks.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def enrich_with_ast_view(
+    context_map: Dict[str, Any],
+    target_path: Path,
+    *,
+    inventory: Optional[Dict[str, Any]] = None,
+) -> int:
+    """Walk ``context_map``'s ``entry_points`` and ``sinks`` lists
+    and attach an ``ast_view`` field to each entry whose
+    ``(file, line)`` resolves to an enclosing function.
+
+    ``inventory`` may be provided by the caller (avoids a redundant
+    inventory build when a sibling consumer already constructed
+    one). When omitted, builds one over ``target_path``.
+
+    Returns the count of entries enriched (sum across entry points
+    and sinks). Idempotent — re-running overwrites prior enrichment.
+    """
+    if not isinstance(context_map, dict):
+        return 0
+
+    sections: List[List[Any]] = []
+    for key in ("entry_points", "sinks"):
+        sec = context_map.get(key)
+        if isinstance(sec, list) and sec:
+            sections.append(sec)
+    if not sections:
+        return 0
+
+    if inventory is None:
+        try:
+            from core.inventory.builder import build_inventory
+            import tempfile
+            with tempfile.TemporaryDirectory() as td:
+                inventory = build_inventory(str(target_path), td)
+        except Exception as e:                              # noqa: BLE001
+            logger.debug(
+                "context_map_ast_view: inventory build failed (%s); "
+                "skipping enrichment", e,
+            )
+            return 0
+
+    try:
+        from core.ast import view
+        from core.inventory.reachability import enclosing_function
+    except ImportError:
+        return 0
+
+    enriched_count = 0
+    target_root = Path(target_path).resolve()
+
+    for section in sections:
+        for entry in section:
+            if not isinstance(entry, dict):
+                continue
+            file_path = entry.get("file") or entry.get("file_path")
+            line = entry.get("line") or entry.get("line_start")
+            if not isinstance(file_path, str) or not file_path:
+                continue
+            if not isinstance(line, int) or line <= 0:
+                continue
+
+            host = enclosing_function(inventory, file_path, line)
+            if host is None:
+                # Module-level entry, or path/line not in inventory.
+                # Skip rather than emitting a placeholder.
+                continue
+
+            # context-map paths are repo-relative; resolve under
+            # target_root for view() which needs an absolute or
+            # CWD-resolvable path.
+            #
+            # Defence: context-map.json is LLM output and may carry
+            # injected entries (e.g. via prompt injection in the
+            # scanned repo). Reject paths that escape target_root —
+            # absolute paths (``/etc/passwd``) and traversal
+            # (``../../etc/passwd``) both. ``Path.resolve()`` follows
+            # symlinks, so symlinked-out files are also caught.
+            abs_path = (target_root / file_path).resolve()
+            try:
+                abs_path.relative_to(target_root)
+            except ValueError:
+                logger.debug(
+                    "context_map_ast_view: skipping entry whose file "
+                    "%r escapes target_root %s",
+                    file_path, target_root,
+                )
+                continue
+            if not abs_path.is_file():
+                # File missing on disk (stale map, moved/deleted).
+                # Skip — don't fabricate an ast_view.
+                continue
+
+            try:
+                fv = view(abs_path, host.name, at_line=line)
+            except Exception:                              # noqa: BLE001
+                # core.ast.view is documented as returning None on
+                # error, but defensively swallow exceptions too —
+                # one bad entry must not block the rest.
+                continue
+            if fv is None:
+                continue
+
+            entry["ast_view"] = fv.to_dict()
+            enriched_count += 1
+
+    if enriched_count:
+        logger.info(
+            "context_map_ast_view: enriched %d map entry(ies) with "
+            "ast_view", enriched_count,
+        )
+    return enriched_count
+
+
+__all__ = ["enrich_with_ast_view"]

--- a/core/orchestration/tests/test_context_map_ast_view.py
+++ b/core/orchestration/tests/test_context_map_ast_view.py
@@ -1,0 +1,220 @@
+"""Tests for ``core.orchestration.context_map_ast_view`` — AST-view
+enrichment for /understand --map's context-map.json output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.orchestration.context_map_ast_view import enrich_with_ast_view
+
+
+def _project(tmp_path: Path, files: dict) -> Path:
+    for rel, contents in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(contents)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Happy path: entry_points + sinks both get ast_view
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_entry_point_and_sink_both_attached(tmp_path):
+    target = _project(tmp_path, {
+        "src/auth.py": (
+            "def check_password(user, pw):\n"   # 1
+            "    if user is None:\n"             # 2
+            "        return -1\n"                # 3
+            "    h = compute_hash(pw)\n"         # 4
+            "    if compare(user.h, h):\n"       # 5
+            "        return 0\n"                 # 6
+            "    return 1\n"                     # 7
+        ),
+    })
+    cmap = {
+        "entry_points": [{"id": "EP-001", "file": "src/auth.py", "line": 4}],
+        "sinks":        [{"id": "SK-001", "file": "src/auth.py", "line": 5}],
+    }
+    n = enrich_with_ast_view(cmap, target)
+    assert n == 2
+
+    ep = cmap["entry_points"][0]
+    assert "ast_view" in ep
+    assert ep["ast_view"]["function"] == "check_password"
+    assert ep["ast_view"]["language"] == "python"
+
+    sk = cmap["sinks"][0]
+    assert "ast_view" in sk
+    assert sk["ast_view"]["function"] == "check_password"
+
+
+def test_trust_boundaries_not_walked(tmp_path):
+    """Trust boundaries don't have a single host function — the
+    enricher only walks entry_points + sinks. Pin the contract."""
+    target = _project(tmp_path, {
+        "src/auth.py": "def f(): pass\n",
+    })
+    cmap = {
+        "trust_boundaries": [{"id": "TB-001", "description": "cross-VM"}],
+    }
+    n = enrich_with_ast_view(cmap, target)
+    assert n == 0
+    assert "ast_view" not in cmap["trust_boundaries"][0]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_context_map(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f(): pass\n"})
+    assert enrich_with_ast_view({}, target) == 0
+    assert enrich_with_ast_view({"entry_points": []}, target) == 0
+
+
+def test_non_dict_context_map(tmp_path):
+    """Robustness: a non-dict value (corrupted JSON) returns 0
+    rather than raising."""
+    target = _project(tmp_path, {"src/x.py": "def f(): pass\n"})
+    assert enrich_with_ast_view([], target) == 0  # type: ignore[arg-type]
+    assert enrich_with_ast_view("not a dict", target) == 0  # type: ignore[arg-type]
+
+
+def test_entry_with_missing_file_field_skipped(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f(): pass\n"})
+    cmap = {
+        "entry_points": [
+            {"id": "EP-NO-FILE", "line": 1},
+            {"id": "EP-NO-LINE", "file": "src/x.py"},
+        ],
+    }
+    # Neither has the required (file, line) pair.
+    assert enrich_with_ast_view(cmap, target) == 0
+    assert "ast_view" not in cmap["entry_points"][0]
+    assert "ast_view" not in cmap["entry_points"][1]
+
+
+def test_module_level_line_skipped(tmp_path):
+    """A line at module scope (not inside any function) shouldn't
+    get an ast_view block — there's no host function."""
+    target = _project(tmp_path, {
+        "src/x.py": (
+            "import os\n"              # 1 — module-level line
+            "def f():\n"                # 2
+            "    return os.getcwd()\n"  # 3
+        ),
+    })
+    cmap = {
+        "entry_points": [{"id": "EP-MODULE", "file": "src/x.py", "line": 1}],
+    }
+    n = enrich_with_ast_view(cmap, target)
+    assert n == 0
+    assert "ast_view" not in cmap["entry_points"][0]
+
+
+def test_stale_path_skipped(tmp_path):
+    """A context-map entry whose file is in the inventory but
+    missing on disk now (e.g. moved/deleted between /understand run
+    and a re-enrich) shouldn't crash or fabricate an ast_view."""
+    target = _project(tmp_path, {"src/keep.py": "def f(): pass\n"})
+    cmap = {
+        "entry_points": [
+            {"id": "EP-STALE", "file": "src/keep.py", "line": 1},
+            {"id": "EP-MISSING", "file": "src/nope.py", "line": 1},
+        ],
+    }
+    n = enrich_with_ast_view(cmap, target)
+    # Only the valid one is enriched; the stale path is silently
+    # skipped (not None, not a crash).
+    assert n == 1
+    assert "ast_view" in cmap["entry_points"][0]
+    assert "ast_view" not in cmap["entry_points"][1]
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_rerun(tmp_path):
+    target = _project(tmp_path, {
+        "src/x.py": "def f():\n    g()\n    return 1\n",
+    })
+    cmap = {
+        "entry_points": [{"id": "EP", "file": "src/x.py", "line": 2}],
+    }
+    enrich_with_ast_view(cmap, target)
+    first = dict(cmap["entry_points"][0])
+    enrich_with_ast_view(cmap, target)
+    second = dict(cmap["entry_points"][0])
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Multiple file_path / line key fallbacks
+# ---------------------------------------------------------------------------
+
+
+def test_alternate_field_names(tmp_path):
+    """Some context maps emit ``file_path`` instead of ``file`` and
+    ``line_start`` instead of ``line``. The enricher accepts either
+    (matches the callgraph enricher's fallback)."""
+    target = _project(tmp_path, {
+        "src/x.py": "def f():\n    return 1\n",
+    })
+    cmap = {
+        "entry_points": [{
+            "id": "EP",
+            "file_path": "src/x.py",
+            "line_start": 1,
+        }],
+    }
+    n = enrich_with_ast_view(cmap, target)
+    assert n == 1
+    assert cmap["entry_points"][0]["ast_view"]["function"] == "f"
+
+
+# ---------------------------------------------------------------------------
+# Inventory injection (caller already built one)
+# ---------------------------------------------------------------------------
+
+
+def test_inventory_injection_avoids_rebuild(tmp_path):
+    """When the caller supplies an inventory (e.g. a sibling enricher
+    already built one), the enricher uses it rather than rebuilding."""
+    target = _project(tmp_path, {
+        "src/x.py": "def f():\n    return 1\n",
+    })
+    from core.inventory.builder import build_inventory
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        inv = build_inventory(str(target), td)
+        cmap = {
+            "entry_points": [{"id": "EP", "file": "src/x.py", "line": 1}],
+        }
+        n = enrich_with_ast_view(cmap, target, inventory=inv)
+        assert n == 1
+
+
+# ---------------------------------------------------------------------------
+# Non-dict entries are skipped (defensive — corrupted lists)
+# ---------------------------------------------------------------------------
+
+
+def test_non_dict_entries_skipped(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f():\n    return 1\n"})
+    cmap = {
+        "entry_points": [
+            "not a dict",            # type: ignore[list-item]
+            {"id": "EP", "file": "src/x.py", "line": 1},
+            None,                    # type: ignore[list-item]
+            42,                      # type: ignore[list-item]
+        ],
+    }
+    n = enrich_with_ast_view(cmap, target)
+    assert n == 1
+    # The valid one got enriched.
+    assert "ast_view" in cmap["entry_points"][1]

--- a/libexec/raptor-enrich-context-map-ast-view
+++ b/libexec/raptor-enrich-context-map-ast-view
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Enrich a context-map.json with structured per-function AST views.
+Runs after raptor-normalize-context-map.
+
+Usage: raptor-enrich-context-map-ast-view <understand_dir>
+
+Wraps core.orchestration.context_map_ast_view.enrich_with_ast_view
+for invocation from skill markdown. Adds an ``ast_view`` field to
+each entry point and sink in context-map.json whose ``(file, line)``
+resolves to an enclosing function. Idempotent — safe to re-run.
+
+Best-effort: missing checklist / inventory build failure / unresolved
+host functions log warnings but never abort the run.
+"""
+import argparse
+import sys
+from pathlib import Path
+
+# ─── trust-marker check (do not import; inline by design) ───
+import os
+if not (os.environ.get("CLAUDECODE")
+        or os.environ.get("_RAPTOR_TRUSTED")):
+    sys.stderr.write(
+        f"{sys.argv[0]}: internal dispatch script.\n"
+        "  Run via 'bin/raptor' instead.\n"
+        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
+    )
+    sys.exit(2)
+# ─── end trust-marker check ─────────────────────────────────
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.json import load_json, save_json
+from core.orchestration.context_map_ast_view import enrich_with_ast_view
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="raptor-enrich-context-map-ast-view",
+        description=(
+            "Enrich context-map.json entry points + sinks with structured "
+            "per-function AST views (signature, calls, returns, asm flag)."
+        ),
+    )
+    parser.add_argument("understand_dir", help="path to /understand run dir")
+    args = parser.parse_args()
+
+    understand_dir = Path(args.understand_dir).resolve()
+    if not understand_dir.is_dir():
+        print(
+            f"raptor-enrich-context-map-ast-view: {understand_dir} is "
+            "not a directory", file=sys.stderr,
+        )
+        return 1
+
+    context_map_path = understand_dir / "context-map.json"
+    if not context_map_path.exists():
+        print(
+            f"raptor-enrich-context-map-ast-view: {context_map_path} "
+            "does not exist", file=sys.stderr,
+        )
+        return 1
+
+    context_map = load_json(context_map_path)
+    if not isinstance(context_map, dict):
+        print(
+            f"raptor-enrich-context-map-ast-view: {context_map_path} "
+            "is not a JSON object", file=sys.stderr,
+        )
+        return 1
+
+    checklist = load_json(understand_dir / "checklist.json") or {}
+    target_path = (
+        checklist.get("target_path") if isinstance(checklist, dict) else None
+    )
+    if not target_path:
+        print(
+            "raptor-enrich-context-map-ast-view: checklist missing "
+            "target_path; skipping enrichment", file=sys.stderr,
+        )
+        return 0
+
+    enriched = enrich_with_ast_view(context_map, Path(target_path))
+    if enriched:
+        save_json(context_map_path, context_map)
+        print(
+            f"raptor-enrich-context-map-ast-view: enriched {enriched} "
+            f"map entry(ies) in {context_map_path}"
+        )
+    else:
+        print(
+            "raptor-enrich-context-map-ast-view: no entries enriched "
+            "(no entry_points/sinks fields, all hosts unresolvable, or "
+            "inventory build skipped)"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/libexec/tests/test_raptor_enrich_context_map_ast_view.py
+++ b/libexec/tests/test_raptor_enrich_context_map_ast_view.py
@@ -1,0 +1,154 @@
+"""Tests for the libexec/raptor-enrich-context-map-ast-view wrapper.
+
+The underlying ``core.orchestration.context_map_ast_view`` module
+has its own unit tests; this file pins the shim contracts (exit
+codes, error paths, idempotency, on-disk mutation) as exercised
+by the skill markdown when it calls the wrapper.
+"""
+
+import json
+import os
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WRAPPER = REPO_ROOT / "libexec" / "raptor-enrich-context-map-ast-view"
+
+
+def _run(*args, **kwargs):
+    """Invoke the wrapper as a real subprocess (matches how skills call it)."""
+    env = {**os.environ, "_RAPTOR_TRUSTED": "1"}
+    return subprocess.run(
+        [str(WRAPPER), *args],
+        capture_output=True, text=True, timeout=30,
+        env=env, **kwargs,
+    )
+
+
+class RaptorEnrichContextMapAstViewTests(unittest.TestCase):
+
+    def test_wrapper_exists_and_is_executable(self):
+        self.assertTrue(WRAPPER.exists(), msg=f"missing: {WRAPPER}")
+        self.assertTrue(os.access(WRAPPER, os.X_OK),
+                        msg=f"not executable: {WRAPPER}")
+
+    def test_no_args_prints_usage_and_fails(self):
+        proc = _run()
+        self.assertNotEqual(proc.returncode, 0)
+        # argparse usage banner — exact format varies by argparse
+        # version, but "usage" appears in every Python version we
+        # care about.
+        self.assertIn("usage", proc.stderr.lower())
+
+    def test_missing_understand_dir_fails_cleanly(self):
+        proc = _run("/nonexistent/path/that/does/not/exist")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("not a directory", proc.stderr)
+
+    def test_missing_context_map_fails_cleanly(self):
+        with TemporaryDirectory() as tmp:
+            proc = _run(tmp)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("does not exist", proc.stderr)
+
+    def test_missing_checklist_returns_zero_no_op(self):
+        """If checklist.json is absent or doesn't carry target_path,
+        the wrapper logs a warning and exits 0 — the skill is allowed
+        to call the enricher even when inventory data is missing."""
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "context-map.json").write_text(json.dumps({
+                "entry_points": [{"file": "x.py", "line": 1}],
+            }))
+            proc = _run(str(tmp))
+            self.assertEqual(proc.returncode, 0,
+                             msg=f"wrapper failed: {proc.stderr}")
+            self.assertIn("checklist missing", proc.stderr)
+
+    def test_corrupt_context_map_fails_cleanly(self):
+        """A context-map.json that isn't a JSON object (e.g. a top-
+        level list, or invalid JSON entirely) shouldn't traceback —
+        the wrapper rejects it with a specific message."""
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "context-map.json").write_text("[]")  # list, not dict
+            proc = _run(str(tmp))
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("not a JSON object", proc.stderr)
+
+    def test_enriches_in_place(self):
+        """Happy path: context-map.json + checklist.json present;
+        wrapper attaches ast_view to the entry point and writes the
+        file back. Verifies the wrapper actually mutates on disk."""
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            target = tmp / "target"
+            target.mkdir()
+            (target / "app.py").write_text(
+                "def handle():\n"
+                "    return 0\n"
+            )
+            (tmp / "context-map.json").write_text(json.dumps({
+                "entry_points": [{
+                    "id": "EP-001",
+                    "file": "app.py",
+                    "line": 1,
+                }],
+            }))
+            (tmp / "checklist.json").write_text(json.dumps({
+                "target_path": str(target),
+            }))
+            proc = _run(str(tmp))
+            self.assertEqual(proc.returncode, 0,
+                             msg=f"wrapper failed: {proc.stderr}")
+            self.assertIn("enriched 1", proc.stdout)
+
+            enriched = json.loads((tmp / "context-map.json").read_text())
+            entry = enriched["entry_points"][0]
+            self.assertIn("ast_view", entry)
+            self.assertEqual(entry["ast_view"]["function"], "handle")
+            self.assertEqual(entry["ast_view"]["language"], "python")
+
+    def test_idempotent_on_repeated_invocation(self):
+        """Re-running the wrapper on already-enriched data must
+        produce the same output — skills may invoke iteratively."""
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            target = tmp / "target"
+            target.mkdir()
+            (target / "app.py").write_text(
+                "def handle():\n    return 0\n"
+            )
+            (tmp / "context-map.json").write_text(json.dumps({
+                "entry_points": [{"file": "app.py", "line": 1}],
+            }))
+            (tmp / "checklist.json").write_text(json.dumps({
+                "target_path": str(target),
+            }))
+            _run(str(tmp))
+            first = (tmp / "context-map.json").read_text()
+            _run(str(tmp))
+            second = (tmp / "context-map.json").read_text()
+            self.assertEqual(first, second)
+
+    def test_trust_marker_required(self):
+        """No CLAUDECODE and no _RAPTOR_TRUSTED → refuse with exit 2."""
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "context-map.json").write_text("{}")
+            # Strip both trust markers — must refuse.
+            env = {k: v for k, v in os.environ.items()
+                   if k not in ("CLAUDECODE", "_RAPTOR_TRUSTED")}
+            proc = subprocess.run(
+                [str(WRAPPER), str(tmp)],
+                capture_output=True, text=True, timeout=10, env=env,
+            )
+            self.assertEqual(proc.returncode, 2)
+            self.assertIn("internal dispatch script", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Second consumer for `core.ast.view` after the libexec CLI shim (PR #527). `/understand --map` entry points and sinks now carry a structured per-function `ast_view` block alongside the LLM's narrative — signature, calls made, returns, inline-asm flag.

What lands:

  * `core/orchestration/context_map_ast_view.py` — the enricher. Walks `context_map["entry_points"]` and `context_map["sinks"]`, resolves `(file, line)` to a host function via `core.inventory.reachability.enclosing_function`, calls `core.ast.view(abs_path, host.name, at_line=line)`, attaches `entry["ast_view"] = fv.to_dict()`. Idempotent. Best-effort per entry — a single failure leaves that entry unchanged but doesn't abort the run.

  * `libexec/raptor-enrich-context-map-ast-view` — CLI shim matching the established `raptor-enrich-context-map-callgraph` pattern (trust-marker check + sys.path setup + checklist target_path lookup + idempotent write-back).

  * `.claude/skills/code-understanding/map.md` — adds MAP-5c step invoking the shim after MAP-5b (callgraph enricher) + MAP-5 (normaliser).

  * Tests: 11 module + 9 shim. Wider sanity 774/774 across orchestration + ast + inventory.