### PR TITLE
feat(witness, stage_e): mechanical witness discovery + empirical mitigation enrichment

### DIFF
--- a/.claude/skills/exploitability-validation/stage-e-feasibility.md
+++ b/.claude/skills/exploitability-validation/stage-e-feasibility.md
@@ -89,10 +89,30 @@ For each applicable finding:
 For each binary group discovered by the prep script, run:
 
 ```bash
-libexec/raptor-run-feasibility <binary_path> "$OUTPUT_DIR/findings.json" "$OUTPUT_DIR"
+libexec/raptor-run-feasibility <binary_path> "$OUTPUT_DIR/findings.json" "$OUTPUT_DIR" --target "$TARGET_PATH"
 ```
 
-This runs `analyze_binary` once per binary, saves exploit context, maps constraints to all findings referencing that binary, and updates findings.json with feasibility verdicts and `stage_e_summary`.
+This runs `analyze_binary` once per binary, saves exploit context,
+maps constraints to all findings referencing that binary, and updates
+findings.json with feasibility verdicts and `stage_e_summary`.
+
+**`--target` enables empirical mitigation analysis.** When a witness
+is discoverable for a finding (from this run's stores, or — when a
+`/project` is active — from any sibling run's stores), the script
+additionally rebuilds the target source under 4 mitigation profiles
+(permissive / default-debian / hardened / asan-only), replays the
+witness against each, and attaches `feasibility.empirical_mitigation_map`
+to the finding. The full per-finding `FeasibilityMap` JSON lands at
+`<output_dir>/mitigation_feasibility/<finding_id>.json`. No operator
+action required — discovery + matching are mechanical; the empirical
+step silently skips when source or witness is unavailable.
+
+Stage E's per-finding verdict (Likely / Difficult / Unlikely) should
+**lift toward Confirmed** when `empirical_mitigation_map.summary.bug_fired_under`
+includes the profile matching the target's actual deployment, and
+**soften** when it appears in `blocked_under`. The empirical evidence
+is artefact-grade — strictly more trustworthy than the static
+`analyze_binary` reasoning alone.
 
 ### [E-3] Review Results
 

--- a/core/witness/__init__.py
+++ b/core/witness/__init__.py
@@ -25,6 +25,15 @@ to avoid the layering inversion of ``core/`` importing
 ``packages/``.
 """
 
+from core.witness.discovery import (
+    discover_witness_stores,
+    iter_visible_witnesses,
+)
+from core.witness.matching import (
+    WitnessMatch,
+    best_match_for_finding,
+    score_witness_for_finding,
+)
 from core.witness.sandbox_outcome import outcome_from_sandbox_info
 from core.witness.store import WitnessStore, WitnessStoreError
 from core.witness.types import (
@@ -42,4 +51,9 @@ __all__ = [
     "WitnessStoreError",
     "compute_bytes_hash",
     "outcome_from_sandbox_info",
+    "discover_witness_stores",
+    "iter_visible_witnesses",
+    "WitnessMatch",
+    "best_match_for_finding",
+    "score_witness_for_finding",
 ]

--- a/core/witness/discovery.py
+++ b/core/witness/discovery.py
@@ -1,0 +1,152 @@
+"""Locate WitnessStore-shaped directories visible to a run.
+
+A single RAPTOR run typically has 1-2 stores under its own output
+dir (``<out>/witnesses/`` for fuzz crashes, ``<out>/analysis/
+witnesses/`` for crash-agent LLM exploits, ``<out>/autonomous/
+witnesses/`` for ``/agentic``). When the operator has a
+``/project`` active, prior runs against the same target add more:
+a ``/fuzz`` run last week may have produced witnesses that today's
+``/validate`` should consume to upgrade its mitigation verdicts.
+
+This module is the discovery seam between "find every store
+visible to me" and the per-consumer matching logic (in e.g.
+``core/witness/matching.py``).
+
+Two scopes:
+
+  * **Run-local** — always: the current run's own stores.
+  * **Project-wide** — when a project root is known: all sibling
+    runs' stores under that root.
+
+Stores are returned as paths to the store *root* (the directory
+containing ``manifests/`` and ``blobs/``). Consumers wrap each in
+``WitnessStore(root)`` and iterate.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# Sub-paths within a run's output dir that conventionally hold
+# witness stores. Order is informational only — discovery returns
+# every existing store; consumers do their own ranking.
+_RUN_LOCAL_SUBPATHS = (
+    "witnesses",
+    "analysis/witnesses",       # crash-agent under raptor_fuzzing
+    "autonomous/witnesses",     # /agentic's AutonomousSecurityAgentV2
+)
+
+
+def _is_store_dir(path: Path) -> bool:
+    """A directory is a WitnessStore root when it contains a
+    ``manifests/`` subdir (the blobs/ subdir is created on first
+    write but absent on a never-written store)."""
+    return path.is_dir() and (path / "manifests").is_dir()
+
+
+def discover_witness_stores(
+    output_dir: Optional[Path],
+    *,
+    project_root: Optional[Path] = None,
+) -> List[Path]:
+    """Return all WitnessStore root directories visible to this run.
+
+    Args:
+        output_dir: The current run's output dir. ``None`` is
+            tolerated (returns empty list when project_root is
+            also None).
+        project_root: When set, also scan every sibling run under
+            this directory. Typically the resolved
+            ``<active_project>.output_dir`` from
+            ``_resolve_active_project()``. ``None`` for runs
+            without a project.
+
+    Returns:
+        Deduplicated list of store roots. Run-local stores appear
+        first (operators tend to expect the current run's data
+        listed first); project-wide siblings follow. Each path
+        is verified to contain a ``manifests/`` subdir.
+
+    Never raises. Missing dirs, permission errors, and unreadable
+    project roots all log at debug and produce a shorter list.
+    """
+    seen: set = set()
+    out: List[Path] = []
+
+    # Run-local first
+    if output_dir is not None:
+        for sub in _RUN_LOCAL_SUBPATHS:
+            candidate = Path(output_dir) / sub
+            if _is_store_dir(candidate):
+                resolved = candidate.resolve()
+                if resolved not in seen:
+                    seen.add(resolved)
+                    out.append(candidate)
+
+    # Project-wide siblings
+    if project_root is not None:
+        try:
+            entries = list(Path(project_root).iterdir())
+        except OSError as e:
+            logger.debug(
+                "discover_witness_stores: cannot list project root "
+                "%s: %s", project_root, e,
+            )
+            entries = []
+
+        for run_dir in sorted(entries):
+            if not run_dir.is_dir():
+                continue
+            for sub in _RUN_LOCAL_SUBPATHS:
+                candidate = run_dir / sub
+                if _is_store_dir(candidate):
+                    resolved = candidate.resolve()
+                    if resolved not in seen:
+                        seen.add(resolved)
+                        out.append(candidate)
+
+    return out
+
+
+def iter_visible_witnesses(stores: List[Path]):
+    """Yield (store_path, Witness) pairs across the supplied
+    stores in their listed order.
+
+    Dedup by ``bytes_hash`` — if the same exploit bytes appear in
+    multiple stores (cross-run dedup), only the first occurrence
+    is yielded. Run-local stores come first per
+    :func:`discover_witness_stores`, so a project's older
+    duplicate yields after the current run's copy.
+
+    Failures within a store (malformed manifests, missing
+    Witness fields) are skipped per the store's own
+    ``list_witnesses`` contract.
+    """
+    from core.witness.store import WitnessStore
+
+    seen_hashes: set = set()
+    for root in stores:
+        try:
+            store = WitnessStore(root)
+        except Exception as e:  # noqa: BLE001 — best-effort
+            logger.debug(
+                "iter_visible_witnesses: skipping %s: %s: %s",
+                root, type(e).__name__, e,
+            )
+            continue
+        try:
+            for w in store.list_witnesses():
+                if w.bytes_hash in seen_hashes:
+                    continue
+                seen_hashes.add(w.bytes_hash)
+                yield root, w
+        except Exception as e:  # noqa: BLE001 — best-effort
+            logger.debug(
+                "iter_visible_witnesses: iteration aborted in %s: "
+                "%s: %s", root, type(e).__name__, e,
+            )

