### PR TITLE
ci: keep slowest-test durations + a CI hang net permanently

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,15 @@ concurrency:
 env:
   PYTHON_VERSION: '3.12'
   VENV_PATH: .venv
+  # CI-only hang net: dump every worker's Python stack if any single
+  # test runs >120s, then let it continue (the dump is the signal, not
+  # a failure). The slowest legit default-tier test is a few seconds —
+  # slow/integration tests are gated out of these runs — so 120s only
+  # fires on a genuine hang, surfacing the stuck call in ~2 min instead
+  # of waiting out the job timeout. Set via PYTEST_ADDOPTS (not
+  # pytest.ini) so it covers every tier here but NOT local `pytest`,
+  # where it would dump on pdb / breakpoint sessions.
+  PYTEST_ADDOPTS: "-o faulthandler_timeout=120"
   # Opt the runner into Node.js 24 for JavaScript actions.
   # GitHub deprecated Node.js 20 on 2025-09-19; runners enforce
   # Node 24 by default from 2026-06-02 and remove Node 20 on

--- a/pytest.ini
+++ b/pytest.ini
@@ -24,7 +24,12 @@ markers =
     integration: tests that hit live network — deselected by default
     slow: tests that take >30s (perf baselines, large-fixture E2E) — opt in with `pytest -m slow`
 
-addopts = -m "not integration and not slow" --import-mode=importlib
+# --durations=25 prints the 25 slowest tests at the end of every run
+# (CI + local) — the standing "what's getting slow" signal. Near-free:
+# pytest already times every test; this only prints the tail. (A hung
+# test is caught separately by faulthandler_timeout, set CI-only via
+# PYTEST_ADDOPTS in tests.yml so local pdb sessions aren't disrupted.)
+addopts = -m "not integration and not slow" --import-mode=importlib --durations=25
 
 # Ensure each package's source root is importable without requiring an
 # editable install. Mirrors pytest's prepend-mode behaviour for the


### PR DESCRIPTION
Promotes the two useful halves of yesterday's temporary SCA probe to standing diagnostics (the noisy half, -v, is intentionally dropped — one log line per test across ~15k tests buries signal).

- pytest.ini: add --durations=25 to addopts. Near-free (pytest already times every test; this only prints the tail) and universal (CI + local), so "what's getting slow" shows on every run.
- tests.yml: set PYTEST_ADDOPTS="-o faulthandler_timeout=120" at the workflow env level. Any test exceeding 120s dumps every worker's stack (then continues — the dump is the signal, not a failure), pinpointing a hang in ~2 min instead of waiting out the 20-25 min job timeout. 120s is ~15-20x the slowest legit default-tier test (slow/integration are gated out of these runs), so it only fires on a real hang. Via PYTEST_ADDOPTS (env, CI-only) rather than pytest.ini so it never disrupts local pdb/breakpoint sessions, and applies to every tier without per-invocation edits.

Not made permanent: -v (per-test verbose) — debugging-only log spam at this test count.