### PR TITLE
feat(project): surface SCA findings in /project findings

### DIFF
--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -821,18 +821,37 @@ def _print_coverage(project, detailed=False, fail_under=None):
 
 
 def _print_findings(project, detailed=False):
-    """Print merged findings across all runs, grouped by vuln."""
+    """Print merged findings across all runs.
+
+    Code findings (each run's ``findings.json``) render first; SCA /
+    dependency findings (each run's ``sca/findings.json``) render in
+    their own section below, so dependency-CVE volume doesn't swamp the
+    code-finding table.
+    """
     from .merge import merge_findings
-    from .findings_utils import count_vulns, group_findings
-    from core.reporting.findings import build_findings_summary, findings_summary_line
-    from core.reporting.formatting import get_display_status, title_case_type, truncate_path
+    from .findings_utils import merge_sca_findings
 
     run_dirs = project.get_run_dirs(sweep=False)
     merged = merge_findings(run_dirs)
+    sca_findings = merge_sca_findings(run_dirs)
 
-    if not merged:
+    if not merged and not sca_findings:
         print("No findings.")
         return
+
+    if merged:
+        _print_code_findings(merged, detailed)
+    if sca_findings:
+        if merged:
+            print()
+        _print_sca_findings_section(sca_findings, detailed)
+
+
+def _print_code_findings(merged, detailed=False):
+    """Render code findings as a grouped table (the original view)."""
+    from .findings_utils import count_vulns, group_findings
+    from core.reporting.findings import build_findings_summary, findings_summary_line
+    from core.reporting.formatting import get_display_status, title_case_type, truncate_path
 
     vuln_count = count_vulns(merged)
     counts = build_findings_summary(merged)
@@ -917,6 +936,82 @@ def _print_findings(project, detailed=False):
                 parts.append(f"sink: {proof_sink}")
             print(f"{indent}Proof: {', '.join(parts)}")
 
+        print()
+
+
+_SCA_SEVERITY_RANK = {
+    "critical": 0, "high": 1, "medium": 2, "low": 3,
+    "none": 4, "info": 5, "": 6,
+}
+
+
+def _sca_finding_kind(finding):
+    """Human label for an SCA finding's class/kind, from its
+    ``vuln_type`` tag (``sca:<class>:<kind>``)."""
+    vt = finding.get("vuln_type", "")
+    tag = vt[4:] if vt.startswith("sca:") else vt
+    return tag.replace("_", " ").replace(":", " · ").title() or "—"
+
+
+def _sca_finding_package(finding):
+    """``ecosystem:name`` for an SCA finding (falls back to the
+    ``function`` field, which carries the package name)."""
+    sca = finding.get("sca") or {}
+    name = sca.get("name") or finding.get("function", "") or "—"
+    eco = sca.get("ecosystem", "")
+    return f"{eco}:{name}" if eco else name
+
+
+def _print_sca_findings_section(sca_findings, detailed=False):
+    """Render SCA / dependency findings in their own section.
+
+    Discovered from each run's ``sca/findings.json`` (see
+    ``findings_utils.merge_sca_findings``). Sorted by severity so the
+    high-signal supply-chain hits (slopsquat / typosquat) surface above
+    dependency-CVE volume. Kept separate from the code-finding table
+    because these are dep-level (no source file:line).
+    """
+    def _sev_rank(finding):
+        return _SCA_SEVERITY_RANK.get((finding.get("severity") or "").lower(), 6)
+
+    ordered = sorted(sca_findings, key=lambda f: (_sev_rank(f), _sca_finding_package(f)))
+
+    print(f"Supply chain / dependencies (SCA) — {len(ordered)} findings")
+    print()
+
+    rows = []
+    for f in ordered:
+        sev = (f.get("severity") or "").strip()
+        rows.append((
+            _sca_finding_package(f),
+            _sca_finding_kind(f),
+            sev.title() if sev else "—",
+        ))
+
+    headers = ("Package", "Kind", "Severity")
+    widths = [len(h) for h in headers]
+    for r in rows:
+        for i, cell in enumerate(r):
+            widths[i] = max(widths[i], len(cell))
+    fmt = f"  {{:<{widths[0]}s}}  {{:<{widths[1]}s}}  {{:<{widths[2]}s}}"
+    print(fmt.format(*headers))
+    print(f"  {'-' * widths[0]}  {'-' * widths[1]}  {'-' * widths[2]}")
+    for r in rows:
+        print(fmt.format(*r))
+
+    if not detailed:
+        return
+
+    print()
+    pad = len(str(len(ordered)))
+    indent = " " * (pad + 5)
+    for i, f in enumerate(ordered, 1):
+        title = f.get("title") or _sca_finding_package(f)
+        print(f"  [{i:0{pad}d}] {title}")
+        desc = f.get("description")
+        if desc and isinstance(desc, str):
+            for ln in desc.strip().split("\n")[:2]:
+                print(f"{indent}{ln.strip()}")
         print()
 
 

