### PR TITLE
feat(trust-corpus): CVEfixes-scale walker + multi-language barrier dialects

### DIFF
--- a/core/dataflow/barrier_synth.py
+++ b/core/dataflow/barrier_synth.py
@@ -35,11 +35,58 @@ from core.dataflow.codeql_augmented_run import (
     analyze,
 )
 
-# sink-class -> (customizations module, module name exposing Source/Sink/Sanitizer)
+# sink-class -> (customizations module, module name exposing Source/Sink/Sanitizer).
+# Python: each module imports Concepts/RemoteFlowSources/BarrierGuards and
+# defines its concrete Source/Sink subclasses in-file, so importing the
+# customizations module alone registers sources + sinks for the taint flow.
 _CUSTOMIZATIONS = {
     "cmdi": ("semmle.python.security.dataflow.CommandInjectionCustomizations", "CommandInjection"),
     "sqli": ("semmle.python.security.dataflow.SqlInjectionCustomizations", "SqlInjection"),
     "pathtrav": ("semmle.python.security.dataflow.PathInjectionCustomizations", "PathInjection"),
+    "xss": ("semmle.python.security.dataflow.ReflectedXSSCustomizations", "ReflectedXss"),
+}
+
+# JavaScript/TypeScript equivalents. JS uses the legacy TaintTracking::Configuration
+# class API (the new ConfigSig/BarrierGuard the Python dialect uses is unused in the
+# JS libs), so barriers go through `isSanitizerGuard` + a SanitizerGuardNode subclass
+# rather than a flat `proposedGuard/3` predicate — a different proposer contract.
+_JS_CUSTOMIZATIONS = {
+    "cmdi": ("semmle.javascript.security.dataflow.CommandInjectionCustomizations", "CommandInjection"),
+    "sqli": ("semmle.javascript.security.dataflow.SqlInjectionCustomizations", "SqlInjection"),
+    "pathtrav": ("semmle.javascript.security.dataflow.TaintedPathCustomizations", "TaintedPath"),
+    "xss": ("semmle.javascript.security.dataflow.ReflectedXssCustomizations", "ReflectedXss"),
+}
+
+# Ruby. Like Python it uses the new ConfigSig/BarrierGuard API (the legacy
+# Configuration class is deprecated), so the Ruby dialect mirrors the Python
+# template — but with Ruby imports and a Ruby guard signature
+# (proposedGuard(CfgNodes::AstCfgNode g, CfgNode node, boolean branch)). Source/
+# Sink/Sanitizer are pulled in unqualified via `import <file>::<module>`.
+_RB_CUSTOMIZATIONS = {
+    "cmdi": ("codeql.ruby.security.CommandInjectionCustomizations", "CommandInjection"),
+    "sqli": ("codeql.ruby.security.SqlInjectionCustomizations", "SqlInjection"),
+    "pathtrav": ("codeql.ruby.security.PathInjectionCustomizations", "PathInjection"),
+    "xss": ("codeql.ruby.security.XSS", "ReflectedXss"),
+}
+
+# Java. New ConfigSig/BarrierGuard API like Python/Ruby, guard sig uses a
+# boolean branch (proposedGuard(Guard g, Expr e, boolean branch)) — so the
+# dialect is Python-shaped with Java imports. Unlike the others Java has no
+# uniform <X>::Source/Sink module: the source is always RemoteFlowSource and the
+# sink is a per-CWE class/predicate. Map: sink_class -> (sink import, isSink body).
+_JAVA_SINKS = {
+    "sqli": ("semmle.code.java.security.QueryInjection", "n instanceof QueryInjectionSink"),
+    "cmdi": ("semmle.code.java.security.CommandLineQuery", "n instanceof CommandInjectionSink"),
+    "xss": ("semmle.code.java.security.XSS", "n instanceof XssSink"),
+    "pathtrav": ("semmle.code.java.dataflow.ExternalFlow", 'sinkNode(n, "path-injection")'),
+}
+
+# language -> the CodeQL standard-library pack the assembled query depends on.
+_LANG_PACK = {
+    "python": "codeql/python-all",
+    "javascript": "codeql/javascript-all",
+    "ruby": "codeql/ruby-all",
+    "java": "codeql/java-all",
 }
 
 
