### PR TITLE
feat(reachability): --allow-unreachable opt-out for in-isolation review

### DIFF
--- a/core/orchestration/agentic_passes.py
+++ b/core/orchestration/agentic_passes.py
@@ -321,17 +321,27 @@ def run_validate_postpass(
     analysis_report: Path,
     block_cc_dispatch: bool = False,
     claude_bin: Optional[str] = None,
+    *,
+    allow_unreachable: bool = False,
 ) -> PostpassResult:
     """Run /validate against findings flagged exploitable or high-confidence.
 
     Creates a proper /validate run directory as a sibling of the agentic dir
     so the bridge's tier-2 lookup finds any /understand sibling automatically.
 
+    ``allow_unreachable`` is forwarded into the validate-driver prompt so
+    the claude-code sub-agent knows the operator opted into in-isolation
+    review. The agent passes it through to the PipelineConfig when
+    constructing the validation pipeline (the substrate's
+    PipelineConfig.allow_unreachable field threads to the Stage B
+    attack-path demoter).
+
     Never raises — enrichment failure must not break the base agentic pipeline.
     """
     try:
         return _run_validate_postpass_unsafe(
-            target, agentic_out_dir, analysis_report, block_cc_dispatch, claude_bin)
+            target, agentic_out_dir, analysis_report, block_cc_dispatch,
+            claude_bin, allow_unreachable=allow_unreachable)
     except Exception as e:
         logger.exception("validate post-pass crashed unexpectedly")
         return PostpassResult(ran=False,
@@ -344,6 +354,8 @@ def _run_validate_postpass_unsafe(
     analysis_report: Path,
     block_cc_dispatch: bool,
     claude_bin: Optional[str],
+    *,
+    allow_unreachable: bool = False,
 ) -> PostpassResult:
     if block_cc_dispatch:
         return PostpassResult(ran=False, skipped_reason="cc_trust blocked dispatch (untrusted target)")
@@ -454,8 +466,23 @@ def _run_validate_postpass_unsafe(
                 },
             )
 
+        # Operator-flag handoff to the validation orchestrator.
+        # Mirrors the parent-checklist-pointer.json pattern: the
+        # launcher writes overrides to a known filename in
+        # validate_dir; the orchestrator's Stage 0 reads it and
+        # merges into self.config. Substrate-enforced — bypasses
+        # the claude-code sub-agent's prompt-interpretation path
+        # entirely, so the flag works regardless of whether the
+        # SKILL.md teaches the agent about it.
+        if allow_unreachable:
+            save_json(
+                validate_dir / "pipeline-config-overrides.json",
+                {"allow_unreachable": True},
+            )
+
         prompt = _build_validate_prompt(target, agentic_out_dir, validate_dir,
-                                        analysis_report, selection_file, len(selected))
+                                        analysis_report, selection_file, len(selected),
+                                        allow_unreachable=allow_unreachable)
 
         try:
             from core.llm.cc_adapter import CCDispatchConfig, build_cc_command
@@ -1150,7 +1177,24 @@ Keep output concise. Report what you mapped and exit.
 
 def _build_validate_prompt(target: Path, agentic_out_dir: Path, validate_dir: Path,
                             analysis_report: Path, selection_file: Path,
-                            selected_count: int) -> str:
+                            selected_count: int,
+                            *,
+                            allow_unreachable: bool = False) -> str:
+    allow_unreachable_note = ""
+    if allow_unreachable:
+        allow_unreachable_note = """
+**OPERATOR FLAG: --allow-unreachable**
+
+The operator passed --allow-unreachable. When constructing the
+validation PipelineConfig (or whatever your equivalent invocation
+path uses), set ``allow_unreachable=True`` so the Stage B attack-
+path demoter does NOT demote paths anchored to NOT_CALLED
+functions. The substrate's PipelineConfig.allow_unreachable
+threads to packages.exploitability_validation.reachability.
+demote_unreachable_paths and turns the demotion into a no-op.
+Reachability-related findings still surface; the report ranking
+reflects the LLM verdict rather than the static reachability gate.
+"""
     return f"""You are running the /validate post-pass for the /agentic security
 workflow. The base agentic pipeline has finished and produced an analysis
 report; your job is to run the full validation pipeline against the
@@ -1161,7 +1205,7 @@ Agentic out_dir:      {agentic_out_dir}
 Analysis report:      {analysis_report}
 Selection file:       {selection_file}
 Validate output dir:  {validate_dir}
-
+{allow_unreachable_note}
 Read the findings from {selection_file}. **The launcher has already
 translated them into /validate's FindingsContainer shape** (id, file, line,
 description, ruling.status, etc.) — no field-mapping needed on your end.

--- a/core/orchestration/agentic_passes.py
+++ b/core/orchestration/agentic_passes.py
@@ -901,6 +901,8 @@ def _enrich_agentic_checklist(agentic_out_dir: Path, context_map_path: Path) -> 
 
 def _mark_unreachable_low_priority(
     agentic_out_dir: Path, target: Path,
+    *,
+    allow_unreachable: bool = False,
 ) -> int:
     """Mark dead-code functions as ``priority=low`` in the
     agentic checklist.
