### PR TITLE
feat(core/inventory): auto-detect target_kind (library/hybrid/application) + operator override

### DIFF
--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -211,6 +211,13 @@ class RaptorConfig:
     ENV_OUT_DIR = "RAPTOR_OUT_DIR"
     ENV_JOB_ID = "RAPTOR_JOB_ID"
     ENV_LLM_CMD = "RAPTOR_LLM_CMD"
+    # Operator override for target classification
+    # (auto|library|hybrid|application) consulted by
+    # core.inventory.library_detection.resolve_library_mode when the
+    # programmatic setting is "auto". The escape hatch for when
+    # auto-detection misclassifies a target (e.g. asserting 'hybrid' on a
+    # lib+CLI whose manifest only exposes the library side).
+    ENV_TARGET_KIND = "RAPTOR_TARGET_KIND"
 
     # LLM Provider Configuration.
     #
@@ -314,6 +321,13 @@ class RaptorConfig:
         # so an attacker setting them gains nothing beyond what they
         # already had with same-UID write access to ~/raptor-out.
         "RAPTOR_OUT_DIR", "RAPTOR_DIR",
+        #   RAPTOR_TARGET_KIND  operator's target-classification override
+        #                    (auto|library|hybrid|application). Must survive
+        #                    the subprocess boundary so an inventory rebuilt in
+        #                    a child honours the operator's intent. Only ever
+        #                    read as an enum (any other value → auto); no
+        #                    injection surface.
+        "RAPTOR_TARGET_KIND",
     })
 
     # Name prefixes — any variable whose name starts with one of these is

--- a/core/inventory/builder.py
+++ b/core/inventory/builder.py
@@ -13,7 +13,7 @@ import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Union
 
 from core.hash import sha256_bytes
 from core.json import load_json
