### PR TITLE
feat(provenance): seal per-run manifest + surface in /project

### DIFF
--- a/core/llm/client.py
+++ b/core/llm/client.py
@@ -301,6 +301,11 @@ class LLMClient:
         self.total_cost = 0.0
         self.request_count = 0
         self.task_type_costs: Dict[str, float] = {}  # task_type → cumulative cost
+        # Distinct models actually invoked during this client's lifetime,
+        # keyed by (provider, alias, resolved, role) → call count. Feeds the
+        # run provenance manifest. Cache hits are NOT recorded — a cache hit
+        # fired no provider call. Guarded by _stats_lock.
+        self._fired_models: Dict[tuple, int] = {}
         # Number of full ANALYSE calls avoided because the scorecard
         # trusted the cheap-tier verdict and the consumer short-
         # circuited. Bumped by consumers via ``record_short_circuit``;
@@ -552,6 +557,48 @@ class LLMClient:
             # Schemas should always serialise; fall back to a stable
             # repr if a caller passes something weird.
             return repr(sorted(kwargs.items()))
+
+    def _record_fired_model(self, provider: str, alias: str,
+                            resolved: Optional[str], role: str) -> None:
+        """Record that a provider call fired for (provider, alias, role).
+
+        ``resolved`` is the provider-served snapshot when the SDK exposed one,
+        else None (alias-only — never guessed). Deduped by the full key so the
+        manifest stays compact; repeated calls bump the count.
+
+        Never raises. This runs inside the generation try-block, and provenance
+        bookkeeping must not be able to fail a real LLM call — including on a
+        client built via ``__new__`` that skipped ``__init__`` (some test and
+        dispatcher paths do this), where ``_fired_models`` / ``_stats_lock`` may
+        be absent. Lazily initialises the map and swallows any error.
+        """
+        try:
+            key = (provider, alias, resolved, role)
+            with self._stats_lock:
+                fired = getattr(self, "_fired_models", None)
+                if fired is None:
+                    fired = self._fired_models = {}
+                fired[key] = fired.get(key, 0) + 1
+        except Exception:
+            pass
+
+    def get_fired_models(self) -> list:
+        """Distinct models invoked during this run (cache hits excluded).
+
+        Each entry: ``{provider, alias, resolved, role, calls}``. ``resolved``
+        is the served snapshot or None. Powers the provenance manifest's model
+        attribution. Empty when no provider call fired (a fully cached re-run,
+        or a non-LLM command) — which is the honest record, not a gap.
+        """
+        fired = getattr(self, "_fired_models", None)
+        if not fired:
+            return []
+        with self._stats_lock:
+            items = list(fired.items())
+        return [
+            {"provider": p, "alias": a, "resolved": r, "role": role, "calls": n}
+            for (p, a, r, role), n in items
+        ]
 
     def _get_cache_key(
         self, prompt: str, system_prompt: Optional[str], model: str,
@@ -954,6 +1001,14 @@ class LLMClient:
                         # Cache response
                         self._save_to_cache(cache_key, response)
 
+                        # Record provenance: this provider call fired. role is
+                        # primary for the first model tried, fallback otherwise.
+                        self._record_fired_model(
+                            model.provider, model.model_name,
+                            response.resolved_model,
+                            "primary" if model_idx == 0 else "fallback",
+                        )
+
                         logger.debug(f"Generation successful: {model.provider}/{model.model_name} "
                                     f"(tokens: {response.tokens_used}, cost: ${response.cost:.4f}, "
                                     f"duration: {duration:.1f}s)")
@@ -1182,6 +1237,10 @@ class LLMClient:
                                     f"duration: {duration:.1f}s)")
 
                         result_dict, raw = result_tuple
+                        # Lift the resolved snapshot the provider attached
+                        # (StructuredResponse carries it; a bare-tuple return
+                        # yields None — alias-only, never guessed).
+                        resolved = getattr(result_tuple, "resolved_model", None)
                         structured_response = StructuredResponse(
                             result=result_dict,
                             raw=raw,
@@ -1190,6 +1249,11 @@ class LLMClient:
                             model=model.model_name,
                             provider=model.provider,
                             duration=duration,
+                            resolved_model=resolved,
+                        )
+                        self._record_fired_model(
+                            model.provider, model.model_name, resolved,
+                            "primary" if model_idx == 0 else "fallback",
                         )
                         # Cache before returning so repeated identical calls
                         # short-circuit the provider entirely. Cache key is

--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -103,6 +103,11 @@ class LLMResponse:
     output_tokens: int = 0
     thinking_tokens: int = 0
     duration: float = 0.0
+    # The concrete model snapshot the provider actually served, lifted from
+    # the SDK response when it exposes one (e.g. alias "gemini-2.5-pro" →
+    # "gemini-2.5-pro-002"). None when the provider doesn't surface it — the
+    # provenance manifest then records the alias only, never a guess.
+    resolved_model: Optional[str] = None
 
 
 @dataclass
@@ -119,10 +124,36 @@ class StructuredResponse:
     provider: str = ""
     duration: float = 0.0
     cached: bool = False
+    # Concrete model snapshot the provider served (see LLMResponse.resolved_model).
+    resolved_model: Optional[str] = None
 
     def __iter__(self):
         """Allow unpacking as 2-tuple for backwards compatibility."""
         return iter((self.result, self.raw))
+
+
+def extract_resolved_model(raw: Any) -> Optional[str]:
+    """Best-effort: the concrete model id from a provider SDK response object.
+
+    Providers are configured with floating aliases ("gemini-2.5-pro"); the SDK
+    response usually echoes the snapshot the provider actually served
+    ("gemini-2.5-pro-002"). That snapshot is the only honest record of *which*
+    model ran, so we lift it when present. Returns None when the SDK doesn't
+    surface it — callers then fall back to the alias and never fabricate a
+    snapshot. Never raises; provenance must not break a generation.
+    """
+    if raw is None:
+        return None
+    # OpenAI / litellm / Anthropic SDK response objects expose `.model`;
+    # Google genai exposes `.model_version`.
+    for attr in ("model", "model_version"):
+        try:
+            value = getattr(raw, attr, None)
+        except Exception:
+            value = None
+        if isinstance(value, str) and value:
+            return value
+    return None
 
 
 class LLMProvider(ABC):
