### PR TITLE
Enhance reachability analysis with config-aware prefiltering

### DIFF
--- a/core/build/macro_config.py
+++ b/core/build/macro_config.py
@@ -1,0 +1,221 @@
+"""Extract a *macro definition config* — the preprocessor symbols a build is
+known to define or leave undefined — for config-aware ``#ifdef`` resolution.
+
+This is deliberately an ALLOWLIST, not a guess. A symbol is reported as
+known-defined or known-undefined ONLY when a build artifact says so
+explicitly:
+
+  * ``compile_commands.json`` — ``-DNAME[=val]`` (defined) / ``-UNAME``
+    (undefined), unioned across translation units. A symbol that is BOTH
+    defined and undefined across entries is config-dependent project-wide,
+    so it is dropped (left unknown).
+  * ``.config`` (kernel Kconfig) — ``CONFIG_X=y|m`` (defined to "1") /
+    ``# CONFIG_X is not set`` (undefined). Applies to ``CONFIG_*`` only.
+
+Everything not explicitly named stays UNKNOWN. This is the load-bearing
+soundness property: a symbol absent from the config might still be
+``#define``d in an included header, so "absent" must never be read as
+"undefined" — doing so would delete code that is live in the real build
+(a false negative). The config-aware dead-arm detector only fires on KNOWN
+symbols, so it can never over-fire relative to the real build.
+
+Never raises on missing / malformed artifacts: returns an empty
+``MacroConfig`` (``source='absent'``), which makes the detector degrade
+to literal-only (``#if 0``) behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import shlex
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MacroConfig:
+    """Known-defined / known-undefined preprocessor symbols for one build.
+
+    ``defined`` maps name → value string (``"1"`` for a bare ``-DNAME``).
+    ``undefined`` is the set of explicitly-undefined names. A name in
+    neither is UNKNOWN — callers must treat unknown as config-dependent
+    and leave the arm untouched.
+    """
+
+    defined: Dict[str, str] = field(default_factory=dict)
+    undefined: frozenset = field(default_factory=frozenset)
+    source: str = "absent"
+
+    def __bool__(self) -> bool:
+        return bool(self.defined or self.undefined)
+
+    def is_defined(self, name: str) -> Optional[bool]:
+        """``True`` known-defined, ``False`` known-undefined, ``None``
+        unknown (config-dependent / possibly header-defined)."""
+        if name in self.defined:
+            return True
+        if name in self.undefined:
+            return False
+        return None
+
+    def value_of(self, name: str) -> Optional[str]:
+        """Macro value if known-defined, else ``None``."""
+        return self.defined.get(name)
+
+    def fingerprint(self) -> str:
+        """Deterministic short hash of the config's contents — empty string
+        when the config is empty. Used to fold the config into the inventory
+        cache key so a config change (e.g. a regenerated ``.config``)
+        invalidates cached blanking even when file contents are unchanged."""
+        if not self:
+            return ""
+        import hashlib
+        payload = repr((sorted(self.defined.items()), sorted(self.undefined)))
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+# A -D token: ``-DNAME`` | ``-DNAME=value``. Space-separated ``-D NAME`` is
+# handled by the tokenizer (a lone ``-D`` consumes the next token).
+_D_INLINE = re.compile(r"^-D(\w+)(?:=(.*))?$")
+_U_INLINE = re.compile(r"^-U(\w+)$")
+
+
+def _tokens(entry: dict) -> List[str]:
+    """Command tokens for one compile_commands entry (``arguments`` array
+    preferred; ``command`` string shlex-split)."""
+    if isinstance(entry.get("arguments"), list):
+        return [str(a) for a in entry["arguments"]]
+    cmd = entry.get("command")
+    if isinstance(cmd, str):
+        try:
+            return shlex.split(cmd)
+        except ValueError:
+            return cmd.split()
+    return []
+
+
+def _scan_tokens(tokens: List[str], defined: Dict[str, str],
+                 undefined: set, conflict: set) -> None:
+    """Accumulate -D/-U across one entry into the running union. A name seen
+    both defined and undefined (here or in a prior entry) goes to
+    ``conflict`` and is later dropped — it is config-dependent."""
+    i = 0
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+        name = val = None
+        is_undef = False
+        if tok == "-D" and i + 1 < n:
+            i += 1
+            m = re.match(r"^(\w+)(?:=(.*))?$", tokens[i])
+            if m:
+                name, val = m.group(1), m.group(2)
+        elif tok == "-U" and i + 1 < n:
+            i += 1
+            if re.match(r"^\w+$", tokens[i]):
+                name, is_undef = tokens[i], True
+        else:
+            md = _D_INLINE.match(tok)
+            mu = _U_INLINE.match(tok)
+            if md:
+                name, val = md.group(1), md.group(2)
+            elif mu:
+                name, is_undef = mu.group(1), True
+        if name is not None:
+            if is_undef:
+                if name in defined:
+                    conflict.add(name)
+                undefined.add(name)
+            else:
+                if name in undefined:
+                    conflict.add(name)
+                defined[name] = "1" if val is None or val == "" else val
+        i += 1
+
+
+def _from_compile_commands(path: Path) -> MacroConfig:
+    raw = path.read_text(errors="replace")
+    entries = json.loads(raw)
+    if not isinstance(entries, list) or not entries:
+        return MacroConfig(source="compile_commands.json")
+    defined: Dict[str, str] = {}
+    undefined: set = set()
+    conflict: set = set()
+    for entry in entries:
+        if isinstance(entry, dict):
+            _scan_tokens(_tokens(entry), defined, undefined, conflict)
+    # Drop conflicting symbols — defined in one TU, undefined in another →
+    # genuinely config-dependent project-wide, so not safe to resolve.
+    for name in conflict:
+        defined.pop(name, None)
+        undefined.discard(name)
+    if not defined and not undefined:
+        return MacroConfig(source="compile_commands.json")
+    return MacroConfig(defined=defined, undefined=frozenset(undefined),
+                       source="compile_commands.json")
+
+
+def _from_kconfig(path: Path) -> MacroConfig:
+    text = path.read_text(errors="replace")
+    defined: Dict[str, str] = {}
+    undefined: set = set()
+    for m in re.finditer(r"^(CONFIG_[A-Z0-9_]+)=([ym])\s*$", text, re.MULTILINE):
+        defined[m.group(1)] = "1"
+    for m in re.finditer(r"^#\s*(CONFIG_[A-Z0-9_]+)\s+is\s+not\s+set\s*$",
+                         text, re.MULTILINE):
+        # A CONFIG_X set to =y elsewhere wins (shouldn't happen in a real
+        # .config, but be deterministic): only mark undefined if not defined.
+        if m.group(1) not in defined:
+            undefined.add(m.group(1))
+    if not defined and not undefined:
+        return MacroConfig(source="kconfig")
+    return MacroConfig(defined=defined, undefined=frozenset(undefined),
+                       source="kconfig")
+
+
+def _find_compile_commands(target: Path) -> Optional[Path]:
+    for c in (target / "compile_commands.json",
+              target / "build" / "compile_commands.json"):
+        if c.is_file():
+            return c
+    return None
+
+
+def extract_macro_config(target: Path) -> MacroConfig:
+    """Probe ``target`` for an explicit macro-definition config.
+
+    Priority: ``compile_commands.json`` (per-TU ``-D``/``-U``), then
+    ``.config`` (kernel ``CONFIG_*``). First non-empty wins. Returns an
+    empty :class:`MacroConfig` when nothing recognizable is present.
+    """
+    target = Path(target)
+    if not target.is_dir():
+        return MacroConfig()
+
+    cc = _find_compile_commands(target)
+    if cc is not None:
+        try:
+            mc = _from_compile_commands(cc)
+            if mc:
+                return mc
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            logger.debug("compile_commands.json macro parse failed: %s", exc)
+
+    kconfig = target / ".config"
+    if kconfig.is_file():
+        try:
+            mc = _from_kconfig(kconfig)
+            if mc:
+                return mc
+        except OSError as exc:
+            logger.debug(".config macro parse failed: %s", exc)
+
+    return MacroConfig()
+
+
+__all__ = ["MacroConfig", "extract_macro_config"]

--- a/core/build/tests/test_macro_config.py
+++ b/core/build/tests/test_macro_config.py
@@ -1,0 +1,105 @@
+"""Tests for the macro-definition config extractor (config-aware #ifdef)."""
+
+from __future__ import annotations
+
+import json
+
+from core.build.macro_config import MacroConfig, extract_macro_config
+
+
+def _write_cc(tmp_path, entries):
+    p = tmp_path / "compile_commands.json"
+    p.write_text(json.dumps(entries))
+    return tmp_path
+
+
+def test_absent_when_no_artifacts(tmp_path):
+    mc = extract_macro_config(tmp_path)
+    assert not mc
+    assert mc.source == "absent"
+    # Unknown for everything — the load-bearing soundness property.
+    assert mc.is_defined("ANYTHING") is None
+
+
+def test_nonexistent_target():
+    assert not extract_macro_config("/no/such/dir")
+
+
+def test_compile_commands_arguments_array(tmp_path):
+    _write_cc(tmp_path, [{
+        "file": "a.c", "directory": ".",
+        "arguments": ["cc", "-DFOO", "-DBAR=2", "-UBAZ", "-c", "a.c"],
+    }])
+    mc = extract_macro_config(tmp_path)
+    assert mc.source == "compile_commands.json"
+    assert mc.is_defined("FOO") is True
+    assert mc.value_of("FOO") == "1"        # bare -D defines to 1
+    assert mc.value_of("BAR") == "2"
+    assert mc.is_defined("BAZ") is False    # -U
+    assert mc.is_defined("UNSEEN") is None  # absent => unknown, never False
+
+
+def test_compile_commands_command_string(tmp_path):
+    _write_cc(tmp_path, [{
+        "file": "a.c", "directory": ".",
+        "command": "cc -DENABLE_X=1 -D SPACED -c a.c",
+    }])
+    mc = extract_macro_config(tmp_path)
+    assert mc.value_of("ENABLE_X") == "1"
+    assert mc.is_defined("SPACED") is True   # space-separated -D NAME
+
+
+def test_conflicting_symbol_dropped_to_unknown(tmp_path):
+    # FOO defined in one TU, undefined in another => config-dependent
+    # project-wide => must NOT be resolvable (stays unknown).
+    _write_cc(tmp_path, [
+        {"file": "a.c", "directory": ".", "arguments": ["cc", "-DFOO", "a.c"]},
+        {"file": "b.c", "directory": ".", "arguments": ["cc", "-UFOO", "b.c"]},
+    ])
+    mc = extract_macro_config(tmp_path)
+    assert mc.is_defined("FOO") is None
+
+
+def test_build_subdir_compile_commands(tmp_path):
+    (tmp_path / "build").mkdir()
+    (tmp_path / "build" / "compile_commands.json").write_text(
+        json.dumps([{"file": "a.c", "directory": ".",
+                     "arguments": ["cc", "-DCMAKE_X", "a.c"]}]))
+    assert extract_macro_config(tmp_path).is_defined("CMAKE_X") is True
+
+
+def test_kconfig(tmp_path):
+    (tmp_path / ".config").write_text(
+        "CONFIG_FOO=y\n"
+        "CONFIG_MOD=m\n"
+        "# CONFIG_BAR is not set\n"
+        "# a comment\n"
+    )
+    mc = extract_macro_config(tmp_path)
+    assert mc.source == "kconfig"
+    assert mc.is_defined("CONFIG_FOO") is True
+    assert mc.is_defined("CONFIG_MOD") is True   # =m also defined
+    assert mc.is_defined("CONFIG_BAR") is False
+    assert mc.is_defined("CONFIG_UNSEEN") is None
+
+
+def test_compile_commands_preferred_over_kconfig(tmp_path):
+    _write_cc(tmp_path, [{"file": "a.c", "directory": ".",
+                          "arguments": ["cc", "-DFROM_CC", "a.c"]}])
+    (tmp_path / ".config").write_text("CONFIG_FROM_KCONFIG=y\n")
+    mc = extract_macro_config(tmp_path)
+    assert mc.source == "compile_commands.json"
+    assert mc.is_defined("FROM_CC") is True
+
+
+def test_malformed_compile_commands_falls_through(tmp_path):
+    (tmp_path / "compile_commands.json").write_text("{not json")
+    (tmp_path / ".config").write_text("CONFIG_OK=y\n")
+    mc = extract_macro_config(tmp_path)
+    assert mc.source == "kconfig"
+    assert mc.is_defined("CONFIG_OK") is True
+
+
+def test_empty_macroconfig_is_falsy():
+    assert not MacroConfig()
+    assert MacroConfig(defined={"X": "1"})

--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -39,6 +39,7 @@ from .call_graph import (
     extract_call_graph_rust,
 )
 from .diff import compare_inventories
+from core.build.macro_config import extract_macro_config
 from .dead_scope import detect_dead_scopes
 from .module_load_abort import detect_module_load_abort
 from .translation_view import detect_macro_call_targets, preprocess_view
@@ -86,6 +87,7 @@ _DEFAULT_INVENTORY_CACHE_ROOT = (
 
 def default_cache_dir(
     target_path: str, *, allow_unreachable: bool = False,
+    config_fingerprint: str = "",
 ) -> Path:
     """Return the persistent cache directory for ``target_path``'s
     inventory checklist.
@@ -106,6 +108,13 @@ def default_cache_dir(
     # a cached checklist. Default mode keeps the original hash input, so
     # existing cache dirs are unchanged.
     key = target_abs if not allow_unreachable else target_abs + "\0allow_unreachable"
+    # Fold the macro config too: config-aware blanking (#ifdef resolved via
+    # -D/-U/.config) changes which arms are dead, so a config change must
+    # invalidate the cache even when file contents are identical (else a
+    # newly-live arm would stay blanked from cache → a false negative). Empty
+    # fingerprint (no config / non-C target) leaves the key unchanged.
+    if config_fingerprint:
+        key += "\0cfg=" + config_fingerprint
     target_hash = hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
     return _DEFAULT_INVENTORY_CACHE_ROOT / target_hash
 
@@ -148,9 +157,18 @@ def build_inventory(
     Returns:
         Inventory dict (also saved to ``<output_dir>/checklist.json``).
     """
+    # Build macro config once (compile_commands.json / .config). Drives
+    # config-aware #ifdef resolution in each file's TranslationView. Empty
+    # (and inert) when no build artifacts are present or in isolation mode.
+    macro_config = extract_macro_config(target_path)
+    if allow_unreachable:
+        macro_config = None
+    cfg_fp = macro_config.fingerprint() if macro_config else ""
+
     if output_dir is None:
         output_dir = str(default_cache_dir(
             target_path, allow_unreachable=allow_unreachable,
+            config_fingerprint=cfg_fp,
         ))
     if exclude_patterns is None:
         exclude_patterns = DEFAULT_EXCLUDES
@@ -211,7 +229,8 @@ def build_inventory(
             futures = {
                 executor.submit(
                     _process_single_file, fp, target, exclude_patterns,
-                    skip_generated, old_files_by_path, allow_unreachable
+                    skip_generated, old_files_by_path, allow_unreachable,
+                    macro_config,
                 ): fp
                 for fp in file_list
             }
@@ -241,7 +260,7 @@ def build_inventory(
             _collect_result(
                 _process_single_file(filepath, target, exclude_patterns,
                                      skip_generated, old_files_by_path,
-                                     allow_unreachable)
+                                     allow_unreachable, macro_config)
             )
 
     # Sort for consistent output
@@ -457,6 +476,7 @@ def _process_single_file(
     skip_generated: bool = True,
     old_files: Dict[str, Any] = None,
     allow_unreachable: bool = False,
+    macro_config: Optional[object] = None,
 ) -> Optional[Dict[str, Any]]:
     """Process a single file for the inventory.
 
@@ -558,6 +578,7 @@ def _process_single_file(
         view = preprocess_view(
             str(filepath), language, content,
             allow_unreachable=allow_unreachable,
+            config=macro_config,
         )
         parse_text = view.parse_text
         tree_cache = {}

--- a/core/inventory/reach_audit.py
+++ b/core/inventory/reach_audit.py
@@ -69,17 +69,21 @@ def classify_reachability(
         return "lexical_dead"
 
     target = InternalFunction(file_path=file_path, name=name, line=line)
+    # Specific reachable reasons first — framework decorator dispatch and
+    # function-as-argument registration — so they surface as their own
+    # (informative) verdicts rather than being absorbed into the general
+    # "reachable" by entry-reachability (which also counts them as entries).
+    if is_framework_callable(inventory, target):
+        return "framework_callable"
+    if is_registered_via_call(inventory, target):
+        return "registered_via_call"
+    # General entry-point forward reachability.
     er = entry_reachability(inventory, target)
     if er == "reachable":
         return "reachable"
     if er == "no_path_from_entry":
         return "no_path_from_entry"
-    # er == "uncertain": fall through to framework / 1-hop logic.
-
-    if is_framework_callable(inventory, target):
-        return "framework_callable"
-    if is_registered_via_call(inventory, target):
-        return "registered_via_call"
+    # er == "uncertain": fall through to the 1-hop verdict.
     try:
         verdict = function_called(inventory, f"{module}.{name}").verdict
     except ValueError:

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -811,3 +811,59 @@ class TestAllowUnreachableView:
         # Default mode must hash identically to the no-arg call so existing
         # persistent caches are not invalidated when this lands.
         assert default_cache_dir(str(tmp_path), allow_unreachable=False) == d_def
+
+
+class TestConfigAwareView:
+    """U12: a build macro config (compile_commands.json / .config) threads
+    through build_inventory so config-aware #ifdef arms are blanked, and a
+    config change invalidates the cache even when file contents are equal."""
+
+    _SRC = (
+        "#ifdef CONFIG_FEATURE\n"
+        "void feature_sink(char *q){ system(q); }\n"
+        "#endif\n"
+        "void always_live(void){ return; }\n"
+    )
+
+    def _names(self, inv):
+        return {i["name"] for f in inv["files"] for i in f["items"]
+                if i.get("kind", "function") == "function"}
+
+    def test_feature_off_blanks_guarded_sink(self, tmp_path):
+        (tmp_path / "m.c").write_text(self._SRC)
+        (tmp_path / ".config").write_text("# CONFIG_FEATURE is not set\n")
+        inv = build_inventory(str(tmp_path), str(tmp_path / "out"))
+        assert self._names(inv) == {"always_live"}
+
+    def test_feature_on_keeps_guarded_sink(self, tmp_path):
+        (tmp_path / "m.c").write_text(self._SRC)
+        (tmp_path / ".config").write_text("CONFIG_FEATURE=y\n")
+        inv = build_inventory(str(tmp_path), str(tmp_path / "out"))
+        assert self._names(inv) == {"always_live", "feature_sink"}
+
+    def test_no_config_is_conservative(self, tmp_path):
+        # No build artifacts → #ifdef untouched → sink kept (live in some
+        # build; blanking it would be a false negative).
+        (tmp_path / "m.c").write_text(self._SRC)
+        inv = build_inventory(str(tmp_path), str(tmp_path / "out"))
+        assert self._names(inv) == {"always_live", "feature_sink"}
+
+    def test_config_change_invalidates_persistent_cache(self, tmp_path):
+        # The critical correctness check: same file content, default
+        # (persistent, config-keyed) cache. Flipping the config must NOT
+        # serve a stale blanked entry for the now-live arm.
+        (tmp_path / "m.c").write_text(self._SRC)
+        (tmp_path / ".config").write_text("# CONFIG_FEATURE is not set\n")
+        assert self._names(build_inventory(str(tmp_path))) == {"always_live"}
+        (tmp_path / ".config").write_text("CONFIG_FEATURE=y\n")
+        assert self._names(build_inventory(str(tmp_path))) == {
+            "always_live", "feature_sink"}
+
+    def test_cache_key_folds_config_fingerprint(self, tmp_path):
+        from core.inventory.builder import default_cache_dir
+        d_plain = default_cache_dir(str(tmp_path))
+        d_cfg = default_cache_dir(str(tmp_path), config_fingerprint="abc123")
+        assert d_plain != d_cfg
+        # Empty fingerprint must hash identically to the no-arg call so
+        # non-C projects' existing caches are untouched.
+        assert default_cache_dir(str(tmp_path), config_fingerprint="") == d_plain

--- a/core/inventory/tests/test_translation_view.py
+++ b/core/inventory/tests/test_translation_view.py
@@ -196,3 +196,192 @@ def test_call_shaped_text_in_comment_not_a_target():
 def test_char_literal_paren_not_a_target():
     got = detect_macro_call_targets("#define C(x) g(x, ')')")
     assert got == {"g"}, got
+
+
+# ---------------------------------------------------------------------------
+# U12 — config-aware #ifdef / #if resolution (fidelity 2)
+# ---------------------------------------------------------------------------
+
+def _mc(defined=None, undefined=()):
+    from core.build.macro_config import MacroConfig
+    return MacroConfig(defined=dict(defined or {}),
+                       undefined=frozenset(undefined))
+
+
+def test_ifdef_known_undefined_is_dead():
+    src = "#ifdef HAVE_FOO\nvoid gone(void){}\n#endif\n"
+    mc = _mc(undefined={"HAVE_FOO"})
+    assert detect_preprocessor_dead_ranges(src, mc) == [(2, 2)]
+
+
+def test_ifdef_known_defined_is_live():
+    src = "#ifdef HAVE_FOO\nvoid kept(void){}\n#endif\n"
+    mc = _mc(defined={"HAVE_FOO": "1"})
+    assert detect_preprocessor_dead_ranges(src, mc) == []
+
+
+def test_ifdef_absent_symbol_stays_unknown_even_with_config():
+    # The load-bearing soundness property: a symbol NOT in the config might
+    # still be #define'd in a header — never treat absence as undefined.
+    src = "#ifdef MAYBE_IN_HEADER\nvoid x(void){}\n#endif\n"
+    mc = _mc(defined={"SOMETHING_ELSE": "1"}, undefined={"AND_ANOTHER"})
+    assert detect_preprocessor_dead_ranges(src, mc) == []
+
+
+def test_ifndef_known_defined_is_dead():
+    src = "#ifndef HAVE_FOO\nvoid fallback(void){}\n#endif\n"
+    mc = _mc(defined={"HAVE_FOO": "1"})
+    assert detect_preprocessor_dead_ranges(src, mc) == [(2, 2)]
+
+
+def test_ifndef_known_undefined_is_live():
+    src = "#ifndef HAVE_FOO\nvoid fallback(void){}\n#endif\n"
+    mc = _mc(undefined={"HAVE_FOO"})
+    assert detect_preprocessor_dead_ranges(src, mc) == []
+
+
+def test_if_defined_and_negation():
+    on = "#if defined(X)\nvoid a(void){}\n#endif\n"
+    off = "#if !defined(X)\nvoid b(void){}\n#endif\n"
+    mc = _mc(defined={"X": "1"})
+    assert detect_preprocessor_dead_ranges(on, mc) == []
+    assert detect_preprocessor_dead_ranges(off, mc) == [(2, 2)]
+
+
+def test_if_macro_value_zero_is_dead_but_ifdef_still_live():
+    # -DFLAG=0 : the macro IS defined (so #ifdef is live) but its value is 0
+    # (so #if is dead). The two forms must not be conflated.
+    mc = _mc(defined={"FLAG": "0"})
+    ifdef_src = "#ifdef FLAG\nvoid a(void){}\n#endif\n"
+    if_src = "#if FLAG\nvoid b(void){}\n#endif\n"
+    assert detect_preprocessor_dead_ranges(ifdef_src, mc) == []
+    assert detect_preprocessor_dead_ranges(if_src, mc) == [(2, 2)]
+
+
+def test_if_macro_value_nonzero_is_live():
+    mc = _mc(defined={"LEVEL": "2"})
+    src = "#if LEVEL\nvoid a(void){}\n#endif\n"
+    assert detect_preprocessor_dead_ranges(src, mc) == []
+
+
+def test_if_known_undefined_identifier_evaluates_to_zero():
+    # In #if, an undefined identifier is 0 → arm dead. Only when KNOWN-undef.
+    mc = _mc(undefined={"NOPE"})
+    src = "#if NOPE\nvoid a(void){}\n#endif\n"
+    assert detect_preprocessor_dead_ranges(src, mc) == [(2, 2)]
+
+
+def test_compound_expression_stays_unknown_with_config():
+    # We do not partially evaluate &&/|| — stays untouched (safe).
+    mc = _mc(defined={"A": "1"}, undefined={"B"})
+    for cond in ("#if defined(A) && defined(B)",
+                 "#if A || B",
+                 "#if VERSION > 3"):
+        src = cond + "\nvoid f(void){}\n#endif\n"
+        assert detect_preprocessor_dead_ranges(src, mc) == [], cond
+
+
+def test_nested_dead_arm_with_config():
+    src = (
+        "#ifdef OFF\n"
+        "void outer(void){}\n"
+        "#ifdef ALSO\n"
+        "void inner(void){}\n"
+        "#endif\n"
+        "#endif\n"
+    )
+    mc = _mc(undefined={"OFF"}, defined={"ALSO": "1"})
+    # Whole outer arm dead (OFF undefined) — inner body dead regardless of
+    # ALSO; the inner #ifdef/#endif directive lines are left in place.
+    assert detect_preprocessor_dead_ranges(src, mc) == [(2, 2), (4, 4)]
+
+
+def test_elif_resolved_against_config():
+    src = (
+        "#if defined(A)\n"
+        "void a(void){}\n"
+        "#elif defined(B)\n"
+        "void b(void){}\n"
+        "#else\n"
+        "void c(void){}\n"
+        "#endif\n"
+    )
+    # A undefined, B defined → a dead, b live, c dead (only body lines).
+    mc = _mc(defined={"B": "1"}, undefined={"A"})
+    assert detect_preprocessor_dead_ranges(src, mc) == [(2, 2), (6, 6)]
+
+
+def test_preprocess_view_fidelity_2_with_config():
+    src = "#ifdef OFF\nvoid gone(void){}\n#endif\nvoid kept(void){}\n"
+    mc = _mc(undefined={"OFF"})
+    v = preprocess_view("t.c", "c", src, config=mc)
+    assert v.fidelity == 2
+    assert _names(v) == {"kept"}
+    assert v.line_map is IDENTITY_LINE_MAP        # blanking preserves lines
+
+
+def test_preprocess_view_empty_config_is_fidelity_1():
+    from core.build.macro_config import MacroConfig
+    src = "#if 0\nvoid d(void){}\n#endif\nvoid k(void){}\n"
+    v = preprocess_view("t.c", "c", src, config=MacroConfig())
+    assert v.fidelity == 1                          # empty config → literal-only
+    assert _names(v) == {"k"}
+
+
+def test_config_aware_blanking_still_blanks_literal_zero():
+    mc = _mc(defined={"X": "1"})
+    src = "#if 0\nvoid d(void){}\n#endif\nvoid k(void){}\n"
+    assert detect_preprocessor_dead_ranges(src, mc) == [(2, 2)]
+
+
+def test_allow_unreachable_ignores_config():
+    # Isolation mode returns the raw view even when a config is supplied.
+    src = "#ifdef OFF\nvoid gone(void){}\n#endif\n"
+    mc = _mc(undefined={"OFF"})
+    v = preprocess_view("t.c", "c", src, allow_unreachable=True, config=mc)
+    assert v.fidelity == 0
+    assert "gone" in v.parse_text
+
+
+# --- over-fire (false-negative) guards: unknown leading arms in chains ------
+
+def test_elif_unknown_leading_arm_does_not_blank_live_arms():
+    # #if defined(A) with A UNKNOWN (may be #define'd in a header). Even though
+    # B is known-defined, neither arm1 (live when A defined) nor arm2 (live when
+    # A undefined) may be blanked — only the #else, dead under every build
+    # consistent with the config.
+    src = (
+        "#if defined(A)\n" "void a(void){}\n"
+        "#elif defined(B)\n" "void b(void){}\n"
+        "#else\n" "void c(void){}\n" "#endif\n"
+    )
+    mc = _mc(defined={"B": "1"})            # A unknown, B defined
+    dead = detect_preprocessor_dead_ranges(src, mc)
+    flat = {ln for lo, hi in dead for ln in range(lo, hi + 1)}
+    assert 2 not in flat and 4 not in flat, "must not blank a possibly-live arm"
+
+
+def test_elif_unknown_arm_after_known_false_blanks_nothing_more():
+    # A known-undef → arm1 dead. B UNKNOWN → arm2 / arm3 could each be live, so
+    # only arm1 may be blanked.
+    src = (
+        "#if defined(A)\n" "void a(void){}\n"
+        "#elif defined(B)\n" "void b(void){}\n"
+        "#else\n" "void c(void){}\n" "#endif\n"
+    )
+    mc = _mc(undefined={"A"})               # A undef, B unknown
+    assert detect_preprocessor_dead_ranges(src, mc) == [(2, 2)]
+
+
+def test_unknown_parent_does_not_blank_its_body():
+    # OUTER unknown → its body survives; INNER explicitly-undef child is dead.
+    src = (
+        "#ifdef OUTER\n" "void o(void){}\n"
+        "#ifdef INNER\n" "void i(void){}\n"
+        "#endif\n" "#endif\n"
+    )
+    mc = _mc(undefined={"INNER"})           # OUTER unknown, INNER undef
+    flat = {ln for lo, hi in detect_preprocessor_dead_ranges(src, mc)
+            for ln in range(lo, hi + 1)}
+    assert 2 not in flat, "must not blank body under an unknown #ifdef"
+    assert 4 in flat, "explicitly-undef INNER arm should be dead"

--- a/core/inventory/translation_view.py
+++ b/core/inventory/translation_view.py
@@ -10,11 +10,22 @@ consumer.
 
 Fidelity ladder (the view's ``fidelity`` field):
 
-  * 0 — raw text (today's behavior; what non-C/C++ always gets).
-  * 1 — ``#if 0`` / literal-false arms blanked in-memory (layer 1).
-  * 2 — plus function-like-macro masking flags recorded (layer 2).
-  * 3 — real ``cpp`` with a build config; one variant; macros expanded;
-        a non-identity ``line_map`` from ``#line`` markers (layer 3, later).
+  * 0 — raw text (what non-C/C++ and isolation mode always get).
+  * 1 — literal-only dead arms blanked: ``#if 0`` / ``#elif 0`` and the
+        ``#else`` of ``#if 1`` (config-INDEPENDENT, dead under every build).
+  * 2 — config-aware dead arms: also ``#ifdef X`` / ``#ifndef X`` /
+        ``#if defined(X)`` / ``#if X`` resolved against a build
+        :class:`~core.build.macro_config.MacroConfig` (explicit
+        ``-D``/``-U`` / ``.config``). Config-DEPENDENT → heuristic, not sound.
+  * 3 — real ``cpp`` with full macro expansion + ``#line``-derived
+        non-identity ``line_map`` (deferred; line-preserving config-aware
+        blanking at layer 2 captures the dominant extraction win soundly,
+        without a subprocess or ``#include`` inlining).
+
+Function-like-macro call targets (``#define CALL_F() f()``) are handled
+orthogonally by ``detect_macro_call_targets`` — consumed by the resolver to
+keep a macro-only-reachable function UNCERTAIN rather than NOT_CALLED — not
+via a fidelity level.
 
 Two fields are first-class from the start specifically so layer 3 is a
 provider swap rather than a rewrite:
@@ -47,30 +58,110 @@ _C_FAMILY = frozenset({"c", "cpp"})
 
 _PP_DIRECTIVE = re.compile(r"^\s*#\s*(if|ifdef|ifndef|elif|else|endif)\b(.*)$")
 
+# `#if`/`#elif` operand forms we resolve against a config. Single-term only —
+# compound expressions (``&&`` / ``||`` / comparisons / arithmetic) stay
+# 'unknown' rather than risk a wrong partial evaluation (a false negative).
+_DEFINED_RE = re.compile(r"^(!\s*)?defined\s*\(\s*(\w+)\s*\)$")
+_DEFINED_BARE_RE = re.compile(r"^(!\s*)?defined\s+(\w+)$")
+_IDENT_RE = re.compile(r"^(\w+)$")
 
-def _pp_cond(kind: str, rest: str) -> str:
-    """Classify an #if/#elif controlling expression as
-    'false' | 'true' | 'unknown'. Only literal 0/1 are decidable without a
-    build config — `#ifdef X` / `#if SYMBOL` / `#if EXPR` are config- or
-    value-dependent and MUST stay 'unknown' (firing on them would wrongly
-    delete code that is live in some build → a false negative)."""
-    if kind in ("ifdef", "ifndef"):
-        return "unknown"
+
+def _strip_pp_comments(rest: str) -> str:
     r = re.sub(r"/\*.*?\*/", "", rest)
-    r = re.sub(r"//.*$", "", r).strip()
+    return re.sub(r"//.*$", "", r).strip()
+
+
+def _eval_int_literal(s: str) -> Optional[int]:
+    """Parse a bare integer literal (decimal / 0x-hex, optional surrounding
+    parens / L/U suffix). Returns ``None`` for anything non-trivial — we only
+    evaluate values we can be certain about."""
+    t = s.strip()
+    while t.startswith("(") and t.endswith(")"):
+        t = t[1:-1].strip()
+    t = re.sub(r"[uUlL]+$", "", t)
+    try:
+        return int(t, 0) if t else None
+    except ValueError:
+        return None
+
+
+def _pp_cond(kind: str, rest: str, macros: Optional["object"] = None) -> str:
+    """Classify an #if/#ifdef/#ifndef/#elif controlling expression as
+    'false' | 'true' | 'unknown'.
+
+    Without a config only literal ``0``/``1`` are decidable; ``#ifdef X`` and
+    value-dependent ``#if`` stay 'unknown'. With a :class:`MacroConfig`
+    (``macros``) we additionally resolve forms whose every symbol is KNOWN
+    (explicitly ``-D``/``-U`` or named in ``.config``):
+
+      * ``#ifdef X`` / ``#ifndef X``
+      * ``#if defined(X)`` / ``#if !defined(X)`` (and ``defined X``)
+      * ``#if X`` where X is known-defined to an integer literal, or
+        known-undefined (→ 0 in ``#if`` per C semantics).
+
+    A symbol absent from the config stays UNKNOWN — it may be ``#define``d in
+    an included header, so we must not treat absence as undefined (that would
+    delete live code → false negative). Compound expressions stay 'unknown'.
+    """
+    if kind in ("ifdef", "ifndef"):
+        m = _IDENT_RE.match(_strip_pp_comments(rest))
+        if not (m and macros):
+            return "unknown"
+        d = macros.is_defined(m.group(1))
+        if d is None:
+            return "unknown"
+        defined_true = d if kind == "ifdef" else (not d)
+        return "true" if defined_true else "false"
+
+    r = _strip_pp_comments(rest)
     if r in ("0", "(0)", "00"):
         return "false"
     if r in ("1", "(1)"):
         return "true"
+    if not macros:
+        return "unknown"
+
+    # defined(X) / !defined(X) / defined X
+    dm = _DEFINED_RE.match(r) or _DEFINED_BARE_RE.match(r)
+    if dm:
+        d = macros.is_defined(dm.group(2))
+        if d is None:
+            return "unknown"
+        res = (not d) if dm.group(1) else d
+        return "true" if res else "false"
+
+    # bare single identifier: #if MACRO
+    im = _IDENT_RE.match(r)
+    if im:
+        name = im.group(1)
+        val = macros.value_of(name)
+        if val is not None:
+            iv = _eval_int_literal(val)
+            return "unknown" if iv is None else ("true" if iv != 0 else "false")
+        # known-undefined identifier evaluates to 0 in #if → false. Absent
+        # (unknown) stays unknown — header might define it.
+        if macros.is_defined(name) is False:
+            return "false"
     return "unknown"
 
 
-def detect_preprocessor_dead_ranges(content: str) -> List[Tuple[int, int]]:
-    """Inclusive 1-indexed line ranges of statically-dead preprocessor arms
-    (`#if 0` / `#elif 0`, and the `#else` of a `#if 1`). Config-INDEPENDENT
-    only — dead under every build configuration. Nesting-aware: anything
-    inside a dead arm is dead. Validated 0 over-fires across OpenSSL's ~17k
-    `#ifdef` directives."""
+def detect_preprocessor_dead_ranges(
+    content: str, macros: Optional["object"] = None,
+) -> List[Tuple[int, int]]:
+    """Inclusive 1-indexed line ranges of statically-dead preprocessor arms.
+
+    Without ``macros``: literal-only — ``#if 0`` / ``#elif 0`` and the
+    ``#else`` of a ``#if 1``. Config-INDEPENDENT (dead under every build),
+    validated 0 over-fires across OpenSSL's ~17k ``#ifdef`` directives.
+
+    With a :class:`~core.build.macro_config.MacroConfig` (``macros``): also
+    resolves ``#ifdef`` / ``#ifndef`` / ``#if defined(X)`` / ``#if X`` arms
+    whose symbols are explicitly KNOWN in the build config. Still cannot
+    over-fire: symbols absent from the config stay 'unknown' (untouched).
+    Config-DEPENDENT, so the resulting view is heuristic, not sound.
+
+    Nesting-aware: anything inside a dead arm is dead.
+    """
     lines = content.split("\n")
     stack: list[dict] = []
     dead: set[int] = set()
@@ -83,14 +174,14 @@ def detect_preprocessor_dead_ranges(content: str) -> List[Tuple[int, int]]:
         kind, rest = m.group(1), m.group(2)
         parent_dead = stack[-1]["effective_dead"] if stack else False
         if kind in ("if", "ifdef", "ifndef"):
-            lit = _pp_cond(kind, rest)
+            lit = _pp_cond(kind, rest, macros)
             f = {"parent_dead": parent_dead, "taken": lit == "true",
                  "arm_dead": lit == "false"}
             f["effective_dead"] = parent_dead or f["arm_dead"]
             stack.append(f)
         elif kind == "elif" and stack:
             f = stack[-1]
-            lit = _pp_cond("elif", rest)
+            lit = _pp_cond("elif", rest, macros)
             if f["taken"] or lit == "false":
                 f["arm_dead"] = True
             elif lit == "true":
@@ -256,10 +347,14 @@ def preprocess_view(
 ) -> TranslationView:
     """Return the parser's view of ``content``.
 
-    Non-C/C++ → identity view (fidelity 0): byte-identical to today, so the
-    seam is free for every other language. C/C++ handling (``#if 0``
-    blanking + macro flags) is layered on in subsequent units; for now this
-    is the identity provider so introducing the seam changes no behavior.
+    Non-C/C++ → identity view (fidelity 0): byte-identical, so the seam is
+    free for every other language. C/C++ → dead preprocessor arms blanked
+    in-memory: literal-only (fidelity 1) by default, or config-aware
+    (fidelity 2) when ``config`` is a non-empty
+    :class:`~core.build.macro_config.MacroConfig`. Isolation mode
+    (``allow_unreachable``) returns the raw view so disabled code stays
+    visible for review. No on-disk mutation; ``line_map`` is identity at
+    every fidelity < 3 (blanking preserves line numbers).
     """
     # Non-C/C++ → identity (byte-identical to today).
     if language not in _C_FAMILY:
@@ -276,16 +371,20 @@ def preprocess_view(
                                fidelity=0, masking_flags=frozenset(),
                                config=config)
 
-    # Default C/C++ view (fidelity 1): blank statically-dead `#if 0` arms
-    # in-memory before the parser sees them. tree-sitter doesn't run the
-    # preprocessor, so without this, functions (and parser garbage) inside
-    # `#if 0` enter the inventory + call graph as if live. Config-dependent
-    # `#ifdef` arms are NOT touched — that needs real preprocessing (layer
-    # 3). line_map stays identity (blanking preserves line numbers).
-    dead = detect_preprocessor_dead_ranges(content)
+    # Blank statically-dead arms in-memory before the parser sees them.
+    # tree-sitter doesn't run the preprocessor, so without this, functions
+    # (and parser garbage) inside dead arms enter the inventory + call graph
+    # as if live. With a build macro config (``config``), resolve `#ifdef` /
+    # `#if defined(X)` / `#if X` arms whose symbols are explicitly known
+    # (fidelity 2); without one, literal-only `#if 0` (fidelity 1). Either
+    # way line_map stays identity — blanking replaces dead-arm characters
+    # with spaces and never moves a line.
+    macros = config if config else None
+    dead = detect_preprocessor_dead_ranges(content, macros)
     parse_text = _blank_ranges(content, dead)
     return TranslationView(parse_text=parse_text, line_map=IDENTITY_LINE_MAP,
-                           fidelity=1, masking_flags=frozenset(), config=config)
+                           fidelity=2 if macros else 1,
+                           masking_flags=frozenset(), config=config)
 
 
 __all__ = [

--- a/core/orchestration/tests/test_reachability_consumer_wirings_e2e.py
+++ b/core/orchestration/tests/test_reachability_consumer_wirings_e2e.py
@@ -19,8 +19,13 @@ Architecture exercised:
   3. Codeql analyzer constructed with ``reachability_inventory=``
      pointing at the prepass's inventory. Analyzer's
      ``_check_reachability`` returns "not_called" for findings
-     in the dead function and "called" for findings in the live
-     one — WITHOUT rebuilding the inventory.
+     in the dead function and "reachable" for findings in the live
+     one (it has an entry→sink path from main) — WITHOUT rebuilding
+     the inventory. ``not_called`` is a
+     HEURISTIC verdict: it is surfaced but NO LONGER hard-skips
+     the expensive analysis (only SOUND witnesses — module_aborts
+     / lexical_dead — do; that wiring lives in the codeql
+     prefilter test).
   4. /validate's ``demote_unreachable_paths`` invoked with the
      SAME inventory (via ``inventory=`` kwarg). Attack paths
      anchored to dead-code findings get proximity clamped and
@@ -34,7 +39,9 @@ Verifies:
   * Prepass builds + persists priority markers to checklist.
   * In-process inventory sharing actually works (no rebuilds in
     sibling consumers when DI'd).
-  * Codeql short-circuits before the dataflow validator runs.
+  * Codeql surfaces the not_called verdict but (U11) does NOT
+    hard-skip on it — the finding proceeds past the reachability
+    skip gate into the full analysis.
   * /validate demotes the right paths.
   * All three consumers' verdicts are CONSISTENT for the same
     function (synthetic project shape verifies the resolver's
@@ -207,25 +214,32 @@ def test_full_pipeline_dead_code_deprioritised(tmp_path):
     )
 
     assert analyzer._check_reachability(dead_finding, target) == "not_called"
-    assert analyzer._check_reachability(live_finding, target) == "called"
+    # Routed through the entry-aware classifier: the live handler has an
+    # entry→sink path from main(), so it classifies "reachable" (a strictly
+    # stronger live verdict than the 1-hop "called"). Either way: LIVE, no skip.
+    assert analyzer._check_reachability(live_finding, target) == "reachable"
 
-    # Stage-2b: short-circuit observable in analyze_finding_autonomous.
-    analyzer.dataflow_validator = MagicMock()
-    analyzer.dataflow_validator.validate_finding.side_effect = (
-        AssertionError(
-            "dataflow validator should not have been invoked for "
-            "dead-code finding"
-        )
-    )
-    # Stub parse_sarif_finding so we don't need real SARIF.
+    # Stage-2b (U11): not_called is a HEURISTIC verdict — surface-only, NOT
+    # a hard skip. The finding must proceed PAST the reachability skip gate
+    # into the full analysis (only SOUND witnesses hard-skip). We prove this
+    # with a sentinel raised by the first post-gate stage; a hard skip would
+    # have returned before reaching it.
     analyzer.parse_sarif_finding = lambda r, run: dead_finding
-
-    result = analyzer.analyze_finding_autonomous(
-        sarif_result={}, sarif_run={},
-        repo_path=target, out_dir=tmp_path / "codeql-out",
+    analyzer.read_vulnerable_code = MagicMock(
+        side_effect=RuntimeError("reached past reachability skip gate")
     )
-    assert result.skipped_reason == "reachability_not_called"
-    assert result.reachability_verdict == "not_called"
+    got_past = False
+    try:
+        analyzer.analyze_finding_autonomous(
+            sarif_result={}, sarif_run={},
+            repo_path=target, out_dir=tmp_path / "codeql-out",
+        )
+    except RuntimeError as e:
+        got_past = "past reachability skip gate" in str(e)
+    assert got_past, (
+        "not_called is heuristic — it must surface but NOT hard-skip "
+        "the analysis under U11"
+    )
 
     # ----- Stage 3: /validate consumer with shared inventory -----
     from packages.exploitability_validation.reachability import (

--- a/packages/codeql/autonomous_analyzer.py
+++ b/packages/codeql/autonomous_analyzer.py
@@ -125,9 +125,12 @@ class AutonomousAnalysisResult:
     # pattern). Both treated as reachable; full LLM analysis runs.
     reachability_verdict: Optional[str] = None
     # Set to a non-None reason when the analyzer short-circuited
-    # without running deep analysis. Today the only value is
-    # ``"reachability_not_called"`` (sink function provably dead
-    # code); future iterations may add more.
+    # without running deep analysis. The reachability prefilter
+    # hard-skips ONLY on a SOUND witness — ``"reachability_module_aborts"``
+    # (file aborts on load before the sink binds) or
+    # ``"reachability_lexical_dead"`` (sink defined in an always-false
+    # guard). Heuristic verdicts (``not_called`` / ``no_path_from_entry``)
+    # are surface-only: recorded in ``reachability_verdict`` but NOT skipped.
     skipped_reason: Optional[str] = None
 
 
@@ -299,14 +302,7 @@ class AutonomousCodeQLAnalyzer:
 
         try:
             from core.inventory.lookup import lookup_function
-            from core.inventory.reachability import (
-                InternalFunction,
-                function_called,
-                is_framework_callable,
-                is_lexically_dead,
-                is_registered_via_call,
-                module_aborts_on_load,
-            )
+            from core.inventory.reach_audit import classify_reachability
         except ImportError:
             return None
 
@@ -322,102 +318,26 @@ class AutonomousCodeQLAnalyzer:
         func_name = func_info.get("name")
         if not isinstance(func_name, str) or not func_name:
             return None
-
-        # Build the qualified name. For Python files we derive the
-        # module from the relative path; for other languages the
-        # resolver handles the dotted-chain matching directly off
-        # the inventory's call_graph data, but we still need a
-        # qualified name to query. ``<module>.<func>`` works for
-        # both — when the file isn't Python, the lookup just won't
-        # match and we get NOT_CALLED, which the caller treats
-        # conservatively (skip if the verdict is the answer; the
-        # None return from non-callable lookups falls through).
         rel_path = self._relative_path(finding.file_path, repo_path)
         if rel_path is None:
             return None
         module = self._path_to_module(rel_path)
         if not module:
             return None
-        qualified = f"{module}.{func_name}"
 
-        # S4: whole-file module-load-abort gate, checked before the
-        # call-graph verdict because it trumps CALLED. If the file's
-        # top-level execution unconditionally aborts (raise
-        # ImportError / throw new Error / init() panic /
-        # compile_error!) before this function's def runs, the sink
-        # is dead regardless of static call edges — peers calling it
-        # are equally dead. Short-circuit like not_called. The
-        # framework_callable / registered_via_call escape hatches
-        # below do NOT apply: registration code beneath the abort
-        # never executes. Respects --allow-unreachable (operator
-        # opt-out for in-isolation review).
-        if not self._allow_unreachable:
-            abort = module_aborts_on_load(
-                self._reachability_inventory, rel_path,
-            )
-            if abort is not None:
-                abort_line = int(abort.get("line") or 0)
-                func_line = int(func_info.get("line_start") or 0)
-                if abort_line and func_line and func_line > abort_line:
-                    return "module_aborts"
-            # S3: lexical-dead gate. Function defined inside an
-            # always-false guard (if False: / if (false) /
-            # #[cfg(any())]) never binds — dead regardless of call
-            # edges, and decorator/registration code inside the dead
-            # scope never runs. Trumps the framework escape hatches.
-            if is_lexically_dead(
-                self._reachability_inventory, rel_path, func_name,
-                int(func_info.get("line_start") or 0),
-            ):
-                return "lexical_dead"
-
-        try:
-            result = function_called(
-                self._reachability_inventory, qualified,
-            )
-        except ValueError:
-            return None
-        verdict = result.verdict.value
-        # Operator opt-out: --allow-unreachable disables the
-        # short-circuit path entirely. Return None ("prefilter
-        # had no opinion") instead of the verdict — the caller
-        # then proceeds with full LLM analysis regardless of
-        # static-graph reachability. The flag is intended for
-        # in-isolation review (CTF, snippet, vendor reference)
-        # where the operator explicitly wants to evaluate the
-        # code pattern's inherent vulnerability shape rather
-        # than its deployment reachability.
-        if self._allow_unreachable and verdict == "not_called":
-            return None
-        # NOT_CALLED in the static graph doesn't mean unreachable
-        # when the function is framework-registered (Flask
-        # ``@app.route``, Celery ``@shared_task``, Django
-        # ``@receiver``, etc.). The substrate's
-        # ``is_framework_callable`` recognises these. Without this
-        # check, the prefilter short-circuits framework handlers
-        # before any LLM analysis runs — a false-negative class on
-        # any web / task / signal codebase.
-        if verdict == "not_called":
-            line = int(func_info.get("line_start") or 0)
-            target = InternalFunction(
-                file_path=rel_path, name=func_name, line=line,
-            )
-            if is_framework_callable(
-                self._reachability_inventory, target,
-            ):
-                # New verdict value the caller treats as "don't
-                # short-circuit". Distinct from "called" so the
-                # reachability_verdict field reports accurately.
-                return "framework_callable"
-            if is_registered_via_call(
-                self._reachability_inventory, target,
-            ):
-                # JS / Go function-as-argument registration
-                # (``http.HandleFunc("/x", target)``). Distinct
-                # verdict value so operators can see WHICH
-                # mechanism kept the finding alive.
-                return "registered_via_call"
-        return verdict
+        # Delegate to the shared, entry-aware classifier — the same
+        # precedence the /agentic enrichment prepass uses: module_aborts ->
+        # lexical_dead -> entry-reachability (reachable / no_path_from_entry)
+        # -> framework / registration -> 1-hop called / not_called. Using
+        # the entry-aware classifier means an exported / public entry with
+        # no in-project caller no longer reads not_called. The CALLER
+        # decides whether a verdict hard-suppresses, via the witness
+        # chokepoint may_suppress() (sound + corpus-earned only) — so
+        # --allow-unreachable handling lives there, not here.
+        return classify_reachability(
+            self._reachability_inventory, rel_path, func_name,
+            int(func_info.get("line_start") or 0), module,
+        )
 
     def _relative_path(
         self, file_path: str, repo_path: Path,
@@ -1170,27 +1090,31 @@ class AutonomousCodeQLAnalyzer:
         reachability_verdict = self._check_reachability(
             finding, repo_path,
         )
-        if reachability_verdict in (
-            "not_called", "module_aborts", "lexical_dead",
-        ):
-            if reachability_verdict == "module_aborts":
-                self.logger.info(
-                    "⏭️  Sink's file aborts on load (raise/throw/panic "
-                    "before binding) — skipping expensive analysis",
-                )
-                skipped_reason = "reachability_module_aborts"
-            elif reachability_verdict == "lexical_dead":
-                self.logger.info(
-                    "⏭️  Sink's function is in an always-false guard "
-                    "(if False / #[cfg(any())]) — skipping analysis",
-                )
-                skipped_reason = "reachability_lexical_dead"
-            else:
-                self.logger.info(
-                    "⏭️  Sink function not called from project — "
-                    "skipping expensive analysis",
-                )
-                skipped_reason = "reachability_not_called"
+        # Hard-suppress (skip the expensive LLM analysis) ONLY on a SOUND,
+        # corpus-earned witness — module_aborts / lexical_dead. Heuristic
+        # verdicts (not_called, no_path_from_entry) are surface-only: they
+        # still get full analysis (the enrichment prepass soft-demotes
+        # them), because 1-hop / entry-completeness assumptions can miss
+        # reflection, cross-file, or address-of edges. --allow-unreachable
+        # empties the earned set so nothing is hard-suppressed in the
+        # in-isolation review mode.
+        if reachability_verdict:
+            from core.inventory.reach_witness import (
+                STRUCTURALLY_SUPPRESSIBLE_KINDS,
+                verdict_from_classification,
+            )
+            earned = (frozenset() if self._allow_unreachable
+                      else STRUCTURALLY_SUPPRESSIBLE_KINDS)
+            suppress = verdict_from_classification(
+                reachability_verdict,
+            ).may_suppress(earned)
+        else:
+            suppress = False
+        if suppress:
+            self.logger.info(
+                "⏭️  Sink unreachable (%s — sound witness) — skipping "
+                "expensive analysis", reachability_verdict,
+            )
             return AutonomousAnalysisResult(
                 finding=finding,
                 analysis=None,
@@ -1202,7 +1126,7 @@ class AutonomousCodeQLAnalyzer:
                 refinement_iterations=0,
                 total_duration_seconds=time.time() - start_time,
                 reachability_verdict=reachability_verdict,
-                skipped_reason=skipped_reason,
+                skipped_reason=f"reachability_{reachability_verdict}",
             )
 
         # Stage 2: Read vulnerable code

--- a/packages/codeql/tests/test_reachability_prefilter.py
+++ b/packages/codeql/tests/test_reachability_prefilter.py
@@ -8,10 +8,21 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 
+from core.inventory.reach_witness import (
+    STRUCTURALLY_SUPPRESSIBLE_KINDS,
+    verdict_from_classification,
+)
 from packages.codeql.autonomous_analyzer import (
     AutonomousCodeQLAnalyzer,
     CodeQLFinding,
 )
+
+
+def _suppresses(verdict, earned=STRUCTURALLY_SUPPRESSIBLE_KINDS) -> bool:
+    """Mirror the caller's hard-skip decision: a verdict hard-suppresses
+    iff its witness may_suppress on the earned set (empty earned set =
+    --allow-unreachable mode)."""
+    return verdict_from_classification(verdict).may_suppress(earned)
 
 
 def _analyzer() -> AutonomousCodeQLAnalyzer:
@@ -75,9 +86,10 @@ def test_path_to_module_empty():
 # ---------------------------------------------------------------------------
 
 
-def test_reachability_called_for_used_function(tmp_path):
-    """A function that's called from another function in the
-    project returns ``"called"``."""
+def test_reachability_reachable_for_used_function(tmp_path):
+    """A function reachable from an entry (here: called by ``main``)
+    returns ``"reachable"`` under the entry-aware classifier — and is
+    not hard-suppressed."""
     src = tmp_path / "src"
     src.mkdir()
     (src / "vuln.py").write_text(
@@ -92,7 +104,8 @@ def test_reachability_called_for_used_function(tmp_path):
     a = _analyzer()
     finding = _finding("src/vuln.py", line=2)
     verdict = a._check_reachability(finding, tmp_path)
-    assert verdict == "called"
+    assert verdict == "reachable"
+    assert _suppresses(verdict) is False
 
 
 def test_reachability_not_called_for_dead_function(tmp_path):
@@ -264,48 +277,85 @@ def test_checklist_path_invalid_falls_back_to_build(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_short_circuit_on_not_called(tmp_path, monkeypatch):
-    """When the prefilter returns ``"not_called"``,
-    analyze_finding_autonomous returns immediately — the
-    expensive dataflow validator + LLM stages are NOT invoked."""
+def test_sound_witness_short_circuits(tmp_path, monkeypatch):
+    """A SOUND, corpus-earned witness (module_aborts) hard-suppresses:
+    analyze_finding_autonomous returns immediately, before the expensive
+    dataflow validator + LLM stages."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "disabled.py").write_text(
+        "raise ImportError('retired')\n"
+        "def dead(q):\n"
+        "    cursor.execute(q)\n"
+    )
+    a = _analyzer()
+    canned = _finding("src/disabled.py", line=3)
+    monkeypatch.setattr(a, "parse_sarif_finding", lambda r, run: canned)
+    a.dataflow_validator = MagicMock()
+    a.dataflow_validator.validate_finding.side_effect = AssertionError(
+        "dataflow validator was invoked despite short-circuit"
+    )
+    result = a.analyze_finding_autonomous(
+        sarif_result={}, sarif_run={},
+        repo_path=tmp_path, out_dir=tmp_path / "out",
+    )
+    assert result.skipped_reason == "reachability_module_aborts"
+    assert result.reachability_verdict == "module_aborts"
+    assert result.exploitable is False
+    a.dataflow_validator.validate_finding.assert_not_called()
+
+
+def test_allow_unreachable_disables_hard_skip_in_analyze(tmp_path, monkeypatch):
+    """Wiring: with allow_unreachable=True the analyzer's earned set is
+    empty, so even a module_aborts finding is NOT short-circuited — the
+    pipeline proceeds (dataflow validator IS reached)."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "disabled.py").write_text(
+        "raise ImportError('retired')\n"
+        "def dead(q):\n"
+        "    cursor.execute(q)\n"
+    )
+    a = AutonomousCodeQLAnalyzer(
+        llm_client=MagicMock(), exploit_validator=MagicMock(),
+        multi_turn_analyzer=None, enable_visualization=False,
+        allow_unreachable=True,
+    )
+    canned = _finding("src/disabled.py", line=3)
+    monkeypatch.setattr(a, "parse_sarif_finding", lambda r, run: canned)
+    # Stop the pipeline right after the skip gate so we don't exercise the
+    # whole analysis — a sentinel proves we got PAST the short-circuit.
+    monkeypatch.setattr(
+        a, "read_vulnerable_code",
+        MagicMock(side_effect=RuntimeError("reached past skip gate")),
+    )
+    try:
+        a.analyze_finding_autonomous(
+            sarif_result={}, sarif_run={},
+            repo_path=tmp_path, out_dir=tmp_path / "out",
+        )
+        reached = False
+    except RuntimeError as e:
+        reached = "past skip gate" in str(e)
+    assert reached, "allow_unreachable must NOT short-circuit module_aborts"
+
+
+def test_not_called_no_longer_hard_suppresses(tmp_path):
+    """U11: not_called is HEURISTIC — it does NOT hard-suppress (surface-
+    only). The prefilter still classifies it, but the caller's
+    may_suppress() decision declines to skip."""
     src = tmp_path / "src"
     src.mkdir()
     (src / "vuln.py").write_text(
         "def dead(q):\n"
         "    cursor.execute(q)\n"
-        "\n"
-        "def other():\n"
-        "    pass\n"
     )
-    (src / "main.py").write_text(
-        "from src.vuln import other\nother()\n"
-    )
-
     a = _analyzer()
-    # Stub out the parser to skip SARIF shape parsing in this test.
-    canned = _finding("src/vuln.py", line=2)
-    monkeypatch.setattr(
-        a, "parse_sarif_finding", lambda r, run: canned,
+    verdict = a._check_reachability(_finding("src/vuln.py", line=2), tmp_path)
+    assert verdict == "not_called"
+    assert _suppresses(verdict) is False, (
+        "not_called is heuristic and must not hard-suppress"
     )
-
-    # Replace the dataflow_validator with a mock so we can assert
-    # it was never called (short-circuit happened before stage 3).
-    a.dataflow_validator = MagicMock()
-    a.dataflow_validator.validate_finding.side_effect = AssertionError(
-        "dataflow validator was invoked despite short-circuit"
-    )
-
-    result = a.analyze_finding_autonomous(
-        sarif_result={}, sarif_run={},
-        repo_path=tmp_path, out_dir=tmp_path / "out",
-    )
-    assert result.skipped_reason == "reachability_not_called"
-    assert result.reachability_verdict == "not_called"
-    assert result.exploitable is False
-    # The dataflow validator must NOT have been invoked — its
-    # side_effect would have raised. The short-circuit fires
-    # before stage 3.
-    a.dataflow_validator.validate_finding.assert_not_called()
 
 
 def test_no_short_circuit_when_called(tmp_path, monkeypatch):
@@ -446,25 +496,19 @@ def test_framework_callable_does_not_short_circuit(
 # ---------------------------------------------------------------------------
 
 
-def test_allow_unreachable_suppresses_not_called_short_circuit(tmp_path):
-    """C2: --allow-unreachable on the analyzer → the prefilter
-    returns None (no opinion) instead of 'not_called', letting
-    the caller proceed with full LLM analysis."""
-    src = tmp_path / "src"
-    src.mkdir()
-    (src / "v.py").write_text(
-        "def dead(): cursor.execute('x')\n"
-    )
-    a = AutonomousCodeQLAnalyzer(
-        llm_client=MagicMock(), exploit_validator=MagicMock(),
-        multi_turn_analyzer=None, enable_visualization=False,
-        allow_unreachable=True,
-    )
-    verdict = a._check_reachability(_finding("src/v.py", line=1), tmp_path)
-    assert verdict is None, (
-        f"--allow-unreachable must suppress not_called signal; "
-        f"got {verdict!r}"
-    )
+def test_allow_unreachable_empties_earned_set_so_nothing_suppresses(tmp_path):
+    """Under --allow-unreachable the caller's earned set is empty, so NO
+    verdict hard-suppresses — even the sound module_aborts / lexical_dead.
+    The prefilter still classifies (for reporting); the decision declines."""
+    for verdict in ("module_aborts", "lexical_dead", "not_called"):
+        # allow-unreachable: earned set empty -> nothing suppresses
+        assert _suppresses(verdict, earned=frozenset()) is False, (
+            f"{verdict} must not suppress under allow_unreachable"
+        )
+    # sanity: in default mode the sound witnesses DO suppress
+    assert _suppresses("module_aborts") is True
+    assert _suppresses("lexical_dead") is True
+    assert _suppresses("not_called") is False   # heuristic, never suppresses
 
 
 def test_default_still_returns_not_called(tmp_path):
@@ -578,12 +622,12 @@ def test_allow_unreachable_suppresses_module_abort(tmp_path):
         multi_turn_analyzer=None, enable_visualization=False,
         allow_unreachable=True,
     )
+    # The prefilter still classifies module_aborts (for reporting); under
+    # --allow-unreachable the caller's earned set is empty, so it does not
+    # hard-suppress (the operator wants in-isolation evaluation).
     verdict = a._check_reachability(_finding("src/disabled.py", line=3), tmp_path)
-    # With the gate suppressed, the sink falls through to the call-
-    # graph verdict. `sink` IS called by `entry`'s peer... here there's
-    # no caller, so it's not_called — but --allow-unreachable also
-    # suppresses not_called → None. The key assertion: NOT module_aborts.
-    assert verdict != "module_aborts"
+    assert verdict == "module_aborts"
+    assert _suppresses(verdict, earned=frozenset()) is False
 
 
 def test_function_above_abort_not_module_aborts(tmp_path):
@@ -647,4 +691,5 @@ def test_allow_unreachable_suppresses_lexical_dead(tmp_path):
         allow_unreachable=True,
     )
     verdict = a._check_reachability(_finding("src/mod.py", line=3), tmp_path)
-    assert verdict != "lexical_dead"
+    assert verdict == "lexical_dead"
+    assert _suppresses(verdict, earned=frozenset()) is False


### PR DESCRIPTION
  The final two units of the reachability-accuracy arc — enforcement tightening plus a heuristic extraction improvement.

  - Sound-witness enforcement (U11): the CodeQL prefilter now hard-skips expensive analysis ONLY on a sound, config-independent witness (module_aborts / lexical_dead). Heuristic verdicts (not_called /
  no_path_from_entry) are surface-only — recorded and soft-demoted by the enrichment prepass, but still fully analysed — closing a false-negative class (reflection / cross-file / address-of edges the static
  graph can't see). --allow-unreachable empties the earned set, so nothing hard-suppresses in isolation review.
  - Config-aware #ifdef (U12): the C/C++ TranslationView resolves #ifdef / #if defined(X) / #if X against a build macro config (an allowlist from compile_commands.json -D/-U or a kernel .config). Symbols absent
  from the config stay unknown and are never blanked — they may be #defined in a header, so treating absence as undefined would delete live code. Cannot over-fire by construction. Line-preserving, no subprocess;
   fidelity 2 = heuristic (earns no hard-suppression — only the sound witnesses do).

  Net: hard-suppression fires only on sound structural witnesses, while config-aware blanking sharpens the heuristic extraction that feeds every downstream consumer.
