### PR TITLE
feat(reachability): reachability audit harness + synthetic regression gate

### DIFF
--- a/core/inventory/reach_audit.py
+++ b/core/inventory/reach_audit.py
@@ -1,0 +1,184 @@
+"""Reachability audit harness — corpus-agnostic measurement of the
+reachability substrate's classification accuracy.
+
+Given a target tree plus a label map (function → ``"dead"`` | ``"live"``),
+classify every labelled function with the shipped reachability signals and
+report:
+
+  * coverage — labelled-dead functions correctly classified dead;
+  * **false-suppress** — labelled-live functions wrongly classified dead.
+    This is the false-negative-critical metric: a witness kind earns the
+    right to *enforce* (hard-suppress) only once its false-suppress count
+    is zero across a labelled corpus. Until then, surface-only.
+
+The harness is deliberately corpus-agnostic: it takes a directory and a
+label map, names no particular corpus, and is driven by tests (a committed
+synthetic corpus) and, off-repo, by whatever labelled trees the operator
+points it at.
+
+``classify_reachability`` composes the public accessors in precedence
+order; it is the read-only "audit" sibling of the /agentic enrichment
+prepass (which mutates a checklist with the same precedence).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Tuple
+
+# Verdicts that mean "not reachable in this deployment" (dead).
+_DEAD_VERDICTS = frozenset({
+    "module_aborts", "lexical_dead", "no_path_from_entry", "not_called",
+})
+# Verdicts that mean "reachable / has a live path".
+_LIVE_VERDICTS = frozenset({
+    "reachable", "framework_callable", "registered_via_call", "called",
+})
+# "uncertain" is neither — the substrate declines to claim.
+
+
+def classify_reachability(
+    inventory: Dict[str, object],
+    file_path: str,
+    name: str,
+    line: int,
+    module: str,
+) -> str:
+    """Strongest applicable reachability verdict for one function, in the
+    same precedence the enrichment prepass uses:
+
+    module_aborts → lexical_dead → entry-reachability (reachable /
+    no_path_from_entry / uncertain) → framework/registration → 1-hop
+    function_called (called / not_called / uncertain).
+    """
+    from core.inventory.reachability import (
+        InternalFunction,
+        Verdict,
+        entry_reachability,
+        function_called,
+        is_framework_callable,
+        is_lexically_dead,
+        is_registered_via_call,
+        module_aborts_on_load,
+    )
+
+    abort = module_aborts_on_load(inventory, file_path)
+    if abort and line and line > int(abort.get("line") or 0):
+        return "module_aborts"
+    if is_lexically_dead(inventory, file_path, name, line):
+        return "lexical_dead"
+
+    target = InternalFunction(file_path=file_path, name=name, line=line)
+    er = entry_reachability(inventory, target)
+    if er == "reachable":
+        return "reachable"
+    if er == "no_path_from_entry":
+        return "no_path_from_entry"
+    # er == "uncertain": fall through to framework / 1-hop logic.
+
+    if is_framework_callable(inventory, target):
+        return "framework_callable"
+    if is_registered_via_call(inventory, target):
+        return "registered_via_call"
+    try:
+        verdict = function_called(inventory, f"{module}.{name}").verdict
+    except ValueError:
+        return "uncertain"
+    if verdict == Verdict.CALLED:
+        return "called"
+    if verdict == Verdict.NOT_CALLED:
+        return "not_called"
+    return "uncertain"
+
+
+@dataclass
+class AuditReport:
+    total: int = 0
+    caught_dead: int = 0          # labelled dead, classified dead
+    missed_dead: int = 0          # labelled dead, classified live/uncertain
+    false_suppress: int = 0       # labelled LIVE, classified dead (FN-critical)
+    live_ok: int = 0              # labelled live, classified live/uncertain
+    not_found: int = 0            # labelled fn not in inventory (extraction
+                                  # gap, NOT a reachability misclassification)
+    per_verdict: Dict[str, int] = field(default_factory=dict)
+    false_suppress_detail: list = field(default_factory=list)
+    missed_detail: list = field(default_factory=list)
+    not_found_detail: list = field(default_factory=list)
+
+    @property
+    def coverage(self) -> float:
+        dead = self.caught_dead + self.missed_dead
+        return self.caught_dead / dead if dead else 1.0
+
+
+def _path_to_module(rel_path: str) -> Optional[str]:
+    from pathlib import PurePosixPath
+    p = PurePosixPath(rel_path.replace("\\", "/"))
+    if not p.suffix:
+        return None
+    parts = list(p.with_suffix("").parts)
+    return ".".join(parts) if parts else None
+
+
+def audit_corpus(
+    target_dir: str,
+    labels: Dict[Tuple[str, str], str],
+    *,
+    inventory: Optional[Dict[str, object]] = None,
+) -> AuditReport:
+    """Classify each labelled ``(rel_path, func_name) → "dead"|"live"`` and
+    tally coverage + false-suppress. ``inventory`` may be supplied (tests
+    inject a synthetic one to stay tree-sitter-independent); otherwise it's
+    built from ``target_dir``.
+    """
+    if inventory is None:
+        import tempfile
+        from core.inventory.builder import build_inventory
+        with tempfile.TemporaryDirectory() as td:
+            inventory = build_inventory(target_dir, td)
+
+    # Index items by (rel_path, name) → line, for label lookup.
+    line_of: Dict[Tuple[str, str], int] = {}
+    for f in inventory.get("files", []):
+        if not isinstance(f, dict):
+            continue
+        rel = f.get("path") or ""
+        for it in f.get("items", []):
+            if isinstance(it, dict) and it.get("kind", "function") == "function":
+                line_of[(rel, it.get("name") or "")] = int(
+                    it.get("line_start") or 0)
+
+    report = AuditReport()
+    for (rel, name), label in labels.items():
+        module = _path_to_module(rel)
+        if not module:
+            continue
+        if (rel, name) not in line_of:
+            # The labelled function isn't in the inventory at all — an
+            # extraction gap, not a reachability verdict. Bucket it
+            # separately so it can't masquerade as a false-suppress (which
+            # would falsely fail the FN gate) or a coverage miss.
+            report.not_found += 1
+            report.not_found_detail.append((rel, name))
+            continue
+        line = line_of[(rel, name)]
+        verdict = classify_reachability(inventory, rel, name, line, module)
+        report.total += 1
+        report.per_verdict[verdict] = report.per_verdict.get(verdict, 0) + 1
+        is_dead = verdict in _DEAD_VERDICTS
+        if label == "dead":
+            if is_dead:
+                report.caught_dead += 1
+            else:
+                report.missed_dead += 1
+                report.missed_detail.append((rel, name, verdict))
+        else:  # label == "live"
+            if is_dead:
+                report.false_suppress += 1
+                report.false_suppress_detail.append((rel, name, verdict))
+            else:
+                report.live_ok += 1
+    return report
+
+
+__all__ = ["AuditReport", "audit_corpus", "classify_reachability"]

--- a/core/inventory/tests/test_reach_audit.py
+++ b/core/inventory/tests/test_reach_audit.py
@@ -1,0 +1,146 @@
+"""Reachability audit harness + committed synthetic dead-code corpus.
+
+This is the CI regression gate for the reachability substrate: a small,
+generic, multi-shape corpus of dead and live functions (no relation to any
+external corpus — deprecation stubs, disabled guards, orphans, framework
+handlers). The harness classifies each and the test asserts:
+
+  * coverage == 1.0   — every labelled-dead function is caught, and
+  * false_suppress == 0 — no labelled-live function is wrongly called dead
+    (the false-negative-critical contract).
+
+The Python corpus runs everywhere (stdlib ast). The C dead-island case is
+gated on tree-sitter-c (the call graph it needs), exercising the
+no_path_from_entry witness where the grammar is present.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.inventory.reach_audit import audit_corpus, classify_reachability
+
+
+def _write(root: Path, rel: str, body: str) -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body)
+
+
+def _python_corpus(root: Path) -> dict:
+    # live: called from main / framework handler. dead: orphan / disabled
+    # module / always-false guard.
+    _write(root, "app/main.py",
+           "from app.handlers import live_handler\n"
+           "def main():\n"
+           "    return live_handler(1)\n")
+    _write(root, "app/handlers.py",
+           "def live_handler(x):\n"
+           "    return x + 1\n"
+           "def orphan(x):\n"
+           "    return x - 1\n")
+    _write(root, "app/disabled.py",
+           "raise ImportError('module retired')\n"
+           "def vuln_below(cmd):\n"
+           "    import os; os.system(cmd)\n")
+    _write(root, "app/legacy.py",
+           "if False:\n"
+           "    def dead_guarded(x):\n"
+           "        return x\n"
+           "def used_here():\n"
+           "    return dead_guarded(1)\n")  # references the guarded name
+    _write(root, "app/api.py",
+           "from flask import Flask\n"
+           "app = Flask(__name__)\n"
+           "@app.route('/x')\n"
+           "def route_handler():\n"
+           "    return 'ok'\n")
+    return {
+        ("app/main.py", "main"): "live",
+        ("app/handlers.py", "live_handler"): "live",
+        ("app/handlers.py", "orphan"): "dead",
+        ("app/disabled.py", "vuln_below"): "dead",
+        ("app/legacy.py", "dead_guarded"): "dead",
+        ("app/api.py", "route_handler"): "live",
+    }
+
+
+def test_python_corpus_full_coverage_zero_false_suppress(tmp_path):
+    labels = _python_corpus(tmp_path)
+    report = audit_corpus(str(tmp_path), labels)
+    assert report.false_suppress == 0, (
+        f"live functions wrongly called dead: {report.false_suppress_detail}"
+    )
+    assert report.coverage == 1.0, (
+        f"dead functions missed: {report.missed_detail}"
+    )
+
+
+def test_c_dead_island_caught(tmp_path):
+    pytest.importorskip("tree_sitter_c")
+    # static helper reachable only via a static peer that is itself
+    # referenced solely from an unread (static) function-pointer table —
+    # an orphaned dead-island. A non-static function is a live entry.
+    _write(tmp_path, "m.c",
+           "static int read_be(const unsigned char *p){ return p[0]; }\n"
+           "static int parse(const unsigned char *p){ return read_be(p); }\n"
+           "static int (*const table[])(const unsigned char *) = { parse };\n"
+           "int public_api(const unsigned char *p){ return p[1]; }\n")
+    labels = {
+        ("m.c", "read_be"): "dead",
+        ("m.c", "parse"): "dead",
+        ("m.c", "public_api"): "live",
+    }
+    report = audit_corpus(str(tmp_path), labels)
+    assert report.false_suppress == 0, report.false_suppress_detail
+    assert report.coverage == 1.0, report.missed_detail
+    # specifically the dead-island verdict, not just "not_called"
+    assert report.per_verdict.get("no_path_from_entry", 0) >= 1
+
+
+def test_missing_function_is_not_found_not_false_suppress(tmp_path):
+    # A labelled function that the extractor never produced is an
+    # extraction gap, not a reachability misclassification — it must land
+    # in not_found, never in false_suppress (which would falsely fail the
+    # FN gate).
+    _write(tmp_path, "m.py", "def real(): pass\n")
+    report = audit_corpus(str(tmp_path), {
+        ("m.py", "ghost"): "live",   # never extracted
+        ("m.py", "real"): "dead",
+    })
+    assert report.false_suppress == 0
+    assert report.not_found == 1
+    assert ("m.py", "ghost") in report.not_found_detail
+
+
+def test_label_dead_means_statically_dead_not_deployment_isolated(tmp_path):
+    # Boundary doc: "dead" labels mean STATICALLY unreachable. Code that
+    # genuinely runs but is excluded from a deployment (e.g. a non-static C
+    # helper that another TU could link, or Go init() that runs at load)
+    # is correctly "reachable" — the substrate doesn't model deployment
+    # isolation (operator knowledge). Here: a non-static C function is an
+    # entry, so it's reachable, not a coverage miss.
+    pytest.importorskip("tree_sitter_c")
+    _write(tmp_path, "lib.c",
+           "int linkable(int x){ return x; }\n")  # non-static = entry
+    report = audit_corpus(str(tmp_path), {("lib.c", "linkable"): "live"})
+    assert report.false_suppress == 0
+    assert report.live_ok == 1
+
+
+def test_classify_precedence_module_abort_wins(tmp_path):
+    # A function below a top-level abort classifies module_aborts even if
+    # it also reads as called by a peer.
+    _write(tmp_path, "d.py",
+           "raise ImportError('x')\n"
+           "def a():\n"
+           "    return b()\n"
+           "def b():\n"
+           "    return a()\n")
+    import tempfile
+    from core.inventory.builder import build_inventory
+    with tempfile.TemporaryDirectory() as td:
+        inv = build_inventory(str(tmp_path), td)
+    assert classify_reachability(inv, "d.py", "a", 2, "d") == "module_aborts"


