### PR TITLE
Reachability: dead-scope + module-load-abort gates

### DIFF
--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -39,6 +39,8 @@ from .call_graph import (
     extract_call_graph_rust,
 )
 from .diff import compare_inventories
+from .dead_scope import detect_dead_scopes
+from .module_load_abort import detect_module_load_abort
 
 logger = logging.getLogger(__name__)
 
@@ -548,6 +550,21 @@ def _process_single_file(
             '_stat': file_stat,
             'items': [item.to_dict() for item in items],
         }
+        # S3: per-function lexical-dead tagging. Functions whose
+        # definition lies inside an always-false guard (``if False:``,
+        # ``if (false) {…}``, ``#[cfg(any())]``) never bind — the
+        # guard's body never runs / compiles. The reachability prepass
+        # demotes such functions regardless of in-scope call edges
+        # (two dead-scope functions calling each other otherwise read
+        # as mutually CALLED). Tagged here (not in each extractor) so
+        # detection lives in one place per language; field is set only
+        # when dead so inventory size stays flat.
+        dead_ranges = detect_dead_scopes(language, content)
+        if dead_ranges:
+            for item_dict in record['items']:
+                ls = item_dict.get('line_start') or 0
+                if ls and any(lo <= ls <= hi for lo, hi in dead_ranges):
+                    item_dict['lexical_dead'] = True
         # Call-graph extraction. The resolver in
         # core.inventory.reachability is language-agnostic; per-file
         # extractors emit the same FileCallGraph dataclass for
