### PR TITLE
feat(coverage): persistent verdict-bearing coverage store, wired to the real pipeline

### DIFF
--- a/core/coverage/__init__.py
+++ b/core/coverage/__init__.py
@@ -16,6 +16,34 @@ from .record import (
     COVERAGE_RECORD_FILE,
     READS_MANIFEST,
 )
+from .store import (
+    CoverageStore,
+    COVERAGE_STORE_FILE,
+    coverage_store_lock,
+    iter_inventory_functions,
+    content_identity,
+)
+from .registry import category_of, depth_of, classify
+from .importer import (
+    backfill,
+    import_run_dir,
+    import_checked_by,
+    import_findings,
+    import_run_findings,
+    import_annotations,
+    run_provenance,
+)
+from .store_summary import (
+    store_view, format_store_view, file_level_view, format_file_level_view,
+)
+from .clean import (
+    clean_run,
+    classify_removal,
+    apply_removal,
+    dedup_runs,
+    format_consequence,
+    CleanConsequence,
+)
 
 __all__ = [
     "build_from_manifest",
@@ -28,4 +56,29 @@ __all__ = [
     "cleanup_manifest",
     "COVERAGE_RECORD_FILE",
     "READS_MANIFEST",
+    "CoverageStore",
+    "COVERAGE_STORE_FILE",
+    "coverage_store_lock",
+    "iter_inventory_functions",
+    "content_identity",
+    "category_of",
+    "depth_of",
+    "classify",
+    "backfill",
+    "import_run_dir",
+    "import_checked_by",
+    "import_findings",
+    "import_run_findings",
+    "import_annotations",
+    "run_provenance",
+    "store_view",
+    "format_store_view",
+    "file_level_view",
+    "format_file_level_view",
+    "clean_run",
+    "classify_removal",
+    "apply_removal",
+    "dedup_runs",
+    "format_consequence",
+    "CleanConsequence",
 ]

--- a/core/coverage/clean.py
+++ b/core/coverage/clean.py
@@ -1,0 +1,183 @@
+"""Coverage-aware ``/project clean``: snapshot a run's coverage into the
+durable store before its dir is deleted, and classify the removal.
+
+Per the locked model, deleting a run must not silently lose what it uniquely
+contributed:
+
+  - its coverage (examined extent) is **snapshotted** into the durable store,
+    so clean/examined coverage survives the deletion;
+  - findings the victim run held are linked with ``retained=False`` *iff no
+    surviving run still holds them* — those functions become
+    ``found_then_lost`` (re-examine); findings still held elsewhere stay
+    ``open``;
+  - the removal is **classified** (duplicate / sole-source findings) so the
+    operator — and auto-dedup ``--keep`` — knows whether it was free or lossy.
+
+Substantiation is computed against the **surviving runs** (the common case).
+Not counting coverage already durably in the store is deliberately
+conservative: at worst it flags a re-review that wasn't strictly needed,
+which is the safe direction (re-running is cheap; silently skipping a lost
+finding is not). The caller saves the store after processing all victims.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Set, Tuple
+
+from .importer import import_findings, import_run_dir, load_run_findings
+from .record import load_records
+from .store import CoverageStore
+
+
+def _finding_key(f: Dict[str, Any]) -> Tuple[Any, Any, Any]:
+    """A cross-run identity for a finding: ``(file, location, issue)``.
+
+    Location is the line (``("L", n)``) or, absent a line, the id (``("I",
+    id)``). The ``issue`` discriminator (rule / CWE / vuln type) is what keeps
+    two *distinct* findings that happen to share a line from collapsing to one
+    key — without it, a survivor holding either would mask the loss of the
+    other, so a real finding could be silently discarded with no
+    ``found_then_lost`` re-review flag. Preferring rule/CWE over id makes the
+    key stable across runs (the same issue re-found at the same line matches
+    even if its per-run id differs)."""
+    file = f.get("file") or f.get("file_path") or f.get("path")
+    line = f.get("line") or f.get("line_start") or f.get("start_line")
+    issue = (f.get("rule_id") or f.get("cwe_id") or f.get("vuln_type")
+             or f.get("rule") or f.get("id") or f.get("finding_id"))
+    loc = ("L", line) if line is not None else ("I", f.get("id") or f.get("finding_id"))
+    return (file, loc, issue)
+
+
+def _files_examined(run_dir: Path) -> Set[str]:
+    out: Set[str] = set()
+    for rec in load_records(run_dir):
+        out.update(rec.get("files_examined", []) or [])
+    return out
+
+
+@dataclass
+class CleanConsequence:
+    """What deleting one run does to coverage."""
+
+    run: str
+    duplicate: bool                              # adds nothing the survivors lack
+    findings_lost: List[Tuple[Any, Any]] = field(default_factory=list)
+    coverage_files: List[str] = field(default_factory=list)
+
+    @property
+    def lossy(self) -> bool:
+        return bool(self.findings_lost)
+
+
+def classify_removal(
+    victim_run_dir: Path, surviving_run_dirs: Iterable[Path],
+) -> CleanConsequence:
+    """Read-only: classify what deleting ``victim`` would lose, net of the
+    surviving runs. Safe to call before the operator confirms (no store
+    mutation) — use it to drive the warning."""
+    victim = Path(victim_run_dir)
+    survivors = [Path(d) for d in surviving_run_dirs]
+
+    surv_files: Set[str] = set()
+    surv_finding_keys: Set[Tuple[Any, Any]] = set()
+    for d in survivors:
+        surv_files |= _files_examined(d)
+        for f in load_run_findings(d):
+            if isinstance(f, dict):
+                surv_finding_keys.add(_finding_key(f))
+
+    victim_files = _files_examined(victim)
+    findings_lost = [
+        _finding_key(f) for f in load_run_findings(victim)
+        if isinstance(f, dict) and _finding_key(f) not in surv_finding_keys
+    ]
+    duplicate = victim_files.issubset(surv_files) and not findings_lost
+    return CleanConsequence(
+        run=victim.name,
+        duplicate=duplicate,
+        findings_lost=findings_lost,
+        coverage_files=sorted(victim_files),
+    )
+
+
+def dedup_runs(
+    run_dirs: Iterable[Path],
+) -> Tuple[List[Path], List[CleanConsequence]]:
+    """Greedy lossless dedup: return the run dirs that can be deleted without
+    losing examined extent or a unique finding, because each is fully subsumed
+    by the runs that remain. Always keeps at least one run; keeps the newest
+    representative (oldest duplicates dropped first).
+
+    Lossless by construction: a run is only marked droppable when it is a
+    duplicate w.r.t. the *current* survivor set, and that set only ever shrinks
+    by removing already-subsumed runs — so every survivor at drop-time stays,
+    fully covering what was dropped. (Tool-specific coverage of a dropped run
+    is independently preserved by :func:`apply_removal`'s store snapshot before
+    deletion, so "duplicate" here need only mean files+findings subsumed.)
+    """
+    # Oldest-first so the newest run is the representative we keep. Run dir
+    # names are timestamped, so name order is chronological.
+    survivors = sorted((Path(d) for d in run_dirs), key=lambda p: p.name)
+    droppable: List[Path] = []
+    reasons: List[CleanConsequence] = []
+    i = 0
+    while i < len(survivors):
+        victim = survivors[i]
+        others = survivors[:i] + survivors[i + 1:]
+        if not others:
+            break
+        cons = classify_removal(victim, others)
+        if cons.duplicate:
+            droppable.append(victim)
+            reasons.append(cons)
+            survivors.pop(i)          # next run shifts into i; re-evaluate
+        else:
+            i += 1
+    return droppable, reasons
+
+
+def apply_removal(
+    store: CoverageStore,
+    victim_run_dir: Path,
+    checklist: Dict[str, Any],
+    consequence: CleanConsequence,
+) -> None:
+    """Snapshot the victim's coverage into the store and link its findings
+    with ``retained`` per the classification. Mutates the store; call AFTER
+    the deletion is confirmed but BEFORE the dir is removed (it reads the
+    victim's records/findings). Caller saves."""
+    victim = Path(victim_run_dir)
+    import_run_dir(store, victim, checklist)          # coverage persists
+    inv_paths = {fe.get("path") for fe in checklist.get("files", []) if fe.get("path")}
+    lost = set(consequence.findings_lost)
+    for f in load_run_findings(victim):
+        if isinstance(f, dict):
+            retained = _finding_key(f) not in lost
+            import_findings(store, [f], retained=retained, inventory_paths=inv_paths)
+
+
+def clean_run(
+    store: CoverageStore,
+    victim_run_dir: Path,
+    surviving_run_dirs: Iterable[Path],
+    checklist: Dict[str, Any],
+) -> CleanConsequence:
+    """Classify + apply in one step (snapshot, retained flips, classification).
+    Mutates the store (caller saves)."""
+    consequence = classify_removal(victim_run_dir, surviving_run_dirs)
+    apply_removal(store, victim_run_dir, checklist, consequence)
+    return consequence
+
+
+def format_consequence(c: CleanConsequence) -> str:
+    """One-line operator summary of a planned/applied removal."""
+    if c.duplicate:
+        return f"  {c.run}: duplicate — covered by surviving runs; free to remove"
+    if c.lossy:
+        return (
+            f"  {c.run}: drops {len(c.findings_lost)} unique finding(s) — "
+            f"those functions become re-review gaps (found-then-lost)"
+        )
+    return f"  {c.run}: unique coverage preserved into the store; no findings lost"

--- a/core/coverage/importer.py
+++ b/core/coverage/importer.py
@@ -1,0 +1,332 @@
+"""Backfill: fold per-run coverage records + inventory checked_by into the
+persistent CoverageStore.
+
+Producers keep emitting per-run ``coverage-record.json`` (file-level
+``files_examined``) and the inventory keeps per-item ``checked_by``
+(function-level, LLM-driven). The store is the durable union that survives
+``/project clean``; this module is the bridge that imports both. Call
+:func:`import_run_dir` per run, or :func:`backfill` over all run dirs once.
+
+File-level marks need each file's ``total_lines`` (from the inventory) to
+place the whole-file interval; files absent from the inventory are skipped
+(their extent is unknown). Granularity is therefore: whole-file from the
+records, function-level from ``checked_by``. True line-level coverage
+arrives only when a producer emits ranges -- a later format extension.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from core.json import load_json
+from core.run.metadata import load_run_metadata
+from core.run.provenance import (
+    run_engines,
+    run_framework_sha,
+    run_models,
+    run_target,
+    run_timestamp,
+)
+
+from .record import load_records
+from .registry import category_of
+from .store import CoverageStore, file_line_count
+from .summary import _match_to_inventory
+
+
+def _inventory_paths(checklist: Dict[str, Any]) -> set:
+    return {fe.get("path") for fe in checklist.get("files", []) if fe.get("path")}
+
+
+def _to_inventory_path(path: str, inventory_paths: set) -> str:
+    """Normalise a tool-reported path to the inventory's key. Scanners report
+    ABSOLUTE paths (semgrep) or paths relative to a different root, while the
+    inventory keys on target-relative paths — without this the join silently
+    misses every file. Reuses Phase 2's tested matcher (exact / ``./`` strip /
+    basename / component-aware suffix); falls back to the raw path."""
+    if not inventory_paths:
+        return path
+    return _match_to_inventory(path, inventory_paths) or path
+
+
+def _field(d: Dict[str, Any], *names: str) -> Optional[Any]:
+    for n in names:
+        v = d.get(n)
+        if v is not None:
+            return v
+    return None
+
+
+def run_provenance(run_dir: Path) -> Dict[str, Any]:
+    """Read a run's ``.raptor-run.json`` manifest into a stamping dict
+    (``{}`` when absent — pre-provenance runs degrade gracefully). The
+    coverage store is the (file,function) sink; this is the run-keyed
+    source, read via the documented ``core.run.provenance`` accessors."""
+    md = load_run_metadata(Path(run_dir))
+    if not md:
+        return {}
+    return {
+        "engines": run_engines(md),                  # {tool: version}
+        "models": [m.get("resolved") for m in run_models(md) if m.get("resolved")],
+        "timestamp": run_timestamp(md),
+        "target": run_target(md),                    # acquisition stamp (loose)
+        "framework_sha": run_framework_sha(md),
+        "run": Path(run_dir).name,
+    }
+
+
+def _tool_stamp(tool: str, prov: Dict[str, Any]) -> Dict[str, Any]:
+    """The provenance slice for one (file, tool): engine version for a
+    scanner, resolved model(s) for an LLM tool, plus run-level fields."""
+    stamp: Dict[str, Any] = {
+        "timestamp": prov.get("timestamp"),
+        "target": prov.get("target"),
+        "framework_sha": prov.get("framework_sha"),
+        "run": prov.get("run"),
+    }
+    base = tool.split(":", 1)[0]
+    engines = prov.get("engines") or {}
+    if base in engines:
+        stamp["version"] = engines[base]
+    if category_of(tool) == "llm" and prov.get("models"):
+        stamp["models"] = prov["models"]
+    return stamp
+
+
+def _total_lines_by_file(checklist: Dict[str, Any]) -> Dict[str, int]:
+    out: Dict[str, int] = {}
+    for fe in checklist.get("files", []):
+        path = fe.get("path")
+        tl = file_line_count(fe)
+        if path and tl:
+            out[path] = tl
+    return out
+
+
+def import_checked_by(store: CoverageStore, checklist: Dict[str, Any]) -> int:
+    """Function-level marks from inventory ``checked_by`` labels.
+
+    Returns the number of (function, tool) marks applied.
+    """
+    marks = 0
+    for fe in checklist.get("files", []):
+        path = fe.get("path")
+        if not path:
+            continue
+        for fn in fe.get("items", fe.get("functions", [])):
+            lo = fn.get("line_start", 0)
+            hi = fn.get("line_end")
+            hi = hi if hi is not None else lo
+            for tool in fn.get("checked_by", []) or []:
+                store.mark(path, lo, hi, tool)
+                marks += 1
+    return marks
+
+
+def import_record(
+    store: CoverageStore,
+    record: Dict[str, Any],
+    total_lines: Dict[str, int],
+    provenance: Optional[Dict[str, Any]] = None,
+) -> int:
+    """Whole-file marks from one record's ``files_examined``.
+
+    ``total_lines`` maps file path -> line count (from the inventory).
+    Files not in that map are skipped (unknown extent). When ``provenance``
+    (from :func:`run_provenance`) is supplied, each marked ``(file, tool)``
+    is stamped with engine version / resolved model / timestamp / target.
+    Returns the number of files marked.
+    """
+    tool = record.get("tool")
+    if not tool:
+        return 0
+    stamp = _tool_stamp(tool, provenance) if provenance else None
+    inv_paths = set(total_lines)                     # inventory keys (target-relative)
+    marked = 0
+    for path in record.get("files_examined", []) or []:
+        key = _to_inventory_path(path, inv_paths)    # tools may report abs paths
+        tl = total_lines.get(key)
+        if not tl:
+            continue
+        # Inventory line numbers are 1-based ([1, tl]); the whole-file
+        # interval must match so a function ending on the last line (or a
+        # file without a trailing newline) isn't left a line short.
+        store.mark(key, 1, tl, tool)
+        if stamp:
+            store.stamp_coverage(key, tool, **stamp)
+        marked += 1
+    return marked
+
+
+def import_findings(
+    store: CoverageStore, findings: List[Dict[str, Any]], retained: bool = True,
+    inventory_paths: Optional[set] = None,
+) -> int:
+    """Link findings into the store with their line, so functions get an
+    ``open`` / ``found_then_lost`` verdict.
+
+    Tolerant of field-name variants (file / file_path / path; line /
+    line_start / start_line; id / finding_id). Findings without a resolvable
+    file are skipped. ``retained`` = whether the finding detail is still on
+    disk (``False`` once the holding run is cleaned -> ``found_then_lost``).
+    Returns the number linked.
+    """
+    linked = 0
+    for f in findings or []:
+        if not isinstance(f, dict):
+            continue
+        file = _field(f, "file", "file_path", "path")
+        if not file:
+            continue
+        if inventory_paths:
+            file = _to_inventory_path(file, inventory_paths)   # match verdict's key
+        line = _field(f, "line", "line_start", "start_line")
+        # A stable, position-independent id so re-linking the same finding
+        # (e.g. backfill then a clean snapshot's retained flip) targets the
+        # SAME store entry rather than appending a duplicate. The list index
+        # used previously differed between callers, defeating link_finding's
+        # dedup-by-id and leaving a stale retained=True entry.
+        fid = _field(f, "id", "finding_id")
+        if not fid:
+            issue = _field(f, "rule_id", "cwe_id", "vuln_type", "rule") or "f"
+            fid = f"{file}:{line}:{issue}"
+        store.link_finding(file, str(fid), line=line, retained=retained)
+        linked += 1
+    return linked
+
+
+# Where the producers drop a run's CODE findings (source-function-located).
+# `/scan`-style writes a top-level findings.json; `/agentic` writes its
+# validated code findings to validation/findings.json. SCA's sca/findings.json
+# is DELIBERATELY excluded: those are dependency-class rows (a CVE in a package
+# manifest), not source-function findings — attributing them to a function
+# range is meaningless. core.project.findings_utils keeps SCA separate for the
+# same reason (load_sca_findings_from_dir is a distinct loader). This discovery
+# is the store's own — it does NOT touch the shared findings_utils that
+# merge/correlate/report depend on.
+_FINDINGS_LOCATIONS = ("findings.json", "validation/findings.json")
+
+
+def _load_findings_file(path: Path) -> List[Dict[str, Any]]:
+    data = load_json(path)
+    if isinstance(data, dict):
+        data = data.get("findings", data.get("results", []))
+    return data if isinstance(data, list) else []
+
+
+def load_run_findings(run_dir: Path) -> List[Dict[str, Any]]:
+    """Union of a run's findings across the layouts producers use (top-level
+    findings.json, validation/, sca/). The store dedups by id on link, so
+    overlap is harmless; absent files contribute nothing."""
+    run = Path(run_dir)
+    out: List[Dict[str, Any]] = []
+    for rel in _FINDINGS_LOCATIONS:
+        out.extend(_load_findings_file(run / rel))
+    return out
+
+
+def import_run_findings(
+    store: CoverageStore, run_dir: Path, inventory_paths: Optional[set] = None,
+) -> int:
+    """Link a run's findings (detail present, since the run dir exists)."""
+    return import_findings(
+        store, load_run_findings(run_dir), retained=True,
+        inventory_paths=inventory_paths,
+    )
+
+
+def _parse_lines(spec: Optional[str]) -> Optional[tuple]:
+    if not spec or "-" not in spec:
+        return None
+    try:
+        lo, hi = spec.split("-", 1)
+        return (int(lo), int(hi))
+    except ValueError:
+        return None
+
+
+def import_annotations(
+    store: CoverageStore,
+    base_dir: Path,
+    checklist: Dict[str, Any],
+    tool: str = "annotations",
+) -> int:
+    """Import durable per-function annotations as llm-category coverage.
+
+    Annotations (``core.annotations``) are project-level and survive
+    ``/project clean``, so importing them keeps retained *reviews* counting
+    even after the run dirs that produced them are gone. A ``clean`` status
+    -> clean coverage; ``finding`` / ``suspicious`` -> a linked finding so the
+    function reads ``open``. Function line ranges come from the inventory
+    (file+name), falling back to the annotation's ``lines`` metadata; an
+    annotation that resolves to neither is skipped. Returns the count.
+    """
+    base_dir = Path(base_dir)
+    if not base_dir.exists():
+        return 0
+    from core.annotations.storage import iter_all_annotations
+
+    ranges: Dict[tuple, tuple] = {}
+    for fe in checklist.get("files", []):
+        path = fe.get("path")
+        if not path:
+            continue
+        for it in fe.get("items", fe.get("functions", [])):
+            name = it.get("name")
+            if name:
+                ranges[(path, name)] = (it.get("line_start", 0), it.get("line_end"))
+
+    imported = 0
+    for ann in iter_all_annotations(base_dir):
+        rng = ranges.get((ann.file, ann.function)) or _parse_lines(
+            ann.metadata.get("lines")
+        )
+        if rng is None:
+            continue
+        lo, hi = rng
+        store.mark(ann.file, lo, hi if hi is not None else lo, tool)
+        if ann.metadata.get("status") in ("finding", "suspicious"):
+            store.link_finding(
+                ann.file, f"annotation:{ann.file}:{ann.function}",
+                line=lo, retained=True,
+            )
+        imported += 1
+    return imported
+
+
+def import_run_dir(
+    store: CoverageStore, run_dir: Path, checklist: Dict[str, Any],
+) -> int:
+    """Import all coverage records in ``run_dir`` (file-level), stamping each
+    contribution with the run's manifest provenance."""
+    total_lines = _total_lines_by_file(checklist)
+    prov = run_provenance(run_dir)
+    return sum(
+        import_record(store, rec, total_lines, prov)
+        for rec in load_records(Path(run_dir))
+    )
+
+
+def backfill(
+    store: CoverageStore,
+    run_dirs: Iterable[Path],
+    checklist: Dict[str, Any],
+    annotations_base: Optional[Path] = None,
+) -> int:
+    """One-shot backfill: inventory meta + function-level ``checked_by`` +
+    file-level records from every run dir + (when ``annotations_base`` is
+    given) durable annotations as llm-category coverage. Returns total marks.
+
+    The caller saves the store afterwards.
+    """
+    store.import_inventory_meta(checklist)
+    store.set_content_id(checklist)            # git-X ≡ zip-X equivalence id
+    inv_paths = _inventory_paths(checklist)
+    total = import_checked_by(store, checklist)
+    for run_dir in run_dirs:
+        total += import_run_dir(store, run_dir, checklist)
+        import_run_findings(store, run_dir, inv_paths)   # link findings for verdicts
+    if annotations_base is not None:
+        total += import_annotations(store, annotations_base, checklist)
+    return total

