### PR TITLE
feat(core/inventory): C++ namespace + class capture for reachability

### DIFF
--- a/core/inventory/call_graph.py
+++ b/core/inventory/call_graph.py
@@ -3906,6 +3906,12 @@ class _CppCallGraph(_CCallGraph):
     def __init__(self) -> None:
         super().__init__()
         self._class_stack: List[ClassDef] = []
+        # Namespace nesting stack. Each entry is a segment name
+        # (e.g. ``ns`` for ``namespace ns { ... }``; ``a``, ``b``
+        # for ``namespace a::b { ... }``). The dotted join feeds
+        # ``graph.package_name`` for resolver canonicalisation —
+        # parity with Java/C#/PHP/Ruby/Go.
+        self._ns_stack: List[str] = []
 
     # ------------------------------------------------------------------
     # Walk dispatch
@@ -3916,6 +3922,9 @@ class _CppCallGraph(_CCallGraph):
         if t == self._PREPROC_INCLUDE:
             self._visit_include(node)
             return
+        if t == self._NAMESPACE_DEFINITION:
+            self._visit_namespace_definition(node)
+            return
         if t in (self._CLASS_SPECIFIER, self._STRUCT_SPECIFIER):
             self._visit_class_specifier(node)
             return  # children are visited inside _visit_class_specifier
@@ -3925,8 +3934,52 @@ class _CppCallGraph(_CCallGraph):
         if t == self._CALL_EXPRESSION:
             self._visit_call(node)
             # Fall through — nested calls in arg list still walked.
+        if t == "field_initializer":
+            self._visit_field_initializer(node)
+            # Fall through — nested calls inside the argument_list
+            # (e.g. ``Base(helper())``) still need to be walked.
         for child in node.children:
             self.walk(child)
+
+    # ------------------------------------------------------------------
+    # Namespace
+    # ------------------------------------------------------------------
+
+    def _visit_namespace_definition(self, node) -> None:
+        """``namespace ns { ... }`` / ``namespace a::b { ... }`` —
+        push namespace segments and walk the body. Anonymous
+        namespaces (``namespace { ... }`` with no name) push
+        nothing — the body's symbols have internal linkage but
+        no qualified-name prefix in the call graph."""
+        parts: List[str] = []
+        for c in node.children:
+            if c.type == "namespace_identifier":
+                parts.append(c.text.decode("utf-8", errors="replace"))
+            elif c.type == "nested_namespace_specifier":
+                # ``a::b`` — multiple namespace_identifier children.
+                for sub in c.children:
+                    if sub.type == "namespace_identifier":
+                        parts.append(
+                            sub.text.decode("utf-8", errors="replace"),
+                        )
+        self._ns_stack.extend(parts)
+        if self._ns_stack:
+            self.graph.package_name = ".".join(self._ns_stack)
+        try:
+            for c in node.children:
+                self.walk(c)
+        finally:
+            for _ in parts:
+                self._ns_stack.pop()
+            # Deepest-wins: don't decrement ``package_name`` when a
+            # nested namespace closes. ``namespace outer { namespace
+            # inner { ... } }`` should produce ``package_name=
+            # "outer.inner"`` (the deepest scope, where the class
+            # actually lives). Restoring to the outer dotted form on
+            # close would lose the inner segment that's typically
+            # the more useful canonical form for cross-file
+            # canonicalisation. Matches Ruby's module-nesting
+            # convention.
 
     # ------------------------------------------------------------------
     # Class / struct
@@ -3964,13 +4017,21 @@ class _CppCallGraph(_CCallGraph):
 
     def _collect_method_declarations(self, class_node, cdef: ClassDef) -> None:
         """Scan a ``class_specifier`` / ``struct_specifier`` body for
-        method *declarations* (in addition to any inline definitions
-        already in the body). A method declaration is a
-        ``field_declaration`` that wraps a ``function_declarator``.
+        method *declarations* + *inline definitions*. Populates
+        ``cdef.methods`` BEFORE the body walk so receiver-class
+        inference works on the very first call site visited.
 
-        Out-of-line definitions don't appear here; the in-class
-        declaration is the load-bearing record for the method's
-        existence as far as receiver-class inference is concerned.
+        Three method shapes appear inside a class body:
+          * ``field_declaration`` — declared method (no body); has a
+            return-type child + function_declarator child.
+          * ``declaration`` — destructors / constructors (no return
+            type).
+          * ``function_definition`` — inline method with a body.
+            This is the typical shape for header-defined methods
+            and is what the original PR-527 pre-pass missed —
+            inline ``helper()`` calls from a sibling method
+            walked first would fail to find ``helper`` in the
+            methods set and miss receiver_class tagging.
         """
         body = None
         for c in class_node.children:
