### PR TITLE
feat(sca): correct Debian/apt version handling + opt-in --pin-debian

### DIFF
--- a/packages/sca/__init__.py
+++ b/packages/sca/__init__.py
@@ -60,7 +60,7 @@ SCA_ALLOWED_HOSTS = (
     "search.maven.org",
     "repo.packagist.org",
     "api.nuget.org",
-    "sources.debian.org",
+    "api.ftp-master.debian.org",                    # Debian madison (binary-aware, per-suite versions)
     "formulae.brew.sh",
     # GHSA — GitHub's security advisory feed; not the same
     # data as OSV's GHSA mirror (slight latency + occasional

--- a/packages/sca/harden.py
+++ b/packages/sca/harden.py
@@ -98,6 +98,12 @@ class HardenCandidate:
                                 workflow / shell script)
       - ``no_versions``      — registry returned nothing (404, etc.)
       - ``registry_unsupported`` — ecosystem has no client yet
+      - ``pinning_deferred`` — Debian/apt dep not pinned: either pinning
+                                is off (the default — opt in with
+                                ``--pin-debian``) or ``--pin-debian`` is
+                                set but the base image has no determinable
+                                Debian suite to pin within (so a pin would
+                                risk being uninstallable)
       - ``needs_network``    — ``--offline`` and no cached versions
       - ``error``            — something else failed; see ``detail``
     """
@@ -185,6 +191,7 @@ def main(argv: Sequence[str]) -> int:
         offline=args.offline,
         allow_major=args.allow_major,
         pin_only=args.pin_only,
+        pin_debian=args.pin_debian,
     )
 
     # ``--ecosystems`` is a post-plan filter: candidates outside the
@@ -258,7 +265,7 @@ def main(argv: Sequence[str]) -> int:
             target=target, out_dir=out_dir, patch_path=patch_path,
             registries=registries, osv=osv, kev=kev, epss=epss,
             offline=args.offline, allow_major=args.allow_major,
-            pin_only=args.pin_only,
+            pin_only=args.pin_only, pin_debian=args.pin_debian,
             ecosystem_allowlist=ecosystem_allowlist,
             allow_major_without_review=args.allow_major_without_review,
             allow_degraded=args.allow_degraded,
@@ -285,6 +292,7 @@ def plan(
     offline: bool,
     allow_major: bool,
     pin_only: bool = False,
+    pin_debian: bool = False,
 ) -> List[HardenCandidate]:
     """Walk the target and produce one HardenCandidate per dep.
 
