### PR TITLE
feat(reachability): Rust crate-module membership (mod-tree) build_excluded

### DIFF
--- a/core/build/rust_modules.py
+++ b/core/build/rust_modules.py
@@ -1,0 +1,133 @@
+"""Resolve a Rust crate's module tree → the set of compiled ``.rs`` files.
+
+Rust only compiles a source file if it is reachable from a crate root through
+explicit ``mod`` declarations (or ``#[path]`` / ``include!``). A ``.rs`` file in
+the project that no crate root reaches via the mod tree is **not part of the
+crate** — never compiled, so every function in it is dead. This is the Rust
+analog of C/C++ translation-unit membership (compile_commands).
+
+:func:`extract_rust_crate_modules` returns the set of absolute ``.rs`` paths
+reachable from the crate's roots, or ``None`` when membership can't be
+determined (no ``Cargo.toml``, or no recognizable crate root — e.g. a bare
+workspace root). ``None`` means UNKNOWN: the build-membership witness must not
+fire.
+
+Heuristic / surface-only, like the C/C++ counterpart. The mod scan is regex
+based (no tree-sitter dependency, so it works on every CI path), and errs
+toward INCLUSION: a missed ``mod`` edge under-counts the reachable set, which
+at worst marks a genuinely-compiled file build_excluded — and since the witness
+only demotes/surfaces (never hard-suppresses), that is noise, not a false
+negative. ``#[path]`` and per-target path overrides in ``Cargo.toml`` and
+workspaces are best-effort; unresolved cases stay conservative.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# A FILE module declaration: ``mod foo;`` (ends with ``;``), optionally preceded
+# by an inline ``#[path = "…"]`` and visibility. Inline modules (``mod foo {``)
+# declare no file, so the trailing ``;`` is required. Attributes/visibility
+# before ``mod`` are tolerated by anchoring only on the ``mod NAME ;`` shape.
+_MOD_DECL = re.compile(
+    r'(?:#\[\s*path\s*=\s*"([^"]*)"\s*\]\s*)?'      # optional #[path="..."]
+    r'(?:pub\s*(?:\([^)]*\)\s*)?)?'                  # optional pub / pub(...)
+    r'\bmod\s+([A-Za-z_]\w*)\s*;',
+)
+_LINE_COMMENT = re.compile(r"//[^\n]*")
+_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+_SPECIAL_ROOT_NAMES = frozenset({"lib.rs", "main.rs", "mod.rs"})
+
+
+def _strip_comments(text: str) -> str:
+    return _LINE_COMMENT.sub("", _BLOCK_COMMENT.sub("", text))
+
+
+def _crate_roots(target: Path) -> List[Path]:
+    """Default-layout crate roots. Path overrides in Cargo.toml and workspace
+    members are not resolved (best-effort); missing a root only causes
+    conservative noise, never a false negative."""
+    roots: List[Path] = []
+    src = target / "src"
+    for name in ("lib.rs", "main.rs"):
+        p = src / name
+        if p.is_file():
+            roots.append(p)
+    for sub in ("bin",):
+        d = src / sub
+        if d.is_dir():
+            roots.extend(sorted(d.glob("*.rs")))
+    for d_name in ("examples", "tests", "benches"):
+        d = target / d_name
+        if d.is_dir():
+            roots.extend(sorted(d.glob("*.rs")))
+    build_rs = target / "build.rs"
+    if build_rs.is_file():
+        roots.append(build_rs)
+    return roots
+
+
+def _module_base_dir(parent_file: Path) -> Path:
+    """Directory Rust searches for a child ``mod`` of ``parent_file``.
+    ``lib.rs`` / ``main.rs`` / ``mod.rs`` search their own directory; any other
+    module file ``foo.rs`` searches the ``foo/`` subdirectory."""
+    if parent_file.name in _SPECIAL_ROOT_NAMES:
+        return parent_file.parent
+    return parent_file.parent / parent_file.stem
+
+
+def _resolve_child(parent_file: Path, mod_name: str,
+                   path_attr: Optional[str]) -> Optional[Path]:
+    if path_attr:
+        cand = (parent_file.parent / path_attr)
+        return cand if cand.is_file() else None
+    base = _module_base_dir(parent_file)
+    for cand in (base / f"{mod_name}.rs", base / mod_name / "mod.rs"):
+        if cand.is_file():
+            return cand
+    return None
+
+
+def _file_mods(file: Path) -> List[Tuple[Optional[str], str]]:
+    try:
+        text = _strip_comments(file.read_text(errors="replace"))
+    except OSError:
+        return []
+    return [(m.group(1), m.group(2)) for m in _MOD_DECL.finditer(text)]
+
+
+def extract_rust_crate_modules(target: Path) -> Optional[frozenset]:
+    """Set of absolute ``.rs`` paths compiled into the crate(s) under
+    ``target`` (resolved to match the inventory builder's paths), or ``None``
+    when membership is unknown (no ``Cargo.toml`` / no crate root found)."""
+    target = Path(target)
+    if not target.is_dir() or not (target / "Cargo.toml").is_file():
+        return None
+    roots = _crate_roots(target)
+    if not roots:
+        return None
+    reachable = set()
+    queue: List[Path] = list(roots)
+    while queue:
+        f = queue.pop()
+        try:
+            rf = f.resolve()
+        except OSError:
+            rf = f
+        key = str(rf)
+        if key in reachable or not f.is_file():
+            continue
+        reachable.add(key)
+        for path_attr, mod_name in _file_mods(f):
+            child = _resolve_child(f, mod_name, path_attr)
+            if child is not None:
+                queue.append(child)
+    return frozenset(reachable) if reachable else None
+
+
+__all__ = ["extract_rust_crate_modules"]

--- a/core/build/tests/test_rust_modules.py
+++ b/core/build/tests/test_rust_modules.py
@@ -1,0 +1,98 @@
+"""Tests for Rust crate-module-tree membership resolution."""
+
+from __future__ import annotations
+
+from core.build.rust_modules import extract_rust_crate_modules
+
+_CARGO = '[package]\nname = "x"\nversion = "0.1.0"\n'
+
+
+def _crate(tmp_path, files):
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+
+
+def _r(tmp_path, rel):
+    return str((tmp_path / rel).resolve())
+
+
+def test_none_without_cargo_toml(tmp_path):
+    _crate(tmp_path, {"src/lib.rs": "pub fn a(){}\n"})
+    assert extract_rust_crate_modules(tmp_path) is None  # not a crate → unknown
+
+
+def test_reachable_modules_from_lib_root(tmp_path):
+    _crate(tmp_path, {
+        "Cargo.toml": _CARGO,
+        "src/lib.rs": "mod util;\nmod net;\n",
+        "src/util.rs": "",               # foo.rs form
+        "src/net/mod.rs": "",            # foo/mod.rs form
+        "src/orphan.rs": "",             # not declared anywhere
+    })
+    mods = extract_rust_crate_modules(tmp_path)
+    assert _r(tmp_path, "src/lib.rs") in mods
+    assert _r(tmp_path, "src/util.rs") in mods
+    assert _r(tmp_path, "src/net/mod.rs") in mods
+    assert _r(tmp_path, "src/orphan.rs") not in mods
+
+
+def test_nested_mod_uses_stem_subdir(tmp_path):
+    # A non-mod.rs module file foo.rs searches the foo/ subdirectory for its
+    # own submodules (Rust 2018 layout).
+    _crate(tmp_path, {
+        "Cargo.toml": _CARGO,
+        "src/main.rs": "mod foo;\n",
+        "src/foo.rs": "mod bar;\n",
+        "src/foo/bar.rs": "",
+    })
+    mods = extract_rust_crate_modules(tmp_path)
+    assert _r(tmp_path, "src/foo/bar.rs") in mods
+
+
+def test_path_attribute_override(tmp_path):
+    _crate(tmp_path, {
+        "Cargo.toml": _CARGO,
+        "src/lib.rs": '#[path = "custom/thing.rs"]\nmod thing;\n',
+        "src/custom/thing.rs": "",
+    })
+    mods = extract_rust_crate_modules(tmp_path)
+    assert _r(tmp_path, "src/custom/thing.rs") in mods
+
+
+def test_inline_mod_is_not_a_file(tmp_path):
+    # `mod inner { … }` (no trailing ;) declares no file — must not be treated
+    # as a file mod, and must not crash.
+    _crate(tmp_path, {
+        "Cargo.toml": _CARGO,
+        "src/lib.rs": "mod inner { pub fn z(){} }\nmod real;\n",
+        "src/real.rs": "",
+    })
+    mods = extract_rust_crate_modules(tmp_path)
+    assert _r(tmp_path, "src/real.rs") in mods
+
+
+def test_bin_and_examples_are_roots(tmp_path):
+    _crate(tmp_path, {
+        "Cargo.toml": _CARGO,
+        "src/bin/tool.rs": "fn main(){}\n",
+        "examples/demo.rs": "fn main(){}\n",
+        "src/orphan.rs": "",          # no lib/main root reaches it
+    })
+    mods = extract_rust_crate_modules(tmp_path)
+    assert _r(tmp_path, "src/bin/tool.rs") in mods
+    assert _r(tmp_path, "examples/demo.rs") in mods
+    assert _r(tmp_path, "src/orphan.rs") not in mods
+
+
+def test_commented_mod_ignored(tmp_path):
+    _crate(tmp_path, {
+        "Cargo.toml": _CARGO,
+        "src/lib.rs": "// mod ghost;\n/* mod ghost2; */\nmod real;\n",
+        "src/real.rs": "",
+        "src/ghost.rs": "",
+    })
+    mods = extract_rust_crate_modules(tmp_path)
+    assert _r(tmp_path, "src/real.rs") in mods
+    assert _r(tmp_path, "src/ghost.rs") not in mods

--- a/core/inventory/build_membership.py
+++ b/core/inventory/build_membership.py
@@ -141,4 +141,36 @@ def tu_membership_excluded(
     return BuildExcluded(line=0, summary="not in compile_commands.json")
 
 
-__all__ = ["BuildExcluded", "detect_build_excluded", "tu_membership_excluded"]
+def crate_module_excluded(
+    abs_path: str, crate_modules: Optional[frozenset],
+) -> Optional[BuildExcluded]:
+    """Rust crate-module-membership witness: a ``.rs`` file not reachable via
+    the ``mod`` tree from any crate root is not part of the crate — never
+    compiled, so every function in it is dead. Heuristic / surface-only (the
+    mod scan is best-effort), so it only demotes / surfaces.
+
+    Returns ``None`` (no exclusion) when:
+      * ``crate_modules`` is ``None`` — membership unknown (no Cargo.toml / no
+        crate root), so never fire on absence-of-evidence;
+      * ``abs_path`` is not a ``.rs`` file;
+      * ``abs_path`` IS in the crate.
+
+    ``abs_path`` must be resolved to match the resolved
+    :func:`core.build.rust_modules.extract_rust_crate_modules` set.
+    """
+    if crate_modules is None:
+        return None
+    if not abs_path.endswith(".rs"):
+        return None
+    if abs_path in crate_modules:
+        return None
+    return BuildExcluded(
+        line=0, summary="not reachable from any crate root (no mod path)")
+
+
+__all__ = [
+    "BuildExcluded",
+    "detect_build_excluded",
+    "tu_membership_excluded",
+    "crate_module_excluded",
+]

--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -40,8 +40,13 @@ from .call_graph import (
 )
 from .diff import compare_inventories
 from core.build.macro_config import extract_build_tus, extract_macro_config
+from core.build.rust_modules import extract_rust_crate_modules
 from .dead_scope import detect_dead_scopes
-from .build_membership import detect_build_excluded, tu_membership_excluded
+from .build_membership import (
+    crate_module_excluded,
+    detect_build_excluded,
+    tu_membership_excluded,
+)
 from .module_load_abort import detect_module_load_abort
 from .translation_view import detect_macro_call_targets, preprocess_view
 
@@ -169,13 +174,18 @@ def build_inventory(
     # so — like the Go //go:build detector — it is NOT disabled under
     # allow_unreachable; the surface-only consumers ignore it in that mode.
     build_tus = extract_build_tus(target_path)
+    # Rust crate-module set (mod-tree membership), same role for .rs sources.
+    crate_modules = extract_rust_crate_modules(target_path)
     cfg_fp = macro_config.fingerprint() if macro_config else ""
-    # Fold the TU set into the cache key: a compile_commands change (a file
-    # added to / removed from the build) must invalidate cached build_excluded
-    # marks even when file contents are unchanged.
+    # Fold the membership sets into the cache key: a compile_commands / mod-tree
+    # change (a file added to / removed from the build) must invalidate cached
+    # build_excluded marks even when file contents are unchanged.
     if build_tus:
         cfg_fp += "|tu=" + hashlib.sha256(
             "\0".join(sorted(build_tus)).encode("utf-8")).hexdigest()[:16]
+    if crate_modules:
+        cfg_fp += "|rs=" + hashlib.sha256(
+            "\0".join(sorted(crate_modules)).encode("utf-8")).hexdigest()[:16]
 
     if output_dir is None:
         output_dir = str(default_cache_dir(
@@ -242,7 +252,7 @@ def build_inventory(
                 executor.submit(
                     _process_single_file, fp, target, exclude_patterns,
                     skip_generated, old_files_by_path, allow_unreachable,
-                    macro_config, build_tus,
+                    macro_config, build_tus, crate_modules,
                 ): fp
                 for fp in file_list
             }
@@ -272,7 +282,8 @@ def build_inventory(
             _collect_result(
                 _process_single_file(filepath, target, exclude_patterns,
                                      skip_generated, old_files_by_path,
-                                     allow_unreachable, macro_config, build_tus)
+                                     allow_unreachable, macro_config, build_tus,
+                                     crate_modules)
             )
 
     # Sort for consistent output
@@ -490,6 +501,7 @@ def _process_single_file(
     allow_unreachable: bool = False,
     macro_config: Optional[object] = None,
     build_tus: Optional[frozenset] = None,
+    crate_modules: Optional[frozenset] = None,
 ) -> Optional[Dict[str, Any]]:
     """Process a single file for the inventory.
 
@@ -727,6 +739,17 @@ def _process_single_file(
                 record['build_excluded'] = {
                     'line': tu_excluded.line,
                     'summary': tu_excluded.summary,
+                }
+        # Rust crate-module membership: a .rs not reachable via the mod tree
+        # from any crate root is not compiled → dead. Whole-file, heuristic.
+        if 'build_excluded' not in record and crate_modules is not None:
+            rs_excluded = crate_module_excluded(
+                str(filepath.resolve()), crate_modules,
+            )
+            if rs_excluded is not None:
+                record['build_excluded'] = {
+                    'line': rs_excluded.line,
+                    'summary': rs_excluded.summary,
                 }
         return record
 

--- a/core/inventory/tests/test_build_membership.py
+++ b/core/inventory/tests/test_build_membership.py
@@ -98,3 +98,31 @@ def test_tu_membership_cpp_source_extensions_covered():
     for ext in (".cc", ".cpp", ".cxx", ".c++", ".m", ".mm"):
         assert tu_membership_excluded(
             f"/p/x{ext}", frozenset({"/p/y.c"})) is not None, ext
+
+
+# --- Rust crate-module membership ------------------------------------------
+
+def test_crate_module_none_when_unknown():
+    from core.inventory.build_membership import crate_module_excluded
+    assert crate_module_excluded("/p/x.rs", None) is None
+
+
+def test_crate_module_orphan_excluded():
+    from core.inventory.build_membership import (
+        crate_module_excluded, BuildExcluded,
+    )
+    r = crate_module_excluded("/p/orphan.rs", frozenset({"/p/lib.rs"}))
+    assert isinstance(r, BuildExcluded)
+    assert "mod path" in r.summary
+
+
+def test_crate_module_in_tree_not_excluded():
+    from core.inventory.build_membership import crate_module_excluded
+    assert crate_module_excluded(
+        "/p/lib.rs", frozenset({"/p/lib.rs"})) is None
+
+
+def test_crate_module_non_rs_exempt():
+    from core.inventory.build_membership import crate_module_excluded
+    for other in ("/p/a.c", "/p/a.go", "/p/a.py"):
+        assert crate_module_excluded(other, frozenset({"/p/lib.rs"})) is None

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -918,3 +918,48 @@ class TestCppTuMembership:
         inv2 = build_inventory(str(tmp_path))
         assert {f["path"]: ("build_excluded" in f)
                 for f in inv2["files"]}.get("unbuilt.c") is False
+
+
+class TestRustCrateMembership:
+    """Rust crate-module membership: a .rs not reachable via the mod tree from
+    any crate root is marked build_excluded; no Cargo.toml → never fires.
+    Record-level (set pre-extraction) so it holds on both extractor paths."""
+
+    def _be_map(self, tmp_path, with_cargo):
+        (tmp_path / "src").mkdir()
+        if with_cargo:
+            (tmp_path / "Cargo.toml").write_text(
+                '[package]\nname = "x"\nversion = "0.1.0"\n')
+        (tmp_path / "src" / "lib.rs").write_text("mod util;\npub fn api(){}\n")
+        (tmp_path / "src" / "util.rs").write_text("pub fn helper(){}\n")
+        (tmp_path / "src" / "orphan.rs").write_text("pub fn dead(){}\n")
+        inv = build_inventory(str(tmp_path), str(tmp_path / "out"))
+        return {f["path"]: ("build_excluded" in f)
+                for f in inv["files"] if f["path"].endswith(".rs")}
+
+    def test_orphan_excluded_intree_not(self, tmp_path):
+        be = self._be_map(tmp_path, with_cargo=True)
+        assert be.get("src/orphan.rs") is True   # no mod path → excluded
+        assert be.get("src/lib.rs") is False      # crate root
+        assert be.get("src/util.rs") is False     # reached via `mod util;`
+
+    def test_no_cargo_never_excludes(self, tmp_path):
+        be = self._be_map(tmp_path, with_cargo=False)
+        assert not any(be.values())               # not a crate → unknown
+
+    def test_mod_tree_change_invalidates_persistent_cache(self, tmp_path):
+        # Same orphan.rs content, default persistent (mod-fingerprint-keyed)
+        # cache: adding `mod orphan;` to lib.rs must drop its build_excluded.
+        (tmp_path / "src").mkdir()
+        (tmp_path / "Cargo.toml").write_text(
+            '[package]\nname = "x"\nversion = "0.1.0"\n')
+        (tmp_path / "src" / "lib.rs").write_text("mod util;\n")
+        (tmp_path / "src" / "util.rs").write_text("")
+        (tmp_path / "src" / "orphan.rs").write_text("pub fn d(){}\n")
+        inv1 = build_inventory(str(tmp_path))
+        assert {f["path"]: ("build_excluded" in f)
+                for f in inv1["files"]}.get("src/orphan.rs") is True
+        (tmp_path / "src" / "lib.rs").write_text("mod util;\nmod orphan;\n")
+        inv2 = build_inventory(str(tmp_path))
+        assert {f["path"]: ("build_excluded" in f)
+                for f in inv2["files"]}.get("src/orphan.rs") is False


### PR DESCRIPTION
A Rust ``.rs`` file is compiled only if a crate root reaches it through the ``mod`` tree. A source file in the project that no crate root reaches is not part of the crate — never compiled, so every function in it is dead. The entry / call-graph analyses treated it as ordinary source. This is the Rust analog of C/C++ translation-unit membership; it feeds the existing heuristic ``build_excluded`` witness.

- core/build/rust_modules.py (new): ``extract_rust_crate_modules(target)`` → the set of absolute ``.rs`` paths reachable from the crate roots (``src/lib.rs``, ``src/main.rs``, ``src/bin/*``, ``examples|tests|benches/*``, ``build.rs``) by following file ``mod name;`` declarations (and inline ``#[path = "…"]``) transitively, with the mod.rs-vs-name.rs / stem-subdir resolution rules. ``None`` when membership is unknown (no ``Cargo.toml`` / no crate root — e.g. a bare workspace root): the witness must not fire.
- core/inventory/build_membership.py: ``crate_module_excluded(abs_path, crate_modules)`` — a ``.rs`` not in the reachable set → build_excluded; ``None`` for non-``.rs`` files, in-crate files, or unknown membership.
- core/inventory/builder.py: build the crate-module set once; mark each unreached ``.rs`` build_excluded (when an earlier detector didn't fire); fold its fingerprint into the cache key so a mod-tree change re-includes a now-reachable file even when contents are unchanged.

Heuristic / surface-only, and the regex mod-scan errs toward INCLUSION (a missed ``mod`` edge under-counts reachability → at worst marks a compiled file build_excluded, which only adds noise since the witness never hard-suppresses — never a false negative). Verified on a freshly-built inventory (both extractor paths): an orphaned ``.rs`` is excluded, crate-root and mod-declared files are not, a non-Cargo tree never fires, and a mod-tree change re-includes a now-reachable file. Inert on trees with no crate root (existing behaviour unchanged).

``#[cfg(feature = "…")]`` resolution is intentionally NOT included: Cargo features are additive (a non-default feature can be enabled by ``--features`` or any dependent), so "absent from Cargo.toml defaults" does not prove "disabled" — it can't be resolved soundly without a build-time cfg manifest, and the only statically-false case (``#[cfg(any())]``) is already covered by the lexical-dead witness. Deferred until a resolved-cfg source exists.