### PR TITLE
feat(coverage): read-vs-reviewed split — Phase-7 /audit prerequisite

### DIFF
--- a/core/coverage/registry.py
+++ b/core/coverage/registry.py
@@ -36,7 +36,17 @@ _REGISTRY = {
     "codeql": (CATEGORY_STATIC, DEPTH_SCANNED),
     "claude": (CATEGORY_LLM, DEPTH_ANALYSED),
     "llm": (CATEGORY_LLM, DEPTH_ANALYSED),
-    "understand": (CATEGORY_LLM, DEPTH_ANALYSED),
+    # "read" = the LLM *read* the file (reads-manifest, whole-file) — llm
+    # category but only SCANNED depth, i.e. NOT a function-level review. The
+    # read-vs-reviewed distinction: reviewed = llm at depth >= analysed.
+    "read": (CATEGORY_LLM, DEPTH_SCANNED),
+    # "understand" = /understand IDENTIFIES attack surface (entry points /
+    # sinks / flows) — a structural map, NOT a per-function vuln review. So it
+    # is llm-extent but only SCANNED depth (not "reviewed"): the functions it
+    # flags are review *targets*, and must stay in the review gap, not drop out
+    # of it. (Uses the same not-reviewed bucket as "read"; the depth ladder has
+    # no distinct "mapped" rung and the review axis is depth's only consumer.)
+    "understand": (CATEGORY_LLM, DEPTH_SCANNED),
     "audit": (CATEGORY_LLM, DEPTH_ANALYSED),
     # checked_by source_labels are command:stage (all LLM-driven; scanners
     # use the file-level coverage records, not checked_by).

--- a/core/coverage/store_summary.py
+++ b/core/coverage/store_summary.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Iterable, List
 
-from .registry import category_of
+from .registry import DEPTH_SCANNED, category_of, depth_of
 from .store import CoverageStore, iter_inventory_functions
 
 _CATEGORIES = ("static", "llm", "runtime")
@@ -155,12 +155,14 @@ def file_breakdown(store: CoverageStore, checklist: Dict[str, Any]) -> List[Dict
         row = files.setdefault(f, {
             "path": f, "items": 0, "reviewable": 0, "llm": 0, "examined": 0})
         row["items"] += 1
-        cats = {category_of(t) for t in store.tool_coverage_of_range(f, lo, high)}
+        cov = store.tool_coverage_of_range(f, lo, high)
         if store.function_verdict(f, lo, high) != "unexamined":
             row["examined"] += 1
         if kind in _REVIEWABLE_KINDS:
             row["reviewable"] += 1
-            if "llm" in cats:
+            # reviewed = deep llm review (depth >= analysed), not a whole-file read.
+            if any(category_of(t) == "llm" and depth_of(t) != DEPTH_SCANNED
+                   for t in cov):
                 row["llm"] += 1
     for f, row in files.items():
         row["findings"] = len(store.finding_ids(f))
@@ -261,6 +263,7 @@ def store_view(store: CoverageStore, checklist: Dict[str, Any]) -> Dict[str, Any
     total = 0
     covered_any = 0
     reviewable_total = 0
+    reviewed_count = 0
     by_category = {c: 0 for c in _CATEGORIES}
     by_kind: Dict[str, int] = {}
     llm_gap: List[Dict[str, Any]] = []
@@ -274,6 +277,12 @@ def store_view(store: CoverageStore, checklist: Dict[str, Any]) -> Dict[str, Any
         high = hi if hi is not None else lo
         cov = store.tool_coverage_of_range(file, lo, high)
         cats = {category_of(tool) for tool in cov}
+        # REVIEWED = an llm-category tool examined this at depth >= analysed (a
+        # function-level review). A whole-file `read` (llm/scanned) does NOT
+        # count — reading a file is not reviewing its functions. This is the
+        # read-vs-reviewed distinction the LLM-review gap (and /audit) needs.
+        reviewed = any(category_of(t) == "llm" and depth_of(t) != DEPTH_SCANNED
+                       for t in cov)
         verdict = store.function_verdict(file, lo, high)
         # "Examined" tracks the verdict, not just coverage marks: a finding is
         # itself examination evidence (see function_verdict), so an open /
@@ -298,7 +307,11 @@ def store_view(store: CoverageStore, checklist: Dict[str, Any]) -> Dict[str, Any
         # include every kind.)
         if kind in _REVIEWABLE_KINDS:
             reviewable_total += 1
-            if "llm" not in cats:
+            if reviewed:
+                reviewed_count += 1
+            else:
+                # not reviewed — even if the LLM merely READ the file, it lands
+                # here (that's the point: read ≠ reviewed).
                 llm_gap.append({"file": file, "function": name, "line": lo})
 
         verdicts[verdict] = verdicts.get(verdict, 0) + 1
@@ -318,6 +331,7 @@ def store_view(store: CoverageStore, checklist: Dict[str, Any]) -> Dict[str, Any
         "functions_covered": covered_any,
         "functions_by_category": by_category,
         "llm_reviewable": reviewable_total,
+        "functions_reviewed": reviewed_count,   # reviewable units with a deep llm review
         "gap_no_tool": total_gap,
         "gap_no_llm": len(llm_gap),
         "llm_gap_functions": llm_gap,
@@ -347,6 +361,12 @@ def format_store_view(view: Dict[str, Any], max_gap: int = 15) -> str:
     for cat in _CATEGORIES:
         n = view["functions_by_category"][cat]
         lines.append(f"      {cat:<8} {n:>5} ({_pct(n, total):.1f}%)")
+    reviewable = view.get("llm_reviewable", 0)
+    if reviewable:
+        rev = view.get("functions_reviewed", 0)
+        lines.append(
+            f"    llm-reviewed: {rev}/{reviewable} reviewable units "
+            f"({_pct(rev, reviewable):.1f}%) — whole-file reads excluded")
     v = view.get("verdicts")
     if v:
         lines.append("  Verdict:")

--- a/core/coverage/tests/test_registry.py
+++ b/core/coverage/tests/test_registry.py
@@ -27,6 +27,18 @@ def test_command_source_labels_are_llm():
     assert category_of("annotations") == "llm"
 
 
+def test_read_and_understand_are_llm_but_not_reviewed():
+    # read (whole-file read) and understand (structural attack-surface map) are
+    # llm-EXTENT but only scanned depth -- NOT a per-function vuln review. The
+    # review axis is depth >= analysed, so neither counts as reviewed.
+    assert classify("read") == ("llm", "scanned")
+    assert classify("understand") == ("llm", "scanned")
+    # Actual review tools stay at analysed depth (= reviewed).
+    for tool in ("claude", "audit", "validate:stage-a", "annotations", "agentic"):
+        assert category_of(tool) == "llm"
+        assert depth_of(tool) == "analysed"
+
+
 def test_unknown_tool_is_conservative():
     # Unknown producers are never credited as deep coverage.
     assert classify("mystery-tool") == ("unknown", "scanned")

--- a/core/coverage/tests/test_store_summary.py
+++ b/core/coverage/tests/test_store_summary.py
@@ -228,10 +228,25 @@ def test_llm_gap_lists_only_reviewable_kinds(tmp_path):
 def test_llm_gap_excludes_reviewed_function(tmp_path):
     s = _store(tmp_path)
     s.import_inventory_meta(_MIXED_KINDS)
-    s.mark("a.c", 1, 10, "claude:audit")       # llm reviews fn
+    s.mark("a.c", 1, 10, "claude:audit")       # llm reviews fn (analysed depth)
     view = store_view(s, _MIXED_KINDS)
     assert {g["function"] for g in view["llm_gap_functions"]} == {"tl"}
     assert view["llm_reviewable"] == 2
+    assert view["functions_reviewed"] == 1
+
+
+def test_whole_file_read_is_not_reviewed(tmp_path):
+    # A whole-file `read` mark (llm category, scanned depth) is NOT a review —
+    # the functions stay in the LLM-review gap. This is the read-vs-reviewed
+    # distinction /audit depends on.
+    s = _store(tmp_path)
+    s.import_inventory_meta(_MIXED_KINDS)
+    s.mark("a.c", 1, 50, "read")               # the LLM only READ the file
+    view = store_view(s, _MIXED_KINDS)
+    assert view["functions_reviewed"] == 0
+    assert {g["function"] for g in view["llm_gap_functions"]} == {"fn", "tl"}
+    # ...but it does count as llm *extent* (the LLM did touch it).
+    assert view["functions_by_category"]["llm"] >= 1
 
 
 def test_store_threshold_helpers(tmp_path):

--- a/core/run/metadata.py
+++ b/core/run/metadata.py
@@ -560,18 +560,22 @@ def complete_run(output_dir: Path, extra: Dict[str, Any] = None,
 def _convert_reads_manifest(output_dir: Path) -> None:
     """Turn the coverage plugin's ``.reads-manifest`` (the files the LLM read
     this run, captured by the PostToolUse-on-Read hook) into a
-    ``coverage-llm.json`` record so LLM examined-extent reaches the store.
+    ``coverage-read.json`` record so LLM read-extent reaches the store.
 
-    The plugin captures the reads but nothing converted them — this wires that
-    conversion at run completion. Best-effort: a missing/empty manifest is a
-    no-op, and a failure must never break the lifecycle.
+    Labelled ``read`` (not ``llm``): a whole-file *read* is shallow coverage —
+    it is NOT a function-level review. The store distinguishes read from
+    reviewed by depth, so a file the LLM merely read still surfaces in the
+    LLM-review gap (the gap /audit fills). The plugin captures the reads but
+    nothing converted them — this wires that conversion at run completion.
+    Best-effort: a missing/empty manifest is a no-op, and a failure must never
+    break the lifecycle.
     """
     import logging
     try:
         from core.coverage.record import build_from_manifest, write_record
-        record = build_from_manifest(Path(output_dir), "llm")
+        record = build_from_manifest(Path(output_dir), "read")
         if record:
-            write_record(Path(output_dir), record, tool_name="llm")
+            write_record(Path(output_dir), record, tool_name="read")
     except Exception:  # noqa: BLE001 — never fail lifecycle on a coverage write
         logging.getLogger(__name__).debug(
             "_convert_reads_manifest failed for %s", output_dir, exc_info=True

--- a/core/run/tests/test_metadata.py
+++ b/core/run/tests/test_metadata.py
@@ -405,11 +405,15 @@ class TestRunCoverageSnapshot(unittest.TestCase):
             self.assertEqual(store.who_checked("a.c", 10), ["semgrep"])
             self.assertEqual(store.function_verdict("a.c", 1, 20), "open")  # F1 in f1
 
-    def test_completion_converts_reads_manifest_to_llm_coverage(self):
+    def test_completion_converts_reads_manifest_to_read_coverage(self):
         # The coverage plugin captures LLM file-reads into .reads-manifest;
-        # complete_run must materialise that into a coverage-llm.json record so
-        # LLM examined-extent reaches the store.
+        # complete_run materialises that into a coverage-read.json record.
+        # Labelled `read` (shallow), NOT a function-level review — so the
+        # function still surfaces in the LLM-review gap (read != reviewed).
+        import json
+
         from core.coverage.store import CoverageStore
+        from core.coverage.store_summary import store_view
         with TemporaryDirectory() as d:
             proj = Path(d)
             (proj / "checklist.json").write_text(self._checklist())  # a.c, lines 50
@@ -418,9 +422,14 @@ class TestRunCoverageSnapshot(unittest.TestCase):
             (run / ".reads-manifest").write_text("a.c\n")  # the LLM read a.c
             complete_run(run)
 
-            self.assertTrue((run / "coverage-llm.json").exists())
+            self.assertTrue((run / "coverage-read.json").exists())
             store = CoverageStore(proj / "coverage.json")
-            self.assertEqual(store.who_checked("a.c", 5), ["llm"])
+            self.assertEqual(store.who_checked("a.c", 5), ["read"])
+            # read != reviewed: f1 is still in the LLM-review gap.
+            view = store_view(store, json.loads(self._checklist()))
+            self.assertEqual(view["functions_reviewed"], 0)
+            self.assertTrue(any(g["file"] == "a.c"
+                                for g in view["llm_gap_functions"]))
 
     def test_standalone_run_writes_no_store(self):
         import json


### PR DESCRIPTION
A whole-file LLM *read*, and /understand's structural attack-surface *map*, are not per-function vuln *reviews* — yet both were credited as "reviewed", masking exactly the functions /audit must look at (read-but-unreviewed code, and the entry-points/sinks /understand flags as review TARGETS).

- reads-manifest record relabelled `read` (coverage-read.json); registry maps `read` -> (llm, SCANNED).
- registry: `understand` demoted (llm, ANALYSED) -> (llm, SCANNED). /understand IDENTIFIES attack surface (a review target), it does not review/clear it, so its functions must STAY in the gap. Still llm-EXTENT, just not "reviewed".
- store_view: REVIEWED = an llm-category tool at depth >= analysed (audit / validate / claude / annotations / agentic). The LLM-review gap now lists reviewable units not reviewed (read-only and understand-mapped functions are in the gap). Adds functions_reviewed; render shows "llm-reviewed N/M reviewable — whole-file reads excluded". file_breakdown's per-file llm count is likewise reviewed-based.