### PR TITLE
feat(llm_analysis): wire core/ast view into /exploit + /patch prompts

### DIFF
--- a/packages/llm_analysis/prompts/exploit.py
+++ b/packages/llm_analysis/prompts/exploit.py
@@ -143,6 +143,7 @@ def build_exploit_prompt_bundle(
     feasibility: Optional[Dict[str, Any]] = None,
     profile: Optional[ModelDefenseProfile] = None,
     extra_blocks: tuple[UntrustedBlock, ...] = (),
+    ast_view: Optional[Dict[str, Any]] = None,
 ) -> PromptBundle:
     """Build the exploit prompt as a PromptBundle (system + user, role-separated)."""
     profile = profile or CONSERVATIVE
@@ -186,6 +187,29 @@ def build_exploit_prompt_bundle(
                 content=witness_text,
                 kind="smt-witness",
                 origin=f"smt:{rule_id}",
+            ))
+
+    # Per-function AST view (signature, calls inside body, returns,
+    # inline-asm flag). Gives the exploit-writing LLM the function's
+    # shape — particularly its calls — without making it re-parse
+    # ``surrounding_context``. Calls inside the body often reveal
+    # exploitation primitives (``system``, ``execve``, ``memcpy``,
+    # ``__builtin_*``) the LLM can target. ``has_inline_asm`` flags
+    # functions where the bug may sit in a non-portable primitive.
+    # Block sits BEFORE vulnerable-code so the LLM has the function
+    # context before reading the specific bug line.
+    if ast_view:
+        from packages.llm_analysis.prompts.analysis import (
+            _render_ast_view_block,
+        )
+        view_text = _render_ast_view_block(
+            ast_view, file_path_override=file_path,
+        )
+        if view_text:
+            blocks.append(UntrustedBlock(
+                content=view_text,
+                kind="ast-view",
+                origin=f"{file_path}:{ast_view.get('function', '?')}",
             ))
 
     if code:
@@ -239,6 +263,12 @@ def build_exploit_prompt_bundle_from_finding(
         feasibility=finding.get("feasibility"),
         profile=profile,
         extra_blocks=extra_blocks,
+        # Per-function structured AST view (populated by
+        # ``packages.llm_analysis.agent`` enrichment loop — shared
+        # with the analysis-family tasks). Absent when the
+        # function can't be located in the inventory or the
+        # parser doesn't support the language.
+        ast_view=finding.get("ast_view"),
     )
 
 

--- a/packages/llm_analysis/prompts/patch.py
+++ b/packages/llm_analysis/prompts/patch.py
@@ -86,6 +86,7 @@ def build_patch_prompt_bundle(
     attack_path: Optional[Dict[str, Any]] = None,
     profile: Optional[ModelDefenseProfile] = None,
     extra_blocks: tuple[UntrustedBlock, ...] = (),
+    ast_view: Optional[Dict[str, Any]] = None,
 ) -> PromptBundle:
     """Build the patch prompt as a PromptBundle (system + user, role-separated)."""
     profile = profile or CONSERVATIVE
@@ -124,6 +125,29 @@ def build_patch_prompt_bundle(
                 content=ap,
                 kind="attack-path",
                 origin=f"feasibility:{rule_id}",
+            ))
+
+    # Per-function AST view (signature, calls inside body, returns,
+    # inline-asm flag). Gives the patch-generating LLM the
+    # function's current shape so the fix can preserve existing
+    # call semantics, return paths, and parameter contracts.
+    # Particularly useful for patches that must add a check
+    # without breaking other return paths — the LLM sees every
+    # exit point. Block sits BEFORE vulnerable-code so the LLM
+    # has the function's current contract before editing the
+    # buggy span.
+    if ast_view:
+        from packages.llm_analysis.prompts.analysis import (
+            _render_ast_view_block,
+        )
+        view_text = _render_ast_view_block(
+            ast_view, file_path_override=file_path,
+        )
+        if view_text:
+            blocks.append(UntrustedBlock(
+                content=view_text,
+                kind="ast-view",
+                origin=f"{file_path}:{ast_view.get('function', '?')}",
             ))
 
     if code:
@@ -180,6 +204,9 @@ def build_patch_prompt_bundle_from_finding(
         attack_path=attack_path,
         profile=profile,
         extra_blocks=extra_blocks,
+        # Per-function structured AST view (shared with the
+        # analysis-family tasks via the agent's enrichment loop).
+        ast_view=finding.get("ast_view"),
     )
 
 

