### PR TITLE
feat(zkpox): Tier 1.5 — native reproduction + operator CLI

### DIFF
--- a/libexec/raptor-zkpox
+++ b/libexec/raptor-zkpox
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""ZKPoX operator CLI — assemble bundles and reproduce witnesses.
+
+Two subcommands covering the dependency-free tiers:
+
+    raptor-zkpox bundle <witness_store> <witness_hash> --out <dir>
+        Tier 0/1: assemble a prover-ready bundle for one eligible
+        witness, persisted under <out>/zkpox/<witness_hash>/.
+
+    raptor-zkpox reproduce <bundle_dir> [--binary <path>] [--n 3]
+        Tier 1.5: re-run the bundle's witness N times in the
+        sandbox, confirm the recorded outcome reproduces, and fold
+        the result back into the bundle manifest (bumps tier to 1.5
+        when it reproduces).
+
+Eligibility is FREE and surfaced automatically in run summaries;
+these subcommands are the ON-REQUEST steps. The tier model lives in
+the package docstring (packages/zkpox/__init__.py).
+"""
+import sys
+from pathlib import Path
+
+# ─── trust-marker check (do not import; inline by design) ───
+import os
+if not (os.environ.get("CLAUDECODE")
+        or os.environ.get("_RAPTOR_TRUSTED")):
+    sys.stderr.write(
+        f"{sys.argv[0]}: internal dispatch script.\n"
+        "  Run via 'bin/raptor' instead.\n"
+        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
+    )
+    sys.exit(2)
+# ─── end trust-marker check ─────────────────────────────────
+
+import argparse
+import json
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def _cmd_bundle(args) -> int:
+    from core.witness import WitnessStore, WitnessStoreError
+    from packages.zkpox import (
+        ZKPoXBundleError,
+        assemble_bundle,
+        render_bundle,
+        write_bundle,
+    )
+
+    store_root = Path(args.witness_store)
+    if not (store_root / "manifests").is_dir():
+        sys.stderr.write(
+            f"not a witness store (no manifests/): {store_root}\n"
+        )
+        return 2
+
+    store = WitnessStore(store_root)
+    try:
+        witness = store.get_witness(args.witness_hash)
+    except WitnessStoreError as e:
+        sys.stderr.write(f"witness lookup failed: {e}\n")
+        return 2
+
+    try:
+        bundle = assemble_bundle(witness, store)
+    except ZKPoXBundleError as e:
+        sys.stderr.write(f"bundle assembly refused: {e}\n")
+        return 1
+
+    bundle_dir = write_bundle(bundle, store, Path(args.out))
+    print(render_bundle(bundle))
+    print(f"  bundle dir: {bundle_dir}")
+    return 0
+
+
+def _cmd_reproduce(args) -> int:
+    from packages.zkpox import (
+        ZKPoXBundle,
+        attach_reproduction,
+        render_bundle,
+        reproduce_witness,
+    )
+
+    bundle_dir = Path(args.bundle_dir)
+    manifest_path = bundle_dir / "manifest.json"
+    witness_path = bundle_dir / "witness.bin"
+    if not manifest_path.is_file():
+        sys.stderr.write(f"no manifest.json in {bundle_dir}\n")
+        return 2
+    if not witness_path.is_file():
+        sys.stderr.write(f"no witness.bin in {bundle_dir}\n")
+        return 2
+
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        sys.stderr.write(f"manifest.json is not valid JSON: {e}\n")
+        return 2
+    if not isinstance(manifest, dict):
+        sys.stderr.write("manifest.json is not a JSON object\n")
+        return 2
+
+    # The four fields reproduce_witness reads are load-bearing; a
+    # manifest missing any of them is corrupt, not reproducible.
+    required = ("witness_hash", "witness_len", "source", "observed_outcome")
+    missing = [k for k in required if k not in manifest]
+    if missing:
+        sys.stderr.write(
+            f"manifest.json missing required field(s): "
+            f"{', '.join(missing)}\n"
+        )
+        return 2
+
+    # Reconstruct the bundle dataclass from the manifest. The rest
+    # round-trip for re-persistence.
+    bundle = ZKPoXBundle(
+        witness_hash=manifest["witness_hash"],
+        witness_len=manifest["witness_len"],
+        source=manifest["source"],
+        observed_outcome=manifest["observed_outcome"],
+        outcome_detail=manifest.get("outcome_detail", {}),
+        target_binary_hash=manifest.get("target_binary_hash"),
+        target_source_hash=manifest.get("target_source_hash"),
+        produced_by=manifest.get("produced_by"),
+        timestamp=manifest.get("timestamp"),
+        attestation=manifest.get("attestation", {}),
+        tier=manifest.get("tier", "0/1"),
+        reproduction=manifest.get("reproduction"),
+    )
+
+    witness_bytes = witness_path.read_bytes()
+    binary_path = Path(args.binary) if args.binary else None
+
+    result = reproduce_witness(
+        bundle, witness_bytes,
+        binary_path=binary_path, n=args.n,
+    )
+    attach_reproduction(bundle, result)
+
+    # Re-persist the manifest with the reproduction block + tier bump.
+    manifest_path.write_text(
+        json.dumps(bundle.as_dict(), indent=2), encoding="utf-8",
+    )
+
+    print(render_bundle(bundle))
+    print(f"  reproduced: {result.reproduced} "
+          f"(attempted={result.attempted}, {result.reason})")
+    # Exit 0 when it reproduced; 1 when attempted-but-not; 2 when
+    # not attempted (couldn't run) — so scripts can branch.
+    if result.reproduced:
+        return 0
+    return 1 if result.attempted else 2
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        prog="raptor-zkpox",
+        description="ZKPoX bundle assembly + witness reproduction.",
+    )
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    b = sub.add_parser("bundle", help="Tier 0/1: assemble a bundle")
+    b.add_argument("witness_store", help="WitnessStore root dir")
+    b.add_argument("witness_hash", help="sha256 of the witness bytes")
+    b.add_argument("--out", required=True, help="output dir")
+
+    r = sub.add_parser("reproduce", help="Tier 1.5: reproduce a bundle")
+    r.add_argument("bundle_dir", help="bundle dir (with manifest.json)")
+    r.add_argument("--binary", help="target binary (FUZZ/replay sources)")
+    r.add_argument("--n", type=int, default=3,
+                   help="consecutive runs (default 3)")
+
+    args = ap.parse_args()
+    if args.cmd == "bundle":
+        return _cmd_bundle(args)
+    if args.cmd == "reproduce":
+        return _cmd_reproduce(args)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/zkpox/__init__.py
+++ b/packages/zkpox/__init__.py
@@ -22,7 +22,7 @@ runs when only its own (and lower tiers') dependencies are present.
   Tier 1.5 — reproduction  Re-execute W against H N times in the
                            sandbox; confirm O reproduces. Sandbox
                            dep only; reproducibility, not ZK.
-                           (next increment)
+                           IMPLEMENTED HERE (on request).
   Tier 2 — RISC-V          Execute the target in a RISC-V emulator
                            for a deterministic trace. Needs a RISC-V
                            toolchain. (not yet implemented)
@@ -45,13 +45,16 @@ default-on because cheap; running code is opt-in):
 ## This package today
 
 Everything achievable *without* the heavyweight proving stack —
-Tier 0/1, the dependency-free attestation tier:
+Tiers 0/1 and 1.5:
 
   * :mod:`packages.zkpox.eligibility` — candidacy classification
     (free) + the free end-of-run summary.
   * :mod:`packages.zkpox.bundle` — prover-ready bundle assembly
     (on request); the stable hand-off shape every higher tier
     consumes.
+  * :mod:`packages.zkpox.reproduce` — Tier 1.5 native reproduction
+    (on request): re-run the witness N times, confirm the outcome
+    reproduces, fold the result into the bundle.
 
 The point: the real ZK tiers (2 RISC-V, 3 SP1) pull a large
 dependency chain. An operator who wants them installs those deps
@@ -75,6 +78,11 @@ from packages.zkpox.eligibility import (
     render_eligibility_summary,
     summarize_eligibility,
 )
+from packages.zkpox.reproduce import (
+    ReproductionResult,
+    attach_reproduction,
+    reproduce_witness,
+)
 from packages.zkpox.surfacing import render_run_eligibility
 
 __all__ = [
@@ -88,4 +96,7 @@ __all__ = [
     "assemble_bundle",
     "write_bundle",
     "render_bundle",
+    "ReproductionResult",
+    "reproduce_witness",
+    "attach_reproduction",
 ]

--- a/packages/zkpox/reproduce.py
+++ b/packages/zkpox/reproduce.py
@@ -1,0 +1,321 @@
+"""ZKPoX Tier 1.5 — native reproduction.
+
+The strongest claim achievable *without* the heavy ZK stack: take
+a bundle's witness, run it against the target N times in the
+sandbox, and confirm the recorded outcome reproduces every time.
+"Verified-reproducible exploit" — not zero-knowledge, but
+empirically solid.
+
+**On request** in the trigger model: N× sandbox execution is real
+cost + a policy shift (running code repeatedly), so it never fires
+automatically — the operator asks for it.
+
+Reproduction is source-dispatched, because "re-run the witness"
+means different things depending on what the witness *is*:
+
+  * ``LLM_EMIT_RUN`` — the witness bytes are exploit *source code*.
+    Reproduce = recompile + run, N times, via
+    ``exploit_verify.compile_and_execute``. Self-contained for the
+    inline-trigger PoCs the crash-analysis prompt now produces. If
+    the recorded outcome is a sanitizer report, the recompile uses
+    the matching ``-fsanitize`` flag so ASAN can fire again.
+
+  * ``FUZZ`` / other input-replay sources — the witness bytes are
+    *input* to a target binary. Reproduce = feed the bytes to the
+    binary's stdin N times, mapping each run through
+    ``core.witness.outcome_from_sandbox_info``. Needs the actual
+    target binary supplied by the caller (the store holds only its
+    hash); we verify the supplied binary's sha256 matches the
+    bundle's ``target_binary_hash`` before trusting the result.
+
+The full tier model lives in the package docstring
+(``packages/zkpox/__init__.py``).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+from core.witness.types import WitnessOutcome
+
+from packages.zkpox.bundle import ZKPoXBundle
+
+logger = logging.getLogger(__name__)
+
+
+# Sanitizer enum-name (as observe.py records it) → gcc -fsanitize flag.
+# Used to recompile an LLM_EMIT_RUN witness faithfully when its
+# recorded outcome was a sanitizer report — without the matching
+# flag the recompiled binary wouldn't fire the sanitizer and
+# reproduction would spuriously fail.
+_SANITIZER_FLAG = {
+    "asan": "address",
+    "ubsan": "undefined",
+    "msan": "memory",
+    "tsan": "thread",
+}
+
+
+@dataclass
+class ReproductionResult:
+    """Outcome of an N-run reproduction attempt."""
+    attempted: bool
+    runs: int
+    expected_outcome: str
+    observed_outcomes: List[str] = field(default_factory=list)
+    reproduced: bool = False        # every run matched expected
+    deterministic: bool = False     # every run produced the SAME outcome
+    reason: str = ""
+
+    def as_dict(self) -> dict:
+        return {
+            "attempted": self.attempted,
+            "runs": self.runs,
+            "expected_outcome": self.expected_outcome,
+            "observed_outcomes": list(self.observed_outcomes),
+            "reproduced": self.reproduced,
+            "deterministic": self.deterministic,
+            "reason": self.reason,
+        }
+
+
+def _finalize(
+    expected: str,
+    observed: List[str],
+    n: int,
+    *,
+    reason: str = "",
+) -> ReproductionResult:
+    """Build the result from the per-run observed outcomes."""
+    reproduced = bool(observed) and all(o == expected for o in observed)
+    deterministic = bool(observed) and len(set(observed)) == 1
+    if not reason:
+        if reproduced:
+            reason = f"all {len(observed)} runs reproduced {expected!r}"
+        elif deterministic:
+            reason = (
+                f"deterministic but off-target: all runs produced "
+                f"{observed[0]!r}, expected {expected!r}"
+            )
+        else:
+            reason = (
+                f"non-deterministic: outcomes varied across runs "
+                f"({observed})"
+            )
+    return ReproductionResult(
+        attempted=True,
+        runs=n,
+        expected_outcome=expected,
+        observed_outcomes=observed,
+        reproduced=reproduced,
+        deterministic=deterministic,
+        reason=reason,
+    )
+
+
+def reproduce_witness(
+    bundle: ZKPoXBundle,
+    witness_bytes: bytes,
+    *,
+    binary_path: Optional[Path] = None,
+    n: int = 3,
+    sandbox_timeout: int = 5,
+    logger_: Optional[logging.Logger] = None,
+) -> ReproductionResult:
+    """Re-run ``bundle``'s witness ``n`` times; confirm the recorded
+    outcome reproduces.
+
+    Args:
+        bundle: the Tier 0/1 bundle (carries source, expected
+            outcome, target hashes).
+        witness_bytes: the raw witness bytes (caller reads them from
+            the bundle dir's ``witness.bin`` or the store).
+        binary_path: required for input-replay sources (FUZZ); the
+            target binary to feed the witness to. Its sha256 is
+            verified against ``bundle.target_binary_hash`` before
+            use. Ignored for LLM_EMIT_RUN (recompile) sources.
+        n: number of consecutive runs (default 3). The recorded
+            outcome must reproduce in ALL of them for
+            ``reproduced=True``.
+        sandbox_timeout: per-run timeout in seconds.
+        logger_: optional logger.
+
+    Returns:
+        :class:`ReproductionResult`. ``attempted=False`` when the
+        source isn't reproducible by this v1 (with the reason),
+        rather than raising.
+
+    Never raises — a compile failure, a hash mismatch, an
+    unsupported source all surface as ``attempted=False`` /
+    ``reproduced=False`` with a reason.
+    """
+    log = logger_ if logger_ is not None else logger
+
+    if bundle.source == "llm_emit_run":
+        return _reproduce_source(
+            bundle, witness_bytes, n=n,
+            sandbox_timeout=sandbox_timeout, log=log,
+        )
+
+    # Input-replay sources (FUZZ and any future input-shaped source).
+    return _reproduce_replay(
+        bundle, witness_bytes, binary_path=binary_path, n=n,
+        sandbox_timeout=sandbox_timeout, log=log,
+    )
+
+
+def _reproduce_source(
+    bundle: ZKPoXBundle,
+    witness_bytes: bytes,
+    *,
+    n: int,
+    sandbox_timeout: int,
+    log: logging.Logger,
+) -> ReproductionResult:
+    """LLM_EMIT_RUN: the witness bytes are exploit source. Recompile
+    + run N times via compile_and_execute."""
+    expected = bundle.observed_outcome
+    try:
+        from packages.llm_analysis.exploit_verify import compile_and_execute
+    except ImportError as e:
+        return ReproductionResult(
+            attempted=False, runs=0, expected_outcome=expected,
+            reason=f"compile_and_execute unavailable: {e}",
+        )
+
+    exploit_code = witness_bytes.decode("utf-8", errors="replace")
+
+    # Faithful recompile: if the recorded outcome was a sanitizer
+    # report, recompile with the matching sanitizer flag so it can
+    # fire again. Sanitizer name lives in the bundle's outcome_detail.
+    sanitizers = None
+    if expected == WitnessOutcome.SANITIZER_REPORT.value:
+        san_name = (bundle.outcome_detail or {}).get("sanitizer")
+        flag = _SANITIZER_FLAG.get(san_name)
+        if flag:
+            sanitizers = [flag]
+
+    observed: List[str] = []
+    for i in range(n):
+        compiled, errors, outcome, _detail = compile_and_execute(
+            exploit_code,
+            None,  # no target source path → attempt gcc unconditionally
+            f"{bundle.witness_hash[:12]}-rep{i}",
+            timeout=sandbox_timeout,
+            logger=log,
+            sanitizers=sanitizers,
+        )
+        if not compiled:
+            return ReproductionResult(
+                attempted=True, runs=n, expected_outcome=expected,
+                observed_outcomes=observed,
+                reason=(
+                    f"run {i + 1}/{n}: recompile failed "
+                    f"({len(errors)} error(s)) — cannot reproduce"
+                ),
+            )
+        observed.append(outcome.value if outcome is not None else "none")
+
+    return _finalize(expected, observed, n)
+
+
+def _reproduce_replay(
+    bundle: ZKPoXBundle,
+    witness_bytes: bytes,
+    *,
+    binary_path: Optional[Path],
+    n: int,
+    sandbox_timeout: int,
+    log: logging.Logger,
+) -> ReproductionResult:
+    """FUZZ / input-replay: feed the witness bytes to the target
+    binary's stdin N times."""
+    expected = bundle.observed_outcome
+
+    if binary_path is None:
+        return ReproductionResult(
+            attempted=False, runs=0, expected_outcome=expected,
+            reason=(
+                f"source {bundle.source!r} is input-replay; needs a "
+                f"target binary (pass binary_path)"
+            ),
+        )
+    binary_path = Path(binary_path)
+    if not binary_path.is_file():
+        return ReproductionResult(
+            attempted=False, runs=0, expected_outcome=expected,
+            reason=f"binary not found: {binary_path}",
+        )
+
+    # Verify we're reproducing against the RIGHT binary — the one the
+    # witness was recorded against — before trusting the result.
+    if bundle.target_binary_hash:
+        from core.hash import sha256_file
+        actual = sha256_file(binary_path)
+        if actual != bundle.target_binary_hash:
+            return ReproductionResult(
+                attempted=False, runs=0, expected_outcome=expected,
+                reason=(
+                    f"binary hash mismatch: supplied {actual[:16]}... "
+                    f"!= recorded {bundle.target_binary_hash[:16]}...; "
+                    f"refusing to reproduce against a different build"
+                ),
+            )
+
+    try:
+        from core.config import RaptorConfig
+        from core.sandbox import run as sandbox_run
+        from core.witness import outcome_from_sandbox_info
+    except ImportError as e:
+        return ReproductionResult(
+            attempted=False, runs=0, expected_outcome=expected,
+            reason=f"sandbox unavailable: {e}",
+        )
+
+    observed: List[str] = []
+    for _i in range(n):
+        try:
+            result = sandbox_run(
+                [str(binary_path)],
+                block_network=True,
+                target=str(binary_path.parent),
+                output=str(binary_path.parent),
+                capture_output=True,
+                text=False,
+                input=witness_bytes,
+                timeout=sandbox_timeout,
+                env=RaptorConfig.get_safe_env(),
+                strict_env=True,
+            )
+        except Exception as e:  # noqa: BLE001 — best-effort per run
+            observed.append("error")
+            log.debug("reproduce replay run raised: %s", e)
+            continue
+        sandbox_info = getattr(result, "sandbox_info", None)
+        returncode = getattr(result, "returncode", None)
+        outcome, _detail = outcome_from_sandbox_info(
+            sandbox_info, returncode=returncode,
+        )
+        observed.append(outcome.value)
+
+    return _finalize(expected, observed, n)
+
+
+def attach_reproduction(
+    bundle: ZKPoXBundle,
+    result: ReproductionResult,
+) -> ZKPoXBundle:
+    """Fold a reproduction result into a bundle: store it under
+    ``bundle.reproduction`` and, when the witness reproduced, bump
+    the tier label to ``"1.5"``.
+
+    Mutates and returns the bundle (callers typically re-persist it
+    with ``write_bundle``).
+    """
+    bundle.reproduction = result.as_dict()
+    if result.reproduced:
+        bundle.tier = "1.5"
+    return bundle

