### PR TITLE
feat(reachability): build-membership witness, static-inline linkage, unify /validate demoter

### DIFF
--- a/core/inventory/build_membership.py
+++ b/core/inventory/build_membership.py
@@ -1,0 +1,108 @@
+"""Detect translation units excluded from the build.
+
+A source file that the build never compiles contributes no reachable code:
+every function in it is dead in any normal build, regardless of in-file call
+edges or external linkage. The call-graph and entry-point analyses can't see
+this — they treat the file as ordinary source.
+
+This module adds per-language detection of *build exclusion*. A single helper
+:func:`detect_build_excluded` returns either ``None`` (no exclusion detected)
+or a structured record. Consumers treat a detected exclusion as a whole-file
+reachability gate: every function in the file is dead.
+
+Unlike a module-load abort (a runtime event with a line threshold — functions
+defined above the abort may already have bound), build exclusion is a
+*compile-time, whole-file* property: nothing in the file is ever built, so
+there is no line threshold.
+
+Soundness: this is a HEURISTIC signal, never sound. A build constraint is
+config-dependent — ``//go:build ignore`` excludes the file from *normal*
+builds, but ``go build -tags ignore`` would still compile it; and a build
+system may include a file by other means. So a ``build_excluded`` verdict is
+surface-only (it demotes / annotates, never hard-suppresses), matching the
+``no_path_from_entry`` tier.
+
+Per-language detection currently wired:
+
+  * Go: a build-constraint comment whose expression is exactly ``ignore`` —
+    the idiomatic "never built in any normal configuration" marker, used for
+    ``go run gen.go`` codegen scripts and standalone tools. Both the modern
+    ``//go:build ignore`` and the legacy ``// +build ignore`` forms.
+
+Other languages return ``None``. (C/C++ translation-unit membership against
+``compile_commands.json`` and Rust crate-module membership are build-manifest
+properties rather than file-content properties — a natural extension of the
+same ``build_excluded`` witness, wired at the builder level rather than here.)
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class BuildExcluded:
+    """Describes a detected build exclusion.
+
+    ``line``: 1-indexed line of the constraint (for display only — the gate
+    is whole-file, not line-relative).
+    ``summary``: short human-readable label for prompts / logs, e.g.
+    ``"//go:build ignore"``.
+    """
+    line: int
+    summary: str
+
+
+def detect_build_excluded(
+    language: str, content: str,
+) -> Optional[BuildExcluded]:
+    """Per-language dispatch. Returns the detected build exclusion, or
+    ``None`` when none is detected (or the language has no detector wired).
+    Best-effort: any parse failure returns ``None``."""
+    if not content:
+        return None
+    try:
+        if language == "go":
+            return _detect_go(content)
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Go build constraints. The expression must be exactly ``ignore`` — a complex
+# expression like ``ignore || linux`` is satisfiable (builds on linux) and is
+# NOT flagged. Constraints are only valid in the leading comment block, before
+# the ``package`` clause, so we stop scanning at the package declaration.
+# ---------------------------------------------------------------------------
+
+_GO_BUILD_LINE = re.compile(r"^//go:build\s+(.+?)\s*$")
+_GO_LEGACY_BUILD_LINE = re.compile(r"^//\s*\+build\s+(.+?)\s*$")
+_GO_PACKAGE = re.compile(r"^\s*package\s+\w+")
+
+
+def _detect_go(content: str) -> Optional[BuildExcluded]:
+    for i, raw in enumerate(content.split("\n"), 1):
+        line = raw.strip()
+        if _GO_PACKAGE.match(raw):
+            # Build constraints must precede the package clause; once we
+            # reach it, no exclusion was found in the header.
+            return None
+        m = _GO_BUILD_LINE.match(line)
+        if m and m.group(1).strip() == "ignore":
+            return BuildExcluded(line=i, summary="//go:build ignore")
+        m = _GO_LEGACY_BUILD_LINE.match(line)
+        # Legacy ``// +build`` args are space-separated OR-terms; only a lone
+        # ``ignore`` term means never-built. ``// +build ignore foo`` is
+        # ``ignore OR foo`` → satisfiable, so not flagged.
+        if m and m.group(1).split() == ["ignore"]:
+            return BuildExcluded(line=i, summary="// +build ignore")
+    return None
+
+
+__all__ = ["BuildExcluded", "detect_build_excluded"]

--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -41,6 +41,7 @@ from .call_graph import (
 from .diff import compare_inventories
 from core.build.macro_config import extract_macro_config
 from .dead_scope import detect_dead_scopes
+from .build_membership import detect_build_excluded
 from .module_load_abort import detect_module_load_abort
 from .translation_view import detect_macro_call_targets, preprocess_view
 
@@ -690,6 +691,16 @@ def _process_single_file(
             record['module_aborts_on_load'] = {
                 'line': abort.line,
                 'summary': abort.summary,
+            }
+        # Whole-file build exclusion (e.g. Go `//go:build ignore`): the file
+        # is never compiled, so every function in it is dead regardless of
+        # call edges or external linkage. Heuristic (config-dependent) — a
+        # surface-only gate, never hard-suppress.
+        excluded = detect_build_excluded(language, content)
+        if excluded is not None:
+            record['build_excluded'] = {
+                'line': excluded.line,
+                'summary': excluded.summary,
             }
         return record
 

--- a/core/inventory/extractors.py
+++ b/core/inventory/extractors.py
@@ -378,14 +378,25 @@ class CExtractor:
         try:
             prefix = line.split(name)[0].strip() if name in line else ""
             words = prefix.split()
-            visibility = None
+            storage = set()
             type_words = []
             for w in words:
                 w = w.strip("*")
                 if w in self.STORAGE_CLASSES:
-                    visibility = w
+                    storage.add(w)
                 elif w in self.C_TYPE_HINTS or w not in self.KEYWORDS:
                     type_words.append(w)
+            # Linkage is the entry signal. `static` (internal linkage) is
+            # load-bearing and must not be masked by `inline` (not a linkage
+            # class) — `static inline` is still internal. `extern` wins: it is
+            # external linkage, and the invalid `extern static` combo is
+            # treated as external (never under-claim reachability).
+            if "extern" in storage:
+                visibility = "extern"
+            elif "static" in storage:
+                visibility = "static"
+            else:
+                visibility = None
             return_type = " ".join(type_words) if type_words else None
             return FunctionMetadata(visibility=visibility, return_type=return_type)
         except Exception:
@@ -946,10 +957,19 @@ class TreeSitterExtractor:
                             visibility = (visibility or "") + " static"
                             visibility = visibility.strip()
 
-        # C/C++: storage class specifier
-        for child in node.children:
-            if child.type == "storage_class_specifier":
-                visibility = child.text.decode()
+        # C/C++: storage class specifier. Linkage is the entry signal:
+        # `static` = internal linkage (not externally callable). It is
+        # load-bearing and must NOT be masked by a following `inline` (not a
+        # linkage class) — `static inline` is still internal. `extern` takes
+        # priority: it means external linkage, and the invalid `extern static`
+        # combo is treated as external (the reachability-conservative choice —
+        # never under-claim reachability on malformed input).
+        specs = [c.text.decode() for c in node.children
+                 if c.type == "storage_class_specifier"]
+        if "extern" in specs:
+            visibility = "extern"
+        elif "static" in specs:
+            visibility = "static"
 
         # Go: exported from capitalisation, receiver as class_name
         if self.language == "go":

--- a/core/inventory/reach_audit.py
+++ b/core/inventory/reach_audit.py
@@ -28,7 +28,8 @@ from typing import Dict, Optional, Tuple
 
 # Verdicts that mean "not reachable in this deployment" (dead).
 _DEAD_VERDICTS = frozenset({
-    "module_aborts", "lexical_dead", "no_path_from_entry", "not_called",
+    "module_aborts", "lexical_dead", "build_excluded",
+    "no_path_from_entry", "not_called",
 })
 # Verdicts that mean "reachable / has a live path".
 _LIVE_VERDICTS = frozenset({
@@ -47,13 +48,20 @@ def classify_reachability(
     """Strongest applicable reachability verdict for one function, in the
     same precedence the enrichment prepass uses:
 
