### PR TITLE
feat(provenance): run-provenance layer (L1) + finder identity & harness model

### DIFF
--- a/.claude/commands/understand.md
+++ b/.claude/commands/understand.md
@@ -97,9 +97,9 @@ annotations under `$OUTPUT_DIR/annotations/` for entry points, sinks,
 trust boundaries, unchecked flows, and trace steps. Best-effort — exits
 0 with "nothing to synthesise" when no inputs are present.
 
-**Step 5: Complete the run:**
+**Step 5: Complete the run.** Replace `<your-model-id>` with your exact model ID from your system prompt (e.g. `claude-opus-4-7`) — it records which model performed the analysis, which only you (the harness) know (RAPTOR's Python can't read `/model`). If you don't know your model ID, drop the `--model` flag entirely; the run still completes, the model is just left unrecorded.
 ```bash
-libexec/raptor-run-lifecycle complete "$OUTPUT_DIR"
+libexec/raptor-run-lifecycle complete "$OUTPUT_DIR" --model <your-model-id>
 ```
 
 **On failure** (at any point):

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -106,11 +106,13 @@ Skip Stage E if `--skip-feasibility` or no memory corruption findings.
 
 ### Stage 1 (Python): Report Generation
 
+Replace `<your-model-id>` with your exact model ID from your system prompt (e.g. `claude-opus-4-7`) — it records which model performed the validation, which only you (the harness) know (RAPTOR's Python can't read `/model`). If you don't know your model ID, drop the `--model` flag; the run still completes, the model is just unrecorded.
+
 ```bash
-libexec/raptor-validation-helper 1 "$OUTPUT_DIR"
+libexec/raptor-validation-helper 1 "$OUTPUT_DIR" --model <your-model-id>
 ```
 
-This merges stage-f.json, generates the validation report, diagrams, coverage records, and completes the run lifecycle. The findings summary and coverage summary are printed to stdout.
+This merges stage-f.json, generates the validation report, diagrams, coverage records, and completes the run lifecycle (recording the model into the manifest). The findings summary and coverage summary are printed to stdout.
 
 Then read `{output_dir}/validation-report.md` and add a 1-2 sentence summary paragraph
 after the `# Exploitability Validation Report` header — e.g., "All 3 buffer overflows are

--- a/.claude/skills/exploitability-validation/stage-1-outputs.md
+++ b/.claude/skills/exploitability-validation/stage-1-outputs.md
@@ -12,8 +12,10 @@ Terminal stage. Runs after all reasoning (Stages A-F) is complete.
 
 ### [1-0] Run the prep script
 
+Replace `<your-model-id>` with your exact model ID from your system prompt (e.g. `claude-opus-4-7`) — it records which model performed the validation (only the harness knows it; RAPTOR's Python can't read `/model`). If you don't know your model ID, drop the `--model` flag; the run still completes, the model is just unrecorded.
+
 ```bash
-libexec/raptor-validation-helper 1 "$OUTPUT_DIR"
+libexec/raptor-validation-helper 1 "$OUTPUT_DIR" --model <your-model-id>
 ```
 
 This merges `stage-f.json`, recomputes CVSS scores from final vectors, generates `validation-report.md` and `diagrams.md`, writes coverage records, prints findings and coverage summaries, and completes the run lifecycle.

--- a/core/archive/__init__.py
+++ b/core/archive/__init__.py
@@ -1,0 +1,30 @@
+"""Archive facade — multi-format detection + safe extraction.
+
+The umbrella layer over the format-specific primitives. Single-file compressors
+(gz/bz2/xz/zst) live here directly (stdlib one-liners); zip and tar delegate to
+``core.zip`` / ``core.tar``. New formats land here, never as new top-level
+packages.
+
+Public API:
+    from core.archive import detect_format, is_archive, extract_to_dir
+    from core.archive import ArchiveError, UnsupportedArchive, DecompressionLimitExceeded
+"""
+
+from .detect import detect_format, is_archive
+from .errors import ArchiveError, DecompressionLimitExceeded, UnsupportedArchive
+from .extract import (
+    DEFAULT_MAX_FILES,
+    DEFAULT_MAX_TOTAL_BYTES,
+    extract_to_dir,
+)
+
+__all__ = [
+    "ArchiveError",
+    "DEFAULT_MAX_FILES",
+    "DEFAULT_MAX_TOTAL_BYTES",
+    "DecompressionLimitExceeded",
+    "UnsupportedArchive",
+    "detect_format",
+    "extract_to_dir",
+    "is_archive",
+]

--- a/core/archive/compression.py
+++ b/core/archive/compression.py
@@ -1,0 +1,72 @@
+"""Single-file decompression (gz / bz2 / xz / zst), capped against bombs.
+
+We read at most ``max_bytes + 1`` of *decompressed* output from the stdlib's
+lazy decompressing readers, so a bomb (tiny input → enormous output) is never
+fully materialised in memory — we stop one byte past the cap and reject.
+"""
+
+import bz2
+import gzip
+import lzma
+from pathlib import Path
+
+from .errors import ArchiveError, DecompressionLimitExceeded, UnsupportedArchive
+
+# Cap on decompressed output for a single compressed file (also the budget for
+# a compressed-tar's decompressed bytes before tar parsing).
+DEFAULT_MAX_DECOMPRESSED_BYTES = 1 << 30  # 1 GiB
+
+_TAR_MAGIC_OFFSET = 257
+_TAR_MAGICS = (b"ustar\x0000", b"ustar  \x00", b"ustar")
+
+
+def _zstd_open(path, mode="rb"):
+    # Python 3.14+ ships zstd in the stdlib (PEP 784); fall back to the
+    # third-party `zstandard` package on older interpreters.
+    try:
+        from compression import zstd
+        return zstd.open(path, mode)
+    except Exception:
+        import zstandard
+        return zstandard.open(path, mode)
+
+
+_OPENERS = {
+    "gz": gzip.open,
+    "bz2": bz2.open,
+    "xz": lzma.open,
+    "zst": _zstd_open,
+}
+
+
+def decompress_single(path, fmt: str,
+                      max_bytes: int = DEFAULT_MAX_DECOMPRESSED_BYTES) -> bytes:
+    """Decompress a single-file ``gz``/``bz2``/``xz``/``zst`` to bytes, capped.
+
+    Raises ``DecompressionLimitExceeded`` if output would exceed ``max_bytes``
+    (bomb defense), ``UnsupportedArchive`` for an unknown ``fmt``, and
+    ``ArchiveError`` if the stream is corrupt/truncated.
+    """
+    opener = _OPENERS.get(fmt)
+    if opener is None:
+        raise UnsupportedArchive(f"no single-file decompressor for {fmt!r}")
+    try:
+        with opener(Path(path), "rb") as fh:
+            data = fh.read(max_bytes + 1)
+    except DecompressionLimitExceeded:
+        raise
+    except Exception as e:  # malformed/truncated stream, decompress error
+        raise ArchiveError(f"{fmt} decompression failed: {e}") from e
+    if len(data) > max_bytes:
+        raise DecompressionLimitExceeded(
+            f"{fmt} stream exceeds {max_bytes} bytes decompressed — refusing as bomb"
+        )
+    return data
+
+
+def looks_like_tar(data: bytes) -> bool:
+    """True if ``data`` carries a POSIX tar header (ustar magic at offset 257)."""
+    if len(data) <= _TAR_MAGIC_OFFSET:
+        return False
+    window = data[_TAR_MAGIC_OFFSET:_TAR_MAGIC_OFFSET + 8]
+    return any(window.startswith(m) for m in _TAR_MAGICS)

