### PR TITLE
fix(llm_analysis): defensive type-checks in IntentMatchJudge (PR #577 follow-up)

### DIFF
--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -1291,8 +1291,13 @@ class AutonomousSecurityAgentV2:
         ``intent_match['llm_error']`` — never raises.
         """
         # Skip when analysis already classified the finding as FP.
-        # No exploit can meaningfully target a non-bug.
-        if vuln.analysis:
+        # No exploit can meaningfully target a non-bug. Be defensive
+        # against ``vuln.analysis`` being non-dict — the type hint
+        # says ``Optional[Dict[str, Any]]`` but in-flight pipelines
+        # have been observed to set it to other shapes (raw response
+        # strings, lists). Treat anything non-dict as "no analysis
+        # signal" and proceed to judge.
+        if isinstance(vuln.analysis, dict):
             is_tp = vuln.analysis.get("is_true_positive")
             if is_tp is False:
                 logger.debug(
@@ -1301,16 +1306,21 @@ class AutonomousSecurityAgentV2:
                 )
                 return
 
+        # Function name from inventory-checklist metadata. Defensive
+        # against ``vuln.metadata`` being non-dict — same shape-
+        # tolerance reasoning as for vuln.analysis above.
+        if isinstance(vuln.metadata, dict):
+            function_name = vuln.metadata.get("name")
+        else:
+            function_name = None
+
         from dataclasses import asdict
         from packages.llm_analysis.intent_match import intent_match
 
         verdict = intent_match(
             exploit_code=exploit_code,
             finding_file_path=vuln.file_path,
-            finding_function_name=(
-                (vuln.metadata or {}).get("name")
-                if vuln.metadata else None
-            ),
+            finding_function_name=function_name,
             finding_cwe=vuln.cwe_id,
             finding_message=vuln.message,
             exploit_compile_errors=list(vuln.exploit_compile_errors),

--- a/packages/llm_analysis/intent_match.py
+++ b/packages/llm_analysis/intent_match.py
@@ -555,7 +555,16 @@ def _llm_tiebreak(
             cost_usd, "describe: no response",
         )
 
-    description = (getattr(describe_response, "content", "") or "").strip()
+    # Coerce content to str defensively. Real LLM clients return str,
+    # but the loose ``getattr`` access tolerates anything; if a custom
+    # provider hands back ``bytes`` (rare but observed in synthetic
+    # tests), passing it through to the prompt envelope later crashes
+    # the envelope's regex sub with a "string pattern on bytes-like
+    # object" TypeError. Coerce here so the failure can't propagate.
+    raw_content = getattr(describe_response, "content", "") or ""
+    if isinstance(raw_content, (bytes, bytearray)):
+        raw_content = raw_content.decode("utf-8", errors="replace")
+    description = str(raw_content).strip()
     cost_usd += getattr(describe_response, "cost_usd", 0.0) or 0.0
 
     if not description:
@@ -596,7 +605,11 @@ def _llm_tiebreak(
             cost_usd, "judge: no response",
         )
 
-    judge_content = (getattr(judge_response, "content", "") or "").strip()
+    # Same bytes-tolerance defensive coerce as the describe step.
+    raw_judge = getattr(judge_response, "content", "") or ""
+    if isinstance(raw_judge, (bytes, bytearray)):
+        raw_judge = raw_judge.decode("utf-8", errors="replace")
+    judge_content = str(raw_judge).strip()
     cost_usd += getattr(judge_response, "cost_usd", 0.0) or 0.0
 
     verdict, reason = _parse_judge_response(judge_content)

--- a/packages/llm_analysis/tests/test_agent_judge_intent_defense.py
+++ b/packages/llm_analysis/tests/test_agent_judge_intent_defense.py
@@ -1,0 +1,181 @@
+"""Defensive tests for ``AutonomousSecurityAgentV2._judge_exploit_intent``.
+
+Adversarial review of PR #577 surfaced type-confusion crashes
+when ``vuln.metadata`` or ``vuln.analysis`` weren't the
+``Optional[Dict[str, Any]]`` shape the type hint promises but
+something else (list, str, etc.) — pipelines have been observed
+to set these to unusual shapes in flight. Pre-fix the helper
+called ``.get(...)`` unconditionally and crashed with
+``AttributeError``; post-fix it gates on ``isinstance(..., dict)``
+and treats anything else as "no signal."
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+# packages/llm_analysis/tests/test_agent_judge_intent_defense.py
+#   parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from packages.llm_analysis.agent import (  # noqa: E402
+    AutonomousSecurityAgentV2,
+    VulnerabilityContext,
+)
+
+
+def _stub_agent():
+    """Minimal stand-in for AutonomousSecurityAgentV2 that supplies
+    only ``llm`` (set to None so intent_match runs heuristic-only
+    and never invokes the LLM tiebreak)."""
+    agent = SimpleNamespace(llm=None)
+    agent._judge_exploit_intent = (
+        AutonomousSecurityAgentV2._judge_exploit_intent.__get__(
+            agent, type(agent)
+        )
+    )
+    return agent
+
+
+def _make_vuln(metadata=None, analysis=None):
+    """Construct a VulnerabilityContext sidestepping the full
+    constructor (which needs Finding-shaped data + repo_path)."""
+    vuln = VulnerabilityContext.__new__(VulnerabilityContext)
+    vuln.finding_id = "FIND-0001"
+    vuln.rule_id = "test/rule"
+    vuln.file_path = "src/auth.c"
+    vuln.start_line = 1
+    vuln.end_line = 1
+    vuln.level = "error"
+    vuln.message = "test"
+    vuln.cwe_id = "CWE-120"
+    vuln.tool = "test"
+    vuln.full_code = None
+    vuln.surrounding_context = None
+    vuln.exploitable = True
+    vuln.exploitability_score = 0.8
+    vuln.exploit_code = '// targets src/auth.c\npayload = "A" * 100'
+    vuln.exploit_compiled = None
+    vuln.exploit_compile_errors = []
+    vuln.intent_match = None
+    vuln.patch_code = None
+    vuln.feasibility = {"status": "pending"}
+    vuln.has_dataflow = False
+    vuln.metadata = metadata
+    vuln.analysis = analysis
+    return vuln
+
+
+# ----------------------------------------------------------------------
+# vuln.metadata shape tolerance
+# ----------------------------------------------------------------------
+
+
+class TestMetadataShapeTolerance:
+    def test_metadata_dict_normal(self):
+        """Sanity: a proper dict metadata works (regression guard
+        for the happy path)."""
+        agent = _stub_agent()
+        vuln = _make_vuln(metadata={"name": "check_password"})
+        agent._judge_exploit_intent(vuln, vuln.exploit_code)
+        assert vuln.intent_match is not None
+        # function_overlap should fire — function name in exploit code? No,
+        # exploit doesn't mention check_password. So no overlap. But the
+        # call shouldn't crash.
+
+    def test_metadata_none(self):
+        """``None`` metadata is the common default — must not crash."""
+        agent = _stub_agent()
+        vuln = _make_vuln(metadata=None)
+        agent._judge_exploit_intent(vuln, vuln.exploit_code)
+        assert vuln.intent_match is not None
+
+    @pytest.mark.parametrize("bad_metadata", [
+        ["not", "a", "dict"],          # list
+        "raw string",                   # string
+        42,                             # int
+        object(),                       # arbitrary object
+    ])
+    def test_metadata_non_dict_does_not_crash(self, bad_metadata):
+        """Pre-fix this raised AttributeError on ``.get("name")``.
+        Post-fix the helper treats non-dict metadata as "no
+        function-name signal" and runs intent_match with
+        ``function_name=None``."""
+        agent = _stub_agent()
+        vuln = _make_vuln(metadata=bad_metadata)
+        # Must not raise
+        agent._judge_exploit_intent(vuln, vuln.exploit_code)
+        assert vuln.intent_match is not None
+
+
+# ----------------------------------------------------------------------
+# vuln.analysis shape tolerance
+# ----------------------------------------------------------------------
+
+
+class TestAnalysisShapeTolerance:
+    def test_analysis_dict_with_true_positive_false_skips(self):
+        """Regression guard: the FP-skip path still fires when
+        analysis is a proper dict."""
+        agent = _stub_agent()
+        vuln = _make_vuln(analysis={"is_true_positive": False})
+        agent._judge_exploit_intent(vuln, vuln.exploit_code)
+        # Skipped — intent_match stays None
+        assert vuln.intent_match is None
+
+    def test_analysis_dict_with_true_positive_true_runs(self):
+        agent = _stub_agent()
+        vuln = _make_vuln(analysis={"is_true_positive": True})
+        agent._judge_exploit_intent(vuln, vuln.exploit_code)
+        assert vuln.intent_match is not None
+
+    def test_analysis_dict_missing_true_positive_runs(self):
+        """``is_true_positive`` not in the dict → judge runs."""
+        agent = _stub_agent()
+        vuln = _make_vuln(analysis={"some_other_field": "value"})
+        agent._judge_exploit_intent(vuln, vuln.exploit_code)
+        assert vuln.intent_match is not None
+
+    def test_analysis_none_runs(self):
+        agent = _stub_agent()
+        vuln = _make_vuln(analysis=None)
+        agent._judge_exploit_intent(vuln, vuln.exploit_code)
+        assert vuln.intent_match is not None
+
+    @pytest.mark.parametrize("bad_analysis", [
+        "raw string",
+        ["a", "list"],
+        42,
+        object(),
+    ])
+    def test_analysis_non_dict_does_not_crash(self, bad_analysis):
+        """Pre-fix this raised AttributeError on
+        ``.get("is_true_positive")``. Post-fix non-dict analysis
+        is treated as "no triage signal" and the judge runs."""
+        agent = _stub_agent()
+        vuln = _make_vuln(analysis=bad_analysis)
+        agent._judge_exploit_intent(vuln, vuln.exploit_code)
+        assert vuln.intent_match is not None
+
+
+# ----------------------------------------------------------------------
+# Combined shape-mismatch
+# ----------------------------------------------------------------------
+
+
+def test_both_metadata_and_analysis_non_dict_does_not_crash():
+    """Worst-case: pipeline upstream wrote both fields to unusual
+    shapes. Judge still runs."""
+    agent = _stub_agent()
+    vuln = _make_vuln(
+        metadata=["broken", "shape"],
+        analysis="even more broken",
+    )
+    agent._judge_exploit_intent(vuln, vuln.exploit_code)
+    assert vuln.intent_match is not None