### PR DESCRIPTION
Adds a corpus-agnostic measurement harness for the reachability substrate plus a committed synthetic dead-code corpus that runs as a CI regression gate.

core/inventory/reach_audit.py:
- classify_reachability(): the strongest reachability verdict for one function, composing the shipped accessors in the same precedence as the /agentic enrichment prepass (module_aborts -> lexical_dead -> entry-reachability -> framework/registration -> 1-hop function_called). The read-only "audit" sibling of the prepass; verified to agree with it on every function of a mixed corpus (no drift).
- audit_corpus(target, labels): classify each labelled (rel_path, name) ->
  "dead"|"live" function and report coverage (dead correctly caught) and false_suppress (live wrongly called dead — the false-negative-critical metric). The corpus is an argument; the harness names no corpus.

The committed corpus (test_reach_audit.py) is a small, generic set of dead and live functions — deprecation stubs, disabled modules, always-false guards, orphans, framework handlers — with no relation to any external corpus. The gate asserts coverage == 1.0 and false_suppress == 0. The Python corpus runs everywhere (stdlib ast); the C dead-island case is gated on tree-sitter-c.

Two correctness rules the harness enforces:
- A labelled function absent from the inventory is bucketed not_found, not false_suppress — an extraction gap is not a reachability misclassification and must not fail the FN gate.
- "dead" labels mean STATICALLY dead. Code that runs but is excluded from a deployment (a non-static C helper another TU could link; Go init() that runs at load) is correctly classified reachable — the substrate does not model deployment isolation.

Prerequisite for sound-witness enforcement: a witness kind earns the right to hard-suppress only once its false_suppress is zero across a labelled corpus.