@@ -148,8 +179,12 @@ class LLMProvider(ABC):
     @abstractmethod
     def generate_structured(self, prompt: str, schema: Dict[str, Any],
                            system_prompt: Optional[str] = None,
-                           **kwargs) -> Tuple[Dict[str, Any], str]:
+                           **kwargs) -> "StructuredResponse":
         """Generate structured output matching the provided schema.
+
+        Returns a ``StructuredResponse`` (which unpacks as a ``(result, raw)``
+        2-tuple via ``__iter__`` for backwards compatibility, and carries the
+        resolved model snapshot).
 
         ``**kwargs`` accepts per-call generation overrides — most
         notably ``temperature``. Pre-fix the abstract signature did
@@ -362,7 +397,13 @@ class LLMProvider(ABC):
             parsed = _coerce_to_schema(parsed, schema)
             validated = pydantic_model.model_validate(parsed)
             result_dict = validated.model_dump()
-            return result_dict, json.dumps(result_dict, indent=2)
+            # Carry the resolved model from the underlying generate() call so
+            # the JSON-fallback path attributes correctly too.
+            return StructuredResponse(
+                result=result_dict,
+                raw=json.dumps(result_dict, indent=2),
+                resolved_model=response.resolved_model,
+            )
         except Exception as e:
             # Pre-fix the logger interpolated `e` directly into the
             # log line. For `pydantic.ValidationError` (the typical
@@ -943,6 +984,7 @@ class OpenAICompatibleProvider(LLMProvider):
                 output_tokens=output_tokens,
                 thinking_tokens=thinking_tokens,
                 duration=duration,
+                resolved_model=extract_resolved_model(response),
             )
 
         except Exception as e:
@@ -1004,7 +1046,11 @@ class OpenAICompatibleProvider(LLMProvider):
                 cost = self._calculate_cost_split(input_tokens, output_tokens, thinking_tokens)
                 self.track_usage(tokens_used, cost, input_tokens, output_tokens, duration)
 
-                return result_dict, full_response
+                return StructuredResponse(
+                    result=result_dict,
+                    raw=full_response,
+                    resolved_model=extract_resolved_model(completion),
+                )
 
             except Exception as e:
                 if not self._instructor_warned:
@@ -1522,6 +1568,7 @@ class AnthropicProvider(LLMProvider):
                 output_tokens=output_tokens,
                 thinking_tokens=thinking_tokens,
                 duration=duration,
+                resolved_model=extract_resolved_model(response),
             )
 
         except Exception as e:
@@ -1578,7 +1625,11 @@ class AnthropicProvider(LLMProvider):
                 cost = self._calculate_cost_split(input_tokens, output_tokens, thinking_tokens)
                 self.track_usage(tokens_used, cost, input_tokens, output_tokens, duration)
 
-                return result_dict, full_response
+                return StructuredResponse(
+                    result=result_dict,
+                    raw=full_response,
+                    resolved_model=extract_resolved_model(completion),
+                )
 
             except Exception as e:
                 if not self._instructor_warned:
@@ -2086,6 +2137,7 @@ class GeminiProvider(LLMProvider):
                 tokens_used=tokens_used,
                 cost=cost,
                 finish_reason=finish_reason,
+                resolved_model=extract_resolved_model(response),
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
                 thinking_tokens=thinking_tokens,
@@ -2161,7 +2213,11 @@ class GeminiProvider(LLMProvider):
             logger.debug(f"[Gemini] structured model={self.config.model_name}, tokens={tokens_used}, "
                          f"cost=${cost:.4f}, duration={duration:.2f}s, thinking={thinking_tokens}")
 
-            return result_dict, full_response
+            return StructuredResponse(
+                result=result_dict,
+                raw=full_response,
+                resolved_model=extract_resolved_model(response),
+            )
 
         except (json.JSONDecodeError, ValueError, KeyError) as e:
             # Schema/parsing error — native mode incompatible, fall back to JSON-in-prompt
@@ -2415,6 +2471,14 @@ class ClaudeCodeLLMProvider(LLMProvider):
             duration=duration,
         )
 
+        # The claude-code harness reports the model it used in `analysed_by`;
+        # treat that as the resolved snapshot. But cc_adapter may set it to a
+        # comma-joined list (main + tool-routing helper) — that's not a single
+        # snapshot, so leave resolved_model None rather than emit a bogus
+        # multi-value "version" into the manifest/scorecard.
+        analysed_by = parsed.get("analysed_by")
+        resolved = analysed_by if (analysed_by and "," not in analysed_by) else None
+
         return LLMResponse(
             content=content,
             model=parsed.get("analysed_by", self.config.model_name),
@@ -2422,6 +2486,7 @@ class ClaudeCodeLLMProvider(LLMProvider):
             tokens_used=tokens,
             cost=cost,
             finish_reason="stop",
+            resolved_model=resolved,
             input_tokens=0,
             output_tokens=tokens,
             duration=duration,

--- a/core/llm/scorecard/consensus.py
+++ b/core/llm/scorecard/consensus.py
@@ -145,34 +145,39 @@ def record_consensus_outcomes(
         for model, verdict in verdicts.items():
             with_majority = (verdict == majority_says_exploitable)
             outcome = "correct" if with_majority else "incorrect"
+            # This model's per-finding result — used both for the resolved
+            # model snapshot (model_version) and, on disagreement, the sample.
+            this_model_result = next(
+                (r for r in this_finding_per_model
+                 if str(r.get("analysed_by") or r.get("model") or "") == model),
+                None,
+            )
+            # Concrete snapshot the provider served (e.g. gemini-2.5-pro-002);
+            # None when unavailable so the cell stays alias-keyed, never guessed.
+            model_version = (this_model_result or {}).get("resolved_model")
             sample = None
-            if outcome == "incorrect":
+            if outcome == "incorrect" and this_model_result is not None:
                 # Capture the minority model's OWN reasoning. If we
                 # can't find it in ``per_finding_results`` (caller
                 # didn't supply, or the per-model record is missing),
                 # skip the sample rather than fall back to the
                 # primary's reasoning — that would mis-attribute the
                 # majority's text to the dissenter.
-                this_model_result = next(
-                    (r for r in this_finding_per_model
-                     if str(r.get("analysed_by") or r.get("model") or "") == model),
-                    None,
-                )
-                if this_model_result is not None:
-                    reasoning = str(this_model_result.get("reasoning") or "")
-                    sample = {
-                        "this_reasoning": reasoning[:_MAX_REASONING_CHARS],
-                        "other_reasoning": (
-                            f"majority of {len(verdicts)} models voted "
-                            f"{'exploitable' if majority_says_exploitable else 'not exploitable'}"
-                        ),
-                    }
+                reasoning = str(this_model_result.get("reasoning") or "")
+                sample = {
+                    "this_reasoning": reasoning[:_MAX_REASONING_CHARS],
+                    "other_reasoning": (
+                        f"majority of {len(verdicts)} models voted "
+                        f"{'exploitable' if majority_says_exploitable else 'not exploitable'}"
+                    ),
+                }
             try:
                 scorecard.record_event(
                     decision_class=decision_class,
                     model=model,
                     event_type=EventType.MULTI_MODEL_CONSENSUS,
                     outcome=outcome,
+                    model_version=model_version,
                     sample=sample,
                 )
                 n_recorded += 1

--- a/core/llm/scorecard/judge.py
+++ b/core/llm/scorecard/judge.py
@@ -96,6 +96,7 @@ def record_judge_outcomes(
             scorecard,
             decision_class=decision_class,
             model=primary_model,
+            model_version=result.get("resolved_model"),
             outcome="correct" if primary_correct else "incorrect",
             sample_reasoning=(
                 None if primary_correct
@@ -117,6 +118,7 @@ def record_judge_outcomes(
                 scorecard,
                 decision_class=decision_class,
                 model=judge_model,
+                model_version=ja.get("resolved_model"),
                 outcome="correct" if judge_correct else "incorrect",
                 sample_reasoning=(
                     None if judge_correct
@@ -139,6 +141,7 @@ def _record_one(
     outcome: str,
     sample_reasoning: Optional[str],
     other_summary: str,
+    model_version: Optional[str] = None,
 ) -> None:
     sample = None
     if outcome == "incorrect" and sample_reasoning is not None:
@@ -152,6 +155,7 @@ def _record_one(
             model=model,
             event_type=EventType.JUDGE_REVIEW,
             outcome=outcome,
+            model_version=model_version,
             sample=sample,
         )
     except Exception as e:                              # noqa: BLE001

--- a/core/llm/scorecard/tests/test_consensus.py
+++ b/core/llm/scorecard/tests/test_consensus.py
@@ -99,6 +99,37 @@ class TestDisputedFindings:
         assert _stat(scorecard, dc, "opus",  EventType.MULTI_MODEL_CONSENSUS) == (1, 0)
         assert _stat(scorecard, dc, "flash", EventType.MULTI_MODEL_CONSENSUS) == (0, 1)
 
+    def test_resolved_model_recorded_as_model_version(self, scorecard):
+        """The per-model result's resolved snapshot lands in the cell's
+        model_version; a model with no resolved snapshot stays alias-only
+        (empty), never guessed."""
+        matrix = {
+            "f1": {
+                "pro":   {"is_exploitable": True},
+                "opus":  {"is_exploitable": True},
+                "flash": {"is_exploitable": False},
+            },
+        }
+        confidence = {"f1": "disputed"}
+        results = {"f1": {"rule_id": "py/sqli", "reasoning": "..."}}
+        per_finding_results = {"f1": [
+            {"analysed_by": "pro", "resolved_model": "gemini-2.5-pro-002", "reasoning": "x"},
+            {"analysed_by": "flash", "resolved_model": "gemini-2.5-flash-001", "reasoning": "y"},
+            # 'opus' intentionally has no resolved_model.
+            {"analysed_by": "opus", "reasoning": "z"},
+        ]}
+        record_consensus_outcomes(
+            scorecard,
+            correlation=_correlation(matrix=matrix, confidence=confidence),
+            results_by_id=results,
+            per_finding_results=per_finding_results,
+        )
+        dc = "agentic:py/sqli"
+        assert scorecard.get_stat(dc, "pro").model_version == "gemini-2.5-pro-002"
+        assert scorecard.get_stat(dc, "flash").model_version == "gemini-2.5-flash-001"
+        # No snapshot supplied → alias-only, not fabricated.
+        assert scorecard.get_stat(dc, "opus").model_version == ""
+
     def test_1v2_minority_incorrect_majority_correct(self, scorecard):
         """Symmetric case: 2 say not-exploitable, 1 dissents (says exploitable)."""
         matrix = {

--- a/core/llm/scorecard/tests/test_judge.py
+++ b/core/llm/scorecard/tests/test_judge.py
@@ -105,6 +105,35 @@ class TestMultiJudgeDispute:
         assert _stat(scorecard, dc, "gpt-4",       EventType.JUDGE_REVIEW) == (1, 0)
         assert _stat(scorecard, dc, "gemini",      EventType.JUDGE_REVIEW) == (1, 0)
 
+    def test_resolved_model_recorded_as_model_version(self, scorecard):
+        """Regression: the primary's and EACH judge's resolved snapshot must
+        land in the cell model_version. Previously tasks.py dropped
+        resolved_model from the judge_analyses projection, so judge cells were
+        always model_version=None."""
+        results = {"f1": {
+            "rule_id": "py/sqli",
+            "judge": "disputed",
+            "is_exploitable": False,
+            "analysed_by": "claude-opus",
+            "resolved_model": "claude-opus-4-7",
+            "reasoning": "x",
+            "judge_analyses": [
+                {"model": "gpt-4", "resolved_model": "gpt-4-0613",
+                 "is_exploitable": False, "reasoning": "a"},
+                {"model": "gemini", "resolved_model": "gemini-2.5-pro-002",
+                 "is_exploitable": False, "reasoning": "b"},
+            ],
+        }}
+        record_judge_outcomes(
+            scorecard,
+            results_by_id=results,
+            primary_verdicts_before_judge={"f1": True},
+        )
+        dc = "agentic:py/sqli"
+        assert scorecard.get_stat(dc, "claude-opus").model_version == "claude-opus-4-7"
+        assert scorecard.get_stat(dc, "gpt-4").model_version == "gpt-4-0613"
+        assert scorecard.get_stat(dc, "gemini").model_version == "gemini-2.5-pro-002"
+
     def test_panel_kept_primary(self, scorecard):
         """Primary said exploitable; 1 judge dissented but the other
         agreed. With 3 voters (primary + 2 judges) and 2-vs-1

