### PR TITLE
feat(dispatcher): AWS Bedrock signing proxy (SigV4 + API-key bearer)

### DIFF
--- a/core/llm/dispatcher/__init__.py
+++ b/core/llm/dispatcher/__init__.py
@@ -25,6 +25,7 @@ each LLM-calling subprocess and switches it to ``spawn_worker`` +
 
 from .client import (
     make_anthropic_client,
+    make_bedrock_client,
     make_gemini_base_url,
     make_openai_client,
     relay_for_grandchild,
@@ -39,6 +40,7 @@ __all__ = [
     "dispatcher_for_run",
     "llm_dispatcher_in_run",
     "make_anthropic_client",
+    "make_bedrock_client",
     "make_gemini_base_url",
     "make_openai_client",
     "relay_for_grandchild",

--- a/core/llm/dispatcher/auth.py
+++ b/core/llm/dispatcher/auth.py
@@ -10,18 +10,35 @@ Only providers RAPTOR actively dispatches to are supported here. If
 ``503 Service Unavailable: provider not configured`` so the worker's
 SDK surfaces a clear error rather than a mysterious 401 from upstream.
 
-Out of scope for the proxy-based dispatcher (Phase C-β):
+Most providers are bearer-auth on a known upstream URL: the rule strips
+the worker's (dummy) auth header and injects the real one. **AWS
+Bedrock** is the exception — it uses sigv4 request signing (a per-request
+signature over method/path/headers/body/timestamp), which can't be
+relayed as a static header. Bedrock is handled by a ``prepare_request``
+hook on its rule: the dispatcher rewrites the worker's stock-Anthropic
+``/v1/messages`` request into Bedrock's ``/model/<id>/invoke`` shape, then
+attaches auth in one of two modes —
 
-  * **AWS Bedrock** — uses sigv4 request signing. The signing
-    happens inside the AWS SDK over the request body, in worker
-    process address space (where the keys must live to sign).
-    The proxy can't transparently re-sign without a custom Bedrock
-    client shim that sends unsigned requests for the dispatcher to
-    sign with the parent's keys + per-model-family request shapes.
-    Until that ships, ``AWS_*`` env vars stay flowing through to
-    workers; operators wanting Bedrock isolation should rely on
-    AWS-native short-lived credentials (EC2/EKS instance roles,
-    SSO cache) which obviate the env-var question.
+  * **Bedrock API key** (``AWS_BEARER_TOKEN_BEDROCK``) — a static
+    ``Authorization: Bearer <token>`` header. No botocore, no signing;
+    same shape as every other bearer provider. Takes precedence over
+    SigV4 when present (matching the AWS SDKs). Needs a region only for
+    the regional host.
+  * **SigV4** — sign the rewritten request with the parent's AWS
+    credentials via botocore's ``SigV4Auth`` (access key / secret /
+    session token, or the resolved profile/SSO/IMDS chain).
+
+The worker keeps using the plain Anthropic SDK with no boto3 in its
+address space, and the parent's ``AWS_*`` secrets (keys and bearer token)
+are read-and-erased at ``CredentialStore`` construction like every other
+provider key — so they never flow to spawned workers. ``botocore`` is an
+optional, parent-only dependency needed **only for the SigV4 mode**; the
+bearer-token mode works without it. When no usable auth (or region)
+resolves, the bedrock rule reports ``503 provider not configured`` like
+any unconfigured provider. Non-streaming ``InvokeModel`` only — Bedrock's
+streaming endpoint uses a different response framing and is out of scope.
+
+Out of scope for the proxy-based dispatcher:
 
   * **GCP Vertex AI** — uses OAuth refresh from a service-account
     JSON file (``GOOGLE_APPLICATION_CREDENTIALS``). The dispatcher
@@ -29,19 +46,52 @@ Out of scope for the proxy-based dispatcher (Phase C-β):
     token at request time. Deferred to a focused follow-up; until
     then ``GOOGLE_APPLICATION_CREDENTIALS`` flows through env to
     workers and the SDK does its own OAuth exchange.
-
-The remaining providers in ``LLM_API_KEY_VARS`` (the three OG
-providers + the Phase C-β aggregators below) are all bearer-auth
-on a known upstream URL and route cleanly through the proxy.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import sys
+import threading
+import urllib.parse
 from dataclasses import dataclass
+from typing import Callable, Mapping, Optional
 from pathlib import Path
-from typing import Callable
+
+
+@dataclass(frozen=True)
+class PreparedRequest:
+    """A fully-prepared upstream request returned by a rule's
+    ``prepare_request`` hook.
+
+    Unlike the static strip/inject path, a prepared request carries the
+    *absolute* upstream ``url`` plus the exact headers and body to
+    forward verbatim — the dispatcher does no further header rewriting.
+    Used by the Bedrock rule, whose SigV4 signature is computed over the
+    rewritten URL + headers + body and would break if anything else
+    touched them afterwards. ``headers`` intentionally omits ``Host`` and
+    ``Content-Length`` so the HTTP client derives them from ``url`` /
+    ``body`` (matching what was signed).
+    """
+
+    method: str
+    url: str
+    headers: dict[str, str]
+    body: bytes
+
+
+class BedrockTransformError(Exception):
+    """Raised by the Bedrock ``prepare_request`` hook when a worker
+    request can't be turned into a signed Bedrock call. Carries the HTTP
+    ``status`` + ``message`` the dispatcher should return to the worker
+    (e.g. 400 for a malformed/streaming request, 503 when Bedrock isn't
+    configured)."""
+
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+        self.message = message
 
 
 @dataclass(frozen=True)
@@ -59,6 +109,19 @@ class ProviderRule:
     it back). Defence-in-depth — without this, a worker that overrode
     ``api_key`` with a real-looking value would have its value forwarded
     upstream alongside the real one.
