### PR TITLE
feat(core/function_taxonomy): source-side frozensets + fingerprint schema fix

### DIFF
--- a/core/binary/fingerprint.py
+++ b/core/binary/fingerprint.py
@@ -49,10 +49,13 @@ from core.function_taxonomy import (
     EXEC_FUNCS,
     FORMAT_STRING_FUNCS,
     INTEGER_PARSE_FUNCS,
+    IPC_FUNCS,
     MEMORY_COPY_FUNCS,
     NETWORK_INGEST_FUNCS,
     PARSER_FUNCS,
+    PROCESS_BOUNDARY_FUNCS,
     SCAN_FAMILY_FUNCS,
+    STREAM_INPUT_FUNCS,
     STRING_OVERFLOW_FUNCS,
     TOCTOU_FUNCS,
 )
@@ -63,7 +66,12 @@ logger = logging.getLogger(__name__)
 # Schema version. Bump when changing the meaning of any
 # fingerprint field. Consumers check this on read and refuse to
 # diff across versions (better to recompute than mis-attribute).
-FINGERPRINT_SCHEMA_VERSION = 1
+#
+# v2: added stream_input / process_boundary / ipc buckets. A binary
+# fingerprinted under v1 may legitimately have these capabilities
+# but they were not surfaced — re-fingerprint rather than diff across
+# the bump.
+FINGERPRINT_SCHEMA_VERSION = 2
 
 
 # Per-bucket capability classification. Single source of truth —
@@ -81,6 +89,9 @@ BUCKETS: Tuple[Tuple[str, FrozenSet[str]], ...] = (
     ("parser", PARSER_FUNCS),
     ("integer_parse", INTEGER_PARSE_FUNCS),
     ("toctou", TOCTOU_FUNCS),
+    ("stream_input", STREAM_INPUT_FUNCS),
+    ("process_boundary", PROCESS_BOUNDARY_FUNCS),
+    ("ipc", IPC_FUNCS),
 )
 
 # Buckets that warrant high-severity treatment when they appear

--- a/core/binary/fingerprint_store.py
+++ b/core/binary/fingerprint_store.py
@@ -57,7 +57,10 @@ import tempfile
 from pathlib import Path
 from typing import Iterator, Optional, Tuple
 
