### PR TITLE
feat(validation): wire core/ast view into /validate Stage B prep

### DIFF
--- a/libexec/raptor-validation-helper
+++ b/libexec/raptor-validation-helper
@@ -506,6 +506,74 @@ def prepare_B(workdir, target=None):
         if not finding.get("origin"):
             print(f"  WARN: {finding['id']} missing origin field")
 
+    # --- ast_view enrichment ---
+    # Attach a compact per-function AST view (signature, calls
+    # inside body, returns, inline-asm flag) to each active finding
+    # so Stage B's LLM can reason about exploitability with the
+    # function's actual shape, not just the line number. The LLM
+    # reading findings.json sees ``ast_view`` as a per-finding
+    # field; the Stage B skill doesn't need updating to know about
+    # it — the field is self-explanatory.
+    #
+    # Best-effort: parse failure / unsupported language / function
+    # not in inventory all leave the finding's ast_view unset.
+    # Disproven findings are skipped (no need to enrich what's
+    # already ruled out). Pre-existing ast_view fields (e.g.
+    # carried forward from /agentic when /validate consumes its
+    # output) are preserved.
+    #
+    # Target resolution: --target arg wins, else fall back to the
+    # findings container's ``target_path``. If neither is known,
+    # skip enrichment with a notice — best to do nothing than to
+    # fabricate paths.
+    ast_target = target or data.get("target_path")
+    ast_enriched = 0
+    ast_skipped = 0
+    if ast_target:
+        target_root = Path(ast_target).resolve()
+        try:
+            from core.ast import view as _ast_view
+        except ImportError:
+            _ast_view = None
+            print("  Note: core.ast not importable; skipping ast_view enrichment")
+        if _ast_view is not None:
+            for finding in findings:
+                if finding.get("status") == "disproven":
+                    continue
+                if finding.get("ast_view"):
+                    continue  # already set (carried forward)
+                fpath = finding.get("file") or ""
+                fname = finding.get("function") or ""
+                fline = finding.get("line") or 0
+                if not (fpath and fname and isinstance(fline, int) and fline > 0):
+                    ast_skipped += 1
+                    continue
+                abs_path = (target_root / fpath).resolve()
+                try:
+                    abs_path.relative_to(target_root)
+                except ValueError:
+                    # Path escapes target_root (file with traversal /
+                    # absolute path). Skip — never enrich something
+                    # outside the project.
+                    ast_skipped += 1
+                    continue
+                if not abs_path.is_file():
+                    ast_skipped += 1
+                    continue
+                try:
+                    fv = _ast_view(abs_path, fname, at_line=fline)
+                    if fv is not None:
+                        finding["ast_view"] = fv.to_dict()
+                        ast_enriched += 1
+                    else:
+                        ast_skipped += 1
+                except Exception:                          # noqa: BLE001
+                    ast_skipped += 1
+        if ast_enriched or ast_skipped:
+            print(f"  ast_view: enriched {ast_enriched}, skipped {ast_skipped}")
+    else:
+        print("  Note: no target_path known; skipping ast_view enrichment")
+
     _save_findings(workdir, data)
 
     # --- Schema validation ---

--- a/packages/exploitability_validation/tests/test_prepare_validation.py
+++ b/packages/exploitability_validation/tests/test_prepare_validation.py
@@ -418,5 +418,168 @@ class TestNullDerefVerdict(unittest.TestCase):
         self.assertNotEqual(result[0].verdict, "unknown")
 
 
