### PR TITLE
feat(exploit_validator): optional sanitizer compile flags

### DIFF
--- a/packages/autonomous/exploit_validator.py
+++ b/packages/autonomous/exploit_validator.py
@@ -74,13 +74,25 @@ class ExploitValidator:
             logger.debug("Exploit feasibility analysis not available")
             return True, "Exploit feasibility analysis not available"
 
-    def validate_exploit(self, exploit_code: str, exploit_name: str) -> ValidationResult:
+    def validate_exploit(
+        self, exploit_code: str, exploit_name: str,
+        sanitizers: Optional[List[str]] = None,
+    ) -> ValidationResult:
         """
         Validate an exploit by attempting to compile it.
 
         Args:
             exploit_code: C source code of exploit
             exploit_name: Name for the exploit
+            sanitizers: Optional list of clang/gcc sanitizer names to enable
+                on the compile (``"address"``, ``"undefined"``, ``"memory"``,
+                ``"thread"`` — passed verbatim as ``-fsanitize=<name>``).
+                Default ``None`` preserves the historical compile-verify
+                behaviour (plain gcc, no instrumentation). When set, the
+                produced binary is instrumented and a subsequent run can
+                surface runtime bug evidence (ASAN reports, etc.) — the
+                Witness-capture path consumes these as ``SANITIZER_REPORT``
+                outcomes.
 
         Returns:
             ValidationResult with compilation status
@@ -120,6 +132,37 @@ class ExploitValidator:
                 str(exploit_source),
                 "-w",  # Suppress warnings for now
             ]
+            # Sanitizer flags: validated against an allowlist of names
+            # gcc actually recognises in the ``-fsanitize=`` family.
+            # Unknown names would otherwise produce a confusing
+            # ``gcc: error: unrecognized command-line option`` cascade
+            # — fail clean here instead, with a structured error the
+            # caller can surface. Some pairs (``address`` + ``memory``,
+            # ``address`` + ``thread``) are mutually exclusive in gcc;
+            # we don't enforce that here — let gcc reject and surface
+            # the real error if the caller asks for an invalid combo.
+            if sanitizers:
+                _ALLOWED_SANITIZERS = {
+                    "address", "undefined", "memory", "thread",
+                    "leak", "kernel-address", "hwaddress",
+                }
+                unknown = [s for s in sanitizers if s not in _ALLOWED_SANITIZERS]
+                if unknown:
+                    return ValidationResult(
+                        success=False,
+                        compilation_errors=[
+                            f"unrecognised sanitizer name(s) "
+                            f"{sorted(unknown)}; allowed: "
+                            f"{sorted(_ALLOWED_SANITIZERS)}"
+                        ],
+                        runtime_errors=[],
+                        warnings=[],
+                    )
+                for san in sanitizers:
+                    compile_cmd.append(f"-fsanitize={san}")
+                # ASAN benefits from frame pointers for accurate stack
+                # traces in the report; harmless for the others.
+                compile_cmd.extend(["-fno-omit-frame-pointer", "-g"])
 
             from core.sandbox import run as sandbox_run
             # Both target and output point at work_dir: gcc needs to read

--- a/packages/autonomous/tests/test_exploit_validator_sanitizers.py
+++ b/packages/autonomous/tests/test_exploit_validator_sanitizers.py
@@ -1,0 +1,267 @@
+"""Tests for the ``sanitizers=`` kwarg on ``ExploitValidator.validate_exploit``.
+
+The behaviour pinned:
+
+  * Default (no kwarg): unchanged gcc command (no ``-fsanitize=``).
+  * ``sanitizers=["address"]``: ``-fsanitize=address`` lands in the gcc
+    invocation. Produced binary, when run, fires ASAN on the BOF
+    fixture.
+  * Allowlist rejection: unknown sanitizer name returns a clean
+    structured error rather than a confusing gcc cascade.
+
+Requires gcc + libasan; skipped if either is missing.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# packages/autonomous/tests/test_exploit_validator_sanitizers.py
+#   parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from packages.autonomous.exploit_validator import (  # noqa: E402
+    ExploitValidator,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("gcc") is None,
+    reason="gcc not available",
+)
+
+
+# Trivially-fuzzable BOF source — strcpy of 20 attacker bytes into an
+# 8-byte stack buffer. ASAN reports stack-buffer-overflow; without
+# ASAN the binary typically SIGSEGVs at the canary or further down.
+_BOF_SOURCE = """
+#include <string.h>
+#include <stdio.h>
+int main(void) {
+    char buf[8];
+    char *src = "AAAAAAAAAAAAAAAAAAAA";
+    strcpy(buf, src);
+    puts(buf);
+    return 0;
+}
+"""
+
+
+# Source without any bug — pin "compile clean" with sanitizers on.
+_CLEAN_SOURCE = """
+#include <stdio.h>
+int main(void) {
+    puts("hi");
+    return 0;
+}
+"""
+
+
+# ----------------------------------------------------------------------
+# Default behaviour preserved
+# ----------------------------------------------------------------------
+
+
+def test_default_no_sanitizer_flags(tmp_path, monkeypatch):
+    """No ``sanitizers=`` kwarg → gcc command must not contain any
+    ``-fsanitize=`` flag. Regression guard against accidentally
+    enabling sanitizers by default (changes binary behaviour for
+    every existing caller)."""
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append(cmd)
+
+        class Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return Result()
+
+    import core.sandbox as sandbox_mod
+    monkeypatch.setattr(sandbox_mod, "run", fake_run)
+
+    v = ExploitValidator(work_dir=tmp_path)
+    v.validate_exploit(_CLEAN_SOURCE, "default-test")
+
+    assert captured, "gcc must have been invoked"
+    cmd = captured[0]
+    assert not any(arg.startswith("-fsanitize=") for arg in cmd), (
+        f"unexpected sanitizer flag in default command: {cmd}"
+    )
+
+
+# ----------------------------------------------------------------------
+# Sanitizer flag plumbing
+# ----------------------------------------------------------------------
+
+
+def test_address_sanitizer_in_gcc_command(tmp_path, monkeypatch):
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append(cmd)
+
+        class Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return Result()
+
+    import core.sandbox as sandbox_mod
+    monkeypatch.setattr(sandbox_mod, "run", fake_run)
+
+    v = ExploitValidator(work_dir=tmp_path)
+    v.validate_exploit(
+        _CLEAN_SOURCE, "asan-test", sanitizers=["address"],
+    )
+
+    cmd = captured[0]
+    assert "-fsanitize=address" in cmd
+    # Frame pointers + debug info improve ASAN report quality
+    assert "-fno-omit-frame-pointer" in cmd
+    assert "-g" in cmd
+
+
+def test_multiple_sanitizers_all_threaded(tmp_path, monkeypatch):
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append(cmd)
+
+        class Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return Result()
+
+    import core.sandbox as sandbox_mod
+    monkeypatch.setattr(sandbox_mod, "run", fake_run)
+
+    v = ExploitValidator(work_dir=tmp_path)
+    v.validate_exploit(
+        _CLEAN_SOURCE, "multi", sanitizers=["address", "undefined"],
+    )
+
+    cmd = captured[0]
+    assert "-fsanitize=address" in cmd
+    assert "-fsanitize=undefined" in cmd
+
+
+# ----------------------------------------------------------------------
+# Allowlist rejection
+# ----------------------------------------------------------------------
+
+
+def test_unknown_sanitizer_rejected_cleanly(tmp_path):
+    """Unknown name → structured error, no gcc invocation. Pre-fix
+    this would have cascaded as a gcc "unrecognized command-line
+    option" error — confusing because the error came from gcc, not
+    from the validator."""
+    v = ExploitValidator(work_dir=tmp_path)
+    result = v.validate_exploit(
+        _CLEAN_SOURCE, "bad-san", sanitizers=["bogus-name"],
+    )
+    assert result.success is False
+    assert any("unrecognised sanitizer" in e for e in result.compilation_errors)
+    assert any("bogus-name" in e for e in result.compilation_errors)
+
+
+def test_unknown_sanitizer_mixed_with_known_rejects(tmp_path):
+    """Reject as soon as any name is unknown — don't compile a
+    partial command. Easier for the caller to reason about."""
+    v = ExploitValidator(work_dir=tmp_path)
+    result = v.validate_exploit(
+        _CLEAN_SOURCE, "mixed", sanitizers=["address", "made-up"],
+    )
+    assert result.success is False
+    assert any("made-up" in e for e in result.compilation_errors)
+
+
+# ----------------------------------------------------------------------
+# End-to-end: ASAN-instrumented binary actually fires ASAN
+# ----------------------------------------------------------------------
+
+
+def _has_libasan() -> bool:
+    """gcc is installed but libasan may not be — quick probe."""
+    if shutil.which("gcc") is None:
+        return False
+    try:
+        result = subprocess.run(
+            ["gcc", "-fsanitize=address", "-x", "c", "-", "-o", "/dev/null"],
+            input="int main(void){return 0;}",
+            text=True,
+            capture_output=True,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
+@pytest.mark.skipif(
+    not _has_libasan(),
+    reason="gcc -fsanitize=address not usable on this host",
+)
+def test_asan_binary_actually_fires_on_bof(tmp_path):
+    """End-to-end: compile the BOF fixture with ASAN, run the
+    produced binary, verify ASAN reports stack-buffer-overflow.
+
+    Pins the substrate we need for PR E to surface
+    SANITIZER_REPORT outcomes through ``compile_and_execute``.
+    """
+    v = ExploitValidator(work_dir=tmp_path)
+    result = v.validate_exploit(
+        _BOF_SOURCE, "bof-test", sanitizers=["address"],
+    )
+    assert result.success is True
+    assert result.exploit_path is not None
+    assert result.exploit_path.is_file()
+
+    # Now run the produced binary. ASAN should fire.
+    proc = subprocess.run(
+        [str(result.exploit_path)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env={**os.environ, "ASAN_OPTIONS": "halt_on_error=1"},
+    )
+    # Returncode is non-zero — ASAN aborted the process.
+    assert proc.returncode != 0
+    # Stderr carries the ASAN report banner.
+    assert "AddressSanitizer" in proc.stderr
+    assert "stack-buffer-overflow" in proc.stderr
+
+
+@pytest.mark.skipif(
+    not _has_libasan(),
+    reason="gcc -fsanitize=address not usable on this host",
+)
+def test_asan_binary_does_not_fire_on_clean_source(tmp_path):
+    """ASAN-instrumented binary on clean source: compiles, runs
+    cleanly, no ASAN output. Regression guard against any
+    spurious ASAN fires from the instrumentation itself."""
+    v = ExploitValidator(work_dir=tmp_path)
+    result = v.validate_exploit(
+        _CLEAN_SOURCE, "clean-asan", sanitizers=["address"],
+    )
+    assert result.success is True
+
+    proc = subprocess.run(
+        [str(result.exploit_path)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert proc.returncode == 0
+    assert "AddressSanitizer" not in proc.stderr
+    assert proc.stdout.strip() == "hi"

--- a/packages/llm_analysis/exploit_verify.py
+++ b/packages/llm_analysis/exploit_verify.py
@@ -53,6 +53,7 @@ def compile_verify(
     target_file_path: Optional[str],
     artifact_id: str,
     logger: Optional[logging.Logger] = None,
+    sanitizers: Optional[List[str]] = None,
 ) -> Tuple[Optional[bool], List[str]]:
     """Compile-check ``exploit_code`` in a sandboxed tempdir.
 
@@ -69,6 +70,12 @@ def compile_verify(
             traversal segments are sanitised before use.
         logger: Optional logger for status / diagnostic lines. Defaults
             to a module logger.
+        sanitizers: Optional list of gcc sanitizer names to enable
+            (``"address"``, ``"undefined"``, etc.). Passes through to
+            ``ExploitValidator.validate_exploit`` — see that method
+            for the allowlist + behaviour. ``None`` (default) keeps
+            the historical compile-verify behaviour with no
+            instrumentation.
 
     Returns:
         ``(compiled, errors)`` where:
@@ -137,7 +144,9 @@ def compile_verify(
         work_dir = Path(work_dir_str)
         try:
             validator = ExploitValidator(work_dir=work_dir)
-            result = validator.validate_exploit(exploit_code, safe_id)
+            result = validator.validate_exploit(
+                exploit_code, safe_id, sanitizers=sanitizers,
+            )
         except Exception as e:  # noqa: BLE001 — validator is best-effort
             log.warning(
                 f"   ⚠ Compile-verify raised {type(e).__name__}: {e}; "

--- a/test/data/trivially_fuzzable/Makefile
+++ b/test/data/trivially_fuzzable/Makefile
@@ -1,0 +1,27 @@
+# Build the trivially-fuzzable target for RAPTOR end-to-end tests.
+#
+# Default target builds with -fsanitize=address (the variant
+# /fuzz --execute-exploits and exploit_verify with sanitizers=
+# expect, so ASAN reports flow into Witness SANITIZER_REPORT
+# outcomes).
+#
+# `make plain` builds without sanitizers — useful for the
+# baseline SIGSEGV path or for AFL++ runs that supply their own
+# instrumentation.
+
+CC      ?= gcc
+CFLAGS  ?= -O0 -g -fno-omit-frame-pointer -fsanitize=address -Wall
+LDFLAGS ?=
+
+all: target
+
+target: target.c
+	$(CC) $(CFLAGS) -o target target.c $(LDFLAGS)
+
+plain: target.c
+	$(CC) -O0 -g -Wall -o target-plain target.c
+
+clean:
+	rm -f target target-plain
+
+.PHONY: all plain clean

--- a/test/data/trivially_fuzzable/README.md
+++ b/test/data/trivially_fuzzable/README.md
@@ -1,0 +1,55 @@
+# trivially_fuzzable — RAPTOR end-to-end test target
+
+A 60-line C program with three deliberate, obvious bugs reachable by a
+single byte of stdin. Used to E2E-test the chain:
+
+```
+/fuzz → crash collection → CrashAnalysisAgent →
+  exploit_verify.compile_and_execute (with sanitizers) →
+    sandbox run → outcome classification → Witness record
+```
+
+Each branch exercises a distinct `WitnessOutcome`:
+
+| Trigger | Tag | Outcome (no sanitizers) | Outcome (`-fsanitize=address`) |
+|---------|-----|-------------------------|---------------------------------|
+| `A` + ≥8 attacker bytes | strcpy BOF | `EXIT_SIGNAL` (SIGSEGV usually) | `SANITIZER_REPORT` (`asan`) |
+| `B` | NULL deref | `EXIT_SIGNAL` (SIGSEGV) | `EXIT_SIGNAL` (SIGSEGV) |
+| `C` | clean exit | `NO_OBVIOUS_EFFECT` | `NO_OBVIOUS_EFFECT` |
+
+## Build
+
+```sh
+make           # default: -fsanitize=address
+make plain     # without sanitizers
+```
+
+## Operator probes
+
+```sh
+# BOF — should produce ASAN report
+echo -n 'AAAAAAAAAAAAAAAAAA' | ./target
+
+# NULL deref
+echo -n 'B' | ./target
+
+# Clean exit
+echo -n 'C' | ./target
+```
+
+## Why this exists
+
+`/fuzz --execute-exploits` (PR E) needs a target where RAPTOR can:
+1. Find a crash via AFL++
+2. Have the LLM emit a PoC
+3. Compile-and-execute the PoC in the sandbox
+4. Observe a sanitizer/signal outcome
+5. Persist that outcome as a `Witness`
+
+A handful of single-byte inputs reach all three outcomes deterministically,
+which is good enough to exercise the wiring without paying real-world
+fuzzing wall-clock time.
+
+This is intentionally **not** a benchmark or realistic vuln — it's a
+fixture, sibling to `test/data/javascript_xss.js` and
+`test/data/python_sql_injection.py`.

--- a/test/data/trivially_fuzzable/target.c
+++ b/test/data/trivially_fuzzable/target.c
@@ -1,0 +1,70 @@
+/*
+ * Trivially-fuzzable target for end-to-end testing of:
+ *   - /fuzz crash collection
+ *   - /fuzz --execute-exploits (PR E) Witness capture
+ *   - exploit_verify.compile_and_execute with sanitizers
+ *
+ * Reads up to 64 bytes from stdin. The first byte is a tag:
+ *
+ *   'A'  → strcpy() the rest into an 8-byte stack buffer.
+ *          With -fsanitize=address, AFL or a hand-written PoC of
+ *          more than 8 bytes triggers a stack-buffer-overflow
+ *          ASAN report. Without sanitizers, it usually crashes
+ *          with SIGSEGV.
+ *   'B'  → dereference NULL → SIGSEGV.
+ *   'C'  → clean exit (control case — exercises NO_OBVIOUS_EFFECT).
+ *   else → exit(0) silently.
+ *
+ * Deliberately compact + obvious: this is a TEST FIXTURE, not a
+ * realistic vulnerability. Operators run RAPTOR against it to
+ * verify the full pipeline (compile → fuzz → crash collect →
+ * LLM analyse → execute exploit in sandbox → record Witness)
+ * works end-to-end with sanitized binaries.
+ *
+ * Build:
+ *   make -C test/data/trivially_fuzzable         # with sanitizers
+ *   make -C test/data/trivially_fuzzable plain   # without
+ *
+ * Probe:
+ *   echo -n 'AAAAAAAAAAAAAAAAAAAA' | ./target    # BOF
+ *   echo -n 'B'                    | ./target    # NULL deref
+ *   echo -n 'C'                    | ./target    # clean
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(void) {
+    char input[64];
+    ssize_t n = read(0, input, sizeof(input) - 1);
+    if (n <= 0) {
+        return 1;
+    }
+    input[n] = '\0';
+
+    switch (input[0]) {
+    case 'A': {
+        char buf[8];
+        /* Deliberate strcpy of attacker-controlled bytes into
+         * an 8-byte buffer. ASAN reports stack-buffer-overflow
+         * on any input where strlen(input + 1) >= 8. */
+        strcpy(buf, input + 1);
+        puts(buf);
+        return 0;
+    }
+    case 'B': {
+        /* Deliberate NULL deref → SIGSEGV. */
+        int *p = NULL;
+        *p = 42;
+        return 0;
+    }
+    case 'C':
+        /* Control: clean exit, no observable bug signal. */
+        puts("ok");
+        return 0;
+    default:
+        return 0;
+    }
+}


### PR DESCRIPTION
Adds a sanitizers= kwarg to ExploitValidator.validate_exploit and compile_verify so callers can opt into compiling exploits with -fsanitize=address (or other sanitizer-family flags) for runtime bug detection. Default behaviour unchanged (no instrumentation).

Allowlist validates names against gcc's recognised set (address, undefined, memory, thread, leak, kernel-address, hwaddress) so an unknown name fails with a clean structured error rather than a confusing gcc "unrecognized command-line option" cascade. With ASAN enabled, -fno-omit-frame-pointer + -g are added for accurate stack-trace reports.

Adds a tiny end-to-end test fixture at
test/data/trivially_fuzzable/ — a stdin-driven C target with three deterministic branches (BOF / NULL-deref / clean exit). Used by this PR's live ASAN integration test (compiles BOF source with -fsanitize=address, runs the binary, confirms stack-buffer-overflow fires) and available for future end-to-end fuzz testing.

Tests (7) cover default-off, flag threading, multi-sanitizer, allowlist rejection (clean + mixed), live ASAN fire on BOF, clean-source no-spurious-fire.