### PR TITLE
feat(reachability): C/C++ build-membership witness (compile_commands TU set)

### DIFF
--- a/core/build/macro_config.py
+++ b/core/build/macro_config.py
@@ -218,4 +218,47 @@ def extract_macro_config(target: Path) -> MacroConfig:
     return MacroConfig()
 
 
-__all__ = ["MacroConfig", "extract_macro_config"]
+def extract_build_tus(target: Path) -> Optional[frozenset]:
+    """Set of absolute translation-unit paths in ``target``'s
+    ``compile_commands.json`` (resolved so they match the inventory builder's
+    file paths), or ``None`` when there is no parseable, non-empty
+    compile_commands.
+
+    ``None`` means build membership is UNKNOWN — the C/C++ build-membership
+    witness must not fire (a source absent from an absent/empty manifest tells
+    us nothing). Heuristic even when present: a compile_commands may be partial
+    (one target, a sub-build), so a source's absence is evidence, not proof —
+    the witness it feeds is surface-only.
+    """
+    target = Path(target)
+    if not target.is_dir():
+        return None
+    cc = _find_compile_commands(target)
+    if cc is None:
+        return None
+    try:
+        entries = json.loads(cc.read_text(errors="replace"))
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        logger.debug("compile_commands.json TU-set parse failed: %s", exc)
+        return None
+    if not isinstance(entries, list):
+        return None
+    tus = set()
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        f = e.get("file")
+        if not isinstance(f, str) or not f:
+            continue
+        p = Path(f)
+        d = e.get("directory")
+        if not p.is_absolute() and isinstance(d, str):
+            p = Path(d) / f
+        try:
+            tus.add(str(p.resolve()))
+        except OSError:
+            tus.add(str(p))
+    return frozenset(tus) if tus else None
+
+
+__all__ = ["MacroConfig", "extract_macro_config", "extract_build_tus"]

--- a/core/build/tests/test_macro_config.py
+++ b/core/build/tests/test_macro_config.py
@@ -103,3 +103,35 @@ def test_malformed_compile_commands_falls_through(tmp_path):
 def test_empty_macroconfig_is_falsy():
     assert not MacroConfig()
     assert MacroConfig(defined={"X": "1"})
+
+
+def test_extract_build_tus_none_when_no_manifest(tmp_path):
+    from core.build.macro_config import extract_build_tus
+    assert extract_build_tus(tmp_path) is None  # no compile_commands → unknown
+
+
+def test_extract_build_tus_collects_resolved_paths(tmp_path):
+    import json
+    from core.build.macro_config import extract_build_tus
+    (tmp_path / "compile_commands.json").write_text(json.dumps([
+        {"directory": str(tmp_path), "file": "a.c",
+         "arguments": ["cc", "-c", "a.c"]},                     # relative
+        {"directory": str(tmp_path), "file": str(tmp_path / "b.c"),
+         "command": "cc -c b.c"},                               # absolute
+    ]))
+    tus = extract_build_tus(tmp_path)
+    assert str((tmp_path / "a.c").resolve()) in tus
+    assert str((tmp_path / "b.c").resolve()) in tus
+
+
+def test_extract_build_tus_empty_manifest_is_none(tmp_path):
+    # An empty/degenerate manifest → unknown, NOT "everything excluded".
+    from core.build.macro_config import extract_build_tus
+    (tmp_path / "compile_commands.json").write_text("[]")
+    assert extract_build_tus(tmp_path) is None
+
+
+def test_extract_build_tus_malformed_is_none(tmp_path):
+    from core.build.macro_config import extract_build_tus
+    (tmp_path / "compile_commands.json").write_text("{not json")
+    assert extract_build_tus(tmp_path) is None

--- a/core/inventory/build_membership.py
+++ b/core/inventory/build_membership.py
@@ -38,11 +38,18 @@ same ``build_excluded`` witness, wired at the builder level rather than here.)
 from __future__ import annotations
 
 import logging
