### PR TITLE
test(project): isolate output base in ProjectManager tests (xdist race)

### DIFF
--- a/core/project/tests/test_add.py
+++ b/core/project/tests/test_add.py
@@ -3,6 +3,7 @@
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from core.project.project import ProjectManager
 from core.run import RUN_METADATA_FILE
@@ -114,6 +115,15 @@ class TestRemoveRun(unittest.TestCase):
     def setUp(self):
         self.tmpdir = TemporaryDirectory()
         self.projects_dir = Path(self.tmpdir.name) / "projects"
+        # Isolate the output base: two tests here call create("myapp")
+        # without an explicit output_dir, which defaults to the shared
+        # repo-relative DEFAULT_OUTPUT_BASE (``out/projects/myapp``). Patch
+        # it to a per-test tmpdir so they don't write to / race on the
+        # shared path under xdist. (See test_project.py for the full race.)
+        out_base = Path(self.tmpdir.name) / "out" / "projects"
+        _ob = patch("core.project.project.DEFAULT_OUTPUT_BASE", out_base)
+        _ob.start()
+        self.addCleanup(_ob.stop)
         # Per-test scratch target; lives under the same tmpdir, so no
         # hardcoded host path leaks into Project(target=...) values.
         self.target_code = str(Path(self.tmpdir.name) / "code")

--- a/core/project/tests/test_project.py
+++ b/core/project/tests/test_project.py
@@ -168,6 +168,18 @@ class TestProjectManager(unittest.TestCase):
     def setUp(self):
         self.tmpdir = TemporaryDirectory()
         self.projects_dir = Path(self.tmpdir.name) / "projects"
+        # Isolate the output base. ProjectManager.create() defaults
+        # output_dir to the shared repo-relative DEFAULT_OUTPUT_BASE
+        # (``out/projects/<name>``) regardless of projects_dir, so under
+        # xdist two workers using the same project name race on
+        # ``out/projects/myapp`` — one test's purge wipes another's output
+        # (surfaced as a flaky test_delete_keeps_output_by_default). Patch
+        # the module global to a per-test tmpdir so create() and delete()'s
+        # base check both stay isolated.
+        out_base = Path(self.tmpdir.name) / "out" / "projects"
+        _ob = patch("core.project.project.DEFAULT_OUTPUT_BASE", out_base)
+        _ob.start()
+        self.addCleanup(_ob.stop)
         self.mgr = ProjectManager(projects_dir=self.projects_dir)
         # Per-test scratch targets; the names are stable so listing /
         # rename / find-project-for-target assertions can match


### PR DESCRIPTION
ProjectManager.create() defaults output_dir to the shared repo-relative DEFAULT_OUTPUT_BASE (out/projects/<name>) regardless of the (isolated) projects_dir. So two project tests using the same name "myapp" — e.g. test_delete_purges_output (purge=True → rmtree out/projects/myapp) and test_delete_keeps_output_by_default (expects it to survive) — race on the same path under xdist, and TestRemoveRun also created myapp there. The flake only surfaces when pytest-split happens to land colliding tests in parallel groups (an unrelated PR's test additions can trigger it by shifting group boundaries).

Patch DEFAULT_OUTPUT_BASE to a per-test tmpdir in the two affected setUps (TestProjectManager, TestRemoveRun) so create() and delete()'s base check both stay isolated. test_export/test_cli already isolate via tmpdir output_base / patched PROJECTS_DIR; TestAddDirectory/TestProject pass explicit output_dirs — left as-is.

Verified: the project suites no longer create out/projects/ in the repo, so there's no shared state to race on; 50 tests pass.