### PR TITLE
Reachability: framework-aware coverage for TS/TSX, C#, Ruby + Java interface dispatch

### DIFF
--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -676,11 +676,12 @@ def _process_single_file(
         # whichever languages have a walker.
         if language == 'python':
             record['call_graph'] = extract_call_graph_python(parse_text).to_dict()
-        elif language in ('javascript', 'typescript'):
+        elif language in ('javascript', 'typescript', 'tsx'):
             # Tree-sitter-driven; gracefully empty when the grammar
-            # isn't installed.
+            # isn't installed. TS/TSX use the typescript grammar so typed
+            # source (annotations, decorators, interfaces) parses.
             record['call_graph'] = extract_call_graph_javascript(
-                parse_text,
+                parse_text, language=language,
             ).to_dict()
         elif language == 'go':
             record['call_graph'] = extract_call_graph_go(

--- a/core/inventory/call_graph.py
+++ b/core/inventory/call_graph.py
@@ -642,15 +642,25 @@ def _attribute_chain(node: ast.AST) -> Optional[List[str]]:
 # ---------------------------------------------------------------------------
 
 
-def extract_call_graph_javascript(content: str) -> FileCallGraph:
-    """Walk a JavaScript / TypeScript source string via tree-sitter
-    and return its :class:`FileCallGraph`.
+def extract_call_graph_javascript(
+    content: str, language: str = "javascript",
+) -> FileCallGraph:
+    """Walk a JavaScript / TypeScript / TSX source string via
+    tree-sitter and return its :class:`FileCallGraph`.
+
+    ``language`` selects the grammar: ``javascript`` →
+    tree-sitter-javascript; ``typescript`` / ``tsx`` →
+    tree-sitter-typescript (``language_typescript`` / ``language_tsx``).
+    Using the JS grammar on typed TS produced ERROR nodes and an empty
+    graph (no edges), so TS reachability was blind — pick the matching
+    grammar. The node types the walker keys on (``call_expression``,
+    ``method_definition``, ``import_statement`` …) are shared across
+    both grammars.
 
     Returns an empty graph when:
 
-      * tree-sitter or ``tree_sitter_javascript`` isn't installed
-        (the inventory builder degrades; resolver treats absence
-        as no-evidence)
+      * the matching grammar isn't installed (the inventory builder
+        degrades; resolver treats absence as no-evidence)
       * The file is unparseable
 
     Captures both ES-module imports and CommonJS requires; both
@@ -661,19 +671,27 @@ def extract_call_graph_javascript(content: str) -> FileCallGraph:
     resolver's chain semantics work unchanged.
     """
     try:
-        import tree_sitter_javascript as ts_js
+        if language == "typescript":
+            import tree_sitter_typescript as ts_ts
+            language_fn = ts_ts.language_typescript
+        elif language == "tsx":
+            import tree_sitter_typescript as ts_ts
+            language_fn = ts_ts.language_tsx
+        else:
+            import tree_sitter_javascript as ts_js
+            language_fn = ts_js.language
     except ImportError:
         logger.debug(
-            "call_graph: tree-sitter JavaScript grammar not "
-            "installed; returning empty graph",
+            "call_graph: tree-sitter grammar for %s not installed; "
+            "returning empty graph", language,
         )
         return FileCallGraph()
 
     try:
-        parser = _get_ts_parser(ts_js.language)
+        parser = _get_ts_parser(language_fn)
         tree = parser.parse(content.encode("utf-8", errors="replace"))
     except Exception as e:                          # noqa: BLE001
-        logger.debug("call_graph: JS parse failed (%s)", e)
+        logger.debug("call_graph: %s parse failed (%s)", language, e)
         return FileCallGraph()
 
     walker = _JsCallGraph()
@@ -726,8 +744,15 @@ class _JsCallGraph:
         is the innermost NAMED enclosing function — anonymous
         functions / arrows are walked-through without affecting
         the caller attribution."""
-        if node.type == self._CLASS_DECL:
-            name_node = self._first_child_of_type(node, (self._IDENT_NODE,))
+        if node.type in (self._CLASS_DECL, "abstract_class_declaration"):
+            # TS class names are ``type_identifier`` (JS uses ``identifier``).
+            # Without type_identifier the class was never pushed onto the
+            # class stack, so ``this.method()`` calls got no receiver_class and
+            # intra-class edges (a reachable method calling a private helper)
+            # were lost — every such helper read not_called.
+            name_node = self._first_child_of_type(
+                node, (self._IDENT_NODE, "type_identifier"),
+            )
             if name_node is not None:
                 bases: List[str] = []
                 heritage = self._first_child_of_type(node, (

--- a/core/inventory/dead_scope.py
+++ b/core/inventory/dead_scope.py
@@ -63,7 +63,7 @@ def detect_dead_scopes(language: str, content: str) -> List[DeadRange]:
     try:
         if language == "python":
             return _detect_python(content)
-        if language in ("javascript", "typescript"):
+        if language in ("javascript", "typescript", "tsx"):
             return _detect_javascript(content)
         if language == "rust":
             return _detect_rust(content)

--- a/core/inventory/extractors.py
+++ b/core/inventory/extractors.py
@@ -797,6 +797,10 @@ def _ts_language(lang: str):
             import tree_sitter_cpp as ts
         elif lang == "go":
             import tree_sitter_go as ts
+        elif lang == "csharp":
+            import tree_sitter_c_sharp as ts
+        elif lang == "ruby":
+            import tree_sitter_ruby as ts
         else:
             return None
         return Language(ts.language())
@@ -839,6 +843,9 @@ class TreeSitterExtractor:
         "c": ("function_definition",),
         "cpp": ("function_definition",),
         "go": ("function_declaration", "method_declaration"),
+        "csharp": ("method_declaration", "constructor_declaration",
+                   "local_function_statement"),
+        "ruby": ("method", "singleton_method"),
     }
 
     _CLASS_TYPES = {
@@ -850,6 +857,9 @@ class TreeSitterExtractor:
         "c": (),
         "cpp": ("class_specifier", "struct_specifier"),
         "go": (),
+        "csharp": ("class_declaration", "interface_declaration",
+                   "struct_declaration", "record_declaration"),
+        "ruby": ("class", "module"),
     }
 
     def __init__(self, language: str):
@@ -873,11 +883,11 @@ class TreeSitterExtractor:
         return functions
 
     def _class_annotations(self, node) -> List[str]:
-        """Annotations declared on a class/interface (Java).
+        """Annotations / attributes declared on a class/interface.
 
-        Reads the class node's ``modifiers`` block, the same shape used for
-        method annotations. Other languages don't put annotations there, so
-        this returns ``[]`` for them.
+        Java: the ``modifiers`` block holds ``marker_annotation`` / ``annotation``.
+        C#: ``attribute_list`` children hold ``[Attr]`` attributes. Other
+        languages put neither here, so this returns ``[]`` for them.
         """
         out: List[str] = []
         for child in node.children:
@@ -885,6 +895,40 @@ class TreeSitterExtractor:
                 for mod in child.children:
                     if mod.type in ("marker_annotation", "annotation"):
                         out.append(mod.text.decode().lstrip("@"))
+            elif child.type == "attribute_list":
+                out.extend(self._csharp_attr_names(child))
+            elif child.type == "superclass":
+                # Ruby: ``class X < ApplicationController`` — record the base so
+                # the Rails convention (controller/job/mailer) can fire. The
+                # base is a ``constant`` or a ``scope_resolution`` (Foo::Bar).
+                for sc in child.children:
+                    if sc.type in ("constant", "scope_resolution"):
+                        out.append(sc.text.decode())
+        return out
+
+    @staticmethod
+    def _csharp_attr_names(attribute_list_node) -> List[str]:
+        """Attribute names in one C# ``attribute_list`` (``[HttpGet, Route(\"x\")]``
+        → ``["HttpGet", "Route"]``). The name is the ``attribute`` node's leading
+        identifier / qualified_name; reachability tail-matches it."""
+        out: List[str] = []
+        for a in attribute_list_node.children:
+            if a.type != "attribute":
+                continue
+            for ac in a.children:
+                if ac.type in ("identifier", "qualified_name"):
+                    out.append(ac.text.decode())
+                    break
+        return out
+
+    def _csharp_attributes(self, node) -> List[str]:
+        """C# attributes on a method/ctor — its ``attribute_list`` children."""
+        if self.language != "csharp":
+            return []
+        out: List[str] = []
+        for child in node.children:
+            if child.type == "attribute_list":
+                out.extend(self._csharp_attr_names(child))
         return out
 
     # Sibling node types allowed between a TS/JS decorator and the
@@ -984,7 +1028,8 @@ class TreeSitterExtractor:
             elif child.type in self.func_types:
                 # JS/TS: method/function decorators are preceding siblings
                 # (@Get() / @Cron() …). Python: a decorated_definition wrapper.
-                attrs = self._ts_decorators(child)
+                # C#: ``[HttpGet]`` attribute_list children (gathered here).
+                attrs = self._ts_decorators(child) + self._csharp_attributes(child)
                 parent = child.parent
                 if parent and parent.type == "decorated_definition":
                     for sib in parent.children:
@@ -1061,6 +1106,19 @@ class TreeSitterExtractor:
         if node.type == "method_definition":
             visibility = self._ts_member_visibility(node)
 
+        # C#: ``modifier`` children carry access keywords; members default to
+        # ``private`` (the framework-entry rule keys on public action methods).
+        if self.language == "csharp" and node.type in (
+            "method_declaration", "constructor_declaration",
+        ):
+            visibility = "private"
+            for child in node.children:
+                if child.type == "modifier" and child.text.decode() in (
+                    "public", "private", "protected", "internal",
+                ):
+                    visibility = child.text.decode()
+                    break
+
         # Java: modifiers block contains annotations and access keywords
         for child in node.children:
             if child.type == "modifiers":
@@ -1115,15 +1173,34 @@ class TreeSitterExtractor:
         return visibility, class_name
 
     def _get_name(self, node) -> Optional[str]:
+        # C#: a method/ctor name is the identifier immediately BEFORE the
+        # ``parameter_list`` — the identifiers before THAT are the return type
+        # (``IActionResult GetAll()`` → ``GetAll``, not ``IActionResult``).
+        if self.language == "csharp" and node.type in (
+            "method_declaration", "constructor_declaration",
+            "local_function_statement",
+        ):
+            plist = next(
+                (c for c in node.children if c.type == "parameter_list"), None)
+            sib = plist.prev_sibling if plist is not None else None
+            while sib is not None:
+                if sib.type in ("identifier", "name"):
+                    return sib.text.decode()
+                sib = sib.prev_sibling
         # ``type_identifier`` names a TS class/interface — but in a Java/TS
         # method it's the RETURN TYPE (``public String handle()``), which
         # precedes the method name, so only accept it on a class declaration.
         is_class_decl = node.type in (
             "class_declaration", "abstract_class_declaration",
             "interface_declaration",
+            "class", "module",          # Ruby
         )
         for child in node.children:
             if child.type in ("identifier", "name"):
+                return child.text.decode()
+            # Ruby class/module name is a ``constant`` (the first one; a
+            # superclass constant is nested inside the ``superclass`` node).
+            if child.type == "constant" and is_class_decl:
                 return child.text.decode()
             # JS/TS class method names are ``property_identifier`` (safe in any
             # node — no language puts a return type there). Without this, every
@@ -1308,6 +1385,8 @@ _REGEX_EXTRACTORS = {
     'javascript': JavaScriptExtractor(),
     'typescript': JavaScriptExtractor(),
     'tsx': JavaScriptExtractor(),
+    'csharp': GenericExtractor(),
+    'ruby': GenericExtractor(),
     'c': CExtractor(),
     'cpp': CExtractor(),
     'java': JavaExtractor(),

--- a/core/inventory/extractors.py
+++ b/core/inventory/extractors.py
@@ -898,12 +898,43 @@ class TreeSitterExtractor:
             elif child.type == "attribute_list":
                 out.extend(self._csharp_attr_names(child))
             elif child.type == "superclass":
-                # Ruby: ``class X < ApplicationController`` — record the base so
-                # the Rails convention (controller/job/mailer) can fire. The
-                # base is a ``constant`` or a ``scope_resolution`` (Foo::Bar).
+                # Ruby: ``class X < ApplicationController`` — base is a
+                # ``constant`` / ``scope_resolution``. Java: ``extends Foo`` —
+                # base is a ``type_identifier`` / ``generic_type``. Capture both.
                 for sc in child.children:
                     if sc.type in ("constant", "scope_resolution"):
-                        out.append(sc.text.decode())
+                        out.append(sc.text.decode())          # Ruby
+                out.extend(self._java_base_names(child))       # Java (no-op for Ruby)
+            elif child.type in ("super_interfaces", "extends_interfaces"):
+                # Java: ``implements Bar`` / interface ``extends Baz`` — record
+                # the base type names so framework bases (JpaRepository →
+                # Spring Data, Validator → a framework-dispatched interface)
+                # can mark the class's methods as entries.
+                out.extend(self._java_base_names(child))
+        return out
+
+    @staticmethod
+    def _java_base_names(node) -> List[str]:
+        """Base type tail-names from a Java ``superclass`` / ``super_interfaces``
+        / ``extends_interfaces`` node (``JpaRepository<Owner,Integer>`` →
+        ``JpaRepository``; ``org.x.Validator`` → ``Validator``). Iterates the
+        individual type nodes (a ``type_list`` separates them with ``,`` tokens)
+        so a generic's inner comma isn't mistaken for a type separator."""
+        _TYPE_NODES = ("type_identifier", "scoped_type_identifier", "generic_type")
+        out: List[str] = []
+
+        def add(tn) -> None:
+            base = tn.text.decode().split("<")[0].strip().split(".")[-1].strip()
+            if base:
+                out.append(base)
+
+        for n in node.children:
+            if n.type == "type_list":
+                for tn in n.children:
+                    if tn.type in _TYPE_NODES:
+                        add(tn)
+            elif n.type in _TYPE_NODES:
+                add(n)
         return out
 
     @staticmethod

--- a/core/inventory/extractors.py
+++ b/core/inventory/extractors.py
@@ -770,8 +770,20 @@ def _ts_language(lang: str):
             import tree_sitter_python as ts
         elif lang == "java":
             import tree_sitter_java as ts
-        elif lang in ("javascript", "typescript"):
+        elif lang == "javascript":
             import tree_sitter_javascript as ts
+        elif lang in ("typescript", "tsx"):
+            # Pre-2026-05-26 this branch loaded ``tree_sitter_javascript``,
+            # which can't parse TS type annotations / interfaces / enums /
+            # access modifiers / decorators — a typed file produced ERROR
+            # nodes and extracted ZERO functions (the same class of bug the
+            # cpp branch had with tree_sitter_c). ``.ts`` and ``.tsx`` need
+            # DIFFERENT grammars: ``language_typescript`` parses ``<T>x`` casts
+            # but errors on JSX; ``language_tsx`` parses JSX but errors on the
+            # cast syntax. Pick by the language (``.tsx`` → ``tsx``).
+            import tree_sitter_typescript as ts
+            ts_fn = ts.language_tsx if lang == "tsx" else ts.language_typescript
+            return Language(ts_fn())
         elif lang == "c":
             import tree_sitter_c as ts
         elif lang == "cpp":
@@ -823,6 +835,7 @@ class TreeSitterExtractor:
         "java": ("method_declaration", "constructor_declaration"),
         "javascript": ("function_declaration", "method_definition", "arrow_function"),
         "typescript": ("function_declaration", "method_definition", "arrow_function"),
+        "tsx": ("function_declaration", "method_definition", "arrow_function"),
         "c": ("function_definition",),
         "cpp": ("function_definition",),
         "go": ("function_declaration", "method_declaration"),
@@ -832,7 +845,8 @@ class TreeSitterExtractor:
         "python": ("class_definition",),
         "java": ("class_declaration", "interface_declaration"),
         "javascript": ("class_declaration",),
-        "typescript": ("class_declaration",),
+        "typescript": ("class_declaration", "abstract_class_declaration"),
+        "tsx": ("class_declaration", "abstract_class_declaration"),
         "c": (),
         "cpp": ("class_specifier", "struct_specifier"),
         "go": (),
@@ -873,13 +887,71 @@ class TreeSitterExtractor:
                         out.append(mod.text.decode().lstrip("@"))
         return out
 
+    # Sibling node types allowed between a TS/JS decorator and the
+    # declaration it decorates (keywords / modifiers / punctuation).
+    _TS_DECORATOR_SKIP = frozenset({
+        "export", "default", "abstract", "async", "static", "readonly",
+        "accessibility_modifier", "comment", "override",
+    })
+
+    def _ts_decorators(self, node) -> List[str]:
+        """Decorators on a JS/TS class or method. tree-sitter-typescript
+        places ``@Foo(...)`` as a preceding SIBLING of the decorated node
+        (inside class_body / export_statement), not a wrapper as Python does.
+        Walk back over decorators + intervening keywords, stopping at the
+        first real node. Stored ``@``-stripped (e.g. ``Controller('x')``),
+        like Java annotations, so reachability tail-matching works uniformly.
+        Gated to JS-family languages so Python's decorated_definition path
+        (handled separately) isn't double-counted.
+        """
+        if self.language not in ("javascript", "typescript", "tsx"):
+            return []
+        out: List[str] = []
+        sib = node.prev_sibling
+        while sib is not None:
+            if sib.type == "decorator":
+                out.append(sib.text.decode().lstrip("@").strip())
+            elif sib.is_named and sib.type not in self._TS_DECORATOR_SKIP:
+                break  # a real declaration / statement — decorators stop here
+            sib = sib.prev_sibling
+        out.reverse()
+        return out
+
     def _walk(self, node, functions: List[FunctionInfo], class_name: Optional[str],
               class_attributes: Sequence[str] = ()) -> None:
         for child in node.children:
             if child.type in self.class_types:
                 cname = self._get_name(child)
+                # Class-level stereotype signal: Java modifier annotations
+                # OR JS/TS class decorators (@Controller / @Injectable /
+                # @Entity / @Component …) attached as preceding siblings.
+                cattrs = self._ts_decorators(child) + self._class_annotations(child)
                 self._walk(child, functions, class_name=cname,
-                           class_attributes=self._class_annotations(child))
+                           class_attributes=cattrs)
+            elif child.type == "public_field_definition":
+                # TS class property holding an arrow / function expression —
+                # ``handler = (x) => {...}`` (Angular/NestJS/event handlers).
+                # A real function the inventory must see; not a method_definition.
+                arrow = self._find_child(child, ("arrow_function", "function"))
+                name = self._get_name(child)
+                if arrow and name:
+                    fattrs = self._ts_decorators(child)
+                    functions.append(FunctionInfo(
+                        name=name,
+                        line_start=child.start_point[0] + 1,
+                        line_end=child.end_point[0] + 1,
+                        signature=child.text.decode()[:200].split("{")[0].strip(),
+                        metadata=FunctionMetadata(
+                            class_name=class_name,
+                            visibility=self._ts_member_visibility(child),
+                            attributes=fattrs,
+                            parameters=self._extract_parameters(arrow),
+                            class_attributes=list(class_attributes),
+                        ),
+                    ))
+                self._walk(child, functions, class_name=class_name,
+                           class_attributes=class_attributes)
+                continue
             elif child.type in ("lexical_declaration", "variable_declaration"):
                 # JS/TS: const foo = () => {} — arrow function inside variable declaration
                 self._walk(child, functions, class_name=class_name,
@@ -910,8 +982,9 @@ class TreeSitterExtractor:
                            class_attributes=class_attributes)
                 continue
             elif child.type in self.func_types:
-                # Check for decorated_definition wrapper (Python)
-                attrs = []
+                # JS/TS: method/function decorators are preceding siblings
+                # (@Get() / @Cron() …). Python: a decorated_definition wrapper.
+                attrs = self._ts_decorators(child)
                 parent = child.parent
                 if parent and parent.type == "decorated_definition":
                     for sib in parent.children:
@@ -966,10 +1039,27 @@ class TreeSitterExtractor:
             ),
         )
 
