### PR TITLE
feat(llm): harden --model resolution (override, creds, loud failures)

### DIFF
--- a/core/llm/config.py
+++ b/core/llm/config.py
@@ -908,6 +908,18 @@ class ModelConfig:
     role: Optional[str] = None  # "analysis", "code", "consensus", "fallback", "judge", "aggregate"
 
 
+def _shared_prefix_len(a: str, b: str) -> int:
+    """Length of the common case-insensitive prefix of two model names —
+    the specificity score for credential reuse (longer = closer relative)."""
+    a, b = a.lower(), b.lower()
+    n = 0
+    for ca, cb in zip(a, b):
+        if ca != cb:
+            break
+        n += 1
+    return n
+
+
 @dataclass
 class LLMConfig:
     """Main LLM configuration for RAPTOR."""
@@ -983,6 +995,67 @@ class LLMConfig:
             return
         for task in FAST_TIER_TASKS:
             self.specialized_models.setdefault(task, fast_config)
+
+    def _configured_models(self) -> List[ModelConfig]:
+        """Every model the operator has configured: primary + fallbacks +
+        specialized."""
+        models: List[ModelConfig] = []
+        if self.primary_model is not None:
+            models.append(self.primary_model)
+        models.extend(self.fallback_models or [])
+        models.extend((self.specialized_models or {}).values())
+        return models
+
+    def config_for_model(self, model_id: str) -> ModelConfig:
+        """Build a ModelConfig for an arbitrary ``model_id``, reusing the
+        most specific credential already configured.
+
+        Resolution, most specific first:
+          1. an exact configured entry for ``model_id`` — returned as-is, so
+             its per-model settings (temperature, base, role) are preserved;
+          2. otherwise, among configured models of the same provider that
+             carry a credential, the one whose name shares the longest prefix
+             with ``model_id`` — a configured ``claude-opus-4-6`` lends its
+             key to ``claude-opus-4-8`` ahead of a ``claude-haiku-*`` entry;
+             its api_key / api_base are borrowed onto a config for ``model_id``;
+          3. otherwise a bare config (api_key=None) so the SDK / dispatcher /
+             provider env var supplies the credential at call time.
+        """
+        from core.security.llm_family import (
+            bare_model_id,
+            provider_of,
+            unknown_model_message,
+        )
+
+        candidates = self._configured_models()
+        for mc in candidates:
+            if mc.model_name == model_id:
+                return mc
+
+        provider = provider_of(model_id)
+        if not provider:
+            # Fail loudly rather than synthesizing a keyless, provider-less
+            # config that fails opaquely downstream — an explicit override
+            # with an unrecognizable name is almost always a typo / nickname.
+            raise ValueError(unknown_model_message(model_id))
+        same_provider = [
+            mc for mc in candidates if mc.provider == provider and mc.api_key
+        ]
+        if same_provider:
+            target = bare_model_id(model_id)
+            best = max(
+                same_provider,
+                key=lambda mc: _shared_prefix_len(
+                    target, bare_model_id(mc.model_name)
+                ),
+            )
+            return ModelConfig(
+                provider=provider,
+                model_name=model_id,
+                api_key=best.api_key,
+                api_base=best.api_base,
+            )
+        return ModelConfig(provider=provider, model_name=model_id)
 
     def to_file(self, config_path: Path) -> None:
         """Save a MINIMAL snapshot of this configuration to JSON.

--- a/core/llm/tests/test_config_for_model.py
+++ b/core/llm/tests/test_config_for_model.py
@@ -1,0 +1,93 @@
+"""Tests for LLMConfig.config_for_model — credential reuse by specificity.
+
+The rule: when resolving an arbitrary model id, reuse the most specific
+configured credential — exact model, else the closest same-provider relative
+(longest shared name prefix), else any same-provider key, else bare.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# core/llm/tests/test_config_for_model.py -> parents[3] = repo root
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
+
+from core.llm.config import LLMConfig, ModelConfig  # noqa: E402
+from core.security.llm_family import provider_of  # noqa: E402
+
+
+def _cfg():
+    # primary=None so __post_init__ does not seed specialized fast-tier models.
+    return LLMConfig(
+        primary_model=None,
+        fallback_models=[
+            ModelConfig(provider="anthropic", model_name="claude-opus-4-6", api_key="K_OPUS"),
+            ModelConfig(
+                provider="anthropic",
+                model_name="claude-haiku-4-5-20251001",
+                api_key="K_HAIKU",
+            ),
+            ModelConfig(provider="gemini", model_name="gemini-2.5-pro", api_key="K_GEM"),
+        ],
+        specialized_models={},
+    )
+
+
+def test_exact_match_returns_configured_entry_as_is():
+    cfg = _cfg()
+    got = cfg.config_for_model("claude-opus-4-6")
+    assert got.api_key == "K_OPUS"
+    assert got.model_name == "claude-opus-4-6"
+
+
+def test_closest_relative_lends_credential():
+    # opus-4-8 is unconfigured; the opus-4-6 key is a closer fit than haiku's.
+    cfg = _cfg()
+    got = cfg.config_for_model("claude-opus-4-8")
+    assert got.provider == "anthropic"
+    assert got.model_name == "claude-opus-4-8"
+    assert got.api_key == "K_OPUS"
+
+
+def test_any_same_provider_key_when_no_close_relative():
+    # sonnet shares only "claude-" with both; any anthropic key is acceptable.
+    cfg = _cfg()
+    got = cfg.config_for_model("claude-sonnet-4-6")
+    assert got.provider == "anthropic"
+    assert got.api_key in {"K_OPUS", "K_HAIKU"}
+
+
+def test_provider_isolation_gemini_borrows_gemini_key():
+    cfg = _cfg()
+    got = cfg.config_for_model("gemini-2.5-flash")
+    assert got.provider == "gemini"
+    assert got.api_key == "K_GEM"
+
+
+def test_bare_config_when_no_matching_provider_key():
+    cfg = _cfg()
+    got = cfg.config_for_model("gpt-5.4")
+    assert got.api_key is None
+    assert got.provider == provider_of("gpt-5.4")
+    assert got.model_name == "gpt-5.4"
+
+
+def test_unrecognized_model_name_raises_loudly():
+    # prefix-less nickname -> no resolvable provider -> loud error, not a
+    # silent keyless config
+    cfg = _cfg()
+    with pytest.raises(ValueError) as ei:
+        cfg.config_for_model("opus-4-8")
+    assert "opus-4-8" in str(ei.value)
+
+
+def test_exact_configured_name_wins_even_if_provider_unrecognized():
+    # an operator who configured a model under an unusual name still gets it
+    # (exact match short-circuits the loud-failure path)
+    weird = ModelConfig(provider="ollama", model_name="weird-local-model", api_key="K")
+    cfg = LLMConfig(primary_model=None, fallback_models=[weird], specialized_models={})
+    assert cfg.config_for_model("weird-local-model") is weird

