### PR TITLE
Standardize SCA bot-PR labels and improve data-fetching logic

### DIFF
--- a/.github/workflows/refit-sca-calibration.yml
+++ b/.github/workflows/refit-sca-calibration.yml
@@ -210,9 +210,13 @@ jobs:
               --base main \
               --head "$BRANCH" \
               --title "chore(sca): refit risk-score multipliers" \
-              --label sca \
-              --label automated \
               --body "$BODY"
           else
             gh pr edit "$BRANCH" --body "$BODY"
           fi
+          # Labels best-effort (see sca-self-bump): a missing label must
+          # never block the PR. Create them once under Settings → Labels.
+          for lbl in automated sca; do
+            gh pr edit "$BRANCH" --add-label "$lbl" 2>/dev/null \
+              || echo "label '$lbl' not in repo; skipping (create it under Settings → Labels to auto-apply)"
+          done

--- a/.github/workflows/refresh-sca-calibration.yml
+++ b/.github/workflows/refresh-sca-calibration.yml
@@ -187,15 +187,20 @@ jobs:
           } > pr-body.md
           # Idempotent create-or-update: ``gh pr create`` exits non-zero
           # when a PR for the branch already exists — fall through to
-          # ``gh pr edit`` to refresh the body. Labels match the sibling
-          # data-refresh workflows so the PR can be filtered / routed.
+          # ``gh pr edit`` to refresh the body. (Labels applied below.)
           if ! gh pr create \
                 --base main \
                 --head "$BRANCH" \
                 --title "chore(sca): refresh calibration corpus" \
-                --label sca \
-                --label data-refresh \
-                --label automated \
                 --body-file pr-body.md 2>/dev/null; then
             gh pr edit "$BRANCH" --body-file pr-body.md
           fi
+          # Labels best-effort (see sca-self-bump): pull-requests:write
+          # applies EXISTING labels but can't create them, and
+          # ``gh pr create --label`` hard-errors on an unknown label
+          # (which killed this step in run #3). Create the canonical
+          # labels once under Settings → Labels to auto-apply them.
+          for lbl in automated sca data-refresh; do
+            gh pr edit "$BRANCH" --add-label "$lbl" 2>/dev/null \
+              || echo "label '$lbl' not in repo; skipping (create it under Settings → Labels to auto-apply)"
+          done

--- a/.github/workflows/refresh-sca-data.yml
+++ b/.github/workflows/refresh-sca-data.yml
@@ -139,9 +139,12 @@ jobs:
                 --base main \
                 --head "$BRANCH" \
                 --title "chore(sca): refresh bundled popular-package lists" \
-                --body "$BODY" \
-                --label sca \
-                --label data-refresh \
-                --label automated 2>/dev/null; then
+                --body "$BODY" 2>/dev/null; then
             gh pr edit "$BRANCH" --body "$BODY"
           fi
+          # Labels best-effort (see sca-self-bump): a missing label must
+          # never block the PR. Create them once under Settings → Labels.
+          for lbl in automated sca data-refresh; do
+            gh pr edit "$BRANCH" --add-label "$lbl" 2>/dev/null \
+              || echo "label '$lbl' not in repo; skipping (create it under Settings → Labels to auto-apply)"
+          done

--- a/.github/workflows/refresh-sca-project-samples.yml
+++ b/.github/workflows/refresh-sca-project-samples.yml
@@ -171,9 +171,12 @@ jobs:
                 --base main \
                 --head "$BRANCH" \
                 --title "chore(sca): refresh calibration project samples" \
-                --body "$BODY" \
-                --label sca \
-                --label data-refresh \
-                --label automated 2>/dev/null; then
+                --body "$BODY" 2>/dev/null; then
             gh pr edit "$BRANCH" --body "$BODY"
           fi
+          # Labels best-effort (see sca-self-bump): a missing label must
+          # never block the PR. Create them once under Settings → Labels.
+          for lbl in automated sca data-refresh; do
+            gh pr edit "$BRANCH" --add-label "$lbl" 2>/dev/null \
+              || echo "label '$lbl' not in repo; skipping (create it under Settings → Labels to auto-apply)"
+          done

