### PR TITLE
feat(understand): mechanical ownership/privilege site enrichment for --map

### DIFF
--- a/.claude/skills/code-understanding/map.md
+++ b/.claude/skills/code-understanding/map.md
@@ -248,6 +248,24 @@ the function *is*) alongside the LLM's narrative (what the function
 this without re-parsing source. Idempotent. Skip if
 `$WORKDIR/checklist.json` doesn't exist or doesn't carry `target_path`.
 
+**[MAP-5d] Enrich with ownership / privilege sites (C/C++)**
+
+After normalisation, run the site enricher. Uses `source_intel` (cocci) to
+attach `ownership_model` (alloc / checked-alloc / paired-free / double-free
+sites) and `privilege_model` (capability-check / LSM-hook sites) sections,
+each entry carrying `kind`, `file`, `line`, and `function`.
+
+```bash
+libexec/raptor-enrich-context-map-sites "$WORKDIR"
+```
+
+These are the *mechanical* halves of those sections — deterministic call
+sites, no LLM. (Semantic analysis — refcount-protocol anomalies, ownership
+transfers, privilege bypass paths — is the LLM's job when you populate the
+narrative.) Skip-silent: no-ops on non-C/C++ targets or when `spatch` isn't
+on PATH, so it only adds a cocci pass where it has something to find.
+Idempotent. Skip if `$WORKDIR/checklist.json` lacks `target_path`.
+
 **[MAP-6] Record Coverage**
 
 After writing `context-map.json`, update the inventory with which functions you examined.