--- a/core/coverage/record.py
+++ b/core/coverage/record.py
@@ -473,12 +473,24 @@ def load_records(run_dir: Path) -> List[Dict[str, Any]]:
     """
     run_dir = Path(run_dir)
     records = []
-    # Per-tool files (must be dicts with a "tool" key)
-    for p in sorted(run_dir.glob("coverage-*.json")):
+    seen_tools = set()
+    # Per-tool files at the run-dir top level AND in immediate tool subdirs.
+    # Producers write coverage records into their own subdir (agentic's scanner
+    # -> scan/, codeql -> codeql/), while a standalone /scan writes them at the
+    # top level. coverage-*.json only appears in those tool dirs, so the
+    # one-level subdir glob picks up nothing unrelated. Top level is listed
+    # first so it wins the per-tool de-dup if a tool's record is in both places.
+    candidates = (sorted(run_dir.glob("coverage-*.json"))
+                  + sorted(run_dir.glob("*/coverage-*.json")))
+    for p in candidates:
         if p.name == COVERAGE_RECORD_FILE:
             continue
         data = load_json(p)
         if isinstance(data, dict) and "tool" in data:
+            tool = data.get("tool")
+            if tool in seen_tools:
+                continue
+            seen_tools.add(tool)
             records.append(data)
     # Legacy single file (if no per-tool files found)
     if not records:

--- a/core/coverage/registry.py
+++ b/core/coverage/registry.py
@@ -1,0 +1,67 @@
+"""Tool registry: classify coverage tool labels by category and depth.
+
+Coverage is keyed by tool label (e.g. ``semgrep``, ``claude:audit``,
+``gcov:campaign-1``). The label's *base* (before ``:``) maps to a
+category (static / llm / runtime) and a depth on the
+scanned -> analysed -> dataflow-traced -> runtime-tested ladder.
+
+The category is what consumers query on -- ``gaps(category="llm")`` =
+"what has no LLM examined yet, regardless of scanner coverage". Depth is
+a finer signal kept for later prioritisation; it does not gate gaps().
+
+Unknown tools fall back to ``unknown`` / ``scanned`` -- the most
+conservative depth -- so a new producer is never silently credited as
+deep coverage. The mapping is intentionally small and easy to extend.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+CATEGORY_STATIC = "static"
+CATEGORY_LLM = "llm"
+CATEGORY_RUNTIME = "runtime"
+CATEGORY_UNKNOWN = "unknown"
+
+# Depth ladder, shallow -> deep.
+DEPTH_SCANNED = "scanned"
+DEPTH_ANALYSED = "analysed"
+DEPTH_DATAFLOW = "dataflow-traced"
+DEPTH_RUNTIME = "runtime-tested"
+
+# base tool -> (category, depth)
+_REGISTRY = {
+    "semgrep": (CATEGORY_STATIC, DEPTH_SCANNED),
+    "coccinelle": (CATEGORY_STATIC, DEPTH_SCANNED),
+    "codeql": (CATEGORY_STATIC, DEPTH_SCANNED),
+    "claude": (CATEGORY_LLM, DEPTH_ANALYSED),
+    "llm": (CATEGORY_LLM, DEPTH_ANALYSED),
+    "understand": (CATEGORY_LLM, DEPTH_ANALYSED),
+    "audit": (CATEGORY_LLM, DEPTH_ANALYSED),
+    # checked_by source_labels are command:stage (all LLM-driven; scanners
+    # use the file-level coverage records, not checked_by).
+    "validate": (CATEGORY_LLM, DEPTH_ANALYSED),
+    "agentic": (CATEGORY_LLM, DEPTH_ANALYSED),
+    "annotations": (CATEGORY_LLM, DEPTH_ANALYSED),
+    "gcov": (CATEGORY_RUNTIME, DEPTH_RUNTIME),
+    "afl": (CATEGORY_RUNTIME, DEPTH_RUNTIME),
+    "fuzz": (CATEGORY_RUNTIME, DEPTH_RUNTIME),
+}
+_DEFAULT: Tuple[str, str] = (CATEGORY_UNKNOWN, DEPTH_SCANNED)
+
+
+def _base(tool_label: str) -> str:
+    return tool_label.split(":", 1)[0]
+
+
+def classify(tool_label: str) -> Tuple[str, str]:
+    """Return ``(category, depth)`` for a tool label."""
+    return _REGISTRY.get(_base(tool_label), _DEFAULT)
+
+
+def category_of(tool_label: str) -> str:
+    return classify(tool_label)[0]
+
+
+def depth_of(tool_label: str) -> str:
+    return classify(tool_label)[1]

