### PR TITLE
test: kill real-sleep/real-tool waits surfaced by --durations sweep

### DIFF
--- a/packages/cve_diff/tests/unit/conftest.py
+++ b/packages/cve_diff/tests/unit/conftest.py
@@ -83,3 +83,26 @@ def _bypass_git_sandbox(monkeypatch):
     monkeypatch.setattr(layers_mod, "fetch_commit", _test_fetch_commit)
 
 
+@pytest.fixture(autouse=True)
+def _no_real_retry_backoff(monkeypatch):
+    """No-op ``time.sleep`` for unit tests.
+
+    ResilientLLMClient (``llm/client.py``) retries with
+    ``time.sleep(backoff_factor ** attempt)`` and AgentLoop adds an
+    in-loop 0/5/15s backoff. Tests that drive the retry path with a
+    mocked-failing provider otherwise sit through the REAL backoff —
+    measured at 14s for ``test_provider_error_raises_llm_call_failed``
+    and ~9-11s each for the pipeline retry tests on the 2-core CI
+    runner (they were the entire cve_diff tier's wall-clock). The retry
+    COUNT and error-propagation behaviour is independent of how long
+    the backoff sleeps, so no-op the sleep.
+
+    Safe across the unit tree: the only timing-sensitive tests
+    (``infra/test_rate_limit.py``) drive an INJECTED fake clock
+    (``clk.sleep``), not the global ``time.sleep``, so their assertions
+    are unaffected.
+    """
+    import time
+    monkeypatch.setattr(time, "sleep", lambda *a, **k: None)
+
+

--- a/packages/exploit_feasibility/tests/test_integration.py
+++ b/packages/exploit_feasibility/tests/test_integration.py
@@ -75,8 +75,16 @@ def test_binary(tmp_path_factory):
     pytest.skip("No suitable test binary available")
 
 
+@pytest.mark.slow
 class TestAnalyzeBinaryIntegration:
-    """Integration tests for analyze_binary with a real binary."""
+    """Integration tests for analyze_binary with a real binary.
+
+    Slow-gated: analyze_binary runs a full real radare2 pass over the
+    binary — ~15s for the dict test on the 2-core CI runner, the
+    exploit-feasibility tier's whole wall-clock. It's genuine real-tool
+    work (not mockable without gutting the test's point), so it belongs
+    in the nightly `-m slow` tier rather than the per-PR gate.
+    """
 
     def test_analyze_binary_returns_dict(self, test_binary):
         """Test that analyze_binary returns a dictionary."""

--- a/packages/sca/resolvers/tests/test_resolvers.py
+++ b/packages/sca/resolvers/tests/test_resolvers.py
@@ -26,8 +26,22 @@ from packages.sca.resolvers.pip import PipResolver
 
 
 @pytest.fixture(autouse=True)
-def _reset_sandbox_probe_caches():
-    """Reset ``core.sandbox.state`` probe caches before each test.
+def _reset_sandbox_probe_caches(monkeypatch):
+    """Reset ``core.sandbox.state`` probe caches before each test, and
+    short-circuit the proxy-hosts auto-calibration so no resolver test
+    can trigger a real landlock probe.
+
+    The calibration short-circuit is the load-bearing half for CI cost.
+    ``_proxy_hosts._calibrated_profile`` → ``load_or_calibrate`` →
+    ``_spawn_probe`` runs a REAL sandbox probe (landlock/seccomp/
+    namespace). Tests that only patch ``subprocess.run`` (via
+    ``_patch_run``) leave that path live, so on the 2-core CI runner it
+    costs 30-80s per test (it was 84s for test_pip_resolver_failure_*,
+    20s for test_npm_always_passes_ignore_scripts) — and it once hung
+    test_composer_proxy_hosts outright. Stubbing it to None here (the
+    function's documented "calibration unavailable" path → static-layer
+    proxy_hosts) makes EVERY resolver test immune, present and future,
+    rather than relying on each remembering to call _capture_sandbox_call.
 
     Several module-level caches in ``core.sandbox.state`` record
     whether unprivileged user-namespaces work on this host
@@ -51,8 +65,11 @@ def _reset_sandbox_probe_caches():
     Idempotent + cheap; safe to run unconditionally.
     """
     from core.sandbox import state
+    from packages.sca.resolvers import _proxy_hosts as _ph
     state._net_available_cache = None
     state._mount_available_cache = None
+    # Never let a resolver test reach real proxy-hosts calibration.
+    monkeypatch.setattr(_ph, "_calibrated_profile", lambda *a, **k: None)
     # ``_resolve_sandbox_binary`` also caches per-binary paths in
     # ``state._<name>_path_cache`` attributes — they're keyed on
     # the binary name (``unshare`` / ``prlimit``) and the path


### PR DESCRIPTION
A --durations=25 sweep across every CI tier found the slow tests are dominated by real waits that should be mocked or gated — not by test count. Three fixes, one per offending cluster:

1. sca resolvers (was: shard 1 = 104s). Autouse fixture now stubs _proxy_hosts._calibrated_profile → None, so no resolver test can reach the real landlock calibration probe. Caught the siblings the per-test gating missed (test_pip_resolver_failure_propagates_via_venv 84s, test_npm_always_passes_ignore_scripts 20s, test_go_tidy_failure 4s) — same root cause as the composer-hang fix, fixed systemically.

2. cve_diff (was: tier ≈ 61s). New autouse fixture in tests/unit/ conftest.py no-ops time.sleep. ResilientLLMClient retries with time.sleep(backoff_factor**attempt) and AgentLoop adds a 0/5/15s in-loop backoff; retry-path tests with a mocked-failing provider sat through the real backoff (14s for test_provider_error, ~9-11s each for the pipeline retry tests). Retry COUNT/propagation is unchanged by sleep duration. infra/test_rate_limit drives an injected fake clock, not time.sleep, so its timing assertions are unaffected.

3. exploit_feasibility (was: 15s + 3s setup). @pytest.mark.slow on TestAnalyzeBinaryIntegration — a full real radare2 pass, genuine heavy work (not mockable without gutting the test), so it moves to the nightly slow tier rather than the per-PR gate.

Local: cve_diff unit 32 pass 8s (was ~60s); resolvers 51 pass; exploit class deselected by default; rate_limit 9 pass unchanged.

Left alone (diminishing returns / intentional): radare2 TestCmdTimeout
+ urllib breaker *_real_clock (timing-mechanism tests, already small timeouts), cli_smoke / libexec_shim / wrapper subprocess overhead.