### PR TITLE
feat(reachability): JS/Go function-as-argument framework registration

### DIFF
--- a/core/inventory/_reach_cache.py
+++ b/core/inventory/_reach_cache.py
@@ -73,7 +73,12 @@ logger = logging.getLogger(__name__)
 # to definitive forward/reverse edges. An old V4 cache would have
 # returned these callers in ``method_match_overinclusive`` instead
 # of ``definitive`` — same correctness shift, bump for parity.
-_CACHE_VERSION = 5
+# V6 (2026-05-23): _AdjacencyIndex grew a `framework_registered`
+# field (S2: JS / Go function-as-argument framework registration
+# via _FRAMEWORK_REGISTRATION_TAILS + CallSite.argument_identifiers).
+# An old V5 cache returns _AdjacencyIndex instances without the
+# new attribute — AttributeError on access by is_registered_via_call.
+_CACHE_VERSION = 6
 
 _CACHE_DIR = Path.home() / ".cache" / "raptor" / "reachability"
 
@@ -281,19 +286,6 @@ def load_index(fingerprint: Optional[str]) -> Optional["_AdjacencyIndex"]:
         )
         return None
     try:
-        # nosemgrep: python.lang.security.deserialization.pickle.avoid-pickle
-        # Trust analysis: cache path is ``~/.cache/raptor/
-        # reachability/<fingerprint>.bin`` — RAPTOR's own cache dir
-        # under the operator's home. Files are created with mode
-        # ``0o600`` (owner-only) via O_EXCL atomic write
-        # (no symlink-following). A magic-prefix sentinel
-        # (``_HEADER_MAGIC``) guards format; mismatched files skip
-        # the pickle path entirely. An attacker with write access
-        # here has already broken the security boundary far worse
-        # than pickle exposure. Accept pickle for fast cache
-        # load/save of compiled adjacency indices over a code-
-        # execution-class CWE that doesn't apply to this trust
-        # profile.
         idx = pickle.loads(blob[len(_HEADER_MAGIC):])
     except (pickle.UnpicklingError, EOFError, AttributeError,
             ImportError, IndexError, TypeError, ValueError) as exc:
@@ -322,8 +314,6 @@ def save_index(
         return
     try:
         _CACHE_DIR.mkdir(parents=True, exist_ok=True)
-        # nosemgrep: python.lang.security.audit.insecure-file-permissions
-        # 0o700 = owner-only — most restrictive POSIX mode.
         os.chmod(_CACHE_DIR, 0o700)
     except OSError as exc:
         logger.debug("reach_cache: dir setup failed: %s", exc)
@@ -342,8 +332,6 @@ def save_index(
                 # newer Python is still readable on older runtimes
                 # in the same dev environment.
                 pickle.dump(index, f, protocol=4)
-            # nosemgrep: python.lang.security.audit.insecure-file-permissions
-            # 0o600 = owner-only file mode (no group/other).
             os.chmod(tmp_path, 0o600)
             os.rename(tmp_path, path)
         except BaseException:

--- a/core/inventory/call_graph.py
+++ b/core/inventory/call_graph.py
@@ -128,11 +128,25 @@ class CallSite:
     ``class C.foo`` if B and C are unrelated. ``None`` everywhere
     else — module-level call, non-self chain, longer chain than the
     safe-narrow case.
+
+    ``argument_identifiers`` is the list of bare-identifier
+    arguments at this call site. For ``http.HandleFunc("/x",
+    handler)`` the list is ``["handler"]``; for ``app.use(mw1,
+    mw2)`` it is ``["mw1", "mw2"]``; for ``f("string", 42)`` it
+    is ``[]``. Used by the reachability resolver to detect
+    function-as-argument registration (Express / Fastify / Koa /
+    net/http / gin / echo route handlers) — a function passed as
+    an argument to a recognised registration method is callable
+    via that framework's runtime dispatch even though no static
+    call site invokes it directly. Populated by extractors that
+    bother — empty list when the extractor hasn't been taught to
+    record arguments (backwards-compatible default).
     """
     line: int
     chain: List[str]
     caller: Optional[str] = None
     receiver_class: Optional[str] = None
+    argument_identifiers: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -255,6 +269,15 @@ class FileCallGraph:
                 entry["caller"] = intern(c.caller)
             if c.receiver_class is not None:
                 entry["receiver_class"] = intern(c.receiver_class)
+            # argument_identifiers omitted from serialised form when
+            # empty — the vast majority of call sites have no
+            # identifier args (constant args, no args, etc.) and
+            # writing empty lists for all of them inflates inventory
+            # JSON size meaningfully on large repos.
+            if c.argument_identifiers:
+                entry["argument_identifiers"] = [
+                    intern(a) for a in c.argument_identifiers
+                ]
             calls.append(entry)
 
         # Intern import keys + values — the same dependency name
@@ -299,6 +322,11 @@ class FileCallGraph:
                     chain=list(c.get("chain") or []),
                     caller=c.get("caller"),
                     receiver_class=c.get("receiver_class"),
+                    # Older inventories pre-date argument_identifiers;
+                    # `or []` defaults to empty for backwards compat.
+                    argument_identifiers=list(
+                        c.get("argument_identifiers") or []
+                    ),
                 )
                 for c in (d.get("calls") or [])
             ],
@@ -983,6 +1011,7 @@ class _JsCallGraph:
             chain=chain,
             caller=caller,
             receiver_class=receiver_class,
+            argument_identifiers=self._call_identifier_args(node),
         ))
 
     # ------------------------------------------------------------------
@@ -1074,6 +1103,36 @@ class _JsCallGraph:
             if c.is_named:
                 return c.type == self._STRING_NODE
         return False
+
+    def _call_identifier_args(self, call_node) -> List[str]:
+        """Bare-identifier argument names at this call site, in order.
+
+        ``f(handler)`` → ``["handler"]``.
+        ``app.get('/x', handler)`` → ``["handler"]`` (string literal
+        skipped — only identifiers are recorded).
+        ``app.use(mw1, mw2)`` → ``["mw1", "mw2"]``.
+        ``f(() => {}, 42)`` → ``[]`` (arrow function not an identifier).
+        ``f(obj.method)`` → ``[]`` (member access not a bare ident;
+        recorded as a CALL chain elsewhere when invoked but here as
+        an argument we conservatively skip — bare references to
+        functions defined in the file are the load-bearing case for
+        framework-registration detection).
+
+        Used by the resolver to detect function-as-argument
+        registration patterns (Express ``app.get(path, handler)``,
+        Go ``http.HandleFunc(path, handler)``). Empty list when no
+        identifier args present — vast majority of call sites.
+        """
+        args = self._first_child_of_type(call_node, (self._ARGS_NODE,))
+        if args is None:
+            return []
+        out: List[str] = []
+        for c in args.children:
+            if not c.is_named:
+                continue
+            if c.type == self._IDENT_NODE:
+                out.append(c.text.decode())
+        return out
 
     def _subscript_string_literal(self, subscript_node) -> Optional[str]:
         """``obj["name"]`` → ``"name"``. Returns None for
@@ -1466,6 +1525,7 @@ class _GoCallGraph:
             line=node.start_point[0] + 1,
             chain=chain,
             caller=caller,
+            argument_identifiers=self._call_identifier_args(node),
         ))
 
     def _call_callee(self, call_node):
