### PR TITLE
feat(core/inventory): multi-lang class + package_name capture for reachability

### DIFF
--- a/core/inventory/_reach_cache.py
+++ b/core/inventory/_reach_cache.py
@@ -58,7 +58,15 @@ logger = logging.getLogger(__name__)
 # automatically. Don't bump for pure additive changes that an old
 # cache could still satisfy — the in-process build is fast enough
 # that operators don't need version-skew sympathy.
-_CACHE_VERSION = 3
+#
+# V4 (2026-05-16): per-language alias canonicalisation extended
+# ``qualified_to_internal`` with ``<pkg>.<Class>.<method>`` entries
+# for Java/C#/PHP/Rust/JS-TS/Ruby method definitions. An old V3
+# cache returned ``InternalFunction(verdict=UNCERTAIN)`` for
+# class-qualified queries that the new build would have resolved
+# to ``CALLED``/``NOT_CALLED`` — a real correctness regression on
+# stale caches, so this is a bump-worthy change.
+_CACHE_VERSION = 4
 
 _CACHE_DIR = Path.home() / ".cache" / "raptor" / "reachability"
 
@@ -67,7 +75,7 @@ _CACHE_DIR = Path.home() / ".cache" / "raptor" / "reachability"
 # the same name. Also doubles as a cheap "is this a raptor cache
 # file" check before handing bytes to ``pickle.load``. The numeric
 # suffix tracks ``_CACHE_VERSION``.
-_HEADER_MAGIC = b"RAPTOR-REACHABILITY-CACHE-V3\n"
+_HEADER_MAGIC = b"RAPTOR-REACHABILITY-CACHE-V4\n"
 
 
 def compute_fingerprint(inventory: Dict[str, Any]) -> Optional[str]:

--- a/core/inventory/call_graph.py
+++ b/core/inventory/call_graph.py
@@ -165,6 +165,18 @@ class FileCallGraph:
     getattr_targets: Set[str] = field(default_factory=set)
     classes: List[ClassDef] = field(default_factory=list)
     decorated_functions: List[DecoratedFunction] = field(default_factory=list)
+    # Module/package/namespace declared inside this file. The
+    # reachability resolver uses this to canonicalise cross-package
+    # references into project-defined functions for languages where
+    # the source file's package isn't derivable from the file path
+    # alone — Go (``package <name>``), Java (``package com.foo;``),
+    # Rust (``mod`` chains), C# (``namespace Foo.Bar``), PHP
+    # (``namespace Foo\Bar``). For Python this stays ``None``: the
+    # resolver derives the qualified name from the file path
+    # heuristically. For JS/TS each file IS its module — also
+    # path-derivable, so stays ``None``. For Ruby the
+    # module/class nesting at file scope.
+    package_name: Optional[str] = None
     # Relative imports (Python ``from . import x`` /
     # ``from ..pkg import y``). Stored as
     # ``(level, module_or_empty, name, asname_or_None)`` quads. Not
@@ -200,6 +212,7 @@ class FileCallGraph:
                  "decorators": [list(ch) for ch in d.decorators]}
                 for d in self.decorated_functions
             ],
+            "package_name": self.package_name,
             "relative_imports": [list(ri) for ri in self.relative_imports],
         }
 
@@ -244,6 +257,7 @@ class FileCallGraph:
                 )
                 for df in (d.get("decorated_functions") or [])
             ],
+            package_name=d.get("package_name"),
             relative_imports=[
                 (int(r[0]), str(r[1] or ""), str(r[2] or ""),
                  r[3] if len(r) > 3 else None)
@@ -591,10 +605,21 @@ class _JsCallGraph:
         "generator_function_declaration", "generator_function",
     )
     _NEW_NODE = "new_expression"
+    _CLASS_DECL = "class_declaration"
+    _CLASS_EXPR = "class"  # tree-sitter-js node type for class expressions
+    _CLASS_BODY = "class_body"
+    _CLASS_HERITAGE = "class_heritage"
+    _METHOD_DEF = "method_definition"
+    _THIS_NODE = "this"
 
     def __init__(self) -> None:
         self.graph = FileCallGraph()
         self._enclosing: List[str] = []
+        # Class context for ``class Foo { method() { this.x(); } }``.
+        # JS classes are single-inheritance (one ``extends`` target)
+        # but mixin patterns mean class_heritage may carry a call
+        # expression — we capture the surface identifier when present.
+        self._class_stack: List[ClassDef] = []
 
     def walk(self, node) -> None:
         """Recursive descent. We push/pop the enclosing-function
@@ -602,9 +627,51 @@ class _JsCallGraph:
         is the innermost NAMED enclosing function — anonymous
         functions / arrows are walked-through without affecting
         the caller attribution."""
+        if node.type == self._CLASS_DECL:
+            name_node = self._first_child_of_type(node, (self._IDENT_NODE,))
+            if name_node is not None:
+                bases: List[str] = []
+                heritage = self._first_child_of_type(node, (
+                    self._CLASS_HERITAGE,
+                ))
+                if heritage is not None:
+                    # ``extends Foo`` → identifier child; ``extends
+                    # mixin(Base)`` → call_expression. Capture the
+                    # innermost identifier where present.
+                    for hc in heritage.children:
+                        if hc.type == self._IDENT_NODE:
+                            bases.append(hc.text.decode())
+                cdef = ClassDef(
+                    name=name_node.text.decode(),
+                    line=node.start_point[0] + 1,
+                    bases=bases,
+                    nested=bool(self._class_stack) or bool(self._enclosing),
+                )
+                self.graph.classes.append(cdef)
+                self._class_stack.append(cdef)
+                try:
+                    for child in node.children:
+                        self.walk(child)
+                finally:
+                    self._class_stack.pop()
+                return
+            # Anon class — recurse without push.
+            for child in node.children:
+                self.walk(child)
+            return
+
         if node.type in self._FUNC_NODES:
             name = self._function_name(node)
             if name is not None:
+                # Register method on the immediate class (only when
+                # this is a method_definition, not a nested function
+                # or arrow inside a method).
+                if (node.type == self._METHOD_DEF
+                        and self._class_stack
+                        and not self._enclosing):
+                    self._class_stack[-1].methods.append(
+                        (name, node.start_point[0] + 1),
+                    )
                 self._enclosing.append(name)
                 try:
                     for child in node.children:
@@ -677,13 +744,29 @@ class _JsCallGraph:
         self.graph.imports[bound] = f"{module}.{original}"
 
     def _visit_lex_decl(self, node) -> None:
-        """``const x = require('foo')`` / ``const { y } = require('foo')``."""
+        """``const x = require('foo')`` / ``const { y } = require('foo')``
+        / ``const Foo = class extends Bar { ... }``."""
         for declarator in node.children:
             if declarator.type != self._VAR_DECLARATOR_NODE:
                 continue
             value = self._declarator_value(declarator)
             if value is None:
                 continue
+            # ``const Foo = class ... {}`` — synthesise a ClassDef
+            # with the LHS identifier as the class name. Bases come
+            # from class_heritage; methods from the class_body. We
+            # only synthesise metadata here; the walker still
+            # descends into the body so calls inside class methods
+            # are recorded as call sites (just without class
+            # context, since class expressions are anonymous in the
+            # grammar and we don't push class_stack from here).
+            if value.type == self._CLASS_EXPR:
+                target = declarator.children[0] if declarator.children else None
+                if (target is not None
+                        and target.type == self._IDENT_NODE):
+                    self._synthesise_class_from_expr(
+                        value, target.text.decode(),
+                    )
             module = self._require_module_name(value)
             if module is None:
                 continue
@@ -714,6 +797,45 @@ class _JsCallGraph:
                             orig = ids[0].text.decode()
                             alias = ids[1].text.decode()
                             self.graph.imports[alias] = f"{module}.{orig}"
+
+    def _synthesise_class_from_expr(self, cls_node, name: str) -> None:
+        """``const Foo = class extends Bar { method() {} };``
+
+        Pulls bases from class_heritage and method names from
+        class_body.method_definition. Adds a ClassDef carrying
+        ``name`` (taken from the variable_declarator's LHS,
+        since class expressions are anonymous in the grammar).
+        """
+        bases: List[str] = []
+        body = None
+        for c in cls_node.children:
+            if c.type == self._CLASS_HERITAGE:
+                for hc in c.children:
+                    if hc.type == self._IDENT_NODE:
+                        bases.append(hc.text.decode())
+            elif c.type == self._CLASS_BODY:
+                body = c
+        methods: List[Tuple[str, int]] = []
+        if body is not None:
+            for c in body.children:
+                if c.type != self._METHOD_DEF:
+                    continue
+                m_name = self._first_child_of_type(c, (
+                    self._IDENT_NODE, self._PROP_IDENT_NODE,
+                    "private_property_identifier",
+                ))
+                if m_name is not None:
+                    methods.append((
+                        m_name.text.decode(),
+                        c.start_point[0] + 1,
+                    ))
+        self.graph.classes.append(ClassDef(
+            name=name,
+            line=cls_node.start_point[0] + 1,
+            bases=bases,
+            methods=methods,
+            nested=bool(self._class_stack) or bool(self._enclosing),
+        ))
 
     # ------------------------------------------------------------------
     # Calls + indirection
@@ -775,10 +897,21 @@ class _JsCallGraph:
             self.graph.indirection.add(INDIRECTION_DYNAMIC_IMPORT)
 
         caller = self._enclosing[-1] if self._enclosing else None
+        # ``this.foo()`` inside an instance method → narrow to the
+        # enclosing class. Unqualified ``foo()`` inside a method
+        # does NOT — JS unqualified names resolve through the
+        # lexical scope (could be a module-level function, an
+        # import, or a closure variable), not via implicit-this.
+        receiver_class: Optional[str] = None
+        if (self._class_stack and not self._class_stack[-1].nested
+                and self._enclosing
+                and len(chain) >= 2 and chain[0] == "this"):
+            receiver_class = self._class_stack[-1].name
         self.graph.calls.append(CallSite(
             line=node.start_point[0] + 1,
             chain=chain,
             caller=caller,
+            receiver_class=receiver_class,
         ))
 
     # ------------------------------------------------------------------
@@ -811,7 +944,10 @@ class _JsCallGraph:
         if node.type not in named_kinds:
             return None
         ident = self._first_child_of_type(
-            node, (self._IDENT_NODE, self._PROP_IDENT_NODE),
+            node, (
+                self._IDENT_NODE, self._PROP_IDENT_NODE,
+                "private_property_identifier",
+            ),
         )
         if ident is not None:
             return ident.text.decode()
@@ -840,7 +976,8 @@ class _JsCallGraph:
             cur = callee
             while cur is not None and cur.type == self._MEMBER_NODE:
                 prop = self._last_child_of_type(
-                    cur, (self._PROP_IDENT_NODE,),
+                    cur, (self._PROP_IDENT_NODE,
+                          "private_property_identifier"),
                 )
                 if prop is None:
                     return None
@@ -848,6 +985,12 @@ class _JsCallGraph:
                 cur = cur.children[0] if cur.children else None
             if cur is not None and cur.type == self._IDENT_NODE:
                 parts.append(cur.text.decode())
+                return list(reversed(parts))
+            if cur is not None and cur.type == self._THIS_NODE:
+                # ``this.X.Y()`` — preserve ``this`` as the head so
+                # the call site can be tagged with the enclosing
+                # class as receiver_class.
+                parts.append("this")
                 return list(reversed(parts))
             return None
         return None
@@ -1072,6 +1215,7 @@ class _GoCallGraph:
     _ARG_LIST_NODE = "argument_list"
     _FUNC_DECL_NODE = "function_declaration"
     _METHOD_DECL_NODE = "method_declaration"