--- a/core/security/llm_family.py
+++ b/core/security/llm_family.py
@@ -97,6 +97,20 @@ def provider_of(model_id: str) -> str:
     return provider_for_family(family_of(model_id))
 
 
+def unknown_model_message(model_id: str) -> str:
+    """Operator-facing hint for a model id whose provider can't be resolved.
+
+    Used to fail loudly (instead of silently producing a keyless / provider-
+    less config) when an operator passes a prefix-less nickname like
+    ``opus-4-8`` rather than a recognizable id."""
+    return (
+        f"unrecognized model {model_id!r}: cannot determine its provider. "
+        f"Use a recognizable id (e.g. 'claude-opus-4-8', 'gpt-5', "
+        f"'gemini-2.5-pro') or an explicit 'provider/model' form "
+        f"(e.g. 'anthropic/claude-opus-4-8')."
+    )
+
+
 def bare_model_id(model_id: str) -> str:
     """Return the model identifier with any aggregator + provider
     prefix peeled off.

--- a/packages/llm_analysis/orchestrator.py
+++ b/packages/llm_analysis/orchestrator.py
@@ -184,7 +184,11 @@ def build_llm_config_from_flags(
 
     Args:
         models: List of analysis model names. Single entry = one primary.
-            Multiple = multi-model mode (each independently analyses).
+            Multiple = multi-model mode (each independently analyses). When
+            set, this is a GENERAL OVERRIDE: config-derived fallback / role
+            defaults from models.json are suppressed, so only these models +
+            any explicit --consensus/--judge/--aggregate are used (nothing
+            cross-provider sneaks in from config).
         consensus: Blind second-opinion model name.
         judge: Non-blind review model name.
         aggregate: Final synthesis model name.
@@ -233,6 +237,13 @@ def build_llm_config_from_flags(
                 break
         mc = _model_config_from_entry(entry)
         if not mc.api_key:
+            if not provider:
+                # Unrecognizable name and no configured entry matched it by
+                # name — fail loudly with the recognizable-id hint rather
+                # than the unhelpful "Set ??? env var" path below.
+                from core.security.llm_family import unknown_model_message
+                print(f"\n  Error: {unknown_model_message(name)}")
+                return None
             env_key = PROVIDER_ENV_KEYS.get(provider, "???")
             print(f"\n  Error: no API key for --model {name}")
             print(f"  Set {env_key} or add the key to models.json")
@@ -242,7 +253,17 @@ def build_llm_config_from_flags(
     if models:
         primary_mc = _resolve_model(models[0], "analysis")
         if primary_mc:
-            llm_config = LLMConfig(primary_model=primary_mc)
+            # Explicit --model is a GENERAL OVERRIDE over config-derived
+            # defaults: construct with fallback_models=[] so the models.json /
+            # env fallback + role models (e.g. a configured cross-provider
+            # fallback, or a role="consensus" entry) do NOT load. Only the
+            # explicit --model list (here) and explicit --consensus/--judge/
+            # --aggregate flags (below) populate roles — nothing the operator
+            # didn't ask for sneaks in, and an explicit single-provider --model
+            # can never silently fall back cross-provider. Specialized
+            # fast-tier models are still auto-seeded by __post_init__ from the
+            # primary's OWN provider, so they stay same-provider (cheap).
+            llm_config = LLMConfig(primary_model=primary_mc, fallback_models=[])
             for extra in models[1:]:
                 mc = _resolve_model(extra, "analysis")
                 if mc:

--- a/packages/llm_analysis/tests/test_dispatch.py
+++ b/packages/llm_analysis/tests/test_dispatch.py
@@ -1111,6 +1111,25 @@ class TestConfigRoleValidation:
         assert result["analysis_model"] == m1
 
 
+class _StubConfigWithDefaults:
+    """Stand-in for LLMConfig that injects config-derived defaults (a
+    cross-provider fallback + a role=consensus model) when constructed
+    WITHOUT an explicit fallback_models — i.e. what models.json would load.
+    Passing fallback_models=[] (the override path) yields no defaults."""
+
+    def __init__(self, primary_model=None, fallback_models=None, **kw):
+        from core.llm.config import ModelConfig
+        self.primary_model = primary_model
+        if fallback_models is None:
+            self.fallback_models = [
+                ModelConfig(provider="gemini", model_name="gemini-2.5-flash", role="fallback"),
+                ModelConfig(provider="anthropic", model_name="claude-haiku-4-5", role="consensus"),
+            ]
+        else:
+            self.fallback_models = list(fallback_models)
+        self.specialized_models = {}
+
+
 class TestBuildLLMConfigFromFlags:
     def test_no_flags_no_autodetect_returns_none(self):
         from packages.llm_analysis.orchestrator import build_llm_config_from_flags
@@ -1215,6 +1234,41 @@ class TestBuildLLMConfigFromFlags:
         consensus_models = [m for m in result.fallback_models if m.role == "consensus"]
         assert len(consensus_models) == 1
         assert consensus_models[0].model_name == "mistral-large-latest"
+
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "k"})
+    def test_explicit_model_suppresses_config_derived_defaults(self):
+        """An explicit --model is a general override: config-derived fallback
+        / role models (e.g. a cross-provider fallback or a role=consensus
+        entry from models.json) must NOT load when --model is set without the
+        matching role flag."""
+        from packages.llm_analysis.orchestrator import build_llm_config_from_flags
+        with patch("core.llm.config.LLMConfig", _StubConfigWithDefaults):
+            result = build_llm_config_from_flags(models=["gpt-5"], auto_detect=False)
+        assert result is not None
+        assert result.fallback_models == []  # nothing config-derived leaked
+        assert all(m.provider != "gemini" for m in result.fallback_models)
+        assert all(m.role != "consensus" for m in result.fallback_models)
+
+    def test_unrecognized_model_name_fails_loudly(self, capsys):
+        from packages.llm_analysis.orchestrator import build_llm_config_from_flags
+        result = build_llm_config_from_flags(models=["opus-4-8"], auto_detect=False)
+        assert result is None
+        assert "unrecognized model" in capsys.readouterr().out
+
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "k", "MISTRAL_API_KEY": "k2"})
+    def test_explicit_model_composes_with_role_flag_only(self):
+        """--model X --consensus Y → only Y as consensus; the config-derived
+        consensus + cross-provider fallback are still suppressed."""
+        from packages.llm_analysis.orchestrator import build_llm_config_from_flags
+        with patch("core.llm.config.LLMConfig", _StubConfigWithDefaults):
+            result = build_llm_config_from_flags(
+                models=["gpt-5"], consensus="mistral-large-latest", auto_detect=False,
+            )
+        assert result is not None
+        consensus_models = [m for m in result.fallback_models if m.role == "consensus"]
+        assert len(consensus_models) == 1
+        assert consensus_models[0].model_name == "mistral-large-latest"
+        assert all(m.provider != "gemini" for m in result.fallback_models)
 
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
Three related improvements to how an explicit model selection is resolved, so "use the json or specify it on the CLI, but they don't mix" holds — and nothing cross-provider sneaks in.

config_for_model (core/llm/config.py): resolving an arbitrary model id now reuses the most specific credential already configured — exact configured entry > closest same-provider relative (longest shared name prefix) > any same-provider key > bare. So a configured claude-haiku-4-5 lends its Anthropic key to claude-opus-4-8, a configured claude-opus-4-6 is preferred over haiku for opus-4-8, and credentials never cross providers. Previously an override synthesized a keyless config and only worked via a provider env var.

--model as a general override (orchestrator build_llm_config_from_flags): an explicit --model now constructs LLMConfig with fallback_models=[], so config-derived fallback/role models from models.json (e.g. a role=fallback cross-provider model or a role=consensus entry) are suppressed. Only the explicit --model list and explicit --consensus/--judge/--aggregate populate roles; a single-provider --model can no longer silently fall back cross-provider. Specialized fast-tier models still auto-seed from the primary's own provider. Repeatable --model and role-flag composition unchanged.

Loud failure on an unrecognized model name (llm_family.unknown_model_message): a prefix-less nickname like 'opus-4-8' has no resolvable provider; instead of a silent keyless config that fails opaquely, config_for_model raises, _resolve_model prints an actionable hint and returns None, and the eval CLI exits 2 with a one-line error. An exact configured entry still short-circuits.

Tests: credential-reuse tiers; --model suppresses config defaults + composes with role flags; unrecognized-name failure across all three paths.