### PR TITLE
Add lifecycle_drift strategy + a reusable strategy-eval framework

### DIFF
--- a/core/llm/cwe_strategies/strategies/lifecycle_drift.yml
+++ b/core/llm/cwe_strategies/strategies/lifecycle_drift.yml
@@ -1,0 +1,88 @@
+name: lifecycle_drift
+description: |
+  Context drift of an invariant. A state field or flag is set under
+  some precondition P (object owns an mm, credentials committed,
+  socket connected, file opened) and later consumed on a code path
+  where P no longer holds. The value's bit pattern is correct at
+  write-time; its security meaning is wrong at read-time. Distinct
+  from memory aliasing and cross-subsystem variants — the defect is
+  temporal, not spatial: the same field means different things in
+  different lifecycle phases of the same object.
+
+signals:
+  paths:
+    - kernel/ptrace.c
+    - kernel/cred.c
+    - kernel/exit.c
+    - kernel/sys.c
+    - fs/exec.c
+  includes:
+    - linux/ptrace.h
+    - linux/cred.h
+    - linux/sched/mm.h
+  function_keywords:
+    - dumpable
+    - ptrace
+  function_calls:
+    - get_dumpable
+    - __get_dumpable
+    - set_dumpable
+    - ptrace_may_access
+    - __ptrace_may_access
+    - commit_creds
+  cwes:
+    # Incorrect authorization is the *consequence* (a security check
+    # consumes a value that carries no meaning in the read context).
+    # The deeper class — "lifecycle-invariant misapplication" — has no
+    # clean CWE; keep this list narrow so the strategy doesn't become a
+    # magnet for every access-control finding.
+    - CWE-863   # incorrect authorization
+
+key_questions:
+  - "Does this code read a state field/flag it did NOT just compute — one set at a different lifecycle stage (construction, credential change, exec, exit, connect/open)?"
+  - "What precondition made that value meaningful when it was written (e.g. 'task owns an mm', 'creds already committed')? Is that precondition guaranteed on every path that reaches this read?"
+  - "If the precondition does NOT hold here (kernel thread, task mid-exit, swapped-out/reaped mm, pre-commit creds), what does the field carry — stale, default, or meaningless — and does the consumer still treat it as authoritative?"
+  - "Is the value used in a security decision (access control, privilege, authorization)? What is the wrong decision when the precondition is violated?"
+
+prompt_addendum: |
+  Context-drift bugs are invisible at the read site: the value is the
+  right type, usually the right bit pattern, and the code reads
+  correctly under local inspection. The defect is temporal — a value
+  established under precondition P is consumed on a path where P no
+  longer holds, so its semantics silently changed between write and
+  read. Identify every state field the function reads but did not just
+  compute. For each, find the write site(s) and the precondition that
+  made it meaningful, then ask whether that precondition is guaranteed
+  at this read. Pay special attention to objects with lifecycle phases
+  — tasks with vs without an mm, credentials before vs after commit,
+  sockets before vs after connect, files before vs after open: a flag
+  that is authoritative in one phase can be meaningless in another, and
+  a security check that consumes it across the phase boundary makes the
+  wrong decision.
+
+exemplars:
+  - cve: CVE-2026-46333
+    title: ptrace dumpability — __ptrace_may_access() trusts get_dumpable() for
+      tasks without an mm
+    pattern: |
+      __ptrace_may_access() reads get_dumpable(task) as one of its
+      access-control inputs. get_dumpable() reports the dumpability
+      flag of the task's mm. For tasks that have no mm — kernel
+      threads, processes mid-exit, processes whose mm was reaped or
+      swapped out — there is no mm to carry the invariant, yet the
+      call still returns a value (stale or default) that the check
+      consumes as authoritative.
+    why_buggy: |
+      The dumpability invariant ("this task's memory image is
+      non-dumpable") is only meaningful for a task that owns an mm.
+      The flag's bit pattern is correct at the time it was written
+      (when the mm existed); its semantics are wrong at read-time in
+      an mm-less context. __ptrace_may_access() trusted the returned
+      value as a valid security signal regardless of whether the task
+      had an mm, producing the wrong access decision for
+      kernel-thread / exiting / mm-less targets. Fixed by caching
+      last-known dumpability for tasks that had an mm, returning zero
+      for kernel threads, and gating mm-less access on CAP_SYS_PTRACE.
+      The lesson: a state field is only as trustworthy as the
+      precondition under which it was set — read it on a path where
+      that precondition fails and it lies.

--- a/core/llm/cwe_strategies/strategies/lifecycle_drift.yml
+++ b/core/llm/cwe_strategies/strategies/lifecycle_drift.yml
@@ -1,64 +1,67 @@
 name: lifecycle_drift
 description: |
-  Context drift of an invariant. A state field or flag is set under
-  some precondition P (object owns an mm, credentials committed,
-  socket connected, file opened) and later consumed on a code path
-  where P no longer holds. The value's bit pattern is correct at
+  Context drift of an invariant in a kernel task's lifecycle. A state
+  field is set under some precondition P (the task owns an mm,
+  credentials have been committed) and later consumed on a path where
+  P no longer holds — a kernel thread, a task mid-exit, a task whose
+  mm was swapped out. The value's bit pattern is correct at
   write-time; its security meaning is wrong at read-time. Distinct
-  from memory aliasing and cross-subsystem variants — the defect is
-  temporal, not spatial: the same field means different things in
-  different lifecycle phases of the same object.
+  from auth_privilege's TOCTOU angle (a value that *changes* between
+  check and use): here the value need not change at all — the
+  precondition that made it meaningful is simply absent in this
+  lifecycle phase. The signals below are deliberately narrow, targeting
+  the kernel task-state / mm-ownership surface where this class is
+  known to occur; the reasoning in the addendum generalises, but the
+  triggers stay tight so the strategy does not fire on unrelated code.
 
 signals:
+  # Intentionally narrow — the precise signal is "this function calls
+  # an mm-conditional accessor like get_dumpable()". Broad paths
+  # (kernel/cred.c, fs/exec.c) and tokens (ptrace, commit_creds) were
+  # dropped: they made the strategy a magnet for every function in the
+  # cred/exec/ptrace neighbourhood and collided with auth_privilege.
   paths:
     - kernel/ptrace.c
-    - kernel/cred.c
-    - kernel/exit.c
-    - kernel/sys.c
-    - fs/exec.c
   includes:
     - linux/ptrace.h
-    - linux/cred.h
     - linux/sched/mm.h
   function_keywords:
     - dumpable
-    - ptrace
   function_calls:
     - get_dumpable
     - __get_dumpable
     - set_dumpable
     - ptrace_may_access
     - __ptrace_may_access
-    - commit_creds
-  cwes:
-    # Incorrect authorization is the *consequence* (a security check
-    # consumes a value that carries no meaning in the read context).
-    # The deeper class — "lifecycle-invariant misapplication" — has no
-    # clean CWE; keep this list narrow so the strategy doesn't become a
-    # magnet for every access-control finding.
-    - CWE-863   # incorrect authorization
+  # No `cwes:` on purpose. CWE-863 (incorrect authorization) is the
+  # consequence, but auth_privilege already claims it; sharing the tag
+  # makes both strategies tie on the dominant signal and split the
+  # prompt budget. The bespoke function_calls above are the precise,
+  # low-false-positive trigger.
 
 key_questions:
