### PR TITLE
feat(understand): assign trust_level (provenance) to sources in /understand --map

### DIFF
--- a/.claude/skills/code-understanding/map.md
+++ b/.claude/skills/code-understanding/map.md
@@ -48,6 +48,15 @@ Find all locations where external input enters the application:
 
 For each: record file path, line number, and what data it accepts.
 
+For each source, also assign a **`trust_level`** — the provenance of the data it introduces, i.e. how attacker-controllable it is *at the point it enters*:
+
+- `attacker_controlled` — the attacker supplies it directly: HTTP body/query/headers/cookies, `argv`/stdin, `recv`/socket reads, uploaded file contents, webhook payloads before signature verification.
+- `persistent_store` — read from storage that may hold attacker data written in an earlier request: DB rows, cache, message queues, files written by another actor. Cross-class flow out of here is the "stored" vuln family (stored XSS / stored cmd-injection) — note it for Stage B.
+- `internal_value` — server-generated, not attacker-influenced: UUIDs / sequence IDs the server mints, JWT claims *after* signature verification, values checked against a closed allow-list.
+- `runtime_constant` — fixed before any request: compile-time constants, hardcoded config, env vars loaded at startup.
+
+When a value combines inputs, take the most-attacker-controlled (`attacker_controlled` > `persistent_store` > `internal_value` > `runtime_constant`). These labels correspond to L1-L4 respectively for anyone coming from that vocabulary.
+
 **[MAP-2] Trust Boundary Identification**
 
 Identify where the code makes (or should make) trust decisions:
