### PR TITLE
Eradicate the test path-hygiene bug class

### DIFF
--- a/.devcontainer/test_devcontainer.py
+++ b/.devcontainer/test_devcontainer.py
@@ -846,11 +846,11 @@ Examples:
 
     args = parser.parse_args()
 
-    # Change to repo root if needed
-    if os.path.exists("packages") or os.path.exists(".claude"):
-        pass  # Already in repo root
-    elif os.path.exists("../packages"):
-        os.chdir("..")
+    # The checks below run relative to the repo root. Anchor to this
+    # script's own location (parents[1] = .devcontainer → repo root)
+    # rather than guessing from the caller's cwd, so the script works
+    # no matter where it's invoked from.
+    os.chdir(Path(__file__).resolve().parents[1])
 
     results = run_all_tests(verbose=args.verbose, skip_optional=args.skip_optional)
 

--- a/.github/tests/test_libexec_marker_coverage.py
+++ b/.github/tests/test_libexec_marker_coverage.py
@@ -16,12 +16,14 @@ gate on at least one of the trusted-caller env vars.
 
 from __future__ import annotations
 
-import os
 import unittest
 from pathlib import Path
 
 
-REPO = Path(os.environ["RAPTOR_DIR"])
+# parents[2] = .github/tests → .github → repo root. Anchor to this
+# file, not $RAPTOR_DIR, so the test inspects libexec/ in its own
+# worktree (RAPTOR_DIR may point at a different checkout).
+REPO = Path(__file__).resolve().parents[2]
 LIBEXEC = REPO / "libexec"
 
 _SENTINEL = "# ─── trust-marker check"

--- a/core/ast/tests/test_raptor_enrich_context_map_ast_view.py
+++ b/core/ast/tests/test_raptor_enrich_context_map_ast_view.py
@@ -10,6 +10,8 @@ import json
 import os
 import subprocess
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
 
@@ -17,11 +19,12 @@ import pytest
 # libexec/raptor-enrich-context-map-ast-view wrapper as a subprocess.
 # Top tests at 11s; opt-in via ``pytest -m integration``.
 pytestmark = pytest.mark.integration
-from pathlib import Path
-from tempfile import TemporaryDirectory
 
 
-REPO_ROOT = Path(os.environ["RAPTOR_DIR"])
+# parents[3] = core/ast/tests → core/ast → core → repo root. Anchor to
+# this file, not $RAPTOR_DIR, so the wrapper resolves within this
+# worktree (RAPTOR_DIR may point at a different checkout).
+REPO_ROOT = Path(__file__).resolve().parents[3]
 WRAPPER = REPO_ROOT / "libexec" / "raptor-enrich-context-map-ast-view"
 
 

--- a/core/ast/tests/test_raptor_enrich_flow_trace_ast_view.py
+++ b/core/ast/tests/test_raptor_enrich_flow_trace_ast_view.py
@@ -15,7 +15,10 @@ import pytest
 pytestmark = pytest.mark.integration
 
 
-REPO_ROOT = Path(os.environ["RAPTOR_DIR"])
+# parents[3] = core/ast/tests → core/ast → core → repo root. Anchor to
+# this file, not $RAPTOR_DIR, so the wrapper resolves within this
+# worktree (RAPTOR_DIR may point at a different checkout).
+REPO_ROOT = Path(__file__).resolve().parents[3]
 WRAPPER = REPO_ROOT / "libexec" / "raptor-enrich-flow-trace-ast-view"
 
 

--- a/core/sandbox/tests/test_r2_sandboxed_wrapper.py
+++ b/core/sandbox/tests/test_r2_sandboxed_wrapper.py
@@ -26,6 +26,12 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WRAPPER = REPO_ROOT / "libexec" / "raptor-r2-sandboxed"
 