@@ -3979,22 +4040,33 @@ class _CppCallGraph(_CCallGraph):
                 break
         if body is None:
             return
-        # Methods declared inside a class body come in two shapes:
-        #   * ``field_declaration`` — normal methods (have a return
-        #     type child + function_declarator child).
-        #   * ``declaration`` — destructors and constructors (no
-        #     return type, so the grammar doesn't fit the
-        #     ``field_declaration`` shape).
         for member in body.children:
-            if member.type not in (self._FIELD_DECLARATION, "declaration"):
+            # ``template<T> T get();`` and ``template<T> void m() {}``
+            # wrap the declaration / function_definition inside a
+            # ``template_declaration`` node. Unwrap one level so the
+            # inner declarator is reachable from the same loop.
+            target = member
+            if target.type == self._TEMPLATE_DECLARATION:
+                for sub in target.children:
+                    if sub.type in (
+                        self._FIELD_DECLARATION, "declaration",
+                        self._FUNCTION_DEFINITION,
+                    ):
+                        target = sub
+                        break
+                else:
+                    continue
+            if target.type not in (self._FIELD_DECLARATION, "declaration",
+                                    self._FUNCTION_DEFINITION):
                 continue
-            for sub in member.children:
+            for sub in target.children:
                 if sub.type == self._FUNCTION_DECLARATOR:
                     name = self._declarator_name_cpp(sub)
                     if name:
                         cdef.methods.append(
-                            (name, member.start_point[0] + 1),
+                            (name, target.start_point[0] + 1),
                         )
+                    break
 
     def _class_name(self, node) -> Optional[str]:
         # class_specifier: "class" type_identifier base_class_clause? body
