### PR TITLE
fix(sca): repair typosquat-list refresh feeds (PyPI move + npm cap/parser)

### DIFF
--- a/packages/sca/refresh_typosquat_lists.py
+++ b/packages/sca/refresh_typosquat_lists.py
@@ -29,10 +29,16 @@ produces an unchanged output file (sorted, stable JSON shape). The
 auto-PR workflow only opens a PR when ``git status`` reports a
 diff after the run.
 
+A transient blip is retried: ``get_json`` parses the body *after* its
+network-retry loop, so a non-JSON 200 (an empty/HTML response from a
+CDN-hosted feed) escapes that retry — ``_get_json`` retries it here.
+
 Failure modes:
-  - Per-ecosystem source down → log warning, leave that file alone.
-  - All sources down → no file changes; the workflow's auto-PR step
-    detects no diff and exits cleanly.
+  - Per-ecosystem source down (after retries) → log warning, leave that
+    file alone, and keep going. Soft: a single source missing one run is
+    tolerated (exit 0) — the auto-PR just omits that ecosystem's update.
+  - All attempted sources down → systemic; exit 1 so the workflow
+    surfaces it.
   - Output target unwritable → log error, exit 1 so the workflow
     surfaces the failure.
 """
@@ -43,10 +49,16 @@ import argparse
 import json
 import logging
 import sys
+import time
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from core.http import HttpClient
+from core.http import (
+    DEFAULT_MAX_BYTES,
+    HttpClient,
+    HttpError,
+    SizeLimitExceeded,
+)
 from core.http.urllib_backend import UrllibClient
 
 logger = logging.getLogger(__name__)
@@ -68,8 +80,19 @@ _DATA_DIR = Path(__file__).resolve().parent / "data"
 # successful return with an empty list means "source returned nothing
 # parseable" and is treated as a soft failure (existing list left alone).
 
+# hugovk's top-pypi-packages moved off github.io: the old hugovk.github.io URL
+# now 301-redirects cross-host to hugovk.dev (the owner-declared homepage), and
+# the egress client won't follow a cross-host redirect. Rather than chase the
+# redirect to a personal domain (which could lapse and be re-registered — a
+# real risk for a feed that SEEDS the typosquat allowlist), fetch the same file
+# straight from the repo via raw.githubusercontent.com: identical content,
+# anchored to the GitHub account `hugovk` rather than a domain registration,
+# and no redirect to follow. Use the ``HEAD`` ref, not a pinned branch — it
+# tracks the default branch (the repo currently carries both main and master),
+# so a future branch rename can't silently break the fetch.
 _HUGOVK_TOP_PYPI = (
-    "https://hugovk.github.io/top-pypi-packages/top-pypi-packages.json"
+    "https://raw.githubusercontent.com/hugovk/top-pypi-packages/HEAD/"
+    "top-pypi-packages.json"
 )
 _ANVAKA_NPM_RANK = (
     "https://anvaka.github.io/npmrank/online/npmrank.json"
@@ -77,9 +100,44 @@ _ANVAKA_NPM_RANK = (
 _CRATES_API = "https://crates.io/api/v1/crates"
 _PACKAGIST_POPULAR = "https://packagist.org/explore/popular.json"
 
+# anvaka's npmrank index is the whole npm dependency graph's rank table —
+# ~85 MB and growing, well over HttpClient's 50 MB DEFAULT_MAX_BYTES. Cap it
+# at 256 MB so the fetch doesn't trip SizeLimitExceeded as the feed grows.
+_NPM_MAX_BYTES = 256 * 1024 * 1024
+
+
+def _get_json(
+    http: HttpClient,
+    url: str,
+    *,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+    attempts: int = 3,
+) -> Any:
+    """``get_json`` with a retry that covers what the client's own retry does
+    not: a **non-JSON 200** (an empty/HTML blip from a CDN-hosted feed). The
+    client parses the body *after* its network-retry loop, so such a blip
+    surfaces as :class:`HttpError` and is never retried — exactly the failure
+    that reddened the weekly cron. We retry it here with a short backoff.
+
+    :class:`SizeLimitExceeded` is re-raised immediately (a too-large response
+    won't shrink on retry — the caller must raise ``max_bytes`` instead).
+    """
+    last: Optional[HttpError] = None
+    for i in range(attempts):
+        try:
+            return http.get_json(url, retries=2, max_bytes=max_bytes)
+        except SizeLimitExceeded:
+            raise
+        except HttpError as e:
+            last = e
+            if i + 1 < attempts:
+                time.sleep(0.5 * (i + 1))
+    assert last is not None
+    raise last
+
 
 def fetch_pypi(http: HttpClient, top_n: int) -> List[str]:
-    data = http.get_json(_HUGOVK_TOP_PYPI, retries=2)
+    data = _get_json(http, _HUGOVK_TOP_PYPI)
     rows = data.get("rows") or data.get("packages") or []
     names: List[str] = []
     for r in rows[:top_n]:
@@ -92,14 +150,25 @@ def fetch_pypi(http: HttpClient, top_n: int) -> List[str]:
 
 
 def fetch_npm(http: HttpClient, top_n: int) -> List[str]:
-    data = http.get_json(_ANVAKA_NPM_RANK, retries=2)
-    # The anvaka npmrank format is a dict: ``{name: rank, ...}`` where
-    # lower rank = more popular. Sort and take the top N.
-    if not isinstance(data, dict):
+    data = _get_json(http, _ANVAKA_NPM_RANK, max_bytes=_NPM_MAX_BYTES)
+    # The anvaka npmrank format is ``{"tags": {...}, "rank": {name: score}}``
+    # where ``score`` is a (stringified) pagerank-style weight over the
+    # dependency graph — HIGHER = more depended-upon = more attack-relevant.
+    # Take the top N by descending score. (The earlier code sorted the
+    # top-level ``{tags, rank}`` dict, which is not the package table.)
+    rank = data.get("rank") if isinstance(data, dict) else None
+    if not isinstance(rank, dict):
         return []
-    ranked = sorted(data.items(), key=lambda kv: kv[1])
-    return sorted({n for n, _ in ranked[:top_n]
-                    if isinstance(n, str) and n})
+    scored: List[Tuple[str, float]] = []
+    for name, score in rank.items():
+        if not (isinstance(name, str) and name):
+            continue
+        try:
+            scored.append((name.lower(), float(score)))
+        except (TypeError, ValueError):
+            continue
+    scored.sort(key=lambda ns: ns[1], reverse=True)
+    return sorted({n for n, _ in scored[:top_n]})
 
 
 def fetch_crates(
@@ -211,10 +280,18 @@ def refresh_all(
             continue
         target = popular_dir / fname
         new_blob = json.dumps(names, indent=2) + "\n"
-        if target.exists() and target.read_text(encoding="utf-8") == new_blob:
-            out[fname] = "unchanged"
+        try:
+            if (target.exists()
+                    and target.read_text(encoding="utf-8") == new_blob):
+                out[fname] = "unchanged"
+                continue
+            target.write_text(new_blob, encoding="utf-8")
+        except OSError as e:
+            # Output target unwritable: a hard failure (see ``main``), kept
+            # distinct from a soft per-source fetch failure above.
+            logger.error("writing %s failed: %s", target, e)
+            out[fname] = f"write-failed: {type(e).__name__}: {e}"
             continue
-        target.write_text(new_blob, encoding="utf-8")
         out[fname] = "updated"
         logger.info("refreshed %s (%d entries)", target, len(names))
     return out
@@ -263,8 +340,29 @@ def main(argv: Optional[List[str]] = None) -> int:
                            data_dir=args.data_dir)
     for fname, status in sorted(results.items()):
         print(f"  {fname:20s}  {status}")
-    failed = [k for k, v in results.items() if v.startswith("failed:")]
-    return 1 if failed else 0
+
+    attempted = {k: v for k, v in results.items() if v != "skipped"}
+    write_failures = [k for k, v in attempted.items()
+                      if v.startswith("write-failed:")]
+    fetch_failures = [k for k, v in attempted.items()
+                      if v.startswith("failed:")]
+    if fetch_failures:
+        logger.warning("%d of %d source(s) left unchanged this run: %s",
+                       len(fetch_failures), len(attempted),
+                       ", ".join(sorted(fetch_failures)))
+
+    # A single source failing to fetch is soft: the cron's auto-PR simply
+    # won't carry that ecosystem's update this run, and the existing bundled
+    # file is left intact (see module docstring). Hard failures — which redden
+    # the run so the workflow surfaces them — are an unwritable output target
+    # or a TOTAL fetch outage (every attempted source down, i.e. systemic).
+    if write_failures:
+        return 1
+    if attempted and len(fetch_failures) == len(attempted):
+        logger.error("all %d attempted source(s) failed to fetch",
+                     len(attempted))
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/packages/sca/tests/test_refresh_typosquat_lists.py
+++ b/packages/sca/tests/test_refresh_typosquat_lists.py
@@ -11,16 +11,21 @@ import json
 from pathlib import Path
 from typing import Any, Dict, List
 
+import pytest
 
+from core.http import HttpError, SizeLimitExceeded
 from packages.sca.refresh_typosquat_lists import (
     _ANVAKA_NPM_RANK,
     _CRATES_API,
     _HUGOVK_TOP_PYPI,
+    _NPM_MAX_BYTES,
     _PACKAGIST_POPULAR,
+    _get_json,
     fetch_crates,
     fetch_npm,
     fetch_packagist,
     fetch_pypi,
+    main,
     refresh_all,
 )
 
@@ -72,8 +77,13 @@ def test_fetch_pypi_top_n_truncates():
 
 
 def test_fetch_npm_anvaka_format():
+    """anvaka npmrank: ``{"tags": {...}, "rank": {name: score}}`` where a
+    HIGHER score = more depended-upon = more popular. Scores arrive as
+    strings; take the top N by descending score."""
     http = _StubHttp({_ANVAKA_NPM_RANK: {
-        "lodash": 1, "react": 2, "express": 3, "obscure": 9999,
+        "tags": {"0": ["ignored", "structural", "key"]},
+        "rank": {"lodash": "9.5", "react": "8.0", "express": "7.0",
+                 "obscure": "0.0001"},
     }})
     out = fetch_npm(http, top_n=3)
     assert set(out) == {"lodash", "react", "express"}
@@ -84,6 +94,20 @@ def test_fetch_npm_handles_non_dict():
     """Server returned a list (corrupt response) → empty result."""
     http = _StubHttp({_ANVAKA_NPM_RANK: ["not", "a", "dict"]})
     assert fetch_npm(http, top_n=10) == []
+
+
+def test_fetch_npm_missing_rank_table():
+    """Only the 'tags' index present (no 'rank' table) → empty, not a crash."""
+    http = _StubHttp({_ANVAKA_NPM_RANK: {"tags": {"0": ["a", "b"]}}})
+    assert fetch_npm(http, top_n=10) == []
+
+
+def test_fetch_npm_skips_non_numeric_scores():
+    """A non-floatable score is skipped, not fatal."""
+    http = _StubHttp({_ANVAKA_NPM_RANK: {"rank": {
+        "good": "5.0", "bad": "not-a-number", "alsogood": "3.0",
+    }}})
+    assert fetch_npm(http, top_n=10) == ["alsogood", "good"]
 
 
 def test_fetch_crates_paginates():
@@ -129,7 +153,7 @@ def test_fetch_packagist_follows_next():
 def test_refresh_all_writes_canonical_files(tmp_path: Path):
     http = _StubHttp({
         _HUGOVK_TOP_PYPI: {"rows": [{"project": "requests"}]},
-        _ANVAKA_NPM_RANK: {"lodash": 1},
+        _ANVAKA_NPM_RANK: {"rank": {"lodash": "9.0"}},
         _CRATES_API: [
             {"crates": [{"name": "serde"}]},
             {"crates": []},   # terminator for the loop
@@ -161,7 +185,7 @@ def test_refresh_all_idempotent_when_unchanged(tmp_path: Path):
             {"rows": [{"project": "requests"}]},
         ],
         _ANVAKA_NPM_RANK: [
-            {"lodash": 1}, {"lodash": 1},
+            {"rank": {"lodash": "9.0"}}, {"rank": {"lodash": "9.0"}},
         ],
         _CRATES_API: [
             {"crates": [{"name": "serde"}]},   # run 1
@@ -207,10 +231,130 @@ def test_refresh_all_empty_response_treated_as_failure(tmp_path: Path):
     the bundled list with [] — that would silently disarm typosquat."""
     http = _StubHttp({
         _HUGOVK_TOP_PYPI: {"rows": []},
-        _ANVAKA_NPM_RANK: {"lodash": 1},
+        _ANVAKA_NPM_RANK: {"rank": {"lodash": "9.0"}},
         _CRATES_API: [{"crates": [{"name": "serde"}]}, {"crates": []}],
         _PACKAGIST_POPULAR: {"packages": [{"name": "m/m"}]},
     })
     results = refresh_all(http, top_n=10, data_dir=tmp_path)
     assert results["PyPI.json"] == "failed: empty result"
     assert not (tmp_path / "popular" / "PyPI.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Transient-failure retry + size cap (_get_json)
+# ---------------------------------------------------------------------------
+
+class _FlakyHttp:
+    """Raises ``exc`` for the first ``fail_times`` calls, then returns ``body``.
+    Records the ``max_bytes`` passed on each call."""
+
+    def __init__(self, body: Any, exc: Exception, fail_times: int) -> None:
+        self.body = body
+        self.exc = exc
+        self.fail_times = fail_times
+        self.calls = 0
+        self.max_bytes_seen: List[Any] = []
+
+    def get_json(self, url: str, *, retries: int = 0,
+                 max_bytes: Any = None, **kw: Any) -> Any:
+        self.calls += 1
+        self.max_bytes_seen.append(max_bytes)
+        if self.calls <= self.fail_times:
+            raise self.exc
+        return self.body
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """Keep the retry backoff from slowing the suite."""
+    monkeypatch.setattr(
+        "packages.sca.refresh_typosquat_lists.time.sleep", lambda *_: None)
+
+
+def test_get_json_retries_transient_non_json():
+    """A non-JSON 200 surfaces as HttpError (parse sits outside the client's
+    own retry loop). ``_get_json`` retries it and eventually succeeds."""
+    http = _FlakyHttp({"ok": 1},
+                      HttpError("Response is not valid JSON: "
+                                "Expecting value: line 1 column 1 (char 0)"),
+                      fail_times=2)
+    assert _get_json(http, "https://example/x", attempts=3) == {"ok": 1}
+    assert http.calls == 3
+
+
+def test_get_json_gives_up_after_attempts():
+    http = _FlakyHttp({"ok": 1}, HttpError("still bad"), fail_times=99)
+    with pytest.raises(HttpError):
+        _get_json(http, "https://example/x", attempts=3)
+    assert http.calls == 3
+
+
+def test_get_json_does_not_retry_size_limit():
+    """A too-large response won't shrink on retry — re-raise immediately so
+    the caller raises ``max_bytes`` instead."""
+    http = _FlakyHttp({"ok": 1}, SizeLimitExceeded("too big"), fail_times=99)
+    with pytest.raises(SizeLimitExceeded):
+        _get_json(http, "https://example/x", attempts=3)
+    assert http.calls == 1
+
+
+def test_fetch_npm_requests_large_cap():
+    """npmrank.json is ~85 MB > the 50 MB default — fetch_npm must lift the
+    cap so the read doesn't trip SizeLimitExceeded."""
+    http = _FlakyHttp({"rank": {"lodash": "9.0"}},
+                      HttpError("unused"), fail_times=0)
+    fetch_npm(http, top_n=5)
+    assert http.max_bytes_seen[0] == _NPM_MAX_BYTES
+
+
+# ---------------------------------------------------------------------------
+# Write-failure status + main() exit semantics
+# ---------------------------------------------------------------------------
+
+def test_refresh_all_write_failure_marked_distinctly(tmp_path, monkeypatch):
+    """An unwritable target is a *hard* failure (distinct ``write-failed:``
+    status), not a soft per-source fetch failure."""
+    http = _StubHttp({_HUGOVK_TOP_PYPI: {"rows": [{"project": "requests"}]}})
+
+    def boom(*a, **k):
+        raise PermissionError("read-only filesystem")
+
+    monkeypatch.setattr(Path, "write_text", boom)
+    results = refresh_all(http, top_n=10, data_dir=tmp_path, only=["PyPI"])
+    assert results["PyPI.json"].startswith("write-failed:")
+
+
+def _main_with_results(monkeypatch, tmp_path, results):
+    monkeypatch.setattr(
+        "packages.sca.refresh_typosquat_lists.refresh_all",
+        lambda *a, **k: results)
+    return main(["--data-dir", str(tmp_path)])
+
+
+def test_main_partial_fetch_failure_is_soft(monkeypatch, tmp_path):
+    """One source down among successes → exit 0 (the cron just omits it)."""
+    rc = _main_with_results(monkeypatch, tmp_path, {
+        "PyPI.json": "updated", "npm.json": "failed: HttpError: blip",
+        "Cargo.json": "unchanged", "Packagist.json": "updated"})
+    assert rc == 0
+
+
+def test_main_total_fetch_outage_is_hard(monkeypatch, tmp_path):
+    rc = _main_with_results(monkeypatch, tmp_path, {
+        "PyPI.json": "failed: x", "npm.json": "failed: y",
+        "Cargo.json": "failed: z", "Packagist.json": "failed: w"})
+    assert rc == 1
+
+
+def test_main_write_failure_is_hard(monkeypatch, tmp_path):
+    rc = _main_with_results(monkeypatch, tmp_path, {
+        "PyPI.json": "updated",
+        "npm.json": "write-failed: PermissionError: read-only"})
+    assert rc == 1
+
+
+def test_main_all_skipped_is_ok(monkeypatch, tmp_path):
+    """``--only`` filtering everything out → nothing attempted → exit 0."""
+    rc = _main_with_results(monkeypatch, tmp_path, {
+        "PyPI.json": "skipped", "npm.json": "skipped"})
+    assert rc == 0


### PR DESCRIPTION
The weekly "Refresh SCA bundled data" cron was failing on two of its four popularity feeds:

- PyPI: hugovk's top-pypi-packages moved off github.io; the old URL now 301-redirects cross-host to hugovk.dev (the owner-declared homepage), which the egress client rightly won't follow, so it parsed the redirect HTML. Fetch the file directly from the repo via raw.githubusercontent.com at the HEAD ref: account-anchored (not a personal domain that could lapse and be re-registered), no redirect, and rename-proof per the #684 pattern.

- npm: anvaka's npmrank index outgrew the client's 50 MB default cap (now ~85 MB), and its format is {"tags":..., "rank": {name: score}} — the old parser sorted the top-level dict, not the package table. Lift the cap to 256 MB and select the top N by descending score (higher = more popular).

Also:
- _get_json retries a non-JSON 200 (a CDN blip the client doesn't retry, since it parses the body after its network-retry loop); SizeLimitExceeded is re-raised, not retried.
- main() treats a single source failing as soft (leave that file alone, exit 0) and reddens the run only on a total fetch outage or an unwritable target, matching the documented failure modes; write failures get a distinct status.

All four feeds verified live end-to-end; 23 unit tests pass.