### PR TITLE
feat(sca): corridor-preserving pins + bounded downgrade remediation

### DIFF
--- a/packages/sca/harden.py
+++ b/packages/sca/harden.py
@@ -85,6 +85,10 @@ class HardenCandidate:
       - ``degraded_safety``  — no fully-clean version exists; promoted
                                 the version with fewest residual
                                 advisories (gated behind ``--allow-degraded``)
+      - ``downgraded_safety`` — no clean version exists at/above the pin;
+                                bounded downgrade to the highest clean
+                                version >= the recorded corridor floor
+                                (gated behind ``--allow-degraded``)
       - ``up_to_date``       — already at latest safe in range
       - ``review_required``  — bump exists but crosses a major (gated)
       - ``skipped_loose_pin`` — ``--pin-only`` set + dep is loose
@@ -439,23 +443,36 @@ def _plan_one(
         residual_advs: List[str] = []
         target_status = "promoted"
     else:
-        # No version is fully clean. Best-effort: pick the *least worst*
-        # candidate by (any_in_kev, max_severity, max_epss, count, idx).
-        # KEV-listed advisories are actively exploited in the wild and
-        # outrank everything else; CVSS severity outranks EPSS; EPSS
-        # outranks raw count; idx breaks ties newest-first.
-        ranked_sorted = sorted(
-            enumerate(ranked),
-            key=lambda kv: (int(kv[1].any_in_kev),
-                            kv[1].max_severity,
-                            kv[1].max_epss,
-                            len(kv[1].advisory_ids),
-                            kv[0]),
-        )
-        best = ranked_sorted[0][1]
-        target_version = best.version
-        residual_advs = list(best.advisory_ids)
-        target_status = "degraded_safety"
+        # No clean version exists at/above the pin. Before settling for a
+        # still-vulnerable upgrade, try a BOUNDED DOWNGRADE: the highest
+        # CLEAN version in ``[floor, installed)``, where floor is the
+        # recorded corridor lower bound. This clears the advisory with no
+        # residual risk (the target is clean) at the cost of moving
+        # backwards, so it's surfaced as ``downgraded_safety`` and gated
+        # like degraded promotions (operator opt-in via --allow-degraded).
+        down = _bounded_downgrade(dep, versions, osv=osv, kev=kev, epss=epss)
+        if down is not None:
+            target_version = down
+            residual_advs = []
+            target_status = "downgraded_safety"
+        else:
+            # Nothing clean in either direction. Best-effort: pick the
+            # *least worst* candidate above by (any_in_kev, max_severity,
+            # max_epss, count, idx). KEV-listed advisories are actively
+            # exploited and outrank everything; CVSS severity outranks
+            # EPSS; EPSS outranks raw count; idx breaks ties newest-first.
+            ranked_sorted = sorted(
+                enumerate(ranked),
+                key=lambda kv: (int(kv[1].any_in_kev),
+                                kv[1].max_severity,
+                                kv[1].max_epss,
+                                len(kv[1].advisory_ids),
+                                kv[0]),
+            )
+            best = ranked_sorted[0][1]
+            target_version = best.version
+            residual_advs = list(best.advisory_ids)
+            target_status = "degraded_safety"
 
     cand.to_version = target_version
     cand.cve_remaining = list(residual_advs)
@@ -482,6 +499,12 @@ def _plan_one(
             f"{target_version} with {len(residual_advs)} residual "
             f"advisor{'y' if len(residual_advs) == 1 else 'ies'}: "
             f"{', '.join(residual_advs)}"
+        )
+    elif target_status == "downgraded_safety":
+        cand.detail = (
+            f"no fully-safe version at/above {dep.version}; bounded "
+            f"downgrade to clean {target_version} "
+            f"(>= recorded floor {dep.version_floor})"
         )
 
     # Full safety check — the "harden" promise. Beyond OSV/KEV/EPSS,
@@ -563,6 +586,48 @@ def _versions_above_installed(
         if cmp > 0:
             out.append(v)
     return out
+
+
+def _bounded_downgrade(
+    dep: Dependency,
+    versions: List[str],
+    *,
+    osv: Any, kev: Any, epss: Any,
+) -> Optional[str]:
+    """Highest CLEAN version in ``[floor, installed)``, or None.
+
+    Called when no clean version exists at/above the installed pin: the
+    only safe remediation is to move *down* to the highest version that
+    is (a) ``>=`` the recorded corridor floor, (b) ``<`` the installed
+    pin, and (c) carries no advisories. The floor caps how far down we go
+    — without it a downgrade could reintroduce other problems. PyPI only
+    (uses pep440 comparison); returns None for other ecosystems or when
+    the corridor floor / installed version is unknown.
+    """
+    floor = dep.version_floor
+    installed = dep.version
+    if floor is None or installed is None or dep.ecosystem != "PyPI":
+        return None
+    pool: List[str] = []
+    for v in versions:
+        try:
+            if (pep440.compare(v, floor) >= 0
+                    and pep440.compare(v, installed) < 0):
+                pool.append(v)
+        except Exception:                   # noqa: BLE001
+            continue
+    if not pool:
+        return None
+    ranked = _rank_candidates_by_safety(
+        ecosystem=dep.ecosystem, name=dep.name,
+        candidates=pool, osv=osv, kev=kev, epss=epss,
+    )
+    clean = [r.version for r in ranked if not r.advisory_ids]
+    if not clean:
+        return None
+    import functools
+    # Highest clean version (pep440 descending).
+    return max(clean, key=functools.cmp_to_key(pep440.compare))
 
 
 # Severity ordinal: lower is less bad. ``None`` (advisory has no scored
@@ -997,7 +1062,8 @@ def _count_actionable(
             total += 1
         elif c.status == "review_required" and allow_major_without_review:
             total += 1
-        elif c.status == "degraded_safety" and allow_degraded:
+        elif (c.status in ("degraded_safety", "downgraded_safety")
+              and allow_degraded):
             total += 1
     return total
 
@@ -1026,7 +1092,7 @@ def _apply(
         elif (cand.status == "review_required" and
               allow_major_without_review and cand.to_version):
             pass
-        elif (cand.status == "degraded_safety" and
+        elif (cand.status in ("degraded_safety", "downgraded_safety") and
               allow_degraded and cand.to_version):
             pass
         else:

--- a/packages/sca/models.py
+++ b/packages/sca/models.py
@@ -134,6 +134,16 @@ class Dependency:
                                             # use this as the cluster
                                             # key.
 
+    version_floor: Optional[str] = None     # tightest lower bound
+                                            # (``>=`` / ``>``) from the
+                                            # original specifier — the
+                                            # downgrade floor harden
+                                            # honours when remediating
+                                            # below the current pin.
+    version_ceiling: Optional[str] = None   # tightest upper bound
+                                            # (``<`` / ``<=``) — the
+                                            # upgrade ceiling.
+
     def key(self) -> str:
         """Stable identity for dedup / cross-reference."""
         return f"{self.ecosystem}:{self.name}@{self.version or '*'}"

--- a/packages/sca/parsers/inline_installs/__init__.py
+++ b/packages/sca/parsers/inline_installs/__init__.py
@@ -203,9 +203,16 @@ def _scan_shell_lines(
                 # package names. Skip to avoid emitting bogus deps.
                 continue
             args = sub[m.end():]
-            for name, version, pin in mgr.parse_args(args):
+            for parsed in mgr.parse_args(args):
+                # Most managers yield (name, version, pin); the pip
+                # manager additionally yields (floor, ceiling) corridor
+                # bounds. Unpack defensively so both shapes work.
+                name, version, pin = parsed[0], parsed[1], parsed[2]
+                floor = parsed[3] if len(parsed) > 3 else None
+                ceiling = parsed[4] if len(parsed) > 4 else None
                 deps.append(_make_dep(
                     name=name, version=version, pin_style=pin,
+                    version_floor=floor, version_ceiling=ceiling,
                     ecosystem=mgr.ecosystem,
                     purl_type=mgr.purl_type,
                     purl_namespace=mgr.purl_namespace,
@@ -266,6 +273,8 @@ def _make_dep(
     source_kind: str,
     commented: bool,
     line_no: int,
+    version_floor: Optional[str] = None,
+    version_ceiling: Optional[str] = None,
 ) -> Dependency:
     canon = _canonicalise_name(name, ecosystem)
     purl_base = (
@@ -292,6 +301,8 @@ def _make_dep(
         ),
         commented_out=commented,
         source_kind=source_kind,
+        version_floor=version_floor,
+        version_ceiling=version_ceiling,
     )
 
 

--- a/packages/sca/parsers/inline_installs/_managers.py
+++ b/packages/sca/parsers/inline_installs/_managers.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from typing import Callable, Iterator, List, Optional, Tuple
 
 from ...models import PinStyle
+from ..requirements import _spec_bounds
 
 
 # ---------------------------------------------------------------------------
@@ -112,20 +113,24 @@ def _parse_pip_args(
 
 def _classify_pip_token(
     tok: str,
-) -> Optional[Tuple[str, Optional[str], PinStyle]]:
-    """Map one ``pkg[<spec>...]`` token to ``(name, version, pin_style)``.
+) -> Optional[Tuple[str, Optional[str], PinStyle,
+                    Optional[str], Optional[str]]]:
+    """Map one ``pkg[<spec>...]`` token to
+    ``(name, version, pin_style, floor, ceiling)``.
 
     Splits on the first PEP 508 operator and runs the constraints
-    through ``packaging.specifiers.SpecifierSet``. Returns None when
-    the token doesn't look like a package spec (caller skips silently
-    rather than yielding garbage)."""
+    through ``packaging.specifiers.SpecifierSet``. ``floor`` / ``ceiling``
+    are the safe-corridor bounds harden records (see
+    ``requirements._spec_bounds``). Returns None when the token doesn't
+    look like a package spec (caller skips silently rather than yielding
+    garbage)."""
     m = re.match(rf"^({_NAME_RE})\s*(.*)$", tok)
     if m is None:
         return None
     name = m.group(1)
     rest = m.group(2).strip()
     if not rest:
-        return name, None, PinStyle.WILDCARD
+        return name, None, PinStyle.WILDCARD, None, None
     if not re.match(r"^[<>!~=]", rest):
         return None
     try:
@@ -138,22 +143,32 @@ def _classify_pip_token(
         return _legacy_single_spec(name, rest)
     items = list(spec)
     if not items:
-        return name, None, PinStyle.WILDCARD
+        return name, None, PinStyle.WILDCARD, None, None
+    floor, ceiling = _spec_bounds(spec)
+    # An ``==`` / ``===`` clause pins the version exactly even alongside
+    # range bounds: ``foo>=2.0,==2.7.0,<3.0`` resolves to exactly 2.7.0.
+    # The sibling bounds record the safe corridor (floor for downgrades,
+    # ceiling for upgrades) that harden preserves across runs — the
+    # effective version is the ``==`` operand. Mirrors the requirements
+    # parser's _classify_specifier so both surfaces agree.
+    exact = next(
+        (s for s in items if s.operator in ("==", "===")), None)
+    if exact is not None:
+        return name, exact.version, PinStyle.EXACT, floor, ceiling
     if len(items) == 1:
         only = items[0]
         op = only.operator
         ver = only.version
-        if op in ("==", "==="):
-            return name, ver, PinStyle.EXACT
         if op == "~=":
-            return name, ver, PinStyle.TILDE
-        return name, ver, PinStyle.RANGE
-    return name, None, PinStyle.RANGE
+            return name, ver, PinStyle.TILDE, floor, ceiling
+        return name, ver, PinStyle.RANGE, floor, ceiling
+    return name, None, PinStyle.RANGE, floor, ceiling
 
 
 def _legacy_single_spec(
     name: str, rest: str,
-) -> Optional[Tuple[str, Optional[str], PinStyle]]:
+) -> Optional[Tuple[str, Optional[str], PinStyle,
+                    Optional[str], Optional[str]]]:
     """Pre-``packaging`` fallback for single-specifier shapes only.
 
     Multi-spec rests get rejected (yield None) rather than mangled.
@@ -167,7 +182,9 @@ def _legacy_single_spec(
     pin = PinStyle.EXACT if op in ("==", "===") else (
         PinStyle.TILDE if op == "~=" else PinStyle.RANGE
     )
-    return name, version, pin
+    floor = version if op in (">=", ">") else None
+    ceiling = version if op in ("<", "<=") else None
+    return name, version, pin, floor, ceiling
 
 
 # --- apt ------------------------------------------------------------------

--- a/packages/sca/parsers/requirements.py
+++ b/packages/sca/parsers/requirements.py
@@ -36,11 +36,13 @@ logger = logging.getLogger(__name__)
 try:
     from packaging.requirements import InvalidRequirement, Requirement
     from packaging.specifiers import SpecifierSet
+    from packaging.version import Version
     _AVAILABLE = True
 except ImportError:                       # pragma: no cover — env-dependent
     InvalidRequirement = Exception        # type: ignore[assignment,misc]
     Requirement = None                    # type: ignore[assignment]
     SpecifierSet = None                   # type: ignore[assignment]
+    Version = None                        # type: ignore[assignment]
     _AVAILABLE = False
     logger.warning(
         "sca.parsers.requirements: 'packaging' not installed — requirements*.txt "
@@ -319,6 +321,7 @@ def _parse_requirement_line(
         return None
 
     pin_style, version = _classify_specifier(req.specifier, req.url)
+    version_floor, version_ceiling = _spec_bounds(req.specifier)
     name = req.name
     if req.url:
         if req.url.startswith(_VCS_PREFIXES):
@@ -342,6 +345,8 @@ def _parse_requirement_line(
         direct=True,
         purl=_build_purl(name, version),
         parser_confidence=_confidence(pin_style, version, editable),
+        version_floor=version_floor,
+        version_ceiling=version_ceiling,
         commented_out=commented,
     )
 
@@ -408,20 +413,51 @@ def _classify_specifier(
     items = list(spec)
     if not items:
         return PinStyle.WILDCARD, None
+    # An ``==`` / ``===`` clause pins the version exactly even when it
+    # sits alongside range bounds: ``>=2.0,==2.7.0,<3.0`` resolves to
+    # exactly 2.7.0. The sibling bounds are a deliberate record of the
+    # safe corridor — floor for downgrades, ceiling for upgrades — that
+    # harden preserves across runs. The *effective* version is the
+    # ``==`` operand, so classify the whole spec as EXACT.
+    exact = next(
+        (s for s in items if s.operator in ("==", "===")), None)
+    if exact is not None:
+        return PinStyle.EXACT, exact.version
     if len(items) == 1:
         only = items[0]
         op = only.operator
         ver = only.version
-        if op in ("==", "==="):
-            return PinStyle.EXACT, ver
         if op == "~=":
             return PinStyle.TILDE, ver
-        if op in ("!=",):
-            # Pure exclusion is effectively an unbounded range.
-            return PinStyle.RANGE, ver
-        # >=, <=, >, < — a single bound is still a range.
+        # >=, <=, >, <, != — a single bound is still a range.
         return PinStyle.RANGE, ver
     return PinStyle.RANGE, None
+
+
+def _spec_bounds(spec) -> Tuple[Optional[str], Optional[str]]:
+    """Return ``(floor, ceiling)`` from a ``SpecifierSet``: the tightest
+    lower (``>=`` / ``>``) and upper (``<`` / ``<=``) version bounds, or
+    None when absent.
+
+    harden records these so a future bounded *downgrade* knows how far
+    down is acceptable (floor) and an upgrade knows its ceiling. ``==`` /
+    ``~=`` / ``!=`` clauses pin or exclude — they don't bound the
+    corridor — so they're ignored here.
+    """
+    if spec is None or Version is None:
+        return None, None
+
+    def _key(v: str):
+        try:
+            return Version(v)
+        except Exception:                   # noqa: BLE001
+            return Version("0")
+
+    lowers = [s.version for s in spec if s.operator in (">=", ">")]
+    uppers = [s.version for s in spec if s.operator in ("<", "<=")]
+    floor = max(lowers, key=_key) if lowers else None
+    ceiling = min(uppers, key=_key) if uppers else None
+    return floor, ceiling
 
 
 def _normalise_name(name: str) -> str:

--- a/packages/sca/tests/test_harden_planner.py
+++ b/packages/sca/tests/test_harden_planner.py
@@ -8,7 +8,7 @@ needs_network.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence
 
@@ -659,3 +659,64 @@ def test_registry_stub_without_get_metadata_is_safe() -> None:
         offline=False, allow_major=False,
     )
     assert cand.status == "promoted"
+
+
+# ---------------------------------------------------------------------------
+# Bounded downgrade: no clean version at/above the pin → move DOWN to the
+# highest clean version within the recorded corridor floor.
+# ---------------------------------------------------------------------------
+
+def test_bounded_downgrade_to_highest_clean_within_floor() -> None:
+    """``pkg==2.7.0`` (corridor floor 2.0) where 2.7.0 and everything
+    above is CVE-bearing but 2.5 is clean → bounded downgrade to 2.5."""
+    dep = replace(_dep(pin_style=PinStyle.EXACT, version="2.7.0"),
+                  version_floor="2.0")
+    osv = _FakeOsv({
+        "2.0": [_adv("CVE-A")],     # clean-but-below not needed; CVE anyway
+        "2.7.0": [_adv("CVE-B")],
+        "2.8": [_adv("CVE-C")],
+        "2.9": [_adv("CVE-D")],
+        # 2.5 absent => clean
+    })
+    cand = _plan_one(
+        dep,
+        registries={"PyPI": _FakeRegistry(
+            ["2.0", "2.5", "2.7.0", "2.8", "2.9"])},
+        osv=osv, offline=False, allow_major=False,
+    )
+    assert cand.status == "downgraded_safety", cand.status
+    assert cand.to_version == "2.5"
+    assert "downgrade" in cand.detail.lower()
+
+
+def test_bounded_downgrade_respects_floor() -> None:
+    """A clean version BELOW the floor is not eligible. When nothing in
+    ``[floor, installed)`` is clean, fall back to a degraded upgrade —
+    never a sub-floor downgrade."""
+    dep = replace(_dep(pin_style=PinStyle.EXACT, version="2.7.0"),
+                  version_floor="2.6")
+    osv = _FakeOsv({
+        # only clean version (1.9) is below floor 2.6; the rest carry CVEs
+        "2.7.0": [_adv("CVE-B")],
+        "2.8": [_adv("CVE-C")],
+    })
+    cand = _plan_one(
+        dep,
+        registries={"PyPI": _FakeRegistry(["1.9", "2.7.0", "2.8"])},
+        osv=osv, offline=False, allow_major=False,
+    )
+    assert cand.status == "degraded_safety", cand.status
+
+
+def test_no_downgrade_when_clean_version_above_exists() -> None:
+    """A clean version at/above the pin always wins — never downgrade."""
+    dep = replace(_dep(pin_style=PinStyle.EXACT, version="2.7.0"),
+                  version_floor="2.0")
+    osv = _FakeOsv({"2.7.0": [_adv("CVE-B")]})   # 2.9 clean
+    cand = _plan_one(
+        dep,
+        registries={"PyPI": _FakeRegistry(["2.0", "2.5", "2.7.0", "2.9"])},
+        osv=osv, offline=False, allow_major=False,
+    )
+    assert cand.status == "promoted"
+    assert cand.to_version == "2.9"

--- a/packages/sca/tests/test_inline_install_rewriter.py
+++ b/packages/sca/tests/test_inline_install_rewriter.py
@@ -27,13 +27,27 @@ def test_pypi_pinned_eq() -> None:
     assert new == "RUN pip install django==4.2.10\n"
 
 
-def test_pypi_pinned_gte_normalised_to_eq() -> None:
-    """Range pin gets pinned to exact (harden's whole point)."""
+def test_pypi_lower_bound_floor_preserved() -> None:
+    """A lone lower bound is the downgrade floor — keep it alongside the
+    new exact pin rather than collapsing it away."""
     text = "RUN pip install requests>=2.31.0\n"
     plan = _plan("PyPI", "requests", "2.33.0")
     new, hit, _ = _rewrite_inline_install(text, plan)
     assert hit is True
-    assert new == "RUN pip install requests==2.33.0\n"
+    assert new == "RUN pip install requests>=2.31.0,==2.33.0\n"
+
+
+def test_pypi_quoted_multi_constraint_range_keeps_corridor() -> None:
+    """``'urllib3>=2.0,<3.0'`` → ``'urllib3>=2.0,==2.7.0,<3.0'`` — floor
+    and ceiling are preserved as the safe corridor with the new exact pin
+    slotted between. Still round-trips to up_to_date because the parser
+    now treats an ``==``-bearing spec as EXACT. Regression for the
+    sca-self-bump CI urllib3 stragglers."""
+    text = "RUN pip install 'urllib3>=2.0,<3.0'\n"
+    plan = _plan("PyPI", "urllib3", "2.7.0")
+    new, hit, _ = _rewrite_inline_install(text, plan)
+    assert hit is True
+    assert new == "RUN pip install 'urllib3>=2.0,==2.7.0,<3.0'\n"
 
 
 def test_pypi_unpinned_gets_pin_appended() -> None:
@@ -220,6 +234,63 @@ def test_multiline_only_updates_install_lines() -> None:
     assert "ENV LANG=en_US.UTF-8" in new  # untouched (the `LANG=...` could
                                           # look like a `pkg=ver` but the
                                           # line has no install cmd)
+
+
+def test_apt_multiline_continuation_block_pins_package() -> None:
+    """The sca-self-bump failure: a ``\\``-continued ``apt-get install``
+    block with one package per line (and interspersed ``#`` comments)
+    must pin packages on the *continuation* lines, not just the command
+    line. Mirrors the .devcontainer/Dockerfile block exactly."""
+    text = (
+        "RUN apt-get update \\\n"
+        "    && apt-get install -y --no-install-recommends \\\n"
+        "    #\n"
+        "    # --- Network Tools ---\n"
+        "    curl \\\n"
+        "    git \\\n"
+        "    jq \\\n"
+        "    && apt-get clean \\\n"
+        "    && rm -rf /var/lib/apt/lists/*\n"
+    )
+    plan = _plan("Debian", "curl", "8.20.0-2")
+    new, hit, _ = _rewrite_inline_install(text, plan)
+    assert hit is True
+    assert "    curl=8.20.0-2 \\\n" in new        # continuation line pinned
+    assert "    git \\\n" in new                  # other packages untouched
+    assert "    jq \\\n" in new
+    assert "&& apt-get clean" in new              # post-separator cmd untouched
+    assert "rm -rf /var/lib/apt/lists/*" in new
+
+
+def test_apt_multiline_does_not_rewrite_name_inside_comment() -> None:
+    """A package name appearing inside a ``#`` comment within the
+    continuation block must not be pinned — only the real arg line is."""
+    text = (
+        "RUN apt-get install -y --no-install-recommends \\\n"
+        "    # install git for cloning repos\n"
+        "    git \\\n"
+        "    && apt-get clean\n"
+    )
+    plan = _plan("Debian", "git", "1:2.53.0")
+    new, hit, _ = _rewrite_inline_install(text, plan)
+    assert hit is True
+    assert "    git=1:2.53.0 \\\n" in new                 # arg line pinned
+    assert "    # install git for cloning repos\n" in new  # comment verbatim
+
+
+def test_apt_separator_ends_args_no_false_pin_in_next_command() -> None:
+    """After ``&&`` the install's args are over; a package name that
+    appears in the following command must not be pinned."""
+    text = (
+        "RUN apt-get install -y --no-install-recommends \\\n"
+        "    curl \\\n"
+        "    && echo installing curl done\n"
+    )
+    plan = _plan("Debian", "curl", "8.20.0-2")
+    new, hit, _ = _rewrite_inline_install(text, plan)
+    assert hit is True
+    assert "    curl=8.20.0-2 \\\n" in new            # the arg
+    assert "&& echo installing curl done\n" in new   # echo's 'curl' untouched
 
 
 # ---------------------------------------------------------------------------

--- a/packages/sca/update.py
+++ b/packages/sca/update.py
@@ -1064,12 +1064,12 @@ def _rewrite_requirements_txt(
             # version. If somehow it doesn't, leave the line alone.
             out_lines.append(raw)
             continue
-        new_inner = re.sub(
-            r"^([A-Za-z0-9_\-.]+)\s*[<>=!~]=?[^\s;]+",
-            rf"\g<1>=={plan.target}",
-            line_value,
-            count=1,
-        )
+        # Preserve any range bounds (floor/ceiling) around the new exact
+        # pin instead of collapsing them — they record the safe corridor
+        # for future up/downgrades. Splicing on the match end keeps any
+        # trailing PEP 508 marker (``; python_version >= ...``) intact.
+        new_spec = _pypi_pin_preserving_bounds(m.group(2) or "", plan.target)
+        new_inner = m.group(1) + new_spec + line_value[m.end():]
         new_line = f"{comment_prefix}{new_inner}" if comment_prefix else new_inner
         out_lines.append(raw.replace(stripped, new_line))
         rewrote = True
@@ -1128,6 +1128,15 @@ _INLINE_INSTALL_CMD_RES = {
 }
 
 
+_INLINE_SHELL_SEP_RE = re.compile(r"&&|\|\||;|(?<!\|)\|(?!\|)")
+
+
+def _inline_line_continues(raw: str) -> bool:
+    """True if ``raw`` ends with a shell line-continuation ``\\``
+    (ignoring the trailing newline / whitespace)."""
+    return raw.rstrip().endswith("\\")
+
+
 def _rewrite_inline_install(
     text: str, plan: _PlanEntry,
 ) -> Tuple[str, bool, Optional[str]]:
@@ -1139,20 +1148,29 @@ def _rewrite_inline_install(
     ``npm install foo@X``, etc.) might live.
 
     Strategy:
-      1. Walk the file line by line.
-      2. Skip lines that don't contain a known install command for the
-         plan's ecosystem (avoid false-positive rewrites in comments,
-         echo statements, paths, etc.).
-      3. On candidate lines, run the per-ecosystem version substitution
-         within the args portion. Both pinned and unpinned forms are
-         handled; an unpinned ``pip install pkg`` is rewritten to
-         ``pip install pkg==<target>``.
+      1. Walk the file physical line by line, tracking whether we are
+         inside the *argument region* of a matching install command —
+         a region that spans ``\\``-continuation lines, so a multi-line
+         ``apt-get install -y \\`` … block with one package per line is
+         covered, not just same-line installs.
+      2. On a line carrying the install command, substitute within its
+         same-line args. While inside the continued arg region, each
+         package-on-its-own-line is substituted too.
+      3. ``#`` comment lines inside a continuation are transparent
+         (Docker strips them before the shell runs), so they neither
+         terminate the region nor get rewritten. A shell separator
+         (``&&`` / ``||`` / ``;`` / ``|``) ends the region — a new
+         command starts there.
+      4. Both pinned and unpinned forms are handled; an unpinned
+         ``pip install pkg`` / continuation-line ``pkg`` is rewritten to
+         the pinned form (``pkg==<target>`` / ``pkg=<target>`` /
+         ``pkg@<target>`` per ecosystem).
 
     GHA YAML and devcontainer.json have richer structure (block
     scalars, JSON string fields) but ``run:`` block bodies and JSONC
     string values still parse correctly under line-level processing —
     the substitutions only fire on lines that contain an actual install
-    command keyword.
+    command keyword or sit inside its continued args.
     """
     eco = plan.ecosystem
     cmd_re = _INLINE_INSTALL_CMD_RES.get(eco)
@@ -1169,20 +1187,42 @@ def _rewrite_inline_install(
 
     out_lines: List[str] = []
     rewrote = False
+    in_args = False   # inside a matching install command's continued args
     for raw in text.splitlines(keepends=True):
-        if not cmd_re.search(raw):
-            out_lines.append(raw)
-            continue
         m = cmd_re.search(raw)
-        assert m is not None
-        prefix = raw[: m.end()]
-        rest = raw[m.end():]
-        new_rest, hit = sub_fn(rest, plan.name, plan.target)
-        if hit:
-            rewrote = True
+        if m is not None:
+            # Install command on this physical line: rewrite same-line args.
+            prefix = raw[: m.end()]
+            new_rest, hit = sub_fn(raw[m.end():], plan.name, plan.target)
+            rewrote = rewrote or hit
             out_lines.append(prefix + new_rest)
-        else:
-            out_lines.append(raw)
+            in_args = _inline_line_continues(raw)
+            continue
+        if in_args:
+            if raw.lstrip().startswith("#"):
+                # Docker strips ``#`` comment lines inside a RUN
+                # continuation before the shell sees them, so they
+                # neither carry a package nor break the continuation.
+                out_lines.append(raw)
+                continue
+            sep = _INLINE_SHELL_SEP_RE.search(raw)
+            if sep is not None:
+                # A shell separator ends this install's args; a new
+                # command starts. Only the portion before the separator
+                # is still install args (usually just whitespace here).
+                new_before, hit = sub_fn(
+                    raw[: sep.start()], plan.name, plan.target)
+                rewrote = rewrote or hit
+                out_lines.append(new_before + raw[sep.start():])
+                in_args = False
+                continue
+            # A package token on its own continuation line.
+            new_line, hit = sub_fn(raw, plan.name, plan.target)
+            rewrote = rewrote or hit
+            out_lines.append(new_line)
+            in_args = _inline_line_continues(raw)
+            continue
+        out_lines.append(raw)
     if not rewrote:
         return text, False, (
             f"name {plan.name!r} not found in inline {eco} installs"
@@ -1190,18 +1230,65 @@ def _rewrite_inline_install(
     return "".join(out_lines), True, None
 
 
+_PYPI_CLAUSE_RE = re.compile(r"^\s*(===|==|>=|<=|~=|!=|>|<)\s*(.+?)\s*$")
+
+
+def _pypi_pin_preserving_bounds(spec: str, target: str) -> str:
+    """Return a PEP 440 specifier that pins to ``target`` while keeping
+    any range bounds from ``spec`` as a record of the safe corridor.
+
+    ``spec`` is the specifier text *after* the package name::
+
+        >=2.0,<3.0  ->  >=2.0,==<target>,<3.0   (floor + ceiling kept)
+        >=2.31.0    ->  >=2.31.0,==<target>      (downgrade floor kept)
+        ==2.30.0    ->  ==<target>               (old exact pin replaced)
+        ""/bare     ->  ==<target>
+
+    Bounds (``>=`` ``>`` ``<`` ``<=`` ``!=``) are preserved; existing pin
+    clauses (``==`` ``===`` ``~=``) are dropped and replaced by a single
+    ``==<target>``. The floor lets a future ``degraded_safety`` downgrade
+    know how far down is acceptable; the ceiling stops an auto-jump past
+    a declared major. Assumes ``target`` satisfies the kept bounds —
+    harden's selection honours the corridor (see ``_plan_one``).
+    """
+    lowers, uppers, excludes = [], [], []
+    for part in spec.split(","):
+        cm = _PYPI_CLAUSE_RE.match(part)
+        if cm is None:
+            continue
+        op, ver = cm.group(1), cm.group(2)
+        if op in (">=", ">"):
+            lowers.append(f"{op}{ver}")
+        elif op in ("<", "<="):
+            uppers.append(f"{op}{ver}")
+        elif op == "!=":
+            excludes.append(f"{op}{ver}")
+        # ==, ===, ~= are dropped — replaced by the ==target below.
+    return ",".join(lowers + [f"=={target}"] + uppers + excludes)
+
+
 def _inline_sub_pypi(
     text: str, name: str, new_version: str,
 ) -> Tuple[str, bool]:
-    """``pip install foo==1.0`` / ``pip install foo``."""
+    """``pip install foo==1.0`` / ``pip install 'foo>=2,<3'`` / ``foo``."""
     name_re = re.escape(name)
-    # 1. Pinned form: ``pkg(op)version`` → ``pkg==new``.
-    pinned = re.compile(
-        rf"(?<![A-Za-z0-9._-])({name_re})\s*"
-        rf"(==|>=|<=|~=|>|<|!=)\s*[^\s\\,;\"']+",
+    # 1. Specifier form: ``pkg<spec>`` where <spec> is one or more
+    #    comma-joined PEP 440 clauses. Capture the WHOLE spec so range
+    #    bounds survive the pin (see _pypi_pin_preserving_bounds). ``,``
+    #    is excluded from the version class so clauses split cleanly;
+    #    ``;`` stays excluded to leave PEP 508 markers untouched.
+    spec_re = re.compile(
+        rf"(?<![A-Za-z0-9._-])({name_re})"
+        # Horizontal whitespace only between clauses — ``\s`` would let
+        # the trailing ``\s*`` swallow the line's newline into the spec.
+        rf"((?:[ \t]*(?:===|==|>=|<=|~=|!=|>|<)[ \t]*[^\s\\;\"',]+[ \t]*,?)+)",
         re.IGNORECASE,
     )
-    new_text, n = pinned.subn(rf"\1=={new_version}", text)
+    new_text, n = spec_re.subn(
+        lambda m: m.group(1) + _pypi_pin_preserving_bounds(
+            m.group(2), new_version),
+        text, count=1,
+    )
     if n > 0:
         return new_text, True
     # 2. Bare name (not part of another identifier or version-separated).


### PR DESCRIPTION
harden's inline rewriter now pins packages on backslash-continuation apt-get install lines, not just same-line installs. The devcontainer Dockerfile's multi-line ``apt-get install -y \`` block left 17 packages unpinned, which the sca-self-bump --self-test flagged as a regression; the rewriter walks the continued arg region (comments transparent, a shell separator ends it) and pins each package on its own line.

When pinning a ranged dep, preserve its bounds as a recorded corridor instead of collapsing them: ``>=2.0,<3.0`` -> ``>=2.0,==2.7.0,<3.0``. The floor is the downgrade floor; the ceiling stops an auto-jump past a declared major. Both PyPI parsers (requirements + inline-install) now classify an ==-bearing multi-clause spec as EXACT so the corridor pin round-trips to up_to_date rather than re-reading as an actionable range.

Add a bounded-downgrade remediation: when no clean version exists at or above the installed pin, downgrade to the highest clean version >= the recorded corridor floor (new status downgraded_safety, gated behind --allow-degraded like degraded promotions). Carries the corridor on two new Dependency fields, version_floor / version_ceiling.