### PR TITLE
fix(llm): omit `temperature` for Anthropic Opus 4.7+ (deprecated → 400)

### DIFF
--- a/core/llm/providers.py
+++ b/core/llm/providers.py
@@ -10,6 +10,7 @@ JSON-in-prompt fallback for providers that lack native structured support.
 
 import json
 import os
+import re
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
@@ -37,6 +38,31 @@ from .tool_use.types import (
 )
 
 logger = get_logger()
+
+_TEMPERATURE_DEPRECATED_FROM = (4, 7)
+_CLAUDE_VERSION_RE = re.compile(r"claude-[a-z]+-(\d+)-(\d+)")
+
+
+def supports_temperature(model_name: str) -> bool:
+    """Whether ``model_name`` accepts the ``temperature`` request parameter.
+
+    Anthropic deprecated ``temperature`` for the reasoning tier from 4.7:
+    verified empirically that opus-4-7 / opus-4-8 reject it with a 400, while
+    opus-4-6-and-older and all sonnet/haiku (<=4-6) still accept it. We gate on
+    version >= 4.7 across tiers — every model that is actually >4.6 today is a
+    deprecated opus, and omitting ``temperature`` is harmless (the model falls
+    back to its default) whereas sending it to a deprecated model is a hard 400,
+    so we err toward omitting for >=4.7 (over-omitting a future tier that still
+    accepts it costs nothing). The regex matches the ``claude-<tier>-<major>-
+    <minor>`` core anywhere in the identifier, so Bedrock region prefixes
+    (``us.anthropic.claude-opus-4-7``) and dated snapshots
+    (``claude-opus-4-7-20260301``) are handled. Non-claude / unparseable names
+    keep ``temperature``.
+    """
+    m = _CLAUDE_VERSION_RE.search(model_name or "")
+    if not m:
+        return True
+    return (int(m.group(1)), int(m.group(2))) < _TEMPERATURE_DEPRECATED_FROM
 
 
 def _safe_float(value: Any, *, default: float) -> float:
@@ -1515,9 +1541,11 @@ class AnthropicProvider(LLMProvider):
         create_kwargs = {
             "model": self.config.model_name,
             "messages": messages,
-            "temperature": kwargs.get("temperature", self.config.temperature),
             "max_tokens": kwargs.get("max_tokens", self.config.max_tokens),
         }
+        # Opus 4.7+ deprecated `temperature` (400 if sent); omit it for those.
+        if supports_temperature(self.config.model_name):
+            create_kwargs["temperature"] = kwargs.get("temperature", self.config.temperature)
         if system_prompt:
             create_kwargs["system"] = system_prompt
 
@@ -1599,9 +1627,11 @@ class AnthropicProvider(LLMProvider):
                     "model": self.config.model_name,
                     "response_model": pydantic_model,
                     "messages": messages,
-                    "temperature": temperature,
                     "max_tokens": self.config.max_tokens,
                 }
+                # Opus 4.7+ deprecated `temperature` (400 if sent); omit it for those.
+                if supports_temperature(self.config.model_name):
+                    create_kwargs["temperature"] = temperature
                 if system_prompt:
                     create_kwargs["system"] = system_prompt
 

--- a/core/llm/tests/test_temperature_gating.py
+++ b/core/llm/tests/test_temperature_gating.py
@@ -1,0 +1,42 @@
+"""`temperature` is deprecated for Anthropic's reasoning tier (Opus 4.7+).
+
+Cutoff verified empirically against the live API: opus-4-7/4-8 reject it with a
+400; opus<=4-6 and all sonnet/haiku accept it. The gate omits temperature for
+version >= 4.7 across tiers (over-omitting a future tier that still accepts it is
+harmless; sending it to a deprecated model is a hard 400).
+"""
+
+from core.llm.providers import supports_temperature
+
+
+def test_opus_cutoff_at_4_7():
+    assert supports_temperature("claude-opus-4-6") is True      # verified: accepts
+    assert supports_temperature("claude-opus-4-7") is False     # verified: 400
+    assert supports_temperature("claude-opus-4-8") is False     # verified: 400
+    assert supports_temperature("claude-opus-4-1") is True
+
+
+def test_other_tiers_below_cutoff_keep_temperature():
+    assert supports_temperature("claude-sonnet-4-6") is True     # verified: accepts
+    assert supports_temperature("claude-sonnet-4-5") is True
+    assert supports_temperature("claude-haiku-4-5") is True
+
+
+def test_future_versions_at_or_above_cutoff_omit():
+    assert supports_temperature("claude-opus-4-9") is False
+    assert supports_temperature("claude-sonnet-4-7") is False    # over-omit, but safe
+    assert supports_temperature("claude-opus-5-0") is False
+
+
+def test_bedrock_prefixes_and_snapshots():
+    assert supports_temperature("us.anthropic.claude-opus-4-7") is False
+    assert supports_temperature("global.anthropic.claude-opus-4-8") is False
+    assert supports_temperature("claude-opus-4-7-20260301") is False
+    assert supports_temperature("us.anthropic.claude-sonnet-4-6") is True
+
+
+def test_non_claude_and_unparseable_keep_temperature():
+    assert supports_temperature("gemini-2.5-pro") is True
+    assert supports_temperature("gpt-5.2") is True
+    assert supports_temperature("") is True
+    assert supports_temperature("llama3:70b") is True


### PR DESCRIPTION
Anthropic deprecated the `temperature` request parameter for the reasoning tier from Opus 4.7: sending it returns a 400 invalid_request_error. Verified empirically against the live API — opus-4-7 and opus-4-8 reject it, while opus-4-6-and-older and all sonnet/haiku (<=4-6) still accept it.

Add supports_temperature(model_name) — a version gate that omits the parameter for version >= 4.7 across tiers (robust to Bedrock region prefixes and dated snapshots) — and apply it at both AnthropicProvider send-sites (generate and generate_structured), so temperature is dropped only for models that reject it.

Chosen as a version rule rather than a hardcoded allowlist so new reasoning models (4-8 and beyond) are covered automatically with no per-model upkeep. Rationale: omitting temperature is harmless (the model uses its default) while sending it to a deprecated model is a hard 400, so erring toward omitting for
>= 4.7 is safe — a future tier that still accepts it is over-omitted at worst.

Brings forward the temperature-gating fix from #696 (AWS Bedrock provider) as a standalone change, since it blocks using Opus 4.7+ through the dispatcher.