+
+    ``prepare_request`` is an optional hook for providers whose auth
+    can't be expressed as static header injection (AWS Bedrock's SigV4
+    signing). When set, the dispatcher hands it the worker's
+    ``(method, path, headers, body)`` and forwards the returned
+    :class:`PreparedRequest` verbatim — the ``upstream_base_url`` /
+    ``inject_headers`` / ``strip_request_headers`` fields are unused for
+    such a rule. It may raise :class:`BedrockTransformError`.
+
+    ``is_configured`` overrides the default "configured?" predicate
+    (``bool(inject_headers())``) for rules whose readiness isn't a single
+    injected header — Bedrock checks that botocore + AWS creds + a region
+    all resolved.
     """
 
     name: str
@@ -68,6 +131,16 @@ class ProviderRule:
         "authorization", "x-api-key", "x-goog-api-key",
         "api-key", "openai-organization",
     )
+    prepare_request: Optional[
+        Callable[[str, str, Mapping[str, str], bytes], PreparedRequest]
+    ] = None
+    is_configured: Optional[Callable[[], bool]] = None
+
+
+# Sentinel for "AWS signer not yet resolved" — distinct from a resolved
+# value of ``None`` (botocore/creds absent), which is cached so we don't
+# re-attempt botocore resolution on every request.
+_UNRESOLVED = object()
 
 
 def _read_env(var: str) -> str | None:
@@ -122,7 +195,33 @@ class CredentialStore:
             # providers).
             "azure_openai":           _read_env("AZURE_OPENAI_API_KEY"),
             "azure_openai_endpoint":  _read_env("AZURE_OPENAI_ENDPOINT"),
+            # AWS Bedrock — the *secret* parts are read-and-erased like
+            # every other provider key so they never reach a spawned
+            # worker's env. Static creds set this way; SSO/IMDS/profile
+            # creds (no env keys) are resolved by botocore at signing
+            # time. Region + endpoint are NOT secrets, so they're read
+            # without popping (workers may legitimately need the region).
+            "aws_access_key_id":      _read_env("AWS_ACCESS_KEY_ID"),
+            "aws_secret_access_key":  _read_env("AWS_SECRET_ACCESS_KEY"),
+            "aws_session_token":      _read_env("AWS_SESSION_TOKEN"),
+            # Bedrock API key (newer bearer-token auth). When present it
+            # takes precedence over SigV4 (matching the AWS SDKs) and the
+            # request is authed with a static ``Authorization: Bearer``
+            # header — no botocore, no signing. Secret → read-and-erased.
+            "aws_bearer_token":       _read_env("AWS_BEARER_TOKEN_BEDROCK"),
         }
+        self._aws_region: str | None = (
+            os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+        )
+        self._aws_endpoint: str | None = os.environ.get("AWS_ENDPOINT_URL_BEDROCK")
+        # Resolved (credentials, region, endpoint) tuple, or None once we
+        # know Bedrock isn't usable. ``_UNRESOLVED`` until first lookup.
+        # The lock serialises first-resolution across the threading
+        # dispatcher's concurrent request handlers — the resolution is
+        # idempotent, but the botocore credential-chain probe (which may
+        # hit IMDS) should run once, not once per concurrent first call.
+        self._aws_signer_cache: object = _UNRESOLVED
+        self._aws_signer_lock = threading.Lock()
 
     def get(self, provider: str) -> str | None:
         return self._keys.get(provider)
@@ -134,6 +233,185 @@ class CredentialStore:
         from ``models.json``. No other production caller touches this.
         """
         self._keys[provider] = key