+    _PKG_CLAUSE_NODE = "package_clause"
 
     def __init__(self) -> None:
         self.graph = FileCallGraph()
@@ -1113,6 +1257,27 @@ class _GoCallGraph:
         if node.type == self._IMPORT_DECL_NODE:
             self._visit_import(node)
             # Don't recurse inside (no calls / functions live there).
+            return
+
+        if node.type == self._PKG_CLAUSE_NODE:
+            # Every Go source file starts with ``package <name>``.
+            # The package name authoritatively identifies cross-
+            # file references; the dir name is NOT canonical.
+            # We store the package-as-declared (a single identifier,
+            # not the full module path — the latter requires
+            # go.mod context which the per-file extractor doesn't
+            # have). The reachability resolver combines this with
+            # the function name to seed ``qualified_to_internal``.
+            pkg_ident = self._first_child_of_type(
+                node, (self._PKG_IDENT_NODE, self._IDENT_NODE),
+            )
+            if pkg_ident is not None:
+                try:
+                    self.graph.package_name = pkg_ident.text.decode(
+                        "utf-8", errors="replace",
+                    ).strip()
+                except Exception:                       # noqa: BLE001
+                    pass
             return
 
         if node.type == self._CALL_NODE:
@@ -1367,6 +1532,7 @@ class _JavaCallGraph:
 
     _METHOD_INVOCATION = "method_invocation"
     _IMPORT_DECL = "import_declaration"
+    _PKG_DECL = "package_declaration"
     _SCOPED_IDENT = "scoped_identifier"
     _IDENT = "identifier"
     _FIELD_ACCESS = "field_access"
@@ -1374,6 +1540,13 @@ class _JavaCallGraph:
     _METHOD_DECL = "method_declaration"
     _CONSTRUCTOR_DECL = "constructor_declaration"
     _CLASS_DECL = "class_declaration"
+    _INTERFACE_DECL = "interface_declaration"
+    _RECORD_DECL = "record_declaration"
+    _ENUM_DECL = "enum_declaration"
+    _SUPERCLASS = "superclass"
+    _SUPER_INTERFACES = "super_interfaces"
+    _EXTENDS_INTERFACES = "extends_interfaces"
+    _TYPE_IDENT = "type_identifier"
     _ASTERISK = "asterisk"
     _STATIC = "static"
     _STRING_LIT = "string_literal"
@@ -1381,15 +1554,27 @@ class _JavaCallGraph:
     def __init__(self) -> None:
         self.graph = FileCallGraph()
         self._enclosing: List[str] = []
+        # Class-context stack — Java methods always live inside a
+        # class. The innermost class is what ``self.method()`` /
+        # ``this.method()`` calls dispatch on. Captured for
+        # class-aware narrowing parity with Python.
+        self._class_stack: List[ClassDef] = []
 
     def walk(self, node) -> None:
         """Recursive descent. Push/pop enclosing-method stack so
         ``CallSite.caller`` carries the innermost named method."""
         if node.type == self._METHOD_DECL:
             name = self._first_child_of_type(node, (self._IDENT,))
-            self._enclosing.append(
-                name.text.decode() if name else "<anon>"
-            )
+            method_name = name.text.decode() if name else "<anon>"
+            # Register the method on the directly-enclosing class
+            # (depth-1 only; nested-class methods stay on the
+            # nested class). ``_enclosing`` is empty here because
+            # methods aren't nested inside methods in Java.
+            if self._class_stack and not self._enclosing:
+                self._class_stack[-1].methods.append(
+                    (method_name, node.start_point[0] + 1),
+                )
+            self._enclosing.append(method_name)
             try:
                 for child in node.children:
                     self.walk(child)
@@ -1400,9 +1585,12 @@ class _JavaCallGraph:
         if node.type == self._CONSTRUCTOR_DECL:
             # Constructors use the class name as the identifier.
             name = self._first_child_of_type(node, (self._IDENT,))
-            self._enclosing.append(
-                name.text.decode() if name else "<ctor>"
-            )
+            ctor_name = name.text.decode() if name else "<ctor>"
+            if self._class_stack and not self._enclosing:
+                self._class_stack[-1].methods.append(
+                    (ctor_name, node.start_point[0] + 1),
+                )
+            self._enclosing.append(ctor_name)
             try:
                 for child in node.children:
                     self.walk(child)
@@ -1412,6 +1600,94 @@ class _JavaCallGraph:
 
         if node.type == self._IMPORT_DECL:
             self._visit_import(node)
+            return
+
+        if node.type == self._PKG_DECL:
+            # ``package com.foo.bar;`` — the dotted prefix every
+            # class in this file lives under. Java's fully-qualified
+            # name is ``<package>.<class>`` (and method invocations
+            # resolve via the import map + class hierarchy).
+            scoped = self._first_child_of_type(node, (
+                self._SCOPED_IDENT, self._IDENT,
+            ))
+            if scoped is not None:
+                if scoped.type == self._SCOPED_IDENT:
+                    pkg = self._scoped_identifier_text(scoped)
+                else:
+                    pkg = scoped.text.decode("utf-8", errors="replace")
+                if pkg:
+                    self.graph.package_name = pkg.strip()
+            return
+
+        if node.type in (self._CLASS_DECL, self._INTERFACE_DECL,
+                         self._RECORD_DECL, self._ENUM_DECL):
+            # Capture for class-aware narrowing. Java's
+            # ``superclass`` + ``super_interfaces`` lists are
+            # the bases; record them so ancestor resolution at
+            # query time can narrow correctly. ``record_declaration``
+            # (Java 14+) and ``enum_declaration`` share the same
+            # body+heritage shape and host method definitions same
+            # as a class.
+            name_node = self._first_child_of_type(node, (
+                self._IDENT, self._TYPE_IDENT,
+            ))
+            cls_name = (
+                name_node.text.decode("utf-8", errors="replace")
+                if name_node is not None else None
+            )
+            bases: List[str] = []
+            for child in node.children:
+                if child.type == self._SUPERCLASS:
+                    # ``extends Base`` — direct type_identifier child.
+                    for sub in child.children:
+                        if sub.type in (self._IDENT, self._TYPE_IDENT,
+                                        self._SCOPED_IDENT):
+                            text = (
+                                self._scoped_identifier_text(sub)
+                                if sub.type == self._SCOPED_IDENT
+                                else sub.text.decode(
+                                    "utf-8", errors="replace",
+                                )
+                            )
+                            if text:
+                                bases.append(text)
+                elif child.type in (self._SUPER_INTERFACES,
+                                    self._EXTENDS_INTERFACES):
+                    # ``implements A, B`` (class) or ``extends A, B``
+                    # (interface) — both wrap a ``type_list``.
+                    for grandchild in child.children:
+                        if grandchild.type != "type_list":
+                            continue
+                        for sub in grandchild.children:
+                            if sub.type in (self._IDENT, self._TYPE_IDENT,
+                                            self._SCOPED_IDENT):
+                                text = (
+                                    self._scoped_identifier_text(sub)
+                                    if sub.type == self._SCOPED_IDENT
+                                    else sub.text.decode(
+                                        "utf-8", errors="replace",
+                                    )
+                                )
+                                if text:
+                                    bases.append(text)
+            if cls_name:
+                cdef = ClassDef(
+                    name=cls_name,
+                    line=node.start_point[0] + 1,
+                    bases=bases,
+                    nested=bool(self._class_stack) or bool(self._enclosing),
+                )
+                self.graph.classes.append(cdef)
+                self._class_stack.append(cdef)
+                try:
+                    for child in node.children:
+                        self.walk(child)
+                finally:
+                    self._class_stack.pop()
+                return
+            # Anon / malformed — recurse without class push
+            for child in node.children:
+                self.walk(child)
             return
 
         if node.type == self._METHOD_INVOCATION:
@@ -1502,10 +1778,25 @@ class _JavaCallGraph:
             self.graph.indirection.add(INDIRECTION_REFLECT)
 
         caller = self._enclosing[-1] if self._enclosing else None
+
+        # Class-aware narrowing. Java implicit-receiver calls
+        # (``foo()`` from inside a method) and ``this.foo()``
+        # dispatch on the innermost non-nested enclosing class.
+        # ``super.foo()`` is the parent — leave receiver_class
+        # None and let the resolver search bases via the hierarchy.
+        receiver_class: Optional[str] = None
+        if (self._class_stack and not self._class_stack[-1].nested
+                and self._enclosing):
+            if len(chain) == 1:
+                receiver_class = self._class_stack[-1].name
+            elif len(chain) == 2 and chain[0] == "this":
+                receiver_class = self._class_stack[-1].name
+
         self.graph.calls.append(CallSite(
             line=node.start_point[0] + 1,
             chain=chain,
             caller=caller,
+            receiver_class=receiver_class,
         ))
 
     def _invocation_chain(self, node) -> Optional[List[str]]:
@@ -1537,7 +1828,8 @@ class _JavaCallGraph:
                 break
             if not child.is_named:
                 continue
-            if child.type in (self._IDENT, self._FIELD_ACCESS):
+            if child.type in (self._IDENT, self._FIELD_ACCESS,
+                              "this", "super"):
                 named_before_args.append(child)
             elif child.type == "type_arguments":
                 # Java generics on the call: ``foo.<T>bar()`` —
@@ -1565,6 +1857,9 @@ class _JavaCallGraph:
 
         if operand.type == self._IDENT:
             return [operand.text.decode(), method_name]
+
+        if operand.type in ("this", "super"):
+            return [operand.type, method_name]
 
         if operand.type == self._FIELD_ACCESS:
             parts = self._field_access_chain(operand)
@@ -1678,20 +1973,47 @@ class _RustCallGraph:
     _IDENT = "identifier"
     _FIELD_IDENT = "field_identifier"
     _FUNCTION_ITEM = "function_item"
+    _FUNCTION_SIG = "function_signature_item"
     _CALL_EXPR = "call_expression"
     _FIELD_EXPR = "field_expression"
     _ARGS = "arguments"
+    _TYPE_IDENT = "type_identifier"
+    _STRUCT_ITEM = "struct_item"
+    _ENUM_ITEM = "enum_item"
+    _UNION_ITEM = "union_item"
+    _TRAIT_ITEM = "trait_item"
+    _IMPL_ITEM = "impl_item"
+    _MOD_ITEM = "mod_item"
+    _DECL_LIST = "declaration_list"
+    _SELF = "self"
 
     def __init__(self) -> None:
         self.graph = FileCallGraph()
         self._enclosing: List[str] = []
+        # Class context for ``impl Foo { fn m() {} }`` — methods
+        # in the impl block belong to ``Foo``. ``impl Trait for
+        # Foo`` also belongs to ``Foo`` (the second type_identifier).
+        # Same convention as Python / Java class_stack.
+        self._class_stack: List[ClassDef] = []
+        # Module nesting for mod_item; not threaded into
+        # package_name (Rust file modules are path-derived) but
+        # used to mark nested classes.
+        self._mod_depth: int = 0
 
     def walk(self, node) -> None:
         if node.type == self._FUNCTION_ITEM:
             name = self._first_child_of_type(node, (self._IDENT,))
-            self._enclosing.append(
-                name.text.decode() if name else "<anon>"
-            )
+            method_name = name.text.decode() if name else "<anon>"
+            # Register the method on the directly-enclosing impl
+            # block (the innermost class on the stack). Skip if
+            # we're inside a nested function (functions can be
+            # nested inside other functions in Rust — those aren't
+            # methods of the outer class).
+            if self._class_stack and not self._enclosing:
+                self._class_stack[-1].methods.append(
+                    (method_name, node.start_point[0] + 1),
+                )
+            self._enclosing.append(method_name)
             try:
                 for c in node.children:
                     self.walk(c)
