### PR TITLE
feat(reachability): Ruby/PHP module_aborts + broader framework entries

### DIFF
--- a/core/inventory/extractors.py
+++ b/core/inventory/extractors.py
@@ -982,6 +982,19 @@ class TreeSitterExtractor:
                 for b in child.children:
                     if b.type in ("identifier", "attribute"):
                         out.append(b.text.decode().split(".")[-1].strip())
+            elif child.type == "base_list":
+                # C#: ``: ControllerBase, IFoo<int>`` — record base/interface
+                # tail names so framework base classes (ControllerBase / Hub /
+                # BackgroundService) mark the class's methods as entries. Bases
+                # are identifier / qualified_name / generic_name children.
+                for b in child.children:
+                    if b.type in ("identifier", "qualified_name"):
+                        out.append(b.text.decode().split(".")[-1].strip())
+                    elif b.type == "generic_name":
+                        ident = next((g for g in b.children
+                                      if g.type == "identifier"), None)
+                        if ident is not None:
+                            out.append(ident.text.decode())
         return out
 
     @staticmethod

--- a/core/inventory/module_load_abort.py
+++ b/core/inventory/module_load_abort.py
@@ -86,6 +86,10 @@ def detect_module_load_abort(
             return _detect_go(content)
         if language == "rust":
             return _detect_rust(content)
+        if language == "php":
+            return _detect_php(content)
+        if language == "ruby":
+            return _detect_ruby(content)
     except Exception:  # noqa: BLE001
         # Detection failures are non-fatal — the consumer treats
         # ``None`` as "no abort detected", which matches the
@@ -397,6 +401,120 @@ def _detect_rust(content: str) -> Optional[ModuleLoadAbort]:
         line=line_no,
         summary="compile_error!(...)",
     )
