### PR TITLE
fix(core/llm/dispatcher): preserve Content-Encoding on response forwarding

### DIFF
--- a/core/llm/dispatcher/server.py
+++ b/core/llm/dispatcher/server.py
@@ -500,8 +500,17 @@ def _make_request_handler(dispatcher: LLMDispatcher) -> type:
                     with client.stream(method, url, content=body, headers=forwarded) as up:
                         self.send_response(up.status_code)
                         for k, v in up.headers.items():
+                            # Strip hop-by-hop headers only. ``content-
+                            # encoding`` is response-scoped and MUST be
+                            # preserved: ``iter_raw()`` below forwards
+                            # the upstream's still-compressed bytes (it
+                            # does not auto-decompress), so the worker
+                            # needs the header to know to decompress.
+                            # Stripping it ships gzipped bytes labelled
+                            # as plain JSON — Anthropic always gzips,
+                            # so worker SDK calls choke on the bytes.
                             if k.lower() in (
-                                "transfer-encoding", "content-encoding",
+                                "transfer-encoding",
                                 "connection",
                             ):
                                 continue

--- a/core/llm/dispatcher/tests/test_dispatcher.py
+++ b/core/llm/dispatcher/tests/test_dispatcher.py
@@ -759,3 +759,111 @@ class TestSpawnHelperTokenIsolation:
             assert len(token_value) >= 32   # url-safe 32 bytes -> 43 chars
         finally:
             d.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Regression — response Content-Encoding must survive forwarding
+# ---------------------------------------------------------------------------
+
+
+class _GzipCaptiveUpstream:
+    """Captive HTTP server that gzip-encodes its response body and
+    serves it with ``Content-Encoding: gzip`` — mirrors how Anthropic
+    (always) and Gemini (often) reply in production."""
+
+    def __init__(self, payload: bytes):
+        import gzip
+        import http.server
+
+        compressed = gzip.compress(payload)
+
+        class _H(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *_a, **_kw):
+                return
+
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", "0"))
+                _ = self.rfile.read(length) if length else b""
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Encoding", "gzip")
+                self.send_header("Content-Length", str(len(compressed)))
+                self.end_headers()
+                self.wfile.write(compressed)
+
+        self._server = http.server.HTTPServer(("127.0.0.1", 0), _H)
+        self.host, self.port = self._server.server_address
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def shutdown(self):
+        self._server.shutdown()
+        self._server.server_close()
+
+
+class TestE2EResponseEncodingPreserved:
+    """Regression: the dispatcher used to strip ``Content-Encoding``
+    from upstream responses while forwarding the still-compressed
+    ``iter_raw()`` bytes — workers received gzipped bytes labelled as
+    plain, and the SDK's JSON parse choked on garbage (Gemini: char-0
+    parse error; Anthropic: binary in the error string)."""
+
+    def _setup(self, fake_creds, tmp_path, payload: bytes):
+        upstream = _GzipCaptiveUpstream(payload)
+        d = LLMDispatcher(
+            run_id="gzip-e2e", creds=fake_creds,
+            audit_path=tmp_path / "audit.jsonl",
+            token_ttl_s=3600, token_budget=100,
+        )
+        from core.llm.dispatcher.auth import ProviderRule
+        original = d._rules["anthropic"]
+        d._rules["anthropic"] = ProviderRule(
+            name=original.name,
+            upstream_base_url=upstream.base_url,
+            inject_headers=original.inject_headers,
+            strip_request_headers=original.strip_request_headers,
+        )
+        return d, upstream
+
+    def test_gzipped_upstream_body_decompresses_at_worker(
+        self, fake_creds, tmp_path,
+    ):
+        payload = b'{"id":"msg_test","content":"hello gzipped world"}'
+        d, upstream = self._setup(fake_creds, tmp_path, payload)
+        try:
+            _, fd = d.allocate_worker(label="gzip-e2e")
+            token = os.read(fd, 64).decode().strip()
+            os.close(fd)
+
+            transport = httpx.HTTPTransport(uds=str(d.socket_path))
+            with httpx.Client(transport=transport, timeout=10.0) as client:
+                resp = client.post(
+                    "http://_/anthropic/v1/messages",
+                    headers={
+                        _TOKEN_HEADER: token,
+                        "x-api-key": "dummy-not-used",
+                        "Content-Type": "application/json",
+                    },
+                    content=b'{"model":"claude-3-haiku","messages":[]}',
+                )
+
+            assert resp.status_code == 200
+            # With ``Content-Encoding: gzip`` preserved, httpx
+            # auto-decompresses and ``resp.json()`` returns the
+            # original payload. Pre-fix this raised JSONDecodeError
+            # on the still-compressed bytes.
+            assert resp.json() == {
+                "id": "msg_test", "content": "hello gzipped world",
+            }
+            # And the worker's response headers retain the encoding
+            # advertisement — without that signal httpx falls back
+            # to opaque-bytes mode.
+            ce = {k.lower(): v for k, v in resp.headers.items()}.get("content-encoding")
+            assert ce == "gzip"
+        finally:
+            upstream.shutdown()
+            d.shutdown()


### PR DESCRIPTION
The proxy forwards ``iter_raw()`` bytes from upstream (deliberate — the module docstring promises "does NOT terminate TLS, MITM, or read prompt/response content beyond what's needed to inject the auth header"). ``iter_raw()`` yields the upstream's still-compressed body without decoding. But the response-header forwarding loop in ``server.py`` was stripping ``Content-Encoding`` alongside the genuine hop-by-hop framing headers (``Transfer-Encoding``, ``Connection``).

Workers therefore received gzipped bytes labelled as plain JSON. The SDK's response parser choked on opaque binary:
  * Anthropic (always ``Content-Encoding: gzip``) — binary garbage in error strings, ``UnicodeDecodeError`` on ``.text`` access.
  * Gemini (often gzips JSON) — ``Expecting value: line 1 column 1 (char 0)`` from the JSON parser hitting compressed bytes.

This shipped because every existing E2E test served plain JSON from the captive upstream — the gzip path was uncovered. The Layer-3 test even noted the symptom in passing ("upstream may return gzipped body") with a ``try/except`` workaround, but the cause wasn't pursued.

Fix is one line in the strip tuple — drop ``content-encoding`` and preserve the response semantics. ``Content-Encoding`` is response- content scope, NOT hop-by-hop; the proxy must forward it verbatim alongside the still-compressed body. With the header preserved, ``httpx`` auto-decompresses on the worker side.

Regression test ``TestE2EResponseEncodingPreserved`` spins up a captive upstream that gzip-encodes its JSON body and serves ``Content-Encoding: gzip``, drives a request through the dispatcher, and asserts ``resp.json()`` parses correctly.

Files:
  * core/llm/dispatcher/server.py — remove ``content-encoding`` from the response-header strip tuple. Inline comment now spells out why hop-by-hop framing is stripped and why content-encoding is not.
  * core/llm/dispatcher/tests/test_dispatcher.py — new ``_GzipCaptiveUpstream`` helper and ``TestE2EResponseEncoding Preserved`` regression class.