-  - "Does this code read a state field/flag it did NOT just compute — one set at a different lifecycle stage (construction, credential change, exec, exit, connect/open)?"
-  - "What precondition made that value meaningful when it was written (e.g. 'task owns an mm', 'creds already committed')? Is that precondition guaranteed on every path that reaches this read?"
-  - "If the precondition does NOT hold here (kernel thread, task mid-exit, swapped-out/reaped mm, pre-commit creds), what does the field carry — stale, default, or meaningless — and does the consumer still treat it as authoritative?"
-  - "Is the value used in a security decision (access control, privilege, authorization)? What is the wrong decision when the precondition is violated?"
+  - "Does this code read a state field/flag it did NOT just compute — one set at a different lifecycle stage (mm acquired at exec, credentials committed)?"
+  - "What precondition made that value meaningful when written (e.g. 'the task owns an mm')? Is that precondition guaranteed on every path that reaches this read?"
+  - "If the precondition does NOT hold here (kernel thread, task mid-exit, swapped-out mm), what does the field carry — stale, default, or meaningless — and does the consumer still treat it as authoritative?"
+  - "This is not a check/use race: the value need not change. Does a security decision here consume a field whose invariant simply doesn't apply in the task's current lifecycle phase?"
 
 prompt_addendum: |
   Context-drift bugs are invisible at the read site: the value is the
   right type, usually the right bit pattern, and the code reads
   correctly under local inspection. The defect is temporal — a value
   established under precondition P is consumed on a path where P no
-  longer holds, so its semantics silently changed between write and
+  longer holds, so its meaning silently changed between write and
   read. Identify every state field the function reads but did not just
   compute. For each, find the write site(s) and the precondition that
   made it meaningful, then ask whether that precondition is guaranteed
-  at this read. Pay special attention to objects with lifecycle phases
-  — tasks with vs without an mm, credentials before vs after commit,
-  sockets before vs after connect, files before vs after open: a flag
-  that is authoritative in one phase can be meaningless in another, and
-  a security check that consumes it across the phase boundary makes the
-  wrong decision.
+  at this read. The canonical shape: an access-control helper
+  (``*_may_access``, ``*_check_*``) that derives a verdict from an
+  mm-conditional field — e.g. ``get_dumpable()`` — without first
+  guarding on ``task->mm != NULL``, so kernel threads and exiting
+  tasks reach the consumer with a field that carries no meaning. This
+  is NOT a check/use race: the field need not change; the precondition
+  under which it was authoritative is simply absent in this lifecycle
+  phase.
 
 exemplars:
   - cve: CVE-2026-46333
@@ -68,10 +71,10 @@ exemplars:
       __ptrace_may_access() reads get_dumpable(task) as one of its
       access-control inputs. get_dumpable() reports the dumpability
       flag of the task's mm. For tasks that have no mm — kernel
-      threads, processes mid-exit, processes whose mm was reaped or
-      swapped out — there is no mm to carry the invariant, yet the
-      call still returns a value (stale or default) that the check
-      consumes as authoritative.
+      threads, processes mid-exit, processes whose mm was swapped
+      out — there is no mm to carry the invariant, yet the call still
+      returns a value (stale or default) that the check consumes as
+      authoritative.
     why_buggy: |
       The dumpability invariant ("this task's memory image is
       non-dumpable") is only meaningful for a task that owns an mm.

--- a/core/llm/cwe_strategies/strategies/lifecycle_drift.yml
+++ b/core/llm/cwe_strategies/strategies/lifecycle_drift.yml
@@ -9,10 +9,14 @@ description: |
   from auth_privilege's TOCTOU angle (a value that *changes* between
   check and use): here the value need not change at all — the
   precondition that made it meaningful is simply absent in this
-  lifecycle phase. The signals below are deliberately narrow, targeting
-  the kernel task-state / mm-ownership surface where this class is
-  known to occur; the reasoning in the addendum generalises, but the
-  triggers stay tight so the strategy does not fire on unrelated code.
+  lifecycle phase. Scope, stated honestly: the signals below fire
+  ONLY on the kernel ptrace / mm-dumpability surface (get_dumpable,
+  __ptrace_may_access) — this is a precise, low-false-positive lens for
+  that one shape today, NOT a general context-drift detector. The
+  addendum describes the general method, but the picker is mechanical:
+  broadening to sibling bugs (other mm-conditional accessors,
+  credential / namespace lifecycle) means adding signals plus a worked
+  exemplar as those bugs surface in other subsystems.
 
 signals:
   # Intentionally narrow — the precise signal is "this function calls

--- a/core/llm/cwe_strategies/tests/test_bundled_strategies.py
+++ b/core/llm/cwe_strategies/tests/test_bundled_strategies.py
@@ -1,4 +1,4 @@
-"""Coverage for the 7 bundled strategies.
+"""Coverage for the 8 bundled strategies.
 
 Verifies every shipped strategy:
   * Loads cleanly via the strict schema.
@@ -29,6 +29,7 @@ _EXPECTED_STRATEGIES = {
     "auth_privilege",
     "cryptography",
     "memory_aliasing",
+    "lifecycle_drift",
 }
 
 
@@ -48,7 +49,7 @@ def by_name(all_strategies):
 
 
 class TestBundle:
-    def test_all_seven_present(self, by_name):
+    def test_all_expected_present(self, by_name):
         names = set(by_name)
         missing = _EXPECTED_STRATEGIES - names
         assert not missing, f"missing bundled strategies: {sorted(missing)}"
@@ -179,6 +180,20 @@ class TestPickerReachability:
             function_name="splice_pages",
         )
         assert "memory_aliasing" in {s.name for s in out}
+
+    def test_lifecycle_drift_via_path(self, by_name):
+        out = pick_strategies(
+            file_path="kernel/ptrace.c",
+            function_name="__ptrace_may_access",
+        )
+        assert "lifecycle_drift" in {s.name for s in out}
+
+    def test_lifecycle_drift_via_keyword(self, by_name):
+        out = pick_strategies(
+            file_path="src/foo.c",
+            function_name="check_dumpable",
+        )
+        assert "lifecycle_drift" in {s.name for s in out}
 
 
 # ---------------------------------------------------------------------------

--- a/core/llm/cwe_strategies/tests/test_prompts.py
+++ b/core/llm/cwe_strategies/tests/test_prompts.py
@@ -318,9 +318,9 @@ class TestE2EBundledStrategies:
         assert "truncated" not in out
         assert len(out.encode("utf-8")) <= DEFAULT_MAX_BYTES
 
-    def test_all_seven_bundled_might_truncate(self):
-        """All 7 strategies rendered together MAY exceed the default
-        budget. Pin behaviour: either fits, or truncates cleanly."""
+    def test_all_bundled_might_truncate(self):
+        """All bundled strategies rendered together MAY exceed the
+        default budget. Pin behaviour: either fits, or truncates cleanly."""
         all_strats = load_all()
         out = render_strategies(all_strats)
         # Either no truncation OR clean truncation marker.

