### PR TITLE
feat(reachability): Java servlet/JAX-RS/Spring entry detection + corpus refs

### DIFF
--- a/core/inventory/REACH_CORPUS.md
+++ b/core/inventory/REACH_CORPUS.md
@@ -1,0 +1,52 @@
+# Reachability corpora
+
+The reachability audit harness (`core/inventory/reach_audit.py`,
+`audit_corpus`) measures classification accuracy against a labelled tree.
+It is corpus-agnostic — point it at any directory plus a label map. Three
+roles, with three corpora:
+
+| role | what it proves | corpus |
+|---|---|---|
+| **coverage** | dead code is caught | committed synthetic fixtures (`tests/test_reach_audit.py`) + any operator-supplied labelled tree (path-configurable, not committed) |
+| **FN-gate** | live reachable code is never called dead | OWASP Benchmark (below) |
+| **over-fire** | the `#if 0` detector stays off config `#ifdef` | OpenSSL (below) |
+
+Large external corpora are **not vendored** — they're pinned and fetched on
+demand (same pattern as `core/dataflow/corpus/SOURCES.md`). The synthetic
+coverage corpus runs in CI; the external corpora are fetched locally / in a
+networked CI job.
+
+## OWASP Benchmark (FN-gate, Java)
+
+Whole-project labelled corpus: 2740 servlet test cases with TP/FP verdicts
+in `expectedresults-1.2.csv`. RAPTOR reachability needs only the Java
+source (no Maven build).
+
+- Upstream: `https://github.com/OWASP-Benchmark/BenchmarkJava`
+- Pinned sha: `b06d6efaebd577a327514364951916e7df3290b4`
+- Fetch:
+  ```
+  git clone --depth 1 https://github.com/OWASP-Benchmark/BenchmarkJava <dir>
+  cd <dir> && git fetch --depth 1 origin b06d6ef… && git checkout b06d6ef…
+  ```
+- Run: build an inventory of `<dir>/src`, label each TP test's
+  `doPost`/`doGet` `"live"`, and assert `audit_corpus(...).false_suppress == 0`.
+
+Note: OWASP exercises the *surface* Java reachability (and was what
+surfaced the servlet-entry handling now in `entry_reachability`). It does
+**not** exercise the enforce-eligible sound witnesses (`module_aborts`,
+`lexical_dead`), which are py/js/go/rust-only — for those, use live trees
+in those languages.
+
+## OpenSSL (over-fire gate, C)
+
+- Upstream: `https://github.com/openssl/openssl`
+- Run: `detect_preprocessor_dead_ranges` over every `.c`; assert it fires
+  only on literal-`0` conditions, never on `#ifdef`/`#if SYMBOL`.
+
+## Earning enforcement
+
+A witness kind earns the right to hard-suppress (see
+`reach_witness.may_suppress`) only once a labelled corpus shows
+`false_suppress == 0` for it. The enforcement consumer passes the earned
+set; nothing is suppressed otherwise.

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -2282,6 +2282,31 @@ def is_lexically_dead(
 # is trustworthy). Others degrade to UNCERTAIN.
 _CLOSEABLE_ENTRY_LANGS = frozenset({"c", "cpp", "go", "rust"})
 
+# Java servlet / filter lifecycle methods — invoked by the container, no
+# in-project caller. (init/destroy are generic names too; treating them as
+# entries is the conservative, false-negative-safe direction.)
+_JAVA_SERVLET_METHODS = frozenset({
+    "doGet", "doPost", "doPut", "doDelete", "doHead", "doOptions",
+    "doTrace", "service", "doFilter", "init", "destroy",
+})
+# JAX-RS / Spring routing annotation tail-names → the method is a route
+# handler dispatched by the web framework.
+_JAVA_ROUTE_ANNOTATIONS = frozenset({
+    "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH", "Path",
+    "RequestMapping", "GetMapping", "PostMapping", "PutMapping",
+    "DeleteMapping", "PatchMapping",
+})
+
+
+def _java_web_entry(name: str, item: Dict[str, Any]) -> bool:
+    if name in _JAVA_SERVLET_METHODS:
+        return True
+    for a in (item.get("metadata") or {}).get("attributes") or []:
+        tail = str(a).split("(")[0].strip().split(".")[-1]
+        if tail in _JAVA_ROUTE_ANNOTATIONS:
+            return True
+    return False
+
 
 def _item_is_entry(item: Dict[str, Any], language: str) -> bool:
     """Is this inventory item an externally-invocable entry point under its
@@ -2303,6 +2328,12 @@ def _item_is_entry(item: Dict[str, Any], language: str) -> bool:
     # Go runs every ``func init()`` automatically at package load — init
     # and its call tree are reachable even with no explicit caller.
     if language == "go" and name == "init":
+        return True
+    # Java web handlers are framework-dispatched entries with no in-project
+    # caller: servlet lifecycle methods by name and JAX-RS / Spring routing
+    # annotations. Without this, live servlet handlers (doPost/doGet) read
+    # not_called and get surface-demoted.
+    if language == "java" and _java_web_entry(name, item):
         return True
     if language not in _CLOSEABLE_ENTRY_LANGS:
         return False

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -592,6 +592,41 @@ def test_non_closeable_language_is_uncertain():
     assert _er(inv, "m.py", "_helper", 1) == "uncertain"
 
 
+def _jfn(name, line, attrs=None, vis="public"):
+    return {"name": name, "kind": "function", "line_start": line,
+            "metadata": {"visibility": vis, "attributes": attrs or []}}
+
+
+def test_java_servlet_method_is_entry():
+    # A servlet handler is framework-dispatched (no in-project caller); it
+    # and its callees must read reachable, not surface-demoted as not_called.
+    inv = _entry_inv(
+        "S.java", "java",
+        [_jfn("doPost", 1), _jfn("helper", 5, vis="private")],
+        [{"caller": "doPost", "chain": ["helper"], "line": 2}],
+    )
+    assert _er(inv, "S.java", "doPost", 1) == "reachable"
+    assert _er(inv, "S.java", "helper", 5) == "reachable"
+
+
+def test_java_jaxrs_and_spring_annotations_are_entries():
+    inv = _entry_inv(
+        "R.java", "java",
+        [_jfn("jaxrs", 1, attrs=["GET"]),
+         _jfn("spring", 5, attrs=['GetMapping("/y")'])],
+        [],
+    )
+    assert _er(inv, "R.java", "jaxrs", 1) == "reachable"
+    assert _er(inv, "R.java", "spring", 5) == "reachable"
+
+
+def test_java_plain_method_stays_uncertain():
+    # A non-servlet, non-annotated Java method isn't a confident entry
+    # (Java non-closeable) → uncertain → caller's 1-hop logic, unchanged.
+    inv = _entry_inv("P.java", "java", [_jfn("compute", 1)], [])
+    assert _er(inv, "P.java", "compute", 1) == "uncertain"
+
+
 def test_go_init_is_entry():
     # Adversarial FN: Go runs every `func init()` at package load, so init
     # and its callees are reachable even with no explicit caller.


### PR DESCRIPTION
Java web handlers are framework-dispatched (the servlet container / web framework invokes them) with no in-project caller, so the non-closeable Java entry model surface-demoted live handlers as not_called. Recognize them as entries:
- servlet/filter lifecycle methods by name (doGet / doPost / ... / service / doFilter / init / destroy),
- JAX-RS / Spring routing annotations (GET / POST / ... / Path / RequestMapping / GetMapping / ...), matched by annotation tail-name.

FN-safe by direction: this only makes MORE functions reachable (never demotes), so it cannot introduce a false negative; the cost is mild over-keep on generically-named methods, which is the safe side.

Validated on the OWASP Benchmark FN-gate: 500 labelled-live TP servlet handlers (250 tests) all classify reachable, false_suppress == 0 (was 24/40 not_called on the diagnostic sample).

Adds core/inventory/REACH_CORPUS.md documenting the labelled corpora the audit harness runs on (synthetic coverage in CI; OWASP FN-gate + OpenSSL over-fire, pinned-fetched) and how a witness kind earns enforcement.