### PR TITLE
feat(validate): sanitization gates + cross-class rule + triage order in Stage A

### DIFF
--- a/.claude/skills/exploitability-validation/stage-a-oneshot.md
+++ b/.claude/skills/exploitability-validation/stage-a-oneshot.md
@@ -42,6 +42,16 @@ If binaries are available, use them for PoC evidence (crash output, leak output)
 
 **Priority targets from /understand:** If `checklist.json` contains a `priority_targets` array, these are unchecked flows identified by `/understand --map` — entry points that reach sinks without passing through a trust boundary. Assess these first, as they are the highest-value candidates for exploitable findings. The prep output prints them.
 
+**Source-type triage order.** When the candidate set is large and full coverage isn't immediately tractable, work in this order:
+
+1. Direct attacker input → dangerous sink (request body / query / headers / argv / network recv reaching SQL / shell / HTML / `memcpy`)
+2. Direct attacker input → persistent-storage write (these become the sources for category 3)
+3. Persistent-storage source → cross-class sink (DB→HTML, cache→shell — stored variants of category 1)
+4. Internal computed value → sink (only when no attacker-input path reaches the same compute)
+5. System / runtime constant → sink (only when attacker can influence the constant, e.g. via suid env-var read)
+
+Categories 1+3 produce the highest-confidence findings; 2 records stored-flow setup; 4+5 are usually safe and rarely worth Stage A's budget.
+
 **Bug-class lenses (CWE-strategy guidance):** For each priority target or function you're about to assess, run:
 ```bash
 libexec/raptor-pick-strategies --file <path> --function <name> [--cwe <CWE-XX>]
@@ -49,6 +59,33 @@ libexec/raptor-pick-strategies --file <path> --function <name> [--cwe <CWE-XX>]
 The output is a markdown block of 1–3 matching review strategies — each with key questions, prompt addendum, and 1–2 worked CVE exemplars for the bug class. Use the strategy guidance to focus reasoning on the right invariants for the bug class (e.g., race-window analysis for concurrency strategies; lengths-before-bounds for input-handling strategies).
 
 When the function's CWE class isn't yet known (typical for Stage A), pass `--file` and `--function` and let the picker infer from path / function-name signals. After Stage A assigns `cwe_id` to a finding, downstream stages re-run the helper with `--cwe` for tighter guidance.
+
+**Sanitizer + cross-class checks (apply during step 1 of DO below).** For each candidate, walk the chain source→sink and apply two checks. These let you `disprove` fast (a correct sanitizer) or escalate `not_disproven` (cross-class stored flow) before reaching for a PoC.
+
+*Sanitization gate on the path.* If the path between source and sink correctly applies any one of these gates, mark `status: "disproven"` with `disproved_because.investigated` set to the gate name and `conclusion` of "<gate> correctly applied between source and sink":
+
+| Gate | What it does | Example |
+|---|---|---|
+| Parameterization | DB engine handles content separation | `db.query("SELECT * WHERE id=?", [val])` |
+| Escape / encode | Per-sink encoding before interpolation | `html.escape`, `urlencode`, `json.dumps` |
+| Whitelist validation | Value falls in a closed allowed set | regex match, enum check, length+charset bounds |
+| Length-check + bounds-clamp | Prevents memcpy/strcpy overflow | explicit `if (len > sizeof(dst)) return;` |
+| Type-narrowing cast | Value space narrowed by parsing | `parseInt` / `atoi` strips non-numeric input |
+
+"Correctly applied" means before the sink, on the actual tainted variable, and the sanitised result (not the original input) reaches the sink. If any of those conditions fails, the gate doesn't hold — mark `not_disproven` and let Stage B walk the path.
+
+*Cross-class escalation for persistent-storage sources.* If the source is persistent storage (DB row, cache, file written by another process, IPC) AND the sink class differs from the source class, mark `not_disproven` regardless of how safe the sink interpolation looks in isolation — stored content may carry attacker data from an earlier write:
+
+| Source class | Sink class | Treatment |
+|---|---|---|
+| DB row → SQL query | same | apply gate check above |
+| DB row → HTML render | cross | flag stored-XSS candidate |
+| DB row → shell exec | cross | flag stored-cmd-injection candidate |
+| DB row → URL / redirect | cross | flag stored-open-redirect / SSRF candidate |
+| DB row → file path | cross | flag stored-path-traversal candidate |
+| Cache / IPC → any non-same-class sink | cross | flag (same shape as DB) |
+
+Set `proof_source` to identify the storage location and note in `candidate_reasoning` that exploitation requires a prior attacker write.
 
 DO:
 1. For each function in checklist.json, assess for target vulnerability type (start with priority targets if present)

--- a/.claude/skills/exploitability-validation/stage-b-process.md
+++ b/.claude/skills/exploitability-validation/stage-b-process.md
@@ -137,6 +137,8 @@ When the flow is real, walk the chain source→sink and apply two checks.
 
 "Correctly applied" means: (1) before the sink, not after; (2) on the actual tainted variable, not a parallel copy; (3) the sanitised result, not the unsanitised input, reaches the sink. If a gate holds, mark the attack path blocked and record the gate name in `attack-paths.json` `blockers[]`.
 
+If the finding's `candidate_reasoning` from Stage A already names a gate ("<gate> appears correctly applied — Stage B to confirm path dominance"), verify that gate's three conditions first. Confirming or refuting Stage A's flagged gate resolves the finding faster than re-checking all five from scratch.
+
 **Cross-class escalation for persistent-storage sources.** When the source is persistent storage (database row, cache, file written by another process, IPC), check whether the sink class differs from the source class:
 
 | Source class | Sink class | Verdict |


### PR DESCRIPTION
Replicates the Stage B [B-3.1] additions from PR #588 in Stage A's oneshot detection pass, plus a source-type triage ordering, plus a small completing edit on the Stage B side so the handshake is symmetric.

1. Five-gate sanitization checklist in Stage A — same rules as Stage B (parameterization / escape-encode / whitelist / length-check / type-narrowing). Stage A is one-shot and can't verify gate dominance, so a gate match produces `status: "not_disproven"` with `candidate_reasoning` noting the apparent gate; Stage B's identical gate list (with the 3 dominance conditions) decides definitively. Adversarial review confirmed the asymmetry with Stage B's `blockers[]` recording — Stage A shouldn't claim the harder verdict.

2. Cross-class escalation table in Stage A — persistent-storage source flowing into a different sink class (DB→HTML, cache→shell, etc.) gets `status: "not_disproven"` with `confidence: "medium"` and `uncertainty` explicitly naming the prior-write requirement. Catches stored-XSS / stored-cmd-inject candidates that the existing Stage A reasoning would have missed when the sink interpolation looks safe in isolation.

3. Source-type triage order — five-bucket prioritisation (direct attacker input → dangerous sink first; persistent-storage cross-class next; internal/system-constant last) for large checklists. Functional language rather than L-tier labels — keeps the door open for the trust-vocabulary naming discussion still open on the issue. Defers to `priority_targets` from /understand when they're present.

4. Stage B handshake — one-line addition to `[B-3.1]` so Stage B prioritises verifying any gate Stage A flagged in `candidate_reasoning`, instead of re-checking all five from scratch.

Pure prompt edits to two skill files (Stage A + small Stage B addendum). No schema or code changes. Detection-time counterpart to PR #588's validation-time gates — FPs suppressed at Stage A don't waste Stage B's budget; FPs that slip through Stage A still get caught by Stage B's identical gate list.

Suggested-by: Nicolas Krassas <3851678+dinosn@users.noreply.github.com>