### PR TITLE
feat(llm_analysis): record LLM-emitted exploits as canonical Witnesses

### DIFF
--- a/packages/llm_analysis/agent.py
+++ b/packages/llm_analysis/agent.py
@@ -500,7 +500,8 @@ class AutonomousSecurityAgentV2:
                  prep_only: bool = False,
                  synthesise_checkers: bool = True,
                  verify_exploits: bool = True,
-                 judge_intent: bool = True):
+                 judge_intent: bool = True,
+                 record_witnesses: bool = True):
         self.repo_path = repo_path
         self.out_dir = out_dir
         self.out_dir.mkdir(parents=True, exist_ok=True)
@@ -530,6 +531,17 @@ class AutonomousSecurityAgentV2:
         # unwanted. See ``_judge_exploit_intent`` and
         # ``packages.llm_analysis.intent_match``.
         self.judge_intent = judge_intent
+        # Record each LLM-emitted exploit as a canonical Witness
+        # (source=LLM_EMIT_RUN, outcome=NOT_RUN) so the bytes are
+        # available to downstream consumers (reporting, future
+        # ZKPoX) on the same data path as fuzz witnesses. Lazy: the
+        # WitnessStore is opened on the first successful exploit
+        # generation rather than eagerly, so prep-only runs never
+        # touch the filesystem. Failures are non-fatal — the
+        # exploit artefact remains on disk regardless. Default on;
+        # opt out via ``--no-record-witnesses``.
+        self.record_witnesses = record_witnesses
+        self._witness_store = None  # lazy
 
         # Detect LLM availability and choose provider
         availability = detect_llm_availability()
@@ -1228,6 +1240,16 @@ class AutonomousSecurityAgentV2:
                 if self.judge_intent:
                     self._judge_exploit_intent(vuln, exploit_code)
 
+                # Record the LLM-emitted exploit as a canonical
+                # Witness (source=LLM_EMIT_RUN, outcome=NOT_RUN).
+                # Same data path as fuzz witnesses; downstream
+                # consumers filter by ``source`` when they care
+                # about provenance. Gated on
+                # ``self.record_witnesses``; failures are non-
+                # fatal — the exploit file on disk is unaffected.
+                if self.record_witnesses:
+                    self._record_exploit_witness(vuln, exploit_code)
+
                 return True
             else:
                 logger.warning("   ✗ LLM response did not contain valid code")
@@ -1346,6 +1368,69 @@ class AutonomousSecurityAgentV2:
             logger.info(
                 f"   · Intent-match: uncertain "
                 f"(used_llm={verdict.used_llm})"
+            )
+
+    def _record_exploit_witness(
+        self, vuln: VulnerabilityContext, exploit_code: str,
+    ) -> None:
+        """Record the LLM-emitted exploit as a canonical Witness.
+
+        Lazy-opens ``self._witness_store`` against
+        ``self.out_dir / "witnesses"`` on first call so prep-only
+        runs never touch the filesystem. Reads ``compile_verify``
+        and ``intent_match`` verdicts off the finding for the
+        ``outcome_detail``; both may be ``None`` if their gates
+        were disabled.
+
+        Failures are non-fatal: a witness-store I/O error, an
+        adapter exception, or a non-UTF-8 exploit_code (LLMs
+        sometimes emit binary-looking fixtures inside code blocks)
+        all log+continue. The exploit artefact on disk is the
+        primary record; the witness is a downstream-facing
+        secondary record.
+        """
+        try:
+            if self._witness_store is None:
+                from core.witness import WitnessStore
+                self._witness_store = WitnessStore(
+                    self.out_dir / "witnesses"
+                )
+            from packages.llm_analysis.witness_adapter import (
+                witness_from_exploit,
+            )
+            target_source_path = vuln.get_full_file_path()
+            intent_verdict = None
+            intent_confidence = None
+            if vuln.intent_match is not None:
+                intent_verdict = getattr(
+                    vuln.intent_match, "verdict", None,
+                )
+                intent_confidence = getattr(
+                    vuln.intent_match, "confidence", None,
+                )
+            witness, data = witness_from_exploit(
+                exploit_code,
+                finding_id=vuln.finding_id,
+                cwe_id=vuln.cwe_id,
+                rule_id=vuln.rule_id,
+                file_path=vuln.file_path,
+                compiled=vuln.exploit_compiled,
+                compile_error_count=len(
+                    vuln.exploit_compile_errors or []
+                ),
+                intent_verdict=intent_verdict,
+                intent_confidence=intent_confidence,
+                target_source_path=target_source_path,
+            )
+            self._witness_store.put(witness, data)
+            logger.debug(
+                f"   · Recorded witness {witness.bytes_hash[:12]} "
+                f"({witness.bytes_len}B)"
+            )
+        except Exception as e:  # noqa: BLE001 — best-effort
+            logger.warning(
+                f"   · Witness record failed for "
+                f"{vuln.finding_id}: {type(e).__name__}: {e}"
             )
 
     def generate_patch(self, vuln: VulnerabilityContext) -> bool:
@@ -2026,6 +2111,20 @@ def main() -> None:
              "judge not invoked). See "
              "packages/llm_analysis/intent_match.py for design.",
     )
+    ap.add_argument(
+        "--no-record-witnesses",
+        action="store_true",
+        help="Skip recording LLM-emitted exploits as canonical "
+             "Witnesses under <out>/witnesses/ (default on). "
+             "Each successful exploit generation otherwise produces "
+             "one Witness with source=LLM_EMIT_RUN, "
+             "outcome=NOT_RUN, carrying the compile + intent-match "
+             "verdicts in outcome_detail. Negligible wall-clock "
+             "cost (single sha256 + JSON write per finding); the "
+             "opt-out exists for benchmarks that compare runs "
+             "byte-for-byte and for ephemeral CI runs that don't "
+             "persist the out/ tree.",
+    )
     ap.add_argument("--prep-only", action="store_true",
                     help="Skip LLM analysis; produce structured findings for external orchestration")
     ap.add_argument("--max-parallel", type=int, default=3, help="Max parallel dispatch threads")
@@ -2103,6 +2202,7 @@ def main() -> None:
         synthesise_checkers=not args.no_checker_synthesis,
         verify_exploits=not args.no_verify_exploits,
         judge_intent=not args.no_judge_intent,
+        record_witnesses=not args.no_record_witnesses,
     )
 
     # Load checklist for metadata lookup

