### PR TITLE
ci: add default-tier slow-test guard (preventive)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,15 @@ env:
   # pytest.ini) so it covers every tier here but NOT local `pytest`,
   # where it would dump on pdb / breakpoint sessions.
   PYTEST_ADDOPTS: "-o faulthandler_timeout=120"
+  # Default-tier slow-test guard (root conftest.py). Fails the run if any
+  # test's call phase exceeds this many seconds — the preventive backstop
+  # for "real I/O that should be mocked" landing in the fast tier (the
+  # 14s/20s/84s class the --durations sweep found). 10s is well above the
+  # slowest legit default-tier test (~3s) with headroom for runner
+  # variance, and well below faulthandler's 120s hang net. NOT set in
+  # nightly.yml — its `-m "slow or integration"` tests are legitimately
+  # slow. A genuinely-heavy new test should be marked @pytest.mark.slow.
+  RAPTOR_MAX_TEST_SECONDS: "10"
   # Opt the runner into Node.js 24 for JavaScript actions.
   # GitHub deprecated Node.js 20 on 2025-09-19; runners enforce
   # Node 24 by default from 2026-06-02 and remove Node 20 on

--- a/conftest.py
+++ b/conftest.py
@@ -48,3 +48,64 @@ if _existing and _existing != _conftest_dir:
         file=sys.stderr,
     )
 os.environ["RAPTOR_DIR"] = _conftest_dir
+
+
+# ---------------------------------------------------------------------------
+# Default-tier slow-test guard
+# ---------------------------------------------------------------------------
+#
+# Preventive backstop for the "a default-tier test is slow because it
+# does real I/O it should mock" class — real subprocess / network /
+# time.sleep / sandbox setup that turns a 30ms unit test into a 30s one.
+# faulthandler_timeout (set in tests.yml) catches a *hang*; this catches
+# slow-but-finishes, the day it lands, instead of in a later --durations
+# sweep.
+#
+# Activated ONLY when RAPTOR_MAX_TEST_SECONDS is set — tests.yml sets it
+# for the default-tier matrix; nightly.yml deliberately does NOT (its
+# `-m "slow or integration"` tests are legitimately slow), and local
+# `pytest` is unaffected. The guard FLAGS, it does not kill: every test
+# still runs to completion; the session then fails at the end naming the
+# offenders, so the signal is "this test got slow", not "killed mid-run".
+#
+# A genuinely-heavy test is not a bug — mark it @pytest.mark.slow (moves
+# it to the nightly tier, out of this guard's scope).
+
+_MAX_TEST_SECONDS = os.environ.get("RAPTOR_MAX_TEST_SECONDS")
+_slow_test_threshold = float(_MAX_TEST_SECONDS) if _MAX_TEST_SECONDS else None
+_slow_test_overruns: "list[tuple[str, float]]" = []
+
+
+def pytest_runtest_logreport(report):
+    """Record any test whose CALL phase exceeds the threshold."""
+    if _slow_test_threshold is None:
+        return
+    if report.when == "call" and report.duration > _slow_test_threshold:
+        _slow_test_overruns.append((report.nodeid, report.duration))
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Fail an otherwise-green session if any test overran the threshold."""
+    if _slow_test_threshold is None or not _slow_test_overruns:
+        return
+    if session.exitstatus == 0:
+        session.exitstatus = 1
+
+
+def pytest_terminal_summary(terminalreporter):
+    if _slow_test_threshold is None or not _slow_test_overruns:
+        return
+    tr = terminalreporter
+    tr.section("default-tier slow-test guard FAILED", red=True, bold=True)
+    tr.write_line(
+        f"{len(_slow_test_overruns)} test(s) exceeded "
+        f"RAPTOR_MAX_TEST_SECONDS={_slow_test_threshold}s in the default tier."
+    )
+    tr.write_line(
+        "A default-tier test this slow is almost always real I/O that "
+        "should be mocked (subprocess / network / time.sleep / sandbox "
+        "setup). Fix it — or, if the cost is genuine, mark it "
+        "@pytest.mark.slow so it runs in the nightly tier instead.",
+    )
+    for nodeid, dur in sorted(_slow_test_overruns, key=lambda x: -x[1]):
+        tr.write_line(f"  {dur:7.1f}s  {nodeid}")


### PR DESCRIPTION
Turns the reactive --durations sweep into an automatic gate. The CI overhaul fixed today's slow tests (sca calibration probe, cve_diff retry backoff, exploit radare2), but nothing PREVENTED the next "real I/O that should be mocked" test from landing in the fast tier — it'd just show up in a future sweep. This catches it the day it merges.

Root conftest.py gains an env-gated guard: when RAPTOR_MAX_TEST_SECONDS is set, any test whose call phase exceeds it fails the session (exit 1) with a terminal summary naming the offenders and pointing at the fix (mock the I/O, or @pytest.mark.slow if the cost is genuine). It FLAGS, it does not kill — tests still run to completion, so the signal is "this got slow", not "killed mid-run".

tests.yml sets RAPTOR_MAX_TEST_SECONDS=10 for the default-tier matrix: well above the slowest legit default test (~3s) with runner-variance headroom, well below the 120s faulthandler hang net (which catches hangs; this catches slow-but-finishes). nightly.yml deliberately omits it — its `-m "slow or integration"` tests are legitimately slow — and local `pytest` is unaffected (env unset → guard inert).

Verified: a 2s test under RAPTOR_MAX_TEST_SECONDS=1 fails the session (exit 1) and is named; unset → exit 0. Tunable via the env value if a legit test ever false-fires under CI load (one-line, no code change).