--- a/core/project/findings_utils.py
+++ b/core/project/findings_utils.py
@@ -67,3 +67,50 @@ def load_findings_from_dir(run_dir: Path) -> List[Dict[str, Any]]:
     if isinstance(data, dict):
         return data.get("findings", data.get("results", []))
     return []
+
+
+def load_sca_findings_from_dir(run_dir: Path) -> List[Dict[str, Any]]:
+    """Load SCA findings from a run's ``sca/findings.json`` subdir.
+
+    ``/sca`` and ``/agentic`` write dependency findings to
+    ``<run_dir>/sca/findings.json`` (a bare list of rows) rather than the
+    top-level ``findings.json`` that :func:`load_findings_from_dir` reads,
+    so the unified project view never saw them. The rows are already
+    normalised to the common finding shape (``id`` / ``file`` = manifest
+    path / ``function`` = package name / ``line`` / ``severity`` /
+    ``vuln_type`` = ``sca:<class>:<kind>``), so they group, dedup, and
+    render through the same machinery — they're only *discovered*
+    separately. Kept distinct from :func:`load_findings_from_dir` so
+    correlate / merge_runs / run-summary keep their code-finding scope;
+    the findings view opts in explicitly.
+    """
+    data = load_json(run_dir / "sca" / "findings.json")
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        return data.get("findings", data.get("results", []))
+    return []
+
+
+def merge_sca_findings(run_dirs: List[Path]) -> List[Dict[str, Any]]:
+    """Collect + dedup SCA findings across runs.
+
+    Dedup by stable finding id, falling back to ``dedup_key``
+    (file, function, line). ``run_dirs`` is ordered (later overrides
+    earlier), so the latest run's copy of a recurring finding wins —
+    matching :func:`core.project.merge.merge_findings` semantics for
+    code findings.
+    """
+    merged: Dict[Any, Dict[str, Any]] = {}
+    for run_dir in run_dirs:
+        for finding in load_sca_findings_from_dir(Path(run_dir)):
+            # SCA rows always carry a stable finding_id, so the fallback
+            # is for malformed/legacy rows only. Use group_key (includes
+            # vuln_type), NOT dedup_key (file, function, line) — every SCA
+            # row has line=0 and file=manifest, so dedup_key would collide
+            # distinct findings on the same package (a slopsquat AND a CVE
+            # on `lodash` share ("package.json","lodash",0)). group_key
+            # keeps them distinct via the sca:<class>:<kind> vuln_type.
+            key = get_finding_id(finding) or group_key(finding)
+            merged[key] = finding
+    return list(merged.values())

--- a/core/project/tests/test_cli.py
+++ b/core/project/tests/test_cli.py
@@ -1,12 +1,138 @@
 """Basic smoke tests for the project CLI."""
 
+import contextlib
+import io
+import json
 import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
