### PR TITLE
feat(llm_analysis): wire core/ast view into /agentic finding analysis

### DIFF
--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -38,6 +38,72 @@ from core.llm.providers import ClaudeCodeProvider
 logger = get_logger()
 
 
+def _enrich_finding_with_ast_view(
+    finding: Dict[str, Any], repo_path: Path,
+) -> None:
+    """Attach a compact per-function AST view to ``finding["ast_view"]``.
+
+    Mutates ``finding`` in-place. Idempotent — a pre-existing
+    ``ast_view`` is preserved (caller-supplied or earlier-run wins).
+    Best-effort: parse failure / unsupported language / function not
+    in inventory / file missing all leave ``finding["ast_view"]``
+    unset and the prompt builder's ``ast-view`` block is skipped.
+
+    Function name resolution order:
+      1. ``finding["metadata"]["name"]`` (set by the inventory
+         enrichment block that runs just before this).
+      2. ``finding["function"]`` (some scanners set this directly).
+      3. Otherwise → no enrichment.
+
+    File-path resolution:
+      * Absolute paths pass through.
+      * Relative paths resolve under ``repo_path``.
+
+    Runs once per finding before any LLM call sees it; the four
+    analysis-family tasks (Analysis, Consensus, Judge, Retry) all
+    share the result via
+    ``build_analysis_prompt_bundle_from_finding`` reading
+    ``finding["ast_view"]``.
+    """
+    if finding.get("ast_view"):
+        return
+    fpath = finding.get("file_path") or finding.get("file") or ""
+    fline = (
+        finding.get("start_line")
+        if finding.get("start_line") is not None
+        else finding.get("startLine", 0)
+    )
+    metadata = finding.get("metadata") or {}
+    function_name = (
+        metadata.get("name")
+        or finding.get("function")
+        or ""
+    )
+    if not (function_name and fpath):
+        return
+    try:
+        # Lazy-import keeps the agent.py module load light when
+        # core.ast / tree-sitter grammars aren't installed (the
+        # ImportError shouldn't break the whole agent).
+        from core.ast import view as _view
+    except ImportError:
+        logger.debug("ast_view enrichment: core.ast not importable")
+        return
+    try:
+        fp = Path(fpath)
+        if not fp.is_absolute():
+            fp = repo_path / fp
+        fv = _view(fp, function_name, at_line=fline)
+        if fv is not None:
+            finding["ast_view"] = fv.to_dict()
+    except Exception:                                       # noqa: BLE001
+        logger.debug(
+            "ast_view enrichment failed for %s:%s %s",
+            fpath, fline, function_name,
+            exc_info=True,
+        )
+
+
 def get_vuln_type(rule_id: str) -> Optional[str]:
     """Map SARIF rule_id to vulnerability type for mitigation checks."""
     try:
@@ -1348,6 +1414,13 @@ class AutonomousSecurityAgentV2:
                         if func.get("priority_reason"):
                             metadata["priority_reason"] = func["priority_reason"]
                         finding["metadata"] = metadata
+
+                # Per-function AST view enrichment. Sits outside the
+                # metadata-enrichment gate above so findings that
+                # arrive pre-populated with metadata (from upstream
+                # scanners) still get ast_view. See
+                # ``_enrich_finding_with_ast_view`` for the contract.
+                _enrich_finding_with_ast_view(finding, self.repo_path)
 
                 vuln = VulnerabilityContext(finding, self.repo_path)
 