@@ -134,7 +134,7 @@ def build_inventory(
     skip_generated: bool = True,
     parallel: bool = True,
     allow_unreachable: bool = False,
-    treat_exports_as_entries: bool = False,
+    treat_exports_as_entries: Union[bool, str] = "auto",
 ) -> Dict[str, Any]:
     """Build a source inventory of all files and functions in the target path.
 
@@ -161,6 +161,15 @@ def build_inventory(
         extensions: File extensions to include (defaults to LANGUAGE_MAP keys).
         skip_generated: Skip auto-generated files.
         parallel: Use parallel processing for large codebases.
+        treat_exports_as_entries: target classification driving library mode
+            (reachability treats exported/public symbols as entry points).
+            ``True``/``"library"``/``"hybrid"``/``"on"`` enable it, ``False``/
+            ``"application"``/``"off"`` disable it, and ``"auto"`` (default)
+            classifies the target via
+            :func:`core.inventory.library_detection.detect_target_kind`
+            (library/hybrid → enabled). The classification is recorded in
+            ``inventory['target_kind']`` (+ ``_reason``/``_source``);
+            ``RAPTOR_TARGET_KIND`` is the operator env override.
 
     Returns:
         Inventory dict (also saved to ``<output_dir>/checklist.json``).
@@ -317,11 +326,20 @@ def build_inventory(
         'excluded_files': excluded_files,
         'files': files_info,
     }
-    if treat_exports_as_entries:
-        # Library mode: reachability treats exported/public symbols as entry
-        # points (the API surface is reachable by consumers). Read by
-        # core.inventory.reachability._entry_functions.
-        inventory['treat_exports_as_entries'] = True
+    # Target classification (library | hybrid | application | unknown) — a
+    # first-class, neutral signal for downstream consumers (reachability,
+    # attack-surface mapping, taint sources, SCA pinning posture). Setting is
+    # auto|library|hybrid|application (auto = sniff package manifests;
+    # RAPTOR_TARGET_KIND env is the operator override). ``treat_exports_as_
+    # entries`` is the derived bool read by reachability._entry_functions:
+    # library mode is on for library/hybrid kinds (public API consumed
+    # externally).
+    from .library_detection import resolve_library_mode
+    _lib = resolve_library_mode(treat_exports_as_entries, target_path, files_info)
+    inventory['treat_exports_as_entries'] = _lib['enabled']
+    inventory['target_kind'] = _lib['kind']
+    inventory['target_kind_reason'] = _lib['reason']
+    inventory['target_kind_source'] = _lib['source']
     if limitations:
         inventory['limitations'] = limitations
 

--- a/core/inventory/library_detection.py
+++ b/core/inventory/library_detection.py
@@ -1,0 +1,428 @@
+"""Auto-detect whether an analysis target is a *library* (its public/exported
+surface is the API consumers call) versus an *application* (entry points are
+``main`` / CLI / framework dispatch).
+
+Drives the ``auto`` setting of ``build_inventory(treat_exports_as_entries=)``:
+when the operator does not force the flag, we sniff the per-ecosystem package
+manifests and turn library mode on only when there is a positive library
+signal.
+
+FN-safety (why the asymmetry is safe): library mode only *promotes* exported
+symbols toward reachable. A wrong "library" verdict over-analyses a few dead
+public methods (a precision cost); a wrong "application" verdict just keeps
+today's surface-only behaviour. Neither can suppress a live function. We
+therefore require a positive library signal and otherwise stay OFF — that
+matches the pre-auto default, so single-file targets, apps, and the synthetic
+test fixtures (which carry no manifest) are unchanged.
+
+Static + read-only: we parse manifest files (``package.json``,
+``pyproject.toml``, ``*.csproj``, ``composer.json``, ``pom.xml``,
+``build.gradle``, ``setup.py``/``setup.cfg``). No subprocess, no code
+execution, no shell — safe on untrusted repos. Paths come from a bounded
+``pathlib`` walk inside the target root; symlinks are skipped (no
+traversal-read of out-of-tree files) and nothing is interpolated into a shell.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+_ON_WORDS = frozenset({"on", "true", "yes", "1", "enable", "enabled"})
+_OFF_WORDS = frozenset({"off", "false", "no", "0", "disable", "disabled"})
+
+# Directories never worth descending for manifests. Mirrors the dir entries of
+# exclusions.DEFAULT_EXCLUDES (kept as a local exact-match frozenset for speed).
+# Critically includes test/fixture/example dirs: a target's OWN test fixtures
+# frequently carry foreign manifests (e.g. a struts CVE pom.xml under
+# test/data/) that must not drive the host project's library verdict.
+_SKIP_DIRS = frozenset({
+    # vendored deps
+    "node_modules", "vendor", "third_party", "third-party", "deps",
+    "dependencies", "external", "site-packages",
+    # build output
+    "dist", "build", "target", "out", "output", "bin", "obj",
+    # virtualenvs / caches
+    ".venv", "venv", "env", "virtualenv", ".tox", ".eggs", "__pycache__",
+    ".pytest_cache",
+    # VCS / editor
+    ".git", ".svn", ".hg", ".bzr", ".idea", ".vscode", ".vs",
+    # tests / fixtures / examples / generated — foreign manifests live here
+    "test", "tests", "__tests__", "spec", "testing", "fixtures",
+    "__fixtures__", "testdata", "test-data", "examples", "example",
+    "samples", "sample", "demo", "demos", "generated", "gen", "autogen",
+})
+
+# Bound the walk so a pathological / hostile tree can't turn detection into a
+# DoS, and cap per-category manifests + per-file read size for the same reason.
+_MAX_DIRS = 4000
+_MAX_PER_CAT = 100
+_MAX_MANIFEST_BYTES = 2_000_000
+
+
+def _rel(p: Path, root: Path) -> str:
+    try:
+        return str(p.relative_to(root))
+    except ValueError:
+        return p.name
+
+
+def _read_text(path: Path) -> Optional[str]:
+    try:
+        if path.stat().st_size > _MAX_MANIFEST_BYTES:
+            return None
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _collect_manifests(root: Path) -> Dict[str, List[Path]]:
+    """One bounded, vendor-skipping walk that buckets manifest files by kind.
+
+    A single walk (rather than one per ecosystem) keeps the cost bounded
+    regardless of how many ecosystems are present.
+    """
+    out: Dict[str, List[Path]] = {
+        "npm": [], "pyproject": [], "setup": [], "csproj": [],
+        "composer": [], "pom": [], "gradle": [], "pymain": [],
+    }
+    seen = 0
+    stack: List[Path] = [root]
+    while stack and seen < _MAX_DIRS:
+        d = stack.pop()
+        seen += 1
+        try:
+            entries = list(d.iterdir())
+        except OSError:
+            continue
+        for e in entries:
+            try:
+                if e.is_symlink():
+                    continue
+                if e.is_dir():
+                    if e.name not in _SKIP_DIRS and not e.name.startswith("."):
+                        stack.append(e)
+                    continue
+                n = e.name
+                if n == "package.json":
+                    out["npm"].append(e)
+                elif n == "pyproject.toml":
+                    out["pyproject"].append(e)
+                elif n in ("setup.py", "setup.cfg"):
+                    out["setup"].append(e)
+                elif n.endswith(".csproj"):
+                    out["csproj"].append(e)
+                elif n == "composer.json":
+                    out["composer"].append(e)
+                elif n == "pom.xml":
+                    out["pom"].append(e)
+                elif n in ("build.gradle", "build.gradle.kts"):
+                    out["gradle"].append(e)
+                elif n == "__main__.py":
+                    out["pymain"].append(e)
+            except OSError:
+                continue
+    for k in out:
+        out[k] = out[k][:_MAX_PER_CAT]
+    return out
+
+
+# Per-ecosystem verdicts. ``library`` and ``application`` are the pure cases;
+# ``hybrid`` means a target that ships BOTH a consumable API surface and a CLI/
+# app entry (e.g. an npm package with ``main`` AND ``bin``, or a Python package
+# with ``console_scripts``). A hybrid IS a library for our purposes — its public
+# API is consumed externally — so library mode is enabled for it; the app entry
+# is additive (reachability keeps main/CLI as entries too). ``None`` = the
+# ecosystem contributes no signal.
+
+
+def _check_npm(manifests, root):
+    """package.json: main/module/exports = library surface; ``bin`` = CLI."""
+    for p in manifests["npm"]:
+        text = _read_text(p)
+        if text is None:
+            continue
+        try:
+            data = json.loads(text)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        has_lib = any(k in data for k in
+                      ("main", "module", "exports", "types", "typings"))
+        has_bin = bool(data.get("bin"))
+        rel = _rel(p, root)
+        if has_lib and has_bin:
+            return ("hybrid", f"{rel}: library entry + bin (CLI)")
+        if has_lib:
+            return ("library", f"{rel}: library entry (main/module/exports)")
+        if has_bin:
+            return ("application", f"{rel}: bin-only (CLI)")
+    return (None, "")
+
+
+def _check_python(manifests, root):
+    """Distributable package = library surface; console_scripts /
+    [project.scripts] / __main__.py = app entry. Both → hybrid (a packaged CLI
+    that is also importable, e.g. black/pytest)."""
+    package = ""
+    app = ""
+    if manifests["pymain"]:
+        app = f"{_rel(manifests['pymain'][0], root)}"
+    for p in manifests["pyproject"]:
+        text = _read_text(p) or ""
+        if (re.search(r"(?m)^\s*\[project\]", text)
+                or re.search(r"(?m)^\s*\[tool\.poetry\]", text)):
+            package = package or f"{_rel(p, root)} ([project]/[tool.poetry])"
+        if (re.search(r"(?m)^\s*\[project\.(gui-)?scripts\]", text)
+                or re.search(r"(?m)^\s*\[tool\.poetry\.scripts\]", text)):
+            app = app or f"{_rel(p, root)} ([project.scripts])"
+    for p in manifests["setup"]:
+        text = _read_text(p) or ""
+        if (re.search(r"\b(packages|py_modules)\s*=", text)
+                or re.search(r"(?m)^\s*packages\s*=", text)):
+            package = package or f"{_rel(p, root)} (packages=)"
+        if "console_scripts" in text or "gui_scripts" in text:
+            app = app or f"{_rel(p, root)} (console_scripts)"
+    if package and app:
+        return ("hybrid", f"Python package {package} + app entry {app}")
+    if package:
+        return ("library", f"Python package: {package}")
+    if app:
+        return ("application", f"Python app entry: {app}")
+    return (None, "")
+
+
+def _check_csharp(manifests, root):
+    """Library iff any .csproj is OutputType=Library (or a bare
+    Microsoft.NET.Sdk classlib); Exe/WinExe/Web/Worker → application. A solution
+    carrying both → hybrid."""
+    lib = ""
+    app = ""
+    for p in manifests["csproj"]:
+        text = _read_text(p)
+        if text is None:
+            continue
+        rel = _rel(p, root)
+        m = re.search(r"<OutputType>\s*([A-Za-z]+)\s*</OutputType>", text, re.I)
+        if m:
+            if m.group(1).lower() == "library":
+                lib = lib or f"{rel} (OutputType=Library)"
+            else:
+                app = app or f"{rel} (OutputType={m.group(1)})"
+            continue
+        # No OutputType: bare Microsoft.NET.Sdk defaults to Library; the
+        # trailing quote keeps Sdk.Web / Sdk.Worker (apps) from matching.
+        if re.search(r'Sdk\s*=\s*"Microsoft\.NET\.Sdk"', text, re.I):
+            lib = lib or f"{rel} (SDK class library)"
+        elif re.search(r'Sdk\s*=\s*"Microsoft\.NET\.Sdk\.(Web|Worker)"', text, re.I):
+            app = app or f"{rel} (Web/Worker SDK)"
+    if lib and app:
+        return ("hybrid", f"C# library {lib} + app {app}")
+    if lib:
+        return ("library", f"C#: {lib}")
+    if app:
+        return ("application", f"C#: {app}")
+    return (None, "")
+
+
+def _check_php(manifests, root):
+    """composer.json: autoload = library surface; ``bin`` = CLI; ``type:
+    project`` (Symfony/Laravel) = application. autoload + bin → hybrid."""
+    for p in manifests["composer"]:
+        text = _read_text(p)
+        if text is None:
+            continue
+        try:
+            data = json.loads(text)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        rel = _rel(p, root)
+        if data.get("type") == "project":
+            return ("application", f"{rel}: composer type=project")
+        has_lib = bool(data.get("autoload") or data.get("autoload-dev"))
+        has_bin = bool(data.get("bin"))
+        if has_lib and has_bin:
+            return ("hybrid", f"{rel}: composer autoload + bin (CLI)")
+        if has_lib:
+            t = data.get("type") or "library (default)"
+            return ("library", f"{rel}: composer autoload, type={t}")
+        if has_bin:
+            return ("application", f"{rel}: composer bin-only (CLI)")
+    return (None, "")
+
+
+def _check_java(manifests, root, has_main):
+    """Maven jar / Gradle (no ``application`` plugin) with no ``main`` method →
+    library. war/ear or a ``main`` method → application. Java lib+CLI hybrids
+    aren't reliably distinguishable from manifests, so we stay conservative
+    (no hybrid verdict here)."""
+    for p in manifests["pom"]:
+        text = _read_text(p)
+        if text is None:
+            continue
+        m = re.search(r"<packaging>\s*([a-z]+)\s*</packaging>", text, re.I)
+        packaging = m.group(1).lower() if m else "jar"  # Maven default = jar
+        if packaging in ("war", "ear"):
+            return ("application", f"{_rel(p, root)}: Maven {packaging}")
+        if has_main:
+            return ("application", f"{_rel(p, root)}: Maven {packaging} with main()")
+        return ("library", f"{_rel(p, root)}: Maven {packaging}, no main()")
+    for p in manifests["gradle"]:
+        text = _read_text(p)
+        if text is None:
+            continue
+        if re.search(r"""(?:id|plugin:)\s*['"]application['"]""", text):
+            return ("application", f"{_rel(p, root)}: Gradle application plugin")
+        if has_main:
+            return ("application", f"{_rel(p, root)}: Gradle build with main()")
+        return ("library", f"{_rel(p, root)}: Gradle build, no main()")
+    return (None, "")
+
+
+def _has_java_main(files_info: Optional[List[Dict[str, Any]]]) -> bool:
+    for f in files_info or []:
+        if not isinstance(f, dict):
+            continue
+        if f.get("language") not in ("java", "kotlin"):
+            continue
+        for it in f.get("items", []) or []:
+            if isinstance(it, dict) and it.get("name") == "main":
+                return True
+    return False
+
+
+def detect_target_kind(
+    target_path: str,
+    files_info: Optional[List[Dict[str, Any]]] = None,
+) -> Tuple[str, str]:
+    """Classify a target as ``library`` | ``hybrid`` | ``application`` |
+    ``unknown`` from its package manifests, with a human ``reason``.
+
+    ``hybrid`` (the seer / black / eslint case): ships both a consumable API
+    surface AND a CLI/app entry. A hybrid is treated as a library for
+    export-promotion (its public API is consumed externally) while the app
+    entry remains an entry too — the two are additive.
+
+    Note: only the dynamic/JVM ecosystems carry a lib-vs-app manifest signal.
+    A C/C++/Makefile project returns ``unknown`` here — but that's harmless for
+    reachability, which classifies native code by sound linkage (non-static =
+    entry, ``main`` = entry) regardless of this verdict. ``files_info`` is used
+    only for the Java/Kotlin "no main method" discriminator.
+    """
+    root = Path(target_path)
+    if not root.exists():
+        return ("unknown", "target path does not exist")
+    if root.is_file():
+        return ("unknown", "single-file target: no package manifest")
+
+    manifests = _collect_manifests(root)
+    has_main = _has_java_main(files_info)
+    checks = (
+        lambda: _check_npm(manifests, root),
+        lambda: _check_python(manifests, root),
+        lambda: _check_csharp(manifests, root),
+        lambda: _check_php(manifests, root),
+        lambda: _check_java(manifests, root, has_main),
+    )
+    lib_reasons: List[str] = []
+    app_reasons: List[str] = []
+    for fn in checks:
+        try:
+            verdict, reason = fn()
+        except Exception:  # detection must never break the inventory build
+            verdict, reason = None, ""
+        if verdict == "hybrid":
+            lib_reasons.append(reason)
+            app_reasons.append(reason)
+        elif verdict == "library":
+            lib_reasons.append(reason)
+        elif verdict == "application":
+            app_reasons.append(reason)
+
+    if lib_reasons and app_reasons:
+        return ("hybrid", "; ".join(lib_reasons + app_reasons))
+    if lib_reasons:
+        return ("library", "; ".join(lib_reasons))
+    if app_reasons:
+        return ("application", "; ".join(app_reasons))
+    return ("unknown", "no package manifest signal "
+                       "(package.json/pyproject/csproj/composer/pom/gradle)")
+
+
+def detect_library_target(
+    target_path: str,
+    files_info: Optional[List[Dict[str, Any]]] = None,
+) -> Tuple[bool, str]:
+    """Back-compat bool wrapper over :func:`detect_target_kind`. Library mode is
+    enabled for ``library`` and ``hybrid`` kinds (both have a consumed API)."""
+    kind, reason = detect_target_kind(target_path, files_info)
+    return (kind in ("library", "hybrid"), reason)
+
+
+def _kind_from_token(tok: str) -> Optional[Tuple[bool, str]]:
+    """Map an operator override token to ``(library_mode_enabled, kind)``, or
+    ``None`` for ``auto``/unrecognised (→ fall through to detection).
+
+    Accepts the first-class ``target_kind`` vocabulary (``library``/``hybrid``/
+    ``application``) plus the legacy ``on``/``off`` aliases. ``hybrid`` enables
+    library mode (its public API is consumed) exactly like ``library`` — the
+    distinction is recorded in ``kind`` for the threat-model consumers (taint
+    sources / attack surface / PoC shape treat a hybrid's inputs as the UNION
+    of caller-controlled and app-I/O channels)."""
+    t = (tok or "").strip().lower()
+    if t == "library" or t in _ON_WORDS:
+        return (True, "library")
+    if t == "hybrid":
+        return (True, "hybrid")
+    if t == "application" or t in _OFF_WORDS:
+        return (False, "application")
+    return None
+
+
+def resolve_library_mode(
+    setting: Union[bool, str, None],
+    target_path: str,
+    files_info: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """Resolve the ``treat_exports_as_entries`` setting to a record
+    ``{enabled, source, reason, kind}``.
+
+    The setting accepts ``True``/``False`` (back-compat), ``auto`` (default),
+    or an explicit kind: ``library``/``hybrid``/``application`` (``on``/``off``
+    are aliases for library/application). Precedence: an explicit programmatic
+    value wins; otherwise (``auto``) the operator's ``RAPTOR_TARGET_KIND`` env
+    override is consulted — the escape hatch for when auto-detection is wrong,
+    and the only way to assert ``hybrid`` on a target whose manifest hides it
+    (e.g. seer's C lib+CLI behind a pure-library Python binding) — and only if
+    that too is unset/``auto`` do we run :func:`detect_target_kind`.
+    """
+    if setting is True:
+        return {"enabled": True, "source": "operator", "reason": "forced library",
+                "kind": "library"}
+    if setting is False:
+        return {"enabled": False, "source": "operator",
+                "reason": "forced application", "kind": "application"}
+    mapped = _kind_from_token(str(setting or "auto"))
+    if mapped is not None:
+        enabled, kind = mapped
+        return {"enabled": enabled, "source": "operator",
+                "reason": f"forced {kind}", "kind": kind}
+    # setting == "auto": operator env override beats detection.
+    mapped = _kind_from_token(os.environ.get("RAPTOR_TARGET_KIND", ""))
+    if mapped is not None:
+        enabled, kind = mapped
+        return {"enabled": enabled, "source": "operator-env",
+                "reason": f"forced {kind} (RAPTOR_TARGET_KIND)", "kind": kind}
+    try:
+        kind, reason = detect_target_kind(target_path, files_info)
+    except Exception:
+        return {"enabled": False, "source": "auto", "kind": "unknown",
+                "reason": "auto-detection failed (defaulting off)"}
+    return {"enabled": kind in ("library", "hybrid"), "source": "auto",
+            "reason": reason, "kind": kind}

--- a/core/inventory/tests/test_library_detection.py
+++ b/core/inventory/tests/test_library_detection.py
@@ -1,0 +1,350 @@
+"""Auto-detection of library vs application targets (drives the ``auto``
+setting of build_inventory(treat_exports_as_entries=)).
+
+The detector is manifest-only, so these tests need no tree-sitter grammar —
+they write package manifests into a tmp tree and assert the verdict. FN-safety
+contract under test: a positive library manifest signal flips it on; no
+manifest / app marker / single file → off.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from core.inventory.library_detection import (
+    detect_library_target,
+    detect_target_kind,
+    resolve_library_mode,
+)
+
+
+def _det(tmp_path, files: dict, files_info=None):
+    """Returns (library_mode_enabled, reason)."""
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    return detect_library_target(str(tmp_path), files_info)
+
+
+def _kind(tmp_path, files: dict, files_info=None):
+    """Returns the target_kind string."""
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    return detect_target_kind(str(tmp_path), files_info)[0]
+
+
+# ── npm ────────────────────────────────────────────────────────────────────
+def test_npm_main_is_library(tmp_path):
+    ok, _ = _det(tmp_path, {"package.json": json.dumps({"name": "x", "main": "index.js"})})
+    assert ok is True
+
+
+def test_npm_exports_is_library(tmp_path):
+    ok, _ = _det(tmp_path, {"package.json": json.dumps({"exports": "./index.js"})})
+    assert ok is True
+
+
+def test_npm_bin_only_is_app(tmp_path):
+    ok, _ = _det(tmp_path, {"package.json": json.dumps({"name": "cli", "bin": {"cli": "c.js"}})})
+    assert ok is False
+
+
+def test_npm_main_and_bin_is_hybrid(tmp_path):
+    # eslint/typescript shape: importable API + a CLI → hybrid (library mode ON)
+    assert _kind(tmp_path, {"package.json":
+                            json.dumps({"main": "i.js", "bin": {"t": "c.js"}})}) == "hybrid"
+
+
+def test_npm_neither_is_not_library(tmp_path):
+    ok, _ = _det(tmp_path, {"package.json": json.dumps({"name": "x", "dependencies": {}})})
+    assert ok is False
+
+
+def test_vendored_manifest_is_skipped(tmp_path):
+    # A library package.json buried in node_modules must NOT count.
+    ok, _ = _det(tmp_path, {"node_modules/dep/package.json":
+                            json.dumps({"main": "i.js"})})
+    assert ok is False
+
+
+def test_fixture_manifest_is_skipped(tmp_path):
+    # A foreign manifest under the target's OWN test fixtures must NOT drive
+    # the verdict (regression: a CVE pom.xml under test/data/ flagged the host
+    # repo as a library).
+    ok, _ = _det(tmp_path, {"test/data/cve-fixture/pom.xml":
+                            "<project><packaging>jar</packaging></project>"})
+    assert ok is False
+
+
+# ── python ───────────────────────────────────────────────────────────────--
+def test_python_pyproject_project_is_library(tmp_path):
+    assert _kind(tmp_path, {"pyproject.toml": "[project]\nname = 'x'\n"}) == "library"
+
+
+def test_python_pyproject_with_scripts_is_hybrid(tmp_path):
+    # package + CLI entry = hybrid (lib+CLI like black/pytest): library mode ON
+    # because the public API is still consumed; the CLI entry is additive.
+    assert _kind(tmp_path, {"pyproject.toml":
+                            "[project]\nname='x'\n[project.scripts]\nx='x:main'\n"}) == "hybrid"
+
+
+def test_python_dunder_main_is_hybrid(tmp_path):
+    assert _kind(tmp_path, {"pyproject.toml": "[project]\nname='x'\n",
+                            "x/__main__.py": "print(1)\n"}) == "hybrid"
+
+
+def test_python_setup_packages_is_library(tmp_path):
+    ok, _ = _det(tmp_path, {"setup.py": "from setuptools import setup\nsetup(packages=['x'])\n"})
+    assert ok is True
+
+
+def test_python_setup_console_scripts_is_hybrid(tmp_path):
+    assert _kind(tmp_path, {"setup.py":
+                            "setup(packages=['x'], entry_points={'console_scripts': ['c=x:m']})\n"}) == "hybrid"
+
+
+def test_python_console_script_no_package_is_app(tmp_path):
+    # app entry, no distributable package → pure application
+    assert _kind(tmp_path, {"x/__main__.py": "print(1)\n"}) == "application"
+
+
+# ── c# ───────────────────────────────────────────────────────────────────--
+def test_csharp_library_outputtype(tmp_path):
+    ok, _ = _det(tmp_path, {"L.csproj": "<Project><PropertyGroup><OutputType>Library</OutputType></PropertyGroup></Project>"})
+    assert ok is True
+
+
+def test_csharp_exe_is_app(tmp_path):
+    ok, _ = _det(tmp_path, {"A.csproj": "<Project><PropertyGroup><OutputType>Exe</OutputType></PropertyGroup></Project>"})
+    assert ok is False
+
+
+def test_csharp_sdk_classlib_default_is_library(tmp_path):
+    ok, _ = _det(tmp_path, {"L.csproj": '<Project Sdk="Microsoft.NET.Sdk"></Project>'})
+    assert ok is True
+
+
+def test_csharp_sdk_web_is_app(tmp_path):
+    ok, _ = _det(tmp_path, {"W.csproj": '<Project Sdk="Microsoft.NET.Sdk.Web"></Project>'})
+    assert ok is False
+
+
+# ── php ──────────────────────────────────────────────────────────────────--
+def test_php_type_library(tmp_path):
+    ok, _ = _det(tmp_path, {"composer.json":
+                            json.dumps({"type": "library", "autoload": {"psr-4": {}}})})
+    assert ok is True
+
+
+def test_php_type_project_is_app(tmp_path):
+    ok, _ = _det(tmp_path, {"composer.json":
+                            json.dumps({"type": "project", "autoload": {"psr-4": {}}})})
+    assert ok is False
+
+
+def test_php_default_type_with_autoload_is_library(tmp_path):
+    ok, _ = _det(tmp_path, {"composer.json": json.dumps({"autoload": {"psr-4": {}}})})
+    assert ok is True
+
+
+def test_php_autoload_and_bin_is_hybrid(tmp_path):
+    assert _kind(tmp_path, {"composer.json":
+                            json.dumps({"autoload": {"psr-4": {}}, "bin": ["bin/c"]})}) == "hybrid"
+
+
+def test_php_bin_only_is_app(tmp_path):
+    assert _kind(tmp_path, {"composer.json":
+                            json.dumps({"bin": ["bin/c"]})}) == "application"
+
+
+# ── java (uses the "no main()" discriminator) ──────────────────────────────-
+def test_java_jar_no_main_is_library(tmp_path):
+    ok, why = _det(tmp_path, {"pom.xml": "<project><packaging>jar</packaging></project>"})
+    assert ok is True and "no main()" in why
+
+
+def test_java_with_main_is_app(tmp_path):
+    info = [{"language": "java", "items": [{"name": "main"}]}]
+    ok, _ = _det(tmp_path, {"pom.xml": "<project><packaging>jar</packaging></project>"}, info)
+    assert ok is False
+
+
+def test_java_war_is_app(tmp_path):
+    ok, _ = _det(tmp_path, {"pom.xml": "<project><packaging>war</packaging></project>"})
+    assert ok is False
+
+
+def test_java_gradle_application_plugin_is_app(tmp_path):
+    ok, _ = _det(tmp_path, {"build.gradle": "plugins { id 'application' }\n"})
+    assert ok is False
+
+
+def test_java_gradle_no_app_is_library(tmp_path):
+    ok, _ = _det(tmp_path, {"build.gradle": "plugins { id 'java-library' }\n"})
+    assert ok is True
+
+
+# ── edge cases ─────────────────────────────────────────────────────────────
+def test_single_file_target_is_not_library(tmp_path):
+    f = tmp_path / "x.py"
+    f.write_text("def f(): pass\n")
+    ok, _ = detect_library_target(str(f))
+    assert ok is False
+
+
+def test_no_manifest_is_not_library(tmp_path):
+    (tmp_path / "x.py").write_text("def f(): pass\n")
+    ok, _ = detect_library_target(str(tmp_path))
+    assert ok is False
+
+
+def test_nonexistent_target(tmp_path):
+    ok, _ = detect_library_target(str(tmp_path / "nope"))
+    assert ok is False
+
+
+def test_malformed_manifest_does_not_raise(tmp_path):
+    ok, _ = _det(tmp_path, {"package.json": "{not json", "pyproject.toml": "[broken"})
+    assert ok is False  # unparseable → no signal, no exception
+
+
+# ── override resolution ──────────────────────────────────────────────────--
+@pytest.mark.parametrize("setting,enabled,kind", [
+    (True, True, "library"),
+    (False, False, "application"),
+    ("on", True, "library"),
+    ("off", False, "application"),
+    ("ON", True, "library"),
+    ("disabled", False, "application"),
+    ("library", True, "library"),
+    ("hybrid", True, "hybrid"),       # hybrid enables library mode, records hybrid
+    ("application", False, "application"),
+    ("Hybrid", True, "hybrid"),       # case-insensitive
+])
+def test_resolve_forced(tmp_path, setting, enabled, kind):
+    r = resolve_library_mode(setting, str(tmp_path))
+    assert (r["enabled"], r["source"], r["kind"]) == (enabled, "operator", kind)
+
+
+def test_resolve_auto_on_library(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    r = resolve_library_mode("auto", str(tmp_path))
+    assert (r["enabled"], r["source"], r["kind"]) == (True, "auto", "library")
+
+
+def test_resolve_auto_off_bare(tmp_path):
+    (tmp_path / "x.py").write_text("def f(): pass\n")
+    r = resolve_library_mode("auto", str(tmp_path))
+    assert (r["enabled"], r["source"], r["kind"]) == (False, "auto", "unknown")
+
+
+def test_resolve_env_override_library_beats_detection(tmp_path, monkeypatch):
+    # A bare app dir auto-detects unknown→off, but the operator env forces it.
+    (tmp_path / "x.py").write_text("def f(): pass\n")
+    monkeypatch.setenv("RAPTOR_TARGET_KIND", "library")
+    r = resolve_library_mode("auto", str(tmp_path))
+    assert (r["enabled"], r["source"], r["kind"]) == (True, "operator-env", "library")
+
+
+def test_resolve_env_override_hybrid(tmp_path, monkeypatch):
+    # The seer case: operator asserts hybrid on a dir the manifest can't show.
+    monkeypatch.setenv("RAPTOR_TARGET_KIND", "hybrid")
+    r = resolve_library_mode("auto", str(tmp_path))
+    assert (r["enabled"], r["source"], r["kind"]) == (True, "operator-env", "hybrid")
+
+
+def test_resolve_env_override_application_beats_detection(tmp_path, monkeypatch):
+    # A library dir auto-detects library→on, but the operator env forces off.
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    monkeypatch.setenv("RAPTOR_TARGET_KIND", "application")
+    r = resolve_library_mode("auto", str(tmp_path))
+    assert (r["enabled"], r["source"], r["kind"]) == (False, "operator-env", "application")
+
+
+def test_resolve_explicit_arg_beats_env(tmp_path, monkeypatch):
+    # An explicit programmatic value wins over the env override.
+    monkeypatch.setenv("RAPTOR_TARGET_KIND", "library")
+    r = resolve_library_mode("application", str(tmp_path))
+    assert (r["enabled"], r["source"], r["kind"]) == (False, "operator", "application")
+
+
+# ── builder integration (stdlib Python extractor → no grammar needed) ──────-
+def _build(tmp_path, **kw):
+    from core.inventory.builder import build_inventory
+    return build_inventory(str(tmp_path), str(tmp_path / "_out"), **kw)
+
+
+def _verdict(inv, name):
+    from core.inventory.reach_audit import classify_reachability
+    for f in inv["files"]:
+        mod = ".".join(f["path"].rsplit(".", 1)[0].split("/"))
+        for it in f["items"]:
+            if it.get("name") == name:
+                return classify_reachability(inv, f["path"], name,
+                                             int(it.get("line_start") or 0), mod)
+    return None
+
+
+def test_build_auto_enables_on_python_library(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'mylib'\n")
+    (tmp_path / "mylib.py").write_text("def public_api():\n    return 1\n")
+    inv = _build(tmp_path)  # default treat_exports_as_entries="auto"
+    assert inv["target_kind"] == "library"
+    assert inv["target_kind_source"] == "auto"
+    assert inv["treat_exports_as_entries"] is True
+    assert _verdict(inv, "public_api") == "reachable"  # export = entry
+
+
+def test_build_auto_hybrid_enables_library_mode(tmp_path):
+    # lib + CLI (the seer/black shape) → hybrid → library mode ON, so the
+    # public API is credited as reachable even though there's also a CLI entry.
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname='tool'\n[project.scripts]\ntool='tool:cli'\n")
+    (tmp_path / "tool.py").write_text("def public_api():\n    return 1\n")
+    inv = _build(tmp_path)
+    assert inv["target_kind"] == "hybrid"
+    assert inv["treat_exports_as_entries"] is True
+    assert _verdict(inv, "public_api") == "reachable"
+
+
+def test_build_auto_off_without_manifest(tmp_path):
+    (tmp_path / "app.py").write_text("def public_api():\n    return 1\n")
+    inv = _build(tmp_path)
+    assert inv["target_kind"] == "unknown"
+    assert inv["target_kind_source"] == "auto"
+    assert inv["treat_exports_as_entries"] is False
+    assert _verdict(inv, "public_api") == "not_called"  # app default unchanged
+
+
+def test_build_operator_off_overrides_library(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'mylib'\n")
+    (tmp_path / "mylib.py").write_text("def public_api():\n    return 1\n")
+    inv = _build(tmp_path, treat_exports_as_entries="off")
+    assert inv["target_kind"] == "application"
+    assert inv["target_kind_source"] == "operator"
+    assert inv["treat_exports_as_entries"] is False
+    assert _verdict(inv, "public_api") == "not_called"
+
+
+def test_build_operator_bool_true_back_compat(tmp_path):
+    (tmp_path / "app.py").write_text("def public_api():\n    return 1\n")
+    inv = _build(tmp_path, treat_exports_as_entries=True)  # legacy bool
+    assert inv["target_kind"] == "library"
+    assert inv["target_kind_source"] == "operator"
+    assert _verdict(inv, "public_api") == "reachable"
+
+
+def test_build_operator_forces_hybrid(tmp_path):
+    # seer case asserted by the operator: hybrid → library mode on + kind=hybrid
+    # recorded (so the threat-model consumers see the union of input channels).
+    (tmp_path / "app.py").write_text("def public_api():\n    return 1\n")
+    inv = _build(tmp_path, treat_exports_as_entries="hybrid")
+    assert inv["target_kind"] == "hybrid"
+    assert inv["target_kind_source"] == "operator"
+    assert inv["treat_exports_as_entries"] is True
+    assert _verdict(inv, "public_api") == "reachable"

--- a/raptor_agentic.py
+++ b/raptor_agentic.py
@@ -743,6 +743,24 @@ Examples:
             "text → informational only)."
         ),
     )
+    parser.add_argument(
+        "--target-kind",
+        choices=("auto", "library", "hybrid", "application"),
+        default="auto",
+        help=(
+            "Classify the target so reachability treats a library's "
+            "exported/public symbols as entry points (its API is reachable by "
+            "external consumers). 'auto' (default) classifies from package "
+            "manifests; force it when auto is wrong. 'library' and 'hybrid' "
+            "both enable export-as-entry (a hybrid = lib + CLI, e.g. seer, so "
+            "BOTH its API and its CLI/main are entries); 'application' "
+            "disables it. Only affects the dynamic/JVM languages "
+            "(Python/JS/TS/Java/C#/PHP) — native code (C/C++/Rust/Go) uses "
+            "sound linkage regardless. Sets RAPTOR_TARGET_KIND so the "
+            "inventory honours it across subprocess boundaries (e.g. the "
+            "/validate helper)."
+        ),
+    )
 
     # Mitigation analysis options (NEW)
     parser.add_argument("--binary", help="Target binary for mitigation analysis (enables pre-exploit checks)")
@@ -925,6 +943,15 @@ Examples:
         set_trust_override(True)
         from core.security.codeql_trust import set_trust_override as _ql_set
         _ql_set(True)
+
+    # --target-kind: translate the operator's choice into RAPTOR_TARGET_KIND
+    # (the env override consulted by inventory's library-mode resolver). 'auto'
+    # leaves it unset → per-target manifest detection. Setting the env var is
+    # how the intent reaches build_inventory both in-process and across the
+    # /validate libexec subprocess boundary.
+    _target_kind = getattr(args, "target_kind", "auto")
+    if _target_kind != "auto":
+        os.environ[RaptorConfig.ENV_TARGET_KIND] = _target_kind
 
     if not args.repo:
         parser.error("--repo is required (or launch via `raptor` from the target directory)")

--- a/raptor_codeql.py
+++ b/raptor_codeql.py
@@ -17,6 +17,7 @@ Workflow:
 """
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -311,6 +312,18 @@ Examples:
             "regardless of this flag."
         ),
     )