--- a/core/coverage/store.py
+++ b/core/coverage/store.py
@@ -1,0 +1,500 @@
+"""Persistent coverage store (Phase 3).
+
+Phase 2 wrote one immutable ``coverage-record.json`` per tool per run and
+unioned them at query time. Phase 3 adds ``CoverageStore`` + a persistent
+``coverage.json``: a (file, line-interval)-keyed record of which tool
+examined which lines, surviving across pipeline stages and runs. Tools
+report what they examined via :meth:`mark`; consumers query it.
+
+Coverage is keyed by *tool label* (e.g. ``semgrep``, ``claude:audit``,
+``gcov:campaign-1``). The label both names the producer and -- via the
+tool registry (a later step) -- its depth on the
+scanned -> analysed -> dataflow-traced -> runtime-tested ladder. The
+store treats the label as an opaque string; categorisation lives in the
+registry, not here.
+
+This is the (file,function)-keyed coverage sink. Per-run provenance
+(tool version, resolved model, timestamp, target identity) is sourced
+separately from the run manifest (``.raptor-run.json``) and joined in by
+callers -- coverage does not embed it, and keys on file *content* SHA
+(via the inventory), so it is identical whether the target arrived as a
+git clone or a zip extraction. See ``~/design/coverage-layer.md``.
+
+Intervals are inclusive ``[lo, hi]`` line ranges, kept sorted and
+coalesced per tool. (Bitmap fallback for files with very many intervals
+-- sparse runtime/gcov data -- is a later optimisation; the public API
+does not change when it lands.)
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+from .registry import category_of
+
+try:
+    import fcntl
+    _HAS_FCNTL = True
+except ImportError:                      # non-POSIX (Windows)
+    _HAS_FCNTL = False
+
+COVERAGE_STORE_FILE = "coverage.json"
+SCHEMA_VERSION = 1
+
+Interval = List[int]  # [lo, hi], inclusive
+
+
+@contextlib.contextmanager
+def coverage_store_lock(coverage_path):
+    """Cross-process exclusive lock guarding a ``coverage.json``
+    read-modify-write window.
+
+    The durable store is mutated by two best-effort paths that each
+    load -> mutate -> save: a run's completion snapshot and ``/project clean``'s
+    snapshot. Without a lock, two racing (a run finishing during a clean, or
+    several parallel runs completing at once) last-writer-wins and one
+    snapshot's contribution is dropped. Hold this across the WHOLE window:
+    acquire BEFORE constructing the store and release AFTER ``save()``.
+
+    Locks a sibling ``.lock`` file (not ``coverage.json`` itself, which
+    ``save()`` atomically replaces). No-op without fcntl (non-POSIX) —
+    degrades to the prior last-writer-wins, no regression.
+    """
+    if not _HAS_FCNTL:
+        yield
+        return
+    path = Path(coverage_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+def _coalesce(intervals: List[Interval]) -> List[Interval]:
+    """Sort and merge overlapping or adjacent inclusive intervals."""
+    if not intervals:
+        return []
+    ordered = sorted([lo, hi] if lo <= hi else [hi, lo] for lo, hi in intervals)
+    merged: List[Interval] = [list(ordered[0])]
+    for lo, hi in ordered[1:]:
+        last = merged[-1]
+        if lo <= last[1] + 1:          # overlapping or adjacent
+            last[1] = max(last[1], hi)
+        else:
+            merged.append([lo, hi])
+    return merged
+
+
+def _covered_count(intervals: List[Interval]) -> int:
+    return sum(hi - lo + 1 for lo, hi in intervals)
+
+
+def _overlap_count(intervals: List[Interval], lo: int, hi: int) -> int:
+    """Lines in ``[lo, hi]`` already present in ``intervals``."""
+    total = 0
+    for a, b in intervals:
+        left, right = max(a, lo), min(b, hi)
+        if left <= right:
+            total += right - left + 1
+    return total
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def content_identity(checklist: Dict[str, Any]) -> Optional[str]:
+    """A deterministic content-equivalence id over the inventory's analyzed
+    source: ``sha256`` of the sorted ``(relpath, content_sha256)`` set.
+
+    Equal iff the analyzed file content is byte-identical — so a git checkout
+    and a zip of the same source resolve to the SAME id (``git-X ≡ zip-X``),
+    while CRLF / file-selection drift correctly yields different ids. Derived
+    from the inventory, which already excludes ``.git`` / archive container /
+    build artifacts — NOT from any acquisition hash (that's the run manifest's
+    loose per-method stamp). Returns ``None`` for an empty inventory.
+    """
+    entries = [
+        f"{fe['path']}\0{fe['sha256']}"
+        for fe in checklist.get("files", [])
+        if fe.get("path") and fe.get("sha256")
+    ]
+    if not entries:
+        return None
+    digest = hashlib.sha256("\n".join(sorted(entries)).encode("utf-8")).hexdigest()
+    return f"content:{digest[:16]}"
+
+
+def file_line_count(fe: Dict[str, Any]) -> Optional[int]:
+    """Total line count from an inventory file entry. The inventory emits
+    ``lines``; hand-built / legacy checklists may use ``total_lines``. This is
+    what whole-file scanner coverage (``files_examined``) is placed against, so
+    reading the wrong key silently drops all file-level coverage."""
+    return fe.get("lines") or fe.get("total_lines")
+
+
+def iter_inventory_functions(
+    checklist: Dict[str, Any],
+) -> Iterator[Tuple[str, str, int, Optional[int], str]]:
+    """Yield ``(file, name, line_start, line_end, kind)`` for every inventory
+    item.
+
+    Handles the ``items`` key with ``functions`` fallback (matching
+    ``core.inventory``). ``line_end`` may be ``None`` when the extractor
+    couldn't determine it. ``kind`` defaults to ``"function"`` for legacy
+    entries lacking it.
+    """
+    for fe in checklist.get("files", []):
+        path = fe.get("path")
+        if not path:
+            continue
+        for fn in fe.get("items", fe.get("functions", [])):
+            yield (
+                path,
+                fn.get("name"),
+                fn.get("line_start", 0),
+                fn.get("line_end"),
+                fn.get("kind", "function"),
+            )
+
+
+class CoverageStore:
+    """Persistent, line-interval coverage keyed by file and tool label.
+
+    Load on construction, mutate via :meth:`mark` / :meth:`set_file_meta`
+    / :meth:`link_finding`, persist with :meth:`save`.
+    """
+
+    def __init__(self, coverage_path: Path, target: str | None = None):
+        self.path = Path(coverage_path)
+        self.target = target
+        self.content_id: Optional[str] = None
+        self.version = SCHEMA_VERSION
+        self._files: Dict[str, Dict[str, Any]] = {}
+        if self.path.exists():
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+            self.version = data.get("version", SCHEMA_VERSION)
+            # Constructor-supplied target wins only when the store is new.
+            self.target = data.get("target") or target
+            self.content_id = data.get("content_id")
+            self._files = data.get("files", {}) or {}
+
+    # --- mutation ---------------------------------------------------------
+
+    def _entry(self, file: str) -> Dict[str, Any]:
+        return self._files.setdefault(
+            file,
+            {
+                "total_lines": None, "sloc": None,
+                "tools": {}, "findings": [], "provenance": {},
+            },
+        )
+
+    def mark(self, file: str, start: int, end: int, tool: str) -> int:
+        """Record that ``tool`` examined lines ``[start, end]`` of ``file``.
+
+        Returns the number of *newly* covered lines for that tool (the
+        delta) -- 0 means the range was already fully covered by it.
+        """
+        if start > end:
+            start, end = end, start
+        entry = self._entry(file)
+        existing = entry["tools"].get(tool, [])
+        newly = (end - start + 1) - _overlap_count(existing, start, end)
+        entry["tools"][tool] = _coalesce(existing + [[start, end]])
+        return newly
+
+    def set_file_meta(
+        self, file: str, total_lines: int | None = None, sloc: int | None = None,
+    ) -> None:
+        """Record line counts (from the inventory) so coverage % is defined."""
+        entry = self._entry(file)
+        if total_lines is not None:
+            entry["total_lines"] = total_lines
+        if sloc is not None:
+            entry["sloc"] = sloc
+
+    def link_finding(
+        self,
+        file: str,
+        finding_id: str,
+        line: Optional[int] = None,
+        retained: bool = True,
+    ) -> None:
+        """Link a finding to a file.
+
+        ``line`` (when known) lets the finding be attributed to a function
+        for verdict computation. ``retained`` is whether the finding's
+        bulky detail is still on disk; ``/project clean`` flips it to
+        ``False`` when it deletes the only run that held the detail, which
+        turns the function's verdict into ``found_then_lost``. Dedup by id;
+        a later call refreshes ``line``/``retained``.
+        """
+        entry = self._entry(file)
+        for f in entry["findings"]:
+            if f["id"] == finding_id:
+                if line is not None:
+                    f["line"] = line
+                f["retained"] = retained
+                return
+        entry["findings"].append(
+            {"id": finding_id, "line": line, "retained": retained}
+        )
+
+    def stamp_coverage(self, file: str, tool: str, **provenance: Any) -> None:
+        """Attach provenance (engine version / resolved model / timestamp /
+        acquisition target / framework_sha / run) to a ``(file, tool)``
+        contribution — the who/what-version/when that makes a durable
+        coverage entry self-substantiating. Read from the run manifest at
+        import time. Latest stamp wins (a re-examination refreshes it);
+        ``None`` values are dropped so they don't clobber a known value."""
+        entry = self._entry(file)
+        slot = entry["provenance"].setdefault(tool, {})
+        slot.update({k: v for k, v in provenance.items() if v is not None})
+
+    # --- queries (file/line level; inventory-join queries come next step) -
+
+    def tool_provenance(self, file: str, tool: str) -> Dict[str, Any]:
+        """The provenance stamp for a ``(file, tool)`` contribution, or ``{}``."""
+        entry = self._files.get(file)
+        if not entry:
+            return {}
+        return dict(entry.get("provenance", {}).get(tool, {}))
+
+    def provenance_summary(self) -> Dict[str, Any]:
+        """Aggregate provenance across the store for reporting: distinct engine
+        versions per tool, distinct resolved models, and the newest run
+        timestamp seen. ``{}``-ish when nothing is stamped."""
+        tools: Dict[str, set] = {}
+        models: set = set()
+        newest: Optional[str] = None
+        for entry in self._files.values():
+            for tool, p in entry.get("provenance", {}).items():
+                versions = tools.setdefault(tool, set())
+                if p.get("version"):
+                    versions.add(p["version"])
+                for m in p.get("models") or []:
+                    models.add(m)
+                ts = p.get("timestamp")
+                if ts and (newest is None or ts > newest):
+                    newest = ts
+        return {
+            "tools": {t: sorted(vs) for t, vs in sorted(tools.items())},
+            "models": sorted(models),
+            "newest": newest,
+        }
+
+    def who_checked(self, file: str, line: int) -> List[str]:
+        """Tool labels whose intervals cover ``line`` of ``file``."""
+        entry = self._files.get(file)
+        if not entry:
+            return []
+        return sorted(
+            tool for tool, ivs in entry["tools"].items()
+            if any(lo <= line <= hi for lo, hi in ivs)
+        )
+
+    def covered_lines(self, file: str) -> List[Interval]:
+        """Union of all tools' intervals for ``file`` (coalesced)."""
+        entry = self._files.get(file)
+        if not entry:
+            return []
+        return _coalesce(
+            [iv for ivs in entry["tools"].values() for iv in ivs]
+        )
+
+    def file_coverage(self, file: str) -> float:
+        """Percent of ``file``'s lines covered by at least one tool.
+
+        Returns 0.0 when the file is unknown or its ``total_lines`` has
+        not been set from the inventory yet.
+        """
+        entry = self._files.get(file)
+        if not entry or not entry.get("total_lines"):
+            return 0.0
+        return _covered_count(self.covered_lines(file)) / entry["total_lines"] * 100.0
+
+    def finding_ids(self, file: str) -> List[str]:
+        entry = self._files.get(file)
+        return [f["id"] for f in entry["findings"]] if entry else []
+
+    def _findings(self, file: str) -> List[Dict[str, Any]]:
+        entry = self._files.get(file)
+        return entry["findings"] if entry else []
+
+    def files(self) -> List[str]:
+        return sorted(self._files)
+
+    # --- inventory-join queries (function level) --------------------------
+
+    def tool_coverage_of_range(
+        self, file: str, lo: int, hi: int,
+    ) -> Dict[str, int]:
+        """``{tool: covered_line_count}`` over ``[lo, hi]`` (only tools that
+        cover at least one line)."""
+        entry = self._files.get(file)
+        if not entry:
+            return {}
+        out: Dict[str, int] = {}
+        for tool, ivs in entry["tools"].items():
+            n = _overlap_count(ivs, lo, hi)
+            if n:
+                out[tool] = n
+        return out
+
+    def who_checked_function(
+        self, file: str, lo: int, hi: int,
+    ) -> Dict[str, str]:
+        """``{tool: 'full' | 'partial (N%)'}`` for a function's line range."""
+        total = hi - lo + 1
+        if total <= 0:                       # malformed range (hi < lo)
+            return {}
+        out: Dict[str, str] = {}
+        for tool, n in self.tool_coverage_of_range(file, lo, hi).items():
+            out[tool] = "full" if n >= total else f"partial ({n / total * 100:.0f}%)"
+        return out
+
+    def function_covered(
+        self, file: str, lo: int, hi: int, category: Optional[str] = None,
+    ) -> bool:
+        """True if any tool covers a line of ``[lo, hi]``. When ``category``
+        is given, only tools of that category count (e.g. ``"llm"`` -> has
+        any LLM examined this function?)."""
+        for tool in self.tool_coverage_of_range(file, lo, hi):
+            if category is None or category_of(tool) == category:
+                return True
+        return False
+
+    def unchecked_functions(
+        self, checklist: Dict[str, Any], category: Optional[str] = None,
+    ) -> List[Tuple[str, str, int]]:
+        """Inventory functions with no coverage (the gap). When ``category``
+        is given, functions with no coverage *by that category* -- e.g.
+        ``category="llm"`` is the gap ``/audit`` fills. Returns
+        ``[(file, name, line_start)]``."""
+        gaps: List[Tuple[str, str, int]] = []
+        for file, name, lo, hi, _kind in iter_inventory_functions(checklist):
+            # No line_end -> probe the single declaration line.
+            high = hi if hi is not None else lo
+            if not self.function_covered(file, lo, high, category):
+                gaps.append((file, name, lo))
+        return gaps
+
+    def import_inventory_meta(self, checklist: Dict[str, Any]) -> None:
+        """Populate per-file ``total_lines`` / ``sloc`` from the inventory so
+        :meth:`file_coverage` is defined."""
+        for fe in checklist.get("files", []):
+            path = fe.get("path")
+            if path:
+                self.set_file_meta(path, file_line_count(fe), fe.get("sloc"))
+
+    def set_content_id(self, checklist: Dict[str, Any]) -> Optional[str]:
+        """Set the store's content-equivalence id from the inventory (see
+        :func:`content_identity`). Two acquisitions of identical source —
+        a git checkout and a zip — get the same id, so coverage is recognised
+        as being for the same target regardless of how it was acquired."""
+        cid = content_identity(checklist)
+        if cid is not None:
+            self.content_id = cid
+        return self.content_id
+
+    # --- verdict-bearing coverage (the three states) ----------------------
+
+    def function_verdict(self, file: str, lo: int, hi: int) -> str:
+        """One of: ``unexamined`` / ``clean`` / ``open`` / ``found_then_lost``.
+
+        - open:            a finding lands in it and its detail is retained.
+        - found_then_lost: a finding landed in it but its detail was deleted
+                           (the run that held it was cleaned). Kept as a fact;
+                           does NOT count as covered -- it's a re-review gap.
+        - clean:           examined (a tool covered it), no finding lands in it.
+        - unexamined:      no finding and no tool examined the range.
+
+        Findings are checked FIRST: a finding *is* examination evidence (a tool
+        flagged this code), so a function with a finding is never ``unexamined``
+        even if no whole-file coverage record happens to cover its line. The
+        safe direction — surface the finding rather than bury it as a gap.
+
+        Findings linked without a ``line`` can't be attributed to a function,
+        so they don't affect a function verdict (they remain a file-level
+        signal via ``finding_ids``).
+        """
+        in_range = [
+            f for f in self._findings(file)
+            if f.get("line") is not None and lo <= f["line"] <= hi
+        ]
+        if in_range:
+            if any(f.get("retained", True) for f in in_range):
+                return "open"
+            return "found_then_lost"
+        if not self.tool_coverage_of_range(file, lo, hi):
+            return "unexamined"
+        return "clean"
+
+    def function_verdicts(
+        self, checklist: Dict[str, Any],
+    ) -> List[Tuple[str, str, int, str]]:
+        """``(file, name, line_start, verdict)`` for every inventory function."""
+        out: List[Tuple[str, str, int, str]] = []
+        for file, name, lo, hi, _kind in iter_inventory_functions(checklist):
+            high = hi if hi is not None else lo
+            out.append((file, name, lo, self.function_verdict(file, lo, high)))
+        return out
+
+    def review_gap(
+        self, checklist: Dict[str, Any],
+    ) -> List[Tuple[str, str, int, str]]:
+        """Functions needing (re-)review: ``unexamined`` or ``found_then_lost``.
+
+        Returns ``(file, name, line_start, verdict)``. ``found_then_lost`` is
+        the case where a previously-found finding's detail was discarded --
+        surfaced here so it's re-examined rather than silently skipped.
+        """
+        return [
+            row for row in self.function_verdicts(checklist)
+            if row[3] in ("unexamined", "found_then_lost")
+        ]
+
+    # --- persistence ------------------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "generated_at": _now_iso(),
+            "target": self.target,
+            "content_id": self.content_id,
+            "files": self._files,
+        }
+
+    def save(self) -> Path:
+        """Atomically write ``coverage.json`` (tempfile + os.replace)."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(self.to_dict(), indent=2, sort_keys=True)
+        fd, tmp = tempfile.mkstemp(
+            dir=str(self.path.parent), prefix=".coverage-", suffix=".json.tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(payload)
+            os.replace(tmp, self.path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+        return self.path

--- a/core/coverage/store_summary.py
+++ b/core/coverage/store_summary.py
@@ -1,0 +1,261 @@
+"""Durable, category/depth-aware coverage view derived from the store.
+
+This is the dimension the persistent store *adds* to coverage reporting:
+function-level coverage broken down by tool category (static / llm /
+runtime), the gaps (no tool at all; no LLM review), and -- because it
+reads the persistent ``coverage.json`` -- numbers that survive
+``/project clean`` rather than vanishing with the per-run records.
+
+It does NOT replace the record-based per-tool summary in ``summary.py``
+(which carries rules_applied / functions_analysed / files_failed detail
+that lives only in the records). The two are complementary; this view is
+shown alongside.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from .registry import category_of
+from .store import CoverageStore, iter_inventory_functions
+
+_CATEGORIES = ("static", "llm", "runtime")
+
+
+def file_level_view(run_dirs: Iterable[Path]) -> Dict[str, Any]:
+    """File-level coverage for the no-inventory case: per-tool files-examined
+    from the coverage records, plus run provenance from each ``.raptor-run.json``.
+
+    This is the shallowest 'scanned' rung of the depth ladder — derivable from
+    records + manifest alone, so a standalone ``/scan`` or ``/codeql`` (which
+    build no function inventory) still has a coverage story. No percentages: a
+    scanner's ``files_examined`` is a filtered subset and there's no inventory
+    to give a denominator, so this reports absolute counts, not a fraction of
+    the codebase. (For a stable *codebase* identity — content_id — a full
+    source-tree hash is needed; that's a /cite concern, not this view.)
+    """
+    from core.run.metadata import load_run_metadata
+    from core.run.provenance import run_target, run_timestamp
+
+    from .record import load_records
+
+    tools: Dict[str, Dict[str, Any]] = {}
+    runs: List[Dict[str, Any]] = []
+    for rd in run_dirs:
+        rd = Path(rd)
+        md = load_run_metadata(rd)
+        if md:
+            runs.append({
+                "run": rd.name,
+                "command": md.get("command"),
+                "status": md.get("status"),
+                "timestamp": run_timestamp(md),
+                "target": run_target(md),
+            })
+        for rec in load_records(rd):
+            tool = rec.get("tool")
+            if not tool:
+                continue
+            t = tools.setdefault(
+                tool, {"files": set(), "versions": set(), "rules": set(), "newest": None}
+            )
+            t["files"].update(rec.get("files_examined", []) or [])
+            if rec.get("version"):
+                t["versions"].add(rec["version"])
+            t["rules"].update(rec.get("rules_applied", []) or [])
+            ts = rec.get("timestamp")
+            if ts and (t["newest"] is None or ts > t["newest"]):
+                t["newest"] = ts
+    return {
+        "tools": {
+            k: {
+                "files": sorted(v["files"]),
+                "versions": sorted(v["versions"]),
+                "rules": sorted(v["rules"]),
+                "newest": v["newest"],
+            }
+            for k, v in sorted(tools.items())
+        },
+        "runs": runs,
+    }
+
+
+def render_run_coverage(run_dir) -> "str | None":
+    """Build and format a single run's coverage view on-demand, or None if
+    there's nothing to show. Store view (category/depth + verdicts) when the run
+    has an inventory (checklist.json — possibly a symlink to the project one);
+    the file-level tier otherwise. Used to print a coverage summary at the end
+    of a run (e.g. /agentic). Read-only — does not persist."""
+    from core.json import load_json
+
+    from .importer import backfill
+    from .store import CoverageStore
+
+    run = Path(run_dir)
+    checklist = load_json(run / "checklist.json")
+    if checklist:
+        store = CoverageStore(run / "coverage.json")  # fresh; backfill fills it
+        backfill(store, [run], checklist)
+        return format_store_view(store_view(store, checklist))
+    view = file_level_view([run])
+    if view.get("tools") or view.get("runs"):
+        return format_file_level_view(view)
+    return None
+
+
+def format_file_level_view(view: Dict[str, Any], max_files: int = 20) -> str:
+    """Render :func:`file_level_view` as an operator-facing section."""
+    lines = ["Coverage (file-level — no function inventory)"]
+    runs = view.get("runs") or []
+    if runs:
+        lines.append(f"  Runs: {len(runs)}")
+        for r in runs:
+            tgt = r.get("target")
+            tgt = tgt.get("source") if isinstance(tgt, dict) else tgt
+            lines.append(
+                f"    {r.get('command')} / {r.get('status')} / "
+                f"{r.get('timestamp')} / target: {tgt}"
+            )
+    tools = view.get("tools") or {}
+    if not tools:
+        lines.append("  (no coverage records found)")
+    for tool, info in tools.items():
+        ver = ", ".join(info["versions"]) or "?"
+        rules = f"  (rules: {', '.join(info['rules'])})" if info["rules"] else ""
+        lines.append(f"  {tool} {ver}: {len(info['files'])} file(s) examined{rules}")
+        for f in info["files"][:max_files]:
+            lines.append(f"    {f}")
+        if len(info["files"]) > max_files:
+            lines.append(f"    … (+{len(info['files']) - max_files} more)")
+    return "\n".join(lines)
+
+
+def store_view(store: CoverageStore, checklist: Dict[str, Any]) -> Dict[str, Any]:
+    """Function-level coverage rollup from the store, against the inventory.
+
+    One store query per inventory function. Returns a JSON-friendly dict.
+    """
+    total = 0
+    covered_any = 0
+    by_category = {c: 0 for c in _CATEGORIES}
+    by_kind: Dict[str, int] = {}
+    llm_gap: List[Dict[str, Any]] = []
+    total_gap = 0
+    verdicts = {"clean": 0, "open": 0, "found_then_lost": 0, "unexamined": 0}
+    review_gap: List[Dict[str, Any]] = []
+
+    for file, name, lo, hi, kind in iter_inventory_functions(checklist):
+        total += 1
+        by_kind[kind] = by_kind.get(kind, 0) + 1
+        high = hi if hi is not None else lo
+        cov = store.tool_coverage_of_range(file, lo, high)
+        cats = {category_of(tool) for tool in cov}
+        verdict = store.function_verdict(file, lo, high)
+        # "Examined" tracks the verdict, not just coverage marks: a finding is
+        # itself examination evidence (see function_verdict), so an open /
+        # found_then_lost function counts as examined and is NOT a "no tool"
+        # gap — otherwise the report self-contradicts ("open findings: 1" while
+        # the same function shows under "no tool at all"). by_category stays
+        # mark-based: it reports tool-category *extent*, which a finding alone
+        # doesn't establish.
+        if verdict == "unexamined":
+            total_gap += 1
+        else:
+            covered_any += 1
+        for c in _CATEGORIES:
+            if c in cats:
+                by_category[c] += 1
+        # Interstitial counts toward completeness (total/by_kind/examined/
+        # verdicts) but is kept OUT of the actionable gap *listings*: it's
+        # non-function glue (includes, top-level lines) that whole-file scanners
+        # cover and that the LLM doesn't review unit-by-unit — listing every
+        # file's interstitial would drown the real function gaps.
+        is_interstitial = kind == "interstitial"
+        if "llm" not in cats and not is_interstitial:
+            llm_gap.append({"file": file, "function": name, "line": lo})
+
+        verdicts[verdict] = verdicts.get(verdict, 0) + 1
+        # The re-review gap: never examined, or found-then-lost (functions only).
+        if verdict in ("unexamined", "found_then_lost") and not is_interstitial:
+            review_gap.append(
+                {"file": file, "function": name, "line": lo, "verdict": verdict}
+            )
+
+    return {
+        "target": store.target,
+        "content_id": store.content_id,
+        "total_functions": total,        # all items (kept name for compatibility)
+        "items_by_kind": by_kind,
+        "functions_covered": covered_any,
+        "functions_by_category": by_category,
+        "gap_no_tool": total_gap,
+        "gap_no_llm": len(llm_gap),
+        "llm_gap_functions": llm_gap,
+        "verdicts": verdicts,
+        "review_gap": review_gap,
+        "provenance": store.provenance_summary(),
+    }
+
+
+def _pct(n: int, total: int) -> float:
+    return (n / total * 100.0) if total else 0.0
+
+
+def format_store_view(view: Dict[str, Any], max_gap: int = 15) -> str:
+    """Render :func:`store_view` output as an operator-facing section."""
+    total = view["total_functions"]
+    target_label = view.get("target") or view.get("content_id") or "unknown"
+    by_kind = view.get("items_by_kind") or {}
+    kind_str = ", ".join(f"{k} {n}" for k, n in sorted(by_kind.items())) if by_kind else ""
+    lines = [
+        f"Coverage (persistent store) — target {target_label}",
+        f"  Items: {total} total" + (f"  ({kind_str})" if kind_str else ""),
+        f"    examined (any tool): {view['functions_covered']} "
+        f"({_pct(view['functions_covered'], total):.1f}%)",
+        "    by category:",
+    ]
+    for cat in _CATEGORIES:
+        n = view["functions_by_category"][cat]
+        lines.append(f"      {cat:<8} {n:>5} ({_pct(n, total):.1f}%)")
+    v = view.get("verdicts")
+    if v:
+        lines.append("  Verdict:")
+        lines.append(f"    clean:           {v.get('clean', 0)}")
+        lines.append(f"    open findings:   {v.get('open', 0)}")
+        lines.append(f"    found-then-lost: {v.get('found_then_lost', 0)}  (re-examine)")
+        lines.append(f"    unexamined:      {v.get('unexamined', 0)}")
+
+    lines.append("  Gaps:")
+    lines.append(f"    no tool at all: {view['gap_no_tool']}")
+    lines.append(f"    no LLM review:  {view['gap_no_llm']}")
+
+    # Found-then-lost is the one to flag loudly: a prior finding's detail was
+    # discarded, so re-examine rather than trust "covered".
+    ftl = [g for g in view.get("review_gap", []) if g.get("verdict") == "found_then_lost"]
+    if ftl:
+        shown = ftl[:max_gap]
+        lines.append(f"  Found-then-lost — detail discarded, re-examine "
+                     f"(first {len(shown)} of {len(ftl)}):")
+        for g in shown:
+            lines.append(f"    {g['file']}:{g['function']} @ {g['line']}")
+
+    gap = view["llm_gap_functions"]
+    if gap:
+        shown = gap[:max_gap]
+        lines.append(f"  LLM-review gap (first {len(shown)} of {len(gap)}):")
+        for g in shown:
+            lines.append(f"    {g['file']}:{g['function']} @ {g['line']}")
+
+    prov = view.get("provenance") or {}
+    tools = {t: vs for t, vs in (prov.get("tools") or {}).items()}
+    if tools or prov.get("models") or prov.get("newest"):
+        lines.append("  Provenance:")
+        for tool, versions in tools.items():
+            ver = ", ".join(versions) if versions else "(version unrecorded)"
+            lines.append(f"    {tool}: {ver}")
+        if prov.get("models"):
+            lines.append(f"    llm models: {', '.join(prov['models'])}")
+        if prov.get("newest"):
+            lines.append(f"    newest run: {prov['newest']}")
+    return "\n".join(lines)

--- a/core/coverage/tests/test_annotations_import.py
+++ b/core/coverage/tests/test_annotations_import.py
@@ -1,0 +1,79 @@
+"""Tests for importing durable annotations as llm-category coverage."""
+
+from __future__ import annotations
+
+from core.annotations.models import Annotation
+from core.annotations.storage import write_annotation
+from core.coverage.importer import import_annotations
+from core.coverage.store import CoverageStore
+
+_CHECKLIST = {
+    "files": [
+        {"path": "a.c", "total_lines": 100, "items": [
+            {"name": "f1", "line_start": 0, "line_end": 20},
+            {"name": "f2", "line_start": 30, "line_end": 60},
+        ]},
+        {"path": "b.c", "total_lines": 50, "functions": [
+            {"name": "g1", "line_start": 0, "line_end": 10},
+        ]},
+    ],
+}
+
+
+def _store(tmp_path):
+    return CoverageStore(tmp_path / "coverage.json", target="zip:abc")
+
+
+def _ann(base, file, function, status, source="llm"):
+    write_annotation(
+        base,
+        Annotation(file=file, function=function, body="note",
+                   metadata={"status": status, "source": source}),
+    )
+
+
+def test_clean_annotation_becomes_llm_coverage(tmp_path):
+    base = tmp_path / "annotations"
+    _ann(base, "a.c", "f1", "clean")
+    s = _store(tmp_path)
+    n = import_annotations(s, base, _CHECKLIST)
+    assert n == 1
+    # f1 now llm-examined over its inventory range, verdict clean.
+    assert "annotations" in s.tool_coverage_of_range("a.c", 0, 20)
+    assert s.function_verdict("a.c", 0, 20) == "clean"
+
+
+def test_finding_annotation_links_finding_open(tmp_path):
+    base = tmp_path / "annotations"
+    _ann(base, "a.c", "f2", "finding")
+    _ann(base, "b.c", "g1", "suspicious")
+    s = _store(tmp_path)
+    import_annotations(s, base, _CHECKLIST)
+    assert s.function_verdict("a.c", 30, 60) == "open"
+    assert s.function_verdict("b.c", 0, 10) == "open"
+
+
+def test_annotation_for_unknown_function_is_skipped(tmp_path):
+    base = tmp_path / "annotations"
+    _ann(base, "a.c", "nonexistent", "clean")
+    s = _store(tmp_path)
+    # No inventory range and no lines metadata -> skipped.
+    assert import_annotations(s, base, _CHECKLIST) == 0
+
+
+def test_lines_metadata_fallback(tmp_path):
+    base = tmp_path / "annotations"
+    write_annotation(
+        base,
+        Annotation(file="c.c", function="h", body="",
+                   metadata={"status": "clean", "source": "llm", "lines": "5-9"}),
+    )
+    s = _store(tmp_path)
+    # c.c not in the checklist -> falls back to the lines metadata.
+    assert import_annotations(s, base, _CHECKLIST) == 1
+    assert "annotations" in s.tool_coverage_of_range("c.c", 5, 9)
+
+
+def test_missing_base_dir_is_noop(tmp_path):
+    s = _store(tmp_path)
+    assert import_annotations(s, tmp_path / "nope", _CHECKLIST) == 0