@@ -4006,7 +4078,9 @@ class _CppCallGraph(_CCallGraph):
     def _extract_bases(self, node) -> List[str]:
         """Parse ``: public Foo, protected Bar`` into ``["Foo",
         "Bar"]``. Access specifiers are dropped; only the type names
-        survive."""
+        survive. ``Foo<T>`` (template_type) base is reduced to
+        ``Foo`` — type args are erased for the same reason
+        template_function callees emit the bare name."""
         bases: List[str] = []
         for c in node.children:
             if c.type != self._BASE_CLASS_CLAUSE:
@@ -4020,6 +4094,16 @@ class _CppCallGraph(_CCallGraph):
                     parts = self._qualified_parts(sub)
                     if parts:
                         bases.append("::".join(parts))
+                elif sub.type == self._TEMPLATE_TYPE:
+                    inner = None
+                    for ti in sub.children:
+                        if ti.type == self._TYPE_IDENTIFIER:
+                            inner = ti
+                            break
+                    if inner is not None:
+                        bases.append(
+                            inner.text.decode("utf-8", errors="replace"),
+                        )
         return bases
 
     # ------------------------------------------------------------------
@@ -4035,11 +4119,19 @@ class _CppCallGraph(_CCallGraph):
                 self.walk(c)
             return
 
-        # In-class inline method: record method on the current class.
+        # In-class inline method: record method on the current
+        # class — UNLESS the pre-pass already captured it
+        # (collect_method_declarations now picks up function_definition
+        # too, so a second append here would duplicate the entry).
         if self._class_stack and qualified_class is None:
-            self._class_stack[-1].methods.append(
-                (name, node.start_point[0] + 1),
+            current_class = self._class_stack[-1]
+            method_line = node.start_point[0] + 1
+            already = any(
+                m_name == name and m_line == method_line
+                for m_name, m_line in current_class.methods
             )
+            if not already:
+                current_class.methods.append((name, method_line))
 
         # Push enclosing function name. For out-of-line methods, also
         # synthesise a transient ClassDef-like context so calls inside
@@ -4235,6 +4327,15 @@ class _CppCallGraph(_CCallGraph):
             # Override C base: field_expression in C++ may root on
             # ``this`` (own node type) rather than an identifier.
             return self._field_chain_cpp(node), False
+        if node.type == self._TEMPLATE_FUNCTION:
+            # ``get<int>()`` — callee is template_function wrapping
+            # an identifier + template_argument_list. Emit just the
+            # identifier; downstream tools match on the bare name,
+            # template args are erased.
+            for c in node.children:
+                if c.type == self._IDENTIFIER:
+                    return [c.text.decode("utf-8", errors="replace")], False
+            return None, False
         return super()._callee_chain(node)
 
     def _field_chain_cpp(self, node) -> Optional[List[str]]:
@@ -4247,16 +4348,42 @@ class _CppCallGraph(_CCallGraph):
         parts: List[str] = []
         cur = node
         while cur is not None and cur.type == self._FIELD_EXPRESSION:
+            # The field side is either a plain ``field_identifier``
+            # (``a.b``) or a ``template_method`` wrapping one
+            # (``a.b<T>()``). For the template case, recover the
+            # inner field_identifier — template args are dropped.
             field_node = None
             for c in cur.children:
                 if c.type == self._FIELD_IDENTIFIER:
                     field_node = c
+                elif c.type == "template_method":
+                    for sub in c.children:
+                        if sub.type == self._FIELD_IDENTIFIER:
+                            field_node = sub
+                            break
+                elif c.type == "dependent_name":
+                    # ``c.template put<int>()`` — dependent-name
+                    # disambiguation. Wraps ``template_method``
+                    # which wraps the field_identifier. Same
+                    # erasure: drop template args, keep the name.
+                    for sub in c.children:
+                        if sub.type == "template_method":
+                            for inner in sub.children:
+                                if inner.type == self._FIELD_IDENTIFIER:
+                                    field_node = inner
+                                    break
+                            break
+                        if sub.type == self._FIELD_IDENTIFIER:
+                            field_node = sub
+                            break
             if field_node is None:
                 return None
             parts.append(field_node.text.decode("utf-8", errors="replace"))
             operand = None
             for c in cur.children:
-                if c.is_named and c.type != self._FIELD_IDENTIFIER:
+                if c.is_named and c.type not in (
+                    self._FIELD_IDENTIFIER, "template_method",
+                ):
                     operand = c
                     break
             cur = operand
@@ -4273,6 +4400,32 @@ class _CppCallGraph(_CCallGraph):
             if not head:
                 return None
             return head + list(reversed(parts))
+        if cur.type == "compound_literal_expression":
+            # ``Foo{}.method()`` / ``vector<int>{}.size()`` — the
+            # operand is an unnamed temporary of type Foo. Recover
+            # the type name for the chain head so a target named
+            # ``Foo.method`` still matches; type args are erased
+            # (same as template_function callee handling). Loses
+            # namespace prefix (we'd need symbol resolution to
+            # know it).
+            type_name = self._compound_literal_type_name(cur)
+            if type_name is not None:
+                parts.append(type_name)
+                return list(reversed(parts))
+            return None
+        return None
+
+    def _compound_literal_type_name(self, node) -> Optional[str]:
+        """Pull the type's bare name from a compound_literal_expression.
+        Handles plain ``Foo{}`` (type_identifier) and templated
+        ``vector<int>{}`` (template_type → type_identifier)."""
+        for c in node.children:
+            if c.type == self._TYPE_IDENTIFIER:
+                return c.text.decode("utf-8", errors="replace")
+            if c.type == self._TEMPLATE_TYPE:
+                for sub in c.children:
+                    if sub.type == self._TYPE_IDENTIFIER:
+                        return sub.text.decode("utf-8", errors="replace")
         return None
 
     def _visit_call(self, node) -> None:
@@ -4301,6 +4454,51 @@ class _CppCallGraph(_CCallGraph):
             chain=chain,
             caller=caller,
             receiver_class=receiver_class,
+        ))
+
+    def _visit_field_initializer(self, node) -> None:
+        """Constructor initialiser list entry: ``Base(x)`` or
+        ``member_(0)``. The field_identifier child names either:
+          * a base class (delegating constructor call) — semantically
+            a call to ``Base::Base``;
+          * a data member (initialiser with value, not a call).
+        Without symbol-table access we can't distinguish, so emit
+        both as CallSite chains. Downstream resolver narrows via
+        the class context — a target named ``Base`` lookup matches
+        the base-constructor case; targets named after the member
+        get a benign no-op (member name isn't in any class's
+        methods list, so reachability returns NOT_CALLED).
+
+        Bare member-init ``m_(0)`` is over-reporting but contained.
+        Base-constructor delegation is the load-bearing case for
+        SCA reachability against subclass-of-known-base sinks.
+        """
+        name_node = None
+        for c in node.children:
+            if c.type == self._FIELD_IDENTIFIER:
+                name_node = c
+                break
+            if c.type == "template_method":
+                # ``Base<T>(args)`` — template form of init list entry.
+                # Drop template args; recover the inner field_identifier.
+                for sub in c.children:
+                    if sub.type == self._FIELD_IDENTIFIER:
+                        name_node = sub
+                        break
+                if name_node is not None:
+                    break
+        if name_node is None:
+            return
+        name = name_node.text.decode("utf-8", errors="replace")
+        caller = self._enclosing[-1] if self._enclosing else None
+        # No receiver_class tag — initialiser-list entries dispatch
+        # on the literal name (base class or member), not on the
+        # enclosing class's method set.
+        self.graph.calls.append(CallSite(
+            line=node.start_point[0] + 1,
+            chain=[name],
+            caller=caller,
+            receiver_class=None,
         ))
 
     def _infer_receiver_class(self, chain: List[str]) -> Optional[str]:

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -248,6 +248,24 @@ def function_called(
                     file_has_evidence = True
                     evidence.append((path, int(call.get("line", 0) or 0)))
 
+        # Fully-qualified-call fast-path: when the chain itself
+        # spells out the qualified name (e.g. C++ ``ns::Util::
+        # helper()`` → chain ``["ns", "Util", "helper"]``, or Java
+        # ``com.foo.Util.helper()``, or PHP ``\Foo\Bar::method()``),
+        # the import map is bypassed entirely in source. The
+        # import-map path can't see these; receiver_class isn't
+        # set either. Strict equality of the joined dotted form
+        # to the target catches them with no false-positive risk:
+        # if the chain literally spells the target, it IS the
+        # target. Most useful for C/C++ (no symbol-level imports)
+        # and any cross-language fully-qualified call shape.
+        if not file_has_evidence:
+            for call in calls:
+                chain = call.get("chain") or []
+                if len(chain) >= 2 and ".".join(chain) == qualified_name:
+                    file_has_evidence = True
+                    evidence.append((path, int(call.get("line", 0) or 0)))
+
         if file_has_evidence:
             continue
 

--- a/core/inventory/tests/test_call_graph_cpp.py
+++ b/core/inventory/tests/test_call_graph_cpp.py
@@ -310,3 +310,395 @@ class TestSchemaContract:
         )
         assert g.decorated_functions == []
         assert g.relative_imports == []
+
+
+# ---------------------------------------------------------------------------
+# Namespace capture
+# ---------------------------------------------------------------------------
+
+
+class TestNamespaceCapture:
+    """``namespace ns { ... }`` → ``graph.package_name``. Enables
+    resolver canonicalisation of ``ns::Class::method`` calls."""
+
+    def test_simple_namespace(self):
+        g = extract_call_graph_cpp(
+            "namespace ns {\n    class C { void m() {} };\n}\n"
+        )
+        assert g.package_name == "ns"
+        assert any(c.name == "C" for c in g.classes)
+
+    def test_nested_namespace_specifier(self):
+        """``namespace a::b { ... }`` is one node with
+        ``nested_namespace_specifier``."""
+        g = extract_call_graph_cpp("namespace a::b { class C {}; }\n")
+        assert g.package_name == "a.b"
+
+    def test_namespace_within_namespace(self):
+        """Pushed segments concatenate; inner gets the dotted form."""
+        g = extract_call_graph_cpp(
+            "namespace outer {\n"
+            "    namespace inner { class C {}; }\n"
+            "}\n"
+        )
+        assert g.package_name == "outer.inner"
+
+    def test_anonymous_namespace(self):
+        """``namespace { ... }`` (no name) — internal linkage; no
+        qualified-name prefix."""
+        g = extract_call_graph_cpp("namespace { void f() {} }\n")
+        assert g.package_name is None
+
+    def test_no_namespace(self):
+        g = extract_call_graph_cpp("class C { void m() {} };\n")
+        assert g.package_name is None
+
+
+# ---------------------------------------------------------------------------
+# Implicit-this receiver_class fix (inline method registered pre-walk)
+# ---------------------------------------------------------------------------
+
+
+class TestImplicitThisReceiverClass:
+    """Pre-pass now collects inline ``function_definition`` nodes
+    too, so a bare ``helper()`` call from a sibling method walked
+    earlier still sees ``helper`` in the methods list and tags
+    receiver_class."""
+
+    def test_inline_method_called_before_sibling_defined(self):
+        g = extract_call_graph_cpp(
+            "class Service {\n"
+            "public:\n"
+            "    void run() { helper(); }\n"
+            "    void helper() {}\n"
+            "};\n"
+        )
+        call = next(c for c in g.calls if c.chain == ["helper"])
+        assert call.receiver_class == "Service"
+        assert call.caller == "run"
+
+    def test_method_definition_not_duplicated(self):
+        """Inline method shouldn't appear twice in ClassDef.methods."""
+        g = extract_call_graph_cpp("class C { void m() {} };\n")
+        cls = next(c for c in g.classes if c.name == "C")
+        names = [m[0] for m in cls.methods]
+        assert names.count("m") == 1
+
+    def test_struct_implicit_this_works(self):
+        """Struct is class with default-public access; same
+        implicit-this rules apply."""
+        g = extract_call_graph_cpp(
+            "struct S {\n"
+            "    void method() { helper(); }\n"
+            "    void helper() {}\n"
+            "};\n"
+        )
+        call = next(c for c in g.calls if c.chain == ["helper"])
+        assert call.receiver_class == "S"
+
+
+# ---------------------------------------------------------------------------
+# function_called consumer wiring — receiver_class fast-path resolves
+# C++ implicit-this calls via the new ``<ns>.<Class>.<method>`` synthesis
+# ---------------------------------------------------------------------------
+
+
+class TestFunctionCalledIntegration:
+    """The receiver_class fast-path in ``function_called`` (added
+    alongside the multi-lang substrate) now sees C++ classes too —
+    when a bare or ``this->`` call's chain tail matches the target
+    and the call carries ``receiver_class``, the resolver
+    synthesises ``<file_pkg>.<Class>.<tail>`` and compares against
+    the query."""
+
+    def test_namespace_class_method_resolves(self):
+        """``ns::Foo::bar()`` invoked via implicit-this from
+        ``ns::Foo::other()`` — resolver synthesises
+        ``ns.Foo.bar`` from the file's namespace + receiver_class."""
+        from core.inventory.reachability import (
+            Verdict, function_called,
+        )
+
+        g = extract_call_graph_cpp(
+            "namespace ns {\n"
+            "    class Foo {\n"
+            "    public:\n"
+            "        void other() { bar(); }\n"
+            "        void bar() {}\n"
+            "    };\n"
+            "}\n"
+        )
+        inv = {"files": [{"path": "src/foo.cpp", "language": "cpp",
+                           "call_graph": g.to_dict()}]}
+        r = function_called(inv, "ns.Foo.bar")
+        assert r.verdict == Verdict.CALLED
+        # Wrong class — same method name on a sibling → NOT_CALLED
+        r = function_called(inv, "ns.Other.bar")
+        assert r.verdict == Verdict.NOT_CALLED
+
+
+# ---------------------------------------------------------------------------
+# Templated callees + constructor initialiser lists
+# ---------------------------------------------------------------------------
+
+
+class TestTemplatedCallees:
+    """``get<int>()`` and ``this->put<double>()`` callees wrap their
+    name in ``template_function`` / ``template_method`` nodes. The
+    chain extraction recovers the inner identifier; template args
+    are dropped (parity with what other languages do — call
+    matching is by name, not by argument types)."""
+
+    def test_template_function_bare_call(self):
+        """``get<int>()`` → chain ``["get"]``."""
+        g = extract_call_graph_cpp(
+            "void f() { get<int>(); }\n"
+        )
+        chains = [c.chain for c in g.calls]
+        assert ["get"] in chains
+
+    def test_template_method_via_this(self):
+        """``this->put<double>(1.0)`` → chain ``["this", "put"]``
+        with ``receiver_class`` tagged."""
+        g = extract_call_graph_cpp(
+            "class C {\n"
+            "public:\n"
+            "    template<typename T> void put(T x);\n"
+            "    void use() { this->put<double>(1.0); }\n"
+            "};\n"
+        )
+        call = next(c for c in g.calls if c.chain == ["this", "put"])
+        assert call.receiver_class == "C"
+
+    def test_template_method_in_class_implicit_this(self):
+        """``get<int>()`` inside a sibling method of a class that
+        declares a template method ``get`` → receiver_class tag
+        fires via the implicit-this rule. Requires the pre-pass
+        to unwrap ``template_declaration`` so ``get`` registers as
+        a method on the class."""
+        g = extract_call_graph_cpp(
+            "class C {\n"
+            "public:\n"
+            "    template<typename T> T get();\n"
+            "    void use() { get<int>(); }\n"
+            "};\n"
+        )
+        cls = next(c for c in g.classes if c.name == "C")
+        method_names = [m[0] for m in cls.methods]
+        assert "get" in method_names
+        call = next(c for c in g.calls if c.chain == ["get"])
+        assert call.receiver_class == "C"
+
+
+class TestConstructorInitialiserList:
+    """``Derived(int x) : Base(x), member_(0) {}`` — the
+    field_initializer_list entries become call sites with the
+    base/member name as the chain head. Distinguishing base-
+    constructor delegation from data-member initialisation
+    requires symbol-table access we don't have at extract time,
+    so both shapes emit; the resolver's class-context narrowing
+    keeps the noise contained."""
+
+    def test_base_constructor_call_in_init_list(self):
+        """``: Base(x)`` records a call to ``Base`` — load-bearing
+        for SCA queries against subclass-of-known-base sinks."""
+        g = extract_call_graph_cpp(
+            "class Derived : public Base {\n"
+            "public:\n"
+            "    Derived(int x) : Base(x) {}\n"
+            "};\n"
+        )
+        chains = [c.chain for c in g.calls]
+        assert ["Base"] in chains
+
+    def test_member_initialiser_emits_call(self):
+        """``member_(0)`` emits ``chain=["member_"]``. Cost is some
+        noise on data-member inits; benefit is uniform handling
+        of base-constructor delegation."""
+        g = extract_call_graph_cpp(
+            "class C {\n"
+            "public:\n"
+            "    C(int x) : member_(x) {}\n"
+            "private:\n"
+            "    int member_;\n"
+            "};\n"
+        )
+        chains = [c.chain for c in g.calls]
+        assert ["member_"] in chains
+
+    def test_nested_call_inside_init_arg_still_walked(self):
+        """``member_(helper(x))`` should yield both ``member_``
+        and ``helper`` calls — the fall-through walks the
+        argument_list."""
+        g = extract_call_graph_cpp(
+            "class C {\n"
+            "public:\n"
+            "    C(int x) : member_(helper(x)) {}\n"
+            "};\n"
+        )
+        chains = [c.chain for c in g.calls]
+        assert ["member_"] in chains
+        assert ["helper"] in chains
+
+    def test_init_list_caller_is_constructor(self):
+        """Calls inside the init list attribute to the enclosing
+        constructor (the function_definition pushes its name)."""
+        g = extract_call_graph_cpp(
+            "class Derived : public Base {\n"
+            "public:\n"
+            "    Derived(int x) : Base(x) {}\n"
+            "};\n"
+        )
+        call = next(c for c in g.calls if c.chain == ["Base"])
+        assert call.caller == "Derived"
+
+    def test_templated_base_class_captured(self):
+        """``class D : public B<T>`` → base ``B`` (template args
+        erased, parity with template_function callee handling)."""
+        g = extract_call_graph_cpp(
+            "template<typename T>\n"
+            "class D : public B<T> {};\n"
+        )
+        d = next(c for c in g.classes if c.name == "D")
+        assert "B" in d.bases
+
+    def test_templated_base_constructor_in_init_list(self):
+        """``Derived() : B<T>()`` — the init list entry uses
+        ``template_method`` instead of ``field_identifier``;
+        recover the inner identifier so the base-constructor
+        call still emits."""
+        g = extract_call_graph_cpp(
+            "template<typename T>\n"
+            "class D : public B<T> {\n"
+            "public:\n"
+            "    D() : B<T>() {}\n"
+            "};\n"
+        )
+        chains = [c.chain for c in g.calls]
+        assert ["B"] in chains
+
+
+# ---------------------------------------------------------------------------
+# Cross-file resolver — fully-qualified-call fast-path
+# ---------------------------------------------------------------------------
+
+
+class TestCrossFileFullyQualifiedCall:
+    """C++ ``ns::Util::helper()`` doesn't go through any import
+    map — namespace names are used directly. The import-map path
+    in function_called can't resolve such chains; the
+    receiver_class fast-path doesn't fire either (the chain isn't
+    a ``this->X()`` or implicit-this shape). The fully-qualified
+    fast-path catches them: strict equality of the joined dotted
+    chain to the target → CALLED with no false-positive risk."""
+
+    def test_cross_file_namespace_class_method(self):
+        """File A defines ``ns::Util::helper()``; file B calls
+        ``ns::Util::helper()`` directly. The resolver matches via
+        the dotted-chain fast-path, NOT via the import map."""
+        from core.inventory.reachability import (
+            Verdict, function_called,
+        )
+
+        util_cg = extract_call_graph_cpp(
+            "namespace ns {\n"
+            "    class Util {\n"
+            "    public:\n"
+            "        static void helper() {}\n"
+            "    };\n"
+            "}\n"
+        ).to_dict()
+        caller_cg = extract_call_graph_cpp(
+            "void use() { ns::Util::helper(); }\n"
+        ).to_dict()
+        inv = {"files": [
+            {"path": "src/util.cpp", "language": "cpp",
+             "call_graph": util_cg,
+             "items": [{"kind": "function", "name": "helper",
+                        "line_start": 4}]},
+            {"path": "src/main.cpp", "language": "cpp",
+             "call_graph": caller_cg,
+             "items": [{"kind": "function", "name": "use",
+                        "line_start": 1}]},
+        ]}
+        r = function_called(inv, "ns.Util.helper")
+        assert r.verdict == Verdict.CALLED
+
+    def test_wrong_class_not_called(self):
+        """Strict equality: target ``ns.Other.helper`` doesn't
+        match chain ``ns::Util::helper`` — must return
+        NOT_CALLED."""
+        from core.inventory.reachability import (
+            Verdict, function_called,
+        )
+
+        caller_cg = extract_call_graph_cpp(
+            "void use() { ns::Util::helper(); }\n"
+        ).to_dict()
+        inv = {"files": [{"path": "src/main.cpp", "language": "cpp",
+                           "call_graph": caller_cg}]}
+        r = function_called(inv, "ns.Other.helper")
+        assert r.verdict == Verdict.NOT_CALLED
+
+    def test_partial_chain_match_not_false_positive(self):
+        """Chain ``["Util", "helper"]`` (no namespace prefix) must
+        NOT match target ``ns.Util.helper``. Strict equality
+        guards against partial-match false positives."""
+        from core.inventory.reachability import (
+            Verdict, function_called,
+        )
+
+        caller_cg = extract_call_graph_cpp(
+            "void use() { Util::helper(); }\n"
+        ).to_dict()
+        inv = {"files": [{"path": "src/main.cpp", "language": "cpp",
+                           "call_graph": caller_cg}]}
+        r = function_called(inv, "ns.Util.helper")
+        assert r.verdict == Verdict.NOT_CALLED
+
+
+# ---------------------------------------------------------------------------
+# Compound-literal receivers + dependent-name disambiguation
+# ---------------------------------------------------------------------------
+
+
+class TestCompoundLiteralReceiver:
+    """``vector<int>{}.size()`` / ``Foo{}.method()`` — the receiver
+    is an unnamed temporary. Recover the type name as the chain
+    head so a target like ``vector.size`` matches; template args
+    are erased (same as template_function callees). Loses
+    namespace prefix (would need symbol-table access)."""
+
+    def test_template_temporary_method_call(self):
+        """``vector<int>{}.size()`` → ``["vector", "size"]``."""
+        g = extract_call_graph_cpp(
+            "void f() { vector<int>{}.size(); }\n"
+        )
+        chains = [c.chain for c in g.calls]
+        assert ["vector", "size"] in chains
+
+    def test_non_template_temporary_method_call(self):
+        """``Foo{}.method()`` → ``["Foo", "method"]``."""
+        g = extract_call_graph_cpp(
+            "void f() { Foo{}.method(); }\n"
+        )
+        chains = [c.chain for c in g.calls]
+        assert ["Foo", "method"] in chains
+
+
+class TestDependentNameDisambiguation:
+    """``c.template put<int>()`` — the ``template`` keyword
+    disambiguates dependent names in template functions. The
+    grammar wraps the call's name in a ``dependent_name`` node
+    containing a ``template_method`` containing the
+    ``field_identifier``. Recover the inner name, drop template
+    args."""
+
+    def test_dependent_template_method_call(self):
+        g = extract_call_graph_cpp(
+            "template<typename T> void f(T& c) {\n"
+            "    c.template put<int>();\n"
+            "}\n"
+        )
+        chains = [c.chain for c in g.calls]
+        assert ["c", "put"] in chains