--- a/packages/llm_analysis/tests/test_intent_match.py
+++ b/packages/llm_analysis/tests/test_intent_match.py
@@ -567,3 +567,81 @@ class TestSchemaShape:
         assert VERDICT_MATCHES == "matches"
         assert VERDICT_OFF_TARGET == "off_target"
         assert VERDICT_UNCERTAIN == "uncertain"
+
+
+# ---------------------------------------------------------------------------
+# Defensive paths added in the adversarial-review stacked fix
+# ---------------------------------------------------------------------------
+
+
+class TestLLMContentTypeTolerance:
+    """The judge tolerates unusual LLM client return shapes without
+    crashing the prompt envelope. Real providers return ``str``, but
+    custom adapters / wrappers have been seen to return ``bytes`` —
+    the envelope's regex sub then raises TypeError on bytes input.
+    Pre-fix this crashed mid-tiebreak; post-fix the bytes get
+    decoded to UTF-8 (with errors=replace) before reaching the
+    envelope."""
+
+    _AMBIGUOUS_KWARGS = dict(
+        exploit_code='payload = "A" * 200',
+        finding_file_path="src/other.c",
+        finding_function_name="check_password",
+        finding_cwe="CWE-120",
+    )
+
+    def test_describe_response_bytes_content_decoded(self):
+        """Step 1 (describe) returning bytes content doesn't crash."""
+        from unittest.mock import MagicMock
+        llm = MagicMock()
+        # describe-step → bytes content; judge-step → str
+        describe_resp = MagicMock()
+        describe_resp.content = b"The exploit constructs a long payload."
+        describe_resp.cost_usd = 0.001
+        judge_resp = MagicMock()
+        judge_resp.content = "matches: payload aimed at target"
+        judge_resp.cost_usd = 0.001
+        llm.generate.side_effect = [describe_resp, judge_resp]
+
+        v = intent_match(**self._AMBIGUOUS_KWARGS, llm_client=llm)
+        assert v.used_llm is True
+        # Verdict can be matches OR uncertain depending on how the
+        # decoded content gets judged — what matters is no crash.
+        assert v.verdict in {VERDICT_MATCHES, VERDICT_OFF_TARGET, VERDICT_UNCERTAIN}
+        assert v.llm_error is None
+
+    def test_judge_response_bytes_content_decoded(self):
+        """Step 2 (judge) returning bytes content doesn't crash and
+        parses correctly after decode."""
+        from unittest.mock import MagicMock
+        llm = MagicMock()
+        describe_resp = MagicMock()
+        describe_resp.content = "the exploit does X"
+        describe_resp.cost_usd = 0.001
+        judge_resp = MagicMock()
+        judge_resp.content = b"matches: bytes-typed verdict"
+        judge_resp.cost_usd = 0.001
+        llm.generate.side_effect = [describe_resp, judge_resp]
+
+        v = intent_match(**self._AMBIGUOUS_KWARGS, llm_client=llm)
+        assert v.verdict == VERDICT_MATCHES
+        assert v.used_llm is True
+        assert v.llm_error is None
+
+    def test_invalid_utf8_bytes_replaced_not_raised(self):
+        """Non-UTF8 bytes (decoder error) get replaced rather than
+        raised — best-effort decode."""
+        from unittest.mock import MagicMock
+        llm = MagicMock()
+        describe_resp = MagicMock()
+        # Invalid UTF-8 byte sequence
+        describe_resp.content = b"\xff\xfe invalid utf-8 attempt"
+        describe_resp.cost_usd = 0.001
+        judge_resp = MagicMock()
+        judge_resp.content = "uncertain: garbled input"
+        judge_resp.cost_usd = 0.001
+        llm.generate.side_effect = [describe_resp, judge_resp]
+
+        v = intent_match(**self._AMBIGUOUS_KWARGS, llm_client=llm)
+        assert v.used_llm is True
+        # No specific verdict expected — what matters is no crash.


