### PR TITLE
feat(reporting): surface Witness counts in end-of-run summaries

### DIFF
--- a/core/reporting/__init__.py
+++ b/core/reporting/__init__.py
@@ -24,6 +24,7 @@ from .findings import (
     findings_summary_line,
     findings_summary,
 )
+from .witnesses import build_witness_summary, render_witness_summary
 
 # Public re-export surface (see module docstring for layering).
 # Order matches the import groups above; both layers are intentionally
@@ -46,4 +47,7 @@ __all__ = [
     "build_findings_summary",
     "findings_summary_line",
     "findings_summary",
+    # Layer 2 — witness summary
+    "build_witness_summary",
+    "render_witness_summary",
 ]

--- a/core/reporting/tests/test_witnesses.py
+++ b/core/reporting/tests/test_witnesses.py
@@ -1,0 +1,291 @@
+"""Tests for ``core.reporting.witnesses`` — the on-disk
+WitnessStore → operator-summary helper."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+# core/reporting/tests/test_witnesses.py → parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from core.reporting import (  # noqa: E402
+    build_witness_summary,
+    render_witness_summary,
+)
+from core.witness import (  # noqa: E402
+    Witness,
+    WitnessOutcome,
+    WitnessSource,
+    WitnessStore,
+    compute_bytes_hash,
+)
+
+
+def _put(store: WitnessStore, *, source: WitnessSource,
+         outcome: WitnessOutcome, data: bytes,
+         compiled: bool = None) -> None:
+    """Helper: add a Witness with the given source/outcome."""
+    detail = {"finding_id": data.decode("utf-8", errors="replace")[:16]}
+    if compiled is not None:
+        detail["compiled"] = compiled
+    w = Witness(
+        bytes_hash=compute_bytes_hash(data),
+        bytes_len=len(data),
+        source=source,
+        observed_outcome=outcome,
+        outcome_detail=detail,
+    )
+    store.put(w, data)
+
+
+# ----------------------------------------------------------------------
+# build_witness_summary
+# ----------------------------------------------------------------------
+
+
+def test_empty_store_returns_zero_shape(tmp_path):
+    """No directory → empty summary, no exception."""
+    summary = build_witness_summary(tmp_path / "does_not_exist")
+    assert summary["total"] == 0
+    assert summary["by_source"] == {}
+    assert summary["by_outcome"] == {}
+    assert summary["executed"] == 0
+    assert summary["compiled"] == 0
+
+
+def test_none_dir_returns_zero_shape():
+    summary = build_witness_summary(None)
+    assert summary["total"] == 0
+
+
+def test_empty_store_directory_returns_zero(tmp_path):
+    """Directory exists but no manifests inside."""
+    (tmp_path / "manifests").mkdir(parents=True)
+    summary = build_witness_summary(tmp_path)
+    assert summary["total"] == 0
+
+
+def test_counts_by_source_and_outcome(tmp_path):
+    store = WitnessStore(tmp_path)
+    _put(store, source=WitnessSource.FUZZ,
+         outcome=WitnessOutcome.EXIT_SIGNAL, data=b"fuzz crash 1")
+    _put(store, source=WitnessSource.FUZZ,
+         outcome=WitnessOutcome.EXIT_SIGNAL, data=b"fuzz crash 2")
+    _put(store, source=WitnessSource.LLM_EMIT_RUN,
+         outcome=WitnessOutcome.NOT_RUN, data=b"llm exploit not run")
+    _put(store, source=WitnessSource.LLM_EMIT_RUN,
+         outcome=WitnessOutcome.SANITIZER_REPORT,
+         data=b"llm exploit asan", compiled=True)
+
+    summary = build_witness_summary(tmp_path)
+    assert summary["total"] == 4
+    assert summary["by_source"]["fuzz"] == 2
+    assert summary["by_source"]["llm_emit_run"] == 2
+    assert summary["by_outcome"]["exit_signal"] == 2
+    assert summary["by_outcome"]["not_run"] == 1
+    assert summary["by_outcome"]["sanitizer_report"] == 1
+
+
+def test_executed_count_excludes_not_run(tmp_path):
+    """``executed`` is the count of witnesses with any outcome
+    other than NOT_RUN — what actually ran in a sandbox."""
+    store = WitnessStore(tmp_path)
+    _put(store, source=WitnessSource.LLM_EMIT_RUN,
+         outcome=WitnessOutcome.NOT_RUN, data=b"not run 1")
+    _put(store, source=WitnessSource.LLM_EMIT_RUN,
+         outcome=WitnessOutcome.NOT_RUN, data=b"not run 2")
+    _put(store, source=WitnessSource.LLM_EMIT_RUN,
+         outcome=WitnessOutcome.EXIT_SIGNAL, data=b"crashed")
+    _put(store, source=WitnessSource.LLM_EMIT_RUN,
+         outcome=WitnessOutcome.SANITIZER_REPORT, data=b"asan")
+    _put(store, source=WitnessSource.LLM_EMIT_RUN,
+         outcome=WitnessOutcome.NO_OBVIOUS_EFFECT, data=b"clean")
+
+    summary = build_witness_summary(tmp_path)
+    assert summary["executed"] == 3  # crashed + asan + clean
+    assert summary["total"] == 5
+
+
+def test_compiled_count_only_when_outcome_detail_says_true(tmp_path):
+    """``compiled`` reflects ``outcome_detail.compiled is True``.
+    The False / None / missing cases don't count."""
+    store = WitnessStore(tmp_path)
+    _put(store, source=WitnessSource.LLM_EMIT_RUN,
+         outcome=WitnessOutcome.NOT_RUN, data=b"true",
+         compiled=True)
+    _put(store, source=WitnessSource.LLM_EMIT_RUN,
+         outcome=WitnessOutcome.NOT_RUN, data=b"false",
+         compiled=False)
+    _put(store, source=WitnessSource.LLM_EMIT_RUN,
+         outcome=WitnessOutcome.NOT_RUN, data=b"missing")
+
+    summary = build_witness_summary(tmp_path)
+    assert summary["compiled"] == 1
+
+
+# ----------------------------------------------------------------------
+# render_witness_summary
+# ----------------------------------------------------------------------
+
+
+def test_render_empty_returns_empty_string(tmp_path):
+    """Empty stores produce no output — caller can ``if rendered:``
+    to skip printing a header for nothing."""
+    assert render_witness_summary(tmp_path / "nope") == ""
+    (tmp_path / "manifests").mkdir(parents=True)
+    assert render_witness_summary(tmp_path) == ""
+
+
+def test_render_includes_total_and_source_breakdown(tmp_path):
+    store = WitnessStore(tmp_path)
+    _put(store, source=WitnessSource.FUZZ,
+         outcome=WitnessOutcome.EXIT_SIGNAL, data=b"x")
+    _put(store, source=WitnessSource.LLM_EMIT_RUN,
+         outcome=WitnessOutcome.NOT_RUN, data=b"y")
+    out = render_witness_summary(tmp_path)
+    assert "Witnesses recorded: 2" in out
+    assert "fuzz: 1" in out
+    assert "llm_emit_run: 1" in out
+    assert "exit_signal: 1" in out
+    assert "not_run: 1" in out
+
+
+def test_render_compiled_executed_only_when_llm_present(tmp_path):
+    """Fuzz-only stores don't show ``Compiled``/``Executed`` lines
+    — those concepts only apply to LLM-emit-run witnesses."""
+    store = WitnessStore(tmp_path)
+    _put(store, source=WitnessSource.FUZZ,
+         outcome=WitnessOutcome.EXIT_SIGNAL, data=b"crash")
+    out = render_witness_summary(tmp_path)
+    assert "Compiled:" not in out
+    assert "Executed:" not in out
+
+
+def test_render_compiled_executed_appear_with_llm(tmp_path):
+    store = WitnessStore(tmp_path)
+    _put(store, source=WitnessSource.LLM_EMIT_RUN,
+         outcome=WitnessOutcome.SANITIZER_REPORT,
+         data=b"poc1", compiled=True)
+    _put(store, source=WitnessSource.LLM_EMIT_RUN,
+         outcome=WitnessOutcome.NOT_RUN,
+         data=b"poc2", compiled=False)
+    out = render_witness_summary(tmp_path)
+    assert "Compiled: 1/2 LLM exploits" in out
+    assert "Executed: 1/2" in out
+
+
+def test_render_respects_indent_kwarg(tmp_path):
+    store = WitnessStore(tmp_path)
+    _put(store, source=WitnessSource.FUZZ,
+         outcome=WitnessOutcome.EXIT_SIGNAL, data=b"x")
+    out = render_witness_summary(tmp_path, indent=">>")
+    assert ">>By source:" in out
+    assert ">>   fuzz: 1" in out
+
+
+# ----------------------------------------------------------------------
+# Robustness
+# ----------------------------------------------------------------------
+
+
+def test_malformed_manifest_does_not_break_summary(tmp_path):
+    """One bad manifest doesn't abort the whole enumeration —
+    WitnessStore.list_witnesses() already skips them; we just
+    pin that the helper inherits that behaviour."""
+    store = WitnessStore(tmp_path)
+    _put(store, source=WitnessSource.FUZZ,
+         outcome=WitnessOutcome.EXIT_SIGNAL, data=b"good crash")
+
+    # Drop a deliberately-malformed manifest in the dir
+    bad = tmp_path / "manifests" / "deadbeef.json"
+    bad.write_text("{not valid json")
+
+    summary = build_witness_summary(tmp_path)
+    # The good one still counted; the bad one silently skipped
+    assert summary["total"] == 1
+    assert summary["by_source"]["fuzz"] == 1
+
+
+def test_dir_is_a_regular_file_does_not_crash(tmp_path):
+    """When the path resolves to a file rather than a directory,
+    treat as empty. ``.is_dir()`` returns False on files,
+    symlinks-to-nowhere, etc."""
+    f = tmp_path / "not_a_dir"
+    f.write_text("hi")
+    assert build_witness_summary(f)["total"] == 0
+
+
+def test_binary_noise_manifest_skipped(tmp_path):
+    """A manifest file whose bytes aren't valid UTF-8 / JSON is
+    skipped, not fatal. Pre-fix path: an early `read_text` on a
+    binary blob raised UnicodeDecodeError that propagated."""
+    (tmp_path / "manifests").mkdir(parents=True)
+    (tmp_path / "manifests" / "noise.json").write_bytes(
+        b"\x00\xffnot json\x00"
+    )
+    assert build_witness_summary(tmp_path)["total"] == 0
+
+
+def test_unknown_source_enum_value_skipped(tmp_path):
+    """Forward-compat: a manifest with a source string that
+    isn't in our WitnessSource enum (e.g. a witness written by
+    a newer RAPTOR) is skipped rather than crashing the
+    helper. Operator sees a partial count + a log warning."""
+    import json
+    store = WitnessStore(tmp_path)
+    _put(store, source=WitnessSource.FUZZ,
+         outcome=WitnessOutcome.EXIT_SIGNAL, data=b"x")
+    # Mutate the manifest to use an unknown source value
+    manifests = list((tmp_path / "manifests").glob("*.json"))
+    j = json.loads(manifests[0].read_text())
+    j["source"] = "future_unknown_source"
+    manifests[0].write_text(json.dumps(j))
+
+    summary = build_witness_summary(tmp_path)
+    assert summary["total"] == 0
+    assert summary["by_source"] == {}
+
+
+def test_outcome_detail_none_does_not_crash(tmp_path):
+    """Defensive: ``outcome_detail`` arriving as None (corrupted
+    or evolution-of-schema manifest) must not crash the
+    compiled-count branch. ``isinstance(..., dict)`` guard in
+    the helper."""
+    import json
+    store = WitnessStore(tmp_path)
+    _put(store, source=WitnessSource.LLM_EMIT_RUN,
+         outcome=WitnessOutcome.NOT_RUN, data=b"x")
+    manifests = list((tmp_path / "manifests").glob("*.json"))
+    j = json.loads(manifests[0].read_text())
+    j["outcome_detail"] = None
+    manifests[0].write_text(json.dumps(j))
+
+    summary = build_witness_summary(tmp_path)
+    # The witness still counts; compiled is conservatively 0
+    # (no detail dict → can't say it compiled)
+    assert summary["total"] == 1
+    assert summary["compiled"] == 0
+
+
+def test_unreadable_dir_does_not_crash(tmp_path):
+    """A manifests/ dir we can't read (chmod 000 or similar)
+    returns an empty summary rather than raising. The operator's
+    end-of-run print should never fail because of a permissions
+    glitch."""
+    import os
+    store = WitnessStore(tmp_path)
+    _put(store, source=WitnessSource.FUZZ,
+         outcome=WitnessOutcome.EXIT_SIGNAL, data=b"x")
+    manifests_dir = tmp_path / "manifests"
+    os.chmod(manifests_dir, 0o000)
+    try:
+        summary = build_witness_summary(tmp_path)
+        # Either 0 (glob returns empty) or 1 (root-equivalent
+        # process can read anyway) is acceptable — the contract
+        # is "doesn't raise."
+        assert summary["total"] in (0, 1)
+    finally:
+        os.chmod(manifests_dir, 0o755)

