### PR TITLE
feat(core/logging): accept format-string args in RaptorLogger levels

### DIFF
--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -1191,16 +1191,10 @@ class OpenAICompatibleProvider(LLMProvider):
                 _raw = str(getattr(tc.function, "arguments", ""))[:400]
                 _name = getattr(tc.function, "name", "?")
                 _tcid = getattr(tc, "id", "?")
-                # `RaptorLogger.warning(message, **kwargs)` accepts
-                # ONLY a single message arg (no printf-style varargs
-                # like stdlib `logging.Logger.warning`). Pre-fix the
-                # call passed positional substitution args and raised
-                # `TypeError: warning() takes 2 positional arguments
-                # but 6 were given`. Pre-format via f-string instead.
                 logger.warning(
-                    f"OpenAI-compat tool-call arguments unparseable for "
-                    f"tool={_name!r} (id={_tcid!r}): {_arg_exc}. "
-                    f"Raw: {_raw!r}"
+                    "OpenAI-compat tool-call arguments unparseable for "
+                    "tool=%r (id=%r): %s. Raw: %r",
+                    _name, _tcid, _arg_exc, _raw,
                 )
                 args = {}
             out_blocks.append(ToolCall(
@@ -2571,19 +2565,13 @@ class ClaudeCodeLLMProvider(LLMProvider):
         # can decide whether to switch providers or accept the gap.
         if provider_specific and not type(self)._provider_specific_warned:
             type(self)._provider_specific_warned = True
-            # `RaptorLogger.warning(message, **kwargs)` accepts only a
-            # single message arg (no printf-style varargs). Pre-fix
-            # this site passed a positional substitution arg and
-            # raised `TypeError: warning() takes 2 positional arguments
-            # but 3 were given` on the FIRST call that hit this
-            # branch. Same root cause as batches J33 + 532. Pre-format
-            # via f-string.
             _kwargs_list = sorted(provider_specific.keys())
             logger.warning(
-                f"ClaudeCodeLLMProvider.turn: ignoring provider_specific "
-                f"kwargs {_kwargs_list} — CC's subprocess interface doesn't expose these. "
-                f"If you need per-turn control over temperature/top_p/etc., "
-                f"switch to AnthropicProvider (set ANTHROPIC_API_KEY)."
+                "ClaudeCodeLLMProvider.turn: ignoring provider_specific "
+                "kwargs %s — CC's subprocess interface doesn't expose these. "
+                "If you need per-turn control over temperature/top_p/etc., "
+                "switch to AnthropicProvider (set ANTHROPIC_API_KEY).",
+                _kwargs_list,
             )
 
         # No tools → plain text generation. Skip the schema overhead.

--- a/core/logging/__init__.py
+++ b/core/logging/__init__.py
@@ -200,30 +200,49 @@ class RaptorLogger:
                 extra[k] = v
         return exc_info, stack_info, extra
 
-    def debug(self, message: str, **kwargs: Any) -> None:
+    # ── Level methods ──────────────────────────────────────────────
+    #
+    # All five accept the standard stdlib `logging.Logger` signature
+    # `(message, *args, **kwargs)` so format strings work natively:
+    #
+    #     logger.info("Processing %s files", count)
+    #     logger.warning("%(host)s failed: %(err)s", {"host": h, "err": e})
+    #
+    # `args` flows through to `self.logger.<level>(...)`; the stdlib
+    # `LogRecord.getMessage()` applies %-formatting lazily (only when
+    # a handler is at the right level), so DEBUG calls cost nothing
+    # when the configured level is WARNING.
+    #
+    # Pre-fix the signature was `(message, **kwargs)` — positional
+    # args raised `TypeError: info() takes 2 positional arguments but
+    # 3 were given`, forcing callers into eagerly-formatted f-strings.
+    # See `get_logger("name")` which already returned a raw stdlib
+    # `logging.Logger`; the two surfaces are now consistent.
+
+    def debug(self, message: str, *args: Any, **kwargs: Any) -> None:
         """Log debug message."""
         exc_info, stack_info, extra = self._split_kwargs(kwargs)
-        self.logger.debug(message, extra=extra, exc_info=exc_info, stack_info=stack_info)
+        self.logger.debug(message, *args, extra=extra, exc_info=exc_info, stack_info=stack_info)
 
-    def info(self, message: str, **kwargs: Any) -> None:
+    def info(self, message: str, *args: Any, **kwargs: Any) -> None:
         """Log info message."""
         exc_info, stack_info, extra = self._split_kwargs(kwargs)
-        self.logger.info(message, extra=extra, exc_info=exc_info, stack_info=stack_info)
+        self.logger.info(message, *args, extra=extra, exc_info=exc_info, stack_info=stack_info)
 
-    def warning(self, message: str, **kwargs: Any) -> None:
+    def warning(self, message: str, *args: Any, **kwargs: Any) -> None:
         """Log warning message."""
         exc_info, stack_info, extra = self._split_kwargs(kwargs)
-        self.logger.warning(message, extra=extra, exc_info=exc_info, stack_info=stack_info)
+        self.logger.warning(message, *args, extra=extra, exc_info=exc_info, stack_info=stack_info)
 
-    def error(self, message: str, **kwargs: Any) -> None:
+    def error(self, message: str, *args: Any, **kwargs: Any) -> None:
         """Log error message."""
         exc_info, stack_info, extra = self._split_kwargs(kwargs)
-        self.logger.error(message, extra=extra, exc_info=exc_info, stack_info=stack_info)
+        self.logger.error(message, *args, extra=extra, exc_info=exc_info, stack_info=stack_info)
 
-    def critical(self, message: str, **kwargs: Any) -> None:
+    def critical(self, message: str, *args: Any, **kwargs: Any) -> None:
         """Log critical message."""
         exc_info, stack_info, extra = self._split_kwargs(kwargs)
-        self.logger.critical(message, extra=extra, exc_info=exc_info, stack_info=stack_info)
+        self.logger.critical(message, *args, extra=extra, exc_info=exc_info, stack_info=stack_info)
 
     def log_job_start(self, job_id: str, tool: str, arguments: Dict[str, Any]) -> None:
         """Log job start event."""

--- a/core/logging/tests/test_logger_format_args.py
+++ b/core/logging/tests/test_logger_format_args.py
@@ -1,0 +1,147 @@
+"""Regression tests for RaptorLogger format-string / positional-args support.
+
+Pre-fix the level methods had signature `(message: str, **kwargs)`. Callers
+using the standard stdlib `logging.Logger` API — `logger.info("Processing
+%s files", count)` — got `TypeError: info() takes 2 positional arguments
+but 3 were given`. The bifurcation between `get_logger()` (RaptorLogger
+wrapper, no positional args) and `get_logger("name")` (raw `logging.Logger`,
+positional args fine) was an accidental API divergence; ~21 callsites in
+the tree were silently broken because the majority pattern was the wrapper.
+
+Post-fix: `(message: str, *args, **kwargs)` — args flow through to
+`self.logger.<level>(message, *args, extra=..., exc_info=..., stack_info=...)`
+and the stdlib `LogRecord.getMessage()` applies %-formatting lazily.
+
+This test covers all five level methods × the three format styles that
+matter (single %s, multi-arg, mapping-style %(name)s), plus the no-args
+backwards-compat path and the args+extra interaction so future regressions
+don't reintroduce the bifurcation.
+"""
+
+from __future__ import annotations
+
+import logging
+import unittest
+
+from core.logging import RaptorLogger
+
+
+class _CapturingHandler(logging.Handler):
+    """Collect records for inspection without touching disk."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+class FormatArgsAcrossLevelsTest(unittest.TestCase):
+    """Every level method must accept positional args and %-format them."""
+
+    def setUp(self) -> None:
+        self.raptor_logger = RaptorLogger()
+        self.handler = _CapturingHandler()
+        self.raptor_logger.logger.addHandler(self.handler)
+
+    def tearDown(self) -> None:
+        self.raptor_logger.logger.removeHandler(self.handler)
+
+    def _last_message(self) -> str:
+        return self.handler.records[-1].getMessage()
+
+    def _assert_single_arg(self, method_name: str) -> None:
+        method = getattr(self.raptor_logger, method_name)
+        # Pre-fix: TypeError. Post-fix: stdlib %-formatting via getMessage().
+        method("Processing %s files", 42)
+        self.assertEqual(self._last_message(), "Processing 42 files")
+
+    def test_debug_accepts_positional_args(self) -> None:
+        self._assert_single_arg("debug")
+
+    def test_info_accepts_positional_args(self) -> None:
+        self._assert_single_arg("info")
+
+    def test_warning_accepts_positional_args(self) -> None:
+        self._assert_single_arg("warning")
+
+    def test_error_accepts_positional_args(self) -> None:
+        self._assert_single_arg("error")
+
+    def test_critical_accepts_positional_args(self) -> None:
+        self._assert_single_arg("critical")
+
+
+class FormatStyleTest(unittest.TestCase):
+    """Exercise the three %-formatting shapes stdlib logging supports."""
+
+    def setUp(self) -> None:
+        self.raptor_logger = RaptorLogger()
+        self.handler = _CapturingHandler()
+        self.raptor_logger.logger.addHandler(self.handler)
+
+    def tearDown(self) -> None:
+        self.raptor_logger.logger.removeHandler(self.handler)
+
+    def test_multi_positional_args(self) -> None:
+        self.raptor_logger.info("git fetch (depth=%d): %s @ %s", 1, "github.com/x/y", "abc123")
+        self.assertEqual(
+            self.handler.records[-1].getMessage(),
+            "git fetch (depth=1): github.com/x/y @ abc123",
+        )
+
+    def test_mapping_style_format(self) -> None:
+        # Stdlib supports `args` being a single dict for %(name)s formatting.
+        self.raptor_logger.warning(
+            "%(host)s failed: %(err)s",
+            {"host": "example.com", "err": "timeout"},
+        )
+        self.assertEqual(
+            self.handler.records[-1].getMessage(),
+            "example.com failed: timeout",
+        )
+
+    def test_typeful_args_repr_via_pct_s(self) -> None:
+        # `%s` calls str() on the arg — Path / Exception / custom objects
+        # serialise without the caller pre-stringifying.
+        from pathlib import Path
+        self.raptor_logger.error("read failed for %s: %s", Path("/tmp/x"), ValueError("nope"))
+        self.assertEqual(
+            self.handler.records[-1].getMessage(),
+            "read failed for /tmp/x: nope",
+        )
+
+
+class BackwardsCompatTest(unittest.TestCase):
+    """Existing f-string + bare-message callers must still work."""
+
+    def setUp(self) -> None:
+        self.raptor_logger = RaptorLogger()
+        self.handler = _CapturingHandler()
+        self.raptor_logger.logger.addHandler(self.handler)
+
+    def tearDown(self) -> None:
+        self.raptor_logger.logger.removeHandler(self.handler)
+
+    def test_no_args_no_formatting(self) -> None:
+        # f-string / pre-formatted message, no positional args. Must NOT
+        # try to %-format (would crash on `%` chars in the message).
+        self.raptor_logger.info("Coverage: 87% of files reviewed")
+        self.assertEqual(
+            self.handler.records[-1].getMessage(),
+            "Coverage: 87% of files reviewed",
+        )
+
+    def test_kwargs_still_route_to_extra(self) -> None:
+        # Pre-existing kwarg-as-extra contract preserved (the reserved-
+        # kwarg test covers the rename path; this one covers the
+        # plain-passthrough path alongside positional args).
+        self.raptor_logger.info("Processed %s files", 5, job_id="abc-123")
+        last = self.handler.records[-1]
+        self.assertEqual(last.getMessage(), "Processed 5 files")
+        self.assertEqual(getattr(last, "job_id", None), "abc-123")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
RaptorLogger.{debug,info,warning,error,critical} had signature `(message: str, **kwargs)` — positional args raised TypeError ("info() takes 2 positional arguments but 3 were given"), forcing callers into eagerly-formatted f-strings. The wrapper's API surface accidentally diverged from `get_logger("name")`, which returned a raw stdlib logging.Logger and always accepted `*args` — ~96% of consumers got the silently-broken variant.

Hard numbers on origin/main pre-fix:
  - 56 .py files call bare get_logger() (broken signature)
  - 2 .py files call get_logger("name") (stdlib, works)
  - 21 .py files contain logger.<level>("...%s...", arg) calls against the broken variant

Fix: add `*args: Any` to all five level methods and forward to self.logger.<level>(message, *args, extra=..., exc_info=..., stack_info=...). Stdlib LogRecord.getMessage() then applies %-formatting lazily; JSONFormatter already routes through getMessage() so JSONL audit-trail output picks up formatted strings correctly.

Bonus wins:
  - Lazy formatting: DEBUG-level calls cost nothing under a WARNING-level handler, vs. f-strings which eager-format every time regardless of level.
  - API parity: get_logger() and get_logger("name") now behave identically.

100% backwards compatible: existing f-string and bare-message callers pass zero positional args, so the *args tuple is empty and stdlib skips formatting unchanged.

Cleaned up the two workaround sites that explicitly cited this bug as their reason for existing:
  - core/llm/providers.py:1190 — OpenAI-compat tool-call argument parse failure (was a multi-line f-string with a 6-line block comment apologising for it)
  - core/llm/providers.py:2570 — ClaudeCodeLLMProvider provider_specific kwargs warning (same shape, same apology) Both now use %-format directly; the apology comments are gone.

Other f-string log calls in providers.py remain as-is — they're stylistic, not workarounds, and converting them is unrelated scope.