### PR TITLE
feat(orchestration): wire core/ast view into /understand --trace

### DIFF
--- a/.claude/skills/code-understanding/trace.md
+++ b/.claude/skills/code-understanding/trace.md
@@ -179,6 +179,25 @@ OUTPUT: `$WORKDIR/flow-trace-<entry-id>.json` (one file per traced flow)
 
 Display the flow to the user as a narrative walkthrough after writing, not just the JSON. Show each step as: `[step N] file:line — what happens — what attacker controls`.
 
+**[TRACE-OUT] Enrich steps with per-function AST views**
+
+After writing all `flow-trace-*.json` files, run the AST-view enricher.
+Uses the inventory to attach an `ast_view` field to each step whose
+`definition` resolves to a function in the inventory: signature,
+calls inside the body, explicit returns, inline-asm flag.
+
+```bash
+libexec/raptor-enrich-flow-trace-ast-view "$WORKDIR"
+```
+
+The enriched flow-trace-*.json files carry machine-derived
+structure (what the function *is* at each hop) alongside the LLM's
+narrative (what the data does as it flows through). Downstream
+consumers — `/validate` Stage B via the understand-bridge, `/audit`
+Phase A — can read this without re-parsing source. Idempotent.
+Skip if `$WORKDIR/checklist.json` doesn't exist or doesn't carry
+`target_path`.
+
 ## Gates
 
 GATES APPLY: U1 [READ-FIRST], U2 [ATTACKER-LENS], U3 [FULL-FLOW], U5 [EVIDENCE-ONLY]

