### PR TITLE
fix(sca): vulnrichment develop branch + harden calibration refresh CI

### DIFF
--- a/.github/workflows/refit-sca-calibration.yml
+++ b/.github/workflows/refit-sca-calibration.yml
@@ -210,6 +210,8 @@ jobs:
               --base main \
               --head "$BRANCH" \
               --title "chore(sca): refit risk-score multipliers" \
+              --label sca \
+              --label automated \
               --body "$BODY"
           else
             gh pr edit "$BRANCH" --body "$BODY"

--- a/.github/workflows/refresh-sca-calibration.yml
+++ b/.github/workflows/refresh-sca-calibration.yml
@@ -49,17 +49,22 @@ jobs:
       - name: Install minimal deps
         run: |
           python -m pip install --upgrade pip==26.1.1
-          # The build script needs urllib3 (core.http dependency)
-          # plus pytest for the validation step. No other
-          # requirements-dev — keep this fast.
+          # The build script needs only urllib3 (the core.http
+          # backend). The validate step runs on the stdlib + the
+          # bundled corpus — no pytest required. Keep this fast.
           pip install 'urllib3==2.7.0,<3.0'
 
       - name: Refresh corpus
-        # ``-v`` emits per-source ``updated/unchanged`` lines so the
-        # PR body can quote them. Exit 0 = at least one source
-        # succeeded; exit 1 = every source failed (transient global
-        # event, retried at next schedule).
-        run: packages/sca/scripts/raptor-sca-build-corpus -v
+        # ``-v`` emits per-source ``updated/unchanged`` (and
+        # ``FAILED``) lines; we capture them to refresh.log and embed
+        # them in the PR body so a drifted source shows up in review.
+        # Exit 0 = at least one source produced output; exit 1 = every
+        # source failed (a global outage, retried next schedule). A
+        # single source drifting does NOT fail the run or discard the
+        # rest. (GHA's default shell sets pipefail, so the script's
+        # exit code propagates through the ``tee``.)
+        run: |
+          packages/sca/scripts/raptor-sca-build-corpus -v 2>&1 | tee refresh.log
 
       - name: License-compliance check
         # Defence in depth: enforces the ATTRIBUTION.md cross-
@@ -145,7 +150,11 @@ jobs:
         run: |
           set -eu
           BRANCH="auto/sca-calibration-refresh"
