### PR TITLE
fix(core/witness): defensive validation on WitnessStore.put + atomic writes

### DIFF
--- a/core/witness/__init__.py
+++ b/core/witness/__init__.py
@@ -25,11 +25,12 @@ to avoid the layering inversion of ``core/`` importing
 ``packages/``.
 """
 
-from core.witness.store import WitnessStore
+from core.witness.store import WitnessStore, WitnessStoreError
 from core.witness.types import (
     Witness,
     WitnessOutcome,
     WitnessSource,
+    compute_bytes_hash,
 )
 
 __all__ = [
@@ -37,4 +38,6 @@ __all__ = [
     "WitnessOutcome",
     "WitnessSource",
     "WitnessStore",
+    "WitnessStoreError",
+    "compute_bytes_hash",
 ]

--- a/core/witness/store.py
+++ b/core/witness/store.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Iterator, Optional
 
@@ -87,16 +88,26 @@ class WitnessStore:
     def put(self, witness: Witness, data: bytes) -> Path:
         """Persist ``witness`` and ``data``. Returns the blob path.
 
-        Validates that ``witness.bytes_hash`` matches
-        ``sha256(data)`` — passing mismatched hash + bytes raises
-        :class:`WitnessStoreError`. Catches the common bug of a
-        producer computing the hash on a transformed copy of the
-        bytes (e.g. forgetting to strip a header).
+        Validates four invariants before touching disk:
+
+        1. ``witness.bytes_hash == sha256(data)`` — catches the
+           producer bug of hashing a transformed copy of the bytes.
+        2. If ``witness.bytes_len`` is set (non-zero), it matches
+           ``len(data)``. If left at default ``0``, the store
+           stamps it from the actual length.
+        3. ``witness.outcome_detail`` is JSON-serialisable.
+           Pre-check catches non-serialisable values
+           (:class:`pathlib.Path`, :class:`datetime`, ``bytes``,
+           etc.) with a clear ``WitnessStoreError`` *before* the
+           blob is written, so a serialisation failure can't leave
+           an orphan blob.
 
         Blob writes are idempotent — if the same hash is put again,
