### PR TITLE
feat(sca): typosquat denylist + self-feeding curation

### DIFF
--- a/.github/workflows/refresh-sca-data.yml
+++ b/.github/workflows/refresh-sca-data.yml
@@ -79,6 +79,23 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Typosquat candidate nudge
+        if: steps.diff.outputs.changed == 'true'
+        # Mechanical, LLM-FREE (CI has no LLM, and the data-refresh path must
+        # not depend on one). Lists near-names that rode the refreshed feeds in
+        # and are not yet classified — present in neither the denylist nor the
+        # reviewed-legit list. Written to RUNNER_TEMP (never committed to the
+        # repo) and appended to the PR body below as a triage nudge. The actual
+        # judgement — fetch evidence, LLM-triage, gate — runs OPERATOR-side via
+        # ``raptor-sca triage`` when reviewing this PR, where an LLM is
+        # available. continue-on-error: a flaky popularity feed must surface the
+        # data refresh, not redden it over an advisory nudge.
+        continue-on-error: true
+        run: |
+          set -eu
+          python -m packages.sca.supply_chain.typosquat_audit \
+            --format markdown --out "$RUNNER_TEMP/typosquat-candidates.md"
+
       - name: Commit + push to refresh branch
         if: steps.diff.outputs.changed == 'true'
         env:
@@ -106,8 +123,14 @@ jobs:
           # --force-with-lease (not --force): refuses the push if the
           # remote branch moved since our fetch — e.g. an operator amended
           # the open auto-PR — rather than clobbering it. Fetch first to
-          # seed the lease baseline; || true for the first run (no branch).
-          git fetch origin "$BRANCH" || true
+          # seed the lease baseline, but only when the branch already exists
+          # remotely: a bare fetch of a missing ref prints a misleading
+          # ``fatal: couldn't find remote ref`` on the first run (or after
+          # the prior auto-PR branch was merged + deleted). When the guard
+          # skips the fetch, the push simply creates the branch.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git fetch origin "$BRANCH" || true   # tolerate a transient blip
+          fi
           git push --force-with-lease origin "$BRANCH"
 
       - name: Create or update PR
@@ -134,6 +157,12 @@ jobs:
           - Tests pass.
           EOF
           )
+          # Append the typosquat candidate nudge if the audit produced one.
+          # The file lives in RUNNER_TEMP (not the repo); empty = no candidates.
+          CAND="$RUNNER_TEMP/typosquat-candidates.md"
+          if [ -s "$CAND" ]; then
+            BODY="$BODY"$'\n\n---\n\n'"$(cat "$CAND")"
+          fi
           if ! gh pr create \
                 --base main \
                 --head "$BRANCH" \

--- a/packages/sca/cli.py
+++ b/packages/sca/cli.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 SUBCOMMANDS = ("fix", "check", "upgrade", "diff",
                "verify", "health", "purl", "render",
                "clean-cache", "dt-push", "suppress", "bump",
-               "fingerprint")
+               "fingerprint", "triage")
 _SUBCOMMANDS = SUBCOMMANDS  # backcompat alias for internal callers
 
 
@@ -118,6 +118,9 @@ def _dispatch(subcommand: str, argv: List[str]) -> int:
     if subcommand == "fingerprint":
         from . import fingerprint_cli
         return fingerprint_cli.main(argv)
+    if subcommand == "triage":
+        from .supply_chain import typosquat_audit
+        return typosquat_audit.main(argv)
     print(f"raptor-sca: unknown subcommand {subcommand!r}", file=sys.stderr)
     return 2
 

--- a/packages/sca/data/typosquat_denylist.json
+++ b/packages/sca/data/typosquat_denylist.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Hand-vetted typosquat / confusable package names that must NOT be trusted even when they appear in the bundled popularity feeds (data/popular/<eco>.json). The popularity feeds are download/dependent rank lists; a name that ranks high enough can slip in (e.g. npm 'loadash' at rank ~3851, one edit from 'lodash') and, once trusted by an exact match, can never be flagged. Subtracting it here forces the detector to evaluate it as distance-1 from its near-twin. CURATION RULE: only add a name a human has confirmed is a confusable near-miss of a more-popular package (not an independent legitimate project). This is deliberately manual: automated rank/edit-distance heuristics were validated as ~10:1 false-positive (preact, enquirer, jslint, boto, pipx are all legit near-names), and OSV MAL- records cover legit packages with compromised versions (litellm, node-ipc), so neither is safe to auto-apply. Keys are ecosystem names matching data/popular/<eco>.json; values are lowercased names.",
+  "npm": [
+    "loadash"
+  ],
+  "PyPI": [],
+  "Cargo": [],
+  "Packagist": []
+}