--- a/libexec/raptor-enrich-context-map-sites
+++ b/libexec/raptor-enrich-context-map-sites
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Enrich a context-map.json with mechanically-detected ownership/privilege sites.
+
+Usage: raptor-enrich-context-map-sites <understand_dir>
+
+Runs source_intel (cocci) on the run's target and projects its
+alloc / checked-alloc / paired-free / double-free sites (ownership_model)
+and capability-check / LSM-hook sites (privilege_model) into
+context-map.json via
+``packages.code_understanding.context_map_sites.enrich_context_map_with_sites``.
+
+Idempotent — safe to re-run. Best-effort and skip-silent: source_intel
+returns an empty result (no spatch on PATH, non-C/C++ target, or rules
+missing) rather than raising, so this no-ops cleanly on those targets and
+adds a cocci pass only where C/C++ source is present.
+"""
+import argparse
+import sys
+from pathlib import Path
+
+# ─── trust-marker check (do not import; inline by design) ───
+import os
+if not (os.environ.get("CLAUDECODE")
+        or os.environ.get("_RAPTOR_TRUSTED")):
+    sys.stderr.write(
+        f"{sys.argv[0]}: internal dispatch script.\n"
+        "  Run via 'bin/raptor' instead.\n"
+        "  Tests / power users: set _RAPTOR_TRUSTED=1 to bypass.\n"
+    )
+    sys.exit(2)
+# ─── end trust-marker check ─────────────────────────────────
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.json import load_json, save_json
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="raptor-enrich-context-map-sites",
+        description=(
+            "Enrich context-map.json with source_intel-detected ownership "
+            "(alloc/free/double-free) and privilege (capability/LSM-hook) "
+            "sites. Mechanical, deterministic, best-effort."
+        ),
+    )
+    parser.add_argument("understand_dir", help="path to /understand run dir")
+    args = parser.parse_args()
+
+    understand_dir = Path(args.understand_dir).resolve()
+    if not understand_dir.is_dir():
+        print(
+            f"raptor-enrich-context-map-sites: {understand_dir} is not a "
+            "directory", file=sys.stderr,
+        )
+        return 1
+
+    context_map_path = understand_dir / "context-map.json"
+    if not context_map_path.exists():
+        print(
+            f"raptor-enrich-context-map-sites: {context_map_path} does not "
+            "exist", file=sys.stderr,
+        )
+        return 1
+
+    context_map = load_json(context_map_path)
+    if not isinstance(context_map, dict):
+        print(
+            f"raptor-enrich-context-map-sites: {context_map_path} is not a "
+            "JSON object", file=sys.stderr,
+        )
+        return 1
+
+    checklist = load_json(understand_dir / "checklist.json") or {}
+    target_path = (
+        checklist.get("target_path") if isinstance(checklist, dict) else None
+    )
+    if not target_path:
+        print(
+            "raptor-enrich-context-map-sites: checklist missing target_path; "
+            "skipping enrichment", file=sys.stderr,
+        )
+        return 0
+
+    try:
+        from packages.code_understanding.context_map_sites import (
+            enrich_context_map_with_sites,
+        )
+        from packages.source_intel import analyze
+    except Exception as e:  # noqa: BLE001 — best-effort
+        print(
+            f"raptor-enrich-context-map-sites: substrate unavailable ({e}); "
+            "skipping", file=sys.stderr,
+        )
+        return 0
+
+    # analyze() is skip-silent: spatch-missing / non-C / rules-missing all
+    # return an empty result rather than raising.
+    try:
+        si = analyze(Path(target_path))
+    except Exception as e:  # noqa: BLE001 — never abort the run on this
+        print(
+            f"raptor-enrich-context-map-sites: source_intel analysis "
+            f"skipped ({e})", file=sys.stderr,
+        )
+        return 0
+
+    counts = enrich_context_map_with_sites(
+        context_map, si, repo_root=target_path,
+    )
+    total = counts["ownership_model"] + counts["privilege_model"]
+    if total:
+        save_json(context_map_path, context_map)
+        print(
+            f"raptor-enrich-context-map-sites: enriched "
+            f"{counts['ownership_model']} ownership + "
+            f"{counts['privilege_model']} privilege site(s) in "
+            f"{context_map_path}"
+        )
+    else:
+        reason = getattr(si, "skipped_reason", None)
+        suffix = f" ({reason})" if reason else ""
+        print(
+            "raptor-enrich-context-map-sites: no ownership/privilege sites "
+            f"detected{suffix}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/code_understanding/annotation_synth.py
+++ b/packages/code_understanding/annotation_synth.py
@@ -197,6 +197,74 @@ def _emit_entry_points(
         _write(base_dir, ann, counts, "entry_point")
 
 
+def _emit_site_annotations(
+    cmap: Dict[str, Any],
+    base_dir: Path, checklist: Dict[str, Any], repo_root: Path,
+    counts: SynthCounts,
+) -> None:
+    """Emit ONE annotation per function aggregating its mechanically-detected
+    ownership + privilege sites (from ``context_map_sites``).
+
+    Aggregation is mandatory: annotations key on ``(file, function)`` and a
+    function commonly holds several sites (e.g. alloc + double-free, or
+    ownership *and* a capability check), so a per-site write would clobber
+    down to the last one. Each site already carries its ``function``
+    (source_intel's enclosing function); checklist resolution is a fallback so
+    coverage survives an inventory miss. Source is ``source_intel`` and the
+    substrate's ``respect-manual`` write never clobbers an operator note.
+    """
+    groups: Dict[tuple, Dict[str, Any]] = {}
+    for category, section_key in (
+        ("ownership", "ownership_model"),
+        ("privilege", "privilege_model"),
+    ):
+        for item in _safe_list_of_dicts(cmap, section_key):
+            file_path = item.get("file")
+            line = item.get("line")
+            func_name = item.get("function")
+            func = _resolve(checklist, file_path, line, repo_root)
+            if not func_name and func:
+                func_name = func.get("name")
+            if not file_path or not func_name:
+                counts.skipped_no_function += 1
+                continue
+            g = groups.setdefault(
+                (file_path, func_name),
+                {"categories": set(), "kinds": [], "lines": [], "func": None},
+            )
+            if g["func"] is None and func:
+                g["func"] = func
+            g["categories"].add(category)
+            kind = item.get("kind") or "site"
+            g["kinds"].append(kind)
+            head = f"- {category} site: {kind}"
+            if line:
+                head += f" (line {line})"
+            detail = [head]
+            for k in ("allocator", "free_fn", "name", "grade", "role"):
+                if item.get(k):
+                    detail.append(f"  {k}: {item[k]}")
+            g["lines"].append("\n".join(detail))
+
+    for (file_path, func_name), g in groups.items():
+        body = (
+            "Mechanically-detected sites (source_intel):\n\n"
+            + "\n".join(g["lines"])
+        )
+        metadata = {
+            "source": "source_intel",
+            "status": "source_intel_site",
+            "site_categories": _safe_meta(",".join(sorted(g["categories"]))),
+            "site_kinds": _safe_meta(",".join(sorted(set(g["kinds"])))),
+        }
+        if g["func"]:
+            metadata.update(_hash_metadata(repo_root, file_path, g["func"]))
+        ann = Annotation(
+            file=file_path, function=func_name, body=body, metadata=metadata,
+        )
+        _write(base_dir, ann, counts, "source_intel_site")
+
+
 def _emit_sinks(
     cmap: Dict[str, Any],
     base_dir: Path, checklist: Dict[str, Any], repo_root: Path,
@@ -536,6 +604,7 @@ def synthesise_from_understand_output(
         _emit_sinks(cmap, base_dir, checklist, repo_root, counts)
         _emit_trust_boundaries(cmap, base_dir, checklist, repo_root, counts)
         _emit_unchecked_flows(cmap, base_dir, checklist, repo_root, counts)
+        _emit_site_annotations(cmap, base_dir, checklist, repo_root, counts)
 
     variants_data = _load_json(output_dir / "variants.json")
     if variants_data:

--- a/packages/code_understanding/context_map_sites.py
+++ b/packages/code_understanding/context_map_sites.py
@@ -1,0 +1,150 @@
+"""Substrate-derived ownership / privilege SITE enrichment for context maps.
+
+Mechanical counterpart to the LLM-emitted map sections. ``source_intel``
+already detects, via cocci, the sites these sections care about — allocation /
+checked-allocation / paired-free / double-free (ownership) and
+capability-check / LSM-hook (privilege) — each carrying a source location and
+enclosing function. This projects those deterministically into
+``context-map.json``'s ``ownership_model`` / ``privilege_model`` sections: no
+LLM, idempotent, best-effort.
+
+The LLM populator (``map.md``) later layers the *semantic* analysis on top —
+refcount-protocol anomalies, ownership transfers, privilege bypass paths — the
+parts that genuinely need a model. This module ships the deterministic site
+inventory those analyses (and ``/audit``, annotation synthesis, ``/agentic``)
+build on, with zero LLM-emit reliability risk.
+
+Duck-typed on the ``SourceIntelResult`` (reads its tuple fields via
+``getattr``) so importing this module never pulls source_intel's analysis
+machinery — the producer-side shim hands in an already-computed result.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+
+if TYPE_CHECKING:  # type-only — no runtime dep on packages.source_intel
+    from packages.source_intel import SourceIntelResult
+
+
+def _relativize(path: Optional[str], repo_root: Optional[Path]) -> Optional[str]:
+    """Make a site's file path relative to the run target.
+
+    source_intel emits ABSOLUTE paths; the context-map convention (and the
+    annotation substrate, which rejects absolute ``source_file``) is repo-
+    relative. Best-effort: a path that isn't under ``repo_root`` (or any
+    parse error) is left untouched rather than dropped.
+    """
+    if not path or repo_root is None:
+        return path
+    try:
+        p = Path(path)
+        if p.is_absolute():
+            return str(p.relative_to(repo_root))
+    except (ValueError, TypeError):
+        return path
+    return path
+
+
+def _loc(ev: Any) -> Tuple[Optional[str], Optional[int]]:
+    loc = getattr(ev, "location", None)
+    if isinstance(loc, (tuple, list)) and len(loc) == 2:
+        return loc[0], loc[1]
+    return None, None
+
+
+def _site(kind: str, ev: Any, **extra: Any) -> Dict[str, Any]:
+    file_, line = _loc(ev)
+    site: Dict[str, Any] = {
+        "kind": kind,
+        "file": file_,
+        "line": line,
+        "function": getattr(ev, "enclosing_function", None),
+    }
+    for k, v in extra.items():
+        if v is not None:
+            site[k] = v
+    return site
+
+
+def build_ownership_model(si: "SourceIntelResult") -> List[Dict[str, Any]]:
+    """Alloc / checked-alloc / paired-free / double-free sites, in order."""
+    out: List[Dict[str, Any]] = []
+    for a in getattr(si, "allocations", ()) or ():
+        out.append(_site("alloc", a, allocator=getattr(a, "allocator", None)))
+    for a in getattr(si, "checked_allocations", ()) or ():
+        out.append(_site(
+            "alloc_checked", a, allocator=getattr(a, "allocator", None),
+        ))
+    for p in getattr(si, "paired_frees", ()) or ():
+        out.append(_site(
+            "paired_free", p,
+            allocator=getattr(p, "allocator", None),
+            free_fn=getattr(p, "free_fn", None),
+        ))
+    for d in getattr(si, "double_frees", ()) or ():
+        out.append(_site(
+            "double_free", d,
+            free_fn=getattr(d, "free_fn", None),
+            role=getattr(d, "role", None),
+        ))
+    return out
+
+
+def build_privilege_model(si: "SourceIntelResult") -> List[Dict[str, Any]]:
+    """Capability-check + LSM-hook sites."""
+    out: List[Dict[str, Any]] = []
+    for c in getattr(si, "capabilities", ()) or ():
+        out.append(_site(
+            "capability", c,
+            name=getattr(c, "cap_function", None),
+            grade=getattr(c, "grade", None),
+        ))
+    for h in getattr(si, "lsm_hooks", ()) or ():
+        out.append(_site("lsm_hook", h, name=getattr(h, "hook_name", None)))
+    return out
+
+
+def enrich_context_map_with_sites(
+    cmap: Dict[str, Any], si: "SourceIntelResult",
+    *, repo_root: Optional[Union[str, Path]] = None,
+) -> Dict[str, int]:
+    """Inject ``ownership_model`` / ``privilege_model`` into ``cmap`` from a
+    SourceIntelResult.
+
+    ``repo_root`` (the run target) relativises site file paths to match the
+    context-map convention; pass it whenever the SourceIntelResult carries
+    absolute paths (it always does in production).
+
+    Idempotent — re-running overwrites a prior mechanical pass with fresh
+    data. Best-effort — never raises; a malformed result just yields fewer
+    sites. A section key is written only when it has entries, so an empty
+    section doesn't clutter the map (and doesn't shadow an LLM-populated one
+    with an empty list). Returns per-section site counts.
+
+    NOTE (forward-compat): today the mechanical pass is the *only* producer of
+    these sections, so overwrite-when-non-empty is correct. When the LLM
+    semantic layer (map.md) lands and may populate the same keys, this needs a
+    merge-vs-replace decision — resolve it then, against that layer's design
+    (the intended flow is mechanical-sites-first, LLM-enriches-on-top).
+    """
+    counts = {"ownership_model": 0, "privilege_model": 0}
+    if not isinstance(cmap, dict):
+        return counts
+    root = Path(repo_root) if repo_root is not None else None
+    for key, builder in (
+        ("ownership_model", build_ownership_model),
+        ("privilege_model", build_privilege_model),
+    ):
+        try:
+            sites = builder(si)
+        except Exception:  # noqa: BLE001 — best-effort enrichment
+            sites = []
+        if root is not None:
+            for s in sites:
+                s["file"] = _relativize(s.get("file"), root)
+        if sites:
+            cmap[key] = sites
+            counts[key] = len(sites)
+    return counts

--- a/packages/code_understanding/tests/test_context_map_sites.py
+++ b/packages/code_understanding/tests/test_context_map_sites.py
@@ -1,0 +1,255 @@
+"""Tests for the mechanical ownership/privilege site enrichment
+(``context_map_sites``) and its annotation-synth consumers.
+
+Fully deterministic — no LLM, no cocci. The enricher is driven by a
+duck-typed SourceIntelResult; the consumer path runs the real annotation
+synth driver over a context-map.json carrying the sections.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# packages/code_understanding/tests/test_context_map_sites.py
+#   parents[0]=tests  [1]=code_understanding  [2]=packages  [3]=repo
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from packages.code_understanding.annotation_synth import (  # noqa: E402
+    synthesise_from_understand_output,
+)
+from packages.code_understanding.context_map_sites import (  # noqa: E402
+    enrich_context_map_with_sites,
+)
+
+
+class _Ev:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+class _SI:
+    """Duck-typed stand-in for SourceIntelResult."""
+
+    _FIELDS = (
+        "allocations", "checked_allocations", "paired_frees",
+        "double_frees", "capabilities", "lsm_hooks",
+    )
+
+    def __init__(self, **kw):
+        for f in self._FIELDS:
+            setattr(self, f, tuple(kw.get(f, ())))
+
+
+# --- enricher -------------------------------------------------------------
+
+
+def test_ownership_sites_aggregated_with_kinds_and_fields():
+    si = _SI(
+        allocations=[_Ev(location=("a.c", 10), enclosing_function="f",
+                         allocator="kmalloc")],
+        double_frees=[_Ev(location=("b.c", 20), enclosing_function="g",
+                          free_fn="kfree", role="second")],
+        paired_frees=[_Ev(location=("c.c", 5), enclosing_function="h",
+                          allocator="kzalloc", free_fn="kfree")],
+    )
+    cmap: dict = {}
+    counts = enrich_context_map_with_sites(cmap, si)
+    assert counts["ownership_model"] == 3
+    own = cmap["ownership_model"]
+    assert {e["kind"] for e in own} == {"alloc", "double_free", "paired_free"}
+    alloc = next(e for e in own if e["kind"] == "alloc")
+    assert alloc == {
+        "kind": "alloc", "file": "a.c", "line": 10,
+        "function": "f", "allocator": "kmalloc",
+    }
+    df = next(e for e in own if e["kind"] == "double_free")
+    assert df["free_fn"] == "kfree" and df["role"] == "second"
+
+
+def test_privilege_sites():
+    si = _SI(
+        capabilities=[_Ev(location=("k.c", 1), enclosing_function="sys_x",
+                          cap_function="capable", grade="same_function")],
+        lsm_hooks=[_Ev(location=("k.c", 9), enclosing_function="sys_y",
+                       hook_name="security_file_open")],
+    )
+    cmap: dict = {}
+    counts = enrich_context_map_with_sites(cmap, si)
+    assert counts["privilege_model"] == 2
+    assert {e["kind"] for e in cmap["privilege_model"]} == {
+        "capability", "lsm_hook",
+    }
+    cap = next(e for e in cmap["privilege_model"] if e["kind"] == "capability")
+    assert cap["name"] == "capable" and cap["grade"] == "same_function"
+
+
+def test_empty_result_writes_no_keys():
+    cmap = {"entry_points": []}
+    counts = enrich_context_map_with_sites(cmap, _SI())
+    assert counts == {"ownership_model": 0, "privilege_model": 0}
+    assert "ownership_model" not in cmap and "privilege_model" not in cmap
+
+
+def test_idempotent_overwrite():
+    si = _SI(allocations=[_Ev(location=("a.c", 1), enclosing_function="f",
+                              allocator="kmalloc")])
+    cmap: dict = {}
+    enrich_context_map_with_sites(cmap, si)
+    enrich_context_map_with_sites(cmap, si)
+    assert len(cmap["ownership_model"]) == 1  # overwrite, not append
+
+
+def test_best_effort_on_malformed_evidence():
+    # Missing/!=2-tuple location -> file/line None, no crash.
+    si = _SI(allocations=[_Ev(enclosing_function="f")])
+    cmap: dict = {}
+    counts = enrich_context_map_with_sites(cmap, si)
+    assert counts["ownership_model"] == 1
+    e = cmap["ownership_model"][0]
+    assert e["file"] is None and e["line"] is None
+
+
+def test_non_dict_cmap_is_noop():
+    assert enrich_context_map_with_sites(None, _SI()) == {
+        "ownership_model": 0, "privilege_model": 0,
+    }
+
+
+def test_relativizes_absolute_paths_to_repo_root():
+    # source_intel emits ABSOLUTE paths; the map (and the annotation
+    # substrate) want repo-relative. Regression: real-spatch E2E showed
+    # absolute paths breaking annotation writes.
+    si = _SI(allocations=[_Ev(location=("/repo/src/a.c", 3),
+                              enclosing_function="f", allocator="kmalloc")])
+    cmap: dict = {}
+    enrich_context_map_with_sites(cmap, si, repo_root="/repo")
+    assert cmap["ownership_model"][0]["file"] == "src/a.c"
+
+
+def test_path_outside_repo_root_left_as_is():
+    si = _SI(allocations=[_Ev(location=("/other/a.c", 3),
+                              enclosing_function="f", allocator="kmalloc")])
+    cmap: dict = {}
+    enrich_context_map_with_sites(cmap, si, repo_root="/repo")
+    assert cmap["ownership_model"][0]["file"] == "/other/a.c"
+
+
+def test_degrades_gracefully_without_spatch(monkeypatch):
+    # Force spatch unavailable (the cocci-missing case the operator asked
+    # about). analyze() must RETURN a skipped result, not raise; the
+    # enricher must then no-op (no sections written).
+    import packages.coccinelle.runner as cocci_runner
+    monkeypatch.setattr(cocci_runner, "is_available", lambda: False)
+
+    from packages.source_intel import analyze
+    si = analyze(Path("/any/target"))
+    assert si.skipped_reason == "spatch_not_available"  # returned, didn't raise
+
+    cmap = {"entry_points": []}
+    counts = enrich_context_map_with_sites(cmap, si)
+    assert counts == {"ownership_model": 0, "privilege_model": 0}
+    assert "ownership_model" not in cmap and "privilege_model" not in cmap
+
+
+# --- consumer: annotation synth -------------------------------------------
+
+
+def test_synth_emits_site_annotations(tmp_path):
+    out = tmp_path / "run"
+    out.mkdir()
+    (out / "checklist.json").write_text(
+        json.dumps({"target_path": str(tmp_path / "repo")}),
+        encoding="utf-8",
+    )
+    cmap = {
+        "ownership_model": [
+            {"kind": "alloc", "file": "a.c", "line": 10,
+             "function": "f", "allocator": "kmalloc"},
+        ],
+        "privilege_model": [
+            {"kind": "capability", "file": "k.c", "line": 1,
+             "function": "sys_x", "name": "capable"},
+        ],
+    }
+    (out / "context-map.json").write_text(json.dumps(cmap), encoding="utf-8")
+
+    counts = synthesise_from_understand_output(out)
+
+    assert counts.sources.get("source_intel_site", 0) == 2  # two functions
+    assert counts.emitted == 2
+    # Annotation files mirror the source tree under annotations/.
+    a = (out / "annotations" / "a.c.md").read_text(encoding="utf-8")
+    assert "source_intel_site" in a and "ownership" in a and "kmalloc" in a
+
+
+def test_synth_aggregates_multiple_sites_per_function(tmp_path):
+    # A function with several sites (ownership x2 + privilege) must yield ONE
+    # annotation carrying all of them. Annotations key on (file, function),
+    # so per-site emission would clobber to the last — the exact data-loss the
+    # real-spatch E2E surfaced (3 sites collapsing to 1).
+    out = tmp_path / "run"
+    out.mkdir()
+    (out / "checklist.json").write_text(
+        json.dumps({"target_path": str(tmp_path / "repo")}), encoding="utf-8",
+    )
+    cmap = {
+        "ownership_model": [
+            {"kind": "double_free", "file": "m.c", "line": 9,
+             "function": "do_thing", "free_fn": "kfree", "role": "first"},
+            {"kind": "double_free", "file": "m.c", "line": 10,
+             "function": "do_thing", "free_fn": "kfree", "role": "second"},
+        ],
+        "privilege_model": [
+            {"kind": "capability", "file": "m.c", "line": 7,
+             "function": "do_thing", "name": "capable"},
+        ],
+    }
+    (out / "context-map.json").write_text(json.dumps(cmap), encoding="utf-8")
+
+    counts = synthesise_from_understand_output(out)
+    assert counts.emitted == 1  # ONE annotation for do_thing, not three
+    body = (out / "annotations" / "m.c.md").read_text(encoding="utf-8")
+    assert body.count("site:") == 3  # all three sites survive
+    assert "line 9" in body and "line 10" in body and "line 7" in body
+    assert "site_categories=ownership,privilege" in body
+
+
+# --- producer shim --------------------------------------------------------
+
+_SHIM = REPO / "libexec" / "raptor-enrich-context-map-sites"
+
+
+def test_shim_requires_trust_marker():
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("CLAUDECODE", "_RAPTOR_TRUSTED")}
+    r = subprocess.run([sys.executable, str(_SHIM), "/tmp"],
+                       capture_output=True, text=True, env=env)
+    assert r.returncode == 2
+    assert "internal dispatch script" in r.stderr
+
+
+def test_shim_noop_on_non_c_target(tmp_path):
+    # source_intel.analyze is skip-silent on a non-C/C++ target, so the shim
+    # leaves the map untouched and exits 0 — deterministic, no spatch needed.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "notes.txt").write_text("not source", encoding="utf-8")
+    out = tmp_path / "run"
+    out.mkdir()
+    (out / "checklist.json").write_text(
+        json.dumps({"target_path": str(repo)}), encoding="utf-8",
+    )
+    cmap = {"entry_points": []}
+    (out / "context-map.json").write_text(json.dumps(cmap), encoding="utf-8")
+
+    env = {**os.environ, "_RAPTOR_TRUSTED": "1"}
+    r = subprocess.run([sys.executable, str(_SHIM), str(out)],
+                       capture_output=True, text=True, env=env)
+    assert r.returncode == 0, r.stderr
+    after = json.loads((out / "context-map.json").read_text(encoding="utf-8"))
+    assert "ownership_model" not in after and "privilege_model" not in after


### PR DESCRIPTION
The deterministic half of the /understand --map Phase-B growth, decoupled from the LLM-emit risk. source_intel already detects (via cocci) the sites the ownership_model/privilege_model sections care about; this projects them into context-map.json and on into per-function annotations, with zero LLM.

- packages/code_understanding/context_map_sites.py: enrich_context_map_with_sites builds ownership_model (alloc/checked-alloc/paired-free/double-free) and privilege_model (capability/LSM-hook) from a SourceIntelResult. Duck-typed (no source_intel import), idempotent, best-effort, relativizes paths to the target, writes a section only when non-empty.
- annotation_synth._emit_site_annotations: one aggregated annotation per function (all its ownership+privilege sites; status=source_intel_site, site_categories/site_kinds meta), registered in the synth driver.
- libexec/raptor-enrich-context-map-sites + map.md [MAP-5d]: runs source_intel on the target and populates the sections. Skip-silent (no spatch / non-C -> no-op), so --map only pays a cocci pass where there's C/C++ to analyse.

The LLM populator (map.md) layers the SEMANTIC analysis (refcount-protocol anomalies, ownership transfers, privilege bypass paths) on these sites later. E2E-verified on real spatch (caught + fixed an absolute-path bug and a per-function annotation collision); degrades gracefully without spatch. 17 tests; 364 regression-clean.