### PR DESCRIPTION
Extends the C/C++ call_graph walker (#527) to match the multi-lang substrate from #531: namespace → package_name, implicit-this receiver_class tagging, templated callees, constructor initialiser lists, compound-literal temporaries, dependent-name disambiguation. Adds a fully-qualified-call fast-path to function_called so C++ ``ns::Util::helper()`` cross-file dispatch resolves correctly (also benefits Java/C#/PHP fully-qualified calls).

Namespace + implicit-this
- ``namespace ns { ... }`` / ``namespace a::b { ... }`` populate ``package_name``; deepest-wins on nested. Anonymous namespaces leave None.
- The pre-pass that collects method declarations now picks up inline ``function_definition`` nodes too (plus unwraps ``template_declaration``), so a bare ``helper()`` call from a sibling method walked first sees ``helper`` in the methods set and gets receiver_class tagged. The body walk's later append de-dups by ``(name, line)``.

Templated callees + init lists
- ``get<int>()`` (template_function) and ``this->put<double>()`` (template_method inside field_expression) recover the inner identifier; template args erased.
- ``Derived(int x) : Base(x), member_(0) {}`` — each field_initializer emits a CallSite. Base-constructor delegation (load-bearing for SCA against subclass-of-known-base sinks) and member init (noisy but contained — member names aren't in any class's methods list).
- ``B<T>(x)`` templated base in init list and ``: public B<T>`` templated base in class heritage both recover the bare type identifier.

Fully-qualified-call fast-path
- C++ ``ns::Util::helper()`` chains bypass the file's import map entirely. The import-map and receiver_class paths in ``function_called`` both miss them. Added a fast-path: after earlier paths fail, check if ``".".join(chain) == qualified_name`` exactly. No false-positive risk under strict equality.

Compound literals + dependent names
- ``Foo{}.method()`` / ``vector<int>{}.size()`` — operand is ``compound_literal_expression``. Recover the type name as the chain head. Limitation: no namespace prefix.
- ``c.template put<int>()`` — dependent_name disambiguation wrapping template_method. Unwrap both layers.

Tests
- +27 unit tests across namespace, implicit-this, templated callees, init lists, cross-file resolver, compound literals, dependent names. +1 resolver E2E (``ns::Foo::bar()`` invoked via implicit-this).
- 616 inventory tests / 5715 broader-core tests pass.
- E2E on Firefox SpiderMonkey GC: 27 cpp files, 0 parse errors, 121 methods, 11,643 calls (up from 10,969 pre-deferred-items).