### PR TITLE
test(semgrep): mark TestIntegration class with @pytest.mark.integration

### DIFF
--- a/packages/semgrep/tests/test_runner.py
+++ b/packages/semgrep/tests/test_runner.py
@@ -322,6 +322,19 @@ class TestConfigToName:
 
 # Integration ------------------------------------------------------------------
 
+# Marked ``integration`` so pytest.ini's default
+# ``-m "not integration and not slow"`` deselects this class in
+# regular suite runs. Reason: the tests call ``run_rule(... "p/python"
+# ...)`` which downloads the ``p/python`` rule pack from semgrep.dev
+# at scan time. Two consequences:
+#   * The default suite shouldn't depend on outbound HTTPS to
+#     semgrep.dev — flaky on sandboxed CI, fails when an unrelated
+#     test in the same process has spun up the egress-proxy with a
+#     narrower allowlist.
+#   * 6-second wall per test (real semgrep invocation) is integration
+#     territory, not unit-test cadence.
+# Opt-in with ``pytest -m integration``.
+@pytest.mark.integration
 @pytest.mark.skipif(not is_available(), reason="semgrep not installed")
 class TestIntegration:
     """Real-semgrep tests. Skipped when binary unavailable."""


### PR DESCRIPTION
The two ``TestIntegration`` tests in ``packages/semgrep/tests/test_runner.py`` call ``run_rule(target, "p/python", ...)`` — a real semgrep invocation that fetches the ``p/python`` rule pack from ``semgrep.dev`` at scan time. Two reasons that's integration-tier, not unit-tier:

  * The default suite shouldn't depend on outbound HTTPS to semgrep.dev. The current invocation succeeds today because main's runner has unrestricted egress; it'd break under any test in the same process that engages the egress-proxy with a narrower allowlist. ``cve_diff`` already takes this posture (``TestOSVLive`` / ``TestNVDLive`` are ``@integration``) — semgrep's class is the outlier.

  * Each test takes ~6 seconds wallclock for a real semgrep invocation. Integration cadence, not unit cadence.

Adding ``@pytest.mark.integration`` makes pytest.ini's default ``-m "not integration and not slow"`` deselect the class in regular suite runs. Opt-in via ``pytest -m integration``.

No production-code change. Class-level marker plus an inline comment documenting the rationale.