### PR TITLE
ci(tests): reusable _tier.yml with fork-PR runner fallback (sage canary)

### DIFF
--- a/.github/workflows/_tier.yml
+++ b/.github/workflows/_tier.yml
@@ -1,0 +1,102 @@
+name: Test tier
+
+# Reusable per-tier test runner with two execution paths, selected by the
+# `use_container` input the caller passes:
+#
+#   image  — runs inside ghcr.io/<owner>/raptor-ci-deps (deps baked in).
+#            The fast path for same-repo events; needs packages:read + a
+#            GHCR login.
+#   runner — builds deps on the bare runner via uv. The fallback for fork
+#            PRs, whose read-only token cannot pull a private GHCR package.
+#            Slower, but never blocked on the image's visibility.
+#
+# Exactly one path runs per call; the other is skipped via `if`. Job
+# display names carry the tier so the status check reads
+# `python-unit-tests-<tier> / python-<tier>[-runner]` — never a bare
+# `image`/`runner` label.
+
+on:
+  workflow_call:
+    inputs:
+      tier:
+        description: Short tier id (e.g. "sage") — used in job display names.
+        required: true
+        type: string
+      test_path:
+        description: pytest target path (e.g. "core/sage/tests").
+        required: true
+        type: string
+      pytest_args:
+        description: Extra pytest args.
+        required: false
+        type: string
+        default: "-n auto"
+      python_version:
+        description: Runner-path Python (must track the image's base).
+        required: false
+        type: string
+        default: "3.12"
+      use_container:
+        description: true → run in the prebuilt image; false → venv on the runner.
+        required: true
+        type: boolean
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  # Fast path: deps are already on the image's system Python.
+  image:
+    if: ${{ inputs.use_container }}
+    name: python-${{ inputs.tier }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/raptor-ci-deps:main
+      credentials:
+        username: ${{ github.actor }}
+        # github.token is always available inside a called workflow — no
+        # `secrets: inherit` needed. Read access to the repo's own GHCR
+        # package is covered by the caller's packages:read grant.
+        password: ${{ github.token }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        with:
+          persist-credentials: false
+      - name: Reconcile deps
+        # No-op unless this PR changed requirements*.txt before the image
+        # rebuilt on main; then installs only the delta.
+        run: pip install --no-cache-dir -r requirements-dev.txt
+      - name: Run tests
+        run: python -m pytest ${{ inputs.test_path }} ${{ inputs.pytest_args }}
+
+  # Fallback path: fork PRs can't pull the private image, so install into
+  # the runner's system Python (uv's cache keyed on requirements*.txt).
+  runner:
+    if: ${{ !inputs.use_container }}
+    name: python-${{ inputs.tier }}-runner
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # was v6
+        with:
+          python-version: ${{ inputs.python_version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # was v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "requirements*.txt"
+      - name: Install deps
+        # --system installs into the setup-python interpreter so the test
+        # step's `python` resolves the deps without venv activation,
+        # matching the image path's "system Python, no venv" model.
+        run: uv pip install --system -r requirements-dev.txt
+      - name: Run tests
+        run: python -m pytest ${{ inputs.test_path }} ${{ inputs.pytest_args }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,11 @@ jobs:
     timeout-minutes: 2
     outputs:
       should_skip: ${{ steps.dup.outputs.should_skip }}
+      # true for same-repo events (push / merge_group / schedule / dispatch
+      # / branch PRs); false only for fork PRs, whose read-only token can't
+      # pull the private GHCR deps image. Tiers pass this to _tier.yml to
+      # choose the image (fast) vs runner (fallback) path.
+      pkg_access: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - id: dup
         env:
@@ -669,35 +674,25 @@ jobs:
   # venv-download from the fan-out that queues under a runner cap.
   # sandbox (namespaces) + exploit_feasibility (radare2/gcc) will NOT
   # migrate; the slim image can't host them.
+  # CANARY for the reusable-workflow migration. sage proves the _tier.yml
+  # two-path (image / runner-fallback) shape before the other container
+  # tiers (codeql, llm-analysis, fuzzing, orchestration) follow. The
+  # caller keeps its path-filter `if:` and name; _tier.yml picks the
+  # execution path from pkg_access.
   python-unit-tests-sage:
     needs: [pre_check, changes]
     if: |
       needs.pre_check.outputs.should_skip != 'true' &&
       (needs.changes.outputs.force_full == 'true' ||
        needs.changes.outputs.sage == 'true')
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
     permissions:
       contents: read
-      packages: read              # pull the private GHCR deps image
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/raptor-ci-deps:main
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
-        with:
-          persist-credentials: false
-      - name: Reconcile deps
-        # No-op when this PR didn't touch requirements*.txt (everything
-        # already satisfied in the image); installs only the delta when
-        # a PR changes deps before the image has rebuilt on main.
-        run: pip install --no-cache-dir -r requirements-dev.txt
-      - name: Run sage tests
-        # Deps are on the image's system Python — no venv to activate.
-        run: python -m pytest core/sage/tests -n auto
+      packages: read              # pull the private GHCR deps image (image path)
+    uses: ./.github/workflows/_tier.yml
+    with:
+      tier: sage
+      test_path: core/sage/tests
+      use_container: ${{ needs.pre_check.outputs.pkg_access == 'true' }}
 
   python-unit-tests-orchestration:
     needs: [pre_check, changes]
@@ -726,4 +721,49 @@ jobs:
         run: pip install --no-cache-dir -r requirements-dev.txt
       - name: Run orchestration tests
         run: python -m pytest core/orchestration/tests -n auto
+
+  # Single aggregate gate over the whole suite. `needs:` every job and
+  # `if: always()` so it still runs when an upstream tier is path-filtered
+  # out (skipped) or fails. This is the one check to pin in a future
+  # branch-protection ruleset: individual tier job names can then change
+  # — notably the reusable-workflow `/ python-<tier>` rename — without
+  # touching protection. Skipped is a pass (dedup / path-filter); only
+  # failure or cancellation blocks.
+  tests-passed:
+    name: tests-passed
+    if: always()
+    needs:
+      - pre_check
+      - changes
+      - deps
+      - python-unit-tests-fast
+      - python-unit-tests-sca
+      - python-unit-tests-sandbox
+      - python-unit-tests-exploit-feasibility
+      - python-prompt-audit
+      - ci-lint-tests
+      - python-unit-tests-codeql
+      - python-unit-tests-llm-analysis
+      - python-unit-tests-cve-diff
+      - python-unit-tests-fuzzing
+      - python-unit-tests-sage
+      - python-unit-tests-orchestration
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Verify all tiers passed
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          set -euo pipefail
+          echo "Tier results: ${RESULTS}"
+          ok=1
+          for r in ${RESULTS}; do
+            case "$r" in
+              success|skipped) ;;
+              *) echo "::error::A required tier reported '${r}'"; ok=0 ;;
+            esac
+          done
+          [ "$ok" -eq 1 ] || exit 1
+          echo "All tiers passed or were legitimately skipped."
 


### PR DESCRIPTION
The container test tiers pull the private ghcr.io/<owner>/raptor-ci-deps image, which fork PRs can't read — their token has no package access to the upstream. Add a reusable workflow with two paths, selected by a new `pkg_access` output on pre_check:
  - image  — fast, in-container; same-repo events (push/PR/merge_group)
  - runner — uv install on the bare runner; the fork-PR fallback

Fork PRs route to `runner` by event context and never attempt the private pull, so the deps image can go private without breaking fork CI.

Migrate sage only as the canary; codeql/llm-analysis/fuzzing/ orchestration follow once this proves green. Also add a `tests-passed` aggregate gate (needs all jobs, always() runs, skipped=pass) as the single stable check to pin in a future ruleset — decoupling branch protection from the reusable-workflow `/ python-<tier>` check rename.