### PR TITLE
fix(sca): harden bumps versioned non-PyPI deps (npm/Maven/NuGet/Cargo)

### DIFF
--- a/packages/sca/harden.py
+++ b/packages/sca/harden.py
@@ -44,6 +44,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from .versions import pep440
+from .versions import compare as version_compare
 from core.json import JsonCache
 from . import SCA_CACHE_ROOT
 from .discovery import find_manifests
@@ -574,13 +575,22 @@ def _versions_above_installed(
 
     If ``installed`` is None (unpinned dep), return ``versions`` unchanged
     so we can still propose the latest. Output preserves input ordering.
+
+    Uses the per-ecosystem comparator (``version_compare``) rather than
+    PyPI's only. Previously non-PyPI ecosystems short-circuited to ``0``
+    (nothing ever above installed → every versioned npm/Maven/NuGet/Cargo
+    dep fell through to ``up_to_date``, so ``--harden`` never bumped them).
+    ``version_compare`` raises ``VersionError`` for ecosystems with no
+    comparator (e.g. Debian) or unparseable inputs (a RANGE dep whose
+    ``installed`` is the whole spec string) — both caught below and that
+    version skipped, so those keep the prior no-bump behaviour.
     """
     if installed is None:
         return list(versions)
     out = []
     for v in versions:
         try:
-            cmp = pep440.compare(v, installed) if ecosystem == "PyPI" else 0
+            cmp = version_compare(ecosystem, v, installed)
         except Exception:                   # noqa: BLE001
             continue
         if cmp > 0:

--- a/packages/sca/tests/test_harden_planner.py
+++ b/packages/sca/tests/test_harden_planner.py
@@ -720,3 +720,40 @@ def test_no_downgrade_when_clean_version_above_exists() -> None:
     )
     assert cand.status == "promoted"
     assert cand.to_version == "2.9"
+
+
+# ---------------------------------------------------------------------------
+# Non-PyPI promotion: harden now bumps versioned npm/Maven/Cargo deps via the
+# per-ecosystem comparator (regression for _versions_above_installed having
+# short-circuited every non-PyPI dep to up_to_date with `else 0`).
+# ---------------------------------------------------------------------------
+
+def test_npm_exact_pin_now_promotable() -> None:
+    """A versioned npm dep is compared with semver and gets promoted —
+    previously it short-circuited to up_to_date."""
+    dep = replace(_dep(ecosystem="npm", name="lodash", version="4.17.0",
+                       pin_style=PinStyle.EXACT),
+                  declared_in=Path("/x/package.json"))
+    cand = _plan_one(
+        dep,
+        registries={"npm": _FakeRegistry(["4.17.0", "4.17.21"], ecosystem="npm")},
+        osv=_FakeOsv({"4.17.21": []}),
+        offline=False, allow_major=False,
+    )
+    assert cand.status == "promoted", cand.status
+    assert cand.to_version == "4.17.21"
+
+
+def test_npm_range_spec_still_up_to_date() -> None:
+    """A RANGE dep's recorded version is the whole spec string, not a
+    comparable version, so the comparator can't place it 'above' anything
+    — it stays up_to_date (unchanged, no spurious bump)."""
+    dep = replace(_dep(ecosystem="npm", name="x", version=">=4.0.0 <5.0.0",
+                       pin_style=PinStyle.RANGE),
+                  declared_in=Path("/x/package.json"))
+    cand = _plan_one(
+        dep,
+        registries={"npm": _FakeRegistry(["4.5.0", "4.9.0"], ecosystem="npm")},
+        osv=_FakeOsv(), offline=False, allow_major=False,
+    )
+    assert cand.status == "up_to_date", cand.status


### PR DESCRIPTION
harden.py:_versions_above_installed compared with pep440 only for PyPI and short-circuited every other ecosystem to 0, so nothing was ever "above installed" -> every versioned npm/Maven/NuGet/Cargo dep fell through to up_to_date and `fix --harden` silently never bumped them (it handled only unpinned non-PyPI deps and all PyPI). Use the per-ecosystem comparator.

Safe: version_compare raises VersionError for ecosystems with no comparator (Debian) and unparseable inputs (a RANGE dep whose recorded version is the whole spec string) — both caught and skipped, keeping prior no-bump behaviour. The existing _has_rewriter() gate already marks no-rewriter manifests unsupported_manifest before version selection, so promotion stays confined to rewritable manifests. _crosses_major is a generic leading-int heuristic, so the major-gate keeps working.