+
+    def set_aws(
+        self,
+        *,
+        access_key: str | None = None,
+        secret_key: str | None = None,
+        session_token: str | None = None,
+        bearer_token: str | None = None,
+        region: str | None = None,
+        endpoint: str | None = None,
+    ) -> None:
+        """Inject static AWS credentials/region/endpoint and reset the
+        resolved-signer cache. Used by tests to drive the Bedrock path
+        deterministically (and to point it at a local stub endpoint)
+        without relying on the ambient botocore credential chain."""
+        if access_key is not None:
+            self._keys["aws_access_key_id"] = access_key
+        if secret_key is not None:
+            self._keys["aws_secret_access_key"] = secret_key
+        if session_token is not None:
+            self._keys["aws_session_token"] = session_token
+        if bearer_token is not None:
+            self._keys["aws_bearer_token"] = bearer_token
+        if region is not None:
+            self._aws_region = region
+        if endpoint is not None:
+            self._aws_endpoint = endpoint
+        self._aws_signer_cache = _UNRESOLVED
+
+    def aws_bedrock_endpoint(self) -> str | None:
+        """Return the Bedrock-runtime base URL, or ``None`` if no region
+        is known. Region comes from ``AWS_REGION`` / ``AWS_DEFAULT_REGION``
+        (or :meth:`set_aws`); it isn't a secret. Used by the bearer-token
+        path, which needs the regional host but does no botocore work."""
+        if not self._aws_region:
+            return None
+        return (
+            self._aws_endpoint
+            or f"https://bedrock-runtime.{self._aws_region}.amazonaws.com"
+        )
+
+    def aws_signer(self):
+        """Return ``(credentials, region, endpoint_base)`` for SigV4
+        signing, or ``None`` when Bedrock isn't usable (botocore missing,
+        no resolvable credentials, or no region). Resolved once and
+        cached — including a cached ``None`` so we don't re-probe the
+        botocore credential chain on every request."""
+        if self._aws_signer_cache is _UNRESOLVED:
+            with self._aws_signer_lock:
+                # Double-checked: another thread may have resolved it
+                # while we waited on the lock.
+                if self._aws_signer_cache is _UNRESOLVED:
+                    self._aws_signer_cache = self._resolve_aws_signer()
+        return self._aws_signer_cache
+
+    def _resolve_aws_signer(self):
+        try:
+            import botocore.credentials
+            import botocore.session
+        except ImportError:
+            return None
+
+        ak = self._keys.get("aws_access_key_id")
+        sk = self._keys.get("aws_secret_access_key")
+        st = self._keys.get("aws_session_token")
+        region = self._aws_region
+
+        credentials = None
+        if ak and sk:
+            # Static creds the parent supplied via env (already erased
+            # from os.environ) or via set_aws().
+            credentials = botocore.credentials.Credentials(ak, sk, st)
+        else:
+            # No static keys: fall back to botocore's natural credential
+            # chain (shared config/profile, SSO cache, container creds,
+            # IMDS instance role). The parent is the trust boundary, so
+            # the full chain is appropriate here. RefreshableCredentials
+            # transparently re-fetch on access, so SSO/IMDS rotation is
+            # handled per request.
+            try:
+                session = botocore.session.Session()
+                credentials = session.get_credentials()
+                if not region:
+                    region = session.get_config_variable("region")
+            except Exception:
+                credentials = None
+
+        if credentials is None or not region:
+            return None
+        endpoint = (
+            self._aws_endpoint
+            or f"https://bedrock-runtime.{region}.amazonaws.com"
+        )
+        return (credentials, region, endpoint)
+
+
+_BEDROCK_ANTHROPIC_VERSION = "bedrock-2023-05-31"
+
+
+def _transform_bedrock_request(endpoint: str, body: bytes) -> tuple[str, bytes]:
+    """Rewrite a stock-Anthropic ``/v1/messages`` body into the Bedrock
+    ``InvokeModel`` shape, returning ``(url, new_body)``.
+
+    Pops ``model`` (it becomes the ``/model/<id>/invoke`` URL path), adds
+    ``anthropic_version`` to the body, and targets the regional
+    bedrock-runtime endpoint. Auth-agnostic — shared by both the SigV4
+    and bearer-token request builders. Raises :class:`BedrockTransformError`
+    on a malformed/streaming/model-less request.
+    """
+    try:
+        payload = json.loads(body) if body else {}
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        raise BedrockTransformError(400, "bedrock: request body is not valid JSON")
+    if not isinstance(payload, dict):
+        raise BedrockTransformError(400, "bedrock: request body must be a JSON object")
+    # v1 is non-streaming only. The Anthropic SDK sets ``stream`` in the
+    # body for ``messages.stream``/``create(stream=True)``; Bedrock's
+    # streaming endpoint uses different response framing (out of scope).
+    if payload.get("stream"):
+        raise BedrockTransformError(
+            400, "bedrock: streaming is not supported (non-streaming InvokeModel only)"
+        )
+    payload.pop("stream", None)
+    model = payload.pop("model", None)
+    if not isinstance(model, str) or not model:
+        raise BedrockTransformError(400, "bedrock: request body missing 'model'")
+    payload.setdefault("anthropic_version", _BEDROCK_ANTHROPIC_VERSION)
+    new_body = json.dumps(payload).encode("utf-8")
+    url = endpoint.rstrip("/") + f"/model/{urllib.parse.quote(model, safe='')}/invoke"
+    return url, new_body
+
+
+def _build_signed_bedrock_request(
+    credentials, region: str, endpoint: str, body: bytes,
+) -> PreparedRequest:
+    """Transform + SigV4-sign with the parent's AWS credentials. The
+    signed ``Authorization`` / ``X-Amz-Date`` / ``X-Amz-Security-Token``
+    headers are returned for verbatim forwarding; ``Host`` and
+    ``Content-Length`` are dropped so the HTTP client reproduces exactly
+    what SigV4 signed (host from the URL, length from the body).
+    """
+    # Imported here, not at module top, so ``auth.py`` loads without
+    # botocore — the dependency is parent-only and only needed for SigV4
+    # (the bearer-token path below needs no botocore at all).
+    from botocore.auth import SigV4Auth
+    from botocore.awsrequest import AWSRequest
+
+    url, new_body = _transform_bedrock_request(endpoint, body)
+    # Sign Content-Type AND Accept (both go into SignedHeaders) to match
+    # boto3's bedrock-runtime InvokeModel request byte-for-byte:
+    # ``SignedHeaders=accept;content-type;host;x-amz-date``. AWS would
+    # accept the three-header form too (it only verifies what we declare
+    # in SignedHeaders), but matching the official client removes any
+    # edge where Bedrock treats an unsigned Accept differently.
+    aws_req = AWSRequest(
+        method="POST", url=url, data=new_body,
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+    )
+    SigV4Auth(credentials, "bedrock", region).add_auth(aws_req)
+
+    forwarded = dict(aws_req.headers.items())
+    for drop in ("Host", "host", "Content-Length", "content-length"):
+        forwarded.pop(drop, None)
+    return PreparedRequest(method="POST", url=url, headers=forwarded, body=new_body)
+
+
+def _build_bearer_bedrock_request(
+    bearer_token: str, endpoint: str, body: bytes,
+) -> PreparedRequest:
+    """Transform + attach a static ``Authorization: Bearer <token>``
+    header (Bedrock API-key auth). No botocore, no signing — matches what
+    the AWS SDKs send when ``AWS_BEARER_TOKEN_BEDROCK`` is set."""
+    url, new_body = _transform_bedrock_request(endpoint, body)
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Authorization": f"Bearer {bearer_token}",
+    }
+    return PreparedRequest(method="POST", url=url, headers=headers, body=new_body)
 
 
 def build_rules(creds: CredentialStore) -> dict[str, ProviderRule]:
@@ -208,6 +486,35 @@ def build_rules(creds: CredentialStore) -> dict[str, ProviderRule]:
         creds.get("azure_openai_endpoint")
         or "https://azure-openai-not-configured.invalid"
     )