+import os.path
 import re
 from dataclasses import dataclass
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+# Source translation-unit extensions — a file the build COMPILES. Headers are
+# deliberately excluded: a .h is never a TU (never in compile_commands) but its
+# functions are reachable via the .c files that #include it, so header
+# membership must never be inferred from compile_commands.
+_TU_SOURCE_EXT = frozenset({".c", ".cc", ".cpp", ".cxx", ".c++", ".m", ".mm"})
 
 
 @dataclass(frozen=True)
@@ -105,4 +112,33 @@ def _detect_go(content: str) -> Optional[BuildExcluded]:
     return None
 
 
-__all__ = ["BuildExcluded", "detect_build_excluded"]
+def tu_membership_excluded(
+    abs_path: str, tu_files: Optional[frozenset],
+) -> Optional[BuildExcluded]:
+    """C/C++ build-membership witness: a SOURCE translation unit (``.c`` /
+    ``.cpp`` / …) absent from ``compile_commands.json`` is not compiled in this
+    build, so every function in it is dead. Heuristic (the manifest may be
+    partial) → surface-only, never hard-suppress.
+
+    Returns ``None`` (no exclusion) when:
+      * ``tu_files`` is ``None`` — no parseable compile_commands ⇒ membership
+        unknown (never fire on absence-of-evidence);
+      * ``abs_path`` is not a source-TU extension — headers (``.h`` / ``.hpp``)
+        are never TUs but their functions are reachable via includers, so they
+        are exempt; non-C/C++ files are irrelevant;
+      * ``abs_path`` IS in the build.
+
+    ``abs_path`` must be resolved (realpath) to match the ``tu_files`` entries,
+    which :func:`core.build.macro_config.extract_build_tus` resolves.
+    """
+    if tu_files is None:
+        return None
+    ext = os.path.splitext(abs_path)[1].lower()
+    if ext not in _TU_SOURCE_EXT:
+        return None
+    if abs_path in tu_files:
+        return None
+    return BuildExcluded(line=0, summary="not in compile_commands.json")
+
+
+__all__ = ["BuildExcluded", "detect_build_excluded", "tu_membership_excluded"]

--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -39,9 +39,9 @@ from .call_graph import (
     extract_call_graph_rust,
 )
 from .diff import compare_inventories
-from core.build.macro_config import extract_macro_config
+from core.build.macro_config import extract_build_tus, extract_macro_config
 from .dead_scope import detect_dead_scopes
-from .build_membership import detect_build_excluded
+from .build_membership import detect_build_excluded, tu_membership_excluded
 from .module_load_abort import detect_module_load_abort
 from .translation_view import detect_macro_call_targets, preprocess_view
 
