### PR TITLE
ci: test-infra overhaul (phase 1) — nightly tier, cron right-sizing, image foundation

### DIFF
--- a/.github/docker/ci-deps.Dockerfile
+++ b/.github/docker/ci-deps.Dockerfile
@@ -1,0 +1,26 @@
+# CI dependency image — requirements-dev.txt baked in so the Python
+# unit-test tiers skip the per-job venv build + artifact download. That
+# fan-out (one venv download per tier × ~14 tiers) is what queues under
+# a concurrent-runner cap; running the tiers inside this image removes
+# it. Rebuilt by .github/workflows/ci-deps-image.yml whenever
+# requirements*.txt (or this Dockerfile) change.
+#
+# Base pinned to bookworm to match the devcontainer
+# (mcr.microsoft.com/devcontainers/python:1-3.12-bookworm, glibc 2.36)
+# so platform-sensitive wheels resolve identically — notably z3-solver
+# 4.15.4.0's manylinux_2_34 wheel (see the cap rationale in
+# requirements-dev.txt). PYTHON_VERSION here must track tests.yml's
+# env.PYTHON_VERSION (3.12).
+FROM python:3.12-slim-bookworm
+
+WORKDIR /opt/raptor-ci
+
+# Copy only the manifests first so the dependency layer cache survives
+# source-only changes to the repo.
+COPY requirements.txt requirements-dev.txt ./
+
+RUN pip install --no-cache-dir -r requirements-dev.txt
+
+# Build-time smoke import: fail the IMAGE build (not downstream CI) if a
+# pinned dependency can't import on this base.
+RUN python -c "import pytest, requests, pydantic, yaml, bs4, z3, defusedxml, packaging, tabulate, typer, instructor"

--- a/.github/workflows/ci-deps-image.yml
+++ b/.github/workflows/ci-deps-image.yml
@@ -1,0 +1,71 @@
+name: CI deps image
+
+# Builds + pushes the CI dependency image (.github/docker/ci-deps.Dockerfile)
+# to GHCR. The Python unit-test tiers in tests.yml will run inside this
+# image instead of each rebuilding + downloading the venv artifact — the
+# fan-out that queues under a concurrent-runner cap.
+#
+# Tags pushed:
+#   :main        — moving tag the test tiers pull. Updated on every build.
+#   :req-<hash>  — content tag (first 12 hex of sha256 over requirements*.txt)
+#                  for traceability + rollback.
+#
+# Uses the plain `docker` CLI (preinstalled on ubuntu runners) rather than
+# docker/* marketplace actions, to keep the third-party action surface to
+# just actions/checkout (pinned to the same SHA the rest of the repo uses).
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'requirements.txt'
+      - 'requirements-dev.txt'
+      - '.github/docker/ci-deps.Dockerfile'
+      - '.github/workflows/ci-deps-image.yml'
+  workflow_dispatch:
+  schedule:
+    # Weekly rebuild (Wed 03:00 UTC) so the base image picks up Debian
+    # security patches even when requirements don't change. Off-peak vs
+    # the Mon/Thu test crons and the nightly tier.
+    - cron: '0 3 * * 3'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        with:
+          persist-credentials: false
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ github.token }}" \
+            | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build and push
+        run: |
+          set -euo pipefail
+          # Lowercase the owner — GHCR repository paths must be lowercase
+          # and ${{ github.repository_owner }} can carry mixed case.
+          owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          image="ghcr.io/${owner}/raptor-ci-deps"
+          # Content tag over the manifests that define the image.
+          reqhash="$(cat requirements.txt requirements-dev.txt | sha256sum | cut -c1-12)"
+          docker build \
+            -f .github/docker/ci-deps.Dockerfile \
+            -t "${image}:main" \
+            -t "${image}:req-${reqhash}" \
+            .
+          docker push "${image}:main"
+          docker push "${image}:req-${reqhash}"
+          echo "Pushed ${image}:main and ${image}:req-${reqhash}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,81 @@
+name: Nightly (slow + integration)
+
+# The `slow` and `integration` markers are deselected by default in
+# pytest.ini (`addopts = -m "not integration and not slow"`), so these
+# tests run NOWHERE in the per-PR / per-push test matrix. This workflow
+# is the only place they execute in CI:
+#
+#   * slow        — perf baselines + sandbox-setup-heavy resolver tests
+#                   (deterministic; a failure is a real regression).
+#   * integration — live-network contract tests against OSV / NVD /
+#                    GitHub (flaky by nature; an external outage must
+#                    not red-fail the run, so that step is
+#                    continue-on-error).
+#
+# Deliberately a standalone workflow, NOT a job in tests.yml: it must
+# never ride tests.yml's `merge_group` force_full path — the merge queue
+# must not block on a live-API hiccup or a multi-minute perf baseline.
+
+on:
+  schedule:
+    # 07:00 UTC — on the days tests.yml's full-suite cron also fires
+    # (Mon/Thu 06:00) this stays an hour clear of it; every other day
+    # it runs alone.
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: '3.12'
+  VENV_PATH: .venv
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  slow-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # was v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "requirements*.txt"
+
+      - name: Create venv and install deps
+        run: |
+          uv venv $VENV_PATH
+          source $VENV_PATH/bin/activate
+          uv pip install -r requirements-dev.txt
+
+      - name: Run slow tests (deterministic — failure is a real regression)
+        run: |
+          source $VENV_PATH/bin/activate
+          # CLI -m overrides pytest.ini's default deselect.
+          python -m pytest -m slow core packages --durations=25
+
+      - name: Run integration tests (live network — informational)
+        # External-service outages (OSV/NVD/GitHub down or rate-limited)
+        # must not red-fail the nightly. A genuine contract break still
+        # shows as a failed step for a human to inspect.
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}  # higher rate limits for the live GitHub tests
+        run: |
+          source $VENV_PATH/bin/activate
+          python -m pytest -m integration core packages --durations=25

