### PR TITLE
feat(inventory): thread --allow-unreachable to the TranslationView

### DIFF
--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -84,7 +84,9 @@ _DEFAULT_INVENTORY_CACHE_ROOT = (
 )
 
 
-def default_cache_dir(target_path: str) -> Path:
+def default_cache_dir(
+    target_path: str, *, allow_unreachable: bool = False,
+) -> Path:
     """Return the persistent cache directory for ``target_path``'s
     inventory checklist.
 
@@ -99,9 +101,12 @@ def default_cache_dir(target_path: str) -> Path:
     without picking a project-specific path themselves.
     """
     target_abs = str(Path(target_path).resolve())
-    target_hash = hashlib.sha256(
-        target_abs.encode("utf-8"),
-    ).hexdigest()[:16]
+    # Fold the parse mode into the key: allow_unreachable changes the
+    # C/C++ view (#if 0 kept vs blanked), so the two modes must not share
+    # a cached checklist. Default mode keeps the original hash input, so
+    # existing cache dirs are unchanged.
+    key = target_abs if not allow_unreachable else target_abs + "\0allow_unreachable"
+    target_hash = hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
     return _DEFAULT_INVENTORY_CACHE_ROOT / target_hash
 
 
@@ -112,6 +117,7 @@ def build_inventory(
     extensions: Optional[Set[str]] = None,
     skip_generated: bool = True,
     parallel: bool = True,
+    allow_unreachable: bool = False,
 ) -> Dict[str, Any]:
     """Build a source inventory of all files and functions in the target path.
 
@@ -143,7 +149,9 @@ def build_inventory(
         Inventory dict (also saved to ``<output_dir>/checklist.json``).
     """
     if output_dir is None:
-        output_dir = str(default_cache_dir(target_path))
+        output_dir = str(default_cache_dir(
+            target_path, allow_unreachable=allow_unreachable,
+        ))
     if exclude_patterns is None:
         exclude_patterns = DEFAULT_EXCLUDES
 
