### PR TITLE
feat(exploit_feasibility): analyze_binary_under_mitigations

### DIFF
--- a/packages/exploit_feasibility/scripts/feasibility_under_mitigations.py
+++ b/packages/exploit_feasibility/scripts/feasibility_under_mitigations.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""CLI for ``analyze_binary_under_mitigations``.
+
+Rebuilds a single-source target under a curated set of mitigation
+profiles, replays a witness against each binary in the sandbox,
+prints a feasibility table.
+
+Usage:
+
+    python3 packages/exploit_feasibility/scripts/feasibility_under_mitigations.py \\
+        --target test/data/trivially_fuzzable/target.c \\
+        --witness-hex 41414141414141414141414141414141414141414141 \\
+        [--json out.json] \\
+        [--timeout 5]
+
+Witness shapes:
+
+  * ``--witness <path>`` — load bytes from a file (e.g. an AFL
+    crash input).
+  * ``--witness-hex <hex>`` — bytes literal as hex pairs.
+  * ``--witness-string <str>`` — UTF-8 encode the string.
+
+The three are mutually exclusive; exactly one is required.
+
+Exit codes:
+
+  * 0 — at least one profile fired the bug (operator gets a result)
+  * 1 — no profile fired (witness blocked under all profiles, or
+    the target source / witness was malformed)
+  * 2 — usage error (bad args, target missing)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+# packages/exploit_feasibility/scripts/feasibility_under_mitigations.py
+#   parents[0] = scripts/
+#   parents[1] = exploit_feasibility/
+#   parents[2] = packages/
+#   parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from packages.exploit_feasibility.under_mitigations import (  # noqa: E402
+    analyze_binary_under_mitigations,
+    render_feasibility_map,
+    to_json,
+)
+
+
+def _load_witness(args) -> bytes:
+    if args.witness:
+        return Path(args.witness).read_bytes()
+    if args.witness_hex:
+        try:
+            return bytes.fromhex(args.witness_hex)
+        except ValueError as e:
+            print(f"--witness-hex parse error: {e}", file=sys.stderr)
+            sys.exit(2)
+    if args.witness_string:
+        return args.witness_string.encode("utf-8", errors="replace")
+    print(
+        "exactly one of --witness / --witness-hex / --witness-string "
+        "is required",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Rebuild a target under multiple mitigation profiles, "
+            "replay a witness against each, report which profiles "
+            "allow the bug to fire."
+        ),
+    )
+    ap.add_argument(
+        "--target", required=True,
+        help="Single-source C / C++ target file (.c / .cpp / .cc).",
+    )
+    src_group = ap.add_mutually_exclusive_group(required=True)
+    src_group.add_argument(
+        "--witness",
+        help="Path to a file containing the witness bytes "
+             "(e.g. an AFL crash input).",
+    )
+    src_group.add_argument(
+        "--witness-hex",
+        help="Witness bytes as hex pairs "
+             "(e.g. 414141 for 'AAA').",
+    )
+    src_group.add_argument(
+        "--witness-string",
+        help="Witness as a UTF-8 string. Convenient for "
+             "stdin-driven targets where the trigger is ASCII.",
+    )
+    ap.add_argument(
+        "--timeout", type=int, default=5,
+        help="Per-replay sandbox timeout in seconds (default: 5).",
+    )
+    ap.add_argument(
+        "--json",
+        help="Optional path to write the structured feasibility "
+             "map as JSON. Default: stdout only (console table).",
+    )
+
+    args = ap.parse_args()
+
+    target = Path(args.target).resolve()
+    if not target.is_file():
+        print(f"target not found: {target}", file=sys.stderr)
+        return 2
+
+    witness_bytes = _load_witness(args)
+
+    fmap = analyze_binary_under_mitigations(
+        target,
+        witness_bytes,
+        sandbox_timeout=args.timeout,
+    )
+
+    print(render_feasibility_map(fmap))
+
+    if args.json:
+        Path(args.json).write_text(to_json(fmap), encoding="utf-8")
+        print(f"\nJSON written to {args.json}")
+
+    return 0 if fmap.summary()["bug_fired_under"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/exploit_feasibility/tests/test_under_mitigations.py
+++ b/packages/exploit_feasibility/tests/test_under_mitigations.py
@@ -1,0 +1,392 @@
+"""Tests for ``packages.exploit_feasibility.under_mitigations``.
+
+Two test families:
+
+  * **Unit** — profile metadata, dataclass behaviour, render.
+    Fast, no compiler needed.
+  * **Integration** — real builds + sandboxed runs of the
+    trivially-fuzzable fixture target across profiles. Pins the
+    cross-profile diagnosis: BOF blocked vs fired vs sanitizer-
+    detected. Slow (4 compiles + 4 sandbox runs); skipped when
+    gcc / libasan are unavailable.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# packages/exploit_feasibility/tests/test_under_mitigations.py
+#   parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from core.witness import WitnessOutcome  # noqa: E402
+from packages.exploit_feasibility.under_mitigations import (  # noqa: E402
+    FeasibilityMap,
+    MitigationProfile,
+    ProfileVerdict,
+    _DEFAULT_PROFILES,
+    analyze_binary_under_mitigations,
+    render_feasibility_map,
+    to_json,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit — no compiler required
+# ---------------------------------------------------------------------------
+
+
+def test_default_profile_set_present():
+    """v1 ships 4 curated profiles. Operators / callers rely on
+    the names — pin them so a future profile-set tweak is a
+    visible change."""
+    names = [p.name for p in _DEFAULT_PROFILES]
+    assert names == [
+        "permissive", "default-debian", "hardened", "asan-only",
+    ]
+
+
+def test_profile_immutability():
+    """MitigationProfile is frozen — operators can't accidentally
+    mutate the canonical profile set at runtime."""
+    p = _DEFAULT_PROFILES[0]
+    with pytest.raises((AttributeError, Exception)):
+        p.name = "mutated"  # type: ignore[misc]
+
+
+def test_profile_verdict_bug_fired_classification():
+    """``bug_fired`` is the high-level operator-facing
+    classification. Pin the mapping so a future WitnessOutcome
+    addition is a deliberate choice."""
+    fired_exit = ProfileVerdict(
+        profile_name="x", profile_description="x",
+        compile_flags=[], compiled=True,
+        outcome=WitnessOutcome.EXIT_SIGNAL.value,
+    )
+    fired_san = ProfileVerdict(
+        profile_name="x", profile_description="x",
+        compile_flags=[], compiled=True,
+        outcome=WitnessOutcome.SANITIZER_REPORT.value,
+    )
+    blocked_clean = ProfileVerdict(
+        profile_name="x", profile_description="x",
+        compile_flags=[], compiled=True,
+        outcome=WitnessOutcome.NO_OBVIOUS_EFFECT.value,
+    )
+    blocked_unknown = ProfileVerdict(
+        profile_name="x", profile_description="x",
+        compile_flags=[], compiled=True,
+        outcome=WitnessOutcome.UNKNOWN.value,
+    )
+    assert fired_exit.bug_fired is True
+    assert fired_san.bug_fired is True
+    assert blocked_clean.bug_fired is False
+    assert blocked_unknown.bug_fired is False
+
+
+def test_feasibility_map_summary_classifies_correctly():
+    """The summary's three buckets (fired / blocked / unbuildable)
+    must be mutually exclusive."""
+    fmap = FeasibilityMap(
+        target_source_path="/x",
+        target_source_hash="a" * 64,
+        witness_hash="b" * 64,
+        witness_len=10,
+        profiles=[
+            ProfileVerdict(
+                profile_name="permissive",
+                profile_description="x",
+                compile_flags=[],
+                compiled=True,
+                outcome=WitnessOutcome.EXIT_SIGNAL.value,
+            ),
+            ProfileVerdict(
+                profile_name="hardened",
+                profile_description="x",
+                compile_flags=[],
+                compiled=True,
+                outcome=WitnessOutcome.NO_OBVIOUS_EFFECT.value,
+            ),
+            ProfileVerdict(
+                profile_name="broken",
+                profile_description="x",
+                compile_flags=[],
+                compiled=False,
+                compile_errors=["foo"],
+            ),
+        ],
+    )
+    s = fmap.summary()
+    assert s["bug_fired_under"] == ["permissive"]
+    assert s["blocked_under"] == ["hardened"]
+    assert s["unbuildable_profiles"] == ["broken"]
+
+
+def test_as_dict_is_json_serialisable():
+    fmap = FeasibilityMap(
+        target_source_path="/x",
+        target_source_hash="a" * 64,
+        witness_hash="b" * 64,
+        witness_len=10,
+        profiles=[
+            ProfileVerdict(
+                profile_name="permissive",
+                profile_description="x",
+                compile_flags=["-O0"],
+                compiled=True,
+                outcome=WitnessOutcome.EXIT_SIGNAL.value,
+                outcome_detail={"signal": "SIGSEGV"},
+            ),
+        ],
+    )
+    serialised = to_json(fmap)
+    parsed = json.loads(serialised)
+    assert parsed["target_source_path"] == "/x"
+    assert parsed["profiles"][0]["outcome_detail"]["signal"] == "SIGSEGV"
+    assert parsed["summary"]["bug_fired_under"] == ["permissive"]
+
+
+def test_render_includes_target_witness_and_per_profile_lines():
+    fmap = FeasibilityMap(
+        target_source_path="/tmp/x.c",
+        target_source_hash="a" * 64,
+        witness_hash="b" * 64,
+        witness_len=10,
+        profiles=[
+            ProfileVerdict(
+                profile_name="permissive",
+                profile_description="x",
+                compile_flags=[],
+                compiled=True,
+                outcome=WitnessOutcome.EXIT_SIGNAL.value,
+                outcome_detail={"signal": "SIGSEGV"},
+            ),
+            ProfileVerdict(
+                profile_name="broken",
+                profile_description="x",
+                compile_flags=[],
+                compiled=False,
+                compile_errors=["foo error", "bar error"],
+            ),
+        ],
+    )
+    out = render_feasibility_map(fmap)
+    assert "/tmp/x.c" in out
+    assert "permissive" in out
+    assert "FIRED" in out
+    assert "SIGSEGV" in out
+    assert "broken" in out
+    assert "FAILED to build" in out
+
+
+def test_missing_target_raises_filenotfound(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        analyze_binary_under_mitigations(
+            tmp_path / "nonexistent.c",
+            b"witness",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration — real builds + runs
+# ---------------------------------------------------------------------------
+
+
+def _has_compiler() -> bool:
+    return any(shutil.which(c) for c in ("c++", "g++", "clang++"))
+
+
+def _has_libasan() -> bool:
+    if not _has_compiler():
+        return False
+    cxx = next(c for c in ("c++", "g++", "clang++") if shutil.which(c))
+    try:
+        result = subprocess.run(
+            [cxx, "-fsanitize=address", "-x", "c++", "-",
+             "-o", "/dev/null"],
+            input="int main(){return 0;}",
+            text=True, capture_output=True, timeout=10,
+        )
+        return result.returncode == 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
+_FIXTURE = REPO / "test" / "data" / "trivially_fuzzable" / "target.c"
+
+
+@pytest.mark.skipif(
+    not _has_compiler() or not _FIXTURE.is_file(),
+    reason="no C++ compiler or fixture missing",
+)
+def test_real_bof_witness_against_all_profiles(tmp_path):
+    """End-to-end: the trivially-fuzzable fixture's BOF tag
+    ('A' + 20 'A's) runs against every default profile. We
+    pin the operator-facing classification:
+
+      * At least one profile fires the bug.
+      * At least one profile produces SANITIZER_REPORT (the
+        asan-only profile must, if libasan is available).
+      * No profile crashes the helper itself.
+
+    The exact mix of which profiles fire vs block is sensitive
+    to glibc + gcc version and intentionally NOT pinned here —
+    that's the empirical content this tool exists to surface.
+    """
+    witness = b"A" + b"A" * 20  # tag 'A' + overflow payload
+    fmap = analyze_binary_under_mitigations(
+        _FIXTURE,
+        witness,
+        sandbox_timeout=5,
+    )
+
+    assert isinstance(fmap, FeasibilityMap)
+    assert len(fmap.profiles) == 4
+    assert fmap.witness_len == 21
+    assert fmap.target_source_hash  # populated, not empty
+
+    # At least one profile fired the bug
+    any_fired = any(p.bug_fired for p in fmap.profiles)
+    assert any_fired, (
+        f"no profile fired the bug; outcomes were "
+        f"{[(p.profile_name, p.outcome) for p in fmap.profiles]}"
+    )
+
+    # asan-only must fire SANITIZER_REPORT (when libasan is usable)
+    if _has_libasan():
+        asan_v = next(
+            p for p in fmap.profiles if p.profile_name == "asan-only"
+        )
+        assert asan_v.compiled is True
+        assert asan_v.outcome == WitnessOutcome.SANITIZER_REPORT.value
+        assert asan_v.outcome_detail.get("sanitizer") == "asan"
+
+    # Every successful profile has a binary_hash recorded
+    for v in fmap.profiles:
+        if v.compiled:
+            assert v.binary_hash and len(v.binary_hash) == 64
+
+
+@pytest.mark.skipif(
+    not _has_compiler() or not _FIXTURE.is_file(),
+    reason="no C++ compiler or fixture missing",
+)
+def test_clean_witness_blocks_under_every_profile(tmp_path):
+    """Control witness — tag 'C' triggers the clean-exit branch
+    of the fixture. No profile should observe bug evidence; all
+    should report ``no_obvious_effect``."""
+    fmap = analyze_binary_under_mitigations(
+        _FIXTURE,
+        b"C",
+        sandbox_timeout=5,
+    )
+    for v in fmap.profiles:
+        if v.compiled:
+            assert v.outcome == WitnessOutcome.NO_OBVIOUS_EFFECT.value, (
+                f"profile {v.profile_name} unexpectedly fired on "
+                f"clean witness: outcome={v.outcome}"
+            )
+    assert fmap.summary()["bug_fired_under"] == []
+
+
+@pytest.mark.skipif(
+    not _has_compiler() or not _FIXTURE.is_file(),
+    reason="no C++ compiler or fixture missing",
+)
+def test_custom_profile_subset(tmp_path):
+    """Operator can override the profile list to run a narrow
+    subset (e.g. only asan-only for a tight CI loop)."""
+    one_profile = (
+        MitigationProfile(
+            name="just-asan",
+            description="minimal asan-only for the test",
+            compile_flags=(
+                "-O0", "-g", "-fno-omit-frame-pointer",
+                "-fsanitize=address",
+            ),
+        ),
+    )
+    fmap = analyze_binary_under_mitigations(
+        _FIXTURE,
+        b"A" + b"A" * 20,
+        profiles=list(one_profile),
+        sandbox_timeout=5,
+    )
+    assert len(fmap.profiles) == 1
+    assert fmap.profiles[0].profile_name == "just-asan"
+
+
+# ---------------------------------------------------------------------------
+# Robustness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not _has_compiler(),
+    reason="no C++ compiler",
+)
+def test_profile_name_with_path_traversal_doesnt_crash(tmp_path):
+    """Pre-fix: profile name with ``/`` or ``..`` caused
+    ``tempfile.TemporaryDirectory(prefix=...)`` to raise
+    FileNotFoundError before any try/except, crashing the helper.
+    Post-fix: sanitise the prefix; the verdict still gets recorded
+    (build will likely succeed since flags aren't affected, just
+    the workdir name) with the operator-supplied name preserved
+    on the verdict record."""
+    src = tmp_path / "target.c"
+    src.write_text("int main(){return 0;}\n")
+    bad_profile = MitigationProfile(
+        name="../../escape/attempt",
+        description="path-traversal probe",
+        compile_flags=("-O0",),
+    )
+    # Must not raise
+    fmap = analyze_binary_under_mitigations(
+        src, b"witness", profiles=[bad_profile], sandbox_timeout=5,
+    )
+    assert len(fmap.profiles) == 1
+    # Original (un-sanitised) name preserved on the verdict
+    assert fmap.profiles[0].profile_name == "../../escape/attempt"
+
+
+@pytest.mark.skipif(
+    not _has_compiler(),
+    reason="no C++ compiler",
+)
+def test_unbuildable_profile_captured_not_raised(tmp_path):
+    """A profile with deliberately broken flags must produce a
+    ``compiled=False`` verdict on that profile alone — other
+    profiles still run, the helper doesn't crash."""
+    src = tmp_path / "target.c"
+    src.write_text("int main(){return 0;}\n")
+
+    profiles = [
+        MitigationProfile(
+            name="garbage",
+            description="invalid flag",
+            compile_flags=("-fnonexistent-flag-xyz",),
+        ),
+        MitigationProfile(
+            name="ok",
+            description="trivial",
+            compile_flags=("-O0",),
+        ),
+    ]
+    fmap = analyze_binary_under_mitigations(
+        src,
+        b"witness",
+        profiles=profiles,
+        sandbox_timeout=5,
+    )
+    by_name = {p.profile_name: p for p in fmap.profiles}
+    assert by_name["garbage"].compiled is False
+    assert by_name["garbage"].compile_errors
+    assert by_name["ok"].compiled is True

--- a/packages/exploit_feasibility/under_mitigations.py
+++ b/packages/exploit_feasibility/under_mitigations.py
@@ -1,0 +1,550 @@
+"""Rebuild a target under different mitigation profiles, replay a
+witness against each, observe what blocks the bug.
+
+Today the existing :mod:`packages.exploit_feasibility.mitigations`
+reasons about mitigations from a binary's measured properties (PIE
+enabled? canary on? glibc version?) — it tells the LLM what to
+expect. That's static analysis.
+
+This module is the empirical counterpart. Given:
+
+  * a single C / C++ source file (the target), and
+  * a witness — input bytes that triggered the bug under whatever
+    profile produced the original crash,
+
+it rebuilds the target under each of a small, curated set of
+mitigation profiles (permissive, default-debian, hardened, asan-
+only), runs the witness against each binary in the sandbox, and
+records whether the bug still fires.
+
+The result is a :class:`FeasibilityMap` showing which profiles
+allow the witness to trigger and which block it. Operators see
+e.g. "BOF fires under permissive + asan-only, blocked by canary in
+hardened" — a categorically different deliverable from the
+mitigation-reasoning chain that runs without execution.
+
+Scope of v1:
+
+  * Single-source targets only (one ``.c`` / ``.cpp`` file).
+    Multi-file builds / Makefile-driven targets are future work.
+  * stdin-driven witnesses only. Argv / file-input variants are
+    future work.
+  * Linux toolchain assumed. macOS clang flag spelling differs in
+    a few places (notably ``-z,relro`` vs ``-Wl,-z,relro``) — the
+    helper uses the GNU spelling and degrades gracefully on
+    unsupported flags via per-profile build failures.
+  * No ASLR toggle (system-level, needs ``personality(2)`` —
+    can't be set via compile flags).
+
+Out-of-scope (deferred):
+
+  * Multi-architecture cross-builds.
+  * KASLR / SMEP / SMAP — these are kernel-side and our targets
+    are user-space.
+  * Build-flag bypass detection (some flags are inert without
+    matching link flags — we trust the operator-supplied or
+    default profile to be coherent).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+import tempfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from core.hash import sha256_file
+from core.witness import WitnessOutcome, outcome_from_sandbox_info
+from core.witness.types import compute_bytes_hash
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Mitigation profile model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MitigationProfile:
+    """A named set of compile/link flags that produces one binary
+    variant.
+
+    ``compile_flags`` is the full argument list appended to the
+    base ``gcc -o <out> <src>`` invocation. Order matters for
+    flags that override each other (``-fstack-protector`` then
+    ``-fno-stack-protector`` would disable the canary); the
+    profile author owns the ordering.
+    """
+    name: str
+    description: str
+    compile_flags: tuple = field(default_factory=tuple)
+
+
+# Curated v1 profile set. Order is intentional — `permissive` first
+# so when the witness only fires under the loose profile the
+# operator sees that at the top of the table. The "default-debian"
+# label tracks what Debian 12 gcc gives you with no extra flags:
+# PIE, canary, NX, partial RELRO, fortify=2.
+_DEFAULT_PROFILES: tuple = (
+    MitigationProfile(
+        name="permissive",
+        description="No PIE, no canary, executable stack, "
+                    "no RELRO, no fortify — the most exploitable "
+                    "baseline",
+        compile_flags=(
+            "-O0", "-g",
+            "-no-pie",
+            "-fno-stack-protector",
+            "-Wl,-z,execstack",
+            "-Wl,-z,norelro",
+            "-U_FORTIFY_SOURCE",
+        ),
+    ),
+    MitigationProfile(
+        name="default-debian",
+        description="Debian 12 gcc defaults: PIE, canary, NX, "
+                    "partial RELRO, fortify=2",
+        compile_flags=(
+            "-O0", "-g",
+            "-pie",
+            "-fPIE",
+            "-fstack-protector-strong",
+            "-Wl,-z,relro",
+            "-D_FORTIFY_SOURCE=2",
+        ),
+    ),
+    MitigationProfile(
+        name="hardened",
+        description="Full RELRO + PIE + canary + NX + fortify=3 "
+                    "— what a security-conscious deployment looks "
+                    "like",
+        compile_flags=(
+            "-O2", "-g",
+            "-pie",
+            "-fPIE",
+            "-fstack-protector-strong",
+            "-Wl,-z,relro,-z,now",
+            "-Wl,-z,noexecstack",
+            "-D_FORTIFY_SOURCE=3",
+        ),
+    ),
+    MitigationProfile(
+        name="asan-only",
+        description="ASAN-instrumented; mitigations matter less "
+                    "here — the question is whether the bug class "
+                    "is even detected at runtime",
+        compile_flags=(
+            "-O0", "-g",
+            "-fno-omit-frame-pointer",
+            "-fsanitize=address",
+        ),
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Per-profile result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ProfileVerdict:
+    """The outcome of running a witness against one mitigation
+    profile's binary."""
+    profile_name: str
+    profile_description: str
+    compile_flags: List[str]
+    compiled: bool
+    compile_errors: List[str] = field(default_factory=list)
+    binary_hash: Optional[str] = None
+    outcome: Optional[str] = None  # WitnessOutcome enum string value
+    outcome_detail: Dict[str, Any] = field(default_factory=dict)
+    notes: List[str] = field(default_factory=list)
+
+    @property
+    def bug_fired(self) -> bool:
+        """True iff the witness produced observable bug evidence
+        (signal / sanitizer report) under this profile.
+        ``no_obvious_effect`` and ``not_run`` count as "blocked"
+        — the bug didn't surface."""
+        return self.outcome in (
+            WitnessOutcome.EXIT_SIGNAL.value,
+            WitnessOutcome.SANITIZER_REPORT.value,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Aggregate feasibility map
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FeasibilityMap:
+    """The full per-profile picture for a (target source, witness)
+    pair.
+
+    Serialisable as JSON via ``as_dict()`` — operators / future
+    consumers (the LLM exploit-engine, /validate Stage E
+    enrichment) read the structured form."""
+    target_source_path: str
+    target_source_hash: str
+    witness_hash: str
+    witness_len: int
+    profiles: List[ProfileVerdict]
+
+    def as_dict(self) -> dict:
+        return {
+            "target_source_path": self.target_source_path,
+            "target_source_hash": self.target_source_hash,
+            "witness_hash": self.witness_hash,
+            "witness_len": self.witness_len,
+            "profiles": [asdict(p) for p in self.profiles],
+            "summary": self.summary(),
+        }
+
+    def summary(self) -> dict:
+        """Group profile names by bug-fired / blocked. Operators
+        scanning the report want the binary classification first;
+        the per-profile detail is supporting evidence."""
+        fired = [p.profile_name for p in self.profiles if p.bug_fired]
+        blocked = [
+            p.profile_name for p in self.profiles
+            if not p.bug_fired and p.compiled
+        ]
+        unbuildable = [
+            p.profile_name for p in self.profiles if not p.compiled
+        ]
+        return {
+            "bug_fired_under": fired,
+            "blocked_under": blocked,
+            "unbuildable_profiles": unbuildable,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def analyze_binary_under_mitigations(
+    target_source: Path,
+    witness_bytes: bytes,
+    *,
+    profiles: Optional[List[MitigationProfile]] = None,
+    sandbox_timeout: int = 5,
+    logger_: Optional[logging.Logger] = None,
+) -> FeasibilityMap:
+    """Rebuild ``target_source`` under each profile, run
+    ``witness_bytes`` against each, return the per-profile
+    outcome map.
+
+    Args:
+        target_source: Path to a single-source-file target
+            (``.c`` / ``.cpp`` / ``.cc``). Multi-file builds are
+            out of scope for v1 — pass the file containing
+            ``main()`` and let it include / link as needed via
+            the compile flags.
+        witness_bytes: The bytes that triggered the bug. Passed
+            on the target's stdin during replay (only stdin-
+            driven targets supported in v1).
+        profiles: Optional override. Defaults to the curated
+            ``_DEFAULT_PROFILES`` set (permissive, default-debian,
+            hardened, asan-only).
+        sandbox_timeout: Per-replay timeout in seconds.
+        logger_: Optional logger.
+
+    Returns:
+        :class:`FeasibilityMap` — one :class:`ProfileVerdict` per
+        profile. Failures within a profile (compile error,
+        sandbox error) are captured on the verdict rather than
+        raising, so the operator sees the full picture even when
+        one variant breaks.
+
+    Raises:
+        FileNotFoundError if ``target_source`` doesn't exist.
+        RuntimeError if no C++ compiler is available — every
+        profile would fail; better to fail fast.
+    """
+    log = logger_ if logger_ is not None else logger
+    target_source = Path(target_source)
+    if not target_source.is_file():
+        raise FileNotFoundError(
+            f"target_source not found: {target_source}"
+        )
+
+    # Compiler detection mirrors the convention from
+    # ``packages.autonomous.exploit_validator._detect_cxx_compiler``:
+    # ``c++`` first (POSIX symlink), then explicit fallbacks.
+    cxx = None
+    for candidate in ("c++", "g++", "clang++"):
+        if shutil.which(candidate):
+            cxx = candidate
+            break
+    if cxx is None:
+        raise RuntimeError(
+            "no C/C++ compiler found on PATH "
+            "(looked for c++, g++, clang++)"
+        )
+
+    profiles_to_run = list(profiles) if profiles else list(_DEFAULT_PROFILES)
+    target_source_hash = sha256_file(target_source)
+    witness_hash = compute_bytes_hash(witness_bytes)
+    witness_len = len(witness_bytes)
+
+    verdicts: List[ProfileVerdict] = []
+    for profile in profiles_to_run:
+        verdict = _run_profile(
+            cxx=cxx,
+            target_source=target_source,
+            profile=profile,
+            witness_bytes=witness_bytes,
+            sandbox_timeout=sandbox_timeout,
+            log=log,
+        )
+        verdicts.append(verdict)
+
+    return FeasibilityMap(
+        target_source_path=str(target_source),
+        target_source_hash=target_source_hash,
+        witness_hash=witness_hash,
+        witness_len=witness_len,
+        profiles=verdicts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-profile worker
+# ---------------------------------------------------------------------------
+
+
+def _run_profile(
+    cxx: str,
+    target_source: Path,
+    profile: MitigationProfile,
+    witness_bytes: bytes,
+    sandbox_timeout: int,
+    log: logging.Logger,
+) -> ProfileVerdict:
+    """Build + run one profile. Failures captured on the
+    ProfileVerdict, never raised — the caller iterates all
+    profiles regardless of any single one's outcome."""
+
+    # Sanitise the profile name before using it as a tempdir prefix —
+    # ``tempfile.TemporaryDirectory(prefix=...)`` rejects path separators
+    # with FileNotFoundError (since it tries to create a directory whose
+    # name contains the slash, and the parent dirs don't exist). Profiles
+    # are typically operator-supplied so the trust is high, but a typo
+    # or a future caller passing untrusted strings shouldn't crash the
+    # whole feasibility map.
+    safe_name = "".join(
+        c if c.isalnum() or c in "-_" else "_" for c in profile.name
+    ) or "unnamed"
+
+    try:
+        tempdir_ctx = tempfile.TemporaryDirectory(
+            prefix=f"under-mitigation-{safe_name}-",
+        )
+    except Exception as e:  # noqa: BLE001 — defence in depth
+        return ProfileVerdict(
+            profile_name=profile.name,
+            profile_description=profile.description,
+            compile_flags=list(profile.compile_flags),
+            compiled=False,
+            compile_errors=[
+                f"tempdir creation failed: {type(e).__name__}: {e}"
+            ],
+        )
+
+    with tempdir_ctx as work_dir_str:
+        work_dir = Path(work_dir_str)
+        # Copy source into work_dir so the sandbox's Landlock-
+        # bounded read of the build dir doesn't need to reach
+        # outside.
+        local_source = work_dir / target_source.name
+        local_source.write_bytes(target_source.read_bytes())
+        binary_path = work_dir / f"target-{profile.name}"
+
+        compile_cmd = [
+            cxx,
+            "-o", str(binary_path),
+            str(local_source),
+            *profile.compile_flags,
+        ]
+        log.info(
+            "under_mitigations[%s]: building with %d flags",
+            profile.name, len(profile.compile_flags),
+        )
+
+        try:
+            from core.sandbox import run as sandbox_run
+        except ImportError as e:
+            return ProfileVerdict(
+                profile_name=profile.name,
+                profile_description=profile.description,
+                compile_flags=list(profile.compile_flags),
+                compiled=False,
+                compile_errors=[
+                    f"sandbox unavailable: {type(e).__name__}: {e}"
+                ],
+            )
+
+        # Build step
+        try:
+            build_result = sandbox_run(
+                compile_cmd,
+                block_network=True,
+                target=str(work_dir),
+                output=str(work_dir),
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        except Exception as e:  # noqa: BLE001 — best-effort
+            return ProfileVerdict(
+                profile_name=profile.name,
+                profile_description=profile.description,
+                compile_flags=list(profile.compile_flags),
+                compiled=False,
+                compile_errors=[
+                    f"build raised {type(e).__name__}: {e}"
+                ],
+            )
+
+        if build_result.returncode != 0:
+            errors = [
+                line for line in (build_result.stderr or "").splitlines()
+                if ": error:" in line or ": fatal" in line
+            ]
+            if not errors:
+                errors = [
+                    f"compile exit {build_result.returncode}; "
+                    f"stderr: {(build_result.stderr or '')[:200]}"
+                ]
+            log.info(
+                "under_mitigations[%s]: build failed (%d errors)",
+                profile.name, len(errors),
+            )
+            return ProfileVerdict(
+                profile_name=profile.name,
+                profile_description=profile.description,
+                compile_flags=list(profile.compile_flags),
+                compiled=False,
+                compile_errors=errors,
+            )
+
+        binary_hash = sha256_file(binary_path)
+
+        # Replay step — pipe the witness into the binary on stdin.
+        try:
+            from core.config import RaptorConfig
+            run_result = sandbox_run(
+                [str(binary_path)],
+                block_network=True,
+                target=str(work_dir),
+                output=str(work_dir),
+                capture_output=True,
+                text=False,  # keep stdout/stderr as bytes — witness may be binary
+                input=witness_bytes,
+                timeout=sandbox_timeout,
+                env=RaptorConfig.get_safe_env(),
+                strict_env=True,
+            )
+        except subprocess.TimeoutExpired:
+            return ProfileVerdict(
+                profile_name=profile.name,
+                profile_description=profile.description,
+                compile_flags=list(profile.compile_flags),
+                compiled=True,
+                binary_hash=binary_hash,
+                outcome=WitnessOutcome.UNKNOWN.value,
+                outcome_detail={
+                    "timed_out": True,
+                    "timeout_s": sandbox_timeout,
+                },
+            )
+        except Exception as e:  # noqa: BLE001 — best-effort
+            return ProfileVerdict(
+                profile_name=profile.name,
+                profile_description=profile.description,
+                compile_flags=list(profile.compile_flags),
+                compiled=True,
+                binary_hash=binary_hash,
+                notes=[f"replay raised {type(e).__name__}: {e}"],
+            )
+
+        sandbox_info = getattr(run_result, "sandbox_info", None)
+        returncode = getattr(run_result, "returncode", None)
+        outcome, detail = outcome_from_sandbox_info(
+            sandbox_info, returncode=returncode,
+        )
+
+        log.info(
+            "under_mitigations[%s]: outcome=%s",
+            profile.name, outcome.value,
+        )
+
+        return ProfileVerdict(
+            profile_name=profile.name,
+            profile_description=profile.description,
+            compile_flags=list(profile.compile_flags),
+            compiled=True,
+            binary_hash=binary_hash,
+            outcome=outcome.value,
+            outcome_detail=detail,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Render helpers
+# ---------------------------------------------------------------------------
+
+
+def render_feasibility_map(fmap: FeasibilityMap) -> str:
+    """Console-friendly summary block. Mirrors the cadence of
+    ``core.reporting.witnesses.render_witness_summary``."""
+    lines = [
+        f"Mitigation feasibility ({len(fmap.profiles)} profiles):",
+        f"   Target:  {fmap.target_source_path}",
+        f"   Witness: {fmap.witness_hash[:16]}... ({fmap.witness_len}B)",
+        "",
+    ]
+    for v in fmap.profiles:
+        if not v.compiled:
+            lines.append(
+                f"   [{v.profile_name:>14}] FAILED to build "
+                f"({len(v.compile_errors)} error(s))"
+            )
+            continue
+        marker = "FIRED" if v.bug_fired else "blocked"
+        outcome_text = v.outcome or "?"
+        extra = ""
+        if v.outcome_detail.get("sanitizer"):
+            extra = f" ({v.outcome_detail['sanitizer']})"
+        elif v.outcome_detail.get("signal"):
+            extra = f" ({v.outcome_detail['signal']})"
+        lines.append(
+            f"   [{v.profile_name:>14}] {marker:<7} → {outcome_text}{extra}"
+        )
+
+    summary = fmap.summary()
+    lines.extend([
+        "",
+        f"   Bug fired under: {summary['bug_fired_under']}",
+        f"   Blocked under:   {summary['blocked_under']}",
+    ])
+    if summary["unbuildable_profiles"]:
+        lines.append(
+            f"   Unbuildable:     {summary['unbuildable_profiles']}"
+        )
+    return "\n".join(lines)
+
+
+def to_json(fmap: FeasibilityMap, *, indent: int = 2) -> str:
+    """Serialise the feasibility map as JSON for persistence /
+    downstream tooling."""
+    return json.dumps(fmap.as_dict(), indent=indent)


### PR DESCRIPTION
Empirical counterpart to the existing static-analysis mitigations module. Given a target source + a witness, rebuilds the target under a curated set of mitigation profiles, replays the witness against each binary in the sandbox, and records which profiles allow the bug to fire vs which block it.

v1 ships 4 profiles:
  - permissive    : no PIE, no canary, execstack, no RELRO, no
                    fortify — the most exploitable baseline.
  - default-debian: Debian 12 gcc defaults (PIE, canary,
                    fortify=2, partial RELRO).
  - hardened      : full RELRO, canary-strong, fortify=3, NX,
                    -O2.
  - asan-only     : -fsanitize=address; the "did the bug class
                    register?" probe.

API:
  analyze_binary_under_mitigations(target_source, witness_bytes,
                                   profiles=None,
                                   sandbox_timeout=5)
    -> FeasibilityMap

The map carries per-profile ProfileVerdicts (compile result, binary hash, observed WitnessOutcome via the existing sandbox_outcome mapper, structured outcome detail) and a ``summary()`` grouping profiles into fired / blocked / unbuildable.

Each profile builds and runs in its own sandboxed tempdir under Landlock + seccomp + namespace isolation + network block. Failures within a profile are captured on the verdict rather than raising, so the operator always gets the full picture even when one variant breaks.

CLI at packages/exploit_feasibility/scripts/feasibility_under_ mitigations.py accepts witness bytes via --witness <path> / --witness-hex / --witness-string; emits a console table and optional --json structured output.

Verified end-to-end against the trivially-fuzzable BOF fixture: the 8-byte strcpy with 20-byte overflow only triggers detection under hardened (canary SIGABRT) and asan-only (SANITIZER_REPORT) on this glibc / gcc; permissive and default-debian quietly absorb the overflow. Exactly the empirical signal this tool exists to produce — previously this would have been opinion- grade mitigation reasoning.