### PR TITLE
fix(ci): silence misleading "fatal: couldn't find remote ref" in auto-PR pushes

### DIFF
--- a/.github/workflows/refit-sca-calibration.yml
+++ b/.github/workflows/refit-sca-calibration.yml
@@ -176,8 +176,14 @@ jobs:
           # --force-with-lease (not --force): refuses the push if the
           # remote branch moved since our fetch — e.g. an operator amended
           # the open auto-PR — rather than clobbering it. Fetch first to
-          # seed the lease baseline; || true for the first run (no branch).
-          git fetch origin "$BRANCH" || true
+          # seed the lease baseline, but only when the branch already exists
+          # remotely: a bare fetch of a missing ref prints a misleading
+          # ``fatal: couldn't find remote ref`` on the first run (or after
+          # the prior auto-PR branch was merged + deleted). When the guard
+          # skips the fetch, the push simply creates the branch.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git fetch origin "$BRANCH" || true   # tolerate a transient blip
+          fi
           git push --force-with-lease origin "$BRANCH"
 
       - name: Create or update PR

--- a/.github/workflows/refresh-sca-calibration.yml
+++ b/.github/workflows/refresh-sca-calibration.yml
@@ -144,8 +144,14 @@ jobs:
           # --force-with-lease (not --force): refuses the push if the
           # remote branch moved since our fetch — e.g. an operator amended
           # the open auto-PR — rather than clobbering it. Fetch first to
-          # seed the lease baseline; || true for the first run (no branch).
-          git fetch origin "$BRANCH" || true
+          # seed the lease baseline, but only when the branch already exists
+          # remotely: a bare fetch of a missing ref prints a misleading
+          # ``fatal: couldn't find remote ref`` on the first run (or after
+          # the prior auto-PR branch was merged + deleted). When the guard
+          # skips the fetch, the push simply creates the branch.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git fetch origin "$BRANCH" || true   # tolerate a transient blip
+          fi
           git push --force-with-lease origin "$BRANCH"
 
       - name: Create or update PR

--- a/.github/workflows/refresh-sca-data.yml
+++ b/.github/workflows/refresh-sca-data.yml
@@ -106,8 +106,14 @@ jobs:
           # --force-with-lease (not --force): refuses the push if the
           # remote branch moved since our fetch — e.g. an operator amended
           # the open auto-PR — rather than clobbering it. Fetch first to
-          # seed the lease baseline; || true for the first run (no branch).
-          git fetch origin "$BRANCH" || true
+          # seed the lease baseline, but only when the branch already exists
+          # remotely: a bare fetch of a missing ref prints a misleading
+          # ``fatal: couldn't find remote ref`` on the first run (or after
+          # the prior auto-PR branch was merged + deleted). When the guard
+          # skips the fetch, the push simply creates the branch.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git fetch origin "$BRANCH" || true   # tolerate a transient blip
+          fi
           git push --force-with-lease origin "$BRANCH"
 
       - name: Create or update PR

--- a/.github/workflows/refresh-sca-project-samples.yml
+++ b/.github/workflows/refresh-sca-project-samples.yml
@@ -128,8 +128,14 @@ jobs:
           # --force-with-lease (not --force): refuses the push if the
           # remote branch moved since our fetch — e.g. an operator amended
           # the open auto-PR — rather than clobbering it. Fetch first to
-          # seed the lease baseline; || true for the first run (no branch).
-          git fetch origin "$BRANCH" || true
+          # seed the lease baseline, but only when the branch already exists
+          # remotely: a bare fetch of a missing ref prints a misleading
+          # ``fatal: couldn't find remote ref`` on the first run (or after
+          # the prior auto-PR branch was merged + deleted). When the guard
+          # skips the fetch, the push simply creates the branch.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git fetch origin "$BRANCH" || true   # tolerate a transient blip
+          fi
           git push --force-with-lease origin "$BRANCH"
 
       - name: Create or update PR

--- a/.github/workflows/sca-self-bump.yml
+++ b/.github/workflows/sca-self-bump.yml
@@ -201,12 +201,18 @@ jobs:
           Every change passed the full raptor-sca signal set
           (vulns / KEV / EPSS / yanked / license / hygiene /
           supply-chain / capability-delta / reachability)."
-          # Fetch the remote branch (if any) so ``--force-with-lease`` has a
-          # baseline to compare against; best-effort since the first run has
-          # no such branch yet. ``--force-with-lease`` then refuses the push
-          # if the branch moved since this fetch (e.g. an operator amended
-          # the open PR), where a plain ``--force`` would clobber it.
-          git fetch origin sca-self-bump || true
+          # Fetch the remote branch so ``--force-with-lease`` has a baseline
+          # to compare against, but only when it already exists remotely: a
+          # bare fetch of a missing ref prints a misleading
+          # ``fatal: couldn't find remote ref`` on the first run (or after
+          # the prior PR branch was merged + deleted). ``--force-with-lease``
+          # then refuses the push if the branch moved since this fetch (e.g.
+          # an operator amended the open PR), where a plain ``--force`` would
+          # clobber it. When the guard skips the fetch, the push creates the
+          # branch.
+          if git ls-remote --exit-code --heads origin sca-self-bump >/dev/null 2>&1; then
+            git fetch origin sca-self-bump || true   # tolerate a transient blip
+          fi
           git push --force-with-lease origin sca-self-bump
 
       - name: Open or update PR


### PR DESCRIPTION
The refresh/refit/self-bump workflows pre-fetch the auto-PR branch to seed the --force-with-lease baseline via ``git fetch origin "$BRANCH" || true``. When the branch doesn't exist remotely yet (first run, or after the prior auto-PR branch was merged + deleted) the fetch prints ``fatal: couldn't find remote ref "$BRANCH"`` -- the || true swallows the exit code but not the stderr, so a succeeding job logs a scary-looking non-error.

Guard the fetch with ``git ls-remote --exit-code --heads origin "$BRANCH"`` so it only runs when the branch exists; the push then creates it on the first run. Behaviour-preserving: --force-with-lease still gets its baseline when the branch exists, and the inner fetch keeps || true for transient blips. Applied to refresh-sca-calibration, refresh-sca-data, refit-sca-calibration, refresh-sca-project-samples, and sca-self-bump.