--- a/packages/llm_analysis/crash_agent.py
+++ b/packages/llm_analysis/crash_agent.py
@@ -295,7 +295,8 @@ class CrashAnalysisAgent:
     def __init__(self, binary_path: Path, out_dir: Path,
                  llm_config: LLMConfig = None,
                  verify_exploits: bool = True,
-                 judge_intent: bool = True):
+                 judge_intent: bool = True,
+                 record_witnesses: bool = True):
         self.binary = Path(binary_path)
         self.out_dir = Path(out_dir)
         self.out_dir.mkdir(parents=True, exist_ok=True)
@@ -314,6 +315,16 @@ class CrashAnalysisAgent:
         # ``raptor_fuzzing.py``). Mirrors the
         # ``AutonomousSecurityAgentV2`` contract.
         self.judge_intent = judge_intent
+        # Record each LLM-emitted exploit as a canonical Witness
+        # alongside the fuzz-crash witnesses that
+        # ``raptor_fuzzing.py`` already records. Same data path,
+        # same WitnessStore root — the bytes_hash deduplicates if
+        # an exploit ever matches a real crash input. Default on;
+        # opt out via ``--no-record-witnesses``. Lazy store open
+        # (filesystem untouched on prep-only / failed runs);
+        # failures are non-fatal.
+        self.record_witnesses = record_witnesses
+        self._witness_store = None  # lazy
 
         # Detect LLM availability and choose provider
         availability = detect_llm_availability()
@@ -665,6 +676,14 @@ FULL LLM RESPONSE:
                 if self.judge_intent:
                     self._judge_exploit_intent(crash_context, exploit_code)
 
+                # Record the LLM-emitted exploit as a canonical
+                # Witness alongside the fuzz-crash witnesses from
+                # ``raptor_fuzzing.py``. Same store, same source=
+                # LLM_EMIT_RUN, outcome=NOT_RUN encoding as the
+                # /agentic path. Failures are non-fatal.
+                if self.record_witnesses:
+                    self._record_exploit_witness(crash_context, exploit_code)
+
                 return True
             else:
                 logger.warning("   ✗ LLM response did not contain valid code")
@@ -784,6 +803,84 @@ FULL LLM RESPONSE:
             logger.info(
                 f"   · Intent-match: uncertain "
                 f"(used_llm={verdict.used_llm})"
+            )
+
+    def _record_exploit_witness(
+        self, crash_context: CrashContext, exploit_code: str,
+    ) -> None:
+        """Record the LLM-emitted exploit as a canonical Witness.
+
+        Lazy-opens ``self._witness_store`` against
+        ``self.out_dir / "witnesses"`` on first call. Reuses the
+        same ``crash_type_to_cwe`` lookup as
+        ``_judge_exploit_intent`` (both make best-effort CWE
+        mappings on the same field).
+
+        Note ``crash_context.intent_match`` is a ``dict`` here
+        (``asdict(verdict)``) rather than the dataclass instance
+        the /agentic path holds, so we read via ``.get(...)`` not
+        attribute access.
+
+        Failures are non-fatal: the exploit artefact on disk is
+        the primary record; the witness is a downstream-facing
+        secondary record.
+        """
+        try:
+            if self._witness_store is None:
+                from core.witness import WitnessStore
+                self._witness_store = WitnessStore(
+                    self.out_dir / "witnesses"
+                )
+            from packages.llm_analysis.witness_adapter import (
+                witness_from_exploit,
+            )
+
+            # Same crash_type → CWE table as _judge_exploit_intent
+            # uses; keep them in lockstep when one is extended.
+            crash_type_to_cwe = {
+                "heap_overflow": "CWE-122",
+                "stack_overflow": "CWE-121",
+                "buffer_overflow": "CWE-120",
+                "null_deref": "CWE-476",
+                "integer_overflow": "CWE-190",
+                "command_injection": "CWE-78",
+            }
+            cwe_id = crash_type_to_cwe.get(crash_context.crash_type)
+
+            intent_verdict = None
+            intent_confidence = None
+            if isinstance(crash_context.intent_match, dict):
+                intent_verdict = crash_context.intent_match.get("verdict")
+                intent_confidence = crash_context.intent_match.get(
+                    "confidence"
+                )
+
+            witness, data = witness_from_exploit(
+                exploit_code,
+                finding_id=crash_context.crash_id,
+                cwe_id=cwe_id,
+                file_path=(
+                    crash_context.source_location.rsplit(":", 1)[0]
+                    if crash_context.source_location else None
+                ),
+                compiled=crash_context.exploit_compiled,
+                compile_error_count=len(
+                    crash_context.exploit_compile_errors or []
+                ),
+                intent_verdict=intent_verdict,
+                intent_confidence=intent_confidence,
+                target_binary_path=self.binary,
+                produced_by="crash-agent",
+            )
+            self._witness_store.put(witness, data)
+            logger.debug(
+                f"   · Recorded witness {witness.bytes_hash[:12]} "
+                f"({witness.bytes_len}B)"
+            )
+        except Exception as e:  # noqa: BLE001 — best-effort
+            logger.warning(
+                f"   · Witness record failed for "
+                f"{crash_context.crash_id}: {type(e).__name__}: {e}"
             )
 
     def _signal_name(self, signal: str) -> str:

