### PR TITLE
feat(zkpox): dependency-free ZKPoX tier — eligibility + bundles

### DIFF
--- a/packages/zkpox/__init__.py
+++ b/packages/zkpox/__init__.py
@@ -1,0 +1,91 @@
+"""ZKPoX — Zero-Knowledge Proof of Exploit (tiered proving).
+
+Downstream consumer of the ``core.witness`` substrate. Proves the
+statement "I possess an input that makes binary H exhibit outcome
+O" *without revealing the input*. The verifier learns a working,
+reproducing exploit exists; they do not learn the exploit bytes.
+Use cases: coordinated disclosure (prove capability before a patch
+lands), bug-bounty triage, escrowing exploit existence.
+
+## Tiers
+
+Proving is staged so it degrades gracefully by dependency weight.
+Each tier is a strictly stronger claim than the one below; each
+runs when only its own (and lower tiers') dependencies are present.
+
+  Tier 0/1 — attestation   "I assert W produced O against H",
+                           carried by provenance hashes. No deps,
+                           no crypto. IMPLEMENTED HERE.
+  Tier 1.5* — synthetic    Dry-run of the proving pipeline with no
+                           real prover / no optional deps. Plumbing
+                           proof only. (not yet implemented)
+  Tier 1.5 — reproduction  Re-execute W against H N times in the
+                           sandbox; confirm O reproduces. Sandbox
+                           dep only; reproducibility, not ZK.
+                           (next increment)
+  Tier 2 — RISC-V          Execute the target in a RISC-V emulator
+                           for a deterministic trace. Needs a RISC-V
+                           toolchain. (not yet implemented)
+  Tier 3 — SP1             Full STARK proof via the SP1 zkVM: the ZK
+                           statement above, input hidden. Heavy
+                           proving stack. (not yet implemented)
+
+## Trigger model (free vs on-request)
+
+Mirrors the witness arc's cost-based split (witness recording is
+default-on because cheap; running code is opt-in):
+
+  - FREE: eligibility classification. Pure field-reading — surfaced
+    in end-of-run summaries ("N of M witnesses are ZKPoX-eligible")
+    with no flag, no execution, no artifacts.
+  - ON REQUEST: bundle assembly (produces persistent prover-ready
+    artifacts), reproduction (Tier 1.5 — N× sandbox execution), and
+    everything above.
+
+## This package today
+
+Everything achievable *without* the heavyweight proving stack —
+Tier 0/1, the dependency-free attestation tier:
+
+  * :mod:`packages.zkpox.eligibility` — candidacy classification
+    (free) + the free end-of-run summary.
+  * :mod:`packages.zkpox.bundle` — prover-ready bundle assembly
+    (on request); the stable hand-off shape every higher tier
+    consumes.
+
+The point: the real ZK tiers (2 RISC-V, 3 SP1) pull a large
+dependency chain. An operator who wants them installs those deps
+themselves — but they shouldn't have to install anything to learn
+*whether it's worth it*. The free eligibility surfacing is that
+pre-flight signal: "you have N witnesses that could be proven" (or
+"zero — don't bother"). Tiers 1.5 / 2 / 3 layer on the bundle shape
+defined here once the operator opts in.
+"""
+
+from packages.zkpox.bundle import (
+    ZKPoXBundle,
+    ZKPoXBundleError,
+    assemble_bundle,
+    render_bundle,
+    write_bundle,
+)
+from packages.zkpox.eligibility import (
+    ZKPoXEligibility,
+    is_zkpox_eligible,
+    render_eligibility_summary,
+    summarize_eligibility,
+)
+from packages.zkpox.surfacing import render_run_eligibility
+
+__all__ = [
+    "ZKPoXEligibility",
+    "is_zkpox_eligible",
+    "summarize_eligibility",
+    "render_eligibility_summary",
+    "render_run_eligibility",
+    "ZKPoXBundle",
+    "ZKPoXBundleError",
+    "assemble_bundle",
+    "write_bundle",
+    "render_bundle",
+]

