### PR TITLE
feat: slopsquat hunt backend + render SCA escalation reasons (#583)

### DIFF
--- a/.claude/skills/code-understanding/hunt.md
+++ b/.claude/skills/code-understanding/hunt.md
@@ -18,6 +18,8 @@ One of:
 
 **Disambiguation:** `FIND-*` or `EP-*` → ID lookup in findings.json / context-map.json. `sink:` prefix → filter by sink type. Everything else → treat as a freeform pattern description.
 
+**Backends (`--hunt-tool`):** The default is the multi-model LLM hunt described below (any language). Two deterministic backends bypass the LLM: `cocci` (Coccinelle AST match, C/C++ only) and `slopsquat`. The `slopsquat` backend is an offline, network-free, no-API-key supply-chain hunt — it parses the target's dependency manifests and flags package names matching the AI-hallucination shape (popular prefix + generic suffix, lookalike-character substitution, untrusted scope). Use it at comprehension time to catch likely-hallucinated imports in LLM-generated code *before* installing them; the `--hunt` pattern is ignored. Registry verification (publish date, downloads, maintainer) is a separate, networked concern handled by `/sca`.
+
 ## Purpose
 
 Answer: *"Is this the only place this happens, or did the same mistake get made everywhere?"*

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -975,6 +975,20 @@ def _sca_finding_package(finding):
     return f"{eco}:{name}" if eco else name
 
 
+def _sca_finding_escalations(finding):
+    """Cross-detector escalation rationale for an SCA finding, if any.
+
+    Set by SCA's ``supply_chain`` layer when a slopsquat-shaped name
+    co-occurs with recent_publish / low_bus_factor / maintainer change;
+    explains a bumped severity. Lands at
+    ``finding['sca']['evidence']['escalation_reasons']``.
+    """
+    sca = finding.get("sca") or {}
+    evidence = sca.get("evidence") or {}
+    reasons = evidence.get("escalation_reasons") or []
+    return [str(r) for r in reasons] if isinstance(reasons, list) else []
+
+
 def _print_sca_findings_section(sca_findings, detailed=False):
     """Render SCA / dependency findings in their own section.
 
@@ -1025,6 +1039,8 @@ def _print_sca_findings_section(sca_findings, detailed=False):
         if desc and isinstance(desc, str):
             for ln in desc.strip().split("\n")[:2]:
                 print(f"{indent}{ln.strip()}")
+        for reason in _sca_finding_escalations(f):
+            print(f"{indent}escalated: {reason}")
         print()
 
 

--- a/core/project/report.py
+++ b/core/project/report.py
@@ -251,6 +251,11 @@ def render_grouped_findings_markdown(
                 f"- **{_finding_title(finding)}** (`{finding_id}`) — "
                 f"{package} — {severity}"
             )
+            evidence = sca.get("evidence") or {}
+            reasons = evidence.get("escalation_reasons") or []
+            if isinstance(reasons, list):
+                for reason in reasons:
+                    lines.append(f"  - escalated: {reason}")
         lines.append("")
 
     return "\n".join(lines).rstrip() + "\n"

--- a/core/project/tests/test_cli.py
+++ b/core/project/tests/test_cli.py
@@ -13,6 +13,8 @@ from core.project.cli import (
     _get_active_project,
     _get_output_summary,
     _print_findings,
+    _print_sca_findings_section,
+    _sca_finding_escalations,
     _sca_finding_kind,
     _sca_finding_package,
     main,
@@ -29,14 +31,17 @@ class _FakeProject:
         return self._run_dirs
 
 
-def _sca_finding(name, *, severity="high"):
+def _sca_finding(name, *, severity="high", escalation_reasons=None):
+    sca = {"kind": "slopsquat_suspect", "ecosystem": "npm", "name": name}
+    if escalation_reasons is not None:
+        sca["evidence"] = {"escalation_reasons": escalation_reasons}
     return {
         "id": f"SCA-{name}", "finding_id": f"SCA-{name}",
         "vuln_type": "sca:supply_chain:slopsquat_suspect", "tool": "sca",
         "file": "package.json", "function": name, "line": 0,
         "severity": severity, "title": f"Slopsquat suspect: {name}",
         "description": "looks like an LLM-hallucinated package name",
-        "sca": {"kind": "slopsquat_suspect", "ecosystem": "npm", "name": name},
+        "sca": sca,
     }
 
 
@@ -94,6 +99,31 @@ class TestPrintFindingsSca(unittest.TestCase):
         f = _sca_finding("lodahs")
         self.assertEqual(_sca_finding_package(f), "npm:lodahs")
         self.assertEqual(_sca_finding_kind(f), "Supply Chain · Slopsquat Suspect")
+
+    def test_escalation_helper_extracts_reasons(self):
+        f = _sca_finding("react-helper", escalation_reasons=["co-occurs with X"])
+        self.assertEqual(_sca_finding_escalations(f), ["co-occurs with X"])
+        # Absent / malformed evidence yields an empty list, never raises.
+        self.assertEqual(_sca_finding_escalations(_sca_finding("lodahs")), [])
+        self.assertEqual(_sca_finding_escalations({}), [])
+
+    def test_escalation_reasons_printed_in_detailed_mode(self):
+        rows = [_sca_finding("react-helper", severity="critical",
+                             escalation_reasons=["co-occurs with recent_publish"])]
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            _print_sca_findings_section(rows, detailed=True)
+        self.assertIn("escalated: co-occurs with recent_publish", buf.getvalue())
+
+    def test_escalation_reasons_absent_from_summary_mode(self):
+        rows = [_sca_finding("react-helper", severity="critical",
+                             escalation_reasons=["co-occurs with recent_publish"])]
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            _print_sca_findings_section(rows, detailed=False)
+        # Summary table shows the (bumped) severity but not the prose reasons.
+        self.assertNotIn("escalated:", buf.getvalue())
+        self.assertIn("Critical", buf.getvalue())
 
     def test_sca_section_renders(self):
         with TemporaryDirectory() as d:

--- a/core/project/tests/test_report.py
+++ b/core/project/tests/test_report.py
@@ -13,14 +13,17 @@ from core.project.report import (
 from core.run import start_run, complete_run
 
 
-def _sca_row(name, *, severity="high"):
+def _sca_row(name, *, severity="high", escalation_reasons=None):
+    sca = {"kind": "slopsquat_suspect", "ecosystem": "npm", "name": name}
+    if escalation_reasons is not None:
+        sca["evidence"] = {"escalation_reasons": escalation_reasons}
     return {
         "id": f"sca:supply_chain:slopsquat_suspect:npm:{name}",
         "finding_id": f"sca:supply_chain:slopsquat_suspect:npm:{name}",
         "vuln_type": "sca:supply_chain:slopsquat_suspect",
         "tool": "sca", "file": "package.json", "function": name, "line": 0,
         "severity": severity, "title": f"Slopsquat suspect: {name}",
-        "sca": {"kind": "slopsquat_suspect", "ecosystem": "npm", "name": name},
+        "sca": sca,
     }
 
 
@@ -245,6 +248,18 @@ class TestRenderGroupedFindingsMarkdownSca(unittest.TestCase):
             [], "proj", sca_findings=[_sca_row("expresss")])
         self.assertNotIn("No findings.", md)
         self.assertIn("## Supply chain / dependencies (SCA)", md)
+
+    def test_escalation_reasons_rendered_as_sub_bullet(self):
+        sca = [_sca_row("react-helper", severity="critical",
+                        escalation_reasons=[
+                            "co-occurs with recent_publish + low_bus_factor"])]
+        md = render_grouped_findings_markdown([], "proj", sca_findings=sca)
+        self.assertIn("escalated: co-occurs with recent_publish", md)
+
+    def test_no_escalation_reasons_no_sub_bullet(self):
+        md = render_grouped_findings_markdown(
+            [], "proj", sca_findings=[_sca_row("react-helper")])
+        self.assertNotIn("escalated:", md)
 
 
 if __name__ == "__main__":

--- a/libexec/raptor-understand
+++ b/libexec/raptor-understand
@@ -143,7 +143,7 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     p.add_argument(
-        "--hunt-tool", choices=("auto", "llm", "cocci"), default="auto",
+        "--hunt-tool", choices=("auto", "llm", "cocci", "slopsquat"), default="auto",
         help=(
             "Backend for --hunt. ``llm`` = the multi-model LLM with "
             "sandboxed Read/Grep/Glob (default before this flag, works "
@@ -151,9 +151,13 @@ def _build_parser() -> argparse.ArgumentParser:
             "match — C/C++ targets only, deterministic, dramatically "
             "more precise on structural patterns; uses 1 LLM call to "
             "translate the pattern into a .cocci rule, then spatch "
-            "does the matching. ``auto`` = cocci when spatch is "
-            "installed AND the target has C/C++ source, otherwise llm. "
-            "Has no effect on --trace."
+            "does the matching. ``slopsquat`` = offline supply-chain hunt "
+            "for LLM-hallucinated package names: parses the target's "
+            "dependency manifests and flags names matching the slopsquat "
+            "shape (no LLM, no network, no API key; --hunt pattern and "
+            "--model are ignored). "
+            "``auto`` = cocci when spatch is installed AND the target has "
+            "C/C++ source, otherwise llm. Has no effect on --trace."
         ),
     )
     return p
@@ -278,6 +282,9 @@ def _do_hunt(args: argparse.Namespace) -> dict:
     from packages.code_understanding.dispatch.hunt_cocci_dispatch import (
         cocci_hunt_dispatch, repo_looks_c_cpp,
     )
+    from packages.code_understanding.dispatch.hunt_slopsquat_dispatch import (
+        SLOPSQUAT_MODEL, slopsquat_hunt_dispatch,
+    )
     from packages.coccinelle.runner import is_available as spatch_available
 
     target = Path(args.target).resolve()
@@ -289,19 +296,29 @@ def _do_hunt(args: argparse.Namespace) -> dict:
     # default. Explicit ``cocci`` honours the operator's choice
     # (the dispatch surfaces a clean error if spatch is missing or
     # the repo isn't C/C++ — better UX than a silent fallback).
+    # ``slopsquat`` is explicit-only (never auto): a deterministic,
+    # network-free supply-chain hunt that ignores model and pattern.
     use_cocci = False
+    use_slopsquat = args.hunt_tool == "slopsquat"
     if args.hunt_tool == "cocci":
         use_cocci = True
     elif args.hunt_tool == "auto":
         use_cocci = spatch_available() and repo_looks_c_cpp(str(target))
-    backend_label = "cocci" if use_cocci else "llm"
+    backend_label = "slopsquat" if use_slopsquat else ("cocci" if use_cocci else "llm")
 
-    models, missing = _resolve_models(args.model)
-    if missing:
-        raise SystemExit(
-            "Unable to resolve --model entries: " + ", ".join(missing) +
-            "\nCheck models.json or set the relevant *_API_KEY env var."
-        )
+    # slopsquat is offline, deterministic, and model-independent — it needs
+    # no LLM key. Drive the hunt() orchestration with a single sentinel
+    # handle (the substrate only reads .model_name); the dispatch ignores it.
+    # Every other backend resolves the operator's --model list normally.
+    if use_slopsquat:
+        models = [SLOPSQUAT_MODEL]
+    else:
+        models, missing = _resolve_models(args.model)
+        if missing:
+            raise SystemExit(
+                "Unable to resolve --model entries: " + ", ".join(missing) +
+                "\nCheck models.json or set the relevant *_API_KEY env var."
+            )
 
     # Per-model budget = total / N, with a small per-model floor.
     # The cocci backend uses far less of this (1 LLM call to write
@@ -313,6 +330,10 @@ def _do_hunt(args: argparse.Namespace) -> dict:
     cost_by_model, verbose_logger = _build_cost_and_verbose_helpers(args.verbose)
 
     def _bound_dispatch(model, pattern, repo_path):
+        if use_slopsquat:
+            # No LLM, no network — zero cost.
+            cost_by_model[model.model_name] = 0.0
+            return slopsquat_hunt_dispatch(model, pattern, repo_path)
         if use_cocci:
             # cocci dispatch tracks no per-call cost callback (only one
             # small LLM round-trip) — record a nominal value so the

--- a/packages/code_understanding/dispatch/hunt_slopsquat_dispatch.py
+++ b/packages/code_understanding/dispatch/hunt_slopsquat_dispatch.py
@@ -1,0 +1,129 @@
+"""Slopsquat dispatch for /understand --hunt — supply-chain, any language.
+
+Same ``HuntDispatchFn`` shape as ``hunt_dispatch.default_hunt_dispatch`` and
+``hunt_cocci_dispatch.cocci_hunt_dispatch`` — ``(model, pattern, repo_path)``
+returning a list of variant dicts — so the ``hunt(...)`` substrate treats it
+as a drop-in backend, selected via ``--hunt-tool=slopsquat``.
+
+Unlike the LLM and cocci backends this is **model-independent and
+network-free**: it reuses the SCA manifest parsers to enumerate third-party
+dependencies and runs the pure-heuristic slopsquat detector
+(``packages.sca.supply_chain.slopsquat``) over them, flagging names matching
+the LLM-hallucination shape (generic suffix on a popular prefix, lookalike-
+character substitution, untrusted scope). ``model`` and ``pattern`` are
+ignored — the "pattern" is fixed (the slopsquat shape).
+
+This is the comprehension-time use context from issue #583: surfacing
+likely-hallucinated imports *while reading LLM-generated code*, before any
+``npm install`` / ``pip install``. Registry verification (publish date,
+download counts, maintainer) stays in ``/sca``; this dispatch does no network
+— it's a fast, offline "this import looks slopsquatted, verify before
+installing" flag.
+
+SCA is an optional dependency of /understand; if it isn't importable the
+dispatch returns an error variant (substrate convention for ``failed_models``),
+the same way cocci does for a missing ``spatch``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+SLOPSQUAT_MODEL_NAME = "sca-slopsquat"
+
+
+class _SlopsquatModel:
+    """Sentinel ``ModelHandle`` for the offline slopsquat backend.
+
+    The ``hunt()`` substrate only reads ``.model_name`` (it's a Protocol);
+    this dispatch ignores the handle entirely. Wrapping a sentinel — exactly
+    the pattern the ``ModelHandle`` docstring describes for non-LLM consumers
+    — lets ``--hunt-tool=slopsquat`` run with **no LLM key configured**,
+    which is the whole point: it's an offline, pre-install check.
+    """
+
+    model_name = SLOPSQUAT_MODEL_NAME
+
+
+SLOPSQUAT_MODEL = _SlopsquatModel()
+
+
+def _finding_to_variant(finding: Any, repo: Path) -> Dict[str, Any]:
+    """Map a ``SlopsquatFinding`` to the variant-dict shape the
+    ``VariantAdapter`` expects (file/line/function/snippet/confidence/tool).
+
+    A slopsquat finding is dependency-level, not source-line-level, so
+    ``file`` is the manifest it was declared in and ``line`` is 0. The
+    package name goes in ``function`` (matching how the SCA→finding row
+    uses ``function`` for the package), and the heuristic reasons +
+    suspected imitated package go in ``snippet``.
+    """
+    dep = finding.dependency
+    file_rel = str(dep.declared_in)
+    try:
+        p = Path(dep.declared_in)
+        if p.is_absolute():
+            file_rel = str(p.resolve().relative_to(repo.resolve()))
+    except (ValueError, OSError):
+        pass  # cross-FS or non-repo manifest — leave as-is
+
+    snippet = f"slopsquat shape (score {finding.score:.2f}): {', '.join(finding.reasons)}"
+    if finding.suspected_root:
+        snippet += f"; resembles popular package '{finding.suspected_root}'"
+
+    return {
+        "file": file_rel,
+        "line": 0,
+        "function": f"{dep.ecosystem}:{dep.name}",
+        "snippet": snippet,
+        "confidence": str(finding.confidence.level),
+        "tool": "sca-slopsquat",
+    }
+
+
+def slopsquat_hunt_dispatch(
+    model: Any,
+    pattern: str,
+    repo_path: str,
+) -> List[Dict[str, Any]]:
+    """``HuntDispatchFn`` backed by the SCA slopsquat detector.
+
+    ``model`` and ``pattern`` are accepted for interface parity but
+    ignored — the hunt is for a fixed shape (LLM-hallucinated package
+    names), not a caller-supplied pattern. Errors are returned as a
+    single-element ``[{"error": ...}]`` list (substrate convention).
+    """
+    repo = Path(repo_path)
+    if not repo.is_dir():
+        return [{"error": f"invalid repo_path: {repo_path!r} is not a directory"}]
+
+    try:
+        from packages.sca.discovery import find_manifests
+        from packages.sca.parsers import capture_parse_failures, parse_manifest
+        from packages.sca.supply_chain.slopsquat import scan_deps
+    except ImportError as exc:
+        return [{"error": (
+            f"SCA package not importable ({exc}); --hunt-tool=slopsquat needs "
+            f"packages/sca. Use --hunt-tool=llm for a natural-language hunt."
+        )}]
+
+    try:
+        manifests = find_manifests(repo)
+        deps = []
+        with capture_parse_failures():
+            for m in manifests:
+                # Inline manifests (Dockerfile RUN apt-get ...) aren't
+                # registry packages the slopsquat heuristic reasons about.
+                if getattr(m, "ecosystem", "") == "Inline":
+                    continue
+                deps.extend(parse_manifest(m))
+        findings = scan_deps(deps)
+    except Exception as exc:  # noqa: BLE001 — any SCA-side failure
+        logger.warning("slopsquat_hunt: scan failed for %s: %s", repo_path, exc)
+        return [{"error": f"slopsquat scan failed: {type(exc).__name__}: {exc}"}]
+
+    return [_finding_to_variant(f, repo) for f in findings]

--- a/packages/code_understanding/tests/dispatch/test_hunt_slopsquat_dispatch.py
+++ b/packages/code_understanding/tests/dispatch/test_hunt_slopsquat_dispatch.py
@@ -1,0 +1,167 @@
+"""Tests for the slopsquat dispatch backend for /understand --hunt.
+
+The dispatch is offline and side-effect-free: it reuses the SCA manifest
+parsers (pure Python, no binary, no network) and the pure-heuristic
+slopsquat detector. So unlike the cocci tests — which must mock spatch —
+these exercise the real SCA stack against tmp-dir fixtures, which is
+higher fidelity. Only the "SCA not installed" path is simulated.
+
+Coverage:
+  * slopsquat-shaped dep (popular prefix + generic suffix) → variant
+    with the file/line/function/snippet/confidence/tool shape the
+    VariantAdapter consumes
+  * clean repo (only popular deps) → []
+  * repo with no manifests → []
+  * non-existent / non-dir repo_path → error variant
+  * SCA package not importable → error variant (not a crash)
+  * SLOPSQUAT_MODEL sentinel exposes a stable model_name
+  * _finding_to_variant: absolute manifest path → repo-relative file
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+
+# parents[4] climbs:
+#   [0] packages/code_understanding/tests/dispatch/  (this file's directory)
+#   [1] packages/code_understanding/tests/
+#   [2] packages/code_understanding/
+#   [3] packages/
+#   [4] <repo root>
+_REPO_ROOT = str(Path(__file__).resolve().parents[4])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+from packages.code_understanding.dispatch import hunt_slopsquat_dispatch as mod  # noqa: E402
+
+
+def _write_package_json(repo: Path, deps: dict) -> None:
+    (repo / "package.json").write_text(
+        json.dumps({"name": "fixture", "version": "1.0.0", "dependencies": deps})
+    )
+
+
+# ---------------------------------------------------------------------
+# Dispatch entry-point
+# ---------------------------------------------------------------------
+
+def test_slopsquat_shape_dep_yields_variant(tmp_path: Path) -> None:
+    # react-helper = popular prefix ("react") + generic suffix ("helper").
+    _write_package_json(tmp_path, {"react": "^18.0.0", "react-helper": "^1.0.0"})
+
+    variants = mod.slopsquat_hunt_dispatch(None, "ignored", str(tmp_path))
+
+    assert len(variants) == 1
+    v = variants[0]
+    # Shape the VariantAdapter consumes.
+    assert set(v) >= {"file", "line", "function", "snippet", "confidence", "tool"}
+    assert v["file"] == "package.json"          # repo-relative manifest
+    assert v["line"] == 0                         # dependency-level, no source line
+    assert v["function"] == "npm:react-helper"
+    assert v["tool"] == "sca-slopsquat"
+    assert "slopsquat shape" in v["snippet"]
+    assert "react" in v["snippet"]                # suspected imitated package
+    assert isinstance(v["confidence"], str)
+
+
+def test_clean_repo_only_popular_deps_yields_nothing(tmp_path: Path) -> None:
+    _write_package_json(tmp_path, {"react": "^18.0.0", "express": "^4.0.0"})
+    assert mod.slopsquat_hunt_dispatch(None, "x", str(tmp_path)) == []
+
+
+def test_repo_with_no_manifests_yields_nothing(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("no manifests here")
+    assert mod.slopsquat_hunt_dispatch(None, "x", str(tmp_path)) == []
+
+
+def test_nonexistent_repo_returns_error_variant() -> None:
+    out = mod.slopsquat_hunt_dispatch(None, "x", "/no/such/dir/xyz")
+    assert len(out) == 1
+    assert "error" in out[0]
+    assert "not a directory" in out[0]["error"]
+
+
+def test_file_path_as_repo_returns_error_variant(tmp_path: Path) -> None:
+    f = tmp_path / "afile.txt"
+    f.write_text("x")
+    out = mod.slopsquat_hunt_dispatch(None, "x", str(f))
+    assert len(out) == 1 and "error" in out[0]
+
+
+def test_sca_not_importable_returns_error_variant(tmp_path: Path) -> None:
+    _write_package_json(tmp_path, {"react-helper": "^1.0.0"})
+    # Setting a module to None in sys.modules makes `import` of it raise
+    # ImportError — simulates SCA not being installed alongside /understand.
+    with mock.patch.dict(sys.modules, {"packages.sca.discovery": None}):
+        out = mod.slopsquat_hunt_dispatch(None, "x", str(tmp_path))
+    assert len(out) == 1
+    assert "error" in out[0]
+    assert "SCA package not importable" in out[0]["error"]
+
+
+def test_scan_failure_returns_error_variant_not_crash(tmp_path: Path) -> None:
+    _write_package_json(tmp_path, {"react-helper": "^1.0.0"})
+    with mock.patch.object(mod, "Path", wraps=Path):
+        # Force scan_deps to blow up after imports succeed.
+        with mock.patch(
+            "packages.sca.supply_chain.slopsquat.scan_deps",
+            side_effect=RuntimeError("boom"),
+        ):
+            out = mod.slopsquat_hunt_dispatch(None, "x", str(tmp_path))
+    assert len(out) == 1
+    assert "error" in out[0]
+    assert "slopsquat scan failed" in out[0]["error"]
+
+
+# ---------------------------------------------------------------------
+# Sentinel handle + mapping helper
+# ---------------------------------------------------------------------
+
+def test_sentinel_model_has_stable_name() -> None:
+    assert mod.SLOPSQUAT_MODEL.model_name == mod.SLOPSQUAT_MODEL_NAME
+    assert mod.SLOPSQUAT_MODEL_NAME == "sca-slopsquat"
+
+
+def test_finding_to_variant_relativizes_absolute_manifest_path(tmp_path: Path) -> None:
+    # Duck-typed stand-in for SlopsquatFinding — _finding_to_variant only
+    # reads these attributes, so we avoid constructing the full dataclass.
+    abs_manifest = tmp_path / "sub" / "package.json"
+    finding = SimpleNamespace(
+        dependency=SimpleNamespace(
+            declared_in=abs_manifest, ecosystem="npm", name="react-helper",
+        ),
+        score=0.6,
+        reasons=("popular_prefix_generic_suffix",),
+        suspected_root="react",
+        confidence=SimpleNamespace(level="low"),
+    )
+    v = mod._finding_to_variant(finding, tmp_path)
+    assert v["file"] == str(Path("sub") / "package.json")  # repo-relative
+    assert v["function"] == "npm:react-helper"
+    assert v["confidence"] == "low"
+
+
+def test_finding_to_variant_leaves_foreign_path_unchanged() -> None:
+    # declared_in outside the repo → relative_to raises → left as-is.
+    finding = SimpleNamespace(
+        dependency=SimpleNamespace(
+            declared_in=Path("/elsewhere/package.json"), ecosystem="npm", name="x-cli",
+        ),
+        score=0.5, reasons=("r",), suspected_root=None,
+        confidence=SimpleNamespace(level="low"),
+    )
+    v = mod._finding_to_variant(finding, Path("/repo"))
+    assert v["file"] == "/elsewhere/package.json"
+    assert "resembles" not in v["snippet"]  # suspected_root None → no clause
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/packages/sca/report.py
+++ b/packages/sca/report.py
@@ -739,6 +739,27 @@ def _render_one_kinded_group(group: Sequence) -> str:
     bullets = [
         f"- Detail: {sanitise_string(primary.detail, max_chars=_DETAIL_MAX_CHARS)}"
     ]
+
+    # Cross-detector escalation rationale, set by
+    # supply_chain._escalate_cross_detector when a slopsquat-shaped name
+    # co-occurs with recent_publish / low_bus_factor / maintainer change.
+    # Surface it so the (possibly bumped) header severity is explained
+    # rather than mysterious. Union across the group — escalation is keyed
+    # on the same dep+kind, so members normally share reasons.
+    escalation_reasons: List[str] = []
+    for f in group:
+        ev = getattr(f, "evidence", None)
+        if isinstance(ev, dict):
+            for r in ev.get("escalation_reasons") or ():
+                if r not in escalation_reasons:
+                    escalation_reasons.append(str(r))
+    if len(escalation_reasons) == 1:
+        bullets.append(f"- Escalated: {escape_nonprintable(escalation_reasons[0])}")
+    elif escalation_reasons:
+        bullets.append("- Escalated:")
+        for r in escalation_reasons:
+            bullets.append(f"  - {escape_nonprintable(r)}")
+
     # Switch to a list when there are MULTIPLE distinct source
     # paths. A group of N findings that all share one declared_in
     # path (duplicate findings the emitter happened to produce

--- a/packages/sca/tests/test_report.py
+++ b/packages/sca/tests/test_report.py
@@ -438,7 +438,8 @@ def test_write_markdown_report_atomic(tmp_path: Path) -> None:
 def _supply_chain(kind: str = "version_publish",
                   declared_in: str = "/repo/package.json",
                   detail: str = "publish frequency outlier",
-                  severity: str = "info"):
+                  severity: str = "info",
+                  evidence=None):
     """Build a SupplyChainFinding for dedup tests. Each fixture lets
     callers override ``declared_in`` to simulate the same dep being
     flagged in multiple manifests."""
@@ -454,7 +455,8 @@ def _supply_chain(kind: str = "version_publish",
     return SupplyChainFinding(
         finding_id=f"sca:supply_chain:{kind}:PyPI:requests:{declared_in}",
         kind=kind,                                         # type: ignore[arg-type]
-        dependency=dep, detail=detail, evidence={},
+        dependency=dep, detail=detail,
+        evidence=evidence if evidence is not None else {},
         severity=severity,                                 # type: ignore[arg-type]
         confidence=Confidence("high", reason="t"),
     )
@@ -711,3 +713,39 @@ def test_advisory_text_with_ansi_or_bidi_is_sanitised() -> None:
     assert "\x07" not in md
     # The visible text survives.
     assert "danger" in md and "red" in md and "malicious" in md
+
+
+# ---------------------------------------------------------------------------
+# Cross-detector escalation rationale
+# ---------------------------------------------------------------------------
+
+def test_supply_chain_escalation_reasons_rendered() -> None:
+    """When supply_chain._escalate_cross_detector bumps severity it
+    records why in evidence['escalation_reasons']; the report must
+    surface that so the bumped severity isn't mysterious."""
+    sc = _supply_chain(kind="slopsquat_suspect", severity="critical",
+                       evidence={"escalation_reasons": [
+                           "co-occurs with recent_publish + low_bus_factor "
+                           "(LLM-hallucination-bait archetype)"
+                       ]})
+    md = render_markdown_report(
+        target=Path("/x"),
+        deps_analysed=1,
+        vuln_findings=[],
+        hygiene_findings=[],
+        supply_chain_findings=[sc],
+    )
+    assert "Escalated:" in md
+    assert "LLM-hallucination-bait archetype" in md
+
+
+def test_supply_chain_without_escalation_has_no_escalated_bullet() -> None:
+    sc = _supply_chain(kind="slopsquat_suspect", evidence={})
+    md = render_markdown_report(
+        target=Path("/x"),
+        deps_analysed=1,
+        vuln_findings=[],
+        hygiene_findings=[],
+        supply_chain_findings=[sc],
+    )
+    assert "Escalated:" not in md


### PR DESCRIPTION
Two additive follow-ons to issue #583 (LLM-hallucinated-package detection).

/understand --hunt --hunt-tool=slopsquat: an offline, network-free, no-API-key supply-chain hunt. Reuses the SCA manifest parsers to enumerate third-party deps and runs the pure-heuristic slopsquat detector over them, flagging names matching the AI-hallucination shape (popular prefix + generic suffix, lookalike substitution, untrusted scope). Model-independent — drives the hunt via a sentinel ModelHandle so it runs with no LLM configured. Registry verification stays in /sca.

Surface SCA cross-detector escalation reasons: _escalate_cross_detector already bumped slopsquat severity on co-occurrence with recent_publish / low_bus_factor / maintainer change and recorded the rationale in evidence['escalation_reasons'], but no view printed it. Render it in the SCA report, /project findings --detailed, and the merged project report so a bumped severity is explained rather than mysterious.