### PR TITLE
feat(reachability): entry-point forward reachability 

### DIFF
--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -2246,6 +2246,229 @@ def is_lexically_dead(
     return False
 
 
+# ---------------------------------------------------------------------------
+# Entry-point forward reachability (U7) — "is this reachable from a real
+# entry, or only from an orphaned/dead chain?"
+# ---------------------------------------------------------------------------
+#
+# ``function_called`` answers the 1-hop "does anything call this name?" — it
+# reads CALLED for a function whose only caller is itself dead (a cluster of
+# mutually-calling functions with no external entry: the dead-island). This
+# adds the transitive answer: a function is reachable-from-entry iff it OR
+# some function in its reverse-closure is an entry point. If none is, and
+# the entry model is closeable for the language and no indirection could
+# hide an entry edge, it's NO_PATH_FROM_ENTRY.
+#
+# Entry model per language (what can be invoked from outside the project's
+# own call graph):
+#   * any language: framework_callable / framework_registered (runtime
+#     dispatch), and a function named ``main``.
+#   * C/C++: non-``static`` functions (external linkage — another TU may
+#     call them). SOUND + closeable: the static/extern split is total.
+#   * Go: exported (Capitalized) functions.
+#   * Rust: ``pub`` functions.
+#   * JS/TS: exported functions.
+#   * Java: ``public`` methods.
+#   * Python: module-level public (non-``_``) functions.
+#   * unknown language: treat every function as an entry → never flags
+#     (false-negative-safe).
+#
+# Completeness: where the entry model isn't a closed signal, or an ancestor
+# file uses call-masking indirection (getattr / reflection / func-like
+# macros) that could hide an entry edge, return UNCERTAIN rather than claim
+# NO_PATH_FROM_ENTRY. Surface-only consumers treat UNCERTAIN as "analyze".
+
+# Languages whose entry model is a closed, sound signal (a NO_PATH verdict
+# is trustworthy). Others degrade to UNCERTAIN.
+_CLOSEABLE_ENTRY_LANGS = frozenset({"c", "cpp", "go", "rust"})
+
+
+def _item_is_entry(item: Dict[str, Any], language: str) -> bool:
+    """Is this inventory item an externally-invocable entry point under its
+    language's linkage/visibility model? (Framework dispatch is handled
+    separately off the adjacency index.)
+
+    Visibility/linkage is only treated as an entry signal for the
+    *closeable-entry* languages (C/C++ static-vs-extern, Go exported, Rust
+    pub) — there it's total and sound. For fuzzy languages (Python / JS /
+    Java) a public symbol is NOT reliably an entry (a public app function
+    may be plain dead code, not a library API), so we don't treat it as
+    one; those functions fall through to UNCERTAIN and the caller's
+    existing 1-hop NOT_CALLED logic, leaving their behavior unchanged.
+    ``main`` and framework dispatch are entries in every language.
+    """
+    name = item.get("name") or ""
+    if name == "main":
+        return True
+    # Go runs every ``func init()`` automatically at package load — init
+    # and its call tree are reachable even with no explicit caller.
+    if language == "go" and name == "init":
+        return True
+    if language not in _CLOSEABLE_ENTRY_LANGS:
+        return False
+    md = item.get("metadata") or {}
+    vis = md.get("visibility")
+    if language in ("c", "cpp"):
+        # External linkage = potential entry from another TU. NOTE: a
+        # ``static`` function whose ADDRESS is stored in a non-static /
+        # exported object (an ops/vtable dispatch table) is externally
+        # reachable too, but the call graph doesn't track address-taking —
+        # such functions can read NO_PATH_FROM_ENTRY. Surface-only keeps
+        # this from silencing them (the LLM still analyses); tracking
+        # address-of is a substrate follow-up.
+        return vis != "static"
+    if language == "go":
+        return vis == "exported" or name[:1].isupper()
+    if language == "rust":
+        return vis in ("public", "pub")
+    return False
+
+
+_ENTRY_SET_CACHE: Dict[int, Tuple[Dict[str, Any], "frozenset"]] = {}
+_ENTRY_SET_CACHE_MAX = 8
+
+
+def _entry_functions(inventory: Dict[str, Any]) -> "frozenset":
+    """Set of InternalFunction entry points (visibility/linkage model +
+    framework dispatch). Cached per-inventory by identity."""
+    inv_id = id(inventory)
+    cached = _ENTRY_SET_CACHE.get(inv_id)
+    if cached is not None and cached[0] is inventory:
+        return cached[1]
+    entries: Set[InternalFunction] = set()
+    for fr in inventory.get("files", []):
+        if not isinstance(fr, dict):
+            continue
+        lang = fr.get("language") or ""
+        path = fr.get("path") or ""
+        for item in fr.get("items", []):
+            if not isinstance(item, dict):
+                continue
+            if item.get("kind", "function") != "function":
+                continue
+            if _item_is_entry(item, lang):
+                entries.add(InternalFunction(
+                    file_path=path, name=item.get("name") or "",
+                    line=int(item.get("line_start") or 0),
+                ))
+    idx = _get_or_build_index(inventory, exclude_test_files=True)
+    entries |= idx.framework_callable
+    entries |= idx.framework_registered
+    frozen = frozenset(entries)
+    _ENTRY_SET_CACHE[inv_id] = (inventory, frozen)
+    if len(_ENTRY_SET_CACHE) > _ENTRY_SET_CACHE_MAX:
+        _ENTRY_SET_CACHE.pop(next(iter(_ENTRY_SET_CACHE)), None)
+    return frozen
+
+
+# (reachable_set, closure_truncated) per inventory.
+_ENTRY_REACHABLE_CACHE: Dict[int, Tuple[Dict[str, Any], "frozenset", bool]] = {}
+# Closure depth for the entry set. Far above any realistic call-chain
+# depth so reachability isn't lost to truncation (a truncated closure
+# would falsely read deep-reachable functions as NO_PATH). It's a single
+# cached BFS bounded by the graph size, so a high cap costs nothing extra.
+_ENTRY_CLOSURE_MAX_DEPTH = 100_000
+
+
+def _entry_reachable_set(
+    inventory: Dict[str, Any],
+) -> Tuple["frozenset", bool]:
+    """``(reachable_set, truncated)``. ``reachable_set`` is every
+    InternalFunction reachable from any entry (entries + their forward
+    closure). ``truncated`` is True if the closure hit the depth cap — in
+    which case the set may be incomplete and callers must not claim
+    NO_PATH from a miss.
+
+    One cached forward_closure (not a reverse walk per query), so
+    membership is O(1) and the prepass can query every function cheaply.
+    """
+    inv_id = id(inventory)
+    cached = _ENTRY_REACHABLE_CACHE.get(inv_id)
+    if cached is not None and cached[0] is inventory:
+        return cached[1], cached[2]
+    entries = _entry_functions(inventory)
+    fc = forward_closure(
+        inventory, entries, max_depth=_ENTRY_CLOSURE_MAX_DEPTH,
+    )
+    reachable = set(entries)
+    reachable.update(
+        n for n in fc.nodes if isinstance(n, InternalFunction)
+    )
+    frozen = frozenset(reachable)
+    _ENTRY_REACHABLE_CACHE[inv_id] = (inventory, frozen, fc.truncated)
+    if len(_ENTRY_REACHABLE_CACHE) > _ENTRY_SET_CACHE_MAX:
+        _ENTRY_REACHABLE_CACHE.pop(next(iter(_ENTRY_REACHABLE_CACHE)), None)
+    return frozen, fc.truncated
+
+
+def _file_language(inventory: Dict[str, Any], file_path: str) -> Optional[str]:
+    norm = file_path.replace("\\", "/")
+    for fr in inventory.get("files", []):
+        if isinstance(fr, dict) and (fr.get("path") or "").replace("\\", "/") == norm:
+            return fr.get("language")
+    return None
+
+
+def _file_has_masking(inventory: Dict[str, Any], file_path: str) -> bool:
+    norm = file_path.replace("\\", "/")
+    for fr in inventory.get("files", []):
+        if not isinstance(fr, dict) or (fr.get("path") or "").replace("\\", "/") != norm:
+            continue
+        cg = fr.get("call_graph") or {}
+        if set(cg.get("indirection") or []) & _MASKING_FLAGS:
+            return True
+        if cg.get("macro_call_targets"):
+            return True
+        return False
+    return False
+
+
+def entry_reachability(
+    inventory: Dict[str, Any],
+    target: InternalFunction,
+    *,
+    max_depth: int = 50,
+) -> str:
+    """``"reachable"`` | ``"no_path_from_entry"`` | ``"uncertain"``.
+
+    Reachable iff ``target`` is in the entry-reachable set (entries + their
+    forward closure). NO_PATH_FROM_ENTRY only when the language's entry
+    model is closeable AND no file on a path that could reach the target
+    carries call-masking indirection that might hide an entry edge;
+    otherwise UNCERTAIN (the false-negative-safe default). Surface-only:
+    consumers surface the verdict, they do not suppress on it.
+
+    Perf: the reachable set is one cached forward-closure, so the common
+    "reachable" answer is an O(1) membership test. The reverse-closure walk
+    (for the masking check) runs ONLY for the non-reachable minority.
+    """
+    reachable, truncated = _entry_reachable_set(inventory)
+    if target in reachable:
+        return "reachable"
+    if truncated:
+        # The closure was depth-capped, so the reachable set may be
+        # incomplete — a deep-reachable function could be missing. Don't
+        # claim NO_PATH off an incomplete set.
+        return "uncertain"
+    # Not reachable from any entry. Decide confident-dead vs uncertain.
+    lang = _file_language(inventory, target.file_path)
+    if lang not in _CLOSEABLE_ENTRY_LANGS:
+        return "uncertain"          # fuzzy entry model (py/js/...) → don't claim
+    # Call-masking indirection (reflection / func-like macros) in the
+    # target's file, or in any function that transitively calls it, could
+    # hide an entry edge the static graph didn't capture → don't claim
+    # dead. This reverse walk only runs for the not-reachable minority.
+    if _file_has_masking(inventory, target.file_path):
+        return "uncertain"
+    rc = reverse_closure(inventory, target, max_depth=max_depth)
+    for fn in rc.nodes:
+        if isinstance(fn, InternalFunction) and _file_has_masking(
+            inventory, fn.file_path,
+        ):
+            return "uncertain"
+    return "no_path_from_entry"
+
+
 def callees_of(
     inventory: Dict[str, Any],
     source: InternalFunction,
@@ -2825,6 +3048,7 @@ __all__ = [
     "forward_closure",
     "function_called",
     "is_framework_callable",
+    "entry_reachability",
     "is_lexically_dead",
     "is_registered_via_call",
     "module_aborts_on_load",

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -14,7 +14,9 @@ from core.inventory.call_graph import (
     extract_call_graph_python,
 )
 from core.inventory.reachability import (
+    InternalFunction,
     Verdict,
+    entry_reachability,
     function_called,
 )
 
@@ -507,3 +509,110 @@ def test_directly_called_beats_macro_masking():
     # Same-file bare-name resolution requires the call's module to match;
     # the macro check must not downgrade a genuine CALLED to UNCERTAIN.
     assert function_called(inv, "src.m.f").verdict == Verdict.CALLED
+
+
+# ---------------------------------------------------------------------------
+# U7 — entry-point forward reachability
+# ---------------------------------------------------------------------------
+# Synthetic inventories (no tree-sitter): inject visibility + call edges
+# directly so the dead-island / entry logic is exercised on any CI.
+
+
+def _entry_inv(path, language, items, calls, indirection=None):
+    cg = {"imports": {}, "calls": calls}
+    if indirection:
+        cg["indirection"] = indirection
+    return {"files": [{
+        "path": path, "language": language,
+        "items": items, "call_graph": cg,
+    }]}
+
+
+def _fn(name, line, vis=None):
+    return {"name": name, "kind": "function", "line_start": line,
+            "metadata": {"visibility": vis}}
+
+
+def _er(inv, path, name, line):
+    return entry_reachability(inv, InternalFunction(
+        file_path=path, name=name, line=line))
+
+
+def test_entry_reachable_via_main():
+    inv = _entry_inv("app.c", "c",
+                     [_fn("main", 1), _fn("helper", 5, "static")],
+                     [{"caller": "main", "chain": ["helper"], "line": 2}])
+    assert _er(inv, "app.c", "helper", 5) == "reachable"
+
+
+def test_entry_non_static_is_entry():
+    inv = _entry_inv("app.c", "c", [_fn("api", 1)], [])
+    assert _er(inv, "app.c", "api", 1) == "reachable"
+
+
+def test_dead_island_no_path_from_entry():
+    # island_a <-> island_b mutually call; both static; no entry reaches.
+    inv = _entry_inv(
+        "app.c", "c",
+        [_fn("island_a", 1, "static"), _fn("island_b", 5, "static")],
+        [{"caller": "island_a", "chain": ["island_b"], "line": 2},
+         {"caller": "island_b", "chain": ["island_a"], "line": 6}],
+    )
+    assert _er(inv, "app.c", "island_a", 1) == "no_path_from_entry"
+    assert _er(inv, "app.c", "island_b", 5) == "no_path_from_entry"
+
+
+def test_go_exported_is_entry_unexported_orphan_dead():
+    inv = _entry_inv(
+        "svc.go", "go",
+        [_fn("Handler", 1, "exported"), _fn("helper", 5),
+         _fn("orphan", 9)],
+        [{"caller": "Handler", "chain": ["helper"], "line": 2}],
+    )
+    assert _er(inv, "svc.go", "Handler", 1) == "reachable"
+    assert _er(inv, "svc.go", "helper", 5) == "reachable"
+    assert _er(inv, "svc.go", "orphan", 9) == "no_path_from_entry"
+
+
+def test_masking_indirection_forces_uncertain():
+    # A file with call-masking indirection could hide an entry edge →
+    # never claim no_path_from_entry.
+    inv = _entry_inv(
+        "app.c", "c", [_fn("maybe", 1, "static")], [],
+        indirection=["reflect"],
+    )
+    assert _er(inv, "app.c", "maybe", 1) == "uncertain"
+
+
+def test_non_closeable_language_is_uncertain():
+    # Python's entry model isn't a closed signal (a public fn may be dead
+    # app code, not a library API) → uncertain (caller falls back to its
+    # 1-hop NOT_CALLED logic), never a confident no_path verdict.
+    inv = _entry_inv("m.py", "python", [_fn("_helper", 1)], [])
+    assert _er(inv, "m.py", "_helper", 1) == "uncertain"
+
+
+def test_go_init_is_entry():
+    # Adversarial FN: Go runs every `func init()` at package load, so init
+    # and its callees are reachable even with no explicit caller.
+    inv = _entry_inv(
+        "p.go", "go", [_fn("init", 1), _fn("setup", 5)],
+        [{"caller": "init", "chain": ["setup"], "line": 2}],
+    )
+    assert _er(inv, "p.go", "init", 1) == "reachable"
+    assert _er(inv, "p.go", "setup", 5) == "reachable"
+
+
+def test_deep_chain_not_truncated_to_no_path():
+    # Adversarial FN: a function reachable from an entry via a chain deeper
+    # than forward_closure's default depth must NOT read no_path. The entry
+    # closure uses a high depth cap; on the off chance it still truncates,
+    # the verdict degrades to uncertain (never a false no_path).
+    items = [_fn("entry", 1)]
+    calls = []
+    for k in range(60):
+        items.append(_fn(f"f{k}", 10 + k, "static"))
+        calls.append({"caller": "entry" if k == 0 else f"f{k - 1}",
+                      "chain": [f"f{k}"], "line": 10 + k})
+    inv = _entry_inv("d.c", "c", items, calls)
+    assert _er(inv, "d.c", "f55", 65) == "reachable"

--- a/core/orchestration/reachability_enrichment.py
+++ b/core/orchestration/reachability_enrichment.py
@@ -102,6 +102,7 @@ def mark_unreachable_low_priority(
         from core.inventory.reachability import (
             InternalFunction,
             Verdict,
+            entry_reachability,
             function_called,
             is_framework_callable,
             is_lexically_dead,
@@ -191,6 +192,49 @@ def mark_unreachable_low_priority(
                 marked += 1
                 continue
 
+            line = int(func.get("line_start") or 0)
+            target = InternalFunction(
+                file_path=rel_path, name=name, line=line,
+            )
+
+            # U7: entry-point forward reachability. Transitive, entry-aware
+            # answer that 1-hop NOT_CALLED can't give:
+            #   * "reachable" — target OR a reverse-closure ancestor is an
+            #     entry (framework dispatch, main, or an exported/public/
+            #     non-static symbol). Keep it — this also AVOIDS demoting an
+            #     exported public-API function that has no in-project caller
+            #     (the library-API false negative 1-hop NOT_CALLED caused).
+            #   * "no_path_from_entry" — nothing reachable from any entry
+            #     leads here (the dead-island: reads CALLED only because a
+            #     peer that is itself unreachable calls it). Demote.
+            #   * "uncertain" — fuzzy entry model or masking indirection;
+            #     fall through to the existing framework / NOT_CALLED logic
+            #     unchanged. Surface-only: no hard gate, soft-demote only.
+            er = entry_reachability(inventory, target)
+            if er == "reachable":
+                # Keep it (path from a real entry exists). Preserve the
+                # diagnostic annotation downstream consumers expect when
+                # the entry is framework dispatch, so the
+                # framework_callable / registered_via_call reasons still
+                # surface as before.
+                if is_framework_callable(inventory, target):
+                    func["priority_reason"] = (
+                        "reachability:framework_callable"
+                    )
+                elif is_registered_via_call(inventory, target):
+                    func["priority_reason"] = (
+                        "reachability:registered_via_call"
+                    )
+                continue
+            if er == "no_path_from_entry":
+                if allow_unreachable:
+                    continue
+                func["priority"] = "low"
+                func["priority_reason"] = "reachability:no_path_from_entry"
+                marked += 1
+                continue
+            # er == "uncertain" → existing 1-hop logic below.
+
             qualified = f"{module}.{name}"
             try:
                 result = function_called(inventory, qualified)
@@ -209,10 +253,8 @@ def mark_unreachable_low_priority(
             # analysis prompt's reachability engagement, attack-
             # path demoter) treat them as dead code — false
             # negatives on any web/task/signal-heavy codebase.
-            line = int(func.get("line_start") or 0)
-            target = InternalFunction(
-                file_path=rel_path, name=name, line=line,
-            )
+            # (``target`` was computed above for the entry-reachability
+            # gate; reuse it.)
             if is_framework_callable(inventory, target):
                 # Optionally annotate so operators / downstream
                 # consumers can see this function was static-

--- a/core/orchestration/tests/test_reachability_enrichment.py
+++ b/core/orchestration/tests/test_reachability_enrichment.py
@@ -837,3 +837,58 @@ class TestLexicalDeadGate:
         mark_unreachable_low_priority(checklist, target)
         func = checklist["files"][0]["items"][0]
         assert func.get("priority_reason") != "reachability:lexical_dead"
+
+
+class TestEntryReachabilityGate:
+    """U7: entry-point forward reachability. Catches the dead-island (a
+    function that reads CALLED but no path from any entry reaches it) and
+    keeps exported/non-static entries that 1-hop NOT_CALLED would wrongly
+    demote. CI-safe: a synthetic inventory (visibility + call edges) is
+    passed in, so no tree-sitter grammar is needed."""
+
+    def _synthetic_c(self):
+        items = [
+            {"name": "api", "kind": "function", "line_start": 1,
+             "metadata": {"visibility": None}},           # non-static entry
+            {"name": "isl_a", "kind": "function", "line_start": 5,
+             "metadata": {"visibility": "static"}},
+            {"name": "isl_b", "kind": "function", "line_start": 9,
+             "metadata": {"visibility": "static"}},
+        ]
+        calls = [
+            {"caller": "isl_a", "chain": ["isl_b"], "line": 6},
+            {"caller": "isl_b", "chain": ["isl_a"], "line": 10},
+        ]
+        inv = {"files": [{"path": "app.c", "language": "c",
+                          "items": items,
+                          "call_graph": {"imports": {}, "calls": calls}}]}
+        checklist = {"files": [{"path": "app.c", "items": items}]}
+        return inv, checklist
+
+    def test_dead_island_demoted(self, tmp_path):
+        inv, checklist = self._synthetic_c()
+        mark_unreachable_low_priority(checklist, tmp_path, inventory=inv)
+        funcs = {f["name"]: f for f in checklist["files"][0]["items"]}
+        for n in ("isl_a", "isl_b"):
+            assert funcs[n]["priority"] == "low"
+            assert funcs[n]["priority_reason"] == (
+                "reachability:no_path_from_entry"
+            )
+
+    def test_non_static_entry_not_demoted(self, tmp_path):
+        # The library-API fix: an exported (non-static) function with no
+        # in-project caller is an entry → must NOT be demoted (1-hop
+        # NOT_CALLED would have wrongly demoted it).
+        inv, checklist = self._synthetic_c()
+        mark_unreachable_low_priority(checklist, tmp_path, inventory=inv)
+        funcs = {f["name"]: f for f in checklist["files"][0]["items"]}
+        assert funcs["api"].get("priority") != "low"
+
+    def test_allow_unreachable_suppresses_no_path_demotion(self, tmp_path):
+        inv, checklist = self._synthetic_c()
+        marked = mark_unreachable_low_priority(
+            checklist, tmp_path, inventory=inv, allow_unreachable=True,
+        )
+        funcs = {f["name"]: f for f in checklist["files"][0]["items"]}
+        assert funcs["isl_a"].get("priority") != "low"
+        assert marked == 0

--- a/packages/llm_analysis/prompts/analysis.py
+++ b/packages/llm_analysis/prompts/analysis.py
@@ -61,6 +61,7 @@ If the metadata block contains a "Reachability:" section, use it as evidence:
 - "Verdict: REACHABLE via ..." — reachability is established via a runtime-dispatch mechanism (framework decorator or registration call); treat as live, focus on exploit feasibility.
 - "Verdict: MODULE_ABORTS_ON_LOAD" — the file's top-level execution unconditionally aborts (raise ImportError, throw new Error, init() panic, compile_error!) before this function's definition runs. The function is never importable/callable in this deployment, regardless of in-file call edges — peers that appear to call it are equally dead, since the file never finishes loading. This is a STRONGER signal than NOT_CALLED: there is no framework-dispatch escape hatch (registration code below the abort never executes). Mark is_exploitable=False with ruling="dead_code". The vulnerability shape may still be a true positive (is_true_positive=True), but it is unreachable in this deployment.
 - "Verdict: LEXICAL_DEAD" — this function is defined inside an always-false guard (if False:, if (false) {…}, #[cfg(any())]). The guard's body never executes or compiles, so the function never binds. Like MODULE_ABORTS_ON_LOAD this trumps in-scope call edges (two dead-scope functions calling each other read as mutually called, but the whole scope is dead) and any decorator inside the dead scope never registers anything. Mark is_exploitable=False with ruling="dead_code". The vulnerability shape may still be a true positive (is_true_positive=True), but it is unreachable.
+- "Verdict: NO_PATH_FROM_ENTRY" — this function has in-project callers, but no path from any entry point (main, framework dispatch, or an exported/public symbol) reaches it: the entire calling chain is an orphaned dead-island (e.g. a static helper called only by another unreachable static function, or a function referenced only from an unread function-pointer table). Stronger than a raw caller count — having a caller doesn't mean the caller itself ever runs. Before marking exploitable, identify a real invocation path from a deployment entry point; if none exists, mark is_exploitable=False with ruling="dead_code" or "unreachable". The vulnerability shape may still be a true positive (is_true_positive=True), but it is unreachable in this deployment.
 - "Caller graph: N direct, M transitive" with N=0 but uncertain > 0 — the substrate found indirection it cannot resolve (string-dispatch / reflect / plugin registries). Treat as potentially reachable; note the indirection class in your reasoning.
 - "Caller graph: N direct, M transitive" with N > 0 — reachability is established; focus on exploit feasibility.
 
@@ -194,6 +195,16 @@ def _format_reachability_block(metadata: Dict[str, Any]) -> str:
         lines.append(
             "Verdict: LEXICAL_DEAD — defined inside an always-false "
             "guard (if False / #[cfg(any())]); never binds"
+        )
+    elif priority_reason == "reachability:no_path_from_entry":
+        # U7: transitive entry-reachability. The function may have an
+        # in-project caller, but no path from any entry point (main /
+        # framework dispatch / exported-public symbol) reaches it — the
+        # whole calling chain is an orphaned dead-island. System prompt
+        # explains how to treat it.
+        lines.append(
+            "Verdict: NO_PATH_FROM_ENTRY — has callers, but none reachable "
+            "from any entry point (orphaned dead-island)"
         )
     elif priority == "low":
         lines.append(

--- a/packages/llm_analysis/tests/test_reachability_in_analysis_prompt.py
+++ b/packages/llm_analysis/tests/test_reachability_in_analysis_prompt.py
@@ -81,6 +81,17 @@ class TestVerdictLine:
         assert "Verdict: LEXICAL_DEAD" in out
         assert "NOT_CALLED" not in out
 
+    def test_no_path_from_entry_renders_distinct_verdict(self):
+        # U7: dead-island gets its own verdict line, distinct from
+        # NOT_CALLED — the function HAS callers, just none reachable from
+        # an entry.
+        out = _format_reachability_block({
+            "priority": "low",
+            "priority_reason": "reachability:no_path_from_entry",
+        })
+        assert "Verdict: NO_PATH_FROM_ENTRY" in out
+        assert "NOT_CALLED" not in out
+
     def test_no_priority_no_verdict_line(self):
         # Priority not set + no framework reason → no verdict line.
         # Caller counts may still render below.


### PR DESCRIPTION
1-hop NOT_CALLED reads a function CALLED whenever any peer calls it — even if that peer is itself unreachable. So an orphaned cluster of mutually- calling functions (e.g. a static C helper called only by another static function that's referenced only from an unread function-pointer table) escapes detection. Add the transitive, entry-aware verdict.

entry_reachability(inventory, target) → reachable | no_path_from_entry | uncertain:
- reachable: target is in the entry-reachable set (entries + their forward closure). Entries = framework_callable / framework_registered, `main`, Go `init` (auto-run at package load), and — for the closeable-entry languages only (C/C++ non-static, Go exported, Rust pub) — externally- linkable symbols.
- no_path_from_entry: closeable language, nothing reachable from an entry leads here, and no masking indirection on a calling path could hide an entry edge.
- uncertain: fuzzy entry model (Python/JS/Java — a public symbol isn't reliably an entry), masking present, or an incomplete (depth-truncated) closure → fall back to the caller's existing 1-hop logic, unchanged.

Wired surface-only into the /agentic enrichment prepass: no_path_from_entry demotes (priority=low, reason "reachability:no_path_from_entry") and the analysis prompt renders a distinct NO_PATH_FROM_ENTRY verdict. A "reachable" result also keeps exported/non-static symbols that 1-hop NOT_CALLED would have wrongly demoted (the library-API false negative). No hard gate / no suppression — that waits for the corpus-gated enforcement unit.

Perf: the reachable set is one cached forward-closure (O(1) membership for the common reachable case); reverse_closure runs only for the not-reachable minority's masking check. The closure uses a high depth cap and a truncation guard, so a depth-capped (incomplete) closure degrades a miss to "uncertain" rather than a false no_path.

Known limitation: a static C function whose address is stored in a non-static / exported dispatch table is externally reachable but the call graph doesn't track address-of, so it can read no_path. Surface-only keeps this from silencing it (the LLM still analyses); address-of tracking is a substrate follow-up.

Verified end-to-end on a real C target with the dead-island shape (a static helper reachable only through a static peer that's referenced solely from an unread function-pointer table): both functions are now demoted no_path_from_entry, where 1-hop NOT_CALLED read them CALLED. Adversarial sweep fixed Go-init, deep-chain truncation, and public-symbol-as-entry false negatives. Python-without-framework behavior unchanged. 862 tests green on tree-sitter and stdlib paths.