--- a/packages/zkpox/tests/test_libexec_raptor_zkpox.py
+++ b/packages/zkpox/tests/test_libexec_raptor_zkpox.py
@@ -1,0 +1,192 @@
+"""Tests for ``libexec/raptor-zkpox`` — the operator CLI for
+Tier 0/1 bundle assembly + Tier 1.5 reproduction.
+
+Trust-marker rejection, error-path handling (missing/corrupt/
+incomplete manifest, non-store dir), and a happy-path
+bundle→reproduce walk via the FUZZ replay mode (real binary).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# packages/zkpox/tests/test_libexec_raptor_zkpox.py → parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+SCRIPT = REPO / "libexec" / "raptor-zkpox"
+
+
+def _clean_env() -> dict:
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("CLAUDECODE", "_RAPTOR_TRUSTED")}
+    env["RAPTOR_DIR"] = str(REPO)
+    return env
+
+
+def _trusted_env() -> dict:
+    env = _clean_env()
+    env["_RAPTOR_TRUSTED"] = "1"
+    return env
+
+
+def _run(args, env=None):
+    return subprocess.run(
+        [str(SCRIPT), *args],
+        env=env or _trusted_env(),
+        capture_output=True, text=True, timeout=60,
+    )
+
+
+# ----------------------------------------------------------------------
+# Trust marker
+# ----------------------------------------------------------------------
+
+
+def test_trust_marker_rejects_clean_env():
+    r = _run(["bundle", "x", "y", "--out", "z"], env=_clean_env())
+    assert r.returncode == 2
+    assert "internal dispatch script" in r.stderr
+
+
+# ----------------------------------------------------------------------
+# reproduce error paths
+# ----------------------------------------------------------------------
+
+
+def test_reproduce_missing_dir(tmp_path):
+    r = _run(["reproduce", str(tmp_path / "nope")])
+    assert r.returncode == 2
+    assert "no manifest.json" in r.stderr
+
+
+def test_reproduce_no_witness_bin(tmp_path):
+    d = tmp_path / "b"
+    d.mkdir()
+    (d / "manifest.json").write_text("{}")
+    r = _run(["reproduce", str(d)])
+    assert r.returncode == 2
+    assert "no witness.bin" in r.stderr
+
+
+def test_reproduce_corrupt_manifest(tmp_path):
+    """Pre-fix: json.loads raised JSONDecodeError uncaught →
+    traceback. Post-fix: clean rc=2 message."""
+    d = tmp_path / "b"
+    d.mkdir()
+    (d / "manifest.json").write_text("{not valid json")
+    (d / "witness.bin").write_bytes(b"x")
+    r = _run(["reproduce", str(d)])
+    assert r.returncode == 2
+    assert "not valid JSON" in r.stderr
+    assert "Traceback" not in r.stderr
+
+
+def test_reproduce_incomplete_manifest(tmp_path):
+    """Valid JSON but missing the load-bearing fields → rc=2,
+    not a KeyError traceback."""
+    d = tmp_path / "b"
+    d.mkdir()
+    (d / "manifest.json").write_text(json.dumps({"witness_hash": "abc"}))
+    (d / "witness.bin").write_bytes(b"x")
+    r = _run(["reproduce", str(d)])
+    assert r.returncode == 2
+    assert "missing required field" in r.stderr
+    assert "Traceback" not in r.stderr
+
+
+# ----------------------------------------------------------------------
+# bundle error paths
+# ----------------------------------------------------------------------
+
+
+def test_bundle_non_store_dir(tmp_path):
+    r = _run(["bundle", str(tmp_path / "nostore"), "abc",
+              "--out", str(tmp_path / "out")])
+    assert r.returncode == 2
+    assert "not a witness store" in r.stderr
+
+
+def test_bundle_witness_not_in_store(tmp_path):
+    """Store exists but the hash isn't present."""
+    from core.witness.store import WitnessStore
+    from core.witness.types import (
+        Witness, WitnessOutcome, WitnessSource, compute_bytes_hash,
+    )
+    store = WitnessStore(tmp_path / "w")
+    d = b"present"
+    store.put(Witness(
+        bytes_hash=compute_bytes_hash(d), bytes_len=len(d),
+        source=WitnessSource.FUZZ, observed_outcome=WitnessOutcome.EXIT_SIGNAL,
+        outcome_detail={}, target_binary_hash="a" * 64,
+    ), d)
+    r = _run(["bundle", str(tmp_path / "w"), "f" * 64,
+              "--out", str(tmp_path / "out")])
+    assert r.returncode == 2
+
+
+# ----------------------------------------------------------------------
+# Happy path: bundle → reproduce (FUZZ replay, real binary)
+# ----------------------------------------------------------------------
+
+
+_CRASHER = (
+    "#include <unistd.h>\n"
+    "int main(void){char b[64]; ssize_t n=read(0,b,63); "
+    "if(n>0&&b[0]=='B'){int*p=0;*p=42;} return 0;}\n"
+)
+
+
+@pytest.mark.skipif(
+    shutil.which("cc") is None and shutil.which("gcc") is None,
+    reason="no C compiler",
+)
+def test_bundle_then_reproduce_happy_path(tmp_path):
+    from core.hash import sha256_file
+    from core.witness.store import WitnessStore
+    from core.witness.types import (
+        Witness, WitnessOutcome, WitnessSource, compute_bytes_hash,
+    )
+
+    cc = shutil.which("cc") or shutil.which("gcc")
+    src = tmp_path / "crasher.c"
+    src.write_text(_CRASHER)
+    binary = tmp_path / "crasher"
+    subprocess.run([cc, "-O0", "-o", str(binary), str(src)],
+                   check=True, timeout=30)
+
+    crash_input = b"B" + b"\x00" * 8
+    store = WitnessStore(tmp_path / "w")
+    store.put(Witness(
+        bytes_hash=compute_bytes_hash(crash_input),
+        bytes_len=len(crash_input),
+        source=WitnessSource.FUZZ,
+        observed_outcome=WitnessOutcome.EXIT_SIGNAL,
+        outcome_detail={"finding_id": "F1"},
+        target_binary_hash=sha256_file(binary),
+    ), crash_input)
+    wh = compute_bytes_hash(crash_input)
+
+    # bundle
+    out = tmp_path / "out"
+    r = _run(["bundle", str(tmp_path / "w"), wh, "--out", str(out)])
+    assert r.returncode == 0, r.stderr
+    bundle_dir = out / "zkpox" / wh
+    assert (bundle_dir / "manifest.json").is_file()
+    assert json.loads((bundle_dir / "manifest.json").read_text())["tier"] == "0/1"
+
+    # reproduce
+    r = _run(["reproduce", str(bundle_dir), "--binary", str(binary), "--n", "3"])
+    assert r.returncode == 0, f"stdout={r.stdout}\nstderr={r.stderr}"
+    manifest = json.loads((bundle_dir / "manifest.json").read_text())
+    assert manifest["tier"] == "1.5"  # bumped
+    assert manifest["reproduction"]["reproduced"] is True
+    assert manifest["reproduction"]["runs"] == 3