+    def _ts_member_visibility(self, node) -> Optional[str]:
+        """TS/JS class-member visibility from an ``accessibility_modifier``
+        child (``private`` / ``protected`` / ``public``). TS members are
+        PUBLIC by default, so absence ⇒ ``public`` — which is what the
+        framework-entry stereotype rule keys on (public methods of a
+        container-managed / serialised class are reachable)."""
+        if self.language not in ("javascript", "typescript", "tsx"):
+            return None
+        for child in node.children:
+            if child.type == "accessibility_modifier":
+                return child.text.decode().strip()
+        return "public"
+
     def _extract_visibility(self, node, name: str, class_name: Optional[str],
                             attrs: List[str]) -> Tuple[Optional[str], Optional[str]]:
         """Extract visibility and update class_name. Returns (visibility, class_name)."""
         visibility = None
+
+        # TS/JS class members: accessibility_modifier (default public).
+        if node.type == "method_definition":
+            visibility = self._ts_member_visibility(node)
 
         # Java: modifiers block contains annotations and access keywords
         for child in node.children:
@@ -1025,8 +1115,22 @@ class TreeSitterExtractor:
         return visibility, class_name
 
     def _get_name(self, node) -> Optional[str]:
+        # ``type_identifier`` names a TS class/interface — but in a Java/TS
+        # method it's the RETURN TYPE (``public String handle()``), which
+        # precedes the method name, so only accept it on a class declaration.
+        is_class_decl = node.type in (
+            "class_declaration", "abstract_class_declaration",
+            "interface_declaration",
+        )
         for child in node.children:
             if child.type in ("identifier", "name"):
