### PR TITLE
fix(llm): resolve Anthropic model aliases and wire dispatcher path end-to-end

### DIFF
--- a/core/llm/detection.py
+++ b/core/llm/detection.py
@@ -367,6 +367,13 @@ def _read_config_models() -> list:
 
     Shared config file parsing — used by both detection and config modules.
     Returns a list of model dicts, or empty list on any error.
+
+    Anthropic model names are resolved through the live ``/v1/models``
+    inventory before return: operators usually configure unversioned
+    aliases (e.g. ``claude-haiku-4-5``) but the SDK requires the
+    versioned snapshot (``claude-haiku-4-5-20251001``). See
+    :mod:`core.llm.model_resolution` for the resolver and its failure
+    posture (verbatim passthrough on any error).
     """
     try:
         from core.json import load_json_with_comments
@@ -384,12 +391,54 @@ def _read_config_models() -> list:
         # Accept both {"models": [...]} and bare [...]
         if isinstance(data, dict):
             model_list = data.get("models", [])
-            return model_list if isinstance(model_list, list) else []
+            if not isinstance(model_list, list):
+                return []
         elif isinstance(data, list):
-            return data
-        return []
+            model_list = data
+        else:
+            return []
+
+        return _apply_anthropic_resolution(model_list)
     except Exception:
         return []
+
+
+def _apply_anthropic_resolution(entries: list) -> list:
+    """Rewrite each Anthropic entry's ``model`` field through the resolver.
+
+    Non-anthropic entries are returned unchanged. Anthropic entries
+    with no ``model`` field, a non-string ``model``, or no api_key
+    are returned unchanged (the resolver needs the key for the
+    inventory fetch). Resolution failures fall through to verbatim
+    so a misconfigured or unreachable Anthropic API can never break
+    config reads.
+    """
+    try:
+        from .model_resolution import resolve_anthropic
+    except ImportError:
+        return entries
+
+    out = []
+    for entry in entries:
+        if not isinstance(entry, dict) or entry.get("provider") != "anthropic":
+            out.append(entry)
+            continue
+        name = entry.get("model")
+        api_key = entry.get("api_key") or os.getenv("ANTHROPIC_API_KEY")
+        if not isinstance(name, str) or not api_key:
+            out.append(entry)
+            continue
+        resolved = resolve_anthropic(name, api_key)
+        if resolved == name:
+            out.append(entry)
+        else:
+            new_entry = dict(entry)
+            new_entry["model"] = resolved
+            # Preserve the operator's input for diagnostics. Run logs
+            # and reports can show "configured as X, resolved to Y".
+            new_entry.setdefault("_configured_model", name)
+            out.append(new_entry)
+    return out
 
 
 def _config_has_keyed_models() -> bool:

--- a/core/llm/dispatcher/client.py
+++ b/core/llm/dispatcher/client.py
@@ -154,11 +154,14 @@ def make_anthropic_client(
     http = _make_httpx_client(socket_path, token, timeout=timeout)
     # ``api_key='dummy'`` because the SDK validates that *something*
     # was passed; the dispatcher strips it and injects the real key.
-    # ``base_url`` directs requests to ``/anthropic/v1/...`` so the
-    # dispatcher can route by path prefix.
+    # ``base_url`` directs requests to ``/anthropic/...`` so the
+    # dispatcher can route by path prefix. The Anthropic SDK appends
+    # ``/v1/messages`` itself, so the base URL stops at the provider
+    # prefix — adding ``/v1`` here would double it and produce
+    # ``/v1/v1/messages`` upstream.
     return anthropic.Anthropic(
         api_key="dummy-not-used",
-        base_url="http://_/anthropic/v1",
+        base_url="http://_/anthropic",
         http_client=http,
     )
 

--- a/core/llm/model_resolution.py
+++ b/core/llm/model_resolution.py
@@ -39,6 +39,14 @@ _INVENTORY: Optional[list[str]] = None
 _INVENTORY_PROBED: bool = False
 _INVENTORY_LOCK = threading.Lock()
 
+# Per-process dedupe of resolution log lines. The inventory is cached
+# but the resolver itself runs per-call: multiple readers of
+# ``models.json`` within one process otherwise each emit their own
+# "Resolved alias X -> Y" line, which is noisy and falsely implies
+# repeated network calls. Track which (alias -> resolved) pairs we've
+# already logged so each mapping logs exactly once.
+_LOGGED_RESOLUTIONS: set[tuple[str, str]] = set()
+
 
 def resolve_anthropic(name: str, api_key: Optional[str]) -> str:
     """Return the canonical Anthropic model ID for *name*.
