### PR TITLE
feat(inventory): function-like-macro masking for C/C++ reachability

### DIFF
--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -41,7 +41,7 @@ from .call_graph import (
 from .diff import compare_inventories
 from .dead_scope import detect_dead_scopes
 from .module_load_abort import detect_module_load_abort
-from .translation_view import preprocess_view
+from .translation_view import detect_macro_call_targets, preprocess_view
 
 logger = logging.getLogger(__name__)
 
@@ -631,6 +631,17 @@ def _process_single_file(
             record['call_graph'] = extract_call_graph_cpp(
                 parse_text,
             ).to_dict()
+        # U4 (macro-masking): record the function names invoked inside
+        # function-like macro bodies. tree-sitter sees a macro call as a
+        # call to the macro, not its expansion, so a function reachable
+        # only via a macro reads NOT_CALLED. The resolver consults this to
+        # downgrade such verdicts to UNCERTAIN (FN-safe). C/C++ only;
+        # scanned from parse_text so macros inside blanked #if 0 don't
+        # count. Stored only when non-empty to keep inventory size flat.
+        if language in ('c', 'cpp') and isinstance(record.get('call_graph'), dict):
+            macro_targets = detect_macro_call_targets(parse_text)
+            if macro_targets:
+                record['call_graph']['macro_call_targets'] = sorted(macro_targets)
         # S4: file-level module-load-abort gate. When the file's
         # top-level execution unconditionally aborts (raise
         # ImportError / throw new Error / init() panic /

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -179,6 +179,13 @@ class _FunctionCalledIndex:
     # Files with a wildcard import — visited so the wildcard branch
     # can yield UNCERTAIN via ``_wildcard_could_provide``.
     files_with_wildcard_import: Tuple[int, ...]
+    # U4: function name → file paths whose function-like macro bodies
+    # invoke it (C/C++). A function reachable only via such a macro reads
+    # NOT_CALLED in the static graph (tree-sitter doesn't expand macros);
+    # the resolver maps a hit here to UNCERTAIN. Global membership —
+    # consulted independent of the per-token candidate buckets, because
+    # the macro-defining file may not otherwise mention the target.
+    macro_targets: Dict[str, Tuple[str, ...]] = field(default_factory=dict)
 
 
 # Keyed on ``id(inventory)``; identity-checked on read so a fresh
@@ -196,6 +203,7 @@ def _build_function_called_index(
     files_by_token: Dict[str, Set[int]] = {}
     non_wildcard: Set[int] = set()
     wildcard: Set[int] = set()
+    macro_targets: Dict[str, Set[str]] = {}
 
     def _add(token: str, i: int) -> None:
         if not token:
@@ -240,6 +248,10 @@ def _build_function_called_index(
             non_wildcard.add(i)
         if INDIRECTION_WILDCARD_IMPORT in flags:
             wildcard.add(i)
+        # U4: function-like-macro call targets (C/C++).
+        mpath = fr.get("path") or ""
+        for name in (cg.get("macro_call_targets") or []):
+            macro_targets.setdefault(name, set()).add(mpath)
 
     return _FunctionCalledIndex(
         files_by_token={
@@ -247,6 +259,9 @@ def _build_function_called_index(
         },
         files_with_non_wildcard_masking=tuple(sorted(non_wildcard)),
         files_with_wildcard_import=tuple(sorted(wildcard)),
+        macro_targets={
+            k: tuple(sorted(v)) for k, v in macro_targets.items()
+        },
     )
 
 
@@ -503,6 +518,19 @@ def function_called(
             _wildcard_could_provide(imports, target_module, target_func)
         ):
             uncertain_reasons.append((path, INDIRECTION_WILDCARD_IMPORT))
+
+    # U4: function-like-macro masking (C/C++). A function whose only
+    # invocation is inside a macro body reads NOT_CALLED — tree-sitter
+    # sees the macro name, not the expanded call. Map such targets to
+    # UNCERTAIN (never suppress). Global membership: the macro-defining
+    # file need not appear in the per-token candidate buckets, so this is
+    # checked off the index directly. Skipped when direct evidence exists
+    # (CALLED wins anyway) — but harmless either way since CALLED takes
+    # precedence over uncertain_reasons below.
+    for mpath in index.macro_targets.get(target_func, ()):
+        if exclude_test_files and _is_test_file(mpath):
+            continue
+        uncertain_reasons.append((mpath, "func_like_macro"))
 
     if evidence:
         return ReachabilityResult(

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -463,3 +463,47 @@ class TestSameFileBareNameResolution:
             assert r.verdict in (Verdict.CALLED, Verdict.NOT_CALLED, Verdict.UNCERTAIN)
         except ValueError:
             pass  # extensionless query rejected — also acceptable
+
+
+# ---------------------------------------------------------------------------
+# U4 — function-like-macro masking (C/C++)
+# ---------------------------------------------------------------------------
+# Synthetic inventories (no tree-sitter dependency): a C function whose only
+# invocation is inside a macro body reads NOT_CALLED in the static graph;
+# the macro_call_targets index maps it to UNCERTAIN (FN-safe), never to a
+# suppressible NOT_CALLED.
+
+
+def _c_inv(path: str, calls=None, macro_targets=None) -> Dict[str, Any]:
+    return {"files": [{
+        "path": path, "language": "c",
+        "call_graph": {
+            "imports": {}, "calls": calls or [],
+            "macro_call_targets": macro_targets or [],
+        },
+    }]}
+
+
+def test_macro_masked_function_is_uncertain_not_not_called():
+    inv = _c_inv("src/m.c", macro_targets=["f"])
+    r = function_called(inv, "src.m.f")
+    assert r.verdict == Verdict.UNCERTAIN
+    assert any(reason == "func_like_macro" for _, reason in r.uncertain_reasons)
+
+
+def test_unrelated_macro_leaves_not_called():
+    # Macro references `g`, not `f` — targeted, so `f` stays NOT_CALLED.
+    inv = _c_inv("src/m.c", macro_targets=["g"])
+    assert function_called(inv, "src.m.f").verdict == Verdict.NOT_CALLED
+
+
+def test_directly_called_beats_macro_masking():
+    # Direct call edge to `f` → CALLED wins even if a macro also references it.
+    inv = _c_inv(
+        "src/m.c",
+        calls=[{"chain": ["f"], "line": 9}],
+        macro_targets=["f"],
+    )
+    # Same-file bare-name resolution requires the call's module to match;
+    # the macro check must not downgrade a genuine CALLED to UNCERTAIN.
+    assert function_called(inv, "src.m.f").verdict == Verdict.CALLED

--- a/core/inventory/tests/test_translation_view.py
+++ b/core/inventory/tests/test_translation_view.py
@@ -11,6 +11,7 @@ from core.inventory.translation_view import (
     IDENTITY_LINE_MAP,
     LineMap,
     TranslationView,
+    detect_macro_call_targets,
     detect_preprocessor_dead_ranges,
     preprocess_view,
 )
@@ -143,3 +144,55 @@ def test_detect_ranges_only_fire_on_literal_zero():
     for cond in ("#ifdef X", "#if defined(X)", "#if VERSION > 3", "#if A && B"):
         src = cond + "\nvoid f(void){}\n#endif\n"
         assert detect_preprocessor_dead_ranges(src) == [], cond
+
+
+# ---------------------------------------------------------------------------
+# U4 — function-like-macro call targets
+# ---------------------------------------------------------------------------
+
+
+def test_macro_body_call_target_detected():
+    src = "#define CALL_F(x) f(x)\nstatic int f(int x){ return x; }\n"
+    assert "f" in detect_macro_call_targets(src)
+
+
+def test_macro_with_line_continuation():
+    src = "#define WRAP(a) \\\n    do_thing(a)\nvoid u(void){}\n"
+    assert "do_thing" in detect_macro_call_targets(src)
+
+
+def test_object_like_macro_not_a_target():
+    # Object-like macro (no parens) — not a function-like macro; no targets.
+    src = "#define MAX 100\nint f(void){ return MAX; }\n"
+    assert detect_macro_call_targets(src) == set()
+
+
+def test_control_keywords_excluded():
+    src = "#define GUARD(x) if (x) return\n"
+    got = detect_macro_call_targets(src)
+    assert "if" not in got and "return" not in got
+
+
+def test_macro_not_counted_as_calling_itself():
+    src = "#define F(x) F(x)\n"          # pathological self-reference
+    assert "F" not in detect_macro_call_targets(src)
+
+
+def test_no_macros_empty():
+    assert detect_macro_call_targets("int f(void){ return g(); }\n") == set()
+
+
+def test_call_shaped_text_in_string_literal_not_a_target():
+    # Adversarial FP: a format string with call-shaped text must not count.
+    got = detect_macro_call_targets('#define LOG(x) fprintf(stderr, "evil(): %d", x)')
+    assert got == {"fprintf"}, got
+
+
+def test_call_shaped_text_in_comment_not_a_target():
+    got = detect_macro_call_targets("#define X() /* go to handler() */ real_fn()")
+    assert got == {"real_fn"}, got
+
+
+def test_char_literal_paren_not_a_target():
+    got = detect_macro_call_targets("#define C(x) g(x, ')')")
+    assert got == {"g"}, got

--- a/core/inventory/translation_view.py
+++ b/core/inventory/translation_view.py
@@ -118,6 +118,79 @@ def detect_preprocessor_dead_ranges(content: str) -> List[Tuple[int, int]]:
     return ranges
 
 
+_FUNC_MACRO_DEF = re.compile(
+    r"^[ \t]*#[ \t]*define[ \t]+(\w+)[ \t]*\(([^)]*)\)(.*)$", re.MULTILINE,
+)
+_CALL_IN_BODY = re.compile(r"\b([A-Za-z_]\w*)[ \t]*\(")
+# Control-flow / operator keywords that look like calls but aren't.
+_C_NON_CALL_KW = frozenset({
+    "if", "while", "for", "switch", "return", "sizeof", "defined",
+    "do", "else", "case", "alignof", "_Alignof", "static_assert",
+    "_Static_assert", "catch",
+})
+
+
+def _strip_c_literals_comments(s: str) -> str:
+    """Blank string / char literals and comments in a (logical) macro body
+    so call-shaped text inside them isn't mistaken for a routed call. Walks
+    char-by-char; `//` ends the logical line. Returns the body with those
+    spans removed."""
+    out: List[str] = []
+    i, n = 0, len(s)
+    while i < n:
+        c = s[i]
+        if c == "/" and i + 1 < n and s[i + 1] == "*":
+            j = s.find("*/", i + 2)
+            i = n if j == -1 else j + 2
+            continue
+        if c == "/" and i + 1 < n and s[i + 1] == "/":
+            break
+        if c == '"' or c == "'":
+            q = c
+            i += 1
+            while i < n:
+                if s[i] == "\\":
+                    i += 2
+                    continue
+                if s[i] == q:
+                    i += 1
+                    break
+                i += 1
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def detect_macro_call_targets(content: str) -> set:
+    """Function names invoked inside *function-like* macro bodies.
+
+    tree-sitter sees a macro invocation as a call to the macro name, not to
+    whatever the body expands to — so a function reachable *only* via a
+    macro (``#define CALL_F() f()``) reads NOT_CALLED in the static graph.
+    The resolver treats any name in this set as UNCERTAIN rather than
+    NOT_CALLED, closing that false negative. C/C++ only.
+
+    Targeted, not blanket: a file using ordinary ``UPPER()`` macros doesn't
+    taint every NOT_CALLED — only the specific names a macro body calls.
+    String literals and comments in the body are stripped first so
+    call-shaped text inside them (``"foo()"``, ``/* bar() */``) isn't
+    mistaken for a routed call.
+    """
+    if not content or "define" not in content:
+        return set()
+    joined = content.replace("\\\n", " ")     # fold line-continuations
+    targets: set = set()
+    for m in _FUNC_MACRO_DEF.finditer(joined):
+        macro_name = m.group(1)
+        body = _strip_c_literals_comments(m.group(3))
+        for c in _CALL_IN_BODY.finditer(body):
+            name = c.group(1)
+            if name != macro_name and name not in _C_NON_CALL_KW:
+                targets.add(name)
+    return targets
+
+
 def _blank_ranges(content: str, ranges: List[Tuple[int, int]]) -> str:
     """Replace the body of each dead range with same-length spaces, keeping
     newlines so byte/line offsets — and therefore the identity line_map —
@@ -221,5 +294,6 @@ __all__ = [
     "TranslationView",
     "preprocess_view",
     "detect_preprocessor_dead_ranges",
+    "detect_macro_call_targets",
     "_C_FAMILY",
 ]


### PR DESCRIPTION
A C function whose only invocation is inside a function-like macro body (`#define CALL_F() f()`) reads NOT_CALLED in the static graph — tree-sitter sees a call to the macro name, not to its expansion. That's a false negative: the function is genuinely reachable. Map such targets to UNCERTAIN (never suppress) instead.

- detect_macro_call_targets() scans function-like macro bodies for the names they invoke: folds line-continuations; excludes control-flow keywords; ignores object-like macros. String literals and comments in the body are stripped before scanning, so call-shaped text inside them ("foo()", /* bar() */) isn't mistaken for a routed call.
- builder attaches cg['macro_call_targets'] for C/C++ (scanned from the #if 0-blanked parse_text so dead macros don't count).
- _FunctionCalledIndex gains a global macro_targets map (name → defining file paths); function_called yields UNCERTAIN (reason "func_like_macro") on a hit. Global membership — the macro-defining file needn't appear in the per-token candidate buckets.

Targeted, not blanket: only the specific names a macro body calls are flagged, so ordinary UPPER() macro usage doesn't downgrade every NOT_CALLED. On OpenSSL: 207/1669 files contribute, 637 distinct names — bounded, not wholesale. Direct call edges still win (CALLED > UNCERTAIN).

Verified: macro-only-reachable functions survive the reachability prepass (not demoted) while genuinely-uncalled functions are still demoted; 54 detector + resolver tests green on tree-sitter and stdlib paths.