-from core.project.cli import _get_active_project, main
+from core.project.cli import (
+    _get_active_project,
+    _print_findings,
+    _sca_finding_kind,
+    _sca_finding_package,
+    main,
+)
+
+
+class _FakeProject:
+    """Minimal stand-in: _print_findings only calls get_run_dirs()."""
+
+    def __init__(self, run_dirs):
+        self._run_dirs = run_dirs
+
+    def get_run_dirs(self, sweep=False):
+        return self._run_dirs
+
+
+def _sca_finding(name, *, severity="high"):
+    return {
+        "id": f"SCA-{name}", "finding_id": f"SCA-{name}",
+        "vuln_type": "sca:supply_chain:slopsquat_suspect", "tool": "sca",
+        "file": "package.json", "function": name, "line": 0,
+        "severity": severity, "title": f"Slopsquat suspect: {name}",
+        "description": "looks like an LLM-hallucinated package name",
+        "sca": {"kind": "slopsquat_suspect", "ecosystem": "npm", "name": name},
+    }
+
+
+def _write_sca(run_dir: Path, rows):
+    (run_dir / "sca").mkdir(parents=True, exist_ok=True)
+    (run_dir / "sca" / "findings.json").write_text(json.dumps(rows), encoding="utf-8")
+
+
+class TestPrintFindingsSca(unittest.TestCase):
+
+    def test_sca_helpers(self):
+        f = _sca_finding("lodahs")
+        self.assertEqual(_sca_finding_package(f), "npm:lodahs")
+        self.assertEqual(_sca_finding_kind(f), "Supply Chain · Slopsquat Suspect")
+
+    def test_sca_section_renders(self):
+        with TemporaryDirectory() as d:
+            run_dir = Path(d)
+            _write_sca(run_dir, [_sca_finding("lodahs")])
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                _print_findings(_FakeProject([run_dir]))
+            out = buf.getvalue()
+            self.assertIn("Supply chain / dependencies (SCA)", out)
+            self.assertIn("npm:lodahs", out)
+
+    def test_sca_only_run_not_reported_as_no_findings(self):
+        """Regression: a run with ONLY sca/findings.json (no top-level
+        findings.json) must still surface the SCA section, not print
+        'No findings.' and bail."""
+        with TemporaryDirectory() as d:
+            run_dir = Path(d)
+            _write_sca(run_dir, [_sca_finding("expresss")])
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                _print_findings(_FakeProject([run_dir]))
+            out = buf.getvalue()
+            self.assertNotIn("No findings.", out)
+            self.assertIn("npm:expresss", out)
+
+    def test_truly_empty_reports_no_findings(self):
+        with TemporaryDirectory() as d:
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                _print_findings(_FakeProject([Path(d)]))
+            self.assertIn("No findings.", buf.getvalue())
+
+
+class TestProjectFindingsScaE2E(unittest.TestCase):
+    """End-to-end across the package boundary: a slopsquat detected by
+    the REAL SCA detector + serialised by the REAL write_findings_json
+    must surface in /project findings.
+
+    Guards the contract — SCA's on-disk findings.json shape vs the
+    project view's loader/renderer. A future SCA serializer change that
+    drifts the row shape breaks this test rather than silently dropping
+    dependency findings from the project view. Skipped if the optional
+    SCA package isn't importable.
+    """
+
+    def test_real_slopsquat_surfaces_in_project_findings(self):
+        try:
+            from packages.sca.parsers.package_json import parse as parse_pkg
+            from packages.sca.supply_chain import _slopsquat_to_finding
+            from packages.sca.supply_chain.slopsquat import check_dep
+            from packages.sca.findings import write_findings_json
+        except ImportError:
+            self.skipTest("optional SCA package not importable")
+
+        with TemporaryDirectory() as d:
+            target = Path(d) / "target"
+            target.mkdir()
+            # 'lodash-pro' = popular prefix 'lodash' + generic suffix
+            # 'pro' → the detector's popular_prefix_generic_suffix rule.
+            (target / "package.json").write_text(json.dumps({
+                "name": "victim-app",
+                "dependencies": {"lodash-pro": "^1.0.0", "express": "^4.0.0"},
+            }), encoding="utf-8")
+
+            deps = parse_pkg(target / "package.json")
+            ss = [f for f in (check_dep(dep) for dep in deps) if f]
+            self.assertTrue(ss, "real detector found no slopsquat in 'lodash-pro'")
+            sc_findings = [_slopsquat_to_finding(f) for f in ss]
+
+            run_dir = Path(d) / "run"
+            write_findings_json(
+                run_dir / "sca" / "findings.json",
+                supply_chain_findings=sc_findings,
+            )
+
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                _print_findings(_FakeProject([run_dir]))
+            out = buf.getvalue()
+            self.assertIn("Supply chain / dependencies (SCA)", out)
+            self.assertIn("lodash-pro", out)
+            self.assertIn("Slopsquat", out)
 
 
 class TestCLI(unittest.TestCase):

--- a/core/project/tests/test_findings_utils.py
+++ b/core/project/tests/test_findings_utils.py
@@ -1,8 +1,40 @@
 """Tests for findings_utils — dedup keys, semantic grouping, bug counting."""
 
+import json
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
-from core.project.findings_utils import count_vulns, dedup_key, group_findings, group_key
+from core.project.findings_utils import (
+    count_vulns,
+    dedup_key,
+    group_findings,
+    group_key,
+    load_sca_findings_from_dir,
+    merge_sca_findings,
+)
+
+
+def _sca_row(finding_id, name, *, severity="high", run_tag=""):
+    """A minimal SCA finding row in the canonical shape SCA writes."""
+    return {
+        "id": finding_id,
+        "finding_id": finding_id,
+        "vuln_type": "sca:supply_chain:slopsquat_suspect",
+        "tool": "sca",
+        "file": "package.json",
+        "function": name,
+        "line": 0,
+        "severity": severity,
+        "title": f"Slopsquat suspect: {name}{run_tag}",
+        "sca": {"kind": "slopsquat_suspect", "ecosystem": "npm", "name": name},
+    }
+
+
+def _write_sca_findings(run_dir: Path, rows):
+    sca_dir = run_dir / "sca"
+    sca_dir.mkdir(parents=True, exist_ok=True)
+    (sca_dir / "findings.json").write_text(json.dumps(rows), encoding="utf-8")
 
 
 class TestDedupKey(unittest.TestCase):
