### PR TITLE
chore(sca): move dev/CI scripts out of libexec into packages/sca/scripts

### DIFF
--- a/.github/workflows/refit-sca-calibration.yml
+++ b/.github/workflows/refit-sca-calibration.yml
@@ -70,7 +70,7 @@ jobs:
           _RAPTOR_TRUSTED: '1'
         run: |
           set +e
-          libexec/raptor-sca-validate-corpus
+          packages/sca/scripts/raptor-sca-validate-corpus
           # Re-read the report to extract the verdict for gating.
           python <<'EOF' >> "$GITHUB_OUTPUT"
           import json, glob, os, sys

--- a/.github/workflows/refresh-sca-calibration.yml
+++ b/.github/workflows/refresh-sca-calibration.yml
@@ -59,7 +59,7 @@ jobs:
         # PR body can quote them. Exit 0 = at least one source
         # succeeded; exit 1 = every source failed (transient global
         # event, retried at next schedule).
-        run: libexec/raptor-sca-build-corpus -v
+        run: packages/sca/scripts/raptor-sca-build-corpus -v
 
       - name: License-compliance check
         # Defence in depth: enforces the ATTRIBUTION.md cross-
@@ -85,7 +85,7 @@ jobs:
         # exit. Operators read the report directly.
         run: |
           set +e
-          libexec/raptor-sca-validate-corpus
+          packages/sca/scripts/raptor-sca-validate-corpus
           echo "validate exit: $?"
 
       - name: Diff?

--- a/.github/workflows/refresh-sca-project-samples.yml
+++ b/.github/workflows/refresh-sca-project-samples.yml
@@ -65,7 +65,7 @@ jobs:
         # better than no refresh.
         run: |
           set +e
-          libexec/raptor-sca-collect-samples -v
+          packages/sca/scripts/raptor-sca-collect-samples -v
           # Don't propagate the per-sample exit code — partial
           # success still produces a useful diff.
           true
@@ -85,7 +85,7 @@ jobs:
         # unverified / needs_retune) lands in the same auto-PR.
         run: |
           set +e
-          libexec/raptor-sca-validate-corpus
+          packages/sca/scripts/raptor-sca-validate-corpus
           echo "validate exit: $?"
 
       - name: Diff?

--- a/.github/workflows/sca-compromise-check.yml
+++ b/.github/workflows/sca-compromise-check.yml
@@ -1,6 +1,6 @@
 name: SCA compromise-detection check
 
-# Drives ``libexec/raptor-sca-compromise-check`` against the
+# Drives ``packages/sca/scripts/raptor-sca-compromise-check`` against the
 # committed corpus of known supply-chain compromises. Asserts the
 # SCA pipeline still surfaces the expected detection signal(s)
 # for each incident, plus two end-to-end checks:
@@ -39,12 +39,12 @@ on:
       - feat/sca
     paths:
       - 'packages/sca/**'
-      - 'libexec/raptor-sca-compromise-check'
+      - 'packages/sca/scripts/raptor-sca-compromise-check'
       - 'test/data/sca-e2e/compromise-corpus/**'
       - '.github/workflows/sca-compromise-check.yml'
   pull_request:
     paths:
-      - 'libexec/raptor-sca-compromise-check'
+      - 'packages/sca/scripts/raptor-sca-compromise-check'
       - 'test/data/sca-e2e/compromise-corpus/**'
       - 'packages/sca/supply_chain/**'
       - 'packages/sca/findings.py'
@@ -87,9 +87,9 @@ jobs:
         # workflow check. The per-fixture report (which signals
         # matched / missed) is in the run's stdout; operators
         # reproduce a regression locally via:
-        #   libexec/raptor-sca-compromise-check \
+        #   packages/sca/scripts/raptor-sca-compromise-check \
         #     test/data/sca-e2e/compromise-corpus --only <fixture-name>
         run: |
-          libexec/raptor-sca-compromise-check \
+          packages/sca/scripts/raptor-sca-compromise-check \
             test/data/sca-e2e/compromise-corpus \
             --no-offline

