### PR TITLE
fix(ci): suppress triaged FP flow classes in CodeQL SARIF

### DIFF
--- a/.github/scripts/sarif_known_fp_suppressions.py
+++ b/.github/scripts/sarif_known_fp_suppressions.py
@@ -1,0 +1,184 @@
+"""Apply suppressions for known false-positive flow classes.
+
+CodeQL's heuristic taint-source list pins identifiers containing
+``secret``, ``credential``, ``api_key``, etc. regardless of the
+variable's *type*. A path variable named ``vendor_secret_key: Path``
+is therefore a "source" even though it points at a file on disk —
+the cryptographic material itself lives in the file's contents and
+never enters Python's argv. When such a path string flows through a
+``cmd`` list into a sandbox audit logger or per-run denial marker,
+``py/clear-text-logging-sensitive-data`` and
+``py/clear-text-storage-of-sensitive-information`` fire on every
+operator-visible logger downstream.
+
+The source-side defences (``paths-ignore: core/sandbox/tests/**``
+plus variable renames) handle the bulk of these. This script is the
+defence-in-depth for the residual flow class where the sink is in
+production code that genuinely needs the audit visibility. It runs
+between the multi-run SARIF merge step and the upload step in
+``.github/workflows/codeql.yml``.
+
+The suppression mechanism is the standard SARIF 2.1.0 ``suppressions``
+property on a result object. GitHub Code Scanning honours external
+suppressions on upload, marking the alert as dismissed with the
+attached justification visible in the UI. Adding a new suppression
+to the table requires a code-review-visible PR — there is no
+silent UI dismissal here.
+
+Adding a new entry: append to ``KNOWN_FP_RULES`` below. Each entry
+matches results by ``(rule_id, sink_file_prefix)`` and stamps an
+external suppression with the documented justification.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class KnownFP:
+    """One (rule, sink) pair that has been triaged as a false positive."""
+
+    rule_id: str
+    sink_file_prefixes: tuple[str, ...]
+    justification: str
+
+
+# Each entry is reviewed and signed off by the security team. The
+# justification is what appears in the GitHub Code Scanning UI.
+#
+# When CodeQL surfaces a new flow that's actually a false positive,
+# the procedure is:
+#   1. Confirm the source is heuristically-named (variable name only)
+#      OR the sink is operator-visible by design;
+#   2. Document the reason in justification text below;
+#   3. Open a PR adding the entry — review checks the triage is sound.
+KNOWN_FP_RULES: tuple[KnownFP, ...] = (
+    KnownFP(
+        rule_id="py/clear-text-logging-sensitive-data",
+        sink_file_prefixes=(
+            "core/sandbox/context.py",
+            "core/sandbox/observe.py",
+        ),
+        justification=(
+            "Sandbox audit-log renderer (cmd_display). Source is a "
+            "heuristically-named path variable upstream "
+            "(e.g. vendor_secret_key: Path); the rendered string "
+            "interpolates a truncated cmd argv list for operator "
+            "visibility. Production callers do not pass real "
+            "credential material via argv — credentials live in "
+            "files referenced by path. Triaged FP."
+        ),
+    ),
+    KnownFP(
+        rule_id="py/clear-text-storage-of-sensitive-information",
+        sink_file_prefixes=(
+            "core/sandbox/summary.py",
+            "core/sandbox/observe.py",
+        ),
+        justification=(
+            "Sandbox per-run denial / audit-degraded marker files "
+            "(record_denial, record_audit_degraded). Per-run JSON "
+            "state inside the sandbox's own output directory, "
+            "operator-visible by design. Source taint is a "
+            "heuristically-named path variable, not real secret "
+            "material. Triaged FP."
+        ),
+    ),
+)
+
+
+def _result_sink_uri(result: dict) -> str | None:
+    """Return the sink file URI, or None if the result has no location."""
+    locations = result.get("locations") or []
+    if not locations:
+        return None
+    phys = locations[0].get("physicalLocation") or {}
+    artifact = phys.get("artifactLocation") or {}
+    uri = artifact.get("uri")
+    return uri if isinstance(uri, str) else None
+
+
+def _matches_known_fp(result: dict) -> KnownFP | None:
+    """Return the matching KnownFP entry, or None."""
+    rule_id = result.get("ruleId")
+    if not isinstance(rule_id, str):
+        return None
+    uri = _result_sink_uri(result)
+    if uri is None:
+        return None
+    for entry in KNOWN_FP_RULES:
+        if entry.rule_id != rule_id:
+            continue
+        if any(uri.startswith(p) for p in entry.sink_file_prefixes):
+            return entry
+    return None
+
+
+def _already_suppressed(result: dict) -> bool:
+    """True if the result already carries any external suppression."""
+    for sup in result.get("suppressions") or []:
+        if sup.get("kind") == "external":
+            return True
+    return False
+
+
+def apply_suppressions(sarif: dict) -> tuple[int, int]:
+    """Annotate matching results with external suppressions.
+
+    Returns ``(matched, newly_suppressed)``. ``matched`` counts every
+    result that hit a KnownFP entry; ``newly_suppressed`` excludes
+    results that already carried an external suppression (idempotent
+    re-runs don't double-stamp).
+    """
+    matched = 0
+    newly_suppressed = 0
+    for run in sarif.get("runs") or []:
+        for result in run.get("results") or []:
+            entry = _matches_known_fp(result)
+            if entry is None:
+                continue
+            matched += 1
+            if _already_suppressed(result):
+                continue
+            suppressions = result.setdefault("suppressions", [])
+            suppressions.append(
+                {
+                    "kind": "external",
+                    "status": "accepted",
+                    "justification": entry.justification,
+                }
+            )
+            newly_suppressed += 1
+    return matched, newly_suppressed
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            f"usage: {argv[0]} <sarif_path> "
+            "(modifies the file in place)",
+            file=sys.stderr,
+        )
+        return 2
+    sarif_path = Path(argv[1])
+    if not sarif_path.is_file():
+        print(f"ERROR: {sarif_path} is not a file", file=sys.stderr)
+        return 1
+    sarif = json.loads(sarif_path.read_text(encoding="utf-8"))
+    matched, newly = apply_suppressions(sarif)
+    sarif_path.write_text(
+        json.dumps(sarif, indent=2) + "\n", encoding="utf-8"
+    )
+    print(
+        f"Known-FP triage: matched={matched} newly_suppressed={newly} "
+        f"(rules: {len(KNOWN_FP_RULES)})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/tests/test_sarif_known_fp_suppressions.py
+++ b/.github/tests/test_sarif_known_fp_suppressions.py
@@ -1,0 +1,213 @@
+"""Tests for ``sarif_known_fp_suppressions``.
+
+The script applies SARIF 2.1.0 ``suppressions`` entries to results
+matching a documented ``(rule_id, sink_file_prefix)`` tuple. These
+tests pin the contract so the suppression table can't grow silently
+and the match logic can't regress to over- or under-suppression.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+# .github/tests/test_sarif_known_fp_suppressions.py → parents[2] = repo root
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / ".github" / "scripts"))
+import sarif_known_fp_suppressions as mod  # noqa: E402
+
+
+def _make_result(rule_id: str, uri: str | None) -> dict:
+    locations = []
+    if uri is not None:
+        locations.append(
+            {
+                "physicalLocation": {
+                    "artifactLocation": {"uri": uri},
+                    "region": {"startLine": 1},
+                }
+            }
+        )
+    return {"ruleId": rule_id, "locations": locations}
+
+
+def _wrap_in_sarif(results: list[dict]) -> dict:
+    return {
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {"driver": {"name": "CodeQL"}},
+                "results": results,
+            }
+        ],
+    }
+
+
+class MatchKnownFPTests(unittest.TestCase):
+    def test_matches_sandbox_logging_sink(self):
+        result = _make_result(
+            "py/clear-text-logging-sensitive-data",
+            "core/sandbox/context.py",
+        )
+        self.assertIsNotNone(mod._matches_known_fp(result))
+
+    def test_matches_sandbox_observe_logging_sink(self):
+        result = _make_result(
+            "py/clear-text-logging-sensitive-data",
+            "core/sandbox/observe.py",
+        )
+        self.assertIsNotNone(mod._matches_known_fp(result))
+
+    def test_matches_storage_sink_in_summary(self):
+        result = _make_result(
+            "py/clear-text-storage-of-sensitive-information",
+            "core/sandbox/summary.py",
+        )
+        self.assertIsNotNone(mod._matches_known_fp(result))
+
+    def test_does_not_match_other_rules_on_sandbox_files(self):
+        """Suppression is rule-specific — other rules on the same
+        files must still surface."""
+        result = _make_result(
+            "py/sql-injection", "core/sandbox/context.py"
+        )
+        self.assertIsNone(mod._matches_known_fp(result))
+
+    def test_does_not_match_known_rule_on_other_files(self):
+        """Suppression is path-specific — the same rule on a
+        non-sandbox file must still surface."""
+        result = _make_result(
+            "py/clear-text-logging-sensitive-data",
+            "packages/llm_analysis/agent.py",
+        )
+        self.assertIsNone(mod._matches_known_fp(result))
+
+    def test_handles_missing_location(self):
+        result = _make_result(
+            "py/clear-text-logging-sensitive-data", uri=None
+        )
+        self.assertIsNone(mod._matches_known_fp(result))
+
+    def test_handles_missing_rule_id(self):
+        result = _make_result("py/clear-text-logging-sensitive-data", "x")
+        del result["ruleId"]
+        self.assertIsNone(mod._matches_known_fp(result))
+
+
+class ApplySuppressionsTests(unittest.TestCase):
+    def test_stamps_suppression_on_match(self):
+        sarif = _wrap_in_sarif(
+            [
+                _make_result(
+                    "py/clear-text-logging-sensitive-data",
+                    "core/sandbox/context.py",
+                )
+            ]
+        )
+        matched, newly = mod.apply_suppressions(sarif)
+        self.assertEqual(matched, 1)
+        self.assertEqual(newly, 1)
+        result = sarif["runs"][0]["results"][0]
+        self.assertEqual(len(result["suppressions"]), 1)
+        sup = result["suppressions"][0]
+        self.assertEqual(sup["kind"], "external")
+        self.assertEqual(sup["status"], "accepted")
+        self.assertIn("Triaged FP", sup["justification"])
+
+    def test_idempotent_on_already_suppressed(self):
+        """Re-running the script on a SARIF that's already had this
+        suppression applied must not double-stamp."""
+        sarif = _wrap_in_sarif(
+            [
+                _make_result(
+                    "py/clear-text-logging-sensitive-data",
+                    "core/sandbox/context.py",
+                )
+            ]
+        )
+        mod.apply_suppressions(sarif)  # first pass
+        matched, newly = mod.apply_suppressions(sarif)  # second pass
+        self.assertEqual(matched, 1)
+        self.assertEqual(newly, 0)
+        self.assertEqual(
+            len(sarif["runs"][0]["results"][0]["suppressions"]), 1
+        )
+
+    def test_leaves_unrelated_results_untouched(self):
+        sarif = _wrap_in_sarif(
+            [
+                _make_result(
+                    "py/sql-injection", "core/sandbox/context.py"
+                ),
+                _make_result(
+                    "py/clear-text-logging-sensitive-data",
+                    "packages/llm_analysis/agent.py",
+                ),
+            ]
+        )
+        matched, newly = mod.apply_suppressions(sarif)
+        self.assertEqual(matched, 0)
+        self.assertEqual(newly, 0)
+        for r in sarif["runs"][0]["results"]:
+            self.assertNotIn("suppressions", r)
+
+    def test_multiple_runs_handled(self):
+        sarif = {
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {"driver": {"name": "CodeQL"}},
+                    "results": [
+                        _make_result(
+                            "py/clear-text-logging-sensitive-data",
+                            "core/sandbox/context.py",
+                        )
+                    ],
+                },
+                {
+                    "tool": {"driver": {"name": "CodeQL"}},
+                    "results": [
+                        _make_result(
+                            "py/clear-text-storage-of-sensitive-information",
+                            "core/sandbox/summary.py",
+                        )
+                    ],
+                },
+            ],
+        }
+        matched, newly = mod.apply_suppressions(sarif)
+        self.assertEqual(matched, 2)
+        self.assertEqual(newly, 2)
+
+
+class TableShapeTests(unittest.TestCase):
+    """Pin the suppression table shape so growth stays auditable."""
+
+    def test_table_nonempty(self):
+        self.assertTrue(mod.KNOWN_FP_RULES)
+
+    def test_every_entry_has_justification(self):
+        for entry in mod.KNOWN_FP_RULES:
+            self.assertTrue(
+                entry.justification.strip(),
+                msg=f"empty justification on {entry.rule_id}",
+            )
+            self.assertGreaterEqual(
+                len(entry.justification), 60,
+                msg=(
+                    f"justification too terse on {entry.rule_id} — "
+                    "explain why this is an FP, not just that it is"
+                ),
+            )
+
+    def test_every_entry_has_sink_files(self):
+        for entry in mod.KNOWN_FP_RULES:
+            self.assertTrue(
+                entry.sink_file_prefixes,
+                msg=f"empty sink_file_prefixes on {entry.rule_id}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -386,6 +386,16 @@ jobs:
           echo "Combined $(jq '.runs | length' combined.sarif) runs:"
           jq -r '.runs[] | "  - \(.automationDetails.id)  results=\(.results | length)"' combined.sarif
 
+      # Stamp suppressions on triaged FP flow classes (sandbox audit-
+      # log + denial-marker sinks). Source-side defences
+      # (paths-ignore for tests + path-typed variable renames) handle
+      # the bulk; this script is the defence-in-depth for residual
+      # results where the sink is in production code. Each entry in
+      # the script's KNOWN_FP_RULES table is reviewed in its own PR.
+      - name: Apply known-FP suppressions
+        run: |
+          python3 .github/scripts/sarif_known_fp_suppressions.py combined.sarif
+
       # Single upload, atomic delivery. The action sends one POST to
       # `/code-scanning/sarifs` containing all runs; GitHub processes
       # the multi-run file as one batch and the meta-check fires with


### PR DESCRIPTION
Heuristic-named source variables (vendor_secret_key: Path, real_secret, *_credential) flow through cmd lists into sandbox audit-log + denial-marker sinks, producing py/clear-text-logging-sensitive-data and py/clear-text-storage-of-sensitive-information alerts on every operator-visible sink in core/sandbox/. First surfaced in volume during PR #470 (ZKPoX) review.

Source-side defences (paths-ignore: core/sandbox/tests/** and path-typed variable renames) handle the bulk. This adds the defence-in-depth for residual results where the sink is in production code that genuinely needs the audit visibility.

A new pre-upload step in codeql.yml reads the merged SARIF and stamps an external suppression on each result matching a documented (rule_id, sink_file_prefix) tuple. Suppressions land as the standard SARIF 2.1.0 `suppressions` property; GitHub Code Scanning honours them on upload with the justification visible in the UI.

The KNOWN_FP_RULES table is intentionally narrow — each entry is reviewed in its own PR, with a justification of why this flow class is an FP. A test pins the minimum-justification length so future additions can't slip in unannotated.