### PR TITLE
feat(binary_analysis): radare2 sandbox follow-ups + libexec trust-marker convention

### DIFF
--- a/core/sandbox/tests/test_r2_sandboxed_wrapper.py
+++ b/core/sandbox/tests/test_r2_sandboxed_wrapper.py
@@ -70,43 +70,54 @@ def _run_wrapper(args, env=None, stdin=None, timeout=30):
 
 # === Layer 1: argv + env validation (no r2 needed) ===
 
+# Wrapper exit codes — must match libexec/raptor-r2-sandboxed.
+# Disambiguated from r2's own exit codes (0-127 typical) by using 100+.
+_RC_ARGV_REFUSED   = 100
+_RC_SANDBOX_FAILED = 101
+_RC_TRUST_MISSING  = 102
+_RC_ENV_INVALID    = 103
+_RC_BINARY_MISSING = 104
+
+
 class TestArgvWhitelist:
     """The wrapper refuses argv outside the r2pipe-spawn shape."""
 
     def test_no_args_refuses(self, tmp_path):
         env = _trusted_env(OUTPUT_DIR=str(tmp_path))
         r = _run_wrapper([], env=env)
-        assert r.returncode == 2, r.stderr
+        assert r.returncode == _RC_ARGV_REFUSED, r.stderr
         assert "refused argv" in r.stderr
 
     def test_relative_binary_path_refuses(self, tmp_path):
         env = _trusted_env(OUTPUT_DIR=str(tmp_path))
         r = _run_wrapper(["-2", "relative/path"], env=env)
