### PR TITLE
Integrate C/C++ call-graph extractors into builder dispatch

### DIFF
--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -27,6 +27,8 @@ from .exclusions import (
 )
 from .extractors import extract_items, count_sloc
 from .call_graph import (
+    extract_call_graph_c,
+    extract_call_graph_cpp,
     extract_call_graph_csharp,
     extract_call_graph_go,
     extract_call_graph_java,
@@ -580,6 +582,26 @@ def _process_single_file(
             ).to_dict()
         elif language == 'php':
             record['call_graph'] = extract_call_graph_php(
+                content,
+            ).to_dict()
+        elif language == 'c':
+            # S5: wire the existing extract_call_graph_c into the
+            # dispatch. The walker has been present (and tested in
+            # core/inventory/tests) for a while but was orphaned —
+            # C files were getting empty call_graph records, so
+            # function_called returned no useful data for any C
+            # finding and the analysis prompt's Reachability: block
+            # was absent for every C scan. Closes RAPTOR's largest
+            # whole-language reachability blind spot.
+            record['call_graph'] = extract_call_graph_c(
+                content,
+            ).to_dict()
+        elif language == 'cpp':
+            # S5: same wiring story for C++. _CppCallGraph inherits
+            # from _CCallGraph; adds class/namespace/qualified-id
+            # handling. Covers .cpp / .cc / .cxx / .hpp (per the
+            # languages.py extension map).
+            record['call_graph'] = extract_call_graph_cpp(
                 content,
             ).to_dict()
         return record

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -430,6 +430,42 @@ def function_called(
                     file_has_evidence = True
                     evidence.append((path, int(call.get("line", 0) or 0)))
 
+        # Same-file bare-name fast-path. When chain is
+        # ``[target_func]`` AND this file's path-derived module
+        # matches target_module, treat as a hit. The import-map
+        # path can't address this case: a function defined in the
+        # same file isn't "imported", so it has no import-map
+        # entry for its name to resolve against.
+        #
+        # Particularly load-bearing for C/C++ (no symbol-level
+        # imports for in-file functions) — pre-fix the resolver
+        # said NOT_CALLED for every C bare-name same-file call,
+        # which cascaded to false-negative reachability for any
+        # function called only by another same-file function in
+        # a longer reach chain. Also fixes the equivalent Python
+        # / JS / Go / Rust gap when a same-file caller uses the
+        # bare-name form.
+        #
+        # Defensive: skip when the bare name is shadowed by an
+        # import in THIS file. The import-map path above is
+        # authoritative for shadowed bare-name calls (Python
+        # shadows the local def with the import at module scope;
+        # JS / TS behaves the same with named-import binding).
+        if not file_has_evidence:
+            file_module = _file_path_to_module(path)
+            if file_module == target_module:
+                for call in calls:
+                    chain = call.get("chain") or []
+                    if len(chain) != 1 or chain[0] != target_func:
+                        continue
+                    if chain[0] in imports:
+                        continue
+                    file_has_evidence = True
+                    evidence.append(
+                        (path, int(call.get("line", 0) or 0)),
+                    )
+                    break
+
         if file_has_evidence:
             continue
 
@@ -1737,6 +1773,41 @@ def _apply_reexport_aliases(idx: _AdjacencyIndex) -> int:
                     idx.qualified_to_internal[alias_full] = target_internal
                     added += 1
     return added
+
+
+def _file_path_to_module(rel_path: str) -> Optional[str]:
+    """Universal file-path → module conversion used by the same-file
+    bare-name fast-path in ``function_called``.
+
+    ``c/heartbeat.c`` → ``c.heartbeat``;
+    ``packages/foo/bar.py`` → ``packages.foo.bar``;
+    ``src/api/handler.rs`` → ``src.api.handler``.
+
+    Matches the convention ``core.orchestration.reachability_enrichment.
+    _path_to_module`` uses for the prepass — the prepass passes module-
+    qualified names like ``c.heartbeat.read_u16_be`` to function_called,
+    so the resolver needs to recognise the same module form to match
+    same-file bare-name calls against them.
+
+    Differs from ``_path_derived_module`` above: this helper is
+    language-agnostic (strips ANY single suffix) and emits just the
+    module, not a function-qualified candidate list. The two helpers
+    serve different fast-paths and intentionally diverge in scope.
+
+    Returns ``None`` for paths with no extension (extensionless
+    scripts, Makefile-shaped artefacts) — those don't participate
+    in module-style namespacing.
+    """
+    if not rel_path:
+        return None
+    from pathlib import PurePosixPath
+    p = PurePosixPath(rel_path.replace("\\", "/"))
+    if not p.suffix:
+        return None
+    parts = list(p.with_suffix("").parts)
+    if not parts:
+        return None
+    return ".".join(parts)
 
 
 def _path_derived_module(

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -316,3 +316,142 @@ def test_result_is_immutable():
     import pytest
     with pytest.raises(dataclasses.FrozenInstanceError):
         r.verdict = Verdict.CALLED  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Same-file bare-name resolution. Pre-fix the resolver only matched bare
+# calls via the import map; same-file calls (where the function isn't
+# "imported" because it's defined in the same file) returned NOT_CALLED
+# even when callers_of correctly showed the link. Particularly load-
+# bearing for C / C++ where there are no symbol-level imports for in-
+# file functions — every bare-name same-file C call was a false-negative
+# in the high-level API.
+# ---------------------------------------------------------------------------
+
+
+class TestSameFileBareNameResolution:
+    def _c_inv(self, path: str, source: str) -> dict:
+        from core.inventory.call_graph import extract_call_graph_c
+        from core.inventory.extractors import extract_items
+        items = extract_items(path, "c", source)
+        cg = extract_call_graph_c(source).to_dict()
+        return {"files": [{
+            "path": path, "language": "c",
+            "items": [it.to_dict() for it in items],
+            "call_graph": cg,
+        }]}
+
+    def test_c_bare_name_same_file_resolves(self):
+        # Mirror honeyslop's heartbeat.c shape: helper function
+        # called by another function in the same file. Pre-fix this
+        # returned NOT_CALLED because C has no symbol-level imports
+        # so the import-map path couldn't see the call.
+        inv = self._c_inv("c/heartbeat.c",
+            "uint16_t read_u16_be(const uint8_t *p) {\n"
+            "    return (p[0] << 8) | p[1];\n"
+            "}\n"
+            "int parse_heartbeat(const uint8_t *buf) {\n"
+            "    uint16_t len = read_u16_be(buf);\n"
+            "    return len;\n"
+            "}\n"
+        )
+        r = function_called(inv, "c.heartbeat.read_u16_be")
+        assert r.verdict == Verdict.CALLED, (
+            f"C bare-name same-file call must resolve as CALLED; "
+            f"got {r.verdict.value}"
+        )
+        # Evidence should point at the call site in heartbeat.c.
+        assert any("heartbeat.c" in p for p, _ in r.evidence), (
+            f"evidence missing the calling file; got {r.evidence}"
+        )
+
+    def test_c_bare_name_no_caller_still_not_called(self):
+        # Sanity: a same-file def with no caller is still NOT_CALLED.
+        # The fast-path doesn't over-fire.
+        inv = self._c_inv("c/dead.c",
+            "uint16_t orphan(const uint8_t *p) { return p[0]; }\n"
+            "int main() { return 0; }\n"  # main doesn't call orphan
+        )
+        r = function_called(inv, "c.dead.orphan")
+        assert r.verdict == Verdict.NOT_CALLED
+
+    def test_python_bare_name_same_file_resolves(self):
+        # Python had the same gap. ``helper()`` from another function
+        # in the same file pre-fix returned NOT_CALLED via
+        # function_called (callers_of was correct via the direct
+        # InternalFunction probe, but the high-level API didn't link).
+        from core.inventory.call_graph import extract_call_graph_python
+        cg = extract_call_graph_python(
+            "def helper(): pass\n"
+            "def main():\n"
+            "    helper()\n"
+        ).to_dict()
+        inv = {"files": [{
+            "path": "src/x.py", "language": "python",
+            "items": [
+                {"name": "helper", "kind": "function", "line_start": 1},
+                {"name": "main", "kind": "function", "line_start": 2},
+            ],
+            "call_graph": cg,
+        }]}
+        r = function_called(inv, "src.x.helper")
+        assert r.verdict == Verdict.CALLED
+
+    def test_shadowing_import_takes_precedence(self):
+        # When the bare name is shadowed by an import, the import-map
+        # path is authoritative — the same-file fast-path must NOT
+        # fire, otherwise we'd over-report. The fast-path explicitly
+        # skips when chain[0] is in imports[].
+        from core.inventory.call_graph import extract_call_graph_python
+        # x.py imports helper from src.other, defines NO local helper,
+        # calls helper() bare. The call resolves to src.other.helper
+        # (via the import map), not to anything in x.py.
+        cg = extract_call_graph_python(
+            "from src.other import helper\n"
+            "def main():\n"
+            "    helper()\n"
+        ).to_dict()
+        inv = {"files": [
+            {"path": "src/other.py", "language": "python",
+             "items": [{"name": "helper", "kind": "function",
+                        "line_start": 1}],
+             "call_graph": extract_call_graph_python(
+                 "def helper(): pass\n"
+             ).to_dict()},
+            {"path": "src/x.py", "language": "python",
+             "items": [{"name": "main", "kind": "function",
+                        "line_start": 2}],
+             "call_graph": cg},
+        ]}
+        r = function_called(inv, "src.other.helper")
+        # src.other.helper IS called via the bare-name path in x.py
+        # (the import map resolves "helper" → "src.other.helper").
+        assert r.verdict == Verdict.CALLED, (
+            "import-map path must catch the shadowed bare-name call"
+        )
+
+    def test_no_module_for_extensionless_path_is_no_op(self):
+        # Defensive: a file with no extension can't have a path-
+        # derived module, so the fast-path silently doesn't apply.
+        # The bare-name call still has no evidence → NOT_CALLED.
+        from core.inventory.call_graph import extract_call_graph_c
+        inv = {"files": [{
+            "path": "scripts/build_helper",  # no extension
+            "language": "c",
+            "items": [{"name": "helper", "kind": "function",
+                       "line_start": 1}],
+            "call_graph": extract_call_graph_c(
+                "int helper() { return 0; }\n"
+                "int main() { helper(); return 0; }\n"
+            ).to_dict(),
+        }]}
+        # Can't form a qualified name for extensionless path —
+        # function_called will refuse the query OR return NOT_CALLED.
+        # Either is acceptable; just verify no crash.
+        try:
+            r = function_called(inv, "scripts.build_helper.helper")
+            # If query is accepted, the fast-path is a no-op because
+            # _file_path_to_module returns None for extensionless.
+            assert r.verdict in (Verdict.CALLED, Verdict.NOT_CALLED, Verdict.UNCERTAIN)
+        except ValueError:
+            pass  # extensionless query rejected — also acceptable

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -331,6 +331,13 @@ def test_result_is_immutable():
 
 class TestSameFileBareNameResolution:
     def _c_inv(self, path: str, source: str) -> dict:
+        # tree-sitter-c isn't declared in requirements.txt (only in a
+        # comment) so CI venvs may not have it. Skip the C-flavoured
+        # tests when the grammar isn't importable rather than failing
+        # — the same mechanism the inventory builder uses to degrade
+        # gracefully when the dep is absent.
+        import pytest
+        pytest.importorskip("tree_sitter_c")
         from core.inventory.call_graph import extract_call_graph_c
         from core.inventory.extractors import extract_items
         items = extract_items(path, "c", source)
@@ -342,10 +349,11 @@ class TestSameFileBareNameResolution:
         }]}
 
     def test_c_bare_name_same_file_resolves(self):
