### PR TITLE
test(cve_diff): no-op LLM-client retry backoff in unit tests

### DIFF
--- a/packages/cve_diff/tests/unit/conftest.py
+++ b/packages/cve_diff/tests/unit/conftest.py
@@ -106,19 +106,19 @@ def _no_real_retry_backoff(monkeypatch):
     monkeypatch.setattr(time, "sleep", lambda *a, **k: None)
 
 
-  @pytest.fixture(autouse=True)
-  def _no_retry_backoff_sleep(monkeypatch):
-      """Neutralise the LLM client's retry backoff for unit tests.
+@pytest.fixture(autouse=True)
+def _no_retry_backoff_sleep(monkeypatch):
+    """Neutralise the LLM client's retry backoff for unit tests.
 
-      cve_diff/llm/client.py retries a failed provider.generate with
-      time.sleep(backoff_factor ** attempt) (factor 2.0 -> 2+4+8s...). Any
-      test that drives the pipeline into retries or the meta-retry path
-      otherwise pays real backoff seconds -- the dominant cost behind the
-      slow cve_diff pipeline tests. No-op the sleep: retry *logic* is
-      unchanged, only the wall-clock delay is removed. The infra rate-limit
-      tests inject their own fake clock, so they are unaffected by this
-      global patch.
-      """
-      monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+    cve_diff/llm/client.py retries a failed provider.generate with
+    time.sleep(backoff_factor ** attempt) (factor 2.0 -> 2+4+8s...). Any
+    test that drives the pipeline into retries or the meta-retry path
+    otherwise pays real backoff seconds -- the dominant cost behind the
+    slow cve_diff pipeline tests. No-op the sleep: retry *logic* is
+    unchanged, only the wall-clock delay is removed. The infra rate-limit
+    tests inject their own fake clock, so they are unaffected by this
+    global patch.
+    """
+    monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
 
 

--- a/packages/cve_diff/tests/unit/conftest.py
+++ b/packages/cve_diff/tests/unit/conftest.py
@@ -106,3 +106,19 @@ def _no_real_retry_backoff(monkeypatch):
     monkeypatch.setattr(time, "sleep", lambda *a, **k: None)
 
 
+  @pytest.fixture(autouse=True)
+  def _no_retry_backoff_sleep(monkeypatch):
+      """Neutralise the LLM client's retry backoff for unit tests.
+
+      cve_diff/llm/client.py retries a failed provider.generate with
+      time.sleep(backoff_factor ** attempt) (factor 2.0 -> 2+4+8s...). Any
+      test that drives the pipeline into retries or the meta-retry path
+      otherwise pays real backoff seconds -- the dominant cost behind the
+      slow cve_diff pipeline tests. No-op the sleep: retry *logic* is
+      unchanged, only the wall-clock delay is removed. The infra rate-limit
+      tests inject their own fake clock, so they are unaffected by this
+      global patch.
+      """
+      monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+
+


### PR DESCRIPTION
The cve_diff LLM client retries a failed provider.generate with a real time.sleep(backoff_factor ** attempt) (factor 2.0 -> 2+4+8s...) in cve_diff/llm/client.py. Every unit test that drove the pipeline into retries or the meta-retry path paid those backoff seconds -- the cause of the slow cve_diff pipeline tests (10-19s each, wandering run-to-run because it's wall-clock sleep, not compute).

An autouse fixture no-ops time.sleep for the unit suite. Retry logic is unchanged -- only the wall-clock delay goes. The five offenders drop from ~11-19s to <1s; the infra rate-limit tests inject their own fake clock so they're unaffected. Fixes the class, not individual tests, so future retry-exercising tests stay fast too -- no per-test @slow gating.