### PR TITLE
feat(web): add authenticated ffuf options

### DIFF
--- a/packages/web/ffuf.py
+++ b/packages/web/ffuf.py
@@ -17,7 +17,7 @@ from urllib.parse import urljoin, urlparse
 
 from core.logging import get_logger
 from core.sandbox import run_untrusted
-from core.security.redaction import redact_secrets
+from core.security.redaction import is_secret_field_name, redact_secrets
 
 logger = get_logger()
 
@@ -38,6 +38,8 @@ class FfufConfig:
     match_status: str | None = "200,204,301,302,307,401,403,405,500"
     filter_status: str | None = "404"
     filter_size: int | None = None
+    headers: tuple[str, ...] = ()
+    cookies: tuple[str, ...] = ()
 
 
 class FfufRunner:
@@ -59,6 +61,58 @@ class FfufRunner:
 
     def _redact(self, value: object) -> str:
         return redact_secrets(value, reveal_secrets=self.reveal_secrets)
+
+    def _redact_cookie_value(self, cookie: str) -> str:
+        if self.reveal_secrets:
+            return cookie
+        parts = []
+        for segment in cookie.split(";"):
+            prefix = segment[: len(segment) - len(segment.lstrip())]
+            stripped = segment.strip()
+            if "=" not in stripped:
+                parts.append(segment)
+                continue
+            name, _value = stripped.split("=", 1)
+            parts.append(f"{prefix}{name}=[REDACTED]")
+        return "; ".join(parts)
+
+    def _redact_header_value(self, header: str) -> str:
+        if self.reveal_secrets or ":" not in header:
+            return self._redact(header)
+        name, value = header.split(":", 1)
+        normalized = name.strip().lower()
+        if normalized in {"authorization", "proxy-authorization"}:
+            return f"{name}: {self._redact(value.strip())}"
+        if normalized in {"cookie", "set-cookie"}:
+            return f"{name}: {self._redact_cookie_value(value.strip())}"
+        if is_secret_field_name(normalized) or normalized in {
+            "x-api-key",
+            "x-auth-token",
+            "x-csrf-token",
+        }:
+            return f"{name}: [REDACTED]"
+        return self._redact(header)
+
+    def _redact_command(self, cmd: list[str]) -> list[str]:
+        redacted: list[str] = []
+        redact_next_cookie = False
+        for part in cmd:
+            if redact_next_cookie:
+                redacted.append(self._redact_cookie_value(part))
+                redact_next_cookie = False
+                continue
+            if part == "-b":
+                redacted.append(part)
+                redact_next_cookie = True
+                continue
+            if part == "-H":
+                redacted.append(part)
+                continue
+            if redacted and redacted[-1] == "-H":
+                redacted.append(self._redact_header_value(part))
+                continue
+            redacted.append(self._redact(part))
+        return redacted
 
     def build_url_template(self, path_template: str) -> str:
         """Build and scope-check the ffuf URL template.
@@ -102,6 +156,10 @@ class FfufRunner:
             raise ValueError("ffuf report limit must be >= 0")
         if config.filter_size is not None and config.filter_size < 0:
             raise ValueError("ffuf filter size must be >= 0 when set")
+        if any("\n" in header or "\r" in header for header in config.headers):
+            raise ValueError("ffuf headers must not contain newlines")
+        if any("\n" in cookie or "\r" in cookie for cookie in config.cookies):
+            raise ValueError("ffuf cookies must not contain newlines")
 
         url_template = self.build_url_template(config.path_template)
         cmd = [
@@ -128,6 +186,10 @@ class FfufRunner:
             cmd.extend(["-fc", config.filter_status])
         if config.filter_size is not None:
             cmd.extend(["-fs", str(config.filter_size)])
+        for header in config.headers:
+            cmd.extend(["-H", header])
+        for cookie in config.cookies:
+            cmd.extend(["-b", cookie])
         if config.rate is not None:
             cmd.extend(["-rate", str(config.rate)])
         return cmd
@@ -154,7 +216,7 @@ class FfufRunner:
         self.out_dir.mkdir(parents=True, exist_ok=True)
         output_file = self.out_dir / "ffuf_results.json"
         cmd = self.build_command(config, output_file)
-        redacted_cmd = [self._redact(part) for part in cmd]
+        redacted_cmd = self._redact_command(cmd)
         logger.info(f"Running sandboxed ffuf: {' '.join(redacted_cmd)}")
 
         completed = run_untrusted(

--- a/packages/web/ffuf.py
+++ b/packages/web/ffuf.py
@@ -74,7 +74,7 @@ class FfufRunner:
                 continue
             name, _value = stripped.split("=", 1)
             parts.append(f"{prefix}{name}=[REDACTED]")
-        return "; ".join(parts)
+        return ";".join(parts)
 
     def _redact_header_value(self, header: str) -> str:
         if self.reveal_secrets or ":" not in header:
@@ -82,7 +82,7 @@ class FfufRunner:
         name, value = header.split(":", 1)
         normalized = name.strip().lower()
         if normalized in {"authorization", "proxy-authorization"}:
-            return f"{name}: {self._redact(value.strip())}"
+            return f"{name}: [REDACTED]"
         if normalized in {"cookie", "set-cookie"}:
             return f"{name}: {self._redact_cookie_value(value.strip())}"
         if is_secret_field_name(normalized) or normalized in {
@@ -160,6 +160,11 @@ class FfufRunner:
             raise ValueError("ffuf headers must not contain newlines")
         if any("\n" in cookie or "\r" in cookie for cookie in config.cookies):
             raise ValueError("ffuf cookies must not contain newlines")
+        if any(
+            ":" not in header or not header.split(":", 1)[0].strip()
+            for header in config.headers
+        ):
+            raise ValueError("ffuf headers must be in 'Name: value' form")
 
         url_template = self.build_url_template(config.path_template)
         cmd = [

--- a/packages/web/scanner.py
+++ b/packages/web/scanner.py
@@ -203,6 +203,18 @@ Examples:
         help="Optional ffuf response size filter for -fs",
     )
     parser.add_argument(
+        "--ffuf-header",
+        action="append",
+        default=[],
+        help="Header to pass to ffuf; repeatable, e.g. --ffuf-header 'Header-Name: value'",
+    )
+    parser.add_argument(
+        "--ffuf-cookie",
+        action="append",
+        default=[],
+        help="Cookie to pass to ffuf; repeatable, e.g. --ffuf-cookie 'session=...'",
+    )
+    parser.add_argument(
         "--reveal-secrets",
         action="store_true",
         help="Preserve secrets in web artifacts for local debugging; defaults to redaction",
@@ -227,6 +239,8 @@ def build_ffuf_config(args) -> Optional[FfufConfig]:
         match_status=args.ffuf_match_status or None,
         filter_status=args.ffuf_filter_status or None,
         filter_size=args.ffuf_filter_size,
+        headers=tuple(args.ffuf_header or ()),
+        cookies=tuple(args.ffuf_cookie or ()),
     )
 
 

--- a/packages/web/tests/test_ffuf.py
+++ b/packages/web/tests/test_ffuf.py
@@ -91,6 +91,85 @@ def test_build_command_rejects_invalid_numeric_options(
         runner.build_command(FfufConfig(wordlist=wordlist, **config_kwargs), tmp_path / "out.json")
 
 
+
+def test_build_command_threads_authenticated_ffuf_options(tmp_path: Path):
+    wordlist = tmp_path / "words.txt"
+    wordlist.write_text("admin\n", encoding="utf-8")
+    output = tmp_path / "ffuf_results.json"
+    bearer = "Bearer " + "a" * 32
+
+    runner = FfufRunner("https://example.test", tmp_path)
+    cmd = runner.build_command(
+        FfufConfig(
+            wordlist=wordlist,
+            headers=(bearer, "X-Tenant: test"),
+            cookies=("session=" + "b" * 32, "pref=dark"),
+        ),
+        output,
+    )
+
+    assert cmd[cmd.index("-H") + 1] == bearer
+    assert [cmd[idx + 1] for idx, value in enumerate(cmd) if value == "-H"] == [
+        bearer,
+        "X-Tenant: test",
+    ]
+    assert [cmd[idx + 1] for idx, value in enumerate(cmd) if value == "-b"] == [
+        "session=" + "b" * 32,
+        "pref=dark",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("config_kwargs", "message"),
+    [
+        ({"headers": ("X-Test: ok\nInjected: yes",)}, "headers must not contain newlines"),
+        ({"headers": ("X-Test: ok\rInjected: yes",)}, "headers must not contain newlines"),
+        ({"cookies": ("session=ok\nother=yes",)}, "cookies must not contain newlines"),
+        ({"cookies": ("session=ok\rother=yes",)}, "cookies must not contain newlines"),
+    ],
+)
+def test_build_command_rejects_header_cookie_newlines(
+    tmp_path: Path,
+    config_kwargs: dict[str, tuple[str, ...]],
+    message: str,
+):
+    wordlist = tmp_path / "words.txt"
+    wordlist.write_text("admin\n", encoding="utf-8")
+    runner = FfufRunner("https://example.test", tmp_path)
+
+    with pytest.raises(ValueError, match=message):
+        runner.build_command(FfufConfig(wordlist=wordlist, **config_kwargs), tmp_path / "out.json")
+
+
+def test_run_redacts_authenticated_ffuf_options_from_logs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    wordlist = tmp_path / "words.txt"
+    wordlist.write_text("admin\n", encoding="utf-8")
+    monkeypatch.setattr("packages.web.ffuf.shutil.which", lambda _binary: "/usr/bin/ffuf")
+
+    def fake_run(cmd, **kwargs):
+        output_path = Path(cmd[cmd.index("-o") + 1])
+        output_path.write_text(json.dumps({"results": []}), encoding="utf-8")
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr("packages.web.ffuf.run_untrusted", fake_run)
+    bearer = "Bearer " + "a" * 32
+    cookie = "session=" + "b" * 32
+
+    messages: list[str] = []
+    monkeypatch.setattr("packages.web.ffuf.logger.info", messages.append)
+
+    runner = FfufRunner("https://example.test", tmp_path)
+    runner.run(FfufConfig(wordlist=wordlist, headers=(bearer,), cookies=(cookie,)))
+
+    logs = "\n".join(messages)
+    assert "Bearer [REDACTED]" in logs
+    assert "session=[REDACTED]" in logs
+    assert "a" * 32 not in logs
+    assert "b" * 32 not in logs
+
 def test_run_requires_explicit_ffuf_binary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     wordlist = tmp_path / "words.txt"
     wordlist.write_text("admin\n", encoding="utf-8")
@@ -200,6 +279,8 @@ def test_scanner_cli_wires_all_ffuf_options(tmp_path: Path):
 
     wordlist = tmp_path / "words.txt"
     wordlist.write_text("admin\n", encoding="utf-8")
+    auth_header = "Authorization: Bearer " + "a" * 32
+    session_cookie = "session=" + "b" * 32
     args = build_arg_parser().parse_args(
         [
             "--url",
@@ -227,6 +308,14 @@ def test_scanner_cli_wires_all_ffuf_options(tmp_path: Path):
             "403,404",
             "--ffuf-filter-size",
             "1234",
+            "--ffuf-header",
+            auth_header,
+            "--ffuf-header",
+            "X-Tenant: test",
+            "--ffuf-cookie",
+            session_cookie,
+            "--ffuf-cookie",
+            "pref=dark",
         ]
     )
 
@@ -245,6 +334,8 @@ def test_scanner_cli_wires_all_ffuf_options(tmp_path: Path):
     assert config.match_status == "200,401"
     assert config.filter_status == "403,404"
     assert config.filter_size == 1234
+    assert config.headers == (auth_header, "X-Tenant: test")
+    assert config.cookies == (session_cookie, "pref=dark")
 
 
 def test_scanner_cli_can_omit_optional_ffuf_match_and_filter_status(tmp_path: Path):

--- a/packages/web/tests/test_ffuf.py
+++ b/packages/web/tests/test_ffuf.py
@@ -96,7 +96,7 @@ def test_build_command_threads_authenticated_ffuf_options(tmp_path: Path):
     wordlist = tmp_path / "words.txt"
     wordlist.write_text("admin\n", encoding="utf-8")
     output = tmp_path / "ffuf_results.json"
-    bearer = "Bearer " + "a" * 32
+    bearer = "Authorization: Bearer " + "a" * 32
 
     runner = FfufRunner("https://example.test", tmp_path)
     cmd = runner.build_command(
@@ -124,6 +124,8 @@ def test_build_command_threads_authenticated_ffuf_options(tmp_path: Path):
     [
         ({"headers": ("X-Test: ok\nInjected: yes",)}, "headers must not contain newlines"),
         ({"headers": ("X-Test: ok\rInjected: yes",)}, "headers must not contain newlines"),
+        ({"headers": ("Bearer abc123",)}, "headers must be in 'Name: value' form"),
+        ({"headers": (": abc123",)}, "headers must be in 'Name: value' form"),
         ({"cookies": ("session=ok\nother=yes",)}, "cookies must not contain newlines"),
         ({"cookies": ("session=ok\rother=yes",)}, "cookies must not contain newlines"),
     ],
@@ -155,7 +157,7 @@ def test_run_redacts_authenticated_ffuf_options_from_logs(
         return SimpleNamespace(returncode=0, stderr="")
 
     monkeypatch.setattr("packages.web.ffuf.run_untrusted", fake_run)
-    bearer = "Bearer " + "a" * 32
+    bearer = "Authorization: Bearer " + "a" * 32
     cookie = "session=" + "b" * 32
 
     messages: list[str] = []
@@ -165,10 +167,38 @@ def test_run_redacts_authenticated_ffuf_options_from_logs(
     runner.run(FfufConfig(wordlist=wordlist, headers=(bearer,), cookies=(cookie,)))
 
     logs = "\n".join(messages)
-    assert "Bearer [REDACTED]" in logs
+    assert "Authorization: [REDACTED]" in logs
     assert "session=[REDACTED]" in logs
     assert "a" * 32 not in logs
     assert "b" * 32 not in logs
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "Authorization: Token abc123",
+        "Authorization: ApiKey short",
+        'Authorization: Digest username="u", nonce="n"',
+        "Proxy-Authorization: Negotiate abc",
+    ],
+)
+def test_redacts_authorization_headers_without_relying_on_token_shape(
+    tmp_path: Path,
+    header: str,
+):
+    runner = FfufRunner("https://example.test", tmp_path)
+
+    assert runner._redact_header_value(header) == f"{header.split(':', 1)[0]}: [REDACTED]"
+
+
+def test_cookie_redaction_preserves_separator_spacing(tmp_path: Path):
+    runner = FfufRunner("https://example.test", tmp_path)
+
+    assert (
+        runner._redact_cookie_value("session=abc123; pref=dark")
+        == "session=[REDACTED]; pref=[REDACTED]"
+    )
+
 
 def test_run_requires_explicit_ffuf_binary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     wordlist = tmp_path / "words.txt"


### PR DESCRIPTION
## Summary
- add repeatable `--ffuf-header` and `--ffuf-cookie` options for authenticated ffuf discovery
- thread the options through scanner CLI -> `FfufConfig` -> ffuf argv
- validate header/cookie values before invoking ffuf
- keep sandboxing, target-host proxy allowlisting, and same-origin URL template checks unchanged
- redact authenticated ffuf options from the command log by default

## Safety
- ffuf remains opt-in via `--ffuf-wordlist`
- ffuf still runs through `run_untrusted` with target-host egress allowlisting
- headers/cookies are passed as non-shell argv entries
- CR/LF in header and cookie values is rejected before execution
- authorization headers and cookie values are redacted in the logged command unless `reveal_secrets` is explicitly enabled

Further improvement for #617; this is a narrow authenticated-ffuf slice and does not close the broader issue.

## Test plan
- `uv run python -m pytest packages/web/tests/test_ffuf.py packages/web/tests/test_scanner_none_llm.py -q`
- `uv run python -m pytest packages/web/tests -q`
- `uv run python -m compileall -q packages/web core/security *.py`
- `uv run ruff check packages/web/ffuf.py packages/web/scanner.py packages/web/tests/test_ffuf.py`
- `git diff --check`
