### PR TITLE
fix(codeql/build_detector): subdir-fragment rejection + ancestor includes + missing-config diagnostic

### DIFF
--- a/packages/codeql/build_detector.py
+++ b/packages/codeql/build_detector.py
@@ -18,7 +18,7 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from shlex import quote
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 # Add parent directory to path for imports
 # packages/codeql/build_detector.py -> repo root
@@ -334,6 +334,38 @@ class BuildDetector:
         # Choose command (with fallback support)
         command = config["command"]
 
+        # Special handling for cmake: distinguish "real cmake project
+        # root" (CMakeLists.txt has cmake_minimum_required + project())
+        # from "CMake subdir fragment" (e.g. ``lib/CMakeLists.txt`` in
+        # curl's source tree, meant to be included via
+        # ``add_subdirectory`` from the parent — running ``cmake .``
+        # from the subdir fails with "No cmake_minimum_required
+        # command is present").
+        #
+        # Without this check BuildDetector confidently returned
+        # ``cmake . && make`` for any directory containing a
+        # CMakeLists.txt, which silently broke CodeQL database
+        # creation on subdir targets — surfaced by /agentic on
+        # ``curl-8.11.0/lib`` (rc=1 from the synthesized build script,
+        # zero CodeQL findings, downstream LLM analysis ran without
+        # CodeQL context).
+        if build_type == "cmake":
+            cml = working_dir / "CMakeLists.txt"
+            if cml.is_file() and not self._is_cmake_project_root(cml):
+                logger.warning(
+                    "%s is a CMake subdirectory fragment (no "
+                    "cmake_minimum_required / project() declaration). "
+                    "Skipping cmake build — point CodeQL at the "
+                    "project root instead (typically the directory "
+                    "containing the top-level CMakeLists.txt with "
+                    "project()). Falling through to per-file "
+                    "synthesised compile, which may give partial "
+                    "coverage but won't recover configure-generated "
+                    "headers (e.g. config.h).",
+                    cml,
+                )
+                return None
+
         # Special handling for gradle wrapper
         if build_type == "gradle" and "./gradlew" in command:
             gradlew = self.repo_path / "gradlew"
@@ -361,6 +393,168 @@ class BuildDetector:
             detected_files=detected_files,
             env_detect=config.get("env_detect", []),
         )