+    parser.add_argument(
+        "--target-kind",
+        choices=("auto", "library", "hybrid", "application"),
+        default="auto",
+        help=(
+            "Classify the target: 'library'/'hybrid' treat exported/public "
+            "symbols as reachable entry points (a library's API is reachable "
+            "by external consumers), 'application' does not. 'auto' (default) "
+            "classifies from package manifests. Sets RAPTOR_TARGET_KIND. See "
+            "raptor_agentic.py for detail."
+        ),
+    )
     # ``--max-findings`` default 20 is intentionally HIGHER than
     # ``raptor_agentic.py``'s default 10: codeql-only mode does one
     # pass per finding (filter + summarise), while agentic does the
@@ -348,6 +361,10 @@ Examples:
     # RaptorConfig constant once at startup.
     if args.phase_timeout != RaptorConfig.CODEQL_TIMEOUT:
         RaptorConfig.CODEQL_TIMEOUT = args.phase_timeout if args.phase_timeout > 0 else None
+    # --target-kind → RAPTOR_TARGET_KIND (inventory's library-mode override).
+    # 'auto' leaves it unset (per-target detection). See raptor_agentic.py.
+    if getattr(args, "target_kind", "auto") != "auto":
+        os.environ[RaptorConfig.ENV_TARGET_KIND] = args.target_kind
     # set_trust_override BEFORE apply_cli_args. apply_cli_args
     # may invoke trust-checks downstream (e.g. when validating
     # caller-supplied paths against project trust state). Pre-fix


