### PR TITLE
feat(coverage): harden inventory/store foundation (lines, kinds, schema, bitmap, --keep 0)

### DIFF
--- a/core/coverage/importer.py
+++ b/core/coverage/importer.py
@@ -7,7 +7,7 @@ Producers keep emitting per-run ``coverage-record.json`` (file-level
 ``/project clean``; this module is the bridge that imports both. Call
 :func:`import_run_dir` per run, or :func:`backfill` over all run dirs once.
 
-File-level marks need each file's ``total_lines`` (from the inventory) to
+File-level marks need each file's line count (the inventory's ``lines``) to
 place the whole-file interval; files absent from the inventory are skipped
 (their extent is unknown). Granularity is therefore: whole-file from the
 records, function-level from ``checked_by``. True line-level coverage
@@ -31,7 +31,7 @@ from core.run.provenance import (
 
 from .record import load_records
 from .registry import category_of
-from .store import CoverageStore, file_line_count
+from .store import CoverageStore
 from .summary import _match_to_inventory
 
 
@@ -98,7 +98,7 @@ def _total_lines_by_file(checklist: Dict[str, Any]) -> Dict[str, int]:
     out: Dict[str, int] = {}
     for fe in checklist.get("files", []):
         path = fe.get("path")
-        tl = file_line_count(fe)
+        tl = fe.get("lines")
         if path and tl:
             out[path] = tl
     return out

--- a/core/coverage/schema.py
+++ b/core/coverage/schema.py
@@ -1,0 +1,137 @@
+"""Tolerant validation/normalisation for a loaded coverage store payload.
+
+Phase 4 feeds the store from externally-produced coverage (gcov / lcov /
+coverage.py) and the store round-trips through ``coverage.json`` across runs.
+A single malformed entry — a truncated interval, a string where an int is
+expected, a hand-edited file — must not crash every coverage query. This
+module normalises a loaded payload into a well-formed shape, dropping the
+pieces it can't repair and logging what it dropped, so a damaged store
+degrades to partial coverage rather than an exception.
+
+Validation is intentionally tolerant, not strict: it never raises on bad
+data (only the store's own queries decide meaning) and returns the largest
+well-formed subset it can. The normalised shape is exactly the five keys the
+store's :meth:`CoverageStore._entry` defaults to — unknown keys are dropped,
+which (with the schema-version warning) is the read-side of forward-compat.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _is_int(x: Any) -> bool:
+    # bool is an int subclass; a boolean interval bound / line number is
+    # malformed, so reject it explicitly.
+    return isinstance(x, int) and not isinstance(x, bool)
+
+
+def _opt_int(x: Any) -> Optional[int]:
+    return x if _is_int(x) else None
+
+
+def _valid_interval(iv: Any) -> Optional[List[int]]:
+    """An inclusive ``[lo, hi]`` of two ints, or ``None`` if malformed."""
+    if (isinstance(iv, (list, tuple)) and len(iv) == 2
+            and _is_int(iv[0]) and _is_int(iv[1])):
+        return [int(iv[0]), int(iv[1])]
+    return None
+
+
+def _normalise_tools(tools: Any, path: str, source: str) -> Dict[str, List[List[int]]]:
+    if not isinstance(tools, dict):
+        logger.warning(
+            "coverage store %s: file %r has non-dict 'tools'; dropping", source, path)
+        return {}
+    out: Dict[str, List[List[int]]] = {}
+    for tool, ivs in tools.items():
+        if not isinstance(tool, str) or not isinstance(ivs, list):
+            logger.warning(
+                "coverage store %s: file %r tool %r has malformed intervals; "
+                "dropping", source, path, tool)
+            continue
+        good: List[List[int]] = []
+        for iv in ivs:
+            v = _valid_interval(iv)
+            if v is None:
+                logger.warning(
+                    "coverage store %s: file %r tool %r dropping malformed "
+                    "interval %r", source, path, tool, iv)
+                continue
+            good.append(v)
+        if good:
+            out[tool] = good
+    return out
+
+
+def _normalise_findings(findings: Any, path: str, source: str) -> List[Dict[str, Any]]:
+    if not isinstance(findings, list):
+        return []
+    out: List[Dict[str, Any]] = []
+    for f in findings:
+        if not isinstance(f, dict) or "id" not in f:
+            logger.warning(
+                "coverage store %s: file %r dropping finding without id: %r",
+                source, path, f)
+            continue
+        out.append({
+            "id": str(f["id"]),
+            "line": _opt_int(f.get("line")),
+            "retained": bool(f.get("retained", True)),
+        })
+    return out
+
+
+def _normalise_entry(path: str, entry: Any, source: str) -> Optional[Dict[str, Any]]:
+    if not isinstance(entry, dict):
+        logger.warning(
+            "coverage store %s: file %r entry is not an object; dropping",
+            source, path)
+        return None
+    prov = entry.get("provenance")
+    return {
+        "total_lines": _opt_int(entry.get("total_lines")),
+        "sloc": _opt_int(entry.get("sloc")),
+        "tools": _normalise_tools(entry.get("tools", {}), path, source),
+        "findings": _normalise_findings(entry.get("findings", []), path, source),
+        "provenance": prov if isinstance(prov, dict) else {},
+    }
+
+
+def normalise_loaded_files(
+    files: Any, source: str = "<coverage store>",
+) -> Dict[str, Dict[str, Any]]:
+    """Return the largest well-formed ``{path: entry}`` subset of ``files``.
+
+    Non-dict input, non-string paths, and non-object entries are dropped with
+    a warning; each surviving entry is coerced to the store's canonical shape.
+    """
+    if not isinstance(files, dict):
+        logger.warning(
+            "coverage store %s: 'files' is not an object; ignoring persisted "
+            "coverage", source)
+        return {}
+    out: Dict[str, Dict[str, Any]] = {}
+    for path, entry in files.items():
+        if not isinstance(path, str):
+            logger.warning(
+                "coverage store %s: dropping non-string file key %r", source, path)
+            continue
+        norm = _normalise_entry(path, entry, source)
+        if norm is not None:
+            out[path] = norm
+    return out
+
+
+def check_version(version: Any, current: int, source: str = "<coverage store>") -> None:
+    """Warn (do not raise) when the persisted schema version is newer than the
+    code supports — the store is read best-effort and newer fields are dropped
+    by :func:`normalise_loaded_files`."""
+    if _is_int(version) and version > current:
+        logger.warning(
+            "coverage store %s: schema version %d is newer than supported %d; "
+            "reading best-effort (newer fields ignored)", source, version, current)

--- a/core/coverage/store.py
+++ b/core/coverage/store.py
@@ -37,7 +37,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
+from core.logging import get_logger as _get_logger
+
 from .registry import category_of
+from .schema import check_version, normalise_loaded_files
 
 try:
     import fcntl
@@ -113,6 +116,50 @@ def _overlap_count(intervals: List[Interval], lo: int, hi: int) -> int:
     return total
 
 
+# --- bitmap fallback --------------------------------------------------------
+#
+# A (file, tool) contribution is normally a coalesced interval list. For
+# sparse runtime/gcov data — many small disjoint executed-line ranges — that
+# list grows large and every incremental mark re-coalesces it (O(K log K) per
+# mark → O(K^2 log K) to build). Above ``_BITMAP_THRESHOLD`` intervals the
+# in-memory representation switches to a line-number ``set`` ("bitmap"): mark
+# becomes O(range) with no re-sort. The public API is identical regardless of
+# backend, and the ON-DISK form is always intervals (``to_dict`` normalises),
+# so the persisted schema and its validation (schema.py) are unchanged.
+
+_BITMAP_THRESHOLD = 50
+
+
+def _set_to_intervals(lines: set) -> List[Interval]:
+    """Coalesce a line-number set into sorted inclusive intervals."""
+    out: List[Interval] = []
+    for ln in sorted(lines):
+        if out and ln <= out[-1][1] + 1:
+            out[-1][1] = ln
+        else:
+            out.append([ln, ln])
+    return out
+
+
+def _cov_to_intervals(value) -> List[Interval]:
+    """Normalise a coverage value (interval list or line set) to intervals."""
+    if isinstance(value, set):
+        return _set_to_intervals(value)
+    return value
+
+
+def _cov_covers_line(value, line: int) -> bool:
+    if isinstance(value, set):
+        return line in value
+    return any(lo <= line <= hi for lo, hi in value)
+
+
+def _cov_overlap(value, lo: int, hi: int) -> int:
+    if isinstance(value, set):
+        return sum(1 for ln in range(lo, hi + 1) if ln in value)
+    return _overlap_count(value, lo, hi)
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -137,14 +184,6 @@ def content_identity(checklist: Dict[str, Any]) -> Optional[str]:
         return None
     digest = hashlib.sha256("\n".join(sorted(entries)).encode("utf-8")).hexdigest()
     return f"content:{digest[:16]}"
-
-
-def file_line_count(fe: Dict[str, Any]) -> Optional[int]:
-    """Total line count from an inventory file entry. The inventory emits
-    ``lines``; hand-built / legacy checklists may use ``total_lines``. This is
-    what whole-file scanner coverage (``files_examined``) is placed against, so
-    reading the wrong key silently drops all file-level coverage."""
-    return fe.get("lines") or fe.get("total_lines")
 
 
 def iter_inventory_functions(
@@ -186,12 +225,27 @@ class CoverageStore:
         self.version = SCHEMA_VERSION
         self._files: Dict[str, Dict[str, Any]] = {}
         if self.path.exists():
-            data = json.loads(self.path.read_text(encoding="utf-8"))
+            # A corrupt / unreadable store must not crash every coverage
+            # consumer — degrade to empty (the store is largely reconstructible
+            # via backfill from per-run records). A successfully-parsed payload
+            # is normalised tolerantly (see schema.py) so a single malformed
+            # entry doesn't poison queries.
+            try:
+                data = json.loads(self.path.read_text(encoding="utf-8"))
+            except (ValueError, OSError) as exc:
+                _get_logger(__name__).warning(
+                    "coverage store %s: unreadable (%s); starting empty",
+                    self.path, exc)
+                data = {}
+            if not isinstance(data, dict):
+                data = {}
             self.version = data.get("version", SCHEMA_VERSION)
+            check_version(self.version, SCHEMA_VERSION, str(self.path))
             # Constructor-supplied target wins only when the store is new.
             self.target = data.get("target") or target
             self.content_id = data.get("content_id")
-            self._files = data.get("files", {}) or {}
+            self._files = normalise_loaded_files(
+                data.get("files", {}) or {}, str(self.path))
 
     # --- mutation ---------------------------------------------------------
 
@@ -214,8 +268,20 @@ class CoverageStore:
             start, end = end, start
         entry = self._entry(file)
         existing = entry["tools"].get(tool, [])
-        newly = (end - start + 1) - _overlap_count(existing, start, end)
-        entry["tools"][tool] = _coalesce(existing + [[start, end]])
+        newly = (end - start + 1) - _cov_overlap(existing, start, end)
+        if isinstance(existing, set):
+            existing.update(range(start, end + 1))   # already a bitmap
+        else:
+            merged = _coalesce(existing + [[start, end]])
+            if len(merged) > _BITMAP_THRESHOLD:
+                # Sparse/heavy contribution — switch to a line set so further
+                # marks don't keep re-coalescing a long list.
+                bits: set = set()
+                for lo, hi in merged:
+                    bits.update(range(lo, hi + 1))
+                entry["tools"][tool] = bits
+            else:
+                entry["tools"][tool] = merged
         return newly
 
     def set_file_meta(
@@ -304,8 +370,8 @@ class CoverageStore:
         if not entry:
             return []
         return sorted(
-            tool for tool, ivs in entry["tools"].items()
-            if any(lo <= line <= hi for lo, hi in ivs)
+            tool for tool, value in entry["tools"].items()
+            if _cov_covers_line(value, line)
         )
 
     def covered_lines(self, file: str) -> List[Interval]:
@@ -314,7 +380,8 @@ class CoverageStore:
         if not entry:
             return []
         return _coalesce(
-            [iv for ivs in entry["tools"].values() for iv in ivs]
+            [iv for value in entry["tools"].values()
+             for iv in _cov_to_intervals(value)]
         )
 
     def file_coverage(self, file: str) -> float:
@@ -350,8 +417,8 @@ class CoverageStore:
         if not entry:
             return {}
         out: Dict[str, int] = {}
-        for tool, ivs in entry["tools"].items():
-            n = _overlap_count(ivs, lo, hi)
+        for tool, value in entry["tools"].items():
+            n = _cov_overlap(value, lo, hi)
             if n:
                 out[tool] = n
         return out
@@ -400,7 +467,7 @@ class CoverageStore:
         for fe in checklist.get("files", []):
             path = fe.get("path")
             if path:
-                self.set_file_meta(path, file_line_count(fe), fe.get("sloc"))
+                self.set_file_meta(path, fe.get("lines"), fe.get("sloc"))
 
     def set_content_id(self, checklist: Dict[str, Any]) -> Optional[str]:
         """Set the store's content-equivalence id from the inventory (see
@@ -472,12 +539,24 @@ class CoverageStore:
     # --- persistence ------------------------------------------------------
 
     def to_dict(self) -> Dict[str, Any]:
+        # Normalise any in-memory line-set ("bitmap") back to intervals so the
+        # on-disk form is always intervals (stable schema; JSON-serialisable;
+        # validated by schema.py). Does not mutate the live store.
+        files_out: Dict[str, Any] = {}
+        for path, entry in self._files.items():
+            tools = entry.get("tools", {})
+            if any(isinstance(v, set) for v in tools.values()):
+                entry = dict(entry)
+                entry["tools"] = {
+                    t: _cov_to_intervals(v) for t, v in tools.items()
+                }
+            files_out[path] = entry
         return {
             "version": self.version,
             "generated_at": _now_iso(),
             "target": self.target,
             "content_id": self.content_id,
-            "files": self._files,
+            "files": files_out,
         }
 
     def save(self) -> Path:

--- a/core/coverage/tests/test_annotations_import.py
+++ b/core/coverage/tests/test_annotations_import.py
@@ -9,11 +9,11 @@ from core.coverage.store import CoverageStore
 
 _CHECKLIST = {
     "files": [
-        {"path": "a.c", "total_lines": 100, "items": [
+        {"path": "a.c", "lines": 100, "items": [
             {"name": "f1", "line_start": 0, "line_end": 20},
             {"name": "f2", "line_start": 30, "line_end": 60},
         ]},
-        {"path": "b.c", "total_lines": 50, "functions": [
+        {"path": "b.c", "lines": 50, "functions": [
             {"name": "g1", "line_start": 0, "line_end": 10},
         ]},
     ],

--- a/core/coverage/tests/test_bitmap.py
+++ b/core/coverage/tests/test_bitmap.py
@@ -1,0 +1,95 @@
+"""Bitmap fallback: a (file, tool) with many sparse intervals switches to a
+line-set in memory, with identical query semantics and an interval on-disk form.
+"""
+
+from __future__ import annotations
+
+import json
+
+from core.coverage.store import CoverageStore, _BITMAP_THRESHOLD
+
+
+def _store(tmp_path):
+    return CoverageStore(tmp_path / "coverage.json", target="zip:x")
+
+
+def _sparse_lines(n):
+    """n disjoint single lines (1, 3, 5, …) → n intervals before coalescing."""
+    return list(range(1, 1 + 2 * n, 2))
+
+
+def test_converts_to_bitmap_above_threshold(tmp_path):
+    s = _store(tmp_path)
+    lines = _sparse_lines(_BITMAP_THRESHOLD + 11)
+    for ln in lines:
+        s.mark("a.c", ln, ln, "gcov")
+    # Internal representation switched to a set once it crossed the threshold.
+    assert isinstance(s._files["a.c"]["tools"]["gcov"], set)
+    # Query semantics identical to the interval backend.
+    assert s.who_checked("a.c", lines[0]) == ["gcov"]
+    assert s.who_checked("a.c", lines[-1]) == ["gcov"]
+    assert s.who_checked("a.c", lines[0] + 1) == []          # gap line
+    assert s.tool_coverage_of_range("a.c", 1, 10) == {"gcov": 5}  # 1,3,5,7,9
+
+
+def test_stays_intervals_below_threshold(tmp_path):
+    s = _store(tmp_path)
+    for ln in _sparse_lines(_BITMAP_THRESHOLD - 1):
+        s.mark("a.c", ln, ln, "gcov")
+    assert isinstance(s._files["a.c"]["tools"]["gcov"], list)
+
+
+def test_bitmap_delta_accounting(tmp_path):
+    s = _store(tmp_path)
+    for ln in _sparse_lines(_BITMAP_THRESHOLD + 11):
+        s.mark("a.c", ln, ln, "gcov")
+    assert s.mark("a.c", 1, 1, "gcov") == 0      # already covered (odd line)
+    assert s.mark("a.c", 2, 2, "gcov") == 1      # new (even line)
+    # 2,3,4,5,6: 2 (just added), 3, 5 covered → only 4 and 6 are new.
+    assert s.mark("a.c", 2, 6, "gcov") == 2
+
+
+def test_bitmap_roundtrips_as_intervals_on_disk(tmp_path):
+    s = _store(tmp_path)
+    for ln in _sparse_lines(_BITMAP_THRESHOLD + 11):
+        s.mark("a.c", ln, ln, "gcov")
+    s.set_file_meta("a.c", total_lines=400)
+    cov_before = s.file_coverage("a.c")
+    covered_before = s.covered_lines("a.c")
+    p = s.save()
+
+    disk = json.loads(p.read_text())
+    ivs = disk["files"]["a.c"]["tools"]["gcov"]
+    assert isinstance(ivs, list)
+    assert all(isinstance(x, list) and len(x) == 2 for x in ivs)
+
+    reloaded = CoverageStore(p)
+    # Comes back as intervals (disk form); queries match the pre-save store.
+    assert isinstance(reloaded._files["a.c"]["tools"]["gcov"], list)
+    assert reloaded.file_coverage("a.c") == cov_before
+    assert reloaded.covered_lines("a.c") == covered_before
+
+
+def test_bitmap_and_interval_tools_coexist(tmp_path):
+    s = _store(tmp_path)
+    s.mark("a.c", 1, 400, "semgrep")             # whole file: one interval
+    for ln in _sparse_lines(_BITMAP_THRESHOLD + 11):
+        s.mark("a.c", ln, ln, "gcov")            # sparse: becomes a set
+    assert isinstance(s._files["a.c"]["tools"]["semgrep"], list)
+    assert isinstance(s._files["a.c"]["tools"]["gcov"], set)
+    # Union spans the whole file via semgrep; per-line membership is per-tool.
+    assert s.covered_lines("a.c") == [[1, 400]]
+    assert s.who_checked("a.c", 3) == ["gcov", "semgrep"]
+    assert s.who_checked("a.c", 2) == ["semgrep"]   # gcov skipped even lines
+
+
+def test_bitmap_matches_interval_semantics_for_function_queries(tmp_path):
+    # function_verdict / function_covered work the same over a bitmap-backed
+    # tool as over intervals.
+    s = _store(tmp_path)
+    for ln in _sparse_lines(_BITMAP_THRESHOLD + 11):
+        s.mark("a.c", ln, ln, "gcov")
+    assert s.function_covered("a.c", 1, 9, category="runtime") is True
+    assert s.function_covered("a.c", 2, 2, category="runtime") is False
+    # [1,9] = 9 lines; odd lines 1,3,5,7,9 covered = 5/9 ≈ 56%.
+    assert s.who_checked_function("a.c", 1, 9) == {"gcov": "partial (56%)"}

--- a/core/coverage/tests/test_clean.py
+++ b/core/coverage/tests/test_clean.py
@@ -15,7 +15,7 @@ from core.coverage.store import CoverageStore
 
 _CHECKLIST = {
     "files": [
-        {"path": "a.c", "total_lines": 100, "items": [
+        {"path": "a.c", "lines": 100, "items": [
             {"name": "f1", "line_start": 0, "line_end": 20},
             {"name": "f2", "line_start": 30, "line_end": 60},
         ]},

--- a/core/coverage/tests/test_content_identity.py
+++ b/core/coverage/tests/test_content_identity.py
@@ -8,7 +8,7 @@ from core.coverage.store import CoverageStore, content_identity
 
 def _checklist(files):
     """files: list of (path, sha256)."""
-    return {"files": [{"path": p, "sha256": s, "total_lines": 10} for p, s in files]}
+    return {"files": [{"path": p, "sha256": s, "lines": 10} for p, s in files]}
 
 
 def test_same_content_same_id_regardless_of_order():

--- a/core/coverage/tests/test_importer.py
+++ b/core/coverage/tests/test_importer.py
@@ -20,12 +20,12 @@ def _store(tmp_path):
 
 _CHECKLIST = {
     "files": [
-        {"path": "a.c", "total_lines": 100, "items": [
+        {"path": "a.c", "lines": 100, "items": [
             {"name": "f1", "line_start": 0, "line_end": 20},
             {"name": "f2", "line_start": 30, "line_end": 60,
              "checked_by": ["validate:stage-a"]},
         ]},
-        {"path": "b.c", "total_lines": 50, "functions": [
+        {"path": "b.c", "lines": 50, "functions": [
             {"name": "g1", "line_start": 0, "line_end": 10},
         ]},
     ],
@@ -92,19 +92,24 @@ def test_absolute_scanner_paths_join_to_relative_inventory(tmp_path):
 
 
 def test_file_level_coverage_uses_real_inventory_lines_field(tmp_path):
-    # Regression: the inventory emits per-file `lines`, not `total_lines`
-    # (the latter only appears in hand-built test checklists). Reading the
-    # wrong key silently drops ALL file-level scanner coverage — caught only
-    # against a real checklist. backfill must place whole-file marks here.
+    # Regression: file-level marks read the inventory's `lines` key — what
+    # builder.py actually emits. `total_lines` is NOT a recognised inventory
+    # key (the line-count read was standardised on `lines`, dropping the old
+    # dual-key shim); a `total_lines`-only entry has unknown extent and is
+    # skipped. Reading the wrong key silently drops ALL file-level scanner
+    # coverage, so both halves are asserted here.
     s = _store(tmp_path)
     checklist = {"files": [
         {"path": "a.c", "lines": 40, "sloc": 30, "items": [
             {"name": "f1", "line_start": 0, "line_end": 20}]},
+        {"path": "legacy.c", "total_lines": 40, "items": [
+            {"name": "g1", "line_start": 0, "line_end": 20}]},
     ]}
     run = tmp_path / "scan-1"
     run.mkdir()
     (run / "coverage-semgrep.json").write_text(json.dumps(
-        {"tool": "semgrep", "files_examined": ["a.c"], "timestamp": "t"}))
+        {"tool": "semgrep", "files_examined": ["a.c", "legacy.c"],
+         "timestamp": "t"}))
     (run / "findings.json").write_text("[]")
     backfill(s, [run], checklist)
     assert s.who_checked("a.c", 10) == ["semgrep"]    # whole file marked
@@ -112,6 +117,8 @@ def test_file_level_coverage_uses_real_inventory_lines_field(tmp_path):
     assert s.who_checked("a.c", 40) == ["semgrep"]
     assert s.who_checked("a.c", 0) == []
     assert s.function_covered("a.c", 1, 20, category="static") is True
+    # `total_lines`-only entry: extent unknown -> no whole-file mark.
+    assert s.who_checked("legacy.c", 10) == []
 
 
 def test_import_run_dir_reads_per_tool_records(tmp_path):

--- a/core/coverage/tests/test_provenance_feed.py
+++ b/core/coverage/tests/test_provenance_feed.py
@@ -10,7 +10,7 @@ from core.coverage.store import CoverageStore
 
 _CHECKLIST = {
     "files": [
-        {"path": "a.c", "total_lines": 100, "items": [
+        {"path": "a.c", "lines": 100, "items": [
             {"name": "f1", "line_start": 0, "line_end": 20},
         ]},
     ],

--- a/core/coverage/tests/test_schema.py
+++ b/core/coverage/tests/test_schema.py
@@ -1,0 +1,140 @@
+"""Tests for tolerant coverage-store payload validation (schema.py)."""
+
+from __future__ import annotations
+
+import json
+
+from core.coverage.schema import (
+    check_version,
+    normalise_loaded_files,
+)
+from core.coverage.store import CoverageStore
+
+
+def test_valid_payload_passes_through():
+    files = {
+        "a.c": {
+            "total_lines": 100, "sloc": 80,
+            "tools": {"semgrep": [[1, 100]], "claude:audit": [[10, 20]]},
+            "findings": [{"id": "F1", "line": 12, "retained": True}],
+            "provenance": {"semgrep": {"version": "1.2"}},
+        },
+    }
+    out = normalise_loaded_files(files)
+    assert out == files
+
+
+def test_canonical_shape_drops_unknown_keys():
+    out = normalise_loaded_files({"a.c": {"junk": 1, "tools": {}}})
+    assert set(out["a.c"]) == {
+        "total_lines", "sloc", "tools", "findings", "provenance"}
+    assert "junk" not in out["a.c"]
+
+
+def test_malformed_intervals_dropped_good_kept():
+    files = {"a.c": {"tools": {"semgrep": [[1, 10], [5], "x", [2, 3], [1, "y"]]}}}
+    out = normalise_loaded_files(files)
+    assert out["a.c"]["tools"]["semgrep"] == [[1, 10], [2, 3]]
+
+
+def test_bool_interval_bound_rejected():
+    # bool is an int subclass — must not be accepted as a line number.
+    out = normalise_loaded_files({"a.c": {"tools": {"t": [[True, 5]]}}})
+    assert out["a.c"]["tools"] == {}
+
+
+def test_non_dict_tools_dropped():
+    out = normalise_loaded_files({"a.c": {"tools": ["not", "a", "dict"]}})
+    assert out["a.c"]["tools"] == {}
+
+
+def test_tool_with_only_bad_intervals_omitted():
+    out = normalise_loaded_files({"a.c": {"tools": {"t": ["bad"], "u": [[1, 2]]}}})
+    assert out["a.c"]["tools"] == {"u": [[1, 2]]}
+
+
+def test_finding_without_id_dropped():
+    files = {"a.c": {"findings": [{"line": 5}, {"id": "F1", "line": 5}]}}
+    out = normalise_loaded_files(files)
+    assert out["a.c"]["findings"] == [{"id": "F1", "line": 5, "retained": True}]
+
+
+def test_finding_id_coerced_and_line_validated():
+    out = normalise_loaded_files(
+        {"a.c": {"findings": [{"id": 7, "line": "nope"}]}})
+    assert out["a.c"]["findings"] == [
+        {"id": "7", "line": None, "retained": True}]
+
+
+def test_non_int_line_counts_become_none():
+    out = normalise_loaded_files(
+        {"a.c": {"total_lines": "100", "sloc": True}})
+    assert out["a.c"]["total_lines"] is None
+    assert out["a.c"]["sloc"] is None
+
+
+def test_non_dict_entry_dropped():
+    out = normalise_loaded_files({"a.c": "garbage", "b.c": {"tools": {}}})
+    assert "a.c" not in out
+    assert "b.c" in out
+
+
+def test_non_dict_files_returns_empty():
+    assert normalise_loaded_files(["not", "a", "dict"]) == {}
+    assert normalise_loaded_files(None) == {}
+
+
+def test_non_string_path_key_dropped():
+    out = normalise_loaded_files({5: {"tools": {}}, "a.c": {"tools": {}}})
+    assert list(out) == ["a.c"]
+
+
+def test_non_dict_provenance_defaults_empty():
+    out = normalise_loaded_files({"a.c": {"provenance": "x"}})
+    assert out["a.c"]["provenance"] == {}
+
+
+def test_check_version_tolerates_newer(caplog):
+    # Never raises; warns for a newer schema version.
+    check_version(99, 1, "store.json")
+    check_version(1, 1, "store.json")
+    check_version("bad", 1, "store.json")  # non-int: ignored, no raise
+
+
+# --- integration: the store loads through the validator ---------------------
+
+
+def test_store_loads_corrupt_json_as_empty(tmp_path):
+    p = tmp_path / "coverage.json"
+    p.write_text("{ this is not valid json ")
+    s = CoverageStore(p)                       # must not raise
+    assert s.files() == []
+    assert s.who_checked("a.c", 1) == []
+
+
+def test_store_loads_malformed_entry_keeps_valid(tmp_path):
+    p = tmp_path / "coverage.json"
+    p.write_text(json.dumps({
+        "version": 1,
+        "files": {
+            "a.c": {"total_lines": 50, "tools": {"semgrep": [[1, 50]]},
+                    "findings": [], "provenance": {}},
+            "b.c": {"tools": {"semgrep": [[1, "oops"]]}},   # malformed interval
+            "c.c": "not-an-object",                          # dropped entirely
+        },
+    }))
+    s = CoverageStore(p)
+    assert s.who_checked("a.c", 10) == ["semgrep"]
+    assert s.who_checked("b.c", 10) == []      # malformed interval dropped
+    assert "c.c" not in s.files()
+
+
+def test_store_roundtrip_after_validation(tmp_path):
+    p = tmp_path / "coverage.json"
+    s = CoverageStore(p, target="git:abc")
+    s.mark("a.c", 1, 20, "semgrep")
+    s.set_file_meta("a.c", total_lines=40)
+    s.save()
+    reloaded = CoverageStore(p)
+    assert reloaded.file_coverage("a.c") == 50.0
+    assert reloaded.who_checked("a.c", 5) == ["semgrep"]

--- a/core/coverage/tests/test_store.py
+++ b/core/coverage/tests/test_store.py
@@ -115,12 +115,12 @@ def test_load_keeps_persisted_target_over_constructor_arg(tmp_path):
 
 _CHECKLIST = {
     "files": [
-        {"path": "a.c", "sha256": "x", "total_lines": 100, "sloc": 80,
+        {"path": "a.c", "sha256": "x", "lines": 100, "sloc": 80,
          "items": [
              {"name": "f1", "line_start": 0, "line_end": 20},
              {"name": "f2", "line_start": 30, "line_end": 60},
          ]},
-        {"path": "b.c", "sha256": "y", "total_lines": 50,
+        {"path": "b.c", "sha256": "y", "lines": 50,
          "functions": [   # fallback key
              {"name": "g1", "line_start": 0, "line_end": 10},
          ]},

--- a/core/coverage/tests/test_store_summary.py
+++ b/core/coverage/tests/test_store_summary.py
@@ -7,11 +7,11 @@ from core.coverage.store_summary import format_store_view, store_view
 
 _CHECKLIST = {
     "files": [
-        {"path": "a.c", "total_lines": 100, "items": [
+        {"path": "a.c", "lines": 100, "items": [
             {"name": "f1", "line_start": 0, "line_end": 20},
             {"name": "f2", "line_start": 30, "line_end": 60},
         ]},
-        {"path": "b.c", "total_lines": 50, "functions": [
+        {"path": "b.c", "lines": 50, "functions": [
             {"name": "g1", "line_start": 0, "line_end": 10},
         ]},
     ],

--- a/core/coverage/tests/test_summary_cli.py
+++ b/core/coverage/tests/test_summary_cli.py
@@ -36,7 +36,7 @@ def _run_dir(tmp_path):
     d.mkdir()
     (d / ".raptor-run.json").write_text("{}")
     (d / "checklist.json").write_text(json.dumps({"files": [
-        {"path": "a.c", "total_lines": 100, "items": [
+        {"path": "a.c", "lines": 100, "items": [
             {"name": "f1", "line_start": 0, "line_end": 20},
             {"name": "f2", "line_start": 30, "line_end": 60},
         ]}]}))

--- a/core/inventory/extractors.py
+++ b/core/inventory/extractors.py
@@ -1561,6 +1561,10 @@ def extract_items(filepath: str, language: str, content: str,
             items.extend(_extract_top_level_ts(tree.root_node, language))
         except Exception:
             pass
+        try:
+            items.extend(_extract_c_types_ts(tree.root_node, language))
+        except Exception:
+            pass
 
     # Fallback: functions from AST/regex if tree-sitter didn't produce any
     if not ts_parsed or not any(i.kind == KIND_FUNCTION for i in items):
@@ -1687,6 +1691,76 @@ def _extract_globals_ts(root_node, language: str) -> List[CodeItem]:
     return globals_found
 
 
+_RECORD_BODY_TYPES = ("field_declaration_list", "enumerator_list")
+
+
+def _specifier_tag_name(spec) -> Optional[str]:
+    """Tag name of a struct/union/enum/class specifier that *defines* a type
+    (has a body). Returns None for a forward declaration / use of an existing
+    type (no body) or an anonymous specifier (no tag — a typedef names it
+    instead, handled via ``_typedef_name``)."""
+    if not any(b.type in _RECORD_BODY_TYPES for b in spec.children):
+        return None
+    for b in spec.children:
+        if b.type == "type_identifier":
+            return b.text.decode()
+    return None
+
+
+def _typedef_name(node) -> Optional[str]:
+    """The new type name introduced by a C/C++ ``type_definition`` (typedef).
+    ``typedef struct {…} Foo;`` -> ``Foo``; ``typedef int (*cb)(int);`` -> ``cb``.
+    """
+    decl = node.child_by_field_name("declarator")
+    if decl is not None:
+        if decl.type in ("type_identifier", "identifier"):
+            return decl.text.decode()
+        inner = _c_declarator_name(decl)
+        if inner:
+            return inner
+    # Fallback: a direct type_identifier child (not nested in a specifier).
+    for c in node.children:
+        if c.type in ("type_identifier", "identifier"):
+            return c.text.decode()
+    return None
+
+
+def _extract_c_types_ts(root_node, language: str) -> List[CodeItem]:
+    """File-scope C/C++ type definitions as ``class``-kind items: ``typedef``s
+    and named struct/union/enum (and C++ class) *definitions*. Without these a
+    header of type declarations collapses to anonymous interstitial. Forward
+    declarations and uses of existing types (no body) are not definitions and
+    are skipped; the type's tag is the item name (the typedef name for an
+    anonymous record). A ``struct Foo {…} g;`` yields BOTH the type ``Foo``
+    here and the global ``g`` via ``_extract_globals_ts`` — both are real."""
+    if language not in ("c", "cpp"):
+        return []
+    specifiers = ("struct_specifier", "union_specifier", "enum_specifier")
+    if language == "cpp":
+        specifiers = specifiers + ("class_specifier",)
+    out: List[CodeItem] = []
+    for child in root_node.children:
+        name = None
+        if child.type == "type_definition":
+            name = _typedef_name(child)
+        elif child.type == "declaration":
+            name = next(
+                (_specifier_tag_name(c) for c in child.children
+                 if c.type in specifiers and _specifier_tag_name(c)),
+                None,
+            )
+        elif child.type in specifiers:
+            name = _specifier_tag_name(child)
+        if name:
+            out.append(CodeItem(
+                name=name,
+                kind=KIND_CLASS,
+                line_start=child.start_point[0] + 1,
+                line_end=child.end_point[0] + 1,
+            ))
+    return out
+
+
 def _global_names(node, language: str):
     """Yield every global name in a declaration node.
 
@@ -1750,10 +1824,46 @@ def _global_names(node, language: str):
                 current = next_assignment
             return
 
+    if language in ("c", "cpp"):
+        yield from _c_global_names(node)
+        return
+
+    if language in ("javascript", "typescript", "tsx"):
+        # `const a = 1, b = 2;` is one declaration with multiple
+        # variable_declarators — yield every name, not just the first.
+        # Pre-fix `_global_name` returned only the first, dropping `b`.
+        for child in node.children:
+            if child.type == "variable_declarator":
+                for sub in child.children:
+                    if sub.type in ("identifier", "name"):
+                        yield sub.text.decode()
+                        break
+        return
+
     # Other languages: defer to the single-name function.
     name = _global_name(node, language)
     if name:
         yield name
+
+
+def _c_global_names(node):
+    """Yield every declared name in a C/C++ ``declaration`` node.
+
+    Handles multi-declarator declarations (``int a, b, c;``) where only the
+    first name was captured before (``_c_declarator_name`` on the whole node
+    stops at the first identifier). A bare function prototype (``int foo(int);``
+    — a ``function_declarator`` child) declares no variable, so it yields
+    nothing; its definition is captured as a function elsewhere.
+    """
+    _DECLARATORS = ("identifier", "init_declarator", "array_declarator",
+                    "pointer_declarator", "parenthesized_declarator")
+    if any(c.type == "function_declarator" for c in node.children):
+        return
+    for child in node.children:
+        if child.type in _DECLARATORS:
+            name = _c_declarator_name(child)
+            if name:
+                yield name
 
 
 def _c_declarator_name(node, depth: int = 0) -> Optional[str]:

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -30,6 +30,7 @@ from core.inventory import (
     KIND_FUNCTION,
     KIND_GLOBAL,
     KIND_MACRO,
+    KIND_CLASS,
     PythonExtractor,
     JavaScriptExtractor,
     CExtractor,
@@ -668,6 +669,59 @@ class TestExtractItems:
         names = [m.name for m in macros]
         assert "BUF_SIZE" in names
         assert "MAX" in names
+
+    def test_c_multi_declarator_globals(self):
+        # `int a, b, c;` declares three globals — pre-fix only `a` was kept,
+        # the rest fell to interstitial. Pointer/array declarators too.
+        code = "int a, b, c;\nchar *p, q[8];\nvoid f(void) {}\n"
+        items = extract_items("test.c", "c", code)
+        names = {g.name for g in items if g.kind == KIND_GLOBAL}
+        if not names:
+            import pytest
+            pytest.skip("tree-sitter not available — C globals are TS-only")
+        assert {"a", "b", "c", "p", "q"} <= names
+
+    def test_c_typedef_and_record_defs_are_class_kind(self):
+        code = (
+            "typedef struct { int x; } Foo;\n"
+            "struct Bar { int y; };\n"
+            "enum Color { RED, GREEN };\n"
+            "typedef int myint;\n"
+        )
+        items = extract_items("test.c", "c", code)
+        types = {t.name for t in items if t.kind == KIND_CLASS}
+        if not types:
+            import pytest
+            pytest.skip("tree-sitter not available — C type defs are TS-only")
+        assert {"Foo", "Bar", "Color", "myint"} <= types
+
+    def test_c_forward_decl_and_prototype_not_captured(self):
+        # A forward declaration / use-of-existing-type is not a type
+        # definition; a prototype is not a global. Neither should be emitted.
+        code = (
+            "struct FwdDecl;\n"
+            "struct FwdDecl use_it;\n"   # global of an existing type
+            "int proto(int x);\n"        # prototype, not a global
+            "void real(void) {}\n"
+        )
+        items = extract_items("test.c", "c", code)
+        if not any(i.kind in (KIND_GLOBAL, KIND_CLASS) for i in items):
+            import pytest
+            pytest.skip("tree-sitter not available — C globals/types are TS-only")
+        types = {t.name for t in items if t.kind == KIND_CLASS}
+        globals_ = {g.name for g in items if g.kind == KIND_GLOBAL}
+        assert "FwdDecl" not in types       # no body -> not a definition
+        assert "proto" not in globals_      # prototype is not a global
+        assert "use_it" in globals_         # the global IS captured
+
+    def test_js_multi_declarator_globals(self):
+        code = "const a = 1, b = 2;\nlet x = 3;\n"
+        items = extract_items("test.js", "javascript", code)
+        names = {g.name for g in items if g.kind == KIND_GLOBAL}
+        if not names:
+            import pytest
+            pytest.skip("tree-sitter not available — JS globals are TS-only")
+        assert {"a", "b", "x"} <= names
 
     def test_returns_code_items(self):
         code = "def foo(): pass\n"

--- a/core/project/clean.py
+++ b/core/project/clean.py
@@ -29,10 +29,15 @@ def _run_dir_size(d: Path) -> int:
 def plan_clean(project, keep=1) -> Dict[str, Any]:
     """Plan which runs to delete. Returns stats with directory paths.
 
+    ``keep=0`` is valid: delete as aggressively as possible, bounded by the
+    clean-safety invariant that the last (newest) run of each command type is
+    never deleted (design: project.md). The durable coverage store retains the
+    verdicts of deleted runs (clean/examined coverage is snapshotted before
+    deletion; sole-source findings flip to ``found_then_lost``).
     Does not modify the filesystem.
     """
-    if keep < 1:
-        raise ValueError(f"keep must be >= 1, got {keep}")
+    if keep < 0:
+        raise ValueError(f"keep must be >= 0, got {keep}")
     groups = project.get_run_dirs_by_type()
     stats: Dict[str, Any] = {
         "delete_dirs": [], "deleted": [], "kept": [], "freed_bytes": 0,
@@ -42,6 +47,11 @@ def plan_clean(project, keep=1) -> Dict[str, Any]:
     for cmd_type, dirs in groups.items():
         to_keep = dirs[:keep]
         to_delete = dirs[keep:]
+        # Clean-safety invariant (project.md): never delete the last run of a
+        # command type, even with --keep 0. Preserve the newest (dirs are
+        # newest-first) when the keep slice would otherwise empty the type.
+        if not to_keep and dirs:
+            to_keep, to_delete = dirs[:1], dirs[1:]
         type_freed = 0
 
         for d in to_keep:

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -226,7 +226,9 @@ def main():
     p_clean = sub.add_parser("clean", help="Delete old runs, keep latest n",
                              usage="raptor project clean [<name>] [--keep <n>] [--dedup] [--dry-run] [--yes]", **_F)
     p_clean.add_argument("name", nargs="?", help="Project name")
-    p_clean.add_argument("--keep", type=int, default=1, metavar="<n>", help="Runs to keep per type (default: 1)")
+    p_clean.add_argument("--keep", type=int, default=1, metavar="<n>",
+                         help="Runs to keep per type (default: 1; 0 keeps only "
+                              "the newest — the last run is never deleted)")
     p_clean.add_argument("--dedup", action="store_true",
                          help="Coverage-aware: drop only runs fully subsumed by a survivor "
                               "(provably lossless), ignoring --keep")

--- a/core/project/tests/test_clean.py
+++ b/core/project/tests/test_clean.py
@@ -48,11 +48,30 @@ class TestClean(unittest.TestCase):
             self.assertIn("scan-20260404", stats["kept"])
             self.assertIn("scan-20260403", stats["kept"])
 
-    def test_keep_zero_rejected(self):
+    def test_keep_zero_preserves_last_run_per_type(self):
+        # --keep 0 is valid (design): delete as aggressively as possible,
+        # bounded by the clean-safety floor that never deletes the last run of
+        # a command type. The durable coverage store retains deleted verdicts.
+        with TemporaryDirectory() as d:
+            p = _make_project_with_runs(d, [
+                ("scan", "scan-20260401"),
+                ("scan", "scan-20260402"),
+                ("validate", "validate-20260401"),
+            ])
+            stats = clean_project(p, keep=0)
+            # Newest scan + the sole validate survive; the older scan goes.
+            self.assertEqual(len(stats["kept"]), 2)
+            self.assertEqual(len(stats["deleted"]), 1)
+            self.assertIn("scan-20260402", stats["kept"])
+            self.assertIn("validate-20260401", stats["kept"])
+            self.assertIn("scan-20260401", stats["deleted"])
+            self.assertFalse((p.output_path / "scan-20260401").exists())
+
+    def test_keep_negative_rejected(self):
         with TemporaryDirectory() as d:
             p = _make_project_with_runs(d, [("scan", "scan-20260401")])
             with self.assertRaises(ValueError):
-                clean_project(p, keep=0)
+                clean_project(p, keep=-1)
 
     def test_keep_one_preserves_single_run(self):
         with TemporaryDirectory() as d:

--- a/core/project/tests/test_clean_coverage.py
+++ b/core/project/tests/test_clean_coverage.py
@@ -26,7 +26,7 @@ def _proj(tmp_path):
     proj = tmp_path / "proj"
     proj.mkdir()
     (proj / "checklist.json").write_text(json.dumps({"files": [
-        {"path": "a.c", "total_lines": 100, "items": [
+        {"path": "a.c", "lines": 100, "items": [
             {"name": "f1", "line_start": 0, "line_end": 20},
             {"name": "f2", "line_start": 30, "line_end": 60},
         ]}]}))


### PR DESCRIPTION
- inventory: standardise per-file line count on `lines`; drop the file_line_count dual-key shim (the store keeps its own total_lines field, fed from `lines`)
- inventory: capture C/C++/JS multi-declarator globals and C/C++ typedef/struct/union/enum definitions as class-kind items so interstitial trends to structural glue rather than [UNKNOWN] residue
- store: tolerant load via new schema.py — corrupt JSON degrades to empty with a warning, malformed entries are normalised/dropped, newer schema versions read best-effort
- store: a (file,tool) contribution auto-converts to a line-set above 50 intervals (sparse runtime/gcov data); query API is unchanged and the on-disk form stays intervals
- project clean: accept `--keep 0` (delete-aggressive, bounded by the never-delete-last-run safety floor); reject negatives