+
+    def _discover_ancestor_includes(self, max_depth: int = 3) -> List[str]:
+        """Find ``include/`` directories at ancestors of ``self.repo_path``.
+
+        Used by the synthesised-compile fallback to rescue subdir
+        targets where the public headers live in a sibling of the
+        compiled subdir. Example: repo_path ==
+        ``curl-8.11.0/lib`` — headers at ``curl-8.11.0/include/``.
+
+        Returns absolute paths (the includes are by construction
+        outside repo_path; relative paths would all start with
+        ``../`` and depend on the compiler's cwd at compile time).
+        Bounded depth so a deep target doesn't spend the entire
+        detection budget on filesystem stat() calls.
+
+        Safety: same X_OK + symlink-escape checks the cmake
+        detection path uses. An ``include/`` symlinked to /etc on
+        a malicious target would otherwise leak the operator's
+        filesystem layout into the compile script.
+        """
+        found: List[str] = []
+        try:
+            current = self.repo_path.resolve(strict=False)
+        except OSError:
+            return found
+        for _ in range(max_depth):
+            current = current.parent
+            if not current.is_dir():
+                break
+            if not os.access(current, os.X_OK):
+                break
+            include_dir = current / "include"
+            try:
+                inc_resolved = include_dir.resolve(strict=False)
+            except OSError:
+                continue
+            if (
+                include_dir.is_dir()
+                and os.access(include_dir, os.X_OK)
+                and self._has_c_header(inc_resolved)
+            ):
+                # Sanity-check the resolved path is somewhere
+                # plausible. Reject anything that resolves to a
+                # system path like /etc, /proc, /sys, /dev — these
+                # could not legitimately be the "include/" dir of
+                # the operator's source target.
+                blocked = ("/etc", "/proc", "/sys", "/dev", "/boot")
+                if any(str(inc_resolved).startswith(b) for b in blocked):
+                    logger.debug(
+                        "Skipping ancestor include candidate %s "
+                        "(resolves to a system path)",
+                        include_dir,
+                    )
+                    continue
+                found.append(str(inc_resolved))
+        return found
+
+    @staticmethod
+    def _has_c_header(path: Path) -> bool:
+        """True if ``path`` contains at least one .h/.hpp file
+        recursively. Quick existence check — does not enumerate."""
+        try:
+            for entry in path.rglob("*"):
+                if entry.is_file() and entry.suffix.lower() in (".h", ".hpp", ".hh"):
+                    return True
+        except OSError:
+            return False
+        return False
+
+    def detect_missing_config_headers(self) -> List[Tuple[str, Path]]:
+        """Detect referenced ``*config.h``-shaped headers that don't
+        exist on disk anywhere reachable.
+
+        Returns a list of (header_name, source_file_that_references_it)
+        tuples. Pure diagnostic — does NOT generate or auto-run
+        anything. Caller decides whether to log a WARNING + suggest
+        the operator pre-run ``./configure`` / ``cmake`` to materialise
+        the missing headers.
+
+        Heuristic: scan up to 200 .c/.cpp files at the top of
+        repo_path's sort order; grep for ``#include "<name>_config.h"``
+        or ``#include "config.h"``; cross-check whether each referenced
+        name exists anywhere under repo_path OR any ancestor we'd
+        consider for include discovery. Bounded scan + bounded
+        per-file read so an oversized target doesn't dominate
+        detection wall time.
+        """
+        import re
+        missing: List[Tuple[str, Path]] = []
+        # Build the set of header names that DO exist on disk —
+        # repo_path + ancestor includes we'd consider.
+        existing_header_names = set()
+        for ext in (".h", ".hpp", ".hh"):
+            for h in self.repo_path.rglob(f"*{ext}"):
+                existing_header_names.add(h.name)
+        for parent_inc in self._discover_ancestor_includes(max_depth=3):
+            try:
+                for ext in (".h", ".hpp", ".hh"):
+                    for h in Path(parent_inc).rglob(f"*{ext}"):
+                        existing_header_names.add(h.name)
+            except OSError:
+                continue
+
+        # Pattern: #include "something_config.h" OR #include "config.h"
+        pattern = re.compile(
+            r'^\s*#\s*include\s*"([^"]*config(?:_[a-z0-9_]+)?\.h)"',
+            re.MULTILINE | re.IGNORECASE,
+        )
+        seen_missing = set()
+        sources = []
+        # Also scan local .h files — many projects use a gateway
+        # header (e.g. curl's ``curl_setup.h``) that does the
+        # ``#include "curl_config.h"`` so the .c files never
+        # reference the config header directly.
+        for ext in (".c", ".cc", ".cpp", ".cxx", ".h", ".hpp"):
+            sources.extend(self.repo_path.rglob(f"*{ext}"))
+        # Cap at 200 files to bound scan time on huge targets.
+        for src in sorted(sources, key=lambda p: (len(p.parts), str(p)))[:200]:
+            try:
+                with src.open("rb") as f:
+                    text = f.read(65536).decode("utf-8", "replace")
+            except OSError:
+                continue
+            for m in pattern.finditer(text):
+                header = m.group(1)
+                if header in existing_header_names:
+                    continue
+                if header in seen_missing:
+                    continue
+                seen_missing.add(header)
+                missing.append((header, src))
+        return missing
+
+    @staticmethod
+    def _is_cmake_project_root(cmakelists: Path) -> bool:
+        """Return True if ``CMakeLists.txt`` declares itself a project
+        root (carries ``cmake_minimum_required`` or ``project()``).
+
+        Subdirectory CMakeLists fragments — e.g. ``curl-8.11.0/lib/CMakeLists.txt``,
+        meant to be included via ``add_subdirectory`` from a parent —
+        carry neither declaration and cannot be configured standalone:
+        ``cmake .`` from such a directory fails with "No
+        cmake_minimum_required command is present."
+
+        Detection: scan for either keyword at the start of any
+        non-comment line (case-insensitive — CMake commands are
+        not case-sensitive in the language). Leading whitespace
+        is tolerated so a ``project()`` inside an
+        ``if(BUILD_SOMETHING)`` block still counts. Bounded read
+        (first 64 KB) — real CMakeLists files rarely exceed this;
+        the cap protects against pathological inputs.
+        """
+        try:
+            with cmakelists.open("rb") as f:
+                head = f.read(65536).decode("utf-8", "replace")
+        except OSError:
+            return False
+        for raw in head.splitlines():
+            line = raw.lstrip().lower()
+            if line.startswith("cmake_minimum_required") or line.startswith("project("):
+                return True
+        return False
 
     def _has_build_script(self, package_json: Path) -> bool:
         """Check if package.json has a build script."""
@@ -581,6 +775,34 @@ class BuildDetector:
         if not source_files:
             return None
 
