### PR TITLE
fix(validate): stored-flow exception in Stage D ruling

### DIFF
--- a/.claude/skills/exploitability-validation/stage-d-ruling.md
+++ b/.claude/skills/exploitability-validation/stage-d-ruling.md
@@ -117,12 +117,29 @@ If the tautology holds → RULE OUT with `disqualifier: "D-1.5"`.
 ## [D-2] PRECONDITIONS
 
 ### Disqualifying Preconditions (RULE OUT if checked):
+
+**For stored / persistent-source findings, read the Stored-flow exception below before applying these — three of them mis-fire on legitimate stored vulnerabilities.**
+
 - [ ] Another vulnerability must be exploited first (chaining required)
 - [ ] Infrastructure/dependency must already be compromised
 - [ ] Victim must execute attacker-provided tool
 - [ ] Victim must perform specific action to assist attack
 - [ ] Requires physical access
 - [ ] Requires existing authenticated session (unless auth bypass is the finding)
+
+### Stored-flow exception:
+
+A **stored / persistent-source finding requires the attacker to plant data first — that is the bug class, not a chain.** When a finding's `uncertainty` or `candidate_reasoning` says "requires a prior attacker write to <storage>" (the cross-class escalation from Stage A/B), apply this single test before the disqualifiers above:
+
+**Does the data-plant step require its own exploit?**
+
+- **No** — the attacker plants the data through a write that needs no separate vulnerability (posting a comment, setting a profile field, an ordinary authenticated API write). **Keep the finding** and record `["requires a prior attacker-controlled write via <interface>"]` in `checks.preconditions`. This is the defining mechanism of stored XSS / stored command-injection / stored SSRF, and it **overrides three disqualifiers above** that would otherwise mis-fire:
+  - *chaining required* — a plant that needs no exploit is not a chain.
+  - *requires existing authenticated session* — that disqualifier targets findings where the vulnerable *sink/read* needs pre-existing auth, NOT where the *plant* uses ordinary authenticated functionality the attacker is permitted to use.
+  - *victim must perform specific action* — a victim *viewing* a page that renders stored content is normal usage, not an action that assists the attack.
+- **Yes** — planting the data itself requires exploiting a separate distinct vulnerability (an auth bypass, a second injection, or crossing a tenant/trust boundary the attacker cannot normally cross). **This IS genuine chaining; apply `[D-2]`.**
+
+`[D-1.5]` is not overridden: if the plant requires a privilege that already implies the sink's effect (e.g. an admin plants content only other admins render), D-1.5 still rules out.
 
 ### Non-Disqualifying Access Requirements (RECORD in `checks.preconditions`):
 
@@ -207,7 +224,7 @@ The numeric score is computed by Python (`packages.cvss.compute_base_score`). Do
       "id": "FIND-001",
       "ruling": {
         "status": "exploitable|confirmed|ruled_out",
-        "disqualifier": null|"D-0"|"D-1"|"D-2"|"D-3"|"D-4",
+        "disqualifier": null|"D-0"|"D-1"|"D-1.5"|"D-2"|"D-3"|"D-4",
         "reason": "specific reason if ruled out",
         "evidence_synthesis": {
           "stage_a_confidence": "high|medium|low",
@@ -235,6 +252,7 @@ The numeric score is computed by Python (`packages.cvss.compute_base_score`). Do
     "ruled_out_by_category": {
       "D-0_evidence_synthesis": N,
       "D-1_code_context": N,
+      "D-1.5_privilege_tautology": N,
       "D-2_preconditions": N,
       "D-3_hedging": N,
       "D-4_no_security_impact": N

--- a/packages/exploitability_validation/schemas.py
+++ b/packages/exploitability_validation/schemas.py
@@ -148,7 +148,7 @@ FINDING_SCHEMA = {
                 },
                 "disqualifier": {
                     "type": ["string", "null"],
-                    "description": "D-0 (evidence synthesis), D-1 (code context), D-2 (preconditions), D-3 (hedging), D-4 (no security impact), or null if confirmed"
+                    "description": "D-0 (evidence synthesis), D-1 (code context), D-1.5 (privilege tautology), D-2 (preconditions), D-3 (hedging), D-4 (no security impact), a pipeline-internal value such as 'sanity_check_failed', or null if confirmed. Open string by design — not a closed enum."
                 },
                 "reason": {"type": ["string", "null"]},
                 "evidence_synthesis": {


### PR DESCRIPTION
- [D-2]: stored/persistent-source finding whose data-plant uses a write needing no separate exploit is not a chain. Overrides the chaining, authenticated-session, and victim-action disqualifiers; defers to D-1.5.
- Add D-1.5 to the disqualifier enum + ruled_out_by_category (emitted by [D-1.5] but absent from the output schema).
- schemas.py: disqualifier description lists D-1.5 + notes the open-string design (sanity_check_failed et al.).

Refs #583.

Suggested-by: Nicolas Krassas <3851678+dinosn@users.noreply.github.com>