@@ -338,7 +346,7 @@ def plan(
         out.append(_plan_one(dep, registries=registries, osv=osv,
                              kev=kev, epss=epss,
                              offline=offline, allow_major=allow_major,
-                             pin_only=pin_only,
+                             pin_only=pin_only, pin_debian=pin_debian,
                              platform_matrix=platform_matrix))
     return out
 
@@ -353,6 +361,7 @@ def _plan_one(
     offline: bool,
     allow_major: bool,
     pin_only: bool = False,
+    pin_debian: bool = False,
     platform_matrix=None,
 ) -> HardenCandidate:
     cand = HardenCandidate(
@@ -402,15 +411,58 @@ def _plan_one(
         cand.detail = f"no registry client for ecosystem {dep.ecosystem!r}"
         return cand
 
+    # Debian/apt pinning is OFF by default and opt-in via ``--pin-debian``.
+    # An exact apt pin is inherently fragile — Debian keeps only the current
+    # version per suite, so a ``pkg=version`` pin breaks the build once it's
+    # superseded (snapshot.debian.org is the robust alternative). When the
+    # operator does opt in, we pin to the newest version *in the suite of
+    # the base image governing this apt line* (attributed by the parser into
+    # ``source_extra["suite"]``) so the pin is actually installable there.
+    # A dep with no determinable Debian suite (non-Debian base, silent tag,
+    # no FROM) is skipped rather than pinned to a guessed suite.
+    # (Keyed on the ecosystem string — the only way to resolve a
+    # ``DebianClient`` above is ``dep.ecosystem == "Debian"``, since the
+    # registries dict is ecosystem-keyed.)
+    debian_suite: Optional[str] = None
+    if dep.ecosystem == "Debian":
+        if not pin_debian:
+            cand.status = "pinning_deferred"
+            cand.detail = (
+                "Debian/apt pinning is off by default; rerun with "
+                "--pin-debian to opt in. Note: an exact apt pin is fragile "
+                "— Debian keeps only the current version per suite, so the "
+                "pin breaks once it's superseded (see snapshot.debian.org "
+                "for reproducible installs)."
+            )
+            return cand
+        debian_suite = (dep.source_extra or {}).get("suite")
+        if not debian_suite:
+            base = (dep.source_extra or {}).get("base_image")
+            cand.status = "pinning_deferred"
+            cand.detail = (
+                f"--pin-debian set but no resolvable Debian suite for base "
+                f"image {base!r}; refusing to guess a version (would risk an "
+                f"uninstallable pin)"
+            )
+            return cand
+
+    # Fetch the candidate versions. For an opted-in Debian dep, restrict to
+    # the governing base image's suite so the pin is installable there;
+    # everything else lists all of the ecosystem's versions.
+    def _fetch() -> List[str]:
+        if debian_suite is not None:
+            return registry.versions_in_suite(dep.name, debian_suite)
+        return registry.list_versions(dep.name)
+
     if offline:
         # Best-effort: try the cache via the registry client. If it
         # comes back empty, mark needs_network.
-        versions = registry.list_versions(dep.name)
+        versions = _fetch()
         if not versions:
             cand.status = "needs_network"
             return cand
     else:
-        versions = registry.list_versions(dep.name)
+        versions = _fetch()
         if not versions:
             cand.status = "no_versions"
             cand.detail = (
@@ -603,9 +655,11 @@ def _versions_above_installed(
     (nothing ever above installed → every versioned npm/Maven/NuGet/Cargo
     dep fell through to ``up_to_date``, so ``--harden`` never bumped them).
     ``version_compare`` raises ``VersionError`` for ecosystems with no
-    comparator (e.g. Debian) or unparseable inputs (a RANGE dep whose
-    ``installed`` is the whole spec string) — both caught below and that
-    version skipped, so those keep the prior no-bump behaviour.
+    comparator or unparseable inputs (a RANGE dep whose ``installed`` is
+    the whole spec string) — both caught below and that version skipped,
+    so those keep the prior no-bump behaviour. (Debian *has* a comparator
+    now but is gated out earlier in ``_plan_one`` pending a registry fix,
+    so it never reaches here.)
     """
     if installed is None:
         return list(versions)
@@ -919,6 +973,7 @@ def _run_self_test(
     ecosystem_allowlist: Optional[set],
     allow_major_without_review: bool,
     allow_degraded: bool,
+    pin_debian: bool = False,
 ) -> int:
     """Apply patch to a temp copy of ``target`` and re-run the planner.
 
@@ -1021,11 +1076,15 @@ def _run_self_test(
                   f"{proc.stderr or proc.stdout}", file=sys.stderr)
             return 6
 
-        # Re-plan against the post-state.
+        # Re-plan against the post-state. Same flags as pass 1 — notably
+        # ``pin_debian``, so apt pins are re-validated as up_to_date rather
+        # than silently deferred (which would make the self-test pass
+        # vacuously without confirming the pin landed).
         post_candidates = plan(
             target=worktree,
             registries=registries, osv=osv, kev=kev, epss=epss,
             offline=offline, allow_major=allow_major, pin_only=pin_only,
+            pin_debian=pin_debian,
         )
         post_actionable = _count_actionable(
             post_candidates,
@@ -1233,6 +1292,16 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
                    help="only promote deps that are *already* exact-pinned "
                         "(``==X.Y.Z``); don't tighten loose pins. "
                         "Conservative; mirrors `update --pin-only`.")
+    p.add_argument("--pin-debian", action="store_true",
+                   help="opt in to pinning Debian/apt packages (off by "
+                        "default). Pins to the newest version in the suite "
+                        "of the base image governing each apt-get line "
+                        "(from the Dockerfile FROM); skips deps whose base "
+                        "isn't a determinable Debian suite. Note: an exact "
+                        "apt pin is fragile — Debian keeps only the current "
+                        "version per suite, so the pin breaks once it's "
+                        "superseded; snapshot.debian.org is the robust "
+                        "alternative for reproducible apt installs.")
     p.add_argument("--git-patch", action="store_true",
                    help="emit upgrade.patch alongside candidates.json")
     p.add_argument("--offline", action="store_true",

--- a/packages/sca/parsers/inline_installs/__init__.py
+++ b/packages/sca/parsers/inline_installs/__init__.py
@@ -389,16 +389,31 @@ def _extract_apt_via_core_dockerfile(
             path, exc_info=True,
         )
         return []
+    from ._base_image_suite import stage_image_map
+    stage_img = stage_image_map(instructions)
     out: List[Dependency] = []
     for ap in extract_apt_packages(instructions):
-        out.append(_apt_package_to_dep(ap, path))
+        out.append(_apt_package_to_dep(ap, path,
+                                       base_image=stage_img.get(ap.stage)))
     return out
 
 
-def _apt_package_to_dep(ap, declared_in: Path) -> Dependency:
+def _apt_package_to_dep(ap, declared_in: Path,
+                        base_image: Optional[str] = None) -> Dependency:
     canon = _canonicalise_name(ap.name, "Debian")
     purl_base = f"pkg:deb/debian/{canon}"
     purl = f"{purl_base}@{ap.version}" if ap.version else purl_base
+    # Attribute the apt package to the Debian suite of the base image
+    # governing its build stage, so harden's opt-in ``--pin-debian`` can
+    # pin to a version that's actually installable there. A ``None`` suite
+    # (non-Debian base, undeterminable tag, no FROM) means "don't pin".
+    source_extra = None
+    if base_image:
+        from ._base_image_suite import debian_suite_from_image
+        source_extra = {
+            "base_image": base_image,
+            "suite": debian_suite_from_image(base_image),
+        }
     return Dependency(
         ecosystem="Debian",
         name=canon,
@@ -418,6 +433,7 @@ def _apt_package_to_dep(ap, declared_in: Path) -> Dependency:
         ),
         commented_out=False,
         source_kind="dockerfile",
+        source_extra=source_extra,
     )
 
 

--- a/packages/sca/parsers/inline_installs/_base_image_suite.py
+++ b/packages/sca/parsers/inline_installs/_base_image_suite.py
@@ -1,0 +1,126 @@
+"""Resolve the Debian suite a Dockerfile base image pins to.
+
+A ``RUN apt-get install`` line installs from the apt sources of the base
+image governing its build stage. To pin an apt package to an *installable*
+version we need that base image's Debian suite (codename / alias) — which
+is exactly what madison's ``s=`` filter accepts.
+
+The suite lives in the image tag: ``debian:bookworm``, ``debian:12`` and
+``python:3.12-bookworm-slim`` all resolve to ``bookworm``;
+``debian:stable`` to ``stable``. Non-Debian bases (``ubuntu:22.04``,
+``alpine``, ``scratch``) and undeterminable ones (a ``$ARG`` image,
+``python:3.12`` whose Debian release isn't in the tag) resolve to ``None``
+so the caller skips rather than guesses.
+
+Codename→alias drift (``bookworm`` was *stable*, is *oldstable* in 2026)
+is left to madison's server-side resolution — we pass the codename through
+untouched.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from core.dockerfile.parser import Instruction
+
+# Debian release codenames (recent + current + announced) and the suite
+# aliases madison accepts.
+_CODENAMES = {
+    "stretch", "buster", "bullseye", "bookworm", "trixie", "forky", "duke",
+    "sid",
+}
+_ALIASES = {
+    "stable", "testing", "unstable", "oldstable", "oldoldstable",
+    "experimental",
+}
+_DEBIAN_SUITES = _CODENAMES | _ALIASES
+
+# Numeric tags (``debian:12``). Release numbers are permanent, so this map
+# does not drift — unlike codename↔alias, which madison resolves for us.
+_NUMBER_TO_CODENAME = {
+    "9": "stretch", "10": "buster", "11": "bullseye", "12": "bookworm",
+    "13": "trixie", "14": "forky",
+}
+
+
+def debian_suite_from_image(image_ref: str) -> Optional[str]:
+    """Return the Debian suite token a base image pins to, or ``None``.
+
+    The token is a codename (``bookworm``) or alias (``stable``) suitable
+    for madison's ``s=`` filter. ``None`` means "not a determinable Debian
+    suite" — the caller should skip, not guess.
+    """
+    if not image_ref:
+        return None
+    # Drop a ``@sha256:…`` digest, then take the final path component so a
+    # registry ``host[:port]/namespace/`` prefix can't be mistaken for the
+    # repo:tag split.
+    ref = image_ref.strip().split("@", 1)[0]
+    repo_tag = ref.rsplit("/", 1)[-1]
+    if ":" in repo_tag:
+        repo, tag = repo_tag.split(":", 1)
+    else:
+        repo, tag = repo_tag, ""
+    # A recognisable Debian codename/alias anywhere in the tag wins. This
+    # also covers Debian-derived images (python:3.12-bookworm-slim,
+    # node:20-bullseye); tag components are ``-``-separated.
+    for part in tag.split("-"):
+        if part in _DEBIAN_SUITES:
+            return part
+    # A bare ``debian`` image: numeric tag via the permanent release map;
+    # an empty / ``latest`` tag is the current stable.
+    if repo == "debian":
+        if tag in _NUMBER_TO_CODENAME:
+            return _NUMBER_TO_CODENAME[tag]
+        if tag in ("", "latest"):
+            return "stable"
+    return None
+
+
+def _from_image_ref(args: str) -> Optional[str]:
+    """The image reference of a ``FROM`` instruction's args.
+
+    Skips a leading ``--platform=…`` flag and stops at an ``AS`` clause;
+    returns the first bare token (the image or a referenced stage name).
+    """
+    for tok in args.split():
+        if tok.upper() == "AS":
+            break
+        if tok.startswith("--"):
+            continue
+        return tok
+    return None
+
+
+def stage_image_map(instructions: List[Instruction]) -> Dict[Optional[str], str]:
+    """Map each build stage to the image ref of its governing ``FROM``.
+
+    The key is the stage name (``None`` for a ``FROM`` with no ``AS``).
+    ``FROM <prev-stage>`` chains are followed to the underlying image, so a
+    ``RUN apt-get install`` in a stage built ``FROM builder`` resolves to
+    ``builder``'s base image.
+    """
+    raw: Dict[Optional[str], str] = {}
+    order: List[Optional[str]] = []
+    for inst in instructions:
+        if inst.directive != "FROM":
+            continue
+        img = _from_image_ref(inst.args)
+        if img is None:
+            continue
+        raw[inst.stage_name] = img
+        order.append(inst.stage_name)
+
+    stage_names = set(raw)
+    resolved: Dict[Optional[str], str] = {}
+    for stage in order:
+        img = raw[stage]
+        seen: set = set()
+        while img in stage_names and img not in seen:
+            seen.add(img)
+            img = raw[img]
+        resolved[stage] = img
+    return resolved
+
+
+__all__ = ["debian_suite_from_image", "stage_image_map"]

--- a/packages/sca/parsers/inline_installs/tests/test_base_image_suite.py
+++ b/packages/sca/parsers/inline_installs/tests/test_base_image_suite.py
@@ -1,0 +1,95 @@
+"""Tests for base-image → Debian suite resolution and its attribution to
+apt deps parsed from a Dockerfile."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from packages.sca.parsers.inline_installs import _extract_apt_via_core_dockerfile
+from packages.sca.parsers.inline_installs._base_image_suite import (
+    debian_suite_from_image,
+    stage_image_map,
+)
+from core.dockerfile import parse_dockerfile
+
+
+@pytest.mark.parametrize("ref,expected", [
+    ("debian:bookworm", "bookworm"),
+    ("debian:bookworm-slim", "bookworm"),
+    ("debian:bookworm-backports", "bookworm"),
+    ("debian:12", "bookworm"),                 # permanent number map
+    ("debian:11", "bullseye"),
+    ("debian:stable", "stable"),               # alias passes through
+    ("debian:sid", "sid"),
+    ("debian", "stable"),                      # bare = current stable
+    ("debian:latest", "stable"),
+    # Debian-derived images carry the codename in the tag.
+    ("python:3.12-bookworm-slim", "bookworm"),
+    ("node:20-bullseye", "bullseye"),
+    ("docker.io/library/debian:trixie", "trixie"),
+    ("myreg.example.com:5000/debian:bookworm", "bookworm"),
+    ("debian:bookworm@sha256:abc123", "bookworm"),
+    # Not a determinable Debian suite -> None (caller skips, never guesses).
+    ("ubuntu:22.04", None),
+    ("ubuntu:jammy", None),                    # Ubuntu codename, not Debian
+    ("alpine:3.19", None),
+    ("scratch", None),
+    ("python:3.12", None),                     # Debian-based but tag is silent
+    ("", None),
+])
+def test_debian_suite_from_image(ref, expected) -> None:
+    assert debian_suite_from_image(ref) == expected
+
+
+def test_stage_image_map_follows_from_stage_chains() -> None:
+    text = (
+        "FROM debian:bookworm AS builder\n"
+        "RUN apt-get install -y gcc\n"
+        "FROM builder AS final\n"
+        "RUN apt-get install -y nginx\n"
+        "FROM alpine\n"
+    )
+    m = stage_image_map(parse_dockerfile(text))
+    assert m["builder"] == "debian:bookworm"
+    assert m["final"] == "debian:bookworm"     # final -> builder -> image
+    assert m[None] == "alpine"                 # the AS-less FROM
+
+
+def test_apt_dep_carries_governing_base_image_suite() -> None:
+    text = (
+        "FROM debian:bookworm-slim\n"
+        "RUN apt-get install -y nginx=1.22.1-9+deb12u6 curl\n"
+    )
+    deps = _extract_apt_via_core_dockerfile(text, Path("/x/Dockerfile"))
+    assert deps, "expected apt deps extracted"
+    for d in deps:
+        assert d.ecosystem == "Debian"
+        assert d.source_extra == {
+            "base_image": "debian:bookworm-slim", "suite": "bookworm",
+        }
+
+
+def test_apt_dep_from_non_debian_base_has_no_suite() -> None:
+    """An apt-get on an Ubuntu base resolves suite=None — harden won't pin
+    it (we have no Ubuntu version data)."""
+    text = "FROM ubuntu:22.04\nRUN apt-get install -y nginx\n"
+    deps = _extract_apt_via_core_dockerfile(text, Path("/x/Dockerfile"))
+    assert deps
+    for d in deps:
+        assert d.source_extra == {"base_image": "ubuntu:22.04", "suite": None}
+
+
+def test_multistage_runtime_vs_builder_suites() -> None:
+    """Each apt dep is attributed to its own stage's base image."""
+    text = (
+        "FROM debian:bullseye AS build\n"
+        "RUN apt-get install -y build-essential\n"
+        "FROM debian:bookworm\n"
+        "RUN apt-get install -y nginx\n"
+    )
+    deps = _extract_apt_via_core_dockerfile(text, Path("/x/Dockerfile"))
+    by_name = {d.name: d for d in deps}
+    assert by_name["build-essential"].source_extra["suite"] == "bullseye"
+    assert by_name["nginx"].source_extra["suite"] == "bookworm"

--- a/packages/sca/registries/debian.py
+++ b/packages/sca/registries/debian.py
@@ -1,37 +1,58 @@
 """Debian registry client.
 
-Fetches ``https://sources.debian.org/api/src/<package>/`` — the canonical
-"all known versions of this Debian source package" endpoint. Returns
-versions newest-first.
+Lists the versions of a Debian *binary* package across the active Debian
+suites via the ftp-master ``madison`` service:
+``https://api.ftp-master.debian.org/madison?package=<name>&f=json``.
 
-Note: the Debian Sources API lists *source-package* versions, not the
-binary-package versions you'd see in ``apt list``. For most cases the
-two track each other (binary nginx ↔ source nginx). When they diverge
-the source list is the conservative choice — every binary derives from
-some source version.
+Why madison and not ``sources.debian.org/api/src/<name>/``: the Sources
+API is keyed by *source*-package name and lists every historical version
+back to the distribution's origins. Querying it by *binary* name silently
+mis-resolves —
 
-Suite-aware queries (which versions are in which release) are deferred:
-the simple "list versions" endpoint is sufficient for harden's
-pick-latest-safe semantic.
+  - ``gcc`` hits an ancient standalone source package (newest ``2.95.2-20``
+    from woody, ~2002); the modern binary builds from ``gcc-defaults``,
+  - ``g++`` 404s (there is no source named ``g++``),
+  - ``make`` is really the source ``make-dfsg``,
+
+and even when names coincide it returns long-dead releases unsorted.
+madison is *binary-package-aware* (no binary→source mapping needed), only
+covers *active* suites (oldstable…experimental, plus -security/-backports/
+-proposed-updates), and we sort newest-first with the dpkg version
+comparator (:mod:`packages.sca.versions.debian`).
+
+Note on use: RAPTOR's own ``harden`` deliberately does NOT pin or bump apt
+deps — an exact ``pkg=version`` pin is fragile (Debian keeps only the
+current version per suite, so the pin breaks the build once it's
+superseded). See the ``pinning_deferred`` gate in ``harden._plan_one``.
+This client exists so the version data is *correct* for direct inspection
+and for any consumer that explicitly opts in.
 """
 
 from __future__ import annotations
 
+import functools
 import logging
-from typing import List, Optional
+import urllib.parse
+from typing import Any, List, Optional
 
 from core.json import JsonCache, MISSING
 from core.http import HttpClient
 
+from ..versions.debian import compare as _debian_compare
+
 logger = logging.getLogger(__name__)
 
 
-_CACHE_KEY_PREFIX = "debian-versions"
+_MADISON_URL = "https://api.ftp-master.debian.org/madison"
+# ``-madison`` (was ``debian-versions``) so any entries cached by the old
+# source-API client are bypassed rather than served stale for a TTL window
+# — those held the wrong (source-by-binary, unsorted) version lists.
+_CACHE_KEY_PREFIX = "debian-madison"
 _DEFAULT_TTL = 24 * 3600
 
 
 class DebianClient:
-    """List versions from the Debian Sources API."""
+    """List binary-package versions from the Debian madison service."""
 
     ecosystem = "Debian"
 
@@ -49,7 +70,27 @@ class DebianClient:
         self._offline = offline
 
     def list_versions(self, name: str) -> List[str]:
-        cache_key = f"{_CACHE_KEY_PREFIX}:{name}"
+        """All versions across the active suites, newest-first.
+
+        For direct inspection / SBOM use. ``apt`` pinning wants a single
+        suite — see :meth:`versions_in_suite`.
+        """
+        return self._query(name, suite=None)
+
+    def versions_in_suite(self, name: str, suite: str) -> List[str]:
+        """Versions of ``name`` available in a single suite, newest-first.
+
+        ``suite`` is whatever a Dockerfile ``FROM`` yields — a codename
+        (``bookworm``), an alias (``stable``), or a pocket
+        (``bookworm-security``). madison resolves codenames to their
+        current alias server-side, so no (drifting) codename↔alias table
+        is needed here.
+        """
+        return self._query(name, suite=suite)
+
+    def _query(self, name: str, *, suite: Optional[str]) -> List[str]:
+        cache_key = (f"{_CACHE_KEY_PREFIX}:{name}" if suite is None
+                     else f"{_CACHE_KEY_PREFIX}:{name}:{suite}")
         if self._cache is not None:
             cached = self._cache.try_get(cache_key, ttl_seconds=self._ttl)
             if cached is not MISSING:
@@ -58,9 +99,16 @@ class DebianClient:
         if self._offline:
             return []
 
+        # madison's query string treats ``+`` as a space, so a binary name
+        # like ``g++`` MUST be percent-encoded (``safe=""`` encodes ``+``,
+        # ``&``, ``=`` …). This is also the injection guard for names (and
+        # suites) that originate from a scanned manifest.
+        url = (f"{_MADISON_URL}?package={urllib.parse.quote(name, safe='')}"
+               f"&f=json")
+        if suite is not None:
+            url += f"&s={urllib.parse.quote(suite, safe='')}"
         try:
-            data = self._http.get_json(
-                f"https://sources.debian.org/api/src/{name}/")
+            data = self._http.get_json(url)
         except Exception as e:                # noqa: BLE001
             logger.warning("sca.registries.debian: fetch failed for %r: %s",
                            name, e)
@@ -74,32 +122,37 @@ class DebianClient:
         return versions
 
 
-def _extract_versions(data: dict) -> List[str]:
-    """Pull versions from the Debian Sources response.
+def _extract_versions(data: Any) -> List[str]:
+    """Pull versions from a madison ``f=json`` response, newest-first.
 
-    Shape:
-        {
-          "package": "nginx",
-          "versions": [
-            {"version": "1.22.1-9", "suites": ["bookworm"], ...},
-            {"version": "1.18.0-6.1+deb11u3", "suites": ["bullseye"], ...}
-          ]
-        }
+    Shape (a one-element list; ``[]`` for an unknown package)::
+
+        [ { "<pkg>": { "<suite>": { "<version>": {<metadata>}, ... },
+                       "<suite>-security": { ... }, ... } } ]
+
+    The same version recurs across suites (e.g. ``oldstable`` and its
+    ``oldstable-debug`` shadow); collect across every suite, dedup, then
+    sort with the dpkg comparator so the newest version is first (matching
+    the other registry clients' contract).
     """
-    raw = data.get("versions") or []
-    if not isinstance(raw, list):
+    if not isinstance(data, list):
         return []
     seen: set = set()
     out: List[str] = []
-    for v in raw:
-        if not isinstance(v, dict):
+    for entry in data:
+        if not isinstance(entry, dict):
             continue
-        ver = v.get("version")
-        if not isinstance(ver, str) or ver in seen:
-            continue
-        seen.add(ver)
-        out.append(ver)
-    # The API returns roughly newest-first; preserve.
+        for suites in entry.values():
+            if not isinstance(suites, dict):
+                continue
+            for versions in suites.values():
+                if not isinstance(versions, dict):
+                    continue
+                for ver in versions:
+                    if isinstance(ver, str) and ver not in seen:
+                        seen.add(ver)
+                        out.append(ver)
+    out.sort(key=functools.cmp_to_key(_debian_compare), reverse=True)
     return out
 
 

--- a/packages/sca/registries/tests/test_registries.py
+++ b/packages/sca/registries/tests/test_registries.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 from packages.sca.registries.crates import CratesClient
-from packages.sca.registries.debian import DebianClient
+from packages.sca.registries.debian import DebianClient, _extract_versions
 from packages.sca.registries.golang import GoClient
 from packages.sca.registries.homebrew import HomebrewClient
 from packages.sca.registries.maven import MavenClient
@@ -269,30 +269,116 @@ def test_golang_offline_skips_http() -> None:
 # Debian
 # ---------------------------------------------------------------------------
 
-def test_debian_extracts_versions() -> None:
-    http = _FakeHttp(json_payload={
-        "package": "nginx",
-        "versions": [
-            {"version": "1.22.1-9", "suites": ["bookworm"]},
-            {"version": "1.18.0-6.1", "suites": ["bullseye"]},
-            {"version": "1.22.1-9", "suites": ["unstable"]},   # dup
-        ]
-    })
+# Shape mirrors madison ``?f=json``: a one-element list keyed by package
+# name, then suite, then version. The same version recurs across suites
+# (incl. the -debug shadow) and must be deduped; output is newest-first by
+# dpkg ordering (epoch dominance, ``+debNuM`` security bumps, etc.).
+def _madison(pkg: str, by_suite: Dict[str, List[str]]) -> List[dict]:
+    return [{pkg: {
+        suite: {ver: {"component": "main", "source": pkg} for ver in vers}
+        for suite, vers in by_suite.items()
+    }}]
+
+
+def test_debian_extracts_versions_newest_first_deduped() -> None:
+    http = _FakeHttp(json_payload=_madison("nginx", {
+        "oldoldstable": ["1.18.0-6.1+deb11u3"],
+        "oldoldstable-debug": ["1.18.0-6.1+deb11u3"],            # dup shadow
+        "oldstable": ["1.22.1-9+deb12u6"],
+        "oldstable-proposed-updates": ["1.22.1-9+deb12u7"],
+        "stable": ["1.26.0-1"],
+    }))
     client = DebianClient(http)
-    assert client.list_versions("nginx") == ["1.22.1-9", "1.18.0-6.1"]
+    assert client.list_versions("nginx") == [
+        "1.26.0-1",
+        "1.22.1-9+deb12u7",
+        "1.22.1-9+deb12u6",
+        "1.18.0-6.1+deb11u3",
+    ]
+
+
+def test_debian_epoch_sorts_above_higher_upstream() -> None:
+    """An epoch must dominate: the gcc shape that motivated this fix."""
+    http = _FakeHttp(json_payload=_madison("gcc", {
+        "stable": ["4:14.2.0-1"],
+        "experimental": ["4:16-20251130-1"],
+        # A bogus no-epoch entry must still sort *below* the epoch-4 ones.
+        "ancient": ["2.95.2-20"],
+    }))
+    client = DebianClient(http)
+    assert client.list_versions("gcc") == [
+        "4:16-20251130-1", "4:14.2.0-1", "2.95.2-20",
+    ]
+
+
+def test_debian_binary_name_is_url_encoded() -> None:
+    """``g++`` must be percent-encoded — a raw ``+`` is a space to madison
+    (and unencoded names from manifests are a query-injection vector)."""
+    http = _FakeHttp(json_payload=_madison("g++", {"stable": ["4:14.2.0-1"]}))
+    client = DebianClient(http)
+    assert client.list_versions("g++") == ["4:14.2.0-1"]
+    assert "api.ftp-master.debian.org/madison" in http.calls[0]
+    assert "package=g%2B%2B" in http.calls[0]
+    assert "f=json" in http.calls[0]
 
 
 def test_debian_unknown_package_returns_empty() -> None:
-    """API may return ``{"error": "..."}`` for unknown pkgs."""
-    client = DebianClient(_FakeHttp(json_payload={"error": "nope"}))
+    """madison returns ``[]`` for an unknown package (and the parser also
+    tolerates the no-suites and non-list shapes without raising)."""
+    assert _extract_versions([]) == []
+    assert _extract_versions([{"nope": {}}]) == []          # known pkg, no suites
+    assert _extract_versions({"error": "x"}) == []           # not a list
+    client = DebianClient(_FakeHttp(json_payload=[{"nope": {}}]))
     assert client.list_versions("nonexistent-pkg") == []
 
 
 def test_debian_offline_skips_http() -> None:
-    http = _FakeHttp(json_payload={"versions": [{"version": "1.0"}]})
+    http = _FakeHttp(json_payload=_madison("nginx", {"stable": ["1.0"]}))
     client = DebianClient(http, offline=True)
     assert client.list_versions("nginx") == []
     assert http.calls == []
+
+
+def test_debian_versions_in_suite_adds_suite_filter() -> None:
+    """``versions_in_suite`` passes ``&s=<suite>`` so madison resolves the
+    codename server-side; result is still newest-first."""
+    # madison returns the codename query tagged with its current alias.
+    http = _FakeHttp(json_payload=_madison("nginx", {
+        "oldstable": ["1.22.1-9+deb12u6", "1.22.1-9+deb12u5"],
+    }))
+    client = DebianClient(http)
+    assert client.versions_in_suite("nginx", "bookworm") == [
+        "1.22.1-9+deb12u6", "1.22.1-9+deb12u5",
+    ]
+    assert "s=bookworm" in http.calls[0]
+    assert "f=json" in http.calls[0]
+
+
+def test_debian_suite_pocket_is_url_encoded() -> None:
+    """A pocket/alias is encoded too (defends against injection from a
+    manifest-derived FROM tag)."""
+    http = _FakeHttp(json_payload=_madison("nginx", {"stable": ["1.0"]}))
+    client = DebianClient(http)
+    client.versions_in_suite("nginx", "bookworm-security")
+    assert "s=bookworm-security" in http.calls[0]
+
+
+def test_debian_suite_query_cached_separately_from_all_suites() -> None:
+    """The all-suites list and a per-suite list use distinct cache keys."""
+    import tempfile
+    from pathlib import Path
+    from core.json import JsonCache
+    with tempfile.TemporaryDirectory() as d:
+        cache = JsonCache(root=Path(d))
+        http = _FakeHttp(json_payload=_madison("nginx", {
+            "stable": ["1.26.0-1"], "oldstable": ["1.22.1-9+deb12u6"],
+        }))
+        client = DebianClient(http, cache)
+        allv = client.list_versions("nginx")
+        client.versions_in_suite("nginx", "bookworm")
+        # Two distinct network calls (different cache keys), not one reused.
+        assert len(http.calls) == 2
+        assert "1.26.0-1" in allv and "1.22.1-9+deb12u6" in allv
 
 
 # ---------------------------------------------------------------------------

--- a/packages/sca/tests/test_harden_planner.py
+++ b/packages/sca/tests/test_harden_planner.py
@@ -145,6 +145,113 @@ def test_no_registry_for_ecosystem() -> None:
     assert "Debian" in cand.detail
 
 
+# ---------------------------------------------------------------------------
+# Status: pinning_deferred — Debian/apt pinning is OFF by default. With
+# --pin-debian it opts in, but only pins within the suite of the base image
+# governing the apt line; a dep with no determinable suite still defers
+# (never a guessed, possibly-uninstallable pin).
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _ExplodingRegistry:
+    """Registry that fails if queried — proves the default (no --pin-debian)
+    gate short-circuits before any registry call."""
+
+    ecosystem: str = "Debian"
+
+    def list_versions(self, name: str) -> List[str]:  # pragma: no cover
+        raise AssertionError("registry must not be queried when pinning is off")
+
+    def versions_in_suite(self, name: str, suite: str) -> List[str]:  # pragma: no cover
+        raise AssertionError("registry must not be queried when pinning is off")
+
+
+@dataclass
+class _FakeDebianRegistry:
+    """Debian registry stub: ``versions_in_suite`` returns a canned per-suite
+    list; ``list_versions`` (all suites) should not be used by the pin path."""
+
+    by_suite: Dict[str, List[str]]
+    ecosystem: str = "Debian"
+    suite_calls: List[str] = field(default_factory=list)
+
+    def list_versions(self, name: str) -> List[str]:  # pragma: no cover
+        raise AssertionError("pin path must call versions_in_suite, not list_versions")
+
+    def versions_in_suite(self, name: str, suite: str) -> List[str]:
+        self.suite_calls.append(suite)
+        return list(self.by_suite.get(suite, []))
+
+
+def _debian_dep(version: Optional[str], pin_style: PinStyle,
+                source_extra: Optional[Dict] = None) -> Dependency:
+    return Dependency(
+        ecosystem="Debian", name="gcc", version=version,
+        declared_in=Path("/x/Dockerfile"),
+        scope="main", is_lockfile=False,
+        pin_style=pin_style, direct=True,
+        purl=f"pkg:deb/debian/gcc@{version}",
+        parser_confidence=Confidence("high", reason="test"),
+        source_kind="dockerfile", source_extra=source_extra,
+    )
+
+
+def test_debian_deferred_by_default() -> None:
+    """Without --pin-debian, an apt dep is recorded but never pinned, and
+    the registry isn't even queried."""
+    dep = _debian_dep(version=None, pin_style=PinStyle.UNKNOWN,
+                      source_extra={"base_image": "debian:bookworm",
+                                    "suite": "bookworm"})
+    cand = _plan_one(dep, registries={"Debian": _ExplodingRegistry()},
+                     osv=_FakeOsv(), offline=False, allow_major=False)
+    assert cand.status == "pinning_deferred"
+    assert cand.to_version is None
+    assert "--pin-debian" in cand.detail
+
+
+def test_debian_pin_opt_in_pins_to_newest_in_suite() -> None:
+    """--pin-debian pins an unpinned apt dep to the newest version in the
+    base image's suite (not 'newest across all suites' = experimental)."""
+    reg = _FakeDebianRegistry(by_suite={
+        "bookworm": ["1.22.1-9+deb12u6", "1.22.1-9+deb12u5"],
+        "experimental": ["99:0-1"],            # must NOT be considered
+    })
+    dep = _debian_dep(version=None, pin_style=PinStyle.UNKNOWN,
+                      source_extra={"base_image": "debian:bookworm-slim",
+                                    "suite": "bookworm"})
+    cand = _plan_one(dep, registries={"Debian": reg}, osv=_FakeOsv(),
+                     offline=False, allow_major=False, pin_debian=True)
+    assert cand.status == "promoted"
+    assert cand.to_version == "1.22.1-9+deb12u6"
+    assert reg.suite_calls == ["bookworm"]     # queried the right suite
+
+
+def test_debian_pin_opt_in_bumps_behind_suite_version() -> None:
+    """A dep pinned below the current suite version is bumped up to it."""
+    reg = _FakeDebianRegistry(by_suite={"bookworm": ["1.22.1-9+deb12u6"]})
+    dep = _debian_dep(version="1.22.1-9+deb12u5", pin_style=PinStyle.EXACT,
+                      source_extra={"base_image": "debian:bookworm",
+                                    "suite": "bookworm"})
+    cand = _plan_one(dep, registries={"Debian": reg}, osv=_FakeOsv(),
+                     offline=False, allow_major=False, pin_debian=True)
+    assert cand.status == "promoted"
+    assert cand.to_version == "1.22.1-9+deb12u6"
+
+
+def test_debian_pin_opt_in_skips_when_no_suite() -> None:
+    """--pin-debian on a dep whose base isn't a determinable Debian suite
+    (Ubuntu / silent tag / no FROM) still defers — never a guessed pin."""
+    dep = _debian_dep(version=None, pin_style=PinStyle.UNKNOWN,
+                      source_extra={"base_image": "ubuntu:22.04", "suite": None})
+    cand = _plan_one(dep, registries={"Debian": _ExplodingRegistry()},
+                     osv=_FakeOsv(), offline=False, allow_major=False,
+                     pin_debian=True)
+    assert cand.status == "pinning_deferred"
+    assert cand.to_version is None
+    assert "ubuntu:22.04" in cand.detail
+    assert "uninstallable" in cand.detail
+
+
 def test_git_pin_style_unsupported() -> None:
     dep = _dep(pin_style=PinStyle.GIT)
     cand = _plan_one(dep, registries={"PyPI": _FakeRegistry(["2.0"])},

--- a/packages/sca/tests/test_pin_debian_e2e.py
+++ b/packages/sca/tests/test_pin_debian_e2e.py
@@ -1,0 +1,145 @@
+"""End-to-end coverage for ``--pin-debian``.
+
+Exercises the whole chain on a real Dockerfile: parse → base-image suite
+attribution → plan (newest-in-suite) → apply (the actual rewriter, in
+place). Network is stubbed with a fake Debian registry + fake OSV. These
+lock in the behaviour an earlier ad-hoc run proved by hand:
+
+  * unpinned apt deps get pinned, an old pin gets bumped — to the version
+    in the *base image's* suite, not "newest across all suites";
+  * the rewriter preserves epoch (``4:…``) and ``+debNuN`` versions and the
+    backslash line-continuation;
+  * a non-Debian base (Ubuntu) is skipped, never guessed;
+  * pinning is off without the flag;
+  * a dep already at the suite version re-plans as ``up_to_date`` — the
+    idempotency the ``--self-test`` pass-2 relies on.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from packages.sca.harden import _apply, plan
+from packages.sca.osv import OsvResult
+
+
+@dataclasses.dataclass
+class _FakeDeb:
+    """Debian registry stub keyed by (suite, name)."""
+
+    by_suite_pkg: Dict[Tuple[str, str], List[str]]
+    ecosystem: str = "Debian"
+
+    def list_versions(self, name: str) -> List[str]:  # pragma: no cover
+        raise AssertionError("pin path must use versions_in_suite, not list_versions")
+
+    def versions_in_suite(self, name: str, suite: str) -> List[str]:
+        return list(self.by_suite_pkg.get((suite, name), []))
+
+
+@dataclasses.dataclass
+class _ExplodingDeb:
+    """Fails if queried — proves the planner skips before any network call."""
+
+    ecosystem: str = "Debian"
+
+    def list_versions(self, name: str) -> List[str]:  # pragma: no cover
+        raise AssertionError("registry must not be queried")
+
+    def versions_in_suite(self, name: str, suite: str) -> List[str]:  # pragma: no cover
+        raise AssertionError("registry must not be queried")
+
+
+class _FakeOsv:
+    """No advisories — every candidate ranks clean (OSV doesn't cover Debian)."""
+
+    def query_batch(self, deps):
+        return [OsvResult(dep_key=d.key(), advisories=[]) for d in deps]
+
+
+def _plan(target: Path, registry, **kw):
+    return plan(target=target, registries={"Debian": registry},
+                osv=_FakeOsv(), offline=False, allow_major=False, **kw)
+
+
+def test_pin_debian_pins_bumps_and_preserves_epoch(tmp_path: Path) -> None:
+    (tmp_path / "Dockerfile").write_text(
+        "FROM debian:bookworm-slim\n"
+        "RUN apt-get update && apt-get install -y \\\n"
+        "    nginx curl gcc=4:12.2.0-2\n",
+        encoding="utf-8",
+    )
+    reg = _FakeDeb({
+        ("bookworm", "nginx"): ["1.22.1-9+deb12u6"],
+        ("bookworm", "curl"): ["7.88.1-10+deb12u14"],
+        ("bookworm", "gcc"): ["4:12.2.0-3"],          # epoch bump target
+    })
+    cands = _plan(tmp_path, reg, pin_debian=True)
+    by = {c.name: c for c in cands}
+    assert by["nginx"].status == "promoted"
+    assert by["nginx"].to_version == "1.22.1-9+deb12u6"
+    assert by["gcc"].status == "promoted"
+    assert by["gcc"].from_version == "4:12.2.0-2"
+    assert by["gcc"].to_version == "4:12.2.0-3"
+
+    out = tmp_path / "_out"
+    out.mkdir()
+    changes = _apply(cands, target=tmp_path, out_dir=out,
+                     allow_major_without_review=False, allow_degraded=False)
+    assert changes and all(ch.skipped_reason is None for ch in changes)
+    rewritten = next(out.rglob("Dockerfile")).read_text(encoding="utf-8")
+    assert "nginx=1.22.1-9+deb12u6" in rewritten
+    assert "curl=7.88.1-10+deb12u14" in rewritten
+    assert "gcc=4:12.2.0-3" in rewritten              # epoch colon preserved
+    assert "-y \\\n" in rewritten                      # continuation preserved
+
+
+def test_pin_debian_uses_per_stage_suite(tmp_path: Path) -> None:
+    """Each apt line is pinned within its own stage's base suite."""
+    (tmp_path / "Dockerfile").write_text(
+        "FROM debian:bullseye AS build\n"
+        "RUN apt-get install -y gcc\n"
+        "FROM debian:bookworm\n"
+        "RUN apt-get install -y nginx\n",
+        encoding="utf-8",
+    )
+    reg = _FakeDeb({
+        ("bullseye", "gcc"): ["4:10.2.1-1"],
+        ("bookworm", "nginx"): ["1.22.1-9+deb12u6"],
+    })
+    by = {c.name: c for c in _plan(tmp_path, reg, pin_debian=True)}
+    assert by["gcc"].to_version == "4:10.2.1-1"        # bullseye
+    assert by["nginx"].to_version == "1.22.1-9+deb12u6"  # bookworm
+
+
+def test_pin_debian_skips_non_debian_base(tmp_path: Path) -> None:
+    (tmp_path / "Dockerfile").write_text(
+        "FROM ubuntu:22.04\nRUN apt-get install -y nginx\n", encoding="utf-8")
+    by = {c.name: c for c in _plan(tmp_path, _ExplodingDeb(), pin_debian=True)}
+    assert by["nginx"].status == "pinning_deferred"
+    assert by["nginx"].to_version is None
+    assert "ubuntu:22.04" in by["nginx"].detail
+
+
+def test_pin_debian_off_by_default(tmp_path: Path) -> None:
+    (tmp_path / "Dockerfile").write_text(
+        "FROM debian:bookworm\nRUN apt-get install -y nginx\n", encoding="utf-8")
+    by = {c.name: c for c in _plan(tmp_path, _ExplodingDeb())}   # no pin_debian
+    assert by["nginx"].status == "pinning_deferred"
+    assert "--pin-debian" in by["nginx"].detail
+
+
+def test_pin_debian_idempotent_at_suite_version(tmp_path: Path) -> None:
+    """A dep already at the current suite version re-plans as up_to_date —
+    this is what the self-test's pass-2 (now run *with* pin_debian) checks."""
+    (tmp_path / "Dockerfile").write_text(
+        "FROM debian:bookworm\n"
+        "RUN apt-get install -y nginx=1.22.1-9+deb12u6\n",
+        encoding="utf-8",
+    )
+    reg = _FakeDeb({("bookworm", "nginx"): ["1.22.1-9+deb12u6"]})
+    by = {c.name: c for c in _plan(tmp_path, reg, pin_debian=True)}
+    assert by["nginx"].status == "up_to_date"
+    assert by["nginx"].to_version is None

--- a/packages/sca/versions/__init__.py
+++ b/packages/sca/versions/__init__.py
@@ -177,6 +177,9 @@ _ECOSYSTEM_ALIASES = {
     "packagist": "Packagist",
     "composer": "Packagist",
     "php": "Packagist",
+    "debian": "Debian",
+    "apt": "Debian",
+    "deb": "Debian",
 }
 
 
@@ -195,6 +198,7 @@ from .maven import compare as _maven_compare          # noqa: E402
 from .gem import compare as _gem_compare              # noqa: E402
 from .nuget import compare as _nuget_compare          # noqa: E402
 from .composer import compare as _composer_compare    # noqa: E402
+from .debian import compare as _debian_compare        # noqa: E402
 
 _register("npm", _semver_compare)
 _register("Cargo", _semver_compare)        # mostly semver
@@ -204,5 +208,6 @@ _register("Maven", _maven_compare)
 _register("RubyGems", _gem_compare)
 _register("NuGet", _nuget_compare)
 _register("Packagist", _composer_compare)
+_register("Debian", _debian_compare)
 
 __all__ = ["compare", "in_range", "VersionError"]

--- a/packages/sca/versions/debian.py
+++ b/packages/sca/versions/debian.py
@@ -1,0 +1,115 @@
+"""Debian (dpkg) version comparator.
+
+Implements ``dpkg --compare-versions`` semantics (Debian Policy §5.6.12).
+A version is ``[epoch:]upstream_version[-debian_revision]``:
+
+  - ``epoch``: optional non-negative integer, default 0; compared first,
+    numerically. A higher epoch always wins regardless of the rest.
+  - ``upstream_version`` and ``debian_revision``: each compared with
+    dpkg's ``verrevcmp`` — walk the string in alternating non-digit and
+    digit runs. Digit runs compare numerically (leading zeros ignored,
+    the longer run wins). Non-digit runs compare character by character
+    with a modified order: ``~`` sorts *before* everything including
+    end-of-string (so ``1.0~rc1`` < ``1.0``), letters sort before other
+    punctuation, and otherwise by code point.
+
+Used for OSV/SCA ordering of Debian/apt packages and by harden's
+per-ecosystem version selection (``versions.compare("Debian", ...)``).
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+
+def _split(version: str) -> Tuple[int, str, str]:
+    """Split into ``(epoch, upstream_version, debian_revision)``.
+
+    Epoch is everything before the first ``:`` (must be numeric); the
+    debian revision is everything after the *last* ``-``. Absent epoch
+    defaults to 0; absent revision to ``""`` (which compares equal to
+    ``"0"`` per dpkg).
+    """
+    v = version.strip()
+    epoch = 0
+    if ":" in v:
+        head, _, rest = v.partition(":")
+        if not head.isdigit():
+            raise ValueError(f"invalid Debian epoch in {version!r}")
+        epoch = int(head)
+        v = rest
+    if "-" in v:
+        upstream, _, revision = v.rpartition("-")
+    else:
+        upstream, revision = v, ""
+    return epoch, upstream, revision
+
+
+def _order(c: str) -> int:
+    """Character ordering for dpkg's non-digit comparison.
+
+    ``~`` is below everything (incl. end-of-string, which maps to 0);
+    letters keep their code point; other punctuation sorts *after* all
+    letters; digits are handled by the numeric path (return 0 here).
+    """
+    if c == "" or c.isdigit():
+        return 0
+    if c.isalpha():
+        return ord(c)
+    if c == "~":
+        return -1
+    return ord(c) + 256
+
+
+def _verrevcmp(a: str, b: str) -> int:
+    """dpkg ``verrevcmp`` on a single component (upstream or revision)."""
+    ia, ib = 0, 0
+    la, lb = len(a), len(b)
+    while ia < la or ib < lb:
+        # Non-digit run: advance both in lockstep until either hits a digit.
+        while (ia < la and not a[ia].isdigit()) or (ib < lb and not b[ib].isdigit()):
+            oa = _order(a[ia] if ia < la else "")
+            ob = _order(b[ib] if ib < lb else "")
+            if oa != ob:
+                return -1 if oa < ob else 1
+            ia += 1
+            ib += 1
+        # Strip leading zeros, then compare the digit runs.
+        while ia < la and a[ia] == "0":
+            ia += 1
+        while ib < lb and b[ib] == "0":
+            ib += 1
+        first_diff = 0
+        while ia < la and a[ia].isdigit() and ib < lb and b[ib].isdigit():
+            if first_diff == 0:
+                first_diff = ord(a[ia]) - ord(b[ib])
+            ia += 1
+            ib += 1
+        if ia < la and a[ia].isdigit():     # a's number has more digits
+            return 1
+        if ib < lb and b[ib].isdigit():
+            return -1
+        if first_diff != 0:
+            return -1 if first_diff < 0 else 1
+    return 0
+
+
+def compare(a: str, b: str) -> int:
+    """Return -1, 0, or 1 for ``a < b``, ``a == b``, ``a > b`` per dpkg.
+
+    Raises ``ValueError`` when an epoch is present but non-numeric (the
+    versions dispatcher normalises that to ``VersionError``).
+    """
+    if a == b:
+        return 0
+    ea, ua, ra = _split(a)
+    eb, ub, rb = _split(b)
+    if ea != eb:
+        return -1 if ea < eb else 1
+    c = _verrevcmp(ua, ub)
+    if c != 0:
+        return c
+    return _verrevcmp(ra, rb)
+
+
+__all__ = ["compare"]

--- a/packages/sca/versions/tests/test_debian.py
+++ b/packages/sca/versions/tests/test_debian.py
@@ -1,0 +1,97 @@
+"""Tests for the Debian (dpkg) version comparator.
+
+Cases mirror ``dpkg --compare-versions`` behaviour (Debian Policy
+§5.6.12) and the canonical dpkg test suite: epoch dominance, the ``~``
+ordering quirk, numeric vs lexical runs, leading-zero equality, and
+revision handling. Comparator is also exercised through the
+``versions.compare("Debian", ...)`` dispatcher and ``in_range``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from packages.sca.versions import VersionError, compare, in_range
+from packages.sca.versions.debian import compare as deb_cmp
+
+
+# (a, b, expected sign) — and every pair is also checked for antisymmetry.
+_CASES = [
+    # Plain ordering.
+    ("1.0", "1.0", 0),
+    ("1.0", "2.0", -1),
+    ("2.0", "1.0", 1),
+    ("1.0.0", "1.0", 1),          # extra component sorts higher (non-empty > end)
+    # Numeric runs compare numerically, not lexically.
+    ("1.10", "1.9", 1),
+    ("1.2", "1.10", -1),
+    ("0.99", "1.0", -1),
+    # Leading zeros are ignored within a digit run.
+    ("1.007", "1.7", 0),
+    ("1.0", "1.00", 0),
+    # Epoch dominates everything.
+    ("1:0.1", "2.0", 1),
+    ("2.0", "1:0.1", -1),
+    ("1:1.0", "2:0.1", -1),
+    ("0:1.0", "1.0", 0),          # explicit epoch 0 == no epoch
+    # Debian revision.
+    ("1.0-1", "1.0-2", -1),
+    ("1.0-10", "1.0-9", 1),       # revision compared numerically too
+    ("1.0", "1.0-1", -1),         # no revision (== "0") < revision 1
+    ("1.0-0", "1.0", 0),          # revision "0" == no revision
+    # The ~ quirk: sorts before everything, including end-of-string.
+    ("1.0~rc1", "1.0", -1),
+    ("1.0~rc1", "1.0~rc2", -1),
+    ("1.0~~", "1.0~~a", -1),
+    ("1.0~~a", "1.0~", -1),
+    ("1.0~", "1.0", -1),
+    # Trailing letters sort after end-of-string (letter order > 0).
+    ("1.0a", "1.0", 1),
+    ("1.0a", "1.0b", -1),
+    # Letters sort before non-letter punctuation in a non-digit run.
+    ("1.0a", "1.0+", -1),
+    # Real-world gcc-defaults shape that motivated this (epoch 4, modern
+    # upstream) must outrank the ancient woody source package.
+    ("2.95.2-20", "4:14.2.0-1", -1),
+]
+
+
+@pytest.mark.parametrize("a,b,expected", _CASES)
+def test_compare_cases(a: str, b: str, expected: int) -> None:
+    assert deb_cmp(a, b) == expected
+    # Antisymmetry: reversing the operands negates the sign.
+    assert deb_cmp(b, a) == -expected
+
+
+def test_reflexive_for_distinct_shapes() -> None:
+    for v in ("1.0", "1:2.3-4", "1.0~rc1", "2.95.2-20", "4:14.2.0-1"):
+        assert deb_cmp(v, v) == 0
+
+
+def test_dispatcher_routes_to_debian() -> None:
+    """``versions.compare`` with any Debian alias hits this comparator."""
+    assert compare("Debian", "1.0~rc1", "1.0") == -1
+    assert compare("apt", "1:0.1", "2.0") == 1
+    assert compare("deb", "1.007", "1.7") == 0
+
+
+def test_in_range_via_dispatcher() -> None:
+    """OSV-style range matching dispatches to the Debian comparator."""
+    events = [{"introduced": "1.0"}, {"fixed": "1.0-3"}]
+    assert in_range("Debian", "1.0-1", events) is True
+    assert in_range("Debian", "1.0-3", events) is False     # fixed is exclusive
+    assert in_range("Debian", "1.0~rc1", events) is False   # below introduced
+
+
+def test_invalid_epoch_raises_version_error() -> None:
+    """A non-numeric epoch surfaces as VersionError through the dispatcher."""
+    with pytest.raises(VersionError):
+        compare("Debian", "x:1.0", "1.0")
+
+
+def test_epoch_with_colon_in_upstream() -> None:
+    """Only the first ``:`` is the epoch separator; later colons are upstream."""
+    # epoch 1, upstream "1.2:3" both sides -> equal.
+    assert deb_cmp("1:1.2:3", "1:1.2:3") == 0
+    # Higher epoch still wins regardless of a colon further in.
+    assert deb_cmp("2:0.1:0", "1:9.9:9") == 1


### PR DESCRIPTION
The Debian registry client queried sources.debian.org's SOURCE-package API by BINARY name with no suite filter and no version sort. That mis-resolved every apt dep — gcc -> an ancient standalone source (newest 2.95.2-20, woody ~2002), g++ -> 404, make -> really make-dfsg — and the list mixed experimental/snapshot versions in arbitrary order. harden then auto-pinned that garbage (gcc=2.95.2-20, git=...+next, curl=...+exp1) for every unpinned apt package.

Fix the whole path and make apt pinning correct-and-optional:

  - New dpkg version comparator (packages/sca/versions/debian.py): epoch dominance, the ~-sorts-before-everything rule, leading-zero-insensitive numeric runs, debian-revision handling. Validated against the real `dpkg --compare-versions` (0 mismatches over 100+ pairs). Registered so version_compare("Debian", ...) and OSV in_range work for apt deps.

  - Repoint the registry at the ftp-master madison service (api.ftp-master.debian.org/madison): binary-package-aware (no binary->source mapping needed), active-suites-only, sorted newest-first via the comparator. madison's ?s=<suite> filter resolves codenames (bookworm) server-side, so no drifting codename<->alias table is kept.

  - Attribute each apt dep to the Debian suite of the base image governing its build stage (from the Dockerfile FROM), via source_extra["suite"]; FROM <prev-stage> chains are followed, non-Debian bases resolve to None.

  - harden no longer auto-pins apt by default (status pinning_deferred): an exact apt pin is fragile — Debian keeps only the current version per suite, so the pin breaks once it's superseded (snapshot.debian.org is the robust alternative for reproducible installs). Opt in with --pin-debian, which pins each apt dep to the newest version in its base image's suite (not "newest across all suites" = experimental); a dep with no determinable Debian suite is skipped rather than guessed. The --self-test re-plan threads the flag so apt pins are re-validated.