### PR TITLE
feat(core/binary): capability fingerprinting substrate

### DIFF
--- a/core/binary/__init__.py
+++ b/core/binary/__init__.py
@@ -1,0 +1,66 @@
+"""Binary substrate: fingerprinting + capability diff.
+
+Tool-substrate-level primitives for analysing binaries. The
+high-level analyser (``BinaryUnderstand``) lives in
+:mod:`packages.binary_analysis.radare2_understand`; this package
+contains the lightweight primitives every binary-aware consumer
+shares:
+
+  * :func:`capability_fingerprint` — stable JSON snapshot of one
+    binary's capability surface (bucketed dangerous imports +
+    metadata + content hash).
+  * :func:`diff_binary_capabilities` — diff two binaries'
+    capability surfaces. Returns a :class:`CapabilityDelta` with
+    newly-added dangerous-import buckets.
+  * :data:`BUCKETS` + :func:`bucket_imports` — shared taxonomy
+    for classifying imports into high-CVE-density buckets.
+
+The fingerprint and diff primitives are cross-reference-blind by
+design — they answer "what is this binary capable of calling"
+based on the dynamic symbol table. The expensive cross-reference
+analysis (which functions in the binary actually USE the
+dangerous imports) requires ``BinaryUnderstand`` and is a
+different output shape.
+"""
+
+from core.binary.capability_diff import (
+    CapabilityDelta,
+    diff_binary_capabilities,
+)
+from core.binary.drift import (
+    FingerprintDrift,
+    detect_drift,
+)
+from core.binary.fingerprint import (
+    BUCKETS,
+    CapabilityFingerprint,
+    FINGERPRINT_SCHEMA_VERSION,
+    HIGH_SEVERITY_BUCKETS,
+    bucket_imports,
+    capability_fingerprint,
+)
+from core.binary.fingerprint_store import (
+    STORE_SCHEMA_VERSION,
+    delete_fingerprint,
+    iter_refs,
+    load_fingerprint,
+    save_fingerprint,
+)
+
+__all__ = [
+    "BUCKETS",
+    "CapabilityDelta",
+    "CapabilityFingerprint",
+    "FINGERPRINT_SCHEMA_VERSION",
+    "FingerprintDrift",
+    "HIGH_SEVERITY_BUCKETS",
+    "STORE_SCHEMA_VERSION",
+    "bucket_imports",
+    "capability_fingerprint",
+    "delete_fingerprint",
+    "detect_drift",
+    "diff_binary_capabilities",
+    "iter_refs",
+    "load_fingerprint",
+    "save_fingerprint",
+]

--- a/core/binary/capability_diff.py
+++ b/core/binary/capability_diff.py
@@ -22,13 +22,13 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional
 
 from core.binary.fingerprint import (
-    BUCKETS,
+    BUCKETS,  # noqa: F401  — re-exported for downstream parity
     HIGH_SEVERITY_BUCKETS,
     CapabilityFingerprint,
-    bucket_imports,
+    bucket_imports,  # noqa: F401  — re-exported for downstream parity
 )
 
 logger = logging.getLogger(__name__)

--- a/core/binary/capability_diff.py
+++ b/core/binary/capability_diff.py
@@ -1,0 +1,135 @@
+"""Diff two binaries' capability surfaces.
+
+Substrate for "did this bump / drift / new build add dangerous
+capabilities". The diff operates on the import-bucket view only —
+``dangerous_sinks`` (cross-reference-derived) is intentionally
+out of scope here; that signal requires ``BinaryUnderstand``
+from :mod:`packages.binary_analysis.radare2_understand` and has
+a different output shape.
+
+Two consumers today:
+- ``packages.sca.bump.binary_capability_delta`` — wraps the
+  delta in a ``SupplyChainFinding`` for the bump pipeline.
+- Future drift-detection — compares scan-time fingerprints
+  across runs.
+
+Both share this primitive so the bucket / severity semantics
+stay consistent.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+from core.binary.fingerprint import (
+    BUCKETS,
+    HIGH_SEVERITY_BUCKETS,
+    CapabilityFingerprint,
+    bucket_imports,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CapabilityDelta:
+    """Capability-surface diff between two binaries.
+
+    ``new_dangerous_imports`` — imports in target that weren't in
+    current, grouped by bucket. Only buckets with additions
+    appear. Sorted lists for stable rendering.
+
+    ``current_path`` / ``target_path`` — the binaries that were
+    compared. Informational; not load-bearing for evidence.
+    """
+
+    new_dangerous_imports: Dict[str, List[str]] = field(
+        default_factory=dict,
+    )
+    current_path: Optional[Path] = None
+    target_path: Optional[Path] = None
+    current_fingerprint: Optional[CapabilityFingerprint] = None
+    target_fingerprint: Optional[CapabilityFingerprint] = None
+
+    def is_empty(self) -> bool:
+        """True when target adds no capabilities current didn't have."""
+        return not self.new_dangerous_imports
+
+    def high_severity(self) -> bool:
+        """True when any added bucket is exec or network."""
+        return any(
+            bucket in HIGH_SEVERITY_BUCKETS
+            for bucket in self.new_dangerous_imports
+        )
+
+    def added_buckets(self) -> List[str]:
+        """Sorted list of bucket names with new entries."""
+        return sorted(self.new_dangerous_imports.keys())
+
+
+def diff_binary_capabilities(
+    current_binary: Path,
+    target_binary: Path,
+) -> Optional[CapabilityDelta]:
+    """Compare two binaries' capability surfaces.
+
+    Implemented as a thin diff over two
+    :func:`core.binary.fingerprint.capability_fingerprint` calls
+    — the fingerprint primitive owns tier dispatch (try ELF
+    parser first, fall back to radare2), so this function
+    inherits the same operational properties: sub-millisecond on
+    Linux ELF binaries, falls back to radare2 for PE / Mach-O,
+    works on hosts without r2pipe for the ELF case.
+
+    Returns ``None`` when:
+      * Either binary can't be fingerprinted (unreadable / not
+        ELF + no radare2 / radare2 fails)
+
+    Returns an *empty* :class:`CapabilityDelta` (``is_empty()``)
+    when both fingerprint cleanly but target adds nothing new —
+    the caller can distinguish "couldn't compare" (None) from
+    "no change" (empty delta).
+    """
+    from core.binary.fingerprint import capability_fingerprint
+
+    current_fp = capability_fingerprint(current_binary)
+    if current_fp is None:
+        logger.debug(
+            "core.binary.capability_diff: could not fingerprint "
+            "current %s", current_binary,
+        )
+        return None
+    target_fp = capability_fingerprint(target_binary)
+    if target_fp is None:
+        logger.debug(
+            "core.binary.capability_diff: could not fingerprint "
+            "target %s", target_binary,
+        )
+        return None
+
+    new_imports: Dict[str, List[str]] = {}
+    for bucket_name, target_fns in target_fp.capability_buckets.items():
+        target_set = set(target_fns)
+        current_set = set(
+            current_fp.capability_buckets.get(bucket_name, []),
+        )
+        added = target_set - current_set
+        if added:
+            new_imports[bucket_name] = sorted(added)
+
+    return CapabilityDelta(
+        new_dangerous_imports=new_imports,
+        current_path=current_binary,
+        target_path=target_binary,
+        current_fingerprint=current_fp,
+        target_fingerprint=target_fp,
+    )
+
+
+__all__ = [
+    "CapabilityDelta",
+    "diff_binary_capabilities",
+]

