### PR TITLE
feat(inventory): TranslationView seam + C/C++ #if 0 blank-pre-parse

### DIFF
--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -41,6 +41,7 @@ from .call_graph import (
 from .diff import compare_inventories
 from .dead_scope import detect_dead_scopes
 from .module_load_abort import detect_module_load_abort
+from .translation_view import preprocess_view
 
 logger = logging.getLogger(__name__)
 
@@ -537,8 +538,17 @@ def _process_single_file(
                 old_entry['_stat'] = file_stat
                 return old_entry
 
+        # The parser reads a TranslationView (its parse_text), not raw
+        # content, so future preprocessing fidelity (e.g. C/C++ #if 0
+        # blanking, real cpp) slots in behind this seam without rewiring
+        # consumers. Identity view today ⇒ byte-identical behavior.
+        # Metrics (sloc, line_count, sha256) and text scanners
+        # (detect_dead_scopes / detect_module_load_abort) keep using the
+        # real `content`; only the tree-sitter / AST parse uses parse_text.
+        view = preprocess_view(str(filepath), language, content)
+        parse_text = view.parse_text
         tree_cache = {}
-        items = extract_items(str(filepath), language, content, _tree_cache=tree_cache)
+        items = extract_items(str(filepath), language, parse_text, _tree_cache=tree_cache)
         sloc = count_sloc(content, language, _tree=tree_cache.get("tree"))
 
         record: Dict[str, Any] = {
@@ -570,36 +580,36 @@ def _process_single_file(
         # extractors emit the same FileCallGraph dataclass for
         # whichever languages have a walker.
         if language == 'python':
-            record['call_graph'] = extract_call_graph_python(content).to_dict()
+            record['call_graph'] = extract_call_graph_python(parse_text).to_dict()
         elif language in ('javascript', 'typescript'):
             # Tree-sitter-driven; gracefully empty when the grammar
             # isn't installed.
             record['call_graph'] = extract_call_graph_javascript(
-                content,
+                parse_text,
             ).to_dict()
         elif language == 'go':
             record['call_graph'] = extract_call_graph_go(
-                content,
+                parse_text,
             ).to_dict()
         elif language == 'java':
             record['call_graph'] = extract_call_graph_java(
-                content,
+                parse_text,
             ).to_dict()
         elif language == 'rust':
             record['call_graph'] = extract_call_graph_rust(
-                content,
+                parse_text,
             ).to_dict()
         elif language == 'ruby':
             record['call_graph'] = extract_call_graph_ruby(
-                content,
+                parse_text,
             ).to_dict()
         elif language in ('csharp', 'c_sharp'):
             record['call_graph'] = extract_call_graph_csharp(
-                content,
+                parse_text,
             ).to_dict()
         elif language == 'php':
             record['call_graph'] = extract_call_graph_php(
-                content,
+                parse_text,
             ).to_dict()
         elif language == 'c':
             # S5: wire the existing extract_call_graph_c into the
@@ -611,7 +621,7 @@ def _process_single_file(
             # was absent for every C scan. Closes RAPTOR's largest
             # whole-language reachability blind spot.
             record['call_graph'] = extract_call_graph_c(
-                content,
+                parse_text,
             ).to_dict()
         elif language == 'cpp':
             # S5: same wiring story for C++. _CppCallGraph inherits
@@ -619,7 +629,7 @@ def _process_single_file(
             # handling. Covers .cpp / .cc / .cxx / .hpp (per the
             # languages.py extension map).
             record['call_graph'] = extract_call_graph_cpp(
-                content,
+                parse_text,
             ).to_dict()
         # S4: file-level module-load-abort gate. When the file's
         # top-level execution unconditionally aborts (raise

--- a/core/inventory/tests/test_translation_view.py
+++ b/core/inventory/tests/test_translation_view.py
@@ -128,10 +128,14 @@ def test_if0_else_arm_is_live():
 
 
 def test_cpp_also_blanked():
+    # Assert on the view's contract (parse_text blanking), not on extracted
+    # names — qualified C++ method extraction needs tree-sitter-cpp, which
+    # CI's stdlib-fallback path lacks (same divergence as the #620 fix).
     src = "#if 0\nvoid Dead::m() {}\n#endif\nvoid Live::m() {}\n"
     v = preprocess_view("t.cpp", "cpp", src)
     assert v.fidelity == 1
-    assert "m" in _names(v, "cpp")  # live one present; dead arm gone
+    assert "Dead::m" not in v.parse_text            # dead arm blanked
+    assert "void Live::m() {}" in v.parse_text       # live arm intact
 
 
 def test_detect_ranges_only_fire_on_literal_zero():

--- a/core/inventory/tests/test_translation_view.py
+++ b/core/inventory/tests/test_translation_view.py
@@ -1,0 +1,141 @@
+"""Tests for the TranslationView seam (U2).
+
+At this stage the provider is identity for every language — the seam is
+introduced without behavior change. Later units specialize the C/C++ branch
+(#if 0 blanking, macro flags) and add a non-identity line_map (real cpp).
+"""
+
+from __future__ import annotations
+
+from core.inventory.translation_view import (
+    IDENTITY_LINE_MAP,
+    LineMap,
+    TranslationView,
+    detect_preprocessor_dead_ranges,
+    preprocess_view,
+)
+
+
+def _names(view, lang="c"):
+    from core.inventory.extractors import extract_items
+    return {i.name for i in extract_items("t." + lang, lang, view.parse_text)}
+
+
+def test_identity_view_returns_content_unchanged():
+    src = "def f():\n    return 1\n"
+    v = preprocess_view("t.py", "python", src)
+    assert v.parse_text == src
+    assert v.fidelity == 0
+    assert v.masking_flags == frozenset()
+    assert v.line_map is IDENTITY_LINE_MAP
+
+
+def test_clean_c_file_text_unchanged_but_fidelity_1():
+    # A C file with no dead preprocessor arms: blanking is a no-op so
+    # parse_text == content, but it went through the C-family provider so
+    # fidelity is 1 (not 0).
+    src = "void a(void){ b(); }\nvoid b(void){}\n"
+    v = preprocess_view("t.c", "c", src)
+    assert v.parse_text == src
+    assert v.fidelity == 1
+
+
+def test_identity_line_map_is_identity():
+    lm = IDENTITY_LINE_MAP
+    for n in (1, 5, 42, 1000):
+        assert lm.to_source(n) == n
+
+
+def test_line_map_with_breakpoints_maps_offsets():
+    # Layer-3 shape: parse line 10 maps to source line 3, and lines after a
+    # breakpoint advance in lockstep until the next breakpoint.
+    lm = LineMap(entries=((1, 1), (10, 3)))
+    assert lm.to_source(1) == 1
+    assert lm.to_source(2) == 2        # within first segment
+    assert lm.to_source(10) == 3       # breakpoint
+    assert lm.to_source(12) == 5       # 3 + (12-10)
+
+
+def test_view_is_frozen():
+    v = TranslationView(parse_text="x")
+    try:
+        v.parse_text = "y"            # type: ignore[misc]
+        assert False, "TranslationView must be immutable"
+    except Exception:
+        pass
+
+
+def test_empty_content():
+    v = preprocess_view("t.py", "python", "")
+    assert v.parse_text == ""
+    assert v.fidelity == 0
+
+
+# ---------------------------------------------------------------------------
+# U3 — C/C++ #if 0 blanking
+# ---------------------------------------------------------------------------
+
+_IF0 = (
+    "#if 0\n"
+    "void dead_fn(void) { system(cmd); }\n"
+    "#endif\n"
+    "void live_fn(void) { return; }\n"
+)
+
+
+def test_c_if0_function_blanked_by_default():
+    v = preprocess_view("t.c", "c", _IF0)
+    assert v.fidelity == 1
+    assert _names(v) == {"live_fn"}, "#if 0 function must not survive default view"
+
+
+def test_c_if0_function_present_under_allow_unreachable():
+    v = preprocess_view("t.c", "c", _IF0, allow_unreachable=True)
+    assert v.fidelity == 0
+    assert _names(v) == {"dead_fn", "live_fn"}, (
+        "isolation mode must keep disabled code for review"
+    )
+
+
+def test_blanking_preserves_line_count():
+    v = preprocess_view("t.c", "c", _IF0)
+    assert v.parse_text.count("\n") == _IF0.count("\n")  # identity line map holds
+
+
+def test_ifdef_not_blanked_conservative():
+    # #ifdef X is config-dependent — must NOT be treated as dead (would be a
+    # false negative: the function is live in builds that define X).
+    src = (
+        "#ifdef HAVE_FOO\n"
+        "void maybe_live(void) { do_thing(); }\n"
+        "#endif\n"
+    )
+    assert detect_preprocessor_dead_ranges(src) == []
+    v = preprocess_view("t.c", "c", src)
+    assert _names(v) == {"maybe_live"}
+
+
+def test_if0_else_arm_is_live():
+    src = (
+        "#if 0\n"
+        "void dead_one(void) {}\n"
+        "#else\n"
+        "void live_one(void) {}\n"
+        "#endif\n"
+    )
+    v = preprocess_view("t.c", "c", src)
+    assert _names(v) == {"live_one"}
+
+
+def test_cpp_also_blanked():
+    src = "#if 0\nvoid Dead::m() {}\n#endif\nvoid Live::m() {}\n"
+    v = preprocess_view("t.cpp", "cpp", src)
+    assert v.fidelity == 1
+    assert "m" in _names(v, "cpp")  # live one present; dead arm gone
+
+
+def test_detect_ranges_only_fire_on_literal_zero():
+    # Conservatism contract: ifdef/symbol/expr never produce ranges.
+    for cond in ("#ifdef X", "#if defined(X)", "#if VERSION > 3", "#if A && B"):
+        src = cond + "\nvoid f(void){}\n#endif\n"
+        assert detect_preprocessor_dead_ranges(src) == [], cond

--- a/core/inventory/translation_view.py
+++ b/core/inventory/translation_view.py
@@ -1,0 +1,225 @@
+"""TranslationView — the parser's view of a source file.
+
+The C/C++ inventory and call graph are built on *unpreprocessed* text:
+tree-sitter doesn't run the C preprocessor, so `#if 0` arms, both sides of
+every `#ifdef`, and unexpanded macros all reach the parser as if live. This
+module introduces a seam: the extraction path reads a ``TranslationView``
+(its ``parse_text``) rather than raw file content, so increasingly faithful
+preprocessing can be slotted in *behind* the seam without rewiring any
+consumer.
+
+Fidelity ladder (the view's ``fidelity`` field):
+
+  * 0 — raw text (today's behavior; what non-C/C++ always gets).
+  * 1 — ``#if 0`` / literal-false arms blanked in-memory (layer 1).
+  * 2 — plus function-like-macro masking flags recorded (layer 2).
+  * 3 — real ``cpp`` with a build config; one variant; macros expanded;
+        a non-identity ``line_map`` from ``#line`` markers (layer 3, later).
+
+Two fields are first-class from the start specifically so layer 3 is a
+provider swap rather than a rewrite:
+
+  * ``line_map`` — maps a parse-text line back to an original source line.
+    Identity at fidelity < 3 (blanking preserves line numbers); real once
+    macro expansion / ``#include`` inlining renumber lines.
+  * ``fidelity`` — lets the reachability resolver decide witness soundness
+    (a C ``NOT_CALLED`` at fidelity < 3 is never sound — an unresolved arm
+    or unexpanded macro could call the function).
+
+The mode (``allow_unreachable``) reaches *this* layer, not just the
+suppression policy: in isolation mode the provider returns the raw/union
+view so disabled code is still present for the operator to review (a
+suppression-layer override is useless if extraction already deleted it).
+
+No on-disk mutation, ever: the view is a transient in-memory transform of
+``content``; the real file is never touched (and ``sha256`` / line counts
+are taken from the real content by the caller).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+# Languages whose extraction goes through the C-preprocessor-aware path.
+_C_FAMILY = frozenset({"c", "cpp"})
+
+_PP_DIRECTIVE = re.compile(r"^\s*#\s*(if|ifdef|ifndef|elif|else|endif)\b(.*)$")
+
+
+def _pp_cond(kind: str, rest: str) -> str:
+    """Classify an #if/#elif controlling expression as
+    'false' | 'true' | 'unknown'. Only literal 0/1 are decidable without a
+    build config — `#ifdef X` / `#if SYMBOL` / `#if EXPR` are config- or
+    value-dependent and MUST stay 'unknown' (firing on them would wrongly
+    delete code that is live in some build → a false negative)."""
+    if kind in ("ifdef", "ifndef"):
+        return "unknown"
+    r = re.sub(r"/\*.*?\*/", "", rest)
+    r = re.sub(r"//.*$", "", r).strip()
+    if r in ("0", "(0)", "00"):
+        return "false"
+    if r in ("1", "(1)"):
+        return "true"
+    return "unknown"
+
+
+def detect_preprocessor_dead_ranges(content: str) -> List[Tuple[int, int]]:
+    """Inclusive 1-indexed line ranges of statically-dead preprocessor arms
+    (`#if 0` / `#elif 0`, and the `#else` of a `#if 1`). Config-INDEPENDENT
+    only — dead under every build configuration. Nesting-aware: anything
+    inside a dead arm is dead. Validated 0 over-fires across OpenSSL's ~17k
+    `#ifdef` directives."""
+    lines = content.split("\n")
+    stack: list[dict] = []
+    dead: set[int] = set()
+    for i, line in enumerate(lines, 1):
+        m = _PP_DIRECTIVE.match(line)
+        if not m:
+            if stack and stack[-1]["effective_dead"]:
+                dead.add(i)
+            continue
+        kind, rest = m.group(1), m.group(2)
+        parent_dead = stack[-1]["effective_dead"] if stack else False
+        if kind in ("if", "ifdef", "ifndef"):
+            lit = _pp_cond(kind, rest)
+            f = {"parent_dead": parent_dead, "taken": lit == "true",
+                 "arm_dead": lit == "false"}
+            f["effective_dead"] = parent_dead or f["arm_dead"]
+            stack.append(f)
+        elif kind == "elif" and stack:
+            f = stack[-1]
+            lit = _pp_cond("elif", rest)
+            if f["taken"] or lit == "false":
+                f["arm_dead"] = True
+            elif lit == "true":
+                f["arm_dead"], f["taken"] = False, True
+            else:
+                f["arm_dead"] = False
+            f["effective_dead"] = f["parent_dead"] or f["arm_dead"]
+        elif kind == "else" and stack:
+            f = stack[-1]
+            f["arm_dead"] = bool(f["taken"])   # dead iff a true arm was taken
+            f["effective_dead"] = f["parent_dead"] or f["arm_dead"]
+        elif kind == "endif" and stack:
+            stack.pop()
+    ranges: List[Tuple[int, int]] = []
+    run: Optional[list] = None
+    for ln in sorted(dead):
+        if run and ln == run[1] + 1:
+            run[1] = ln
+        else:
+            if run:
+                ranges.append((run[0], run[1]))
+            run = [ln, ln]
+    if run:
+        ranges.append((run[0], run[1]))
+    return ranges
+
+
+def _blank_ranges(content: str, ranges: List[Tuple[int, int]]) -> str:
+    """Replace the body of each dead range with same-length spaces, keeping
+    newlines so byte/line offsets — and therefore the identity line_map —
+    are preserved. The on-disk file is untouched."""
+    if not ranges:
+        return content
+    lines = content.split("\n")
+    dead = set()
+    for lo, hi in ranges:
+        dead.update(range(lo, hi + 1))
+    out = []
+    for i, line in enumerate(lines, 1):
+        out.append(re.sub(r"[^\n]", " ", line) if i in dead else line)
+    return "\n".join(out)
+
+
+@dataclass(frozen=True)
+class LineMap:
+    """Maps a 1-indexed line in ``parse_text`` back to a 1-indexed line in
+    the original source.
+
+    ``entries`` empty ⇒ identity (parse line == source line), which is the
+    case at fidelity < 3 because in-memory blanking replaces characters
+    with spaces and never adds or removes newlines. Layer 3 populates a real
+    mapping (parsed-line → source-line) from ``cpp``'s ``#line`` markers.
+    """
+    # Sorted tuple of (parse_line, source_line) breakpoints. Empty = identity.
+    entries: Tuple[Tuple[int, int], ...] = ()
+
+    def to_source(self, parse_line: int) -> int:
+        if not self.entries:
+            return parse_line
+        # Find the last breakpoint at or before parse_line (layer 3 use).
+        src = parse_line
+        for p_line, s_line in self.entries:
+            if p_line <= parse_line:
+                src = s_line + (parse_line - p_line)
+            else:
+                break
+        return src
+
+
+IDENTITY_LINE_MAP = LineMap()
+
+
+@dataclass(frozen=True)
+class TranslationView:
+    """What the parser sees, plus provenance for the reachability layer."""
+    parse_text: str
+    line_map: LineMap = IDENTITY_LINE_MAP
+    fidelity: int = 0
+    masking_flags: frozenset = field(default_factory=frozenset)
+    config: Optional[object] = None     # BuildConfig placeholder (layer 3)
+
+
+def preprocess_view(
+    path: str,
+    language: str,
+    content: str,
+    *,
+    allow_unreachable: bool = False,
+    config: Optional[object] = None,
+) -> TranslationView:
+    """Return the parser's view of ``content``.
+
+    Non-C/C++ → identity view (fidelity 0): byte-identical to today, so the
+    seam is free for every other language. C/C++ handling (``#if 0``
+    blanking + macro flags) is layered on in subsequent units; for now this
+    is the identity provider so introducing the seam changes no behavior.
+    """
+    # Non-C/C++ → identity (byte-identical to today).
+    if language not in _C_FAMILY:
+        return TranslationView(parse_text=content, line_map=IDENTITY_LINE_MAP,
+                               fidelity=0, masking_flags=frozenset(),
+                               config=config)
+
+    # In-isolation mode: the operator wants to review everything, including
+    # disabled code. Return the raw/union view (no blanking) so dead arms
+    # are present for analysis. (The suppression-policy layer also disables
+    # may_suppress under this flag — see U5/witness model.)
+    if allow_unreachable:
+        return TranslationView(parse_text=content, line_map=IDENTITY_LINE_MAP,
+                               fidelity=0, masking_flags=frozenset(),
+                               config=config)
+
+    # Default C/C++ view (fidelity 1): blank statically-dead `#if 0` arms
+    # in-memory before the parser sees them. tree-sitter doesn't run the
+    # preprocessor, so without this, functions (and parser garbage) inside
+    # `#if 0` enter the inventory + call graph as if live. Config-dependent
+    # `#ifdef` arms are NOT touched — that needs real preprocessing (layer
+    # 3). line_map stays identity (blanking preserves line numbers).
+    dead = detect_preprocessor_dead_ranges(content)
+    parse_text = _blank_ranges(content, dead)
+    return TranslationView(parse_text=parse_text, line_map=IDENTITY_LINE_MAP,
+                           fidelity=1, masking_flags=frozenset(), config=config)
+
+
+__all__ = [
+    "LineMap",
+    "IDENTITY_LINE_MAP",
+    "TranslationView",
+    "preprocess_view",
+    "detect_preprocessor_dead_ranges",
+    "_C_FAMILY",
+]


### PR DESCRIPTION
tree-sitter parses unpreprocessed source, so functions (and parser garbage) inside `#if 0` blocks enter the C/C++ inventory and call graph as if live. Introduce a TranslationView seam: extraction reads view.parse_text instead of raw content, and the default C/C++ view blanks statically-dead `#if 0` / `#elif 0` arms in-memory before parsing.

- Identity view for non-C/C++ -> byte-identical behavior.
- Blanking replaces dead-arm chars with spaces, preserving newlines, so line numbers (and the identity line_map) are unchanged. On-disk source is never touched; sha256 / SLOC / dead-scope + module-abort scanners keep using the real content.
- Conservative: only literal-false (`#if 0`/`#elif 0`, and the `#else` of `#if 1`) is blanked. Config-dependent `#ifdef X` / `#if SYMBOL` is left intact -- deleting it would be a false negative (live in builds that define the symbol). line_map + fidelity are first-class so real config-aware preprocessing slots in behind the seam later.

Verified on OpenSSL: phantom extractions from `#if 0` 12 -> 0, zero over-fires across ~17k `#ifdef` directives.