@@ -88,10 +96,13 @@ def resolve_anthropic(name: str, api_key: Optional[str]) -> str:
 
     resolved = max(candidates)
     if resolved != name:
-        logger.info(
-            f"Resolved Anthropic model alias {name} -> {resolved} "
-            f"(from /v1/models inventory)"
-        )
+        pair = (name, resolved)
+        if pair not in _LOGGED_RESOLUTIONS:
+            _LOGGED_RESOLUTIONS.add(pair)
+            logger.info(
+                f"Resolved Anthropic model alias {name} -> {resolved} "
+                f"(from /v1/models inventory)"
+            )
     return resolved
 
 
@@ -161,6 +172,7 @@ def _reset_cache_for_tests() -> None:
     with _INVENTORY_LOCK:
         _INVENTORY = None
         _INVENTORY_PROBED = False
+        _LOGGED_RESOLUTIONS.clear()
 
 
 def _seed_cache_for_tests(inventory: list[str]) -> None:

--- a/core/llm/model_resolution.py
+++ b/core/llm/model_resolution.py
@@ -1,0 +1,171 @@
+"""Lazy Anthropic model alias resolution.
+
+Anthropic publishes versioned snapshots (e.g. ``claude-haiku-4-5-20251001``)
+but operators typically configure the unversioned alias
+(``claude-haiku-4-5``) in ``~/.config/raptor/models.json``. The SDK then
+sends the alias to ``/v1/messages`` and gets back ``404 not_found_error``
+because Anthropic has no ``-latest`` alias for every model family.
+
+This module resolves the alias to the most recent matching snapshot
+from the live ``/v1/models`` inventory. Resolution is lazy and
+per-process: the first call to :func:`resolve_anthropic` triggers one
+inventory fetch; later calls hit an in-memory cache. Failure to fetch
+(network, auth) falls through to verbatim — same failure mode as
+today, the SDK still raises a clear 404 if the name is genuinely
+unknown.
+
+Scoped to Anthropic. Gemini and OpenAI IDs are stable enough that
+operators pin them exactly; adding more providers is a one-line
+conditional in the integration point at :func:`_read_config_models`.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Optional
+
+from core.logging import get_logger
+
+logger = get_logger()
+
+
+# Module-level cache. Populated on first :func:`resolve_anthropic` call;
+# stays populated for the process lifetime. ``_INVENTORY_PROBED`` flips to
+# ``True`` after the first fetch attempt regardless of outcome, so a
+# transient network failure at startup doesn't trigger a retry on every
+# subsequent read of ``models.json`` — the same posture as Anthropic's
+# own SDK, which caches model lists between calls.
+_INVENTORY: Optional[list[str]] = None
+_INVENTORY_PROBED: bool = False
+_INVENTORY_LOCK = threading.Lock()
+
+
+def resolve_anthropic(name: str, api_key: Optional[str]) -> str:
+    """Return the canonical Anthropic model ID for *name*.
+
+    Resolution rules, in order:
+
+      1. If *name* is an exact match for a published snapshot, return
+         it verbatim — the operator pinned a specific version.
+      2. If *name* is one date-suffix away from a canonical ID — i.e.
+         every candidate of the form ``{name}-{next_segment}-...`` has
+         ``next_segment`` an 8-digit ``YYYYMMDD`` — return the lex-max
+         match. Lex-max == most-recent because the date is fixed-width.
+      3. Otherwise, return *name* verbatim. This covers:
+           - ambiguous aliases (``claude``, ``claude-opus``,
+             ``claude-opus-4``) whose next segment is a family or
+             version component, not a date — silent resolution would
+             surprise the operator with a "random" model from the
+             family. Better to 404 with the alias they typed.
+           - typos and unknown families — same 404 they'd see without
+             this resolver.
+
+    Inventory is fetched lazily on first call per process. Failures
+    (network, auth, malformed response) are absorbed silently and fall
+    through to verbatim.
+    """
+    inventory = _get_inventory(api_key)
+    if not inventory:
+        return name
+
+    if name in inventory:
+        return name
+
+    prefix = name + "-"
+    candidates = [m for m in inventory if m.startswith(prefix)]
+    if not candidates:
+        return name
+
+    # Guard against ambiguous aliases. The segment immediately after
+    # ``{name}-`` must be a YYYYMMDD date in EVERY candidate; otherwise
+    # the alias spans multiple families/versions and silent resolution
+    # would be surprising. The ``all()`` semantics matter: if any
+    # candidate has a non-date next segment, we refuse the whole batch
+    # rather than picking the date-segmented subset — partial
+    # resolution would be even more surprising than none.
+    if not all(_next_segment_is_date(c, len(prefix)) for c in candidates):
+        return name
+
+    resolved = max(candidates)
+    if resolved != name:
+        logger.info(
+            f"Resolved Anthropic model alias {name} -> {resolved} "
+            f"(from /v1/models inventory)"
+        )
+    return resolved
+
+
+def _next_segment_is_date(model_id: str, prefix_len: int) -> bool:
+    """Is the segment at ``model_id[prefix_len:]`` an 8-digit date?
+
+    A canonical Anthropic snapshot suffix is ``YYYYMMDD`` (e.g.
+    ``20251001``). The segment ends at the next ``-`` or end-of-string.
+    """
+    rest = model_id[prefix_len:]
+    seg = rest.split("-", 1)[0]
+    return len(seg) == 8 and seg.isdigit()
+
+
+def _get_inventory(api_key: Optional[str]) -> list[str]:
+    """Return the cached inventory, fetching it on first call.
+
+    Thread-safe: concurrent first-callers from multiple threads collapse
+    to a single fetch via ``_INVENTORY_LOCK``.
+    """
+    global _INVENTORY, _INVENTORY_PROBED
+
+    # Fast path — already probed. Reads of ``_INVENTORY_PROBED`` and
+    # ``_INVENTORY`` are atomic in CPython (PEP 13), so the lockless
+    # check is safe for the steady-state read pattern.
+    if _INVENTORY_PROBED:
+        return _INVENTORY or []
+
+    with _INVENTORY_LOCK:
+        if _INVENTORY_PROBED:
+            return _INVENTORY or []
+        try:
+            _INVENTORY = _fetch_inventory(api_key) if api_key else []
+        except Exception as exc:
+            logger.debug(f"Anthropic model inventory fetch failed: {exc}")
+            _INVENTORY = []
+        _INVENTORY_PROBED = True
+        return _INVENTORY
+
+
+def _fetch_inventory(api_key: str) -> list[str]:
+    """One-shot ``GET /v1/models`` returning each entry's ``id``.
+
+    Returns an empty list on non-200 responses. Raises on transport
+    errors — :func:`_get_inventory` absorbs those.
+    """
+    import requests
+
+    r = requests.get(
+        "https://api.anthropic.com/v1/models",
+        headers={"x-api-key": api_key, "anthropic-version": "2023-06-01"},
+        timeout=5,
+    )
+    if r.status_code != 200:
+        return []
+    data = r.json().get("data", [])
+    return [
+        entry["id"]
+        for entry in data
+        if isinstance(entry, dict) and isinstance(entry.get("id"), str)
+    ]
+
+
+def _reset_cache_for_tests() -> None:
+    """Test seam — clears the inventory cache between cases."""
+    global _INVENTORY, _INVENTORY_PROBED
+    with _INVENTORY_LOCK:
+        _INVENTORY = None
+        _INVENTORY_PROBED = False
+
+
+def _seed_cache_for_tests(inventory: list[str]) -> None:
+    """Test seam — injects an inventory without going to the network."""
+    global _INVENTORY, _INVENTORY_PROBED
+    with _INVENTORY_LOCK:
+        _INVENTORY = list(inventory)
+        _INVENTORY_PROBED = True

--- a/core/llm/tests/test_model_resolution.py
+++ b/core/llm/tests/test_model_resolution.py
@@ -1,0 +1,300 @@
+"""Tests for ``core/llm/model_resolution`` — Anthropic alias resolution.
+
+The resolver maps unversioned aliases like ``claude-haiku-4-5`` to the
+most recent versioned snapshot Anthropic publishes
+(``claude-haiku-4-5-20251001``) so SDK calls don't 404. Failures fall
+through to verbatim — the SDK still surfaces a clear error for
+genuinely unknown names.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from core.llm import model_resolution
+from core.llm.model_resolution import (
+    resolve_anthropic,
+    _fetch_inventory,
+    _reset_cache_for_tests,
+    _seed_cache_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cache():
+    """Each test starts with an empty resolver cache."""
+    _reset_cache_for_tests()
+    yield
+    _reset_cache_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Pure resolution logic — drives the cache directly
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionLogic:
+
+    def test_exact_match_returned_verbatim(self):
+        _seed_cache_for_tests([
+            "claude-haiku-4-5-20251001",
+            "claude-sonnet-4-6-20251015",
+        ])
+        # Operator pinned a specific snapshot — must not be rewritten.
+        assert resolve_anthropic("claude-haiku-4-5-20251001", "k") == "claude-haiku-4-5-20251001"
+
+    def test_alias_resolves_to_only_snapshot(self):
+        _seed_cache_for_tests(["claude-haiku-4-5-20251001"])
+        assert resolve_anthropic("claude-haiku-4-5", "k") == "claude-haiku-4-5-20251001"
+
+    def test_alias_resolves_to_most_recent_snapshot(self):
+        """Lex-max == most recent because the suffix is YYYYMMDD."""
+        _seed_cache_for_tests([
+            "claude-haiku-4-5-20251001",
+            "claude-haiku-4-5-20260315",
+            "claude-haiku-4-5-20251215",
+        ])
+        assert resolve_anthropic("claude-haiku-4-5", "k") == "claude-haiku-4-5-20260315"
+
+    def test_ambiguous_family_alias_returns_verbatim(self):
+        """``claude`` alone is too vague — the next segment in each
+        candidate is a family name (``haiku``, ``opus``, ``sonnet``),
+        not a date. Silent resolution would pick a "random" family
+        via lex-max; better to 404 with the alias the user typed."""
+        _seed_cache_for_tests([
+            "claude-haiku-4-5-20251001",
+            "claude-opus-4-1-20260101",
+            "claude-sonnet-4-6-20260201",
+        ])
+        assert resolve_anthropic("claude", "k") == "claude"
+
+    def test_ambiguous_major_version_alias_returns_verbatim(self):
+        """``claude-opus`` spans multiple major versions — next
+        segment is the major version digit, not a date. Verbatim."""
+        _seed_cache_for_tests([
+            "claude-opus-3-20240115",
+            "claude-opus-4-1-20260101",
+        ])
+        assert resolve_anthropic("claude-opus", "k") == "claude-opus"
+
+    def test_ambiguous_minor_version_alias_returns_verbatim(self):
+        """``claude-opus-4`` spans multiple minor versions — next
+        segment is the minor version digit, not a date. Verbatim."""
+        _seed_cache_for_tests([
+            "claude-opus-4-1-20260101",
+            "claude-opus-4-2-20260315",
+        ])
+        assert resolve_anthropic("claude-opus-4", "k") == "claude-opus-4"
+
+    def test_unambiguous_alias_resolves_even_with_other_families_present(self):
+        """``claude-haiku-4-5`` is one date away from a canonical ID;
+        the presence of unrelated families in the inventory doesn't
+        derail it."""
+        _seed_cache_for_tests([
+            "claude-haiku-4-5-20251001",
+            "claude-opus-4-1-20260101",
+            "claude-sonnet-4-6-20260201",
+        ])
+        assert resolve_anthropic("claude-haiku-4-5", "k") == "claude-haiku-4-5-20251001"
+
+    def test_no_prefix_match_returns_verbatim(self):
+        _seed_cache_for_tests(["claude-haiku-4-5-20251001"])
+        assert resolve_anthropic("claude-opus-9", "k") == "claude-opus-9"
+
+    def test_empty_inventory_returns_verbatim(self):
+        _seed_cache_for_tests([])
+        assert resolve_anthropic("claude-haiku-4-5", "k") == "claude-haiku-4-5"
+
+
+# ---------------------------------------------------------------------------
+# Cache behaviour — fetch happens at most once per process
+# ---------------------------------------------------------------------------
+
+
+class TestCacheBehaviour:
+
+    def test_fetch_runs_once_on_repeated_resolves(self):
+        """Multiple resolve calls trigger only one inventory fetch."""
+        with patch.object(
+            model_resolution, "_fetch_inventory",
+            return_value=["claude-haiku-4-5-20251001"],
+        ) as fake_fetch:
+            assert resolve_anthropic("claude-haiku-4-5", "k") == "claude-haiku-4-5-20251001"
+            assert resolve_anthropic("claude-haiku-4-5", "k") == "claude-haiku-4-5-20251001"
+            assert resolve_anthropic("claude-sonnet-4-6", "k") == "claude-sonnet-4-6"
+        assert fake_fetch.call_count == 1
+
+    def test_fetch_not_attempted_without_api_key(self):
+        with patch.object(model_resolution, "_fetch_inventory") as fake_fetch:
+            # No api_key — resolver short-circuits, no network attempt.
+            assert resolve_anthropic("claude-haiku-4-5", None) == "claude-haiku-4-5"
+        fake_fetch.assert_not_called()
+
+    def test_fetch_exception_falls_through_to_verbatim(self):
+        """Network blip at startup must not break config reads."""
+        with patch.object(
+            model_resolution, "_fetch_inventory",
+            side_effect=RuntimeError("connection refused"),
+        ):
+            # Verbatim, no exception propagates.
+            assert resolve_anthropic("claude-haiku-4-5", "k") == "claude-haiku-4-5"
+            # And the failure is latched — no retry on next call.
+            assert resolve_anthropic("claude-haiku-4-5", "k") == "claude-haiku-4-5"
+
+
+# ---------------------------------------------------------------------------
+# Network layer — _fetch_inventory parses the real /v1/models shape
+# ---------------------------------------------------------------------------
+
+
+class TestFetchInventory:
+
+    def _mock_response(self, status: int, body: dict | None = None):
+        m = MagicMock()
+        m.status_code = status
+        m.json.return_value = body or {}
+        return m
+
+    def test_parses_id_field_from_each_entry(self):
+        body = {
+            "data": [
+                {"id": "claude-haiku-4-5-20251001", "type": "model"},
+                {"id": "claude-sonnet-4-6-20251015", "type": "model"},
+            ],
+        }
+        with patch("requests.get", return_value=self._mock_response(200, body)):
+            assert _fetch_inventory("k") == [
+                "claude-haiku-4-5-20251001",
+                "claude-sonnet-4-6-20251015",
+            ]
+
+    def test_non_200_returns_empty(self):
+        with patch("requests.get", return_value=self._mock_response(401)):
+            assert _fetch_inventory("bad-key") == []
+
+    def test_malformed_entries_are_skipped(self):
+        body = {
+            "data": [
+                {"id": "claude-haiku-4-5-20251001"},
+                {"no_id": "weird-entry"},
+                "string-not-dict",
+                {"id": 12345},  # non-string id
+            ],
+        }
+        with patch("requests.get", return_value=self._mock_response(200, body)):
+            assert _fetch_inventory("k") == ["claude-haiku-4-5-20251001"]
+
+
+# ---------------------------------------------------------------------------
+# Integration — _read_config_models rewrites Anthropic entries
+# ---------------------------------------------------------------------------
+
+
+class TestReadConfigIntegration:
+
+    def test_anthropic_alias_rewritten_in_returned_entries(
+        self, tmp_path, monkeypatch,
+    ):
+        import json
+
+        from core.llm.detection import _read_config_models
+
+        _seed_cache_for_tests(["claude-haiku-4-5-20251001"])
+
+        config = tmp_path / "models.json"
+        config.write_text(json.dumps({
+            "models": [
+                {"provider": "gemini", "model": "gemini-2.5-pro", "api_key": "g"},
+                {"provider": "anthropic", "model": "claude-haiku-4-5", "api_key": "a"},
+            ]
+        }))
+        monkeypatch.setenv("RAPTOR_CONFIG", str(config))
+
+        entries = _read_config_models()
+        anthropic = next(e for e in entries if e["provider"] == "anthropic")
+        gemini = next(e for e in entries if e["provider"] == "gemini")
+
+        assert anthropic["model"] == "claude-haiku-4-5-20251001"
+        # Operator's input preserved for diagnostics.
+        assert anthropic["_configured_model"] == "claude-haiku-4-5"
+        # Gemini entries untouched.
+        assert gemini["model"] == "gemini-2.5-pro"
+        assert "_configured_model" not in gemini
+
+    def test_already_pinned_anthropic_entry_not_marked_resolved(
+        self, tmp_path, monkeypatch,
+    ):
+        import json
+
+        from core.llm.detection import _read_config_models
+
+        _seed_cache_for_tests(["claude-haiku-4-5-20251001"])
+
+        config = tmp_path / "models.json"
+        config.write_text(json.dumps({
+            "models": [
+                {"provider": "anthropic", "model": "claude-haiku-4-5-20251001", "api_key": "a"},
+            ]
+        }))
+        monkeypatch.setenv("RAPTOR_CONFIG", str(config))
+
+        entries = _read_config_models()
+        assert entries[0]["model"] == "claude-haiku-4-5-20251001"
+        # No "configured_model" marker — there was no rewrite to record.
+        assert "_configured_model" not in entries[0]
+
+    def test_anthropic_entry_without_key_passes_through_unchanged(
+        self, tmp_path, monkeypatch,
+    ):
+        """A configured-but-unkeyed entry can't trigger a fetch and
+        must not be rewritten. Some operators stage entries with the
+        key resolved later via env var."""
+        import json
+
+        from core.llm.detection import _read_config_models
+
+        _seed_cache_for_tests(["claude-haiku-4-5-20251001"])
+
+        config = tmp_path / "models.json"
+        config.write_text(json.dumps({
+            "models": [
+                {"provider": "anthropic", "model": "claude-haiku-4-5"},
+            ]
+        }))
+        monkeypatch.setenv("RAPTOR_CONFIG", str(config))
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        entries = _read_config_models()
+        # No key in entry and none in env — resolver can't fetch, so we
+        # leave the alias as-is. The downstream LLM call will fail with
+        # the same error mode as before this feature shipped.
+        assert entries[0]["model"] == "claude-haiku-4-5"
+
+    def test_resolution_failure_does_not_break_config_read(
+        self, tmp_path, monkeypatch,
+    ):
+        """If the resolver raises, _read_config_models must still
+        return the raw entries — config reads can never be the thing
+        that breaks because Anthropic's models endpoint is down."""
+        import json
+
+        from core.llm.detection import _read_config_models
+
+        config = tmp_path / "models.json"
+        config.write_text(json.dumps({
+            "models": [
+                {"provider": "anthropic", "model": "claude-haiku-4-5", "api_key": "a"},
+            ]
+        }))
+        monkeypatch.setenv("RAPTOR_CONFIG", str(config))
+
+        with patch.object(
+            model_resolution, "_fetch_inventory",
+            side_effect=RuntimeError("nope"),
+        ):
+            entries = _read_config_models()
+            # Verbatim passthrough; no crash, no rewrite.
+            assert entries[0]["model"] == "claude-haiku-4-5"
+            assert "_configured_model" not in entries[0]

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -201,9 +201,35 @@ def build_llm_config_from_flags(
 
     def _resolve_model(name: str, role: str):
         provider = provider_of(name)
-        entry: Dict[str, Any] = {"model": name, "provider": provider, "role": role}
+        # Operators may write either ``--model claude-haiku-4-5`` or
+        # ``--model anthropic/claude-haiku-4-5``; ``models.json``
+        # always stores the bare model under a ``provider`` key. When
+        # the input carries a ``provider/`` prefix, also gate the
+        # entry match by provider so two same-named entries under
+        # different providers (e.g. an ``ollama/llama-3`` local entry
+        # and a ``together/llama-3`` cloud entry) don't collide.
+        # Strip the prefix in the constructed entry too — leaving it
+        # in produces ``anthropic/anthropic/claude-haiku-4-5`` when
+        # downstream re-prepends the provider, and the SDK ships that
+        # to Anthropic which rejects it as an unknown model.
+        if "/" in name:
+            req_provider, bare = name.split("/", 1)
+        else:
+            req_provider, bare = None, name
+        entry: Dict[str, Any] = {"model": bare, "provider": provider, "role": role}
         for cfg_entry in _get_configured_models():
-            if cfg_entry.get("model") == name and cfg_entry.get("api_key"):
+            # Match against either the resolved model name or the
+            # operator's original alias. The Anthropic resolver
+            # rewrites ``model`` to the dated snapshot and stashes
+            # the alias in ``_configured_model``; without the alias
+            # compare, an entry whose ``model`` is now
+            # ``claude-haiku-4-5-20251001`` would miss ``--model
+            # claude-haiku-4-5``.
+            if req_provider and cfg_entry.get("provider") != req_provider:
+                continue
+            cfg_name = cfg_entry.get("model")
+            cfg_alias = cfg_entry.get("_configured_model")
+            if (cfg_name == bare or cfg_alias == bare) and cfg_entry.get("api_key"):
                 entry["api_key"] = cfg_entry["api_key"]
                 break
         mc = _model_config_from_entry(entry)


### PR DESCRIPTION
  Operators configure `claude-haiku-4-5` in models.json, but Anthropic's /v1/messages only accepts dated snapshots like `claude-haiku-4-5-20251001` and the surrounding dispatcher + --model plumbing had latent bugs that made every Anthropic call 404. This PR is the resolver plus the three fixes that fall out of actually exercising the Anthropic path.
  
  ### Resolver (new)
  - `core/llm/model_resolution.py`: `resolve_anthropic(name, api_key)` maps an unversioned alias to its latest matching snapshot from a live `/v1/models` fetch. Lazy, per-process cache; soft-fails to verbatim on any error so a flaky API never breaks config reads.
  - `core/llm/detection.py`: `_apply_anthropic_resolution` rewrites the `model` field in each Anthropic entry returned from models.json and preserves the original alias in `_configured_model` for diagnostics.
    
  ### Follow-up fixes (needed to make resolved names actually work)
  1. **Dispatcher base_url doubled `/v1`.** Worker was at `http://_/anthropic/v1` but the SDK appends `/v1/messages` itself
     → upstream path was `/v1/v1/messages` → 404 on every call. 
  2. **`--model anthropic/<name>` missed its models.json entry.** The lookup didn't peel the `provider/` prefix and compared against the already-rewritten `model` field, never the `_configured_model` alias. The fallback also double-prefixed to `anthropic/anthropic/…`.
  3. **Resolver logged on every call.** Inventory was cached but the log line wasn't — same mapping printed 3× per run.