### PR TITLE
First SCA bump :)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
 # The base image's `node` devcontainer-feature install path added a stale
 # yarn apt source (NO_PUBKEY 62D54FD4003F6525, breaks apt-get update) AND
 # the yarn 1.x package itself (/usr/bin/yarn). Remove both so the later
-# `npm install -g yarn` step doesn't collide on aarch64 builds.
+# `npm install -g yarn@1.22.22` step doesn't collide on aarch64 builds.
 RUN rm -f /etc/apt/sources.list.d/yarn.list \
     && (apt-get -y remove yarn || echo "yarn not installed - skipping removal")
 
@@ -77,7 +77,7 @@ RUN pip install --no-cache-dir semgrep==1.161.0
 # NOTE: Requires --privileged container flag and kernel parameter configuration
 # ============================================================================
 
-RUN apt-get update && apt-get install -y --no-install-recommends rr \
+RUN apt-get update && apt-get install -y --no-install-recommends rr=5.9.0-9 \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     || echo "rr not available on this architecture - skipping"
 
@@ -139,7 +139,7 @@ RUN apt-get update \
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x -o /tmp/nodesource_setup.sh \
     && bash /tmp/nodesource_setup.sh \
     && rm /tmp/nodesource_setup.sh \
-    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get install -y --no-install-recommends nodejs=24.15.0+dfsg+~cs24.12.2-1 \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && npm install -g @anthropic-ai/claude-code@2.1.119
 
@@ -147,7 +147,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x -o /tmp/nodesource_setup.sh
 # JS PACKAGE MANAGERS (npm-managed yarn — apt source + package removed above)
 # ============================================================================
 
-RUN npm install -g yarn pnpm
+RUN npm install -g yarn@1.22.22 pnpm@11.3.0
 
 # ============================================================================
 # ENVIRONMENT CONFIGURATION

--- a/.github/workflows/refit-sca-calibration.yml
+++ b/.github/workflows/refit-sca-calibration.yml
@@ -57,8 +57,8 @@ jobs:
         # Pure-Python refit — no numpy / sklearn. Just whatever
         # the SCA package itself needs to import (urllib3 etc.).
         run: |
-          python -m pip install --upgrade pip
-          pip install 'urllib3>=2.0,<3.0'
+          python -m pip install --upgrade pip==26.1.1
+          pip install 'urllib3==2.7.0,<3.0'
 
       - name: Validate corpus
         # Re-run validation to get the latest verdict. If it's

--- a/.github/workflows/refresh-sca-calibration.yml
+++ b/.github/workflows/refresh-sca-calibration.yml
@@ -48,11 +48,11 @@ jobs:
 
       - name: Install minimal deps
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip==26.1.1
           # The build script needs urllib3 (core.http dependency)
           # plus pytest for the validation step. No other
           # requirements-dev — keep this fast.
-          pip install 'urllib3>=2.0,<3.0'
+          pip install 'urllib3==2.7.0,<3.0'
 
       - name: Refresh corpus
         # ``-v`` emits per-source ``updated/unchanged`` lines so the

--- a/.github/workflows/refresh-sca-data.yml
+++ b/.github/workflows/refresh-sca-data.yml
@@ -55,10 +55,10 @@ jobs:
 
       - name: Install minimal deps
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip==26.1.1
           # The refresh script needs urllib3 (core.http dependency)
           # but nothing else from requirements-dev — keep this fast.
-          pip install 'urllib3>=2.0,<3.0'
+          pip install 'urllib3==2.7.0,<3.0'
 
       - name: Run refresh
         # ``-v`` emits per-ecosystem ``updated/unchanged/skipped``

--- a/.github/workflows/refresh-sca-project-samples.yml
+++ b/.github/workflows/refresh-sca-project-samples.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip==26.1.1
           # Full SCA dep set — the collector runs the SCA pipeline
           # against each cloned project, so it needs everything
           # SCA needs (urllib3 plus parsers' dependencies).

--- a/.github/workflows/sca-compromise-check.yml
+++ b/.github/workflows/sca-compromise-check.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Install runtime deps
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip==26.1.1
           pip install -r requirements.txt
 
       - name: Run compromise-detection harness

--- a/.github/workflows/sca-pr-gate.yml
+++ b/.github/workflows/sca-pr-gate.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip==26.1.1
           pip install -r requirements.txt
 
       - name: Scan PR head

--- a/.github/workflows/sca-self-bump.yml
+++ b/.github/workflows/sca-self-bump.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install RAPTOR + deps
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip==26.1.1
           pip install -r requirements.txt -r requirements-dev.txt
           pip install -e .
 

--- a/.github/workflows/sca-stress-sweep.yml
+++ b/.github/workflows/sca-stress-sweep.yml
@@ -65,7 +65,7 @@ jobs:
         # ``raptor-sca`` needs the full runtime requirements; the
         # sweep then drives the actual scanner against each sample.
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip==26.1.1
           pip install -r requirements.txt
 
       - name: Run stress sweep

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -473,7 +473,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install pytest
-        run: pip install pytest
+        run: pip install pytest==9.0.3
 
       - name: Run prompt-envelope audit
         run: |
@@ -504,7 +504,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install pytest
-        run: pip install pytest
+        run: pip install pytest==9.0.3
 
       - name: Run CI filter-coverage tests
         run: pytest .github/tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,10 +15,10 @@ mypy==2.0.0
 # collision between packages that all carry ``tests/__init__.py``. Pinning
 # avoids surprise regressions from collection-mode changes between minors.
 pytest==9.0.3
-pytest-cov==7.0.0
-pytest-xdist==3.6.1
+pytest-cov==7.1.0
+pytest-xdist==3.8.0
 pytest-split==0.11.0
-gcovr==8.4
+gcovr==8.6
 
 # Optional runtime deps that gate test collection. Listed here (not in
 # requirements.txt) so CI runs the full /web test suite without


### PR DESCRIPTION
  Manually applying the Clean/auto-promote set that the weekly
  sca-self-bump would otherwise open as its first PR — pins
  currently-unpinned dev/CI deps to current safe versions:

  - devcontainer: rr, nodejs (apt), yarn, pnpm (npm globals)
  - workflows: pip, urllib3, pytest install pins
  - requirements-dev: pytest-cov, pytest-xdist, gcovr patch bumps

  All versions are the latest with no supply-chain signal (no OSV/KEV,
  not recently-published, no maintainer change). z3-solver is
  deliberately NOT bumped — 4.16.0.0 ships manylinux_2_38-only
  aarch64 wheels that break the bookworm/glibc-2.36 devcontainer
  (platform_compat_regression); it stays capped at 4.15.4.0.

  Generated via `raptor-sca fix . --harden --git-patch --no-llm`.
  Subsequent weekly runs will be near-empty now these are pinned.
