### PR TITLE
fix(core/llm/dispatcher): seed CredentialStore from models.json

### DIFF
--- a/core/llm/dispatcher/auth.py
+++ b/core/llm/dispatcher/auth.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Callable
 
 
@@ -87,6 +88,11 @@ class CredentialStore:
     Loaded once from the parent's environ at dispatcher startup,
     keys then erased from environ. The store is the single point
     that holds plaintext credentials for the lifetime of the run.
+
+    The launcher may also call :func:`seed_from_config` after
+    constructing the store to fill any provider slots that env
+    didn't supply, from ``~/.config/raptor/models.json``. Env-set
+    keys are preserved (the seed only fills ``None`` slots).
     """
 
     def __init__(self) -> None:
@@ -121,7 +127,11 @@ class CredentialStore:
         return self._keys.get(provider)
 
     def set(self, provider: str, key: str | None) -> None:
-        """Test seam — production code does not call this."""
+        """Set or clear one provider's key.
+
+        Used by tests, and by :func:`seed_from_config` to fill slots
+        from ``models.json``. No other production caller touches this.
+        """
         self._keys[provider] = key
 
 
@@ -278,3 +288,65 @@ def build_rules(creds: CredentialStore) -> dict[str, ProviderRule]:
             ),
         ),
     }
+
+
+def seed_from_config(store: CredentialStore) -> None:
+    """Fill empty slots in *store* from ``~/.config/raptor/models.json``.
+
+    The ``CredentialStore`` reads API keys from env at construction.
+    Operators who instead keep their keys in ``models.json`` (the
+    documented UX that the startup banner advertises with
+    ``via models.json``) would otherwise see a configured-looking
+    system that still 503s every request — the proxy has no creds to
+    inject.
+
+    The launcher calls this after constructing the store, before
+    handing it to ``LLMDispatcher(..., creds=...)``. Env-supplied keys
+    always win: only slots where ``store.get(provider) is None`` are
+    filled, so an explicit env override of a ``models.json`` entry is
+    preserved.
+
+    Path resolution matches ``core/llm/detection.py:_read_config_models``:
+    ``$RAPTOR_CONFIG`` if set, else ``~/.config/raptor/models.json``.
+
+    Silent on file-missing, parse-error, or schema-error — same posture
+    as the rest of the config-reading path. A misconfigured file looks
+    the same as no file at all and surfaces later as the dispatcher's
+    own ``503 provider not configured``.
+    """
+    try:
+        from core.json import load_json_with_comments
+    except ImportError:
+        return
+
+    config_path_str = os.environ.get("RAPTOR_CONFIG")
+    if config_path_str:
+        config_path = Path(config_path_str).expanduser().resolve()
+    else:
+        config_path = Path.home() / ".config" / "raptor" / "models.json"
+
+    data = load_json_with_comments(config_path)
+    if data is None:
+        return
+
+    if isinstance(data, dict):
+        entries = data.get("models") or []
+    elif isinstance(data, list):
+        entries = data
+    else:
+        return
+    if not isinstance(entries, list):
+        return
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        provider = entry.get("provider")
+        api_key = entry.get("api_key")
+        if not isinstance(provider, str) or not isinstance(api_key, str):
+            continue
+        # Env wins: only fill empty slots. Also handles the duplicate-
+        # provider case (operator lists two gemini entries for different
+        # roles, same key) — first match seeds, rest are no-ops.
+        if store.get(provider) is None:
+            store.set(provider, api_key)

--- a/core/llm/dispatcher/tests/test_seed_from_config.py
+++ b/core/llm/dispatcher/tests/test_seed_from_config.py
@@ -1,0 +1,162 @@
+"""Tests for ``seed_from_config`` — the ``models.json`` bridge.
+
+The dispatcher's ``CredentialStore`` reads keys from env at
+construction time. ``seed_from_config`` fills remaining empty slots
+from ``~/.config/raptor/models.json`` so operators who keep their
+keys in the documented config file don't see 503s from the proxy.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from core.llm.dispatcher.auth import CredentialStore, seed_from_config
+
+
+def _make_empty_store() -> CredentialStore:
+    """Build a CredentialStore with all slots empty.
+
+    Bypasses ``__init__`` so the test runner's own env vars (if any
+    leaked through) can't seed the store from underneath us.
+    """
+    creds = CredentialStore.__new__(CredentialStore)
+    creds._keys = {
+        "anthropic": None,
+        "openai": None,
+        "gemini": None,
+        "mistral": None,
+        "groq": None,
+        "together": None,
+        "openrouter": None,
+        "fireworks": None,
+        "deepinfra": None,
+        "perplexity": None,
+        "cohere": None,
+        "replicate": None,
+        "azure_openai": None,
+        "azure_openai_endpoint": None,
+    }
+    return creds
+
+
+def test_seed_fills_empty_slots(tmp_path, monkeypatch):
+    config = tmp_path / "models.json"
+    config.write_text(json.dumps({
+        "models": [
+            {"provider": "gemini",    "api_key": "AIza-test"},
+            {"provider": "anthropic", "api_key": "sk-ant-test"},
+        ]
+    }))
+    monkeypatch.setenv("RAPTOR_CONFIG", str(config))
+
+    creds = _make_empty_store()
+    seed_from_config(creds)
+
+    assert creds.get("gemini") == "AIza-test"
+    assert creds.get("anthropic") == "sk-ant-test"
+    # Untouched providers stay None.
+    assert creds.get("openai") is None
+
+
+def test_env_supplied_keys_are_not_overridden(tmp_path, monkeypatch):
+    """If env already supplied a key, ``models.json`` does not replace it."""
+    config = tmp_path / "models.json"
+    config.write_text(json.dumps({
+        "models": [{"provider": "gemini", "api_key": "AIza-from-config"}]
+    }))
+    monkeypatch.setenv("RAPTOR_CONFIG", str(config))
+
+    creds = _make_empty_store()
+    creds.set("gemini", "AIza-from-env")  # simulate the env-read
+    seed_from_config(creds)
+
+    assert creds.get("gemini") == "AIza-from-env"
+
+
+def test_duplicate_provider_entries_first_wins(tmp_path, monkeypatch):
+    """Two gemini entries (analysis + fallback) — first match seeds."""
+    config = tmp_path / "models.json"
+    config.write_text(json.dumps({
+        "models": [
+            {"provider": "gemini", "role": "analysis", "api_key": "AIza-first"},
+            {"provider": "gemini", "role": "fallback", "api_key": "AIza-second"},
+        ]
+    }))
+    monkeypatch.setenv("RAPTOR_CONFIG", str(config))
+
+    creds = _make_empty_store()
+    seed_from_config(creds)
+
+    assert creds.get("gemini") == "AIza-first"
+
+
+def test_silent_on_missing_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("RAPTOR_CONFIG", str(tmp_path / "does-not-exist.json"))
+
+    creds = _make_empty_store()
+    seed_from_config(creds)  # must not raise
+
+    assert creds.get("gemini") is None
+
+
+def test_silent_on_malformed_json(tmp_path, monkeypatch):
+    config = tmp_path / "models.json"
+    config.write_text("{ this is not json")
+    monkeypatch.setenv("RAPTOR_CONFIG", str(config))
+
+    creds = _make_empty_store()
+    seed_from_config(creds)  # must not raise
+
+    assert creds.get("gemini") is None
+
+
+def test_entries_without_api_key_are_skipped(tmp_path, monkeypatch):
+    config = tmp_path / "models.json"
+    config.write_text(json.dumps({
+        "models": [
+            {"provider": "gemini",    "model": "gemini-2.5-pro"},  # no key
+            {"provider": "anthropic", "api_key": "sk-ant-test"},
+        ]
+    }))
+    monkeypatch.setenv("RAPTOR_CONFIG", str(config))
+
+    creds = _make_empty_store()
+    seed_from_config(creds)
+
+    assert creds.get("gemini") is None
+    assert creds.get("anthropic") == "sk-ant-test"
+
+
+def test_bare_list_shape_is_accepted(tmp_path, monkeypatch):
+    """Config can be ``{"models": [...]}`` or a bare ``[...]``."""
+    config = tmp_path / "models.json"
+    config.write_text(json.dumps([
+        {"provider": "gemini", "api_key": "AIza-bare-list"},
+    ]))
+    monkeypatch.setenv("RAPTOR_CONFIG", str(config))
+
+    creds = _make_empty_store()
+    seed_from_config(creds)
+
+    assert creds.get("gemini") == "AIza-bare-list"
+
+
+def test_non_string_provider_or_key_is_skipped(tmp_path, monkeypatch):
+    config = tmp_path / "models.json"
+    config.write_text(json.dumps({
+        "models": [
+            {"provider": "gemini",     "api_key": 12345},          # non-str key
+            {"provider": ["anthropic"], "api_key": "sk-ant-test"},  # non-str provider
+            {"provider": "openai",      "api_key": "sk-openai-ok"},
+        ]
+    }))
+    monkeypatch.setenv("RAPTOR_CONFIG", str(config))
+
+    creds = _make_empty_store()
+    seed_from_config(creds)
+
+    assert creds.get("gemini") is None
+    assert creds.get("anthropic") is None
+    assert creds.get("openai") == "sk-openai-ok"