--- a/packages/llm_analysis/tests/test_agent_record_witness.py
+++ b/packages/llm_analysis/tests/test_agent_record_witness.py
@@ -1,0 +1,298 @@
+"""Tests for ``AutonomousSecurityAgentV2._record_exploit_witness``.
+
+The wiring is "after compile_verify + intent_match, before
+return". These tests pin:
+
+  * Witness store is lazy (no filesystem touch when the gate
+    fires zero times)
+  * ``record_witnesses=False`` disables the call site cleanly
+  * Recorded witness has the expected verdicts threaded through
+    from the finding's fields
+  * Failures (store I/O, missing fields) are non-fatal
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional
+
+
+# packages/llm_analysis/tests/test_agent_record_witness.py
+#   parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from core.witness import WitnessOutcome, WitnessSource  # noqa: E402
+from packages.llm_analysis.agent import (  # noqa: E402
+    AutonomousSecurityAgentV2,
+    VulnerabilityContext,
+)
+
+
+@dataclass
+class _StubVerdict:
+    verdict: str = "matches"
+    confidence: float = 0.85
+
+
+def _stub_agent(out_dir: Path, record_witnesses: bool = True):
+    """Minimal stub agent with just enough state for
+    ``_record_exploit_witness`` to run."""
+    agent = SimpleNamespace(
+        out_dir=out_dir,
+        record_witnesses=record_witnesses,
+        _witness_store=None,
+    )
+    agent._record_exploit_witness = (
+        AutonomousSecurityAgentV2._record_exploit_witness.__get__(
+            agent, type(agent)
+        )
+    )
+    return agent
+
+
+def _make_vuln(
+    finding_id: str = "FIND-0001",
+    cwe_id: Optional[str] = "CWE-120",
+    intent_match=None,
+    repo_path: Optional[Path] = None,
+    file_path: str = "src/auth.c",
+):
+    vuln = VulnerabilityContext.__new__(VulnerabilityContext)
+    vuln.finding_id = finding_id
+    vuln.rule_id = "cpp/buffer-overflow"
+    vuln.file_path = file_path
+    vuln.start_line = 1
+    vuln.end_line = 1
+    vuln.level = "error"
+    vuln.message = "test"
+    vuln.cwe_id = cwe_id
+    vuln.tool = "test"
+    vuln.full_code = None
+    vuln.surrounding_context = None
+    vuln.exploitable = True
+    vuln.exploitability_score = 0.8
+    vuln.exploit_code = "// poc\n"
+    vuln.exploit_compiled = True
+    vuln.exploit_compile_errors = []
+    vuln.intent_match = intent_match
+    vuln.patch_code = None
+    vuln.feasibility = {"status": "pending"}
+    vuln.has_dataflow = False
+    vuln.metadata = None
+    vuln.analysis = None
+    vuln.repo_path = repo_path or Path("/nonexistent")
+    return vuln
+
+
+# ----------------------------------------------------------------------
+# Happy path
+# ----------------------------------------------------------------------
+
+
+def test_records_one_witness_per_call(tmp_path):
+    agent = _stub_agent(tmp_path)
+    vuln = _make_vuln(intent_match=_StubVerdict())
+    agent._record_exploit_witness(vuln, "// exploit\n")
+
+    assert agent._witness_store is not None
+    # WitnessStore at tmp_path/witnesses; one manifest written
+    manifests = list((tmp_path / "witnesses" / "manifests").glob("*.json"))
+    blobs = list((tmp_path / "witnesses" / "blobs").glob("*"))
+    assert len(manifests) == 1
+    assert len(blobs) == 1
+
+
+def test_recorded_witness_has_llm_emit_run_source(tmp_path):
+    agent = _stub_agent(tmp_path)
+    vuln = _make_vuln(intent_match=_StubVerdict())
+    agent._record_exploit_witness(vuln, "// exploit\n")
+
+    # Read back the manifest via the store
+    from core.witness import WitnessStore
+    store = WitnessStore(tmp_path / "witnesses")
+    manifests = list(
+        (tmp_path / "witnesses" / "manifests").glob("*.json")
+    )
+    bytes_hash = manifests[0].stem
+    witness = store.get_witness(bytes_hash)
+    assert witness.source is WitnessSource.LLM_EMIT_RUN
+    assert witness.observed_outcome is WitnessOutcome.NOT_RUN
+
+
+def test_recorded_witness_carries_intent_match_verdict(tmp_path):
+    """The verdict + confidence on ``vuln.intent_match`` flows
+    into ``outcome_detail`` so consumers don't need to re-judge."""
+    agent = _stub_agent(tmp_path)
+    vuln = _make_vuln(
+        intent_match=_StubVerdict(verdict="off_target", confidence=0.7),
+    )
+    agent._record_exploit_witness(vuln, "// exploit\n")
+
+    from core.witness import WitnessStore
+    store = WitnessStore(tmp_path / "witnesses")
+    manifests = list(
+        (tmp_path / "witnesses" / "manifests").glob("*.json")
+    )
+    witness = store.get_witness(manifests[0].stem)
+    assert witness.outcome_detail["intent_verdict"] == "off_target"
+    assert witness.outcome_detail["intent_confidence"] == 0.7
+
+
+def test_compile_failure_threads_through(tmp_path):
+    agent = _stub_agent(tmp_path)
+    vuln = _make_vuln()
+    vuln.exploit_compiled = False
+    vuln.exploit_compile_errors = ["err1", "err2", "err3"]
+    agent._record_exploit_witness(vuln, "// poc\n")
+
+    from core.witness import WitnessStore
+    store = WitnessStore(tmp_path / "witnesses")
+    manifests = list(
+        (tmp_path / "witnesses" / "manifests").glob("*.json")
+    )
+    witness = store.get_witness(manifests[0].stem)
+    assert witness.outcome_detail["compiled"] is False
+    assert witness.outcome_detail["compile_error_count"] == 3
+
+
+def test_no_intent_match_no_verdict_key(tmp_path):
+    """``vuln.intent_match=None`` → ``intent_verdict`` omitted
+    from outcome_detail (absence-is-encoding)."""
+    agent = _stub_agent(tmp_path)
+    vuln = _make_vuln(intent_match=None)
+    agent._record_exploit_witness(vuln, "// poc\n")
+
+    from core.witness import WitnessStore
+    store = WitnessStore(tmp_path / "witnesses")
+    manifests = list(
+        (tmp_path / "witnesses" / "manifests").glob("*.json")
+    )
+    witness = store.get_witness(manifests[0].stem)
+    assert "intent_verdict" not in witness.outcome_detail
+    assert "intent_confidence" not in witness.outcome_detail
+
+
+# ----------------------------------------------------------------------
+# Store lazy-open
+# ----------------------------------------------------------------------
+
+
+def test_witness_store_lazy_opens_on_first_call(tmp_path):
+    agent = _stub_agent(tmp_path)
+    # Pre-call: no store, no files
+    assert agent._witness_store is None
+    assert not (tmp_path / "witnesses").exists()
+
+    vuln = _make_vuln()
+    agent._record_exploit_witness(vuln, "// poc\n")
+    assert agent._witness_store is not None
+    assert (tmp_path / "witnesses").exists()
+
+
+def test_witness_store_reused_across_calls(tmp_path):
+    """The second call uses the same WitnessStore instance — not
+    a perf bug if it re-opens, but lazy means lazy-once."""
+    agent = _stub_agent(tmp_path)
+    vuln1 = _make_vuln(finding_id="FIND-0001")
+    vuln2 = _make_vuln(finding_id="FIND-0002")
+    agent._record_exploit_witness(vuln1, "// poc 1\n")
+    store_instance = agent._witness_store
+    agent._record_exploit_witness(vuln2, "// poc 2\n")
+    assert agent._witness_store is store_instance
+
+
+# ----------------------------------------------------------------------
+# Failure modes (non-fatal)
+# ----------------------------------------------------------------------
+
+
+def test_store_io_failure_does_not_raise(tmp_path, monkeypatch):
+    """A WitnessStore.put() exception is logged + swallowed —
+    the exploit artefact on disk is the primary record."""
+    agent = _stub_agent(tmp_path)
+    vuln = _make_vuln()
+
+    # Force the put() to raise after the store is opened
+    import core.witness.store as store_mod
+
+    real_put = store_mod.WitnessStore.put
+
+    def _boom(self, witness, data):
+        raise IOError("disk gone")
+
+    monkeypatch.setattr(store_mod.WitnessStore, "put", _boom)
+    try:
+        agent._record_exploit_witness(vuln, "// poc\n")
+    finally:
+        monkeypatch.setattr(store_mod.WitnessStore, "put", real_put)
+
+
+def test_adapter_failure_does_not_raise(tmp_path, monkeypatch):
+    """Adapter exception (e.g. non-encodable string) is logged
+    + swallowed — the exploit artefact on disk is the primary
+    record."""
+    agent = _stub_agent(tmp_path)
+    vuln = _make_vuln()
+
+    import packages.llm_analysis.witness_adapter as adapter_mod
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("adapter exploded")
+
+    monkeypatch.setattr(
+        adapter_mod, "witness_from_exploit", _boom,
+    )
+    # Force store to open first by pre-running once
+    agent._record_exploit_witness(vuln, "// poc\n")
+
+
+# ----------------------------------------------------------------------
+# Dedup via hash
+# ----------------------------------------------------------------------
+
+
+def test_identical_exploits_dedup_in_store(tmp_path):
+    """Two findings, same exploit text → one blob in the store
+    (manifests may differ in outcome_detail — that's WitnessStore's
+    concern; the blob is shared)."""
+    agent = _stub_agent(tmp_path)
+    v1 = _make_vuln(finding_id="FIND-0001")
+    v2 = _make_vuln(finding_id="FIND-0002")
+    agent._record_exploit_witness(v1, "// identical poc\n")
+    agent._record_exploit_witness(v2, "// identical poc\n")
+    blobs = list((tmp_path / "witnesses" / "blobs").glob("*"))
+    assert len(blobs) == 1
+
+
+# ----------------------------------------------------------------------
+# Constructor flag wiring
+# ----------------------------------------------------------------------
+
+
+def test_constructor_default_record_witnesses_true(tmp_path):
+    """The agent constructor defaults ``record_witnesses=True``
+    so operators get the substrate without opting in."""
+    # We can't easily build the full agent without an LLM, so
+    # just inspect the dataclass-style attribute by calling
+    # ``__init__`` with prep_only=True (which uses ClaudeCodeProvider
+    # and is the cheapest constructor path).
+    agent = AutonomousSecurityAgentV2(
+        repo_path=tmp_path,
+        out_dir=tmp_path / "out",
+        prep_only=True,
+    )
+    assert agent.record_witnesses is True
+
+
+def test_constructor_record_witnesses_false_opt_out(tmp_path):
+    agent = AutonomousSecurityAgentV2(
+        repo_path=tmp_path,
+        out_dir=tmp_path / "out",
+        prep_only=True,
+        record_witnesses=False,
+    )
+    assert agent.record_witnesses is False

