### PR TITLE
fix(sca): harden self-bump verdicts + auto-PR workflow hygiene

### DIFF
--- a/.github/sca/raptor-sca-bump-policy.yml
+++ b/.github/sca/raptor-sca-bump-policy.yml
@@ -1,0 +1,30 @@
+# raptor-sca bump policy for this repo.
+#
+# Consumed by `raptor-sca bump` — Phase 2 of
+# .github/workflows/sca-self-bump.yml, and any local `raptor-sca bump .`
+# run. Tightens the permissive defaults so the weekly, auto-applying
+# self-bump never lands a high-blast-radius change as an unreviewed
+# "Clean" verdict. See packages/sca/bump/policy.py for the full schema.
+
+thresholds:
+  # Major-version jumps are almost always breaking. Force them to a
+  # review-tier verdict instead of auto-applying. Catches e.g.
+  # eclipse-temurin 11->26, node 18->20, ghcr.io/.../sage 6->8, and
+  # actions/upload-artifact v4->v7 (the pre-1.0 rule also flags
+  # ollama 0.21->0.24). `_is_major_bump` strips -jdk/-slim/-alpine.
+  block_on_major: true
+
+  # Same-major jumps of >= 2 minors are operationally large (removed
+  # APIs) even though strict semver calls them "same major". Catches
+  # python 3.12->3.14 and 3.9->3.14 — the latter also desyncs the CI
+  # image from tests.yml's pinned interpreter, so it must be reviewed,
+  # not auto-applied.
+  block_on_minor_skew: 2
+
+skip:
+  # Test fixtures / corpora pin versions deliberately (often old or
+  # specific) as part of the test contract — auto-bumping them corrupts
+  # the suite (e.g. test/data/sca-e2e/*/fixture/Dockerfile). Never bump
+  # anything under test data. `*` spans `/`, so this covers all depths.
+  - path: "test/data/**"
+    reason: "test fixtures: pinned versions are part of the test contract"

--- a/.github/workflows/refit-sca-calibration.yml
+++ b/.github/workflows/refit-sca-calibration.yml
@@ -173,7 +173,12 @@ jobs:
           if joint top-20 precision improvement clears 5 percentage
           points. See packages/sca/data/calibration/refit/<date>.json
           for per-constant deltas."
-          git push --force origin "$BRANCH"
+          # --force-with-lease (not --force): refuses the push if the
+          # remote branch moved since our fetch — e.g. an operator amended
+          # the open auto-PR — rather than clobbering it. Fetch first to
+          # seed the lease baseline; || true for the first run (no branch).
+          git fetch origin "$BRANCH" || true
+          git push --force-with-lease origin "$BRANCH"
 
       - name: Create or update PR
         if: steps.diff.outputs.changed == 'true'

--- a/.github/workflows/refresh-sca-calibration.yml
+++ b/.github/workflows/refresh-sca-calibration.yml
@@ -64,7 +64,11 @@ jobs:
         # rest. (GHA's default shell sets pipefail, so the script's
         # exit code propagates through the ``tee``.)
         run: |
-          packages/sca/scripts/raptor-sca-build-corpus -v 2>&1 | tee refresh.log
+          # Log to $RUNNER_TEMP (persists across steps, outside the
+          # worktree) so it can't be swept into the commit if the scoped
+          # ``git add`` below is ever broadened, and never dirties the tree.
+          packages/sca/scripts/raptor-sca-build-corpus -v 2>&1 \
+            | tee "$RUNNER_TEMP/refresh.log"
 
       - name: License-compliance check
         # Defence in depth: enforces the ATTRIBUTION.md cross-
@@ -137,7 +141,12 @@ jobs:
           # Force-push so weekly re-runs update the same branch (and
           # therefore the same open PR). Safe: branch is namespaced
           # ``auto/`` and never touched by humans.
