### PR TITLE
ci: defensive jq for null-files iteration in tests + codeql change-detection

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -127,17 +127,22 @@ jobs:
           set -euo pipefail
           out=/tmp/changed_files.txt
           : > "$out"
+          # ``--jq`` expressions use ``?`` + ``// []`` to suppress jq's
+          # ``cannot iterate over: null`` error on diffs the API
+          # truncates or returns as an error object (compare API caps
+          # at 300 files; past that ``.files`` is omitted entirely).
+          # No list → compute_filters forces all filters true.
           case "$EVENT" in
             pull_request|pull_request_target)
               gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
-                --jq '.[].filename' >> "$out"
+                --jq '(. // [])[]?.filename' >> "$out"
               ;;
             push)
               if [[ "$BEFORE" == "0000000000000000000000000000000000000000" ]]; then
                 rm -f "$out"
               else
                 gh api --paginate "repos/${REPO}/compare/${BEFORE}...${AFTER}" \
-                  --jq '.files[].filename' >> "$out"
+                  --jq '(.files // [])[]?.filename' >> "$out"
               fi
               ;;
             *)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,11 +131,20 @@ jobs:
           set -euo pipefail
           out=/tmp/changed_files.txt
           : > "$out"
+          # ``--jq`` expressions use ``?`` + ``// []`` to suppress jq's
+          # ``cannot iterate over: null`` error on diffs the API
+          # truncates or returns as an error object:
+          #   * compare API caps at 300 files; past that ``.files`` is
+          #     omitted entirely (null on access).
+          #   * pulls/{n}/files can return an error object (non-array)
+          #     for very large PRs or transient API failures.
+          # We treat "no list" the same as the first-push case: fall
+          # through to compute_filters and force all filters true.
           case "$EVENT" in
             pull_request|pull_request_target)
               gh api --paginate \
                 "repos/${REPO}/pulls/${PR_NUMBER}/files" \
-                --jq '.[].filename' >> "$out"
+                --jq '(. // [])[]?.filename' >> "$out"
               ;;
             push)
               if [[ "$BEFORE" == "0000000000000000000000000000000000000000" ]]; then
@@ -145,7 +154,7 @@ jobs:
               else
                 gh api --paginate \
                   "repos/${REPO}/compare/${BEFORE}...${AFTER}" \
-                  --jq '.files[].filename' >> "$out"
+                  --jq '(.files // [])[]?.filename' >> "$out"
               fi
               ;;
             *)


### PR DESCRIPTION
The skip-if-no-changes logic in both workflows queries the GitHub compare / pulls-files API and pipes the response through ``--jq '.files[].filename'`` (push) or ``--jq '.[].filename'`` (PR). For very large diffs the compare API caps at 300 files and omits the ``.files`` field entirely — jq then errors with "cannot iterate over: null" and ``set -euo pipefail`` kills the step. The pulls API can return a non-array error object under the same conditions, breaking the PR case the same way.

Rewrite both jq expressions defensively:

  '(. // [])[]?.filename'          # PR case
  '(.files // [])[]?.filename'     # push case

`// []` substitutes an empty array when the parent is null / missing; `[]?` suppresses any remaining iterate-over-null on non-object children. Net effect: the no-list path falls through to compute_filters.py with an empty list, which forces all filters true (the safe default — analyse everything when the diff isn't introspectable).