@@ -164,7 +164,18 @@ def build_inventory(
     macro_config = extract_macro_config(target_path)
     if allow_unreachable:
         macro_config = None
+    # Translation-unit set (compile_commands membership), built once for the
+    # C/C++ build-membership witness. A witness record (not a view transform),
+    # so — like the Go //go:build detector — it is NOT disabled under
+    # allow_unreachable; the surface-only consumers ignore it in that mode.
+    build_tus = extract_build_tus(target_path)
     cfg_fp = macro_config.fingerprint() if macro_config else ""
+    # Fold the TU set into the cache key: a compile_commands change (a file
+    # added to / removed from the build) must invalidate cached build_excluded
+    # marks even when file contents are unchanged.
+    if build_tus:
+        cfg_fp += "|tu=" + hashlib.sha256(
+            "\0".join(sorted(build_tus)).encode("utf-8")).hexdigest()[:16]
 
     if output_dir is None:
         output_dir = str(default_cache_dir(
@@ -231,7 +242,7 @@ def build_inventory(
                 executor.submit(
                     _process_single_file, fp, target, exclude_patterns,
                     skip_generated, old_files_by_path, allow_unreachable,
-                    macro_config,
+                    macro_config, build_tus,
                 ): fp
                 for fp in file_list
             }
@@ -261,7 +272,7 @@ def build_inventory(
             _collect_result(
                 _process_single_file(filepath, target, exclude_patterns,
                                      skip_generated, old_files_by_path,
-                                     allow_unreachable, macro_config)
+                                     allow_unreachable, macro_config, build_tus)
             )
 
     # Sort for consistent output
@@ -478,6 +489,7 @@ def _process_single_file(
     old_files: Dict[str, Any] = None,
     allow_unreachable: bool = False,
     macro_config: Optional[object] = None,
+    build_tus: Optional[frozenset] = None,
 ) -> Optional[Dict[str, Any]]:
     """Process a single file for the inventory.
 
@@ -702,6 +714,20 @@ def _process_single_file(
                 'line': excluded.line,
                 'summary': excluded.summary,
             }
+        # C/C++ build-membership: a source TU absent from compile_commands.json
+        # is not compiled → dead. Whole-file, heuristic. Only when a
+        # content-based detector above didn't already fire. Headers are exempt
+        # (tu_membership_excluded checks the extension). Path resolved to match
+        # the resolved TU-set entries.
+        if 'build_excluded' not in record and build_tus is not None:
+            tu_excluded = tu_membership_excluded(
+                str(filepath.resolve()), build_tus,
+            )
+            if tu_excluded is not None:
+                record['build_excluded'] = {
+                    'line': tu_excluded.line,
+                    'summary': tu_excluded.summary,
+                }
         return record
 
     except Exception as e:

--- a/core/inventory/tests/test_build_membership.py
+++ b/core/inventory/tests/test_build_membership.py
@@ -55,3 +55,46 @@ def test_non_go_languages_return_none():
 
 def test_empty_content():
     assert detect_build_excluded("go", "") is None
+
+
+# --- C/C++ translation-unit membership (compile_commands) ------------------
+
+def test_tu_membership_none_when_no_manifest():
+    from core.inventory.build_membership import tu_membership_excluded
+    assert tu_membership_excluded("/p/x.c", None) is None
+
+
+def test_tu_membership_source_absent_is_excluded():
+    from core.inventory.build_membership import (
+        tu_membership_excluded, BuildExcluded,
+    )
+    r = tu_membership_excluded("/p/unbuilt.c", frozenset({"/p/built.c"}))
+    assert isinstance(r, BuildExcluded)
+    assert r.summary == "not in compile_commands.json"
+
+
+def test_tu_membership_source_present_not_excluded():
+    from core.inventory.build_membership import tu_membership_excluded
+    assert tu_membership_excluded(
+        "/p/built.c", frozenset({"/p/built.c"})) is None
+
+
+def test_tu_membership_headers_exempt():
+    # Headers are never TUs — absent from compile_commands but reachable via
+    # the .c files that #include them. Must never be excluded by membership.
+    from core.inventory.build_membership import tu_membership_excluded
+    for h in ("/p/u.h", "/p/u.hpp", "/p/u.hh", "/p/u.hxx"):
+        assert tu_membership_excluded(h, frozenset({"/p/built.c"})) is None, h
+
+
+def test_tu_membership_non_c_exempt():
+    from core.inventory.build_membership import tu_membership_excluded
+    for other in ("/p/a.py", "/p/a.go", "/p/a.rs", "/p/a.txt"):
+        assert tu_membership_excluded(other, frozenset({"/p/b.c"})) is None
+
+
+def test_tu_membership_cpp_source_extensions_covered():
+    from core.inventory.build_membership import tu_membership_excluded
+    for ext in (".cc", ".cpp", ".cxx", ".c++", ".m", ".mm"):
+        assert tu_membership_excluded(
+            f"/p/x{ext}", frozenset({"/p/y.c"})) is not None, ext

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -867,3 +867,54 @@ class TestConfigAwareView:
         # Empty fingerprint must hash identically to the no-arg call so
         # non-C projects' existing caches are untouched.
         assert default_cache_dir(str(tmp_path), config_fingerprint="") == d_plain
+
+
+class TestCppTuMembership:
+    """C/C++ build-membership: a source TU absent from compile_commands.json is
+    marked build_excluded (heuristic); headers are exempt; no manifest → never
+    fires. Asserts the file-level record (set pre-extraction) so it holds on
+    both extractor paths."""
+
+    def _be_map(self, tmp_path, with_manifest):
+        import json
+        (tmp_path / "built.c").write_text("int f(void){ return 0; }\n")
+        (tmp_path / "unbuilt.c").write_text("int g(void){ return 0; }\n")
+        (tmp_path / "util.h").write_text("static inline int h(void){ return 0; }\n")
+        if with_manifest:
+            (tmp_path / "compile_commands.json").write_text(json.dumps([
+                {"directory": str(tmp_path), "file": "built.c",
+                 "arguments": ["cc", "-c", "built.c"]},
+            ]))
+        inv = build_inventory(str(tmp_path), str(tmp_path / "out"))
+        return {f["path"]: ("build_excluded" in f) for f in inv["files"]}
+
+    def test_unbuilt_excluded_built_and_header_not(self, tmp_path):
+        be = self._be_map(tmp_path, with_manifest=True)
+        assert be.get("unbuilt.c") is True     # absent from manifest → excluded
+        assert be.get("built.c") is False      # in manifest → not excluded
+        assert be.get("util.h") is False       # header exempt — never a TU
+
+    def test_no_manifest_never_excludes(self, tmp_path):
+        be = self._be_map(tmp_path, with_manifest=False)
+        assert not any(be.values())            # membership unknown → never fire
+
+    def test_manifest_change_invalidates_persistent_cache(self, tmp_path):
+        # Same file content, default persistent (TU-fingerprint-keyed) cache:
+        # adding unbuilt.c to the manifest must drop its build_excluded mark.
+        (tmp_path / "built.c").write_text("int f(void){ return 0; }\n")
+        (tmp_path / "unbuilt.c").write_text("int g(void){ return 0; }\n")
+        cc = tmp_path / "compile_commands.json"
+        cc.write_text(json.dumps([{"directory": str(tmp_path), "file": "built.c",
+                                   "arguments": ["cc", "-c", "built.c"]}]))
+        inv1 = build_inventory(str(tmp_path))
+        assert {f["path"]: ("build_excluded" in f)
+                for f in inv1["files"]}.get("unbuilt.c") is True
+        cc.write_text(json.dumps([
+            {"directory": str(tmp_path), "file": "built.c",
+             "arguments": ["cc", "-c", "built.c"]},
+            {"directory": str(tmp_path), "file": "unbuilt.c",
+             "arguments": ["cc", "-c", "unbuilt.c"]},
+        ]))
+        inv2 = build_inventory(str(tmp_path))
+        assert {f["path"]: ("build_excluded" in f)
+                for f in inv2["files"]}.get("unbuilt.c") is False


### PR DESCRIPTION
A C/C++ source translation unit absent from the project's compile_commands.json is not compiled in that build, so every function in it is dead — but the entry / call-graph analyses treated it as ordinary source. Extend the existing heuristic `build_excluded` witness to cover it.

- core/build/macro_config.py: `extract_build_tus(target)` → the set of absolute TU paths in compile_commands.json (resolved to match the builder's file paths), or `None` when there is no parseable, non-empty manifest (→ build membership UNKNOWN; never fire on absence-of-evidence; an empty manifest is treated as unknown, not "everything excluded").
- core/inventory/build_membership.py: `tu_membership_excluded(abs_path, tu_files)` — a SOURCE-TU extension (.c/.cc/.cpp/.cxx/.m/.mm) not in the set → build_excluded. HEADERS ARE EXEMPT: a .h/.hpp is never a TU (never in compile_commands) but its functions are reachable via the .c files that `#include` it — so headers (and non-C/C++ files) are never excluded by membership.
- core/inventory/builder.py: build the TU set once per inventory; mark each C/C++ source not in it build_excluded (only when a content-based detector didn't already fire); fold the TU-set fingerprint into the cache key so a compile_commands change (a file added to / removed from the build) invalidates cached marks even when file contents are unchanged.

Heuristic / surface-only (the manifest may be partial; a forced or out-of-tree build could include the file) — it feeds the existing build_excluded witness, which never hard-suppresses. Verified on a freshly-built inventory (both extractor paths): an unbuilt .c is marked excluded, a built .c and a header are not, a manifest-less tree never fires, and a manifest change re-includes a now-built source. Tests cover the extractor (relative/absolute/empty/malformed manifests), the witness (header + non-C exemption, present/absent), and the builder record + cache invalidation, on both the tree-sitter and stdlib paths.