### PR TITLE
feat(witness): execute LLM exploits and capture outcomes in Witnesses

### DIFF
--- a/core/witness/__init__.py
+++ b/core/witness/__init__.py
@@ -25,6 +25,7 @@ to avoid the layering inversion of ``core/`` importing
 ``packages/``.
 """
 
+from core.witness.sandbox_outcome import outcome_from_sandbox_info
 from core.witness.store import WitnessStore, WitnessStoreError
 from core.witness.types import (
     Witness,
@@ -40,4 +41,5 @@ __all__ = [
     "WitnessStore",
     "WitnessStoreError",
     "compute_bytes_hash",
+    "outcome_from_sandbox_info",
 ]

--- a/core/witness/sandbox_outcome.py
+++ b/core/witness/sandbox_outcome.py
@@ -1,0 +1,142 @@
+"""Map a sandbox execution's ``sandbox_info`` dict to a ``WitnessOutcome``.
+
+The sandbox layer (``core/sandbox/observe.py::_interpret_result``) already
+classifies post-execution state:
+
+  * crash signals (SIGSEGV / SIGABRT / SIGBUS / SIGFPE / SIGILL)
+  * resource-limit kills (SIGXCPU / SIGXFSZ)
+  * seccomp kills (SIGSYS)
+  * sanitizer reports (ASAN / UBSAN / MSAN / TSAN)
+  * sandbox-enforcement events (network / write / seccomp blocks)
+
+This module is the thin adapter that turns that dict into the
+``WitnessOutcome`` enum plus a structured ``outcome_detail`` payload, so
+consumers (LLM-exploit executors, future PoC runners) can write
+post-execution Witnesses with consistent provenance.
+
+``core.witness`` does not import ``core.sandbox`` — the function takes a
+plain dict so the dependency arrow stays clean. Producers grab the dict
+off the ``CompletedProcess`` (``result.sandbox_info``) and pass it in.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+from core.witness.types import WitnessOutcome
+
+
+def outcome_from_sandbox_info(
+    sandbox_info: Optional[Dict[str, Any]],
+    returncode: Optional[int] = None,
+) -> Tuple[WitnessOutcome, Dict[str, Any]]:
+    """Classify a sandboxed execution as a ``(WitnessOutcome, detail)`` pair.
+
+    Precedence (most-informative wins):
+
+    1. **Sanitizer report** → ``SANITIZER_REPORT``. ASAN with
+       ``halt_on_error=0`` can fire without abnormal exit; we still
+       call that a sanitizer outcome because the bug was observed.
+    2. **Crash signal** (``crashed=True``, or signal in
+       SIGSEGV/SIGABRT/SIGBUS/SIGFPE/SIGILL) → ``EXIT_SIGNAL``.
+    3. **Resource-exceeded** (SIGXCPU / SIGXFSZ) → ``EXIT_SIGNAL``
+       with ``resource_exceeded=True`` in detail. Caller can disambiguate
+       a fuzz-hang from a sanitizer-triggered crash by reading detail.
+    4. **Seccomp kill** (SIGSYS) → ``EXIT_SIGNAL`` with
+       ``seccomp_killed=True``. Operationally a different class than
+       a target crash, but still "the process died by signal."
+    5. **Sandbox enforcement** (``blocked`` non-empty, no other class
+       fired) → ``NO_OBVIOUS_EFFECT`` with ``blocked`` in detail. The
+       process didn't trigger the target bug; the sandbox stopped it
+       doing something else.
+    6. **Nothing classifiable** → ``NO_OBVIOUS_EFFECT`` (clean exit, no
+       sanitizer trip, no enforcement). The exploit ran but produced
+       no observable security-relevant event.
+
+    ``UNKNOWN`` is reserved for "we couldn't even run the sandbox" /
+    "the result object wasn't shaped like CompletedProcess" cases
+    handled by the caller before this function is reached. ``NOT_RUN``
+    is what callers use when they choose not to execute at all and
+    never reaches here.
+
+    ``FLAG_CAPTURED`` (the ExploitGym terminal-success outcome) is
+    not derivable from sandbox_info alone — it requires an oracle
+    that checks for a specific marker (file, stdout pattern, etc.).
+    Producers that have such an oracle should call this function for
+    the substrate classification, then upgrade to ``FLAG_CAPTURED``
+    on a positive oracle match.
+
+    Args:
+        sandbox_info: Dict produced by
+            ``core/sandbox/observe.py::_interpret_result``. May be
+            ``None`` if the sandbox attached no info — treated as
+            "nothing classifiable" (returns ``NO_OBVIOUS_EFFECT``,
+            empty detail).
+        returncode: Optional ``CompletedProcess.returncode`` for
+            inclusion in ``outcome_detail``. Not used for
+            classification (the sandbox layer already did that
+            mapping into ``signal`` / ``signal_num``).
+
+    Returns:
+        ``(outcome, detail)`` where ``outcome`` is one of
+        ``EXIT_SIGNAL`` / ``SANITIZER_REPORT`` / ``NO_OBVIOUS_EFFECT``
+        and ``detail`` is a flat dict carrying only present fields
+        (absent → omitted, matching the rest of the Witness
+        outcome_detail convention).
+    """
+    detail: Dict[str, Any] = {}
+    if returncode is not None:
+        detail["returncode"] = returncode
+
+    info = sandbox_info or {}
+
+    # Sanitizer wins because it directly identifies a bug class, even
+    # when the process exited cleanly via halt_on_error=0.
+    sanitizer = info.get("sanitizer")
+    if sanitizer:
+        detail["sanitizer"] = sanitizer
+        if info.get("crashed"):
+            detail["crashed"] = True
+        if info.get("signal"):
+            detail["signal"] = info["signal"]
+        if info.get("evidence"):
+            detail["evidence"] = info["evidence"]
+        return WitnessOutcome.SANITIZER_REPORT, detail
+
+    # Signal-killed (crash, resource-exceeded, seccomp). All collapse
+    # to EXIT_SIGNAL at the enum level; detail flags disambiguate.
+    if info.get("signal"):
+        detail["signal"] = info["signal"]
+        if "signal_num" in info:
+            detail["signal_num"] = info["signal_num"]
+        if info.get("crashed"):
+            detail["crashed"] = True
+        if info.get("resource_exceeded"):
+            detail["resource_exceeded"] = True
+        if info.get("seccomp_killed"):
+            detail["seccomp_killed"] = True
+        if info.get("evidence"):
+            detail["evidence"] = info["evidence"]
+        if info.get("blocked"):
+            detail["blocked"] = list(info["blocked"])
+        return WitnessOutcome.EXIT_SIGNAL, detail
+
+    # `crashed` without a signal: shouldn't happen with current
+    # observe.py, but defensive — observe might add cases.
+    if info.get("crashed"):
+        detail["crashed"] = True
+        if info.get("evidence"):
+            detail["evidence"] = info["evidence"]
+        return WitnessOutcome.EXIT_SIGNAL, detail
+
+    # Sandbox enforcement only (no crash, no sanitizer).
+    if info.get("blocked"):
+        detail["blocked"] = list(info["blocked"])
+        if info.get("evidence"):
+            detail["evidence"] = info["evidence"]
+        return WitnessOutcome.NO_OBVIOUS_EFFECT, detail
+
+    # Nothing observed.
+    if info.get("evidence"):
+        detail["evidence"] = info["evidence"]
+    return WitnessOutcome.NO_OBVIOUS_EFFECT, detail

--- a/core/witness/store.py
+++ b/core/witness/store.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 from pathlib import Path
 from typing import Iterator, Optional
 
@@ -160,19 +161,40 @@ class WitnessStore:
         # that subsequent puts would skip (since blob_path.exists()
         # was True), producing on-disk corruption invisible to
         # later readers.
+        # ``.tmp`` paths are made unique per (pid, thread) so two
+        # concurrent ``put()`` calls writing the same hash don't
+        # race on the same temp file — the original ``.bin.tmp`` /
+        # ``.json.tmp`` suffix collided when N threads wrote identical
+        # bytes, with N-1 callers raising ``FileNotFoundError`` on
+        # the second ``os.replace`` (the first one had already
+        # consumed the shared tempfile). End state was still correct
+        # (dedup by hash) but most callers got an exception. The
+        # pid+tid suffix keeps the existing crash-mid-write guarantee
+        # (each tempfile is still atomically renamed onto the final
+        # path) while making same-hash concurrent writes succeed.
+        suffix = f".{os.getpid()}.{threading.get_ident()}.tmp"
         if not blob_path.exists():
-            blob_tmp = blob_path.with_suffix(".bin.tmp")
+            blob_tmp = blob_path.with_suffix(".bin" + suffix)
             blob_tmp.write_bytes(data)
-            os.replace(blob_tmp, blob_path)
+            try:
+                os.replace(blob_tmp, blob_path)
+            except FileNotFoundError:
+                # Lost the race: another writer replaced the .tmp out
+                # from under us. The final blob_path now holds the
+                # same bytes (verified by hash); nothing to do.
+                pass
 
         # Atomic manifest write. Pre-fix ``write_text`` was direct
         # and a crash mid-write left a malformed JSON file forever
         # — list_witnesses skipped it with a warning but get_witness
         # raised, and there was no recovery path other than manual
         # cleanup.
-        manifest_tmp = manifest_path.with_suffix(".json.tmp")
+        manifest_tmp = manifest_path.with_suffix(".json" + suffix)
         manifest_tmp.write_text(manifest_text, encoding="utf-8")
