### PR TITLE
ci(tests): migrate codeql/llm_analysis/fuzzing/orchestration to _tier.yml

### DIFF
--- a/.github/workflows/_tier.yml
+++ b/.github/workflows/_tier.yml
@@ -39,6 +39,11 @@ on:
         required: false
         type: string
         default: "3.12"
+      timeout_minutes:
+        description: Per-job timeout in minutes. Heavier tiers (codeql, llm_analysis) override the 20 default.
+        required: false
+        type: number
+        default: 20
       use_container:
         description: true → run in the prebuilt image; false → venv on the runner.
         required: true
@@ -53,7 +58,7 @@ jobs:
   image:
     if: ${{ inputs.use_container }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     container:
       image: ghcr.io/${{ github.repository_owner }}/raptor-ci-deps:main
       credentials:
@@ -79,7 +84,7 @@ jobs:
   runner:
     if: ${{ !inputs.use_container }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -557,27 +557,15 @@ jobs:
       needs.pre_check.outputs.should_skip != 'true' &&
       (needs.changes.outputs.force_full == 'true' ||
        needs.changes.outputs.codeql == 'true')
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
     permissions:
       contents: read
-      packages: read              # pull the private GHCR deps image
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/raptor-ci-deps:main
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
-        with:
-          persist-credentials: false
-      - name: Reconcile deps
-        # No-op unless this PR changed requirements*.txt before the
-        # image rebuilt on main; then installs only the delta.
-        run: pip install --no-cache-dir -r requirements-dev.txt
-      - name: Run codeql tests
-        run: python -m pytest packages/codeql/tests -n auto
+      packages: read              # pull the private GHCR deps image (image path)
+    uses: ./.github/workflows/_tier.yml
+    with:
+      tier: codeql
+      test_path: packages/codeql/tests
+      timeout_minutes: 25
+      use_container: ${{ needs.pre_check.outputs.pkg_access == 'true' }}
 
   python-unit-tests-llm-analysis:
     needs: [pre_check, changes]
@@ -585,27 +573,15 @@ jobs:
       needs.pre_check.outputs.should_skip != 'true' &&
       (needs.changes.outputs.force_full == 'true' ||
        needs.changes.outputs.llm_analysis == 'true')
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
     permissions:
       contents: read
-      packages: read              # pull the private GHCR deps image
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/raptor-ci-deps:main
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
-        with:
-          persist-credentials: false
-      - name: Reconcile deps
-        # No-op unless this PR changed requirements*.txt before the
-        # image rebuilt on main; then installs only the delta.
-        run: pip install --no-cache-dir -r requirements-dev.txt
-      - name: Run llm_analysis tests
-        run: python -m pytest packages/llm_analysis/tests -n auto
+      packages: read              # pull the private GHCR deps image (image path)
+    uses: ./.github/workflows/_tier.yml
+    with:
+      tier: llm_analysis
+      test_path: packages/llm_analysis/tests
+      timeout_minutes: 25
+      use_container: ${{ needs.pre_check.outputs.pkg_access == 'true' }}
 
   python-unit-tests-cve-diff:
     needs: [pre_check, changes, deps]
@@ -643,27 +619,14 @@ jobs:
       needs.pre_check.outputs.should_skip != 'true' &&
       (needs.changes.outputs.force_full == 'true' ||
        needs.changes.outputs.fuzzing == 'true')
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
     permissions:
       contents: read
-      packages: read              # pull the private GHCR deps image
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/raptor-ci-deps:main
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
-        with:
-          persist-credentials: false
-      - name: Reconcile deps
-        # No-op unless this PR changed requirements*.txt before the
-        # image rebuilt on main; then installs only the delta.
-        run: pip install --no-cache-dir -r requirements-dev.txt
-      - name: Run fuzzing tests
-        run: python -m pytest packages/fuzzing/tests -n auto
+      packages: read              # pull the private GHCR deps image (image path)
+    uses: ./.github/workflows/_tier.yml
+    with:
+      tier: fuzzing
+      test_path: packages/fuzzing/tests
+      use_container: ${{ needs.pre_check.outputs.pkg_access == 'true' }}
 
   # CANARY for the prebuilt-image migration (phase 2 of the fan-out
   # fix). sage is the proving ground: zero subprocess usage in
@@ -700,27 +663,14 @@ jobs:
       needs.pre_check.outputs.should_skip != 'true' &&
       (needs.changes.outputs.force_full == 'true' ||
        needs.changes.outputs.orchestration == 'true')
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
     permissions:
       contents: read
-      packages: read              # pull the private GHCR deps image
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/raptor-ci-deps:main
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # was v6
-        with:
-          persist-credentials: false
-      - name: Reconcile deps
-        # No-op unless this PR changed requirements*.txt before the
-        # image rebuilt on main; then installs only the delta.
-        run: pip install --no-cache-dir -r requirements-dev.txt
-      - name: Run orchestration tests
-        run: python -m pytest core/orchestration/tests -n auto
+      packages: read              # pull the private GHCR deps image (image path)
+    uses: ./.github/workflows/_tier.yml
+    with:
+      tier: orchestration
+      test_path: core/orchestration/tests
+      use_container: ${{ needs.pre_check.outputs.pkg_access == 'true' }}
 
   # Single aggregate gate over the whole suite. `needs:` every job and
   # `if: always()` so it still runs when an upstream tier is path-filtered


### PR DESCRIPTION
Phase 2 of the reusable-workflow migration (sage was the canary, #654). Convert the four remaining inline container tiers to _tier.yml callers so they gain the fork-PR runner fallback — the prerequisite for making the ghcr.io/<owner>/raptor-ci-deps image private without breaking fork CI.

Add a timeout_minutes input to _tier.yml (default 20) and pass 25 for codeql and llm_analysis to preserve their existing per-job timeouts; the others keep the 20 default. No other behavior change: each caller keeps its path-filter if:, packages:read grant, and test path.