### PR TITLE
fix(codeql/autonomous): close v2.0 TODO — wire exploit refinement loop

### DIFF
--- a/.github/scripts/compute_filters.py
+++ b/.github/scripts/compute_filters.py
@@ -82,6 +82,8 @@ FILTERS: dict[str, list[str]] = {
     # subsystem, its tier is skipped — net runtime saving on most PRs.
     "codeql": [
         "packages/codeql/**",
+        "packages/autonomous/**",
+        "packages/source_intel/**",
         "core/build/**",
         "core/config/**",
         "core/coverage/**",
@@ -104,6 +106,7 @@ FILTERS: dict[str, list[str]] = {
     ],
     "llm_analysis": [
         "packages/llm_analysis/**",
+        "packages/autonomous/**",
         "packages/binary_analysis/**",
         "packages/checker_synthesis/**",
         "packages/codeql/**",
@@ -112,8 +115,10 @@ FILTERS: dict[str, list[str]] = {
         "packages/exploitability_validation/**",
         "packages/fuzzing/**",
         "packages/hypothesis_validation/**",
+        "packages/source_intel/**",
         "core/annotations/**",
         "core/ast/**",
+        "core/build/**",
         "core/config/**",
         "core/coverage/**",
         "core/inventory/**",

--- a/core/security/prompt_envelope_audit.py
+++ b/core/security/prompt_envelope_audit.py
@@ -213,6 +213,26 @@ _ALLOWLIST: Tuple[AllowlistEntry, ...] = (
     ),
     AllowlistEntry(
         file='packages/codeql/autonomous_analyzer.py',
+        func_name='AutonomousCodeQLAnalyzer._refine_exploit_loop',
+        attr='rule_id',
+        expr_text='{finding.rule_id}',
+        audit_note=(
+            'ID passed to validator.validate_exploit (subprocess '
+            'invocation), not LLM'
+        ),
+    ),
+    AllowlistEntry(
+        file='packages/codeql/autonomous_analyzer.py',
+        func_name='AutonomousCodeQLAnalyzer._refine_exploit_loop',
+        attr='start_line',
+        expr_text='{finding.start_line}',
+        audit_note=(
+            'ID passed to validator.validate_exploit (subprocess '
+            'invocation), not LLM'
+        ),
+    ),
+    AllowlistEntry(
+        file='packages/codeql/autonomous_analyzer.py',
         func_name='AutonomousCodeQLAnalyzer.analyze_finding_autonomous',
         attr='rule_id',
         expr_text='{finding.rule_id}',

--- a/packages/codeql/autonomous_analyzer.py
+++ b/packages/codeql/autonomous_analyzer.py
@@ -913,6 +913,99 @@ class AutonomousCodeQLAnalyzer:
             self.logger.error(f"Exploit generation failed: {e}")
             return None
 
+    def _refine_exploit_loop(
+        self,
+        exploit_code: str,
+        finding: "CodeQLFinding",
+        validation_result,
+        max_refinement: int,
+    ):
+        """Iteratively refine an exploit that failed initial validation.
+
+        Each iteration runs one LLM refinement round (via
+        ``MultiTurnAnalyser.refine_exploit_iteratively`` with
+        ``max_iterations=1``) followed by a fresh compile-validate of
+        the refined code. Returns the final
+        ``(exploit_code, validation_result, refinement_count)``
+        tuple — exploit_code is the most-recently-refined version
+        (the one operators want saved), validation_result reflects
+        its compile state.
+
+        Terminates early when:
+
+        * Compile now succeeds — short-circuits the loop and
+          surfaces a success log.
+        * Refinement produced no change (LLM returned the same
+          code, or returned ``None``) — no point looping further on
+          identical diagnostics.
+        * The multi-turn analyser is unavailable (operator ran
+          without external LLM, or instantiation failed in
+          ``raptor_codeql.py``) — return immediately with the
+          input state, preserving today's behaviour when no LLM is
+          configured.
+
+        Counts attempted iterations whether or not they produced a
+        change; this lets downstream telemetry distinguish a "tried
+        and failed N times" finding from a "didn't try" one.
+
+        Helper extracted from the original inline TODO loop in
+        :meth:`analyze_finding_autonomous` for isolated testing.
+        """
+        refinement_count = 0
+
+        if validation_result.success or not self.multi_turn:
+            return exploit_code, validation_result, refinement_count
+
+        # MultiTurnAnalyser._build_refinement_prompt reads only
+        # ``crash_context.signal``; for the CodeQL path there's no
+        # CrashContext, so synthesise a minimal shim using the
+        # CodeQL rule_id as the "signal" the refinement prompt
+        # surfaces. The LLM sees this as crash_signal in the
+        # envelope's slot — close enough for a one-token hint about
+        # the vulnerability class.
+        from types import SimpleNamespace
+        refinement_context = SimpleNamespace(signal=finding.rule_id)
+
+        while (
+            not validation_result.success
+            and refinement_count < max_refinement
+        ):
+            refinement_count += 1
+            self.logger.info(
+                f"🔄 Refining exploit "
+                f"(attempt {refinement_count}/{max_refinement})..."
+            )
+
+            refined_code = self.multi_turn.refine_exploit_iteratively(
+                exploit_code=exploit_code,
+                crash_context=refinement_context,
+                validation_errors=validation_result.compilation_errors,
+                max_iterations=1,
+            )
+
+            if refined_code is None or refined_code == exploit_code:
+                self.logger.warning(
+                    "Refinement produced no change; "
+                    "abandoning further refinement attempts"
+                )
+                break
+
+            exploit_code = refined_code
+            validation_result = self.validator.validate_exploit(
+                exploit_code,
+                f"{finding.rule_id}_{finding.start_line}_refined_{refinement_count}",
+            )
+
+            if validation_result.success:
+                self.logger.info(
+                    f"✓ Refinement succeeded after "
+                    f"{refinement_count} iteration"
+                    f"{'s' if refinement_count != 1 else ''}"
+                )
+                break
+
+        return exploit_code, validation_result, refinement_count
+
     def analyze_finding_autonomous(
         self,
         sarif_result: Dict,
@@ -1092,14 +1185,24 @@ class AutonomousCodeQLAnalyzer:
 
             exploit_compiled = validation_result.success
 
-            # Refine if needed
-            while not validation_result.success and refinement_count < max_refinement:
-                refinement_count += 1
-                self.logger.info(f"🔄 Refining exploit (attempt {refinement_count}/{max_refinement})...")
-
-                # TODO: Implement refinement using multi-turn dialogue
-                # For now, just break
-                break
+            # Stage 7a: Refine on compile failure. Pre-fix this loop
+            # was a TODO that logged "🔄 Refining exploit..." and then
+            # immediately `break`d, leaving operators with
+            # broken-but-claimed-refined output. The TODO predated
+            # PR #572's compile-verify work and the
+            # MultiTurnAnalyser consumption substrate was already
+            # wired at ``raptor_codeql.py:151`` — only the call site
+            # was missing.
+            if not exploit_compiled:
+                exploit_code, validation_result, refinement_count = (
+                    self._refine_exploit_loop(
+                        exploit_code=exploit_code,
+                        finding=finding,
+                        validation_result=validation_result,
+                        max_refinement=max_refinement,
+                    )
+                )
+                exploit_compiled = validation_result.success
 
         # Save artifacts
         out_dir.mkdir(parents=True, exist_ok=True)

--- a/packages/codeql/scripts/e2e_refine_exploit.py
+++ b/packages/codeql/scripts/e2e_refine_exploit.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""E2E script for the refinement-loop wiring in autonomous_analyzer.py.
+
+Closes the v2.0 TODO at autonomous_analyzer.py:1095-1102 (the
+former stubbed ``break``). Demonstrates the helper's full path
+end-to-end against a realistic fake LLM that produces canned
+responses — exercises:
+
+- The actual ``MultiTurnAnalyser`` (real prompt construction via
+  CONSERVATIVE envelope, real code-extraction regex)
+- The actual ``ExploitValidator`` (real gcc in sandbox)
+- The actual ``_refine_exploit_loop`` helper
+- The actual artefact naming convention used by validate_exploit
+- The actual logger output operators see
+
+Scenarios:
+
+1. Broken C exploit → LLM emits working refinement → compiles.
+2. Broken C exploit → LLM keeps producing broken variants →
+   loop exhausts ``max_refinement`` with a refined-but-broken
+   final state.
+3. Broken C exploit → LLM gives up (returns ``None`` after
+   code-extraction failure) → loop bails after iteration 1.
+4. Broken C exploit + no multi_turn wired → early-return path.
+
+Run from the repo root:
+
+    python3 packages/codeql/scripts/e2e_refine_exploit.py
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+# packages/codeql/scripts/e2e_refine_exploit.py
+#   parents[0] = scripts/
+#   parents[1] = codeql/
+#   parents[2] = packages/
+#   parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+os.environ.setdefault("RAPTOR_DIR", str(REPO))
+
+from packages.autonomous.dialogue import MultiTurnAnalyser  # noqa: E402
+from packages.autonomous.exploit_validator import ExploitValidator  # noqa: E402
+from packages.codeql.autonomous_analyzer import (  # noqa: E402
+    AutonomousCodeQLAnalyzer,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake LLM provider — programmable canned-response sequence.
+# ---------------------------------------------------------------------------
+
+
+class _FakeLLMResponse:
+    def __init__(self, content: str):
+        self.content = content
+
+
+class FakeLLMProvider:
+    """Stand-in for ``LLMClient`` / a real provider that produces
+    canned responses in sequence. Each ``.generate(...)`` call pops
+    the next response off the queue. The MultiTurnAnalyser invokes
+    ``.generate(prompt, system_prompt=..., task_type=...)`` and
+    reads ``.content`` from the returned object.
+    """
+
+    def __init__(self, responses: list[str]):
+        self._responses = list(responses)
+        self.calls = 0
+
+    def generate(self, prompt, system_prompt=None, task_type=None, **kw):
+        self.calls += 1
+        if not self._responses:
+            raise RuntimeError("FakeLLMProvider exhausted")
+        return _FakeLLMResponse(self._responses.pop(0))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+# Broken C — syntax error (missing ``)``)
+BROKEN_C = """\
+#include <stdio.h>
+int main(void {
+    return 0;
+}
+"""
+
+
+# Working refinement — fixes the missing paren
+WORKING_C = """\
+#include <stdio.h>
+int main(void) {
+    printf("verified\\n");
+    return 0;
+}
+"""
+
+
+# Another broken variant — different syntax error
+STILL_BROKEN_C = """\
+#include <stdio.h>
+int main(void) {
+    int x = ;  // empty rvalue
+    return x;
+}
+"""
+
+
+def _wrap_in_code_fence(code: str, lang: str = "c") -> str:
+    """Mimic how the LLM emits code — in a fenced block.
+    MultiTurnAnalyser._extract_code_from_response keys on this."""
+    return f"Here's the fix:\n\n```{lang}\n{code}\n```\n\nExplanation: ..."
+
+
+def _stub_finding(rule_id: str = "py/sql-injection", start_line: int = 42):
+    return SimpleNamespace(rule_id=rule_id, start_line=start_line)
+
+
+def _stub_agent(validator, multi_turn):
+    """Duck-type stand-in for AutonomousCodeQLAnalyzer with just
+    the attributes _refine_exploit_loop reads."""
+    agent = SimpleNamespace(
+        validator=validator,
+        multi_turn=multi_turn,
+        logger=logging.getLogger("e2e"),
+    )
+    agent._refine_exploit_loop = (
+        AutonomousCodeQLAnalyzer._refine_exploit_loop.__get__(
+            agent, type(agent)
+        )
+    )
+    return agent
+
+
+def _hr(title: str) -> None:
+    print()
+    print("=" * 72)
+    print(f"  {title}")
+    print("=" * 72)
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+
+def scenario_1_converges_on_iteration_1(work_dir: Path) -> None:
+    _hr("Scenario 1: LLM produces working refinement on iteration 1")
+    fake_llm = FakeLLMProvider([_wrap_in_code_fence(WORKING_C)])
+    multi_turn = MultiTurnAnalyser(llm_client=fake_llm)
+    validator = ExploitValidator(work_dir=work_dir)
+
+    agent = _stub_agent(validator, multi_turn)
+    initial_result = validator.validate_exploit(BROKEN_C, "scenario1")
+    print(f"  initial compile state: success={initial_result.success}")
+    print(f"  initial errors: {initial_result.compilation_errors[:2]}")
+
+    code, result, count = agent._refine_exploit_loop(
+        exploit_code=BROKEN_C,
+        finding=_stub_finding(),
+        validation_result=initial_result,
+        max_refinement=3,
+    )
+
+    print()
+    print(f"  final compile state: success={result.success}")
+    print(f"  refinement count: {count}")
+    print(f"  code is refined version: {code.strip() == WORKING_C.strip()}")
+    print(f"  LLM calls made: {fake_llm.calls}")
+
+
+def scenario_2_exhausts_max_refinement(work_dir: Path) -> None:
+    _hr("Scenario 2: LLM never converges — exhausts max_refinement")
+    # Each refinement returns a different (still-broken) variant so
+    # the no-change termination doesn't fire.
+    fake_llm = FakeLLMProvider([
+        _wrap_in_code_fence(STILL_BROKEN_C),
+        _wrap_in_code_fence(STILL_BROKEN_C.replace("int x", "int y")),
+        _wrap_in_code_fence(STILL_BROKEN_C.replace("int x", "int z")),
+    ])
+    multi_turn = MultiTurnAnalyser(llm_client=fake_llm)
+    validator = ExploitValidator(work_dir=work_dir)
+
+    agent = _stub_agent(validator, multi_turn)
+    initial_result = validator.validate_exploit(BROKEN_C, "scenario2")
+
+    code, result, count = agent._refine_exploit_loop(
+        exploit_code=BROKEN_C,
+        finding=_stub_finding(start_line=100),
+        validation_result=initial_result,
+        max_refinement=3,
+    )
+
+    print()
+    print(f"  final compile state: success={result.success}")
+    print(f"  refinement count: {count}  (should be 3 = max_refinement)")
+    print("  code is latest-broken version, not original:")
+    print(f"    code != BROKEN_C: {code.strip() != BROKEN_C.strip()}")
+    print(f"  LLM calls made: {fake_llm.calls}")
+
+
+def scenario_3_llm_no_extractable_code(work_dir: Path) -> None:
+    _hr("Scenario 3: LLM responds without extractable code → bail")
+    # No code fence in the response → _extract_code_from_response
+    # returns None → refine_exploit_iteratively returns the *unchanged*
+    # input code → the helper's "no change" termination fires.
+    fake_llm = FakeLLMProvider(["I cannot fix this exploit, sorry."])
+    multi_turn = MultiTurnAnalyser(llm_client=fake_llm)
+    validator = ExploitValidator(work_dir=work_dir)
+
+    agent = _stub_agent(validator, multi_turn)
+    initial_result = validator.validate_exploit(BROKEN_C, "scenario3")
+
+    code, result, count = agent._refine_exploit_loop(
+        exploit_code=BROKEN_C,
+        finding=_stub_finding(start_line=200),
+        validation_result=initial_result,
+        max_refinement=3,
+    )
+
+    print()
+    print(f"  final compile state: success={result.success}")
+    print(f"  refinement count: {count}  (should be 1 — single attempt then bail)")
+    print("  code unchanged (LLM didn't produce extractable code):")
+    print(f"    code == BROKEN_C: {code.strip() == BROKEN_C.strip()}")
+    print(f"  LLM calls made: {fake_llm.calls}")
+
+
+def scenario_4_no_multi_turn(work_dir: Path) -> None:
+    _hr("Scenario 4: no multi_turn analyser configured → early return")
+    validator = ExploitValidator(work_dir=work_dir)
+    agent = _stub_agent(validator, multi_turn=None)
+    initial_result = validator.validate_exploit(BROKEN_C, "scenario4")
+
+    code, result, count = agent._refine_exploit_loop(
+        exploit_code=BROKEN_C,
+        finding=_stub_finding(),
+        validation_result=initial_result,
+        max_refinement=3,
+    )
+
+    print()
+    print(f"  final compile state: success={result.success}")
+    print(f"  refinement count: {count}  (should be 0 — no LLM, no attempts)")
+    print(f"  code unchanged: {code.strip() == BROKEN_C.strip()}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[%(levelname)s] %(message)s",
+    )
+
+    import tempfile
+    with tempfile.TemporaryDirectory(prefix="e2e-refine-") as tmp:
+        work_dir = Path(tmp)
+        scenario_1_converges_on_iteration_1(work_dir)
+        scenario_2_exhausts_max_refinement(work_dir)
+        scenario_3_llm_no_extractable_code(work_dir)
+        scenario_4_no_multi_turn(work_dir)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/codeql/tests/test_autonomous_refine_exploit.py
+++ b/packages/codeql/tests/test_autonomous_refine_exploit.py
@@ -1,0 +1,505 @@
+"""Tests for ``AutonomousCodeQLAnalyzer._refine_exploit_loop``.
+
+The helper closes a TODO that has been outstanding in /codeql
+--autonomous since v2.0: the inline refinement loop in
+``analyze_finding_autonomous`` logged "🔄 Refining exploit..."
+and then immediately ``break``d, leaving operators with
+broken-but-claimed-refined output. These tests pin the loop's
+contract end-to-end via the helper's public-method shape
+(``_refine_exploit_loop`` is underscore-prefixed but testable
+because the refinement contract is the high-leverage thing this
+diff lands).
+
+The full ``analyze_finding_autonomous`` method is heavyweight to
+construct (LLM client, dataflow validator, reachability inventory,
+visualization paths). Test the helper in isolation via a duck-type
+stub agent — the helper only reads ``self.multi_turn``,
+``self.validator``, and ``self.logger``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+# packages/codeql/tests/test_autonomous_refine_exploit.py
+#   → parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from packages.codeql.autonomous_analyzer import (  # noqa: E402
+    AutonomousCodeQLAnalyzer,
+)
+
+
+def _stub_finding(rule_id: str = "py/sql-injection", start_line: int = 42):
+    """Minimal duck-type CodeQLFinding. The refinement loop reads
+    only ``rule_id`` (for the refinement context's ``signal``) and
+    ``start_line`` (for the artefact basename passed to
+    ``validate_exploit``)."""
+    return SimpleNamespace(rule_id=rule_id, start_line=start_line)
+
+
+def _stub_validation_result(success: bool, errors: list[str] | None = None):
+    """Duck-type ValidationResult. Helper reads ``success`` and
+    ``compilation_errors``."""
+    return SimpleNamespace(
+        success=success,
+        compilation_errors=list(errors or []),
+    )
+
+
+def _stub_agent(validator, multi_turn):
+    """Duck-type agent exposing only what the helper needs.
+
+    Binds the unbound method so ``self`` resolves; supplies
+    ``logger``, ``validator``, ``multi_turn`` attributes the
+    helper reads.
+    """
+    import logging
+    agent = SimpleNamespace(
+        validator=validator,
+        multi_turn=multi_turn,
+        logger=logging.getLogger("test"),
+    )
+    agent._refine_exploit_loop = (
+        AutonomousCodeQLAnalyzer._refine_exploit_loop.__get__(
+            agent, type(agent)
+        )
+    )
+    return agent
+
+
+# ----------------------------------------------------------------------
+# Skip / early-return paths
+# ----------------------------------------------------------------------
+
+
+def test_already_compiled_returns_unchanged():
+    """When the input validation_result already reports success, the
+    helper returns the same exploit_code + result + zero refinements.
+    No LLM calls. No validator calls."""
+    validator = MagicMock()
+    multi_turn = MagicMock()
+    agent = _stub_agent(validator, multi_turn)
+
+    initial_code = "int main(){return 0;}"
+    initial_result = _stub_validation_result(success=True)
+
+    code, result, count = agent._refine_exploit_loop(
+        exploit_code=initial_code,
+        finding=_stub_finding(),
+        validation_result=initial_result,
+        max_refinement=3,
+    )
+
+    assert code == initial_code
+    assert result is initial_result
+    assert count == 0
+    multi_turn.refine_exploit_iteratively.assert_not_called()
+    validator.validate_exploit.assert_not_called()
+
+
+def test_no_multi_turn_returns_unchanged():
+    """When no MultiTurnAnalyser is available (operator ran without
+    external LLM), the helper bails immediately with the input state.
+    Today's behaviour pre-fix; preserved as the no-op path."""
+    validator = MagicMock()
+    agent = _stub_agent(validator, multi_turn=None)
+
+    initial_code = "broken {"
+    initial_result = _stub_validation_result(
+        success=False, errors=["expected '}'"]
+    )
+
+    code, result, count = agent._refine_exploit_loop(
+        exploit_code=initial_code,
+        finding=_stub_finding(),
+        validation_result=initial_result,
+        max_refinement=3,
+    )
+
+    assert code == initial_code
+    assert result is initial_result
+    assert count == 0
+    validator.validate_exploit.assert_not_called()
+
+
+# ----------------------------------------------------------------------
+# Convergence
+# ----------------------------------------------------------------------
+
+
+def test_refinement_converges_on_success_after_one_iteration():
+    """First refinement round produces working code → loop returns
+    success on iteration 1, exploit_code is the refined version."""
+    validator = MagicMock()
+    multi_turn = MagicMock()
+
+    multi_turn.refine_exploit_iteratively.return_value = "int main(){return 0;}"
+    validator.validate_exploit.return_value = _stub_validation_result(success=True)
+
+    agent = _stub_agent(validator, multi_turn)
+    initial_code = "broken {"
+    initial_result = _stub_validation_result(
+        success=False, errors=["expected '}'"]
+    )
+
+    code, result, count = agent._refine_exploit_loop(
+        exploit_code=initial_code,
+        finding=_stub_finding(),
+        validation_result=initial_result,
+        max_refinement=3,
+    )
+
+    assert code == "int main(){return 0;}"
+    assert result.success is True
+    assert count == 1
+    assert multi_turn.refine_exploit_iteratively.call_count == 1
+    assert validator.validate_exploit.call_count == 1
+
+
+def test_refinement_converges_after_multiple_iterations():
+    """Refinement produces different code each round; succeeds on
+    iteration 3. exploit_code reflects the final refined version."""
+    validator = MagicMock()
+    multi_turn = MagicMock()
+
+    # Each refinement returns a different (still-broken) version
+    # until the last one.
+    multi_turn.refine_exploit_iteratively.side_effect = [
+        "version 2",
+        "version 3",
+        "version 4 (works)",
+    ]
+    validator.validate_exploit.side_effect = [
+        _stub_validation_result(False, ["err 2"]),
+        _stub_validation_result(False, ["err 3"]),
+        _stub_validation_result(success=True),
+    ]
+
+    agent = _stub_agent(validator, multi_turn)
+    code, result, count = agent._refine_exploit_loop(
+        exploit_code="version 1",
+        finding=_stub_finding(),
+        validation_result=_stub_validation_result(False, ["err 1"]),
+        max_refinement=5,
+    )
+
+    assert code == "version 4 (works)"
+    assert result.success is True
+    assert count == 3
+
+
+# ----------------------------------------------------------------------
+# Termination — non-success cases
+# ----------------------------------------------------------------------
+
+
+def test_refinement_exhausts_max_refinement():
+    """Each iteration produces different code but none compile.
+    Loop terminates after ``max_refinement`` iterations. Final
+    exploit_code is the last refined version."""
+    validator = MagicMock()
+    multi_turn = MagicMock()
+
+    multi_turn.refine_exploit_iteratively.side_effect = [
+        "v2", "v3", "v4",  # each round produces NEW code
+    ]
+    validator.validate_exploit.side_effect = [
+        _stub_validation_result(False, ["e2"]),
+        _stub_validation_result(False, ["e3"]),
+        _stub_validation_result(False, ["e4"]),
+    ]
+
+    agent = _stub_agent(validator, multi_turn)
+    code, result, count = agent._refine_exploit_loop(
+        exploit_code="v1",
+        finding=_stub_finding(),
+        validation_result=_stub_validation_result(False, ["e1"]),
+        max_refinement=3,
+    )
+
+    assert code == "v4"  # last refined version
+    assert result.success is False
+    assert count == 3
+    assert result.compilation_errors == ["e4"]  # final errors surfaced
+
+
+def test_refinement_bails_when_llm_returns_none():
+    """LLM returning ``None`` (extraction failed, or refinement
+    impossible) ends the loop early — no point compiling the
+    pre-refinement code again."""
+    validator = MagicMock()
+    multi_turn = MagicMock()
+
+    multi_turn.refine_exploit_iteratively.return_value = None
+
+    agent = _stub_agent(validator, multi_turn)
+    initial_code = "broken {"
+    code, result, count = agent._refine_exploit_loop(
+        exploit_code=initial_code,
+        finding=_stub_finding(),
+        validation_result=_stub_validation_result(False, ["e1"]),
+        max_refinement=5,
+    )
+
+    # No change, refinement bailed.
+    assert code == initial_code
+    assert count == 1
+    # Validator was never re-invoked (the original failure stands).
+    validator.validate_exploit.assert_not_called()
+
+
+def test_refinement_bails_when_llm_returns_same_code():
+    """LLM returning the SAME code (couldn't fix the errors) ends
+    the loop early. Repeating with identical input would just burn
+    iterations for the same diagnostics."""
+    validator = MagicMock()
+    multi_turn = MagicMock()
+
+    initial_code = "broken {"
+    multi_turn.refine_exploit_iteratively.return_value = initial_code
+
+    agent = _stub_agent(validator, multi_turn)
+    code, result, count = agent._refine_exploit_loop(
+        exploit_code=initial_code,
+        finding=_stub_finding(),
+        validation_result=_stub_validation_result(False, ["e1"]),
+        max_refinement=5,
+    )
+
+    assert code == initial_code
+    assert count == 1
+    validator.validate_exploit.assert_not_called()
+
+
+# ----------------------------------------------------------------------
+# Context shim
+# ----------------------------------------------------------------------
+
+
+def test_refinement_passes_rule_id_as_signal():
+    """``MultiTurnAnalyser._build_refinement_prompt`` reads only
+    ``crash_context.signal``; the helper synthesises a shim using
+    the CodeQL rule_id. Verify the shim is constructed with the
+    rule_id (not the start_line, message, or anything else)."""
+    validator = MagicMock()
+    multi_turn = MagicMock()
+
+    multi_turn.refine_exploit_iteratively.return_value = "refined"
+    validator.validate_exploit.return_value = _stub_validation_result(True)
+
+    agent = _stub_agent(validator, multi_turn)
+    agent._refine_exploit_loop(
+        exploit_code="initial",
+        finding=_stub_finding(rule_id="cpp/use-after-free", start_line=99),
+        validation_result=_stub_validation_result(False, ["e"]),
+        max_refinement=3,
+    )
+
+    call_kwargs = multi_turn.refine_exploit_iteratively.call_args.kwargs
+    assert call_kwargs["crash_context"].signal == "cpp/use-after-free"
+
+
+def test_refinement_passes_compilation_errors_to_llm():
+    """The current iteration's compile errors are handed to the LLM
+    so it has concrete failure diagnostics to fix. Verify the LATEST
+    errors are passed each round, not the original ones."""
+    validator = MagicMock()
+    multi_turn = MagicMock()
+
+    multi_turn.refine_exploit_iteratively.side_effect = ["v2", "v3"]
+    validator.validate_exploit.side_effect = [
+        _stub_validation_result(False, ["new error after v2"]),
+        _stub_validation_result(True),
+    ]
+
+    agent = _stub_agent(validator, multi_turn)
+    agent._refine_exploit_loop(
+        exploit_code="v1",
+        finding=_stub_finding(),
+        validation_result=_stub_validation_result(False, ["original error"]),
+        max_refinement=3,
+    )
+
+    calls = multi_turn.refine_exploit_iteratively.call_args_list
+    assert len(calls) == 2
+    # Round 1: original errors
+    assert calls[0].kwargs["validation_errors"] == ["original error"]
+    # Round 2: errors from v2's validation, not the original
+    assert calls[1].kwargs["validation_errors"] == ["new error after v2"]
+
+
+# ----------------------------------------------------------------------
+# Artefact naming
+# ----------------------------------------------------------------------
+
+
+def test_refinement_artefact_names_carry_iteration_number():
+    """Each refined validate_exploit call uses a name distinct from
+    the original validate (``..._refined_N``), so artefacts don't
+    collide and operators can correlate validator output with
+    iteration count when reading logs / debug output."""
+    validator = MagicMock()
+    multi_turn = MagicMock()
+
+    multi_turn.refine_exploit_iteratively.side_effect = ["v2", "v3"]
+    validator.validate_exploit.side_effect = [
+        _stub_validation_result(False, ["e2"]),
+        _stub_validation_result(True),
+    ]
+
+    agent = _stub_agent(validator, multi_turn)
+    agent._refine_exploit_loop(
+        exploit_code="v1",
+        finding=_stub_finding(rule_id="py/sql-injection", start_line=42),
+        validation_result=_stub_validation_result(False, ["e1"]),
+        max_refinement=3,
+    )
+
+    names = [c.args[1] for c in validator.validate_exploit.call_args_list]
+    assert names == [
+        "py/sql-injection_42_refined_1",
+        "py/sql-injection_42_refined_2",
+    ]
+
+
+# ----------------------------------------------------------------------
+# max_refinement=0 — degenerate input
+# ----------------------------------------------------------------------
+
+
+def test_max_refinement_zero_skips_loop():
+    """``max_refinement=0`` means "don't attempt refinement at all."
+    Helper returns immediately without calling LLM or validator."""
+    validator = MagicMock()
+    multi_turn = MagicMock()
+
+    agent = _stub_agent(validator, multi_turn)
+    initial_code = "broken"
+    initial_result = _stub_validation_result(False, ["e"])
+
+    code, result, count = agent._refine_exploit_loop(
+        exploit_code=initial_code,
+        finding=_stub_finding(),
+        validation_result=initial_result,
+        max_refinement=0,
+    )
+
+    assert code == initial_code
+    assert result is initial_result
+    assert count == 0
+    multi_turn.refine_exploit_iteratively.assert_not_called()
+    validator.validate_exploit.assert_not_called()
+
+
+def test_max_refinement_negative_skips_loop():
+    """Degenerate input — ``max_refinement < 0`` shouldn't loop at
+    all. The while-condition ``refinement_count < max_refinement``
+    is False on entry (``0 < -1``), no iterations run. Pin the
+    behaviour so a future refactor doesn't accidentally treat
+    negative as "unlimited"."""
+    validator = MagicMock()
+    multi_turn = MagicMock()
+
+    agent = _stub_agent(validator, multi_turn)
+    code, result, count = agent._refine_exploit_loop(
+        exploit_code="broken",
+        finding=_stub_finding(),
+        validation_result=_stub_validation_result(False, ["e"]),
+        max_refinement=-1,
+    )
+
+    assert count == 0
+    multi_turn.refine_exploit_iteratively.assert_not_called()
+
+
+# ----------------------------------------------------------------------
+# Propagation of validator / LLM failures
+# ----------------------------------------------------------------------
+
+
+def test_validator_raises_during_refinement_propagates():
+    """If ``validate_exploit`` raises during re-validation of refined
+    code (sandbox crash, disk full, etc.), the exception propagates
+    out of the helper. Consistent with the surrounding analyzer code,
+    which doesn't catch validator exceptions on the initial validate
+    either. Worth pinning so a future try/except wrapper change is
+    a deliberate decision, not silent.
+    """
+    validator = MagicMock()
+    multi_turn = MagicMock()
+
+    multi_turn.refine_exploit_iteratively.return_value = "v2"
+    validator.validate_exploit.side_effect = RuntimeError("sandbox crash")
+
+    agent = _stub_agent(validator, multi_turn)
+
+    import pytest as _pytest
+    with _pytest.raises(RuntimeError, match="sandbox crash"):
+        agent._refine_exploit_loop(
+            exploit_code="v1",
+            finding=_stub_finding(),
+            validation_result=_stub_validation_result(False, ["e"]),
+            max_refinement=3,
+        )
+
+
+def test_llm_raises_during_refinement_propagates():
+    """Likewise for ``refine_exploit_iteratively`` raising (LLM API
+    timeout, auth failure, 429). Propagates cleanly; no partial-
+    state mutation of helper outputs."""
+    validator = MagicMock()
+    multi_turn = MagicMock()
+
+    multi_turn.refine_exploit_iteratively.side_effect = RuntimeError("LLM 429")
+
+    agent = _stub_agent(validator, multi_turn)
+
+    import pytest as _pytest
+    with _pytest.raises(RuntimeError, match="LLM 429"):
+        agent._refine_exploit_loop(
+            exploit_code="v1",
+            finding=_stub_finding(),
+            validation_result=_stub_validation_result(False, ["e"]),
+            max_refinement=3,
+        )
+
+    # Validator was never invoked because the LLM call failed first.
+    validator.validate_exploit.assert_not_called()
+
+
+# ----------------------------------------------------------------------
+# Defensive against unusual finding shapes
+# ----------------------------------------------------------------------
+
+
+def test_refinement_handles_none_rule_id():
+    """``finding.rule_id is None`` — happens when SARIF parsing
+    couldn't extract a rule. The shim's signal becomes ``None``;
+    MultiTurnAnalyser stringifies it to ``"None"`` in the prompt.
+    Ugly but doesn't crash."""
+    validator = MagicMock()
+    multi_turn = MagicMock()
+
+    multi_turn.refine_exploit_iteratively.return_value = "refined"
+    validator.validate_exploit.return_value = _stub_validation_result(True)
+
+    agent = _stub_agent(validator, multi_turn)
+    finding = _stub_finding(rule_id=None, start_line=42)
+
+    code, result, count = agent._refine_exploit_loop(
+        exploit_code="broken",
+        finding=finding,
+        validation_result=_stub_validation_result(False, ["e"]),
+        max_refinement=3,
+    )
+
+    assert count == 1
+    # The shim was constructed with signal=None and passed through.
+    call_kwargs = multi_turn.refine_exploit_iteratively.call_args.kwargs
+    assert call_kwargs["crash_context"].signal is None


### PR DESCRIPTION
The /codeql --autonomous flow has compile-validated LLM-emitted exploits since v2.0 via ExploitValidator.validate_exploit, but the refinement-on-failure step at autonomous_analyzer.py:1095-1102 was stubbed with a `# TODO: Implement refinement` comment and an instantiated and threaded into AutonomousCodeQLAnalyzer since the same v2.0 squash (raptor_codeql.py:151 → analyzer constructor → self.multi_turn). Only the call site was missing.

Extracts the refinement logic into a new helper method `_refine_exploit_loop` for isolated testing. Each iteration runs one LLM refinement round via
MultiTurnAnalyser.refine_exploit_iteratively(max_iterations=1) followed by a fresh compile-validate of the refined code. Terminates early on:
  - compile success
  - LLM returns None or unchanged code (refinement converged or is impossible — no point burning iterations on identical diagnostics)
  - multi_turn unavailable (no external LLM configured; preserves the pre-fix no-op behaviour cleanly)

MultiTurnAnalyser._build_refinement_prompt reads only crash_context.signal; the CodeQL path synthesises a minimal SimpleNamespace(signal=finding.rule_id) shim. The LLM sees the rule_id as crash_signal in the envelope's slot — adequate one- token hint about the vulnerability class without inventing a fake crash record.

Behaviour change worth knowing: when refinement fails to converge after max_refinement iterations, the saved exploit_code is now the latest refined-but-broken attempt instead of the original LLM output. Pre-fix the TODO break preserved the original; post-fix the loop overwrites exploit_code with each refined version, so a 3-iteration failure saves the 3rd attempt. Defensible (the LLM saw the errors at each round, so the latest version is more likely close to working), but operators diffing artefacts between pre-fix and post-fix runs will see different files for the same failing finding.

15 unit tests cover convergence (1-N iterations), exhaustion, LLM-no-change termination, the context shim, artefact naming, the no-multi_turn / max_refinement=0 / max_refinement<0 degenerate paths, and exception propagation from both the validator and the LLM. Plus a runnable E2E script at packages/codeql/scripts/e2e_refine_exploit.py that exercises 4 scenarios against the real MultiTurnAnalyser + real ExploitValidator with a fake LLM provider — confirms behaviour end-to-end through real prompt construction, real envelope wrapping, and real gcc compilation.

Full codeql test suite (351 tests) passes.