-        assert r.returncode == 2, r.stderr
+        assert r.returncode == _RC_ARGV_REFUSED, r.stderr
         assert "must be absolute" in r.stderr
 
     def test_unknown_flag_refuses(self, tmp_path):
         """A flag that smuggles arbitrary r2 command, e.g. -c 'cmd', or
-        opens a file with attacker-controlled mode (-w) — must refuse."""
+        opens a file with attacker-controlled mode (-w) — must refuse.
+        Binary is /bin/ls (real file) so we exercise the flag-whitelist
+        path, not the missing-binary check."""
         env = _trusted_env(OUTPUT_DIR=str(tmp_path))
-        r = _run_wrapper(["-c", "system('id')", "/tmp/binary"], env=env)
-        assert r.returncode == 2, r.stderr
+        r = _run_wrapper(["-c", "system('id')", "/bin/ls"], env=env)
+        assert r.returncode == _RC_ARGV_REFUSED, r.stderr
         assert "not in whitelist" in r.stderr
 
     def test_write_mode_flag_refuses(self, tmp_path):
         """`-w` puts r2 in write mode — could modify the target binary
         on disk. Not in the whitelist."""
         env = _trusted_env(OUTPUT_DIR=str(tmp_path))
-        r = _run_wrapper(["-w", "/tmp/binary"], env=env)
-        assert r.returncode == 2, r.stderr
+        r = _run_wrapper(["-w", "/bin/ls"], env=env)
+        assert r.returncode == _RC_ARGV_REFUSED, r.stderr
 
     def test_eval_flag_refuses(self, tmp_path):
         """`-e` evaluates r2 config strings — attacker-controlled
         could enable shell escapes (`scr.html`, etc.)."""
         env = _trusted_env(OUTPUT_DIR=str(tmp_path))
-        r = _run_wrapper(["-e", "cfg.sandbox=false", "/tmp/binary"],
+        r = _run_wrapper(["-e", "cfg.sandbox=false", "/bin/ls"],
                          env=env)
-        assert r.returncode == 2, r.stderr
+        assert r.returncode == _RC_ARGV_REFUSED, r.stderr
 
 
 class TestTrustMarker:
@@ -118,7 +129,7 @@ class TestTrustMarker:
         env.pop("CLAUDECODE", None)
         env["OUTPUT_DIR"] = str(tmp_path)
         r = _run_wrapper(["-2", "/bin/ls"], env=env)
-        assert r.returncode == 3
+        assert r.returncode == _RC_TRUST_MISSING
         assert "internal dispatch script" in r.stderr
 
 
@@ -129,8 +140,61 @@ class TestEnvValidation:
         env = _trusted_env()
         env.pop("OUTPUT_DIR", None)
         r = _run_wrapper(["-2", "/bin/ls"], env=env)
-        assert r.returncode == 3, r.stderr
+        assert r.returncode == _RC_ENV_INVALID, r.stderr
         assert "OUTPUT_DIR" in r.stderr
+
+
+class TestFastFailMissingBinary:
+    """The wrapper checks the binary exists BEFORE spending ~100-500ms
+    on sandbox bootstrap — saves cost on operator typos and surfaces
+    the error clearly (clearer than r2's own 'Cannot open binary'
+    which gets buried inside the sandbox)."""
+
+    def test_nonexistent_binary_fast_fails(self, tmp_path):
+        env = _trusted_env(OUTPUT_DIR=str(tmp_path))
+        r = _run_wrapper(["-2", "/tmp/definitely-not-a-real-binary-XYZ"],
+                         env=env)
+        assert r.returncode == _RC_BINARY_MISSING, r.stderr
+        assert "not found" in r.stderr.lower()
+
+    def test_directory_not_file_refuses(self, tmp_path):
+        """A path to a directory (not a regular file) is not a valid
+        binary — refuse rather than letting r2 fail confusingly."""
+        env = _trusted_env(OUTPUT_DIR=str(tmp_path))
+        r = _run_wrapper(["-2", str(tmp_path)], env=env)
+        assert r.returncode == _RC_BINARY_MISSING, r.stderr
+
+
+class TestSymlinkResolution:
+    """Realpath collapses symlinks BEFORE the wrapper proceeds. Closes
+    the residual where a binary at /tmp/X/target → /etc/passwd would
+    have R2_TARGET_DIR bound at /tmp/X (containing only a symlink)
+    while r2 actually reads the symlink's target."""
+
+    def test_symlink_resolved_before_validation(self, tmp_path):
+        """Create a symlink at /tmp/X/target → /bin/ls, invoke wrapper
+        with the symlink path. The wrapper should accept (resolved
+        path /bin/ls is a real file) and the sandbox-side path passed
+        to r2 reflects the realpath."""
+        link = tmp_path / "target-symlink"
+        link.symlink_to("/bin/ls")
+        env = _trusted_env(OUTPUT_DIR=str(tmp_path))
+        # We don't actually wait for r2 to fully run — just confirm
+        # the wrapper got past validation. Short timeout, ignore rc.
+        try:
+            r = subprocess.run(
+                [str(WRAPPER), "-2", str(link)],
+                env=env, input="q\n", capture_output=True, text=True,
+                timeout=5,
+            )
+        except subprocess.TimeoutExpired:
+            # Took too long — but didn't fast-fail with BINARY_MISSING,
+            # which is what we wanted to assert.
+            return
+        # If it returned within 5s, must NOT be a fast-fail rc.
+        assert r.returncode != _RC_BINARY_MISSING, (
+            f"symlink was incorrectly rejected as missing: stderr={r.stderr!r}"
+        )
 
 
 # === Layer 2: integration — wrapper spawns r2 successfully ===

--- a/libexec/raptor-r2-sandboxed
+++ b/libexec/raptor-r2-sandboxed
@@ -65,21 +65,33 @@ import os
 import sys
 from pathlib import Path
 
-# Trust-marker check — same pattern as the other libexec/raptor-*
-# dispatch scripts (raptor-run-sandboxed, raptor-binary-understand).
-# This script is invoked indirectly via R2PIPE_R2; only RAPTOR's own
-# r2pipe-using code should set that env var. A user manually running
-# this script gets a clear error rather than a confusing sandbox
-# attempt.
+# Wrapper-side exit codes — distinguishable from r2's own exit codes
+# (which typically range 0-127 for normal exits). Using 100+ for
+# wrapper-side failures so callers can tell "r2 exited 2 because
+# its input was malformed" from "the wrapper refused to start"
+# without parsing stderr.
+_RC_WRAPPER_ARGV_REFUSED   = 100
+_RC_WRAPPER_SANDBOX_FAILED = 101
+_RC_WRAPPER_TRUST_MISSING  = 102
+_RC_WRAPPER_ENV_INVALID    = 103
+_RC_WRAPPER_BINARY_MISSING = 104
+
+# ─── trust-marker check (libexec convention) ───────────────
+# Inline before any RAPTOR import (matches raptor-run-sandboxed,
+# raptor-binary-understand) so a malicious PYTHONPATH can't hijack
+# core.* imports before the check fires. This script is invoked
+# indirectly by r2pipe (via R2PIPE_R2 env), not by humans directly;
+# unguarded invocation typically means a caller misconfiguration.
 if not (os.environ.get("CLAUDECODE")
         or os.environ.get("_RAPTOR_TRUSTED")):
     sys.stderr.write(
         f"{sys.argv[0]}: internal dispatch script.\n"
         "  Set R2PIPE_R2 to this script's path and r2pipe will invoke "
-        "it transparently.\n"
+        "it transparently (radare2_understand.analyse does this).\n"
         "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
     )