@@ -1476,6 +1536,40 @@ class _GoCallGraph:
             if c.is_named:
                 return c
         return None
+
+    def _call_identifier_args(self, call_node) -> List[str]:
+        """Bare-identifier argument names at this call site, in order.
+
+        ``http.HandleFunc("/x", handler)`` → ``["handler"]`` (string
+        literal skipped — only identifiers are recorded).
+        ``router.GET("/users", listUsers, authMW)`` →
+        ``["listUsers", "authMW"]``.
+        ``f(struct{}{})`` → ``[]`` (composite literal not an
+        identifier).
+        ``f(obj.Method)`` → ``[]`` (selector_expression not a bare
+        identifier; method values aren't recorded here — the
+        load-bearing case for framework-registration detection is
+        bare function references defined in the file).
+
+        Used by the resolver to detect function-as-argument
+        registration patterns (net/http ``HandleFunc``, gin/echo
+        ``GET/POST/...``, chi ``Get/Post/...``). Empty list when no
+        identifier args present — vast majority of call sites.
+        """
+        args = None
+        for c in call_node.children:
+            if c.type == self._ARG_LIST_NODE:
+                args = c
+                break
+        if args is None:
+            return []
+        out: List[str] = []
+        for c in args.children:
+            if not c.is_named:
+                continue
+            if c.type == self._IDENT_NODE:
+                out.append(c.text.decode())
+        return out
 
     def _callee_chain(self, callee) -> Optional[List[str]]:
         """``foo`` → ``["foo"]``;

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -783,6 +783,15 @@ class _AdjacencyIndex:
     # ``definitive`` set for these, but they are NOT dead code;
     # consumers should treat them as entry points.
     framework_callable: Set[InternalFunction] = field(default_factory=set)
+    # Functions referenced as identifier arguments to a framework
+    # registration call (``http.HandleFunc("/x", handler)``,
+    # ``app.get("/users", listUsers)``, etc.). Sister to
+    # ``framework_callable`` but covers the JS / Go pattern where
+    # the framework registers handlers via call arguments rather
+    # than decorators. Populated from CallSite.argument_identifiers
+    # which the JS + Go extractors emit (other languages populate
+    # an empty list — the set just stays empty for them).
+    framework_registered: Set[InternalFunction] = field(default_factory=set)
     # ``qualified_name -> InternalFunction`` for project-defined
     # functions reachable via cross-package import. Used by
     # callers_of() to follow ExternalFunction → InternalFunction
@@ -934,6 +943,50 @@ def _get_or_build_index(
                 if fn.line == df_line:
                     idx.framework_callable.add(fn)
                     break
+
+    # Pass 1.3b: scan call sites for framework registration —
+    # ``http.HandleFunc("/x", handler)``, ``app.get("/users",
+    # listUsers)``, etc. The JS / Go pattern that mirrors Python's
+    # decorator-based framework dispatch: a handler function is
+    # passed as an identifier argument to a recognised registration
+    # method. The CallSite.argument_identifiers field carries the
+    # identifier args; ``_FRAMEWORK_REGISTRATION_TAILS`` curates
+    # the chain tails we treat as registration. Chain-length-2
+    # gate parallels the decorator detector — bare ``get(handler)``
+    # calls don't qualify (too generic), but ``app.get(handler)``
+    # does.
+    #
+    # Same-file matching only: the registered function must be
+    # defined in the same file as the registration call. Cross-file
+    # resolution (handler in handlers.js, registration in
+    # routes.js) is a follow-up — would require resolving the
+    # identifier through the file's import map, which is more
+    # invasive. Same-file covers the common Go pattern (handlers
+    # + main in same file or small package) and small Express apps.
+    for file_record in inventory.get("files", []):
+        if not isinstance(file_record, dict):
+            continue
+        path = file_record.get("path") or ""
+        cg = file_record.get("call_graph")
+        if not cg:
+            continue
+        for call in cg.get("calls") or []:
+            if not isinstance(call, dict):
+                continue
+            chain = call.get("chain") or []
+            if len(chain) < 2:
+                continue
+            tail = str(chain[-1])
+            if tail not in _FRAMEWORK_REGISTRATION_TAILS:
+                continue
+            arg_idents = call.get("argument_identifiers") or []
+            for ident in arg_idents:
+                candidates = idx.definitions.get((path, ident), set())
+                # Function defined in same file — register all
+                # matching InternalFunctions (only one per
+                # (path, name) typically, unless overloaded).
+                for fn in candidates:
+                    idx.framework_registered.add(fn)
 
     # Pass 1.4: capture class metadata from call_graph data. Maps
     # each method's InternalFunction to its owning class, and
@@ -1280,6 +1333,48 @@ _FRAMEWORK_DISPATCH_TAILS: FrozenSet[str] = frozenset({
     "query", "mutation", "subscription", "field", "resolver",
     # Build tools (e.g. nox, doit, pyinvoke)
     "session", "module_task",
+})
+
+
+# Chain tails recognised as framework registration calls — the JS /
+# Go pattern where a handler is passed as an identifier argument to a
+# routing or middleware-registration method. For
+# ``app.get("/x", handler)``, the chain tail is ``get`` and ``handler``
+# is the registered function. The set is curated against:
+# Express / Fastify / Koa / Hono (HTTP verb methods + ``use`` + ``route``),
+# Go net/http (``Handle``, ``HandleFunc``), gin / echo (capitalised HTTP
+# verbs + ``Use`` + ``Group``), chi (mixed-case verbs + ``Method`` /
+# ``MethodFunc`` / ``Mount``). The chain-length-2 gate (matching
+# ``_decorators_indicate_framework_dispatch``'s philosophy) keeps bare
+# ``get(...)`` / ``use(...)`` calls from being treated as registration:
+# they're far more likely user-defined helpers than framework calls.
+#
+# FALSE-POSITIVE awareness:
+#   * ``map.get(key)`` shape: any chain ending in ``get`` matches.
+#     Mitigation: tail-set excludes the most generic verbs that double
+#     as Map/Set accessors (``set``, ``has``); registered HTTP verbs
+#     (``get``/``post``/etc.) cannot be cleanly disambiguated without
+#     receiver-type tracking. Accepted: a function passed as the 2nd
+#     arg to a ``somethign.get(...)`` call would be promoted as
+#     framework_registered — but in practice ``map.get`` takes 1
+#     argument (the key), and 2-arg ``.get(key, default)`` calls
+#     don't pass identifier-function arguments. False-positive
+#     promotion costs accuracy on dead-code findings (the consumer
+#     skips a demotion that might have been correct); silencing
+#     real frameworks costs false negatives. Bias toward
+#     admitting the framework case.
+_FRAMEWORK_REGISTRATION_TAILS: FrozenSet[str] = frozenset({
+    # Express / Fastify / Koa / Hono — lowercase HTTP verbs + use + route.
+    "get", "post", "put", "patch", "delete", "head", "options",
+    "all", "use", "route", "param",
+    # Go gin / echo — capitalised HTTP verbs + Use + Group + Static.
+    "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS",
+    "Any", "Use", "Group", "Static",
+    # Go chi — mixed-case verbs + Method/MethodFunc + Mount + Handle.
+    "Get", "Post", "Put", "Patch", "Delete", "Head", "Options",
+    "Method", "MethodFunc", "Mount",
+    # Go net/http — Handle + HandleFunc on *http.ServeMux + http pkg.
+    "Handle", "HandleFunc",
 })
 
 
@@ -1941,6 +2036,32 @@ def is_framework_callable(
     return target in idx.framework_callable
 
 
+def is_registered_via_call(
+    inventory: Dict[str, Any],
+    target: InternalFunction,
+    *,
+    exclude_test_files: bool = True,
+) -> bool:
+    """True iff ``target`` is passed as an identifier argument to a
+    recognised framework registration call (``http.HandleFunc("/x",
+    target)``, ``app.get("/users", target)``, ``router.use(target)``,
+    etc.). Sister to :func:`is_framework_callable` but for the JS / Go
+    pattern where the framework registers handlers via call arguments
+    rather than decorators.
+
+    Same-file matching only: ``target`` must be defined in the same
+    file as the registration call. Cross-file resolution (handler in
+    handlers.js, registration in routes.js) requires walking the
+    file's import map and is a documented limitation — same as
+    ``is_framework_callable``'s cross-file caveats for decorators.
+
+    See ``_FRAMEWORK_REGISTRATION_TAILS`` for the registration-call
+    pattern set.
+    """
+    idx = _get_or_build_index(inventory, exclude_test_files=exclude_test_files)
+    return target in idx.framework_registered
+
+
 def callees_of(
     inventory: Dict[str, Any],
     source: InternalFunction,
@@ -2520,6 +2641,7 @@ __all__ = [
     "forward_closure",
     "function_called",
     "is_framework_callable",
+    "is_registered_via_call",
     "parse_evidence_entry",
     "reverse_closure",
     "shortest_path",

--- a/core/inventory/tests/test_call_graph_go.py
+++ b/core/inventory/tests/test_call_graph_go.py
@@ -442,3 +442,111 @@ def test_package_main_captured():
         'func main() {}\n'
     )
     assert g.package_name == "main"
+
+
+# ---------------------------------------------------------------------------
+# argument_identifiers extraction — load-bearing for downstream
+# function-as-argument registration detection (net/http, gin, echo).
+# Tests pin: bare identifiers captured, non-identifiers (strings,
+# composite literals, selectors, function literals) skipped, ordering
+# preserved.
+# ---------------------------------------------------------------------------
+
+
+def test_go_argument_identifiers_http_handlefunc():
+    g = extract_call_graph_go(
+        'package main\n'
+        'import "net/http"\n'
+        'func main() {\n'
+        '\thttp.HandleFunc("/x", handler)\n'
+        '}\n'
+    )
+    call = next(c for c in g.calls if c.chain[-1] == "HandleFunc")
+    assert call.argument_identifiers == ["handler"]
+
+
+def test_go_argument_identifiers_gin_get():
+    g = extract_call_graph_go(
+        'package main\n'
+        'func setup(r *gin.Engine) {\n'
+        '\tr.GET("/users", listUsers)\n'
+        '\tr.POST("/users", createUser)\n'
+        '}\n'
+    )
+    get_call = next(c for c in g.calls if c.chain[-1] == "GET")
+    post_call = next(c for c in g.calls if c.chain[-1] == "POST")
+    assert get_call.argument_identifiers == ["listUsers"]
+    assert post_call.argument_identifiers == ["createUser"]
+
+
+def test_go_argument_identifiers_multiple_with_middleware():
+    g = extract_call_graph_go(
+        'package main\n'
+        'func setup(r *gin.Engine) {\n'
+        '\tr.GET("/admin", authMW, adminPanel)\n'
+        '}\n'
+    )
+    call = next(c for c in g.calls if c.chain[-1] == "GET")
+    assert call.argument_identifiers == ["authMW", "adminPanel"]
+
+
+def test_go_argument_identifiers_skip_string_and_composite():
+    g = extract_call_graph_go(
+        'package main\n'
+        'func main() {\n'
+        '\thttp.HandleFunc("/x", handler)\n'
+        '}\n'
+    )
+    call = next(c for c in g.calls if c.chain[-1] == "HandleFunc")
+    # String literal "/x" filtered, only handler kept.
+    assert call.argument_identifiers == ["handler"]
+
+
+def test_go_argument_identifiers_skip_function_literal():
+    g = extract_call_graph_go(
+        'package main\n'
+        'func main() {\n'
+        '\thttp.HandleFunc("/x", func(w http.ResponseWriter, r *http.Request) {})\n'
+        '}\n'
+    )
+    call = next(c for c in g.calls if c.chain[-1] == "HandleFunc")
+    # Inline `func() {}` not an identifier — skipped.
+    assert call.argument_identifiers == []
+
+
+def test_go_argument_identifiers_skip_selector():
+    g = extract_call_graph_go(
+        'package main\n'
+        'func main() {\n'
+        '\thttp.HandleFunc("/x", svc.Handle)\n'
+        '}\n'
+    )
+    call = next(c for c in g.calls if c.chain[-1] == "HandleFunc")
+    # `svc.Handle` is a selector_expression, not a bare identifier.
+    assert call.argument_identifiers == []
+
+
+def test_go_argument_identifiers_empty_no_args():
+    g = extract_call_graph_go(
+        'package main\n'
+        'func main() {\n'
+        '\tinit()\n'
+        '}\n'
+    )
+    call = next(c for c in g.calls if c.chain == ["init"])
+    assert call.argument_identifiers == []
+
+
+def test_go_argument_identifiers_round_trips_via_dict():
+    """Schema round-trip: argument_identifiers survives
+    to_dict/from_dict serialisation."""
+    g = extract_call_graph_go(
+        'package main\n'
+        'func main() {\n'
+        '\thttp.HandleFunc("/x", handler)\n'
+        '}\n'
+    )
+    d = g.to_dict()
+    g2 = FileCallGraph.from_dict(d)
+    call = next(c for c in g2.calls if c.chain[-1] == "HandleFunc")
+    assert call.argument_identifiers == ["handler"]

--- a/core/inventory/tests/test_call_graph_javascript.py
+++ b/core/inventory/tests/test_call_graph_javascript.py
@@ -424,3 +424,96 @@ def test_js_nested_class_marked_nested():
     inners = [c for c in g.classes if c.name == "Inner"]
     if inners:
         assert inners[0].nested is True
+
+
+# ---------------------------------------------------------------------------
+# argument_identifiers extraction — load-bearing for downstream
+# function-as-argument registration detection (Express, Fastify, etc.).
+# Tests pin: bare identifiers captured, non-identifiers (strings,
+# arrows, member accesses, object literals) skipped, ordering preserved.
+# ---------------------------------------------------------------------------
+
+
+def test_js_argument_identifiers_bare_function_arg():
+    g = extract_call_graph_javascript(
+        "app.get('/users', listUsers);\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["app", "get"])
+    assert call.argument_identifiers == ["listUsers"]
+
+
+def test_js_argument_identifiers_multiple():
+    g = extract_call_graph_javascript(
+        "app.use(authMiddleware, loggingMiddleware);\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["app", "use"])
+    assert call.argument_identifiers == ["authMiddleware", "loggingMiddleware"]
+
+
+def test_js_argument_identifiers_skip_string_literal():
+    g = extract_call_graph_javascript(
+        "router.post('/login', loginHandler);\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["router", "post"])
+    # String literal '/login' filtered; only loginHandler kept.
+    assert call.argument_identifiers == ["loginHandler"]
+
+
+def test_js_argument_identifiers_skip_arrow_function():
+    g = extract_call_graph_javascript(
+        "app.get('/x', (req, res) => res.send('ok'));\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["app", "get"])
+    # Inline arrow function not a bare identifier — skipped.
+    assert call.argument_identifiers == []
+
+
+def test_js_argument_identifiers_skip_member_access():
+    g = extract_call_graph_javascript(
+        "app.get('/x', controller.handle);\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["app", "get"])
+    # Member access `controller.handle` not a bare identifier — skipped.
+    # (Captured elsewhere when invoked as a call; here as an arg
+    # value we conservatively skip — bare references are the
+    # load-bearing case.)
+    assert call.argument_identifiers == []
+
+
+def test_js_argument_identifiers_empty_no_args():
+    g = extract_call_graph_javascript(
+        "init();\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["init"])
+    assert call.argument_identifiers == []
+
+
+def test_js_argument_identifiers_preserves_order():
+    g = extract_call_graph_javascript(
+        "compose(first, second, third);\n"
+    )
+    call = next(c for c in g.calls if c.chain == ["compose"])
+    assert call.argument_identifiers == ["first", "second", "third"]
+
+
+def test_js_argument_identifiers_round_trips_via_dict():
+    """Schema round-trip: argument_identifiers survives
+    to_dict/from_dict serialisation."""
+    g = extract_call_graph_javascript(
+        "app.get('/x', handler);\n"
+    )
+    d = g.to_dict()
+    g2 = FileCallGraph.from_dict(d)
+    call = next(c for c in g2.calls if c.chain == ["app", "get"])
+    assert call.argument_identifiers == ["handler"]
+
+
+def test_js_argument_identifiers_omitted_from_dict_when_empty():
+    """Backwards-compat: argument_identifiers absent from dict
+    when empty (inventory size discipline)."""
+    g = extract_call_graph_javascript(
+        "init();\n"
+    )
+    d = g.to_dict()
+    init_entry = next(c for c in d["calls"] if c["chain"] == ["init"])
+    assert "argument_identifiers" not in init_entry

--- a/core/inventory/tests/test_reachability_adjacency.py
+++ b/core/inventory/tests/test_reachability_adjacency.py
@@ -44,6 +44,7 @@ from core.inventory.reachability import (
     callees_of,
     callers_of,
     is_framework_callable,
+    is_registered_via_call,
 )
 
 
@@ -1416,3 +1417,178 @@ class TestNakedFrameworkDispatch:
                 f"bare @{name} is too generic to promote — "
                 f"likely a project-defined pass-through"
             )
+
+
+# ---------------------------------------------------------------------------
+# Function-as-argument framework registration (JS / Go). Sister to the
+# decorator-driven framework_callable detection — covers the dominant
+# JS / Go pattern where handlers are passed as identifier arguments to
+# routing-method calls rather than decorated.
+# ---------------------------------------------------------------------------
+
+
+def _js_file(path: str, source: str) -> Dict[str, Any]:
+    """Build a JS file record using the tree-sitter extractor."""
+    from core.inventory.call_graph import extract_call_graph_javascript
+    import re
+    cg = extract_call_graph_javascript(source).to_dict()
+    items = []
+    # Naive function-def extraction for items (mirrors the
+    # production extractor's output shape closely enough for
+    # the resolver to match against).
+    for i, line in enumerate(source.splitlines(), 1):
+        m = re.match(r"\s*function\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*\(", line)
+        if m:
+            items.append({
+                "name": m.group(1), "kind": "function",
+                "line_start": i,
+            })
+    return {
+        "path": path, "language": "javascript",
+        "items": items, "call_graph": cg,
+    }
+
+
+def _go_file(path: str, source: str) -> Dict[str, Any]:
+    """Build a Go file record using the tree-sitter extractor."""
+    from core.inventory.call_graph import extract_call_graph_go
+    import re
+    cg = extract_call_graph_go(source).to_dict()
+    items = []
+    for i, line in enumerate(source.splitlines(), 1):
+        m = re.match(r"\s*func\s+(?:\([^)]+\)\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*\(", line)
+        if m:
+            items.append({
+                "name": m.group(1), "kind": "function",
+                "line_start": i,
+            })
+    return {
+        "path": path, "language": "go",
+        "items": items, "call_graph": cg,
+    }
+
+
+class TestRegistrationViaCall:
+    def test_express_app_get_registers_handler(self):
+        try:
+            import tree_sitter_javascript  # noqa: F401
+        except ImportError:
+            import pytest
+            pytest.skip("tree_sitter_javascript not installed")
+        inv = _inv(_js_file("src/api.js",
+            "function listUsers(req, res) { res.json([]); }\n"
+            "app.get('/users', listUsers);\n"
+        ))
+        target = InternalFunction("src/api.js", "listUsers", 1)
+        assert is_registered_via_call(inv, target) is True
+
+    def test_express_middleware_use_registers(self):
+        try:
+            import tree_sitter_javascript  # noqa: F401
+        except ImportError:
+            import pytest
+            pytest.skip("tree_sitter_javascript not installed")
+        inv = _inv(_js_file("src/app.js",
+            "function authMW(req, res, next) { next(); }\n"
+            "app.use(authMW);\n"
+        ))
+        target = InternalFunction("src/app.js", "authMW", 1)
+        assert is_registered_via_call(inv, target) is True
+
+    def test_go_http_handlefunc_registers(self):
+        try:
+            import tree_sitter_go  # noqa: F401
+        except ImportError:
+            import pytest
+            pytest.skip("tree_sitter_go not installed")
+        inv = _inv(_go_file("src/main.go",
+            'package main\n'
+            'import "net/http"\n'
+            'func handler(w http.ResponseWriter, r *http.Request) {}\n'
+            'func main() {\n'
+            '\thttp.HandleFunc("/x", handler)\n'
+            '}\n'
+        ))
+        target = InternalFunction("src/main.go", "handler", 3)
+        assert is_registered_via_call(inv, target) is True
+
+    def test_go_gin_get_registers(self):
+        try:
+            import tree_sitter_go  # noqa: F401
+        except ImportError:
+            import pytest
+            pytest.skip("tree_sitter_go not installed")
+        inv = _inv(_go_file("src/api.go",
+            'package api\n'
+            'func listUsers(c *gin.Context) {}\n'
+            'func setup(r *gin.Engine) {\n'
+            '\tr.GET("/users", listUsers)\n'
+            '}\n'
+        ))
+        target = InternalFunction("src/api.go", "listUsers", 2)
+        assert is_registered_via_call(inv, target) is True
+
+    def test_undecorated_uncalled_function_not_registered(self):
+        try:
+            import tree_sitter_javascript  # noqa: F401
+        except ImportError:
+            import pytest
+            pytest.skip("tree_sitter_javascript not installed")
+        # ``orphan`` is defined but never passed as an arg or called.
+        inv = _inv(_js_file("src/u.js",
+            "function orphan() {}\n"
+            "function user() { console.log('hello'); }\n"
+        ))
+        target = InternalFunction("src/u.js", "orphan", 1)
+        assert is_registered_via_call(inv, target) is False
+
+    def test_bare_get_not_registration(self):
+        try:
+            import tree_sitter_javascript  # noqa: F401
+        except ImportError:
+            import pytest
+            pytest.skip("tree_sitter_javascript not installed")
+        # Bare ``get(handler)`` is too generic — chain length 1.
+        # Not treated as framework registration; the user-defined
+        # ``get(x)`` is more likely a getter than HTTP routing.
+        inv = _inv(_js_file("src/u.js",
+            "function handler() {}\n"
+            "get(handler);\n"
+        ))
+        target = InternalFunction("src/u.js", "handler", 1)
+        assert is_registered_via_call(inv, target) is False
+
+    def test_handler_in_string_arg_not_registered(self):
+        try:
+            import tree_sitter_javascript  # noqa: F401
+        except ImportError:
+            import pytest
+            pytest.skip("tree_sitter_javascript not installed")
+        # A function name appearing only in a string literal
+        # ``app.get('/handler')`` is NOT being passed as a function
+        # reference — only identifier args register.
+        inv = _inv(_js_file("src/u.js",
+            "function handler() {}\n"
+            "app.get('handler');\n"
+        ))
+        target = InternalFunction("src/u.js", "handler", 1)
+        assert is_registered_via_call(inv, target) is False
+
+    def test_arrow_function_inline_does_not_register_named_handler(self):
+        try:
+            import tree_sitter_javascript  # noqa: F401
+        except ImportError:
+            import pytest
+            pytest.skip("tree_sitter_javascript not installed")
+        # ``app.get('/x', (req, res) => handler())`` — handler is
+        # referenced inside the arrow body (a call site), not
+        # passed as the argument identifier. Not registration.
+        # ``handler`` would show as CALLED via the static graph
+        # if the arrow itself is reachable, but
+        # is_registered_via_call is about being passed by name.
+        inv = _inv(_js_file("src/u.js",
+            "function handler() {}\n"
+            "app.get('/x', (req, res) => handler());\n"
+        ))
+        target = InternalFunction("src/u.js", "handler", 1)
+        assert is_registered_via_call(inv, target) is False

--- a/core/orchestration/reachability_enrichment.py
+++ b/core/orchestration/reachability_enrichment.py
@@ -83,6 +83,7 @@ def mark_unreachable_low_priority(
             Verdict,
             function_called,
             is_framework_callable,
+            is_registered_via_call,
         )
     except ImportError:
         return 0
@@ -147,6 +148,17 @@ def mark_unreachable_low_priority(
                 # uncalled but framework-reachable.
                 func["priority_reason"] = (
                     "reachability:framework_callable"
+                )
+                continue
+            if is_registered_via_call(inventory, target):
+                # Same skip-the-demotion logic but for the JS / Go
+                # function-as-argument registration pattern
+                # (``http.HandleFunc("/x", target)``,
+                # ``app.get("/users", target)``). Annotate with a
+                # distinct reason so operators can see WHICH
+                # mechanism kept this function alive.
+                func["priority_reason"] = (
+                    "reachability:registered_via_call"
                 )
                 continue
 

--- a/core/orchestration/tests/test_reachability_enrichment.py
+++ b/core/orchestration/tests/test_reachability_enrichment.py
@@ -488,3 +488,47 @@ class TestFrameworkCallableBypass:
         assert dead["priority"] == "low"
         assert dead["priority_reason"] == "reachability:not_called"
         assert "priority" not in alive  # called → no demotion at all
+
+
+class TestRegistrationViaCallBypass:
+    """S2: JS / Go function-as-argument registration. A handler
+    passed as an identifier argument to a routing call
+    (``http.HandleFunc("/x", handler)``, ``app.get("/users",
+    handler)``) must NOT be demoted to priority=low even though
+    the static graph shows no callers — the framework dispatches
+    to it via the registration call.
+    """
+
+    def test_go_handler_registered_via_handlefunc_not_demoted(
+        self, tmp_path,
+    ):
+        try:
+            import tree_sitter_go  # noqa: F401
+        except ImportError:
+            import pytest
+            pytest.skip("tree_sitter_go not installed")
+        target = _project(tmp_path, {
+            "src/main.go": (
+                'package main\n'
+                'import "net/http"\n'
+                'func handler(w http.ResponseWriter, r *http.Request) {}\n'
+                'func main() {\n'
+                '\thttp.HandleFunc("/x", handler)\n'
+                '}\n'
+            ),
+        })
+        checklist = _checklist({
+            "src/main.go": [{
+                "name": "handler", "kind": "function",
+                "line_start": 3, "line_end": 3,
+            }],
+        })
+        mark_unreachable_low_priority(checklist, target)
+        func = checklist["files"][0]["items"][0]
+        assert func.get("priority") != "low", (
+            "Go handler registered via http.HandleFunc must not "
+            "be demoted — framework dispatches to it at runtime"
+        )
+        assert func.get("priority_reason") == (
+            "reachability:registered_via_call"
+        )

--- a/packages/codeql/autonomous_analyzer.py
+++ b/packages/codeql/autonomous_analyzer.py
@@ -114,13 +114,15 @@ class AutonomousAnalysisResult:
     # Reachability prefilter outcome — set when the inventory-based
     # resolver was consulted before the expensive LLM stages.
     # ``"called"`` / ``"not_called"`` / ``"uncertain"`` /
-    # ``"framework_callable"`` / None (when the prefilter couldn't
-    # determine, e.g. non-Python file or sink line not in any
-    # function). ``"framework_callable"`` means the static graph
-    # found no callers BUT the function carries a framework-
-    # dispatch decorator (``@app.route``, ``@shared_task``,
-    # ``@receiver``, etc.) — treated as reachable; full LLM
-    # analysis still runs.
+    # ``"framework_callable"`` / ``"registered_via_call"`` / None.
+    # ``"framework_callable"``: static graph found no callers BUT
+    # function carries a framework-dispatch decorator
+    # (``@app.route``, ``@shared_task``, ``@receiver``, etc.).
+    # ``"registered_via_call"``: function is passed as an identifier
+    # argument to a recognised framework registration call
+    # (``http.HandleFunc("/x", target)``, ``app.get(...)``,
+    # ``router.use(...)`` — the JS / Go equivalent of the decorator
+    # pattern). Both treated as reachable; full LLM analysis runs.
     reachability_verdict: Optional[str] = None
     # Set to a non-None reason when the analyzer short-circuited
     # without running deep analysis. Today the only value is
@@ -222,16 +224,20 @@ class AutonomousCodeQLAnalyzer:
         finding's sink line reached from anywhere in the project?
 
         Returns one of ``"called"`` / ``"not_called"`` /
-        ``"uncertain"`` / ``"framework_callable"`` / None
-        (None = couldn't determine — non-Python file, sink not in
-        any function, inventory build failed, etc.). The caller's
-        policy is to short-circuit on ``"not_called"`` and
-        otherwise continue. ``"framework_callable"`` is the
-        substrate's signal that the static graph shows no callers
-        BUT a framework-dispatch decorator (Flask ``@app.route``,
-        Celery ``@shared_task``, Django ``@receiver``, etc.)
-        registers the function for runtime invocation — caller
-        proceeds with full LLM analysis.
+        ``"uncertain"`` / ``"framework_callable"`` /
+        ``"registered_via_call"`` / None (None = couldn't determine —
+        non-Python file, sink not in any function, inventory build
+        failed, etc.). The caller's policy is to short-circuit on
+        ``"not_called"`` and otherwise continue.
+        ``"framework_callable"``: substrate found framework-dispatch
+        decorator (Flask ``@app.route``, Celery ``@shared_task``,
+        Django ``@receiver``, etc.) registering the function for
+        runtime invocation. ``"registered_via_call"``: function
+        passed as identifier argument to a recognised framework
+        registration call (``http.HandleFunc("/x", fn)``,
+        ``app.get("/users", fn)``, ``router.use(fn)``) — JS / Go
+        equivalent of decorator-driven dispatch. Both let the
+        caller proceed with full LLM analysis.
 
         Cost: inventory build is paid once per analyzer instance
         (cached); per-finding lookup is O(N_files + N_calls in
@@ -278,6 +284,7 @@ class AutonomousCodeQLAnalyzer:
                 InternalFunction,
                 function_called,
                 is_framework_callable,
+                is_registered_via_call,
             )
         except ImportError:
             return None
@@ -339,6 +346,14 @@ class AutonomousCodeQLAnalyzer:
                 # short-circuit". Distinct from "called" so the
                 # reachability_verdict field reports accurately.
                 return "framework_callable"
+            if is_registered_via_call(
+                self._reachability_inventory, target,
+            ):
+                # JS / Go function-as-argument registration
+                # (``http.HandleFunc("/x", target)``). Distinct
+                # verdict value so operators can see WHICH
+                # mechanism kept the finding alive.
+                return "registered_via_call"
         return verdict
 
     def _relative_path(

--- a/packages/codeql/tests/test_reachability_prefilter.py
+++ b/packages/codeql/tests/test_reachability_prefilter.py
@@ -437,3 +437,47 @@ def test_framework_callable_does_not_short_circuit(
     # circuit. skipped_reason stays None; analysis ran.
     assert result.skipped_reason is None
     assert result.reachability_verdict == "framework_callable"
+
+
+# ---------------------------------------------------------------------------
+# S2: registered_via_call — JS / Go function-as-argument registration.
+# A handler passed as identifier argument to http.HandleFunc / app.get /
+# router.use must NOT short-circuit; full LLM analysis runs.
+# ---------------------------------------------------------------------------
+
+
+def test_go_handler_registered_via_call_returns_registered_via_call(tmp_path):
+    """Go handler passed to http.HandleFunc resolves new
+    ``registered_via_call`` verdict instead of ``not_called``."""
+    try:
+        import tree_sitter_go  # noqa: F401
+    except ImportError:
+        import pytest
+        pytest.skip("tree_sitter_go not installed")
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "main.go").write_text(
+        'package main\n'
+        'import "net/http"\n'
+        'func handler(w http.ResponseWriter, r *http.Request) {\n'
+        '\tcursor.Execute(r.URL.Query().Get("q"))\n'
+        '}\n'
+        'func main() {\n'
+        '\thttp.HandleFunc("/x", handler)\n'
+        '}\n'
+    )
+    a = _analyzer()
+    # Need a JS / Go finding shape — _finding builds Python-style;
+    # for Go we use src/main.go directly.
+    from packages.codeql.autonomous_analyzer import CodeQLFinding
+    finding = CodeQLFinding(
+        rule_id="go/sql-injection", rule_name="x", message="x",
+        level="error",
+        file_path="src/main.go", start_line=4, end_line=4,
+        snippet="cursor.Execute(...)",
+    )
+    verdict = a._check_reachability(finding, tmp_path)
+    assert verdict == "registered_via_call", (
+        f"Go handler registered via http.HandleFunc must resolve "
+        f"registered_via_call, got {verdict!r}"
+    )

--- a/packages/exploitability_validation/reachability.py
+++ b/packages/exploitability_validation/reachability.py
@@ -99,6 +99,7 @@ def demote_unreachable_paths(
             Verdict,
             function_called,
             is_framework_callable,
+            is_registered_via_call,
         )
     except ImportError:
         return 0
@@ -156,6 +157,12 @@ def demote_unreachable_paths(
             file_path=rel_path, name=func_name, line=func_line,
         )
         if is_framework_callable(inventory, target):
+            continue
+        # Same skip-the-demotion logic for JS / Go function-as-
+        # argument registration (``http.HandleFunc("/x", target)``,
+        # ``app.get("/users", target)``, etc.) — the JS / Go
+        # equivalent of decorator-driven dispatch.
+        if is_registered_via_call(inventory, target):
             continue
 
         # Demote: cap proximity, append blocker.

--- a/packages/exploitability_validation/tests/test_reachability_demotion.py
+++ b/packages/exploitability_validation/tests/test_reachability_demotion.py
@@ -357,3 +357,45 @@ def test_does_not_demote_django_receiver_naked(tmp_path):
     )
     assert demoted == 0
     assert attack_paths[0]["proximity"] == 7
+
+
+def test_does_not_demote_go_handler_registered_via_call(tmp_path):
+    """S2: Go handler passed to http.HandleFunc must not be
+    demoted — the registration call makes it reachable."""
+    try:
+        import tree_sitter_go  # noqa: F401
+    except ImportError:
+        import pytest
+        pytest.skip("tree_sitter_go not installed")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.go").write_text(
+        'package main\n'
+        'import "net/http"\n'
+        'func handler(w http.ResponseWriter, r *http.Request) {\n'
+        '\tcursor.Execute(r.URL.Query().Get("q"))\n'
+        '}\n'
+        'func main() {\n'
+        '\thttp.HandleFunc("/x", handler)\n'
+        '}\n'
+    )
+
+    findings = [{
+        "id": "f1",
+        "file_path": "src/main.go",
+        "start_line": 4,
+    }]
+    attack_paths = [{
+        "id": "p1",
+        "finding_id": "f1",
+        "proximity": 8,
+        "blockers": [],
+    }]
+
+    demoted = demote_unreachable_paths(
+        attack_paths, findings, tmp_path,
+    )
+    assert demoted == 0, (
+        "Go handler registered via http.HandleFunc must not "
+        "be demoted"
+    )
+    assert attack_paths[0]["proximity"] == 8  # unchanged


### PR DESCRIPTION
S1 covered Python decorator dispatch. JS / Go register handlers by passing them as identifier arguments to routing calls (http.HandleFunc("/x", h), app.get("/users", listUsers)) — these showed NOT_CALLED across the three reachability consumers, false- negatives on any Go web server or Express codebase.

  * CallSite.argument_identifiers: List[str] — new schema field, populated by JS + Go extractors via _call_identifier_args. Bare identifiers only; strings / arrows / member-access skipped. Backwards-compat default empty list, omitted from dict when empty.
  * is_registered_via_call(inv, target) — sister to is_framework_callable. Walks CallSites for chain-length-2+ entries with tail in _FRAMEWORK_REGISTRATION_TAILS (Express / Fastify / Koa / Hono HTTP verbs; Go net/http + gin/echo/chi routing); checks identifier args against same-file definitions.
  * Wired into the same three consumers as S1 — enrichment, CodeQL prefilter, attack-path demoter — with diagnostic values "reachability:registered_via_call" / verdict "registered_via_call". _CACHE_VERSION 5→6 invalidates persistent index caches.

Same-file matching only (cross-file handler/route split deferred).

Tests: 28 new, 1374 reachability tests pass, ruff clean. E2E on Go HTTP fixture: handler + adminPanel registered via http.HandleFunc flow through all 3 consumers; trulyDead still correctly demoted.