### PR TITLE
feat(project): surface SCA findings in report, run-summary, and merged SARIF

### DIFF
--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -706,20 +706,32 @@ def _get_output_summary(run_dir, meta):
     from core.json import save_json
     from core.run.metadata import RUN_METADATA_FILE
 
-    # Use cached summary if present
+    # Cache schema version — bump whenever the counting logic changes so
+    # stale cached strings are recomputed rather than silently served.
+    # v2: counts SCA findings (sca/ subdir) in addition to code findings;
+    # a v1 string (code-only) must NOT short-circuit or SCA-containing
+    # runs completed before this change would under-count forever.
+    summary_version = 2
+
+    # Use cached summary only if it was computed by the current logic.
     cached = (meta or {}).get("output_summary")
-    if cached:
+    if cached and (meta or {}).get("output_summary_v") == summary_version:
         return cached
 
-    # Compute from findings or SARIF
-    from .findings_utils import load_findings_from_dir, count_vulns
-    findings = load_findings_from_dir(run_dir)
+    # Compute from findings or SARIF. Code findings (top-level
+    # findings.json) + SCA dependency findings (sca/ subdir) both count,
+    # so the run-list total matches what `/project findings` shows.
+    from .findings_utils import (
+        count_vulns,
+        load_findings_from_dir,
+        load_sca_findings_from_dir,
+    )
+    findings = load_findings_from_dir(run_dir) + load_sca_findings_from_dir(run_dir)
     if findings:
-        vuln_count = count_vulns(findings)
-        if vuln_count != len(findings):
-            result = f"{vuln_count} findings"
-        else:
-            result = f"{len(findings)} findings"
+        # count_vulns groups by (file, function, vuln_type); the prior
+        # branch always displayed this value, so this is behaviour-
+        # preserving for code-only runs and additive for SCA.
+        result = f"{count_vulns(findings)} findings"
     else:
         sarif_count = _count_sarif_results(run_dir)
         result = f"{sarif_count} results" if sarif_count else ""
@@ -730,6 +742,7 @@ def _get_output_summary(run_dir, meta):
         meta_path = run_dir / RUN_METADATA_FILE
         if meta_path.exists() and meta:
             meta["output_summary"] = result
+            meta["output_summary_v"] = summary_version
             save_json(meta_path, meta)
 
     return result

--- a/core/project/merge.py
+++ b/core/project/merge.py
@@ -266,9 +266,14 @@ def merge_runs(run_dirs: List[Path], output_dir: Path) -> Dict[str, Any]:
         save_json(output_dir / "findings.json", {"findings": merged})
 
     # --- Merge SARIF ---
+    # Top-level *.sarif are the code-scan outputs; SCA writes its SARIF
+    # to the sca/ subdir (<run>/sca/findings.sarif), so include that too
+    # or merged.sarif would silently omit dependency findings.
     sarif_paths: List[str] = []
     for run_dir in run_dirs:
         for sarif_file in run_dir.glob("*.sarif"):
+            sarif_paths.append(str(sarif_file))
+        for sarif_file in (run_dir / "sca").glob("*.sarif"):
             sarif_paths.append(str(sarif_file))
 
     sarif_files_merged = len(sarif_paths)

--- a/core/project/report.py
+++ b/core/project/report.py
@@ -181,14 +181,30 @@ def _severity_key(finding: Dict[str, Any]) -> tuple[int, str]:
     return (_SEVERITY_ORDER.get(severity, _SEVERITY_ORDER["unknown"]), severity)
 
 
-def render_grouped_findings_markdown(findings: Iterable[Dict[str, Any]], project_name: str) -> str:
-    """Render all findings into one project-level Markdown report."""
+def render_grouped_findings_markdown(
+    findings: Iterable[Dict[str, Any]],
+    project_name: str,
+    *,
+    sca_findings: Iterable[Dict[str, Any]] = (),
+) -> str:
+    """Render all findings into one project-level Markdown report.
+
+    Code findings are grouped by severity. SCA / dependency findings
+    (``sca_findings``) render in their own "Supply chain (SCA)" section
+    below — they're dep-level (no source file:line), so bucketing them
+    separately keeps the severity-grouped code view clean. Mirrors the
+    interactive ``/project findings`` view.
+    """
     findings = sorted(
         list(findings),
         key=lambda item: (*_severity_key(item), _finding_title(item).lower()),
     )