--- a/packages/zkpox/tests/test_reproduce.py
+++ b/packages/zkpox/tests/test_reproduce.py
@@ -1,0 +1,328 @@
+"""Tests for ``packages.zkpox.reproduce`` — Tier 1.5 native
+reproduction.
+
+Two families:
+  * Unit — result-finalisation logic + dispatch + defensive paths,
+    monkeypatched (no real compile/sandbox). Fast.
+  * Integration — real recompile of an LLM_EMIT_RUN witness (BOF
+    source) via compile_and_execute; needs gcc + libasan. Pins
+    that a real sanitizer-report witness reproduces.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# packages/zkpox/tests/test_reproduce.py → parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from core.witness.store import WitnessStore  # noqa: E402
+from core.witness.types import (  # noqa: E402
+    Witness,
+    WitnessOutcome,
+    WitnessSource,
+    compute_bytes_hash,
+)
+from packages.zkpox.bundle import assemble_bundle  # noqa: E402
+from packages.zkpox.reproduce import (  # noqa: E402
+    ReproductionResult,
+    attach_reproduction,
+    reproduce_witness,
+)
+
+
+def _bundle(
+    tmp_path,
+    *,
+    source: WitnessSource,
+    outcome: WitnessOutcome,
+    data: bytes,
+    target_binary_hash="a" * 64,
+    sanitizer=None,
+):
+    store = WitnessStore(tmp_path / "w")
+    detail = {"finding_id": "F"}
+    if sanitizer:
+        detail["sanitizer"] = sanitizer
+    store.put(Witness(
+        bytes_hash=compute_bytes_hash(data), bytes_len=len(data),
+        source=source, observed_outcome=outcome,
+        outcome_detail=detail, target_binary_hash=target_binary_hash,
+    ), data)
+    w = store.get_witness(compute_bytes_hash(data))
+    return assemble_bundle(w, store), data
+
+
+# ----------------------------------------------------------------------
+# Result finalisation (via monkeypatched compile_and_execute)
+# ----------------------------------------------------------------------
+
+
+def test_all_runs_match_reproduces(tmp_path, monkeypatch):
+    bundle, data = _bundle(
+        tmp_path, source=WitnessSource.LLM_EMIT_RUN,
+        outcome=WitnessOutcome.EXIT_SIGNAL, data=b"// poc",
+    )
+    import packages.llm_analysis.exploit_verify as ev
+
+    monkeypatch.setattr(
+        ev, "compile_and_execute",
+        lambda *a, **k: (True, [], WitnessOutcome.EXIT_SIGNAL, {}),
+    )
+    result = reproduce_witness(bundle, data, n=3)
+    assert result.attempted is True
+    assert result.runs == 3
+    assert result.reproduced is True
+    assert result.deterministic is True
+    assert result.observed_outcomes == ["exit_signal"] * 3
+
+
+def test_consistent_but_off_target_not_reproduced(tmp_path, monkeypatch):
+    """All runs agree, but on a DIFFERENT outcome than recorded —
+    deterministic=True, reproduced=False."""
+    bundle, data = _bundle(
+        tmp_path, source=WitnessSource.LLM_EMIT_RUN,
+        outcome=WitnessOutcome.SANITIZER_REPORT, data=b"// poc",
+        sanitizer="asan",
+    )
+    import packages.llm_analysis.exploit_verify as ev
+    monkeypatch.setattr(
+        ev, "compile_and_execute",
+        lambda *a, **k: (True, [], WitnessOutcome.EXIT_SIGNAL, {}),
+    )
+    result = reproduce_witness(bundle, data, n=3)
+    assert result.reproduced is False
+    assert result.deterministic is True
+    assert "off-target" in result.reason
+
+
+def test_nondeterministic_not_reproduced(tmp_path, monkeypatch):
+    bundle, data = _bundle(
+        tmp_path, source=WitnessSource.LLM_EMIT_RUN,
+        outcome=WitnessOutcome.EXIT_SIGNAL, data=b"// poc",
+    )
+    import packages.llm_analysis.exploit_verify as ev
+    seq = [
+        (True, [], WitnessOutcome.EXIT_SIGNAL, {}),
+        (True, [], WitnessOutcome.NO_OBVIOUS_EFFECT, {}),
+        (True, [], WitnessOutcome.EXIT_SIGNAL, {}),
+    ]
+    calls = iter(seq)
+    monkeypatch.setattr(
+        ev, "compile_and_execute", lambda *a, **k: next(calls),
+    )
+    result = reproduce_witness(bundle, data, n=3)
+    assert result.reproduced is False
+    assert result.deterministic is False
+    assert "non-deterministic" in result.reason
+
+
+def test_compile_failure_aborts_with_reason(tmp_path, monkeypatch):
+    bundle, data = _bundle(
+        tmp_path, source=WitnessSource.LLM_EMIT_RUN,
+        outcome=WitnessOutcome.EXIT_SIGNAL, data=b"// poc",
+    )
+    import packages.llm_analysis.exploit_verify as ev
+    monkeypatch.setattr(
+        ev, "compile_and_execute",
+        lambda *a, **k: (False, ["err"], None, {}),
+    )
+    result = reproduce_witness(bundle, data, n=3)
+    assert result.reproduced is False
+    assert "recompile failed" in result.reason
+
+
+def test_sanitizer_flag_inferred_from_outcome(tmp_path, monkeypatch):
+    """When the recorded outcome is SANITIZER_REPORT, the recompile
+    must pass the matching -fsanitize flag. Capture the kwarg."""
+    bundle, data = _bundle(
+        tmp_path, source=WitnessSource.LLM_EMIT_RUN,
+        outcome=WitnessOutcome.SANITIZER_REPORT, data=b"// poc",
+        sanitizer="asan",
+    )
+    import packages.llm_analysis.exploit_verify as ev
+    captured = {}
+
+    def fake(*a, **k):
+        captured["sanitizers"] = k.get("sanitizers")
+        return (True, [], WitnessOutcome.SANITIZER_REPORT, {})
+
+    monkeypatch.setattr(ev, "compile_and_execute", fake)
+    reproduce_witness(bundle, data, n=1)
+    assert captured["sanitizers"] == ["address"]
+
+
+# ----------------------------------------------------------------------
+# FUZZ / input-replay dispatch
+# ----------------------------------------------------------------------
+
+
+def test_fuzz_source_without_binary_not_attempted(tmp_path):
+    bundle, data = _bundle(
+        tmp_path, source=WitnessSource.FUZZ,
+        outcome=WitnessOutcome.EXIT_SIGNAL, data=b"crashbytes",
+    )
+    result = reproduce_witness(bundle, data, n=3)  # no binary_path
+    assert result.attempted is False
+    assert "needs a target binary" in result.reason
+
+
+def test_fuzz_binary_hash_mismatch_refused(tmp_path):
+    """Supplied binary doesn't match the recorded hash → refuse
+    (we'd be reproducing against the wrong build)."""
+    bundle, data = _bundle(
+        tmp_path, source=WitnessSource.FUZZ,
+        outcome=WitnessOutcome.EXIT_SIGNAL, data=b"crashbytes",
+        target_binary_hash="d" * 64,  # won't match the real file
+    )
+    fake_bin = tmp_path / "target"
+    fake_bin.write_bytes(b"not the recorded binary")
+    result = reproduce_witness(bundle, data, binary_path=fake_bin, n=3)
+    assert result.attempted is False
+    assert "hash mismatch" in result.reason
+
+
+# ----------------------------------------------------------------------
+# attach_reproduction
+# ----------------------------------------------------------------------
+
+
+def test_attach_reproduction_bumps_tier_when_reproduced(tmp_path):
+    bundle, _ = _bundle(
+        tmp_path, source=WitnessSource.LLM_EMIT_RUN,
+        outcome=WitnessOutcome.EXIT_SIGNAL, data=b"// poc",
+    )
+    assert bundle.tier == "0/1"
+    result = ReproductionResult(
+        attempted=True, runs=3, expected_outcome="exit_signal",
+        observed_outcomes=["exit_signal"] * 3, reproduced=True,
+        deterministic=True,
+    )
+    attach_reproduction(bundle, result)
+    assert bundle.tier == "1.5"
+    assert bundle.reproduction["reproduced"] is True
+
+
+def test_attach_reproduction_keeps_tier_when_not_reproduced(tmp_path):
+    bundle, _ = _bundle(
+        tmp_path, source=WitnessSource.LLM_EMIT_RUN,
+        outcome=WitnessOutcome.EXIT_SIGNAL, data=b"// poc",
+    )
+    result = ReproductionResult(
+        attempted=True, runs=3, expected_outcome="exit_signal",
+        observed_outcomes=["no_obvious_effect"] * 3, reproduced=False,
+        deterministic=True,
+    )
+    attach_reproduction(bundle, result)
+    assert bundle.tier == "0/1"  # NOT bumped
+    assert bundle.reproduction["reproduced"] is False
+
+
+# ----------------------------------------------------------------------
+# Integration — real recompile (needs gcc + libasan)
+# ----------------------------------------------------------------------
+
+
+def _has_libasan() -> bool:
+    cxx = next((c for c in ("c++", "g++", "clang++") if shutil.which(c)), None)
+    if cxx is None:
+        return False
+    try:
+        r = subprocess.run(
+            [cxx, "-fsanitize=address", "-x", "c++", "-",
+             "-o", "/dev/null"],
+            input="int main(){return 0;}",
+            text=True, capture_output=True, timeout=10,
+        )
+        return r.returncode == 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
+_BOF_SOURCE = """
+#include <cstring>
+#include <iostream>
+int main() {
+    char buf[8];
+    const char *src = "AAAAAAAAAAAAAAAAAAAA";
+    strcpy(buf, src);
+    std::cout << buf << std::endl;
+    return 0;
+}
+"""
+
+
+@pytest.mark.skipif(not _has_libasan(),
+                    reason="gcc -fsanitize=address not usable")
+def test_real_sanitizer_witness_reproduces(tmp_path):
+    """End-to-end: an LLM_EMIT_RUN witness whose bytes are a BOF
+    source recorded as SANITIZER_REPORT must reproduce — recompile
+    with -fsanitize=address (inferred), run 3×, ASAN fires each
+    time."""
+    bundle, data = _bundle(
+        tmp_path, source=WitnessSource.LLM_EMIT_RUN,
+        outcome=WitnessOutcome.SANITIZER_REPORT,
+        data=_BOF_SOURCE.encode(), sanitizer="asan",
+    )
+    result = reproduce_witness(bundle, data, n=3, sandbox_timeout=10)
+    assert result.attempted is True
+    assert result.runs == 3
+    assert result.reproduced is True, (
+        f"expected reproduce; got {result.observed_outcomes} "
+        f"({result.reason})"
+    )
+    assert result.observed_outcomes == ["sanitizer_report"] * 3
+
+
+# stdin-driven crasher: reads stdin, NULL-derefs on input starting 'B'
+_CRASHER_SRC = """
+#include <unistd.h>
+int main(void){
+    char b[64]; ssize_t n = read(0, b, 63);
+    if (n > 0 && b[0]=='B'){ int *p=0; *p=42; }
+    return 0;
+}
+"""
+
+
+@pytest.mark.skipif(shutil.which("gcc") is None and
+                    shutil.which("cc") is None,
+                    reason="no C compiler")
+def test_real_fuzz_replay_reproduces(tmp_path):
+    """End-to-end Mode B: a FUZZ witness (crash input) replayed
+    against the actual binary N times. Build a stdin crasher,
+    record the binary's hash on the witness, feed the crash input
+    3×, confirm EXIT_SIGNAL reproduces."""
+    cc = shutil.which("cc") or shutil.which("gcc")
+    src = tmp_path / "crasher.c"
+    src.write_text(_CRASHER_SRC)
+    binary = tmp_path / "crasher"
+    subprocess.run(
+        [cc, "-O0", "-g", "-o", str(binary), str(src)],
+        check=True, timeout=30,
+    )
+
+    from core.hash import sha256_file
+    crash_input = b"B" + b"\x00" * 8
+    bundle, data = _bundle(
+        tmp_path, source=WitnessSource.FUZZ,
+        outcome=WitnessOutcome.EXIT_SIGNAL,
+        data=crash_input,
+        target_binary_hash=sha256_file(binary),
+    )
+    result = reproduce_witness(
+        bundle, data, binary_path=binary, n=3, sandbox_timeout=10,
+    )
+    assert result.attempted is True
+    assert result.reproduced is True, (
+        f"expected reproduce; got {result.observed_outcomes} "
+        f"({result.reason})"
+    )
+    assert result.observed_outcomes == ["exit_signal"] * 3


### PR DESCRIPTION
The strongest claim achievable without the heavy ZK stack: re-run a bundle's witness against the target N times in the sandbox and confirm the recorded outcome reproduces. On-request, default off (N× execution is a policy shift).

reproduce_witness dispatches on source:
  - LLM_EMIT_RUN: recompile + run the exploit source N times. When the recorded outcome was a sanitizer report, infers the matching -fsanitize flag so ASAN fires again.
  - FUZZ/input-replay: feed the bytes to the target binary's stdin N times. Verifies the supplied binary's sha256 matches the bundle's target_binary_hash before trusting the result.

ReproductionResult separates reproduced (all N matched the recorded outcome) from deterministic (all N agreed, maybe off-target). attach_reproduction bumps the bundle to tier 1.5 on success. libexec/raptor-zkpox gives the dependency-free tiers an operator surface: `bundle` (0/1) + `reproduce` (1.5).

Completes the dependency-free ZKPoX surface; RISC-V/SP1 stay behind the Tier-2.0 line.

E2E both modes (live ASAN recompile + live FUZZ replay) and a full bundle→reproduce CLI walk. Adversarial review caught a corrupt/ incomplete manifest.json tracebacking on reproduce — fixed with a JSONDecodeError catch + required-field guard, regression-tested.