@@ -90,7 +99,8 @@ Produce a brief summary covering:
   "sources": [
     {
       "type": "http_route",
-      "entry": "POST /api/v2/query @ src/routes/query.py:34"
+      "entry": "POST /api/v2/query @ src/routes/query.py:34",
+      "trust_level": "attacker_controlled"
     }
   ],
   "sinks": [

--- a/core/orchestration/tests/test_understand_bridge.py
+++ b/core/orchestration/tests/test_understand_bridge.py
@@ -510,6 +510,29 @@ class TestLoadUnderstandContextAttackSurface:
         assert len(surface["sinks"]) == 1
         assert len(surface["trust_boundaries"]) == 1
 
+    def test_source_trust_level_survives_into_attack_surface(self, tmp_path):
+        """A source's trust_level (provenance, assigned by /understand
+        --map) must ride through the bridge into attack-surface.json so
+        /validate Stage B's prompt sees it — the bridge copies whole
+        source dicts, so the field is preserved without special-casing."""
+        understand_dir = tmp_path / "understand"
+        validate_dir = tmp_path / "validate"
+        understand_dir.mkdir()
+        validate_dir.mkdir()
+
+        ctx = dict(MINIMAL_CONTEXT_MAP)
+        ctx["sources"] = [{
+            "type": "http_route",
+            "entry": "POST /api/query @ src/routes/query.py:34",
+            "trust_level": "attacker_controlled",
+        }]
+        _write_json(understand_dir / "context-map.json", ctx)
+
+        load_understand_context(understand_dir, validate_dir)
+
+        surface = json.loads((validate_dir / "attack-surface.json").read_text())
+        assert surface["sources"][0]["trust_level"] == "attacker_controlled"
+
     def test_does_not_raise_on_non_string_file_during_stale_filter(self, tmp_path):
         # _references_file does `f in stale_files` — list-typed file would
         # raise TypeError. Pre-existing weakness, but newly exposed once

--- a/packages/exploitability_validation/schemas.py
+++ b/packages/exploitability_validation/schemas.py
@@ -501,7 +501,30 @@ ATTACK_SURFACE_SCHEMA = {
                     "entry": {"type": "string", "description": "Entry point description"},
                     "location": {"type": "string", "description": "Alias for entry"},
                     "trust": {"type": "string", "description": "Free-text trust description"},
-                    "trust_level": {"type": "string", "enum": ["untrusted", "semi-trusted", "trusted"]},
+                    "trust_level": {
+                        "type": "string",
+                        # Provenance of the source's data, assigned by
+                        # /understand --map. Descriptive labels (≈ vbsec
+                        # L1-L4): attacker_controlled=L1 (req/argv/recv),
+                        # persistent_store=L2 (DB row/cache — may hold an
+                        # earlier attacker write), internal_value=L3
+                        # (server-generated IDs, verified JWT claims),
+                        # runtime_constant=L4 (compile-time consts, startup
+                        # env). The legacy untrusted/semi-trusted/trusted
+                        # triple is accepted for back-compat and maps onto
+                        # attacker_controlled / persistent_store / (internal
+                        # _value|runtime_constant) respectively.
+                        "enum": [
+                            "attacker_controlled",
+                            "persistent_store",
+                            "internal_value",
+                            "runtime_constant",
+                            # legacy aliases
+                            "untrusted",
+                            "semi-trusted",
+                            "trusted",
+                        ],
+                    },
                     "fields": {"type": "array", "items": {"type": "string"}},
                     "description": {"type": "string"}
                 }

--- a/packages/exploitability_validation/tests/test_attack_surface_schema.py
+++ b/packages/exploitability_validation/tests/test_attack_surface_schema.py
@@ -1,26 +1,23 @@
 """Schema tests for ATTACK_SURFACE_SCHEMA source trust_level.
 
 Locks the back-compat property of the trust_level enum widening: the four
-descriptive provenance labels validate, the legacy three still validate
-(so old context-map / attack-surface JSON keeps passing), omitting the
-field validates (it's optional), and a bogus value is still rejected (the
-enum is still enforced — the widening didn't turn it into a free string).
+descriptive provenance labels are present, the legacy three are retained
+(so old context-map / attack-surface JSON keeps validating), the field
+stays optional (not in the source `required` list), and the enum is still
+closed (the widening didn't turn it into a free string).
+
+Asserts against the schema dict directly rather than via ``jsonschema`` —
+that package is NOT a declared RAPTOR dependency (it's absent in CI), and
+RAPTOR's own validation uses ``libexec/raptor-validate-schema``. Importing
+it here passed locally but broke CI collection.
 """
 
 from __future__ import annotations
 
-import jsonschema
-import pytest
-
 from packages.exploitability_validation.schemas import ATTACK_SURFACE_SCHEMA
 
-
-def _surface(trust_level=None):
-    source = {"type": "http_route", "entry": "POST /q @ a.py:1"}
-    if trust_level is not None:
-        source["trust_level"] = trust_level
-    return {"sources": [source], "sinks": [], "trust_boundaries": []}
-
+_SOURCE_ITEMS = ATTACK_SURFACE_SCHEMA["properties"]["sources"]["items"]
+_TRUST_LEVEL = _SOURCE_ITEMS["properties"]["trust_level"]
 
 DESCRIPTIVE = [
     "attacker_controlled", "persistent_store",
@@ -29,23 +26,25 @@ DESCRIPTIVE = [
 LEGACY = ["untrusted", "semi-trusted", "trusted"]
 
 
-@pytest.mark.parametrize("level", DESCRIPTIVE)
-def test_descriptive_labels_valid(level):
-    jsonschema.validate(_surface(level), ATTACK_SURFACE_SCHEMA)
+def test_descriptive_labels_present():
+    for level in DESCRIPTIVE:
+        assert level in _TRUST_LEVEL["enum"]
 
 
-@pytest.mark.parametrize("level", LEGACY)
-def test_legacy_labels_still_valid(level):
-    # Back-compat: pre-widening JSON used these — must keep validating.
-    jsonschema.validate(_surface(level), ATTACK_SURFACE_SCHEMA)
+def test_legacy_labels_retained():
+    # Back-compat: pre-widening JSON used these — must stay accepted.
+    for level in LEGACY:
+        assert level in _TRUST_LEVEL["enum"]
 
 
 def test_trust_level_optional():
-    # The field isn't required; existing data omits it entirely.
-    jsonschema.validate(_surface(None), ATTACK_SURFACE_SCHEMA)
+    # Existing data omits it entirely; it must not be required.
+    assert "trust_level" not in _SOURCE_ITEMS["required"]
 
 
-def test_bogus_trust_level_rejected():
-    # The widening added values but kept the enum closed — garbage fails.
-    with pytest.raises(jsonschema.ValidationError):
-        jsonschema.validate(_surface("totally_trusted"), ATTACK_SURFACE_SCHEMA)
+def test_enum_still_closed():
+    # The widening added values but kept the enum a closed set — a string
+    # type with an enum, not a free-form string.
+    assert _TRUST_LEVEL["type"] == "string"
+    assert "enum" in _TRUST_LEVEL
+    assert "totally_trusted" not in _TRUST_LEVEL["enum"]

--- a/packages/exploitability_validation/tests/test_attack_surface_schema.py
+++ b/packages/exploitability_validation/tests/test_attack_surface_schema.py
@@ -1,0 +1,51 @@
+"""Schema tests for ATTACK_SURFACE_SCHEMA source trust_level.
+
+Locks the back-compat property of the trust_level enum widening: the four
+descriptive provenance labels validate, the legacy three still validate
+(so old context-map / attack-surface JSON keeps passing), omitting the
+field validates (it's optional), and a bogus value is still rejected (the
+enum is still enforced — the widening didn't turn it into a free string).
+"""
+
+from __future__ import annotations
+
+import jsonschema
+import pytest
+
+from packages.exploitability_validation.schemas import ATTACK_SURFACE_SCHEMA
+
+
+def _surface(trust_level=None):
+    source = {"type": "http_route", "entry": "POST /q @ a.py:1"}
+    if trust_level is not None:
+        source["trust_level"] = trust_level
+    return {"sources": [source], "sinks": [], "trust_boundaries": []}
+
+
+DESCRIPTIVE = [
+    "attacker_controlled", "persistent_store",
+    "internal_value", "runtime_constant",
+]
+LEGACY = ["untrusted", "semi-trusted", "trusted"]
+
+
+@pytest.mark.parametrize("level", DESCRIPTIVE)
+def test_descriptive_labels_valid(level):
+    jsonschema.validate(_surface(level), ATTACK_SURFACE_SCHEMA)
+
+
+@pytest.mark.parametrize("level", LEGACY)
+def test_legacy_labels_still_valid(level):
+    # Back-compat: pre-widening JSON used these — must keep validating.
+    jsonschema.validate(_surface(level), ATTACK_SURFACE_SCHEMA)
+
+
+def test_trust_level_optional():
+    # The field isn't required; existing data omits it entirely.
+    jsonschema.validate(_surface(None), ATTACK_SURFACE_SCHEMA)
+
+
+def test_bogus_trust_level_rejected():
+    # The widening added values but kept the enum closed — garbage fails.
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(_surface("totally_trusted"), ATTACK_SURFACE_SCHEMA)


### PR DESCRIPTION
The ATTACK_SURFACE_SCHEMA reserved a `trust_level` field on sources but nothing produced it and nothing consumed it — a latent design gap. Characterising a source's provenance is /understand --map's job (it's the stage that builds the attack-surface model and already finds trust boundaries), so that's where the producer belongs.

- map.md [MAP-1]: each source now gets a trust_level — attacker_controlled (req/argv/recv), persistent_store (DB/cache, may hold an earlier attacker write → stored-vuln family), internal_value (server-minted IDs, verified JWT claims), runtime_constant (compile-time consts, startup env). Combination rule: most-attacker-controlled wins. (≈ L1-L4 for anyone arriving from vbsec / issue #583.)
- schema: widened the trust_level enum with those four descriptive labels, keeping untrusted/semi-trusted/trusted as back-compat aliases. Additive + the field stays optional, so existing context-map / attack-surface JSON keeps validating; enum is still closed (garbage rejected). Tested in test_attack_surface_schema.py.
- the understand→validate bridge already copies whole source dicts, so the label rides through to attack-surface.json (Stage B prompt context) with no bridge change — covered by a new bridge test.

The field is live on day one: populated by map, operator-visible in context-map.json, carried into the Stage B prompt, and diagram-able. Mechanical consumers (Stage B read-not-rederive, /diagram colouring, /annotate) are additive follow-ups.