-    module_aborts → lexical_dead → entry-reachability (reachable /
-    no_path_from_entry / uncertain) → framework/registration → 1-hop
-    function_called (called / not_called / uncertain).
+    module_aborts → lexical_dead → build_excluded → framework/registration
+    → entry-reachability (reachable / no_path_from_entry / uncertain) →
+    1-hop function_called (called / not_called / uncertain).
+
+    Sound witnesses (module_aborts / lexical_dead) come first so they win
+    where they apply (they can hard-suppress); build_excluded (heuristic,
+    whole-file) then catches anything in a never-compiled file — including
+    functions above a module-abort line and framework-decorated functions,
+    since a file the build never compiles registers nothing.
     """
     from core.inventory.reachability import (
         InternalFunction,
         Verdict,
+        build_excluded,
         entry_reachability,
         function_called,
         is_framework_callable,
@@ -67,6 +75,8 @@ def classify_reachability(
         return "module_aborts"
     if is_lexically_dead(inventory, file_path, name, line):
         return "lexical_dead"
+    if build_excluded(inventory, file_path):
+        return "build_excluded"
 
     target = InternalFunction(file_path=file_path, name=name, line=line)
     # Specific reachable reasons first — framework decorator dispatch and

--- a/core/inventory/reach_witness.py
+++ b/core/inventory/reach_witness.py
@@ -39,6 +39,7 @@ class WitnessKind(str, Enum):
     # unreachable
     MODULE_ABORTS = "module_aborts"
     LEXICAL_DEAD = "lexical_dead"
+    BUILD_EXCLUDED = "build_excluded"
     NO_PATH_FROM_ENTRY = "no_path_from_entry"
     NOT_CALLED = "not_called"
     # reachable
@@ -121,6 +122,10 @@ _VERDICT_MAP: Dict[str, Tuple[Reachability, WitnessKind, Soundness, str]] = {
     "lexical_dead": (
         Reachability.UNREACHABLE, WitnessKind.LEXICAL_DEAD, Soundness.SOUND,
         "defined inside an always-false guard",
+    ),
+    "build_excluded": (
+        Reachability.UNREACHABLE, WitnessKind.BUILD_EXCLUDED, Soundness.HEURISTIC,
+        "translation unit excluded from the build (never compiled)",
     ),
     "no_path_from_entry": (
         Reachability.UNREACHABLE, WitnessKind.NO_PATH_FROM_ENTRY,

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -2199,6 +2199,42 @@ def module_aborts_on_load(
     return None
 
 
+def build_excluded(
+    inventory: Dict[str, Any],
+    file_path: str,
+) -> Optional[Dict[str, Any]]:
+    """Return the build-exclusion record for ``file_path`` if the inventory
+    builder detected that the file is never compiled (e.g. Go
+    ``//go:build ignore``), else ``None``.
+
+    When non-None, NO function in the file is reachable: the translation unit
+    is excluded from the build, so nothing in it is compiled or linked —
+    regardless of in-file call edges or external linkage. Unlike
+    :func:`module_aborts_on_load` this is whole-file with no line threshold
+    (a compile-time, not runtime, property). HEURISTIC, not sound: a build
+    constraint is config-dependent (a forced build / alternate tag set could
+    include the file), so consumers surface-only — demote / annotate, never
+    hard-suppress.
+
+    The returned dict carries ``line`` (constraint location, display-only)
+    and ``summary`` (e.g. ``"//go:build ignore"``). Path-keyed lookup, no
+    index build — mirrors :func:`module_aborts_on_load`.
+    """
+    if not file_path:
+        return None
+    normalised = file_path.replace("\\", "/")
+    for file_record in inventory.get("files", []):
+        if not isinstance(file_record, dict):
+            continue
+        rec_path = file_record.get("path")
+        if not isinstance(rec_path, str):
+            continue
+        if rec_path.replace("\\", "/") == normalised:
+            rec = file_record.get("build_excluded")
+            return rec if isinstance(rec, dict) else None
+    return None
+
+
 def is_lexically_dead(
     inventory: Dict[str, Any],
     file_path: str,

--- a/core/inventory/tests/test_build_membership.py
+++ b/core/inventory/tests/test_build_membership.py
@@ -1,0 +1,57 @@
+"""Tests for build-exclusion detection (Gap 1: build_excluded witness)."""
+
+from __future__ import annotations
+
+from core.inventory.build_membership import BuildExcluded, detect_build_excluded
+
+
+def test_go_modern_build_ignore():
+    src = "//go:build ignore\n\npackage main\nfunc main(){}\n"
+    r = detect_build_excluded("go", src)
+    assert isinstance(r, BuildExcluded)
+    assert r.summary == "//go:build ignore"
+    assert r.line == 1
+
+
+def test_go_legacy_build_ignore():
+    src = "// +build ignore\n\npackage main\nfunc main(){}\n"
+    r = detect_build_excluded("go", src)
+    assert r is not None and r.summary == "// +build ignore"
+
+
+def test_go_normal_file_not_excluded():
+    assert detect_build_excluded("go", "package main\nfunc main(){}\n") is None
+
+
+def test_go_satisfiable_constraint_not_excluded():
+    # `ignore || linux` builds on linux → satisfiable → not excluded.
+    assert detect_build_excluded(
+        "go", "//go:build ignore || linux\npackage main\n") is None
+
+
+def test_go_legacy_multi_term_not_excluded():
+    # `// +build ignore foo` == (ignore OR foo) → satisfiable.
+    assert detect_build_excluded(
+        "go", "// +build ignore foo\n\npackage main\n") is None
+
+
+def test_go_constraint_after_package_ignored():
+    # Build constraints are only valid before the package clause.
+    assert detect_build_excluded(
+        "go", "package main\n//go:build ignore\nfunc main(){}\n") is None
+
+
+def test_go_other_tag_not_excluded():
+    # A real platform constraint is not a never-built marker.
+    assert detect_build_excluded(
+        "go", "//go:build linux\npackage main\n") is None
+
+
+def test_non_go_languages_return_none():
+    # Detector is Go-only for now; other langs degrade to None.
+    for lang in ("c", "cpp", "rust", "python", "javascript"):
+        assert detect_build_excluded(lang, "//go:build ignore\n") is None
+
+
+def test_empty_content():
+    assert detect_build_excluded("go", "") is None

--- a/core/inventory/tests/test_extractors.py
+++ b/core/inventory/tests/test_extractors.py
@@ -177,6 +177,26 @@ class TestCRegexExtractor:
         funcs = CExtractor().extract("t.c", code)
         assert funcs[0].metadata.visibility == "extern"
 
+    def test_static_inline_is_static_not_inline(self):
+        # Gap 2: `inline` must not mask the `static` internal-linkage signal
+        # (`static inline` is still internal — not an external entry).
+        code = "static inline int clamp(int a, int b) {\n    return a;\n}\n"
+        funcs = CExtractor().extract("t.h", code)
+        assert funcs[0].metadata.visibility == "static"
+
+    def test_extern_beats_static_on_conflict(self):
+        # Invalid `extern static` (conflicting linkage) is treated as external
+        # — never under-claim reachability on malformed input.
+        code = "extern static int weird(void) {\n    return 0;\n}\n"
+        funcs = CExtractor().extract("t.c", code)
+        assert funcs[0].metadata.visibility == "extern"
+
+    def test_bare_inline_is_not_static(self):
+        # `inline` alone is not a linkage class → external (not "static").
+        code = "inline int helper(void) {\n    return 0;\n}\n"
+        funcs = CExtractor().extract("t.c", code)
+        assert funcs[0].metadata.visibility != "static"
+
     def test_return_type(self):
         code = "int main() {\n}\n"
         funcs = CExtractor().extract("t.c", code)

--- a/core/inventory/tests/test_reach_audit.py
+++ b/core/inventory/tests/test_reach_audit.py
@@ -144,3 +144,33 @@ def test_classify_precedence_module_abort_wins(tmp_path):
     with tempfile.TemporaryDirectory() as td:
         inv = build_inventory(str(tmp_path), td)
     assert classify_reachability(inv, "d.py", "a", 2, "d") == "module_aborts"
+
+
+def test_classify_build_excluded_whole_file():
+    # A build-excluded file (e.g. Go //go:build ignore): every function is
+    # dead, even `main` / `init` which are normally Go entries. Synthetic
+    # inventory keeps this tree-sitter-independent.
+    inv = {"files": [{
+        "path": "go/gen.go", "language": "go",
+        "build_excluded": {"line": 1, "summary": "//go:build ignore"},
+        "items": [{"name": "main", "kind": "function",
+                   "line_start": 3, "line_end": 5}],
+    }]}
+    assert classify_reachability(
+        inv, "go/gen.go", "main", 3, "go.gen") == "build_excluded"
+
+
+def test_classify_sound_witness_beats_build_excluded():
+    # When a function sits below a (sound) module-abort in a file that is ALSO
+    # build-excluded, the sound verdict wins — it can hard-suppress, whereas
+    # build_excluded is heuristic. (A Go file with both a `func init(){panic}`
+    # and a build constraint: functions below the init-panic read
+    # module_aborts; init itself / functions above read build_excluded.)
+    inv = {"files": [{
+        "path": "go/m.go", "language": "go",
+        "module_aborts_on_load": {"line": 2, "summary": "func init(){panic}"},
+        "build_excluded": {"line": 1, "summary": "//go:build ignore"},
+        "items": [{"name": "sink", "kind": "function", "line_start": 4}],
+    }]}
+    assert classify_reachability(
+        inv, "go/m.go", "sink", 4, "go.m") == "module_aborts"

--- a/core/inventory/tests/test_reach_witness.py
+++ b/core/inventory/tests/test_reach_witness.py
@@ -21,9 +21,10 @@ def test_may_suppress_is_safe_by_default_for_everything():
     # corpus-earned set — a static "sound" label is necessary, not
     # sufficient (the detectors are heuristic; a detector bug must not be
     # able to license a false negative).
-    for v in ("module_aborts", "lexical_dead", "no_path_from_entry",
-              "not_called", "called", "framework_callable",
-              "registered_via_call", "reachable", "uncertain"):
+    for v in ("module_aborts", "lexical_dead", "build_excluded",
+              "no_path_from_entry", "not_called", "called",
+              "framework_callable", "registered_via_call", "reachable",
+              "uncertain"):
         assert verdict_from_classification(v).may_suppress() is False, v
 
 
@@ -41,7 +42,7 @@ def test_heuristic_dead_witnesses_never_suppress_even_when_earned():
     # assumptions can miss reflection, cross-file, or address-of edges.
     # Even if an over-eager consumer puts them in the earned set, soundness
     # gates them out.
-    for v in ("no_path_from_entry", "not_called"):
+    for v in ("no_path_from_entry", "not_called", "build_excluded"):
         rv = verdict_from_classification(v)
         assert rv.status is Reachability.UNREACHABLE
         assert rv.witness.soundness is Soundness.HEURISTIC

--- a/core/orchestration/reachability_enrichment.py
+++ b/core/orchestration/reachability_enrichment.py
@@ -102,6 +102,7 @@ def mark_unreachable_low_priority(
         from core.inventory.reachability import (
             InternalFunction,
             Verdict,
+            build_excluded,
             entry_reachability,
             function_called,
             is_framework_callable,
@@ -139,6 +140,10 @@ def mark_unreachable_low_priority(
         abort_line = (
             int(file_abort.get("line") or 0) if file_abort else 0
         )
+        # Whole-file build exclusion (e.g. Go ``//go:build ignore``): the file
+        # is never compiled, so every function in it is dead. Whole-file, no
+        # line threshold. Heuristic (config-dependent) → soft-demote only.
+        file_build_excluded = build_excluded(inventory, rel_path) is not None
 
         for func in funcs:
             if not isinstance(func, dict):
@@ -189,6 +194,16 @@ def mark_unreachable_low_priority(
             ):
                 func["priority"] = "low"
                 func["priority_reason"] = "reachability:lexical_dead"
+                marked += 1
+                continue
+
+            # Whole-file build exclusion. Trumps the framework / call-graph
+            # checks below (a file the build never compiles registers and
+            # calls nothing). Heuristic → soft-demote, respects
+            # allow_unreachable like the other surface-only gates.
+            if not allow_unreachable and file_build_excluded:
+                func["priority"] = "low"
+                func["priority_reason"] = "reachability:build_excluded"
                 marked += 1
                 continue
 

--- a/core/orchestration/tests/test_reachability_enrichment.py
+++ b/core/orchestration/tests/test_reachability_enrichment.py
@@ -892,3 +892,49 @@ class TestEntryReachabilityGate:
         funcs = {f["name"]: f for f in checklist["files"][0]["items"]}
         assert funcs["isl_a"].get("priority") != "low"
         assert marked == 0
+
+
+class TestBuildExcludedGate:
+    """Gap 1: a build-excluded file (Go ``//go:build ignore``) is never
+    compiled, so every function in it demotes — even ``main``/``init``, which
+    are normally Go entries. Heuristic → soft-demote, respects
+    allow_unreachable. Synthetic inventory keeps this tree-sitter-independent."""
+
+    def _synthetic_go(self):
+        items = [
+            {"name": "main", "kind": "function", "line_start": 4},
+            {"name": "run", "kind": "function", "line_start": 5},
+        ]
+        inv = {"files": [{
+            "path": "gen.go", "language": "go", "items": items,
+            "build_excluded": {"line": 1, "summary": "//go:build ignore"},
+            "call_graph": {"imports": {}, "calls": []},
+        }]}
+        checklist = {"files": [{"path": "gen.go", "items": items}]}
+        return inv, checklist
+
+    def test_build_excluded_demotes_every_function(self, tmp_path):
+        inv, checklist = self._synthetic_go()
+        marked = mark_unreachable_low_priority(
+            checklist, tmp_path, inventory=inv,
+        )
+        assert marked == 2
+        funcs = {f["name"]: f for f in checklist["files"][0]["items"]}
+        for name in ("main", "run"):
+            assert funcs[name]["priority"] == "low"
+            assert funcs[name]["priority_reason"] == (
+                "reachability:build_excluded"
+            )
+
+    def test_allow_unreachable_suppresses_build_excluded_demotion(
+        self, tmp_path,
+    ):
+        inv, checklist = self._synthetic_go()
+        marked = mark_unreachable_low_priority(
+            checklist, tmp_path, inventory=inv, allow_unreachable=True,
+        )
+        assert marked == 0
+        funcs = {f["name"]: f for f in checklist["files"][0]["items"]}
+        assert funcs["main"].get("priority_reason") != (
+            "reachability:build_excluded"
+        )

--- a/packages/exploitability_validation/reachability.py
+++ b/packages/exploitability_validation/reachability.py
@@ -38,6 +38,62 @@ logger = logging.getLogger(__name__)
 # misrepresents the LLM's actual analysis.
 _DEMOTED_PROXIMITY_CAP = 1
 
+# Reachability verdicts (from classify_reachability) that demote an attack
+# path. The reachable verdicts (called / reachable / framework_callable /
+# registered_via_call) and "uncertain" are NOT here — they keep the path.
+# Demotion is soft (proximity clamp + blocker), so demoting on the heuristic
+# verdicts (no_path_from_entry / not_called) is safe — never a hard suppress.
+_DEMOTE_VERDICTS = frozenset({
+    "module_aborts", "lexical_dead", "build_excluded",
+    "no_path_from_entry", "not_called",
+})
+
+
+def _blocker_for(
+    verdict: str,
+    module: str,
+    func_name: str,
+    inventory: Dict[str, Any],
+    rel_path: str,
+) -> str:
+    """Human-readable blocker string for a dead reachability ``verdict``,
+    appended to the attack path. module_aborts / build_excluded fetch the
+    file's witness summary for the specific reason (e.g. ``raise ImportError``
+    / ``//go:build ignore``)."""
+    fq = f"`{module}.{func_name}`"
+    if verdict == "module_aborts":
+        from core.inventory.reachability import module_aborts_on_load
+        rec = module_aborts_on_load(inventory, rel_path) or {}
+        return (
+            f"reachability:module_aborts — entry function {fq} is in a file "
+            f"whose top-level execution aborts on load ({rec.get('summary')}) "
+            f"before the function binds"
+        )
+    if verdict == "lexical_dead":
+        return (
+            f"reachability:lexical_dead — entry function {fq} is defined "
+            f"inside an always-false guard (if False / #[cfg(any())]) and "
+            f"never binds"
+        )
+    if verdict == "build_excluded":
+        from core.inventory.reachability import build_excluded
+        rec = build_excluded(inventory, rel_path) or {}
+        return (
+            f"reachability:build_excluded — entry function {fq} is in a file "
+            f"excluded from the build ({rec.get('summary')}) and is never "
+            f"compiled"
+        )
+    if verdict == "no_path_from_entry":
+        return (
+            f"reachability:no_path_from_entry — entry function {fq} has "
+            f"callers, but none reachable from any entry point "
+            f"(orphaned dead-island)"
+        )
+    return (
+        f"reachability:not_called — entry function {fq} is not called from "
+        f"any non-test project source"
+    )
+
 
 def demote_unreachable_paths(
     attack_paths: List[Dict[str, Any]],
@@ -104,15 +160,7 @@ def demote_unreachable_paths(
 
     try:
         from core.inventory.lookup import lookup_function
-        from core.inventory.reachability import (
-            InternalFunction,
-            Verdict,
-            function_called,
-            is_framework_callable,
-            is_lexically_dead,
-            is_registered_via_call,
-            module_aborts_on_load,
-        )
+        from core.inventory.reach_audit import classify_reachability
     except ImportError:
         return 0
 
@@ -149,74 +197,24 @@ def demote_unreachable_paths(
 
         func_line = int(func_info.get("line_start") or 0)
 
-        # S4: whole-file module-load-abort gate, checked before the
-        # call-graph verdict because it trumps CALLED. When the
-        # sink's file aborts at load (raise ImportError / throw new
-        # Error / init() panic / compile_error!) before the entry
-        # function binds, the path is dead regardless of static call
-        # edges — and the framework_callable / registered_via_call
-        # escape hatches below do NOT apply (registration code under
-        # the abort never runs). ``allow_unreachable`` already
-        # short-circuited the whole function above, so no re-check.
-        abort = module_aborts_on_load(inventory, rel_path)
-        blocker: Optional[str] = None
-        if (
-            abort is not None
-            and int(abort.get("line") or 0)
-            and func_line
-            and func_line > int(abort.get("line") or 0)
-        ):
-            blocker = (
-                f"reachability:module_aborts — entry function "
-                f"`{module}.{func_name}` is in a file whose top-level "
-                f"execution aborts on load ({abort.get('summary')}) "
-                f"before the function binds"
-            )
-        elif is_lexically_dead(inventory, rel_path, func_name, func_line):
-            # S3: entry function defined inside an always-false guard
-            # (if False: / if (false) / #[cfg(any())]). Never binds —
-            # dead regardless of call edges. Trumps framework dispatch
-            # (a decorator inside dead scope registers nothing).
-            blocker = (
-                f"reachability:lexical_dead — entry function "
-                f"`{module}.{func_name}` is defined inside an "
-                f"always-false guard (if False / #[cfg(any())]) and "
-                f"never binds"
-            )
-        else:
-            try:
-                result = function_called(
-                    inventory, f"{module}.{func_name}",
-                )
-            except ValueError:
-                continue
-
-            if result.verdict != Verdict.NOT_CALLED:
-                continue
-
-            # NOT_CALLED in the static graph isn't dead code when the
-            # function is framework-registered (Flask ``@app.route``,
-            # Celery ``@shared_task``, Django ``@receiver``, etc.).
-            # The substrate's ``is_framework_callable`` recognises
-            # these; without this check the demoter sinks legitimate
-            # exploitable handlers to proximity=1 + "not_called"
-            # blocker on any web / task / signal codebase.
-            target = InternalFunction(
-                file_path=rel_path, name=func_name, line=func_line,
-            )
-            if is_framework_callable(inventory, target):
-                continue
-            # Same skip-the-demotion logic for JS / Go function-as-
-            # argument registration (``http.HandleFunc("/x", target)``,
-            # ``app.get("/users", target)``, etc.) — the JS / Go
-            # equivalent of decorator-driven dispatch.
-            if is_registered_via_call(inventory, target):
-                continue
-            blocker = (
-                f"reachability:not_called — entry function "
-                f"`{module}.{func_name}` is not called from any "
-                f"non-test project source"
-            )
+        # Reachability verdict via the shared, entry-aware classifier — the
+        # same precedence the /agentic prepass and CodeQL prefilter use:
+        # module_aborts → lexical_dead → build_excluded → framework /
+        # registration → entry-reachability → 1-hop called/not_called.
+        # Routing through it (rather than a hand-rolled 1-hop sequence) gives
+        # /validate the entry-aware no_path_from_entry verdict too, so a
+        # dead-island finding (reachable only via a dead caller) is demoted
+        # consistently across all three consumers. Framework dispatch /
+        # registration surface as reachable verdicts → not demoted, so the
+        # web/task/signal-handler escape hatch is preserved. allow_unreachable
+        # already short-circuited this whole pass upstream, so every dead
+        # verdict demotes (soft — proximity clamp + blocker, never suppress).
+        verdict = classify_reachability(
+            inventory, rel_path, func_name, func_line, module,
+        )
+        if verdict not in _DEMOTE_VERDICTS:
+            continue
+        blocker = _blocker_for(verdict, module, func_name, inventory, rel_path)
 
         # Demote: cap proximity, append blocker.
         original_proximity = path.get("proximity")

--- a/packages/exploitability_validation/tests/test_reachability_demotion.py
+++ b/packages/exploitability_validation/tests/test_reachability_demotion.py
@@ -566,3 +566,50 @@ def test_allow_unreachable_skips_lexical_dead_demotion(tmp_path):
     )
     assert demoted == 0
     assert paths[0]["proximity"] == 8
+
+
+# --- entry-aware routing (Gap 3): /validate demoter now uses the shared
+# classify_reachability, so dead-islands (reachable only via a dead caller)
+# demote consistently with /agentic + the CodeQL prefilter. Synthetic C
+# inventory keeps this tree-sitter-independent. ---
+
+def _dead_island_c_inventory():
+    items = [
+        {"name": "api", "kind": "function", "line_start": 1,
+         "metadata": {"visibility": None}},          # non-static → entry
+        {"name": "isl_a", "kind": "function", "line_start": 5,
+         "metadata": {"visibility": "static"}},
+        {"name": "isl_b", "kind": "function", "line_start": 9,
+         "metadata": {"visibility": "static"}},
+    ]
+    calls = [
+        {"caller": "isl_a", "chain": ["isl_b"], "line": 6},
+        {"caller": "isl_b", "chain": ["isl_a"], "line": 10},
+    ]
+    return {"files": [{"path": "app.c", "language": "c", "items": items,
+                       "call_graph": {"imports": {}, "calls": calls}}]}
+
+
+def test_demotes_dead_island_via_no_path_from_entry(tmp_path):
+    # isl_a reads CALLED in the 1-hop graph (isl_b calls it) but no path from
+    # any entry reaches it. The old 1-hop demoter missed this; the entry-aware
+    # classifier demotes it with a no_path_from_entry blocker.
+    inv = _dead_island_c_inventory()
+    findings = [{"id": "f1", "file_path": "app.c", "start_line": 5}]
+    paths = [{"id": "p1", "finding_id": "f1", "proximity": 8, "blockers": []}]
+    demoted = demote_unreachable_paths(paths, findings, tmp_path, inventory=inv)
+    assert demoted == 1
+    assert paths[0]["proximity"] == 1
+    assert any("reachability:no_path_from_entry" in b
+               for b in paths[0]["blockers"])
+
+
+def test_does_not_demote_reachable_nonstatic_entry(tmp_path):
+    # The non-static `api` is an external entry → reachable → not demoted
+    # (the library-API case must survive the entry-aware routing).
+    inv = _dead_island_c_inventory()
+    findings = [{"id": "f1", "file_path": "app.c", "start_line": 1}]
+    paths = [{"id": "p1", "finding_id": "f1", "proximity": 8, "blockers": []}]
+    demoted = demote_unreachable_paths(paths, findings, tmp_path, inventory=inv)
+    assert demoted == 0
+    assert paths[0]["proximity"] == 8

--- a/packages/llm_analysis/prompts/analysis.py
+++ b/packages/llm_analysis/prompts/analysis.py
@@ -62,6 +62,7 @@ If the metadata block contains a "Reachability:" section, use it as evidence:
 - "Verdict: MODULE_ABORTS_ON_LOAD" — the file's top-level execution unconditionally aborts (raise ImportError, throw new Error, init() panic, compile_error!) before this function's definition runs. The function is never importable/callable in this deployment, regardless of in-file call edges — peers that appear to call it are equally dead, since the file never finishes loading. This is a STRONGER signal than NOT_CALLED: there is no framework-dispatch escape hatch (registration code below the abort never executes). Mark is_exploitable=False with ruling="dead_code". The vulnerability shape may still be a true positive (is_true_positive=True), but it is unreachable in this deployment.
 - "Verdict: LEXICAL_DEAD" — this function is defined inside an always-false guard (if False:, if (false) {…}, #[cfg(any())]). The guard's body never executes or compiles, so the function never binds. Like MODULE_ABORTS_ON_LOAD this trumps in-scope call edges (two dead-scope functions calling each other read as mutually called, but the whole scope is dead) and any decorator inside the dead scope never registers anything. Mark is_exploitable=False with ruling="dead_code". The vulnerability shape may still be a true positive (is_true_positive=True), but it is unreachable.
 - "Verdict: NO_PATH_FROM_ENTRY" — this function has in-project callers, but no path from any entry point (main, framework dispatch, or an exported/public symbol) reaches it: the entire calling chain is an orphaned dead-island (e.g. a static helper called only by another unreachable static function, or a function referenced only from an unread function-pointer table). Stronger than a raw caller count — having a caller doesn't mean the caller itself ever runs. Before marking exploitable, identify a real invocation path from a deployment entry point; if none exists, mark is_exploitable=False with ruling="dead_code" or "unreachable". The vulnerability shape may still be a true positive (is_true_positive=True), but it is unreachable in this deployment.
+- "Verdict: BUILD_EXCLUDED" — this function's file is excluded from the build (e.g. Go //go:build ignore, a standalone `go run gen.go` codegen script), so it is never compiled or linked in the normal build. This is a CONFIG-DEPENDENT (heuristic) signal, weaker than the structural verdicts above: a non-default build (e.g. `go build -tags ignore`) or an alternate build system could include the file. Treat it as strong evidence of unreachability in the shipped configuration — confirm the deployment doesn't compile the file, then mark is_exploitable=False with ruling="dead_code" or "unreachable"; if you have reason to believe the build does include it, say so and analyse normally. The vulnerability shape may still be a true positive (is_true_positive=True).
 - "Caller graph: N direct, M transitive" with N=0 but uncertain > 0 — the substrate found indirection it cannot resolve (string-dispatch / reflect / plugin registries). Treat as potentially reachable; note the indirection class in your reasoning.
 - "Caller graph: N direct, M transitive" with N > 0 — reachability is established; focus on exploit feasibility.
 
@@ -195,6 +196,15 @@ def _format_reachability_block(metadata: Dict[str, Any]) -> str:
         lines.append(
             "Verdict: LEXICAL_DEAD — defined inside an always-false "
             "guard (if False / #[cfg(any())]); never binds"
+        )
+    elif priority_reason == "reachability:build_excluded":
+        # Whole-file build exclusion (e.g. Go //go:build ignore): the file
+        # is never compiled, so nothing in it is reachable. Heuristic
+        # (config-dependent — a forced build could include it), so it's a
+        # surface signal, not a hard verdict; the system prompt explains it.
+        lines.append(
+            "Verdict: BUILD_EXCLUDED — file is excluded from the build "
+            "(e.g. //go:build ignore); never compiled in this configuration"
         )
     elif priority_reason == "reachability:no_path_from_entry":
         # U7: transitive entry-reachability. The function may have an


### PR DESCRIPTION
Three reachability-accuracy precision fixes to the closeable-language (C/C++/Go/Rust) entry model. All FN-safe — they corrected cases that over-surfaced dead code as live-looking, or surfaced it inconsistently across consumers; none can wrongly suppress a real finding.

1. Build-excluded translation units (`build_excluded` witness). A file the build never compiles contributes no reachable code, but the entry / call-graph analyses treated it as ordinary source (so e.g. a standalone `go run gen.go` script's `main`/`init` read reachable). New heuristic, whole-file witness (core/inventory/build_membership.py) with a Go detector for the `ignore` build constraint — `//go:build ignore` and legacy `// +build ignore`, the idiomatic "never built in any normal config" marker. Surface-only (config-dependent: a forced `-tags ignore` build could include it), so it demotes / annotates, never hard-suppresses. The witness is general; C/C++ compile_commands TU-membership and Rust crate-module membership are natural builder-level extensions, noted.

2. C/C++ internal-linkage detection. The extractor derived visibility from the LAST storage-class specifier, so `static inline f()` recorded `inline` and `f` was misread as an external entry rather than internal linkage (not an entry). Both extractor paths now pick the strongest linkage — `extern` > `static`, ignoring `inline` (not a linkage class). Invalid `extern static` resolves to external (never under-claim reachability on malformed input). A non-static function defined in a header stays a legitimate external entry (header-only libraries), so there is deliberately no blanket "header functions aren't entries" rule.

3. Unify the /validate demoter on the shared classifier. The demoter used a hand-rolled 1-hop sequence (module_aborts → lexical_dead → build_excluded → function_called NOT_CALLED) and never received the entry-reachability upgrade the /agentic prepass and CodeQL prefilter have — so a dead-island finding (reachable only via a dead caller) was demoted by those two but NOT by /validate. Routed it through core.inventory.reach_audit .classify_reachability instead, so all three consumers now share one entry-aware classifier (adds no_path_from_entry, removes the duplicated witness logic). Verdict→blocker mapping preserves the existing blocker strings; framework/registration still surface as reachable → not demoted.

build_excluded is wired through the same consumers as module_aborts / lexical_dead (enrichment prepass soft-demote, /validate demoter blocker, analysis-prompt `Verdict: BUILD_EXCLUDED`); the CodeQL prefilter surfaces it automatically via the may_suppress chokepoint (heuristic kind → never hard-skipped). Sound witnesses keep precedence over build_excluded. Tested on both the tree-sitter and stdlib extractor paths.