--- a/core/witness/matching.py
+++ b/core/witness/matching.py
@@ -1,0 +1,166 @@
+"""Rank witnesses by how well they match a given finding.
+
+Stage E (and any future consumer that wants "the most relevant
+witness for this finding") needs to pick from the witness set
+discovered by :mod:`core.witness.discovery`. The matching is
+purely structural — no LLM judgment — driven by the
+``outcome_detail`` fields the witness producers populate.
+
+Ranking (higher score → better match):
+
+  10  Exact finding-id match
+       ``outcome_detail["finding_id"] == finding.id``
+       The producer (e.g. crash_agent / agent.py) recorded this
+       witness specifically for this finding.
+
+  7   CWE + file match
+       ``outcome_detail["cwe_id"] == finding.cwe_id`` AND
+       ``outcome_detail["file_path"] == finding.file``
+       Same bug class, same source file — strong proxy when ids
+       differ (e.g. /fuzz witness vs /validate finding-id).
+
+  4   File match
+       ``outcome_detail["file_path"] == finding.file``
+       Same source file, possibly different CWE — useful when
+       one file has multiple findings.
+
+  2   Same target binary
+       The witness's ``target_binary_hash`` matches a finding's
+       binary. Fuzz witnesses lean on this (no source-level ids
+       — they were produced before any LLM classification).
+
+  0   No structured signal
+       Falls through; consumer can still use the witness as a
+       last-resort but should treat the verdict cautiously.
+
+Ties broken by:
+
+  1. Source preference: ``LLM_EMIT_RUN`` > ``FUZZ`` > others
+     (LLM emit was synthesised against the finding's bug class
+     explicitly; fuzz is generic crash evidence).
+  2. Observed-outcome richness: ``SANITIZER_REPORT`` >
+     ``EXIT_SIGNAL`` > others (sanitizer reports identify the
+     bug class; raw signals are correct but less specific).
+  3. ``bytes_hash`` lex order (deterministic tie-breaker).
+
+Note: the score thresholds are deliberately conservative. A
+finding may have zero matches — that's a "no witness available"
+signal, not an error.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from core.witness.types import Witness, WitnessOutcome, WitnessSource
+
+
+@dataclass(frozen=True)
+class WitnessMatch:
+    """A scored witness candidate for a given finding."""
+    witness: Witness
+    store_root: Any  # Path, but Any to avoid import cycle
+    score: int
+    reason: str
+
+    @property
+    def is_real(self) -> bool:
+        """True iff the match score is above the "no structured
+        signal" threshold. Consumers may want to skip score-0
+        matches entirely."""
+        return self.score > 0
+
+
+def _source_priority(src: WitnessSource) -> int:
+    if src is WitnessSource.LLM_EMIT_RUN:
+        return 2
+    if src is WitnessSource.FUZZ:
+        return 1
+    return 0
+
+
+def _outcome_priority(outcome: WitnessOutcome) -> int:
+    if outcome is WitnessOutcome.SANITIZER_REPORT:
+        return 3
+    if outcome is WitnessOutcome.EXIT_SIGNAL:
+        return 2
+    if outcome is WitnessOutcome.FLAG_CAPTURED:
+        return 4  # rare but most-specific
+    return 1
+
+
+def score_witness_for_finding(
+    witness: Witness,
+    finding: Dict[str, Any],
+) -> Tuple[int, str]:
+    """Return ``(score, reason)`` for one witness against one
+    finding. Consumers loop this over a witness list and pick
+    the maxima via :func:`best_match_for_finding`."""
+    detail = witness.outcome_detail if isinstance(witness.outcome_detail, dict) else {}
+
+    finding_id = finding.get("id")
+    finding_cwe = finding.get("cwe_id") or finding.get("cwe")
+    finding_file = finding.get("file") or finding.get("file_path")
+    binary_path = (
+        finding.get("feasibility", {}).get("binary_path")
+        if isinstance(finding.get("feasibility"), dict)
+        else None
+    )
+
+    if finding_id and detail.get("finding_id") == finding_id:
+        return 10, "exact finding-id match"
+
+    if (finding_cwe and detail.get("cwe_id") == finding_cwe
+            and finding_file and detail.get("file_path") == finding_file):
+        return 7, "cwe + file match"
+
+    if finding_file and detail.get("file_path") == finding_file:
+        return 4, "file match"
+
+    # Binary-hash fallback for fuzz witnesses (no finding_id /
+    # source structure). We don't hash the finding's binary path
+    # here — caller's responsibility — but if a target_binary_hash
+    # exists at all on the witness, that's evidence it ran
+    # against *some* binary, which is more than zero signal.
+    if witness.target_binary_hash and binary_path:
+        return 2, "same target binary (hash-pending)"
+
+    return 0, "no structured signal"
+
+
+def best_match_for_finding(
+    witnesses: Iterable[Tuple[Any, Witness]],
+    finding: Dict[str, Any],
+) -> Optional[WitnessMatch]:
+    """Pick the best-ranked witness for ``finding`` from an
+    iterable of ``(store_root, Witness)`` pairs.
+
+    Returns ``None`` when no candidate scores above 0 (i.e. no
+    structured signal — caller should treat as "no witness").
+
+    Tie-break order: source > outcome > bytes_hash. See module
+    docstring for rationale.
+    """
+    candidates: List[WitnessMatch] = []
+    for store_root, w in witnesses:
+        score, reason = score_witness_for_finding(w, finding)
+        if score == 0:
+            continue
+        candidates.append(WitnessMatch(
+            witness=w, store_root=store_root,
+            score=score, reason=reason,
+        ))
+
+    if not candidates:
+        return None
+
+    candidates.sort(
+        key=lambda m: (
+            -m.score,
+            -_source_priority(m.witness.source),
+            -_outcome_priority(m.witness.observed_outcome),
+            m.witness.bytes_hash,
+        ),
+    )
+    return candidates[0]

--- a/core/witness/tests/test_discovery.py
+++ b/core/witness/tests/test_discovery.py
@@ -1,0 +1,198 @@
+"""Tests for ``core.witness.discovery``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+# core/witness/tests/test_discovery.py → parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from core.witness import (  # noqa: E402
+    Witness,
+    WitnessOutcome,
+    WitnessSource,
+    WitnessStore,
+    compute_bytes_hash,
+    discover_witness_stores,
+    iter_visible_witnesses,
+)
+
+
+def _put_one(root: Path, data: bytes, *, source=WitnessSource.FUZZ):
+    """Create a store at ``root`` with one witness in it."""
+    store = WitnessStore(root)
+    store.put(
+        Witness(
+            bytes_hash=compute_bytes_hash(data),
+            bytes_len=len(data),
+            source=source,
+            observed_outcome=WitnessOutcome.EXIT_SIGNAL,
+            outcome_detail={"finding_id": data.decode("utf-8", "replace")[:16]},
+        ),
+        data,
+    )
+
+
+# ----------------------------------------------------------------------
+# discover_witness_stores
+# ----------------------------------------------------------------------
+
+
+def test_no_output_dir_no_project_returns_empty():
+    assert discover_witness_stores(None) == []
+
+
+def test_nonexistent_output_dir_returns_empty(tmp_path):
+    assert discover_witness_stores(tmp_path / "does_not_exist") == []
+
+
+def test_run_local_finds_witnesses_subdir(tmp_path):
+    """The conventional ``<out>/witnesses/`` store."""
+    _put_one(tmp_path / "witnesses", b"x")
+    stores = discover_witness_stores(tmp_path)
+    assert len(stores) == 1
+    assert (stores[0].resolve()) == (tmp_path / "witnesses").resolve()
+
+
+def test_run_local_finds_analysis_witnesses(tmp_path):
+    """The crash-agent location ``<out>/analysis/witnesses/``."""
+    _put_one(tmp_path / "analysis" / "witnesses", b"x")
+    stores = discover_witness_stores(tmp_path)
+    assert len(stores) == 1
+    assert "analysis" in str(stores[0])
+
+
+def test_run_local_finds_autonomous_witnesses(tmp_path):
+    """The /agentic location ``<out>/autonomous/witnesses/``."""
+    _put_one(tmp_path / "autonomous" / "witnesses", b"x")
+    stores = discover_witness_stores(tmp_path)
+    assert len(stores) == 1
+    assert "autonomous" in str(stores[0])
+
+
+def test_run_local_finds_all_three(tmp_path):
+    _put_one(tmp_path / "witnesses", b"x1")
+    _put_one(tmp_path / "analysis" / "witnesses", b"x2")
+    _put_one(tmp_path / "autonomous" / "witnesses", b"x3")
+    stores = discover_witness_stores(tmp_path)
+    assert len(stores) == 3
+
+
+def test_dir_without_manifests_subdir_not_a_store(tmp_path):
+    """Defensive: a dir named witnesses/ that lacks manifests/
+    is not a WitnessStore — never had a put() call."""
+    (tmp_path / "witnesses").mkdir()
+    # No manifests/ subdir
+    assert discover_witness_stores(tmp_path) == []
+
+
+# ----------------------------------------------------------------------
+# Project-wide discovery
+# ----------------------------------------------------------------------
+
+
+def test_project_root_globs_sibling_runs(tmp_path):
+    """When a project root is provided, every sibling run's
+    witness store is discovered."""
+    project = tmp_path / "project"
+    project.mkdir()
+    # Three sibling runs
+    _put_one(project / "fuzz_001" / "witnesses", b"fuzz1")
+    _put_one(project / "agentic_002" / "autonomous" / "witnesses", b"a1")
+    _put_one(
+        project / "fuzz_003" / "analysis" / "witnesses", b"crash_agent_1",
+    )
+
+    out_dir = project / "validate_004"
+    out_dir.mkdir()
+
+    stores = discover_witness_stores(out_dir, project_root=project)
+    # 3 sibling stores; current run has no store of its own
+    assert len(stores) == 3
+
+
+def test_run_local_listed_before_project_siblings(tmp_path):
+    """Run-local stores come first — operators expect "what I
+    just produced" at the top of the list, sibling-run history
+    after."""
+    project = tmp_path / "project"
+    project.mkdir()
+    _put_one(project / "fuzz_001" / "witnesses", b"sibling")
+
+    out_dir = project / "validate_002"
+    out_dir.mkdir()
+    _put_one(out_dir / "witnesses", b"current")
+
+    stores = discover_witness_stores(out_dir, project_root=project)
+    # First entry is the current run's store
+    assert "validate_002" in str(stores[0])
+    assert any("fuzz_001" in str(s) for s in stores)
+
+
+def test_dedup_by_resolved_path(tmp_path):
+    """Same store reachable via two paths (e.g. current run is
+    under project_root) is deduplicated."""
+    project = tmp_path / "project"
+    project.mkdir()
+    _put_one(project / "fuzz_001" / "witnesses", b"x")
+
+    out_dir = project / "fuzz_001"  # current run IS the sibling
+    stores = discover_witness_stores(out_dir, project_root=project)
+    assert len(stores) == 1
+
+
+def test_project_root_unreadable_returns_empty_silently(tmp_path):
+    """Cannot list project root → empty list, no exception.
+    The end-of-run summary should never crash because of a
+    permissions glitch on a stale project dir."""
+    import os
+    project = tmp_path / "project"
+    project.mkdir()
+    _put_one(project / "fuzz_001" / "witnesses", b"x")
+
+    os.chmod(project, 0o000)
+    try:
+        # Should not raise even though project_root is unreadable
+        stores = discover_witness_stores(None, project_root=project)
+        # Either 0 (unreadable, log+return) or 1 (root-equivalent
+        # bypasses chmod). Contract: doesn't raise.
+        assert isinstance(stores, list)
+    finally:
+        os.chmod(project, 0o755)
+
+
+# ----------------------------------------------------------------------
+# iter_visible_witnesses
+# ----------------------------------------------------------------------
+
+
+def test_iter_yields_pairs(tmp_path):
+    """Each yielded pair is (store_path, Witness)."""
+    _put_one(tmp_path / "witnesses", b"x")
+    stores = discover_witness_stores(tmp_path)
+    pairs = list(iter_visible_witnesses(stores))
+    assert len(pairs) == 1
+    store_path, w = pairs[0]
+    assert store_path == stores[0]
+    assert w.bytes_hash == compute_bytes_hash(b"x")
+
+
+def test_iter_dedups_by_bytes_hash(tmp_path):
+    """Same bytes_hash in two stores → only first yielded."""
+    project = tmp_path / "project"
+    project.mkdir()
+    # Same bytes in two sibling runs
+    _put_one(project / "fuzz_001" / "witnesses", b"shared")
+    _put_one(project / "fuzz_002" / "witnesses", b"shared")
+    _put_one(project / "fuzz_002" / "witnesses", b"unique")
+
+    stores = discover_witness_stores(None, project_root=project)
+    pairs = list(iter_visible_witnesses(stores))
+    hashes = [w.bytes_hash for _, w in pairs]
+    # 2 unique hashes; the duplicate "shared" yielded only once
+    assert len(hashes) == 2
+    assert hashes.count(compute_bytes_hash(b"shared")) == 1
+    assert hashes.count(compute_bytes_hash(b"unique")) == 1