--- a/core/coverage/tests/test_clean.py
+++ b/core/coverage/tests/test_clean.py
@@ -1,0 +1,163 @@
+"""Tests for coverage-aware /project clean (snapshot + classify + retained flip)."""
+
+from __future__ import annotations
+
+import json
+
+from core.coverage.clean import (
+    apply_removal,
+    classify_removal,
+    clean_run,
+    dedup_runs,
+    format_consequence,
+)
+from core.coverage.store import CoverageStore
+
+_CHECKLIST = {
+    "files": [
+        {"path": "a.c", "total_lines": 100, "items": [
+            {"name": "f1", "line_start": 0, "line_end": 20},
+            {"name": "f2", "line_start": 30, "line_end": 60},
+        ]},
+    ],
+}
+
+
+def _store(tmp_path):
+    return CoverageStore(tmp_path / "coverage.json", target="zip:abc")
+
+
+def _run(tmp_path, name, files_examined, findings=None):
+    d = tmp_path / name
+    d.mkdir()
+    (d / "coverage-semgrep.json").write_text(json.dumps(
+        {"tool": "semgrep", "files_examined": files_examined, "timestamp": "t"}))
+    if findings is not None:
+        (d / "findings.json").write_text(json.dumps(findings))
+    return d
+
+
+def test_duplicate_run_is_free(tmp_path):
+    s = _store(tmp_path)
+    victim = _run(tmp_path, "old", ["a.c"], findings=[])
+    survivor = _run(tmp_path, "new", ["a.c"], findings=[])
+    c = clean_run(s, victim, [survivor], _CHECKLIST)
+    assert c.duplicate is True and c.lossy is False
+    assert "free to remove" in format_consequence(c)
+
+
+def test_sole_source_clean_coverage_preserved(tmp_path):
+    s = _store(tmp_path)
+    # victim examined a.c clean; no survivor examined it.
+    victim = _run(tmp_path, "old", ["a.c"], findings=[])
+    c = clean_run(s, victim, [], _CHECKLIST)
+    assert c.duplicate is False and c.lossy is False
+    # Coverage snapshotted -> f1/f2 are now examined-clean in the store.
+    assert s.function_verdict("a.c", 0, 20) == "clean"
+    assert "preserved into the store" in format_consequence(c)
+
+
+def test_sole_source_finding_becomes_found_then_lost(tmp_path):
+    s = _store(tmp_path)
+    victim = _run(tmp_path, "old", ["a.c"],
+                  findings=[{"id": "F1", "file": "a.c", "line": 42}])  # in f2
+    c = clean_run(s, victim, [], _CHECKLIST)
+    assert c.lossy is True and len(c.findings_lost) == 1
+    assert s.function_verdict("a.c", 30, 60) == "found_then_lost"
+    assert "re-review gaps" in format_consequence(c)
+
+
+def test_classify_is_read_only_then_apply_mutates(tmp_path):
+    # classify needs no store and doesn't touch one; apply does the snapshot.
+    victim = _run(tmp_path, "old", ["a.c"],
+                  findings=[{"id": "F1", "file": "a.c", "line": 42}])
+    c = classify_removal(victim, [])
+    assert c.lossy is True
+    s = _store(tmp_path)
+    assert s.function_verdict("a.c", 30, 60) == "unexamined"   # untouched by classify
+    apply_removal(s, victim, _CHECKLIST, c)
+    assert s.function_verdict("a.c", 30, 60) == "found_then_lost"
+
+
+def test_finding_also_in_survivor_stays_open(tmp_path):
+    s = _store(tmp_path)
+    finding = [{"id": "F1", "file": "a.c", "line": 42}]
+    victim = _run(tmp_path, "old", ["a.c"], findings=finding)
+    survivor = _run(tmp_path, "new", ["a.c"], findings=finding)  # same location
+    c = clean_run(s, victim, [survivor], _CHECKLIST)
+    assert c.findings_lost == []          # survivor still holds it
+    assert s.function_verdict("a.c", 30, 60) == "open"
+    assert c.duplicate is True            # same files + same findings
+
+
+def test_dedup_drops_older_identical_keeps_newest(tmp_path):
+    # Three identical runs (name order = chronological): drop the two older.
+    a = _run(tmp_path, "run-01", ["a.c"], findings=[])
+    b = _run(tmp_path, "run-02", ["a.c"], findings=[])
+    c = _run(tmp_path, "run-03", ["a.c"], findings=[])
+    droppable, reasons = dedup_runs([c, a, b])   # order-insensitive
+    assert set(d.name for d in droppable) == {"run-01", "run-02"}
+    assert all(r.duplicate for r in reasons)
+
+
+def test_dedup_keeps_run_with_unique_findings(tmp_path):
+    # run-01 holds a finding; run-02 (same files, no findings) adds nothing ->
+    # run-02 is the droppable one, the finding-bearing run is kept.
+    a = _run(tmp_path, "run-01", ["a.c"],
+             findings=[{"id": "F1", "file": "a.c", "line": 42}])
+    b = _run(tmp_path, "run-02", ["a.c"], findings=[])
+    droppable, _ = dedup_runs([a, b])
+    assert [d.name for d in droppable] == ["run-02"]
+
+
+def test_dedup_keeps_both_when_each_has_a_unique_finding(tmp_path):
+    a = _run(tmp_path, "run-01", ["a.c"],
+             findings=[{"id": "F1", "file": "a.c", "line": 42}])
+    b = _run(tmp_path, "run-02", ["a.c"],
+             findings=[{"id": "F2", "file": "a.c", "line": 10}])
+    droppable, _ = dedup_runs([a, b])
+    assert droppable == []                       # neither subsumes the other
+
+
+def test_dedup_keeps_run_with_unique_coverage(tmp_path):
+    a = _run(tmp_path, "run-01", ["a.c", "b.c"], findings=[])
+    b = _run(tmp_path, "run-02", ["a.c"], findings=[])
+    droppable, _ = dedup_runs([a, b])
+    # run-02's files (a.c) ⊆ run-01's -> run-02 droppable; run-01 has unique b.c.
+    assert [d.name for d in droppable] == ["run-02"]
+
+
+def test_dedup_single_run_kept(tmp_path):
+    a = _run(tmp_path, "run-01", ["a.c"], findings=[])
+    assert dedup_runs([a]) == ([], [])
+
+
+def test_distinct_findings_same_line_not_collapsed(tmp_path):
+    # Two different issues at a.c:42; the survivor holds only one. Without an
+    # issue discriminator both key as (a.c, L42), so xss would look "covered"
+    # by the survivor's sqli and be silently lost. It must be flagged lost.
+    victim = _run(tmp_path, "old", ["a.c"], findings=[
+        {"file": "a.c", "line": 42, "rule_id": "sqli"},
+        {"file": "a.c", "line": 42, "rule_id": "xss"}])
+    survivor = _run(tmp_path, "new", ["a.c"], findings=[
+        {"file": "a.c", "line": 42, "rule_id": "sqli"}])
+    c = classify_removal(victim, [survivor])
+    assert c.lossy is True and len(c.findings_lost) == 1
+
+
+def test_idless_finding_flip_targets_same_entry(tmp_path):
+    # Backfill links findings retained=True; a clean snapshot must FLIP the
+    # same entries to retained=False, not append duplicates. The index-1
+    # finding is the regression: a position-dependent fallback id gave it a
+    # different id across the two link paths, leaving a stale retained=True
+    # entry that kept the verdict 'open' instead of 'found_then_lost'.
+    from core.coverage.importer import import_run_dir, import_run_findings
+    s = _store(tmp_path)
+    victim = _run(tmp_path, "old", ["a.c"], findings=[
+        {"file": "a.c", "line": 10, "rule_id": "a"},    # f1 (0-20), index 0
+        {"file": "a.c", "line": 42, "rule_id": "b"}])   # f2 (30-60), index 1
+    import_run_dir(s, victim, _CHECKLIST)
+    import_run_findings(s, victim)                       # retained=True (backfill)
+    clean_run(s, victim, [], _CHECKLIST)                 # apply: flip to retained=False
+    assert s.function_verdict("a.c", 0, 20) == "found_then_lost"
+    assert s.function_verdict("a.c", 30, 60) == "found_then_lost"

--- a/core/coverage/tests/test_content_identity.py
+++ b/core/coverage/tests/test_content_identity.py
@@ -1,0 +1,54 @@
+"""Tests for the content-equivalence id (Phase 3, step e2): git-X ≡ zip-X
+derived from the inventory's {relpath -> sha256} set."""
+
+from __future__ import annotations
+
+from core.coverage.store import CoverageStore, content_identity
+
+
+def _checklist(files):
+    """files: list of (path, sha256)."""
+    return {"files": [{"path": p, "sha256": s, "total_lines": 10} for p, s in files]}
+
+
+def test_same_content_same_id_regardless_of_order():
+    a = _checklist([("a.c", "h1"), ("b.c", "h2")])
+    b = _checklist([("b.c", "h2"), ("a.c", "h1")])      # different file order
+    assert content_identity(a) == content_identity(b)
+    assert content_identity(a).startswith("content:")
+
+
+def test_git_checkout_and_zip_of_same_source_match():
+    # The acquisition differs (git vs zip) but the analyzed file set + content
+    # SHAs are identical -> same content id. This is the git-X ≡ zip-X property.
+    git_inv = _checklist([("src/main.c", "aaa"), ("src/util.c", "bbb")])
+    zip_inv = _checklist([("src/main.c", "aaa"), ("src/util.c", "bbb")])
+    assert content_identity(git_inv) == content_identity(zip_inv)
+
+
+def test_different_content_different_id():
+    base = _checklist([("a.c", "h1"), ("b.c", "h2")])
+    changed = _checklist([("a.c", "h1"), ("b.c", "DIFFERENT")])   # b.c edited
+    added = _checklist([("a.c", "h1"), ("b.c", "h2"), ("c.c", "h3")])  # extra file
+    assert content_identity(base) != content_identity(changed)
+    assert content_identity(base) != content_identity(added)
+
+
+def test_empty_inventory_is_none():
+    assert content_identity({"files": []}) is None
+    assert content_identity({}) is None
+
+
+def test_files_without_sha_are_ignored():
+    # Only analyzed files with a content SHA contribute.
+    a = _checklist([("a.c", "h1")])
+    b = {"files": [{"path": "a.c", "sha256": "h1"}, {"path": "gen.c"}]}  # no sha
+    assert content_identity(a) == content_identity(b)
+
+
+def test_store_records_and_persists_content_id(tmp_path):
+    s = CoverageStore(tmp_path / "coverage.json")
+    cid = s.set_content_id(_checklist([("a.c", "h1")]))
+    assert cid and cid.startswith("content:")
+    s.save()
+    assert CoverageStore(tmp_path / "coverage.json").content_id == cid

--- a/core/coverage/tests/test_importer.py
+++ b/core/coverage/tests/test_importer.py
@@ -1,0 +1,188 @@
+"""Tests for the Phase 3 backfill importer (per-run records + checked_by)."""
+
+from __future__ import annotations
+
+import json
+
+from core.coverage.importer import (
+    backfill,
+    import_checked_by,
+    import_findings,
+    import_record,
+    import_run_dir,
+)
+from core.coverage.store import CoverageStore
+
+
+def _store(tmp_path):
+    return CoverageStore(tmp_path / "coverage.json", target="zip:abc")
+
+
+_CHECKLIST = {
+    "files": [
+        {"path": "a.c", "total_lines": 100, "items": [
+            {"name": "f1", "line_start": 0, "line_end": 20},
+            {"name": "f2", "line_start": 30, "line_end": 60,
+             "checked_by": ["validate:stage-a"]},
+        ]},
+        {"path": "b.c", "total_lines": 50, "functions": [
+            {"name": "g1", "line_start": 0, "line_end": 10},
+        ]},
+    ],
+}
+
+
+def test_import_checked_by_is_function_level_and_llm(tmp_path):
+    s = _store(tmp_path)
+    assert import_checked_by(s, _CHECKLIST) == 1     # only f2 has checked_by
+    assert s.who_checked_function("a.c", 30, 60) == {"validate:stage-a": "full"}
+    # validate:* classifies as llm, so f2 is NOT an llm gap; f1/g1 are.
+    assert s.function_covered("a.c", 30, 60, category="llm") is True
+
+
+def test_import_record_is_whole_file_and_skips_unknown(tmp_path):
+    s = _store(tmp_path)
+    tl = {"a.c": 100}
+    rec = {"tool": "semgrep", "files_examined": ["a.c", "vendor/x.c"]}
+    assert import_record(s, rec, tl) == 1            # a.c marked; vendor/x.c skipped (no extent)
+    assert s.who_checked("a.c", 50) == ["semgrep"]
+    assert s.who_checked("a.c", 99) == ["semgrep"]   # whole file [0, 99]
+    assert s.who_checked("vendor/x.c", 0) == []
+
+
+def test_load_run_findings_discovers_validation_excludes_sca(tmp_path):
+    from core.coverage.importer import load_run_findings
+
+    run = tmp_path / "agentic-1"
+    (run / "validation").mkdir(parents=True)
+    (run / "sca").mkdir()
+    # agentic's validated code findings live under validation/
+    (run / "validation" / "findings.json").write_text(json.dumps(
+        {"findings": [{"id": "SARIF-0", "file": "/tmp/clone/parse.c", "line": 5}]}))
+    # SCA (dependency-class) findings must NOT be pulled into source-function
+    # coverage — they don't map to a function range.
+    (run / "sca" / "findings.json").write_text(json.dumps(
+        [{"finding_id": "CVE-2021-1", "file_path": "requirements.txt", "line": 3}]))
+    found = load_run_findings(run)
+    ids = {f.get("id") or f.get("finding_id") for f in found}
+    assert "SARIF-0" in ids
+    assert "CVE-2021-1" not in ids        # sca excluded by design
+
+
+def test_absolute_scanner_paths_join_to_relative_inventory(tmp_path):
+    # Regression: real scanners (semgrep) emit ABSOLUTE files_examined paths,
+    # while the inventory keys on target-relative paths. Without normalisation
+    # the join misses every file -> 0 marks. Findings carry absolute paths too.
+    s = _store(tmp_path)
+    checklist = {"files": [
+        {"path": "src/auth.py", "lines": 40, "items": [
+            {"name": "f1", "line_start": 1, "line_end": 20}]},
+    ]}
+    run = tmp_path / "scan-1"
+    run.mkdir()
+    (run / "coverage-semgrep.json").write_text(json.dumps({
+        "tool": "semgrep",
+        "files_examined": ["/abs/target/src/auth.py"],     # absolute
+        "timestamp": "t"}))
+    (run / "findings.json").write_text(json.dumps(
+        [{"id": "SG1", "file": "/abs/target/src/auth.py", "line": 10}]))
+    backfill(s, [run], checklist)
+    assert s.who_checked("src/auth.py", 10) == ["semgrep"]          # joined
+    assert s.function_verdict("src/auth.py", 1, 20) == "open"        # finding joined too
+
+
+def test_file_level_coverage_uses_real_inventory_lines_field(tmp_path):
+    # Regression: the inventory emits per-file `lines`, not `total_lines`
+    # (the latter only appears in hand-built test checklists). Reading the
+    # wrong key silently drops ALL file-level scanner coverage — caught only
+    # against a real checklist. backfill must place whole-file marks here.
+    s = _store(tmp_path)
+    checklist = {"files": [
+        {"path": "a.c", "lines": 40, "sloc": 30, "items": [
+            {"name": "f1", "line_start": 0, "line_end": 20}]},
+    ]}
+    run = tmp_path / "scan-1"
+    run.mkdir()
+    (run / "coverage-semgrep.json").write_text(json.dumps(
+        {"tool": "semgrep", "files_examined": ["a.c"], "timestamp": "t"}))
+    (run / "findings.json").write_text("[]")
+    backfill(s, [run], checklist)
+    assert s.who_checked("a.c", 10) == ["semgrep"]    # whole file marked
+    # 1-based: the last inventory line (tl) is covered; phantom line 0 is not.
+    assert s.who_checked("a.c", 40) == ["semgrep"]
+    assert s.who_checked("a.c", 0) == []
+    assert s.function_covered("a.c", 1, 20, category="static") is True
+
+
+def test_import_run_dir_reads_per_tool_records(tmp_path):
+    s = _store(tmp_path)
+    run = tmp_path / "scan-1"
+    run.mkdir()
+    (run / "coverage-semgrep.json").write_text(json.dumps(
+        {"tool": "semgrep", "files_examined": ["a.c"], "timestamp": "t"}))
+    (run / "coverage-codeql.json").write_text(json.dumps(
+        {"tool": "codeql", "files_examined": ["b.c"], "timestamp": "t"}))
+    assert import_run_dir(s, run, _CHECKLIST) == 2
+    assert s.who_checked("a.c", 10) == ["semgrep"]
+    assert s.who_checked("b.c", 5) == ["codeql"]
+
+
+def test_import_findings_sets_open_verdict(tmp_path):
+    s = _store(tmp_path)
+    s.mark("a.c", 30, 60, "semgrep")         # f2 examined
+    findings = [
+        {"id": "F1", "file": "a.c", "line": 42},          # in f2
+        {"file_path": "a.c", "start_line": 5},            # variant field names
+        {"note": "no file"},                              # skipped
+    ]
+    assert import_findings(s, findings) == 2
+    assert s.function_verdict("a.c", 30, 60) == "open"    # retained by default
+
+
+def test_import_findings_retained_false_is_found_then_lost(tmp_path):
+    s = _store(tmp_path)
+    s.mark("a.c", 30, 60, "semgrep")
+    import_findings(s, [{"id": "F1", "file": "a.c", "line": 42}], retained=False)
+    assert s.function_verdict("a.c", 30, 60) == "found_then_lost"
+
+
+def test_backfill_imports_findings_for_verdict(tmp_path):
+    s = _store(tmp_path)
+    run = tmp_path / "scan-1"
+    run.mkdir()
+    (run / "coverage-semgrep.json").write_text(json.dumps(
+        {"tool": "semgrep", "files_examined": ["a.c"], "timestamp": "t"}))
+    (run / "findings.json").write_text(json.dumps(
+        [{"id": "F1", "file": "a.c", "line": 42}]))      # lands in f2 [30,60]
+    backfill(s, [run], _CHECKLIST)
+    assert s.function_verdict("a.c", 30, 60) == "open"   # f2 has a retained finding
+    assert s.function_verdict("a.c", 0, 20) == "clean"   # f1 examined, no finding
+
+
+def test_backfill_unions_checked_by_and_records_then_gap(tmp_path):
+    s = _store(tmp_path)
+    run = tmp_path / "scan-1"
+    run.mkdir()
+    (run / "coverage-semgrep.json").write_text(json.dumps(
+        {"tool": "semgrep", "files_examined": ["a.c", "b.c"], "timestamp": "t"}))
+
+    marks = backfill(s, [run], _CHECKLIST)
+    assert marks == 3        # 1 checked_by (f2) + 2 record files (a.c, b.c)
+
+    # file-level meta imported -> coverage % defined.
+    assert s.file_coverage("a.c") == 100.0    # semgrep marked whole file
+
+    # The /audit gap: f2 was LLM-reviewed (validate); f1 and g1 only have
+    # static (semgrep) coverage -> they ARE the llm gap.
+    assert s.unchecked_functions(_CHECKLIST, category="llm") == [
+        ("a.c", "f1", 0),
+        ("b.c", "g1", 0),
+    ]
+    # Nothing is a *total* gap -- semgrep touched every file.
+    assert s.unchecked_functions(_CHECKLIST) == []
+
+    # Persists.
+    s.save()
+    assert CoverageStore(tmp_path / "coverage.json").who_checked("a.c", 40) == [
+        "semgrep", "validate:stage-a",
+    ]

