### PR TITLE
feat(coverage): Phase 4 — external/runtime coverage import (gcov/lcov/coverage.py)

### DIFF
--- a/core/coverage/__init__.py
+++ b/core/coverage/__init__.py
@@ -34,6 +34,7 @@ from .importer import (
     import_run_findings,
     import_annotations,
     import_understand,
+    import_runtime,
     run_provenance,
 )
 from .store_summary import (
@@ -77,6 +78,7 @@ __all__ = [
     "import_run_findings",
     "import_annotations",
     "import_understand",
+    "import_runtime",
     "run_provenance",
     "store_view",
     "format_store_view",

--- a/core/coverage/importer.py
+++ b/core/coverage/importer.py
@@ -441,3 +441,43 @@ def backfill(
     if annotations_base is not None:
         total += import_annotations(store, annotations_base, checklist)
     return total
+
+
+def _runs(lines):
+    """Coalesce a set/iterable of line numbers into sorted contiguous
+    ``[lo, hi]`` runs (so executed lines mark as ranges, not one call each)."""
+    out = []
+    for ln in sorted(lines):
+        if out and ln == out[-1][1] + 1:
+            out[-1][1] = ln
+        else:
+            out.append([ln, ln])
+    return out
+
+
+def import_runtime(
+    store: CoverageStore, path, checklist: Dict[str, Any],
+    fmt: Optional[str] = None, tool: Optional[str] = None,
+) -> int:
+    """Import external runtime coverage (gcov / lcov / coverage.py) into the
+    store (Phase 4). Detects the format (unless ``fmt`` given), parses executed
+    source lines, normalises each source path to the inventory's key (gcov/lcov
+    report build-relative or absolute paths — reuse the tested matcher), and
+    marks contiguous runs under the runtime ``tool`` label. Returns marks made.
+    """
+    from .parsers import default_tool, detect_format, parse
+
+    fmt = fmt or detect_format(path)
+    if not fmt:
+        return 0
+    tool = tool or default_tool(fmt)
+    inv = _inventory_paths(checklist)
+    marked = 0
+    for src, lines in parse(path, fmt).items():
+        key = _to_inventory_path(src, inv)
+        if key not in inv:
+            continue          # not an inventory file (system header, non-target)
+        for lo, hi in _runs(lines):
+            store.mark(key, lo, hi, tool)
+            marked += 1
+    return marked

--- a/core/coverage/parsers/__init__.py
+++ b/core/coverage/parsers/__init__.py
@@ -1,0 +1,66 @@
+"""External/runtime coverage parsers (Phase 4).
+
+Each parser reads a runtime-coverage artifact and returns
+``{source_path: set(executed_line_numbers)}``. The importer
+(:func:`core.coverage.importer.import_runtime`) normalises those paths to the
+inventory's keys and marks them in the store under a runtime tool label, so the
+``runtime`` category/depth in the unified report lights up.
+
+Formats: ``coverage.py`` (the ``coverage json`` report), ``gcov`` (raw
+``.gcov``), ``lcov`` (``.info``). AFL bitmap→source is a planned follow-on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+from .coverage_py import parse_coverage_py
+from .gcov import parse_gcov, parse_lcov
+
+# format name -> (parser, default tool label)
+_PARSERS = {
+    "coverage.py": (parse_coverage_py, "coverage.py"),
+    "gcov": (parse_gcov, "gcov"),
+    "lcov": (parse_lcov, "lcov"),
+}
+
+
+def detect_format(path) -> Optional[str]:
+    """Best-effort format detection from a file or directory path. None when
+    nothing recognisable is present."""
+    p = Path(path)
+    if p.is_dir():
+        if (p / "coverage.json").exists():
+            return "coverage.py"
+        if any(p.glob("*.gcov")):
+            return "gcov"
+        if any(p.glob("*.info")):
+            return "lcov"
+        return None
+    name = p.name
+    if name == "coverage.json":
+        return "coverage.py"
+    if name.endswith(".gcov"):
+        return "gcov"
+    if name.endswith(".info"):
+        return "lcov"
+    return None
+
+
+def parse(path, fmt: Optional[str] = None) -> Dict[str, Set[int]]:
+    """Parse ``path`` (auto-detecting the format if not given) into
+    ``{source_path: set(executed_lines)}``. ``{}`` if unrecognised."""
+    fmt = fmt or detect_format(path)
+    if fmt not in _PARSERS:
+        return {}
+    return _PARSERS[fmt][0](path)
+
+
+def default_tool(fmt: Optional[str]) -> Optional[str]:
+    """The default store tool label for a format (runtime-category)."""
+    return _PARSERS[fmt][1] if fmt in _PARSERS else None
+
+
+def available_formats() -> List[str]:
+    return sorted(_PARSERS)

--- a/core/coverage/parsers/coverage_py.py
+++ b/core/coverage/parsers/coverage_py.py
@@ -1,0 +1,41 @@
+"""Parse coverage.py output into executed source lines.
+
+Reads the ``coverage json`` report (``{"files": {path: {"executed_lines":
+[...]}}}``) — the stable, documented interface. The raw ``.coverage`` SQLite DB
+is intentionally NOT parsed (schema-coupled); run ``coverage json`` first.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Set
+
+
+def parse_coverage_py(path) -> Dict[str, Set[int]]:
+    """Return ``{source_path: set(executed_line_numbers)}`` from a coverage.json
+    report (or a directory containing one). Tolerant: bad/missing pieces are
+    skipped, never raised."""
+    p = Path(path)
+    if p.is_dir():
+        cand = p / "coverage.json"
+        if cand.exists():
+            p = cand
+    try:
+        data = json.loads(Path(p).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    files = data.get("files") if isinstance(data, dict) else None
+    if not isinstance(files, dict):
+        return {}
+    out: Dict[str, Set[int]] = {}
+    for src, info in files.items():
+        if not isinstance(src, str) or not isinstance(info, dict):
+            continue
+        executed = info.get("executed_lines")
+        if not isinstance(executed, list):
+            continue
+        nums = {n for n in executed if isinstance(n, int) and not isinstance(n, bool)}
+        if nums:
+            out[src] = nums
+    return out

--- a/core/coverage/parsers/gcov.py
+++ b/core/coverage/parsers/gcov.py
@@ -1,0 +1,95 @@
+"""Parse gcov / lcov coverage into executed source lines.
+
+- raw ``.gcov`` files: each code line is ``<count>:<lineno>:<source>``. Executed
+  iff ``count`` is a number > 0 (``-`` = non-code, ``#####`` / ``=====`` = never
+  executed). The ``Source:<path>`` header (lineno 0) names the source file.
+- lcov ``.info``: ``SF:<path>`` opens a file section; ``DA:<line>,<count>`` is a
+  line with an execution count; count > 0 = executed; ``end_of_record`` closes it.
+
+Both return ``{source_path: set(executed_line_numbers)}``. Tolerant — malformed
+lines are skipped, never raised.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Dict, Set
+
+_NEVER = ("-", "#####", "=====")
+_SOURCE_RE = re.compile(r"Source:(.*)")
+
+
+def parse_gcov(path) -> Dict[str, Set[int]]:
+    """Parse a ``.gcov`` file, or a directory of them."""
+    p = Path(path)
+    files = sorted(p.glob("*.gcov")) if p.is_dir() else [p]
+    out: Dict[str, Set[int]] = {}
+    for gcov_file in files:
+        _parse_one_gcov(gcov_file, out)
+    return out
+
+
+def _parse_one_gcov(gcov_file: Path, out: Dict[str, Set[int]]) -> None:
+    try:
+        text = gcov_file.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return
+    src = None
+    lines: Set[int] = set()
+    for raw in text.splitlines():
+        parts = raw.split(":", 2)              # count : lineno : source
+        if len(parts) < 2:
+            continue
+        count_s, lineno_s = parts[0].strip(), parts[1].strip()
+        if lineno_s == "0":                    # metadata line
+            if len(parts) > 2:
+                m = _SOURCE_RE.match(parts[2].strip())
+                if m:
+                    src = m.group(1).strip()
+            continue
+        try:
+            lineno = int(lineno_s)
+        except ValueError:
+            continue
+        if not count_s or count_s in _NEVER:
+            continue
+        # Executed: a plain count > 0, OR a human-readable count (`1.2k`, gcov
+        # `-H`) which gcov only emits for non-zero counts. `-`/`#####`/`=====`
+        # (handled above) are the only "not executed" markers.
+        try:
+            if int(count_s) <= 0:
+                continue
+        except ValueError:
+            pass                               # human-readable non-zero count
+        lines.add(lineno)
+    if lines:
+        # Prefer the Source: header; fall back to the .gcov stem
+        # (Path.stem strips the .gcov suffix: foo.c.gcov -> foo.c).
+        out.setdefault(src or gcov_file.stem, set()).update(lines)
+
+
+def parse_lcov(path) -> Dict[str, Set[int]]:
+    """Parse an lcov ``.info`` file (``SF:`` / ``DA:`` records)."""
+    try:
+        text = Path(path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}
+    out: Dict[str, Set[int]] = {}
+    cur = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("SF:"):
+            cur = line[3:].strip() or None
+        elif line == "end_of_record":
+            cur = None
+        elif line.startswith("DA:") and cur:
+            bits = line[3:].split(",")
+            if len(bits) >= 2:
+                try:
+                    lineno, count = int(bits[0]), int(bits[1])
+                except ValueError:
+                    continue
+                if count > 0:
+                    out.setdefault(cur, set()).add(lineno)
+    return out

--- a/core/coverage/parsers/tests/test_parsers.py
+++ b/core/coverage/parsers/tests/test_parsers.py
@@ -1,0 +1,122 @@
+"""Unit tests for the Phase 4 runtime-coverage parsers + dispatch."""
+
+from __future__ import annotations
+
+import json
+
+from core.coverage.parsers import (
+    available_formats,
+    default_tool,
+    detect_format,
+    parse,
+)
+from core.coverage.parsers.coverage_py import parse_coverage_py
+from core.coverage.parsers.gcov import parse_gcov, parse_lcov
+
+_GCOV = """\
+        -:    0:Source:foo.c
+        -:    0:Graph:foo.gcno
+        5:    1:int main(void) {
+        5:    2:    return helper();
+    #####:    3:    dead();
+        -:    4:}
+"""
+
+_LCOV = """\
+SF:src/bar.c
+DA:1,3
+DA:2,0
+DA:5,1
+end_of_record
+SF:src/baz.c
+DA:10,2
+end_of_record
+"""
+
+
+# --- coverage.py ------------------------------------------------------------
+
+def test_coverage_py_executed_lines(tmp_path):
+    p = tmp_path / "coverage.json"
+    p.write_text(json.dumps({"files": {
+        "pkg/mod.py": {"executed_lines": [1, 2, 5, 6], "missing_lines": [3, 4]},
+        "pkg/empty.py": {"executed_lines": []},
+    }}))
+    out = parse_coverage_py(p)
+    assert out == {"pkg/mod.py": {1, 2, 5, 6}}      # empty file dropped
+
+
+def test_coverage_py_accepts_directory(tmp_path):
+    (tmp_path / "coverage.json").write_text(json.dumps(
+        {"files": {"a.py": {"executed_lines": [1]}}}))
+    assert parse_coverage_py(tmp_path) == {"a.py": {1}}
+
+
+def test_coverage_py_tolerates_garbage(tmp_path):
+    p = tmp_path / "coverage.json"
+    p.write_text("{ not json")
+    assert parse_coverage_py(p) == {}
+    p.write_text(json.dumps({"files": "nope"}))
+    assert parse_coverage_py(p) == {}
+
+
+# --- gcov -------------------------------------------------------------------
+
+def test_gcov_executed_lines_and_source_header(tmp_path):
+    g = tmp_path / "foo.c.gcov"
+    g.write_text(_GCOV)
+    out = parse_gcov(g)
+    assert out == {"foo.c": {1, 2}}             # line 3 never-run, 4 non-code
+
+
+def test_gcov_human_readable_count_executed(tmp_path):
+    # gcov -H emits counts like "1.2k"; treat any non-#####/=====/- count as run.
+    g = tmp_path / "x.c.gcov"
+    g.write_text("        -:    0:Source:x.c\n"
+                 "     1.2k:    1:hot();\n"
+                 "    #####:    2:cold();\n")
+    assert parse_gcov(g) == {"x.c": {1}}
+
+
+def test_gcov_directory_and_stem_fallback(tmp_path):
+    # No Source: header -> fall back to the .gcov stem (foo.c.gcov -> foo.c).
+    (tmp_path / "foo.c.gcov").write_text("        7:    1:x\n")
+    out = parse_gcov(tmp_path)
+    assert out == {"foo.c": {1}}
+
+
+# --- lcov -------------------------------------------------------------------
+
+def test_lcov_da_records(tmp_path):
+    info = tmp_path / "cov.info"
+    info.write_text(_LCOV)
+    out = parse_lcov(info)
+    assert out == {"src/bar.c": {1, 5}, "src/baz.c": {10}}   # DA count 0 dropped
+
+
+# --- dispatch ---------------------------------------------------------------
+
+def test_detect_format(tmp_path):
+    (tmp_path / "coverage.json").write_text("{}")
+    assert detect_format(tmp_path / "coverage.json") == "coverage.py"
+    assert detect_format(tmp_path / "foo.c.gcov") == "gcov"
+    assert detect_format(tmp_path / "x.info") == "lcov"
+    assert detect_format(tmp_path) == "coverage.py"          # dir w/ coverage.json
+    assert detect_format(tmp_path / "nope.txt") is None
+
+
+def test_detect_format_dir_gcov(tmp_path):
+    (tmp_path / "a.c.gcov").write_text("        1:    1:x\n")
+    assert detect_format(tmp_path) == "gcov"
+
+
+def test_parse_dispatch_and_default_tool():
+    assert default_tool("gcov") == "gcov"
+    assert default_tool("coverage.py") == "coverage.py"
+    assert default_tool("lcov") == "lcov"
+    assert default_tool(None) is None
+    assert set(available_formats()) == {"coverage.py", "gcov", "lcov"}
+
+
+def test_parse_unknown_format_empty(tmp_path):
+    assert parse(tmp_path / "nope.txt") == {}

--- a/core/coverage/registry.py
+++ b/core/coverage/registry.py
@@ -44,8 +44,13 @@ _REGISTRY = {
     "agentic": (CATEGORY_LLM, DEPTH_ANALYSED),
     "annotations": (CATEGORY_LLM, DEPTH_ANALYSED),
     "gcov": (CATEGORY_RUNTIME, DEPTH_RUNTIME),
+    "lcov": (CATEGORY_RUNTIME, DEPTH_RUNTIME),
     "afl": (CATEGORY_RUNTIME, DEPTH_RUNTIME),
     "fuzz": (CATEGORY_RUNTIME, DEPTH_RUNTIME),
+    # Python-test runtime (coverage.py / pytest-cov).
+    "coverage.py": (CATEGORY_RUNTIME, DEPTH_RUNTIME),
+    "coverage": (CATEGORY_RUNTIME, DEPTH_RUNTIME),
+    "pytest": (CATEGORY_RUNTIME, DEPTH_RUNTIME),
 }
 _DEFAULT: Tuple[str, str] = (CATEGORY_UNKNOWN, DEPTH_SCANNED)
 

--- a/core/coverage/tests/test_runtime_import.py
+++ b/core/coverage/tests/test_runtime_import.py
@@ -1,0 +1,104 @@
+"""import_runtime: external gcov/lcov/coverage.py coverage → store (Phase 4)."""
+
+from __future__ import annotations
+
+import json
+
+from core.coverage.importer import import_runtime
+from core.coverage.store import CoverageStore
+from core.coverage.store_summary import store_view
+
+
+def _store(tmp_path):
+    return CoverageStore(tmp_path / "coverage.json", target="zip:x")
+
+
+_C_CHECKLIST = {"files": [
+    {"path": "src/foo.c", "lines": 10, "items": [
+        {"name": "main", "kind": "function", "line_start": 1, "line_end": 6}]},
+]}
+
+
+def test_gcov_marks_runtime_coverage(tmp_path):
+    s = _store(tmp_path)
+    s.import_inventory_meta(_C_CHECKLIST)
+    gdir = tmp_path / "gcov"
+    gdir.mkdir()
+    (gdir / "foo.c.gcov").write_text(
+        "        -:    0:Source:src/foo.c\n"
+        "        5:    1:int main(void){\n"
+        "        5:    2:  return 0;\n"
+        "    #####:    3:  dead();\n")
+    n = import_runtime(s, gdir, _C_CHECKLIST)
+    assert n >= 1
+    assert s.who_checked("src/foo.c", 1) == ["gcov"]
+    assert s.who_checked("src/foo.c", 3) == []                 # never-executed
+    # Runtime category lights up; the function reads as runtime-covered.
+    assert s.function_covered("src/foo.c", 1, 6, category="runtime") is True
+    view = store_view(s, _C_CHECKLIST)
+    assert view["functions_by_category"]["runtime"] == 1
+
+
+def test_gcov_abs_path_normalised_to_inventory(tmp_path):
+    s = _store(tmp_path)
+    s.import_inventory_meta(_C_CHECKLIST)
+    g = tmp_path / "foo.c.gcov"
+    g.write_text(
+        "        -:    0:Source:/abs/build/src/foo.c\n"   # absolute build path
+        "        9:    1:int main(void){\n")
+    import_runtime(s, g, _C_CHECKLIST)
+    assert s.who_checked("src/foo.c", 1) == ["gcov"]           # matched to inventory
+
+
+def test_coverage_py_marks_runtime(tmp_path):
+    checklist = {"files": [{"path": "pkg/mod.py", "lines": 8, "items": [
+        {"name": "f", "kind": "function", "line_start": 1, "line_end": 4}]}]}
+    s = _store(tmp_path)
+    s.import_inventory_meta(checklist)
+    cov = tmp_path / "coverage.json"
+    cov.write_text(json.dumps({"files": {
+        "pkg/mod.py": {"executed_lines": [1, 2, 3]}}}))
+    n = import_runtime(s, cov, checklist)
+    assert n >= 1
+    assert s.who_checked("pkg/mod.py", 2) == ["coverage.py"]
+    assert s.function_covered("pkg/mod.py", 1, 4, category="runtime") is True
+
+
+def test_lcov_info_marks_runtime(tmp_path):
+    s = _store(tmp_path)
+    s.import_inventory_meta(_C_CHECKLIST)
+    info = tmp_path / "cov.info"
+    info.write_text("SF:src/foo.c\nDA:1,4\nDA:2,0\nend_of_record\n")
+    import_runtime(s, info, _C_CHECKLIST)
+    assert s.who_checked("src/foo.c", 1) == ["lcov"]
+    assert s.who_checked("src/foo.c", 2) == []                 # DA count 0
+
+
+def test_runtime_marks_coalesce_into_runs(tmp_path):
+    # Contiguous executed lines mark as one interval, not one per line.
+    s = _store(tmp_path)
+    s.import_inventory_meta(_C_CHECKLIST)
+    info = tmp_path / "cov.info"
+    info.write_text("SF:src/foo.c\n" + "".join(
+        f"DA:{i},1\n" for i in range(1, 7)) + "end_of_record\n")
+    n = import_runtime(s, info, _C_CHECKLIST)
+    assert n == 1                                              # 1..6 -> one run
+    assert s.covered_lines("src/foo.c") == [[1, 6]]
+
+
+def test_import_runtime_unknown_format_noop(tmp_path):
+    s = _store(tmp_path)
+    assert import_runtime(s, tmp_path / "nope.txt", _C_CHECKLIST) == 0
+
+
+def test_import_runtime_skips_non_inventory_files(tmp_path):
+    # Source paths that don't resolve to an inventory file are skipped — the
+    # store stays inventory-anchored (no system-header / non-target pollution).
+    s = _store(tmp_path)
+    s.import_inventory_meta(_C_CHECKLIST)              # only src/foo.c
+    g = tmp_path / "sys.h.gcov"
+    g.write_text("        -:    0:Source:/usr/include/sys.h\n"
+                 "        3:    1:x\n")
+    assert import_runtime(s, g, _C_CHECKLIST) == 0
+    assert "/usr/include/sys.h" not in s.files()      # non-inventory file not added
+    assert s.who_checked("src/foo.c", 1) == []        # nothing mis-attributed

--- a/core/coverage/tests/test_summary_cli.py
+++ b/core/coverage/tests/test_summary_cli.py
@@ -58,3 +58,24 @@ def test_store_refuses_without_trust_marker(tmp_path):
     r = _run(str(_run_dir(tmp_path)), "--store", marker=False)
     assert r.returncode == 2
     assert "internal dispatch" in r.stderr
+
+
+def test_import_gcov_persists_and_shows_runtime(tmp_path):
+    # Fixture-based (no gcc needed): a .gcov whose executed lines fall in f1's
+    # range. --import should parse, mark the durable store, and persist.
+    run = _run_dir(tmp_path)
+    gdir = tmp_path / "gcov"
+    gdir.mkdir()
+    (gdir / "a.c.gcov").write_text(
+        "        -:    0:Source:a.c\n"
+        "        9:    5:int f1(void){\n"
+        "    #####:   25:  dead();\n")
+    imp = _run(str(run), "--import", str(gdir))
+    assert imp.returncode == 0, imp.stderr
+    assert "Imported" in imp.stdout
+    assert (run / "coverage.json").exists()            # persisted
+    # The default report now shows runtime coverage non-zero.
+    rep = _run(str(run))
+    assert rep.returncode == 0, rep.stderr
+    assert "runtime" in rep.stdout
+    assert "runtime      0 (0.0%)" not in rep.stdout

--- a/libexec/raptor-coverage-summary
+++ b/libexec/raptor-coverage-summary
@@ -9,6 +9,9 @@ Usage:
   raptor-coverage-summary [<dir>] --mark <file:item>    Mark item(s) as reviewed
   raptor-coverage-summary [<dir>] --mark-file <json>    Mark functions from JSON file
   raptor-coverage-summary [<dir>] --unmark <file:item>  Remove item from reviewed
+  raptor-coverage-summary [<dir>] --import <path>       Ingest external runtime
+      [--format gcov|lcov|coverage.py] [--tool <label>] coverage (gcov/lcov/
+                                                        coverage.py) into the store
 
 If <dir> is omitted, uses the active project.
 Accepts: project output dir, run dir, target path, or project name.
@@ -247,8 +250,45 @@ def _cmd_unmark(unmark_targets, run_dir):
     print(f"Removed {removed} item{'s' if removed != 1 else ''} from reviewed in {run_dir.name}")
 
 
+def _cmd_import(import_path, fmt, tool, args):
+    """Ingest external runtime coverage (gcov/lcov/coverage.py) into the target's
+    durable store. The positional <dir> (if any) resolves the project/run store;
+    --import names the coverage artifact. Persists under the store lock."""
+    from core.coverage.importer import import_runtime
+    from core.coverage.store import CoverageStore, coverage_store_lock
+
+    if not Path(import_path).exists():
+        print(f"ERROR: coverage path not found: {import_path}", file=sys.stderr)
+        sys.exit(1)
+    checklist, _run_dirs, store_path, _ann = _store_inputs(args)
+    if not checklist or not store_path:
+        print("ERROR: no inventory (checklist.json) for the target — runtime "
+              "coverage needs a project/run with an inventory. Specify a project "
+              "or run dir.", file=sys.stderr)
+        sys.exit(1)
+    with coverage_store_lock(store_path):
+        store = CoverageStore(store_path)
+        n = import_runtime(store, import_path, checklist, fmt=fmt, tool=tool)
+        store.save()
+    print(f"Imported {n} runtime coverage range(s) from {import_path} -> {store_path}")
+
+
 def main():
     argv = sys.argv[1:]
+
+    # --import <path> [--format <fmt>] [--tool <label>]: ingest external runtime
+    # coverage. Extract the flag+value pairs up front so the path value isn't
+    # later mistaken for a positional <dir>.
+    def _take_opt(flag, av):
+        if flag in av:
+            i = av.index(flag)
+            if i + 1 < len(av):
+                return av[i + 1], av[:i] + av[i + 2:]
+        return None, av
+    import_path, argv = _take_opt("--import", argv)
+    import_fmt, argv = _take_opt("--format", argv)
+    import_tool, argv = _take_opt("--tool", argv)
+
     detailed = "--detailed" in argv
     show_gaps = "--gaps" in argv
     # `--store` is the default behaviour now; accepted (and stripped as a
@@ -339,6 +379,10 @@ def main():
             _cmd_mark(mark_targets, run_dir)
         if unmark_targets:
             _cmd_unmark(unmark_targets, run_dir)
+        return
+
+    if import_path:
+        _cmd_import(import_path, import_fmt, import_tool, args)
         return
 
     # All report views go through the unified store-backed renderer. `--store`

--- a/libexec/raptor-validation-helper
+++ b/libexec/raptor-validation-helper
@@ -442,7 +442,7 @@ def prepare_A(workdir, target=None):
         executables = _discover_executables(target)
         build_exes = _discover_executables(str(build_dir)) if build_dir.exists() else {}
         if executables or build_exes:
-            print(f"Source → binary mapping:")
+            print("Source → binary mapping:")
             for f in checklist.get("files", []):
                 src = f["path"]
                 stem = Path(src).stem


### PR DESCRIPTION
Feed the built-but-unfed runtime dimension. Parsers read externally-produced coverage and mark the store, so the `runtime` category + `runtime-tested` depth in the unified report light up.

- core/coverage/parsers/: framework (detect_format + dispatch) with a coverage.py parser (the `coverage json` report) and a gcov/lcov parser (raw `.gcov` Source:/count lines; lcov `.info` SF:/DA: records). Tolerant parsing; `.coverage` SQLite intentionally not read (run `coverage json` first).
- importer.import_runtime(): detect → parse executed lines → normalise source paths to inventory keys (reuse _match_to_inventory — gcov/lcov report build-relative/absolute paths) → mark contiguous runs under the runtime tool label. Stays inventory-anchored (skips non-target/system-header paths).
- registry: coverage.py/coverage/pytest/lcov → runtime category.
- raptor-coverage-summary --import <path> [--format] [--tool]: ingest into the durable store under the store lock (persists).
- AFL bitmap→source (DWARF/addr2line) is the planned follow-on.
- also: drop a stray f-string prefix in raptor-validation-helper (F541).