### PR TITLE
feat(core/inventory): close per-language reachability coverage gaps (extraction + dead-witness + library mode)

### DIFF
--- a/core/inventory/REACH_CORPUS.md
+++ b/core/inventory/REACH_CORPUS.md
@@ -34,9 +34,10 @@ source (no Maven build).
 
 Note: OWASP exercises the *surface* Java reachability (and was what
 surfaced the servlet-entry handling now in `entry_reachability`). It does
-**not** exercise the enforce-eligible sound witnesses (`module_aborts`,
-`lexical_dead`), which are py/js/go/rust-only — for those, use live trees
-in those languages.
+**not** exercise the enforce-eligible sound witnesses — `module_aborts`
+(py/js/ts/go/rust/ruby/php) and `lexical_dead` (py/js/ts/rust/ruby/php) — for
+those, use live trees in those languages. (Java/C# have neither: no top-level
+execution, no def-inside-always-false-guard.)
 
 ## OpenSSL (over-fire gate, C)
 

--- a/core/inventory/_reach_cache.py
+++ b/core/inventory/_reach_cache.py
@@ -83,7 +83,10 @@ logger = logging.getLogger(__name__)
 # V8 (2026-05-28): override_methods now seeded for Go methods (every
 # Go method is a structural-interface virtual-dispatch candidate). Changed
 # index contents; a V7 pickle would serve stale verdicts.
-_CACHE_VERSION = 8
+# V9 (2026-05-28): Rust now uses tree-sitter item extraction (impl→
+# class assoc) + trait impls record the trait as a base → override_methods
+# gains Rust trait-impl methods. Changed index contents; bump to rebuild.
+_CACHE_VERSION = 9
 
 _CACHE_DIR = Path.home() / ".cache" / "raptor" / "reachability"
 