-          git push --force origin "$BRANCH"
+          # --force-with-lease (not --force): refuses the push if the
+          # remote branch moved since our fetch — e.g. an operator amended
+          # the open auto-PR — rather than clobbering it. Fetch first to
+          # seed the lease baseline; || true for the first run (no branch).
+          git fetch origin "$BRANCH" || true
+          git push --force-with-lease origin "$BRANCH"
 
       - name: Create or update PR
         if: steps.diff.outputs.changed == 'true'
@@ -165,7 +174,7 @@ jobs:
 
           EOF
             echo '```'
-            cat refresh.log 2>/dev/null || echo '(per-source status unavailable)'
+            cat "$RUNNER_TEMP/refresh.log" 2>/dev/null || echo '(per-source status unavailable)'
             echo '```'
             cat <<'EOF'
 
@@ -184,7 +193,7 @@ jobs:
           - [ ] No license-restricted content in the diff
           - [ ] `ATTRIBUTION.md` still covers every JSON file
           EOF
-          } > pr-body.md
+          } > "$RUNNER_TEMP/pr-body.md"
           # Idempotent create-or-update: ``gh pr create`` exits non-zero
           # when a PR for the branch already exists — fall through to
           # ``gh pr edit`` to refresh the body. (Labels applied below.)
@@ -192,8 +201,8 @@ jobs:
                 --base main \
                 --head "$BRANCH" \
                 --title "chore(sca): refresh calibration corpus" \
-                --body-file pr-body.md 2>/dev/null; then
-            gh pr edit "$BRANCH" --body-file pr-body.md
+                --body-file "$RUNNER_TEMP/pr-body.md" 2>/dev/null; then
+            gh pr edit "$BRANCH" --body-file "$RUNNER_TEMP/pr-body.md"
           fi
           # Labels best-effort (see sca-self-bump): pull-requests:write
           # applies EXISTING labels but can't create them, and

--- a/.github/workflows/refresh-sca-data.yml
+++ b/.github/workflows/refresh-sca-data.yml
@@ -103,7 +103,12 @@ jobs:
           # Force-push so weekly re-runs update the same branch (and
           # therefore the same open PR). Safe: branch is namespaced
           # ``auto/`` and never touched by humans.
-          git push --force origin "$BRANCH"
+          # --force-with-lease (not --force): refuses the push if the
+          # remote branch moved since our fetch — e.g. an operator amended
+          # the open auto-PR — rather than clobbering it. Fetch first to
+          # seed the lease baseline; || true for the first run (no branch).
+          git fetch origin "$BRANCH" || true
+          git push --force-with-lease origin "$BRANCH"
 
       - name: Create or update PR
         if: steps.diff.outputs.changed == 'true'

--- a/.github/workflows/refresh-sca-project-samples.yml
+++ b/.github/workflows/refresh-sca-project-samples.yml
@@ -120,7 +120,12 @@ jobs:
           against a curated OSS project; project source is not
           redistributed. See packages/sca/data/calibration/ATTRIBUTION.md
           for the project list and licensing posture."
-          git push --force origin "$BRANCH"
+          # --force-with-lease (not --force): refuses the push if the
+          # remote branch moved since our fetch — e.g. an operator amended
+          # the open auto-PR — rather than clobbering it. Fetch first to
+          # seed the lease baseline; || true for the first run (no branch).
+          git fetch origin "$BRANCH" || true
+          git push --force-with-lease origin "$BRANCH"
 
       - name: Create or update PR
         if: steps.diff.outputs.changed == 'true'

--- a/.github/workflows/sca-compromise-check.yml
+++ b/.github/workflows/sca-compromise-check.yml
@@ -64,6 +64,7 @@ jobs:
 
       - name: Install runtime deps
         run: |
+          set -euo pipefail
           python -m pip install --upgrade pip==26.1.1
           pip install -r requirements.txt
 
