### PR TITLE
fix(sandbox,codeql,llm): fire Semgrep, fix CodeQL crash, harden alias lookup

### DIFF
--- a/core/llm/dispatcher/tests/test_dispatcher.py
+++ b/core/llm/dispatcher/tests/test_dispatcher.py
@@ -555,6 +555,21 @@ class TestRealAnthropicSDKThroughDispatcher:
             req_body = json.loads(upstream.captured["body"])
             assert req_body["model"] == "claude-3-haiku-20240307"
             assert req_body["messages"][0]["content"] == "ping"
+
+            # ---- upstream path is exactly ``/v1/messages`` ----
+            # Pins the contract that the worker base_url + dispatcher
+            # prefix-strip + SDK's own ``/v1/messages`` append produce
+            # the right upstream path. A regression that returns to
+            # the old doubled-``/v1/v1/messages`` shape would fail
+            # against the real Anthropic 404 in production without
+            # this assertion.
+            assert upstream.captured["path"] == "/v1/messages", (
+                f"upstream path = {upstream.captured['path']!r} "
+                "— expected '/v1/messages'. If this fails with "
+                "'/v1/v1/messages' the worker base_url has been "
+                "set to 'http://_/anthropic/v1' instead of "
+                "'http://_/anthropic' (SDK appends /v1 itself)."
+            )
         finally:
             upstream.shutdown()
             d.shutdown()

--- a/core/llm/model_resolution.py
+++ b/core/llm/model_resolution.py
@@ -97,8 +97,19 @@ def resolve_anthropic(name: str, api_key: Optional[str]) -> str:
     resolved = max(candidates)
     if resolved != name:
         pair = (name, resolved)