@@ -47,10 +94,11 @@ _CUSTOMIZATIONS = {
 class BarrierProposal:
     """Context handed to the proposer for one flagged FP."""
 
-    sink_class: str          # "cmdi" | "sqli" | "pathtrav"
+    sink_class: str          # "cmdi" | "sqli" | "pathtrav" | "xss"
     finding_id: str
     sink_snippet: str
     source_context: str      # the function/path source the LLM reasons over
+    language: str = "python"  # "python" | "javascript" (selects the QL dialect)
 
 
 # proposer(proposal, prior_error) -> a CodeQL guardChecks predicate named
@@ -82,9 +130,28 @@ class SynthResult:
         return self.suppressed_fp and self.preserved_tp
 
 
-def assemble_barrier_query(proposed_guard: str, *, sink_class: str, query_id: str) -> str:
-    """Wrap a proposed ``proposedGuard`` predicate into a runnable CWE-class
-    taint query (the validated §9 template)."""
+def assemble_barrier_query(
+    proposed_guard: str, *, sink_class: str, query_id: str, language: str = "python",
+) -> str:
+    """Wrap a proposed barrier into a runnable CWE-class taint query.
+
+    ``language`` selects the QL dialect: ``python`` uses the new
+    ``ConfigSig``/``BarrierGuard<proposedGuard/3>`` API (§9 template); ``javascript``
+    uses the legacy ``TaintTracking::Configuration`` + a ``ProposedGuard``
+    SanitizerGuardNode subclass (the only API the JS libs expose)."""
+    if language == "python":
+        return _assemble_python(proposed_guard, sink_class, query_id)
+    if language == "javascript":
+        return _assemble_javascript(proposed_guard, sink_class, query_id)
+    if language == "ruby":
+        return _assemble_ruby(proposed_guard, sink_class, query_id)
+    if language == "java":
+        return _assemble_java(proposed_guard, sink_class, query_id)
+    raise ValueError(
+        f"unknown language {language!r}; known: {sorted(_LANG_PACK)}")
+
+
+def _assemble_python(proposed_guard: str, sink_class: str, query_id: str) -> str:
     if sink_class not in _CUSTOMIZATIONS:
         raise ValueError(f"unknown sink_class {sink_class!r}; "
                          f"known: {sorted(_CUSTOMIZATIONS)}")
@@ -121,6 +188,118 @@ select sink, "synthesized-barrier {sink_class}"
 """
 
 
+def _assemble_javascript(proposed_guard: str, sink_class: str, query_id: str) -> str:
+    if sink_class not in _JS_CUSTOMIZATIONS:
+        raise ValueError(f"unknown sink_class {sink_class!r}; "
+                         f"known: {sorted(_JS_CUSTOMIZATIONS)}")
+    if "ProposedGuard" not in proposed_guard:
+        raise ValueError(
+            "proposer must define a `ProposedGuard` SanitizerGuardNode subclass")
+    module_import, module_name = _JS_CUSTOMIZATIONS[sink_class]
+    return f"""/**
+ * @name Synthesized barrier ({sink_class}) [js]
+ * @kind problem
+ * @problem.severity error
+ * @id {query_id}
+ */
+import javascript
+import {module_import}::{module_name}
+
+{proposed_guard.strip()}
+
+class SynthConfig extends TaintTracking::Configuration {{
+  SynthConfig() {{ this = "raptor-synth-{sink_class}" }}
+  override predicate isSource(DataFlow::Node n) {{ n instanceof Source }}
+  override predicate isSink(DataFlow::Node n) {{ n instanceof Sink }}
+  override predicate isSanitizer(DataFlow::Node n) {{
+    super.isSanitizer(n) or n instanceof Sanitizer
+  }}
+  override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode g) {{
+    g instanceof ProposedGuard
+  }}
+}}
+
+from SynthConfig cfg, DataFlow::Node source, DataFlow::Node sink
+where cfg.hasFlow(source, sink)
+select sink, "synthesized-barrier {sink_class} [js]"
+"""
+
+
+def _assemble_ruby(proposed_guard: str, sink_class: str, query_id: str) -> str:
+    if sink_class not in _RB_CUSTOMIZATIONS:
+        raise ValueError(f"unknown sink_class {sink_class!r}; "
+                         f"known: {sorted(_RB_CUSTOMIZATIONS)}")
+    if "proposedGuard" not in proposed_guard:
+        raise ValueError("proposer must define a `proposedGuard` predicate")
+    module_import, module_name = _RB_CUSTOMIZATIONS[sink_class]
+    return f"""/**
+ * @name Synthesized barrier ({sink_class}) [rb]
+ * @kind problem
+ * @problem.severity error
+ * @id {query_id}
+ */
+import codeql.ruby.DataFlow
+import codeql.ruby.TaintTracking
+import codeql.ruby.CFG
+import {module_import}::{module_name}
+
+{proposed_guard.strip()}
+
+module Cfg implements DataFlow::ConfigSig {{
+  predicate isSource(DataFlow::Node n) {{ n instanceof Source }}
+  predicate isSink(DataFlow::Node n) {{ n instanceof Sink }}
+  predicate isBarrier(DataFlow::Node n) {{
+    n instanceof Sanitizer or
+    n = DataFlow::BarrierGuard<proposedGuard/3>::getABarrierNode()
+  }}
+}}
+
+module Flow = TaintTracking::Global<Cfg>;
+
+from DataFlow::Node source, DataFlow::Node sink
+where Flow::flow(source, sink)
+select sink, "synthesized-barrier {sink_class} [rb]"
+"""
+
+
+def _assemble_java(proposed_guard: str, sink_class: str, query_id: str) -> str:
+    if sink_class not in _JAVA_SINKS:
+        raise ValueError(f"unknown sink_class {sink_class!r}; "
+                         f"known: {sorted(_JAVA_SINKS)}")
+    if "proposedGuard" not in proposed_guard:
+        raise ValueError("proposer must define a `proposedGuard` predicate")
+    sink_import, sink_expr = _JAVA_SINKS[sink_class]
+    return f"""/**
+ * @name Synthesized barrier ({sink_class}) [java]
+ * @kind problem
+ * @problem.severity error
+ * @id {query_id}
+ */
+import java
+import semmle.code.java.dataflow.DataFlow
+import semmle.code.java.dataflow.TaintTracking
+import semmle.code.java.dataflow.FlowSources
+import semmle.code.java.controlflow.Guards
+import {sink_import}
+
+{proposed_guard.strip()}
+
+module Cfg implements DataFlow::ConfigSig {{
+  predicate isSource(DataFlow::Node n) {{ n instanceof RemoteFlowSource }}
+  predicate isSink(DataFlow::Node n) {{ {sink_expr} }}
+  predicate isBarrier(DataFlow::Node n) {{
+    n = DataFlow::BarrierGuard<proposedGuard/3>::getABarrierNode()
+  }}
+}}
+
+module Flow = TaintTracking::Global<Cfg>;
+
+from DataFlow::Node source, DataFlow::Node sink
+where Flow::flow(source, sink)
+select sink, "synthesized-barrier {sink_class} [java]"
+"""
+
+
 def _count_sarif_results(sarif_path: Path) -> int:
     data = json.loads(Path(sarif_path).read_text())
     return sum(len(r.get("results", [])) for r in data.get("runs", []))
@@ -131,6 +310,7 @@ def adjudicate(
     db_path: Path,
     *,
     work_dir: Path,
+    language: str = "python",
     search_path: Optional[str] = None,
     codeql_bin: str = DEFAULT_CODEQL_BIN,
     runner: Optional[RunnerFn] = None,
@@ -139,9 +319,12 @@ def adjudicate(
     finding count. Writes the query + a minimal qlpack into ``work_dir``."""
     pack = work_dir
     pack.mkdir(parents=True, exist_ok=True)
+    dep = _LANG_PACK.get(language)
+    if dep is None:
+        raise ValueError(f"unknown language {language!r}; known: {sorted(_LANG_PACK)}")
     (pack / "qlpack.yml").write_text(
         'name: raptor/barrier-synth\nversion: 0.0.1\n'
-        'dependencies:\n  codeql/python-all: "*"\n'
+        f'dependencies:\n  {dep}: "*"\n'
     )
     ql = pack / "SynthBarrier.ql"
     ql.write_text(query_ql)
