### PR TITLE
harden(sca): fetch all branch-pinned corpus/vuln indexes via HEAD

### DIFF
--- a/core/cve/tests/test_vulnrichment.py
+++ b/core/cve/tests/test_vulnrichment.py
@@ -61,13 +61,13 @@ class TestUrlForCve:
     def test_high_number(self):
         assert _url_for_cve("CVE-2024-12345") == (
             "https://raw.githubusercontent.com/cisagov/vulnrichment/"
-            "develop/2024/12xxx/CVE-2024-12345.json"
+            "HEAD/2024/12xxx/CVE-2024-12345.json"
         )
 
     def test_low_number_uses_0xxx(self):
         assert _url_for_cve("CVE-2024-500") == (
             "https://raw.githubusercontent.com/cisagov/vulnrichment/"
-            "develop/2024/0xxx/CVE-2024-500.json"
+            "HEAD/2024/0xxx/CVE-2024-500.json"
         )
 
     def test_case_insensitive_input(self):
@@ -218,7 +218,7 @@ class TestVulnrichmentClient:
     def test_lookup_hits_canonical_url(self, tmp_path: Path):
         url = (
             "https://raw.githubusercontent.com/cisagov/vulnrichment/"
-            "develop/2024/12xxx/CVE-2024-12345.json"
+            "HEAD/2024/12xxx/CVE-2024-12345.json"
         )
         http = FakeHttp(responses={
             url: _vulnrichment_record(exploitation="active"),
@@ -236,7 +236,7 @@ class TestVulnrichmentClient:
         once."""
         url = (
             "https://raw.githubusercontent.com/cisagov/vulnrichment/"
-            "develop/2024/12xxx/CVE-2024-12345.json"
+            "HEAD/2024/12xxx/CVE-2024-12345.json"
         )
         http = FakeHttp(responses={
             url: _vulnrichment_record(exploitation="poc"),
@@ -258,7 +258,7 @@ class TestVulnrichmentClient:
         without hitting HTTP."""
         url = (
             "https://raw.githubusercontent.com/cisagov/vulnrichment/"
-            "develop/2024/12xxx/CVE-2024-12345.json"
+            "HEAD/2024/12xxx/CVE-2024-12345.json"
         )
         cache = JsonCache(root=tmp_path)
         http_a = FakeHttp(responses={
@@ -283,7 +283,7 @@ class TestVulnrichmentClient:
         lookup within the negative-TTL window doesn't re-probe."""
         url = (
             "https://raw.githubusercontent.com/cisagov/vulnrichment/"
-            "develop/2024/12xxx/CVE-2024-12345.json"
+            "HEAD/2024/12xxx/CVE-2024-12345.json"
         )
         http = FakeHttp(errors={
             url: HttpError("404 Not Found"),
@@ -310,7 +310,7 @@ class TestVulnrichmentClient:
         The next call gets a fresh attempt."""
         url = (
             "https://raw.githubusercontent.com/cisagov/vulnrichment/"
-            "develop/2024/12xxx/CVE-2024-12345.json"
+            "HEAD/2024/12xxx/CVE-2024-12345.json"
         )
         cache = JsonCache(root=tmp_path)
         http_fail = FakeHttp(errors={

--- a/core/cve/vulnrichment.py
+++ b/core/cve/vulnrichment.py
@@ -54,10 +54,11 @@ from core.json import JsonCache
 logger = logging.getLogger(__name__)
 
 
-# ``develop`` is the repo's default branch — CISA does not publish
-# to ``main`` (raw fetches against ``/main/`` 404).
+# ``HEAD`` resolves to the repo's default branch at request time
+# (CISA publishes to ``develop``, not ``main``); raw.githubusercontent
+# honours it, so a future default-branch rename can't 404 us.
 _REPO_RAW_BASE = (
-    "https://raw.githubusercontent.com/cisagov/vulnrichment/develop"
+    "https://raw.githubusercontent.com/cisagov/vulnrichment/HEAD"
 )
 _DEFAULT_TTL = 7 * 24 * 3600   # SSVC drifts slowly; weekly refresh is fine
 _CACHE_KEY_PREFIX = "vulnrichment"

--- a/packages/sca/calibration/build.py
+++ b/packages/sca/calibration/build.py
@@ -167,10 +167,11 @@ def _build_kev(out_dir: Path, http: Any) -> BuildResult:
 
 # Exploit-DB index CSV. Fetched by BOTH _build_exploitdb and
 # _build_github_poc (the latter re-parses it for github.com PoC URLs),
-# so it lives here as a single source of truth — a branch/path rename
-# upstream is then a one-line fix, not a fix-one-miss-the-other trap.
+# so it lives here as a single source of truth. The ``HEAD`` ref
+# resolves to the repo's default branch at request time (GitLab raw
+# honours HEAD), so a branch rename upstream can't 404 us.
 _EDB_CSV_URL = (
-    "https://gitlab.com/exploit-database/exploitdb/-/raw/main/"
+    "https://gitlab.com/exploit-database/exploitdb/-/raw/HEAD/"
     "files_exploits.csv"
 )
 
@@ -270,9 +271,12 @@ def _build_metasploit(out_dir: Path, http: Any) -> BuildResult:
     module path; each module has a ``references`` list with
     ``CVE-...`` entries.
     """
+    # ``HEAD`` resolves to the repo's default branch at request time
+    # (raw.githubusercontent honours it), so a master→main rename
+    # upstream can't 404 this fetch.
     MSF_URL = (
         "https://raw.githubusercontent.com/rapid7/metasploit-framework/"
-        "master/db/modules_metadata_base.json"
+        "HEAD/db/modules_metadata_base.json"
     )
     data = http.get_json(MSF_URL)
     if not isinstance(data, dict):
@@ -766,11 +770,11 @@ def _build_vulnrichment(out_dir: Path, http: Any) -> BuildResult:
     import io
     import tarfile
 
-    # ``develop`` is the repo's default branch — CISA does not
-    # publish to ``main`` (a fetch of ``refs/heads/main`` 404s).
+    # ``HEAD`` resolves to the repo's default branch at request time
+    # (CISA publishes to ``develop``, not ``main``); codeload honours
+    # it, so a future default-branch rename can't 404 this fetch.
     VULNRICHMENT_TARBALL = (
-        "https://codeload.github.com/cisagov/vulnrichment/tar.gz/"
-        "refs/heads/develop"
+        "https://codeload.github.com/cisagov/vulnrichment/tar.gz/HEAD"
     )
     raw = http.get_bytes(
         VULNRICHMENT_TARBALL, max_bytes=300 * 1024 * 1024,

--- a/packages/sca/calibration/tests/test_build.py
+++ b/packages/sca/calibration/tests/test_build.py
@@ -27,8 +27,7 @@ from packages.sca.calibration.build import (
 )
 
 _VULNRICHMENT_URL = (
-    "https://codeload.github.com/cisagov/vulnrichment/tar.gz/"
-    "refs/heads/develop"
+    "https://codeload.github.com/cisagov/vulnrichment/tar.gz/HEAD"
 )
 
 
@@ -335,7 +334,7 @@ _EDB_CSV = (
 
 def test_build_exploitdb_extracts_cve_to_edb_id_mapping(tmp_path: Path) -> None:
     http = _StubHttp({
-        "https://gitlab.com/exploit-database/exploitdb/-/raw/main/"
+        "https://gitlab.com/exploit-database/exploitdb/-/raw/HEAD/"
         "files_exploits.csv": _EDB_CSV,
     })
     result = _build_exploitdb(tmp_path, http)
@@ -357,7 +356,7 @@ def test_build_exploitdb_no_exploit_content_emitted(tmp_path: Path) -> None:
     """The output must NOT contain any of the forbidden field
     names that would indicate exploit content."""
     http = _StubHttp({
-        "https://gitlab.com/exploit-database/exploitdb/-/raw/main/"
+        "https://gitlab.com/exploit-database/exploitdb/-/raw/HEAD/"
         "files_exploits.csv": _EDB_CSV,
     })
     _build_exploitdb(tmp_path, http)
@@ -371,7 +370,7 @@ def test_build_exploitdb_no_exploit_content_emitted(tmp_path: Path) -> None:
 
 def test_build_exploitdb_idempotent(tmp_path: Path) -> None:
     http = _StubHttp({
-        "https://gitlab.com/exploit-database/exploitdb/-/raw/main/"
+        "https://gitlab.com/exploit-database/exploitdb/-/raw/HEAD/"
         "files_exploits.csv": _EDB_CSV,
     })
     r1 = _build_exploitdb(tmp_path, http)
@@ -412,7 +411,7 @@ _MSF_INDEX = {
 def test_build_metasploit_extracts_cve_to_module_mapping(tmp_path: Path) -> None:
     http = _StubHttp({
         "https://raw.githubusercontent.com/rapid7/metasploit-framework/"
-        "master/db/modules_metadata_base.json": _MSF_INDEX,
+        "HEAD/db/modules_metadata_base.json": _MSF_INDEX,
     })
     result = _build_metasploit(tmp_path, http)
     assert result.source == "metasploit"
@@ -438,7 +437,7 @@ def test_build_metasploit_no_module_code_emitted(tmp_path: Path) -> None:
     """Output is paths + booleans only — no module code / payload."""
     http = _StubHttp({
         "https://raw.githubusercontent.com/rapid7/metasploit-framework/"
-        "master/db/modules_metadata_base.json": _MSF_INDEX,
+        "HEAD/db/modules_metadata_base.json": _MSF_INDEX,
     })
     _build_metasploit(tmp_path, http)
     text = (tmp_path / "metasploit_signals.json").read_text().lower()

--- a/packages/sca/data/calibration/ATTRIBUTION.md
+++ b/packages/sca/data/calibration/ATTRIBUTION.md
@@ -32,7 +32,8 @@ attribution requirements for sources where the data license requires it.
   We embed **only** boolean signals + entry-ID references (public
   observable facts that an exploit exists for a given CVE).
 - **Source:** <https://gitlab.com/exploit-database/exploitdb>
-- **Index file:** `files_exploits.csv` from upstream main branch.
+- **Index file:** `files_exploits.csv` from the upstream default
+  branch (fetched via the `HEAD` ref, so a branch rename can't break it).
 - **What's stored:** `{cve_id: {has_exploitdb_entry: true, edb_ids: [N, ...]}}`.
 - **What's NEVER stored:** exploit bodies, payloads, shellcode, or
   any exploit content. The license-compliance check
@@ -48,8 +49,8 @@ attribution requirements for sources where the data license requires it.
   references + booleans is sufficient for calibration without
   vendoring the framework.
 - **Source:** <https://github.com/rapid7/metasploit-framework>
-- **Index file:** `db/modules_metadata_base.json` from upstream
-  master branch.
+- **Index file:** `db/modules_metadata_base.json` from the upstream
+  default branch (fetched via the `HEAD` ref, so a branch rename can't break it).
 - **What's stored:** `{cve_id: {has_msf_module: true, module_paths: ["exploits/...", ...]}}`.
 - **What's NEVER stored:** Metasploit Framework code (modules,
   payloads, evasion, post-exploitation, etc.). Same forbidden-


### PR DESCRIPTION
Every VCS-backed fetch pinned a literal default branch — Exploit-DB's GitLab CSV (main), Metasploit's GitHub raw JSON (master), and vulnrichment's codeload tarball + runtime raw client (develop) — so an upstream default-branch rename would 404 them (the failure that started this arc). Switch them all to the HEAD ref, which raw.githubusercontent, codeload, and GitLab raw each resolve to the repo's current default branch at request time: no extra API call, no rate limit, byte-identical content today, immune to a future rename.

KEV/EPSS/OSV are CMS/API endpoints with no branch ref (HEAD N/A); gha_action_image uses a dynamic <ref> by design; sarif.py's master URL is a $schema identifier (wants a stable pin) — all intentionally left.