### PR TITLE
feat(reachability): Java framework-dispatch entries (Spring/Jakarta beans)

### DIFF
--- a/core/inventory/extractors.py
+++ b/core/inventory/extractors.py
@@ -12,7 +12,7 @@ import re
 import logging
 import warnings
 from dataclasses import dataclass, field, asdict
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +75,10 @@ class FunctionMetadata:
     attributes: List[str] = field(default_factory=list)  # decorators AND annotations
     return_type: Optional[str] = None
     parameters: List[Tuple[str, Optional[str]]] = field(default_factory=list)
+    # Annotations on the ENCLOSING class (Java only): a method carries its
+    # class's stereotype annotations (@Service / @Component / …) so reachability
+    # can treat public methods of a container-managed bean as framework entries.
+    class_attributes: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -851,17 +855,35 @@ class TreeSitterExtractor:
                 logger.warning(f"tree-sitter parse failed for {filepath}: {e}")
                 return []  # Caller will fall back to regex extractor
         functions = []
-        self._walk(_tree.root_node, functions, class_name=None)
+        self._walk(_tree.root_node, functions, class_name=None, class_attributes=())
         return functions
 
-    def _walk(self, node, functions: List[FunctionInfo], class_name: Optional[str]) -> None:
+    def _class_annotations(self, node) -> List[str]:
+        """Annotations declared on a class/interface (Java).
+
+        Reads the class node's ``modifiers`` block, the same shape used for
+        method annotations. Other languages don't put annotations there, so
+        this returns ``[]`` for them.
+        """
+        out: List[str] = []
+        for child in node.children:
+            if child.type == "modifiers":
+                for mod in child.children:
+                    if mod.type in ("marker_annotation", "annotation"):
+                        out.append(mod.text.decode().lstrip("@"))
+        return out
+
+    def _walk(self, node, functions: List[FunctionInfo], class_name: Optional[str],
+              class_attributes: Sequence[str] = ()) -> None:
         for child in node.children:
             if child.type in self.class_types:
                 cname = self._get_name(child)
-                self._walk(child, functions, class_name=cname)
+                self._walk(child, functions, class_name=cname,
+                           class_attributes=self._class_annotations(child))
             elif child.type in ("lexical_declaration", "variable_declaration"):
                 # JS/TS: const foo = () => {} — arrow function inside variable declaration
-                self._walk(child, functions, class_name=class_name)
+                self._walk(child, functions, class_name=class_name,
+                           class_attributes=class_attributes)
                 continue
             elif child.type == "variable_declarator":
                 # JS/TS: const bar = () => {} or const bar = function() {}
@@ -884,7 +906,8 @@ class TreeSitterExtractor:
                             ),
                         ))
                     continue
-                self._walk(child, functions, class_name=class_name)
+                self._walk(child, functions, class_name=class_name,
+                           class_attributes=class_attributes)
                 continue
             elif child.type in self.func_types:
                 # Check for decorated_definition wrapper (Python)
@@ -897,20 +920,24 @@ class TreeSitterExtractor:
                     child = self._find_child(parent, self.func_types) or child
 
                 try:
-                    fi = self._extract_function(child, class_name, attrs)
+                    fi = self._extract_function(child, class_name, attrs, class_attributes)
                     if fi:
                         functions.append(fi)
                 except Exception as e:
                     logger.debug(f"tree-sitter: failed to extract function at line {child.start_point[0]+1}: {e}")
-                self._walk(child, functions, class_name=class_name)
+                self._walk(child, functions, class_name=class_name,
+                           class_attributes=class_attributes)
             elif child.type == "decorated_definition":
                 # Python: walk into decorated definitions
-                self._walk(child, functions, class_name=class_name)
+                self._walk(child, functions, class_name=class_name,
+                           class_attributes=class_attributes)
             else:
-                self._walk(child, functions, class_name=class_name)
+                self._walk(child, functions, class_name=class_name,
+                           class_attributes=class_attributes)
 
     def _extract_function(self, node, class_name: Optional[str],
-                          attrs: List[str]) -> Optional[FunctionInfo]:
+                          attrs: List[str],
+                          class_attributes: Sequence[str] = ()) -> Optional[FunctionInfo]:
         name = self._get_name(node)
         if not name:
             return None
@@ -935,6 +962,7 @@ class TreeSitterExtractor:
                 attributes=attrs,
                 return_type=return_type,
                 parameters=parameters,
