### PR TITLE
fix(sca/reachability): anchor Cargo example/test/bench target dirs to the crate root

### DIFF
--- a/packages/sca/reachability/cargo.py
+++ b/packages/sca/reachability/cargo.py
@@ -126,10 +126,20 @@ def _walk_rust_sources(
 
 
 def _is_test_file(path: Path, target: Path) -> bool:
-    """``tests/``, ``examples/``, ``benches/``, ``fuzz/`` directories OR
-    a file ending in ``_test.rs`` (uncommon but seen)."""
+    """A Cargo non-library target: a file under a crate-root ``tests/`` /
+    ``examples/`` / ``benches/`` / ``fuzz/`` directory, or a ``*_test.rs`` file.
+
+    Cargo only treats those directory names as integration / example / bench
+    targets at the CRATE ROOT. A module nested inside the library — e.g.
+    ``src/foo/examples/bar.rs`` — is ordinary production code, so matching the
+    name at any depth would misclassify it as test-only and wrongly downgrade
+    the reachability of a dependency it uses (a false negative). Anchor to the
+    first path component relative to the scanned crate root. (In a workspace
+    where ``target`` is the workspace root, a nested crate's target dir is
+    treated as production — the reachability-conservative direction.)
+    """
     rel_parts = path.relative_to(target).parts
-    if any(p in _TEST_DIR_NAMES for p in rel_parts):
+    if rel_parts and rel_parts[0] in _TEST_DIR_NAMES:
         return True
     if path.name.endswith("_test.rs"):
         return True

--- a/packages/sca/reachability/tests/test_new_ecosystems.py
+++ b/packages/sca/reachability/tests/test_new_ecosystems.py
@@ -63,6 +63,32 @@ def test_cargo_only_in_tests(tmp_path: Path) -> None:
     assert r.verdict == "not_reachable"
 
 
+def test_cargo_crate_root_examples_still_test(tmp_path: Path) -> None:
+    # A crate-root examples/ dir IS a Cargo example target (not in the lib),
+    # so a dep used only there stays not_reachable.
+    (tmp_path / "examples").mkdir()
+    (tmp_path / "examples" / "demo.rs").write_text(
+        "use rand::random;\nfn main() {}\n", encoding="utf-8")
+    scan = rcargo.scan_imports(tmp_path)
+    r = rcargo.resolve_dep("rand", scan, target=tmp_path)
+    assert r.verdict == "not_reachable"
+
+
+def test_cargo_nested_examples_module_is_production(tmp_path: Path) -> None:
+    # A module named examples NESTED in the library (src/foo/examples/…) is
+    # compiled into the crate = production code. It must NOT be treated as a
+    # Cargo example target, or a dependency it uses is wrongly downgraded
+    # (the silent false-negative this fix addresses).
+    nested = tmp_path / "src" / "foo" / "examples"
+    nested.mkdir(parents=True)
+    (nested / "bar.rs").write_text(
+        "use rand::random;\npub fn use_it() { let _ = random::<u8>(); }\n",
+        encoding="utf-8")
+    scan = rcargo.scan_imports(tmp_path)
+    r = rcargo.resolve_dep("rand", scan, target=tmp_path)
+    assert r.verdict == "imported"
+
+
 def test_cargo_no_match(tmp_path: Path) -> None:
     (tmp_path / "src").mkdir()
     (tmp_path / "src" / "main.rs").write_text(


### PR DESCRIPTION
Cargo's `tests/` `examples/` `benches/` `fuzz/` are non-library target directories ONLY at the crate root. `_is_test_file` matched those names against any path component at any depth, so a module nested in the library — e.g. `src/foo/examples/bar.rs`, which is compiled into the crate and is ordinary production code — was misclassified as an example/test target. A dependency imported only from such a module was then resolved `not_reachable`, silently downgrading a reachable dependency (a false negative). Same basename-anywhere shape as the inventory dir-exclusion fix (#672), scoped here to Cargo's crate-root target dirs.

Anchor the match to the first path component relative to the scanned crate root: a crate-root `examples/`/`tests/`/`benches/`/`fuzz/` dir is still classified as a non-lib target (a dep used only there stays not_reachable), but a nested module of the same name is treated as production. In a workspace where the scan target is the workspace root, a nested crate's target dir is treated as production — the reachability-conservative direction (never under-reports a reachable dep). The `*_test.rs` filename check is unchanged (a naming convention, not a dir).

Only Cargo is changed: its target dirs are crate-root-anchored by Cargo semantics and `examples/` collides with plausible first-party module names. The other ecosystems are not touched — Node's `__tests__` is co-located by Jest convention (anchoring would be wrong), and the rest are weaker collisions.

Tests: nested `src/foo/examples/bar.rs` → `imported` (fix); crate-root `examples/demo.rs` → `not_reachable` (preserved); existing tests-only case unchanged. 198 reachability tests pass.