### PR TITLE
fix(sca/harden): thread platform matrix into promotion-safety check

### DIFF
--- a/packages/sca/harden.py
+++ b/packages/sca/harden.py
@@ -304,6 +304,22 @@ def plan(
     for m in manifests:
         raw_deps.extend(parse_manifest(m))
 
+    # Derive the project's (arch, libc) platform matrix once for the
+    # whole run, from the target's committed build artifacts (Dockerfile
+    # FROM / buildx platforms / CI runs-on). Threaded into the promotion-
+    # safety check so a bump that drops a wheel-tag the project's declared
+    # platforms require demotes to review_required — same protection the
+    # ``bump`` subcommand gets. Static file-walk, no network, so it runs
+    # even under ``offline``. Defaults to {(x86_64, glibc 2.17)} when the
+    # repo declares no platforms (see platform_matrix.discover docs).
+    try:
+        from .platform_matrix import discover_platform_matrix
+        platform_matrix = discover_platform_matrix(target)
+    except Exception as exc:                          # noqa: BLE001
+        logger.debug("sca.harden: platform-matrix discovery failed "
+                     "(%s); promotion compat-check degrades to skip", exc)
+        platform_matrix = None
+
     out: List[HardenCandidate] = []
     for dep in raw_deps:
         if dep.commented_out:
@@ -318,7 +334,8 @@ def plan(
         out.append(_plan_one(dep, registries=registries, osv=osv,
                              kev=kev, epss=epss,
                              offline=offline, allow_major=allow_major,
-                             pin_only=pin_only))
+                             pin_only=pin_only,
+                             platform_matrix=platform_matrix))
     return out
 
 
@@ -332,6 +349,7 @@ def _plan_one(
     offline: bool,
     allow_major: bool,
     pin_only: bool = False,
+    platform_matrix=None,
 ) -> HardenCandidate:
     cand = HardenCandidate(
         ecosystem=dep.ecosystem,
@@ -490,6 +508,7 @@ def _plan_one(
         sc_findings = _evaluate_promotion_safety(
             dep=dep, target_version=target_version,
             registries=registries,
+            platform_matrix=platform_matrix,
         )
         if sc_findings:
             kinds = sorted({f.kind for f in sc_findings})
@@ -709,6 +728,7 @@ def _evaluate_promotion_safety(
     dep: Dependency,
     target_version: str,
     registries: Dict[str, Any],
+    platform_matrix=None,
 ) -> List[Any]:
     """Run ``evaluate_bump_supply_chain`` for ``dep → target_version``.
 
@@ -756,6 +776,7 @@ def _evaluate_promotion_safety(
             target_version=target_version,
             pypi_client=pypi_client,
             npm_client=npm_client,
+            platform_matrix=platform_matrix,
         )
     except Exception as e:                          # noqa: BLE001
         # Evaluator should be exception-safe for production callers,


### PR DESCRIPTION
`raptor-sca fix --harden` ran evaluate_bump_supply_chain without a platform_matrix, so the evaluator's platform_compat_regression guard (`platform_matrix is not None and non-empty`) silently skipped — the harden path had zero wheel-platform-compat protection. Only the `bump` subcommand derived + passed the matrix.

The scheduled sca-self-bump.yml uses `fix --harden`, so a bump that drops a wheel-tag the project's platforms require (canonical case: z3-solver 4.16.0.0 ships only manylinux_2_38_aarch64, breaking the aarch64/glibc-2.36 bookworm devcontainer) was auto-promoted Clean.

plan() now derives discover_platform_matrix(target) once per run and threads it through _plan_one → _evaluate_promotion_safety → evaluate_bump_supply_chain. Static file-walk, offline-safe, degrades to skip (matrix=None) on discovery error.

No platform declaration needed: the devcontainer Dockerfile's no-`--platform` `FROM ...bookworm` already implies the {x86_64, aarch64} @ glibc 2.36 support set via platform_matrix's multi-arch- by-convention rule. The fix self-dissolves — when the base moves bookworm→trixie the derived glibc rises and z3 un-caps automatically.

Verified end-to-end: z3-solver 4.16 moves promoted→review_required citing platform_compat_regression; 33 harden planner tests pass.