@@ -203,7 +211,7 @@ def build_inventory(
             futures = {
                 executor.submit(
                     _process_single_file, fp, target, exclude_patterns,
-                    skip_generated, old_files_by_path
+                    skip_generated, old_files_by_path, allow_unreachable
                 ): fp
                 for fp in file_list
             }
@@ -232,7 +240,8 @@ def build_inventory(
         for filepath in file_list:
             _collect_result(
                 _process_single_file(filepath, target, exclude_patterns,
-                                     skip_generated, old_files_by_path)
+                                     skip_generated, old_files_by_path,
+                                     allow_unreachable)
             )
 
     # Sort for consistent output
@@ -447,6 +456,7 @@ def _process_single_file(
     exclude_patterns: List[str],
     skip_generated: bool = True,
     old_files: Dict[str, Any] = None,
+    allow_unreachable: bool = False,
 ) -> Optional[Dict[str, Any]]:
     """Process a single file for the inventory.
 
@@ -545,7 +555,10 @@ def _process_single_file(
         # Metrics (sloc, line_count, sha256) and text scanners
         # (detect_dead_scopes / detect_module_load_abort) keep using the
         # real `content`; only the tree-sitter / AST parse uses parse_text.
-        view = preprocess_view(str(filepath), language, content)
+        view = preprocess_view(
+            str(filepath), language, content,
+            allow_unreachable=allow_unreachable,
+        )
         parse_text = view.parse_text
         tree_cache = {}
         items = extract_items(str(filepath), language, parse_text, _tree_cache=tree_cache)

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -773,3 +773,41 @@ class TestDefaultCacheDir:
         inv = build_inventory(str(src), str(explicit))
         assert inv["total_files"] == 1
         assert (explicit / "checklist.json").is_file()
+
+
+class TestAllowUnreachableView:
+    """U5: allow_unreachable threads through build_inventory to the
+    TranslationView, so isolation mode keeps disabled C/C++ code for
+    review instead of blanking #if 0."""
+
+    def _c_names(self, tmp_path, allow_unreachable):
+        from core.inventory.builder import build_inventory
+        src = tmp_path / "src"
+        src.mkdir(exist_ok=True)
+        (src / "m.c").write_text(
+            "#if 0\n"
+            "void disabled_fn(void){ dangerous(); }\n"
+            "#endif\n"
+            "void live_fn(void){ ok(); }\n"
+        )
+        out = tmp_path / ("au" if allow_unreachable else "def")
+        inv = build_inventory(
+            str(src), str(out), allow_unreachable=allow_unreachable,
+        )
+        return {i["name"] for f in inv["files"] for i in f["items"]
+                if i.get("kind", "function") == "function"}
+
+    def test_default_blanks_if0(self, tmp_path):
+        assert self._c_names(tmp_path, False) == {"live_fn"}
+
+    def test_isolation_keeps_disabled_code(self, tmp_path):
+        assert self._c_names(tmp_path, True) == {"disabled_fn", "live_fn"}
+
+    def test_cache_dirs_isolated_by_mode(self, tmp_path):
+        from core.inventory.builder import default_cache_dir
+        d_def = default_cache_dir(str(tmp_path))
+        d_iso = default_cache_dir(str(tmp_path), allow_unreachable=True)
+        assert d_def != d_iso
+        # Default mode must hash identically to the no-arg call so existing
+        # persistent caches are not invalidated when this lands.
+        assert default_cache_dir(str(tmp_path), allow_unreachable=False) == d_def

--- a/core/orchestration/reachability_enrichment.py
+++ b/core/orchestration/reachability_enrichment.py
@@ -84,7 +84,13 @@ def mark_unreachable_low_priority(
             from core.inventory.builder import build_inventory
             import tempfile
             with tempfile.TemporaryDirectory() as td:
-                inventory = build_inventory(str(target_path), td)
+                # Union/raw view in isolation mode so the reachability
+                # query graph matches the operator's declared intent
+                # (review everything, incl. #if 0 code).
+                inventory = build_inventory(
+                    str(target_path), td,
+                    allow_unreachable=allow_unreachable,
+                )
         except Exception as e:                      # noqa: BLE001
             logger.debug(
                 "reachability_enrichment: inventory build failed (%s); "

--- a/packages/codeql/autonomous_analyzer.py
+++ b/packages/codeql/autonomous_analyzer.py
@@ -283,8 +283,11 @@ class AutonomousCodeQLAnalyzer:
                     from core.inventory.builder import build_inventory
                     import tempfile
                     with tempfile.TemporaryDirectory() as td:
+                        # Union/raw view in isolation mode so the prefilter's
+                        # reachability graph matches the operator's intent.
                         self._reachability_inventory = build_inventory(
                             str(repo_path), td,
+                            allow_unreachable=self._allow_unreachable,
                         )
                 except Exception as e:              # noqa: BLE001
                     self.logger.debug(


### PR DESCRIPTION
The C/C++ #if 0 blanking (PR #628) always ran, so isolation mode (--allow-unreachable) couldn't surface disabled code for review — the suppression-layer opt-out never reached the extraction layer. Thread the flag through build_inventory → _process_single_file → preprocess_view so isolation mode returns the raw/union view (no blanking) and the operator sees #if 0 code.

- build_inventory(allow_unreachable=...) + default_cache_dir folds the mode into the cache key, so the two parse modes (#if 0 kept vs blanked) never share a cached checklist. Default mode hashes identically to before — existing persistent caches are not invalidated.
- Wired at the reachability-query build sites that reach build_inventory in isolation mode (the /agentic enrichment prepass, the CodeQL prefilter) so their reachability graph matches the operator's mode. The /validate demoter is deliberately not wired — it early-returns under --allow-unreachable, so its build_inventory never runs in that mode.

Verified: build_inventory(allow_unreachable=True) keeps #if 0 functions, =False blanks them; cache dirs differ by mode; default-mode hash unchanged.