### PR TITLE
fix(ci): force-on filters when changed-files list is empty

### DIFF
--- a/.github/scripts/compute_filters.py
+++ b/.github/scripts/compute_filters.py
@@ -311,15 +311,26 @@ def evaluate(changed_files: list[str] | None) -> dict[str, bool]:
 
 
 def _read_changed_files() -> list[str] | None:
+    """Return the list of changed files, or ``None`` if unavailable.
+
+    A real PR always changes at least one file, so an *empty* list file
+    means the upstream diff fetch silently produced zero entries (e.g.
+    a fork-PR ``gh api .../pulls/N/files`` call that returned an empty
+    page on partial auth). Treat that as "diff base unavailable" and
+    force every filter on, rather than skipping all jobs.
+    """
     list_path = os.environ.get("CHANGED_FILES_LIST")
     if not list_path:
         return None
     p = Path(list_path)
     if not p.is_file():
         return None
-    return [
+    files = [
         line.strip() for line in p.read_text().splitlines() if line.strip()
     ]
+    if not files:
+        return None
+    return files
 
 
 def main() -> int:
@@ -336,7 +347,14 @@ def main() -> int:
             fh.write(f"{name}={'true' if hit else 'false'}\n")
 
     if changed is None:
-        print("No diff base available — forcing all filters to true.")
+        list_path = os.environ.get("CHANGED_FILES_LIST")
+        if list_path and Path(list_path).is_file():
+            print(
+                f"Diff base produced empty file list ({list_path}) — "
+                "treating as unavailable and forcing all filters to true."
+            )
+        else:
+            print("No diff base available — forcing all filters to true.")
     else:
         print(f"Changed files: {len(changed)}")
         for name, hit in results.items():

--- a/.github/tests/test_compute_filters.py
+++ b/.github/tests/test_compute_filters.py
@@ -1,0 +1,128 @@
+"""Tests for ``compute_filters._read_changed_files`` fallback behaviour.
+
+The workflow's ``changes`` job writes a list of changed files to
+``$CHANGED_FILES_LIST``. ``_read_changed_files`` decides how to
+interpret the four observable states:
+
+1. env var unset                 → ``None`` (force all filters on)
+2. env var set, file missing     → ``None`` (force all filters on)
+3. env var set, file empty       → ``None`` (force all filters on)
+4. env var set, file non-empty   → parsed list
+
+State 3 is the cross-fork PR case: ``gh api .../pulls/N/files`` can
+silently return zero entries on partial auth, and a real PR always
+changes at least one file, so an empty list means "diff base
+unavailable" — force-on is the safe interpretation, since the
+alternative (returning ``[]``) would skip every gated matrix entry
+and report a green CI while CodeQL ran nothing.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+# .github/tests/test_compute_filters.py → parents[2] = repo root
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / ".github" / "scripts"))
+import compute_filters  # noqa: E402
+
+
+class ReadChangedFilesTests(unittest.TestCase):
+    def test_unset_env_returns_none(self):
+        import os as _os
+        env = {k: v for k, v in _os.environ.items() if k != "CHANGED_FILES_LIST"}
+        with mock.patch.dict("os.environ", env, clear=True):
+            self.assertIsNone(compute_filters._read_changed_files())
+
+    def test_missing_file_returns_none(self):
+        with tempfile.TemporaryDirectory() as d:
+            ghost = Path(d) / "does_not_exist.txt"
+            with mock.patch.dict(
+                "os.environ", {"CHANGED_FILES_LIST": str(ghost)}
+            ):
+                self.assertIsNone(compute_filters._read_changed_files())
+
+    def test_empty_file_returns_none(self):
+        """Fork-PR partial-auth case: gh api returned zero entries."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", delete=False, suffix=".txt"
+        ) as f:
+            f.write("")
+            empty_path = f.name
+        try:
+            with mock.patch.dict(
+                "os.environ", {"CHANGED_FILES_LIST": empty_path}
+            ):
+                self.assertIsNone(compute_filters._read_changed_files())
+        finally:
+            Path(empty_path).unlink(missing_ok=True)
+
+    def test_whitespace_only_file_returns_none(self):
+        """Blank-lines-only file — same defensive intent as empty."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", delete=False, suffix=".txt"
+        ) as f:
+            f.write("\n  \n\t\n")
+            ws_path = f.name
+        try:
+            with mock.patch.dict(
+                "os.environ", {"CHANGED_FILES_LIST": ws_path}
+            ):
+                self.assertIsNone(compute_filters._read_changed_files())
+        finally:
+            Path(ws_path).unlink(missing_ok=True)
+
+    def test_populated_file_returns_list(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", delete=False, suffix=".txt"
+        ) as f:
+            f.write("core/sandbox/context.py\n")
+            f.write("packages/codeql/agent.py\n")
+            pop_path = f.name
+        try:
+            with mock.patch.dict(
+                "os.environ", {"CHANGED_FILES_LIST": pop_path}
+            ):
+                got = compute_filters._read_changed_files()
+                self.assertEqual(
+                    got,
+                    ["core/sandbox/context.py", "packages/codeql/agent.py"],
+                )
+        finally:
+            Path(pop_path).unlink(missing_ok=True)
+
+
+class EvaluateFallbackTests(unittest.TestCase):
+    def test_none_forces_all_filters_true(self):
+        """``None`` (any of the three unavailable cases) must force-on
+        every filter so CodeQL runs full analysis rather than silently
+        skipping the matrix."""
+        results = compute_filters.evaluate(None)
+        self.assertEqual(set(results), set(compute_filters.FILTERS))
+        for name, hit in results.items():
+            self.assertTrue(
+                hit,
+                msg=f"filter {name!r} was not forced on under None input",
+            )
+
+    def test_empty_list_distinct_from_none(self):
+        """Explicit empty list (genuinely no changes) → all filters off.
+
+        ``_read_changed_files`` no longer surfaces this state to
+        ``evaluate``, but the function's contract is unchanged:
+        an empty list means "no files matched anything".
+        """
+        results = compute_filters.evaluate([])
+        for name, hit in results.items():
+            self.assertFalse(
+                hit,
+                msg=f"filter {name!r} matched on empty input",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A real PR always changes at least one file, so an empty list from the `gh api .../pulls/N/files` step means the upstream diff fetch silently produced zero entries — most commonly on a fork PR where cross-repo auth partially succeeds. The prior behaviour returned `[]` to evaluate(), which set every filter to False and skipped every gated matrix entry, including all three CodeQL Analyze jobs, while reporting the workflow green. That hid the CI-integrity hole seen on PR #470.

Treat an empty (or whitespace-only) list file the same as a missing one: return None and force every filter on. Operator log now distinguishes "env unset" from "fork-PR empty list — fell back" so the failure mode is visible in workflow output.

Adds .github/tests/test_compute_filters.py covering the four observable states (unset / missing / empty / populated) and the evaluate(None) vs evaluate([]) contract.