@@ -180,12 +363,15 @@ def run_synthesis_loop(
             query_ql = assemble_barrier_query(
                 proposed, sink_class=proposal.sink_class,
                 query_id=f"raptor/synth/{proposal.finding_id}/{attempt}",
+                language=proposal.language,
             )
             after_count = adjudicate(
                 query_ql, after_db, work_dir=work_dir / f"after-{attempt}",
+                language=proposal.language,
                 search_path=search_path, codeql_bin=codeql_bin, runner=runner)
             before_count = adjudicate(
                 query_ql, before_db, work_dir=work_dir / f"before-{attempt}",
+                language=proposal.language,
                 search_path=search_path, codeql_bin=codeql_bin, runner=runner)
         except (ValueError, CodeQLRunError) as exc:
             prior_error = f"{type(exc).__name__}: {exc}"
@@ -274,7 +460,7 @@ def render_corpus_report(r: CorpusSynthReport) -> str:
 # proposer is testable with a stub and the real LLM is wired lazily.
 Completer = Callable[[str, str], str]
 
-_SYSTEM_PROMPT = (
+_PY_SYSTEM_PROMPT = (
     "You are a CodeQL expert. A taint-analysis finding has been flagged as a "
     "false positive because a PROJECT-SPECIFIC validator/sanitizer on the path "
     "neutralizes the attacker input — but the analyzer doesn't model it. Your "
@@ -288,15 +474,72 @@ _SYSTEM_PROMPT = (
     "customizations module are already imported. No prose, no markdown fences."
 )
 
+_JS_SYSTEM_PROMPT = (
+    "You are a CodeQL expert. A JavaScript taint-analysis finding has been flagged "
+    "as a false positive because a PROJECT-SPECIFIC validator/sanitizer on the path "
+    "neutralizes the attacker input — but the analyzer doesn't model it. Your job: "
+    "emit a CodeQL SanitizerGuardNode subclass that recognizes that validator.\n\n"
+    "Output ONLY a CodeQL class, exactly this name and shape:\n"
+    "  class ProposedGuard extends TaintTracking::SanitizerGuardNode {\n"
+    "    ProposedGuard() { /* select the guard node: the validator call/comparison */ }\n"
+    "    override predicate sanitizes(boolean outcome, Expr e) "
+    "{ /* `e` is safe on the `outcome` branch */ }\n"
+    "  }\n"
+    "Semantics: the constructor selects the guard DataFlow node; `sanitizes(outcome, e)` "
+    "holds when expression `e` is neutralized on the `outcome` branch of the guard. "
+    "`javascript`, `DataFlow`, `TaintTracking`, and the relevant security "
+    "customizations module are already imported. No prose, no markdown fences."
+)
+
+_RB_SYSTEM_PROMPT = (
+    "You are a CodeQL expert. A Ruby taint-analysis finding has been flagged as a "
+    "false positive because a PROJECT-SPECIFIC validator/sanitizer on the path "
+    "neutralizes the attacker input — but the analyzer doesn't model it. Your job: "
+    "emit a CodeQL guard predicate that recognizes that validator.\n\n"
+    "Output ONLY a CodeQL predicate, exactly this signature and name:\n"
+    "  predicate proposedGuard(CfgNodes::AstCfgNode g, CfgNode node, boolean branch)\n"
+    "Semantics: `g` is the guard (the validator call/comparison); `node` is the CFG "
+    "node of the value it checks; `branch` is the boolean value of `g` on which "
+    "`node` is safe. `codeql.ruby.DataFlow`, `TaintTracking`, `CFG`, and the relevant "
+    "security customizations module are already imported. No prose, no markdown fences."
+)
+
+_JAVA_SYSTEM_PROMPT = (
+    "You are a CodeQL expert. A Java taint-analysis finding has been flagged as a "
+    "false positive because a PROJECT-SPECIFIC validator/sanitizer on the path "
+    "neutralizes the attacker input — but the analyzer doesn't model it. Your job: "
+    "emit a CodeQL guard predicate that recognizes that validator.\n\n"
+    "Output ONLY a CodeQL predicate, exactly this signature and name:\n"
+    "  predicate proposedGuard(Guard g, Expr e, boolean branch)\n"
+    "Semantics: `g` is the guard (the validator call/comparison); `e` is the "
+    "expression it checks; `branch` is the boolean value of `g` on which `e` is "
+    "safe. `java`, `DataFlow`, `TaintTracking`, `Guards`, and the relevant security "
+    "module are already imported. No prose, no markdown fences."
+)
+
+_SYSTEM_PROMPTS = {
+    "python": _PY_SYSTEM_PROMPT,
+    "javascript": _JS_SYSTEM_PROMPT,
+    "ruby": _RB_SYSTEM_PROMPT,
+    "java": _JAVA_SYSTEM_PROMPT,
+}
+
 
 def _build_prompt(proposal: BarrierProposal, prior_error: Optional[str]) -> str:
+    emit = (
+        "Emit the `ProposedGuard` SanitizerGuardNode subclass recognizing the "
+        "validator on this path."
+        if proposal.language == "javascript"
+        else "Emit the `proposedGuard` predicate recognizing the validator on this path."
+    )
     parts = [
         f"sink class: {proposal.sink_class}",
+        f"language: {proposal.language}",
         f"flagged sink: {proposal.sink_snippet}",
         "source (the function/path the finding flows through):",
         proposal.source_context,
         "",
-        "Emit the `proposedGuard` predicate recognizing the validator on this path.",
+        emit,
     ]
     if prior_error:
         parts += [
@@ -322,7 +565,8 @@ def _extract_ql(reply: str) -> str:
 def make_llm_proposer(complete: Completer) -> BarrierProposer:
     """Build a proposer backed by an LLM ``complete`` callable."""
     def propose(proposal: BarrierProposal, prior_error: Optional[str]) -> str:
-        return _extract_ql(complete(_SYSTEM_PROMPT, _build_prompt(proposal, prior_error)))
+        system_prompt = _SYSTEM_PROMPTS.get(proposal.language, _PY_SYSTEM_PROMPT)
+        return _extract_ql(complete(system_prompt, _build_prompt(proposal, prior_error)))
     return propose
 
 
@@ -346,6 +590,7 @@ def main(argv: Optional[list] = None) -> int:
     p.add_argument("before_db", type=Path, help="CodeQL DB of the pre-fix (vulnerable) source")
     p.add_argument("after_db", type=Path, help="CodeQL DB of the post-fix (sanitized) source")
     p.add_argument("--sink-class", required=True, choices=sorted(_CUSTOMIZATIONS))
+    p.add_argument("--language", default="python", choices=sorted(_LANG_PACK))
     p.add_argument("--finding-id", required=True)
     p.add_argument("--sink", required=True, help="flagged sink snippet/description")
     p.add_argument("--source-file", type=Path, required=True,
@@ -356,7 +601,7 @@ def main(argv: Optional[list] = None) -> int:
     args = p.parse_args(argv)
 
     proposal = BarrierProposal(
-        sink_class=args.sink_class, finding_id=args.finding_id,
+        sink_class=args.sink_class, finding_id=args.finding_id, language=args.language,
         sink_snippet=args.sink, source_context=args.source_file.read_text(encoding="utf-8"),
     )
     res = run_synthesis_loop(

--- a/core/dataflow/cvefix_loader.py
+++ b/core/dataflow/cvefix_loader.py
@@ -1,0 +1,96 @@
+"""Load CVE fix-commit pairs from a CVEfixes metadata SQLite DB.
+
+Queries a CVEfixes metadata DB (the relational dump, optionally with the
+code-blob tables `method_change`/`file_change` skipped — they're irrelevant
+here) for fix-commits of given CWEs in CodeQL-supported languages, yielding
+before/after commit pairs. The trust-corpus pipeline then clones each repo at
+the fix + parent commits and builds CodeQL DBs — so we need the repo URL +
+fix hash + parent hash, not the per-method code blobs.
+
+Join path: `cwe_classification(cve_id, cwe_id)` → `fixes(cve_id, hash, repo_url)`
+→ `commits(hash, parents)` → `repository(repo_url, repo_language)`. The
+`parents` column is a Python-list-repr string (e.g. `"['abc...']"`); we keep
+only single-parent commits (merges have ambiguous before-state).
+
+PHP is excluded: it's the largest injection bucket but has no CodeQL extractor
+(see `~/design/trust-witness.md` §10 — PHP needs the Semgrep-flavored tier).
+"""
+
+from __future__ import annotations
+
+import ast
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+# CodeQL-supported languages present in CVEfixes repo_language values.
+CODEQL_LANGUAGES = (
+    "Python", "Java", "JavaScript", "TypeScript", "Go", "Ruby", "C", "C++", "C#",
+)
+
+# Injection CWEs the trust sound-tier targets.
+INJECTION_CWES = ("CWE-89", "CWE-78", "CWE-79", "CWE-22")
+
+
+@dataclass(frozen=True)
+class CveFixPair:
+    cve_id: str
+    cwe: str
+    repo_url: str
+    repo_language: str
+    fix_hash: str       # the fix commit — post-fix (AFTER) state
+    parent_hash: str    # its single parent — pre-fix (BEFORE) state
+
+
+def _single_parent(parents_repr: Optional[str]) -> Optional[str]:
+    """Extract the lone parent hash from the list-repr string; None for merges
+    (≥2 parents), roots (0), or anything unparseable."""
+    if not parents_repr:
+        return None
+    try:
+        parents = ast.literal_eval(parents_repr)
+    except (ValueError, SyntaxError):
+        return None
+    if isinstance(parents, (list, tuple)) and len(parents) == 1:
+        return str(parents[0])
+    return None
+
+
+def load_pairs(
+    db_path: Path,
+    *,
+    cwes: Sequence[str] = INJECTION_CWES,
+    languages: Sequence[str] = CODEQL_LANGUAGES,
+    limit: Optional[int] = None,
+) -> List[CveFixPair]:
+    """Return CodeQL-buildable before/after CVE fix-commit pairs."""
+    cwe_ph = ",".join("?" * len(cwes))
+    lang_ph = ",".join("?" * len(languages))
+    sql = f"""
+        SELECT DISTINCT f.cve_id, c.cwe_id, f.repo_url, r.repo_language,
+               f.hash, cm.parents
+        FROM fixes f
+        JOIN cwe_classification c ON f.cve_id = c.cve_id
+        JOIN commits cm ON f.hash = cm.hash
+        JOIN repository r ON f.repo_url = r.repo_url
+        WHERE c.cwe_id IN ({cwe_ph})
+          AND r.repo_language IN ({lang_ph})
+          AND f.repo_url LIKE 'https://github.com/%'
+        ORDER BY f.cve_id
+    """
+    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        rows = con.execute(sql, (*cwes, *languages)).fetchall()
+    finally:
+        con.close()
+
+    pairs: List[CveFixPair] = []
+    for cve_id, cwe, repo_url, lang, fix_hash, parents in rows:
+        parent = _single_parent(parents)
+        if parent is None:
+            continue
+        pairs.append(CveFixPair(cve_id, cwe, repo_url, lang, fix_hash, parent))
+        if limit is not None and len(pairs) >= limit:
+            break
+    return pairs

--- a/core/dataflow/cvefix_walk.py
+++ b/core/dataflow/cvefix_walk.py
@@ -1,0 +1,387 @@
+"""Walk a CVEfixes metadata DB: drive each fix pair through CodeQL, harvest yielders.
+
+For each CWE-filtered, CodeQL-language fix pair (from :mod:`cvefix_loader`):
+fetch the repo at fix+parent (shallow, by-SHA), build before/after CodeQL DBs,
+run the CWE-appropriate query, and record the before/after finding counts.
+
+Designed for a long unattended campaign over thousands of pairs:
+  * **Resumable** — results persist to a SQLite (`walk_results`, keyed by
+    fix_hash); already-processed pairs are skipped on restart.
+  * **Disk-safe** — each pair's clone + DBs are removed after measuring; a
+    yielder is cheaply rebuilt later from its recorded repo + hashes.
+  * **Bounded** — per-step timeouts; failures are recorded as a status, never
+    fatal to the walk.
+
+A pair with ``before_count > 0`` is a real CVE CodeQL flags (a TP); additionally
+``after_count > 0`` is a candidate missing-sanitizer FP — the trust sound-tier's
+input. The git/CodeQL steps are module-level functions so tests stub them.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Sequence
+
+from core.config import RaptorConfig
+from core.dataflow.cvefix_loader import CveFixPair, INJECTION_CWES, load_pairs
+
+DEFAULT_CODEQL_BIN = "codeql"
+
+# Package repos autobuild may fetch from. A build needing other repos fails the
+# egress allowlist and falls back to buildless (graceful) — see _run_autobuild_sandboxed.
+_MAVEN_PROXY_HOSTS = [
+    "repo.maven.apache.org", "repo1.maven.org", "repo.maven.org",
+    "central.sonatype.com", "oss.sonatype.org", "maven.google.com", "dl.google.com",
+]
+
+# codeql extractor language -> (queries pack, {cwe: pack-relative query path}).
+# Ruby uses a different path scheme (lowercase queries/security/cwe-0XX) and query
+# names (ReflectedXSS, not ReflectedXss; PathInjection, not TaintedPath).
+_QUERIES = {
+    "python": ("python-queries", {
+        "CWE-89": "Security/CWE-089/SqlInjection.ql",
+        "CWE-78": "Security/CWE-078/CommandInjection.ql",
+        "CWE-79": "Security/CWE-079/ReflectedXss.ql",
+        "CWE-22": "Security/CWE-022/PathInjection.ql",
+    }),
+    "javascript": ("javascript-queries", {
+        "CWE-89": "Security/CWE-089/SqlInjection.ql",
+        "CWE-78": "Security/CWE-078/CommandInjection.ql",
+        "CWE-79": "Security/CWE-079/ReflectedXss.ql",
+        "CWE-22": "Security/CWE-022/TaintedPath.ql",
+    }),
+    "ruby": ("ruby-queries", {
+        "CWE-89": "queries/security/cwe-089/SqlInjection.ql",
+        "CWE-78": "queries/security/cwe-078/CommandInjection.ql",
+        "CWE-79": "queries/security/cwe-079/ReflectedXSS.ql",
+        "CWE-22": "queries/security/cwe-022/PathInjection.ql",
+    }),
+    "java": ("java-queries", {
+        "CWE-89": "Security/CWE/CWE-089/SqlTainted.ql",
+        "CWE-78": "Security/CWE/CWE-078/ExecTainted.ql",
+        "CWE-79": "Security/CWE/CWE-079/XSS.ql",
+        "CWE-22": "Security/CWE/CWE-022/TaintedPath.ql",
+    }),
+}
+
+# CVEfixes repo_language -> codeql extractor language. TypeScript extracts with
+# the javascript extractor; Ruby/Java are their own; else python/js.
+_LANG_MAP = {"Python": "python", "Ruby": "ruby", "Java": "java"}
+
+# Compiled languages we extract build-free via `--build-mode=none`. Source-
+# extracted langs (python/js/ruby) take no build mode. Java's buildless recall is
+# weaker (no type resolution → Spring/interface flows missed); the build-promote
+# pass recovers those `before==0` misses with a real build.
+_BUILDLESS_COMPILED = {"java"}
+
+
+def _codeql_lang(repo_language: str) -> str:
+    return _LANG_MAP.get(repo_language, "javascript")
+
+
+def query_for(repo_language: str, cwe: str) -> Optional[str]:
+    pack, table = _QUERIES[_codeql_lang(repo_language)]
+    sub = table.get(cwe)
+    return None if sub is None else f"codeql/{pack}:{sub}"
+
+
+@dataclass(frozen=True)
+class WalkResult:
+    fix_hash: str
+    status: str               # ok | fetch_fail | build_fail | analyze_fail | no_query
+    before_count: int = -1
+    after_count: int = -1
+
+    @property
+    def is_yield(self) -> bool:
+        return self.status == "ok" and self.before_count > 0
+
+    @property
+    def is_fp_candidate(self) -> bool:
+        return self.status == "ok" and self.after_count > 0
+
+
+# --- subprocess steps (module-level so tests can stub them) ---
+
+def _run(cmd, timeout) -> bool:
+    # get_safe_env() strips env vars tools may shell-evaluate (untrusted-repo
+    # hygiene per CLAUDE.md); buildless extraction + git read-only ops only.
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout,
+                           check=False, env=RaptorConfig.get_safe_env())
+        return r.returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _toolchain_readable_paths(codeql_bin: str) -> list:
+    """Paths the sandboxed autobuild must read/exec (codeql install, system
+    toolchain, CA certs) on top of the work area — restrict_reads denies $HOME."""
+    real = os.path.realpath(shutil.which(codeql_bin) or codeql_bin)
+    return [
+        str(Path(real).resolve().parent), str(Path.home() / ".local"),
+        "/usr", "/etc/alternatives", "/etc/ssl", "/etc/ca-certificates",
+    ]
+
+
+def _run_autobuild_sandboxed(cmd, *, work_root: Path, codeql_bin: str, timeout: int) -> bool:
+    """Run `codeql database create --build-mode=autobuild` — which EXECUTES the
+    untrusted project build (mvn runs pom plugins = arbitrary code) — under the
+    untrusted sandbox. FAIL CLOSED: refuse rather than run an untrusted build
+    unsandboxed. Landlock restricts writes to the work area, reads exclude host
+    credentials, egress is allowlisted to package repos; maven's local repo is
+    redirected into the work area so the build never writes to host ~/.m2.
+    """
+    try:
+        from core.sandbox import check_landlock_available, run_untrusted_networked
+    except ImportError as exc:
+        raise RuntimeError(
+            "core.sandbox unavailable — refusing to autobuild an untrusted repo") from exc
+    if not check_landlock_available():
+        raise RuntimeError(
+            "Landlock unavailable — refusing to autobuild an untrusted repo unsandboxed")
+    env = RaptorConfig.get_safe_env(preserve_proxy=True)
+    env["MAVEN_OPTS"] = f"-Dmaven.repo.local={work_root / '.m2'}"
+    try:
+        proc = run_untrusted_networked(
+            cmd, target=str(work_root), output=str(work_root),
+            proxy_hosts=_MAVEN_PROXY_HOSTS,
+            readable_paths=_toolchain_readable_paths(codeql_bin),
+            env=env, timeout=timeout,
+        )
+        return proc.returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _fetch_pair(repo_url: str, fix_hash: str, dest: Path, timeout: int) -> bool:
+    shutil.rmtree(dest, ignore_errors=True)
+    dest.mkdir(parents=True, exist_ok=True)
+    if not _run(["git", "init", "-q", str(dest)], 30):
+        return False
+    if not _run(["git", "-C", str(dest), "remote", "add", "origin", repo_url], 30):
+        return False
+    # --depth 2 brings the fix + its single parent.
+    return _run(["git", "-C", str(dest), "fetch", "-q", "--depth", "2", "origin", fix_hash], timeout)
+
+
+def _build_db(src: Path, commit: str, db: Path, lang: str, codeql_bin: str, timeout: int,
+              build_mode: Optional[str] = None) -> bool:
+    if not _run(["git", "-C", str(src), "checkout", "-q", commit], 60):
+        return False
+    cmd = [codeql_bin, "database", "create", str(db), f"--language={lang}",
+           f"--source-root={src}", "--overwrite"]
+    if build_mode:
+        cmd.append(f"--build-mode={build_mode}")
+    # autobuild executes untrusted build scripts → must be sandboxed (fail-closed).
+    # Buildless/source extraction runs no repo code → plain spawn (get_safe_env).
+    if build_mode == "autobuild":
+        return _run_autobuild_sandboxed(cmd, work_root=db.parent, codeql_bin=codeql_bin,
+                                        timeout=timeout)
+    return _run(cmd, timeout)
+
+
+def _count_query(db: Path, query: str, out: Path, codeql_bin: str, timeout: int) -> Optional[int]:
+    if not _run([codeql_bin, "database", "analyze", str(db), query,
+                 "--format=sarif-latest", f"--output={out}"], timeout):
+        return None
+    try:
+        import json
+        data = json.loads(out.read_text())
+        return sum(len(r.get("results", [])) for r in data.get("runs", []))
+    except (OSError, ValueError):
+        return None
+
+
+def process_pair(
+    pair: CveFixPair, *, work_dir: Path, codeql_bin: str = DEFAULT_CODEQL_BIN,
+    fetch_timeout: int = 150, build_timeout: int = 240, analyze_timeout: int = 180,
+    build_mode: Optional[str] = None,
+) -> WalkResult:
+    """Fetch, build before/after DBs, run the CWE query; clean up; return counts.
+
+    ``build_mode`` overrides the CodeQL extraction mode; when None it is auto-
+    picked per language (``none`` for buildless-compiled langs like Java, no flag
+    for source-extracted langs). The build-promote pass passes ``autobuild``.
+    """
+    query = query_for(pair.repo_language, pair.cwe)
+    if query is None:
+        return WalkResult(pair.fix_hash, "no_query")
+    lang = _codeql_lang(pair.repo_language)
+    mode = build_mode or ("none" if lang in _BUILDLESS_COMPILED else None)
+    repo = work_dir / "repo"
+    db_a, db_b = work_dir / "db-a", work_dir / "db-b"
+    sa, sb = work_dir / "a.sarif", work_dir / "b.sarif"
+    try:
+        if not _fetch_pair(pair.repo_url, pair.fix_hash, repo, fetch_timeout):
+            return WalkResult(pair.fix_hash, "fetch_fail")
+        if not _build_db(repo, pair.fix_hash, db_a, lang, codeql_bin, build_timeout, mode):
+            return WalkResult(pair.fix_hash, "build_fail")
+        if not _build_db(repo, pair.parent_hash, db_b, lang, codeql_bin, build_timeout, mode):
+            return WalkResult(pair.fix_hash, "build_fail")
+        after = _count_query(db_a, query, sa, codeql_bin, analyze_timeout)
+        before = _count_query(db_b, query, sb, codeql_bin, analyze_timeout)
+        if after is None or before is None:
+            return WalkResult(pair.fix_hash, "analyze_fail")
+        return WalkResult(pair.fix_hash, "ok", before_count=before, after_count=after)
+    finally:
+        for p in (repo, db_a, db_b, sa, sb):
+            shutil.rmtree(p, ignore_errors=True) if p.is_dir() else p.unlink(missing_ok=True)
+
+
+# --- resumable results store ---
+
+# Keyed by (fix_hash, cwe): the before/after result depends on the commit AND the
+# CWE-specific query, so one commit that fixes two CWEs yields two distinct
+# results. (Keying on fix_hash alone collapses them.) Same fix_hash+cwe under
+# different CVE ids is genuinely redundant — same DB, same query — so deduped.
+_SCHEMA = (
+    "CREATE TABLE IF NOT EXISTS walk_results ("
+    "fix_hash TEXT, cve_id TEXT, cwe TEXT, repo_language TEXT,"
+    "repo_url TEXT, parent_hash TEXT, status TEXT, before_count INT,"
+    "after_count INT, ts REAL, PRIMARY KEY (fix_hash, cwe))"
+)
+
+
+def _processed(con: sqlite3.Connection) -> set:
+    return {(r[0], r[1]) for r in con.execute("SELECT fix_hash, cwe FROM walk_results")}
+
+
+def _record(con: sqlite3.Connection, pair: CveFixPair, res: WalkResult) -> None:
+    con.execute(
+        "INSERT OR REPLACE INTO walk_results VALUES (?,?,?,?,?,?,?,?,?,?)",
+        (res.fix_hash, pair.cve_id, pair.cwe, pair.repo_language, pair.repo_url,
+         pair.parent_hash, res.status, res.before_count, res.after_count, time.time()),
+    )
+    con.commit()
+
+
+def walk(
+    db_path: Path, results_db: Path, *,
+    cwes: Sequence[str] = INJECTION_CWES,
+    languages=("Python", "JavaScript", "TypeScript"),
+    work_dir: Path = Path("/data/corpus/clones/walk"),
+    codeql_bin: str = DEFAULT_CODEQL_BIN,
+    limit: Optional[int] = None,
+    log=print,
+) -> dict:
+    """Walk the metadata DB's pairs through CodeQL, recording results (resumable)."""
+    pairs = load_pairs(db_path, cwes=cwes, languages=languages)
+    con = sqlite3.connect(str(results_db))
+    con.execute(_SCHEMA)
+    done = _processed(con)
+    todo = [p for p in pairs if (p.fix_hash, p.cwe) not in done]
+    log(f"walk: {len(pairs)} pairs, {len(done)} already done, {len(todo)} to process")
+    work_dir.mkdir(parents=True, exist_ok=True)
+    n = 0
+    for pair in todo:
+        if limit is not None and n >= limit:
+            break
+        res = process_pair(pair, work_dir=work_dir, codeql_bin=codeql_bin)
+        _record(con, pair, res)
+        n += 1
+        tag = "YIELD" if res.is_yield else res.status
+        log(f"  [{n}/{len(todo)}] {pair.cve_id} {pair.cwe} {pair.repo_language} "
+            f"{pair.repo_url.split('github.com/')[-1]}: {tag} "
+            f"before={res.before_count} after={res.after_count}")
+    summary = dict(con.execute(
+        "SELECT 'total', count(*) FROM walk_results UNION ALL "
+        "SELECT 'yield', count(*) FROM walk_results WHERE status='ok' AND before_count>0 UNION ALL "
+        "SELECT 'fp_candidate', count(*) FROM walk_results WHERE status='ok' AND after_count>0"
+    ).fetchall())
+    con.close()
+    return summary
+
+
+def promote_misses(
+    results_db: Path, *,
+    work_dir: Path = Path("/data/corpus/clones/promote"),
+    codeql_bin: str = DEFAULT_CODEQL_BIN,
+    promote_languages: Sequence[str] = ("Java",),
+    build_timeout: int = 600,
+    limit: Optional[int] = None,
+    log=print,
+) -> dict:
+    """Build-promote buildless misses (the second half of the Java plan).
+
+    For ``ok`` rows in ``promote_languages`` whose buildless run flagged nothing
+    (``before_count == 0`` — a likely type-resolution miss, e.g. Spring/interface
+    dispatch), retry with a real ``--build-mode=autobuild``. Update the row ONLY
+    if the build recovers a yielder (``before_count > 0``, status ``ok_built``);
+    autobuild failures or still-0 keep the buildless row, so the result is never
+    worse than buildless-only. Targeted at exactly the cases a build can help, so
+    the expensive autobuilds are bounded to the buildless false-negative set.
+    """
+    con = sqlite3.connect(str(results_db))
+    con.execute(_SCHEMA)
+    ph = ",".join("?" * len(promote_languages))
+    rows = con.execute(
+        f"SELECT fix_hash, cve_id, cwe, repo_language, repo_url, parent_hash "
+        f"FROM walk_results WHERE status='ok' AND before_count=0 "
+        f"AND repo_language IN ({ph}) ORDER BY cve_id", tuple(promote_languages)
+    ).fetchall()
+    log(f"promote: {len(rows)} buildless-miss rows in {tuple(promote_languages)}")
+    work_dir.mkdir(parents=True, exist_ok=True)
+    promoted = n = 0
+    for fix_hash, cve_id, cwe, lang, repo_url, parent_hash in rows:
+        if limit is not None and n >= limit:
+            break
+        n += 1
+        pair = CveFixPair(cve_id, cwe, repo_url, lang, fix_hash, parent_hash)
+        res = process_pair(pair, work_dir=work_dir, codeql_bin=codeql_bin,
+                           build_timeout=build_timeout, build_mode="autobuild")
+        if res.status == "ok" and res.before_count > 0:
+            con.execute(
+                "UPDATE walk_results SET status=?, before_count=?, after_count=?, ts=? "
+                "WHERE fix_hash=? AND cwe=?",
+                ("ok_built", res.before_count, res.after_count, time.time(), fix_hash, cwe))
+            con.commit()
+            promoted += 1
+            log(f"  [{n}/{len(rows)}] PROMOTED {cve_id} {cwe} "
+                f"{repo_url.split('github.com/')[-1]}: before={res.before_count} "
+                f"after={res.after_count}")
+        else:
+            log(f"  [{n}/{len(rows)}] no-recovery {cve_id} {cwe}: "
+                f"{res.status} before={res.before_count}")
+    con.close()
+    return {"candidates": len(rows), "promoted": promoted}
+
+
+def main(argv=None) -> None:
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Walk CVEfixes pairs through CodeQL, harvest yielders.")
+    ap.add_argument("--db", type=Path, default=Path("/data/corpus/cvefixes-meta.db"))
+    ap.add_argument("--results", type=Path, default=Path("/data/corpus/walk-results.db"))
+    ap.add_argument("--work-dir", type=Path, default=Path("/data/corpus/clones/walk"))
+    ap.add_argument("--languages", nargs="+", default=["Python", "JavaScript", "TypeScript"])
+    ap.add_argument("--cwes", nargs="+", default=list(INJECTION_CWES))
+    ap.add_argument("--codeql-bin", default=DEFAULT_CODEQL_BIN)
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--promote", action="store_true",
+                    help="build-promote buildless misses (autobuild) instead of walking")
+    ap.add_argument("--promote-languages", nargs="+", default=["Java"])
+    a = ap.parse_args(argv)
+    log = lambda m: print(m, flush=True)  # noqa: E731
+    if a.promote:
+        summary = promote_misses(
+            a.results, work_dir=a.work_dir, codeql_bin=a.codeql_bin,
+            promote_languages=a.promote_languages, limit=a.limit, log=log,
+        )
+        print(f"=== PROMOTE SUMMARY {summary} ===", flush=True)
+        return
+    summary = walk(
+        a.db, a.results, cwes=a.cwes, languages=a.languages,
+        work_dir=a.work_dir, codeql_bin=a.codeql_bin, limit=a.limit, log=log,
+    )
+    print(f"=== SUMMARY {summary} ===", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/core/dataflow/tests/test_barrier_synth.py
+++ b/core/dataflow/tests/test_barrier_synth.py
@@ -57,6 +57,85 @@ def test_assemble_wires_guard_and_stock_source_sink():
     assert "proposedGuard" in q
 
 
+def test_assemble_supports_python_xss():
+    q = assemble_barrier_query(_GUARD, sink_class="xss", query_id="raptor/xss")
+    assert "ReflectedXSSCustomizations" in q      # the customizations module import
+    assert "ReflectedXss::Source" in q
+    assert "ReflectedXss::Sink" in q
+    assert "BarrierGuard<proposedGuard/3>" in q
+
+
+_JS_GUARD = (
+    "class ProposedGuard extends TaintTracking::SanitizerGuardNode {\n"
+    "  ProposedGuard() { this = this }\n"
+    "  override predicate sanitizes(boolean outcome, Expr e) { none() }\n"
+    "}"
+)
+
+
+def test_assemble_javascript_uses_legacy_config_and_guard_class():
+    q = assemble_barrier_query(_JS_GUARD, sink_class="xss", query_id="raptor/js",
+                               language="javascript")
+    assert "import javascript" in q
+    assert "ReflectedXssCustomizations::ReflectedXss" in q
+    assert "extends TaintTracking::Configuration" in q
+    assert "isSanitizerGuard" in q and "g instanceof ProposedGuard" in q
+    assert "cfg.hasFlow(source, sink)" in q
+
+
+def test_assemble_javascript_requires_proposedguard_class():
+    with pytest.raises(ValueError):
+        assemble_barrier_query("predicate proposedGuard() { any() }",
+                               sink_class="xss", query_id="x", language="javascript")
+
+
+_RB_GUARD = (
+    "predicate proposedGuard(CfgNodes::AstCfgNode g, CfgNode node, boolean branch) "
+    "{ none() }"
+)
+
+
+def test_assemble_ruby_mirrors_python_configsig_with_ruby_imports():
+    q = assemble_barrier_query(_RB_GUARD, sink_class="sqli", query_id="raptor/rb",
+                               language="ruby")
+    assert "import codeql.ruby.DataFlow" in q
+    assert "SqlInjectionCustomizations::SqlInjection" in q
+    assert "implements DataFlow::ConfigSig" in q                 # python-style, not legacy
+    assert "BarrierGuard<proposedGuard/3>" in q
+    assert "Flow::flow(source, sink)" in q
+
+
+def test_assemble_ruby_xss_uses_xss_module():
+    q = assemble_barrier_query(_RB_GUARD, sink_class="xss", query_id="raptor/rbx",
+                               language="ruby")
+    assert "codeql.ruby.security.XSS::ReflectedXss" in q
+
+
+_JAVA_GUARD = "predicate proposedGuard(Guard g, Expr e, boolean branch) { none() }"
+
+
+def test_assemble_java_configsig_remoteflowsource_per_cwe_sink():
+    q = assemble_barrier_query(_JAVA_GUARD, sink_class="sqli", query_id="raptor/jv",
+                               language="java")
+    assert "import java" in q
+    assert "n instanceof RemoteFlowSource" in q           # uniform source
+    assert "n instanceof QueryInjectionSink" in q          # per-CWE sink
+    assert "BarrierGuard<proposedGuard/3>" in q
+    assert "Flow::flow(source, sink)" in q
+
+
+def test_assemble_java_path_uses_sinknode_predicate():
+    q = assemble_barrier_query(_JAVA_GUARD, sink_class="pathtrav", query_id="raptor/jvp",
+                               language="java")
+    assert 'sinkNode(n, "path-injection")' in q            # not an instanceof sink
+    assert "semmle.code.java.dataflow.ExternalFlow" in q
+
+
+def test_assemble_rejects_unknown_language():
+    with pytest.raises(ValueError):
+        assemble_barrier_query(_GUARD, sink_class="cmdi", query_id="x", language="go")
+
+
 def test_assemble_rejects_unknown_sink_class():
     with pytest.raises(ValueError):
         assemble_barrier_query(_GUARD, sink_class="nosuch", query_id="x")

--- a/core/dataflow/tests/test_cvefix_loader.py
+++ b/core/dataflow/tests/test_cvefix_loader.py
@@ -1,0 +1,77 @@
+"""Tests for the CVEfixes metadata loader (synthetic fixture DB)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from core.dataflow.cvefix_loader import _single_parent, load_pairs
+
+
+def _make_db(path: Path) -> None:
+    con = sqlite3.connect(str(path))
+    con.executescript(
+        "CREATE TABLE cwe_classification (cve_id TEXT, cwe_id TEXT);"
+        "CREATE TABLE fixes (cve_id TEXT, hash TEXT, repo_url TEXT);"
+        "CREATE TABLE commits (hash TEXT, repo_url TEXT, parents TEXT);"
+        "CREATE TABLE repository (repo_url TEXT, repo_name TEXT, repo_language TEXT);"
+    )
+
+    def add(cve, cwe, repo, h, parents, lang):
+        con.execute("INSERT INTO cwe_classification VALUES(?,?)", (cve, cwe))
+        con.execute("INSERT INTO fixes VALUES(?,?,?)", (cve, h, repo))
+        con.execute("INSERT INTO commits VALUES(?,?,?)", (h, repo, parents))
+        con.execute("INSERT INTO repository VALUES(?,?,?)", (repo, repo.split("/")[-1], lang))
+
+    G = "https://github.com/org/"
+    # good: Python SQLi, single parent, github  -> loads
+    add("CVE-GOOD", "CWE-89", G + "py-app", "fix1", "['par1']", "Python")
+    # PHP -> filtered by language
+    add("CVE-PHP", "CWE-89", G + "php-app", "fix2", "['par2']", "PHP")
+    # merge commit (2 parents) -> filtered (ambiguous before-state)
+    add("CVE-MERGE", "CWE-78", G + "go-app", "fix3", "['pa', 'pb']", "Go")
+    # non-github -> filtered
+    add("CVE-GL", "CWE-79", "https://gitlab.com/org/x", "fix4", "['par4']", "Java")
+    # non-injection CWE -> filtered by cwe set
+    add("CVE-OTHER", "CWE-476", G + "java-app", "fix5", "['par5']", "Java")
+    con.commit()
+    con.close()
+
+
+def test_loads_only_codeql_lang_single_parent_github_injection(tmp_path: Path):
+    db = tmp_path / "meta.db"
+    _make_db(db)
+    pairs = load_pairs(db)
+    assert len(pairs) == 1
+    p = pairs[0]
+    assert p.cve_id == "CVE-GOOD"
+    assert p.cwe == "CWE-89"
+    assert p.repo_language == "Python"
+    assert p.fix_hash == "fix1"
+    assert p.parent_hash == "par1"
+
+
+def test_language_filter_excludes_php(tmp_path: Path):
+    db = tmp_path / "meta.db"
+    _make_db(db)
+    # widen CWEs but PHP must still be excluded (no CodeQL extractor)
+    cves = {p.cve_id for p in load_pairs(db, cwes=("CWE-89", "CWE-78", "CWE-79"))}
+    assert "CVE-PHP" not in cves
+
+
+def test_cwe_filter(tmp_path: Path):
+    db = tmp_path / "meta.db"
+    _make_db(db)
+    # CVE-OTHER (CWE-476, single-parent github Java) is excluded by the default
+    # injection CWE set, but loads when its CWE is explicitly requested.
+    assert "CVE-OTHER" not in {p.cve_id for p in load_pairs(db)}
+    cves = {p.cve_id for p in load_pairs(db, cwes=("CWE-476",), languages=("Java",))}
+    assert cves == {"CVE-OTHER"}
+
+
+def test_single_parent_helper():
+    assert _single_parent("['abc']") == "abc"
+    assert _single_parent("['a', 'b']") is None   # merge
+    assert _single_parent("[]") is None            # root
+    assert _single_parent("garbage") is None
+    assert _single_parent(None) is None

--- a/core/dataflow/tests/test_cvefix_walk.py
+++ b/core/dataflow/tests/test_cvefix_walk.py
@@ -1,0 +1,214 @@
+"""Tests for the CVEfixes CodeQL walker (git/CodeQL steps stubbed)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from core.dataflow import cvefix_walk
+from core.dataflow.cvefix_loader import CveFixPair
+from core.dataflow.cvefix_walk import WalkResult, process_pair, promote_misses, query_for, walk
+
+
+def test_query_for_maps_lang_and_cwe():
+    assert query_for("Python", "CWE-89") == "codeql/python-queries:Security/CWE-089/SqlInjection.ql"
+    # TS routes through the javascript pack; CWE-22 uses TaintedPath (not PathInjection).
+    assert query_for("TypeScript", "CWE-22") == "codeql/javascript-queries:Security/CWE-022/TaintedPath.ql"
+    assert query_for("Python", "CWE-22") == "codeql/python-queries:Security/CWE-022/PathInjection.ql"
+    assert query_for("Python", "CWE-999") is None
+    # Ruby: distinct pack + lowercase path scheme + ReflectedXSS (not ReflectedXss).
+    assert query_for("Ruby", "CWE-89") == "codeql/ruby-queries:queries/security/cwe-089/SqlInjection.ql"
+    assert query_for("Ruby", "CWE-79") == "codeql/ruby-queries:queries/security/cwe-079/ReflectedXSS.ql"
+    # Java: java-queries, Security/CWE/CWE-0XX path level, ExecTainted for cmdi.
+    assert query_for("Java", "CWE-78") == "codeql/java-queries:Security/CWE/CWE-078/ExecTainted.ql"
+
+
+def test_process_pair_build_mode_autopick(monkeypatch, tmp_path: Path):
+    seen = {}
+    monkeypatch.setattr(cvefix_walk, "_fetch_pair", lambda *a, **k: True)
+
+    def fake_build(src, commit, db, lang, codeql_bin, timeout, build_mode=None):
+        seen["lang"], seen["mode"] = lang, build_mode
+        return True
+
+    monkeypatch.setattr(cvefix_walk, "_build_db", fake_build)
+    monkeypatch.setattr(cvefix_walk, "_count_query", lambda *a, **k: 0)
+    java = CveFixPair("CVE-J", "CWE-89", "https://github.com/o/a", "Java", "fJ", "pJ")
+    py = CveFixPair("CVE-P", "CWE-89", "https://github.com/o/p", "Python", "fP", "pP")
+    process_pair(java, work_dir=tmp_path)
+    assert seen["lang"] == "java" and seen["mode"] == "none"   # buildless-compiled
+    process_pair(py, work_dir=tmp_path)
+    assert seen["mode"] is None                                 # source lang, no flag
+    process_pair(java, work_dir=tmp_path, build_mode="autobuild")
+    assert seen["mode"] == "autobuild"                          # explicit override (promote)
+
+
+def _pair(cwe="CWE-89", lang="Python", fix="fix1"):
+    return CveFixPair("CVE-X", cwe, "https://github.com/org/app", lang, fix, "par1")
+
+
+def test_process_pair_yield(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(cvefix_walk, "_fetch_pair", lambda *a, **k: True)
+    monkeypatch.setattr(cvefix_walk, "_build_db", lambda *a, **k: True)
+    # _count_query called for after-db first, then before-db.
+    counts = iter([1, 3])
+    monkeypatch.setattr(cvefix_walk, "_count_query", lambda *a, **k: next(counts))
+    res = process_pair(_pair(), work_dir=tmp_path)
+    assert res.status == "ok"
+    assert res.after_count == 1 and res.before_count == 3
+    assert res.is_yield and res.is_fp_candidate
+
+
+def test_process_pair_build_fail(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(cvefix_walk, "_fetch_pair", lambda *a, **k: True)
+    monkeypatch.setattr(cvefix_walk, "_build_db", lambda *a, **k: False)
+    res = process_pair(_pair(), work_dir=tmp_path)
+    assert res.status == "build_fail"
+    assert not res.is_yield
+
+
+def test_process_pair_no_query(tmp_path: Path):
+    res = process_pair(_pair(cwe="CWE-999"), work_dir=tmp_path)
+    assert res.status == "no_query"
+
+
+def _make_meta_db(path: Path):
+    con = sqlite3.connect(str(path))
+    con.executescript(
+        "CREATE TABLE cwe_classification (cve_id TEXT, cwe_id TEXT);"
+        "CREATE TABLE fixes (cve_id TEXT, hash TEXT, repo_url TEXT);"
+        "CREATE TABLE commits (hash TEXT, repo_url TEXT, parents TEXT);"
+        "CREATE TABLE repository (repo_url TEXT, repo_name TEXT, repo_language TEXT);"
+    )
+    G = "https://github.com/org/"
+    for i in (1, 2):
+        repo, h = f"{G}app{i}", f"fix{i}"
+        con.execute("INSERT INTO cwe_classification VALUES(?,?)", ("CVE-%d" % i, "CWE-89"))
+        con.execute("INSERT INTO fixes VALUES(?,?,?)", ("CVE-%d" % i, h, repo))
+        con.execute("INSERT INTO commits VALUES(?,?,?)", (h, repo, "['par%d']" % i))
+        con.execute("INSERT INTO repository VALUES(?,?,?)", (repo, "app%d" % i, "Python"))
+    con.commit()
+    con.close()
+
+
+def test_walk_records_and_resumes(monkeypatch, tmp_path: Path):
+    meta, results = tmp_path / "meta.db", tmp_path / "results.db"
+    _make_meta_db(meta)
+    calls = []
+
+    def fake_process(pair, **kw):
+        calls.append(pair.fix_hash)
+        return WalkResult(pair.fix_hash, "ok", before_count=2, after_count=1)
+
+    monkeypatch.setattr(cvefix_walk, "process_pair", fake_process)
+    summ = walk(meta, results, work_dir=tmp_path / "w", log=lambda *a: None)
+    assert summ == {"total": 2, "yield": 2, "fp_candidate": 2}
+    assert len(calls) == 2
+
+    # Second walk: everything already recorded -> nothing reprocessed.
+    calls.clear()
+    walk(meta, results, work_dir=tmp_path / "w", log=lambda *a: None)
+    assert calls == []
+    with sqlite3.connect(str(results)) as con:
+        assert con.execute("SELECT count(*) FROM walk_results").fetchone()[0] == 2
+
+
+def test_walk_keeps_both_cwes_of_one_commit(monkeypatch, tmp_path: Path):
+    """One fix commit mapped to two CWEs must produce two rows, not collapse."""
+    meta, results = tmp_path / "meta.db", tmp_path / "results.db"
+    con = sqlite3.connect(str(meta))
+    con.executescript(
+        "CREATE TABLE cwe_classification (cve_id TEXT, cwe_id TEXT);"
+        "CREATE TABLE fixes (cve_id TEXT, hash TEXT, repo_url TEXT);"
+        "CREATE TABLE commits (hash TEXT, repo_url TEXT, parents TEXT);"
+        "CREATE TABLE repository (repo_url TEXT, repo_name TEXT, repo_language TEXT);"
+    )
+    repo = "https://github.com/org/app"
+    con.execute("INSERT INTO fixes VALUES(?,?,?)", ("CVE-1", "fixA", repo))
+    con.execute("INSERT INTO commits VALUES(?,?,?)", ("fixA", repo, "['parA']"))
+    con.execute("INSERT INTO repository VALUES(?,?,?)", (repo, "app", "Python"))
+    con.execute("INSERT INTO cwe_classification VALUES(?,?)", ("CVE-1", "CWE-89"))
+    con.execute("INSERT INTO cwe_classification VALUES(?,?)", ("CVE-1", "CWE-79"))
+    con.commit()
+    con.close()
+
+    monkeypatch.setattr(
+        cvefix_walk, "process_pair",
+        lambda pair, **kw: WalkResult(pair.fix_hash, "ok", before_count=1, after_count=1),
+    )
+    cvefix_walk.walk(meta, results, work_dir=tmp_path / "w", log=lambda *a: None)
+    with sqlite3.connect(str(results)) as con:
+        rows = con.execute(
+            "SELECT cwe FROM walk_results WHERE fix_hash='fixA' ORDER BY cwe").fetchall()
+    assert [r[0] for r in rows] == ["CWE-79", "CWE-89"]  # both kept, not collapsed
+
+
+def test_promote_updates_only_on_recovery(monkeypatch, tmp_path: Path):
+    results = tmp_path / "r.db"
+    con = sqlite3.connect(str(results))
+    con.execute(cvefix_walk._SCHEMA)
+
+    def ins(fix, cwe, before):
+        con.execute("INSERT INTO walk_results VALUES (?,?,?,?,?,?,?,?,?,?)",
+                    (fix, "CVE-" + fix, cwe, "Java", "https://github.com/o/a",
+                     fix + "p", "ok", before, 0, 0.0))
+    ins("f1", "CWE-89", 0)   # buildless miss -> autobuild recovers it
+    ins("f2", "CWE-79", 0)   # buildless miss -> autobuild still finds nothing
+    ins("f3", "CWE-22", 2)   # already yields -> not a promote candidate
+    con.commit()
+    con.close()
+
+    def fake(pair, **kw):
+        assert kw.get("build_mode") == "autobuild"
+        if pair.fix_hash == "f1":
+            return WalkResult("f1", "ok", before_count=5, after_count=3)
+        return WalkResult(pair.fix_hash, "ok", before_count=0, after_count=0)
+
+    monkeypatch.setattr(cvefix_walk, "process_pair", fake)
+    summ = promote_misses(results, work_dir=tmp_path / "w", log=lambda *a: None)
+    assert summ == {"candidates": 2, "promoted": 1}             # f3 not a candidate
+    with sqlite3.connect(str(results)) as con:
+        got = {r[0]: (r[1], r[2], r[3]) for r in con.execute(
+            "SELECT fix_hash, status, before_count, after_count FROM walk_results")}
+    assert got["f1"] == ("ok_built", 5, 3)                     # promoted
+    assert got["f2"] == ("ok", 0, 0)                           # unchanged (graceful)
+    assert got["f3"] == ("ok", 2, 0)                           # untouched
+
+
+def test_run_passes_safe_env(monkeypatch):
+    from core.config import RaptorConfig
+    monkeypatch.setattr(RaptorConfig, "get_safe_env", staticmethod(lambda *a, **k: {"SENT": "1"}))
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured.update(kw)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(cvefix_walk.subprocess, "run", fake_run)
+    assert cvefix_walk._run(["true"], 5) is True
+    assert captured["env"] == {"SENT": "1"}            # sanitised env, not os.environ
+
+
+def test_autobuild_fails_closed_without_sandbox(monkeypatch):
+    """Untrusted autobuild must REFUSE rather than run unsandboxed."""
+    import core.sandbox as sb
+    monkeypatch.setattr(sb, "check_landlock_available", lambda: False)
+    with pytest.raises(RuntimeError, match="refusing to autobuild"):
+        cvefix_walk._run_autobuild_sandboxed(
+            ["codeql", "database", "create"], work_root=Path("/tmp/x"),
+            codeql_bin="codeql", timeout=10)
+
+
+def test_walk_limit(monkeypatch, tmp_path: Path):
+    meta, results = tmp_path / "meta.db", tmp_path / "results.db"
+    _make_meta_db(meta)
+    monkeypatch.setattr(
+        cvefix_walk, "process_pair",
+        lambda pair, **kw: WalkResult(pair.fix_hash, "ok", before_count=0, after_count=0),
+    )
+    walk(meta, results, work_dir=tmp_path / "w", limit=1, log=lambda *a: None)
+    with sqlite3.connect(str(results)) as con:
+        assert con.execute("SELECT count(*) FROM walk_results").fetchone()[0] == 1


### PR DESCRIPTION
Scale layer for the trust sound-tier: harvest real missing_sanitizer FP candidates from CVE fix-commits and make them synthesizable across languages.

- cvefix_loader: select injection-CWE (78/79/89/22) fix pairs from the CVEfixes metadata DB, restricted to CodeQL-buildable languages + single-parent commits (merges have ambiguous before-state).
- cvefix_walk: resumable, disk-safe walker — fetch each fix+parent by SHA, build before/after CodeQL DBs, run the CWE query, record which findings survive the fix (still flagged post-fix = a missing_sanitizer FP candidate; pre-fix = the TP). Results keyed by (fix_hash, cwe). Java build-promote pass recovers buildless type-resolution misses via a real autobuild.
- barrier_synth: per-language dialects so the LLM-proposed guard assembles into each language's native taint-config idiom for CodeQL to adjudicate — Python (incl. reflected XSS), JavaScript/TypeScript (legacy Configuration + SanitizerGuardNode), Ruby (ConfigSig), Java (RemoteFlowSource + per-CWE sinks, buildless). Each compile-validated against real CodeQL.

Security: every subprocess uses get_safe_env(); the autobuild path (which executes untrusted project builds) runs under the untrusted sandbox (Landlock fs restriction, credential-read isolation, egress allowlist) and is fail-closed — it refuses rather than run an untrusted build unsandboxed.

Adds loader/walk/dialect tests plus safe-env and fail-closed guards; full core/dataflow trust suite (44) green, ruff clean.