+        # Diagnostic — does NOT auto-run anything. If the target's
+        # .c files reference ``*_config.h``-shaped headers that
+        # don't exist on disk, surface a single WARNING listing
+        # them with the recommended manual fix. Configure/cmake
+        # auto-execution is intentionally out of scope (arbitrary
+        # code execution from untrusted source); the operator must
+        # opt in by running the build step themselves.
+        if language == "cpp":
+            try:
+                missing_cfg = self.detect_missing_config_headers()
+            except Exception as e:  # noqa: BLE001
+                logger.debug("missing-config-header detection failed: %s", e)
+                missing_cfg = []
+            if missing_cfg:
+                names = sorted({h for h, _ in missing_cfg})
+                sample_src = missing_cfg[0][1]
+                logger.warning(
+                    "Synthesised compile: %d config-header(s) missing "
+                    "(%s) — referenced by e.g. %s. These are typically "
+                    "generated by ``./configure`` or ``cmake`` at the "
+                    "project root. Re-run after pre-building (NOT "
+                    "auto-executed — arbitrary code execution risk) to "
+                    "recover full CodeQL coverage. Synthesised build "
+                    "will continue with partial coverage.",
+                    len(names), ", ".join(names[:5]) + ("..." if len(names) > 5 else ""),
+                    sample_src,
+                )
+
         # Create build dir and script once — reused across heuristic and CC
         import tempfile
         build_dir = Path(tempfile.mkdtemp(prefix=".raptor_build_", dir=self.repo_path))
@@ -689,6 +911,20 @@ class BuildDetector:
                         include_flags.add(f"-I{h.parent.relative_to(self.repo_path)}")
                     except ValueError:
                         pass
+            # Subdir-target rescue: walk UP from repo_path looking for
+            # sibling ``include/`` directories at ancestors. Real-world
+            # case: repo_path points at ``curl-8.11.0/lib`` and the
+            # public headers live at ``curl-8.11.0/include/curl/``;
+            # without this rescue, every ``#include <curl/curl.h>`` in
+            # the .c files fails to resolve and the synthesised
+            # compile produces a near-empty CodeQL database.
+            #
+            # Compile-context expansion only — these -I paths let the
+            # compiler find headers, but CodeQL DB still scopes to
+            # compilation events INSIDE the build target. No expansion
+            # of operator-stated scan scope.
+            for parent_inc in self._discover_ancestor_includes():
+                include_flags.add(f"-I{parent_inc}")
             include_flags = sorted(include_flags)
         elif language == "java":
             source_files = list(self.repo_path.rglob("*.java"))

--- a/packages/codeql/tests/test_build_synthesis.py
+++ b/packages/codeql/tests/test_build_synthesis.py
@@ -3,6 +3,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 
 # packages/codeql/tests/test_build_synthesis.py -> repo root
 sys.path.insert(0, str(Path(__file__).parents[3]))
@@ -205,3 +207,212 @@ class TestScriptSafety:
         # subprocess.run". Accept either.
         assert "subprocess.run(cmd" in script or "subprocess.Popen(cmd" in script
         assert "shell=True" not in script
