### PR TITLE
feat(crash_agent): prompt for inline-trigger PoCs, not subprocess-target

### DIFF
--- a/packages/llm_analysis/crash_agent.py
+++ b/packages/llm_analysis/crash_agent.py
@@ -191,13 +191,28 @@ def _build_crash_analysis_bundle(
 _CRASH_EXPLOIT_SYSTEM_PROMPT = """You are an expert binary exploitation specialist.
 Generate structured JSON output with exploit code and reasoning.
 
-CRITICAL: The exploit must actually run the target binary and send input to it to trigger the vulnerability.
-Do NOT generate code that just demonstrates the vulnerability in isolation.
+The exploit must trigger the vulnerability **inline within the PoC
+binary itself** — port the vulnerable code path from the target
+source into the PoC's main() and feed it the crashing input
+directly. Do NOT shell out to the target binary (execve, system,
+subprocess, fork+exec). RAPTOR runs the PoC under Landlock /
+seccomp / namespace isolation: the sandbox blocks the PoC from
+reading or executing files outside its own work directory, so any
+attempt to spawn the target will fail before the bug fires.
+Inlining the trigger also lets RAPTOR's sandbox observer surface
+sanitizer reports (ASAN / UBSAN / MSAN) on the PoC's stderr, which
+the witness-capture path classifies as ``SANITIZER_REPORT``
+outcomes — strictly more information than a clean exit.
 
 The exploit should:
-1. Use execve() or system() to run the target binary
-2. Send the exact crashing input bytes via stdin or a file
-3. Demonstrate that the vulnerability is triggered
+1. Reproduce the vulnerable function from the target source
+   (use source_location to find it, source the snippet from
+   the surrounding context the user provides).
+2. Construct an input that exercises the bug path — typically
+   the same bytes as the crash-input-hex block but tailored to
+   the inlined function's signature.
+3. Call the inlined function with that input, in main(), so the
+   bug fires on PoC execution.
 
 The "code" field must contain complete, compilable C or C++ code.
 The "reasoning" field can contain explanations and analysis."""
@@ -205,13 +220,26 @@ The "reasoning" field can contain explanations and analysis."""
 
 _CRASH_EXPLOIT_TASK_INSTRUCTIONS = """The user message contains the crash context (prior analysis, crash details, the crashing input bytes in hex and ASCII), all wrapped as untrusted data. Identifiers (binary name, crash type, function, crash address) are passed through named slots; refer to slots by name.
 
-Create a working proof-of-concept exploit that demonstrates the vulnerability by sending the crashing input to the target binary.
+Create a self-contained proof-of-concept exploit that triggers the
+vulnerability **inside the PoC binary itself**. The PoC must NOT
+attempt to subprocess / execve / fork the target binary — RAPTOR's
+sandbox blocks cross-binary execution, and inlining the trigger
+lets sanitizers (ASAN / UBSAN / MSAN) fire on the PoC's stderr
+where the witness-capture path can observe them.
 
 The exploit must:
-1. Execute the target binary referenced by the binary_name slot
-2. Send the exact input bytes from the crash-input-hex untrusted block to trigger the vulnerability
-3. Demonstrate that the vulnerability can be reached and exploited
-4. Include full logging and visible terminal output showing the exploit in action
+1. Port the vulnerable function from the target source into the
+   PoC. The function_name and source_location slots tell you which
+   function and which file:line range to look at — the surrounding
+   source-context block (if provided) carries the snippet.
+2. Build an input that drives that function down the buggy path.
+   Usually the bytes in the crash-input-hex block, possibly
+   reshaped to match the function's parameter type (char *,
+   size_t, etc.).
+3. Call the inlined function with that input, in main(), so the
+   bug fires on PoC execution.
+4. Include visible output (stderr is fine — sanitizer reports go
+   there naturally) so the observer has something to record.
 
 Respond with valid JSON containing exactly these fields:
 - "code": The complete, compilable C or C++ exploit code as a string


### PR DESCRIPTION
The crash-analysis exploit prompt mandated "execve() or system() to run the target binary" with an explicit "Do NOT generate code that just demonstrates the vulnerability in isolation." That worked against the witness-execute path landed in #602:

  - Sandbox Landlock restricts the PoC to its own work directory, so any execve() of the target binary outside that path fails before the bug can fire.
  - Even when execve() succeeded, ASAN's stderr from the target would only be observable if the PoC inherited fd 2 cleanly. Most LLM-emitted execve() wrappers don't.
  - End result: every operator E2E run produced outcome=NO_OBVIOUS_EFFECT — the substrate worked but the sanitizer-fires path was never observably reached.

Prompt now prefers **inline-trigger** PoCs: port the vulnerable function from the target source into the PoC's main() and call it with the crashing input directly. Sanitizers (ASAN / UBSAN / MSAN) fire on the PoC's own stderr where the observer can classify them as WitnessOutcome.SANITIZER_REPORT.

Verified end-to-end against Gemini 2.5 Pro via packages/llm_analysis/scripts/e2e_execute_witness.py:

  Before: outcome=no_obvious_effect (LLM emitted execve() wrapper, Landlock blocked the target read)
  After:  outcome=sanitizer_report, sanitizer=asan, evidence="AddressSanitizer: stack-buffer-overflow"

Subprocess-target style (the ExploitGym-aligned semantics where the PoC drives the deployed binary) is intentionally left for a future PR that extends the sandbox to allow target-binary reads — that's a separate sandbox-design change, not a prompt change.