--- a/libexec/raptor-strategy-eval
+++ b/libexec/raptor-strategy-eval
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Evaluate the cwe_strategies bug-class lenses.
+
+Two modes:
+
+  raptor-strategy-eval [--selection] [--cases PATH]
+      Deterministic routing eval (no LLM): does the picker select the
+      right strategy for a labeled set of signal cases, and refrain from
+      firing where it shouldn't? Exit 1 on any routing regression, so it
+      doubles as a gate.
+
+  raptor-strategy-eval --efficacy --corpus DIR [--runs N]
+      Offline A/B efficacy eval (LIVE LLM, makes paid calls): for each
+      labeled sample, run an otherwise-identical review prompt with vs
+      without the target lens and report detection lift / false-positive
+      delta. Point --corpus at a labeled corpus (manifest.yml + source);
+      a synthetic seed ships at packages/strategy_eval/data/seed_corpus.
+
+Exit codes:
+  0  — eval ran (selection: all cases passed)
+  1  — selection routing regression, or invalid arguments
+  2  — substrate not installed
+"""
+import sys
+from pathlib import Path
+
+# ─── trust-marker check (do not import; inline by design) ───
+import os
+if not (os.environ.get("CLAUDECODE")
+        or os.environ.get("_RAPTOR_TRUSTED")):
+    sys.stderr.write(
+        f"{sys.argv[0]}: internal dispatch script.\n"
+        "  Run via 'bin/raptor' instead.\n"
+        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
+    )
+    sys.exit(2)
+# ─── end trust-marker check ─────────────────────────────────
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import argparse
+
+
+def _run_selection(args) -> int:
+    from packages.strategy_eval.selection import (
+        format_report,
+        load_cases,
+        run_selection_eval,
+    )
+
+    cases = load_cases(Path(args.cases)) if args.cases else None
+    outcomes = run_selection_eval(cases)
+    print(format_report(outcomes))
+    return 0 if all(o.passed for o in outcomes) else 1
+
+
+def _run_efficacy(args) -> int:
+    if not args.corpus:
+        sys.stderr.write("raptor-strategy-eval: --efficacy requires --corpus DIR\n")
+        return 1
+    from packages.strategy_eval.efficacy import (
+        default_completer,
+        format_report,
+        load_corpus,
+        run_efficacy_eval,
+    )
+
+    samples = load_corpus(Path(args.corpus))
+    if not samples:
+        sys.stderr.write(f"raptor-strategy-eval: no samples in {args.corpus}\n")
+        return 1
+    sys.stderr.write(
+        f"raptor-strategy-eval: efficacy mode makes LIVE LLM calls "
+        f"({len(samples)} samples x 2 arms x {args.runs} runs). Ctrl-C to abort.\n"
+    )
+    results = run_efficacy_eval(samples, default_completer(), runs=args.runs)
+    print(format_report(results))
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        prog="raptor-strategy-eval",
+        description="Evaluate the cwe_strategies bug-class lenses.",
+    )
+    p.add_argument(
+        "--efficacy", action="store_true",
+        help="run the offline A/B efficacy eval (LIVE LLM) instead of "
+             "the default deterministic selection eval",
+    )
+    p.add_argument("--cases", default="",
+                   help="selection mode: path to a cases YAML "
+                        "(default: bundled selection_cases.yml)")
+    p.add_argument("--corpus", default="",
+                   help="efficacy mode: path to a labeled corpus dir")
+    p.add_argument("--runs", type=int, default=3,
+                   help="efficacy mode: A/B repetitions per sample "
+                        "(default 3)")
+    args = p.parse_args()
+
+    try:
+        if args.efficacy:
+            return _run_efficacy(args)
+        return _run_selection(args)
+    except ImportError as e:
+        sys.stderr.write(f"raptor-strategy-eval: substrate unavailable: {e}\n")
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/code_understanding/tests/dispatch/test_hunt_strategy_wiring.py
+++ b/packages/code_understanding/tests/dispatch/test_hunt_strategy_wiring.py
@@ -250,3 +250,19 @@ class TestStrategyBlockDirect:
         # intentional.
         block = _build_hunt_strategy_block("")
         assert "## Strategy: general" in block
+
+
+# ---------------------------------------------------------------------------
+# lifecycle_drift reaches the hunt prompt (no CWE pin — keyword only)
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycleDriftReaches:
+    def test_dumpable_pattern_pins_lifecycle_drift(self):
+        # lifecycle_drift has no CWE signal; the ``dumpable`` token in
+        # ``get_dumpable`` is what pins it, exemplar and all.
+        block = _build_hunt_strategy_block(
+            "get_dumpable trusted for tasks without an mm",
+        )
+        assert "## Strategy: lifecycle_drift" in block
+        assert "CVE-2026-46333" in block  # lifecycle_drift exemplar

--- a/packages/code_understanding/tests/dispatch/test_trace_strategy_wiring.py
+++ b/packages/code_understanding/tests/dispatch/test_trace_strategy_wiring.py
@@ -258,3 +258,22 @@ class TestStrategyBlockDirect:
             {"trace_id": "T1", "entry": "parse_input", "sink": "exec"},
         ])
         assert "## Strategy: input_handling" in block
+
+
+# ---------------------------------------------------------------------------
+# lifecycle_drift reaches the trace prompt (no CWE pin — step callee only)
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycleDriftReaches:
+    def test_get_dumpable_step_pins_lifecycle_drift(self):
+        # A trace step calling get_dumpable() surfaces the ``dumpable``
+        # token in the serialised trace, pinning lifecycle_drift.
+        traces = [{
+            "trace_id": "T1",
+            "entry": "__ptrace_may_access",
+            "steps": [{"function": "get_dumpable"}],
+        }]
+        block = _build_strategy_block(traces)
+        assert "## Strategy: lifecycle_drift" in block
+        assert "CVE-2026-46333" in block  # lifecycle_drift exemplar

--- a/packages/llm_analysis/tests/test_iris_strategy_wiring.py
+++ b/packages/llm_analysis/tests/test_iris_strategy_wiring.py
@@ -210,3 +210,21 @@ class TestStrategyBlockDirect:
             finding=finding,
         )
         assert "## Strategy: concurrency" in block
+
+
+# ---------------------------------------------------------------------------
+# lifecycle_drift reaches the validator context (no CWE pin — callee only)
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycleDriftReaches:
+    def test_get_dumpable_callee_pins_lifecycle_drift(self):
+        # No CWE; the get_dumpable() callee + kernel/ptrace.c path pin
+        # lifecycle_drift into the validator's trusted context.
+        block = _build_strategy_block(
+            cwe="", file_path="kernel/ptrace.c",
+            function="__ptrace_may_access",
+            finding={"metadata": {"calls": ["get_dumpable"]}},
+        )
+        assert "## Strategy: lifecycle_drift" in block
+        assert "CVE-2026-46333" in block  # lifecycle_drift exemplar

--- a/packages/llm_analysis/tests/test_strategy_in_analysis_prompt.py
+++ b/packages/llm_analysis/tests/test_strategy_in_analysis_prompt.py
@@ -250,3 +250,69 @@ class TestStrategyInSystemPrompt:
         assert "Bug-class lenses" in sys
         # NOT in the user message (which carries untrusted content).
         assert "Bug-class lenses" not in user
+
+
+# ---------------------------------------------------------------------------
+# lifecycle_drift end-to-end: dumpability signals reach the live prompt,
+# and the deliberately-narrow signals do NOT over-fire on unrelated code.
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycleDriftReachesPrompt:
+    def test_get_dumpable_call_selects_lifecycle_drift(self):
+        """A function calling get_dumpable() pulls the lifecycle_drift
+        lens into the system prompt — exemplar and all. This is the full
+        chain: signal -> picker -> render -> system message."""
+        bundle = build_analysis_prompt_bundle(
+            rule_id="x", level="warning",
+            file_path="kernel/ptrace.c",
+            start_line=1, end_line=40,
+            message="access check",
+            function_name="__ptrace_may_access",
+            function_calls_made=["get_dumpable"],
+        )
+        sys = _system_message(bundle)
+        assert "## Strategy: lifecycle_drift" in sys
+        # The worked exemplar — the actual content the LLM reads.
+        assert "CVE-2026-46333" in sys
+
+    def test_dumpable_keyword_selects_lifecycle_drift(self):
+        bundle = build_analysis_prompt_bundle(
+            rule_id="x", level="warning",
+            file_path="src/foo.c",
+            start_line=1, end_line=10,
+            message="m",
+            function_name="check_dumpable",
+        )
+        sys = _system_message(bundle)
+        assert "## Strategy: lifecycle_drift" in sys
+
+    def test_does_not_overfire_on_unrelated_finding(self):
+        """Regression guard for the over-trigger risk flagged in review:
+        with the broad ptrace/cred paths and the commit_creds magnet
+        removed, a plain command-injection finding must NOT drag in
+        lifecycle_drift."""
+        bundle = build_analysis_prompt_bundle(
+            rule_id="py/command-injection", level="warning",
+            file_path="src/runner.py",
+            start_line=10, end_line=15,
+            message="subprocess.call with user input",
+            cwe_id="CWE-78",
+        )
+        sys = _system_message(bundle)
+        assert "## Strategy: lifecycle_drift" not in sys
+
+    def test_cwe_863_does_not_collide_with_auth_privilege(self):
+        """lifecycle_drift dropped CWE-863 to avoid colliding with
+        auth_privilege. A bare CWE-863 finding (no dumpability signals)
+        selects auth_privilege, not lifecycle_drift."""
+        bundle = build_analysis_prompt_bundle(
+            rule_id="x", level="warning",
+            file_path="src/foo.c",
+            start_line=1, end_line=10,
+            message="authorization check",
+            cwe_id="CWE-863",
+        )
+        sys = _system_message(bundle)
+        assert "## Strategy: auth_privilege" in sys
+        assert "## Strategy: lifecycle_drift" not in sys

--- a/packages/strategy_eval/__init__.py
+++ b/packages/strategy_eval/__init__.py
@@ -1,0 +1,16 @@
+"""Evaluation harness for the cwe_strategies bug-class lenses.
+
+Two evals, deliberately separate because they answer different questions
+and cost wildly different amounts:
+
+  * **selection** (deterministic, no LLM, CI-able) — does the picker route
+    the right strategy for a labeled set of signal cases, and refrain from
+    firing where it shouldn't? Measures the ROUTING layer only.
+
+  * **efficacy** (offline, live LLM) — does injecting a strategy's guidance
+    actually improve the model's findings on labeled code? A/B per sample
+    (strategy on vs off). Needs a labeled corpus and an LLM; not CI.
+
+See ``selection.py`` / ``efficacy.py``. Driven by
+``libexec/raptor-strategy-eval``.
+"""

--- a/packages/strategy_eval/data/seed_corpus/manifest.yml
+++ b/packages/strategy_eval/data/seed_corpus/manifest.yml
@@ -1,0 +1,22 @@
+# Synthetic seed corpus for the efficacy eval.
+#
+# These are hand-written MINIMAL REPROS of each bug-class shape, NOT
+# extracted real-world source. They measure whether a lens helps the
+# model spot the bug-class pattern in isolation; they are not a
+# substitute for a real corpus and may show a ceiling effect (the bug is
+# obvious enough that the model finds it with or without the lens). Drop
+# real vulnerable/patched samples in the same format (id / strategy /
+# file / variant) for a higher-fidelity run.
+#
+# Partial coverage by design: four bug classes with a vulnerable +
+# patched pair each. Extend with more classes / real source as needed.
+
+samples:
+  - {id: lifecycle_drift_vuln,    strategy: lifecycle_drift,    file: samples/lifecycle_drift_vuln.c,    variant: vulnerable, synthetic: true}
+  - {id: lifecycle_drift_patched, strategy: lifecycle_drift,    file: samples/lifecycle_drift_patched.c, variant: patched,    synthetic: true}
+  - {id: input_handling_vuln,     strategy: input_handling,     file: samples/input_handling_vuln.c,     variant: vulnerable, synthetic: true}
+  - {id: input_handling_patched,  strategy: input_handling,     file: samples/input_handling_patched.c,  variant: patched,    synthetic: true}
+  - {id: memory_management_vuln,    strategy: memory_management, file: samples/memory_management_vuln.c,    variant: vulnerable, synthetic: true}
+  - {id: memory_management_patched, strategy: memory_management, file: samples/memory_management_patched.c, variant: patched,    synthetic: true}
+  - {id: concurrency_vuln,        strategy: concurrency,        file: samples/concurrency_vuln.c,        variant: vulnerable, synthetic: true}
+  - {id: concurrency_patched,     strategy: concurrency,        file: samples/concurrency_patched.c,     variant: patched,    synthetic: true}

--- a/packages/strategy_eval/data/seed_corpus/samples/concurrency_patched.c
+++ b/packages/strategy_eval/data/seed_corpus/samples/concurrency_patched.c
@@ -1,0 +1,12 @@
+/* Patched variant: every return path releases the lock. */
+int update(struct obj *o, int val)
+{
+	mutex_lock(&o->lock);
+	if (val < 0) {
+		mutex_unlock(&o->lock);
+		return -EINVAL;
+	}
+	o->val = val;
+	mutex_unlock(&o->lock);
+	return 0;
+}

--- a/packages/strategy_eval/data/seed_corpus/samples/concurrency_vuln.c
+++ b/packages/strategy_eval/data/seed_corpus/samples/concurrency_vuln.c
@@ -1,0 +1,11 @@
+/* Synthetic minimal repro: a lock is leaked on an early-return error
+ * path, leaving the mutex held forever (deadlock for the next acquirer). */
+int update(struct obj *o, int val)
+{
+	mutex_lock(&o->lock);
+	if (val < 0)
+		return -EINVAL;	/* BUG: returns with o->lock still held */
+	o->val = val;
+	mutex_unlock(&o->lock);
+	return 0;
+}

--- a/packages/strategy_eval/data/seed_corpus/samples/input_handling_patched.c
+++ b/packages/strategy_eval/data/seed_corpus/samples/input_handling_patched.c
@@ -1,0 +1,11 @@
+/* Patched variant: the caller-controlled length is validated against the
+ * destination buffer before the copy. */
+void handle(struct packet *p)
+{
+	char buf[64];
+
+	if (p->len > sizeof(buf))
+		return;		/* reject oversized input */
+	memcpy(buf, p->data, p->len);
+	process(buf);
+}

--- a/packages/strategy_eval/data/seed_corpus/samples/input_handling_vuln.c
+++ b/packages/strategy_eval/data/seed_corpus/samples/input_handling_vuln.c
@@ -1,0 +1,11 @@
+/* Synthetic minimal repro: a caller-controlled length is used to size a
+ * copy into a fixed buffer with no bounds check (length-confusion). */
+void handle(struct packet *p)
+{
+	char buf[64];
+
+	/* BUG: p->len is attacker-controlled and never validated against
+	 * sizeof(buf) before the copy — a stack overflow. */
+	memcpy(buf, p->data, p->len);
+	process(buf);
+}

--- a/packages/strategy_eval/data/seed_corpus/samples/lifecycle_drift_patched.c
+++ b/packages/strategy_eval/data/seed_corpus/samples/lifecycle_drift_patched.c
@@ -1,0 +1,11 @@
+/* Patched variant: the precondition is guarded. Dumpability is only
+ * meaningful for a task that owns an mm; mm-less tasks are gated on
+ * CAP_SYS_PTRACE instead of trusting a meaningless flag. */
+int may_access(struct task_struct *task)
+{
+	if (!task->mm)
+		return capable(CAP_SYS_PTRACE) ? 0 : -EPERM;
+	if (get_dumpable(task->mm) == SUID_DUMP_USER)
+		return 0;
+	return -EPERM;
+}

--- a/packages/strategy_eval/data/seed_corpus/samples/lifecycle_drift_vuln.c
+++ b/packages/strategy_eval/data/seed_corpus/samples/lifecycle_drift_vuln.c
@@ -1,0 +1,14 @@
+/* Synthetic minimal repro of the context-drift / lifecycle-invariant
+ * class (cf. CVE-2026-46333, ptrace dumpability). The dumpability flag is
+ * only meaningful for a task that owns an mm; this access check trusts it
+ * unconditionally. */
+int may_access(struct task_struct *task)
+{
+	/* BUG: no `task->mm != NULL` guard. For a kernel thread or an
+	 * exiting task, task->mm is NULL and get_dumpable() returns a
+	 * stale/default value that carries no security meaning — but it is
+	 * consumed here as authoritative, yielding the wrong decision. */
+	if (get_dumpable(task->mm) == SUID_DUMP_USER)
+		return 0;	/* permit trace */
+	return -EPERM;
+}

--- a/packages/strategy_eval/data/seed_corpus/samples/memory_management_patched.c
+++ b/packages/strategy_eval/data/seed_corpus/samples/memory_management_patched.c
@@ -1,0 +1,8 @@
+/* Patched variant: the last use happens before the free, and the pointer
+ * is cleared to prevent a later dangling dereference. */
+void cleanup(struct conn *c)
+{
+	log_bytes(c->buf, c->len);
+	kfree(c->buf);
+	c->buf = NULL;
+}

--- a/packages/strategy_eval/data/seed_corpus/samples/memory_management_vuln.c
+++ b/packages/strategy_eval/data/seed_corpus/samples/memory_management_vuln.c
@@ -1,0 +1,8 @@
+/* Synthetic minimal repro: object is used after it has been freed. */
+void cleanup(struct conn *c)
+{
+	kfree(c->buf);
+	/* BUG: c->buf is dereferenced after the free above (use-after-free).
+	 * c->buf is also left dangling for any later caller. */
+	log_bytes(c->buf, c->len);
+}

--- a/packages/strategy_eval/data/selection_cases.yml
+++ b/packages/strategy_eval/data/selection_cases.yml
@@ -1,0 +1,69 @@
+# Labeled routing cases for the selection eval.
+#
+# Positives reuse triggers already proven in core/llm/cwe_strategies's own
+# tests, so the eval is grounded in known-good signals. Negatives
+# (expect_not_selected) pin that a strategy does NOT fire where it
+# shouldn't — the over-trigger / collision guard.
+#
+# signals: forwarded verbatim to pick_strategies (file_path required).
+
+cases:
+  - name: input_handling via netfilter path
+    signals: {file_path: net/netfilter/nf_tables_api.c, function_name: nft_payload_eval}
+    expect_selected: [input_handling]
+    expect_not_selected: [lifecycle_drift]
+
+  - name: concurrency via locking path
+    signals: {file_path: kernel/locking/rwsem.c, function_name: rwsem_down_read}
+    expect_selected: [concurrency]
+
+  - name: concurrency via mutex include
+    signals: {file_path: src/dev.c, function_name: dev_ioctl, file_includes: [linux/mutex.h]}
+    expect_selected: [concurrency]
+
+  - name: memory_management via refcount keyword
+    signals: {file_path: src/obj.c, function_name: kref_put_obj}
+    expect_selected: [memory_management]
+
+  - name: auth_privilege via commoncap path
+    signals: {file_path: security/commoncap.c, function_name: cap_capable}
+    expect_selected: [auth_privilege]
+
+  - name: cryptography via crypto path
+    signals: {file_path: crypto/aes_generic.c, function_name: aes_encrypt}
+    expect_selected: [cryptography]
+
+  - name: memory_aliasing via splice path
+    signals: {file_path: fs/splice.c, function_name: splice_to_pipe}
+    expect_selected: [memory_aliasing]
+
+  - name: lifecycle_drift via get_dumpable callee
+    signals:
+      file_path: kernel/ptrace.c
+      function_name: __ptrace_may_access
+      function_calls_made: [get_dumpable]
+    expect_selected: [lifecycle_drift]
+    # De-collision: it routes via the bespoke callee, not a shared CWE tag.
+    expect_not_selected: [auth_privilege]
+
+  - name: lifecycle_drift via dumpable keyword
+    signals: {file_path: src/foo.c, function_name: check_dumpable}
+    expect_selected: [lifecycle_drift]
+
+  # --- over-trigger / collision negatives ---
+
+  - name: command-injection routes input_handling, not lifecycle_drift
+    signals: {file_path: src/runner.py, function_name: run_cmd, candidate_cwes: [CWE-78]}
+    expect_selected: [input_handling]
+    expect_not_selected: [lifecycle_drift]
+
+  - name: CWE-863 routes auth_privilege, not lifecycle_drift
+    signals: {file_path: src/authz.c, function_name: do_check, candidate_cwes: [CWE-863]}
+    expect_selected: [auth_privilege]
+    expect_not_selected: [lifecycle_drift]
+
+  # --- always-on fallback ---
+
+  - name: general always present on a signal-less target
+    signals: {file_path: data/blob.bin, function_name: opaque}
+    expect_selected: [general]

--- a/packages/strategy_eval/efficacy.py
+++ b/packages/strategy_eval/efficacy.py
@@ -1,0 +1,186 @@
+"""Offline A/B efficacy eval for cwe_strategies.
+
+Question: does injecting a strategy's guidance actually improve the
+model's findings? For each labeled sample we run an otherwise-identical
+review prompt twice:
+
+  * control   — review instructions + the always-on ``general`` lens
+  * treatment — same + the target strategy's lens
+
+so the target lens is the ONLY variable (``general`` is present in both
+because it is always pinned in production). On a ``vulnerable`` sample,
+a VULNERABLE verdict is a hit; on a ``patched`` sample it is a false
+positive. Lift = treatment hit-rate − control hit-rate.
+
+This needs a live LLM and is nondeterministic, so it is an on-demand
+tool, never a CI gate. The LLM call is injected (``complete``) so the
+harness logic is unit-tested with a fake. Results are only as meaningful
+as the corpus: a synthetic seed measures whether the lens helps on the
+bug-class *shape*, not on real-world code.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Callable, Dict, List
+
+import yaml
+
+from core.llm.cwe_strategies import load_all, render_strategies
+
+from .models import ABResult, EfficacySample
+
+# complete(system_prompt, user_prompt) -> model reply text
+Completer = Callable[[str, str], str]
+
+_REVIEW_INSTRUCTIONS = (
+    "You are a security code reviewer. Review the function in the user "
+    "message for security vulnerabilities. Reason briefly, then end your "
+    "reply with EXACTLY one line:\n"
+    "  VERDICT: VULNERABLE   (the function contains a security bug)\n"
+    "  VERDICT: SAFE         (it does not)\n"
+)
+
+_VERDICT_RE = re.compile(r"VERDICT:\s*VULNERABLE", re.IGNORECASE)
+
+
+def grade(reply: str) -> bool:
+    """True iff the model returned a VULNERABLE verdict."""
+    return bool(_VERDICT_RE.search(reply or ""))
+
+
+def _strategies_by_name() -> Dict[str, object]:
+    return {s.name: s for s in load_all()}
+
+
+def build_prompts(sample: EfficacySample) -> "tuple[str, str, str]":
+    """Return (control_system, treatment_system, user_prompt).
+
+    The two system prompts differ ONLY by the target lens, so any verdict
+    difference is attributable to it.
+    """
+    by_name = _strategies_by_name()
+    general = by_name.get("general")
+    lens = by_name.get(sample.strategy)
+    if lens is None:
+        raise KeyError(f"unknown strategy {sample.strategy!r} for sample {sample.id}")
+
+    baseline = [general] if general is not None else []
+    control_system = _REVIEW_INSTRUCTIONS + "\n\n" + render_strategies(baseline)
+    # If the target IS general, treatment == control (no delta).
+    treat_lenses = baseline if lens is general else baseline + [lens]
+    treatment_system = _REVIEW_INSTRUCTIONS + "\n\n" + render_strategies(treat_lenses)
+    return control_system, treatment_system, sample.code
+
+
+def run_ab(sample: EfficacySample, complete: Completer, runs: int = 3) -> ABResult:
+    control_system, treatment_system, user = build_prompts(sample)
+    control_flagged = sum(
+        1 for _ in range(runs) if grade(complete(control_system, user))
+    )
+    treatment_flagged = sum(
+        1 for _ in range(runs) if grade(complete(treatment_system, user))
+    )
+    return ABResult(
+        sample_id=sample.id,
+        strategy=sample.strategy,
+        variant=sample.variant,
+        runs=runs,
+        control_flagged=control_flagged,
+        treatment_flagged=treatment_flagged,
+    )
+
+
+def run_efficacy_eval(
+    samples: List[EfficacySample], complete: Completer, runs: int = 3,
+) -> List[ABResult]:
+    return [run_ab(s, complete, runs) for s in samples]
+
+
+# ---------------------------------------------------------------------------
+# Corpus loading
+# ---------------------------------------------------------------------------
+
+
+def load_corpus(corpus_dir: Path) -> List[EfficacySample]:
+    """Load a labeled corpus: a ``manifest.yml`` listing samples, each with
+    ``id``, ``strategy``, ``file`` (relative path to the source), ``variant``
+    and optional ``synthetic``. Real samples drop in via the same format.
+    """
+    corpus_dir = Path(corpus_dir)
+    manifest = yaml.safe_load((corpus_dir / "manifest.yml").read_text("utf-8")) or {}
+    samples: List[EfficacySample] = []
+    for raw in manifest.get("samples", []):
+        code = (corpus_dir / raw["file"]).read_text(encoding="utf-8")
+        samples.append(
+            EfficacySample(
+                id=raw["id"],
+                strategy=raw["strategy"],
+                code=code,
+                variant=raw["variant"],
+                synthetic=bool(raw.get("synthetic", False)),
+            )
+        )
+    return samples
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def format_report(results: List[ABResult]) -> str:
+    # Aggregate per strategy × variant: total runs and flagged counts.
+    agg: Dict[tuple, List[int]] = defaultdict(lambda: [0, 0, 0])  # runs, ctrl, treat
+    for r in results:
+        slot = agg[(r.strategy, r.variant)]
+        slot[0] += r.runs
+        slot[1] += r.control_flagged
+        slot[2] += r.treatment_flagged
+
+    lines = ["Efficacy eval (A/B: baseline vs baseline+lens) — live LLM", ""]
+    strategies = sorted({s for (s, _v) in agg})
+    for strat in strategies:
+        lines.append(f"{strat}:")
+        for variant in ("vulnerable", "patched"):
+            slot = agg.get((strat, variant))
+            if not slot:
+                continue
+            runs, ctrl, treat = slot
+            c_rate = ctrl / runs if runs else 0.0
+            t_rate = treat / runs if runs else 0.0
+            if variant == "vulnerable":
+                lines.append(
+                    f"  vulnerable  detection  control {c_rate*100:5.1f}%  "
+                    f"treatment {t_rate*100:5.1f}%  lift {(t_rate-c_rate)*100:+5.1f}%"
+                )
+            else:
+                lines.append(
+                    f"  patched     false-pos  control {c_rate*100:5.1f}%  "
+                    f"treatment {t_rate*100:5.1f}%  delta {(t_rate-c_rate)*100:+5.1f}%"
+                )
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+# ---------------------------------------------------------------------------
+# Default live completer (lazily wires the real LLM client)
+# ---------------------------------------------------------------------------
+
+
+def default_completer() -> Completer:
+    """Wire a Completer onto the real LLM client. Imported lazily so the
+    harness (and its tests) don't require the client unless a live run is
+    actually requested."""
+    from core.llm.client import LLMClient
+
+    client = LLMClient()
+
+    def _complete(system_prompt: str, user_prompt: str) -> str:
+        resp = client.generate(user_prompt, system_prompt=system_prompt)
+        text = getattr(resp, "content", None)
+        return text if text is not None else str(resp)
+
+    return _complete