+
+
+# ---------------------------------------------------------------------------
+# PHP — ``<?php`` files execute top-level code on include/require. An
+# unconditional file-scope ``throw new <Class>``, ``die`` or ``exit``
+# aborts the load before any declaration below it binds. Brace-depth
+# tracking (mirrors the JS detector) + a statement-initial gate so a
+# CONDITIONAL abort (``if (x) die();`` — the abort follows ``)``) is
+# never flagged (a false positive would wrongly hard-suppress live code).
+# ---------------------------------------------------------------------------
+
+
+_PHP_LINE_COMMENT = re.compile(r"(//|#)[^\n]*")
+_PHP_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+_PHP_TAG = re.compile(r"<\?php|<\?=|<\?|\?>")
+_PHP_ABORT = re.compile(r"throw\s+new\s+([A-Za-z_\\][\w\\]*)|die\b|exit\b")
+# A statement-initial abort is preceded (ignoring whitespace) by one of
+# these — i.e. it begins a statement, so it is not a branch/modifier body.
+# (Open/close tags are stripped to whitespace first, so the first statement
+# after ``<?php`` sees ``last_significant is None`` and counts as initial.)
+_PHP_STMT_BOUNDARY = frozenset({";", "{", "}"})
+
+
+def _detect_php(content: str) -> Optional[ModuleLoadAbort]:
+    def _spaces(m: "re.Match[str]") -> str:
+        return re.sub(r"[^\n]", " ", m.group(0))
+    stripped = _PHP_BLOCK_COMMENT.sub(_spaces, content)
+    stripped = _PHP_LINE_COMMENT.sub(_spaces, stripped)
+    # Blank the PHP open/close tags so the first statement after ``<?php``
+    # is statement-initial and ``->`` / ``?>`` ``>`` chars never read as a
+    # boundary.
+    stripped = _PHP_TAG.sub(_spaces, stripped)
+    depth = 0
+    last_significant = None  # last non-whitespace char seen
+    i = 0
+    n = len(stripped)
+    while i < n:
+        c = stripped[i]
+        if c in "\"'":
+            j = _js_skip_string(stripped, i)
+            if j is None:
+                break
+            last_significant = stripped[j - 1] if j else c
+            i = j
+            continue
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth = max(0, depth - 1)
+        elif depth == 0 and (c in "tde") and (
+                last_significant is None or last_significant in _PHP_STMT_BOUNDARY):
+            # Only attempt a match at a statement boundary at file scope.
+            m = _PHP_ABORT.match(stripped, i)
+            if m:
+                tok = m.group(0).split()[0]
+                summary = (f"throw new {m.group(1).split(chr(92))[-1]}"
+                           if m.group(1) else tok)
+                line_no = stripped.count("\n", 0, i) + 1
+                return ModuleLoadAbort(line=line_no, summary=summary)
+        if not c.isspace():
+            last_significant = c
+        i += 1
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Ruby — top-level code runs on require. An unconditional column-0
+# ``raise`` / ``abort`` / ``exit`` / ``fail`` aborts the load. Ruby has no
+# braces for blocks (def/class/module/if/… end), so nesting is tracked by
+# COLUMN-0 block openers vs ``end`` — Ruby bodies are indented by universal
+# convention, so a column-0 statement is top-level. We flag only an
+# unconditional (no trailing ``if``/``unless``/… modifier) column-0 abort at
+# nesting depth 0. Conservative by design: ambiguous cases under-detect
+# (FN-safe) rather than risk a false positive (which would hard-suppress).
+# ---------------------------------------------------------------------------
+
+
+_RB_OPENER = re.compile(
+    r"^(class|module|def|begin|if|unless|while|until|case|for)\b")
+_RB_END = re.compile(r"^end\b")
+# A one-liner (``def foo; end`` / ``class X; end``) opens AND closes on the
+# same line — net zero nesting. Detected by a trailing ``end`` word so it
+# doesn't leave depth stuck at 1 (which would hide a top-level abort below).
+_RB_ONELINER = re.compile(r"\bend\s*$")
+_RB_ABORT = re.compile(r"^(raise\s+\S|abort\b|exit\b|exit!|fail\s+\S|Kernel\.(abort|exit))")
+_RB_MODIFIER = re.compile(r"\b(if|unless|while|until)\b")
+
+
+def _detect_ruby(content: str) -> Optional[ModuleLoadAbort]:
+    depth = 0
+    for idx, raw in enumerate(content.splitlines()):
+        # Strip trailing line comment (best-effort; a ``#`` inside a string
+        # is rare at module scope and only risks under-detection).
+        line = re.sub(r"#.*$", "", raw)
+        stripped = line.strip()
+        if not stripped:
+            continue
+        is_col0 = line[:1] not in (" ", "\t")
+        if is_col0 and depth == 0:
+            abort = _RB_ABORT.match(stripped)
+            if abort and not _RB_MODIFIER.search(stripped[len(abort.group(0)):]):
+                # Exclude conditional modifier forms (``raise X if cond``).
+                return ModuleLoadAbort(
+                    line=idx + 1,
+                    summary=stripped.split()[0].split(".")[-1])
+        # Track nesting via COLUMN-0 openers / ends only (indented inner
+        # structure is irrelevant to whether a column-0 line is top-level).
+        if is_col0:
+            if _RB_END.match(stripped):
+                depth = max(0, depth - 1)
+            elif _RB_OPENER.match(stripped) and not _RB_ONELINER.search(stripped):
+                # one-liner (``def f; end``) is net-zero — don't increment.
+                depth += 1
+    return None
 
 
 __all__ = ["ModuleLoadAbort", "detect_module_load_abort"]

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -2570,6 +2570,11 @@ _CSHARP_METHOD_DISPATCH_ATTRS = frozenset({
 # caller.
 _CSHARP_CLASS_STEREOTYPE_ATTRS = frozenset({
     "ApiController", "Controller", "Route",
+    # Base CLASSES the runtime dispatches into (class_attributes captures
+    # both [Attributes] and `: Base` types): MVC/API controllers without an
+    # explicit attribute, SignalR hubs, and hosted/background services whose
+    # ExecuteAsync/StartAsync the host invokes with no in-project caller.
+    "ControllerBase", "Hub", "BackgroundService", "IHostedService",
 })
 
 
@@ -2670,12 +2675,24 @@ _PYTHON_FRAMEWORK_BASES = frozenset({
     # Django generic class-based views
     "View", "TemplateView", "RedirectView", "ListView", "DetailView",
     "CreateView", "UpdateView", "DeleteView", "FormView", "ArchiveIndexView",
-    # Django REST Framework
+    # Django REST Framework views
     "APIView", "GenericAPIView", "ViewSet", "ViewSetMixin", "GenericViewSet",
     "ModelViewSet", "ReadOnlyModelViewSet", "ListAPIView", "RetrieveAPIView",
     "CreateAPIView", "UpdateAPIView", "DestroyAPIView", "ListCreateAPIView",
     "RetrieveUpdateAPIView", "RetrieveDestroyAPIView",
     "RetrieveUpdateDestroyAPIView",
+    # DRF serializers / permissions / auth (validate_*/create/update,
+    # has_permission, authenticate are framework-dispatched by convention)
+    "Serializer", "ModelSerializer", "ListSerializer",
+    "HyperlinkedModelSerializer", "BasePermission", "BaseAuthentication",
+    # Django management commands (the runner invokes handle()/add_arguments)
+    "BaseCommand", "AppCommand", "LabelCommand",
+    # Django forms (clean_*/clean dispatched on validation)
+    "Form", "ModelForm", "BaseForm",
+    # Django admin (action / display callables) + middleware
+    "ModelAdmin", "TabularInline", "StackedInline", "MiddlewareMixin",
+    # Celery class-based tasks (run() invoked by the worker)
+    "Task",
     # Flask / Flask-RESTful
     "MethodView", "Resource",
 })

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -1638,6 +1638,31 @@ class TestCSharpCoverage:
         assert verdict("DeadHelper") == "not_called"  # private uncalled
         assert verdict("Lonely") == "not_called"    # public, non-stereotype class
 
+    def test_csharp_base_class_stereotypes(self, tmp_path):
+        # Base CLASSES (no attribute) the runtime dispatches into — captured
+        # from the C# base_list into class_attributes.
+        pytest.importorskip("tree_sitter_c_sharp")
+        from core.inventory.reach_audit import classify_reachability
+        (tmp_path / "f.cs").write_text(
+            "public class BlogController : ControllerBase {\n"
+            "  public IActionResult Index() { return Ok(); }\n}\n"
+            "public class ChatHub : Hub {\n  public void Send(string m) {} }\n"
+            "public class Plain {\n  public void Dead() {} }\n")
+        inv = build_inventory(str(tmp_path), str(tmp_path / "out"))
+
+        def verdict(name):
+            for f in inv["files"]:
+                for it in f["items"]:
+                    if it.get("name") == name:
+                        return classify_reachability(
+                            inv, f["path"], name,
+                            int(it.get("line_start") or 0), f["path"].rsplit(".", 1)[0])
+            return None
+
+        assert verdict("Index") == "reachable"   # : ControllerBase (no [attr])
+        assert verdict("Send") == "reachable"     # : Hub (SignalR)
+        assert verdict("Dead") == "not_called"    # plain class control
+
 
 class TestRubyCoverage:
     """End-to-end Ruby / Rails coverage. Ruby used the regex extractor; now
@@ -1755,6 +1780,39 @@ class TestPythonFrameworkConvention:
         assert verdict("get") == "reachable"           # DRF APIView verb handler
         assert verdict("get_queryset") == "reachable"   # Django ListView hook
         assert verdict("dead") == "not_called"          # non-CBV control
+
+    def test_python_convention_breadth(self, tmp_path):
+        # Beyond web CBVs: Django management commands, DRF serializers, forms,
+        # admin — methods dispatched by the framework with no in-project caller.
+        from core.inventory.reach_audit import classify_reachability
+        (tmp_path / "fw.py").write_text(
+            "from django.core.management.base import BaseCommand\n"
+            "class Command(BaseCommand):\n"
+            "    def handle(self, *a, **k): return self._work()\n"
+            "    def _work(self): return 1\n"
+            "from rest_framework import serializers\n"
+            "class UserSer(serializers.ModelSerializer):\n"
+            "    def validate_email(self, v): return v\n"
+            "class ContactForm(forms.Form):\n"
+            "    def clean_email(self): return 1\n"
+            "class Plain:\n"
+            "    def dead(self): return 9\n")
+        inv = build_inventory(str(tmp_path), str(tmp_path / "out"))
+
+        def verdict(name):
+            for f in inv["files"]:
+                for it in f["items"]:
+                    if it.get("name") == name:
+                        return classify_reachability(
+                            inv, f["path"], name,
+                            int(it.get("line_start") or 0), "fw")
+            return None
+
+        assert verdict("handle") == "reachable"          # Django mgmt command
+        assert verdict("_work") == "reachable"            # transitively via this
+        assert verdict("validate_email") == "reachable"   # DRF serializer hook
+        assert verdict("clean_email") == "reachable"      # Django form hook
+        assert verdict("dead") == "not_called"            # control
 
 
 class TestPhpCoverage:

--- a/core/inventory/tests/test_module_load_abort.py
+++ b/core/inventory/tests/test_module_load_abort.py
@@ -248,6 +248,89 @@ def test_rust_cfg_gated_compile_error_does_not_fire():
 
 
 # ---------------------------------------------------------------------------
+# PHP — file-scope die / exit / throw new aborts include/require.
+# ---------------------------------------------------------------------------
+
+
+def test_php_top_level_die_fires():
+    r = detect_module_load_abort("php", "<?php\ndie('disabled');\nfunction f(){}\n")
+    assert r is not None and r.line == 2 and r.summary == "die"
+
+
+def test_php_top_level_throw_new_fires():
+    r = detect_module_load_abort(
+        "php", "<?php\nthrow new \\App\\DisabledException();\nclass C{}\n")
+    assert r is not None and r.summary == "throw new DisabledException"
+
+
+def test_php_exit_after_function_fires():
+    # The function binds, then an unconditional exit aborts the rest.
+    r = detect_module_load_abort("php", "<?php\nfunction g(){}\nexit;\n")
+    assert r is not None and r.line == 3
+
+
+def test_php_die_inside_function_does_not_fire():
+    assert detect_module_load_abort("php", "<?php\nfunction f(){ die('x'); }\n") is None
+
+
+def test_php_throw_inside_method_does_not_fire():
+    assert detect_module_load_abort(
+        "php", "<?php\nclass C{ function m(){ throw new E(); } }\n") is None
+
+
+def test_php_conditional_die_does_not_fire():
+    # ``if ($x) die();`` — the die follows ``)`` so it is not statement-initial.
+    assert detect_module_load_abort("php", "<?php\nif ($x) die('x');\n") is None
+
+
+def test_php_die_in_string_does_not_fire():
+    assert detect_module_load_abort("php", "<?php\n$s = 'die()';\nfunction f(){}\n") is None
+
+
+def test_php_exit_method_call_does_not_fire():
+    # ``$o->exit()`` is a method call, not the language construct.
+    assert detect_module_load_abort("php", "<?php\n$o->exit();\nfunction f(){}\n") is None
+
+
+# ---------------------------------------------------------------------------
+# Ruby — column-0 unconditional raise / abort / exit / fail aborts require.
+# ---------------------------------------------------------------------------
+
+
+def test_ruby_top_level_raise_fires():
+    r = detect_module_load_abort("ruby", "raise 'disabled'\nclass C\n  def m; end\nend\n")
+    assert r is not None and r.line == 1 and r.summary == "raise"
+
+
+def test_ruby_abort_after_oneliner_def_fires():
+    # A one-liner ``def`` before the abort must not leave nesting stuck at 1.
+    r = detect_module_load_abort("ruby", "def early; 1; end\nabort 'no'\ndef late; end\n")
+    assert r is not None and r.line == 2 and r.summary == "abort"
+
+
+def test_ruby_raise_inside_def_does_not_fire():
+    assert detect_module_load_abort("ruby", "def f\n  raise 'x'\nend\n") is None
+
+
+def test_ruby_raise_inside_class_method_does_not_fire():
+    assert detect_module_load_abort(
+        "ruby", "class C\n  def m\n    raise 'x'\n  end\nend\n") is None
+
+
+def test_ruby_conditional_raise_modifier_does_not_fire():
+    assert detect_module_load_abort("ruby", "raise 'x' if broken?\n") is None
+
+
+def test_ruby_raise_inside_if_block_does_not_fire():
+    assert detect_module_load_abort("ruby", "if cond\n  raise 'x'\nend\n") is None
+
+
+def test_ruby_bare_raise_does_not_fire():
+    # Bare ``raise`` (re-raise) has no argument — not a module-abort signal.
+    assert detect_module_load_abort("ruby", "raise\n") is None
+
+
+# ---------------------------------------------------------------------------
 # Cross-cutting
 # ---------------------------------------------------------------------------
 
@@ -257,9 +340,10 @@ def test_empty_content_returns_none():
 
 
 def test_unwired_language_returns_none():
-    # Ruby has a call-graph extractor but no abort detector — must
-    # degrade gracefully (no false "loadable" claim, just no signal).
-    assert detect_module_load_abort("ruby", "raise 'x'\n") is None
+    # Java has a call-graph extractor but no abort detector (no top-level
+    # execution model) — must degrade gracefully (no signal, not a crash).
+    assert detect_module_load_abort(
+        "java", "class X { static { throw new RuntimeException(); } }\n") is None
 
 
 def test_clean_python_file_returns_none():


### PR DESCRIPTION
FN-safe per-language gap closures (audit batch 2):

- Ruby/PHP module_aborts: the sound, hard-suppressing dead witness was wired for py/js/ts/go/rust only. Both run top-level code on require/include, so an unconditional file-scope abort kills everything below it. PHP: throw new/die/ exit via brace-depth + a statement-initial gate (so `if(x)die()` is never flagged) + tag-strip. Ruby: column-0 unconditional raise/abort/exit/fail at keyword-nesting depth 0 (one-liner def…end handled; modifier and bare-raise forms excluded). Conservative by design — a false positive would suppress live code, so ambiguous cases under-detect.

- Framework-entry breadth (convention/base-class, not decorators which are already covered): Python += Django BaseCommand/mgmt commands, DRF Serializer/permissions/auth, Form/ModelForm, ModelAdmin/inlines/ MiddlewareMixin, Celery Task. C#: capture the base_list into class_attributes (extractor only recorded [attributes] before) + ControllerBase/Hub/ BackgroundService/IHostedService stereotypes. Java/Ruby already comprehensive.

All additive/conservative → FN-safe. Verified on the stdlib ast path too. 1098 inventory + SCA tests pass.