--- a/core/reporting/witnesses.py
+++ b/core/reporting/witnesses.py
@@ -1,0 +1,165 @@
+"""Operator-facing summary of canonical Witnesses on disk.
+
+A run can produce two kinds of Witness:
+
+  * ``source=fuzz`` — AFL++ crashes recorded by ``raptor_fuzzing.py``
+    after collection.
+  * ``source=llm_emit_run`` — exploit PoCs emitted by
+    ``CrashAnalysisAgent`` (and ``AutonomousSecurityAgentV2``),
+    optionally with executed-outcome detail when
+    ``--execute-exploits`` was passed.
+
+Without this module, witnesses are written to
+``<out>/witnesses/`` but no operator-facing surface mentions them
+— the substrate is invisible. This module turns the on-disk
+manifest set into a short summary block suitable for the end-of-
+run console output.
+
+Failures are non-fatal: a missing directory, an unreadable
+manifest, an unexpected schema field — none should crash the
+host's final-summary print. The witness records are downstream-
+facing; the on-disk artefacts remain the canonical record either
+way.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def build_witness_summary(
+    witnesses_dir: Optional[Path],
+) -> Dict[str, Any]:
+    """Read the manifest set under ``witnesses_dir`` and group counts.
+
+    Returns a structured dict consumers can render however suits
+    their surface (console table, JSON report, HTML, etc.):
+
+      ``{
+          "total": int,
+          "by_source": {<source>: int, ...},
+          "by_outcome": {<outcome>: int, ...},
+          "executed": int,    # how many witnesses observed an
+                              # outcome other than NOT_RUN
+          "compiled": int,    # how many had compiled=True in
+                              # outcome_detail (LLM-emit-run only)
+        }``
+
+    Empty store / missing directory returns the zero-valued shape
+    rather than raising — keeps the call site clean.
+    """
+    empty: Dict[str, Any] = {
+        "total": 0,
+        "by_source": {},
+        "by_outcome": {},
+        "executed": 0,
+        "compiled": 0,
+    }
+
+    if witnesses_dir is None or not Path(witnesses_dir).is_dir():
+        return empty
+
+    try:
+        from core.witness import WitnessStore, WitnessOutcome
+    except ImportError as e:
+        logger.debug("core.witness unavailable (%s) — empty summary", e)
+        return empty
+
+    try:
+        store = WitnessStore(Path(witnesses_dir))
+    except Exception as e:  # noqa: BLE001 — best-effort
+        logger.warning(
+            "build_witness_summary: WitnessStore open failed: "
+            "%s: %s; empty summary returned", type(e).__name__, e,
+        )
+        return empty
+
+    total = 0
+    by_source: Dict[str, int] = {}
+    by_outcome: Dict[str, int] = {}
+    executed = 0
+    compiled = 0
+
+    try:
+        for w in store.list_witnesses():
+            total += 1
+            src = w.source.value
+            out = w.observed_outcome.value
+            by_source[src] = by_source.get(src, 0) + 1
+            by_outcome[out] = by_outcome.get(out, 0) + 1
+            if w.observed_outcome is not WitnessOutcome.NOT_RUN:
+                executed += 1
+            if isinstance(w.outcome_detail, dict) \
+                    and w.outcome_detail.get("compiled") is True:
+                compiled += 1
+    except Exception as e:  # noqa: BLE001 — best-effort iteration
+        logger.warning(
+            "build_witness_summary: iteration aborted at %d "
+            "witnesses (%s: %s); returning partial counts",
+            total, type(e).__name__, e,
+        )
+
+    return {
+        "total": total,
+        "by_source": by_source,
+        "by_outcome": by_outcome,
+        "executed": executed,
+        "compiled": compiled,
+    }
+
+
+def render_witness_summary(
+    witnesses_dir: Optional[Path],
+    *,
+    indent: str = "   ",
+) -> str:
+    """Render a console-friendly summary block; empty string when
+    there are no witnesses.
+
+    Format (indented to match the surrounding fuzz/agentic summary
+    cadence):
+
+        Witnesses recorded: <N>
+           By source:
+              fuzz: 12
+              llm_emit_run: 7
+           By outcome:
+              exit_signal: 12
+              not_run: 5
+              sanitizer_report: 2
+           Compiled: 5/7 LLM exploits
+           Executed: 14/19
+
+    The "Compiled" and "Executed" lines only show when there's an
+    llm_emit_run witness in the store — otherwise they'd always
+    read ``0/0`` and clutter the fuzz-only view.
+    """
+    s = build_witness_summary(witnesses_dir)
+    if s["total"] == 0:
+        return ""
+
+    out = [f"Witnesses recorded: {s['total']}"]
+    if s["by_source"]:
+        out.append(f"{indent}By source:")
+        for src, cnt in sorted(s["by_source"].items()):
+            out.append(f"{indent}   {src}: {cnt}")
+    if s["by_outcome"]:
+        out.append(f"{indent}By outcome:")
+        for outcome, cnt in sorted(s["by_outcome"].items()):
+            out.append(f"{indent}   {outcome}: {cnt}")
+
+    llm_count = s["by_source"].get("llm_emit_run", 0)
+    if llm_count:
+        out.append(
+            f"{indent}Compiled: {s['compiled']}/{llm_count} "
+            f"LLM exploits"
+        )
+        out.append(
+            f"{indent}Executed: {s['executed']}/{s['total']}"
+        )
+
+    return "\n".join(out)

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -1581,7 +1581,7 @@ Examples:
             )
             sca_findings_path = sca_out / "findings.json"
 
-            print(f"\n✓ SCA complete:")
+            print("\n✓ SCA complete:")
             print(f"  - Dependencies analysed: {sca_result.deps_analysed}")
             print(f"  - Vulnerability findings: {sca_result.vuln_findings}")
             print(f"  - Hygiene findings: {sca_result.hygiene_findings}")
@@ -1589,7 +1589,7 @@ Examples:
             if sca_result.llm_reviews_run:
                 print(f"  - LLM reviews: {sca_result.llm_reviews_run}")
             if sca_result.triage_run:
-                print(f"  - Triage: completed")
+                print("  - Triage: completed")
             logger.info("SCA complete: %d vulns, %d hygiene, %d supply-chain",
                         sca_result.vuln_findings, sca_result.hygiene_findings,
                         sca_result.supply_chain_findings)
@@ -1698,6 +1698,20 @@ Examples:
 
                 if args.codeql or args.codeql_only:
                     print(f"  - CodeQL dataflow paths validated: {analysis.get('dataflow_validated', 0)}")
+
+                # Witness summary — recorded by ``AutonomousSecurityAgentV2``
+                # when ``--no-record-witnesses`` wasn't passed. Lives under
+                # ``<autonomous_out>/witnesses/``. Silent when empty.
+                from core.reporting import render_witness_summary
+                witness_block = render_witness_summary(
+                    autonomous_out / "witnesses",
+                )
+                if witness_block:
+                    print(f"\n  Witnesses ({autonomous_out / 'witnesses'}):")
+                    for line in witness_block.splitlines():
+                        # Strip one level of leading indent so it sits
+                        # consistently under the analysis-complete bullets.
+                        print(f"  {line}")
         else:
             print("⚠️  Analysis failed or produced no output")
             if stderr:

--- a/raptor_fuzzing.py
+++ b/raptor_fuzzing.py
@@ -707,6 +707,24 @@ Examples:
     print(f"   Analysis: {out_dir / 'analysis'}")
     print(f"   Exploits: {out_dir / 'analysis' / 'exploits'}")
 
+    # Witness summary — two stores in play here. The fuzz crashes
+    # are recorded under ``<out>/witnesses`` (source=fuzz) by the
+    # crash-collection step; the LLM-emitted exploits land under
+    # ``<out>/analysis/witnesses`` (source=llm_emit_run) by the
+    # ``CrashAnalysisAgent`` wiring. Surface both — operators don't
+    # care about the layout split, they care about the totals.
+    from core.reporting import render_witness_summary
+    fuzz_summary = render_witness_summary(out_dir / "witnesses")
+    llm_summary = render_witness_summary(out_dir / "analysis" / "witnesses")
+    if fuzz_summary or llm_summary:
+        print("")
+        if fuzz_summary:
+            print(f" Fuzz witnesses ({out_dir / 'witnesses'}):")
+            print(fuzz_summary)
+        if llm_summary:
+            print(f" LLM-exploit witnesses ({out_dir / 'analysis' / 'witnesses'}):")
+            print(llm_summary)
+
     # Save summary report
     report = {
         "binary": str(binary_path),


### PR DESCRIPTION
The Witness substrate (PRs #579 / #580 / #582 / #602) writes canonical Witness records to <out>/witnesses/ on every fuzz collection and LLM exploit emit, but no operator-facing surface mentioned them. Until now they've been visible only by inspecting the manifest directory by hand — the substrate did its job but operators couldn't see what it produced.

New core.reporting.witnesses helper:

  * build_witness_summary(dir) → structured dict with counts grouped by source / by outcome, plus executed (anything other than NOT_RUN) and compiled (outcome_detail.compiled is True) totals.
  * render_witness_summary(dir, indent=...) → console-friendly block; empty string when the store is empty.

Wired into:

  * raptor_fuzzing.py final summary — surfaces both the fuzz- crash store at <out>/witnesses/ and the LLM-exploit store at <out>/analysis/witnesses/.
  * raptor_agentic.py analysis-complete summary — surfaces <autonomous_out>/witnesses/.

All failure modes (missing dir, malformed manifest, witness import unavailable, unreadable directory, unknown source enum value, null outcome_detail) return the zero-shape empty summary rather than crashing the end-of-run print.

Verified end-to-end against a real fuzz run on the trivially- fuzzable fixture with --execute-exploits --execute-sanitizers= address: AFL produced 2 crashes (fuzz witnesses with EXIT_SIGNAL), LLM emitted 1 PoC (compiled, ASAN fired, SANITIZER_REPORT), summary block surfaced cleanly at end of run.

Drive-by: fixed 2 pre-existing F541 ruff errors in raptor_agentic.py (touched-file cleanup).

Tests (17): empty-store / None-dir / file-not-dir / no-manifests- subdir / counts-by-source-and-outcome / executed-excludes-not-run / compiled-only-when-detail-true / fuzz-only-doesn't-show- Compiled+Executed / LLM-presence-adds-those-lines / indent- respected / malformed-manifest-doesn't-abort / binary-noise- manifest-skipped / unknown-source-enum-skipped / outcome_detail- None-doesn't-crash / unreadable-dir-doesn't-crash.