@@ -912,6 +914,11 @@ def _mark_unreachable_low_priority(
     complementary and run consecutively. Functions already
     marked ``priority=high`` by context-map enrichment are
     skipped (entry-point analysis trumps reachability).
+
+    ``allow_unreachable`` (from --allow-unreachable) is threaded
+    to ``mark_unreachable_low_priority``: when True, NOT_CALLED
+    functions do NOT get the priority=low demotion. Framework-
+    callable / registered-via-call annotations still apply.
 
     Returns the count of functions marked low-priority. Best-
     effort; failures logged at debug.
@@ -927,7 +934,9 @@ def _mark_unreachable_low_priority(
         checklist = load_json(checklist_path)
         if not isinstance(checklist, dict):
             return 0
-        marked = mark_unreachable_low_priority(checklist, target)
+        marked = mark_unreachable_low_priority(
+            checklist, target, allow_unreachable=allow_unreachable,
+        )
         if marked:
             save_json(checklist_path, checklist)
         return marked
@@ -942,6 +951,8 @@ def _mark_unreachable_low_priority(
 def run_reachability_prepass(
     target: Path,
     agentic_out_dir: Path,
+    *,
+    allow_unreachable: bool = False,
 ) -> "ReachabilityPrepassResult":
     """Always-on companion to ``run_understand_prepass``.
 
@@ -956,6 +967,11 @@ def run_reachability_prepass(
     them to the model — so the priority=low marking shifts the
     analysis budget to live code regardless of whether the
     operator passed --understand.
+
+    ``allow_unreachable`` (from --allow-unreachable) is threaded
+    to the underlying enrichment pass. When True, NOT_CALLED
+    functions are NOT demoted (still get caller-context fields
+    + framework_callable / registered_via_call annotations).
 
     Best-effort: any failure (missing checklist, inventory build
     error, malformed call_graph) is logged at debug; the
@@ -1003,6 +1019,7 @@ def run_reachability_prepass(
             )
         marked = mark_unreachable_low_priority(
             checklist, target, inventory=inventory,
+            allow_unreachable=allow_unreachable,
         )
         # Caller-context enrichment runs AFTER the dead-code
         # marking so already-marked functions can be skipped

--- a/core/orchestration/reachability_enrichment.py
+++ b/core/orchestration/reachability_enrichment.py
@@ -46,6 +46,7 @@ def mark_unreachable_low_priority(
     target_path: Path,
     *,
     inventory: Optional[Dict[str, Any]] = None,
+    allow_unreachable: bool = False,
 ) -> int:
     """Walk ``checklist["files"][*]["items"]`` and mark functions
     that are provably dead (NOT_CALLED) as ``priority="low"``.
@@ -56,7 +57,21 @@ def mark_unreachable_low_priority(
     (avoids a redundant tree walk when a sibling consumer
     already built one).
 
-    Returns the count of functions marked low-priority.
+    ``allow_unreachable=True`` is the operator-opt-out for the
+    in-isolation use case (CTF challenges, vendor reference
+    snippets, exploit-research targets, intentional dead-code
+    review). When set, NOT_CALLED functions do NOT receive the
+    ``priority="low"`` demotion — the analysis prompt won't
+    surface a "Verdict: NOT_CALLED" line, and the LLM is asked to
+    evaluate the function's inherent vulnerability shape rather
+    than its deployment reachability. Framework-callable /
+    registered-via-call annotations are STILL applied (they're
+    affirmative reachability evidence regardless of mode).
+
+    Returns the count of functions marked low-priority. Zero when
+    ``allow_unreachable=True`` (nothing demoted) but still mutates
+    the checklist with the framework_callable / registered_via_call
+    annotations.
     """
     if not isinstance(checklist, dict):
         return 0
@@ -162,6 +177,12 @@ def mark_unreachable_low_priority(
                 )
                 continue
 
+            if allow_unreachable:
+                # In-isolation mode: don't demote NOT_CALLED
+                # functions. The analysis prompt will see caller
+                # counts (informational) but no "Verdict:
+                # NOT_CALLED" line that would trigger deferral.
+                continue
             func["priority"] = "low"
             func["priority_reason"] = "reachability:not_called"
             marked += 1

--- a/core/orchestration/tests/test_reachability_enrichment.py
+++ b/core/orchestration/tests/test_reachability_enrichment.py
@@ -499,6 +499,60 @@ class TestRegistrationViaCallBypass:
     to it via the registration call.
     """
 
+    def test_allow_unreachable_suppresses_demotion(self, tmp_path):
+        # C2: --allow-unreachable opts out of NOT_CALLED demotion.
+        # A genuinely-dead function does NOT get priority=low.
+        target = _project(tmp_path, {
+            "src/v.py": "def dead(): pass\n",
+        })
+        checklist = _checklist({
+            "src/v.py": [{
+                "name": "dead", "kind": "function",
+                "line_start": 1, "line_end": 1,
+            }],
+        })
+        marked = mark_unreachable_low_priority(
+            checklist, target, allow_unreachable=True,
+        )
+        assert marked == 0
+        func = checklist["files"][0]["items"][0]
+        assert "priority" not in func, (
+            "--allow-unreachable must NOT demote NOT_CALLED functions"
+        )
+        assert "priority_reason" not in func
+
+    def test_allow_unreachable_still_annotates_framework_callable(
+        self, tmp_path,
+    ):
+        # Framework-callable annotation is affirmative reachability
+        # evidence, not a deferral signal — should still apply even
+        # under --allow-unreachable (the operator may find it useful
+        # to know which functions ARE framework-registered).
+        target = _project(tmp_path, {
+            "src/api.py": (
+                "from flask import Flask\n"
+                "app = Flask(__name__)\n"
+                "\n"
+                "@app.route('/x')\n"
+                "def handler():\n"
+                "    return 1\n"
+            ),
+        })
+        checklist = _checklist({
+            "src/api.py": [{
+                "name": "handler", "kind": "function",
+                "line_start": 5, "line_end": 6,
+            }],
+        })
+        mark_unreachable_low_priority(
+            checklist, target, allow_unreachable=True,
+        )
+        func = checklist["files"][0]["items"][0]
+        # framework_callable annotation still applies
+        assert func.get("priority_reason") == (
+            "reachability:framework_callable"
+        )
+
     def test_go_handler_registered_via_handlefunc_not_demoted(
         self, tmp_path,
     ):

--- a/core/orchestration/tests/test_validate_checklist_handoff_e2e.py
+++ b/core/orchestration/tests/test_validate_checklist_handoff_e2e.py
@@ -299,3 +299,46 @@ def test_e2e_pointer_drives_full_reuse_and_demotion(tmp_path):
     # Live path untouched.
     assert paths_by_id["p-live"]["proximity"] == 8
     assert paths_by_id["p-live"]["blockers"] == []
+
+
+# ---------------------------------------------------------------------------
+# C2-followup: --allow-unreachable threads through the agentic
+# post-pass into the prompt that drives the claude-code validation
+# sub-agent.
+# ---------------------------------------------------------------------------
+
+
+def test_build_validate_prompt_default_omits_allow_unreachable_note():
+    """Sanity: default prompt has no in-isolation-mode notice."""
+    from pathlib import Path
+    from core.orchestration.agentic_passes import _build_validate_prompt
+    prompt = _build_validate_prompt(
+        target=Path("/tmp/x"),
+        agentic_out_dir=Path("/tmp/x/out"),
+        validate_dir=Path("/tmp/x/validate"),
+        analysis_report=Path("/tmp/x/report.json"),
+        selection_file=Path("/tmp/x/sel.json"),
+        selected_count=3,
+    )
+    assert "OPERATOR FLAG: --allow-unreachable" not in prompt
+
+
+def test_build_validate_prompt_with_allow_unreachable_includes_notice():
+    """C2-followup: the operator flag surfaces as a prompt section
+    so the claude-code sub-agent knows to thread it into the
+    PipelineConfig when invoking the validation pipeline."""
+    from pathlib import Path
+    from core.orchestration.agentic_passes import _build_validate_prompt
+    prompt = _build_validate_prompt(
+        target=Path("/tmp/x"),
+        agentic_out_dir=Path("/tmp/x/out"),
+        validate_dir=Path("/tmp/x/validate"),
+        analysis_report=Path("/tmp/x/report.json"),
+        selection_file=Path("/tmp/x/sel.json"),
+        selected_count=3,
+        allow_unreachable=True,
+    )
+    assert "OPERATOR FLAG: --allow-unreachable" in prompt
+    assert "allow_unreachable=True" in prompt
+    assert "PipelineConfig" in prompt
+    assert "demote_unreachable_paths" in prompt

--- a/packages/codeql/autonomous_analyzer.py
+++ b/packages/codeql/autonomous_analyzer.py
@@ -151,6 +151,7 @@ class AutonomousCodeQLAnalyzer:
         enable_visualization=True,
         reachability_inventory=None,
         reachability_checklist_path=None,
+        allow_unreachable=False,
     ):
         """
         Initialize autonomous analyzer.
@@ -216,6 +217,14 @@ class AutonomousCodeQLAnalyzer:
         #     retry.
         self._reachability_inventory: Any = reachability_inventory
         self._reachability_checklist_path = reachability_checklist_path
+        # Operator opt-out for the in-isolation use case. When True,
+        # the prefilter NEVER short-circuits NOT_CALLED findings —
+        # full LLM analysis runs even on dead-code-looking sinks.
+        # Matched in raptor_agentic by --allow-unreachable + threaded
+        # to mark_unreachable_low_priority / demote_unreachable_paths
+        # / the analysis prompt builder so all four reachability
+        # consumer sites move together.
+        self._allow_unreachable = bool(allow_unreachable)
 
     def _check_reachability(
         self, finding: CodeQLFinding, repo_path: Path,
@@ -326,6 +335,17 @@ class AutonomousCodeQLAnalyzer:
         except ValueError:
             return None
         verdict = result.verdict.value
+        # Operator opt-out: --allow-unreachable disables the
+        # short-circuit path entirely. Return None ("prefilter
+        # had no opinion") instead of the verdict — the caller
+        # then proceeds with full LLM analysis regardless of
+        # static-graph reachability. The flag is intended for
+        # in-isolation review (CTF, snippet, vendor reference)
+        # where the operator explicitly wants to evaluate the
+        # code pattern's inherent vulnerability shape rather
+        # than its deployment reachability.
+        if self._allow_unreachable and verdict == "not_called":
+            return None
         # NOT_CALLED in the static graph doesn't mean unreachable
         # when the function is framework-registered (Flask
         # ``@app.route``, Celery ``@shared_task``, Django

--- a/packages/codeql/tests/test_reachability_prefilter.py
+++ b/packages/codeql/tests/test_reachability_prefilter.py
@@ -446,6 +446,41 @@ def test_framework_callable_does_not_short_circuit(
 # ---------------------------------------------------------------------------
 
 
+def test_allow_unreachable_suppresses_not_called_short_circuit(tmp_path):
+    """C2: --allow-unreachable on the analyzer → the prefilter
+    returns None (no opinion) instead of 'not_called', letting
+    the caller proceed with full LLM analysis."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "v.py").write_text(
+        "def dead(): cursor.execute('x')\n"
+    )
+    a = AutonomousCodeQLAnalyzer(
+        llm_client=MagicMock(), exploit_validator=MagicMock(),
+        multi_turn_analyzer=None, enable_visualization=False,
+        allow_unreachable=True,
+    )
+    verdict = a._check_reachability(_finding("src/v.py", line=1), tmp_path)
+    assert verdict is None, (
+        f"--allow-unreachable must suppress not_called signal; "
+        f"got {verdict!r}"
+    )
+
+
+def test_default_still_returns_not_called(tmp_path):
+    """Sanity: with allow_unreachable=False (default), dead
+    function still returns 'not_called' — preserving the existing
+    short-circuit path."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "v.py").write_text(
+        "def dead(): cursor.execute('x')\n"
+    )
+    a = _analyzer()  # default constructor; allow_unreachable defaults False
+    verdict = a._check_reachability(_finding("src/v.py", line=1), tmp_path)
+    assert verdict == "not_called"
+
+
 def test_go_handler_registered_via_call_returns_registered_via_call(tmp_path):
     """Go handler passed to http.HandleFunc resolves new
     ``registered_via_call`` verdict instead of ``not_called``."""

--- a/packages/exploitability_validation/orchestrator.py
+++ b/packages/exploitability_validation/orchestrator.py
@@ -119,6 +119,15 @@ class PipelineConfig:
     stage_b_max_attempts: int = 5  # Max attempts per attack path
     stage_b_proximity_threshold: int = 3  # Min proximity to continue
 
+    # Operator opt-out for the in-isolation use case. When True,
+    # the Stage B attack-path demoter does NOT demote paths anchored
+    # to NOT_CALLED functions — the report ranking reflects the LLM
+    # verdict rather than the static reachability gate. Pairs with
+    # the same flag on raptor_agentic / raptor_codeql so the four
+    # reachability consumer sites move together across the
+    # /scan → /agentic → /validate pipeline.
+    allow_unreachable: bool = False
+
 
 @dataclass
 class PipelineState:
@@ -504,7 +513,19 @@ class ValidationOrchestrator:
         run dir. We reuse that instead of paying for another
         full source-tree walk + AST parse — typical large repos
         save 30-60s here, which dominates Stage 0 cost.
+
+        Also reads ``pipeline-config-overrides.json`` if present
+        and merges into ``self.config`` — substrate-enforced
+        operator-flag handoff from the launcher (e.g.
+        ``--allow-unreachable``). Bypasses the claude-code sub-
+        agent's prompt-interpretation entirely so the flag works
+        regardless of skill-text changes.
         """
+        # Apply launcher-side config overrides before any stage
+        # logic reads from self.config. Same file-handoff pattern
+        # as parent-checklist-pointer.json: read-if-present,
+        # silently no-op on absence or malformed content.
+        self._apply_pipeline_config_overrides()
         # Check for parent-process checklist pointer first.
         reused = self._try_reuse_parent_checklist()
         if reused is not None:
@@ -540,6 +561,55 @@ class ValidationOrchestrator:
     # 1 hour is generous for the live case, conservative for
     # drift.
     _PARENT_CHECKLIST_TTL_SECONDS = 3600
+
+    def _apply_pipeline_config_overrides(self) -> None:
+        """Read launcher-side config overrides from
+        ``pipeline-config-overrides.json`` in the workdir and
+        merge them into ``self.config``.
+
+        Pattern mirrors :func:`_try_reuse_parent_checklist` —
+        read-if-present, silently no-op on absence or malformed
+        content (best-effort). The launcher writes this file when
+        the operator passes flags that need to reach the validation
+        pipeline (currently: ``--allow-unreachable``).
+
+        Substrate-enforced. Does not depend on the claude-code
+        sub-agent reading any prompt instruction — the orchestrator
+        code reads the file directly. The agent could even ignore
+        every flag-related prompt instruction; this code path still
+        applies the override.
+
+        Supported keys (silently ignored if unknown so future
+        launchers can add new flags without an orchestrator update
+        breaking on parse):
+          * ``allow_unreachable`` (bool) — gates Stage B demoter.
+        """
+        overrides_path = (
+            Path(self.config.workdir) / "pipeline-config-overrides.json"
+        )
+        if not overrides_path.is_file():
+            return
+        try:
+            overrides = self.state.load_json("pipeline-config-overrides.json")
+        except Exception:                           # noqa: BLE001
+            logger.debug(
+                "pipeline-config-overrides.json present but unreadable; "
+                "ignoring",
+            )
+            return
+        if not isinstance(overrides, dict):
+            return
+        # Apply known overrides. Type-check each so a malformed
+        # value (e.g. allow_unreachable as a string) doesn't break
+        # the boolean gate downstream.
+        if "allow_unreachable" in overrides:
+            v = overrides["allow_unreachable"]
+            if isinstance(v, bool):
+                self.config.allow_unreachable = v
+                logger.info(
+                    "pipeline-config-overrides: allow_unreachable=%s "
+                    "(from launcher)", v,
+                )
 
     def _try_reuse_parent_checklist(self) -> Optional[Dict[str, Any]]:
         """Look for a ``parent-checklist-pointer.json`` written by
@@ -1008,6 +1078,7 @@ class ValidationOrchestrator:
                 self.state.findings.get("findings", []),
                 Path(self.config.target_path),
                 inventory=self.state.checklist,
+                allow_unreachable=self.config.allow_unreachable,
             )
             # Stage F path verification: every attack path whose
             # sink is alive (not demoted) gets a substrate_evidence

--- a/packages/exploitability_validation/reachability.py
+++ b/packages/exploitability_validation/reachability.py
@@ -45,6 +45,7 @@ def demote_unreachable_paths(
     target_path: Path,
     *,
     inventory: Optional[Dict[str, Any]] = None,
+    allow_unreachable: bool = False,
 ) -> int:
     """Walk ``attack_paths``, demote any whose entry function is
     NOT_CALLED. Mutates the list in place. Returns the count of
@@ -57,7 +58,14 @@ def demote_unreachable_paths(
     when it's already been built (e.g. by a sibling reachability
     consumer); otherwise we build one over ``target_path``.
 
+    ``allow_unreachable=True`` is the operator-opt-out for the
+    in-isolation use case. When set, the function is a no-op
+    (returns 0) — NOT_CALLED paths are admitted unfiltered so the
+    report ranking reflects the LLM's analysis verdict rather
+    than the static reachability gate.
+
     No-op when:
+      * ``allow_unreachable=True``
       * attack_paths is empty
       * no path can be linked to a finding-with-location
       * the inventory build fails (graceful degradation —
@@ -68,6 +76,8 @@ def demote_unreachable_paths(
     The function is a single best-effort pass; per-path errors are
     logged at debug and the remaining paths still get processed.
     """
+    if allow_unreachable:
+        return 0
     if not attack_paths:
         return 0
 

--- a/packages/exploitability_validation/tests/test_parent_checklist_pointer.py
+++ b/packages/exploitability_validation/tests/test_parent_checklist_pointer.py
@@ -342,8 +342,10 @@ def test_stage_b_passes_state_checklist_to_demotion(tmp_path):
     captured = {}
     from unittest.mock import patch
 
-    def _capture(attack_paths, findings, target_path, *, inventory=None):
+    def _capture(attack_paths, findings, target_path, *,
+                 inventory=None, allow_unreachable=False):
         captured["inventory"] = inventory
+        captured["allow_unreachable"] = allow_unreachable
         return 0
 
     with patch(
@@ -356,3 +358,221 @@ def test_stage_b_passes_state_checklist_to_demotion(tmp_path):
     # The orchestrator should have passed state.checklist as the
     # inventory kwarg.
     assert captured["inventory"] is orchestrator.state.checklist
+
+
+def test_pipeline_config_allow_unreachable_threads_to_demoter():
+    """C2-followup: PipelineConfig.allow_unreachable threads to
+    demote_unreachable_paths so the operator opt-out from
+    --allow-unreachable reaches the Stage B post-pass."""
+    from packages.exploitability_validation.orchestrator import (
+        PipelineConfig, PipelineState, ValidationOrchestrator,
+    )
+    import tempfile
+    from unittest.mock import patch
+
+    with tempfile.TemporaryDirectory() as td:
+        cfg = PipelineConfig(
+            target_path=td, workdir=td, vuln_type="x",
+            allow_unreachable=True,
+        )
+        orch = ValidationOrchestrator(cfg)
+        orch.state = PipelineState(config=cfg)
+        orch.state.findings = {
+            "stage": "A",
+            "findings": [{
+                "id": "f1",
+                "status": "not_disproven",
+                "vuln_type": "sql-injection",
+                "file_path": "x.py",
+                "start_line": 1,
+            }],
+        }
+        orch.state.attack_paths = [{
+            "id": "p1", "finding_id": "f1",
+            "proximity": 8, "blockers": [],
+        }]
+        orch.state.checklist = {"files": []}
+
+        captured = {}
+
+        def _capture(attack_paths, findings, target_path, *,
+                     inventory=None, allow_unreachable=False):
+            captured["allow_unreachable"] = allow_unreachable
+            return 0
+
+        with patch(
+            "packages.exploitability_validation.reachability."
+            "demote_unreachable_paths",
+            side_effect=_capture,
+        ), patch(
+            "packages.exploitability_validation.reachability."
+            "enrich_with_substrate_evidence",
+            return_value=0,
+        ):
+            try:
+                orch._run_stage_b()
+            except Exception:
+                # Best-effort — Stage B has many side-effect
+                # branches; we only care that the demoter call
+                # forwarded the flag.
+                pass
+
+        assert captured.get("allow_unreachable") is True, (
+            "PipelineConfig.allow_unreachable=True must thread "
+            "to demote_unreachable_paths"
+        )
+
+
+def test_pipeline_config_default_allow_unreachable_is_false():
+    """Sanity: PipelineConfig default keeps allow_unreachable=False
+    so existing direct PipelineExecutor callers (tests, libexec)
+    aren't quietly switched into in-isolation mode."""
+    from packages.exploitability_validation.orchestrator import (
+        PipelineConfig,
+    )
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        cfg = PipelineConfig(target_path=td, workdir=td)
+        assert cfg.allow_unreachable is False
+
+
+# ---------------------------------------------------------------------------
+# C2-followup-2: pipeline-config-overrides.json file handoff
+# Substrate-enforced operator-flag propagation that bypasses the
+# claude-code sub-agent's prompt-interpretation path entirely.
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineConfigOverridesFile:
+    def _orch(self, td: str):
+        from packages.exploitability_validation.orchestrator import (
+            PipelineConfig, PipelineState, ValidationOrchestrator,
+        )
+        cfg = PipelineConfig(
+            target_path=td, workdir=td, vuln_type="x",
+        )
+        orch = ValidationOrchestrator(cfg)
+        orch.state = PipelineState(config=cfg)
+        return orch
+
+    def test_overrides_file_sets_allow_unreachable(self, tmp_path):
+        """Substrate-enforced: launcher writes the file, orchestrator
+        reads it at Stage 0, self.config.allow_unreachable flips."""
+        from core.json import save_json
+        save_json(
+            tmp_path / "pipeline-config-overrides.json",
+            {"allow_unreachable": True},
+        )
+        orch = self._orch(str(tmp_path))
+        assert orch.config.allow_unreachable is False  # initial default
+        orch._apply_pipeline_config_overrides()
+        assert orch.config.allow_unreachable is True, (
+            "overrides file with allow_unreachable=True must flip "
+            "self.config.allow_unreachable"
+        )
+
+    def test_missing_overrides_file_is_no_op(self, tmp_path):
+        """Backwards-compat: when the launcher didn't write the file
+        (e.g. operator didn't pass --allow-unreachable, or running
+        /validate standalone without /agentic), the orchestrator
+        proceeds with default config."""
+        orch = self._orch(str(tmp_path))
+        orch._apply_pipeline_config_overrides()
+        assert orch.config.allow_unreachable is False
+
+    def test_malformed_overrides_file_is_ignored(self, tmp_path):
+        """Defensive: a malformed overrides file (invalid JSON,
+        wrong shape, wrong types) doesn't crash Stage 0 — it's
+        silently ignored, falling back to defaults."""
+        (tmp_path / "pipeline-config-overrides.json").write_text(
+            "{not valid json"
+        )
+        orch = self._orch(str(tmp_path))
+        orch._apply_pipeline_config_overrides()  # must not raise
+        assert orch.config.allow_unreachable is False
+
+    def test_wrong_type_value_is_ignored(self, tmp_path):
+        """Defensive: allow_unreachable expects bool; a string
+        value is rejected silently rather than coerced (a
+        'truthy' string like 'false' would otherwise enable the
+        flag — exactly backwards)."""
+        from core.json import save_json
+        save_json(
+            tmp_path / "pipeline-config-overrides.json",
+            {"allow_unreachable": "true"},  # string, not bool
+        )
+        orch = self._orch(str(tmp_path))
+        orch._apply_pipeline_config_overrides()
+        assert orch.config.allow_unreachable is False, (
+            "string value must NOT be coerced to bool"
+        )
+
+    def test_unknown_keys_are_ignored(self, tmp_path):
+        """Forward-compat: unknown keys in the overrides file
+        don't crash — future launchers can add new flags without
+        breaking older orchestrators."""
+        from core.json import save_json
+        save_json(
+            tmp_path / "pipeline-config-overrides.json",
+            {
+                "allow_unreachable": True,
+                "future_flag_we_dont_know_about": "some-value",
+            },
+        )
+        orch = self._orch(str(tmp_path))
+        orch._apply_pipeline_config_overrides()  # must not raise
+        assert orch.config.allow_unreachable is True
+
+    def test_overrides_applied_before_parent_checklist_reuse(self, tmp_path):
+        """The override is applied at the TOP of _run_stage_0 —
+        BEFORE the parent-checklist reuse path. If the order were
+        reversed, the reuse path could read stale config when
+        deciding how to interpret the checklist."""
+        from unittest.mock import patch
+        from core.json import save_json
+
+        save_json(
+            tmp_path / "pipeline-config-overrides.json",
+            {"allow_unreachable": True},
+        )
+        orch = self._orch(str(tmp_path))
+
+        captured = {}
+
+        def cap_overrides(self_):
+            # Capture the order: this should run before reuse.
+            captured["overrides_applied"] = True
+            captured["allow_unreachable_at_apply"] = self_.config.allow_unreachable
+            # Actually do the apply so downstream sees it.
+            self_.__class__._apply_pipeline_config_overrides.__wrapped__(self_) if hasattr(
+                self_.__class__._apply_pipeline_config_overrides, "__wrapped__"
+            ) else None
+            # Manually re-do (no wrapped attr; apply directly)
+            from core.json import load_json
+            data = load_json(str(tmp_path / "pipeline-config-overrides.json"))
+            self_.config.allow_unreachable = bool(data.get("allow_unreachable"))
+
+        def cap_reuse(self_):
+            captured["reuse_called"] = True
+            captured["allow_unreachable_at_reuse"] = self_.config.allow_unreachable
+            return None
+
+        with patch.object(
+            orch.__class__, "_apply_pipeline_config_overrides",
+            cap_overrides,
+        ), patch.object(
+            orch.__class__, "_try_reuse_parent_checklist",
+            cap_reuse,
+        ), patch("core.inventory.build_inventory", return_value={"files": []}):
+            try:
+                orch._run_stage_0()
+            except Exception:
+                pass
+
+        assert captured.get("overrides_applied") is True
+        assert captured.get("reuse_called") is True
+        # By the time reuse is consulted, the override is set.
+        assert captured.get("allow_unreachable_at_reuse") is True, (
+            "override must be applied BEFORE reuse so downstream "
+            "sees the updated config"
+        )

--- a/packages/exploitability_validation/tests/test_reachability_demotion.py
+++ b/packages/exploitability_validation/tests/test_reachability_demotion.py
@@ -359,6 +359,31 @@ def test_does_not_demote_django_receiver_naked(tmp_path):
     assert attack_paths[0]["proximity"] == 7
 
 
+def test_allow_unreachable_skips_demotion_entirely(tmp_path):
+    """C2: --allow-unreachable → demote_unreachable_paths is a
+    no-op. NOT_CALLED paths flow through unfiltered so the report
+    ranking reflects the LLM verdict, not the static gate."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "vuln.py").write_text(
+        "def dead(query):\n"
+        "    cursor.execute(query)\n"
+    )
+    findings = [{"id": "f1", "file_path": "src/vuln.py", "start_line": 2}]
+    paths = [{
+        "id": "p1", "finding_id": "f1",
+        "proximity": 8, "blockers": [],
+    }]
+    demoted = demote_unreachable_paths(
+        paths, findings, tmp_path,
+        allow_unreachable=True,
+    )
+    assert demoted == 0
+    assert paths[0]["proximity"] == 8, (
+        "--allow-unreachable must leave dead-code paths untouched"
+    )
+    assert paths[0]["blockers"] == []
+
+
 def test_does_not_demote_go_handler_registered_via_call(tmp_path):
     """S2: Go handler passed to http.HandleFunc must not be
     demoted — the registration call makes it reachable."""

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -322,6 +322,7 @@ def orchestrate(
     deep_validate: bool = False,
     deep_validate_disabled: bool = False,
     deep_validate_budget: float = 0.60,
+    allow_unreachable: bool = False,
 ) -> Optional[Dict[str, Any]]:
     """Orchestrate vulnerability analysis via external LLM or Claude Code.
 
@@ -684,7 +685,8 @@ def orchestrate(
             return prefilter_for_finding(client, item)
 
     analysis_results = dispatch_task(
-        AnalysisTask(profile=profile), findings, dispatch_fn, role_resolution,
+        AnalysisTask(profile=profile, allow_unreachable=allow_unreachable),
+        findings, dispatch_fn, role_resolution,
         results_by_id, cost_tracker, max_parallel,
         prefilter_fn=prefilter_fn,
     )
@@ -713,7 +715,8 @@ def orchestrate(
             # primary path even though the same Claude model was
             # behind it.
             analysis_results = dispatch_task(
-                AnalysisTask(profile=profile), findings, dispatch_fn, role_resolution,
+                AnalysisTask(profile=profile, allow_unreachable=allow_unreachable),
+        findings, dispatch_fn, role_resolution,
                 results_by_id, cost_tracker, max_parallel,
             )
 

--- a/packages/llm_analysis/prompts/analysis.py
+++ b/packages/llm_analysis/prompts/analysis.py
@@ -95,6 +95,26 @@ Be rigorous. False positives waste significant downstream effort (exploit genera
 patch creation, review). But do not dismiss real vulnerabilities — investigate first."""
 
 
+# Appended to the system prompt when the operator passes
+# --allow-unreachable. Switches the Stage C REACHABILITY ENGAGEMENT
+# guidance from "you must engage with reachability before marking
+# exploitable" to "reachability is informational only; evaluate the
+# inherent vulnerability shape". The addendum approach avoids
+# restructuring the multi-paragraph base prompt — the default
+# behaviour (which has been A/B validated to shift verdicts
+# correctly) stays unchanged for normal /agentic runs.
+_ALLOW_UNREACHABLE_ADDENDUM = """
+
+**ADDENDUM — IN-ISOLATION MODE (--allow-unreachable):**
+
+This analysis is running with reachability gating disabled. The operator has chosen to evaluate code in isolation (CTF challenge, vendor reference snippet, exploit-research target, or intentional dead-code review). The REACHABILITY ENGAGEMENT guidance in Stage C above is **suspended** for this run.
+
+- Reachability data shown in the metadata block (caller counts, caller names, REACHABLE-via verdicts) is INFORMATIONAL ONLY.
+- Do NOT defer based on "no callers" or "NOT_CALLED" — the operator wants the inherent vulnerability shape evaluated under plausible attacker-controllable inputs.
+- is_exploitable should reflect whether the code pattern is exploitable in isolation, NOT whether it is reachable from a project entry point.
+- The deferral rulings (unreachable, dead_code) should only be used if the FUNCTION BODY ITSELF (not its containing scope) is provably unreachable under all inputs."""
+
+
 def build_analysis_schema(has_dataflow: bool = False) -> Dict[str, str]:
     """Build the analysis schema, optionally including dataflow fields."""
     schema = dict(ANALYSIS_SCHEMA)
@@ -294,6 +314,7 @@ def build_analysis_prompt_bundle(
     file_includes: Iterable[str] = (),
     function_calls_made: Iterable[str] = (),
     ast_view: Optional[Dict[str, Any]] = None,
+    allow_unreachable: bool = False,
 ) -> PromptBundle:
     """Build the analysis prompt as a PromptBundle (system + user, role-separated).
 
@@ -302,6 +323,12 @@ def build_analysis_prompt_bundle(
     envelope tags inside the user message. Identifiers (rule_id, file_path,
     line range, dataflow labels) are passed through named slots. Static
     instructions stay in the system message.
+
+    ``allow_unreachable=True`` appends an addendum that suspends the
+    Stage C REACHABILITY ENGAGEMENT guidance — for in-isolation
+    review where the operator wants the inherent vulnerability shape
+    evaluated regardless of static reachability. Default behaviour
+    (engagement required) is unchanged.
 
     Caller routes ``bundle.messages`` to ``LLMClient.generate_structured``
     by role (system message → ``system_prompt`` parameter; user message →
@@ -314,6 +341,8 @@ def build_analysis_prompt_bundle(
         + "\n\n"
         + ANALYSIS_TASK_INSTRUCTIONS
     )
+    if allow_unreachable:
+        system += _ALLOW_UNREACHABLE_ADDENDUM
 
     # Append CWE-specialised review strategies when context allows.
     # Each strategy contributes its key questions, prompt addendum,
@@ -583,8 +612,16 @@ def build_analysis_prompt_bundle_from_finding(
     *,
     profile: Optional[ModelDefenseProfile] = None,
     extra_blocks: tuple[UntrustedBlock, ...] = (),
+    allow_unreachable: bool = False,
 ) -> PromptBundle:
-    """Bundle-shape equivalent of ``build_analysis_prompt_from_finding``."""
+    """Bundle-shape equivalent of ``build_analysis_prompt_from_finding``.
+
+    ``allow_unreachable`` threads through to
+    :func:`build_analysis_prompt_bundle` and switches the system
+    prompt's reachability-engagement text. See that function for
+    semantics. Task-level setting (the operator's --allow-unreachable
+    flag) — not a per-finding decision.
+    """
     dataflow = finding.get("dataflow", {})
     metadata = finding.get("metadata") or {}
     return build_analysis_prompt_bundle(
@@ -619,6 +656,7 @@ def build_analysis_prompt_bundle_from_finding(
         # when the function can't be located in the inventory or
         # the parser doesn't support the language.
         ast_view=finding.get("ast_view"),
+        allow_unreachable=allow_unreachable,
     )
 
 

--- a/packages/llm_analysis/tasks.py
+++ b/packages/llm_analysis/tasks.py
@@ -64,8 +64,19 @@ class AnalysisTask(DispatchTask):
     name = "analysis"
     model_role = "analysis"
 
-    def __init__(self, profile: ModelDefenseProfile = CONSERVATIVE):
+    def __init__(
+        self,
+        profile: ModelDefenseProfile = CONSERVATIVE,
+        *,
+        allow_unreachable: bool = False,
+    ):
         self.profile = profile
+        # Operator's --allow-unreachable; threaded into the prompt
+        # builder so the system message switches from "engagement
+        # required" to "informational only" Stage C text. The
+        # substrate-side enricher skip is independent — that runs
+        # in the reachability pre-pass before AnalysisTask exists.
+        self.allow_unreachable = bool(allow_unreachable)
         self._tls = threading.local()
 
     def get_models(self, role_resolution):
@@ -87,6 +98,7 @@ class AnalysisTask(DispatchTask):
         si_blocks = evidence_blocks_for_finding(finding)
         bundle = build_analysis_prompt_bundle_from_finding(
             finding, profile=self.profile, extra_blocks=si_blocks,
+            allow_unreachable=self.allow_unreachable,
         )
         self._tls.nonce = bundle.nonce
         return _user_message_from_bundle(bundle)

--- a/packages/llm_analysis/tests/test_reachability_in_analysis_prompt.py
+++ b/packages/llm_analysis/tests/test_reachability_in_analysis_prompt.py
@@ -237,3 +237,76 @@ class TestCombinedRendering:
         assert "Reachability:" in out
         assert "Verdict: NOT_CALLED" in out
         assert "0 direct" in out
+
+
+# ---------------------------------------------------------------------------
+# C2: --allow-unreachable conditional system-prompt addendum
+# ---------------------------------------------------------------------------
+
+
+class TestAllowUnreachableAddendum:
+    """The system prompt grows an in-isolation-mode addendum when
+    the operator passes --allow-unreachable. The addendum overrides
+    the Stage C REACHABILITY ENGAGEMENT guidance — for CTF / vendor
+    snippet / exploit-research / intentional dead-code review.
+    Default behaviour (engagement required) unchanged."""
+
+    def _bundle(self, **kw):
+        from packages.llm_analysis.prompts.analysis import (
+            build_analysis_prompt_bundle,
+        )
+        return build_analysis_prompt_bundle(
+            rule_id="r", level="warning",
+            file_path="src/v.py", start_line=1, end_line=1,
+            message="m", **kw,
+        )
+
+    def _system(self, bundle):
+        return next(m.content for m in bundle.messages if m.role == "system")
+
+    def test_default_omits_addendum(self):
+        bundle = self._bundle()
+        system = self._system(bundle)
+        assert "IN-ISOLATION MODE" not in system
+        assert "suspended" not in system.lower()
+
+    def test_allow_unreachable_appends_addendum(self):
+        bundle = self._bundle(allow_unreachable=True)
+        system = self._system(bundle)
+        assert "IN-ISOLATION MODE" in system
+        assert "REACHABILITY ENGAGEMENT" in system
+        assert "suspended" in system.lower()
+
+    def test_addendum_appears_after_base_instructions(self):
+        # The addendum is meant to OVERRIDE the C1 Stage C
+        # engagement guidance — must appear AFTER it in the prompt
+        # so the LLM's last-instruction-wins behaviour favours the
+        # addendum. Use the unique Stage C lead-in phrase as the
+        # anchor (the addendum doesn't use this exact wording).
+        bundle = self._bundle(allow_unreachable=True)
+        system = self._system(bundle)
+        stage_c_pos = system.find('If the metadata block contains a "Reachability:"')
+        addendum_pos = system.find("IN-ISOLATION MODE")
+        assert stage_c_pos != -1, "Stage C engagement anchor missing"
+        assert addendum_pos != -1, "Addendum header missing"
+        assert addendum_pos > stage_c_pos, (
+            f"Addendum (pos {addendum_pos}) must follow Stage C "
+            f"engagement text (pos {stage_c_pos}) so it overrides"
+        )
+
+    def test_addendum_propagates_from_finding_builder(self):
+        # build_analysis_prompt_bundle_from_finding forwards the
+        # flag to the underlying builder.
+        from packages.llm_analysis.prompts.analysis import (
+            build_analysis_prompt_bundle_from_finding,
+        )
+        bundle = build_analysis_prompt_bundle_from_finding(
+            {
+                "rule_id": "r", "level": "warning",
+                "file_path": "src/v.py", "start_line": 1, "end_line": 1,
+                "message": "m", "metadata": {"name": "fn"},
+            },
+            allow_unreachable=True,
+        )
+        system = self._system(bundle)
+        assert "IN-ISOLATION MODE" in system

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -724,6 +724,26 @@ Examples:
     parser.add_argument("--codeql-cli", help="Path to CodeQL CLI (auto-detected if not specified)")
     parser.add_argument("--no-visualizations", action="store_true", help="Disable dataflow visualizations for CodeQL findings")
 
+    # Reachability gating control
+    parser.add_argument(
+        "--allow-unreachable",
+        action="store_true",
+        help=(
+            "Admit findings on functions the reachability substrate "
+            "marks NOT_CALLED. Default behaviour filters / demotes "
+            "these and the analysis prompt asks the LLM to defer. "
+            "Use when evaluating code in isolation: CTF challenges, "
+            "vendor reference snippets, exploit-research targets, "
+            "deliberate dead-code review. Does NOT change handling "
+            "of UNCERTAIN cases — those always flow through to "
+            "avoid false confidence in non-reachability. Affects 4 "
+            "wiring sites: reachability_enrichment (no priority=low "
+            "demotion), CodeQL prefilter (no short-circuit), attack-"
+            "path demoter (no demote), analysis prompt (engagement "
+            "text → informational only)."
+        ),
+    )
+
     # Mitigation analysis options (NEW)
     parser.add_argument("--binary", help="Target binary for mitigation analysis (enables pre-exploit checks)")
     parser.add_argument("--check-mitigations", action="store_true",
@@ -1172,6 +1192,7 @@ Examples:
         reachability_prepass_result = run_reachability_prepass(
             target=original_repo_path,
             agentic_out_dir=out_dir,
+            allow_unreachable=getattr(args, "allow_unreachable", False),
         )
         if reachability_prepass_result.ran:
             logger.info(
@@ -1758,6 +1779,7 @@ Examples:
                 deep_validate=getattr(args, "deep_validate", False),
                 deep_validate_disabled=getattr(args, "no_deep_validate", False),
                 deep_validate_budget=getattr(args, "deep_validate_budget", 0.60),
+                allow_unreachable=getattr(args, "allow_unreachable", False),
             )
         else:
             print("\n  No analysis report from Phase 3 — skipping orchestration")
@@ -1786,6 +1808,7 @@ Examples:
             agentic_out_dir=out_dir,
             analysis_report=validate_input_report,
             block_cc_dispatch=block_cc_dispatch,
+            allow_unreachable=getattr(args, "allow_unreachable", False),
         )
         if postpass_result.ran:
             logger.info(f"Post-pass validated {postpass_result.selected_count} findings "

--- a/raptor_codeql.py
+++ b/raptor_codeql.py
@@ -156,7 +156,8 @@ def run_autonomous_workflow(args):
         llm_client=llm_client,
         exploit_validator=exploit_validator,
         multi_turn_analyzer=multi_turn,
-        enable_visualization=not args.no_visualizations
+        enable_visualization=not args.no_visualizations,
+        allow_unreachable=getattr(args, "allow_unreachable", False),
     )
 
     # Analyze each SARIF file
@@ -298,6 +299,18 @@ Examples:
     parser.add_argument("--min-files", type=int, default=3, help="Min files to detect language")
     parser.add_argument("--codeql-cli", help="Path to CodeQL CLI")
     parser.add_argument("--scan-only", action="store_true", help="Scan only (skip autonomous analysis)")
+    parser.add_argument(
+        "--allow-unreachable",
+        action="store_true",
+        help=(
+            "Disable the reachability prefilter's NOT_CALLED short-"
+            "circuit. Full LLM analysis runs on dead-code findings "
+            "instead of being skipped. Use for in-isolation review "
+            "(CTF / vendor snippet / exploit research / intentional "
+            "dead-code audit). UNCERTAIN cases always flow through "
+            "regardless of this flag."
+        ),
+    )
     # ``--max-findings`` default 20 is intentionally HIGHER than
     # ``raptor_agentic.py``'s default 10: codeql-only mode does one
     # pass per finding (filter + summarise), while agentic does the


### PR DESCRIPTION
C1 surfaces reachability evidence and the system prompt asks the LLM to defer on NOT_CALLED findings. Correct for project-mode analysis, wrong for the in-isolation use case (CTF challenges, vendor reference snippets, exploit-research targets, intentional dead-code review) where the operator wants the inherent vulnerability shape evaluated under plausible attacker-controllable inputs. C2 adds a single boolean opt-in that flips four wiring sites together so the substrate gate and the prompt addendum stay in sync.

  * argparse: --allow-unreachable on raptor_agentic and raptor_codeql.
  * core.orchestration.reachability_enrichment.mark_unreachable_low_priority: new allow_unreachable kwarg. When True, NOT_CALLED functions do NOT get priority=low + reachability:not_called annotation — so the prompt's "Verdict: NOT_CALLED" line does not render. framework_callable / registered_via_call annotations still apply (affirmative reachability evidence, not deferral).
  * packages.codeql.autonomous_analyzer._check_reachability: returns None ("no opinion") instead of "not_called" when the flag is set, letting the caller proceed with full LLM analysis.
  * packages.exploitability_validation.reachability.demote_unreachable_paths: no-op when the flag is set.
  * packages.llm_analysis.prompts.analysis: new _ALLOW_UNREACHABLE_ADDENDUM appended after the base instructions when allow_unreachable=True. Suspends the Stage C REACHABILITY ENGAGEMENT guidance; instructs the LLM to treat reachability data as informational only and evaluate inherent vulnerability shape.
  * Threaded via packages.llm_analysis.orchestrator.orchestrate → AnalysisTask.__init__ → build_analysis_prompt_bundle_from_finding.

UNCERTAIN cases always flow through unchanged regardless of the flag — per REACHABILITY.md, "false confidence in non-reachability is the worst outcome".

Tests: 11 new (per-site wiring + addendum text + ordering). 2645 reachability + llm_analysis tests pass, ruff clean.

E2E A/B on Gemini 2.5 Pro with identical NOT_CALLED finding:
  * Default:               is_exploitable=False ruling=unreachable
  * --allow-unreachable:   is_exploitable=True  ruling=validated

Same finding, same code, flag flips verdict in the designed direction.