### PR TITLE
test(stage_e): reusable harness measuring empirical-map LLM influence

### DIFF
--- a/packages/exploitability_validation/scripts/measure_stage_e_empirical_influence.py
+++ b/packages/exploitability_validation/scripts/measure_stage_e_empirical_influence.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Measure whether the Stage E LLM consumes ``empirical_mitigation_map``.
+
+PR #609 added ``analyze_binary_under_mitigations`` (empirical
+mitigation feasibility); PR #614 wired it into Stage E so each
+finding can carry an ``empirical_mitigation_map`` stanza. This
+harness answers the follow-up question: **does the LLM judge
+actually USE that stanza to shift its verdict, or is it
+decorative?**
+
+It poses the *same* confirmed stack-BOF finding to the configured
+LLM under four feasibility-evidence conditions and prints a
+comparison:
+
+  A. static-only            — no empirical map (pre-#614 behaviour)
+  B. empirical: mixed       — fires under hardened+asan, blocked
+                              under permissive+default-debian
+  C. empirical: all-blocked — witness never triggers, any profile
+  D. empirical: fires-on-deploy — bug fires under the deployment
+                              profile (default-debian), directly
+                              contradicting the static "canary
+                              present, looks unlikely" reasoning
+
+Expected (and observed 2026-05-24 on gemini-2.5-pro):
+
+  - B/C/D cite ``empirical_map`` as primary evidence; A falls back
+    to ``static_mitigations`` — the LLM consumes the map when present.
+  - A→D verdict shifts ``unlikely`` → ``difficult``: the empirical
+    "fires on deploy" fact overrides the static canary reasoning,
+    but the judge correctly stays ``difficult`` (not
+    ``likely_exploitable``) because the canary still constrains the
+    technique.
+
+This is a *measurement* harness, not a deterministic test — it
+makes real LLM calls (cost: one analysis call per condition, ~4
+total). Skips cleanly when no external LLM is configured.
+
+Run from the repo root:
+
+    python3 packages/exploitability_validation/scripts/measure_stage_e_empirical_influence.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+# packages/exploitability_validation/scripts/measure_stage_e_empirical_influence.py
+#   parents[0] = scripts/
+#   parents[1] = exploitability_validation/
+#   parents[2] = packages/
+#   parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+
+_SYSTEM = """You are RAPTOR's Stage E exploit-feasibility judge.
+
+Given a CONFIRMED memory-corruption finding plus binary/mitigation
+evidence, emit a feasibility verdict — one of:
+
+  - "likely_exploitable"  : exploitation is realistic on the deployed build
+  - "difficult"           : primitives exist but mitigations heavily constrain
+  - "unlikely"            : mitigations block the bug on the deployed build
+
+Weigh EMPIRICAL evidence (a witness was actually replayed against
+rebuilt binary variants) above REASONED evidence (static mitigation
+analysis) when both are present. The empirical map tells you which
+mitigation profiles actually let the bug fire when the real witness
+ran against them.
+
+Be honest and decisive. Cite the specific evidence that drove your
+verdict."""
+
+
+_DEPLOY_NOTE = (
+    "Deployment context: the production build is the "
+    "'default-debian' profile (PIE + stack-protector-strong + "
+    "partial RELRO + fortify=2)."
+)
+
+
+_MIXED_MAP = {
+    "summary": {
+        "bug_fired_under": ["hardened", "asan-only"],
+        "blocked_under": ["permissive", "default-debian"],
+        "unbuildable_profiles": [],
+    },
+    "witness_hash": "f48de165" + "0" * 56,
+    "witness_len": 21,
+    "match_reason": "exact finding-id match",
+}
+
+_ALL_BLOCKED_MAP = {
+    "summary": {
+        "bug_fired_under": [],
+        "blocked_under": ["permissive", "default-debian",
+                          "hardened", "asan-only"],
+        "unbuildable_profiles": [],
+    },
+    "witness_hash": "f48de165" + "0" * 56,
+    "witness_len": 21,
+    "match_reason": "exact finding-id match",
+}
+
+# The discriminator: empirical map shows the bug FIRES under the
+# deployment profile, contradicting the static "canary present →
+# unlikely" reasoning. A judge that weights empirical above reasoned
+# must flip the verdict up.
+_FIRES_ON_DEPLOY_MAP = {
+    "summary": {
+        "bug_fired_under": ["default-debian", "hardened", "asan-only"],
+        "blocked_under": ["permissive"],
+        "unbuildable_profiles": [],
+    },
+    "witness_hash": "f48de165" + "0" * 56,
+    "witness_len": 21,
+    "match_reason": "exact finding-id match",
+}
+
+
+_SCHEMA = {
+    "verdict": "string (likely_exploitable | difficult | unlikely)",
+    "reasoning": "string — 1-3 sentences citing the specific evidence",
+    "primary_evidence": "string (empirical_map | static_mitigations | source_only)",
+}
+
+
+def _finding_block(empirical):
+    """Render the finding + feasibility evidence as the Stage E LLM
+    would see it. ``empirical`` is the empirical_mitigation_map
+    stanza, or None for the static-only condition. The static
+    verdict is deliberately neutral ('difficult') so the empirical
+    map has room to move it in either direction."""
+    feasibility = {
+        "status": "analyzed",
+        "binary_path": "/opt/svc/target",
+        "verdict": "difficult",
+        "protections": {"PIE": True, "NX": True, "Canary": True,
+                        "RELRO": "Partial"},
+        "glibc": {"version": "2.38"},
+        "chain_breaks": ["Stack canary present on the deployed build"],
+        "impact": "code_execution",
+    }
+    if empirical is not None:
+        feasibility["empirical_mitigation_map"] = empirical
+
+    finding = {
+        "id": "FIND-BOF-1",
+        "vuln_type": "cwe_121_stack_buffer_overflow",
+        "cwe_id": "CWE-121",
+        "file": "src/parse.c",
+        "function": "parse_record",
+        "message": "strcpy of attacker-controlled bytes into an "
+                   "8-byte stack buffer; 20+ byte input overflows.",
+        "status": "confirmed",
+        "feasibility": feasibility,
+    }
+    return json.dumps(finding, indent=2)
+
+
+def _ask(client, condition, empirical):
+    prompt = (
+        f"{_DEPLOY_NOTE}\n\n"
+        f"Finding under review:\n\n{_finding_block(empirical)}\n\n"
+        f"Emit your feasibility verdict as JSON."
+    )
+    data, _ = client.generate_structured(
+        prompt=prompt,
+        schema=_SCHEMA,
+        system_prompt=_SYSTEM,
+        task_type="ANALYSE",
+    )
+    if isinstance(data, list):
+        data = data[0] if data and isinstance(data[0], dict) else {}
+    data = data or {}
+    return {
+        "condition": condition,
+        "verdict": data.get("verdict", "?"),
+        "primary_evidence": data.get("primary_evidence", "?"),
+        "reasoning": data.get("reasoning", "?"),
+    }
+
+
+def main() -> int:
+    from core.llm.detection import detect_llm_availability
+    if not detect_llm_availability().external_llm:
+        print("SKIP: no external LLM configured "
+              "(need ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI / etc.)")
+        return 0
+
+    from core.llm.client import LLMClient
+    from core.llm.config import LLMConfig
+
+    cfg = LLMConfig()
+    client = LLMClient(cfg)
+    print(
+        f"Model: {cfg.primary_model.provider}/"
+        f"{cfg.primary_model.model_name}\n"
+    )
+
+    conditions = [
+        ("A: static-only (no map)", None),
+        ("B: empirical mixed", _MIXED_MAP),
+        ("C: empirical all-blocked", _ALL_BLOCKED_MAP),
+        ("D: empirical FIRES on deploy", _FIRES_ON_DEPLOY_MAP),
+    ]
+    results = [_ask(client, name, m) for name, m in conditions]
+
+    print("=" * 78)
+    for r in results:
+        print(f"\n[{r['condition']}]")
+        print(f"  verdict          : {r['verdict']}")
+        print(f"  primary_evidence : {r['primary_evidence']}")
+        print(f"  reasoning        : {r['reasoning']}")
+    print("\n" + "=" * 78)
+
+    a, b, c, d = results
+    print("\nMeasurement read:")
+    print(f"  A (static reasoning) verdict  : {a['verdict']}")
+    print(f"  D (empirical fires on deploy) : {d['verdict']}")
+    shifted = a["verdict"] != d["verdict"]
+    print(
+        f"  A→D verdict shift: {a['verdict']} → {d['verdict']} "
+        f"({'SHIFTED — map overrides static' if shifted else 'NO CHANGE — map may be ignored'})"
+    )
+    cite_all = all(
+        r["primary_evidence"] == "empirical_map" for r in (b, c, d)
+    )
+    print(f"  B/C/D cite empirical_map as primary: {cite_all}")
+    print(
+        "\nInterpretation: a healthy result has B/C/D citing the "
+        "empirical map AND A→D shifting (the empirical fact "
+        "overriding the static canary reasoning). If A==D and the "
+        "map is never cited, the judge is ignoring the empirical "
+        "evidence — investigate the Stage E prompt."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
PR #614 wires empirical_mitigation_map into Stage E findings; this adds a re-runnable measurement harness that answers "does the LLM judge actually use it, or is it decorative?"

The harness poses one confirmed stack-BOF finding to the configured LLM under four feasibility-evidence conditions:

  A. static-only (no map) — pre-#614 behaviour
  B. empirical: mixed (blocked on the deployment profile)
  C. empirical: all-blocked
  D. empirical: fires-on-deploy — contradicts the static
     "canary present → unlikely" reasoning

and prints a verdict/evidence comparison plus an automated read.

Observed 2026-05-24 on gemini-2.5-pro:
  - B/C/D cite empirical_map as primary evidence; A falls back to static_mitigations — the LLM consumes the map when present.
  - A→D verdict shifts unlikely → difficult: the empirical fires-on-deploy fact overrides the static canary reasoning, but the judge correctly stays "difficult" (not likely_exploitable) because the canary still constrains the technique.

Measurement harness, not a deterministic CI test — it makes real LLM calls (4 per run) and skips cleanly when no external LLM is configured. Lives in packages/exploitability_validation/scripts/ alongside the other operator-facing e2e/measurement scripts.