-from core.binary.fingerprint import CapabilityFingerprint
+from core.binary.fingerprint import (
+    FINGERPRINT_SCHEMA_VERSION,
+    CapabilityFingerprint,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -174,6 +177,21 @@ def load_fingerprint(
     fp_dict = payload.get("fingerprint")
     if not isinstance(fp_dict, dict):
         return None
+    # Embedded fingerprint shape is versioned separately from the
+    # store wrapper. Bucket-shape evolution (e.g. adding new BUCKETS
+    # in fingerprint.py) bumps FINGERPRINT_SCHEMA_VERSION; a stale
+    # baseline at the old shape would otherwise produce false-positive
+    # drift for every binary whose imports newly populate the new
+    # buckets. Treat shape mismatch as "no baseline" — operator
+    # re-fingerprints on next run.
+    fp_version = fp_dict.get("schema_version")
+    if fp_version != FINGERPRINT_SCHEMA_VERSION:
+        logger.debug(
+            "core.binary.fingerprint_store: fingerprint shape version "
+            "%s != %s for %s; treating as no baseline",
+            fp_version, FINGERPRINT_SCHEMA_VERSION, file_path,
+        )
+        return None
     try:
         return CapabilityFingerprint.from_dict(fp_dict)
     except (KeyError, TypeError, ValueError) as e:
@@ -215,6 +233,10 @@ def iter_refs(
         ref = payload.get("ref")
         fp_dict = payload.get("fingerprint")
         if not isinstance(ref, str) or not isinstance(fp_dict, dict):
+            continue
+        # See load_fingerprint() for why embedded shape version is
+        # checked separately from the wrapper.
+        if fp_dict.get("schema_version") != FINGERPRINT_SCHEMA_VERSION:
             continue
         try:
             fp = CapabilityFingerprint.from_dict(fp_dict)

--- a/core/binary/tests/test_fingerprint.py
+++ b/core/binary/tests/test_fingerprint.py
@@ -69,6 +69,45 @@ class TestBucketImports:
     def test_empty_input_empty_output(self):
         assert bucket_imports(set()) == {}
 
+    def test_stream_input_classified(self):
+        out = bucket_imports({"fgets", "getline", "fread"})
+        assert "stream_input" in out
+        # fread is ubiquitous — excluded from the source taxonomy
+        assert out["stream_input"] == {"fgets", "getline"}
+
+    def test_process_boundary_classified(self):
+        """Only `getenv` is the attacker-controlled source; markers
+        (secure_getenv, getauxval) are NOT in the bucket — they
+        live in PROCESS_BOUNDARY_MARKERS and would need a separate
+        bucket if we ever surface them."""
+        out = bucket_imports(
+            {"getenv", "secure_getenv", "getauxval", "malloc"},
+        )
+        assert "process_boundary" in out
+        assert out["process_boundary"] == {"getenv"}
+
+    def test_ipc_classified(self):
+        """shmat triggers; shm_open and pipe deliberately don't
+        (open-not-read / setup primitive)."""
+        out = bucket_imports(
+            {"shmat", "msgrcv", "shm_open", "pipe", "mmap"},
+        )
+        assert "ipc" in out
+        assert out["ipc"] == {"shmat", "msgrcv"}
+
+    def test_kernel_userspace_not_a_user_binary_bucket(self):
+        """KERNEL_USERSPACE_FUNCS is deliberately NOT in BUCKETS —
+        kernel-side symbols don't appear in user-space binary
+        imports, so including them would add a permanently-empty
+        bucket."""
+        out = bucket_imports(
+            {"copy_from_user", "memdup_user", "get_user"},
+        )
+        assert "kernel_userspace" not in out
+        # The whole input maps to zero buckets — kernel symbols in
+        # a user-space binary are typically just unresolved relocs.
+        assert out == {}
+
 
 class TestBucketTaxonomy:
     """The BUCKETS table is shared between fingerprint + SCA bump
@@ -81,6 +120,7 @@ class TestBucketTaxonomy:
             "exec", "network", "string_overflow", "scan",
             "memory_copy", "format_string", "alloc", "parser",
             "integer_parse", "toctou",
+            "stream_input", "process_boundary", "ipc",
         ]
 
     def test_high_severity_buckets_subset_of_buckets(self):
@@ -405,6 +445,114 @@ class TestCapabilityFingerprint:
         assert "exec" in out
         # ASCII matches captured; non-ASCII ignored
         assert out["exec"] == {"execve", "popen"}
+
+
+# ---------------------------------------------------------------------------
+# Source-side bucket E2E — compiles a small C program with the exact
+# imports we want to surface, then asserts the fingerprint primitive
+# walks all the way through (ELF parse → bucket classification → JSON
+# shape) and produces the right bucket contents. Catches regressions
+# in BUCKETS ordering, taxonomy exclusions, ELF parser drift, and the
+# schema-version constant in one go.
+# ---------------------------------------------------------------------------
+
+
+_SOURCE_SIDE_E2E_SRC = r"""
+/* Exercises every source-side bucket (issue #583). Functions are
+ * intentionally called so the linker emits them in the dynamic
+ * symbol table; the bodies don't have to be sensible. */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/uio.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+#include <sys/msg.h>
+
+int main(int argc, char **argv) {
+    char buf[64];
+    fgets(buf, sizeof(buf), stdin);                 /* stream_input */
+    char *line = NULL; size_t cap = 0;
+    getline(&line, &cap, stdin);                    /* stream_input */
+    struct iovec iov = {buf, sizeof(buf)};
+    readv(0, &iov, 1);                              /* stream_input */
+    const char *home = getenv("HOME");              /* process_boundary */
+    int shmid = shmget(IPC_PRIVATE, 4096, 0666);    /* ipc */
+    void *seg = shmat(shmid, NULL, 0);              /* ipc */
+    struct { long mtype; char mtext[8]; } mbuf;
+    msgrcv(0, &mbuf, sizeof(mbuf.mtext), 1, 0);     /* ipc */
+    if (argc > 1) system(argv[1]);                  /* exec (baseline) */
+    return (int)(size_t)(home != NULL) + (seg != (void*)-1);
+}
+"""
+
+
+class TestSourceSideBucketsE2E:
+    """End-to-end: compile a real ELF that imports every source-side
+    function, fingerprint it via the tier-0 ELF parser (no radare2
+    dependency), assert the three source-side buckets surface with
+    the expected contents."""
+
+    @pytest.fixture(autouse=True)
+    def _gate(self):
+        import shutil
+        if shutil.which("gcc") is None:
+            pytest.skip("gcc not on PATH — needed to build E2E target")
+
+    def test_fingerprint_surfaces_source_side_buckets(self, tmp_path):
+        import subprocess
+        src = tmp_path / "src.c"
+        binary = tmp_path / "source_side_e2e_bin"
+        src.write_text(_SOURCE_SIDE_E2E_SRC)
+        result = subprocess.run(
+            ["gcc", "-O0", str(src), "-o", str(binary)],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode != 0:
+            pytest.skip(
+                f"gcc build failed (likely missing libc headers in CI):\n"
+                f"{result.stderr}",
+            )
+
+        fp = capability_fingerprint(binary)
+        assert fp is not None, (
+            "fingerprint primitive returned None on a freshly-built "
+            "ELF binary — tier-0 ELF parser regression"
+        )
+        assert fp.schema_version == FINGERPRINT_SCHEMA_VERSION
+        assert fp.binary_format == "elf"
+        assert fp.bits == 64
+
+        buckets = {k: set(v) for k, v in fp.capability_buckets.items()}
+
+        # Each source-side bucket must surface its contributors.
+        # Subset assertion rather than equality so a future taxonomy
+        # expansion (e.g. fgetws added to STREAM_INPUT_FUNCS) doesn't
+        # break the test as long as our intentionally-imported
+        # functions still land in their bucket.
+        assert "stream_input" in buckets, (
+            f"stream_input bucket missing from {buckets.keys()}"
+        )
+        assert {"fgets", "getline", "readv"} <= buckets["stream_input"]
+
+        assert "process_boundary" in buckets, (
+            "process_boundary bucket missing"
+        )
+        assert buckets["process_boundary"] == {"getenv"}, (
+            "process_boundary expected only {'getenv'} — markers "
+            "must NOT contaminate this bucket"
+        )
+
+        assert "ipc" in buckets, "ipc bucket missing"
+        assert {"shmat", "shmget", "msgrcv"} <= buckets["ipc"]
+
+        # Baseline: pre-existing exec bucket still works
+        assert "exec" in buckets
+        assert "system" in buckets["exec"]
+
+        # Negative: kernel_userspace is intentionally NOT a bucket
+        assert "kernel_userspace" not in buckets
 
 
 # ---------------------------------------------------------------------------

--- a/core/binary/tests/test_fingerprint_store.py
+++ b/core/binary/tests/test_fingerprint_store.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import json
 
-from core.binary.fingerprint import CapabilityFingerprint
+from core.binary.fingerprint import (
+    FINGERPRINT_SCHEMA_VERSION,
+    CapabilityFingerprint,
+)
 from core.binary.fingerprint_store import (
     STORE_SCHEMA_VERSION,
     delete_fingerprint,
@@ -22,7 +25,7 @@ from core.binary.fingerprint_store import (
 def _fp(*, sha="abc", arch="x86", bits=64,
         buckets=None) -> CapabilityFingerprint:
     return CapabilityFingerprint(
-        schema_version=1,
+        schema_version=FINGERPRINT_SCHEMA_VERSION,
         binary_path="/test",
         binary_sha256=sha, arch=arch, bits=bits,
         binary_format="elf",
@@ -165,6 +168,52 @@ class TestSchemaVersioning:
         with open(file_path, "w") as f:
             json.dump(data, f)
         assert load_fingerprint(tmp_path, "ref") is None
+
+    def test_mismatched_fingerprint_shape_load_returns_none(
+            self, tmp_path):
+        """Wrapper version OK, embedded fingerprint shape stale —
+        treat as no baseline. Regression for the silent-false-
+        positive-drift bug: a stored fingerprint with an old
+        FINGERPRINT_SCHEMA_VERSION must not be diffed against a
+        fresh one with a newer shape (new buckets would all show
+        as drift)."""
+        save_fingerprint(tmp_path, "ref", _fp())
+        file_path = next(tmp_path.glob("*.json"))
+        with open(file_path) as f:
+            data = json.load(f)
+        # Wrapper stays current; tamper only with embedded shape.
+        data["fingerprint"]["schema_version"] = \
+            FINGERPRINT_SCHEMA_VERSION - 1
+        with open(file_path, "w") as f:
+            json.dump(data, f)
+        assert load_fingerprint(tmp_path, "ref") is None
+
+    def test_iter_refs_skips_mismatched_fingerprint_shape(
+            self, tmp_path):
+        """Same regression as above, applied to iter_refs() —
+        stale-shape entries must be skipped by the enumeration
+        path too (drift detectors that scan the whole store
+        depend on this)."""
+        save_fingerprint(tmp_path, "good", _fp(sha="A"))
+        # Write a stale-shape entry directly (correct wrapper,
+        # stale embedded schema_version).
+        (tmp_path / "deadbeef.json").write_text(json.dumps({
+            "schema_version": STORE_SCHEMA_VERSION,
+            "ref": "stale-shape",
+            "fingerprint": {
+                "schema_version": FINGERPRINT_SCHEMA_VERSION - 1,
+                "binary_path": "/test",
+                "binary_sha256": "B",
+                "arch": "x86",
+                "bits": 64,
+                "binary_format": "elf",
+                "capability_buckets": {},
+            },
+        }))
+        refs = dict(iter_refs(tmp_path))
+        assert "good" in refs
+        assert "stale-shape" not in refs
+        assert len(refs) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/core/function_taxonomy/__init__.py
+++ b/core/function_taxonomy/__init__.py
@@ -170,6 +170,99 @@ NETWORK_INGEST_FUNCS: FrozenSet[str] = frozenset({
 })
 
 
+# === Stream / file input (non-ubiquitous variants) ===
+# Buffered line/delimiter input + non-trivial fd-level reads. The
+# ubiquitous variants (read, fread, fopen) are excluded per the
+# module-wide policy — they're in every binary so their import is
+# zero fuzz-priority signal. The variants kept here are deliberate
+# choices: someone using getline/getdelim is doing structured parsing,
+# someone using pread/readv is doing positional or scatter-gather I/O,
+# someone using fgets is reading bounded lines (common in CLI parsers
+# and network protocol handlers). gets() lives in STRING_OVERFLOW_FUNCS
+# (banned API) and is therefore excluded here to keep categories
+# disjoint.
+STREAM_INPUT_FUNCS: FrozenSet[str] = frozenset({
+    "fgets", "fgetws",
+    "getline", "getdelim",
+    "pread", "preadv", "readv",
+})
+
+
+# === Process boundary inputs (env) ===
+# argv / envp are MAIN parameters, not function calls — they appear
+# in source code but not in import tables, so they're outside this
+# module's grain (function-name catalog). The function-call shaped
+# attacker-controlled equivalent is plain getenv. secure_getenv and
+# getauxval are NOT here — they're context markers, not sources
+# (see PROCESS_BOUNDARY_MARKERS below).
+PROCESS_BOUNDARY_FUNCS: FrozenSet[str] = frozenset({
+    "getenv",
+})
+
+
+# === IPC primitives where less-privileged peers can write ===
+# Shared memory + message queues. Deliberately excluded:
+#   * mmap — most usage is file-backed read-only, not attacker-
+#     controlled shared memory, and you cannot distinguish from the
+#     call site alone (CVE-shape-determines-category policy).
+#   * shm_open — returns an fd; the actual attacker-data read goes
+#     through mmap (excluded above) or read (ubiquitous), so flagging
+#     shm_open alone yields a category with no live read primitive.
+#   * pipe / mkfifo — setup primitives, not read primitives. The
+#     actual attacker-data read happens via read() on the resulting
+#     fd (ubiquitous).
+IPC_FUNCS: FrozenSet[str] = frozenset({
+    "shmat", "shmget",
+    "mq_receive", "mq_timedreceive",
+    "msgrcv",
+})
+
+
+# === Kernel / userspace boundary (kernel-side only) ===
+# Functions called by KERNEL CODE (drivers, syscalls, kernel modules)
+# to read attacker-controlled data from less-privileged userspace.
+# These do NOT appear in user-space binary import tables, so the
+# binary-fingerprint and fuzz-priority consumers ignore them; the
+# value is for source-code analysis of kernel modules and driver
+# audits where userspace pointers are the canonical L1 source. The
+# `_*` / `__` prefixes are kept because Linux kernel symbol naming
+# uses them at the call site (no need for fortified() expansion).
+#
+# Covers three sub-families:
+#   1. Bare-copy primitives (copy_from_user, get_user, raw / inatomic)
+#   2. Allocator wrappers that copy in one call (memdup_user et al.)
+#   3. iovec / pages interfaces for scatter-gather + DMA paths
+KERNEL_USERSPACE_FUNCS: FrozenSet[str] = frozenset({
+    # Bare copies
+    "copy_from_user", "_copy_from_user",
+    "raw_copy_from_user", "__copy_from_user_inatomic",
+    "get_user", "__get_user",
+    "strncpy_from_user", "strnlen_user",
+    # Allocator wrappers (alloc + copy_from_user in one call)
+    "memdup_user", "memdup_user_nul",
+    "vmemdup_user",
+    "strndup_user",
+    # iovec / pages — scatter-gather, DMA-adjacent
+    "import_iovec", "import_single_range",
+    "_copy_from_iter", "copy_from_iter_full",
+    "get_user_pages", "get_user_pages_fast",
+})
+
+
+# === Process boundary markers (suid-context signal) ===
+# NOT a source set — separate to avoid contaminating consumers that
+# expect "attacker-controlled input lands here". These are *signals*
+# that the author was aware of suid safety (or that suid context
+# matters). Their *return values* are either NULL (secure_getenv in
+# suid) or kernel-supplied (getauxval). A static analyser uses these
+# to weight the suspicion of co-located plain getenv calls, not as
+# direct taint sources.
+PROCESS_BOUNDARY_MARKERS: FrozenSet[str] = frozenset({
+    "secure_getenv",
+    "getauxval",
+})
+
+
 # === High-CVE-density parser entry points ===
 # The biggest single signal source for fuzz prioritisation. A binary
 # that imports any of these is processing structured external input
@@ -329,6 +422,11 @@ __all__ = [
     "EXEC_FUNCS",
     "ALLOC_FUNCS",
     "NETWORK_INGEST_FUNCS",
+    "STREAM_INPUT_FUNCS",
+    "PROCESS_BOUNDARY_FUNCS",
+    "PROCESS_BOUNDARY_MARKERS",
+    "IPC_FUNCS",
+    "KERNEL_USERSPACE_FUNCS",
     "PARSER_FUNCS",
     "INTEGER_PARSE_FUNCS",
     "TOCTOU_FUNCS",

--- a/core/function_taxonomy/tests/test_function_taxonomy.py
+++ b/core/function_taxonomy/tests/test_function_taxonomy.py
@@ -17,11 +17,16 @@ from core.function_taxonomy import (
     EXEC_FUNCS,
     FORMAT_STRING_FUNCS,
     INTEGER_PARSE_FUNCS,
+    IPC_FUNCS,
+    KERNEL_USERSPACE_FUNCS,
     MACOS_DANGEROUS_SUBSTRINGS,
     MEMORY_COPY_FUNCS,
     NETWORK_INGEST_FUNCS,
     PARSER_FUNCS,
+    PROCESS_BOUNDARY_FUNCS,
+    PROCESS_BOUNDARY_MARKERS,
     SCAN_FAMILY_FUNCS,
+    STREAM_INPUT_FUNCS,
     STRING_OVERFLOW_FUNCS,
     TOCTOU_FUNCS,
     fortified,
@@ -33,6 +38,8 @@ ALL_DANGEROUS_CATEGORIES = [
     FORMAT_STRING_FUNCS, EXEC_FUNCS, ALLOC_FUNCS,
     NETWORK_INGEST_FUNCS, PARSER_FUNCS, INTEGER_PARSE_FUNCS,
     TOCTOU_FUNCS,
+    STREAM_INPUT_FUNCS, PROCESS_BOUNDARY_FUNCS, IPC_FUNCS,
+    KERNEL_USERSPACE_FUNCS,
 ]
 
 
@@ -143,6 +150,160 @@ class TestKeyParsersPresent(unittest.TestCase):
         self.assertIn("Py_CompileString", PARSER_FUNCS)
 
 
+# === Source-side categories (data-flow classification) ===
+
+class TestStreamInputFuncs(unittest.TestCase):
+    """STREAM_INPUT_FUNCS = bounded line / delimiter / fd-level
+    input that isn't ubiquitous. fgets/getline are the signature
+    parse-attacker-line patterns; pread/readv signal positional or
+    scatter-gather I/O."""
+
+    def test_fgets_and_getline_present(self):
+        self.assertIn("fgets", STREAM_INPUT_FUNCS)
+        self.assertIn("getline", STREAM_INPUT_FUNCS)
+        self.assertIn("getdelim", STREAM_INPUT_FUNCS)
+
+    def test_pread_readv_present(self):
+        self.assertIn("pread", STREAM_INPUT_FUNCS)
+        self.assertIn("readv", STREAM_INPUT_FUNCS)
+
+    def test_ubiquitous_read_fread_excluded(self):
+        """read/fread are ubiquitous per module policy — must not
+        be in STREAM_INPUT_FUNCS (their presence carries zero
+        fuzz-priority signal). Consumers that want them add them
+        explicitly (see exploit_feasibility.constants.INPUT_FUNCTIONS)."""
+        self.assertNotIn("read", STREAM_INPUT_FUNCS)
+        self.assertNotIn("fread", STREAM_INPUT_FUNCS)
+
+    def test_gets_not_duplicated_here(self):
+        """gets() is banned by C11 Annex K and lives in
+        STRING_OVERFLOW_FUNCS — must not be duplicated here."""
+        self.assertNotIn("gets", STREAM_INPUT_FUNCS)
+        self.assertIn("gets", STRING_OVERFLOW_FUNCS)
+
+
+class TestProcessBoundaryFuncs(unittest.TestCase):
+    """PROCESS_BOUNDARY_FUNCS = direct attacker-controlled env
+    sources. Currently only `getenv`. argv/envp are main()
+    parameters, not function calls, so out of scope (this module
+    is a function-name catalog). secure_getenv and getauxval are
+    NOT here — they're markers (see PROCESS_BOUNDARY_MARKERS)."""
+
+    def test_getenv_present(self):
+        self.assertIn("getenv", PROCESS_BOUNDARY_FUNCS)
+
+    def test_markers_not_in_funcs(self):
+        """secure_getenv returns NULL in suid context (sanitiser,
+        not source); getauxval is kernel-supplied. Both live in
+        PROCESS_BOUNDARY_MARKERS and must NOT contaminate the
+        attacker-source set that downstream consumers treat as
+        taint origins."""
+        self.assertNotIn("secure_getenv", PROCESS_BOUNDARY_FUNCS)
+        self.assertNotIn("getauxval", PROCESS_BOUNDARY_FUNCS)
+
+    def test_setenv_excluded(self):
+        """setenv/putenv are sinks (writing env), not sources of
+        attacker-controlled data."""
+        self.assertNotIn("setenv", PROCESS_BOUNDARY_FUNCS)
+        self.assertNotIn("putenv", PROCESS_BOUNDARY_FUNCS)
+
+
+class TestProcessBoundaryMarkers(unittest.TestCase):
+    """PROCESS_BOUNDARY_MARKERS = suid-context signal functions.
+    Separate from PROCESS_BOUNDARY_FUNCS because their returns are
+    NOT attacker-controlled (NULL in suid, or kernel-supplied),
+    so they're not taint sources. Their presence at a call site
+    weights the suspicion of co-located plain getenv calls."""
+
+    def test_secure_getenv_present(self):
+        self.assertIn("secure_getenv", PROCESS_BOUNDARY_MARKERS)
+
+    def test_getauxval_present(self):
+        self.assertIn("getauxval", PROCESS_BOUNDARY_MARKERS)
+
+
+class TestIpcFuncs(unittest.TestCase):
+    """IPC_FUNCS = inter-process communication source primitives.
+    Several explicit exclusions per the CVE-shape policy — see
+    docstring on the set."""
+
+    def test_sysv_shm_present(self):
+        self.assertIn("shmat", IPC_FUNCS)
+        self.assertIn("shmget", IPC_FUNCS)
+
+    def test_message_queues_present(self):
+        self.assertIn("mq_receive", IPC_FUNCS)
+        self.assertIn("msgrcv", IPC_FUNCS)
+
+    def test_mmap_excluded(self):
+        """mmap usage is dominantly file-backed read-only; the
+        attacker-controlled MAP_SHARED case is not distinguishable
+        from the call site, so the category excludes it per the
+        CVE-shape policy."""
+        self.assertNotIn("mmap", IPC_FUNCS)
+
+    def test_shm_open_excluded(self):
+        """shm_open returns an fd; the actual read goes through
+        mmap (excluded above) or read (ubiquitous). Flagging
+        shm_open alone gives a category with no live read
+        primitive — drop per the CVE-shape policy."""
+        self.assertNotIn("shm_open", IPC_FUNCS)
+
+    def test_pipe_excluded(self):
+        """pipe/mkfifo are setup primitives — the actual attacker
+        data read happens via read() on the resulting fd (which
+        is ubiquitous and excluded everywhere)."""
+        self.assertNotIn("pipe", IPC_FUNCS)
+        self.assertNotIn("mkfifo", IPC_FUNCS)
+
+
+class TestKernelUserspaceFuncs(unittest.TestCase):
+    """KERNEL_USERSPACE_FUNCS = kernel-side functions reading
+    userspace data. These do not appear in user-space binary
+    import tables — value is for source-code analysis of kernel
+    modules / drivers where userspace pointers are the canonical
+    L1 source. Covers bare copies, allocator wrappers, and
+    iovec/pages interfaces."""
+
+    def test_bare_copy_primitives_present(self):
+        self.assertIn("copy_from_user", KERNEL_USERSPACE_FUNCS)
+        self.assertIn("_copy_from_user", KERNEL_USERSPACE_FUNCS)
+        self.assertIn("raw_copy_from_user", KERNEL_USERSPACE_FUNCS)
+        self.assertIn("__copy_from_user_inatomic",
+                      KERNEL_USERSPACE_FUNCS)
+
+    def test_get_user_present(self):
+        self.assertIn("get_user", KERNEL_USERSPACE_FUNCS)
+        self.assertIn("__get_user", KERNEL_USERSPACE_FUNCS)
+
+    def test_string_variants_present(self):
+        self.assertIn("strncpy_from_user", KERNEL_USERSPACE_FUNCS)
+        self.assertIn("strnlen_user", KERNEL_USERSPACE_FUNCS)
+        self.assertIn("strndup_user", KERNEL_USERSPACE_FUNCS)
+
+    def test_allocator_wrappers_present(self):
+        """memdup_user-family is more common at call sites in
+        modern kernel code than bare copy_from_user."""
+        self.assertIn("memdup_user", KERNEL_USERSPACE_FUNCS)
+        self.assertIn("memdup_user_nul", KERNEL_USERSPACE_FUNCS)
+        self.assertIn("vmemdup_user", KERNEL_USERSPACE_FUNCS)
+
+    def test_iovec_pages_interfaces_present(self):
+        """iovec + get_user_pages cover scatter-gather + DMA paths."""
+        self.assertIn("import_iovec", KERNEL_USERSPACE_FUNCS)
+        self.assertIn("import_single_range", KERNEL_USERSPACE_FUNCS)
+        self.assertIn("_copy_from_iter", KERNEL_USERSPACE_FUNCS)
+        self.assertIn("copy_from_iter_full", KERNEL_USERSPACE_FUNCS)
+        self.assertIn("get_user_pages", KERNEL_USERSPACE_FUNCS)
+        self.assertIn("get_user_pages_fast", KERNEL_USERSPACE_FUNCS)
+
+    def test_copy_to_user_excluded(self):
+        """copy_to_user is a sink (kernel writes to user), not a
+        source — must not be in this set."""
+        self.assertNotIn("copy_to_user", KERNEL_USERSPACE_FUNCS)
+        self.assertNotIn("put_user", KERNEL_USERSPACE_FUNCS)
+
+
 # === Cross-category invariants ===
 
 class TestCrossCategory(unittest.TestCase):
@@ -249,6 +410,34 @@ class TestSizeBounds(unittest.TestCase):
 
     def test_macos_substrings_nontrivial(self):
         self.assertGreater(len(MACOS_DANGEROUS_SUBSTRINGS), 10)
+
+    def test_stream_input_size_reasonable(self):
+        n = len(STREAM_INPUT_FUNCS)
+        self.assertGreater(n, 4, f"only {n} entries — pruned too far?")
+        self.assertLess(n, 20, f"{n} entries — likely bloat")
+
+    def test_process_boundary_size_reasonable(self):
+        n = len(PROCESS_BOUNDARY_FUNCS)
+        self.assertGreaterEqual(n, 1,
+                                f"only {n} entries — pruned too far?")
+        self.assertLess(n, 10, f"{n} entries — likely bloat")
+
+    def test_process_boundary_markers_size_reasonable(self):
+        n = len(PROCESS_BOUNDARY_MARKERS)
+        self.assertGreaterEqual(n, 1)
+        self.assertLess(n, 10)
+
+    def test_ipc_size_reasonable(self):
+        n = len(IPC_FUNCS)
+        self.assertGreater(n, 2, f"only {n} entries — pruned too far?")
+        self.assertLess(n, 15, f"{n} entries — likely bloat")
+
+    def test_kernel_userspace_size_reasonable(self):
+        """Linux kernel uaccess + memdup_user + iovec/pages
+        interfaces — meaningful range is 10-40."""
+        n = len(KERNEL_USERSPACE_FUNCS)
+        self.assertGreater(n, 10, f"only {n} entries — pruned too far?")
+        self.assertLess(n, 40, f"{n} entries — likely bloat")
 
 
 if __name__ == "__main__":

--- a/packages/binary_analysis/radare2_understand.py
+++ b/packages/binary_analysis/radare2_understand.py
@@ -55,11 +55,13 @@ from core.function_taxonomy import (
     EXEC_FUNCS as _T_EXEC,
     FORMAT_STRING_FUNCS as _T_FMT,
     INTEGER_PARSE_FUNCS as _T_INT_PARSE,
+    IPC_FUNCS as _T_IPC,
     MACOS_DANGEROUS_SUBSTRINGS as _DANGEROUS_MACOS_SUBSTRINGS,
     MEMORY_COPY_FUNCS as _T_MEMCPY,
     NETWORK_INGEST_FUNCS as _T_NET,
     PARSER_FUNCS as _T_PARSER,
     SCAN_FAMILY_FUNCS as _T_SCAN,
+    STREAM_INPUT_FUNCS as _T_STREAM,
     STRING_OVERFLOW_FUNCS as _T_STROVF,
     TOCTOU_FUNCS as _T_TOCTOU,
 )
@@ -70,9 +72,20 @@ from core.function_taxonomy import (
 # "interesting sink" means for THIS consumer (fuzz prioritisation).
 # Other consumers (e.g. exploit_feasibility) compose different
 # subsets for different purposes.
+#
+# Deliberately omitted:
+#   * KERNEL_USERSPACE_FUNCS — kernel-side symbols don't appear in
+#     user-space binary import tables, so including them would add
+#     catalog without matches.
+#   * PROCESS_BOUNDARY_FUNCS — getenv is imported by ~half of typical
+#     /usr/bin binaries (vs. 3% for recv). Including it would defeat
+#     the ubiquity-exclusion policy that already drops `read` from
+#     NETWORK_INGEST_FUNCS. The bucket survives in fingerprint.BUCKETS
+#     where presence is informational, not prioritisational.
 _DANGEROUS_IMPORTS = frozenset(
     _T_STROVF | _T_SCAN | _T_MEMCPY | _T_FMT | _T_EXEC | _T_ALLOC
     | _T_NET | _T_PARSER | _T_INT_PARSE | _T_TOCTOU
+    | _T_STREAM | _T_IPC
 )
 
 

--- a/packages/exploit_feasibility/constants.py
+++ b/packages/exploit_feasibility/constants.py
@@ -273,6 +273,7 @@ from core.function_taxonomy import (
     MEMORY_COPY_FUNCS as _T_MEMCPY,
     NETWORK_INGEST_FUNCS as _T_NET,
     SCAN_FAMILY_FUNCS as _T_SCAN,
+    STREAM_INPUT_FUNCS as _T_STREAM,
     STRING_OVERFLOW_FUNCS as _T_STROVF,
 )
 
@@ -302,14 +303,22 @@ COMMON_FUNCTIONS = frozenset(
 # Input functions that affect payload constraints (where attacker-
 # controlled data lands in the binary). Includes the taxonomy's
 # string-overflow / scan-family / format-string / memcpy / network
-# entries PLUS the SAFE-input functions that aren't in the dangerous
-# categories but still constrain payload shape (NUL-termination,
-# line-termination, length-limits).
+# / stream-input entries PLUS the ubiquitous input variants that the
+# taxonomy excludes due to zero fuzz-priority signal but which still
+# constrain payload shape here (NUL-termination, line-termination,
+# length-limits).
+#
+# PROCESS_BOUNDARY_FUNCS is DELIBERATELY EXCLUDED — env-var payload
+# constraints (no NUL, no '=' in name, ARG_MAX bound) differ from the
+# network/file constraints this set's downstream payload-shape
+# analysis assumes. If we ever wire env-var-aware exploit analysis,
+# it'll need its own constraint dispatch, not a union with this set.
 INPUT_FUNCTIONS = frozenset(
-    _T_STROVF | _T_SCAN | _T_FMT | _T_MEMCPY | _T_NET | frozenset({
-        # Line-based (newline terminates) — safe but still shapes payload
-        'fgets', 'getline',
-        # Binary-safe (length-limited) — safe but constraint-relevant
+    _T_STROVF | _T_SCAN | _T_FMT | _T_MEMCPY | _T_NET
+    | _T_STREAM | frozenset({
+        # Binary-safe (length-limited) — ubiquitous so excluded from
+        # the taxonomy STREAM_INPUT set, but still constraint-relevant
+        # for payload-shape analysis.
         'read', 'fread',
         # Format output (format string vulns) — common variants the
         # taxonomy excludes from FORMAT_STRING_FUNCS due to ubiquity,


### PR DESCRIPTION
Adds a source-side function catalog (input syscalls / IPC reads / kernel-uaccess primitives) to core/function_taxonomy, symmetric with the existing sink-side one. Surfaces three new fingerprint buckets and fixes a drift-detection bug found during review.

  What's in here
  
  - New frozensets in core/function_taxonomy/__init__.py: STREAM_INPUT_FUNCS, PROCESS_BOUNDARY_FUNCS, IPC_FUNCS, KERNEL_USERSPACE_FUNCS, plus PROCESS_BOUNDARY_MARKERS for suid-context signals that aren't taint sources (secure_getenv, getauxval). Each set respects the existing ubiquity-exclusion + CVE-shape curation policy.
  - Three new fingerprint.BUCKETS (stream_input / process_boundary / ipc). FINGERPRINT_SCHEMA_VERSION 1 → 2.
  - Wired into all three existing consumers. PROCESS_BOUNDARY is deliberately excluded from fuzz-priority and INPUT_FUNCTIONS — getenv is ~47% prevalent in /usr/bin vs ~3% for recv, so including it would defeat
  the same ubiquity policy that already drops read.
  - Drift bug fix: fingerprint_store.load_fingerprint and iter_refs only checked the wrapper version; a stored v1 fingerprint would diff against fresh v2 producing spurious drift on every newly-populated bucket. Both paths now also check the embedded FINGERPRINT_SCHEMA_VERSION.

  Credit
  
  Thanks @dinosn — the function catalog content comes directly from the data-flow-classification.md spec Nicolas Krassas attached to #583. Suggested-by: trailer in the commit.