### PR DESCRIPTION
Classify a target from its package manifests and treat a library's exported/public symbols as reachable entry points — its API surface is reachable by external consumers, so without this a library's whole public API looks dead. Promotes the prior opt-in bool to a first-class, neutral `inventory['target_kind']` (library|hybrid|application|unknown, + reason/ source) that downstream consumers (reachability, attack-surface mapping, taint-source selection, SCA pinning) can read; `treat_exports_as_entries` is the derived reachability bool.

- detect_target_kind: per-ecosystem manifest sniff (npm main/exports, Python distributable-pkg + "no app entry" discriminator, C# csproj OutputType, PHP composer autoload, Maven/Gradle + "no main()"). Skips vendor/test/fixture dirs so a target's own fixtures can't drive the verdict. Static read-only, bounded walk, symlinks skipped — safe on untrusted repos.
- hybrid (lib+CLI, e.g. seer/black/eslint): library mode ON because the API is consumed, while main/CLI stays an entry (additive). Recorded as kind=hybrid so threat-model consumers see the union of input channels.
- FN-safe: only a positive library signal enables it (no manifest/app/ single-file → off, matching prior default); enabling only promotes toward reachable, never suppresses.
- Setting is auto|library|hybrid|application (default auto; True/on, False/off as back-compat aliases). RAPTOR_TARGET_KIND env override (allowlisted so it survives the /validate subprocess boundary) and --target-kind on /agentic and /codeql, for when auto is wrong.
- Affects only the dynamic/JVM languages; native code (C/C++/Rust/Go) uses sound linkage regardless.