--- a/packages/zkpox/bundle.py
+++ b/packages/zkpox/bundle.py
@@ -1,0 +1,228 @@
+"""ZKPoX Tier 0/1 — prover-ready bundle assembly.
+
+Once a witness is eligible (see :mod:`packages.zkpox.eligibility`),
+the bundle is the stable hand-off shape that every higher tier
+(1.5 reproduction, 2 RISC-V, 3 SP1) consumes. Assembly is **on
+request** in the design's trigger model — it produces a persistent
+artifact on disk, so the operator asks for it rather than getting
+it automatically.
+
+A bundle gathers everything a prover needs *about* the claim:
+
+  * the witness bytes (the secret the ZK tiers will hide; held in
+    the clear at Tier 0/1),
+  * the target artefact hashes (binary / source),
+  * the observed outcome + detail,
+  * provenance (source pipeline, produced_by, timestamp),
+  * a Tier-1 attestation: the structured claim itself.
+
+A bundle is NOT a proof. Tier 0/1 is attestation-only — "I assert
+this". The cryptographic strength comes at Tier 3. The bundle is
+the substrate the prover reads.
+
+The full tier model lives in the package docstring
+(``packages/zkpox/__init__.py``).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from core.witness.store import WitnessStore
+from core.witness.types import Witness
+
+from packages.zkpox.eligibility import is_zkpox_eligible
+
+
+# A witness identity is always a sha256 hex digest. We use it as a
+# path component (bundle dir name), so anything that isn't a clean
+# 64-char lowercase hex string is rejected — a corrupt / malicious
+# value containing ``/`` or ``..`` must never reach ``Path(...)``
+# where it could escape the output tree. Honest data always matches.
+_SHA256_HEX = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ZKPoXBundleError(Exception):
+    """Raised when a bundle can't be assembled (ineligible witness,
+    missing bytes, etc.)."""
+
+
+def _require_clean_hash(witness_hash: str) -> None:
+    """Reject a witness_hash that isn't a bare sha256 hex digest.
+
+    Defends the path construction in :func:`write_bundle` against
+    traversal: the hash is used as a directory name, so a value
+    with ``..`` / ``/`` segments could otherwise ``mkdir`` outside
+    the intended output tree.
+    """
+    if not isinstance(witness_hash, str) or not _SHA256_HEX.match(witness_hash):
+        raise ZKPoXBundleError(
+            f"witness_hash {witness_hash!r} is not a sha256 hex "
+            f"digest; refusing to use it as a path component"
+        )
+
+
+@dataclass
+class ZKPoXBundle:
+    """A Tier 0/1 prover-ready bundle for one witness.
+
+    ``tier`` starts at ``"0/1"`` (attestation). The reproduction
+    step (Tier 1.5) upgrades a persisted bundle by attaching a
+    ``reproduction`` block and bumping ``tier`` — this dataclass
+    carries the slot but leaves it ``None`` at assembly time.
+    """
+    witness_hash: str
+    witness_len: int
+    source: str               # WitnessSource value
+    observed_outcome: str     # WitnessOutcome value
+    outcome_detail: Dict[str, Any]
+    target_binary_hash: Optional[str]
+    target_source_hash: Optional[str]
+    produced_by: Optional[str]
+    timestamp: Optional[str]
+    attestation: Dict[str, Any]
+    tier: str = "0/1"
+    reproduction: Optional[Dict[str, Any]] = None
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+def _build_attestation(witness: Witness) -> Dict[str, Any]:
+    """The Tier-1 claim, stated plainly. No crypto — this is the
+    assertion a Tier-3 proof would later make zero-knowledge."""
+    target = witness.target_binary_hash or witness.target_source_hash
+    target_kind = (
+        "binary" if witness.target_binary_hash else "source"
+    )
+    return {
+        "claim": (
+            f"input with sha256 {witness.bytes_hash} makes the "
+            f"{target_kind} artefact (sha256 {target}) exhibit "
+            f"outcome {witness.observed_outcome.value}"
+        ),
+        "witness_bytes_sha256": witness.bytes_hash,
+        "target_artefact_sha256": target,
+        "target_artefact_kind": target_kind,
+        "observed_outcome": witness.observed_outcome.value,
+        "attestation_only": True,
+        "note": (
+            "Tier 0/1 attestation — asserted, not proven. "
+            "Cryptographic proof requires Tier 3 (SP1)."
+        ),
+    }
+
+
+def assemble_bundle(
+    witness: Witness,
+    store: WitnessStore,
+) -> ZKPoXBundle:
+    """Assemble a Tier 0/1 bundle for ``witness``.
+
+    Raises :class:`ZKPoXBundleError` if the witness is ineligible
+    or its bytes blob is missing from ``store`` (can't assemble a
+    bundle whose subject bytes we can't retrieve).
+
+    The bytes themselves are NOT inlined into the returned bundle
+    object (they may be large); :func:`write_bundle` copies the
+    blob alongside the manifest on persist.
+    """
+    _require_clean_hash(witness.bytes_hash)
+
+    verdict = is_zkpox_eligible(witness)
+    if not verdict.eligible:
+        raise ZKPoXBundleError(
+            f"witness {witness.bytes_hash[:16]} ineligible: "
+            f"{verdict.reason}"
+        )
+
+    # Confirm the bytes are retrievable — a bundle for bytes we
+    # can't produce is useless to a prover.
+    if store.blob_path(witness.bytes_hash) is None:
+        raise ZKPoXBundleError(
+            f"witness {witness.bytes_hash[:16]} bytes blob missing "
+            f"from store; cannot assemble bundle"
+        )
+
+    return ZKPoXBundle(
+        witness_hash=witness.bytes_hash,
+        witness_len=witness.bytes_len,
+        source=witness.source.value,
+        observed_outcome=witness.observed_outcome.value,
+        outcome_detail=(
+            dict(witness.outcome_detail)
+            if isinstance(witness.outcome_detail, dict) else {}
+        ),
+        target_binary_hash=witness.target_binary_hash,
+        target_source_hash=witness.target_source_hash,
+        produced_by=witness.produced_by,
+        timestamp=(
+            witness.timestamp.isoformat()
+            if witness.timestamp is not None else None
+        ),
+        attestation=_build_attestation(witness),
+    )
+
+
+def write_bundle(
+    bundle: ZKPoXBundle,
+    store: WitnessStore,
+    out_dir: Path,
+) -> Path:
+    """Persist a bundle under ``out_dir/zkpox/<witness_hash>/``.
+
+    Layout mirrors the WitnessStore convention:
+
+        <out_dir>/zkpox/<witness_hash>/
+            manifest.json      # the ZKPoXBundle
+            witness.bin        # the raw witness bytes (copied from store)
+
+    Returns the bundle directory path. The bytes are copied so the
+    bundle is self-contained — a prover (or an operator handing the
+    bundle off) doesn't need the original WitnessStore.
+    """
+    # Re-validate before using the hash as a path component — a
+    # caller could have mutated bundle.witness_hash after assembly.
+    _require_clean_hash(bundle.witness_hash)
+    bundle_dir = Path(out_dir) / "zkpox" / bundle.witness_hash
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    # Copy the witness bytes into the bundle (self-contained).
+    data = store.get_bytes(bundle.witness_hash)
+    (bundle_dir / "witness.bin").write_bytes(data)
+
+    manifest_path = bundle_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(bundle.as_dict(), indent=2),
+        encoding="utf-8",
+    )
+    return bundle_dir
+
+
+def render_bundle(bundle: ZKPoXBundle) -> str:
+    """Console-friendly one-block view of a bundle."""
+    lines = [
+        f"ZKPoX bundle (tier {bundle.tier}):",
+        f"   witness:  {bundle.witness_hash[:16]}... "
+        f"({bundle.witness_len}B, source={bundle.source})",
+        f"   outcome:  {bundle.observed_outcome}",
+        "   target:   "
+        + (
+            f"binary {bundle.target_binary_hash[:16]}..."
+            if bundle.target_binary_hash
+            else f"source {bundle.target_source_hash[:16]}..."
+            if bundle.target_source_hash else "none"
+        ),
+        f"   claim:    {bundle.attestation['claim']}",
+    ]
+    if bundle.reproduction is not None:
+        rep = bundle.reproduction
+        lines.append(
+            f"   reproduced: {rep.get('reproduced')} "
+            f"({rep.get('runs')} runs)"
+        )
+    return "\n".join(lines)

--- a/packages/zkpox/eligibility.py
+++ b/packages/zkpox/eligibility.py
@@ -1,0 +1,183 @@
+"""ZKPoX Tier 0/1 — witness eligibility classification.
+
+A ZKPoX (Zero-Knowledge Proof of Exploit) proves "I possess an
+input that makes binary H exhibit outcome O" without revealing the
+input. Before any proving can happen, a witness has to *qualify* as
+a candidate. This module is that classifier.
+
+Eligibility is **free** (the package's trigger model): it reads the
+witness record and checks fields — no execution, no artifacts. It's
+surfaced in end-of-run summaries the way witness counts are
+(#607), so operators see "N of M witnesses are ZKPoX-eligible"
+without asking for anything heavier.
+
+The full tier model + free/on-request split lives in the package
+docstring (``packages/zkpox/__init__.py``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from core.witness.types import Witness, WitnessOutcome
+
+
+# Outcomes that represent an *observed security-relevant event* —
+# the bug actually fired. These are the only outcomes worth proving:
+# a NOT_RUN / NO_OBVIOUS_EFFECT / UNKNOWN witness has nothing to
+# prove ("I have bytes that make the binary do nothing" is not a
+# proof of exploit).
+_PROVABLE_OUTCOMES = frozenset({
+    WitnessOutcome.EXIT_SIGNAL,
+    WitnessOutcome.SANITIZER_REPORT,
+    WitnessOutcome.FLAG_CAPTURED,
+})
+
+
+@dataclass(frozen=True)
+class ZKPoXEligibility:
+    """Result of classifying one witness for ZKPoX candidacy."""
+    witness_hash: str
+    eligible: bool
+    reason: str
+    # The strongest tier this witness could *reach* given its
+    # current record. Tier 0/1 always (if eligible); 1.5 requires a
+    # runnable target artefact, which eligibility can't confirm on
+    # its own (the artefact lives outside the witness store) — so we
+    # report the ceiling as "0/1" here and let the reproduction step
+    # confirm 1.5 when the operator supplies the artefact.
+    max_tier_from_record: str = "none"
+
+
+def is_zkpox_eligible(witness: Witness) -> ZKPoXEligibility:
+    """Classify a single ``Witness`` for ZKPoX candidacy.
+
+    A witness is eligible iff ALL hold:
+
+      1. ``observed_outcome`` is a *provable* outcome — the bug was
+         actually observed (EXIT_SIGNAL / SANITIZER_REPORT /
+         FLAG_CAPTURED). NOT_RUN / NO_OBVIOUS_EFFECT / UNKNOWN have
+         nothing to prove.
+      2. A target artefact hash is present — at least one of
+         ``target_binary_hash`` or ``target_source_hash``. Without
+         a concrete target, there's no "binary H" to prove against.
+
+    ``bytes_len`` of 0 (empty witness) is *not* a hard
+    disqualifier — an empty input that triggers a crash is a valid
+    (if unusual) proof target — but it's noted in the reason so
+    operators can eyeball it.
+
+    Returns a :class:`ZKPoXEligibility`. Never raises — a witness
+    with surprising field shapes is reported ineligible with the
+    reason, not an exception.
+    """
+    h = witness.bytes_hash
+
+    outcome = witness.observed_outcome
+    if outcome not in _PROVABLE_OUTCOMES:
+        return ZKPoXEligibility(
+            witness_hash=h,
+            eligible=False,
+            reason=(
+                f"outcome {outcome.value!r} is not provable "
+                f"(need one of: "
+                f"{sorted(o.value for o in _PROVABLE_OUTCOMES)})"
+            ),
+        )
+
+    if not (witness.target_binary_hash or witness.target_source_hash):
+        return ZKPoXEligibility(
+            witness_hash=h,
+            eligible=False,
+            reason=(
+                "no target artefact hash "
+                "(need target_binary_hash or target_source_hash) — "
+                "nothing concrete to prove against"
+            ),
+        )
+
+    note = ""
+    if witness.bytes_len == 0:
+        note = " (note: zero-length witness — verify the empty input "
+        note += "genuinely triggers the outcome)"
+
+    return ZKPoXEligibility(
+        witness_hash=h,
+        eligible=True,
+        reason=f"provable outcome {outcome.value!r} + target hash present{note}",
+        max_tier_from_record="0/1",
+    )
+
+
+def summarize_eligibility(witnesses) -> dict:
+    """Classify an iterable of witnesses; return aggregate counts
+    for the free end-of-run surfacing.
+
+    Returns::
+
+        {
+          "total": int,
+          "eligible": int,
+          "ineligible": int,
+          "by_reason": {<reason-class>: count, ...},
+          "eligible_hashes": [<bytes_hash>, ...],
+        }
+
+    ``by_reason`` keys are coarse reason-classes (not the full
+    per-witness strings) so the summary stays compact:
+    ``provable`` / ``outcome_not_provable`` / ``no_target``.
+    """
+    total = 0
+    eligible = 0
+    by_reason: dict = {}
+    eligible_hashes = []
+
+    for w in witnesses:
+        total += 1
+        verdict = is_zkpox_eligible(w)
+        if verdict.eligible:
+            eligible += 1
+            eligible_hashes.append(verdict.witness_hash)
+            key = "provable"
+        elif "not provable" in verdict.reason:
+            key = "outcome_not_provable"
+        else:
+            key = "no_target"
+        by_reason[key] = by_reason.get(key, 0) + 1
+
+    return {
+        "total": total,
+        "eligible": eligible,
+        "ineligible": total - eligible,
+        "by_reason": by_reason,
+        "eligible_hashes": eligible_hashes,
+    }
+
+
+def render_eligibility_summary(
+    witnesses,
+    *,
+    indent: str = "   ",
+) -> Optional[str]:
+    """Console block for the free end-of-run surfacing; ``None``
+    when there are no witnesses (caller skips printing a header).
+
+        ZKPoX-eligible witnesses: 2 / 7
+           provable:             2
+           outcome_not_provable: 4
+           no_target:            1
+
+    Mirrors the cadence of
+    ``core.reporting.witnesses.render_witness_summary``.
+    """
+    s = summarize_eligibility(witnesses)
+    if s["total"] == 0:
+        return None
+    lines = [
+        f"ZKPoX-eligible witnesses: {s['eligible']} / {s['total']}",
+    ]
+    for key in ("provable", "outcome_not_provable", "no_target"):
+        if key in s["by_reason"]:
+            lines.append(f"{indent}{key}: {s['by_reason'][key]}")
+    return "\n".join(lines)

--- a/packages/zkpox/surfacing.py
+++ b/packages/zkpox/surfacing.py
@@ -1,0 +1,69 @@
+"""Free end-of-run surfacing of ZKPoX eligibility.
+
+The design's trigger model makes eligibility *free* — operators
+see "N of M witnesses are ZKPoX-eligible" in the run summary
+without asking for anything heavier (no bundle assembly, no
+execution). This module is the run-script-facing entry point that
+does the discovery + classification + render in one call.
+
+Lives in ``packages/zkpox/`` (not ``core/reporting/``) because it
+imports ``packages.zkpox.eligibility`` — and ``core/`` must not
+import ``packages/``. Run scripts (``raptor_fuzzing``,
+``raptor_agentic``) sit above both layers and call this alongside
+``core.reporting.render_witness_summary``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def render_run_eligibility(
+    output_dir: Optional[Path],
+    *,
+    project_root: Optional[Path] = None,
+    indent: str = "   ",
+) -> Optional[str]:
+    """Discover witnesses visible to a run and render the free
+    ZKPoX-eligibility summary block.
+
+    Reuses ``core.witness.discover_witness_stores`` /
+    ``iter_visible_witnesses`` (#614) so it sees the same stores
+    the witness summary does — run-local plus, when a ``/project``
+    is active, sibling runs.
+
+    Returns ``None`` when there are no witnesses (caller skips the
+    header), matching the cadence of
+    ``core.reporting.render_witness_summary``.
+
+    Never raises — discovery / classification failures log at
+    debug and produce ``None``. The end-of-run summary must not
+    crash because of a witness-store hiccup.
+    """
+    try:
+        from core.witness import (
+            discover_witness_stores,
+            iter_visible_witnesses,
+        )
+        from packages.zkpox.eligibility import render_eligibility_summary
+    except ImportError as e:
+        logger.debug("render_run_eligibility: import failed: %s", e)
+        return None
+
+    try:
+        stores = discover_witness_stores(
+            output_dir, project_root=project_root,
+        )
+        if not stores:
+            return None
+        witnesses = [w for _, w in iter_visible_witnesses(stores)]
+        return render_eligibility_summary(witnesses, indent=indent)
+    except Exception as e:  # noqa: BLE001 — best-effort surfacing
+        logger.debug(
+            "render_run_eligibility: %s: %s", type(e).__name__, e,
+        )
+        return None

--- a/packages/zkpox/tests/test_bundle.py
+++ b/packages/zkpox/tests/test_bundle.py
@@ -1,0 +1,194 @@
+"""Tests for ``packages.zkpox.bundle`` — Tier 0/1 prover-ready
+bundle assembly + persistence."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# packages/zkpox/tests/test_bundle.py → parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from core.witness.store import WitnessStore  # noqa: E402
+from core.witness.types import (  # noqa: E402
+    Witness,
+    WitnessOutcome,
+    WitnessSource,
+    compute_bytes_hash,
+)
+from packages.zkpox.bundle import (  # noqa: E402
+    ZKPoXBundleError,
+    assemble_bundle,
+    render_bundle,
+    write_bundle,
+)
+
+
+def _store_with_witness(
+    tmp_path: Path,
+    *,
+    outcome: WitnessOutcome = WitnessOutcome.EXIT_SIGNAL,
+    target_binary_hash="a" * 64,
+    target_source_hash=None,
+    data: bytes = b"crash-input",
+    source: WitnessSource = WitnessSource.FUZZ,
+):
+    store = WitnessStore(tmp_path / "witnesses")
+    w = Witness(
+        bytes_hash=compute_bytes_hash(data),
+        bytes_len=len(data),
+        source=source,
+        observed_outcome=outcome,
+        outcome_detail={"finding_id": "FIND-1", "signal": "SIGSEGV"},
+        target_binary_hash=target_binary_hash,
+        target_source_hash=target_source_hash,
+        produced_by="afl++",
+    )
+    store.put(w, data)
+    return store, w
+
+
+# ----------------------------------------------------------------------
+# Assembly
+# ----------------------------------------------------------------------
+
+
+def test_assemble_eligible_witness(tmp_path):
+    store, w = _store_with_witness(tmp_path)
+    bundle = assemble_bundle(w, store)
+    assert bundle.witness_hash == w.bytes_hash
+    assert bundle.tier == "0/1"
+    assert bundle.observed_outcome == "exit_signal"
+    assert bundle.target_binary_hash == "a" * 64
+    assert bundle.reproduction is None
+    # Attestation carries the plain claim
+    assert "exhibit outcome exit_signal" in bundle.attestation["claim"]
+    assert bundle.attestation["attestation_only"] is True
+    assert bundle.attestation["target_artefact_kind"] == "binary"
+
+
+def test_assemble_source_target(tmp_path):
+    store, w = _store_with_witness(
+        tmp_path, target_binary_hash=None, target_source_hash="b" * 64,
+    )
+    bundle = assemble_bundle(w, store)
+    assert bundle.target_source_hash == "b" * 64
+    assert bundle.attestation["target_artefact_kind"] == "source"
+
+
+def test_assemble_ineligible_raises(tmp_path):
+    """A NOT_RUN witness can't be bundled."""
+    store, w = _store_with_witness(
+        tmp_path, outcome=WitnessOutcome.NOT_RUN,
+    )
+    with pytest.raises(ZKPoXBundleError) as e:
+        assemble_bundle(w, store)
+    assert "ineligible" in str(e.value)
+
+
+def test_assemble_missing_blob_raises(tmp_path):
+    """Witness manifest exists but blob is gone → can't assemble."""
+    store, w = _store_with_witness(tmp_path)
+    # Delete the blob
+    blob = store.blob_path(w.bytes_hash)
+    blob.unlink()
+    with pytest.raises(ZKPoXBundleError) as e:
+        assemble_bundle(w, store)
+    assert "bytes blob missing" in str(e.value)
+
+
+# ----------------------------------------------------------------------
+# Persistence
+# ----------------------------------------------------------------------
+
+
+def test_write_bundle_layout(tmp_path):
+    store, w = _store_with_witness(tmp_path, data=b"the-crash-bytes")
+    bundle = assemble_bundle(w, store)
+    out = tmp_path / "out"
+    bundle_dir = write_bundle(bundle, store, out)
+
+    assert bundle_dir == out / "zkpox" / w.bytes_hash
+    assert (bundle_dir / "manifest.json").is_file()
+    assert (bundle_dir / "witness.bin").is_file()
+
+    # Bytes copied verbatim (self-contained bundle)
+    assert (bundle_dir / "witness.bin").read_bytes() == b"the-crash-bytes"
+
+    # Manifest round-trips
+    manifest = json.loads((bundle_dir / "manifest.json").read_text())
+    assert manifest["witness_hash"] == w.bytes_hash
+    assert manifest["tier"] == "0/1"
+    assert manifest["observed_outcome"] == "exit_signal"
+    assert manifest["attestation"]["attestation_only"] is True
+
+
+def test_write_bundle_self_contained_bytes_match_hash(tmp_path):
+    """The copied witness.bin must hash to the manifest's
+    witness_hash — a prover handed just the bundle dir can verify
+    integrity without the original store."""
+    store, w = _store_with_witness(tmp_path, data=b"xyz" * 100)
+    bundle = assemble_bundle(w, store)
+    bundle_dir = write_bundle(bundle, store, tmp_path / "out")
+    copied = (bundle_dir / "witness.bin").read_bytes()
+    assert compute_bytes_hash(copied) == bundle.witness_hash
+
+
+# ----------------------------------------------------------------------
+# Render
+# ----------------------------------------------------------------------
+
+
+def test_render_bundle_includes_claim(tmp_path):
+    store, w = _store_with_witness(tmp_path)
+    bundle = assemble_bundle(w, store)
+    out = render_bundle(bundle)
+    assert "tier 0/1" in out
+    assert "exit_signal" in out
+    assert "claim:" in out
+
+
+def test_render_bundle_shows_reproduction_when_present(tmp_path):
+    store, w = _store_with_witness(tmp_path)
+    bundle = assemble_bundle(w, store)
+    bundle.reproduction = {"reproduced": True, "runs": 3}
+    out = render_bundle(bundle)
+    assert "reproduced: True" in out
+
+
+# ----------------------------------------------------------------------
+# Path-traversal defense
+# ----------------------------------------------------------------------
+
+
+def test_write_bundle_rejects_traversal_hash(tmp_path):
+    """A mutated/corrupt witness_hash containing path-traversal
+    segments must NOT cause write_bundle to mkdir outside the
+    output tree. Pre-fix the mkdir(parents=True) ran on the
+    escaped path before the blob lookup raised — creating a dir
+    in the wrong place. Post-fix _require_clean_hash rejects any
+    non-sha256-hex value before any path is touched."""
+    store, w = _store_with_witness(tmp_path)
+    bundle = assemble_bundle(w, store)
+    bundle.witness_hash = "../../../../tmp/zkpox_traversal_probe"
+    out = tmp_path / "out"
+    with pytest.raises(ZKPoXBundleError) as e:
+        write_bundle(bundle, store, out)
+    assert "not a sha256 hex digest" in str(e.value)
+    assert not Path("/tmp/zkpox_traversal_probe").exists()
+
+
+def test_assemble_rejects_non_hex_hash(tmp_path):
+    """assemble_bundle validates the hash up-front too — a witness
+    whose bytes_hash isn't a clean digest is refused."""
+    store, w = _store_with_witness(tmp_path)
+    # Forge a bad hash on the witness object
+    object.__setattr__(w, "bytes_hash", "not-a-real-hash")
+    with pytest.raises(ZKPoXBundleError) as e:
+        assemble_bundle(w, store)
+    assert "not a sha256 hex digest" in str(e.value)

--- a/packages/zkpox/tests/test_eligibility.py
+++ b/packages/zkpox/tests/test_eligibility.py
@@ -1,0 +1,180 @@
+"""Tests for ``packages.zkpox.eligibility`` — witness → ZKPoX
+candidacy classification (the free Tier 0/1 layer)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+# packages/zkpox/tests/test_eligibility.py → parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from core.witness.types import (  # noqa: E402
+    Witness,
+    WitnessOutcome,
+    WitnessSource,
+    compute_bytes_hash,
+)
+from packages.zkpox.eligibility import (  # noqa: E402
+    is_zkpox_eligible,
+    render_eligibility_summary,
+    summarize_eligibility,
+)
+
+
+def _w(
+    *,
+    outcome: WitnessOutcome,
+    target_binary_hash=None,
+    target_source_hash=None,
+    bytes_len=10,
+    data: bytes = b"witness",
+) -> Witness:
+    return Witness(
+        bytes_hash=compute_bytes_hash(data),
+        bytes_len=bytes_len,
+        source=WitnessSource.LLM_EMIT_RUN,
+        observed_outcome=outcome,
+        outcome_detail={},
+        target_binary_hash=target_binary_hash,
+        target_source_hash=target_source_hash,
+    )
+
+
+# ----------------------------------------------------------------------
+# Provable-outcome gate
+# ----------------------------------------------------------------------
+
+
+def test_exit_signal_with_binary_is_eligible():
+    w = _w(outcome=WitnessOutcome.EXIT_SIGNAL,
+           target_binary_hash="a" * 64)
+    v = is_zkpox_eligible(w)
+    assert v.eligible is True
+    assert v.max_tier_from_record == "0/1"
+
+
+def test_sanitizer_report_with_source_is_eligible():
+    w = _w(outcome=WitnessOutcome.SANITIZER_REPORT,
+           target_source_hash="b" * 64)
+    assert is_zkpox_eligible(w).eligible is True
+
+
+def test_flag_captured_is_eligible():
+    w = _w(outcome=WitnessOutcome.FLAG_CAPTURED,
+           target_binary_hash="c" * 64)
+    assert is_zkpox_eligible(w).eligible is True
+
+
+def test_not_run_is_ineligible():
+    w = _w(outcome=WitnessOutcome.NOT_RUN, target_binary_hash="a" * 64)
+    v = is_zkpox_eligible(w)
+    assert v.eligible is False
+    assert "not provable" in v.reason
+
+
+def test_no_obvious_effect_is_ineligible():
+    w = _w(outcome=WitnessOutcome.NO_OBVIOUS_EFFECT,
+           target_binary_hash="a" * 64)
+    assert is_zkpox_eligible(w).eligible is False
+
+
+def test_unknown_is_ineligible():
+    w = _w(outcome=WitnessOutcome.UNKNOWN, target_binary_hash="a" * 64)
+    assert is_zkpox_eligible(w).eligible is False
+
+
+# ----------------------------------------------------------------------
+# Target-artefact gate
+# ----------------------------------------------------------------------
+
+
+def test_provable_outcome_no_target_is_ineligible():
+    """A real outcome but no target hash → nothing to prove
+    against."""
+    w = _w(outcome=WitnessOutcome.EXIT_SIGNAL)  # no target
+    v = is_zkpox_eligible(w)
+    assert v.eligible is False
+    assert "no target artefact" in v.reason
+
+
+def test_either_target_hash_suffices():
+    w_bin = _w(outcome=WitnessOutcome.EXIT_SIGNAL,
+               target_binary_hash="a" * 64)
+    w_src = _w(outcome=WitnessOutcome.EXIT_SIGNAL,
+               target_source_hash="b" * 64)
+    assert is_zkpox_eligible(w_bin).eligible is True
+    assert is_zkpox_eligible(w_src).eligible is True
+
+
+# ----------------------------------------------------------------------
+# Edge cases
+# ----------------------------------------------------------------------
+
+
+def test_zero_length_witness_eligible_but_noted():
+    """Empty input that triggers a crash is valid but flagged for
+    eyeballing."""
+    w = _w(outcome=WitnessOutcome.EXIT_SIGNAL,
+           target_binary_hash="a" * 64, bytes_len=0)
+    v = is_zkpox_eligible(w)
+    assert v.eligible is True
+    assert "zero-length" in v.reason
+
+
+# ----------------------------------------------------------------------
+# Aggregate summary
+# ----------------------------------------------------------------------
+
+
+def test_summarize_counts():
+    witnesses = [
+        _w(outcome=WitnessOutcome.EXIT_SIGNAL,
+           target_binary_hash="a" * 64, data=b"1"),
+        _w(outcome=WitnessOutcome.SANITIZER_REPORT,
+           target_binary_hash="a" * 64, data=b"2"),
+        _w(outcome=WitnessOutcome.NOT_RUN,
+           target_binary_hash="a" * 64, data=b"3"),
+        _w(outcome=WitnessOutcome.NO_OBVIOUS_EFFECT,
+           target_binary_hash="a" * 64, data=b"4"),
+        _w(outcome=WitnessOutcome.EXIT_SIGNAL, data=b"5"),  # no target
+    ]
+    s = summarize_eligibility(witnesses)
+    assert s["total"] == 5
+    assert s["eligible"] == 2
+    assert s["ineligible"] == 3
+    assert s["by_reason"]["provable"] == 2
+    assert s["by_reason"]["outcome_not_provable"] == 2
+    assert s["by_reason"]["no_target"] == 1
+    assert len(s["eligible_hashes"]) == 2
+
+
+def test_summarize_empty():
+    s = summarize_eligibility([])
+    assert s["total"] == 0
+    assert s["eligible"] == 0
+    assert s["eligible_hashes"] == []
+
+
+# ----------------------------------------------------------------------
+# Render
+# ----------------------------------------------------------------------
+
+
+def test_render_none_when_empty():
+    assert render_eligibility_summary([]) is None
+
+
+def test_render_shows_ratio_and_breakdown():
+    witnesses = [
+        _w(outcome=WitnessOutcome.EXIT_SIGNAL,
+           target_binary_hash="a" * 64, data=b"1"),
+        _w(outcome=WitnessOutcome.NOT_RUN,
+           target_binary_hash="a" * 64, data=b"2"),
+    ]
+    out = render_eligibility_summary(witnesses)
+    assert "ZKPoX-eligible witnesses: 1 / 2" in out
+    assert "provable: 1" in out
+    assert "outcome_not_provable: 1" in out

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -1733,6 +1733,18 @@ Examples:
                         # Strip one level of leading indent so it sits
                         # consistently under the analysis-complete bullets.
                         print(f"  {line}")
+
+                # ZKPoX eligibility — FREE surfacing (design trigger
+                # model): classification only, no bundle assembly,
+                # no execution. Shows how many witnesses are ZK-proof
+                # candidates.
+                from packages.zkpox import render_run_eligibility
+                elig_block = render_run_eligibility(
+                    autonomous_out / "witnesses",
+                )
+                if elig_block:
+                    for line in elig_block.splitlines():
+                        print(f"  {line}")
         else:
             print("⚠️  Analysis failed or produced no output")
             if stderr:

--- a/raptor_fuzzing.py
+++ b/raptor_fuzzing.py
@@ -778,6 +778,20 @@ Examples:
             print(f" LLM-exploit witnesses ({out_dir / 'analysis' / 'witnesses'}):")
             print(llm_summary)
 
+    # ZKPoX eligibility — FREE surfacing (trigger model): pure
+    # classification of the witnesses we just recorded, no bundle
+    # assembly and no execution. Tells the operator how many
+    # witnesses could become zero-knowledge proof candidates — a
+    # pre-flight signal for whether installing the heavyweight
+    # proving stack would have anything to chew on. Discovery scans
+    # both run-local stores (<out>/witnesses + <out>/analysis/
+    # witnesses) in one pass.
+    from packages.zkpox import render_run_eligibility
+    elig = render_run_eligibility(out_dir)
+    if elig:
+        print("")
+        print(elig)
+
     # Save summary report
     report = {
         "binary": str(binary_path),


### PR DESCRIPTION
Lands everything achievable toward Zero-Knowledge Proof of Exploit WITHOUT the heavyweight proving stack (SP1 zkVM + RISC-V toolchain
+ the crypto chain). The point: an operator who wants real ZK proofs installs those deps themselves — but they shouldn't have to install anything to learn whether it's even worth it. This is the pre-flight signal.

Consumes the core.witness substrate the exploitation arc shipped (#579–#614), and nothing else — no SMT/Z3, no SP1, no RISC-V. The full tier model lives in the package docstring
(packages/zkpox/__init__.py) so this is self-contained.

Trigger model (mirrors the witness arc's cheap-is-default, running-code-is-opt-in split):

  - FREE: eligibility classification. is_zkpox_eligible(witness) flags a candidate iff the outcome is provable (EXIT_SIGNAL / SANITIZER_REPORT / FLAG_CAPTURED — the bug actually fired) AND a target artefact hash is present. Surfaced in raptor_fuzzing and raptor_agentic end-of-run summaries like witness counts (#607): "N of M witnesses are ZKPoX-eligible." Zero deps, no execution, no artifacts — just tells the operator whether installing the heavy proving stack would have anything to chew on.

  - ON REQUEST: bundle assembly. assemble_bundle() builds the prover-ready manifest (witness bytes, target hashes, observed outcome, provenance, a Tier-1 attestation claim); write_bundle() persists it self-contained under <out>/zkpox/<witness_hash>/ (manifest.json + witness.bin copied from the store, so a prover needs only the bundle dir). This is the stable hand-off shape every higher tier (1.5 reproduction, 2 RISC-V, 3 SP1) consumes.

Tier 0/1 is attestation-only — the claim is asserted, not proven; cryptographic strength comes at Tier 3. This ships the substrate the prover reads plus the free eligibility surfacing.

Module home: packages/zkpox/ (consumes core.witness, not core itself). N for reproduction and the heavier tiers land in follow-ups.