### PR TITLE
Refactor reachability handling and consolidate witness metadata

### DIFF
--- a/core/inventory/reach_audit.py
+++ b/core/inventory/reach_audit.py
@@ -38,6 +38,93 @@ _LIVE_VERDICTS = frozenset({
 # "uncertain" is neither — the substrate declines to claim.
 
 
+@dataclass
+class _ClassifyCtx:
+    """Per-target inputs shared by the precedence stages."""
+    inventory: Dict[str, object]
+    file_path: str
+    name: str
+    line: int
+    module: str
+    target: object          # reachability.InternalFunction
+
+
+# --- precedence stages: each (ctx, R) -> verdict string | None -------------
+# R is the core.inventory.reachability module (the accessors). A stage returns
+# its verdict when it fires, else None to fall through to the next stage.
+
+def _stage_module_aborts(ctx: "_ClassifyCtx", R) -> Optional[str]:
+    abort = R.module_aborts_on_load(ctx.inventory, ctx.file_path)
+    if abort and ctx.line and ctx.line > int(abort.get("line") or 0):
+        return "module_aborts"
+    return None
+
+
+def _stage_lexical_dead(ctx: "_ClassifyCtx", R) -> Optional[str]:
+    if R.is_lexically_dead(ctx.inventory, ctx.file_path, ctx.name, ctx.line):
+        return "lexical_dead"
+    return None
+
+
+def _stage_build_excluded(ctx: "_ClassifyCtx", R) -> Optional[str]:
+    if R.build_excluded(ctx.inventory, ctx.file_path):
+        return "build_excluded"
+    return None
+
+
+def _stage_framework(ctx: "_ClassifyCtx", R) -> Optional[str]:
+    if R.is_framework_callable(ctx.inventory, ctx.target):
+        return "framework_callable"
+    return None
+
+
+def _stage_registered(ctx: "_ClassifyCtx", R) -> Optional[str]:
+    if R.is_registered_via_call(ctx.inventory, ctx.target):
+        return "registered_via_call"
+    return None
+
+
+def _stage_entry(ctx: "_ClassifyCtx", R) -> Optional[str]:
+    er = R.entry_reachability(ctx.inventory, ctx.target)
+    if er == "reachable":
+        return "reachable"
+    if er == "no_path_from_entry":
+        return "no_path_from_entry"
+    return None
+
+
+def _stage_one_hop(ctx: "_ClassifyCtx", R) -> Optional[str]:
+    try:
+        verdict = R.function_called(
+            ctx.inventory, f"{ctx.module}.{ctx.name}").verdict
+    except ValueError:
+        return None
+    if verdict == R.Verdict.CALLED:
+        return "called"
+    if verdict == R.Verdict.NOT_CALLED:
+        return "not_called"
+    return None
+
+
+# Ordered precedence. Sound witnesses (module_aborts / lexical_dead) first so
+# they win where they apply (they can hard-suppress); build_excluded
+# (heuristic, whole-file) next so it catches anything in a never-compiled file
+# — incl. functions above a module-abort line and framework-decorated ones,
+# since a file the build never compiles registers nothing; then the specific
+# reachable reasons (framework / registration) before the general
+# entry-reachability and the 1-hop fallback. Adding a witness = insert a stage
+# here + a VERDICTS entry in reach_witness.
+PRECEDENCE = (
+    _stage_module_aborts,
+    _stage_lexical_dead,
+    _stage_build_excluded,
+    _stage_framework,
+    _stage_registered,
+    _stage_entry,
+    _stage_one_hop,
+)
+
+
 def classify_reachability(
     inventory: Dict[str, object],
     file_path: str,
@@ -45,63 +132,20 @@ def classify_reachability(
     line: int,
     module: str,
 ) -> str:
-    """Strongest applicable reachability verdict for one function, in the
-    same precedence the enrichment prepass uses:
-
-    module_aborts → lexical_dead → build_excluded → framework/registration
-    → entry-reachability (reachable / no_path_from_entry / uncertain) →
-    1-hop function_called (called / not_called / uncertain).
-
-    Sound witnesses (module_aborts / lexical_dead) come first so they win
-    where they apply (they can hard-suppress); build_excluded (heuristic,
-    whole-file) then catches anything in a never-compiled file — including
-    functions above a module-abort line and framework-decorated functions,
-    since a file the build never compiles registers nothing.
-    """
-    from core.inventory.reachability import (
-        InternalFunction,
-        Verdict,
-        build_excluded,
-        entry_reachability,
-        function_called,
-        is_framework_callable,
-        is_lexically_dead,
-        is_registered_via_call,
-        module_aborts_on_load,
+    """Strongest applicable reachability verdict for one function — the first
+    stage in :data:`PRECEDENCE` that fires, else ``"uncertain"``. Single
+    source of truth consumed by the CodeQL prefilter, the /agentic enrichment
+    prepass, and the /validate demoter."""
+    from core.inventory import reachability as R
+    ctx = _ClassifyCtx(
+        inventory=inventory, file_path=file_path, name=name, line=line,
+        module=module,
+        target=R.InternalFunction(file_path=file_path, name=name, line=line),
     )
-
-    abort = module_aborts_on_load(inventory, file_path)
-    if abort and line and line > int(abort.get("line") or 0):
-        return "module_aborts"
-    if is_lexically_dead(inventory, file_path, name, line):
-        return "lexical_dead"
-    if build_excluded(inventory, file_path):
-        return "build_excluded"
-
-    target = InternalFunction(file_path=file_path, name=name, line=line)
-    # Specific reachable reasons first — framework decorator dispatch and
-    # function-as-argument registration — so they surface as their own
-    # (informative) verdicts rather than being absorbed into the general
-    # "reachable" by entry-reachability (which also counts them as entries).
-    if is_framework_callable(inventory, target):
-        return "framework_callable"
-    if is_registered_via_call(inventory, target):
-        return "registered_via_call"
-    # General entry-point forward reachability.
-    er = entry_reachability(inventory, target)
-    if er == "reachable":
-        return "reachable"
-    if er == "no_path_from_entry":
-        return "no_path_from_entry"
-    # er == "uncertain": fall through to the 1-hop verdict.
-    try:
-        verdict = function_called(inventory, f"{module}.{name}").verdict
-    except ValueError:
-        return "uncertain"
-    if verdict == Verdict.CALLED:
-        return "called"
-    if verdict == Verdict.NOT_CALLED:
-        return "not_called"
+    for stage in PRECEDENCE:
+        verdict = stage(ctx, R)
+        if verdict:
+            return verdict
     return "uncertain"
 
 

--- a/core/inventory/reach_witness.py
+++ b/core/inventory/reach_witness.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Tuple
+from typing import Dict, Optional
 
 
 class Reachability(str, Enum):
@@ -97,79 +97,153 @@ class ReachabilityVerdict:
                 and self.witness.kind in earned_kinds)
 
 
-# The witness kinds that CAN earn suppression (config-independent structural
-# deadness). A kind here still suppresses only once a corpus has validated
-# it (passed to ``may_suppress`` as ``earned_kinds``) — membership here is
-# necessary, not sufficient.
-STRUCTURALLY_SUPPRESSIBLE_KINDS = frozenset({
-    WitnessKind.MODULE_ABORTS,
-    WitnessKind.LEXICAL_DEAD,
-})
+@dataclass(frozen=True)
+class VerdictSpec:
+    """All metadata for one ``classify_reachability`` verdict string — the
+    single source of truth that subsumes the old ``_VERDICT_MAP``, the
+    ``/validate`` demoter blocker strings, and the analysis-prompt verdict
+    lines. Adding a witness's metadata is one entry here."""
+    status: Reachability
+    kind: WitnessKind
+    soundness: Soundness
+    # Can this kind EARN hard-suppression? SOUND is necessary-but-not-
+    # sufficient; this is explicit so a sound-but-config-dependent witness
+    # can never qualify by inference.
+    earns_suppression: bool
+    summary: str
+    # /validate demoter blocker template. ``{fq}`` = ``module.func``;
+    # ``{detail}`` = the file-witness summary (only for verdicts whose blocker
+    # embeds one — see ``blocker_detail``). "" ⇒ verdict isn't a demotable
+    # dead verdict.
+    blocker_template: str = ""
+    # Which file-witness summary fills ``{detail}``: "module_aborts" |
+    # "build_excluded" | "" (none).
+    blocker_detail: str = ""
+    # analysis-prompt "Verdict: …" line. "" ⇒ rendered by a special-case
+    # branch (not_called catch-all / framework REACHABLE rendering).
+    prompt_verdict: str = ""
 
 
-# Map a classify_reachability() string verdict → (status, kind, soundness,
-# summary). Candidate soundness: only the structural, config-independent
-# dead witnesses (module-load abort, always-false lexical guard) are SOUND.
-# no_path_from_entry and not_called are UNREACHABLE but HEURISTIC (entry-set
-# completeness / 1-hop assumptions can miss reflection, cross-file, or
-# address-of edges). Reachable/uncertain are never suppress-eligible, so
-# their soundness is immaterial (recorded HEURISTIC).
-_VERDICT_MAP: Dict[str, Tuple[Reachability, WitnessKind, Soundness, str]] = {
-    "module_aborts": (
+# Candidate soundness: only the structural, config-independent dead witnesses
+# (module-load abort, always-false lexical guard) are SOUND and earn
+# suppression. build_excluded / no_path_from_entry / not_called are
+# UNREACHABLE but HEURISTIC (build-config dependence, entry-set completeness,
+# or 1-hop assumptions can miss reflection, cross-file, or address-of edges).
+# Reachable/uncertain are never suppress-eligible.
+VERDICTS: Dict[str, VerdictSpec] = {
+    "module_aborts": VerdictSpec(
         Reachability.UNREACHABLE, WitnessKind.MODULE_ABORTS, Soundness.SOUND,
-        "file aborts on load before this function binds",
+        earns_suppression=True,
+        summary="file aborts on load before this function binds",
+        blocker_template=(
+            "reachability:module_aborts — entry function {fq} is in a file "
+            "whose top-level execution aborts on load ({detail}) before the "
+            "function binds"),
+        blocker_detail="module_aborts",
+        prompt_verdict=(
+            "Verdict: MODULE_ABORTS_ON_LOAD — file aborts at load before this "
+            "function binds; never importable/callable"),
     ),
-    "lexical_dead": (
+    "lexical_dead": VerdictSpec(
         Reachability.UNREACHABLE, WitnessKind.LEXICAL_DEAD, Soundness.SOUND,
-        "defined inside an always-false guard",
+        earns_suppression=True,
+        summary="defined inside an always-false guard",
+        blocker_template=(
+            "reachability:lexical_dead — entry function {fq} is defined inside "
+            "an always-false guard (if False / #[cfg(any())]) and never binds"),
+        prompt_verdict=(
+            "Verdict: LEXICAL_DEAD — defined inside an always-false guard "
+            "(if False / #[cfg(any())]); never binds"),
     ),
-    "build_excluded": (
-        Reachability.UNREACHABLE, WitnessKind.BUILD_EXCLUDED, Soundness.HEURISTIC,
-        "translation unit excluded from the build (never compiled)",
+    "build_excluded": VerdictSpec(
+        Reachability.UNREACHABLE, WitnessKind.BUILD_EXCLUDED,
+        Soundness.HEURISTIC, earns_suppression=False,
+        summary="translation unit excluded from the build (never compiled)",
+        blocker_template=(
+            "reachability:build_excluded — entry function {fq} is in a file "
+            "excluded from the build ({detail}) and is never compiled"),
+        blocker_detail="build_excluded",
+        prompt_verdict=(
+            "Verdict: BUILD_EXCLUDED — file is excluded from the build "
+            "(e.g. //go:build ignore); never compiled in this configuration"),
     ),
-    "no_path_from_entry": (
+    "no_path_from_entry": VerdictSpec(
         Reachability.UNREACHABLE, WitnessKind.NO_PATH_FROM_ENTRY,
-        Soundness.HEURISTIC,
-        "no path from any entry point (orphaned dead-island)",
+        Soundness.HEURISTIC, earns_suppression=False,
+        summary="no path from any entry point (orphaned dead-island)",
+        blocker_template=(
+            "reachability:no_path_from_entry — entry function {fq} has "
+            "callers, but none reachable from any entry point "
+            "(orphaned dead-island)"),
+        prompt_verdict=(
+            "Verdict: NO_PATH_FROM_ENTRY — has callers, but none reachable "
+            "from any entry point (orphaned dead-island)"),
     ),
-    "not_called": (
+    "not_called": VerdictSpec(
         Reachability.UNREACHABLE, WitnessKind.NOT_CALLED, Soundness.HEURISTIC,
-        "no caller found in non-test project source",
+        earns_suppression=False,
+        summary="no caller found in non-test project source",
+        blocker_template=(
+            "reachability:not_called — entry function {fq} is not called from "
+            "any non-test project source"),
+        # prompt_verdict: rendered by the ``priority == low`` catch-all branch.
     ),
-    "called": (
+    "called": VerdictSpec(
         Reachability.REACHABLE, WitnessKind.HAS_CALLER, Soundness.HEURISTIC,
-        "called from project source",
-    ),
-    "framework_callable": (
+        earns_suppression=False, summary="called from project source"),
+    "framework_callable": VerdictSpec(
         Reachability.REACHABLE, WitnessKind.FRAMEWORK_CALLABLE,
-        Soundness.HEURISTIC, "registered via framework dispatch",
-    ),
-    "registered_via_call": (
+        Soundness.HEURISTIC, earns_suppression=False,
+        summary="registered via framework dispatch"),
+    "registered_via_call": VerdictSpec(
         Reachability.REACHABLE, WitnessKind.REGISTERED_VIA_CALL,
-        Soundness.HEURISTIC, "passed as a framework registration argument",
-    ),
-    "reachable": (
+        Soundness.HEURISTIC, earns_suppression=False,
+        summary="passed as a framework registration argument"),
+    "reachable": VerdictSpec(
         Reachability.REACHABLE, WitnessKind.REACHABLE_FROM_ENTRY,
-        Soundness.HEURISTIC, "reachable from an entry point",
-    ),
-    "uncertain": (
+        Soundness.HEURISTIC, earns_suppression=False,
+        summary="reachable from an entry point"),
+    "uncertain": VerdictSpec(
         Reachability.UNCERTAIN, WitnessKind.UNCERTAIN, Soundness.HEURISTIC,
-        "reachability could not be determined",
-    ),
+        earns_suppression=False,
+        summary="reachability could not be determined"),
 }
+
+_UNCERTAIN_SPEC = VERDICTS["uncertain"]
+
+# Derived: the witness kinds that CAN earn suppression (membership necessary,
+# not sufficient — ``may_suppress`` still requires the corpus-earned set).
+STRUCTURALLY_SUPPRESSIBLE_KINDS = frozenset(
+    spec.kind for spec in VERDICTS.values() if spec.earns_suppression
+)
 
 
 def verdict_from_classification(verdict: str) -> ReachabilityVerdict:
     """Wrap a ``classify_reachability`` string verdict in a structured
     ReachabilityVerdict. Unknown strings → UNCERTAIN (fail safe)."""
-    status, kind, soundness, summary = _VERDICT_MAP.get(
-        verdict,
-        (Reachability.UNCERTAIN, WitnessKind.UNCERTAIN, Soundness.HEURISTIC,
-         "reachability could not be determined"),
-    )
+    spec = VERDICTS.get(verdict, _UNCERTAIN_SPEC)
     return ReachabilityVerdict(
-        status=status, witness=Witness(kind=kind, soundness=soundness,
-                                       summary=summary))
+        status=spec.status,
+        witness=Witness(kind=spec.kind, soundness=spec.soundness,
+                        summary=spec.summary))
+
+
+def blocker_for(verdict: str, fq: str, detail: str = "") -> Optional[str]:
+    """The /validate demoter blocker string for a dead ``verdict``, or ``None``
+    when the verdict has no blocker template. ``fq`` = ``module.func``;
+    ``detail`` = the witness summary for verdicts whose blocker embeds one
+    (the caller fetches it per ``VERDICTS[verdict].blocker_detail``)."""
+    spec = VERDICTS.get(verdict)
+    if spec is None or not spec.blocker_template:
+        return None
+    return spec.blocker_template.format(fq=fq, detail=detail)
+
+
+def prompt_verdict_for(verdict: str) -> str:
+    """The analysis-prompt 'Verdict: …' line for a verdict, or '' when the
+    verdict is rendered by a special-case branch (not_called / framework)."""
+    spec = VERDICTS.get(verdict)
+    return spec.prompt_verdict if spec else ""
 
 
 def resolve_reachability(
@@ -193,7 +267,11 @@ __all__ = [
     "Soundness",
     "Witness",
     "ReachabilityVerdict",
+    "VerdictSpec",
+    "VERDICTS",
     "STRUCTURALLY_SUPPRESSIBLE_KINDS",
     "verdict_from_classification",
+    "blocker_for",
+    "prompt_verdict_for",
     "resolve_reachability",
 ]

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -2314,9 +2314,59 @@ def is_lexically_dead(
 # macros) that could hide an entry edge, return UNCERTAIN rather than claim
 # NO_PATH_FROM_ENTRY. Surface-only consumers treat UNCERTAIN as "analyze".
 
-# Languages whose entry model is a closed, sound signal (a NO_PATH verdict
-# is trustworthy). Others degrade to UNCERTAIN.
-_CLOSEABLE_ENTRY_LANGS = frozenset({"c", "cpp", "go", "rust"})
+# Per-language reachability profile — the declarative entry model. Adding a
+# language's entry behaviour is one PROFILES entry; the entry accessors below
+# derive from it instead of inline ``if language ==`` chains.
+#
+#   entry_model:
+#     "sound"     — closed linkage/visibility signal; a NO_PATH_FROM_ENTRY
+#                   verdict is trustworthy (C/C++ static-vs-extern, Go
+#                   exported, Rust pub). entry_reachability may return NO_PATH.
+#     "heuristic" — entries identifiable but the model isn't closed (dynamic
+#                   dispatch / reflection); NO_PATH would be surface-only.
+#                   (No language uses this yet — the Python/Java dead-island
+#                   coverage units flip it on; today nothing is "heuristic".)
+#     "none"      — no visibility-based entry signal; functions fall through
+#                   to UNCERTAIN + the 1-hop NOT_CALLED logic (py/js/java/…).
+#   visibility_entry: how a function's visibility marks it an external entry —
+#     "non_static" (C/C++) | "go_exported" | "rust_pub" | "" (none).
+#   has_go_init / has_java_web: language-specific framework-dispatch entries.
+@dataclass(frozen=True)
+class ReachabilityProfile:
+    language: str
+    entry_model: str = "none"
+    visibility_entry: str = ""
+    has_go_init: bool = False
+    has_java_web: bool = False
+
+
+PROFILES: Dict[str, ReachabilityProfile] = {
+    "c":    ReachabilityProfile("c", "sound", "non_static"),
+    "cpp":  ReachabilityProfile("cpp", "sound", "non_static"),
+    "go":   ReachabilityProfile("go", "sound", "go_exported", has_go_init=True),
+    "rust": ReachabilityProfile("rust", "sound", "rust_pub"),
+    "java": ReachabilityProfile("java", "none", has_java_web=True),
+    "python":     ReachabilityProfile("python", "none"),
+    "javascript": ReachabilityProfile("javascript", "none"),
+    "typescript": ReachabilityProfile("typescript", "none"),
+    "ruby":       ReachabilityProfile("ruby", "none"),
+    "csharp":     ReachabilityProfile("csharp", "none"),
+    "php":        ReachabilityProfile("php", "none"),
+}
+
+_DEFAULT_PROFILE = ReachabilityProfile("")
+
+
+def _profile(language: str) -> ReachabilityProfile:
+    return PROFILES.get(language or "", _DEFAULT_PROFILE)
+
+
+# Languages whose entry model is a closed, sound signal — DERIVED from the
+# profiles (a NO_PATH verdict is trustworthy only for these). Kept as a
+# frozenset for the entry_reachability soundness gate.
+_CLOSEABLE_ENTRY_LANGS = frozenset(
+    lang for lang, p in PROFILES.items() if p.entry_model == "sound"
+)
 
 # Java servlet / filter lifecycle methods — invoked by the container, no
 # in-project caller. (init/destroy are generic names too; treating them as
@@ -2361,32 +2411,34 @@ def _item_is_entry(item: Dict[str, Any], language: str) -> bool:
     name = item.get("name") or ""
     if name == "main":
         return True
+    p = _profile(language)
     # Go runs every ``func init()`` automatically at package load — init
     # and its call tree are reachable even with no explicit caller.
-    if language == "go" and name == "init":
+    if p.has_go_init and name == "init":
         return True
     # Java web handlers are framework-dispatched entries with no in-project
     # caller: servlet lifecycle methods by name and JAX-RS / Spring routing
     # annotations. Without this, live servlet handlers (doPost/doGet) read
     # not_called and get surface-demoted.
-    if language == "java" and _java_web_entry(name, item):
+    if p.has_java_web and _java_web_entry(name, item):
         return True
-    if language not in _CLOSEABLE_ENTRY_LANGS:
+    # Visibility/linkage entry signal (only for languages whose model is a
+    # closed signal; "" ⇒ a public symbol is NOT reliably an entry, so those
+    # fall through to UNCERTAIN + 1-hop NOT_CALLED, behaviour unchanged).
+    if not p.visibility_entry:
         return False
-    md = item.get("metadata") or {}
-    vis = md.get("visibility")
-    if language in ("c", "cpp"):
+    vis = (item.get("metadata") or {}).get("visibility")
+    if p.visibility_entry == "non_static":
         # External linkage = potential entry from another TU. NOTE: a
         # ``static`` function whose ADDRESS is stored in a non-static /
         # exported object (an ops/vtable dispatch table) is externally
         # reachable too, but the call graph doesn't track address-taking —
-        # such functions can read NO_PATH_FROM_ENTRY. Surface-only keeps
-        # this from silencing them (the LLM still analyses); tracking
-        # address-of is a substrate follow-up.
+        # such functions can read NO_PATH_FROM_ENTRY. Surface-only keeps this
+        # from silencing them; tracking address-of is a substrate follow-up.
         return vis != "static"
-    if language == "go":
+    if p.visibility_entry == "go_exported":
         return vis == "exported" or name[:1].isupper()
-    if language == "rust":
+    if p.visibility_entry == "rust_pub":
         return vis in ("public", "pub")
     return False
 

--- a/core/inventory/tests/test_reach_witness.py
+++ b/core/inventory/tests/test_reach_witness.py
@@ -108,10 +108,10 @@ def test_verdict_map_covers_every_classifier_output():
     # explicitly mapped (not silently routed to the uncertain fail-safe).
     # If classify_reachability gains a verdict, this fails until it's mapped.
     from core.inventory.reach_audit import _DEAD_VERDICTS, _LIVE_VERDICTS
-    from core.inventory.reach_witness import _VERDICT_MAP
+    from core.inventory.reach_witness import VERDICTS
     emitted = set(_DEAD_VERDICTS) | set(_LIVE_VERDICTS) | {"uncertain"}
-    unmapped = emitted - set(_VERDICT_MAP)
-    assert not unmapped, f"classifier verdicts missing from map: {unmapped}"
+    unmapped = emitted - set(VERDICTS)
+    assert not unmapped, f"classifier verdicts missing from VERDICTS: {unmapped}"
 
 
 def test_resolve_reachability_end_to_end():
@@ -129,3 +129,39 @@ def test_resolve_reachability_end_to_end():
     assert rv.witness.kind is WitnessKind.MODULE_ABORTS
     assert rv.may_suppress() is False              # not earned by default
     assert rv.may_suppress(_EARNED) is True        # corpus-earned
+
+
+def test_structurally_suppressible_derived_from_table():
+    # The suppressible set is DERIVED from VERDICTS[*].earns_suppression, not
+    # hand-maintained. Pin the expected membership so a stray earns_suppression
+    # flip is caught.
+    from core.inventory.reach_witness import (
+        STRUCTURALLY_SUPPRESSIBLE_KINDS, WitnessKind,
+    )
+    assert STRUCTURALLY_SUPPRESSIBLE_KINDS == frozenset({
+        WitnessKind.MODULE_ABORTS, WitnessKind.LEXICAL_DEAD,
+    })
+
+
+def test_verdicts_blocker_detail_consistency():
+    # A {detail} slot in a blocker template requires a detail source, and a
+    # declared detail source requires a {detail} slot — else the demoter
+    # silently drops/misformats the witness summary.
+    from core.inventory.reach_witness import VERDICTS
+    for v, spec in VERDICTS.items():
+        if "{detail}" in spec.blocker_template:
+            assert spec.blocker_detail in ("module_aborts", "build_excluded"), v
+        if spec.blocker_detail:
+            assert "{detail}" in spec.blocker_template, v
+
+
+def test_blocker_for_and_prompt_verdict_for_round_trip():
+    from core.inventory.reach_witness import blocker_for, prompt_verdict_for
+    # blocker fills fq + detail; non-dead verdicts have no blocker.
+    b = blocker_for("module_aborts", "`m.f`", "raise ImportError")
+    assert b and "`m.f`" in b and "raise ImportError" in b
+    assert blocker_for("reachable", "`m.f`") is None
+    # prompt verdict present for structural dead verdicts, empty for the rest.
+    assert prompt_verdict_for("build_excluded").startswith("Verdict: BUILD_EXCLUDED")
+    assert prompt_verdict_for("not_called") == ""
+    assert prompt_verdict_for("framework_callable") == ""

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -651,3 +651,27 @@ def test_deep_chain_not_truncated_to_no_path():
                       "chain": [f"f{k}"], "line": 10 + k})
     inv = _entry_inv("d.c", "c", items, calls)
     assert _er(inv, "d.c", "f55", 65) == "reachable"
+
+
+def test_closeable_langs_derived_from_profiles():
+    # _CLOSEABLE_ENTRY_LANGS is derived from PROFILES (entry_model=="sound"),
+    # not hand-maintained — pin the membership + the per-language entry rules.
+    from core.inventory.reachability import _CLOSEABLE_ENTRY_LANGS, PROFILES
+    assert _CLOSEABLE_ENTRY_LANGS == frozenset({"c", "cpp", "go", "rust"})
+    for lang in ("c", "cpp", "go", "rust"):
+        assert PROFILES[lang].entry_model == "sound", lang
+    assert PROFILES["c"].visibility_entry == "non_static"
+    assert PROFILES["go"].has_go_init and PROFILES["go"].visibility_entry == "go_exported"
+    assert PROFILES["rust"].visibility_entry == "rust_pub"
+    assert PROFILES["java"].entry_model == "none" and PROFILES["java"].has_java_web
+    assert PROFILES["python"].entry_model == "none"
+
+
+def test_unknown_language_profile_has_no_entry_signal():
+    # A language with no profile (e.g. kotlin) falls back to the default:
+    # no visibility entry, entry_model "none" → UNCERTAIN, FN-safe.
+    from core.inventory.reachability import _profile
+    p = _profile("kotlin")
+    assert p.entry_model == "none"
+    assert p.visibility_entry == ""
+    assert not p.has_go_init and not p.has_java_web

--- a/core/orchestration/reachability_enrichment.py
+++ b/core/orchestration/reachability_enrichment.py
@@ -70,8 +70,12 @@ def mark_unreachable_low_priority(
 
     Returns the count of functions marked low-priority. Zero when
     ``allow_unreachable=True`` (nothing demoted) but still mutates
-    the checklist with the framework_callable / registered_via_call
-    annotations.
+    the checklist with framework_callable / registered_via_call
+    annotations for functions that are *affirmatively* reachable. A
+    framework handler shadowed by a whole-file dead witness (its file
+    aborts on load / is build-excluded, or it's in an always-false
+    guard) is NOT annotated framework-reachable — its registration
+    never runs, so the dead witness wins even in isolation mode.
     """
     if not isinstance(checklist, dict):
         return 0
@@ -99,16 +103,10 @@ def mark_unreachable_low_priority(
             return 0
 
     try:
-        from core.inventory.reachability import (
-            InternalFunction,
-            Verdict,
-            build_excluded,
-            entry_reachability,
-            function_called,
-            is_framework_callable,
-            is_lexically_dead,
-            is_registered_via_call,
-            module_aborts_on_load,
+        from core.inventory.reach_audit import classify_reachability
+        from core.inventory.reach_witness import (
+            Reachability,
+            verdict_from_classification,
         )
     except ImportError:
         return 0
@@ -130,21 +128,6 @@ def mark_unreachable_low_priority(
         if not isinstance(funcs, list):
             continue
 
-        # S4: whole-file module-load-abort gate. Looked up once per
-        # file. When set, the file's top-level execution
-        # unconditionally aborts (raise ImportError / throw new Error
-        # / init() panic / compile_error!), so any function whose
-        # ``def`` lies at or below the abort line never binds — dead
-        # regardless of in-file call edges or framework registration.
-        file_abort = module_aborts_on_load(inventory, rel_path)
-        abort_line = (
-            int(file_abort.get("line") or 0) if file_abort else 0
-        )
-        # Whole-file build exclusion (e.g. Go ``//go:build ignore``): the file
-        # is never compiled, so every function in it is dead. Whole-file, no
-        # line threshold. Heuristic (config-dependent) → soft-demote only.
-        file_build_excluded = build_excluded(inventory, rel_path) is not None
-
         for func in funcs:
             if not isinstance(func, dict):
                 continue
@@ -160,145 +143,33 @@ def mark_unreachable_low_priority(
             if not isinstance(name, str) or not name:
                 continue
 
-            # S4 gate. A function defined STRICTLY below the abort
-            # line never has its ``def`` / decorator executed, so it
-            # can't be registered or called — dead even when the
-            # static graph shows in-file callers (those callers are
-            # equally dead). Trumps the framework_callable /
-            # registered_via_call checks below for exactly this
-            # reason: registration code that never runs registers
-            # nothing. Functions ABOVE the abort line may have
-            # completed registration before the abort fired, so they
-            # fall through to normal call-graph logic. Respects
-            # ``allow_unreachable`` like the NOT_CALLED path.
-            if abort_line and not allow_unreachable:
-                func_line = int(func.get("line_start") or 0)
-                if func_line and func_line > abort_line:
-                    func["priority"] = "low"
-                    func["priority_reason"] = (
-                        "reachability:module_aborts"
-                    )
-                    marked += 1
-                    continue
-
-            # S3: lexical-dead gate. A function defined inside an
-            # always-false guard (``if False:`` / ``if (false) {…}``
-            # / ``#[cfg(any())]``) never binds — the guard body never
-            # runs / compiles. Trumps CALLED (two dead-scope functions
-            # calling each other read as mutually CALLED) and the
-            # framework checks below (a decorator inside dead scope
-            # never registers anything). Respects ``allow_unreachable``.
-            if not allow_unreachable and is_lexically_dead(
-                inventory, rel_path, name,
-                int(func.get("line_start") or 0),
-            ):
-                func["priority"] = "low"
-                func["priority_reason"] = "reachability:lexical_dead"
-                marked += 1
-                continue
-
-            # Whole-file build exclusion. Trumps the framework / call-graph
-            # checks below (a file the build never compiles registers and
-            # calls nothing). Heuristic → soft-demote, respects
-            # allow_unreachable like the other surface-only gates.
-            if not allow_unreachable and file_build_excluded:
-                func["priority"] = "low"
-                func["priority_reason"] = "reachability:build_excluded"
-                marked += 1
-                continue
-
             line = int(func.get("line_start") or 0)
-            target = InternalFunction(
-                file_path=rel_path, name=name, line=line,
-            )
 
-            # U7: entry-point forward reachability. Transitive, entry-aware
-            # answer that 1-hop NOT_CALLED can't give:
-            #   * "reachable" — target OR a reverse-closure ancestor is an
-            #     entry (framework dispatch, main, or an exported/public/
-            #     non-static symbol). Keep it — this also AVOIDS demoting an
-            #     exported public-API function that has no in-project caller
-            #     (the library-API false negative 1-hop NOT_CALLED caused).
-            #   * "no_path_from_entry" — nothing reachable from any entry
-            #     leads here (the dead-island: reads CALLED only because a
-            #     peer that is itself unreachable calls it). Demote.
-            #   * "uncertain" — fuzzy entry model or masking indirection;
-            #     fall through to the existing framework / NOT_CALLED logic
-            #     unchanged. Surface-only: no hard gate, soft-demote only.
-            er = entry_reachability(inventory, target)
-            if er == "reachable":
-                # Keep it (path from a real entry exists). Preserve the
-                # diagnostic annotation downstream consumers expect when
-                # the entry is framework dispatch, so the
-                # framework_callable / registered_via_call reasons still
-                # surface as before.
-                if is_framework_callable(inventory, target):
-                    func["priority_reason"] = (
-                        "reachability:framework_callable"
-                    )
-                elif is_registered_via_call(inventory, target):
-                    func["priority_reason"] = (
-                        "reachability:registered_via_call"
-                    )
-                continue
-            if er == "no_path_from_entry":
+            # ONE entry-aware classifier — the same precedence the CodeQL
+            # prefilter and /validate demoter use (module_aborts →
+            # lexical_dead → build_excluded → framework / registration →
+            # entry-reachability → 1-hop called/not_called). Single source of
+            # truth; no parallel precedence chain here to drift out of sync.
+            verdict = classify_reachability(
+                inventory, rel_path, name, line, module,
+            )
+            if verdict_from_classification(verdict).status is (
+                Reachability.UNREACHABLE
+            ):
+                # Surface-only soft-demote. allow_unreachable (the in-isolation
+                # opt-out) skips the demotion so the analysis prompt emits no
+                # dead-code verdict line. Covers module_aborts / lexical_dead /
+                # build_excluded / no_path_from_entry / not_called uniformly.
                 if allow_unreachable:
                     continue
                 func["priority"] = "low"
-                func["priority_reason"] = "reachability:no_path_from_entry"
+                func["priority_reason"] = f"reachability:{verdict}"
                 marked += 1
-                continue
-            # er == "uncertain" → existing 1-hop logic below.
-
-            qualified = f"{module}.{name}"
-            try:
-                result = function_called(inventory, qualified)
-            except ValueError:
-                continue
-            if result.verdict != Verdict.NOT_CALLED:
-                continue
-
-            # NOT_CALLED in the static graph — but the function may
-            # still be reachable via framework dispatch (Flask
-            # ``@app.route``, Celery ``@shared_task``, Django
-            # ``@receiver``, etc.). The substrate's
-            # ``is_framework_callable`` recognises these. Without
-            # this check, framework-registered handlers regress to
-            # ``priority="low"`` and downstream consumers (LLM
-            # analysis prompt's reachability engagement, attack-
-            # path demoter) treat them as dead code — false
-            # negatives on any web/task/signal-heavy codebase.
-            # (``target`` was computed above for the entry-reachability
-            # gate; reuse it.)
-            if is_framework_callable(inventory, target):
-                # Optionally annotate so operators / downstream
-                # consumers can see this function was static-
-                # uncalled but framework-reachable.
-                func["priority_reason"] = (
-                    "reachability:framework_callable"
-                )
-                continue
-            if is_registered_via_call(inventory, target):
-                # Same skip-the-demotion logic but for the JS / Go
-                # function-as-argument registration pattern
-                # (``http.HandleFunc("/x", target)``,
-                # ``app.get("/users", target)``). Annotate with a
-                # distinct reason so operators can see WHICH
-                # mechanism kept this function alive.
-                func["priority_reason"] = (
-                    "reachability:registered_via_call"
-                )
-                continue
-
-            if allow_unreachable:
-                # In-isolation mode: don't demote NOT_CALLED
-                # functions. The analysis prompt will see caller
-                # counts (informational) but no "Verdict:
-                # NOT_CALLED" line that would trigger deferral.
-                continue
-            func["priority"] = "low"
-            func["priority_reason"] = "reachability:not_called"
-            marked += 1
+            elif verdict in ("framework_callable", "registered_via_call"):
+                # Affirmative reachability evidence (framework dispatch /
+                # function-as-argument registration) — annotate, never demote,
+                # in both modes. (reachable / called / uncertain: leave as-is.)
+                func["priority_reason"] = f"reachability:{verdict}"
 
     if marked:
         logger.info(

--- a/core/orchestration/tests/test_reachability_enrichment.py
+++ b/core/orchestration/tests/test_reachability_enrichment.py
@@ -721,6 +721,38 @@ class TestModuleLoadAbortGate:
         assert "priority" not in func
         assert func.get("priority_reason") != "reachability:module_aborts"
 
+    def test_allow_unreachable_framework_handler_in_aborting_file_not_live(
+        self, tmp_path,
+    ):
+        # A framework handler defined BELOW a top-level abort: its @route
+        # decorator never runs (the file aborts on import), so it is NOT
+        # affirmatively framework-reachable. Under allow_unreachable it is not
+        # demoted AND not annotated framework_callable — the whole-file abort
+        # witness shadows the framework signal (the unified classifier checks
+        # module_aborts before framework). [pr11 behaviour refinement]
+        target = _project(tmp_path, {
+            "src/disabled.py": (
+                "raise ImportError('disabled')\n"
+                "@app.route('/y')\n"
+                "def handler(q):\n"
+                "    cursor.execute(q)\n"
+            ),
+        })
+        checklist = _checklist({
+            "src/disabled.py": [{
+                "name": "handler", "kind": "function",
+                "line_start": 3, "line_end": 4,
+            }],
+        })
+        mark_unreachable_low_priority(
+            checklist, target, allow_unreachable=True,
+        )
+        func = checklist["files"][0]["items"][0]
+        assert func.get("priority") != "low"          # isolation: not demoted
+        assert func.get("priority_reason") != (        # but NOT called live
+            "reachability:framework_callable"
+        )
+
     def test_clean_file_not_module_demoted(self, tmp_path):
         # No abort → S4 gate dormant; normal NOT_CALLED logic only.
         target = _project(tmp_path, {

--- a/packages/exploitability_validation/reachability.py
+++ b/packages/exploitability_validation/reachability.py
@@ -60,39 +60,21 @@ def _blocker_for(
     appended to the attack path. module_aborts / build_excluded fetch the
     file's witness summary for the specific reason (e.g. ``raise ImportError``
     / ``//go:build ignore``)."""
+    from core.inventory.reach_witness import VERDICTS, blocker_for
     fq = f"`{module}.{func_name}`"
-    if verdict == "module_aborts":
+    # Some blockers embed the file-witness summary (e.g. `raise ImportError` /
+    # `//go:build ignore`); fetch it per the verdict's declared detail source.
+    spec = VERDICTS.get(verdict)
+    detail = ""
+    if spec is not None and spec.blocker_detail == "module_aborts":
         from core.inventory.reachability import module_aborts_on_load
-        rec = module_aborts_on_load(inventory, rel_path) or {}
-        return (
-            f"reachability:module_aborts — entry function {fq} is in a file "
-            f"whose top-level execution aborts on load ({rec.get('summary')}) "
-            f"before the function binds"
-        )
-    if verdict == "lexical_dead":
-        return (
-            f"reachability:lexical_dead — entry function {fq} is defined "
-            f"inside an always-false guard (if False / #[cfg(any())]) and "
-            f"never binds"
-        )
-    if verdict == "build_excluded":
+        detail = (module_aborts_on_load(inventory, rel_path) or {}).get(
+            "summary") or ""
+    elif spec is not None and spec.blocker_detail == "build_excluded":
         from core.inventory.reachability import build_excluded
-        rec = build_excluded(inventory, rel_path) or {}
-        return (
-            f"reachability:build_excluded — entry function {fq} is in a file "
-            f"excluded from the build ({rec.get('summary')}) and is never "
-            f"compiled"
-        )
-    if verdict == "no_path_from_entry":
-        return (
-            f"reachability:no_path_from_entry — entry function {fq} has "
-            f"callers, but none reachable from any entry point "
-            f"(orphaned dead-island)"
-        )
-    return (
-        f"reachability:not_called — entry function {fq} is not called from "
-        f"any non-test project source"
-    )
+        detail = (build_excluded(inventory, rel_path) or {}).get(
+            "summary") or ""
+    return blocker_for(verdict, fq, detail) or ""
 
 
 def demote_unreachable_paths(

--- a/packages/llm_analysis/prompts/analysis.py
+++ b/packages/llm_analysis/prompts/analysis.py
@@ -179,43 +179,18 @@ def _format_reachability_block(metadata: Dict[str, Any]) -> str:
 
     priority = metadata.get("priority")
     priority_reason = metadata.get("priority_reason") or ""
-    if priority_reason == "reachability:module_aborts":
-        # S4: whole-file module-load abort. Distinct verdict from
-        # NOT_CALLED — the function's def never executes, so there's
-        # no framework-dispatch escape hatch and in-file callers are
-        # equally dead. The system prompt explains how to treat it.
-        lines.append(
-            "Verdict: MODULE_ABORTS_ON_LOAD — file aborts at load "
-            "before this function binds; never importable/callable"
-        )
-    elif priority_reason == "reachability:lexical_dead":
-        # S3: function defined inside an always-false guard
-        # (if False: / if (false) / #[cfg(any())]). Body never
-        # runs / compiles, so the function never binds — trumps
-        # in-scope call edges. System prompt explains treatment.
-        lines.append(
-            "Verdict: LEXICAL_DEAD — defined inside an always-false "
-            "guard (if False / #[cfg(any())]); never binds"
-        )
-    elif priority_reason == "reachability:build_excluded":
-        # Whole-file build exclusion (e.g. Go //go:build ignore): the file
-        # is never compiled, so nothing in it is reachable. Heuristic
-        # (config-dependent — a forced build could include it), so it's a
-        # surface signal, not a hard verdict; the system prompt explains it.
-        lines.append(
-            "Verdict: BUILD_EXCLUDED — file is excluded from the build "
-            "(e.g. //go:build ignore); never compiled in this configuration"
-        )
-    elif priority_reason == "reachability:no_path_from_entry":
-        # U7: transitive entry-reachability. The function may have an
-        # in-project caller, but no path from any entry point (main /
-        # framework dispatch / exported-public symbol) reaches it — the
-        # whole calling chain is an orphaned dead-island. System prompt
-        # explains how to treat it.
-        lines.append(
-            "Verdict: NO_PATH_FROM_ENTRY — has callers, but none reachable "
-            "from any entry point (orphaned dead-island)"
-        )
+    # Reachability verdict line. The structural dead verdicts (module_aborts /
+    # lexical_dead / build_excluded / no_path_from_entry) render a canonical
+    # "Verdict: …" line from the witness table — single source of truth, so a
+    # new dead witness surfaces here automatically. not_called falls to the
+    # low-priority catch-all; framework / registration render an affirmative
+    # "REACHABLE via …" line (annotated without demotion).
+    from core.inventory.reach_witness import prompt_verdict_for
+    verdict = (priority_reason.split("reachability:", 1)[1]
+               if priority_reason.startswith("reachability:") else "")
+    pv = prompt_verdict_for(verdict)
+    if pv:
+        lines.append(pv)
     elif priority == "low":
         lines.append(
             f"Verdict: NOT_CALLED ({priority_reason or 'no callers in project'})"
@@ -224,12 +199,6 @@ def _format_reachability_block(metadata: Dict[str, Any]) -> str:
         "reachability:framework_callable",
         "reachability:registered_via_call",
     ):
-        # The reachability enricher annotates these reasons WITHOUT
-        # demoting priority — the function is reachable via runtime
-        # dispatch the static graph doesn't see. Surfacing the
-        # mechanism lets the LLM trust the reachability picture
-        # instead of seeing "no static callers" and inferring dead
-        # code.
         mechanism = (
             "framework decorator dispatch"
             if priority_reason == "reachability:framework_callable"


### PR DESCRIPTION
  Make the reachability substrate table-driven so adding a witness or a language is a single declarative entry instead of edits scattered across the classifier, the witness map, and three consumers. Three focused, independent (file-disjoint) refactors:

  1. Unify the /agentic prepass on classify_reachability — removes the last duplicated precedence chain; all three consumers (CodeQL prefilter, /validate demoter, /agentic prepass) now share one entry-aware classifier.
  2. Witness registry — VERDICTS (one VerdictSpec per verdict) + PRECEDENCE (ordered stage pipeline). _VERDICT_MAP, STRUCTURALLY_SUPPRESSIBLE_KINDS, demoter blockers, and prompt verdict lines all derive from the table.
  3. Language profiles — ReachabilityProfile/PROFILES drive the entry model; _CLOSEABLE_ENTRY_LANGS and _item_is_entry derive from it.

  Net: adding a witness = one VERDICTS entry + one PRECEDENCE stage + a detector; adding a language = one PROFILES entry. Sets up the per-language dead-code coverage work to land as small, measured additions.

  Behaviour-preserving, proven by old-vs-new differentials (byte-identical): classify over a real multi-language dead-code corpus + synthetic framework/registration/precedence fixtures, _item_is_entry over the full language × visibility matrix, and every demoter-blocker / prompt-verdict string. One deliberate, disclosed, test-pinned refinement (pr11). FN-safety re-verified end-to-end: only the sound witnesses  (module_aborts / lexical_dead) remain hard-suppressible — zero heuristic leakage through the may_suppress chokepoint.