### PR TITLE
perf(sca): speed up SCA refresh workflows + harden dep extraction

### DIFF
--- a/.github/workflows/refresh-sca-project-samples.yml
+++ b/.github/workflows/refresh-sca-project-samples.yml
@@ -37,8 +37,10 @@ concurrency:
 jobs:
   collect:
     runs-on: ubuntu-latest
-    # Higher than the daily refreshes — cloning + scanning ten
-    # projects can run 30-60 minutes on a cold cache.
+    # Higher than the daily refreshes — cloning + scanning the corpus is
+    # the heaviest job. The collector now scans projects in parallel
+    # (``--jobs``), which cut a sequential ~20-min run to a few minutes;
+    # the headroom stays for cold caches and corpus growth.
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -65,7 +67,10 @@ jobs:
         # better than no refresh.
         run: |
           set +e
-          packages/sca/scripts/raptor-sca-collect-samples -v
+          # ``--jobs 4`` matches the ubuntu-latest vCPU count. Each project
+          # scans in its own process (full isolation; the egress proxy binds
+          # an ephemeral per-process port) and they share the on-disk cache.
+          packages/sca/scripts/raptor-sca-collect-samples -v --jobs 4
           # Don't propagate the per-sample exit code — partial
           # success still produces a useful diff.
           true

--- a/core/json/jsonc.py
+++ b/core/json/jsonc.py
@@ -1,0 +1,82 @@
+"""Tolerant JSON-with-comments (JSONC) loading.
+
+``devcontainer.json``, ``tsconfig.json`` and friends are JSONC: standard JSON
+plus ``//`` / ``/* */`` comments and trailing commas. A naive regex strip of
+``//`` corrupts string *values* that contain ``//`` — a ``https://`` URL is the
+common casualty, which silently breaks the parse — so the comment stripper here
+is string-aware: it only removes comment markers that sit outside string
+literals.
+
+Sibling, not duplicate: :func:`core.json.load_json_with_comments` is the
+loader for RAPTOR's own *config* files (``models.json``, ``tuning.json``),
+which use the ``//`` + ``#`` dialect. This module targets the standard-JSONC
+dialect (``//`` + ``/* */`` + trailing commas, no ``#``) used by third-party
+data files we parse but don't own. They stay separate because the config
+stripper is line-oriented (can't span a multi-line ``/* */`` block) and ``#``
+is a *value* character in JSONC, not a comment.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, List
+
+
+def strip_jsonc_comments(text: str) -> str:
+    """Remove ``//`` and ``/* */`` comments that are OUTSIDE string literals.
+
+    Walks the text tracking string state (and backslash escapes) so a comment
+    marker inside a quoted value — e.g. the ``//`` in ``"https://..."`` — is
+    left untouched. A regex can't do this safely.
+    """
+    out: List[str] = []
+    i, n = 0, len(text)
+    in_str = False
+    while i < n:
+        c = text[i]
+        if in_str:
+            out.append(c)
+            if c == "\\" and i + 1 < n:        # keep the escaped char verbatim
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if c == '"':
+                in_str = False
+            i += 1
+            continue
+        if c == '"':
+            in_str = True
+            out.append(c)
+            i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            i += 2
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            i += 2
+            while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+_TRAILING_COMMA_RE = re.compile(r",(\s*[}\]])")
+
+
+def load_jsonc(text: str) -> Any:
+    """Parse JSONC ``text``: strip comments (string-aware) and tolerate
+    trailing commas (``{ "a": 1, }``), then ``json.loads``. Raises
+    ``json.JSONDecodeError`` on genuinely malformed input, like ``json.loads``.
+    """
+    cleaned = strip_jsonc_comments(text)
+    cleaned = _TRAILING_COMMA_RE.sub(r"\1", cleaned)
+    return json.loads(cleaned)
+
+
+__all__ = ["strip_jsonc_comments", "load_jsonc"]

--- a/core/json/tests/test_jsonc.py
+++ b/core/json/tests/test_jsonc.py
@@ -1,0 +1,40 @@
+"""Tests for core.json.jsonc — the string-aware JSONC loader."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from core.json.jsonc import load_jsonc, strip_jsonc_comments
+
+
+def test_url_in_string_value_not_mangled():
+    """The bug this exists to prevent: a // inside a string value (a URL)
+    must survive comment stripping."""
+    text = '{\n  // a comment\n  "repo": "https://github.com/o/r"\n}\n'
+    data = load_jsonc(text)
+    assert data == {"repo": "https://github.com/o/r"}
+
+
+def test_block_comment_and_trailing_comma():
+    text = '{\n  /* block\n     comment */\n  "a": 1,\n  "b": [1, 2,],\n}\n'
+    assert load_jsonc(text) == {"a": 1, "b": [1, 2]}
+
+
+def test_comment_markers_inside_strings_preserved():
+    assert strip_jsonc_comments('"a/*b*/c"') == '"a/*b*/c"'
+    assert strip_jsonc_comments('"x // y"') == '"x // y"'
+    # Escaped quote inside a string must not end the string early.
+    assert strip_jsonc_comments('"he said \\"hi//\\" ok"') == \
+        '"he said \\"hi//\\" ok"'
+
+
+def test_plain_json_round_trips():
+    obj = {"k": ["v", 1, True, None]}
+    assert load_jsonc(json.dumps(obj)) == obj
+
+
+def test_malformed_raises_like_json_loads():
+    with pytest.raises(ValueError):   # JSONDecodeError is a ValueError
+        load_jsonc("{not valid")

--- a/packages/sca/calibration/build.py
+++ b/packages/sca/calibration/build.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import json
 import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -53,17 +54,54 @@ class BuildResult:
     record_count: int
 
 