--- a/core/witness/tests/test_matching.py
+++ b/core/witness/tests/test_matching.py
@@ -1,0 +1,212 @@
+"""Tests for ``core.witness.matching`` — finding → witness
+ranking semantics."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+# core/witness/tests/test_matching.py → parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from core.witness import (  # noqa: E402
+    Witness,
+    WitnessOutcome,
+    WitnessSource,
+    best_match_for_finding,
+    compute_bytes_hash,
+    score_witness_for_finding,
+)
+
+
+def _make_witness(
+    detail: dict = None,
+    *,
+    source: WitnessSource = WitnessSource.LLM_EMIT_RUN,
+    outcome: WitnessOutcome = WitnessOutcome.EXIT_SIGNAL,
+    target_binary_hash: str = None,
+    data: bytes = b"witness-bytes",
+) -> Witness:
+    return Witness(
+        bytes_hash=compute_bytes_hash(data),
+        bytes_len=len(data),
+        source=source,
+        observed_outcome=outcome,
+        outcome_detail=detail or {},
+        target_binary_hash=target_binary_hash,
+    )
+
+
+_FINDING = {
+    "id": "FIND-0001",
+    "cwe_id": "CWE-120",
+    "file": "src/auth.c",
+    "feasibility": {"binary_path": "/usr/bin/svc"},
+}
+
+
+# ----------------------------------------------------------------------
+# Score thresholds
+# ----------------------------------------------------------------------
+
+
+def test_exact_finding_id_match_scores_10():
+    w = _make_witness({"finding_id": "FIND-0001"})
+    score, reason = score_witness_for_finding(w, _FINDING)
+    assert score == 10
+    assert "finding-id" in reason
+
+
+def test_cwe_plus_file_match_scores_7():
+    w = _make_witness({
+        "cwe_id": "CWE-120",
+        "file_path": "src/auth.c",
+    })
+    score, _ = score_witness_for_finding(w, _FINDING)
+    assert score == 7
+
+
+def test_file_only_match_scores_4():
+    w = _make_witness({"file_path": "src/auth.c"})
+    score, _ = score_witness_for_finding(w, _FINDING)
+    assert score == 4
+
+
+def test_binary_hash_fallback_scores_2():
+    """No structured signals match, but the witness ran against
+    some target binary — weak but non-zero signal."""
+    w = _make_witness({}, target_binary_hash="deadbeef" * 8)
+    score, _ = score_witness_for_finding(w, _FINDING)
+    assert score == 2
+
+
+def test_no_signal_scores_0():
+    w = _make_witness({})
+    score, _ = score_witness_for_finding(w, _FINDING)
+    assert score == 0
+
+
+def test_cwe_only_or_file_only_doesnt_promote_to_7():
+    """CWE without matching file stays at 0 (or 4 for file
+    alone). Pin that the cwe-only case doesn't elevate."""
+    w_cwe_only = _make_witness({"cwe_id": "CWE-120"})
+    assert score_witness_for_finding(w_cwe_only, _FINDING)[0] == 0
+
+
+# ----------------------------------------------------------------------
+# Tie-breaking
+# ----------------------------------------------------------------------
+
+
+def test_tie_break_prefers_llm_emit_run_over_fuzz():
+    """Same score (file match), different source — LLM emit was
+    synthesised against the finding's bug class; ranked higher."""
+    w_fuzz = _make_witness(
+        {"file_path": "src/auth.c"},
+        source=WitnessSource.FUZZ,
+        data=b"fuzz-data",
+    )
+    w_llm = _make_witness(
+        {"file_path": "src/auth.c"},
+        source=WitnessSource.LLM_EMIT_RUN,
+        data=b"llm-data",
+    )
+    best = best_match_for_finding(
+        [(Path("/a"), w_fuzz), (Path("/b"), w_llm)], _FINDING,
+    )
+    assert best is not None
+    assert best.witness.source is WitnessSource.LLM_EMIT_RUN
+
+
+def test_tie_break_prefers_sanitizer_over_exit_signal():
+    """Same score + same source, different outcome — sanitizer
+    report identifies the bug class more specifically."""
+    w_signal = _make_witness(
+        {"file_path": "src/auth.c"},
+        source=WitnessSource.LLM_EMIT_RUN,
+        outcome=WitnessOutcome.EXIT_SIGNAL,
+        data=b"signal",
+    )
+    w_san = _make_witness(
+        {"file_path": "src/auth.c"},
+        source=WitnessSource.LLM_EMIT_RUN,
+        outcome=WitnessOutcome.SANITIZER_REPORT,
+        data=b"san",
+    )
+    best = best_match_for_finding(
+        [(Path("/a"), w_signal), (Path("/b"), w_san)], _FINDING,
+    )
+    assert best.witness.observed_outcome is WitnessOutcome.SANITIZER_REPORT
+
+
+# ----------------------------------------------------------------------
+# best_match_for_finding semantics
+# ----------------------------------------------------------------------
+
+
+def test_best_match_picks_highest_score():
+    """Exact id beats cwe+file beats file alone."""
+    w_file = _make_witness({"file_path": "src/auth.c"}, data=b"file-only")
+    w_cwe = _make_witness({
+        "cwe_id": "CWE-120", "file_path": "src/auth.c",
+    }, data=b"cwe-file")
+    w_id = _make_witness({"finding_id": "FIND-0001"}, data=b"exact")
+    best = best_match_for_finding(
+        [
+            (Path("/a"), w_file),
+            (Path("/b"), w_cwe),
+            (Path("/c"), w_id),
+        ],
+        _FINDING,
+    )
+    assert best is not None
+    assert best.score == 10
+    assert best.witness.bytes_hash == compute_bytes_hash(b"exact")
+
+
+def test_best_match_returns_none_when_no_signal():
+    """All score-0 → None, not the random first one."""
+    w1 = _make_witness({}, data=b"a")
+    w2 = _make_witness({"cwe_id": "CWE-789"}, data=b"b")  # mismatching CWE
+    best = best_match_for_finding(
+        [(Path("/a"), w1), (Path("/b"), w2)], _FINDING,
+    )
+    assert best is None
+
+
+def test_best_match_handles_empty_iterable():
+    best = best_match_for_finding([], _FINDING)
+    assert best is None
+
+
+def test_is_real_flag():
+    w = _make_witness({"finding_id": "FIND-0001"})
+    best = best_match_for_finding([(Path("/a"), w)], _FINDING)
+    assert best is not None
+    assert best.is_real is True
+
+
+# ----------------------------------------------------------------------
+# Defensive: malformed outcome_detail
+# ----------------------------------------------------------------------
+
+
+def test_outcome_detail_non_dict_does_not_crash():
+    """``outcome_detail`` being None / list / string should not
+    crash the scorer; treat as "no signal"."""
+    w = _make_witness({}, data=b"x")
+    # Bypass the dataclass init for outcome_detail
+    object.__setattr__(w, "outcome_detail", None)  # type: ignore[arg-type]
+    score, _ = score_witness_for_finding(w, _FINDING)
+    assert score == 0
+
+
+def test_finding_missing_id_does_not_crash():
+    """A finding without an id field doesn't match by id but
+    can still match by file/cwe. Pin no exception."""
+    w = _make_witness({"file_path": "src/auth.c"})
+    finding = {"file": "src/auth.c"}
+    score, _ = score_witness_for_finding(w, finding)
+    assert score == 4

