### PR TITLE
Test improvements

### DIFF
--- a/.github/scripts/compute_filters.py
+++ b/.github/scripts/compute_filters.py
@@ -183,6 +183,36 @@ FILTERS: dict[str, list[str]] = {
         "requirements*.txt",
         ".github/workflows/tests.yml",
     ],
+    # SCA tier — ~3,255 tests as of 2026-05-23, ≈30% of the broad
+    # ``python`` fast tier's collected count. Carving into its own
+    # gated job removes a 30-percent-of-corpus cluster from the
+    # 4-way pytest-split, evening out the fast-tier shards. Globs
+    # cover packages/sca + the 16 core/ and 3 packages/ siblings
+    # SCA actually imports (validated by test_filter_coverage.py).
+    "sca": [
+        "packages/sca/**",
+        "core/binary/**",
+        "core/config/**",
+        "core/coverage/**",
+        "core/cve/**",
+        "core/dockerfile/**",
+        "core/http/**",
+        "core/inventory/**",
+        "core/json/**",
+        "core/llm/**",
+        "core/oci/**",
+        "core/progress/**",
+        "core/sandbox/**",
+        "core/security/**",
+        "core/tar/**",
+        "core/upstream_latest/**",
+        "core/zip/**",
+        "packages/binary_analysis/**",
+        "packages/cvss/**",
+        "packages/osv/**",
+        "requirements*.txt",
+        ".github/workflows/tests.yml",
+    ],
     "orchestration": [
         "core/orchestration/**",
         "core/ast/**",

--- a/.github/tests/test_filter_coverage.py
+++ b/.github/tests/test_filter_coverage.py
@@ -42,6 +42,7 @@ SUBSYSTEMS: list[tuple[str, str]] = [
     ("fuzzing", "packages/fuzzing"),
     ("sage", "core/sage"),
     ("orchestration", "core/orchestration"),
+    ("sca", "packages/sca"),
 ]
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,6 +101,7 @@ jobs:
       fuzzing: ${{ steps.filter.outputs.fuzzing }}
       sage: ${{ steps.filter.outputs.sage }}
       orchestration: ${{ steps.filter.outputs.orchestration }}
+      sca: ${{ steps.filter.outputs.sca }}
       force_full: ${{ steps.force.outputs.force_full }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
@@ -302,6 +303,7 @@ jobs:
             --ignore=packages/cve_diff/tests \
             --ignore=packages/fuzzing/tests \
             --ignore=packages/oss_forensics/tests \
+            --ignore=packages/sca \
             --ignore=core/sage/tests \
             --ignore=core/orchestration/tests \
             --ignore=core/security/tests/test_prompt_envelope_audit.py
@@ -318,6 +320,49 @@ jobs:
       # run in this job (group 1 only). They now have their own
       # dedicated job (`ci-lint-tests`) gated on `.github/**` changes
       # so a code-only PR doesn't pay for them.
+
+  # SCA tier: ~3,255 tests covering manifest parsers across 12 ecosystems,
+  # the dep-resolver fleet, the bumper, the supply-chain detectors, and
+  # the calibration substrate. The size class (≈30% of the broad ``python``
+  # fast tier's collected count) is why it gets carved out — a single
+  # cluster of that magnitude blew out one shard of the 4-way pytest-split
+  # before this carve-out. Internally 4-way split (same shape as fast tier).
+  python-unit-tests-sca:
+    needs: [pre_check, changes, deps]
+    if: |
+      needs.pre_check.outputs.should_skip != 'true' &&
+      (needs.changes.outputs.force_full == 'true' ||
+       needs.changes.outputs.sca == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Download venv artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # was v8.0.1
+        with:
+          name: venv-${{ github.run_id }}
+          path: ${{ env.VENV_PATH }}
+
+      - name: Restore venv permissions
+        run: chmod +x $VENV_PATH/bin/*
+
+      - name: Run SCA tests (group ${{ matrix.group }} of 4)
+        run: |
+          source $VENV_PATH/bin/activate
+          python -m pytest -n auto --splits 4 --group ${{ matrix.group }} packages/sca
 
   # Sandbox tier: ~251 heavyweight tests doing real namespace/mount/seccomp
   # work. Gated on sandbox-related path changes only.

--- a/packages/sca/supply_chain/tests/test_slopsquat.py
+++ b/packages/sca/supply_chain/tests/test_slopsquat.py
@@ -262,13 +262,13 @@ def test_split_suffix_handles_scoped_name() -> None:
 # Orchestrator integration.
 # ---------------------------------------------------------------------------
 
-def test_emits_through_supply_chain_orchestrator() -> None:
+def test_emits_through_supply_chain_orchestrator(tmp_path) -> None:
     """End-to-end: ``supply_chain.evaluate`` wires the slopsquat
     detector and produces a ``slopsquat_suspect`` finding with
     the documented shape."""
     from packages.sca.supply_chain import evaluate
     deps = [_dep("lodash-pro", "npm")]
-    findings = evaluate(target=Path("/tmp"), manifests=[], deps=deps)
+    findings = evaluate(target=tmp_path, manifests=[], deps=deps)
     slop = [f for f in findings if f.kind == "slopsquat_suspect"]
     assert len(slop) == 1
     f = slop[0]
@@ -278,13 +278,13 @@ def test_emits_through_supply_chain_orchestrator() -> None:
     assert f.evidence["reasons"] == ["popular_prefix_generic_suffix"]
 
 
-def test_orchestrator_emits_multiple_per_dep_list() -> None:
+def test_orchestrator_emits_multiple_per_dep_list(tmp_path) -> None:
     """Two suspect deps → two findings."""
     from packages.sca.supply_chain import evaluate
     deps = [
         _dep("lodash-pro", "npm"),
         _dep("@cool-utils/express-utils", "npm"),
     ]
-    findings = evaluate(target=Path("/tmp"), manifests=[], deps=deps)
+    findings = evaluate(target=tmp_path, manifests=[], deps=deps)
     slop = [f for f in findings if f.kind == "slopsquat_suspect"]
     assert len(slop) == 2


### PR DESCRIPTION
test(sca): use tmp_path fixture in slopsquat orchestrator tests

Two end-to-end tests passed `Path('/tmp')` as the supply-chain `evaluate()` target. Two of `evaluate()`'s downstream detectors  (_artefacts.scan_target, _python_imports.scan_target) walk the   target tree recursively even when manifests=[]. With a populated  /tmp (dev box or any CI runner that doesn't isolate /tmp per-job),  those walks accidentally exercise whatever's there:

     clean tmpdir → 0.008s
     populated /tmp → 140s

So these two tests dominated the SCA wall-clock — when one shard of the 4-way pytest-split happened to pick both, that shard ran 4+ minutes longer than the others. Hence the "python-unit-tests-4 slow" report.

Switch to the pytest `tmp_path` fixture so the tests exercise the slopsquat detector against a hermetic empty directory, as intended. No behaviour assertion changes — the slopsquat findings shape was always the test's point; the target dir was incidental plumbing.