--- a/core/llm/dispatcher/tests/test_seed_from_config.py
+++ b/core/llm/dispatcher/tests/test_seed_from_config.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 
 import json
 
-import pytest
-
 from core.llm.dispatcher.auth import CredentialStore, seed_from_config
 
 

--- a/raptor.py
+++ b/raptor.py
@@ -247,9 +247,21 @@ def _get_or_start_dispatcher():
     if _active_dispatcher is not None:
         return _active_dispatcher
     try:
+        from core.llm.dispatcher.auth import CredentialStore, seed_from_config
         from core.llm.dispatcher.server import LLMDispatcher
         import uuid, atexit
-        _active_dispatcher = LLMDispatcher(run_id=f"raptor-{uuid.uuid4().hex[:8]}")
+        # CredentialStore.__init__ reads env vars. Operators who keep
+        # keys in ~/.config/raptor/models.json (the documented UX the
+        # startup banner advertises) need the explicit seed pass —
+        # without it the proxy 503s every request even though the
+        # config "looks" populated. Env-set keys win; seed only fills
+        # None slots.
+        creds = CredentialStore()
+        seed_from_config(creds)
+        _active_dispatcher = LLMDispatcher(
+            run_id=f"raptor-{uuid.uuid4().hex[:8]}",
+            creds=creds,
+        )
         atexit.register(_active_dispatcher.shutdown)
         return _active_dispatcher
     except Exception as exc:


### PR DESCRIPTION
CredentialStore.__init__ reads provider API keys from env vars only (ANTHROPIC_API_KEY, GEMINI_API_KEY, ...) — never from ~/.config/raptor/models.json. Operators who follow the documented UX of keeping keys in models.json saw the startup banner report "gemini/gemini-2.5-pro (via models.json)", then every dispatcher request returned `503 provider not configured` because the proxy's key table was empty. Two separate readers — the selection layer opens models.json; the dispatcher didn't.

Add `seed_from_config(store)` as a free function in core/llm/dispatcher/auth.py. The launcher
(raptor.py:_get_or_start_dispatcher) builds a `CredentialStore()` (env reads happen as today), calls `seed_from_config(creds)` to fill any provider slots still `None` from models.json, then passes the populated store to `LLMDispatcher(creds=...)`.

Design choice — fill-on-None at the launcher rather than inside the constructor:
  * Keeps `CredentialStore` a tight security primitive with a single documented source (env). No surprise file read from a homedir path inside the auth module.
  * Tests that build `CredentialStore()` for unrelated reasons don't silently inherit the operator's real keys.
  * Env still wins — the seed only fills slots env left `None`, so explicit env overrides of a models.json entry survive.

Path resolution mirrors core/llm/detection.py:_read_config_models — $RAPTOR_CONFIG if set, else ~/.config/raptor/models.json. Silent on file-missing / parse-error / schema-error; misconfigured files surface later as the dispatcher's own `503 provider not configured`.

Files:
  * core/llm/dispatcher/auth.py — new `seed_from_config`; docstring updates on `CredentialStore` and `.set()` to reflect that the launcher seeds via this bridge.
  * raptor.py — `_get_or_start_dispatcher` builds the store, seeds it, passes via `creds=`.
  * core/llm/dispatcher/tests/test_seed_from_config.py — 8 tests: fills empty slots, env wins over file, first-of-duplicate wins, silent on missing/malformed, skips entries without keys, accepts bare-list shape, skips non-string types.