--- a/libexec/raptor-run-feasibility
+++ b/libexec/raptor-run-feasibility
@@ -28,7 +28,10 @@ from core.json import load_json, save_json
 
 def main():
     if len(sys.argv) < 4:
-        print(f"Usage: {sys.argv[0]} <binary_path> <findings.json> <output_dir> [--vuln-type <type>]")
+        print(
+            f"Usage: {sys.argv[0]} <binary_path> <findings.json> "
+            f"<output_dir> [--vuln-type <type>] [--target <path>]"
+        )
         sys.exit(1)
 
     binary_path = sys.argv[1]
@@ -40,6 +43,20 @@ def main():
         idx = sys.argv.index("--vuln-type")
         if idx + 1 < len(sys.argv):
             vuln_type = sys.argv[idx + 1]
+
+    # ``--target <path>`` enables the per-finding empirical
+    # mitigation analysis: with a source root we can resolve
+    # ``finding.file`` to an on-disk source file and feed it +
+    # a matching witness to
+    # ``analyze_binary_under_mitigations`` (PR #609). Without
+    # ``--target`` (legacy callers), the empirical step is
+    # silently skipped — the static analyze_binary path runs
+    # unchanged.
+    target_path = None
+    if "--target" in sys.argv:
+        idx = sys.argv.index("--target")
+        if idx + 1 < len(sys.argv):
+            target_path = Path(sys.argv[idx + 1]).resolve()
 
     if not Path(binary_path).exists():
         print(f"ERROR: binary not found: {binary_path}")