--- a/core/coverage/tests/test_provenance_feed.py
+++ b/core/coverage/tests/test_provenance_feed.py
@@ -1,0 +1,85 @@
+"""Tests for the provenance feed (Phase 3, step e): stamping coverage with
+who/what-version/when from a run's .raptor-run.json manifest."""
+
+from __future__ import annotations
+
+import json
+
+from core.coverage.importer import backfill, run_provenance
+from core.coverage.store import CoverageStore
+
+_CHECKLIST = {
+    "files": [
+        {"path": "a.c", "total_lines": 100, "items": [
+            {"name": "f1", "line_start": 0, "line_end": 20},
+        ]},
+    ],
+}
+
+_MANIFEST = {
+    "timestamp": "2026-05-26T10:00:00Z",
+    "manifest": {
+        "engines": {"semgrep": "1.67.0"},
+        "models": [{"provider": "google", "alias": "gemini-2.5-pro",
+                    "resolved": "gemini-2.5-pro-002", "role": "analysis"}],
+        "target": {"source": "archive", "archive_sha256": "abc123",
+                   "archive_name": "proj.zip"},
+        "source_control": {"base_sha": "deadbeef"},
+        "deterministically_reproducible": True,
+    },
+}
+
+
+def _run(tmp_path, name, tool, files, manifest=None):
+    d = tmp_path / name
+    d.mkdir()
+    (d / f"coverage-{tool}.json").write_text(json.dumps(
+        {"tool": tool, "files_examined": files, "timestamp": "t"}))
+    if manifest is not None:
+        (d / ".raptor-run.json").write_text(json.dumps(manifest))
+    return d
+
+
+def test_run_provenance_reads_manifest(tmp_path):
+    run = _run(tmp_path, "scan-1", "semgrep", ["a.c"], manifest=_MANIFEST)
+    prov = run_provenance(run)
+    assert prov["engines"] == {"semgrep": "1.67.0"}
+    assert prov["models"] == ["gemini-2.5-pro-002"]      # resolved snapshot
+    assert prov["timestamp"] == "2026-05-26T10:00:00Z"
+    assert prov["target"]["source"] == "archive"
+    assert prov["framework_sha"] == "deadbeef"
+
+
+def test_no_manifest_degrades_gracefully(tmp_path):
+    run = _run(tmp_path, "scan-1", "semgrep", ["a.c"])   # no .raptor-run.json
+    assert run_provenance(run) == {}
+
+
+def test_scanner_coverage_stamped_with_engine_version(tmp_path):
+    s = CoverageStore(tmp_path / "coverage.json")
+    run = _run(tmp_path, "scan-1", "semgrep", ["a.c"], manifest=_MANIFEST)
+    backfill(s, [run], _CHECKLIST)
+    p = s.tool_provenance("a.c", "semgrep")
+    assert p["version"] == "1.67.0"                      # engine version
+    assert p["timestamp"] == "2026-05-26T10:00:00Z"
+    assert p["target"]["source"] == "archive"
+    assert p["framework_sha"] == "deadbeef"
+    assert "models" not in p                             # scanner -> no model
+
+
+def test_llm_coverage_stamped_with_resolved_model(tmp_path):
+    s = CoverageStore(tmp_path / "coverage.json")
+    run = _run(tmp_path, "agentic-1", "llm", ["a.c"], manifest=_MANIFEST)
+    backfill(s, [run], _CHECKLIST)
+    p = s.tool_provenance("a.c", "llm")
+    assert p["models"] == ["gemini-2.5-pro-002"]         # resolved model = scorecard hook
+    assert p["timestamp"] == "2026-05-26T10:00:00Z"
+    assert "version" not in p                            # llm tool not in engines
+
+
+def test_unstamped_when_no_manifest(tmp_path):
+    s = CoverageStore(tmp_path / "coverage.json")
+    run = _run(tmp_path, "scan-1", "semgrep", ["a.c"])   # no manifest
+    backfill(s, [run], _CHECKLIST)
+    assert s.who_checked("a.c", 5) == ["semgrep"]        # coverage still recorded
+    assert s.tool_provenance("a.c", "semgrep") == {}     # just no provenance

--- a/core/coverage/tests/test_record.py
+++ b/core/coverage/tests/test_record.py
@@ -330,6 +330,32 @@ class TestWriteAndLoad(unittest.TestCase):
             tools = {r["tool"] for r in records}
             self.assertEqual(tools, {"semgrep", "codeql", "llm"})
 
+    def test_load_records_finds_tool_subdirs(self):
+        # Agentic writes scanner records into scan/ and codeql into codeql/.
+        # load_records must find records in immediate tool subdirs, not only
+        # at the top level.
+        with TemporaryDirectory() as d:
+            run = Path(d)
+            (run / "scan").mkdir()
+            write_record(run / "scan", {"tool": "semgrep"}, tool_name="semgrep")
+            write_record(run / "scan", {"tool": "coccinelle"}, tool_name="coccinelle")
+            write_record(run, {"tool": "codeql"}, tool_name="codeql")  # top level
+            tools = {r["tool"] for r in load_records(run)}
+            self.assertEqual(tools, {"semgrep", "coccinelle", "codeql"})
+
+    def test_load_records_dedups_tool_across_top_and_subdir(self):
+        with TemporaryDirectory() as d:
+            run = Path(d)
+            (run / "codeql").mkdir()
+            write_record(run, {"tool": "codeql", "files_examined": ["top.c"]},
+                         tool_name="codeql")
+            write_record(run / "codeql", {"tool": "codeql", "files_examined": ["sub.c"]},
+                         tool_name="codeql")
+            records = load_records(run)
+            codeql = [r for r in records if r["tool"] == "codeql"]
+            self.assertEqual(len(codeql), 1)                     # de-duped
+            self.assertEqual(codeql[0]["files_examined"], ["top.c"])  # top wins
+
     def test_load_records_falls_back_to_legacy(self):
         with TemporaryDirectory() as d:
             write_record(Path(d), {"tool": "legacy"})

--- a/core/coverage/tests/test_registry.py
+++ b/core/coverage/tests/test_registry.py
@@ -1,0 +1,33 @@
+"""Tests for the coverage tool registry (category / depth classification)."""
+
+from __future__ import annotations
+
+from core.coverage.registry import category_of, classify, depth_of
+
+
+def test_known_tools_classify():
+    assert category_of("semgrep") == "static"
+    assert category_of("codeql") == "static"
+    assert category_of("gcov") == "runtime"
+    assert depth_of("gcov") == "runtime-tested"
+    assert classify("claude") == ("llm", "analysed")
+
+
+def test_labelled_tool_uses_base():
+    # The label's base (before ":") drives classification.
+    assert category_of("claude:audit") == "llm"
+    assert category_of("gcov:campaign-1") == "runtime"
+    assert depth_of("claude:stage-a") == "analysed"
+
+
+def test_command_source_labels_are_llm():
+    # checked_by source_labels (command:stage) classify as llm.
+    assert category_of("validate:stage-a") == "llm"
+    assert category_of("agentic:post-pass") == "llm"
+    assert category_of("annotations") == "llm"
+
+
+def test_unknown_tool_is_conservative():
+    # Unknown producers are never credited as deep coverage.
+    assert classify("mystery-tool") == ("unknown", "scanned")
+    assert category_of("mystery-tool:v2") == "unknown"

--- a/core/coverage/tests/test_store.py
+++ b/core/coverage/tests/test_store.py
@@ -1,0 +1,266 @@
+"""Tests for the Phase 3 persistent CoverageStore (core/coverage/store.py)."""
+
+from __future__ import annotations
+
+from core.coverage.store import CoverageStore, _coalesce
+
+
+def _store(tmp_path):
+    return CoverageStore(tmp_path / "coverage.json", target="zip:abc123")
+
+
+# --- interval coalescing ---------------------------------------------------
+
+
+def test_coalesce_merges_overlapping_and_adjacent():
+    assert _coalesce([[0, 5], [3, 8]]) == [[0, 8]]        # overlap
+    assert _coalesce([[0, 5], [6, 9]]) == [[0, 9]]        # adjacent (5,6)
+    assert _coalesce([[0, 5], [10, 12]]) == [[0, 5], [10, 12]]  # disjoint
+    assert _coalesce([[10, 12], [0, 5]]) == [[0, 5], [10, 12]]  # unsorted in
+    assert _coalesce([]) == []
+
+
+# --- mark() + delta --------------------------------------------------------
+
+
+def test_mark_returns_newly_covered_delta(tmp_path):
+    s = _store(tmp_path)
+    assert s.mark("a.c", 0, 9, "semgrep") == 10        # 10 fresh lines
+    assert s.mark("a.c", 0, 9, "semgrep") == 0         # all already covered
+    assert s.mark("a.c", 5, 14, "semgrep") == 5        # only 10..14 are new
+    assert s.mark("a.c", 0, 9, "codeql") == 10         # different tool = fresh
+
+
+def test_mark_tolerates_swapped_bounds(tmp_path):
+    s = _store(tmp_path)
+    assert s.mark("a.c", 9, 0, "semgrep") == 10
+
+
+def test_mark_coalesces_into_one_interval(tmp_path):
+    s = _store(tmp_path)
+    s.mark("a.c", 0, 5, "semgrep")
+    s.mark("a.c", 6, 9, "semgrep")          # adjacent
+    assert s.covered_lines("a.c") == [[0, 9]]
+
+
+# --- queries ---------------------------------------------------------------
+
+
+def test_who_checked(tmp_path):
+    s = _store(tmp_path)
+    s.mark("a.c", 0, 50, "semgrep")
+    s.mark("a.c", 30, 89, "claude:audit")
+    assert s.who_checked("a.c", 40) == ["claude:audit", "semgrep"]
+    assert s.who_checked("a.c", 10) == ["semgrep"]
+    assert s.who_checked("a.c", 200) == []
+    assert s.who_checked("missing.c", 1) == []
+
+
+def test_file_coverage_needs_total_lines(tmp_path):
+    s = _store(tmp_path)
+    s.mark("a.c", 0, 49, "semgrep")          # 50 lines
+    assert s.file_coverage("a.c") == 0.0     # total_lines unknown -> 0
+    s.set_file_meta("a.c", total_lines=100)
+    assert s.file_coverage("a.c") == 50.0
+    s.mark("a.c", 50, 99, "codeql")          # union now full
+    assert s.file_coverage("a.c") == 100.0
+
+
+def test_covered_lines_unions_across_tools(tmp_path):
+    s = _store(tmp_path)
+    s.mark("a.c", 0, 10, "semgrep")
+    s.mark("a.c", 8, 20, "claude:audit")
+    assert s.covered_lines("a.c") == [[0, 20]]
+
+
+def test_link_finding_dedups(tmp_path):
+    s = _store(tmp_path)
+    s.link_finding("a.c", "FIND-1")
+    s.link_finding("a.c", "FIND-1")
+    s.link_finding("a.c", "FIND-2")
+    assert s.finding_ids("a.c") == ["FIND-1", "FIND-2"]
+
+
+# --- persistence -----------------------------------------------------------
+
+
+def test_save_load_roundtrip(tmp_path):
+    s = _store(tmp_path)
+    s.mark("a.c", 0, 9, "semgrep")
+    s.mark("a.c", 30, 89, "claude:audit")
+    s.set_file_meta("a.c", total_lines=100, sloc=80)
+    s.link_finding("a.c", "FIND-1")
+    path = s.save()
+    assert path.exists()
+
+    reloaded = CoverageStore(path)
+    assert reloaded.target == "zip:abc123"        # persisted, not re-supplied
+    assert reloaded.who_checked("a.c", 40) == ["claude:audit"]
+    assert reloaded.file_coverage("a.c") == 70.0  # (10 + 60) / 100 union
+    assert reloaded.finding_ids("a.c") == ["FIND-1"]
+    assert reloaded.files() == ["a.c"]
+
+
+def test_load_keeps_persisted_target_over_constructor_arg(tmp_path):
+    s = CoverageStore(tmp_path / "coverage.json", target="git:deadbeef")
+    s.mark("a.c", 0, 1, "semgrep")
+    s.save()
+    # A later run that passes a different target must not clobber the
+    # store's recorded identity.
+    reopened = CoverageStore(tmp_path / "coverage.json", target="git:OTHER")
+    assert reopened.target == "git:deadbeef"
+
+
+# --- inventory-join queries (step 2) ---------------------------------------
+
+_CHECKLIST = {
+    "files": [
+        {"path": "a.c", "sha256": "x", "total_lines": 100, "sloc": 80,
+         "items": [
+             {"name": "f1", "line_start": 0, "line_end": 20},
+             {"name": "f2", "line_start": 30, "line_end": 60},
+         ]},
+        {"path": "b.c", "sha256": "y", "total_lines": 50,
+         "functions": [   # fallback key
+             {"name": "g1", "line_start": 0, "line_end": 10},
+         ]},
+    ],
+}
+
+
+def test_iter_inventory_functions_handles_items_and_functions():
+    from core.coverage.store import iter_inventory_functions
+    got = list(iter_inventory_functions(_CHECKLIST))
+    # 5th element is kind; legacy items without a kind default to "function".
+    assert got == [
+        ("a.c", "f1", 0, 20, "function"),
+        ("a.c", "f2", 30, 60, "function"),
+        ("b.c", "g1", 0, 10, "function"),
+    ]
+
+
+def test_who_checked_function_full_vs_partial(tmp_path):
+    s = _store(tmp_path)
+    s.mark("a.c", 0, 20, "semgrep")          # all of f1
+    s.mark("a.c", 30, 44, "claude:audit")    # 15 of f2's 31 lines
+    assert s.who_checked_function("a.c", 0, 20) == {"semgrep": "full"}
+    assert s.who_checked_function("a.c", 30, 60) == {"claude:audit": "partial (48%)"}
+
+
+def test_function_covered_with_category(tmp_path):
+    s = _store(tmp_path)
+    s.mark("a.c", 0, 20, "semgrep")          # f1: static only
+    s.mark("a.c", 30, 60, "claude:audit")    # f2: llm
+    assert s.function_covered("a.c", 0, 20) is True
+    assert s.function_covered("a.c", 0, 20, category="llm") is False
+    assert s.function_covered("a.c", 30, 60, category="llm") is True
+
+
+def test_unchecked_functions_overall_and_by_category(tmp_path):
+    s = _store(tmp_path)
+    s.mark("a.c", 0, 20, "semgrep")          # f1 scanned (static)
+    s.mark("a.c", 30, 60, "claude:audit")    # f2 analysed (llm)
+    # b.c/g1 untouched by anything.
+    assert s.unchecked_functions(_CHECKLIST) == [("b.c", "g1", 0)]
+    # The /audit gap: functions no LLM has examined -> f1 (semgrep only) + g1.
+    assert s.unchecked_functions(_CHECKLIST, category="llm") == [
+        ("a.c", "f1", 0),
+        ("b.c", "g1", 0),
+    ]
+
+
+def test_unchecked_functions_handles_missing_line_end(tmp_path):
+    s = _store(tmp_path)
+    checklist = {"files": [{"path": "c.c", "items": [
+        {"name": "h", "line_start": 5, "line_end": None}]}]}
+    assert s.unchecked_functions(checklist) == [("c.c", "h", 5)]
+    s.mark("c.c", 5, 5, "semgrep")           # cover the declaration line
+    assert s.unchecked_functions(checklist) == []
+
+
+def test_import_inventory_meta_enables_file_coverage(tmp_path):
+    s = _store(tmp_path)
+    s.import_inventory_meta(_CHECKLIST)
+    s.mark("a.c", 0, 49, "semgrep")          # 50 of 100 lines
+    assert s.file_coverage("a.c") == 50.0
+
+
+# --- verdict-bearing coverage (the three states) ---------------------------
+
+
+def test_function_verdict_four_states(tmp_path):
+    s = _store(tmp_path)
+    # f1 [0,20]: examined, no finding -> clean
+    s.mark("a.c", 0, 20, "semgrep")
+    assert s.function_verdict("a.c", 0, 20) == "clean"
+    # f2 [30,60]: examined + a retained finding inside -> open
+    s.mark("a.c", 30, 60, "semgrep")
+    s.link_finding("a.c", "F1", line=42, retained=True)
+    assert s.function_verdict("a.c", 30, 60) == "open"
+    # flip the finding's detail to lost -> found_then_lost
+    s.link_finding("a.c", "F1", line=42, retained=False)
+    assert s.function_verdict("a.c", 30, 60) == "found_then_lost"
+    # never examined -> unexamined
+    assert s.function_verdict("b.c", 0, 10) == "unexamined"
+
+
+def test_finding_without_line_does_not_set_function_verdict(tmp_path):
+    s = _store(tmp_path)
+    s.mark("a.c", 0, 20, "semgrep")
+    s.link_finding("a.c", "F1")              # no line -> can't attribute
+    assert s.function_verdict("a.c", 0, 20) == "clean"
+    assert s.finding_ids("a.c") == ["F1"]    # still a file-level signal
+
+
+def test_finding_implies_examined_without_coverage_record(tmp_path):
+    # A finding IS examination evidence: a function with an in-range finding
+    # must never read 'unexamined' just because no whole-file coverage record
+    # happens to cover its line. open (retained) / found_then_lost (not).
+    s = _store(tmp_path)
+    s.link_finding("a.c", "F1", line=42, retained=True)     # no mark() at all
+    assert s.function_verdict("a.c", 30, 60) == "open"
+    s.link_finding("a.c", "F1", line=42, retained=False)
+    assert s.function_verdict("a.c", 30, 60) == "found_then_lost"
+    # a sibling range with neither finding nor coverage is still unexamined
+    assert s.function_verdict("a.c", 0, 20) == "unexamined"
+
+
+def test_review_gap_includes_unexamined_and_found_then_lost(tmp_path):
+    s = _store(tmp_path)
+    s.mark("a.c", 0, 20, "semgrep")          # f1 clean
+    s.mark("a.c", 30, 60, "semgrep")
+    s.link_finding("a.c", "F1", line=42, retained=False)   # f2 found_then_lost
+    # b.c/g1 unexamined
+    gap = s.review_gap(_CHECKLIST)
+    assert gap == [
+        ("a.c", "f2", 30, "found_then_lost"),
+        ("b.c", "g1", 0, "unexamined"),
+    ]
+
+
+def test_coverage_store_lock_excludes_other_process(tmp_path):
+    import subprocess
+    import sys
+
+    from core.coverage.store import _HAS_FCNTL, coverage_store_lock
+
+    if not _HAS_FCNTL:
+        return                                   # no-op lock on non-POSIX
+    cov = tmp_path / "coverage.json"
+    cov.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = str(cov) + ".lock"
+    child = tmp_path / "try_lock.py"
+    child.write_text(
+        "import os, fcntl, sys\n"
+        f"fd = os.open({lock_path!r}, os.O_WRONLY | os.O_CREAT, 0o600)\n"
+        "try:\n"
+        "    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)\n"
+        "    sys.exit(0)\n"                       # acquired
+        "except OSError:\n"
+        "    sys.exit(3)\n"                       # blocked by the holder
+    )
+    with coverage_store_lock(cov):
+        held = subprocess.run([sys.executable, str(child)])
+        assert held.returncode == 3              # mutual exclusion across processes
+    released = subprocess.run([sys.executable, str(child)])
+    assert released.returncode == 0              # lock dropped on context exit