-        the existing blob is reused (no rewrite). Manifest writes
-        overwrite — later put-calls with the same hash but
-        different provenance update the manifest.
+        the existing blob is reused (no rewrite). Both blob and
+        manifest writes are atomic via the temp-file + rename
+        pattern; a process killed mid-write leaves the on-disk
+        state at "before the put started", never a partial /
+        corrupt artefact.
         """
         expected = compute_bytes_hash(data)
         if expected != witness.bytes_hash:
@@ -107,27 +118,61 @@ class WitnessStore:
                 "actual bytes being stored"
             )
 
-        # Stamp bytes_len from the actual data length, in case the
-        # producer left it at the default 0.
+        # Enforce bytes_len agreement when caller set it. Pre-fix
+        # the store accepted (and persisted) a caller-supplied
+        # bytes_len that disagreed with len(data) — silent corruption
+        # of the manifest, which downstream consumers trust.
+        if witness.bytes_len and witness.bytes_len != len(data):
+            raise WitnessStoreError(
+                f"witness.bytes_len ({witness.bytes_len}) does not "
+                f"match len(data) ({len(data)}); pass bytes_len=0 to "
+                f"let the store stamp it, or fix the producer"
+            )
         if witness.bytes_len == 0 and data:
             witness.bytes_len = len(data)
+
+        # Pre-serialise the manifest so non-JSON-safe values in
+        # ``outcome_detail`` fail loudly here, not after we've
+        # already written the blob. Common offenders:
+        # :class:`pathlib.Path`, :class:`datetime`, ``bytes``,
+        # custom classes. The fix at the call site is to stringify.
+        try:
+            manifest_text = (
+                json.dumps(witness.to_dict(), indent=2) + "\n"
+            )
+        except (TypeError, ValueError) as exc:
+            raise WitnessStoreError(
+                f"witness manifest is not JSON-serialisable "
+                f"({type(exc).__name__}: {exc}); convert any "
+                f"Path / datetime / bytes / custom-class values in "
+                f"outcome_detail to strings before constructing the "
+                f"Witness"
+            ) from exc
 
         self._ensure_dirs()
 
         blob_path = self._blobs_dir / f"{witness.bytes_hash}.bin"
         manifest_path = self._manifests_dir / f"{witness.bytes_hash}.json"
 
-        # Blob write: skip if the same content already there. Avoids
-        # a redundant fsync on dedup.
+        # Atomic blob write: write to .tmp + os.replace. POSIX
+        # guarantees the rename is atomic. Pre-fix ``write_bytes``
+        # was direct and a crash mid-write left a partial blob
+        # that subsequent puts would skip (since blob_path.exists()
+        # was True), producing on-disk corruption invisible to
+        # later readers.
         if not blob_path.exists():
-            blob_path.write_bytes(data)
+            blob_tmp = blob_path.with_suffix(".bin.tmp")
+            blob_tmp.write_bytes(data)
+            os.replace(blob_tmp, blob_path)
 
-        # Manifest write: always. Each call's provenance / outcome
-        # is the most recent canonical view.
-        manifest_path.write_text(
-            json.dumps(witness.to_dict(), indent=2) + "\n",
-            encoding="utf-8",
-        )
+        # Atomic manifest write. Pre-fix ``write_text`` was direct
+        # and a crash mid-write left a malformed JSON file forever
+        # — list_witnesses skipped it with a warning but get_witness
+        # raised, and there was no recovery path other than manual
+        # cleanup.
+        manifest_tmp = manifest_path.with_suffix(".json.tmp")
+        manifest_tmp.write_text(manifest_text, encoding="utf-8")
+        os.replace(manifest_tmp, manifest_path)
 
         logger.debug(
             "WitnessStore.put: hash=%s len=%d source=%s outcome=%s",

--- a/core/witness/tests/test_store.py
+++ b/core/witness/tests/test_store.py
@@ -241,3 +241,110 @@ def test_manifest_is_valid_json(tmp_path):
     parsed = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert parsed["bytes_hash"] == w.bytes_hash
     assert parsed["source"] == "fuzz"
+
+
+# ----------------------------------------------------------------------
+# Defensive checks added in the stacked fix on top of #579
+# ----------------------------------------------------------------------
+
+
+def test_put_rejects_bytes_len_mismatch(tmp_path):
+    """Caller-supplied ``bytes_len`` that disagrees with
+    ``len(data)`` is silent corruption of the manifest if not
+    caught — downstream consumers trust this field. Reject with a
+    clear error pointing at the producer."""
+    store = WitnessStore(tmp_path)
+    data = b"actual data"
+    w = Witness(
+        bytes_hash=compute_bytes_hash(data),
+        source=WitnessSource.FUZZ,
+        observed_outcome=WitnessOutcome.EXIT_SIGNAL,
+        bytes_len=9999,  # caller lied
+    )
+    with pytest.raises(WitnessStoreError, match="bytes_len"):
+        store.put(w, data)
+
+
+def test_put_accepts_bytes_len_equal_to_data_length(tmp_path):
+    """Caller-supplied ``bytes_len`` that DOES match is fine — only
+    the mismatch path raises."""
+    store = WitnessStore(tmp_path)
+    data = b"actual data"
+    w = Witness(
+        bytes_hash=compute_bytes_hash(data),
+        source=WitnessSource.FUZZ,
+        observed_outcome=WitnessOutcome.EXIT_SIGNAL,
+        bytes_len=len(data),  # matches
+    )
+    store.put(w, data)  # must not raise
+    loaded = store.get_witness(w.bytes_hash)
+    assert loaded.bytes_len == len(data)
+
+
+def test_put_rejects_non_json_outcome_detail(tmp_path):
+    """outcome_detail with a non-JSON-safe value (Path, datetime,
+    bytes, custom class) is rejected with a clear error BEFORE the
+    blob is written. Pre-fix the blob landed first and the manifest
+    write failed with a confusing ``TypeError`` from json.dumps,
+    leaving an orphan blob."""
+    store = WitnessStore(tmp_path)
+    data = b"x"
+    w = Witness(
+        bytes_hash=compute_bytes_hash(data),
+        source=WitnessSource.FUZZ,
+        observed_outcome=WitnessOutcome.EXIT_SIGNAL,
+        outcome_detail={"path_obj": Path("/tmp/foo")},  # not JSON-safe
+    )
+    with pytest.raises(WitnessStoreError, match="JSON-serialisable"):
+        store.put(w, data)
+    # Confirm no orphan blob landed.
+    blobs_dir = tmp_path / "blobs"
+    if blobs_dir.is_dir():
+        assert list(blobs_dir.iterdir()) == [], (
+            "non-JSON failure left an orphan blob behind"
+        )
+
+
+def test_put_atomic_blob_write_no_tmp_residue_on_success(tmp_path):
+    """Successful blob writes go through .tmp + os.replace — verify
+    no .tmp residue lingers after a clean put. (Failure mode for
+    atomic-write is hard to test without crash injection; this
+    pins the happy-path cleanup.)"""
+    store = WitnessStore(tmp_path)
+    data = b"atomic"
+    w = _make_witness(data)
+    store.put(w, data)
+    blobs_dir = tmp_path / "blobs"
+    tmp_files = list(blobs_dir.glob("*.tmp"))
+    assert tmp_files == [], f"residue: {tmp_files}"
+
+
+def test_put_atomic_manifest_write_no_tmp_residue_on_success(tmp_path):
+    """Same as above for manifests."""
+    store = WitnessStore(tmp_path)
+    data = b"atomic-manifest"
+    w = _make_witness(data)
+    store.put(w, data)
+    manifests_dir = tmp_path / "manifests"
+    tmp_files = list(manifests_dir.glob("*.tmp"))
+    assert tmp_files == [], f"residue: {tmp_files}"
+
+
+def test_compute_bytes_hash_importable_from_init(tmp_path):
+    """``compute_bytes_hash`` is part of the public API — consumers
+    should import it from ``core.witness``, not from the private
+    ``core.witness.types`` path. Pre-fix the symbol existed but
+    wasn't re-exported, forcing the awkward import."""
+    from core.witness import compute_bytes_hash as imported
+    # Sanity: same function as the types-module version
+    from core.witness.types import compute_bytes_hash as direct
+    assert imported is direct
+
+
+def test_witness_store_error_importable_from_init(tmp_path):
+    """Likewise for ``WitnessStoreError`` — callers that want to
+    catch store-specific errors shouldn't reach into the
+    submodule."""
+    from core.witness import WitnessStoreError as imported
+    from core.witness.store import WitnessStoreError as direct
+    assert imported is direct


