### PR TITLE
feat(validate): sanitization gates + cross-class rule in Stage B [B-3.1]

### DIFF
--- a/.claude/skills/exploitability-validation/stage-b-process.md
+++ b/.claude/skills/exploitability-validation/stage-b-process.md
@@ -123,6 +123,33 @@ The output lists 1–3 strategies (general + specialised bug-class lenses) with 
 **[B-3.1] Input Verification**
 Verify that suspected findings actually process user input (not just hardcoded values), and there is a proven flow from input to vulnerable code.
 
+When the flow is real, walk the chain source→sink and apply two checks.
+
+**Sanitization gates on the path.** A finding is non-exploitable when the path between source and sink correctly applies any one of these gates:
+
+| Gate | What it does | Example |
+|---|---|---|
+| Parameterization | DB engine handles content separation | `db.query("SELECT * WHERE id=?", [val])` |
+| Escape / encode | Per-sink encoding before interpolation | `html.escape`, `urlencode`, `json.dumps` |
+| Whitelist validation | Value falls in a closed allowed set | regex match, enum check, length+charset bounds |
+| Length-check + bounds-clamp | Prevents memcpy/strcpy overflow | explicit `if (len > sizeof(dst)) return;` |
+| Type-narrowing cast | Value space narrowed by parsing | `parseInt` / `atoi` strips non-numeric input |
+
+"Correctly applied" means: (1) before the sink, not after; (2) on the actual tainted variable, not a parallel copy; (3) the sanitised result, not the unsanitised input, reaches the sink. If a gate holds, mark the attack path blocked and record the gate name in `attack-paths.json` `blockers[]`.
+
+**Cross-class escalation for persistent-storage sources.** When the source is persistent storage (database row, cache, file written by another process, IPC), check whether the sink class differs from the source class:
+
+| Source class | Sink class | Verdict |
+|---|---|---|
+| DB row → SQL query | same | safe with parameterization |
+| DB row → HTML render | cross | escalate — stored XSS |
+| DB row → shell exec | cross | escalate — stored cmd-injection |
+| DB row → URL / redirect | cross | escalate — stored open-redirect / SSRF |
+| DB row → file path | cross | escalate — stored path-traversal |
+| Cache / IPC → any non-same-class sink | cross | escalate (same shape as DB) |
+
+Persistent storage may contain attacker data written in an earlier request. Cross-class flow from such a source MUST be treated as attacker-controlled in the new sink class — assume an earlier write put attacker data there. Record the escalation in the hypothesis's `evidence_for` as `"cross_class:<source>→<sink>"`.
+
 **[B-3.1.5] SMT Pre-flight (memory-corruption / arithmetic / bounds CWEs)**
 
 Before constructing an attack path, ask Z3 whether the path conditions you've identified are jointly satisfiable. SMT is a decision procedure within its domain — when it says `feasible: false`, the path IS infeasible (sound even with `_anon_N` placeholders in the unsat core); when it says `feasible: true` with a named-local witness, you have concrete trigger values to use as the PoC seed instead of deriving them from first principles.


### PR DESCRIPTION
  Two additions to /validate's Stage B Input Verification step. Both are pure-prompt edits to one skill file — no schema changes, no code changes, no behaviour change for runs that don't trigger the new text. Adds explicit refutation gates and stored-vulnerability coverage we didn't have.

  What's in here

  1. Five-gate sanitization checklist. Stage B previously asked "is there a sanitizer somewhere?" — the LLM now walks the chain source→sink and applies a named gate list:

  - Parameterization (DB engine handles content separation)
  - Escape / encode (per-sink encoding before interpolation)
  - Whitelist validation (closed allowed set)
  - Length-check + bounds-clamp (overflow prevention)
  - Type-narrowing cast (parsing strips space)

  "Correctly applied" criteria are made explicit (before-the-sink, on-the-actual-tainted-variable, sanitised-result-reaches-sink). When a gate holds, the attack path is recorded in attack-paths.json blockers[] by gate name — structured data instead of free-form prose.

  2. Cross-class escalation table for persistent-storage sources. Stage B previously treated all tainted-reaching-sink uniformly, so stored-XSS / stored-cmd-injection / stored-open-redirect / content unaffected)


 Thanks to @dinosn — the five sanitization gates and the cross-class escalation rule come directly from the data-flow-classification.md spec Nicolas Krassas attached to #583. Suggested-by: trailer in the commit.