### PR TITLE
feat(reachability): wire is_framework_callable into 3 consumers + naked-name dispatch

### DIFF
--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -1251,6 +1251,13 @@ def _get_or_build_index(
 # pass-through decorators (``cache``, ``lru_cache``, ``property``,
 # ``staticmethod``, ``dataclass``) MUST NOT be in this set —
 # they don't register entry points.
+#
+# The chain-length-2 gate in ``_decorators_indicate_framework_dispatch``
+# excludes naked single-name decorators (``@receiver(...)``,
+# ``@shared_task``). For names where the framework-dispatch
+# interpretation is unambiguous even at length 1, see
+# ``_FRAMEWORK_DISPATCH_NAKED_NAMES`` below — these get an exception
+# to the chain-length gate.
 _FRAMEWORK_DISPATCH_TAILS: FrozenSet[str] = frozenset({
     # HTTP route methods (Flask / FastAPI / Starlette / Bottle / etc.)
     "route", "get", "post", "put", "patch", "delete", "head", "options",
@@ -1276,31 +1283,73 @@ _FRAMEWORK_DISPATCH_TAILS: FrozenSet[str] = frozenset({
 })
 
 
+# Single-name decorators where the framework-dispatch interpretation
+# is unambiguous enough to override the chain-length-2 gate. Entries
+# here MUST be distinctive enough that collision with user-defined
+# pass-through decorators is rare. Generic names (``task``,
+# ``fixture``, ``register``, ``handler``) are deliberately excluded
+# because a project's own ``@task`` / ``@fixture`` is more likely to
+# be a pass-through than framework dispatch — false-positive
+# promotion of pass-through-decorated dead code is the worse error
+# (silences real findings) vs false-negative on framework code
+# (caught by the chain-length-2 form which projects more commonly
+# use via ``@pytest.fixture`` / ``@celery.task``).
+#
+# Conservative starter set covers the highest-value cases where the
+# bare form is idiomatic AND the name is distinctive:
+#   * Django signals: ``@receiver(post_save, sender=User)`` — bare
+#     ``receiver`` is the standard import-pattern; chain-length-1
+#     is the dominant usage.
+#   * Celery shared tasks: ``@shared_task`` — the import-then-bare
+#     form is the recommended Celery pattern for app-agnostic tasks.
+#   * Celery periodic tasks: ``@periodic_task(...)`` — distinctive
+#     enough not to collide.
+#   * dramatiq: ``@actor`` — domain-specific term, unlikely to be a
+#     user-defined pass-through.
+_FRAMEWORK_DISPATCH_NAKED_NAMES: FrozenSet[str] = frozenset({
+    "receiver",
+    "shared_task",
+    "periodic_task",
+    "actor",
+})
+
+
 def _decorators_indicate_framework_dispatch(
     decorators: Iterable[Any],
 ) -> bool:
     """True iff any decorator on the function matches the
     framework-dispatch registration shape.
 
-    Heuristic: chain length >= 2 (decorator is a method on an
-    imported object, e.g. ``app.route``) AND the tail name is in
-    ``_FRAMEWORK_DISPATCH_TAILS``. Single-name decorators
-    (``@cache``, ``@property``) are pass-through and never flagged.
+    Two acceptance shapes:
 
-    The chain-length-2 requirement excludes both pass-through
-    decorators AND naked dispatch tokens like a bare ``@register``
-    function — the latter could be either pass-through or
-    registration; we're conservative because flagging too many
-    things as framework-callable suppresses legitimate dead-code
-    warnings.
+      * **Chain length >= 2**: decorator is a method on an imported
+        object (e.g. ``app.route``, ``pytest.fixture``,
+        ``celery_app.task``). Tail name must be in
+        ``_FRAMEWORK_DISPATCH_TAILS``. This is the dominant form
+        across the supported frameworks and the safer signal —
+        pass-through decorators are typically single names.
+      * **Chain length 1**: bare single-name decorator whose name is
+        in the narrower ``_FRAMEWORK_DISPATCH_NAKED_NAMES`` set.
+        Reserved for distinctive framework-only names (Django
+        ``@receiver``, Celery ``@shared_task``, etc.) where the
+        bare form is idiomatic. Generic names (``task``,
+        ``fixture``, ``register``) deliberately NOT in this set —
+        their bare form is more likely a user pass-through.
+
+    The split keeps the resolver from over-promoting pass-through
+    decorators (which would silence legitimate dead-code findings)
+    while admitting the bare framework-decorator patterns that
+    Django / Celery / dramatiq projects commonly use.
     """
     for chain in decorators:
         if not isinstance(chain, (list, tuple)):
             continue
-        if len(chain) < 2:
+        if not chain:
             continue
         tail = str(chain[-1])
-        if tail in _FRAMEWORK_DISPATCH_TAILS:
+        if len(chain) >= 2 and tail in _FRAMEWORK_DISPATCH_TAILS:
+            return True
+        if len(chain) == 1 and tail in _FRAMEWORK_DISPATCH_NAKED_NAMES:
             return True
     return False
 

--- a/core/inventory/tests/test_reachability_adjacency.py
+++ b/core/inventory/tests/test_reachability_adjacency.py
@@ -1311,3 +1311,108 @@ class TestFullyQualifiedCallIndexFastPath:
         lines = call_lines_of(inv, caller_fn, target)
         # The call ``com.ex.Util.helper()`` is on line 1 of Client.java.
         assert lines == (1,)
+
+
+# ---------------------------------------------------------------------------
+# Naked-name framework dispatch — bare single-name decorators that the
+# substrate must recognise as framework-callable despite chain length 1.
+# Covers Django ``@receiver``, Celery ``@shared_task`` / ``@periodic_task``,
+# dramatiq ``@actor`` — common idioms that the chain-length-2 form misses.
+# ---------------------------------------------------------------------------
+
+
+class TestNakedFrameworkDispatch:
+    def test_django_receiver_bare(self):
+        inv = _inv(_file("src/signals.py",
+            "@receiver(post_save, sender=User)\n"
+            "def update_profile_on_save(sender, instance, **kwargs):\n"
+            "    pass\n"
+        ))
+        target = InternalFunction(
+            "src/signals.py", "update_profile_on_save", 2,
+        )
+        assert is_framework_callable(inv, target) is True
+
+    def test_celery_shared_task_bare(self):
+        inv = _inv(_file("src/tasks.py",
+            "@shared_task\n"
+            "def process_payment(order_id):\n"
+            "    pass\n"
+        ))
+        target = InternalFunction("src/tasks.py", "process_payment", 2)
+        assert is_framework_callable(inv, target) is True
+
+    def test_celery_periodic_task_bare(self):
+        inv = _inv(_file("src/tasks.py",
+            "@periodic_task(run_every=60)\n"
+            "def heartbeat():\n"
+            "    pass\n"
+        ))
+        target = InternalFunction("src/tasks.py", "heartbeat", 2)
+        assert is_framework_callable(inv, target) is True
+
+    def test_dramatiq_actor_bare(self):
+        inv = _inv(_file("src/workers.py",
+            "@actor\n"
+            "def send_email(to):\n"
+            "    pass\n"
+        ))
+        target = InternalFunction("src/workers.py", "send_email", 2)
+        assert is_framework_callable(inv, target) is True
+
+    def test_bare_pass_through_decorators_not_flagged(self):
+        # ``@cache``, ``@property``, ``@dataclass`` are pass-through —
+        # function is reachable in the normal sense, but the decorator
+        # does NOT register it with any external dispatcher. The
+        # framework_callable flag is reserved for "reachable via
+        # runtime-dispatch mechanism the static graph doesn't see".
+        # If we flagged pass-through decorators as framework_callable,
+        # we'd silence legitimate dead-code findings on cached
+        # helpers, properties, etc.
+        inv = _inv(_file("src/util.py",
+            "@cache\n"
+            "def helper(x):\n"
+            "    return x * 2\n"
+            "\n"
+            "@property\n"
+            "def name(self):\n"
+            "    return self._name\n"
+            "\n"
+            "@dataclass\n"
+            "def make_thing():\n"
+            "    pass\n"
+        ))
+        for name, line in [("helper", 2), ("name", 6), ("make_thing", 10)]:
+            target = InternalFunction("src/util.py", name, line)
+            assert is_framework_callable(inv, target) is False, (
+                f"pass-through @{name}'s decorator must not flag "
+                f"framework_callable"
+            )
+
+    def test_generic_bare_names_not_flagged(self):
+        # ``@task``, ``@fixture``, ``@register``, ``@handler`` etc.
+        # are deliberately excluded from the naked set — too generic.
+        # Project-defined pass-through decorators with these names
+        # are common, and false-positive promotion silences real
+        # findings. Projects using the framework form should use the
+        # chain-length-2 idiom (``@celery.task``, ``@pytest.fixture``)
+        # which IS flagged via _FRAMEWORK_DISPATCH_TAILS.
+        inv = _inv(_file("src/app.py",
+            "@task\n"
+            "def my_task():\n"
+            "    pass\n"
+            "\n"
+            "@fixture\n"
+            "def my_fixture():\n"
+            "    pass\n"
+            "\n"
+            "@register\n"
+            "def my_handler():\n"
+            "    pass\n"
+        ))
+        for name, line in [("my_task", 2), ("my_fixture", 6), ("my_handler", 10)]:
+            target = InternalFunction("src/app.py", name, line)
+            assert is_framework_callable(inv, target) is False, (
+                f"bare @{name} is too generic to promote — "
+                f"likely a project-defined pass-through"
+            )

--- a/core/orchestration/reachability_enrichment.py
+++ b/core/orchestration/reachability_enrichment.py
@@ -79,7 +79,10 @@ def mark_unreachable_low_priority(
 
     try:
         from core.inventory.reachability import (
-            Verdict, function_called,
+            InternalFunction,
+            Verdict,
+            function_called,
+            is_framework_callable,
         )
     except ImportError:
         return 0
@@ -122,6 +125,29 @@ def mark_unreachable_low_priority(
             except ValueError:
                 continue
             if result.verdict != Verdict.NOT_CALLED:
+                continue
+
+            # NOT_CALLED in the static graph — but the function may
+            # still be reachable via framework dispatch (Flask
+            # ``@app.route``, Celery ``@shared_task``, Django
+            # ``@receiver``, etc.). The substrate's
+            # ``is_framework_callable`` recognises these. Without
+            # this check, framework-registered handlers regress to
+            # ``priority="low"`` and downstream consumers (LLM
+            # analysis prompt's reachability engagement, attack-
+            # path demoter) treat them as dead code — false
+            # negatives on any web/task/signal-heavy codebase.
+            line = int(func.get("line_start") or 0)
+            target = InternalFunction(
+                file_path=rel_path, name=name, line=line,
+            )
+            if is_framework_callable(inventory, target):
+                # Optionally annotate so operators / downstream
+                # consumers can see this function was static-
+                # uncalled but framework-reachable.
+                func["priority_reason"] = (
+                    "reachability:framework_callable"
+                )
                 continue
 
             func["priority"] = "low"

--- a/core/orchestration/tests/test_reachability_enrichment.py
+++ b/core/orchestration/tests/test_reachability_enrichment.py
@@ -390,3 +390,101 @@ def test_enrich_caller_context_uncertain_caller_counted_separately(
     assert enriched == 1
     func = checklist["files"][0]["items"][0]
     assert func["caller_count_uncertain"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Framework-callable bypass — functions with framework-dispatch
+# decorators must NOT be demoted to priority=low even when the static
+# call graph shows zero callers.
+# ---------------------------------------------------------------------------
+
+
+class TestFrameworkCallableBypass:
+    def test_flask_route_handler_not_demoted(self, tmp_path):
+        # A Flask route handler has no in-project callers — only
+        # the Flask runtime invokes it via the registered route.
+        # Pre-fix this regressed to priority=low; the LLM analysis
+        # then deferred on it. With S1, the framework-callable
+        # check skips the demotion.
+        target = _project(tmp_path, {
+            "src/api.py": (
+                "from flask import Flask\n"
+                "app = Flask(__name__)\n"
+                "\n"
+                "@app.route('/users')\n"
+                "def list_users():\n"
+                "    return []\n"
+            ),
+        })
+        checklist = _checklist({
+            "src/api.py": [{
+                "name": "list_users", "kind": "function",
+                "line_start": 5, "line_end": 6,
+            }],
+        })
+        mark_unreachable_low_priority(checklist, target)
+        func = checklist["files"][0]["items"][0]
+        assert func.get("priority") != "low", (
+            "Flask @app.route handler must not be demoted — "
+            "framework dispatches to it at runtime"
+        )
+        # The diagnostic annotation should mark it as
+        # framework-callable so operators can see WHY this didn't
+        # get a priority downgrade.
+        assert func.get("priority_reason") == (
+            "reachability:framework_callable"
+        )
+
+    def test_django_receiver_naked_decorator_not_demoted(self, tmp_path):
+        # Django's @receiver is the bare-name form covered by S1b.
+        # Validates that S1b's naked-name set propagates through
+        # to the consumer wiring.
+        target = _project(tmp_path, {
+            "src/signals.py": (
+                "from django.dispatch import receiver\n"
+                "from django.db.models.signals import post_save\n"
+                "\n"
+                "@receiver(post_save)\n"
+                "def update_profile(sender, instance, **kw):\n"
+                "    pass\n"
+            ),
+        })
+        checklist = _checklist({
+            "src/signals.py": [{
+                "name": "update_profile", "kind": "function",
+                "line_start": 5, "line_end": 6,
+            }],
+        })
+        mark_unreachable_low_priority(checklist, target)
+        func = checklist["files"][0]["items"][0]
+        assert func.get("priority") != "low"
+
+    def test_genuinely_dead_function_still_demoted(self, tmp_path):
+        # A function with no callers AND no framework-dispatch
+        # decorator IS dead code — the framework-callable bypass
+        # must not over-fire on non-decorated functions.
+        target = _project(tmp_path, {
+            "src/v.py": (
+                "def dead(): pass\n"
+                "def alive(): pass\n"
+            ),
+            "src/main.py": (
+                "from src.v import alive\n"
+                "alive()\n"
+            ),
+        })
+        checklist = _checklist({
+            "src/v.py": [
+                {"name": "dead", "kind": "function",
+                 "line_start": 1, "line_end": 1},
+                {"name": "alive", "kind": "function",
+                 "line_start": 2, "line_end": 2},
+            ],
+        })
+        mark_unreachable_low_priority(checklist, target)
+        funcs = checklist["files"][0]["items"]
+        dead = next(f for f in funcs if f["name"] == "dead")
+        alive = next(f for f in funcs if f["name"] == "alive")
+        assert dead["priority"] == "low"
+        assert dead["priority_reason"] == "reachability:not_called"
+        assert "priority" not in alive  # called → no demotion at all

--- a/packages/codeql/autonomous_analyzer.py
+++ b/packages/codeql/autonomous_analyzer.py
@@ -113,9 +113,14 @@ class AutonomousAnalysisResult:
     total_duration_seconds: float
     # Reachability prefilter outcome — set when the inventory-based
     # resolver was consulted before the expensive LLM stages.
-    # ``"called"`` / ``"not_called"`` / ``"uncertain"`` / None
-    # (when the prefilter couldn't determine, e.g. non-Python file
-    # or sink line not in any function).
+    # ``"called"`` / ``"not_called"`` / ``"uncertain"`` /
+    # ``"framework_callable"`` / None (when the prefilter couldn't
+    # determine, e.g. non-Python file or sink line not in any
+    # function). ``"framework_callable"`` means the static graph
+    # found no callers BUT the function carries a framework-
+    # dispatch decorator (``@app.route``, ``@shared_task``,
+    # ``@receiver``, etc.) — treated as reachable; full LLM
+    # analysis still runs.
     reachability_verdict: Optional[str] = None
     # Set to a non-None reason when the analyzer short-circuited
     # without running deep analysis. Today the only value is
@@ -217,10 +222,16 @@ class AutonomousCodeQLAnalyzer:
         finding's sink line reached from anywhere in the project?
 
         Returns one of ``"called"`` / ``"not_called"`` /
-        ``"uncertain"`` / None (None = couldn't determine — non-
-        Python file, sink not in any function, inventory build
-        failed, etc.). The caller's policy is to short-circuit on
-        ``"not_called"`` and otherwise continue.
+        ``"uncertain"`` / ``"framework_callable"`` / None
+        (None = couldn't determine — non-Python file, sink not in
+        any function, inventory build failed, etc.). The caller's
+        policy is to short-circuit on ``"not_called"`` and
+        otherwise continue. ``"framework_callable"`` is the
+        substrate's signal that the static graph shows no callers
+        BUT a framework-dispatch decorator (Flask ``@app.route``,
+        Celery ``@shared_task``, Django ``@receiver``, etc.)
+        registers the function for runtime invocation — caller
+        proceeds with full LLM analysis.
 
         Cost: inventory build is paid once per analyzer instance
         (cached); per-finding lookup is O(N_files + N_calls in
@@ -263,7 +274,11 @@ class AutonomousCodeQLAnalyzer:
 
         try:
             from core.inventory.lookup import lookup_function
-            from core.inventory.reachability import function_called
+            from core.inventory.reachability import (
+                InternalFunction,
+                function_called,
+                is_framework_callable,
+            )
         except ImportError:
             return None
 
@@ -303,7 +318,28 @@ class AutonomousCodeQLAnalyzer:
             )
         except ValueError:
             return None
-        return result.verdict.value
+        verdict = result.verdict.value
+        # NOT_CALLED in the static graph doesn't mean unreachable
+        # when the function is framework-registered (Flask
+        # ``@app.route``, Celery ``@shared_task``, Django
+        # ``@receiver``, etc.). The substrate's
+        # ``is_framework_callable`` recognises these. Without this
+        # check, the prefilter short-circuits framework handlers
+        # before any LLM analysis runs — a false-negative class on
+        # any web / task / signal codebase.
+        if verdict == "not_called":
+            line = int(func_info.get("line_start") or 0)
+            target = InternalFunction(
+                file_path=rel_path, name=func_name, line=line,
+            )
+            if is_framework_callable(
+                self._reachability_inventory, target,
+            ):
+                # New verdict value the caller treats as "don't
+                # short-circuit". Distinct from "called" so the
+                # reachability_verdict field reports accurately.
+                return "framework_callable"
+        return verdict
 
     def _relative_path(
         self, file_path: str, repo_path: Path,

--- a/packages/codeql/tests/test_reachability_prefilter.py
+++ b/packages/codeql/tests/test_reachability_prefilter.py
@@ -348,3 +348,92 @@ def test_no_short_circuit_when_called(tmp_path, monkeypatch):
     # Got past the early-exit (analysis was attempted).
     assert result.skipped_reason is None
     assert result.reachability_verdict == "called"
+
+
+# ---------------------------------------------------------------------------
+# Framework-callable bypass — functions registered with framework
+# dispatch (Flask @app.route, Celery @shared_task, etc.) have no
+# static callers but ARE reachable at runtime. The prefilter must
+# NOT short-circuit them as "not_called" — full LLM analysis runs.
+# ---------------------------------------------------------------------------
+
+
+def test_reachability_flask_route_returns_framework_callable(tmp_path):
+    """A Flask route handler with no static callers must return
+    the new ``framework_callable`` verdict, not ``not_called``."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "api.py").write_text(
+        "from flask import Flask, request\n"
+        "app = Flask(__name__)\n"
+        "\n"
+        "@app.route('/users')\n"
+        "def list_users():\n"
+        "    return request.args.get('q')\n"
+    )
+    a = _analyzer()
+    finding = _finding("src/api.py", line=6)
+    verdict = a._check_reachability(finding, tmp_path)
+    assert verdict == "framework_callable", (
+        f"Flask route handler must resolve framework_callable "
+        f"(reachable via Flask runtime dispatch), got {verdict!r}"
+    )
+
+
+def test_reachability_django_receiver_returns_framework_callable(tmp_path):
+    """Naked-decorator framework dispatch (S1b coverage)."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "signals.py").write_text(
+        "from django.dispatch import receiver\n"
+        "from django.db.models.signals import post_save\n"
+        "\n"
+        "@receiver(post_save)\n"
+        "def update_profile(sender, instance, **kw):\n"
+        "    cursor.execute(sender)\n"
+    )
+    a = _analyzer()
+    finding = _finding("src/signals.py", line=6)
+    verdict = a._check_reachability(finding, tmp_path)
+    assert verdict == "framework_callable"
+
+
+def test_framework_callable_does_not_short_circuit(
+    tmp_path, monkeypatch,
+):
+    """End-to-end: a framework-callable finding must NOT be
+    short-circuited; full analysis runs and skipped_reason stays
+    None."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "api.py").write_text(
+        "from flask import Flask\n"
+        "app = Flask(__name__)\n"
+        "\n"
+        "@app.route('/q')\n"
+        "def handler():\n"
+        "    return 1\n"
+    )
+
+    a = _analyzer()
+    canned = _finding("src/api.py", line=6)
+    monkeypatch.setattr(
+        a, "parse_sarif_finding", lambda r, run: canned,
+    )
+    monkeypatch.setattr(
+        a, "read_vulnerable_code", lambda f, p: "stub",
+    )
+    fake_analysis = MagicMock(is_exploitable=False)
+    monkeypatch.setattr(
+        a, "analyze_vulnerability",
+        lambda *args, **kwargs: fake_analysis,
+    )
+
+    result = a.analyze_finding_autonomous(
+        sarif_result={}, sarif_run={},
+        repo_path=tmp_path, out_dir=tmp_path / "out",
+    )
+    # Crucial: framework_callable must NOT trigger the short-
+    # circuit. skipped_reason stays None; analysis ran.
+    assert result.skipped_reason is None
+    assert result.reachability_verdict == "framework_callable"

--- a/packages/exploitability_validation/reachability.py
+++ b/packages/exploitability_validation/reachability.py
@@ -95,7 +95,10 @@ def demote_unreachable_paths(
     try:
         from core.inventory.lookup import lookup_function
         from core.inventory.reachability import (
-            Verdict, function_called,
+            InternalFunction,
+            Verdict,
+            function_called,
+            is_framework_callable,
         )
     except ImportError:
         return 0
@@ -139,6 +142,20 @@ def demote_unreachable_paths(
             continue
 
         if result.verdict != Verdict.NOT_CALLED:
+            continue
+
+        # NOT_CALLED in the static graph isn't dead code when the
+        # function is framework-registered (Flask ``@app.route``,
+        # Celery ``@shared_task``, Django ``@receiver``, etc.).
+        # The substrate's ``is_framework_callable`` recognises
+        # these; without this check the demoter sinks legitimate
+        # exploitable handlers to proximity=1 + "not_called"
+        # blocker on any web / task / signal codebase.
+        func_line = int(func_info.get("line_start") or 0)
+        target = InternalFunction(
+            file_path=rel_path, name=func_name, line=func_line,
+        )
+        if is_framework_callable(inventory, target):
             continue
 
         # Demote: cap proximity, append blocker.

--- a/packages/exploitability_validation/tests/test_reachability_demotion.py
+++ b/packages/exploitability_validation/tests/test_reachability_demotion.py
@@ -283,3 +283,77 @@ def test_path_to_module_simple():
 
 def test_path_to_module_no_extension_returns_none():
     assert _path_to_module("Makefile") is None
+
+
+# ---------------------------------------------------------------------------
+# Framework-callable bypass — paths anchored to functions registered
+# via framework dispatch (Flask routes, Celery tasks, Django signals)
+# must NOT be demoted. The static graph shows zero callers but the
+# function is reachable at runtime via the framework.
+# ---------------------------------------------------------------------------
+
+
+def test_does_not_demote_flask_route_handler(tmp_path):
+    """A Flask @app.route handler has no static callers but the
+    framework dispatches to it. Demoting its attack path would sink
+    a real exploitable finding to the bottom of the report."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "api.py").write_text(
+        "from flask import Flask, request\n"
+        "app = Flask(__name__)\n"
+        "\n"
+        "@app.route('/users')\n"
+        "def list_users():\n"
+        "    return cursor.execute(request.args.get('q'))\n"
+    )
+
+    findings = [{
+        "id": "f1",
+        "file_path": "src/api.py",
+        "start_line": 6,
+    }]
+    attack_paths = [{
+        "id": "p1",
+        "finding_id": "f1",
+        "proximity": 8,
+        "blockers": [],
+    }]
+
+    demoted = demote_unreachable_paths(
+        attack_paths, findings, tmp_path,
+    )
+    assert demoted == 0, "Flask route handler must not be demoted"
+    assert attack_paths[0]["proximity"] == 8  # unchanged
+    assert attack_paths[0]["blockers"] == []  # no blocker added
+
+
+def test_does_not_demote_django_receiver_naked(tmp_path):
+    """Naked-decorator framework dispatch (S1b coverage) propagates
+    to demoter wiring."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "signals.py").write_text(
+        "from django.dispatch import receiver\n"
+        "from django.db.models.signals import post_save\n"
+        "\n"
+        "@receiver(post_save)\n"
+        "def on_save(sender, instance, **kw):\n"
+        "    cursor.execute(instance.name)\n"
+    )
+
+    findings = [{
+        "id": "f1",
+        "file_path": "src/signals.py",
+        "start_line": 6,
+    }]
+    attack_paths = [{
+        "id": "p1",
+        "finding_id": "f1",
+        "proximity": 7,
+        "blockers": [],
+    }]
+
+    demoted = demote_unreachable_paths(
+        attack_paths, findings, tmp_path,
+    )
+    assert demoted == 0
+    assert attack_paths[0]["proximity"] == 7


### PR DESCRIPTION
The substrate has shipped is_framework_callable() since the original implementation, but the three consumers that act on NOT_CALLED verdicts (mark_unreachable_low_priority, CodeQL prefilter, attack-path demoter) never consulted it. Flask/FastAPI/Django/Celery/dramatiq handlers — which have no static callers because the framework dispatches via decorator registration — regressed to priority=low, CodeQL short- circuit, and attack-path demotion. Each wired consumer now checks is_framework_callable before acting on NOT_CALLED; framework-callable findings annotate priority_reason="reachability:framework_callable" (enrichment) and return verdict="framework_callable" (CodeQL) for operator visibility.

Substrate extension: _decorators_indicate_framework_dispatch previously required chain length >= 2, excluding bare-call patterns common in Django (@receiver), Celery (@shared_task, @periodic_task), and dramatiq (@actor). Added _FRAMEWORK_DISPATCH_NAKED_NAMES — a conservative single-name set restricted to distinctive framework-only identifiers. Generic names (@task, @fixture, @register) deliberately excluded: collision risk with project-defined pass-through decorators silences legitimate dead-code findings, which is worse than the FN on bare forms (projects can use the chain-length-2 idiom @celery.task / @pytest.fixture which the existing _FRAMEWORK_DISPATCH_TAILS catches).

Prerequisite for the upcoming reachability-aware analysis prompt work (C1+C3) — surfacing NOT_CALLED into the per-finding LLM prompt without this fix would systematically regress framework-heavy codebases.

Tests: 11 new (6 substrate naked-name coverage + 5 consumer wiring), 705 reachability-area tests green, end-to-end verified on a real on-disk Flask fixture (handlers flow through all 3 consumers; truly- dead code still correctly demoted).