### PR TITLE
ci: containerize codeql/llm_analysis/fuzzing/orchestration tiers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -518,62 +518,60 @@ jobs:
   # touching only one package skips the others. Filters live in
   # compute_filters.FILTERS and are validated by ci-lint-tests above.
   python-unit-tests-codeql:
-    needs: [pre_check, changes, deps]
+    needs: [pre_check, changes]
     if: |
       needs.pre_check.outputs.should_skip != 'true' &&
       (needs.changes.outputs.force_full == 'true' ||
        needs.changes.outputs.codeql == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    permissions:
+      contents: read
+      packages: read              # pull the private GHCR deps image
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/raptor-ci-deps:main
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
         with:
           persist-credentials: false
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Download venv artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # was v8.0.1
-        with:
-          name: venv-${{ github.run_id }}
-          path: ${{ env.VENV_PATH }}
-      - name: Restore venv permissions
-        run: chmod +x $VENV_PATH/bin/*
+      - name: Reconcile deps
+        # No-op unless this PR changed requirements*.txt before the
+        # image rebuilt on main; then installs only the delta.
+        run: pip install --no-cache-dir -r requirements-dev.txt
       - name: Run codeql tests
-        run: |
-          source $VENV_PATH/bin/activate
-          python -m pytest packages/codeql/tests -n auto
+        run: python -m pytest packages/codeql/tests -n auto
 
   python-unit-tests-llm-analysis:
-    needs: [pre_check, changes, deps]
+    needs: [pre_check, changes]
     if: |
       needs.pre_check.outputs.should_skip != 'true' &&
       (needs.changes.outputs.force_full == 'true' ||
        needs.changes.outputs.llm_analysis == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    permissions:
+      contents: read
+      packages: read              # pull the private GHCR deps image
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/raptor-ci-deps:main
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
         with:
           persist-credentials: false
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Download venv artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # was v8.0.1
-        with:
-          name: venv-${{ github.run_id }}
-          path: ${{ env.VENV_PATH }}
-      - name: Restore venv permissions
-        run: chmod +x $VENV_PATH/bin/*
+      - name: Reconcile deps
+        # No-op unless this PR changed requirements*.txt before the
+        # image rebuilt on main; then installs only the delta.
+        run: pip install --no-cache-dir -r requirements-dev.txt
       - name: Run llm_analysis tests
-        run: |
-          source $VENV_PATH/bin/activate
-          python -m pytest packages/llm_analysis/tests -n auto
+        run: python -m pytest packages/llm_analysis/tests -n auto
 
   python-unit-tests-cve-diff:
     needs: [pre_check, changes, deps]
@@ -605,89 +603,97 @@ jobs:
           python -m pytest packages/cve_diff/tests -n auto
 
   python-unit-tests-fuzzing:
-    needs: [pre_check, changes, deps]
+    needs: [pre_check, changes]
     if: |
       needs.pre_check.outputs.should_skip != 'true' &&
       (needs.changes.outputs.force_full == 'true' ||
        needs.changes.outputs.fuzzing == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read              # pull the private GHCR deps image
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/raptor-ci-deps:main
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
         with:
           persist-credentials: false
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Download venv artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # was v8.0.1
-        with:
-          name: venv-${{ github.run_id }}
-          path: ${{ env.VENV_PATH }}
-      - name: Restore venv permissions
-        run: chmod +x $VENV_PATH/bin/*
+      - name: Reconcile deps
+        # No-op unless this PR changed requirements*.txt before the
+        # image rebuilt on main; then installs only the delta.
+        run: pip install --no-cache-dir -r requirements-dev.txt
       - name: Run fuzzing tests
-        run: |
-          source $VENV_PATH/bin/activate
-          python -m pytest packages/fuzzing/tests -n auto
+        run: python -m pytest packages/fuzzing/tests -n auto
 
+  # CANARY for the prebuilt-image migration (phase 2 of the fan-out
+  # fix). sage is the proving ground: zero subprocess usage in
+  # core/sage/tests, so if this goes green the container approach is
+  # sound and the remaining pure-Python tiers can follow. It runs
+  # INSIDE ghcr.io/<owner>/raptor-ci-deps (deps baked in) instead of
+  # `needs: deps` + downloading the venv artifact — removing one
+  # venv-download from the fan-out that queues under a runner cap.
+  # sandbox (namespaces) + exploit_feasibility (radare2/gcc) will NOT
+  # migrate; the slim image can't host them.
   python-unit-tests-sage:
-    needs: [pre_check, changes, deps]
+    needs: [pre_check, changes]
     if: |
       needs.pre_check.outputs.should_skip != 'true' &&
       (needs.changes.outputs.force_full == 'true' ||
        needs.changes.outputs.sage == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read              # pull the private GHCR deps image
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/raptor-ci-deps:main
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
         with:
           persist-credentials: false
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Download venv artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # was v8.0.1
-        with:
-          name: venv-${{ github.run_id }}
-          path: ${{ env.VENV_PATH }}
-      - name: Restore venv permissions
-        run: chmod +x $VENV_PATH/bin/*
+      - name: Reconcile deps
+        # No-op when this PR didn't touch requirements*.txt (everything
+        # already satisfied in the image); installs only the delta when
+        # a PR changes deps before the image has rebuilt on main.
+        run: pip install --no-cache-dir -r requirements-dev.txt
       - name: Run sage tests
-        run: |
-          source $VENV_PATH/bin/activate
-          python -m pytest core/sage/tests -n auto
+        # Deps are on the image's system Python — no venv to activate.
+        run: python -m pytest core/sage/tests -n auto
 
   python-unit-tests-orchestration:
-    needs: [pre_check, changes, deps]
+    needs: [pre_check, changes]
     if: |
       needs.pre_check.outputs.should_skip != 'true' &&
       (needs.changes.outputs.force_full == 'true' ||
        needs.changes.outputs.orchestration == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read              # pull the private GHCR deps image
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/raptor-ci-deps:main
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
         with:
           persist-credentials: false
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Download venv artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # was v8.0.1
-        with:
-          name: venv-${{ github.run_id }}
-          path: ${{ env.VENV_PATH }}
-      - name: Restore venv permissions
-        run: chmod +x $VENV_PATH/bin/*
+      - name: Reconcile deps
+        # No-op unless this PR changed requirements*.txt before the
+        # image rebuilt on main; then installs only the delta.
+        run: pip install --no-cache-dir -r requirements-dev.txt
       - name: Run orchestration tests
-        run: |
-          source $VENV_PATH/bin/activate
-          python -m pytest core/orchestration/tests -n auto
+        run: python -m pytest core/orchestration/tests -n auto
 


### PR DESCRIPTION
Phase 2 rollout, after the sage canary went green. Migrates four more pure-Python tiers to run inside ghcr.io/\<owner>/raptor-ci-deps (same pattern as sage): drop `needs: deps` + the venv download / setup-python / activate, add packages:read + container.credentials, and a pip reconcile (no-op unless a PR changed deps pre-rebuild). Removes four more venv-downloads from the fan-out that queues under a concurrent-runner cap (five total now, with sage).

Each tier was checked for real exec of a system tool absent from the slim image (only git + Python are present):
- fuzzing  — no real subprocess.run calls (mock-target refs only)
- codeql / llm_analysis — subprocess.run is mock-patched in tests
- orchestration — mock-patched, except one real call that runs a repo libexec script via its python shebang (works in-image)

NOT migrated, on purpose:
- cve_diff — 8 test files call subprocess.run; couldn't confirm offline that none exec a missing tool. Left on the venv pending its own canary.
- fast / sca — broad tiers spanning packages that DO exec system tools (radare2, semgrep, gcc); the slim image can't host those.
- sandbox (namespaces) / exploit_feasibility (radare2/gcc) — need real system tooling; stay on the runner by design.

Each migrated tier is an independent job: if one reds on a missing tool the container CI surfaces it in isolation and it reverts to the runner in one block, without affecting the others.