### PR TITLE
ci: share venv via actions/cache, not run artifact (kills download stall)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -218,7 +218,15 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "requirements*.txt"
 
+      - name: Restore venv from cache
+        id: venv-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
+        with:
+          path: ${{ env.VENV_PATH }}
+          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+
       - name: Create venv and install deps
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
           uv venv $VENV_PATH
           source $VENV_PATH/bin/activate
@@ -227,13 +235,12 @@ jobs:
       - name: Verify venv exists
         run: test -d "$VENV_PATH" || (echo "venv missing at $VENV_PATH" && exit 1)
 
-      - name: Upload venv for this run
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # was v7
+      - name: Save venv to cache
+        if: steps.venv-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
         with:
-          name: venv-${{ github.run_id }}
           path: ${{ env.VENV_PATH }}
-          include-hidden-files: true
-          retention-days: 1
+          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
 
   # Fast tier: everything under core/ and packages/ except the two
   # heavyweight subdirs that get their own jobs (sandbox, exploit_feasibility).
@@ -270,11 +277,12 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Download venv artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # was v8.0.1
+      - name: Restore venv from cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
         with:
-          name: venv-${{ github.run_id }}
           path: ${{ env.VENV_PATH }}
+          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          fail-on-cache-miss: true
 
       - name: Restore venv permissions
         run: chmod +x $VENV_PATH/bin/*
@@ -364,11 +372,12 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Download venv artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # was v8.0.1
+      - name: Restore venv from cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
         with:
-          name: venv-${{ github.run_id }}
           path: ${{ env.VENV_PATH }}
+          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          fail-on-cache-miss: true
 
       - name: Restore venv permissions
         run: chmod +x $VENV_PATH/bin/*
@@ -405,11 +414,12 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Download venv artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # was v8.0.1
+      - name: Restore venv from cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
         with:
-          name: venv-${{ github.run_id }}
           path: ${{ env.VENV_PATH }}
+          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          fail-on-cache-miss: true
 
       - name: Restore venv permissions
         run: chmod +x $VENV_PATH/bin/*
@@ -445,11 +455,12 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Download venv artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # was v8.0.1
+      - name: Restore venv from cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
         with:
-          name: venv-${{ github.run_id }}
           path: ${{ env.VENV_PATH }}
+          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          fail-on-cache-miss: true
 
       - name: Restore venv permissions
         run: chmod +x $VENV_PATH/bin/*
@@ -599,11 +610,12 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: Download venv artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # was v8.0.1
+      - name: Restore venv from cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # was v5.0.5
         with:
-          name: venv-${{ github.run_id }}
           path: ${{ env.VENV_PATH }}
+          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          fail-on-cache-miss: true
       - name: Restore venv permissions
         run: chmod +x $VENV_PATH/bin/*
       - name: Run cve_diff tests


### PR DESCRIPTION
The venv-tier fan-out (fast×4 + sca×4 + sandbox + exploit_feasibility
+ cve_diff) each downloaded a ~130 MB run-scoped artifact. Under the Free 20-runner pool those concurrent pulls hit GitHub's artifact service throttle: measured 6s on one run, 4m+ on another for the same artifact — variable stalls that dominated wall-clock.

Switch venv sharing from upload/download-artifact to actions/cache:
- deps: restore .venv from cache → build (uv) only on miss → save. Removes the upload-artifact step. Cross-run bonus: unchanged requirements*.txt → cache hit → uv install skipped entirely.
- the 5 venv consumers: restore .venv from cache (fail-on-cache-miss: true, so a miss fails loudly rather than silently running without a venv) instead of downloading the artifact.

actions/cache is CDN-backed and built for many jobs restoring the same key concurrently — exactly the fan-out the artifact service chokes on. Key: venv-<os>-py<ver>-<hash(requirements*.txt)>. deps `needs`-precedes every consumer, so the cache is always saved before they restore, and the in-run flow holds even on a cold cache (build+save then restore).

No new action: actions/cache is first-party and already SHA-pinned in this workflow (the __pycache__ cache); its restore/save sub-actions live at the same commit (27d5ce7f…, v5.0.5).

The 5 container tiers already sidestep the venv entirely (deps baked into the image); this covers the tiers that can't containerize (they need the runner's system toolchain). Can't be validated locally (Actions cache is GitHub-only) — branch CI is the proof: first run builds+saves, consumers restore.