+def _build_one_source(source: str, out_dir: Path, http: Any) -> BuildResult:
+    """Run one source's fetcher, never raising — failures (and unknown
+    sources) come back as a ``BuildResult`` with ``error`` set.
+
+    The dispatch table is built here (not at module level) because the
+    ``_build_*`` functions are defined further down the module.
+    """
+    builders = {
+        "kev": _build_kev,
+        "epss": _build_epss,
+        "exploitdb": _build_exploitdb,
+        "metasploit": _build_metasploit,
+        "github_poc": _build_github_poc,
+        "osv_evidence": _build_osv_evidence,
+        "vulnrichment": _build_vulnrichment,
+    }
+    fn = builders.get(source)
+    if fn is None:
+        return BuildResult(source=source, written=False,
+                           error=f"unknown source {source!r}", record_count=0)
+    try:
+        return fn(out_dir, http)
+    except Exception as e:                              # noqa: BLE001
+        # Defensive: an individual source breaking shouldn't abort the rest.
+        logger.warning("sca.calibration: %s build failed: %s", source, e,
+                       exc_info=True)
+        return BuildResult(source=source, written=False,
+                           error=str(e), record_count=0)
+
+
 def build_corpus(
     *,
     out_dir: Optional[Path] = None,
     http: Optional[Any] = None,
     sources: Optional[List[str]] = None,
+    jobs: int = 0,
 ) -> List[BuildResult]:
     """Refresh the calibration corpus.
 
     ``sources`` filters which fetchers run. Default is all known
     sources. Each source is independent — one failure doesn't abort
-    the rest; the BuildResult list reports per-source status.
+    the rest; the BuildResult list reports per-source status (always in
+    input order, regardless of completion order).
+
+    Sources are fetched in parallel by default (``jobs=0`` → one thread per
+    source, capped): each is an independent bulk download to a distinct host
+    and writes its own file, so they overlap cleanly and share the one
+    keep-alive HTTP pool. ``jobs=1`` forces sequential.
 
     The function never raises on individual source failures —
     captures them in BuildResult.error so the CI workflow can keep
@@ -82,41 +120,22 @@ def build_corpus(
         sources = ["kev", "epss", "exploitdb", "metasploit",
                    "github_poc", "osv_evidence", "vulnrichment"]
 
-    results: List[BuildResult] = []
-    for source in sources:
-        try:
-            if source == "kev":
-                results.append(_build_kev(out_dir, http))
-            elif source == "epss":
-                results.append(_build_epss(out_dir, http))
-            elif source == "exploitdb":
-                results.append(_build_exploitdb(out_dir, http))
-            elif source == "metasploit":
-                results.append(_build_metasploit(out_dir, http))
-            elif source == "github_poc":
-                results.append(_build_github_poc(out_dir, http))
-            elif source == "osv_evidence":
-                results.append(_build_osv_evidence(out_dir, http))
-            elif source == "vulnrichment":
-                results.append(_build_vulnrichment(out_dir, http))
-            else:
-                results.append(BuildResult(
-                    source=source, written=False,
-                    error=f"unknown source {source!r}",
-                    record_count=0,
-                ))
-        except Exception as e:                          # noqa: BLE001
-            # Defensive: an individual source breaking shouldn't
-            # abort the rest. Logged + surfaced in BuildResult.
-            logger.warning(
-                "sca.calibration: %s build failed: %s", source, e,
-                exc_info=True,
-            )
-            results.append(BuildResult(
-                source=source, written=False,
-                error=str(e), record_count=0,
-            ))
-    return results
+    if jobs <= 0:
+        jobs = min(len(sources), 8) or 1
+
+    results: List[Optional[BuildResult]] = [None] * len(sources)
+    if jobs <= 1 or len(sources) <= 1:
+        for i, source in enumerate(sources):
+            results[i] = _build_one_source(source, out_dir, http)
+    else:
+        with ThreadPoolExecutor(max_workers=jobs) as pool:
+            fut_to_idx = {
+                pool.submit(_build_one_source, source, out_dir, http): i
+                for i, source in enumerate(sources)
+            }
+            for fut in as_completed(fut_to_idx):
+                results[fut_to_idx[fut]] = fut.result()
+    return [r for r in results if r is not None]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/sca/calibration/project_samples.py
+++ b/packages/sca/calibration/project_samples.py
@@ -37,8 +37,12 @@ from __future__ import annotations
 
 import json
 import logging
+import multiprocessing as mp
+import os
 import subprocess
+import sys
 import tempfile
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -583,6 +587,9 @@ def collect_project_samples(
     git_clone_timeout: int = 120,
     sca_timeout: int = 300,
     only_licenses: Optional[List[str]] = None,
+    jobs: int = 1,
+    prewarm: bool = True,
+    _mp_start_method: str = "spawn",
 ) -> List[CollectResult]:
     """Clone each sample, run SCA, write findings.
 