+    sca_findings = sorted(
+        list(sca_findings),
+        key=lambda item: (*_severity_key(item), _finding_title(item).lower()),
+    )
     lines = [f"# {project_name} findings", ""]
-    if not findings:
+    if not findings and not sca_findings:
         lines.append("No findings.")
         return "\n".join(lines) + "\n"
 
@@ -217,6 +233,26 @@ def render_grouped_findings_markdown(findings: Iterable[Dict[str, Any]], project
             )
         lines.append("")
 
+    if sca_findings:
+        lines.append("## Supply chain / dependencies (SCA)")
+        lines.append("")
+        for finding in sca_findings:
+            finding_id = (
+                finding.get("id")
+                or finding.get("finding_id")
+                or _finding_fingerprint(finding)
+            )
+            sca = finding.get("sca") or {}
+            name = sca.get("name") or finding.get("function") or "unknown package"
+            eco = sca.get("ecosystem", "")
+            package = f"{eco}:{name}" if eco else name
+            severity = str(finding.get("severity") or "unknown").strip().lower() or "unknown"
+            lines.append(
+                f"- **{_finding_title(finding)}** (`{finding_id}`) — "
+                f"{package} — {severity}"
+            )
+        lines.append("")
+
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -232,15 +268,22 @@ def _clear_generated_findings_dir(findings_dir: Path) -> None:
 
 
 def export_findings_directory(
-    findings: Iterable[Dict[str, Any]], output_dir: Path, *, project_name: str = "project"
+    findings: Iterable[Dict[str, Any]], output_dir: Path, *,
+    project_name: str = "project",
+    sca_findings: Iterable[Dict[str, Any]] = (),
 ) -> Dict[str, Any]:
     """Write grouped Markdown/JSON findings under ``output_dir/findings``.
 
     The directory is intended for handoff to issue trackers, disclosure notes,
     and audits. It is regenerated from merged findings each time project report
     runs, so stale findings are not retained after they disappear from inputs.
+
+    ``sca_findings`` (dependency findings from each run's ``sca/`` subdir)
+    appear in their own section of the aggregate Markdown. The per-finding
+    file/JSONL artefacts below remain code-finding-only for now.
     """
     findings = list(findings)
+    sca_findings = list(sca_findings)
     output_dir = Path(output_dir)
     findings_dir = output_dir / "findings"
     _clear_generated_findings_dir(findings_dir)
