### PR TITLE
feat(reachability): Java reflective-binding entries (JPA entity + JAXB)

### DIFF
--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -2397,15 +2397,29 @@ _JAVA_METHOD_DISPATCH_ANNOTATIONS = frozenset({
     # JPA / Hibernate entity lifecycle callbacks (persistence-provider-invoked)
     "PrePersist", "PostPersist", "PreUpdate", "PostUpdate",
     "PreRemove", "PostRemove", "PostLoad",
+    # JAXB property bindings — the getter is accessed reflectively by the XML
+    # marshaller, not via a static call. (Jackson @JsonProperty/@JsonGetter is
+    # the same pattern for JSON; add when a consumer surfaces it.)
+    "XmlElement", "XmlAttribute", "XmlValue", "XmlElementWrapper",
 })
-# Class-level stereotype annotation tail-names. The DI container instantiates
-# the annotated class and dispatches into its PUBLIC methods (via injected
-# references / proxies) with no in-project caller. Private / protected /
-# package-private methods stay reachable only through the static closure from
-# those public entries, so they are NOT promoted here.
+# Class-level stereotype annotation tail-names. A framework instantiates the
+# annotated class and reaches its PUBLIC methods with no in-project caller —
+# either the DI container dispatching into bean methods (via injected
+# references / proxies), or a persistence provider / (de)serialiser accessing
+# the class's properties reflectively (Hibernate dirty-checking + hydration,
+# JAXB XML marshalling). Private / protected / package-private methods stay
+# reachable only through the static closure from those public entries, so they
+# are NOT promoted here. Tail-matched, so javax.* and jakarta.* both resolve.
 _JAVA_CLASS_STEREOTYPES = frozenset({
+    # Spring DI / web stereotypes
     "Component", "Service", "Repository", "Controller", "RestController",
     "Configuration", "ControllerAdvice", "RestControllerAdvice",
+    # JPA / Jakarta Persistence entity classes — getters/setters are accessed
+    # reflectively by the provider and by serializers, not via static calls.
+    "Entity", "Embeddable", "MappedSuperclass",
+    # JAXB-bound classes — properties accessed reflectively by the XML
+    # marshaller. (Jackson @JsonRootName etc. is the JSON analogue.)
+    "XmlRootElement", "XmlType",
 })
 
 

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -737,6 +737,38 @@ def test_java_class_stereotype_promotes_public_methods_only():
         "pp", _java_item("pp", class_attrs=["Component"], visibility=None))
 
 
+def test_java_jpa_entity_stereotype_promotes_public_methods():
+    from core.inventory.reachability import _java_framework_entry
+    # @Entity / @Embeddable / @MappedSuperclass public accessors are reached
+    # reflectively by the JPA provider / serializer, not via static calls.
+    assert _java_framework_entry(
+        "getName", _java_item("getName", class_attrs=["Entity"], visibility="public"))
+    assert _java_framework_entry(
+        "getId", _java_item("getId", class_attrs=["MappedSuperclass"], visibility="public"))
+    assert _java_framework_entry(
+        "getStreet",
+        _java_item("getStreet",
+                   class_attrs=["jakarta.persistence.Embeddable"], visibility="public"))
+    # a private entity method is not reflectively dispatched → not promoted.
+    assert not _java_framework_entry(
+        "calcChecksum",
+        _java_item("calcChecksum", class_attrs=["Entity"], visibility="private"))
+
+
+def test_java_jaxb_reflective_serialization_entries():
+    from core.inventory.reachability import _java_framework_entry
+    # @XmlRootElement / @XmlType class → public accessors marshalled reflectively.
+    assert _java_framework_entry(
+        "getVetList",
+        _java_item("getVetList", class_attrs=["XmlRootElement"], visibility="public"))
+    # @XmlElement / @XmlAttribute on a getter → reflectively accessed property,
+    # even in a class that isn't itself a root element.
+    assert _java_framework_entry(
+        "getName", _java_item("getName", attrs=["XmlElement"], visibility="public"))
+    assert _java_framework_entry(
+        "getId", _java_item("getId", attrs=["XmlAttribute"], visibility="public"))
+
+
 def test_java_async_transactional_and_plain_are_not_entries():
     from core.inventory.reachability import _java_framework_entry
     # @Async / @Transactional only WRAP a normally-called method (it still has


### PR DESCRIPTION
Extends the Java framework-entry model (#667) to a second no-caller dispatch class: properties of a persistence/serialisation-bound class reached REFLECTIVELY by the framework, with no static call. Without modelling these, a getter/setter that the application never calls directly — only the JPA provider or the XML marshaller touches it — reads not_called and is surface-demoted.

- _JAVA_CLASS_STEREOTYPES += Entity / Embeddable / MappedSuperclass (JPA), XmlRootElement / XmlType (JAXB): public methods of these classes are reflectively accessed → entries.
- _JAVA_METHOD_DISPATCH_ANNOTATIONS += XmlElement / XmlAttribute / XmlValue / XmlElementWrapper: a property getter so annotated is marshalled reflectively, even in a class that isn't itself a root element.

Same monotonic add-entries lever as #667 — only ever GROWS the reachable set, so it can never suppress real code or demote live code; the worst case is failing to demote a genuinely-dead reflectively-bound accessor (the safe direction). javax.* and jakarta.* both resolve (tail-matched).

Measured on spring-petclinic (full inventory, post-#672):
  * JAXB closes the one real residual — Vets.getVetList (@XmlElement, class @XmlRootElement) flips not_called → reachable.
  * The JPA trio is INERT here and shipped as FN-safe insurance: with the full call graph, petclinic's entity accessors are already statically reachable (controllers call them), so the earlier "entity accessors dominate the residual" reading was an artefact of the pre-#672 incomplete inventory. JPA reflective-only accessors (write-only / serialised-only fields) do occur in DTO/API-heavy codebases, hence keeping it.
  * The remaining petclinic residual (Spring Data @Repository interface methods, framework-interface @Override impls) is cross-file INTERFACE DISPATCH — out of scope here; it needs interface-dispatch resolution (the dispatch-aware reachability arc).

Jackson (@JsonProperty / @JsonRootName) is the JSON analogue of the same pattern — add when a consumer surfaces it.

Tests: JPA + JAXB class/method cases (path-independent, run without tree-sitter-java); 837 inventory tests pass; ruff clean.