### PR TITLE
fix(sca): refresh-output hygiene — stable sample sort, quieter logs

### DIFF
--- a/packages/sca/calibration/project_samples.py
+++ b/packages/sca/calibration/project_samples.py
@@ -924,6 +924,18 @@ def _sanitise_findings(
             "ssvc_exploitation": sca.get("ssvc_exploitation"),
             "ssvc_automatable": sca.get("ssvc_automatable"),
         })
+    # Stable, total ordering so a refresh only diffs on real changes. The
+    # pipeline emits findings in a concurrency-dependent order, which made
+    # every weekly corpus refresh churn whole files (equal insert/delete
+    # counts) and buried the actual deltas. Key on the fields that identify
+    # a finding; ``finding_id`` encodes ecosystem:name:cve so it groups
+    # sensibly, with purl + version as tie-breakers.
+    out.sort(key=lambda f: (
+        f.get("finding_id") or "",
+        f.get("purl") or "",
+        f.get("dep_name") or "",
+        f.get("dep_version") or "",
+    ))
     return out
 
 

--- a/packages/sca/calibration/tests/test_project_samples.py
+++ b/packages/sca/calibration/tests/test_project_samples.py
@@ -117,6 +117,31 @@ def test_sanitise_skips_malformed_entries(tmp_path):
     assert len(out) == 1
 
 
+def test_sanitise_orders_deterministically(tmp_path):
+    """Output is in a stable, total order independent of input order, so a
+    corpus refresh only diffs on real changes (not reordering churn)."""
+    def _vuln(fid: str, name: str):
+        return {
+            "vuln_type": "sca:vulnerable_dependency",
+            "finding_id": fid,
+            "severity": "high",
+            "sca": {"ecosystem": "npm", "name": name, "version": "1.0.0",
+                    "purl": f"pkg:npm/{name}@1.0.0"},
+        }
+
+    scrambled = [
+        _vuln("sca:vd:npm:z:CVE-2", "z"),
+        _vuln("sca:vd:npm:a:CVE-1", "a"),
+        _vuln("sca:vd:npm:m:CVE-3", "m"),
+    ]
+    ids = [f["finding_id"] for f in _sanitise_findings(scrambled, tmp_path)]
+    assert ids == sorted(ids)
+    # Reversed input → identical output (the churn this prevents).
+    rev = [f["finding_id"]
+           for f in _sanitise_findings(list(reversed(scrambled)), tmp_path)]
+    assert rev == ids
+
+
 # ---------------------------------------------------------------------------
 # collect_project_samples — orchestrator + license filter
 # ---------------------------------------------------------------------------

--- a/packages/sca/parsers/nuget.py
+++ b/packages/sca/parsers/nuget.py
@@ -160,6 +160,7 @@ def parse_msbuild_project(path: Path) -> List[Dependency]:
 
     # MSBuild XML is namespaced (xmlns="http://schemas...") in some files
     # but namespace-less in modern SDK-style projects; iter both.
+    skipped_no_version = []
     for el in _findall_pkgref(root):
         name = el.get("Include") or el.get("Update")
         if not name:
@@ -186,16 +187,12 @@ def parse_msbuild_project(path: Path) -> List[Dependency]:
             if version is not None:
                 source_origin = "cpm_central"
         if not version:
-            # Still no version — log a parser warning that the
-            # ``capture_parse_failures`` handler picks up and
-            # surfaces in report.md.
-            logger.warning(
-                "sca.parsers.nuget: PackageReference parse failed "
-                "for %s: <PackageReference Include=%r/> has no "
-                "Version, no VersionOverride, and no CPM entry; "
-                "skipping",
-                path, name,
-            )
+            # No resolvable version (no inline, no VersionOverride, no CPM
+            # entry). Common + benign for shared-framework refs whose version
+            # comes from the SDK (e.g. Microsoft.AspNetCore.App). Collect and
+            # emit ONE warning per file below — a .NET monorepo's sample
+            # projects otherwise produce dozens of per-ref lines.
+            skipped_no_version.append(name)
             continue
         pin_style, normalised = _classify_version_spec(version)
         if normalised is not None:
@@ -214,6 +211,19 @@ def parse_msbuild_project(path: Path) -> List[Dependency]:
             continue
         seen_keys.add(dep.key())
         out.append(dep)
+    if skipped_no_version:
+        # One aggregated parser warning per file instead of one per
+        # PackageReference. Keep the canonical "<kind> parse failed for
+        # <path>: <reason>" shape so capture_parse_failures still lifts it
+        # into report.md (it matches on that format, not the logger name).
+        # Sorted names for a stable message.
+        logger.warning(
+            "sca.parsers.nuget: PackageReference parse failed for %s: "
+            "%d reference(s) have no Version, VersionOverride, or CPM "
+            "entry (skipped): %s",
+            path, len(skipped_no_version),
+            ", ".join(sorted(skipped_no_version)),
+        )
     return out
 
 

--- a/packages/sca/registries/crates.py
+++ b/packages/sca/registries/crates.py
@@ -16,6 +16,8 @@ from typing import List, Optional
 from core.json import JsonCache, MISSING
 from core.http import HttpClient
 
+from ._negative_cache import log_fetch_failure
+
 logger = logging.getLogger(__name__)
 
 
@@ -73,10 +75,7 @@ class CratesClient:
                 f"https://crates.io/api/v1/crates/{name}",
             )
         except Exception as e:                # noqa: BLE001
-            logger.warning(
-                "sca.registries.crates: meta fetch failed for %r: %s",
-                name, e,
-            )
+            log_fetch_failure(logger, "sca.registries.crates", name, e)
             if self._cache is not None:
                 self._cache.put(cache_key, None, ttl_seconds=self._ttl)
             return None
@@ -107,10 +106,8 @@ class CratesClient:
                 f"{version}/dependencies",
             )
         except Exception as e:                # noqa: BLE001
-            logger.warning(
-                "sca.registries.crates: deps fetch failed for "
-                "%r@%r: %s", name, version, e,
-            )
+            log_fetch_failure(
+                logger, "sca.registries.crates", f"{name}@{version}", e)
             if self._cache is not None:
                 self._cache.put(cache_key, None, ttl_seconds=self._ttl)
             return None

--- a/packages/sca/registries/packagist.py
+++ b/packages/sca/registries/packagist.py
@@ -19,6 +19,8 @@ from typing import List, Optional
 from core.json import JsonCache, MISSING
 from core.http import HttpClient
 
+from ._negative_cache import log_fetch_failure
+
 logger = logging.getLogger(__name__)
 
 
@@ -93,10 +95,7 @@ class PackagistClient:
                 f"https://repo.packagist.org/p2/{name}.json",
             )
         except Exception as e:                # noqa: BLE001
-            logger.warning(
-                "sca.registries.packagist: meta fetch failed for %r: %s",
-                name, e,
-            )
+            log_fetch_failure(logger, "sca.registries.packagist", name, e)
             if self._cache is not None:
                 self._cache.put(cache_key, None, ttl_seconds=self._ttl)
             return None


### PR DESCRIPTION
Deterministically sort calibration sample findings (kills the reorder churn in weekly corpus auto-PRs); aggregate NuGet version-less PackageReference warnings to one per file (still captured into report.md); and route crates/packagist fetch failures through log_fetch_failure so every registry logs 404s at debug, real failures at warning.