--- a/packages/llm_analysis/tests/test_prompt_ast_view_exploit_patch.py
+++ b/packages/llm_analysis/tests/test_prompt_ast_view_exploit_patch.py
@@ -1,0 +1,247 @@
+"""Tests for ``ast_view`` integration in the exploit + patch prompt
+bundles.
+
+The renderer (``_render_ast_view_block``) is shared with the analysis
+bundle and is covered by ``test_prompt_ast_view.py``. These tests
+pin the bundle-threading: that ``finding["ast_view"]`` flows through
+``build_exploit_prompt_bundle_from_finding`` and
+``build_patch_prompt_bundle_from_finding`` into an ``ast-view``
+untrusted block, with the expected ordering relative to the
+bundle-specific blocks (prior-analysis, vulnerable-code, etc.).
+"""
+
+from __future__ import annotations
+
+from packages.llm_analysis.prompts.exploit import (
+    build_exploit_prompt_bundle,
+    build_exploit_prompt_bundle_from_finding,
+)
+from packages.llm_analysis.prompts.patch import (
+    build_patch_prompt_bundle,
+    build_patch_prompt_bundle_from_finding,
+)
+
+
+def _av(**overrides):
+    base = {
+        "function": "handle_query",
+        "file": "src/routes.py",
+        "language": "python",
+        "lines": [34, 58],
+        "signature": "handle_query(req: Request) -> Response",
+        "calls_made": [
+            {"line": 36, "chain": ["execute_query"], "caller": "handle_query", "receiver_class": None},
+        ],
+        "returns": [{"line": 57, "value_text": "response"}],
+        "has_inline_asm": False,
+        "schema_version": 1,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Exploit
+# ---------------------------------------------------------------------------
+
+
+class TestExploitBundle:
+    def test_finding_with_ast_view_emits_block(self):
+        finding = {
+            "rule_id": "sql-injection",
+            "file_path": "src/routes.py",
+            "start_line": 36,
+            "level": "warning",
+            "analysis": {"is_exploitable": True},
+            "code": "execute_query(...)",
+            "ast_view": _av(),
+        }
+        bundle = build_exploit_prompt_bundle_from_finding(finding)
+        user = bundle.messages[1].content
+        assert "ast-view" in user
+        assert "handle_query" in user
+        assert "execute_query" in user
+
+    def test_finding_without_ast_view_omits_block(self):
+        finding = {
+            "rule_id": "x", "file_path": "src/routes.py",
+            "start_line": 36, "level": "warning",
+            "analysis": {"is_exploitable": True},
+            "code": "x",
+        }
+        bundle = build_exploit_prompt_bundle_from_finding(finding)
+        user = bundle.messages[1].content
+        assert "ast-view" not in user
+
+    def test_direct_call_with_ast_view_kwarg(self):
+        bundle = build_exploit_prompt_bundle(
+            rule_id="x", file_path="src/x.py", start_line=1,
+            level="warning", analysis={}, ast_view=_av(),
+        )
+        user = bundle.messages[1].content
+        assert "ast-view" in user
+
+    def test_ast_view_block_before_vulnerable_code(self):
+        """In the exploit prompt, ast-view sits BEFORE vulnerable-code
+        so the LLM understands the function shape before reading the
+        bug-specific code. Pin this ordering."""
+        finding = {
+            "rule_id": "x", "file_path": "src/x.py",
+            "start_line": 1, "level": "warning",
+            "analysis": {"is_exploitable": True},
+            "code": "vulnerable_call()",
+            "ast_view": _av(),
+        }
+        bundle = build_exploit_prompt_bundle_from_finding(finding)
+        user = bundle.messages[1].content
+        ast_idx = user.find('kind="ast-view"')
+        code_idx = user.find('kind="vulnerable-code"')
+        assert ast_idx >= 0 and code_idx >= 0
+        assert ast_idx < code_idx, (
+            f"ast-view at {ast_idx} after vulnerable-code at {code_idx}"
+        )
+
+    def test_path_consistency_envelope_and_body(self):
+        """Repo-relative path appears in both envelope origin and
+        rendered body (PR3 fix; same contract here)."""
+        av = _av(file="/tmp/abs/src/routes.py")  # absolute, like view() emits
+        finding = {
+            "rule_id": "x", "file_path": "src/routes.py",
+            "start_line": 1, "level": "warning",
+            "analysis": {"is_exploitable": True},
+            "ast_view": av,
+        }
+        bundle = build_exploit_prompt_bundle_from_finding(finding)
+        user = bundle.messages[1].content
+        assert 'origin="src/routes.py:handle_query"' in user
+        # Body uses the override.
+        assert "src/routes.py:34-58" in user
+        assert "/tmp/abs" not in user
+
+
+# ---------------------------------------------------------------------------
+# Patch
+# ---------------------------------------------------------------------------
+
+
+class TestPatchBundle:
+    def test_finding_with_ast_view_emits_block(self):
+        finding = {
+            "rule_id": "sql-injection",
+            "file_path": "src/routes.py",
+            "start_line": 36, "end_line": 40,
+            "message": "test",
+            "analysis": {"is_exploitable": True},
+            "code": "execute_query(...)",
+            "ast_view": _av(),
+        }
+        bundle = build_patch_prompt_bundle_from_finding(finding)
+        user = bundle.messages[1].content
+        assert "ast-view" in user
+        assert "handle_query" in user
+
+    def test_finding_without_ast_view_omits_block(self):
+        finding = {
+            "rule_id": "x", "file_path": "src/x.py",
+            "start_line": 1, "end_line": 1,
+            "message": "test",
+            "analysis": {"is_exploitable": True},
+        }
+        bundle = build_patch_prompt_bundle_from_finding(finding)
+        user = bundle.messages[1].content
+        assert "ast-view" not in user
+
+    def test_direct_call_with_ast_view_kwarg(self):
+        bundle = build_patch_prompt_bundle(
+            rule_id="x", file_path="src/x.py",
+            start_line=1, end_line=1,
+            message="test", analysis={},
+            ast_view=_av(),
+        )
+        user = bundle.messages[1].content
+        assert "ast-view" in user
+
+    def test_ast_view_block_before_vulnerable_code(self):
+        """In the patch prompt, ast-view sits BEFORE vulnerable-code
+        so the patcher sees the function's current shape (returns,
+        calls) before reading the buggy span — essential for
+        preserving existing return paths in the fix."""
+        finding = {
+            "rule_id": "x", "file_path": "src/x.py",
+            "start_line": 1, "end_line": 1,
+            "message": "test",
+            "analysis": {"is_exploitable": True},
+            "code": "buggy()",
+            "ast_view": _av(),
+        }
+        bundle = build_patch_prompt_bundle_from_finding(finding)
+        user = bundle.messages[1].content
+        ast_idx = user.find('kind="ast-view"')
+        code_idx = user.find('kind="vulnerable-code"')
+        assert ast_idx >= 0 and code_idx >= 0
+        assert ast_idx < code_idx
+
+    def test_path_consistency_envelope_and_body(self):
+        av = _av(file="/tmp/abs/src/routes.py")
+        finding = {
+            "rule_id": "x", "file_path": "src/routes.py",
+            "start_line": 1, "end_line": 1,
+            "message": "test", "analysis": {"is_exploitable": True},
+            "ast_view": av,
+        }
+        bundle = build_patch_prompt_bundle_from_finding(finding)
+        user = bundle.messages[1].content
+        assert 'origin="src/routes.py:handle_query"' in user
+        assert "src/routes.py:34-58" in user
+        assert "/tmp/abs" not in user
+
+
+# ---------------------------------------------------------------------------
+# SCA routing — ast_view doesn't apply to SCA bundles (different shape)
+# ---------------------------------------------------------------------------
+
+
+class TestSCARouting:
+    """SCA findings route to a different prompt bundle
+    (``build_sca_exploit_prompt_bundle`` / ``build_sca_patch_prompt_bundle``).
+    The SCA bundles today take a different shape (manifest-anchored
+    findings, no per-function host) and don't accept ``ast_view``.
+    Pin that the threading doesn't accidentally apply or crash on
+    SCA findings.
+
+    **Future revisit when ``feat/sca`` lands**: SCA has shipped
+    function-level reachability
+    (``core/inventory/reachability.function_called`` + 8 language-
+    specific wirings per memory ``project_function_level_reachability``).
+    If a future SCA finding shape surfaces a *caller function* (the
+    function that calls the vulnerable API rather than just the
+    manifest line), the SCA bundle author can opt in by adding an
+    ``ast_view`` kwarg + threading. The finding's ``file_path`` would
+    then point at the caller's source file rather than the manifest.
+    Today that data isn't there; these tests pin the "ignored"
+    contract until it is."""
+
+    def test_sca_exploit_finding_ignores_ast_view(self):
+        finding = {
+            "rule_id": "sca:vulnerable_dependency:CVE-2024-12345",
+            "file_path": "package.json",
+            "start_line": 1, "level": "warning",
+            "analysis": {"is_exploitable": True},
+            "sca": {"reachability": "likely_called"},
+            "ast_view": _av(),  # ignored today; may carry meaning post-SCA-merge
+        }
+        # Should not raise; SCA bundle handles its own structure.
+        bundle = build_exploit_prompt_bundle_from_finding(finding)
+        assert bundle is not None
+
+    def test_sca_patch_finding_ignores_ast_view(self):
+        finding = {
+            "rule_id": "sca:vulnerable_dependency:CVE-2024-12345",
+            "file_path": "package.json",
+            "start_line": 1, "end_line": 1,
+            "message": "test",
+            "analysis": {"is_exploitable": True},
+            "ast_view": _av(),  # ignored today; may carry meaning post-SCA-merge
+        }
+        bundle = build_patch_prompt_bundle_from_finding(finding)
+        assert bundle is not None


### PR DESCRIPTION
Fourth consumer for `core.ast.view` after the libexec CLI shim (PR #527), `/understand --map` (#528), and `/agentic` analysis- family prompts (#533). Exploit and patch prompts now carry the compact ast_view block (signature, calls inside body, returns, inline-asm flag) alongside the existing prior-analysis, exploitation-constraints, smt-witness, attack-path, vulnerable- code, and full-file-content blocks.

What lands:

  * `packages/llm_analysis/prompts/exploit.py` — `build_exploit_prompt_bundle` gains optional `ast_view` kwarg; `..._from_finding` threads `finding["ast_view"]` through. New `ast-view` untrusted block emitted before `vulnerable-code` so the exploit-writing LLM sees the function shape (calls inside body — often exploitation primitives like `system`, `execve`, `memcpy`, `__builtin_*`) before reading the bug-specific code. `has_inline_asm` flags functions where standard taint reasoning may not apply.

  * `packages/llm_analysis/prompts/patch.py` — same kwarg + threading + block emission. Block sits before `vulnerable-code` so the patch-generating LLM sees the function's current contract (returns, calls, signature) before editing the buggy span — essential for preserving existing return paths in the fix.

  * Renderer reused: `_render_ast_view_block` from `prompts/analysis.py` is imported across-module within the package. Private (`_`-prefixed) to mark it as internal API; works fine within the same package. Promotion to a shared `prompts/ast_view.py` module is the right shape if a fifth consumer appears.

  * SCA findings deliberately unrouted. SCA findings live at manifest-anchored locations (`package.json:N`); the SCA prompt bundles (`build_sca_exploit_prompt_bundle`, `build_sca_patch_prompt_bundle`) don't accept ast_view because the data has no host function today. Pinned-by- test contract documents the "ignored on SCA" behavior. When feat/sca merges AND surfaces caller-function context (function-level reachability per `project_function_level_reachability` is already shipped on feat/sca, so the substrate is there), the SCA bundles can opt in via the same pattern. Memory entry `project_core_ast.md` records the TRIGGER.

  * Inheritance: `ExploitTask` (`packages/llm_analysis/tasks.py:102`) and `PatchTask` (line 165) delegate to `build_exploit_prompt_bundle_from_finding` and `build_patch_prompt_bundle_from_finding` respectively. Both pick up `finding["ast_view"]` automatically — no Task-side changes needed. The shared agent enrichment from PR #533 (`_enrich_finding_with_ast_view`) populates the finding once per analysis run, before any LLM call.

Testing:

  Unit: 12 new (5 exploit + 5 patch + 2 SCA-routing). Wider `packages/llm_analysis/` regression 1047/1047 clean. Ruff
  F401/F811/F821/F841 gate clean.

  E2E: real Linux kernel `lib/string_helpers.c` finding (`parse_int_array_user`) run through the full pipeline —
  shared enrichment from PR #533, then both exploit and patch bundles. Verified:
    * ast-view block present in both prompts with realistic content (7 calls dedup'd including `get_options(x2)`, 2 returns at correct lines, full signature).
    * Block ordering correct in both: ast-view before vulnerable-code (function context before bug span).
    * Path consistency: neither prompt leaks the absolute temp-dir path; both render `lib/string_helpers.c` via the `file_path_override` kwarg from PR #533.
    * Token cost bounded: 388 tokens (exploit) / 336 tokens (patch) total prompt cost for a realistic kernel finding.