@@ -251,7 +294,9 @@ def export_findings_directory(
     jsonl_records = []
     aggregate_path = findings_dir / f"{_slug(project_name, fallback='project')}.md"
     aggregate_path.write_text(
-        render_grouped_findings_markdown(findings, project_name),
+        render_grouped_findings_markdown(
+            findings, project_name, sca_findings=sca_findings,
+        ),
         encoding="utf-8",
     )
 
@@ -399,6 +444,7 @@ def generate_project_report(project) -> Dict[str, Any]:
     Non-destructive — runs preserved.
     """
     from core.project.merge import merge_findings
+    from core.project.findings_utils import merge_sca_findings
     from core.json import save_json
 
     report_dir = project.output_path / "_report"
@@ -408,13 +454,20 @@ def generate_project_report(project) -> Dict[str, Any]:
     if not run_dirs:
         return {"findings": 0, "runs": 0, "annotations": 0}
 
-    # Merge findings
+    # Merge findings — code findings + SCA dependency findings (the
+    # latter discovered from each run's sca/ subdir; surfaced in their
+    # own section of the report, see render_grouped_findings_markdown).
     merged = merge_findings(run_dirs)
-    save_json(report_dir / "findings.json", {"findings": merged})
+    sca_findings = merge_sca_findings(run_dirs)
+    save_json(
+        report_dir / "findings.json",
+        {"findings": merged, "sca_findings": sca_findings},
+    )
     findings_export = export_findings_directory(
         merged,
         project.output_path,
         project_name=project.name,
+        sca_findings=sca_findings,
     )
 
     # Aggregate annotations across runs + project-level overrides.
@@ -426,6 +479,7 @@ def generate_project_report(project) -> Dict[str, Any]:
 
     return {
         "findings": len(merged),
+        "sca_findings": len(sca_findings),
         "runs": len(run_dirs),
         "annotations": len(annotations),
         "report_dir": str(report_dir),

--- a/core/project/tests/test_cli.py
+++ b/core/project/tests/test_cli.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 from core.project.cli import (
     _get_active_project,
+    _get_output_summary,
     _print_findings,
     _sca_finding_kind,
     _sca_finding_package,
@@ -42,6 +43,49 @@ def _sca_finding(name, *, severity="high"):
 def _write_sca(run_dir: Path, rows):
     (run_dir / "sca").mkdir(parents=True, exist_ok=True)
     (run_dir / "sca" / "findings.json").write_text(json.dumps(rows), encoding="utf-8")
+
+
+class TestRunSummarySca(unittest.TestCase):
+    """The per-run summary count (run list) includes SCA findings, so it
+    matches what /project findings shows."""
+
+    def test_sca_only_run_counted(self):
+        with TemporaryDirectory() as d:
+            run_dir = Path(d)
+            _write_sca(run_dir, [_sca_finding("lodash-pro")])
+            # meta with no status → computed, not cached/written back.
+            self.assertEqual(_get_output_summary(run_dir, {}), "1 findings")
+
+    def test_code_plus_sca_combined(self):
+        with TemporaryDirectory() as d:
+            run_dir = Path(d)
+            (run_dir / "findings.json").write_text(json.dumps([
+                {"id": "F-1", "file": "a.c", "function": "main", "line": 5,
+                 "vuln_type": "buffer_overflow"},
+            ]), encoding="utf-8")
+            _write_sca(run_dir, [_sca_finding("expresss")])
+            self.assertEqual(_get_output_summary(run_dir, {}), "2 findings")
+
+    def test_stale_v1_cache_recomputed(self):
+        """A pre-SCA cached summary (no version, or version != current)
+        must NOT short-circuit — else SCA-containing runs completed before
+        this change under-count forever."""
+        with TemporaryDirectory() as d:
+            run_dir = Path(d)
+            _write_sca(run_dir, [_sca_finding("lodash-pro")])
+            # Stale v1 cache: count present, no version stamp.
+            stale_meta = {"output_summary": "0 findings"}
+            self.assertEqual(
+                _get_output_summary(run_dir, stale_meta), "1 findings")
+
+    def test_current_version_cache_used(self):
+        with TemporaryDirectory() as d:
+            run_dir = Path(d)
+            _write_sca(run_dir, [_sca_finding("lodash-pro")])
+            # Current-version cache short-circuits (returns cached, no recompute).
+            fresh_meta = {"output_summary": "99 findings", "output_summary_v": 2}
+            self.assertEqual(
+                _get_output_summary(run_dir, fresh_meta), "99 findings")
 
 
 class TestPrintFindingsSca(unittest.TestCase):

--- a/core/project/tests/test_merge.py
+++ b/core/project/tests/test_merge.py
@@ -221,25 +221,46 @@ class TestMergeRuns(unittest.TestCase):
 
 class TestSarifMerge(unittest.TestCase):
 
-    def _make_run(self, tmpdir, name, findings, sarif=None):
+    _MINIMAL_SARIF = {
+        "version": "2.1.0",
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+        "runs": [{"tool": {"driver": {"name": "test"}}, "results": []}],
+    }
+
+    def _make_run(self, tmpdir, name, findings, sarif=None, sca_sarif=None):
         run_dir = Path(tmpdir) / name
         run_dir.mkdir()
         (run_dir / "findings.json").write_text(json.dumps(findings))
         if sarif is not None:
             (run_dir / "results.sarif").write_text(json.dumps(sarif))
+        if sca_sarif is not None:
+            (run_dir / "sca").mkdir()
+            (run_dir / "sca" / "findings.sarif").write_text(json.dumps(sca_sarif))
         return run_dir
 
     def test_sarif_files_merged(self):
-        minimal_sarif = {
-            "version": "2.1.0",
-            "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
-            "runs": [{"tool": {"driver": {"name": "test"}}, "results": []}],
-        }
         with TemporaryDirectory() as d:
-            a = self._make_run(d, "a", [{"id": "F-001", "file": "a.c", "function": "main", "line": 10}], sarif=minimal_sarif)
-            b = self._make_run(d, "b", [{"id": "F-002", "file": "b.c", "function": "foo", "line": 20}], sarif=minimal_sarif)
+            a = self._make_run(d, "a", [{"id": "F-001", "file": "a.c", "function": "main", "line": 10}], sarif=self._MINIMAL_SARIF)
+            b = self._make_run(d, "b", [{"id": "F-002", "file": "b.c", "function": "foo", "line": 20}], sarif=self._MINIMAL_SARIF)
             out = Path(d) / "merged"
             merge_runs([a, b], out)
+            self.assertTrue((out / "merged.sarif").exists())
+
+    def test_sca_subdir_sarif_included(self):
+        """merged.sarif must include SCA SARIF written to <run>/sca/, not
+        just the top-level *.sarif (regression for the subdir-discovery
+        gap)."""
+        with TemporaryDirectory() as d:
+            # One run with a top-level SARIF + a sca/ SARIF.
+            a = self._make_run(
+                d, "a",
+                [{"id": "F-001", "file": "a.c", "function": "main", "line": 10}],
+                sarif=self._MINIMAL_SARIF, sca_sarif=self._MINIMAL_SARIF,
+            )
+            out = Path(d) / "merged"
+            stats = merge_runs([a], out)
+            # Both the top-level and the sca/ SARIF discovered.
+            self.assertEqual(stats["sarif_files_merged"], 2)
             self.assertTrue((out / "merged.sarif").exists())
 
 

--- a/core/project/tests/test_report.py
+++ b/core/project/tests/test_report.py
@@ -6,13 +6,27 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from core.project.project import Project
-from core.project.report import generate_project_report
+from core.project.report import (
+    generate_project_report,
+    render_grouped_findings_markdown,
+)
 from core.run import start_run, complete_run
+
+
+def _sca_row(name, *, severity="high"):
+    return {
+        "id": f"sca:supply_chain:slopsquat_suspect:npm:{name}",
+        "finding_id": f"sca:supply_chain:slopsquat_suspect:npm:{name}",
+        "vuln_type": "sca:supply_chain:slopsquat_suspect",
+        "tool": "sca", "file": "package.json", "function": name, "line": 0,
+        "severity": severity, "title": f"Slopsquat suspect: {name}",
+        "sca": {"kind": "slopsquat_suspect", "ecosystem": "npm", "name": name},
+    }
 
 
 class TestProjectReport(unittest.TestCase):
 
-    def _make_project(self, tmpdir, runs):
+    def _make_project(self, tmpdir, runs, sca_runs=None):
         output_dir = Path(tmpdir) / "project"
         output_dir.mkdir()
         for name, findings in runs.items():
@@ -20,6 +34,10 @@ class TestProjectReport(unittest.TestCase):
             start_run(run_dir, "scan")
             complete_run(run_dir)
             (run_dir / "findings.json").write_text(json.dumps(findings))
+            sca_rows = (sca_runs or {}).get(name)
+            if sca_rows is not None:
+                (run_dir / "sca").mkdir()
+                (run_dir / "sca" / "findings.json").write_text(json.dumps(sca_rows))
         return Project(name="test", target=str(Path(tmpdir) / "code"),
                        output_dir=str(output_dir))
 
@@ -38,6 +56,60 @@ class TestProjectReport(unittest.TestCase):
             stats = generate_project_report(p)
             self.assertEqual(stats["findings"], 3)  # a.c, b.c, c.c
             self.assertEqual(stats["runs"], 2)
+
+    def test_sca_findings_in_report(self):
+        """SCA findings (from each run's sca/ subdir) are counted and
+        appear in the aggregate report markdown under their own section."""
+        with TemporaryDirectory() as d:
+            p = self._make_project(
+                d,
+                {"scan-1": [{"id": "F-001", "file": "a.c", "function": "main", "line": 10}]},
+                sca_runs={"scan-1": [_sca_row("lodash-pro")]},
+            )
+            stats = generate_project_report(p)
+            self.assertEqual(stats["findings"], 1)
+            self.assertEqual(stats["sca_findings"], 1)
+            agg = next((p.output_path / "findings").glob("*.md"))
+            text = agg.read_text(encoding="utf-8")
+            self.assertIn("Supply chain / dependencies (SCA)", text)
+            self.assertIn("npm:lodash-pro", text)
+
+    def test_real_slopsquat_surfaces_in_report_e2e(self):
+        """Cross-package E2E: a slopsquat from the REAL SCA detector +
+        REAL serializer surfaces in the generated project report. Guards
+        the on-disk contract (SCA findings.json shape vs report reader).
+        Skipped if the optional SCA package isn't importable."""
+        try:
+            from packages.sca.parsers.package_json import parse as parse_pkg
+            from packages.sca.supply_chain import _slopsquat_to_finding
+            from packages.sca.supply_chain.slopsquat import check_dep
+            from packages.sca.findings import write_findings_json
+        except ImportError:
+            self.skipTest("optional SCA package not importable")
+
+        with TemporaryDirectory() as d:
+            p = self._make_project(d, {
+                "scan-1": [{"id": "F-1", "file": "a.c", "function": "main", "line": 1}],
+            })
+            run_dir = p.output_path / "scan-1"
+            pkg = run_dir / "pkg" / "package.json"
+            pkg.parent.mkdir(parents=True)
+            pkg.write_text(json.dumps({
+                "name": "victim", "dependencies": {"lodash-pro": "^1.0.0"},
+            }))
+            deps = parse_pkg(pkg)
+            ss = [f for f in (check_dep(dep) for dep in deps) if f]
+            self.assertTrue(ss, "real detector found no slopsquat in 'lodash-pro'")
+            write_findings_json(
+                run_dir / "sca" / "findings.json",
+                supply_chain_findings=[_slopsquat_to_finding(f) for f in ss],
+            )
+            stats = generate_project_report(p)
+            self.assertEqual(stats["sca_findings"], len(ss))
+            agg = next((p.output_path / "findings").glob("*.md"))
+            text = agg.read_text(encoding="utf-8")
+            self.assertIn("Supply chain / dependencies (SCA)", text)
+            self.assertIn("lodash-pro", text)
 
     def test_report_dir_created(self):
         with TemporaryDirectory() as d:
@@ -149,6 +221,30 @@ class TestProjectReport(unittest.TestCase):
             stats = generate_project_report(p)
             self.assertEqual(stats["runs"], 1)
             self.assertEqual(stats["findings"], 1)
+
+
+class TestRenderGroupedFindingsMarkdownSca(unittest.TestCase):
+
+    def test_sca_section_appended(self):
+        code = [{"id": "F-1", "file": "a.c", "function": "main",
+                 "severity": "high", "title": "Overflow"}]
+        sca = [_sca_row("lodash-pro", severity="medium")]
+        md = render_grouped_findings_markdown(code, "proj", sca_findings=sca)
+        self.assertIn("## Supply chain / dependencies (SCA)", md)
+        self.assertIn("npm:lodash-pro", md)
+        # Code finding still rendered under its severity heading.
+        self.assertIn("## High", md)
+
+    def test_no_sca_no_section(self):
+        code = [{"id": "F-1", "file": "a.c", "severity": "high", "title": "X"}]
+        md = render_grouped_findings_markdown(code, "proj")
+        self.assertNotIn("Supply chain", md)
+
+    def test_sca_only_not_no_findings(self):
+        md = render_grouped_findings_markdown(
+            [], "proj", sca_findings=[_sca_row("expresss")])
+        self.assertNotIn("No findings.", md)
+        self.assertIn("## Supply chain / dependencies (SCA)", md)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #622 (which surfaced SCA in the /project findings view). Extends SCA visibility to the remaining /project read surfaces so dependency findings are consistent everywhere, not just in `findings`:

- report: render_grouped_findings_markdown gains an optional sca_findings arg → a "Supply chain / dependencies (SCA)" section below the severity-grouped code findings. generate_project_report loads them via merge_sca_findings, saves them under sca_findings in the report findings.json, and counts them in the returned stats.
- run-summary: _get_output_summary now counts SCA findings too. The cached summary is version-stamped (output_summary_v=2) so a pre-SCA cached count from a run completed before this change is recomputed rather than silently under-counting forever.
- merged SARIF: merge_runs globbed only top-level *.sarif; it now also picks up <run_dir>/sca/*.sarif so merged.sarif includes dependency findings.

/project export needs no change — it rglob-zips the whole project dir, so the sca/ subdir is already included.

Surgical (consistent with #622): the load_findings_from_dir primitive and correlate stay code-finding-only; each display surface opts into SCA explicitly. Co-occurrence escalation-highlight is deliberately NOT here — it belongs in the SCA render layer (a separate change).

Adversarial-reviewed (caught the cache-staleness issue, now fixed) + cross-package E2E (real detector → real serializer → report markdown).