### PR TITLE
fix(codeql): detect small modules with valid build manifests (#548)

### DIFF
--- a/packages/codeql/language_detector.py
+++ b/packages/codeql/language_detector.py
@@ -41,7 +41,16 @@ class LanguageDetector:
     based on file extensions, build files, and structural indicators.
     """
 
-    # Language patterns with extensions, build files, and structural indicators
+    # Language patterns with extensions, build files, and structural indicators.
+    #
+    # ``min_confidence`` is the gate that keeps stray build manifests
+    # (e.g. a ``pom.xml`` in a docs example dir, a meta-repo
+    # ``package.json`` with no JS/TS source) from forcing a detection.
+    # With ``file_count=0`` the confidence math caps at ~0.2 (build-file
+    # boost only, no base or ratio). Every value here is >=0.5 by
+    # design — DO NOT lower any of these below 0.3 without re-deriving
+    # the manifest-only ceiling in ``_analyze_language``. The
+    # build-manifest-promotion path (gh #548) relies on this gap.
     LANGUAGE_PATTERNS = {
         "java": {
             "extensions": {".java"},
@@ -159,7 +168,12 @@ class LanguageDetector:
         Detect all languages in repository with confidence scores.
 
         Args:
-            min_files: Minimum files required to consider a language present
+            min_files: Minimum source files required when no build
+                manifest is present. Languages with a matching build
+                manifest (``go.mod``, ``pom.xml``, ``package.json``,
+                etc.) are detected regardless of source-file count,
+                provided the per-language confidence threshold is met
+                (gh #548).
 
         Returns:
             Dict mapping language name -> LanguageInfo
@@ -174,12 +188,36 @@ class LanguageDetector:
         for lang, patterns in self.LANGUAGE_PATTERNS.items():
             info = self._analyze_language(lang, patterns, stats)
 
-            # Only include if meets minimum criteria
-            if info.file_count >= min_files and info.confidence >= patterns["min_confidence"]:
+            # `min_files` exists to filter out false positives from stray
+            # source files. A matching build manifest defeats that risk
+            # on its own — see gh #548, where a real Go API with 2 .go
+            # files + go.mod was silently dropped under the old `>=3`
+            # gate. `min_confidence` still protects against stray
+            # manifests alone (e.g. a `pom.xml` in a docs example dir):
+            # a manifest without matching source extensions yields
+            # confidence ~0.2, below every language's per-pattern
+            # threshold.
+            has_build_signal = bool(info.build_files_found)
+            meets_threshold = info.file_count >= min_files or has_build_signal
+            meets_confidence = info.confidence >= patterns["min_confidence"]
+
+            if meets_threshold and meets_confidence:
                 detected[lang] = info
                 logger.info(
                     f"✓ Detected {lang}: {info.file_count} files, "
                     f"confidence={info.confidence:.2f}"
+                )
+            elif info.file_count > 0 or has_build_signal:
+                # Language had *some* signal but didn't pass — flag
+                # loudly so operators don't silently skip languages
+                # they expect to be covered. Quiet path is reserved
+                # for languages with zero presence in the repo.
+                # (gh #548)
+                logger.warning(
+                    f"⚠ Skipping {lang}: file_count={info.file_count} "
+                    f"(min={min_files}), confidence={info.confidence:.2f} "
+                    f"(min={patterns['min_confidence']}), build_files="
+                    f"{sorted(info.build_files_found) or 'none'}"
                 )
 
         if not detected:

--- a/packages/codeql/tests/test_language_detector.py
+++ b/packages/codeql/tests/test_language_detector.py
@@ -10,8 +10,6 @@ continues to protect against stray manifests alone.
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import pytest
-
 from packages.codeql import language_detector as ld_mod
 from packages.codeql.language_detector import LanguageDetector
 

--- a/packages/codeql/tests/test_language_detector.py
+++ b/packages/codeql/tests/test_language_detector.py
@@ -1,0 +1,181 @@
+"""Tests for language_detector's build-manifest-aware detection (gh #548).
+
+Regression test for the silent-skip bug where ``min_files=3`` dropped
+tiny-but-real modules (e.g. a Go API with 2 ``.go`` files + ``go.mod``).
+The fix: a matching build manifest counts as evidence on its own,
+provided per-language confidence still passes — ``min_confidence``
+continues to protect against stray manifests alone.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from packages.codeql import language_detector as ld_mod
+from packages.codeql.language_detector import LanguageDetector
+
+
+def _write(repo: Path, rel: str, content: str = "") -> None:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+
+class TestBuildManifestPromotion:
+    """A matching build manifest forces detection regardless of file_count."""
+
+    def test_tiny_go_module_with_gomod(self, tmp_path: Path):
+        # 1 .go file + go.mod — pre-fix dropped by min_files=3.
+        _write(tmp_path, "go.mod", "module tiny\n\ngo 1.21\n")
+        _write(tmp_path, "cmd/main.go", "package main\nfunc main() {}\n")
+
+        detected = LanguageDetector(tmp_path).detect_languages()
+
+        assert "go" in detected
+        assert detected["go"].file_count == 1
+        assert "go.mod" in detected["go"].build_files_found
+
+    def test_tiny_java_module_with_pom(self, tmp_path: Path):
+        _write(tmp_path, "pom.xml", "<project/>")
+        _write(tmp_path, "src/Main.java", "class Main {}")
+
+        detected = LanguageDetector(tmp_path).detect_languages()
+
+        assert "java" in detected
+        assert detected["java"].file_count == 1
+
+    def test_python_pyproject_only(self, tmp_path: Path):
+        _write(tmp_path, "pyproject.toml", "[project]\nname='x'\n")
+        _write(tmp_path, "x.py", "")
+
+        detected = LanguageDetector(tmp_path).detect_languages()
+
+        assert "python" in detected
+
+
+class TestStrayManifestRejection:
+    """A manifest alone (no matching sources) must NOT trigger detection.
+
+    Closes the inverse failure mode in gh #548 — dev-only Node ingest
+    scripts with a stray ``package.json`` would force a JS scan that
+    surfaces noise rather than real findings.
+    """
+
+    def test_pom_without_java_sources(self, tmp_path: Path):
+        _write(tmp_path, "pom.xml", "<project/>")
+        _write(tmp_path, "README.md", "")
+
+        detected = LanguageDetector(tmp_path).detect_languages()
+
+        assert "java" not in detected
+
+    def test_package_json_without_js_or_ts(self, tmp_path: Path):
+        _write(tmp_path, "package.json", "{}")
+        _write(tmp_path, "README.md", "")
+
+        detected = LanguageDetector(tmp_path).detect_languages()
+
+        assert "javascript" not in detected
+        assert "typescript" not in detected
+
+
+class TestFileCountAloneStillWorks:
+    """Existing path (file_count >= min_files, no manifest) keeps working."""
+
+    def test_many_python_files_no_manifest(self, tmp_path: Path):
+        for i in range(5):
+            _write(tmp_path, f"mod_{i}.py", "")
+
+        detected = LanguageDetector(tmp_path).detect_languages()
+
+        assert "python" in detected
+        assert detected["python"].file_count == 5
+
+    def test_single_go_file_no_manifest_rejected(self, tmp_path: Path):
+        # No build signal AND below file threshold — must NOT detect.
+        _write(tmp_path, "scratch.go", "package main\n")
+
+        detected = LanguageDetector(tmp_path).detect_languages()
+
+        assert "go" not in detected
+
+
+class TestPolyglotMonorepo:
+    """The real-world clydehq case: Go API + JS frontend, each module
+    too small to clear the old ``min_files=3`` gate. Pre-fix dropped
+    both silently; post-fix detects both via their respective build
+    manifests, while NOT promoting typescript (no ``.ts`` files even
+    though ``package.json`` is in both JS and TS build-file sets).
+    """
+
+    def test_go_api_and_js_frontend_both_detected(self, tmp_path: Path):
+        # Go API
+        _write(tmp_path, "api/go.mod", "module api\n")
+        _write(tmp_path, "api/main.go", "package main\n")
+        # JS frontend
+        _write(tmp_path, "web/package.json", "{}")
+        _write(tmp_path, "web/index.js", "// js\n")
+
+        detected = LanguageDetector(tmp_path).detect_languages()
+
+        assert "go" in detected, "Go module must be detected via go.mod"
+        assert "javascript" in detected, "JS module must be detected via package.json"
+        assert "typescript" not in detected, (
+            "typescript shares package.json but has no .ts files; "
+            "confidence must keep it out"
+        )
+
+
+class TestSkipLogging:
+    """Languages with *some* signal that fail the gates must log at WARN.
+
+    Closes the "operator thinks /agentic succeeded but a language got
+    dropped" class of bug — silent skips are the surprise; loud skips
+    are operator-actionable. Equally important: languages with *no*
+    signal at all stay quiet — otherwise every detection run would
+    emit ~10 WARN lines for every absent language.
+    """
+
+    def test_low_signal_language_warns(self, tmp_path: Path, monkeypatch):
+        # One stray .rb with no Gemfile — below file threshold, no
+        # manifest, but file_count > 0 so the WARN branch fires.
+        _write(tmp_path, "scratch.rb", "")
+
+        # core.logging's "raptor" wrapper installs a StreamHandler
+        # against the *original* sys.stderr at import time and sets
+        # propagate=False, so neither caplog nor capsys captures it
+        # mid-test. Mock the module-level logger to inspect the call
+        # directly — this is the cleanest unit-level assertion.
+        mock_logger = MagicMock()
+        monkeypatch.setattr(ld_mod, "logger", mock_logger)
+
+        LanguageDetector(tmp_path).detect_languages()
+
+        warning_calls = [c.args[0] for c in mock_logger.warning.call_args_list]
+        assert any(
+            "Skipping ruby" in msg for msg in warning_calls
+        ), f"expected ruby-skip WARN; got warnings: {warning_calls}"
+
+    def test_completely_absent_languages_do_not_warn(self, tmp_path: Path, monkeypatch):
+        # Just Python source — no ruby, no go, no java, no js etc.
+        # The WARN branch must stay quiet for every absent language;
+        # otherwise every clean detection run would emit ~10 spurious
+        # "Skipping <lang>" lines for every language NOT in the repo.
+        _write(tmp_path, "a.py", "")
+        _write(tmp_path, "b.py", "")
+        _write(tmp_path, "c.py", "")
+
+        mock_logger = MagicMock()
+        monkeypatch.setattr(ld_mod, "logger", mock_logger)
+
+        LanguageDetector(tmp_path).detect_languages()
+
+        spurious = [
+            c.args[0] for c in mock_logger.warning.call_args_list
+            if "Skipping" in c.args[0]
+        ]
+        assert spurious == [], (
+            f"expected no skip-WARNs for absent languages; "
+            f"got noisy warnings: {spurious}"
+        )


### PR DESCRIPTION
`language_detector.py` gated detection on `file_count >= min_files=3`, silently dropping modules with a valid build manifest but few source files — e.g. a real Go API with 2 .go files plus go.mod. Operators had no signal a language was skipped, and `/agentic` reported success while skipping an entire language on real monorepo targets.

A matching build manifest now clears the file-count gate on its own; `min_confidence` still backstops against stray-manifest false positives (manifest-only confidence caps at ~0.2, well below every language's \>=0.5 threshold). Languages with file_count > 0 or a manifest that still fail the gates now log at WARN instead of disappearing silently.

Reported with a precise repro by @ZephrFish.