--- a/packages/strategy_eval/models.py
+++ b/packages/strategy_eval/models.py
@@ -35,3 +35,36 @@ class SelectionOutcome:
     @property
     def passed(self) -> bool:
         return not self.missing and not self.overfired
+
+
+@dataclass(frozen=True)
+class EfficacySample:
+    """One labeled code sample for the A/B efficacy eval.
+
+    ``variant`` is ``"vulnerable"`` or ``"patched"``. ``strategy`` is the
+    lens whose marginal contribution this sample tests. ``synthetic``
+    flags hand-written minimal repros vs. real extracted source.
+    """
+
+    id: str
+    strategy: str
+    code: str
+    variant: str
+    synthetic: bool = False
+
+
+@dataclass(frozen=True)
+class ABResult:
+    """A/B outcome for one sample over ``runs`` repetitions.
+
+    ``*_flagged`` count how many runs the model returned a VULNERABLE
+    verdict under each arm (control = baseline lens only; treatment =
+    baseline + the target lens).
+    """
+
+    sample_id: str
+    strategy: str
+    variant: str
+    runs: int
+    control_flagged: int
+    treatment_flagged: int

--- a/packages/strategy_eval/models.py
+++ b/packages/strategy_eval/models.py
@@ -1,0 +1,37 @@
+"""Dataclasses shared by the selection and efficacy evals."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Tuple
+
+
+@dataclass(frozen=True)
+class SelectionCase:
+    """A labeled routing case: picker signals in, expected outcome out.
+
+    ``signals`` is a kwargs dict forwarded verbatim to ``pick_strategies``
+    (``file_path`` is required; ``function_name`` / ``file_includes`` /
+    ``function_calls_made`` / ``candidate_cwes`` / ``max_strategies`` are
+    optional). ``expect_selected`` names must appear in the picked set;
+    ``expect_not_selected`` names must not (the over-trigger guard).
+    """
+
+    name: str
+    signals: Dict[str, Any]
+    expect_selected: Tuple[str, ...] = ()
+    expect_not_selected: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SelectionOutcome:
+    """Result of running one SelectionCase through the picker."""
+
+    case: SelectionCase
+    picked: Tuple[str, ...]
+    missing: Tuple[str, ...]     # expect_selected names absent from picked
+    overfired: Tuple[str, ...]   # expect_not_selected names present in picked
+
+    @property
+    def passed(self) -> bool:
+        return not self.missing and not self.overfired

--- a/packages/strategy_eval/selection.py
+++ b/packages/strategy_eval/selection.py
@@ -1,0 +1,102 @@
+"""Deterministic selection eval for cwe_strategies.
+
+Runs the picker over a labeled set of signal cases and checks the right
+strategy is routed (and the wrong ones are not). No LLM — fast, repeatable,
+CI-able. This measures the ROUTING layer only: it proves the right lens is
+chosen for a given function shape, NOT that the lens helps the model (that
+is the efficacy eval).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
+
+from core.llm.cwe_strategies import load_all, pick_strategies
+
+from .models import SelectionCase, SelectionOutcome
+
+
+def default_cases_path() -> Path:
+    return Path(__file__).resolve().parent / "data" / "selection_cases.yml"
+
+
+def load_cases(path: Optional[Path] = None) -> List[SelectionCase]:
+    path = Path(path) if path is not None else default_cases_path()
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    cases: List[SelectionCase] = []
+    for raw in data.get("cases", []):
+        cases.append(
+            SelectionCase(
+                name=raw["name"],
+                signals=dict(raw.get("signals", {})),
+                expect_selected=tuple(raw.get("expect_selected", ())),
+                expect_not_selected=tuple(raw.get("expect_not_selected", ())),
+            )
+        )
+    return cases
+
+
+def run_case(case: SelectionCase) -> SelectionOutcome:
+    picked = tuple(s.name for s in pick_strategies(**case.signals))
+    missing = tuple(n for n in case.expect_selected if n not in picked)
+    overfired = tuple(n for n in case.expect_not_selected if n in picked)
+    return SelectionOutcome(
+        case=case, picked=picked, missing=missing, overfired=overfired,
+    )
+
+
+def run_selection_eval(
+    cases: Optional[List[SelectionCase]] = None,
+) -> List[SelectionOutcome]:
+    cases = cases if cases is not None else load_cases()
+    return [run_case(c) for c in cases]
+
+
+def per_strategy_recall(outcomes: List[SelectionOutcome]) -> Dict[str, float]:
+    """For each strategy named in any ``expect_selected``, the fraction of
+    its positive cases where it was actually selected."""
+    hits: Dict[str, int] = defaultdict(int)
+    total: Dict[str, int] = defaultdict(int)
+    for o in outcomes:
+        for name in o.case.expect_selected:
+            total[name] += 1
+            if name not in o.missing:
+                hits[name] += 1
+    return {name: hits[name] / total[name] for name in sorted(total)}
+
+
+def format_report(outcomes: List[SelectionOutcome]) -> str:
+    passed = [o for o in outcomes if o.passed]
+    failed = [o for o in outcomes if not o.passed]
+    lines = [
+        "Selection eval (routing) — deterministic, no LLM",
+        f"  cases: {len(outcomes)}   passed: {len(passed)}   failed: {len(failed)}",
+        "",
+        "Per-strategy routing recall:",
+    ]
+    for name, recall in per_strategy_recall(outcomes).items():
+        lines.append(f"  {name:18s} {recall * 100:5.1f}%")
+    if failed:
+        lines.append("")
+        lines.append("Failures:")
+        for o in failed:
+            lines.append(
+                f"  {o.case.name}\n"
+                f"    picked      = {list(o.picked)}\n"
+                f"    missing     = {list(o.missing)}\n"
+                f"    overfired   = {list(o.overfired)}"
+            )
+    return "\n".join(lines)
+
+
+def uncovered_strategies(outcomes: List[SelectionOutcome]) -> List[str]:
+    """Bundled strategies with no positive selection case — the eval would
+    silently stop covering them."""
+    covered = set()
+    for o in outcomes:
+        covered.update(o.case.expect_selected)
+    return sorted({s.name for s in load_all()} - covered)