@@ -1699,8 +2021,129 @@ class _RustCallGraph:
                 self._enclosing.pop()
             return
 
+        if node.type == self._FUNCTION_SIG:
+            # ``fn name(args);`` inside a trait body — no body, no
+            # calls to walk, but does count as a method definition
+            # on the trait.
+            name = self._first_child_of_type(node, (self._IDENT,))
+            if name is not None and self._class_stack:
+                method_name = name.text.decode()
+                self._class_stack[-1].methods.append(
+                    (method_name, node.start_point[0] + 1),
+                )
+            return
+
         if node.type == self._USE_DECL:
             self._handle_use(node)
+            return
+
+        if node.type == self._MOD_ITEM:
+            self._mod_depth += 1
+            try:
+                for c in node.children:
+                    self.walk(c)
+            finally:
+                self._mod_depth -= 1
+            return
+
+        if node.type in (self._STRUCT_ITEM, self._ENUM_ITEM,
+                         self._UNION_ITEM, self._TRAIT_ITEM):
+            # ``struct Foo;`` / ``enum E { ... }`` / ``trait T``
+            # declares the class itself. Bases are the trait
+            # supertraits for trait_item (``trait T: A + B``); for
+            # struct/enum/union there are no bases (impls add them).
+            name_node = self._first_child_of_type(node, (
+                self._TYPE_IDENT,
+            ))
+            bases: List[str] = []
+            if node.type == self._TRAIT_ITEM:
+                # Trait supertraits live inside a ``trait_bounds``
+                # node — collect type_identifiers there.
+                bounds = self._first_child_of_type(node, (
+                    "trait_bounds",
+                ))
+                if bounds is not None:
+                    for sub in bounds.children:
+                        if sub.type == self._TYPE_IDENT:
+                            bases.append(sub.text.decode())
+            if name_node is not None:
+                cdef = ClassDef(
+                    name=name_node.text.decode(),
+                    line=node.start_point[0] + 1,
+                    bases=bases,
+                    nested=(
+                        bool(self._class_stack)
+                        or bool(self._enclosing)
+                        or self._mod_depth > 0
+                    ),
+                )
+                self.graph.classes.append(cdef)
+                # Trait bodies hold method signatures we want
+                # registered; struct/enum bodies don't define
+                # methods (those live in separate impl blocks).
+                self._class_stack.append(cdef)
+                try:
+                    for c in node.children:
+                        self.walk(c)
+                finally:
+                    self._class_stack.pop()
+                return
+            # Anon — recurse without push.
+            for c in node.children:
+                self.walk(c)
+            return
+
+        if node.type == self._IMPL_ITEM:
+            # ``impl Foo`` or ``impl Trait for Foo``. Method
+            # definitions inside belong to ``Foo``. The grammar
+            # emits two type_identifier children for the second
+            # shape; the impl target is the LAST one. Generic
+            # impls (``impl<T> Box<T>``) wrap the target in a
+            # ``generic_type`` node whose first child is the
+            # type_identifier we want.
+            target_names: List[str] = []
+            for c in node.children:
+                if c.type == self._TYPE_IDENT:
+                    target_names.append(c.text.decode())
+                elif c.type == "generic_type":
+                    ti = self._first_child_of_type(c, (self._TYPE_IDENT,))
+                    if ti is not None:
+                        target_names.append(ti.text.decode())
+                elif c.type == self._SCOPED_IDENT:
+                    parts = self._scoped_parts(c)
+                    if parts:
+                        target_names.append(parts[-1])
+            if not target_names:
+                # Unsupported shape — skip class binding, still
+                # recurse so calls inside are still captured.
+                for c in node.children:
+                    self.walk(c)
+                return
+            target = target_names[-1]
+            # Try to bind to the already-recorded ClassDef
+            # (same-file struct/enum) so methods accumulate on a
+            # single ClassDef rather than per-impl. If the impl
+            # target wasn't declared in this file, synthesise an
+            # impl-only ClassDef so cross-file method matching
+            # still works.
+            target_cls = next(
+                (c for c in self.graph.classes if c.name == target),
+                None,
+            )
+            if target_cls is None:
+                target_cls = ClassDef(
+                    name=target,
+                    line=node.start_point[0] + 1,
+                    bases=[],
+                    nested=self._mod_depth > 0,
+                )
+                self.graph.classes.append(target_cls)
+            self._class_stack.append(target_cls)
+            try:
+                for c in node.children:
+                    self.walk(c)
+            finally:
+                self._class_stack.pop()
             return
 
         if node.type == self._CALL_EXPR:
@@ -1708,8 +2151,18 @@ class _RustCallGraph:
             if chain:
                 line = node.start_point[0] + 1
                 caller = self._enclosing[-1] if self._enclosing else None
+                # Class-aware: ``self.foo()`` inside a method
+                # dispatches on the enclosing impl target. The
+                # chain shape is ``["self", "foo"]``.
+                receiver_class: Optional[str] = None
+                if (self._class_stack and self._enclosing
+                        and len(chain) == 2 and chain[0] == "self"):
+                    receiver_class = self._class_stack[-1].name
                 self.graph.calls.append(
-                    CallSite(line=line, chain=chain, caller=caller)
+                    CallSite(
+                        line=line, chain=chain, caller=caller,
+                        receiver_class=receiver_class,
+                    )
                 )
             for c in node.children:
                 self.walk(c)
@@ -1865,6 +2318,9 @@ class _RustCallGraph:
         if cur.type == self._IDENT:
             parts.append(cur.text.decode())
             return list(reversed(parts))
+        if cur.type == self._SELF:
+            parts.append("self")
+            return list(reversed(parts))
         if cur.type == self._SCOPED_IDENT:
             scoped = self._scoped_parts(cur)
             if not scoped:
@@ -1936,12 +2392,17 @@ class _RubyCallGraph:
 
     _CALL = "call"
     _METHOD = "method"
+    _SINGLETON_METHOD = "singleton_method"
     _IDENT = "identifier"
     _CONSTANT = "constant"
     _SCOPE_RES = "scope_resolution"
     _STRING = "string"
     _STRING_CONTENT = "string_content"
     _ARG_LIST = "argument_list"
+    _CLASS_NODE = "class"
+    _MODULE_NODE = "module"
+    _SUPERCLASS = "superclass"
+    _SELF = "self"
 
     _REFLECT_NAMES = {"send", "public_send", "__send__"}
     _CONST_GET_NAMES = {"const_get"}
@@ -1951,13 +2412,94 @@ class _RubyCallGraph:
     def __init__(self) -> None:
         self.graph = FileCallGraph()
         self._enclosing: List[str] = []
+        # Class context. Ruby ``self.foo()`` dispatches on the
+        # innermost ``class`` (modules dispatch to module functions
+        # but those aren't instance-bound, so we don't tag
+        # receiver_class for modules).
+        self._class_stack: List[ClassDef] = []
+        # Module nesting stack — used to build ``package_name``
+        # for nested modules. Ruby's top-level file is its own
+        # module; nested ``module Foo; module Bar; ...`` produce
+        # ``package_name="Foo.Bar"``.
+        self._mod_stack: List[str] = []
 
     def walk(self, node) -> None:
-        if node.type == self._METHOD:
+        if node.type == self._MODULE_NODE:
+            name_node = self._first_child_of_type(node, (
+                self._CONSTANT,
+            ))
+            if name_node is not None:
+                mod_name = name_node.text.decode()
+                self._mod_stack.append(mod_name)
+                # Set graph.package_name to the dotted form of the
+                # current module nesting. Last setter wins per
+                # file — typical Ruby files declare one or two
+                # module nesting levels at file top, so the deepest
+                # nesting is the canonical package.
+                self.graph.package_name = ".".join(self._mod_stack)
+                try:
+                    for c in node.children:
+                        self.walk(c)
+                finally:
+                    self._mod_stack.pop()
+                return
+            for c in node.children:
+                self.walk(c)
+            return
+
+        if node.type == self._CLASS_NODE:
+            name_node = self._first_child_of_type(node, (
+                self._CONSTANT,
+            ))
+            if name_node is not None:
+                bases: List[str] = []
+                # Ruby is single-inheritance — ``superclass`` carries
+                # exactly one base.
+                supercls = self._first_child_of_type(node, (
+                    self._SUPERCLASS,
+                ))
+                if supercls is not None:
+                    base_node = self._first_child_of_type(supercls, (
+                        self._CONSTANT, self._SCOPE_RES,
+                    ))
+                    if base_node is not None:
+                        if base_node.type == self._SCOPE_RES:
+                            bases = [".".join(
+                                self._chain_from_node(base_node)
+                            )]
+                        else:
+                            bases = [base_node.text.decode()]
+                cdef = ClassDef(
+                    name=name_node.text.decode(),
+                    line=node.start_point[0] + 1,
+                    bases=bases,
+                    nested=bool(self._class_stack) or bool(self._enclosing),
+                )
+                self.graph.classes.append(cdef)
+                self._class_stack.append(cdef)
+                try:
+                    for c in node.children:
+                        self.walk(c)
+                finally:
+                    self._class_stack.pop()
+                return
+            for c in node.children:
+                self.walk(c)
+            return
+
+        if node.type in (self._METHOD, self._SINGLETON_METHOD):
+            # ``def helper`` (method) and ``def self.helper`` /
+            # ``def Cls.helper`` (singleton_method) share the same
+            # method-name shape — the first ``identifier`` after the
+            # ``def`` keyword. Singleton methods inside a module
+            # body are the typical ``self.x`` module function form.
             name = self._first_child_of_type(node, (self._IDENT,))
-            self._enclosing.append(
-                name.text.decode() if name else "<anon>"
-            )
+            method_name = name.text.decode() if name else "<anon>"
+            if self._class_stack and not self._enclosing:
+                self._class_stack[-1].methods.append(
+                    (method_name, node.start_point[0] + 1),
+                )
+            self._enclosing.append(method_name)
             try:
                 for c in node.children:
                     self.walk(c)
@@ -2001,6 +2543,10 @@ class _RubyCallGraph:
                         receiver = c
                     else:
                         method = c
+                elif c.type == self._SELF and receiver is None:
+                    # ``self.foo`` — keep ``self`` as the receiver
+                    # so the chain reads ``["self", "foo"]``.
+                    receiver = c
                 elif c.type == self._SCOPE_RES:
                     receiver = c
                 elif c.type == self._CALL:
@@ -2060,6 +2606,8 @@ class _RubyCallGraph:
             return []
         if node.type in (self._IDENT, self._CONSTANT):
             return [node.text.decode()]
+        if node.type == self._SELF:
+            return ["self"]
         if node.type == self._SCOPE_RES:
             parts: List[str] = []
             for c in node.children:
@@ -2098,8 +2646,21 @@ class _RubyCallGraph:
     def _record(self, node, chain: List[str]) -> None:
         line = node.start_point[0] + 1
         caller = self._enclosing[-1] if self._enclosing else None
+        # ``self.foo()`` inside an instance method → narrow to the
+        # enclosing class. Bare-name ``foo()`` resolves through
+        # Ruby's method-lookup chain (could be from a mixin, the
+        # superclass, or the same class); without runtime semantics
+        # we can't narrow it, so leave receiver_class None.
+        receiver_class: Optional[str] = None
+        if (self._class_stack and not self._class_stack[-1].nested
+                and self._enclosing
+                and len(chain) >= 2 and chain[0] == "self"):
+            receiver_class = self._class_stack[-1].name
         self.graph.calls.append(
-            CallSite(line=line, chain=chain, caller=caller)
+            CallSite(
+                line=line, chain=chain, caller=caller,
+                receiver_class=receiver_class,
+            )
         )
 
     @staticmethod