--- a/.github/workflows/sca-compromise-check.yml
+++ b/.github/workflows/sca-compromise-check.yml
@@ -21,8 +21,6 @@ name: SCA compromise-detection check
 #   - manual dispatch (workflow_dispatch) — operator-triggered
 #   - weekly cron (Monday 05:00 UTC, one hour after the stress
 #     sweep so they don't queue against each other)
-#   - push to feat/sca — catches regressions during active dev
-#     before a PR opens
 #   - PR touching the corpus / harness / supply-chain detector —
 #     prevents an incoming change from quietly breaking detection
 #
@@ -34,14 +32,6 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: '0 5 * * 1'
-  push:
-    branches:
-      - feat/sca
-    paths:
-      - 'packages/sca/**'
-      - 'packages/sca/scripts/raptor-sca-compromise-check'
-      - 'test/data/sca-e2e/compromise-corpus/**'
-      - '.github/workflows/sca-compromise-check.yml'
   pull_request:
     paths:
       - 'packages/sca/scripts/raptor-sca-compromise-check'

--- a/.github/workflows/sca-stress-sweep.yml
+++ b/.github/workflows/sca-stress-sweep.yml
@@ -18,8 +18,6 @@ name: SCA stress sweep
 #     when investigating
 #   - weekly cron (Monday 04:00 UTC) — catches drift from
 #     external service shifts (registry data, OSV updates)
-#   - push to feat/sca — catches regressions during active dev
-#     before a PR opens
 #
 # Network: hits OSV / KEV / EPSS / multiple package registries
 # / OCI registries. Per-host circuit breaker bounds 429 cascades
@@ -30,14 +28,6 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: '0 4 * * 1'
-  push:
-    branches:
-      - feat/sca
-    paths:
-      - 'packages/sca/**'
-      - 'core/inventory/**'
-      - 'core/http/**'
-      - '.github/workflows/sca-stress-sweep.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,11 +7,16 @@ on:
     branches: [ main ]
   merge_group:
   schedule:
-    # Daily full-suite run catches indirect breakage a path filter
-    # would miss (e.g. a refactor breaks an API contract without
-    # touching the tests that exercise it). Daily rather than weekly
-    # given the codebase's churn rate.
-    - cron: '0 6 * * *'
+    # Twice-weekly full-suite (force_full) run catches cross-tier
+    # breakage a path filter would miss — e.g. a refactor changes an
+    # API that another package's tests exercise, but the PR only
+    # touched the first package's paths so the second tier was
+    # skipped. PR + push-to-main are path-filtered; merge_group is the
+    # only other full-unfiltered run, and only fires when something is
+    # going through the merge queue. Mon+Thu keeps blind-spot latency
+    # under ~3-4 days on a quiet (no-merge) stretch while halving the
+    # redundant compute the old daily cron paid on active days.
+    - cron: '0 6 * * 1,4'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Four independent CI improvements; none touch an existing test gate's pass/fail behaviour. The venv-fan-out fix (the real wall-clock lever under a runner cap) lands its foundation here and is completed in a follow-up PR once the image is built + a canary tier is proven.

- drop dead feat/sca push triggers (sca-stress-sweep, sca-compromise-check) — branch retired post-#595; weekly cron + workflow_dispatch (+ compromise-check's PR trigger) still cover it.

- add nightly.yml running `-m "slow or integration"`. These markers are deselected by default in pytest.ini, and no workflow ever lifted the deselect — so on current main 32 slow + 199 integration tests (OSV/NVD/GitHub live contract tests, perf baselines) ran NOWHERE in CI. slow is authoritative; integration is continue-on-error so an external-service outage doesn't red-fail the run. Standalone so it never rides tests.yml's merge_group force_full path.

- demote tests.yml full-suite cron daily -> twice-weekly (Mon+Thu). It's the only full-unfiltered run on main (PR/push are path-filtered; merge_group only fires on queue activity); daily was redundant on active days. Mon+Thu keeps blind-spot latency under ~3-4 days.

- add the prebuilt deps-image pipeline (.github/docker/ci-deps.Dockerfile
  + ci-deps-image.yml -> ghcr.io/<owner>/raptor-ci-deps). Additive and inert: no test job uses it yet. Lets the pure-Python tiers later run in the image instead of each downloading the venv artifact — the fan-out that queues under a concurrent-runner cap.