### PR TITLE
fix(sca): npm package.json rewriter keeps the upper bound on an explicit range

### DIFF
--- a/packages/sca/tests/test_npm_bump_spec.py
+++ b/packages/sca/tests/test_npm_bump_spec.py
@@ -1,0 +1,68 @@
+"""Tests for _bump_npm_spec — npm harden spec rewriting.
+
+Regression focus: an explicit comparator range must keep its upper bound
+(``>=2.0.0 <3.0.0`` -> ``>=2.8.0 <3.0.0``), not collapse to a bare
+``2.8.0`` that silently drops the operator's ceiling.
+"""
+from __future__ import annotations
+
+import pytest
+
+from packages.sca.update import _bump_npm_spec
+
+
+@pytest.mark.parametrize("current,target,expected", [
+    # operator forms are preserved (already corridors — unchanged behaviour)
+    ("^2.0.0", "2.8.0", "^2.8.0"),
+    ("~2.0.0", "2.8.0", "~2.8.0"),
+    ("2.0.0",  "2.8.0", "2.8.0"),          # exact
+    ("*",      "2.8.0", "2.8.0"),
+    # THE FIX: explicit range bumps the floor, keeps the ceiling
+    (">=2.0.0 <3.0.0", "2.8.0", ">=2.8.0 <3.0.0"),
+    (">=2.0.0",        "2.8.0", ">=2.8.0"),
+    (">2.0.0 <3.0.0",  "2.8.0", ">2.8.0 <3.0.0"),   # strict > kept
+    (">=2 <3",         "2.8.0", ">=2.8.0 <3"),       # partial bounds kept
+    ("<=2.9.0 >=2.0.0", "2.8.0", "<=2.9.0 >=2.8.0"),  # order-independent
+    # target at/above the declared ceiling -> manual review (no invalid range)
+    (">=2.0.0 <3.0.0", "3.5.0", None),
+    (">=2.0.0 <3.0.0", "3.0.0", None),
+    # target BELOW the declared floor -> manual review (don't widen down)
+    (">=2.0.0", "1.0.0", None),
+    (">=2.0.0 <3.0.0", "1.5.0", None),
+    # ambiguous / unbumpable -> manual review
+    (">=1.0.0 || >=2.0.0", "2.8.0", None),   # OR range
+    ("<3.0.0",             "2.8.0", None),    # upper-only, no floor
+    ("git+https://x/y.git", "2.8.0", None),   # VCS
+    ("npm:lodash@^4",       "2.8.0", None),   # alias
+])
+def test_bump_npm_spec(current, target, expected):
+    # installed arg is the planner's from_version; for a RANGE dep it is
+    # the whole spec string — pass `current` to mirror that.
+    assert _bump_npm_spec(current, current, target) == expected
+
+
+def test_rewrite_package_json_reason_distinguishes_declined_from_missing():
+    """A dep that's present but declined (target outside its declared
+    range) must NOT be reported as 'no matching spec found' — that would
+    mislead the operator's skip report into thinking the dep is absent."""
+    from pathlib import Path
+
+    from packages.sca.update import _PlanEntry, _rewrite_package_json
+
+    text = '{\n  "dependencies": {\n    "capped": ">=1.0.0 <2.0.0"\n  }\n}\n'
+    # target 2.5.0 is past the <2.0.0 ceiling -> _bump_npm_spec declines.
+    plan = _PlanEntry(ecosystem="npm", name="capped",
+                      installed=">=1.0.0 <2.0.0", target="2.5.0",
+                      manifest=Path("/x/package.json"), advisory_ids=[])
+    new, applied, reason = _rewrite_package_json(text, plan)
+    assert applied is False
+    assert new == text                          # unchanged, valid JSON
+    assert "not safely bumpable" in (reason or "")
+
+    # a genuinely absent dep still reports 'no matching spec found'.
+    plan2 = _PlanEntry(ecosystem="npm", name="absent",
+                       installed="1.0.0", target="2.0.0",
+                       manifest=Path("/x/package.json"), advisory_ids=[])
+    _, applied2, reason2 = _rewrite_package_json(text, plan2)
+    assert applied2 is False
+    assert reason2 == "no matching spec found"

--- a/packages/sca/update.py
+++ b/packages/sca/update.py
@@ -978,10 +978,15 @@ def _rewrite_package_json(
         rewrote = True
         return f"{prefix}{new_spec}{suffix}"
 
-    new_text, _ = pat.subn(_replace, text, count=1)
-    if not rewrote:
+    new_text, n_matched = pat.subn(_replace, text, count=1)
+    if rewrote:
+        return new_text, True, None
+    if n_matched == 0:
         return text, False, "no matching spec found"
-    return new_text, True, None
+    # The dep was found but _bump_npm_spec declined (VCS/alias/tarball, or
+    # a range whose target falls outside the operator's declared bounds) —
+    # don't mislabel that as 'not found'.
+    return text, False, "spec matched but not safely bumpable (out of declared range or unsupported form)"
 
 
 def _bump_npm_spec(current: str, installed: str, target: str) -> Optional[str]:
@@ -1005,8 +1010,31 @@ def _bump_npm_spec(current: str, installed: str, target: str) -> Optional[str]:
         if s.startswith(prefix):
             return f"{prefix}{target}"
     if any(ch in s for ch in "<>=| "):
-        # range / multi-bound — replace inline match if possible.
-        return s.replace(installed, target) if installed in s else None
+        # Explicit comparator range (caret / tilde already returned
+        # above). Bump the lower bound (``>=`` / ``>``) to the target and
+        # leave any upper bound intact — collapsing ``>=2.0.0 <3.0.0`` to
+        # a bare ``2.8.0`` (the old inline-replace, which fired when
+        # ``installed`` was the whole spec string) silently dropped the
+        # operator's ``<3.0.0`` ceiling. Defer to manual review (None) for
+        # ``||`` (OR) ranges, ranges with no lower bound, and a target
+        # outside the declared corridor (at/above the ceiling, or below
+        # the floor) defer to manual review — never emit an empty/invalid
+        # range like ``>=3.5.0 <3.0.0`` and never silently widen the floor
+        # down past the operator's declared minimum.
+        if "||" in s:
+            return None
+        lo = re.search(r"(>=|>)\s*([0-9][^\s,|]*)", s)
+        if lo is None:
+            return None
+        hi = re.search(r"(<=|<)\s*([0-9][^\s,|]*)", s)
+        try:
+            if hi is not None and version_compare("npm", target, hi.group(2)) >= 0:
+                return None
+            if version_compare("npm", target, lo.group(2)) < 0:
+                return None
+        except VersionError:
+            return None
+        return s[:lo.start(2)] + target + s[lo.end(2):]
     return target
 
 


### PR DESCRIPTION
_bump_npm_spec — used by the CVE-driven `fix`/`update` path when a vulnerable npm dep is bumped to its fix version — collapsed an explicit comparator range to a bare exact version (`>=2.0.0 <3.0.0` -> `2.8.0`): a RANGE dep's `installed` is the whole spec string, so the inline replace nuked everything, silently dropping the operator's `<3.0.0` ceiling.

Bump only the lower bound and keep the upper bound (`>=2.8.0 <3.0.0`), staying idiomatic npm. Defer to manual review (None) for `||` ranges, ranges with no lower bound, and targets outside the declared corridor (at/above the ceiling OR below the floor) — never emit an empty range like `>=3.5.0 <3.0.0` nor widen the floor below the declared minimum. Caret/tilde unchanged. Also: _rewrite_package_json now distinguishes "spec found but declined" from "no matching spec" in its skip reason.