### PR TITLE
fix(core/inventory): callers_of / callees_of fully-qualified-call parity

### DIFF
--- a/core/inventory/_reach_cache.py
+++ b/core/inventory/_reach_cache.py
@@ -66,7 +66,14 @@ logger = logging.getLogger(__name__)
 # class-qualified queries that the new build would have resolved
 # to ``CALLED``/``NOT_CALLED`` — a real correctness regression on
 # stale caches, so this is a bump-worthy change.
-_CACHE_VERSION = 4
+#
+# V5 (2026-05-17): index pass-2 fully-qualified-call fast-path
+# promotes C++ ``ns::Util::helper()`` chains (and any other
+# language's fully-qualified shape) from method_match_overinclusive
+# to definitive forward/reverse edges. An old V4 cache would have
+# returned these callers in ``method_match_overinclusive`` instead
+# of ``definitive`` — same correctness shift, bump for parity.
+_CACHE_VERSION = 5
 
 _CACHE_DIR = Path.home() / ".cache" / "raptor" / "reachability"
 
@@ -75,7 +82,7 @@ _CACHE_DIR = Path.home() / ".cache" / "raptor" / "reachability"
 # the same name. Also doubles as a cheap "is this a raptor cache
 # file" check before handing bytes to ``pickle.load``. The numeric
 # suffix tracks ``_CACHE_VERSION``.
-_HEADER_MAGIC = b"RAPTOR-REACHABILITY-CACHE-V4\n"
+_HEADER_MAGIC = b"RAPTOR-REACHABILITY-CACHE-V5\n"
 
 
 def compute_fingerprint(inventory: Dict[str, Any]) -> Optional[str]:

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -938,6 +938,26 @@ def _get_or_build_index(
                 _record_call_line(idx, caller_node, callee, line)
                 continue
 
+            # Fully-qualified-call index path: when the chain itself
+            # spells out a project-defined function's qualified name
+            # (e.g. C++ ``ns::Util::helper()`` → chain ``["ns",
+            # "Util", "helper"]``), the import-map path can't see it
+            # because namespace names aren't in the imports dict.
+            # If the dotted-join matches a seeded
+            # ``qualified_to_internal`` entry, record a definitive
+            # internal edge — parity with the function_called
+            # fast-path. Strict equality keeps the rule
+            # over-conservative: chains that don't literally spell
+            # a known qualified name fall through to method_match.
+            if len(chain) >= 2:
+                dotted = ".".join(chain)
+                aliased = qualified_to_internal.get(dotted)
+                if aliased is not None:
+                    idx.forward.setdefault(caller_node, set()).add(aliased)
+                    idx.reverse.setdefault(aliased, set()).add(caller_node)
+                    _record_call_line(idx, caller_node, aliased, line)
+                    continue
+
             # Couldn't resolve via import map. Two sub-cases:
             #   (a) chain head is unbound — likely a method call
             #       (``self.foo()`` / ``obj.foo()``). Tail name is

--- a/core/inventory/tests/test_call_graph_cpp.py
+++ b/core/inventory/tests/test_call_graph_cpp.py
@@ -702,3 +702,133 @@ class TestDependentNameDisambiguation:
         )
         chains = [c.chain for c in g.calls]
         assert ["c", "put"] in chains