@@ -604,6 +621,21 @@ def _process_single_file(
             record['call_graph'] = extract_call_graph_cpp(
                 content,
             ).to_dict()
+        # S4: file-level module-load-abort gate. When the file's
+        # top-level execution unconditionally aborts (raise
+        # ImportError / throw new Error / init() panic /
+        # compile_error!), no function it defines is reachable
+        # through import / link regardless of in-file call edges.
+        # The reachability resolver treats this as a whole-file
+        # NOT_REACHED gate. Stored only when detected so the field
+        # is absent (not False) on the overwhelming majority of
+        # files — keeps inventory size flat.
+        abort = detect_module_load_abort(language, content)
+        if abort is not None:
+            record['module_aborts_on_load'] = {
+                'line': abort.line,
+                'summary': abort.summary,
+            }
         return record
 
     except Exception as e:

--- a/core/inventory/dead_scope.py
+++ b/core/inventory/dead_scope.py
@@ -1,0 +1,273 @@
+"""Detect lexically dead scopes — blocks guarded by an always-false
+condition or build gate, inside which function definitions never bind.
+
+A function defined inside ``if False:`` (Python), ``if (false) {…}``
+(JS/TS), or behind ``#[cfg(any())]`` (Rust) is never created: the
+guard's body never executes / compiles. The substrate's call-graph
+analysis can't see this — two dead-scope functions that call each
+other read as mutually CALLED, masking that the whole scope is dead.
+
+This module returns the *line ranges* of dead scopes. The inventory
+builder maps function ``line_start`` values into those ranges and tags
+the matching items ``lexical_dead=True``; the reachability prepass
+then demotes them regardless of in-scope call edges.
+
+Conservative bias (same as :mod:`core.inventory.module_load_abort`):
+only fire on unambiguously-constant guards. ``if DEBUG:`` is NOT dead
+(DEBUG is a runtime name); ``if False:`` IS. ``#[cfg(test)]`` is NOT
+dead (it compiles under the test profile); ``#[cfg(any())]`` IS
+(an empty ``any()`` is the canonical always-false cfg). False
+negatives are cheap (miss a deferral); false positives are expensive
+(silence a real finding in live code).
+
+Per-language detection currently handled:
+
+  * Python: ``if <falsey-constant>:`` / ``while <falsey-constant>:``
+    — the BODY only (``else`` / ``elif`` branches stay live). Falsey
+    constants: ``False``, ``0``, ``0.0``, ``""``, ``None``.
+  * JavaScript / TypeScript: ``if (false) {…}`` / ``if (0) {…}`` at
+    any brace depth — the guarded block range.
+  * Rust: ``if false {…}`` blocks, and ``#[cfg(any())]`` /
+    ``#[cfg(all(any()))]`` attributes — the following ``fn`` block.
+
+Other languages return ``[]`` (no detector wired) — graceful
+degradation; the consumer treats absence as "no dead scope found",
+never as "everything is live".
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import re
+from typing import List, Tuple
+
+logger = logging.getLogger(__name__)
+
+# A dead scope is reported as an inclusive ``(start_line, end_line)``
+# 1-indexed range. A function whose ``line_start`` falls within any
+# returned range is lexically dead.
+DeadRange = Tuple[int, int]
+
+
+def detect_dead_scopes(language: str, content: str) -> List[DeadRange]:
+    """Per-language dispatch. Returns inclusive 1-indexed line ranges
+    of lexically dead scopes, or ``[]`` when none found (or the
+    language has no detector wired).
+
+    Best-effort: any parse failure returns ``[]``; the caller treats
+    absence as "no dead scope".
+    """
+    if not content:
+        return []
+    try:
+        if language == "python":
+            return _detect_python(content)
+        if language in ("javascript", "typescript"):
+            return _detect_javascript(content)
+        if language == "rust":
+            return _detect_rust(content)
+    except Exception:  # noqa: BLE001
+        return []
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Python
+# ---------------------------------------------------------------------------
+
+
+def _detect_python(content: str) -> List[DeadRange]:
+    import warnings
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", SyntaxWarning)
+            tree = ast.parse(content)
+    except SyntaxError:
+        return []
+    ranges: List[DeadRange] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.If, ast.While)) and _py_test_is_false(
+            node.test
+        ):
+            # Only the guard's BODY is dead — orelse (else / elif)
+            # stays live and is walked separately by ast.walk, so a
+            # const-false elif nested in orelse is still caught on its
+            # own iteration.
+            body = node.body
+            if not body:
+                continue
+            start = body[0].lineno
+            end = max(_py_end_line(s) for s in body)
+            ranges.append((start, end))
+    return ranges
+
+
+def _py_test_is_false(test: ast.expr) -> bool:
+    """True iff the guard expression is an unambiguous falsey literal
+    (``False`` / ``0`` / ``0.0`` / ``""`` / ``None``). Runtime names
+    (``if DEBUG:``) and any non-literal expression are NOT dead."""
+    if not isinstance(test, ast.Constant):
+        return False
+    return not bool(test.value)
+
+
+def _py_end_line(stmt: ast.stmt) -> int:
+    return getattr(stmt, "end_lineno", None) or stmt.lineno
+
+
+# ---------------------------------------------------------------------------
+# JavaScript / TypeScript — brace-tracked ``if (false) {…}`` blocks.
+# Regex finds the guard header; manual brace matching finds the block
+# extent (no stdlib JS AST; tree-sitter would be heavier than needed).
+# ---------------------------------------------------------------------------
+
+
+_JS_LINE_COMMENT = re.compile(r"//[^\n]*")
+_JS_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+_JS_DEAD_IF = re.compile(r"\bif\s*\(\s*(?:false|0)\s*\)\s*\{")
+
+
+def _detect_javascript(content: str) -> List[DeadRange]:
+    stripped = _js_strip_comments(content)
+    ranges: List[DeadRange] = []
+    for m in _JS_DEAD_IF.finditer(stripped):
+        # The opening brace is the last char of the match.
+        brace_pos = m.end() - 1
+        close = _match_brace(stripped, brace_pos)
+        if close is None:
+            continue
+        start_line = stripped.count("\n", 0, m.start()) + 1
+        end_line = stripped.count("\n", 0, close) + 1
+        ranges.append((start_line, end_line))
+    return ranges
+
+
+def _js_strip_comments(content: str) -> str:
+    def _spaces(m: "re.Match[str]") -> str:
+        return re.sub(r"[^\n]", " ", m.group(0))
+    out = _JS_BLOCK_COMMENT.sub(_spaces, content)
+    out = _JS_LINE_COMMENT.sub(_spaces, out)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Rust — ``if false {…}`` blocks plus ``#[cfg(any())]`` attributes
+# (empty ``any()`` is the canonical always-false cfg) gating a fn.
+# ---------------------------------------------------------------------------
+
+
+_RUST_DEAD_IF = re.compile(r"\bif\s+false\s*\{")
+# ``#[cfg(any())]`` or ``#[cfg(all(any()))]`` — empty any() is false,
+# and all(false) is false. Whitespace-tolerant.
+_RUST_DEAD_CFG = re.compile(
+    r"#\s*\[\s*cfg\s*\(\s*(?:any\s*\(\s*\)|all\s*\(\s*any\s*\(\s*\)\s*\))\s*\)\s*\]"
+)
+# The IMMEDIATELY-following item, allowing chained attributes,
+# visibility and fn qualifiers between the cfg and the keyword. An
+# always-false cfg gates exactly the next item — so we only range it
+# when that item is a ``fn`` or ``mod`` (whose body is then dead). If
+# the cfg gates a non-fn/mod item (``struct`` / ``const`` / ``use`` /
+# ``impl`` / ``static``) we must NOT grab an unrelated ``fn`` later in
+# the file — that was a false positive flagging live code as dead.
+_RUST_ITEM_AFTER_CFG = re.compile(
+    r"\s*(?:#\s*\[[^\]]*\]\s*)*"                       # chained attrs
+    r"(?:pub\s*(?:\([^)]*\)\s*)?)?"                    # visibility
+    r"(?:(?:async|unsafe|const|extern(?:\s+\"[^\"]*\")?)\s+)*"  # qualifiers
+    r"(fn|mod)\b"
+)
+
+
+def _detect_rust(content: str) -> List[DeadRange]:
+    ranges: List[DeadRange] = []
+    # ``if false { … }`` blocks.
+    for m in _RUST_DEAD_IF.finditer(content):
+        brace_pos = m.end() - 1
+        close = _match_brace(content, brace_pos)
+        if close is None:
+            continue
+        start_line = content.count("\n", 0, m.start()) + 1
+        end_line = content.count("\n", 0, close) + 1
+        ranges.append((start_line, end_line))
+    # ``#[cfg(any())]`` gating the immediately-following fn / mod.
+    for m in _RUST_DEAD_CFG.finditer(content):
+        after = content[m.end():]
+        if not _RUST_ITEM_AFTER_CFG.match(after):
+            # cfg gates a non-fn/mod item — do not range (avoids the
+            # false positive of grabbing an unrelated later fn).
+            continue
+        # First ``{`` after the attribute is the gated item's body —
+        # nothing between the cfg and the body uses braces (attributes
+        # use ``[]``, visibility uses ``()``, generics use ``<>``).
+        brace_rel = after.find("{")
+        if brace_rel == -1:
+            continue
+        close = _match_brace(content, m.end() + brace_rel)
+        if close is None:
+            continue
+        # Range spans from the attribute to the item's closing brace,
+        # so the fn/mod ``line_start`` is captured (and, for mod, every
+        # nested fn inside the dead module).
+        start_line = content.count("\n", 0, m.start()) + 1
+        end_line = content.count("\n", 0, close) + 1
+        ranges.append((start_line, end_line))
+    return ranges
+
+
+# ---------------------------------------------------------------------------
+# Shared — brace matcher with string / char / line-comment skipping.
+# ---------------------------------------------------------------------------
+
+
+def _match_brace(source: str, open_pos: int) -> "int | None":
+    """Given the index of an opening ``{``, return the index of the
+    matching ``}``. Skips string / template / char literals and line
+    comments so braces inside them don't unbalance the count. Returns
+    None on malformed input."""
+    if open_pos < 0 or open_pos >= len(source) or source[open_pos] != "{":
+        return None
+    depth = 1
+    i = open_pos + 1
+    n = len(source)
+    while i < n:
+        c = source[i]
+        if c in "\"'`":
+            j = _skip_string(source, i)
+            if j is None:
+                return None
+            i = j
+            continue
+        if c == "/" and i + 1 < n and source[i + 1] == "/":
+            nl = source.find("\n", i)
+            if nl == -1:
+                return None
+            i = nl + 1
+            continue
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return None
+
+
+def _skip_string(source: str, start: int) -> "int | None":
+    """Advance past a string / template / char literal starting at
+    ``start``. Handles backslash escapes."""
+    quote = source[start]
+    i = start + 1
+    n = len(source)
+    while i < n:
+        c = source[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == quote:
+            return i + 1
+        i += 1
+    return None
+
+
+__all__ = ["DeadRange", "detect_dead_scopes"]

--- a/core/inventory/extractors.py
+++ b/core/inventory/extractors.py
@@ -154,6 +154,20 @@ class PythonExtractor:
                 functions.append(self._extract_function(child, class_name))
                 # Walk into nested functions/classes
                 self._walk(child, functions, class_name=class_name)
+            else:
+                # Descend into compound statements (if / try / with /
+                # for / while / match) so functions nested inside them
+                # are still captured. tree-sitter extraction already
+                # does this; the stdlib fallback previously stopped at
+                # the first non-class/def node, so functions inside
+                # e.g. ``if False:`` guards, ``try/except`` import
+                # fallbacks, or context managers were invisible to
+                # inventory + reachability on tree-sitter-less
+                # environments. class_name is preserved — these nodes
+                # don't open a class scope. Only FunctionDef nodes are
+                # collected, so recursing through expression children
+                # is harmless (lambdas are ast.Lambda, not FunctionDef).
+                self._walk(child, functions, class_name=class_name)
 
     def _extract_function(self, node: ast.AST, class_name: Optional[str]) -> FunctionInfo:
         """Extract a single function with full metadata."""

--- a/core/inventory/module_load_abort.py
+++ b/core/inventory/module_load_abort.py
@@ -1,0 +1,402 @@
+"""Detect unconditional module-load aborts at file scope.
+
+When a source file's top-level execution unconditionally raises /
+throws / panics before any function binding completes, no function
+defined in that file is reachable through normal import / link. The
+substrate's call-graph analysis can't see this — it counts call
+edges between in-file functions and reports CALLED for any function
+referenced by another, even though the entire file is unloadable.
+
+This module adds per-language detection: a single helper
+:func:`detect_module_load_abort` returns either ``None`` (no abort
+detected) or a structured record describing what was found.
+Consumers (the inventory builder + the reachability prepass) treat
+detected aborts as a file-level reachability gate — every function
+in the file is marked dead regardless of in-file call edges.
+
+Conservative bias: the detection only fires when the abort is
+unambiguously unconditional. ``raise ImportError`` inside
+``if sys.version_info < (3, 10):`` is NOT flagged — the file may
+still import on the supported-version branch. ``func init() { if
+config == nil { panic(...) } }`` is NOT flagged — the panic is
+config-gated. False negatives are cheap (we miss a deferral
+opportunity); false positives are expensive (we silence a real
+finding on a file that's actually loadable).
+
+Per-language detection currently handled:
+
+  * Python: ``raise <AbortException>(...)`` at module scope, NOT
+    inside any conditional. Recognised exceptions:
+    ``ImportError``, ``ModuleNotFoundError``, ``SystemExit``,
+    ``RuntimeError``, ``NotImplementedError``.
+  * JavaScript / TypeScript: ``throw new <NameError>(...)`` at
+    brace-depth zero (module scope), before any function binding.
+  * Go: ``func init() { panic(...) }`` where the panic is at the
+    init body's top scope (not inside a conditional / loop).
+  * Rust: ``compile_error!(...)`` at module scope.
+
+Other languages return ``None`` (no detection wired) — same
+graceful-degradation pattern as the call-graph extractors. The
+consumer treats absence as "no abort detected", never as "file is
+guaranteed loadable".
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ModuleLoadAbort:
+    """Describes a detected unconditional module-load abort.
+
+    ``line``: 1-indexed line number of the abort statement.
+    ``summary``: short human-readable label for prompts / logs —
+    e.g. ``"raise ImportError"`` or ``"func init() { panic(...) }"``.
+    Consumers display this verbatim; keep it concise.
+    """
+    line: int
+    summary: str
+
+
+def detect_module_load_abort(
+    language: str, content: str,
+) -> Optional[ModuleLoadAbort]:
+    """Per-language dispatch. Returns the first detected unconditional
+    abort, or ``None`` when no abort is detected (or the language
+    has no detector wired).
+
+    Best-effort: any parse failure inside a per-language detector
+    returns ``None``; the caller treats absence as "no signal".
+    """
+    if not content:
+        return None
+    try:
+        if language == "python":
+            return _detect_python(content)
+        if language in ("javascript", "typescript"):
+            return _detect_javascript(content)
+        if language == "go":
+            return _detect_go(content)
+        if language == "rust":
+            return _detect_rust(content)
+    except Exception:  # noqa: BLE001
+        # Detection failures are non-fatal — the consumer treats
+        # ``None`` as "no abort detected", which matches the
+        # graceful-degradation pattern the call-graph extractors
+        # use when their grammar dep is missing.
+        return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Python
+# ---------------------------------------------------------------------------
+
+
+_PY_ABORT_EXCEPTIONS = frozenset({
+    "ImportError",
+    "ModuleNotFoundError",
+    "SystemExit",
+    "RuntimeError",
+    "NotImplementedError",
+})
+
+
+def _detect_python(content: str) -> Optional[ModuleLoadAbort]:
+    try:
+        tree = ast.parse(content)
+    except SyntaxError:
+        return None
+    # Walk module-scope statements in order. A ``raise`` at module
+    # scope (i.e. directly in tree.body, not nested inside any
+    # If / Try / With / For / While) runs unconditionally at import
+    # time and aborts before any def below it binds.
+    for node in tree.body:
+        if isinstance(node, ast.Raise) and _py_is_abort_raise(node):
+            return ModuleLoadAbort(
+                line=node.lineno,
+                summary=_py_summarise_raise(node),
+            )
+    return None
+
+
+def _py_is_abort_raise(node: ast.Raise) -> bool:
+    """Is this a ``raise SomeAbortError(...)`` (or bare class)
+    matching the abort-exception allow-list?
+
+    Bare ``raise`` with no exception (a re-raise inside an except
+    handler) doesn't apply at module scope — module-scope ast.Raise
+    nodes with exc=None can't actually execute meaningfully but the
+    AST allows them; defensively treat as not-an-abort.
+    """
+    if node.exc is None:
+        return False
+    exc = node.exc
+    name = None
+    if isinstance(exc, ast.Call):
+        if isinstance(exc.func, ast.Name):
+            name = exc.func.id
+        elif isinstance(exc.func, ast.Attribute):
+            name = exc.func.attr
+    elif isinstance(exc, ast.Name):
+        name = exc.id
+    elif isinstance(exc, ast.Attribute):
+        name = exc.attr
+    return name in _PY_ABORT_EXCEPTIONS
+
+
+def _py_summarise_raise(node: ast.Raise) -> str:
+    if node.exc is None:
+        return "raise"
+    exc = node.exc
+    if isinstance(exc, ast.Call):
+        if isinstance(exc.func, ast.Name):
+            return f"raise {exc.func.id}"
+        if isinstance(exc.func, ast.Attribute):
+            return f"raise {exc.func.attr}"
+    if isinstance(exc, ast.Name):
+        return f"raise {exc.id}"
+    if isinstance(exc, ast.Attribute):
+        return f"raise {exc.attr}"
+    return "raise"
+
+
+# ---------------------------------------------------------------------------
+# JavaScript / TypeScript — regex with brace-depth tracking. No AST
+# in stdlib; pulling tree-sitter just for this detector is overkill
+# (the call-graph extractor already does that work). False-negative
+# bias on ambiguous cases is acceptable.
+# ---------------------------------------------------------------------------
+
+
+_JS_LINE_COMMENT = re.compile(r"//[^\n]*")
+_JS_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+# Any ``throw new <Capitalized>`` at module scope aborts load — the
+# class need not be named ``*Error`` (``throw new Disabled()`` counts).
+# Capitalised initial keeps us off ``throw new lowerCaseFactory()``
+# false-positives where a value (not an error) is being constructed.
+_JS_THROW_NEW = re.compile(
+    r"\bthrow\s+new\s+([A-Z][A-Za-z0-9_]*)\b"
+)
+
+
+def _detect_javascript(content: str) -> Optional[ModuleLoadAbort]:
+    # Strip comments first so commented-out throw text doesn't trip
+    # the regex. Replace with whitespace of equal length to preserve
+    # line/offset arithmetic for the line-number report.
+    def _spaces(m: re.Match[str]) -> str:
+        return re.sub(r"[^\n]", " ", m.group(0))
+    stripped = _JS_BLOCK_COMMENT.sub(_spaces, content)
+    stripped = _JS_LINE_COMMENT.sub(_spaces, stripped)
+    # Walk character-by-character tracking brace and paren depth.
+    # An unconditional module-level throw is one at depth zero
+    # before any function body opens it. String / template / char
+    # literals are skipped wholesale — without this a function body
+    # containing a string with an unbalanced brace (``const s =
+    # "}";``) corrupts the depth counter and a throw INSIDE the
+    # function reads as depth-zero, a false-positive module-abort
+    # that would silence every finding below it.
+    depth = 0
+    paren = 0
+    i = 0
+    n = len(stripped)
+    while i < n:
+        c = stripped[i]
+        if c in "\"'`":
+            j = _js_skip_string(stripped, i)
+            if j is None:
+                break
+            i = j
+            continue
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth = max(0, depth - 1)
+        elif c == "(":
+            paren += 1
+        elif c == ")":
+            paren = max(0, paren - 1)
+        elif c == "t" and depth == 0 and paren == 0:
+            m = _JS_THROW_NEW.match(stripped, i)
+            if m:
+                line_no = stripped.count("\n", 0, i) + 1
+                err_name = m.group(1)
+                return ModuleLoadAbort(
+                    line=line_no,
+                    summary=f"throw new {err_name}",
+                )
+        i += 1
+    return None
+
+
+def _js_skip_string(source: str, start: int) -> Optional[int]:
+    """Advance past a JS string / template / char literal beginning at
+    ``start``. Returns the index just past the closing quote, or
+    ``None`` on an unterminated literal. Handles backslash escapes;
+    treats template literals (`` ` ``) as opaque (``${…}`` interior is
+    skipped wholesale — conservative for abort detection)."""
+    quote = source[start]
+    i = start + 1
+    n = len(source)
+    while i < n:
+        c = source[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == quote:
+            return i + 1
+        i += 1
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Go — ``func init() { panic(...) }`` where the panic is at the init
+# body's top scope (not gated by an enclosing conditional). Regex-based;
+# tree-sitter-go usage would be heavier than warranted for this single
+# detector.
+# ---------------------------------------------------------------------------
+
+
+_GO_INIT_HEADER = re.compile(r"\bfunc\s+init\s*\(\s*\)\s*\{")
+_GO_PANIC_CALL = re.compile(r"\bpanic\s*\(")
+
+
+def _detect_go(content: str) -> Optional[ModuleLoadAbort]:
+    init_match = _GO_INIT_HEADER.search(content)
+    if not init_match:
+        return None
+    body_start = init_match.end()
+    body_end = _go_find_matching_brace(content, body_start - 1)
+    if body_end is None:
+        return None
+    init_body = content[body_start:body_end]
+    panic_match = _GO_PANIC_CALL.search(init_body)
+    if not panic_match:
+        return None
+    # Panic must be at init body's top scope (not inside any
+    # nested block — if / for / switch / select). If brace depth
+    # at the panic's location relative to the body is > 0, it's
+    # conditional.
+    if not _go_panic_is_unconditional(init_body, panic_match.start()):
+        return None
+    # Convert body-relative offset to absolute line number.
+    abs_offset = body_start + panic_match.start()
+    line_no = content.count("\n", 0, abs_offset) + 1
+    return ModuleLoadAbort(
+        line=line_no,
+        summary="func init() { panic(...) }",
+    )
+
+
+def _go_find_matching_brace(source: str, open_pos: int) -> Optional[int]:
+    """Given index of an opening ``{``, return index of the
+    matching closing ``}``. Returns None on malformed input."""
+    if open_pos < 0 or open_pos >= len(source) or source[open_pos] != "{":
+        return None
+    depth = 1
+    i = open_pos + 1
+    n = len(source)
+    while i < n and depth > 0:
+        c = source[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+        elif c in '"`':
+            j = _go_skip_string(source, i)
+            if j is None:
+                return None
+            i = j
+            continue
+        i += 1
+    return None
+
+
+def _go_skip_string(source: str, start: int) -> Optional[int]:
+    """Advance past a Go string literal starting at ``start``.
+    Handles both interpreted (``"…"``) and raw (`` `…` ``) strings.
+    """
+    quote = source[start]
+    i = start + 1
+    n = len(source)
+    while i < n:
+        c = source[i]
+        if c == "\\" and quote == '"':
+            i += 2
+            continue
+        if c == quote:
+            return i + 1
+        i += 1
+    return None
+
+
+def _go_panic_is_unconditional(body: str, panic_offset: int) -> bool:
+    """The panic is unconditional iff brace depth at its location
+    (relative to the init body) is zero — i.e. it's a statement
+    directly in the function body, not nested inside any conditional
+    block (if / for / switch / select)."""
+    depth = 0
+    i = 0
+    while i < panic_offset:
+        c = body[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth = max(0, depth - 1)
+        elif c in '"`':
+            j = _go_skip_string(body, i)
+            if j is None:
+                return False
+            i = j
+            continue
+        i += 1
+    return depth == 0
+
+
+# ---------------------------------------------------------------------------
+# Rust — ``compile_error!(...)`` at module scope. Triggers at
+# compile time; module never compiles, hence never loads. Macro
+# may also appear inside ``#[cfg(...)]`` gates — those are
+# conditional on build features and we conservatively do NOT
+# flag them (build configuration is out of scope for static
+# analysis).
+# ---------------------------------------------------------------------------
+
+
+_RUST_COMPILE_ERROR = re.compile(
+    r"^\s*compile_error\s*!\s*\(", re.MULTILINE,
+)
+
+
+def _detect_rust(content: str) -> Optional[ModuleLoadAbort]:
+    # Naive but effective: compile_error! at line start (after any
+    # leading whitespace) with no preceding ``#[cfg`` attribute on
+    # the same logical statement. The substrate doesn't model cfg
+    # gates; we conservatively flag any unconditional compile_error
+    # and treat cfg-gated ones as out of scope (false-negative bias).
+    m = _RUST_COMPILE_ERROR.search(content)
+    if not m:
+        return None
+    # Check that the preceding non-whitespace token isn't ``]`` (end
+    # of an attribute). A bare attribute-attached compile_error like
+    # ``#[cfg(...)] compile_error!(...)`` is conditional; skip it.
+    before = content[: m.start()].rstrip()
+    if before.endswith("]"):
+        return None
+    line_no = content.count("\n", 0, m.start()) + 1
+    return ModuleLoadAbort(
+        line=line_no,
+        summary="compile_error!(...)",
+    )
+
+
+__all__ = ["ModuleLoadAbort", "detect_module_load_abort"]

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -2133,6 +2133,91 @@ def is_registered_via_call(
     return target in idx.framework_registered
 
 
+def module_aborts_on_load(
+    inventory: Dict[str, Any],
+    file_path: str,
+) -> Optional[Dict[str, Any]]:
+    """Return the module-load-abort record for ``file_path`` if the
+    inventory builder detected an unconditional top-of-module abort
+    (``raise ImportError`` / ``throw new Error`` / ``init() panic`` /
+    ``compile_error!``), else ``None``.
+
+    When non-None, no function defined in the file (at or below the
+    abort's line) is reachable through normal import / link: the
+    file's top-level execution aborts before those bindings complete.
+    Consumers treat this as a whole-file reachability gate that
+    supersedes in-file call edges — a function called only by peers
+    in the same aborting file is still dead, because the file never
+    finishes loading.
+
+    The returned dict carries ``line`` (1-indexed location of the
+    abort) and ``summary`` (short label, e.g. ``"raise ImportError"``)
+    — see :class:`core.inventory.module_load_abort.ModuleLoadAbort`.
+    Detected at inventory-build time and stored on the file record;
+    this accessor is a simple path-keyed lookup (no index build).
+    """
+    if not file_path:
+        return None
+    normalised = file_path.replace("\\", "/")
+    for file_record in inventory.get("files", []):
+        if not isinstance(file_record, dict):
+            continue
+        rec_path = file_record.get("path")
+        if not isinstance(rec_path, str):
+            continue
+        if rec_path.replace("\\", "/") == normalised:
+            abort = file_record.get("module_aborts_on_load")
+            return abort if isinstance(abort, dict) else None
+    return None
+
+
+def is_lexically_dead(
+    inventory: Dict[str, Any],
+    file_path: str,
+    name: str,
+    line: int = 0,
+) -> bool:
+    """True iff ``name`` (at ``line``, when given) is defined inside a
+    lexically dead scope — an always-false guard (``if False:`` /
+    ``if (false) {…}`` / ``#[cfg(any())]``) whose body never executes
+    or compiles, so the function never binds (S3).
+
+    Consumers treat this like a per-function reachability gate that
+    supersedes in-scope call edges: two dead-scope functions calling
+    each other read as mutually CALLED in the static graph, but the
+    whole scope is dead. Detected at inventory-build time and stored
+    as ``lexical_dead=True`` on the matching item; this accessor is a
+    path/name-keyed lookup (no index build).
+
+    Match is exact on ``(name, line)`` when ``line > 0`` — defensive
+    against shadowed names / overloads. With ``line == 0`` it matches
+    by name within the file (first hit wins). Returns ``False`` when
+    the file or function isn't found (false-negative-safe: never
+    claims dead when uncertain).
+    """
+    if not file_path or not name:
+        return False
+    normalised = file_path.replace("\\", "/")
+    for file_record in inventory.get("files", []):
+        if not isinstance(file_record, dict):
+            continue
+        rec_path = file_record.get("path")
+        if not isinstance(rec_path, str):
+            continue
+        if rec_path.replace("\\", "/") != normalised:
+            continue
+        for item in file_record.get("items", []):
+            if not isinstance(item, dict):
+                continue
+            if item.get("name") != name:
+                continue
+            if line and item.get("line_start") != line:
+                continue
+            return bool(item.get("lexical_dead"))
+        return False
+    return False
+
+
 def callees_of(
     inventory: Dict[str, Any],
     source: InternalFunction,
@@ -2712,7 +2797,9 @@ __all__ = [
     "forward_closure",
     "function_called",
     "is_framework_callable",
+    "is_lexically_dead",
     "is_registered_via_call",
+    "module_aborts_on_load",
     "parse_evidence_entry",
     "reverse_closure",
     "shortest_path",

--- a/core/inventory/tests/test_dead_scope.py
+++ b/core/inventory/tests/test_dead_scope.py
@@ -1,0 +1,267 @@
+"""Tests for :mod:`core.inventory.dead_scope` (S3).
+
+Covers per-language detection of always-false lexical guards plus the
+conservative-bias negatives (runtime-name guards and build-profile
+cfgs must NOT fire — false positives silence real findings).
+"""
+
+from __future__ import annotations
+
+from core.inventory.dead_scope import detect_dead_scopes
+
+
+# ---------------------------------------------------------------------------
+# Python
+# ---------------------------------------------------------------------------
+
+
+def test_python_if_false_body_detected():
+    src = (
+        "if False:\n"
+        "    def dead(x):\n"
+        "        return x\n"
+        "\n"
+        "def live():\n"
+        "    return 1\n"
+    )
+    ranges = detect_dead_scopes("python", src)
+    # if-False body spans the def + its body (lines 2-3).
+    assert (2, 3) in ranges
+
+
+def test_python_if_zero_detected():
+    src = "if 0:\n    pass\n"
+    assert detect_dead_scopes("python", src) == [(2, 2)]
+
+
+def test_python_while_false_detected():
+    src = "while False:\n    do_thing()\n"
+    assert detect_dead_scopes("python", src) == [(2, 2)]
+
+
+def test_python_if_true_not_detected():
+    # if True: is live.
+    assert detect_dead_scopes("python", "if True:\n    pass\n") == []
+
+
+def test_python_runtime_name_guard_not_detected():
+    # if DEBUG: is a runtime condition, not a constant — must NOT fire.
+    src = "if DEBUG:\n    def maybe(): pass\n"
+    assert detect_dead_scopes("python", src) == []
+
+
+def test_python_else_branch_not_marked_dead():
+    # The else branch of `if False:` is LIVE — only the body is dead.
+    src = (
+        "if False:\n"
+        "    dead_call()\n"      # line 2 (dead)
+        "else:\n"
+        "    live_call()\n"      # line 4 (live)
+    )
+    ranges = detect_dead_scopes("python", src)
+    # The dead body is line 2; line 4 (else) must not be in any range.
+    assert any(lo <= 2 <= hi for lo, hi in ranges)
+    assert not any(lo <= 4 <= hi for lo, hi in ranges)
+
+
+def test_python_syntax_error_returns_empty():
+    assert detect_dead_scopes("python", "def (:\n") == []
+
+
+# ---------------------------------------------------------------------------
+# JavaScript / TypeScript
+# ---------------------------------------------------------------------------
+
+
+def test_js_if_false_block_detected():
+    src = (
+        "function alive() { return 1; }\n"
+        "if (false) {\n"
+        "  function deadJs(p) { eval(p); }\n"
+        "}\n"
+    )
+    ranges = detect_dead_scopes("javascript", src)
+    assert (2, 4) in ranges
+
+
+def test_js_if_zero_detected():
+    src = "if (0) {\n  bad();\n}\n"
+    assert (1, 3) in detect_dead_scopes("javascript", src)
+
+
+def test_js_if_true_not_detected():
+    assert detect_dead_scopes("javascript", "if (true) {\n  ok();\n}\n") == []
+
+
+def test_js_runtime_guard_not_detected():
+    src = "if (cfg.disabled) {\n  bad();\n}\n"
+    assert detect_dead_scopes("javascript", src) == []
+
+
+def test_js_commented_if_false_not_detected():
+    src = "// if (false) {\n/* if (false) { */\nconst ok = 1;\n"
+    assert detect_dead_scopes("javascript", src) == []
+
+
+def test_typescript_alias_detected():
+    src = "if (false) {\n  bad();\n}\n"
+    assert detect_dead_scopes("typescript", src) == [(1, 3)]
+
+
+# ---------------------------------------------------------------------------
+# Rust
+# ---------------------------------------------------------------------------
+
+
+def test_rust_cfg_any_empty_gates_fn():
+    src = (
+        "#[cfg(any())]\n"
+        "fn dead_rs() {\n"
+        "    dangerous();\n"
+        "}\n"
+        "fn live_rs() {}\n"
+    )
+    ranges = detect_dead_scopes("rust", src)
+    # Range spans the attribute through the fn's closing brace so the
+    # fn line_start (line 2) is captured.
+    assert any(lo <= 2 <= hi for lo, hi in ranges)
+    # live_rs (line 5) is NOT in a dead range.
+    assert not any(lo <= 5 <= hi for lo, hi in ranges)
+
+
+def test_rust_if_false_block_detected():
+    src = (
+        "fn f() {\n"
+        "    if false {\n"
+        "        dangerous();\n"
+        "    }\n"
+        "}\n"
+    )
+    ranges = detect_dead_scopes("rust", src)
+    assert (2, 4) in ranges
+
+
+def test_rust_cfg_test_not_detected():
+    # #[cfg(test)] compiles under the test profile — NOT always-false.
+    src = "#[cfg(test)]\nfn t() {}\n"
+    assert detect_dead_scopes("rust", src) == []
+
+
+def test_rust_cfg_feature_not_detected():
+    src = '#[cfg(feature = "x")]\nfn f() {}\n'
+    assert detect_dead_scopes("rust", src) == []
+
+
+def test_rust_cfg_on_struct_does_not_grab_later_fn():
+    # Adversarial false-positive: #[cfg(any())] gating a STRUCT must
+    # NOT range an unrelated `fn` further down the file. Pre-fix the
+    # detector grabbed the next fn anywhere, tagging live code dead.
+    src = (
+        "#[cfg(any())]\n"
+        "struct Dead;\n"
+        "\n"
+        "fn totally_live() {\n"
+        "    dangerous();\n"
+        "}\n"
+    )
+    ranges = detect_dead_scopes("rust", src)
+    assert not any(lo <= 4 <= hi for lo, hi in ranges), (
+        "live fn must not be tagged when cfg gates a non-fn item"
+    )
+
+
+def test_rust_cfg_on_const_does_not_grab_later_fn():
+    src = (
+        "#[cfg(any())]\n"
+        "const X: u32 = 1;\n"
+        "fn live() { ok(); }\n"
+    )
+    assert detect_dead_scopes("rust", src) == []
+
+
+def test_rust_cfg_chained_attrs_then_fn():
+    # cfg + other attributes + visibility qualifiers still resolve to
+    # the gated fn.
+    src = (
+        "#[cfg(any())]\n"
+        "#[inline]\n"
+        "pub fn dead() {\n"
+        "    bad();\n"
+        "}\n"
+    )
+    ranges = detect_dead_scopes("rust", src)
+    assert any(lo <= 3 <= hi for lo, hi in ranges)
+
+
+def test_rust_cfg_on_mod_ranges_module_body():
+    # #[cfg(any())] gating a module makes everything inside dead —
+    # the range covers the nested fn.
+    src = (
+        "#[cfg(any())]\n"
+        "mod dead {\n"
+        "    fn g() { bad(); }\n"
+        "}\n"
+        "fn live() {}\n"
+    )
+    ranges = detect_dead_scopes("rust", src)
+    assert any(lo <= 3 <= hi for lo, hi in ranges)   # nested fn g
+    assert not any(lo <= 5 <= hi for lo, hi in ranges)  # live fn
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting
+# ---------------------------------------------------------------------------
+
+
+def test_empty_content_returns_empty():
+    assert detect_dead_scopes("python", "") == []
+
+
+def test_unwired_language_returns_empty():
+    # Go has a call-graph extractor but no dead-scope detector — must
+    # degrade gracefully (no false "live" claim, just no signal).
+    assert detect_dead_scopes("go", "if false {\n  bad()\n}\n") == []
+
+
+def test_clean_python_no_dead_scope():
+    src = "def handler(x):\n    return x\n"
+    assert detect_dead_scopes("python", src) == []
+
+
+# ---------------------------------------------------------------------------
+# Builder wiring + resolver accessor
+# ---------------------------------------------------------------------------
+
+
+def test_builder_tags_lexical_dead(tmp_path):
+    import tempfile
+    from core.inventory.builder import build_inventory
+    from core.inventory.reachability import is_lexically_dead
+
+    (tmp_path / "mod.py").write_text(
+        "if False:\n"
+        "    def dead_fn(x):\n"
+        "        import os\n"
+        "        os.system(x)\n"
+        "\n"
+        "def live_fn(y):\n"
+        "    return y\n"
+    )
+    with tempfile.TemporaryDirectory() as td:
+        inv = build_inventory(str(tmp_path), td)
+
+    items = {
+        it["name"]: it
+        for it in {f["path"]: f for f in inv["files"]}["mod.py"]["items"]
+    }
+    assert items["dead_fn"].get("lexical_dead") is True
+    assert "lexical_dead" not in items["live_fn"]
+
+    # Accessor: exact (name, line) match.
+    assert is_lexically_dead(inv, "mod.py", "dead_fn", 2) is True
+    assert is_lexically_dead(inv, "mod.py", "live_fn", 6) is False
+    # Name-only match (line=0) also works.
+    assert is_lexically_dead(inv, "mod.py", "dead_fn") is True
+    # Unknown function / file → False (never claims dead when unsure).
+    assert is_lexically_dead(inv, "mod.py", "ghost", 0) is False
+    assert is_lexically_dead(inv, "nope.py", "dead_fn", 2) is False

--- a/core/inventory/tests/test_extractors.py
+++ b/core/inventory/tests/test_extractors.py
@@ -112,6 +112,31 @@ class TestPythonExtractor:
         funcs = PythonExtractor().extract("t.py", code)
         assert funcs[0].line_end == 3
 
+    def test_function_inside_compound_statement_extracted(self):
+        # The stdlib walker must descend into compound statements (if /
+        # try / with / for / while) so nested functions are captured —
+        # matching tree-sitter. Pre-fix it stopped at the first non-
+        # class/def node, so functions inside ``if False:`` guards or
+        # ``try/except`` import fallbacks were invisible to inventory +
+        # reachability on tree-sitter-less environments. Required for
+        # the dead-scope reachability gate to have anything to tag.
+        code = (
+            "if False:\n"
+            "    def dead_fn(x):\n"
+            "        return x\n"
+            "\n"
+            "try:\n"
+            "    import fast\n"
+            "except ImportError:\n"
+            "    def fallback(y):\n"
+            "        return y\n"
+            "\n"
+            "def live(z):\n"
+            "    return z\n"
+        )
+        names = {f.name for f in PythonExtractor().extract("t.py", code)}
+        assert names == {"dead_fn", "fallback", "live"}
+
 
 # ---------------------------------------------------------------------------
 # Regex extractors — basic metadata

--- a/core/inventory/tests/test_module_load_abort.py
+++ b/core/inventory/tests/test_module_load_abort.py
@@ -1,0 +1,309 @@
+"""Tests for :mod:`core.inventory.module_load_abort` (S4).
+
+Covers per-language detection of unconditional top-of-module aborts
+plus the conservative-bias negatives (conditional aborts must NOT
+fire — false positives silence real findings on loadable files).
+"""
+
+from __future__ import annotations
+
+from core.inventory.module_load_abort import (
+    ModuleLoadAbort,
+    detect_module_load_abort,
+)
+
+
+# ---------------------------------------------------------------------------
+# Python
+# ---------------------------------------------------------------------------
+
+
+def test_python_top_level_raise_import_error_fires():
+    src = (
+        "import os\n"
+        "raise ImportError('this module is disabled')\n"
+        "\n"
+        "def vulnerable(cmd):\n"
+        "    os.system(cmd)\n"
+    )
+    abort = detect_module_load_abort("python", src)
+    assert isinstance(abort, ModuleLoadAbort)
+    assert abort.line == 2
+    assert abort.summary == "raise ImportError"
+
+
+def test_python_module_not_found_error_fires():
+    src = "raise ModuleNotFoundError('nope')\n"
+    abort = detect_module_load_abort("python", src)
+    assert abort is not None
+    assert abort.summary == "raise ModuleNotFoundError"
+
+
+def test_python_system_exit_fires():
+    src = "raise SystemExit(1)\n"
+    abort = detect_module_load_abort("python", src)
+    assert abort is not None
+    assert abort.summary == "raise SystemExit"
+
+
+def test_python_conditional_raise_does_not_fire():
+    # The canonical false-positive trap: a version-gated raise. The
+    # file still imports on the supported branch, so we must NOT flag.
+    src = (
+        "import sys\n"
+        "if sys.version_info < (3, 10):\n"
+        "    raise ImportError('needs 3.10+')\n"
+        "\n"
+        "def handler():\n"
+        "    return 1\n"
+    )
+    assert detect_module_load_abort("python", src) is None
+
+
+def test_python_raise_inside_try_does_not_fire():
+    src = (
+        "try:\n"
+        "    import fast_impl\n"
+        "except Exception:\n"
+        "    raise ImportError('fallback unavailable')\n"
+    )
+    assert detect_module_load_abort("python", src) is None
+
+
+def test_python_raise_inside_function_does_not_fire():
+    # A raise in a function body runs only when the function is
+    # called — not at module load. Not an abort.
+    src = (
+        "def guard():\n"
+        "    raise ImportError('only when called')\n"
+    )
+    assert detect_module_load_abort("python", src) is None
+
+
+def test_python_non_abort_exception_does_not_fire():
+    # ValueError isn't in the abort allow-list — too generic; a
+    # module-scope ValueError is unusual and we stay conservative.
+    src = "raise ValueError('weird but loadable-ish')\n"
+    assert detect_module_load_abort("python", src) is None
+
+
+def test_python_syntax_error_returns_none():
+    assert detect_module_load_abort("python", "def (:\n") is None
+
+
+def test_python_dotted_exception_name_fires():
+    # ``raise exceptions.ImportError(...)`` — attribute form.
+    src = "import errors\nraise errors.ImportError('x')\n"
+    abort = detect_module_load_abort("python", src)
+    assert abort is not None
+    assert abort.summary == "raise ImportError"
+
+
+# ---------------------------------------------------------------------------
+# JavaScript / TypeScript
+# ---------------------------------------------------------------------------
+
+
+def test_js_top_level_throw_fires():
+    src = (
+        "const x = 1;\n"
+        "throw new Error('module disabled');\n"
+        "function vuln(p) { eval(p); }\n"
+    )
+    abort = detect_module_load_abort("javascript", src)
+    assert abort is not None
+    assert abort.line == 2
+    assert abort.summary == "throw new Error"
+
+
+def test_js_typescript_alias_fires():
+    src = "throw new TypeError('disabled');\n"
+    abort = detect_module_load_abort("typescript", src)
+    assert abort is not None
+    assert abort.summary == "throw new TypeError"
+
+
+def test_js_throw_inside_function_does_not_fire():
+    src = (
+        "function guard() {\n"
+        "  throw new Error('only when called');\n"
+        "}\n"
+    )
+    assert detect_module_load_abort("javascript", src) is None
+
+
+def test_js_throw_inside_if_does_not_fire():
+    src = (
+        "if (process.env.DISABLED) {\n"
+        "  throw new Error('conditionally disabled');\n"
+        "}\n"
+    )
+    assert detect_module_load_abort("javascript", src) is None
+
+
+def test_js_commented_throw_does_not_fire():
+    src = (
+        "// throw new Error('this is a comment');\n"
+        "/* throw new Error('block comment'); */\n"
+        "const ok = true;\n"
+    )
+    assert detect_module_load_abort("javascript", src) is None
+
+
+def test_js_throw_in_fn_with_string_brace_does_not_fire():
+    # Adversarial false-positive: a string literal with an unbalanced
+    # brace (``const s = "}";``) must NOT corrupt the depth counter and
+    # make a throw INSIDE the function read as module-level. Pre-fix
+    # this fired and silenced `vuln` (and everything below).
+    src = (
+        "function f() {\n"
+        "  const s = \"}\";\n"
+        "  throw new Error('boom');\n"
+        "}\n"
+        "function vuln(p) { eval(p); }\n"
+    )
+    assert detect_module_load_abort("javascript", src) is None
+
+
+def test_js_template_literal_braces_do_not_break_detection():
+    # A template literal with ``${…}`` braces before a real top-level
+    # throw must not desync the walker — the throw still fires.
+    src = (
+        "const x = `val=${1 + 2}`;\n"
+        "throw new Error('dead');\n"
+    )
+    abort = detect_module_load_abort("javascript", src)
+    assert abort is not None
+    assert abort.line == 2
+
+
+def test_js_arrow_function_throw_does_not_fire():
+    src = "const f = () => { throw new Error('x'); };\n"
+    assert detect_module_load_abort("javascript", src) is None
+
+
+# ---------------------------------------------------------------------------
+# Go
+# ---------------------------------------------------------------------------
+
+
+def test_go_init_unconditional_panic_fires():
+    src = (
+        "package main\n"
+        "\n"
+        "func init() {\n"
+        "    panic(\"this package is disabled\")\n"
+        "}\n"
+        "\n"
+        "func Vuln(cmd string) {\n"
+        "}\n"
+    )
+    abort = detect_module_load_abort("go", src)
+    assert abort is not None
+    assert abort.summary == "func init() { panic(...) }"
+
+
+def test_go_init_conditional_panic_does_not_fire():
+    # panic gated by a config check — not unconditional.
+    src = (
+        "package main\n"
+        "\n"
+        "func init() {\n"
+        "    if cfg == nil {\n"
+        "        panic(\"missing config\")\n"
+        "    }\n"
+        "}\n"
+    )
+    assert detect_module_load_abort("go", src) is None
+
+
+def test_go_no_init_does_not_fire():
+    src = (
+        "package main\n"
+        "func helper() { panic(\"runtime only\") }\n"
+    )
+    assert detect_module_load_abort("go", src) is None
+
+
+# ---------------------------------------------------------------------------
+# Rust
+# ---------------------------------------------------------------------------
+
+
+def test_rust_compile_error_fires():
+    src = (
+        "compile_error!(\"this module is disabled\");\n"
+        "pub fn vuln() {}\n"
+    )
+    abort = detect_module_load_abort("rust", src)
+    assert abort is not None
+    assert abort.summary == "compile_error!(...)"
+
+
+def test_rust_cfg_gated_compile_error_does_not_fire():
+    # Build-config-gated compile_error is conditional on features;
+    # out of scope for static analysis (conservative no-fire).
+    src = "#[cfg(not(feature = \"x\"))] compile_error!(\"need x\");\n"
+    assert detect_module_load_abort("rust", src) is None
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting
+# ---------------------------------------------------------------------------
+
+
+def test_empty_content_returns_none():
+    assert detect_module_load_abort("python", "") is None
+
+
+def test_unwired_language_returns_none():
+    # Ruby has a call-graph extractor but no abort detector — must
+    # degrade gracefully (no false "loadable" claim, just no signal).
+    assert detect_module_load_abort("ruby", "raise 'x'\n") is None
+
+
+def test_clean_python_file_returns_none():
+    src = (
+        "import os\n"
+        "def handler(cmd):\n"
+        "    return os.system(cmd)\n"
+    )
+    assert detect_module_load_abort("python", src) is None
+
+
+# ---------------------------------------------------------------------------
+# Builder wiring + resolver accessor — the field must land on the
+# inventory file record and the public ``module_aborts_on_load``
+# accessor must surface it for downstream consumers.
+# ---------------------------------------------------------------------------
+
+
+def test_builder_records_abort_field(tmp_path):
+    import tempfile
+    from core.inventory.builder import build_inventory
+    from core.inventory.reachability import module_aborts_on_load
+
+    (tmp_path / "disabled.py").write_text(
+        "raise ImportError('disabled')\n"
+        "def vuln(cmd):\n"
+        "    import os; os.system(cmd)\n"
+    )
+    (tmp_path / "ok.py").write_text(
+        "def handler(x):\n"
+        "    return x\n"
+    )
+    with tempfile.TemporaryDirectory() as td:
+        inv = build_inventory(str(tmp_path), td)
+
+    # The aborting file carries the field; the clean file does not.
+    by_path = {f["path"]: f for f in inv["files"]}
+    assert "module_aborts_on_load" in by_path["disabled.py"]
+    assert by_path["disabled.py"]["module_aborts_on_load"]["line"] == 1
+    assert "module_aborts_on_load" not in by_path["ok.py"]
+
+    # Accessor surfaces the record for the aborting file, None else.
+    abort = module_aborts_on_load(inv, "disabled.py")
+    assert abort is not None
+    assert abort["summary"] == "raise ImportError"
+    assert module_aborts_on_load(inv, "ok.py") is None
+    assert module_aborts_on_load(inv, "nonexistent.py") is None

--- a/core/orchestration/reachability_enrichment.py
+++ b/core/orchestration/reachability_enrichment.py
@@ -98,7 +98,9 @@ def mark_unreachable_low_priority(
             Verdict,
             function_called,
             is_framework_callable,
+            is_lexically_dead,
             is_registered_via_call,
+            module_aborts_on_load,
         )
     except ImportError:
         return 0
@@ -120,6 +122,17 @@ def mark_unreachable_low_priority(
         if not isinstance(funcs, list):
             continue
 
+        # S4: whole-file module-load-abort gate. Looked up once per
+        # file. When set, the file's top-level execution
+        # unconditionally aborts (raise ImportError / throw new Error
+        # / init() panic / compile_error!), so any function whose
+        # ``def`` lies at or below the abort line never binds — dead
+        # regardless of in-file call edges or framework registration.
+        file_abort = module_aborts_on_load(inventory, rel_path)
+        abort_line = (
+            int(file_abort.get("line") or 0) if file_abort else 0
+        )
+
         for func in funcs:
             if not isinstance(func, dict):
                 continue
@@ -133,6 +146,43 @@ def mark_unreachable_low_priority(
                 continue
             name = func.get("name")
             if not isinstance(name, str) or not name:
+                continue
+
+            # S4 gate. A function defined STRICTLY below the abort
+            # line never has its ``def`` / decorator executed, so it
+            # can't be registered or called — dead even when the
+            # static graph shows in-file callers (those callers are
+            # equally dead). Trumps the framework_callable /
+            # registered_via_call checks below for exactly this
+            # reason: registration code that never runs registers
+            # nothing. Functions ABOVE the abort line may have
+            # completed registration before the abort fired, so they
+            # fall through to normal call-graph logic. Respects
+            # ``allow_unreachable`` like the NOT_CALLED path.
+            if abort_line and not allow_unreachable:
+                func_line = int(func.get("line_start") or 0)
+                if func_line and func_line > abort_line:
+                    func["priority"] = "low"
+                    func["priority_reason"] = (
+                        "reachability:module_aborts"
+                    )
+                    marked += 1
+                    continue
+
+            # S3: lexical-dead gate. A function defined inside an
+            # always-false guard (``if False:`` / ``if (false) {…}``
+            # / ``#[cfg(any())]``) never binds — the guard body never
+            # runs / compiles. Trumps CALLED (two dead-scope functions
+            # calling each other read as mutually CALLED) and the
+            # framework checks below (a decorator inside dead scope
+            # never registers anything). Respects ``allow_unreachable``.
+            if not allow_unreachable and is_lexically_dead(
+                inventory, rel_path, name,
+                int(func.get("line_start") or 0),
+            ):
+                func["priority"] = "low"
+                func["priority_reason"] = "reachability:lexical_dead"
+                marked += 1
                 continue
 
             qualified = f"{module}.{name}"

--- a/core/orchestration/tests/test_reachability_enrichment.py
+++ b/core/orchestration/tests/test_reachability_enrichment.py
@@ -586,3 +586,254 @@ class TestRegistrationViaCallBypass:
         assert func.get("priority_reason") == (
             "reachability:registered_via_call"
         )
+
+
+class TestModuleLoadAbortGate:
+    """S4: a file whose top-level execution unconditionally aborts
+    (raise ImportError / throw / panic / compile_error!) is a whole-
+    file reachability gate — every function defined below the abort
+    line is dead regardless of in-file call edges. The gate trumps
+    CALLED (peers calling the function are equally dead) and trumps
+    framework registration (decorator/registration code beneath the
+    abort never executes)."""
+
+    def test_all_functions_below_abort_demoted(self, tmp_path):
+        # Top-of-module raise → everything below it is dead even
+        # though the two functions call each other (which would
+        # otherwise read CALLED for `helper`).
+        target = _project(tmp_path, {
+            "src/disabled.py": (
+                "import os\n"
+                "raise ImportError('module disabled')\n"
+                "\n"
+                "def entry(cmd):\n"
+                "    return helper(cmd)\n"
+                "\n"
+                "def helper(cmd):\n"
+                "    return os.system(cmd)\n"
+            ),
+        })
+        checklist = _checklist({
+            "src/disabled.py": [
+                {"name": "entry", "kind": "function",
+                 "line_start": 4, "line_end": 5},
+                {"name": "helper", "kind": "function",
+                 "line_start": 7, "line_end": 8},
+            ],
+        })
+        marked = mark_unreachable_low_priority(checklist, target)
+        assert marked == 2
+        funcs = {f["name"]: f for f in checklist["files"][0]["items"]}
+        for name in ("entry", "helper"):
+            assert funcs[name]["priority"] == "low"
+            assert funcs[name]["priority_reason"] == (
+                "reachability:module_aborts"
+            )
+
+    def test_function_above_abort_not_module_demoted(self, tmp_path):
+        # A function whose def lies ABOVE the abort line ran (and
+        # could have registered) before the abort fired — the S4
+        # gate must not fire for it. It falls through to normal
+        # call-graph logic.
+        target = _project(tmp_path, {
+            "src/mixed.py": (
+                "def early(cmd):\n"           # line 1
+                "    return cmd\n"             # line 2
+                "raise SystemExit(1)\n"        # line 3
+                "def late(cmd):\n"             # line 4
+                "    return cmd\n"             # line 5
+            ),
+            "src/main.py": (
+                "from src.mixed import early\n"
+                "early('x')\n"
+            ),
+        })
+        checklist = _checklist({
+            "src/mixed.py": [
+                {"name": "early", "kind": "function",
+                 "line_start": 1, "line_end": 2},
+                {"name": "late", "kind": "function",
+                 "line_start": 4, "line_end": 5},
+            ],
+        })
+        mark_unreachable_low_priority(checklist, target)
+        funcs = {f["name"]: f for f in checklist["files"][0]["items"]}
+        # `late` is below the abort → module_aborts demotion.
+        assert funcs["late"]["priority"] == "low"
+        assert funcs["late"]["priority_reason"] == (
+            "reachability:module_aborts"
+        )
+        # `early` is above the abort → S4 gate did NOT fire. It has
+        # a real caller (main.py) so it isn't NOT_CALLED-demoted
+        # either; the key assertion is that its reason is not the
+        # module-abort reason.
+        assert funcs["early"].get("priority_reason") != (
+            "reachability:module_aborts"
+        )
+
+    def test_module_abort_trumps_framework_callable(self, tmp_path):
+        # Even a Flask route handler is dead if its @app.route
+        # decorator sits below a module-load abort — the decorator
+        # never runs, so the route is never registered.
+        target = _project(tmp_path, {
+            "src/api.py": (
+                "from flask import Flask\n"
+                "app = Flask(__name__)\n"
+                "raise ImportError('disabled')\n"
+                "\n"
+                "@app.route('/users')\n"
+                "def list_users():\n"
+                "    return []\n"
+            ),
+        })
+        checklist = _checklist({
+            "src/api.py": [{
+                "name": "list_users", "kind": "function",
+                "line_start": 6, "line_end": 7,
+            }],
+        })
+        mark_unreachable_low_priority(checklist, target)
+        func = checklist["files"][0]["items"][0]
+        assert func["priority"] == "low"
+        assert func["priority_reason"] == "reachability:module_aborts"
+
+    def test_allow_unreachable_suppresses_module_abort_demotion(
+        self, tmp_path,
+    ):
+        target = _project(tmp_path, {
+            "src/disabled.py": (
+                "raise ImportError('module disabled')\n"
+                "def vuln(cmd):\n"
+                "    import os; os.system(cmd)\n"
+            ),
+        })
+        checklist = _checklist({
+            "src/disabled.py": [{
+                "name": "vuln", "kind": "function",
+                "line_start": 2, "line_end": 3,
+            }],
+        })
+        marked = mark_unreachable_low_priority(
+            checklist, target, allow_unreachable=True,
+        )
+        assert marked == 0
+        func = checklist["files"][0]["items"][0]
+        assert "priority" not in func
+        assert func.get("priority_reason") != "reachability:module_aborts"
+
+    def test_clean_file_not_module_demoted(self, tmp_path):
+        # No abort → S4 gate dormant; normal NOT_CALLED logic only.
+        target = _project(tmp_path, {
+            "src/v.py": (
+                "def dead(): pass\n"
+                "def alive(): pass\n"
+            ),
+            "src/main.py": (
+                "from src.v import alive\n"
+                "alive()\n"
+            ),
+        })
+        checklist = _checklist({
+            "src/v.py": [
+                {"name": "dead", "kind": "function",
+                 "line_start": 1, "line_end": 1},
+                {"name": "alive", "kind": "function",
+                 "line_start": 2, "line_end": 2},
+            ],
+        })
+        mark_unreachable_low_priority(checklist, target)
+        funcs = {f["name"]: f for f in checklist["files"][0]["items"]}
+        # dead → NOT_CALLED (not module_aborts), alive → untouched.
+        assert funcs["dead"]["priority_reason"] == (
+            "reachability:not_called"
+        )
+        assert "priority" not in funcs["alive"]
+
+
+class TestLexicalDeadGate:
+    """S3: functions defined inside an always-false guard
+    (``if False:`` / ``if (false) {…}`` / ``#[cfg(any())]``) never
+    bind — the guard body never runs / compiles. The gate trumps
+    CALLED (two dead-scope functions calling each other read as
+    mutually CALLED) and framework registration."""
+
+    def test_function_in_if_false_demoted(self, tmp_path):
+        # dead_a and dead_b call each other inside `if False:`, so
+        # the static graph reads both CALLED — but the whole scope
+        # is dead.
+        target = _project(tmp_path, {
+            "src/mod.py": (
+                "if False:\n"
+                "    def dead_a(x):\n"
+                "        return dead_b(x)\n"
+                "    def dead_b(x):\n"
+                "        return dead_a(x)\n"
+                "\n"
+                "def live():\n"
+                "    return 1\n"
+            ),
+        })
+        checklist = _checklist({
+            "src/mod.py": [
+                {"name": "dead_a", "kind": "function",
+                 "line_start": 2, "line_end": 3},
+                {"name": "dead_b", "kind": "function",
+                 "line_start": 4, "line_end": 5},
+                {"name": "live", "kind": "function",
+                 "line_start": 7, "line_end": 8},
+            ],
+        })
+        mark_unreachable_low_priority(checklist, target)
+        funcs = {f["name"]: f for f in checklist["files"][0]["items"]}
+        for name in ("dead_a", "dead_b"):
+            assert funcs[name]["priority"] == "low"
+            assert funcs[name]["priority_reason"] == (
+                "reachability:lexical_dead"
+            )
+
+    def test_allow_unreachable_suppresses_lexical_dead(self, tmp_path):
+        target = _project(tmp_path, {
+            "src/mod.py": (
+                "if False:\n"
+                "    def dead(x):\n"
+                "        return x\n"
+            ),
+        })
+        checklist = _checklist({
+            "src/mod.py": [{
+                "name": "dead", "kind": "function",
+                "line_start": 2, "line_end": 3,
+            }],
+        })
+        marked = mark_unreachable_low_priority(
+            checklist, target, allow_unreachable=True,
+        )
+        assert marked == 0
+        func = checklist["files"][0]["items"][0]
+        assert "priority" not in func
+
+    def test_live_function_not_lexical_demoted(self, tmp_path):
+        # A function with a dead `if False:` block INSIDE its body is
+        # itself live — only the inner statements are dead, and there's
+        # no nested function to tag. The function must not be demoted.
+        target = _project(tmp_path, {
+            "src/mod.py": (
+                "def handler(x):\n"
+                "    if False:\n"
+                "        unreachable_call(x)\n"
+                "    return x\n"
+            ),
+            "src/main.py": (
+                "from src.mod import handler\n"
+                "handler('x')\n"
+            ),
+        })
+        checklist = _checklist({
+            "src/mod.py": [{
+                "name": "handler", "kind": "function",
+                "line_start": 1, "line_end": 4,
+            }],
+        })
+        mark_unreachable_low_priority(checklist, target)
+        func = checklist["files"][0]["items"][0]
+        assert func.get("priority_reason") != "reachability:lexical_dead"

--- a/packages/codeql/agent.py
+++ b/packages/codeql/agent.py
@@ -281,7 +281,7 @@ class CodeQLAgent:
                 # (e.g. a `pom.xml` in a docs example dir) but is also
                 # tripped by trees with real source code and zero build
                 # files — multi-language minimal repros, fixture trees,
-                # honeyslop-shaped adversarial canaries. The two retry
+                # vendored reference snapshots. The two retry
                 # tiers above both gate on confidence; if both returned
                 # empty, fall back to a file-count-only floor and log
                 # loud per-language WARNINGs so the operator knows the

--- a/packages/codeql/autonomous_analyzer.py
+++ b/packages/codeql/autonomous_analyzer.py
@@ -234,10 +234,17 @@ class AutonomousCodeQLAnalyzer:
 
         Returns one of ``"called"`` / ``"not_called"`` /
         ``"uncertain"`` / ``"framework_callable"`` /
-        ``"registered_via_call"`` / None (None = couldn't determine —
+        ``"registered_via_call"`` / ``"module_aborts"`` /
+        ``"lexical_dead"`` / None (None = couldn't determine —
         non-Python file, sink not in any function, inventory build
         failed, etc.). The caller's policy is to short-circuit on
-        ``"not_called"`` and otherwise continue.
+        ``"not_called"``, ``"module_aborts"`` and ``"lexical_dead"``
+        and otherwise continue. ``"module_aborts"``: the file's top-
+        level execution unconditionally aborts before the sink's
+        function binds — dead regardless of call edges (S4).
+        ``"lexical_dead"``: the sink's function is defined inside an
+        always-false guard (if False: / #[cfg(any())]) and never
+        binds — dead regardless of call edges (S3).
         ``"framework_callable"``: substrate found framework-dispatch
         decorator (Flask ``@app.route``, Celery ``@shared_task``,
         Django ``@receiver``, etc.) registering the function for
@@ -293,7 +300,9 @@ class AutonomousCodeQLAnalyzer:
                 InternalFunction,
                 function_called,
                 is_framework_callable,
+                is_lexically_dead,
                 is_registered_via_call,
+                module_aborts_on_load,
             )
         except ImportError:
             return None
@@ -327,6 +336,37 @@ class AutonomousCodeQLAnalyzer:
         if not module:
             return None
         qualified = f"{module}.{func_name}"
+
+        # S4: whole-file module-load-abort gate, checked before the
+        # call-graph verdict because it trumps CALLED. If the file's
+        # top-level execution unconditionally aborts (raise
+        # ImportError / throw new Error / init() panic /
+        # compile_error!) before this function's def runs, the sink
+        # is dead regardless of static call edges — peers calling it
+        # are equally dead. Short-circuit like not_called. The
+        # framework_callable / registered_via_call escape hatches
+        # below do NOT apply: registration code beneath the abort
+        # never executes. Respects --allow-unreachable (operator
+        # opt-out for in-isolation review).
+        if not self._allow_unreachable:
+            abort = module_aborts_on_load(
+                self._reachability_inventory, rel_path,
+            )
+            if abort is not None:
+                abort_line = int(abort.get("line") or 0)
+                func_line = int(func_info.get("line_start") or 0)
+                if abort_line and func_line and func_line > abort_line:
+                    return "module_aborts"
+            # S3: lexical-dead gate. Function defined inside an
+            # always-false guard (if False: / if (false) /
+            # #[cfg(any())]) never binds — dead regardless of call
+            # edges, and decorator/registration code inside the dead
+            # scope never runs. Trumps the framework escape hatches.
+            if is_lexically_dead(
+                self._reachability_inventory, rel_path, func_name,
+                int(func_info.get("line_start") or 0),
+            ):
+                return "lexical_dead"
 
         try:
             result = function_called(
@@ -1127,11 +1167,27 @@ class AutonomousCodeQLAnalyzer:
         reachability_verdict = self._check_reachability(
             finding, repo_path,
         )
-        if reachability_verdict == "not_called":
-            self.logger.info(
-                "⏭️  Sink function not called from project — "
-                "skipping expensive analysis",
-            )
+        if reachability_verdict in (
+            "not_called", "module_aborts", "lexical_dead",
+        ):
+            if reachability_verdict == "module_aborts":
+                self.logger.info(
+                    "⏭️  Sink's file aborts on load (raise/throw/panic "
+                    "before binding) — skipping expensive analysis",
+                )
+                skipped_reason = "reachability_module_aborts"
+            elif reachability_verdict == "lexical_dead":
+                self.logger.info(
+                    "⏭️  Sink's function is in an always-false guard "
+                    "(if False / #[cfg(any())]) — skipping analysis",
+                )
+                skipped_reason = "reachability_lexical_dead"
+            else:
+                self.logger.info(
+                    "⏭️  Sink function not called from project — "
+                    "skipping expensive analysis",
+                )
+                skipped_reason = "reachability_not_called"
             return AutonomousAnalysisResult(
                 finding=finding,
                 analysis=None,
@@ -1143,7 +1199,7 @@ class AutonomousCodeQLAnalyzer:
                 refinement_iterations=0,
                 total_duration_seconds=time.time() - start_time,
                 reachability_verdict=reachability_verdict,
-                skipped_reason="reachability_not_called",
+                skipped_reason=skipped_reason,
             )
 
         # Stage 2: Read vulnerable code

--- a/packages/codeql/language_detector.py
+++ b/packages/codeql/language_detector.py
@@ -237,7 +237,7 @@ class LanguageDetector:
         Use only when ``detect_languages`` has already returned empty
         with min_files=1 — i.e. the target has source code present but
         no build manifests or structural indicators that would let
-        confidence clear the gate. honeyslop-shaped trees (multi-
+        confidence clear the gate. Fixture / vendored trees (multi-
         language, no build files by design) and minimal repros land
         here. Caller is responsible for ordering: floor detection is
         a fallback, not a default.

--- a/packages/codeql/tests/test_language_detector.py
+++ b/packages/codeql/tests/test_language_detector.py
@@ -182,14 +182,14 @@ class TestSkipLogging:
 class TestFloorFallback:
     """detect_languages_floor() is the last-resort tier for repos with
     real source code but no build manifests — multi-language minimal
-    repros, fixture trees, honeyslop-shaped adversarial canaries. It
+    repros, fixture trees, vendored reference snapshots. It
     bypasses the confidence gate and admits any language above the
     file-count floor. Caller (agent.py) only invokes it when the two
     confidence-gated tiers have already returned empty.
     """
 
     def test_multilang_no_manifests_all_admitted(self, tmp_path: Path):
-        # honeyslop shape: 4 py + 2 js + 6 go + 4 cpp + non-source
+        # mixed-language shape: 4 py + 2 js + 6 go + 4 cpp + non-source
         # files (README, LICENSE, docs, images) that dilute the per-
         # language ratio below the confidence threshold. Zero build
         # files. Every language clears file_count >= 2 under floor.
@@ -201,11 +201,11 @@ class TestFloorFallback:
             _write(tmp_path, f"go/a{i}.go", "")
         for i in range(4):
             _write(tmp_path, f"c/a{i}.c", "")
-        # Decoy non-source files — match honeyslop's README/LICENSE/
-        # docs/images bulk. Need enough to push every language's
+        # Filler non-source files — README/LICENSE/docs/images bulk.
+        # Need enough to push every language's
         # ratio below its min_confidence gate (cap +0.3 on ratio
         # means ratio < 0.2 keeps cpp/python/js below 0.5; go is
-        # gated at 0.6 so needs ratio < 0.3). 26 decoys + 16 sources
+        # gated at 0.6 so needs ratio < 0.3). 26 fillers + 16 sources
         # = 42 total; go gets 6/42 = 0.14, well under the gate.
         for i in range(26):
             _write(tmp_path, f"docs/note{i}.md", "")

--- a/packages/codeql/tests/test_reachability_prefilter.py
+++ b/packages/codeql/tests/test_reachability_prefilter.py
@@ -516,3 +516,135 @@ def test_go_handler_registered_via_call_returns_registered_via_call(tmp_path):
         f"Go handler registered via http.HandleFunc must resolve "
         f"registered_via_call, got {verdict!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# S4: module-load-abort gate
+# ---------------------------------------------------------------------------
+
+
+def test_reachability_module_aborts_for_sink_below_abort(tmp_path):
+    """Sink in a file that raises ImportError at load → the prefilter
+    returns the ``module_aborts`` verdict even though a same-file peer
+    calls the sink (CALLED in the static graph)."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "disabled.py").write_text(
+        "raise ImportError('module disabled')\n"
+        "def entry(q):\n"
+        "    return sink(q)\n"
+        "def sink(q):\n"
+        "    cursor.execute(q)\n"
+    )
+    a = _analyzer()
+    verdict = a._check_reachability(_finding("src/disabled.py", line=5), tmp_path)
+    assert verdict == "module_aborts", (
+        f"sink below a module-load abort must resolve module_aborts, "
+        f"got {verdict!r}"
+    )
+
+
+def test_module_abort_trumps_framework_callable_in_prefilter(tmp_path):
+    """A Flask route handler below a module-load abort → module_aborts,
+    NOT framework_callable (the decorator never runs)."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "api.py").write_text(
+        "from flask import Flask, request\n"
+        "app = Flask(__name__)\n"
+        "raise ImportError('disabled')\n"
+        "\n"
+        "@app.route('/users')\n"
+        "def list_users():\n"
+        "    return cursor.execute(request.args.get('q'))\n"
+    )
+    a = _analyzer()
+    verdict = a._check_reachability(_finding("src/api.py", line=7), tmp_path)
+    assert verdict == "module_aborts"
+
+
+def test_allow_unreachable_suppresses_module_abort(tmp_path):
+    """--allow-unreachable disables the module-abort gate too —
+    the operator wants in-isolation evaluation."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "disabled.py").write_text(
+        "raise ImportError('disabled')\n"
+        "def sink(q):\n"
+        "    cursor.execute(q)\n"
+    )
+    a = AutonomousCodeQLAnalyzer(
+        llm_client=MagicMock(), exploit_validator=MagicMock(),
+        multi_turn_analyzer=None, enable_visualization=False,
+        allow_unreachable=True,
+    )
+    verdict = a._check_reachability(_finding("src/disabled.py", line=3), tmp_path)
+    # With the gate suppressed, the sink falls through to the call-
+    # graph verdict. `sink` IS called by `entry`'s peer... here there's
+    # no caller, so it's not_called — but --allow-unreachable also
+    # suppresses not_called → None. The key assertion: NOT module_aborts.
+    assert verdict != "module_aborts"
+
+
+def test_function_above_abort_not_module_aborts(tmp_path):
+    """A sink whose function is defined ABOVE the abort line must NOT
+    get the module_aborts verdict (its def ran before the abort)."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "mixed.py").write_text(
+        "def early(q):\n"            # line 1
+        "    cursor.execute(q)\n"    # line 2
+        "raise SystemExit(1)\n"      # line 3
+        "def late(q):\n"            # line 4
+        "    cursor.execute(q)\n"   # line 5
+    )
+    (src / "main.py").write_text(
+        "from src.mixed import early\n"
+        "early('x')\n"
+    )
+    a = _analyzer()
+    verdict = a._check_reachability(_finding("src/mixed.py", line=2), tmp_path)
+    assert verdict != "module_aborts"
+
+
+# ---------------------------------------------------------------------------
+# S3: lexical-dead gate
+# ---------------------------------------------------------------------------
+
+
+def test_reachability_lexical_dead_for_sink_in_if_false(tmp_path):
+    """Sink in a function defined inside `if False:` → lexical_dead,
+    even though a same-scope peer calls it (CALLED in the graph)."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "mod.py").write_text(
+        "if False:\n"
+        "    def dead_a(q):\n"
+        "        return dead_b(q)\n"
+        "    def dead_b(q):\n"
+        "        cursor.execute(q)\n"
+    )
+    a = _analyzer()
+    verdict = a._check_reachability(_finding("src/mod.py", line=5), tmp_path)
+    assert verdict == "lexical_dead", (
+        f"sink inside if False: must resolve lexical_dead, "
+        f"got {verdict!r}"
+    )
+
+
+def test_allow_unreachable_suppresses_lexical_dead(tmp_path):
+    """--allow-unreachable disables the lexical-dead gate too."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "mod.py").write_text(
+        "if False:\n"
+        "    def dead(q):\n"
+        "        cursor.execute(q)\n"
+    )
+    a = AutonomousCodeQLAnalyzer(
+        llm_client=MagicMock(), exploit_validator=MagicMock(),
+        multi_turn_analyzer=None, enable_visualization=False,
+        allow_unreachable=True,
+    )
+    verdict = a._check_reachability(_finding("src/mod.py", line=3), tmp_path)
+    assert verdict != "lexical_dead"

--- a/packages/exploitability_validation/reachability.py
+++ b/packages/exploitability_validation/reachability.py
@@ -109,7 +109,9 @@ def demote_unreachable_paths(
             Verdict,
             function_called,
             is_framework_callable,
+            is_lexically_dead,
             is_registered_via_call,
+            module_aborts_on_load,
         )
     except ImportError:
         return 0
@@ -145,35 +147,76 @@ def demote_unreachable_paths(
         if not module:
             continue
 
-        try:
-            result = function_called(
-                inventory, f"{module}.{func_name}",
-            )
-        except ValueError:
-            continue
-
-        if result.verdict != Verdict.NOT_CALLED:
-            continue
-
-        # NOT_CALLED in the static graph isn't dead code when the
-        # function is framework-registered (Flask ``@app.route``,
-        # Celery ``@shared_task``, Django ``@receiver``, etc.).
-        # The substrate's ``is_framework_callable`` recognises
-        # these; without this check the demoter sinks legitimate
-        # exploitable handlers to proximity=1 + "not_called"
-        # blocker on any web / task / signal codebase.
         func_line = int(func_info.get("line_start") or 0)
-        target = InternalFunction(
-            file_path=rel_path, name=func_name, line=func_line,
-        )
-        if is_framework_callable(inventory, target):
-            continue
-        # Same skip-the-demotion logic for JS / Go function-as-
-        # argument registration (``http.HandleFunc("/x", target)``,
-        # ``app.get("/users", target)``, etc.) — the JS / Go
-        # equivalent of decorator-driven dispatch.
-        if is_registered_via_call(inventory, target):
-            continue
+
+        # S4: whole-file module-load-abort gate, checked before the
+        # call-graph verdict because it trumps CALLED. When the
+        # sink's file aborts at load (raise ImportError / throw new
+        # Error / init() panic / compile_error!) before the entry
+        # function binds, the path is dead regardless of static call
+        # edges — and the framework_callable / registered_via_call
+        # escape hatches below do NOT apply (registration code under
+        # the abort never runs). ``allow_unreachable`` already
+        # short-circuited the whole function above, so no re-check.
+        abort = module_aborts_on_load(inventory, rel_path)
+        blocker: Optional[str] = None
+        if (
+            abort is not None
+            and int(abort.get("line") or 0)
+            and func_line
+            and func_line > int(abort.get("line") or 0)
+        ):
+            blocker = (
+                f"reachability:module_aborts — entry function "
+                f"`{module}.{func_name}` is in a file whose top-level "
+                f"execution aborts on load ({abort.get('summary')}) "
+                f"before the function binds"
+            )
+        elif is_lexically_dead(inventory, rel_path, func_name, func_line):
+            # S3: entry function defined inside an always-false guard
+            # (if False: / if (false) / #[cfg(any())]). Never binds —
+            # dead regardless of call edges. Trumps framework dispatch
+            # (a decorator inside dead scope registers nothing).
+            blocker = (
+                f"reachability:lexical_dead — entry function "
+                f"`{module}.{func_name}` is defined inside an "
+                f"always-false guard (if False / #[cfg(any())]) and "
+                f"never binds"
+            )
+        else:
+            try:
+                result = function_called(
+                    inventory, f"{module}.{func_name}",
+                )
+            except ValueError:
+                continue
+
+            if result.verdict != Verdict.NOT_CALLED:
+                continue
+
+            # NOT_CALLED in the static graph isn't dead code when the
+            # function is framework-registered (Flask ``@app.route``,
+            # Celery ``@shared_task``, Django ``@receiver``, etc.).
+            # The substrate's ``is_framework_callable`` recognises
+            # these; without this check the demoter sinks legitimate
+            # exploitable handlers to proximity=1 + "not_called"
+            # blocker on any web / task / signal codebase.
+            target = InternalFunction(
+                file_path=rel_path, name=func_name, line=func_line,
+            )
+            if is_framework_callable(inventory, target):
+                continue
+            # Same skip-the-demotion logic for JS / Go function-as-
+            # argument registration (``http.HandleFunc("/x", target)``,
+            # ``app.get("/users", target)``, etc.) — the JS / Go
+            # equivalent of decorator-driven dispatch.
+            if is_registered_via_call(inventory, target):
+                continue
+            blocker = (
+                f"reachability:not_called — entry function "
+                f"`{module}.{func_name}` is not called from any "
+                f"non-test project source"
+            )
 
         # Demote: cap proximity, append blocker.
         original_proximity = path.get("proximity")
@@ -184,11 +227,6 @@ def demote_unreachable_paths(
         blockers = path.get("blockers")
         if not isinstance(blockers, list):
             blockers = []
-        blocker = (
-            f"reachability:not_called — entry function "
-            f"`{module}.{func_name}` is not called from any "
-            f"non-test project source"
-        )
         if blocker not in blockers:
             blockers.append(blocker)
         path["blockers"] = blockers
@@ -424,7 +462,12 @@ def _is_demoted(path: Dict[str, Any]) -> bool:
     if not isinstance(blockers, list):
         return False
     return any(
-        isinstance(b, str) and b.startswith("reachability:not_called")
+        isinstance(b, str)
+        and (
+            b.startswith("reachability:not_called")
+            or b.startswith("reachability:module_aborts")
+            or b.startswith("reachability:lexical_dead")
+        )
         for b in blockers
     )
 

--- a/packages/exploitability_validation/tests/test_reachability_demotion.py
+++ b/packages/exploitability_validation/tests/test_reachability_demotion.py
@@ -423,3 +423,146 @@ def test_does_not_demote_go_handler_registered_via_call(tmp_path):
         "be demoted"
     )
     assert attack_paths[0]["proximity"] == 8  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# S4: module-load-abort gate
+# ---------------------------------------------------------------------------
+
+
+def test_demotes_path_in_module_that_aborts_on_load(tmp_path):
+    """Finding's file aborts at load (raise ImportError above the
+    function) → path demoted with a module_aborts blocker, even when
+    the function is called by a same-file peer (CALLED in the static
+    graph) — that caller is equally dead."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "disabled.py").write_text(
+        "raise ImportError('module disabled')\n"
+        "def entry(query):\n"
+        "    return sink(query)\n"
+        "def sink(query):\n"
+        "    cursor.execute(query)\n"
+    )
+    findings = [{
+        "id": "f1", "file_path": "src/disabled.py", "start_line": 5,
+    }]
+    attack_paths = [{
+        "id": "p1", "finding_id": "f1", "proximity": 8, "blockers": [],
+    }]
+    demoted = demote_unreachable_paths(
+        attack_paths, findings, tmp_path,
+    )
+    assert demoted == 1
+    assert attack_paths[0]["proximity"] == 1
+    assert any(
+        "reachability:module_aborts" in b
+        for b in attack_paths[0]["blockers"]
+    )
+
+
+def test_module_abort_trumps_flask_route_in_demoter(tmp_path):
+    """A Flask handler whose @app.route sits below a module-load
+    abort is dead — the decorator never runs. The module-abort gate
+    must override the framework-callable bypass."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "api.py").write_text(
+        "from flask import Flask, request\n"
+        "app = Flask(__name__)\n"
+        "raise ImportError('disabled')\n"
+        "\n"
+        "@app.route('/users')\n"
+        "def list_users():\n"
+        "    return cursor.execute(request.args.get('q'))\n"
+    )
+    findings = [{
+        "id": "f1", "file_path": "src/api.py", "start_line": 7,
+    }]
+    attack_paths = [{
+        "id": "p1", "finding_id": "f1", "proximity": 8, "blockers": [],
+    }]
+    demoted = demote_unreachable_paths(
+        attack_paths, findings, tmp_path,
+    )
+    assert demoted == 1, (
+        "module-load abort must override framework-callable bypass"
+    )
+    assert any(
+        "reachability:module_aborts" in b
+        for b in attack_paths[0]["blockers"]
+    )
+
+
+def test_allow_unreachable_skips_module_abort_demotion(tmp_path):
+    """C2 opt-out covers the module-abort gate too (the whole
+    function early-returns when allow_unreachable=True)."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "disabled.py").write_text(
+        "raise ImportError('disabled')\n"
+        "def sink(query):\n"
+        "    cursor.execute(query)\n"
+    )
+    findings = [{
+        "id": "f1", "file_path": "src/disabled.py", "start_line": 3,
+    }]
+    paths = [{
+        "id": "p1", "finding_id": "f1", "proximity": 8, "blockers": [],
+    }]
+    demoted = demote_unreachable_paths(
+        paths, findings, tmp_path, allow_unreachable=True,
+    )
+    assert demoted == 0
+    assert paths[0]["proximity"] == 8
+    assert paths[0]["blockers"] == []
+
+
+# ---------------------------------------------------------------------------
+# S3: lexical-dead gate
+# ---------------------------------------------------------------------------
+
+
+def test_demotes_path_in_lexically_dead_function(tmp_path):
+    """Finding's function is defined inside `if False:` → demoted with
+    a lexical_dead blocker, even though a same-scope peer calls it."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "mod.py").write_text(
+        "if False:\n"
+        "    def dead_a(q):\n"
+        "        return dead_b(q)\n"
+        "    def dead_b(q):\n"
+        "        cursor.execute(q)\n"
+    )
+    findings = [{
+        "id": "f1", "file_path": "src/mod.py", "start_line": 5,
+    }]
+    attack_paths = [{
+        "id": "p1", "finding_id": "f1", "proximity": 8, "blockers": [],
+    }]
+    demoted = demote_unreachable_paths(
+        attack_paths, findings, tmp_path,
+    )
+    assert demoted == 1
+    assert attack_paths[0]["proximity"] == 1
+    assert any(
+        "reachability:lexical_dead" in b
+        for b in attack_paths[0]["blockers"]
+    )
+
+
+def test_allow_unreachable_skips_lexical_dead_demotion(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "mod.py").write_text(
+        "if False:\n"
+        "    def dead(q):\n"
+        "        cursor.execute(q)\n"
+    )
+    findings = [{
+        "id": "f1", "file_path": "src/mod.py", "start_line": 3,
+    }]
+    paths = [{
+        "id": "p1", "finding_id": "f1", "proximity": 8, "blockers": [],
+    }]
+    demoted = demote_unreachable_paths(
+        paths, findings, tmp_path, allow_unreachable=True,
+    )
+    assert demoted == 0
+    assert paths[0]["proximity"] == 8

--- a/packages/llm_analysis/prompts/analysis.py
+++ b/packages/llm_analysis/prompts/analysis.py
@@ -59,6 +59,8 @@ Is this code reachable from an entry point, or is it dead code?
 If the metadata block contains a "Reachability:" section, use it as evidence:
 - "Verdict: NOT_CALLED" — the static call-graph resolver found no callers in the project. Before marking exploitable, identify a plausible reach mechanism the substrate could miss (framework dispatch the resolver didn't recognise, dynamic dispatch via reflection/registry lookups, public API surface called by external consumers, plugin entry points). If no plausible mechanism exists, mark is_exploitable=False with ruling="unreachable" or "dead_code" — the vulnerability shape may still be a true positive (is_true_positive=True) but it isn't exploitable in this deployment.
 - "Verdict: REACHABLE via ..." — reachability is established via a runtime-dispatch mechanism (framework decorator or registration call); treat as live, focus on exploit feasibility.
+- "Verdict: MODULE_ABORTS_ON_LOAD" — the file's top-level execution unconditionally aborts (raise ImportError, throw new Error, init() panic, compile_error!) before this function's definition runs. The function is never importable/callable in this deployment, regardless of in-file call edges — peers that appear to call it are equally dead, since the file never finishes loading. This is a STRONGER signal than NOT_CALLED: there is no framework-dispatch escape hatch (registration code below the abort never executes). Mark is_exploitable=False with ruling="dead_code". The vulnerability shape may still be a true positive (is_true_positive=True), but it is unreachable in this deployment.
+- "Verdict: LEXICAL_DEAD" — this function is defined inside an always-false guard (if False:, if (false) {…}, #[cfg(any())]). The guard's body never executes or compiles, so the function never binds. Like MODULE_ABORTS_ON_LOAD this trumps in-scope call edges (two dead-scope functions calling each other read as mutually called, but the whole scope is dead) and any decorator inside the dead scope never registers anything. Mark is_exploitable=False with ruling="dead_code". The vulnerability shape may still be a true positive (is_true_positive=True), but it is unreachable.
 - "Caller graph: N direct, M transitive" with N=0 but uncertain > 0 — the substrate found indirection it cannot resolve (string-dispatch / reflect / plugin registries). Treat as potentially reachable; note the indirection class in your reasoning.
 - "Caller graph: N direct, M transitive" with N > 0 — reachability is established; focus on exploit feasibility.
 
@@ -175,7 +177,25 @@ def _format_reachability_block(metadata: Dict[str, Any]) -> str:
 
     priority = metadata.get("priority")
     priority_reason = metadata.get("priority_reason") or ""
-    if priority == "low":
+    if priority_reason == "reachability:module_aborts":
+        # S4: whole-file module-load abort. Distinct verdict from
+        # NOT_CALLED — the function's def never executes, so there's
+        # no framework-dispatch escape hatch and in-file callers are
+        # equally dead. The system prompt explains how to treat it.
+        lines.append(
+            "Verdict: MODULE_ABORTS_ON_LOAD — file aborts at load "
+            "before this function binds; never importable/callable"
+        )
+    elif priority_reason == "reachability:lexical_dead":
+        # S3: function defined inside an always-false guard
+        # (if False: / if (false) / #[cfg(any())]). Body never
+        # runs / compiles, so the function never binds — trumps
+        # in-scope call edges. System prompt explains treatment.
+        lines.append(
+            "Verdict: LEXICAL_DEAD — defined inside an always-false "
+            "guard (if False / #[cfg(any())]); never binds"
+        )
+    elif priority == "low":
         lines.append(
             f"Verdict: NOT_CALLED ({priority_reason or 'no callers in project'})"
         )

--- a/packages/llm_analysis/prompts/schemas.py
+++ b/packages/llm_analysis/prompts/schemas.py
@@ -155,7 +155,7 @@ FINDING_RESULT_SCHEMA = {
         # description text (line 17 above) already advertises the
         # allowed values, but the JSON Schema previously accepted
         # any string — Haiku organically emitted ``not_called`` on
-        # a 2026-05-24 honeyslop multi-model run because the C1
+        # a 2026-05-24 multi-model run because the C1
         # prompt surfaces ``Verdict: NOT_CALLED`` and Haiku echoed
         # it back. Structured-output providers (Gemini / Anthropic
         # tool-use) honour the enum, so this forces the LLM to map

--- a/packages/llm_analysis/tests/test_orchestrator.py
+++ b/packages/llm_analysis/tests/test_orchestrator.py
@@ -559,7 +559,7 @@ class TestBuildSchema:
         """Regression: ``ruling`` field carries an ``enum`` constraint
         matching the documented AGENTIC_RULING_VALUES (plus None).
         Pre-fix the field accepted any string — Haiku organically
-        emitted ``not_called`` on a multi-model honeyslop run because
+        emitted ``not_called`` on a multi-model run because
         the C1 prompt surfaces ``Verdict: NOT_CALLED``. Structured-
         output providers (Gemini / Anthropic tool-use) honour the
         enum, so this forces the LLM to map to canonical vocabulary

--- a/packages/llm_analysis/tests/test_reachability_in_analysis_prompt.py
+++ b/packages/llm_analysis/tests/test_reachability_in_analysis_prompt.py
@@ -60,6 +60,27 @@ class TestVerdictLine:
         assert "registration call" in out
         assert "handler passed as argument" in out
 
+    def test_module_aborts_renders_distinct_verdict(self):
+        # S4: a whole-file load abort gets its own verdict line,
+        # distinct from NOT_CALLED — the function's def never runs.
+        out = _format_reachability_block({
+            "priority": "low",
+            "priority_reason": "reachability:module_aborts",
+        })
+        assert "Verdict: MODULE_ABORTS_ON_LOAD" in out
+        # Must NOT mislabel it as NOT_CALLED.
+        assert "NOT_CALLED" not in out
+
+    def test_lexical_dead_renders_distinct_verdict(self):
+        # S3: function inside an always-false guard gets its own
+        # verdict line, distinct from NOT_CALLED.
+        out = _format_reachability_block({
+            "priority": "low",
+            "priority_reason": "reachability:lexical_dead",
+        })
+        assert "Verdict: LEXICAL_DEAD" in out
+        assert "NOT_CALLED" not in out
+
     def test_no_priority_no_verdict_line(self):
         # Priority not set + no framework reason → no verdict line.
         # Caller counts may still render below.


### PR DESCRIPTION
  Two static-reachability detectors that catch functions the call graph reads as CALLED but which never actually bind at runtime — a confident-false-positive source in triage:

  - Module-load abort: a file whose top-level execution unconditionally aborts (raise ImportError, throw new Error, init(){panic()}, compile_error!) gates every function below the abort line.
  - Dead scope: a function inside an always-false guard (if False:, if (false){}, #[cfg(any())]) is tagged lexical_dead.

  Completes the substrate reachability extensions on top of the framework-callable work already on main.
