### PR TITLE
fix(security): propagate --trust-repo to codeql/agentic subprocesses

### DIFF
--- a/core/security/tests/test_trust_repo_propagation.py
+++ b/core/security/tests/test_trust_repo_propagation.py
@@ -1,0 +1,61 @@
+"""--trust-repo must reach the subprocess mode handlers' children.
+
+The unified ``raptor.py`` launcher strips ``--trust-repo`` from argv and sets
+the trust override in its OWN process. But codeql/agentic spawn the target work
+in a SUBPROCESS, which neither inherits that module-level flag nor sees the
+stripped argv — so the handlers must re-inject ``--trust-repo`` into the child
+args. Without this, ``raptor.py codeql --trust-repo`` silently fails to lift the
+child's target-repo trust checks (fail-closed: it over-blocks, but the documented
+override is broken). These tests pin the re-injection.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import raptor
+
+
+class TestTrustRepoReinjection(unittest.TestCase):
+    def setUp(self):
+        saved = raptor._TRUST_REPO_SEEN
+        self.addCleanup(setattr, raptor, "_TRUST_REPO_SEEN", saved)
+
+    def _captured_args(self, mode_fn, argv):
+        captured = {}
+
+        def fake_lifecycle(command, script_path, args, *a, **k):
+            captured["args"] = args
+            return 0
+
+        with mock.patch.object(raptor, "_run_with_lifecycle", fake_lifecycle):
+            rc = mode_fn(list(argv))
+        self.assertEqual(rc, 0)
+        return captured["args"]
+
+    def test_codeql_reinjects_when_seen(self):
+        raptor._TRUST_REPO_SEEN = True
+        self.assertIn("--trust-repo",
+                      self._captured_args(raptor.mode_codeql, ["--repo", "/tgt"]))
+
+    def test_agentic_reinjects_when_seen(self):
+        raptor._TRUST_REPO_SEEN = True
+        self.assertIn("--trust-repo",
+                      self._captured_args(raptor.mode_agentic, ["--repo", "/tgt"]))
+
+    def test_no_reinjection_when_not_seen(self):
+        raptor._TRUST_REPO_SEEN = False
+        self.assertNotIn("--trust-repo",
+                         self._captured_args(raptor.mode_codeql, ["--repo", "/tgt"]))
+        self.assertNotIn("--trust-repo",
+                         self._captured_args(raptor.mode_agentic, ["--repo", "/tgt"]))
+
+    def test_no_duplicate_when_already_present(self):
+        raptor._TRUST_REPO_SEEN = True
+        args = self._captured_args(
+            raptor.mode_codeql, ["--trust-repo", "--repo", "/tgt"])
+        self.assertEqual(args.count("--trust-repo"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/raptor.py
+++ b/raptor.py
@@ -370,6 +370,11 @@ def _run_with_lifecycle(command: str, script_path: Path, args: list,
     return rc
 
 
+# Set True by main() when --trust-repo is seen (and stripped from argv).
+# Read by the subprocess mode handlers (codeql/agentic) to re-inject the
+# flag into their child args — see the note in main().
+_TRUST_REPO_SEEN = False
+
 _active_dispatcher = None
 
 
@@ -659,6 +664,11 @@ def mode_agentic(args: list) -> int:
     if '--codeql' not in args and '--codeql-only' not in args and '--no-codeql' not in args:
         args = ['--codeql'] + args
 
+    # Re-inject --trust-repo stripped by main(): the agentic child parses it
+    # to set the cc_trust + codeql_trust overrides in its own process.
+    if _TRUST_REPO_SEEN and '--trust-repo' not in args:
+        args = ['--trust-repo'] + args
+
     return _run_with_lifecycle("agentic", agentic_script, args,
                               "Starting full autonomous workflow (Semgrep + CodeQL)...")
 
@@ -675,6 +685,11 @@ def mode_codeql(args: list) -> int:
     # Default to scan-only; autonomous analysis requires explicit --analyze
     if '--scan-only' not in args and '--analyze' not in args:
         args = ['--scan-only'] + args
+
+    # Re-inject --trust-repo stripped by main(): the codeql child parses it
+    # to set the cc_trust + codeql_trust overrides in its own process.
+    if _TRUST_REPO_SEEN and '--trust-repo' not in args:
+        args = ['--trust-repo'] + args
 
     return _run_with_lifecycle("codeql", codeql_script, args,
                               "Running CodeQL analysis...")
@@ -828,11 +843,18 @@ def main():
     """Main entry point for unified RAPTOR launcher."""
     # Pre-process --trust-repo at the top level so it works in any position
     # (`raptor --trust-repo scan /x` or `raptor scan /x --trust-repo`).
-    # Sets the module-level flag in core.security.cc_trust; mode handlers
-    # don't need to know about it.
+    # Sets the cc_trust module flag for in-process / parent-side checks.
+    # SUBPROCESS mode handlers (codeql/agentic) can't rely on that flag —
+    # module-level trust state doesn't cross the subprocess boundary, and
+    # we strip the flag from argv here — so they re-inject --trust-repo into
+    # their child args via _TRUST_REPO_SEEN. Without that, `raptor.py codeql
+    # --trust-repo` silently fails to lift the child's target-repo trust
+    # checks (fail-closed: it over-blocks, but the documented override breaks).
     if "--trust-repo" in sys.argv:
         from core.security.cc_trust import set_trust_override
+        global _TRUST_REPO_SEEN
         set_trust_override(True)
+        _TRUST_REPO_SEEN = True
         sys.argv = [a for a in sys.argv if a != "--trust-repo"]
 
     # If no arguments provided, show help


### PR DESCRIPTION
The unified raptor.py launcher strips --trust-repo and sets the trust override in its own process, but /codeql and /agentic run the target work in a subprocess that neither inherits the module-level flag nor sees the stripped argv — so the cc_trust + codeql_trust overrides were never set in the child, and --trust-repo silently failed to lift the target-repo trust checks (fail-closed: over-blocked). Re-inject --trust-repo into the child args for the modes whose scripts parse it.