### PR TITLE
fix(test): test-isolation + path-resolution hygiene in orchestration/exploitability suites

### DIFF
--- a/core/orchestration/tests/test_raptor_normalize_context_map.py
+++ b/core/orchestration/tests/test_raptor_normalize_context_map.py
@@ -8,7 +8,11 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 
-REPO_ROOT = Path(os.environ["RAPTOR_DIR"])
+# parents[3] climbs: [0] tests/ -> [1] orchestration/ -> [2] core/ -> [3] repo root.
+# Derive from __file__ rather than os.environ["RAPTOR_DIR"]: it doesn't KeyError
+# when the env var is unset, and it correctly resolves to *this* checkout (e.g. a
+# git worktree), not whatever RAPTOR_DIR happens to point at.
+REPO_ROOT = Path(__file__).resolve().parents[3]
 WRAPPER = REPO_ROOT / "libexec" / "raptor-normalize-context-map"
 
 

--- a/packages/exploitability_validation/tests/test_prepare_validation.py
+++ b/packages/exploitability_validation/tests/test_prepare_validation.py
@@ -1,6 +1,5 @@
 """Tests for raptor-validation-helper and related libexec scripts."""
 
-import os
 import sys
 import unittest
 from pathlib import Path
@@ -274,10 +273,12 @@ class TestStageFileValidator(unittest.TestCase):
         with TemporaryDirectory() as d:
             p = Path(d) / "stage-b.json"
             save_json(p, {"stage": "B", "updates": {"F1": {"x": 1}}})
-            # This would fail with "findings" validator but should auto-detect
-            os.chdir(d)
-            # Can't easily test the CLI auto-detect without subprocess,
-            # but we can test the _validate_stage_file function directly
+            # This would fail with the "findings" validator but should
+            # auto-detect. NOTE: no os.chdir here — _validate_stage_file takes
+            # the absolute path, so the chdir was dead code AND polluting: it
+            # left the process CWD on a since-deleted TemporaryDirectory,
+            # breaking later tests that resolve relative paths against CWD
+            # (e.g. find_understand_output's tier-3 global-out scan).
             errors = _validator._validate_stage_file(
                 load_json(p), "stage-b.json"
             )


### PR DESCRIPTION
Two fixes found during a hardcoded-paths audit of core/orchestration and packages/exploitability_validation test suites:

1. Removed a dead, unrestored os.chdir in test_prepare_validation. test_auto_detect_stage_file did os.chdir(d) inside a `with TemporaryDirectory() as d:` and never restored it — when the block exited and d was deleted, the process CWD was left pointing at a deleted directory, breaking any later test that resolves a relative path against CWD. Concretely it broke find_understand_output's tier-3 global-out tests (test_understand_bridge.TestFindUnderstandOutput) when the exploitability_validation suite ran before core/orchestration in the same session — 3 failures that only surfaced under cross-module ordering. The chdir was also dead code: the test validates an absolute path that never consults CWD. Removed it and the now-unused `import os`.

2. test_raptor_normalize_context_map now derives the repo root from Path(__file__).resolve().parents[3] (the documented convention) instead of Path(os.environ["RAPTOR_DIR"]), which KeyErrors when the env var is unset and, in a git worktree, resolved to the MAIN checkout's wrapper rather than the worktree's. (import os stays — still used by os.access.)

Proof: pytest packages/exploitability_validation/tests/ core/orchestration/tests/ went from 3 failed -> 737 passed.