### PR TITLE
feat(prompt): surface reachability evidence in per-finding analysis prompt

### DIFF
--- a/packages/llm_analysis/prompts/analysis.py
+++ b/packages/llm_analysis/prompts/analysis.py
@@ -56,6 +56,14 @@ Does the code at the stated location match the finding description?
 Is the source-to-sink flow real, or did the scanner fabricate a connection?
 Is this code reachable from an entry point, or is it dead code?
 
+If the metadata block contains a "Reachability:" section, use it as evidence:
+- "Verdict: NOT_CALLED" — the static call-graph resolver found no callers in the project. Before marking exploitable, identify a plausible reach mechanism the substrate could miss (framework dispatch the resolver didn't recognise, dynamic dispatch via reflection/registry lookups, public API surface called by external consumers, plugin entry points). If no plausible mechanism exists, mark is_exploitable=False with ruling="unreachable" or "dead_code" — the vulnerability shape may still be a true positive (is_true_positive=True) but it isn't exploitable in this deployment.
+- "Verdict: REACHABLE via ..." — reachability is established via a runtime-dispatch mechanism (framework decorator or registration call); treat as live, focus on exploit feasibility.
+- "Caller graph: N direct, M transitive" with N=0 but uncertain > 0 — the substrate found indirection it cannot resolve (string-dispatch / reflect / plugin registries). Treat as potentially reachable; note the indirection class in your reasoning.
+- "Caller graph: N direct, M transitive" with N > 0 — reachability is established; focus on exploit feasibility.
+
+The absence of a "Reachability:" section means the substrate couldn't compute reachability for this function (non-Python/JS/TS/Go/Java file, inventory build failed, or the function wasn't found in the project). Reason from the source code in that case — don't infer reachability from the absence alone.
+
 **Stage D: Ruling**
 Is this test code, example code, or documentation?
 Does exploitation require another vulnerability as a prerequisite?
@@ -112,7 +120,95 @@ def _format_metadata_for_block(metadata: Dict[str, Any]) -> str:
     if metadata.get("priority") == "high":
         reason = metadata.get("priority_reason", "high-priority")
         parts.append(f"Architectural role: {reason} (from /understand --map)")
+    reach_block = _format_reachability_block(metadata)
+    if reach_block:
+        parts.append(reach_block)
     return "\n".join(parts)
