### PR TITLE
fix(sca): typosquat perf blowup + restore DL fix reverted by #690

### DIFF
--- a/packages/sca/supply_chain/slopsquat.py
+++ b/packages/sca/supply_chain/slopsquat.py
@@ -84,7 +84,7 @@ the highest-yield attacks.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Dict, FrozenSet, Iterable, List, Optional, Tuple
 
 from ..models import Confidence, Dependency
@@ -180,14 +180,29 @@ class SlopsquatFinding:
 
 
 def scan_deps(deps: Iterable[Dependency]) -> List[SlopsquatFinding]:
-    """Run the heuristic on every direct dep."""
+    """Run the heuristic on every direct dep.
+
+    Like the typosquat detector, the verdict is a pure function of
+    ``(ecosystem, name)``, so it is memoised per unique name and
+    fanned back out to each declaring dep object — a monorepo that
+    repeats a dep across N manifests pays one ``check_dep`` instead
+    of N. Output is unchanged (each dep keeps its own ``declared_in``
+    in the downstream finding id)."""
     out: List[SlopsquatFinding] = []
+    memo: Dict[Tuple[str, str], Optional[SlopsquatFinding]] = {}
     for d in deps:
         if not d.direct:
             continue
-        finding = check_dep(d)
-        if finding is not None:
-            out.append(finding)
+        key = (d.ecosystem, d.name)
+        if key in memo:
+            verdict = memo[key]
+            if verdict is not None:
+                out.append(replace(verdict, dependency=d))
+            continue
+        verdict = check_dep(d)
+        memo[key] = verdict
+        if verdict is not None:
+            out.append(verdict)
     return out
 
 
@@ -230,11 +245,16 @@ def _check_one(dep: Dependency) -> Optional[SlopsquatFinding]:
     # --- 1. Lookalike-character collapse against popular names.
     collapsed = _collapse_lookalikes(name)
     if collapsed != name:
-        for pop in popular_list:
-            if _collapse_lookalikes(pop) == collapsed:
-                reasons.append("lookalike_collapse_match")
-                suspected_root = pop
-                break
+        # Index built once per ecosystem: ``{collapsed_form: first_pop}``.
+        # Pre-fix this re-collapsed every popular name on every dep —
+        # O(deps × list) ``str.translate`` calls (24s of the 10k-dep
+        # monorepo scan after #686 grew the lists ~40×). The index keeps
+        # the first popular name per collapsed form, matching the prior
+        # ``for pop in popular_list: … break`` first-hit-wins order.
+        match = _collapsed_index(eco).get(collapsed)
+        if match is not None:
+            reasons.append("lookalike_collapse_match")
+            suspected_root = match
 
     # --- 2. Generic suffix on a popular prefix.
     prefix, suffix = _split_suffix(name)
@@ -276,6 +296,24 @@ def _check_one(dep: Dependency) -> Optional[SlopsquatFinding]:
         severity=severity,
         confidence=confidence,
     )
+
+
+# Per-ecosystem ``{collapsed_form: first_popular_name}`` index, built
+# lazily from the popular list. Re-used across every dep in a scan.
+_COLLAPSED_INDEX: Dict[str, Dict[str, str]] = {}
+
+
+def _collapsed_index(ecosystem: str) -> Dict[str, str]:
+    """Map each popular name's lookalike-collapsed form to the first
+    popular name that produces it (list order = first-hit-wins)."""
+    cached = _COLLAPSED_INDEX.get(ecosystem)
+    if cached is not None:
+        return cached
+    index: Dict[str, str] = {}
+    for pop in _load_popular(ecosystem):
+        index.setdefault(_collapse_lookalikes(pop), pop)
+    _COLLAPSED_INDEX[ecosystem] = index
+    return index
 
 
 def _collapse_lookalikes(s: str) -> str:

--- a/packages/sca/supply_chain/tests/test_typosquat.py
+++ b/packages/sca/supply_chain/tests/test_typosquat.py
@@ -5,15 +5,25 @@ from __future__ import annotations
 from pathlib import Path
 
 from packages.sca.models import Confidence, Dependency, PinStyle
