### PR TITLE
feat(understand): surface a library's public API as attack surface (target_kind consumer)

### DIFF
--- a/core/orchestration/tests/test_understand_bridge.py
+++ b/core/orchestration/tests/test_understand_bridge.py
@@ -1155,6 +1155,112 @@ class TestNormalizeContextMap:
 
 
 # ---------------------------------------------------------------------------
+# library-surface augmentation (target_kind consumer)
+# ---------------------------------------------------------------------------
+
+class TestAugmentLibrarySurface:
+    """Pass 6 of normalize_context_map: the first consumer of target_kind.
+    For library/hybrid, the public API is surfaced as attack surface (trust
+    boundary + sources + backfilled entry points). Python items use name
+    convention so no metadata is needed (grammar-independent)."""
+
+    def _checklist(self, kind, items):
+        return {
+            "target_path": "/repo",
+            "target_kind": kind,
+            "target_kind_reason": "test",
+            "files": [{"path": "lib.py", "language": "python", "items": items}],
+        }
+
+    _ITEMS = [
+        {"name": "public_api", "kind": "function", "line_start": 1, "line_end": 3},
+        {"name": "another_pub", "kind": "function", "line_start": 5, "line_end": 7},
+        {"name": "_private", "kind": "function", "line_start": 9, "line_end": 11},
+    ]
+
+    def _origins(self, lst, origin):
+        return [x for x in lst if isinstance(x, dict) and x.get("origin") == origin]
+
+    def test_library_surfaces_exports_as_entry_points(self):
+        ctx = {}
+        normalize_context_map(ctx, self._checklist("library", self._ITEMS))
+        assert ctx["target_kind"] == "library"
+        eps = self._origins(ctx["entry_points"], "inventory-entry")
+        names = {e["name"] for e in eps}
+        assert names == {"public_api", "another_pub"}   # _private excluded
+        assert all(e["type"] == "library_api" for e in eps)
+        # boundary + source records
+        assert len(self._origins(ctx["trust_boundaries"], "library-surface")) == 1
+        assert len(self._origins(ctx["sources"], "library-surface")) == 1
+        assert ctx["sources"][-1]["trust_level"] == "attacker_controlled"
+
+    def test_no_cap_surfaces_all_exports(self):
+        items = [{"name": f"api_{i}", "kind": "function", "line_start": i}
+                 for i in range(200)]
+        ctx = {}
+        normalize_context_map(ctx, self._checklist("library", items))
+        assert len(self._origins(ctx["entry_points"], "inventory-entry")) == 200
+
+    def test_hybrid_also_enables(self):
+        ctx = {}
+        normalize_context_map(ctx, self._checklist("hybrid", self._ITEMS))
+        assert ctx["target_kind"] == "hybrid"
+        assert len(self._origins(ctx["entry_points"], "inventory-entry")) == 2
+
+    def test_dedups_against_llm_found_entry(self):
+        # The LLM already listed public_api; we must not double-list it.
+        ctx = {"entry_points": [{"id": "EP-001", "name": "public_api",
+                                 "file": "lib.py", "line": 1}]}
+        normalize_context_map(ctx, self._checklist("library", self._ITEMS))
+        names = [e["name"] for e in ctx["entry_points"]]
+        assert names.count("public_api") == 1
+        # the other export still gets added
+        assert "another_pub" in names
+
+    def test_idempotent(self):
+        ctx = {}
+        cl = self._checklist("library", self._ITEMS)
+        normalize_context_map(ctx, cl)
+        first = copy.deepcopy(ctx)
+        normalize_context_map(ctx, cl)   # second pass adds nothing
+        assert ctx == first
+
+    def test_application_is_stamped_only(self):
+        ctx = {}
+        normalize_context_map(ctx, self._checklist("application", self._ITEMS))
+        assert ctx["target_kind"] == "application"
+        assert "entry_points" not in ctx or not self._origins(
+            ctx.get("entry_points", []), "inventory-entry")
+        assert not self._origins(ctx.get("trust_boundaries", []), "library-surface")
+
+    def test_no_target_kind_is_noop(self):
+        # Pre-#719 checklist with no target_kind → nothing added/stamped.
+        ctx = {}
+        normalize_context_map(ctx, {"target_path": "/repo", "files": []})
+        assert "target_kind" not in ctx
+
+    def test_native_c_library_surfaces_non_static_linkage(self):
+        # A C library's attack surface is its non-static (external-linkage)
+        # functions, which the dynamic-langs-only export predicate would miss.
+        # _item_is_entry's linkage branch surfaces them; static stays internal.
+        ctx = {}
+        checklist = {
+            "target_path": "/repo", "target_kind": "library",
+            "files": [{"path": "lib.c", "language": "c", "items": [
+                {"name": "lib_encode", "kind": "function", "line_start": 10,
+                 "metadata": {"visibility": "extern"}},
+                {"name": "lib_decode", "kind": "function", "line_start": 20,
+                 "metadata": {"visibility": "extern"}},
+                {"name": "internal_helper", "kind": "function", "line_start": 30,
+                 "metadata": {"visibility": "static"}},
+            ]}],
+        }
+        normalize_context_map(ctx, checklist)
+        names = {e["name"] for e in self._origins(ctx["entry_points"], "inventory-entry")}
+        assert names == {"lib_encode", "lib_decode"}   # static excluded
+
+
+# ---------------------------------------------------------------------------
 # enrich_checklist
 # ---------------------------------------------------------------------------
 