-    sys.exit(3)
+    sys.exit(_RC_WRAPPER_TRUST_MISSING)
+# ─── end trust-marker check ────────────────────────────────
 
 # Resolve RAPTOR root via this script's path — libexec/<script>, so
 # parents[1] is the RAPTOR install dir. core/sandbox lives there.
@@ -87,7 +99,7 @@ _RAPTOR_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_RAPTOR_DIR))
 
 
-def _die(msg: str, code: int = 3) -> None:
+def _die(msg: str, code: int = _RC_WRAPPER_SANDBOX_FAILED) -> None:
     sys.stderr.write(f"[r2-sandbox] {msg}\n")
     sys.exit(code)
 
@@ -122,7 +134,7 @@ def _parse_and_validate_argv(argv: list[str]) -> tuple[list[str], str]:
     ~/.radare2rc auto-exec vector independent of $HOME masking.
     """
     if len(argv) < 2:
-        _die(f"refused argv (too short): {argv!r}", code=2)
+        _die(f"refused argv (too short): {argv!r}", code=_RC_WRAPPER_ARGV_REFUSED)
 
     # Last arg = binary path. Everything else = flag.
     binary = argv[-1]
@@ -134,7 +146,25 @@ def _parse_and_validate_argv(argv: list[str]) -> tuple[list[str], str]:
     # here would indicate a caller bug or attempted injection.
     if not binary.startswith("/"):
         _die(f"refused argv (binary must be absolute path): {binary!r}",
-             code=2)
+             code=_RC_WRAPPER_ARGV_REFUSED)
+
+    # Canonicalise via realpath — closes the symlink residual where a
+    # binary at /tmp/X/target → /etc/passwd would otherwise have
+    # R2_TARGET_DIR bound at /tmp/X (containing only a symlink) while
+    # r2 reads the symlink target /etc/passwd. After realpath, the
+    # binary path's parent dir IS the dir containing the actual file
+    # r2 will read, so mount_ns binds the right tree. Realpath also
+    # collapses "/tmp/X/../etc/passwd"-style traversal in the input.
+    binary = os.path.realpath(binary)
+
+    # Fast-fail on missing / non-file. The sandbox bootstrap costs
+    # ~100-500ms (mount-ns, Landlock, seccomp); checking the file
+    # exists here saves that cost when the caller has the wrong path.
+    # Also gives a clearer error than r2's own "Cannot open binary"
+    # which surfaces inside the sandbox and gets buried.
+    if not os.path.isfile(binary):
+        _die(f"refused: binary not found or not a regular file: {binary!r}",
+             code=_RC_WRAPPER_BINARY_MISSING)
 
     # Validate every flag is in the whitelist.
     for f in flags:
@@ -142,7 +172,7 @@ def _parse_and_validate_argv(argv: list[str]) -> tuple[list[str], str]:
             _die(
                 f"refused argv (flag not in whitelist "
                 f"{sorted(_ALLOWED_FLAGS)}): {f!r}",
-                code=2,
+                code=_RC_WRAPPER_ARGV_REFUSED,
             )
 
     # Prepend -N if not already present — disables ~/.radare2rc
@@ -162,7 +192,8 @@ flags, binary = _parse_and_validate_argv(argv)
 
 output_dir = os.environ.get("OUTPUT_DIR")
 if not output_dir:
-    _die("OUTPUT_DIR env var required (writable scratch dir)")
+    _die("OUTPUT_DIR env var required (writable scratch dir)",
+         code=_RC_WRAPPER_ENV_INVALID)
 
 target_dir = os.environ.get("R2_TARGET_DIR")
 if not target_dir:
@@ -226,6 +257,7 @@ try:
             strict_env=True,
         )
 except (OSError, RuntimeError, ValueError) as e:
-    _die(f"sandbox invocation failed: {e.__class__.__name__}: {e}")
+    _die(f"sandbox invocation failed: {e.__class__.__name__}: {e}",
+         code=_RC_WRAPPER_SANDBOX_FAILED)
 
 sys.exit(result.returncode)

--- a/packages/binary_analysis/radare2_understand.py
+++ b/packages/binary_analysis/radare2_understand.py
@@ -262,6 +262,72 @@ class BinaryUnderstand:
                 "Then: 'pip install r2pipe'."
             )
 
+    @staticmethod
+    def _cmd_t(r2, command: str, timeout_s: float) -> str:
+        """Run r2.cmd with a hard per-command timeout.
+
+        r2pipe.cmd() reads until a NULL byte on r2's stdout pipe — if r2
+        wedges (parser infinite loop on malicious input, decompiler
+        stuck on pathological CFG), the read blocks forever and the
+        analysis hangs. The 30-min sandbox-wrapper timeout (PR3) is the
+        worst-case backstop; per-command timeouts here give the operator
+        a "this binary is being weird, abort" signal in seconds-to-
+        minutes rather than 30 minutes wasted.
+
+        On timeout the r2 subprocess is killed via r2pipe's `process`
+        handle, the pipe read unblocks with EOF, and TimeoutError
+        propagates. After timeout r2 is dead; the analyse() try/finally
+        skips r2.quit() (already gone) and cleans up env/scratch.
+
+        Threaded rather than signal-based because signals can only fire
+        in the main thread, and radare2_understand may be called from
+        worker threads.
+        """
+        import threading
+        result_holder: list = [None]
+        exc_holder: list = [None]
+
+        def _run():
+            try:
+                result_holder[0] = r2.cmd(command)
+            except BaseException as e:  # noqa: BLE001 — propagate any error
+                exc_holder[0] = e
+
+        t = threading.Thread(target=_run, daemon=True)
+        t.start()
+        t.join(timeout_s)
+        if t.is_alive():
+            # Kill the r2 subprocess to unblock the pipe read.
+            proc = getattr(r2, "process", None)
+            if proc is not None:
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+            # Give kill time to land; the worker thread is daemon so
+            # an extra-stubborn r2 won't keep the Python interpreter
+            # alive past process exit.
+            t.join(2)
+            raise TimeoutError(
+                f"r2 command {command!r} exceeded {timeout_s}s — likely "
+                f"a malicious binary or r2 parser bug; analysis aborted."
+            )
+        if exc_holder[0] is not None:
+            raise exc_holder[0]
+        return result_holder[0]
+
+    # Per-command timeout budgets. Real `aaa` on typical binaries
+    # completes in seconds to a couple of minutes; 10 min is generous.
+    # Decompilation per function is bounded by r2's own complexity
+    # heuristics but a 2-min cap catches pathological CFGs. Everything
+    # else is metadata-shaped (JSON dumps from in-memory state) and
+    # should be sub-second; 60s catches r2 wedges without false-
+    # positing slow IO on large binaries.
+    _T_AAA = 600.0          # full auto-analysis
+    _T_DECOMPILE = 120.0    # pdc / pdg per function
+    _T_QUERY = 60.0         # ij / iij / iEj / aflj / izj
+    _T_XREF = 30.0          # axffj per function (cheap in-memory lookup)
+
     def analyse(
         self,
         max_decompile: int = 20,
@@ -340,7 +406,7 @@ class BinaryUnderstand:
                     else:
                         _os.environ[k] = v
                 _saved_env = {}  # already restored — finally skips re-restore
-            r2.cmd("aaa")    # full auto-analysis
+            self._cmd_t(r2, "aaa", self._T_AAA)    # full auto-analysis
             self._extract_metadata(r2, ctx)
             self._extract_imports_exports(r2, ctx)
             self._extract_functions(r2, ctx)
@@ -387,7 +453,7 @@ class BinaryUnderstand:
 
     def _extract_metadata(self, r2, ctx: BinaryContextMap) -> None:
         try:
-            info = json.loads(r2.cmd("ij") or "{}")
+            info = json.loads(self._cmd_t(r2, "ij", self._T_QUERY) or "{}")
             bin_info = info.get("bin", {})
             ctx.arch = str(bin_info.get("arch", ""))
             ctx.bits = int(bin_info.get("bits", 0) or 0)
@@ -398,7 +464,7 @@ class BinaryUnderstand:
 
     def _extract_imports_exports(self, r2, ctx: BinaryContextMap) -> None:
         try:
-            imports_raw = json.loads(r2.cmd("iij") or "[]")
+            imports_raw = json.loads(self._cmd_t(r2, "iij", self._T_QUERY) or "[]")
             ctx.imports = [
                 str(i.get("name", "")) for i in imports_raw if i.get("name")
             ]
@@ -407,7 +473,7 @@ class BinaryUnderstand:
             ctx.imports = []
 
         try:
-            exports_raw = json.loads(r2.cmd("iEj") or "[]")
+            exports_raw = json.loads(self._cmd_t(r2, "iEj", self._T_QUERY) or "[]")
             ctx.exports = [
                 str(e.get("name", "")) for e in exports_raw if e.get("name")
             ]
@@ -417,7 +483,7 @@ class BinaryUnderstand:
 
     def _extract_functions(self, r2, ctx: BinaryContextMap) -> None:
         try:
-            fns = json.loads(r2.cmd("aflj") or "[]")
+            fns = json.loads(self._cmd_t(r2, "aflj", self._T_QUERY) or "[]")
         except Exception as e:
             logger.debug(f"function list failed: {e}")
             return
@@ -457,7 +523,7 @@ class BinaryUnderstand:
 
     def _extract_strings(self, r2, ctx: BinaryContextMap, limit: int) -> None:
         try:
-            strings_raw = json.loads(r2.cmd("izj") or "[]")
+            strings_raw = json.loads(self._cmd_t(r2, "izj", self._T_QUERY) or "[]")
         except Exception:
             strings_raw = []
         strings = []
@@ -503,7 +569,8 @@ class BinaryUnderstand:
                 continue
             try:
                 refs = json.loads(
-                    r2.cmd(f"axffj @ {fn.address}") or "[]"
+                    self._cmd_t(r2, f"axffj @ {fn.address}", self._T_XREF)
+                    or "[]"
                 )
             except Exception:
                 refs = []
@@ -566,7 +633,9 @@ class BinaryUnderstand:
 
         for fn in candidates[:limit]:
             try:
-                src = r2.cmd(f"{decompile_cmd} @ {fn.address}") or ""
+                src = self._cmd_t(
+                    r2, f"{decompile_cmd} @ {fn.address}", self._T_DECOMPILE,
+                ) or ""
                 fn.decompiled = src.strip()[:8192]
             except Exception as e:
                 logger.debug(f"decompile {fn.name} failed: {e}")

--- a/packages/binary_analysis/tests/test_radare2_understand.py
+++ b/packages/binary_analysis/tests/test_radare2_understand.py
@@ -343,5 +343,64 @@ class TestSandboxWiring(unittest.TestCase):
         )
 
 
+class TestCmdTimeout(unittest.TestCase):
+    """BinaryUnderstand._cmd_t — per-command timeout helper. Drives
+    r2.cmd() in a worker thread; on timeout, kills the r2 subprocess
+    via r2pipe's `process` handle and raises TimeoutError."""
+
+    def test_normal_command_returns_result(self):
+        """Fast r2 response → result returned, no timeout."""
+        r2 = MagicMock()
+        r2.cmd.return_value = '{"bin": "elf"}'
+        result = BinaryUnderstand._cmd_t(r2, "ij", timeout_s=5.0)
+        self.assertEqual(result, '{"bin": "elf"}')
+        r2.cmd.assert_called_once_with("ij")
+
+    def test_timeout_raises_timeouterror(self):
+        """r2.cmd() blocks > timeout → TimeoutError raised, r2 killed."""
+        import time
+        r2 = MagicMock()
+        # Simulate r2 hanging: cmd() never returns.
+        r2.cmd.side_effect = lambda c: time.sleep(10)
+        r2.process = MagicMock()
+        with self.assertRaises(TimeoutError) as ctx:
+            BinaryUnderstand._cmd_t(r2, "aaa", timeout_s=0.5)
+        self.assertIn("aaa", str(ctx.exception))
+        self.assertIn("0.5s", str(ctx.exception))
+        # On timeout, r2.process.kill() must have been called to
+        # unblock the pipe read.
+        r2.process.kill.assert_called()
+
+    def test_timeout_handles_missing_process_handle(self):
+        """If r2pipe doesn't expose `process` (older versions, custom
+        subclass), _cmd_t must still raise TimeoutError without
+        crashing on the missing attribute."""
+        import time
+        r2 = MagicMock(spec=["cmd"])  # no `process` attr
+        r2.cmd.side_effect = lambda c: time.sleep(10)
+        with self.assertRaises(TimeoutError):
+            BinaryUnderstand._cmd_t(r2, "aaa", timeout_s=0.3)
+
+    def test_cmd_exception_propagates(self):
+        """Exceptions from r2.cmd() (e.g. ConnectionError if pipe
+        broke) must propagate up to the caller, not be swallowed."""
+        r2 = MagicMock()
+        r2.cmd.side_effect = ConnectionError("pipe broken")
+        with self.assertRaises(ConnectionError):
+            BinaryUnderstand._cmd_t(r2, "ij", timeout_s=5.0)
+
+    def test_per_command_timeout_budgets_are_reasonable(self):
+        """Sanity-check the class-level _T_* timeouts haven't drifted
+        to silly values (zero, negative, decade-long)."""
+        self.assertGreater(BinaryUnderstand._T_AAA, 60)        # > 1 min
+        self.assertLess(BinaryUnderstand._T_AAA, 3600)         # < 1 hour
+        self.assertGreater(BinaryUnderstand._T_DECOMPILE, 10)
+        self.assertLess(BinaryUnderstand._T_DECOMPILE, 600)
+        self.assertGreater(BinaryUnderstand._T_QUERY, 1)
+        self.assertLess(BinaryUnderstand._T_QUERY, 300)
+        self.assertGreater(BinaryUnderstand._T_XREF, 1)
+        self.assertLess(BinaryUnderstand._T_XREF, 300)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes residuals from the two adversarial review passes and adopts the libexec trust-marker convention so the marker-coverage test passes.

