### PR TITLE
ci: install git in the deps image for container-job checkout

### DIFF
--- a/.github/docker/ci-deps.Dockerfile
+++ b/.github/docker/ci-deps.Dockerfile
@@ -13,6 +13,16 @@
 # env.PYTHON_VERSION (3.12).
 FROM python:3.12-slim-bookworm
 
+# git is required by actions/checkout when this image is used as a
+# container-job base — the slim base ships none, and checkout fails
+# without it. ca-certificates is already present in the slim image.
+# Kept to the single tool checkout needs; tiers that require heavier
+# system tooling (sandbox namespaces, radare2/gcc) stay on the runner
+# rather than bloating this image.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /opt/raptor-ci
 
 # Copy only the manifests first so the dependency layer cache survives


### PR DESCRIPTION
Prerequisite for running the Python test tiers inside the deps image (phase 2 of the fan-out fix). actions/checkout requires git to be present, and python:3.12-slim-bookworm ships none — so a container job using this image would fail at checkout before any test runs.

Adds git only (the one tool checkout needs); ca-certificates is already in the slim base. Heavier-tooling tiers (sandbox namespaces, exploit_feasibility's radare2/gcc) deliberately stay on the runner.

Must land + rebuild :main BEFORE the canary tier rewrite, so the canary validates against an image that can actually be checked out.