--- a/core/orchestration/understand_bridge.py
+++ b/core/orchestration/understand_bridge.py
@@ -477,7 +477,7 @@ def normalize_context_map(context_map: Dict[str, Any], checklist: Dict[str, Any]
     """Mechanically fix up an LLM-produced context-map using the checklist
     as ground truth.
 
-    Mutates ``context_map`` in place; returns it for chaining. Does five
+    Mutates ``context_map`` in place; returns it for chaining. Does six
     deterministic passes that are safe to run multiple times (idempotent):
 
     1. **Path normalisation** on every ``file:`` field across entry_points,
@@ -502,6 +502,12 @@ def normalize_context_map(context_map: Dict[str, Any], checklist: Dict[str, Any]
        references entry_point or sink IDs that don't exist in the
        respective lists.
 
+    6. **Library-surface augmentation** (``_augment_library_surface``): the
+       first consumer of ``checklist['target_kind']``. For a library/hybrid
+       target, stamps the kind, records the public API as a trust boundary +
+       attacker-controlled source, and backfills the exported functions as
+       entry points the LLM missed. No-op for application/unknown.
+
     Returns the (mutated) context_map for caller convenience. Bails as a
     no-op if either input is missing or wrong-typed.
     """
@@ -524,7 +530,117 @@ def normalize_context_map(context_map: Dict[str, Any], checklist: Dict[str, Any]
         if isinstance(fi, dict) and fi.get("path")
     }
     _backfill_and_validate_locations(context_map, files_by_path)
+    _augment_library_surface(context_map, checklist)
     return context_map
+
+
+def _augment_library_surface(context_map: Dict[str, Any],
+                             checklist: Dict[str, Any]) -> None:
+    """6th normalise pass — the first consumer of ``checklist['target_kind']``.
+
+    For a ``library``/``hybrid`` target the public/exported API *is* the attack
+    surface: a consumer passes attacker-controlled data into the exported
+    functions, so their parameters are untrusted sources. The LLM, looking for
+    HTTP routes / a ``main``, often reports a pure library as having "no entry
+    points"; this pass closes that gap deterministically from the inventory.
+
+    Three additions (idempotent — safe to re-run, tagged with stable
+    ``origin`` markers so a second pass adds nothing):
+      1. Stamp ``context_map['target_kind']`` (+ reason) for any kind.
+      2. A single ``library-api`` trust-boundary record and a matching
+         attacker-controlled ``sources`` record.
+      3. Backfill *every* exported function as an entry point (no cap —
+         truncating attack surface is a false negative, and reachability
+         already treats all exports as entries), deduped against entries the
+         LLM already enumerated.
+
+    No-op for ``application``/``unknown`` (and for pre-#719 checklists with no
+    ``target_kind``), beyond the stamp.
+    """
+    kind = checklist.get("target_kind")
+    if not kind:
+        return
+    context_map["target_kind"] = kind
+    reason = checklist.get("target_kind_reason")
+    if reason:
+        context_map["target_kind_reason"] = reason
+    if kind not in ("library", "hybrid"):
+        return
+
+    boundaries = context_map.setdefault("trust_boundaries", [])
+    if isinstance(boundaries, list) and not any(
+        isinstance(b, dict) and b.get("origin") == "library-surface"
+        for b in boundaries
+    ):
+        boundaries.append({
+            "boundary": "Public API surface (library/hybrid target): exported "
+                        "functions are invoked by external consumers, so their "
+                        "parameters are caller-controlled (untrusted).",
+            "check": "",
+            "origin": "library-surface",
+        })
+
+    sources = context_map.setdefault("sources", [])
+    if isinstance(sources, list) and not any(
+        isinstance(s, dict) and s.get("origin") == "library-surface"
+        for s in sources
+    ):
+        sources.append({
+            "type": "library_api",
+            "entry": "exported public API parameters",
+            "trust_level": "attacker_controlled",
+            "origin": "library-surface",
+        })
+
+    eps = context_map.setdefault("entry_points", [])
+    if not isinstance(eps, list):
+        return
+    # Dedup against entries the LLM already found (names are backfilled by the
+    # prior pass) and against ones we add.
+    seen: Set[Tuple[str, str]] = set()
+    for ep in eps:
+        if isinstance(ep, dict):
+            f, n = ep.get("file"), ep.get("name")
+            if isinstance(f, str) and isinstance(n, str):
+                seen.add((f, n))
+
+    # Use the same per-item entry predicate reachability uses, in library
+    # mode: covers the dynamic/JVM EXPORTS *and* native LINKAGE entries (C
+    # non-static, Go-exported, Rust-pub) — so a C/Rust/Go library's public API
+    # surfaces too, not just the dynamic langs. library_mode=True is correct
+    # here because we only reach this for a library/hybrid target.
+    from core.inventory.reachability import _item_is_entry
+    added = 0
+    for fi in _list_at(checklist, "files"):
+        if not isinstance(fi, dict):
+            continue
+        lang = fi.get("language")
+        path = fi.get("path")
+        if not isinstance(path, str):
+            continue
+        for item in fi.get("items") or []:
+            if not isinstance(item, dict):
+                continue
+            if item.get("kind", "function") != "function":
+                continue
+            name = item.get("name")
+            if not isinstance(name, str) or not name:
+                continue
+            if (path, name) in seen or not _item_is_entry(item, lang, library_mode=True):
+                continue
+            seen.add((path, name))
+            added += 1
+            eps.append({
+                "id": f"EP-LIB-{added:03d}",
+                "type": "library_api",
+                "name": name,
+                "file": path,
+                "line": item.get("line_start"),
+                "auth_required": False,
+                "origin": "inventory-entry",
+                "notes": "Library API entry point (export/linkage) — "
+                         "reachable by external consumers.",
+            })
 
 
 # Top-level keys whose entries carry a (file, line) pair worth normalising.


### PR DESCRIPTION
normalize_context_map gains a 6th deterministic pass — the first consumer of the inventory's target_kind. For a library/hybrid target the public/exported API IS the attack surface (a consumer feeds attacker-controlled data into the exported functions), so the LLM's "no entry points" verdict on a pure library misses it. The pass:

  1. stamps context_map['target_kind'] (+ reason),
  2. records the public API as a trust boundary + an attacker-controlled source, and
  3. backfills every entry-point function the LLM missed, deduped against entries it already found, with no cap (truncating attack surface would be a false negative, and reachability already treats every entry as live).

Entry selection uses reachability's _item_is_entry(library_mode=True), so it covers native LINKAGE entries (C non-static, Go-exported, Rust-pub) as well as the dynamic/JVM exports — a C/Rust/Go library's API surfaces, not just the dynamic langs. No-op for application/unknown and for pre-#719 checklists. FN-safe (additive only); idempotent.