--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -134,6 +134,7 @@ def build_inventory(
     skip_generated: bool = True,
     parallel: bool = True,
     allow_unreachable: bool = False,
+    treat_exports_as_entries: bool = False,
 ) -> Dict[str, Any]:
     """Build a source inventory of all files and functions in the target path.
 
@@ -316,6 +317,11 @@ def build_inventory(
         'excluded_files': excluded_files,
         'files': files_info,
     }
+    if treat_exports_as_entries:
+        # Library mode: reachability treats exported/public symbols as entry
+        # points (the API surface is reachable by consumers). Read by
+        # core.inventory.reachability._entry_functions.
+        inventory['treat_exports_as_entries'] = True
     if limitations:
         inventory['limitations'] = limitations
 

--- a/core/inventory/call_graph.py
+++ b/core/inventory/call_graph.py
@@ -2596,6 +2596,17 @@ class _RustCallGraph:
                     self.walk(c)
                 return
             target = target_names[-1]
+            # ``impl Trait for Foo`` (a ``for`` keyword + >=2 type names) is a
+            # TRAIT impl — record the trait as a base of the target so its
+            # methods become virtual-dispatch candidates (a trait method is
+            # reachable via ``&dyn Trait`` / a generic bound even with no
+            # resolved caller). ``impl Foo`` (inherent) records no base.
+            trait_base = (
+                target_names[0]
+                if (len(target_names) >= 2
+                    and any(c.type == "for" for c in node.children))
+                else None
+            )
             # Try to bind to the already-recorded ClassDef
             # (same-file struct/enum) so methods accumulate on a
             # single ClassDef rather than per-impl. If the impl
@@ -2610,10 +2621,13 @@ class _RustCallGraph:
                 target_cls = ClassDef(
                     name=target,
                     line=node.start_point[0] + 1,
-                    bases=[],
+                    bases=[trait_base] if trait_base else [],
                     nested=self._mod_depth > 0,
                 )
                 self.graph.classes.append(target_cls)
+            elif trait_base and trait_base not in target_cls.bases:
+                # Accumulate trait bases across multiple impl blocks.
+                target_cls.bases.append(trait_base)
             self._class_stack.append(target_cls)
             try:
                 for c in node.children:

--- a/core/inventory/dead_scope.py
+++ b/core/inventory/dead_scope.py
@@ -67,6 +67,10 @@ def detect_dead_scopes(language: str, content: str) -> List[DeadRange]:
             return _detect_javascript(content)
         if language == "rust":
             return _detect_rust(content)
+        if language == "php":
+            return _detect_php(content)
+        if language == "ruby":
+            return _detect_ruby(content)
     except Exception:  # noqa: BLE001
         return []
     return []
@@ -268,6 +272,82 @@ def _skip_string(source: str, start: int) -> "int | None":
             return i + 1
         i += 1
     return None
+
+
+# ---------------------------------------------------------------------------
+# PHP — ``if (false) {…}`` / ``if (0)`` / ``if (null)`` blocks. Same brace
+# shape as JS, so the JS block-matching is reused; PHP adds ``#`` line
+# comments. Conservative: only literal always-false constants (NOT
+# ``if ($flag)`` — a runtime name). Mutually-recursive functions inside the
+# block otherwise read CALLED, masking that the whole block is dead.
+# ---------------------------------------------------------------------------
+
+
+_PHP_HASH_COMMENT = re.compile(r"#[^\n]*")
+_PHP_DEAD_IF = re.compile(r"\bif\s*\(\s*(?:false|0|null)\s*\)\s*\{")
+
+
+def _detect_php(content: str) -> List[DeadRange]:
+    # Strip /* */, // and # comments so a brace/keyword inside one doesn't
+    # mislead the matcher (mirrors the JS detector + PHP's extra # comments).
+    def _spaces(m: "re.Match[str]") -> str:
+        return re.sub(r"[^\n]", " ", m.group(0))
+    stripped = _JS_BLOCK_COMMENT.sub(_spaces, content)
+    stripped = _JS_LINE_COMMENT.sub(_spaces, stripped)
+    stripped = _PHP_HASH_COMMENT.sub(_spaces, stripped)
+    ranges: List[DeadRange] = []
+    for m in _PHP_DEAD_IF.finditer(stripped):
+        close = _match_brace(stripped, m.end() - 1)
+        if close is None:
+            continue
+        ranges.append((stripped.count("\n", 0, m.start()) + 1,
+                       stripped.count("\n", 0, close) + 1))
+    return ranges
+
+
+# ---------------------------------------------------------------------------
+# Ruby — ``if false`` / ``if nil`` / ``unless true`` / ``while false`` blocks
+# (Ruby's only falsey constants are ``false`` and ``nil``). No braces, so the
+# matching ``end`` is found by INDENTATION anchoring: Ruby's universal
+# convention puts the closing ``end`` at the same column as the opening
+# keyword. The dead branch ends at an ``else``/``elsif`` (live) or the ``end``
+# at that column; if the scan dedents past the opener first (malformed /
+# unconventional), we BAIL and report nothing — a false positive here would
+# hard-suppress live code, so ambiguity must under-detect.
+# ---------------------------------------------------------------------------
+
+
+_RB_DEAD_IF = re.compile(
+    r"^(\s*)(?:if\s+(?:false|nil)|unless\s+true|while\s+false|until\s+true)"
+    r"\s*(?:then\b.*)?$")
+_RB_BRANCH_AT = re.compile(r"^(\s*)(?:else|elsif)\b")
+_RB_END_AT = re.compile(r"^(\s*)end\b")
+
+
+def _detect_ruby(content: str) -> List[DeadRange]:
+    lines = [re.sub(r"#.*$", "", ln) for ln in content.split("\n")]
+    ranges: List[DeadRange] = []
+    for i, line in enumerate(lines):
+        m = _RB_DEAD_IF.match(line)
+        if not m:
+            continue
+        ind = m.group(1)
+        for j in range(i + 1, len(lines)):
+            lj = lines[j]
+            if not lj.strip():
+                continue
+            cur = lj[:len(lj) - len(lj.lstrip())]
+            be = _RB_BRANCH_AT.match(lj)
+            en = _RB_END_AT.match(lj)
+            if (be and be.group(1) == ind) or (en and en.group(1) == ind):
+                # dead branch body is lines i+1..j-1 (0-indexed) →
+                # (i+2 .. j) 1-indexed.
+                if i + 2 <= j:
+                    ranges.append((i + 2, j))
+                break
+            if len(cur) < len(ind):
+                break  # dedented past the opener without a match — bail (sound)
+    return ranges
 
 
 __all__ = ["DeadRange", "detect_dead_scopes"]

--- a/core/inventory/extractors.py
+++ b/core/inventory/extractors.py
@@ -842,6 +842,8 @@ def _ts_language(lang: str):
             import tree_sitter_cpp as ts
         elif lang == "go":
             import tree_sitter_go as ts
+        elif lang == "rust":
+            import tree_sitter_rust as ts
         elif lang == "csharp":
             import tree_sitter_c_sharp as ts
         elif lang == "ruby":
@@ -892,14 +894,23 @@ class TreeSitterExtractor:
         "cpp": ("function_definition",),
         "go": ("function_declaration", "method_declaration"),
         "csharp": ("method_declaration", "constructor_declaration",
-                   "local_function_statement"),
+                   "local_function_statement",
+                   # operator overloads / conversions / indexers carry method
+                   # bodies (logic) — previously dropped from the inventory.
+                   "operator_declaration", "conversion_operator_declaration",
+                   "indexer_declaration"),
         "ruby": ("method", "singleton_method"),
         "php": ("method_declaration", "function_definition"),
+        # Rust: ``fn`` with a body (free fns, impl methods, trait default
+        # methods). Trait method SIGNATURES (no body) are
+        # ``function_signature_item`` — intentionally excluded (no code).
+        "rust": ("function_item",),
     }
 
     _CLASS_TYPES = {
         "python": ("class_definition",),
-        "java": ("class_declaration", "interface_declaration"),
+        "java": ("class_declaration", "interface_declaration",
+                 "enum_declaration"),
         "javascript": ("class_declaration",),
         "typescript": ("class_declaration", "abstract_class_declaration"),
         "tsx": ("class_declaration", "abstract_class_declaration"),
@@ -910,6 +921,10 @@ class TreeSitterExtractor:
                    "struct_declaration", "record_declaration"),
         "ruby": ("class", "module"),
         "php": ("class_declaration", "interface_declaration", "trait_declaration"),
+        # Rust: ``impl`` / ``trait`` bodies host the methods (struct/enum hold
+        # no fns). ``impl Trait for Foo`` associates its methods with ``Foo``;
+        # ``trait T`` with ``T`` (for default methods).
+        "rust": ("impl_item", "trait_item"),
     }
 
     def __init__(self, language: str):
@@ -1259,6 +1274,15 @@ class TreeSitterExtractor:
                     visibility = child.text.decode().strip()
                     break
 
+        # Rust: a ``visibility_modifier`` child (``pub`` / ``pub(crate)`` /
+        # ``pub(super)``) marks external visibility — the reachability entry
+        # signal (``rust_pub``). Default (no modifier) is private-to-module.
+        if self.language == "rust" and node.type == "function_item":
+            for child in node.children:
+                if child.type == "visibility_modifier":
+                    visibility = child.text.decode().split("(")[0].strip()
+                    break
+
         # C#: ``modifier`` children carry access keywords; members default to
         # ``private`` (the framework-entry rule keys on public action methods).
         if self.language == "csharp" and node.type in (
@@ -1326,6 +1350,25 @@ class TreeSitterExtractor:
         return visibility, class_name
 
     def _get_name(self, node) -> Optional[str]:
+        # Rust: an ``impl`` block associates its methods with the TARGET type
+        # — ``impl Foo`` / ``impl Trait for Foo`` / ``impl<T> Box<T>``. The
+        # target is the last type node before the body (after ``for`` in a
+        # trait impl). Return its simple name so methods read class_name=Foo.
+        if self.language == "rust" and node.type == "impl_item":
+            target = None
+            for c in node.children:
+                if c.type == "declaration_list":
+                    break  # body — stop before method return types etc.
+                if c.type == "type_identifier":
+                    target = c.text.decode()
+                elif c.type == "generic_type":
+                    ti = next((g for g in c.children
+                               if g.type == "type_identifier"), None)
+                    if ti is not None:
+                        target = ti.text.decode()
+                elif c.type == "scoped_type_identifier":
+                    target = c.text.decode().split("::")[-1].strip()
+            return target
         # C#: a method/ctor name is the identifier immediately BEFORE the
         # ``parameter_list`` — the identifiers before THAT are the return type
         # (``IActionResult GetAll()`` → ``GetAll``, not ``IActionResult``).
@@ -1340,13 +1383,36 @@ class TreeSitterExtractor:
                 if sib.type in ("identifier", "name"):
                     return sib.text.decode()
                 sib = sib.prev_sibling
+        # C#: operator overloads / conversions / indexers have no plain name
+        # identifier — synthesise one ("operator+", "operator int", "this[]").
+        if self.language == "csharp" and node.type == "indexer_declaration":
+            return "this[]"
+        if self.language == "csharp" and node.type in (
+            "operator_declaration", "conversion_operator_declaration",
+        ):
+            kids = list(node.children)
+            op_i = next((i for i, c in enumerate(kids)
+                         if c.type == "operator"), None)
+            tail = kids[op_i + 1] if op_i is not None and op_i + 1 < len(kids) \
+                else None
+            if tail is not None:
+                # operator_declaration → "operator+"; conversion → "operator int"
+                sep = " " if node.type == "conversion_operator_declaration" else ""
+                return "operator" + sep + tail.text.decode()
+            return "operator"
         # ``type_identifier`` names a TS class/interface — but in a Java/TS
         # method it's the RETURN TYPE (``public String handle()``), which
         # precedes the method name, so only accept it on a class declaration.
         is_class_decl = node.type in (
             "class_declaration", "abstract_class_declaration",
             "interface_declaration",
+            "enum_declaration",         # Java enum (methods/constructors inside)
             "class", "module",          # Ruby
+            "trait_item",               # Rust: name is the trait type_identifier
+            # C++: the class/struct NAME is a type_identifier child; without
+            # this the name didn't resolve and inline methods read
+            # class_name=None (no CHA / framework / qualname association).
+            "class_specifier", "struct_specifier",
         )
         for child in node.children:
             if child.type in ("identifier", "name"):
@@ -1355,23 +1421,42 @@ class TreeSitterExtractor:
             # superclass constant is nested inside the ``superclass`` node).
             if child.type == "constant" and is_class_decl:
                 return child.text.decode()
+            # Ruby operator method: ``def []=`` / ``def <=>`` / ``def +`` — the
+            # name is an ``operator`` node, not an identifier. Without this,
+            # every Ruby operator method was dropped from the inventory.
+            if child.type == "operator":
+                return child.text.decode()
             # JS/TS class method names are ``property_identifier`` (safe in any
             # node — no language puts a return type there). Without this, every
             # JS/TS class METHOD was silently dropped from the inventory.
-            if child.type == "property_identifier":
+            # ``private_property_identifier`` covers ``#privateMethod()`` —
+            # otherwise ES private methods were dropped entirely.
+            if child.type in ("property_identifier",
+                              "private_property_identifier"):
                 return child.text.decode()
             if child.type == "type_identifier" and is_class_decl:
                 return child.text.decode()
             # C/C++: name is inside function_declarator
             if child.type == "function_declarator":
                 return self._get_name(child)
-            # C/C++: pointer-return functions wrap the
-            # function_declarator inside a pointer_declarator. Without
-            # this case, every `static char *foo(...)`-style decl is
-            # silently dropped from the inventory — surfaced by
-            # source_intel E2E on linux net/ (rc80211_minstrel_ht_debugfs.c
-            # `minstrel_ht_stats_csv_dump`).
-            if child.type == "pointer_declarator":
+            # C++: ``operator+`` / ``operator==`` / ``operator[]`` etc. — the
+            # name is an ``operator_name`` node. Without this, every operator
+            # overload was dropped from the inventory entirely (a vuln in
+            # operator[] bounds / operator= would be invisible).
+            if child.type == "operator_name":
+                return child.text.decode()
+            # C++ conversion operator: ``operator int()`` / ``operator bool()``
+            # — an ``operator_cast`` node. Strip the ``()`` declarator to name
+            # it "operator int". Also previously dropped.
+            if child.type == "operator_cast":
+                return child.text.decode().split("(")[0].strip()
+            # C/C++: pointer- or reference-return functions wrap the
+            # function_declarator inside a pointer_declarator /
+            # reference_declarator. Without these, every `static char
+            # *foo(...)`-style decl (surfaced by source_intel E2E on linux
+            # net/ rc80211_minstrel_ht_debugfs.c) and every `Foo&
+            # operator+(...)` is silently dropped from the inventory.
+            if child.type in ("pointer_declarator", "reference_declarator"):
                 return self._get_name(child)
             # Go: name is inside field_identifier for methods.
             # C++: same node type covers in-class method declarations

--- a/core/inventory/reachability.py
+++ b/core/inventory/reachability.py
@@ -2712,7 +2712,33 @@ def _python_framework_entry(name: str, item: Dict[str, Any]) -> bool:
     return False
 
 
-def _item_is_entry(item: Dict[str, Any], language: str) -> bool:
+def _is_library_export(item: Dict[str, Any], language: str) -> bool:
+    """In LIBRARY mode, an exported / public symbol is an entry point — a
+    library's public API is reachable by consumers even with no in-project
+    caller. Opt-in (off by default): treating exports as entries would mask
+    genuinely-dead public functions in an APPLICATION (FP toward reachable),
+    so it's only correct when the target is a library. Per-language public
+    signal: Python name convention (leading single ``_`` is private; dunders
+    are public protocol), JS/TS ``export``, Java/C#/PHP ``public``. Ruby is
+    unsupported here (its method visibility isn't captured, so every method
+    would over-qualify)."""
+    name = item.get("name") or ""
+    if not name:
+        return False
+    vis = (item.get("metadata") or {}).get("visibility") or ""
+    if language == "python":
+        if name.startswith("__") and name.endswith("__"):
+            return True  # dunder = public protocol (__init__, __call__, …)
+        return not name.startswith("_")
+    if language in ("javascript", "typescript", "tsx"):
+        return vis == "exported"
+    if language in ("java", "csharp", "php"):
+        return "public" in vis.split()
+    return False
+
+
+def _item_is_entry(item: Dict[str, Any], language: str,
+                   library_mode: bool = False) -> bool:
     """Is this inventory item an externally-invocable entry point under its
     language's linkage/visibility model? (Framework dispatch is handled
     separately off the adjacency index.)