--- a/core/binary/drift.py
+++ b/core/binary/drift.py
@@ -20,7 +20,7 @@ but a stored-fingerprint comparison surfaces it.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from core.binary.fingerprint import (
     CapabilityFingerprint,

--- a/core/binary/drift.py
+++ b/core/binary/drift.py
@@ -1,0 +1,141 @@
+"""Capability drift between two fingerprints.
+
+Where :func:`core.binary.capability_diff.diff_binary_capabilities`
+asks "what does target ADD over current" (unidirectional —
+appropriate for bump capability-delta where the operator
+proposes a forward change), :func:`detect_drift` asks "what
+CHANGED between previous and now" (bidirectional — additions
++ removals + metadata shifts). Both signals come from the
+fingerprint primitive but consumers want different framing:
+
+- Bumps: "is the proposed upgrade introducing dangerous caps"
+- Drift: "did the image we've been pulling silently change"
+
+A re-tagged ``alpine:3.18`` whose registry-side digest moves
+to bytes with different capabilities is exactly the
+drift case — there's no version bump for the bumper to catch,
+but a stored-fingerprint comparison surfaces it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from core.binary.fingerprint import (
+    CapabilityFingerprint,
+    HIGH_SEVERITY_BUCKETS,
+)
+
+
+@dataclass
+class FingerprintDrift:
+    """Difference between two fingerprints of the same logical
+    binary at different points in time.
+
+    Field semantics:
+    - ``new_buckets`` — buckets in current that weren't in
+      previous (capabilities added). Each value is the sorted
+      list of newly-added function names.
+    - ``removed_buckets`` — buckets in previous that aren't in
+      current. Same shape.
+    - ``hash_changed`` — bytes differ (binary_sha256 doesn't
+      match). True is the trigger for everything else; without
+      this, no drift could exist.
+    - ``arch_changed`` / ``bits_changed`` / ``format_changed`` —
+      metadata-level changes. Format change is a strong signal
+      (the operator switched between ELF/PE/Mach-O); arch/bits
+      changes flag accidental multi-arch confusion.
+    """
+
+    hash_changed: bool = False
+    arch_changed: bool = False
+    bits_changed: bool = False
+    format_changed: bool = False
+    new_buckets: Dict[str, List[str]] = field(default_factory=dict)
+    removed_buckets: Dict[str, List[str]] = field(default_factory=dict)
+
+    def is_empty(self) -> bool:
+        """True when previous and current are capability-
+        equivalent. ``hash_changed`` alone (bytes changed but
+        capabilities didn't) is NOT considered drift — that's
+        the legitimate-rebuild case, suppressed."""
+        return not (
+            self.new_buckets
+            or self.removed_buckets
+            or self.arch_changed
+            or self.bits_changed
+            or self.format_changed
+        )
+
+    def high_severity(self) -> bool:
+        """True when ANY added bucket is exec or network — the
+        strongest signal that a re-tagged image now does
+        something dangerous it previously didn't."""
+        return any(
+            bucket in HIGH_SEVERITY_BUCKETS
+            for bucket in self.new_buckets
+        )
+
+    def added_buckets(self) -> List[str]:
+        return sorted(self.new_buckets.keys())
+
+    def removed_bucket_names(self) -> List[str]:
+        return sorted(self.removed_buckets.keys())
+
+
+def detect_drift(
+    previous: CapabilityFingerprint,
+    current: CapabilityFingerprint,
+) -> FingerprintDrift:
+    """Diff two fingerprints. Returns a :class:`FingerprintDrift`
+    summarising every dimension of change. Always returns a
+    drift object (never None) — callers use ``is_empty()`` to
+    distinguish "no drift" from "drift detected".
+
+    Bytes-unchanged is the no-op case (``is_empty()`` returns
+    True without comparing buckets). For meaningfully-different
+    bytes, we walk every bucket in both directions.
+    """
+    if previous.binary_sha256 == current.binary_sha256:
+        # Same bytes → no drift by definition. Short-circuit so
+        # the bucket walk is skipped (and we don't surface
+        # legitimate filesystem-level differences like
+        # binary_path).
+        return FingerprintDrift()
+
+    drift = FingerprintDrift(hash_changed=True)
+
+    if previous.arch != current.arch:
+        drift.arch_changed = True
+    if previous.bits != current.bits:
+        drift.bits_changed = True
+    if previous.binary_format != current.binary_format:
+        drift.format_changed = True
+
+    prev_buckets = previous.capability_buckets
+    cur_buckets = current.capability_buckets
+
+    # Additions: in current, not in previous (or expanded entries).
+    for bucket, cur_items in cur_buckets.items():
+        cur_set = set(cur_items)
+        prev_set = set(prev_buckets.get(bucket, []))
+        added = cur_set - prev_set
+        if added:
+            drift.new_buckets[bucket] = sorted(added)
+
+    # Removals: in previous, not in current.
+    for bucket, prev_items in prev_buckets.items():
+        prev_set = set(prev_items)
+        cur_set = set(cur_buckets.get(bucket, []))
+        removed = prev_set - cur_set
+        if removed:
+            drift.removed_buckets[bucket] = sorted(removed)
+
+    return drift
+
+
+__all__ = [
+    "FingerprintDrift",
+    "detect_drift",
+]

--- a/core/binary/elf.py
+++ b/core/binary/elf.py
@@ -1,0 +1,390 @@
+"""Native ELF parser — tier 0 of the binary substrate.
+
+Stdlib-only (``struct``) parser of the ELF dynamic-import table.
+Sub-millisecond on typical binaries; no radare2 / r2pipe / lief
+dependency. Used by :mod:`core.binary.fingerprint` as the
+preferred path for Linux ELF binaries; falls back to the tier-1
+radare2 path for PE / Mach-O / cross-reference analysis.
+
+Scope
+- ELF32 + ELF64
+- Little- and big-endian
+- Linux + BSD + bare-metal ABIs (we don't filter by OSABI)
+- Imports = entries in ``.dynsym`` whose section index is
+  ``SHN_UNDEF`` (i.e. unresolved at link time, satisfied by the
+  dynamic linker — exactly what ``radare2 iij`` calls "imports")
+
+Out of scope
+- ``.symtab`` static symbols (not relevant for capability surface)
+- ``DT_NEEDED`` library names (separate question — what does this
+  link against, not what symbols does it call)
+- Cross-references / call graph (radare2's territory)
+- Mach-O / PE (different format; fall back to radare2)
+
+Error handling
+Every parse failure returns ``None``. The parser is intentionally
+defensive — corrupt / truncated / non-ELF inputs return cleanly
+because we run against operator-supplied bytes which may come
+from misconfigured registries, mislabelled files, etc.
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# ELF magic — first 4 bytes of any valid ELF file
+_ELF_MAGIC = b"\x7fELF"
+
+# EI_CLASS values
+_ELFCLASS32 = 1
+_ELFCLASS64 = 2
+
+# EI_DATA values
+_ELFDATA2LSB = 1
+_ELFDATA2MSB = 2
+
+# Section types
+_SHT_SYMTAB = 2
+_SHT_STRTAB = 3
+_SHT_DYNSYM = 11
+
+# Symbol section index — SHN_UNDEF means "imported"
+_SHN_UNDEF = 0
+_SHN_LORESERVE = 0xFF00
+
+# e_machine → arch FAMILY string. Convention matches radare2
+# (``r2 ij`` reports bin.arch as the family with bits as a
+# separate field), so fingerprints produced by the native ELF
+# tier and by the radare2 tier are bit-compatible:
+#   * EM_386 → arch="x86" bits=32  (i386)
+#   * EM_X86_64 → arch="x86" bits=64  (x86_64)
+#   * EM_ARM → arch="arm" bits=32
+#   * EM_AARCH64 → arch="arm" bits=64
+# Combined ``(arch, bits)`` tuple uniquely identifies the
+# instruction set. Unknown e_machine values fall through to
+# ``"unknown"``.
+_MACHINE_ARCH = {
+    0x03: "x86",      # EM_386
+    0x28: "arm",      # EM_ARM
+    0x3E: "x86",      # EM_X86_64
+    0xB7: "arm",      # EM_AARCH64
+    0xF3: "riscv",
+    0x14: "ppc",
+    0x15: "ppc",      # EM_PPC64 — same family, bits=64 disambiguates
+    0x16: "s390",
+    0x08: "mips",
+    0x0A: "mips",     # EM_MIPS_RS3_LE — same family, endian differs
+}
+
+# Sanity caps on field values. ELF spec doesn't bound these but
+# real-world binaries stay well under; treating anything outside
+# as malformed defends against pathological / hostile inputs.
+_MAX_SHNUM = 100_000
+_MAX_DYNSYM_ENTRIES = 1_000_000
+_MAX_SHSTRNDX_BOUND = 100_000
+
+
+@dataclass
+class ElfMetadata:
+    """Minimal ELF metadata + import-symbol list.
+
+    ``imports`` is the set of names from ``.dynsym`` whose
+    ``st_shndx == SHN_UNDEF`` — the dynamic-linker-satisfied
+    symbols. Order is not preserved (set semantics; consumers
+    sort if rendering).
+
+    ``arch`` / ``bits`` / ``binary_format`` mirror the radare2-
+    populated fields on :class:`packages.binary_analysis.
+    radare2_understand.BinaryContextMap`, so fingerprints
+    produced by the ELF tier and by the radare2 tier are
+    comparable.
+    """
+
+    arch: str
+    bits: int
+    binary_format: str = "elf"
+    imports: Set[str] = field(default_factory=set)
+
+
+def parse_elf(path: Path) -> Optional[ElfMetadata]:
+    """Parse ``path`` as ELF and return its capability-relevant
+    metadata, or ``None`` on any read / parse failure.
+
+    Reads only the bytes it needs (header + section headers +
+    .dynsym + .dynstr); does not load the whole binary into
+    memory.
+    """
+    try:
+        with open(path, "rb") as f:
+            return _parse_elf_stream(f)
+    except OSError as e:
+        logger.debug("core.binary.elf: read failed for %s: %s", path, e)
+        return None
+    except struct.error as e:
+        logger.debug("core.binary.elf: truncated / malformed %s: %s",
+                     path, e)
+        return None
+
+
+def _parse_elf_stream(f) -> Optional[ElfMetadata]:
+    # --- e_ident (first 16 bytes) -----------------------------
+    e_ident = f.read(16)
+    if len(e_ident) < 16 or e_ident[:4] != _ELF_MAGIC:
+        return None
+    ei_class = e_ident[4]
+    ei_data = e_ident[5]
+    if ei_class not in (_ELFCLASS32, _ELFCLASS64):
+        return None
+    if ei_data not in (_ELFDATA2LSB, _ELFDATA2MSB):
+        return None
+    bits = 64 if ei_class == _ELFCLASS64 else 32
+    endian = "<" if ei_data == _ELFDATA2LSB else ">"
+
+    # --- ELF header (continues after e_ident) -----------------
+    # ELF64: HHIQQQIHHHHHH (12-byte preamble + Q for entry/phoff/shoff)
+    # ELF32: HHIIIIIHHHHHH
+    if bits == 64:
+        # e_type(H) e_machine(H) e_version(I) e_entry(Q) e_phoff(Q)
+        # e_shoff(Q) e_flags(I) e_ehsize(H) e_phentsize(H) e_phnum(H)
+        # e_shentsize(H) e_shnum(H) e_shstrndx(H)
+        rest_fmt = endian + "HHIQQQIHHHHHH"
+    else:
+        rest_fmt = endian + "HHIIIIIHHHHHH"
+    rest_size = struct.calcsize(rest_fmt)
+    rest = f.read(rest_size)
+    if len(rest) < rest_size:
+        return None
+    (e_type, e_machine, _e_version, _e_entry, _e_phoff,
+     e_shoff, _e_flags, _e_ehsize, _e_phentsize, _e_phnum,
+     e_shentsize, e_shnum, e_shstrndx) = struct.unpack(
+        rest_fmt, rest,
+    )
+
+    if e_shoff == 0 or e_shnum == 0 or e_shnum > _MAX_SHNUM:
+        # No section headers — possible (PIE stripped binary)
+        # but we can't enumerate imports without them. Bail.
+        return _bare_metadata(e_machine, bits)
+    if e_shstrndx >= _MAX_SHSTRNDX_BOUND:
+        # SHN_XINDEX or similar — would require reading
+        # section 0 for the extended index. Not handling.
+        return _bare_metadata(e_machine, bits)
+
+    # --- Section header table ----------------------------------
+    sections = _read_section_headers(
+        f, e_shoff, e_shentsize, e_shnum, bits=bits, endian=endian,
+    )
+    if sections is None or e_shstrndx >= len(sections):
+        return _bare_metadata(e_machine, bits)
+
+    # --- Section-name string table -----------------------------
+    shstrtab_section = sections[e_shstrndx]
+    shstrtab = _read_section_bytes(f, shstrtab_section)
+    if shstrtab is None:
+        return _bare_metadata(e_machine, bits)
+
+    # Resolve section names so we can find .dynsym + .dynstr
+    named_sections: List[Tuple[str, "_SectionHeader"]] = []
+    for sh in sections:
+        name = _read_strtab_string(shstrtab, sh.sh_name)
+        named_sections.append((name, sh))
+
+    # --- Find .dynsym and .dynstr ------------------------------
+    dynsym = None
+    dynstr = None
+    for name, sh in named_sections:
+        if name == ".dynsym" and sh.sh_type == _SHT_DYNSYM:
+            dynsym = sh
+        elif name == ".dynstr" and sh.sh_type == _SHT_STRTAB:
+            dynstr = sh
+
+    if dynsym is None or dynstr is None:
+        # Static binary or stripped — no dynamic imports.
+        # Return metadata without imports.
+        return _bare_metadata(e_machine, bits)
+
+    # --- Read .dynstr (the symbol-name string table) -----------
+    dynstr_bytes = _read_section_bytes(f, dynstr)
+    if dynstr_bytes is None:
+        return _bare_metadata(e_machine, bits)
+
+    # --- Walk .dynsym entries, collect imports -----------------
+    imports = _read_dynsym_imports(
+        f, dynsym, dynstr_bytes, bits=bits, endian=endian,
+    )
+
+    return ElfMetadata(
+        arch=_MACHINE_ARCH.get(e_machine, "unknown"),
+        bits=bits,
+        binary_format="elf",
+        imports=imports,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section header parsing
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _SectionHeader:
+    """Fields we care about from an ELF section header. The
+    full struct has more (sh_flags, sh_addr, sh_addralign, etc.)
+    but they're not relevant for the import-table extraction."""
+
+    sh_name: int          # offset into shstrtab
+    sh_type: int
+    sh_offset: int
+    sh_size: int
+    sh_link: int
+    sh_entsize: int
+
+
+def _read_section_headers(
+    f, e_shoff: int, e_shentsize: int, e_shnum: int,
+    *, bits: int, endian: str,
+) -> Optional[List[_SectionHeader]]:
+    f.seek(e_shoff)
+    out: List[_SectionHeader] = []
+    # ELF64 section header: 64 bytes
+    # ELF32 section header: 40 bytes
+    if bits == 64:
+        # sh_name(I) sh_type(I) sh_flags(Q) sh_addr(Q) sh_offset(Q)
+        # sh_size(Q) sh_link(I) sh_info(I) sh_addralign(Q) sh_entsize(Q)
+        fmt = endian + "IIQQQQIIQQ"
+    else:
+        fmt = endian + "IIIIIIIIII"
+    record_size = struct.calcsize(fmt)
+    if e_shentsize < record_size:
+        return None
+    for _ in range(e_shnum):
+        buf = f.read(record_size)
+        if len(buf) < record_size:
+            return None
+        if bits == 64:
+            (sh_name, sh_type, _sh_flags, _sh_addr, sh_offset,
+             sh_size, sh_link, _sh_info, _sh_align,
+             sh_entsize) = struct.unpack(fmt, buf)
+        else:
+            (sh_name, sh_type, _sh_flags, _sh_addr, sh_offset,
+             sh_size, sh_link, _sh_info, _sh_align,
+             sh_entsize) = struct.unpack(fmt, buf)
+        out.append(_SectionHeader(
+            sh_name=sh_name, sh_type=sh_type,
+            sh_offset=sh_offset, sh_size=sh_size,
+            sh_link=sh_link, sh_entsize=sh_entsize,
+        ))
+        # Skip extra bytes if e_shentsize > record_size (rare;
+        # spec allows but no real ELF does this).
+        if e_shentsize > record_size:
+            f.read(e_shentsize - record_size)
+    return out
+
+
+def _read_section_bytes(f, sh: _SectionHeader) -> Optional[bytes]:
+    if sh.sh_size == 0:
+        return b""
+    # Sanity cap — 256 MB is way larger than any realistic
+    # section we'd want to read; bigger usually means malformed.
+    if sh.sh_size > 256 * 1024 * 1024:
+        return None
+    f.seek(sh.sh_offset)
+    data = f.read(sh.sh_size)
+    if len(data) < sh.sh_size:
+        return None
+    return data
+
+
+def _read_strtab_string(strtab: bytes, offset: int) -> str:
+    """Read a NUL-terminated string at ``offset`` in ``strtab``.
+    Returns ``""`` for any out-of-bounds / malformed input."""
+    if offset < 0 or offset >= len(strtab):
+        return ""
+    end = strtab.find(b"\x00", offset)
+    if end < 0:
+        end = len(strtab)
+    raw = strtab[offset:end]
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        # Tolerate non-UTF-8 symbol names — they exist in some
+        # binaries built with exotic toolchains. Replace
+        # un-decodable bytes; the symbol still matches the
+        # taxonomy buckets if it has any printable ASCII core.
+        return raw.decode("utf-8", errors="replace")
+
+
+def _read_dynsym_imports(
+    f, dynsym: _SectionHeader, dynstr_bytes: bytes,
+    *, bits: int, endian: str,
+) -> Set[str]:
+    """Walk ``.dynsym`` and collect undefined-section symbol
+    names (the imports)."""
+    if dynsym.sh_entsize == 0 or dynsym.sh_size == 0:
+        return set()
+    entries = dynsym.sh_size // dynsym.sh_entsize
+    if entries > _MAX_DYNSYM_ENTRIES:
+        return set()
+
+    # ELF64 sym: st_name(I) st_info(B) st_other(B) st_shndx(H)
+    #           st_value(Q) st_size(Q)  → 24 bytes
+    # ELF32 sym: st_name(I) st_value(I) st_size(I) st_info(B)
+    #           st_other(B) st_shndx(H) → 16 bytes
+    if bits == 64:
+        sym_fmt = endian + "IBBHQQ"
+    else:
+        sym_fmt = endian + "IIIBBH"
+    record_size = struct.calcsize(sym_fmt)
+    if dynsym.sh_entsize < record_size:
+        return set()
+
+    imports: Set[str] = set()
+    f.seek(dynsym.sh_offset)
+    for _ in range(entries):
+        buf = f.read(record_size)
+        if len(buf) < record_size:
+            break
+        if bits == 64:
+            (st_name, _st_info, _st_other, st_shndx,
+             _st_value, _st_size) = struct.unpack(sym_fmt, buf)
+        else:
+            (st_name, _st_value, _st_size, _st_info, _st_other,
+             st_shndx) = struct.unpack(sym_fmt, buf)
+        # Skip padding if entsize > record_size (rare)
+        if dynsym.sh_entsize > record_size:
+            f.read(dynsym.sh_entsize - record_size)
+        # SHN_UNDEF (0) = imported (satisfied by dynamic linker).
+        # Everything else is defined in some section of this
+        # binary — exported or local.
+        if st_shndx != _SHN_UNDEF:
+            continue
+        if st_name == 0:
+            continue
+        name = _read_strtab_string(dynstr_bytes, st_name)
+        if name:
+            imports.add(name)
+    return imports
+
+
+def _bare_metadata(e_machine: int, bits: int) -> ElfMetadata:
+    """Return metadata-only result (no imports). Used when the
+    section headers are malformed or absent — we can still
+    surface arch / bits / format from the ELF header alone."""
+    return ElfMetadata(
+        arch=_MACHINE_ARCH.get(e_machine, "unknown"),
+        bits=bits,
+        binary_format="elf",
+        imports=set(),
+    )
+
+
+__all__ = [
+    "ElfMetadata",
+    "parse_elf",
+]

--- a/core/binary/fingerprint.py
+++ b/core/binary/fingerprint.py
@@ -1,0 +1,360 @@
+"""Capability fingerprint for a single binary.
+
+A *fingerprint* is a small, stable, comparable JSON shape that
+summarises what a binary is capable of doing — its dangerous
+imports bucketed by capability family (exec / network / parser /
+etc.), plus binary metadata (arch / bits / format) and a content
+hash for the bytes.
+
+Two fingerprints with the same shape have the same capability
+surface; two with different shapes have different attack surfaces.
+The fingerprint is the primitive every higher-level capability-
+aware feature builds on:
+
+  * **Drift detection**: store last-seen fingerprint per image
+    ref; diff against fresh extraction on each scan.
+  * **CI gate**: assert all images' capability_buckets ⊆ allowed.
+  * **SBOM property**: embed alongside the image component for
+    audit / VEX context.
+  * **Bump finding evidence**: structured payload inside
+    ``SupplyChainFinding.evidence``.
+
+Scope boundary
+- The fingerprint is import-table-based only — it surfaces "what
+  is this binary capable of calling into" via the dynamic symbol
+  table. Cross-reference-aware analysis ("which of this binary's
+  own functions actually call into execve") requires
+  ``BinaryUnderstand`` from :mod:`packages.binary_analysis.
+  radare2_understand` and its expensive ``aaa`` step. That signal
+  has a different output shape and lives in a different
+  abstraction; the fingerprint primitive deliberately stays
+  cheap-to-compute substrate.
+
+The schema is versioned (``schema_version``). Bumps when adding
+fields that change diff semantics; consumers reject mismatched
+versions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple
+
+from core.function_taxonomy import (
+    ALLOC_FUNCS,
+    EXEC_FUNCS,
+    FORMAT_STRING_FUNCS,
+    INTEGER_PARSE_FUNCS,
+    MEMORY_COPY_FUNCS,
+    NETWORK_INGEST_FUNCS,
+    PARSER_FUNCS,
+    SCAN_FAMILY_FUNCS,
+    STRING_OVERFLOW_FUNCS,
+    TOCTOU_FUNCS,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Schema version. Bump when changing the meaning of any
+# fingerprint field. Consumers check this on read and refuse to
+# diff across versions (better to recompute than mis-attribute).
+FINGERPRINT_SCHEMA_VERSION = 1
+
+
+# Per-bucket capability classification. Single source of truth —
+# the SCA bump detector and any future capability-aware consumer
+# imports from here so the bucket names stay consistent across
+# fingerprints + findings + drift records.
+BUCKETS: Tuple[Tuple[str, FrozenSet[str]], ...] = (
+    ("exec", EXEC_FUNCS),
+    ("network", NETWORK_INGEST_FUNCS),
+    ("string_overflow", STRING_OVERFLOW_FUNCS),
+    ("scan", SCAN_FAMILY_FUNCS),
+    ("memory_copy", MEMORY_COPY_FUNCS),
+    ("format_string", FORMAT_STRING_FUNCS),
+    ("alloc", ALLOC_FUNCS),
+    ("parser", PARSER_FUNCS),
+    ("integer_parse", INTEGER_PARSE_FUNCS),
+    ("toctou", TOCTOU_FUNCS),
+)
+
+# Buckets that warrant high-severity treatment when they appear
+# as a NEW addition (drift detection, bump capability-delta).
+# ``exec`` is RCE-flavoured; ``network`` is exfil-flavoured.
+HIGH_SEVERITY_BUCKETS: FrozenSet[str] = frozenset({"exec", "network"})
+
+
+def bucket_imports(imports: Set[str]) -> Dict[str, Set[str]]:
+    """Classify an import set by capability bucket.
+
+    Returns ``{bucket_name: {fn1, fn2, ...}}`` for each bucket
+    with at least one matching entry. Imports outside the
+    high-CVE-density taxonomy buckets are intentionally dropped —
+    ubiquitous functions like ``malloc`` / ``printf`` / ``read``
+    aren't signal at fingerprint scale either.
+    """
+    out: Dict[str, Set[str]] = {}
+    for bucket_name, fn_set in BUCKETS:
+        matched = imports & fn_set
+        if matched:
+            out[bucket_name] = matched
+    return out
+
+
+@dataclass
+class CapabilityFingerprint:
+    """Stable snapshot of one binary's capability surface,
+    derived from its dynamic import table.
+
+    Serialised via :meth:`to_dict`; the dict is suitable for
+    direct JSON storage / SBOM property / diff comparison. Two
+    fingerprints with equal ``canonical_json()`` outputs are
+    capability-equivalent.
+
+    ``binary_sha256`` is the SHA-256 of the binary bytes — the
+    cryptographically strong content key. Two different bytes
+    with the same capability *shape* will still have different
+    ``binary_sha256``, which is the signal "this rebuild
+    changed bytes but didn't change capabilities" (acceptable
+    noise; suppressible in consumers).
+    """
+
+    schema_version: int
+    binary_path: str          # operator-facing only; not hashed
+    binary_sha256: str
+    arch: str
+    bits: int
+    binary_format: str        # 'elf' / 'mach-o' / 'pe'
+    capability_buckets: Dict[str, List[str]] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Full JSON-ready representation INCLUDING the
+        informational ``binary_path``. For storage / operator-
+        facing rendering / SBOM property. Use
+        :meth:`canonical_json` (which drops binary_path) for
+        comparison / hashing — two fingerprints of the same
+        bytes from different filesystem paths should compare
+        equal, and they will via canonical_json but won't via
+        to_dict."""
+        return {
+            "schema_version": self.schema_version,
+            "binary_path": self.binary_path,
+            "binary_sha256": self.binary_sha256,
+            "arch": self.arch,
+            "bits": self.bits,
+            "binary_format": self.binary_format,
+            "capability_buckets": {
+                k: sorted(v) for k, v in sorted(
+                    self.capability_buckets.items(),
+                )
+            },
+        }
+
+    def _comparison_dict(self) -> Dict[str, Any]:
+        """The fields that define identity for comparison / drift
+        detection. Excludes ``binary_path`` (legitimately varies
+        across machines / tempdirs for the same bytes)."""
+        d = self.to_dict()
+        d.pop("binary_path", None)
+        return d
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CapabilityFingerprint":
+        return cls(
+            schema_version=int(data.get("schema_version", 0)),
+            binary_path=str(data.get("binary_path", "")),
+            binary_sha256=str(data.get("binary_sha256", "")),
+            arch=str(data.get("arch", "")),
+            bits=int(data.get("bits", 0)),
+            binary_format=str(data.get("binary_format", "")),
+            capability_buckets={
+                str(k): list(v) for k, v in (
+                    data.get("capability_buckets") or {}
+                ).items()
+            },
+        )
+
+    def canonical_json(self) -> str:
+        """Stable bytes for content-hashing or eq-comparison
+        between fingerprints. Sorted keys, compact whitespace,
+        and EXCLUDES the informational ``binary_path`` so the
+        same binary bytes at two different filesystem paths
+        produce identical canonical_json (drift detection
+        depends on this — without it, comparing
+        ``/tmp/dl-abc/foo`` to ``/tmp/dl-xyz/foo`` for the
+        same image would always look like drift).
+        """
+        return json.dumps(
+            self._comparison_dict(),
+            sort_keys=True, separators=(",", ":"),
+        )
+
+
+def capability_fingerprint(
+    binary_path: Path,
+) -> Optional[CapabilityFingerprint]:
+    """Compute the capability fingerprint of ``binary_path``.
+
+    Tier dispatch:
+      1. Try :func:`core.binary.elf.parse_elf` — stdlib-only ELF
+         parser, sub-millisecond on typical binaries, no
+         external deps. Covers the operationally-common case
+         (Linux container binaries).
+      2. Fall back to ``analyse_binary_context`` (radare2,
+         quick mode) for PE / Mach-O / anything tier 0 can't
+         identify as ELF.
+      3. If neither tier works, return ``None``.
+
+    The fingerprint shape is tier-agnostic — fingerprints
+    produced by either tier compare bit-for-bit (the arch
+    taxonomy is aligned to radare2's family convention).
+
+    Returns ``None`` when:
+      * The binary can't be read (OSError)
+      * It's neither ELF nor analysable by radare2
+      * Radare2 is unavailable AND the binary isn't ELF
+
+    Operational consequence: on hosts WITHOUT r2pipe installed,
+    Linux ELF binaries still fingerprint successfully via
+    tier 0. Only PE / Mach-O require tier 1.
+    """
+    try:
+        content_hash = _sha256_of_file(binary_path)
+    except OSError as e:
+        logger.warning(
+            "core.binary.fingerprint: could not hash %s: %s",
+            binary_path, e,
+        )
+        return None
+
+    # Tier 0: native ELF parser.
+    fp = _fingerprint_via_elf(binary_path, content_hash)
+    if fp is not None:
+        return fp
+
+    # Tier 1: radare2 (covers PE / Mach-O + corrupted ELF
+    # the native parser couldn't handle).
+    return _fingerprint_via_radare2(binary_path, content_hash)
+
+
+def _fingerprint_via_elf(
+    binary_path: Path, content_hash: str,
+) -> Optional[CapabilityFingerprint]:
+    """Try the stdlib ELF parser. Returns ``None`` for non-ELF
+    inputs or unrecoverable parse failures — caller falls
+    through to tier 1."""
+    from core.binary.elf import parse_elf
+
+    meta = parse_elf(binary_path)
+    if meta is None:
+        return None
+    buckets = bucket_imports(meta.imports)
+    return CapabilityFingerprint(
+        schema_version=FINGERPRINT_SCHEMA_VERSION,
+        binary_path=str(binary_path),
+        binary_sha256=content_hash,
+        arch=meta.arch,
+        bits=meta.bits,
+        binary_format=meta.binary_format,
+        capability_buckets={k: list(v) for k, v in buckets.items()},
+    )
+
+
+def _fingerprint_via_radare2(
+    binary_path: Path, content_hash: str,
+) -> Optional[CapabilityFingerprint]:
+    """Tier 1 fallback. Used for PE / Mach-O and any input the
+    ELF parser couldn't identify. Returns ``None`` if radare2
+    isn't installed, or if the analyser couldn't extract any
+    meaningful signal from the file (empty bytes, unrecognised
+    format, etc.)."""
+    try:
+        from packages.binary_analysis.radare2_understand import (
+            analyse_binary_context,
+            probe_capability,
+        )
+    except ImportError:
+        logger.debug(
+            "core.binary.fingerprint: tier 0 didn't match and "
+            "radare2_understand not importable — no fingerprint",
+        )
+        return None
+
+    cap = probe_capability()
+    if not cap.get("available"):
+        logger.debug(
+            "core.binary.fingerprint: tier 0 didn't match and "
+            "radare2 stack unavailable (%s) — no fingerprint",
+            cap.get("reason", "<no reason>"),
+        )
+        return None
+
+    try:
+        ctx = analyse_binary_context(
+            binary_path,
+            max_strings=0,
+            max_decompile=0,
+            quick=True,
+        )
+    except Exception as e:                            # noqa: BLE001
+        logger.warning(
+            "core.binary.fingerprint: radare2 fallback failed "
+            "for %s: %s",
+            binary_path, e,
+        )
+        return None
+
+    # Empty file, unrecognised format, or anything radare2 opened
+    # but couldn't classify yields a fully-empty context. Reject
+    # — a fingerprint of "I have nothing to say about this file"
+    # only pollutes the fingerprint store (drift detection would
+    # match every unparseable file to every other one via the
+    # empty-string SHA isn't even unique once the file is empty).
+    if (not ctx.binary_format and not ctx.arch
+            and not ctx.imports):
+        logger.debug(
+            "core.binary.fingerprint: radare2 returned empty "
+            "context for %s — no fingerprint",
+            binary_path,
+        )
+        return None
+
+    buckets = bucket_imports(set(ctx.imports))
+    return CapabilityFingerprint(
+        schema_version=FINGERPRINT_SCHEMA_VERSION,
+        binary_path=str(binary_path),
+        binary_sha256=content_hash,
+        arch=ctx.arch,
+        bits=ctx.bits,
+        binary_format=ctx.binary_format,
+        capability_buckets={k: list(v) for k, v in buckets.items()},
+    )
+
+
+def _sha256_of_file(path: Path, *, chunk_size: int = 64 * 1024) -> str:
+    """Stream-hash a file. ``64KB`` chunks balance throughput vs
+    memory across small (binaries) + large (containers) inputs.
+    """
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(chunk_size)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+__all__ = [
+    "BUCKETS",
+    "CapabilityFingerprint",
+    "FINGERPRINT_SCHEMA_VERSION",
+    "HIGH_SEVERITY_BUCKETS",
+    "bucket_imports",
+    "capability_fingerprint",
+]

--- a/core/binary/fingerprint_store.py
+++ b/core/binary/fingerprint_store.py
@@ -55,7 +55,7 @@ import logging
 import os
 import tempfile
 from pathlib import Path
-from typing import Dict, Iterator, Optional, Tuple
+from typing import Iterator, Optional, Tuple
 
 from core.binary.fingerprint import CapabilityFingerprint
 

--- a/core/binary/fingerprint_store.py
+++ b/core/binary/fingerprint_store.py
@@ -1,0 +1,252 @@
+"""Persistent fingerprint store — substrate for drift detection.
+
+Maps ``ref`` (operator-visible identifier, typically an image
+ref like ``docker.io/library/alpine:3.18`` or a file path) to
+the most recently observed :class:`CapabilityFingerprint`.
+Stored on disk so subsequent scans can compare against the
+previous run's baseline.
+
+File layout
+-----------
+The store is a directory. One file per ref, named by SHA-256 of
+the ref string:
+
+::
+
+    <store_dir>/
+        sha256_abc.../...json     # one ref's most recent fingerprint
+        sha256_def.../...json     # another ref
+        ...
+
+The hashing avoids escaping pathologies in filenames (image refs
+contain ``/`` and ``:``); the original ref is recorded inside
+the file so :func:`iter_refs` can enumerate by ref, not by hash.
+
+Writes are atomic: tmp file + rename. A partial write never
+leaves the store inconsistent.
+
+File schema (versioned)
+-----------------------
+::
+
+    {
+        "schema_version": 1,
+        "ref": "<operator-visible identifier>",
+        "fingerprint": { ... CapabilityFingerprint.to_dict() ... }
+    }
+
+The fingerprint version (``schema_version`` inside the
+fingerprint dict) is checked separately by consumers; the store
+schema versions the wrapper around it.
+
+Error handling
+--------------
+All operations return ``None`` / ``[]`` on routine failure
+(missing file, corrupt JSON, permission denied). The store
+NEVER raises during scan-path use — a drift-detector that
+crashes on a corrupt entry would block scans.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Dict, Iterator, Optional, Tuple
+
+from core.binary.fingerprint import CapabilityFingerprint
+
+logger = logging.getLogger(__name__)
+
+
+# Bump when the WRAPPER format around the fingerprint changes
+# (not the fingerprint itself — that has its own version).
+STORE_SCHEMA_VERSION = 1
+
+
+def _ref_filename(ref: str) -> str:
+    """SHA-256 of the ref → safe filename. Hashing avoids
+    filename-escaping bugs across the variety of refs we'll see
+    (image refs with ``/`` and ``:`` and ``@``, file paths with
+    spaces, etc.)."""
+    digest = hashlib.sha256(ref.encode("utf-8")).hexdigest()
+    return f"{digest}.json"
+
+
+def save_fingerprint(
+    store_dir: Path, ref: str, fingerprint: CapabilityFingerprint,
+) -> Optional[Path]:
+    """Atomically write ``fingerprint`` to ``store_dir`` keyed
+    by ``ref``. Replaces any previous entry for the same ref.
+
+    Returns the written path, or None on any I/O failure
+    (logs at warning).
+    """
+    if not ref:
+        logger.debug(
+            "core.binary.fingerprint_store: empty ref; skipping write",
+        )
+        return None
+    try:
+        store_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        logger.warning(
+            "core.binary.fingerprint_store: mkdir failed for %s: %s",
+            store_dir, e,
+        )
+        return None
+
+    payload = {
+        "schema_version": STORE_SCHEMA_VERSION,
+        "ref": ref,
+        "fingerprint": fingerprint.to_dict(),
+    }
+    final_path = store_dir / _ref_filename(ref)
+    # Atomic write: tmp file in the same dir (so rename is on
+    # the same filesystem and stays atomic), then os.replace.
+    try:
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=".tmp-", suffix=".json", dir=store_dir,
+        )
+    except OSError as e:
+        logger.warning(
+            "core.binary.fingerprint_store: tempfile failed for %s: %s",
+            store_dir, e,
+        )
+        return None
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(payload, f, sort_keys=True, indent=2)
+        os.replace(tmp_name, final_path)
+    except OSError as e:
+        logger.warning(
+            "core.binary.fingerprint_store: write failed for %s: %s",
+            final_path, e,
+        )
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        return None
+    return final_path
+
+
+def load_fingerprint(
+    store_dir: Path, ref: str,
+) -> Optional[CapabilityFingerprint]:
+    """Load the most recently stored fingerprint for ``ref``.
+
+    Returns ``None`` when:
+      * No entry exists for that ref (first-ever scan of this
+        image — the drift detector treats this as "no baseline,
+        no drift signal yet").
+      * Store entry is corrupt / unreadable.
+      * Store schema version doesn't match — caller treats as
+        no-baseline rather than risking misinterpretation.
+    """
+    if not ref:
+        return None
+    file_path = store_dir / _ref_filename(ref)
+    if not file_path.is_file():
+        return None
+    try:
+        with open(file_path, "r") as f:
+            payload = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.debug(
+            "core.binary.fingerprint_store: load failed for %s: %s",
+            file_path, e,
+        )
+        return None
+    if not isinstance(payload, dict):
+        return None
+    version = payload.get("schema_version")
+    if version != STORE_SCHEMA_VERSION:
+        logger.debug(
+            "core.binary.fingerprint_store: schema version %s != %s "
+            "for %s; treating as no baseline",
+            version, STORE_SCHEMA_VERSION, file_path,
+        )
+        return None
+    fp_dict = payload.get("fingerprint")
+    if not isinstance(fp_dict, dict):
+        return None
+    try:
+        return CapabilityFingerprint.from_dict(fp_dict)
+    except (KeyError, TypeError, ValueError) as e:
+        logger.debug(
+            "core.binary.fingerprint_store: from_dict failed for "
+            "%s: %s", file_path, e,
+        )
+        return None
+
+
+def iter_refs(
+    store_dir: Path,
+) -> Iterator[Tuple[str, CapabilityFingerprint]]:
+    """Yield ``(ref, fingerprint)`` for every entry in the store.
+
+    Useful for store-wide audits / CI gates / drift-detection
+    reports. Skips entries that don't load cleanly (corrupt,
+    wrong schema version, etc.) — logs each skip at debug.
+    """
+    if not store_dir.is_dir():
+        return
+    for entry in sorted(store_dir.iterdir()):
+        if not entry.is_file() or not entry.name.endswith(".json"):
+            continue
+        if entry.name.startswith(".tmp-"):
+            # An in-flight atomic write left a tmp file behind
+            # (process killed mid-write). Skip silently — the
+            # final-named entry is what's load-bearing.
+            continue
+        try:
+            with open(entry, "r") as f:
+                payload = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("schema_version") != STORE_SCHEMA_VERSION:
+            continue
+        ref = payload.get("ref")
+        fp_dict = payload.get("fingerprint")
+        if not isinstance(ref, str) or not isinstance(fp_dict, dict):
+            continue
+        try:
+            fp = CapabilityFingerprint.from_dict(fp_dict)
+        except (KeyError, TypeError, ValueError):
+            continue
+        yield ref, fp
+
+
+def delete_fingerprint(store_dir: Path, ref: str) -> bool:
+    """Remove the entry for ``ref``. Returns True if a file was
+    removed, False if no entry existed. Useful for operators
+    invalidating a baseline manually."""
+    if not ref:
+        return False
+    file_path = store_dir / _ref_filename(ref)
+    if not file_path.is_file():
+        return False
+    try:
+        file_path.unlink()
+        return True
+    except OSError as e:
+        logger.warning(
+            "core.binary.fingerprint_store: delete failed for %s: %s",
+            file_path, e,
+        )
+        return False
+
+
+__all__ = [
+    "STORE_SCHEMA_VERSION",
+    "delete_fingerprint",
+    "iter_refs",
+    "load_fingerprint",
+    "save_fingerprint",
+]

--- a/core/binary/tests/test_capability_diff.py
+++ b/core/binary/tests/test_capability_diff.py
@@ -8,10 +8,20 @@ doesn't require r2pipe / radare2.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import List
 
 import pytest
+
+# parents[3] climbs:
+#   [0] core/binary/tests/  (this file's directory)
+#   [1] core/binary/
+#   [2] core/
+#   [3] <repo root>         (where ``packages/`` lives)
+_REPO_ROOT = str(Path(__file__).resolve().parents[3])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
 from core.binary.capability_diff import diff_binary_capabilities
 from core.binary.fingerprint import bucket_imports

--- a/core/binary/tests/test_capability_diff.py
+++ b/core/binary/tests/test_capability_diff.py
@@ -13,10 +13,7 @@ from typing import List
 
 import pytest
 
-from core.binary.capability_diff import (
-    CapabilityDelta,
-    diff_binary_capabilities,
-)
+from core.binary.capability_diff import diff_binary_capabilities
 from core.binary.fingerprint import bucket_imports
 from packages.binary_analysis.radare2_understand import (
     BinaryContextMap,

--- a/core/binary/tests/test_capability_diff.py
+++ b/core/binary/tests/test_capability_diff.py
@@ -1,0 +1,236 @@
+"""Tests for ``core.binary.capability_diff``.
+
+The diff primitive compares two binaries' capability surfaces via
+:func:`core.binary.fingerprint.bucket_imports` over each binary's
+import table. Tests stub ``analyse_binary_context`` so the suite
+doesn't require r2pipe / radare2.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from core.binary.capability_diff import (
+    CapabilityDelta,
+    diff_binary_capabilities,
+)
+from core.binary.fingerprint import bucket_imports
+from packages.binary_analysis.radare2_understand import (
+    BinaryContextMap,
+)
+
+
+def _ctx(path, *, imports: List[str]) -> BinaryContextMap:
+    """Build a minimal BinaryContextMap with the supplied imports.
+    The diff primitive only reads ``ctx.imports``; metadata
+    defaults are fine."""
+    return BinaryContextMap(
+        binary_path=Path(path),
+        arch="x86", bits=64, binary_format="elf",
+        imports=list(imports),
+    )
+
+
+def _make_non_elf_file(path: Path, content: bytes = b"stub-bytes") -> Path:
+    """Create a real on-disk file that is NOT ELF — defeats the
+    tier-0 ELF parser so tier-1 (the stubbed radare2) is reached.
+    Also gives ``_sha256_of_file`` something to hash so
+    ``capability_fingerprint`` doesn't bail on OSError."""
+    path.write_bytes(content)
+    return path
+
+
+@pytest.fixture
+def patched_analyser(monkeypatch, tmp_path):
+    """Replace ``analyse_binary_context`` + ``probe_capability``
+    on the radare2 module so tests drive the substrate without
+    r2pipe. Yields a state dict with an ``add_binary(name, imports)``
+    helper that creates a real (non-ELF) file at ``tmp_path/name``
+    AND registers its stubbed analyse output, returning the Path.
+    """
+    state = {"available": True, "ctxs": {}}
+
+    def fake_analyse(path: Path, **kwargs):
+        if path in state["ctxs"]:
+            return state["ctxs"][path]
+        raise FileNotFoundError(f"no stub for {path}")
+
+    def fake_probe():
+        return {"available": state["available"], "reason": "stub"}
+
+    monkeypatch.setattr(
+        "packages.binary_analysis.radare2_understand."
+        "analyse_binary_context",
+        fake_analyse,
+    )
+    monkeypatch.setattr(
+        "packages.binary_analysis.radare2_understand.probe_capability",
+        fake_probe,
+    )
+
+    def add_binary(name: str, *, imports: List[str]) -> Path:
+        p = _make_non_elf_file(tmp_path / name)
+        state["ctxs"][p] = _ctx(name, imports=imports)
+        return p
+
+    state["add_binary"] = add_binary
+    yield state
+
+
+# ---------------------------------------------------------------------------
+# bucket_imports — substrate classification
+# ---------------------------------------------------------------------------
+
+
+class TestBucketImports:
+    def test_exec_imports_classified(self):
+        out = bucket_imports({"execve", "popen", "fread"})
+        assert "exec" in out
+        assert "execve" in out["exec"]
+        assert "popen" in out["exec"]
+        # fread is not in any high-CVE bucket
+        assert "fread" not in {
+            fn for fns in out.values() for fn in fns
+        }
+
+    def test_network_imports_classified(self):
+        out = bucket_imports({"recv", "accept", "bind"})
+        assert "network" in out
+        assert out["network"] >= {"recv", "accept", "bind"}
+
+    def test_string_overflow_classified(self):
+        out = bucket_imports({"strcpy", "strcat", "gets"})
+        assert "string_overflow" in out
+
+    def test_ubiquitous_imports_dropped(self):
+        """``malloc`` / ``printf`` / ``read`` aren't in the
+        high-CVE-density taxonomy. Bucket map empty."""
+        assert bucket_imports({"malloc", "printf", "read"}) == {}
+
+
+# ---------------------------------------------------------------------------
+# diff_binary_capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestDiffBinaryCapabilities:
+    def test_no_change_returns_empty_delta(self, patched_analyser):
+        """Same imports in both → empty delta (not None).
+        Callers distinguish 'couldn't compare' (None) from 'no
+        change' (empty delta)."""
+        cur = patched_analyser["add_binary"](
+            "cur.bin", imports=["strcpy", "recv"],
+        )
+        tgt = patched_analyser["add_binary"](
+            "tgt.bin", imports=["strcpy", "recv"],
+        )
+        delta = diff_binary_capabilities(cur, tgt)
+        assert delta is not None
+        assert delta.is_empty()
+
+    def test_new_exec_capability_high_severity(self, patched_analyser):
+        """Target adds ``execve`` → ``high_severity()`` True."""
+        cur = patched_analyser["add_binary"](
+            "cur.bin", imports=["strcpy"],
+        )
+        tgt = patched_analyser["add_binary"](
+            "tgt.bin", imports=["strcpy", "execve"],
+        )
+        delta = diff_binary_capabilities(cur, tgt)
+        assert delta is not None
+        assert not delta.is_empty()
+        assert "exec" in delta.new_dangerous_imports
+        assert delta.new_dangerous_imports["exec"] == ["execve"]
+        assert delta.high_severity() is True
+
+    def test_new_network_capability_high_severity(self, patched_analyser):
+        cur = patched_analyser["add_binary"](
+            "cur.bin", imports=["malloc"],
+        )
+        tgt = patched_analyser["add_binary"](
+            "tgt.bin", imports=["malloc", "recv", "accept"],
+        )
+        delta = diff_binary_capabilities(cur, tgt)
+        assert delta is not None
+        assert "network" in delta.new_dangerous_imports
+        assert delta.high_severity() is True
+
+    def test_new_string_overflow_only_medium_severity(self, patched_analyser):
+        """Adding a non-exec / non-network bucket doesn't escalate."""
+        cur = patched_analyser["add_binary"](
+            "cur.bin", imports=["malloc"],
+        )
+        tgt = patched_analyser["add_binary"](
+            "tgt.bin", imports=["malloc", "strcpy"],
+        )
+        delta = diff_binary_capabilities(cur, tgt)
+        assert delta is not None
+        assert "string_overflow" in delta.new_dangerous_imports
+        assert delta.high_severity() is False
+
+    def test_removed_capabilities_ignored(self, patched_analyser):
+        """Bumps that drop dangerous capabilities aren't flagged
+        — those are usually security improvements."""
+        cur = patched_analyser["add_binary"](
+            "cur.bin", imports=["strcpy", "execve"],
+        )
+        tgt = patched_analyser["add_binary"](
+            "tgt.bin", imports=["strcpy"],
+        )
+        delta = diff_binary_capabilities(cur, tgt)
+        assert delta is not None
+        assert delta.is_empty()
+
+    def test_radare2_unavailable_returns_none(self, patched_analyser, tmp_path):
+        """When the tier-0 ELF parser doesn't match AND radare2
+        is unavailable, no fingerprint, no diff."""
+        patched_analyser["available"] = False
+        # Create non-ELF files so ELF parser bails to tier 1
+        cur = tmp_path / "cur.bin"
+        tgt = tmp_path / "tgt.bin"
+        cur.write_bytes(b"not-elf")
+        tgt.write_bytes(b"not-elf")
+        out = diff_binary_capabilities(cur, tgt)
+        assert out is None
+
+    def test_current_analyse_failure_returns_none(
+        self, patched_analyser, tmp_path,
+    ):
+        """``cur`` has no analyser stub → both tier-0 (non-ELF)
+        and tier-1 (FileNotFoundError) fail → None."""
+        cur = tmp_path / "cur_unstubbed.bin"
+        cur.write_bytes(b"not-elf")
+        tgt = patched_analyser["add_binary"](
+            "tgt.bin", imports=["execve"],
+        )
+        out = diff_binary_capabilities(cur, tgt)
+        assert out is None
+
+    def test_target_analyse_failure_returns_none(
+        self, patched_analyser, tmp_path,
+    ):
+        cur = patched_analyser["add_binary"](
+            "cur.bin", imports=["strcpy"],
+        )
+        tgt = tmp_path / "tgt_unstubbed.bin"
+        tgt.write_bytes(b"not-elf")
+        out = diff_binary_capabilities(cur, tgt)
+        assert out is None
+
+    def test_multiple_added_buckets(self, patched_analyser):
+        cur = patched_analyser["add_binary"](
+            "cur.bin", imports=["malloc"],
+        )
+        tgt = patched_analyser["add_binary"](
+            "tgt.bin",
+            imports=["malloc", "execve", "recv", "strcpy"],
+        )
+        delta = diff_binary_capabilities(cur, tgt)
+        assert delta is not None
+        assert set(delta.added_buckets()) >= {
+            "exec", "network", "string_overflow",
+        }
+        assert delta.high_severity() is True