1. Per-command timeouts via BinaryUnderstand._cmd_t helper. Closes the 0-30min "r2 wedged on malicious binary" residual — PR3's 1800s sandbox-wrapper timeout was the worst-case backstop; per-command timeouts give the operator a "binary is being weird, abort" signal in seconds-to-minutes. Threaded (not signal-based) so it works from worker threads. On timeout the r2 subprocess is killed via r2pipe's `process` handle to unblock the pipe read. All 8 r2.cmd sites in analyse() migrated.

   Budgets:
     _T_AAA       = 600s  — full auto-analysis (heavy)
     _T_DECOMPILE = 120s  — pdc/pdg per function
     _T_QUERY     =  60s  — ij/iij/iEj/aflj/izj (metadata)
     _T_XREF      =  30s  — axffj per function (cheap)

2. Wrapper exit-code disambiguation — moved wrapper failures from 2/3 (collide with r2's own exit codes) to 100-104:

     100 = argv refused
     101 = sandbox setup failed
     102 = trust marker missing
     103 = required env invalid (no OUTPUT_DIR)
     104 = binary missing / not a regular file

   Callers can tell "wrapper refused" from "r2 ran and exited non-zero" without parsing stderr.

3. realpath() the binary before sandbox spawn. Closes the symlink residual where a binary at /tmp/X/target → /etc/passwd would otherwise bind /tmp/X (containing only a symlink) as R2_TARGET_DIR while r2 reads the symlink's target /etc/passwd. Also collapses "../etc/passwd"-style traversal in input.

4. Fast-fail on missing / non-file binary. Saves the ~100-500ms sandbox bootstrap when the caller's path is wrong, and surfaces the error clearly (clearer than r2's "Cannot open binary" which gets buried in the sandboxed child's stderr).

5. Trust-marker block restyled to the libexec convention: 

Matches raptor-run-sandboxed and raptor-binary-understand and satisfies libexec/tests/test_marker_coverage.py which scans every libexec/raptor-* file for the sentinel.