--- a/packages/sca/data/typosquat_reviewed_legit.json
+++ b/packages/sca/data/typosquat_reviewed_legit.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Confirmed-legitimate near-name packages: real, independent projects whose names are one edit from a more-popular package (npm 'preact' vs 'react'). They are NOT typosquats and stay trusted in the popularity feeds. This file is NOT read by the detector (legit names are already trusted by popular-list membership) — it exists only to SUPPRESS these names from the typosquat-curation candidate queue (see typosquat_audit.py) so the recurring review delta de-noises to near-empty and a genuinely-new near-name stands out. Counterpart to typosquat_denylist.json (confirmed squats, which the detector DOES subtract). Adding here is FP-safe (changes nothing about trust); adding to the denylist is the FP-creating action and stays human-gated. Keys are ecosystem names; values map name -> {near_twin, decided_by, date, note}. Seeded from a 2026-05-28 audit of the npm top-5000 (all distance-1 candidates were legit except 'loadash', which is on the denylist).",
+  "npm": {
+    "preact": {"near_twin": "react", "decided_by": "human", "date": "2026-05-28", "note": "distinct project: fast 3kB React alternative"},
+    "enquirer": {"near_twin": "inquirer", "decided_by": "human", "date": "2026-05-28", "note": "distinct, widely-used prompt library"},
+    "gaxios": {"near_twin": "axios", "decided_by": "human", "date": "2026-05-28", "note": "Google's HTTP client (google-gax); real project"},
+    "mquery": {"near_twin": "jquery", "decided_by": "human", "date": "2026-05-28", "note": "MongoDB query builder; unrelated to jquery"},
+    "useragent": {"near_twin": "superagent", "decided_by": "human", "date": "2026-05-28", "note": "UA-string parser; unrelated to the HTTP client"},
+    "vasync": {"near_twin": "async", "decided_by": "human", "date": "2026-05-28", "note": "Joyent's async-control library; real project"},
+    "inherit": {"near_twin": "inherits", "decided_by": "human", "date": "2026-05-28", "note": "real OOP-inheritance helper, distinct from inherits"},
+    "rambda": {"near_twin": "ramda", "decided_by": "human", "date": "2026-05-28", "note": "deliberate lightweight ramda alternative; real project"},
+    "jslint": {"near_twin": "eslint", "decided_by": "human", "date": "2026-05-28", "note": "Crockford's original linter; predates eslint"},
+    "reqwest": {"near_twin": "request", "decided_by": "human", "date": "2026-05-28", "note": "real AJAX library; deliberate pun name"}
+  },
+  "PyPI": {},
+  "Cargo": {},
+  "Packagist": {}
+}