+
+
+# ---------------------------------------------------------------------------
+# callers_of / callees_of index-side fast-path
+# ---------------------------------------------------------------------------
+
+
+class TestCallersCalleesIndexParity:
+    """Index-side equivalent of the function_called
+    fully-qualified-call fast-path: C++ ``ns::Util::helper()`` chains
+    land in the definitive forward/reverse graph (not just
+    method_match_overinclusive) when the dotted chain matches a
+    seeded ``qualified_to_internal`` entry. Without this, callers_of
+    returned the C++ caller in method_match instead of definitive."""
+
+    def test_callers_of_namespace_class_method_definitive(self):
+        from core.inventory.reachability import (
+            callers_of, InternalFunction,
+        )
+
+        util = extract_call_graph_cpp(
+            "namespace ns {\n"
+            "    class Util {\n"
+            "    public:\n"
+            "        static void helper() {}\n"
+            "    };\n"
+            "}\n"
+        ).to_dict()
+        caller = extract_call_graph_cpp(
+            "void use() { ns::Util::helper(); }\n"
+        ).to_dict()
+        inv = {"files": [
+            {"path": "src/util.cpp", "language": "cpp",
+             "call_graph": util,
+             "items": [{"kind": "function", "name": "helper",
+                        "line_start": 4}]},
+            {"path": "src/main.cpp", "language": "cpp",
+             "call_graph": caller,
+             "items": [{"kind": "function", "name": "use",
+                        "line_start": 1}]},
+        ]}
+        target = InternalFunction(
+            file_path="src/util.cpp", name="helper", line=4,
+        )
+        r = callers_of(inv, target, exclude_test_files=False)
+        # Caller must be in definitive, not method_match.
+        assert any(
+            c.file_path == "src/main.cpp" for c in r.definitive
+        ), (
+            f"caller not in definitive — "
+            f"definitive={r.definitive}, "
+            f"method_match={r.method_match_overinclusive}"
+        )
+
+    def test_callees_of_namespace_class_method_definitive(self):
+        """Symmetric: callees_of(use) lists ns::Util::helper as
+        a definitive callee."""
+        from core.inventory.reachability import (
+            callees_of, InternalFunction,
+        )
+
+        util = extract_call_graph_cpp(
+            "namespace ns {\n"
+            "    class Util {\n"
+            "    public:\n"
+            "        static void helper() {}\n"
+            "    };\n"
+            "}\n"
+        ).to_dict()
+        caller = extract_call_graph_cpp(
+            "void use() { ns::Util::helper(); }\n"
+        ).to_dict()
+        inv = {"files": [
+            {"path": "src/util.cpp", "language": "cpp",
+             "call_graph": util,
+             "items": [{"kind": "function", "name": "helper",
+                        "line_start": 4}]},
+            {"path": "src/main.cpp", "language": "cpp",
+             "call_graph": caller,
+             "items": [{"kind": "function", "name": "use",
+                        "line_start": 1}]},
+        ]}
+        source = InternalFunction(
+            file_path="src/main.cpp", name="use", line=1,
+        )
+        r = callees_of(inv, source, exclude_test_files=False)
+        assert any(
+            getattr(c, "file_path", None) == "src/util.cpp"
+            for c in r.definitive
+        )
+
+    def test_partial_chain_stays_in_method_match(self):
+        """Chain ``["Util", "helper"]`` (no namespace prefix) does
+        NOT match the seeded ``ns.Util.helper`` qualified name —
+        falls through to method_match_overinclusive. Strict
+        equality guards against over-promoting partial matches."""
+        from core.inventory.reachability import (
+            callers_of, InternalFunction,
+        )
+
+        util = extract_call_graph_cpp(
+            "namespace ns {\n"
+            "    class Util {\n"
+            "    public:\n"
+            "        static void helper() {}\n"
+            "    };\n"
+            "}\n"
+        ).to_dict()
+        caller = extract_call_graph_cpp(
+            "void use() { Util::helper(); }\n"
+        ).to_dict()
+        inv = {"files": [
+            {"path": "src/util.cpp", "language": "cpp",
+             "call_graph": util,
+             "items": [{"kind": "function", "name": "helper",
+                        "line_start": 4}]},
+            {"path": "src/main.cpp", "language": "cpp",
+             "call_graph": caller,
+             "items": [{"kind": "function", "name": "use",
+                        "line_start": 1}]},
+        ]}
+        target = InternalFunction(
+            file_path="src/util.cpp", name="helper", line=4,
+        )
+        r = callers_of(inv, target, exclude_test_files=False)
+        # Partial chain stays in method_match (over-inclusive),
+        # NOT promoted to definitive.
+        assert not any(
+            c.file_path == "src/main.cpp" for c in r.definitive
+        )