--- a/packages/llm_analysis/prompts/analysis.py
+++ b/packages/llm_analysis/prompts/analysis.py
@@ -197,6 +197,7 @@ def build_analysis_prompt_bundle(
     function_name: Optional[str] = None,
     file_includes: Iterable[str] = (),
     function_calls_made: Iterable[str] = (),
+    ast_view: Optional[Dict[str, Any]] = None,
 ) -> PromptBundle:
     """Build the analysis prompt as a PromptBundle (system + user, role-separated).
 
@@ -249,6 +250,33 @@ def build_analysis_prompt_bundle(
                 content=meta_text,
                 kind="function-context",
                 origin=file_path,
+            ))
+
+    # Structured per-function AST view: ALL calls inside the host
+    # function body, all explicit returns, inline-asm flag.
+    # Complements ``function-context`` (which is the static profile
+    # of the function's declaration) by giving the LLM a compact
+    # summary of what the body actually does — particularly useful
+    # for large functions where ``surrounding_context`` doesn't
+    # cover sanitiser calls or early returns that affect
+    # exploitability reasoning. See ``core.ast.view`` for the
+    # source; ``packages/llm_analysis/agent.py`` populates the
+    # finding's ``ast_view`` field before this builder runs.
+    if ast_view:
+        # Pass the finding's ``file_path`` as the display path so the
+        # rendered block body matches the block's ``origin``
+        # attribute (and the rest of the prompt's path conventions).
+        # Without this, ``ast_view["file"]`` would be the absolute
+        # path that ``core.ast.view`` saw — operator-facing
+        # inconsistency when scanning prompt logs.
+        view_text = _render_ast_view_block(
+            ast_view, file_path_override=file_path,
+        )
+        if view_text:
+            blocks.append(UntrustedBlock(
+                content=view_text,
+                kind="ast-view",
+                origin=f"{file_path}:{ast_view.get('function', '?')}",
             ))
 
     if has_dataflow and dataflow_source and dataflow_sink:
@@ -490,4 +518,124 @@ def build_analysis_prompt_bundle_from_finding(
         function_calls_made=(
             metadata.get("calls") or metadata.get("callees") or ()
         ),
+        # Per-function structured AST view (populated by
+        # ``packages.llm_analysis.agent`` enrichment loop). Absent
+        # when the function can't be located in the inventory or
+        # the parser doesn't support the language.
+        ast_view=finding.get("ast_view"),
     )
+
+
+# ---------------------------------------------------------------------------
+# AST-view rendering
+# ---------------------------------------------------------------------------
+
+
+# Limits keep the rendered block bounded in pathological cases (a
+# function with hundreds of calls or returns). The LLM doesn't need
+# every call — the first N is enough to detect sanitisers and
+# control-flow shape. Truncation is marked so the LLM knows the
+# list isn't exhaustive.
+_AST_VIEW_MAX_CALLS = 20
+_AST_VIEW_MAX_RETURNS = 10
+
+
+def _render_ast_view_block(
+    ast_view: Dict[str, Any],
+    *,
+    file_path_override: Optional[str] = None,
+) -> str:
+    """Render an ``ast_view`` dict (from ``core.ast.view().to_dict()``)
+    as a compact text summary for inclusion in the analysis prompt.
+
+    ``file_path_override`` lets the caller substitute a display
+    path for ``ast_view["file"]`` — useful when the ast_view's
+    file is an absolute (target-rooted) path that resolves
+    differently from the finding's repo-relative file. Passing
+    the finding's ``file_path`` keeps the block's body consistent
+    with the block's ``origin`` envelope attribute and with every
+    other untrusted block in the prompt. When omitted, falls back
+    to ``ast_view["file"]``.
+
+    Trade-offs:
+      * **Compact, not JSON.** Full ``ast_view`` JSON is 200-500
+        tokens per finding; this rendering is ~50-100 tokens
+        depending on call/return count.
+      * **Calls deduplicated.** Same callee at multiple lines
+        collapses to the callee name with hit count (``execute(x3)``).
+        Preserves the "this function calls a sanitiser N times"
+        signal while shrinking the token cost.
+      * **Lines on returns preserved.** Control-flow reasoning
+        depends on knowing which return is at which line.
+      * **Truncation marked.** Over-cap → ``...`` suffix so the
+        LLM knows the listing isn't exhaustive.
+
+    Returns ``""`` when the view contains nothing worth rendering
+    (no calls, no returns, no signature, asm absent). The caller
+    skips emitting an empty block.
+    """
+    function = ast_view.get("function") or "?"
+    file_str = file_path_override or ast_view.get("file") or "?"
+    lines = ast_view.get("lines") or (0, 0)
+    signature = (ast_view.get("signature") or "").strip()
+    has_asm = bool(ast_view.get("has_inline_asm"))
+
+    out_lines = []
+    if signature:
+        out_lines.append(
+            f"host function: {signature}  [{file_str}:{lines[0]}-{lines[1]}]"
+        )
+    else:
+        out_lines.append(
+            f"host function: {function}  [{file_str}:{lines[0]}-{lines[1]}]"
+        )
+    out_lines.append(f"- inline asm: {'yes' if has_asm else 'no'}")
+
+    # Defensive: callers should hand us a dict matching
+    # FunctionView.to_dict(), but ast_view can travel through JSON
+    # round-trips and corrupted-state caches — wrong types in
+    # ``calls_made`` / ``returns`` shouldn't crash the renderer.
+    # Non-list / non-dict entries are silently dropped.
+    raw_calls = ast_view.get("calls_made") or []
+    calls = [c for c in raw_calls if isinstance(c, dict)] if isinstance(raw_calls, list) else []
+    if calls:
+        # Deduplicate by callee name; record hit counts. ``chain``
+        # is the ordered name components (``["obj", "method"]`` for
+        # ``obj.method()``); render the dotted form.
+        counts: Dict[str, int] = {}
+        order: list = []
+        for c in calls:
+            chain = c.get("chain") or []
+            if not isinstance(chain, list):
+                chain = []
+            name = ".".join(str(p) for p in chain) if chain else "?"
+            if name not in counts:
+                order.append(name)
+                counts[name] = 0
+            counts[name] += 1
+        rendered = []
+        for name in order[:_AST_VIEW_MAX_CALLS]:
+            n = counts[name]
+            rendered.append(f"{name}(x{n})" if n > 1 else name)
+        suffix = "..." if len(order) > _AST_VIEW_MAX_CALLS else ""
+        out_lines.append(
+            f"- calls inside body ({len(calls)}): "
+            f"{', '.join(rendered)}{suffix}"
+        )
+    else:
+        out_lines.append("- calls inside body: (none)")
+
+    raw_returns = ast_view.get("returns") or []
+    returns = [r for r in raw_returns if isinstance(r, dict)] if isinstance(raw_returns, list) else []
+    if returns:
+        head = returns[:_AST_VIEW_MAX_RETURNS]
+        return_lines = ", ".join(str(r.get("line", "?")) for r in head)
+        suffix = "..." if len(returns) > _AST_VIEW_MAX_RETURNS else ""
+        out_lines.append(
+            f"- explicit returns: {len(returns)} "
+            f"(lines {return_lines}{suffix})"
+        )
+    else:
+        out_lines.append("- explicit returns: (none)")
+
+    return "\n".join(out_lines)

--- a/packages/llm_analysis/tests/test_agent_ast_view_enrichment.py
+++ b/packages/llm_analysis/tests/test_agent_ast_view_enrichment.py
@@ -1,0 +1,253 @@
+"""Tests for the per-finding ast_view enrichment in
+``packages.llm_analysis.agent`` — exercises the production helper
+``_enrich_finding_with_ast_view`` directly.
+
+The helper is private (underscore-prefixed) but importable from tests
+— that's the right shape for a function with a narrow contract that
+the wider package shouldn't depend on but that needs to be pinned by
+behavioral tests rather than source-grep mirror tests.
+
+The prompt-builder side is covered by ``test_prompt_ast_view``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from packages.llm_analysis.agent import _enrich_finding_with_ast_view
+
+
+def _project(tmp_path: Path, files: dict) -> Path:
+    for rel, contents in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(contents)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_python_function(tmp_path):
+    target = _project(tmp_path, {
+        "src/auth.py": (
+            "def check(user, pw):\n"        # 1
+            "    if user is None:\n"         # 2
+            "        return -1\n"            # 3
+            "    h = compute(pw)\n"          # 4
+            "    return 0\n"                 # 5
+        ),
+    })
+    finding = {
+        "file_path": "src/auth.py",
+        "start_line": 4,
+        "metadata": {"name": "check"},
+    }
+    _enrich_finding_with_ast_view(finding, target)
+    assert "ast_view" in finding
+    av = finding["ast_view"]
+    assert av["function"] == "check"
+    assert av["language"] == "python"
+    assert any(c["chain"] == ["compute"] for c in av["calls_made"])
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+
+def test_absolute_file_path_passes_through(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    finding = {
+        "file_path": str(target / "src" / "x.py"),  # absolute
+        "start_line": 1,
+        "metadata": {"name": "f"},
+    }
+    _enrich_finding_with_ast_view(finding, target)
+    assert "ast_view" in finding
+    assert finding["ast_view"]["function"] == "f"
+
+
+def test_relative_file_path_resolved_under_repo(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    finding = {
+        "file_path": "src/x.py",  # relative
+        "start_line": 1,
+        "metadata": {"name": "f"},
+    }
+    _enrich_finding_with_ast_view(finding, target)
+    assert "ast_view" in finding
+
+
+# ---------------------------------------------------------------------------
+# Function name resolution
+# ---------------------------------------------------------------------------
+
+
+def test_function_name_from_metadata(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def alpha(): return 1\n"})
+    finding = {
+        "file_path": "src/x.py", "start_line": 1,
+        "metadata": {"name": "alpha"},
+    }
+    _enrich_finding_with_ast_view(finding, target)
+    assert finding["ast_view"]["function"] == "alpha"
+
+
+def test_function_name_from_finding_field_when_metadata_missing(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def beta(): return 1\n"})
+    finding = {
+        "file_path": "src/x.py", "start_line": 1,
+        "function": "beta",  # no metadata
+    }
+    _enrich_finding_with_ast_view(finding, target)
+    assert finding["ast_view"]["function"] == "beta"
+
+
+def test_metadata_name_takes_precedence_over_function_field(tmp_path):
+    target = _project(tmp_path, {
+        "src/x.py": "def alpha(): return 1\ndef beta(): return 2\n",
+    })
+    finding = {
+        "file_path": "src/x.py", "start_line": 1,
+        "metadata": {"name": "alpha"},
+        "function": "beta",  # should lose to metadata
+    }
+    _enrich_finding_with_ast_view(finding, target)
+    assert finding["ast_view"]["function"] == "alpha"
+
+
+def test_no_function_name_skips_enrichment(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    finding = {
+        "file_path": "src/x.py", "start_line": 1,
+        # No name in metadata or finding
+    }
+    _enrich_finding_with_ast_view(finding, target)
+    assert "ast_view" not in finding
+
+
+def test_no_file_path_skips_enrichment(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    finding = {
+        "start_line": 1,
+        "metadata": {"name": "f"},
+        # No file_path
+    }
+    _enrich_finding_with_ast_view(finding, target)
+    assert "ast_view" not in finding
+
+
+# ---------------------------------------------------------------------------
+# Field-name fallbacks
+# ---------------------------------------------------------------------------
+
+
+def test_file_field_used_when_file_path_absent(tmp_path):
+    """Some scanners emit ``file`` instead of ``file_path`` — the
+    helper accepts either."""
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    finding = {
+        "file": "src/x.py",  # not file_path
+        "start_line": 1,
+        "metadata": {"name": "f"},
+    }
+    _enrich_finding_with_ast_view(finding, target)
+    assert "ast_view" in finding
+
+
+def test_startLine_field_used_when_start_line_absent(tmp_path):
+    """Some scanners emit the SARIF camelCase ``startLine``."""
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    finding = {
+        "file_path": "src/x.py",
+        "startLine": 1,  # not start_line
+        "metadata": {"name": "f"},
+    }
+    _enrich_finding_with_ast_view(finding, target)
+    assert "ast_view" in finding
+
+
+# ---------------------------------------------------------------------------
+# Idempotency + overwrite policy
+# ---------------------------------------------------------------------------
+
+
+def test_existing_ast_view_not_overwritten(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    pre_existing = {"function": "preset", "schema_version": 1}
+    finding = {
+        "file_path": "src/x.py", "start_line": 1,
+        "metadata": {"name": "f"},
+        "ast_view": pre_existing,
+    }
+    _enrich_finding_with_ast_view(finding, target)
+    # Pre-existing value preserved verbatim (object identity).
+    assert finding["ast_view"] is pre_existing
+    assert finding["ast_view"]["function"] == "preset"
+
+
+def test_idempotent_re_run(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    finding = {
+        "file_path": "src/x.py", "start_line": 1,
+        "metadata": {"name": "f"},
+    }
+    _enrich_finding_with_ast_view(finding, target)
+    first = finding["ast_view"]
+    _enrich_finding_with_ast_view(finding, target)
+    # Second call sees existing ast_view and is a no-op → object
+    # identity preserved.
+    assert finding["ast_view"] is first
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation
+# ---------------------------------------------------------------------------
+
+
+def test_function_not_found_skips_enrichment(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    finding = {
+        "file_path": "src/x.py", "start_line": 1,
+        "metadata": {"name": "nonexistent"},
+    }
+    _enrich_finding_with_ast_view(finding, target)
+    assert "ast_view" not in finding
+
+
+def test_missing_file_skips_enrichment(tmp_path):
+    target = _project(tmp_path, {})
+    finding = {
+        "file_path": "src/nope.py", "start_line": 1,
+        "metadata": {"name": "f"},
+    }
+    _enrich_finding_with_ast_view(finding, target)
+    assert "ast_view" not in finding
+
+
+def test_unsupported_language_skips(tmp_path):
+    target = _project(tmp_path, {"src/x.unknownext": "stuff"})
+    finding = {
+        "file_path": "src/x.unknownext", "start_line": 1,
+        "metadata": {"name": "f"},
+    }
+    _enrich_finding_with_ast_view(finding, target)
+    assert "ast_view" not in finding
+
+
+def test_unreadable_file_does_not_raise(tmp_path):
+    """A file the OS refuses to read (e.g. permission-denied,
+    EISDIR) should leave the finding alone, not raise."""
+    target = _project(tmp_path, {})
+    # Give a path that exists as a directory — OSError on read.
+    (target / "src").mkdir(exist_ok=True)
+    finding = {
+        "file_path": "src",  # is a directory, not a file
+        "start_line": 1,
+        "metadata": {"name": "f"},
+    }
+    _enrich_finding_with_ast_view(finding, target)
+    assert "ast_view" not in finding

--- a/packages/llm_analysis/tests/test_prompt_ast_view.py
+++ b/packages/llm_analysis/tests/test_prompt_ast_view.py
@@ -1,0 +1,296 @@
+"""Tests for the ``ast_view`` integration in
+``packages.llm_analysis.prompts.analysis``.
+
+Covers the renderer (``_render_ast_view_block``) and the bundle
+threading (``build_analysis_prompt_bundle_from_finding`` lifting
+``finding["ast_view"]`` into an untrusted-block in the user message).
+
+The agent-side enrichment (``packages/llm_analysis/agent.py`` walking
+findings and computing ``view()``) is exercised separately by
+``test_agent_ast_view_enrichment``.
+"""
+
+from __future__ import annotations
+
+from packages.llm_analysis.prompts.analysis import (
+    _render_ast_view_block,
+    build_analysis_prompt_bundle,
+    build_analysis_prompt_bundle_from_finding,
+)
+
+
+def _av(**overrides):
+    """Helper: build a default ast_view dict matching
+    ``FunctionView.to_dict()`` shape, with field overrides."""
+    base = {
+        "function": "handle_query",
+        "file": "src/routes.py",
+        "language": "python",
+        "lines": [34, 58],
+        "signature": "handle_query(req: Request) -> Response",
+        "calls_made": [
+            {"line": 36, "chain": ["validate"], "caller": "handle_query", "receiver_class": None},
+            {"line": 40, "chain": ["execute_query"], "caller": "handle_query", "receiver_class": None},
+            {"line": 50, "chain": ["render_template"], "caller": "handle_query", "receiver_class": None},
+        ],
+        "returns": [
+            {"line": 47, "value_text": "Response(400)"},
+            {"line": 57, "value_text": "response"},
+        ],
+        "has_inline_asm": False,
+        "schema_version": 1,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Renderer
+# ---------------------------------------------------------------------------
+
+
+class TestRenderer:
+    def test_renders_signature_calls_returns_asm(self):
+        text = _render_ast_view_block(_av())
+        assert "handle_query(req: Request) -> Response" in text
+        assert "src/routes.py:34-58" in text
+        assert "inline asm: no" in text
+        assert "validate" in text
+        assert "execute_query" in text
+        assert "render_template" in text
+        # Two returns surfaced with lines.
+        assert "47" in text and "57" in text
+
+    def test_dedup_calls_with_hit_count(self):
+        # Same call name on multiple lines collapses to "name(xN)".
+        av = _av(calls_made=[
+            {"line": 36, "chain": ["execute"], "caller": "f", "receiver_class": None},
+            {"line": 40, "chain": ["execute"], "caller": "f", "receiver_class": None},
+            {"line": 50, "chain": ["execute"], "caller": "f", "receiver_class": None},
+        ])
+        text = _render_ast_view_block(av)
+        assert "execute(x3)" in text, text
+
+    def test_dotted_chains_for_method_calls(self):
+        av = _av(calls_made=[
+            {"line": 36, "chain": ["obj", "method"], "caller": "f", "receiver_class": None},
+        ])
+        text = _render_ast_view_block(av)
+        assert "obj.method" in text
+
+    def test_truncation_marker_on_large_call_list(self):
+        # Many distinct callees → truncated with "..."
+        many = [
+            {"line": 10 + i, "chain": [f"f{i}"], "caller": "h", "receiver_class": None}
+            for i in range(30)
+        ]
+        text = _render_ast_view_block(_av(calls_made=many))
+        assert "..." in text
+        # Counts are preserved even with truncation.
+        assert "(30)" in text
+
+    def test_asm_flag_surfaced(self):
+        text = _render_ast_view_block(_av(has_inline_asm=True))
+        assert "inline asm: yes" in text
+
+    def test_empty_calls_renders_none_marker(self):
+        text = _render_ast_view_block(_av(calls_made=[]))
+        assert "calls inside body: (none)" in text
+
+    def test_empty_returns_renders_none_marker(self):
+        text = _render_ast_view_block(_av(returns=[]))
+        assert "explicit returns: (none)" in text
+
+    def test_signature_fallback_to_function_name(self):
+        # Signature empty → fall back to bare function name in header.
+        text = _render_ast_view_block(_av(signature=""))
+        assert "host function: handle_query" in text
+
+    def test_file_path_override_displaces_ast_view_file(self):
+        """``file_path_override`` kwarg substitutes the display path
+        for ``ast_view["file"]``. Used by the prompt builder so the
+        rendered block body matches the block's ``origin`` (the
+        finding's repo-relative path) rather than the absolute path
+        ``core.ast.view`` resolved internally."""
+        av = _av(file="/tmp/scan-tmpdir/src/routes.py")
+        text = _render_ast_view_block(
+            av, file_path_override="src/routes.py",
+        )
+        assert "src/routes.py:" in text
+        assert "/tmp/scan-tmpdir" not in text
+
+    def test_file_path_override_default_is_ast_view_file(self):
+        """No override → use ``ast_view["file"]`` (backwards-compat
+        for any caller that doesn't supply the override)."""
+        av = _av(file="some/path.py")
+        text = _render_ast_view_block(av)  # no override
+        assert "some/path.py:" in text
+
+    def test_compactness_under_100_tokens(self):
+        # Rough proxy for token cost: lines and chars.
+        text = _render_ast_view_block(_av())
+        # 4 lines: header + asm + calls + returns
+        assert text.count("\n") == 3
+        # Under 400 chars for a typical function.
+        assert len(text) < 400, len(text)
+
+
+# ---------------------------------------------------------------------------
+# Bundle threading
+# ---------------------------------------------------------------------------
+
+
+class TestBundleThreading:
+    def test_finding_with_ast_view_emits_untrusted_block(self):
+        finding = {
+            "rule_id": "sql-injection",
+            "file_path": "src/routes.py",
+            "start_line": 36,
+            "end_line": 36,
+            "message": "potential SQLi",
+            "ast_view": _av(),
+        }
+        bundle = build_analysis_prompt_bundle_from_finding(finding)
+        user = bundle.messages[1].content  # [0]=system, [1]=user
+        assert "ast-view" in user
+        assert "handle_query" in user
+        assert "validate" in user
+
+    def test_finding_without_ast_view_omits_block(self):
+        finding = {
+            "rule_id": "sql-injection",
+            "file_path": "src/routes.py",
+            "start_line": 36,
+            "end_line": 36,
+            "message": "potential SQLi",
+            # No ast_view field
+        }
+        bundle = build_analysis_prompt_bundle_from_finding(finding)
+        user = bundle.messages[1].content
+        assert "ast-view" not in user
+
+    def test_finding_with_empty_ast_view_dict_still_emits(self):
+        # Empty-ish dict (no signature, no calls, no returns, asm=False)
+        # — the renderer falls back to bare function + (none) markers,
+        # which is still informative ("we know the function exists").
+        finding = {
+            "rule_id": "sql-injection",
+            "file_path": "src/routes.py",
+            "start_line": 1,
+            "ast_view": {
+                "function": "f", "file": "x.py", "language": "python",
+                "lines": [1, 1], "signature": "", "calls_made": [],
+                "returns": [], "has_inline_asm": False, "schema_version": 1,
+            },
+        }
+        bundle = build_analysis_prompt_bundle_from_finding(finding)
+        user = bundle.messages[1].content
+        assert "ast-view" in user
+        assert "host function: f" in user
+
+    def test_direct_bundle_call_with_ast_view_kwarg(self):
+        # Direct ``build_analysis_prompt_bundle`` call (not the
+        # finding wrapper) also accepts the kwarg.
+        bundle = build_analysis_prompt_bundle(
+            rule_id="x", level="warning",
+            file_path="src/x.py", start_line=1, end_line=1,
+            message="test", ast_view=_av(),
+        )
+        user = bundle.messages[1].content
+        assert "ast-view" in user
+
+    def test_bundle_without_ast_view_kwarg_works(self):
+        # Backwards-compat: omitting the kwarg works (default None).
+        bundle = build_analysis_prompt_bundle(
+            rule_id="x", level="warning",
+            file_path="src/x.py", start_line=1, end_line=1,
+            message="test",
+        )
+        user = bundle.messages[1].content
+        assert "ast-view" not in user
+
+    def test_ast_view_block_envelope_origin_includes_function(self):
+        # The untrusted-block envelope carries an origin field for
+        # debug/audit; ours sets it to
+        # ``<finding's file_path>:<function-from-ast_view>`` — file
+        # comes from the finding (matches every other block's
+        # origin convention), function comes from the ast_view
+        # (machine-derived from the parser).
+        finding = {
+            "rule_id": "x", "file_path": "src/x.py", "start_line": 1,
+            "ast_view": _av(),  # ast_view.function = "handle_query"
+        }
+        bundle = build_analysis_prompt_bundle_from_finding(finding)
+        user = bundle.messages[1].content
+        assert 'origin="src/x.py:handle_query"' in user
+
+
+# ---------------------------------------------------------------------------
+# Robustness — malformed ast_view dicts
+# ---------------------------------------------------------------------------
+
+
+class TestRobustness:
+    def test_missing_function_field(self):
+        text = _render_ast_view_block({"calls_made": [], "returns": []})
+        assert text  # non-empty
+        assert "host function:" in text
+
+    def test_missing_lines_field(self):
+        text = _render_ast_view_block({"function": "f", "calls_made": [], "returns": []})
+        assert "0-0" in text
+
+    def test_call_with_no_chain(self):
+        # A CallSite with chain=[] (theoretically possible from a
+        # buggy walker) renders as "?".
+        av = _av(calls_made=[
+            {"line": 10, "chain": [], "caller": "f", "receiver_class": None},
+        ])
+        text = _render_ast_view_block(av)
+        assert "?" in text
+
+    def test_return_without_line(self):
+        av = _av(returns=[{"value_text": "x"}])
+        text = _render_ast_view_block(av)
+        # Doesn't crash; renders "?" for the missing line.
+        assert "?" in text or "explicit returns: 1" in text
+
+    def test_calls_made_not_a_list_silently_dropped(self):
+        """Malformed input: ``calls_made`` is a string (e.g. via a
+        corrupted JSON round-trip). The renderer must not crash —
+        treat as empty list. Pinned because the iterator-over-string
+        pattern is a common Python footgun."""
+        text = _render_ast_view_block({
+            "function": "f", "lines": [1, 1], "signature": "",
+            "calls_made": "not_a_list", "returns": [],
+            "has_inline_asm": False,
+        })
+        assert "calls inside body: (none)" in text
+
+    def test_returns_not_a_list_silently_dropped(self):
+        text = _render_ast_view_block({
+            "function": "f", "lines": [1, 1], "signature": "",
+            "calls_made": [], "returns": "not_a_list",
+            "has_inline_asm": False,
+        })
+        assert "explicit returns: (none)" in text
+
+    def test_non_dict_entries_in_calls_dropped(self):
+        text = _render_ast_view_block({
+            "function": "f", "lines": [1, 1], "signature": "",
+            "calls_made": ["bare-string", None, 42, {"chain": ["valid"]}],
+            "returns": [], "has_inline_asm": False,
+        })
+        # Only the dict entry survives.
+        assert "calls inside body (1)" in text
+        assert "valid" in text
+
+    def test_chain_not_a_list_silently_treated_as_empty(self):
+        text = _render_ast_view_block({
+            "function": "f", "lines": [1, 1], "signature": "",
+            "calls_made": [{"chain": "should_be_a_list"}],
+            "returns": [], "has_inline_asm": False,
+        })
+        # Bad chain → "?" placeholder.
+        assert "calls inside body (1)" in text
+        assert "?" in text


### PR DESCRIPTION
Third consumer for `core.ast.view` after the libexec CLI shim (PR #527) and `/understand --map` (PR2). Per-finding analysis prompts now carry a compact ast_view block (signature, calls inside body, returns, inline-asm flag) alongside the existing function-context, scanner message, vulnerable code, and dataflow blocks.

What lands:

* `packages/llm_analysis/agent.py` — private helper `_enrich_finding_with_ast_view(finding, repo_path)` runs once per finding before any LLM call, attaching `finding["ast_view"]` via `core.ast.view`. Sits outside the metadata-enrichment gate so pre-metadata-enriched findings (from upstream scanners) still get ast_view. Idempotent (pre-existing values preserved). Best-effort: parse failure / unsupported language / function not in inventory all leave `finding["ast_view"]` unset and the prompt builder skips the block.

* `packages/llm_analysis/prompts/analysis.py` — `build_analysis_prompt_bundle` gains an optional `ast_view` kwarg; `build_analysis_prompt_bundle_from_finding` threads `finding["ast_view"]` through; new `_render_ast_view_block` helper emits a compact text summary (~50-100 tokens/finding depending on call/return count). Accepts `file_path_override` so the rendered block body uses the finding's repo-relative path rather than the absolute path `core.ast.view` resolved internally — keeps the body consistent with the block's envelope `origin` attribute. Render features: dedup callees with hit count (`execute(x3)`), truncate over-cap call/return lists with `...` marker, fallback to bare function name when signature is empty. Defensive against type-confused input (`calls_made` as a string, `chain` as a non-list, etc.) — drops malformed entries silently rather than raising.

* Coverage of analysis-family tasks: AnalysisTask / ConsensusTask / JudgeTask / RetryTask all delegate to `build_analysis_prompt_bundle_from_finding` and inherit the enrichment automatically. ExploitTask / PatchTask use different bundle builders (deferred to a follow-up PR). GroupAnalysisTask deferred (its group-prompt structure needs its own design — render N member ast_views or a structural diff between members).

Block ordering in the prompt: `ast-view` sits between the existing `function-context` block and the dataflow / code blocks. Reasoning:
* Function-info grouping — function-context (static profile) and ast-view (body shape) are both "what is this function"; the LLM builds a single mental model before reading bug context.
* Dataflow narrative integrity — when has_dataflow=True the prompt has a source→step→sink arc; inserting ast-view inside breaks the narrative.
* Prompt-prefix cache friendliness — function-info blocks are stable across findings inside the same function; the bug-specific blocks vary per finding. Structural-first layout improves cache hit rates.

Rendering trade-off: compact prose (~50-100 tokens/finding) chosen over JSON (~250+ tokens). The LLM uses ast_view for narrative reasoning ("does this function call a sanitiser elsewhere?", "are there early returns that gate the sink?") — narrative input fits narrative reasoning. JSON would inflate 100-finding scans by ~20K extra tokens for no narrative gain. The renderer is a single helper; switchable to JSON with a one-function change if measurement later shows the LLM needs structured fields.

Testing:

Unit: 41 new (22 prompt-side renderer + bundle, 19 agent- side enrichment). Wider `packages/llm_analysis/` regression 1035/1035 clean. Ruff F401/F811/F821/F841 gate clean.

Adversarial review (10 scenarios): script-tag in signature / envelope-marker-like text / 1000-callee list / garbage ast_view dict / None values where lists expected / finding without file_path / JSON serialisability / ast_view + dataflow interaction / no-ast_view regression / token cost on realistic kernel-ish function. 8 first-pass + 2 surfaced findings:
  * adv-01 (`<script>` in signature) — already defended by the existing prompt-envelope auto-fetch-markup sanitiser. Confirms our new block participates in the established defense. No code change needed.
  * adv-04 (`calls_made: "not_a_list"` crashed renderer) — real robustness gap. Added type guards in `_render_ast_view_block` for malformed types; 4 new pinning tests; re-run clean.

E2E: real Linux kernel `lib/string_helpers.c` finding (rule pointing at `parse_int_array_user`) run through the full enrichment → prompt-building pipeline. ast_view block correctly emitted with realistic content: 7 calls dedup'd with hit count (`get_options(x2)` because the function calls it on two different lines), 2 explicit returns at the right lines, signature extracted. Total prompt token cost reasonable (~260 tokens for a minimal finding; ast-view block accounts for ~95 of that). Surfaced + fixed an operator-facing path inconsistency (block body showed absolute path while envelope origin showed repo-relative) via the `file_path_override` kwarg.

Production code is testable directly: the enrichment block was extracted into a module-level helper
(`_enrich_finding_with_ast_view`), which the test imports and exercises. No source-grep mirror tests.