--- a/core/llm/tests/test_resolved_model.py
+++ b/core/llm/tests/test_resolved_model.py
@@ -1,0 +1,91 @@
+"""Tests for resolved-model capture: extract_resolved_model + the client's
+fired-models accumulator (provenance Phase 2)."""
+
+import threading
+import unittest
+from types import SimpleNamespace
+
+from core.llm.client import LLMClient
+from core.llm.providers import extract_resolved_model
+
+
+class TestExtractResolvedModel(unittest.TestCase):
+
+    def test_openai_anthropic_style_model_attr(self):
+        resp = SimpleNamespace(model="gemini-2.5-pro-002")
+        self.assertEqual(extract_resolved_model(resp), "gemini-2.5-pro-002")
+
+    def test_gemini_style_model_version_attr(self):
+        # No `.model`, but `.model_version` (google-genai shape).
+        resp = SimpleNamespace(model_version="gemini-2.5-pro-002")
+        self.assertEqual(extract_resolved_model(resp), "gemini-2.5-pro-002")
+
+    def test_empty_model_falls_through_to_model_version(self):
+        resp = SimpleNamespace(model="", model_version="snap-1")
+        self.assertEqual(extract_resolved_model(resp), "snap-1")
+
+    def test_none_and_missing_return_none(self):
+        self.assertIsNone(extract_resolved_model(None))
+        self.assertIsNone(extract_resolved_model(SimpleNamespace()))
+
+    def test_non_string_model_ignored(self):
+        # A non-string `.model` (e.g. an enum/object) is not a snapshot id.
+        resp = SimpleNamespace(model=123)
+        self.assertIsNone(extract_resolved_model(resp))
+
+    def test_attribute_access_raising_is_swallowed(self):
+        class Hostile:
+            @property
+            def model(self):
+                raise RuntimeError("boom")
+        # Must not propagate — provenance capture cannot break generation.
+        self.assertIsNone(extract_resolved_model(Hostile()))
+
+
+def _bare_client() -> LLMClient:
+    """Client built via __new__ (skips __init__), with only the lock the
+    accumulator needs — mirrors the dispatcher/test construction path the
+    defensive methods must tolerate."""
+    c = LLMClient.__new__(LLMClient)
+    c._stats_lock = threading.RLock()
+    return c
+
+
+class TestFiredModels(unittest.TestCase):
+
+    def test_empty_when_nothing_fired(self):
+        self.assertEqual(_bare_client().get_fired_models(), [])
+
+    def test_dedup_and_count(self):
+        c = _bare_client()
+        c._record_fired_model("gemini", "gemini-2.5-pro", "gemini-2.5-pro-002", "primary")
+        c._record_fired_model("gemini", "gemini-2.5-pro", "gemini-2.5-pro-002", "primary")
+        fired = c.get_fired_models()
+        self.assertEqual(len(fired), 1)
+        entry = fired[0]
+        self.assertEqual(entry["calls"], 2)
+        self.assertEqual(entry["resolved"], "gemini-2.5-pro-002")
+        self.assertEqual(entry["role"], "primary")
+        self.assertEqual(entry["provider"], "gemini")
+
+    def test_role_and_resolved_distinguish_entries(self):
+        c = _bare_client()
+        c._record_fired_model("gemini", "gemini-2.5-pro", "snap-a", "primary")
+        c._record_fired_model("gemini", "gemini-2.5-flash", None, "fallback")
+        fired = c.get_fired_models()
+        self.assertEqual(len(fired), 2)
+        # Alias-only (resolved=None) is preserved, never guessed.
+        flash = [e for e in fired if e["alias"] == "gemini-2.5-flash"][0]
+        self.assertIsNone(flash["resolved"])
+        self.assertEqual(flash["role"], "fallback")
+
+    def test_record_never_raises_without_lock(self):
+        # A client missing even _stats_lock must not crash recording.
+        c = LLMClient.__new__(LLMClient)
+        c._record_fired_model("p", "a", None, "primary")  # no exception
+        # get_fired_models also tolerant.
+        self.assertEqual(c.get_fired_models(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -83,6 +83,25 @@ def main():
         help="Exit non-zero unless LLM item coverage is at least this percentage",
     )
 
+    # provenance
+    p_prov = sub.add_parser(
+        "provenance",
+        help="Show provenance rollup across all runs (SHAs, engines, models, reproducibility)",
+        usage="raptor project provenance [<name>]",
+        **_F,
+    )
+    p_prov.add_argument("name", nargs="?", help="Project name")
+
+    # show
+    p_show = sub.add_parser(
+        "show",
+        help="Show one run's provenance detail",
+        usage="raptor project show <run> [<name>]",
+        **_F,
+    )
+    p_show.add_argument("run", help="Run directory name (or unique substring)")
+    p_show.add_argument("name", nargs="?", help="Project name")
+
     # findings
     p_findings = sub.add_parser("findings", help="Show merged findings across all runs",
                                 usage="raptor project findings [<name>] [--detailed]", **_F)
@@ -303,6 +322,28 @@ def main():
             result = _print_coverage(p, detailed=args.detailed, fail_under=args.fail_under)
             if result is False:
                 sys.exit(1)
+
+        elif args.subcommand == "provenance":
+            name = args.name or _get_active_project()
+            if not name:
+                print("No project specified.")
+                return
+            p = mgr.load(name)
+            if not p:
+                print(f"Project '{name}' not found.")
+                return
+            _print_provenance(p)
+
+        elif args.subcommand == "show":
+            name = args.name or _get_active_project()
+            if not name:
+                print("No project specified.")
+                return
+            p = mgr.load(name)
+            if not p:
+                print(f"Project '{name}' not found.")
+                return
+            _print_run_provenance(p, args.run)
 
         elif args.subcommand == "findings":
             name = args.name or _get_active_project()
@@ -617,6 +658,8 @@ def main():
             print(f"  Merged findings: {stats['findings']}")
             if stats.get("annotations") is not None:
                 print(f"  Annotations: {stats['annotations']}")
+            if stats.get("provenance_markdown"):
+                print(f"  Provenance: {stats['provenance_markdown']}")
 
         elif args.subcommand == "export":
             from .export import export_project
@@ -778,7 +821,17 @@ def _print_status(project):
                 status_str = _yellow(status)
             else:
                 status_str = status
-            print(f"  {d.name:<{name_col}s}  {cmd:12s}  {findings_str:24s}  {status_str}")
+            # Compact provenance tag: "<sha7>[*] repro|llm" (* = modified tree;
+            # repro = deterministic/mechanical, llm = LLM-mediated). Empty for
+            # legacy/unavailable runs. Appended last so colour codes in
+            # status_str don't disturb column padding.
+            from core.run.provenance import format_repro_short, format_sha_short
+            _manifest = (meta or {}).get("manifest")
+            tag = " ".join(
+                t for t in (format_sha_short(_manifest), format_repro_short(_manifest)) if t
+            )
+            line = f"  {d.name:<{name_col}s}  {cmd:12s}  {findings_str:24s}  {status_str}"
+            print(f"{line}  {tag}" if tag else line)
         # Disk usage — use os.walk(followlinks=False) so we stay inside
         # the run dir even if a stray symlink points outside (or back into
         # the run, creating a loop). Path.rglob follows symlinked dirs on
@@ -807,6 +860,47 @@ def _print_status(project):
 
     else:
         print("\nNo runs.")
+
+
+def _print_provenance(project):
+    """Print the project-level provenance rollup across all runs."""
+    from core.run import load_run_metadata
+    from core.run.provenance import aggregate_provenance, format_provenance_rollup
+
+    runs = project.get_run_dirs(sweep=False)
+    metadatas = [load_run_metadata(d) for d in runs]
+    print(f"Project: {project.name}")
+    print(format_provenance_rollup(aggregate_provenance(metadatas)))
+
+
+def _print_run_provenance(project, run_query):
+    """Print one run's provenance detail. ``run_query`` matches a run dir by
+    exact name, else by unique substring."""
+    from core.run import load_run_metadata
+    from core.run.provenance import format_manifest_block
+
+    runs = project.get_run_dirs(sweep=False)
+    exact = [d for d in runs if d.name == run_query]
+    matches = exact or [d for d in runs if run_query in d.name]
+    if not matches:
+        print(f"No run matching '{run_query}' in project '{project.name}'.")
+        return
+    if len(matches) > 1:
+        print(f"Ambiguous '{run_query}' — matches {len(matches)} runs:")
+        for d in matches:
+            print(f"  {d.name}")
+        return
+
+    d = matches[0]
+    meta = load_run_metadata(d) or {}
+    print(f"Run: {d.name}")
+    print(f"  Command: {meta.get('command', '?')}")
+    ts = (meta.get("timestamp") or "")[:19]
+    if ts:
+        print(f"  When: {ts}")
+    print(f"  Status: {meta.get('status', '?')}")
+    block = format_manifest_block(meta.get("manifest"))
+    print(block or "  (no provenance manifest)")
 
 
 def _print_coverage(project, detailed=False, fail_under=None):

--- a/core/project/report.py
+++ b/core/project/report.py
@@ -482,6 +482,23 @@ def generate_project_report(project) -> Dict[str, Any]:
     annotations_md_path = report_dir / "annotations.md"
     annotations_md_path.write_text(annotations_md, encoding="utf-8")
 
+    # Per-run provenance — what produced each run (framework SHA + dirty flag,
+    # environment, engines, models that fired, reproducibility). Honest about
+    # runs with no/unavailable manifest rather than inventing current state.
+    from core.run.metadata import load_run_metadata
+    from core.run.provenance import format_manifest_block
+    prov_lines = [f"# Provenance — {project.name}", ""]
+    for d in run_dirs:
+        meta = load_run_metadata(d) or {}
+        ts = (meta.get("timestamp") or "")[:19]
+        prov_lines.append(f"## {d.name}")
+        prov_lines.append(f"{meta.get('command', '?')} · {ts}")
+        block = format_manifest_block(meta.get("manifest"), indent="- ")
+        prov_lines.append(block or "- (no provenance manifest)")
+        prov_lines.append("")
+    provenance_md_path = report_dir / "provenance.md"
+    provenance_md_path.write_text("\n".join(prov_lines), encoding="utf-8")
+
     return {
         "findings": len(merged),
         "sca_findings": len(sca_findings),
@@ -492,4 +509,5 @@ def generate_project_report(project) -> Dict[str, Any]:
         "aggregate_markdown": findings_export["aggregate_markdown"],
         "finding_buckets": findings_export["counts"],
         "annotations_markdown": str(annotations_md_path),
+        "provenance_markdown": str(provenance_md_path),
     }

--- a/core/project/tests/test_provenance_surface.py
+++ b/core/project/tests/test_provenance_surface.py
@@ -1,0 +1,79 @@
+"""E2E: `/project provenance` rollup and `/project show <run>` render real run
+directories (with real .raptor-run.json manifests) through the cli helpers."""
+
+import json
+from pathlib import Path
+
+from core.project.cli import _print_provenance, _print_run_provenance
+
+
+class _StubProject:
+    """Minimal project: the cli helpers only need .name + .get_run_dirs()."""
+
+    def __init__(self, name, runs):
+        self.name = name
+        self._runs = runs
+
+    def get_run_dirs(self, sweep=False):
+        return self._runs
+
+
+def _mk_run(parent: Path, name: str, manifest: dict, *,
+            command: str = "scan", status: str = "completed") -> Path:
+    d = parent / name
+    d.mkdir()
+    (d / ".raptor-run.json").write_text(json.dumps({
+        "version": 2, "command": command, "status": status,
+        "timestamp": "2026-05-25T10:00:00+00:00", "manifest": manifest,
+    }))
+    return d
+
+
+def test_provenance_rollup_and_show(tmp_path, capsys):
+    r1 = _mk_run(tmp_path, "scan-1", {
+        "source_control": {"base_sha": "9668aa8c3b0f", "dirty": True},
+        "environment": {"python": "3.14.4", "os": "Linux", "arch": "x86_64"},
+        "engines": {"semgrep": "1.79.0"},
+        "deterministically_reproducible": True,
+    })
+    r2 = _mk_run(tmp_path, "agentic-1", {
+        "source_control": {"base_sha": "9668aa8c3b0f", "dirty": True},
+        "models": [{"alias": "gemini-2.5-pro", "resolved": "gemini-2.5-pro",
+                    "role": "primary", "calls": 5}],
+        "deterministically_reproducible": False,
+    }, command="agentic")
+    proj = _StubProject("demo", [r1, r2])
+
+    # Rollup across runs.
+    _print_provenance(proj)
+    out = capsys.readouterr().out
+    assert "Provenance across 2 run" in out
+    assert "9668aa8c3b0f (2)" in out          # same SHA, both runs
+    assert "Modified-tree runs: 2/2" in out
+    assert "1 deterministic, 1 LLM-mediated" in out
+
+    # Per-run detail.
+    _print_run_provenance(proj, "agentic-1")
+    out = capsys.readouterr().out
+    assert "Run: agentic-1" in out
+    assert "gemini-2.5-pro" in out
+    assert "no (LLM-mediated)" in out
+
+    # Substring match.
+    _print_run_provenance(proj, "scan")
+    assert "Run: scan-1" in capsys.readouterr().out
+
+    # Missing run — graceful, no crash.
+    _print_run_provenance(proj, "nonexistent")
+    assert "No run matching" in capsys.readouterr().out
+
+
+def test_show_run_with_no_manifest_is_graceful(tmp_path, capsys):
+    d = tmp_path / "legacy-run"
+    d.mkdir()
+    (d / ".raptor-run.json").write_text(json.dumps(
+        {"version": 1, "command": "scan", "status": "completed"}))  # no manifest
+    _print_run_provenance(_StubProject("demo", [d]), "legacy-run")
+    out = capsys.readouterr().out
+    assert "Run: legacy-run" in out
+    assert "no provenance manifest" in out

--- a/core/run/metadata.py
+++ b/core/run/metadata.py
@@ -202,11 +202,19 @@ def start_run(output_dir: Path, command: str, extra: Dict[str, Any] = None,
     if session_pid is not None:
         _cleanup_abandoned(output_dir.parent, command, session_pid)
 
+    # Seal the provenance manifest NOW, before any analysis runs. The
+    # source-control snapshot in particular must be taken here — the tree
+    # can change mid-run or after, and the only honest record of what
+    # produced this run is the state at its start. complete_run merges in
+    # end-of-run facts (models that fired, engine versions).
+    from core.run.provenance import build_start_manifest
+
     metadata = {
-        "version": 1,
+        "version": 2,
         "command": command,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "status": STATUS_RUNNING,
+        "manifest": build_start_manifest(target=target),
         "extra": extra or {},
     }
     if session_pid is not None:
@@ -525,10 +533,17 @@ def _finalize_sandbox_summary(output_dir: Path) -> None:
 #    file. Misleading.
 # Finalizing first preserves the data; status update is just the signal.
 
-def complete_run(output_dir: Path, extra: Dict[str, Any] = None) -> None:
-    """Update .raptor-run.json to status=completed."""
+def complete_run(output_dir: Path, extra: Dict[str, Any] = None,
+                 manifest: Dict[str, Any] = None) -> None:
+    """Update .raptor-run.json to status=completed.
+
+    ``manifest`` merges end-of-run provenance — the models that fired, engine
+    versions, ``deterministically_reproducible`` — into the manifest sealed at
+    start_run. Top-level keys overwrite; the start-sealed source_control /
+    environment snapshots are preserved unless explicitly overwritten.
+    """
     _finalize_sandbox_summary(output_dir)
-    _update_status(output_dir, STATUS_COMPLETED, extra)
+    _update_status(output_dir, STATUS_COMPLETED, extra, manifest=manifest)
 
 
 def fail_run(output_dir: Path, error: str = None, extra: Dict[str, Any] = None,
@@ -661,11 +676,19 @@ def generate_run_metadata(run_dir: Path) -> None:
         mtime = run_dir.stat().st_mtime
         timestamp = datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
 
+    # Adopted/legacy dirs never had provenance sealed at run time, and it
+    # cannot be reconstructed (today's git/model/tool state is unrelated to
+    # the run that produced these artifacts). Stamp the manifest as
+    # explicitly unavailable so cite/reporting degrade honestly rather than
+    # backfilling current values.
+    from core.run.provenance import UNAVAILABLE_MANIFEST
+
     metadata = {
-        "version": 1,
+        "version": 2,
         "command": command,
         "timestamp": timestamp,
         "status": STATUS_COMPLETED,  # Assume completed if it exists
+        "manifest": dict(UNAVAILABLE_MANIFEST),
         "extra": {"adopted": True},
     }
 
@@ -676,7 +699,8 @@ _TERMINAL_STATUSES = frozenset({STATUS_COMPLETED, STATUS_FAILED, STATUS_CANCELLE
 
 
 def _update_status(output_dir: Path, status: str, extra: Dict[str, Any] = None,
-                   record_timing: bool = True) -> None:
+                   record_timing: bool = True,
+                   manifest: Dict[str, Any] = None) -> None:
     """Update the status field in .raptor-run.json.
 
     When record_timing is True (default), also records end_timestamp and
@@ -727,6 +751,15 @@ def _update_status(output_dir: Path, status: str, extra: Dict[str, Any] = None,
         existing_extra = metadata.get("extra", {})
         existing_extra.update(extra)
         metadata["extra"] = existing_extra
+
+    if manifest:
+        # Merge end-of-run provenance into the start-sealed manifest. Shallow
+        # top-level merge: source_control / environment (sealed at start) stay
+        # put; models / engines / deterministically_reproducible land here.
+        existing_manifest = metadata.get("manifest", {})
+        existing_manifest.update(manifest)
+        metadata["manifest"] = existing_manifest
+
     save_json(path, metadata)
 
 

--- a/core/run/provenance.py
+++ b/core/run/provenance.py
@@ -1,0 +1,525 @@
+"""Run provenance — point-in-time facts sealed into .raptor-run.json.
+
+The manifest answers "what produced this run" and must be captured WHEN
+the run executes, never reconstructed afterwards. Today's git SHA, today's
+models.json, and today's tool versions have nothing to do with the run that
+found a bug weeks ago — citing them later would be a fabrication. So
+`start_run` seals the source-control + environment snapshot before analysis
+touches anything, and `complete_run` merges in what is only knowable at the
+end (the models that actually fired, engine versions).
+
+Every value here is best-effort: a fact that cannot be determined is recorded
+as ``None``, never as a fabricated or "today" placeholder. A consumer reading
+``base_sha is None`` knows the provenance was unavailable; it must not infer
+the current HEAD.
+"""
+
+import hashlib
+import platform
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+# Repo root = parents[2] of this file:
+#   parents[0] = core/run   (this module's dir)
+#   parents[1] = core
+#   parents[2] = <repo root> (the RAPTOR checkout)
+# Derived from __file__ rather than $RAPTOR_DIR so the snapshot always
+# reflects the checkout the running code actually lives in. RAPTOR_DIR can
+# be unset for direct ``python3 raptor.py`` invocations (see the startup
+# doctor's "RAPTOR_DIR not set" warning), whereas __file__ is always right.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Per-git-call wall-clock cap. start_run sits on the hot path of every
+# command; a hung git (network filesystem, index.lock contention) must not
+# stall the run. On timeout the affected field degrades to None.
+_GIT_TIMEOUT_S = 5.0
+
+# Same cap for `<tool> --version` probes (run once at run completion).
+_PROBE_TIMEOUT_S = 5.0
+
+# Version-probe argv per analysis engine. stdout (or stderr) first line is
+# taken as the version string. Extend as engines are added.
+_VERSION_PROBES = {
+    "semgrep": ["semgrep", "--version"],
+    "codeql": ["codeql", "version", "--format=terse"],
+    "coccinelle": ["spatch", "--version"],
+}
+
+
+def _git(repo_dir: Path, *args: str, untrusted: bool = False) -> Optional[str]:
+    """Run ``git <args>`` in ``repo_dir``; return stripped stdout or None.
+
+    Best-effort: returns None on non-zero exit, missing git, timeout, or a
+    non-repository directory. Never raises — provenance capture must not be
+    able to break a run.
+
+    ``untrusted=True`` MUST be passed when ``repo_dir`` is a SCANNED TARGET
+    (attacker-controlled). A hostile ``.git/config`` (``core.fsmonitor``,
+    ``core.hooksPath``, …) can otherwise turn a plain ``git status`` into RCE
+    (CVE-2024-32002 family). It layers ``safe_git_command``'s per-invocation
+    overrides that neutralise those vectors. RAPTOR's own checkout is trusted,
+    so ``source_control_snapshot`` leaves it False.
+    """
+    # get_safe_env strips shell-evaluated vars (EDITOR/PAGER/…) before we spawn
+    # git — cheap hygiene and the house rule for every subprocess. Lazy import
+    # keeps core.config off this module's import path (no cycle at import time).
+    try:
+        from core.config import RaptorConfig
+        env = RaptorConfig.get_safe_env()
+    except Exception:
+        env = None
+    if untrusted:
+        from core.git.clone import safe_git_command
+        cmd = safe_git_command("-C", str(repo_dir), *args)
+    else:
+        cmd = ["git", "-C", str(repo_dir), *args]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_S,
+            env=env,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def source_control_snapshot(repo_dir: Optional[Path] = None) -> Dict[str, Any]:
+    """Snapshot RAPTOR's own source-control state. Sealed at run START.
+
+    Describes the *framework* version that produced the run — not the scanned
+    target (that is recorded separately as ``target_path``). An operator
+    running a modified fork shows up as ``dirty=True`` with ``diff_sha256``
+    set, so attribution stays honest about "modified from base".
+
+    Returns a dict with:
+      base_sha     full 40-char HEAD sha, or None if not a git checkout.
+      dirty        True if the working tree has uncommitted changes
+                   (including untracked files), False if clean, None if the
+                   git state could not be determined.
+      diff_sha256  sha256 hex of ``git diff HEAD`` (tracked changes) when
+                   dirty, else None. The diff *content* is never stored —
+                   only its hash — so the manifest cannot leak source. Note
+                   an untracked-only modification sets dirty=True but leaves
+                   diff_sha256 None (``git diff HEAD`` omits untracked files).
+    """
+    repo_dir = repo_dir or _REPO_ROOT
+    sha = _git(repo_dir, "rev-parse", "HEAD")
+    if sha is None:
+        # Not a git checkout (or git unavailable) — provenance unknowable.
+        # Report None across the board; do NOT substitute any current value.
+        return {"base_sha": None, "dirty": None, "diff_sha256": None}
+
+    porcelain = _git(repo_dir, "status", "--porcelain")
+    # Empty porcelain output == clean tree. None == status failed (unknowable).
+    dirty = bool(porcelain) if porcelain is not None else None
+
+    diff_sha256 = None
+    if dirty:
+        diff = _git(repo_dir, "diff", "HEAD")
+        if diff:
+            diff_sha256 = hashlib.sha256(
+                diff.encode("utf-8", "replace")
+            ).hexdigest()
+
+    return {"base_sha": sha, "dirty": dirty, "diff_sha256": diff_sha256}
+
+
+def tool_version(name: str) -> Optional[str]:
+    """Best-effort version string for an analysis engine (``semgrep`` /
+    ``codeql`` / ``coccinelle``).
+
+    Returns the first line of the tool's ``--version`` output, or None if the
+    tool is unknown, not installed, times out, or reports nothing. Never raises
+    — engine provenance is best-effort and must not break run finalisation.
+    """
+    probe = _VERSION_PROBES.get(name)
+    if not probe:
+        return None
+    try:
+        from core.config import RaptorConfig
+        env = RaptorConfig.get_safe_env()
+    except Exception:
+        env = None
+    try:
+        result = subprocess.run(
+            probe,
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_S,
+            env=env,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    out = (result.stdout or result.stderr or "").strip()
+    if not out:
+        return None
+    return out.splitlines()[0].strip() or None
+
+
+def target_snapshot(target_path: Optional[Any]) -> Optional[Dict[str, Any]]:
+    """Snapshot the SCANNED TARGET's own VCS state. Sealed at run START.
+
+    This is the other half of attribution: ``source_control_snapshot`` records
+    the framework version; this records *what code was analysed* — "found X in
+    project Y at commit Z". Returns None when there's no path or the target is
+    not a git checkout (we record nothing rather than a half-empty block).
+
+    Only commit / dirty / branch — no diff hash. We don't fingerprint someone
+    else's (possibly large, possibly sensitive) working diff. The target is
+    attacker-controlled, so every git call here uses ``untrusted=True`` (safe
+    per-invocation overrides — see ``_git``); a hostile ``.git/config`` cannot
+    turn these into code execution.
+    """
+    if not target_path:
+        return None
+    p = Path(target_path)
+    # untrusted=True: the target is attacker-controlled — a hostile .git/config
+    # could turn `git status` into RCE without the safe overrides.
+    sha = _git(p, "rev-parse", "HEAD", untrusted=True)
+    if sha is None:
+        return None
+    porcelain = _git(p, "status", "--porcelain", untrusted=True)
+    branch = _git(p, "rev-parse", "--abbrev-ref", "HEAD", untrusted=True)
+    return {
+        "vcs": "git",
+        "commit": sha,
+        "dirty": bool(porcelain) if porcelain is not None else None,
+        "branch": branch,
+    }
+
+
+# Canonical per-run output files that signal an engine ran, mapped to the
+# probe name in _VERSION_PROBES. Semgrep/CodeQL emit SARIF (``<engine>_*.sarif``;
+# ``.json`` tolerated for alternate modes); coccinelle emits ``cocci.sarif``.
+_ENGINE_OUTPUT_GLOBS = {
+    "semgrep": ("semgrep_*.sarif", "semgrep_*.json"),
+    "codeql": ("codeql_*.sarif", "codeql_*.json"),
+    "coccinelle": ("cocci.sarif", "coccinelle_*.sarif"),
+}
+
+
+def detect_engines(out_dir: Any) -> Dict[str, Optional[str]]:
+    """Which static engines left output in ``out_dir``, with each version.
+
+    Best-effort: version is None if the tool isn't installed. Shared by scan/
+    codeql completion and the agentic scan phase so engine capture is uniform.
+    """
+    out_dir = Path(out_dir)
+    engines: Dict[str, Optional[str]] = {}
+    for name, patterns in _ENGINE_OUTPUT_GLOBS.items():
+        if any(any(out_dir.glob(p)) for p in patterns):
+            engines[name] = tool_version(name)
+    return engines
+
+
+def environment_snapshot() -> Dict[str, Any]:
+    """Snapshot the runtime environment. Sealed at run START.
+
+    Coarse but stable facts about the interpreter and OS the run executed
+    under. Kept deliberately small — the heavy, run-specific provenance
+    (models, engines) is merged later by complete_run.
+
+    ``os`` / ``arch`` are deliberately coarse (``platform.system()`` +
+    ``platform.machine()``, e.g. "Linux" / "x86_64") rather than
+    ``platform.platform()``. The full string ("Linux-7.0.0-15-generic-
+    x86_64-with-glibc2.43") is a near-unique host fingerprint that nothing
+    in RAPTOR reads operationally — its only consumers would be debug
+    logs. Since the manifest is built to be publishable (for attribution),
+    we don't store fingerprint precision we'd only have to redact. Do not
+    "enrich" this back to the full platform string.
+    """
+    return {
+        "python": platform.python_version(),
+        "os": platform.system(),
+        "arch": platform.machine(),
+    }
+
+
+def build_start_manifest(repo_dir: Optional[Path] = None,
+                         target: Optional[Any] = None) -> Dict[str, Any]:
+    """Assemble the manifest fragment sealed at run START.
+
+    Carries a ``schema`` integer so the manifest can evolve independently of
+    the enclosing .raptor-run.json ``version``. complete_run later merges
+    end-of-run facts (models, engines) into this same dict.
+
+    ``target`` (the scanned path) is snapshotted into a ``target`` block when
+    it is a git checkout — the "what code was analysed" half of attribution.
+    """
+    manifest: Dict[str, Any] = {
+        "schema": 1,
+        "source_control": source_control_snapshot(repo_dir),
+        "environment": environment_snapshot(),
+    }
+    tgt = target_snapshot(target)
+    if tgt:
+        manifest["target"] = tgt
+    return manifest
+
+
+# Stamp written into the manifest of a run we cannot characterise — adopted
+# legacy directories, or anything created before manifest capture existed.
+# cite/reporting key off this to degrade honestly ("provenance unavailable")
+# instead of reading today's state and pretending it produced the run.
+UNAVAILABLE_MANIFEST: Dict[str, Any] = {
+    "schema": 1,
+    "provenance": "unavailable",
+    "reason": "run predates manifest capture",
+}
+
+
+# --- Rendering ------------------------------------------------------------
+# Shared formatters so every operator-facing surface (run listings, reports,
+# end-of-run footer) renders provenance identically. These are LOCAL views —
+# they may show source paths and full SHAs. The publication/redaction view for
+# cite is a separate concern and must not reuse these verbatim.
+
+def format_sha_short(manifest: Optional[Dict[str, Any]]) -> str:
+    """Compact VCS tag for a one-line run listing: ``<sha7>`` with a trailing
+    ``*`` when the tree was modified. Empty string when no source-control info
+    is available (legacy / unavailable runs) — callers render nothing.
+    """
+    sc = (manifest or {}).get("source_control") or {}
+    sha = sc.get("base_sha")
+    if not sha:
+        return ""
+    return sha[:7] + ("*" if sc.get("dirty") else "")
+
+
+def format_manifest_block(manifest: Optional[Dict[str, Any]],
+                          indent: str = "  ") -> str:
+    """Multi-line human-readable provenance for reports / footers. Empty string
+    when there is no manifest. Honest about unavailable provenance rather than
+    inventing current state.
+    """
+    if not manifest:
+        return ""
+    if manifest.get("provenance") == "unavailable":
+        return f"{indent}Provenance: unavailable (run predates manifest capture)"
+
+    lines = []
+    sc = manifest.get("source_control") or {}
+    if sc.get("base_sha"):
+        suffix = " (modified)" if sc.get("dirty") else ""
+        lines.append(f"{indent}RAPTOR: {sc['base_sha'][:12]}{suffix}")
+
+    env = manifest.get("environment") or {}
+    if env:
+        lines.append(
+            f"{indent}Env: Python {env.get('python', '?')} "
+            f"on {env.get('os', '?')}/{env.get('arch', '?')}"
+        )
+
+    engines = manifest.get("engines") or {}
+    if engines:
+        rendered = ", ".join(
+            f"{name} {ver or '?'}" for name, ver in sorted(engines.items())
+        )
+        lines.append(f"{indent}Engines: {rendered}")
+
+    for m in manifest.get("models") or []:
+        resolved = m.get("resolved") or m.get("alias") or "?"
+        lines.append(
+            f"{indent}Model: {m.get('alias', '?')} → {resolved} "
+            f"({m.get('role', '?')}, {m.get('calls', '?')}×)"
+        )
+
+    if "deterministically_reproducible" in manifest:
+        repro = manifest["deterministically_reproducible"]
+        lines.append(
+            f"{indent}Reproducible: "
+            + ("yes" if repro else "no (LLM-mediated)")
+        )
+
+    return "\n".join(lines)
+
+
+# --- Publication / redaction view ----------------------------------------
+# Safe top-level run fields that may be published for attribution/citation.
+# Deliberately excludes target_path (leaks operator username, internal dir
+# structure, possibly an embargoed target), session_pid / tool_pid (machine
+# state), and `extra` (a free-form grab-bag that can carry raw exception
+# strings — paths, secrets — via fail_run(error=...)).
+_PUBLIC_TOPLEVEL_FIELDS = (
+    "command", "timestamp", "end_timestamp", "duration_seconds",
+    "status", "version",
+)
+
+
+def public_view(run_metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Publish-safe projection of a run's ``.raptor-run.json`` for citation.
+
+    The full record is for LOCAL use only — `/project status`, sweep,
+    diagnostics. It carries the operator's absolute ``target_path``, machine
+    PIDs, and a free-form ``extra`` that may include raw exception text. NONE
+    of that may leave the machine. This projection is the ONLY thing a
+    cite/publish path may emit.
+
+    Allowlist, not denylist: anything not explicitly named is dropped, so a
+    field added to ``.raptor-run.json`` later cannot silently leak. ``extra``
+    is default-denied wholesale; ``target_path`` is dropped entirely (an
+    opt-in target *label* belongs to the cite UX, not to this primitive). The
+    manifest is itself publish-safe by construction — base_sha (public repo),
+    dirty flag, diff *hash* (never content), coarse env, engine versions, and
+    model snapshots — so it is forwarded under an explicit field allowlist.
+    """
+    md = run_metadata or {}
+    out: Dict[str, Any] = {}
+
+    for key in _PUBLIC_TOPLEVEL_FIELDS:
+        if key in md:
+            out[key] = md[key]
+
+    manifest = md.get("manifest") or {}
+    if not manifest:
+        return out
+
+    if manifest.get("provenance") == "unavailable":
+        out["manifest"] = {"provenance": "unavailable"}
+        return out
+
+    pub: Dict[str, Any] = {}
+    sc = manifest.get("source_control") or {}
+    if sc:
+        pub["source_control"] = {
+            "base_sha": sc.get("base_sha"),
+            "dirty": sc.get("dirty"),
+            # Hash only — the diff content is never stored, so this is safe.
+            "diff_sha256": sc.get("diff_sha256"),
+        }
+    # Field-allowlist INSIDE each sub-dict too — never forward verbatim, so a
+    # crafted/imported manifest can't smuggle a path or secret under an extra
+    # key in environment / engines / models.
+    env = manifest.get("environment") or {}
+    if isinstance(env, dict):
+        env_pub = {k: env[k] for k in ("python", "os", "arch") if k in env}
+        if env_pub:
+            pub["environment"] = env_pub
+    engines = manifest.get("engines")
+    if isinstance(engines, dict) and engines:
+        # name -> version string. Richer engine metadata (rulesets/queries),
+        # if ever added, must be re-allowlisted here — don't pass dicts through.
+        pub["engines"] = {
+            str(name): ver
+            for name, ver in engines.items()
+            if isinstance(name, str) and (ver is None or isinstance(ver, str))
+        }
+    models = manifest.get("models")
+    if isinstance(models, list) and models:
+        pub["models"] = [
+            {k: m.get(k) for k in ("provider", "alias", "resolved", "role", "calls")}
+            for m in models if isinstance(m, dict)
+        ]
+    if "deterministically_reproducible" in manifest:
+        pub["deterministically_reproducible"] = manifest["deterministically_reproducible"]
+    if pub:
+        out["manifest"] = pub
+    return out
+
+
+def format_repro_short(manifest: Optional[Dict[str, Any]]) -> str:
+    """Compact reproducibility tag for a run listing: ``repro`` (mechanical,
+    deterministic) / ``llm`` (LLM-mediated verdict) / ``""`` when unknown."""
+    if not manifest or "deterministically_reproducible" not in manifest:
+        return ""
+    return "repro" if manifest["deterministically_reproducible"] else "llm"
+
+
+def aggregate_provenance(
+    metadatas: Iterable[Optional[Dict[str, Any]]],
+) -> Dict[str, Any]:
+    """Roll up per-run ``.raptor-run.json`` manifests into a project summary.
+
+    Counts runs by framework SHA, flags modified-tree runs, unions engine
+    versions, counts runs per model (by resolved snapshot, else alias), and
+    splits reproducible vs LLM-mediated. Runs with no / unavailable manifest
+    are counted as ``unavailable`` rather than guessed.
+    """
+    summary: Dict[str, Any] = {
+        "runs": 0,
+        "shas": {},          # base_sha -> run count
+        "dirty_runs": 0,
+        "engines": {},       # name -> sorted versions seen
+        "models": {},        # resolved-or-alias -> run count
+        "reproducible": {"yes": 0, "no": 0, "unknown": 0},
+        "unavailable": 0,
+    }
+    engines_acc: Dict[str, set] = {}
+    for md in metadatas:
+        if not md:
+            continue
+        summary["runs"] += 1
+        m = md.get("manifest") or {}
+        if not m or m.get("provenance") == "unavailable":
+            if m.get("provenance") == "unavailable":
+                summary["unavailable"] += 1
+            summary["reproducible"]["unknown"] += 1
+            continue
+        sc = m.get("source_control") or {}
+        sha = sc.get("base_sha")
+        if sha:
+            summary["shas"][sha] = summary["shas"].get(sha, 0) + 1
+        if sc.get("dirty"):
+            summary["dirty_runs"] += 1
+        engines = m.get("engines")
+        if isinstance(engines, dict):  # tolerate malformed/imported manifests
+            for name, ver in engines.items():
+                engines_acc.setdefault(name, set()).add(ver or "?")
+        seen = {
+            (mdl.get("resolved") or mdl.get("alias") or "?")
+            for mdl in (m.get("models") or [])
+        }
+        for key in seen:
+            summary["models"][key] = summary["models"].get(key, 0) + 1
+        dr = m.get("deterministically_reproducible")
+        bucket = "yes" if dr is True else "no" if dr is False else "unknown"
+        summary["reproducible"][bucket] += 1
+    summary["engines"] = {k: sorted(v) for k, v in sorted(engines_acc.items())}
+    return summary
+
+
+def format_provenance_rollup(summary: Dict[str, Any]) -> str:
+    """Human-readable project-level provenance rollup from aggregate_provenance."""
+    runs = summary.get("runs", 0)
+    if not runs:
+        return "No runs with provenance."
+    lines = [f"Provenance across {runs} run(s):"]
+
+    shas = summary.get("shas") or {}
+    if shas:
+        ordered = sorted(shas.items(), key=lambda kv: (-kv[1], kv[0]))
+        lines.append("  Framework SHAs: "
+                     + ", ".join(f"{s[:12]} ({n})" for s, n in ordered))
+        if len(shas) > 1:
+            lines.append(f"    ⚠ {len(shas)} distinct RAPTOR versions across runs")
+
+    dirty = summary.get("dirty_runs", 0)
+    if dirty:
+        lines.append(f"  Modified-tree runs: {dirty}/{runs}")
+
+    engines = summary.get("engines") or {}
+    if engines:
+        lines.append("  Engines: "
+                     + "; ".join(f"{k} {'/'.join(v)}" for k, v in engines.items()))
+
+    models = summary.get("models") or {}
+    if models:
+        ordered_m = sorted(models.items(), key=lambda kv: (-kv[1], kv[0]))
+        lines.append("  Models: " + ", ".join(f"{k} ({n})" for k, n in ordered_m))
+
+    r = summary.get("reproducible") or {}
+    lines.append(
+        f"  Reproducible: {r.get('yes', 0)} deterministic, "
+        f"{r.get('no', 0)} LLM-mediated, {r.get('unknown', 0)} unknown"
+    )
+    if summary.get("unavailable"):
+        lines.append(f"  Provenance unavailable: {summary['unavailable']} run(s)")
+    return "\n".join(lines)

--- a/core/run/tests/test_metadata.py
+++ b/core/run/tests/test_metadata.py
@@ -21,8 +21,12 @@ class TestRunLifecycle(unittest.TestCase):
             meta = load_json(out / RUN_METADATA_FILE)
             self.assertEqual(meta["command"], "scan")
             self.assertEqual(meta["status"], "running")
-            self.assertEqual(meta["version"], 1)
+            self.assertEqual(meta["version"], 2)
             self.assertIn("timestamp", meta)
+            # Provenance manifest is sealed at start.
+            self.assertIn("manifest", meta)
+            self.assertIn("source_control", meta["manifest"])
+            self.assertIn("environment", meta["manifest"])
 
     def test_start_with_extra(self):
         with TemporaryDirectory() as d:
@@ -39,6 +43,26 @@ class TestRunLifecycle(unittest.TestCase):
             meta = load_json(out / RUN_METADATA_FILE)
             self.assertEqual(meta["status"], "completed")
             self.assertEqual(meta["extra"]["findings_count"], 12)
+
+    def test_complete_merges_manifest_preserving_start_seal(self):
+        with TemporaryDirectory() as d:
+            out = Path(d) / "run"
+            start_run(out, "agentic")
+            complete_run(out, manifest={
+                "models": [{
+                    "provider": "gemini", "alias": "gemini-2.5-pro",
+                    "resolved": "gemini-2.5-pro-002", "role": "primary",
+                    "calls": 3,
+                }],
+                "deterministically_reproducible": False,
+            })
+            m = load_json(out / RUN_METADATA_FILE)["manifest"]
+            # Start-sealed snapshots survive the end-of-run merge.
+            self.assertIn("source_control", m)
+            self.assertIn("environment", m)
+            # End-of-run provenance is merged in.
+            self.assertEqual(m["deterministically_reproducible"], False)
+            self.assertEqual(m["models"][0]["resolved"], "gemini-2.5-pro-002")
 
     def test_fail_updates_status(self):
         with TemporaryDirectory() as d:

--- a/core/run/tests/test_provenance.py
+++ b/core/run/tests/test_provenance.py
@@ -1,0 +1,540 @@
+"""Tests for run provenance manifest capture (core/run/provenance.py)."""
+
+import json
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from core.run.provenance import (
+    UNAVAILABLE_MANIFEST,
+    aggregate_provenance,
+    build_start_manifest,
+    detect_engines,
+    environment_snapshot,
+    format_manifest_block,
+    format_provenance_rollup,
+    format_repro_short,
+    format_sha_short,
+    public_view,
+    source_control_snapshot,
+    target_snapshot,
+    tool_version,
+)
+
+
+def _full_run_metadata() -> dict:
+    """A realistic .raptor-run.json with both safe and sensitive fields."""
+    return {
+        "version": 2,
+        "command": "agentic",
+        "timestamp": "2026-05-24T16:00:00+00:00",
+        "end_timestamp": "2026-05-24T16:05:00+00:00",
+        "duration_seconds": 300.0,
+        "status": "completed",
+        # --- sensitive — must never be published ---
+        "target_path": "/home/jcartwright/clients/acme/secret-product/src",
+        "session_pid": 1434317,
+        "tool_pid": 1794072,
+        "extra": {"error": "FileNotFoundError: /home/jcartwright/.ssh/id_rsa", "packs": ["x"]},
+        # --- manifest ---
+        "manifest": {
+            "schema": 1,
+            "source_control": {"base_sha": "9668aa8c", "dirty": True, "diff_sha256": "deadbeef"},
+            # Target block: captured locally, but its commit/branch may be a
+            # private engagement — opt-in for publication, so public_view drops it.
+            "target": {"vcs": "git", "commit": "4f2a9b1c", "dirty": False, "branch": "release/2.3"},
+            "environment": {"python": "3.14.4", "os": "Linux", "arch": "x86_64"},
+            "engines": {"semgrep": "1.79.0"},
+            "models": [{"alias": "gemini-2.5-pro", "resolved": "gemini-2.5-pro",
+                        "role": "primary", "calls": 3}],
+            "deterministically_reproducible": False,
+        },
+    }
+
+
+def _have_git() -> bool:
+    try:
+        subprocess.run(["git", "--version"], capture_output=True, check=True)
+        return True
+    except (OSError, subprocess.CalledProcessError):
+        return False
+
+
+_GIT = _have_git()
+
+
+def _init_repo(path: Path) -> None:
+    """Init a git repo at ``path`` with one commit.
+
+    Config is set inline (``-c``-style via ``git config`` on the repo) so the
+    test never depends on the operator's global gitconfig — CI runners often
+    have none.
+    """
+    def g(*args):
+        subprocess.run(
+            ["git", "-C", str(path), *args],
+            capture_output=True, text=True, check=True,
+        )
+    g("init", "-q")
+    g("config", "user.email", "t@example.com")
+    g("config", "user.name", "Test")
+    (path / "a.txt").write_text("hello\n")
+    g("add", "a.txt")
+    g("commit", "-q", "-m", "init")
+
+
+class TestSourceControlSnapshot(unittest.TestCase):
+
+    def test_non_git_dir_reports_all_none(self):
+        # A directory that is not a git checkout: provenance is unknowable,
+        # so every field is None — never a fabricated/current value.
+        with TemporaryDirectory() as d:
+            snap = source_control_snapshot(Path(d))
+            self.assertIsNone(snap["base_sha"])
+            self.assertIsNone(snap["dirty"])
+            self.assertIsNone(snap["diff_sha256"])
+
+    @unittest.skipUnless(_GIT, "git not available")
+    def test_clean_repo(self):
+        with TemporaryDirectory() as d:
+            repo = Path(d)
+            _init_repo(repo)
+            snap = source_control_snapshot(repo)
+            self.assertRegex(snap["base_sha"], r"^[0-9a-f]{40}$")
+            self.assertFalse(snap["dirty"])
+            self.assertIsNone(snap["diff_sha256"])
+
+    @unittest.skipUnless(_GIT, "git not available")
+    def test_dirty_tracked_change_sets_diff_hash(self):
+        with TemporaryDirectory() as d:
+            repo = Path(d)
+            _init_repo(repo)
+            (repo / "a.txt").write_text("hello\nworld\n")  # modify tracked file
+            snap = source_control_snapshot(repo)
+            self.assertTrue(snap["dirty"])
+            self.assertRegex(snap["diff_sha256"], r"^[0-9a-f]{64}$")
+
+    @unittest.skipUnless(_GIT, "git not available")
+    def test_untracked_only_is_dirty_without_diff_hash(self):
+        # An untracked-only modification still flags dirty=True (a "modified
+        # variant"), but `git diff HEAD` omits untracked files, so the diff
+        # hash stays None. Documents the known v1 boundary.
+        with TemporaryDirectory() as d:
+            repo = Path(d)
+            _init_repo(repo)
+            (repo / "new.txt").write_text("x\n")
+            snap = source_control_snapshot(repo)
+            self.assertTrue(snap["dirty"])
+            self.assertIsNone(snap["diff_sha256"])
+
+
+class TestTargetSnapshot(unittest.TestCase):
+
+    def test_none_path(self):
+        self.assertIsNone(target_snapshot(None))
+
+    def test_non_git_dir(self):
+        with TemporaryDirectory() as d:
+            self.assertIsNone(target_snapshot(Path(d)))
+
+    @unittest.skipUnless(_GIT, "git not available")
+    def test_git_target(self):
+        with TemporaryDirectory() as d:
+            repo = Path(d)
+            _init_repo(repo)
+            snap = target_snapshot(repo)
+            self.assertEqual(snap["vcs"], "git")
+            self.assertRegex(snap["commit"], r"^[0-9a-f]{40}$")
+            self.assertFalse(snap["dirty"])
+            self.assertTrue(snap["branch"])
+
+    def test_target_git_uses_untrusted_safe_overrides(self):
+        # SECURITY REGRESSION: the target is attacker-controlled — every git
+        # invocation must carry the safe overrides that neutralise config-based
+        # RCE (core.fsmonitor / core.hooksPath / credential.helper, CVE-2024-32002
+        # family). Spy on the argv git is actually invoked with. Works even on a
+        # non-git dir — the first (rev-parse) call already carries the overrides.
+        import core.run.provenance as prov
+        seen = []
+        real_run = prov.subprocess.run
+
+        def spy(cmd, *a, **k):
+            seen.append(cmd)
+            return real_run(cmd, *a, **k)
+
+        with TemporaryDirectory() as d:
+            with mock.patch.object(prov.subprocess, "run", side_effect=spy):
+                prov.target_snapshot(Path(d))
+        joined = " ".join(" ".join(map(str, c)) for c in seen)
+        self.assertTrue(seen, "no git invocation captured")
+        self.assertIn("core.fsmonitor=", joined)
+        self.assertIn("core.hooksPath=/dev/null", joined)
+
+    def test_source_control_uses_bare_git(self):
+        # RAPTOR's own checkout is trusted — no per-invocation overrides needed
+        # (and adding them everywhere would be noise). Confirm the framework
+        # snapshot does NOT route through the untrusted-safe path.
+        import core.run.provenance as prov
+        seen = []
+        real_run = prov.subprocess.run
+
+        def spy(cmd, *a, **k):
+            seen.append(cmd)
+            return real_run(cmd, *a, **k)
+
+        with TemporaryDirectory() as d:
+            with mock.patch.object(prov.subprocess, "run", side_effect=spy):
+                prov.source_control_snapshot(Path(d))
+        joined = " ".join(" ".join(map(str, c)) for c in seen)
+        self.assertNotIn("core.fsmonitor=", joined)
+
+
+class TestDetectEngines(unittest.TestCase):
+
+    def test_empty_dir(self):
+        with TemporaryDirectory() as d:
+            self.assertEqual(detect_engines(Path(d)), {})
+
+    def test_detects_from_canonical_output_files(self):
+        with TemporaryDirectory() as d:
+            out = Path(d)
+            (out / "semgrep_owasp.sarif").write_text("{}")
+            (out / "cocci.sarif").write_text("{}")
+            eng = detect_engines(out)
+            self.assertIn("semgrep", eng)
+            self.assertIn("coccinelle", eng)
+            self.assertNotIn("codeql", eng)
+
+
+class TestBuildStartManifestTarget(unittest.TestCase):
+
+    def test_no_target_block_when_not_git(self):
+        with TemporaryDirectory() as d:
+            m = build_start_manifest(target=Path(d))
+            self.assertNotIn("target", m)
+
+    @unittest.skipUnless(_GIT, "git not available")
+    def test_target_block_when_git(self):
+        with TemporaryDirectory() as d:
+            repo = Path(d)
+            _init_repo(repo)
+            m = build_start_manifest(target=repo)
+            self.assertIn("target", m)
+            self.assertEqual(m["target"]["vcs"], "git")
+
+
+class TestEnvironmentSnapshot(unittest.TestCase):
+
+    def test_has_python_os_arch(self):
+        env = environment_snapshot()
+        self.assertIn("python", env)
+        self.assertTrue(env["python"])
+        # Coarse os/arch only — not the fingerprinting platform.platform()
+        # string. See environment_snapshot docstring.
+        self.assertIn("os", env)
+        self.assertIn("arch", env)
+        self.assertNotIn("platform", env)
+
+
+class TestBuildStartManifest(unittest.TestCase):
+
+    def test_shape(self):
+        with TemporaryDirectory() as d:
+            m = build_start_manifest(Path(d))
+            self.assertEqual(m["schema"], 1)
+            self.assertIn("source_control", m)
+            self.assertIn("environment", m)
+
+
+class TestToolVersion(unittest.TestCase):
+
+    def test_unknown_tool_returns_none(self):
+        self.assertIsNone(tool_version("not-a-real-engine"))
+
+    @unittest.skipUnless(shutil.which("semgrep"), "semgrep not installed")
+    def test_semgrep_returns_version_string(self):
+        v = tool_version("semgrep")
+        self.assertIsInstance(v, str)
+        self.assertTrue(v)
+
+    def test_absent_tool_returns_none(self):
+        # 'coccinelle' probes `spatch`; if it isn't installed the probe must
+        # degrade to None rather than raise.
+        if shutil.which("spatch"):
+            self.skipTest("spatch installed — can't exercise the absent path")
+        self.assertIsNone(tool_version("coccinelle"))
+
+
+class TestScanEngineManifest(unittest.TestCase):
+    """Gating in raptor._scan_engine_manifest — only mechanical commands get
+    engine versions + deterministically_reproducible, and a non-scan command
+    must never produce a manifest (so it can't clobber agentic's)."""
+
+    def test_non_scan_command_returns_none(self):
+        import raptor
+        with TemporaryDirectory() as d:
+            self.assertIsNone(raptor._scan_engine_manifest(Path(d), "agentic"))
+            self.assertIsNone(raptor._scan_engine_manifest(Path(d), "fuzz"))
+
+    def test_scan_detects_engine_from_output_file(self):
+        import raptor
+        with TemporaryDirectory() as d:
+            out = Path(d)
+            # Real output filenames: semgrep_*.sarif, codeql_*.sarif, cocci.sarif.
+            (out / "semgrep_semgrep_injection.sarif").write_text("{}")
+            (out / "codeql_java.sarif").write_text("{}")
+            (out / "cocci.sarif").write_text("{}")
+            m = raptor._scan_engine_manifest(out, "scan")
+            self.assertTrue(m["deterministically_reproducible"])
+            # Engines detected from canonical output files (value may be the
+            # version string or None if the tool isn't installed in CI).
+            self.assertIn("semgrep", m["engines"])
+            self.assertIn("codeql", m["engines"])
+            self.assertIn("coccinelle", m["engines"])
+
+    def test_scan_with_no_output_still_reproducible(self):
+        import raptor
+        with TemporaryDirectory() as d:
+            m = raptor._scan_engine_manifest(Path(d), "scan")
+            self.assertEqual(m["engines"], {})
+            self.assertTrue(m["deterministically_reproducible"])
+
+
+class TestFormatShaShort(unittest.TestCase):
+
+    def test_clean_tree(self):
+        m = {"source_control": {"base_sha": "9668aa8c3b0f", "dirty": False}}
+        self.assertEqual(format_sha_short(m), "9668aa8")
+
+    def test_dirty_tree_gets_star(self):
+        m = {"source_control": {"base_sha": "9668aa8c3b0f", "dirty": True}}
+        self.assertEqual(format_sha_short(m), "9668aa8*")
+
+    def test_no_sha_or_no_manifest_is_empty(self):
+        self.assertEqual(format_sha_short(None), "")
+        self.assertEqual(format_sha_short({}), "")
+        self.assertEqual(format_sha_short({"source_control": {"base_sha": None}}), "")
+
+
+class TestFormatManifestBlock(unittest.TestCase):
+
+    def test_empty_for_no_manifest(self):
+        self.assertEqual(format_manifest_block(None), "")
+
+    def test_unavailable_is_honest(self):
+        block = format_manifest_block(UNAVAILABLE_MANIFEST)
+        self.assertIn("unavailable", block)
+
+    def test_full_block_renders_all_sections(self):
+        m = {
+            "schema": 1,
+            "source_control": {"base_sha": "9668aa8c3b0f54b9", "dirty": True},
+            "environment": {"python": "3.14.4", "os": "Linux", "arch": "x86_64"},
+            "engines": {"semgrep": "1.79.0"},
+            "models": [{"alias": "gemini-2.5-pro", "resolved": "gemini-2.5-pro-002",
+                        "role": "primary", "calls": 3}],
+            "deterministically_reproducible": False,
+        }
+        block = format_manifest_block(m)
+        self.assertIn("9668aa8c3b0f", block)
+        self.assertIn("(modified)", block)
+        self.assertIn("Python 3.14.4", block)
+        self.assertIn("semgrep 1.79.0", block)
+        self.assertIn("gemini-2.5-pro-002", block)
+        self.assertIn("no (LLM-mediated)", block)
+
+
+class TestPublicView(unittest.TestCase):
+
+    def test_drops_sensitive_fields(self):
+        pub = public_view(_full_run_metadata())
+        # The leak vectors must be gone entirely.
+        self.assertNotIn("target_path", pub)
+        self.assertNotIn("extra", pub)
+        self.assertNotIn("session_pid", pub)
+        self.assertNotIn("tool_pid", pub)
+        # And nothing nested should echo the operator's home path.
+        self.assertNotIn("jcartwright", json.dumps(pub))
+
+    def test_target_block_dropped_by_default(self):
+        # The target's commit/branch may be a private engagement — not in the
+        # publish allowlist; an opt-in label belongs to the cite UX.
+        pub = public_view(_full_run_metadata())
+        self.assertNotIn("target", pub.get("manifest", {}))
+        self.assertNotIn("4f2a9b1c", json.dumps(pub))
+
+    def test_keeps_safe_run_and_manifest_fields(self):
+        pub = public_view(_full_run_metadata())
+        self.assertEqual(pub["command"], "agentic")
+        self.assertEqual(pub["status"], "completed")
+        m = pub["manifest"]
+        self.assertEqual(m["source_control"]["base_sha"], "9668aa8c")
+        self.assertTrue(m["source_control"]["dirty"])
+        self.assertEqual(m["source_control"]["diff_sha256"], "deadbeef")  # hash, content-safe
+        self.assertEqual(m["environment"]["os"], "Linux")
+        self.assertEqual(m["engines"]["semgrep"], "1.79.0")
+        self.assertEqual(m["models"][0]["resolved"], "gemini-2.5-pro")
+        self.assertIs(m["deterministically_reproducible"], False)
+
+    def test_allowlist_drops_unknown_future_fields(self):
+        md = _full_run_metadata()
+        md["some_future_secret"] = "leak-me"
+        md["manifest"]["some_future_manifest_secret"] = "leak-me-too"
+        pub = public_view(md)
+        self.assertNotIn("some_future_secret", pub)
+        self.assertNotIn("some_future_manifest_secret", pub["manifest"])
+
+    def test_subdict_fields_allowlisted(self):
+        # Allowlist must apply INSIDE environment/engines/models too — a crafted
+        # manifest can't smuggle a secret/path under an extra sub-dict key.
+        md = {"command": "scan", "manifest": {
+            "environment": {"python": "3.14", "os": "Linux", "arch": "x86_64", "SECRET": "leak"},
+            "engines": {"semgrep": "1.79.0", "evil": {"cmd": "/leak"}},
+            "models": [{"provider": "g", "alias": "a", "resolved": "r",
+                        "role": "primary", "calls": 1, "api_key": "LEAK"}],
+        }}
+        pub = public_view(md)
+        self.assertEqual(set(pub["manifest"]["environment"]), {"python", "os", "arch"})
+        # non-string engine value (a dict) dropped
+        self.assertEqual(pub["manifest"]["engines"], {"semgrep": "1.79.0"})
+        self.assertEqual(set(pub["manifest"]["models"][0]),
+                         {"provider", "alias", "resolved", "role", "calls"})
+        self.assertNotIn("LEAK", json.dumps(pub))
+
+    def test_unavailable_manifest_passthrough(self):
+        md = {"command": "scan", "manifest": dict(UNAVAILABLE_MANIFEST)}
+        pub = public_view(md)
+        self.assertEqual(pub["manifest"], {"provenance": "unavailable"})
+
+    def test_none_and_empty(self):
+        self.assertEqual(public_view(None), {})
+        self.assertEqual(public_view({}), {})
+
+
+class TestFormatReproShort(unittest.TestCase):
+
+    def test_values(self):
+        self.assertEqual(format_repro_short({"deterministically_reproducible": True}), "repro")
+        self.assertEqual(format_repro_short({"deterministically_reproducible": False}), "llm")
+        self.assertEqual(format_repro_short({}), "")
+        self.assertEqual(format_repro_short(None), "")
+
+
+class TestAggregateProvenance(unittest.TestCase):
+
+    def _metas(self):
+        return [
+            {"manifest": {
+                "source_control": {"base_sha": "aaa", "dirty": False},
+                "engines": {"semgrep": "1.79.0"},
+                "models": [{"alias": "gemini-2.5-pro", "resolved": "gemini-2.5-pro"}],
+                "deterministically_reproducible": True}},
+            {"manifest": {
+                "source_control": {"base_sha": "aaa", "dirty": True},
+                "engines": {"codeql": "2.23.8"},
+                "models": [{"alias": "claude-haiku-4-5", "resolved": "claude-haiku-4-5-20251001"}],
+                "deterministically_reproducible": False}},
+            {"manifest": {"provenance": "unavailable"}},
+            None,  # skipped entirely
+        ]
+
+    def test_rollup_counts(self):
+        s = aggregate_provenance(self._metas())
+        self.assertEqual(s["runs"], 3)             # None skipped
+        self.assertEqual(s["shas"]["aaa"], 2)      # same SHA across two runs
+        self.assertEqual(s["dirty_runs"], 1)
+        self.assertIn("semgrep", s["engines"])
+        self.assertIn("codeql", s["engines"])
+        self.assertEqual(s["models"]["gemini-2.5-pro"], 1)
+        self.assertEqual(s["models"]["claude-haiku-4-5-20251001"], 1)  # by resolved snapshot
+        self.assertEqual(s["reproducible"], {"yes": 1, "no": 1, "unknown": 1})
+        self.assertEqual(s["unavailable"], 1)
+
+    def test_empty(self):
+        self.assertEqual(aggregate_provenance([])["runs"], 0)
+
+    def test_tolerates_non_dict_engines(self):
+        # Malformed/imported manifest with engines as a list must not crash.
+        s = aggregate_provenance([{"manifest": {
+            "engines": ["semgrep"],
+            "source_control": {"base_sha": "x", "dirty": False},
+            "deterministically_reproducible": True,
+        }}])
+        self.assertEqual(s["runs"], 1)
+        self.assertEqual(s["engines"], {})
+
+
+class TestFormatProvenanceRollup(unittest.TestCase):
+
+    def test_no_runs(self):
+        self.assertEqual(format_provenance_rollup({"runs": 0}), "No runs with provenance.")
+
+    def test_render(self):
+        s = aggregate_provenance([
+            {"manifest": {
+                "source_control": {"base_sha": "abc123def456", "dirty": True},
+                "engines": {"semgrep": "1.79.0"},
+                "models": [{"resolved": "gemini-2.5-pro"}],
+                "deterministically_reproducible": False}},
+        ])
+        out = format_provenance_rollup(s)
+        self.assertIn("Provenance across 1 run", out)
+        self.assertIn("abc123def456", out)
+        self.assertIn("Modified-tree runs: 1/1", out)
+        self.assertIn("semgrep 1.79.0", out)
+        self.assertIn("LLM-mediated", out)
+
+
+class TestLifecycleE2E(unittest.TestCase):
+    """End-to-end: start_run seals framework+target+env, a scan drops engine
+    output, complete_run merges engines+reproducibility — the full manifest a
+    real /scan run produces, exercised through the real lifecycle + raptor's
+    _scan_engine_manifest (no mocks)."""
+
+    @unittest.skipUnless(_GIT, "git not available")
+    def test_scan_run_seals_and_enriches_full_manifest(self):
+        import raptor
+        from core.run import complete_run, load_run_metadata, start_run
+        with TemporaryDirectory() as d:
+            target = Path(d) / "target"
+            target.mkdir()
+            _init_repo(target)
+            out = Path(d) / "scan-run"
+
+            start_run(out, "scan", target=str(target))
+            # The manifest is sealed at START: framework + target + env present
+            # before any analysis runs.
+            sealed = load_run_metadata(out)["manifest"]
+            self.assertIn("source_control", sealed)       # RAPTOR's own repo
+            self.assertEqual(sealed["target"]["vcs"], "git")
+            self.assertRegex(sealed["target"]["commit"], r"^[0-9a-f]{40}$")
+            self.assertIn("environment", sealed)
+            self.assertNotIn("engines", sealed)            # not known yet
+
+            # Scanner drops its SARIF output, then the run completes.
+            (out / "semgrep_owasp.sarif").write_text("{}")
+            complete_run(out, manifest=raptor._scan_engine_manifest(out, "scan"))
+
+            final = load_run_metadata(out)
+            m = final["manifest"]
+            self.assertEqual(final["status"], "completed")
+            # Start-sealed facts survive the merge…
+            self.assertIn("source_control", m)
+            self.assertEqual(m["target"]["vcs"], "git")
+            # …and end-of-run facts are merged in.
+            self.assertIn("semgrep", m["engines"])
+            self.assertTrue(m["deterministically_reproducible"])
+
+
+class TestUnavailableManifest(unittest.TestCase):
+
+    def test_marked_unavailable(self):
+        self.assertEqual(UNAVAILABLE_MANIFEST["provenance"], "unavailable")
+        self.assertIn("reason", UNAVAILABLE_MANIFEST)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/llm_analysis/dispatch.py
+++ b/packages/llm_analysis/dispatch.py
@@ -30,13 +30,18 @@ class DispatchResult:
 
     def __init__(self, result: Dict[str, Any], cost: float = 0.0,
                  tokens: int = 0, model: str = "", duration: float = 0.0,
-                 quality: float = 1.0):
+                 quality: float = 1.0, resolved_model: Optional[str] = None):
         self.result = result
         self.cost = cost
         self.tokens = tokens
         self.model = model
         self.duration = duration
         self.quality = quality
+        # Provider-served snapshot behind the (possibly floating) `model`
+        # alias, when the SDK exposed one. Carried into the per-finding result
+        # dict so consensus/judge can record scorecard reliability against the
+        # concrete model version, not the drifting alias.
+        self.resolved_model = resolved_model
 
 
 class DispatchTask:
@@ -93,6 +98,10 @@ class DispatchTask:
             out["duration_seconds"] = round(result.duration, 1)
         if result.model:
             out["analysed_by"] = result.model
+        if getattr(result, "resolved_model", None):
+            # Concrete snapshot behind the alias — consumed by consensus/judge
+            # scorecard recording (model_version) and available to coverage.
+            out["resolved_model"] = result.resolved_model
         # Surface the validator quality score when the response was
         # incomplete. Lets downstream report consumers see *why* a
         # finding is unverdicted (gh #549) — `quality` defaults to 1.0

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -511,6 +511,7 @@ def orchestrate(
                     result=result, cost=response.cost,
                     tokens=response.tokens_used, model=response.model,
                     duration=response.duration, quality=quality,
+                    resolved_model=response.resolved_model,
                 )
             else:
                 response = client.generate(
@@ -522,6 +523,7 @@ def orchestrate(
                     result={"content": response.content}, cost=response.cost,
                     tokens=response.tokens_used, model=response.model,
                     duration=response.duration,
+                    resolved_model=response.resolved_model,
                 )
 
         dispatch_mode = "external_llm"
@@ -1239,6 +1241,14 @@ def orchestrate(
         # on CC-prep / CC-fallback paths (no prefilter wiring).
         "fast_tier_short_circuits": (
             getattr(client, "short_circuits", 0) if client is not None else 0
+        ),
+        # Models that actually fired in-process during analysis, each with the
+        # provider-served snapshot when the SDK exposed one (alias-only
+        # otherwise). Feeds the run provenance manifest. Empty on CC-prep /
+        # subprocess-dispatch paths (no in-process client calls) — alias-level
+        # attribution still lives in `analysis_models` above.
+        "fired_models": (
+            client.get_fired_models() if client is not None else []
         ),
     }
 

--- a/packages/llm_analysis/tasks.py
+++ b/packages/llm_analysis/tasks.py
@@ -664,6 +664,9 @@ class JudgeTask(DispatchTask):
                 primary["is_exploitable"] = final
                 primary["judge_analyses"] = [
                     {"model": ja.get("analysed_by", "?"),
+                     # Carry the resolved snapshot through so judge scorecard
+                     # outcomes record model_version (else it's always None).
+                     "resolved_model": ja.get("resolved_model"),
                      "is_exploitable": ja.get("is_exploitable"),
                      "reasoning": ja.get("reasoning", "")}
                     for ja in judge_analyses

--- a/raptor.py
+++ b/raptor.py
@@ -80,6 +80,26 @@ def _extract_target(args: list) -> str | None:
     return None
 
 
+def _scan_engine_manifest(out_dir: Path, command: str) -> dict | None:
+    """End-of-run provenance for mechanical scan commands.
+
+    Only ``scan`` and ``codeql`` are purely mechanical — static rules/queries
+    with no LLM in the verdict path — so only they record engine versions and
+    ``deterministically_reproducible=True`` here. Other commands routed through
+    ``_run_with_lifecycle`` (agentic, fuzz, web) either manage their own
+    provenance (agentic seals ``deterministically_reproducible=False``) or are
+    not yet covered; returning None leaves their manifest untouched so we never
+    clobber it. Engines are detected from their canonical output files.
+    """
+    if command not in ("scan", "codeql"):
+        return None
+    from core.run.provenance import detect_engines
+    return {
+        "engines": detect_engines(out_dir),
+        "deterministically_reproducible": True,
+    }
+
+
 def _run_with_lifecycle(command: str, script_path: Path, args: list,
                         label: str) -> int:
     """Run a script with lifecycle start/complete/fail wrapping.
@@ -225,7 +245,7 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
             pass
 
     if rc == 0:
-        complete_run(out_dir)
+        complete_run(out_dir, manifest=_scan_engine_manifest(out_dir, command))
     else:
         fail_run(out_dir, error=f"exit code {rc}")
     return rc

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -2409,6 +2409,7 @@ Examples:
     # Mark run as completed
     try:
         from core.run import complete_run
+        from core.run.provenance import detect_engines as _provenance_detect_engines
         orch_meta = (orchestration_result or {}).get("orchestration", {})
         complete_run(out_dir, extra={
             "findings_count": analysed_count,
@@ -2418,6 +2419,16 @@ Examples:
             "analysis_models": orch_meta.get("analysis_models", []),
             "aggregate_models": orch_meta.get("aggregate_models", []),
             "aggregated": orch_meta.get("aggregated", False),
+        }, manifest={
+            # End-of-run provenance merged into the start-sealed manifest.
+            "models": orch_meta.get("fired_models", []),
+            # Engines from the scan phase (/agentic runs semgrep/codeql before
+            # analysis) — captured the same way /scan does.
+            "engines": _provenance_detect_engines(out_dir),
+            # Agentic analysis is LLM-mediated by definition — the verdict path
+            # always runs through a model (in-process or subprocess), so the
+            # result is never deterministically reproducible.
+            "deterministically_reproducible": False,
         })
     except Exception as e:
         logger.debug(f"Run metadata: {e}")  # Optional — don't fail the pipeline


### PR DESCRIPTION
Record what produced each run, captured at run time:
- start_run seals a manifest (.raptor-run.json version 1->2; manifest schema 1): framework git SHA + dirty flag + diff hash, coarse env (python/os/arch), and the scanned target's commit/branch/dirty when it is a git checkout. Target git calls use untrusted-safe overrides so a hostile .git/config can't achieve code execution.
- LLM client captures the resolved model snapshot per response (e.g. claude-haiku-4-5-20251001) through providers; the orchestrator records the IN-PROCESS models that fired (CC-dispatch agentic records none -- feed-only first cut).
- complete_run records engine versions (semgrep/codeql/coccinelle) for scan/codeql/agentic plus a deterministically_reproducible flag.
- scorecard records the resolved snapshot via model_version (consensus + judge) -- feed only; recency-weighting is a follow-up.

Surface (local operator views):
- /project status: per-run "<sha>* repro|llm" tag
- /project show <run>: full per-run provenance detail
- /project provenance: rollup (SHAs, modified-tree count, engines, models by snapshot, reproducible/LLM split)
- /project report: provenance.md

Publish-safe public_view() redaction primitive (allowlist, including inside each sub-dict; drops target_path, extra, PIDs, target block) for a future cite path.

Captured and surfaced only -- does not yet act on provenance (no cite command, scorecard recency-weighting, or coverage linkage; design docs track these). Non-git targets get no target block yet. The manifest is captured at run time, not signed -- provenance, not tamper-proof.