### PR TITLE
fix(validate): Stage A gate verdict + cross-class fields (#589 followup

### DIFF
--- a/.claude/skills/exploitability-validation/stage-a-oneshot.md
+++ b/.claude/skills/exploitability-validation/stage-a-oneshot.md
@@ -42,7 +42,7 @@ If binaries are available, use them for PoC evidence (crash output, leak output)
 
 **Priority targets from /understand:** If `checklist.json` contains a `priority_targets` array, these are unchecked flows identified by `/understand --map` — entry points that reach sinks without passing through a trust boundary. Assess these first, as they are the highest-value candidates for exploitable findings. The prep output prints them.
 
-**Source-type triage order.** When the candidate set is large and full coverage isn't immediately tractable, work in this order:
+**Source-type triage order.** Within `priority_targets` (above), and then across the remaining candidate set, when full coverage isn't immediately tractable work in this order:
 
 1. Direct attacker input → dangerous sink (request body / query / headers / argv / network recv reaching SQL / shell / HTML / `memcpy`)
 2. Direct attacker input → persistent-storage write (these become the sources for category 3)
@@ -60,9 +60,9 @@ The output is a markdown block of 1–3 matching review strategies — each with
 
 When the function's CWE class isn't yet known (typical for Stage A), pass `--file` and `--function` and let the picker infer from path / function-name signals. After Stage A assigns `cwe_id` to a finding, downstream stages re-run the helper with `--cwe` for tighter guidance.
 
-**Sanitizer + cross-class checks (apply during step 1 of DO below).** For each candidate, walk the chain source→sink and apply two checks. These let you `disprove` fast (a correct sanitizer) or escalate `not_disproven` (cross-class stored flow) before reaching for a PoC.
+**Sanitizer + cross-class checks (apply during step 1 of DO below).** For each candidate, walk the chain source→sink and apply two checks. Both produce `not_disproven` markings for Stage B to verify or refute — Stage A's one-shot read can flag the presence of a gate or cross-class flow, but cannot definitively disprove or confirm without the structured analysis Stage B applies.
 
-*Sanitization gate on the path.* If the path between source and sink correctly applies any one of these gates, mark `status: "disproven"` with `disproved_because.investigated` set to the gate name and `conclusion` of "<gate> correctly applied between source and sink":
+*Sanitization gate on the path.* If the path between source and sink appears to apply any one of these gates, mark `status: "not_disproven"` with `candidate_reasoning: "<gate> appears correctly applied — Stage B to confirm path dominance"`. Stage A is one-shot and cannot verify that the gate's call site dominates every sink-reaching path or that no parallel unsanitised copy is used — leave the definitive disprove to Stage B's hypothesis-driven analysis (it has the same gate list in `[B-3.1]`):
 
 | Gate | What it does | Example |
 |---|---|---|
@@ -74,7 +74,7 @@ When the function's CWE class isn't yet known (typical for Stage A), pass `--fil
 
 "Correctly applied" means before the sink, on the actual tainted variable, and the sanitised result (not the original input) reaches the sink. If any of those conditions fails, the gate doesn't hold — mark `not_disproven` and let Stage B walk the path.
 
-*Cross-class escalation for persistent-storage sources.* If the source is persistent storage (DB row, cache, file written by another process, IPC) AND the sink class differs from the source class, mark `not_disproven` regardless of how safe the sink interpolation looks in isolation — stored content may carry attacker data from an earlier write:
+*Cross-class escalation for persistent-storage sources.* If the source is persistent storage (DB row, cache, file written by another process, IPC) AND the sink class differs from the source class, mark `status: "not_disproven"` with `confidence: "medium"` and `uncertainty: "exploitation requires a prior attacker write to <storage>"` regardless of how safe the sink interpolation looks in isolation — stored content may carry attacker data from an earlier write:
 
 | Source class | Sink class | Treatment |
 |---|---|---|
@@ -85,7 +85,7 @@ When the function's CWE class isn't yet known (typical for Stage A), pass `--fil
 | DB row → file path | cross | flag stored-path-traversal candidate |
 | Cache / IPC → any non-same-class sink | cross | flag (same shape as DB) |
 
-Set `proof_source` to identify the storage location and note in `candidate_reasoning` that exploitation requires a prior attacker write.
+Set `proof_source` to identify the storage location.
 
 DO:
 1. For each function in checklist.json, assess for target vulnerability type (start with priority targets if present)


### PR DESCRIPTION
- Gate-hit: `status: "disproven"` -> `"not_disproven"`; drop the `disproved_because` fill (no longer needed at this status).
- Cross-class escalation: explicitly set `confidence: "medium"` and `uncertainty: "exploitation requires a prior attacker write to <storage>"`.
- Triage order: prefix with "Within `priority_targets` (above), and then across the remaining candidate set" to resolve precedence against the existing /understand priority.

Refs #583.

Suggested-by: Nicolas Krassas <3851678+dinosn@users.noreply.github.com>