-        # Mirror honeyslop's heartbeat.c shape: helper function
-        # called by another function in the same file. Pre-fix this
-        # returned NOT_CALLED because C has no symbol-level imports
-        # so the import-map path couldn't see the call.
+        # Helper function called by another function in the same C
+        # file — the dominant shape for static helpers in driver /
+        # kernel / library code. Pre-fix this returned NOT_CALLED
+        # because C has no symbol-level imports so the import-map
+        # path couldn't see the call.
         inv = self._c_inv("c/heartbeat.c",
             "uint16_t read_u16_be(const uint8_t *p) {\n"
             "    return (p[0] << 8) | p[1];\n"


### PR DESCRIPTION
  Two commits, both surfaced 2026-05-24 while extending Phase D
  substrate work to close RAPTOR's C/C++ reachability blind spot.
  
    1. feat(inventory): wire C/C++ call-graph extractors into builder
       dispatch. extract_call_graph_c / extract_call_graph_cpp +
       _CCallGraph / _CppCallGraph have existed in
       core/inventory/call_graph.py for a while (function defs, calls,
       field expressions, pointer-call indirection, C++ classes /
       namespaces / qualified-IDs all handled). They were orphaned —
       builder.py's per-language dispatch covered Python/JS/Go/Java/
       Rust/Ruby/CSharp/PHP but not C or C++, so every C/C++ file got
       an empty call_graph record. Downstream consequence: zero
       reachability data on C findings; the analysis prompt's
       Reachability: block was absent on every C/C++ scan. Substrate's
       largest whole-language blind spot. 10-line dispatch addition.
  
    2. fix(reachability): function_called resolves same-file bare-name
       calls. The S5 wiring exposed a pre-existing resolver gap:
       function_called only matched bare-name calls (chain length 1)
       via the import map. Same-file calls — where the function isn't
       "imported" because it's defined in the same file — returned
       NOT_CALLED even though callers_of(InternalFunction) correctly
       linked them via the direct adjacency index. Particularly
       load-bearing for C/C++ (no symbol-level imports for in-file
       functions); the same gap existed for Python/JS/Go/Rust but
       only mattered when callers_of-derived analyses had reasons to
       disagree with function_called.
  
       Fix: new same-file fast-path in function_called's per-file
       walk. When chain == [target_func] AND _file_path_to_module(path)
       == target_module, treat as a hit. Defensive: skip when chain[0]
       is in imports[] so the import-map path stays authoritative for
       shadowed bare-name calls.