+
+
+def _format_reachability_block(metadata: Dict[str, Any]) -> str:
+    """Render reachability evidence — fires whenever ANY reachability
+    signal is present on the function.
+
+    Surfaces data already computed by
+    :mod:`core.orchestration.reachability_enrichment` (the pre-pass
+    that marks ``priority="low"`` for NOT_CALLED functions and
+    populates per-function caller counts + direct caller names).
+    Pre-C1 the analysis prompt rendered only ``priority="high"`` —
+    the rest of the reachability picture was invisible to the LLM
+    even though it sat in the per-finding metadata. C1 surfaces it
+    so the LLM can integrate reachability into its is_exploitable
+    reasoning instead of guessing.
+
+    No verdict mutation; this is information-only. See the
+    ``REACHABILITY ENGAGEMENT`` section of the task prompt for how
+    the LLM should use the data.
+
+    Output shape (only emits the lines whose data is present):
+
+        Reachability:
+          Verdict: NOT_CALLED (reachability:not_called)
+          Caller graph: 3 direct, 12 transitive, 1 uncertain (indirection masking)
+          Direct callers: auth.py:handle_login, api/users.py:create_user
+    """
+    lines = []
+
+    priority = metadata.get("priority")
+    priority_reason = metadata.get("priority_reason") or ""
+    if priority == "low":
+        lines.append(
+            f"Verdict: NOT_CALLED ({priority_reason or 'no callers in project'})"
+        )
+    elif priority_reason in (
+        "reachability:framework_callable",
+        "reachability:registered_via_call",
+    ):
+        # The reachability enricher annotates these reasons WITHOUT
+        # demoting priority — the function is reachable via runtime
+        # dispatch the static graph doesn't see. Surfacing the
+        # mechanism lets the LLM trust the reachability picture
+        # instead of seeing "no static callers" and inferring dead
+        # code.
+        mechanism = (
+            "framework decorator dispatch"
+            if priority_reason == "reachability:framework_callable"
+            else "framework registration call (handler passed as argument)"
+        )
+        lines.append(f"Verdict: REACHABLE via {mechanism}")
+
+    direct = metadata.get("caller_count_direct")
+    transitive = metadata.get("caller_count_transitive")
+    uncertain = metadata.get("caller_count_uncertain")
+    if direct is not None or transitive is not None or uncertain:
+        bits = []
+        if direct is not None:
+            bits.append(f"{direct} direct")
+        if transitive is not None and transitive != direct:
+            bits.append(f"{transitive} transitive")
+        if uncertain:
+            bits.append(
+                f"{uncertain} uncertain (indirection masking — "
+                f"getattr/reflect/dispatch)"
+            )
+        if bits:
+            lines.append(f"Caller graph: {', '.join(bits)}")
+
+    names = metadata.get("direct_caller_names") or []
+    if names:
+        # Cap at 10 so we don't blow the prompt budget on busy
+        # functions. The substrate's enricher already caps via
+        # max_direct_caller_names but defending here too.
+        shown = list(names[:10])
+        suffix = (
+            f" (+{len(names) - 10} more)"
+            if len(names) > 10
+            else ""
+        )
+        lines.append(f"Direct callers: {', '.join(shown)}{suffix}")
+
+    if not lines:
+        return ""
+    return "Reachability:\n  " + "\n  ".join(lines)
 
 
 def _build_strategy_block(

--- a/packages/llm_analysis/tests/test_reachability_in_analysis_prompt.py
+++ b/packages/llm_analysis/tests/test_reachability_in_analysis_prompt.py
@@ -1,0 +1,239 @@
+"""Tests for reachability evidence surfacing in the analysis prompt (C1).
+
+Pre-C1 the analysis prompt rendered only ``priority="high"`` from the
+metadata. The reachability pre-pass enriches every checklist function
+with priority/priority_reason/caller_count_*/direct_caller_names — all
+invisible to the LLM analysis prompt that decides is_exploitable.
+
+C1 surfaces this data:
+  * NOT_CALLED (priority=low) becomes a "Verdict: NOT_CALLED" line.
+  * REACHABLE-via-decorator (priority_reason=framework_callable) and
+    REACHABLE-via-registration-call (priority_reason=
+    registered_via_call) become explicit "Verdict: REACHABLE via X" lines.
+  * Caller counts (direct/transitive/uncertain) become a summary line.
+  * Direct caller names become a comma-separated list (capped at 10).
+
+No verdict mutation; this is information-only. The matching system-
+prompt section ("REACHABILITY ENGAGEMENT") tells the LLM how to
+integrate the data into its is_exploitable reasoning.
+"""
+
+from __future__ import annotations
+
+from packages.llm_analysis.prompts.analysis import (
+    _format_metadata_for_block,
+    _format_reachability_block,
+)
+
+
+# ---------------------------------------------------------------------------
+# Verdict line surfaces priority + reason
+# ---------------------------------------------------------------------------
+
+
+class TestVerdictLine:
+    def test_priority_low_renders_not_called(self):
+        out = _format_reachability_block({
+            "priority": "low",
+            "priority_reason": "reachability:not_called",
+        })
+        assert "Verdict: NOT_CALLED" in out
+        assert "reachability:not_called" in out
+
+    def test_priority_low_default_reason(self):
+        out = _format_reachability_block({"priority": "low"})
+        assert "Verdict: NOT_CALLED" in out
+        assert "no callers in project" in out
+
+    def test_framework_callable_reason_renders_reachable(self):
+        out = _format_reachability_block({
+            "priority_reason": "reachability:framework_callable",
+        })
+        assert "Verdict: REACHABLE" in out
+        assert "framework decorator dispatch" in out
+
+    def test_registered_via_call_reason_renders_reachable(self):
+        out = _format_reachability_block({
+            "priority_reason": "reachability:registered_via_call",
+        })
+        assert "Verdict: REACHABLE" in out
+        assert "registration call" in out
+        assert "handler passed as argument" in out
+
+    def test_no_priority_no_verdict_line(self):
+        # Priority not set + no framework reason → no verdict line.
+        # Caller counts may still render below.
+        out = _format_reachability_block({})
+        assert "Verdict" not in out
+
+    def test_priority_high_does_not_render_verdict_line(self):
+        # priority=high is the architectural-role signal already
+        # rendered by _format_metadata_for_block — the reachability
+        # block doesn't duplicate it as a verdict.
+        out = _format_reachability_block({
+            "priority": "high",
+            "priority_reason": "entry_point",
+        })
+        assert "Verdict" not in out
+
+
+# ---------------------------------------------------------------------------
+# Caller graph summary
+# ---------------------------------------------------------------------------
+
+
+class TestCallerGraphSummary:
+    def test_direct_only(self):
+        out = _format_reachability_block({"caller_count_direct": 3})
+        assert "Caller graph: 3 direct" in out
+
+    def test_direct_and_transitive_different(self):
+        out = _format_reachability_block({
+            "caller_count_direct": 3,
+            "caller_count_transitive": 12,
+        })
+        assert "3 direct" in out
+        assert "12 transitive" in out
+
+    def test_transitive_equal_to_direct_omits_transitive(self):
+        # When transitive == direct, the function has no further-out
+        # callers; rendering "3 direct, 3 transitive" is noise.
+        out = _format_reachability_block({
+            "caller_count_direct": 3,
+            "caller_count_transitive": 3,
+        })
+        assert "3 direct" in out
+        assert "transitive" not in out
+
+    def test_uncertain_callers_rendered_with_explanation(self):
+        out = _format_reachability_block({
+            "caller_count_direct": 0,
+            "caller_count_uncertain": 2,
+        })
+        assert "0 direct" in out
+        assert "2 uncertain" in out
+        assert "indirection" in out.lower()
+
+    def test_zero_callers_renders(self):
+        # Explicit "0 direct" is signal — must render, not be omitted.
+        out = _format_reachability_block({"caller_count_direct": 0})
+        assert "0 direct" in out
+
+    def test_none_callers_omits_graph_line(self):
+        # caller_count_direct=None (enricher didn't run) → no line.
+        out = _format_reachability_block({})
+        assert "Caller graph" not in out
+
+
+# ---------------------------------------------------------------------------
+# Direct caller names list
+# ---------------------------------------------------------------------------
+
+
+class TestDirectCallerNames:
+    def test_renders_list(self):
+        out = _format_reachability_block({
+            "direct_caller_names": [
+                "auth.py:handle_login",
+                "api/users.py:create_user",
+            ],
+        })
+        assert "auth.py:handle_login" in out
+        assert "api/users.py:create_user" in out
+        assert out.count("Direct callers:") == 1
+
+    def test_caps_at_10_names_with_overflow_count(self):
+        names = [f"f{i}.py:fn{i}" for i in range(15)]
+        out = _format_reachability_block({"direct_caller_names": names})
+        # First 10 appear; +5 more is summarised.
+        for i in range(10):
+            assert f"f{i}.py:fn{i}" in out
+        assert "+5 more" in out
+        # The 11th through 15th names are NOT in the output verbatim
+        # — capped.
+        for i in range(10, 15):
+            assert f"f{i}.py:fn{i}" not in out
+
+    def test_empty_names_list_omits_line(self):
+        out = _format_reachability_block({"direct_caller_names": []})
+        assert "Direct callers" not in out
+
+    def test_missing_names_omits_line(self):
+        out = _format_reachability_block({})
+        assert "Direct callers" not in out
+
+
+# ---------------------------------------------------------------------------
+# Combined rendering (the realistic per-finding scenario)
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedRendering:
+    def test_dead_function_full_block(self):
+        # A function the substrate marked NOT_CALLED.
+        out = _format_reachability_block({
+            "priority": "low",
+            "priority_reason": "reachability:not_called",
+            "caller_count_direct": 0,
+            "caller_count_transitive": 0,
+            "direct_caller_names": [],
+        })
+        assert out.startswith("Reachability:")
+        assert "Verdict: NOT_CALLED" in out
+        assert "0 direct" in out
+        # Empty names list → no Direct callers line.
+        assert "Direct callers" not in out
+
+    def test_live_function_with_callers(self):
+        out = _format_reachability_block({
+            "caller_count_direct": 3,
+            "caller_count_transitive": 12,
+            "direct_caller_names": [
+                "auth.py:handle_login",
+                "api/users.py:create_user",
+                "tests/test_auth.py:test_e2e",
+            ],
+        })
+        assert "Verdict" not in out  # no priority signal set
+        assert "3 direct" in out
+        assert "12 transitive" in out
+        assert "auth.py:handle_login" in out
+
+    def test_framework_callable_with_zero_static_callers(self):
+        # Flask-route shape: framework dispatches at runtime,
+        # static graph has no callers. The C1 surfacing should
+        # make BOTH facts visible to the LLM.
+        out = _format_reachability_block({
+            "priority_reason": "reachability:framework_callable",
+            "caller_count_direct": 0,
+            "caller_count_transitive": 0,
+        })
+        assert "Verdict: REACHABLE" in out
+        assert "framework decorator dispatch" in out
+        assert "0 direct" in out
+
+    def test_no_signals_returns_empty(self):
+        # Metadata with none of the reachability fields → empty
+        # string (no "Reachability:" header emitted).
+        out = _format_reachability_block({
+            "class_name": "MyClass",
+            "return_type": "int",
+        })
+        assert out == ""
+
+    def test_integration_through_format_metadata_for_block(self):
+        # End-to-end: the wrapper function appends the reachability
+        # block to the existing metadata output, with the existing
+        # fields preserved.
+        out = _format_metadata_for_block({
+            "class_name": "ApiRouter",
+            "return_type": "Response",
+            "priority": "low",
+            "priority_reason": "reachability:not_called",
+            "caller_count_direct": 0,
+        })
+        assert "Class: ApiRouter" in out
+        assert "Return type: Response" in out
+        assert "Reachability:" in out
+        assert "Verdict: NOT_CALLED" in out
+        assert "0 direct" in out


### PR DESCRIPTION

The reachability pre-pass enriches every checklist function with priority / priority_reason / caller_count_* / direct_caller_names — all invisible to the per-finding analysis prompt that decides is_exploitable. Pre-C1 only priority="high" was rendered; the rest of the substrate's reachability picture sat unused.

  * _format_reachability_block renders a "Reachability:" section whenever any signal is present: - "Verdict: NOT_CALLED (priority_reason)" for priority=low - "Verdict: REACHABLE via framework decorator dispatch" (framework_callable) - "Verdict: REACHABLE via framework registration call" (registered_via_call) - "Caller graph: N direct, M transitive, K uncertain (...)" - "Direct callers: a, b, c (+N more)" (capped at 10 names) Empty when no signal present — backwards-compat with older inventories that pre-date the enricher.

  * ANALYSIS_TASK_INSTRUCTIONS Stage C now references the Reachability: block and tells the LLM how to interpret each verdict. For NOT_CALLED, asks the LLM to identify a plausible reach mechanism the substrate could miss before marking exploitable; failing that, mark is_exploitable=False with ruling=unreachable/dead_code (is_true_positive stays True — the vulnerability shape may still be real, just not exploitable in this deployment).

No verdict mutation. Pure visibility — the LLM gets the data the substrate already computed.

Tests: 21 new on _format_reachability_block + _format_metadata_for_block (verdict lines, caller graph summary, caller name cap, combined renderings). 1263 llm_analysis tests pass, ruff clean.

E2E A/B test on real LLM call: identical NOT_CALLED finding on identical code analysed twice via Gemini 2.5 Pro:
  * Without C1: is_exploitable=True ruling=validated severity=critical
  * With C1:    is_exploitable=False ruling=unreachable severity=informational (is_true_positive=True preserved — shape acknowledged)

Visibility alone shifts the verdict; the LLM uses the surfaced data to reach the correct conclusion without any enforcement layer.