-        os.replace(manifest_tmp, manifest_path)
+        try:
+            os.replace(manifest_tmp, manifest_path)
+        except FileNotFoundError:
+            pass
 
         logger.debug(
             "WitnessStore.put: hash=%s len=%d source=%s outcome=%s",

--- a/core/witness/tests/test_sandbox_outcome.py
+++ b/core/witness/tests/test_sandbox_outcome.py
@@ -1,0 +1,238 @@
+"""Tests for ``core.witness.outcome_from_sandbox_info``.
+
+These pin the precedence semantics (sanitizer > signal > blocked-only >
+clean-exit) and the detail-extraction shape (absent → omitted).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+# core/witness/tests/test_sandbox_outcome.py → parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from core.witness import (  # noqa: E402
+    WitnessOutcome,
+    outcome_from_sandbox_info,
+)
+
+
+# ----------------------------------------------------------------------
+# Crash signal — EXIT_SIGNAL
+# ----------------------------------------------------------------------
+
+
+def test_sigsegv_crash_to_exit_signal():
+    info = {
+        "signal": "SIGSEGV",
+        "signal_num": 11,
+        "crashed": True,
+        "evidence": "Process crashed with SIGSEGV",
+    }
+    outcome, detail = outcome_from_sandbox_info(info)
+    assert outcome is WitnessOutcome.EXIT_SIGNAL
+    assert detail["signal"] == "SIGSEGV"
+    assert detail["signal_num"] == 11
+    assert detail["crashed"] is True
+    assert detail["evidence"] == "Process crashed with SIGSEGV"
+
+
+def test_sigabrt_crash_to_exit_signal():
+    info = {"signal": "SIGABRT", "signal_num": 6, "crashed": True}
+    outcome, detail = outcome_from_sandbox_info(info)
+    assert outcome is WitnessOutcome.EXIT_SIGNAL
+    assert detail["signal"] == "SIGABRT"
+
+
+def test_returncode_threads_into_detail():
+    info = {"signal": "SIGSEGV", "signal_num": 11, "crashed": True}
+    _, detail = outcome_from_sandbox_info(info, returncode=-11)
+    assert detail["returncode"] == -11
+
+
+# ----------------------------------------------------------------------
+# Sanitizer — SANITIZER_REPORT
+# ----------------------------------------------------------------------
+
+
+def test_asan_with_crash_to_sanitizer_report():
+    """Sanitizer takes precedence over signal — even when the
+    process died, the SANITIZER_REPORT outcome carries the
+    more specific bug-class signal."""
+    info = {
+        "signal": "SIGABRT",
+        "signal_num": 6,
+        "crashed": True,
+        "sanitizer": "asan",
+        "evidence": "AddressSanitizer: heap-buffer-overflow",
+    }
+    outcome, detail = outcome_from_sandbox_info(info)
+    assert outcome is WitnessOutcome.SANITIZER_REPORT
+    assert detail["sanitizer"] == "asan"
+    assert detail["crashed"] is True
+    assert detail["signal"] == "SIGABRT"
+    assert "heap-buffer-overflow" in detail["evidence"]
+
+
+def test_asan_without_crash_still_sanitizer_report():
+    """ASan with ``halt_on_error=0`` reports without aborting.
+    The outcome must still be SANITIZER_REPORT — the bug was
+    observed even though exit was clean."""
+    info = {
+        "sanitizer": "asan",
+        "evidence": "AddressSanitizer: stack-use-after-return",
+    }
+    outcome, detail = outcome_from_sandbox_info(info)
+    assert outcome is WitnessOutcome.SANITIZER_REPORT
+    assert detail["sanitizer"] == "asan"
+    assert "crashed" not in detail
+
+
+def test_ubsan_to_sanitizer_report():
+    info = {"sanitizer": "ubsan", "evidence": "UBSAN triggered"}
+    outcome, _ = outcome_from_sandbox_info(info)
+    assert outcome is WitnessOutcome.SANITIZER_REPORT
+
+
+def test_msan_to_sanitizer_report():
+    info = {"sanitizer": "msan", "crashed": True}
+    outcome, _ = outcome_from_sandbox_info(info)
+    assert outcome is WitnessOutcome.SANITIZER_REPORT
+
+
+def test_tsan_to_sanitizer_report():
+    info = {"sanitizer": "tsan"}
+    outcome, _ = outcome_from_sandbox_info(info)
+    assert outcome is WitnessOutcome.SANITIZER_REPORT
+
+
+# ----------------------------------------------------------------------
+# Resource / seccomp — still EXIT_SIGNAL with disambiguating flags
+# ----------------------------------------------------------------------
+
+
+def test_sigxcpu_resource_exceeded():
+    info = {
+        "signal": "SIGXCPU",
+        "signal_num": 24,
+        "resource_exceeded": True,
+        "evidence": "Process killed by SIGXCPU — CPU time exhausted",
+    }
+    outcome, detail = outcome_from_sandbox_info(info)
+    assert outcome is WitnessOutcome.EXIT_SIGNAL
+    assert detail["resource_exceeded"] is True
+    assert detail["signal"] == "SIGXCPU"
+
+
+def test_sigsys_seccomp_killed():
+    info = {
+        "signal": "SIGSYS",
+        "signal_num": 31,
+        "seccomp_killed": True,
+        "evidence": "Process killed by SIGSYS — seccomp blocked a syscall",
+    }
+    outcome, detail = outcome_from_sandbox_info(info)
+    assert outcome is WitnessOutcome.EXIT_SIGNAL
+    assert detail["seccomp_killed"] is True
+
+
+# ----------------------------------------------------------------------
+# `crashed` without explicit signal (defensive — observe could add this)
+# ----------------------------------------------------------------------
+
+
+def test_crashed_without_signal_to_exit_signal():
+    info = {"crashed": True, "evidence": "abnormal exit"}
+    outcome, detail = outcome_from_sandbox_info(info)
+    assert outcome is WitnessOutcome.EXIT_SIGNAL
+    assert detail["crashed"] is True
+
+
+# ----------------------------------------------------------------------
+# Sandbox enforcement only — NO_OBVIOUS_EFFECT
+# ----------------------------------------------------------------------
+
+
+def test_blocked_only_to_no_obvious_effect():
+    """Sandbox stopped the process from doing something else; no
+    target-bug evidence. ``blocked`` lands in detail so operators
+    can see what was attempted."""
+    info = {
+        "blocked": [
+            {"kind": "network", "detail": "Connection refused"},
+        ],
+        "evidence": "Network connection blocked",
+    }
+    outcome, detail = outcome_from_sandbox_info(info)
+    assert outcome is WitnessOutcome.NO_OBVIOUS_EFFECT
+    assert detail["blocked"][0]["kind"] == "network"
+
+
+def test_blocked_with_signal_keeps_exit_signal():
+    """The process died by signal — that's the primary outcome.
+    blocked still rides along in detail for diagnosis."""
+    info = {
+        "signal": "SIGSEGV",
+        "signal_num": 11,
+        "crashed": True,
+        "blocked": [{"kind": "write", "detail": "Read-only file system"}],
+    }
+    outcome, detail = outcome_from_sandbox_info(info)
+    assert outcome is WitnessOutcome.EXIT_SIGNAL
+    assert detail["blocked"][0]["kind"] == "write"
+
+
+# ----------------------------------------------------------------------
+# Clean exit / nothing observed
+# ----------------------------------------------------------------------
+
+
+def test_empty_sandbox_info_to_no_obvious_effect():
+    outcome, detail = outcome_from_sandbox_info({})
+    assert outcome is WitnessOutcome.NO_OBVIOUS_EFFECT
+    assert detail == {}
+
+
+def test_none_sandbox_info_to_no_obvious_effect():
+    """The sandbox attached no info (e.g. unsandboxed fallback).
+    Defensive default: nothing observed, no detail to surface."""
+    outcome, detail = outcome_from_sandbox_info(None)
+    assert outcome is WitnessOutcome.NO_OBVIOUS_EFFECT
+    assert detail == {}
+
+
+def test_clean_exit_with_evidence_still_no_obvious_effect():
+    """``crashed=False`` with some evidence text doesn't escalate
+    — the bug-class signals are what trigger non-default outcomes."""
+    info = {"crashed": False}
+    outcome, detail = outcome_from_sandbox_info(info)
+    assert outcome is WitnessOutcome.NO_OBVIOUS_EFFECT
+    assert detail == {}
+
+
+# ----------------------------------------------------------------------
+# Detail-shape invariants
+# ----------------------------------------------------------------------
+
+
+def test_absent_fields_are_omitted_not_nulled():
+    """Convention: absent in input → absent in detail (no None
+    values cluttering downstream consumers)."""
+    info = {"signal": "SIGSEGV", "signal_num": 11, "crashed": True}
+    _, detail = outcome_from_sandbox_info(info)
+    for k in ("sanitizer", "blocked", "resource_exceeded",
+              "seccomp_killed", "evidence"):
+        assert k not in detail
+
+
+def test_blocked_list_is_copied_not_aliased():
+    """Mutating the returned detail must not back-mutate
+    sandbox_info — safer for callers that reuse the dict."""
+    blocked = [{"kind": "network"}]
+    info = {"blocked": blocked}
+    _, detail = outcome_from_sandbox_info(info)
+    detail["blocked"].append({"kind": "write"})
+    assert len(blocked) == 1

--- a/core/witness/tests/test_store.py
+++ b/core/witness/tests/test_store.py
@@ -348,3 +348,104 @@ def test_witness_store_error_importable_from_init(tmp_path):
     from core.witness import WitnessStoreError as imported
     from core.witness.store import WitnessStoreError as direct
     assert imported is direct
+
+
+def test_concurrent_same_hash_writes_do_not_race(tmp_path):
+    """N threads writing the SAME bytes concurrently must all
+    succeed. Pre-fix the atomic write used a shared ``.bin.tmp`` /
+    ``.json.tmp`` suffix per blob; concurrent writers raced on
+    that file and ``os.replace`` raised ``FileNotFoundError`` for
+    the losers (the first ``replace`` consumed the shared tempfile).
+    Per-(pid, thread) suffix on the tempfile name fixed it.
+
+    PR E surfaced this: LLM exploits with identical bytes across
+    findings are realistic and could trigger the race once
+    crash_agent or a future caller goes multi-threaded. The end
+    state was always correct (dedup-by-hash works); only the
+    losing callers' exceptions were the bug.
+    """
+    import threading
+    N = 16
+    shared_bytes = b"// identical exploit text across findings\n"
+    shared_hash = compute_bytes_hash(shared_bytes)
+    store = WitnessStore(tmp_path / "witnesses")
+    errors = []
+    barrier = threading.Barrier(N)
+
+    def worker(tid):
+        try:
+            barrier.wait()
+            w = Witness(
+                bytes_hash=shared_hash,
+                bytes_len=len(shared_bytes),
+                source=WitnessSource.LLM_EMIT_RUN,
+                observed_outcome=WitnessOutcome.NOT_RUN,
+                outcome_detail={"finding_id": f"F-{tid}"},
+            )
+            store.put(w, shared_bytes)
+        except Exception as e:  # noqa: BLE001
+            errors.append((tid, type(e).__name__, str(e)))
+
+    threads = [
+        threading.Thread(target=worker, args=(i,)) for i in range(N)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == [], f"concurrent put() raised on {len(errors)}/{N} threads"
+    # End state: one blob, one manifest (last-write-wins on outcome_detail)
+    blobs = list((tmp_path / "witnesses" / "blobs").glob("*"))
+    manifests = list(
+        (tmp_path / "witnesses" / "manifests").glob("*.json")
+    )
+    assert len(blobs) == 1
+    assert len(manifests) == 1
+    loaded = store.get_witness(shared_hash)
+    assert loaded.outcome_detail["finding_id"].startswith("F-")
+
+
+def test_concurrent_distinct_hash_writes_succeed(tmp_path):
+    """Distinct hashes from concurrent writers: also must succeed.
+    This was already safe pre-fix (each writer's hash was unique
+    so tempfile names didn't collide) — pin it as a regression
+    guard."""
+    import threading
+    N = 8
+    PER = 20
+    store = WitnessStore(tmp_path / "witnesses")
+    errors = []
+    barrier = threading.Barrier(N)
+
+    def worker(tid):
+        try:
+            barrier.wait()
+            for i in range(PER):
+                data = f"thread-{tid}-write-{i}".encode()
+                w = Witness(
+                    bytes_hash=compute_bytes_hash(data),
+                    bytes_len=len(data),
+                    source=WitnessSource.LLM_EMIT_RUN,
+                    observed_outcome=WitnessOutcome.NOT_RUN,
+                    outcome_detail={"finding_id": f"F-{tid}-{i}"},
+                )
+                store.put(w, data)
+        except Exception as e:  # noqa: BLE001
+            errors.append((tid, type(e).__name__, str(e)))
+
+    threads = [
+        threading.Thread(target=worker, args=(i,)) for i in range(N)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    blobs = list((tmp_path / "witnesses" / "blobs").glob("*"))
+    manifests = list(
+        (tmp_path / "witnesses" / "manifests").glob("*.json")
+    )
+    assert len(blobs) == N * PER
+    assert len(manifests) == N * PER

--- a/packages/binary_analysis/crash_analyser.py
+++ b/packages/binary_analysis/crash_analyser.py
@@ -82,6 +82,19 @@ class CrashContext:
     # contract on ``VulnerabilityContext.intent_match``.
     intent_match: Optional[Dict] = None
 
+    # Executed-outcome from running the compiled exploit in the
+    # sandbox (only populated when ``--execute-exploits`` is on).
+    # ``execute_outcome`` is the ``WitnessOutcome`` enum string
+    # value (``"exit_signal"``, ``"sanitizer_report"``, etc.) — kept
+    # as a string here so this module doesn't depend on
+    # ``core.witness``. ``None`` means execution wasn't attempted,
+    # compilation failed, or the sandbox raised. ``execute_detail``
+    # carries the structured outcome detail (signal name, sanitizer
+    # type, blocked-actions list, etc.); empty when execution
+    # wasn't attempted.
+    execute_outcome: Optional[str] = None
+    execute_detail: Dict = field(default_factory=dict)
+
 
 class CrashAnalyser:
     """Analyses crashes using debugger and LLM."""

--- a/packages/llm_analysis/crash_agent.py
+++ b/packages/llm_analysis/crash_agent.py
@@ -300,7 +300,10 @@ class CrashAnalysisAgent:
                  llm_config: LLMConfig = None,
                  verify_exploits: bool = True,
                  judge_intent: bool = True,
-                 record_witnesses: bool = True):
+                 record_witnesses: bool = True,
+                 execute_exploits: bool = False,
+                 execute_timeout: int = 5,
+                 execute_sanitizers: Optional[list] = None):
         self.binary = Path(binary_path)
         self.out_dir = Path(out_dir)
         self.out_dir.mkdir(parents=True, exist_ok=True)
@@ -329,6 +332,29 @@ class CrashAnalysisAgent:
         # failures are non-fatal.
         self.record_witnesses = record_witnesses
         self._witness_store = None  # lazy
+        # Execute the LLM-emitted exploit against the fuzzed binary
+        # in the sandbox after compile-verify, then thread the
+        # observed outcome (EXIT_SIGNAL / SANITIZER_REPORT / etc.)
+        # into the Witness. Default OFF — actually running LLM-
+        # generated code is a policy shift that needs operator
+        # opt-in even with the sandbox. Enable via
+        # ``--execute-exploits``. Requires ``verify_exploits``
+        # (compilation is a prerequisite for execution). The
+        # crash_agent path has a natural target (``self.binary``);
+        # the /agentic path stays NOT_RUN until a build harness
+        # lands.
+        self.execute_exploits = execute_exploits
+        self.execute_timeout = execute_timeout
+        # When set, the compiled exploit is built with these gcc
+        # sanitizer flags (e.g. ``["address"]`` → ``-fsanitize=address``)
+        # so runtime memory-safety bugs surface as ASAN reports
+        # — landing as ``WitnessOutcome.SANITIZER_REPORT`` rather
+        # than just ``EXIT_SIGNAL``. Default ``None`` keeps the
+        # historical no-instrumentation behaviour. Opt-in via
+        # ``--execute-sanitizers=address,undefined`` on
+        # ``raptor_fuzzing.py``. Only meaningful with
+        # ``execute_exploits=True``.
+        self.execute_sanitizers = execute_sanitizers
 
         # Detect LLM availability and choose provider
         availability = detect_llm_availability()
@@ -669,7 +695,19 @@ FULL LLM RESPONSE:
                 # /crash-analysis case of native binaries built from
                 # C/C++. Gated on ``self.verify_exploits`` so
                 # operators can opt out for time-sensitive runs.
-                if self.verify_exploits:
+                # When ``execute_exploits`` is on, we use the
+                # unified compile-and-execute path instead so the
+                # binary is reachable for the run before tempdir
+                # cleanup. Execution requires compile-verify (no
+                # binary → no run), so the flag combination
+                # ``execute_exploits=True, verify_exploits=False``
+                # silently falls back to compile-only — operator
+                # opted out of the prerequisite.
+                if self.verify_exploits and self.execute_exploits:
+                    self._compile_and_execute_exploit(
+                        crash_context, exploit_code,
+                    )
+                elif self.verify_exploits:
                     self._verify_exploit_compiles(crash_context, exploit_code)
 
                 # Intent-match judgement on the (possibly compile-
@@ -737,6 +775,51 @@ FULL LLM RESPONSE:
         )
         crash_context.exploit_compiled = compiled
         crash_context.exploit_compile_errors = errors
+
+    def _compile_and_execute_exploit(
+        self, crash_context: CrashContext, exploit_code: str,
+    ) -> None:
+        """Compile-verify AND sandbox-execute the LLM-emitted exploit.
+
+        Used when ``--execute-exploits`` is on. Replaces the compile-
+        only path: both the compiled binary and the executed outcome
+        live in the same tempdir scope, so the binary is reachable
+        for the run before cleanup.
+
+        Threads the executed outcome onto the crash context as
+        ``execute_outcome`` (string form of ``WitnessOutcome``) and
+        ``execute_detail`` (dict). The witness recorder consumes
+        those fields to upgrade the Witness from ``NOT_RUN`` to the
+        observed outcome.
+
+        Failures are non-fatal: a sandbox import failure, a binary
+        path that vanished, an unexpected ``compile_and_execute``
+        return shape — any of these leave ``execute_outcome=None``
+        and the witness ends up ``NOT_RUN`` as if execution had
+        been opted out. The exploit file on disk is unaffected.
+        """
+        from packages.llm_analysis.exploit_verify import compile_and_execute
+
+        target_file_path = ""
+        if crash_context.source_location:
+            target_file_path = crash_context.source_location.rsplit(
+                ":", 1
+            )[0]
+
+        compiled, errors, outcome, detail = compile_and_execute(
+            exploit_code,
+            target_file_path,
+            crash_context.crash_id,
+            target_binary_path=self.binary,
+            timeout=self.execute_timeout,
+            logger=logger,
+            sanitizers=self.execute_sanitizers,
+        )
+        crash_context.exploit_compiled = compiled
+        crash_context.exploit_compile_errors = errors
+        if outcome is not None:
+            crash_context.execute_outcome = outcome.value
+            crash_context.execute_detail = detail
 
     def _judge_exploit_intent(
         self, crash_context: CrashContext, exploit_code: str,
@@ -874,6 +957,21 @@ FULL LLM RESPONSE:
                 intent_verdict=intent_verdict,
                 intent_confidence=intent_confidence,
                 target_binary_path=self.binary,
+                # PR E: when execution actually ran, upgrade the
+                # Witness's observed_outcome from NOT_RUN to the
+                # observed one. ``execute_outcome`` is the
+                # WitnessOutcome enum *string* on the crash context
+                # (kept as string so the binary_analysis module
+                # doesn't depend on core.witness); convert back here.
+                executed_outcome=(
+                    self._resolve_execute_outcome(
+                        crash_context.execute_outcome,
+                    )
+                    if crash_context.execute_outcome else None
+                ),
+                executed_detail=(
+                    crash_context.execute_detail or None
+                ),
                 produced_by="crash-agent",
             )
             self._witness_store.put(witness, data)
@@ -886,6 +984,26 @@ FULL LLM RESPONSE:
                 f"   · Witness record failed for "
                 f"{crash_context.crash_id}: {type(e).__name__}: {e}"
             )
+
+    @staticmethod
+    def _resolve_execute_outcome(value: Optional[str]):
+        """Map the string form on CrashContext back to WitnessOutcome.
+
+        ``CrashContext.execute_outcome`` is a string (enum ``.value``)
+        so the binary_analysis module doesn't depend on
+        ``core.witness``. The witness recorder re-lifts it into the
+        enum here. Unknown values fall back to ``UNKNOWN`` defensively
+        rather than raising — if a future code path writes an
+        unrecognised string we don't want to break the witness
+        record.
+        """
+        if not value:
+            return None
+        from core.witness import WitnessOutcome
+        try:
+            return WitnessOutcome(value)
+        except ValueError:
+            return WitnessOutcome.UNKNOWN
 
     def _signal_name(self, signal: str) -> str:
         """Convert signal number to name."""

--- a/packages/llm_analysis/exploit_verify.py
+++ b/packages/llm_analysis/exploit_verify.py
@@ -35,7 +35,9 @@ from __future__ import annotations
 import logging
 import tempfile
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
+
+from core.witness import WitnessOutcome, outcome_from_sandbox_info
 
 
 # File extensions that map to languages the gcc-based validator can
@@ -53,7 +55,6 @@ def compile_verify(
     target_file_path: Optional[str],
     artifact_id: str,
     logger: Optional[logging.Logger] = None,
-    sanitizers: Optional[List[str]] = None,
 ) -> Tuple[Optional[bool], List[str]]:
     """Compile-check ``exploit_code`` in a sandboxed tempdir.
 
@@ -70,12 +71,6 @@ def compile_verify(
             traversal segments are sanitised before use.
         logger: Optional logger for status / diagnostic lines. Defaults
             to a module logger.
-        sanitizers: Optional list of gcc sanitizer names to enable
-            (``"address"``, ``"undefined"``, etc.). Passes through to
-            ``ExploitValidator.validate_exploit`` — see that method
-            for the allowlist + behaviour. ``None`` (default) keeps
-            the historical compile-verify behaviour with no
-            instrumentation.
 
     Returns:
         ``(compiled, errors)`` where:
@@ -144,9 +139,7 @@ def compile_verify(
         work_dir = Path(work_dir_str)
         try:
             validator = ExploitValidator(work_dir=work_dir)
-            result = validator.validate_exploit(
-                exploit_code, safe_id, sanitizers=sanitizers,
-            )
+            result = validator.validate_exploit(exploit_code, safe_id)
         except Exception as e:  # noqa: BLE001 — validator is best-effort
             log.warning(
                 f"   ⚠ Compile-verify raised {type(e).__name__}: {e}; "
@@ -171,3 +164,247 @@ def compile_verify(
                 log.info(f"     ... ({err_count - 3} more)")
 
         return compiled, errors
+
+
+def compile_and_execute(
+    exploit_code: str,
+    target_file_path: Optional[str],
+    artifact_id: str,
+    target_binary_path: Optional[Path] = None,
+    timeout: int = 5,
+    logger: Optional[logging.Logger] = None,
+    sanitizers: Optional[List[str]] = None,
+) -> Tuple[
+    Optional[bool],
+    List[str],
+    Optional[WitnessOutcome],
+    Dict[str, Any],
+]:
+    """Compile an LLM-emitted exploit and run it in a sandbox.
+
+    Extends :func:`compile_verify` with an execution step. Both
+    compilation and execution happen inside a single tempdir scope so
+    the compiled artefact is reachable for the run before cleanup.
+
+    The exploit is run under ``core.sandbox.run`` with the same
+    network-block + Landlock + seccomp posture ``safe_test_exploit``
+    has always used. Post-execution classification reads
+    ``result.sandbox_info`` (populated by
+    ``core/sandbox/observe.py::_interpret_result``) and maps to a
+    :class:`WitnessOutcome` via
+    :func:`core.witness.outcome_from_sandbox_info` — the substrate
+    already classifies crash signals, sanitizer reports, resource
+    exhaustion, and sandbox-enforcement events, so this function
+    is wiring rather than inventing.
+
+    Args:
+        exploit_code: LLM-emitted source. Same shape as
+            :func:`compile_verify`.
+        target_file_path: Source path the exploit targets — used for
+            the language gate.
+        artifact_id: Stable identifier for log lines + tempdir name.
+        target_binary_path: Optional path to the target binary the
+            exploit attacks (e.g. the fuzzed binary for crash-agent
+            cases). Exposed to the exploit via the ``TARGET`` env var
+            inside the sandbox — same calling convention the long-
+            dormant ``safe_test_exploit`` set up. ``None`` for the
+            ``/agentic`` path that has no built target.
+        timeout: Per-execution timeout in seconds.
+        logger: Optional logger for diagnostics.
+        sanitizers: Optional list of gcc sanitizer names (``"address"``,
+            ``"undefined"``, etc.) passed through to
+            :class:`ExploitValidator`. When ``["address"]`` is set
+            and the exploit triggers a memory-safety bug at runtime,
+            ASAN's report flows through ``observe._interpret_result``
+            and lands as ``WitnessOutcome.SANITIZER_REPORT``.
+            Default ``None`` keeps the historical no-instrumentation
+            behaviour.
+
+    Returns:
+        ``(compiled, errors, outcome, outcome_detail)`` where:
+
+        * ``compiled`` / ``errors`` match :func:`compile_verify`.
+        * ``outcome`` is the executed :class:`WitnessOutcome`, or
+          ``None`` if execution was not attempted (compile failed,
+          language unsupported, validator unavailable, sandbox import
+          failed). ``None`` distinguishes "didn't run" from
+          ``WitnessOutcome.NO_OBVIOUS_EFFECT`` (ran cleanly with
+          nothing observed).
+        * ``outcome_detail`` is the structured detail dict (empty
+          when execution wasn't attempted). When execution was
+          attempted, carries the fields the mapper extracted —
+          ``signal`` / ``sanitizer`` / ``blocked`` / etc.
+
+    Never raises. Compile-side failures match ``compile_verify``'s
+    contract; execution-side failures (subprocess error, sandbox
+    raise) are logged and surfaced as ``outcome=None``.
+    """
+    log = logger if logger is not None else logging.getLogger(__name__)
+
+    target_ext = ""
+    if target_file_path:
+        target_ext = Path(target_file_path).suffix.lower()
+    if target_ext and target_ext not in _COMPILABLE_EXTENSIONS:
+        log.debug(
+            f"   · Skipping compile-and-execute for {artifact_id} "
+            f"(target language {target_ext!r} not gcc-compilable)"
+        )
+        return (
+            None,
+            [
+                f"language_not_supported: target extension "
+                f"{target_ext!r} is not in the gcc-compilable set"
+            ],
+            None,
+            {},
+        )
+
+    try:
+        from packages.autonomous.exploit_validator import ExploitValidator
+    except ImportError as e:
+        log.debug(
+            f"ExploitValidator unavailable ({e}) — leaving "
+            f"compile-and-execute verdict unset for {artifact_id}"
+        )
+        return None, [], None, {}
+
+    safe_id = Path(artifact_id or "exploit").name.replace("..", "_") \
+        or "exploit"
+
+    with tempfile.TemporaryDirectory(
+        prefix=f"execute-exploit-{safe_id}-",
+    ) as work_dir_str:
+        work_dir = Path(work_dir_str)
+
+        # --- Compile ---
+        try:
+            validator = ExploitValidator(work_dir=work_dir)
+            compile_result = validator.validate_exploit(
+                exploit_code, safe_id, sanitizers=sanitizers,
+            )
+        except Exception as e:  # noqa: BLE001 — validator is best-effort
+            log.warning(
+                f"   ⚠ Compile-and-execute (compile phase) raised "
+                f"{type(e).__name__}: {e}; verdict unset for {artifact_id}"
+            )
+            return None, [], None, {}
+
+        compiled = bool(compile_result.success)
+        errors = list(compile_result.compilation_errors or [])
+        exploit_path = compile_result.exploit_path
+
+        if not compiled:
+            err_count = len(errors)
+            log.info(
+                f"   ⚠ Exploit failed to compile, skipping execution "
+                f"({err_count} error{'s' if err_count != 1 else ''})"
+            )
+            for err in errors[:3]:
+                log.info(f"     - {err}")
+            if err_count > 3:
+                log.info(f"     ... ({err_count - 3} more)")
+            return compiled, errors, None, {}
+
+        log.info("   ✓ Exploit compiled — proceeding to sandboxed execution")
+
+        if exploit_path is None or not Path(exploit_path).is_file():
+            log.warning(
+                f"   ⚠ Compiled successfully but exploit_path is "
+                f"missing for {artifact_id}; skipping execution"
+            )
+            return compiled, errors, None, {}
+
+        # --- Execute ---
+        try:
+            from core.config import RaptorConfig
+            from core.sandbox import run as sandbox_run
+        except ImportError as e:
+            log.warning(
+                f"   ⚠ Sandbox unavailable ({e}); compiled but not "
+                f"executed for {artifact_id}"
+            )
+            return compiled, errors, None, {}
+
+        env = {**RaptorConfig.get_safe_env()}
+        if target_binary_path is not None:
+            env["TARGET"] = str(target_binary_path)
+
+        import subprocess as _subprocess
+        try:
+            run_result = sandbox_run(
+                [str(exploit_path)],
+                block_network=True,
+                target=str(work_dir),
+                output=str(work_dir),
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                env=env,
+                # ``env`` is built on top of get_safe_env() so the
+                # caller-env warning the sandbox emits is benign here.
+                # ``strict_env=True`` adds defence-in-depth: re-strips
+                # DANGEROUS_ENV_VARS from our composed dict in case
+                # anything snuck back in.
+                strict_env=True,
+            )
+        except _subprocess.TimeoutExpired:
+            # Distinct from generic failure: the exploit ran but
+            # didn't terminate within the budget. ``UNKNOWN`` is
+            # accurate (we don't know what would have happened);
+            # ``timed_out=True`` lets consumers spot infinite-loop
+            # exploits vs. "we never ran it."
+            log.info(
+                f"   · Exploit ran — timed out after {timeout}s "
+                f"for {artifact_id}"
+            )
+            return (
+                compiled, errors, WitnessOutcome.UNKNOWN,
+                {"timed_out": True, "timeout_s": timeout},
+            )
+        except Exception as e:  # noqa: BLE001 — execution is best-effort
+            log.warning(
+                f"   ⚠ Compile-and-execute (run phase) raised "
+                f"{type(e).__name__}: {e} for {artifact_id}"
+            )
+            return compiled, errors, None, {}
+
+        sandbox_info = getattr(run_result, "sandbox_info", None)
+        returncode = getattr(run_result, "returncode", None)
+        outcome, detail = outcome_from_sandbox_info(
+            sandbox_info, returncode=returncode,
+        )
+
+        # One-line execution summary; full detail flows into the
+        # Witness via the caller. The summary lines match the
+        # compile-verify pattern so operators get a consistent
+        # cadence in their logs.
+        if outcome is WitnessOutcome.SANITIZER_REPORT:
+            log.info(
+                f"   ✓ Exploit ran — sanitizer fired "
+                f"({detail.get('sanitizer', 'unknown')})"
+            )
+        elif outcome is WitnessOutcome.EXIT_SIGNAL:
+            sig = detail.get("signal", "unknown signal")
+            if detail.get("resource_exceeded"):
+                log.info(
+                    f"   ⚠ Exploit ran — killed by {sig} (resource limit)"
+                )
+            elif detail.get("seccomp_killed"):
+                log.info(
+                    f"   ⚠ Exploit ran — killed by {sig} (seccomp)"
+                )
+            else:
+                log.info(f"   ✓ Exploit ran — crashed via {sig}")
+        else:
+            blocked = detail.get("blocked")
+            if blocked:
+                log.info(
+                    f"   · Exploit ran — sandbox blocked "
+                    f"{len(blocked)} action(s), no target-bug evidence"
+                )
+            else:
+                log.info(
+                    "   · Exploit ran — no observable bug signal"
+                )
+
+        return compiled, errors, outcome, detail

--- a/packages/llm_analysis/scripts/e2e_execute_witness.py
+++ b/packages/llm_analysis/scripts/e2e_execute_witness.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""E2E script for the operator-facing ``--execute-exploits`` flow.
+
+Exercises every layer end-to-end, using the *real* configured LLM:
+
+  1. Compile a trivially-fuzzable target binary with
+     ``-fsanitize=address``.
+  2. Produce a real crash by running the target with an
+     overflowing input.
+  3. Build a ``CrashContext`` shaped like ``addr2line + AFL``
+     output would produce.
+  4. Instantiate ``CrashAnalysisAgent`` with
+     ``execute_exploits=True`` and
+     ``execute_sanitizers=["address"]``.
+  5. Call ``generate_exploit(crash_context)`` — the real LLM
+     synthesises an exploit, ``compile_and_execute`` runs it in
+     the sandbox, ``observe._interpret_result`` classifies the
+     outcome, and the recorder writes a ``Witness`` to disk.
+  6. Inspect the manifest on disk.
+
+Cost: one LLM call per run (~5–50K tokens depending on provider).
+Skip-gated on ``gcc -fsanitize=address`` availability + a working
+LLM config; prints what was checked / what was skipped.
+
+Run from the repo root:
+
+    python3 packages/llm_analysis/scripts/e2e_execute_witness.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+# packages/llm_analysis/scripts/e2e_execute_witness.py
+#   parents[0] = scripts/
+#   parents[1] = llm_analysis/
+#   parents[2] = packages/
+#   parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+
+_TARGET_SOURCE = """
+#include <string.h>
+#include <unistd.h>
+int main(void) {
+    char buf[8];
+    char input[64];
+    ssize_t n = read(0, input, sizeof(input) - 1);
+    if (n <= 0) return 1;
+    input[n] = 0;
+    strcpy(buf, input);
+    return 0;
+}
+"""
+
+
+def _has_libasan() -> bool:
+    if shutil.which("gcc") is None:
+        return False
+    try:
+        result = subprocess.run(
+            ["gcc", "-fsanitize=address", "-x", "c", "-",
+             "-o", "/dev/null"],
+            input="int main(void){return 0;}",
+            text=True,
+            capture_output=True,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def main() -> int:
+    if not _has_libasan():
+        print("SKIP: gcc -fsanitize=address not usable on this host")
+        return 0
+
+    from core.llm.detection import detect_llm_availability
+    avail = detect_llm_availability()
+    if not avail.external_llm:
+        print("SKIP: no external LLM configured "
+              "(need ANTHROPIC_API_KEY / OPENAI_API_KEY / etc.)")
+        return 0
+
+    from core.witness import WitnessOutcome, WitnessStore
+    from packages.binary_analysis.crash_analyser import CrashContext
+    from packages.llm_analysis.crash_agent import CrashAnalysisAgent
+
+    with tempfile.TemporaryDirectory(prefix="e2e-execute-witness-") as td:
+        td_path = Path(td)
+        print(f"[1/6] Workdir: {td_path}")
+
+        # --- 1. Build target binary with ASAN ---
+        src = td_path / "target.c"
+        src.write_text(_TARGET_SOURCE)
+        binary = td_path / "target"
+        subprocess.run(
+            ["gcc", "-O0", "-g", "-fno-omit-frame-pointer",
+             "-fsanitize=address", "-o", str(binary), str(src)],
+            check=True, timeout=30,
+        )
+        print(f"[2/6] Built ASAN-instrumented target: {binary.name}")
+
+        # --- 2. Crash input (BOF — 20 'A's into an 8-byte buf) ---
+        crash_dir = td_path / "crashes"
+        crash_dir.mkdir()
+        crash_file = crash_dir / "id_000000"
+        crash_file.write_bytes(b"A" * 20)
+        print(f"[3/6] Wrote crash input: {crash_file.name} "
+              f"({crash_file.stat().st_size}B)")
+
+        # --- 3. Real CrashContext ---
+        crash = CrashContext(
+            crash_id="000000",
+            binary_path=binary,
+            input_file=crash_file,
+            signal="11",
+            stack_trace=(
+                "#0 strcpy in target.c:10\n"
+                "#1 main in target.c:9"
+            ),
+            registers={"rip": "0x401234", "rsp": "0x7ffeXXX0"},
+            crash_instruction="mov BYTE PTR [rdi], al",
+            crash_address="0x7ffeYYYY",
+            stack_hash="deadbeefcafebabe",
+            disassembly="0x401234: mov BYTE PTR [rdi], al",
+            function_name="strcpy",
+            source_location="target.c:10",
+            binary_info={
+                "asan_enabled": "true",
+                "aslr_enabled": "true",
+                "nx_enabled": "true",
+                "stack_canaries": "true",
+            },
+            exploitability="exploitable",
+            crash_type="stack_overflow",
+            cvss_estimate=7.5,
+            analysis={},
+            exploit_code=None,
+        )
+        print(f"[4/6] Built CrashContext: {crash.crash_type} "
+              f"at {crash.source_location}")
+
+        # --- 4. Real CrashAnalysisAgent with execute=True ---
+        out_dir = td_path / "out"
+        agent = CrashAnalysisAgent(
+            binary_path=binary,
+            out_dir=out_dir,
+            verify_exploits=True,
+            judge_intent=False,  # save the extra LLM tiebreak call
+            record_witnesses=True,
+            execute_exploits=True,
+            execute_timeout=15,
+            execute_sanitizers=["address"],
+        )
+
+        # --- 5. Real LLM exploit generation + execution ---
+        print(f"[5/6] Invoking LLM (provider="
+              f"{agent.llm_config.primary_model.provider}, "
+              f"model={agent.llm_config.primary_model.model_name})...")
+        ok = agent.generate_exploit(crash)
+        if not ok:
+            print("FAIL: generate_exploit returned False — "
+                  "LLM produced no usable exploit code")
+            return 1
+
+        # --- 6. Inspect the recorded Witness ---
+        store_root = out_dir / "witnesses"
+        manifests = sorted((store_root / "manifests").glob("*.json"))
+        blobs = sorted((store_root / "blobs").glob("*"))
+        print(f"[6/6] Witnesses on disk: "
+              f"{len(manifests)} manifests, {len(blobs)} blobs")
+
+        store = WitnessStore(store_root)
+        for m in manifests:
+            w = store.get_witness(m.stem)
+            print(f"  - bytes_hash={w.bytes_hash[:16]}... "
+                  f"bytes_len={w.bytes_len} "
+                  f"source={w.source.value} "
+                  f"outcome={w.observed_outcome.value}")
+            for k, v in sorted(w.outcome_detail.items()):
+                if k == "evidence":
+                    print(f"    {k}: {v[:100]}{'...' if len(str(v)) > 100 else ''}")
+                else:
+                    print(f"    {k}: {v}")
+
+        # --- Hard assertions ---
+        ok_compile = crash.exploit_compiled is True
+        ok_executed = crash.execute_outcome is not None
+        outcome_value = crash.execute_outcome
+        # ASAN should have fired since we asked for sanitizers=["address"]
+        # AND the LLM was prompted with a stack_overflow crash context.
+        # If the LLM emitted code that doesn't trigger ASAN, we still
+        # consider the wiring proven — the substrate did its job.
+        print()
+        print("=" * 60)
+        print(f"compile_verify success: {ok_compile}")
+        print(f"execute attempted:      {ok_executed}")
+        print(f"observed outcome:       {outcome_value}")
+        if outcome_value == WitnessOutcome.SANITIZER_REPORT.value:
+            print("✓ ASAN fired — full chain proven end-to-end "
+                  "(LLM emit → sanitised compile → sandbox run → "
+                  "ASAN detect → witness with SANITIZER_REPORT)")
+        elif outcome_value == WitnessOutcome.EXIT_SIGNAL.value:
+            print("· Exit-signal outcome (substrate proven; LLM exploit "
+                  "didn't trigger ASAN — fine, the wiring still works)")
+        elif outcome_value == WitnessOutcome.NO_OBVIOUS_EFFECT.value:
+            print("· No-effect outcome (substrate proven; LLM exploit "
+                  "compiled + ran cleanly without triggering the bug)")
+        else:
+            print(f"· Other outcome: {outcome_value}")
+
+        # Pin the exploit_code → bytes_hash → manifest invariant
+        if crash.exploit_code:
+            expected = hashlib.sha256(
+                crash.exploit_code.encode("utf-8", errors="replace")
+            ).hexdigest()
+            blob_path = store_root / "blobs" / f"{expected}.bin"
+            if blob_path.exists():
+                print(f"✓ Exploit bytes_hash matches on-disk blob: "
+                      f"{expected[:16]}...")
+            else:
+                print(f"FAIL: expected blob {expected[:16]}... "
+                      f"not on disk")
+                return 1
+
+        return 0 if (ok_compile and ok_executed) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/llm_analysis/tests/test_crash_agent_execute.py
+++ b/packages/llm_analysis/tests/test_crash_agent_execute.py
@@ -1,0 +1,288 @@
+"""Tests for the ``--execute-exploits`` path in ``CrashAnalysisAgent``.
+
+The full end-to-end (compile → sandbox-run → witness write) is
+covered by ``test_exploit_verify_execute.py`` (which needs gcc).
+These tests focus on the wiring: that the agent calls
+``compile_and_execute`` instead of ``compile_verify`` when the flag
+is on, that the outcome flows into the Witness, that the executor
+respects the gate combinations.
+
+monkeypatched throughout — no real sandbox / gcc needed.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional
+
+
+# packages/llm_analysis/tests/test_crash_agent_execute.py
+#   parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from core.witness import WitnessOutcome  # noqa: E402
+from packages.binary_analysis.crash_analyser import CrashContext  # noqa: E402
+from packages.llm_analysis.crash_agent import CrashAnalysisAgent  # noqa: E402
+
+
+def _make_crash_context(
+    crash_id: str = "C0001",
+    binary_path: Optional[Path] = None,
+    source_location: str = "src/parser.c:42",
+) -> CrashContext:
+    return CrashContext(
+        crash_id=crash_id,
+        binary_path=binary_path or Path("/nonexistent"),
+        input_file=Path("/nonexistent_input"),
+        signal="11",
+        crash_type="stack_overflow",
+        source_location=source_location,
+        exploit_code="// poc",
+        exploit_compiled=None,
+        exploit_compile_errors=[],
+        intent_match=None,
+    )
+
+
+def _stub_agent(
+    tmp_path: Path,
+    binary: Path,
+    execute_exploits: bool = True,
+    execute_timeout: int = 5,
+    execute_sanitizers=None,
+):
+    """Build a minimal agent that has just enough state for the
+    execute + record helpers; bypasses the LLM-init constructor."""
+    agent = SimpleNamespace(
+        out_dir=tmp_path,
+        binary=binary,
+        record_witnesses=True,
+        _witness_store=None,
+        execute_exploits=execute_exploits,
+        execute_timeout=execute_timeout,
+        execute_sanitizers=execute_sanitizers,
+    )
+    agent._compile_and_execute_exploit = (
+        CrashAnalysisAgent._compile_and_execute_exploit.__get__(
+            agent, type(agent)
+        )
+    )
+    agent._record_exploit_witness = (
+        CrashAnalysisAgent._record_exploit_witness.__get__(
+            agent, type(agent)
+        )
+    )
+    agent._resolve_execute_outcome = (
+        CrashAnalysisAgent._resolve_execute_outcome
+    )
+    return agent
+
+
+# ----------------------------------------------------------------------
+# _compile_and_execute_exploit threads outcome onto crash_context
+# ----------------------------------------------------------------------
+
+
+def test_compile_and_execute_writes_execute_fields(tmp_path, monkeypatch):
+    """The helper must populate exploit_compiled + execute_outcome
+    + execute_detail on the crash_context."""
+    binary = tmp_path / "target"
+    binary.write_bytes(b"ELF")
+    agent = _stub_agent(tmp_path, binary)
+    crash = _make_crash_context()
+
+    captured_kwargs = {}
+
+    def fake_compile_and_execute(
+        exploit_code, target_file_path, artifact_id, **kwargs,
+    ):
+        captured_kwargs["target_file_path"] = target_file_path
+        captured_kwargs["artifact_id"] = artifact_id
+        captured_kwargs.update(kwargs)
+        return (
+            True, [], WitnessOutcome.EXIT_SIGNAL,
+            {"signal": "SIGSEGV", "crashed": True},
+        )
+
+    import packages.llm_analysis.exploit_verify as ev_mod
+    monkeypatch.setattr(
+        ev_mod, "compile_and_execute", fake_compile_and_execute,
+    )
+
+    agent._compile_and_execute_exploit(crash, "// exploit\n")
+
+    assert crash.exploit_compiled is True
+    assert crash.execute_outcome == WitnessOutcome.EXIT_SIGNAL.value
+    assert crash.execute_detail["signal"] == "SIGSEGV"
+    assert crash.execute_detail["crashed"] is True
+    # target_binary_path must flow through as self.binary
+    assert captured_kwargs["target_binary_path"] == binary
+    # timeout must be the agent's configured value
+    assert captured_kwargs["timeout"] == 5
+    # No sanitizers by default
+    assert captured_kwargs.get("sanitizers") is None
+    # source_location → target_file_path (strip line number)
+    assert captured_kwargs["target_file_path"] == "src/parser.c"
+
+
+def test_compile_and_execute_outcome_none_leaves_field_unset(
+    tmp_path, monkeypatch,
+):
+    """When compile_and_execute returns outcome=None (compile
+    failure, sandbox unavailable, etc.), execute_outcome stays
+    None on the crash_context."""
+    binary = tmp_path / "target"
+    binary.write_bytes(b"ELF")
+    agent = _stub_agent(tmp_path, binary)
+    crash = _make_crash_context()
+
+    def fake_compile_and_execute(*args, **kwargs):
+        return False, ["error line 1"], None, {}
+
+    import packages.llm_analysis.exploit_verify as ev_mod
+    monkeypatch.setattr(
+        ev_mod, "compile_and_execute", fake_compile_and_execute,
+    )
+
+    agent._compile_and_execute_exploit(crash, "// bad exploit\n")
+    assert crash.exploit_compiled is False
+    assert crash.exploit_compile_errors == ["error line 1"]
+    assert crash.execute_outcome is None
+    assert crash.execute_detail == {}
+
+
+# ----------------------------------------------------------------------
+# Witness recorder upgrades NOT_RUN → executed outcome
+# ----------------------------------------------------------------------
+
+
+def test_witness_records_executed_outcome(tmp_path, monkeypatch):
+    """When execute_outcome is set on the crash context, the
+    recorded Witness uses that outcome, not NOT_RUN."""
+    binary = tmp_path / "target"
+    binary.write_bytes(b"ELF")
+    agent = _stub_agent(tmp_path, binary)
+    crash = _make_crash_context()
+    crash.execute_outcome = WitnessOutcome.SANITIZER_REPORT.value
+    crash.execute_detail = {"sanitizer": "asan", "crashed": True}
+
+    agent._record_exploit_witness(crash, "// exploit\n")
+
+    from core.witness import WitnessStore
+    store = WitnessStore(tmp_path / "witnesses")
+    manifests = list(
+        (tmp_path / "witnesses" / "manifests").glob("*.json")
+    )
+    assert len(manifests) == 1
+    witness = store.get_witness(manifests[0].stem)
+    assert witness.observed_outcome is WitnessOutcome.SANITIZER_REPORT
+    assert witness.outcome_detail["sanitizer"] == "asan"
+    assert witness.outcome_detail["crashed"] is True
+
+
+def test_witness_keeps_not_run_when_executed_outcome_unset(
+    tmp_path, monkeypatch,
+):
+    """When execute_outcome is None (operator didn't pass
+    --execute-exploits or execution failed), the Witness stays
+    NOT_RUN — the legacy behaviour."""
+    binary = tmp_path / "target"
+    binary.write_bytes(b"ELF")
+    agent = _stub_agent(tmp_path, binary)
+    crash = _make_crash_context()
+    # execute_outcome stays default (None)
+
+    agent._record_exploit_witness(crash, "// exploit\n")
+
+    from core.witness import WitnessStore
+    store = WitnessStore(tmp_path / "witnesses")
+    manifests = list(
+        (tmp_path / "witnesses" / "manifests").glob("*.json")
+    )
+    witness = store.get_witness(manifests[0].stem)
+    assert witness.observed_outcome is WitnessOutcome.NOT_RUN
+    assert "sanitizer" not in witness.outcome_detail
+    assert "signal" not in witness.outcome_detail
+
+
+def test_resolve_execute_outcome_known_values():
+    assert (
+        CrashAnalysisAgent._resolve_execute_outcome("exit_signal")
+        is WitnessOutcome.EXIT_SIGNAL
+    )
+    assert (
+        CrashAnalysisAgent._resolve_execute_outcome("sanitizer_report")
+        is WitnessOutcome.SANITIZER_REPORT
+    )
+    assert (
+        CrashAnalysisAgent._resolve_execute_outcome("no_obvious_effect")
+        is WitnessOutcome.NO_OBVIOUS_EFFECT
+    )
+
+
+def test_resolve_execute_outcome_none_passes_through():
+    assert CrashAnalysisAgent._resolve_execute_outcome(None) is None
+    assert CrashAnalysisAgent._resolve_execute_outcome("") is None
+
+
+def test_resolve_execute_outcome_unknown_string_to_unknown():
+    """Defensive: future code path emitting an unrecognised
+    string should not break the witness write."""
+    assert (
+        CrashAnalysisAgent._resolve_execute_outcome("future_outcome")
+        is WitnessOutcome.UNKNOWN
+    )
+
+
+# ----------------------------------------------------------------------
+# Gate combination semantics
+# ----------------------------------------------------------------------
+
+
+def test_constructor_defaults():
+    """Default: execute_exploits=False (policy shift; opt-in only).
+    execute_timeout=5 matches the long-dormant safe_test_exploit
+    default. Inspected via signature rather than constructed,
+    since the real constructor needs LLM credentials."""
+    import inspect
+    sig = inspect.signature(CrashAnalysisAgent.__init__)
+    assert sig.parameters["execute_exploits"].default is False
+    assert sig.parameters["execute_timeout"].default == 5
+    assert sig.parameters["execute_sanitizers"].default is None
+
+
+def test_execute_sanitizers_flows_to_compile_and_execute(
+    tmp_path, monkeypatch,
+):
+    """``execute_sanitizers=['address']`` on the agent must reach
+    ``compile_and_execute`` as ``sanitizers=['address']``."""
+    binary = tmp_path / "target"
+    binary.write_bytes(b"ELF")
+    agent = _stub_agent(
+        tmp_path, binary, execute_sanitizers=["address", "undefined"],
+    )
+    crash = _make_crash_context()
+
+    captured_kwargs = {}
+
+    def fake_compile_and_execute(
+        exploit_code, target_file_path, artifact_id, **kwargs,
+    ):
+        captured_kwargs.update(kwargs)
+        return True, [], WitnessOutcome.SANITIZER_REPORT, {
+            "sanitizer": "asan", "crashed": True,
+        }
+
+    import packages.llm_analysis.exploit_verify as ev_mod
+    monkeypatch.setattr(
+        ev_mod, "compile_and_execute", fake_compile_and_execute,
+    )
+
+    agent._compile_and_execute_exploit(crash, "// exploit\n")
+
+    assert captured_kwargs.get("sanitizers") == ["address", "undefined"]
+    assert crash.execute_outcome == WitnessOutcome.SANITIZER_REPORT.value
+    assert crash.execute_detail["sanitizer"] == "asan"

--- a/packages/llm_analysis/tests/test_exploit_verify_execute.py
+++ b/packages/llm_analysis/tests/test_exploit_verify_execute.py
@@ -1,0 +1,318 @@
+"""Integration tests for ``compile_and_execute``.
+
+The unit-mappable side (outcome classification) is covered in
+``core/witness/tests/test_sandbox_outcome.py``. These tests exercise
+the full compile-then-sandbox-run path with real toy exploits so we
+catch wiring regressions (binary path missing, env not forwarded,
+sandbox kwargs drifting, etc.).
+
+Skipped when gcc isn't available — the host's gcc is required for the
+compile step. CI runners have gcc; some developer environments may not.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# packages/llm_analysis/tests/test_exploit_verify_execute.py
+#   parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from core.witness import WitnessOutcome  # noqa: E402
+from packages.llm_analysis.exploit_verify import (  # noqa: E402
+    compile_and_execute,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("gcc") is None,
+    reason="gcc not available — compile_and_execute needs it",
+)
+
+
+# ----------------------------------------------------------------------
+# Compile-only (execution skipped)
+# ----------------------------------------------------------------------
+
+
+def test_language_unsupported_returns_none_outcome():
+    """Non-C/C++ target: no compile, no execute, outcome=None."""
+    compiled, errors, outcome, detail = compile_and_execute(
+        "print('hi')",
+        target_file_path="src/foo.py",
+        artifact_id="lang-test",
+        timeout=2,
+    )
+    assert compiled is None
+    assert any("language_not_supported" in e for e in errors)
+    assert outcome is None
+    assert detail == {}
+
+
+def test_compile_failure_no_execution():
+    """When compilation fails, execution is skipped and outcome=None."""
+    bad_code = "this is not valid C syntax {{{"
+    compiled, errors, outcome, detail = compile_and_execute(
+        bad_code,
+        target_file_path="src/foo.c",
+        artifact_id="badcode-test",
+        timeout=2,
+    )
+    assert compiled is False
+    assert errors  # at least one compile error
+    assert outcome is None
+    assert detail == {}
+
+
+# ----------------------------------------------------------------------
+# Real execution
+# ----------------------------------------------------------------------
+
+
+_NULL_DEREF_C = """
+#include <stdio.h>
+int main(void) {
+    int *p = NULL;
+    *p = 42;
+    return 0;
+}
+"""
+
+
+_CLEAN_EXIT_C = """
+#include <stdio.h>
+int main(void) {
+    puts("hello from a clean exploit");
+    return 0;
+}
+"""
+
+
+def test_null_deref_to_exit_signal():
+    """End-to-end: NULL-deref toy exploit compiles, runs, gets
+    SIGSEGV in the sandbox, outcome=EXIT_SIGNAL with signal info."""
+    compiled, errors, outcome, detail = compile_and_execute(
+        _NULL_DEREF_C,
+        target_file_path="src/foo.c",
+        artifact_id="nullderef-test",
+        timeout=5,
+    )
+    assert compiled is True
+    assert errors == []
+    assert outcome is WitnessOutcome.EXIT_SIGNAL
+    assert detail.get("signal") == "SIGSEGV"
+    assert detail.get("crashed") is True
+
+
+def test_clean_exit_to_no_obvious_effect():
+    """Clean-exit exploit: outcome=NO_OBVIOUS_EFFECT, no signal info."""
+    compiled, _, outcome, detail = compile_and_execute(
+        _CLEAN_EXIT_C,
+        target_file_path="src/foo.c",
+        artifact_id="clean-test",
+        timeout=5,
+    )
+    assert compiled is True
+    assert outcome is WitnessOutcome.NO_OBVIOUS_EFFECT
+    assert "signal" not in detail
+    assert "sanitizer" not in detail
+
+
+def test_target_env_var_forwarded(tmp_path):
+    """The ``target_binary_path`` must reach the running exploit via
+    the ``TARGET`` env var — same calling convention
+    ``safe_test_exploit`` set up. Exploit code reads ``$TARGET`` and
+    writes to stdout; we verify by checking detail/output."""
+    target = tmp_path / "fake-target"
+    target.write_bytes(b"ELF-mock")
+
+    code = """
+#include <stdio.h>
+#include <stdlib.h>
+int main(void) {
+    const char *t = getenv("TARGET");
+    if (t == NULL) {
+        return 7;  /* TARGET missing → non-zero exit */
+    }
+    return 0;
+}
+"""
+    compiled, _, outcome, detail = compile_and_execute(
+        code,
+        target_file_path="src/foo.c",
+        artifact_id="target-env-test",
+        target_binary_path=target,
+        timeout=5,
+    )
+    assert compiled is True
+    # TARGET present → exits 0 → NO_OBVIOUS_EFFECT (no signal, no sanitizer)
+    assert outcome is WitnessOutcome.NO_OBVIOUS_EFFECT
+    assert detail.get("returncode") == 0
+
+
+def test_timeout_classified_as_unknown_with_detail():
+    """An exploit that loops forever hits the timeout. The sandbox
+    raises ``subprocess.TimeoutExpired`` rather than returning a
+    CompletedProcess, so the mapper has no ``sandbox_info`` to
+    classify. The contract: don't raise, return
+    ``outcome=UNKNOWN`` with ``timed_out=True`` so consumers can
+    distinguish a hang from "we never tried" (outcome=None)."""
+    code = """
+int main(void) {
+    while (1) {}
+    return 0;
+}
+"""
+    compiled, _, outcome, detail = compile_and_execute(
+        code,
+        target_file_path="src/foo.c",
+        artifact_id="timeout-test",
+        timeout=1,
+    )
+    assert compiled is True
+    assert outcome is WitnessOutcome.UNKNOWN
+    assert detail.get("timed_out") is True
+    assert detail.get("timeout_s") == 1
+
+
+# ----------------------------------------------------------------------
+# Sanitizer integration — SANITIZER_REPORT outcome via -fsanitize=address
+# ----------------------------------------------------------------------
+
+
+def _has_libasan() -> bool:
+    """gcc may be present but libasan missing — check by compiling
+    a no-op program with ``-fsanitize=address``."""
+    if shutil.which("gcc") is None:
+        return False
+    try:
+        result = subprocess.run(
+            ["gcc", "-fsanitize=address", "-x", "c", "-",
+             "-o", "/dev/null"],
+            input="int main(void){return 0;}",
+            text=True,
+            capture_output=True,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
+# Trivially-fuzzable BOF — same shape as the
+# test/data/trivially_fuzzable/target.c fixture, but standalone
+# in-memory so we don't depend on the fixture being on the
+# Python path. Source is a strcpy of 20 bytes into an 8-byte
+# stack buffer.
+_BOF_SOURCE_FOR_ASAN = """
+#include <string.h>
+#include <stdio.h>
+int main(void) {
+    char buf[8];
+    const char *src = "AAAAAAAAAAAAAAAAAAAA";
+    strcpy(buf, src);
+    puts(buf);
+    return 0;
+}
+"""
+
+
+@pytest.mark.skipif(
+    not _has_libasan(),
+    reason="gcc -fsanitize=address not usable on this host",
+)
+def test_sanitizer_address_flows_to_sanitizer_report_outcome():
+    """End-to-end: compile a BOF with sanitizers=['address'], run
+    in the sandbox, expect ``WitnessOutcome.SANITIZER_REPORT`` with
+    ``sanitizer='asan'`` in detail.
+
+    Closes the loop between:
+
+      * ExploitValidator's ``sanitizers=`` kwarg (compile-side
+        instrumentation)
+      * ``compile_and_execute`` threading the kwarg through
+      * The sandbox layer's ``observe._interpret_result``
+        catching the ASAN report on stderr
+      * The witness mapper classifying as SANITIZER_REPORT
+
+    Pre-fix (before sanitizers threaded through compile_and_execute),
+    the same source compiled cleanly but produced an unsanitised
+    binary — runtime BOF surfaced as EXIT_SIGNAL (SIGSEGV or SIGABRT
+    via stack canary) rather than the more specific SANITIZER_REPORT.
+    """
+    compiled, errors, outcome, detail = compile_and_execute(
+        _BOF_SOURCE_FOR_ASAN,
+        target_file_path="src/foo.c",
+        artifact_id="asan-bof-test",
+        timeout=10,
+        sanitizers=["address"],
+    )
+    assert compiled is True, f"compile errors: {errors}"
+    assert outcome is WitnessOutcome.SANITIZER_REPORT
+    assert detail.get("sanitizer") == "asan"
+    # Modern libsanitizer (default halt_on_error=1) exits via
+    # ``_exit(1)`` rather than raising a signal — sandbox_info's
+    # ``crashed`` is set on the ASAN-detection branch even
+    # without a signal.
+    assert detail.get("crashed") is True
+    # Evidence summary surfaces the bug class — useful for
+    # downstream consumers reading the manifest.
+    assert "AddressSanitizer" in detail.get("evidence", "")
+
+
+@pytest.mark.skipif(
+    not _has_libasan(),
+    reason="gcc -fsanitize=address not usable on this host",
+)
+def test_sanitizer_address_clean_source_no_false_fire():
+    """ASAN-instrumented clean source: runs to completion, outcome
+    is NO_OBVIOUS_EFFECT (not SANITIZER_REPORT). Guards against
+    instrumentation noise falsely firing the sanitizer-class
+    detection."""
+    clean_code = """
+#include <stdio.h>
+int main(void) {
+    puts("hi");
+    return 0;
+}
+"""
+    compiled, _, outcome, detail = compile_and_execute(
+        clean_code,
+        target_file_path="src/foo.c",
+        artifact_id="asan-clean-test",
+        timeout=5,
+        sanitizers=["address"],
+    )
+    assert compiled is True
+    assert outcome is WitnessOutcome.NO_OBVIOUS_EFFECT
+    assert "sanitizer" not in detail
+    assert "signal" not in detail
+
+
+def test_no_sanitizer_default_unchanged():
+    """Regression guard: omitting ``sanitizers=`` keeps the
+    historical behaviour (no instrumentation). A BOF still
+    crashes, but as EXIT_SIGNAL rather than SANITIZER_REPORT —
+    confirming the kwarg is genuinely opt-in."""
+    compiled, _, outcome, detail = compile_and_execute(
+        _BOF_SOURCE_FOR_ASAN,
+        target_file_path="src/foo.c",
+        artifact_id="no-san-bof-test",
+        timeout=5,
+    )
+    assert compiled is True
+    # The exact outcome depends on host glibc (stack canary may
+    # catch the overflow → SIGABRT; without canary → SIGSEGV).
+    # Either way it's EXIT_SIGNAL, never SANITIZER_REPORT
+    # because nothing's instrumented.
+    assert outcome is WitnessOutcome.EXIT_SIGNAL
+    assert detail.get("sanitizer") is None
+    # Should NOT have a sanitizer key at all
+    assert "sanitizer" not in detail

--- a/packages/llm_analysis/witness_adapter.py
+++ b/packages/llm_analysis/witness_adapter.py
@@ -49,6 +49,8 @@ def witness_from_exploit(
     intent_confidence: Optional[float] = None,
     target_source_path: Optional[Path] = None,
     target_binary_path: Optional[Path] = None,
+    executed_outcome: Optional[WitnessOutcome] = None,
+    executed_detail: Optional[dict] = None,
     produced_by: str = "agentic",
 ) -> tuple[Witness, bytes]:
     """Wrap an LLM-emitted exploit as a ``Witness`` + the raw bytes.
@@ -81,6 +83,14 @@ def witness_from_exploit(
     when the LLM-emitted exploit was synthesised against a built
     target (e.g. crash-agent's path from a fuzz crash). The
     ``/agentic`` path normally has source only, no binary.
+
+    ``executed_outcome`` overrides the default ``NOT_RUN`` when the
+    caller actually ran the exploit (the PR E path:
+    ``--execute-exploits`` is on, ``compile_and_execute`` returned an
+    outcome). ``executed_detail`` (when present) merges into
+    ``outcome_detail`` so the executed signal / sanitizer / blocked
+    fields land alongside the compile + intent-match verdicts.
+    Default ``None`` keeps the legacy NOT_RUN behaviour.
     """
     data = exploit_code.encode("utf-8", errors="replace")
     bytes_hash = compute_bytes_hash(data)
@@ -100,6 +110,12 @@ def witness_from_exploit(
         outcome_detail["intent_verdict"] = intent_verdict
     if intent_confidence is not None:
         outcome_detail["intent_confidence"] = intent_confidence
+    if executed_detail:
+        # Executed-side fields don't collide with the compile/
+        # intent-match keys above; merge in directly. Caller is
+        # responsible for not stuffing huge payloads here — keep
+        # the manifest readable.
+        outcome_detail.update(executed_detail)
 
     target_source_hash: Optional[str] = None
     if target_source_path is not None and target_source_path.is_file():
@@ -109,11 +125,16 @@ def witness_from_exploit(
     if target_binary_path is not None and target_binary_path.is_file():
         target_binary_hash = sha256_file(target_binary_path)
 
+    observed_outcome = (
+        executed_outcome if executed_outcome is not None
+        else WitnessOutcome.NOT_RUN
+    )
+
     witness = Witness(
         bytes_hash=bytes_hash,
         bytes_len=len(data),
         source=WitnessSource.LLM_EMIT_RUN,
-        observed_outcome=WitnessOutcome.NOT_RUN,
+        observed_outcome=observed_outcome,
         outcome_detail=outcome_detail,
         target_binary_hash=target_binary_hash,
         target_source_hash=target_source_hash,

--- a/raptor_fuzzing.py
+++ b/raptor_fuzzing.py
@@ -120,6 +120,49 @@ Examples:
              "flag only affects the secondary LLM-exploit "
              "Witnesses produced by ``CrashAnalysisAgent``.",
     )
+    ap.add_argument(
+        "--execute-exploits",
+        action="store_true",
+        help="Execute each LLM-emitted exploit against the fuzzed "
+             "binary inside the sandbox after compile-verify, then "
+             "thread the observed outcome (EXIT_SIGNAL / "
+             "SANITIZER_REPORT / NO_OBVIOUS_EFFECT / ...) into the "
+             "recorded Witness. DEFAULT OFF — actually running LLM-"
+             "generated code is a policy shift even with the "
+             "sandbox (Landlock + seccomp + namespaces + network "
+             "block). Enable when you want post-execution evidence "
+             "in the Witness manifest; pair with --no-network if "
+             "you want the strictest containment. Requires "
+             "compile-verify (cannot run without a binary), so "
+             "implicitly no-op when --no-verify-exploits is also "
+             "set. Per-exploit timeout: 5s by default; raise via "
+             "--execute-timeout if your exploits genuinely need "
+             "more wall-clock.",
+    )
+    ap.add_argument(
+        "--execute-timeout",
+        type=int,
+        default=5,
+        help="Per-exploit execution timeout in seconds (only "
+             "meaningful with --execute-exploits). Default 5s — "
+             "matches the long-dormant ``safe_test_exploit`` "
+             "default. Timeouts surface as outcome=UNKNOWN with "
+             "timed_out=True in the Witness detail.",
+    )
+    ap.add_argument(
+        "--execute-sanitizers",
+        type=str,
+        default="",
+        help="Comma-separated gcc sanitizer names to compile each "
+             "exploit with before execution (e.g. "
+             "``address,undefined``). Only meaningful with "
+             "--execute-exploits. When ``address`` is included, an "
+             "exploit that triggers a memory-safety bug surfaces as "
+             "WitnessOutcome.SANITIZER_REPORT (vs the bare "
+             "EXIT_SIGNAL you get from an unsanitised crash). "
+             "Allowlist matches ExploitValidator: address, undefined, "
+             "memory, thread, leak, kernel-address, hwaddress.",
+    )
 
     from core.sandbox import add_cli_args, apply_cli_args
     add_cli_args(ap)
@@ -465,6 +508,13 @@ Examples:
             verify_exploits=not args.no_verify_exploits,
             judge_intent=not args.no_judge_intent,
             record_witnesses=not args.no_record_witnesses,
+            execute_exploits=args.execute_exploits,
+            execute_timeout=args.execute_timeout,
+            execute_sanitizers=(
+                [s.strip() for s in args.execute_sanitizers.split(",")
+                 if s.strip()]
+                if args.execute_sanitizers else None
+            ),
         )
 
         # Initialize multi-turn analyser if autonomous mode


### PR DESCRIPTION
Wires the long-dormant safe_test_exploit machinery into the Witness substrate so an LLM-emitted exploit from
CrashAnalysisAgent can be executed against the fuzzed binary in the sandbox, with the observed outcome (EXIT_SIGNAL / SANITIZER_REPORT / NO_OBVIOUS_EFFECT / UNKNOWN) threaded back into the Witness manifest.

Three layers:

1. core/witness/sandbox_outcome.py — pure mapper from the sandbox's sandbox_info dict (signal, sanitizer, blocked, etc.) to (WitnessOutcome, detail). Sanitizer > signal > blocked-only > clean-exit precedence. core/witness/ stays free of core/sandbox/ imports — the function takes a plain dict so the dependency arrow points the right way.

2. compile_and_execute in packages/llm_analysis/exploit_verify.py — compiles in a tempdir, then runs the binary via core.sandbox.run within the same tempdir scope. Reads result.sandbox_info, maps through the new mapper. Accepts sanitizers= and threads it to ExploitValidator so an exploit instrumented with -fsanitize=address surfaces ASAN reports as SANITIZER_REPORT outcomes. Timeouts → UNKNOWN with timed_out=True so consumers distinguish a hang from "never tried" (outcome=None).

3. CrashAnalysisAgent wiring: --execute-exploits (DEFAULT OFF — running LLM code is a policy shift even with Landlock+seccomp+namespaces+network block), --execute-timeout (5s default), --execute-sanitizers=address,undefined for runtime memory-safety detection. CrashContext gains execute_outcome + execute_detail; the witness recorder upgrades the Witness from NOT_RUN to the observed outcome.

WitnessStore atomic-write fix: per-(pid, thread) suffix on .tmp filenames. Adversarial review surfaced a race where N threads writing the same hash concurrently raced on the shared .bin.tmp / .json.tmp paths and N-1 callers raised
FileNotFoundError from os.replace.

All failure modes log+continue — the exploit artefact on disk is the primary record; the witness is downstream-facing. Operator E2E verified end-to-end against Gemini 2.5 Pro: LLM emits exploit → c++ compiles → sandbox runs → witness recorded with correct outcome + bytes_hash + target_binary_hash
+ cwe_id derived from crash_type. Re-runnable via packages/llm_analysis/scripts/e2e_execute_witness.py.

Tests (73 new):
- Mapper unit (18): every outcome path, precedence, detail- shape invariants.
- WitnessStore concurrency (2): same-hash and distinct-hash multi-thread regression guards.
- compile_and_execute integration with real gcc (9): language gate, compile-fail, NULL-deref → EXIT_SIGNAL, clean exit → NO_OBVIOUS_EFFECT, TARGET env, timeout → UNKNOWN, live ASAN BOF → SANITIZER_REPORT, ASAN clean source no false-fire, no- sanitizer default unchanged.
- CrashAnalysisAgent wiring (9): kwargs threaded, sanitizers threaded, outcome flows to witness, defaults preserved, store.put failure non-fatal.
- Adapter, agent-record-witness, crash-agent-record-witness parity with the existing wiring.