### PR TITLE
fix(agentic): distinguish None verdicts from true positives (#549)

### DIFF
--- a/core/llm/cc_adapter.py
+++ b/core/llm/cc_adapter.py
@@ -38,6 +38,15 @@ class CCDispatchConfig:
     # thought they were setting. None means "no system prompt"
     # (pass-through).
     system_prompt: Optional[str] = None
+    # Default-True: sub-agents spawned by raptor's dispatch paths
+    # (cc_dispatch, build_detector) don't need MCP servers and
+    # shouldn't inherit the operator's ``~/.claude.json`` config.
+    # Without this, every sub-agent attempts MCP bootstrap, which
+    # under raptor's sandbox egress-allowlist produces a DENY for
+    # every non-allowlisted MCP host AND wastes startup time. Set
+    # False only if a caller genuinely needs MCP servers available
+    # inside the sub-agent (no current consumer does). (gh #549)
+    strict_mcp: bool = True
 
 
 def build_cc_command(config: CCDispatchConfig) -> list[str]:
@@ -64,6 +73,14 @@ def build_cc_command(config: CCDispatchConfig) -> list[str]:
         cmd.extend(["--output-format", "json"])
     if config.json_schema is not None:
         cmd.extend(["--json-schema", json.dumps(config.json_schema)])
+    if config.strict_mcp:
+        # ``--strict-mcp-config`` tells Claude Code to ignore
+        # ``~/.claude.json`` and any project-scope ``.mcp.json``,
+        # using only what's passed via ``--mcp-config``. Pairing it
+        # with an empty config (``{}``) gives a sub-agent zero MCP
+        # servers — the right posture for raptor's per-finding
+        # analysis dispatches.
+        cmd.extend(["--strict-mcp-config", "--mcp-config", "{}"])
     return cmd
 
 

--- a/core/llm/tests/test_cc_adapter.py
+++ b/core/llm/tests/test_cc_adapter.py
@@ -23,6 +23,17 @@ class TestBuildCCCommand:
         assert cmd[cmd.index("--allowed-tools") + 1] == "Read,Grep,Glob"
         assert cmd[cmd.index("--max-budget-usd") + 1] == "1.00"
         assert "--output-format" in cmd
+        # gh #549: strict_mcp defaults to True so sub-agents don't
+        # inherit the operator's ~/.claude.json MCP servers.
+        assert "--strict-mcp-config" in cmd
+        assert cmd[cmd.index("--mcp-config") + 1] == "{}"
+
+    def test_strict_mcp_can_be_disabled(self):
+        # Opt-out path for any future consumer that genuinely needs MCP.
+        config = CCDispatchConfig(claude_bin="claude", strict_mcp=False)
+        cmd = build_cc_command(config)
+        assert "--strict-mcp-config" not in cmd
+        assert "--mcp-config" not in cmd
 
     def test_no_envelope(self):
         config = CCDispatchConfig(claude_bin="claude", capture_json_envelope=False)

--- a/core/orchestration/__init__.py
+++ b/core/orchestration/__init__.py
@@ -8,6 +8,7 @@ from core.orchestration.agentic_passes import (
     PostpassResult,
     ReachabilityPrepassResult,
 )
+from core.orchestration.funnel import bucket_orchestration_results
 
 __all__ = [
     "run_reachability_prepass",
@@ -16,4 +17,5 @@ __all__ = [
     "PrepassResult",
     "PostpassResult",
     "ReachabilityPrepassResult",
+    "bucket_orchestration_results",
 ]

--- a/core/orchestration/funnel.py
+++ b/core/orchestration/funnel.py
@@ -1,0 +1,81 @@
+"""Orchestration-result funnel classification.
+
+Pure-data helper used by the ``/agentic`` console summary (via
+``raptor_agentic.main``) and available to any future consumer that
+needs to bucket a list of per-finding LLM dispatch results.
+
+Lives here rather than inline in ``raptor_agentic.py`` so the
+classification can be unit-tested without pulling in the
+``raptor_agentic`` module's transitive imports (every ``core.*`` and
+``packages.*`` it touches), and so report writers / dashboards can
+reuse the same bucketing logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def bucket_orchestration_results(results: list[dict]) -> dict[str, Any]:
+    """Classify orchestration results into funnel counts.
+
+    Splits ``is_true_positive`` into three buckets:
+
+    * ``True``  → ``true_positives``
+    * ``False`` → ``false_positives`` (also tracked in
+      ``severity_mismatches`` when scanner level == ``"error"``)
+    * any other value, most commonly ``None`` from a q<0.5 empty
+      ``cc_dispatch`` response → ``unverdicted``
+
+    Pre-fix the inline loop in ``raptor_agentic`` treated everything
+    except ``False`` as a true positive, so a per-finding LLM call that
+    returned ``is_true_positive: None`` was silently counted as a
+    confirmed finding — masking total dispatch failure behind a
+    successful-looking funnel (gh #549).
+
+    Errored / blocked items are counted separately and skip the
+    verdict-classification path entirely; results without the
+    ``is_true_positive`` key at all are not counted (pre-existing
+    "not analysed" semantics preserved).
+
+    Returns a dict with keys:
+      - ``true_positives``    (int)
+      - ``false_positives``   (int)
+      - ``unverdicted``       (int)
+      - ``exploitable``       (int)
+      - ``failed``            (int)
+      - ``blocked``           (int)
+      - ``severity_mismatches`` (list[dict] — full result dicts for
+        scanner-error findings the LLM ruled false-positive; the
+        caller surfaces these for review)
+    """
+    buckets: dict[str, Any] = {
+        "true_positives": 0,
+        "false_positives": 0,
+        "unverdicted": 0,
+        "exploitable": 0,
+        "failed": 0,
+        "blocked": 0,
+        "severity_mismatches": [],
+    }
+    for r in results:
+        if "error" in r:
+            if r.get("error_type") == "blocked":
+                buckets["blocked"] += 1
+            else:
+                buckets["failed"] += 1
+            continue
+        if "is_true_positive" not in r:
+            continue
+        verdict = r.get("is_true_positive")
+        if verdict is True:
+            buckets["true_positives"] += 1
+        elif verdict is False:
+            buckets["false_positives"] += 1
+            if r.get("level") == "error":
+                buckets["severity_mismatches"].append(r)
+        else:
+            buckets["unverdicted"] += 1
+        if r.get("is_exploitable"):
+            buckets["exploitable"] += 1
+    return buckets

--- a/core/orchestration/tests/test_funnel.py
+++ b/core/orchestration/tests/test_funnel.py
@@ -1,0 +1,175 @@
+"""Tests for core.orchestration.funnel — bucket classification (gh #549).
+
+Regression coverage for the silent-success bug where every per-finding
+LLM dispatch returning ``is_true_positive: None`` (q<0.5 from
+cc_dispatch) was counted as a confirmed true positive, masking total
+dispatch failure behind a successful-looking report.
+"""
+
+from __future__ import annotations
+
+from core.orchestration.funnel import bucket_orchestration_results
+
+
+class TestVerdictBucketing:
+    """True / False / None on ``is_true_positive`` route correctly."""
+
+    def test_true_verdict_counts_as_true_positive(self):
+        results = [{"is_true_positive": True}]
+        b = bucket_orchestration_results(results)
+        assert b["true_positives"] == 1
+        assert b["false_positives"] == 0
+        assert b["unverdicted"] == 0
+
+    def test_false_verdict_counts_as_false_positive(self):
+        results = [{"is_true_positive": False}]
+        b = bucket_orchestration_results(results)
+        assert b["false_positives"] == 1
+        assert b["true_positives"] == 0
+        assert b["unverdicted"] == 0
+
+    def test_none_verdict_is_unverdicted_not_true_positive(self):
+        # THE bug: pre-fix the `else` branch counted this as a true
+        # positive. Three None verdicts must show as 3 unverdicted, 0
+        # true_positives.
+        results = [
+            {"is_true_positive": None},
+            {"is_true_positive": None},
+            {"is_true_positive": None},
+        ]
+        b = bucket_orchestration_results(results)
+        assert b["unverdicted"] == 3
+        assert b["true_positives"] == 0
+        assert b["false_positives"] == 0
+
+    def test_missing_key_is_not_counted(self):
+        # Pre-existing semantics: results without the ``is_true_positive``
+        # key are treated as "not analysed" and contribute to none of
+        # the three buckets.
+        results = [{"file_path": "x.py"}]
+        b = bucket_orchestration_results(results)
+        assert b["true_positives"] == 0
+        assert b["false_positives"] == 0
+        assert b["unverdicted"] == 0
+
+
+class TestErrorAndBlockedBucketing:
+    """Errored / blocked items skip the verdict path entirely."""
+
+    def test_error_increments_failed(self):
+        results = [{"error": "exit code 1: boom"}]
+        b = bucket_orchestration_results(results)
+        assert b["failed"] == 1
+        assert b["blocked"] == 0
+
+    def test_blocked_error_type_increments_blocked(self):
+        results = [{"error": "policy block", "error_type": "blocked"}]
+        b = bucket_orchestration_results(results)
+        assert b["blocked"] == 1
+        assert b["failed"] == 0
+
+    def test_error_does_not_count_verdict_or_exploitable(self):
+        # Even if the dict happens to carry is_true_positive / is_exploitable,
+        # an error short-circuits to the failed/blocked bucket only.
+        results = [{
+            "error": "timeout",
+            "is_true_positive": True,
+            "is_exploitable": True,
+        }]
+        b = bucket_orchestration_results(results)
+        assert b["failed"] == 1
+        assert b["true_positives"] == 0
+        assert b["exploitable"] == 0
+
+
+class TestExploitableTracking:
+    """``is_exploitable`` truthy increments the exploitable count."""
+
+    def test_true_positive_exploitable_counts_both(self):
+        results = [{"is_true_positive": True, "is_exploitable": True}]
+        b = bucket_orchestration_results(results)
+        assert b["true_positives"] == 1
+        assert b["exploitable"] == 1
+
+    def test_unverdicted_with_none_exploitable_is_not_counted(self):
+        # Defensive: a q<0.5 empty response has BOTH verdicts as None.
+        # Unverdicted bucket fires; exploitable does NOT (None is falsy).
+        results = [{"is_true_positive": None, "is_exploitable": None}]
+        b = bucket_orchestration_results(results)
+        assert b["unverdicted"] == 1
+        assert b["exploitable"] == 0
+
+
+class TestSeverityMismatch:
+    """False-positive verdict on a scanner-flagged ``error`` finding lands
+    in ``severity_mismatches`` for operator review.
+    """
+
+    def test_false_positive_with_error_level_flagged(self):
+        finding = {"is_true_positive": False, "level": "error", "file_path": "x.c"}
+        b = bucket_orchestration_results([finding])
+        assert b["false_positives"] == 1
+        assert b["severity_mismatches"] == [finding]
+
+    def test_false_positive_without_error_level_not_flagged(self):
+        finding = {"is_true_positive": False, "level": "warning"}
+        b = bucket_orchestration_results([finding])
+        assert b["false_positives"] == 1
+        assert b["severity_mismatches"] == []
+
+    def test_unverdicted_does_not_land_in_severity_mismatches(self):
+        # gh #549 inverse: a None verdict on an error-level scanner
+        # finding must NOT be treated as a "scanner said error but
+        # LLM said FP" mismatch — the LLM didn't say anything.
+        finding = {"is_true_positive": None, "level": "error"}
+        b = bucket_orchestration_results([finding])
+        assert b["unverdicted"] == 1
+        assert b["severity_mismatches"] == []
+
+
+class TestRealWorldShape:
+    """End-to-end shapes mirroring the gh #549 repro."""
+
+    def test_zephrfish_repro_three_empty_verdicts(self):
+        # All three findings came back with empty verdicts (q=0.08).
+        # Pre-fix: reported "True positives: 3" (silent success).
+        # Post-fix: 0 TP, 3 unverdicted, 0 exploitable.
+        results = [
+            {"is_true_positive": None, "is_exploitable": None, "file_path": "a.mjs"},
+            {"is_true_positive": None, "is_exploitable": None, "file_path": "b.mjs"},
+            {"is_true_positive": None, "is_exploitable": None, "file_path": "c.mjs"},
+        ]
+        b = bucket_orchestration_results(results)
+        assert b["true_positives"] == 0
+        assert b["false_positives"] == 0
+        assert b["unverdicted"] == 3
+        assert b["exploitable"] == 0
+        assert b["failed"] == 0
+        assert b["blocked"] == 0
+
+    def test_mixed_run(self):
+        results = [
+            {"is_true_positive": True, "is_exploitable": True},
+            {"is_true_positive": False, "level": "error"},
+            {"is_true_positive": None},
+            {"error": "timeout"},
+            {"error": "policy", "error_type": "blocked"},
+        ]
+        b = bucket_orchestration_results(results)
+        assert b["true_positives"] == 1
+        assert b["false_positives"] == 1
+        assert b["unverdicted"] == 1
+        assert b["exploitable"] == 1
+        assert b["failed"] == 1
+        assert b["blocked"] == 1
+        assert len(b["severity_mismatches"]) == 1
+
+    def test_empty_results_returns_all_zeros(self):
+        b = bucket_orchestration_results([])
+        assert b["true_positives"] == 0
+        assert b["false_positives"] == 0
+        assert b["unverdicted"] == 0
+        assert b["exploitable"] == 0
+        assert b["failed"] == 0
+        assert b["blocked"] == 0
+        assert b["severity_mismatches"] == []

--- a/packages/llm_analysis/dispatch.py
+++ b/packages/llm_analysis/dispatch.py
@@ -93,6 +93,16 @@ class DispatchTask:
             out["duration_seconds"] = round(result.duration, 1)
         if result.model:
             out["analysed_by"] = result.model
+        # Surface the validator quality score when the response was
+        # incomplete. Lets downstream report consumers see *why* a
+        # finding is unverdicted (gh #549) — `quality` defaults to 1.0
+        # and only drops when `validate_structured_response` flags
+        # missing required fields, so quietly omit it on the happy path.
+        # Gate on the rounded value so a 0.999 score (which would
+        # display as "1.00" anyway) doesn't pollute the output.
+        quality_rounded = round(result.quality, 2)
+        if quality_rounded < 1.0:
+            out["quality"] = quality_rounded
         return out
 
     def finalize(self, results: List[Dict], prior_results: dict) -> List[Dict]:

--- a/packages/llm_analysis/tests/test_dispatch.py
+++ b/packages/llm_analysis/tests/test_dispatch.py
@@ -78,6 +78,32 @@ class TestDispatchTask:
         assert processed["analysed_by"] == "test-model"
         assert processed["duration_seconds"] == 5.0
 
+    def test_process_result_omits_quality_on_happy_path(self):
+        # quality defaults to 1.0; happy path must NOT pollute every
+        # result dict with a "quality" field. gh #549.
+        task = DispatchTask()
+        dr = DispatchResult(result={"is_true_positive": True}, quality=1.0)
+        out = task.process_result({}, dr)
+        assert "quality" not in out
+
+    def test_process_result_surfaces_low_quality(self):
+        # The zephrfish-shape case (q=0.08 from cc_dispatch leaves
+        # is_true_positive=None): quality must surface in the dict so
+        # downstream report consumers can see *why* it's unverdicted.
+        task = DispatchTask()
+        dr = DispatchResult(result={"is_true_positive": None}, quality=0.08)
+        out = task.process_result({}, dr)
+        assert out["quality"] == 0.08
+
+    def test_process_result_quality_rounds_to_two_decimals(self):
+        # q=0.999 would display as "1.00" if surfaced — that's
+        # indistinguishable from the happy path, so the branch must
+        # gate on the *rounded* value, not the raw one.
+        task = DispatchTask()
+        dr = DispatchResult(result={}, quality=0.999)
+        out = task.process_result({}, dr)
+        assert "quality" not in out
+
     def test_finalize_default_noop(self):
         task = DispatchTask()
         results = [{"a": 1}]

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -1786,6 +1786,7 @@ Examples:
     analysed_count = 0
     true_positives = 0
     false_positives = 0
+    unverdicted = 0
     exploitable_count = 0
     failed_count = 0
     blocked_count = 0
@@ -1798,26 +1799,18 @@ Examples:
         analysed_count = orch.get("findings_analysed", 0)
         exploits_count = max(exploits_count, orchestration_result.get('exploits_generated', 0))
         patches_count = max(patches_count, orchestration_result.get('patches_generated', 0))
-        for r in orchestration_result.get("results", []):
-            if "error" in r:
-                if r.get("error_type") == "blocked":
-                    blocked_count += 1
-                else:
-                    failed_count += 1
-                continue
-            # Only count findings that were actually analysed (have explicit verdict)
-            if "is_true_positive" not in r:
-                continue
-            if r.get("is_true_positive") is False:
-                false_positives += 1
-                # Flag severity mismatches: scanner says error/critical but LLM says false positive
-                scanner_level = r.get("level", "")
-                if scanner_level == "error":
-                    severity_mismatches.append(r)
-            else:
-                true_positives += 1
-            if r.get("is_exploitable"):
-                exploitable_count += 1
+        # gh #549: distinguish is_true_positive=None (q<0.5 empty
+        # dispatch) from True at bucket time; otherwise total
+        # dispatch failure looks like a successful run.
+        from core.orchestration.funnel import bucket_orchestration_results
+        _buckets = bucket_orchestration_results(orchestration_result.get("results", []))
+        true_positives = _buckets["true_positives"]
+        false_positives = _buckets["false_positives"]
+        unverdicted = _buckets["unverdicted"]
+        exploitable_count = _buckets["exploitable"]
+        failed_count = _buckets["failed"]
+        blocked_count = _buckets["blocked"]
+        severity_mismatches = _buckets["severity_mismatches"]
     else:
         analysed_count = analysis.get('analyzed', 0)
         exploitable_count = analysis.get('exploitable', 0)
@@ -1865,6 +1858,14 @@ Examples:
         print(f"   True positives: {true_positives}")
         if false_positives > 0:
             print(f"   False positives: {false_positives}")
+    if unverdicted > 0:
+        # Per-finding LLM dispatch returned empty / low-quality response
+        # (q<0.5 from cc_dispatch leaves verdict fields as None). Pre-fix
+        # `else: true_positives += 1` counted these as confirmed findings,
+        # so total dispatch failure looked like a successful run.
+        # gh #549 — print loudly so the operator sees the analysis gap.
+        print(f"   ⚠️  Unverdicted: {unverdicted} "
+              f"(LLM dispatch returned empty/low-quality — analysis is incomplete)")
     contradictions = sum(1 for r in orchestration_result.get("results", [])
                          if r.get("self_contradictory")) if orchestration_result else 0
     if contradictions > 0:


### PR DESCRIPTION
`raptor_agentic` bucketed orchestration results with `if X is False else true_positive`, so per-finding dispatches that returned `is_true_positive: None` (q<0.5 empty response from cc_dispatch) were silently counted as confirmed true positives. Operators saw "True positives: 3" while every verdict field was empty.

Three coordinated fixes:

1. New `core/orchestration/funnel.bucket_orchestration_results`: True/False/None route to true_positives / false_positives / unverdicted respectively. `raptor_agentic.main` calls the helper instead of inlining the loop and surfaces `unverdicted` in the console funnel with a ⚠ marker, so total dispatch failure no longer hides behind a successful-looking run.
2. `dispatch.process_result`: propagate the validator quality score into the result dict when q<1.0, so the report shows *why* a finding is unverdicted. Gates on the rounded value to avoid a 0.999 score polluting the output as "1.00".
3. `core.llm.cc_adapter`: new `strict_mcp` field (default True) appends `--strict-mcp-config --mcp-config '{}'` so sub-agents don't inherit `~/.claude.json`. Eliminates upstream MCP-bootstrap DENY noise that was a red herring for this bug, and is a hygiene win independent of the visibility fix.

Reported with a precise repro and a sharp self-correction by @ZephrFish.