+                return child.text.decode()
+            # JS/TS class method names are ``property_identifier`` (safe in any
+            # node — no language puts a return type there). Without this, every
+            # JS/TS class METHOD was silently dropped from the inventory.
+            if child.type == "property_identifier":
+                return child.text.decode()
+            if child.type == "type_identifier" and is_class_decl:
                 return child.text.decode()
             # C/C++: name is inside function_declarator
             if child.type == "function_declarator":
@@ -1203,6 +1307,7 @@ _REGEX_EXTRACTORS = {
     'python': PythonExtractor(),
     'javascript': JavaScriptExtractor(),
     'typescript': JavaScriptExtractor(),
+    'tsx': JavaScriptExtractor(),
     'c': CExtractor(),
     'cpp': CExtractor(),
     'java': JavaExtractor(),
@@ -1303,6 +1408,7 @@ def _extract_globals_ts(root_node, language: str) -> List[CodeItem]:
         "python": ("expression_statement", "assignment"),
         "javascript": ("lexical_declaration", "variable_declaration"),
         "typescript": ("lexical_declaration", "variable_declaration"),
+        "tsx": ("lexical_declaration", "variable_declaration"),
         "c": ("declaration",),
         "cpp": ("declaration",),
         "java": ("field_declaration",),
@@ -1449,7 +1555,7 @@ def _global_name(node, language: str) -> Optional[str]:
                     return name
         return None
 
-    if language in ("javascript", "typescript"):
+    if language in ("javascript", "typescript", "tsx"):
         for child in node.children:
             if child.type == "variable_declarator":
                 for sub in child.children:
@@ -1607,7 +1713,7 @@ def _count_comment_lines_regex(content: str, language: str) -> int:
         if language == "python":
             if stripped.startswith("#"):
                 count += 1
-        elif language in ("c", "cpp", "java", "javascript", "typescript", "go"):
+        elif language in ("c", "cpp", "java", "javascript", "typescript", "tsx", "go"):
             # State-machine comment-walk per line so the in_block
             # state tracks every `/*` open and `*/` close on the
             # line, including the `*/ /* still open` shape where a

--- a/core/inventory/languages.py
+++ b/core/inventory/languages.py
@@ -8,7 +8,7 @@ LANGUAGE_MAP = {
     '.js': 'javascript',
     '.jsx': 'javascript',
     '.ts': 'typescript',
-    '.tsx': 'typescript',
+    '.tsx': 'tsx',
     '.c': 'c',
     '.h': 'c',
     '.cpp': 'cpp',

--- a/core/inventory/module_load_abort.py
+++ b/core/inventory/module_load_abort.py
@@ -80,7 +80,7 @@ def detect_module_load_abort(
     try:
         if language == "python":
             return _detect_python(content)
-        if language in ("javascript", "typescript"):
+        if language in ("javascript", "typescript", "tsx"):
             return _detect_javascript(content)
         if language == "go":
             return _detect_go(content)

--- a/core/inventory/reach_audit.py
+++ b/core/inventory/reach_audit.py
@@ -47,6 +47,7 @@ class _ClassifyCtx:
     line: int
     module: str
     target: object          # reachability.InternalFunction
+    class_name: Optional[str] = None   # enclosing class, for method qualnames
 
 
 # --- precedence stages: each (ctx, R) -> verdict string | None -------------
@@ -94,14 +95,24 @@ def _stage_entry(ctx: "_ClassifyCtx", R) -> Optional[str]:
 
 
 def _stage_one_hop(ctx: "_ClassifyCtx", R) -> Optional[str]:
-    try:
-        verdict = R.function_called(
-            ctx.inventory, f"{ctx.module}.{ctx.name}").verdict
-    except ValueError:
-        return None
-    if verdict == R.Verdict.CALLED:
+    # A method called only via ``this.m()`` / ``self.m()`` resolves through the
+    # method-match index under its CLASS-qualified name (``mod.Class.m``); the
+    # bare ``mod.m`` form misses it and reads not_called. Try the class-qualified
+    # name first (when the item is a method), then the bare form (top-level
+    # functions / where the class-qualified form isn't how the file is indexed).
+    candidates = []
+    if ctx.class_name:
+        candidates.append(f"{ctx.module}.{ctx.class_name}.{ctx.name}")
+    candidates.append(f"{ctx.module}.{ctx.name}")
+    verdicts = []
+    for qn in candidates:
+        try:
+            verdicts.append(R.function_called(ctx.inventory, qn).verdict)
+        except ValueError:
+            continue
+    if R.Verdict.CALLED in verdicts:
         return "called"
-    if verdict == R.Verdict.NOT_CALLED:
+    if R.Verdict.NOT_CALLED in verdicts:
         return "not_called"
     return None
 
@@ -125,6 +136,27 @@ PRECEDENCE = (
 )
 
 
+def _lookup_class_name(
+    inventory: Dict[str, object], file_path: str, name: str, line: int,
+) -> Optional[str]:
+    """The enclosing class of the ``(file_path, name)`` item, if any — used to
+    build a method's class-qualified name for the 1-hop check. Scans the target
+    file's items only (matching the other (inventory, file_path) accessors)."""
+    files = inventory.get("files") or []
+    if not isinstance(files, list):
+        return None
+    for f in files:
+        if not isinstance(f, dict) or f.get("path") != file_path:
+            continue
+        for it in f.get("items") or []:
+            if it.get("name") != name:
+                continue
+            if line and int(it.get("line_start") or 0) != line:
+                continue
+            return (it.get("metadata") or {}).get("class_name")
+    return None
+
+
 def classify_reachability(
     inventory: Dict[str, object],
     file_path: str,
@@ -141,6 +173,7 @@ def classify_reachability(
         inventory=inventory, file_path=file_path, name=name, line=line,
         module=module,
         target=R.InternalFunction(file_path=file_path, name=name, line=line),
+        class_name=_lookup_class_name(inventory, file_path, name, line),
     )
     for stage in PRECEDENCE:
         verdict = stage(ctx, R)

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -2339,6 +2339,8 @@ class ReachabilityProfile:
     has_go_init: bool = False
     has_java_web: bool = False
     has_ts_framework: bool = False
+    has_csharp_framework: bool = False
+    has_ruby_framework: bool = False
 
 
 PROFILES: Dict[str, ReachabilityProfile] = {
@@ -2351,8 +2353,8 @@ PROFILES: Dict[str, ReachabilityProfile] = {
     "javascript": ReachabilityProfile("javascript", "none"),
     "typescript": ReachabilityProfile("typescript", "none", has_ts_framework=True),
     "tsx":        ReachabilityProfile("tsx", "none", has_ts_framework=True),
-    "ruby":       ReachabilityProfile("ruby", "none"),
-    "csharp":     ReachabilityProfile("csharp", "none"),
+    "ruby":       ReachabilityProfile("ruby", "none", has_ruby_framework=True),
+    "csharp":     ReachabilityProfile("csharp", "none", has_csharp_framework=True),
     "php":        ReachabilityProfile("php", "none"),
 }
 
@@ -2501,6 +2503,64 @@ def _ts_framework_entry(name: str, item: Dict[str, Any]) -> bool:
     return False
 
 
+# Method-level C# attributes whose presence marks the method as
+# framework-dispatched (ASP.NET MVC / Web API routing — the runtime invokes
+# the action with no in-project caller).
+_CSHARP_METHOD_DISPATCH_ATTRS = frozenset({
+    "HttpGet", "HttpPost", "HttpPut", "HttpDelete", "HttpPatch",
+    "HttpHead", "HttpOptions", "Route", "AcceptVerbs",
+})
+# Class-level C# stereotype attributes: the ASP.NET runtime instantiates the
+# controller and dispatches into its PUBLIC action methods with no in-project
+# caller.
+_CSHARP_CLASS_STEREOTYPE_ATTRS = frozenset({
+    "ApiController", "Controller", "Route",
+})
+
+
+def _csharp_framework_entry(name: str, item: Dict[str, Any]) -> bool:
+    """A C# method dispatched by ASP.NET with no in-project caller — a method
+    routing attribute (``[HttpGet]`` / ``[Route]``) or a PUBLIC method of a
+    ``[ApiController]`` / ``[Controller]`` class. Monotonic add-entries lever:
+    worst case is failing to demote a genuinely-dead action (safe direction)."""
+    meta = item.get("metadata") or {}
+    for a in meta.get("attributes") or []:
+        if _annotation_tail(a) in _CSHARP_METHOD_DISPATCH_ATTRS:
+            return True
+    if "public" in str(meta.get("visibility") or "").split():
+        for a in meta.get("class_attributes") or []:
+            if _annotation_tail(a) in _CSHARP_CLASS_STEREOTYPE_ATTRS:
+                return True
+    return False
+
+
+# Rails (and Sidekiq) base classes whose subclasses are framework-dispatched:
+# the router invokes controller actions, the queue invokes a job's ``perform``,
+# the mailer framework invokes mailer methods — none has an in-project caller.
+_RUBY_FRAMEWORK_BASES = frozenset({
+    "ApplicationController", "ActionController::Base", "ActionController::API",
+    "ApplicationJob", "ActiveJob::Base",
+    "ApplicationMailer", "ActionMailer::Base",
+    "ApplicationCable::Channel", "ActionCable::Channel::Base",
+})
+
+
+def _ruby_framework_entry(name: str, item: Dict[str, Any]) -> bool:
+    """A Ruby method dispatched by Rails with no in-project caller. Rails uses
+    CONVENTION (no annotations): a class inheriting a framework base (a
+    ``*Controller`` / job / mailer / channel) has its methods invoked by the
+    framework — controller actions by the router, ``perform`` by the queue,
+    callbacks (``before_action`` targets) by the request lifecycle. All are
+    methods of the class, so we promote the class's methods (Ruby visibility is
+    positional and not modelled; over-including a private helper is the
+    FN-safe direction — it's reachable via the public actions anyway). The
+    signal is the base class captured in ``class_attributes``."""
+    for base in (item.get("metadata") or {}).get("class_attributes") or []:
+        if base in _RUBY_FRAMEWORK_BASES or base.endswith("Controller"):
+            return True
+    return False
+
+
 def _item_is_entry(item: Dict[str, Any], language: str) -> bool:
     """Is this inventory item an externally-invocable entry point under its
     language's linkage/visibility model? (Framework dispatch is handled
@@ -2535,6 +2595,14 @@ def _item_is_entry(item: Dict[str, Any], language: str) -> bool:
     # Angular / TypeORM method route/handler/resolver decorators and public
     # methods of stereotyped (DI-managed / template-bound / entity) classes.
     if p.has_ts_framework and _ts_framework_entry(name, item):
+        return True
+    # C# ASP.NET dispatched entries: [HttpGet]/[Route] action methods and
+    # public methods of [ApiController]/[Controller] classes.
+    if p.has_csharp_framework and _csharp_framework_entry(name, item):
+        return True
+    # Ruby/Rails convention: methods of a class inheriting a framework base
+    # (*Controller / job / mailer / channel) are framework-dispatched entries.
+    if p.has_ruby_framework and _ruby_framework_entry(name, item):
         return True
     # Visibility/linkage entry signal (only for languages whose model is a
     # closed signal; "" ⇒ a public symbol is NOT reliably an entry, so those

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -2338,6 +2338,7 @@ class ReachabilityProfile:
     visibility_entry: str = ""
     has_go_init: bool = False
     has_java_web: bool = False
+    has_ts_framework: bool = False
 
 
 PROFILES: Dict[str, ReachabilityProfile] = {
@@ -2348,7 +2349,8 @@ PROFILES: Dict[str, ReachabilityProfile] = {
     "java": ReachabilityProfile("java", "none", has_java_web=True),
     "python":     ReachabilityProfile("python", "none"),
     "javascript": ReachabilityProfile("javascript", "none"),
-    "typescript": ReachabilityProfile("typescript", "none"),
+    "typescript": ReachabilityProfile("typescript", "none", has_ts_framework=True),
+    "tsx":        ReachabilityProfile("tsx", "none", has_ts_framework=True),
     "ruby":       ReachabilityProfile("ruby", "none"),
     "csharp":     ReachabilityProfile("csharp", "none"),
     "php":        ReachabilityProfile("php", "none"),
@@ -2455,6 +2457,50 @@ def _java_framework_entry(name: str, item: Dict[str, Any]) -> bool:
     return False
 
 
+# Method-level TS/JS decorators whose presence marks the method as
+# framework-dispatched (the framework invokes it with no in-project caller):
+# NestJS HTTP routes / microservice + websocket handlers / schedulers, and
+# GraphQL resolvers (NestJS @nestjs/graphql + TypeGraphQL).
+_TS_METHOD_DISPATCH_DECORATORS = frozenset({
+    "Get", "Post", "Put", "Delete", "Patch", "Options", "Head", "All", "Search",
+    "MessagePattern", "EventPattern", "SubscribeMessage",
+    "Cron", "Interval", "Timeout",
+    "Query", "Mutation", "Subscription",
+    "ResolveField", "ResolveProperty", "FieldResolver",
+})
+# Class-level TS/JS stereotype decorators. The framework instantiates the class
+# and reaches its PUBLIC methods with no in-project caller — DI container
+# (NestJS / Angular providers + controllers), template binding + lifecycle
+# (Angular components), or reflective property access (TypeORM entities).
+_TS_CLASS_STEREOTYPE_DECORATORS = frozenset({
+    # NestJS
+    "Controller", "Injectable", "Module", "Resolver", "Catch",
+    "WebSocketGateway", "Gateway",
+    # Angular
+    "Component", "Directive", "Pipe", "NgModule",
+    # TypeORM / MikroORM entities (reflective accessor access)
+    "Entity", "ViewEntity", "ChildEntity",
+})
+
+
+def _ts_framework_entry(name: str, item: Dict[str, Any]) -> bool:
+    """A TS/JS method dispatched by a framework / DI container with no
+    in-project caller — a method-level route/handler/resolver decorator, or a
+    PUBLIC method of a stereotyped (container-managed / template-bound /
+    reflectively-serialised) class. Adding an entry only grows the reachable
+    set, so this can't suppress real code; worst case is failing to demote a
+    genuinely-dead decorated method (the safe direction)."""
+    meta = item.get("metadata") or {}
+    for a in meta.get("attributes") or []:
+        if _annotation_tail(a) in _TS_METHOD_DISPATCH_DECORATORS:
+            return True
+    if "public" in str(meta.get("visibility") or "").split():
+        for a in meta.get("class_attributes") or []:
+            if _annotation_tail(a) in _TS_CLASS_STEREOTYPE_DECORATORS:
+                return True
+    return False
+
+
 def _item_is_entry(item: Dict[str, Any], language: str) -> bool:
     """Is this inventory item an externally-invocable entry point under its
     language's linkage/visibility model? (Framework dispatch is handled
@@ -2484,6 +2530,11 @@ def _item_is_entry(item: Dict[str, Any], language: str) -> bool:
     # container-managed handlers (doPost, @EventListener, @Service methods)
     # read not_called and get surface-demoted.
     if p.has_java_web and _java_framework_entry(name, item):
+        return True
+    # TS/JS framework-dispatched entries with no in-project caller: NestJS /
+    # Angular / TypeORM method route/handler/resolver decorators and public
+    # methods of stereotyped (DI-managed / template-bound / entity) classes.
+    if p.has_ts_framework and _ts_framework_entry(name, item):
         return True
     # Visibility/linkage entry signal (only for languages whose model is a
     # closed signal; "" ⇒ a public symbol is NOT reliably an entry, so those

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -2425,6 +2425,22 @@ _JAVA_CLASS_STEREOTYPES = frozenset({
     # marshaller. (Jackson @JsonRootName etc. is the JSON analogue.)
     "XmlRootElement", "XmlType",
 })
+# Framework base types (extends/implements, captured in class_attributes) whose
+# methods the framework invokes with no in-project caller — so the class's
+# methods are entries. Spring Data repositories (the impl is generated at
+# runtime) and dispatched framework interfaces (the runtime calls the impl via
+# the interface — the type-free way to catch interface dispatch the inventory
+# can't resolve without type info; generic typed dispatch stays CodeQL's job).
+_JAVA_FRAMEWORK_BASES = frozenset({
+    # Spring Data repositories
+    "Repository", "CrudRepository", "JpaRepository",
+    "PagingAndSortingRepository", "ReactiveCrudRepository",
+    "MongoRepository", "JpaSpecificationExecutor",
+    # Dispatched framework interfaces (impl methods are framework-invoked)
+    "Validator", "RuntimeHintsRegistrar", "Filter", "HandlerInterceptor",
+    "Converter", "Formatter", "ApplicationRunner", "CommandLineRunner",
+    "ApplicationListener", "InitializingBean", "DisposableBean",
+})
 
 
 def _annotation_tail(annotation: Any) -> str:
@@ -2451,9 +2467,17 @@ def _java_framework_entry(name: str, item: Dict[str, Any]) -> bool:
     for a in meta.get("attributes") or []:
         if _annotation_tail(a) in _JAVA_METHOD_DISPATCH_ANNOTATIONS:
             return True
+    class_attrs = meta.get("class_attributes") or []
+    # Framework base type (extends/implements): a repository interface's query
+    # methods / a dispatched interface impl's methods are framework-invoked with
+    # no in-project caller — promote regardless of visibility (interface methods
+    # are implicitly public; impl methods are public).
+    for a in class_attrs:
+        if _annotation_tail(a) in _JAVA_FRAMEWORK_BASES:
+            return True
     # Class stereotype → only the bean's PUBLIC methods are container-dispatched.
     if "public" in str(meta.get("visibility") or "").split():
-        for a in meta.get("class_attributes") or []:
+        for a in class_attrs:
             if _annotation_tail(a) in _JAVA_CLASS_STEREOTYPES:
                 return True
     return False

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -51,7 +51,9 @@ class TestLanguageDetection:
 
     def test_typescript(self):
         assert detect_language("baz.ts") == "typescript"
-        assert detect_language("baz.tsx") == "typescript"
+        # .tsx is its own language (needs tree-sitter-typescript's tsx grammar,
+        # which parses JSX; the plain typescript grammar errors on JSX).
+        assert detect_language("baz.tsx") == "tsx"
 
     def test_c(self):
         assert detect_language("main.c") == "c"
@@ -1178,3 +1180,108 @@ class TestJavaFrameworkEntries:
         assert verdict("Ctl.java", "bg") == "not_called"       # @Async is not an entry
         assert verdict("Ctl.java", "wr") == "not_called"       # @Transactional is not an entry
         assert verdict("Ctl.java", "dead") == "not_called"     # plain uncalled
+
+
+class TestTypeScriptCoverage:
+    """End-to-end TypeScript coverage. Typed TS was parsed with the JS grammar,
+    which errors on type annotations / decorators → ZERO functions extracted
+    (the whole TS ecosystem was invisible to the inventory + reachability).
+    Switching to tree-sitter-typescript fixes extraction; class methods extract
+    (property_identifier / type_identifier names); decorators are captured; and
+    NestJS / Angular / TypeORM dispatch decorators + class stereotypes promote
+    methods to framework entries. All needs tree-sitter-typescript and skips
+    without it."""
+
+    _FILES = {
+        "users.controller.ts": (
+            "import { Controller, Get, Post } from '@nestjs/common';\n"
+            "@Controller('users')\nexport class UsersController {\n"
+            "  @Get() findAll(): string { return 'all'; }\n"
+            "  @Post() create(): void {}\n"
+            "  private deadHelper(): void {}\n}\n"),
+        "users.service.ts": (
+            "import { Injectable } from '@nestjs/common';\n"
+            "@Injectable()\nexport class UsersService {\n"
+            "  findOne(): string { return 'one'; }\n}\n"),
+        "user.entity.ts": (
+            "import { Entity, Column } from 'typeorm';\n"
+            "@Entity()\nexport class User {\n"
+            "  getName(): string { return this.name; }\n}\n"),
+        "orphan.ts": "function reallyDead(): number { return 9; }\n",
+    }
+
+    def _build(self, tmp_path):
+        for rel, c in self._FILES.items():
+            (tmp_path / rel).write_text(c)
+        return build_inventory(str(tmp_path), str(tmp_path / "out"))
+
+    def test_typed_ts_extracts_functions(self, tmp_path):
+        pytest.importorskip("tree_sitter_typescript")
+        inv = self._build(tmp_path)
+        names = {it["name"] for f in inv["files"] for it in f["items"]}
+        # class methods + top-level fn extracted (was 0 under the JS grammar).
+        assert {"findAll", "create", "findOne", "getName", "reallyDead"} <= names
+
+    def test_ts_decorators_captured(self, tmp_path):
+        pytest.importorskip("tree_sitter_typescript")
+        inv = self._build(tmp_path)
+        meta = {}
+        for f in inv["files"]:
+            for it in f["items"]:
+                meta[it["name"]] = it.get("metadata") or {}
+        # method decorator on attributes, class decorator on class_attributes.
+        assert any(a.startswith("Get") for a in meta["findAll"]["attributes"])
+        assert any(a.startswith("Controller") for a in meta["findAll"]["class_attributes"])
+        assert any(a.startswith("Injectable") for a in meta["findOne"]["class_attributes"])
+
+    def test_ts_framework_entry_verdicts(self, tmp_path):
+        pytest.importorskip("tree_sitter_typescript")
+        from core.inventory.reach_audit import classify_reachability
+        inv = self._build(tmp_path)
+
+        def verdict(rel, name):
+            for f in inv["files"]:
+                if f["path"] != rel:
+                    continue
+                for it in f["items"]:
+                    if it.get("name") == name:
+                        m = rel.rsplit(".", 1)[0]
+                        return classify_reachability(
+                            inv, rel, name, int(it.get("line_start") or 0), m)
+            return None
+
+        assert verdict("users.controller.ts", "findAll") == "reachable"   # @Get
+        assert verdict("users.controller.ts", "create") == "reachable"    # @Post
+        assert verdict("users.service.ts", "findOne") == "reachable"      # @Injectable bean
+        assert verdict("user.entity.ts", "getName") == "reachable"        # @Entity accessor
+        # over-fire controls — entries only grow the set:
+        assert verdict("users.controller.ts", "deadHelper") == "not_called"  # private
+        assert verdict("orphan.ts", "reallyDead") == "not_called"            # uncalled
+
+    def test_ts_intra_class_this_method_resolves(self, tmp_path):
+        # A private helper reached only via this.helper() from a framework
+        # entry must resolve (class-qualified 1-hop), not read not_called.
+        pytest.importorskip("tree_sitter_typescript")
+        from core.inventory.reach_audit import classify_reachability
+        (tmp_path / "svc.ts").write_text(
+            "@Injectable()\nexport class Svc {\n"
+            "  handle() { return this.step(); }\n"        # public bean entry
+            "  private step() { return this.deep(); }\n"  # via this.
+            "  private deep() { return 1; }\n"            # via this. (transitive)
+            "  private orphan() { return 2; }\n}\n",       # genuinely uncalled
+            encoding="utf-8")
+        inv = build_inventory(str(tmp_path), str(tmp_path / "out"))
+
+        def verdict(name):
+            for f in inv["files"]:
+                for it in f["items"]:
+                    if it.get("name") == name:
+                        return classify_reachability(
+                            inv, f["path"], name,
+                            int(it.get("line_start") or 0), "svc")
+            return None
+
+        assert verdict("handle") == "reachable"   # @Injectable public method
+        assert verdict("step") == "called"        # via this.step()
+        assert verdict("deep") == "called"        # via this.deep() (transitive)
+        assert verdict("orphan") == "not_called"  # genuinely uncalled control

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -1285,3 +1285,119 @@ class TestTypeScriptCoverage:
         assert verdict("step") == "called"        # via this.step()
         assert verdict("deep") == "called"        # via this.deep() (transitive)
         assert verdict("orphan") == "not_called"  # genuinely uncalled control
+
+
+class TestCSharpCoverage:
+    """End-to-end C# / ASP.NET coverage. C# used the regex extractor (no
+    attribute/visibility capture); now wired to tree-sitter-c-sharp so methods
+    extract (name = identifier before parameter_list, NOT the return type) with
+    attributes + visibility, and ASP.NET routing attributes / [ApiController]
+    stereotypes promote action methods to framework entries. Needs
+    tree-sitter-c-sharp; skips without it."""
+
+    _FILES = {
+        "UsersController.cs": (
+            "[ApiController]\n[Route(\"api/users\")]\n"
+            "public class UsersController : ControllerBase {\n"
+            "  [HttpGet] public IActionResult GetAll() { return Ok(Fmt()); }\n"
+            "  [HttpPost] public IActionResult Create() { return Ok(); }\n"
+            "  private string Fmt() { return \"x\"; }\n"
+            "  private string DeadHelper() { return \"never\"; }\n}\n"),
+        "Svc.cs": (
+            "public class Svc {\n  public string Lonely() { return \"x\"; }\n}\n"),
+    }
+
+    def _build(self, tmp_path):
+        for rel, c in self._FILES.items():
+            (tmp_path / rel).write_text(c)
+        return build_inventory(str(tmp_path), str(tmp_path / "out"))
+
+    def test_csharp_extracts_methods_and_attributes(self, tmp_path):
+        pytest.importorskip("tree_sitter_c_sharp")
+        inv = self._build(tmp_path)
+        meta = {it["name"]: (it.get("metadata") or {})
+                for f in inv["files"] for it in f["items"]}
+        # method name is GetAll (not the return type IActionResult).
+        assert {"GetAll", "Create", "Fmt", "Lonely"} <= set(meta)
+        assert "HttpGet" in meta["GetAll"]["attributes"]
+        assert "ApiController" in meta["GetAll"]["class_attributes"]
+        assert meta["Fmt"]["visibility"] == "private"
+
+    def test_csharp_framework_entry_verdicts(self, tmp_path):
+        pytest.importorskip("tree_sitter_c_sharp")
+        from core.inventory.reach_audit import classify_reachability
+        inv = self._build(tmp_path)
+
+        def verdict(name):
+            for f in inv["files"]:
+                for it in f["items"]:
+                    if it.get("name") == name:
+                        return classify_reachability(
+                            inv, f["path"], name,
+                            int(it.get("line_start") or 0),
+                            f["path"].rsplit(".", 1)[0])
+            return None
+
+        assert verdict("GetAll") == "reachable"     # [HttpGet]
+        assert verdict("Create") == "reachable"     # [HttpPost]
+        assert verdict("Fmt") == "called"           # called intra-class by GetAll
+        assert verdict("DeadHelper") == "not_called"  # private uncalled
+        assert verdict("Lonely") == "not_called"    # public, non-stereotype class
+
+
+class TestRubyCoverage:
+    """End-to-end Ruby / Rails coverage. Ruby used the regex extractor; now
+    wired to tree-sitter-ruby (class name = constant, methods, superclass
+    captured). Rails dispatch is CONVENTION-based (no annotations): methods of a
+    class inheriting a framework base (*Controller / job / mailer) are
+    framework entries. Needs tree-sitter-ruby; skips without it."""
+
+    _FILES = {
+        "users_controller.rb": (
+            "class UsersController < ApplicationController\n"
+            "  before_action :authenticate\n"
+            "  def index\n    @u = fetch\n  end\n"
+            "  def show; end\n"
+            "  private\n  def fetch; User.all; end\n"
+            "  def authenticate; end\nend\n"),
+        "widget_job.rb": (
+            "class WidgetJob < ApplicationJob\n  def perform(id); end\nend\n"),
+        "plain.rb": "class PlainThing\n  def lonely; end\nend\n",
+    }
+
+    def _build(self, tmp_path):
+        for rel, c in self._FILES.items():
+            (tmp_path / rel).write_text(c)
+        return build_inventory(str(tmp_path), str(tmp_path / "out"))
+
+    def test_ruby_extracts_methods_and_superclass(self, tmp_path):
+        pytest.importorskip("tree_sitter_ruby")
+        inv = self._build(tmp_path)
+        meta = {it["name"]: (it.get("metadata") or {})
+                for f in inv["files"] for it in f["items"]}
+        assert {"index", "show", "fetch", "perform", "lonely"} <= set(meta)
+        assert meta["index"]["class_name"] == "UsersController"
+        assert "ApplicationController" in meta["index"]["class_attributes"]
+
+    def test_ruby_rails_framework_entry_verdicts(self, tmp_path):
+        pytest.importorskip("tree_sitter_ruby")
+        from core.inventory.reach_audit import classify_reachability
+        inv = self._build(tmp_path)
+
+        def verdict(name):
+            for f in inv["files"]:
+                for it in f["items"]:
+                    if it.get("name") == name:
+                        return classify_reachability(
+                            inv, f["path"], name,
+                            int(it.get("line_start") or 0),
+                            f["path"].rsplit(".", 1)[0])
+            return None
+
+        # controller actions + private callbacks/helpers are Rails-dispatched.
+        assert verdict("index") == "reachable"
+        assert verdict("show") == "reachable"
+        assert verdict("authenticate") == "reachable"   # before_action callback
+        assert verdict("fetch") == "reachable"           # helper in a controller
+        assert verdict("perform") == "reachable"         # job entry
+        assert verdict("lonely") == "not_called"         # plain class control

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -1181,6 +1181,35 @@ class TestJavaFrameworkEntries:
         assert verdict("Ctl.java", "wr") == "not_called"       # @Transactional is not an entry
         assert verdict("Ctl.java", "dead") == "not_called"     # plain uncalled
 
+    def test_java_framework_base_extends_implements(self, tmp_path):
+        # extends/implements a framework base → methods are entries (closes the
+        # interface-dispatch residuals type-free: Spring Data repos + dispatched
+        # framework-interface @Override impls).
+        pytest.importorskip("tree_sitter_java")
+        from core.inventory.reach_audit import classify_reachability
+        (tmp_path / "OwnerRepository.java").write_text(
+            "package x;\npublic interface OwnerRepository "
+            "extends JpaRepository<Owner,Integer> {\n  Owner findByLastName(String n);\n}\n")
+        (tmp_path / "PetValidator.java").write_text(
+            "package x;\npublic class PetValidator implements Validator {\n"
+            "  @Override public void validate(Object o) {}\n}\n")
+        (tmp_path / "Plain.java").write_text(
+            "package x;\npublic class Plain {\n  public void lonely() {}\n}\n")
+        inv = build_inventory(str(tmp_path), str(tmp_path / "out"))
+
+        def verdict(rel, name):
+            for f in inv["files"]:
+                for it in f["items"]:
+                    if it.get("name") == name and f["path"].endswith(rel):
+                        return classify_reachability(
+                            inv, f["path"], name,
+                            int(it.get("line_start") or 0), f["path"].rsplit(".", 1)[0])
+            return None
+
+        assert verdict("OwnerRepository.java", "findByLastName") == "reachable"  # Spring Data
+        assert verdict("PetValidator.java", "validate") == "reachable"           # Validator impl
+        assert verdict("Plain.java", "lonely") == "not_called"                   # control
+
 
 class TestTypeScriptCoverage:
     """End-to-end TypeScript coverage. Typed TS was parsed with the JS grammar,

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -793,3 +793,39 @@ def test_java_framework_entry_degrades_gracefully_on_stale_metadata():
     # ``attributes`` field predates this feature), so Tier-1 dispatch is robust.
     assert _java_framework_entry(
         "on", {"name": "on", "metadata": {"attributes": ["EventListener"]}})
+
+
+# ---------------------------------------------------------------------------
+# TS/JS framework-dispatch entries (_ts_framework_entry). Path-independent:
+# operate on synthetic item dicts (decorators stored @-stripped, e.g.
+# ``Get()`` / ``Controller('x')``), so they run on CI without
+# tree-sitter-typescript. The key guarantees are the negatives — a plain
+# method and a private stereotype method must NOT be promoted.
+# ---------------------------------------------------------------------------
+
+
+def test_ts_method_dispatch_decorators_are_entries():
+    from core.inventory.reachability import _ts_framework_entry
+    for dec in ("Get()", "Post('x')", "MessagePattern('cmd')",
+                "Cron('* * * * *')", "Query()", "SubscribeMessage('ev')"):
+        assert _ts_framework_entry(
+            "h", _java_item("h", attrs=[dec], visibility="public")), dec
+
+
+def test_ts_class_stereotype_promotes_public_methods_only():
+    from core.inventory.reachability import _ts_framework_entry
+    for st in ("Controller('u')", "Injectable()", "Component({})",
+               "Resolver()", "Entity()", "Directive()"):
+        assert _ts_framework_entry(
+            "m", _java_item("m", class_attrs=[st], visibility="public")), st
+    # TS members default to public; a private member is not container-dispatched.
+    assert not _ts_framework_entry(
+        "helper", _java_item("helper", class_attrs=["Injectable()"], visibility="private"))
+
+
+def test_ts_plain_method_and_stale_metadata_not_entries():
+    from core.inventory.reachability import _ts_framework_entry
+    # plain public method of a non-stereotype class → not an entry.
+    assert not _ts_framework_entry("dead", _java_item("dead", visibility="public"))
+    # graceful on missing metadata (degrade to 1-hop, no crash).
+    assert _ts_framework_entry("x", {"name": "x", "kind": "function"}) is False

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -779,6 +779,26 @@ def test_java_async_transactional_and_plain_are_not_entries():
     assert not _java_framework_entry("dead", _java_item("dead"))
 
 
+def test_java_framework_base_promotes_methods():
+    # extends/implements a framework base (captured in class_attributes): the
+    # framework invokes the methods with no in-project caller — Spring Data
+    # repository query methods + dispatched-interface (@Override) impls. No
+    # visibility gate (interface methods are implicitly public). This is the
+    # type-free way to catch interface dispatch the inventory can't resolve
+    # without type info (generic typed dispatch stays CodeQL's job).
+    from core.inventory.reachability import _java_framework_entry
+    assert _java_framework_entry(
+        "findById", _java_item("findById", class_attrs=["JpaRepository"], visibility=None))
+    assert _java_framework_entry(
+        "validate", _java_item("validate", class_attrs=["Validator"], attrs=["Override"]))
+    assert _java_framework_entry(
+        "registerHints",
+        _java_item("registerHints", class_attrs=["RuntimeHintsRegistrar"]))
+    # a class extending a non-framework base is NOT promoted.
+    assert not _java_framework_entry(
+        "helper", _java_item("helper", class_attrs=["SomeBaseClass"]))
+
+
 def test_java_framework_entry_degrades_gracefully_on_stale_metadata():
     # A pre-feature checklist.json (reused for an unchanged file) has no
     # ``class_attributes`` key — and a malformed record may have no metadata at

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -829,3 +829,57 @@ def test_ts_plain_method_and_stale_metadata_not_entries():
     assert not _ts_framework_entry("dead", _java_item("dead", visibility="public"))
     # graceful on missing metadata (degrade to 1-hop, no crash).
     assert _ts_framework_entry("x", {"name": "x", "kind": "function"}) is False
+
+
+# ---------------------------------------------------------------------------
+# C# / ASP.NET framework-dispatch entries (_csharp_framework_entry).
+# Path-independent: synthetic item dicts (attributes stored as the tail name,
+# e.g. "HttpGet" / "ApiController"), so they run on CI without tree-sitter-c#.
+# ---------------------------------------------------------------------------
+
+
+def test_csharp_method_route_attrs_are_entries():
+    from core.inventory.reachability import _csharp_framework_entry
+    for attr in ("HttpGet", "HttpPost", "Route",
+                 "Microsoft.AspNetCore.Mvc.HttpDelete"):
+        assert _csharp_framework_entry(
+            "Act", _java_item("Act", attrs=[attr], visibility="public")), attr
+
+
+def test_csharp_controller_stereotype_promotes_public_only():
+    from core.inventory.reachability import _csharp_framework_entry
+    assert _csharp_framework_entry(
+        "Index", _java_item("Index", class_attrs=["ApiController"], visibility="public"))
+    assert _csharp_framework_entry(
+        "List", _java_item("List", class_attrs=["Controller"], visibility="public"))
+    # C# members default to private; a private action isn't dispatched.
+    assert not _csharp_framework_entry(
+        "Helper", _java_item("Helper", class_attrs=["ApiController"], visibility="private"))
+
+
+def test_csharp_plain_and_stale_not_entries():
+    from core.inventory.reachability import _csharp_framework_entry
+    assert not _csharp_framework_entry("Lonely", _java_item("Lonely", visibility="public"))
+    assert _csharp_framework_entry("x", {"name": "x", "kind": "function"}) is False
+
+
+# ---------------------------------------------------------------------------
+# Ruby / Rails framework entries (_ruby_framework_entry). Convention-based: the
+# signal is the base class captured in class_attributes (no annotations).
+# ---------------------------------------------------------------------------
+
+
+def test_ruby_framework_base_promotes_class_methods():
+    from core.inventory.reachability import _ruby_framework_entry
+    # any method of a class inheriting a Rails base is framework-dispatched.
+    for base in ("ApplicationController", "Admin::UsersController",
+                 "ApplicationJob", "ActionMailer::Base"):
+        assert _ruby_framework_entry("m", _java_item("m", class_attrs=[base])), base
+
+
+def test_ruby_non_framework_class_not_entry():
+    from core.inventory.reachability import _ruby_framework_entry
+    # a plain class (no Rails base) is not framework-dispatched.
+    assert not _ruby_framework_entry("lonely", _java_item("lonely", class_attrs=["SomeBase"]))
+    assert not _ruby_framework_entry("lonely", _java_item("lonely"))
+    assert _ruby_framework_entry("x", {"name": "x", "kind": "function"}) is False

--- a/packages/exploitability_validation/tests/test_validation.py
+++ b/packages/exploitability_validation/tests/test_validation.py
@@ -43,7 +43,9 @@ class TestLanguageDetection:
 
     def test_typescript(self):
         assert detect_language("baz.ts") == "typescript"
-        assert detect_language("baz.tsx") == "typescript"
+        # .tsx is its own language (tree-sitter-typescript's tsx grammar parses
+        # JSX; the plain typescript grammar errors on it).
+        assert detect_language("baz.tsx") == "tsx"
 
     def test_c(self):
         assert detect_language("main.c") == "c"


### PR DESCRIPTION
  Expands the inventory reachability layer so framework-dispatched code (handlers with no static caller) is correctly reachable instead of false-demoted — the build-free, all-language tier beneath CodeQL.
  
  - TypeScript/TSX: fixed a foundational bug (TS was parsed with the JS grammar → typed files extracted almost nothing; NestJS core measured 470 → 1033 functions, +120%). Now captures decorators +
  NestJS/Angular/TypeORM framework entries; .tsx is its own grammar. Plus a general this.method() 1-hop fix (benefits JS/Java/Python too).
  - C# / ASP.NET: wired tree-sitter-c#; [ApiController]/[HttpGet]/[Route] actions are entries.
  - Ruby / Rails: wired tree-sitter-ruby; convention-based entries (controllers/jobs/mailers via superclass).
  - Java: Spring Data repositories + dispatched framework-interface impls (Validator/RuntimeHintsRegistrar) — closes the measured petclinic interface-dispatch residuals type-free.
  
  All changes are the monotonic add-entries lever (only grow the reachable set → can't suppress real code, FP/FN-safe). Generic typed iface.method() resolution is deliberately left to CodeQL.