--- a/core/coverage/tests/test_store_summary.py
+++ b/core/coverage/tests/test_store_summary.py
@@ -1,0 +1,203 @@
+"""Tests for the store-backed coverage view (category/depth + gaps)."""
+
+from __future__ import annotations
+
+from core.coverage.store import CoverageStore
+from core.coverage.store_summary import format_store_view, store_view
+
+_CHECKLIST = {
+    "files": [
+        {"path": "a.c", "total_lines": 100, "items": [
+            {"name": "f1", "line_start": 0, "line_end": 20},
+            {"name": "f2", "line_start": 30, "line_end": 60},
+        ]},
+        {"path": "b.c", "total_lines": 50, "functions": [
+            {"name": "g1", "line_start": 0, "line_end": 10},
+        ]},
+    ],
+}
+
+
+def _store(tmp_path):
+    return CoverageStore(tmp_path / "coverage.json", target="zip:abc")
+
+
+def test_store_view_category_breakdown_and_gaps(tmp_path):
+    s = _store(tmp_path)
+    s.mark("a.c", 0, 20, "semgrep")          # f1: static
+    s.mark("a.c", 30, 60, "claude:audit")    # f2: llm
+    # b.c/g1: nothing.
+    v = store_view(s, _CHECKLIST)
+
+    assert v["total_functions"] == 3
+    assert v["functions_covered"] == 2       # f1, f2
+    assert v["functions_by_category"] == {"static": 1, "llm": 1, "runtime": 0}
+    assert v["gap_no_tool"] == 1             # g1
+    assert v["gap_no_llm"] == 2              # f1 (static only) + g1
+    gap_keys = {(g["file"], g["function"]) for g in v["llm_gap_functions"]}
+    assert gap_keys == {("a.c", "f1"), ("b.c", "g1")}
+
+
+def test_store_view_counts_a_function_once_per_category(tmp_path):
+    s = _store(tmp_path)
+    # f2 covered by two llm tools -> still counts once for llm.
+    s.mark("a.c", 30, 60, "claude:audit")
+    s.mark("a.c", 30, 60, "validate:stage-a")
+    v = store_view(s, _CHECKLIST)
+    assert v["functions_by_category"]["llm"] == 1
+
+
+def test_store_view_verdict_buckets_and_review_gap(tmp_path):
+    s = _store(tmp_path)
+    s.mark("a.c", 0, 20, "semgrep")                       # f1 clean
+    s.mark("a.c", 30, 60, "semgrep")
+    s.link_finding("a.c", "F1", line=42, retained=False)  # f2 found_then_lost
+    # b.c/g1 unexamined
+    v = store_view(s, _CHECKLIST)
+    assert v["verdicts"] == {
+        "clean": 1, "open": 0, "found_then_lost": 1, "unexamined": 1,
+    }
+    review = {(g["function"], g["verdict"]) for g in v["review_gap"]}
+    assert review == {("f2", "found_then_lost"), ("g1", "unexamined")}
+
+
+def test_store_view_counts_interstitial_by_kind_and_surfaces_gap(tmp_path):
+    # Interstitial items must be counted as their own kind (not "functions")
+    # and must show up in the review gap when unexamined — that's the point.
+    s = _store(tmp_path)
+    checklist = {"files": [
+        {"path": "a.c", "lines": 100, "items": [
+            {"name": "f1", "kind": "function", "line_start": 1, "line_end": 20},
+            {"name": "interstitial:30-35", "kind": "interstitial",
+             "line_start": 30, "line_end": 35},
+        ]},
+    ]}
+    s.mark("a.c", 1, 20, "semgrep")          # f1 examined; interstitial not
+    v = store_view(s, checklist)
+    # counted for completeness...
+    assert v["items_by_kind"] == {"function": 1, "interstitial": 1}
+    assert v["total_functions"] == 2         # all items
+    assert v["verdicts"]["unexamined"] == 1  # the interstitial is unexamined
+    # ...but kept OUT of the actionable gap listings (it's non-function glue)
+    review_names = {g["function"] for g in v["review_gap"]}
+    assert "interstitial:30-35" not in review_names
+    llm_names = {g["function"] for g in v["llm_gap_functions"]}
+    assert "interstitial:30-35" not in llm_names
+
+    out = format_store_view(v)
+    assert "Items: 2 total" in out
+    assert "function 1" in out and "interstitial 1" in out
+
+
+def test_render_run_coverage_store_view(tmp_path):
+    import json
+
+    from core.coverage.store_summary import render_run_coverage
+
+    run = tmp_path / "agentic-1"
+    (run / "scan").mkdir(parents=True)
+    (run / "checklist.json").write_text(json.dumps({"files": [
+        {"path": "a.c", "lines": 50, "items": [
+            {"name": "f1", "line_start": 1, "line_end": 20}]}]}))
+    (run / "scan" / "coverage-semgrep.json").write_text(json.dumps(
+        {"tool": "semgrep", "files_examined": ["a.c"], "timestamp": "t"}))
+    out = render_run_coverage(run)
+    assert "Coverage (persistent store)" in out
+    assert "static" in out
+
+
+def test_render_run_coverage_file_level_when_no_checklist(tmp_path):
+    import json
+
+    from core.coverage.store_summary import render_run_coverage
+
+    run = tmp_path / "scan-1"
+    run.mkdir()
+    (run / "coverage-semgrep.json").write_text(json.dumps(
+        {"tool": "semgrep", "files_examined": ["/abs/a.py"],
+         "version": "1.79.0", "timestamp": "t"}))
+    out = render_run_coverage(run)
+    assert "file-level — no function inventory" in out
+
+
+def test_render_run_coverage_none_when_empty(tmp_path):
+    from core.coverage.store_summary import render_run_coverage
+
+    run = tmp_path / "empty"
+    run.mkdir()
+    assert render_run_coverage(run) is None
+
+
+def test_file_level_view_without_inventory(tmp_path):
+    import json
+
+    from core.coverage.store_summary import file_level_view, format_file_level_view
+
+    run = tmp_path / "scan-1"
+    run.mkdir()
+    (run / "coverage-semgrep.json").write_text(json.dumps({
+        "tool": "semgrep", "files_examined": ["/abs/a.py", "/abs/b.py"],
+        "version": "1.79.0", "rules_applied": ["all"],
+        "timestamp": "2026-05-26T10:00:00Z"}))
+    (run / ".raptor-run.json").write_text(json.dumps({
+        "command": "scan", "status": "completed",
+        "timestamp": "2026-05-26T09:59:00Z",
+        "manifest": {"target": {"source": "directory"}}}))
+
+    v = file_level_view([run])
+    assert v["tools"]["semgrep"]["files"] == ["/abs/a.py", "/abs/b.py"]
+    assert v["tools"]["semgrep"]["versions"] == ["1.79.0"]
+    assert v["runs"][0]["command"] == "scan" and v["runs"][0]["status"] == "completed"
+
+    out = format_file_level_view(v)
+    assert "file-level — no function inventory" in out
+    assert "semgrep 1.79.0: 2 file(s) examined" in out
+    assert "scan / completed" in out
+
+
+def test_open_finding_without_coverage_counts_as_examined(tmp_path):
+    # A finding with no coverage record (the agentic case before coverage
+    # records are wired): the function reads 'open' and must count as examined,
+    # NOT under "no tool at all" — the two sections must agree.
+    s = _store(tmp_path)
+    s.link_finding("a.c", "F1", line=42, retained=True)   # f2 (30-60), no mark()
+    v = store_view(s, _CHECKLIST)
+    assert v["verdicts"]["open"] == 1
+    assert v["functions_covered"] == 1                    # the open-finding fn
+    assert v["gap_no_tool"] == 2                          # f1 + g1 (truly unexamined)
+    assert v["functions_by_category"] == {"static": 0, "llm": 0, "runtime": 0}
+
+
+def test_store_view_surfaces_provenance(tmp_path):
+    s = _store(tmp_path)
+    s.mark("a.c", 0, 20, "semgrep")
+    s.stamp_coverage("a.c", "semgrep", version="1.67.0",
+                     timestamp="2026-05-26T10:00:00Z")
+    s.mark("a.c", 30, 60, "llm")
+    s.stamp_coverage("a.c", "llm", models=["gemini-2.5-pro-002"],
+                     timestamp="2026-05-26T11:00:00Z")
+    v = store_view(s, _CHECKLIST)
+    assert v["provenance"]["tools"]["semgrep"] == ["1.67.0"]
+    assert v["provenance"]["models"] == ["gemini-2.5-pro-002"]
+    assert v["provenance"]["newest"] == "2026-05-26T11:00:00Z"
+
+    out = format_store_view(v)
+    assert "Provenance:" in out
+    assert "semgrep: 1.67.0" in out
+    assert "llm models: gemini-2.5-pro-002" in out
+
+
+def test_format_store_view_renders(tmp_path):
+    s = _store(tmp_path)
+    s.mark("a.c", 0, 20, "semgrep")
+    s.mark("a.c", 30, 60, "semgrep")
+    s.link_finding("a.c", "F1", line=42, retained=False)  # found_then_lost
+    out = format_store_view(store_view(s, _CHECKLIST))
+    assert "Coverage (persistent store)" in out
+    assert "zip:abc" in out
+    assert "no LLM review:" in out
+    assert "found-then-lost:" in out
+    assert "Found-then-lost — detail discarded, re-examine" in out
+    assert "a.c:f2" in out
+    # No red/green indicators (output-style rule).
+    assert "🔴" not in out and "🟢" not in out

