### PR TITLE
refactor: pull raptor's own tests out of test/, anchor dir purpose

### DIFF
--- a/.github/tests/test_release_workflow.sh
+++ b/.github/tests/test_release_workflow.sh
@@ -5,12 +5,13 @@
 # Creates a disposable git repo with synthetic commits and tags, then runs
 # each workflow step's logic and asserts expected outcomes.
 #
-# Usage: bash test/test_release_workflow.sh
+# Usage: bash .github/tests/test_release_workflow.sh
 #
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# SCRIPT_DIR resolves to the repo root: .github/tests/<this> -> ../.. = repo root.
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 TMPDIR_BASE=$(mktemp -d)
 REPO="${TMPDIR_BASE}/test-repo"
 PASS=0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -297,15 +297,13 @@ jobs:
             --ignore=core/orchestration/tests \
             --ignore=core/security/tests/test_prompt_envelope_audit.py
 
-      - name: Run CLI smoke tests (group 1 only)
-        if: matrix.group == 1
-        run: |
-          source $VENV_PATH/bin/activate
-          # End-to-end argparse acceptance + entry-point smoke for
-          # raptor.py. Ported from the now-retired test/real_tests_fast.sh.
-          # Kept separate from `pytest core packages` to avoid pytest
-          # import-name collisions with the top-level tests package.
-          pytest test/test_cli_smoke.py -n auto
+      # Note: the CLI smoke tests for raptor.py used to live at
+      # test/test_cli_smoke.py with a dedicated group-1 step (to dodge
+      # pytest import-name collisions with the top-level tests/ dir
+      # that no longer exists). They now live at
+      # core/startup/tests/test_cli_smoke.py and are collected by the
+      # fast-tier `pytest core packages` step above — pytest-split
+      # distributes them across groups, no dedicated step needed.
 
       # Note: the path-filter coverage tests at `.github/tests/` used to
       # run in this job (group 1 only). They now have their own

--- a/core/startup/tests/test_cli_smoke.py
+++ b/core/startup/tests/test_cli_smoke.py
@@ -19,6 +19,7 @@ duplicate the existing ``compileall`` step in ``.github/workflows/tests.yml``.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -26,7 +27,7 @@ from pathlib import Path
 import pytest
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(os.environ["RAPTOR_DIR"])
 RAPTOR_PY = REPO_ROOT / "raptor.py"
 
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,30 @@
+# test/ — sample target code for RAPTOR to scan
+
+This directory holds **sample vulnerable code that RAPTOR scans** during
+development, ad-hoc testing, and CodeQL/SMT testbench work. It is
+intentionally *not* RAPTOR's own test suite — the project's unit and
+integration tests live colocated with the package they exercise
+(`core/<pkg>/tests/`, `packages/<pkg>/tests/`, `.github/tests/`).
+
+## Layout
+
+```
+test/
+├── data/
+│   ├── javascript_xss.js              # XSS sample, JS scanner target
+│   ├── python_sql_injection.py        # SQL-i sample, Python scanner target
+│   └── smt_codeql_testbench/          # CodeQL + SMT path-feasibility testbench
+│       ├── README.md
+│       └── smt_codeql_testbench.c
+└── README.md                          # this file
+```
+
+## What does NOT belong here
+
+- RAPTOR's own pytest tests → `core/<pkg>/tests/` or `packages/<pkg>/tests/`
+- CI-invariant tests (filter coverage, libexec marker, release workflow) → `.github/tests/`
+- Wrapper-script tests → the package whose code the wrapper invokes
+
+If you find yourself reaching for `test/test_foo.py`, it's almost
+certainly in the wrong place. See `project_test_directory_cleanup.md`
+in the operator memory for the colocation principle.


### PR DESCRIPTION
`test/` is sample vulnerable code that RAPTOR scans (its data/ subdir holds the actual targets — javascript_xss.js, python_sql_ injection.py, smt_codeql_testbench/). Two of RAPTOR's own tests had drifted into `test/` over time, violating the colocation convention enforced by the prior test-dir cleanup.

Moves (history-preserving):

  test/test_cli_smoke.py
    -> core/startup/tests/test_cli_smoke.py
       (subject = raptor.py CLI dispatch, which routes through
       core/startup/init.py; REPO_ROOT upgraded from
       Path(__file__).parents[1] to os.environ["RAPTOR_DIR"])

  test/test_release_workflow.sh
    -> .github/tests/test_release_workflow.sh
       (subject = .github/workflows/release.yml; sibling to the
       other CI invariant tests test_filter_coverage.py and
       test_libexec_marker_coverage.py; SCRIPT_DIR walk updated
       from `..` to `../..`)

CI workflow: dropped the dedicated "Run CLI smoke tests (group 1 only)" step. The test now lives under core/startup/tests/ and is collected by the existing fast-tier `pytest core packages` run — pytest-split distributes it across groups. The standalone step was a hangover from when /tests/ existed and risked import-name collisions; that concern is gone.

Added test/README.md anchoring the dir's purpose ("sample target code for RAPTOR to scan — not RAPTOR's own tests") so the next contributor reaching for `test/test_foo.py` is caught at review.

Verified: 25/25 CLI smoke tests pass from new home, 60/60 release workflow simulation passes from new home, 3/3 filter coverage still green, test/ now contains only README.md + data/.