### PR TITLE
fix(smt): wire raptor-smt-check-overflow-to-oob for CWE-680

### DIFF
--- a/.claude/skills/exploitability-validation/stage-e-feasibility.md
+++ b/.claude/skills/exploitability-validation/stage-e-feasibility.md
@@ -154,7 +154,7 @@ You have three SMT tools, listed in the order to reach for them:
 | Situation | Tool | Why first |
 |---|---|---|
 | The finding has an imported `/understand` flow trace with `path_conditions` (look in `attack-paths.json` for entries with `source: "understand:trace"` carrying that field) | `raptor-smt-validate-path --from-trace TRACE-ID --workdir "$OUTPUT_DIR"` ([E-3c]) | The trace's conditions were extracted alongside the dataflow walk with full source-code context — usually richer and more accurate than re-extracting from prose |
-| The source matches a named pattern: `count * size` or similar arithmetic-with-guard (CWE-190); `arr[index]` access (CWE-125 / CWE-787); pointer deref of a possibly-null pointer (CWE-476) | Named verb: `raptor-smt-check-overflow` / `-oob` / `-null-deref` ([E-3d]) | The verb's intrinsic predicate is right by construction (csem-built); you only have to extract operands and guards, not derive the encoding |
+| The source matches a named pattern: `count * size` or similar arithmetic-with-guard (CWE-190); `arr[index]` access (CWE-125 / CWE-787); pointer deref of a possibly-null pointer (CWE-476); chained `malloc(count * size)` + `for i < count: buf[i]` (CWE-680) | Named verb: `raptor-smt-check-overflow` / `-oob` / `-null-deref` / `-overflow-to-oob` ([E-3d]) | The verb's intrinsic predicate is right by construction (csem-built); you only have to extract operands and guards, not derive the encoding |
 | Anything else — bespoke path conditions, multi-stage taint, mixed bitmask/relational guards, or a pattern none of the verbs cover | `raptor-smt-validate-path` with free-form predicates ([E-3c]) | The general-purpose escape hatch; richer expressiveness at the cost of you constructing the predicate |
 
 All three share Z3 availability, profile semantics, and `unknown_reasons` shape, so the iterate-on-rejection loop documented in [E-3c] applies uniformly. **Do not call multiple tools for the same finding** — pick one based on the table and trust the verdict (or its caveats) it returns.
@@ -270,7 +270,7 @@ The verdict is only as trustworthy as the conditions you extract — a `false` v
 
 ### [E-3d] Named SMT verbs — pattern-shaped helpers
 
-Three pattern-named helpers cover the most common memory-corruption shapes. Use them when the source matches the verb's pattern — they construct the right SMT predicate internally (built directly via `core.smt_solver.csem` — no parser round-trip for the verb's own predicate) so you don't have to derive the encoding from scratch.
+Four pattern-named helpers cover the most common memory-corruption shapes: CWE-190 (overflow), CWE-125/787 (OOB), CWE-476 (null deref), and CWE-680 (chained overflow→OOB). Use them when the source matches the verb's pattern — they construct the right SMT predicate internally (built directly via `core.smt_solver.csem` — no parser round-trip for the verb's own predicate) so you don't have to derive the encoding from scratch.
 
 **Each verb returns the same JSON shape as `raptor-smt-validate-path`** — `feasible` / `model` / `reasoning` / `unknown_reasons` etc. — so you read the result the same way.
 
@@ -332,9 +332,36 @@ libexec/raptor-smt-check-null-deref --ptr ptr \
 
 `feasible: true` means the null deref IS reachable; `feasible: false` means a guard genuinely proves `ptr` cannot be NULL here.
 
+#### `check_overflow_to_oob` — CWE-680 integer overflow → buffer overflow
+
+When the source shows a CWE-680 chained pattern — integer wrap at allocation sizing causes an undersized buffer, then a subsequent indexed write/read goes past the wrap. Canonical example:
+
+```c
+size_t alloc_size = count * element_size;  // overflows on uint32
+buf = malloc(alloc_size);                  // undersized due to wrap
+for (i = 0; i < count; i++) buf[i] = ...;  // OOB write past wrap
+```
+
+Pre-fix this needed running `check_overflow` AND `check_oob` and reconciling the two verdicts manually; this verb composes both predicates into one solver call.
+
+```bash
+libexec/raptor-smt-check-overflow-to-oob \
+  --count count \
+  --element-size 16 \
+  --index i \
+  --profile uint32 \
+  --guard 'count > 0'
+```
+
+- `--count`, `--element-size`, `--index` are the three operands of the canonical pattern: count of elements at allocation, per-element size, and the index used at the write/read site. Same operand-form rules as the other verbs (identifiers, numeric literals, balanced function-call shapes).
+- `--profile` defaults to `uint32` (most CWE-680 findings involve 32-bit unsigned arithmetic — `size_t` on 32-bit platforms or `unsigned int` operand width). Override to match the C type of `alloc_size` (the wrapped result).
+- `--guard` repeats; pass any visible bounds checks. A guard like `count < 0x1000` will refute the pattern (no wrap reachable at that count); a guard like `count > 0` excludes the degenerate empty-allocation case without preventing the wrap.
+
+`feasible: true` means CWE-680 IS reachable; the model carries a concrete `(count, i)` pair satisfying both the wrap AND the OOB-write. `feasible: false` means the guards rule out either the wrap or the OOB.
+
 #### When to use a verb vs `raptor-smt-validate-path`
 
-- **Use a verb** when the source matches one of the three patterns above — the verb's predicate construction is right by construction, and the witness model is already shaped the way you'd want it for a PoC.
+- **Use a verb** when the source matches one of the four patterns above — the verb's predicate construction is right by construction, and the witness model is already shaped the way you'd want it for a PoC.
 - **Use `raptor-smt-validate-path`** for free-form path conditions that don't fit a pattern (e.g. multi-stage taint with mixed integer + bitmask + string-shape guards), or when iterating on conditions extracted from a `/understand` flow trace via `--from-trace`.
 - Verbs and `validate-path` share Z3 availability, profile semantics, and `unknown_reasons` behaviour — the iterate-on-rejection loop from [E-3c] applies to verb results too.
 


### PR DESCRIPTION
PR #475 shipped the verb + shim but missed the stage-e-feasibility.md integration — the LLM had no skill-level pointer for CWE-680 chained findings. E2E re-verified verb works correctly; this adds the decision- table row + check_overflow_to_oob subsection alongside the three existing sibling verbs. Closes the operator-reachable side of #475's B5.