### PR TITLE
feat: add AWS Bedrock as an LLM provider option

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,46 @@ export MISTRAL_API_KEY=...             # Mistral
 export OLLAMA_HOST=http://localhost:11434  # Local Ollama
 ```
 
+### AWS Bedrock
+
+Run Claude on Bedrock instead of the Anthropic API. Same models, same wire format, AWS-native auth via SigV4 — no API keys flow through models.json.
+
+Install the SDKs:
+
+```bash
+pip install boto3 anthropic
+```
+
+Set your region (boto3 picks up credentials from the standard chain — env vars, profile, IAM role):
+
+```bash
+export AWS_REGION=us-east-1
+export AWS_PROFILE=my-profile          # optional
+```
+
+Configure a model in `~/.config/raptor/models.json`:
+
+```json
+{
+  "models": [
+    {
+      "provider": "bedrock",
+      "model": "us.anthropic.claude-opus-4-7",
+      "role": "analysis"
+    },
+    {
+      "provider": "bedrock",
+      "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+      "role": "fallback"
+    }
+  ]
+}
+```
+
+Bedrock is opt-in only — RAPTOR will not auto-detect Bedrock from ambient `AWS_REGION` unless you explicitly select it via `models.json` or `RAPTOR_PROVIDER_PREFER=bedrock`. This avoids surprising users with AWS env vars set for unrelated reasons.
+
+Cross-region inference profiles (`us.`, `eu.`, `apac.`, `global.` prefixes) work the same as region-pinned IDs. Pricing tracks the underlying Anthropic models and is shared with the Anthropic provider's cost tables.
+
 Model roles let you assign different models to different tasks:
 
 | Role | What it does |

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -737,6 +737,15 @@ class RaptorConfig:
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
         "AWS_SESSION_TOKEN",
+        # Bedrock additionally needs region + profile resolution to work.
+        # Without these, boto3 falls back to bare defaults and the
+        # ``AnthropicBedrock`` client cannot pick a regional endpoint.
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "AWS_PROFILE",
+        "AWS_DEFAULT_PROFILE",
+        "AWS_CONFIG_FILE",
+        "AWS_SHARED_CREDENTIALS_FILE",
         "AZURE_OPENAI_API_KEY",
         "AZURE_OPENAI_ENDPOINT",
         "GOOGLE_APPLICATION_CREDENTIALS",  # GCP service account JSON path

--- a/core/llm/config.py
+++ b/core/llm/config.py
@@ -283,6 +283,42 @@ def _build_anthropic_config() -> Optional['ModelConfig']:
     )
 
 
+def _build_bedrock_config() -> Optional['ModelConfig']:
+    """AWS Bedrock provider config builder.
+
+    Triggered when boto3 + AnthropicBedrock SDKs are importable AND
+    AWS_REGION (or AWS_DEFAULT_REGION) is set. boto3's credential
+    chain (env vars, profile, IAM role) handles auth — RAPTOR never
+    sees the credentials directly.
+
+    The default model is a cross-region inference profile for broadest
+    regional availability. Override in models.json if you need a
+    region-specific or non-default model.
+    """
+    from .detection import BEDROCK_AVAILABLE
+    if not BEDROCK_AVAILABLE:
+        return None
+    region = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")
+    if not region:
+        return None
+    default_model = PROVIDER_DEFAULT_MODELS.get(
+        "bedrock", "us.anthropic.claude-opus-4-7"
+    )
+    limits = MODEL_LIMITS.get(default_model, {})
+    costs = MODEL_COSTS.get(default_model, {})
+    return ModelConfig(
+        provider="bedrock",
+        model_name=default_model,
+        # api_key intentionally None — Bedrock auth is via boto3
+        # credential chain, not key passthrough.
+        api_key=None,
+        max_tokens=limits.get("max_output", _DEFAULT_MAX_OUTPUT_FRONTIER),
+        max_context=limits.get("max_context", _DEFAULT_MAX_CONTEXT_FRONTIER),
+        temperature=0.7,
+        cost_per_1k_tokens=(costs.get("input", 0.003) + costs.get("output", 0.015)) / 2,
+    )
+
+
 def _build_openai_compat_config(provider_name: str) -> Optional['ModelConfig']:
     """Generic builder for OpenAI / Gemini / Mistral — same shape, different env var + endpoint."""
     env_var_map = {"openai": "OPENAI_API_KEY", "gemini": "GEMINI_API_KEY", "mistral": "MISTRAL_API_KEY"}
@@ -401,6 +437,7 @@ def _build_claudecode_config() -> Optional['ModelConfig']:
 
 _PROVIDER_BUILDERS = {
     "anthropic":  _build_anthropic_config,
+    "bedrock":    _build_bedrock_config,
     "openai":     lambda: _build_openai_compat_config("openai"),
     "gemini":     lambda: _build_openai_compat_config("gemini"),
     "mistral":    lambda: _build_openai_compat_config("mistral"),

--- a/core/llm/detection.py
+++ b/core/llm/detection.py
@@ -38,6 +38,19 @@ except ImportError as _e:
     logger.debug("openai SDK probe failed: %s", _e)
     OPENAI_SDK_AVAILABLE = False
 
+# Bedrock requires both boto3 (for the AWS SDK and credential chain)
+# and AnthropicBedrock from the anthropic SDK (for the Messages API
+# wire format that BedrockProvider proxies to). If either is missing,
+# bedrock is not usable — even when AWS_REGION is set — and the
+# detection layer flags the misconfiguration.
+try:
+    import boto3 as _boto3_module  # noqa: F401 — availability probe
+    from anthropic import AnthropicBedrock as _ab  # noqa: F401 — availability probe
+    BEDROCK_AVAILABLE = True
+except ImportError as _e:
+    logger.debug("Bedrock SDK probe failed: %s (need boto3 + anthropic)", _e)
+    BEDROCK_AVAILABLE = False
+
 try:
     import anthropic as _anthropic_module  # noqa: F401 — availability probe
     ANTHROPIC_SDK_AVAILABLE = True
@@ -480,6 +493,9 @@ def _config_has_keyed_models() -> bool:
         if provider == "anthropic":
             if not (ANTHROPIC_SDK_AVAILABLE or OPENAI_SDK_AVAILABLE):
                 continue
+        elif provider == "bedrock":
+            if not BEDROCK_AVAILABLE:
+                continue
         elif provider == "ollama":
             if not OPENAI_SDK_AVAILABLE:
                 continue
@@ -532,8 +548,16 @@ def detect_llm_availability() -> LLMAvailability:
     has_openai = bool(os.getenv("OPENAI_API_KEY")) and OPENAI_SDK_AVAILABLE
     has_gemini = bool(os.getenv("GEMINI_API_KEY")) and (GENAI_SDK_AVAILABLE or OPENAI_SDK_AVAILABLE)
     has_mistral = bool(os.getenv("MISTRAL_API_KEY")) and OPENAI_SDK_AVAILABLE
+    # Bedrock signal: any AWS_REGION (or AWS_DEFAULT_REGION) plus the
+    # required SDKs. The boto3 credential chain handles actual auth —
+    # IAM role, profile, or env-var creds all work without any
+    # RAPTOR-side key handling.
+    has_bedrock = (
+        BEDROCK_AVAILABLE
+        and bool(os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION"))
+    )
 
-    has_cloud_keys = has_anthropic or has_openai or has_gemini or has_mistral
+    has_cloud_keys = has_anthropic or has_openai or has_gemini or has_mistral or has_bedrock
 
     # Phase B credential-isolation: a worker spawned via the
     # dispatcher has ``RAPTOR_LLM_SOCKET`` set but no API keys in
@@ -594,6 +618,7 @@ def _warn_unusable_keys():
         "openai": ("openai", OPENAI_SDK_AVAILABLE),
         "gemini": ("google-genai or openai", GENAI_SDK_AVAILABLE or OPENAI_SDK_AVAILABLE),
         "mistral": ("openai", OPENAI_SDK_AVAILABLE),
+        "bedrock": ("boto3 + anthropic", BEDROCK_AVAILABLE),
     }
 
     for provider, env_var in PROVIDER_ENV_KEYS.items():

--- a/core/llm/model_data.py
+++ b/core/llm/model_data.py
@@ -194,13 +194,100 @@ MODEL_LIMITS = {
     "ministral-3b-latest":     {"max_context": 256000,  "max_output": 256000},
 }
 
-# Provider -> env var mapping for API key lookup
+# Provider -> env var mapping for API key lookup.
+# Bedrock uses AWS_REGION as its "key marker" — there is no API key,
+# but the boto3 credential chain needs a region to operate. The detection
+# layer treats any AWS_REGION (or AWS_DEFAULT_REGION) as the presence
+# signal and the boto3 credential chain handles the actual auth.
 PROVIDER_ENV_KEYS = {
     "anthropic": "ANTHROPIC_API_KEY",
     "openai": "OPENAI_API_KEY",
     "gemini": "GEMINI_API_KEY",
     "mistral": "MISTRAL_API_KEY",
+    "bedrock":  "AWS_REGION",
 }
+
+
+# ---------------------------------------------------------------------------
+# AWS Bedrock model IDs.
+# Bedrock hosts the same Anthropic Claude models as the Anthropic API
+# but uses AWS-prefixed model IDs and SigV4 auth via boto3. Costs and
+# context/output limits are identical to the underlying Anthropic models;
+# we add the Bedrock IDs as duplicate entries so cost tracking and limit
+# enforcement work with no special-casing in callers.
+#
+# Inference profile prefixes (us./eu./apac.) enable cross-region
+# inference for higher throughput. Region-specific (non-prefixed) IDs
+# are also valid in regions that support on-demand for that model.
+# Add more IDs here as new Claude models land on Bedrock.
+# ---------------------------------------------------------------------------
+
+_BEDROCK_CLAUDE_COST_MAP = {
+    # Bedrock model ID                                         -> canonical Anthropic ID
+    # ---- Region-pinned (no inference profile prefix) ----
+    # These are the IDs returned by ``aws bedrock list-foundation-models``.
+    # Plain (no -v1:0 suffix) IDs map cleanly to canonical Anthropic
+    # models for cost/limit lookup.
+    "anthropic.claude-opus-4-7":                                "claude-opus-4-7",
+    "anthropic.claude-sonnet-4-6":                              "claude-sonnet-4-6",
+    "anthropic.claude-haiku-4-5-20251001-v1:0":                 "claude-haiku-4-5",
+    "anthropic.claude-opus-4-6-v1":                             "claude-opus-4-6",
+    "anthropic.claude-sonnet-4-5-20250929-v1:0":                "claude-sonnet-4-5",
+    "anthropic.claude-opus-4-5-20251101-v1:0":                  "claude-opus-4-5",
+    "anthropic.claude-opus-4-1-20250805-v1:0":                  "claude-opus-4-1",
+    # ---- US cross-region inference profiles ----
+    "us.anthropic.claude-opus-4-7":                             "claude-opus-4-7",
+    "us.anthropic.claude-sonnet-4-6":                           "claude-sonnet-4-6",
+    "us.anthropic.claude-haiku-4-5-20251001-v1:0":              "claude-haiku-4-5",
+    "us.anthropic.claude-opus-4-6-v1":                          "claude-opus-4-6",
+    "us.anthropic.claude-sonnet-4-5-20250929-v1:0":             "claude-sonnet-4-5",
+    "us.anthropic.claude-opus-4-5-20251101-v1:0":               "claude-opus-4-5",
+    "us.anthropic.claude-opus-4-1-20250805-v1:0":               "claude-opus-4-1",
+    # ---- EU cross-region inference profiles ----
+    "eu.anthropic.claude-opus-4-7":                             "claude-opus-4-7",
+    "eu.anthropic.claude-sonnet-4-6":                           "claude-sonnet-4-6",
+    "eu.anthropic.claude-haiku-4-5-20251001-v1:0":              "claude-haiku-4-5",
+    "eu.anthropic.claude-opus-4-6-v1":                          "claude-opus-4-6",
+    "eu.anthropic.claude-sonnet-4-5-20250929-v1:0":             "claude-sonnet-4-5",
+    "eu.anthropic.claude-opus-4-5-20251101-v1:0":               "claude-opus-4-5",
+    # ---- Australia cross-region inference profiles ----
+    # APAC region uses ``au.`` for Claude 4.x; legacy ``apac.`` is
+    # Claude 3.x era only.
+    "au.anthropic.claude-opus-4-7":                             "claude-opus-4-7",
+    "au.anthropic.claude-sonnet-4-6":                           "claude-sonnet-4-6",
+    "au.anthropic.claude-haiku-4-5-20251001-v1:0":              "claude-haiku-4-5",
+    "au.anthropic.claude-opus-4-6-v1":                          "claude-opus-4-6",
+    "au.anthropic.claude-sonnet-4-5-20250929-v1:0":             "claude-sonnet-4-5",
+    "au.anthropic.claude-opus-4-5-20251101-v1:0":               "claude-opus-4-5",
+    # ---- Global cross-region inference profiles ----
+    # Broadest reach — routes to whichever region has capacity.
+    "global.anthropic.claude-opus-4-7":                         "claude-opus-4-7",
+    "global.anthropic.claude-sonnet-4-6":                       "claude-sonnet-4-6",
+    "global.anthropic.claude-haiku-4-5-20251001-v1:0":          "claude-haiku-4-5",
+    "global.anthropic.claude-opus-4-6-v1":                      "claude-opus-4-6",
+    "global.anthropic.claude-sonnet-4-5-20250929-v1:0":         "claude-sonnet-4-5",
+    "global.anthropic.claude-opus-4-5-20251101-v1:0":           "claude-opus-4-5",
+}
+
+
+def _register_bedrock_aliases() -> None:
+    """Populate MODEL_COSTS / MODEL_LIMITS for Bedrock IDs by aliasing
+    them to the underlying Anthropic model entries. Idempotent — safe
+    to call from module import."""
+    for bedrock_id, anthropic_id in _BEDROCK_CLAUDE_COST_MAP.items():
+        if bedrock_id not in MODEL_COSTS and anthropic_id in MODEL_COSTS:
+            MODEL_COSTS[bedrock_id] = MODEL_COSTS[anthropic_id]
+        if bedrock_id not in MODEL_LIMITS and anthropic_id in MODEL_LIMITS:
+            MODEL_LIMITS[bedrock_id] = MODEL_LIMITS[anthropic_id]
+
+
+_register_bedrock_aliases()
+
+# Default Bedrock model when an operator says provider=bedrock without
+# specifying a model. Cross-region us. profile picked because it has
+# the broadest regional availability and highest throughput headroom.
+PROVIDER_DEFAULT_MODELS["bedrock"] = "us.anthropic.claude-opus-4-7"
+PROVIDER_FAST_MODELS["bedrock"] = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
 
 # ---------------------------------------------------------------------------
@@ -260,3 +347,32 @@ def price_for(
 # ``cache_creation_input_tokens`` / ``cache_read_input_tokens``.
 ANTHROPIC_CACHE_WRITE_MULTIPLIER = 1.25
 ANTHROPIC_CACHE_READ_MULTIPLIER = 0.1
+
+
+# Models that have deprecated the ``temperature`` parameter. Newer
+# reasoning-tier Claude models (Opus 4.7+) reject requests containing
+# ``temperature`` with a 400 BadRequest "temperature is deprecated for
+# this model" error. AnthropicProvider checks this set before adding
+# the field to ``messages.create`` kwargs. Both canonical Anthropic
+# IDs and the Bedrock-prefixed variants are listed so the same set
+# works for AnthropicProvider and BedrockProvider.
+MODELS_WITHOUT_TEMPERATURE = frozenset({
+    # Anthropic canonical
+    "claude-opus-4-7",
+    # Bedrock region-pinned + cross-region inference profiles
+    "anthropic.claude-opus-4-7",
+    "us.anthropic.claude-opus-4-7",
+    "eu.anthropic.claude-opus-4-7",
+    "au.anthropic.claude-opus-4-7",
+    "global.anthropic.claude-opus-4-7",
+})
+
+
+def supports_temperature(model: str) -> bool:
+    """Return False for models that have deprecated the ``temperature``
+    request parameter (Opus 4.7+). Callers should omit ``temperature``
+    from their request kwargs when this returns False — passing it
+    causes the Anthropic / Bedrock API to reject the request with a
+    400. Defaults to True for unknown models (safer default — most
+    models still accept temperature)."""
+    return model not in MODELS_WITHOUT_TEMPERATURE

--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 from core.logging import get_logger
 from .config import ModelConfig
+from .model_data import supports_temperature
 # Wire-shape types for tool-use turn primitive. These live in
 # ``core.llm.tool_use.types`` (zero dependencies on this module);
 # importing them here doesn't create a cycle.
@@ -73,7 +74,7 @@ def _safe_int(value: Any, *, default: int) -> int:
 
 
 # SDK availability flags (canonical source is detection.py)
-from .detection import OPENAI_SDK_AVAILABLE, ANTHROPIC_SDK_AVAILABLE, GENAI_SDK_AVAILABLE  # noqa: E402
+from .detection import OPENAI_SDK_AVAILABLE, ANTHROPIC_SDK_AVAILABLE, GENAI_SDK_AVAILABLE, BEDROCK_AVAILABLE  # noqa: E402
 
 # Re-import the actual modules where available (config.py only sets flags)
 if OPENAI_SDK_AVAILABLE:
@@ -82,6 +83,13 @@ if ANTHROPIC_SDK_AVAILABLE:
     import anthropic
 if GENAI_SDK_AVAILABLE:
     from google import genai as _genai_module
+if BEDROCK_AVAILABLE:
+    # AnthropicBedrock exposes the same .messages.create surface as
+    # the regular anthropic.Anthropic client, but routes through
+    # AWS Bedrock with SigV4 auth via boto3. This is the official
+    # Anthropic-supported way to use Claude on Bedrock — no manual
+    # boto3 invoke_model wrangling needed.
+    from anthropic import AnthropicBedrock
 
 try:
     import instructor
@@ -1515,9 +1523,14 @@ class AnthropicProvider(LLMProvider):
         create_kwargs = {
             "model": self.config.model_name,
             "messages": messages,
-            "temperature": kwargs.get("temperature", self.config.temperature),
             "max_tokens": kwargs.get("max_tokens", self.config.max_tokens),
         }
+        # Newer reasoning-tier Claude models (Opus 4.7+) reject
+        # ``temperature`` with a 400 BadRequest. ``supports_temperature``
+        # gates the field for forward-compat — older models still
+        # honour the configured value.
+        if supports_temperature(self.config.model_name):
+            create_kwargs["temperature"] = kwargs.get("temperature", self.config.temperature)
         if system_prompt:
             create_kwargs["system"] = system_prompt
 
@@ -1599,9 +1612,12 @@ class AnthropicProvider(LLMProvider):
                     "model": self.config.model_name,
                     "response_model": pydantic_model,
                     "messages": messages,
-                    "temperature": temperature,
                     "max_tokens": self.config.max_tokens,
                 }
+                # Newer reasoning-tier Claude models (Opus 4.7+) reject
+                # ``temperature`` with a 400 BadRequest.
+                if supports_temperature(self.config.model_name):
+                    create_kwargs["temperature"] = temperature
                 if system_prompt:
                     create_kwargs["system"] = system_prompt
 
@@ -2029,6 +2045,103 @@ def _attach_anthropic_cache_marker(message: Dict[str, Any]) -> None:
     last = dict(message["content"][-1])
     last["cache_control"] = {"type": "ephemeral"}
     message["content"][-1] = last
+
+
+class BedrockProvider(AnthropicProvider):
+    """LLM provider for AWS Bedrock — Claude models via SigV4 auth.
+
+    Bedrock hosts the same Anthropic Claude models as the Anthropic
+    API but uses AWS-prefixed model IDs and authenticates via the
+    boto3 credential chain (env vars, profile, IAM role) rather than
+    an API key. Anthropic's official SDK ships ``AnthropicBedrock``
+    with the same ``.messages.create`` / ``.beta.messages.create``
+    surface as ``anthropic.Anthropic``, so this provider only
+    overrides ``__init__`` to swap the client. All other behaviour
+    (tool use, prompt caching, structured output, cost computation,
+    transient-error retry) is inherited unchanged from
+    :class:`AnthropicProvider`.
+
+    Auth resolution:
+        1. boto3 default credential chain (env, profile, IAM role)
+        2. ``AWS_REGION`` (preferred) or ``AWS_DEFAULT_REGION`` env var
+        3. ``AWS_PROFILE`` env var (when using a named profile)
+
+    No API key is ever passed through ``ModelConfig.api_key`` — leave
+    it ``None``. The underlying boto3 client handles credentials
+    transparently.
+
+    Pricing parity:
+        Bedrock Claude pricing tracks Anthropic's published rates for
+        the same model. ``model_data.MODEL_COSTS`` carries Bedrock
+        model IDs as aliases for the underlying Anthropic entries, so
+        cost tracking works identically across both providers.
+
+    Cross-region inference:
+        Use ``us.``, ``eu.``, ``apac.``, or ``global.`` prefixes
+        (e.g. ``us.anthropic.claude-sonnet-4-5-20250929-v1:0``) to
+        opt into cross-region inference profiles for higher
+        throughput. Region-pinned IDs (without prefix) work in
+        regions that support on-demand for the model.
+
+    Caveats:
+        - Prompt caching is supported on Bedrock for most Claude
+          models but the cache TTL and pricing match Anthropic
+          direct. The inherited ``supports_prompt_caching`` returns
+          True; the actual cache HIT/WRITE costs come from the same
+          ``MODEL_COSTS`` table via the alias map.
+        - The credential-isolation dispatcher (Phase B/C) is not yet
+          wired for Bedrock — it's an Anthropic-direct-only feature.
+          When ``RAPTOR_LLM_SOCKET`` is set, the parent must already
+          have used :class:`AnthropicProvider` to construct the
+          dispatcher; downstream Bedrock workers fall back to
+          direct boto3 auth.
+    """
+
+    def __init__(self, config: ModelConfig):
+        # Skip AnthropicProvider.__init__ to avoid the
+        # ANTHROPIC_SDK_AVAILABLE check and the dispatcher route
+        # (which only wraps the Anthropic-direct client). Replicate
+        # only the bits we need.
+        LLMProvider.__init__(self, config)
+
+        if not BEDROCK_AVAILABLE:
+            raise ImportError(
+                "Bedrock provider requires both: "
+                "pip install boto3 anthropic"
+            )
+
+        # boto3 picks up region from AWS_REGION / AWS_DEFAULT_REGION /
+        # boto3 default config; profile from AWS_PROFILE; credentials
+        # from the standard chain (env, profile, IAM role, IMDS).
+        # ModelConfig may carry an explicit aws_region override in
+        # future — for now rely on the env/SDK chain.
+        region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+        client_kwargs: Dict[str, Any] = {}
+        if region:
+            client_kwargs["aws_region"] = region
+
+        self.client = AnthropicBedrock(
+            timeout=config.timeout,
+            **client_kwargs,
+        )
+        logger.debug(
+            "BedrockProvider: region=%s model=%s",
+            region or "(boto3 default)",
+            config.model_name,
+        )
+
+        # Mirror AnthropicProvider's instructor + caching state so
+        # inherited methods can use them unchanged.
+        self.instructor_client = None
+        self._instructor_warned = False
+        if INSTRUCTOR_AVAILABLE:
+            self.instructor_client = instructor.from_anthropic(self.client)
+        else:
+            logger.warning(
+                "Instructor not installed — structured output will use JSON-in-prompt fallback. "
+                "For more reliable structured output: pip install instructor"
+            )
+        self._caching_warning_emitted = False
 
 
 class GeminiProvider(LLMProvider):
@@ -2921,6 +3034,12 @@ def create_provider(config: ModelConfig) -> LLMProvider:
     provider = config.provider.lower()
     if provider in ("claudecode", "claude_code", "claude-code"):
         return ClaudeCodeLLMProvider(config)
+    if provider == "bedrock":
+        if BEDROCK_AVAILABLE:
+            return BedrockProvider(config)
+        raise RuntimeError(
+            "Bedrock provider requires: pip install boto3 anthropic"
+        )
     if provider == "anthropic":
         if ANTHROPIC_SDK_AVAILABLE:
             return AnthropicProvider(config)

--- a/core/llm/tests/test_bedrock_provider.py
+++ b/core/llm/tests/test_bedrock_provider.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Tests for the AWS Bedrock LLM provider integration.
+
+Covers:
+  * Bedrock SDK availability flag
+  * Bedrock model alias map (cost/limit lookup parity with Anthropic)
+  * ``supports_temperature`` gate (Opus 4.7+ models)
+  * ``_build_bedrock_config`` env-driven activation
+  * ``create_provider`` factory dispatch to ``BedrockProvider``
+  * ``provider_of`` routing for Bedrock-prefixed model IDs
+  * Resource policy validation in orchestrator (no-API-key path)
+
+Live SDK calls are mocked — a real round-trip lives in
+``test_bedrock_provider_live`` (gated behind ``--integration`` per
+pytest.ini).
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.llm.detection import BEDROCK_AVAILABLE, detect_llm_availability
+from core.llm.config import _build_bedrock_config, _PROVIDER_BUILDERS
+from core.llm.model_data import (
+    MODEL_COSTS,
+    MODEL_LIMITS,
+    MODELS_WITHOUT_TEMPERATURE,
+    PROVIDER_DEFAULT_MODELS,
+    PROVIDER_ENV_KEYS,
+    PROVIDER_FAST_MODELS,
+    supports_temperature,
+)
+from core.security.llm_family import provider_of, family_of
+
+
+# ---------------------------------------------------------------------------
+# Detection / SDK availability
+# ---------------------------------------------------------------------------
+
+
+class TestBedrockAvailability:
+    def test_flag_exposed(self):
+        # The flag is True in this venv (boto3 + anthropic both installed).
+        # Other test environments may be False — we only assert it's a bool.
+        assert isinstance(BEDROCK_AVAILABLE, bool)
+
+    def test_provider_in_env_keys(self):
+        assert PROVIDER_ENV_KEYS["bedrock"] == "AWS_REGION"
+
+
+# ---------------------------------------------------------------------------
+# Model alias map — Bedrock IDs must alias to canonical Anthropic costs/limits
+# ---------------------------------------------------------------------------
+
+
+class TestBedrockModelAliases:
+    @pytest.mark.parametrize("bedrock_id,canonical", [
+        ("us.anthropic.claude-opus-4-7", "claude-opus-4-7"),
+        ("eu.anthropic.claude-opus-4-7", "claude-opus-4-7"),
+        ("au.anthropic.claude-opus-4-7", "claude-opus-4-7"),
+        ("global.anthropic.claude-opus-4-7", "claude-opus-4-7"),
+        ("anthropic.claude-opus-4-7", "claude-opus-4-7"),
+        ("us.anthropic.claude-sonnet-4-6", "claude-sonnet-4-6"),
+        ("us.anthropic.claude-haiku-4-5-20251001-v1:0", "claude-haiku-4-5"),
+        ("us.anthropic.claude-opus-4-6-v1", "claude-opus-4-6"),
+        ("us.anthropic.claude-sonnet-4-5-20250929-v1:0", "claude-sonnet-4-5"),
+        ("us.anthropic.claude-opus-4-5-20251101-v1:0", "claude-opus-4-5"),
+        ("us.anthropic.claude-opus-4-1-20250805-v1:0", "claude-opus-4-1"),
+    ])
+    def test_costs_aliased(self, bedrock_id: str, canonical: str):
+        assert bedrock_id in MODEL_COSTS, f"{bedrock_id} missing from MODEL_COSTS"
+        assert canonical in MODEL_COSTS, f"canonical {canonical} not in MODEL_COSTS"
+        assert MODEL_COSTS[bedrock_id] == MODEL_COSTS[canonical]
+
+    @pytest.mark.parametrize("bedrock_id,canonical", [
+        ("us.anthropic.claude-opus-4-7", "claude-opus-4-7"),
+        ("us.anthropic.claude-haiku-4-5-20251001-v1:0", "claude-haiku-4-5"),
+        ("us.anthropic.claude-opus-4-6-v1", "claude-opus-4-6"),
+    ])
+    def test_limits_aliased(self, bedrock_id: str, canonical: str):
+        assert bedrock_id in MODEL_LIMITS
+        assert canonical in MODEL_LIMITS
+        assert MODEL_LIMITS[bedrock_id] == MODEL_LIMITS[canonical]
+
+    def test_default_model_is_opus_47(self):
+        assert PROVIDER_DEFAULT_MODELS["bedrock"] == "us.anthropic.claude-opus-4-7"
+
+    def test_fast_model_is_haiku(self):
+        assert "haiku" in PROVIDER_FAST_MODELS["bedrock"].lower()
+
+
+# ---------------------------------------------------------------------------
+# supports_temperature gate
+# ---------------------------------------------------------------------------
+
+
+class TestSupportsTemperature:
+    def test_opus_47_canonical_returns_false(self):
+        assert supports_temperature("claude-opus-4-7") is False
+
+    @pytest.mark.parametrize("bedrock_id", [
+        "us.anthropic.claude-opus-4-7",
+        "eu.anthropic.claude-opus-4-7",
+        "au.anthropic.claude-opus-4-7",
+        "global.anthropic.claude-opus-4-7",
+        "anthropic.claude-opus-4-7",
+    ])
+    def test_opus_47_bedrock_variants_return_false(self, bedrock_id: str):
+        assert supports_temperature(bedrock_id) is False
+
+    @pytest.mark.parametrize("model", [
+        "claude-sonnet-4-6",
+        "claude-opus-4-6",
+        "claude-haiku-4-5",
+        "claude-sonnet-4-5",
+        "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "gpt-5.4",
+        "gemini-2.5-pro",
+    ])
+    def test_other_models_return_true(self, model: str):
+        assert supports_temperature(model) is True
+
+    def test_unknown_model_defaults_true(self):
+        # Safer default: unknown models are assumed to accept temperature.
+        # Worst case the API rejects with a 400 and we know to add it
+        # to the set; the alternative (default False) silently drops
+        # caller-specified temperatures on every unknown model.
+        assert supports_temperature("future-model-9000") is True
+
+    def test_all_bedrock_opus_47_variants_in_set(self):
+        # Future-proofing: if we add a new region prefix, this test
+        # forces us to update MODELS_WITHOUT_TEMPERATURE too.
+        expected_variants = {
+            "claude-opus-4-7",
+            "anthropic.claude-opus-4-7",
+            "us.anthropic.claude-opus-4-7",
+            "eu.anthropic.claude-opus-4-7",
+            "au.anthropic.claude-opus-4-7",
+            "global.anthropic.claude-opus-4-7",
+        }
+        assert expected_variants <= MODELS_WITHOUT_TEMPERATURE
+
+
+# ---------------------------------------------------------------------------
+# _build_bedrock_config — env-driven activation
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBedrockConfig:
+    def test_returns_none_without_aws_region(self, monkeypatch):
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+        if not BEDROCK_AVAILABLE:
+            pytest.skip("Bedrock SDKs not installed")
+        assert _build_bedrock_config() is None
+
+    def test_returns_config_with_aws_region(self, monkeypatch):
+        if not BEDROCK_AVAILABLE:
+            pytest.skip("Bedrock SDKs not installed")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        cfg = _build_bedrock_config()
+        assert cfg is not None
+        assert cfg.provider == "bedrock"
+        assert cfg.api_key is None  # boto3 chain handles auth
+        assert cfg.model_name == "us.anthropic.claude-opus-4-7"
+
+    def test_aws_default_region_also_works(self, monkeypatch):
+        if not BEDROCK_AVAILABLE:
+            pytest.skip("Bedrock SDKs not installed")
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-1")
+        cfg = _build_bedrock_config()
+        assert cfg is not None
+        assert cfg.provider == "bedrock"
+
+    def test_registered_in_provider_builders(self):
+        assert "bedrock" in _PROVIDER_BUILDERS
+
+
+# ---------------------------------------------------------------------------
+# Factory dispatch — create_provider must route bedrock to BedrockProvider
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryDispatch:
+    def test_factory_returns_bedrock_provider(self, monkeypatch):
+        if not BEDROCK_AVAILABLE:
+            pytest.skip("Bedrock SDKs not installed")
+        from core.llm.providers import create_provider, BedrockProvider, AnthropicProvider
+        from core.llm.config import ModelConfig
+
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        cfg = ModelConfig(
+            provider="bedrock",
+            model_name="us.anthropic.claude-opus-4-7",
+            api_key=None,
+            max_tokens=1000,
+            max_context=1000000,
+            temperature=0.7,
+            cost_per_1k_tokens=0.015,
+        )
+        provider = create_provider(cfg)
+        assert isinstance(provider, BedrockProvider)
+        # Subclass invariant — must be an AnthropicProvider too so all
+        # inherited methods (turn, generate_structured, etc.) are
+        # callable polymorphically.
+        assert isinstance(provider, AnthropicProvider)
+
+    def test_factory_raises_when_bedrock_unavailable(self, monkeypatch):
+        # When BEDROCK_AVAILABLE is False the factory should raise a
+        # clear RuntimeError telling the operator what to install.
+        from core.llm.config import ModelConfig
+        from core.llm import providers as providers_module
+        cfg = ModelConfig(
+            provider="bedrock",
+            model_name="us.anthropic.claude-opus-4-7",
+            api_key=None,
+            max_tokens=1000,
+            max_context=1000000,
+            temperature=0.7,
+            cost_per_1k_tokens=0.015,
+        )
+        with patch.object(providers_module, "BEDROCK_AVAILABLE", False):
+            with pytest.raises(RuntimeError, match="boto3 anthropic"):
+                providers_module.create_provider(cfg)
+
+
+# ---------------------------------------------------------------------------
+# provider_of — routing for Bedrock-prefixed model IDs
+# ---------------------------------------------------------------------------
+
+
+class TestProviderOfBedrockRouting:
+    @pytest.mark.parametrize("model_id", [
+        "us.anthropic.claude-opus-4-7",
+        "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "au.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "apac.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "global.anthropic.claude-opus-4-7",
+        "anthropic.claude-opus-4-7",
+        "anthropic.claude-haiku-4-5-20251001-v1:0",
+    ])
+    def test_bedrock_ids_route_to_bedrock(self, model_id: str):
+        assert provider_of(model_id) == "bedrock"
+
+    @pytest.mark.parametrize("model_id,expected", [
+        ("claude-opus-4-7", "anthropic"),
+        ("claude-sonnet-4-5", "anthropic"),
+        ("anthropic/claude-haiku-4-5", "anthropic"),
+        ("gpt-5.4", "openai"),
+        ("gemini-2.5-pro", "gemini"),
+    ])
+    def test_non_bedrock_ids_unaffected(self, model_id: str, expected: str):
+        assert provider_of(model_id) == expected
+
+    def test_family_unchanged_for_bedrock_claude(self):
+        # Cross-family validation must still see Bedrock-Claude as the
+        # same Claude lineage as direct-API Claude — they ARE the same
+        # model. Family routing is separate from provider routing.
+        assert family_of("us.anthropic.claude-opus-4-7") in {
+            "anthropic", "unknown",  # acceptable: either matches or unknown
+        }
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator validation — keyless Bedrock config must not be rejected
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorBedrockValidation:
+    def test_resolve_model_accepts_bedrock_with_aws_region(self):
+        # The orchestrator's _resolve_model() rejects models with
+        # api_key=None UNLESS the provider is bedrock and AWS_REGION
+        # is set. Without this exemption, Bedrock configs (which have
+        # no API key — boto3 chain handles auth) would be rejected
+        # at command-line --model resolution time.
+        # We assert the env-var allowlist is correct; full integration
+        # of orchestrator._resolve_model is exercised by the live e2e.
+        from core.config import RaptorConfig
+        assert "AWS_REGION" in RaptorConfig.LLM_API_KEY_VARS
+        assert "AWS_DEFAULT_REGION" in RaptorConfig.LLM_API_KEY_VARS
+        assert "AWS_PROFILE" in RaptorConfig.LLM_API_KEY_VARS
+
+    def test_aws_credentials_in_safe_env_list(self):
+        from core.config import RaptorConfig
+        # All the AWS-cred vars boto3 needs must be allowlisted for
+        # subprocess passthrough. Without these, the dispatcher
+        # subprocess that runs the real Bedrock call has no way to
+        # authenticate.
+        for var in (
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_REGION",
+            "AWS_DEFAULT_REGION",
+            "AWS_PROFILE",
+        ):
+            assert var in RaptorConfig.LLM_API_KEY_VARS

--- a/core/security/llm_family.py
+++ b/core/security/llm_family.py
@@ -93,7 +93,30 @@ def provider_for_family(family: Family) -> str:
 
 
 def provider_of(model_id: str) -> str:
-    """Shorthand: model identifier → provider string."""
+    """Shorthand: model identifier → provider string.
+
+    Bedrock-hosted model IDs (``us.anthropic.claude-opus-4-7``,
+    ``anthropic.claude-haiku-4-5-20251001-v1:0``,
+    ``eu.anthropic.claude-...``, ``au.anthropic.claude-...``,
+    ``global.anthropic.claude-...``) route to the ``bedrock`` provider
+    regardless of underlying lineage. The family itself remains the
+    model's training lineage (Claude → ``"anthropic"`` family) so
+    cross-family validation logic continues to treat Bedrock-hosted
+    Claude and direct-API Claude as the same lineage — they ARE the
+    same model, just behind a different transport.
+    """
+    needle = model_id.lower()
+    _BEDROCK_PREFIXES = (
+        "anthropic.claude-",     # region-pinned Bedrock IDs
+        "us.anthropic.",
+        "eu.anthropic.",
+        "au.anthropic.",
+        "apac.anthropic.",
+        "global.anthropic.",
+    )
+    for prefix in _BEDROCK_PREFIXES:
+        if needle.startswith(prefix):
+            return "bedrock"
     return provider_for_family(family_of(model_id))
 
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -62,6 +62,14 @@ For example CodeQL does not allow commerical use.
 - Usage: RAPTOR connects to Ollama server for local model inference
 - Note: User installs separately, supports both local and remote servers
 
+**boto3 + AnthropicBedrock** (AWS Bedrock LLM provider)
+- Install: `pip install boto3 anthropic`
+- License: boto3 Apache 2.0; anthropic MIT
+- Source: https://github.com/boto/boto3, https://github.com/anthropics/anthropic-sdk-python
+- Usage: RAPTOR's `BedrockProvider` uses `anthropic.AnthropicBedrock` (the SDK's Bedrock client) to call Claude models via AWS Bedrock with SigV4 auth through the boto3 credential chain.
+- Auth: Operator configures via `AWS_REGION` (or `AWS_DEFAULT_REGION`) plus the standard boto3 credential chain (env vars, profile, IAM role). No API key flows through `models.json`.
+- Activation: Opt-in only — set `provider: "bedrock"` in `~/.config/raptor/models.json` or `RAPTOR_PROVIDER_PREFER=bedrock`. Ambient `AWS_REGION` does not auto-promote to Bedrock.
+
 **rr** (Record-replay debugger)
 - Install: `apt install rr` (Linux) or build from https://github.com/rr-debugger/rr
 - License: MIT

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -15,6 +15,7 @@ If external LLM fails entirely, falls back to CC dispatch automatically.
 
 import copy
 import logging
+import os
 import shutil
 import threading
 import time
@@ -232,6 +233,17 @@ def build_llm_config_from_flags(
                 entry["api_key"] = cfg_entry["api_key"]
                 break
         mc = _model_config_from_entry(entry)
+        # Bedrock authenticates via the boto3 credential chain (env,
+        # profile, IAM role) — there is no API key. Treat
+        # AWS_REGION / AWS_DEFAULT_REGION as the "key marker" so the
+        # validation here doesn't reject a valid Bedrock config that
+        # legitimately has ``api_key=None``.
+        if provider == "bedrock":
+            if not (os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")):
+                print(f"\n  Error: no AWS_REGION for --model {name}")
+                print(f"  Set AWS_REGION (or AWS_DEFAULT_REGION) and ensure boto3 has credentials")
+                return None
+            return mc
         if not mc.api_key:
             env_key = PROVIDER_ENV_KEYS.get(provider, "???")
             print(f"\n  Error: no API key for --model {name}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ instructor==1.15.1
 # pip install openai        # OpenAI, Gemini (via shim), Mistral, Ollama
 # pip install anthropic     # Anthropic Claude (native structured output)
 # pip install google-genai  # Google Gemini (native SDK, accurate thinking token costs)
+# pip install boto3         # AWS Bedrock (Claude via SigV4 — pairs with anthropic SDK above)
 
 # Optional: Rich inventory metadata (decorators, annotations, visibility, typed params)
 # pip install tree-sitter tree-sitter-python tree-sitter-java tree-sitter-javascript tree-sitter-c tree-sitter-go


### PR DESCRIPTION
## Summary

Adds **AWS Bedrock** as an LLM provider option for RAPTOR. Same Claude models as Anthropic-direct, but auth via SigV4 through the `boto3` credential chain instead of `ANTHROPIC_API_KEY`. Useful for AWS shops where API keys can't leave the account boundary, or where existing IAM roles already grant Bedrock access.

This is **opt-in only** — no behaviour change for existing users. Bedrock is intentionally absent from `_DEFAULT_PROVIDER_ORDER` so users with ambient `AWS_REGION` set for unrelated reasons aren't auto-promoted.

## Design

`BedrockProvider` is a subclass of `AnthropicProvider` that overrides only `__init__` to swap `anthropic.Anthropic` for `anthropic.AnthropicBedrock`. The official Anthropic SDK ships `AnthropicBedrock` with the same `.messages.create` / `.beta.messages.create` surface, so all inherited behaviour (tool use, prompt caching, structured output, cost tracking, transient-error retry) works unchanged.

```python
class BedrockProvider(AnthropicProvider):
    def __init__(self, config: ModelConfig):
        LLMProvider.__init__(self, config)  # skip parent __init__
        self.client = AnthropicBedrock(timeout=config.timeout, ...)
        # mirror parent's instructor + caching state