### PR DESCRIPTION
Adversarial review of PR #577 surfaced three real crashes that bypassed pre-merge review:

1. vuln.metadata non-dict → AttributeError on .get("name"). Pipelines have been observed to set this field to lists/strings in flight; the type hint Optional[Dict[str, Any]] is not load-bearing.
2. vuln.analysis non-dict → AttributeError on .get("is_true_positive"). Same shape-confusion class.
3. LLM response with content=bytes → TypeError from prompt_envelope's regex pass. Some providers return raw bytes for non-text content parts; intent_match.py was passing them straight through.

Fixes:
- agent.py: isinstance(..., dict) gates before .get() on both fields; non-dict treated as "no signal" rather than fatal.
- intent_match.py: bytes→str coercion via decode("utf-8", errors= "replace") in both describe-step and judge-step LLM-tiebreak response handlers.
- test_intent_match.py: TestLLMContentTypeTolerance (3 tests) covering the bytes content path plus invalid UTF-8.
- test_agent_judge_intent_defense.py (new): 17 tests across TestMetadataShapeTolerance / TestAnalysisShapeTolerance / combined worst-case, parametrised over list/str/int/object shapes.

The crash_agent.py side of intent-match and PR #574 (crash-verify) were probed against the same adversarial corpus and came out clean — no companion fix needed.