@@ -2166,6 +2727,14 @@ class _CSharpCallGraph:
     _INVOCATION = "invocation_expression"
     _MEMBER_ACCESS = "member_access_expression"
     _ARG_LIST = "argument_list"
+    _NAMESPACE_DECL = "namespace_declaration"
+    _FILE_NAMESPACE_DECL = "file_scoped_namespace_declaration"
+    _CLASS_DECL = "class_declaration"
+    _INTERFACE_DECL = "interface_declaration"
+    _STRUCT_DECL = "struct_declaration"
+    _RECORD_DECL = "record_declaration"
+    _BASE_LIST = "base_list"
+    _THIS = "this_expression"
 
     _REFLECT_METHODS = {
         "Invoke", "GetMethod", "CreateInstance",
@@ -2176,13 +2745,97 @@ class _CSharpCallGraph:
     def __init__(self) -> None:
         self.graph = FileCallGraph()
         self._enclosing: List[str] = []
+        self._class_stack: List[ClassDef] = []
+        # Namespace nesting; can be ``namespace Foo.Bar { ... }``
+        # (one node carrying dotted form) OR nested ``namespace Foo
+        # { namespace Bar { ... } }``. Track each segment separately.
+        self._ns_stack: List[str] = []
 
     def walk(self, node) -> None:
+        if node.type == self._FILE_NAMESPACE_DECL:
+            # C# 10's file-scoped namespace: ``namespace Foo.Bar;``
+            # with no braces. The namespace applies to every
+            # declaration that follows in the same compilation
+            # unit (which are SIBLINGS of this node, not children).
+            # Set ``package_name`` once and let the normal recursion
+            # continue — don't push/pop the stack because the scope
+            # doesn't close.
+            name_node = self._first_child_of_type(node, (
+                self._QUALIFIED, self._IDENT,
+            ))
+            if name_node is not None:
+                if name_node.type == self._QUALIFIED:
+                    parts = self._qualified_parts(name_node)
+                else:
+                    parts = [name_node.text.decode()]
+                self._ns_stack.extend(parts)
+                self.graph.package_name = ".".join(self._ns_stack)
+            return
+
+        if node.type == self._NAMESPACE_DECL:
+            # Braced ``namespace Foo.Bar { ... }`` — applies to the
+            # nested declaration_list only.
+            name_node = self._first_child_of_type(node, (
+                self._QUALIFIED, self._IDENT,
+            ))
+            if name_node is not None:
+                if name_node.type == self._QUALIFIED:
+                    parts = self._qualified_parts(name_node)
+                else:
+                    parts = [name_node.text.decode()]
+                self._ns_stack.extend(parts)
+                self.graph.package_name = ".".join(self._ns_stack)
+                try:
+                    for c in node.children:
+                        self.walk(c)
+                finally:
+                    for _ in parts:
+                        self._ns_stack.pop()
+                return
+            for c in node.children:
+                self.walk(c)
+            return
+
+        if node.type in (self._CLASS_DECL, self._INTERFACE_DECL,
+                         self._STRUCT_DECL, self._RECORD_DECL):
+            name_node = self._first_child_of_type(node, (self._IDENT,))
+            if name_node is not None:
+                bases: List[str] = []
+                bl = self._first_child_of_type(node, (self._BASE_LIST,))
+                if bl is not None:
+                    for sub in bl.children:
+                        if sub.type == self._IDENT:
+                            bases.append(sub.text.decode())
+                        elif sub.type == self._QUALIFIED:
+                            qparts = self._qualified_parts(sub)
+                            if qparts:
+                                bases.append(".".join(qparts))
+                cdef = ClassDef(
+                    name=name_node.text.decode(),
+                    line=node.start_point[0] + 1,
+                    bases=bases,
+                    nested=bool(self._class_stack) or bool(self._enclosing),
+                )
+                self.graph.classes.append(cdef)
+                self._class_stack.append(cdef)
+                try:
+                    for c in node.children:
+                        self.walk(c)
+                finally:
+                    self._class_stack.pop()
+                return
+            for c in node.children:
+                self.walk(c)
+            return
+
         if node.type in (self._METHOD_DECL, self._CONSTRUCTOR_DECL):
             name = self._first_child_of_type(node, (self._IDENT,))
-            self._enclosing.append(
-                name.text.decode() if name else "<anon>"
-            )
+            method_name = name.text.decode() if name else "<anon>"
+            if self._class_stack and not self._enclosing:
+                self._class_stack[-1].methods.append(
+                    (method_name, node.start_point[0] + 1),
+                )
+            self._enclosing.append(method_name)
             try:
                 for c in node.children:
                     self.walk(c)
@@ -2199,8 +2852,24 @@ class _CSharpCallGraph:
             if chain:
                 line = node.start_point[0] + 1
                 caller = self._enclosing[-1] if self._enclosing else None
+                # ``this.X()`` inside an instance method → narrow
+                # to the enclosing class. C# unqualified ``X()``
+                # also dispatches via implicit-this (no module-
+                # level functions in C#), so tag length-1 chains
+                # too when inside a class.
+                receiver_class: Optional[str] = None
+                if (self._class_stack
+                        and not self._class_stack[-1].nested
+                        and self._enclosing):
+                    if len(chain) == 1:
+                        receiver_class = self._class_stack[-1].name
+                    elif len(chain) == 2 and chain[0] == "this":
+                        receiver_class = self._class_stack[-1].name
                 self.graph.calls.append(
-                    CallSite(line=line, chain=chain, caller=caller)
+                    CallSite(
+                        line=line, chain=chain, caller=caller,
+                        receiver_class=receiver_class,
+                    )
                 )
                 # Indirection flags
                 tail = chain[-1]
@@ -2285,12 +2954,35 @@ class _CSharpCallGraph:
         return None
 
     def _member_access_chain(self, node) -> Optional[List[str]]:
-        """``a.b.c`` (member_access_expression)."""
+        """``a.b.c`` (member_access_expression).
+
+        ``this.X`` and ``base.X`` use unnamed keyword tokens for the
+        LHS in tree-sitter-c_sharp — special-cased below."""
         parts: List[str] = []
         cur = node
         while cur is not None and cur.type == self._MEMBER_ACCESS:
-            # member_access: expression + . + name (identifier)
             named = [c for c in cur.children if c.is_named]
+            if len(named) == 1:
+                # Only the trailing name is named — LHS is an
+                # unnamed keyword. Check for ``this`` / ``base``.
+                has_this = any(
+                    not c.is_named and c.type in ("this", "base")
+                    for c in cur.children
+                )
+                if not has_this:
+                    return None
+                tail = named[-1]
+                if tail.type != self._IDENT:
+                    return None
+                parts.append(tail.text.decode())
+                # Synthesise the unnamed-this LHS as the chain head.
+                kw = next(
+                    (c.type for c in cur.children
+                     if not c.is_named and c.type in ("this", "base")),
+                    "this",
+                )
+                parts.append(kw)
+                return list(reversed(parts))
             if len(named) < 2:
                 return None
             tail = named[-1]
@@ -2302,6 +2994,9 @@ class _CSharpCallGraph:
             return None
         if cur.type == self._IDENT:
             parts.append(cur.text.decode())
+            return list(reversed(parts))
+        if cur.type == self._THIS:
+            parts.append("this")
             return list(reversed(parts))
         if cur.type == self._QUALIFIED:
             qparts = self._qualified_parts(cur)
@@ -2413,6 +3108,7 @@ class _PhpCallGraph:
     _NAMESPACE_USE_DECL = "namespace_use_declaration"
     _NAMESPACE_USE_CLAUSE = "namespace_use_clause"
     _NAMESPACE_NAME = "namespace_name"
+    _NAMESPACE_DEF = "namespace_definition"
     _QUALIFIED = "qualified_name"
     _NAME = "name"
     _IDENT = "name"          # PHP grammar uses ``name`` for identifiers
@@ -2424,6 +3120,12 @@ class _PhpCallGraph:
     _MEMBER_ACCESS = "member_access_expression"
     _ARGS = "arguments"
     _VAR = "variable_name"
+    _CLASS_DECL = "class_declaration"
+    _INTERFACE_DECL = "interface_declaration"
+    _TRAIT_DECL = "trait_declaration"
+    _ENUM_DECL = "enum_declaration"
+    _BASE_CLAUSE = "base_clause"
+    _CLASS_INTERFACE_CLAUSE = "class_interface_clause"
 
     _REFLECT_FNS = {
         "call_user_func", "call_user_func_array",
@@ -2437,13 +3139,79 @@ class _PhpCallGraph:
     def __init__(self) -> None:
         self.graph = FileCallGraph()
         self._enclosing: List[str] = []
+        self._class_stack: List[ClassDef] = []
 
     def walk(self, node) -> None:
+        if node.type == self._NAMESPACE_DEF:
+            # ``namespace Foo\Bar;`` — capture as dotted package
+            # name. The namespace_name child carries the parts.
+            ns_name = self._first_child_of_type(node, (
+                self._NAMESPACE_NAME,
+            ))
+            if ns_name is not None:
+                parts = self._namespace_parts(ns_name)
+                if parts:
+                    self.graph.package_name = ".".join(parts)
+            # Descend into the namespace body (declarations live
+            # inside compound_statement if braced, or as siblings).
+            for c in node.children:
+                self.walk(c)
+            return
+
+        if node.type in (self._CLASS_DECL, self._INTERFACE_DECL,
+                         self._TRAIT_DECL, self._ENUM_DECL):
+            name_node = self._first_child_of_type(node, (self._NAME,))
+            if name_node is not None:
+                bases: List[str] = []
+                # ``extends Base`` (single-class inheritance in PHP).
+                bc = self._first_child_of_type(node, (self._BASE_CLAUSE,))
+                if bc is not None:
+                    for sub in bc.children:
+                        if sub.type == self._NAME:
+                            bases.append(sub.text.decode())
+                        elif sub.type == self._QUALIFIED:
+                            qparts = self._namespace_parts(sub)
+                            if qparts:
+                                bases.append(".".join(qparts))
+                # ``implements I1, I2`` (multiple interfaces).
+                cic = self._first_child_of_type(node, (
+                    self._CLASS_INTERFACE_CLAUSE,
+                ))
+                if cic is not None:
+                    for sub in cic.children:
+                        if sub.type == self._NAME:
+                            bases.append(sub.text.decode())
+                        elif sub.type == self._QUALIFIED:
+                            qparts = self._namespace_parts(sub)
+                            if qparts:
+                                bases.append(".".join(qparts))
+                cdef = ClassDef(
+                    name=name_node.text.decode(),
+                    line=node.start_point[0] + 1,
+                    bases=bases,
+                    nested=bool(self._class_stack) or bool(self._enclosing),
+                )
+                self.graph.classes.append(cdef)
+                self._class_stack.append(cdef)
+                try:
+                    for c in node.children:
+                        self.walk(c)
+                finally:
+                    self._class_stack.pop()
+                return
+            for c in node.children:
+                self.walk(c)
+            return
+
         if node.type in (self._FUNCTION_DEF, self._METHOD_DECL):
             name = self._first_child_of_type(node, (self._NAME,))
-            self._enclosing.append(
-                name.text.decode() if name else "<anon>"
-            )
+            method_name = name.text.decode() if name else "<anon>"
+            if (node.type == self._METHOD_DECL
+                    and self._class_stack and not self._enclosing):
+                self._class_stack[-1].methods.append(
+                    (method_name, node.start_point[0] + 1),
+                )
+            self._enclosing.append(method_name)
             try:
                 for c in node.children:
                     self.walk(c)
@@ -2514,8 +3282,30 @@ class _PhpCallGraph:
             return
         line = node.start_point[0] + 1
         caller = self._enclosing[-1] if self._enclosing else None
+        # ``$this->X()`` (already canonicalised to chain ``["this",
+        # "X"]`` by _object_chain stripping the $) inside an
+        # instance method → narrow to the enclosing class. Bare
+        # function calls are NOT implicit-this in PHP — they
+        # resolve to namespaced/global functions.
+        # ``self::X()`` and ``static::X()`` (late-static-binding)
+        # also dispatch on the enclosing class; ``parent::X()``
+        # dispatches on the parent (leave None, let resolver
+        # search bases).
+        receiver_class: Optional[str] = None
+        if (self._class_stack and not self._class_stack[-1].nested
+                and self._enclosing
+                and len(chain) >= 2):
+            if (node.type == self._MEMBER_CALL
+                    and chain[0] == "this"):
+                receiver_class = self._class_stack[-1].name
+            elif (node.type == self._SCOPED_CALL
+                  and chain[0] in ("self", "static")):
+                receiver_class = self._class_stack[-1].name
         self.graph.calls.append(
-            CallSite(line=line, chain=chain, caller=caller)
+            CallSite(
+                line=line, chain=chain, caller=caller,
+                receiver_class=receiver_class,
+            )
         )
         # Indirection flags
         tail = chain[-1]
@@ -2544,7 +3334,11 @@ class _PhpCallGraph:
         return None
 
     def _scoped_call_chain(self, node) -> Optional[List[str]]:
-        # scoped_call_expression: scope (Class) :: name + arguments
+        # scoped_call_expression: scope (Class) :: name + arguments.
+        # PHP's ``self::method()`` / ``static::method()`` /
+        # ``parent::method()`` use a ``relative_scope`` node holding
+        # the keyword. ``Class::method()`` uses a ``name`` or
+        # ``qualified_name`` scope.
         scope = None
         method = None
         for c in node.children:
@@ -2561,6 +3355,18 @@ class _PhpCallGraph:
             scope_parts = [scope.text.decode()]
         elif scope.type in (self._QUALIFIED, self._NAMESPACE_NAME):
             scope_parts = self._namespace_parts(scope)
+        elif scope.type == "relative_scope":
+            # ``self``/``static``/``parent``. Use the keyword as
+            # the chain head so receiver_class can be set when
+            # applicable.
+            kw = None
+            for sub in scope.children:
+                if sub.type in ("self", "static", "parent"):
+                    kw = sub.type
+                    break
+            if kw is None:
+                return None
+            scope_parts = [kw]
         else:
             return None
         return scope_parts + [method.text.decode()]

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -214,6 +214,40 @@ def function_called(
                     file_has_evidence = True
                     evidence.append((path, int(call.get("line", 0) or 0)))
 
+        # Class-aware receiver_class fast-path: when the chain
+        # tail is the target_func AND the call carries a
+        # ``receiver_class``, synthesise the qualified name
+        # ``<file_package>.<receiver_class>.<tail>`` and compare
+        # against the target. This catches Java's implicit-this
+        # (``helper()`` inside a class method), Ruby's
+        # ``self.helper``, C#'s implicit-this, etc. — bare calls
+        # the import-map path can't resolve because their head
+        # isn't in imports.
+        if not file_has_evidence:
+            file_pkg = cg.get("package_name")
+            for call in calls:
+                chain = call.get("chain") or []
+                if not chain or chain[-1] != target_func:
+                    continue
+                rc = call.get("receiver_class")
+                if rc is None:
+                    continue
+                # Construct the resolved qualified name. For
+                # languages with a declared package_name the form
+                # is ``<pkg>.<Class>.<method>``. For languages
+                # where the file IS the module (Python / JS /
+                # Ruby class-less), fall back to path-derived form.
+                candidates: List[str] = []
+                if file_pkg:
+                    candidates.append(f"{file_pkg}.{rc}.{target_func}")
+                else:
+                    candidates.extend(
+                        _path_derived_module(path, rc, target_func),
+                    )
+                if qualified_name in candidates:
+                    file_has_evidence = True
+                    evidence.append((path, int(call.get("line", 0) or 0)))
+
         if file_has_evidence:
             continue
 
@@ -760,16 +794,48 @@ def _get_or_build_index(
     #   * ``a/b/__init__.py`` → ``a.b``
     #   * ``src/a/b/c.py`` → also ``a.b.c`` (src-layout)
     #
-    # Limitations (documented; consumer should be aware):
-    #   * Non-Python files: file-path-to-module heuristic doesn't run;
-    #     no internal aliasing for JS/Go/Java/etc.
+    # For non-Python files the qualified-name shape isn't derivable
+    # from the file path alone:
+    #   * Go: ``package <name>`` in the source decides the dotted
+    #     prefix — directory name is NOT authoritative
+    #   * Java: ``package com.foo.bar;`` declared in the source
+    #   * Rust: chain of ``mod foo;`` declarations
+    #   * C#: ``namespace Foo.Bar``
+    #   * PHP: ``namespace Foo\Bar``
+    # Each non-Python extractor that knows its own package
+    # declaration writes it into ``FileCallGraph.package_name``;
+    # we read it here and combine with the function name to seed
+    # ``qualified_to_internal``.
+    file_packages: Dict[str, Optional[str]] = {}
+    for file_record in inventory.get("files", []):
+        if not isinstance(file_record, dict):
+            continue
+        path = file_record.get("path") or ""
+        cg = file_record.get("call_graph")
+        if cg:
+            pkg = cg.get("package_name")
+            if pkg:
+                file_packages[path] = pkg
+
     for (file_path, fn_name), fns in idx.definitions.items():
         # Pick the lowest-line def as canonical — typically the
         # module-level one, which is the only one externally
         # importable. Same-name nested defs aren't reachable from
         # outside; we don't disambiguate further.
         canonical = min(fns, key=lambda f: f.line)
-        for candidate in _candidate_qualified_names(file_path, fn_name):
+        # Class-qualified candidates — for Java / C# / PHP / Rust
+        # impl-blocks / JS classes the externally-visible name is
+        # ``<pkg>.<Class>.<method>`` (or ``<file_module>.<Class>.
+        # <method>`` for path-derived languages). ``class_of_method``
+        # is populated above (line ~743) from each FileCallGraph's
+        # classes[].methods list. Pass None when no class — the
+        # candidate function emits the module-level form.
+        cls_name = idx.class_of_method.get(canonical)
+        for candidate in _candidate_qualified_names(
+                file_path, fn_name,
+                package_name=file_packages.get(file_path),
+                class_name=cls_name,
+        ):
             idx.qualified_to_internal.setdefault(candidate, canonical)
 
     # Pass 1.6: ``__init__.py`` re-export aliasing.
@@ -1305,35 +1371,150 @@ def _apply_reexport_aliases(idx: _AdjacencyIndex) -> int:
     return added
 
 
-def _candidate_qualified_names(file_path: str, fn_name: str) -> List[str]:
-    """Heuristic: derive plausible Python qualified names for an
+def _path_derived_module(
+    file_path: str, class_name: str, fn_name: str,
+) -> List[str]:
+    """Synthesise candidate ``<file_module>.<class_name>.<fn_name>``
+    forms for languages where the file IS the module (Python / JS-TS
+    / Ruby where no top-level module declaration sets
+    ``package_name``).
+
+    Returns one or two candidates — the raw path-derived form, plus
+    a src-stripped form when the path starts with ``src/`` (the
+    common Python src-layout / JS-TS monorepo convention). Empty
+    list when the extension isn't recognised.
+    """
+    base = file_path
+    suffix_match = None
+    for suffix in (".pyi", ".py", ".tsx", ".jsx", ".mjs", ".cjs",
+                    ".ts", ".js", ".rb"):
+        if base.endswith(suffix):
+            base = base[: -len(suffix)]
+            suffix_match = suffix
+            break
+    if suffix_match is None:
+        return []
+    if base.endswith("/__init__"):
+        base = base[: -len("/__init__")]
+    elif base.endswith("/index"):
+        base = base[: -len("/index")]
+    if not base:
+        return []
+    out: List[str] = [f"{base.replace('/', '.')}.{class_name}.{fn_name}"]
+    if base.startswith("src/"):
+        stripped = base[len("src/"):]
+        if stripped:
+            out.append(
+                f"{stripped.replace('/', '.')}.{class_name}.{fn_name}",
+            )
+    return out
+
+
+def _candidate_qualified_names(
+    file_path: str,
+    fn_name: str,
+    *,
+    package_name: Optional[str] = None,
+    class_name: Optional[str] = None,
+) -> List[str]:
+    """Heuristic: derive plausible qualified names for an
     InternalFunction defined at ``(file_path, fn_name)``.
 
     Returns at most a handful of candidates (typically 1-2). Used by
     the index builder to canonicalise external callee edges that
     actually resolve to project-defined functions.
 
-    Non-Python files: returns empty list. Other-language internal
-    aliasing isn't modelled.
+    Path-based heuristics (Python, JS/TS, Ruby): the file path
+    encodes the module shape:
+      * ``a/b/c.py`` → ``a.b.c``
+      * ``a/b/__init__.py`` → ``a.b``
+      * ``src/a/b/c.py`` → ``a.b.c`` (src-layout)
+      * ``a/b/c.js`` → ``a.b.c`` / ``a/b/c``
+
+    Declaration-based languages (Go, Java, Rust, C#, PHP) need
+    the source's own package declaration to resolve correctly —
+    the dir name is NOT authoritative. Those languages populate
+    ``FileCallGraph.package_name`` from the extractor, and the
+    resolver threads it in via ``package_name``.
+
+    Returns an empty list when the file type isn't recognised and
+    no package_name was supplied. Multiple candidates are returned
+    in priority order; consumers do ``setdefault`` so the highest-
+    confidence form wins.
     """
-    if not (file_path.endswith(".py") or file_path.endswith(".pyi")):
-        return []
-    base = file_path
-    for suffix in (".pyi", ".py"):
-        if base.endswith(suffix):
-            base = base[: -len(suffix)]
-            break
-    if base.endswith("/__init__"):
-        base = base[: -len("/__init__")]
     candidates: List[str] = []
-    if base:
-        candidates.append(f"{base.replace('/', '.')}.{fn_name}")
-    # ``src/`` layout: ``src/mypkg/foo.py`` is imported as
-    # ``mypkg.foo``, not ``src.mypkg.foo``. Generate both candidates.
-    if base.startswith("src/"):
-        stripped = base[len("src/"):]
-        if stripped:
-            candidates.append(f"{stripped.replace('/', '.')}.{fn_name}")
+
+    # Declaration-based path: ``package_name`` from the extractor.
+    # The qualified form depends on whether the language allows
+    # module-level functions:
+    #   * Java: every function lives inside a class. ONLY the
+    #     class-qualified form ``<pkg>.<Class>.<method>`` is a
+    #     valid resolution; the module-level form would falsely
+    #     collide with another file declaring class ``<pkg>``.
+    #   * C# / PHP: methods live inside classes, but module-level
+    #     functions / global functions exist. Emit class-qualified
+    #     first; fall through to module-level when no class.
+    #   * Go / Rust: free functions are the norm; emit module-
+    #     level. (Class-qualified is added too when present —
+    #     Rust impl methods + Go method receivers benefit.)
+    class_required = file_path.endswith(".java")
+    if package_name and class_name:
+        candidates.append(f"{package_name}.{class_name}.{fn_name}")
+    if package_name and not (class_required and class_name is None):
+        # In Java, a method with no class context shouldn't exist
+        # — skip the module-level form to avoid colliding with
+        # other files' class-qualified candidates that happen to
+        # share the dotted prefix (e.g. ``com.example.Util.helper``
+        # where one file's package is ``com.example.Util`` and
+        # another's class is ``Util``).
+        if not class_required:
+            candidates.append(f"{package_name}.{fn_name}")
+
+    # Python path-based heuristic.
+    if file_path.endswith(".py") or file_path.endswith(".pyi"):
+        base = file_path
+        for suffix in (".pyi", ".py"):
+            if base.endswith(suffix):
+                base = base[: -len(suffix)]
+                break
+        if base.endswith("/__init__"):
+            base = base[: -len("/__init__")]
+        if base:
+            candidates.append(f"{base.replace('/', '.')}.{fn_name}")
+        # src-layout: ``src/mypkg/foo.py`` is imported as ``mypkg.foo``
+        if base.startswith("src/"):
+            stripped = base[len("src/"):]
+            if stripped:
+                candidates.append(
+                    f"{stripped.replace('/', '.')}.{fn_name}",
+                )
+
+    # JS/TS / Ruby: file IS the module. Cross-package call sites
+    # reference the file path (sans extension) or a stripped form.
+    # Both shapes feed the import map.
+    if file_path.endswith((".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs",
+                            ".rb")):
+        base = file_path
+        for suffix in (".tsx", ".mjs", ".cjs", ".jsx", ".js", ".ts", ".rb"):
+            if base.endswith(suffix):
+                base = base[: -len(suffix)]
+                break
+        if base.endswith("/index"):
+            base = base[: -len("/index")]
+        if base:
+            module_form = base.replace("/", ".")
+            # Class-qualified takes priority — JS / Ruby classes
+            # exported from the file appear as ``<module>.<Class>.
+            # <method>`` to importing callers that reference the
+            # method via the class.
+            if class_name:
+                candidates.append(
+                    f"{module_form}.{class_name}.{fn_name}",
+                )
+            # Dotted form (matches Ruby module nesting + JS's
+            # canonical import-path-to-dotted transform).
+            candidates.append(f"{module_form}.{fn_name}")
+
     return candidates
 
 

--- a/core/inventory/tests/test_call_graph_go.py
+++ b/core/inventory/tests/test_call_graph_go.py
@@ -423,3 +423,22 @@ def test_resolver_not_called_when_function_unused():
     }
     r = function_called(inv, "net/http.Get")
     assert r.verdict == Verdict.NOT_CALLED
+
+
+def test_package_clause_captured():
+    """``package mypkg`` at file top → ``graph.package_name``."""
+    g = extract_call_graph_go(
+        'package mypkg\n'
+        'func Hello() {}\n'
+    )
+    assert g.package_name == "mypkg"
+
+
+def test_package_main_captured():
+    """``package main`` is captured — entry-point binaries
+    publish their funcs under ``main.<fn>``."""
+    g = extract_call_graph_go(
+        'package main\n'
+        'func main() {}\n'
+    )
+    assert g.package_name == "main"

--- a/core/inventory/tests/test_call_graph_java.py
+++ b/core/inventory/tests/test_call_graph_java.py
@@ -326,3 +326,280 @@ def test_resolver_static_import_resolves():
     }
     r = function_called(inv, "com.example.Helpers.helper")
     assert r.verdict == Verdict.CALLED
+
+
+# ---------------------------------------------------------------------------
+# package_declaration + class capture
+# ---------------------------------------------------------------------------
+
+
+def test_package_declaration_captured():
+    """``package com.foo.bar;`` lands on ``graph.package_name`` so
+    the resolver can canonicalise method calls to their fully-
+    qualified Java names."""
+    g = extract_call_graph_java(
+        "package com.foo.bar;\nclass C {}\n"
+    )
+    assert g.package_name == "com.foo.bar"
+
+
+def test_unnamed_package_stays_none():
+    """No ``package`` declaration → ``package_name`` is None."""
+    g = extract_call_graph_java("class C {}\n")
+    assert g.package_name is None
+
+
+def test_class_declaration_captures_bases_and_methods():
+    """``class Service extends Base implements Logger, Audit``
+    captures all three bases + each method definition (with line
+    numbers) on the ClassDef."""
+    g = extract_call_graph_java(
+        "package com.foo;\n"
+        "public class Service extends Base "
+        "implements Logger, Audit {\n"
+        "    public void run() {}\n"
+        "    private void helper() {}\n"
+        "}\n"
+    )
+    assert len(g.classes) == 1
+    cls = g.classes[0]
+    assert cls.name == "Service"
+    assert cls.bases == ["Base", "Logger", "Audit"]
+    method_names = [m[0] for m in cls.methods]
+    assert method_names == ["run", "helper"]
+    assert cls.nested is False
+
+
+def test_interface_declaration_captured():
+    """``interface I extends A, B`` lands on classes with bases
+    populated."""
+    g = extract_call_graph_java(
+        "package x;\n"
+        "interface I extends A, B {\n"
+        "    default void doIt() {}\n"
+        "}\n"
+    )
+    assert len(g.classes) == 1
+    cls = g.classes[0]
+    assert cls.name == "I"
+    assert cls.bases == ["A", "B"]
+    assert ("doIt", 3) in cls.methods
+
+
+def test_nested_class_marked_nested():
+    """Inner class inside another class → ``nested=True``."""
+    g = extract_call_graph_java(
+        "package x;\n"
+        "class Outer {\n"
+        "    static class Inner {\n"
+        "        void f() {}\n"
+        "    }\n"
+        "}\n"
+    )
+    outer = next(c for c in g.classes if c.name == "Outer")
+    inner = next(c for c in g.classes if c.name == "Inner")
+    assert outer.nested is False
+    assert inner.nested is True
+
+
+def test_implicit_receiver_call_tags_receiver_class():
+    """``foo()`` inside a class method → ``receiver_class``
+    points at the enclosing class."""
+    g = extract_call_graph_java(
+        "package x;\n"
+        "class C {\n"
+        "    void run() { helper(); }\n"
+        "    void helper() {}\n"
+        "}\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["helper"])
+    assert call.receiver_class == "C"
+    assert call.caller == "run"
+
+
+def test_this_dot_method_tags_receiver_class():
+    """``this.helper()`` is a known-self dispatch — tag
+    receiver_class same as implicit-receiver."""
+    g = extract_call_graph_java(
+        "package x;\n"
+        "class C {\n"
+        "    void run() { this.helper(); }\n"
+        "    void helper() {}\n"
+        "}\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["this", "helper"])
+    assert call.receiver_class == "C"
+
+
+def test_super_dot_method_leaves_receiver_class_none():
+    """``super.foo()`` dispatches on the parent class. Leave
+    receiver_class=None and let the resolver search the
+    hierarchy."""
+    g = extract_call_graph_java(
+        "package x;\n"
+        "class C extends Base {\n"
+        "    void run() { super.bake(); }\n"
+        "}\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["super", "bake"])
+    assert call.receiver_class is None
+
+
+def test_qualified_call_leaves_receiver_class_none():
+    """``Util.shared()`` — receiver isn't this/self, so no
+    narrowing on the enclosing class."""
+    g = extract_call_graph_java(
+        "package x;\n"
+        "class C {\n"
+        "    void run() { Util.shared(); }\n"
+        "}\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["Util", "shared"])
+    assert call.receiver_class is None
+
+
+def test_constructor_registered_on_class():
+    """Constructor definitions land on ``ClassDef.methods`` with
+    the class name as the method name."""
+    g = extract_call_graph_java(
+        "package x;\n"
+        "class Foo {\n"
+        "    public Foo() {}\n"
+        "    public Foo(int x) {}\n"
+        "}\n"
+    )
+    cls = g.classes[0]
+    method_names = [m[0] for m in cls.methods]
+    assert method_names.count("Foo") == 2
+
+
+def test_java_record_declaration_captured():
+    """Java 14+ ``record Point(int x, int y) implements P { ... }``
+    shares class_body shape with class_declaration — capture
+    methods and implements bases."""
+    g = extract_call_graph_java(
+        "package x;\n"
+        "record Point(int x, int y) implements P {\n"
+        "    int area() { return 0; }\n"
+        "}\n"
+    )
+    pt = next(c for c in g.classes if c.name == "Point")
+    assert "P" in pt.bases
+    method_names = [m[0] for m in pt.methods]
+    assert "area" in method_names
+
+
+def test_java_enum_declaration_captured():
+    """``enum Color { RED, GREEN; int code() {...} }`` — body
+    holds constants AND methods. Capture as ClassDef."""
+    g = extract_call_graph_java(
+        "package x;\n"
+        "enum Color {\n"
+        "    RED, GREEN;\n"
+        "    int code() { return 0; }\n"
+        "}\n"
+    )
+    color = next(c for c in g.classes if c.name == "Color")
+    method_names = [m[0] for m in color.methods]
+    assert "code" in method_names
+
+
+def test_resolver_no_module_level_collision_for_java():
+    """Pathological shape: file A is ``package com.example.Util;``
+    + class X with method helper. File B is ``package
+    com.example;`` + class Util with method helper. Without the
+    Java-specific guard, both files would seed
+    ``qualified_to_internal['com.example.Util.helper']`` via
+    setdefault — the first file in iteration order would win and
+    the other's Util.helper would canonicalise wrong. The fix
+    skips the module-level ``<pkg>.<fn>`` candidate for Java
+    (which has no module-level functions anyway)."""
+    from core.inventory.reachability import _get_or_build_index
+
+    a = extract_call_graph_java(
+        "package com.example.Util;\nclass X { void helper() {} }\n"
+    ).to_dict()
+    b = extract_call_graph_java(
+        "package com.example;\nclass Util { void helper() {} }\n"
+    ).to_dict()
+    inv = {"files": [
+        {"path": "src/com/example/Util/X.java", "language": "java",
+         "call_graph": a,
+         "items": [{"kind": "function", "name": "helper",
+                    "line_start": 2}]},
+        {"path": "src/com/example/Util.java", "language": "java",
+         "call_graph": b,
+         "items": [{"kind": "function", "name": "helper",
+                    "line_start": 2}]},
+    ]}
+    idx = _get_or_build_index(inv, exclude_test_files=False)
+    # com.example.Util.helper must canonicalise to Util.java
+    # (the Util class's helper), NOT to X.java (whose package
+    # happens to spell ``com.example.Util``).
+    target = idx.qualified_to_internal.get("com.example.Util.helper")
+    assert target is not None
+    assert target.file_path == "src/com/example/Util.java", (
+        f"collision — Util.helper wrongly canonicalised to "
+        f"{target.file_path}"
+    )
+
+
+def test_function_called_resolves_java_implicit_this():
+    """``helper()`` from inside ``Svc.run()`` is an implicit-this
+    dispatch — Java has no module-level functions. The chain head
+    isn't in the import map (no ``import helper``), so the
+    chain-based ``_resolves_to`` path can't see it. The
+    receiver_class fast-path on ``function_called`` synthesises
+    ``<pkg>.<receiver_class>.<tail>`` and compares to the target."""
+    from core.inventory.reachability import Verdict, function_called
+
+    cg = extract_call_graph_java(
+        "package com.example;\n"
+        "public class Svc {\n"
+        "    public void run() { helper(); }\n"
+        "    public void helper() {}\n"
+        "}\n"
+    )
+    inv = {"files": [{"path": "src/com/example/Svc.java",
+                       "language": "java",
+                       "call_graph": cg.to_dict()}]}
+    # Right class — CALLED
+    r = function_called(inv, "com.example.Svc.helper")
+    assert r.verdict == Verdict.CALLED
+
+    # Different class same method name — NOT_CALLED (narrowing
+    # held: receiver_class tagged Svc, target asked Other).
+    r = function_called(inv, "com.example.Other.helper")
+    assert r.verdict == Verdict.NOT_CALLED
+
+
+def test_resolver_cross_file_class_qualified():
+    """Caller in file A invokes ``Util.helper()``; Util.java in
+    file B declares ``package com.example; class Util { static
+    void helper() {} }``. The resolver canonicalises the callee
+    to ``com.example.Util.helper`` (class-qualified) and matches
+    the internal definition that lives in B."""
+    from core.inventory.reachability import Verdict, function_called
+
+    util = extract_call_graph_java(
+        "package com.example;\n"
+        "public class Util {\n"
+        "    public static void helper() {}\n"
+        "}\n"
+    ).to_dict()
+    caller = extract_call_graph_java(
+        "package com.example.client;\n"
+        "import com.example.Util;\n"
+        "class Client { void m() { Util.helper(); } }\n"
+    ).to_dict()
+    inv = {
+        "files": [
+            {"path": "src/com/example/Util.java", "language": "java",
+             "call_graph": util},
+            {"path": "src/com/example/client/Client.java",
+             "language": "java",
+             "call_graph": caller},
+        ],
+    }
+    r = function_called(inv, "com.example.Util.helper")
+    assert r.verdict == Verdict.CALLED

--- a/core/inventory/tests/test_call_graph_javascript.py
+++ b/core/inventory/tests/test_call_graph_javascript.py
@@ -328,3 +328,99 @@ def test_resolver_not_called_when_function_unused():
     }
     r = function_called(inv, "lodash.get")
     assert r.verdict == Verdict.NOT_CALLED
+
+
+# ---------------------------------------------------------------------------
+# Class capture
+# ---------------------------------------------------------------------------
+
+
+def test_js_class_declaration_records_methods_and_bases():
+    """``class Foo extends Bar { m() {} n() {} }`` →
+    classes[0].bases=['Bar'], methods=[(m,..), (n,..)]."""
+    g = extract_call_graph_javascript(
+        "class Foo extends Bar {\n"
+        "    m() {}\n"
+        "    n() {}\n"
+        "}\n"
+    )
+    assert len(g.classes) == 1
+    cls = g.classes[0]
+    assert cls.name == "Foo"
+    assert cls.bases == ["Bar"]
+    method_names = [m[0] for m in cls.methods]
+    assert "m" in method_names
+    assert "n" in method_names
+    assert cls.nested is False
+
+
+def test_js_class_without_extends_has_no_bases():
+    """``class Foo { method() {} }`` → bases=[]."""
+    g = extract_call_graph_javascript(
+        "class Foo { method() {} }\n"
+    )
+    assert len(g.classes) == 1
+    assert g.classes[0].bases == []
+
+
+def test_js_this_dot_method_tags_receiver_class():
+    """``this.foo()`` inside an instance method → receiver_class
+    points at the enclosing class."""
+    g = extract_call_graph_javascript(
+        "class C {\n"
+        "    run() { this.helper(); }\n"
+        "    helper() {}\n"
+        "}\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["this", "helper"])
+    assert call.receiver_class == "C"
+    assert call.caller == "run"
+
+
+def test_js_unqualified_call_no_receiver_class():
+    """JS unqualified ``foo()`` inside a method resolves through
+    lexical scope (could be a closure / module-level / import),
+    not via implicit-this. Leave receiver_class=None."""
+    g = extract_call_graph_javascript(
+        "class C {\n"
+        "    run() { helper(); }\n"
+        "    helper() {}\n"
+        "}\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["helper"])
+    assert call.receiver_class is None
+
+
+def test_js_constructor_registered():
+    """``constructor() {}`` is a method_definition like any
+    other — registers on the class with name 'constructor'."""
+    g = extract_call_graph_javascript(
+        "class C {\n"
+        "    constructor() {}\n"
+        "    run() {}\n"
+        "}\n"
+    )
+    method_names = [m[0] for m in g.classes[0].methods]
+    assert "constructor" in method_names
+    assert "run" in method_names
+
+
+def test_js_nested_class_marked_nested():
+    """Class defined inside another class method's closure
+    scope is marked nested (resolver treats nested classes as
+    opaque for narrowing)."""
+    g = extract_call_graph_javascript(
+        "class Outer {\n"
+        "    factory() {\n"
+        "        return class Inner { method() {} };\n"
+        "    }\n"
+        "}\n"
+    )
+    outer = next(c for c in g.classes if c.name == "Outer")
+    assert outer.nested is False
+    # ``class Inner`` is a class_expression in JS; tree-sitter
+    # may or may not emit it under class_declaration. If captured,
+    # it should be nested.
+    inners = [c for c in g.classes if c.name == "Inner"]
+    if inners:
+        assert inners[0].nested is True

--- a/core/inventory/tests/test_call_graph_new_langs.py
+++ b/core/inventory/tests/test_call_graph_new_langs.py
@@ -17,6 +17,7 @@ from core.inventory.call_graph import (
     INDIRECTION_REFLECT,
     INDIRECTION_WILDCARD_IMPORT,
     extract_call_graph_csharp,
+    extract_call_graph_javascript,
     extract_call_graph_php,
     extract_call_graph_ruby,
     extract_call_graph_rust,
@@ -214,3 +215,446 @@ def test_php_eval_flagged():
         '<?php\nfunction m() { eval($s); }\n'
     )
     assert INDIRECTION_EVAL in g.indirection
+
+
+# ---------------------------------------------------------------------------
+# Rust class capture (struct / enum / trait / impl)
+# ---------------------------------------------------------------------------
+
+
+def test_rust_struct_recorded():
+    """``struct Foo;`` lands on classes with empty bases and no
+    methods (methods live in impl blocks)."""
+    g = extract_call_graph_rust("struct Foo;\n")
+    assert len(g.classes) == 1
+    cls = g.classes[0]
+    assert cls.name == "Foo"
+    assert cls.bases == []
+    assert cls.methods == []
+    assert cls.nested is False
+
+
+def test_rust_impl_methods_attach_to_struct():
+    """``impl Foo { fn helper() {} }`` — helper attaches to the
+    same ClassDef as ``struct Foo;``."""
+    g = extract_call_graph_rust(
+        "struct Foo;\n"
+        "impl Foo {\n"
+        "    fn new() -> Foo { Foo }\n"
+        "    fn helper(&self) -> u32 { 0 }\n"
+        "}\n"
+    )
+    foos = [c for c in g.classes if c.name == "Foo"]
+    assert len(foos) == 1
+    method_names = [m[0] for m in foos[0].methods]
+    assert method_names == ["new", "helper"]
+
+
+def test_rust_impl_trait_for_struct_binds_to_struct():
+    """``impl Trait for Foo { fn m() {} }`` — m attaches to Foo,
+    not Trait."""
+    g = extract_call_graph_rust(
+        "struct Foo;\n"
+        "impl Greeter for Foo {\n"
+        "    fn greet(&self) {}\n"
+        "}\n"
+    )
+    foo = next(c for c in g.classes if c.name == "Foo")
+    method_names = [m[0] for m in foo.methods]
+    assert "greet" in method_names
+
+
+def test_rust_trait_default_methods_captured():
+    """Trait body holds function_signature_item for required
+    methods and function_item for default methods. Both land
+    on the trait's ClassDef."""
+    g = extract_call_graph_rust(
+        "trait Greeter {\n"
+        "    fn greet(&self);\n"
+        "    fn default_method(&self) {}\n"
+        "}\n"
+    )
+    trait = next(c for c in g.classes if c.name == "Greeter")
+    method_names = [m[0] for m in trait.methods]
+    assert "greet" in method_names
+    assert "default_method" in method_names
+
+
+def test_rust_trait_supertraits_become_bases():
+    """``trait T: A + B`` → bases=[A, B]."""
+    g = extract_call_graph_rust(
+        "trait T: A + B { fn m(&self); }\n"
+    )
+    t = next(c for c in g.classes if c.name == "T")
+    assert "A" in t.bases
+    assert "B" in t.bases
+
+
+def test_rust_self_method_call_tags_receiver_class():
+    """``self.foo()`` inside an impl block → receiver_class
+    points at the impl target."""
+    g = extract_call_graph_rust(
+        "struct Foo;\n"
+        "impl Foo {\n"
+        "    fn helper(&self) {}\n"
+        "    fn run(&self) { self.helper(); }\n"
+        "}\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["self", "helper"])
+    assert call.receiver_class == "Foo"
+    assert call.caller == "run"
+
+
+def test_rust_qualified_call_no_receiver_class():
+    """``Bar::new()`` — class-qualified call doesn't get
+    narrowed by the enclosing impl context."""
+    g = extract_call_graph_rust(
+        "struct Bar;\n"
+        "impl Bar {\n"
+        "    fn new() -> Bar { Bar }\n"
+        "}\n"
+        "fn other() { Bar::new(); }\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["Bar", "new"])
+    assert call.receiver_class is None
+
+
+def test_rust_mod_marks_inner_class_nested():
+    """``mod foo { struct Bar; }`` — Bar is nested."""
+    g = extract_call_graph_rust(
+        "mod inner {\n"
+        "    struct Bar;\n"
+        "}\n"
+    )
+    bar = next(c for c in g.classes if c.name == "Bar")
+    assert bar.nested is True
+
+
+def test_rust_impl_on_external_type_synthesises_classdef():
+    """``impl Foo`` where Foo is imported (no in-file struct
+    declaration) — synthesise a ClassDef so cross-file method
+    matching still works."""
+    g = extract_call_graph_rust(
+        "use other::Foo;\n"
+        "impl Foo {\n"
+        "    fn local_method(&self) {}\n"
+        "}\n"
+    )
+    foo = next(c for c in g.classes if c.name == "Foo")
+    method_names = [m[0] for m in foo.methods]
+    assert "local_method" in method_names
+
+
+# ---------------------------------------------------------------------------
+# Ruby class + module capture
+# ---------------------------------------------------------------------------
+
+
+def test_ruby_class_with_superclass():
+    """``class Service < Base`` → bases=['Base']."""
+    g = extract_call_graph_ruby(
+        "class Service < Base\n"
+        "  def run; end\n"
+        "  def helper; end\n"
+        "end\n"
+    )
+    cls = next(c for c in g.classes if c.name == "Service")
+    assert cls.bases == ["Base"]
+    method_names = [m[0] for m in cls.methods]
+    assert method_names == ["run", "helper"]
+
+
+def test_ruby_class_no_superclass():
+    """``class Foo\n  def m; end\nend`` → bases=[]."""
+    g = extract_call_graph_ruby("class Foo\n  def m; end\nend\n")
+    cls = next(c for c in g.classes if c.name == "Foo")
+    assert cls.bases == []
+
+
+def test_ruby_module_nesting_sets_package_name():
+    """Nested ``module Foo; module Bar; ...`` populates the
+    deepest dotted name on ``graph.package_name``."""
+    g = extract_call_graph_ruby(
+        "module Foo\n"
+        "  module Bar\n"
+        "    class Service; def m; end; end\n"
+        "  end\n"
+        "end\n"
+    )
+    assert g.package_name == "Foo.Bar"
+
+
+def test_ruby_self_dot_method_tags_receiver_class():
+    """``self.foo`` inside an instance method → receiver_class
+    points at the enclosing class."""
+    g = extract_call_graph_ruby(
+        "class C\n"
+        "  def run\n"
+        "    self.helper\n"
+        "  end\n"
+        "  def helper; end\n"
+        "end\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["self", "helper"])
+    assert call.receiver_class == "C"
+    assert call.caller == "run"
+
+
+def test_ruby_unqualified_call_no_receiver_class():
+    """Bare-name calls in Ruby could be from a mixin / superclass
+    / current class — we can't narrow without runtime semantics."""
+    g = extract_call_graph_ruby(
+        "class C\n"
+        "  def run\n"
+        "    helper()\n"
+        "  end\n"
+        "  def helper; end\n"
+        "end\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["helper"])
+    assert call.receiver_class is None
+
+
+# ---------------------------------------------------------------------------
+# C# namespace + class capture
+# ---------------------------------------------------------------------------
+
+
+def test_csharp_namespace_captured():
+    """``namespace Foo.Bar { ... }`` → package_name='Foo.Bar'."""
+    g = extract_call_graph_csharp(
+        "namespace Foo.Bar { class C {} }\n"
+    )
+    assert g.package_name == "Foo.Bar"
+
+
+def test_csharp_class_with_base_list():
+    """``class Service : Base, ILogger`` → bases=['Base', 'ILogger']."""
+    g = extract_call_graph_csharp(
+        "class Service : Base, ILogger {\n"
+        "    public void Run() {}\n"
+        "    private void Helper() {}\n"
+        "}\n"
+    )
+    cls = next(c for c in g.classes if c.name == "Service")
+    assert cls.bases == ["Base", "ILogger"]
+    method_names = [m[0] for m in cls.methods]
+    assert method_names == ["Run", "Helper"]
+
+
+def test_csharp_this_dot_method_tags_receiver_class():
+    """``this.X()`` inside an instance method → receiver_class
+    points at the enclosing class. Tree-sitter-c_sharp marks the
+    ``this`` keyword as unnamed; the parser special-cases it."""
+    g = extract_call_graph_csharp(
+        "class C {\n"
+        "    void Run() { this.Helper(); }\n"
+        "    void Helper() {}\n"
+        "}\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["this", "Helper"])
+    assert call.receiver_class == "C"
+
+
+def test_csharp_unqualified_call_tags_receiver_class():
+    """C# unqualified ``Helper()`` is implicit-this — no module-
+    level functions exist in C# so the dispatch target is always
+    a method of the enclosing class or a base class."""
+    g = extract_call_graph_csharp(
+        "class C {\n"
+        "    void Run() { Helper(); }\n"
+        "    void Helper() {}\n"
+        "}\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["Helper"])
+    assert call.receiver_class == "C"
+
+
+def test_csharp_interface_declaration_captured():
+    """``interface I {}`` → recorded as a class with no methods
+    (interface methods are signatures, but the resolver still
+    benefits from the class-ID entry for ``ClassName.method``
+    canonicalisation)."""
+    g = extract_call_graph_csharp(
+        "interface I {\n"
+        "    void DoIt();\n"
+        "}\n"
+    )
+    cls = next(c for c in g.classes if c.name == "I")
+    assert cls.name == "I"
+
+
+# ---------------------------------------------------------------------------
+# PHP namespace + class capture
+# ---------------------------------------------------------------------------
+
+
+def test_php_namespace_captured():
+    """``namespace Foo\\Bar;`` → package_name='Foo.Bar' (dotted)."""
+    g = extract_call_graph_php(
+        '<?php\nnamespace Foo\\Bar;\nclass C {}\n'
+    )
+    assert g.package_name == "Foo.Bar"
+
+
+def test_php_class_extends_and_implements():
+    """``class Service extends Base implements I1, I2`` →
+    bases=['Base', 'I1', 'I2']."""
+    g = extract_call_graph_php(
+        '<?php\n'
+        'class Service extends Base implements I1, I2 {\n'
+        '    public function run() {}\n'
+        '    public function helper() {}\n'
+        '}\n'
+    )
+    cls = next(c for c in g.classes if c.name == "Service")
+    assert "Base" in cls.bases
+    assert "I1" in cls.bases
+    assert "I2" in cls.bases
+    method_names = [m[0] for m in cls.methods]
+    assert method_names == ["run", "helper"]
+
+
+def test_php_this_arrow_method_tags_receiver_class():
+    """``$this->helper()`` inside an instance method →
+    receiver_class points at the enclosing class. The $-stripping
+    in _object_chain makes the chain ``["this", "helper"]``."""
+    g = extract_call_graph_php(
+        '<?php\n'
+        'class C {\n'
+        '    public function run() { $this->helper(); }\n'
+        '    public function helper() {}\n'
+        '}\n'
+    )
+    call = next(c for c in g.calls if c.chain == ["this", "helper"])
+    assert call.receiver_class == "C"
+    assert call.caller == "run"
+
+
+def test_php_bare_function_call_no_receiver_class():
+    """Bare function calls in PHP resolve to namespaced/global
+    functions — NOT implicit-this. No narrowing."""
+    g = extract_call_graph_php(
+        '<?php\n'
+        'class C {\n'
+        '    public function run() { global_func(); }\n'
+        '}\n'
+    )
+    call = next(c for c in g.calls if c.chain == ["global_func"])
+    assert call.receiver_class is None
+
+
+def test_php_interface_declaration_captured():
+    """``interface I { function doIt(); }`` → recorded as class
+    with the method signature on methods."""
+    g = extract_call_graph_php(
+        '<?php\n'
+        'interface I {\n'
+        '    public function doIt();\n'
+        '}\n'
+    )
+    cls = next(c for c in g.classes if c.name == "I")
+    method_names = [m[0] for m in cls.methods]
+    assert "doIt" in method_names
+
+
+# ---------------------------------------------------------------------------
+# Adversarial edge cases (real-language constructs caught during review)
+# ---------------------------------------------------------------------------
+
+
+def test_rust_generic_impl_captures_target():
+    """``impl<T> Box<T>`` — the impl target is wrapped in a
+    ``generic_type`` node. Extract the inner type_identifier so
+    methods still attach to Box."""
+    g = extract_call_graph_rust(
+        "struct Box<T>(T);\n"
+        "impl<T> Box<T> {\n"
+        "    fn new(x: T) -> Box<T> { Box(x) }\n"
+        "}\n"
+    )
+    box = next(c for c in g.classes if c.name == "Box")
+    method_names = [m[0] for m in box.methods]
+    assert "new" in method_names
+
+
+def test_rust_impl_on_unknown_generic_synthesises():
+    """``impl<T: Clone> Vec<T>`` for a Vec not declared in this
+    file — synthesise a ClassDef so cross-file method matching
+    still works."""
+    g = extract_call_graph_rust(
+        "impl<T: Clone> Vec<T> {\n"
+        "    fn cloned(&self) -> Self { self.clone() }\n"
+        "}\n"
+    )
+    vec = next(c for c in g.classes if c.name == "Vec")
+    assert any(m[0] == "cloned" for m in vec.methods)
+
+
+def test_csharp_file_scoped_namespace_captured():
+    """C# 10's ``namespace Foo.Bar;`` (no braces) — the
+    declarations are SIBLINGS of the namespace node, not nested.
+    Set package_name without push/pop so it applies file-wide."""
+    g = extract_call_graph_csharp(
+        "namespace Foo.Bar;\n"
+        "\n"
+        "class C { void m() {} }\n"
+    )
+    assert g.package_name == "Foo.Bar"
+    cls = next(c for c in g.classes if c.name == "C")
+    assert any(m[0] == "m" for m in cls.methods)
+
+
+def test_ruby_singleton_method_registered():
+    """``def self.foo`` (singleton_method node) inside a class /
+    module body — register as a method on the class same as
+    regular ``def`` would."""
+    g = extract_call_graph_ruby(
+        "class C\n"
+        "  def self.class_method\n"
+        "  end\n"
+        "  def instance_method\n"
+        "  end\n"
+        "end\n"
+    )
+    cls = next(c for c in g.classes if c.name == "C")
+    method_names = [m[0] for m in cls.methods]
+    assert "class_method" in method_names
+    assert "instance_method" in method_names
+
+
+def test_js_private_method_captured():
+    """``#priv()`` method uses private_property_identifier as
+    its name node. Function-name extraction + member-chain
+    extraction both need to accept private_property_identifier
+    so ``this.#priv()`` is recorded with chain ``["this", "#priv"]``."""
+    g = extract_call_graph_javascript(
+        "class C {\n"
+        "  #priv() {}\n"
+        "  pub() { this.#priv(); }\n"
+        "}\n"
+    )
+    cls = g.classes[0]
+    method_names = [m[0] for m in cls.methods]
+    assert "#priv" in method_names
+    assert "pub" in method_names
+    call = next(c for c in g.calls if c.chain == ["this", "#priv"])
+    assert call.receiver_class == "C"
+
+
+def test_js_class_expression_assigned_to_const():
+    """``const Foo = class extends Bar { method() {} }`` —
+    class expressions are anonymous in the grammar; we
+    synthesise a ClassDef using the variable_declarator's LHS
+    identifier as the class name."""
+    g = extract_call_graph_javascript(
+        "const Foo = class extends Bar {\n"
+        "  method() {}\n"
+        "  helper() {}\n"
+        "};\n"
+    )
+    foo = next(c for c in g.classes if c.name == "Foo")
+    assert foo.bases == ["Bar"]
+    method_names = [m[0] for m in foo.methods]
+    assert "method" in method_names
+    assert "helper" in method_names


### PR DESCRIPTION
Extends the call_graph + reachability substrate so Go/Java/Rust/ JS-TS/Ruby/C#/PHP get parity with what Python had from PR #523: declared package/namespace, ClassDef with bases + methods, and receiver_class tagging on this/self/super calls.

Substrate
- FileCallGraph.package_name: written by extractor for languages where it's source-declared (Go/Java/Ruby/C#/PHP); None for Rust + JS/TS (path-derived).
- _candidate_qualified_names now takes class_name and emits <pkg>.<Class>.<method> ahead of <pkg>.<method>. Wired through pass-1.5 via class_of_method.
- function_called gains a receiver_class fast-path: when a chain's tail matches the target and the call carries receiver_class, synthesise <pkg>.<class>.<tail> and compare. Catches Java/C#/ Ruby implicit-this bare calls that the import-map path couldn't see. Polyglot stress (1400 files, 7 langs): queries 37ms → 6ms because the fast-path short-circuits the index lookup.

Per-language receiver_class semantics
- Java/C#: this.X() + implicit X() → enclosing class (neither language has module-level functions; implicit-receiver is this).
- Rust: self.X() → enclosing impl target.
- Ruby: self.X → enclosing class. Bare X() left alone (method- lookup chain is opaque without runtime semantics).
- JS/TS: this.X() only → enclosing class. Bare X() resolves via lexical scope.
- PHP: $this->X() and self::/static:: → enclosing class. Bare function calls resolve namespaced/global, not implicit-this.

Per-language edge cases handled
- Java: record_declaration (14+) + enum_declaration share class shape. extends_interfaces (interface) vs super_interfaces (class) both yield bases.
- Rust: impl<T> Box<T> extracts type_identifier from generic_type wrapper. impl on undeclared types synthesises a ClassDef so cross-file method matching still works.
- C#: file_scoped_namespace_declaration (10+) sets package_name without push/pop so it applies file-wide. Unnamed this/base keyword tokens handled in member_access_expression.
- Ruby: singleton_method (`def self.x`) registered same as method. Nested module → dotted package_name.
- JS: #priv() methods + this.#priv() use private_property_ identifier. const Foo = class {} synthesises ClassDef from LHS identifier.
- PHP: self::/static::/parent:: via relative_scope. namespace_ definition with \-separator → dotted package_name.

Tests
- 102 new unit + resolver tests including a Java collision regression test that asserts <pkg>.<Class>.<method> survives the pathological two-file shape.
- 543 inventory / 5592 broader-core tests pass (was 490 / 5582 pre-substrate).
- E2E verified on 482-file Spring Boot core (549 classes, 3216 methods, 0 parse errors, 866ms extract + 106ms index build).