--- a/packages/sca/refresh_typosquat_lists.py
+++ b/packages/sca/refresh_typosquat_lists.py
@@ -136,7 +136,10 @@ def _get_json(
     raise last
 
 
-def fetch_pypi(http: HttpClient, top_n: int) -> List[str]:
+def _fetch_pypi_ranked(http: HttpClient, top_n: int) -> List[str]:
+    """Rank-ordered (most-popular-first) PyPI names — the order the typosquat
+    curation audit needs (rank is the signal it reasons about). May contain
+    duplicates; callers that want the canonical bundle ``sorted(set(...))`` it."""
     data = _get_json(http, _HUGOVK_TOP_PYPI)
     rows = data.get("rows") or data.get("packages") or []
     names: List[str] = []
@@ -146,10 +149,15 @@ def fetch_pypi(http: HttpClient, top_n: int) -> List[str]:
         n = r.get("project") or r.get("name")
         if isinstance(n, str) and n:
             names.append(n.lower())
-    return sorted(set(names))
+    return names
 
 
-def fetch_npm(http: HttpClient, top_n: int) -> List[str]:
+def fetch_pypi(http: HttpClient, top_n: int) -> List[str]:
+    return sorted(set(_fetch_pypi_ranked(http, top_n)))
+
+
+def _fetch_npm_ranked(http: HttpClient, top_n: int) -> List[str]:
+    """Rank-ordered (most-depended-upon-first) npm names. See _fetch_pypi_ranked."""
     data = _get_json(http, _ANVAKA_NPM_RANK, max_bytes=_NPM_MAX_BYTES)
     # The anvaka npmrank format is ``{"tags": {...}, "rank": {name: score}}``
     # where ``score`` is a (stringified) pagerank-style weight over the
@@ -168,10 +176,14 @@ def fetch_npm(http: HttpClient, top_n: int) -> List[str]:
         except (TypeError, ValueError):
             continue
     scored.sort(key=lambda ns: ns[1], reverse=True)
-    return sorted({n for n, _ in scored[:top_n]})
+    return [n for n, _ in scored[:top_n]]
 
 
-def fetch_crates(
+def fetch_npm(http: HttpClient, top_n: int) -> List[str]:
+    return sorted(set(_fetch_npm_ranked(http, top_n)))
+
+
+def _fetch_crates_ranked(
     http: HttpClient, top_n: int, *, per_page: int = 100,
 ) -> List[str]:
     """crates.io paginates ``per_page`` (max 100) per request. Fetch
@@ -179,7 +191,7 @@ def fetch_crates(
     rate-limited; honour rate limits via ``retries=`` (the proxy +
     backoff path handles 429 transparently). ``per_page`` is a
     parameter so tests can exercise pagination with small fixtures.
-    """
+    Returns names in download-rank order (see _fetch_pypi_ranked)."""
     names: List[str] = []
     pages = (top_n + per_page - 1) // per_page
     for page in range(1, pages + 1):
@@ -199,11 +211,18 @@ def fetch_crates(
                 names.append(n.lower())
         if len(crates) < per_page:
             break
-    return sorted(set(names))[:top_n]
+    return names
 
 
-def fetch_packagist(http: HttpClient, top_n: int) -> List[str]:
-    """Packagist's popular endpoint is paginated; ``page=N`` query param."""
+def fetch_crates(
+    http: HttpClient, top_n: int, *, per_page: int = 100,
+) -> List[str]:
+    return sorted(set(_fetch_crates_ranked(http, top_n, per_page=per_page)))[:top_n]
+
+
+def _fetch_packagist_ranked(http: HttpClient, top_n: int) -> List[str]:
+    """Packagist's popular endpoint is paginated; ``page=N`` query param.
+    Returns names in popularity-rank order (see _fetch_pypi_ranked)."""
     names: List[str] = []
     page = 1
     while len(names) < top_n:
@@ -226,7 +245,11 @@ def fetch_packagist(http: HttpClient, top_n: int) -> List[str]:
         page += 1
         if page > 200:               # safety: 200 pages × 12/pg ≈ 2400
             break
-    return sorted(set(names))[:top_n]
+    return names
+
+
+def fetch_packagist(http: HttpClient, top_n: int) -> List[str]:
+    return sorted(set(_fetch_packagist_ranked(http, top_n)))[:top_n]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/sca/supply_chain/tests/test_typosquat_audit.py
+++ b/packages/sca/supply_chain/tests/test_typosquat_audit.py
@@ -1,0 +1,186 @@
+"""Tests for the typosquat-denylist candidate generator (Stages 1–2).
+
+Mechanical, LLM-free, offline. Stage 1 (`generate_candidates`) is the validated
+rank+distance heuristic emitting candidates; Stage 2 (`pending_candidates`)
+subtracts the denylist + reviewed-legit so the delta de-noises.
+"""
+
+from __future__ import annotations
+
+import json
+
+from packages.sca.supply_chain import typosquat_audit as A
+from packages.sca.supply_chain.typosquat_audit import (
+    Candidate,
+    _load_name_set,
+    audit,
+    generate_candidates,
+    pending_candidates,
+    render_markdown,
+    render_text,
+)
+
+_FILL = [f"pkg{i}" for i in range(60)]   # pad past the default min_pos=50
+
+
+# ---------------------------------------------------------------------------
+# Stage 1 — generate_candidates
+# ---------------------------------------------------------------------------
+
+def test_flags_distance1_lower_ranked_twin():
+    ranked = ["lodash"] + _FILL + ["loadash"]
+    cands = generate_candidates(ranked)
+    c = next((c for c in cands if c.name == "loadash"), None)
+    assert c is not None
+    assert c.near_twin == "lodash" and c.distance == 1
+    assert c.twin_rank == 1 and c.rank == len(ranked)
+
+
+def test_short_names_skipped_by_default_min_len():
+    # 3-char near-pair (abc/abd) — below default min_len=6, so not a candidate
+    # (short names' distance-1 neighbours are dominated by natural collisions).
+    ranked = ["abc"] + _FILL + ["abd"]
+    assert generate_candidates(ranked) == []
+
+
+def test_min_len_is_tunable():
+    ranked = ["abcdef"] + _FILL + ["abcxef"]
+    assert any(c.name == "abcxef" for c in generate_candidates(ranked, min_len=6))
+    assert generate_candidates(ranked, min_len=7) == []
+
+
+def test_distance2_not_flagged():
+    ranked = ["abcdef"] + _FILL + ["abxxef"]   # two substitutions
+    assert generate_candidates(ranked) == []
+
+
+def test_similar_rank_pair_not_flagged():
+    # Two near-names at adjacent ranks: the twin does not out-rank by `ratio`,
+    # so neither is a candidate (the rule that spares legit color/colors pairs).
+    ranked = _FILL + ["abcdef", "abcdeg"]
+    assert generate_candidates(ranked) == []
+
+
+def test_top_names_never_flagged():
+    # A near-twin inside the protected top-min_pos window is not a candidate.
+    ranked = ["lodash", "loadash"] + _FILL
+    assert not any(c.name == "loadash" for c in generate_candidates(ranked))
+
+
+def test_ratio_zero_does_not_crash():
+    # Guarded with max(1, ratio); must not ZeroDivisionError.
+    generate_candidates(["abcdef"] + _FILL + ["abcdeg"], ratio=0)
+
+
+# ---------------------------------------------------------------------------
+# loader — _load_name_set (tolerant of both file shapes)
+# ---------------------------------------------------------------------------
+
+def test_load_name_set_bare_list(tmp_path):
+    p = tmp_path / "d.json"
+    p.write_text(json.dumps({"npm": ["loadash", "EvilPkg"]}))
+    assert _load_name_set(p, "npm") == {"loadash", "evilpkg"}
+    assert _load_name_set(p, "PyPI") == set()
+
+
+def test_load_name_set_enriched_dict_and_comment(tmp_path):
+    p = tmp_path / "d.json"
+    p.write_text(json.dumps({"_comment": "x",
+                             "npm": {"LoAdAsh": {"near_twin": "lodash"}}}))
+    assert _load_name_set(p, "npm") == {"loadash"}
+
+
+def test_load_name_set_missing_or_malformed(tmp_path):
+    assert _load_name_set(tmp_path / "nope.json", "npm") == set()
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    assert _load_name_set(bad, "npm") == set()
+
+
+# ---------------------------------------------------------------------------
+# Stage 2 — pending_candidates
+# ---------------------------------------------------------------------------
+
+def test_pending_subtracts_denylist_and_reviewed_legit(tmp_path):
+    dl = tmp_path / "dl.json"
+    dl.write_text(json.dumps({"npm": ["loadash"]}))
+    rl = tmp_path / "rl.json"
+    rl.write_text(json.dumps({"npm": {"preact": {"near_twin": "react"}}}))
+    ranked = (["lodash", "react", "express"] + _FILL
+              + ["loadash", "preact", "expresss"])
+    pending = pending_candidates(ranked, "npm",
+                                 denylist_path=dl, reviewed_legit_path=rl)
+    # loadash → denylist, preact → reviewed_legit; only the unclassified
+    # near-name survives as pending.
+    assert {c.name for c in pending} == {"expresss"}
+
+
+def test_pending_against_bundled_files_filters_loadash():
+    # The shipped denylist carries loadash; pending must not re-surface it.
+    ranked = ["lodash"] + _FILL + ["loadash"]
+    assert not any(c.name == "loadash"
+                   for c in pending_candidates(ranked, "npm"))
+
+
+# ---------------------------------------------------------------------------
+# audit() — fetch + delta per ecosystem
+# ---------------------------------------------------------------------------
+
+def test_audit_uses_stub_feed_and_bundled_denylist(monkeypatch):
+    ranked = ["express", "lodash"] + _FILL + ["expresss", "loadash"]
+    monkeypatch.setitem(A._RANKED_FETCHERS, "npm",
+                        lambda http, top_n: ranked)
+    res = audit(object(), ["npm"])
+    names = {c.name for c in res["npm"]}
+    assert "expresss" in names          # new near-name → pending
+    assert "loadash" not in names       # bundled denylist filters it
+
+
+def test_audit_fail_soft_on_fetch_error(monkeypatch):
+    def boom(http, top_n):
+        raise RuntimeError("feed down")
+    monkeypatch.setitem(A._RANKED_FETCHERS, "npm", boom)
+    assert audit(object(), ["npm"]) == {}     # skipped, not raised
+
+
+# ---------------------------------------------------------------------------
+# rendering
+# ---------------------------------------------------------------------------
+
+def test_render_empty_is_blank_markdown_and_none_text():
+    assert render_markdown({"npm": []}) == ""
+    assert "No pending" in render_text({"npm": []})
+
+
+def test_render_markdown_lists_candidate():
+    md = render_markdown({"npm": [Candidate("expresss", "express", 3000, 5, 1)]})
+    assert "expresss" in md and "express" in md
+    assert "pending triage" in md
+
+
+def test_main_writes_report_and_empty_skips(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        A, "audit",
+        lambda *a, **k: {"npm": [Candidate("expresss", "express", 3000, 5, 1)]})
+    out = tmp_path / "r.md"
+    assert A.main(["--format", "markdown", "--out", str(out)]) == 0
+    assert "expresss" in out.read_text()
+
+    monkeypatch.setattr(A, "audit", lambda *a, **k: {"npm": []})
+    out2 = tmp_path / "r2.md"
+    A.main(["--format", "markdown", "--out", str(out2)])
+    assert out2.read_text() == ""        # empty → workflow's [ -s ] skips nudge
+
+
+# ---------------------------------------------------------------------------
+# shipped data-file guards
+# ---------------------------------------------------------------------------
+
+def test_bundled_reviewed_legit_valid_and_seeded():
+    raw = json.loads(A._REVIEWED_LEGIT_PATH.read_text(encoding="utf-8"))
+    assert "preact" in raw.get("npm", {})
+
+
+def test_triage_subcommand_registered():
+    from packages.sca.cli import SUBCOMMANDS
+    assert "triage" in SUBCOMMANDS

--- a/packages/sca/supply_chain/tests/test_typosquat_denylist.py
+++ b/packages/sca/supply_chain/tests/test_typosquat_denylist.py
@@ -1,0 +1,129 @@
+"""Typosquat denylist: hand-vetted confusable names subtracted from the
+trusted popular list at load time.
+
+The bundled popularity feeds (``data/popular/<eco>.json``) are download/
+dependent rank lists; a name one edit from a far-more-popular package (npm
+``loadash`` vs ``lodash``) can rank high enough to slip in, and once it sits in
+the trusted list an exact match short-circuits the scan so it can never be
+flagged. ``data/typosquat_denylist.json`` subtracts such hand-confirmed names
+at the point of trust, with zero false positives by construction (only names a
+human vetted are removed — legit near-names like ``preact``/``litellm`` stay).
+
+These tests exercise the REAL ``_load_popular`` (the shared autouse fixture in
+``packages/sca/conftest.py`` swaps it for a curated stub, which would bypass the
+subtraction), so they capture and restore it explicitly.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import pytest
+
+from packages.sca.models import Dependency
+from packages.sca.supply_chain import typosquat
+
+# Captured at import (collection) time, before any per-test autouse fixture
+# replaces ``_load_popular`` with the curated stub. The denylist subtraction
+# lives inside the real function, so the integration tests need it back.
+_REAL_LOAD_POPULAR = typosquat._load_popular
+
+
+def _dep(name: str, eco: str = "npm") -> Dependency:
+    kw = {}
+    for f in dataclasses.fields(Dependency):
+        if f.name == "name":
+            kw[f.name] = name
+        elif f.name == "ecosystem":
+            kw[f.name] = eco
+        elif f.name == "direct":
+            kw[f.name] = True
+        elif f.name == "version":
+            kw[f.name] = "1.0.0"
+        elif (f.default is not dataclasses.MISSING
+              or f.default_factory is not dataclasses.MISSING):
+            pass
+        else:
+            kw[f.name] = None
+    return Dependency(**kw)
+
+
+def _reset_caches() -> None:
+    for c in (typosquat._POPULAR_BY_ECO, typosquat._POPULAR_SET,
+              typosquat._POPULAR_BY_LEN, typosquat._DENYLIST_BY_ECO):
+        c.clear()
+    typosquat._DENYLIST_RAW = None
+
+
+@pytest.fixture
+def real_loader(tmp_path, monkeypatch):
+    """Restore the real ``_load_popular`` and point the data dir + denylist at
+    tmp files. Clears every cache on entry and exit so nothing leaks."""
+    pop = tmp_path / "popular"
+    pop.mkdir()
+    monkeypatch.setattr(typosquat, "_DATA_DIR", pop)
+    monkeypatch.setattr(typosquat, "_DENYLIST_PATH",
+                        tmp_path / "typosquat_denylist.json")
+    monkeypatch.setattr(typosquat, "_load_popular", _REAL_LOAD_POPULAR)
+    _reset_caches()
+    yield tmp_path
+    _reset_caches()
+
+
+def _write(tmp, popular, denylist=None):
+    (tmp / "popular" / "npm.json").write_text(json.dumps(popular))
+    if denylist is not None:
+        (tmp / "typosquat_denylist.json").write_text(json.dumps(denylist))
+    _reset_caches()
+
+
+def test_denylisted_name_is_flagged_not_trusted(real_loader):
+    # loadash rode the popularity feed in; denylisting it forces the detector
+    # to evaluate it as distance-1 from lodash instead of trusting the match.
+    _write(real_loader, ["lodash", "loadash"], {"npm": ["loadash"]})
+    res = typosquat.scan_deps([_dep("loadash")])
+    assert res, "denylisted loadash should be flagged"
+    assert res[0].nearest_popular == "lodash"
+    assert res[0].distance == 1
+
+
+def test_non_denylisted_near_name_stays_trusted(real_loader):
+    # preact is a legitimate package one edit from react and is NOT denylisted
+    # → it remains a trusted exact-match (no false positive).
+    _write(real_loader, ["react", "preact"], {"npm": ["loadash"]})
+    assert typosquat.scan_deps([_dep("preact")]) == []
+
+
+def test_denylist_only_affects_its_ecosystem(real_loader):
+    # The entry is filed under PyPI, so npm's loadash is untouched.
+    _write(real_loader, ["lodash", "loadash"], {"PyPI": ["loadash"]})
+    assert typosquat.scan_deps([_dep("loadash")]) == []
+
+
+def test_missing_denylist_file_is_noop(real_loader):
+    # No denylist file at all → nothing subtracted, loadash stays trusted.
+    _write(real_loader, ["lodash", "loadash"], denylist=None)
+    assert typosquat.scan_deps([_dep("loadash")]) == []
+
+
+def test_malformed_denylist_degrades_to_empty(real_loader):
+    _write(real_loader, ["lodash", "loadash"], denylist=None)
+    (real_loader / "typosquat_denylist.json").write_text("{not json")
+    _reset_caches()
+    # Malformed file must not raise; loadash simply stays trusted.
+    assert typosquat.scan_deps([_dep("loadash")]) == []
+    assert typosquat._load_denylist("npm") == set()
+
+
+def test_load_denylist_lowercases_and_scopes(real_loader):
+    _write(real_loader, [], {"npm": ["LoAdAsh"], "Cargo": ["serdex"]})
+    assert typosquat._load_denylist("npm") == {"loadash"}      # lowercased
+    assert typosquat._load_denylist("Cargo") == {"serdex"}
+    assert typosquat._load_denylist("PyPI") == set()           # unknown → empty
+
+
+def test_bundled_denylist_contains_loadash():
+    """Regression guard on the shipped data file (real _DENYLIST_PATH)."""
+    raw = json.loads(typosquat._DENYLIST_PATH.read_text(encoding="utf-8"))
+    assert "loadash" in {n.lower() for n in raw.get("npm", [])}

--- a/packages/sca/supply_chain/typosquat.py
+++ b/packages/sca/supply_chain/typosquat.py
@@ -34,6 +34,19 @@ logger = logging.getLogger(__name__)
 
 _DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "popular"
 
+# Hand-vetted typosquat / confusable names to subtract from the popular feeds
+# before they become a trusted exact-match. The popularity feeds occasionally
+# carry a name that is one edit from a far-more-popular package (npm ``loadash``
+# vs ``lodash``); once it sits in the trusted list an exact match short-circuits
+# the scan and it can never be flagged. This denylist is the *sound* fix:
+# automated rank/edit-distance heuristics were validated at ~10:1 false-positive
+# (``preact``/``enquirer``/``jslint``/``boto``/``pipx`` are all legitimate
+# near-names — lower rank does NOT mean "typosquat"), and OSV ``MAL-`` records
+# cover legit packages with compromised *versions* (``litellm``, ``node-ipc``),
+# so neither is safe to auto-apply. Only hand-confirmed names go here → zero
+# false positives by construction.
+_DENYLIST_PATH = _DATA_DIR.parent / "typosquat_denylist.json"
+
 # Distances above this are not interesting; below it we always flag
 # (with severity scaled by distance).
 _MAX_DISTANCE = 2
@@ -55,6 +68,10 @@ _POPULAR_BY_LEN: Dict[str, Dict[int, List[str]]] = {}
 # Set view of the popular list for the O(1) "is it popular" test
 # in ``_check_one`` (was a list ``in`` linear scan pre-fix).
 _POPULAR_SET: Dict[str, set] = {}
+# Per-ecosystem denylist sets, loaded once from ``_DENYLIST_PATH``.
+_DENYLIST_BY_ECO: Dict[str, set] = {}
+# Sentinel so a missing/!exists denylist file is loaded (and logged) once.
+_DENYLIST_RAW: Optional[Dict[str, set]] = None
 
 
 @dataclass(frozen=True)
@@ -180,9 +197,50 @@ def _load_popular(ecosystem: str) -> List[str]:
     if not isinstance(data, list):
         _POPULAR_BY_ECO[ecosystem] = []
         return []
-    cleaned = [n.lower() for n in data if isinstance(n, str)]
+    # Subtract the hand-vetted denylist so a confusable name that rode the
+    # popularity feed into the list (npm ``loadash``) is no longer a trusted
+    # exact-match — the detector then evaluates it as distance-1 from its
+    # near-twin. See ``_DENYLIST_PATH``.
+    denied = _load_denylist(ecosystem)
+    cleaned = [n.lower() for n in data
+               if isinstance(n, str) and n.lower() not in denied]
     _POPULAR_BY_ECO[ecosystem] = cleaned
     return cleaned
+
+
+def _load_denylist(ecosystem: str) -> set:
+    """Return the lowercased denylist name-set for ``ecosystem`` (empty if the
+    file is absent, malformed, or has no entry for it). Loaded once and cached;
+    a missing/malformed file degrades to "no denylist" (never raises)."""
+    global _DENYLIST_RAW
+    if _DENYLIST_RAW is None:
+        _DENYLIST_RAW = {}
+        try:
+            raw = _json.loads(_DENYLIST_PATH.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            raw = {}
+        except (OSError, _json.JSONDecodeError) as e:
+            logger.warning("sca.supply_chain.typosquat: failed to load "
+                           "denylist %s: %s", _DENYLIST_PATH, e)
+            raw = {}
+        if isinstance(raw, dict):
+            for eco, names in raw.items():
+                # Two accepted shapes per ecosystem: a bare ``[name, ...]``
+                # list, or an enriched ``{name: {provenance...}}`` map (the
+                # curation pipeline records who/when/why). Either way we only
+                # need the name set here. A ``_comment`` string key is neither
+                # and is skipped.
+                if isinstance(names, list):
+                    _DENYLIST_RAW[eco] = {
+                        n.lower() for n in names if isinstance(n, str)}
+                elif isinstance(names, dict):
+                    _DENYLIST_RAW[eco] = {
+                        k.lower() for k in names if isinstance(k, str)}
+    cached = _DENYLIST_BY_ECO.get(ecosystem)
+    if cached is None:
+        cached = _DENYLIST_RAW.get(ecosystem, set())
+        _DENYLIST_BY_ECO[ecosystem] = cached
+    return cached
 
 
 def _popular_set(ecosystem: str) -> set:

--- a/packages/sca/supply_chain/typosquat_audit.py
+++ b/packages/sca/supply_chain/typosquat_audit.py
@@ -1,0 +1,280 @@
+"""Typosquat-denylist curation: candidate generation (Stages 1–2).
+
+The denylist (`data/typosquat_denylist.json`) is the sound fix for typosquats
+that ride the popularity feeds into the trusted list (npm ``loadash``), but it
+is hand-curated — so it needs a *discovery* loop to stay current without
+sacrificing the property that makes it sound (every entry is confirmed → zero
+false positives). This module is the mechanical, **LLM-free** half of that loop
+(see ``~/design/typosquat-denylist-curation.md``):
+
+  Stage 1 — generate near-name candidates from the rank-ordered feeds (a name
+            one edit from a *much-higher-ranked* name is a candidate). This is
+            the rank+distance heuristic — validated as ~10:1 false-positive for
+            *auto-dropping*, but exactly right for *generating candidates* a
+            human/LLM then triages.
+  Stage 2 — subtract the denylist (confirmed squats) and the reviewed-legit list
+            (confirmed-legit near-names, ``data/typosquat_reviewed_legit.json``)
+            so the recurring delta de-noises to ~empty and a genuinely-new
+            near-name stands out.
+
+Runs in two homes, both LLM-free:
+  - the weekly ``refresh-sca-data`` workflow, which has the live rank-ordered
+    feeds and emits the pending delta as a nudge in the refresh PR body;
+  - the operator command ``raptor-sca triage``, run when reviewing that PR.
+
+The judgement step (Stage 3 evidence + Stage A LLM triage + the gate) is the
+*next* build and runs operator-side where an LLM is available — never in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json as _json
+import logging
+import sys
+from pathlib import Path
+from typing import Dict, List, NamedTuple, Optional, Sequence
+
+from core.http import HttpClient
+from core.http.urllib_backend import UrllibClient
+
+from ..refresh_typosquat_lists import (
+    _DEFAULT_TOP_N,
+    _fetch_crates_ranked,
+    _fetch_npm_ranked,
+    _fetch_packagist_ranked,
+    _fetch_pypi_ranked,
+)
+from .typosquat import _DENYLIST_PATH, _MAX_DISTANCE, _damerau_levenshtein
+
+logger = logging.getLogger(__name__)
+
+_REVIEWED_LEGIT_PATH = _DENYLIST_PATH.parent / "typosquat_reviewed_legit.json"
+
+# Candidate-generation knobs (validated 2026-05-28 against live npm/PyPI feeds).
+# A name P is a candidate when a name Q ranked >= ``_RATIO``x higher is within
+# Damerau distance 1. The ratio (not a fixed cutoff) keeps similar-rank legit
+# pairs out; ``_MIN_POS`` never flags the very top; ``_MIN_LEN`` skips short
+# names, whose distance-1 neighbours are dominated by natural collisions
+# (``fs``/``ms``, ``id``/``six``) rather than typosquats — npm at len>=6 yielded
+# 15 candidates (the real one, ``loadash``, plus legit near-names) vs 88 at
+# len>=0. All three are tunable from the CLI.
+_RATIO = 20
+_MIN_POS = 50
+_MIN_LEN = 6
+
+# eco display-name → rank-ordered fetcher. Keys match the popular-list and
+# denylist/reviewed-legit ecosystem keys.
+_RANKED_FETCHERS = {
+    "PyPI": _fetch_pypi_ranked,
+    "npm": _fetch_npm_ranked,
+    "Cargo": _fetch_crates_ranked,
+    "Packagist": _fetch_packagist_ranked,
+}
+
+
+class Candidate(NamedTuple):
+    name: str
+    near_twin: str
+    rank: int        # 1-based rank of the candidate in the feed
+    twin_rank: int   # 1-based rank of the much-more-popular near-twin
+    distance: int
+
+
+def generate_candidates(
+    ranked: Sequence[str],
+    *,
+    ratio: int = _RATIO,
+    min_pos: int = _MIN_POS,
+    min_len: int = _MIN_LEN,
+) -> List[Candidate]:
+    """Stage 1. ``ranked`` is most-popular-first. Emit a candidate for each name
+    that is Damerau distance ≤1 from a name ranked at least ``ratio``× higher.
+    Uses the detector's own metric so build-time and scan-time agree."""
+    ratio = max(1, ratio)
+    # Dedup, preserving rank order (first occurrence = best rank).
+    seen: set = set()
+    names: List[str] = []
+    for n in ranked:
+        if n not in seen:
+            seen.add(n)
+            names.append(n)
+
+    out: List[Candidate] = []
+    # references that out-rank P by >= ratio, bucketed by length, with their rank
+    ref_by_len: Dict[int, List[tuple]] = {}
+    next_ref = 0
+    for i, p in enumerate(names):
+        cutoff = i // ratio
+        while next_ref < cutoff:
+            q = names[next_ref]
+            ref_by_len.setdefault(len(q), []).append((q, next_ref))
+            next_ref += 1
+        if i < min_pos or len(p) < min_len:
+            continue
+        lp = len(p)
+        twin: Optional[str] = None
+        twin_idx = -1
+        for length in (lp - 1, lp, lp + 1):
+            for q, qi in ref_by_len.get(length, ()):
+                if _damerau_levenshtein(p, q, _MAX_DISTANCE) <= 1:
+                    twin, twin_idx = q, qi
+                    break
+            if twin is not None:
+                break
+        if twin is not None:
+            out.append(Candidate(
+                name=p, near_twin=twin, rank=i + 1, twin_rank=twin_idx + 1,
+                distance=_damerau_levenshtein(p, twin, _MAX_DISTANCE)))
+    return out
+
+
+def _load_name_set(path: Path, ecosystem: str) -> set:
+    """Lowercased name set for ``ecosystem`` from a curation file. Tolerant of
+    both the bare ``{eco: [name, ...]}`` and enriched ``{eco: {name: {...}}}``
+    shapes; a missing/malformed file (or absent ecosystem) → empty set."""
+    try:
+        raw = _json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, _json.JSONDecodeError):
+        return set()
+    if not isinstance(raw, dict):
+        return set()
+    entry = raw.get(ecosystem)
+    if isinstance(entry, list):
+        return {n.lower() for n in entry if isinstance(n, str)}
+    if isinstance(entry, dict):
+        return {k.lower() for k in entry if isinstance(k, str)}
+    return set()
+
+
+def pending_candidates(
+    ranked: Sequence[str],
+    ecosystem: str,
+    *,
+    denylist_path: Path = _DENYLIST_PATH,
+    reviewed_legit_path: Path = _REVIEWED_LEGIT_PATH,
+    **gen_kwargs,
+) -> List[Candidate]:
+    """Stage 2. Candidates minus already-classified names (denylist ∪
+    reviewed-legit) — the delta a human/LLM still needs to decide."""
+    skip = (_load_name_set(denylist_path, ecosystem)
+            | _load_name_set(reviewed_legit_path, ecosystem))
+    return [c for c in generate_candidates(ranked, **gen_kwargs)
+            if c.name not in skip]
+
+
+def audit(
+    http: HttpClient,
+    ecosystems: Optional[Sequence[str]] = None,
+    *,
+    top_n: int = _DEFAULT_TOP_N,
+    **gen_kwargs,
+) -> Dict[str, List[Candidate]]:
+    """Fetch each ecosystem's rank-ordered feed and return its pending delta.
+    A feed that fails to fetch is logged and skipped (fail-soft)."""
+    ecos = list(ecosystems) if ecosystems else list(_RANKED_FETCHERS)
+    results: Dict[str, List[Candidate]] = {}
+    for eco in ecos:
+        fetch = _RANKED_FETCHERS.get(eco)
+        if fetch is None:
+            logger.warning("no rank feed for ecosystem %r; skipping", eco)
+            continue
+        try:
+            ranked = fetch(http, top_n)
+        except Exception as e:                   # noqa: BLE001
+            logger.warning("%s feed fetch failed: %s", eco, e)
+            continue
+        results[eco] = pending_candidates(ranked, eco, **gen_kwargs)
+    return results
+
+
+def render_markdown(results: Dict[str, List[Candidate]]) -> str:
+    """Markdown for the refresh PR body. Returns ``""`` when nothing is pending
+    (so the workflow can skip the nudge entirely)."""
+    total = sum(len(v) for v in results.values())
+    if total == 0:
+        return ""
+    lines = [
+        f"### ⚠️ {total} new typosquat candidate(s) pending triage",
+        "",
+        "Near-names that rode the popularity feed in and are not yet classified "
+        "(in neither `typosquat_denylist.json` nor `typosquat_reviewed_legit.json`). "
+        "Triage with `raptor-sca triage` (fetches evidence + proposes a verdict); "
+        "confirm squats into the denylist, legit near-names into reviewed-legit.",
+        "",
+    ]
+    for eco in sorted(results):
+        cands = results[eco]
+        if not cands:
+            continue
+        lines.append(f"**{eco}** ({len(cands)}):")
+        lines.append("")
+        lines.append("| candidate | rank | near-twin | twin rank | dist |")
+        lines.append("|---|--:|---|--:|--:|")
+        for c in cands:
+            lines.append(
+                f"| `{c.name}` | {c.rank} | `{c.near_twin}` "
+                f"| {c.twin_rank} | {c.distance} |")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_text(results: Dict[str, List[Candidate]]) -> str:
+    total = sum(len(v) for v in results.values())
+    if total == 0:
+        return "No pending typosquat candidates.\n"
+    lines = [f"{total} pending typosquat candidate(s):"]
+    for eco in sorted(results):
+        for c in results[eco]:
+            lines.append(
+                f"  [{eco}] {c.name} (#{c.rank}) ~ {c.near_twin} "
+                f"(#{c.twin_rank}, dist {c.distance})")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="raptor-sca triage",
+        description=("List typosquat-denylist candidates pending triage: "
+                     "near-names that rode the popularity feeds in and are not "
+                     "yet in the denylist or the reviewed-legit list."),
+    )
+    p.add_argument("--only", action="append", metavar="ECO",
+                   help="restrict to one or more ecosystems "
+                        "(PyPI, npm, Cargo, Packagist). Repeatable.")
+    p.add_argument("--top-n", type=int, default=_DEFAULT_TOP_N,
+                   help=f"feed depth per ecosystem (default {_DEFAULT_TOP_N})")
+    p.add_argument("--ratio", type=int, default=_RATIO,
+                   help=f"min rank ratio twin:candidate (default {_RATIO})")
+    p.add_argument("--min-pos", type=int, default=_MIN_POS,
+                   help=f"never flag names above this rank (default {_MIN_POS})")
+    p.add_argument("--min-len", type=int, default=_MIN_LEN,
+                   help=f"skip names shorter than this (default {_MIN_LEN})")
+    p.add_argument("--format", choices=("text", "markdown"), default="text")
+    p.add_argument("--out", type=Path,
+                   help="write the report here instead of stdout "
+                        "(nothing written when there are no candidates)")
+    p.add_argument("-v", "--verbose", action="count", default=0)
+    args = p.parse_args(argv if argv is not None else sys.argv[1:])
+
+    logging.basicConfig(
+        level=logging.WARNING - 10 * min(args.verbose, 2),
+        format="%(levelname)s %(name)s: %(message)s")
+
+    http = UrllibClient()
+    results = audit(http, args.only, top_n=args.top_n, ratio=args.ratio,
+                    min_pos=args.min_pos, min_len=args.min_len)
+
+    report = (render_markdown if args.format == "markdown"
+              else render_text)(results)
+    if args.out is not None:
+        # Empty markdown (no candidates) → write nothing so the workflow's
+        # ``[ -s file ]`` check skips the PR-body nudge.
+        args.out.write_text(report, encoding="utf-8")
+    else:
+        sys.stdout.write(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Makes typosquats that ride the popularity feeds into the trusted list (e.g. npm `loadash`, one edit from `lodash`, ranked ~#3851) detectable — without the false positives that sink the obvious automated approaches.

Validated against live PyPI/npm feeds + OSV + a detector soundness E2E:
- **rank + edit-distance auto-drop → ~10:1 false positives.** `preact`, `enquirer`, `jslint`, `gaxios`, `boto`, `pipx` are all legit near-names; lower rank ≠ typosquat (jslint predates eslint).
- **OSV `MAL-` cross-check → also unsound here.** `MAL-` covers legit packages with compromised *versions* (`litellm`, `node-ipc`), which must stay trusted so *their* typosquats remain detectable.

Only a hand-confirmed list cleanly separates the two → zero false positives by construction.

1. **Denylist** — `data/typosquat_denylist.json`, subtracted at the trust point (`typosquat._load_popular`). Seeded with `loadash`.
2. **Self-feeding curation (step 1, LLM-free)** — `reviewed_legit.json` (de-noises the queue), a candidate generator (`typosquat_audit.py`, exposed as `raptor-sca triage`), and a candidate nudge in the weekly `refresh-sca-data` PR body (written to `$RUNNER_TEMP`, never the repo). The cron stays mechanical; LLM triage (step 2) runs operator-side.
3. **CI hygiene** — guard the refresh branch fetch with `git ls-remote --exit-code --heads` (matches `sca-self-bump.yml`), dropping the misleading `fatal: couldn't find remote ref` on first run.

- Real-bundled E2E: `loadash` flagged; `lodash`/`preact`/`litellm` spared.
- Live npm audit de-noises the candidate queue 15 → 4.
- Full SCA suite 3432 pass; ruff clean; workflow YAML valid; 19 new tests.