--- a/core/archive/detect.py
+++ b/core/archive/detect.py
@@ -1,0 +1,64 @@
+"""Magic-byte detection of archive / single-file-compression formats.
+
+Detection is by content, never by file extension — an attacker-supplied
+target can lie about (or omit) its extension, and the whole point of recording
+provenance is that we know what we *actually* unpacked.
+
+Returns the OUTER format. A compressed tar (``.tar.gz``) is reported as its
+compressor (``gz``); the extractor then probes whether the decompressed bytes
+are a tar or a single file.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+# Formats whose magic sits at offset 0. Order matters only in that more
+# specific signatures must precede generic ones (none overlap here).
+_MAGIC_AT_0 = (
+    ("zip", b"PK\x03\x04"),
+    ("zip", b"PK\x05\x06"),   # empty archive
+    ("zip", b"PK\x07\x08"),   # spanned/data-descriptor
+    ("gz",  b"\x1f\x8b"),
+    ("bz2", b"BZh"),
+    ("xz",  b"\xfd7zXZ\x00"),
+    ("zst", b"\x28\xb5\x2f\xfd"),
+)
+
+# POSIX tar carries "ustar" at offset 257 (both GNU and POSIX variants).
+_TAR_MAGIC_OFFSET = 257
+_TAR_MAGICS = (b"ustar\x0000", b"ustar  \x00", b"ustar")
+
+# Enough to cover the tar magic at offset 257 plus all offset-0 signatures.
+_PEEK_BYTES = 512
+
+
+def detect_format(path) -> Optional[str]:
+    """Return ``'zip'|'tar'|'gz'|'bz2'|'xz'|'zst'`` from the file's magic
+    bytes, or ``None`` if it is not a recognised archive/compressed file
+    (or can't be read). Never raises.
+    """
+    p = Path(path)
+    try:
+        with open(p, "rb") as fh:
+            head = fh.read(_PEEK_BYTES)
+    except OSError:
+        return None
+    if not head:
+        return None
+
+    # Tar first: its magic is deep in the header, and a tar is never also a
+    # zip/gz/… at offset 0, so there's no ambiguity.
+    if len(head) > _TAR_MAGIC_OFFSET:
+        window = head[_TAR_MAGIC_OFFSET:_TAR_MAGIC_OFFSET + 8]
+        if any(window.startswith(m) for m in _TAR_MAGICS):
+            return "tar"
+
+    for fmt, magic in _MAGIC_AT_0:
+        if head.startswith(magic):
+            return fmt
+    return None
+
+
+def is_archive(path) -> bool:
+    """True if ``path`` is a recognised archive/compressed file."""
+    return detect_format(path) is not None

--- a/core/archive/errors.py
+++ b/core/archive/errors.py
@@ -1,0 +1,14 @@
+"""Exceptions for the archive facade. Kept in their own module so detect /
+compression / extract can share them without import cycles through __init__."""
+
+
+class ArchiveError(Exception):
+    """Base for archive extraction failures."""
+
+
+class UnsupportedArchive(ArchiveError):
+    """The file is not a recognised Tier-1 archive/compressed format."""
+
+
+class DecompressionLimitExceeded(ArchiveError):
+    """A size / file-count cap was exceeded — treated as a decompression bomb."""

--- a/core/archive/extract.py
+++ b/core/archive/extract.py
@@ -1,0 +1,158 @@
+"""``extract_to_dir`` — safely unpack a Tier-1 archive into a directory.
+
+Delegates to the hardened ``core.zip`` / ``core.tar`` primitives (which already
+do zip-slip + bomb defense and hand back regular-files-only ``{name: bytes}``),
+then writes those bytes to disk under ``dest``, re-validating each path stays
+inside ``dest``. Only regular files are ever created — no symlinks or device
+nodes — so symlink-escape attacks are impossible by construction.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from core.tar import (
+    TarEntryCountExceeded,
+    TarTotalBytesExceeded,
+    extract_files_from_tar,
+)
+from core.zip import (
+    DEFAULT_MAX_ENTRIES,
+    DEFAULT_MAX_MEMBER_BYTES,
+    ZipTotalBytesExceeded,
+    extract_files_from_zip,
+)
+
+from .compression import decompress_single, looks_like_tar
+from .detect import detect_format
+from .errors import DecompressionLimitExceeded, UnsupportedArchive
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_TOTAL_BYTES = 2 << 30  # 2 GiB summed across all extracted members
+DEFAULT_MAX_FILES = DEFAULT_MAX_ENTRIES
+
+# Compression suffixes stripped to name a single decompressed file.
+_SINGLE_SUFFIXES = (".gz", ".xz", ".bz2", ".zst")
+
+
+def _keep_files(info: Any) -> Optional[str]:
+    """Selector for the zip/tar primitives: keep regular files, skip dirs.
+
+    Handles both ``ZipInfo`` (``.filename`` + ``.is_dir()``) and ``TarInfo``
+    (``.name``; the tar primitive already filtered to ``isfile()``)."""
+    is_dir = getattr(info, "is_dir", None)
+    if callable(is_dir) and is_dir():
+        return None
+    return getattr(info, "filename", None) or getattr(info, "name", None)
+
+
+def _single_file_name(src: Path) -> str:
+    """Filename for a single decompressed file: the archive name minus its
+    compression suffix (``notes.txt.gz`` → ``notes.txt``), else ``<name>.out``."""
+    name = src.name
+    low = name.lower()
+    for suf in _SINGLE_SUFFIXES:
+        if low.endswith(suf):
+            return name[: -len(suf)] or "decompressed.out"
+    return name + ".out"
+
+
+def _safe_dest_path(dest_root: Path, member_name: str) -> Optional[Path]:
+    """Resolve ``member_name`` under ``dest_root`` or return None if it escapes.
+
+    The primitives already reject traversal; this is the write-boundary
+    re-check (defense in depth) so we can never write outside ``dest_root``.
+    Returns None for any name that escapes OR can't be resolved at all (e.g. an
+    embedded NUL/control byte that makes resolve() raise ValueError) — such a
+    member is simply dropped rather than crashing extraction.
+    """
+    rel = member_name.lstrip("/\\")
+    try:
+        root = dest_root.resolve()
+        target = (root / rel).resolve()
+        target.relative_to(root)
+    except (OSError, ValueError):
+        return None
+    return target
+
+
+def _write_members(members: Dict[str, bytes], dest: Path,
+                   max_total: int, max_files: int) -> Dict[str, int]:
+    if len(members) > max_files:
+        raise DecompressionLimitExceeded(
+            f"archive has {len(members)} files — exceeds cap of {max_files}")
+    total = 0
+    written = 0
+    for name, data in members.items():
+        total += len(data)
+        if total > max_total:
+            raise DecompressionLimitExceeded(
+                f"archive exceeds {max_total} bytes extracted — refusing as bomb")
+        target = _safe_dest_path(dest, name)
+        if target is None:
+            logger.warning("core.archive: dropping out-of-tree member %r", name)
+            continue
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with open(target, "wb") as fh:
+                fh.write(data)
+        except (OSError, ValueError) as e:
+            # Never let one pathological member (an OS-unwritable name that
+            # slipped the safety gate, a disk error) crash extraction of
+            # attacker-controlled input — skip it and carry on.
+            logger.warning("core.archive: skipping unwritable member %r (%s)", name, e)
+            continue
+        written += 1
+    return {"files": written, "bytes": total}
+
+
+def extract_to_dir(path, dest, *,
+                   max_total_bytes: int = DEFAULT_MAX_TOTAL_BYTES,
+                   max_files: int = DEFAULT_MAX_FILES,
+                   max_member_bytes: int = DEFAULT_MAX_MEMBER_BYTES) -> Dict[str, Any]:
+    """Extract a Tier-1 archive (``path``) into ``dest``; return a summary dict
+    ``{"format", "files", "bytes"}``.
+
+    Tier 1: zip, tar, ``.tar.{gz,xz,bz2}``, and single-file gz/bz2/xz/zst.
+    Raises ``UnsupportedArchive`` for unknown formats and
+    ``DecompressionLimitExceeded`` / ``ArchiveError`` on unsafe or corrupt input.
+    """
+    src = Path(path)
+    dest = Path(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+
+    fmt = detect_format(src)
+    if fmt is None:
+        raise UnsupportedArchive(f"{src} is not a recognised archive")
+
+    # The primitives now enforce ``max_total_bytes`` as a RUNNING sum (and tar
+    # an entry count), so peak memory is bounded to ~max_total instead of
+    # entries×member_bytes (~640 GiB worst case). Their bomb exceptions are
+    # mapped to DecompressionLimitExceeded.
+    try:
+        if fmt == "zip":
+            members = extract_files_from_zip(
+                src, selector=_keep_files, max_member_bytes=max_member_bytes,
+                max_entry_count=max_files, max_total_bytes=max_total_bytes)
+        elif fmt == "tar":
+            members = extract_files_from_tar(
+                src.read_bytes(), selector=_keep_files, mode="r:*",
+                max_member_bytes=max_member_bytes,
+                max_total_bytes=max_total_bytes, max_entry_count=max_files)
+        else:
+            # gz/bz2/xz/zst: a compressed tar OR a single compressed file.
+            raw = decompress_single(src, fmt, max_bytes=max_total_bytes)
+            if looks_like_tar(raw):
+                members = extract_files_from_tar(
+                    raw, selector=_keep_files, mode="r:",
+                    max_member_bytes=max_member_bytes,
+                    max_total_bytes=max_total_bytes, max_entry_count=max_files)
+            else:
+                members = {_single_file_name(src): raw}
+    except (ZipTotalBytesExceeded, TarTotalBytesExceeded, TarEntryCountExceeded) as e:
+        raise DecompressionLimitExceeded(str(e)) from e
+
+    stats = _write_members(members, dest, max_total_bytes, max_files)
+    stats["format"] = fmt
+    return stats

--- a/core/archive/tests/test_archive.py
+++ b/core/archive/tests/test_archive.py
@@ -1,0 +1,185 @@
+"""Tests for the core.archive facade — detection, Tier-1 extraction, hardening."""
+
+import bz2
+import gzip
+import io
+import lzma
+import tarfile
+import unittest
+import zipfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from core.archive import (
+    DecompressionLimitExceeded,
+    UnsupportedArchive,
+    detect_format,
+    extract_to_dir,
+    is_archive,
+)
+from core.archive.errors import ArchiveError
+
+
+def _zip(path, entries):
+    with zipfile.ZipFile(path, "w") as z:
+        for name, data in entries.items():
+            z.writestr(name, data)
+
+
+def _tar(path, entries, mode="w"):
+    with tarfile.open(path, mode) as t:
+        for name, data in entries.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            t.addfile(info, io.BytesIO(data))
+
+
+def _files(root: Path):
+    return sorted(str(p.relative_to(root)) for p in root.rglob("*") if p.is_file())
+
+
+class TestDetect(unittest.TestCase):
+
+    def test_each_format_by_magic_not_extension(self):
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            _zip(d / "a.zip", {"f": b"x"})
+            _tar(d / "a.tar", {"f": b"x"}, mode="w")
+            _tar(d / "a.tgz", {"f": b"x"}, mode="w:gz")
+            with gzip.open(d / "f.gz", "wb") as f:
+                f.write(b"x")
+            with lzma.open(d / "f.xz", "wb") as f:
+                f.write(b"x")
+            with bz2.open(d / "f.bz2", "wb") as f:
+                f.write(b"x")
+            self.assertEqual(detect_format(d / "a.zip"), "zip")
+            self.assertEqual(detect_format(d / "a.tar"), "tar")
+            self.assertEqual(detect_format(d / "a.tgz"), "gz")   # outer compressor
+            self.assertEqual(detect_format(d / "f.gz"), "gz")
+            self.assertEqual(detect_format(d / "f.xz"), "xz")
+            self.assertEqual(detect_format(d / "f.bz2"), "bz2")
+
+    def test_extension_lies_content_wins(self):
+        # A plain text file named .zip is NOT detected as zip.
+        with TemporaryDirectory() as d:
+            p = Path(d) / "fake.zip"
+            p.write_text("not actually a zip")
+            self.assertIsNone(detect_format(p))
+            self.assertFalse(is_archive(p))
+
+    def test_missing_and_empty(self):
+        with TemporaryDirectory() as d:
+            self.assertIsNone(detect_format(Path(d) / "nope"))
+            empty = Path(d) / "e"
+            empty.write_bytes(b"")
+            self.assertIsNone(detect_format(empty))
+
+
+class TestExtract(unittest.TestCase):
+
+    def test_zip_extracts_files_skips_dirs(self):
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            _zip(d / "a.zip", {"src/x.py": b"print()\n", "dir/": b""})
+            out = d / "out"
+            stats = extract_to_dir(d / "a.zip", out)
+            self.assertEqual(stats["format"], "zip")
+            self.assertEqual(_files(out), ["src/x.py"])
+
+    def test_plain_tar(self):
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            _tar(d / "a.tar", {"a/b.txt": b"hi"}, mode="w")
+            out = d / "out"
+            extract_to_dir(d / "a.tar", out)
+            self.assertEqual(_files(out), ["a/b.txt"])
+
+    def test_compressed_tar_routes_to_tar_not_single_file(self):
+        # A .tar.gz must extract its members, NOT write one "a.tar" blob.
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            _tar(d / "a.tar.gz", {"src/y.py": b"y\n"}, mode="w:gz")
+            out = d / "out"
+            extract_to_dir(d / "a.tar.gz", out)
+            self.assertEqual(_files(out), ["src/y.py"])
+
+    def test_single_gz_strips_suffix(self):
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            with gzip.open(d / "notes.txt.gz", "wb") as f:
+                f.write(b"hello\n")
+            out = d / "out"
+            extract_to_dir(d / "notes.txt.gz", out)
+            self.assertEqual(_files(out), ["notes.txt"])
+            self.assertEqual((out / "notes.txt").read_bytes(), b"hello\n")
+
+    def test_non_archive_raises(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "plain.txt"
+            p.write_text("nope")
+            with self.assertRaises(UnsupportedArchive):
+                extract_to_dir(p, Path(d) / "out")
+
+
+class TestHardening(unittest.TestCase):
+
+    def test_zip_slip_member_not_written_outside_dest(self):
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            zp = d / "evil.zip"
+            with zipfile.ZipFile(zp, "w") as z:
+                z.writestr(zipfile.ZipInfo("../../escape.txt"), b"pwned")
+                z.writestr("safe.txt", b"ok")
+            out = d / "out"
+            extract_to_dir(zp, out)
+            # The traversal member is dropped; nothing escapes dest.
+            self.assertFalse((d / "escape.txt").exists())
+            self.assertFalse((out.parent / "escape.txt").exists())
+            self.assertEqual(_files(out), ["safe.txt"])
+
+    def test_file_count_cap(self):
+        # tar has no built-in entry cap, so _write_members enforces it.
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            _tar(d / "many.tar", {f"f{i}": b"x" for i in range(5)}, mode="w")
+            with self.assertRaises(DecompressionLimitExceeded):
+                extract_to_dir(d / "many.tar", d / "out", max_files=2)
+
+    def test_total_size_cap(self):
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            _zip(d / "big.zip", {"f": b"x" * 100})
+            with self.assertRaises(DecompressionLimitExceeded):
+                extract_to_dir(d / "big.zip", d / "out", max_total_bytes=10)
+
+    def test_single_file_decompression_bomb_capped(self):
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            with gzip.open(d / "bomb.gz", "wb") as f:
+                f.write(b"A" * 10000)
+            with self.assertRaises(DecompressionLimitExceeded):
+                extract_to_dir(d / "bomb.gz", d / "out", max_total_bytes=100)
+
+    def test_corrupt_stream_raises_archive_error(self):
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            # Valid gzip magic, garbage body.
+            (d / "broken.gz").write_bytes(b"\x1f\x8b\x08" + b"\x00\xff\xab\xcd" * 4)
+            with self.assertRaises(ArchiveError):
+                extract_to_dir(d / "broken.gz", d / "out")
+
+    def test_nul_byte_member_dropped_not_crash(self):
+        # A NUL byte in a name makes resolve()/open() raise ValueError; the
+        # member must be DROPPED (not crash extraction), with good members
+        # still written. (Real zip/tar parsers strip NUL, but defend anyway.)
+        from core.archive.extract import _safe_dest_path, _write_members
+        with TemporaryDirectory() as d:
+            out = Path(d)
+            self.assertIsNone(_safe_dest_path(out, "a\x00b"))
+            stats = _write_members({"a\x00b": b"x", "good.txt": b"ok"}, out, 1 << 20, 100)
+            self.assertEqual(stats["files"], 1)
+            self.assertTrue((out / "good.txt").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core/run/identity.py
+++ b/core/run/identity.py
@@ -1,0 +1,83 @@
+"""Operator / finder identity — the WHO of a run (citation-only).
+
+This is the human half of run provenance: who to credit when a finding from
+this run is published (#485). It is deliberately minimal and deliberately
+explicit:
+
+  * **Per-uid, local config.** Read from ``~/.raptor/identity.json`` — $HOME-
+    rooted, so each OS user on a shared box has their own, with no extra
+    machinery.
+  * **Never auto-detected.** We do NOT fall back to ``$USER`` / ``git config
+    user.email`` / a GitHub handle — those would leak the operator's real
+    identity into a published citation without consent (the same leak the
+    public_view redaction exists to prevent). The uid scopes *where* the file
+    lives; the operator types *what* is in it.
+  * **No default.** Absent / empty / nameless file ⇒ ``None`` — *no* identity
+    asserted (no placeholder "Raptor User"). The manifest then omits ``who``
+    entirely, and ``/cite`` gates on its presence: setting a public-facing
+    identity is the deliberate, informed act of consent.
+
+The value is operator-chosen and publish-intended by construction, so the
+fields are an allowlisted ``{name, handle?, url?}``.
+"""
+
+from __future__ import annotations
+
+import json
+import unicodedata
+from pathlib import Path
+from typing import Dict, Optional
+
+# $HOME-rooted ⇒ per-uid isolation for free. Same dir as the inventory cache.
+IDENTITY_PATH = Path.home() / ".raptor" / "identity.json"
+
+# A real identity file is tiny; cap the read so a huge/symlinked file can't OOM
+# the hot start path (`who` is sealed on every start_run).
+_MAX_FILE_BYTES = 64 * 1024
+_FIELD_MAXLEN = {"name": 256, "handle": 128, "url": 2048}
+
+
+def _clean_field(value: object, maxlen: int) -> Optional[str]:
+    """A field is usable iff it's a non-empty, length-bounded string with no
+    control/format characters — the latter rejected because ``who`` is sealed
+    into a publish-bound manifest, and control bytes / ANSI escapes / unicode
+    bidi-overrides would inject into or spoof a rendered citation. Returns the
+    stripped value or None."""
+    if not isinstance(value, str):
+        return None
+    s = value.strip()
+    if not s or len(s) > maxlen:
+        return None
+    # Unicode category 'C*' = control (Cc) / format (Cf, incl. RTL-override +
+    # zero-width) / surrogate / private / unassigned. None belong in a name.
+    if any(unicodedata.category(ch).startswith("C") for ch in s):
+        return None
+    return s
+
+
+def load_finder_identity(path: Optional[Path] = None) -> Optional[Dict[str, str]]:
+    """The operator's public-facing identity, or ``None`` when unset.
+
+    Returns ``{"name": ..., "handle"?: ..., "url"?: ...}`` — name required and
+    non-empty (a file without a usable name is treated as unset; there is no
+    default). ``None`` on absent / unreadable / malformed file, so a broken
+    config never breaks a run — it just means "no identity asserted".
+    """
+    p = path or IDENTITY_PATH
+    try:
+        if not p.exists() or p.stat().st_size > _MAX_FILE_BYTES:
+            return None  # absent, or implausibly large (DoS / not a real config)
+        data = json.loads(p.read_text())
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    name = _clean_field(data.get("name"), _FIELD_MAXLEN["name"])
+    if not name:
+        return None  # no usable name ⇒ not set (never a placeholder default)
+    out: Dict[str, str] = {"name": name}
+    for key in ("handle", "url"):
+        val = _clean_field(data.get(key), _FIELD_MAXLEN[key])
+        if val:
+            out[key] = val
+    return out

--- a/core/run/metadata.py
+++ b/core/run/metadata.py
@@ -182,7 +182,7 @@ def _pid_alive(pid: int) -> bool:
 
 
 def start_run(output_dir: Path, command: str, extra: Dict[str, Any] = None,
-              target: str = None) -> Path:
+              target: str = None, target_identity: Dict[str, Any] = None) -> Path:
     """Write initial .raptor-run.json with status=running.
 
     Call this at the start of a command. Returns the output_dir (for chaining).
@@ -214,7 +214,7 @@ def start_run(output_dir: Path, command: str, extra: Dict[str, Any] = None,
         "command": command,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "status": STATUS_RUNNING,
-        "manifest": build_start_manifest(target=target),
+        "manifest": build_start_manifest(target=target, target_identity=target_identity),
         "extra": extra or {},
     }
     if session_pid is not None:
@@ -537,10 +537,15 @@ def complete_run(output_dir: Path, extra: Dict[str, Any] = None,
                  manifest: Dict[str, Any] = None) -> None:
     """Update .raptor-run.json to status=completed.
 
-    ``manifest`` merges end-of-run provenance — the models that fired, engine
-    versions, ``deterministically_reproducible`` — into the manifest sealed at
+    ``manifest`` merges end-of-run provenance into the manifest sealed at
     start_run. Top-level keys overwrite; the start-sealed source_control /
     environment snapshots are preserved unless explicitly overwritten.
+
+    Standard end-of-run provenance the lifecycle can derive itself — engine
+    versions (``detect_engines``) and ``deterministically_reproducible`` (from
+    the command) — is filled automatically for EVERY completion path, so a
+    caller only needs to pass the facts unique to it (the models that fired).
+    Callers still win on conflict: an explicitly-passed key is never clobbered.
     """
     _finalize_sandbox_summary(output_dir)
     _update_status(output_dir, STATUS_COMPLETED, extra, manifest=manifest)
@@ -753,14 +758,37 @@ def _update_status(output_dir: Path, status: str, extra: Dict[str, Any] = None,
         metadata["extra"] = existing_extra
 
     if manifest:
-        # Merge end-of-run provenance into the start-sealed manifest. Shallow
-        # top-level merge: source_control / environment (sealed at start) stay
-        # put; models / engines / deterministically_reproducible land here.
+        # Merge caller-supplied end-of-run provenance into the start-sealed
+        # manifest. Shallow top-level merge: source_control / environment
+        # (sealed at start) stay put; models land here.
         existing_manifest = metadata.get("manifest", {})
         existing_manifest.update(manifest)
         metadata["manifest"] = existing_manifest
 
+    if status == STATUS_COMPLETED:
+        _apply_standard_provenance(metadata, Path(output_dir))
+
     save_json(path, metadata)
+
+
+def _apply_standard_provenance(metadata: Dict[str, Any], output_dir: Path) -> None:
+    """Fill the manifest with the standard end-of-run provenance the lifecycle
+    derives itself — engine versions + ``deterministically_reproducible`` — so
+    EVERY completion path enriches uniformly without per-command wiring.
+
+    Caller-supplied keys win (``setdefault``): the lifecycle only fills gaps,
+    never clobbers a value a command passed via ``complete_run(manifest=...)``.
+    Skipped when there's no real manifest to enrich — a run that predates
+    manifest capture carries the ``provenance: unavailable`` stamp, and a run
+    whose ``start_run`` never sealed one has no ``manifest`` key at all.
+    """
+    existing = metadata.get("manifest")
+    if not existing or existing.get("provenance") == "unavailable":
+        return
+    from core.run.provenance import standard_completion_provenance
+    standard = standard_completion_provenance(output_dir, metadata.get("command"))
+    for key, value in standard.items():
+        existing.setdefault(key, value)
 
 
 def parse_timestamp_from_name(name: str) -> Optional[str]:

--- a/core/run/provenance.py
+++ b/core/run/provenance.py
@@ -18,7 +18,7 @@ import hashlib
 import platform
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 # Repo root = parents[2] of this file:
 #   parents[0] = core/run   (this module's dir)
@@ -196,6 +196,53 @@ def target_snapshot(target_path: Optional[Any]) -> Optional[Dict[str, Any]]:
     }
 
 
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def archive_snapshot(archive_path: Optional[Any]) -> Optional[Dict[str, Any]]:
+    """Identity of the SCANNED ARCHIVE file — the "which distribution" half.
+
+    Hashes the archive bytes; returns ``{archive_sha256, archive_name, format}``
+    or None if it isn't a recognised archive. Publish-safe (hash + name only,
+    no path).
+    """
+    if not archive_path:
+        return None
+    from core.archive import detect_format
+    p = Path(archive_path)
+    fmt = detect_format(p)
+    if fmt is None:
+        return None
+    try:
+        digest = _sha256_file(p)
+    except OSError:
+        return None
+    return {"archive_sha256": digest, "archive_name": p.name, "format": fmt}
+
+
+def archive_target_identity(
+    archive_path: Optional[Any],
+) -> Optional[Dict[str, Any]]:
+    """Compose the manifest ``target`` block for an archive target — the
+    archive file's ACQUISITION identity ``{source, archive_sha256,
+    archive_name, format}``. None if ``archive_path`` isn't a recognised
+    archive. Hashes/names only, so (unlike the git block) it's publish-safe.
+
+    The extracted tree's content-EQUIVALENCE id is deliberately not here: that
+    is the coverage store's to derive from the inventory (one content identity,
+    and it belongs to the store, not a second source of truth in the manifest).
+    """
+    a = archive_snapshot(archive_path)
+    if a is None:
+        return None
+    return {"source": "archive", **a}
+
+
 # Canonical per-run output files that signal an engine ran, mapped to the
 # probe name in _VERSION_PROBES. Semgrep/CodeQL emit SARIF (``<engine>_*.sarif``;
 # ``.json`` tolerated for alternate modes); coccinelle emits ``cocci.sarif``.
@@ -218,6 +265,47 @@ def detect_engines(out_dir: Any) -> Dict[str, Optional[str]]:
         if any(any(out_dir.glob(p)) for p in patterns):
             engines[name] = tool_version(name)
     return engines
+
+
+# Commands whose verdict is a pure function of the inputs — static rules /
+# queries, no LLM and no stochastic/runtime component — so a re-run on the
+# same tree reproduces the same findings. Fuzzing (stochastic mutation),
+# dynamic web scans (target-state-dependent), and every LLM-mediated command
+# (agentic / validate / understand) are NOT deterministically reproducible.
+# #4 will refine this single bool into a richer `method` taxonomy
+# (mechanical / runtime / llm_assisted); for now the bool preserves exactly
+# the scan/codeql=True, everything-else=False behaviour the per-command
+# callers hard-coded, while letting the lifecycle apply it uniformly.
+_DETERMINISTIC_COMMANDS = frozenset({"scan", "codeql"})
+
+
+def is_deterministically_reproducible(command: Optional[str]) -> bool:
+    """Whether ``command``'s verdict path is deterministic (no LLM, no
+    stochastic/runtime component) — i.e. re-running on the same inputs
+    reproduces the same findings."""
+    return command in _DETERMINISTIC_COMMANDS
+
+
+def standard_completion_provenance(
+    out_dir: Any, command: Optional[str],
+) -> Dict[str, Any]:
+    """The end-of-run provenance EVERY command contributes, derived only from
+    facts the lifecycle can see for itself: which engines left output, and
+    whether the command's verdict is deterministic.
+
+    Centralised here so enrichment is uniform across every completion path —
+    the Python orchestrators (scan / codeql / agentic) AND the Claude-driven
+    commands that finish through the lifecycle stubs (/validate, /understand)
+    — instead of being hand-wired per caller (which is why coverage used to be
+    uneven). Facts only an in-process orchestrator knows — the models that
+    fired — stay with the caller and merge separately; the lifecycle fills
+    these two only where the caller didn't supply them.
+    """
+    return {
+        "engines": detect_engines(out_dir),
+        "deterministically_reproducible": is_deterministically_reproducible(
+            command),
+    }
 
 
 def environment_snapshot() -> Dict[str, Any]:
@@ -244,24 +332,41 @@ def environment_snapshot() -> Dict[str, Any]:
 
 
 def build_start_manifest(repo_dir: Optional[Path] = None,
-                         target: Optional[Any] = None) -> Dict[str, Any]:
+                         target: Optional[Any] = None,
+                         target_identity: Optional[Dict[str, Any]] = None,
+                         ) -> Dict[str, Any]:
     """Assemble the manifest fragment sealed at run START.
 
     Carries a ``schema`` integer so the manifest can evolve independently of
     the enclosing .raptor-run.json ``version``. complete_run later merges
     end-of-run facts (models, engines) into this same dict.
 