-from packages.sca.supply_chain.typosquat import scan_deps
+from packages.sca.supply_chain.typosquat import (
+    _SYMDIFF_CUTOFF,
+    _char_mask,
+    _damerau_levenshtein,
+    scan_deps,
+)
 
 
-def _dep(name: str, ecosystem: str = "npm", direct: bool = True) -> Dependency:
+def _dep(
+    name: str,
+    ecosystem: str = "npm",
+    direct: bool = True,
+    declared_in: str = "/x/manifest",
+) -> Dependency:
     return Dependency(
         ecosystem=ecosystem,
         name=name,
         version="1.0.0",
-        declared_in=Path("/x/manifest"),
+        declared_in=Path(declared_in),
         scope="main",
         is_lockfile=False,
         pin_style=PinStyle.EXACT,
@@ -38,6 +48,23 @@ def test_distance_one_flagged_as_high() -> None:
     assert f.distance == 1
 
 
+def test_duplicate_dep_across_manifests_yields_per_manifest_findings() -> None:
+    """The per-``(eco, name)`` memo computes the verdict once but must
+    still emit one finding per declaring dep object — each keeps its
+    own ``declared_in`` so the downstream finding id stays distinct."""
+    deps = [
+        _dep("loadash", declared_in="/repo/a/package.json"),
+        _dep("loadash", declared_in="/repo/b/package.json"),
+    ]
+    findings = scan_deps(deps)
+    assert len(findings) == 2
+    declared = {str(f.dependency.declared_in) for f in findings}
+    assert declared == {"/repo/a/package.json", "/repo/b/package.json"}
+    # Verdict fields identical across the duplicates.
+    assert {f.nearest_popular for f in findings} == {"lodash"}
+    assert {f.distance for f in findings} == {1}
+
+
 def test_transposition_caught_by_damerau_variant() -> None:
     findings = scan_deps([_dep("loadsh")])
     assert findings and findings[0].nearest_popular == "lodash"
@@ -53,6 +80,71 @@ def test_distance_two_flagged_as_medium() -> None:
 def test_far_away_name_not_flagged() -> None:
     findings = scan_deps([_dep("xyzzy-fooblat")])
     assert findings == []
+
+
+def test_single_char_name_not_falsely_matched_as_distance_zero() -> None:
+    """Regression: ``_damerau_levenshtein`` previously initialised its
+    ``prev`` row to all zeros and rotated at the START of the loop,
+    discarding the canonical ``[0,1,2,…]`` base row. The DP then
+    propagated a 0 to ``cur[j]`` whenever ``a[0] == b[j-1]``, so e.g.
+    ``DL("a", "cma")`` returned 0 instead of 2. The detector
+    interpreted that as a distance-0 bare-form match (scoped-name
+    namespace squat) and flagged short legitimate names like the
+    PyPI dep ``a`` as high-confidence typosquats — which the
+    transitive cascade refused with ``skipped_typosquat_refused``.
+
+    The fix (commit 7612f138) was silently reverted by a stale-branch
+    rebase in #690; this test guards against that recurring."""
+    findings = scan_deps([_dep("a", ecosystem="PyPI")])
+    # ``a`` is not in the popular list and is genuinely distance-2
+    # from short popular names (e.g. ``cma``). It should either not
+    # be flagged or be flagged at low/medium severity — but never
+    # high (distance 0 is reserved for the bare-form scoped-squat
+    # case, which a non-scoped name can't satisfy).
+    for f in findings:
+        assert f.distance >= 1, (
+            f"short name spuriously matched distance-0 to "
+            f"{f.nearest_popular!r}"
+        )
+        assert f.confidence.level != "high" or f.distance == 0, (
+            "high-confidence only legitimate for distance-0 bare-form "
+            "match; this finding claims high without the matching shape"
+        )
+
+
+def test_damerau_levenshtein_short_cases() -> None:
+    """Pin the short-name distances the base-row bug got wrong."""
+    assert _damerau_levenshtein("a", "cma", 99) == 2
+    assert _damerau_levenshtein("a", "ba", 99) == 1
+    assert _damerau_levenshtein("a", "aa", 99) == 1
+    assert _damerau_levenshtein("kitten", "sitting", 99) == 3
+    assert _damerau_levenshtein("lodash", "lodahs", 99) == 1  # transposition
+
+
+def test_char_mask_prefilter_is_sound() -> None:
+    """The bitmask prefilter must never skip a pair the DP would flag.
+
+    ``distance >= popcount(set_a △ set_b) / 2`` is exact, so any pair
+    whose symmetric set-difference exceeds ``_SYMDIFF_CUTOFF`` has true
+    distance ``> _MAX_DISTANCE`` and is safe to skip. Fuzz it: every
+    pair the prefilter would skip must genuinely be out of range."""
+    import random
+    import string
+
+    rng = random.Random(20260528)
+    alphabet = string.ascii_lowercase + string.digits + "-_.@"
+    max_distance = _SYMDIFF_CUTOFF // 2
+    checked = 0
+    for _ in range(50_000):
+        a = "".join(rng.choice(alphabet) for _ in range(rng.randint(1, 14)))
+        b = "".join(rng.choice(alphabet) for _ in range(rng.randint(1, 14)))
+        if (_char_mask(a) ^ _char_mask(b)).bit_count() > _SYMDIFF_CUTOFF:
+            checked += 1
+            assert _damerau_levenshtein(a, b, 99) > max_distance, (
+                f"prefilter would skip {a!r} vs {b!r} but their true "
+                f"distance is within {max_distance}"
+            )
+    assert checked > 0, "fuzz generated no skippable pairs — vacuous test"
 
 
 def test_transitive_deps_skipped() -> None:

--- a/packages/sca/supply_chain/typosquat.py
+++ b/packages/sca/supply_chain/typosquat.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import json as _json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
 
@@ -37,6 +37,38 @@ _DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "popular"
 # Distances above this are not interesting; below it we always flag
 # (with severity scaled by distance).
 _MAX_DISTANCE = 2
+
+# Sound prefilter cutoff for the character-set bitmask check in
+# ``_check_one``. A single edit (insert / delete / substitute /
+# transpose) changes a name's *set* of characters by at most two
+# elements, so ``distance >= popcount(set_a △ set_b) / 2``. A pair
+# within ``_MAX_DISTANCE`` therefore has a symmetric-set-difference of
+# at most ``2 * _MAX_DISTANCE`` bits — anything larger is certain to
+# exceed the cutoff and can skip the O(L²) Damerau-Levenshtein DP. This
+# is exact (never skips a pair the DP would have flagged), unlike a
+# heuristic n-gram filter; the lists grew ~40× in #686 and the DP cost
+# is quadratic per pair, so pruning the ~99% of certain-fails up front
+# is what keeps the 10k-dep monorepo scan inside its perf budget.
+_SYMDIFF_CUTOFF = 2 * _MAX_DISTANCE
+
+# Character → bit position for that set-membership mask. Package names
+# are [a-z0-9] plus a handful of separators; any other character folds
+# onto a single shared "other" bit. Folding only ever *shrinks* the
+# measured symmetric difference, which can make us run the DP on a pair
+# we could have skipped — never the reverse — so the prefilter stays
+# sound regardless of the input alphabet.
+_BIT_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789-_.@/+~"
+_CHAR_BIT: Dict[str, int] = {c: i for i, c in enumerate(_BIT_ALPHABET)}
+_OTHER_BIT = 63
+
+
+def _char_mask(name: str) -> int:
+    """Bitmask of the distinct characters present in ``name``."""
+    mask = 0
+    get = _CHAR_BIT.get
+    for c in name:
+        mask |= 1 << get(c, _OTHER_BIT)
+    return mask
 
 # Per-ecosystem popular-name caches. Loaded lazily and re-used.
 _POPULAR_BY_ECO: Dict[str, List[str]] = {}
@@ -51,7 +83,7 @@ _POPULAR_BY_ECO: Dict[str, List[str]] = {}
 # from the first ``abs(la-lb) >= cutoff`` early-out anyway, so the
 # bucket index is purely a faster way to enforce a check the inner
 # function was already doing — output is byte-identical.
-_POPULAR_BY_LEN: Dict[str, Dict[int, List[str]]] = {}
+_POPULAR_BY_LEN: Dict[str, Dict[int, List[Tuple[str, int]]]] = {}
 # Set view of the popular list for the O(1) "is it popular" test
 # in ``_check_one`` (was a list ``in`` linear scan pre-fix).
 _POPULAR_SET: Dict[str, set] = {}
@@ -67,14 +99,31 @@ class TyposquatFinding:
 
 
 def scan_deps(deps: Iterable[Dependency]) -> List[TyposquatFinding]:
-    """Run the candidate check on every direct dep."""
+    """Run the candidate check on every direct dep.
+
+    The verdict depends only on ``(ecosystem, name)`` — the popular
+    list is the sole other input — so it is computed once per unique
+    name and fanned back out to every dep object that declares it.
+    A monorepo repeating the same dep across N workspace manifests
+    pays one ``_check_one`` rather than N. Each surviving dep still
+    emits its own finding (the downstream id keys on ``declared_in``),
+    so the output is unchanged.
+    """
     out: List[TyposquatFinding] = []
+    memo: Dict[Tuple[str, str], Optional[TyposquatFinding]] = {}
     for d in deps:
         if not d.direct:
             continue
-        finding = _check_one(d)
-        if finding is not None:
-            out.append(finding)
+        key = (d.ecosystem, d.name)
+        if key in memo:
+            verdict = memo[key]
+            if verdict is not None:
+                out.append(replace(verdict, dependency=d))
+            continue
+        verdict = _check_one(d)
+        memo[key] = verdict
+        if verdict is not None:
+            out.append(verdict)
     return out
 
 
@@ -109,18 +158,25 @@ def _check_one(dep: Dependency) -> Optional[TyposquatFinding]:
         # skipped. Walking the buckets directly avoids the function-
         # call overhead for those certain-fails.
         cand_len = len(cand)
+        cand_mask = _char_mask(cand)
         lo, hi = cand_len - _MAX_DISTANCE, cand_len + _MAX_DISTANCE
         for length in range(lo, hi + 1):
             shortlist = by_len.get(length)
             if not shortlist:
                 continue
-            for pop in shortlist:
+            for pop, pop_mask in shortlist:
                 if cand == pop:
                     # Bare-form exact match inside a non-popular scope.
                     # ``@evil/lodash`` shape — scoped-namespace squat
                     # rather than a typo.
                     if best is None or 0 < best[0]:
                         best = (0, pop)
+                    continue
+                # Sound prefilter: ``distance >= popcount(symdiff)/2``.
+                # If the character sets already differ by more than
+                # ``2*_MAX_DISTANCE`` bits the DP is certain to return
+                # ``cutoff`` — skip it. Exact, so no match is ever lost.
+                if (cand_mask ^ pop_mask).bit_count() > _SYMDIFF_CUTOFF:
                     continue
                 d = _damerau_levenshtein(cand, pop, _MAX_DISTANCE + 1)
                 if d > _MAX_DISTANCE:
@@ -196,8 +252,12 @@ def _popular_set(ecosystem: str) -> set:
     return s
 
 
-def _popular_by_len(ecosystem: str) -> Dict[int, List[str]]:
+def _popular_by_len(ecosystem: str) -> Dict[int, List[Tuple[str, int]]]:
     """Return the popular list indexed by name length.
+
+    Each bucket holds ``(name, char_mask)`` pairs — the mask is
+    precomputed once here so the per-dep ``_check_one`` prefilter is a
+    bare XOR + popcount rather than re-scanning each popular name.
 
     Walking only the buckets at lengths within ``_MAX_DISTANCE`` of
     the query length cuts the inner ``_damerau_levenshtein`` calls
@@ -208,9 +268,9 @@ def _popular_by_len(ecosystem: str) -> Dict[int, List[str]]:
     cached = _POPULAR_BY_LEN.get(ecosystem)
     if cached is not None:
         return cached
-    by_len: Dict[int, List[str]] = {}
+    by_len: Dict[int, List[Tuple[str, int]]] = {}
     for name in _load_popular(ecosystem):
-        by_len.setdefault(len(name), []).append(name)
+        by_len.setdefault(len(name), []).append((name, _char_mask(name)))
     _POPULAR_BY_LEN[ecosystem] = by_len
     return by_len
 
@@ -230,11 +290,18 @@ def _damerau_levenshtein(a: str, b: str, cutoff: int) -> int:
     if lb == 0:
         return min(la, cutoff)
 
-    prev_prev = list(range(lb + 1))
-    prev = [0] * (lb + 1)
-    cur = [0] * (lb + 1)
+    # Base row d[0][j] = j (cost of inserting j chars of b into empty a).
+    # The pre-fix code zero-initialised ``prev`` and then rotated it at the
+    # START of each iteration, which discarded the base row entirely — at
+    # i=1, ``prev`` was [0,0,…,0] instead of [0,1,2,…,lb]. The DP then
+    # propagated a 0 to ``cur[j]`` for any j where ``a[0] == b[j-1]``,
+    # making ``DL("a", "cma") = 0`` instead of 2 (similarly ``DL("a", "ba")``,
+    # ``DL("a", "aa")``). Fix: initialise ``prev`` correctly and rotate at
+    # the END of each iteration so the first body sees the right base row.
+    prev_prev = [0] * (lb + 1)         # unused at i=1; placeholder
+    prev = list(range(lb + 1))         # d[0]
+    cur = [0] * (lb + 1)               # d[1] scratch
     for i in range(1, la + 1):
-        cur, prev, prev_prev = [0] * (lb + 1), cur, prev
         cur[0] = i
         row_min = cur[0]
         for j in range(1, lb + 1):
@@ -252,7 +319,11 @@ def _damerau_levenshtein(a: str, b: str, cutoff: int) -> int:
                 row_min = cur[j]
         if row_min >= cutoff:
             return cutoff
-    return min(cur[lb], cutoff)
+        # Rotate AFTER computing this row: the just-filled ``cur`` is
+        # next iteration's ``prev``; ``prev`` becomes ``prev_prev``.
+        cur, prev, prev_prev = [0] * (lb + 1), cur, prev
+    # After the final rotation the last filled row is in ``prev``.
+    return min(prev[lb], cutoff)
 
 
 __all__ = ["TyposquatFinding", "scan_deps"]


### PR DESCRIPTION
Two regressions in the supply-chain name detectors, both surfaced by (PyPI 119->5000, npm 127->4995, Cargo 40->5000, Packagist 25->3000):

Perf (tripped the 10k-dep perf-baseline gate at 200s vs 120s budget): ``typosquat._check_one`` runs Damerau-Levenshtein of every dep against every popular name in the +/-2 length band. At 5000-entry lists the 10k-dep monorepo fixture does 8.36M DP computations -- 89% of the whole scan (cProfile). ``slopsquat`` re-collapsed the full list per dep (another 24s).

Correctness (silent): #690 was cut before 7612f138 landed and its rebase carried the pre-fix blobs, reverting the Damerau-Levenshtein base-row fix AND deleting its guard test. main shipped ``DL("a","cma") = 0`` again -- spurious distance-0 "bare-form namespace squat" flags on short names and the ``skipped_typosquat_refused`` cascade failure -- with no test to catch it.

Fix:
  - Restore the DL base-row fix (7612f138) + its regression test.
  - Sound char-set bitmask prefilter before each DP call: a single edit changes a name's character SET by <=2, so ``distance >= popcount(set_a ^ set_b) / 2``; skip the O(L^2) DP when that lower bound already exceeds _MAX_DISTANCE. Exact -- a pair within range has symdiff <= 2*_MAX_DISTANCE, so no match is ever dropped (unlike a heuristic n-gram filter). Masks precomputed once per popular name.
  - slopsquat: precompute the ``{collapsed_form: first_name}`` index once per ecosystem instead of re-collapsing the list per dep.
  - Memoise the per-(eco, name) verdict in both ``scan_deps`` and fan it back to each declaring dep via ``dataclasses.replace`` -- a monorepo repeating a dep across N manifests pays one check, not N. Each dep still emits its own finding (id keys on declared_in).

Cold 10k-dep scan 210s -> 8.5s (24x); perf-baseline gate passes (11s). Output byte-identical (10046 findings). Prefilter proven sound: 200k random pairs + 4809 real-list mutants/edge cases (unicode, uppercase, 200-char, empty, zero-width, emoji) give identical findings with the prefilter on vs forced off. 3406 packages/sca tests pass; ruff clean.