+
+
+# =====================================================================
+# Item 1: CMake subdirectory-fragment rejection
+# =====================================================================
+
+class TestCmakeSubdirRejection:
+    """When the only CMakeLists.txt at the target is a subdir
+    fragment (no ``cmake_minimum_required`` / ``project()``),
+    BuildDetector must NOT return ``cmake . && make`` — that would
+    fail at configure and silently break CodeQL DB creation.
+    """
+
+    def test_real_cmake_root_accepted(self, tmp_path):
+        (tmp_path / "CMakeLists.txt").write_text(
+            "cmake_minimum_required(VERSION 3.10)\n"
+            "project(TestProj C)\n"
+            "add_executable(foo main.c)\n"
+        )
+        (tmp_path / "main.c").write_text("int main() { return 0; }")
+        bs = BuildDetector(tmp_path).detect_build_system("cpp")
+        assert bs is not None and bs.type == "cmake"
+
+    def test_subdir_fragment_rejected(self, tmp_path):
+        (tmp_path / "CMakeLists.txt").write_text(
+            "# Subdir fragment — meant for add_subdirectory()\n"
+            "add_library(curl_lib STATIC altsvc.c easy.c)\n"
+        )
+        (tmp_path / "altsvc.c").write_text("// stub")
+        bs = BuildDetector(tmp_path).detect_build_system("cpp")
+        assert bs is None or bs.type != "cmake"
+
+    def test_project_decl_uppercase_or_indented(self, tmp_path):
+        """CMake commands are case-insensitive; project() inside
+        ``if (BUILD_X)`` is still a project root marker."""
+        (tmp_path / "CMakeLists.txt").write_text(
+            "CMAKE_MINIMUM_REQUIRED(VERSION 3.10)\n"
+            "if(BUILD_ALL)\n"
+            "    PROJECT(MixedProj)\n"
+            "endif()\n"
+        )
+        assert BuildDetector._is_cmake_project_root(tmp_path / "CMakeLists.txt")
+
+    def test_missing_file_returns_false(self, tmp_path):
+        assert not BuildDetector._is_cmake_project_root(tmp_path / "does-not-exist.txt")
+
+
+# =====================================================================
+# Item 2: Ancestor-include discovery
+# =====================================================================
+
+class TestAncestorIncludeDiscovery:
+    """Walk up from repo_path looking for sibling ``include/``
+    directories at ancestors. Used by synthesised compile to fix
+    ``#include <foo/bar.h>`` references in subdir targets.
+    """
+
+    def test_finds_sibling_include_at_parent(self, tmp_path):
+        # tmp_path/include/foo.h + tmp_path/lib/main.c
+        (tmp_path / "include").mkdir()
+        (tmp_path / "include" / "foo.h").write_text("// header")
+        (tmp_path / "lib").mkdir()
+        (tmp_path / "lib" / "main.c").write_text("// stub")
+        bd = BuildDetector(tmp_path / "lib")
+        found = bd._discover_ancestor_includes()
+        assert any("include" in p for p in found)
+
+    def test_returns_empty_when_no_ancestor_include(self, tmp_path):
+        (tmp_path / "main.c").write_text("// stub")
+        bd = BuildDetector(tmp_path)
+        # parent of tmp_path may or may not have include/, but we're
+        # at tmp_path which has no siblings — so under normal
+        # conditions this is empty. Just verify the call works.
+        found = bd._discover_ancestor_includes()
+        # The check is type-shape: must be a list of strings.
+        assert isinstance(found, list)
+        assert all(isinstance(p, str) for p in found)
+
+    def test_skips_system_path_targets(self, tmp_path):
+        """A symlinked include/ that resolves to /etc must be rejected
+        (filesystem-layout leak defence)."""
+        import os
+        (tmp_path / "lib").mkdir()
+        try:
+            # Symlink tmp_path/include → /etc — if include/ exists
+            # and resolves to /etc, the resolution-block check should
+            # reject it.
+            os.symlink("/etc", str(tmp_path / "include"))
+        except (OSError, PermissionError):
+            pytest.skip("symlink creation not permitted")
+        bd = BuildDetector(tmp_path / "lib")
+        found = bd._discover_ancestor_includes()
+        assert not any(p.startswith("/etc") for p in found), found
+
+    def test_max_depth_bounds_walk(self, tmp_path):
+        """Walk should stop at max_depth levels even if more ancestors exist."""
+        # Make tmp_path/a/b/c/lib/main.c
+        deep = tmp_path / "a" / "b" / "c" / "lib"
+        deep.mkdir(parents=True)
+        (deep / "main.c").write_text("// stub")
+        # Put include at tmp_path (4 levels up from lib)
+        (tmp_path / "include").mkdir()
+        (tmp_path / "include" / "x.h").write_text("// hdr")
+        bd = BuildDetector(deep)
+        # max_depth=2 isn't enough to reach tmp_path/include
+        found_shallow = bd._discover_ancestor_includes(max_depth=2)
+        assert not found_shallow
+        # max_depth=4 IS enough
+        found_deep = bd._discover_ancestor_includes(max_depth=4)
+        assert any("include" in p for p in found_deep)
+
+    def test_include_flags_use_absolute_paths(self, tmp_path):
+        """End-to-end: synthesised build script uses absolute -I
+        for ancestor includes (relative would be ambiguous from the
+        compiler's cwd)."""
+        (tmp_path / "include").mkdir()
+        (tmp_path / "include" / "lib.h").write_text("// header")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.c").write_text("int main() { return 0; }")
+        bd = BuildDetector(tmp_path / "src")
+        bd.synthesise_build_command("cpp")
+        script = _find_script(tmp_path / "src").read_text()
+        # Should contain absolute -I path to tmp_path/include.
+        assert f"-I{tmp_path}/include" in script or f"-I{tmp_path.resolve()}/include" in script
+
+
+# =====================================================================
+# Item 3: Missing-config-header detection (diagnostic only, no exec)
+# =====================================================================
+
+class TestMissingConfigHeaderDetection:
+    """``detect_missing_config_headers`` is a pure diagnostic — it
+    surfaces a list of referenced ``*config.h`` headers that don't
+    exist on disk anywhere reachable. Does NOT auto-execute
+    configure/cmake (arbitrary-code-execution risk).
+    """
+
+    def test_detects_missing_curl_config(self, tmp_path):
+        """``#include "curl_config.h"`` in a .h with no such file on disk."""
+        (tmp_path / "main.c").write_text(
+            "#include \"setup.h\"\nint main() { return 0; }"
+        )
+        (tmp_path / "setup.h").write_text(
+            "#include \"curl_config.h\"\n"  # missing target
+        )
+        bd = BuildDetector(tmp_path)
+        missing = bd.detect_missing_config_headers()
+        assert any(h == "curl_config.h" for h, _ in missing)
+
+    def test_detects_missing_plain_config_h(self, tmp_path):
+        """``#include "config.h"`` is the autoconf-canonical pattern."""
+        (tmp_path / "x.c").write_text("#include \"config.h\"\n")
+        bd = BuildDetector(tmp_path)
+        missing = bd.detect_missing_config_headers()
+        assert any(h == "config.h" for h, _ in missing)
+
+    def test_reports_zero_when_header_exists(self, tmp_path):
+        """If the referenced config.h is present on disk, no report."""
+        (tmp_path / "x.c").write_text("#include \"my_config.h\"\n")
+        (tmp_path / "my_config.h").write_text("/* generated */\n")
+        bd = BuildDetector(tmp_path)
+        missing = bd.detect_missing_config_headers()
+        assert not [h for h, _ in missing if h == "my_config.h"]
+
+    def test_reports_zero_when_ancestor_include_has_it(self, tmp_path):
+        """Header at ancestor include/ counts as 'on disk'."""
+        (tmp_path / "include").mkdir()
+        (tmp_path / "include" / "ancestor_config.h").write_text("/* gen */\n")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.c").write_text("#include \"ancestor_config.h\"\n")
+        bd = BuildDetector(tmp_path / "src")
+        missing = bd.detect_missing_config_headers()
+        assert not [h for h, _ in missing if h == "ancestor_config.h"]
+
+    def test_dedupes_repeated_references(self, tmp_path):
+        """Same missing header referenced from 5 files → one entry."""
+        for i in range(5):
+            (tmp_path / f"f{i}.c").write_text("#include \"missing_config.h\"\n")
+        bd = BuildDetector(tmp_path)
+        missing = bd.detect_missing_config_headers()
+        names = [h for h, _ in missing if h == "missing_config.h"]
+        assert len(names) == 1
+
+    def test_synthesised_compile_logs_missing_config_warning(
+        self, tmp_path, caplog
+    ):
+        """End-to-end: synthesise_build_command emits a WARNING when
+        config headers are missing, but does NOT auto-execute anything."""
+        import logging
+        (tmp_path / "x.c").write_text("#include \"missing_config.h\"\nint main(){return 0;}")
+        bd = BuildDetector(tmp_path)
+        # build_detector uses ``core.logging.get_logger()`` which
+        # returns a wrapper around the ``"raptor"`` stdlib logger
+        # (see core/logging/__init__.py:RaptorLogger). Attach the
+        # capture there. caplog's pytest integration doesn't see
+        # these messages because the wrapper bypasses the standard
+        # propagation chain.
+        captured: list[logging.LogRecord] = []
+        class _Capture(logging.Handler):
+            def emit(self, record): captured.append(record)
+        h = _Capture(level=logging.WARNING)
+        target_logger = logging.getLogger("raptor")
+        target_logger.addHandler(h)
+        try:
+            bd.synthesise_build_command("cpp")
+        finally:
+            target_logger.removeHandler(h)
+        warnings = [r.getMessage() for r in captured if r.levelno == logging.WARNING]
+        assert any("missing_config.h" in m for m in warnings), warnings


### PR DESCRIPTION
`BuildDetector` claimed any directory with a `CMakeLists.txt` as a buildable cmake project — wrong for subdir fragments (no `project()` declaration) like curl-8.11.0/lib/CMakeLists.txt, which silently broke CodeQL DB creation.

Three changes:
- Reject fragments; WARNING points operator at the project root.
- Synthesised compile walks up to find sibling `include/` dirs (bounded depth, X_OK + symlink-escape safety), adding them as absolute `-I` flags so subdir targets resolve `<curl/curl.h>`-style includes.
- Detect missing `*config.h` references on disk; emit WARNING with the manual fix (pre-run ./configure or cmake). No auto-execute — arbitrary-code- execution from operator-untrusted source is a deliberate non-goal.