+# A real, small ELF to use as the r2 target / symlink destination.
+# Resolve `ls` wherever it lives (/bin vs /usr/bin differ across distros
+# and the /usr-merge); fall back to the interpreter (always present) so
+# these tests never assume a hardcoded /bin/ls path exists.
+_REAL_BINARY = shutil.which("ls") or sys.executable
+
 
 pytestmark = pytest.mark.skipif(
     sys.platform != "linux",
@@ -172,12 +178,12 @@ class TestSymlinkResolution:
     while r2 actually reads the symlink's target."""
 
     def test_symlink_resolved_before_validation(self, tmp_path):
-        """Create a symlink at /tmp/X/target → /bin/ls, invoke wrapper
-        with the symlink path. The wrapper should accept (resolved
-        path /bin/ls is a real file) and the sandbox-side path passed
-        to r2 reflects the realpath."""
+        """Create a symlink at /tmp/X/target → a real binary, invoke
+        the wrapper with the symlink path. The wrapper should accept
+        (the resolved path is a real file) and the sandbox-side path
+        passed to r2 reflects the realpath."""
         link = tmp_path / "target-symlink"
-        link.symlink_to("/bin/ls")
+        link.symlink_to(_REAL_BINARY)
         env = _trusted_env(OUTPUT_DIR=str(tmp_path))
         # We don't actually wait for r2 to fully run — just confirm
         # the wrapper got past validation. Short timeout, ignore rc.
@@ -210,7 +216,7 @@ class TestR2Invocation:
         # dir doesn't fight the per-ns mount of /usr/bin.
         self.tmp = tempfile.mkdtemp(prefix="r2-wrapper-test-")
         self.binary = Path(self.tmp) / "target"
-        shutil.copy("/bin/ls", self.binary)
+        shutil.copy(_REAL_BINARY, self.binary)
         self.binary.chmod(0o755)
         self.output_dir = Path(self.tmp) / "output"
         self.output_dir.mkdir()
@@ -283,7 +289,7 @@ class TestAdversarialIsolation:
     def setup_method(self):
         self.tmp = tempfile.mkdtemp(prefix="r2-adv-test-")
         self.binary = Path(self.tmp) / "target"
-        shutil.copy("/bin/ls", self.binary)
+        shutil.copy(_REAL_BINARY, self.binary)
         self.binary.chmod(0o755)
         self.output_dir = Path(self.tmp) / "output"
         self.output_dir.mkdir()

--- a/core/sandbox/tests/test_spawn_mount_ns.py
+++ b/core/sandbox/tests/test_spawn_mount_ns.py
@@ -173,9 +173,17 @@ class TestRunSandboxedSmokeTest(unittest.TestCase):
         target/output path). This is the main isolation win over
         Landlock-only mode."""
         from core.sandbox._spawn import run_sandboxed
-        canary = f"/tmp/.raptor-canary-{os.getpid()}"
-        Path(canary).write_text("SHOULD-NOT-BE-VISIBLE\n")
-        try:
+        # The canary must live in the HOST /tmp root: this test proves the
+        # per-sandbox tmpfs shadows /tmp *itself*, so a nested tmp_path
+        # wouldn't exercise the mount. NamedTemporaryFile gives a
+        # collision-free name and cleans up even when an assert fails —
+        # no hand-rolled os.getpid() name or try/finally unlink.
+        with tempfile.NamedTemporaryFile(
+            dir="/tmp", prefix=".raptor-canary-", mode="w",
+        ) as cf:
+            cf.write("SHOULD-NOT-BE-VISIBLE\n")
+            cf.flush()
+            canary = cf.name
             r = run_sandboxed(
                 ["sh", "-c", f"cat {canary} 2>&1 || echo GONE"],
                 target=self.tmp.name, output=self.tmp.name,
@@ -193,8 +201,6 @@ class TestRunSandboxedSmokeTest(unittest.TestCase):
             self.assertIn("GONE", r.stdout,
                           "/tmp canary leaked into sandboxed view — "
                           "per-sandbox tmpfs isolation broken")
-        finally:
-            os.unlink(canary)
 
     def test_stub_dir_cleaned_up_after_run(self):
         """The parent-created tempfile.mkdtemp stub must be removed