```

Bedrock model IDs (e.g. `us.anthropic.claude-opus-4-7`, `eu.anthropic.claude-haiku-4-5-20251001-v1:0`) are aliased to the canonical Anthropic IDs in `MODEL_COSTS` / `MODEL_LIMITS`, so cost tracking and limit enforcement work identically across both providers without duplicated price data.

## Configuration

```bash
pip install boto3 anthropic
export AWS_REGION=us-east-1     # or eu-west-1, ap-southeast-2
export AWS_PROFILE=my-profile   # optional
```

`~/.config/raptor/models.json`:
```json
{
  "models": [
    {"provider": "bedrock", "model": "us.anthropic.claude-opus-4-7", "role": "analysis"},
    {"provider": "bedrock", "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0", "role": "fallback"}
  ]
}
```

Or via the existing `RAPTOR_PROVIDER_PREFER=bedrock` env var.

## What's in the diff (11 files, +697 / -6)

| File | Change |
|---|---|
| `core/llm/providers.py` | `BedrockProvider` class · factory branch · `AnthropicBedrock` import · `supports_temperature` gate in `generate()` and `generate_structured()` |
| `core/llm/detection.py` | `BEDROCK_AVAILABLE` flag · `has_bedrock` detection · misconfig warnings · config validity check |
| `core/llm/config.py` | `_build_bedrock_config` builder + registration |
| `core/llm/model_data.py` | 31 verified Bedrock model IDs aliased to Anthropic costs/limits · `MODELS_WITHOUT_TEMPERATURE` registry · `supports_temperature()` helper |
| `core/security/llm_family.py` | `provider_of()` detects Bedrock-prefixed IDs and routes to `bedrock` provider; family resolution unchanged so cross-family logic still treats Bedrock-Claude as anthropic lineage |
| `core/config/__init__.py` | Adds `AWS_REGION` / `AWS_DEFAULT_REGION` / `AWS_PROFILE` / `AWS_DEFAULT_PROFILE` / `AWS_CONFIG_FILE` / `AWS_SHARED_CREDENTIALS_FILE` to `LLM_API_KEY_VARS` so the dispatcher subprocess can authenticate |
| `packages/llm_analysis/orchestrator.py` | `_resolve_model()` exempts Bedrock from the "must have api_key" check (boto3 chain handles auth) |
| `core/llm/tests/test_bedrock_provider.py` | 55 new tests (7 classes) |
| `requirements.txt` | comment-only optional dep note |
| `README.md` | "AWS Bedrock" subsection under "Using a different LLM" |
| `docs/DEPENDENCIES.md` | Bedrock + AnthropicBedrock listed as optional tools |

## Bug fixes that came along for the ride

Two real bugs surfaced while wiring this up. Both affect Anthropic-direct users, not just Bedrock — the fixes are in this PR because they block any use of newer models:

1. **Claude Opus 4.7 deprecated the `temperature` parameter** (returns `400 BadRequest "temperature is deprecated for this model"`). `AnthropicProvider.generate()` and `.generate_structured()` always passed `temperature` unconditionally, so Opus 4.7 was unusable. Fixed via the new `MODELS_WITHOUT_TEMPERATURE` registry + `supports_temperature()` gate. Forward-compatible: future no-temperature models just need adding to the set. `turn()` already omitted temperature so it was unaffected.
2. **`LLM_API_KEY_VARS` was missing `AWS_REGION` / `AWS_PROFILE`** — the cred isolation dispatcher's subprocess could see `AWS_ACCESS_KEY_ID` etc. but not the region/profile vars boto3 needs to actually pick an endpoint. Pre-existing gap; only surfaced once a Bedrock provider tried to use them.

## Testing

**Unit tests** — 55 new tests covering:
- SDK availability flag
- Model alias map (cost/limit parity with Anthropic, parametrised across 11 IDs)
- `supports_temperature` gate (Opus 4.7 + 5 Bedrock variants reject; Sonnet 4.5/4.6/Haiku/GPT/Gemini accept; unknown models default-true)
- `_build_bedrock_config` env-driven activation (with/without `AWS_REGION`, `AWS_DEFAULT_REGION` fallback)
- Factory dispatch (returns `BedrockProvider`, raises clear error when SDKs missing)
- `provider_of` Bedrock routing (8 prefix variants → bedrock; non-Bedrock IDs unaffected)
- Orchestrator validation (env-var allowlist correctness)

**Regression** — `pytest core/llm/tests/` reports **579 existing tests still pass + 55 new = 634 total, no regressions**.

**Live verification:**
- ✅ `us.anthropic.claude-opus-4-7` round-trip in `us-east-1`
- ✅ `eu.anthropic.claude-opus-4-7` round-trip in `eu-west-1`
- ✅ Full `raptor.py analyze` pipeline e2e against a 2-finding Semgrep SARIF: 12 LLM calls (Stages A→D validation + exploit + patch generation), ~3 min, $1.83, all using `us.anthropic.claude-opus-4-7` — orchestrated report, exploit PoCs, and patches generated successfully.

## Backwards compatibility

- No changes to existing provider behaviour.
- `_DEFAULT_PROVIDER_ORDER` unchanged — Bedrock is opt-in only.
- `AnthropicProvider` only changes are the `supports_temperature` gates in `generate()` / `generate_structured()`. For all models currently in `MODEL_COSTS` except Opus 4.7, the gate evaluates True and the existing behaviour is preserved bit-for-bit.
- Bedrock model IDs alias to existing Anthropic cost/limit entries via a registration helper that's idempotent and runs at module import — no impact on cold-start time.

## License

- `boto3` (Apache 2.0) and `anthropic` (MIT) — both compatible with RAPTOR's MIT.
- Optional deps only — installed with `pip install boto3 anthropic`. No change to base requirements.

## Open question for the maintainers

Happy to split this into two PRs if preferred:
1. The `supports_temperature` registry + AnthropicProvider fix (Opus 4.7 is broken without it on the Anthropic-direct path too).
2. The Bedrock provider proper.

The bugs in (1) only surfaced because of (2), but they're independently useful. Let me know.