--- a/core/orchestration/flow_trace_ast_view.py
+++ b/core/orchestration/flow_trace_ast_view.py
@@ -1,0 +1,209 @@
+"""Structured AST-view enrichment for /understand --trace.
+
+After ``/understand --trace`` produces ``flow-trace-<id>.json``
+files (step-by-step source→sink walks), this module attaches a
+per-step ``ast_view`` block to each step whose ``definition``
+field resolves to a function in the inventory. The LLM following
+the trace — or consuming the trace via the understand-bridge
+into /validate Stage B — gets the host function's compact shape
+(signature, calls inside body, returns, inline-asm flag) at
+every hop.
+
+This is a sibling of ``context_map_ast_view`` (PR2 for
+``/understand --map`` entry points and sinks). The two cover
+the two output products of ``/understand`` that anchor
+downstream reasoning: the static attack-surface map and the
+dynamic data-flow traces.
+
+## Output shape
+
+Each step in ``trace["steps"]`` gains an ``ast_view`` field
+containing :func:`core.ast.view`'s ``FunctionView.to_dict()``
+output for the enclosing function at the step's ``definition``
+file:line:
+
+    {
+      "step": 2,
+      "type": "call",
+      "call_site": "src/routes/query.py:48",
+      "definition": "src/services/query_service.py:12",
+      "description": "...",
+      ...,
+      "ast_view": {
+        "function": "run",
+        "language": "python",
+        "lines": [12, 35],
+        "signature": "run(query_str: str) -> ResultSet",
+        "calls_made": [
+          {"line": 31, "chain": ["psycopg2", "cursor", "execute"], ...}
+        ],
+        "returns": [{"line": 34, "value_text": "result"}],
+        "has_inline_asm": false,
+        "schema_version": 1
+      }
+    }
+
+The ``ast_view`` field is absent (rather than null) when:
+
+  * The step has no ``definition`` field or it doesn't parse as
+    ``file:line``.
+  * The definition's file path escapes ``target_root`` (defence
+    in depth — trace files are LLM output and may carry injected
+    entries; same path-containment check as the map enricher).
+  * The file isn't in the inventory (e.g. external dep — typical
+    for sink steps where ``definition`` points at a library
+    function like ``psycopg2.cursor.execute()``).
+  * ``core.ast.view`` returns None (parse failure / unsupported
+    language).
+
+The ``call_site`` field is NOT enriched in this revision. The
+caller's function shape is interesting in principle but doubles
+the per-step token cost; ``definition`` enrichment alone gives
+the LLM the function being stepped *into*, which is the new
+context at each hop. Follow-up if measurement shows the LLM
+needs caller-side shape too.
+
+Idempotent — re-running overwrites prior enrichment with fresh
+data, except a pre-existing ``ast_view`` is preserved
+(consistent with the map enricher and the agent enrichment).
+Best-effort: any individual step's failure leaves that step
+unchanged but doesn't abort the run.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# ``file:line`` with file optionally containing slashes/dots and line
+# being a non-zero positive integer. Anchored — partial matches don't
+# count (a malformed string like ``foo:bar:42`` should fail to parse
+# rather than capturing some sub-fragment).
+_DEFINITION_RE = re.compile(r"^(.+):(\d+)$")
+
+
+def enrich_with_ast_view(
+    trace: Dict[str, Any],
+    target_path: Path,
+    *,
+    inventory: Optional[Dict[str, Any]] = None,
+) -> int:
+    """Walk ``trace["steps"]`` and attach an ``ast_view`` field to
+    each step whose ``definition`` resolves to an in-inventory
+    function.
+
+    ``inventory`` may be provided by the caller (avoids a redundant
+    inventory build when a sibling consumer already constructed
+    one). When omitted, builds one over ``target_path``.
+
+    Returns the count of steps enriched. Idempotent — re-running
+    overwrites prior enrichment with fresh data.
+    """
+    if not isinstance(trace, dict):
+        return 0
+    steps = trace.get("steps")
+    if not isinstance(steps, list) or not steps:
+        return 0
+
+    if inventory is None:
+        try:
+            from core.inventory.builder import build_inventory
+            import tempfile
+            with tempfile.TemporaryDirectory() as td:
+                inventory = build_inventory(str(target_path), td)
+        except Exception as e:                              # noqa: BLE001
+            logger.debug(
+                "flow_trace_ast_view: inventory build failed (%s); "
+                "skipping enrichment", e,
+            )
+            return 0
+
+    try:
+        from core.ast import view
+        from core.inventory.reachability import enclosing_function
+    except ImportError:
+        return 0
+
+    target_root = Path(target_path).resolve()
+    enriched = 0
+
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        if step.get("ast_view"):
+            continue  # already set (e.g. carried forward)
+
+        definition = step.get("definition")
+        if not isinstance(definition, str) or not definition:
+            continue
+
+        parsed = _parse_definition(definition)
+        if parsed is None:
+            continue
+        file_path, line = parsed
+
+        host = enclosing_function(inventory, file_path, line)
+        if host is None:
+            # External function (typical for sink steps) or path
+            # not in inventory. Skip — don't fabricate.
+            continue
+
+        abs_path = (target_root / file_path).resolve()
+        # Defence: trace files are LLM output; reject paths that
+        # escape target_root (absolute or traversal).
+        try:
+            abs_path.relative_to(target_root)
+        except ValueError:
+            logger.debug(
+                "flow_trace_ast_view: skipping step whose definition "
+                "%r escapes target_root %s", file_path, target_root,
+            )
+            continue
+        if not abs_path.is_file():
+            continue
+
+        try:
+            fv = view(abs_path, host.name, at_line=line)
+        except Exception:                                   # noqa: BLE001
+            continue
+        if fv is None:
+            continue
+
+        step["ast_view"] = fv.to_dict()
+        enriched += 1
+
+    if enriched:
+        logger.info(
+            "flow_trace_ast_view: enriched %d step(s) with ast_view",
+            enriched,
+        )
+    return enriched
+
+
+def _parse_definition(definition: str) -> Optional[Tuple[str, int]]:
+    """Parse a step's ``definition`` field into ``(file_path, line)``.
+
+    Returns None for unparseable input — module-level entries (no
+    line), external references (no file:line), or malformed strings.
+    The line must be a positive integer; zero is rejected because
+    ``core.inventory.reachability.enclosing_function`` requires
+    ``line >= 1``.
+    """
+    m = _DEFINITION_RE.match(definition.strip())
+    if m is None:
+        return None
+    try:
+        line = int(m.group(2))
+    except ValueError:
+        return None
+    if line < 1:
+        return None
+    return m.group(1), line
+
+
+__all__ = ["enrich_with_ast_view"]

--- a/core/orchestration/tests/test_flow_trace_ast_view.py
+++ b/core/orchestration/tests/test_flow_trace_ast_view.py
@@ -1,0 +1,257 @@
+"""Tests for ``core.orchestration.flow_trace_ast_view`` — per-step
+AST-view enrichment for /understand --trace's flow-trace-*.json
+output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.orchestration.flow_trace_ast_view import (
+    _parse_definition,
+    enrich_with_ast_view,
+)
+
+
+def _project(tmp_path: Path, files: dict) -> Path:
+    for rel, contents in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(contents)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# _parse_definition — the only non-trivial pure helper
+# ---------------------------------------------------------------------------
+
+
+class TestParseDefinition:
+    def test_valid_file_and_line(self):
+        assert _parse_definition("src/x.py:42") == ("src/x.py", 42)
+
+    def test_nested_path(self):
+        assert _parse_definition("a/b/c.py:1") == ("a/b/c.py", 1)
+
+    def test_line_zero_rejected(self):
+        # enclosing_function requires line >= 1.
+        assert _parse_definition("x.py:0") is None
+
+    def test_negative_line_rejected(self):
+        assert _parse_definition("x.py:-5") is None
+
+    def test_external_reference_rejected(self):
+        # ``psycopg2.cursor.execute()`` — no :line.
+        assert _parse_definition("psycopg2.cursor.execute()") is None
+
+    def test_empty_string(self):
+        assert _parse_definition("") is None
+
+    def test_whitespace_stripped(self):
+        assert _parse_definition("  src/x.py:42  ") == ("src/x.py", 42)
+
+    def test_non_numeric_line_rejected(self):
+        assert _parse_definition("x.py:abc") is None
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_steps_with_definitions(tmp_path):
+    target = _project(tmp_path, {
+        "src/auth.py": (
+            "def check(user, pw):\n"           # 1
+            "    if user is None:\n"            # 2
+            "        return -1\n"               # 3
+            "    h = compute(pw)\n"             # 4
+            "    return 0\n"                    # 5
+        ),
+    })
+    trace = {
+        "id": "TRACE-001",
+        "steps": [
+            {"step": 1, "type": "entry", "call_site": None,
+             "definition": "src/auth.py:1"},
+            {"step": 2, "type": "call", "call_site": "src/auth.py:4",
+             "definition": "src/auth.py:1"},
+        ],
+    }
+    n = enrich_with_ast_view(trace, target)
+    assert n == 2
+    for s in trace["steps"]:
+        assert "ast_view" in s
+        assert s["ast_view"]["function"] == "check"
+        assert s["ast_view"]["language"] == "python"
+
+
+# ---------------------------------------------------------------------------
+# External / sink steps that don't resolve
+# ---------------------------------------------------------------------------
+
+
+def test_external_definition_skipped(tmp_path):
+    """Sink steps often point at external deps
+    (``psycopg2.cursor.execute()``) — those don't parse as
+    ``file:line``, so the step is left unenriched."""
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    trace = {
+        "steps": [
+            {"step": 1, "type": "sink", "call_site": "src/x.py:1",
+             "definition": "psycopg2.cursor.execute()"},
+        ],
+    }
+    n = enrich_with_ast_view(trace, target)
+    assert n == 0
+    assert "ast_view" not in trace["steps"][0]
+
+
+def test_in_tree_definition_not_in_inventory(tmp_path):
+    """A definition that parses but whose function isn't in the
+    inventory (e.g. stale trace or moved code) gets skipped."""
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    trace = {
+        "steps": [
+            {"step": 1, "type": "call", "call_site": "src/x.py:1",
+             "definition": "src/x.py:999"},  # line outside any function
+        ],
+    }
+    n = enrich_with_ast_view(trace, target)
+    assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# Defence in depth: path traversal in definition
+# ---------------------------------------------------------------------------
+
+
+def test_path_traversal_in_definition_rejected(tmp_path):
+    """LLM-emitted traces may carry injected entries with file paths
+    that escape target_root. Reject those — never enrich a file
+    outside the project."""
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    trace = {
+        "steps": [
+            {"step": 1, "type": "call", "call_site": "src/x.py:1",
+             "definition": "../../../etc/passwd:1"},
+        ],
+    }
+    n = enrich_with_ast_view(trace, target)
+    assert n == 0
+    assert "ast_view" not in trace["steps"][0]
+
+
+def test_absolute_path_in_definition_rejected(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    trace = {
+        "steps": [
+            {"step": 1, "type": "call", "call_site": "src/x.py:1",
+             "definition": "/etc/passwd:1"},
+        ],
+    }
+    n = enrich_with_ast_view(trace, target)
+    assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# Idempotency + overwrite policy
+# ---------------------------------------------------------------------------
+
+
+def test_existing_ast_view_preserved(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    pre_existing = {"function": "preset", "schema_version": 999}
+    trace = {
+        "steps": [
+            {"step": 1, "definition": "src/x.py:1",
+             "ast_view": pre_existing},
+        ],
+    }
+    enrich_with_ast_view(trace, target)
+    assert trace["steps"][0]["ast_view"] is pre_existing
+
+
+def test_idempotent_re_run(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    trace = {
+        "steps": [{"step": 1, "definition": "src/x.py:1"}],
+    }
+    enrich_with_ast_view(trace, target)
+    first = trace["steps"][0]["ast_view"]
+    enrich_with_ast_view(trace, target)
+    assert trace["steps"][0]["ast_view"] is first
+
+
+# ---------------------------------------------------------------------------
+# Trace shape edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_steps(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    assert enrich_with_ast_view({"steps": []}, target) == 0
+    assert enrich_with_ast_view({}, target) == 0
+
+
+def test_non_dict_trace(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    assert enrich_with_ast_view([], target) == 0  # type: ignore[arg-type]
+    assert enrich_with_ast_view("not a dict", target) == 0  # type: ignore[arg-type]
+
+
+def test_non_dict_steps_skipped(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    trace = {
+        "steps": [
+            "not a dict",            # type: ignore[list-item]
+            {"step": 2, "definition": "src/x.py:1"},
+            None,                    # type: ignore[list-item]
+            42,                      # type: ignore[list-item]
+        ],
+    }
+    n = enrich_with_ast_view(trace, target)
+    assert n == 1
+    assert "ast_view" in trace["steps"][1]
+
+
+def test_step_without_definition(tmp_path):
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    trace = {
+        "steps": [
+            {"step": 1, "type": "entry"},  # no definition
+        ],
+    }
+    n = enrich_with_ast_view(trace, target)
+    assert n == 0
+
+
+def test_step_with_null_definition(tmp_path):
+    """``definition`` can be explicitly None (e.g. for some entry
+    steps where the LLM hasn't recorded a line). Should skip
+    gracefully."""
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    trace = {
+        "steps": [
+            {"step": 1, "type": "entry", "definition": None},
+        ],
+    }
+    n = enrich_with_ast_view(trace, target)
+    assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# Inventory injection (caller already built one)
+# ---------------------------------------------------------------------------
+
+
+def test_inventory_injection_avoids_rebuild(tmp_path):
+    """The libexec shim builds the inventory once and shares across
+    all trace files. Pin that the injected inventory is used."""
+    target = _project(tmp_path, {"src/x.py": "def f(): return 1\n"})
+    from core.inventory.builder import build_inventory
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        inv = build_inventory(str(target), td)
+        trace = {"steps": [{"step": 1, "definition": "src/x.py:1"}]}
+        n = enrich_with_ast_view(trace, target, inventory=inv)
+        assert n == 1

--- a/libexec/raptor-enrich-flow-trace-ast-view
+++ b/libexec/raptor-enrich-flow-trace-ast-view
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Enrich every flow-trace-*.json file in an /understand run dir with
+per-step structured AST views.
+
+Usage: raptor-enrich-flow-trace-ast-view <understand_dir>
+
+Wraps core.orchestration.flow_trace_ast_view.enrich_with_ast_view
+for invocation from skill markdown. For each ``flow-trace-*.json``
+file in the run directory, walks ``trace["steps"]`` and attaches
+an ``ast_view`` field to each step whose ``definition`` resolves
+to a function in the inventory. Idempotent — safe to re-run.
+
+Best-effort: missing checklist / inventory build failure / a
+single unparseable trace file all log warnings but never abort
+the run (other trace files in the same run continue to enrich).
+"""
+import argparse
+import sys
+from pathlib import Path
+
+# ─── trust-marker check (do not import; inline by design) ───
+import os
+if not (os.environ.get("CLAUDECODE")
+        or os.environ.get("_RAPTOR_TRUSTED")):
+    sys.stderr.write(
+        f"{sys.argv[0]}: internal dispatch script.\n"
+        "  Run via 'bin/raptor' instead.\n"
+        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
+    )
+    sys.exit(2)
+# ─── end trust-marker check ─────────────────────────────────
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.json import load_json, save_json
+from core.orchestration.flow_trace_ast_view import enrich_with_ast_view
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="raptor-enrich-flow-trace-ast-view",
+        description=(
+            "Enrich each flow-trace-*.json's steps with structured "
+            "per-function AST views (signature, calls, returns, "
+            "asm flag) for the function at each step's definition."
+        ),
+    )
+    parser.add_argument("understand_dir", help="path to /understand run dir")
+    args = parser.parse_args()
+
+    understand_dir = Path(args.understand_dir).resolve()
+    if not understand_dir.is_dir():
+        print(
+            f"raptor-enrich-flow-trace-ast-view: {understand_dir} is "
+            "not a directory", file=sys.stderr,
+        )
+        return 1
+
+    checklist = load_json(understand_dir / "checklist.json") or {}
+    target_path = (
+        checklist.get("target_path") if isinstance(checklist, dict) else None
+    )
+    if not target_path:
+        print(
+            "raptor-enrich-flow-trace-ast-view: checklist missing "
+            "target_path; skipping enrichment", file=sys.stderr,
+        )
+        return 0
+
+    # Build the inventory once and share across all trace files —
+    # the per-call default would rebuild for every file, painful
+    # when /understand --trace runs N times and emits N files.
+    try:
+        from core.inventory.builder import build_inventory
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            inventory = build_inventory(target_path, td)
+    except Exception as e:                                  # noqa: BLE001
+        print(
+            f"raptor-enrich-flow-trace-ast-view: inventory build "
+            f"failed ({e}); skipping enrichment", file=sys.stderr,
+        )
+        return 0
+
+    trace_files = sorted(understand_dir.glob("flow-trace-*.json"))
+    if not trace_files:
+        print(
+            "raptor-enrich-flow-trace-ast-view: no flow-trace-*.json "
+            "files in directory; nothing to enrich"
+        )
+        return 0
+
+    total_enriched = 0
+    total_files = 0
+    for trace_path in trace_files:
+        trace = load_json(trace_path)
+        if not isinstance(trace, dict):
+            print(
+                f"raptor-enrich-flow-trace-ast-view: skipping "
+                f"{trace_path.name} — not a JSON object",
+                file=sys.stderr,
+            )
+            continue
+        n = enrich_with_ast_view(
+            trace, Path(target_path), inventory=inventory,
+        )
+        if n:
+            save_json(trace_path, trace)
+            total_enriched += n
+            total_files += 1
+
+    if total_enriched:
+        print(
+            f"raptor-enrich-flow-trace-ast-view: enriched "
+            f"{total_enriched} step(s) across {total_files} trace "
+            f"file(s) (of {len(trace_files)} total)"
+        )
+    else:
+        print(
+            f"raptor-enrich-flow-trace-ast-view: no steps enriched "
+            f"across {len(trace_files)} trace file(s) "
+            "(no steps with resolvable definitions, or inventory "
+            "build skipped)"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/libexec/tests/test_raptor_enrich_flow_trace_ast_view.py
+++ b/libexec/tests/test_raptor_enrich_flow_trace_ast_view.py
@@ -1,0 +1,176 @@
+"""Tests for the libexec/raptor-enrich-flow-trace-ast-view wrapper."""
+
+import json
+import os
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WRAPPER = REPO_ROOT / "libexec" / "raptor-enrich-flow-trace-ast-view"
+
+
+def _run(*args, **kwargs):
+    env = {**os.environ, "_RAPTOR_TRUSTED": "1"}
+    return subprocess.run(
+        [str(WRAPPER), *args],
+        capture_output=True, text=True, timeout=30,
+        env=env, **kwargs,
+    )
+
+
+class RaptorEnrichFlowTraceAstViewTests(unittest.TestCase):
+
+    def test_wrapper_exists_and_is_executable(self):
+        self.assertTrue(WRAPPER.exists(), msg=f"missing: {WRAPPER}")
+        self.assertTrue(os.access(WRAPPER, os.X_OK),
+                        msg=f"not executable: {WRAPPER}")
+
+    def test_no_args_prints_usage_and_fails(self):
+        proc = _run()
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("usage", proc.stderr.lower())
+
+    def test_missing_understand_dir_fails_cleanly(self):
+        proc = _run("/nonexistent/path/that/does/not/exist")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("not a directory", proc.stderr)
+
+    def test_missing_checklist_returns_zero_no_op(self):
+        """If checklist.json is absent or doesn't carry target_path,
+        the wrapper logs a warning and exits 0."""
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "flow-trace-001.json").write_text(json.dumps({
+                "steps": [{"step": 1, "definition": "x.py:1"}],
+            }))
+            proc = _run(str(tmp))
+            self.assertEqual(proc.returncode, 0,
+                             msg=f"wrapper failed: {proc.stderr}")
+            self.assertIn("checklist missing", proc.stderr)
+
+    def test_no_trace_files_returns_zero(self):
+        """An understand dir with checklist but no flow-trace-*.json
+        files is fine — nothing to enrich, exit 0 with notice."""
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            target = tmp / "target"
+            target.mkdir()
+            (target / "x.py").write_text("def f(): return 1\n")
+            (tmp / "checklist.json").write_text(json.dumps({
+                "target_path": str(target),
+            }))
+            proc = _run(str(tmp))
+            self.assertEqual(proc.returncode, 0,
+                             msg=f"wrapper failed: {proc.stderr}")
+            self.assertIn("no flow-trace-", proc.stdout)
+
+    def test_enriches_single_trace_file(self):
+        """Happy path: one trace file with a resolvable step gets
+        enriched in place; wrapper reports the count."""
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            target = tmp / "target"
+            target.mkdir()
+            (target / "auth.py").write_text(
+                "def check():\n    return 0\n"
+            )
+            (tmp / "checklist.json").write_text(json.dumps({
+                "target_path": str(target),
+            }))
+            (tmp / "flow-trace-001.json").write_text(json.dumps({
+                "id": "TRACE-001",
+                "steps": [{"step": 1, "definition": "auth.py:1"}],
+            }))
+            proc = _run(str(tmp))
+            self.assertEqual(proc.returncode, 0,
+                             msg=f"wrapper failed: {proc.stderr}")
+            self.assertIn("enriched 1", proc.stdout)
+
+            enriched = json.loads((tmp / "flow-trace-001.json").read_text())
+            step = enriched["steps"][0]
+            self.assertIn("ast_view", step)
+            self.assertEqual(step["ast_view"]["function"], "check")
+
+    def test_enriches_multiple_trace_files(self):
+        """Wrapper iterates every flow-trace-*.json in the dir."""
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            target = tmp / "target"
+            target.mkdir()
+            (target / "a.py").write_text("def fa(): return 1\n")
+            (target / "b.py").write_text("def fb(): return 2\n")
+            (tmp / "checklist.json").write_text(json.dumps({
+                "target_path": str(target),
+            }))
+            (tmp / "flow-trace-a.json").write_text(json.dumps({
+                "steps": [{"step": 1, "definition": "a.py:1"}],
+            }))
+            (tmp / "flow-trace-b.json").write_text(json.dumps({
+                "steps": [{"step": 1, "definition": "b.py:1"}],
+            }))
+            proc = _run(str(tmp))
+            self.assertEqual(proc.returncode, 0,
+                             msg=f"wrapper failed: {proc.stderr}")
+            self.assertIn("across 2 trace file(s)", proc.stdout)
+
+    def test_corrupt_trace_file_skipped_others_enriched(self):
+        """A single corrupt trace file doesn't abort the whole run —
+        the wrapper logs and continues to other files."""
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            target = tmp / "target"
+            target.mkdir()
+            (target / "a.py").write_text("def fa(): return 1\n")
+            (tmp / "checklist.json").write_text(json.dumps({
+                "target_path": str(target),
+            }))
+            # Corrupt: top-level list, not dict
+            (tmp / "flow-trace-bad.json").write_text("[]")
+            # Valid
+            (tmp / "flow-trace-good.json").write_text(json.dumps({
+                "steps": [{"step": 1, "definition": "a.py:1"}],
+            }))
+            proc = _run(str(tmp))
+            self.assertEqual(proc.returncode, 0,
+                             msg=f"wrapper failed: {proc.stderr}")
+            self.assertIn("not a JSON object", proc.stderr)
+            self.assertIn("enriched 1", proc.stdout)
+            # The good file was enriched.
+            good = json.loads((tmp / "flow-trace-good.json").read_text())
+            self.assertIn("ast_view", good["steps"][0])
+
+    def test_idempotent_on_repeated_invocation(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            target = tmp / "target"
+            target.mkdir()
+            (target / "a.py").write_text("def fa(): return 1\n")
+            (tmp / "checklist.json").write_text(json.dumps({
+                "target_path": str(target),
+            }))
+            (tmp / "flow-trace-001.json").write_text(json.dumps({
+                "steps": [{"step": 1, "definition": "a.py:1"}],
+            }))
+            _run(str(tmp))
+            first = (tmp / "flow-trace-001.json").read_text()
+            _run(str(tmp))
+            second = (tmp / "flow-trace-001.json").read_text()
+            self.assertEqual(first, second)
+
+    def test_trust_marker_required(self):
+        with TemporaryDirectory() as tmp:
+            env = {k: v for k, v in os.environ.items()
+                   if k not in ("CLAUDECODE", "_RAPTOR_TRUSTED")}
+            proc = subprocess.run(
+                [str(WRAPPER), tmp],
+                capture_output=True, text=True, timeout=10, env=env,
+            )
+            self.assertEqual(proc.returncode, 2)
+            self.assertIn("internal dispatch script", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Sixth and final Tier-1 consumer for ``core.ast.view`` after the libexec CLI shim (#527), ``/understand --map`` (#528), ``/agentic`` analysis-family (#533), ``/exploit`` + ``/patch`` prompts (#534), and ``/validate`` Stage B prep (#537). Each step in ``/understand --trace``'s output now carries an ``ast_view`` field for the function the trace is moving *into* at that hop.

What lands:

  * ``core/orchestration/flow_trace_ast_view.py`` — new enricher. Walks ``trace["steps"]``, parses each step's ``definition`` field as ``file:line``, resolves to the enclosing function via ``core.inventory.reachability.enclosing_function``, calls ``core.ast.view(target_root/file, host.name, at_line=line)``, attaches ``step["ast_view"] = fv.to_dict()``. Idempotent (pre-existing values preserved); best-effort (parse failure / external reference / function not in inventory all leave that step unchanged).

  * ``libexec/raptor-enrich-flow-trace-ast-view`` — CLI shim. Iterates every ``flow-trace-*.json`` in the run dir, builds inventory ONCE, shares across all files (a /understand --trace run that emits N traces would otherwise rebuild inventory N times). Trust-marker check + ``sys.path`` setup match the established libexec convention.

  * ``.claude/skills/code-understanding/trace.md`` — adds [TRACE-OUT] step invoking the shim after writing all flow-trace-*.json files.

  * Tests: 19 module + 9 shim + 3 sub-cases.

Definition-only enrichment (not call_site): each step is enriched with the function being stepped *into* (definition's host), not the caller (call_site's host). Rationale:
  * At each hop the caller is already context the LLM has from continuity (it's the previous step's definition or the entry).
  * Adding call_site enrichment would double per-step token cost without much marginal narrative gain.
  * If measurement shows the LLM needs caller-side shape, the change is single-file (~10 LOC). Trust-and-measure.

Path-traversal defence: ``Path.resolve()`` +
``Path.relative_to()`` reject any step whose ``definition`` file escapes target_root (absolute path, ``../../`` traversal, symlinks pointing out). Flow traces are LLM-emitted and may carry injected entries — same defence as PR2's context-map enricher and PR5's findings.json enricher.

Coverage of /understand product surface: this is the sibling of PR2's ``context_map_ast_view`` enrichment for
``/understand --map``. The two together cover both ``/understand`` output products that anchor downstream reasoning — the static attack-surface map and the dynamic data-flow traces. Stage B's understand-bridge consumes both and propagates ast_view into ``attack-paths.json`` automatically.

Testing:

  Unit: 31 new (19 module + 9 shim + 3 _parse_definition edge cases). Wider ``core/orchestration/`` +
  ``libexec/tests/`` regression 274/274 clean. Ruff F401/F811/F821/F841 gate clean. No schema validator for flow-trace files exists (LLM-emitted, downstream-consumed via understand-bridge); ``ast_view`` field is purely additive.

  E2E: real Linux kernel ``lib/string_helpers.c`` → synthetic /understand workdir with a 3-step trace (entry / call / sink). Result: ``enriched 2 step(s) across 1 trace file(s)``. Steps 1+2 (definitions resolve to ``parse_int_array_user`` in the inventory) got the full function shape (7 calls, 2 returns); step 3 (definition ``mm/util.c:kfree()`` — external, no ``file:line`` parse) correctly skipped.