--- a/packages/llm_analysis/tests/test_crash_agent_record_witness.py
+++ b/packages/llm_analysis/tests/test_crash_agent_record_witness.py
@@ -1,0 +1,232 @@
+"""Tests for ``CrashAnalysisAgent._record_exploit_witness``.
+
+Mirrors ``test_agent_record_witness.py`` but for the fuzzing
+side: ``crash_context.intent_match`` is a ``dict`` (asdict
+flavour) rather than the ``IntentMatchVerdict`` dataclass that
+``/agentic`` holds, so the recorder reads via ``.get(...)``
+rather than attribute access.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional
+
+
+# packages/llm_analysis/tests/test_crash_agent_record_witness.py
+#   parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from core.witness import WitnessOutcome, WitnessSource  # noqa: E402
+from packages.binary_analysis.crash_analyser import CrashContext  # noqa: E402
+from packages.llm_analysis.crash_agent import CrashAnalysisAgent  # noqa: E402
+
+
+def _stub_agent(
+    out_dir: Path,
+    binary: Path,
+    record_witnesses: bool = True,
+):
+    agent = SimpleNamespace(
+        out_dir=out_dir,
+        binary=binary,
+        record_witnesses=record_witnesses,
+        _witness_store=None,
+    )
+    agent._record_exploit_witness = (
+        CrashAnalysisAgent._record_exploit_witness.__get__(
+            agent, type(agent)
+        )
+    )
+    return agent
+
+
+def _make_crash_context(
+    crash_id: str = "000001",
+    crash_type: str = "stack_overflow",
+    source_location: str = "src/parser.c:42",
+    intent_match: Optional[dict] = None,
+    binary_path: Optional[Path] = None,
+):
+    return CrashContext(
+        crash_id=crash_id,
+        binary_path=binary_path or Path("/nonexistent"),
+        input_file=Path("/nonexistent_input"),
+        signal="11",
+        crash_type=crash_type,
+        source_location=source_location,
+        exploit_code="// PoC\n",
+        exploit_compiled=True,
+        exploit_compile_errors=[],
+        intent_match=intent_match,
+    )
+
+
+# ----------------------------------------------------------------------
+# Happy path
+# ----------------------------------------------------------------------
+
+
+def test_records_witness_with_llm_emit_run_source(tmp_path):
+    binary = tmp_path / "target"
+    binary.write_bytes(b"ELF mock")
+    agent = _stub_agent(tmp_path, binary=binary)
+    crash = _make_crash_context(binary_path=binary)
+    agent._record_exploit_witness(crash, "// exploit\n")
+
+    from core.witness import WitnessStore
+    store = WitnessStore(tmp_path / "witnesses")
+    manifests = list(
+        (tmp_path / "witnesses" / "manifests").glob("*.json")
+    )
+    assert len(manifests) == 1
+    witness = store.get_witness(manifests[0].stem)
+    assert witness.source is WitnessSource.LLM_EMIT_RUN
+    assert witness.observed_outcome is WitnessOutcome.NOT_RUN
+    assert witness.produced_by == "crash-agent"
+
+
+def test_target_binary_hashed(tmp_path):
+    """Binary hash is the relevant target slot for fuzzing
+    (vs source for /agentic) — must be set."""
+    binary = tmp_path / "target"
+    binary.write_bytes(b"\x7fELF...binary contents")
+    agent = _stub_agent(tmp_path, binary=binary)
+    crash = _make_crash_context()
+    agent._record_exploit_witness(crash, "// exploit\n")
+
+    from core.witness import WitnessStore
+    store = WitnessStore(tmp_path / "witnesses")
+    manifests = list(
+        (tmp_path / "witnesses" / "manifests").glob("*.json")
+    )
+    witness = store.get_witness(manifests[0].stem)
+    assert witness.target_binary_hash is not None
+    assert len(witness.target_binary_hash) == 64
+
+
+def test_crash_type_mapped_to_cwe(tmp_path):
+    """The same crash_type → CWE lookup the judge uses flows
+    into outcome_detail."""
+    binary = tmp_path / "target"
+    binary.write_bytes(b"x")
+    agent = _stub_agent(tmp_path, binary=binary)
+    crash = _make_crash_context(crash_type="heap_overflow")
+    agent._record_exploit_witness(crash, "// exploit\n")
+
+    from core.witness import WitnessStore
+    store = WitnessStore(tmp_path / "witnesses")
+    manifests = list(
+        (tmp_path / "witnesses" / "manifests").glob("*.json")
+    )
+    witness = store.get_witness(manifests[0].stem)
+    assert witness.outcome_detail["cwe_id"] == "CWE-122"
+
+
+def test_unmapped_crash_type_no_cwe(tmp_path):
+    """``use_after_free`` is in the judge's table but has
+    ``None`` — adapter should omit the field (absence is
+    encoding)."""
+    binary = tmp_path / "target"
+    binary.write_bytes(b"x")
+    agent = _stub_agent(tmp_path, binary=binary)
+    crash = _make_crash_context(crash_type="use_after_free")
+    agent._record_exploit_witness(crash, "// exploit\n")
+
+    from core.witness import WitnessStore
+    store = WitnessStore(tmp_path / "witnesses")
+    manifests = list(
+        (tmp_path / "witnesses" / "manifests").glob("*.json")
+    )
+    witness = store.get_witness(manifests[0].stem)
+    assert "cwe_id" not in witness.outcome_detail
+
+
+def test_intent_match_dict_threaded_through(tmp_path):
+    """``crash_context.intent_match`` is a ``dict`` here, not
+    the dataclass — the recorder must read via ``.get(...)``."""
+    binary = tmp_path / "target"
+    binary.write_bytes(b"x")
+    agent = _stub_agent(tmp_path, binary=binary)
+    crash = _make_crash_context(
+        intent_match={
+            "verdict": "matches",
+            "confidence": 0.92,
+            "reasoning": "should not leak",
+        }
+    )
+    agent._record_exploit_witness(crash, "// exploit\n")
+
+    from core.witness import WitnessStore
+    store = WitnessStore(tmp_path / "witnesses")
+    manifests = list(
+        (tmp_path / "witnesses" / "manifests").glob("*.json")
+    )
+    witness = store.get_witness(manifests[0].stem)
+    assert witness.outcome_detail["intent_verdict"] == "matches"
+    assert witness.outcome_detail["intent_confidence"] == 0.92
+    # reasoning should NOT leak (avoid bloating outcome_detail)
+    assert "reasoning" not in witness.outcome_detail
+
+
+def test_intent_match_non_dict_does_not_crash(tmp_path):
+    """Defensive: same shape-tolerance lesson as the agent.py
+    side learned post-merge of #577."""
+    binary = tmp_path / "target"
+    binary.write_bytes(b"x")
+    agent = _stub_agent(tmp_path, binary=binary)
+    crash = _make_crash_context(intent_match="raw string")
+    agent._record_exploit_witness(crash, "// exploit\n")
+
+    from core.witness import WitnessStore
+    store = WitnessStore(tmp_path / "witnesses")
+    manifests = list(
+        (tmp_path / "witnesses" / "manifests").glob("*.json")
+    )
+    witness = store.get_witness(manifests[0].stem)
+    assert "intent_verdict" not in witness.outcome_detail
+
+
+def test_source_location_threads_into_file_path(tmp_path):
+    """``source_location`` is ``"file:line"`` — only the path
+    half should land in outcome_detail."""
+    binary = tmp_path / "target"
+    binary.write_bytes(b"x")
+    agent = _stub_agent(tmp_path, binary=binary)
+    crash = _make_crash_context(source_location="src/parser.c:42")
+    agent._record_exploit_witness(crash, "// exploit\n")
+
+    from core.witness import WitnessStore
+    store = WitnessStore(tmp_path / "witnesses")
+    manifests = list(
+        (tmp_path / "witnesses" / "manifests").glob("*.json")
+    )
+    witness = store.get_witness(manifests[0].stem)
+    assert witness.outcome_detail["file_path"] == "src/parser.c"
+
+
+# ----------------------------------------------------------------------
+# Failure modes (non-fatal)
+# ----------------------------------------------------------------------
+
+
+def test_store_io_failure_does_not_raise(tmp_path, monkeypatch):
+    binary = tmp_path / "target"
+    binary.write_bytes(b"x")
+    agent = _stub_agent(tmp_path, binary=binary)
+    crash = _make_crash_context()
+
+    import core.witness.store as store_mod
+    real_put = store_mod.WitnessStore.put
+
+    def _boom(self, witness, data):
+        raise IOError("disk gone")
+
+    monkeypatch.setattr(store_mod.WitnessStore, "put", _boom)
+    try:
+        agent._record_exploit_witness(crash, "// exploit\n")
+    finally:
+        monkeypatch.setattr(store_mod.WitnessStore, "put", real_put)

