### PR TITLE
fix(core/llm/cc_adapter): include mcpServers key in empty --mcp-config

### DIFF
--- a/core/llm/cc_adapter.py
+++ b/core/llm/cc_adapter.py
@@ -77,10 +77,21 @@ def build_cc_command(config: CCDispatchConfig) -> list[str]:
         # ``--strict-mcp-config`` tells Claude Code to ignore
         # ``~/.claude.json`` and any project-scope ``.mcp.json``,
         # using only what's passed via ``--mcp-config``. Pairing it
-        # with an empty config (``{}``) gives a sub-agent zero MCP
+        # with an empty-but-shaped config gives a sub-agent zero MCP
         # servers — the right posture for raptor's per-finding
         # analysis dispatches.
-        cmd.extend(["--strict-mcp-config", "--mcp-config", "{}"])
+        #
+        # The config value must include the ``mcpServers`` key (even
+        # if its value is an empty record). Earlier versions of
+        # Claude Code accepted a bare ``{}``; recent versions reject
+        # it with ``mcpServers: Invalid input: expected record,
+        # received undefined``. Surfaced by
+        # ``test_live_cc_dispatch_no_unexpected_essential_traffic_denials``
+        # failing after a Claude Code MCP-validation tightening.
+        cmd.extend([
+            "--strict-mcp-config",
+            "--mcp-config", '{"mcpServers": {}}',
+        ])
     return cmd
 
 

--- a/core/llm/tests/test_cc_adapter.py
+++ b/core/llm/tests/test_cc_adapter.py
@@ -26,7 +26,11 @@ class TestBuildCCCommand:
         # gh #549: strict_mcp defaults to True so sub-agents don't
         # inherit the operator's ~/.claude.json MCP servers.
         assert "--strict-mcp-config" in cmd
-        assert cmd[cmd.index("--mcp-config") + 1] == "{}"
+        # Value must include the `mcpServers` key (even empty);
+        # bare `{}` is rejected by recent Claude Code MCP validation
+        # (`mcpServers: Invalid input: expected record, received
+        # undefined`).
+        assert cmd[cmd.index("--mcp-config") + 1] == '{"mcpServers": {}}'
 
     def test_strict_mcp_can_be_disabled(self):
         # Opt-out path for any future consumer that genuinely needs MCP.


### PR DESCRIPTION
Claude Code now rejects bare `{}` for `--mcp-config` ("mcpServers: Invalid input: expected record, received undefined"). Pass `{"mcpServers": {}}` instead — empty-but-shaped, semantically identical, satisfies validation. Updates matching unit test assertion that pinned the old shape.