--- a/core/coverage/tests/test_summary_cli.py
+++ b/core/coverage/tests/test_summary_cli.py
@@ -1,0 +1,60 @@
+"""Smoke tests for libexec/raptor-coverage-summary --store wiring.
+
+Drives the CLI as a subprocess; the store view logic itself is unit-tested
+in test_store_summary.py. Here we only confirm the wiring + trust marker.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# parents[3] = core/coverage/tests -> core/coverage -> core -> repo root.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CLI = REPO_ROOT / "libexec" / "raptor-coverage-summary"
+
+
+def _run(*args, marker=True):
+    env = dict(os.environ)
+    if marker:
+        env["_RAPTOR_TRUSTED"] = "1"
+    else:
+        env.pop("_RAPTOR_TRUSTED", None)
+        env.pop("CLAUDECODE", None)
+    env["RAPTOR_DIR"] = str(REPO_ROOT)
+    return subprocess.run(
+        [sys.executable, str(CLI), *args],
+        env=env, capture_output=True, text=True,
+    )
+
+
+def _run_dir(tmp_path):
+    d = tmp_path / "scan-1"
+    d.mkdir()
+    (d / ".raptor-run.json").write_text("{}")
+    (d / "checklist.json").write_text(json.dumps({"files": [
+        {"path": "a.c", "total_lines": 100, "items": [
+            {"name": "f1", "line_start": 0, "line_end": 20},
+            {"name": "f2", "line_start": 30, "line_end": 60},
+        ]}]}))
+    (d / "coverage-semgrep.json").write_text(json.dumps(
+        {"tool": "semgrep", "files_examined": ["a.c"], "timestamp": "t"}))
+    return d
+
+
+def test_store_view_renders(tmp_path):
+    r = _run(str(_run_dir(tmp_path)), "--store")
+    assert r.returncode == 0, r.stderr
+    assert "Coverage (persistent store)" in r.stdout
+    # Both functions are semgrep(static)-covered, neither LLM -> LLM gap of 2.
+    assert "no LLM review:  2" in r.stdout
+    assert "a.c:f1" in r.stdout
+
+
+def test_store_refuses_without_trust_marker(tmp_path):
+    r = _run(str(_run_dir(tmp_path)), "--store", marker=False)
+    assert r.returncode == 2
+    assert "internal dispatch" in r.stderr

--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -26,7 +26,7 @@ from .exclusions import (
     is_generated_file,
     match_exclusion_reason,
 )
-from .extractors import extract_items, count_sloc
+from .extractors import extract_items, count_sloc, compute_interstitial_items
 from .call_graph import (
     extract_call_graph_c,
     extract_call_graph_cpp,
@@ -644,6 +644,10 @@ def _process_single_file(
         parse_text = view.parse_text
         tree_cache = {}
         items = extract_items(str(filepath), language, parse_text, _tree_cache=tree_cache)
+        # Safety net: every SLOC-bearing line outside an extracted item becomes
+        # an interstitial item, so non-function code (top-level statements,
+        # missed globals) is never invisible to coverage (coverage Decision #2).
+        items = items + compute_interstitial_items(items, parse_text)
         sloc = count_sloc(content, language, _tree=tree_cache.get("tree"))
 
         record: Dict[str, Any] = {

--- a/core/inventory/extractors.py
+++ b/core/inventory/extractors.py
@@ -22,6 +22,9 @@ KIND_FUNCTION = "function"
 KIND_GLOBAL = "global"
 KIND_MACRO = "macro"
 KIND_CLASS = "class"
+KIND_TOP_LEVEL = "top_level"        # module-scope executable code (runs at import)
+KIND_INTERSTITIAL = "interstitial"  # residue not yet classified — trends to glue
+                                    # (whitespace/braces/comments) as kinds fill in
 
 
 @dataclass
@@ -142,11 +145,31 @@ class PythonExtractor:
                 warnings.simplefilter("ignore", SyntaxWarning)
                 tree = ast.parse(content)
             self._walk(tree, functions, class_name=None)
+            functions.extend(self._top_level_items(tree))
         except SyntaxError as e:
             logger.warning(f"Failed to parse {filepath}: {e}")
             functions = self._regex_fallback(content)
 
         return functions
+
+    def _top_level_items(self, tree: ast.AST) -> List["CodeItem"]:
+        """Module-scope executable statements that run at import — a bare
+        expression statement containing a call (e.g. ``os.system(...)``,
+        ``eval(...)``). Captured as ``top_level`` so it's a named, reviewable,
+        reachability-eligible unit instead of anonymous interstitial.
+        Assignments are globals; defs/classes/imports are their own kinds."""
+        out: List[CodeItem] = []
+        for node in getattr(tree, "body", []):
+            if isinstance(node, ast.Expr) and any(
+                isinstance(n, ast.Call) for n in ast.walk(node)
+            ):
+                out.append(CodeItem(
+                    name=f"top_level:{node.lineno}",
+                    kind=KIND_TOP_LEVEL,
+                    line_start=node.lineno,
+                    line_end=getattr(node, "end_lineno", None) or node.lineno,
+                ))
+        return out
 
     def _walk(self, node: ast.AST, functions: List[FunctionInfo],
               class_name: Optional[str]) -> None:
@@ -1449,6 +1472,48 @@ def extract_functions(filepath: str, language: str, content: str) -> List[Functi
     return extractor.extract(filepath, content)
 
 
+def compute_interstitial_items(
+    items: List[CodeItem], content: str,
+) -> List[CodeItem]:
+    """Synthesise ``interstitial`` items for line ranges NOT inside any
+    extracted item — the safety net that makes "every meaningful line belongs
+    to a CodeItem" true (coverage-layer Decision #2), so non-function code
+    (top-level statements, missed globals, file-scope logic) is never invisible
+    to coverage. One item per contiguous gap; gaps with no non-blank line are
+    skipped (pure blank-line runs aren't worth a coverage unit). Line numbers
+    are 1-based, matching the extractors.
+    """
+    lines = content.splitlines()
+    total = len(lines)
+    if total == 0:
+        return []
+    covered = [False] * (total + 2)  # 1-based; index 0 and total+1 unused
+    for it in items:
+        lo = max(1, it.line_start or 0)
+        hi = it.line_end if it.line_end is not None else it.line_start or lo
+        for ln in range(lo, min(total, hi) + 1):
+            covered[ln] = True
+
+    out: List[CodeItem] = []
+    ln = 1
+    while ln <= total:
+        if covered[ln]:
+            ln += 1
+            continue
+        start = ln
+        while ln <= total and not covered[ln]:
+            ln += 1
+        end = ln - 1
+        if any(lines[i - 1].strip() for i in range(start, end + 1)):
+            out.append(CodeItem(
+                name=f"interstitial:{start}-{end}",
+                kind=KIND_INTERSTITIAL,
+                line_start=start,
+                line_end=end,
+            ))
+    return out
+
+
 def extract_items(filepath: str, language: str, content: str,
                   _tree_cache: dict = None) -> List[CodeItem]:
     """Extract all code items (functions + globals + macros) from a file.
@@ -1487,18 +1552,26 @@ def extract_items(filepath: str, language: str, content: str,
         except Exception:
             pass  # Fall through to AST/regex fallback
 
-        # Globals from the same parse tree (independent of function extraction)
+        # Globals + module-scope executable code from the same parse tree
         try:
             items.extend(_extract_globals_ts(tree.root_node, language))
+        except Exception:
+            pass
+        try:
+            items.extend(_extract_top_level_ts(tree.root_node, language))
         except Exception:
             pass
 
     # Fallback: functions from AST/regex if tree-sitter didn't produce any
     if not ts_parsed or not any(i.kind == KIND_FUNCTION for i in items):
-        items = [i for i in items if i.kind != KIND_FUNCTION]  # keep non-function items
         if language == "python":
+            # PythonExtractor (AST) re-derives functions AND top_level; drop any
+            # tree-sitter-derived ones first to avoid duplicates (keep globals).
+            items = [i for i in items
+                     if i.kind not in (KIND_FUNCTION, KIND_TOP_LEVEL)]
             items.extend(PythonExtractor().extract(filepath, content))
         else:
+            items = [i for i in items if i.kind != KIND_FUNCTION]
             extractor = _REGEX_EXTRACTORS.get(language, GenericExtractor())
             items.extend(extractor.extract(filepath, content))
 
@@ -1507,6 +1580,43 @@ def extract_items(filepath: str, language: str, content: str,
         items.extend(_extract_macros_regex(content))
 
     return items
+
+
+_TOP_LEVEL_LANGS = ("python", "javascript", "typescript", "tsx")
+_CALL_NODE_TYPES = ("call", "call_expression")
+_ASSIGN_NODE_TYPES = ("assignment", "assignment_expression", "augmented_assignment")
+
+
+def _ts_contains_call(node, depth: int = 0) -> bool:
+    if node.type in _CALL_NODE_TYPES:
+        return True
+    if depth > 5:
+        return False
+    return any(_ts_contains_call(c, depth + 1) for c in node.children)
+
+
+def _extract_top_level_ts(root_node, language: str) -> List[CodeItem]:
+    """Module-scope executable statements (run at import) as ``top_level`` items
+    — a root-level ``expression_statement`` containing a call but not an
+    assignment (assignments are globals). Captures the security-relevant case
+    (``os.system(...)`` / ``eval(...)`` at module scope) as a named, reviewable
+    unit instead of anonymous interstitial. Script-like languages only."""
+    if language not in _TOP_LEVEL_LANGS:
+        return []
+    out: List[CodeItem] = []
+    for child in root_node.children:
+        if child.type != "expression_statement":
+            continue
+        if any(c.type in _ASSIGN_NODE_TYPES for c in child.children):
+            continue
+        if _ts_contains_call(child):
+            out.append(CodeItem(
+                name=f"top_level:{child.start_point[0] + 1}",
+                kind=KIND_TOP_LEVEL,
+                line_start=child.start_point[0] + 1,
+                line_end=child.end_point[0] + 1,
+            ))
+    return out
 
 
 def _extract_globals_ts(root_node, language: str) -> List[CodeItem]:
@@ -1646,6 +1756,39 @@ def _global_names(node, language: str):
         yield name
 
 
+def _c_declarator_name(node, depth: int = 0) -> Optional[str]:
+    """Descend C/C++ declarator wrappers to the declared identifier. Returns the
+    first identifier found, or None.
+
+    For ``init_declarator`` only the declarator side is followed, never the RHS
+    init value — otherwise ``int (*handler)(int) = foo;`` would return the
+    initializer ``foo`` (the declared name ``handler`` is nested in the
+    function-pointer declarator). The pointer/parenthesized recursion still
+    reaches the real name (function-pointer *variables* declare a name;
+    plain function prototypes are rejected earlier by the function_declarator
+    guard on the declaration's direct children)."""
+    if depth > 6:
+        return None
+    if node.type == "identifier":            # the declarator IS the name
+        return node.text.decode()
+    for child in node.children:
+        if child.type == "identifier":
+            return child.text.decode()
+        if child.type == "init_declarator":
+            decl = child.child_by_field_name("declarator")
+            if decl is None and child.children:
+                decl = child.children[0]
+            name = _c_declarator_name(decl, depth + 1) if decl is not None else None
+            if name:
+                return name
+        elif child.type in ("array_declarator", "pointer_declarator",
+                            "parenthesized_declarator", "function_declarator"):
+            name = _c_declarator_name(child, depth + 1)
+            if name:
+                return name
+    return None
+
+
 def _global_name(node, language: str) -> Optional[str]:
     """Extract the name from a global declaration node."""
     if language == "python":
@@ -1679,14 +1822,13 @@ def _global_name(node, language: str) -> Optional[str]:
         for child in node.children:
             if child.type == "function_declarator":
                 return None
-        for child in node.children:
-            if child.type == "init_declarator":
-                for sub in child.children:
-                    if sub.type == "identifier":
-                        return sub.text.decode()
-            if child.type == "identifier":
-                return child.text.decode()
-        return None
+        # Descend declarator wrappers to the identifier. Pre-fix this only
+        # handled init_declarator/bare identifier, so array globals
+        # (`char g_buf[8]` → array_declarator) and pointer globals
+        # (`char *p` → pointer_declarator) were missed and fell to
+        # interstitial. Recursion catches the common wrapped forms; exotic
+        # shapes (multi-declarator, function-pointer) remain unclassified.
+        return _c_declarator_name(node)
 
     if language == "java":
         for child in node.children:

--- a/core/inventory/lookup.py
+++ b/core/inventory/lookup.py
@@ -85,6 +85,13 @@ def lookup_function(checklist: Dict[str, Any], file_path: str, line: int,
             continue
 
         for func in file_entry.get("items", file_entry.get("functions", [])):
+            # Only FUNCTION items enclose a "function" — globals, macros,
+            # classes, top_level and interstitial are not callable units, so a
+            # sink landing in one has no enclosing function (callers expect
+            # None there, e.g. reachability stays conservative rather than
+            # mislabelling import-time / glue code as "not_called").
+            if func.get("kind", "function") != "function":
+                continue
             func_start = func.get("line_start", 0)
             func_end = func.get("line_end")
 

--- a/core/inventory/tests/test_extractors.py
+++ b/core/inventory/tests/test_extractors.py
@@ -406,3 +406,92 @@ class TestCppTreeSitter:
         funcs = extract_functions("t.cpp", "cpp", src)
         names = [f.name for f in funcs]
         assert "upper" in names
+
+
+class TestInterstitialItems:
+    """compute_interstitial_items — the 'every SLOC belongs to an item' net."""
+
+    def test_gaps_between_items_become_interstitial(self):
+        from core.inventory.extractors import (
+            CodeItem, KIND_FUNCTION, KIND_INTERSTITIAL,
+            compute_interstitial_items,
+        )
+        # 1: import os   2: (blank)   3: def f():   4:   pass   5: x = os.system(z)
+        content = "import os\n\ndef f():\n    pass\nx = os.system('z')\n"
+        items = [CodeItem(name="f", kind=KIND_FUNCTION, line_start=3, line_end=4)]
+        inter = compute_interstitial_items(items, content)
+        ranges = {(it.line_start, it.line_end): it.kind for it in inter}
+        assert ranges.get((1, 2)) == KIND_INTERSTITIAL    # import (blank trailing kept)
+        assert ranges.get((5, 5)) == KIND_INTERSTITIAL    # top-level os.system
+
+    def test_blank_only_gap_is_skipped(self):
+        from core.inventory.extractors import (
+            CodeItem, KIND_FUNCTION, compute_interstitial_items,
+        )
+        content = "def a():\n    pass\n\n\ndef b():\n    pass\n"
+        items = [
+            CodeItem(name="a", kind=KIND_FUNCTION, line_start=1, line_end=2),
+            CodeItem(name="b", kind=KIND_FUNCTION, line_start=5, line_end=6),
+        ]
+        # lines 3-4 are blank-only → no interstitial item
+        assert compute_interstitial_items(items, content) == []
+
+    def test_fully_covered_file_has_no_interstitial(self):
+        from core.inventory.extractors import (
+            CodeItem, KIND_FUNCTION, compute_interstitial_items,
+        )
+        content = "def a():\n    pass\n"
+        items = [CodeItem(name="a", kind=KIND_FUNCTION, line_start=1, line_end=2)]
+        assert compute_interstitial_items(items, content) == []
+
+
+class TestTopLevelItems:
+    """top_level — module-scope executable code (runs at import)."""
+
+    def test_python_module_level_call_is_top_level(self):
+        # AST path (no tree-sitter needed → testable in CI).
+        from core.inventory.extractors import PythonExtractor, KIND_TOP_LEVEL
+        content = "import os\nos.system('x')\ndef f():\n    pass\n"
+        items = PythonExtractor().extract("t.py", content)
+        kinds = {(i.kind, i.line_start) for i in items}
+        assert (KIND_TOP_LEVEL, 2) in kinds          # os.system at module scope
+        assert any(i.kind == "function" for i in items)
+
+    def test_python_bare_non_call_expr_is_not_top_level(self):
+        # A docstring / bare literal isn't executable-of-interest.
+        from core.inventory.extractors import PythonExtractor
+        content = '"""module docstring"""\n42\n'
+        items = PythonExtractor().extract("t.py", content)
+        assert not any(i.kind == "top_level" for i in items)
+
+
+class TestCGlobalDeclarators:
+    """C/C++ globals through declarator wrappers (array/pointer)."""
+
+    def test_c_array_and_pointer_globals_captured(self):
+        from core.inventory.extractors import (
+            _TS_AVAILABLE, extract_items, KIND_GLOBAL,
+        )
+        if not _TS_AVAILABLE:
+            pytest.skip("tree-sitter required for C global extraction")
+        content = ("char g_buf[8];\nchar *p;\nint x = 0;\n"
+                   "int f(void) { return 0; }\n")
+        items = extract_items("t.c", "c", content)
+        names = {i.name for i in items if i.kind == KIND_GLOBAL}
+        assert {"g_buf", "p", "x"} <= names      # array, pointer, scalar
+        assert "f" not in names                  # function not a global
+
+    def test_function_pointer_global_named_by_variable_not_initializer(self):
+        # Regression: `int (*h)(int) = foo;` must be the variable `h`, NOT the
+        # initializer `foo` (the declared name is nested in the FP declarator).
+        from core.inventory.extractors import (
+            _TS_AVAILABLE, extract_items, KIND_GLOBAL,
+        )
+        if not _TS_AVAILABLE:
+            pytest.skip("tree-sitter required for C global extraction")
+        content = "int (*h)(int) = foo;\nint x = 0;\n"
+        names = {i.name for i in extract_items("t.c", "c", content)
+                 if i.kind == KIND_GLOBAL}
+        assert "h" in names              # the function-pointer variable
+        assert "foo" not in names        # NOT the initializer value
+        assert "x" in names              # plain scalar still works

--- a/core/project/clean.py
+++ b/core/project/clean.py
@@ -6,6 +6,26 @@ from pathlib import Path
 from typing import Any, Dict
 
 
+def _run_dir_size(d: Path) -> int:
+    # `Path.rglob` follows symlinks under Python <3.13 with no opt-out; a
+    # malicious or accidental symlink under the run dir (e.g.
+    # `out/run-X/incoming -> /var/log`) would walk into and stat-sum
+    # unrelated trees, double-counting bytes and (worse) reading from
+    # arbitrary file descriptors. Use os.walk(followlinks=False) so we stay
+    # inside the run dir tree on every supported Python version.
+    size = 0
+    for root, _dirs, files in os.walk(d, followlinks=False):
+        for fname in files:
+            fp = Path(root) / fname
+            try:
+                st = fp.stat()
+            except OSError:
+                continue
+            if not fp.is_symlink():
+                size += st.st_size
+    return size
+
+
 def plan_clean(project, keep=1) -> Dict[str, Any]:
     """Plan which runs to delete. Returns stats with directory paths.
 
@@ -28,23 +48,7 @@ def plan_clean(project, keep=1) -> Dict[str, Any]:
             stats["kept"].append(d.name)
 
         for d in to_delete:
-            # `Path.rglob` follows symlinks under Python <3.13 with no
-            # opt-out; a malicious or accidental symlink under the run
-            # dir (e.g. `out/run-X/incoming -> /var/log`) would walk
-            # into and stat-sum unrelated trees, double-counting bytes
-            # and (worse) reading from arbitrary file descriptors. Use
-            # os.walk(followlinks=False) so we stay inside the run dir
-            # tree on every supported Python version.
-            size = 0
-            for root, _dirs, files in os.walk(d, followlinks=False):
-                for fname in files:
-                    fp = Path(root) / fname
-                    try:
-                        st = fp.stat()
-                    except OSError:
-                        continue
-                    if not fp.is_symlink():
-                        size += st.st_size
+            size = _run_dir_size(d)
             stats["freed_bytes"] += size
             type_freed += size
             stats["delete_dirs"].append(d)
@@ -57,6 +61,45 @@ def plan_clean(project, keep=1) -> Dict[str, Any]:
             "freed_bytes": type_freed,
         }
 
+    return stats
+
+
+def plan_dedup(project) -> Dict[str, Any]:
+    """Lossless dedup plan: per command type, drop runs fully subsumed (same
+    files examined, no unique findings) by a surviving run, keeping the newest
+    representative. Same shape as :func:`plan_clean` so the clean machinery
+    (coverage snapshot-before-delete, containment-checked execute) is reused.
+
+    Unlike recency-based ``--keep N``, this is provably lossless: only
+    duplicates are removed, and the to-be-deleted run's coverage is snapshotted
+    into the durable store before deletion. Does not modify the filesystem.
+    """
+    from core.coverage.clean import dedup_runs
+
+    groups = project.get_run_dirs_by_type()
+    stats: Dict[str, Any] = {
+        "delete_dirs": [], "deleted": [], "kept": [], "freed_bytes": 0,
+        "by_type": {},
+    }
+    for cmd_type, dirs in groups.items():
+        droppable, _ = dedup_runs(dirs)
+        drop_set = set(droppable)
+        type_freed = 0
+        for d in dirs:
+            if d in drop_set:
+                size = _run_dir_size(d)
+                stats["freed_bytes"] += size
+                type_freed += size
+                stats["delete_dirs"].append(d)
+                stats["deleted"].append(d.name)
+            else:
+                stats["kept"].append(d.name)
+        stats["by_type"][cmd_type] = {
+            "total": len(dirs),
+            "keep": len(dirs) - len(droppable),
+            "delete": len(droppable),
+            "freed_bytes": type_freed,
+        }
     return stats
 
 

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -224,9 +224,12 @@ def main():
 
     # clean
     p_clean = sub.add_parser("clean", help="Delete old runs, keep latest n",
-                             usage="raptor project clean [<name>] [--keep <n>] [--dry-run] [--yes]", **_F)
+                             usage="raptor project clean [<name>] [--keep <n>] [--dedup] [--dry-run] [--yes]", **_F)
     p_clean.add_argument("name", nargs="?", help="Project name")
     p_clean.add_argument("--keep", type=int, default=1, metavar="<n>", help="Runs to keep per type (default: 1)")
+    p_clean.add_argument("--dedup", action="store_true",
+                         help="Coverage-aware: drop only runs fully subsumed by a survivor "
+                              "(provably lossless), ignoring --keep")
     p_clean.add_argument("--dry-run", action="store_true", help="Show what would be deleted")
     p_clean.add_argument("--yes", action="store_true", help="Skip confirmation")
 
@@ -700,7 +703,7 @@ def main():
             if not p:
                 print(f"Project '{name}' not found.")
                 return
-            _do_clean(p, args.keep, args.dry_run, args.yes)
+            _do_clean(p, args.keep, args.dry_run, args.yes, dedup=args.dedup)
 
         elif args.subcommand == "merge":
             name = args.name or _get_active_project()
@@ -1371,14 +1374,16 @@ def _do_correlate(project, json_out=False):
         print(f"\n  Coverage: {', '.join(cov_parts)} files")
 
 
-def _do_clean(project, keep, dry_run, yes):
-    """Clean old runs from a project."""
-    from .clean import plan_clean, execute_clean
+def _do_clean(project, keep, dry_run, yes, dedup=False):
+    """Clean old runs from a project. With ``dedup``, the deletion set is the
+    coverage-aware lossless subset (runs fully subsumed by a survivor) rather
+    than recency-based ``--keep N``."""
+    from .clean import plan_clean, plan_dedup, execute_clean
 
-    plan = plan_clean(project, keep=keep)
+    plan = plan_dedup(project) if dedup else plan_clean(project, keep=keep)
 
     if not plan["deleted"]:
-        print("Nothing to clean.")
+        print("No redundant runs to dedup." if dedup else "Nothing to clean.")
         return
 
     # Per-type breakdown
@@ -1392,6 +1397,19 @@ def _do_clean(project, keep, dry_run, yes):
     total_runs = len(plan['deleted']) + len(plan['kept'])
     print(f"\n  Total: {total_runs} runs → {len(plan['kept'])} runs ({freed_mb:.1f}MB to free)")
 
+    # Coverage-aware: classify what each removal costs (read-only).
+    consequences = _classify_clean_coverage(project, plan)
+    if consequences:
+        from core.coverage.clean import format_consequence
+        print()
+        for c in consequences:
+            print(format_consequence(c))
+        lost = [c for c in consequences if c.lossy]
+        if lost:
+            n = sum(len(c.findings_lost) for c in lost)
+            print(_red(f"  ⚠ {n} unique finding(s) across {len(lost)} run(s) "
+                       f"will become re-review gaps (found-then-lost)."))
+
     if dry_run:
         print("\n(dry run — no changes)")
         return
@@ -1401,11 +1419,61 @@ def _do_clean(project, keep, dry_run, yes):
             print("Cancelled.")
             return
 
+    # Snapshot coverage into the durable store BEFORE deleting (preserves
+    # clean/examined coverage; flips sole-source findings to found_then_lost).
+    _apply_clean_coverage(project, plan, consequences)
+
     # Execute the exact plan that was shown — no re-query
     execute_clean(plan)
     for name in plan["deleted"]:
         print(_red(f"  Deleted: {name}"))
     print(f"Done. {len(plan['deleted'])} runs deleted ({freed_mb:.1f}MB freed)")
+
+
+def _classify_clean_coverage(project, plan):
+    """Read-only: per to-be-deleted run, classify the coverage consequence
+    (duplicate / sole-clean / sole-source-findings). Best-effort — a coverage
+    hiccup must never block a clean. Returns [] when there's no inventory."""
+    try:
+        from core.json import load_json
+        from core.coverage.clean import classify_removal
+
+        checklist = load_json(Path(project.output_dir) / "checklist.json")
+        victims = plan.get("delete_dirs", [])
+        if not checklist or not victims:
+            return []
+        victim_set = set(victims)
+        survivors = [d for d in project.get_run_dirs(sweep=False)
+                     if d not in victim_set]
+        return [classify_removal(v, survivors) for v in victims]
+    except Exception:
+        return []
+
+
+def _apply_clean_coverage(project, plan, consequences):
+    """Snapshot to-be-deleted runs' coverage into the durable project
+    ``coverage.json`` (and flip sole-source findings to found_then_lost)
+    before the dirs are removed. Best-effort — never blocks the clean."""
+    if not consequences:
+        return
+    try:
+        from core.json import load_json
+        from core.coverage.store import CoverageStore, coverage_store_lock
+        from core.coverage.clean import apply_removal
+
+        checklist = load_json(Path(project.output_dir) / "checklist.json")
+        if not checklist:
+            return
+        cov_path = Path(project.output_dir) / "coverage.json"
+        # Lock the whole read-modify-write: a run completing mid-clean snapshots
+        # into the same coverage.json (see _snapshot_run_coverage).
+        with coverage_store_lock(cov_path):
+            store = CoverageStore(cov_path)
+            for victim, cons in zip(plan.get("delete_dirs", []), consequences):
+                apply_removal(store, victim, checklist, cons)
+            store.save()
+    except Exception as e:
+        print(_red(f"  (coverage snapshot skipped: {e})"))
 
 
 def _do_merge(project, merge_type, yes):

--- a/core/project/project.py
+++ b/core/project/project.py
@@ -61,6 +61,20 @@ class Project:
     def output_path(self) -> Path:
         return Path(self.output_dir)
 
+    @property
+    def content_id(self) -> Optional[str]:
+        """The project's content-equivalence id, read lazily from the durable
+        coverage store (``coverage.json``). The store is the single source of
+        truth for this id (L2-owned); it is ``None`` until a coverage build has
+        stamped one. Two acquisitions of identical source (git checkout vs zip
+        extraction) share a ``content_id`` even though their ``target`` paths
+        differ — this is what lets them resolve to the same project."""
+        try:
+            data = load_json(self.output_path / "coverage.json")
+        except Exception:
+            return None
+        return data.get("content_id") if isinstance(data, dict) else None
+
     def _list_run_dirs(self) -> List[Path]:
         """List run directories (unsorted). Shared by get_run_dirs and sweep."""
         if not self.output_path.exists():
@@ -530,10 +544,32 @@ class ProjectManager:
                 active_link.unlink(missing_ok=True)
         return None
 
-    def find_project_for_target(self, target: str) -> Optional[Project]:
-        """Auto-detect: find a project whose target matches the given path."""
+    def find_project_for_target(
+        self, target: str, content_id: Optional[str] = None,
+    ) -> Optional[Project]:
+        """Auto-detect a project for the given target.
+
+        Path match first (unchanged default). When ``content_id`` is supplied
+        and no project's path matches, fall back to a content match: a project
+        whose durable store carries the same content-equivalence id. This is
+        what lets a git checkout and a zip extraction of identical source share
+        one project/store even though their ``target`` paths differ. Callers
+        that have built an inventory pass its ``content_identity``; callers that
+        haven't pass nothing and get the original path-only behaviour."""
         resolved = str(Path(target).resolve())
         for project in self.list_projects():
             if project.target == resolved:
+                return project
+        if content_id:
+            return self.find_project_by_content_id(content_id)
+        return None
+
+    def find_project_by_content_id(self, content_id: str) -> Optional[Project]:
+        """Find a project whose durable store carries ``content_id`` (the
+        content-equivalence id). Returns ``None`` if none match."""
+        if not content_id:
+            return None
+        for project in self.list_projects():
+            if project.content_id == content_id:
                 return project
         return None

--- a/core/project/tests/test_clean_coverage.py
+++ b/core/project/tests/test_clean_coverage.py
@@ -1,0 +1,96 @@
+"""Coverage-aware /project clean wiring (_classify_clean_coverage /
+_apply_clean_coverage in core.project.cli)."""
+
+from __future__ import annotations
+
+import json
+
+from core.coverage.store import CoverageStore
+from core.project.cli import _apply_clean_coverage, _classify_clean_coverage
+
+
+class _FakeProject:
+    def __init__(self, output_dir, run_dirs, by_type=None):
+        self.output_dir = str(output_dir)
+        self._run_dirs = run_dirs
+        self._by_type = by_type or {}
+
+    def get_run_dirs(self, sweep=False):
+        return list(self._run_dirs)
+
+    def get_run_dirs_by_type(self):
+        return {k: list(v) for k, v in self._by_type.items()}
+
+
+def _proj(tmp_path):
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / "checklist.json").write_text(json.dumps({"files": [
+        {"path": "a.c", "total_lines": 100, "items": [
+            {"name": "f1", "line_start": 0, "line_end": 20},
+            {"name": "f2", "line_start": 30, "line_end": 60},
+        ]}]}))
+    return proj
+
+
+def _run(proj, name, files, findings=None):
+    d = proj / name
+    d.mkdir()
+    (d / "coverage-semgrep.json").write_text(json.dumps(
+        {"tool": "semgrep", "files_examined": files, "timestamp": "t"}))
+    if findings is not None:
+        (d / "findings.json").write_text(json.dumps(findings))
+    return d
+
+
+def test_clean_snapshots_coverage_and_flips_sole_source_finding(tmp_path):
+    proj = _proj(tmp_path)
+    victim = _run(proj, "scan-old", ["a.c"],
+                  findings=[{"id": "F1", "file": "a.c", "line": 42}])  # in f2
+    fp = _FakeProject(proj, [victim])
+    plan = {"delete_dirs": [victim]}
+
+    cons = _classify_clean_coverage(fp, plan)
+    assert len(cons) == 1 and cons[0].lossy is True       # F1 is sole-source
+
+    _apply_clean_coverage(fp, plan, cons)                 # snapshot + flip + save
+
+    store = CoverageStore(proj / "coverage.json")          # persisted at project level
+    assert store.function_verdict("a.c", 0, 20) == "clean"            # examined, no finding
+    assert store.function_verdict("a.c", 30, 60) == "found_then_lost"  # finding detail going away
+
+
+def test_clean_duplicate_run_loses_nothing(tmp_path):
+    proj = _proj(tmp_path)
+    victim = _run(proj, "scan-old", ["a.c"], findings=[])
+    survivor = _run(proj, "scan-new", ["a.c"], findings=[])
+    fp = _FakeProject(proj, [victim, survivor])
+    plan = {"delete_dirs": [victim]}
+
+    cons = _classify_clean_coverage(fp, plan)
+    assert cons[0].duplicate is True and cons[0].lossy is False
+
+
+def test_plan_dedup_selects_only_subsumed_runs(tmp_path):
+    from core.project.clean import plan_dedup
+
+    proj = _proj(tmp_path)
+    old = _run(proj, "scan-01", ["a.c"], findings=[])
+    new = _run(proj, "scan-02", ["a.c"], findings=[])     # subsumes old (same a.c)
+    uniq = _run(proj, "scan-03", ["b.c"], findings=[])    # disjoint -> unique
+    fp = _FakeProject(proj, [old, new, uniq],
+                      by_type={"scan": [old, new, uniq]})
+    plan = plan_dedup(fp)
+    # scan-01 subsumed by scan-02; scan-02/03 each carry coverage not elsewhere.
+    assert plan["deleted"] == ["scan-01"]
+    assert set(plan["kept"]) == {"scan-02", "scan-03"}
+    assert plan["by_type"]["scan"]["delete"] == 1
+
+
+def test_no_checklist_is_a_safe_noop(tmp_path):
+    proj = tmp_path / "bare"
+    proj.mkdir()
+    fp = _FakeProject(proj, [])
+    assert _classify_clean_coverage(fp, {"delete_dirs": []}) == []
+    _apply_clean_coverage(fp, {"delete_dirs": []}, [])     # no crash, no file
+    assert not (proj / "coverage.json").exists()

--- a/core/project/tests/test_project.py
+++ b/core/project/tests/test_project.py
@@ -344,6 +344,45 @@ class TestProjectManager(unittest.TestCase):
         self.mgr.create("myapp", self.target_code)
         self.assertIsNone(self.mgr.find_project_for_target(self.target_other))
 
+    def _stamp_content_id(self, project, content_id):
+        from core.json import save_json
+        Path(project.output_dir).mkdir(parents=True, exist_ok=True)
+        save_json(Path(project.output_dir) / "coverage.json",
+                  {"version": 1, "content_id": content_id, "files": {}})
+
+    def test_content_id_read_from_store(self):
+        p = self.mgr.create("myapp", self.target_code)
+        self.assertIsNone(p.content_id)                     # no store yet
+        self._stamp_content_id(p, "content:deadbeefcafe0001")
+        self.assertEqual(self.mgr.load("myapp").content_id,
+                         "content:deadbeefcafe0001")
+
+    def test_find_by_content_id_across_acquisitions(self):
+        # A git checkout and a zip extraction of identical source: different
+        # target paths, same content id -> resolve to the same project.
+        git_p = self.mgr.create("from-git", self.target_a)
+        self._stamp_content_id(git_p, "content:abc123")
+        found = self.mgr.find_project_for_target(
+            self.target_b, content_id="content:abc123")
+        self.assertIsNotNone(found)
+        self.assertEqual(found.name, "from-git")
+
+    def test_path_match_takes_precedence_over_content(self):
+        p = self.mgr.create("myapp", self.target_code)
+        self._stamp_content_id(p, "content:abc123")
+        # Exact path still matches even when a content_id is supplied.
+        found = self.mgr.find_project_for_target(
+            self.target_code, content_id="content:nomatch")
+        self.assertEqual(found.name, "myapp")
+
+    def test_find_by_content_id_no_match_returns_none(self):
+        p = self.mgr.create("myapp", self.target_code)
+        self._stamp_content_id(p, "content:abc123")
+        self.assertIsNone(
+            self.mgr.find_project_for_target(self.target_other,
+                                             content_id="content:xyz789"))
+        self.assertIsNone(self.mgr.find_project_by_content_id(""))
+
     def test_remove_run(self):
         p = self.mgr.create("myapp", self.target_code)
         run_dir = Path(p.output_dir) / "scan-20260406"

--- a/core/run/metadata.py
+++ b/core/run/metadata.py
@@ -549,6 +549,74 @@ def complete_run(output_dir: Path, extra: Dict[str, Any] = None,
     """
     _finalize_sandbox_summary(output_dir)
     _update_status(output_dir, STATUS_COMPLETED, extra, manifest=manifest)
+    # Materialise the LLM read-coverage record from the plugin's .reads-manifest
+    # FIRST, so the snapshot below imports it alongside the scanner records.
+    _convert_reads_manifest(output_dir)
+    # Snapshot AFTER the status/manifest write so coverage provenance can read
+    # the sealed manifest (engine versions / resolved models).
+    _snapshot_run_coverage(output_dir)
+
+
+def _convert_reads_manifest(output_dir: Path) -> None:
+    """Turn the coverage plugin's ``.reads-manifest`` (the files the LLM read
+    this run, captured by the PostToolUse-on-Read hook) into a
+    ``coverage-llm.json`` record so LLM examined-extent reaches the store.
+
+    The plugin captures the reads but nothing converted them — this wires that
+    conversion at run completion. Best-effort: a missing/empty manifest is a
+    no-op, and a failure must never break the lifecycle.
+    """
+    import logging
+    try:
+        from core.coverage.record import build_from_manifest, write_record
+        record = build_from_manifest(Path(output_dir), "llm")
+        if record:
+            write_record(Path(output_dir), record, tool_name="llm")
+    except Exception:  # noqa: BLE001 — never fail lifecycle on a coverage write
+        logging.getLogger(__name__).debug(
+            "_convert_reads_manifest failed for %s", output_dir, exc_info=True
+        )
+
+
+def _snapshot_run_coverage(output_dir: Path) -> None:
+    """Best-effort: fold a just-completed run's coverage into the project's
+    durable ``coverage.json`` so it survives out-of-band deletion of the run
+    dir (manual ``rm``, tmpfs) — not only ``/project clean``.
+
+    Scoped to THIS run's records + findings (bounded cost); project-level
+    ``checked_by`` / annotations live in the project checklist and are captured
+    by the on-demand ``--store`` union, surviving deletion regardless. No-op
+    for a standalone ``out/`` run (no project store). The coverage.json
+    read-modify-write is taken under :func:`coverage_store_lock` so parallel
+    run completions (and a concurrent clean) can't last-writer-wins each other.
+    Never raises — lifecycle hooks must not fail on a snapshot error.
+    """
+    import logging
+    log = logging.getLogger(__name__)
+    try:
+        run_dir = Path(output_dir)
+        proj = run_dir.parent
+        checklist_path = proj / "checklist.json"
+        if not checklist_path.exists():
+            return                       # standalone run — no durable project store
+        from core.json import load_json
+        from core.coverage.store import CoverageStore, coverage_store_lock
+        from core.coverage.importer import (
+            _inventory_paths, import_run_dir, import_run_findings,
+        )
+
+        checklist = load_json(checklist_path)
+        if not checklist:
+            return
+        cov_path = proj / "coverage.json"
+        with coverage_store_lock(cov_path):
+            store = CoverageStore(cov_path)
+            store.set_content_id(checklist)
+            import_run_dir(store, run_dir, checklist)
+            import_run_findings(store, run_dir, _inventory_paths(checklist))
+            store.save()
+    except Exception:  # noqa: BLE001 — never fail lifecycle on a snapshot error
+        log.debug("_snapshot_run_coverage failed for %s", output_dir, exc_info=True)
 
 
 def fail_run(output_dir: Path, error: str = None, extra: Dict[str, Any] = None,

--- a/core/run/tests/test_metadata.py
+++ b/core/run/tests/test_metadata.py
@@ -374,3 +374,85 @@ class TestTrackedRun(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestRunCoverageSnapshot(unittest.TestCase):
+    """complete_run folds a project run's coverage into the durable store
+    (so it survives out-of-band deletion), and is a no-op for standalone runs."""
+
+    def _checklist(self):
+        import json
+        return json.dumps({"files": [
+            {"path": "a.c", "lines": 50, "items": [
+                {"name": "f1", "line_start": 1, "line_end": 20}]}]})
+
+    def test_completion_snapshots_project_run_coverage(self):
+        import json
+
+        from core.coverage.store import CoverageStore
+        with TemporaryDirectory() as d:
+            proj = Path(d)
+            (proj / "checklist.json").write_text(self._checklist())
+            run = proj / "scan-20260526_120000"
+            start_run(run, "scan")
+            (run / "coverage-semgrep.json").write_text(json.dumps(
+                {"tool": "semgrep", "files_examined": ["a.c"], "timestamp": "t"}))
+            (run / "findings.json").write_text(json.dumps(
+                [{"id": "F1", "file": "a.c", "line": 10, "rule_id": "x"}]))
+            complete_run(run)
+
+            store = CoverageStore(proj / "coverage.json")    # persisted at completion
+            self.assertEqual(store.who_checked("a.c", 10), ["semgrep"])
+            self.assertEqual(store.function_verdict("a.c", 1, 20), "open")  # F1 in f1
+
+    def test_completion_converts_reads_manifest_to_llm_coverage(self):
+        # The coverage plugin captures LLM file-reads into .reads-manifest;
+        # complete_run must materialise that into a coverage-llm.json record so
+        # LLM examined-extent reaches the store.
+        from core.coverage.store import CoverageStore
+        with TemporaryDirectory() as d:
+            proj = Path(d)
+            (proj / "checklist.json").write_text(self._checklist())  # a.c, lines 50
+            run = proj / "agentic-20260526_120000"
+            start_run(run, "agentic")
+            (run / ".reads-manifest").write_text("a.c\n")  # the LLM read a.c
+            complete_run(run)
+
+            self.assertTrue((run / "coverage-llm.json").exists())
+            store = CoverageStore(proj / "coverage.json")
+            self.assertEqual(store.who_checked("a.c", 5), ["llm"])
+
+    def test_standalone_run_writes_no_store(self):
+        import json
+        with TemporaryDirectory() as d:
+            out = Path(d) / "out"
+            out.mkdir()
+            run = out / "scan-20260526_120000"
+            start_run(run, "scan")
+            (run / "coverage-semgrep.json").write_text(json.dumps(
+                {"tool": "semgrep", "files_examined": ["a.c"], "timestamp": "t"}))
+            complete_run(run)
+            # No project-level checklist in the parent -> no durable store written.
+            self.assertFalse((out / "coverage.json").exists())
+
+    def test_two_completions_accumulate_under_lock(self):
+        import json
+
+        from core.coverage.store import CoverageStore
+        with TemporaryDirectory() as d:
+            proj = Path(d)
+            (proj / "checklist.json").write_text(json.dumps({"files": [
+                {"path": "a.c", "lines": 50, "items": [
+                    {"name": "f1", "line_start": 1, "line_end": 20}]},
+                {"path": "b.c", "lines": 30, "items": [
+                    {"name": "g1", "line_start": 1, "line_end": 10}]}]}))
+            for nm, f in [("scan-20260526_01", "a.c"), ("codeql-20260526_02", "b.c")]:
+                run = proj / nm
+                start_run(run, nm.split("-")[0])
+                (run / "coverage-semgrep.json").write_text(json.dumps(
+                    {"tool": "semgrep", "files_examined": [f], "timestamp": "t"}))
+                complete_run(run)
+            # Second snapshot's read-modify-write preserved the first's coverage.
+            store = CoverageStore(proj / "coverage.json")
+            self.assertEqual(store.who_checked("a.c", 5), ["semgrep"])
+            self.assertEqual(store.who_checked("b.c", 5), ["semgrep"])

--- a/libexec/raptor-coverage-summary
+++ b/libexec/raptor-coverage-summary
@@ -3,6 +3,8 @@
 
 Usage:
   raptor-coverage-summary [<dir>] [--detailed]          Show coverage summary
+  raptor-coverage-summary [<dir>] --store               Show persistent-store view
+                                                        (category/depth + LLM-review gap)
   raptor-coverage-summary [<dir>] --gaps                List unreviewed items
   raptor-coverage-summary [<dir>] --mark <file:item>    Mark item(s) as reviewed
   raptor-coverage-summary [<dir>] --mark-file <json>    Mark functions from JSON file
@@ -151,6 +153,61 @@ def _get_summary(args):
         return compute_summary(run_dir), run_dir
 
 
+def _store_inputs(args):
+    """Resolve (checklist, run_dirs, store_path, annotations_base)."""
+    from core.json import load_json
+
+    project = run_dir = None
+    if args:
+        project, run_dir = _resolve_dir(args[0])
+        if not project and not run_dir:
+            d = Path(args[0])
+            if d.exists():
+                run_dir = d
+    else:
+        project = _resolve_active_project()
+
+    if project:
+        base = Path(project.output_dir)
+        try:
+            run_dirs = list(project.get_run_dirs(sweep=False))
+        except Exception:
+            run_dirs = []
+        return (load_json(base / "checklist.json"), run_dirs,
+                base / "coverage.json", base / "annotations")
+    if run_dir:
+        return (load_json(run_dir / "checklist.json"), [run_dir],
+                run_dir / "coverage.json", run_dir / "annotations")
+    return None, [], None, None
+
+
+def _cmd_store_view(args):
+    """Build the store on-demand (load persisted + import current records +
+    durable annotations) and print the category/depth + gap view. Read-only:
+    does not persist."""
+    from core.coverage.importer import backfill
+    from core.coverage.store import CoverageStore
+    from core.coverage.store_summary import (
+        file_level_view, format_file_level_view, format_store_view, store_view,
+    )
+
+    checklist, run_dirs, store_path, annotations_base = _store_inputs(args)
+    if not checklist:
+        # No function inventory (e.g. a standalone /scan or /codeql, which
+        # build none). The lifecycle still recorded what ran + which files each
+        # tool examined, so degrade to the file-level tier rather than erroring.
+        if run_dirs:
+            print(format_file_level_view(file_level_view(run_dirs)))
+            return
+        print("No coverage data (no checklist and no run records).", file=sys.stderr)
+        sys.exit(1)
+    # Loads an existing coverage.json if present (durable accumulation);
+    # re-importing current records is idempotent (interval coalesce).
+    store = CoverageStore(store_path)
+    backfill(store, run_dirs, checklist, annotations_base=annotations_base)
+    print(format_store_view(store_view(store, checklist)))
+
+
 def _cmd_gaps(summary):
     """Print unreviewed items."""
     if not summary:
@@ -180,7 +237,6 @@ def _cmd_mark(mark_targets, run_dir):
         sys.exit(1)
 
     from core.coverage.record import load_records, write_record
-    from core.json import load_json
 
     # Load existing LLM record or create new
     records = load_records(run_dir)
@@ -268,6 +324,7 @@ def main():
     argv = sys.argv[1:]
     detailed = "--detailed" in argv
     show_gaps = "--gaps" in argv
+    show_store = "--store" in argv
 
     # Extract --mark, --mark-file, --unmark targets
     mark_targets = []
@@ -354,6 +411,10 @@ def main():
             _cmd_mark(mark_targets, run_dir)
         if unmark_targets:
             _cmd_unmark(unmark_targets, run_dir)
+        return
+
+    if show_store:
+        _cmd_store_view(args)
         return
 
     summary, _ = _get_summary(args)

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -756,6 +756,19 @@ def run_cocci(
     sarif_path = out_dir / "cocci.sarif"
     save_json(sarif_path, sarif_doc)
 
+    # Coverage record — the SARIF translation drops files_examined, so build it
+    # from the spatch results (the true examined-set). Best-effort: a coverage
+    # write must never fail the scan. Previously cocci's examined-set was
+    # recorded nowhere, in any context.
+    try:
+        from packages.coccinelle.runner import version as _spatch_version
+        from core.coverage.record import build_from_cocci, write_record
+        cov = build_from_cocci(results, spatch_version=_spatch_version())
+        if cov:
+            write_record(out_dir, cov, tool_name="coccinelle")
+    except Exception:
+        logger.debug("cocci: coverage record write failed", exc_info=True)
+
     n_results = sum(len(r.matches) for r in results)
     n_errors = sum(len(r.errors or []) for r in results)
     logger.info(

--- a/raptor.py
+++ b/raptor.py
@@ -254,7 +254,12 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
                     write_record(out_dir, record, tool_name="semgrep")
                     break
         if not (out_dir / "coverage-codeql.json").exists():
-            for sarif_path in out_dir.glob("codeql_*.sarif"):
+            # /scan writes codeql_*.sarif at the top level; /agentic writes it
+            # into a codeql/ subdir. Search both. (First match wins — single-
+            # language coverage; multi-language merge is a later refinement.)
+            codeql_sarifs = (list(out_dir.glob("codeql_*.sarif"))
+                             + list((out_dir / "codeql").glob("*.sarif")))
+            for sarif_path in codeql_sarifs:
                 record = build_from_codeql(sarif_path)
                 if record:
                     write_record(out_dir, record, tool_name="codeql")
@@ -349,6 +354,17 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
         # lifecycle itself now (core.run.complete_run), uniformly for every
         # command — no per-command manifest wiring here.
         complete_run(out_dir)
+        # Print a coverage summary at the end of /agentic (after complete_run,
+        # so the scanner + codeql + llm-read records are all materialised).
+        # /scan and /validate print their own; this closes the agentic gap.
+        if command == "agentic":
+            try:
+                from core.coverage.store_summary import render_run_coverage
+                summary = render_run_coverage(out_dir)
+                if summary:
+                    print("\n" + summary)
+            except Exception:
+                pass
     else:
         fail_run(out_dir, error=f"exit code {rc}")
     return rc

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -1267,6 +1267,10 @@ Examples:
             str(script_root / "packages/static-analysis/scanner.py"),
             "--repo", str(repo_path),
             "--policy_groups", args.policy_groups,
+            # Write into the run dir's scan/ subdir (mirrors codeql/) so the
+            # scanner's coverage records (semgrep + cocci) are first-class run
+            # artifacts the coverage store reads — no transient dir, no copy.
+            "--out", str(out_dir / "scan"),
             *sandbox_passthrough,
         ]
         logger.info("Running: Scanning code with Semgrep")
@@ -1394,29 +1398,29 @@ Examples:
                 sys.exit(1)
 
         if rc in (0, 1):
-            scanner_out_dir = RaptorConfig.get_out_dir()
-            scan_dirs = sorted(scanner_out_dir.glob("scan_*"), key=lambda p: p.stat().st_mtime, reverse=True)
+            # The scanner now writes into the run dir's scan/ subdir (--out
+            # above), so its outputs — combined.sarif, scan_metrics.json, and
+            # the coverage records — are first-class run artifacts. No transient
+            # dir to discover, no copy.
+            actual_scan_dir = out_dir / "scan"
+            logger.info(f"Semgrep output in run dir: {actual_scan_dir}")
 
-            if scan_dirs:
-                actual_scan_dir = scan_dirs[0]
-                logger.info(f"Found Semgrep output at: {actual_scan_dir}")
+            scan_metrics_file = actual_scan_dir / "scan_metrics.json"
+            if scan_metrics_file.exists():
+                semgrep_metrics = load_json(scan_metrics_file)
 
-                scan_metrics_file = actual_scan_dir / "scan_metrics.json"
-                if scan_metrics_file.exists():
-                    semgrep_metrics = load_json(scan_metrics_file)
+                print("\n✓ Semgrep scan complete:")
+                print(f"  - Files scanned: {semgrep_metrics.get('total_files_scanned', 0)}")
+                print(f"  - Findings: {semgrep_metrics.get('total_findings', 0)}")
+                print(f"  - Critical: {semgrep_metrics.get('findings_by_severity', {}).get('error', 0)}")
+                print(f"  - Warnings: {semgrep_metrics.get('findings_by_severity', {}).get('warning', 0)}")
 
-                    print("\n✓ Semgrep scan complete:")
-                    print(f"  - Files scanned: {semgrep_metrics.get('total_files_scanned', 0)}")
-                    print(f"  - Findings: {semgrep_metrics.get('total_findings', 0)}")
-                    print(f"  - Critical: {semgrep_metrics.get('findings_by_severity', {}).get('error', 0)}")
-                    print(f"  - Warnings: {semgrep_metrics.get('findings_by_severity', {}).get('warning', 0)}")
-
-                sarif_file = actual_scan_dir / "combined.sarif"
-                if sarif_file.exists():
-                    all_sarif_files.append(sarif_file)
-                else:
-                    semgrep_sarifs = list(actual_scan_dir.glob("semgrep_*.sarif"))
-                    all_sarif_files.extend(semgrep_sarifs)
+            sarif_file = actual_scan_dir / "combined.sarif"
+            if sarif_file.exists():
+                all_sarif_files.append(sarif_file)
+            else:
+                semgrep_sarifs = list(actual_scan_dir.glob("semgrep_*.sarif"))
+                all_sarif_files.extend(semgrep_sarifs)
         elif rc != -1:  # -1 is timeout, already reported
             print(f"❌ Semgrep scan failed (exit code {rc})")
             if not run_codeql:


### PR DESCRIPTION
Adds a durable CoverageStore (extent + depth/category + verdict + provenance) that survives /project clean, fed by the actual scan/agentic/codeql/cocci producers; completes Phase-1 inventory (top_level + interstitial + C globals) so every SLOC is a classified, coverage-visible item.