-    ``target`` (the scanned path) is snapshotted into a ``target`` block when
-    it is a git checkout — the "what code was analysed" half of attribution.
+    The ``target`` block (the "what code was analysed" half of attribution) is
+    an ACQUISITION stamp — how the code arrived, NOT a content-equivalence id
+    (that is the coverage store's, derived from the inventory's per-file SHAs):
+    ``target_identity`` verbatim when the caller supplies one (e.g. the archive
+    block from a target the run unpacked), else ``target_snapshot(target)`` for
+    a git checkout, else ``{source: "directory"}`` for a plain directory.
     """
     manifest: Dict[str, Any] = {
         "schema": 1,
         "source_control": source_control_snapshot(repo_dir),
         "environment": environment_snapshot(),
     }
-    tgt = target_snapshot(target)
+    tgt = target_identity if target_identity is not None else target_snapshot(target)
+    if not tgt and target and Path(target).is_dir():
+        # Non-git, non-archive directory: record only that it was a directory
+        # acquisition. Its content identity is the coverage store's to derive.
+        tgt = {"source": "directory"}
     if tgt:
         manifest["target"] = tgt
+    # WHO — the operator's public-facing identity (#485), from the per-uid
+    # ~/.raptor/identity.json. Omitted entirely when unset (no default); the
+    # citation view gates on its presence. See core.run.identity.
+    from core.run.identity import load_finder_identity
+    who = load_finder_identity()
+    if who:
+        manifest["who"] = who
     return manifest
 
 
@@ -395,6 +500,20 @@ def public_view(run_metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
             # Hash only — the diff content is never stored, so this is safe.
             "diff_sha256": sc.get("diff_sha256"),
         }
+    # Target block: a git target carries commit/branch (possibly a private
+    # engagement) → dropped. A non-git target (archive / directory) is an
+    # acquisition stamp — hashes + names only → publish-safe, the attribution a
+    # citation wants ("found in archive X"). Discriminate by `commit`. The
+    # content-equivalence id is the coverage store's, not published here.
+    tgt = manifest.get("target")
+    if isinstance(tgt, dict) and not tgt.get("commit"):
+        safe_tgt = {
+            k: tgt[k] for k in
+            ("source", "archive_sha256", "archive_name", "format")
+            if k in tgt
+        }
+        if safe_tgt:
+            pub["target"] = safe_tgt
     # Field-allowlist INSIDE each sub-dict too — never forward verbatim, so a
     # crafted/imported manifest can't smuggle a path or secret under an extra
     # key in environment / engines / models.
@@ -523,3 +642,121 @@ def format_provenance_rollup(summary: Dict[str, Any]) -> str:
     if summary.get("unavailable"):
         lines.append(f"  Provenance unavailable: {summary['unavailable']} run(s)")
     return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Manifest read accessors — the stable read contract.
+#
+# Consumers that read a run's provenance (the CoverageStore's import step, the
+# /project rollup, a future citation view) go through THESE rather than indexing
+# the raw ``.raptor-run.json`` dict, so the manifest's internal shape can evolve
+# without breaking them. Every accessor takes the loaded run-metadata dict (from
+# ``load_run_metadata(run_dir)``) and degrades gracefully — missing/legacy
+# fields return None / empty, never raise — so the same call works against an
+# old manifest, today's, and one with fields not yet added.
+#
+# The companion location convention is ``RUN_METADATA_FILE`` +
+# ``load_run_metadata(run_dir)`` in core.run.metadata.
+# ---------------------------------------------------------------------------
+
+
+def run_manifest(run_metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """The sealed manifest sub-dict of a loaded run metadata, or ``{}`` when
+    absent or the 'unavailable' stamp (legacy/adopted runs). The base every
+    field accessor below reads through."""
+    if not run_metadata:
+        return {}
+    m = run_metadata.get("manifest")
+    if not isinstance(m, dict) or m.get("provenance") == "unavailable":
+        return {}
+    return m
+
+
+def run_engines(run_metadata: Optional[Dict[str, Any]]) -> Dict[str, Optional[str]]:
+    """``{engine_name: version}`` that ran (version may be None), or ``{}``."""
+    engines = run_manifest(run_metadata).get("engines")
+    return dict(engines) if isinstance(engines, dict) else {}
+
+
+def run_models(run_metadata: Optional[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """The models that fired — each a dict with ``provider`` / ``alias`` /
+    ``resolved`` (the snapshot, not the floating alias) / ``role`` / ``calls``.
+    ``[]`` when none (e.g. a mechanical scan)."""
+    models = run_manifest(run_metadata).get("models")
+    return [m for m in models if isinstance(m, dict)] if isinstance(models, list) else []
+
+
+def run_target(run_metadata: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """The target's ACQUISITION stamp — how the code was acquired: git
+    ``{vcs, commit, branch, dirty}`` / archive ``{source, archive_sha256, …}`` /
+    ``{source: "directory"}``. None when absent.
+
+    This is the loose, per-acquisition audit stamp, NOT a content-equivalence
+    id: two acquisitions of identical bytes (a git checkout vs a zip) carry
+    *different* stamps here by design. A consumer that needs content
+    equivalence (git-X ≡ zip-X) derives it from the inventory's per-file
+    SHA-256 set, not from this field.
+    """
+    target = run_manifest(run_metadata).get("target")
+    return target if isinstance(target, dict) else None
+
+
+def run_framework_sha(run_metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+    """The RAPTOR framework ``base_sha`` that produced the run, or None."""
+    sc = run_manifest(run_metadata).get("source_control")
+    return sc.get("base_sha") if isinstance(sc, dict) else None
+
+
+def run_timestamp(run_metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+    """The run's start timestamp (ISO 8601). Top-level on the metadata, not in
+    the manifest — the accessor hides that."""
+    if not run_metadata:
+        return None
+    ts = run_metadata.get("timestamp")
+    return ts if isinstance(ts, str) else None
+
+
+def run_deterministically_reproducible(
+    run_metadata: Optional[Dict[str, Any]],
+) -> Optional[bool]:
+    """Whether the run's verdict is a pure function of its inputs (mechanical),
+    or None when the manifest predates the field — so a consumer can tell
+    "not reproducible" apart from "unknown"."""
+    v = run_manifest(run_metadata).get("deterministically_reproducible")
+    return v if isinstance(v, bool) else None
+
+
+def run_who(run_metadata: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """The operator's public-facing identity (``{name, handle?, url?}``) sealed
+    at run start, or None when no identity was set — the WHO a citation
+    credits. See core.run.identity."""
+    who = run_manifest(run_metadata).get("who")
+    return who if isinstance(who, dict) else None
+
+
+def harness_model_entry(model: Optional[str]) -> Optional[Dict[str, Any]]:
+    """A ``models[]`` entry for an agent-supplied ambient harness model — the
+    only value only the harness (the Claude session) knows, since RAPTOR's
+    Python can't read ``/model`` (no env var). The completion stubs build this
+    from the ``--model`` the /validate, /understand skills instruct the agent
+    to pass.
+
+    Hardened against the agent getting it wrong (it will): an unsubstituted
+    ``<your-model-id>`` placeholder, a stray flag captured as the value (leading
+    ``-``), whitespace-bearing prose, an empty/missing string, or an
+    implausibly long value all return None — the manifest then omits the model
+    rather than recording garbage (a wrong/junk model is worse than absent)."""
+    if not isinstance(model, str):
+        return None
+    m = model.strip()
+    if (not m
+            or m.startswith("-")                # a stray flag captured as value
+            or "<" in m or ">" in m             # unsubstituted <placeholder>
+            or len(m) > 128                      # implausibly long
+            # printable non-space ASCII only (0x21-0x7e): model ids are ASCII
+            # with no spaces, so this single check rejects prose/whitespace,
+            # control bytes (\x00, \x1b ANSI escapes), and unicode tricks
+            # (RTL-override) that would inject into / spoof the published manifest.
+            or any(not (0x21 <= ord(ch) <= 0x7e) for ch in m)):
+        return None
+    return {"role": "harness", "alias": m, "resolved": m}

--- a/core/run/tests/test_identity.py
+++ b/core/run/tests/test_identity.py
@@ -1,0 +1,98 @@
+"""Tests for core.run.identity — the operator/finder identity (#485 WHO)."""
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from core.run.identity import load_finder_identity
+
+
+class TestLoadFinderIdentity(unittest.TestCase):
+
+    def _write(self, d, obj):
+        p = Path(d) / "identity.json"
+        p.write_text(json.dumps(obj))
+        return p
+
+    def test_full_identity_allowlisted(self):
+        # name/handle/url kept; anything else dropped.
+        with TemporaryDirectory() as d:
+            p = self._write(d, {"name": "Jane Doe", "handle": "@jane",
+                                "url": "https://x", "secret": "drop-me"})
+            self.assertEqual(
+                load_finder_identity(p),
+                {"name": "Jane Doe", "handle": "@jane", "url": "https://x"})
+
+    def test_name_only(self):
+        with TemporaryDirectory() as d:
+            self.assertEqual(
+                load_finder_identity(self._write(d, {"name": "Jane"})),
+                {"name": "Jane"})
+
+    def test_no_usable_name_is_unset(self):
+        # No default "Raptor User": a nameless / blank / non-string name = unset.
+        with TemporaryDirectory() as d:
+            self.assertIsNone(load_finder_identity(self._write(d, {"handle": "@x"})))
+            self.assertIsNone(load_finder_identity(self._write(d, {"name": "   "})))
+            self.assertIsNone(load_finder_identity(self._write(d, {"name": 123})))
+            self.assertIsNone(load_finder_identity(self._write(d, {})))
+
+    def test_absent_file_is_none(self):
+        with TemporaryDirectory() as d:
+            self.assertIsNone(load_finder_identity(Path(d) / "nope.json"))
+
+    def test_malformed_is_none(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "identity.json"
+            p.write_text("not json{")
+            self.assertIsNone(load_finder_identity(p))
+            p.write_text(json.dumps(["a", "list"]))  # not a dict
+            self.assertIsNone(load_finder_identity(p))
+
+    def test_strips_whitespace(self):
+        with TemporaryDirectory() as d:
+            self.assertEqual(
+                load_finder_identity(self._write(d, {"name": "  Jane  ",
+                                                     "handle": "  @j  "})),
+                {"name": "Jane", "handle": "@j"})
+
+    # --- adversarial: who is publish-bound, so no injection/spoof/DoS ---
+
+    def test_rejects_control_and_format_chars(self):
+        # Null bytes / ANSI escapes / unicode bidi-override / zero-width must
+        # not reach a published identity (terminal injection, spoofing).
+        with TemporaryDirectory() as d:
+            for bad in ("Jane\x00Doe", "Jane\x1b[31mDoe", "Jane‮Doe",
+                        "a​b"):
+                self.assertIsNone(
+                    load_finder_identity(self._write(d, {"name": bad})),
+                    f"control/format char should reject: {bad!r}")
+
+    def test_keeps_legitimate_unicode_name(self):
+        # Real non-ASCII names are fine — only control/format chars are rejected.
+        with TemporaryDirectory() as d:
+            self.assertEqual(
+                load_finder_identity(self._write(d, {"name": "José 李"})),
+                {"name": "José 李"})
+
+    def test_length_caps(self):
+        with TemporaryDirectory() as d:
+            self.assertIsNone(
+                load_finder_identity(self._write(d, {"name": "x" * 500})))
+            # over-long handle dropped; usable name kept
+            self.assertEqual(
+                load_finder_identity(self._write(d, {"name": "Jane",
+                                                     "handle": "h" * 500})),
+                {"name": "Jane"})
+
+    def test_oversize_file_rejected(self):
+        # A huge (or huge-symlinked) file must not be read on the hot start path.
+        with TemporaryDirectory() as d:
+            p = Path(d) / "big.json"
+            p.write_text('{"name":"' + ("A" * (70 * 1024)) + '"}')
+            self.assertIsNone(load_finder_identity(p))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core/run/tests/test_provenance.py
+++ b/core/run/tests/test_provenance.py
@@ -18,7 +18,16 @@ from core.run.provenance import (
     format_provenance_rollup,
     format_repro_short,
     format_sha_short,
+    harness_model_entry,
     public_view,
+    run_deterministically_reproducible,
+    run_engines,
+    run_framework_sha,
+    run_manifest,
+    run_models,
+    run_target,
+    run_timestamp,
+    run_who,
     source_control_snapshot,
     target_snapshot,
     tool_version,
@@ -211,10 +220,13 @@ class TestDetectEngines(unittest.TestCase):
 
 class TestBuildStartManifestTarget(unittest.TestCase):
 
-    def test_no_target_block_when_not_git(self):
+    def test_directory_target_gets_acquisition_marker(self):
+        # A non-git directory now gets the {source:"directory"} acquisition
+        # stamp (no git block, no content hash — the equivalence id is the
+        # coverage store's, derived from the inventory).
         with TemporaryDirectory() as d:
             m = build_start_manifest(target=Path(d))
-            self.assertNotIn("target", m)
+            self.assertEqual(m["target"], {"source": "directory"})
 
     @unittest.skipUnless(_GIT, "git not available")
     def test_target_block_when_git(self):
@@ -268,37 +280,41 @@ class TestToolVersion(unittest.TestCase):
         self.assertIsNone(tool_version("coccinelle"))
 
 
-class TestScanEngineManifest(unittest.TestCase):
-    """Gating in raptor._scan_engine_manifest — only mechanical commands get
-    engine versions + deterministically_reproducible, and a non-scan command
-    must never produce a manifest (so it can't clobber agentic's)."""
+class TestStandardCompletionProvenance(unittest.TestCase):
+    """standard_completion_provenance — the end-of-run facts the lifecycle
+    derives itself: engines detected from output files for EVERY command, with
+    deterministically_reproducible True only for the deterministic static-rule
+    commands (scan/codeql)."""
 
-    def test_non_scan_command_returns_none(self):
-        import raptor
-        with TemporaryDirectory() as d:
-            self.assertIsNone(raptor._scan_engine_manifest(Path(d), "agentic"))
-            self.assertIsNone(raptor._scan_engine_manifest(Path(d), "fuzz"))
+    def test_deterministic_only_for_static_rule_commands(self):
+        from core.run.provenance import is_deterministically_reproducible
+        self.assertTrue(is_deterministically_reproducible("scan"))
+        self.assertTrue(is_deterministically_reproducible("codeql"))
+        # LLM-mediated (agentic/validate/understand) and stochastic/runtime
+        # (fuzz/web) commands are not — nor is an unknown command.
+        for cmd in ("agentic", "validate", "understand", "fuzz", "web", None):
+            self.assertFalse(is_deterministically_reproducible(cmd))
 
-    def test_scan_detects_engine_from_output_file(self):
-        import raptor
+    def test_engines_detected_for_any_command(self):
+        from core.run.provenance import standard_completion_provenance
         with TemporaryDirectory() as d:
             out = Path(d)
             # Real output filenames: semgrep_*.sarif, codeql_*.sarif, cocci.sarif.
             (out / "semgrep_semgrep_injection.sarif").write_text("{}")
             (out / "codeql_java.sarif").write_text("{}")
             (out / "cocci.sarif").write_text("{}")
-            m = raptor._scan_engine_manifest(out, "scan")
-            self.assertTrue(m["deterministically_reproducible"])
-            # Engines detected from canonical output files (value may be the
-            # version string or None if the tool isn't installed in CI).
+            # Even a non-scan command captures engines now (uniform coverage);
+            # only the reproducibility verdict differs by command.
+            m = standard_completion_provenance(out, "validate")
             self.assertIn("semgrep", m["engines"])
             self.assertIn("codeql", m["engines"])
             self.assertIn("coccinelle", m["engines"])
+            self.assertFalse(m["deterministically_reproducible"])
 
-    def test_scan_with_no_output_still_reproducible(self):
-        import raptor
+    def test_scan_reproducible_with_no_output(self):
+        from core.run.provenance import standard_completion_provenance
         with TemporaryDirectory() as d:
-            m = raptor._scan_engine_manifest(Path(d), "scan")
+            m = standard_completion_provenance(Path(d), "scan")
             self.assertEqual(m["engines"], {})
             self.assertTrue(m["deterministically_reproducible"])
 
@@ -490,13 +506,11 @@ class TestFormatProvenanceRollup(unittest.TestCase):
 
 class TestLifecycleE2E(unittest.TestCase):
     """End-to-end: start_run seals framework+target+env, a scan drops engine
-    output, complete_run merges engines+reproducibility — the full manifest a
-    real /scan run produces, exercised through the real lifecycle + raptor's
-    _scan_engine_manifest (no mocks)."""
+    output, complete_run fills engines+reproducibility — the full manifest a
+    real /scan run produces, exercised through the real lifecycle (no mocks)."""
 
     @unittest.skipUnless(_GIT, "git not available")
     def test_scan_run_seals_and_enriches_full_manifest(self):
-        import raptor
         from core.run import complete_run, load_run_metadata, start_run
         with TemporaryDirectory() as d:
             target = Path(d) / "target"
@@ -514,9 +528,11 @@ class TestLifecycleE2E(unittest.TestCase):
             self.assertIn("environment", sealed)
             self.assertNotIn("engines", sealed)            # not known yet
 
-            # Scanner drops its SARIF output, then the run completes.
+            # Scanner drops its SARIF output, then the run completes. No
+            # per-command manifest wiring — the lifecycle fills engines +
+            # deterministically_reproducible itself, uniformly.
             (out / "semgrep_owasp.sarif").write_text("{}")
-            complete_run(out, manifest=raptor._scan_engine_manifest(out, "scan"))
+            complete_run(out)
 
             final = load_run_metadata(out)
             m = final["manifest"]
@@ -524,9 +540,60 @@ class TestLifecycleE2E(unittest.TestCase):
             # Start-sealed facts survive the merge…
             self.assertIn("source_control", m)
             self.assertEqual(m["target"]["vcs"], "git")
-            # …and end-of-run facts are merged in.
+            # …and end-of-run facts are filled by the lifecycle.
             self.assertIn("semgrep", m["engines"])
             self.assertTrue(m["deterministically_reproducible"])
+
+
+class TestUniformCompletionEnrichment(unittest.TestCase):
+    """complete_run fills standard provenance for EVERY completion path —
+    including the Claude-driven commands that finish through the lifecycle
+    stubs without passing a manifest — and never clobbers a caller-supplied
+    fact."""
+
+    def test_non_scan_command_enriched_without_caller_manifest(self):
+        # /validate and /understand finish via the lifecycle stubs with no
+        # manifest=. They must still get engines + reproducibility — this is
+        # the uneven-coverage gap closed.
+        from core.run import complete_run, load_run_metadata, start_run
+        with TemporaryDirectory() as d:
+            out = Path(d) / "validate-run"
+            start_run(out, "validate", target=str(Path(d)))
+            (out / "semgrep_x.sarif").write_text("{}")
+            complete_run(out)  # no manifest — the stub path
+            m = load_run_metadata(out)["manifest"]
+            self.assertIn("semgrep", m["engines"])
+            self.assertFalse(m["deterministically_reproducible"])
+
+    def test_caller_supplied_key_is_not_clobbered(self):
+        # setdefault precedence: an explicit caller value wins over the
+        # lifecycle's derived default.
+        from core.run import complete_run, load_run_metadata, start_run
+        with TemporaryDirectory() as d:
+            out = Path(d) / "run"
+            start_run(out, "validate", target=str(Path(d)))
+            complete_run(out, manifest={"deterministically_reproducible": True})
+            m = load_run_metadata(out)["manifest"]
+            self.assertTrue(m["deterministically_reproducible"])
+
+    def test_unavailable_manifest_not_enriched(self):
+        # A run carrying the 'unavailable' stamp (predates manifest capture) is
+        # left untouched — no engines/reproducibility grafted on.
+        import json
+        from core.run import complete_run, load_run_metadata, start_run
+        from core.run.metadata import RUN_METADATA_FILE
+        with TemporaryDirectory() as d:
+            out = Path(d) / "run"
+            start_run(out, "scan", target=str(Path(d)))
+            meta_path = out / RUN_METADATA_FILE
+            meta = json.loads(meta_path.read_text())
+            meta["manifest"] = dict(UNAVAILABLE_MANIFEST)
+            meta_path.write_text(json.dumps(meta))
+            (out / "semgrep_x.sarif").write_text("{}")
+            complete_run(out)
+            m = load_run_metadata(out)["manifest"]
+            self.assertEqual(m.get("provenance"), "unavailable")
+            self.assertNotIn("engines", m)
 
 
 class TestUnavailableManifest(unittest.TestCase):
@@ -534,6 +601,102 @@ class TestUnavailableManifest(unittest.TestCase):
     def test_marked_unavailable(self):
         self.assertEqual(UNAVAILABLE_MANIFEST["provenance"], "unavailable")
         self.assertIn("reason", UNAVAILABLE_MANIFEST)
+
+
+class TestManifestReadAccessors(unittest.TestCase):
+    """The stable read contract consumers (CoverageStore import, /project rollup,
+    future citation) go through instead of indexing the raw manifest dict."""
+
+    def test_reads_each_field_from_a_real_manifest(self):
+        md = _full_run_metadata()
+        self.assertEqual(run_engines(md), {"semgrep": "1.79.0"})
+        self.assertEqual(run_models(md)[0]["resolved"], "gemini-2.5-pro")
+        self.assertEqual(run_target(md)["commit"], "4f2a9b1c")
+        self.assertEqual(run_framework_sha(md), "9668aa8c")
+        self.assertEqual(run_timestamp(md), "2026-05-24T16:00:00+00:00")
+        self.assertIs(run_deterministically_reproducible(md), False)
+
+    def test_degrades_gracefully_on_none_and_unavailable(self):
+        # None input and the 'unavailable' stamp both yield empty/None — never
+        # raise — so the same call works on legacy/adopted runs.
+        for md in (None, {}, {"manifest": dict(UNAVAILABLE_MANIFEST)}):
+            self.assertEqual(run_manifest(md), {})
+            self.assertEqual(run_engines(md), {})
+            self.assertEqual(run_models(md), [])
+            self.assertIsNone(run_target(md))
+            self.assertIsNone(run_framework_sha(md))
+            self.assertIsNone(run_deterministically_reproducible(md))
+
+    def test_missing_fields_return_empty_not_raise(self):
+        # A manifest that predates a field (e.g. no det_repro / no target yet)
+        # reads as None/empty, distinguishable from a present value.
+        md = {"timestamp": "2026-05-25T00:00:00+00:00",
+              "manifest": {"source_control": {"base_sha": "abc"}}}
+        self.assertEqual(run_engines(md), {})
+        self.assertEqual(run_models(md), [])
+        self.assertIsNone(run_target(md))
+        self.assertIsNone(run_deterministically_reproducible(md))
+        self.assertEqual(run_framework_sha(md), "abc")
+        self.assertEqual(run_timestamp(md), "2026-05-25T00:00:00+00:00")
+
+    def test_malformed_shapes_tolerated(self):
+        # Imported/corrupt manifest with wrong types must not crash accessors.
+        md = {"manifest": {"engines": ["not", "a", "dict"],
+                           "models": {"not": "a list"},
+                           "target": "not a dict"}}
+        self.assertEqual(run_engines(md), {})
+        self.assertEqual(run_models(md), [])
+        self.assertIsNone(run_target(md))
+
+
+class TestWhoAndHarnessModel(unittest.TestCase):
+    """#1 — the WHO (finder identity) sealed at start, and the agent-supplied
+    ambient harness model recorded at completion."""
+
+    def test_build_start_manifest_seals_who_when_set(self):
+        from unittest import mock
+        with mock.patch("core.run.identity.load_finder_identity",
+                        return_value={"name": "Jane Doe", "handle": "@jane"}):
+            m = build_start_manifest(target=None)
+            self.assertEqual(m["who"], {"name": "Jane Doe", "handle": "@jane"})
+
+    def test_build_start_manifest_omits_who_when_unset(self):
+        from unittest import mock
+        with mock.patch("core.run.identity.load_finder_identity", return_value=None):
+            self.assertNotIn("who", build_start_manifest(target=None))
+
+    def test_run_who_accessor(self):
+        self.assertEqual(run_who({"manifest": {"who": {"name": "Jane"}}}),
+                         {"name": "Jane"})
+        self.assertIsNone(run_who({"manifest": {}}))
+        self.assertIsNone(run_who(None))
+        self.assertIsNone(run_who({"manifest": {"who": "not-a-dict"}}))
+
+    def test_harness_model_entry_valid(self):
+        self.assertEqual(
+            harness_model_entry("claude-opus-4-7[1m]"),
+            {"role": "harness", "alias": "claude-opus-4-7[1m]",
+             "resolved": "claude-opus-4-7[1m]"})
+
+    def test_harness_model_entry_tolerates_agent_mistakes(self):
+        # The agent WILL fumble it — every bad shape must omit, never record junk.
+        for bad in (
+            None, "", "   ",
+            "<your-model-id>",            # unsubstituted placeholder
+            "claude-opus<x>",             # stray angle bracket
+            "--model",                    # a flag captured as the value
+            "-opus",                      # leading dash
+            "the model is opus",          # prose (whitespace)
+            "claude opus 4.7",            # whitespace
+            "x" * 200,                    # implausibly long
+            123,                          # non-string
+            # adversarial: manifest is publish-bound, so no injection/spoof
+            "claude\x00evil",             # null byte
+            "claude\x1b[31mRED",          # ANSI terminal-injection escape
+            "claude‮RTL",                 # unicode RTL-override spoof
+            "café-model",                 # non-ASCII (model ids are ASCII)
+        ):
+            self.assertIsNone(harness_model_entry(bad), f"should omit: {bad!r}")
 
 
 if __name__ == "__main__":

--- a/core/run/tests/test_provenance_archive.py
+++ b/core/run/tests/test_provenance_archive.py
@@ -1,0 +1,186 @@
+"""Tests for archive / tree target-identity provenance (core.run.provenance)."""
+
+import json
+import unittest
+import zipfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from core.run.provenance import (
+    archive_snapshot,
+    archive_target_identity,
+    build_start_manifest,
+    public_view,
+)
+
+
+def _zip(path, entries):
+    with zipfile.ZipFile(path, "w") as z:
+        for name, data in entries.items():
+            z.writestr(name, data)
+
+
+class TestArchiveSnapshot(unittest.TestCase):
+
+    def test_zip(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "a.zip"
+            _zip(p, {"f": b"x"})
+            s = archive_snapshot(p)
+            self.assertRegex(s["archive_sha256"], r"^[0-9a-f]{64}$")
+            self.assertEqual(s["archive_name"], "a.zip")
+            self.assertEqual(s["format"], "zip")
+
+    def test_non_archive_and_none(self):
+        with TemporaryDirectory() as d:
+            p = Path(d) / "plain.txt"
+            p.write_text("x")
+            self.assertIsNone(archive_snapshot(p))
+        self.assertIsNone(archive_snapshot(None))
+
+
+class TestArchiveTargetIdentity(unittest.TestCase):
+
+    def test_acquisition_stamp_only(self):
+        # Acquisition stamp only — NO content_sha256 (the content-equivalence
+        # id is the coverage store's, derived from the inventory).
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            ap = d / "a.zip"
+            _zip(ap, {"f": b"x"})
+            b = archive_target_identity(ap)
+            self.assertEqual(b["source"], "archive")
+            self.assertRegex(b["archive_sha256"], r"^[0-9a-f]{64}$")
+            self.assertEqual(b["archive_name"], "a.zip")
+            self.assertEqual(b["format"], "zip")
+            self.assertNotIn("content_sha256", b)
+
+    def test_non_archive_none(self):
+        with TemporaryDirectory() as d:
+            self.assertIsNone(archive_target_identity(Path(d) / "missing.zip"))
+
+
+class TestBuildStartManifestTargetIdentity(unittest.TestCase):
+
+    def test_explicit_identity_overrides_snapshot(self):
+        ident = {"source": "archive", "archive_sha256": "a" * 64}
+        m = build_start_manifest(target=None, target_identity=ident)
+        self.assertEqual(m["target"], ident)
+
+    def test_plain_directory_gets_source_marker(self):
+        # A non-git/non-archive dir target gets the acquisition marker only
+        # (no content hash — that's the store's equivalence id).
+        with TemporaryDirectory() as d:
+            m = build_start_manifest(target=d)
+            self.assertEqual(m["target"], {"source": "directory"})
+
+    def test_no_target_no_block(self):
+        self.assertNotIn("target", build_start_manifest(target=None))
+
+
+class TestPublicViewTarget(unittest.TestCase):
+
+    def test_archive_acquisition_published_content_hash_dropped(self):
+        md = {"command": "scan", "manifest": {
+            "source_control": {"base_sha": "x", "dirty": False},
+            "target": {"source": "archive", "archive_sha256": "a" * 64,
+                       "archive_name": "a.zip", "format": "zip",
+                       "content_sha256": "b" * 64},
+        }}
+        pv = public_view(md)
+        t = pv["manifest"]["target"]
+        self.assertEqual(t["archive_sha256"], "a" * 64)
+        self.assertEqual(t["source"], "archive")
+        self.assertEqual(t["format"], "zip")
+        # content_sha256 is NOT published — it's the store's equivalence id,
+        # never a manifest field.
+        self.assertNotIn("content_sha256", t)
+
+    def test_git_target_dropped(self):
+        md = {"command": "scan", "manifest": {
+            "source_control": {"base_sha": "x"},
+            "target": {"vcs": "git", "commit": "deadbeef",
+                       "branch": "secret/engagement", "dirty": False},
+        }}
+        pv = public_view(md)
+        self.assertNotIn("target", pv.get("manifest", {}))
+        self.assertNotIn("secret/engagement", json.dumps(pv))
+
+
+class TestRewriteTargetArg(unittest.TestCase):
+
+    def test_space_form(self):
+        import raptor
+        self.assertEqual(
+            raptor._rewrite_target_arg(["--repo", "/a.zip", "-x"], "/a.zip", "/ex"),
+            ["--repo", "/ex", "-x"])
+
+    def test_eq_form(self):
+        import raptor
+        self.assertEqual(
+            raptor._rewrite_target_arg(["--repo=/a.zip"], "/a.zip", "/ex"),
+            ["--repo=/ex"])
+
+    def test_binary_flag_and_passthrough(self):
+        import raptor
+        self.assertEqual(
+            raptor._rewrite_target_arg(["--binary", "/a.zip"], "/a.zip", "/ex"),
+            ["--binary", "/ex"])
+        self.assertEqual(
+            raptor._rewrite_target_arg(["--foo", "bar"], "/a.zip", "/ex"),
+            ["--foo", "bar"])
+
+
+class TestUnpackArchiveTarget(unittest.TestCase):
+
+    def test_content_addressed_cache_and_reuse(self):
+        import raptor
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            ap = d / "a.zip"
+            _zip(ap, {"src/x.py": b"print()\n"})
+            out1 = d / "proj" / "scan_1"
+            out1.mkdir(parents=True)
+            res = raptor._unpack_archive_target(
+                str(ap), ["--repo", str(ap), "--no-codeql"], out1)
+            self.assertIsNotNone(res)
+            new_args, identity = res
+            canonical = Path(new_args[new_args.index("--repo") + 1])
+            # Extracted into <project>/_sources/<name>-<sha>/ — not the run dir.
+            self.assertEqual(canonical.parent, d / "proj" / "_sources")
+            # Dir name is human-readable (archive name) AND collision-free (sha).
+            self.assertTrue(canonical.name.startswith("a.zip-"))
+            self.assertTrue(canonical.name.endswith(identity["archive_sha256"]))
+            self.assertTrue((canonical / "src" / "x.py").exists())
+            self.assertEqual(identity["source"], "archive")
+            self.assertNotIn("content_sha256", identity)  # equivalence id is the store's
+            # Navigation symlink from the run dir.
+            self.assertTrue((out1 / "_source").is_symlink())
+
+            # A second run (same project, different run dir) REUSES the cached
+            # extraction — no duplicate copy — and yields the same identity.
+            out2 = d / "proj" / "scan_2"
+            out2.mkdir(parents=True)
+            new_args2, identity2 = raptor._unpack_archive_target(
+                str(ap), ["--repo", str(ap)], out2)
+            canonical2 = Path(new_args2[new_args2.index("--repo") + 1])
+            self.assertEqual(canonical2, canonical)  # same cache dir, not duplicated
+            self.assertEqual(identity2["archive_sha256"], identity["archive_sha256"])
+            # Exactly one extraction dir under _sources.
+            extracted_dirs = [p for p in (d / "proj" / "_sources").iterdir() if p.is_dir()]
+            self.assertEqual(len(extracted_dirs), 1)
+
+    def test_corrupt_archive_returns_none(self):
+        import raptor
+        with TemporaryDirectory() as d:
+            d = Path(d)
+            bad = d / "broken.gz"
+            bad.write_bytes(b"\x1f\x8b\x08" + b"\xff" * 8)
+            out_dir = d / "proj" / "scan"
+            out_dir.mkdir(parents=True)
+            self.assertIsNone(
+                raptor._unpack_archive_target(str(bad), ["--repo", str(bad)], out_dir))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core/tar/__init__.py
+++ b/core/tar/__init__.py
@@ -37,7 +37,11 @@ Limitations:
     always returns bytes. Callers that want text decode themselves.
 """
 
-from .extract import extract_files_from_tar
+from .extract import (
+    TarEntryCountExceeded,
+    TarTotalBytesExceeded,
+    extract_files_from_tar,
+)
 from .safe_member import (
     DEFAULT_MAX_MEMBER_BYTES,
     UnsafeMemberReason,
@@ -47,6 +51,8 @@ from .safe_member import (
 
 __all__ = [
     "DEFAULT_MAX_MEMBER_BYTES",
+    "TarEntryCountExceeded",
+    "TarTotalBytesExceeded",
     "UnsafeMemberReason",
     "extract_files_from_tar",
     "is_safe_member",

--- a/core/tar/extract.py
+++ b/core/tar/extract.py
@@ -109,6 +109,17 @@ def _to_fileobj(source: Union[bytes, Iterable[bytes]]) -> io.IOBase:
     return _ChunkStream(source)
 
 
+class TarEntryCountExceeded(Exception):
+    """Raised when a tar's member count exceeds ``max_entry_count`` (opt-in).
+    Tar has no central directory, so this bounds a million-tiny-entries walk."""
+
+
+class TarTotalBytesExceeded(Exception):
+    """Raised when the cumulative extracted-bytes total exceeds
+    ``max_total_bytes`` (opt-in) — the aggregate-size bomb defense (per-member
+    cap doesn't bound the sum). Always raises, never silently truncates."""
+
+
 def extract_files_from_tar(
     source: Union[bytes, Iterable[bytes]],
     *,
@@ -118,6 +129,8 @@ def extract_files_from_tar(
     allow_absolute_paths: bool = False,
     expected_count: Optional[int] = None,
     unique_keys: bool = False,
+    max_total_bytes: Optional[int] = None,
+    max_entry_count: Optional[int] = None,
 ) -> Dict[str, bytes]:
     """Walk ``source`` (a tar archive) and return selected members
     as a ``{key: bytes}`` dict.
@@ -160,7 +173,13 @@ def extract_files_from_tar(
         return found
 
     try:
+        total_bytes = 0
+        count = 0
         for member in tf:
+            count += 1
+            if max_entry_count is not None and count > max_entry_count:
+                raise TarEntryCountExceeded(
+                    f"tar exceeds {max_entry_count} entries (bomb-shape); refusing")
             if not member.isfile():
                 continue
             reason = safe_member_reason(
@@ -195,9 +214,16 @@ def extract_files_from_tar(
                     f"duplicate tar key {key!r} (unique_keys=True)"
                 )
             try:
-                found[key] = f.read()
+                data = f.read()
             finally:
                 f.close()
+            if max_total_bytes is not None:
+                total_bytes += len(data)
+                if total_bytes > max_total_bytes:
+                    raise TarTotalBytesExceeded(
+                        f"tar extraction exceeds {max_total_bytes} bytes "
+                        f"(bomb-shape); refusing")
+            found[key] = data
             if expected_count is not None and len(found) >= expected_count:
                 break
     finally:

--- a/core/tar/tests/test_extract.py
+++ b/core/tar/tests/test_extract.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import gzip
 import io
 import tarfile
+
+import pytest
 from typing import List, Optional
 
 from core.tar.extract import extract_files_from_tar
@@ -309,3 +311,18 @@ def test_selector_is_only_called_on_files():
         buf.getvalue(), selector=_s, mode="r:*",
     )
     assert seen == [("afile.txt", True)]
+
+
+def test_max_total_and_entry_caps_with_default_unchanged():
+    from core.tar.extract import TarEntryCountExceeded, TarTotalBytesExceeded
+    raw = _make_tar([(f"f{i}", b"A" * 100) for i in range(5)])
+    # Default (no caps): all extracted — existing callers unaffected.
+    assert len(extract_files_from_tar(raw, selector=lambda m: m.name, mode="r:")) == 5
+    # Aggregate-bytes cap raises (never silently truncates).
+    with pytest.raises(TarTotalBytesExceeded):
+        extract_files_from_tar(
+            raw, selector=lambda m: m.name, mode="r:", max_total_bytes=250)
+    # Entry-count cap raises.
+    with pytest.raises(TarEntryCountExceeded):
+        extract_files_from_tar(
+            raw, selector=lambda m: m.name, mode="r:", max_entry_count=2)

--- a/core/zip/__init__.py
+++ b/core/zip/__init__.py
@@ -45,7 +45,11 @@ Limitations:
 """
 
 from .eocd import DEFAULT_MAX_ENTRIES, peek_total_entries
-from .extract import ZipEntryCountExceeded, extract_files_from_zip
+from .extract import (
+    ZipEntryCountExceeded,
+    ZipTotalBytesExceeded,
+    extract_files_from_zip,
+)
 from .safe_member import (
     DEFAULT_MAX_MEMBER_BYTES,
     DEFAULT_MAX_RATIO,
@@ -60,6 +64,7 @@ __all__ = [
     "DEFAULT_MAX_RATIO",
     "UnsafeMemberReason",
     "ZipEntryCountExceeded",
+    "ZipTotalBytesExceeded",
     "extract_files_from_zip",
     "is_safe_member",
     "peek_total_entries",

--- a/core/zip/extract.py
+++ b/core/zip/extract.py
@@ -72,6 +72,18 @@ class ZipEntryCountExceeded(Exception):
     """
 
 
+class ZipTotalBytesExceeded(Exception):
+    """Raised when the CUMULATIVE extracted-bytes total exceeds the caller's
+    ``max_total_bytes``.
+
+    The per-member size and entry-count caps bound each member and the count,
+    but NOT the aggregate — N members each just under ``max_member_bytes``
+    still sum to N×64 MiB in memory. ``max_total_bytes`` (opt-in) bounds the
+    sum and ALWAYS raises (never truncates), so a caller extracting to disk
+    can't be handed a silently-incomplete result.
+    """
+
+
 def extract_files_from_zip(
     source: Union[bytes, str, os.PathLike, io.IOBase],
     *,
@@ -82,6 +94,7 @@ def extract_files_from_zip(
     allow_absolute_paths: bool = False,
     expected_count: Optional[int] = None,
     raise_on_entry_count: bool = False,
+    max_total_bytes: Optional[int] = None,
 ) -> Dict[str, bytes]:
     """Walk ``source`` (a zip archive) and return selected members
     as a ``{key: bytes}`` dict.
@@ -157,6 +170,7 @@ def extract_files_from_zip(
         return found
 
     try:
+        total_bytes = 0
         for i, info in enumerate(zf.infolist()):
             # In-memory cap. EOCD pre-flight catches the common bomb
             # case but some archives (unusual but valid) have a
@@ -195,7 +209,7 @@ def extract_files_from_zip(
                 # member's compressed-data bounds — we don't have
                 # to defend against over-read separately.
                 with zf.open(info) as f:
-                    found[key] = f.read()
+                    data = f.read()
             except (zipfile.BadZipFile, OSError, RuntimeError) as e:
                 # ``RuntimeError`` covers password-protected entries
                 # in older Python versions; ``BadZipFile`` covers
@@ -206,6 +220,15 @@ def extract_files_from_zip(
                     info.filename, e,
                 )
                 continue
+            # Aggregate-size cap: bound the SUM of materialised bytes, not just
+            # per-member/count. Always raises (never silently truncates).
+            if max_total_bytes is not None:
+                total_bytes += len(data)
+                if total_bytes > max_total_bytes:
+                    raise ZipTotalBytesExceeded(
+                        f"zip extraction exceeds {max_total_bytes} bytes "
+                        f"(bomb-shape); refusing")
+            found[key] = data
             if expected_count is not None and len(found) >= expected_count:
                 break
     finally:

--- a/core/zip/tests/test_extract.py
+++ b/core/zip/tests/test_extract.py
@@ -251,3 +251,14 @@ def test_compression_bomb_skipped():
     )
     assert "bomb.bin" not in result
     assert result == {"ok.txt": b"hello"}
+
+
+def test_max_total_bytes_caps_aggregate_and_default_unchanged():
+    from core.zip.extract import ZipTotalBytesExceeded
+    z = _make_zip(*[(f"f{i}", b"A" * 100, None) for i in range(5)])
+    # Default (no cap): all members extracted — existing callers unaffected.
+    assert len(extract_files_from_zip(z, selector=lambda i: i.filename)) == 5
+    # A cap below the aggregate raises (never silently truncates).
+    with pytest.raises(ZipTotalBytesExceeded):
+        extract_files_from_zip(
+            z, selector=lambda i: i.filename, max_total_bytes=250)

--- a/libexec/raptor-run-lifecycle
+++ b/libexec/raptor-run-lifecycle
@@ -101,10 +101,23 @@ def main():
 
     elif action == "complete":
         if len(sys.argv) < 3:
-            print("Usage: raptor-run-lifecycle complete <output_dir>", file=sys.stderr)
+            print("Usage: raptor-run-lifecycle complete <output_dir> [--model <id>]",
+                  file=sys.stderr)
             sys.exit(1)
+        # Optional --model: the ambient harness model only the agent knows
+        # (RAPTOR's Python can't read /model — no env var). The /understand
+        # skill instructs the agent to pass its own model id here.
+        rest = sys.argv[3:]
+        model = rest[rest.index("--model") + 1] if (
+            "--model" in rest and rest.index("--model") + 1 < len(rest)) else None
         try:
-            complete_run(Path(sys.argv[2]))
+            manifest = None
+            if model:
+                from core.run.provenance import harness_model_entry
+                entry = harness_model_entry(model)
+                if entry:
+                    manifest = {"models": [entry]}
+            complete_run(Path(sys.argv[2]), manifest=manifest)
         except Exception as e:
             print(f"ERROR: {e}", file=sys.stderr)
             sys.exit(1)

--- a/libexec/raptor-validation-helper
+++ b/libexec/raptor-validation-helper
@@ -1350,7 +1350,7 @@ def prepare_0(workdir_unused, target=None, explicit_out=None, no_bridge=False):
         raise
 
 
-def prepare_1(workdir, target=None):
+def prepare_1(workdir, target=None, model=None):
     """Stage 1: report, coverage, diagrams, complete lifecycle."""
     _apply_stage_file(workdir, "F")
 
@@ -1398,10 +1398,15 @@ def prepare_1(workdir, target=None):
     except Exception:
         pass
 
-    # Complete lifecycle
+    # Complete lifecycle. Record the ambient harness model the agent passed via
+    # --model (only the harness knows /model — RAPTOR's Python can't read it);
+    # omitted when not supplied.
     from core.run.metadata import complete_run
+    from core.run.provenance import harness_model_entry
     try:
-        complete_run(Path(workdir))
+        entry = harness_model_entry(model)
+        manifest = {"models": [entry]} if entry else None
+        complete_run(Path(workdir), manifest=manifest)
     except Exception as e:
         print(f"Lifecycle error: {e}")
 
@@ -1425,7 +1430,7 @@ STAGES = {
 def main():
     args = sys.argv[1:]
     if not args or args[0] not in STAGES:
-        print(f"Usage: {sys.argv[0]} <0|A|B|C|D|E|F|1> [workdir] [--target <path>] [--out <dir>] [--no-bridge]")
+        print(f"Usage: {sys.argv[0]} <0|A|B|C|D|E|F|1> [workdir] [--target <path>] [--out <dir>] [--model <id>] [--no-bridge]")
         sys.exit(1)
 
     stage = args[0]
@@ -1439,6 +1444,13 @@ def main():
         idx = args.index("--out")
         if idx + 1 < len(args):
             explicit_out = args[idx + 1]
+    # Ambient harness model the agent passes (only it knows /model); stage 1
+    # records it into models[]. Omitted when absent.
+    model = None
+    if "--model" in args:
+        idx = args.index("--model")
+        if idx + 1 < len(args):
+            model = args[idx + 1]
     no_bridge = "--no-bridge" in args
 
     # Stage 0 creates its own workdir
@@ -1456,7 +1468,10 @@ def main():
         print(f"ERROR: workdir not found: {workdir}", file=sys.stderr)
         sys.exit(1)
 
-    STAGES[stage](workdir, target)
+    if stage == "1":
+        prepare_1(workdir, target, model=model)
+    else:
+        STAGES[stage](workdir, target)
 
 
 if __name__ == "__main__":

--- a/raptor.py
+++ b/raptor.py
@@ -80,24 +80,110 @@ def _extract_target(args: list) -> str | None:
     return None
 
 
-def _scan_engine_manifest(out_dir: Path, command: str) -> dict | None:
-    """End-of-run provenance for mechanical scan commands.
+def _rewrite_target_arg(args: list, old: str, new: str) -> list:
+    """Return ``args`` with the --repo/--binary/--url value ``old`` replaced by
+    ``new`` (both ``--flag value`` and ``--flag=value`` forms)."""
+    flags = ("--repo", "--binary", "--url")
+    out: list = []
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a in flags and i + 1 < len(args) and args[i + 1] == old:
+            out += [a, new]
+            i += 2
+            continue
+        matched = next((f for f in flags if a == f"{f}={old}"), None)
+        out.append(f"{matched}={new}" if matched else a)
+        i += 1
+    return out
 
-    Only ``scan`` and ``codeql`` are purely mechanical — static rules/queries
-    with no LLM in the verdict path — so only they record engine versions and
-    ``deterministically_reproducible=True`` here. Other commands routed through
-    ``_run_with_lifecycle`` (agentic, fuzz, web) either manage their own
-    provenance (agentic seals ``deterministically_reproducible=False``) or are
-    not yet covered; returning None leaves their manifest untouched so we never
-    clobber it. Engines are detected from their canonical output files.
+
+_CACHE_NAME_ALLOWED = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
+
+
+def _safe_cache_name(archive_name: str, sha: str) -> str:
+    """Content-cache dir name: ``<sanitised archive name>-<sha>`` — readable
+    *and* collision-free. The archive name is attacker-influenced, so it's
+    reduced to a safe charset, stripped of leading separators, and length-capped
+    before the sha (which alone guarantees uniqueness) is appended.
     """
-    if command not in ("scan", "codeql"):
+    base = "".join(c if c in _CACHE_NAME_ALLOWED else "_" for c in archive_name)
+    base = base.strip("._-")[:64] or "archive"
+    return f"{base}-{sha}"
+
+
+def _unpack_archive_target(target: str, args: list, out_dir: Path):
+    """Extract an archive ``target`` into a CONTENT-ADDRESSED shared cache and
+    point the scan at it.
+
+    The extraction lives at ``<out_dir.parent>/_sources/<archive_sha256>/`` —
+    automatically project-scoped (``<project>/_sources/…`` in project mode,
+    ``out/_sources/…`` otherwise) and deduped by content: one copy per distinct
+    archive shared across every run in that scope, never a per-run copy. A
+    second scan of the same archive is a cache hit (no re-extraction). The
+    extracted source persists (findings stay navigable; downstream can read the
+    flagged code); a ``<out_dir>/_source`` symlink makes each run navigable.
+
+    Returns ``(new_args, target_identity)`` — args with the target rewritten to
+    the cache dir and the manifest archive-identity block — or ``None`` if
+    extraction failed (caller should fail the run rather than scan the archive).
+    """
+    import shutil
+    import tempfile
+
+    from core.archive import extract_to_dir
+    from core.run.provenance import archive_snapshot
+
+    snap = archive_snapshot(target)
+    if snap is None:
         return None
-    from core.run.provenance import detect_engines
-    return {
-        "engines": detect_engines(out_dir),
-        "deterministically_reproducible": True,
-    }
+    sha = snap["archive_sha256"]
+    sources_root = out_dir.parent / "_sources"
+    sources_root.mkdir(parents=True, exist_ok=True)
+    # <name>-<sha> so the dir is self-describing ("what is this?") while the sha
+    # keeps it unique/collision-free.
+    cache_name = _safe_cache_name(snap["archive_name"], sha)
+    canonical = sources_root / cache_name
+
+    if canonical.exists():
+        print(f"[*] Reusing extracted {snap['format']} archive (cache hit {sha[:12]})")
+    else:
+        # Extract to a unique temp sibling, then atomically promote to <sha>/.
+        # Presence of <sha>/ therefore means a COMPLETE extraction, and a
+        # concurrent run racing us just loses the os.replace harmlessly.
+        tmp = Path(tempfile.mkdtemp(dir=sources_root, prefix=".extract-"))
+        try:
+            stats = extract_to_dir(target, tmp)
+        except Exception as e:
+            # Broad on purpose: extraction runs on attacker-controlled input,
+            # so ANY failure (ArchiveError, an unforeseen OSError/ValueError, or
+            # a MemoryError from an oversized archive) must fail the run
+            # gracefully — never crash raptor with a traceback.
+            shutil.rmtree(tmp, ignore_errors=True)
+            print(f"✗ archive extraction failed for {target}: {e}", file=sys.stderr)
+            return None
+        try:
+            os.replace(tmp, canonical)
+        except OSError:
+            shutil.rmtree(tmp, ignore_errors=True)  # lost the race; canonical is there
+        print(f"[*] Unpacked {stats['format']} archive: {stats['files']} files (cache {sha[:12]})")
+
+    # Acquisition stamp only — {source, archive_sha256, archive_name, format}.
+    # The extracted tree's content-equivalence id is the coverage store's to
+    # derive from the inventory, not a second source of truth recorded here.
+    identity = {"source": "archive", **snap}
+
+    # Local navigation aid: <out_dir>/_source -> the cached tree (relative).
+    try:
+        link = out_dir / "_source"
+        if not link.exists():
+            link.symlink_to(os.path.relpath(canonical, out_dir))
+    except OSError:
+        pass
+
+    new_args = _rewrite_target_arg(args, target, str(canonical))
+    return new_args, identity
 
 
 def _run_with_lifecycle(command: str, script_path: Path, args: list,
@@ -108,6 +194,7 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
     into the downstream script args, and marks the run complete or failed.
     """
     target = _extract_target(args)
+
     try:
         out_dir = get_output_dir(command, target_path=target)
     except TargetMismatchError as e:
@@ -122,7 +209,20 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
     out_dir.parent.mkdir(parents=True, exist_ok=True)
     safe_run_mkdir(out_dir)
 
-    start_run(out_dir, command, target=target)
+    # Archive target: unpack into the content-addressed shared cache
+    # (<out_dir.parent>/_sources/<sha>), scan the extracted tree, and record the
+    # archive<->tree binding in the manifest. Deduped across runs; a re-scan of
+    # the same archive is a cache hit.
+    target_identity = None
+    if target and Path(target).is_file():
+        from core.archive import is_archive
+        if is_archive(target):
+            res = _unpack_archive_target(target, args, out_dir)
+            if res is None:
+                return 1  # extraction failed (message printed); no run sealed yet
+            args, target_identity = res
+
+    start_run(out_dir, command, target=target, target_identity=target_identity)
 
     # SAGE: Pre-scan recall
     try:
@@ -245,7 +345,10 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
             pass
 
     if rc == 0:
-        complete_run(out_dir, manifest=_scan_engine_manifest(out_dir, command))
+        # Engine versions + deterministically_reproducible are filled by the
+        # lifecycle itself now (core.run.complete_run), uniformly for every
+        # command — no per-command manifest wiring here.
+        complete_run(out_dir)
     else:
         fail_run(out_dir, error=f"exit code {rc}")
     return rc

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -2409,7 +2409,6 @@ Examples:
     # Mark run as completed
     try:
         from core.run import complete_run
-        from core.run.provenance import detect_engines as _provenance_detect_engines
         orch_meta = (orchestration_result or {}).get("orchestration", {})
         complete_run(out_dir, extra={
             "findings_count": analysed_count,
@@ -2420,15 +2419,11 @@ Examples:
             "aggregate_models": orch_meta.get("aggregate_models", []),
             "aggregated": orch_meta.get("aggregated", False),
         }, manifest={
-            # End-of-run provenance merged into the start-sealed manifest.
+            # Only the in-process fact the lifecycle can't see for itself: the
+            # models that fired. Engines (from the scan phase) and
+            # deterministically_reproducible=False (agentic is LLM-mediated)
+            # are filled uniformly by core.run.complete_run.
             "models": orch_meta.get("fired_models", []),
-            # Engines from the scan phase (/agentic runs semgrep/codeql before
-            # analysis) — captured the same way /scan does.
-            "engines": _provenance_detect_engines(out_dir),
-            # Agentic analysis is LLM-mediated by definition — the verdict path
-            # always runs through a model (in-process or subprocess), so the
-            # result is never deterministically reproducible.
-            "deterministically_reproducible": False,
         })
     except Exception as e:
         logger.debug(f"Run metadata: {e}")  # Optional — don't fail the pipeline


### PR DESCRIPTION
Delivers the per-run provenance "feeder" the coverage store (L2) consumes, plus the harness-supplied WHO/model channel (#1). The manifest stays the run-keyed acquisition + how/when/who record; content-equivalence and finding<->provenance are the consumers' jobs, not duplicated here.

- Accessor API — stable run_* readers (run_engines / run_models / run_target / run_framework_sha / run_timestamp / run_deterministically_reproducible / run_who) over a loaded .raptor-run.json, all graceful on missing / unavailable / malformed input. The L1->L2 read contract, so consumers never couple to the raw manifest shape. Location convention: existing RUN_METADATA_FILE + load_run_metadata.

- Archive targets — /scan --repo foo.tar.gz detects (magic bytes), unpacks (hardened: zip-slip / symlink / decompression-bomb caps, incl. an additive max_total_bytes running-sum cap in core.zip/core.tar; default unchanged, so SCA/OCI/codeql consumers are unaffected), scans the extracted tree from a content-addressed shared cache, and records the archive acquisition stamp.

- Uniform enrichment (seam) — complete_run fills engines + reproducibility for EVERY command, so the Claude-driven /validate and /understand, which got no end-of-run provenance before, are now covered uniformly.

- Target = acquisition stamp only — git {commit,...} / archive {archive_sha256, ...} / {source:"directory"}. The content-equivalence id (git-X == zip-X) is left to the coverage store to derive from the inventory; a second tree-walk hash here would be redundant and could disagree.

- Finder identity + harness model — per-uid ~/.raptor/identity.json (never auto-detected from $USER/git/gh; no default, absent => omitted; /cite gates on presence) seals `who` at start. The ambient harness model, which only the agent knows (RAPTOR can't read /model), is passed by the /validate and /understand skills via --model on the completion stubs and recorded into models[]; spawned `claude -p` models stay captured via the response envelope.

Adversarially hardened (the manifest is publish-bound): the model entry and the identity loader reject control bytes, ANSI escapes, unicode bidi-overrides, over-long values, and (identity) oversized files, omitting rather than recording injection / spoof / DoS payloads.