### PR TITLE
feat(codeql): confidence-gate fallback admits source-bearing trees

### DIFF
--- a/packages/codeql/agent.py
+++ b/packages/codeql/agent.py
@@ -276,6 +276,26 @@ class CodeQLAgent:
                     detected = self.language_detector.detect_languages(min_files=1)
                     detected = self.language_detector.filter_codeql_supported(detected)
 
+                # Confidence-gate fallback. The min_confidence threshold
+                # in detect_languages defends against stray manifests
+                # (e.g. a `pom.xml` in a docs example dir) but is also
+                # tripped by trees with real source code and zero build
+                # files — multi-language minimal repros, fixture trees,
+                # honeyslop-shaped adversarial canaries. The two retry
+                # tiers above both gate on confidence; if both returned
+                # empty, fall back to a file-count-only floor and log
+                # loud per-language WARNINGs so the operator knows the
+                # scan is running on low-confidence detection. Better
+                # than the silent-skip footgun of the pre-fix path.
+                if not detected:
+                    logger.warning(
+                        "No languages cleared the confidence gate after "
+                        "two retries; falling back to file-count floor "
+                        "(low-confidence detection — verify results)"
+                    )
+                    detected = self.language_detector.detect_languages_floor(floor=2)
+                    detected = self.language_detector.filter_codeql_supported(detected)
+
             if not detected:
                 error = "No CodeQL-supported languages detected"
                 logger.error(error)

--- a/packages/codeql/language_detector.py
+++ b/packages/codeql/language_detector.py
@@ -227,6 +227,59 @@ class LanguageDetector:
 
         return detected
 