@@ -2763,6 +2789,11 @@ def _item_is_entry(item: Dict[str, Any], language: str) -> bool:
     # dispatched by the framework (verbs/actions by convention).
     if p.has_python_framework and _python_framework_entry(name, item):
         return True
+    # Library mode (opt-in): a public/exported symbol is an entry — the
+    # library's API surface is reachable by consumers. Off by default so an
+    # application's dead public functions are still surfaced.
+    if library_mode and _is_library_export(item, language):
+        return True
     # Visibility/linkage entry signal (only for languages whose model is a
     # closed signal; "" ⇒ a public symbol is NOT reliably an entry, so those
     # fall through to UNCERTAIN + 1-hop NOT_CALLED, behaviour unchanged).
@@ -2795,6 +2826,10 @@ def _entry_functions(inventory: Dict[str, Any]) -> "frozenset":
     cached = _ENTRY_SET_CACHE.get(inv_id)
     if cached is not None and cached[0] is inventory:
         return cached[1]
+    # Library mode (opt-in, set by build_inventory): treat exported/public
+    # symbols as entry points — for scanning a library whose API is reachable
+    # by consumers. Off by default (an app's dead public fns stay surfaced).
+    library_mode = bool(inventory.get("treat_exports_as_entries"))
     entries: Set[InternalFunction] = set()
     for fr in inventory.get("files", []):
         if not isinstance(fr, dict):