-          BODY=$(cat <<'EOF'
+          # Build the PR body, embedding the captured per-source
+          # status (incl. any FAILED sources) so a drifted upstream
+          # shows up in review rather than only in the run log.
+          {
+            cat <<'EOF'
           Auto-PR from `.github/workflows/refresh-sca-calibration.yml`.
 
           Refreshes the bundled `packages/sca/data/calibration/`
@@ -154,9 +163,11 @@ jobs:
 
           ## Per-source status
 
-          See the workflow run log for the per-source
-          `raptor-sca-build-corpus: <source> updated/unchanged
-          (N records)` output.
+          EOF
+            echo '```'
+            cat refresh.log 2>/dev/null || echo '(per-source status unavailable)'
+            echo '```'
+            cat <<'EOF'
 
           ## License compliance
 
@@ -169,17 +180,22 @@ jobs:
           ## Review checklist
 
           - [ ] Per-source counts look reasonable (≥ prior run)
+          - [ ] No source shows FAILED above (or it's a known transient)
           - [ ] No license-restricted content in the diff
           - [ ] `ATTRIBUTION.md` still covers every JSON file
           EOF
-          )
-          # Idempotent create-or-update: ``gh pr create`` exits 1
-          # when a PR for the branch already exists — in that case
-          # we update the body so it always reflects the latest run.
+          } > pr-body.md
+          # Idempotent create-or-update: ``gh pr create`` exits non-zero
+          # when a PR for the branch already exists — fall through to
+          # ``gh pr edit`` to refresh the body. Labels match the sibling
+          # data-refresh workflows so the PR can be filtered / routed.
           if ! gh pr create \
                 --base main \
                 --head "$BRANCH" \
                 --title "chore(sca): refresh calibration corpus" \
-                --body "$BODY" 2>/dev/null; then
-            gh pr edit "$BRANCH" --body "$BODY"
+                --label sca \
+                --label data-refresh \
+                --label automated \
+                --body-file pr-body.md 2>/dev/null; then
+            gh pr edit "$BRANCH" --body-file pr-body.md
           fi

--- a/core/cve/tests/test_vulnrichment.py
+++ b/core/cve/tests/test_vulnrichment.py
@@ -61,13 +61,13 @@ class TestUrlForCve:
     def test_high_number(self):
         assert _url_for_cve("CVE-2024-12345") == (
             "https://raw.githubusercontent.com/cisagov/vulnrichment/"
-            "main/2024/12xxx/CVE-2024-12345.json"
+            "develop/2024/12xxx/CVE-2024-12345.json"
         )
 
     def test_low_number_uses_0xxx(self):
         assert _url_for_cve("CVE-2024-500") == (
             "https://raw.githubusercontent.com/cisagov/vulnrichment/"
-            "main/2024/0xxx/CVE-2024-500.json"
+            "develop/2024/0xxx/CVE-2024-500.json"
         )
 
     def test_case_insensitive_input(self):
@@ -218,7 +218,7 @@ class TestVulnrichmentClient:
     def test_lookup_hits_canonical_url(self, tmp_path: Path):
         url = (
             "https://raw.githubusercontent.com/cisagov/vulnrichment/"
-            "main/2024/12xxx/CVE-2024-12345.json"
+            "develop/2024/12xxx/CVE-2024-12345.json"
         )
         http = FakeHttp(responses={
             url: _vulnrichment_record(exploitation="active"),
@@ -236,7 +236,7 @@ class TestVulnrichmentClient:
         once."""
         url = (
             "https://raw.githubusercontent.com/cisagov/vulnrichment/"
-            "main/2024/12xxx/CVE-2024-12345.json"
+            "develop/2024/12xxx/CVE-2024-12345.json"
         )
         http = FakeHttp(responses={
             url: _vulnrichment_record(exploitation="poc"),
@@ -258,7 +258,7 @@ class TestVulnrichmentClient:
         without hitting HTTP."""
         url = (
             "https://raw.githubusercontent.com/cisagov/vulnrichment/"
-            "main/2024/12xxx/CVE-2024-12345.json"
+            "develop/2024/12xxx/CVE-2024-12345.json"
         )
         cache = JsonCache(root=tmp_path)
         http_a = FakeHttp(responses={
@@ -283,7 +283,7 @@ class TestVulnrichmentClient:
         lookup within the negative-TTL window doesn't re-probe."""
         url = (
             "https://raw.githubusercontent.com/cisagov/vulnrichment/"
-            "main/2024/12xxx/CVE-2024-12345.json"
+            "develop/2024/12xxx/CVE-2024-12345.json"
         )
         http = FakeHttp(errors={
             url: HttpError("404 Not Found"),
@@ -310,7 +310,7 @@ class TestVulnrichmentClient:
         The next call gets a fresh attempt."""
         url = (
             "https://raw.githubusercontent.com/cisagov/vulnrichment/"
-            "main/2024/12xxx/CVE-2024-12345.json"
+            "develop/2024/12xxx/CVE-2024-12345.json"
         )
         cache = JsonCache(root=tmp_path)
         http_fail = FakeHttp(errors={

--- a/core/cve/vulnrichment.py
+++ b/core/cve/vulnrichment.py
@@ -54,8 +54,10 @@ from core.json import JsonCache
 logger = logging.getLogger(__name__)
 
 
+# ``develop`` is the repo's default branch — CISA does not publish
+# to ``main`` (raw fetches against ``/main/`` 404).
 _REPO_RAW_BASE = (
-    "https://raw.githubusercontent.com/cisagov/vulnrichment/main"
+    "https://raw.githubusercontent.com/cisagov/vulnrichment/develop"
 )
 _DEFAULT_TTL = 7 * 24 * 3600   # SSVC drifts slowly; weekly refresh is fine
 _CACHE_KEY_PREFIX = "vulnrichment"

--- a/packages/sca/calibration/build.py
+++ b/packages/sca/calibration/build.py
@@ -654,6 +654,51 @@ def _is_exploit_host_url(url: str) -> bool:
     return host in _OSV_EVIDENCE_EXPLOIT_HOSTS
 
 
+# Decompression-bomb defence for the Vulnrichment tarball walk
+# (:func:`_build_vulnrichment`). ``get_bytes`` bounds the
+# *compressed* download, but the gzip + tar layers below can expand
+# without limit. We cap total decompressed bytes at
+# ``len(compressed) * _DECOMP_RATIO`` (floored at ``_DECOMP_FLOOR``).
+# JSON text gzips ~4-15x, so 50x sits far above any honest ratio yet
+# trips the 1000x+ expansion that defines a bomb. Anchoring the
+# ceiling to the bytes we actually fetched means it auto-scales as the
+# corpus grows — there is no absolute size to re-tune.
+_DECOMP_RATIO = 50
+_DECOMP_FLOOR = 64 * 1024 * 1024
+# A single CVE-JSON-5 record is tens of KB; 8 MB is wildly generous
+# and bounds the in-memory read of any one member so a forged-huge
+# header size can't balloon memory before the stream-level guard fires.
+_PER_RECORD_CAP = 8 * 1024 * 1024
+
+
+class _CappedReader:
+    """Wrap a (decompressed) stream and trip once cumulative bytes
+    read exceed ``cap``.
+
+    Wrapping the gzip layer — rather than only bounding each extracted
+    record — catches a decompression bomb hidden in ANY tar member,
+    including ones the caller filters out: a streaming ``tarfile`` must
+    still read through their decompressed data to reach the next
+    header. Only ``read`` is needed for ``tarfile`` stream mode
+    (``r|``); the wrapped object is closed by its own ``with`` block.
+    """
+
+    def __init__(self, inner: Any, cap: int) -> None:
+        self._inner = inner
+        self._cap = cap
+        self._seen = 0
+
+    def read(self, size: int = -1) -> bytes:
+        chunk = self._inner.read(size)
+        self._seen += len(chunk)
+        if self._seen > self._cap:
+            raise RuntimeError(
+                "vulnrichment tarball decompressed beyond "
+                f"{self._cap} bytes — possible decompression bomb"
+            )
+        return chunk
+
+
 def _build_vulnrichment(out_dir: Path, http: Any) -> BuildResult:
     """Fetch the CISA Vulnrichment repository tarball, walk every
     CVE-*.json record, and emit a CVE-keyed signal file for any
@@ -684,17 +729,23 @@ def _build_vulnrichment(out_dir: Path, http: Any) -> BuildResult:
     import io
     import tarfile
 
+    # ``develop`` is the repo's default branch — CISA does not
+    # publish to ``main`` (a fetch of ``refs/heads/main`` 404s).
     VULNRICHMENT_TARBALL = (
         "https://codeload.github.com/cisagov/vulnrichment/tar.gz/"
-        "refs/heads/main"
+        "refs/heads/develop"
     )
     raw = http.get_bytes(
         VULNRICHMENT_TARBALL, max_bytes=300 * 1024 * 1024,
     )
+    # Bound total decompression so a bomb hidden anywhere in the
+    # tarball can't OOM the runner (see ``_CappedReader``).
+    max_decompressed = max(_DECOMP_FLOOR, len(raw) * _DECOMP_RATIO)
     signals: Dict[str, Dict[str, Any]] = {}
     files_scanned = 0
     with gzip.GzipFile(fileobj=io.BytesIO(raw)) as gz:
-        with tarfile.open(fileobj=gz, mode="r|") as tar:
+        capped = _CappedReader(gz, max_decompressed)
+        with tarfile.open(fileobj=capped, mode="r|") as tar:
             for member in tar:
                 if not member.isfile():
                     continue
@@ -708,8 +759,19 @@ def _build_vulnrichment(out_dir: Path, http: Any) -> BuildResult:
                 f = tar.extractfile(member)
                 if f is None:
                     continue
+                # Bound the per-member read: a real CVE record is tiny,
+                # so a member that reads past the cap is not a genuine
+                # entry — skip it rather than buffer an arbitrary size.
+                blob = f.read(_PER_RECORD_CAP + 1)
+                if len(blob) > _PER_RECORD_CAP:
+                    logger.warning(
+                        "sca.calibration: vulnrichment member %s exceeds "
+                        "%d bytes — skipping (not a genuine CVE record)",
+                        name, _PER_RECORD_CAP,
+                    )
+                    continue
                 try:
-                    record = json.loads(f.read())
+                    record = json.loads(blob)
                 except (json.JSONDecodeError, UnicodeDecodeError):
                     continue
                 decision = _vulnrichment_extract_ssvc(record)

--- a/packages/sca/calibration/tests/test_build.py
+++ b/packages/sca/calibration/tests/test_build.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import gzip
+import io
 import json
+import tarfile
 from pathlib import Path
 from typing import Any, Dict
 
+import pytest
 
+from packages.sca.calibration import build
 from packages.sca.calibration.build import (
     _bytes_equal_excluding_timestamp,
     _build_exploitdb,
@@ -14,11 +19,51 @@ from packages.sca.calibration.build import (
     _build_epss,
     _build_metasploit,
     _build_osv_evidence,
+    _build_vulnrichment,
     _is_exploit_host_url,
     _msf_ref_to_cve,
     _write_if_changed,
     build_corpus,
 )
+
+_VULNRICHMENT_URL = (
+    "https://codeload.github.com/cisagov/vulnrichment/tar.gz/"
+    "refs/heads/develop"
+)
+
+
+def _make_targz(members: Dict[str, bytes]) -> bytes:
+    """Build an in-memory ``.tar.gz`` from ``{member_name: bytes}``."""
+    buf = io.BytesIO()
+    with gzip.GzipFile(fileobj=buf, mode="wb") as gz:
+        with tarfile.open(fileobj=gz, mode="w") as tar:
+            for name, data in members.items():
+                info = tarfile.TarInfo(name=name)
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _ssvc_record(cve_id: str, exploitation: str, **extra: Any) -> bytes:
+    """Serialise a minimal CVE-JSON-5 record carrying a CISA-ADP
+    SSVC scorecard with the given ``Exploitation`` value."""
+    record: Dict[str, Any] = {
+        "cveMetadata": {"cveId": cve_id},
+        "containers": {
+            "adp": [{
+                "providerMetadata": {"shortName": "CISA-ADP"},
+                "metrics": [{
+                    "other": {"content": {"options": [
+                        {"Exploitation": exploitation},
+                        {"Automatable": "no"},
+                        {"Technical Impact": "partial"},
+                    ]}},
+                }],
+            }],
+        },
+    }
+    record.update(extra)
+    return json.dumps(record).encode("utf-8")
 
 
 class _StubHttp:
@@ -559,3 +604,85 @@ def test_build_osv_evidence_swallows_per_cve_404s(
     assert "CVE-2024-A" not in data["signals"]
     assert "CVE-2024-B" in data["signals"]
     assert result.record_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Vulnrichment builder
+# ---------------------------------------------------------------------------
+
+
+def test_build_vulnrichment_extracts_poc_and_active_skips_none(
+    tmp_path: Path,
+) -> None:
+    tarball = _make_targz({
+        "vulnrichment/2024/0xxx/CVE-2024-0001.json": _ssvc_record(
+            "CVE-2024-0001", "poc",
+        ),
+        "vulnrichment/2024/0xxx/CVE-2024-0002.json": _ssvc_record(
+            "CVE-2024-0002", "active",
+        ),
+        # ``none`` carries no exploit signal — must be dropped.
+        "vulnrichment/2024/0xxx/CVE-2024-0003.json": _ssvc_record(
+            "CVE-2024-0003", "none",
+        ),
+        # Non-CVE / non-JSON members must be ignored by the filters.
+        "vulnrichment/README.md": b"not a record",
+    })
+    result = _build_vulnrichment(tmp_path, _StubHttp({
+        _VULNRICHMENT_URL: tarball,
+    }))
+    data = json.loads(
+        (tmp_path / "vulnrichment_signals.json").read_text(),
+    )
+    assert set(data["signals"]) == {"CVE-2024-0001", "CVE-2024-0002"}
+    assert data["signals"]["CVE-2024-0001"]["ssvc_exploitation"] == "poc"
+    assert result.record_count == 2
+
+
+def test_build_vulnrichment_trips_on_decompression_bomb(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A highly compressible member in a member we *filter out* (not a
+    # CVE .json) — proving the stream-level guard catches a bomb hidden
+    # anywhere, not just in extracted records. Lower the threshold so we
+    # trip the mechanism without materialising a 64 MB fixture.
+    monkeypatch.setattr(build, "_DECOMP_FLOOR", 0)
+    monkeypatch.setattr(build, "_DECOMP_RATIO", 1)
+    tarball = _make_targz({"junk.bin": b"\x00" * (256 * 1024)})
+    # Sanity: the fixture really is high-ratio (decompresses to >> its
+    # compressed size), so cap = len(raw) * 1 is far below it.
+    assert len(tarball) * 1 < 256 * 1024
+    with pytest.raises(RuntimeError, match="decompression bomb"):
+        _build_vulnrichment(tmp_path, _StubHttp({
+            _VULNRICHMENT_URL: tarball,
+        }))
+
+
+def test_build_vulnrichment_skips_oversized_member(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Per-member read cap: a CVE-named .json whose body exceeds the cap
+    # is skipped (not parsed), while a normal-sized record survives.
+    monkeypatch.setattr(build, "_PER_RECORD_CAP", 2000)
+    tarball = _make_targz({
+        "vulnrichment/2024/0xxx/CVE-2024-0001.json": _ssvc_record(
+            "CVE-2024-0001", "poc",
+        ),
+        # Oversized member sits BETWEEN two valid ones: proves the
+        # stream recovers from the bounded partial read and still
+        # parses the member that follows it.
+        "vulnrichment/2024/0xxx/CVE-2024-9999.json": _ssvc_record(
+            "CVE-2024-9999", "poc", _pad="x" * 8000,
+        ),
+        "vulnrichment/2024/0xxx/CVE-2024-0002.json": _ssvc_record(
+            "CVE-2024-0002", "active",
+        ),
+    })
+    result = _build_vulnrichment(tmp_path, _StubHttp({
+        _VULNRICHMENT_URL: tarball,
+    }))
+    data = json.loads(
+        (tmp_path / "vulnrichment_signals.json").read_text(),
+    )
+    assert set(data["signals"]) == {"CVE-2024-0001", "CVE-2024-0002"}
+    assert result.record_count == 2

--- a/packages/sca/scripts/raptor-sca-build-corpus
+++ b/packages/sca/scripts/raptor-sca-build-corpus
@@ -5,9 +5,13 @@ Wraps :func:`packages.sca.calibration.build_corpus`. Designed for both
 operator-driven runs and the scheduled GHA refresh workflow.
 
 Exit codes:
-  0  every source attempted produced output (changed or unchanged)
-  1  at least one source failed (network down, schema drift); other
-     sources still wrote what they could.
+  0  at least one source produced output (changed or unchanged).
+     Individual source failures (e.g. an upstream default-branch
+     rename or schema drift) are logged to stderr and surfaced in
+     the PR body, but do NOT fail the run — one drifted source must
+     not discard the refresh of the others.
+  1  every source failed (likely a global outage / network down);
+     retried at the next schedule.
   2  invalid arguments / unwriteable output dir.
 
 Usage:
@@ -81,20 +85,35 @@ def main() -> int:
     from packages.sca.calibration import build_corpus
     results = build_corpus(out_dir=out_dir, sources=sources)
 
-    any_failed = False
     any_changed = False
+    any_ok = False
+    failed_sources = []
     for r in results:
         prefix = "raptor-sca-build-corpus:"
         if r.error:
-            any_failed = True
+            failed_sources.append(r.source)
             print(f"{prefix} {r.source} FAILED: {r.error}", file=sys.stderr)
         else:
+            any_ok = True
             any_changed = any_changed or r.written
             status = "updated" if r.written else "unchanged"
             print(f"{prefix} {r.source} {status} ({r.record_count} records)")
-    if args.verbose and not any_changed and not any_failed:
+    if args.verbose and not any_changed and not failed_sources:
         print("raptor-sca-build-corpus: corpus already current; no writes.")
-    return 1 if any_failed else 0
+    # Exit non-zero ONLY when every source failed (a global outage,
+    # retried next schedule). A single source drifting — e.g. an
+    # upstream default-branch rename, the exact failure that bit
+    # vulnrichment — must NOT discard the others' refresh. Degrade
+    # gracefully: the auto-PR still lands with whatever succeeded,
+    # and the failed sources are named here + in the PR body.
+    if failed_sources:
+        scope = "others refreshed" if any_ok else "ALL sources failed"
+        print(
+            f"raptor-sca-build-corpus: {len(failed_sources)} source(s) "
+            f"failed ({', '.join(failed_sources)}) — {scope}.",
+            file=sys.stderr,
+        )
+    return 0 if any_ok else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The scheduled SCA calibration refresh broke: CISA moved `cisagov/vulnrichment`'s default branch to `develop`, so the corpus tarball fetch (and the runtime per-CVE client) 404'd on `main`.

This branch fixes that and hardens the workflow against the next drift:

- **Repoint vulnrichment to `develop`** — both the corpus tarball and the runtime raw client.
- **Bound tarball decompression** — cap total/per-member expansion relative to the fetched size, so a hostile/malformed 3p archive can't OOM the runner. First tests for the extractor.
- **Tolerate single-source drift** — the refresh script now exits non-zero only when *every* source fails (was: any), so one upstream break no longer discards the others' refresh; failed sources are surfaced in the PR body.
- **Label the calibration auto-PRs** to match sibling data-refresh workflows; drop a stale pytest install note.