+                class_attributes=list(class_attributes),
             ),
         )
 

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -2375,22 +2375,69 @@ _JAVA_SERVLET_METHODS = frozenset({
     "doGet", "doPost", "doPut", "doDelete", "doHead", "doOptions",
     "doTrace", "service", "doFilter", "init", "destroy",
 })
-# JAX-RS / Spring routing annotation tail-names → the method is a route
-# handler dispatched by the web framework.
-_JAVA_ROUTE_ANNOTATIONS = frozenset({
+# Method-level annotation tail-names whose presence marks the method as
+# framework-dispatched: the container / framework invokes it directly, so it
+# needs no in-project caller to be reachable. Only annotations that denote a
+# *no-caller* dispatch belong here — ``@Async`` / ``@Transactional`` are
+# deliberately excluded because they merely wrap a normally-called method
+# (it still has an in-project caller), so treating them as entries would
+# wrongly shield a genuinely-dead async/transactional method from demotion.
+_JAVA_METHOD_DISPATCH_ANNOTATIONS = frozenset({
+    # JAX-RS / Spring MVC routing
     "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH", "Path",
     "RequestMapping", "GetMapping", "PostMapping", "PutMapping",
     "DeleteMapping", "PatchMapping",
+    # Spring bean factory + container lifecycle callbacks
+    "Bean", "PostConstruct", "PreDestroy",
+    # Spring events + scheduling (container-invoked, no in-project caller)
+    "EventListener", "Scheduled",
+    # Message-driven listeners (Spring Messaging / Kafka / Rabbit / JMS / STOMP)
+    "KafkaListener", "RabbitListener", "JmsListener",
+    "MessageMapping", "SubscribeMapping", "StreamListener",
+    # JPA / Hibernate entity lifecycle callbacks (persistence-provider-invoked)
+    "PrePersist", "PostPersist", "PreUpdate", "PostUpdate",
+    "PreRemove", "PostRemove", "PostLoad",
+})
+# Class-level stereotype annotation tail-names. The DI container instantiates
+# the annotated class and dispatches into its PUBLIC methods (via injected
+# references / proxies) with no in-project caller. Private / protected /
+# package-private methods stay reachable only through the static closure from
+# those public entries, so they are NOT promoted here.
+_JAVA_CLASS_STEREOTYPES = frozenset({
+    "Component", "Service", "Repository", "Controller", "RestController",
+    "Configuration", "ControllerAdvice", "RestControllerAdvice",
 })
 
 
-def _java_web_entry(name: str, item: Dict[str, Any]) -> bool:
+def _annotation_tail(annotation: Any) -> str:
+    """``@org.springframework...RequestMapping("/x")`` → ``RequestMapping``.
+
+    Strips a fully-qualified prefix, any argument list, and a leading ``@``
+    (the extractor stores attributes already ``@``-stripped, but be defensive).
+    """
+    return str(annotation).split("(")[0].strip().split(".")[-1].lstrip("@")
+
+
+def _java_framework_entry(name: str, item: Dict[str, Any]) -> bool:
+    """A Java method dispatched by a framework / DI container with no
+    in-project caller — servlet lifecycle method, method-level dispatch
+    annotation, or a public method of a stereotyped (container-managed) class.
+
+    Adding an entry only ever *grows* the reachable set, so this can never
+    suppress real code or demote live code; the worst case is failing to
+    demote a genuinely-dead annotated method (under-claiming dead code).
+    """
     if name in _JAVA_SERVLET_METHODS:
         return True
-    for a in (item.get("metadata") or {}).get("attributes") or []:
-        tail = str(a).split("(")[0].strip().split(".")[-1]
-        if tail in _JAVA_ROUTE_ANNOTATIONS:
+    meta = item.get("metadata") or {}
+    for a in meta.get("attributes") or []:
+        if _annotation_tail(a) in _JAVA_METHOD_DISPATCH_ANNOTATIONS:
             return True
+    # Class stereotype → only the bean's PUBLIC methods are container-dispatched.
+    if "public" in str(meta.get("visibility") or "").split():
+        for a in meta.get("class_attributes") or []:
+            if _annotation_tail(a) in _JAVA_CLASS_STEREOTYPES:
+                return True
     return False
 
 
@@ -2416,11 +2463,13 @@ def _item_is_entry(item: Dict[str, Any], language: str) -> bool:
     # and its call tree are reachable even with no explicit caller.
     if p.has_go_init and name == "init":
         return True
-    # Java web handlers are framework-dispatched entries with no in-project
-    # caller: servlet lifecycle methods by name and JAX-RS / Spring routing
-    # annotations. Without this, live servlet handlers (doPost/doGet) read
-    # not_called and get surface-demoted.
-    if p.has_java_web and _java_web_entry(name, item):
+    # Java framework-dispatched entries with no in-project caller: servlet
+    # lifecycle methods, method-level dispatch annotations (routing, Spring
+    # events/scheduling/messaging, bean factories, JPA callbacks), and public
+    # methods of stereotyped (container-managed) classes. Without this, live
+    # container-managed handlers (doPost, @EventListener, @Service methods)
+    # read not_called and get surface-demoted.
+    if p.has_java_web and _java_framework_entry(name, item):
         return True
     # Visibility/linkage entry signal (only for languages whose model is a
     # closed signal; "" ⇒ a public symbol is NOT reliably an entry, so those

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -1017,3 +1017,99 @@ class TestGoReachability:
         assert verdict("ig.go", "orphan") == "build_excluded"
         assert verdict("island.go", "islA") == "no_path_from_entry"
         assert verdict("live.go", "Exported") == "reachable"   # over-fire control
+
+
+class TestJavaFrameworkEntries:
+    """End-to-end Java framework-dispatch entry coverage. Spring / Jakarta
+    container-managed methods (routes, @EventListener / @Scheduled, @Bean
+    factories, JPA callbacks, and the public methods of @Service / @Component /
+    @RestController beans) have no in-project caller; without modelling them as
+    entries they read not_called and get surface-demoted. Verdicts need the
+    Java call-graph extractor (tree-sitter-java) and skip without it. Adding
+    entries only grows the reachable set, so the controls (a plain class, an
+    @Async / @Transactional method, a private bean method) must stay
+    not_called — that is the FP/FN-safety guard."""
+
+    _FILES = {
+        # @RestController stereotype: public route method = entry; the private
+        # helper is reachable only through the closure from it.
+        "Api.java": ("package x;\n@RestController\npublic class Api {\n"
+                     "  @GetMapping public String handle() { return fmt(); }\n"
+                     "  private String fmt() { return \"x\"; }\n}\n"),
+        # @Service stereotype: an uncalled PUBLIC method is still a bean entry;
+        # the private helper is not.
+        "Svc.java": ("package x;\n@Service\npublic class Svc {\n"
+                     "  public void process() {}\n"
+                     "  private void helper() {}\n}\n"),
+        # method-level dispatch annotations on a plain (non-stereotype) class.
+        "Ev.java": ("package x;\npublic class Ev {\n"
+                    "  @EventListener public void on() {}\n"
+                    "  @Scheduled public void tick() {}\n}\n"),
+        # nested: a @Service INNER class in a plain OUTER class. The inner
+        # public method is a bean entry; the outer plain method (declared after
+        # the inner class) must NOT inherit the inner stereotype.
+        "Nest.java": ("package x;\npublic class Nest {\n"
+                      "  @Service public static class Inner {\n"
+                      "    public void innerBean() {}\n  }\n"
+                      "  public void outerPlain() {}\n}\n"),
+        # controls — must stay not_called:
+        "Ctl.java": ("package x;\npublic class Ctl {\n"
+                     "  @Async public void bg() {}\n"
+                     "  @Transactional public void wr() {}\n"
+                     "  public void dead() {}\n}\n"),
+    }
+
+    def _build(self, tmp_path):
+        for rel, c in self._FILES.items():
+            (tmp_path / rel).write_text(c)
+        return build_inventory(str(tmp_path), str(tmp_path / "out"))
+
+    def test_java_stdlib_path_inert(self, tmp_path, monkeypatch):
+        # On the stdlib path (CI without tree-sitter-java) annotations are not
+        # captured, so the feature is inert: methods are still extracted and
+        # fall through to the existing 1-hop verdict — never a crash, never a
+        # hard suppression.
+        import core.inventory.extractors as ex
+        monkeypatch.setattr(ex, "_TS_AVAILABLE", False)
+        from core.inventory.reach_audit import classify_reachability
+        inv = self._build(tmp_path)
+        saw = False
+        for f in inv["files"]:
+            for it in f["items"]:
+                if it.get("name") == "process":
+                    saw = True
+                    v = classify_reachability(
+                        inv, f["path"], "process",
+                        int(it.get("line_start") or 0), "Svc")
+                    assert v != "reachable"   # not promoted without annotations
+        assert saw   # extraction still works on the stdlib path
+
+    def test_java_framework_entry_verdicts(self, tmp_path):
+        pytest.importorskip("tree_sitter_java")
+        from core.inventory.reach_audit import classify_reachability
+        inv = self._build(tmp_path)
+
+        def verdict(rel, name):
+            for f in inv["files"]:
+                if f["path"] != rel:
+                    continue
+                for it in f["items"]:
+                    if it.get("name") == name:
+                        m = rel.rsplit(".", 1)[0]
+                        return classify_reachability(
+                            inv, rel, name, int(it.get("line_start") or 0), m)
+            return None
+
+        # gains: framework-dispatched methods become reachable.
+        assert verdict("Api.java", "handle") == "reachable"    # @GetMapping + stereotype
+        assert verdict("Api.java", "fmt") == "reachable"       # reachable via closure
+        assert verdict("Svc.java", "process") == "reachable"   # public bean method
+        assert verdict("Ev.java", "on") == "reachable"         # @EventListener
+        assert verdict("Ev.java", "tick") == "reachable"       # @Scheduled
+        assert verdict("Nest.java", "innerBean") == "reachable"  # inner @Service bean
+        # controls: entries only grow the set, so these stay demoted.
+        assert verdict("Svc.java", "helper") == "not_called"   # private bean method
+        assert verdict("Nest.java", "outerPlain") == "not_called"  # no stereotype leak
+        assert verdict("Ctl.java", "bg") == "not_called"       # @Async is not an entry
+        assert verdict("Ctl.java", "wr") == "not_called"       # @Transactional is not an entry
+        assert verdict("Ctl.java", "dead") == "not_called"     # plain uncalled

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -675,3 +675,89 @@ def test_unknown_language_profile_has_no_entry_signal():
     assert p.entry_model == "none"
     assert p.visibility_entry == ""
     assert not p.has_go_init and not p.has_java_web
+
+
+# ---------------------------------------------------------------------------
+# Java framework-dispatch entries (_java_framework_entry / _annotation_tail).
+# Path-independent: operate on synthetic item dicts, so they run on CI without
+# tree-sitter-java. Adding an entry only grows the reachable set, so the key
+# guarantees pinned here are the *negatives* — annotations that do NOT denote a
+# no-caller entry (@Async / @Transactional) and non-public stereotype methods
+# must not be promoted, or live code would never be demoted.
+# ---------------------------------------------------------------------------
+
+
+def _java_item(name, *, attrs=(), class_attrs=(), visibility="public"):
+    return {
+        "name": name,
+        "kind": "function",
+        "metadata": {
+            "attributes": list(attrs),
+            "class_attributes": list(class_attrs),
+            "visibility": visibility,
+        },
+    }
+
+
+def test_annotation_tail_strips_fqn_args_and_at():
+    from core.inventory.reachability import _annotation_tail
+    assert _annotation_tail(
+        "org.springframework.web.bind.annotation.GetMapping(\"/x\")"
+    ) == "GetMapping"
+    assert _annotation_tail("@Service") == "Service"
+    assert _annotation_tail("EventListener") == "EventListener"
+
+
+def test_java_servlet_and_method_dispatch_are_entries():
+    from core.inventory.reachability import _java_framework_entry
+    assert _java_framework_entry("doPost", _java_item("doPost", attrs=()))
+    assert _java_framework_entry("on", _java_item("on", attrs=["EventListener"]))
+    assert _java_framework_entry("tick", _java_item("tick", attrs=["Scheduled"]))
+    assert _java_framework_entry(
+        "consume", _java_item("consume", attrs=["KafkaListener"]))
+    # fully-qualified annotation form resolves via the tail.
+    assert _java_framework_entry(
+        "make",
+        _java_item("make", attrs=["org.springframework.context.annotation.Bean"]),
+    )
+
+
+def test_java_class_stereotype_promotes_public_methods_only():
+    from core.inventory.reachability import _java_framework_entry
+    # public method of a @Service bean → container-dispatched entry.
+    assert _java_framework_entry(
+        "process", _java_item("process", class_attrs=["Service"], visibility="public"))
+    assert _java_framework_entry(
+        "p2", _java_item("p2", class_attrs=["RestController"], visibility="public static"))
+    # private / protected / package-private bean methods are reachable only
+    # through the static closure from the public entries → NOT promoted.
+    assert not _java_framework_entry(
+        "helper", _java_item("helper", class_attrs=["Service"], visibility="private"))
+    assert not _java_framework_entry(
+        "pp", _java_item("pp", class_attrs=["Component"], visibility=None))
+
+
+def test_java_async_transactional_and_plain_are_not_entries():
+    from core.inventory.reachability import _java_framework_entry
+    # @Async / @Transactional only WRAP a normally-called method (it still has
+    # an in-project caller), so they must not be treated as no-caller entries.
+    assert not _java_framework_entry("bg", _java_item("bg", attrs=["Async"]))
+    assert not _java_framework_entry("wr", _java_item("wr", attrs=["Transactional"]))
+    # a plain public method in a non-stereotype class is not an entry.
+    assert not _java_framework_entry("dead", _java_item("dead"))
+
+
+def test_java_framework_entry_degrades_gracefully_on_stale_metadata():
+    # A pre-feature checklist.json (reused for an unchanged file) has no
+    # ``class_attributes`` key — and a malformed record may have no metadata at
+    # all. The entry check must not crash and must not promote (degrades to the
+    # existing 1-hop verdict; FN-safe surface-demote, self-heals on rebuild).
+    from core.inventory.reachability import _java_framework_entry
+    stale = {"name": "process", "kind": "function",
+             "metadata": {"attributes": [], "visibility": "public"}}  # no class_attributes
+    assert _java_framework_entry("process", stale) is False
+    assert _java_framework_entry("x", {"name": "x", "kind": "function"}) is False
+    # a recognised method-level annotation still fires on a stale record (the
+    # ``attributes`` field predates this feature), so Tier-1 dispatch is robust.
+    assert _java_framework_entry(
+        "on", {"name": "on", "metadata": {"attributes": ["EventListener"]}})


### PR DESCRIPTION
Java's entry model recognised only web routing — servlet lifecycle methods and JAX-RS / Spring MVC routing annotations (@RequestMapping / @GetMapping / @Path). Every other container-managed method — the dominant shape in real Java — had no in-project caller, fell through to UNCERTAIN, and read not_called: a surface-demote on essentially every Spring bean method.

Generalise the Java entry signal (rename `_java_web_entry` → `_java_framework_entry`) to cover the framework-dispatch surface:

  * Method-level dispatch annotations (the method's own annotations): Spring events / scheduling (@EventListener, @Scheduled), bean factories (@Bean), container lifecycle (@PostConstruct / @PreDestroy), message-driven listeners (@KafkaListener / @RabbitListener / @JmsListener / @MessageMapping / @SubscribeMapping / @StreamListener), and JPA / Hibernate entity lifecycle callbacks (@PrePersist / @PostLoad / …).
  * Class-level stereotypes (@Component / @Service / @Repository / @Controller / @RestController / @Configuration / @ControllerAdvice): the DI container instantiates the class and dispatches into its PUBLIC methods, so those are entries. Private / protected / package-private methods stay reachable only through the static closure from the public entries.

To see a method's class stereotype, the tree-sitter extractor now captures the enclosing class's annotations and threads them onto each method as `FunctionMetadata.class_attributes` (asdict / from_dict carry it; the field defaults to empty, so old inventories and the stdlib path are unaffected).

@Async and @Transactional are deliberately EXCLUDED: they only wrap a normally-called method (it still has an in-project caller), so treating them as no-caller entries would wrongly shield a genuinely-dead async / transactional method from demotion.

FP/FN-safe by construction: adding an entry only ever GROWS the reachable set, so the change can never suppress real code or demote live code — it strictly removes existing false-demotes. The lone failure mode is failing to demote a genuinely-dead annotated method (under-claiming dead code, the safe direction). A stash differential over a synthetic Spring/Jakarta corpus confirms this: the only verdict changes are not_called → reachable (six gains), with zero changes in any other direction, and the controls (a plain class, @Async / @Transactional methods, a private bean method) all stay not_called.

Annotation capture is tree-sitter-only; on the stdlib (regex) extractor path the feature is inert — methods are still extracted and fall through to the existing 1-hop verdict, never a crash, never a hard suppression. Verdict tests are gated on tree-sitter-java per the stdlib-path convention; the entry-logic unit tests operate on synthetic item dicts and run on CI without it.

Known limitation (FN-safe, self-healing): the class-stereotype tier reads the new `class_attributes` field, which is absent from a checklist.json built before this change. The inventory reuses a file's parsed record verbatim while its SHA-256 is unchanged, so on a warm pre-change cache a stereotype bean's public methods read not_called (surface-demote) until the file is next re-extracted. The method-level tier is unaffected (it reads `attributes`, which predates this change). The entry check degrades gracefully when the field is absent (no crash, no promotion). This matches the established "new inventory fields degrade gracefully when absent" behaviour of the prior coverage units; a checklist schema-version gate that forces re-extraction on any extractor change would benefit every such field and belongs as its own cross-cutting unit.