### PR TITLE
feat(coverage): unified store-backed reporting + /understand fold-in, function-level marks, per-file table

### DIFF
--- a/.claude/skills/coverage.md
+++ b/.claude/skills/coverage.md
@@ -74,60 +74,58 @@ libexec/raptor-project-manager coverage --detailed
 
 ## Python API
 
+Coverage reporting is store-backed and unified: one `render_coverage()` shows
+coverage **state** (from the persistent store) plus per-run tool **execution**
+detail (from the records).
+
 ```python
-from core.coverage.summary import compute_summary, compute_project_summary
-from core.coverage.summary import format_summary, format_detailed
+from pathlib import Path
+from core.coverage.store_summary import (
+    render_coverage,        # unified report string (state + execution detail)
+    render_run_coverage,    # single-run convenience wrapper
+    coverage_view,          # the store-backed view dict (for --fail-under etc.)
+)
 
-# Single run
-summary = compute_summary(Path("out/projects/vulns/validate-20260411/"))
-print(format_summary(summary))
+# Single run (resolves checklist/coverage.json/annotations under the dir):
+print(render_run_coverage(Path("out/projects/vulns/validate-20260411/")))
 
-# Project-wide (aggregated)
-from core.project.project import Project, ProjectManager
-p = ProjectManager().load("vulns")
-summary = compute_project_summary(p)
-print(format_detailed(summary))
+# Explicit inputs (a run dir, or a project's output dir + its run dirs):
+report = render_coverage(run_dirs, checklist, store_path, annotations_base)
+print(report)
+
+# Programmatic view (e.g. to apply a threshold):
+view = coverage_view(run_dirs, checklist, store_path, annotations_base)
 ```
 
-### Summary dict structure
+### View dict structure (store-backed coverage state)
 
 ```python
 {
-    "inventory": {"files": 10, "sloc": 103, "items": 11},
-    "tools": {
-        "semgrep": {
-            "files_examined": 10, "files_total": 10,
-            "rules_applied": ["crypto"], "files_failed": [],
-        },
-        "codeql": {
-            "files_examined": 10, "files_total": 10,
-            "packs": ["codeql/cpp-queries"], "rules_applied": [...],
-        },
-        "llm": {
-            "files_examined": 10, "files_total": 10,
-            "functions_analysed": 10, "functions_total": 11,
-            "sloc_analysed": 95,
-        },
-    },
-    "unreviewed_functions": 1,
-    "unreviewed_sloc": 8,
-    "missing_groups": ["injection", "auth", ...],
-    "per_file": [
-        {
-            "path": "09_stack_overread.c",
-            "sloc": 12,
-            "reviewed": 1,
-            "total": 2,
-            "pct": 50.0,
-            "findings": 1,
-            "unreviewed_functions": ["record"],
-            "scanned_semgrep": True,
-            "scanned_codeql": True,
-            "scanned_llm": True,
-        },
-        ...
-    ],
+    "target": "...", "content_id": "content:...",
+    "total_functions": 11,                 # all items, any kind
+    "items_by_kind": {"function": 8, "global": 2, "interstitial": 1},
+    "functions_covered": 10,               # examined by any tool (verdict-based)
+    "functions_by_category": {"static": 10, "llm": 7, "runtime": 0},
+    "llm_reviewable": 8,                    # function + top_level items only
+    "gap_no_tool": 1, "gap_no_llm": 1,     # gap_no_llm counts reviewable kinds
+    "llm_gap_functions": [{"file": ..., "function": ..., "line": ...}],
+    "verdicts": {"clean": 9, "open": 1, "found_then_lost": 0, "unexamined": 1},
+    "review_gap": [...],
+    "provenance": {...},
 }
+```
+
+Per-run tool **execution** detail (files examined, rules/packs, files failed,
+Semgrep policy-group validation) is separate, read from the records:
+
+```python
+from core.coverage.summary import execution_detail, format_execution_detail
+detail = execution_detail(run_dirs, checklist)
+# {"tools": {"semgrep": {"files_examined": 10, "files_total": 10,
+#                        "rules_applied": ["crypto"], "packs": [],
+#                        "files_failed": [], "version": "1.55"}, ...},
+#  "missing_groups": ["injection", "auth", ...]}
+print(format_execution_detail(detail))
 ```
 
 ### Reading/writing records directly