@@ -591,6 +598,10 @@ def collect_project_samples(
     processed. Operators concerned about license-touch can pass
     e.g. ``["MIT", "Apache-2.0", "BSD-3-Clause"]`` to skip
     anything else.
+
+    ``jobs`` > 1 scans projects in parallel across a process pool (see
+    :func:`_collect_parallel`); the in-process ``http``/``cache`` args are
+    then ignored (each worker builds its own, sharing the on-disk cache).
 
     Returns one :class:`CollectResult` per attempted sample
     (errored or successful). The function never raises on
@@ -606,6 +617,13 @@ def collect_project_samples(
             if any(lic in s.license_spdx for lic in allowed)
         ]
     out_dir.mkdir(parents=True, exist_ok=True)
+
+    if jobs > 1 and len(samples) > 1:
+        return _collect_parallel(
+            samples, out_dir, jobs=jobs,
+            git_clone_timeout=git_clone_timeout, sca_timeout=sca_timeout,
+            mp_start_method=_mp_start_method, prewarm=prewarm,
+        )
 
     results: List[CollectResult] = []
     for sample in samples:
@@ -626,6 +644,129 @@ def collect_project_samples(
             )
         results.append(result)
     return results
+
+
+def _prewarm_global_feeds() -> None:
+    """Load run-global network feeds into the shared on-disk cache ONCE,
+    before the worker pool fans out. The CISA KEV catalog is a single ~1.5 MB
+    document fetched per process; without a pre-warm, N parallel workers each
+    cold-miss it and re-fetch — a cache stampede that parallelism introduces.
+    One warm fetch here populates the shared JsonCache root that every worker
+    reads. Best-effort: any failure just leaves workers to fetch it themselves
+    (the pre-parallel behaviour), so it never blocks a run.
+
+    (EPSS and Vulnrichment are per-CVE, not a single document, so they can't
+    be pre-warmed this cheaply; the exploit-evidence corpus is a local dir.)
+    """
+    try:
+        from core.cve import KevClient
+        from core.http import default_client
+        from core.json import JsonCache
+
+        from .. import SCA_CACHE_ROOT
+        cache = JsonCache(root=SCA_CACHE_ROOT)
+        # A throwaway lookup forces the catalog load → writes the disk cache.
+        KevClient(default_client(), cache).contains("CVE-1970-0000")
+    except Exception as e:                                  # noqa: BLE001
+        logger.debug("sca.calibration: KEV pre-warm skipped: %s", e)
+
+
+def _collect_parallel(
+    samples: List[ProjectSample],
+    out_dir: Path,
+    *,
+    jobs: int,
+    git_clone_timeout: int,
+    sca_timeout: int,
+    mp_start_method: str,
+    prewarm: bool = True,
+) -> List[CollectResult]:
+    """Run the per-project collect across a process pool.
+
+    Each project is independent (its own temp clone + own output file), so
+    they parallelise cleanly. Workers run in separate processes — full
+    isolation, no thread-safety assumptions about the SCA pipeline, and the
+    CPU-heavy reachability phase actually parallelises. A shared in-process
+    ``http``/``cache`` can't cross the process boundary, so each worker builds
+    its own; they still share the on-disk JsonCache root (concurrent-write
+    safe), which is what dedups advisory/registry lookups across projects.
+
+    Process start method is ``spawn`` in production (a fresh interpreter per
+    worker — the egress proxy binds an ephemeral 127.0.0.1 port per process,
+    so no collision); tests inject ``fork`` so a monkeypatched ``_collect_one``
+    is inherited by workers.
+    """
+    if prewarm:
+        _prewarm_global_feeds()
+    ctx = mp.get_context(mp_start_method)
+    results: List[Optional[CollectResult]] = [None] * len(samples)
+    with ProcessPoolExecutor(max_workers=jobs, mp_context=ctx) as pool:
+        fut_to_idx = {
+            pool.submit(
+                _collect_one_captured,
+                (sample, out_dir, git_clone_timeout, sca_timeout),
+            ): i
+            for i, sample in enumerate(samples)
+        }
+        for fut in as_completed(fut_to_idx):
+            idx = fut_to_idx[fut]
+            sample = samples[idx]
+            try:
+                result, captured = fut.result()
+            except Exception as e:                          # noqa: BLE001
+                # A worker crash (segfault, pickling error, OOM-kill) must
+                # not sink the whole run — record it and keep the rest.
+                result = CollectResult(
+                    project=sample.name, ecosystem=sample.ecosystem,
+                    written=False, error=f"worker crashed: {e}",
+                    finding_count=0,
+                )
+                captured = ""
+            # Flush this project's full output as one contiguous block (in
+            # completion order) so parallel logs stay readable instead of
+            # interleaving line-by-line.
+            if captured:
+                sys.stdout.write(captured)
+                sys.stdout.flush()
+            results[idx] = result
+    # Return in input order (stable summary), independent of completion order.
+    return [r for r in results if r is not None]
+
+
+def _collect_one_captured(
+    args: "tuple[ProjectSample, Path, int, int]",
+) -> "tuple[CollectResult, str]":
+    """Process-pool worker: run ``_collect_one`` with all output (prints,
+    logging, the rich ``sca >`` progress, and subprocess stdio) redirected at
+    the file-descriptor level into a temp file, so the parent can flush it as
+    one readable block. Returns ``(result, captured_text)`` and never raises —
+    failures come back as a ``CollectResult`` with ``error`` set.
+    """
+    sample, out_dir, git_clone_timeout, sca_timeout = args
+    with tempfile.TemporaryFile(mode="w+", prefix="sca-cap-") as cap:
+        old_out, old_err = os.dup(1), os.dup(2)
+        os.dup2(cap.fileno(), 1)
+        os.dup2(cap.fileno(), 2)
+        try:
+            result = _collect_one(
+                sample, out_dir, http=None, cache=None,
+                git_clone_timeout=git_clone_timeout, sca_timeout=sca_timeout,
+            )
+        except Exception as e:                              # noqa: BLE001
+            result = CollectResult(
+                project=sample.name, ecosystem=sample.ecosystem,
+                written=False, error=str(e), finding_count=0,
+            )
+        finally:
+            sys.stdout.flush()
+            sys.stderr.flush()
+            os.dup2(old_out, 1)
+            os.dup2(old_err, 2)
+            os.close(old_out)
+            os.close(old_err)
+        cap.seek(0)
+        captured = cap.read()
+    return result, captured
 
 
 def _collect_one(

--- a/packages/sca/calibration/tests/test_build.py
+++ b/packages/sca/calibration/tests/test_build.py
@@ -285,6 +285,27 @@ def test_build_corpus_one_source_failing_doesnt_abort_others(
     assert (tmp_path / "epss_signals.json").exists()
 
 
+def test_build_corpus_parallel_preserves_input_order(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """With jobs>1 the sources run on a thread pool; results must still come
+    back in INPUT order (not completion order), and all sources must run."""
+    import packages.sca.calibration.build as build
+
+    def _fake(source, out_dir, http):
+        return build.BuildResult(
+            source=source, written=True, error=None, record_count=1,
+        )
+
+    monkeypatch.setattr(build, "_build_one_source", _fake)
+    sources = ["kev", "epss", "exploitdb", "metasploit", "github_poc"]
+    results = build.build_corpus(
+        out_dir=tmp_path, http=object(), sources=sources, jobs=4,
+    )
+    assert [r.source for r in results] == sources
+    assert all(r.written for r in results)
+
+
 # ---------------------------------------------------------------------------
 # Diff-friendliness
 # ---------------------------------------------------------------------------

--- a/packages/sca/calibration/tests/test_project_samples.py
+++ b/packages/sca/calibration/tests/test_project_samples.py
@@ -183,6 +183,58 @@ def test_one_sample_failing_doesnt_abort_others(tmp_path: Path):
     assert "simulated clone failure" in by_name["bad"].error
 
 
+def test_parallel_collects_all_samples_input_order(tmp_path: Path):
+    """jobs>1 runs projects across a process pool and returns one result
+    per sample in INPUT order (not completion order), with per-project
+    failures isolated. Uses the ``fork`` start method so the patched
+    ``_collect_one`` is inherited by the worker processes."""
+    samples = [
+        ProjectSample(name=f"p{i}", ecosystem="PyPI",
+                       repo_url=f"https://p{i}/", git_ref="v1",
+                       license_spdx="MIT")
+        for i in range(5)
+    ]
+
+    def _fake(s, *args, **kw):
+        # Emit to stdout so the worker's fd-level capture is exercised.
+        print(f"scanning {s.name}")
+        if s.name == "p3":
+            raise RuntimeError("boom p3")
+        return CollectResult(
+            project=s.name, ecosystem=s.ecosystem,
+            written=True, error=None, finding_count=len(s.name),
+        )
+
+    with patch(
+        "packages.sca.calibration.project_samples._collect_one",
+        side_effect=_fake,
+    ):
+        results = collect_project_samples(
+            out_dir=tmp_path, samples=samples,
+            jobs=3, prewarm=False, _mp_start_method="fork",
+        )
+
+    assert [r.project for r in results] == [f"p{i}" for i in range(5)]
+    by = {r.project: r for r in results}
+    assert by["p0"].written is True
+    assert by["p3"].error is not None and "boom p3" in by["p3"].error
+    # The four non-failing projects all produced a result.
+    assert sum(1 for r in results if r.written) == 4
+
+
+def test_prewarm_global_feeds_is_best_effort(monkeypatch):
+    """The KEV pre-warm must never raise — a fetch/import failure just
+    leaves workers to load the catalog themselves."""
+    from packages.sca.calibration import project_samples as ps
+
+    def _boom():
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr("core.http.default_client", _boom)
+    # Should swallow the error, not propagate.
+    ps._prewarm_global_feeds()
+
+
 def test_default_samples_all_have_licenses():
     """The curated list ships with declared licenses — sanity-
     check the data file."""

--- a/packages/sca/parsers/gemfile.py
+++ b/packages/sca/parsers/gemfile.py
@@ -159,6 +159,13 @@ def parse_lockfile(path: Path) -> List[Dependency]:
             continue
         name = m.group(1)
         version = m.group(2).strip()
+        # A Bundler-resolved version always starts with a digit (optionally
+        # with a ``-platform`` suffix). Anything else is a malformed /
+        # non-standard ``specs:`` row (templated lockfile, source annotation
+        # mis-captured) — skip it rather than emit a phantom gem that 404s
+        # on every registry lookup.
+        if not (version and version[0].isdigit()):
+            continue
         # ``<version>-<platform>`` forms (e.g. ``1.0.0-x86_64-linux``)
         # — keep the version as-is; OSV matches per-platform.
         dep = Dependency(
@@ -247,6 +254,13 @@ def _parse_version_specs(rest: str) -> Tuple[PinStyle, Optional[str]]:
     m = matches[0]
     op = m.group("op") or "="
     ver = m.group("ver")
+    # A RubyGems version always starts with a digit. A hand-written Gemfile
+    # can quote a non-literal where a version goes (e.g. a constant such as
+    # ``gem 'ibm_db', IBM_DB`` lexed loosely), which would otherwise be
+    # emitted as version "IBM_DB" and 404 on every registry lookup. Reject
+    # anything that isn't version-shaped — treat the gem as unpinned.
+    if not (ver and ver[0].isdigit()):
+        return PinStyle.WILDCARD, None
     if op in ("=",):
         return PinStyle.EXACT, ver
     if op == "~>":

--- a/packages/sca/parsers/inline_installs/__init__.py
+++ b/packages/sca/parsers/inline_installs/__init__.py
@@ -61,11 +61,12 @@ report can show where each dep came from.
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 from pathlib import Path
 from typing import List, Optional, Tuple
+
+from core.json.jsonc import load_jsonc
 
 from ...models import Confidence, Dependency, PinStyle
 from .. import register
@@ -155,6 +156,12 @@ def _collapse_continuations(text: str) -> List[Tuple[int, str, bool]]:
     return out
 
 
+# GitHub Actions template expressions: ``${{ matrix.x }}``, ``${{ env.Y }}``,
+# ``${{ secrets.Z }}``. Never literal install targets — stripped before
+# tokenising so they don't surface as phantom packages.
+_GHA_EXPR_RE = re.compile(r"\$\{\{.*?\}\}")
+
+
 def _scan_shell_lines(
     lines: List[Tuple[int, str, bool]],
     declared_in: Path,
@@ -177,6 +184,12 @@ def _scan_shell_lines(
     deps: List[Dependency] = []
     for line_no, body, commented in lines:
         cleaned = _strip_inline_comment(body)
+        # Drop GHA template expressions before tokenising. A workflow line
+        # like ``run: npm i ${{ matrix.npm-i }}`` would otherwise yield a
+        # bogus package "matrix.npm-i" (dots/dashes are legal npm chars) that
+        # 404s — the expression is a placeholder, never a literal install
+        # target. Harmless on non-GHA sources (the syntax doesn't occur).
+        cleaned = _GHA_EXPR_RE.sub(" ", cleaned)
         for sub in _split_compound(cleaned):
             best: Optional[Tuple[_PkgManager, "re.Match[str]"]] = None
             for mgr in _MANAGERS:
@@ -743,12 +756,12 @@ def _safe_read(path: Path) -> Optional[str]:
 
 
 def _load_jsonc(text: str) -> dict:
-    """Tolerant JSON-with-comments loader (devcontainer.json convention)."""
-    cleaned = re.sub(r"//[^\n]*", "", text)
-    cleaned = re.sub(r"/\*.*?\*/", "", cleaned, flags=re.DOTALL)
-    # Tolerate trailing commas: ``{ "a": 1, }``.
-    cleaned = re.sub(r",(\s*[}\]])", r"\1", cleaned)
-    return json.loads(cleaned)
+    """Tolerant JSON-with-comments loader (devcontainer.json convention).
+
+    Delegates to the shared string-aware loader so the ``//``-inside-a-URL
+    bug is fixed in exactly one place (see :mod:`core.json.jsonc`).
+    """
+    return load_jsonc(text)
 
 
 def _flatten_command(val) -> List[str]:

--- a/packages/sca/parsers/inline_installs/tests/test_inline_guards.py
+++ b/packages/sca/parsers/inline_installs/tests/test_inline_guards.py
@@ -1,0 +1,53 @@
+"""Guards for inline-install extraction surfaced by the calibration run:
+
+  * GHA ``${{ ... }}`` template expressions must not become phantom
+    packages (``npm i ${{ matrix.npm-i }}`` produced a bogus
+    "matrix.npm-i" dep that 404'd).
+  * devcontainer.json is JSONC; the comment stripper must not eat ``//``
+    inside string values (a ``https://`` URL would corrupt the JSON and
+    the whole file failed to parse).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from packages.sca.parsers.inline_installs import (
+    parse_devcontainer_json,
+    parse_gha_workflow,
+)
+
+
+def test_gha_expression_not_emitted_as_package(tmp_path: Path) -> None:
+    wf = tmp_path / "ci.yml"
+    wf.write_text(
+        "jobs:\n"
+        "  build:\n"
+        "    steps:\n"
+        "      - run: npm i ${{ matrix.npm-i }} lodash@4.17.21\n",
+        encoding="utf-8",
+    )
+    deps = parse_gha_workflow(wf)
+    names = {d.name for d in deps}
+    # The real package is extracted...
+    assert "lodash" in names
+    # ...but the GHA template expression is not a phantom package.
+    assert not any("matrix" in n for n in names)
+
+
+def test_devcontainer_jsonc_url_not_mangled(tmp_path: Path) -> None:
+    dc = tmp_path / "devcontainer.json"
+    dc.write_text(
+        "{\n"
+        "  // base devcontainer\n"
+        '  "image": "ubuntu:22.04",\n'
+        '  "postCreateCommand": "pip install requests==2.31.0",\n'
+        '  "metadata": {"repo": "https://github.com/owner/repo"},\n'
+        "}\n",
+        encoding="utf-8",
+    )
+    # Old stripper ate the ``//`` in the URL → JSONDecodeError → no deps.
+    deps = parse_devcontainer_json(dc)
+    by = {d.name: d for d in deps}
+    assert "requests" in by
+    assert by["requests"].version == "2.31.0"

--- a/packages/sca/parsers/tests/test_gemfile.py
+++ b/packages/sca/parsers/tests/test_gemfile.py
@@ -64,6 +64,37 @@ def test_git_dependency(tmp_path: Path) -> None:
     assert deps[0].pin_style is PinStyle.GIT
 
 
+def test_non_version_shaped_spec_treated_as_unpinned(tmp_path: Path) -> None:
+    """A quoted non-version where a version goes (a constant lexed loosely)
+    must not become the version — it would 404 on every registry lookup.
+    Gem versions start with a digit; anything else → unpinned."""
+    body = """gem 'ibm_db', 'IBM_DB'\n"""
+    p = _write(tmp_path, body, "Gemfile")
+    deps = parse_manifest(p)
+    assert deps[0].name == "ibm_db"
+    assert deps[0].version is None
+    assert deps[0].pin_style is PinStyle.WILDCARD
+
+
+def test_lockfile_skips_non_version_shaped_rows(tmp_path: Path) -> None:
+    """A malformed ``specs:`` row whose version isn't digit-led is skipped,
+    not emitted as a phantom gem. Real (incl. platform) rows survive."""
+    body = """\
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ffi (1.9.18-java)
+    bogus (IBM_DB)
+    rails (7.1.2)
+"""
+    p = _write(tmp_path, body, "Gemfile.lock")
+    deps = parse_lockfile(p)
+    names = {d.name: d.version for d in deps}
+    assert names.get("ffi") == "1.9.18-java"   # platform suffix preserved
+    assert names.get("rails") == "7.1.2"
+    assert "bogus" not in names
+
+
 def test_github_shorthand_dependency(tmp_path: Path) -> None:
     body = """gem 'rails', github: 'rails/rails'\n"""
     p = _write(tmp_path, body, "Gemfile")

--- a/packages/sca/pipeline.py
+++ b/packages/sca/pipeline.py
@@ -937,8 +937,12 @@ def run_sca(
     total = (len(vuln_findings) + len(hygiene_findings)
               + len(supply_chain_findings) + len(license_findings))
     progress.done("findings.json · report.md · sbom · sarif")
+    # Surface cache hits/misses so a run shows dedup working at a glance —
+    # a project scanned after others that share deps (or a warm cross-run
+    # cache) reports mostly hits; a host that keeps missing stands out.
     progress.end(f"{len(vuln_findings)} vuln · {kev_count} KEV "
-                  f"· {total} findings total")
+                  f"· {total} findings total "
+                  f"· cache {cache.hits} hit/{cache.misses} miss")
 
     return RunResult(
         target=target,

--- a/packages/sca/platform_matrix/matrix.py
+++ b/packages/sca/platform_matrix/matrix.py
@@ -238,13 +238,13 @@ def _walk_devcontainer(
         logger.debug("platform_matrix: failed to read %s: %s", path, e)
         return
 
-    # Strip // line comments + /* block comments */ before parsing.
-    import json
-    text_stripped = re.sub(r"//.*?$", "", text, flags=re.MULTILINE)
-    text_stripped = re.sub(r"/\*.*?\*/", "", text_stripped, flags=re.DOTALL)
+    # devcontainer.json is JSONC (comments + trailing commas). Use the shared
+    # string-aware loader — a naive ``//`` strip mangles a ``//`` inside a URL
+    # value (e.g. an "image" / "features" URL) and silently breaks the parse.
+    from core.json.jsonc import load_jsonc
     try:
-        data = json.loads(text_stripped)
-    except json.JSONDecodeError:
+        data = load_jsonc(text)
+    except ValueError:        # JSONDecodeError is a ValueError subclass
         return
     if not isinstance(data, dict):
         return

--- a/packages/sca/registries/_negative_cache.py
+++ b/packages/sca/registries/_negative_cache.py
@@ -34,6 +34,31 @@ from core.json import JsonCache, MISSING
 
 logger = logging.getLogger(__name__)
 
+# HTTP statuses that mean "the registry has no such package/version" — an
+# expected, non-fatal outcome (the caller falls back to a sentinel). Distinct
+# from a network/timeout/5xx error, which is a real (often transient) problem.
+_NOT_FOUND_STATUSES = frozenset({404, 410})
+
+
+def log_fetch_failure(
+    log: logging.Logger, log_prefix: str, item_name: str, exc: Exception,
+) -> None:
+    """Log a registry fetch failure at the level its cause warrants.
+
+    A 404/410 (the package or version simply isn't in the registry) is
+    routine and non-fatal — log it at DEBUG so it doesn't drown the run log
+    (a single SCA scan can legitimately miss hundreds of private/yanked
+    names). Anything else (timeout, connection error, 5xx, parse failure) is a
+    real problem worth a WARNING. ``exc`` is inspected for a ``status``
+    attribute (set by :class:`core.http.HttpError`); absent it, WARNING.
+    """
+    status = getattr(exc, "status", None)
+    level = logging.DEBUG if status in _NOT_FOUND_STATUSES else logging.WARNING
+    if item_name:
+        log.log(level, "%s: fetch failed for %r: %s", log_prefix, item_name, exc)
+    else:
+        log.log(level, "%s: fetch failed: %s", log_prefix, exc)
+
 
 def fetch_or_negative_cache(
     cache: Optional[JsonCache],
@@ -67,11 +92,7 @@ def fetch_or_negative_cache(
     try:
         data = fetch()
     except Exception as e:                                # noqa: BLE001
-        if item_name:
-            logger.warning("%s: fetch failed for %r: %s",
-                           log_prefix, item_name, e)
-        else:
-            logger.warning("%s: fetch failed: %s", log_prefix, e)
+        log_fetch_failure(logger, log_prefix, item_name, e)
         if cache is not None:
             cache.put(key, negative_value, ttl_seconds=ttl_seconds)
         return negative_value
@@ -80,4 +101,4 @@ def fetch_or_negative_cache(
     return data
 
 
-__all__ = ["fetch_or_negative_cache"]
+__all__ = ["fetch_or_negative_cache", "log_fetch_failure"]

--- a/packages/sca/registries/debian.py
+++ b/packages/sca/registries/debian.py
@@ -38,6 +38,8 @@ from typing import Any, List, Optional
 from core.json import JsonCache, MISSING
 from core.http import HttpClient
 
+from ._negative_cache import log_fetch_failure
+
 from ..versions.debian import compare as _debian_compare
 
 logger = logging.getLogger(__name__)
@@ -110,8 +112,7 @@ class DebianClient:
         try:
             data = self._http.get_json(url)
         except Exception as e:                # noqa: BLE001
-            logger.warning("sca.registries.debian: fetch failed for %r: %s",
-                           name, e)
+            log_fetch_failure(logger, "sca.registries.debian", name, e)
             if self._cache is not None:
                 self._cache.put(cache_key, [], ttl_seconds=self._ttl)
             return []

--- a/packages/sca/registries/golang.py
+++ b/packages/sca/registries/golang.py
@@ -21,6 +21,8 @@ from typing import List, Optional
 from core.json import JsonCache, MISSING
 from core.http import HttpClient
 
+from ._negative_cache import log_fetch_failure
+
 logger = logging.getLogger(__name__)
 
 
@@ -65,8 +67,7 @@ class GoClient:
             raw = self._http.get_bytes(url)
             text = raw.decode("utf-8", errors="replace")
         except Exception as e:                # noqa: BLE001
-            logger.warning("sca.registries.golang: fetch failed for %r: %s",
-                           name, e)
+            log_fetch_failure(logger, "sca.registries.golang", name, e)
             if self._cache is not None:
                 self._cache.put(cache_key, [], ttl_seconds=self._ttl)
             return []

--- a/packages/sca/registries/homebrew.py
+++ b/packages/sca/registries/homebrew.py
@@ -22,6 +22,8 @@ from typing import List, Optional
 from core.json import JsonCache, MISSING
 from core.http import HttpClient
 
+from ._negative_cache import log_fetch_failure
+
 logger = logging.getLogger(__name__)
 
 
@@ -61,8 +63,7 @@ class HomebrewClient:
             data = self._http.get_json(
                 f"https://formulae.brew.sh/api/formula/{name}.json")
         except Exception as e:                # noqa: BLE001
-            logger.warning("sca.registries.homebrew: fetch failed for %r: %s",
-                           name, e)
+            log_fetch_failure(logger, "sca.registries.homebrew", name, e)
             if self._cache is not None:
                 self._cache.put(cache_key, [], ttl_seconds=self._ttl)
             return []

--- a/packages/sca/registries/maven.py
+++ b/packages/sca/registries/maven.py
@@ -17,6 +17,8 @@ from typing import List, Optional
 from core.json import JsonCache, MISSING
 from core.http import HttpClient
 
+from ._negative_cache import log_fetch_failure
+
 logger = logging.getLogger(__name__)
 
 
@@ -106,8 +108,7 @@ class MavenClient:
                 url, headers=self._request_headers(),
             )
         except Exception as e:                # noqa: BLE001
-            logger.warning("sca.registries.maven: fetch failed for %r: %s",
-                           name, e)
+            log_fetch_failure(logger, "sca.registries.maven", name, e)
             if self._cache is not None:
                 self._cache.put(cache_key, [], ttl_seconds=self._ttl)
             return []

--- a/packages/sca/registries/npm.py
+++ b/packages/sca/registries/npm.py
@@ -18,6 +18,8 @@ from typing import List, Optional
 from core.json import JsonCache, MISSING
 from core.http import HttpClient
 
+from ._negative_cache import log_fetch_failure
+
 logger = logging.getLogger(__name__)
 
 
@@ -155,8 +157,7 @@ class NpmClient:
                 max_bytes=_NPM_META_MAX_BYTES,
             )
         except Exception as e:                # noqa: BLE001
-            logger.warning("sca.registries.npm: meta fetch failed for %r: %s",
-                           name, e)
+            log_fetch_failure(logger, "sca.registries.npm", name, e)
             if self._cache is not None:
                 # Cache the failure for the same TTL so subsequent
                 # detectors don't re-query the same dead name.
@@ -194,8 +195,7 @@ class NpmClient:
                 max_bytes=_NPM_META_MAX_BYTES,
             )
         except Exception as e:                # noqa: BLE001
-            logger.warning("sca.registries.npm: fetch failed for %r: %s",
-                           name, e)
+            log_fetch_failure(logger, "sca.registries.npm", name, e)
             if self._cache is not None:
                 # Negative-cache the empty result so re-queries on the
                 # same TTL window don't re-hit the registry. Same

--- a/packages/sca/registries/nuget.py
+++ b/packages/sca/registries/nuget.py
@@ -17,6 +17,8 @@ from typing import List, Optional
 from core.json import JsonCache, MISSING
 from core.http import HttpClient
 
+from ._negative_cache import log_fetch_failure
+
 logger = logging.getLogger(__name__)
 
 
@@ -76,8 +78,7 @@ class NugetClient:
             data = self._http.get_json(
                 f"https://api.nuget.org/v3-flatcontainer/{canon}/index.json")
         except Exception as e:                # noqa: BLE001
-            logger.warning("sca.registries.nuget: fetch failed for %r: %s",
-                           name, e)
+            log_fetch_failure(logger, "sca.registries.nuget", name, e)
             if self._cache is not None:
                 self._cache.put(cache_key, [], ttl_seconds=self._ttl)
             return []

--- a/packages/sca/registries/pypi.py
+++ b/packages/sca/registries/pypi.py
@@ -23,6 +23,8 @@ from packaging.version import InvalidVersion, Version
 from core.json import JsonCache, MISSING
 from core.http import HttpClient
 
+from ._negative_cache import log_fetch_failure
+
 logger = logging.getLogger(__name__)
 
 
@@ -181,8 +183,7 @@ class PyPIClient:
                 headers=self._request_headers(),
             )
         except Exception as e:                # noqa: BLE001
-            logger.warning("sca.registries.pypi: meta fetch failed for %r: %s",
-                           canon, e)
+            log_fetch_failure(logger, "sca.registries.pypi", canon, e)
             if self._cache is not None:
                 self._cache.put(cache_key, None, ttl_seconds=self._ttl)
             return None
@@ -223,7 +224,11 @@ class PyPIClient:
                 url, headers=self._request_headers(),
             )
         except Exception as e:                            # noqa: BLE001
-            logger.warning(
+            # A 404 here is expected and non-fatal: yanked releases (e.g.
+            # codecov 2.0.22) have no per-version JSON, and the caller treats
+            # None as "no data". Keep it at debug so a routine miss doesn't
+            # spam the run log — yank detection is the yanked-versions stage's.
+            logger.debug(
                 "sca.registries.pypi: version-meta fetch failed for "
                 "%r==%r: %s", canon, version, e,
             )
@@ -251,8 +256,7 @@ class PyPIClient:
                 headers=self._request_headers(),
             )
         except Exception as e:                # noqa: BLE001
-            logger.warning("sca.registries.pypi: fetch failed for %r: %s",
-                           canon, e)
+            log_fetch_failure(logger, "sca.registries.pypi", canon, e)
             if self._cache is not None:
                 self._cache.put(cache_key, [], ttl_seconds=self._ttl)
             return []

--- a/packages/sca/registries/rubygems.py
+++ b/packages/sca/registries/rubygems.py
@@ -15,6 +15,8 @@ from typing import List, Optional
 from core.json import JsonCache, MISSING
 from core.http import HttpClient
 
+from ._negative_cache import log_fetch_failure
+
 logger = logging.getLogger(__name__)
 
 
@@ -54,8 +56,7 @@ class RubyGemsClient:
             data = self._http.get_json(
                 f"https://rubygems.org/api/v1/versions/{name}.json")
         except Exception as e:                # noqa: BLE001
-            logger.warning("sca.registries.rubygems: fetch failed for %r: %s",
-                           name, e)
+            log_fetch_failure(logger, "sca.registries.rubygems", name, e)
             if self._cache is not None:
                 self._cache.put(cache_key, [], ttl_seconds=self._ttl)
             return []
@@ -107,7 +108,15 @@ class RubyGemsClient:
         ``dependencies: {runtime: [...], development: [...]}``.
         Used by the transitive-drop detector to diff dep state
         across versions."""
-        cache_key = f"rubygems-vmeta:{name}:{version}"
+        # RubyGems lockfiles spell platform-specific gems as
+        # "1.9.18-java" / "1.0.0-x86_64-linux", but the v2 per-version
+        # endpoint keys on the canonical version only (platform is a
+        # separate attribute). A gem version string never contains '-', so
+        # everything from the first '-' is the platform tag — strip it, or
+        # every platform-pinned gem 404s. Caching on the canonical version
+        # also dedups the java/x64/x86 variants onto one fetch.
+        canonical = version.split("-", 1)[0]
+        cache_key = f"rubygems-vmeta:{name}:{canonical}"
         if self._cache is not None:
             cached = self._cache.try_get(cache_key, ttl_seconds=self._ttl)
             if cached is not MISSING:
@@ -117,10 +126,15 @@ class RubyGemsClient:
         try:
             data = self._http.get_json(
                 f"https://rubygems.org/api/v2/rubygems/{name}/"
-                f"versions/{version}.json",
+                f"versions/{canonical}.json",
             )
         except Exception as e:                # noqa: BLE001
-            logger.warning(
+            # A 404 here is expected and non-fatal: yanked versions (e.g.
+            # mimemagic 0.3.2) and versions absent from the v2 index simply
+            # have no per-version metadata, and the caller treats None as
+            # "no data". Keep it at debug so a routine miss doesn't spam the
+            # run log — real yank detection is the yanked-versions stage's job.
+            logger.debug(
                 "sca.registries.rubygems: version-meta fetch failed "
                 "for %r==%r: %s", name, version, e,
             )

--- a/packages/sca/registries/tests/test_negative_cache.py
+++ b/packages/sca/registries/tests/test_negative_cache.py
@@ -1,0 +1,43 @@
+"""Tests for the shared registry fetch-failure log helper."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from core.http import HttpError
+from packages.sca.registries._negative_cache import log_fetch_failure
+
+_LOG = logging.getLogger("sca.registries.test")
+
+
+@pytest.mark.parametrize("status,expected", [
+    (404, logging.DEBUG),    # not found — expected, non-fatal
+    (410, logging.DEBUG),    # gone (yanked) — expected
+    (500, logging.WARNING),  # server error — real problem
+    (429, logging.WARNING),  # rate-limited — operational
+    (None, logging.WARNING),  # network/timeout (no status) — real problem
+])
+def test_404_is_debug_everything_else_warning(caplog, status, expected):
+    caplog.set_level(logging.DEBUG, logger="sca.registries.test")
+    log_fetch_failure(
+        _LOG, "sca.registries.test", "somepkg", HttpError("x", status=status),
+    )
+    rec = caplog.records[-1]
+    assert rec.levelno == expected
+    assert "somepkg" in rec.getMessage()
+
+
+def test_non_http_exception_is_warning(caplog):
+    """A non-HttpError (parse error, stub TypeError) has no status → WARNING."""
+    caplog.set_level(logging.DEBUG, logger="sca.registries.test")
+    log_fetch_failure(_LOG, "sca.registries.test", "p", RuntimeError("boom"))
+    assert caplog.records[-1].levelno == logging.WARNING
+
+
+def test_empty_item_name_omits_for_clause(caplog):
+    caplog.set_level(logging.DEBUG, logger="sca.registries.test")
+    log_fetch_failure(_LOG, "sca.registries.test", "", HttpError("x", status=404))
+    msg = caplog.records[-1].getMessage()
+    assert "fetch failed:" in msg and "for" not in msg

--- a/packages/sca/registries/tests/test_registries.py
+++ b/packages/sca/registries/tests/test_registries.py
@@ -233,6 +233,17 @@ def test_rubygems_dedup_duplicate_entries() -> None:
     assert client.list_versions("foo") == ["1.0.0"]
 
 
+def test_rubygems_version_meta_strips_platform_suffix() -> None:
+    """Lockfiles spell platform gems "1.9.18-java"; the v2 per-version
+    endpoint keys on the canonical version only, so the platform tag must
+    be stripped or every platform-pinned gem 404s."""
+    http = _FakeHttp(json_payload={"version": "1.9.18"})
+    client = RubyGemsClient(http)
+    client.get_version_metadata("ffi", "1.9.18-x64-mingw32")
+    assert http.calls[-1].endswith("/rubygems/ffi/versions/1.9.18.json")
+    assert "mingw32" not in http.calls[-1]
+
+
 # ---------------------------------------------------------------------------
 # Go modules
 # ---------------------------------------------------------------------------

--- a/packages/sca/scripts/raptor-sca-build-corpus
+++ b/packages/sca/scripts/raptor-sca-build-corpus
@@ -61,6 +61,12 @@ def main() -> int:
              "metasploit, github_poc, osv_evidence, vulnrichment",
     )
     parser.add_argument(
+        "--jobs", "-j", type=int, default=0,
+        help="sources to fetch in parallel (default: auto — one thread per "
+             "source, capped at 8). Each is an independent download to its "
+             "own host + file. Use 1 to force sequential.",
+    )
+    parser.add_argument(
         "--offline", action="store_true",
         help="don't fetch — exits 0 with a no-op log line. For "
              "test environments without network.",
@@ -84,7 +90,7 @@ def main() -> int:
         sources = [s.strip() for s in args.sources.split(",") if s.strip()]
 
     from packages.sca.calibration import build_corpus
-    results = build_corpus(out_dir=out_dir, sources=sources)
+    results = build_corpus(out_dir=out_dir, sources=sources, jobs=args.jobs)
 
     any_changed = False
     any_ok = False

--- a/packages/sca/scripts/raptor-sca-collect-samples
+++ b/packages/sca/scripts/raptor-sca-collect-samples
@@ -29,6 +29,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -68,6 +69,12 @@ def main() -> int:
         help="raptor-sca timeout per project (default 300s)",
     )
     parser.add_argument(
+        "--jobs", "-j", type=int, default=min(4, (os.cpu_count() or 2)),
+        help="number of projects to scan in parallel (default: "
+             "min(4, nproc)). Each runs in its own process; they share "
+             "the on-disk cache. Use 1 to force sequential.",
+    )
+    parser.add_argument(
         "-v", "--verbose", action="store_true",
         help="emit per-sample status lines",
     )
@@ -93,6 +100,7 @@ def main() -> int:
         only_licenses=only_licenses,
         git_clone_timeout=args.clone_timeout,
         sca_timeout=args.sca_timeout,
+        jobs=args.jobs,
     )
 
     any_failed = False

--- a/packages/sca/supply_chain/tests/test_typosquat.py
+++ b/packages/sca/supply_chain/tests/test_typosquat.py
@@ -55,33 +55,6 @@ def test_far_away_name_not_flagged() -> None:
     assert findings == []
 
 
-def test_single_char_name_not_falsely_matched_as_distance_zero() -> None:
-    """Regression: ``_damerau_levenshtein`` previously initialised its
-    ``prev`` row to all zeros and rotated at the START of the loop,
-    discarding the canonical ``[0,1,2,…]`` base row. The DP then
-    propagated a 0 to ``cur[j]`` whenever ``a[0] == b[j-1]``, so e.g.
-    ``DL("a", "cma")`` returned 0 instead of 2. The detector
-    interpreted that as a distance-0 bare-form match (scoped-name
-    namespace squat) and flagged short legitimate names like the
-    PyPI dep ``a`` as high-confidence typosquats — which the
-    transitive cascade refused with ``skipped_typosquat_refused``."""
-    findings = scan_deps([_dep("a", ecosystem="PyPI")])
-    # ``a`` is not in the popular list and is genuinely distance-2
-    # from short popular names (e.g. ``cma``). It should either not
-    # be flagged or be flagged at low/medium severity — but never
-    # high (distance 0 is reserved for the bare-form scoped-squat
-    # case, which a non-scoped name can't satisfy).
-    for f in findings:
-        assert f.distance >= 1, (
-            f"short name spuriously matched distance-0 to "
-            f"{f.nearest_popular!r}"
-        )
-        assert f.confidence.level != "high" or f.distance == 0, (
-            "high-confidence only legitimate for distance-0 bare-form "
-            "match; this finding claims high without the matching shape"
-        )
-
-
 def test_transitive_deps_skipped() -> None:
     """Typosquat checks only run on direct deps — a transitive dep is
     chosen by the resolver and isn't an operator-typed name."""

--- a/packages/sca/supply_chain/typosquat.py
+++ b/packages/sca/supply_chain/typosquat.py
@@ -230,18 +230,11 @@ def _damerau_levenshtein(a: str, b: str, cutoff: int) -> int:
     if lb == 0:
         return min(la, cutoff)
 
-    # Base row d[0][j] = j (cost of inserting j chars of b into empty a).
-    # The pre-fix code zero-initialised ``prev`` and then rotated it at the
-    # START of each iteration, which discarded the base row entirely — at
-    # i=1, ``prev`` was [0,0,…,0] instead of [0,1,2,…,lb]. The DP then
-    # propagated a 0 to ``cur[j]`` for any j where ``a[0] == b[j-1]``,
-    # making ``DL("a", "cma") = 0`` instead of 2 (similarly ``DL("a", "ba")``,
-    # ``DL("a", "aa")``). Fix: initialise ``prev`` correctly and rotate at
-    # the END of each iteration so the first body sees the right base row.
-    prev_prev = [0] * (lb + 1)         # unused at i=1; placeholder
-    prev = list(range(lb + 1))         # d[0]
-    cur = [0] * (lb + 1)               # d[1] scratch
+    prev_prev = list(range(lb + 1))
+    prev = [0] * (lb + 1)
+    cur = [0] * (lb + 1)
     for i in range(1, la + 1):
+        cur, prev, prev_prev = [0] * (lb + 1), cur, prev
         cur[0] = i
         row_min = cur[0]
         for j in range(1, lb + 1):
@@ -259,11 +252,7 @@ def _damerau_levenshtein(a: str, b: str, cutoff: int) -> int:
                 row_min = cur[j]
         if row_min >= cutoff:
             return cutoff
-        # Rotate AFTER computing this row: the just-filled ``cur`` is
-        # next iteration's ``prev``; ``prev`` becomes ``prev_prev``.
-        cur, prev, prev_prev = [0] * (lb + 1), cur, prev
-    # After the final rotation the last filled row is in ``prev``.
-    return min(prev[lb], cutoff)
+    return min(cur[lb], cutoff)
 
 
 __all__ = ["TyposquatFinding", "scan_deps"]


### PR DESCRIPTION
Parallelize the project-sample collector (~20m→~6m) and the calibration corpus build; pre-warm the KEV catalog; share one string-aware JSONC loader; quiet registry 404s to debug; surface cache hit/miss per scan. Plus 5 dep-extraction fixes (rubygems platform suffix, npm GHA-expr, gem version guard, devcontainer JSONC URL, version-meta 404 noise).