### PR TITLE
Implement trust-corpus pipeline with CVE-fix synthesis and reporting

### DIFF
--- a/core/dataflow/barrier_synth.py
+++ b/core/dataflow/barrier_synth.py
@@ -195,6 +195,78 @@ def run_synthesis_loop(
 
 
 # ---------------------------------------------------------------------------
+# Corpus-level aggregate — run synthesis over many FPs, report suppression rate
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CorpusSynthItem:
+    """One flagged FP to synthesize a barrier for, with its before/after DBs."""
+
+    proposal: BarrierProposal
+    after_db: Path
+    before_db: Path
+
+
+@dataclass(frozen=True)
+class CorpusSynthReport:
+    total: int
+    sound: int          # sound barrier synthesized (FP suppressed, TP preserved)
+    not_sound: int      # compiled but failed the soundness check (no suppress / killed TP)
+    no_barrier: int     # no compilable barrier after retries
+    per_finding: tuple  # ((finding_id, status), ...); status in sound/not_sound/no_barrier
+
+    @property
+    def suppression_rate(self) -> Optional[float]:
+        """Fraction of FPs for which a sound barrier was synthesized — the
+        headline scale metric ("how much addressable FP can we suppress")."""
+        return None if self.total == 0 else self.sound / self.total
+
+
+def synthesize_over_corpus(
+    items,
+    *,
+    proposer: BarrierProposer,
+    work_dir: Path,
+    search_path: Optional[str] = None,
+    codeql_bin: str = DEFAULT_CODEQL_BIN,
+    runner: Optional[RunnerFn] = None,
+    max_attempts: int = 1,
+) -> CorpusSynthReport:
+    """Run the synthesis loop over a corpus of flagged FPs and aggregate."""
+    sound = not_sound = no_barrier = 0
+    per: list = []
+    for item in items:
+        res = run_synthesis_loop(
+            item.proposal, item.after_db, item.before_db,
+            proposer=proposer, work_dir=work_dir / item.proposal.finding_id,
+            search_path=search_path, codeql_bin=codeql_bin, runner=runner,
+            max_attempts=max_attempts,
+        )
+        if res is None:
+            status, no_barrier = "no_barrier", no_barrier + 1
+        elif res.is_sound:
+            status, sound = "sound", sound + 1
+        else:
+            status, not_sound = "not_sound", not_sound + 1
+        per.append((item.proposal.finding_id, status))
+    return CorpusSynthReport(
+        total=len(per), sound=sound, not_sound=not_sound,
+        no_barrier=no_barrier, per_finding=tuple(per),
+    )
+
+
+def render_corpus_report(r: CorpusSynthReport) -> str:
+    rate = "n/a" if r.suppression_rate is None else f"{r.suppression_rate * 100:.0f}%"
+    return (
+        f"Trust barrier synthesis over {r.total} FP(s)\n"
+        f"  sound barrier:   {r.sound}  ({rate} of FPs suppressed, zero TP loss)\n"
+        f"  not sound:       {r.not_sound}  (compiled but failed the soundness check)\n"
+        f"  no barrier:      {r.no_barrier}  (no compilable barrier after retries)"
+    )
+
+
+# ---------------------------------------------------------------------------
 # LLM proposer — the production "propose" step
 # ---------------------------------------------------------------------------
 

--- a/core/dataflow/barrier_synth.py
+++ b/core/dataflow/barrier_synth.py
@@ -21,12 +21,19 @@ unit-testable with stubs (no LLM, no CodeQL).
 
 from __future__ import annotations
 
+import argparse
 import json
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional
 
-from core.dataflow.codeql_augmented_run import DEFAULT_CODEQL_BIN, RunnerFn, analyze
+from core.dataflow.codeql_augmented_run import (
+    DEFAULT_CODEQL_BIN,
+    CodeQLRunError,
+    RunnerFn,
+    analyze,
+)
 
 # sink-class -> (customizations module, module name exposing Source/Sink/Sanitizer)
 _CUSTOMIZATIONS = {
@@ -46,9 +53,13 @@ class BarrierProposal:
     source_context: str      # the function/path source the LLM reasons over
 
 
-# proposer(proposal) -> a CodeQL guardChecks predicate named ``proposedGuard``:
-#   predicate proposedGuard(DataFlow::GuardNode g, ControlFlowNode node, boolean branch) { ... }
-BarrierProposer = Callable[[BarrierProposal], str]
+# proposer(proposal, prior_error) -> a CodeQL guardChecks predicate named
+# ``proposedGuard``: predicate proposedGuard(DataFlow::GuardNode g,
+# ControlFlowNode node, boolean branch) { ... }
+# ``prior_error`` is None on the first attempt; on a retry it carries the
+# compile/validation error from the previous attempt so the proposer (LLM)
+# can correct it.
+BarrierProposer = Callable[[BarrierProposal, Optional[str]], str]
 
 
 @dataclass(frozen=True)
@@ -152,15 +163,145 @@ def run_synthesis_loop(
     search_path: Optional[str] = None,
     codeql_bin: str = DEFAULT_CODEQL_BIN,
     runner: Optional[RunnerFn] = None,
-) -> SynthResult:
-    """Propose a barrier, assemble it, and let CodeQL adjudicate on both DBs."""
-    proposed = proposer(proposal)
-    query_ql = assemble_barrier_query(
-        proposed, sink_class=proposal.sink_class,
-        query_id=f"raptor/synth/{proposal.finding_id}",
+    max_attempts: int = 1,
+) -> Optional[SynthResult]:
+    """Propose a barrier, assemble it, and let CodeQL adjudicate on both DBs.
+
+    Retries up to ``max_attempts``: if assembly rejects the proposal or CodeQL
+    fails to compile/run the query, the error is fed back to the proposer for a
+    corrected attempt. Returns ``None`` if no attempt produced a runnable query
+    (the proposer never emitted compilable QL) — the LLM still can't suppress
+    anything it can't get past the compiler.
+    """
+    prior_error: Optional[str] = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            proposed = proposer(proposal, prior_error)
+            query_ql = assemble_barrier_query(
+                proposed, sink_class=proposal.sink_class,
+                query_id=f"raptor/synth/{proposal.finding_id}/{attempt}",
+            )
+            after_count = adjudicate(
+                query_ql, after_db, work_dir=work_dir / f"after-{attempt}",
+                search_path=search_path, codeql_bin=codeql_bin, runner=runner)
+            before_count = adjudicate(
+                query_ql, before_db, work_dir=work_dir / f"before-{attempt}",
+                search_path=search_path, codeql_bin=codeql_bin, runner=runner)
+        except (ValueError, CodeQLRunError) as exc:
+            prior_error = f"{type(exc).__name__}: {exc}"
+            continue
+        return SynthResult(query_ql=query_ql, after_count=after_count, before_count=before_count)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# LLM proposer — the production "propose" step
+# ---------------------------------------------------------------------------
+
+# complete(system_prompt, user_prompt) -> model reply text. Injectable so the
+# proposer is testable with a stub and the real LLM is wired lazily.
+Completer = Callable[[str, str], str]
+
+_SYSTEM_PROMPT = (
+    "You are a CodeQL expert. A taint-analysis finding has been flagged as a "
+    "false positive because a PROJECT-SPECIFIC validator/sanitizer on the path "
+    "neutralizes the attacker input — but the analyzer doesn't model it. Your "
+    "job: emit a CodeQL guard predicate that recognizes that validator so the "
+    "false positive is suppressed.\n\n"
+    "Output ONLY a CodeQL predicate, exactly this signature and name:\n"
+    "  predicate proposedGuard(DataFlow::GuardNode g, ControlFlowNode node, boolean branch)\n"
+    "Semantics: `g` is the guard (the validator call/comparison); `node` is the "
+    "cfg node of the value it checks; `branch` is the boolean value of `g` on "
+    "which `node` is safe. `python`, `DataFlow`, and the relevant security "
+    "customizations module are already imported. No prose, no markdown fences."
+)
+
+
+def _build_prompt(proposal: BarrierProposal, prior_error: Optional[str]) -> str:
+    parts = [
+        f"sink class: {proposal.sink_class}",
+        f"flagged sink: {proposal.sink_snippet}",
+        "source (the function/path the finding flows through):",
+        proposal.source_context,
+        "",
+        "Emit the `proposedGuard` predicate recognizing the validator on this path.",
+    ]
+    if prior_error:
+        parts += [
+            "",
+            "Your PREVIOUS attempt failed — fix it. Error:",
+            prior_error,
+        ]
+    return "\n".join(parts)
+
+
+def _extract_ql(reply: str) -> str:
+    """Pull the QL predicate out of a model reply, tolerating markdown fences."""
+    text = (reply or "").strip()
+    if "```" in text:
+        # take the first fenced block's body
+        block = text.split("```", 2)[1]
+        if "\n" in block:  # drop an optional language tag on the fence line
+            block = block.split("\n", 1)[1]
+        text = block.strip()
+    return text
+
+
+def make_llm_proposer(complete: Completer) -> BarrierProposer:
+    """Build a proposer backed by an LLM ``complete`` callable."""
+    def propose(proposal: BarrierProposal, prior_error: Optional[str]) -> str:
+        return _extract_ql(complete(_SYSTEM_PROMPT, _build_prompt(proposal, prior_error)))
+    return propose
+
+
+def default_completer() -> Completer:
+    """Wire a Completer onto the real LLM client (imported lazily so tests and
+    the harness don't need the client unless a live run is requested)."""
+    from core.llm.client import LLMClient
+
+    client = LLMClient()
+
+    def _complete(system_prompt: str, user_prompt: str) -> str:
+        resp = client.generate(user_prompt, system_prompt=system_prompt)
+        text = getattr(resp, "content", None)
+        return text if text is not None else str(resp)
+
+    return _complete
+
+
+def main(argv: Optional[list] = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("before_db", type=Path, help="CodeQL DB of the pre-fix (vulnerable) source")
+    p.add_argument("after_db", type=Path, help="CodeQL DB of the post-fix (sanitized) source")
+    p.add_argument("--sink-class", required=True, choices=sorted(_CUSTOMIZATIONS))
+    p.add_argument("--finding-id", required=True)
+    p.add_argument("--sink", required=True, help="flagged sink snippet/description")
+    p.add_argument("--source-file", type=Path, required=True,
+                   help="source the LLM reasons over (the function/path)")
+    p.add_argument("--search-path", help="codeql query-pack search path (--additional-packs)")
+    p.add_argument("--max-attempts", type=int, default=3)
+    p.add_argument("--work-dir", type=Path, default=Path("/tmp/trust-synth-work"))
+    args = p.parse_args(argv)
+
+    proposal = BarrierProposal(
+        sink_class=args.sink_class, finding_id=args.finding_id,
+        sink_snippet=args.sink, source_context=args.source_file.read_text(encoding="utf-8"),
     )
-    after_count = adjudicate(query_ql, after_db, work_dir=work_dir / "after",
-                             search_path=search_path, codeql_bin=codeql_bin, runner=runner)
-    before_count = adjudicate(query_ql, before_db, work_dir=work_dir / "before",
-                              search_path=search_path, codeql_bin=codeql_bin, runner=runner)
-    return SynthResult(query_ql=query_ql, after_count=after_count, before_count=before_count)
+    res = run_synthesis_loop(
+        proposal, args.after_db, args.before_db,
+        proposer=make_llm_proposer(default_completer()),
+        work_dir=args.work_dir, search_path=args.search_path,
+        max_attempts=args.max_attempts,
+    )
+    if res is None:
+        print(f"{args.finding_id}: no compilable barrier after {args.max_attempts} attempts",
+              file=sys.stderr)
+        return 1
+    print(f"{args.finding_id}: sound={res.is_sound} "
+          f"(after={res.after_count}, before={res.before_count})", file=sys.stderr)
+    print(res.query_ql)
+    return 0 if res.is_sound else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/dataflow/barrier_synth.py
+++ b/core/dataflow/barrier_synth.py
@@ -1,0 +1,166 @@
+"""Sound-tier barrier synthesis: LLM proposes an isBarrier, CodeQL adjudicates.
+
+The loop (see ``~/design/trust-witness.md`` §9 — the validated mechanism):
+
+  1. A ``proposer`` (the LLM) is handed a flagged FP + its source context and
+     returns a CodeQL ``guardChecks`` predicate recognizing the project
+     sanitizer.
+  2. We assemble that predicate into a CWE-class taint query (reusing the stock
+     source/sink + the proposed barrier).
+  3. CodeQL ADJUDICATES: the query is compiled + run. A valid barrier SUPPRESSES
+     the FP on the post-fix DB; the pre-fix DB still flags the real TP.
+
+Soundness rests on the split: the LLM only PROPOSES (heuristic); CodeQL
+compiles + runs the predicate (mechanical). A malformed predicate fails to
+compile; an over-broad one is caught by the corpus check (it would suppress a
+TP). The LLM is never on the suppress path — it can't silently create an FN.
+
+The ``proposer`` and the CodeQL ``runner`` are both injectable, so the loop is
+unit-testable with stubs (no LLM, no CodeQL).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+from core.dataflow.codeql_augmented_run import DEFAULT_CODEQL_BIN, RunnerFn, analyze
+
+# sink-class -> (customizations module, module name exposing Source/Sink/Sanitizer)
+_CUSTOMIZATIONS = {
+    "cmdi": ("semmle.python.security.dataflow.CommandInjectionCustomizations", "CommandInjection"),
+    "sqli": ("semmle.python.security.dataflow.SqlInjectionCustomizations", "SqlInjection"),
+    "pathtrav": ("semmle.python.security.dataflow.PathInjectionCustomizations", "PathInjection"),
+}
+
+
+@dataclass(frozen=True)
+class BarrierProposal:
+    """Context handed to the proposer for one flagged FP."""
+
+    sink_class: str          # "cmdi" | "sqli" | "pathtrav"
+    finding_id: str
+    sink_snippet: str
+    source_context: str      # the function/path source the LLM reasons over
+
+
+# proposer(proposal) -> a CodeQL guardChecks predicate named ``proposedGuard``:
+#   predicate proposedGuard(DataFlow::GuardNode g, ControlFlowNode node, boolean branch) { ... }
+BarrierProposer = Callable[[BarrierProposal], str]
+
+
+@dataclass(frozen=True)
+class SynthResult:
+    query_ql: str
+    after_count: int     # findings on the post-fix DB with the barrier (want 0)
+    before_count: int    # findings on the pre-fix DB with the barrier (want >=1)
+
+    @property
+    def suppressed_fp(self) -> bool:
+        return self.after_count == 0
+
+    @property
+    def preserved_tp(self) -> bool:
+        return self.before_count >= 1
+
+    @property
+    def is_sound(self) -> bool:
+        """The proposed barrier suppressed the FP AND kept the TP."""
+        return self.suppressed_fp and self.preserved_tp
+
+
+def assemble_barrier_query(proposed_guard: str, *, sink_class: str, query_id: str) -> str:
+    """Wrap a proposed ``proposedGuard`` predicate into a runnable CWE-class
+    taint query (the validated §9 template)."""
+    if sink_class not in _CUSTOMIZATIONS:
+        raise ValueError(f"unknown sink_class {sink_class!r}; "
+                         f"known: {sorted(_CUSTOMIZATIONS)}")
+    if "proposedGuard" not in proposed_guard:
+        raise ValueError("proposer must define a `proposedGuard` predicate")
+    module_import, module_name = _CUSTOMIZATIONS[sink_class]
+    return f"""/**
+ * @name Synthesized barrier ({sink_class})
+ * @kind problem
+ * @problem.severity error
+ * @id {query_id}
+ */
+import python
+import semmle.python.dataflow.new.DataFlow
+import semmle.python.dataflow.new.TaintTracking
+import {module_import}
+
+{proposed_guard.strip()}
+
+module Cfg implements DataFlow::ConfigSig {{
+  predicate isSource(DataFlow::Node n) {{ n instanceof {module_name}::Source }}
+  predicate isSink(DataFlow::Node n) {{ n instanceof {module_name}::Sink }}
+  predicate isBarrier(DataFlow::Node n) {{
+    n instanceof {module_name}::Sanitizer or
+    n = DataFlow::BarrierGuard<proposedGuard/3>::getABarrierNode()
+  }}
+}}
+
+module Flow = TaintTracking::Global<Cfg>;
+
+from DataFlow::Node source, DataFlow::Node sink
+where Flow::flow(source, sink)
+select sink, "synthesized-barrier {sink_class}"
+"""
+
+
+def _count_sarif_results(sarif_path: Path) -> int:
+    data = json.loads(Path(sarif_path).read_text())
+    return sum(len(r.get("results", [])) for r in data.get("runs", []))
+
+
+def adjudicate(
+    query_ql: str,
+    db_path: Path,
+    *,
+    work_dir: Path,
+    search_path: Optional[str] = None,
+    codeql_bin: str = DEFAULT_CODEQL_BIN,
+    runner: Optional[RunnerFn] = None,
+) -> int:
+    """Compile + run ``query_ql`` against ``db_path`` via CodeQL; return the
+    finding count. Writes the query + a minimal qlpack into ``work_dir``."""
+    pack = work_dir
+    pack.mkdir(parents=True, exist_ok=True)
+    (pack / "qlpack.yml").write_text(
+        'name: raptor/barrier-synth\nversion: 0.0.1\n'
+        'dependencies:\n  codeql/python-all: "*"\n'
+    )
+    ql = pack / "SynthBarrier.ql"
+    ql.write_text(query_ql)
+    extra = ["--additional-packs", search_path] if search_path else []
+    result = analyze(
+        db_path, [str(ql)], pack / "out.sarif",
+        codeql_bin=codeql_bin, runner=runner, extra_args=extra,
+    )
+    return _count_sarif_results(Path(result.sarif_path))
+
+
+def run_synthesis_loop(
+    proposal: BarrierProposal,
+    after_db: Path,
+    before_db: Path,
+    *,
+    proposer: BarrierProposer,
+    work_dir: Path,
+    search_path: Optional[str] = None,
+    codeql_bin: str = DEFAULT_CODEQL_BIN,
+    runner: Optional[RunnerFn] = None,
+) -> SynthResult:
+    """Propose a barrier, assemble it, and let CodeQL adjudicate on both DBs."""
+    proposed = proposer(proposal)
+    query_ql = assemble_barrier_query(
+        proposed, sink_class=proposal.sink_class,
+        query_id=f"raptor/synth/{proposal.finding_id}",
+    )
+    after_count = adjudicate(query_ql, after_db, work_dir=work_dir / "after",
+                             search_path=search_path, codeql_bin=codeql_bin, runner=runner)
+    before_count = adjudicate(query_ql, before_db, work_dir=work_dir / "before",
+                              search_path=search_path, codeql_bin=codeql_bin, runner=runner)
+    return SynthResult(query_ql=query_ql, after_count=after_count, before_count=before_count)

--- a/core/dataflow/cvefix_corpus_generator.py
+++ b/core/dataflow/cvefix_corpus_generator.py
@@ -1,0 +1,166 @@
+"""Generate trust-corpus entries from a CVE fix-commit pair.
+
+Sibling of :mod:`core.dataflow.owasp_corpus_generator`, but the ground
+truth comes from the *fix commit* rather than a benchmark's
+``expectedresults`` CSV. The labeling insight (see
+``~/design/trust-witness.md``):
+
+    Run the producer (CodeQL) on the pre-fix and post-fix source of a
+    real injection CVE.
+
+      * A finding on the **pre-fix** code is the real vulnerability →
+        ``true_positive`` (the CVE).
+      * A finding the producer **still emits on the post-fix** code is a
+        ``false_positive``: the fix added a sanitizer the producer does
+        not model. ``fp_category = missing_sanitizer_model``. This is the
+        exact shape the trust sound-tier must learn to suppress.
+      * Findings that *disappear* after the fix (producer recognised the
+        sanitizer) are uninteresting — no FP to fix — and are not emitted.
+
+This module is producer-agnostic about parsing: it consumes already-parsed
+SARIF dicts (the caller runs ``codeql_augmented_run`` / ``finding_diff``)
+and uses :func:`core.dataflow.adapters.codeql.from_sarif_result` to build
+:class:`Finding` objects. It does NOT run CodeQL itself.
+
+**These are CANDIDATE labels, not ground truth.** "Post-fix still-flagged →
+FP" assumes the fix *fully* neutralised the path. Incomplete fixes are common:
+CodeQL may still flag post-fix code because the path is *genuinely still
+vulnerable* (partial fix, or a different path fixed) — a real TP mislabeled FP.
+So generator output MUST be hand-verified before it gates anything (the design's
+"re-label our filtered subset" step). Treating raw output as a soundness corpus
+would corrupt the FN-gate it exists to protect.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, FrozenSet, Iterable, Iterator, List, Mapping, Optional, Tuple
+
+from core.dataflow.adapters.codeql import from_sarif_result
+from core.dataflow.finding import Finding
+from core.dataflow.label import (
+    FP_MISSING_SANITIZER_MODEL,
+    VERDICT_FALSE_POSITIVE,
+    VERDICT_TRUE_POSITIVE,
+    GroundTruth,
+)
+# Reuse the corpus writer verbatim — same on-disk shape as every other corpus.
+from core.dataflow.owasp_corpus_generator import write_corpus  # noqa: F401 (re-exported)
+
+_DEFAULT_LABELER = "trust-corpus-cvefix"
+
+logger = logging.getLogger(__name__)
+
+
+def _slug(s: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", s).strip("-")
+
+
+def _iter_results(sarif: Mapping[str, Any]) -> Iterator[Mapping[str, Any]]:
+    for run in sarif.get("runs", []) or []:
+        for result in run.get("results", []) or []:
+            yield result
+
+
+def _path_touches(f: Finding, files: FrozenSet[str]) -> bool:
+    """True if any step on the finding's path lives in a fix-changed file."""
+    steps = [f.source, *f.intermediate_steps, f.sink]
+    return any(s.file_path in files for s in steps)
+
+
+def _findings_from_sarif(
+    sarif: Mapping[str, Any],
+    *,
+    id_prefix: str,
+    touched: Optional[FrozenSet[str]] = None,
+) -> List[Finding]:
+    out: List[Finding] = []
+    for idx, result in enumerate(_iter_results(sarif)):
+        fid = f"{id_prefix}__{idx:03d}"
+        try:
+            f = from_sarif_result(result, finding_id=fid)
+        except ValueError as exc:
+            # One malformed SARIF entry must not kill a batch over a real
+            # dataset of thousands of findings — skip + record.
+            logger.warning("skipping malformed SARIF result %s: %s", fid, exc)
+            continue
+        if f is None:  # not a dataflow-path result
+            continue
+        # Localize to the fix: only findings whose path touches a changed
+        # file are attributable to THIS CVE. Without this filter, unrelated
+        # findings get mislabeled (a real vuln tagged FP, or an unrelated FP
+        # tagged TP) — corrupting the FN-gate the corpus protects.
+        if touched is not None and not _path_touches(f, touched):
+            continue
+        out.append(f)
+    return out
+
+
+def generate_from_sarif(
+    before_sarif: Mapping[str, Any],
+    after_sarif: Mapping[str, Any],
+    *,
+    cve_id: str,
+    cwe: str,
+    labeled_at: str,
+    labeler: str = _DEFAULT_LABELER,
+    fix_touched_files: Optional[Iterable[str]] = None,
+) -> List[Tuple[Finding, GroundTruth]]:
+    """Build (Finding, GroundTruth) pairs from one CVE fix-commit pair.
+
+    ``before_sarif`` / ``after_sarif`` are parsed CodeQL SARIF dicts from
+    running the same queries on the pre- and post-fix source.
+
+    ``fix_touched_files`` is the set of source files the fix commit changed.
+    **Strongly recommended for real data:** without it, every emitted finding
+    is labeled by position (post → FP, pre → TP), which mislabels findings on
+    paths unrelated to the CVE. With it, only findings whose path touches a
+    changed file are emitted — the ones actually attributable to this CVE.
+    Omitting it is appropriate only for single-finding / synthetic inputs.
+    """
+    cve = _slug(cve_id)
+    touched: Optional[FrozenSet[str]] = (
+        frozenset(fix_touched_files) if fix_touched_files is not None else None
+    )
+    if touched is None:
+        logger.warning(
+            "generate_from_sarif(%s): no fix_touched_files — labels are "
+            "position-only and may mislabel CVE-unrelated findings.", cve_id,
+        )
+    pairs: List[Tuple[Finding, GroundTruth]] = []
+
+    # Post-fix findings the producer still emits = FP candidates (the
+    # added sanitizer isn't modelled). This is the trust sound-tier target.
+    for f in _findings_from_sarif(after_sarif, id_prefix=f"{cve}__post", touched=touched):
+        pairs.append((
+            f,
+            GroundTruth(
+                finding_id=f.finding_id,
+                verdict=VERDICT_FALSE_POSITIVE,
+                fp_category=FP_MISSING_SANITIZER_MODEL,
+                rationale=(
+                    f"{cve_id} ({cwe}): producer still flags the post-fix path; "
+                    f"the fix added a sanitizer the producer does not model "
+                    f"(missing_sanitizer_model). Trust sound-tier should suppress."
+                ),
+                labeler=labeler,
+                labeled_at=labeled_at,
+            ),
+        ))
+
+    # Pre-fix findings = the real vulnerability = true positives (FN-gate:
+    # a sound trust witness must NEVER suppress these).
+    for f in _findings_from_sarif(before_sarif, id_prefix=f"{cve}__pre", touched=touched):
+        pairs.append((
+            f,
+            GroundTruth(
+                finding_id=f.finding_id,
+                verdict=VERDICT_TRUE_POSITIVE,
+                rationale=f"{cve_id} ({cwe}): pre-fix vulnerable path (the CVE).",
+                labeler=labeler,
+                labeled_at=labeled_at,
+            ),
+        ))
+
+    return pairs

--- a/core/dataflow/cvefix_pipeline.py
+++ b/core/dataflow/cvefix_pipeline.py
@@ -1,0 +1,70 @@
+"""Orchestrate: run CodeQL on a CVE fix pair → labeled trust-corpus entries.
+
+Wires the shipped CodeQL runner (:mod:`core.dataflow.codeql_augmented_run`)
+to the generator (:mod:`core.dataflow.cvefix_corpus_generator`). Runs the
+*same* (stock) queries on the pre- and post-fix CodeQL databases — the
+diff in what's flagged is what the generator labels (post-fix-still-flagged
+→ FP candidate, pre-fix → TP). See ``~/design/trust-witness.md``.
+
+This is corpus *generation*, distinct from the sound-tier *measurement*
+(baseline vs custom-``.ql`` isBarrier on the same post-fix DB) which uses the
+same ``analyze`` entry point with a different query + an additional pack.
+
+The CodeQL ``runner`` is injectable (forwarded to ``analyze``), so the whole
+flow is unit-testable with a stub that returns canned SARIF — no CodeQL CLI,
+no database build, no dataset download.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+from core.dataflow.codeql_augmented_run import DEFAULT_CODEQL_BIN, RunnerFn, analyze
+from core.dataflow.cvefix_corpus_generator import generate_from_sarif, write_corpus
+from core.dataflow.finding import Finding
+from core.dataflow.label import GroundTruth
+
+
+def generate_corpus_for_pair(
+    before_db: Path,
+    after_db: Path,
+    queries: Sequence[str],
+    *,
+    cve_id: str,
+    cwe: str,
+    labeled_at: str,
+    out_dir: Path,
+    fix_touched_files: Optional[Iterable[str]] = None,
+    codeql_bin: str = DEFAULT_CODEQL_BIN,
+    runner: Optional[RunnerFn] = None,
+    write: bool = True,
+) -> List[Tuple[Finding, GroundTruth]]:
+    """Run ``queries`` on the pre- and post-fix CodeQL DBs and emit labeled
+    corpus entries for one CVE.
+
+    SARIF is written under ``out_dir/sarif/``; when ``write`` is True the
+    corpus pairs are also written under ``out_dir/corpus/`` via
+    :func:`write_corpus`. Returns the (Finding, GroundTruth) pairs.
+    """
+    sarif_dir = out_dir / "sarif"
+    a_before = analyze(
+        before_db, queries, sarif_dir / "before.sarif",
+        codeql_bin=codeql_bin, runner=runner,
+    )
+    a_after = analyze(
+        after_db, queries, sarif_dir / "after.sarif",
+        codeql_bin=codeql_bin, runner=runner,
+    )
+    before_sarif = json.loads(Path(a_before.sarif_path).read_text())
+    after_sarif = json.loads(Path(a_after.sarif_path).read_text())
+
+    pairs = generate_from_sarif(
+        before_sarif, after_sarif,
+        cve_id=cve_id, cwe=cwe, labeled_at=labeled_at,
+        fix_touched_files=fix_touched_files,
+    )
+    if write:
+        write_corpus(pairs, out_dir / "corpus")
+    return pairs

--- a/core/dataflow/cvefix_pipeline.py
+++ b/core/dataflow/cvefix_pipeline.py
@@ -17,7 +17,10 @@ no database build, no dataset download.
 
 from __future__ import annotations
 
+import argparse
+import datetime
 import json
+import sys
 from pathlib import Path
 from typing import Iterable, List, Optional, Sequence, Tuple
 
@@ -68,3 +71,35 @@ def generate_corpus_for_pair(
     if write:
         write_corpus(pairs, out_dir / "corpus")
     return pairs
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("before_db", type=Path, help="CodeQL DB of the pre-fix source")
+    p.add_argument("after_db", type=Path, help="CodeQL DB of the post-fix source")
+    p.add_argument("--query", action="append", dest="queries", required=True,
+                   metavar="SPEC", help="CodeQL query spec (repeatable)")
+    p.add_argument("--cve", required=True, help="CVE id, e.g. CVE-2021-1234")
+    p.add_argument("--cwe", required=True, help="CWE id, e.g. CWE-89")
+    p.add_argument("--out", type=Path, required=True, help="Output dir (sarif/ + corpus/)")
+    p.add_argument("--fix-touched-file", action="append", dest="fix_touched_files",
+                   metavar="PATH", help="A file the fix changed (repeatable). "
+                   "Strongly recommended — localizes labels to the CVE.")
+    p.add_argument("--labeled-at", default=datetime.date.today().isoformat(),
+                   help="ISO date for the labels (default: today)")
+    args = p.parse_args(argv)
+
+    pairs = generate_corpus_for_pair(
+        args.before_db, args.after_db, args.queries,
+        cve_id=args.cve, cwe=args.cwe, labeled_at=args.labeled_at,
+        out_dir=args.out, fix_touched_files=args.fix_touched_files,
+    )
+    fp = sum(1 for _, gt in pairs if gt.verdict == "false_positive")
+    tp = len(pairs) - fp
+    print(f"{args.cve}: {len(pairs)} corpus entries ({tp} TP / {fp} FP candidate) "
+          f"-> {args.out / 'corpus'}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/dataflow/scripts/trust-corpus
+++ b/core/dataflow/scripts/trust-corpus
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Generate trust-corpus entries from a CVE fix pair via CodeQL.
+
+Usage:
+  core/dataflow/scripts/trust-corpus <before_db> <after_db> \
+      --query <spec> --cve CVE-... --cwe CWE-... --out <dir> \
+      [--fix-touched-file <path> ...] [--labeled-at YYYY-MM-DD]
+
+Runs the given CodeQL queries on the pre- and post-fix databases and emits
+labeled corpus entries: a finding still flagged on the post-fix DB is a
+false-positive CANDIDATE (the fix added a sanitizer CodeQL doesn't model);
+pre-fix findings are true positives. See ~/design/trust-witness.md.
+
+Output is CANDIDATE labels — hand-verify before gating anything (an incomplete
+fix can leave a real TP mislabeled FP).
+
+Dev-tooling only — not invoked by the LLM-driven RAPTOR workflows.
+Co-located with ``core/dataflow/`` (the module it operates on) rather than
+``libexec/`` (which is reserved for framework-internal shims called by the
+launcher, hooks, or other libexec scripts). Sibling to ``corpus-run`` /
+``corpus-metrics``.
+"""
+import sys
+from pathlib import Path
+
+# Repo root: this script lives at core/dataflow/scripts/trust-corpus,
+# three levels deep. parents[3] climbs:
+#   [0] core/dataflow/scripts/  (this file's directory)
+#   [1] core/dataflow/
+#   [2] core/
+#   [3] <repo root>
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from core.dataflow.cvefix_pipeline import main
+
+sys.exit(main())

--- a/core/dataflow/scripts/trust-synth
+++ b/core/dataflow/scripts/trust-synth
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Synthesize a sound CodeQL barrier for a flagged false positive.
+
+Usage:
+  core/dataflow/scripts/trust-synth <before_db> <after_db> \
+      --sink-class cmdi --finding-id F --sink "<snippet>" \
+      --source-file <path> [--search-path <codeql-queries>] [--max-attempts 3]
+
+An LLM proposes a CodeQL guard predicate for the project-specific sanitizer on
+the path; CodeQL adjudicates it (the barrier must suppress the FP on the
+post-fix DB while leaving the real finding on the pre-fix DB). Emits the
+synthesized query to stdout; exit 0 = sound, 2 = compiled but not sound,
+1 = no compilable barrier after retries. See ~/design/trust-witness.md.
+
+Needs CodeQL + an LLM client configured. Dev-tooling, co-located with
+``core/dataflow/`` rather than ``libexec/`` (operator-command surface). Sibling
+to ``trust-corpus`` / ``corpus-run``.
+"""
+import sys
+from pathlib import Path
+
+# Repo root: this script lives at core/dataflow/scripts/trust-synth,
+# three levels deep. parents[3] climbs:
+#   [0] core/dataflow/scripts/  (this file's directory)
+#   [1] core/dataflow/
+#   [2] core/
+#   [3] <repo root>
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from core.dataflow.barrier_synth import main
+
+sys.exit(main())

--- a/core/dataflow/tests/fixtures/cvefix_cmdi_py/after/app.py
+++ b/core/dataflow/tests/fixtures/cvefix_cmdi_py/after/app.py
@@ -1,0 +1,21 @@
+"""Post-fix fixture: neutralized by a PROJECT-SPECIFIC allowlist that CodeQL
+does not model as a barrier — so CodeQL still flags it (a real
+``missing_sanitizer_model`` false positive, the trust sound-tier target)."""
+import os
+
+from flask import Flask, request
+
+app = Flask(__name__)
+
+
+def host_is_allowed(h):
+    return h in ("localhost", "127.0.0.1")
+
+
+@app.route("/ping")
+def ping():
+    host = request.args.get("host")
+    if not host_is_allowed(host):
+        return "rejected"
+    os.system("ping -c 1 " + host)  # neutralized by host_is_allowed()
+    return "ok"

--- a/core/dataflow/tests/fixtures/cvefix_cmdi_py/before/app.py
+++ b/core/dataflow/tests/fixtures/cvefix_cmdi_py/before/app.py
@@ -1,0 +1,13 @@
+"""Pre-fix fixture: CWE-78 command injection (the vulnerability)."""
+import os
+
+from flask import Flask, request
+
+app = Flask(__name__)
+
+
+@app.route("/ping")
+def ping():
+    host = request.args.get("host")
+    os.system("ping -c 1 " + host)  # tainted host -> os.system (real CWE-78)
+    return "ok"

--- a/core/dataflow/tests/test_barrier_synth.py
+++ b/core/dataflow/tests/test_barrier_synth.py
@@ -10,9 +10,12 @@ import pytest
 
 from core.dataflow.barrier_synth import (
     BarrierProposal,
+    CorpusSynthItem,
     assemble_barrier_query,
     make_llm_proposer,
+    render_corpus_report,
     run_synthesis_loop,
+    synthesize_over_corpus,
 )
 
 _GUARD = (
@@ -195,3 +198,30 @@ def test_main_cli_synthesizes_and_emits_sound_query(tmp_path: Path, monkeypatch,
     ])
     assert rc == 0  # sound
     assert "proposedGuard" in capsys.readouterr().out  # synthesized query to stdout
+
+
+# --- corpus aggregate ---
+
+def test_synthesize_over_corpus_aggregates_outcomes(tmp_path: Path):
+    a1, b1 = tmp_path / "a1", tmp_path / "b1"   # sound: after 0 / before 1
+    a2, b2 = tmp_path / "a2", tmp_path / "b2"   # not_sound: after 0 / before 0 (killed TP)
+    a3, b3 = tmp_path / "a3", tmp_path / "b3"   # no_barrier: proposer emits garbage
+    runner = _stub_runner({str(a1): 0, str(b1): 1, str(a2): 0, str(b2): 0})
+
+    def proposer(proposal, _prior):
+        return "no predicate here" if proposal.finding_id == "F-nobar" else _GUARD
+
+    items = [
+        CorpusSynthItem(BarrierProposal("cmdi", "F-sound", "s", "c"), a1, b1),
+        CorpusSynthItem(BarrierProposal("cmdi", "F-killtp", "s", "c"), a2, b2),
+        CorpusSynthItem(BarrierProposal("cmdi", "F-nobar", "s", "c"), a3, b3),
+    ]
+    rep = synthesize_over_corpus(items, proposer=proposer, work_dir=tmp_path / "w",
+                                 runner=runner, max_attempts=1)
+    assert rep.total == 3
+    assert (rep.sound, rep.not_sound, rep.no_barrier) == (1, 1, 1)
+    assert rep.suppression_rate == 1 / 3
+    assert dict(rep.per_finding) == {
+        "F-sound": "sound", "F-killtp": "not_sound", "F-nobar": "no_barrier",
+    }
+    assert "sound barrier:   1" in render_corpus_report(rep)

--- a/core/dataflow/tests/test_barrier_synth.py
+++ b/core/dataflow/tests/test_barrier_synth.py
@@ -1,0 +1,102 @@
+"""Tests for the sound-tier barrier synthesis loop (stubbed proposer + runner)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from core.dataflow.barrier_synth import (
+    BarrierProposal,
+    assemble_barrier_query,
+    run_synthesis_loop,
+)
+
+_GUARD = (
+    "predicate proposedGuard(DataFlow::GuardNode g, ControlFlowNode node, boolean branch) {\n"
+    '  exists(DataFlow::CallCfgNode c |\n'
+    '    c.getFunction().asExpr().(Name).getId() = "host_is_allowed" and\n'
+    "    g = c.asCfgNode() and node = c.getArg(0).asCfgNode() and branch = true) }"
+)
+
+
+def _proposer(_proposal) -> str:
+    return _GUARD
+
+
+def _stub_runner(counts_by_db: dict):
+    """codeql stand-in: writes a SARIF with N results for the queried db."""
+    def run(cmd, **kwargs):
+        db = cmd[3]  # codeql database analyze <db> ...
+        out = next(a.split("=", 1)[1] for a in cmd if a.startswith("--output="))
+        n = counts_by_db[db]
+        results = [{"ruleId": "x", "message": {"text": "m"}} for _ in range(n)]
+        Path(out).write_text(json.dumps({"runs": [{"results": results}]}))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+    return run
+
+
+def _proposal() -> BarrierProposal:
+    return BarrierProposal(sink_class="cmdi", finding_id="F1",
+                           sink_snippet="os.system(...)", source_context="...")
+
+
+# --- assembly (pure) ---
+
+def test_assemble_wires_guard_and_stock_source_sink():
+    q = assemble_barrier_query(_GUARD, sink_class="cmdi", query_id="raptor/x")
+    assert "CommandInjection::Source" in q
+    assert "CommandInjection::Sink" in q
+    assert "BarrierGuard<proposedGuard/3>" in q
+    assert "proposedGuard" in q
+
+
+def test_assemble_rejects_unknown_sink_class():
+    with pytest.raises(ValueError):
+        assemble_barrier_query(_GUARD, sink_class="nosuch", query_id="x")
+
+
+def test_assemble_rejects_proposal_without_guard():
+    with pytest.raises(ValueError):
+        assemble_barrier_query("predicate other() { any() }", sink_class="cmdi", query_id="x")
+
+
+# --- the loop (stubbed proposer + runner) ---
+
+def test_loop_sound_when_fp_suppressed_and_tp_preserved(tmp_path: Path):
+    after_db, before_db = tmp_path / "adb", tmp_path / "bdb"
+    runner = _stub_runner({str(after_db): 0, str(before_db): 1})
+    res = run_synthesis_loop(
+        _proposal(), after_db, before_db,
+        proposer=_proposer, work_dir=tmp_path / "work", runner=runner,
+    )
+    assert res.after_count == 0 and res.before_count == 1
+    assert res.suppressed_fp and res.preserved_tp and res.is_sound
+    assert "BarrierGuard<proposedGuard/3>" in res.query_ql
+
+
+def test_loop_rejects_overbroad_barrier_that_kills_the_tp(tmp_path: Path):
+    # Barrier suppresses BOTH dbs -> it also killed the real TP -> unsound.
+    after_db, before_db = tmp_path / "adb", tmp_path / "bdb"
+    runner = _stub_runner({str(after_db): 0, str(before_db): 0})
+    res = run_synthesis_loop(
+        _proposal(), after_db, before_db,
+        proposer=_proposer, work_dir=tmp_path / "work", runner=runner,
+    )
+    assert res.suppressed_fp        # killed the FP
+    assert not res.preserved_tp     # but also killed the TP
+    assert not res.is_sound         # -> rejected by the soundness check
+
+
+def test_loop_rejects_barrier_that_does_not_suppress(tmp_path: Path):
+    # Barrier changes nothing -> FP still flagged -> not useful.
+    after_db, before_db = tmp_path / "adb", tmp_path / "bdb"
+    runner = _stub_runner({str(after_db): 1, str(before_db): 1})
+    res = run_synthesis_loop(
+        _proposal(), after_db, before_db,
+        proposer=_proposer, work_dir=tmp_path / "work", runner=runner,
+    )
+    assert not res.suppressed_fp
+    assert not res.is_sound

--- a/core/dataflow/tests/test_barrier_synth.py
+++ b/core/dataflow/tests/test_barrier_synth.py
@@ -11,6 +11,7 @@ import pytest
 from core.dataflow.barrier_synth import (
     BarrierProposal,
     assemble_barrier_query,
+    make_llm_proposer,
     run_synthesis_loop,
 )
 
@@ -22,7 +23,7 @@ _GUARD = (
 )
 
 
-def _proposer(_proposal) -> str:
+def _proposer(_proposal, _prior_error=None) -> str:
     return _GUARD
 
 
@@ -100,3 +101,97 @@ def test_loop_rejects_barrier_that_does_not_suppress(tmp_path: Path):
     )
     assert not res.suppressed_fp
     assert not res.is_sound
+
+
+# --- LLM proposer + retry ---
+
+def test_llm_proposer_strips_markdown_fence():
+    captured = {}
+
+    def complete(system_prompt, user_prompt):
+        captured["sys"] = system_prompt
+        captured["user"] = user_prompt
+        return f"```ql\n{_GUARD}\n```"
+
+    proposer = make_llm_proposer(complete)
+    out = proposer(_proposal(), None)
+    assert out.strip().startswith("predicate proposedGuard")
+    assert "```" not in out
+    # the proposal context reaches the prompt
+    assert "os.system(...)" in captured["user"]
+
+
+def test_llm_proposer_passes_prior_error_on_retry():
+    seen = []
+
+    def complete(system_prompt, user_prompt):
+        seen.append(user_prompt)
+        return _GUARD
+
+    proposer = make_llm_proposer(complete)
+    proposer(_proposal(), "ValueError: proposer must define a `proposedGuard` predicate")
+    assert "PREVIOUS attempt failed" in seen[0]
+    assert "proposedGuard" in seen[0]
+
+
+def test_loop_retries_on_bad_proposal_then_succeeds(tmp_path: Path):
+    after_db, before_db = tmp_path / "adb", tmp_path / "bdb"
+    runner = _stub_runner({str(after_db): 0, str(before_db): 1})
+    calls = {"n": 0}
+
+    def flaky_proposer(_proposal, prior_error):
+        calls["n"] += 1
+        # First attempt: garbage (assembly rejects -> ValueError -> retry).
+        if prior_error is None:
+            return "this is not a predicate"
+        return _GUARD  # corrected on retry
+
+    res = run_synthesis_loop(
+        _proposal(), after_db, before_db,
+        proposer=flaky_proposer, work_dir=tmp_path / "work", runner=runner,
+        max_attempts=2,
+    )
+    assert calls["n"] == 2
+    assert res is not None and res.is_sound
+
+
+def test_loop_returns_none_when_proposer_never_compiles(tmp_path: Path):
+    after_db, before_db = tmp_path / "adb", tmp_path / "bdb"
+    runner = _stub_runner({str(after_db): 0, str(before_db): 1})
+    res = run_synthesis_loop(
+        _proposal(), after_db, before_db,
+        proposer=lambda p, e: "garbage, no predicate here",
+        work_dir=tmp_path / "work", runner=runner, max_attempts=3,
+    )
+    assert res is None
+
+
+# --- CLI (stubbed LLM + CodeQL) ---
+
+def test_main_cli_synthesizes_and_emits_sound_query(tmp_path: Path, monkeypatch, capsys):
+    from core.dataflow import barrier_synth
+
+    before_db, after_db = tmp_path / "bdb", tmp_path / "adb"
+    src = tmp_path / "app.py"
+    src.write_text("def host_is_allowed(h):\n    return h in ('localhost',)\n", encoding="utf-8")
+
+    # stub the LLM proposer
+    monkeypatch.setattr(barrier_synth, "default_completer", lambda: (lambda s, u: _GUARD))
+    # stub CodeQL: post-fix suppressed (0), pre-fix preserved (1)
+    counts = {str(after_db): 0, str(before_db): 1}
+
+    def stub_analyze(db_path, queries, output_path, **kwargs):
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        n = counts[str(db_path)]
+        Path(output_path).write_text(json.dumps({"runs": [{"results": [{} for _ in range(n)]}]}))
+        return SimpleNamespace(sarif_path=output_path)
+
+    monkeypatch.setattr(barrier_synth, "analyze", stub_analyze)
+
+    rc = barrier_synth.main([
+        str(before_db), str(after_db), "--sink-class", "cmdi",
+        "--finding-id", "F1", "--sink", "os.system(host)",
+        "--source-file", str(src), "--work-dir", str(tmp_path / "w"),
+    ])
+    assert rc == 0  # sound
+    assert "proposedGuard" in capsys.readouterr().out  # synthesized query to stdout

--- a/core/dataflow/tests/test_cvefix_corpus_pipeline.py
+++ b/core/dataflow/tests/test_cvefix_corpus_pipeline.py
@@ -1,0 +1,168 @@
+"""End-to-end smoke test for the CVE-fix trust-corpus pipeline.
+
+Proves the framework plumbing on a SYNTHETIC before/after SARIF pair (no
+CodeQL, no dataset download), wiring the shipped substrate to the three new
+modules:
+
+  generate_from_sarif  (cvefix_corpus_generator)
+    -> write_corpus     (owasp_corpus_generator, reused)
+    -> run              (run_corpus, shipped)
+    -> report           (trust_report)
+
+The validator here is a STUB suppressor (sanitizer-token match) — it exercises
+the framework, not the real trust detector (that's the qlpack sound tier).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.dataflow.cvefix_corpus_generator import generate_from_sarif, write_corpus
+from core.dataflow.run_corpus import run
+from core.dataflow.trust_report import render, report
+from core.dataflow.validator import ValidatorVerdict
+
+
+def _loc(uri: str, line: int, snippet: str, msg: str) -> dict:
+    return {"location": {"physicalLocation": {
+        "artifactLocation": {"uri": uri},
+        "region": {"startLine": line, "startColumn": 5, "snippet": {"text": snippet}}},
+        "message": {"text": msg}}}
+
+
+def _sarif(sink_line: int, sink_snippet: str) -> dict:
+    return {"runs": [{"results": [{
+        "ruleId": "java/sql-injection",
+        "message": {"text": "user input reaches SQL"},
+        "codeFlows": [{"threadFlows": [{"locations": [
+            _loc("Foo.java", 10, 'request.getParameter("id")', "source"),
+            _loc("Foo.java", sink_line, sink_snippet, "sink"),
+        ]}]}]}]}]}
+
+
+# Vulnerable (pre-fix) vs patched (post-fix, sanitizer added but CodeQL still flags).
+_BEFORE = _sarif(20, "stmt.execute(sql)")
+_AFTER = _sarif(22, "stmt.execute(Sanitizer.clean(sql))")
+
+
+class _SanitizerTokenValidator:
+    """Stub trust suppressor: NOT_EXPLOITABLE if a sanitizer token is on the
+    path, else UNCERTAIN (never EXPLOITABLE). Plumbing stand-in only."""
+
+    def validate(self, finding) -> ValidatorVerdict:
+        path = [finding.source, *finding.intermediate_steps, finding.sink]
+        blob = " ".join((s.snippet or "") for s in path).lower()
+        if any(t in blob for t in ("sanitizer", "clean(", "escape(")):
+            return ValidatorVerdict.NOT_EXPLOITABLE
+        return ValidatorVerdict.UNCERTAIN
+
+
+class _SuppressAllValidator:
+    """Unsound suppressor — suppresses everything. Used to prove the FN-gate
+    actually fires (it must mark a TP false-suppression)."""
+
+    def validate(self, finding) -> ValidatorVerdict:
+        return ValidatorVerdict.NOT_EXPLOITABLE
+
+
+def _generate(**kw):
+    return generate_from_sarif(
+        _BEFORE, _AFTER, cve_id="CVE-2021-9999", cwe="CWE-89",
+        labeled_at="2026-05-25", **kw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Generator
+# ---------------------------------------------------------------------------
+
+def test_generator_labels_post_fix_finding_as_missing_sanitizer_fp():
+    pairs = _generate()
+    by_verdict = {gt.verdict: (f, gt) for f, gt in pairs}
+    assert set(by_verdict) == {"true_positive", "false_positive"}
+    f_fp, gt_fp = by_verdict["false_positive"]
+    assert gt_fp.fp_category == "missing_sanitizer_model"
+    assert "post" in f_fp.finding_id
+    assert "Sanitizer.clean" in f_fp.sink.snippet
+    f_tp, gt_tp = by_verdict["true_positive"]
+    assert gt_tp.fp_category is None
+    assert "pre" in f_tp.finding_id
+
+
+def test_generator_skips_non_dataflow_results():
+    empty = {"runs": [{"results": [{"ruleId": "x", "message": {"text": "no flow"}}]}]}
+    pairs = generate_from_sarif(empty, empty, cve_id="CVE-X", cwe="CWE-89",
+                                labeled_at="2026-05-25")
+    assert pairs == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: generate -> write_corpus -> run_corpus -> trust_report
+# ---------------------------------------------------------------------------
+
+def test_pipeline_suppresses_fp_without_false_suppressing_tp(tmp_path: Path):
+    corpus_dir = tmp_path / "corpus"
+    n = write_corpus(_generate(), corpus_dir)
+    assert n == 2
+
+    csv_out = tmp_path / "trust.csv"
+    rows = run(corpus_dir, _SanitizerTokenValidator(), csv_out)
+    assert rows == 2
+
+    r = report(csv_out)
+    assert r.trust_fp == 1
+    assert r.coverage_n == 1          # the post-fix FP was suppressed
+    assert r.coverage == 1.0
+    assert r.tp == 1
+    assert r.false_suppression_n == 0  # the pre-fix TP was NOT suppressed
+    assert r.is_sound
+    assert "coverage:" in render(r)
+
+
+def test_fn_gate_fires_when_a_tp_is_suppressed(tmp_path: Path):
+    """An unsound validator that suppresses the TP must register as a
+    false-suppression and flip is_sound — otherwise the gate is decorative."""
+    corpus_dir = tmp_path / "corpus"
+    write_corpus(_generate(), corpus_dir)
+    csv_out = tmp_path / "trust.csv"
+    run(corpus_dir, _SuppressAllValidator(), csv_out)
+    r = report(csv_out)
+    assert r.false_suppression_n == 1
+    assert not r.is_sound
+
+
+# ---------------------------------------------------------------------------
+# Localization (Issue 1 fix) + robustness
+# ---------------------------------------------------------------------------
+
+def _result(uri: str, sink_line: int) -> dict:
+    return {"ruleId": "java/sql-injection", "message": {"text": "m"},
+            "codeFlows": [{"threadFlows": [{"locations": [
+                _loc(uri, 5, "src", "source"), _loc(uri, sink_line, "sink", "sink")]}]}]}
+
+
+def test_localization_filters_cve_unrelated_findings():
+    # Two findings: one in the fix-changed file, one unrelated.
+    after = {"runs": [{"results": [_result("Foo.java", 22), _result("Other.java", 99)]}]}
+    empty = {"runs": [{"results": []}]}
+
+    # No localization → both emitted (and the unrelated one is mislabeled FP).
+    assert len(generate_from_sarif(after, empty, cve_id="CVE-A", cwe="CWE-89",
+                                   labeled_at="2026-05-25")) == 2
+    # Localized to Foo.java → only the CVE-attributable finding survives.
+    pairs = generate_from_sarif(after, empty, cve_id="CVE-A", cwe="CWE-89",
+                                labeled_at="2026-05-25", fix_touched_files={"Foo.java"})
+    assert len(pairs) == 1
+    assert pairs[0][0].sink.file_path == "Foo.java"
+
+
+def test_malformed_sarif_result_is_skipped_not_fatal():
+    # startLine 0 makes Step validation raise inside from_sarif_result;
+    # the generator must skip it, not crash the batch.
+    bad = {"runs": [{"results": [{
+        "ruleId": "x", "message": {"text": "m"},
+        "codeFlows": [{"threadFlows": [{"locations": [
+            _loc("F.java", 0, "src", "source"), _loc("F.java", 5, "sink", "sink")]}]}]}]}]}
+    empty = {"runs": [{"results": []}]}
+    assert generate_from_sarif(bad, empty, cve_id="CVE-B", cwe="CWE-89",
+                               labeled_at="2026-05-25") == []

--- a/core/dataflow/tests/test_cvefix_pipeline.py
+++ b/core/dataflow/tests/test_cvefix_pipeline.py
@@ -88,3 +88,32 @@ def test_pipeline_localizes_to_fix_touched_files(tmp_path: Path):
     )
     assert len(pairs) == 1
     assert pairs[0][0].sink.file_path == "Foo.java"
+
+
+def test_main_cli_parses_and_dispatches(tmp_path: Path, monkeypatch):
+    """main() arg-parsing + dispatch, with analyze stubbed to write canned
+    SARIF — exercises the scripts/trust-corpus entry point without CodeQL."""
+    from core.dataflow import cvefix_pipeline
+
+    before_db = tmp_path / "bdb"
+    after_db = tmp_path / "adb"
+    sarif_by_db = {
+        str(before_db): _sarif("stmt.execute(sql)", 20),
+        str(after_db): _sarif("stmt.execute(Sanitizer.clean(sql))", 22),
+    }
+
+    def _stub_analyze(db_path, queries, output_path, **kwargs):
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(sarif_by_db[str(db_path)]))
+        return SimpleNamespace(sarif_path=output_path)
+
+    monkeypatch.setattr(cvefix_pipeline, "analyze", _stub_analyze)
+
+    rc = cvefix_pipeline.main([
+        str(before_db), str(after_db), "--query", "java/sql-injection",
+        "--cve", "CVE-2021-9999", "--cwe", "CWE-89",
+        "--out", str(tmp_path / "out"), "--fix-touched-file", "Foo.java",
+        "--labeled-at", "2026-05-25",
+    ])
+    assert rc == 0
+    assert len(list((tmp_path / "out" / "corpus").glob("*.label.json"))) == 2

--- a/core/dataflow/tests/test_cvefix_pipeline.py
+++ b/core/dataflow/tests/test_cvefix_pipeline.py
@@ -1,0 +1,90 @@
+"""Test the CVE-fix → CodeQL → corpus orchestrator with a stub runner.
+
+Proves the ``analyze`` → generator → ``write_corpus`` wiring end-to-end
+without a real CodeQL CLI: the injected runner writes canned SARIF to the
+``--output=`` path the orchestrator asked ``analyze`` to produce.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from core.dataflow.cvefix_pipeline import generate_corpus_for_pair
+
+
+def _loc(uri: str, line: int, snippet: str, msg: str) -> dict:
+    return {"location": {"physicalLocation": {
+        "artifactLocation": {"uri": uri},
+        "region": {"startLine": line, "startColumn": 5, "snippet": {"text": snippet}}},
+        "message": {"text": msg}}}
+
+
+def _sarif(sink_snippet: str, sink_line: int) -> dict:
+    return {"runs": [{"results": [{
+        "ruleId": "java/sql-injection", "message": {"text": "tainted SQL"},
+        "codeFlows": [{"threadFlows": [{"locations": [
+            _loc("Foo.java", 10, 'request.getParameter("id")', "source"),
+            _loc("Foo.java", sink_line, sink_snippet, "sink"),
+        ]}]}]}]}]}
+
+
+def _stub_codeql_runner(sarif_by_db: dict):
+    """A subprocess.run stand-in: writes the db's canned SARIF to the
+    ``--output=`` path encoded in the codeql command, then 'succeeds'."""
+    def run(cmd, **kwargs):
+        db = cmd[3]  # codeql database analyze <db> ...
+        out = next(a.split("=", 1)[1] for a in cmd if a.startswith("--output="))
+        Path(out).write_text(json.dumps(sarif_by_db[db]))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+    return run
+
+
+def test_pipeline_drives_codeql_then_labels(tmp_path: Path):
+    before_db = tmp_path / "before_db"
+    after_db = tmp_path / "after_db"
+    runner = _stub_codeql_runner({
+        str(before_db): _sarif("stmt.execute(sql)", 20),                   # vulnerable
+        str(after_db): _sarif("stmt.execute(Sanitizer.clean(sql))", 22),   # fixed; still flagged
+    })
+
+    pairs = generate_corpus_for_pair(
+        before_db, after_db, ["java/sql-injection"],
+        cve_id="CVE-2021-9999", cwe="CWE-89", labeled_at="2026-05-25",
+        out_dir=tmp_path / "out", fix_touched_files={"Foo.java"},
+        runner=runner,
+    )
+
+    by_verdict = {gt.verdict: (f, gt) for f, gt in pairs}
+    assert set(by_verdict) == {"true_positive", "false_positive"}
+    assert by_verdict["false_positive"][1].fp_category == "missing_sanitizer_model"
+    # SARIF + corpus written under out_dir.
+    assert (tmp_path / "out" / "sarif" / "before.sarif").exists()
+    assert (tmp_path / "out" / "sarif" / "after.sarif").exists()
+    assert len(list((tmp_path / "out" / "corpus").glob("*.label.json"))) == 2
+
+
+def test_pipeline_localizes_to_fix_touched_files(tmp_path: Path):
+    before_db = tmp_path / "b"
+    after_db = tmp_path / "a"
+    # after-fix SARIF flags two paths: the CVE one (Foo.java) + an unrelated one.
+    after = _sarif("stmt.execute(Sanitizer.clean(sql))", 22)
+    after["runs"][0]["results"].append({
+        "ruleId": "java/sql-injection", "message": {"text": "other"},
+        "codeFlows": [{"threadFlows": [{"locations": [
+            _loc("Other.java", 3, "src", "source"),
+            _loc("Other.java", 9, "sink", "sink")]}]}]})
+    runner = _stub_codeql_runner({
+        str(before_db): {"runs": [{"results": []}]},
+        str(after_db): after,
+    })
+
+    pairs = generate_corpus_for_pair(
+        before_db, after_db, ["java/sql-injection"],
+        cve_id="CVE-X", cwe="CWE-89", labeled_at="2026-05-25",
+        out_dir=tmp_path / "out", fix_touched_files={"Foo.java"},
+        runner=runner, write=False,
+    )
+    assert len(pairs) == 1
+    assert pairs[0][0].sink.file_path == "Foo.java"

--- a/core/dataflow/tests/test_cvefix_pipeline_codeql_e2e.py
+++ b/core/dataflow/tests/test_cvefix_pipeline_codeql_e2e.py
@@ -1,13 +1,16 @@
-"""Real-CodeQL end-to-end for the trust-corpus pipeline.
+"""Real-CodeQL end-to-end for the trust-corpus pipeline AND the sound tier.
 
-Builds CodeQL databases from the committed before/after python fixtures and
-drives the orchestrator with the actual CodeQL CLI (no stub) — proving the
-pipeline handles real SARIF and reproduces the trust-axis target: a
-project-specific sanitizer CodeQL does not model leaves the post-fix code
-still flagged (a real ``missing_sanitizer_model`` false positive).
+Builds CodeQL databases from the committed before/after python fixtures (once,
+module-scoped) and exercises two real-CodeQL paths:
 
-Skipped when CodeQL isn't installed (e.g. CI) — same posture as the
-reachability program's fetched/local-only gates. Slow: builds two DBs.
+  1. the pipeline: generate_corpus_for_pair labels the post-fix-still-flagged
+     finding as a missing_sanitizer_model FP;
+  2. the sound tier: a synthesized barrier (the host_is_allowed guard the LLM
+     would emit) SUPPRESSES that FP while preserving the real pre-fix TP.
+
+Both use the actual CodeQL CLI (no stub) — this is what keeps the QL the loop
+assembles regression-guarded (the unit tests stub CodeQL and never compile it).
+Skipped when CodeQL isn't installed (e.g. CI). Slow: two DB builds + CodeQL runs.
 """
 
 from __future__ import annotations
@@ -18,11 +21,20 @@ from pathlib import Path
 
 import pytest
 
+from core.dataflow.barrier_synth import BarrierProposal, run_synthesis_loop
 from core.dataflow.cvefix_pipeline import generate_corpus_for_pair
 
 _CODEQL = shutil.which("codeql")
 _FIXTURES = Path(__file__).parent / "fixtures" / "cvefix_cmdi_py"
 _QUERY = "codeql/python-queries:Security/CWE-078/CommandInjection.ql"
+
+# The guard a proposer would emit for the fixture's project validator.
+_HOST_ALLOWED_GUARD = (
+    "predicate proposedGuard(DataFlow::GuardNode g, ControlFlowNode node, boolean branch) {\n"
+    "  exists(DataFlow::CallCfgNode c |\n"
+    '    c.getFunction().asExpr().(Name).getId() = "host_is_allowed" and\n'
+    "    g = c.asCfgNode() and node = c.getArg(0).asCfgNode() and branch = true) }"
+)
 
 pytestmark = pytest.mark.skipif(_CODEQL is None, reason="codeql CLI not installed")
 
@@ -35,24 +47,46 @@ def _build_db(src: Path, db: Path) -> None:
     )
 
 
-def test_real_codeql_reproduces_missing_sanitizer_fp(tmp_path: Path):
-    before_db = tmp_path / "before-db"
-    after_db = tmp_path / "after-db"
+@pytest.fixture(scope="module")
+def codeql_dbs(tmp_path_factory):
+    """Build the before/after fixture DBs once for the module."""
+    base = tmp_path_factory.mktemp("codeql-dbs")
+    before_db, after_db = base / "before-db", base / "after-db"
     _build_db(_FIXTURES / "before", before_db)
     _build_db(_FIXTURES / "after", after_db)
+    return before_db, after_db
 
+
+def test_pipeline_labels_post_fix_finding_as_missing_sanitizer_fp(codeql_dbs, tmp_path):
+    before_db, after_db = codeql_dbs
     pairs = generate_corpus_for_pair(
         before_db, after_db, [_QUERY],
         cve_id="DEMO-CVE-0001", cwe="CWE-78", labeled_at="2026-05-25",
         out_dir=tmp_path / "out", fix_touched_files={"app.py"},
     )
-
     by_verdict = {gt.verdict: (f, gt) for f, gt in pairs}
-    # Pre-fix flags the real vuln (TP); post-fix is STILL flagged despite the
-    # project allowlist -> the missing_sanitizer_model FP the trust tier targets.
     assert "true_positive" in by_verdict, "CodeQL should flag the pre-fix vuln"
     assert "false_positive" in by_verdict, (
         "CodeQL should still flag the post-fix code (project allowlist unmodeled)"
     )
     assert by_verdict["false_positive"][1].fp_category == "missing_sanitizer_model"
     assert by_verdict["true_positive"][0].sink.file_path == "app.py"
+
+
+def test_synthesized_barrier_suppresses_fp_and_preserves_tp(codeql_dbs, tmp_path):
+    """The sound-tier capstone, regression-guarded: the assembled barrier query
+    must compile under real CodeQL and suppress the FP (after=0) without
+    suppressing the real TP (before=1)."""
+    before_db, after_db = codeql_dbs
+    res = run_synthesis_loop(
+        BarrierProposal(sink_class="cmdi", finding_id="DEMO",
+                        sink_snippet="os.system(host)", source_context="(fixture)"),
+        after_db, before_db,
+        proposer=lambda _proposal, _err: _HOST_ALLOWED_GUARD,
+        work_dir=tmp_path / "synth",
+        # search_path=None: `codeql database analyze` resolves codeql/python-all
+    )
+    assert res is not None, "the assembled barrier query must compile under CodeQL"
+    assert res.after_count == 0, "the FP should be suppressed by the barrier"
+    assert res.before_count == 1, "the real TP must be preserved"
+    assert res.is_sound

--- a/core/dataflow/tests/test_cvefix_pipeline_codeql_e2e.py
+++ b/core/dataflow/tests/test_cvefix_pipeline_codeql_e2e.py
@@ -1,0 +1,58 @@
+"""Real-CodeQL end-to-end for the trust-corpus pipeline.
+
+Builds CodeQL databases from the committed before/after python fixtures and
+drives the orchestrator with the actual CodeQL CLI (no stub) — proving the
+pipeline handles real SARIF and reproduces the trust-axis target: a
+project-specific sanitizer CodeQL does not model leaves the post-fix code
+still flagged (a real ``missing_sanitizer_model`` false positive).
+
+Skipped when CodeQL isn't installed (e.g. CI) — same posture as the
+reachability program's fetched/local-only gates. Slow: builds two DBs.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from core.dataflow.cvefix_pipeline import generate_corpus_for_pair
+
+_CODEQL = shutil.which("codeql")
+_FIXTURES = Path(__file__).parent / "fixtures" / "cvefix_cmdi_py"
+_QUERY = "codeql/python-queries:Security/CWE-078/CommandInjection.ql"
+
+pytestmark = pytest.mark.skipif(_CODEQL is None, reason="codeql CLI not installed")
+
+
+def _build_db(src: Path, db: Path) -> None:
+    subprocess.run(
+        [_CODEQL, "database", "create", str(db), "--language=python",
+         f"--source-root={src}", "--overwrite"],
+        check=True, capture_output=True, text=True,
+    )
+
+
+def test_real_codeql_reproduces_missing_sanitizer_fp(tmp_path: Path):
+    before_db = tmp_path / "before-db"
+    after_db = tmp_path / "after-db"
+    _build_db(_FIXTURES / "before", before_db)
+    _build_db(_FIXTURES / "after", after_db)
+
+    pairs = generate_corpus_for_pair(
+        before_db, after_db, [_QUERY],
+        cve_id="DEMO-CVE-0001", cwe="CWE-78", labeled_at="2026-05-25",
+        out_dir=tmp_path / "out", fix_touched_files={"app.py"},
+    )
+
+    by_verdict = {gt.verdict: (f, gt) for f, gt in pairs}
+    # Pre-fix flags the real vuln (TP); post-fix is STILL flagged despite the
+    # project allowlist -> the missing_sanitizer_model FP the trust tier targets.
+    assert "true_positive" in by_verdict, "CodeQL should flag the pre-fix vuln"
+    assert "false_positive" in by_verdict, (
+        "CodeQL should still flag the post-fix code (project allowlist unmodeled)"
+    )
+    assert by_verdict["false_positive"][1].fp_category == "missing_sanitizer_model"
+    assert by_verdict["true_positive"][0].sink.file_path == "app.py"

--- a/core/dataflow/trust_report.py
+++ b/core/dataflow/trust_report.py
@@ -1,0 +1,114 @@
+"""Trust-axis measurement over a :mod:`core.dataflow.run_corpus` CSV.
+
+The trust validator is an FP-*suppressor*: it emits ``not_exploitable`` only
+when it holds a (sound) neutralization witness, and ``uncertain`` otherwise —
+it never asserts ``exploitable``. So the meaningful metrics are not standard
+precision/recall but:
+
+  * **coverage** — of the trust-addressable FPs (taint neutralised on the
+    path), how many did the validator suppress?
+  * **false_suppression** — of the true positives, how many did it WRONGLY
+    suppress? Must be 0 for a sound suppressor (the FN-gate).
+  * **defer_rate** — share left ``uncertain``.
+  * **suppression_precision** — of everything suppressed, how much was a real FP.
+
+See ``~/design/trust-witness.md``.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import FrozenSet, Optional
+
+# FP categories whose root cause is "taint neutralised on the path" — the
+# slice a trust witness can act on. (Reachability owns dead_code; SMT owns
+# infeasible_branch.) Callers can narrow this for corpus-specific exclusions.
+TRUST_FP_CATEGORIES: FrozenSet[str] = frozenset(
+    {"missing_sanitizer_model", "framework_mitigation", "type_constraint"}
+)
+
+_SUPPRESS = "not_exploitable"
+_TP = "true_positive"
+_FP = "false_positive"
+
+
+@dataclass(frozen=True)
+class TrustReport:
+    total: int
+    tp: int
+    trust_fp: int
+    coverage_n: int            # trust-FPs suppressed
+    false_suppression_n: int   # TPs wrongly suppressed (must be 0)
+    defer_n: int               # rows left uncertain
+    suppressed_total: int      # all not_exploitable verdicts
+    suppressed_on_fp: int      # of those, how many were real FPs
+
+    @property
+    def coverage(self) -> Optional[float]:
+        return None if self.trust_fp == 0 else self.coverage_n / self.trust_fp
+
+    @property
+    def false_suppression_rate(self) -> Optional[float]:
+        return None if self.tp == 0 else self.false_suppression_n / self.tp
+
+    @property
+    def suppression_precision(self) -> Optional[float]:
+        return None if self.suppressed_total == 0 else self.suppressed_on_fp / self.suppressed_total
+
+    @property
+    def is_sound(self) -> bool:
+        """Sound on this corpus iff it killed no TP — AND there were TPs to
+        kill. With zero TPs the claim is vacuous, so it is not 'sound'."""
+        return self.tp > 0 and self.false_suppression_n == 0
+
+
+def report(
+    csv_path: Path, *, trust_categories: FrozenSet[str] = TRUST_FP_CATEGORIES
+) -> TrustReport:
+    total = tp = trust_fp = 0
+    coverage_n = false_suppression_n = defer_n = 0
+    suppressed_total = suppressed_on_fp = 0
+    with Path(csv_path).open() as f:
+        for row in csv.DictReader(f):
+            total += 1
+            label = row["label_verdict"]
+            suppressed = row["validator_verdict"] == _SUPPRESS
+            is_trust_fp = label == _FP and (row.get("fp_category") or "") in trust_categories
+            if row["validator_verdict"] == "uncertain":
+                defer_n += 1
+            if suppressed:
+                suppressed_total += 1
+                if label == _FP:
+                    suppressed_on_fp += 1
+            if label == _TP:
+                tp += 1
+                if suppressed:
+                    false_suppression_n += 1
+            if is_trust_fp:
+                trust_fp += 1
+                if suppressed:
+                    coverage_n += 1
+    return TrustReport(
+        total=total, tp=tp, trust_fp=trust_fp,
+        coverage_n=coverage_n, false_suppression_n=false_suppression_n,
+        defer_n=defer_n, suppressed_total=suppressed_total,
+        suppressed_on_fp=suppressed_on_fp,
+    )
+
+
+def render(r: TrustReport) -> str:
+    def pct(x: Optional[float]) -> str:
+        return "n/a" if x is None else f"{x * 100:.0f}%"
+
+    lines = [
+        f"Trust FP-suppressor measurement ({r.total} findings)",
+        f"  coverage:          {r.coverage_n}/{r.trust_fp} trust-FPs suppressed ({pct(r.coverage)})",
+        f"  false-suppression: {r.false_suppression_n}/{r.tp} TPs wrongly suppressed "
+        f"({pct(r.false_suppression_rate)}) {'OK' if r.is_sound else '*** NONZERO — UNSOUND ***'}",
+        f"  suppression-prec:  {r.suppressed_on_fp}/{r.suppressed_total} suppressions hit real FPs "
+        f"({pct(r.suppression_precision)})",
+        f"  defer (uncertain): {r.defer_n}/{r.total}",
+    ]
+    return "\n".join(lines)


### PR DESCRIPTION
Adds the trust-witness "sound tier": automatically suppress `missing_sanitizer_model` false positives — findings the analyzer flags but a project-specific sanitizer actually neutralizes — without ever suppressing a true positive.

End to end, all under `core/dataflow/`:

- **Generate** — a CVE fix-commit pair → CodeQL → labeled FP candidates. A finding still flagged on the *post-fix* code is a `missing_sanitizer_model` FP (the fix added a sanitizer CodeQL doesn't model); the pre-fix finding is the true positive. Localized to the fix-changed files. CLI: `scripts/trust-corpus`.
- **Synthesize** — for a flagged FP, an LLM proposes a CodeQL `isBarrier` recognizing the project sanitizer; CodeQL *adjudicates* it by compiling and running it; the loop retries with the compile error on failure. A barrier is **sound** only if it suppresses the FP (post-fix → 0) **and** preserves the TP (pre-fix → 1). CLI: `scripts/trust-synth`.
- **Aggregate** — `synthesize_over_corpus` runs the loop across a corpus and reports the suppression rate.

## Why this is sound

The decision split is structural, mirroring the reachability soundness model: the LLM only **proposes** (heuristic); CodeQL **adjudicates** by compiling + running the predicate (mechanical); an over-broad barrier that kills a true positive is rejected by the corpus check. So the LLM is never on the suppression path and cannot introduce a false negative — a malformed predicate simply fails to compile.

## Reuse

Built on shipped substrate — `codeql_augmented_run`, `finding_diff`, `adapters/codeql`, `owasp_corpus_generator.write_corpus`, `run_corpus`, `corpus_metrics`. 