--- a/core/coverage/__init__.py
+++ b/core/coverage/__init__.py
@@ -1,7 +1,9 @@
 """Coverage tracking and reporting.
 
-Provides coverage record building (from hook manifests and tool output),
-file read tracking, and Phase 2 coverage summary reporting.
+Provides coverage record building (from hook manifests and tool output), file
+read tracking, the persistent verdict-bearing store, and the unified
+store-backed coverage report (coverage state from the store + per-run tool
+execution detail from records).
 """
 
 from .record import (
@@ -31,10 +33,14 @@ from .importer import (
     import_findings,
     import_run_findings,
     import_annotations,
+    import_understand,
     run_provenance,
 )
 from .store_summary import (
     store_view, format_store_view, file_level_view, format_file_level_view,
+    render_coverage, coverage_view, render_run_coverage,
+    store_coverage_threshold_met, format_store_threshold_result,
+    store_llm_coverage_percent,
 )
 from .clean import (
     clean_run,
@@ -70,11 +76,18 @@ __all__ = [
     "import_findings",
     "import_run_findings",
     "import_annotations",
+    "import_understand",
     "run_provenance",
     "store_view",
     "format_store_view",
     "file_level_view",
     "format_file_level_view",
+    "render_coverage",
+    "coverage_view",
+    "render_run_coverage",
+    "store_coverage_threshold_met",
+    "format_store_threshold_result",
+    "store_llm_coverage_percent",
     "clean_run",
     "classify_removal",
     "apply_removal",

--- a/core/coverage/importer.py
+++ b/core/coverage/importer.py
@@ -295,17 +295,127 @@ def import_annotations(
     return imported
 
 
+# /understand --map writes context-map.json (location-bearing sections below);
+# /understand --trace writes flow-trace-*.json with a steps[] call chain. Each
+# carries (file, line) points the LLM identified/traced — real examination
+# evidence. Mapped to the `understand` tool label (llm category via the
+# registry). _UNDERSTAND_SECTIONS mirrors the bridge's _LOCATION_BEARING_SECTIONS.
+_UNDERSTAND_SECTIONS = ("entry_points", "sink_details", "boundary_details")
+
+
+def _understand_points(run_dir: Path):
+    """Yield (file, line) pairs from a run's /understand outputs: context-map
+    entry points / sinks / trust boundaries, and every flow-trace step."""
+    run = Path(run_dir)
+    cm = load_json(run / "context-map.json")
+    if isinstance(cm, dict):
+        for section in _UNDERSTAND_SECTIONS:
+            for entry in cm.get(section) or []:
+                if not isinstance(entry, dict):
+                    continue
+                f = entry.get("file")
+                ln = entry.get("line")
+                if ln is None:
+                    ln = entry.get("line_start")
+                if isinstance(f, str) and f and isinstance(ln, int):
+                    yield f, ln
+    for tf in sorted(run.glob("flow-trace-*.json")):
+        trace = load_json(tf)
+        if not isinstance(trace, dict):
+            continue
+        for step in trace.get("steps") or []:
+            if not isinstance(step, dict):
+                continue
+            f = step.get("file")
+            ln = step.get("line")
+            if isinstance(f, str) and f and isinstance(ln, int):
+                yield f, ln
+
+
+def import_understand(
+    store: CoverageStore, run_dir: Path, checklist: Dict[str, Any],
+    tool: str = "understand",
+) -> int:
+    """Fold a run's /understand outputs into the store as llm-category coverage.
+
+    Lines are marked individually — honest about exactly what /understand
+    identified/traced — and the function-level rollup then counts the containing
+    function as examined. Paths are normalised to the inventory's keys (the
+    on-disk context-map may carry absolute / ``./`` paths). Returns marks made.
+    """
+    inv = _inventory_paths(checklist)
+    marks = 0
+    for f, ln in _understand_points(run_dir):
+        store.mark(_to_inventory_path(f, inv), ln, ln, tool)
+        marks += 1
+    return marks
+
+
+def _function_ranges(checklist: Dict[str, Any]) -> Dict[tuple, tuple]:
+    """``{(path, name): (line_start, line_end)}`` over every inventory item."""
+    out: Dict[tuple, tuple] = {}
+    for fe in checklist.get("files", []):
+        path = fe.get("path")
+        if not path:
+            continue
+        for it in fe.get("items", fe.get("functions", [])):
+            name = it.get("name")
+            if name:
+                out[(path, name)] = (it.get("line_start", 0), it.get("line_end"))
+    return out
+
+
+def import_functions_analysed(
+    store: CoverageStore,
+    record: Dict[str, Any],
+    ranges: Dict[tuple, tuple],
+    inventory_paths: set,
+    provenance: Optional[Dict[str, Any]] = None,
+) -> int:
+    """Function-level marks from a record's ``functions_analysed`` — the precise
+    "this function was reviewed" signal (an operator ``--mark``, or a
+    multi-stage analyser recording the sinks it examined). Distinct from
+    ``files_examined`` (whole-file "the tool looked at this file"): marking one
+    function must NOT mark the whole file. Each (file, function) is resolved to
+    its inventory line range and marked with the record's tool; entries that
+    don't resolve to an inventory function are skipped. Returns the count."""
+    tool = record.get("tool")
+    fa_list = record.get("functions_analysed")
+    if not tool or not fa_list:
+        return 0
+    stamp = _tool_stamp(tool, provenance) if provenance else None
+    marked = 0
+    for fa in fa_list:
+        if not isinstance(fa, dict):
+            continue
+        f = _to_inventory_path(fa.get("file") or "", inventory_paths)
+        rng = ranges.get((f, fa.get("function")))
+        if rng is None:
+            continue
+        lo, hi = rng
+        store.mark(f, lo, hi if hi is not None else lo, tool)
+        if stamp:
+            store.stamp_coverage(f, tool, **stamp)
+        marked += 1
+    return marked
+
+
 def import_run_dir(
     store: CoverageStore, run_dir: Path, checklist: Dict[str, Any],
 ) -> int:
-    """Import all coverage records in ``run_dir`` (file-level), stamping each
-    contribution with the run's manifest provenance."""
+    """Import all coverage records in ``run_dir``: whole-file marks from
+    ``files_examined`` (a tool examined the file) AND function-level marks from
+    ``functions_analysed`` (specific functions reviewed), each stamped with the
+    run's manifest provenance."""
     total_lines = _total_lines_by_file(checklist)
+    ranges = _function_ranges(checklist)
+    inv_paths = _inventory_paths(checklist)
     prov = run_provenance(run_dir)
-    return sum(
-        import_record(store, rec, total_lines, prov)
-        for rec in load_records(Path(run_dir))
-    )
+    total = 0
+    for rec in load_records(Path(run_dir)):
+        total += import_record(store, rec, total_lines, prov)
+        total += import_functions_analysed(store, rec, ranges, inv_paths, prov)
+    return total
 
 
 def backfill(
@@ -326,6 +436,7 @@ def backfill(
     total = import_checked_by(store, checklist)
     for run_dir in run_dirs:
         total += import_run_dir(store, run_dir, checklist)
+        total += import_understand(store, run_dir, checklist)   # /understand fold-in
         import_run_findings(store, run_dir, inv_paths)   # link findings for verdicts
     if annotations_base is not None:
         total += import_annotations(store, annotations_base, checklist)

--- a/core/coverage/store_summary.py
+++ b/core/coverage/store_summary.py
@@ -21,6 +21,10 @@ from .registry import category_of
 from .store import CoverageStore, iter_inventory_functions
 
 _CATEGORIES = ("static", "llm", "runtime")
+# Kinds an LLM reviews unit-by-unit. The LLM-review gap is scoped to these:
+# globals/macros/typedefs/classes are whole-file-scanner territory and
+# interstitial is glue — listing them overstates "unreviewed".
+_REVIEWABLE_KINDS = ("function", "top_level")
 
 
 def file_level_view(run_dirs: Iterable[Path]) -> Dict[str, Any]:
@@ -81,27 +85,145 @@ def file_level_view(run_dirs: Iterable[Path]) -> Dict[str, Any]:
     }
 
 
-def render_run_coverage(run_dir) -> "str | None":
-    """Build and format a single run's coverage view on-demand, or None if
-    there's nothing to show. Store view (category/depth + verdicts) when the run
-    has an inventory (checklist.json — possibly a symlink to the project one);
-    the file-level tier otherwise. Used to print a coverage summary at the end
-    of a run (e.g. /agentic). Read-only — does not persist."""
-    from core.json import load_json
+def render_coverage(
+    run_dirs, checklist, store_path, annotations_base=None, detailed=False,
+) -> "str | None":
+    """The unified coverage report — the single rendering path for every
+    surface (/project coverage, standalone /scan, /agentic, raptor-coverage-summary).
 
+    When an inventory (checklist) is present: builds the store on-demand
+    (loads the durable ``coverage.json`` if any, re-imports current records +
+    /understand + annotations — idempotent, read-only) and renders the
+    store-backed coverage STATE (category/depth, verdicts, kinds, gaps,
+    provenance) followed by the per-run tool EXECUTION detail (rules/packs/
+    files_failed/policy validation) read from records. Coverage numbers are the
+    store's; execution detail is run-scoped diagnostics shown alongside.
+
+    With no inventory (a bare /scan or /codeql): degrades to the file-level
+    tier. Returns ``None`` when there's nothing to show.
+    """
+    from .summary import execution_detail, format_execution_detail
+
+    run_dirs = list(run_dirs)
+    if checklist:
+        store = _build_store(run_dirs, checklist, store_path, annotations_base)
+        parts = [format_store_view(store_view(store, checklist),
+                                   max_gap=200 if detailed else 15)]
+        if detailed:
+            table = format_file_breakdown(file_breakdown(store, checklist))
+            if table:
+                parts.append(table)
+        exec_section = format_execution_detail(execution_detail(run_dirs, checklist))
+        if exec_section:
+            parts.append(exec_section)
+        return "\n".join(parts)
+
+    fv = file_level_view(run_dirs)
+    if fv.get("tools") or fv.get("runs"):
+        return format_file_level_view(fv)
+    return None
+
+
+def _build_store(run_dirs, checklist, store_path, annotations_base=None):
+    """Construct the store on-demand: load the durable ``coverage.json`` (if
+    any) then re-import the current records + /understand + annotations.
+    Idempotent and read-only (never saves). The single store-construction path."""
     from .importer import backfill
     from .store import CoverageStore
 
+    store = CoverageStore(Path(store_path))
+    backfill(store, list(run_dirs), checklist, annotations_base=annotations_base)
+    return store
+
+
+def coverage_view(run_dirs, checklist, store_path, annotations_base=None):
+    """The store-backed :func:`store_view`, or None when there's no inventory.
+    Used for the rendered report and the ``--fail-under`` threshold check."""
+    if not checklist:
+        return None
+    return store_view(
+        _build_store(run_dirs, checklist, store_path, annotations_base), checklist)
+
+
+def file_breakdown(store: CoverageStore, checklist: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Per-file rollup for the ``--detailed`` view: item count, llm-reviewed
+    reviewable units, examined items, findings, and file coverage %. Sorted
+    worst-first by LLM-review ratio so files needing attention surface first."""
+    files: Dict[str, Dict[str, Any]] = {}
+    for f, _name, lo, hi, kind in iter_inventory_functions(checklist):
+        high = hi if hi is not None else lo
+        row = files.setdefault(f, {
+            "path": f, "items": 0, "reviewable": 0, "llm": 0, "examined": 0})
+        row["items"] += 1
+        cats = {category_of(t) for t in store.tool_coverage_of_range(f, lo, high)}
+        if store.function_verdict(f, lo, high) != "unexamined":
+            row["examined"] += 1
+        if kind in _REVIEWABLE_KINDS:
+            row["reviewable"] += 1
+            if "llm" in cats:
+                row["llm"] += 1
+    for f, row in files.items():
+        row["findings"] = len(store.finding_ids(f))
+        row["coverage"] = store.file_coverage(f)
+    return sorted(
+        files.values(),
+        key=lambda r: ((r["llm"] / r["reviewable"]) if r["reviewable"] else 1.0,
+                       r["path"]))
+
+
+def format_file_breakdown(rows: List[Dict[str, Any]], max_files: int = 40) -> str:
+    """Render :func:`file_breakdown` as a per-file table ('' if empty)."""
+    if not rows:
+        return ""
+    name_w = min(max(len(r["path"]) for r in rows), 60)
+    lines = [
+        "  Per-file (worst LLM-review first):",
+        f"    {'file':<{name_w}}  {'cov%':>5}  {'llm':>7}  {'exam':>7}  {'find':>4}",
+    ]
+    for r in rows[:max_files]:
+        llm = f"{r['llm']}/{r['reviewable']}" if r["reviewable"] else "—"
+        exam = f"{r['examined']}/{r['items']}"
+        find = str(r["findings"]) if r["findings"] else "-"
+        lines.append(
+            f"    {r['path'][:name_w]:<{name_w}}  {r['coverage']:>4.0f}%  "
+            f"{llm:>7}  {exam:>7}  {find:>4}")
+    if len(rows) > max_files:
+        lines.append(f"    … (+{len(rows) - max_files} more files)")
+    return "\n".join(lines)
+
+
+def render_run_coverage(run_dir) -> "str | None":
+    """Single-run convenience wrapper over :func:`render_coverage` (used by
+    /agentic and standalone /scan end-of-run printing). Read-only."""
+    from core.json import load_json
+
     run = Path(run_dir)
-    checklist = load_json(run / "checklist.json")
-    if checklist:
-        store = CoverageStore(run / "coverage.json")  # fresh; backfill fills it
-        backfill(store, [run], checklist)
-        return format_store_view(store_view(store, checklist))
-    view = file_level_view([run])
-    if view.get("tools") or view.get("runs"):
-        return format_file_level_view(view)
-    return None
+    return render_coverage(
+        [run], load_json(run / "checklist.json"), run / "coverage.json",
+        annotations_base=run / "annotations",
+    )
+
+
+def store_llm_coverage_percent(view: Dict[str, Any]) -> float:
+    """Percent of REVIEWABLE units (function/top_level) with LLM coverage."""
+    total = view.get("llm_reviewable", 0)
+    if not total:
+        return 100.0
+    reviewed = total - view.get("gap_no_llm", 0)
+    return max(0.0, min(100.0, reviewed / total * 100))
+
+
+def store_coverage_threshold_met(view: Dict[str, Any], fail_under: float) -> bool:
+    return store_llm_coverage_percent(view) >= fail_under
+
+
+def format_store_threshold_result(view: Dict[str, Any], fail_under: float) -> str:
+    pct = store_llm_coverage_percent(view)
+    status = "PASS" if pct >= fail_under else "FAIL"
+    return (
+        f"Coverage threshold: {pct:.1f}% LLM item coverage; "
+        f"required {fail_under:.1f}% — {status}"
+    )
 
 
 def format_file_level_view(view: Dict[str, Any], max_files: int = 20) -> str:
@@ -138,6 +260,7 @@ def store_view(store: CoverageStore, checklist: Dict[str, Any]) -> Dict[str, Any
     """
     total = 0
     covered_any = 0
+    reviewable_total = 0
     by_category = {c: 0 for c in _CATEGORIES}
     by_kind: Dict[str, int] = {}
     llm_gap: List[Dict[str, Any]] = []
@@ -166,17 +289,22 @@ def store_view(store: CoverageStore, checklist: Dict[str, Any]) -> Dict[str, Any
         for c in _CATEGORIES:
             if c in cats:
                 by_category[c] += 1
-        # Interstitial counts toward completeness (total/by_kind/examined/
-        # verdicts) but is kept OUT of the actionable gap *listings*: it's
-        # non-function glue (includes, top-level lines) that whole-file scanners
-        # cover and that the LLM doesn't review unit-by-unit — listing every
-        # file's interstitial would drown the real function gaps.
         is_interstitial = kind == "interstitial"
-        if "llm" not in cats and not is_interstitial:
-            llm_gap.append({"file": file, "function": name, "line": lo})
+        # The LLM-review gap lists only REVIEWABLE units (function / top_level).
+        # Globals/macros/typedefs/classes are whole-file-scanner territory and
+        # interstitial is glue — none are units the LLM reviews one-by-one, so
+        # listing them overstates "unreviewed" and drowns the real gaps.
+        # (Completeness counts above — total/by_kind/examined/verdicts — still
+        # include every kind.)
+        if kind in _REVIEWABLE_KINDS:
+            reviewable_total += 1
+            if "llm" not in cats:
+                llm_gap.append({"file": file, "function": name, "line": lo})
 
         verdicts[verdict] = verdicts.get(verdict, 0) + 1
-        # The re-review gap: never examined, or found-then-lost (functions only).
+        # The re-review gap: never examined (by ANY tool) or found-then-lost.
+        # Interstitial glue excluded; other kinds kept — a genuinely unexamined
+        # global (no scanner ran over it) is a real gap worth surfacing.
         if verdict in ("unexamined", "found_then_lost") and not is_interstitial:
             review_gap.append(
                 {"file": file, "function": name, "line": lo, "verdict": verdict}
@@ -189,6 +317,7 @@ def store_view(store: CoverageStore, checklist: Dict[str, Any]) -> Dict[str, Any
         "items_by_kind": by_kind,
         "functions_covered": covered_any,
         "functions_by_category": by_category,
+        "llm_reviewable": reviewable_total,
         "gap_no_tool": total_gap,
         "gap_no_llm": len(llm_gap),
         "llm_gap_functions": llm_gap,

--- a/core/coverage/summary.py
+++ b/core/coverage/summary.py
@@ -1,541 +1,108 @@
-"""Coverage summary — Phase 2 reporting.
+"""Coverage — per-run tool EXECUTION detail (record-backed).
 
-Computes and formats coverage summaries from checklist.json and
-coverage-*.json records. Supports single-run and project-wide aggregation.
+Coverage *state* (what's examined, verdicts, kinds, %) is owned by the
+persistent store and rendered by ``store_summary.py`` (the single coverage
+report). This module holds the complementary per-run *execution* detail read
+from the ``coverage-<tool>.json`` records — which files each tool examined, the
+rules/packs it applied, files it failed to process, and the Semgrep
+policy-group validation — shown alongside the store-backed report rather than
+folded into it (run-scoped diagnostics, not durable coverage). Also home to
+``_match_to_inventory`` (path normalisation shared with the importer).
 """
 
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from core.json import load_json
-from .record import load_records, write_record
+from .record import load_records
 
 
-def compute_summary(run_dir: Path) -> Optional[Dict[str, Any]]:
-    """Compute coverage summary from a run directory.
+def execution_detail(run_dirs, checklist: Dict[str, Any]) -> Dict[str, Any]:
+    """Per-run tool EXECUTION detail — NOT coverage state (that's the store's).
 
-    Returns a dict with inventory stats and per-tool coverage, or None
-    if no checklist exists.
+    Reads the per-run ``coverage-<tool>.json`` records across ``run_dirs``:
+    which files each tool examined (count vs the inventory total), the
+    rules/packs it applied, files it failed to process, and its version; plus
+    the Semgrep policy-group validation (configured groups NOT used). This is
+    run-scoped diagnostic info — "did the scanners run correctly" — shown
+    alongside the durable store-backed coverage view, not folded into it.
     """
-    run_dir = Path(run_dir)
-    checklist = load_json(run_dir / "checklist.json")
-    if not checklist:
-        return None
+    files = checklist.get("files", []) if checklist else []
+    files_total = len(files)
+    inv_paths = {fe.get("path") for fe in files if fe.get("path")}
 
-    # Inventory stats
-    files = checklist.get("files", [])
-    total_files = len(files)
-    total_sloc = sum(f.get("sloc", 0) for f in files)
-    total_items = sum(
-        len(f.get("items", f.get("functions", [])))
-        for f in files
-    )
-    inventory_paths = set()
-    for f in files:
-        path = f.get("path", "")
-        if path:
-            inventory_paths.add(path)
+    tools: Dict[str, Any] = {}
+    for rd in run_dirs:
+        for rec in load_records(Path(rd)):
+            tool = rec.get("tool")
+            if not tool:
+                continue
+            t = tools.setdefault(tool, {
+                "examined": set(), "rules_applied": set(), "packs": set(),
+                "files_failed": [], "version": None,
+            })
+            for p in rec.get("files_examined", []) or []:
+                t["examined"].add(_match_to_inventory(p, inv_paths) or p)
+            t["rules_applied"].update(rec.get("rules_applied", []) or [])
+            t["packs"].update(rec.get("packs", []) or [])
+            t["files_failed"].extend(rec.get("files_failed", []) or [])
+            if rec.get("version"):
+                t["version"] = rec["version"]
 
-    # Build function lookup: {normalised_path: [func_names]}
-    func_lookup = {}
-    for f in files:
-        path = f.get("path", "")
-        items = f.get("items", f.get("functions", []))
-        func_lookup[path] = [item.get("name", "") for item in items]
-
-    # Load coverage records
-    records = load_records(run_dir)
-
-    tools = {}
-    for record in records:
-        tool = record.get("tool", "unknown")
-        examined = set(record.get("files_examined", []))
-
-        # Normalise: strip leading ./ or target prefix for matching
-        examined_normalised = set()
-        for p in examined:
-            # Try matching against inventory paths
-            matched = _match_to_inventory(p, inventory_paths)
-            if matched:
-                examined_normalised.add(matched)
-            else:
-                examined_normalised.add(p)
-
-        tool_info = {
-            "files_examined": len(examined_normalised & inventory_paths),
-            "files_total": total_files,
+    out_tools: Dict[str, Any] = {}
+    for tool, t in sorted(tools.items()):
+        examined = len(t["examined"] & inv_paths) if inv_paths else len(t["examined"])
+        out_tools[tool] = {
+            "files_examined": examined,
+            "files_total": files_total,
+            "rules_applied": sorted(t["rules_applied"]),
+            "packs": sorted(t["packs"]),
+            "files_failed": t["files_failed"],
+            "version": t["version"],
         }
-
-        # Tool-specific fields
-        if record.get("rules_applied"):
-            tool_info["rules_applied"] = record["rules_applied"]
-        if record.get("packs"):
-            tool_info["packs"] = record["packs"]
-        if record.get("files_failed"):
-            tool_info["files_failed"] = record["files_failed"]
-        if record.get("version"):
-            tool_info["version"] = record["version"]
-
-        # Functions analysed (LLM)
-        functions_analysed = record.get("functions_analysed", [])
-        if functions_analysed:
-            # Deduplicate before counting. A single tool can record
-            # the same (file, function) twice — most commonly when
-            # a multi-stage analyser (validate stages A/B/C/D each
-            # touch the same sink function) appends per-stage entries
-            # without checking; or when an enrichment pass re-records
-            # an already-analysed function. Pre-fix the
-            # `len(functions_analysed)` count and the line-range sum
-            # both double-counted: a function analysed twice was
-            # reported as `functions_analysed=2` and its line range
-            # was added twice to `sloc_analysed`, inflating coverage
-            # numbers for any tool that records repeats.
-            seen_keys = set()
-            deduped = []
-            for fa in functions_analysed:
-                key = (fa.get("file", ""), fa.get("function", ""))
-                if key in seen_keys:
-                    continue
-                seen_keys.add(key)
-                deduped.append(fa)
-
-            tool_info["functions_analysed"] = len(deduped)
-            tool_info["functions_total"] = total_items
-            # Compute SLOC covered by analysed functions.
-            analysed_sloc = 0
-            for fa in deduped:
-                file_path = fa.get("file", "")
-                func_name = fa.get("function", "")
-                matched_path = _match_to_inventory(file_path, inventory_paths) or file_path
-                for f in files:
-                    if f.get("path") == matched_path:
-                        for item in f.get("items", f.get("functions", [])):
-                            if item.get("name") == func_name:
-                                start = item.get("line_start", item.get("line", 0))
-                                end = item.get("line_end", start)
-                                if end > start:
-                                    analysed_sloc += end - start
-                                break
-                        break
-            if analysed_sloc:
-                tool_info["sloc_analysed"] = analysed_sloc
-
-        tools[tool] = tool_info
-
-    # Compute unreviewed
-    llm_info = tools.get("llm", {})
-    reviewed_funcs = llm_info.get("functions_analysed", 0)
-    unreviewed_funcs = total_items - reviewed_funcs
-
-    # Tool config validation — check Semgrep policy groups
-    missing_groups = []
-    semgrep_info = tools.get("semgrep", {})
-    if semgrep_info:
-        try:
-            from core.config import RaptorConfig
-            all_groups = set(RaptorConfig.POLICY_GROUP_TO_SEMGREP_PACK.keys())
-            used_groups = set(semgrep_info.get("rules_applied", []))
-            missing_groups = sorted(all_groups - used_groups)
-        except (AttributeError, ImportError) as exc:
-            # Narrowed from bare Exception — pre-fix any code-bug
-            # (TypeError, KeyError on a renamed field) silently
-            # produced empty ``missing_groups``, making the coverage
-            # report claim complete policy coverage when the check
-            # itself didn't run. The audit explicitly flagged this.
-            # Surface the failure so a renamed constant doesn't
-            # quietly degrade the report.
-            from core.logging import get_logger as _get_logger
-            _get_logger().warning(
-                "coverage.summary: policy-group reflection failed: %s; "
-                "report omits policy-coverage section",
-                exc,
-            )
-
-    # Per-file breakdown
-    # Build sets of files examined by each tool
-    tool_files = {}
-    for record in records:
-        tool = record.get("tool", "unknown")
-        examined = set()
-        for p in record.get("files_examined", []):
-            matched = _match_to_inventory(p, inventory_paths) or p
-            examined.add(matched)
-        tool_files[tool] = examined
-
-    # Build set of analysed functions
-    analysed_funcs_by_file = set()
-    for record in records:
-        for fa in record.get("functions_analysed", []):
-            path = _match_to_inventory(fa.get("file", ""), inventory_paths) or fa.get("file", "")
-            analysed_funcs_by_file.add((path, fa.get("function", "")))
-
-    # Count findings and vulns per file from findings.json
-    findings_by_file = {}
-    vulns_by_file = {}
-    findings_data = load_json(run_dir / "findings.json")
-    if findings_data:
-        if isinstance(findings_data, list):
-            findings_list = findings_data
-        elif isinstance(findings_data, dict):
-            findings_list = findings_data.get("findings", findings_data.get("results", []))
-        else:
-            findings_list = []
-        # Group findings per file for vuln counting
-        from collections import defaultdict
-        per_file_findings = defaultdict(list)
-        for finding in findings_list:
-            fpath = finding.get("file", "")
-            matched = _match_to_inventory(fpath, inventory_paths) or fpath
-            findings_by_file[matched] = findings_by_file.get(matched, 0) + 1
-            per_file_findings[matched].append(finding)
-        from core.project.findings_utils import count_vulns
-        for fpath, flist in per_file_findings.items():
-            vulns_by_file[fpath] = count_vulns(flist)
-
-    per_file = []
-    for f in files:
-        path = f.get("path", "")
-        items = f.get("items", f.get("functions", []))
-        total = len(items)
-        if total == 0:
-            continue
-        reviewed_names = [
-            item.get("name", "") for item in items
-            if (path, item.get("name", "")) in analysed_funcs_by_file
-        ]
-        unreviewed_names = [
-            item.get("name", "") for item in items
-            if (path, item.get("name", "")) not in analysed_funcs_by_file
-        ]
-        reviewed = len(reviewed_names)
-        pf_entry = {
-            "path": path,
-            "reviewed": reviewed,
-            "total": total,
-            "pct": reviewed / total * 100,
-            "sloc": f.get("sloc", 0),
-            "findings": findings_by_file.get(path, 0),
-            "vulns": vulns_by_file.get(path, 0),
-            "unreviewed_functions": unreviewed_names if unreviewed_names else [],
-        }
-        # Per-tool scan flags for detailed view
-        for tool_name in tool_files:
-            pf_entry[f"scanned_{tool_name}"] = path in tool_files[tool_name]
-        per_file.append(pf_entry)
-    per_file.sort(key=lambda x: (x["pct"], x["path"]))
-
-    return {
-        "inventory": {
-            "files": total_files,
-            "sloc": total_sloc,
-            "items": total_items,
-        },
-        "tools": tools,
-        "unreviewed_functions": unreviewed_funcs,
-        "unreviewed_sloc": total_sloc - llm_info.get("sloc_analysed", 0),
-        "missing_groups": missing_groups,
-        "per_file": per_file,
-    }
+    return {"tools": out_tools, "missing_groups": _missing_semgrep_groups(out_tools)}
 
 
-def _pl(n: int, word: str) -> str:
-    """Pluralise: 1 item, 2 items."""
-    return f"{n} {word}" if n == 1 else f"{n} {word}s"
+def _missing_semgrep_groups(tools: Dict[str, Any]) -> list:
+    """Configured Semgrep policy groups that the run did NOT use, or []."""
+    semgrep = tools.get("semgrep")
+    if not semgrep:
+        return []
+    try:
+        from core.config import RaptorConfig
+        all_groups = set(RaptorConfig.POLICY_GROUP_TO_SEMGREP_PACK.keys())
+        return sorted(all_groups - set(semgrep.get("rules_applied", [])))
+    except (AttributeError, ImportError) as exc:
+        # Narrowed: a renamed constant must surface, not silently claim
+        # complete policy coverage (the audit flagged this).
+        from core.logging import get_logger
+        get_logger().warning(
+            "coverage.execution_detail: policy-group reflection failed: %s; "
+            "omitting policy-coverage check", exc)
+        return []
 
 
-def llm_item_coverage_percent(summary: Dict[str, Any]) -> float:
-    """Return percentage of inventory items reviewed by LLM coverage records."""
-    if not summary:
-        return 0.0
-    total = summary.get("inventory", {}).get("items", 0)
-    if not total:
-        return 100.0
-    reviewed = total - summary.get("unreviewed_functions", 0)
-    return max(0.0, min(100.0, reviewed / total * 100))
-
-
-def coverage_threshold_met(summary: Dict[str, Any], fail_under: float) -> bool:
-    """Return whether LLM item coverage satisfies ``fail_under`` percent."""
-    return llm_item_coverage_percent(summary) >= fail_under
-
-
-def format_threshold_result(summary: Dict[str, Any], fail_under: float) -> str:
-    """Format a copy-paste friendly coverage threshold result."""
-    pct = llm_item_coverage_percent(summary)
-    status = "PASS" if coverage_threshold_met(summary, fail_under) else "FAIL"
-    return (
-        f"Coverage threshold: {pct:.1f}% LLM item coverage; "
-        f"required {fail_under:.1f}% — {status}"
-    )
-
-
-def format_summary(summary: Dict[str, Any]) -> str:
-    """Format coverage summary — Option D (actionable overview)."""
-    if not summary:
-        return "No coverage data available."
-
-    inv = summary["inventory"]
-    lines = [
-        "Coverage:",
-        f"  Inventory: {_pl(inv['files'], 'file')}, {inv['sloc']:,} SLOC, {_pl(inv['items'], 'item')}",
-    ]
-
-    for tool, info in summary["tools"].items():
-        files_pct = (info["files_examined"] / info["files_total"] * 100
-                     if info["files_total"] else 0)
-
-        if tool == "semgrep":
-            rules = info.get("rules_applied", [])
-            rules_str = f", {_pl(len(rules), 'group')}" if rules else ""
-            lines.append(
-                f"  Semgrep: {info['files_examined']}/{info['files_total']} files{rules_str}"
-            )
-        elif tool == "codeql":
-            packs = info.get("packs", [])
-            packs_str = f" ({', '.join(packs)})" if packs else ""
-            rules_count = len(info.get("rules_applied", []))
-            lines.append(
-                f"  CodeQL: {info['files_examined']}/{info['files_total']} files, "
-                f"{_pl(rules_count, 'rule')}{packs_str}"
-            )
-        elif tool == "llm":
-            funcs = info.get("functions_analysed", 0)
-            funcs_total = info.get("functions_total", 0)
-            lines.append(
-                f"  LLM: {info['files_examined']}/{info['files_total']} files, "
-                f"{funcs}/{funcs_total} {'function' if funcs_total == 1 else 'functions'}"
-            )
-        else:
-            lines.append(
-                f"  {tool}: {info['files_examined']}/{info['files_total']} files ({files_pct:.0f}%)"
-            )
-
-    # Action needed
-    actions = []
-    missing = summary.get("missing_groups", [])
+def format_execution_detail(detail: Dict[str, Any]) -> str:
+    """Render :func:`execution_detail` as an operator-facing section ('' if none)."""
+    tools = detail.get("tools") or {}
+    if not tools:
+        return ""
+    lines = ["  Tool execution (per-run scan detail):"]
+    for tool, info in tools.items():
+        bits = [f"{info['files_examined']}/{info['files_total']} files"]
+        if info.get("rules_applied"):
+            bits.append(f"{len(info['rules_applied'])} rule-group(s)")
+        if info.get("packs"):
+            bits.append(f"packs: {', '.join(info['packs'])}")
+        if info.get("files_failed"):
+            bits.append(f"{len(info['files_failed'])} failed")
+        ver = f" {info['version']}" if info.get("version") else ""
+        lines.append(f"    {tool}{ver}: {', '.join(bits)}")
+    missing = detail.get("missing_groups") or []
     if missing:
-        actions.append(f"{_pl(len(missing), 'Semgrep policy group')} not used")
-    unrev = summary["unreviewed_functions"]
-    if unrev > 0:
-        actions.append(f"{_pl(unrev, 'item')} not reviewed by LLM")
-    # Count files with findings but no LLM review
-    per_file = summary.get("per_file", [])
-    unreviewed_with_findings = [
-        pf for pf in per_file
-        if pf.get("findings", 0) > 0 and pf["reviewed"] == 0
-    ]
-    if unreviewed_with_findings:
-        total_vulns = sum(pf.get("vulns", pf["findings"]) for pf in unreviewed_with_findings)
-        actions.append(
-            f"{_pl(total_vulns, 'finding')} in {_pl(len(unreviewed_with_findings), 'file')} not yet reviewed"
-        )
-
-    if actions:
-        lines.append("")
-        lines.append("  Action needed:")
-        for a in actions:
-            lines.append(f"    {a}")
-
-    return "\n".join(lines)
-
-
-def format_detailed(summary: Dict[str, Any]) -> str:
-    """Format detailed per-file coverage table."""
-    if not summary:
-        return "No coverage data available."
-
-    inv = summary["inventory"]
-    lines = [
-        "Coverage (detailed):",
-        f"  Inventory: {_pl(inv['files'], 'file')}, {inv['sloc']:,} SLOC, {_pl(inv['items'], 'item')}",
-    ]
-
-    # Tool summary (same as format_summary but compact)
-    tools = summary.get("tools", {})
-    tool_abbrevs = []
-    if "semgrep" in tools:
-        tool_abbrevs.append(("S", "Semgrep"))
-    if "codeql" in tools:
-        tool_abbrevs.append(("C", "CodeQL"))
-    if "llm" in tools:
-        tool_abbrevs.append(("L", "LLM"))
-
-    per_file = summary.get("per_file", [])
-    if not per_file:
-        lines.append("\n  No per-file data available.")
-        return "\n".join(lines)
-
-    # Table header
-    lines.append("")
-    name_col = max(max(len(pf["path"]) for pf in per_file) + 2, 20)
-    fmt = f"  {{:<{name_col}s}} {{:>5s}}  {{:7s}}  {{:>10s}}  {{:>8s}}"
-    lines.append(fmt.format("File", "SLOC", "Scanned", "Items", "Findings"))
-    lines.append(fmt.format("-" * name_col, "-" * 5, "-" * 7, "-" * 10, "-" * 8))
-
-    # Sort: unreviewed with findings first, then unreviewed without, then reviewed
-    def _sort_key(pf):
-        has_findings = pf.get("findings", 0) > 0
-        is_reviewed = pf["reviewed"] > 0
-        # Priority: unreviewed+findings=0, unreviewed+no findings=1, reviewed=2
-        if not is_reviewed and has_findings:
-            return (0, -pf.get("findings", 0), pf["path"])
-        elif not is_reviewed:
-            return (1, 0, pf["path"])
-        else:
-            return (2, 0, pf["path"])
-
-    for pf in sorted(per_file, key=_sort_key):
-        # Scanned column: which tools scanned this file
-        scanned_flags = []
-        for abbrev, tool_name in tool_abbrevs:
-            tool_key = tool_name.lower()
-            # Check if this file was in the tool's examined list
-            if pf.get(f"scanned_{tool_key}", False):
-                scanned_flags.append(abbrev)
-            else:
-                scanned_flags.append(" ")
-        scanned_str = " ".join(scanned_flags) if scanned_flags else "-"
-
-        # Findings (grouped — one logical finding may span multiple lines)
-        vulns = pf.get("vulns", pf.get("findings", 0))
-        findings_str = str(vulns) if vulns else "-"
-
-        # Reviewed
-        if pf["total"] == 0:
-            reviewed_str = f"{'—':>10s}"
-        elif pf["reviewed"] == pf["total"]:
-            reviewed_str = f"{pf['reviewed']}/{pf['total']} \u2713".rjust(10)
-        elif pf["reviewed"] > 0:
-            reviewed_str = f"{pf['reviewed']}/{pf['total']}  ".rjust(10)
-        else:
-            reviewed_str = f"{'—':>10s}"
-
         lines.append(
-            f"  {pf['path']:<{name_col}s} {pf['sloc']:>5d}  {scanned_str:7s}  "
-            f"{reviewed_str}  {findings_str:>8s}"
-        )
-
-    # Legend
-    if tool_abbrevs:
-        legend = "  " + "  ".join(f"{a} = {n}" for a, n in tool_abbrevs)
-        lines.append("")
-        lines.append(legend)
-
+            f"    ⚠ {len(missing)} Semgrep policy group(s) not used: "
+            f"{', '.join(missing)}")
     return "\n".join(lines)
-
-
-def compute_project_summary(project) -> Optional[Dict[str, Any]]:
-    """Compute accumulated coverage across all runs in a project.
-
-    Merges coverage records from every run directory, using the project's
-    checklist as the inventory denominator.
-
-    Args:
-        project: A Project dataclass instance.
-
-    Returns a summary dict (same shape as compute_summary), or None.
-    """
-    output_path = Path(project.output_dir)
-
-    # Find the best checklist (project-level symlink or newest run's)
-    checklist = load_json(output_path / "checklist.json")
-    if not checklist:
-        for d in project.get_run_dirs(sweep=False):
-            cl = load_json(d / "checklist.json")
-            if cl:
-                checklist = cl
-                break
-    if not checklist:
-        return None
-
-    # Collect all records across runs
-    all_records = []
-    for d in project.get_run_dirs(sweep=False):
-        all_records.extend(load_records(d))
-
-    if not all_records:
-        # Still return inventory-only summary
-        pass
-
-    # Merge records by tool — union files_examined, union functions_analysed
-    merged_by_tool = {}
-    for record in all_records:
-        tool = record.get("tool", "unknown")
-        if tool not in merged_by_tool:
-            merged_by_tool[tool] = {
-                "tool": tool,
-                "files_examined": set(),
-                "functions_analysed": [],
-                # Maintain a parallel seen-set for the
-                # functions_analysed list. Pre-fix the dedup check
-                # rebuilt a fresh set comprehension over the entire
-                # list on EVERY incoming entry — O(N²) for N total
-                # functions across all records. Projects with a few
-                # thousand functions across multiple runs spent
-                # multiple seconds in this single line.
-                "_func_keys": set(),
-                "rules_applied": set(),
-                "packs": set(),
-                "files_failed": [],
-            }
-        m = merged_by_tool[tool]
-        for f in record.get("files_examined", []):
-            m["files_examined"].add(f)
-        for fa in record.get("functions_analysed", []):
-            key = (fa.get("file", ""), fa.get("function", ""))
-            if key not in m["_func_keys"]:
-                m["functions_analysed"].append(fa)
-                m["_func_keys"].add(key)
-        for r in record.get("rules_applied", []):
-            m["rules_applied"].add(r)
-        for p in record.get("packs", []):
-            m["packs"].add(p)
-        for f in record.get("files_failed", []):
-            m["files_failed"].append(f)
-
-    # Convert sets back to lists for compute_summary compatibility
-    merged_records = []
-    for m in merged_by_tool.values():
-        rec = {"tool": m["tool"], "files_examined": sorted(m["files_examined"])}
-        if m["functions_analysed"]:
-            rec["functions_analysed"] = m["functions_analysed"]
-        if m["rules_applied"]:
-            rec["rules_applied"] = sorted(m["rules_applied"])
-        if m["packs"]:
-            rec["packs"] = sorted(m["packs"])
-        if m["files_failed"]:
-            rec["files_failed"] = m["files_failed"]
-        merged_records.append(rec)
-
-    # Aggregate findings across all runs, dedup by (file, function, line)
-    all_findings = []
-    seen = set()
-    for d in project.get_run_dirs(sweep=False):
-        fdata = load_json(d / "findings.json")
-        if fdata:
-            if isinstance(fdata, list):
-                flist = fdata
-            elif isinstance(fdata, dict):
-                flist = fdata.get("findings", fdata.get("results", []))
-            else:
-                flist = []
-            for f in flist:
-                key = (f.get("file", ""), f.get("function", ""), f.get("line", 0))
-                if key not in seen:
-                    all_findings.append(f)
-                    seen.add(key)
-
-    # Build synthetic run dir with merged data to reuse compute_summary
-    import tempfile
-    with tempfile.TemporaryDirectory() as tmp:
-        tmp_path = Path(tmp)
-        from core.json import save_json
-        save_json(tmp_path / "checklist.json", checklist)
-        if all_findings:
-            save_json(tmp_path / "findings.json", {"findings": all_findings})
-        for rec in merged_records:
-            write_record(tmp_path, rec, tool_name=rec["tool"])
-        return compute_summary(tmp_path)
 
 
 def _match_to_inventory(path: str, inventory_paths: set) -> Optional[str]:

--- a/core/coverage/tests/test_importer.py
+++ b/core/coverage/tests/test_importer.py
@@ -10,6 +10,7 @@ from core.coverage.importer import (
     import_findings,
     import_record,
     import_run_dir,
+    import_understand,
 )
 from core.coverage.store import CoverageStore
 
@@ -30,6 +31,116 @@ _CHECKLIST = {
         ]},
     ],
 }
+
+
+def test_import_understand_marks_context_map_and_traces(tmp_path):
+    s = _store(tmp_path)
+    s.import_inventory_meta(_CHECKLIST)
+    run = tmp_path / "understand-1"
+    run.mkdir()
+    (run / "context-map.json").write_text(json.dumps({
+        "entry_points": [{"file": "a.c", "line": 5, "name": "f1"}],
+        "sink_details": [{"file": "a.c", "line_start": 35}],   # line_start fallback
+        "boundary_details": [{"file": "b.c", "line": 3}],
+    }))
+    (run / "flow-trace-001.json").write_text(json.dumps({
+        "steps": [{"file": "a.c", "line": 40}, {"file": "b.c", "line": 7}],
+    }))
+    n = import_understand(s, run, _CHECKLIST)
+    assert n == 5
+    # Marked under the `understand` tool (llm category via the registry).
+    assert s.who_checked("a.c", 5) == ["understand"]
+    assert s.who_checked("a.c", 35) == ["understand"]   # line_start used
+    # Function-level rollup: the containing function reads as llm-examined.
+    assert s.function_covered("a.c", 0, 20, category="llm") is True
+    assert s.function_covered("a.c", 30, 60, category="llm") is True
+    assert s.function_covered("b.c", 0, 10, category="llm") is True
+
+
+def test_import_understand_no_files_is_noop(tmp_path):
+    s = _store(tmp_path)
+    empty = tmp_path / "run-empty"
+    empty.mkdir()
+    assert import_understand(s, empty, _CHECKLIST) == 0
+
+
+def test_import_understand_tolerates_malformed(tmp_path):
+    s = _store(tmp_path)
+    run = tmp_path / "u"
+    run.mkdir()
+    (run / "context-map.json").write_text(json.dumps({
+        "entry_points": "not-a-list",
+        "sink_details": [{"file": "a.c"}, {"line": 5}, "junk", {"file": "a.c", "line": 9}],
+    }))
+    (run / "flow-trace-x.json").write_text(json.dumps({"steps": [{"nofile": 1}]}))
+    n = import_understand(s, run, _CHECKLIST)
+    assert n == 1                                  # only the well-formed sink
+    assert s.who_checked("a.c", 9) == ["understand"]
+
+
+def test_backfill_includes_understand(tmp_path):
+    s = _store(tmp_path)
+    run = tmp_path / "run-1"
+    run.mkdir()
+    (run / "context-map.json").write_text(json.dumps({
+        "entry_points": [{"file": "a.c", "line": 5}],
+    }))
+    backfill(s, [run], _CHECKLIST)
+    assert "understand" in s.who_checked("a.c", 5)
+
+
+def test_functions_analysed_marks_function_not_whole_file(tmp_path):
+    # An llm record as --mark now writes it: functions_analysed only (no
+    # files_examined). Only that function is marked — NOT the whole file.
+    s = _store(tmp_path)
+    run = tmp_path / "run"
+    run.mkdir()
+    (run / "coverage-llm.json").write_text(json.dumps({
+        "tool": "llm",
+        "functions_analysed": [{"file": "a.c", "function": "f1"}],
+    }))
+    # Local checklist with NO checked_by — so f2's only llm-coverage path would
+    # be functions_analysed (which doesn't include it), isolating the behaviour.
+    cl = {"files": [{"path": "a.c", "lines": 100, "items": [
+        {"name": "f1", "line_start": 0, "line_end": 20},
+        {"name": "f2", "line_start": 30, "line_end": 60}]}]}
+    backfill(s, [run], cl)
+    assert s.function_covered("a.c", 0, 20, category="llm") is True      # f1
+    assert s.function_covered("a.c", 30, 60, category="llm") is False    # f2 not
+    assert "llm" not in s.who_checked("a.c", 25)                         # gap line
+
+
+def test_files_examined_still_marks_whole_file(tmp_path):
+    # A reads-manifest-style llm record (files_examined, no functions_analysed)
+    # still marks the whole file — "the LLM read it".
+    s = _store(tmp_path)
+    run = tmp_path / "run"
+    run.mkdir()
+    (run / "coverage-llm.json").write_text(json.dumps({
+        "tool": "llm", "files_examined": ["a.c"],
+    }))
+    backfill(s, [run], _CHECKLIST)
+    assert s.function_covered("a.c", 0, 20, category="llm") is True
+    assert s.function_covered("a.c", 30, 60, category="llm") is True     # whole file
+
+
+def test_functions_analysed_resolves_abs_and_skips_unknown(tmp_path):
+    s = _store(tmp_path)
+    run = tmp_path / "run"
+    run.mkdir()
+    (run / "coverage-llm.json").write_text(json.dumps({
+        "tool": "llm",
+        "functions_analysed": [
+            {"file": "/abs/root/a.c", "function": "f1"},     # abs → resolves
+            {"file": "a.c", "function": "nonexistent"},      # skipped
+        ],
+    }))
+    cl = {"files": [{"path": "a.c", "lines": 100, "items": [
+        {"name": "f1", "line_start": 0, "line_end": 20},
+        {"name": "f2", "line_start": 30, "line_end": 60}]}]}
+    backfill(s, [run], cl)
+    assert s.function_covered("a.c", 0, 20, category="llm") is True
+    assert s.function_covered("a.c", 30, 60, category="llm") is False
 
 
 def test_import_checked_by_is_function_level_and_llm(tmp_path):

--- a/core/coverage/tests/test_store_summary.py
+++ b/core/coverage/tests/test_store_summary.py
@@ -201,3 +201,132 @@ def test_format_store_view_renders(tmp_path):
     assert "a.c:f2" in out
     # No red/green indicators (output-style rule).
     assert "🔴" not in out and "🟢" not in out
+
+
+_MIXED_KINDS = {"files": [{"path": "a.c", "lines": 50, "items": [
+    {"name": "fn", "kind": "function", "line_start": 1, "line_end": 10},
+    {"name": "tl", "kind": "top_level", "line_start": 12, "line_end": 12},
+    {"name": "G", "kind": "global", "line_start": 20, "line_end": 20},
+    {"name": "M", "kind": "macro", "line_start": 25, "line_end": 25},
+    {"name": "T", "kind": "class", "line_start": 30, "line_end": 35},
+]}]}
+
+
+def test_llm_gap_lists_only_reviewable_kinds(tmp_path):
+    # No llm coverage anywhere: only function + top_level are the LLM-review
+    # gap; globals/macros/typedefs are excluded by kind.
+    s = _store(tmp_path)
+    s.import_inventory_meta(_MIXED_KINDS)
+    view = store_view(s, _MIXED_KINDS)
+    assert {g["function"] for g in view["llm_gap_functions"]} == {"fn", "tl"}
+    assert view["llm_reviewable"] == 2
+    assert view["gap_no_llm"] == 2
+    # Completeness counts still include every kind.
+    assert view["total_functions"] == 5
+
+
+def test_llm_gap_excludes_reviewed_function(tmp_path):
+    s = _store(tmp_path)
+    s.import_inventory_meta(_MIXED_KINDS)
+    s.mark("a.c", 1, 10, "claude:audit")       # llm reviews fn
+    view = store_view(s, _MIXED_KINDS)
+    assert {g["function"] for g in view["llm_gap_functions"]} == {"tl"}
+    assert view["llm_reviewable"] == 2
+
+
+def test_store_threshold_helpers(tmp_path):
+    from core.coverage.store_summary import (
+        format_store_threshold_result,
+        store_coverage_threshold_met,
+        store_llm_coverage_percent,
+    )
+    s = _store(tmp_path)
+    s.import_inventory_meta(_MIXED_KINDS)
+    s.mark("a.c", 1, 10, "claude:audit")       # 1 of 2 reviewable → 50%
+    view = store_view(s, _MIXED_KINDS)
+    assert store_llm_coverage_percent(view) == 50.0
+    assert store_coverage_threshold_met(view, 50.0)
+    assert not store_coverage_threshold_met(view, 75.0)
+    result = format_store_threshold_result(view, 75.0)
+    assert "50.0% LLM item coverage" in result
+    assert "FAIL" in result
+
+
+def test_store_threshold_no_reviewable_is_100(tmp_path):
+    from core.coverage.store_summary import store_llm_coverage_percent
+    s = _store(tmp_path)
+    only_global = {"files": [{"path": "a.c", "lines": 5, "items": [
+        {"name": "G", "kind": "global", "line_start": 1, "line_end": 1}]}]}
+    s.import_inventory_meta(only_global)
+    assert store_llm_coverage_percent(store_view(s, only_global)) == 100.0
+
+
+def test_render_coverage_combines_state_and_execution(tmp_path):
+    import json
+    from core.coverage.store_summary import render_coverage
+    run = tmp_path / "run"
+    run.mkdir()
+    (run / "coverage-semgrep.json").write_text(json.dumps({
+        "tool": "semgrep", "files_examined": ["a.c"],
+        "rules_applied": ["crypto"], "version": "1.5", "timestamp": "t"}))
+    report = render_coverage([run], _CHECKLIST, run / "coverage.json")
+    assert "Coverage (persistent store)" in report     # store-state section
+    assert "Tool execution" in report                  # execution-detail section
+    assert "semgrep" in report
+
+
+def test_render_coverage_file_level_without_checklist(tmp_path):
+    import json
+    from core.coverage.store_summary import render_coverage
+    run = tmp_path / "run"
+    run.mkdir()
+    (run / ".raptor-run.json").write_text("{}")
+    (run / "coverage-semgrep.json").write_text(json.dumps({
+        "tool": "semgrep", "files_examined": ["x.c"], "timestamp": "t"}))
+    report = render_coverage([run], None, run / "coverage.json")
+    assert report is not None and "file-level" in report
+
+
+def test_coverage_view_none_without_checklist(tmp_path):
+    from core.coverage.store_summary import coverage_view
+    assert coverage_view([tmp_path], None, tmp_path / "coverage.json") is None
+
+
+def test_file_breakdown_counts_and_worst_first(tmp_path):
+    from core.coverage.store_summary import file_breakdown
+    s = _store(tmp_path)
+    s.import_inventory_meta(_CHECKLIST)
+    s.mark("a.c", 0, 20, "claude:audit")       # f1 llm-reviewed
+    s.link_finding("a.c", "F1", line=40)       # finding in f2
+    rows = file_breakdown(s, _CHECKLIST)
+    by_path = {r["path"]: r for r in rows}
+    assert by_path["a.c"]["items"] == 2
+    assert by_path["a.c"]["reviewable"] == 2
+    assert by_path["a.c"]["llm"] == 1
+    assert by_path["a.c"]["findings"] == 1
+    # b.c has no llm coverage (ratio 0) → sorts before a.c (ratio 0.5).
+    assert rows[0]["path"] == "b.c"
+
+
+def test_format_file_breakdown_table(tmp_path):
+    from core.coverage.store_summary import file_breakdown, format_file_breakdown
+    s = _store(tmp_path)
+    s.import_inventory_meta(_CHECKLIST)
+    table = format_file_breakdown(file_breakdown(s, _CHECKLIST))
+    assert "Per-file" in table
+    assert "a.c" in table and "b.c" in table
+    assert format_file_breakdown([]) == ""
+
+
+def test_render_coverage_detailed_includes_per_file_table(tmp_path):
+    import json
+    from core.coverage.store_summary import render_coverage
+    run = tmp_path / "run"
+    run.mkdir()
+    (run / "coverage-semgrep.json").write_text(json.dumps(
+        {"tool": "semgrep", "files_examined": ["a.c"], "timestamp": "t"}))
+    report = render_coverage([run], _CHECKLIST, run / "coverage.json", detailed=True)
+    assert "Per-file" in report
+    # Non-detailed omits the table.
+    plain = render_coverage([run], _CHECKLIST, run / "coverage.json")
+    assert "Per-file" not in plain

--- a/core/coverage/tests/test_summary.py
+++ b/core/coverage/tests/test_summary.py
@@ -1,64 +1,43 @@
-"""Tests for coverage summary computation and formatting."""
+"""Tests for per-run tool EXECUTION detail (record-backed) — the record side
+of the unified coverage report. Coverage *state* is tested in test_store_summary.py.
+"""
 
-import json
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from core.coverage.summary import (
-    compute_summary,
-    compute_project_summary,
-    coverage_threshold_met,
-    format_summary,
-    format_threshold_result,
-    llm_item_coverage_percent,
+    _match_to_inventory,
+    execution_detail,
+    format_execution_detail,
 )
 from core.coverage.record import write_record
 
+_CHECKLIST = {"files": [
+    {"path": "src/auth.c", "sloc": 100, "lines": 100, "items": [
+        {"name": "check_pw", "line_start": 10, "line_end": 40},
+        {"name": "login", "line_start": 50, "line_end": 80}]},
+    {"path": "src/db.c", "sloc": 200, "lines": 200, "items": [
+        {"name": "query", "line_start": 5, "line_end": 50}]},
+]}
 
-class TestComputeSummary(unittest.TestCase):
 
-    def _write_checklist(self, d, files=None):
-        if files is None:
-            files = [
-                {"path": "src/auth.c", "sloc": 100, "items": [
-                    {"name": "check_pw", "line_start": 10, "line_end": 40},
-                    {"name": "login", "line_start": 50, "line_end": 80},
-                ]},
-                {"path": "src/db.c", "sloc": 200, "items": [
-                    {"name": "query", "line_start": 5, "line_end": 50},
-                ]},
-            ]
-        checklist = {"files": files, "total_files": len(files)}
-        (Path(d) / "checklist.json").write_text(json.dumps(checklist))
+class TestExecutionDetail(unittest.TestCase):
 
-    def test_basic_summary(self):
+    def test_semgrep_files_and_rules(self):
         with TemporaryDirectory() as d:
-            self._write_checklist(d)
-            summary = compute_summary(d)
-            self.assertEqual(summary["inventory"]["files"], 2)
-            self.assertEqual(summary["inventory"]["sloc"], 300)
-            self.assertEqual(summary["inventory"]["items"], 3)
-
-    def test_no_checklist(self):
-        with TemporaryDirectory() as d:
-            self.assertIsNone(compute_summary(d))
-
-    def test_semgrep_coverage(self):
-        with TemporaryDirectory() as d:
-            self._write_checklist(d)
             write_record(Path(d), {
                 "tool": "semgrep",
                 "files_examined": ["src/auth.c", "src/db.c"],
                 "rules_applied": ["injection", "crypto"],
             }, tool_name="semgrep")
-            summary = compute_summary(d)
-            self.assertEqual(summary["tools"]["semgrep"]["files_examined"], 2)
-            self.assertEqual(summary["tools"]["semgrep"]["rules_applied"], ["injection", "crypto"])
+            t = execution_detail([Path(d)], _CHECKLIST)["tools"]["semgrep"]
+            self.assertEqual(t["files_examined"], 2)
+            self.assertEqual(t["files_total"], 2)
+            self.assertEqual(t["rules_applied"], ["crypto", "injection"])
 
-    def test_codeql_coverage(self):
+    def test_codeql_packs_and_files_failed(self):
         with TemporaryDirectory() as d:
-            self._write_checklist(d)
             write_record(Path(d), {
                 "tool": "codeql",
                 "files_examined": ["src/auth.c"],
@@ -66,209 +45,75 @@ class TestComputeSummary(unittest.TestCase):
                 "rules_applied": ["cpp/overflow"],
                 "files_failed": [{"path": "src/db.c", "reason": "build error"}],
             }, tool_name="codeql")
-            summary = compute_summary(d)
-            self.assertEqual(summary["tools"]["codeql"]["files_examined"], 1)
-            self.assertEqual(len(summary["tools"]["codeql"]["files_failed"]), 1)
+            t = execution_detail([Path(d)], _CHECKLIST)["tools"]["codeql"]
+            self.assertEqual(t["files_examined"], 1)
+            self.assertEqual(t["packs"], ["codeql/cpp-queries@1.0.0"])
+            self.assertEqual(len(t["files_failed"]), 1)
 
-    def test_llm_coverage(self):
+    def test_absolute_path_matched_to_inventory(self):
         with TemporaryDirectory() as d:
-            self._write_checklist(d)
-            write_record(Path(d), {
-                "tool": "llm",
-                "files_examined": ["src/auth.c"],
-                "functions_analysed": [
-                    {"file": "src/auth.c", "function": "check_pw"},
-                ],
-            }, tool_name="llm")
-            summary = compute_summary(d)
-            self.assertEqual(summary["tools"]["llm"]["functions_analysed"], 1)
-            self.assertEqual(summary["tools"]["llm"]["functions_total"], 3)
-            self.assertEqual(summary["unreviewed_functions"], 2)
-
-    def test_multiple_tools(self):
-        with TemporaryDirectory() as d:
-            self._write_checklist(d)
             write_record(Path(d), {
                 "tool": "semgrep",
-                "files_examined": ["src/auth.c", "src/db.c"],
+                "files_examined": ["/abs/root/src/auth.c"],   # tool emits abs
             }, tool_name="semgrep")
-            write_record(Path(d), {
-                "tool": "llm",
-                "files_examined": ["src/auth.c"],
-                "functions_analysed": [
-                    {"file": "src/auth.c", "function": "check_pw"},
-                    {"file": "src/auth.c", "function": "login"},
-                ],
-            }, tool_name="llm")
-            summary = compute_summary(d)
-            self.assertIn("semgrep", summary["tools"])
-            self.assertIn("llm", summary["tools"])
-            self.assertEqual(summary["unreviewed_functions"], 1)
-
-    def test_per_file_breakdown(self):
-        with TemporaryDirectory() as d:
-            self._write_checklist(d)
-            write_record(Path(d), {
-                "tool": "llm",
-                "files_examined": ["src/auth.c"],
-                "functions_analysed": [
-                    {"file": "src/auth.c", "function": "check_pw"},
-                ],
-            }, tool_name="llm")
-            summary = compute_summary(d)
-            per_file = summary["per_file"]
-            self.assertEqual(len(per_file), 2)
-            # Worst first: db.c has 0%, auth.c has 50%
-            self.assertEqual(per_file[0]["path"], "src/db.c")
-            self.assertEqual(per_file[0]["reviewed"], 0)
-            self.assertEqual(per_file[1]["path"], "src/auth.c")
-            self.assertEqual(per_file[1]["reviewed"], 1)
+            t = execution_detail([Path(d)], _CHECKLIST)["tools"]["semgrep"]
+            self.assertEqual(t["files_examined"], 1)           # matched, counted
 
     def test_missing_semgrep_groups(self):
         with TemporaryDirectory() as d:
-            self._write_checklist(d)
             write_record(Path(d), {
                 "tool": "semgrep",
                 "files_examined": ["src/auth.c"],
                 "rules_applied": ["crypto"],
             }, tool_name="semgrep")
-            summary = compute_summary(d)
-            missing = summary["missing_groups"]
-            self.assertIn("injection", missing)
-            self.assertNotIn("crypto", missing)
+            detail = execution_detail([Path(d)], _CHECKLIST)
+            self.assertIn("injection", detail["missing_groups"])
+            self.assertNotIn("crypto", detail["missing_groups"])
 
-
-class TestFormatSummary(unittest.TestCase):
-
-    def test_formats_basic(self):
-        summary = {
-            "inventory": {"files": 10, "sloc": 1000, "items": 25},
-            "tools": {
-                "semgrep": {
-                    "files_examined": 10, "files_total": 10,
-                    "rules_applied": ["injection", "crypto"],
-                },
-            },
-            "unreviewed_functions": 25,
-            "unreviewed_sloc": 1000,
-            "missing_groups": ["auth", "secrets"],
-            "per_file": [],
-        }
-        text = format_summary(summary)
-        self.assertIn("Inventory: 10 files", text)
-        self.assertIn("Semgrep: 10/10 files", text)
-        self.assertIn("2 groups", text)
-        self.assertIn("25 items not reviewed by LLM", text)
-        self.assertIn("2 Semgrep policy groups not used", text)
-
-    def test_formats_codeql(self):
-        summary = {
-            "inventory": {"files": 5, "sloc": 500, "items": 10},
-            "tools": {
-                "codeql": {
-                    "files_examined": 3, "files_total": 5,
-                    "packs": ["codeql/cpp-queries@1.0.0"],
-                    "rules_applied": ["a", "b"],
-                },
-            },
-            "unreviewed_functions": 10,
-            "unreviewed_sloc": 500,
-            "missing_groups": [],
-            "per_file": [],
-        }
-        text = format_summary(summary)
-        self.assertIn("CodeQL: 3/5 files", text)
-        self.assertIn("codeql/cpp-queries@1.0.0", text)
-        self.assertIn("2 rules", text)
-
-    def test_no_data(self):
-        self.assertEqual(format_summary(None), "No coverage data available.")
-
-    def test_llm_item_coverage_threshold_helpers(self):
-        summary = {
-            "inventory": {"files": 2, "sloc": 120, "items": 4},
-            "tools": {
-                "llm": {
-                    "files_examined": 1,
-                    "files_total": 2,
-                    "functions_analysed": 3,
-                    "functions_total": 4,
-                }
-            },
-            "unreviewed_functions": 1,
-            "unreviewed_sloc": 30,
-            "missing_groups": [],
-            "per_file": [],
-        }
-        self.assertEqual(llm_item_coverage_percent(summary), 75.0)
-        self.assertTrue(coverage_threshold_met(summary, 75.0))
-        self.assertFalse(coverage_threshold_met(summary, 80.0))
-        self.assertIn("75.0% LLM item coverage", format_threshold_result(summary, 80.0))
-        self.assertIn("FAIL", format_threshold_result(summary, 80.0))
-
-
-class TestProjectSummary(unittest.TestCase):
-
-    def test_merges_across_runs(self):
-        """Coverage from multiple runs is accumulated."""
-        from core.project.project import Project
+    def test_merges_across_run_dirs(self):
         with TemporaryDirectory() as d:
-            # Create two run dirs with different coverage
-            run1 = Path(d) / "scan-20260401"
-            run1.mkdir()
-            run2 = Path(d) / "validate-20260402"
-            run2.mkdir()
+            r1 = Path(d) / "scan-1"
+            r1.mkdir()
+            r2 = Path(d) / "validate-2"
+            r2.mkdir()
+            write_record(r1, {"tool": "semgrep", "files_examined": ["src/auth.c"]},
+                         tool_name="semgrep")
+            write_record(r2, {"tool": "semgrep", "files_examined": ["src/db.c"]},
+                         tool_name="semgrep")
+            t = execution_detail([r1, r2], _CHECKLIST)["tools"]["semgrep"]
+            self.assertEqual(t["files_examined"], 2)           # union across runs
 
-            checklist = {"files": [
-                {"path": "src/a.c", "sloc": 50, "items": [
-                    {"name": "foo", "line_start": 1, "line_end": 25},
-                    {"name": "bar", "line_start": 30, "line_end": 50},
-                ]},
-                {"path": "src/b.c", "sloc": 50, "items": [
-                    {"name": "baz", "line_start": 1, "line_end": 50},
-                ]},
-            ]}
-            # Project-level checklist
-            (Path(d) / "checklist.json").write_text(json.dumps(checklist))
-
-            # Run 1: semgrep scanned both files
-            write_record(run1, {
-                "tool": "semgrep",
-                "files_examined": ["src/a.c", "src/b.c"],
-                "rules_applied": ["crypto"],
-            }, tool_name="semgrep")
-
-            # Run 2: LLM analysed one function
-            write_record(run2, {
-                "tool": "llm",
-                "files_examined": ["src/a.c"],
-                "functions_analysed": [{"file": "src/a.c", "function": "foo"}],
-            }, tool_name="llm")
-
-            p = Project(name="test", target=str(Path(d) / "code"), output_dir=d)
-            summary = compute_project_summary(p)
-
-            self.assertEqual(summary["tools"]["semgrep"]["files_examined"], 2)
-            self.assertEqual(summary["tools"]["llm"]["functions_analysed"], 1)
-            self.assertEqual(summary["unreviewed_functions"], 2)
-
-    def test_no_checklist(self):
-        from core.project.project import Project
+    def test_no_records_is_empty(self):
         with TemporaryDirectory() as d:
-            p = Project(name="test", target=str(Path(d) / "code"), output_dir=d)
-            self.assertIsNone(compute_project_summary(p))
+            detail = execution_detail([Path(d)], _CHECKLIST)
+            self.assertEqual(detail["tools"], {})
+            self.assertEqual(detail["missing_groups"], [])
 
-    def test_no_records(self):
-        """With checklist but no coverage records, still returns inventory."""
-        from core.project.project import Project
-        with TemporaryDirectory() as d:
-            (Path(d) / "checklist.json").write_text(json.dumps({
-                "files": [{"path": "a.c", "sloc": 10, "items": [{"name": "main"}]}]
-            }))
-            p = Project(name="test", target=str(Path(d) / "code"), output_dir=d)
-            summary = compute_project_summary(p)
-            self.assertEqual(summary["inventory"]["files"], 1)
-            self.assertEqual(summary["tools"], {})
+
+class TestFormatExecutionDetail(unittest.TestCase):
+
+    def test_renders_tools_and_missing(self):
+        detail = {"tools": {"semgrep": {
+            "files_examined": 1, "files_total": 2, "rules_applied": ["crypto"],
+            "packs": [], "files_failed": [], "version": "1.0"}},
+            "missing_groups": ["injection", "auth"]}
+        text = format_execution_detail(detail)
+        self.assertIn("semgrep", text)
+        self.assertIn("1/2 files", text)
+        self.assertIn("Semgrep policy group(s) not used", text)
+
+    def test_empty_renders_blank(self):
+        self.assertEqual(format_execution_detail({"tools": {}}), "")
+
+
+class TestMatchToInventory(unittest.TestCase):
+
+    def test_exact_relative_and_absolute(self):
+        inv = {"src/auth.c", "src/db.c"}
+        self.assertEqual(_match_to_inventory("src/auth.c", inv), "src/auth.c")
+        self.assertEqual(_match_to_inventory("./src/db.c", inv), "src/db.c")
+        self.assertEqual(_match_to_inventory("/abs/src/auth.c", inv), "src/auth.c")
+        self.assertIsNone(_match_to_inventory("nope.c", inv))
 
 
 if __name__ == "__main__":

--- a/core/coverage/tests/test_summary_with_annotations.py
+++ b/core/coverage/tests/test_summary_with_annotations.py
@@ -1,11 +1,8 @@
-"""End-to-end verification that ``compute_summary`` picks up the
-``coverage-annotations.json`` record written by ``/agentic`` and
-``/understand``.
-
-The standard ``load_records`` reader scans for ``coverage-*.json``
-files. The annotation builder writes one per run. This test pins
-that the wire-up actually flows: write annotations → coverage record
-emitted → compute_summary surfaces it as ``tools["annotations"]``.
+"""Annotations flow into the unified coverage view two ways: the
+``coverage-annotations.json`` record surfaces in the per-run execution detail,
+and durable annotations become llm-category coverage in the store (so annotated
+functions drop out of the LLM-review gap and a ``finding`` annotation reads
+``open``).
 """
 
 from __future__ import annotations
@@ -17,123 +14,53 @@ from tempfile import TemporaryDirectory
 
 from core.annotations import Annotation, write_annotation
 from core.coverage.record import build_from_annotations, write_record
-from core.coverage.summary import compute_summary
+from core.coverage.summary import execution_detail
+from core.coverage.store import CoverageStore
+from core.coverage.importer import backfill
+from core.coverage.store_summary import store_view
+
+_CHECKLIST = {"files": [{"path": "src/foo.py", "sloc": 30, "items": [
+    {"name": "alpha", "line_start": 1, "line_end": 10},
+    {"name": "beta", "line_start": 11, "line_end": 20},
+    {"name": "gamma", "line_start": 21, "line_end": 30}]}]}
 
 
-class TestSummaryWithAnnotations(unittest.TestCase):
-    """Pins that the annotation tool name appears in the summary
-    output, with the right files_examined and functions_analysed."""
+class TestAnnotationsInCoverage(unittest.TestCase):
 
-    def _make_run_with_annotations(self, run_dir: Path):
-        """Create a run dir that mirrors what /agentic writes:
-        a checklist.json (inventory), an annotations tree, and a
-        coverage-annotations.json built from the tree."""
-        # Tiny inventory.
-        checklist = {
-            "target_path": str(run_dir),
-            "total_files": 1,
-            "total_items": 3,
-            "files": [
-                {
-                    "path": "src/foo.py",
-                    "sloc": 30,
-                    "items": [
-                        {"name": "alpha", "line_start": 1, "line_end": 10},
-                        {"name": "beta", "line_start": 11, "line_end": 20},
-                        {"name": "gamma", "line_start": 21, "line_end": 30},
-                    ],
-                }
-            ],
-        }
-        (run_dir / "checklist.json").write_text(json.dumps(checklist))
+    def _make(self, run_dir: Path):
+        (run_dir / "checklist.json").write_text(json.dumps(_CHECKLIST))
+        ann = run_dir / "annotations"
+        write_annotation(ann, Annotation(
+            file="src/foo.py", function="alpha", body="clean",
+            metadata={"source": "human", "status": "clean"}))
+        write_annotation(ann, Annotation(
+            file="src/foo.py", function="beta", body="bug",
+            metadata={"source": "llm", "status": "finding"}))
+        rec = build_from_annotations(ann)
+        assert rec is not None
+        write_record(run_dir, rec, tool_name="annotations")
 
-        # Annotations on two of the three functions.
-        ann_dir = run_dir / "annotations"
-        write_annotation(ann_dir, Annotation(
-            file="src/foo.py", function="alpha",
-            body="reviewed clean",
-            metadata={"source": "human", "status": "clean"},
-        ))
-        write_annotation(ann_dir, Annotation(
-            file="src/foo.py", function="beta",
-            body="LLM finding",
-            metadata={"source": "llm", "status": "finding"},
-        ))
-
-        # Coverage record (matches what /agentic + /understand emit).
-        record = build_from_annotations(ann_dir)
-        assert record is not None
-        write_record(run_dir, record, tool_name="annotations")
-
-    def test_annotations_record_appears_in_summary(self):
+    def test_annotations_record_in_execution_detail(self):
         with TemporaryDirectory() as d:
-            run_dir = Path(d)
-            self._make_run_with_annotations(run_dir)
+            run = Path(d)
+            self._make(run)
+            detail = execution_detail([run], _CHECKLIST)
+            assert "annotations" in detail["tools"]
+            assert detail["tools"]["annotations"]["files_examined"] == 1
 
-            summary = compute_summary(run_dir)
-            assert summary is not None
-            tools = summary["tools"]
-            assert "annotations" in tools, (
-                f"annotations tool missing from summary; "
-                f"got tools: {list(tools.keys())}"
-            )
-            ann_info = tools["annotations"]
-            assert ann_info["files_examined"] == 1
-            assert ann_info["functions_analysed"] == 2
-
-    def test_summary_records_annotation_status_breakdown(self):
-        """The builder stamps annotation_statuses + annotation_sources
-        on the record; verify they survive into the summary's tools
-        dict (readers tolerate unknown keys)."""
+    def test_annotations_become_llm_coverage_in_store(self):
         with TemporaryDirectory() as d:
-            run_dir = Path(d)
-            self._make_run_with_annotations(run_dir)
-
-            summary = compute_summary(run_dir)
-            ann_info = summary["tools"]["annotations"]
-            # Either present (if compute_summary preserves) or absent
-            # (if it filters to the schema fields it knows). Pin the
-            # current behaviour — whichever it is.
-            # If preserved, useful for `/project annotations` etc.
-            # We at minimum want files + functions present.
-            assert "files_examined" in ann_info
-            assert "functions_analysed" in ann_info
-
-    def test_unreviewed_unchanged_when_no_llm_record(self):
-        """Without an LLM record, the existing semantics keep
-        ``unreviewed_functions`` at total_items even when annotations
-        cover some functions. This is documented as conservative —
-        annotations don't currently reduce the LLM-scoped 'unreviewed'
-        count. If that ever changes, this test will surface the
-        semantic shift."""
-        with TemporaryDirectory() as d:
-            run_dir = Path(d)
-            self._make_run_with_annotations(run_dir)
-
-            summary = compute_summary(run_dir)
-            # 3 inventory items, no LLM coverage, 2 annotated.
-            # Current semantics: unreviewed_functions = total_items - llm
-            # = 3 - 0 = 3. (Annotations are out of band today.)
-            assert summary["unreviewed_functions"] == 3
-
-    def test_per_file_breakdown_includes_annotation_functions(self):
-        """The per-file breakdown DOES use the union of all tools'
-        functions_analysed — so annotated functions show up as
-        reviewed in per-file detail even though the top-level
-        unreviewed_functions stays LLM-scoped."""
-        with TemporaryDirectory() as d:
-            run_dir = Path(d)
-            self._make_run_with_annotations(run_dir)
-
-            summary = compute_summary(run_dir)
-            per_file = {pf["path"]: pf for pf in summary["per_file"]}
-            foo = per_file.get("src/foo.py")
-            assert foo is not None
-            # Annotations covered alpha + beta — per-file "reviewed"
-            # count reflects that.
-            assert foo["reviewed"] == 2
-            assert foo["total"] == 3
-            assert "gamma" in foo["unreviewed_functions"]
+            run = Path(d)
+            self._make(run)
+            store = CoverageStore(run / "coverage.json")
+            backfill(store, [run], _CHECKLIST, annotations_base=run / "annotations")
+            view = store_view(store, _CHECKLIST)
+            # alpha (clean) + beta (finding) annotated → llm-examined; gamma not.
+            assert view["functions_by_category"]["llm"] == 2
+            gap = {g["function"] for g in view["llm_gap_functions"]}
+            assert "gamma" in gap and "alpha" not in gap
+            # The finding annotation makes beta read `open`.
+            assert view["verdicts"]["open"] == 1
 
 
 if __name__ == "__main__":

--- a/core/project/cli.py
+++ b/core/project/cli.py
@@ -909,26 +909,45 @@ def _print_run_provenance(project, run_query):
 
 
 def _print_coverage(project, detailed=False, fail_under=None):
-    """Print project coverage summary or detailed view."""
-    from core.coverage.summary import (
-        compute_project_summary,
-        coverage_threshold_met,
-        format_detailed,
-        format_summary,
-        format_threshold_result,
+    """Print project coverage — the unified store-backed report (coverage
+    state + per-run execution detail), plus the ``--fail-under`` check."""
+    from core.json import load_json
+    from core.coverage.store_summary import (
+        coverage_view,
+        format_store_threshold_result,
+        render_coverage,
+        store_coverage_threshold_met,
     )
-    summary = compute_project_summary(project)
-    if not summary:
+
+    base = Path(project.output_dir)
+    try:
+        run_dirs = list(project.get_run_dirs(sweep=False))
+    except Exception:
+        run_dirs = []
+    checklist = load_json(base / "checklist.json")
+    if not checklist:
+        for d in run_dirs:
+            cl = load_json(d / "checklist.json")
+            if cl:
+                checklist = cl
+                break
+    store_path = base / "coverage.json"
+    ann = base / "annotations"
+
+    report = render_coverage(run_dirs, checklist, store_path, ann, detailed=detailed)
+    if not report:
         print("No coverage data (no checklist or coverage records found).")
         return False if fail_under is not None else None
-    if detailed:
-        print(format_detailed(summary))
-    else:
-        print(format_summary(summary))
+    print(report)
+
     if fail_under is not None:
+        view = coverage_view(run_dirs, checklist, store_path, ann)
+        if view is None:
+            print("\nNo function inventory — coverage threshold N/A.")
+            return False
         print()
-        print(format_threshold_result(summary, fail_under))
-        return coverage_threshold_met(summary, fail_under)
+        print(format_store_threshold_result(view, fail_under))
+        return store_coverage_threshold_met(view, fail_under)
     return None
 
 

--- a/libexec/raptor-coverage-summary
+++ b/libexec/raptor-coverage-summary
@@ -116,43 +116,6 @@ def _resolve_active_project():
     return None
 
 
-def _get_summary(args):
-    """Resolve dir and compute summary. Returns (summary, run_dir_for_mark)."""
-    from core.coverage.summary import compute_summary, compute_project_summary
-
-    project = None
-    run_dir = None
-
-    if args:
-        project, run_dir = _resolve_dir(args[0])
-        if not project and not run_dir:
-            d = Path(args[0])
-            if d.exists():
-                run_dir = d
-            else:
-                print(f"ERROR: could not resolve '{args[0]}'.", file=sys.stderr)
-                sys.exit(1)
-    else:
-        project = _resolve_active_project()
-        if not project:
-            print("No directory specified and no active project.", file=sys.stderr)
-            sys.exit(1)
-
-    if project:
-        summary = compute_project_summary(project)
-        # For --mark, find the most recent run dir
-        mark_dir = None
-        try:
-            dirs = project.get_run_dirs(sweep=False)
-            if dirs:
-                mark_dir = dirs[0]
-        except Exception:
-            pass
-        return summary, mark_dir
-    else:
-        return compute_summary(run_dir), run_dir
-
-
 def _store_inputs(args):
     """Resolve (checklist, run_dirs, store_path, annotations_base)."""
     from core.json import load_json
@@ -181,52 +144,19 @@ def _store_inputs(args):
     return None, [], None, None
 
 
-def _cmd_store_view(args):
-    """Build the store on-demand (load persisted + import current records +
-    durable annotations) and print the category/depth + gap view. Read-only:
-    does not persist."""
-    from core.coverage.importer import backfill
-    from core.coverage.store import CoverageStore
-    from core.coverage.store_summary import (
-        file_level_view, format_file_level_view, format_store_view, store_view,
-    )
-
-    checklist, run_dirs, store_path, annotations_base = _store_inputs(args)
-    if not checklist:
-        # No function inventory (e.g. a standalone /scan or /codeql, which
-        # build none). The lifecycle still recorded what ran + which files each
-        # tool examined, so degrade to the file-level tier rather than erroring.
-        if run_dirs:
-            print(format_file_level_view(file_level_view(run_dirs)))
-            return
-        print("No coverage data (no checklist and no run records).", file=sys.stderr)
-        sys.exit(1)
-    # Loads an existing coverage.json if present (durable accumulation);
-    # re-importing current records is idempotent (interval coalesce).
-    store = CoverageStore(store_path)
-    backfill(store, run_dirs, checklist, annotations_base=annotations_base)
-    print(format_store_view(store_view(store, checklist)))
-
-
-def _cmd_gaps(summary):
-    """Print unreviewed items."""
-    if not summary:
+def _cmd_gaps(view):
+    """Print the LLM-review gap — reviewable units (function/top_level) with no
+    LLM review. Globals/macros/typedefs/glue are excluded by design."""
+    if not view:
         print("No coverage data.")
         return
-
-    per_file = summary.get("per_file", [])
-    gaps = []
-    for pf in per_file:
-        for func in pf.get("unreviewed_functions", []):
-            gaps.append((pf["path"], func))
-
+    gaps = view.get("llm_gap_functions", [])
     if not gaps:
-        print("All items reviewed.")
+        print("All reviewable items examined by an LLM.")
         return
-
-    print(f"{len(gaps)} unreviewed item{'s' if len(gaps) != 1 else ''}:")
-    for file_path, func in gaps:
-        print(f"  {file_path}:{func}")
+    print(f"{len(gaps)} item{'s' if len(gaps) != 1 else ''} with no LLM review:")
+    for g in gaps:
+        print(f"  {g['file']}:{g['function']}")
 
 
 def _cmd_mark(mark_targets, run_dir):
@@ -259,7 +189,6 @@ def _cmd_mark(mark_targets, run_dir):
         (fa.get("file"), fa.get("function"))
         for fa in llm_record.get("functions_analysed", [])
     }
-    existing_files = set(llm_record.get("files_examined", []))
 
     added = 0
     for target in mark_targets:
@@ -273,11 +202,9 @@ def _cmd_mark(mark_targets, run_dir):
             )
             existing_funcs.add((file_path, func_name))
             added += 1
-        if file_path not in existing_files:
-            llm_record.setdefault("files_examined", []).append(file_path)
-            existing_files.add(file_path)
-
-    llm_record["files_examined"] = sorted(set(llm_record.get("files_examined", [])))
+    # Marking a function records function-level review only — it must NOT add
+    # the file to files_examined (which is the whole-file "tool scanned this
+    # file" signal; the store would otherwise mark the entire file reviewed).
     write_record(run_dir, llm_record, tool_name="llm")
     print(f"Marked {added} item{'s' if added != 1 else ''} as reviewed in {run_dir.name}")
 
@@ -324,7 +251,8 @@ def main():
     argv = sys.argv[1:]
     detailed = "--detailed" in argv
     show_gaps = "--gaps" in argv
-    show_store = "--store" in argv
+    # `--store` is the default behaviour now; accepted (and stripped as a
+    # flag) for back-compat, no separate branch.
 
     # Extract --mark, --mark-file, --unmark targets
     mark_targets = []
@@ -390,8 +318,8 @@ def main():
     args = [a for a in argv if not a.startswith("--")]
 
     if mark_targets or unmark_targets:
-        _, run_dir = _get_summary(args) if not args else (None, None)
-        if not run_dir and args:
+        run_dir = None
+        if args:
             _, run_dir = _resolve_dir(args[0])
             if not run_dir:
                 d = Path(args[0])
@@ -413,24 +341,22 @@ def main():
             _cmd_unmark(unmark_targets, run_dir)
         return
 
-    if show_store:
-        _cmd_store_view(args)
-        return
+    # All report views go through the unified store-backed renderer. `--store`
+    # is now the default behaviour; the flag is accepted for back-compat.
+    from core.coverage.store_summary import coverage_view, render_coverage
 
-    summary, _ = _get_summary(args)
-
-    if not summary:
-        print("No coverage data (missing checklist.json or coverage records).")
-        return
+    checklist, run_dirs, store_path, annotations_base = _store_inputs(args)
 
     if show_gaps:
-        _cmd_gaps(summary)
-    elif detailed:
-        from core.coverage.summary import format_detailed
-        print(format_detailed(summary))
-    else:
-        from core.coverage.summary import format_summary
-        print(format_summary(summary))
+        _cmd_gaps(coverage_view(run_dirs, checklist, store_path, annotations_base))
+        return
+
+    report = render_coverage(
+        run_dirs, checklist, store_path, annotations_base, detailed=detailed)
+    if not report:
+        print("No coverage data (missing checklist.json or coverage records).")
+        return
+    print(report)
 
 
 if __name__ == "__main__":

--- a/libexec/raptor-validation-helper
+++ b/libexec/raptor-validation-helper
@@ -1388,13 +1388,14 @@ def prepare_1(workdir, target=None, model=None):
     except Exception as e:
         print(f"Diagram error: {e}")
 
-    # Coverage summary
+    # Coverage summary (unified store-backed report; file-level tier when
+    # there's no function inventory).
     try:
-        from core.coverage.summary import compute_summary, format_summary
-        cov = compute_summary(workdir)
+        from core.coverage.store_summary import render_run_coverage
+        cov = render_run_coverage(workdir)
         if cov:
             print()
-            print(format_summary(cov))
+            print(cov)
     except Exception:
         pass
 

--- a/packages/static-analysis/scanner.py
+++ b/packages/static-analysis/scanner.py
@@ -1286,13 +1286,14 @@ def main():
         duration = time.time() - start_time
         logger.info(f"Total scan duration: {duration:.2f}s")
 
-        # Print coverage summary if checklist exists
+        # Print coverage summary (unified store-backed report; file-level tier
+        # when there's no function inventory, e.g. a bare /scan).
         try:
-            from core.coverage.summary import compute_summary, format_summary
-            cov = compute_summary(out_dir)
+            from core.coverage.store_summary import render_run_coverage
+            cov = render_run_coverage(out_dir)
             if cov:
                 print()
-                print(format_summary(cov))
+                print(cov)
                 print()
         except (ImportError, FileNotFoundError) as exc:
             # Narrowed: ImportError if the optional summary module


### PR DESCRIPTION
Retire the dual compute-on-fly reporting path; the persistent store is the single source of truth for coverage state, with per-run execution detail shown alongside (not folded into the store).

- reporting (A): one render_coverage() — store-backed coverage STATE (verdicts/kinds/categories/%) plus per-run tool EXECUTION detail (rules/packs/ files_failed + Semgrep policy validation) read from records. Repointed /project coverage, standalone /scan, /validate, and raptor-coverage-summary; --store is now the default. compute_summary/compute_project_summary/ format_summary/format_detailed retired; summary.py keeps the slim execution_detail helper + _match_to_inventory. --fail-under uses a store-based LLM coverage percent.
- /understand fold-in (G): context-map entry points/sinks/boundaries and flow-trace steps are marked as `understand` (llm-category) coverage.
- function-level llm marks (B): a record's functions_analysed marks just the named function's range (provenance-stamped), not the whole file; `--mark file:fn` no longer writes whole-file files_examined. files_examined still whole-file-marks ("the tool read the file").
- LLM-review gap lists only reviewable kinds (function/top_level).
- --detailed per-file table (C): per-file cov% / llm-reviewed / examined / findings, worst-LLM-review first.