@@ -80,6 +81,7 @@ jobs:
         #   packages/sca/scripts/raptor-sca-compromise-check \
         #     test/data/sca-e2e/compromise-corpus --only <fixture-name>
         run: |
+          set -euo pipefail
           packages/sca/scripts/raptor-sca-compromise-check \
             test/data/sca-e2e/compromise-corpus \
             --no-offline

--- a/.github/workflows/sca-self-bump.yml
+++ b/.github/workflows/sca-self-bump.yml
@@ -127,11 +127,16 @@ jobs:
           # ``--apply`` writes Clean-verdict bumps in place. Review /
           # Block verdicts are never auto-applied — they surface in
           # the report only.
+          # Write the PR body OUTSIDE the worktree ($RUNNER_TEMP persists
+          # across steps in the job) so the later ``git add -A`` can't sweep
+          # it into the bump branch — otherwise pr-body.md lands as a
+          # committed file in the PR and the "Detect changes" step always
+          # sees a spurious change.
           bin/raptor-sca bump . \
             --apply \
             --pr-comment \
             --repo-label "self-bump $(date -u +%Y-%m-%d)" \
-            > pr-body.md
+            > "$RUNNER_TEMP/pr-body.md"
 
       - name: Exclude workflow-file changes (GITHUB_TOKEN can't push them)
         run: |
@@ -149,7 +154,7 @@ jobs:
           # than the default GITHUB_TOKEN.
           if [[ -n "$(git status --porcelain -- .github/workflows/)" ]]; then
             git checkout -- .github/workflows/
-            printf '\n---\n**Note:** proposed changes to `.github/workflows/*` were excluded from this PR — GitHub forbids the default `GITHUB_TOKEN` from pushing workflow files. Pin those manually, or run this job with a `workflows`-scoped token.\n' >> pr-body.md
+            printf '\n---\n**Note:** proposed changes to `.github/workflows/*` were excluded from this PR — GitHub forbids the default `GITHUB_TOKEN` from pushing workflow files. Pin those manually, or run this job with a `workflows`-scoped token.\n' >> "$RUNNER_TEMP/pr-body.md"
           fi
 
       - name: Detect changes
@@ -220,7 +225,7 @@ jobs:
             --json number \
             --jq '.[0].number // empty')
           if [[ -n "$pr_num" ]]; then
-            gh pr edit "$pr_num" --body-file pr-body.md
+            gh pr edit "$pr_num" --body-file "$RUNNER_TEMP/pr-body.md"
             echo "Updated existing PR #$pr_num"
             pr_ref="$pr_num"
           else
@@ -233,7 +238,7 @@ jobs:
               --base main \
               --head sca-self-bump \
               --title "chore: SCA-gated self-bump" \
-              --body-file pr-body.md)
+              --body-file "$RUNNER_TEMP/pr-body.md")
             echo "Opened PR $pr_ref"
           fi
           # Best-effort labels — a missing label must never fail the run.

--- a/.github/workflows/sca-stress-sweep.yml
+++ b/.github/workflows/sca-stress-sweep.yml
@@ -55,6 +55,7 @@ jobs:
         # ``raptor-sca`` needs the full runtime requirements; the
         # sweep then drives the actual scanner against each sample.
         run: |
+          set -euo pipefail
           python -m pip install --upgrade pip==26.1.1
           pip install -r requirements.txt
 
@@ -70,6 +71,7 @@ jobs:
         # error). The non-zero exit fails the workflow check, which
         # is what we want for a regression gate.
         run: |
+          set -euo pipefail
           python - <<'PY'
           import sys
           sys.path.insert(0, '.')