-        if pair not in _LOGGED_RESOLUTIONS:
-            _LOGGED_RESOLUTIONS.add(pair)
+        # Lock around the set check + add so two concurrent
+        # first-callers can't race past the membership test and
+        # double-log the same mapping. Re-use the inventory lock —
+        # the two pieces of dedupe state (cache + log set) move
+        # together at startup and locking them as one ensures no
+        # ordering window where one is populated and the other isn't.
+        with _INVENTORY_LOCK:
+            if pair not in _LOGGED_RESOLUTIONS:
+                _LOGGED_RESOLUTIONS.add(pair)
+                _emit = True
+            else:
+                _emit = False
+        if _emit:
             logger.info(
                 f"Resolved Anthropic model alias {name} -> {resolved} "
                 f"(from /v1/models inventory)"

--- a/core/sandbox/context.py
+++ b/core/sandbox/context.py
@@ -1574,6 +1574,23 @@ def sandbox(block_network: bool = False, target: str = None, output: str = None,
                         if isinstance(_stderr_text, bytes):
                             _stderr_text = _stderr_text.decode(
                                 "utf-8", errors="replace")
+                        # Strip ``RAPTOR:``-prefixed lines before the
+                        # emptiness test. Those are deliberate
+                        # post-fork diagnostics from the sandbox itself
+                        # (see core/sandbox/_fork_safe_warn.py) — e.g.
+                        # the benign ``mount_ns: target remount-ro
+                        # failed; relying on Landlock`` warning, which
+                        # fires on most Linux hosts and would
+                        # otherwise defeat this gate. The convention
+                        # is documented; no tool legitimately emits
+                        # the prefix, and an attacker who could spoof
+                        # it would only re-trigger this same fallback
+                        # — they can already do that today by exiting
+                        # 126 with empty stderr.
+                        _stderr_text = "\n".join(
+                            ln for ln in _stderr_text.splitlines()
+                            if not ln.lstrip().startswith("RAPTOR:")
+                        )
                         if (tool_paths
                                 and result.returncode in (126, 127)
                                 and not _stderr_text.strip()):

--- a/core/sandbox/tests/test_sandbox.py
+++ b/core/sandbox/tests/test_sandbox.py
@@ -1714,6 +1714,23 @@ class TestSpeculativeToolPathsRetry(unittest.TestCase):
         self.assertIn("not _stderr_text.strip()", src,
                       "speculative-C retry must filter on empty stderr")
 
+    def test_raptor_prefix_lines_dont_block_retry(self):
+        """``RAPTOR:``-prefixed lines (sandbox-internal post-fork
+        diagnostics from ``warn_post_fork``) MUST be stripped before
+        the emptiness test — otherwise the benign mount-ns
+        ``remount-ro failed; relying on Landlock`` warning, which
+        fires on most Linux hosts, defeats the retry and Semgrep
+        runs out of the sandbox with no findings.
+
+        Pinned by source-grep so a refactor that drops the
+        prefix-filter doesn't silently regress."""
+        from pathlib import Path
+        from core.sandbox import context as _ctx
+        src = Path(_ctx.__file__).read_text()
+        self.assertIn('startswith("RAPTOR:")', src,
+                      "speculative-C retry must skip RAPTOR:-prefixed "
+                      "sandbox diagnostics in the emptiness check")
+
 
 class TestSpeculativeFailureCache(unittest.TestCase):
     """The per-cmd speculative-failure cache prevents repeated mount-ns

--- a/core/security/llm_family.py
+++ b/core/security/llm_family.py
@@ -97,6 +97,42 @@ def provider_of(model_id: str) -> str:
     return provider_for_family(family_of(model_id))
 
 
+def bare_model_id(model_id: str) -> str:
+    """Return the model identifier with any aggregator + provider
+    prefix peeled off.
+
+    Mirrors :func:`family_of`'s aggregator-peel loop and then strips a
+    single ``<provider>/`` prefix when the head matches one of the
+    known provider strings. Examples::
+
+        bare_model_id("anthropic/claude-haiku-4-5")
+            -> "claude-haiku-4-5"
+        bare_model_id("together/anthropic/claude-haiku-4-5")
+            -> "claude-haiku-4-5"
+        bare_model_id("claude-haiku-4-5")
+            -> "claude-haiku-4-5"
+
+    Used by call-sites that need to match user-supplied ``--model``
+    arguments against ``models.json`` entries (which store the bare
+    model under a separate ``provider`` key).
+    """
+    needle = model_id
+    for _ in range(4):
+        peeled = False
+        for prefix in _AGGREGATOR_PREFIXES:
+            if needle.lower().startswith(prefix):
+                needle = needle[len(prefix):]
+                peeled = True
+                break
+        if not peeled:
+            break
+    if "/" in needle:
+        head, rest = needle.split("/", 1)
+        if head.lower() in {v for v in _FAMILY_TO_PROVIDER.values()}:
+            needle = rest
+    return needle
+
+
 def family_of(model_id: str) -> Family:
     """Return the model family for a model identifier.
 

--- a/core/security/tests/test_llm_family.py
+++ b/core/security/tests/test_llm_family.py
@@ -3,10 +3,36 @@
 from __future__ import annotations
 
 from core.security.llm_family import (
+    bare_model_id,
     family_of,
     same_family,
     select_cross_family_checker,
 )
+
+
+def test_bare_model_id_passes_through_bare_names():
+    assert bare_model_id("claude-haiku-4-5") == "claude-haiku-4-5"
+    assert bare_model_id("gpt-5") == "gpt-5"
+    assert bare_model_id("gemini-2.5-pro") == "gemini-2.5-pro"
+
+
+def test_bare_model_id_peels_provider_prefix():
+    assert bare_model_id("anthropic/claude-haiku-4-5") == "claude-haiku-4-5"
+    assert bare_model_id("openai/gpt-5") == "gpt-5"
+    assert bare_model_id("gemini/gemini-2.5-pro") == "gemini-2.5-pro"
+
+
+def test_bare_model_id_peels_aggregator_then_provider():
+    # ``together/anthropic/claude-haiku-4-5`` — aggregator + provider
+    # both peel; the lookup in models.json sees just ``claude-haiku-4-5``.
+    assert bare_model_id("together/anthropic/claude-haiku-4-5") == "claude-haiku-4-5"
+    assert bare_model_id("openrouter/openai/gpt-5") == "gpt-5"
+
+
+def test_bare_model_id_leaves_unknown_prefixes_alone():
+    # ``foo/`` is not a known provider — preserve as-is so an
+    # operator typo doesn't silently collapse to an unintended match.
+    assert bare_model_id("foo/bar-1") == "foo/bar-1"
 
 
 # --- family_of ---

--- a/packages/codeql/build_detector.py
+++ b/packages/codeql/build_detector.py
@@ -1012,7 +1012,7 @@ print(f"Compiled {{ok}}/{{total}} files ({{fail}} failed)")
                 logger.warning(f"Build script crashed: {tail}")
                 return None
         except (subprocess.TimeoutExpired, Exception) as e:
-            logger.warning("Build script never ran (%r) — treating as 'didn't run'", e)
+            logger.warning(f"Build script never ran ({e!r}) — treating as 'didn't run'")
             return None
 
         # Parse gcc/g++ errors from stderr
@@ -1064,11 +1064,10 @@ print(f"Compiled {{ok}}/{{total}} files ({{fail}} failed)")
         )
         if not any(real_claude.startswith(p) for p in allowed_prefixes):
             logger.info(
-                "  Skipping CC flag inference — `claude` resolves to %r "
+                f"  Skipping CC flag inference — `claude` resolves to {real_claude!r} "
                 "which is outside the install-location allowlist. "
                 "If this is a legitimate location, add it to "
-                "_cc_suggest_flags' `allowed_prefixes`.",
-                real_claude,
+                "_cc_suggest_flags' `allowed_prefixes`."
             )
             return None
 

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -194,28 +194,25 @@ def build_llm_config_from_flags(
     """
     from core.llm.config import LLMConfig, _model_config_from_entry, _get_configured_models
     from core.llm.model_data import PROVIDER_ENV_KEYS
-    from core.security.llm_family import provider_of
+    from core.security.llm_family import provider_of, bare_model_id
 
     models = models or []
     llm_config = None
 
     def _resolve_model(name: str, role: str):
+        # Operators may write any of ``--model claude-haiku-4-5``,
+        # ``--model anthropic/claude-haiku-4-5``, or an aggregator
+        # form like ``--model together/anthropic/claude-haiku-4-5``;
+        # ``models.json`` always stores the bare model under a
+        # separate ``provider`` key. Compute provider via
+        # ``provider_of`` (which peels aggregators) and bare model
+        # via ``bare_model_id`` so all three forms collapse to the
+        # same lookup. Leaving the prefix in the entry's ``model``
+        # field would produce ``anthropic/anthropic/claude-haiku-4-5``
+        # when downstream re-prepends the provider — the SDK ships
+        # that to Anthropic which 404s as an unknown model.
         provider = provider_of(name)
-        # Operators may write either ``--model claude-haiku-4-5`` or
-        # ``--model anthropic/claude-haiku-4-5``; ``models.json``
-        # always stores the bare model under a ``provider`` key. When
-        # the input carries a ``provider/`` prefix, also gate the
-        # entry match by provider so two same-named entries under
-        # different providers (e.g. an ``ollama/llama-3`` local entry
-        # and a ``together/llama-3`` cloud entry) don't collide.
-        # Strip the prefix in the constructed entry too — leaving it
-        # in produces ``anthropic/anthropic/claude-haiku-4-5`` when
-        # downstream re-prepends the provider, and the SDK ships that
-        # to Anthropic which rejects it as an unknown model.
-        if "/" in name:
-            req_provider, bare = name.split("/", 1)
-        else:
-            req_provider, bare = None, name
+        bare = bare_model_id(name)
         entry: Dict[str, Any] = {"model": bare, "provider": provider, "role": role}
         for cfg_entry in _get_configured_models():
             # Match against either the resolved model name or the
@@ -224,8 +221,10 @@ def build_llm_config_from_flags(
             # the alias in ``_configured_model``; without the alias
             # compare, an entry whose ``model`` is now
             # ``claude-haiku-4-5-20251001`` would miss ``--model
-            # claude-haiku-4-5``.
-            if req_provider and cfg_entry.get("provider") != req_provider:
+            # claude-haiku-4-5``. Gate by provider too so two
+            # same-named entries under different providers don't
+            # collide (e.g. ``ollama/llama-3`` vs ``together/llama-3``).
+            if provider and cfg_entry.get("provider") != provider:
                 continue
             cfg_name = cfg_entry.get("model")
             cfg_alias = cfg_entry.get("_configured_model")


### PR DESCRIPTION
Three independent bugs found while exercising the full /agentic pipeline end-to-end through the Anthropic dispatcher, plus follow-up hardening on the dispatcher + alias work already landed.

- core/sandbox/context.py: the speculative-C 126/127 retry that falls back to Landlock-only when mount-ns can't see a tool's native deps was gated on empty stderr — but the sandbox's own benign post-fork warning (`RAPTOR: mount_ns: target remount-ro failed; relying on Landlock`) lands in stderr on most Linux hosts, defeating the gate. Every Semgrep scan exited 126 and contributed zero SARIF; only CodeQL produced findings. Filter `RAPTOR:`-prefixed lines (a documented sandbox-internal sentinel — every emitter lives in trusted sandbox code) out of the emptiness check so the retry fires and Semgrep can resolve `semgrep-core` under Landlock-only. Regression test pins the filter in source.

  Security: the only effect of the filter is re-enabling a fallback that's already reachable today by exiting 126 with empty stderr. Landlock still enforces all read/write rules; the downgrade is path-existence visibility (defense-in-depth), not a control bypass.

- packages/codeql/build_detector.py: two `RaptorLogger.info()` / `.warning()` call sites used printf-style positional args, which the wrapper doesn't support — TypeError aborted CodeQL during build-system detection. Convert to f-strings.

- core/security/llm_family.py: add public `bare_model_id` helper mirroring `family_of`'s aggregator-peel loop, plus a provider- prefix strip. Lets call-sites that match user-supplied `--model` arguments against models.json entries collapse all three forms — bare (`claude-haiku-4-5`), provider-prefixed (`anthropic/claude-haiku-4-5`), and aggregator-prefixed (`together/anthropic/claude-haiku-4-5`) — to the same lookup.

- packages/llm_analysis/orchestrator.py: rewire `_resolve_model` on top of `bare_model_id` so the aggregator form works alongside the bare + `provider/` forms already supported.

- core/llm/model_resolution.py: lock `_LOGGED_RESOLUTIONS` mutation under `_INVENTORY_LOCK` so concurrent first-callers can't race past the membership test and double-log the same mapping.

- core/llm/dispatcher/tests/test_dispatcher.py: pin the upstream path in the real-SDK E2E. A regression that re-doubles `/v1/` in the worker's base_url would surface here instead of as a 404 against live Anthropic in production.