--- a/core/binary/tests/test_drift.py
+++ b/core/binary/tests/test_drift.py
@@ -11,8 +11,6 @@ additions only) because the consumer questions differ:
 
 from __future__ import annotations
 
-import pytest
-
 from core.binary.drift import FingerprintDrift, detect_drift
 from core.binary.fingerprint import CapabilityFingerprint
 

--- a/core/binary/tests/test_drift.py
+++ b/core/binary/tests/test_drift.py
@@ -1,0 +1,214 @@
+"""Tests for ``core.binary.drift``.
+
+The drift primitive compares two fingerprints bidirectionally
+— additions + removals + metadata shifts. Distinct from
+``capability_diff`` (which is unidirectional: target-over-current
+additions only) because the consumer questions differ:
+
+  * Bump capability-delta: "what does the proposed bump ADD"
+  * Drift detection: "what CHANGED since we last saw this image"
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.binary.drift import FingerprintDrift, detect_drift
+from core.binary.fingerprint import CapabilityFingerprint
+
+
+def _fp(*, sha="abc", arch="x86", bits=64,
+        binary_format="elf", buckets=None) -> CapabilityFingerprint:
+    """Build a minimal fingerprint with sensible defaults."""
+    return CapabilityFingerprint(
+        schema_version=1,
+        binary_path="/test",
+        binary_sha256=sha,
+        arch=arch, bits=bits, binary_format=binary_format,
+        capability_buckets=buckets or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Identity case
+# ---------------------------------------------------------------------------
+
+
+class TestNoChange:
+    def test_same_fingerprint_no_drift(self):
+        a = _fp(sha="abc", buckets={"exec": ["execve"]})
+        b = _fp(sha="abc", buckets={"exec": ["execve"]})
+        drift = detect_drift(a, b)
+        assert drift.is_empty()
+        assert not drift.hash_changed
+        assert drift.new_buckets == {}
+        assert drift.removed_buckets == {}
+
+    def test_same_bytes_different_capability_short_circuits(self):
+        """If binary_sha256 matches, drift is empty by definition
+        regardless of bucket differences (which would only happen
+        if the fingerprint primitive itself was inconsistent —
+        the short-circuit defends against that)."""
+        a = _fp(sha="abc", buckets={"exec": ["execve"]})
+        b = _fp(sha="abc", buckets={})  # would be weird, but
+        drift = detect_drift(a, b)
+        assert drift.is_empty()
+        assert not drift.hash_changed
+
+
+# ---------------------------------------------------------------------------
+# Capability additions
+# ---------------------------------------------------------------------------
+
+
+class TestAdditions:
+    def test_new_bucket_added(self):
+        prev = _fp(sha="A", buckets={"alloc": ["calloc"]})
+        cur = _fp(sha="B", buckets={
+            "alloc": ["calloc"], "exec": ["execve"],
+        })
+        drift = detect_drift(prev, cur)
+        assert not drift.is_empty()
+        assert drift.hash_changed
+        assert drift.new_buckets == {"exec": ["execve"]}
+        assert drift.removed_buckets == {}
+        assert drift.high_severity()
+        assert drift.added_buckets() == ["exec"]
+
+    def test_bucket_expanded(self):
+        """Bucket already present in previous; new entries added.
+        Should still surface as a 'new' addition (per-entry, not
+        per-bucket)."""
+        prev = _fp(sha="A", buckets={"exec": ["execve"]})
+        cur = _fp(sha="B", buckets={"exec": ["execve", "popen"]})
+        drift = detect_drift(prev, cur)
+        assert drift.new_buckets == {"exec": ["popen"]}
+        assert drift.high_severity()
+
+    def test_high_severity_only_for_exec_or_network(self):
+        """Adding string_overflow alone isn't high severity —
+        the ladder reserves high for exec/network adds."""
+        prev = _fp(sha="A", buckets={})
+        cur = _fp(sha="B", buckets={"string_overflow": ["strcpy"]})
+        drift = detect_drift(prev, cur)
+        assert not drift.is_empty()
+        assert not drift.high_severity()
+
+
+# ---------------------------------------------------------------------------
+# Capability removals
+# ---------------------------------------------------------------------------
+
+
+class TestRemovals:
+    def test_bucket_dropped(self):
+        prev = _fp(sha="A", buckets={"exec": ["execve"]})
+        cur = _fp(sha="B", buckets={})
+        drift = detect_drift(prev, cur)
+        assert not drift.is_empty()
+        assert drift.removed_buckets == {"exec": ["execve"]}
+        # Drops don't trigger high severity
+        assert not drift.high_severity()
+        assert drift.removed_bucket_names() == ["exec"]
+
+    def test_bucket_partially_shrunk(self):
+        """Some entries kept, others dropped — only the dropped
+        ones surface."""
+        prev = _fp(sha="A", buckets={"exec": ["execve", "popen"]})
+        cur = _fp(sha="B", buckets={"exec": ["execve"]})
+        drift = detect_drift(prev, cur)
+        assert drift.removed_buckets == {"exec": ["popen"]}
+        assert drift.new_buckets == {}
+
+
+# ---------------------------------------------------------------------------
+# Simultaneous add + remove
+# ---------------------------------------------------------------------------
+
+
+class TestSimultaneous:
+    def test_add_and_remove(self):
+        """Real bumps often add AND drop — e.g. a rebuild that
+        switches between two libraries that provide different
+        capability surfaces."""
+        prev = _fp(sha="A", buckets={
+            "string_overflow": ["strcpy"],
+            "alloc": ["calloc"],
+        })
+        cur = _fp(sha="B", buckets={
+            "alloc": ["calloc"],
+            "exec": ["execve"],
+            "network": ["recv"],
+        })
+        drift = detect_drift(prev, cur)
+        assert drift.added_buckets() == ["exec", "network"]
+        assert drift.removed_bucket_names() == ["string_overflow"]
+        assert drift.high_severity()
+
+
+# ---------------------------------------------------------------------------
+# Metadata-level changes
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataChanges:
+    def test_arch_change_surfaced(self):
+        """A re-tagged image that switches arch is a strong
+        signal — operators likely didn't expect cross-arch
+        substitution."""
+        prev = _fp(sha="A", arch="x86", bits=64)
+        cur = _fp(sha="B", arch="arm", bits=64)
+        drift = detect_drift(prev, cur)
+        assert drift.arch_changed
+        assert not drift.is_empty()
+
+    def test_bits_change_surfaced(self):
+        prev = _fp(sha="A", arch="x86", bits=64)
+        cur = _fp(sha="B", arch="x86", bits=32)
+        drift = detect_drift(prev, cur)
+        assert drift.bits_changed
+        assert not drift.is_empty()
+
+    def test_format_change_surfaced(self):
+        """ELF → Mach-O on the same ref would be a deep red flag
+        (someone repackaged the artifact)."""
+        prev = _fp(sha="A", binary_format="elf")
+        cur = _fp(sha="B", binary_format="mach-o")
+        drift = detect_drift(prev, cur)
+        assert drift.format_changed
+        assert not drift.is_empty()
+
+    def test_unchanged_metadata_not_flagged(self):
+        prev = _fp(sha="A", arch="x86", bits=64, binary_format="elf")
+        cur = _fp(sha="B", arch="x86", bits=64, binary_format="elf")
+        drift = detect_drift(prev, cur)
+        assert not drift.arch_changed
+        assert not drift.bits_changed
+        assert not drift.format_changed
+
+
+# ---------------------------------------------------------------------------
+# Empty-state semantics
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyState:
+    def test_empty_drift_object(self):
+        d = FingerprintDrift()
+        assert d.is_empty()
+        assert not d.high_severity()
+        assert d.added_buckets() == []
+        assert d.removed_bucket_names() == []
+
+    def test_hash_changed_alone_not_empty(self):
+        """Bytes-different but capabilities-equivalent IS empty
+        drift — the hash change is implicit in any meaningful
+        drift, but bytes-only changes (legitimate rebuilds) are
+        deliberately suppressed."""
+        prev = _fp(sha="A", buckets={"exec": ["execve"]})
+        cur = _fp(sha="B", buckets={"exec": ["execve"]})
+        drift = detect_drift(prev, cur)
+        # hash_changed is True, but no buckets / metadata
+        # changed → is_empty() True
+        assert drift.hash_changed
+        assert drift.is_empty()

--- a/core/binary/tests/test_elf.py
+++ b/core/binary/tests/test_elf.py
@@ -19,10 +19,7 @@ from pathlib import Path
 
 import pytest
 
-from core.binary.elf import (
-    ElfMetadata,
-    parse_elf,
-)
+from core.binary.elf import parse_elf
 
 
 # ---------------------------------------------------------------------------

--- a/core/binary/tests/test_elf.py
+++ b/core/binary/tests/test_elf.py
@@ -1,0 +1,381 @@
+"""Tests for ``core.binary.elf`` — stdlib ELF import-table parser.
+
+The parser is the tier-0 fast path for the capability fingerprint
+primitive. Correctness target: produce the same import set
+``radare2`` does, in ~1ms vs ~1s. Tests cover:
+
+  * Header parsing (32-bit + 64-bit, both endianness modes)
+  * Negative cases (non-ELF, empty, truncated, malformed)
+  * Real-binary parse (gated on host availability)
+  * Cross-validation against radare2 (gated on r2pipe)
+  * Adversarial: oversized fields, broken section headers,
+    extended-section-index (SHN_XINDEX) unsupported
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+import pytest
+
+from core.binary.elf import (
+    ElfMetadata,
+    parse_elf,
+)
+
+
+# ---------------------------------------------------------------------------
+# Negative cases
+# ---------------------------------------------------------------------------
+
+
+class TestNegativeCases:
+    def test_nonexistent_path(self, tmp_path):
+        assert parse_elf(tmp_path / "missing") is None
+
+    def test_empty_file(self, tmp_path):
+        p = tmp_path / "empty"
+        p.write_bytes(b"")
+        assert parse_elf(p) is None
+
+    def test_text_file_not_elf(self, tmp_path):
+        p = tmp_path / "notelf.txt"
+        p.write_bytes(b"this is not an ELF binary, just text\n" * 50)
+        assert parse_elf(p) is None
+
+    def test_truncated_after_magic(self, tmp_path):
+        """File starts with ELF magic but is too short to be a
+        real header. Parser bails cleanly."""
+        p = tmp_path / "truncated.bin"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        # Magic matches but rest is zeros — e_shnum=0, no sections.
+        # Parser should return metadata-only or None; either is OK.
+        out = parse_elf(p)
+        # With zero section count, we return bare metadata (just
+        # the metadata; no imports). e_machine=0 maps to "unknown".
+        if out is not None:
+            assert out.binary_format == "elf"
+            assert out.imports == set()
+
+    def test_bad_ei_class(self, tmp_path):
+        """ei_class outside {1, 2} → reject."""
+        p = tmp_path / "badclass.bin"
+        header = bytearray(b"\x7fELF")
+        header.append(99)             # ei_class — invalid
+        header.extend(b"\x00" * 11)   # rest of e_ident
+        header.extend(b"\x00" * 100)  # padding so we don't 0-read
+        p.write_bytes(bytes(header))
+        assert parse_elf(p) is None
+
+    def test_bad_ei_data(self, tmp_path):
+        """ei_data outside {1, 2} → reject."""
+        p = tmp_path / "baddata.bin"
+        header = bytearray(b"\x7fELF")
+        header.append(2)              # ei_class = 64-bit
+        header.append(99)             # ei_data — invalid
+        header.extend(b"\x00" * 10)
+        header.extend(b"\x00" * 100)
+        p.write_bytes(bytes(header))
+        assert parse_elf(p) is None
+
+    def test_pe_binary_rejected(self, tmp_path):
+        """A PE binary starts with MZ, not 7f ELF. Reject."""
+        p = tmp_path / "fake.exe"
+        # MZ header + DOS stub
+        p.write_bytes(b"MZ\x90\x00" + b"\x00" * 200)
+        assert parse_elf(p) is None
+
+
+# ---------------------------------------------------------------------------
+# Real-binary tests — gated on host availability
+# ---------------------------------------------------------------------------
+
+
+class TestRealBinaryParse:
+    @pytest.fixture(autouse=True)
+    def _require_elf_host(self):
+        """All tests in this class need a Linux-shaped host with
+        /bin/ls. macOS test runners (Mach-O coreutils) skip."""
+        if not Path("/bin/ls").exists():
+            pytest.skip("/bin/ls not present on host")
+
+    def test_parse_bin_ls(self):
+        """Parser doesn't crash on a real binary; the metadata
+        + imports come back populated."""
+        meta = parse_elf(Path("/bin/ls"))
+        assert meta is not None
+        assert meta.binary_format == "elf"
+        assert meta.bits in (32, 64)
+        assert meta.arch != ""
+        # /bin/ls dynamically links libc — should have at least
+        # a handful of imports
+        assert len(meta.imports) > 10
+
+    def test_parse_bin_ls_fast(self):
+        """Sub-50ms — generous bound that still catches a
+        regression to the slow path."""
+        import time
+        t0 = time.perf_counter()
+        meta = parse_elf(Path("/bin/ls"))
+        elapsed = time.perf_counter() - t0
+        assert meta is not None
+        assert elapsed < 0.05, (
+            f"native ELF parser took {elapsed*1000:.1f}ms — "
+            f"suggests regression to a non-stdlib path"
+        )
+
+    def test_idempotent(self):
+        """Same binary parsed twice → identical metadata.
+        Drift detection prerequisite."""
+        a = parse_elf(Path("/bin/ls"))
+        b = parse_elf(Path("/bin/ls"))
+        assert a is not None and b is not None
+        assert a.arch == b.arch
+        assert a.bits == b.bits
+        assert a.binary_format == b.binary_format
+        assert a.imports == b.imports
+
+    def test_libc_imports_present(self):
+        """Coreutils binaries link against glibc — typical libc
+        symbols should appear. Doesn't pin specific symbols
+        (varies across distros) but checks the parser actually
+        extracts something libc-shaped."""
+        meta = parse_elf(Path("/bin/ls"))
+        assert meta is not None
+        # ANY one of these — libc symbol names vary by version
+        # but at least one always appears in glibc binaries.
+        libc_indicators = {
+            "malloc", "free", "exit", "abort", "memcpy",
+            "strlen", "strcmp", "write", "read", "open",
+            "fprintf", "printf", "fopen", "fclose",
+        }
+        assert meta.imports & libc_indicators, (
+            f"no libc-shaped imports found in /bin/ls — parser "
+            f"likely missed .dynsym. Sample: "
+            f"{sorted(meta.imports)[:10]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cross-validation against radare2 — gated on r2pipe
+# ---------------------------------------------------------------------------
+
+
+class TestRadare2Parity:
+    @pytest.fixture(autouse=True)
+    def _require_radare2(self):
+        from packages.binary_analysis.radare2_understand import (
+            probe_capability,
+        )
+        if not probe_capability().get("available"):
+            pytest.skip("radare2 stack not available")
+        if not Path("/bin/ls").exists():
+            pytest.skip("/bin/ls not present")
+
+    def test_imports_match_radare2_ls(self):
+        """Native ELF parser must produce the exact same import
+        set as radare2's ``iij`` for /bin/ls. Any divergence is
+        a parser bug (or a r2 bug; bias is our parser)."""
+        from packages.binary_analysis.radare2_understand import (
+            analyse_binary_context,
+        )
+        elf = parse_elf(Path("/bin/ls"))
+        ctx = analyse_binary_context(
+            Path("/bin/ls"), max_strings=0, max_decompile=0,
+            quick=True,
+        )
+        assert elf is not None
+        assert elf.imports == set(ctx.imports), (
+            f"diverged from radare2:\n"
+            f"  only in elf parser: "
+            f"{sorted(elf.imports - set(ctx.imports))[:10]}\n"
+            f"  only in radare2:    "
+            f"{sorted(set(ctx.imports) - elf.imports)[:10]}"
+        )
+
+    def test_arch_matches_radare2_ls(self):
+        from packages.binary_analysis.radare2_understand import (
+            analyse_binary_context,
+        )
+        elf = parse_elf(Path("/bin/ls"))
+        ctx = analyse_binary_context(
+            Path("/bin/ls"), max_strings=0, max_decompile=0,
+            quick=True,
+        )
+        assert elf is not None
+        assert elf.arch == ctx.arch
+        assert elf.bits == ctx.bits
+        assert elf.binary_format == ctx.binary_format
+
+
+# ---------------------------------------------------------------------------
+# Adversarial header-level probes
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarialHeaders:
+    """Hand-crafted invalid / malicious headers — parser must
+    return None or bare metadata without crashing."""
+
+    def test_max_shnum_capped(self, tmp_path):
+        """e_shnum at its uint16 max with no real section data —
+        parser should return None or bare metadata rather than
+        burning through 4MB of zero bytes pretending they're
+        valid section headers."""
+        p = tmp_path / "max_shnum.elf"
+        header = bytearray()
+        header.extend(b"\x7fELF\x02\x01\x01\x00")
+        header.extend(b"\x00" * 8)
+        header.extend(struct.pack(
+            "<HHIQQQIHHHHHH",
+            0x02,            # e_type
+            0x3E,            # e_machine x86_64
+            1, 0, 0,
+            64,              # e_shoff = right after header
+            0, 64, 0, 0,
+            64,              # e_shentsize
+            0xFFFF,          # e_shnum = uint16 max
+            0xFFFE,          # e_shstrndx — definitely out of range
+        ))
+        p.write_bytes(bytes(header))
+        out = parse_elf(p)
+        # Either None or bare metadata is acceptable here; the
+        # invariant is "no crash, no fake imports".
+        if out is not None:
+            assert out.imports == set()
+
+    def test_shoff_zero_returns_bare_metadata(self, tmp_path):
+        """e_shoff=0 → no section header table → can't enumerate
+        imports but we can still surface arch / bits."""
+        p = tmp_path / "no_sections.elf"
+        header = bytearray()
+        header.extend(b"\x7fELF\x02\x01\x01\x00")
+        header.extend(b"\x00" * 8)
+        header.extend(struct.pack(
+            "<HHIQQQIHHHHHH",
+            0x02, 0x3E, 1, 0, 0,
+            0,    # e_shoff = 0
+            0, 64, 0, 0, 64, 0, 0,
+        ))
+        p.write_bytes(bytes(header))
+        out = parse_elf(p)
+        assert out is not None
+        assert out.binary_format == "elf"
+        assert out.bits == 64
+        assert out.arch == "x86"        # x86 family, bits=64 → x86_64
+        assert out.imports == set()
+
+    def test_shstrndx_out_of_bounds(self, tmp_path):
+        """e_shstrndx pointing past available sections → bail
+        cleanly with bare metadata (still know arch + bits)."""
+        p = tmp_path / "bad_shstrndx.elf"
+        header = bytearray()
+        header.extend(b"\x7fELF\x02\x01\x01\x00")
+        header.extend(b"\x00" * 8)
+        header.extend(struct.pack(
+            "<HHIQQQIHHHHHH",
+            0x02, 0xB7, 1, 0, 0,       # arm64
+            64, 0, 64, 0, 0, 64, 0,
+            0xFFFE,                     # e_shstrndx — huge
+        ))
+        p.write_bytes(bytes(header))
+        out = parse_elf(p)
+        assert out is not None
+        assert out.arch == "arm"        # arm family, bits=64 → aarch64
+        assert out.bits == 64
+        assert out.imports == set()
+
+
+# ---------------------------------------------------------------------------
+# Endianness + bit-width coverage via synthesised minimal headers
+# ---------------------------------------------------------------------------
+
+
+class TestHeaderShapeCoverage:
+    """Confirm the parser handles all four (32/64) × (LE/BE)
+    combinations of the ELF header. We craft minimal headers
+    that hit the bail-out path (no section headers) so we don't
+    have to build a full synthetic ELF — the point is to prove
+    the header parsing branches correctly route by class+data."""
+
+    def _build_minimal(
+        self, *, bits: int, little_endian: bool,
+        e_machine: int = 0x3E,
+    ) -> bytes:
+        ei_class = 2 if bits == 64 else 1
+        ei_data = 1 if little_endian else 2
+        endian = "<" if little_endian else ">"
+        e_ident = bytes([
+            0x7F, 0x45, 0x4C, 0x46,    # magic
+            ei_class, ei_data,
+            1,                          # version
+            0,                          # OS ABI
+        ]) + b"\x00" * 8
+        if bits == 64:
+            rest = struct.pack(
+                endian + "HHIQQQIHHHHHH",
+                0x02, e_machine, 1, 0, 0,
+                0,    # e_shoff = 0 → no sections
+                0, 64, 0, 0, 64, 0, 0,
+            )
+        else:
+            rest = struct.pack(
+                endian + "HHIIIIIHHHHHH",
+                0x02, e_machine, 1, 0, 0,
+                0,    # e_shoff = 0
+                0, 52, 0, 0, 40, 0, 0,
+            )
+        return e_ident + rest
+
+    def test_elf64_little_endian(self, tmp_path):
+        p = tmp_path / "elf64le.elf"
+        p.write_bytes(self._build_minimal(
+            bits=64, little_endian=True, e_machine=0x3E,
+        ))
+        out = parse_elf(p)
+        assert out is not None
+        # ``arch`` is the family, ``bits`` disambiguates word
+        # size — radare2's convention, mirrored here.
+        assert out.arch == "x86"
+        assert out.bits == 64
+
+    def test_elf64_big_endian(self, tmp_path):
+        p = tmp_path / "elf64be.elf"
+        p.write_bytes(self._build_minimal(
+            bits=64, little_endian=False, e_machine=0x15,   # ppc64
+        ))
+        out = parse_elf(p)
+        assert out is not None
+        assert out.arch == "ppc"
+        assert out.bits == 64
+
+    def test_elf32_little_endian(self, tmp_path):
+        p = tmp_path / "elf32le.elf"
+        p.write_bytes(self._build_minimal(
+            bits=32, little_endian=True, e_machine=0x03,    # i386
+        ))
+        out = parse_elf(p)
+        assert out is not None
+        assert out.arch == "x86"
+        assert out.bits == 32
+
+    def test_elf32_big_endian(self, tmp_path):
+        p = tmp_path / "elf32be.elf"
+        p.write_bytes(self._build_minimal(
+            bits=32, little_endian=False, e_machine=0x28,   # arm BE
+        ))
+        out = parse_elf(p)
+        assert out is not None
+        assert out.arch == "arm"
+        assert out.bits == 32
+
+    def test_unknown_machine_falls_back_to_unknown_arch(self, tmp_path):
+        """e_machine not in our table → arch == 'unknown'."""
+        p = tmp_path / "weird.elf"
+        p.write_bytes(self._build_minimal(
+            bits=64, little_endian=True, e_machine=0xDEAD,
+        ))
+        out = parse_elf(p)
+        assert out is not None
+        assert out.arch == "unknown"

--- a/core/binary/tests/test_fingerprint.py
+++ b/core/binary/tests/test_fingerprint.py
@@ -17,9 +17,19 @@ The full radare2 wire-through is gated by ``probe_capability``
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
+
+# parents[3] climbs:
+#   [0] core/binary/tests/  (this file's directory)
+#   [1] core/binary/
+#   [2] core/
+#   [3] <repo root>         (where ``packages/`` lives)
+_REPO_ROOT = str(Path(__file__).resolve().parents[3])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
 from core.binary.fingerprint import (
     BUCKETS,

--- a/core/binary/tests/test_fingerprint.py
+++ b/core/binary/tests/test_fingerprint.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import List
 
 import pytest
 

--- a/core/binary/tests/test_fingerprint.py
+++ b/core/binary/tests/test_fingerprint.py
@@ -1,0 +1,497 @@
+"""Tests for ``core.binary.fingerprint``.
+
+The fingerprint primitive wraps ``analyse_binary_context`` to
+produce a stable, comparable capability snapshot from the
+dynamic import table. Tests cover:
+
+  * Bucket classification via the shared taxonomy
+  * Stable JSON serialisation (sorted, no whitespace variance)
+  * Round-trip dict ↔ dataclass
+  * Content-hash computation
+  * Graceful degradation: radare2 unavailable, analyser fail
+
+The full radare2 wire-through is gated by ``probe_capability``
+— tests use stubs so the suite doesn't require r2pipe.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from core.binary.fingerprint import (
+    BUCKETS,
+    CapabilityFingerprint,
+    FINGERPRINT_SCHEMA_VERSION,
+    HIGH_SEVERITY_BUCKETS,
+    bucket_imports,
+    capability_fingerprint,
+)
+from packages.binary_analysis.radare2_understand import (
+    BinaryContextMap,
+)
+
+
+# ---------------------------------------------------------------------------
+# bucket_imports — bucket classification
+# ---------------------------------------------------------------------------
+
+
+class TestBucketImports:
+    def test_exec_imports_classified(self):
+        out = bucket_imports({"execve", "popen", "fread"})
+        assert "exec" in out
+        assert out["exec"] == {"execve", "popen"}
+
+    def test_ubiquitous_imports_dropped(self):
+        """``malloc`` / ``printf`` / ``read`` aren't in any
+        high-CVE bucket — return empty."""
+        assert bucket_imports({"malloc", "printf", "read"}) == {}
+
+    def test_multiple_buckets(self):
+        out = bucket_imports({"execve", "recv", "strcpy"})
+        assert "exec" in out
+        assert "network" in out
+        assert "string_overflow" in out
+
+    def test_empty_input_empty_output(self):
+        assert bucket_imports(set()) == {}
+
+
+class TestBucketTaxonomy:
+    """The BUCKETS table is shared between fingerprint + SCA bump
+    detector — these tests pin its shape so a tiny refactor in
+    one consumer doesn't silently change the other."""
+
+    def test_all_bucket_names_present(self):
+        names = [b[0] for b in BUCKETS]
+        assert names == [
+            "exec", "network", "string_overflow", "scan",
+            "memory_copy", "format_string", "alloc", "parser",
+            "integer_parse", "toctou",
+        ]
+
+    def test_high_severity_buckets_subset_of_buckets(self):
+        bucket_names = {b[0] for b in BUCKETS}
+        assert HIGH_SEVERITY_BUCKETS <= bucket_names
+
+
+# ---------------------------------------------------------------------------
+# CapabilityFingerprint serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestFingerprintSerialisation:
+    def test_to_dict_stable_ordering(self):
+        """Same fingerprint → same to_dict output regardless of
+        insertion order of internal dicts / lists. Needed for
+        content-hash-based dedup."""
+        fp1 = CapabilityFingerprint(
+            schema_version=1,
+            binary_path="/x", binary_sha256="abc",
+            arch="x86_64", bits=64, binary_format="elf",
+            capability_buckets={"exec": ["execve", "popen"],
+                                  "network": ["recv"]},
+        )
+        fp2 = CapabilityFingerprint(
+            schema_version=1,
+            binary_path="/x", binary_sha256="abc",
+            arch="x86_64", bits=64, binary_format="elf",
+            capability_buckets={"network": ["recv"],
+                                  "exec": ["popen", "execve"]},
+        )
+        assert fp1.to_dict() == fp2.to_dict()
+        assert fp1.canonical_json() == fp2.canonical_json()
+
+    def test_canonical_json_no_whitespace_variance(self):
+        fp = CapabilityFingerprint(
+            schema_version=1,
+            binary_path="/x", binary_sha256="abc",
+            arch="x86_64", bits=64, binary_format="elf",
+            capability_buckets={"exec": ["execve"]},
+        )
+        out = fp.canonical_json()
+        # Compact: no whitespace around separators
+        assert ": " not in out
+        assert ", " not in out
+        # Parses back to a dict (the comparison view — see
+        # test_canonical_json_excludes_binary_path below).
+        parsed = json.loads(out)
+        assert "binary_path" not in parsed
+        # Every other field present
+        for k in ("schema_version", "binary_sha256", "arch", "bits",
+                  "binary_format", "capability_buckets"):
+            assert k in parsed
+
+    def test_canonical_json_excludes_binary_path(self):
+        """ADVERSARIAL REGRESSION: same binary bytes at two
+        different filesystem paths must produce identical
+        canonical_json. Including binary_path would create
+        false drift signals between CI / local runs / different
+        extraction tempdirs.
+        """
+        kwargs = dict(
+            schema_version=1, binary_sha256="abc",
+            arch="x86_64", bits=64, binary_format="elf",
+            capability_buckets={"exec": ["execve"]},
+        )
+        fp_a = CapabilityFingerprint(
+            binary_path="/usr/bin/foo", **kwargs,
+        )
+        fp_b = CapabilityFingerprint(
+            binary_path="/tmp/dl-xyz/foo", **kwargs,
+        )
+        assert fp_a.canonical_json() == fp_b.canonical_json()
+        # to_dict() does include binary_path (operator-facing
+        # rendering / SBOM property) — that's intentional and
+        # they differ there
+        assert fp_a.to_dict() != fp_b.to_dict()
+        assert fp_a.to_dict()["binary_path"] == "/usr/bin/foo"
+        assert fp_b.to_dict()["binary_path"] == "/tmp/dl-xyz/foo"
+
+    def test_from_dict_roundtrip(self):
+        fp = CapabilityFingerprint(
+            schema_version=1,
+            binary_path="/x", binary_sha256="abc",
+            arch="x86_64", bits=64, binary_format="elf",
+            capability_buckets={"exec": ["execve"]},
+        )
+        restored = CapabilityFingerprint.from_dict(fp.to_dict())
+        assert restored.to_dict() == fp.to_dict()
+
+    def test_schema_version_in_dict(self):
+        fp = CapabilityFingerprint(
+            schema_version=FINGERPRINT_SCHEMA_VERSION,
+            binary_path="/x", binary_sha256="abc",
+            arch="x86_64", bits=64, binary_format="elf",
+        )
+        d = fp.to_dict()
+        assert d["schema_version"] == FINGERPRINT_SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# capability_fingerprint — full path with stubbed analyser
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_analyser(monkeypatch):
+    """Replace ``analyse_binary_context`` + ``probe_capability``
+    on the radare2 module so tests can drive the fingerprint
+    primitive without r2pipe."""
+    state = {"available": True, "ctx": None, "raise": None}
+
+    def fake_probe():
+        return {"available": state["available"], "reason": "stub"}
+
+    def fake_analyse(path, **kwargs):
+        if state["raise"] is not None:
+            raise state["raise"]
+        return state["ctx"]
+
+    monkeypatch.setattr(
+        "packages.binary_analysis.radare2_understand.probe_capability",
+        fake_probe,
+    )
+    monkeypatch.setattr(
+        "packages.binary_analysis.radare2_understand.analyse_binary_context",
+        fake_analyse,
+    )
+    yield state
+
+
+def _real_bytes_tempfile(tmp_path: Path, name: str, content: bytes) -> Path:
+    """Write a file we can actually SHA-256 — fingerprint needs
+    real bytes for the content hash."""
+    out = tmp_path / name
+    out.write_bytes(content)
+    return out
+
+
+class TestCapabilityFingerprint:
+    def test_full_path_returns_fingerprint(
+        self, patched_analyser, tmp_path,
+    ):
+        bin_path = _real_bytes_tempfile(
+            tmp_path, "test.bin", b"\x7fELF\x00\x01" * 50,
+        )
+        patched_analyser["ctx"] = BinaryContextMap(
+            binary_path=bin_path,
+            arch="x86_64", bits=64, binary_format="elf",
+            imports=["execve", "recv", "malloc", "printf"],
+        )
+        fp = capability_fingerprint(bin_path)
+        assert fp is not None
+        assert fp.schema_version == FINGERPRINT_SCHEMA_VERSION
+        assert fp.arch == "x86_64"
+        assert fp.bits == 64
+        assert fp.binary_format == "elf"
+        assert "exec" in fp.capability_buckets
+        assert "network" in fp.capability_buckets
+        assert "malloc" not in {
+            fn for fns in fp.capability_buckets.values() for fn in fns
+        }
+        # Real bytes → real hash, 64 hex chars
+        assert len(fp.binary_sha256) == 64
+        assert all(c in "0123456789abcdef" for c in fp.binary_sha256)
+
+    def test_same_bytes_same_hash(
+        self, patched_analyser, tmp_path,
+    ):
+        """Two files with identical bytes produce identical
+        ``binary_sha256``. Drift detection depends on this
+        property — same image-content → same fingerprint."""
+        ctx_a = BinaryContextMap(
+            binary_path=Path("/a"),
+            arch="x86_64", bits=64, binary_format="elf",
+            imports=["execve"],
+        )
+        ctx_b = BinaryContextMap(
+            binary_path=Path("/b"),
+            arch="x86_64", bits=64, binary_format="elf",
+            imports=["execve"],
+        )
+        bin_a = _real_bytes_tempfile(
+            tmp_path, "a.bin", b"identical bytes",
+        )
+        bin_b = _real_bytes_tempfile(
+            tmp_path, "b.bin", b"identical bytes",
+        )
+        patched_analyser["ctx"] = ctx_a
+        fp_a = capability_fingerprint(bin_a)
+        patched_analyser["ctx"] = ctx_b
+        fp_b = capability_fingerprint(bin_b)
+        assert fp_a.binary_sha256 == fp_b.binary_sha256
+
+    def test_radare2_unavailable_returns_none(
+        self, patched_analyser, tmp_path,
+    ):
+        patched_analyser["available"] = False
+        bin_path = _real_bytes_tempfile(tmp_path, "x", b"bytes")
+        assert capability_fingerprint(bin_path) is None
+
+    def test_analyse_exception_returns_none(
+        self, patched_analyser, tmp_path,
+    ):
+        patched_analyser["raise"] = RuntimeError("parse failed")
+        bin_path = _real_bytes_tempfile(tmp_path, "x", b"bytes")
+        assert capability_fingerprint(bin_path) is None
+
+    def test_missing_file_returns_none(self, patched_analyser):
+        """File doesn't exist → SHA-256 read fails → None."""
+        patched_analyser["ctx"] = BinaryContextMap(
+            binary_path=Path("/nope"), arch="x86_64", bits=64,
+            binary_format="elf", imports=[],
+        )
+        assert capability_fingerprint(Path("/does/not/exist")) is None
+
+    def test_empty_capabilities_still_emits_fingerprint(
+        self, patched_analyser, tmp_path,
+    ):
+        """Binary with NO dangerous imports → fingerprint with
+        empty ``capability_buckets``. That's a valid baseline —
+        means 'this binary doesn't do anything dangerous we
+        recognise' and is the safest snapshot. The analyser MUST
+        still have identified arch / format though — that's how
+        we distinguish "real binary, no dangerous caps" from
+        "unparseable garbage" (the latter returns None)."""
+        bin_path = _real_bytes_tempfile(tmp_path, "x", b"safe")
+        patched_analyser["ctx"] = BinaryContextMap(
+            binary_path=bin_path,
+            arch="x86", bits=64, binary_format="elf",
+            imports=["malloc", "free", "printf"],   # all ubiquitous
+        )
+        fp = capability_fingerprint(bin_path)
+        assert fp is not None
+        assert fp.capability_buckets == {}
+
+    def test_unparseable_input_returns_none(
+        self, patched_analyser, tmp_path,
+    ):
+        """ADVERSARIAL REGRESSION: empty file / corrupt input
+        used to return a fingerprint with all-empty fields and
+        the SHA-256 of the empty string. That's not a usable
+        fingerprint — drift detection would match every
+        unparseable file to every other one. Now both tiers
+        must produce SOME signal (arch OR binary_format OR
+        imports) for capability_fingerprint to return non-None."""
+        empty_path = _real_bytes_tempfile(tmp_path, "empty", b"")
+        # Stub analyser returns context with no arch / format /
+        # imports — simulating radare2's behaviour on an empty
+        # file. The primitive should reject this.
+        patched_analyser["ctx"] = BinaryContextMap(
+            binary_path=empty_path,
+            arch="", bits=0, binary_format="",
+            imports=[],
+        )
+        fp = capability_fingerprint(empty_path)
+        assert fp is None
+
+    def test_empty_file_doesnt_crash(self, patched_analyser, tmp_path):
+        """ADVERSARIAL: empty file — primitive shouldn't crash.
+        Both tiers fail to extract any signal; primitive returns
+        None per the corrected contract (see
+        ``test_unparseable_input_returns_none`` above for the
+        full regression detail)."""
+        bin_path = _real_bytes_tempfile(tmp_path, "empty", b"")
+        patched_analyser["ctx"] = BinaryContextMap(
+            binary_path=bin_path,
+            arch="", bits=0, binary_format="",
+            imports=[],
+        )
+        # No crash, returns None.
+        assert capability_fingerprint(bin_path) is None
+
+    def test_large_file_streams_without_oom(
+        self, patched_analyser, tmp_path,
+    ):
+        """ADVERSARIAL: 10MB file. The SHA-256 streamer must
+        chunk; loading the whole binary into memory would OOM
+        on container images. 10MB is small enough to be cheap
+        in CI but big enough to detect a regression where
+        someone replaces the chunked read with ``read()``.
+        """
+        bin_path = _real_bytes_tempfile(
+            tmp_path, "big.bin", b"x" * (10 * 1024 * 1024),
+        )
+        patched_analyser["ctx"] = BinaryContextMap(
+            binary_path=bin_path, arch="x86_64", bits=64,
+            binary_format="elf", imports=[],
+        )
+        fp = capability_fingerprint(bin_path)
+        assert fp is not None
+        assert len(fp.binary_sha256) == 64
+
+    def test_symlink_follows_to_real_bytes(
+        self, patched_analyser, tmp_path,
+    ):
+        """ADVERSARIAL: symlink → SHA-256 hashes the TARGET's
+        bytes, not the symlink itself. Matters for OCI layer
+        extraction which can place busybox-style symlinks for
+        all commands; we want the actual binary's fingerprint.
+        """
+        import os
+        real = _real_bytes_tempfile(tmp_path, "real.bin", b"target")
+        link = tmp_path / "link.bin"
+        os.symlink(real, link)
+        patched_analyser["ctx"] = BinaryContextMap(
+            binary_path=real, arch="x86_64", bits=64,
+            binary_format="elf", imports=[],
+        )
+        fp = capability_fingerprint(link)
+        assert fp is not None
+        # Hash should be the target's bytes
+        import hashlib
+        assert fp.binary_sha256 == hashlib.sha256(b"target").hexdigest()
+
+    def test_non_ascii_imports_dont_crash(self):
+        """ADVERSARIAL: imports with non-ASCII names (rare; could
+        come from a corrupted analyse pass or a hostile binary).
+        Bucket lookup just ignores them — they don't match any
+        taxonomy entry."""
+        out = bucket_imports({"execve", "réalloc", "🍕", "popen"})
+        assert "exec" in out
+        # ASCII matches captured; non-ASCII ignored
+        assert out["exec"] == {"execve", "popen"}
+
+
+# ---------------------------------------------------------------------------
+# Real-binary integration — gated on radare2 + r2pipe availability
+# ---------------------------------------------------------------------------
+
+
+class TestRealBinaryFingerprint:
+    """End-to-end via radare2. Skipped on hosts without
+    r2pipe (probe_capability returns available=False). Each
+    test asserts the quick-mode path is fast enough to run
+    in a unit-test budget (was 5+ minutes per binary before
+    quick mode was added)."""
+
+    @pytest.fixture(autouse=True)
+    def _gate(self):
+        from packages.binary_analysis.radare2_understand import (
+            probe_capability,
+        )
+        cap = probe_capability()
+        if not cap.get("available"):
+            pytest.skip(f"radare2 stack not available: {cap}")
+
+    def test_quick_fingerprint_of_bin_ls(self):
+        """Fingerprint ``/bin/ls`` in quick mode. Asserts the
+        primitive completes in well under a minute (quick mode
+        skips the expensive ``aaa`` step). Default mode took
+        5+ minutes — far too slow to live in the unit suite."""
+        import time
+        ls = Path("/bin/ls")
+        if not ls.exists():
+            pytest.skip("/bin/ls not present on host")
+        t0 = time.time()
+        fp = capability_fingerprint(ls)
+        elapsed = time.time() - t0
+        assert fp is not None
+        # Be generous — 30s leaves headroom for slow CI runners
+        # while still catching a regression to the multi-minute
+        # default-pipeline path.
+        assert elapsed < 30, (
+            f"quick fingerprint took {elapsed:.1f}s — likely "
+            f"regressed to the full-analysis pipeline"
+        )
+        # Sanity-check the fingerprint shape
+        assert fp.schema_version == FINGERPRINT_SCHEMA_VERSION
+        assert fp.binary_format in ("elf", "elf64", "elf32",
+                                       "mach0", "mach-o", "pe")
+        assert len(fp.binary_sha256) == 64
+
+    def test_buckets_populated(self):
+        """Fingerprint populates ``capability_buckets`` from the
+        binary's imports. ``ls`` imports common libc functions —
+        at minimum it should fingerprint cleanly even if no
+        bucket matches (a clean baseline IS a valid fingerprint)."""
+        ls = Path("/bin/ls")
+        if not ls.exists():
+            pytest.skip("/bin/ls not present on host")
+        fp = capability_fingerprint(ls)
+        assert fp is not None
+        assert isinstance(fp.capability_buckets, dict)
+
+    def test_same_binary_idempotent(self):
+        """Fingerprinting the same path twice produces identical
+        ``canonical_json``. Drift detection depends on this —
+        if quick-mode runs were non-deterministic, every scan
+        would flag drift."""
+        ls = Path("/bin/ls")
+        if not ls.exists():
+            pytest.skip("/bin/ls not present on host")
+        fp_a = capability_fingerprint(ls)
+        fp_b = capability_fingerprint(ls)
+        assert fp_a is not None
+        assert fp_b is not None
+        assert fp_a.canonical_json() == fp_b.canonical_json()
+
+
+# ---------------------------------------------------------------------------
+# Cross-consumer parity — bucket helpers shared with SCA bump detector
+# ---------------------------------------------------------------------------
+
+
+class TestSharedTaxonomyParity:
+    """The SCA bump capability-delta wrapper and the substrate
+    capability_diff module both import the bucket taxonomy from
+    this module. Lock that there's a single source of truth — a
+    future accidental re-definition in either consumer would
+    silently fork bucket semantics."""
+
+    def test_capability_diff_imports_same_BUCKETS(self):
+        from core.binary import capability_diff as cdmod
+        from core.binary.fingerprint import BUCKETS as fp_BUCKETS
+        assert cdmod.BUCKETS is fp_BUCKETS
+
+    def test_capability_diff_imports_same_bucket_imports(self):
+        from core.binary import capability_diff as cdmod
+        from core.binary.fingerprint import (
+            bucket_imports as fp_bucket_imports,
+        )
+        assert cdmod.bucket_imports is fp_bucket_imports

--- a/core/binary/tests/test_fingerprint_store.py
+++ b/core/binary/tests/test_fingerprint_store.py
@@ -1,0 +1,226 @@
+"""Tests for ``core.binary.fingerprint_store``.
+
+Substrate for drift detection: persist fingerprints keyed by
+ref, load them back, enumerate the store, handle corrupt /
+missing / schema-skew gracefully.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.binary.fingerprint import CapabilityFingerprint
+from core.binary.fingerprint_store import (
+    STORE_SCHEMA_VERSION,
+    delete_fingerprint,
+    iter_refs,
+    load_fingerprint,
+    save_fingerprint,
+)
+
+
+def _fp(*, sha="abc", arch="x86", bits=64,
+        buckets=None) -> CapabilityFingerprint:
+    return CapabilityFingerprint(
+        schema_version=1,
+        binary_path="/test",
+        binary_sha256=sha, arch=arch, bits=bits,
+        binary_format="elf",
+        capability_buckets=buckets or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Roundtrip — save + load
+# ---------------------------------------------------------------------------
+
+
+class TestSaveLoad:
+    def test_save_then_load_returns_same_fingerprint(self, tmp_path):
+        fp = _fp(sha="A", buckets={"exec": ["execve"]})
+        ref = "docker.io/library/alpine:3.18"
+        written = save_fingerprint(tmp_path, ref, fp)
+        assert written is not None
+        assert written.is_file()
+        loaded = load_fingerprint(tmp_path, ref)
+        assert loaded is not None
+        # canonical_json is the comparable representation
+        assert loaded.canonical_json() == fp.canonical_json()
+
+    def test_load_missing_ref_returns_none(self, tmp_path):
+        assert load_fingerprint(tmp_path, "never-seen") is None
+
+    def test_load_from_empty_store_returns_none(self, tmp_path):
+        # Don't even create the store dir
+        empty = tmp_path / "nonexistent"
+        assert load_fingerprint(empty, "ref") is None
+
+    def test_save_creates_store_dir(self, tmp_path):
+        """First save creates the store directory; operators
+        shouldn't need to mkdir up-front."""
+        store = tmp_path / "fingerprints"
+        assert not store.exists()
+        save_fingerprint(store, "ref", _fp())
+        assert store.is_dir()
+
+    def test_overwrite_existing_entry(self, tmp_path):
+        """Re-saving the same ref replaces the previous entry."""
+        ref = "x"
+        save_fingerprint(tmp_path, ref, _fp(sha="A"))
+        save_fingerprint(tmp_path, ref, _fp(sha="B"))
+        loaded = load_fingerprint(tmp_path, ref)
+        assert loaded.binary_sha256 == "B"
+
+    def test_empty_ref_skipped(self, tmp_path):
+        """Empty ref is rejected — defends against accidental
+        writes to a wildcard slot."""
+        assert save_fingerprint(tmp_path, "", _fp()) is None
+        assert load_fingerprint(tmp_path, "") is None
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicWrite:
+    def test_no_partial_state_after_save(self, tmp_path):
+        """After save_fingerprint returns, the file is either
+        fully-formed or absent. No half-written JSON visible."""
+        save_fingerprint(tmp_path, "ref", _fp())
+        files = list(tmp_path.iterdir())
+        assert len(files) == 1
+        assert files[0].name.endswith(".json")
+        # File is parseable JSON
+        with open(files[0]) as f:
+            data = json.load(f)
+        assert data["ref"] == "ref"
+
+    def test_tmp_files_filtered_from_iter_refs(self, tmp_path):
+        """A leftover ``.tmp-*.json`` file (process killed
+        mid-write) doesn't pollute iter_refs."""
+        # Simulate the leftover
+        leftover = tmp_path / ".tmp-abc.json"
+        leftover.write_text('{"some": "data"}')
+        save_fingerprint(tmp_path, "real", _fp())
+        refs = list(iter_refs(tmp_path))
+        assert len(refs) == 1
+        assert refs[0][0] == "real"
+
+
+# ---------------------------------------------------------------------------
+# Enumeration
+# ---------------------------------------------------------------------------
+
+
+class TestIterRefs:
+    def test_empty_store(self, tmp_path):
+        assert list(iter_refs(tmp_path)) == []
+
+    def test_missing_store_dir(self, tmp_path):
+        assert list(iter_refs(tmp_path / "nope")) == []
+
+    def test_multiple_refs(self, tmp_path):
+        save_fingerprint(tmp_path, "ref-a", _fp(sha="A"))
+        save_fingerprint(tmp_path, "ref-b", _fp(sha="B"))
+        save_fingerprint(tmp_path, "ref-c", _fp(sha="C"))
+        refs = dict(iter_refs(tmp_path))
+        assert set(refs.keys()) == {"ref-a", "ref-b", "ref-c"}
+
+    def test_iter_skips_corrupt_entries(self, tmp_path):
+        """Corrupt JSON / missing fields / wrong schema_version
+        → skipped silently. Doesn't crash the iteration; doesn't
+        emit a bogus ref."""
+        save_fingerprint(tmp_path, "good", _fp(sha="A"))
+        # Write corrupt entry
+        (tmp_path / "deadbeef.json").write_text("not json")
+        # Write wrong-schema entry
+        (tmp_path / "cafebabe.json").write_text(json.dumps({
+            "schema_version": 999,
+            "ref": "wrong-schema",
+            "fingerprint": {},
+        }))
+        refs = dict(iter_refs(tmp_path))
+        assert "good" in refs
+        assert "wrong-schema" not in refs
+        assert len(refs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Schema versioning
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaVersioning:
+    def test_mismatched_schema_load_returns_none(self, tmp_path):
+        """A future-schema entry is treated as "no baseline" —
+        better to recompute than misinterpret across version
+        skew."""
+        save_fingerprint(tmp_path, "ref", _fp())
+        # Tamper: bump schema version to a future value
+        file_path = next(tmp_path.glob("*.json"))
+        with open(file_path) as f:
+            data = json.load(f)
+        data["schema_version"] = STORE_SCHEMA_VERSION + 100
+        with open(file_path, "w") as f:
+            json.dump(data, f)
+        assert load_fingerprint(tmp_path, "ref") is None
+
+
+# ---------------------------------------------------------------------------
+# Deletion
+# ---------------------------------------------------------------------------
+
+
+class TestDelete:
+    def test_delete_existing(self, tmp_path):
+        save_fingerprint(tmp_path, "ref", _fp())
+        assert delete_fingerprint(tmp_path, "ref") is True
+        assert load_fingerprint(tmp_path, "ref") is None
+
+    def test_delete_missing(self, tmp_path):
+        assert delete_fingerprint(tmp_path, "ref") is False
+
+    def test_delete_empty_ref(self, tmp_path):
+        """Empty ref → no-op (defends against accidentally
+        deleting the wrong slot)."""
+        save_fingerprint(tmp_path, "real-ref", _fp())
+        assert delete_fingerprint(tmp_path, "") is False
+        assert load_fingerprint(tmp_path, "real-ref") is not None
+
+
+# ---------------------------------------------------------------------------
+# Filename safety
+# ---------------------------------------------------------------------------
+
+
+class TestFilenameSafety:
+    def test_ref_with_slashes_and_colons(self, tmp_path):
+        """Image refs contain ``/`` and ``:``. The filename
+        scheme hashes the ref to avoid filesystem escaping."""
+        ref = "docker.io/library/alpine:3.18@sha256:abcdef"
+        save_fingerprint(tmp_path, ref, _fp())
+        loaded = load_fingerprint(tmp_path, ref)
+        assert loaded is not None
+        # No subdirs created — filename is flat
+        files = list(tmp_path.iterdir())
+        assert len(files) == 1
+        # No problematic chars in the filename
+        assert "/" not in files[0].name
+        assert ":" not in files[0].name
+
+    def test_ref_with_traversal_pathologies(self, tmp_path):
+        """Refs with ``..`` / ``/`` can't escape the store
+        directory — the hash scheme makes path-traversal
+        impossible."""
+        ref = "../../../etc/passwd"
+        save_fingerprint(tmp_path, ref, _fp())
+        # File is INSIDE tmp_path
+        files = list(tmp_path.iterdir())
+        assert len(files) == 1
+        assert files[0].parent == tmp_path
+        # And loadable
+        assert load_fingerprint(tmp_path, ref) is not None

--- a/core/binary/tests/test_fingerprint_store.py
+++ b/core/binary/tests/test_fingerprint_store.py
@@ -8,9 +8,6 @@ missing / schema-skew gracefully.
 from __future__ import annotations
 
 import json
-from pathlib import Path
-
-import pytest
 
 from core.binary.fingerprint import CapabilityFingerprint
 from core.binary.fingerprint_store import (

--- a/core/llm/tests/test_dispatcher_startup_loud.py
+++ b/core/llm/tests/test_dispatcher_startup_loud.py
@@ -21,18 +21,22 @@ from __future__ import annotations
 
 import importlib
 import io
-import os
 import sys
 from contextlib import redirect_stderr
+from pathlib import Path
 from unittest import mock
 
 import pytest
 
 
-# Wire RAPTOR onto sys.path the same way other test modules do.
-_RAPTOR_DIR = os.environ["RAPTOR_DIR"]
-if _RAPTOR_DIR not in sys.path:
-    sys.path.insert(0, _RAPTOR_DIR)
+# parents[3] climbs:
+#   [0] core/llm/tests/  (this file's directory)
+#   [1] core/llm/
+#   [2] core/
+#   [3] <repo root>
+_REPO_ROOT = str(Path(__file__).resolve().parents[3])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
 
 @pytest.fixture

--- a/core/startup/tests/test_cli_smoke.py
+++ b/core/startup/tests/test_cli_smoke.py
@@ -19,7 +19,6 @@ duplicate the existing ``compileall`` step in ``.github/workflows/tests.yml``.
 
 from __future__ import annotations
 
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -27,7 +26,12 @@ from pathlib import Path
 import pytest
 
 
-REPO_ROOT = Path(os.environ["RAPTOR_DIR"])
+# parents[3] climbs:
+#   [0] core/startup/tests/  (this file's directory)
+#   [1] core/startup/
+#   [2] core/
+#   [3] <repo root>
+REPO_ROOT = Path(__file__).resolve().parents[3]
 RAPTOR_PY = REPO_ROOT / "raptor.py"
 
 

--- a/packages/autonomous/tests/test_raptor_agentic_wrapper.py
+++ b/packages/autonomous/tests/test_raptor_agentic_wrapper.py
@@ -7,7 +7,12 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 
-REPO_ROOT = Path(os.environ["RAPTOR_DIR"])
+# parents[3] climbs:
+#   [0] packages/autonomous/tests/  (this file's directory)
+#   [1] packages/autonomous/
+#   [2] packages/
+#   [3] <repo root>
+REPO_ROOT = Path(__file__).resolve().parents[3]
 WRAPPER = REPO_ROOT / "libexec" / "raptor-agentic"
 
 

--- a/packages/binary_analysis/radare2_understand.py
+++ b/packages/binary_analysis/radare2_understand.py
@@ -332,11 +332,27 @@ class BinaryUnderstand:
         self,
         max_decompile: int = 20,
         max_strings: int = 100,
+        quick: bool = False,
     ) -> BinaryContextMap:
         """Run the full analysis pipeline.
 
         max_decompile bounds the number of high-priority functions we ask
         the decompiler for, since decompilation is the slowest step.
+
+        ``quick=True`` skips radare2's ``aaa`` (full auto-analysis)
+        and every step that depends on it: function enumeration,
+        cross-reference tagging, transitive callers, decompilation,
+        prioritisation. Only ``_extract_metadata`` + ``_extract_
+        imports_exports`` run — both work on the static binary
+        without analysis. Use when the caller just needs arch /
+        format + the import list (capability fingerprinting, bump
+        capability-delta), not the cross-ref-derived dangerous_
+        sinks / interesting_functions. Order of magnitude faster
+        on typical binaries (single-digit seconds vs minutes for
+        ``/bin/ls``). ``ctx.dangerous_sinks`` and
+        ``ctx.interesting_functions`` come back empty under
+        quick mode — callers that need them must run the full
+        pipeline.
         """
         import os as _os
         import tempfile as _tempfile
@@ -406,23 +422,35 @@ class BinaryUnderstand:
                     else:
                         _os.environ[k] = v
                 _saved_env = {}  # already restored — finally skips re-restore
-            self._cmd_t(r2, "aaa", self._T_AAA)    # full auto-analysis
-            self._extract_metadata(r2, ctx)
-            self._extract_imports_exports(r2, ctx)
-            self._extract_functions(r2, ctx)
-            self._extract_entry_points(ctx)
-            self._extract_strings(r2, ctx, limit=max_strings)
-            self._tag_dangerous_callers(r2, ctx)
-            # Transitive analysis MUST follow _tag_dangerous_callers
-            # because it reads ctx.dangerous_sinks for the BFS seed
-            # set, and adds transitively_reaches_dangerous /
-            # transitive_distance fields used by the prioritise step.
-            self._tag_transitive_callers(r2, ctx)
-            self._decompile_priorities(r2, ctx, limit=max_decompile)
-            if self.llm:
-                self._llm_prioritise(ctx)
+            if quick:
+                # Fast path: metadata + imports only. Both queries
+                # (``ij`` / ``iij``) read the static binary headers
+                # without needing radare2's analysis pass. Skip
+                # ``aaa`` and every downstream step that depends
+                # on the call graph or function inventory.
+                self._extract_metadata(r2, ctx)
+                self._extract_imports_exports(r2, ctx)
             else:
-                self._heuristic_prioritise(ctx)
+                self._cmd_t(r2, "aaa", self._T_AAA)
+                self._extract_metadata(r2, ctx)
+                self._extract_imports_exports(r2, ctx)
+                self._extract_functions(r2, ctx)
+                self._extract_entry_points(ctx)
+                self._extract_strings(r2, ctx, limit=max_strings)
+                self._tag_dangerous_callers(r2, ctx)
+                # Transitive analysis MUST follow _tag_dangerous_
+                # callers because it reads ctx.dangerous_sinks for
+                # the BFS seed set, and adds transitively_reaches_
+                # dangerous / transitive_distance fields used by
+                # the prioritise step.
+                self._tag_transitive_callers(r2, ctx)
+                self._decompile_priorities(
+                    r2, ctx, limit=max_decompile,
+                )
+                if self.llm:
+                    self._llm_prioritise(ctx)
+                else:
+                    self._heuristic_prioritise(ctx)
         finally:
             if r2 is not None:
                 try:
@@ -955,16 +983,26 @@ def analyse_binary_context(
     llm=None,
     max_decompile: int = 20,
     max_strings: int = 100,
+    quick: bool = False,
 ) -> BinaryContextMap:
     """Run radare2 analysis and optionally persist the context map.
 
     This is the shared entry point other RAPTOR commands should use instead
     of depending on fuzzing internals.
+
+    ``quick=True`` skips ``aaa`` + every analysis-dependent step
+    (function enumeration, cross-refs, transitive callers,
+    decompilation, prioritisation). Use when the caller only
+    needs arch / format + the import list — capability
+    fingerprinting, bump capability-delta. Order of magnitude
+    faster on typical binaries. ``dangerous_sinks`` and
+    ``interesting_functions`` come back empty.
     """
     analyser = BinaryUnderstand(binary_path, llm=llm)
     context = analyser.analyse(
         max_decompile=max_decompile,
         max_strings=max_strings,
+        quick=quick,
     )
     if out_path:
         context.write(out_path)

--- a/packages/coccinelle/tests/test_prereqs.py
+++ b/packages/coccinelle/tests/test_prereqs.py
@@ -8,16 +8,21 @@ end-to-end.
 
 from __future__ import annotations
 
-import os
 import shutil
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-_RAPTOR_DIR = os.environ["RAPTOR_DIR"]
-if _RAPTOR_DIR not in sys.path:
-    sys.path.insert(0, _RAPTOR_DIR)
+# parents[3] climbs:
+#   [0] packages/coccinelle/tests/  (this file's directory)
+#   [1] packages/coccinelle/
+#   [2] packages/
+#   [3] <repo root>
+_REPO_ROOT = str(Path(__file__).resolve().parents[3])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
 from packages.coccinelle.models import SpatchMatch, SpatchResult
 from packages.coccinelle.prereqs import (

--- a/packages/coccinelle/tests/test_sarif.py
+++ b/packages/coccinelle/tests/test_sarif.py
@@ -8,14 +8,18 @@ versioning.
 
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 
 
-_RAPTOR_DIR = os.environ["RAPTOR_DIR"]
-if _RAPTOR_DIR not in sys.path:
-    sys.path.insert(0, _RAPTOR_DIR)
+# parents[3] climbs:
+#   [0] packages/coccinelle/tests/  (this file's directory)
+#   [1] packages/coccinelle/
+#   [2] packages/
+#   [3] <repo root>
+_REPO_ROOT = str(Path(__file__).resolve().parents[3])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
 from packages.coccinelle.models import SpatchMatch, SpatchResult
 from packages.coccinelle.sarif import results_to_sarif

--- a/packages/code_understanding/tests/dispatch/test_hunt_cocci_dispatch.py
+++ b/packages/code_understanding/tests/dispatch/test_hunt_cocci_dispatch.py
@@ -18,16 +18,22 @@ Coverage:
 
 from __future__ import annotations
 
-import os
 import sys
+from pathlib import Path
 from unittest import mock
 
 import pytest
 
 
-_RAPTOR_DIR = os.environ["RAPTOR_DIR"]
-if _RAPTOR_DIR not in sys.path:
-    sys.path.insert(0, _RAPTOR_DIR)
+# parents[4] climbs:
+#   [0] packages/code_understanding/tests/dispatch/  (this file's directory)
+#   [1] packages/code_understanding/tests/
+#   [2] packages/code_understanding/
+#   [3] packages/
+#   [4] <repo root>
+_REPO_ROOT = str(Path(__file__).resolve().parents[4])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
 
 from packages.code_understanding.dispatch import hunt_cocci_dispatch as mod

--- a/packages/diagram/tests/test_raptor_render_diagrams.py
+++ b/packages/diagram/tests/test_raptor_render_diagrams.py
@@ -16,7 +16,12 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 
-REPO_ROOT = Path(os.environ["RAPTOR_DIR"])
+# parents[3] climbs:
+#   [0] packages/diagram/tests/  (this file's directory)
+#   [1] packages/diagram/
+#   [2] packages/
+#   [3] <repo root>
+REPO_ROOT = Path(__file__).resolve().parents[3]
 WRAPPER = REPO_ROOT / "libexec" / "raptor-render-diagrams"
 
 

--- a/packages/fuzzing/tests/test_raptor_agentic_replay_except.py
+++ b/packages/fuzzing/tests/test_raptor_agentic_replay_except.py
@@ -12,7 +12,6 @@ get swallowed vs which propagate.
 
 from __future__ import annotations
 
-import os
 import subprocess
 import sys
 import tempfile
@@ -21,8 +20,14 @@ from pathlib import Path
 from unittest.mock import patch
 
 
-REPO_ROOT = Path(os.environ["RAPTOR_DIR"])
-sys.path.insert(0, str(REPO_ROOT))
+# parents[3] climbs:
+#   [0] packages/fuzzing/tests/  (this file's directory)
+#   [1] packages/fuzzing/
+#   [2] packages/
+#   [3] <repo root>
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 
 class TestReplayExceptNarrowing(unittest.TestCase):

--- a/packages/static-analysis/tests/test_scanner_cocci.py
+++ b/packages/static-analysis/tests/test_scanner_cocci.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import os
 import shutil
 import sys
 from pathlib import Path
@@ -22,12 +21,17 @@ from unittest.mock import patch
 
 import pytest
 
-_RAPTOR_DIR = os.environ["RAPTOR_DIR"]
-if _RAPTOR_DIR not in sys.path:
-    sys.path.insert(0, _RAPTOR_DIR)
+# parents[3] climbs:
+#   [0] packages/static-analysis/tests/  (this file's directory)
+#   [1] packages/static-analysis/
+#   [2] packages/
+#   [3] <repo root>
+_REPO_ROOT = str(Path(__file__).resolve().parents[3])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
 # packages/static-analysis has a hyphen — load via importlib.
-_SCANNER_PATH = Path(_RAPTOR_DIR) / "packages/static-analysis/scanner.py"
+_SCANNER_PATH = Path(_REPO_ROOT) / "packages/static-analysis/scanner.py"
 _spec = importlib.util.spec_from_file_location(
     "static_analysis_scanner_cocci", _SCANNER_PATH,
 )


### PR DESCRIPTION
Generic, consumer-agnostic primitive for "what dangerous-import capability surface does this binary expose, and how does it compare to another binary / a previous baseline / a different build of the same image?"

Tier-dispatched fingerprinting:
  * Tier 0 — native stdlib ELF parser (~1ms on /bin/ls)
  * Tier 1 — radare2 fallback for PE / Mach-O / formats tier 0 can't handle; uses ``analyse_binary_context(..., quick=True)`` (186x faster than full ``aaa`` analysis; this PR also adds that kwarg to ``packages.binary_analysis.radare2_understand``)

Produces tier-agnostic ``CapabilityFingerprint`` dataclasses identified by SHA-256 of binary bytes plus the per-bucket classification (alloc / exec / network / string_overflow / scan / memory_copy / format_string / parser / integer_parse / toctou).

Primitives layered on top:
  * ``capability_fingerprint(path)`` — the core call; returns ``None`` when neither tier can read the binary
  * ``diff_binary_capabilities(a, b)`` — unidirectional delta (what does b add that a didn't have?); used by bump pipelines
  * ``detect_drift(prev, cur)`` — bidirectional drift (additions AND removals + arch/bits/format change); used by drift detection across scans
  * persistent fingerprint store with atomic writes, SHA-256-of- ref filenames, schema versioning

12 substrate files, 91 unit tests + 2 radare2-parity integration tests covering tier-0/tier-1 alignment on /bin/ls.