--- a/.github/workflows/sca-self-bump.yml
+++ b/.github/workflows/sca-self-bump.yml
@@ -240,7 +240,7 @@ jobs:
           # The token has pull-requests:write, which applies EXISTING
           # labels but can't create new ones, so create any you want
           # auto-applied once under Settings → Labels.
-          for lbl in dependencies sca-self-bump; do
+          for lbl in automated sca dependencies; do
             gh pr edit "$pr_ref" --add-label "$lbl" 2>/dev/null \
               || echo "label '$lbl' not in repo; skipping (create it under Settings → Labels to auto-apply)"
           done

--- a/packages/sca/calibration/build.py
+++ b/packages/sca/calibration/build.py
@@ -165,6 +165,16 @@ def _build_kev(out_dir: Path, http: Any) -> BuildResult:
     )
 
 
+# Exploit-DB index CSV. Fetched by BOTH _build_exploitdb and
+# _build_github_poc (the latter re-parses it for github.com PoC URLs),
+# so it lives here as a single source of truth — a branch/path rename
+# upstream is then a one-line fix, not a fix-one-miss-the-other trap.
+_EDB_CSV_URL = (
+    "https://gitlab.com/exploit-database/exploitdb/-/raw/main/"
+    "files_exploits.csv"
+)
+
+
 def _build_exploitdb(out_dir: Path, http: Any) -> BuildResult:
     """Fetch the Exploit-DB index CSV and emit a CVE-keyed
     boolean-signal file.
@@ -190,11 +200,7 @@ def _build_exploitdb(out_dir: Path, http: Any) -> BuildResult:
     import csv
     import io
 
-    EDB_CSV_URL = (
-        "https://gitlab.com/exploit-database/exploitdb/-/raw/main/"
-        "files_exploits.csv"
-    )
-    raw = http.get_bytes(EDB_CSV_URL, max_bytes=64 * 1024 * 1024)
+    raw = http.get_bytes(_EDB_CSV_URL, max_bytes=64 * 1024 * 1024)
     text = raw.decode("utf-8", errors="replace")
     reader = csv.DictReader(io.StringIO(text))
     cve_to_ids: Dict[str, List[int]] = {}
@@ -226,7 +232,7 @@ def _build_exploitdb(out_dir: Path, http: Any) -> BuildResult:
     output = {
         "_source": {
             "name": "Exploit-DB index",
-            "url": EDB_CSV_URL,
+            "url": _EDB_CSV_URL,
             "license": (
                 "Exploit-DB content is research/personal-use only. "
                 "We embed ONLY boolean signals + entry-ID references "
@@ -342,11 +348,7 @@ def _build_github_poc(out_dir: Path, http: Any) -> BuildResult:
     import csv
     import io
 
-    EDB_CSV_URL = (
-        "https://gitlab.com/exploit-database/exploitdb/-/raw/main/"
-        "files_exploits.csv"
-    )
-    raw = http.get_bytes(EDB_CSV_URL, max_bytes=64 * 1024 * 1024)
+    raw = http.get_bytes(_EDB_CSV_URL, max_bytes=64 * 1024 * 1024)
     text = raw.decode("utf-8", errors="replace")
     reader = csv.DictReader(io.StringIO(text))
     cve_to_urls: Dict[str, List[str]] = {}
@@ -379,7 +381,7 @@ def _build_github_poc(out_dir: Path, http: Any) -> BuildResult:
     output = {
         "_source": {
             "name": "GitHub PoC URLs (derived from Exploit-DB index)",
-            "url": EDB_CSV_URL,
+            "url": _EDB_CSV_URL,
             "license": (
                 "Derived signal: presence + public URL only. "
                 "Source URLs are public observable facts; the "
@@ -435,40 +437,70 @@ def _msf_ref_to_cve(ref: Any) -> Optional[str]:
     return None
 
 
+# EPSS feed (FIRST.org). We page to completeness rather than capping
+# at a single response: ``_EPSS_PAGE_SIZE`` rows per call, following
+# the API's ``offset``/``total`` envelope. ``_EPSS_MAX_PAGES`` is a
+# defensive ceiling so a misbehaving API can't loop forever.
+_EPSS_BASE_URL = "https://api.first.org/data/v1/epss?epss-gt=0.05"
+_EPSS_PAGE_SIZE = 10000
+_EPSS_MAX_PAGES = 100
+
+
 def _build_epss(out_dir: Path, http: Any) -> BuildResult:
     """Fetch the daily EPSS scores CSV and emit a sorted JSON of
     ``{cve_id: {epss, percentile, fetched_date}}``.
 