--- a/packages/llm_analysis/tests/test_witness_adapter.py
+++ b/packages/llm_analysis/tests/test_witness_adapter.py
@@ -1,0 +1,327 @@
+"""Tests for ``packages.llm_analysis.witness_adapter.witness_from_exploit``.
+
+The adapter wraps LLM-emitted exploit source as a canonical
+``Witness`` so reporting + future ZKPoX consumers see fuzz
+witnesses and LLM-emitted-exploit witnesses on the same data
+path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+
+# packages/llm_analysis/tests/test_witness_adapter.py
+#   parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from core.witness import (  # noqa: E402
+    WitnessOutcome,
+    WitnessSource,
+    WitnessStore,
+)
+from packages.llm_analysis.witness_adapter import (  # noqa: E402
+    witness_from_exploit,
+)
+
+
+_SAMPLE_EXPLOIT = (
+    "// PoC for CWE-120 in src/auth.c::check_password\n"
+    "#include <string.h>\n"
+    "int main(void) {\n"
+    "    char buf[8];\n"
+    '    strcpy(buf, "AAAAAAAAAAAAAAAAAAAA");\n'
+    "    return 0;\n"
+    "}\n"
+)
+
+
+# ----------------------------------------------------------------------
+# Basic adapter contract
+# ----------------------------------------------------------------------
+
+
+def test_returns_witness_and_bytes():
+    witness, bytes_ = witness_from_exploit(
+        _SAMPLE_EXPLOIT, finding_id="FIND-0001",
+    )
+    assert bytes_ == _SAMPLE_EXPLOIT.encode("utf-8")
+    assert witness.bytes_hash == hashlib.sha256(bytes_).hexdigest()
+    assert witness.bytes_len == len(bytes_)
+
+
+def test_source_is_llm_emit_run():
+    """Downstream consumers filter by source to distinguish
+    fuzz-verified from LLM-emitted-but-unrun witnesses."""
+    witness, _ = witness_from_exploit(
+        _SAMPLE_EXPLOIT, finding_id="FIND-0001",
+    )
+    assert witness.source is WitnessSource.LLM_EMIT_RUN
+
+
+def test_outcome_is_not_run():
+    """``/agentic`` never executes exploits. The outcome encoding
+    must match — future Tier-1.5 native execution will emit
+    EXIT_SIGNAL / SANITIZER_REPORT / FLAG_CAPTURED witnesses
+    for the same bytes_hash."""
+    witness, _ = witness_from_exploit(
+        _SAMPLE_EXPLOIT, finding_id="FIND-0001",
+    )
+    assert witness.observed_outcome is WitnessOutcome.NOT_RUN
+
+
+def test_default_produced_by_is_agentic():
+    witness, _ = witness_from_exploit(
+        _SAMPLE_EXPLOIT, finding_id="FIND-0001",
+    )
+    assert witness.produced_by == "agentic"
+
+
+def test_produced_by_overrideable():
+    witness, _ = witness_from_exploit(
+        _SAMPLE_EXPLOIT,
+        finding_id="FIND-0001",
+        produced_by="agentic:claude-opus-4-7",
+    )
+    assert witness.produced_by == "agentic:claude-opus-4-7"
+
+
+# ----------------------------------------------------------------------
+# Outcome detail
+# ----------------------------------------------------------------------
+
+
+def test_outcome_detail_carries_finding_id_minimum():
+    witness, _ = witness_from_exploit(
+        _SAMPLE_EXPLOIT, finding_id="FIND-0042",
+    )
+    assert witness.outcome_detail["finding_id"] == "FIND-0042"
+
+
+def test_outcome_detail_optional_fields_omitted_when_absent():
+    """Adapter should NOT bloat outcome_detail with None /
+    falsy markers — absence is the right encoding."""
+    witness, _ = witness_from_exploit(
+        _SAMPLE_EXPLOIT, finding_id="FIND-0001",
+    )
+    od = witness.outcome_detail
+    for k in (
+        "cwe_id", "rule_id", "file_path", "compiled",
+        "compile_error_count", "intent_verdict", "intent_confidence",
+    ):
+        assert k not in od
+
+
+def test_outcome_detail_full():
+    witness, _ = witness_from_exploit(
+        _SAMPLE_EXPLOIT,
+        finding_id="FIND-0001",
+        cwe_id="CWE-120",
+        rule_id="cpp/buffer-overflow",
+        file_path="src/auth.c",
+        compiled=True,
+        compile_error_count=0,
+        intent_verdict="matches",
+        intent_confidence=0.91,
+    )
+    od = witness.outcome_detail
+    assert od["cwe_id"] == "CWE-120"
+    assert od["rule_id"] == "cpp/buffer-overflow"
+    assert od["file_path"] == "src/auth.c"
+    assert od["compiled"] is True
+    # compile_error_count=0 is falsy and is omitted by design
+    assert "compile_error_count" not in od
+    assert od["intent_verdict"] == "matches"
+    assert od["intent_confidence"] == 0.91
+
+
+def test_outcome_detail_compile_failure():
+    witness, _ = witness_from_exploit(
+        _SAMPLE_EXPLOIT,
+        finding_id="FIND-0001",
+        compiled=False,
+        compile_error_count=3,
+        intent_verdict="off_target",
+    )
+    od = witness.outcome_detail
+    assert od["compiled"] is False
+    assert od["compile_error_count"] == 3
+    assert od["intent_verdict"] == "off_target"
+
+
+def test_outcome_detail_compiled_none_omitted():
+    """``compiled=None`` means verification wasn't attempted —
+    absence is the right encoding, not a ``null`` value."""
+    witness, _ = witness_from_exploit(
+        _SAMPLE_EXPLOIT,
+        finding_id="FIND-0001",
+        compiled=None,
+    )
+    assert "compiled" not in witness.outcome_detail
+
+
+# ----------------------------------------------------------------------
+# Target source hashing
+# ----------------------------------------------------------------------
+
+
+def test_target_source_hashing_when_path_provided(tmp_path):
+    src = tmp_path / "auth.c"
+    src.write_text("int check_password() { return 0; }\n")
+    witness, _ = witness_from_exploit(
+        _SAMPLE_EXPLOIT,
+        finding_id="FIND-0001",
+        target_source_path=src,
+    )
+    assert witness.target_source_hash is not None
+    assert len(witness.target_source_hash) == 64
+    expected = hashlib.sha256(src.read_bytes()).hexdigest()
+    assert witness.target_source_hash == expected
+
+
+def test_target_source_hash_none_when_path_missing(tmp_path):
+    """Path doesn't exist → ``None`` rather than raising. Witness
+    records are best-effort about bindings."""
+    witness, _ = witness_from_exploit(
+        _SAMPLE_EXPLOIT,
+        finding_id="FIND-0001",
+        target_source_path=tmp_path / "does_not_exist.c",
+    )
+    assert witness.target_source_hash is None
+
+
+def test_target_source_hash_none_when_path_not_supplied():
+    witness, _ = witness_from_exploit(
+        _SAMPLE_EXPLOIT, finding_id="FIND-0001",
+    )
+    assert witness.target_source_hash is None
+
+
+def test_target_binary_hash_default_none():
+    """``/agentic``'s common path emits source only with no
+    binary to hash — slot stays ``None``. The fuzz-derived
+    crash-agent path supplies ``target_binary_path`` explicitly."""
+    witness, _ = witness_from_exploit(
+        _SAMPLE_EXPLOIT, finding_id="FIND-0001",
+    )
+    assert witness.target_binary_hash is None
+
+
+def test_target_binary_hashing_when_path_provided(tmp_path):
+    """crash_agent's path supplies the binary that was fuzzed —
+    same slot semantics as the fuzz adapter."""
+    binary = tmp_path / "target"
+    binary.write_bytes(b"\x7fELF...mock binary content")
+    witness, _ = witness_from_exploit(
+        _SAMPLE_EXPLOIT,
+        finding_id="FIND-0001",
+        target_binary_path=binary,
+    )
+    assert witness.target_binary_hash is not None
+    assert len(witness.target_binary_hash) == 64
+    expected = hashlib.sha256(binary.read_bytes()).hexdigest()
+    assert witness.target_binary_hash == expected
+
+
+def test_target_binary_hash_none_when_missing(tmp_path):
+    witness, _ = witness_from_exploit(
+        _SAMPLE_EXPLOIT,
+        finding_id="FIND-0001",
+        target_binary_path=tmp_path / "does_not_exist",
+    )
+    assert witness.target_binary_hash is None
+
+
+# ----------------------------------------------------------------------
+# Edge cases
+# ----------------------------------------------------------------------
+
+
+def test_empty_exploit_code():
+    """LLM occasionally emits an empty exploit (truncation,
+    refusal). Adapter still produces a valid witness — the
+    bytes_hash is just sha256(b'')."""
+    witness, bytes_ = witness_from_exploit("", finding_id="FIND-0001")
+    assert bytes_ == b""
+    assert witness.bytes_len == 0
+    assert witness.bytes_hash == hashlib.sha256(b"").hexdigest()
+
+
+def test_unicode_exploit_code():
+    """Non-ASCII source survives the UTF-8 round trip."""
+    code = '// PoC for finding\nprintf("héllo\\n");\n'
+    witness, bytes_ = witness_from_exploit(
+        code, finding_id="FIND-0001",
+    )
+    assert bytes_ == code.encode("utf-8")
+    assert witness.bytes_hash == hashlib.sha256(bytes_).hexdigest()
+
+
+def test_unpaired_surrogate_does_not_raise():
+    """Pre-fix this raised ``UnicodeEncodeError`` ('surrogates
+    not allowed') from ``str.encode("utf-8")``. The adapter now
+    encodes with ``errors="replace"`` so an LLM response that
+    survived a sloppy decode (carrying unpaired surrogates)
+    still produces a valid Witness — the broken codepoints
+    become U+FFFD bytes and the surrounding exploit text
+    survives intact."""
+    code = "// preamble\n\udcff exploit body\n"
+    witness, bytes_ = witness_from_exploit(
+        code, finding_id="FIND-0001",
+    )
+    assert witness.bytes_len > 0
+    assert witness.bytes_hash == hashlib.sha256(bytes_).hexdigest()
+    # surrogate replaced; surrounding text preserved
+    assert b"preamble" in bytes_
+    assert b"exploit body" in bytes_
+
+
+def test_identical_exploits_dedup_by_hash():
+    """Two findings, same exploit text → same bytes_hash.
+    WitnessStore dedups blobs by hash so this is intentional
+    behaviour — operators inspecting the store can spot
+    cross-finding exploit reuse."""
+    w1, _ = witness_from_exploit(
+        _SAMPLE_EXPLOIT, finding_id="FIND-0001",
+    )
+    w2, _ = witness_from_exploit(
+        _SAMPLE_EXPLOIT, finding_id="FIND-0002",
+    )
+    assert w1.bytes_hash == w2.bytes_hash
+    # but outcome_detail differs
+    assert w1.outcome_detail["finding_id"] != w2.outcome_detail["finding_id"]
+
+
+# ----------------------------------------------------------------------
+# Store round-trip
+# ----------------------------------------------------------------------
+
+
+def test_round_trip_through_witness_store(tmp_path):
+    """The ``(witness, bytes_)`` tuple plugs straight into
+    ``WitnessStore.put`` with no impedance — same contract as
+    the fuzz adapter."""
+    witness, data = witness_from_exploit(
+        _SAMPLE_EXPLOIT,
+        finding_id="FIND-0001",
+        cwe_id="CWE-120",
+        compiled=True,
+        intent_verdict="matches",
+    )
+    store_root = tmp_path / "store"
+    store = WitnessStore(store_root)
+    store.put(witness, data)
+
+    loaded = store.get_witness(witness.bytes_hash)
+    loaded_bytes = store.get_bytes(witness.bytes_hash)
+    assert loaded.bytes_hash == witness.bytes_hash
+    assert loaded.source == WitnessSource.LLM_EMIT_RUN
+    assert loaded.observed_outcome == WitnessOutcome.NOT_RUN
+    assert loaded.outcome_detail["finding_id"] == "FIND-0001"
+    assert loaded.outcome_detail["cwe_id"] == "CWE-120"
+    assert loaded.outcome_detail["compiled"] is True
+    assert loaded.outcome_detail["intent_verdict"] == "matches"
+    assert loaded_bytes == data

--- a/packages/llm_analysis/witness_adapter.py
+++ b/packages/llm_analysis/witness_adapter.py
@@ -1,0 +1,122 @@
+"""Adapter: LLM-emitted exploit → ``core.witness.Witness``.
+
+``/agentic`` synthesises an exploit per finding (via
+``AutonomousSecurityAgentV2``), compile-verifies it, and runs the
+intent-match judge over the result — but never *executes* the
+exploit. The exploit-source bytes are still a witness of intent:
+recording them under the canonical Witness type makes them
+available alongside fuzz-generated witnesses for downstream
+consumers (reporting, future ZKPoX bundle assembly, future
+calibrated IntentMatchJudge) on the same data path.
+
+The witness records:
+
+  * ``source = LLM_EMIT_RUN``
+  * ``observed_outcome = NOT_RUN`` — by design, ``/agentic``
+    doesn't execute exploits. Future Tier-1.5 native execution
+    will produce ``EXIT_SIGNAL`` / ``SANITIZER_REPORT`` /
+    ``FLAG_CAPTURED`` witnesses for the same finding; the
+    bytes_hash matches across both, so the witness store
+    dedups the LLM artefact when the executed run lands.
+  * ``outcome_detail`` carries the compile verdict + intent-match
+    verdict so reporting can filter without re-reading the
+    exploit text.
+
+Adapter lives in ``packages/llm_analysis/`` rather than
+``core/witness/`` so the dependency arrow points the right way
+(packages depend on core, not vice versa).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from core.hash import sha256_file
+from core.witness import Witness, WitnessOutcome, WitnessSource
+from core.witness.types import compute_bytes_hash
+
+
+def witness_from_exploit(
+    exploit_code: str,
+    finding_id: str,
+    cwe_id: Optional[str] = None,
+    rule_id: Optional[str] = None,
+    file_path: Optional[str] = None,
+    compiled: Optional[bool] = None,
+    compile_error_count: int = 0,
+    intent_verdict: Optional[str] = None,
+    intent_confidence: Optional[float] = None,
+    target_source_path: Optional[Path] = None,
+    target_binary_path: Optional[Path] = None,
+    produced_by: str = "agentic",
+) -> tuple[Witness, bytes]:
+    """Wrap an LLM-emitted exploit as a ``Witness`` + the raw bytes.
+
+    Returns ``(witness, bytes_)``. Callers typically pass both
+    straight to ``WitnessStore.put(witness, bytes_)``.
+
+    ``exploit_code`` is UTF-8 encoded once with ``errors="replace"``
+    so unpaired surrogates from a poorly-decoded LLM response don't
+    raise ``UnicodeEncodeError`` — the replacement byte sequence is
+    what gets hashed and stored. The replacement is conservative
+    (U+FFFD per invalid codepoint) so semantically-meaningful
+    exploit text survives intact; only the genuinely-broken bytes
+    are normalised. The resulting bytes are the canonical witness.
+
+    ``compiled`` carries the verify verdict; ``None`` is the right
+    encoding for "verification not attempted" (e.g.
+    ``--no-verify-exploits``).
+
+    ``intent_verdict`` is one of ``"matches"``/``"off_target"``/
+    ``"uncertain"`` (the strings, not the enum — keeping the
+    witness store free of llm_analysis-specific imports). ``None``
+    means the judge wasn't run.
+
+    ``target_source_path`` is optional; when provided and the file
+    exists, it's hashed and stored so a later run can verify it's
+    still the same source before claiming the witness holds.
+
+    ``target_binary_path`` is the analogous slot for binaries — used
+    when the LLM-emitted exploit was synthesised against a built
+    target (e.g. crash-agent's path from a fuzz crash). The
+    ``/agentic`` path normally has source only, no binary.
+    """
+    data = exploit_code.encode("utf-8", errors="replace")
+    bytes_hash = compute_bytes_hash(data)
+
+    outcome_detail: dict = {"finding_id": finding_id}
+    if cwe_id:
+        outcome_detail["cwe_id"] = cwe_id
+    if rule_id:
+        outcome_detail["rule_id"] = rule_id
+    if file_path:
+        outcome_detail["file_path"] = file_path
+    if compiled is not None:
+        outcome_detail["compiled"] = compiled
+    if compile_error_count:
+        outcome_detail["compile_error_count"] = compile_error_count
+    if intent_verdict is not None:
+        outcome_detail["intent_verdict"] = intent_verdict
+    if intent_confidence is not None:
+        outcome_detail["intent_confidence"] = intent_confidence
+
+    target_source_hash: Optional[str] = None
+    if target_source_path is not None and target_source_path.is_file():
+        target_source_hash = sha256_file(target_source_path)
+
+    target_binary_hash: Optional[str] = None
+    if target_binary_path is not None and target_binary_path.is_file():
+        target_binary_hash = sha256_file(target_binary_path)
+
+    witness = Witness(
+        bytes_hash=bytes_hash,
+        bytes_len=len(data),
+        source=WitnessSource.LLM_EMIT_RUN,
+        observed_outcome=WitnessOutcome.NOT_RUN,
+        outcome_detail=outcome_detail,
+        target_binary_hash=target_binary_hash,
+        target_source_hash=target_source_hash,
+        produced_by=produced_by,
+    )
+    return witness, data

--- a/raptor_fuzzing.py
+++ b/raptor_fuzzing.py
@@ -110,6 +110,16 @@ Examples:
              "intent_match stays unset on each crash context "
              "(None — judge not invoked).",
     )