+    def detect_languages_floor(self, floor: int = 2) -> Dict[str, LanguageInfo]:
+        """
+        Last-resort detection tier — include any language with at least
+        ``floor`` source files, **ignoring the per-language confidence
+        threshold**. Logs a loud WARNING per language so the operator
+        knows the scan is running on low-confidence detection.
+
+        Use only when ``detect_languages`` has already returned empty
+        with min_files=1 — i.e. the target has source code present but
+        no build manifests or structural indicators that would let
+        confidence clear the gate. honeyslop-shaped trees (multi-
+        language, no build files by design) and minimal repros land
+        here. Caller is responsible for ordering: floor detection is
+        a fallback, not a default.
+
+        Args:
+            floor: Minimum source files required per language. Default 2
+                — high enough to filter out a single stray file from
+                another language, low enough to admit minimal repros.
+
+        Returns:
+            Dict mapping language name -> LanguageInfo for languages
+            meeting only the file-count floor.
+        """
+        logger.info(
+            f"Detecting languages in: {self.repo_path} (floor tier, "
+            f"floor={floor}, ignoring confidence gate)"
+        )
+        stats = self._scan_repository()
+
+        detected = {}
+        for lang, patterns in self.LANGUAGE_PATTERNS.items():
+            info = self._analyze_language(lang, patterns, stats)
+            if info.file_count >= floor:
+                detected[lang] = info
+                logger.warning(
+                    f"⚠ Floor-tier include {lang}: file_count={info.file_count} "
+                    f"(floor={floor}), confidence={info.confidence:.2f} "
+                    f"(would-be-min={patterns['min_confidence']}), "
+                    f"build_files={sorted(info.build_files_found) or 'none'} "
+                    f"— low-confidence detection, verify scan results"
+                )
+
+        if not detected:
+            logger.warning(
+                f"No languages detected even at floor={floor}; "
+                f"target has no scannable source code"
+            )
+        else:
+            logger.info(f"Floor-tier detected: {len(detected)} language(s)")
+
+        return detected
+
     def _scan_repository(self) -> Dict:
         """
         Scan repository and collect file statistics.

--- a/packages/codeql/tests/test_language_detector.py
+++ b/packages/codeql/tests/test_language_detector.py
@@ -177,3 +177,76 @@ class TestSkipLogging:
             f"expected no skip-WARNs for absent languages; "
             f"got noisy warnings: {spurious}"
         )
+
+
+class TestFloorFallback:
+    """detect_languages_floor() is the last-resort tier for repos with
+    real source code but no build manifests — multi-language minimal
+    repros, fixture trees, honeyslop-shaped adversarial canaries. It
+    bypasses the confidence gate and admits any language above the
+    file-count floor. Caller (agent.py) only invokes it when the two
+    confidence-gated tiers have already returned empty.
+    """
+
+    def test_multilang_no_manifests_all_admitted(self, tmp_path: Path):
+        # honeyslop shape: 4 py + 2 js + 6 go + 4 cpp + non-source
+        # files (README, LICENSE, docs, images) that dilute the per-
+        # language ratio below the confidence threshold. Zero build
+        # files. Every language clears file_count >= 2 under floor.
+        for i in range(4):
+            _write(tmp_path, f"python/a{i}.py", "")
+        for i in range(2):
+            _write(tmp_path, f"js/a{i}.js", "")
+        for i in range(6):
+            _write(tmp_path, f"go/a{i}.go", "")
+        for i in range(4):
+            _write(tmp_path, f"c/a{i}.c", "")
+        # Decoy non-source files — match honeyslop's README/LICENSE/
+        # docs/images bulk. Need enough to push every language's
+        # ratio below its min_confidence gate (cap +0.3 on ratio
+        # means ratio < 0.2 keeps cpp/python/js below 0.5; go is
+        # gated at 0.6 so needs ratio < 0.3). 26 decoys + 16 sources
+        # = 42 total; go gets 6/42 = 0.14, well under the gate.
+        for i in range(26):
+            _write(tmp_path, f"docs/note{i}.md", "")
+
+        det = LanguageDetector(tmp_path)
+        # Confidence tiers return empty (no build files, ratios diluted).
+        assert det.detect_languages(min_files=3) == {}, (
+            "strict tier must reject — no build files, low ratios"
+        )
+        assert det.detect_languages(min_files=1) == {}, (
+            "min_files=1 retry must also reject — confidence still gates"
+        )
+
+        floor = det.detect_languages_floor(floor=2)
+        assert set(floor.keys()) >= {"python", "javascript", "go", "cpp"}, (
+            f"floor tier must admit all four; got {sorted(floor.keys())}"
+        )
+
+    def test_single_file_below_floor_rejected(self, tmp_path: Path):
+        # One .go file is below floor=2 — must NOT be admitted even
+        # in floor tier, otherwise true-empty repos or single-stray-
+        # file trees would silently trigger a scan.
+        _write(tmp_path, "scratch.go", "package main\n")
+
+        floor = LanguageDetector(tmp_path).detect_languages_floor(floor=2)
+        assert "go" not in floor
+
+    def test_floor_logs_per_language_warning(self, tmp_path: Path, monkeypatch):
+        # Operator must see a loud WARNING per admitted language so
+        # they know the scan is running on low-confidence detection.
+        # Silent low-confidence admission would defeat the whole point
+        # of having a confidence gate in the strict tiers.
+        for i in range(3):
+            _write(tmp_path, f"a{i}.py", "")
+
+        mock_logger = MagicMock()
+        monkeypatch.setattr(ld_mod, "logger", mock_logger)
+
+        LanguageDetector(tmp_path).detect_languages_floor(floor=2)
+
+        warns = [c.args[0] for c in mock_logger.warning.call_args_list]
+        assert any(
+            "Floor-tier include python" in w for w in warns
+        ), f"expected loud floor-include WARN for python; got: {warns}"


### PR DESCRIPTION
Add Tier 3 to the language-detection pipeline: when both confidence- gated retries return empty, fall back to file-count-only detection (floor=2) with a loud per-language WARNING. Closes the silent-skip on multi-language minimal repros, fixture trees, and unbuilt canary-style targets where the per-lang ratio cannot clear the confidence threshold without a build manifest.

The two strict tiers are unchanged — well-behaved repos still detect exactly as before. The floor tier only engages as last resort, only admits languages with file_count >= 2 (one stray file from another language stays out), and logs a per-language WARN so operators know the scan is running on low-confidence detection.

Pairs with the earlier raptor_agentic.py stderr-surface fix: even if Tier 3 still finds nothing (truly source-empty target), the operator now sees both the per-language confidence numbers AND the actionable "pass --languages" hint instead of a bare rc=1.