### PR TITLE
feat(reachability): close per-language entry/dispatch gaps (PHP/Python/Go/Rust)

### DIFF
--- a/core/inventory/_reach_cache.py
+++ b/core/inventory/_reach_cache.py
@@ -80,7 +80,10 @@ logger = logging.getLogger(__name__)
 # new attribute — AttributeError on access by is_registered_via_call.
 # V7 (2026-05-26): _AdjacencyIndex grew `override_methods` (CHA virtual-
 # dispatch candidates). Same hazard: an old pickle lacks the attribute.
-_CACHE_VERSION = 7
+# V8 (2026-05-28): override_methods now seeded for Go methods (every
+# Go method is a structural-interface virtual-dispatch candidate). Changed
+# index contents; a V7 pickle would serve stale verdicts.
+_CACHE_VERSION = 8
 
 _CACHE_DIR = Path.home() / ".cache" / "raptor" / "reachability"
 

--- a/core/inventory/call_graph.py
+++ b/core/inventory/call_graph.py
@@ -2404,10 +2404,12 @@ def extract_call_graph_rust(content: str) -> FileCallGraph:
       * ``inst.method()`` -> chain ``["inst", "method"]``
         (instance-method limitation as in Java/Go)
 
-    Reflection-style indirection is uncommon in Rust; we don't flag
-    macros (compile-time expansion is genuinely transparent). Type
-    erasure (``Any::downcast_ref``) is rare in CVE-relevant code
-    and emits a normal call chain.
+    Type-erased dispatch (``Any::downcast{,_ref,_mut}``, ``transmute``)
+    hides the concrete target, so a file using it is flagged
+    ``INDIRECTION_REFLECT`` (its functions hedge to UNCERTAIN). Macros are
+    NOT flagged: macro invocations are ubiquitous in Rust and blanket-
+    masking every macro-using file would gut the not_called signal —
+    macro-generated call edges remain a documented limitation.
     """
     try:
         import tree_sitter_rust as ts_rust
@@ -2455,6 +2457,11 @@ class _RustCallGraph:
     _MOD_ITEM = "mod_item"
     _DECL_LIST = "declaration_list"
     _SELF = "self"
+    # Type-erased dispatch primitives — calls whose concrete target is hidden
+    # at runtime; their presence masks the file's functions to UNCERTAIN.
+    _REFLECT_TAILS = frozenset({
+        "downcast", "downcast_ref", "downcast_mut", "transmute",
+    })
 
     def __init__(self) -> None:
         self.graph = FileCallGraph()
@@ -2633,6 +2640,17 @@ class _RustCallGraph:
                         receiver_class=receiver_class,
                     )
                 )
+            # Type-erased dispatch hides which concrete function runs:
+            # ``Any::downcast{,_ref,_mut}`` (runtime downcast then call) and
+            # ``transmute`` (can fabricate fn pointers). Flag the file →
+            # its functions hedge to UNCERTAIN rather than NOT_CALLED (FN-safe).
+            # Checked off the call NODE (not the chain) so the common turbofish
+            # form ``downcast_ref::<T>()`` — whose ``generic_function`` callee
+            # emits no chain edge — is still caught. (Macros are NOT flagged:
+            # ubiquitous in Rust; blanket-masking would gut the signal — a
+            # documented limitation.)
+            if self._callee_tail(node) in self._REFLECT_TAILS:
+                self.graph.indirection.add(INDIRECTION_REFLECT)
             for c in node.children:
                 self.walk(c)
             return
@@ -2762,6 +2780,38 @@ class _RustCallGraph:
             return self._scoped_parts(callee) or None
         if callee.type == self._FIELD_EXPR:
             return self._field_chain(callee)
+        return None
+
+    def _callee_tail(self, node) -> Optional[str]:
+        """Trailing method/function name of a call, unwrapping a turbofish
+        ``generic_function`` (``x.downcast_ref::<T>()`` → ``downcast_ref``,
+        ``mem::transmute::<A,B>(x)`` → ``transmute``) — used for the reflect
+        masking flag, which must fire even when the generic callee emits no
+        normal chain edge."""
+        callee = None
+        for c in node.children:
+            if c.type == self._ARGS:
+                break
+            if c.is_named:
+                callee = c
+                break
+        if callee is None:
+            return None
+        if callee.type == "generic_function":
+            inner = next((c for c in callee.children
+                          if c.is_named and c.type != "type_arguments"), None)
+            callee = inner if inner is not None else callee
+        if callee.type == self._FIELD_EXPR:
+            fid = None
+            for c in callee.children:
+                if c.type == self._FIELD_IDENT:
+                    fid = c
+            return fid.text.decode() if fid is not None else None
+        if callee.type == self._SCOPED_IDENT:
+            parts = self._scoped_parts(callee)
+            return parts[-1] if parts else None
+        if callee.type == self._IDENT:
+            return callee.text.decode()
         return None
 
     def _field_chain(self, node) -> Optional[List[str]]:

--- a/core/inventory/extractors.py
+++ b/core/inventory/extractors.py
@@ -171,16 +171,35 @@ class PythonExtractor:
                 ))
         return out
 
+    @staticmethod
+    def _class_base_names(node: "ast.ClassDef") -> List[str]:
+        """Simple base-class names of a ``class`` (``class V(a.b.APIView,
+        Mixin)`` → ``["APIView", "Mixin"]``). Keyword bases (``metaclass=``)
+        are in ``node.keywords``, not ``node.bases``, so they're skipped.
+        Mirrors the tree-sitter extractor so the stdlib fallback records the
+        same ``class_attributes`` (framework-base detection needs it)."""
+        out: List[str] = []
+        for b in node.bases:
+            if isinstance(b, ast.Name):
+                out.append(b.id)
+            elif isinstance(b, ast.Attribute):
+                out.append(b.attr)
+        return out
+
     def _walk(self, node: ast.AST, functions: List[FunctionInfo],
-              class_name: Optional[str]) -> None:
+              class_name: Optional[str],
+              class_attributes: Sequence[str] = ()) -> None:
         """Walk AST collecting functions with metadata."""
         for child in ast.iter_child_nodes(node):
             if isinstance(child, ast.ClassDef):
-                self._walk(child, functions, class_name=child.name)
+                self._walk(child, functions, class_name=child.name,
+                           class_attributes=self._class_base_names(child))
             elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                functions.append(self._extract_function(child, class_name))
+                functions.append(
+                    self._extract_function(child, class_name, class_attributes))
                 # Walk into nested functions/classes
-                self._walk(child, functions, class_name=class_name)
+                self._walk(child, functions, class_name=class_name,
+                           class_attributes=class_attributes)
             else:
                 # Descend into compound statements (if / try / with /
                 # for / while / match) so functions nested inside them
@@ -194,9 +213,11 @@ class PythonExtractor:
                 # don't open a class scope. Only FunctionDef nodes are
                 # collected, so recursing through expression children
                 # is harmless (lambdas are ast.Lambda, not FunctionDef).
-                self._walk(child, functions, class_name=class_name)
+                self._walk(child, functions, class_name=class_name,
+                           class_attributes=class_attributes)
 
-    def _extract_function(self, node: ast.AST, class_name: Optional[str]) -> FunctionInfo:
+    def _extract_function(self, node: ast.AST, class_name: Optional[str],
+                          class_attributes: Sequence[str] = ()) -> FunctionInfo:
         """Extract a single function with full metadata."""
         args = node.args.args
         # Build signature
@@ -236,6 +257,7 @@ class PythonExtractor:
                 attributes=attributes,
                 return_type=return_type,
                 parameters=parameters,
+                class_attributes=list(class_attributes),
             ),
         )
 

--- a/core/inventory/extractors.py
+++ b/core/inventory/extractors.py
@@ -824,6 +824,9 @@ def _ts_language(lang: str):
             import tree_sitter_c_sharp as ts
         elif lang == "ruby":
             import tree_sitter_ruby as ts
+        elif lang == "php":
+            import tree_sitter_php as ts
+            return Language(ts.language_php())
         else:
             return None
         return Language(ts.language())
@@ -869,6 +872,7 @@ class TreeSitterExtractor:
         "csharp": ("method_declaration", "constructor_declaration",
                    "local_function_statement"),
         "ruby": ("method", "singleton_method"),
+        "php": ("method_declaration", "function_definition"),
     }
 
     _CLASS_TYPES = {
@@ -883,6 +887,7 @@ class TreeSitterExtractor:
         "csharp": ("class_declaration", "interface_declaration",
                    "struct_declaration", "record_declaration"),
         "ruby": ("class", "module"),
+        "php": ("class_declaration", "interface_declaration", "trait_declaration"),
     }
 
     def __init__(self, language: str):
@@ -919,7 +924,18 @@ class TreeSitterExtractor:
                     if mod.type in ("marker_annotation", "annotation"):
                         out.append(mod.text.decode().lstrip("@"))
             elif child.type == "attribute_list":
-                out.extend(self._csharp_attr_names(child))
+                # C#: attribute_list → attribute. PHP: attribute_list →
+                # attribute_group → attribute (deeper nesting).
+                if self.language == "php":
+                    out.extend(self._php_attr_names(child))
+                else:
+                    out.extend(self._csharp_attr_names(child))
+            elif child.type in ("base_clause", "class_interface_clause"):
+                # PHP: ``extends Base`` / ``implements I1, I2`` — record the base
+                # type names so framework bases (Controller / AbstractController
+                # / Command / ShouldQueue …) can mark the class's methods entries.
+                out.extend(n.text.decode() for n in child.children
+                           if n.type in ("name", "qualified_name"))
             elif child.type == "superclass":
                 # Ruby: ``class X < ApplicationController`` — base is a
                 # ``constant`` / ``scope_resolution``. Java: ``extends Foo`` —
@@ -934,6 +950,16 @@ class TreeSitterExtractor:
                 # Spring Data, Validator → a framework-dispatched interface)
                 # can mark the class's methods as entries.
                 out.extend(self._java_base_names(child))
+            elif child.type == "argument_list" and self.language == "python":
+                # Python: ``class V(APIView, LoginRequiredMixin, metaclass=M)``
+                # — the base classes live in the argument_list. Record their
+                # simple tail names (``rest_framework.views.APIView`` →
+                # ``APIView``) so framework base classes (Django/DRF/Flask
+                # class-based views) can mark the class's methods as entries.
+                # Skip keyword args (``metaclass=…``).
+                for b in child.children:
+                    if b.type in ("identifier", "attribute"):
+                        out.append(b.text.decode().split(".")[-1].strip())
         return out
 
     @staticmethod
@@ -983,6 +1009,34 @@ class TreeSitterExtractor:
         for child in node.children:
             if child.type == "attribute_list":
                 out.extend(self._csharp_attr_names(child))
+        return out
+
+    @staticmethod
+    def _php_attr_names(attribute_list_node) -> List[str]:
+        """Attribute names in one PHP ``attribute_list`` — nests one level deeper
+        than C#: ``attribute_list → attribute_group → attribute → name``
+        (``#[Route('/x')]`` → ``["Route"]``)."""
+        out: List[str] = []
+        for grp in attribute_list_node.children:
+            if grp.type != "attribute_group":
+                continue
+            for a in grp.children:
+                if a.type != "attribute":
+                    continue
+                for c in a.children:
+                    if c.type in ("name", "qualified_name"):
+                        out.append(c.text.decode())
+                        break
+        return out
+
+    def _php_attributes(self, node) -> List[str]:
+        """PHP attributes on a method — its ``attribute_list`` children."""
+        if self.language != "php":
+            return []
+        out: List[str] = []
+        for child in node.children:
+            if child.type == "attribute_list":
+                out.extend(self._php_attr_names(child))
         return out
 
     # Sibling node types allowed between a TS/JS decorator and the
@@ -1083,7 +1137,8 @@ class TreeSitterExtractor:
                 # JS/TS: method/function decorators are preceding siblings
                 # (@Get() / @Cron() …). Python: a decorated_definition wrapper.
                 # C#: ``[HttpGet]`` attribute_list children (gathered here).
-                attrs = self._ts_decorators(child) + self._csharp_attributes(child)
+                attrs = (self._ts_decorators(child) + self._csharp_attributes(child)
+                         + self._php_attributes(child))
                 parent = child.parent
                 if parent and parent.type == "decorated_definition":
                     for sib in parent.children:
@@ -1159,6 +1214,15 @@ class TreeSitterExtractor:
         # TS/JS class members: accessibility_modifier (default public).
         if node.type == "method_definition":
             visibility = self._ts_member_visibility(node)
+
+        # PHP: a method_declaration carries a ``visibility_modifier`` child;
+        # methods default to public when none is present.
+        if self.language == "php" and node.type == "method_declaration":
+            visibility = "public"
+            for child in node.children:
+                if child.type == "visibility_modifier":
+                    visibility = child.text.decode().strip()
+                    break
 
         # C#: ``modifier`` children carry access keywords; members default to
         # ``private`` (the framework-entry rule keys on public action methods).
@@ -1441,6 +1505,7 @@ _REGEX_EXTRACTORS = {
     'tsx': JavaScriptExtractor(),
     'csharp': GenericExtractor(),
     'ruby': GenericExtractor(),
+    'php': GenericExtractor(),
     'c': CExtractor(),
     'cpp': CExtractor(),
     'java': JavaExtractor(),

--- a/core/inventory/reach_audit.py
+++ b/core/inventory/reach_audit.py
@@ -90,6 +90,16 @@ def _stage_entry(ctx: "_ClassifyCtx", R) -> Optional[str]:
     if er == "reachable":
         return "reachable"
     if er == "no_path_from_entry":
+        # CHA: entry-reachability follows resolved call edges, not the
+        # over-inclusive method-dispatch index. A polymorphic-dispatch override
+        # (or any Go method — Go interfaces are structural) whose name is
+        # dispatched via an unresolved member call could be reached at runtime
+        # through interface/virtual dispatch even when no resolved path exists.
+        # Fall through to UNCERTAIN rather than claim no_path_from_entry — the
+        # same FN-safe rule the 1-hop stage applies to NOT_CALLED.
+        if R.is_virtual_dispatch_candidate(
+                ctx.inventory, ctx.class_name, ctx.name):
+            return None
         return "no_path_from_entry"
     return None
 

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -1108,6 +1108,22 @@ def _get_or_build_index(
                         idx.class_of_method[fn] = cls_name
                         break
 
+        # Go has no inheritance and its call graph emits no ClassDef, but the
+        # item extractor records each method's receiver type as ``class_name``.
+        # Go interfaces are STRUCTURAL — any method can satisfy an interface and
+        # be reached via interface dispatch — so every method is a virtual-
+        # dispatch candidate (the analog of override_methods for nominal langs).
+        # Seed from item metadata. Additive → FN-safe.
+        if file_record.get("language") == "go":
+            for it in file_record.get("items") or []:
+                if not isinstance(it, dict) \
+                        or it.get("kind", "function") != "function":
+                    continue
+                cls = (it.get("metadata") or {}).get("class_name")
+                nm = it.get("name")
+                if cls and nm:
+                    idx.override_methods.add((cls, nm))
+
     # Pass 1.5: build a qualified-name → InternalFunction map so that
     # external edges resolving to project-defined physical functions
     # get rewritten into internal edges in pass 2.
@@ -2354,6 +2370,8 @@ class ReachabilityProfile:
     has_ts_framework: bool = False
     has_csharp_framework: bool = False
     has_ruby_framework: bool = False
+    has_python_framework: bool = False
+    has_php_framework: bool = False
 
 
 PROFILES: Dict[str, ReachabilityProfile] = {
@@ -2362,13 +2380,13 @@ PROFILES: Dict[str, ReachabilityProfile] = {
     "go":   ReachabilityProfile("go", "sound", "go_exported", has_go_init=True),
     "rust": ReachabilityProfile("rust", "sound", "rust_pub"),
     "java": ReachabilityProfile("java", "none", has_java_web=True),
-    "python":     ReachabilityProfile("python", "none"),
+    "python":     ReachabilityProfile("python", "none", has_python_framework=True),
     "javascript": ReachabilityProfile("javascript", "none"),
     "typescript": ReachabilityProfile("typescript", "none", has_ts_framework=True),
     "tsx":        ReachabilityProfile("tsx", "none", has_ts_framework=True),
     "ruby":       ReachabilityProfile("ruby", "none", has_ruby_framework=True),
     "csharp":     ReachabilityProfile("csharp", "none", has_csharp_framework=True),
-    "php":        ReachabilityProfile("php", "none"),
+    "php":        ReachabilityProfile("php", "none", has_php_framework=True),
 }
 
 _DEFAULT_PROFILE = ReachabilityProfile("")
@@ -2598,6 +2616,85 @@ def _ruby_framework_entry(name: str, item: Dict[str, Any]) -> bool:
     return False
 
 
+# Method-level PHP attribute tail-names (Symfony route attributes on a method).
+_PHP_METHOD_DISPATCH_ATTRS = frozenset({"Route", "AsController"})
+# PHP framework class signals captured in class_attributes (extends/implements
+# base types AND class-level #[…] attributes) — Laravel + Symfony dispatch the
+# class's methods with no in-project caller (router → controller actions, queue
+# → job ``handle``, console → command ``execute``/``handle``, event lifecycle).
+_PHP_FRAMEWORK_BASES = frozenset({
+    # Laravel
+    "Controller", "BaseController", "FormRequest", "Command", "Job",
+    "Mailable", "Notification", "Middleware",
+    # Symfony base classes
+    "AbstractController", "Route",
+    # Symfony attribute-driven dispatch (class-level #[...] attributes, which
+    # the extractor records in class_attributes alongside bases) — modern
+    # Symfony marks dispatched services by attribute rather than base class.
+    "AsCommand", "AsMessageHandler", "AsEventListener", "AsController",
+    # dispatched interfaces
+    "ShouldQueue", "EventSubscriberInterface", "MessageHandlerInterface",
+    "MiddlewareInterface", "EventListenerInterface", "SubscriberInterface",
+})
+
+
+def _php_framework_entry(name: str, item: Dict[str, Any]) -> bool:
+    """A PHP method dispatched by Laravel / Symfony with no in-project caller —
+    a Symfony ``#[Route]`` method attribute, or a method of a class whose
+    ``class_attributes`` (extends/implements bases + class-level attributes)
+    names a framework base (controller / job / command / event subscriber).
+    Promote regardless of visibility — controller actions and queued handlers
+    are public, the convention is conventional. FN/FP-safe add-entries lever."""
+    meta = item.get("metadata") or {}
+    for a in meta.get("attributes") or []:
+        if _annotation_tail(a) in _PHP_METHOD_DISPATCH_ATTRS:
+            return True
+    for a in meta.get("class_attributes") or []:
+        tail = _annotation_tail(a)
+        # Explicit framework base/attribute, OR the *Controller naming
+        # convention (catches a controller extending a project-custom base,
+        # e.g. ``class UserController extends BaseController``). Convention is
+        # FN-safe: worst case is failing to demote a non-framework class that
+        # merely ends in "Controller".
+        if tail in _PHP_FRAMEWORK_BASES or tail.endswith("Controller"):
+            return True
+    return False
+
+
+# Python class-based-view base classes: the framework (Django URL dispatcher /
+# DRF router / Flask) instantiates the view and dispatches HTTP verbs into its
+# methods (get/post/…) and DRF actions (list/retrieve/…) with no in-project
+# caller. Decorator-based views are already handled by is_framework_callable;
+# this covers the CONVENTION (subclass a CBV base) that decorators miss.
+_PYTHON_FRAMEWORK_BASES = frozenset({
+    # Django generic class-based views
+    "View", "TemplateView", "RedirectView", "ListView", "DetailView",
+    "CreateView", "UpdateView", "DeleteView", "FormView", "ArchiveIndexView",
+    # Django REST Framework
+    "APIView", "GenericAPIView", "ViewSet", "ViewSetMixin", "GenericViewSet",
+    "ModelViewSet", "ReadOnlyModelViewSet", "ListAPIView", "RetrieveAPIView",
+    "CreateAPIView", "UpdateAPIView", "DestroyAPIView", "ListCreateAPIView",
+    "RetrieveUpdateAPIView", "RetrieveDestroyAPIView",
+    "RetrieveUpdateDestroyAPIView",
+    # Flask / Flask-RESTful
+    "MethodView", "Resource",
+})
+
+
+def _python_framework_entry(name: str, item: Dict[str, Any]) -> bool:
+    """A Python method dispatched by a web framework with no in-project caller —
+    a method of a class-based view (Django ``View``/generic CBVs, DRF
+    ``APIView``/``ViewSet``, Flask ``MethodView``). The framework routes HTTP
+    verbs / DRF actions into these methods by convention. The signal is the
+    base class captured in ``class_attributes``; decorator-dispatched views are
+    handled separately. Add-entries lever — FN/FP-safe (worst case: failing to
+    demote a genuinely-dead method of a CBV subclass)."""
+    for base in (item.get("metadata") or {}).get("class_attributes") or []:
+        if _annotation_tail(base) in _PYTHON_FRAMEWORK_BASES:
+            return True
+    return False
+
+
 def _item_is_entry(item: Dict[str, Any], language: str) -> bool:
     """Is this inventory item an externally-invocable entry point under its
     language's linkage/visibility model? (Framework dispatch is handled
@@ -2640,6 +2737,14 @@ def _item_is_entry(item: Dict[str, Any], language: str) -> bool:
     # Ruby/Rails convention: methods of a class inheriting a framework base
     # (*Controller / job / mailer / channel) are framework-dispatched entries.
     if p.has_ruby_framework and _ruby_framework_entry(name, item):
+        return True
+    # PHP/Laravel+Symfony dispatched entries: #[Route] methods and methods of
+    # controller/job/command/subscriber classes (by base type or class attr).
+    if p.has_php_framework and _php_framework_entry(name, item):
+        return True
+    # Python class-based views: methods of a Django/DRF/Flask CBV subclass are
+    # dispatched by the framework (verbs/actions by convention).
+    if p.has_python_framework and _python_framework_entry(name, item):
         return True
     # Visibility/linkage entry signal (only for languages whose model is a
     # closed signal; "" ⇒ a public symbol is NOT reliably an entry, so those

--- a/core/inventory/tests/test_call_graph_new_langs.py
+++ b/core/inventory/tests/test_call_graph_new_langs.py
@@ -54,6 +54,23 @@ def test_rust_use_wildcard_flagged():
     assert INDIRECTION_WILDCARD_IMPORT in g.indirection
 
 
+def test_rust_reflect_masking():
+    # Type-erased dispatch (Any::downcast family, transmute) hides the
+    # concrete target → flag the file REFLECT so its functions hedge to
+    # uncertain. Caught through the turbofish ``generic_function`` wrapper
+    # (the common ``downcast_ref::<T>()`` form emits no normal chain edge).
+    assert INDIRECTION_REFLECT in extract_call_graph_rust(
+        "fn f(x: &dyn Any) { x.downcast_ref::<Foo>(); }\n").indirection
+    assert INDIRECTION_REFLECT in extract_call_graph_rust(
+        "fn f(b: Box<dyn Any>) { b.downcast::<Foo>(); }\n").indirection
+    assert INDIRECTION_REFLECT in extract_call_graph_rust(
+        "fn f() { let p: fn() = unsafe { std::mem::transmute(a) }; p(); }\n"
+    ).indirection
+    # plain calls must NOT be flagged.
+    assert INDIRECTION_REFLECT not in extract_call_graph_rust(
+        "fn f() { helper(); other.method(); }\n").indirection
+
+
 def test_rust_scoped_call():
     g = extract_call_graph_rust(
         "fn main() { Baz::new(); }\n"

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -1086,6 +1086,54 @@ class TestGoReachability:
         assert verdict("live.go", "Exported") == "reachable"   # over-fire control
 
 
+class TestGoInterfaceDispatch:
+    """Go CHA-analog. Go has no inheritance and its call graph emits no
+    ClassDef, but the item extractor records each method's receiver type as
+    class_name, and Go interfaces are STRUCTURAL — any method can satisfy an
+    interface. So an unexported method dispatched via an interface-typed
+    receiver (``x.serve()``) could be reached at runtime even though entry-
+    reachability finds no resolved path; it must read UNCERTAIN, not
+    no_path_from_entry. A method whose name is never dispatched stays dead.
+    Type-free over-approximation (a same-named method on an unrelated type also
+    reads uncertain) — FN-safe. Needs tree-sitter-go."""
+
+    _SRC = (
+        "package main\n"
+        "type handler interface { serve() }\n"
+        "type A struct{}\n"
+        "func (a *A) serve() {}\n"      # unexported, iface-dispatched
+        "func (a *A) deadOne() {}\n"    # unexported, never dispatched
+        "type B struct{}\n"
+        "func (b *B) serve() {}\n"      # name collides with dispatched serve
+        "func Run(h handler) { h.serve() }\n")  # exported entry, dispatches
+
+    def test_go_interface_dispatched_method_is_uncertain(self, tmp_path):
+        pytest.importorskip("tree_sitter_go")
+        from core.inventory.reach_audit import classify_reachability
+        (tmp_path / "go.mod").write_text("module x\ngo 1.21\n")
+        (tmp_path / "m.go").write_text(self._SRC)
+        inv = build_inventory(str(tmp_path), str(tmp_path / "out"))
+
+        def verdict(name, cls):
+            for f in inv["files"]:
+                if not f["path"].endswith("m.go"):
+                    continue
+                for it in f["items"]:
+                    md = it.get("metadata") or {}
+                    if it.get("name") == name and md.get("class_name") == cls:
+                        return classify_reachability(
+                            inv, f["path"], name,
+                            int(it.get("line_start") or 0), "m")
+            return None
+
+        # dispatched via h.serve() → reachable at runtime via the interface
+        assert verdict("serve", "A") == "uncertain"
+        # same-name method on an unrelated type → also uncertain (FN-safe)
+        assert verdict("serve", "B") == "uncertain"
+        # never dispatched → stays dead (gate prevents blanket promotion)
+        assert verdict("deadOne", "A") == "no_path_from_entry"
+
+
 class TestJavaFrameworkEntries:
     """End-to-end Java framework-dispatch entry coverage. Spring / Jakarta
     container-managed methods (routes, @EventListener / @Scheduled, @Bean
@@ -1593,3 +1641,120 @@ class TestRubyCoverage:
         assert verdict("fetch") == "reachable"           # helper in a controller
         assert verdict("perform") == "reachable"         # job entry
         assert verdict("lonely") == "not_called"         # plain class control
+
+
+class TestPythonFrameworkConvention:
+    """Python class-based views (Django/DRF/Flask). Decorator-dispatched views
+    are handled by is_framework_callable; this covers the CONVENTION — a method
+    of a class subclassing a framework CBV base (APIView/ListView/MethodView)
+    is dispatched by the framework with no in-project caller. Requires the
+    extractor to capture Python class bases into class_attributes."""
+
+    _FILES = {
+        "views.py": (
+            "import rest_framework.views\n"
+            "class UserView(rest_framework.views.APIView):\n"
+            "    def get(self, request): return self._fmt()\n"
+            "    def _fmt(self): return 'x'\n"
+            "class BlogList(ListView):\n"
+            "    def get_queryset(self): return []\n"
+            "class Plain:\n"
+            "    def dead(self): return 9\n"),
+    }
+
+    def test_python_class_bases_captured(self, tmp_path):
+        (tmp_path / "views.py").write_text(self._FILES["views.py"])
+        inv = build_inventory(str(tmp_path), str(tmp_path / "out"))
+        meta = {it["name"]: (it.get("metadata") or {})
+                for f in inv["files"] for it in f["items"]}
+        # dotted base recorded by simple tail name; plain class has none.
+        assert "APIView" in meta["get"]["class_attributes"]
+        assert "ListView" in meta["get_queryset"]["class_attributes"]
+        assert meta["dead"]["class_attributes"] == []
+
+    def test_python_cbv_methods_are_entries(self, tmp_path):
+        from core.inventory.reach_audit import classify_reachability
+        (tmp_path / "views.py").write_text(self._FILES["views.py"])
+        inv = build_inventory(str(tmp_path), str(tmp_path / "out"))
+
+        def verdict(name):
+            for f in inv["files"]:
+                for it in f["items"]:
+                    if it.get("name") == name:
+                        return classify_reachability(
+                            inv, f["path"], name,
+                            int(it.get("line_start") or 0), "views")
+            return None
+
+        assert verdict("get") == "reachable"           # DRF APIView verb handler
+        assert verdict("get_queryset") == "reachable"   # Django ListView hook
+        assert verdict("dead") == "not_called"          # non-CBV control
+
+
+class TestPhpCoverage:
+    """End-to-end PHP / Laravel + Symfony coverage. PHP used the regex
+    extractor; now wired to tree-sitter-php (class/method names, visibility,
+    #[…] attributes, extends/implements). Framework dispatch is both
+    attribute-based (Symfony #[Route]) and base-class/interface convention
+    (Laravel/Symfony Controller/AbstractController/Command/ShouldQueue). Needs
+    tree-sitter-php; skips without it."""
+
+    _FILES = {
+        "UserController.php": (
+            "<?php\nclass UserController extends AbstractController {\n"
+            "  #[Route('/list')]\n"
+            "  public function list(): Response { return $this->fmt(); }\n"
+            "  private function fmt(): string { return 'x'; }\n}\n"),
+        "WidgetJob.php": (
+            "<?php\nclass WidgetJob implements ShouldQueue {\n"
+            "  public function handle() {}\n}\n"),
+        "Plain.php": "<?php\nclass Plain {\n  public function lonely() {}\n}\n",
+        # attribute-only Symfony command (no `extends Command`) — modern
+        # Symfony marks dispatch by class attribute, not base class.
+        "FooCommand.php": (
+            "<?php\n#[AsCommand(name: 'app:foo')]\nclass FooCommand {\n"
+            "  public function execute(): int { return 0; }\n}\n"),
+        # controller extending a PROJECT-custom base → caught by the
+        # *Controller naming convention, not an explicit framework base.
+        "BlogController.php": (
+            "<?php\nclass BlogController extends BaseController {\n"
+            "  public function index(): Response { return new Response(); }\n}\n"),
+    }
+
+    def _build(self, tmp_path):
+        for rel, c in self._FILES.items():
+            (tmp_path / rel).write_text(c)
+        return build_inventory(str(tmp_path), str(tmp_path / "out"))
+
+    def test_php_extracts_methods_attrs_bases(self, tmp_path):
+        pytest.importorskip("tree_sitter_php")
+        inv = self._build(tmp_path)
+        meta = {it["name"]: (it.get("metadata") or {})
+                for f in inv["files"] for it in f["items"]}
+        assert {"list", "fmt", "handle", "lonely"} <= set(meta)
+        assert "Route" in meta["list"]["attributes"]
+        assert "AbstractController" in meta["list"]["class_attributes"]
+        assert "ShouldQueue" in meta["handle"]["class_attributes"]
+        assert meta["fmt"]["visibility"] == "private"
+
+    def test_php_framework_entry_verdicts(self, tmp_path):
+        pytest.importorskip("tree_sitter_php")
+        from core.inventory.reach_audit import classify_reachability
+        inv = self._build(tmp_path)
+
+        def verdict(name):
+            for f in inv["files"]:
+                for it in f["items"]:
+                    if it.get("name") == name:
+                        return classify_reachability(
+                            inv, f["path"], name,
+                            int(it.get("line_start") or 0),
+                            f["path"].rsplit(".", 1)[0])
+            return None
+
+        assert verdict("list") == "reachable"      # #[Route] + AbstractController
+        assert verdict("fmt") == "reachable"        # method of a controller class
+        assert verdict("handle") == "reachable"     # implements ShouldQueue
+        assert verdict("lonely") == "not_called"    # plain class control
+        assert verdict("execute") == "reachable"    # class #[AsCommand] attribute
+        assert verdict("index") == "reachable"      # *Controller naming convention

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -1672,6 +1672,18 @@ class TestPythonFrameworkConvention:
         assert "ListView" in meta["get_queryset"]["class_attributes"]
         assert meta["dead"]["class_attributes"] == []
 
+    def test_python_class_bases_captured_stdlib_path(self):
+        # CI has no tree-sitter grammar → the stdlib ast PythonExtractor runs.
+        # Exercise it DIRECTLY (not build_inventory, which prefers tree-sitter
+        # where installed) so base capture is verified on the fallback path
+        # regardless of environment. See feedback-test-on-stdlib-extractor-path.
+        from core.inventory.extractors import PythonExtractor
+        meta = {fi.name: fi.metadata
+                for fi in PythonExtractor().extract("views.py", self._FILES["views.py"])}
+        assert "APIView" in meta["get"].class_attributes        # dotted base
+        assert "ListView" in meta["get_queryset"].class_attributes
+        assert meta["dead"].class_attributes == []
+
     def test_python_cbv_methods_are_entries(self, tmp_path):
         from core.inventory.reach_audit import classify_reachability
         (tmp_path / "views.py").write_text(self._FILES["views.py"])

--- a/core/inventory/tests/test_reachability.py
+++ b/core/inventory/tests/test_reachability.py
@@ -903,3 +903,30 @@ def test_ruby_non_framework_class_not_entry():
     assert not _ruby_framework_entry("lonely", _java_item("lonely", class_attrs=["SomeBase"]))
     assert not _ruby_framework_entry("lonely", _java_item("lonely"))
     assert _ruby_framework_entry("x", {"name": "x", "kind": "function"}) is False
+
+
+# ---------------------------------------------------------------------------
+# PHP / Laravel + Symfony framework entries (_php_framework_entry). Both a
+# method #[Route] attribute and a framework base/interface (in class_attributes)
+# mark methods as dispatched.
+# ---------------------------------------------------------------------------
+
+
+def test_php_method_route_attr_is_entry():
+    from core.inventory.reachability import _php_framework_entry
+    assert _php_framework_entry("list", _java_item("list", attrs=["Route"]))
+
+
+def test_php_framework_base_promotes_methods():
+    from core.inventory.reachability import _php_framework_entry
+    # extends/implements a Laravel/Symfony base or class #[…] → methods entries.
+    for base in ("AbstractController", "Controller", "Command",
+                 "ShouldQueue", "EventSubscriberInterface", "Route"):
+        assert _php_framework_entry("m", _java_item("m", class_attrs=[base])), base
+
+
+def test_php_plain_class_not_entry():
+    from core.inventory.reachability import _php_framework_entry
+    assert not _php_framework_entry("lonely", _java_item("lonely", class_attrs=["SomeBase"]))
+    assert not _php_framework_entry("lonely", _java_item("lonely"))
+    assert _php_framework_entry("x", {"name": "x", "kind": "function"}) is False


### PR DESCRIPTION
FN-safe add-entries/hedge fixes from a per-language audit:
- PHP: Laravel/Symfony framework-entry model (bases + #[Route]/#[AsCommand]
  + *Controller convention) — handlers no longer read not_called
- Python: capture class bases + class-based-view convention (Django/DRF/Flask)
- Go: structural-interface CHA-analog — an interface-dispatched method reads uncertain not no_path_from_entry (seed override_methods from receiver type + intercept the entry stage; also tightens Java/TS)
- Rust: flag Any::downcast/transmute as reflection masking (parity)

All move verdicts only toward reachable/uncertain, never suppress. _CACHE_VERSION bump (Go override_methods). 1076 tests pass.