@@ -2806,7 +2841,7 @@ def _entry_functions(inventory: Dict[str, Any]) -> "frozenset":
                 continue
             if item.get("kind", "function") != "function":
                 continue
-            if _item_is_entry(item, lang):
+            if _item_is_entry(item, lang, library_mode=library_mode):
                 entries.add(InternalFunction(
                     file_path=path, name=item.get("name") or "",
                     line=int(item.get("line_start") or 0),

--- a/core/inventory/tests/test_dead_scope.py
+++ b/core/inventory/tests/test_dead_scope.py
@@ -213,6 +213,61 @@ def test_rust_cfg_on_mod_ranges_module_body():
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# PHP — if (false) {…} blocks (brace-based, like JS).
+# ---------------------------------------------------------------------------
+
+
+def test_php_if_false_block_detected():
+    src = "<?php\nif (false) {\n  function dead() {}\n}\n"
+    assert (2, 4) in detect_dead_scopes("php", src)
+
+
+def test_php_if_zero_and_null_detected():
+    assert detect_dead_scopes("php", "<?php\nif (0) {\n  x();\n}\n") == [(2, 4)]
+    assert detect_dead_scopes("php", "<?php\nif (null) {\n  x();\n}\n") == [(2, 4)]
+
+
+def test_php_runtime_and_true_not_detected():
+    assert detect_dead_scopes("php", "<?php\nif ($flag) {\n  x();\n}\n") == []
+    assert detect_dead_scopes("php", "<?php\nif (true) {\n  x();\n}\n") == []
+
+
+def test_php_commented_if_false_not_detected():
+    assert detect_dead_scopes("php", "<?php\n# if (false) {\n$x=1;\n") == []
+
+
+# ---------------------------------------------------------------------------
+# Ruby — if false / unless true / while false (indentation-anchored end).
+# ---------------------------------------------------------------------------
+
+
+def test_ruby_if_false_block_detected():
+    src = "class C\n  if false\n    def dead; end\n  end\nend\n"
+    assert (3, 3) in detect_dead_scopes("ruby", src)
+
+
+def test_ruby_unless_true_detected():
+    assert detect_dead_scopes("ruby", "  unless true\n    x\n  end\n") == [(2, 2)]
+
+
+def test_ruby_if_false_else_branch_live():
+    # only the if-false branch is dead; the else body stays live.
+    src = "  if false\n    dead\n  else\n    live\n  end\n"
+    assert detect_dead_scopes("ruby", src) == [(2, 2)]
+
+
+def test_ruby_runtime_and_modifier_not_detected():
+    assert detect_dead_scopes("ruby", "  if cond\n    x\n  end\n") == []
+    assert detect_dead_scopes("ruby", "  x = 1 if false\n") == []  # modifier
+    assert detect_dead_scopes("ruby", "  if false || x\n    y\n  end\n") == []
+
+
+def test_ruby_malformed_dedent_bails():
+    # body dedented past the opener → ambiguous → report nothing (sound).
+    assert detect_dead_scopes("ruby", "  if false\nx\n  end\n") == []
+
+
 def test_empty_content_returns_empty():
     assert detect_dead_scopes("python", "") == []
 

--- a/core/inventory/tests/test_extraction_completeness.py
+++ b/core/inventory/tests/test_extraction_completeness.py
@@ -1,0 +1,83 @@
+"""Extraction-completeness self-audit: a curated file per language exercises
+the tricky method/function shapes, and every expected name MUST be extracted
+by the tree-sitter path (the production extractor). Guards against the class
+of bug where a shape is silently dropped from the inventory — e.g. C++
+operator overloads / conversion operators, Rust impl methods, JS ``#private``
+methods, C#/Ruby operators (all found + fixed 2026-05-28/29).
+
+(A regex-vs-tree-sitter superset differential was prototyped too, but the
+crude regex over-matches — e.g. it captures ``int`` from ``operator int(...)``
+— so it's too noisy for a hard gate. The shape-coverage assertion below is the
+reliable guard.)
+
+Each case skips without its grammar.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.inventory.extractors import TreeSitterExtractor, _ts_language
+
+# language -> (grammar module, source, {expected function/method names})
+_SHAPES = {
+    "python": ("tree_sitter_python",
+               "def free(): pass\n"
+               "async def af(): pass\n"
+               "class C:\n  def m(self): pass\n  async def am(self): pass\n"
+               "  def __init__(self): pass\n",
+               {"free", "af", "m", "am", "__init__"}),
+    "javascript": ("tree_sitter_javascript",
+                   "function f(){}\nclass C { m(){} static s(){} #priv(){} *g(){} }\n",
+                   {"f", "m", "s", "#priv", "g"}),
+    "typescript": ("tree_sitter_typescript",
+                   "export function exp(){}\n"
+                   "class C { async am(): Promise<void>{} get x(){return 1} m(){} }\n",
+                   {"exp", "am", "x", "m"}),
+    "java": ("tree_sitter_java",
+             "class O { void m(){} O(){} class I { void n(){} } }\n"
+             "enum E { X; void ev(){} }\ninterface I2 { default void d(){} }\n",
+             {"m", "O", "n", "ev", "d"}),
+    "csharp": ("tree_sitter_c_sharp",
+               "class C {\n  void M(){}\n  C(){}\n"
+               "  public static C operator +(C a, C b){ return a; }\n"
+               "  public int this[int i] => i;\n"
+               "  public static explicit operator int(C c){ return 0; }\n}\n",
+               {"M", "C", "operator+", "this[]", "operator int"}),
+    "go": ("tree_sitter_go",
+           "package p\ntype T struct{}\nfunc (t *T) M(){}\n"
+           "func Generic[X any](x X) X { return x }\nfunc Free(){}\n",
+           {"M", "Generic", "Free"}),
+    "rust": ("tree_sitter_rust",
+             "pub fn api(){}\nfn free(){}\ntrait T { fn td(&self){} }\n"
+             "struct F;\nimpl T for F { fn h(&self){} }\nimpl F { fn inh(&self){} }\n",
+             {"api", "free", "td", "h", "inh"}),
+    "ruby": ("tree_sitter_ruby",
+             "class C\n  def m; end\n  def self.cm; end\n  def []=(k,v); end\nend\n",
+             {"m", "cm", "[]="}),
+    "php": ("tree_sitter_php",
+            "<?php\nclass C { public function m(){} function __construct(){} }\n"
+            "trait Tr { function tm(){} }\ninterface I { public function im(); }\n",
+            {"m", "__construct", "tm", "im"}),
+    "cpp": ("tree_sitter_cpp",
+            "class Foo {\npublic:\n  void m(){}\n  Foo(){}\n  ~Foo(){}\n"
+            "  Foo& operator+(const Foo& o){ return *this; }\n"
+            "  operator bool() const { return true; }\n};\n"
+            "template<class X> class Tpl { public: void tm(){} };\n",
+            {"m", "Foo", "~Foo", "operator+", "operator bool", "tm"}),
+    "c": ("tree_sitter_c",
+          "int f(void){ return 1; }\nstatic int g(void){ return 2; }\n"
+          "char *ptr(void){ return 0; }\n",
+          {"f", "g", "ptr"}),
+}
+
+
+@pytest.mark.parametrize("lang", sorted(_SHAPES))
+def test_treesitter_extracts_all_shapes(lang):
+    grammar, src, expected = _SHAPES[lang]
+    pytest.importorskip(grammar)
+    if _ts_language(lang) is None:
+        pytest.skip(f"{grammar} not available")
+    got = {fi.name for fi in TreeSitterExtractor(lang).extract("f", src)}
+    missing = expected - got
+    assert not missing, f"{lang}: tree-sitter dropped {missing} (extracted {got})"

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -1947,6 +1947,65 @@ class TestPythonFrameworkConvention:
         assert verdict("dead") == "not_called"            # control
 
 
+class TestLibraryEntryMode:
+    """Opt-in library mode (build_inventory(treat_exports_as_entries=True)):
+    for the dynamic/JVM langs (entry_model='none'), a library's exported/public
+    symbols are entry points — the API surface is reachable by consumers. OFF
+    by default so an application's dead public functions are still surfaced.
+    Private/internal symbols stay dead even in library mode; functions reachable
+    FROM the public API become reachable via the closure."""
+
+    def _verds(self, tmp_path, files, library):
+        for fn, src in files.items():
+            (tmp_path / fn).write_text(src)
+        inv = build_inventory(str(tmp_path), str(tmp_path / "out"),
+                              treat_exports_as_entries=library)
+        from core.inventory.reach_audit import classify_reachability
+        out = {}
+        for f in inv["files"]:
+            mod = ".".join(f["path"].rsplit(".", 1)[0].split("/"))
+            for it in f["items"]:
+                if it.get("kind", "function") == "function":
+                    out[it.get("name")] = classify_reachability(
+                        inv, f["path"], it.get("name"),
+                        int(it.get("line_start") or 0), mod)
+        return out
+
+    def test_default_app_mode_public_not_entry(self, tmp_path):
+        v = self._verds(tmp_path, {"x.py": "def public_api(): pass\n"}, False)
+        assert v["public_api"] == "not_called"   # default: public != entry
+
+    def test_python_library_mode(self, tmp_path):
+        files = {"x.py": (
+            "def public_api():\n    return _helper()\n"
+            "def _helper():\n    return 1\n"
+            "def _orphan():\n    return 2\n"
+            "class C:\n  def method(self): pass\n  def _priv(self): pass\n")}
+        v = self._verds(tmp_path, files, True)
+        assert v["public_api"] == "reachable"     # public top-level
+        assert v["_helper"] == "reachable"         # reachable FROM the API
+        assert v["_orphan"] == "not_called"        # private + unreachable -> dead
+        assert v["method"] == "reachable"          # public method
+        assert v["_priv"] == "not_called"          # private method stays dead
+
+    def test_ts_export_and_java_php_public(self, tmp_path):
+        for grammar in ("tree_sitter_typescript", "tree_sitter_java",
+                        "tree_sitter_php"):
+            pytest.importorskip(grammar)
+        files = {
+            "x.ts": "export function expApi(){}\nfunction internalFn(){}\n",
+            "x.java": "public class C { public void pubApi(){} private void prv(){} }\n",
+            "x.php": "<?php\nclass D { public function phpApi(){} private function phpPrv(){} }\n",
+        }
+        v = self._verds(tmp_path, files, True)
+        assert v["expApi"] == "reachable"          # TS export
+        assert v["internalFn"] == "not_called"     # non-export -> dead
+        assert v["pubApi"] == "reachable"          # Java public
+        assert v["prv"] == "not_called"            # Java private stays dead
+        assert v["phpApi"] == "reachable"          # PHP public
+        assert v["phpPrv"] == "not_called"         # PHP private stays dead
+
+
 class TestPhpCoverage:
     """End-to-end PHP / Laravel + Symfony coverage. PHP used the regex
     extractor; now wired to tree-sitter-php (class/method names, visibility,

--- a/core/inventory/tests/test_inventory.py
+++ b/core/inventory/tests/test_inventory.py
@@ -1086,6 +1086,138 @@ class TestRustCrateMembership:
                 for f in inv2["files"]}.get("src/orphan.rs") is False
 
 
+class TestRustExtraction:
+    """Rust item extraction via tree-sitter (previously a regex fallback that
+    dropped impl methods sharing a trait-decl name and never associated methods
+    with their impl type). impl methods now extract with class_name = the impl
+    target; ``pub`` is an entry; and a trait-impl method dispatched via
+    ``&dyn Trait`` reads UNCERTAIN (the trait is recorded as a base → CHA),
+    while a never-dispatched inherent method stays dead. Needs tree-sitter-rust."""
+
+    _SRC = (
+        "pub fn public_api() {}\n"
+        "fn private_free() {}\n"
+        "trait Handler { fn handle(&self); }\n"
+        "struct Foo;\n"
+        "impl Handler for Foo {\n"
+        "    fn handle(&self) { self.helper(); }\n"
+        "    fn helper(&self) {}\n"
+        "}\n"
+        "impl Foo { fn inherent_dead(&self) {} }\n"
+        "fn dispatch(h: &dyn Handler) { h.handle(); }\n")
+
+    def _build(self, tmp_path):
+        pytest.importorskip("tree_sitter_rust")
+        (tmp_path / "m.rs").write_text(self._SRC)
+        return build_inventory(str(tmp_path), str(tmp_path / "out"))
+
+    def test_impl_methods_extracted_with_class(self, tmp_path):
+        inv = self._build(tmp_path)
+        meta = {it["name"]: (it.get("metadata") or {})
+                for f in inv["files"] for it in f["items"]
+                if it.get("kind", "function") == "function"}
+        # impl method `handle` (line 6) is extracted, not dropped by the
+        # same-named trait decl, and associated with its impl target Foo.
+        assert "handle" in meta and meta["handle"]["class_name"] == "Foo"
+        assert meta["helper"]["class_name"] == "Foo"
+        assert meta["public_api"]["visibility"] == "pub"
+
+    def test_rust_dispatch_verdicts(self, tmp_path):
+        from core.inventory.reach_audit import classify_reachability
+        inv = self._build(tmp_path)
+
+        def verdict(name):
+            for f in inv["files"]:
+                for it in f["items"]:
+                    if it.get("name") == name:
+                        return classify_reachability(
+                            inv, f["path"], name,
+                            int(it.get("line_start") or 0), "m")
+            return None
+
+        assert verdict("public_api") == "reachable"        # pub → entry
+        assert verdict("handle") == "uncertain"             # trait dispatch
+        assert verdict("inherent_dead") == "no_path_from_entry"  # genuinely dead
+        assert verdict("private_free") == "no_path_from_entry"   # private, uncalled
+
+
+class TestExtractionCompleteness:
+    """Per-language method↔class association + completeness gaps found by audit:
+    C++ inline methods (class_specifier name wasn't resolved → class_name=None),
+    Java enum methods (enum_declaration wasn't a class type), and JS private
+    methods (``#priv`` — private_property_identifier was dropped). Each case
+    skips without its grammar."""
+
+    def _items(self, tmp_path, fn, src):
+        (tmp_path / fn).write_text(src)
+        inv = build_inventory(str(tmp_path), str(tmp_path / "out"))
+        return {it["name"]: (it.get("metadata") or {}).get("class_name")
+                for f in inv["files"] for it in f["items"]
+                if it.get("kind", "function") == "function"}
+
+    def test_cpp_methods_associate_with_class(self, tmp_path):
+        pytest.importorskip("tree_sitter_cpp")
+        items = self._items(
+            tmp_path, "a.cpp",
+            "class Foo { public: void inl() {} };\n"
+            "struct Bar { void bm() {} };\n"
+            "template<class T> class Tpl { public: void tm() {} };\n")
+        assert items.get("inl") == "Foo"
+        assert items.get("bm") == "Bar"
+        assert items.get("tm") == "Tpl"
+
+    def test_cpp_operator_overloads_extracted(self, tmp_path):
+        # Operator overloads were dropped entirely (operator_name /
+        # reference_declarator unhandled) — a vuln in operator[] / operator=
+        # would be invisible.
+        pytest.importorskip("tree_sitter_cpp")
+        items = self._items(
+            tmp_path, "op.cpp",
+            "class Foo { public:\n"
+            "  Foo& operator+(const Foo& o) { return *this; }\n"
+            "  int& operator[](int i) { static int x; return x; }\n"
+            "  operator bool() const { return true; }\n};\n")
+        assert items.get("operator+") == "Foo"
+        assert items.get("operator[]") == "Foo"
+        assert items.get("operator bool") == "Foo"   # conversion operator
+
+    def test_java_enum_methods_associate(self, tmp_path):
+        pytest.importorskip("tree_sitter_java")
+        items = self._items(
+            tmp_path, "E.java", "enum E { X; void ev() {} E() {} }\n")
+        assert items.get("ev") == "E"
+
+    def test_js_private_method_extracted(self, tmp_path):
+        pytest.importorskip("tree_sitter_javascript")
+        items = self._items(tmp_path, "a.js", "class C { #priv() {} m() {} }")
+        assert items.get("#priv") == "C"   # was dropped entirely
+        assert items.get("m") == "C"
+
+    def test_csharp_operators_and_indexer_extracted(self, tmp_path):
+        # Operator overloads / conversions / indexers carry logic — were
+        # dropped (not in C# func types).
+        pytest.importorskip("tree_sitter_c_sharp")
+        items = self._items(
+            tmp_path, "a.cs",
+            "class C {\n"
+            "  public static C operator +(C a, C b) { return a; }\n"
+            "  public int this[int i] { get { return i; } }\n"
+            "  public static explicit operator int(C c) { return 0; }\n}\n")
+        assert items.get("operator+") == "C"
+        assert items.get("this[]") == "C"
+        assert items.get("operator int") == "C"
+
+    def test_ruby_operator_methods_extracted(self, tmp_path):
+        # ``def []=`` / ``def <=>`` — the name is an ``operator`` node, not an
+        # identifier; previously dropped.
+        pytest.importorskip("tree_sitter_ruby")
+        items = self._items(
+            tmp_path, "a.rb",
+            "class C\n  def []=(k, v); end\n  def <=>(o); 0; end\n  def m; end\nend\n")
+        assert items.get("[]=") == "C"
+        assert items.get("<=>") == "C"
+
+
 class TestGoReachability:
     """End-to-end Go dead-code coverage. Go needed no new substrate (it was
     already complete via //go:build ignore → build_excluded, init-panic →


### PR DESCRIPTION
  - **Extraction completeness**: wire previously-dropped method/function shapes through the
    tree-sitter path (Rust impl/trait methods + pub, C++ operators/conversions/class assoc,
    C#/Ruby operators + indexers, JS #private, Java enums) and thread Python class bases through
    the stdlib-ast path so CBV reachability works without grammars (CI). A dropped shape is
    invisible to the inventory and reachability pass — a coverage false-negative.
  - **Sound dead witness for Ruby/PHP**: extend `lexical_dead` (def inside always-false guard)
    to Ruby and PHP, zero-false-positive by construction.
  - **Opt-in library-entry mode**: `treat_exports_as_entries` makes public/exported symbols
    entry points for languages with no sound linkage model (off by default).