+
+    def _bedrock_prepare(
+        method: str, path: str, headers: Mapping[str, str], body: bytes,
+    ) -> PreparedRequest:
+        # ``method`` / ``path`` / ``headers`` from the worker's stock
+        # Anthropic request are intentionally discarded: Bedrock always
+        # POSTs to a body-derived path with freshly-attached auth.
+        # Bearer-token (Bedrock API key) wins over SigV4 when present,
+        # matching the AWS SDKs — and needs no botocore.
+        bearer = creds.get("aws_bearer_token")
+        if bearer:
+            endpoint = creds.aws_bedrock_endpoint()
+            if endpoint is None:
+                raise BedrockTransformError(
+                    503, "provider not configured: bedrock (no AWS region)"
+                )
+            return _build_bearer_bedrock_request(bearer, endpoint, body)
+        signer = creds.aws_signer()
+        if signer is None:
+            raise BedrockTransformError(503, "provider not configured: bedrock")
+        credentials, region, endpoint = signer
+        return _build_signed_bedrock_request(credentials, region, endpoint, body)
+
+    def _bedrock_configured() -> bool:
+        # Bearer token (+ a region for the host) OR a resolvable SigV4
+        # signer. Bearer is checked first and cheaply (no botocore probe).
+        if creds.get("aws_bearer_token") and creds.aws_bedrock_endpoint():
+            return True
+        return creds.aws_signer() is not None
 
     return {
         "anthropic": ProviderRule(
@@ -287,6 +594,17 @@ def build_rules(creds: CredentialStore) -> dict[str, ProviderRule]:
                 "authorization", "x-api-key", "x-goog-api-key",
                 "api-key", "openai-organization",
             ),
+        ),
+        "bedrock": ProviderRule(
+            name="bedrock",
+            # Unused for a prepare_request rule — the hook returns an
+            # absolute, region-derived URL. Sentinel keeps the dataclass
+            # field populated and makes a stray non-hook forward fail
+            # loudly rather than hitting a real endpoint.
+            upstream_base_url="https://bedrock-runtime-not-configured.invalid",
+            inject_headers=lambda: {},
+            prepare_request=_bedrock_prepare,
+            is_configured=_bedrock_configured,
         ),
     }
 

--- a/core/llm/dispatcher/client.py
+++ b/core/llm/dispatcher/client.py
@@ -184,6 +184,36 @@ def make_anthropic_client(
     )
 
 