### PR DESCRIPTION

Adversarial probe of #579 surfaced four issues; this fixes all of them.

  1. bytes_len mismatch silently persisted. Caller passing a bytes_len value that disagrees with len(data) had the lie stored on disk. The auto-stamp only fired when bytes_len was 0. Now raises WitnessStoreError with the offending values, pointing at the producer.

  2. Non-JSON-safe outcome_detail failed late with confusing TypeError. Values like pathlib.Path / datetime / bytes / custom classes in outcome_detail passed Witness construction, reached put(), got written as a blob, then crashed at json.dumps time — leaving an orphan blob with no manifest. Pre-serialise the manifest now: if json.dumps fails, raise WitnessStoreError BEFORE the blob is written. No orphan possible.

  3. Non-atomic blob writes. Crash mid-write left a partial blob; subsequent puts saw blob_path.exists() == True and skipped the write, producing on-disk corruption invisible to readers. Write to .bin.tmp + os.replace makes the write atomic on POSIX.

  4. Non-atomic manifest writes. Crash mid-write left malformed JSON that list_witnesses skipped (good) but get_witness raised on (acceptable) and that lingered forever (bad — no recovery path). Same .json.tmp + os.replace fix.

Plus two minor API cleanups: compute_bytes_hash and WitnessStoreError are now exported from core.witness so consumers don't reach into the submodules.

Seven new tests pin each defensive check (49/49 pass, lint clean).