@@ -100,6 +132,72 @@ class TestCountVulns(unittest.TestCase):
 
     def test_empty(self):
         self.assertEqual(count_vulns([]), 0)
+
+
+class TestLoadScaFindings(unittest.TestCase):
+
+    def test_reads_sca_subdir(self):
+        with TemporaryDirectory() as d:
+            run_dir = Path(d)
+            _write_sca_findings(run_dir, [_sca_row("SCA-1", "lodahs")])
+            out = load_sca_findings_from_dir(run_dir)
+            self.assertEqual(len(out), 1)
+            self.assertEqual(out[0]["function"], "lodahs")
+
+    def test_absent_subdir_returns_empty(self):
+        with TemporaryDirectory() as d:
+            # No sca/ subdir at all.
+            self.assertEqual(load_sca_findings_from_dir(Path(d)), [])
+
+    def test_does_not_read_top_level_findings(self):
+        """The SCA loader must look ONLY in sca/, not the top-level
+        findings.json (that's load_findings_from_dir's job)."""
+        with TemporaryDirectory() as d:
+            run_dir = Path(d)
+            (run_dir / "findings.json").write_text(
+                json.dumps([{"id": "CODE-1", "file": "a.c"}]), encoding="utf-8")
+            self.assertEqual(load_sca_findings_from_dir(run_dir), [])
+
+
+class TestMergeScaFindings(unittest.TestCase):
+
+    def test_dedup_latest_run_wins(self):
+        with TemporaryDirectory() as d1, TemporaryDirectory() as d2:
+            r1, r2 = Path(d1), Path(d2)
+            _write_sca_findings(r1, [_sca_row("SCA-1", "lodahs", run_tag=" (run1)")])
+            _write_sca_findings(r2, [_sca_row("SCA-1", "lodahs", run_tag=" (run2)")])
+            # run_dirs ordered: later overrides earlier.
+            merged = merge_sca_findings([r1, r2])
+            self.assertEqual(len(merged), 1)
+            self.assertIn("(run2)", merged[0]["title"])
+
+    def test_distinct_ids_kept(self):
+        with TemporaryDirectory() as d1, TemporaryDirectory() as d2:
+            r1, r2 = Path(d1), Path(d2)
+            _write_sca_findings(r1, [_sca_row("SCA-1", "lodahs")])
+            _write_sca_findings(r2, [_sca_row("SCA-2", "expresss")])
+            merged = merge_sca_findings([r1, r2])
+            self.assertEqual(len(merged), 2)
+
+    def test_empty_when_no_sca(self):
+        with TemporaryDirectory() as d:
+            self.assertEqual(merge_sca_findings([Path(d)]), [])
+
+    def test_idless_distinct_findings_same_package_not_collapsed(self):
+        """Regression: two id-less findings on the SAME package but
+        different classes (slopsquat vs CVE) must NOT collide. Both have
+        file=package.json, function=lodash, line=0 — dedup_key would
+        merge them; group_key (vuln_type) keeps them distinct."""
+        with TemporaryDirectory() as d:
+            run_dir = Path(d)
+            slop = _sca_row("", "lodash")  # empty id → fallback path
+            slop.pop("id")
+            slop.pop("finding_id")
+            cve = dict(slop)
+            cve["vuln_type"] = "sca:vulnerable_dependency"
+            _write_sca_findings(run_dir, [slop, cve])
+            merged = merge_sca_findings([run_dir])
+            self.assertEqual(len(merged), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
SCA writes dependency findings to <run_dir>/sca/findings.json, but the project findings view only read the top-level findings.json — so slopsquat / typosquat / dep-CVE findings never appeared in the unified view.

- findings_utils: add load_sca_findings_from_dir + merge_sca_findings (dedup across runs by finding id, latest wins). SCA rows already carry the common shape (file=manifest, function=package, vuln_type= sca:<class>:<kind>), so no schema adaptation needed — only discovery.
- cli: _print_findings now renders code findings, then a dedicated "Supply chain / dependencies (SCA)" section sorted by severity, so dep-CVE volume doesn't swamp the code-finding table. Extracted the existing table into _print_code_findings; fixed the early-return so a run with only SCA findings (no code findings.json) still surfaces them instead of printing "No findings."

The load_findings_from_dir primitive (and correlate / merge_runs / run-summary) are deliberately unchanged — the findings view opts into SCA explicitly.