--- a/packages/strategy_eval/tests/test_efficacy.py
+++ b/packages/strategy_eval/tests/test_efficacy.py
@@ -1,0 +1,114 @@
+"""Unit tests for the efficacy harness — no live LLM.
+
+The LLM call is injected, so a fake Completer lets us test the A/B logic,
+prompt isolation, grading, and corpus loading deterministically.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+from packages.strategy_eval.efficacy import (
+    build_prompts,
+    format_report,
+    grade,
+    load_corpus,
+    run_ab,
+    run_efficacy_eval,
+)
+from packages.strategy_eval.models import EfficacySample
+
+
+def _sample(variant: str = "vulnerable") -> EfficacySample:
+    return EfficacySample(
+        id=f"ld_{variant}",
+        strategy="lifecycle_drift",
+        code="int may_access(struct task *t){ return get_dumpable(t->mm); }",
+        variant=variant,
+        synthetic=True,
+    )
+
+
+# --- grading ---------------------------------------------------------------
+
+
+def test_grade_parses_verdict():
+    assert grade("reasoning...\nVERDICT: VULNERABLE")
+    assert grade("VERDICT: vulnerable")  # case-insensitive
+    assert not grade("looks fine\nVERDICT: SAFE")
+    assert not grade("")
+
+
+# --- prompt isolation ------------------------------------------------------
+
+
+def test_build_prompts_isolates_the_lens():
+    control, treatment, user = build_prompts(_sample())
+    # The target lens's exemplar appears ONLY in treatment.
+    assert "CVE-2026-46333" not in control
+    assert "CVE-2026-46333" in treatment
+    # Both carry the always-on baseline + the review contract.
+    assert "## Strategy: general" in control
+    assert "## Strategy: general" in treatment
+    assert "VERDICT:" in control and "VERDICT:" in treatment
+    # User prompt is the code under review.
+    assert "get_dumpable" in user
+
+
+# --- A/B lift --------------------------------------------------------------
+
+
+def _lens_helps(system_prompt: str, user_prompt: str) -> str:
+    """Fake model: flags the bug only when the lifecycle_drift lens is
+    present (i.e. only under treatment). Simulates a genuinely-helpful
+    lens so we can assert the harness measures the lift."""
+    return (
+        "VERDICT: VULNERABLE"
+        if "CVE-2026-46333" in system_prompt
+        else "VERDICT: SAFE"
+    )
+
+
+def test_run_ab_measures_lift_on_vulnerable_sample():
+    r = run_ab(_sample("vulnerable"), _lens_helps, runs=4)
+    assert r.runs == 4
+    assert r.control_flagged == 0      # baseline misses it
+    assert r.treatment_flagged == 4    # the lens catches it every run
+
+
+def test_run_ab_no_false_positive_when_model_says_safe():
+    always_safe = lambda s, u: "VERDICT: SAFE"  # noqa: E731
+    r = run_ab(_sample("patched"), always_safe, runs=3)
+    assert r.control_flagged == 0 and r.treatment_flagged == 0
+
+
+def test_format_report_renders_lift_and_fp_lines():
+    results = run_efficacy_eval(
+        [_sample("vulnerable"), _sample("patched")], _lens_helps, runs=2,
+    )
+    report = format_report(results)
+    assert "lifecycle_drift:" in report
+    assert "vulnerable" in report and "lift" in report
+    assert "patched" in report and "false-pos" in report
+
+
+# --- corpus loading --------------------------------------------------------
+
+
+def test_load_corpus_reads_manifest_and_code(tmp_path):
+    (tmp_path / "samples").mkdir()
+    (tmp_path / "samples" / "vuln.c").write_text("int f(){return get_dumpable(0);}")
+    (tmp_path / "manifest.yml").write_text(textwrap.dedent("""
+        samples:
+          - id: ld_vuln
+            strategy: lifecycle_drift
+            file: samples/vuln.c
+            variant: vulnerable
+            synthetic: true
+    """))
+    samples = load_corpus(tmp_path)
+    assert len(samples) == 1
+    s = samples[0]
+    assert s.id == "ld_vuln" and s.strategy == "lifecycle_drift"
+    assert s.variant == "vulnerable" and s.synthetic is True
+    assert "get_dumpable" in s.code

--- a/packages/strategy_eval/tests/test_libexec_shim.py
+++ b/packages/strategy_eval/tests/test_libexec_shim.py
@@ -1,0 +1,59 @@
+"""Tests for ``libexec/raptor-strategy-eval``.
+
+Drives the shim as a subprocess. Only the deterministic paths are
+exercised — selection mode and argument handling; efficacy mode makes
+live LLM calls and is never run in CI.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# parents[3] = packages/strategy_eval/tests -> strategy_eval -> packages -> repo root.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SHIM = REPO_ROOT / "libexec" / "raptor-strategy-eval"
+
+
+def _run(*args, env_extra=None):
+    env = dict(os.environ)
+    env["_RAPTOR_TRUSTED"] = "1"
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(SHIM), *args],
+        env=env, capture_output=True, text=True,
+    )
+
+
+class TestTrustMarker:
+    def test_refuses_without_marker(self):
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("_RAPTOR_TRUSTED", "CLAUDECODE")}
+        r = subprocess.run(
+            [sys.executable, str(SHIM)],
+            env=env, capture_output=True, text=True,
+        )
+        assert r.returncode == 2
+        assert "internal dispatch" in r.stderr
+
+
+class TestSelectionMode:
+    def test_default_is_selection_and_passes(self):
+        r = _run()
+        assert r.returncode == 0, r.stderr
+        assert "Selection eval (routing)" in r.stdout
+        # All 8 strategies appear in the recall table.
+        assert "lifecycle_drift" in r.stdout
+        assert "failed: 0" in r.stdout
+
+
+class TestEfficacyArgs:
+    def test_efficacy_without_corpus_errors(self):
+        # Deterministic: no LLM call is reached because the missing
+        # --corpus is rejected first.
+        r = _run("--efficacy")
+        assert r.returncode == 1
+        assert "requires --corpus" in r.stderr