+def make_bedrock_client(
+    *,
+    socket_path: Optional[str] = None,
+    token: Optional[str] = None,
+    timeout: Optional[float] = None,
+):
+    """Return a stock ``anthropic.Anthropic`` client whose requests are
+    rewritten + SigV4-signed for AWS Bedrock by the dispatcher.
+
+    Identical to :func:`make_anthropic_client` except the base URL points
+    at the ``/bedrock`` prefix. The worker still speaks the plain
+    Anthropic Messages API (``client.messages.create(...)``) and holds no
+    AWS credentials — boto3/botocore never load in the worker's address
+    space. The dispatcher's bedrock rule moves ``model`` into the
+    ``/model/<id>/invoke`` path, adds ``anthropic_version`` to the body,
+    retargets the regional bedrock-runtime host, and signs with the
+    parent's AWS credentials. The Bedrock ``InvokeModel`` response is the
+    same Messages JSON the SDK already parses, so the round trip is
+    invisible at the call site (non-streaming only)."""
+    import anthropic
+
+    socket_path, token = _resolve_socket_and_token(socket_path, token)
+    http = _make_httpx_client(socket_path, token, timeout=timeout)
+    return anthropic.Anthropic(
+        api_key="dummy-not-used",
+        base_url="http://_/bedrock",
+        http_client=http,
+    )
+
+
 def make_openai_client(
     *,
     socket_path: Optional[str] = None,

--- a/core/llm/dispatcher/server.py
+++ b/core/llm/dispatcher/server.py
@@ -52,7 +52,12 @@ import httpx
 
 from core.security.log_sanitisation import escape_nonprintable
 
-from .auth import CredentialStore, ProviderRule, build_rules
+from .auth import (
+    BedrockTransformError,
+    CredentialStore,
+    ProviderRule,
+    build_rules,
+)
 
 
 _logger = logging.getLogger(__name__)
@@ -552,6 +557,10 @@ _PROVIDER_FROM_PATH_PREFIX = {
     "/cohere/":       "cohere",
     "/replicate/":    "replicate",
     "/azure_openai/": "azure_openai",
+    # AWS Bedrock — routed by prefix like the others, but the rule
+    # carries a ``prepare_request`` hook that rewrites + SigV4-signs the
+    # request rather than injecting a static header.
+    "/bedrock/":      "bedrock",
 }
 
 
@@ -608,7 +617,17 @@ def _make_request_handler(dispatcher: LLMDispatcher) -> type:
                 self._send_simple(404, "unknown provider path")
                 return
             rule = dispatcher._provider(provider_name)
-            if rule is None or not rule.inject_headers():
+            # "Configured?" defaults to "has an injectable header", but a
+            # rule may override it (Bedrock needs botocore + AWS creds +
+            # region, not a single header).
+            configured = (
+                rule is not None
+                and (
+                    rule.is_configured() if rule.is_configured is not None
+                    else bool(rule.inject_headers())
+                )
+            )
+            if not configured:
                 dispatcher._audit(AuditEvent(
                     ts=time.time(), event="provider.unconfigured",
                     peer_pid=None, peer_uid=None,
@@ -622,19 +641,62 @@ def _make_request_handler(dispatcher: LLMDispatcher) -> type:
             content_length = int(self.headers.get("Content-Length", "0"))
             body = self.rfile.read(content_length) if content_length else b""
 
-            # ---- header rewrite ----
-            forwarded: dict[str, str] = {}
-            for k, v in self.headers.items():
-                if k.lower() in rule.strip_request_headers:
-                    continue
-                if k.lower() in ("host", "content-length", _TOKEN_HEADER.lower()):
-                    continue
-                forwarded[k] = v
-            forwarded.update(rule.inject_headers())
+            method = self.command
+            if rule.prepare_request is not None:
+                # Provider with a non-static auth scheme (Bedrock SigV4):
+                # the rule rewrites + signs the request and we forward
+                # exactly what it returns. No further header rewriting —
+                # any edit would invalidate the signature.
+                try:
+                    prepared = rule.prepare_request(
+                        method, upstream_path, self.headers, body,
+                    )
+                except BedrockTransformError as exc:
+                    dispatcher._audit(AuditEvent(
+                        ts=time.time(), event="provider.transform_reject",
+                        peer_pid=None, peer_uid=None,
+                        token_id=_short(rec.value), worker_label=rec.worker_label,
+                        status="reject", reason=f"{provider_name}: {exc.message}",
+                    ))
+                    self._send_simple(exc.status, exc.message)
+                    return
+                except Exception as exc:  # noqa: BLE001
+                    # Any OTHER exception from request preparation is an
+                    # upstream-signing failure we can't turn into a request —
+                    # most importantly a botocore credential refresh
+                    # (SSO/IMDS token expiry mid-run) raising inside
+                    # SigV4Auth.add_auth. Without this catch the exception
+                    # escapes the handler thread: the worker sees a dropped
+                    # connection with no HTTP status and no audit row. Map it
+                    # to a 502 + audit so the failure is visible and the
+                    # worker SDK surfaces a clean error. Log only the
+                    # exception TYPE (botocore messages can embed request
+                    # context) — never its rendered message.
+                    dispatcher._audit(AuditEvent(
+                        ts=time.time(), event="provider.transform_error",
+                        peer_pid=None, peer_uid=None,
+                        token_id=_short(rec.value), worker_label=rec.worker_label,
+                        status="error", reason=f"{provider_name}: {type(exc).__name__}",
+                    ))
+                    self._send_simple(502, f"request signing failed: {type(exc).__name__}")
+                    return
+                method = prepared.method
+                url = prepared.url
+                body = prepared.body
+                forwarded = dict(prepared.headers)
+            else:
+                # ---- header rewrite (static strip + inject) ----
+                forwarded = {}
+                for k, v in self.headers.items():
+                    if k.lower() in rule.strip_request_headers:
+                        continue
+                    if k.lower() in ("host", "content-length", _TOKEN_HEADER.lower()):
+                        continue
+                    forwarded[k] = v
+                forwarded.update(rule.inject_headers())
+                url = rule.upstream_base_url + upstream_path
 
             # ---- forward to upstream + stream response back ----
-            url = rule.upstream_base_url + upstream_path
-            method = self.command
             try:
                 with httpx.Client(timeout=httpx.Timeout(60.0, connect=10.0)) as client:
                     with client.stream(method, url, content=body, headers=forwarded) as up:

--- a/core/llm/dispatcher/tests/test_bedrock_signing.py
+++ b/core/llm/dispatcher/tests/test_bedrock_signing.py
@@ -1,0 +1,506 @@
+"""Bedrock SigV4 signing-proxy tests for ``core/llm/dispatcher``.
+
+The dispatcher rewrites a worker's stock-Anthropic ``/v1/messages``
+request into a Bedrock ``InvokeModel`` call and SigV4-signs it with the
+parent's AWS credentials (the worker holds none). These tests drive a
+real ``httpx`` client (and the real Anthropic SDK) through the UDS, point
+the bedrock rule at a captive local upstream, and assert on what the
+dispatcher forwarded: the body/path transform and a well-formed SigV4
+``Authorization`` header.
+
+``botocore`` is an optional, parent-only dependency. The signing tests
+skip when it's absent; the unconfigured-503 and env-hygiene tests run
+unconditionally so CI (which has no botocore) still exercises the
+graceful-degradation path and the credential-scrub guarantee.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import httpx
+import pytest
+
+from core.llm.dispatcher.auth import (
+    BedrockTransformError,
+    CredentialStore,
+    build_rules,
+)
+from core.llm.dispatcher.server import LLMDispatcher, _TOKEN_HEADER
+
+try:
+    import botocore  # noqa: F401
+
+    _HAS_BOTOCORE = True
+except ImportError:
+    _HAS_BOTOCORE = False
+
+needs_botocore = pytest.mark.skipif(
+    not _HAS_BOTOCORE,
+    reason="botocore not installed (optional parent-only dependency)",
+)
+
+# Fixture AWS creds — never real. SigV4 over these proves the parent's
+# credentials (not the worker's) signed the request.
+_FAKE_AK = "AKIAIOSFODNN7EXAMPLE"
+_FAKE_SK = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+_REGION = "us-east-1"
+# A realistic Bedrock model id — the colon must survive into the path as
+# %3A (matching boto3's own URL-encoding of modelId).
+_MODEL = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+
+_MESSAGES_RESPONSE = {
+    "id": "msg_bedrock_test",
+    "type": "message",
+    "role": "assistant",
+    "model": _MODEL,
+    "content": [{"type": "text", "text": "pong"}],
+    "stop_reason": "end_turn",
+    "stop_sequence": None,
+    "usage": {"input_tokens": 3, "output_tokens": 1},
+}
+
+
+# ---------------------------------------------------------------------------
+# Captive upstream — stands in for bedrock-runtime.<region>.amazonaws.com
+# ---------------------------------------------------------------------------
+
+
+class _CaptureHandler(BaseHTTPRequestHandler):
+    def log_message(self, *args):  # noqa: A002 — silence stderr spam
+        return
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length) if length else b""
+        self.server.captured = {  # type: ignore[attr-defined]
+            "path": self.path,
+            "headers": {k.lower(): v for k, v in self.headers.items()},
+            "body": body,
+        }
+        resp = json.dumps(_MESSAGES_RESPONSE).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(resp)))
+        self.end_headers()
+        self.wfile.write(resp)
+
+
+@pytest.fixture
+def upstream():
+    """A captive HTTP server the bedrock rule forwards to. Yields
+    ``(endpoint_url, get_captured)``."""
+    server = HTTPServer(("127.0.0.1", 0), _CaptureHandler)
+    server.captured = None  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    try:
+        yield f"http://{host}:{port}", lambda: server.captured  # type: ignore[attr-defined]
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _bedrock_store(endpoint: str) -> CredentialStore:
+    store = CredentialStore()
+    store.set_aws(
+        access_key=_FAKE_AK,
+        secret_key=_FAKE_SK,
+        region=_REGION,
+        endpoint=endpoint,
+    )
+    return store
+
+
+def _post_bedrock(dispatcher: LLMDispatcher, body: dict) -> httpx.Response:
+    socket_path, fd = dispatcher.allocate_worker(label="bedrock-test")
+    token = os.read(fd, 64).decode().strip()
+    os.close(fd)
+    transport = httpx.HTTPTransport(uds=str(dispatcher.socket_path))
+    with httpx.Client(transport=transport, timeout=10.0) as c:
+        return c.post(
+            "http://_/bedrock/v1/messages",
+            headers={
+                _TOKEN_HEADER: token,
+                "Content-Type": "application/json",
+                # Worker SDK leftovers the dispatcher must NOT forward:
+                "x-api-key": "dummy-not-used",
+                "anthropic-version": "2023-06-01",
+            },
+            content=json.dumps(body).encode("utf-8"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Signing + transform (need botocore)
+# ---------------------------------------------------------------------------
+
+
+@needs_botocore
+def test_bedrock_transform_and_sigv4(upstream, tmp_path):
+    endpoint, captured = upstream
+    d = LLMDispatcher(
+        run_id="bedrock-sig",
+        audit_path=tmp_path / "audit.jsonl",
+        creds=_bedrock_store(endpoint),
+    )
+    try:
+        resp = _post_bedrock(
+            d,
+            {
+                "model": _MODEL,
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "ping"}],
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["content"][0]["text"] == "pong"
+    finally:
+        d.shutdown()
+
+    req = captured()
+    assert req is not None, "upstream never received the forwarded request"
+
+    # Path: model moved out of the body into /model/<encoded-id>/invoke.
+    assert req["path"] == f"/model/{urllib.parse.quote(_MODEL, safe='')}/invoke"
+
+    # Body: model removed, anthropic_version added, payload preserved.
+    sent = json.loads(req["body"])
+    assert "model" not in sent
+    assert sent["anthropic_version"] == "bedrock-2023-05-31"
+    assert sent["max_tokens"] == 16
+    assert sent["messages"] == [{"role": "user", "content": "ping"}]
+
+    # Headers: worker's anthropic auth gone; SigV4 present; the signed
+    # content-type/accept were actually transmitted on the wire (not just
+    # declared in SignedHeaders — a dispatcher that signed then dropped
+    # them would otherwise slip through).
+    hdrs = req["headers"]
+    assert "x-api-key" not in hdrs
+    assert "anthropic-version" not in hdrs
+    assert "x-amz-date" in hdrs
+    assert hdrs.get("content-type") == "application/json"
+    assert hdrs.get("accept") == "application/json"
+
+    auth = hdrs["authorization"]
+    assert auth.startswith("AWS4-HMAC-SHA256 ")
+    assert f"Credential={_FAKE_AK}/" in auth
+    assert f"/{_REGION}/bedrock/aws4_request" in auth
+    sig = re.search(r"Signature=([0-9a-f]{64})\b", auth)
+    assert sig, f"no 64-hex signature in {auth!r}"
+    signed = re.search(r"SignedHeaders=([^,]+)", auth).group(1).split(";")
+    # Match boto3's bedrock-runtime InvokeModel signed-header set exactly.
+    # host is signed but never forged by us — httpx's URL-derived Host
+    # must equal what SigV4 signed.
+    assert set(signed) == {"accept", "content-type", "host", "x-amz-date"}
+
+
+@needs_botocore
+def test_bedrock_signature_matches_wire_request(upstream, tmp_path, monkeypatch):
+    """Cryptographic verification, not just structural: freeze botocore's
+    clock, capture the EXACT method/path/host/headers/body the dispatcher
+    transmitted, independently re-sign that wire request, and assert the
+    recomputed SigV4 ``Authorization`` is byte-identical. AWS verifies a
+    request by performing this same recomputation, so a match proves the
+    signature is valid for what actually went on the wire — and would
+    FAIL if httpx altered the path encoding between signing and sending
+    (the sign-here / send-there split's main risk)."""
+    import datetime as _dt
+
+    import botocore.auth as _ba
+    from botocore.auth import SigV4Auth
+    from botocore.awsrequest import AWSRequest
+    from botocore.credentials import Credentials
+
+    fixed = _dt.datetime(2026, 1, 2, 3, 4, 5, tzinfo=_dt.timezone.utc)
+    monkeypatch.setattr(_ba, "get_current_datetime", lambda: fixed)
+
+    endpoint, captured = upstream
+    d = LLMDispatcher(
+        run_id="bedrock-verify",
+        audit_path=tmp_path / "audit.jsonl",
+        creds=_bedrock_store(endpoint),
+    )
+    try:
+        resp = _post_bedrock(
+            d,
+            {
+                "model": _MODEL,
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "ping"}],
+            },
+        )
+        assert resp.status_code == 200
+    finally:
+        d.shutdown()
+
+    req = captured()
+    assert req is not None
+    host = endpoint.split("://", 1)[1]
+    wire_url = f"http://{host}{req['path']}"
+    check = AWSRequest(
+        method="POST", url=wire_url, data=req["body"],
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+    )
+    SigV4Auth(Credentials(_FAKE_AK, _FAKE_SK), "bedrock", _REGION).add_auth(check)
+    assert check.headers["X-Amz-Date"] == req["headers"]["x-amz-date"]
+    assert check.headers["Authorization"] == req["headers"]["authorization"]
+
+
+@needs_botocore
+def test_bedrock_sdk_roundtrip(upstream, tmp_path):
+    """The strongest E2E: the real Anthropic SDK, pointed at /bedrock via
+    make_bedrock_client, gets a parsed Message back."""
+    anthropic = pytest.importorskip("anthropic")  # noqa: F841
+    from core.llm.dispatcher.client import make_bedrock_client
+
+    endpoint, _ = upstream
+    d = LLMDispatcher(
+        run_id="bedrock-sdk",
+        audit_path=tmp_path / "audit.jsonl",
+        creds=_bedrock_store(endpoint),
+    )
+    try:
+        socket_path, fd = d.allocate_worker(label="bedrock-sdk")
+        token = os.read(fd, 64).decode().strip()
+        os.close(fd)
+        client = make_bedrock_client(socket_path=str(d.socket_path), token=token)
+        msg = client.messages.create(
+            model=_MODEL,
+            max_tokens=16,
+            messages=[{"role": "user", "content": "ping"}],
+        )
+        assert msg.content[0].text == "pong"
+        assert msg.role == "assistant"
+    finally:
+        d.shutdown()
+
+
+@needs_botocore
+def test_bedrock_streaming_rejected(upstream):
+    endpoint, _ = upstream
+    rule = build_rules(_bedrock_store(endpoint))["bedrock"]
+    body = json.dumps(
+        {"model": _MODEL, "max_tokens": 8, "stream": True, "messages": []}
+    ).encode()
+    with pytest.raises(BedrockTransformError) as ei:
+        rule.prepare_request("POST", "/v1/messages", {}, body)
+    assert ei.value.status == 400
+    assert "stream" in ei.value.message.lower()
+
+
+@needs_botocore
+def test_bedrock_missing_model_rejected(upstream):
+    endpoint, _ = upstream
+    rule = build_rules(_bedrock_store(endpoint))["bedrock"]
+    body = json.dumps({"max_tokens": 8, "messages": []}).encode()
+    with pytest.raises(BedrockTransformError) as ei:
+        rule.prepare_request("POST", "/v1/messages", {}, body)
+    assert ei.value.status == 400
+    assert "model" in ei.value.message.lower()
+
+
+@needs_botocore
+def test_bedrock_invalid_json_rejected(upstream):
+    endpoint, _ = upstream
+    rule = build_rules(_bedrock_store(endpoint))["bedrock"]
+    with pytest.raises(BedrockTransformError) as ei:
+        rule.prepare_request("POST", "/v1/messages", {}, b"{not json")
+    assert ei.value.status == 400
+
+
+# ---------------------------------------------------------------------------
+# Bedrock API-key / bearer-token auth (no botocore — CI-safe)
+# ---------------------------------------------------------------------------
+
+
+def test_bedrock_bearer_token_auth(upstream, tmp_path):
+    """Bedrock API-key path: a static ``Authorization: Bearer`` header,
+    no SigV4 (no ``x-amz-date``), no botocore — but the same body/path
+    transform as the SigV4 path. Mirrors what the AWS SDKs send when
+    ``AWS_BEARER_TOKEN_BEDROCK`` is set."""
+    endpoint, captured = upstream
+    store = CredentialStore()
+    store.set_aws(bearer_token="ABSK-test-token-xyz", region=_REGION, endpoint=endpoint)
+    d = LLMDispatcher(
+        run_id="bedrock-bearer",
+        audit_path=tmp_path / "audit.jsonl",
+        creds=store,
+    )
+    try:
+        resp = _post_bedrock(
+            d,
+            {
+                "model": _MODEL,
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "ping"}],
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["content"][0]["text"] == "pong"
+    finally:
+        d.shutdown()
+
+    req = captured()
+    assert req["path"] == f"/model/{urllib.parse.quote(_MODEL, safe='')}/invoke"
+    hdrs = req["headers"]
+    assert hdrs.get("authorization") == "Bearer ABSK-test-token-xyz"
+    assert "x-amz-date" not in hdrs  # bearer auth, not SigV4
+    assert hdrs.get("content-type") == "application/json"
+    assert hdrs.get("accept") == "application/json"
+    sent = json.loads(req["body"])
+    assert "model" not in sent
+    assert sent["anthropic_version"] == "bedrock-2023-05-31"
+
+
+def test_bedrock_bearer_precedence_over_sigv4(upstream, tmp_path):
+    """When both a bearer token and SigV4 keys are present, bearer wins
+    (matching the AWS SDKs) — proven by the absence of a SigV4 date and
+    the presence of the Bearer header. Needs no botocore precisely
+    because the bearer branch short-circuits before aws_signer()."""
+    endpoint, captured = upstream
+    store = CredentialStore()
+    store.set_aws(
+        access_key=_FAKE_AK, secret_key=_FAKE_SK,
+        bearer_token="ABSK-wins", region=_REGION, endpoint=endpoint,
+    )
+    d = LLMDispatcher(
+        run_id="bedrock-precedence",
+        audit_path=tmp_path / "audit.jsonl",
+        creds=store,
+    )
+    try:
+        resp = _post_bedrock(
+            d, {"model": _MODEL, "max_tokens": 8, "messages": []}
+        )
+        assert resp.status_code == 200
+    finally:
+        d.shutdown()
+
+    hdrs = captured()["headers"]
+    assert hdrs.get("authorization") == "Bearer ABSK-wins"
+    assert "x-amz-date" not in hdrs
+
+
+def test_bedrock_bearer_without_region_503(tmp_path, monkeypatch):
+    """A bearer token with no resolvable region can't build the regional
+    host → unconfigured → 503. SigV4 fallback forced off so the result is
+    deterministic regardless of ambient AWS creds/botocore."""
+    store = CredentialStore()
+    store.set_aws(bearer_token="ABSK-x")
+    store._aws_region = None
+    monkeypatch.setattr(store, "aws_signer", lambda: None)
+    assert build_rules(store)["bedrock"].is_configured() is False
+
+    d = LLMDispatcher(
+        run_id="bedrock-noregion",
+        audit_path=tmp_path / "audit.jsonl",
+        creds=store,
+    )
+    try:
+        resp = _post_bedrock(
+            d, {"model": _MODEL, "max_tokens": 8, "messages": []}
+        )
+        assert resp.status_code == 503
+    finally:
+        d.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation + env hygiene (run WITHOUT botocore — CI-safe)
+# ---------------------------------------------------------------------------
+
+
+def test_bedrock_unconfigured_returns_503(tmp_path, monkeypatch):
+    """No usable AWS signer (botocore missing / no creds) → 503, the same
+    UX as any unconfigured provider. Forced deterministically so the test
+    is independent of the ambient AWS credential chain."""
+    store = CredentialStore()
+    monkeypatch.setattr(store, "aws_signer", lambda: None)
+    assert build_rules(store)["bedrock"].is_configured() is False
+
+    d = LLMDispatcher(
+        run_id="bedrock-503",
+        audit_path=tmp_path / "audit.jsonl",
+        creds=store,
+    )
+    try:
+        resp = _post_bedrock(
+            d, {"model": _MODEL, "max_tokens": 8, "messages": []}
+        )
+        assert resp.status_code == 503
+        assert "bedrock" in resp.json()["error"]
+    finally:
+        d.shutdown()
+
+
+def test_bedrock_signing_failure_returns_502(tmp_path, monkeypatch):
+    """A signing failure that is NOT a BedrockTransformError — e.g. a
+    botocore credential refresh raising inside SigV4Auth.add_auth when an
+    SSO/IMDS token expires mid-run — is mapped to a clean 502 + audit row,
+    not an exception that escapes the handler thread and drops the worker's
+    connection. Runs without botocore: the signer is faked configured and
+    the transform is forced to raise."""
+    import core.llm.dispatcher.auth as auth_mod
+
+    store = CredentialStore()
+    # Configured (so we get past the 503 gate) ...
+    monkeypatch.setattr(
+        store, "aws_signer",
+        lambda: ("creds", _REGION, "https://x.invalid"),
+    )
+    # ... but signing blows up the way a credential refresh would.
+    def _boom(*a, **k):
+        raise RuntimeError("simulated credential refresh failure")
+
+    monkeypatch.setattr(auth_mod, "_build_signed_bedrock_request", _boom)
+
+    d = LLMDispatcher(
+        run_id="bedrock-502",
+        audit_path=tmp_path / "audit.jsonl",
+        creds=store,
+    )
+    try:
+        resp = _post_bedrock(
+            d, {"model": _MODEL, "max_tokens": 8, "messages": []}
+        )
+        assert resp.status_code == 502
+        assert "signing failed" in resp.json()["error"]
+    finally:
+        d.shutdown()
+
+    audit = (tmp_path / "audit.jsonl").read_text()
+    assert "provider.transform_error" in audit
+
+
+def test_aws_secrets_popped_from_env(monkeypatch):
+    """AWS secret env vars are read-and-erased at CredentialStore
+    construction — so they're gone from os.environ before any worker is
+    spawned (the same isolation the other provider keys get)."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", _FAKE_AK)
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", _FAKE_SK)
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "session-token-xyz")
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "ABSK-bearer-secret")
+    monkeypatch.setenv("AWS_REGION", _REGION)
+
+    store = CredentialStore()
+
+    # Secrets erased from the live environment...
+    assert "AWS_ACCESS_KEY_ID" not in os.environ
+    assert "AWS_SECRET_ACCESS_KEY" not in os.environ
+    assert "AWS_SESSION_TOKEN" not in os.environ
+    assert "AWS_BEARER_TOKEN_BEDROCK" not in os.environ
+    # ...but captured in the parent's store.
+    assert store.get("aws_access_key_id") == _FAKE_AK
+    assert store.get("aws_secret_access_key") == _FAKE_SK
+    assert store.get("aws_session_token") == "session-token-xyz"
+    assert store.get("aws_bearer_token") == "ABSK-bearer-secret"
+    # Region is not a secret and stays readable.
+    assert store._aws_region == _REGION
+    assert os.environ.get("AWS_REGION") == _REGION

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,13 @@ instructor==1.15.1
 # pip install openai        # OpenAI, Gemini (via shim), Mistral, Ollama
 # pip install anthropic     # Anthropic Claude (native structured output)
 # pip install google-genai  # Google Gemini (native SDK, accurate thinking token costs)
+# pip install botocore      # AWS Bedrock SigV4 signing — PARENT-ONLY: imported
+#                           # only by the credential-isolation dispatcher
+#                           # (core/llm/dispatcher) to sign Bedrock requests on
+#                           # the worker's behalf. NOT needed for Bedrock API-key
+#                           # (AWS_BEARER_TOKEN_BEDROCK) auth, only for SigV4.
+#                           # Workers use the stock anthropic SDK and never
+#                           # import boto3/botocore.
 
 # Optional: Rich inventory metadata (decorators, annotations, visibility, typed params)
 # pip install tree-sitter tree-sitter-python tree-sitter-java tree-sitter-javascript tree-sitter-c tree-sitter-go

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,13 +26,11 @@ instructor==1.15.1
 # pip install openai        # OpenAI, Gemini (via shim), Mistral, Ollama
 # pip install anthropic     # Anthropic Claude (native structured output)
 # pip install google-genai  # Google Gemini (native SDK, accurate thinking token costs)
-# pip install botocore      # AWS Bedrock SigV4 signing — PARENT-ONLY: imported
-#                           # only by the credential-isolation dispatcher
-#                           # (core/llm/dispatcher) to sign Bedrock requests on
-#                           # the worker's behalf. NOT needed for Bedrock API-key
-#                           # (AWS_BEARER_TOKEN_BEDROCK) auth, only for SigV4.
-#                           # Workers use the stock anthropic SDK and never
-#                           # import boto3/botocore.
+# AWS Bedrock: botocore is PARENT-ONLY — imported only by the credential-
+# isolation dispatcher (core/llm/dispatcher) to SigV4-sign Bedrock requests on
+# the worker's behalf. NOT needed for Bedrock API-key (AWS_BEARER_TOKEN_BEDROCK)
+# auth, only for SigV4. Workers use the stock anthropic SDK, never boto3/botocore.
+# pip install botocore
 
 # Optional: Rich inventory metadata (decorators, annotations, visibility, typed params)
 # pip install tree-sitter tree-sitter-python tree-sitter-java tree-sitter-javascript tree-sitter-c tree-sitter-go


### PR DESCRIPTION
Route AWS Bedrock through the credential-isolation dispatcher so analysis
workers reach it with no AWS credentials in their address space — closing
the one auth scheme the dispatcher couldn't relay (raised in PR https://github.com/gadievron/raptor/pull/696
review, where a BedrockProvider authenticated with boto3 inside the
worker).

Bedrock can't be relayed as a static header, so the rule gains a
prepare_request hook that rewrites the worker's stock-Anthropic
/v1/messages request into Bedrock's /model/<id>/invoke shape and attaches
auth one of two ways:
  * Bedrock API key (AWS_BEARER_TOKEN_BEDROCK) — static Authorization:
    Bearer header; no botocore, no signing; takes precedence over SigV4
    (matching the AWS SDKs).
  * SigV4 — sign the rewritten request with the parent's AWS credentials
    via botocore's SigV4Auth (static keys or the profile/SSO/IMDS chain).

The parent's AWS secrets (keys + bearer token) are read-and-erased at
CredentialStore construction like every other provider key, so they
never flow to spawned workers. botocore is an optional, parent-only
dependency needed only for SigV4; the bearer path needs nothing extra.
Non-streaming InvokeModel only.

Verified live against AWS Bedrock (eu-west-1) through the dispatcher in
both auth modes; signature additionally checked offline against a re-sign
of the exact wire request and against boto3's own InvokeModel request.

76 dispatcher tests pass (bearer + 503 + env-scrub run without botocore;
SigV4 tests importorskip it).