@@ -114,7 +131,7 @@ def main():
     constraints = load_exploit_context(context_file)
     result = constraints
     print(f"  Binary verdict (generic): {constraints.get('verdict', 'unknown')}")
-    print(f"  Mapping per-finding verdicts (vuln-type-aware)...")
+    print("  Mapping per-finding verdicts (vuln-type-aware)...")
     mapped = map_findings_to_constraints(
         [{"id": f["id"], "vuln_type": f.get("vuln_type", "")} for f in group],
         constraints,
@@ -147,6 +164,20 @@ def main():
             }
             print(f"  {finding['id']}: {assessment.verdict}")
 
+    # --- Empirical mitigation map (PR #609 consumer) ---
+    # Only attempt when ``--target`` was supplied — without a
+    # source root we can't resolve ``finding.file`` to an on-disk
+    # file. Silent skip per-finding when source or witness is
+    # missing; the static feasibility verdict above is the
+    # baseline either way.
+    if target_path is not None:
+        _enrich_with_empirical_mitigation_map(
+            group=group,
+            findings_data=findings_data,
+            output_dir=Path(output_dir),
+            target_path=target_path,
+        )
+
     save_json(findings_path, findings_data)
     # Release the advisory flock by closing the lock handle.
     try:
@@ -155,6 +186,140 @@ def main():
         pass
     findings_lock_fh.close()
     print(f"Updated {len(mapped)} finding(s)")
