### PR TITLE
fix(cve_diff): drop integration test for unbuilt fetch_context feature

### DIFF
--- a/packages/cve_diff/cve_diff/core/models.py
+++ b/packages/cve_diff/cve_diff/core/models.py
@@ -70,9 +70,9 @@ class DiscoveryResult:
     What a single discoverer returns. `tuples` may be empty (miss).
 
     `raw` carries the full upstream payload (currently only populated by the
-    OSV discoverer). The cascade extracts `AdvisoryContext` from it and passes
-    the context to later discoverers' scoring so wrong-repo matches get
-    rejected without a hand-curated slug map.
+    OSV discoverer) and is surfaced to the agent's `osv_raw` / `nvd_raw`
+    tools, which read the CPE vendor/product to disambiguate wrong-repo
+    matches without a hand-curated slug map.
     """
 
     source: str

--- a/packages/cve_diff/tests/integration/test_nvd_live.py
+++ b/packages/cve_diff/tests/integration/test_nvd_live.py
@@ -1,7 +1,6 @@
 """
 Live NVD integration tests. Hit services.nvd.nist.gov for a well-known CVE
-and assert `NvdDiscoverer.fetch` + `fetch_context` extract the signals the
-cascade depends on.
+and assert `NvdDiscoverer.fetch` extracts the signals the cascade depends on.
 
 Skipped by default (addopts `-m 'not integration'`). Run explicitly with
 `.venv/bin/pytest tests/integration -m integration -q`.
@@ -12,24 +11,6 @@ from __future__ import annotations
 import pytest
 
 from cve_diff.discovery.nvd import NvdDiscoverer
-
-
-@pytest.mark.integration
-def test_nvd_live_fetch_context_returns_cpe_products_for_log4shell() -> None:
-    """CVE-2021-44228 (log4shell) has stable NVD CPE entries naming
-    `log4j` as the product. `fetch_context` must surface that via
-    `cpe_products` so the runtime scorer's CPE boost can fire.
-
-    `published` is not asserted — `AdvisoryContext.from_nvd` only populates
-    the CPE-derived fields (vendor/product), deliberately leaving the
-    advisory-publish date to `from_osv`.
-    """
-    ctx = NvdDiscoverer().fetch_context("CVE-2021-44228")
-    assert ctx is not None, "NVD returned None — network or rate-limit?"
-    assert ctx.cve_id == "CVE-2021-44228"
-    assert ctx.cpe_products, "NVD context had no cpe_products"
-    assert any("log4j" in p.lower() for p in ctx.cpe_products)
-    assert ctx.cpe_vendors, "NVD context had no cpe_vendors"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
test_nvd_live_fetch_context_returns_cpe_products_for_log4shell called NvdDiscoverer.fetch_context() expecting an AdvisoryContext with cpe_products/cpe_vendors. None of that was ever implemented: #254 shipped the test plus a comment describing a planned CPE-enrichment call, and #301 removed the comment but left the test dangling. There is no consumer either — CPE vendor/product disambiguation is done by the agent via the nvd_raw tool, not a scorer. Remove the dead test and correct the DiscoveryResult.raw docstring to describe the actual nvd_raw/osv_raw flow instead of the never-built AdvisoryContext cascade.