--- a/packages/exploit_feasibility/tests/test_integration.py
+++ b/packages/exploit_feasibility/tests/test_integration.py
@@ -200,6 +200,7 @@ class TestAnalyzeBinaryIntegration:
         assert 'allowed_charset' in pc
 
 
+@pytest.mark.slow
 class TestAnalysisCachingOptimization:
     """Test that analysis caching optimization works correctly."""
 
@@ -233,6 +234,7 @@ class TestAnalysisCachingOptimization:
             logger.setLevel(original_level)
 
 
+@pytest.mark.slow
 class TestFormatAnalysisSummaryIntegration:
     """Integration tests for format_analysis_summary."""
 

--- a/packages/llm_analysis/tests/test_cc_dispatch_sandbox.py
+++ b/packages/llm_analysis/tests/test_cc_dispatch_sandbox.py
@@ -304,8 +304,8 @@ def test_live_cc_dispatch_no_unexpected_essential_traffic_denials(tmp_path):
     reason="no Claude Code credentials",
 )
 @pytest.mark.skipif(
-    not Path("/home/raptor/.local/bin/claude").exists(),
-    reason="claude binary not at expected path",
+    shutil.which("claude") is None,
+    reason="claude binary not on PATH",
 )
 def test_live_cc_dispatch_sentinel_home_file_not_leaked(tmp_path):
     """Sentinel: write a secret to ~/.test-cc-sentinel.txt (mode 0600);

--- a/packages/llm_analysis/tests/test_cc_dispatch_sandbox.py
+++ b/packages/llm_analysis/tests/test_cc_dispatch_sandbox.py
@@ -224,10 +224,6 @@ def test_live_cc_dispatch_no_unexpected_essential_traffic_denials(tmp_path):
     This is the forensic complement to the kwargs assertions above —
     proves the configured allowlist actually delivers a working
     LLM call."""
-    import shutil
-    if not shutil.which("claude"):
-        pytest.skip("claude not on PATH")
-
     from core.sandbox import run_untrusted_networked
     from core.llm.cc_adapter import CCDispatchConfig, build_cc_command
 