+
+
+def _enrich_with_empirical_mitigation_map(
+    *,
+    group: list,
+    findings_data: dict,
+    output_dir: Path,
+    target_path: Path,
+) -> None:
+    """Per-finding: resolve source, find best-matching witness
+    (run-local + project-wide), run ``analyze_binary_under_
+    mitigations``, attach summary to ``feasibility.empirical_
+    mitigation_map`` and persist the full FeasibilityMap JSON
+    to ``<output_dir>/mitigation_feasibility/<finding_id>.json``.
+
+    Each finding is independent — one bad source or one missing
+    witness doesn't sink the others. All failures are logged
+    + skipped.
+    """
+    try:
+        from core.run.output import _resolve_active_project
+        from core.witness import (
+            discover_witness_stores,
+            iter_visible_witnesses,
+            best_match_for_finding,
+        )
+        from packages.exploit_feasibility.under_mitigations import (
+            analyze_binary_under_mitigations,
+            to_json,
+        )
+    except ImportError as e:
+        print(
+            f"  WARN: empirical mitigation map skipped — "
+            f"import failed: {type(e).__name__}: {e}"
+        )
+        return
+
+    # Resolve project root if a project is active.
+    project_root = None
+    try:
+        active = _resolve_active_project()
+        if active:
+            project_root = Path(active[0])
+    except Exception as e:  # noqa: BLE001
+        print(
+            f"  WARN: active project resolution failed "
+            f"({type(e).__name__}: {e}); using run-local stores only"
+        )
+
+    stores = discover_witness_stores(output_dir, project_root=project_root)
+    if not stores:
+        return  # nothing to match against; silent skip
+
+    # Materialise the visible witnesses once — N findings shouldn't
+    # iterate every store N times.
+    visible = list(iter_visible_witnesses(stores))
+    if not visible:
+        return
+
+    feasibility_dir = output_dir / "mitigation_feasibility"
+    feasibility_dir.mkdir(parents=True, exist_ok=True)
+
+    enriched = 0
+    for finding in group:
+        finding_file = finding.get("file") or finding.get("file_path")
+        if not finding_file:
+            continue
+        source = (target_path / finding_file).resolve()
+        if not source.is_file():
+            continue
+
+        best = best_match_for_finding(visible, finding)
+        if best is None or not best.is_real:
+            continue
+
+        # Resolve the witness bytes from the matched store. We need
+        # the raw file path because the bytes aren't on the Witness
+        # itself.
+        from core.witness import WitnessStore
+        try:
+            store = WitnessStore(best.store_root)
+            witness_bytes = store.get_bytes(best.witness.bytes_hash)
+        except Exception as e:  # noqa: BLE001
+            print(
+                f"  WARN: {finding['id']}: couldn't load witness "
+                f"bytes ({type(e).__name__}: {e})"
+            )
+            continue
+
+        try:
+            fmap = analyze_binary_under_mitigations(
+                source,
+                witness_bytes,
+                sandbox_timeout=5,
+            )
+        except Exception as e:  # noqa: BLE001
+            print(
+                f"  WARN: {finding['id']}: empirical analysis raised "
+                f"({type(e).__name__}: {e}); skipping"
+            )
+            continue
+
+        safe_id = "".join(
+            c if c.isalnum() or c in "-_" else "_"
+            for c in finding["id"]
+        ) or "unnamed"
+        fmap_file = feasibility_dir / f"{safe_id}.json"
+        fmap_file.write_text(to_json(fmap), encoding="utf-8")
+
+        finding.setdefault("feasibility", {})[
+            "empirical_mitigation_map"
+        ] = {
+            "feasibility_map_file": str(fmap_file),
+            "summary": fmap.summary(),
+            "witness_hash": fmap.witness_hash,
+            "witness_len": fmap.witness_len,
+            "target_source_hash": fmap.target_source_hash,
+            "target_source_path": fmap.target_source_path,
+            "match_score": best.score,
+            "match_reason": best.reason,
+        }
+        summary = fmap.summary()
+        print(
+            f"  {finding['id']}: empirical: "
+            f"fired={summary['bug_fired_under']} "
+            f"blocked={summary['blocked_under']}"
+        )
+        enriched += 1
+
+    if enriched:
+        print(
+            f"  Empirical mitigation map: enriched {enriched}/"
+            f"{len(group)} finding(s)"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes the empirical mitigation verdicts follow-up from PR #609 by making Stage E auto-discover witnesses and trigger analyze_binary_under_mitigations per-finding when source + a matching witness are available. Operators get artefact-grade mitigation verdicts when conditions are met; reasoning-grade verdicts when they aren't. No per-finding operator action.

Three layers land:

1. core/witness/discovery.py — discover_witness_stores(out_dir, *, project_root=None) finds WitnessStore-shaped dirs at the conventional sub-paths (witnesses/, analysis/witnesses/, autonomous/witnesses/). When a /project is active (resolved via _resolve_active_project), it also globs sibling runs' stores under the project root — so a /fuzz run last week amplifies every /validate run this week. iter_visible_witnesses yields cross-store (store_root, Witness) pairs with bytes_hash dedup.

2. core/witness/matching.py — score_witness_for_finding ranks witness candidates against a finding structurally: exact finding-id (10) > cwe + file (7) > file (4) > target-binary (2) > no signal (0). best_match_for_finding picks the highest; ties break on source (LLM_EMIT_RUN > FUZZ) > outcome (SANITIZER_REPORT > EXIT_SIGNAL) > bytes_hash. Mechanical ranking — no LLM judgment in the trigger step; the existing Stage E LLM still does the interpretation.

3. libexec/raptor-run-feasibility extended: new optional --target <path> arg + per-finding empirical block after the existing analyze_binary verdict mapping. For each finding with source resolvable from target_path/finding.file AND a best_match witness scored above 0, runs analyze_binary_under_mitigations, writes the full FeasibilityMap JSON to <out>/mitigation_feasibility/<id>.json, and attaches a summary stanza to feasibility.empirical_ mitigation_map. Per-finding failures (missing source, missing witness, analysis raise) skip silently — one bad case doesn't sink the batch. Backward compatible: callers without --target get the static-only path unchanged.

Stage E skill updated to pass --target in the call site and documents the operator-facing semantics — verdicts should lift toward Confirmed when bug_fired_under includes the deployment profile; soften when blocked_under does.