### PR TITLE
fix(exploit_validator): pick a C++ compiler, not bare gcc

### DIFF
--- a/packages/autonomous/exploit_validator.py
+++ b/packages/autonomous/exploit_validator.py
@@ -10,6 +10,7 @@ This module enables RAPTOR to:
 """
 
 import re
+import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -19,6 +20,43 @@ from core.config import RaptorConfig
 from core.logging import get_logger
 
 logger = get_logger()
+
+
+def _detect_cxx_compiler() -> str:
+    """Return the first available C++ compiler on PATH.
+
+    Preference order:
+
+      1. ``c++`` — POSIX-standard symlink resolving to the operator's
+         system default (g++ on Debian, clang++ on macOS, system CC
+         on BSDs / Solaris / AIX). Honouring this symlink means a
+         developer who's set their system to clang doesn't get
+         silently downgraded to gcc, and vice versa.
+      2. ``g++`` — explicit GNU fallback when ``c++`` is unavailable
+         (some minimal containers strip the symlink).
+      3. ``clang++`` — explicit LLVM fallback when neither of the
+         above resolves.
+
+    We use a C++ compiler rather than a C compiler because LLM-emitted
+    exploit PoCs are predominantly C++ (training-data prior). C source
+    is a near-subset of C++ and compiles fine through g++ / clang++
+    via the ``.cpp`` source extension. The handful of C-specific
+    constructs that don't translate (``restrict``, ``_Generic``, K&R
+    syntax) are vanishingly rare in PoC code; if a real-world exploit
+    hits one, the path forward is to add language detection rather
+    than rolling our own gcc-vs-g++ branching here.
+
+    Raises ``RuntimeError`` when nothing is found — the caller can
+    surface this as a structured compile-error rather than crashing.
+    """
+    for candidate in ("c++", "g++", "clang++"):
+        if shutil.which(candidate):
+            return candidate
+    raise RuntimeError(
+        "no C++ compiler found on PATH "
+        "(looked for c++, g++, clang++); install build-essential "
+        "or equivalent for your platform"
+    )
 
 
 @dataclass
@@ -116,18 +154,36 @@ class ExploitValidator:
                 warnings=[],
             )
 
-        # Write exploit to temporary file — sanitize name to prevent path traversal
+        # Write exploit to temporary file — sanitize name to prevent path traversal.
+        # ``.cpp`` extension so the chosen C++ compiler treats the source as
+        # C++ unambiguously. C source compiles fine through this path too
+        # (C is mostly a subset of C++); the alternative — keeping ``.c``
+        # and toggling compilers per-language — would need language
+        # detection and double the test matrix for marginal benefit.
         safe_name = Path(exploit_name).name.replace("..", "_") if exploit_name else "exploit"
-        exploit_source = self.work_dir / f"{safe_name}.c"
+        exploit_source = self.work_dir / f"{safe_name}.cpp"
         exploit_binary = self.work_dir / safe_name
 
         try:
             with open(exploit_source, 'w') as f:
                 f.write(exploit_code)
 
+            # Detect compiler at call time rather than at import time —
+            # operators can install / uninstall toolchains between
+            # process boots and we want to honour the current PATH.
+            try:
+                cxx = _detect_cxx_compiler()
+            except RuntimeError as e:
+                return ValidationResult(
+                    success=False,
+                    compilation_errors=[str(e)],
+                    runtime_errors=[],
+                    warnings=[],
+                )
+
             # Attempt compilation
             compile_cmd = [
-                "gcc",
+                cxx,
                 "-o", str(exploit_binary),
                 str(exploit_source),
                 "-w",  # Suppress warnings for now

--- a/packages/autonomous/tests/test_exploit_validator_compiler_detect.py
+++ b/packages/autonomous/tests/test_exploit_validator_compiler_detect.py
@@ -1,0 +1,286 @@
+"""Tests for ``_detect_cxx_compiler`` + the c++/g++/clang++ compile path.
+
+The compile path was previously hard-coded to ``gcc``, which meant:
+
+  * Operator system where ``gcc`` isn't installed (e.g. macOS with
+    only Xcode CLT, which provides ``clang`` + symlinks but no real
+    ``gcc``) — every compile failed.
+  * LLM emitted C++ (the default for memory-safety PoCs) → gcc rejected
+    with ``iostream: No such file or directory``.
+
+This module pins:
+
+  * Detection order ``c++ > g++ > clang++``.
+  * RuntimeError when nothing on PATH (surfaced cleanly through
+    ``validate_exploit`` as a structured ``ValidationResult``).
+  * C source compiles via the detected compiler.
+  * C++ source (with ``<iostream>``) compiles via the detected compiler.
+  * Sanitizer flags still thread through.
+  * Generated binary actually runs.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# packages/autonomous/tests/test_exploit_validator_compiler_detect.py
+#   parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from packages.autonomous.exploit_validator import (  # noqa: E402
+    ExploitValidator,
+    _detect_cxx_compiler,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    not any(shutil.which(c) for c in ("c++", "g++", "clang++")),
+    reason="no C++ compiler on PATH",
+)
+
+
+# ----------------------------------------------------------------------
+# Detection logic
+# ----------------------------------------------------------------------
+
+
+def test_detection_prefers_c_plus_plus_when_present():
+    """``c++`` is the POSIX symlink; always preferred when available
+    so the operator's system default is honoured."""
+    with patch.object(
+        shutil, "which",
+        side_effect=lambda name: f"/usr/bin/{name}" if name == "c++" else None,
+    ):
+        assert _detect_cxx_compiler() == "c++"
+
+
+def test_detection_falls_back_to_g_plus_plus():
+    """``c++`` missing, ``g++`` present → ``g++``."""
+    with patch.object(
+        shutil, "which",
+        side_effect=lambda name: f"/usr/bin/{name}" if name == "g++" else None,
+    ):
+        assert _detect_cxx_compiler() == "g++"
+
+
+def test_detection_falls_back_to_clang_plus_plus():
+    """``c++`` and ``g++`` missing, ``clang++`` present → ``clang++``."""
+    with patch.object(
+        shutil, "which",
+        side_effect=lambda name: f"/usr/bin/{name}" if name == "clang++" else None,
+    ):
+        assert _detect_cxx_compiler() == "clang++"
+
+
+def test_detection_raises_when_nothing_available():
+    """No compiler on PATH → RuntimeError with actionable message."""
+    with patch.object(shutil, "which", return_value=None):
+        with pytest.raises(RuntimeError) as excinfo:
+            _detect_cxx_compiler()
+    msg = str(excinfo.value)
+    assert "c++" in msg
+    assert "g++" in msg
+    assert "clang++" in msg
+
+
+def test_validator_surfaces_missing_compiler_as_validation_result(tmp_path):
+    """When no compiler is installed, ``validate_exploit`` returns a
+    ValidationResult with ``success=False`` rather than raising — so
+    the caller's witness/intent flow keeps running."""
+    v = ExploitValidator(work_dir=tmp_path)
+    with patch.object(shutil, "which", return_value=None):
+        result = v.validate_exploit(
+            "int main(void){return 0;}", "nocompiler",
+        )
+    assert result.success is False
+    assert any("no c++ compiler" in e.lower()
+               for e in result.compilation_errors)
+
+
+# ----------------------------------------------------------------------
+# Real compile paths
+# ----------------------------------------------------------------------
+
+
+_C_SOURCE = """
+#include <stdio.h>
+int main(void) {
+    puts("c source");
+    return 0;
+}
+"""
+
+
+_CPP_SOURCE = """
+#include <iostream>
+int main() {
+    std::cout << "cpp source" << std::endl;
+    return 0;
+}
+"""
+
+
+def test_c_source_compiles_via_detected_compiler(tmp_path):
+    """C source (the gcc-style PoC the validator used to handle)
+    still compiles through the c++/g++ path."""
+    v = ExploitValidator(work_dir=tmp_path)
+    result = v.validate_exploit(_C_SOURCE, "c-source")
+    assert result.success is True, (
+        f"compile errors: {result.compilation_errors}"
+    )
+    assert result.exploit_path is not None
+    assert result.exploit_path.is_file()
+
+
+def test_cpp_source_compiles_via_detected_compiler(tmp_path):
+    """C++ source with ``<iostream>`` — the case the gcc-only path
+    failed on. Must now succeed because we use c++/g++/clang++."""
+    v = ExploitValidator(work_dir=tmp_path)
+    result = v.validate_exploit(_CPP_SOURCE, "cpp-source")
+    assert result.success is True, (
+        f"compile errors: {result.compilation_errors}"
+    )
+    assert result.exploit_path is not None
+    assert result.exploit_path.is_file()
+
+    # Sanity: produced binary runs and produces expected output
+    proc = subprocess.run(
+        [str(result.exploit_path)],
+        capture_output=True, text=True, timeout=5,
+    )
+    assert proc.returncode == 0
+    assert "cpp source" in proc.stdout
+
+
+def test_cpp_source_with_sanitizer_compiles_and_runs(tmp_path):
+    """Critical case: C++ source + ``sanitizers=['address']`` must
+    flow through cleanly. This is exactly the operator-facing path
+    that surfaced the original gcc-vs-g++ gap."""
+    if not _has_libasan():
+        pytest.skip("libasan not usable on this host")
+
+    bof_cpp = """
+#include <cstring>
+#include <iostream>
+int main() {
+    char buf[8];
+    const char *src = "AAAAAAAAAAAAAAAAAAAA";
+    strcpy(buf, src);
+    std::cout << buf << std::endl;
+    return 0;
+}
+"""
+    v = ExploitValidator(work_dir=tmp_path)
+    result = v.validate_exploit(
+        bof_cpp, "cpp-bof", sanitizers=["address"],
+    )
+    assert result.success is True, (
+        f"compile errors: {result.compilation_errors}"
+    )
+
+    # Run and check ASAN fires
+    proc = subprocess.run(
+        [str(result.exploit_path)],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert proc.returncode != 0
+    assert "AddressSanitizer" in proc.stderr
+    assert "stack-buffer-overflow" in proc.stderr
+
+
+# ----------------------------------------------------------------------
+# Source file extension
+# ----------------------------------------------------------------------
+
+
+def test_source_written_with_cpp_extension(tmp_path):
+    """The on-disk source uses ``.cpp`` so the C++ compiler treats
+    it as C++. Surface this so future contributors don't switch
+    back to ``.c`` and silently re-introduce the iostream problem."""
+    v = ExploitValidator(work_dir=tmp_path)
+    v.validate_exploit(_C_SOURCE, "ext-check")
+    cpp_files = list(tmp_path.glob("*.cpp"))
+    c_files = list(tmp_path.glob("*.c"))
+    assert len(cpp_files) == 1
+    assert len(c_files) == 0
+
+
+# ----------------------------------------------------------------------
+# Documented limitations
+# ----------------------------------------------------------------------
+
+
+def test_c_restrict_keyword_documented_to_fail(tmp_path):
+    """``restrict`` is a C-only keyword; g++ / clang++ in C++ mode
+    reject it. We deliberately accepted this in the design — PoC
+    code almost never uses ``restrict``. Pin the failure mode so
+    a future contributor doesn't see it in the wild and think it's
+    a regression of compiler detection."""
+    src = """
+#include <string.h>
+void copy(char *restrict d, const char *restrict s, int n) {
+    memcpy(d, s, n);
+}
+int main(void) { char buf[8]; copy(buf, "abc", 3); return 0; }
+"""
+    v = ExploitValidator(work_dir=tmp_path)
+    result = v.validate_exploit(src, "restrict-keyword")
+    # Documents the limitation: ``restrict`` is not C++. If a future
+    # change adds language detection + per-language compiler selection,
+    # this test should flip to expect success. Until then it pins the
+    # known-failure case.
+    assert result.success is False
+
+
+def test_python_source_fails_cleanly(tmp_path):
+    """Non-C/C++ source fed to the compile path fails with a
+    structured error rather than crashing. compile_verify's
+    language gate normally prevents this case from reaching the
+    validator; this is the defence-in-depth that catches it
+    if the gate is bypassed."""
+    src = "#!/usr/bin/env python3\nprint('hi')\n"
+    v = ExploitValidator(work_dir=tmp_path)
+    result = v.validate_exploit(src, "python-probe")
+    assert result.success is False
+    assert len(result.compilation_errors) > 0
+
+
+def test_empty_source_fails_cleanly(tmp_path):
+    """Empty source → compile fails (no main), not a crash."""
+    v = ExploitValidator(work_dir=tmp_path)
+    result = v.validate_exploit("", "empty-source")
+    assert result.success is False
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _has_libasan() -> bool:
+    """gcc may be present but libasan missing — quick probe."""
+    cxx = None
+    for candidate in ("c++", "g++", "clang++"):
+        if shutil.which(candidate):
+            cxx = candidate
+            break
+    if cxx is None:
+        return False
+    try:
+        result = subprocess.run(
+            [cxx, "-fsanitize=address", "-x", "c++", "-",
+             "-o", "/dev/null"],
+            input="int main(){return 0;}",
+            text=True, capture_output=True, timeout=10,
+        )
+        return result.returncode == 0
+    except Exception:  # noqa: BLE001
+        return False

--- a/packages/llm_analysis/crash_agent.py
+++ b/packages/llm_analysis/crash_agent.py
@@ -199,7 +199,7 @@ The exploit should:
 2. Send the exact crashing input bytes via stdin or a file
 3. Demonstrate that the vulnerability is triggered
 
-The "code" field must contain complete, compilable C++ code only.
+The "code" field must contain complete, compilable C or C++ code.
 The "reasoning" field can contain explanations and analysis."""
 
 
@@ -214,11 +214,15 @@ The exploit must:
 4. Include full logging and visible terminal output showing the exploit in action
 
 Respond with valid JSON containing exactly these fields:
-- "code": The complete, compilable C++ exploit code as a string
+- "code": The complete, compilable C or C++ exploit code as a string
 - "reasoning": Any reasoning or explanation about the exploit technique
 
-The "code" field must contain ONLY valid C++ code that can be compiled with:
-g++ -o exploit exploit.cpp -fno-stack-protector"""
+The "code" field must contain valid C or C++ that the platform's
+default C++ compiler (``c++``, resolving to g++ on Linux, clang++ on
+macOS, etc.) can compile from a ``.cpp`` source file. Prefer plain C
+when the target source language is C — the C-style PoC is usually
+shorter and more portable. Either language is acceptable; pick what
+matches the target."""
 
 
 def _build_crash_exploit_bundle(crash_context: CrashContext) -> PromptBundle:


### PR DESCRIPTION
ExploitValidator.validate_exploit was hard-coded to invoke ``gcc``, which broke two real cases:

  1. Operator systems without gcc installed (e.g. macOS Xcode CLT gives clang + symlinks, not real gcc) — every compile failed.
  2. LLM-emitted C++ exploits — the crash-analysis system prompt mandated "C++ only" but gcc couldn't compile ``#include <iostream>``. Every LLM exploit emit failed with ``iostream: No such file or directory`` regardless of how well the LLM understood the crash. Verified against Gemini 2.5 Pro twice.

Now detects an available C++ compiler in POSIX-first order: ``c++`` > ``g++`` > ``clang++``. ``c++`` is the standard symlink that resolves to the operator's system default (g++ on Debian, clang++ on macOS), so the operator's choice is honoured without our needing to second-guess.

Source extension switches from ``.c`` to ``.cpp`` so the C++ compiler unambiguously treats the source as C++. C source still compiles fine through this path (C is mostly a subset of C++); the handful of C-specific keywords that don't translate (``restrict``, ``_Generic``) are vanishingly rare in PoC code and are pinned by an explicit known-failure test so they're not mistaken for a regression of compiler detection.

The crash-analysis system prompt at crash_agent.py:202 is loosened from "C++ only" to "C or C++" — picking C when the target source is C produces a shorter, more portable PoC; C++ is fine when the target's a C++ codebase.

Missing-compiler errors surface as a structured ValidationResult (``success=False``, compilation_errors=["no c++ compiler found on PATH..."]) rather than RuntimeError — caller's witness / intent flow keeps running.

Tests (12 new):
- Detection order, fallback chain, RuntimeError → ValidationResult surfacing.
- C source compiles via detected compiler.
- C++ source with ``<iostream>`` compiles.
- C++ + ``-fsanitize=address`` BOF: produced binary actually fires ASAN's stack-buffer-overflow detection (end-to-end).
- ``.cpp`` extension regression guard.
- ``restrict`` keyword known-failure pin (documents the C-only-construct limitation).
- Python source + empty source fail cleanly without crashing.