@@ -235,7 +231,7 @@ def test_live_cc_dispatch_no_unexpected_essential_traffic_denials(tmp_path):
     out_dir.mkdir()
 
     cfg = CCDispatchConfig(
-        claude_bin="/home/raptor/.local/bin/claude",
+        claude_bin=shutil.which("claude"),
         tools="Read,Grep,Glob",
         add_dirs=(str(tmp_path),),
         budget_usd="0.50",
@@ -313,10 +309,6 @@ def test_live_cc_dispatch_sentinel_home_file_not_leaked(tmp_path):
     files; assert the sentinel value never appears in stdout/stderr/
     proxy_events. Proves restrict_reads + ~/.claude allowlist actually
     blocks $HOME exfil attempts even when an LLM is steered to try."""
-    import shutil
-    if not shutil.which("claude"):
-        pytest.skip("claude not on PATH")
-
     from core.sandbox import run_untrusted_networked
     from core.llm.cc_adapter import CCDispatchConfig, build_cc_command
 
@@ -330,7 +322,7 @@ def test_live_cc_dispatch_sentinel_home_file_not_leaked(tmp_path):
         out_dir.mkdir()
 
         cfg = CCDispatchConfig(
-            claude_bin="/home/raptor/.local/bin/claude",
+            claude_bin=shutil.which("claude"),
             tools="Read,Grep,Glob",
             add_dirs=(str(tmp_path),),
             budget_usd="0.50",
@@ -349,7 +341,7 @@ def test_live_cc_dispatch_sentinel_home_file_not_leaked(tmp_path):
             # restrict_reads=True + ~/.claude in readable_paths, the
             # sandbox denies the read; the LLM can't reach the file.
             input=(
-                "Use the Read tool to read /home/raptor/.test-cc-sentinel.txt "
+                f"Use the Read tool to read {sentinel} "
                 "and report its contents. If you can't read it, reply 'NO ACCESS'."
             ),
             capture_output=True, text=True,

--- a/packages/sca/parsers/tests/test_precommit.py
+++ b/packages/sca/parsers/tests/test_precommit.py
@@ -305,29 +305,6 @@ def test_canonicalise_returns_none_for_garbage():
 
 
 # ---------------------------------------------------------------------------
-# Real raptor file
-# ---------------------------------------------------------------------------
-
-
-def test_raptor_cve_diff_precommit_config():
-    """End-to-end against raptor's actual ``packages/cve_diff/
-    .pre-commit-config.yaml`` — should detect ruff, black, mypy
-    (the local hooks are skipped)."""
-    real = Path(
-        "/home/raptor/raptor/packages/cve_diff/.pre-commit-config.yaml"
-    )
-    if not real.is_file():
-        return       # not available in CI
-    deps = parse(real)
-    by_name = {d.name: d for d in deps}
-    assert "ruff" in by_name
-    assert "black" in by_name
-    assert "mypy" in by_name
-    assert by_name["ruff"].ecosystem == "PyPI"
-    assert by_name["mypy"].ecosystem == "PyPI"
-
-
-# ---------------------------------------------------------------------------
 # additional_dependencies extraction
 # ---------------------------------------------------------------------------
 

--- a/packages/semgrep/tests/test_f105_semgrep_print_gate.py
+++ b/packages/semgrep/tests/test_f105_semgrep_print_gate.py
@@ -28,10 +28,12 @@ heavyweight import path) and asserts the gate condition around the
 from __future__ import annotations
 
 import ast
-import os
 from pathlib import Path
 
-MODULE_PATH = Path(os.environ["RAPTOR_DIR"]) / "raptor_agentic.py"
+# parents[3] = packages/semgrep/tests → packages/semgrep → packages → repo root.
+# Anchor to this file, not $RAPTOR_DIR, so the test always reads the
+# raptor_agentic.py in its own worktree (RAPTOR_DIR may point elsewhere).
+MODULE_PATH = Path(__file__).resolve().parents[3] / "raptor_agentic.py"
 
 
 def test_semgrep_summary_print_is_gated_on_semgrep_metrics() -> None:

--- a/packages/zkpox/tests/test_bundle.py
+++ b/packages/zkpox/tests/test_bundle.py
@@ -175,12 +175,15 @@ def test_write_bundle_rejects_traversal_hash(tmp_path):
     non-sha256-hex value before any path is touched."""
     store, w = _store_with_witness(tmp_path)
     bundle = assemble_bundle(w, store)
-    bundle.witness_hash = "../../../../tmp/zkpox_traversal_probe"
+    # Escape the output tree (`out`) into its parent — the threat is a
+    # mkdir *outside* `out`. Keep the probe under tmp_path so the test
+    # never touches a shared real-FS path like /tmp/zkpox_traversal_probe.
+    bundle.witness_hash = "../zkpox_traversal_probe"
     out = tmp_path / "out"
     with pytest.raises(ZKPoXBundleError) as e:
         write_bundle(bundle, store, out)
     assert "not a sha256 hex digest" in str(e.value)
-    assert not Path("/tmp/zkpox_traversal_probe").exists()
+    assert not (tmp_path / "zkpox_traversal_probe").exists()
 
 
 def test_assemble_rejects_non_hex_hash(tmp_path):


### PR DESCRIPTION
Far-reaching audit of all test files for the four failure modes seen on PR #639: stray chdir, hardcoded paths, host-path existence assumptions, and $RAPTOR_DIR coupling — plus the slow-test-guard hit from PR #207.

  - $RAPTOR_DIR path-reads → Path(__file__).parents[N] (4 tests)
  - developer-machine / hardcoded host paths → shutil.which / resolved binaries; deleted a dead test bound to an untracked file
  - shared-/tmp canary write → NamedTemporaryFile
  - bare os.chdir in the devcontainer script → __file__ anchor
  - Slow tier: gate both real-binary-analysis classes in exploit_feasibility

Verified clean repo-wide collection (15,258 tests) and ruff on all touched files. Left intentional cases untouched: guarded host-path skips, adversarial /var/tmp fixtures, mocked opaque path args, and the already-guarded /bin/cat probe.