--- a/packages/sca/data/calibration/ATTRIBUTION.md
+++ b/packages/sca/data/calibration/ATTRIBUTION.md
@@ -122,7 +122,7 @@ RAPTOR-generated and ships under RAPTOR's MIT license. The projects
 themselves are NOT redistributed — only the scan findings (with
 file paths under the discarded clone tree stripped before storage).
 
-Populated by `libexec/raptor-sca-collect-samples`. The curated
+Populated by `packages/sca/scripts/raptor-sca-collect-samples`. The curated
 project list lives in
 `packages/sca/calibration/project_samples.py::PROJECT_SAMPLES`;
 each entry pins a git ref so re-runs are reproducible. License-
@@ -131,7 +131,7 @@ scan-touch to OSI-permissive projects when operators want to
 constrain the license footprint.
 
 `validation/<date>.json` files (created on demand by
-`libexec/raptor-sca-validate-corpus`) carry top-N precision +
+`packages/sca/scripts/raptor-sca-validate-corpus`) carry top-N precision +
 Spearman correlation metrics computed against the
 ground-truth signals. These are RAPTOR-generated and ship under
 MIT. Each report cites the snapshot date of every ground-truth

--- a/packages/sca/scripts/raptor-sca-build-corpus
+++ b/packages/sca/scripts/raptor-sca-build-corpus
@@ -12,10 +12,10 @@ Exit codes:
 
 Usage:
 
-    libexec/raptor-sca-build-corpus
-    libexec/raptor-sca-build-corpus --out custom/dir
-    libexec/raptor-sca-build-corpus --sources kev,epss
-    libexec/raptor-sca-build-corpus --offline    # skip; for tests
+    packages/sca/scripts/raptor-sca-build-corpus
+    packages/sca/scripts/raptor-sca-build-corpus --out custom/dir
+    packages/sca/scripts/raptor-sca-build-corpus --sources kev,epss
+    packages/sca/scripts/raptor-sca-build-corpus --offline    # skip; for tests
 
 The default output dir is ``packages/sca/data/calibration/`` relative
 to RAPTOR's repo root. Override with ``--out`` for ad-hoc snapshots.
@@ -27,9 +27,12 @@ import argparse
 import sys
 from pathlib import Path
 
-# libexec scripts handle their own path setup; mirror the existing
-# pattern (see libexec/raptor-sca-run for reference).
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+# parents[3] climbs:
+#   [0] scripts/   (this script's directory)
+#   [1] sca/       (the package)
+#   [2] packages/  (the packages root)
+#   [3] <repo root>
+_REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(_REPO_ROOT))
 
 

--- a/packages/sca/scripts/raptor-sca-collect-samples
+++ b/packages/sca/scripts/raptor-sca-collect-samples
@@ -16,9 +16,9 @@ redistributed.
 
 Usage:
 
-    libexec/raptor-sca-collect-samples
-    libexec/raptor-sca-collect-samples --out custom/dir
-    libexec/raptor-sca-collect-samples --only-licenses MIT,Apache-2.0,BSD
+    packages/sca/scripts/raptor-sca-collect-samples
+    packages/sca/scripts/raptor-sca-collect-samples --out custom/dir
+    packages/sca/scripts/raptor-sca-collect-samples --only-licenses MIT,Apache-2.0,BSD
 
 Exit codes:
   0  every sample succeeded
@@ -32,7 +32,12 @@ import argparse
 import sys
 from pathlib import Path
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+# parents[3] climbs:
+#   [0] scripts/   (this script's directory)
+#   [1] sca/       (the package)
+#   [2] packages/  (the packages root)
+#   [3] <repo root>
+_REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(_REPO_ROOT))
 
 

--- a/packages/sca/scripts/raptor-sca-compromise-check
+++ b/packages/sca/scripts/raptor-sca-compromise-check
@@ -43,10 +43,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-# parents[1] climbs:
-#   [0] libexec/  (this script's directory)
-#   [1] <repo root>
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+# parents[3] climbs:
+#   [0] scripts/   (this script's directory)
+#   [1] sca/       (the package)
+#   [2] packages/  (the packages root)
+#   [3] <repo root>
+_REPO_ROOT = Path(__file__).resolve().parents[3]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 