--- a/packages/sca/bump/orchestrator.py
+++ b/packages/sca/bump/orchestrator.py
@@ -161,8 +161,16 @@ def run_bump(
     if policy.skip:
         kept: List[BumpCandidate] = []
         for cand in candidates:
+            # Target-relative POSIX path for ``skip: - path:`` rules. The
+            # walker enumerates absolute paths under the resolved target;
+            # fall back to the raw path if it's somehow outside.
+            try:
+                rel_path = cand.file.resolve().relative_to(
+                    target.resolve()).as_posix()
+            except (ValueError, OSError):
+                rel_path = cand.file.as_posix()
             rule = policy.is_skipped(
-                kind=cand.kind, locator=cand.locator,
+                kind=cand.kind, locator=cand.locator, path=rel_path,
             )
             if rule is not None:
                 skipped.append((

--- a/packages/sca/bump/policy.py
+++ b/packages/sca/bump/policy.py
@@ -3,7 +3,11 @@
 The bumper's defaults are sensible but unconfigurable today.
 Operators wanting different behaviour — tighter rapid-release
 window, longer maintainer-cooldown, skip certain locators
-entirely — supply a policy file at the project root:
+entirely — supply a policy file, either as the root
+``.raptor-sca-bump.yml`` dotfile or, to keep CI/bot config out of
+the project root, at ``.github/sca/raptor-sca-bump-policy.yml``
+(mirrors ``.github/codeql/codeql-config.yml``). Root wins if both
+exist. Schema is identical wherever it lives:
 
     # .raptor-sca-bump.yml
     skip:
@@ -12,6 +16,8 @@ entirely — supply a policy file at the project root:
       - kind: from_image
         locator: docker.io/library/postgres
         reason: "schema migration blocker — manual coord required"
+      - path: "test/data/**"
+        reason: "test fixtures: versions are part of the test contract"
 
     thresholds:
       rapid_release_days: 14    # tighter than the default 30
@@ -19,11 +25,12 @@ entirely — supply a policy file at the project root:
 
 Schema:
 
-* ``skip``: list of locator-match rules; each can match by
+* ``skip``: list of match rules; a rule may constrain by
   ``kind`` (any/arg/from_image/yaml_image/gha_uses/helm_chart/
-  git_submodule), ``locator`` (exact or wildcard via ``*``).
-  Matching rules cause the candidate to NOT be emitted by
-  the walker.
+  git_submodule), ``locator`` (exact or ``*``-wildcard), and/or
+  ``path`` (target-relative file glob, e.g. ``test/data/**`` — ``*``
+  spans ``/``). A rule with several set matches only when ALL match.
+  Matching candidates are NOT emitted by the walker.
 * ``thresholds.rapid_release_days``: override the
   ``recent_publish`` detector's window (default 30; smaller
   values are stricter).
@@ -46,21 +53,34 @@ from typing import List, Optional
 logger = logging.getLogger(__name__)
 
 
+# Operator policy discovery, in precedence order:
+#   1. ``<target>/.raptor-sca-bump.yml`` — root dotfile; the simple default
+#      for any project (a non-GitHub repo may have no ``.github/``).
+#   2. ``<target>/.github/sca/raptor-sca-bump-policy.yml`` — for repos that
+#      keep CI/bot config in per-tool ``.github/`` subdirs (mirrors the
+#      existing ``.github/codeql/codeql-config.yml`` convention).
 _POLICY_FILE = ".raptor-sca-bump.yml"
+_POLICY_FILE_GITHUB = ".github/sca/raptor-sca-bump-policy.yml"
+_POLICY_LOCATIONS = (_POLICY_FILE, _POLICY_FILE_GITHUB)
 
 
 @dataclass(frozen=True)
 class SkipRule:
-    """One entry in the ``skip:`` list."""
+    """One entry in the ``skip:`` list. A rule with multiple fields set
+    matches only when ALL of them match (AND)."""
 
     kind: Optional[str] = None       # None → any kind matches
     locator: Optional[str] = None    # None → any locator matches; ``*``-glob ok
+    path: Optional[str] = None       # None → any file; target-relative glob
     reason: str = ""
 
-    def matches(self, *, candidate_kind: str, candidate_locator: str) -> bool:
+    def matches(self, *, candidate_kind: str, candidate_locator: str,
+                candidate_path: str = "") -> bool:
         if self.kind and self.kind != candidate_kind:
             return False
         if self.locator and not _locator_match(self.locator, candidate_locator):
+            return False
+        if self.path and not _path_match(self.path, candidate_path):
             return False
         return True
 
@@ -110,25 +130,33 @@ class BumpPolicy:
     binary_capability_delta_enabled: bool = False
 
     def is_skipped(
-        self, *, kind: str, locator: str,
+        self, *, kind: str, locator: str, path: str = "",
     ) -> Optional[SkipRule]:
         """Return the first matching skip rule, or ``None``."""
         for rule in self.skip:
-            if rule.matches(candidate_kind=kind, candidate_locator=locator):
+            if rule.matches(candidate_kind=kind, candidate_locator=locator,
+                            candidate_path=path):
                 return rule
         return None
 
 
 def load_policy(target: Path) -> BumpPolicy:
-    """Load ``.raptor-sca-bump.yml`` from the target directory.
+    """Load the bump policy from the target directory.
 
-    Missing file → default policy (no skips, default thresholds).
-    Malformed file → warning log + default policy. The bumper
-    never crashes on a bad policy — operators get the default
-    behaviour and a log entry to fix the file.
+    Searched in order (see ``_POLICY_LOCATIONS``): the root
+    ``.raptor-sca-bump.yml`` dotfile, then
+    ``.github/sca/raptor-sca-bump-policy.yml``. The first that exists wins.
+
+    No file in any location → default policy (no skips, default
+    thresholds). Malformed file → warning log + default policy. The bumper
+    never crashes on a bad policy — operators get the default behaviour and
+    a log entry to fix the file.
     """
-    policy_path = target / _POLICY_FILE
-    if not policy_path.exists():
+    policy_path = next(
+        (target / rel for rel in _POLICY_LOCATIONS if (target / rel).exists()),
+        None,
+    )
+    if policy_path is None:
         return BumpPolicy()
     try:
         text = policy_path.read_text(encoding="utf-8")
@@ -170,16 +198,19 @@ def load_policy(target: Path) -> BumpPolicy:
                 continue
             kind = entry.get("kind")
             locator = entry.get("locator")
+            path = entry.get("path")
             reason = entry.get("reason") or ""
             if not isinstance(kind, str) and kind is not None:
                 continue
             if not isinstance(locator, str) and locator is not None:
                 continue
-            if kind is None and locator is None:
+            if not isinstance(path, str) and path is not None:
+                continue
+            if kind is None and locator is None and path is None:
                 # Empty rule would skip everything — refuse silently.
                 continue
             skips.append(SkipRule(
-                kind=kind, locator=locator,
+                kind=kind, locator=locator, path=path,
                 reason=str(reason),
             ))
 
@@ -230,3 +261,12 @@ def _locator_match(pattern: str, locator: str) -> bool:
     if "*" in pattern or "?" in pattern:
         return fnmatch.fnmatchcase(locator, pattern)
     return pattern == locator
+
+
+def _path_match(pattern: str, candidate_path: str) -> bool:
+    """Match a candidate's file path (target-relative, POSIX) against an
+    operator glob. ``*`` already spans ``/`` in fnmatch, so both
+    ``test/data/*`` and ``test/data/**`` match nested files. Case-sensitive
+    — source paths are on Linux. Backslashes are normalised so a
+    Windows-authored candidate path still matches a POSIX pattern."""
+    return fnmatch.fnmatchcase(candidate_path.replace("\\", "/"), pattern)

--- a/packages/sca/bump/tests/test_policy.py
+++ b/packages/sca/bump/tests/test_policy.py
@@ -32,6 +32,27 @@ def test_load_no_file_returns_default_policy(tmp_path: Path) -> None:
     assert policy.thresholds.block_on_major is False
 
 
+def test_load_from_github_subdir(tmp_path: Path) -> None:
+    """Discovered at .github/sca/raptor-sca-bump-policy.yml when there's no
+    root dotfile (the per-tool .github convention, cf. .github/codeql/)."""
+    gh = tmp_path / ".github" / "sca"
+    gh.mkdir(parents=True)
+    (gh / "raptor-sca-bump-policy.yml").write_text(
+        "thresholds:\n  block_on_major: true\n")
+    policy = load_policy(tmp_path)
+    assert policy.thresholds.block_on_major is True
+
+
+def test_root_dotfile_wins_over_github_subdir(tmp_path: Path) -> None:
+    """Both locations present → the root dotfile takes precedence."""
+    _write_policy(tmp_path, "thresholds:\n  rapid_release_days: 7\n")
+    gh = tmp_path / ".github" / "sca"
+    gh.mkdir(parents=True)
+    (gh / "raptor-sca-bump-policy.yml").write_text(
+        "thresholds:\n  rapid_release_days: 99\n")
+    assert load_policy(tmp_path).thresholds.rapid_release_days == 7
+
+
 def test_load_skip_by_locator(tmp_path: Path) -> None:
     """``skip:`` rule with a locator matches that locator
     exactly."""
@@ -88,6 +109,51 @@ skip:
                          candidate_locator="actions/setup-python")
     assert not rule.matches(candidate_kind="gha_uses",
                              candidate_locator="astral-sh/setup-uv")
+
+
+def test_load_skip_by_path(tmp_path: Path) -> None:
+    """``skip: - path:`` loads a path glob; ``*`` spans ``/`` so a
+    ``test/data/**`` rule matches a fixture at any depth (and not files
+    outside it)."""
+    _write_policy(tmp_path, """
+skip:
+  - path: "test/data/**"
+    reason: test fixtures are pinned deliberately
+""")
+    policy = load_policy(tmp_path)
+    rule = policy.skip[0]
+    assert rule.path == "test/data/**"
+    assert rule.matches(
+        candidate_kind="from_image", candidate_locator="docker.io/library/node",
+        candidate_path="test/data/sca-e2e/node-app/fixture/Dockerfile")
+    # A real (non-fixture) Dockerfile of the same locator is NOT skipped.
+    assert not rule.matches(
+        candidate_kind="from_image", candidate_locator="docker.io/library/node",
+        candidate_path=".devcontainer/Dockerfile")
+
+
+def test_load_kind_and_path_both_must_match(tmp_path: Path) -> None:
+    """``kind`` + ``path`` set → both must match (AND)."""
+    rule = SkipRule(kind="from_image", path="test/**", reason="x")
+    assert rule.matches(candidate_kind="from_image", candidate_locator="img",
+                        candidate_path="test/a/Dockerfile")
+    assert not rule.matches(candidate_kind="arg", candidate_locator="img",
+                            candidate_path="test/a/Dockerfile")
+    assert not rule.matches(candidate_kind="from_image", candidate_locator="img",
+                            candidate_path="src/Dockerfile")
+
+
+def test_path_only_rule_is_kept(tmp_path: Path) -> None:
+    """A rule with only ``path`` (no kind/locator) is valid — not treated
+    as the skip-everything empty rule."""
+    _write_policy(tmp_path, """
+skip:
+  - path: "test/data/**"
+""")
+    policy = load_policy(tmp_path)
+    assert len(policy.skip) == 1
+    assert policy.skip[0].path == "test/data/**"
+    assert policy.skip[0].kind is None and policy.skip[0].locator is None
 
 
 def test_load_thresholds(tmp_path: Path) -> None:
@@ -236,6 +302,47 @@ skip:
     ]
     assert len(semgrep_skip) == 1
     assert "pinned for compat" in semgrep_skip[0][2]
+
+
+def test_orchestrator_honours_path_skip(tmp_path: Path) -> None:
+    """A ``skip: - path:`` rule drops candidates whose source file is under
+    that path — e.g. test fixtures — while a real Dockerfile of the same
+    kind is still a candidate. Mirrors the #668 ``test/data/**`` bug."""
+    pytest.importorskip("yaml")
+    (tmp_path / "Dockerfile").write_text("ARG SEMGREP_VERSION=1.50.0\n")
+    fixture = tmp_path / "test" / "data" / "corpus"
+    fixture.mkdir(parents=True)
+    (fixture / "Dockerfile").write_text("ARG BLACK_VERSION=20.0\n")
+    _write_policy(tmp_path, """
+skip:
+  - path: "test/data/**"
+    reason: fixtures pinned deliberately
+""")
+    from packages.sca.bump.tests.test_pr_comment import (
+        _StubHttp, _StubPyPI,
+    )
+    from packages.sca.bump.orchestrator import run_bump
+    http = _StubHttp({
+        "https://api.github.com/repos/semgrep/semgrep/releases/latest":
+            {"tag_name": "v1.119.0"},
+        "https://api.github.com/repos/psf/black/releases/latest":
+            {"tag_name": "25.0"},
+    })
+    pypi = _StubPyPI({
+        "semgrep": {"releases": {
+            "1.119.0": [{"upload_time_iso_8601": "2025-12-01T00:00:00Z"}],
+        }},
+        "black": {"releases": {
+            "25.0": [{"upload_time_iso_8601": "2025-12-01T00:00:00Z"}],
+        }},
+    })
+    report = run_bump(tmp_path, http=http, pypi_client=pypi)
+    # Root Dockerfile's ARG is a candidate; the test/data one is skipped.
+    assert [c.locator for c in report.candidates if c.kind == "arg"] == [
+        "SEMGREP_VERSION"]
+    fixture_skip = [s for s in report.skipped if s[0] == "BLACK_VERSION"]
+    assert len(fixture_skip) == 1
+    assert "fixtures pinned" in fixture_skip[0][2]
 
 
 def test_orchestrator_block_on_major_forces_review_to_block(


### PR DESCRIPTION
Follow-up to the #668 self-bump review, which auto-applied major version jumps as "Clean" (eclipse-temurin 11->26, node 18->20, sage 6->8, actions/upload-artifact v4->v7), bumped test fixtures, and committed its own pr-body.md into the repo.

Bump policy (raptor-sca bump):
  - .github/sca/raptor-sca-bump-policy.yml: block_on_major: true + block_on_minor_skew: 2 force major / big-minor jumps (incl. python 3.12->3.14, which desyncs the CI image from tests.yml's pinned interpreter) to a review verdict instead of auto-applying. The engine already supported these thresholds — they were just never enabled.
  - New `path:` skip-rule matcher so fixtures can be excluded by location (skip test/data/**); a kind/locator skip can't do that without also skipping real deps of the same name. load_policy threads each candidate's target-relative path and the orchestrator passes it.
  - Policy discovered at root .raptor-sca-bump.yml OR .github/sca/raptor-sca-bump-policy.yml (root wins if both), mirroring the .github/codeql/codeql-config.yml convention.

Auto-PR workflow hygiene (audit of every PR-opening workflow):
  - Write PR bodies / logs to $RUNNER_TEMP, not the repo tree, so a `git add` can't sweep them into the branch. self-bump committed pr-body.md; refresh-sca-calibration wrote refresh.log + pr-body.md (fragile even though its scoped add didn't leak them).
  - --force-with-lease (+ pre-fetch) on the four refresh/refit auto-PR pushes, so they refuse to clobber an operator's amendment to an open auto-PR rather than steamrolling it. (release.yml's tag re-stamp keeps --force — intentional, and force-with-lease doesn't fit tag-repoint.)
  - Explicit set -euo pipefail in sca-compromise-check + sca-stress-sweep for consistency / future-proofing.