--- a/packages/strategy_eval/tests/test_seed_corpus.py
+++ b/packages/strategy_eval/tests/test_seed_corpus.py
@@ -1,0 +1,45 @@
+"""Validate the bundled synthetic seed corpus — no LLM.
+
+Proves the seed is well-formed: it loads, every named strategy resolves
+and renders into a treatment prompt, the lens is isolated to treatment,
+and every covered strategy has both a vulnerable and a patched variant
+(so the A/B is meaningful).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+from packages.strategy_eval.efficacy import build_prompts, load_corpus
+
+_SEED = Path(__file__).resolve().parents[1] / "data" / "seed_corpus"
+
+
+def test_seed_corpus_loads():
+    samples = load_corpus(_SEED)
+    assert samples, "seed corpus is empty"
+    assert all(s.synthetic for s in samples), "seed samples must be flagged synthetic"
+
+
+def test_every_seed_strategy_has_both_variants():
+    variants = defaultdict(set)
+    for s in load_corpus(_SEED):
+        variants[s.strategy].add(s.variant)
+    for strategy, seen in variants.items():
+        assert seen == {"vulnerable", "patched"}, (
+            f"{strategy} seed needs both variants, has {sorted(seen)}"
+        )
+
+
+def test_prompts_build_and_isolate_lens_for_every_sample():
+    for s in load_corpus(_SEED):
+        control, treatment, user = build_prompts(s)
+        assert user == s.code
+        # Review contract present in both arms.
+        assert "VERDICT:" in control and "VERDICT:" in treatment
+        # The target lens is named only in the treatment arm's header.
+        header = f"## Strategy: {s.strategy}"
+        assert header in treatment, f"{s.id}: lens not in treatment"
+        if s.strategy != "general":
+            assert header not in control, f"{s.id}: lens leaked into control"

--- a/packages/strategy_eval/tests/test_selection.py
+++ b/packages/strategy_eval/tests/test_selection.py
@@ -1,0 +1,42 @@
+"""CI gate for the selection eval.
+
+Every labeled positive must route to its strategy, no labeled negative
+may over-fire, and every bundled strategy must have at least one positive
+case so the eval can't silently stop covering one.
+"""
+
+from __future__ import annotations
+
+from packages.strategy_eval.selection import (
+    load_cases,
+    run_selection_eval,
+    uncovered_strategies,
+)
+
+
+def test_all_selection_cases_route_correctly():
+    outcomes = run_selection_eval()
+    failures = [o for o in outcomes if not o.passed]
+    detail = "\n".join(
+        f"  {o.case.name}: missing={list(o.missing)} "
+        f"overfired={list(o.overfired)} picked={list(o.picked)}"
+        for o in failures
+    )
+    assert not failures, f"selection routing regressions:\n{detail}"
+
+
+def test_every_strategy_has_a_positive_case():
+    outcomes = run_selection_eval()
+    missing = uncovered_strategies(outcomes)
+    assert not missing, (
+        f"strategies with no positive selection case (eval would stop "
+        f"covering them): {missing}"
+    )
+
+
+def test_cases_load():
+    cases = load_cases()
+    assert cases, "no selection cases loaded"
+    # Every case must carry a file_path (picker requires it).
+    for c in cases:
+        assert "file_path" in c.signals, f"{c.name}: missing file_path signal"


### PR DESCRIPTION
Two related pieces. 

First, an 8th cwe_strategy, lifecycle_drift, for the context-drift / lifecycle-invariant bug class (a value set under a precondition, read where it no longer holds; exemplar CVE-2026-46333, ptrace dumpability). It went through two adversarial-review rounds — de-noised to a precise, low-false-positive lens on the kernel ptrace/mm-dumpability surface, de-collided from auth_privilege, and honestly scoped. E2E tests pin that it reaches all four cwe_strategies consumers (/agentic analysis, /understand --hunt/--trace, IRIS dataflow). 

Second, packages/strategy_eval/ + libexec/raptor-strategy-eval — a reusable harness that evaluates all strategies: selection (default, deterministic, CI-able): does the picker route the right lens and not over-fire? 100% recall over labeled cases + over-trigger/collision guards. efficacy (offline, live LLM): per-sample A/B (baseline vs baseline+lens), reporting detection lift / FP delta. LLM call injected so the logic is unit-tested with a fake; a synthetic seed corpus makes it runnable day one. 

Honest about limits: efficacy is never a CI gate (live/paid/non-deterministic) and is only as good as the corpus. 

A seed smoke-run (gemini-2.5-pro) confirmed the harness end-to-end — detection hit a ceiling on the obvious synthetic bugs, but the lenses showed a directional false-positive-reduction effect (lifecycle_drift included). A real-corpus run for a trustworthy verdict is left as a follow-up.