### PR TITLE
feat(zkpox): proving-stack availability gate (proving_deps)

### DIFF
--- a/packages/zkpox/__init__.py
+++ b/packages/zkpox/__init__.py
@@ -78,6 +78,11 @@ from packages.zkpox.eligibility import (
     render_eligibility_summary,
     summarize_eligibility,
 )
+from packages.zkpox.proving_deps import (
+    ProvingStackUnavailable,
+    proving_stack_available,
+    require_proving_stack,
+)
 from packages.zkpox.reproduce import (
     ReproductionResult,
     attach_reproduction,
@@ -99,4 +104,7 @@ __all__ = [
     "ReproductionResult",
     "reproduce_witness",
     "attach_reproduction",
+    "ProvingStackUnavailable",
+    "proving_stack_available",
+    "require_proving_stack",
 ]

--- a/packages/zkpox/proving_deps.py
+++ b/packages/zkpox/proving_deps.py
@@ -1,0 +1,74 @@
+"""Availability probe + guard for the Tier 2/3 ZKPoX proving stack.
+
+Single source of truth for "is the heavy ZK proving toolchain
+installed here?" — consumed by both the runtime (the future
+``prove`` / ``verify`` entry points, which guard on
+:func:`require_proving_stack`) and tests (which skip on
+``not proving_stack_available()``).
+
+The point is to keep the dependency-free tiers importable. Tiers
+0/1 (eligibility, bundles) and 1.5 (reproduction) ship today and
+must keep importing on a box with none of the proving stack
+present. So the heavy deps (SP1 / RISC-V toolchain) are NEVER
+imported at module load — they're probed here, and the actual
+imports live lazily inside the prove/verify code paths that
+``require_proving_stack`` gates. Importing ``packages.zkpox`` stays
+cheap; only *invoking* a Tier 2/3 operation can fail on missing
+deps.
+
+This module is deliberately separate from the (not-yet-landed)
+prover implementation: ``proving_deps`` is the gate, a future
+``prover`` / ``proving`` module is the SP1 guts. Keeping them apart
+means the gate can ship — and tests can reference it — before the
+prover exists.
+"""
+
+from __future__ import annotations
+
+import functools
+import shutil
+
+# SP1's prover ships its toolchain as a cargo subcommand (`cargo
+# prove`, binary `cargo-prove`). This is the cheapest reliable
+# "is the stack here?" signal. When the Tier 2/3 prover lands it
+# should confirm / extend this set (e.g. add a RISC-V target check
+# or a python-binding import) — erring toward "unavailable" when
+# uncertain is correct, since a false "available" would make the
+# prover refuse on a genuinely-equipped box only after doing work.
+_PROVING_BINARIES = ("cargo-prove",)
+
+
+class ProvingStackUnavailable(RuntimeError):
+    """Raised when a Tier 2/3 operation (prove / verify) is invoked
+    on a host without the proving toolchain installed."""
+
+
+@functools.lru_cache(maxsize=1)
+def proving_stack_available() -> bool:
+    """``True`` iff the SP1 / RISC-V proving toolchain is usable here.
+
+    Cached: the answer can't change within a process, and the probe
+    (PATH lookups, eventually a subprocess / import) isn't free.
+    Call :func:`proving_stack_available.cache_clear` in tests that
+    monkeypatch the underlying probe.
+    """
+    return all(shutil.which(b) is not None for b in _PROVING_BINARIES)
+
+
+def require_proving_stack() -> None:
+    """Guard for the prove / verify entry points.
+
+    Raises :class:`ProvingStackUnavailable` with an actionable
+    message when the stack is absent — so the dependency-free tiers
+    stay importable and only an actual Tier 2/3 invocation surfaces
+    the missing-deps error.
+    """
+    if not proving_stack_available():
+        raise ProvingStackUnavailable(
+            "ZKPoX Tier 2/3 proving requires the SP1 / RISC-V "
+            "proving toolchain, which isn't installed on this host. "
+            "Tiers 0/1 and 1.5 (eligibility, bundle assembly, native "
+            "reproduction) do not need it and continue to work. "
+            "Install the proving toolchain to enable `prove` / "
+            "`verify`."
+        )

--- a/packages/zkpox/tests/test_proving_deps.py
+++ b/packages/zkpox/tests/test_proving_deps.py
@@ -1,0 +1,110 @@
+"""Tests for ``packages.zkpox.proving_deps`` — the Tier 2/3
+proving-stack availability gate.
+
+The gate ships ahead of the prover itself (#470): its job is to
+let the dependency-free tiers stay importable and to give the
+future prove/verify entry points + their slow tests one canonical
+"is the stack here?" check.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# packages/zkpox/tests/test_proving_deps.py → parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+import packages.zkpox.proving_deps as pd  # noqa: E402
+from packages.zkpox import (  # noqa: E402
+    ProvingStackUnavailable,
+    proving_stack_available,
+    require_proving_stack,
+)
+
+
+def test_available_returns_bool():
+    """Whatever the host has, the probe returns a bool and doesn't
+    raise."""
+    pd.proving_stack_available.cache_clear()
+    assert isinstance(proving_stack_available(), bool)
+
+
+def test_available_false_when_binary_missing(monkeypatch):
+    pd.proving_stack_available.cache_clear()
+    monkeypatch.setattr(pd.shutil, "which", lambda _b: None)
+    assert proving_stack_available() is False
+    pd.proving_stack_available.cache_clear()
+
+
+def test_available_true_when_all_binaries_present(monkeypatch):
+    pd.proving_stack_available.cache_clear()
+    monkeypatch.setattr(pd.shutil, "which", lambda b: f"/usr/bin/{b}")
+    assert proving_stack_available() is True
+    pd.proving_stack_available.cache_clear()
+
+
+def test_available_is_cached(monkeypatch):
+    """lru_cache: the probe runs once per process. Pin it so a
+    future contributor doesn't add a per-call subprocess thinking
+    it's cheap."""
+    pd.proving_stack_available.cache_clear()
+    calls = {"n": 0}
+
+    def counting_which(_b):
+        calls["n"] += 1
+        return None
+
+    monkeypatch.setattr(pd.shutil, "which", counting_which)
+    proving_stack_available()
+    proving_stack_available()
+    assert calls["n"] == len(pd._PROVING_BINARIES)  # one sweep, not two
+    pd.proving_stack_available.cache_clear()
+
+
+# ----------------------------------------------------------------------
+# require_proving_stack guard
+# ----------------------------------------------------------------------
+
+
+def test_require_raises_when_unavailable(monkeypatch):
+    monkeypatch.setattr(pd, "proving_stack_available", lambda: False)
+    with pytest.raises(ProvingStackUnavailable) as e:
+        require_proving_stack()
+    msg = str(e.value)
+    # Actionable: names the missing stack + reassures lower tiers work
+    assert "SP1" in msg or "RISC-V" in msg
+    assert "0/1" in msg and "1.5" in msg
+
+
+def test_require_passes_when_available(monkeypatch):
+    monkeypatch.setattr(pd, "proving_stack_available", lambda: True)
+    # Must not raise
+    require_proving_stack()
+
+
+# ----------------------------------------------------------------------
+# Import-cheapness invariant (the whole reason this module exists)
+# ----------------------------------------------------------------------
+
+
+def test_zkpox_import_pulls_no_heavy_deps():
+    """Importing packages.zkpox must not import SP1 / RISC-V / etc.
+    The gate probes by PATH lookup, never by importing the stack at
+    module load. Guard: the proving_deps module's only imports are
+    stdlib (functools, shutil)."""
+    import ast
+    src = (REPO / "packages" / "zkpox" / "proving_deps.py").read_text()
+    tree = ast.parse(src)
+    imported_top = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_top.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_top.add(node.module.split(".")[0])
+    # only stdlib — no sp1/risc-v/age/tle/etc at module scope
+    assert imported_top <= {"__future__", "functools", "shutil"}


### PR DESCRIPTION
Lands the Tier 2/3 dependency gate ahead of the prover itself (#470), so the dependency-free tiers stay importable and the future prove/verify entry points + their slow tests have one canonical "is the stack here?" check to import.

  - proving_stack_available() — cached PATH probe for the SP1 / RISC-V toolchain (cargo-prove). #470 confirms/extends the probe set when it wires the prover; erring toward "unavailable" when uncertain is correct.
  - require_proving_stack() — guard for prove/verify; raises ProvingStackUnavailable with an actionable message (and reassurance that Tiers 0/1 + 1.5 work without it).
  - ProvingStackUnavailable.

Named proving_deps (the gate), deliberately NOT proving.py / prover.py — those stay free for #470's actual SP1 implementation. Stdlib-only imports at module scope: importing packages.zkpox must never pull the heavy stack, or the shipped dependency-free tiers (eligibility, bundles, reproduction) break on a box without it. A test AST-asserts that invariant.

Tests (7): probe returns bool / false-when-missing / true-when-present / cached, guard raises-when-absent / passes-when-present, and the import-cheapness AST guard.