+    ap.add_argument(
+        "--no-record-witnesses",
+        action="store_true",
+        help="Skip recording LLM-emitted exploits as canonical "
+             "Witnesses under <out>/analysis/witnesses/ (default "
+             "on). The fuzz crashes themselves are recorded as "
+             "Witnesses regardless under <out>/witnesses/ — this "
+             "flag only affects the secondary LLM-exploit "
+             "Witnesses produced by ``CrashAnalysisAgent``.",
+    )
 
     from core.sandbox import add_cli_args, apply_cli_args
     add_cli_args(ap)
@@ -454,6 +464,7 @@ Examples:
             out_dir=out_dir / "analysis",
             verify_exploits=not args.no_verify_exploits,
             judge_intent=not args.no_judge_intent,
+            record_witnesses=not args.no_record_witnesses,
         )
 
         # Initialize multi-turn analyser if autonomous mode


### PR DESCRIPTION
Wires the first non-fuzz consumer into the Witness substrate (merged in PR #579 + #580). Each successful exploit synthesis from AutonomousSecurityAgentV2 (/agentic) and CrashAnalysisAgent (fuzzing crash → LLM exploit) now records a Witness with source=LLM_EMIT_RUN, outcome=NOT_RUN under the run's out/.../witnesses/ store, alongside any fuzz-derived witnesses.

Both agents lazy-open the WitnessStore on first successful generation (prep-only runs never touch the filesystem); failures (store I/O, adapter exceptions, non-UTF-8 exploit text) log+ continue so the exploit artefact on disk remains the primary record. UTF-8 encode uses errors="replace" so an LLM emission with unpaired surrogates still produces a valid Witness rather than silently losing it through the wrapper's exception handler.

Default-on; --no-record-witnesses opts out (CLI + constructor).

New adapter packages/llm_analysis/witness_adapter.py mirrors packages/fuzzing/witness_adapter.py — same packages → core dependency-arrow rule. Single function witness_from_exploit threads vuln/crash-context fields into outcome_detail.

Tests (41 new) cover adapter contract, /agentic + crash-agent wiring, lazy store open, dedup-by-hash, empty / 1MB / Unicode / unpaired-surrogate edge cases, store I/O + adapter failure tolerance, intent_match shape tolerance (matching the #581 follow-up lesson).