-    EPSS is FIRST.org's free-for-any-use feed. Bulk daily CSV at
-    epss.cyentia.com / api.first.org. We use the FIRST API for
-    a manageable size (top-N by score) — full bulk is ~30 MB.
+    EPSS is FIRST.org's free-for-any-use feed. We page through the
+    FIRST API for every CVE with EPSS ≥ 0.05, following the
+    ``offset``/``total`` envelope to completeness — a single capped
+    ``limit`` silently dropped the tail once the matching set grew
+    past one page.
     """
-    # FIRST API supports filtering by score threshold. Pull
-    # everything ≥ 0.05 (5% probability) to keep the file
-    # manageable while covering all CVEs that might matter for
-    # calibration.
-    EPSS_URL = "https://api.first.org/data/v1/epss?epss-gt=0.05&limit=10000"
-    data = http.get_json(EPSS_URL)
     signals: Dict[str, Dict[str, Any]] = {}
-    for entry in data.get("data", []):
-        cve = entry.get("cve")
-        if not cve:
-            continue
-        # Reject entries missing epss / percentile entirely — coercing
-        # missing-fields to 0.0 would silently inflate the corpus
-        # with no-data rows that look like "this CVE has 0% EPSS".
-        if entry.get("epss") is None or entry.get("percentile") is None:
-            continue
-        try:
-            score = float(entry["epss"])
-            percentile = float(entry["percentile"])
-        except (TypeError, ValueError):
-            continue
-        signals[cve] = {
-            "epss": score,
-            "percentile": percentile,
-            "as_of": entry.get("date"),
-        }
+    offset = 0
+    total: Optional[int] = None
+    pages = 0
+    while pages < _EPSS_MAX_PAGES:
+        pages += 1
+        url = f"{_EPSS_BASE_URL}&limit={_EPSS_PAGE_SIZE}&offset={offset}"
+        data = http.get_json(url)
+        rows = data.get("data") or []
+        for entry in rows:
+            cve = entry.get("cve")
+            if not cve:
+                continue
+            # Reject entries missing epss / percentile entirely —
+            # coercing missing fields to 0.0 would silently inflate
+            # the corpus with no-data rows that look like "0% EPSS".
+            if entry.get("epss") is None or entry.get("percentile") is None:
+                continue
+            try:
+                score = float(entry["epss"])
+                percentile = float(entry["percentile"])
+            except (TypeError, ValueError):
+                continue
+            signals[cve] = {
+                "epss": score,
+                "percentile": percentile,
+                "as_of": entry.get("date"),
+            }
+        if total is None:
+            total = data.get("total")
+        offset += len(rows)
+        # Last page: a short/empty page, or we've covered the
+        # server-reported total.
+        if len(rows) < _EPSS_PAGE_SIZE:
+            break
+        if total is not None and offset >= total:
+            break
+    else:
+        # Page ceiling hit without a natural stop — surface it rather
+        # than silently truncating the corpus.
+        logger.warning(
+            "sca.calibration: EPSS fetch hit the %d-page ceiling "
+            "(offset=%d, total=%s) — corpus may be truncated",
+            _EPSS_MAX_PAGES, offset, total,
+        )
     output = {
         "_source": {
             "name": "FIRST.org EPSS",

--- a/packages/sca/calibration/tests/test_build.py
+++ b/packages/sca/calibration/tests/test_build.py
@@ -177,7 +177,7 @@ def test_build_kev_idempotent_on_second_run(tmp_path: Path) -> None:
 
 def test_build_epss_writes_signal_file(tmp_path: Path) -> None:
     http = _StubHttp({
-        "https://api.first.org/data/v1/epss?epss-gt=0.05&limit=10000": {
+        "https://api.first.org/data/v1/epss?epss-gt=0.05&limit=10000&offset=0": {
             "data": [
                 {"cve": "CVE-2024-1", "epss": "0.85",
                  "percentile": "0.99", "date": "2024-09-01"},
@@ -195,7 +195,7 @@ def test_build_epss_writes_signal_file(tmp_path: Path) -> None:
 
 def test_build_epss_skips_malformed_scores(tmp_path: Path) -> None:
     http = _StubHttp({
-        "https://api.first.org/data/v1/epss?epss-gt=0.05&limit=10000": {
+        "https://api.first.org/data/v1/epss?epss-gt=0.05&limit=10000&offset=0": {
             "data": [
                 {"cve": "CVE-2024-OK", "epss": "0.5", "percentile": "0.9"},
                 {"cve": "CVE-2024-BAD", "epss": "not-a-number"},
@@ -205,6 +205,33 @@ def test_build_epss_skips_malformed_scores(tmp_path: Path) -> None:
     })
     result = _build_epss(tmp_path, http)
     assert result.record_count == 1
+
+
+def test_build_epss_paginates_to_completeness(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Small page size so two staged pages exercise the offset/total
+    # loop. Only offset=0 and offset=2 are staged — if the loop made a
+    # wasteful third fetch (offset=4) the stub would raise on the
+    # unexpected URL, so a passing test also proves it stops at total.
+    monkeypatch.setattr(build, "_EPSS_PAGE_SIZE", 2)
+    base = "https://api.first.org/data/v1/epss?epss-gt=0.05&limit=2"
+    http = _StubHttp({
+        f"{base}&offset=0": {"total": 4, "data": [
+            {"cve": "CVE-2024-1", "epss": "0.9", "percentile": "0.99"},
+            {"cve": "CVE-2024-2", "epss": "0.8", "percentile": "0.98"},
+        ]},
+        f"{base}&offset=2": {"total": 4, "data": [
+            {"cve": "CVE-2024-3", "epss": "0.7", "percentile": "0.97"},
+            {"cve": "CVE-2024-4", "epss": "0.6", "percentile": "0.96"},
+        ]},
+    })
+    result = _build_epss(tmp_path, http)
+    data = json.loads((tmp_path / "epss_signals.json").read_text())
+    assert set(data["signals"]) == {
+        "CVE-2024-1", "CVE-2024-2", "CVE-2024-3", "CVE-2024-4",
+    }
+    assert result.record_count == 4
 
 
 # ---------------------------------------------------------------------------

--- a/packages/sca/scripts/raptor-sca-build-corpus
+++ b/packages/sca/scripts/raptor-sca-build-corpus
@@ -57,7 +57,8 @@ def main() -> int:
     parser.add_argument(
         "--sources", type=str, default=None,
         help="comma-separated subset of sources to refresh "
-             "(default: all). Available: kev, epss",
+             "(default: all). Available: kev, epss, exploitdb, "
+             "metasploit, github_poc, osv_evidence, vulnrichment",
     )
     parser.add_argument(
         "--offline", action="store_true",


### PR DESCRIPTION
  Follow-ups from the calibration-refresh hardening, after the first
  green run surfaced a label hard-fail and a couple of latent build issues.
  
  ### CI labels (fixes the run #3 PR-step failure)
  `gh pr create --label` hard-errors on a label not defined in the repo,
  which silently killed the calibration refresh PR step. Across all five
  SCA bot-PR workflows, move labels off `create` to best-effort 
  `gh pr edit --add-label` (matching the existing `sca-self-bump` idiom),
  so a missing label can never block a PR again. Converge on a canonical
  4-label set — `automated` / `sca` / `data-refresh` / `dependencies` —
  and drop the bespoke `sca-self-bump` label.
  
  (The 3 new labels must be created once under Settings → Labels — the
  `pull-requests:write` token can apply existing labels but can't create
  them. Until then the workflows just log a skip; no failure.)
  
  ### Corpus-build follow-ups
  - **Dedup** the Exploit-DB CSV URL into one module constant (it was
    duplicated in `_build_exploitdb` and `_build_github_poc`; a branch
    rename is now a one-line fix).
  - **Paginate** the EPSS fetch via the FIRST API `offset`/`total`
    envelope — it was pegged at `limit=10000` and silently dropped the
    tail once the matching set grew past one page.
  - List all 7 sources in the `--sources` help (was "kev, epss").
  
  Verified: 28 calibration build tests pass (incl. a new EPSS pagination
  test); all 5 workflows parse + `bash -n` clean; both diffs apply on
  current `origin/main`.