--- a/packages/sca/scripts/raptor-sca-modes-check
+++ b/packages/sca/scripts/raptor-sca-modes-check
@@ -47,10 +47,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-# parents[1] climbs:
-#   [0] libexec/  (this script's directory)
-#   [1] <repo root>
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+# parents[3] climbs:
+#   [0] scripts/   (this script's directory)
+#   [1] sca/       (the package)
+#   [2] packages/  (the packages root)
+#   [3] <repo root>
+_REPO_ROOT = Path(__file__).resolve().parents[3]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 

--- a/packages/sca/scripts/raptor-sca-validate-corpus
+++ b/packages/sca/scripts/raptor-sca-validate-corpus
@@ -17,9 +17,9 @@ Exit codes:
 
 Usage:
 
-    libexec/raptor-sca-validate-corpus
-    libexec/raptor-sca-validate-corpus --corpus custom/dir
-    libexec/raptor-sca-validate-corpus --threshold-top-20 0.6
+    packages/sca/scripts/raptor-sca-validate-corpus
+    packages/sca/scripts/raptor-sca-validate-corpus --corpus custom/dir
+    packages/sca/scripts/raptor-sca-validate-corpus --threshold-top-20 0.6
 """
 
 from __future__ import annotations
@@ -28,7 +28,12 @@ import argparse
 import sys
 from pathlib import Path
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+# parents[3] climbs:
+#   [0] scripts/   (this script's directory)
+#   [1] sca/       (the package)
+#   [2] packages/  (the packages root)
+#   [3] <repo root>
+_REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(_REPO_ROOT))
 
 

--- a/test/data/sca-e2e/compromise-corpus/README.md
+++ b/test/data/sca-e2e/compromise-corpus/README.md
@@ -69,7 +69,7 @@ extracted bytes can't escape into the host filesystem.
 ## Running the harness
 
 ```
-libexec/raptor-sca-compromise-check tests/sca-e2e/compromise-corpus
+packages/sca/scripts/raptor-sca-compromise-check tests/sca-e2e/compromise-corpus
 ```
 
 The harness:

--- a/test/data/sca-e2e/modes-corpus/README.md
+++ b/test/data/sca-e2e/modes-corpus/README.md
@@ -41,7 +41,7 @@ upstream data (advisories, npm/PyPI version availability, etc).
 ## Running
 
 ```
-libexec/raptor-sca-modes-check tests/sca-e2e/modes-corpus
+packages/sca/scripts/raptor-sca-modes-check tests/sca-e2e/modes-corpus
 ```
 
 Exit 0 if every mode on every fixture passes its assertions; 1


### PR DESCRIPTION
libexec/ is for internal bin/raptor dispatch scripts (enforced by .github/tests/test_libexec_marker_coverage.py — every libexec script must carry the trust-marker check block). These five scripts aren't dispatched by bin/raptor:

  - raptor-sca-build-corpus     calibration: refresh corpus
  - raptor-sca-collect-samples  calibration: collect project samples
  - raptor-sca-validate-corpus  calibration: validate + metrics report
  - raptor-sca-compromise-check E2E: regression harness for compromise detection corpus
  - raptor-sca-modes-check      E2E: regression harness for modes corpus

They're maintainer + CI tooling, not operator dispatch. Right home is alongside the SCA package they serve.

  libexec/raptor-sca-<x>  →  packages/sca/scripts/raptor-sca-<x>

Touches:
  * 4 workflows that invoke them
  * the two corpus README example commands
  * data/calibration/ATTRIBUTION.md
  * the in-script docstring Usage examples

Each script's _REPO_ROOT climb goes from parents[1] to parents[3] (scripts → sca → packages → repo root), annotated per the test-conftest-path-resolution rule.

The two real libexec dispatch scripts that stay (already carry the trust-marker): raptor-sca-run + raptor-sca-refit-calibration.