--- a/core/inventory/tests/test_reachability_adjacency.py
+++ b/core/inventory/tests/test_reachability_adjacency.py
@@ -1177,6 +1177,8 @@ class TestFullyQualifiedCallIndexFastPath:
     caller's chain literally spells the target's qualified name."""
 
     def test_java_fully_qualified(self):
+        import pytest
+        pytest.importorskip("tree_sitter_java")
         from core.inventory.call_graph import extract_call_graph_java
 
         util = extract_call_graph_java(
@@ -1215,6 +1217,8 @@ class TestFullyQualifiedCallIndexFastPath:
         )
 
     def test_php_global_qualified(self):
+        import pytest
+        pytest.importorskip("tree_sitter_php")
         from core.inventory.call_graph import extract_call_graph_php
 
         util = extract_call_graph_php(
@@ -1243,6 +1247,8 @@ class TestFullyQualifiedCallIndexFastPath:
         )
 
     def test_csharp_fully_qualified(self):
+        import pytest
+        pytest.importorskip("tree_sitter_c_sharp")
         from core.inventory.call_graph import extract_call_graph_csharp
 
         util = extract_call_graph_csharp(
@@ -1276,6 +1282,8 @@ class TestFullyQualifiedCallIndexFastPath:
     def test_call_lines_recorded_for_fast_path(self):
         """The fast-path edge construction calls _record_call_line,
         so ``call_lines_of(caller, target)`` returns the right line."""
+        import pytest
+        pytest.importorskip("tree_sitter_java")
         from core.inventory.call_graph import extract_call_graph_java
 
         util = extract_call_graph_java(

--- a/core/inventory/tests/test_reachability_adjacency.py
+++ b/core/inventory/tests/test_reachability_adjacency.py
@@ -1152,3 +1152,154 @@ def test_decorator_call_not_attributed_to_decorated_fn():
     # Must NOT be attributed to ``list_users`` (which would falsely
     # imply ``list_users`` calls ``app.route``).
     assert deco_call.caller is None
+
+
+# ---------------------------------------------------------------------------
+# Fully-qualified-call index fast-path (cross-language)
+# ---------------------------------------------------------------------------
+#
+# When a caller writes the callee's qualified name directly in source
+# (e.g. C++ ``ns::Util::helper()``, Java ``com.example.Util.helper()``,
+# PHP ``\Foo\Bar::method()``, C# ``Foo.Bar.Method()``), the chain head
+# isn't in the file's import map — the dotted prefix is part of the
+# call syntax, not a separately-imported name. The pass-2 edge
+# construction now does a direct ``".".join(chain)`` lookup in
+# ``qualified_to_internal`` after the import-map path fails. Strict
+# equality keeps the rule over-conservative.
+#
+# These tests verify the fast-path is language-agnostic — same shape,
+# same outcome for each target language.
+
+
+class TestFullyQualifiedCallIndexFastPath:
+    """``callers_of(target)`` should return the caller in
+    ``definitive`` (not ``method_match_overinclusive``) when the
+    caller's chain literally spells the target's qualified name."""
+
+    def test_java_fully_qualified(self):
+        from core.inventory.call_graph import extract_call_graph_java
+
+        util = extract_call_graph_java(
+            "package com.example;\n"
+            "public class Util {\n"
+            "    public static void helper() {}\n"
+            "}\n"
+        ).to_dict()
+        # Fully-qualified call WITHOUT an import (rare but legal Java).
+        caller = extract_call_graph_java(
+            "package com.example.client;\n"
+            "class Client { void m() { com.example.Util.helper(); } }\n"
+        ).to_dict()
+        inv = {"files": [
+            {"path": "src/com/example/Util.java", "language": "java",
+             "call_graph": util,
+             "items": [{"kind": "function", "name": "helper",
+                        "line_start": 3}]},
+            {"path": "src/com/example/client/Client.java",
+             "language": "java", "call_graph": caller,
+             "items": [{"kind": "function", "name": "m",
+                        "line_start": 2}]},
+        ]}
+        target = InternalFunction(
+            file_path="src/com/example/Util.java",
+            name="helper", line=3,
+        )
+        r = callers_of(inv, target, exclude_test_files=False)
+        assert any(
+            c.file_path == "src/com/example/client/Client.java"
+            for c in r.definitive
+        ), (
+            f"Java fully-qualified caller not in definitive — "
+            f"definitive={r.definitive}, "
+            f"method_match={r.method_match_overinclusive}"
+        )
+
+    def test_php_global_qualified(self):
+        from core.inventory.call_graph import extract_call_graph_php
+
+        util = extract_call_graph_php(
+            "<?php\nnamespace Foo;\n"
+            "class Bar { public static function method() {} }\n"
+        ).to_dict()
+        caller = extract_call_graph_php(
+            "<?php\nfunction use_it() { \\Foo\\Bar::method(); }\n"
+        ).to_dict()
+        inv = {"files": [
+            {"path": "src/Bar.php", "language": "php",
+             "call_graph": util,
+             "items": [{"kind": "function", "name": "method",
+                        "line_start": 3}]},
+            {"path": "src/main.php", "language": "php",
+             "call_graph": caller,
+             "items": [{"kind": "function", "name": "use_it",
+                        "line_start": 2}]},
+        ]}
+        target = InternalFunction(
+            file_path="src/Bar.php", name="method", line=3,
+        )
+        r = callers_of(inv, target, exclude_test_files=False)
+        assert any(
+            c.file_path == "src/main.php" for c in r.definitive
+        )
+
+    def test_csharp_fully_qualified(self):
+        from core.inventory.call_graph import extract_call_graph_csharp
+
+        util = extract_call_graph_csharp(
+            "namespace Foo {\n"
+            "    class Bar {\n"
+            "        public static void Method() {}\n"
+            "    }\n"
+            "}\n"
+        ).to_dict()
+        caller = extract_call_graph_csharp(
+            "class Client { void M() { Foo.Bar.Method(); } }\n"
+        ).to_dict()
+        inv = {"files": [
+            {"path": "src/Bar.cs", "language": "csharp",
+             "call_graph": util,
+             "items": [{"kind": "function", "name": "Method",
+                        "line_start": 3}]},
+            {"path": "src/Client.cs", "language": "csharp",
+             "call_graph": caller,
+             "items": [{"kind": "function", "name": "M",
+                        "line_start": 1}]},
+        ]}
+        target = InternalFunction(
+            file_path="src/Bar.cs", name="Method", line=3,
+        )
+        r = callers_of(inv, target, exclude_test_files=False)
+        assert any(
+            c.file_path == "src/Client.cs" for c in r.definitive
+        )
+
+    def test_call_lines_recorded_for_fast_path(self):
+        """The fast-path edge construction calls _record_call_line,
+        so ``call_lines_of(caller, target)`` returns the right line."""
+        from core.inventory.call_graph import extract_call_graph_java
+
+        util = extract_call_graph_java(
+            "package com.ex;\nclass Util { static void helper() {} }\n"
+        ).to_dict()
+        caller = extract_call_graph_java(
+            "class Client { void m() { com.ex.Util.helper(); } }\n"
+        ).to_dict()
+        inv = {"files": [
+            {"path": "src/Util.java", "language": "java",
+             "call_graph": util,
+             "items": [{"kind": "function", "name": "helper",
+                        "line_start": 2}]},
+            {"path": "src/Client.java", "language": "java",
+             "call_graph": caller,
+             "items": [{"kind": "function", "name": "m",
+                        "line_start": 1}]},
+        ]}
+        target = InternalFunction(
+            file_path="src/Util.java", name="helper", line=2,
+        )
+        caller_fn = InternalFunction(
+            file_path="src/Client.java", name="m", line=1,
+        )
+        lines = call_lines_of(inv, caller_fn, target)
+        # The call ``com.ex.Util.helper()`` is on line 1 of Client.java.
+        assert lines == (1,)


### PR DESCRIPTION
The function_called fully-qualified-call fast-path (PR #535) gave C++ ``ns::Util::helper()`` cross-file dispatch a direct CALLED verdict. The index-side queries — callers_of / callees_of — had no equivalent path: such chains landed in
method_match_overinclusive instead of the definitive forward/reverse graph because ``_resolve_callee_chain`` requires the chain head in the file's import map (which C++ namespace names, Java fully-qualified prefixes, PHP ``\Foo\Bar`` etc. aren't part of).

Audit finding: class-aware narrowing (``class_of_method`` + ``_method_match_compatible``) is wired into callers_of from PR #523 — that part has no gap. The gap is one level earlier: the chains that SHOULD become definitive edges are getting demoted to method_match because the import-map path can't resolve them.

Fix: pass-2 edge construction now does a direct ``".".join(chain)`` lookup in ``qualified_to_internal`` after the import-map path returns None. If the dotted form matches a seeded qualified name, record a definitive internal edge (and a call_line). Strict equality keeps the rule over-conservative — chains that don't literally spell a known qualified name still fall through to method_match.

Universal benefit
- C++ ``ns::Util::helper()``
- Java ``com.example.Util.helper()`` (fully-qualified, no import)
- PHP ``\Foo\Bar::method()`` (global-qualified)
- C# ``Foo.Bar.Method()`` (fully-qualified) All now land in ``callers_of(...).definitive`` instead of ``method_match_overinclusive``. Same shift in
``callees_of(source).definitive``. Consumers (codeql, /agentic, /validate, SCA reachability) that treat method_match as soft signal now get definitive evidence.

Cache version bump V4 → V5: a stale V4 cache returned these callers in ``method_match_overinclusive`` — same correctness shift as V3→V4, bump for parity.

Tests
- +3 C++ tests in test_call_graph_cpp.py (definitive callers, symmetric definitive callees, partial chain stays in method_match — strict-equality guard).
- +4 cross-language tests in test_reachability_adjacency.py (Java fully-qualified, PHP global-qualified, C# fully-qualified, call_lines_of records the line for the fast-path edge).
- 623 inventory tests pass.