+# ---------------------------------------------------------------------------
+# prepare_B: ast_view enrichment (PR5)
+# ---------------------------------------------------------------------------
+
+
+class PrepareBAstViewTests(unittest.TestCase):
+    """Pin the per-finding ast_view enrichment added to ``prepare_B``.
+
+    The enrichment block runs over each non-disproven finding,
+    resolves ``(target_root/finding.file, finding.function,
+    finding.line)`` via ``core.ast.view``, and attaches
+    ``finding["ast_view"]`` to the finding dict.
+
+    Pre-existing ast_view values (e.g. carried forward from a
+    different consumer's enrichment) are preserved. Disproven
+    findings and findings without a target_path are skipped.
+    """
+
+    def _setup_target(self, tmp_root: Path) -> Path:
+        """Build a tiny Python target with a known function shape."""
+        target = tmp_root / "target"
+        target.mkdir()
+        (target / "src").mkdir()
+        (target / "src" / "auth.py").write_text(
+            "def check_password(user, pw):\n"   # 1
+            "    if user is None:\n"             # 2
+            "        return -1\n"                # 3
+            "    h = compute_hash(pw)\n"         # 4
+            "    return h == user.pw_hash\n"     # 5
+        )
+        return target
+
+    def _stage_a_findings(self, target_path: str, status="not_disproven"):
+        """Build a Stage-A-shape findings.json container."""
+        return {
+            "stage": "A",
+            "target_path": target_path,
+            "findings": [{
+                "id": "FIND-0001",
+                "file": "src/auth.py",
+                "function": "check_password",
+                "line": 4,
+                "vuln_type": "buffer_overflow",
+                "status": status,
+                "confidence": "high",
+                "origin": "claude_native",
+                "stage_a_summary": {"confidence": "high", "status": status},
+            }],
+        }
+
+    def test_active_finding_gets_ast_view(self):
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            target = self._setup_target(d)
+            wd = d / "workdir"
+            wd.mkdir()
+            save_json(wd / "findings.json", self._stage_a_findings(str(target)))
+            _prep.prepare_B(str(wd))
+
+            data = load_json(wd / "findings.json")
+            f = data["findings"][0]
+            self.assertIn("ast_view", f)
+            self.assertEqual(f["ast_view"]["function"], "check_password")
+            self.assertEqual(f["ast_view"]["language"], "python")
+            # Real call captured from the body.
+            chains = [c["chain"] for c in f["ast_view"]["calls_made"]]
+            self.assertIn(["compute_hash"], chains)
+
+    def test_disproven_finding_not_enriched(self):
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            target = self._setup_target(d)
+            wd = d / "workdir"
+            wd.mkdir()
+            save_json(
+                wd / "findings.json",
+                self._stage_a_findings(str(target), status="disproven"),
+            )
+            _prep.prepare_B(str(wd))
+
+            data = load_json(wd / "findings.json")
+            f = data["findings"][0]
+            self.assertNotIn("ast_view", f)
+
+    def test_pre_existing_ast_view_preserved(self):
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            target = self._setup_target(d)
+            wd = d / "workdir"
+            wd.mkdir()
+            data = self._stage_a_findings(str(target))
+            sentinel = {"function": "preset", "schema_version": 999}
+            data["findings"][0]["ast_view"] = sentinel
+            save_json(wd / "findings.json", data)
+            _prep.prepare_B(str(wd))
+
+            after = load_json(wd / "findings.json")
+            self.assertEqual(after["findings"][0]["ast_view"], sentinel)
+
+    def test_function_not_found_skipped(self):
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            target = self._setup_target(d)
+            wd = d / "workdir"
+            wd.mkdir()
+            data = self._stage_a_findings(str(target))
+            data["findings"][0]["function"] = "nonexistent"
+            save_json(wd / "findings.json", data)
+            _prep.prepare_B(str(wd))
+
+            after = load_json(wd / "findings.json")
+            self.assertNotIn("ast_view", after["findings"][0])
+
+    def test_no_target_path_skips_enrichment(self):
+        """If neither --target arg nor findings.target_path is set,
+        the enrichment can't resolve repo-relative paths and skips
+        cleanly rather than crashing."""
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            wd = d / "workdir"
+            wd.mkdir()
+            data = self._stage_a_findings(target_path="")  # blank
+            data["target_path"] = ""
+            save_json(wd / "findings.json", data)
+            _prep.prepare_B(str(wd))
+
+            after = load_json(wd / "findings.json")
+            self.assertNotIn("ast_view", after["findings"][0])
+
+    def test_path_traversal_in_file_field_rejected(self):
+        """A hostile finding whose ``file`` escapes the target_root
+        (e.g. ``../../etc/passwd``) must not be enriched — defence
+        in depth in case a downstream scanner emits a traversal."""
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            target = self._setup_target(d)
+            wd = d / "workdir"
+            wd.mkdir()
+            data = self._stage_a_findings(str(target))
+            data["findings"][0]["file"] = "../../etc/passwd"
+            save_json(wd / "findings.json", data)
+            _prep.prepare_B(str(wd))
+
+            after = load_json(wd / "findings.json")
+            self.assertNotIn("ast_view", after["findings"][0])
+
+    def test_target_arg_takes_precedence_over_findings_target_path(self):
+        """When both --target and findings.target_path are set,
+        the explicit --target wins (matches the precedence
+        elsewhere in validation-helper)."""
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            target = self._setup_target(d)
+            wd = d / "workdir"
+            wd.mkdir()
+            data = self._stage_a_findings(target_path="/bogus/path")
+            save_json(wd / "findings.json", data)
+            _prep.prepare_B(str(wd), target=str(target))
+
+            after = load_json(wd / "findings.json")
+            self.assertIn("ast_view", after["findings"][0])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fifth consumer for `core.ast.view` after the libexec CLI shim (#527), `/understand --map` (#528), `/agentic` analysis-family (#533), and `/exploit` + `/patch` prompts (#534). Stage B's `findings.json` now carries an `ast_view` field per active finding (signature, calls inside body, returns, inline-asm flag) so the LLM building hypotheses + attack paths can reason about the function's actual shape rather than just the line number.

What lands:

  * `libexec/raptor-validation-helper:prepare_B` — adds an ast_view enrichment block after carry-forward checks and before `_save_findings`. Each non-disproven finding gets `finding["ast_view"]` populated via `core.ast.view`. Best- effort: parse failure / unsupported language / function not in inventory / file missing on disk all leave the finding's ast_view unset and Stage B proceeds normally.
    - Target resolution: `--target` arg wins, else fall back to the findings container's `target_path` field, else skip enrichment with a notice (better than fabricating paths).
    - Path-traversal defence: `Path.resolve()` + `Path.relative_to()` reject any finding whose `file` escapes the target_root. Stage A findings shouldn't carry traversal paths, but defence in depth is cheap.
    - Pre-existing ast_view preserved (e.g. when /validate consumes /agentic output that already enriched it).
    - Disproven findings skipped — no need to enrich what's already ruled out.

  * Tests: 7 new in a new `PrepareBAstViewTests` class — happy path, disproven-skip, pre-existing preserved, function-not-found, no-target-path, path-traversal, --target precedence.