### PR TITLE
fix(sca): unblock calibration license check + recover large CVE records

### DIFF
--- a/packages/sca/calibration/_license_check.py
+++ b/packages/sca/calibration/_license_check.py
@@ -44,6 +44,14 @@ _FORBIDDEN_FIELDS = frozenset({
 
 _REQUIRED_SOURCE_FIELDS = frozenset({"license", "url"})
 
+# RAPTOR-generated report subtrees under the calibration dir. These
+# are first-party artefacts (refit constant-deltas, validation
+# precision / Spearman metrics) — not third-party sources — so they
+# carry no ``_source`` block and need no per-file attribution. Skip
+# them entirely (cf. ``project_samples``, which DOES carry ``_source``
+# but is attributed by directory rather than per-file).
+_GENERATED_REPORT_SUBTREES = frozenset({"refit", "validation"})
+
 
 def check(corpus_dir: Path, attribution_md: Path) -> List[str]:
     """Return a list of violation strings (empty when corpus is
@@ -64,6 +72,9 @@ def check(corpus_dir: Path, attribution_md: Path) -> List[str]:
     )
     for path in sorted(corpus_dir.rglob("*.json")):
         rel = path.relative_to(corpus_dir)
+        if rel.parts and rel.parts[0] in _GENERATED_REPORT_SUBTREES:
+            # First-party generated report — not an attributed source.
+            continue
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as e:

--- a/packages/sca/calibration/build.py
+++ b/packages/sca/calibration/build.py
@@ -665,10 +665,15 @@ def _is_exploit_host_url(url: str) -> bool:
 # corpus grows — there is no absolute size to re-tune.
 _DECOMP_RATIO = 50
 _DECOMP_FLOOR = 64 * 1024 * 1024
-# A single CVE-JSON-5 record is tens of KB; 8 MB is wildly generous
-# and bounds the in-memory read of any one member so a forged-huge
-# header size can't balloon memory before the stream-level guard fires.
-_PER_RECORD_CAP = 8 * 1024 * 1024
+# Bounds the in-memory read of any single member so a forged-huge
+# header size can't balloon memory before the stream-level guard
+# fires. Most CVE-JSON-5 records are tens of KB, but CISA-ADP
+# enrichment of mega-vendor CVEs is genuinely large — e.g.
+# CVE-2024-20399 (Cisco NX-OS) is ~9.7 MB of affected-product matrix
+# and carries an active-exploitation SSVC signal we must not drop.
+# 64 MB keeps a wide margin over observed records while still bounding
+# a single read; the stream-level ratio cap is the real bomb guard.
+_PER_RECORD_CAP = 64 * 1024 * 1024
 
 
 class _CappedReader:

--- a/packages/sca/data/calibration/ATTRIBUTION.md
+++ b/packages/sca/data/calibration/ATTRIBUTION.md
@@ -94,6 +94,20 @@ attribution requirements for sources where the data license requires it.
 - **What's NEVER stored:** referenced exploit content. Operators
   inspecting the URL can navigate manually.
 
+### `vulnrichment_signals.json` — CISA Vulnrichment (SSVC)
+
+- **License:** CC0 1.0 Universal (Public Domain Dedication)
+- **Source:** <https://github.com/cisagov/vulnrichment>
+- **Tarball:** `https://codeload.github.com/cisagov/vulnrichment/tar.gz/refs/heads/develop`
+  (`develop` is the repo's default branch — CISA does not publish to `main`)
+- **Maintainer:** Cybersecurity and Infrastructure Security Agency (CISA), USA
+- **What's stored:** `{cve_id: {ssvc_exploitation, ssvc_automatable, ssvc_technical_impact}}`
+  for entries whose SSVC `Exploitation` is `poc` or `active`. `none`
+  entries carry no exploit signal and are dropped.
+- **Use:** Cross-ecosystem exploitation signal — covers Cargo / NuGet /
+  Packagist, where the other five sources return ~0%. CC0 — no
+  attribution requirement, cited for transparency.
+
 ### `stress_baseline.json` — SCA stress-test regression baseline
 
 - **License:** MIT (RAPTOR-generated). Per-sample scan diagnostics
@@ -137,10 +151,19 @@ ground-truth signals. These are RAPTOR-generated and ship under
 MIT. Each report cites the snapshot date of every ground-truth
 source consulted, so reviewers can reproduce metrics.
 
+`refit/<date>.json` files (created by `raptor-sca-refit-calibration`)
+carry the per-constant risk-multiplier deltas + joint-precision
+metrics from a refit run. Also RAPTOR-generated, MIT — no third-party
+content.
+
+Both `validation/` and `refit/` are first-party generated reports, so
+they carry no `_source` block and are exempt from the per-file
+attribution check below.
+
 ## Updates
 
 Refreshed weekly by `.github/workflows/refresh-sca-calibration.yml`
-(Monday 06:00 UTC). The workflow opens an auto-PR when sources have
+(Tuesday 06:00 UTC). The workflow opens an auto-PR when sources have
 shifted; reviewers approve before merge.
 
 ## Pre-commit license check
@@ -153,6 +176,9 @@ hook on changes under `packages/sca/data/calibration/`. It enforces:
      `has_*` booleans + `url` references — no `body` / `payload` /
      `shellcode` fields
   3. New sources require an entry here in `ATTRIBUTION.md`
+
+First-party generated report subtrees (`refit/`, `validation/`) are
+exempt — they are RAPTOR outputs, not attributed third-party sources.
 
 Defence in depth against accidental ingestion of license-restricted
 content.


### PR DESCRIPTION
The first green corpus refresh (after the vulnrichment branch fix) exposed two latent issues the earlier build failure had masked:

- The license check reddened on pre-existing files: vulnrichment_signals.json had no ATTRIBUTION.md entry, and the refit/ + validation/ generated reports (no _source block) tripped the per-file attribution rule. Add a vulnrichment section to ATTRIBUTION.md and exempt the first-party report subtrees (cf. project_samples).

- The 8 MB per-member cap dropped CVE-2024-20399 (Cisco NX-OS, ~9.7 MB of CISA-ADP affected-product matrix) — a legitimate active-exploitation signal. Raise the cap to 64 MB; the stream-level ratio cap remains the bomb guard.