### PR TITLE
test(sca): pin a deterministic typosquat popular-list in tests

### DIFF
--- a/packages/sca/conftest.py
+++ b/packages/sca/conftest.py
@@ -1,0 +1,55 @@
+"""Shared SCA test fixtures.
+
+Deterministic typosquat popular-list: SCA unit tests must not depend on the
+bundled, weekly-refreshed ``packages/sca/data/popular/<eco>.json`` lists. A
+refresh can grow a list to thousands of real packages — and a name a test
+uses as a *synthetic* typosquat may itself be a real package in the refreshed
+list (``loadash`` genuinely exists on npm). When that happens the detector
+treats it as an exact popular match and the test's distance / "flagged"
+assertions silently break (this took out ~11 tests after a list refresh).
+
+Pinning a small curated list of unambiguous top packages makes every
+typosquat-path test deterministic and immune to future data refreshes. The
+list is intentionally small and free of near-typosquats; names are all ≥4
+chars so single-letter transitive-test deps (``a``/``b``) never collide.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Genuine top packages per ecosystem. Ecosystems absent here resolve to an
+# empty list (matching "unsupported ecosystem → no typosquat findings").
+_CURATED_POPULAR = {
+    "npm": [
+        "lodash", "react", "express", "axios", "chalk", "debug",
+        "commander", "vue", "webpack", "eslint", "typescript", "jest",
+        "next", "request", "moment", "async", "yargs", "bluebird",
+    ],
+    "PyPI": [
+        "requests", "django", "flask", "numpy", "pandas", "boto3",
+        "urllib3", "setuptools", "pytest", "pyyaml", "click", "jinja2",
+        "scipy", "sqlalchemy", "werkzeug",
+    ],
+}
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_typosquat_popular(monkeypatch):
+    from packages.sca.supply_chain import typosquat
+
+    monkeypatch.setattr(
+        typosquat, "_load_popular",
+        lambda eco: list(_CURATED_POPULAR.get(eco, [])),
+    )
+    # The derived caches (set view + length buckets) are built lazily from
+    # _load_popular and memoised per ecosystem; clear them so they re-derive
+    # from the curated list (and again on teardown so anything running after
+    # the SCA suite sees the real bundled data).
+    _caches = (typosquat._POPULAR_BY_ECO, typosquat._POPULAR_SET,
+               typosquat._POPULAR_BY_LEN)
+    for cache in _caches:
+        cache.clear()
+    yield
+    for cache in _caches:
+        cache.clear()


### PR DESCRIPTION
The typosquat unit tests loaded the live, weekly-refreshed packages/sca/data/popular/<eco>.json lists and fed in synthetic typosquat names. After #686 grew npm.json to ~5000 real packages, one synthetic name ('loadash') turned out to be a real published package now in the list — so the detector saw an exact popular match and 11 tests (typosquat plus the review / transitive / orchestrator / tier-a paths that call into it) silently went red on main.

Add an autouse fixture (packages/sca/conftest.py) that swaps a small curated list of genuine top packages into typosquat._load_popular for every SCA test, making the whole typosquat path deterministic and immune to future list refreshes. Names are >=4 chars so single-letter transitive deps never collide; near-typosquats are deliberately excluded.

Fixes the 11 failures and immunizes the sibling typosquat-path tests (slopsquat / sentinel / git_drift / registry_metadata / install_hook). The calibration and risk tests already use self-written tmp_path fixtures with monkeypatched loaders, so they were never exposed to this.