### PR TITLE
feat(sca/harden): range-preserving floor-raise across PyPI/npm/NuGet/Gradle/Maven for library targets

### DIFF
--- a/packages/sca/harden.py
+++ b/packages/sca/harden.py
@@ -24,6 +24,21 @@ Behaviour notes:
   - No network calls when ``--offline``: in offline mode every dep
     becomes ``status="needs_network"``.
 
+Library posture (``--target-kind library|hybrid`` or auto-detected from the
+target's package manifests via ``resolve_library_mode``): a library's deps
+are consumed by *downstream* resolvers, so exact-pinning them
+over-constrains every consumer. Under the library posture harden therefore:
+  - leaves an already-safe declared range alone (skip-clean);
+  - emits a RANGE floor-raise (``>=target``, no ``==``) for PyPI + npm +
+    PyPI Poetry; trusts NuGet/Gradle/Maven's existing min/soft-version
+    rewrites (their bumps are already floor-raises);
+  - refuses forms that can only produce an exact pin (inline-install,
+    Debian apt) with ``status="library_floor_raise_unsupported"`` — never
+    silently corridor-pins a library;
+  - picks the MINIMAL safe version (not the newest) as the floor-raise
+    target, to preserve the widest compatible range for consumers.
+``RAPTOR_TARGET_KIND=application`` is the operator override.
+
 What harden does NOT do (deferred):
   - LLM-classified breaking-change analysis — separate follow-up.
     Major-version candidates emit ``status="review_required"`` and are
@@ -121,6 +136,13 @@ class HardenCandidate:
     candidates_rejected_for_cve: int = 0
     status: str = "error"
     detail: str = ""
+    # Version-selection posture. ``highest_safe`` (default, application
+    # targets): pin to the newest safe version in range. ``library_minimal``
+    # (library/hybrid targets): pick the LOWEST safe version above the
+    # baseline — the minimal floor-raise that clears advisories — so the
+    # library's compatible range stays as wide as possible for downstream
+    # consumers (pinning a library's deps to latest over-constrains them).
+    selection: str = "highest_safe"
     # Reserved: the LLM impact analysis (Follow-up #7) populates this.
     impact_analysis: Optional[Dict[str, Any]] = None
 
@@ -140,6 +162,14 @@ def main(argv: Sequence[str]) -> int:
         except ImportError:
             logger.debug("raptor-sca fix: cc_trust unavailable; "
                           "--trust-repo had no effect")
+
+    # --target-kind: translate into RAPTOR_TARGET_KIND so resolve_library_mode
+    # (the in-process detector below) picks it up. 'auto' leaves the env
+    # unset → per-target manifest detection.
+    if getattr(args, "target_kind", "auto") != "auto":
+        import os
+        from core.config import RaptorConfig
+        os.environ[RaptorConfig.ENV_TARGET_KIND] = args.target_kind
 
     target = Path(args.target).resolve()
     if not target.exists():
@@ -182,6 +212,26 @@ def main(argv: Sequence[str]) -> int:
         "Homebrew": HomebrewClient(http, cache, offline=args.offline),
     }
 
+    # Classify the target (manifest-based, reuses the same files harden
+    # parses). For a library/hybrid, pinning deps to latest over-constrains
+    # downstream consumers, so harden raises floors MINIMALLY instead — see
+    # ``selection`` on HardenCandidate. Use resolve_library_mode (not the raw
+    # detector) so the operator's RAPTOR_TARGET_KIND override — which is
+    # allowlisted to survive into this subprocess — takes effect here too.
+    try:
+        from core.inventory.library_detection import resolve_library_mode
+        _mode = resolve_library_mode("auto", str(target))
+        target_kind = _mode["kind"]
+        library_mode = _mode["enabled"]
+        target_kind_reason = _mode["reason"]
+    except Exception as exc:                              # noqa: BLE001
+        logger.debug("sca.harden: target-kind detection failed (%s); "
+                     "defaulting to application posture", exc)
+        target_kind, library_mode, target_kind_reason = "unknown", False, ""
+    if library_mode:
+        logger.info("sca.harden: target classified %s — raising dependency "
+                    "floors minimally to preserve ranges", target_kind)
+
     candidates = plan(
         target=target,
         registries=registries,
@@ -192,6 +242,7 @@ def main(argv: Sequence[str]) -> int:
         allow_major=args.allow_major,
         pin_only=args.pin_only,
         pin_debian=args.pin_debian,
+        library_mode=library_mode,
     )
 
     # ``--ecosystems`` is a post-plan filter: candidates outside the
@@ -221,8 +272,9 @@ def main(argv: Sequence[str]) -> int:
             allow_degraded=args.allow_degraded,
             ecosystem_allowlist=ecosystem_allowlist,
         )
-        _write_report(out_dir / "report.md", candidates, [])
-        _print_summary(candidates, [], out_dir)
+        _write_report(out_dir / "report.md", candidates, [],
+                      target_kind=target_kind, target_kind_reason=target_kind_reason)
+        _print_summary(candidates, [], out_dir, target_kind=target_kind)
         if actionable:
             print(f"raptor-sca fix --harden --check: {actionable} candidate(s) would be "
                   f"applied; rerun without --check to apply.")
@@ -273,8 +325,9 @@ def main(argv: Sequence[str]) -> int:
         if rc != 0:
             return rc
 
-    _write_report(out_dir / "report.md", candidates, changes)
-    _print_summary(candidates, changes, out_dir)
+    _write_report(out_dir / "report.md", candidates, changes,
+                  target_kind=target_kind, target_kind_reason=target_kind_reason)
+    _print_summary(candidates, changes, out_dir, target_kind=target_kind)
     return 0
 
 
@@ -293,6 +346,7 @@ def plan(
     allow_major: bool,
     pin_only: bool = False,
     pin_debian: bool = False,
+    library_mode: bool = False,
 ) -> List[HardenCandidate]:
     """Walk the target and produce one HardenCandidate per dep.
 
@@ -310,6 +364,10 @@ def plan(
       allow_major: when False, candidates whose latest-safe crosses a
         major boundary become ``review_required`` and are omitted from
         the patch.
+      library_mode: when True (library/hybrid target), select the minimal
+        safe version above the baseline rather than the newest — a minimal
+        floor-raise that clears advisories while keeping the dependency
+        range wide for downstream consumers.
     """
     manifests = find_manifests(target)
     raw_deps: List[Dependency] = []
@@ -347,8 +405,65 @@ def plan(
                              kev=kev, epss=epss,
                              offline=offline, allow_major=allow_major,
                              pin_only=pin_only, pin_debian=pin_debian,
-                             platform_matrix=platform_matrix))
+                             platform_matrix=platform_matrix,
+                             library_mode=library_mode))
     return out
+
+
+def _supports_library_floor_raise(dep: Dependency) -> bool:
+    """Whether harden can promote this dep without over-constraining a
+    library's consumers (i.e. without emitting an exact ``==`` pin). True for
+    every manifest whose rewriter yields a range or a minimum/soft version:
+
+      - PyPI requirements.txt / pyproject.toml — explicit floor-raise
+        (``>=target``, no ``==``); see ``_pypi_pin_preserving_bounds`` /
+        ``_bump_npm_spec(floor_raise=)``.
+      - npm package.json — semver (caret/tilde/range stay ranges; a bare
+        exact becomes ``^target``).
+      - NuGet csproj / Directory.Packages.props, Gradle libs.versions.toml,
+        Maven pom.xml — these resolve by MINIMUM (NuGet/Gradle) or SOFT
+        (Maven) version, so the normal bump is already a floor-raise, not an
+        exact pin; the floor_raise flag is a harmless no-op for them.
+
+    False for inline-install files (``pip install x==Y`` is exact by nature,
+    no range form) and Debian apt lines — library mode refuses those rather
+    than pin. Mirrors ``update._rewrite_one``'s dispatch, minus inline.
+
+    Known scope limitations (pre-existing rewriter behaviour, not introduced
+    by library mode; rare in practice):
+      - Maven ``<version>[1.0,2.0)</version>`` *ranges* are collapsed to bare
+        by ``_rewrite_pom_xml`` regardless of mode; library mode doesn't
+        un-collapse them. Maven version ranges are uncommon.
+      - Gradle catalog ``foo = {{ strictly = "X" }}`` keeps the ``strictly``
+        wrapper (so it stays exact-for-downstream). The bare ``foo = "X"``
+        and ``foo = {{ require = "X" }}`` shorthand forms behave as
+        floor/preferred and are fine for libraries."""
+    n = dep.declared_in.name
+    if n in ("pyproject.toml", "package.json", "Directory.Packages.props",
+             "libs.versions.toml", "pom.xml"):
+        return True
+    if n.startswith("requirements") and n.endswith(".txt"):
+        return True
+    return dep.declared_in.suffix.lower() in (".csproj", ".fsproj", ".vbproj")
+
+
+def _baseline_is_clean(dep: Dependency, baseline: Optional[str], *,
+                       osv: OsvClient, kev=None, epss=None) -> bool:
+    """True if the dep's declared floor version itself carries no advisory —
+    i.e. the range's minimum is already safe, so a library should leave the
+    (intentional) range alone. A non-concrete baseline (a RANGE spec string
+    with no recorded floor) can't be assessed → return False so harden still
+    acts (conservative: better to floor-raise than to silently skip a real
+    vuln)."""
+    if not baseline or any(c in baseline for c in "<>=!~ ,*"):
+        return False
+    try:
+        ranked = _rank_candidates_by_safety(
+            ecosystem=dep.ecosystem, name=dep.name,
+            candidates=[baseline], osv=osv, kev=kev, epss=epss)
+    except Exception:                                    # noqa: BLE001
+        return False
+    return bool(ranked) and not ranked[0].advisory_ids
 
 
 def _plan_one(
@@ -363,6 +478,7 @@ def _plan_one(
     pin_only: bool = False,
     pin_debian: bool = False,
     platform_matrix=None,
+    library_mode: bool = False,
 ) -> HardenCandidate:
     cand = HardenCandidate(
         ecosystem=dep.ecosystem,
@@ -513,10 +629,53 @@ def _plan_one(
     cand.candidates_rejected_for_cve = len(ranked) - len(clean)
 
     if clean:
-        # Fully-safe path: pick the newest clean version.
-        target_version = clean[0].version
+        # Fully-safe path. Applications pin to the NEWEST clean version
+        # (clean[0]). Libraries/hybrids instead get a minimal, range-preserving
+        # FLOOR-RAISE — pinning a library's deps over-constrains downstream
+        # consumers' resolvers — but only when there's a security reason and
+        # only where we can emit a range (never corridor-pin a library).
+        if library_mode:
+            # (a) Don't narrow an intentional, already-safe range: if the
+            #     declared floor is itself clean, leave the dep untouched.
+            if _baseline_is_clean(dep, baseline, osv=osv, kev=kev, epss=epss):
+                cand.status = "up_to_date"
+                cand.detail = (
+                    f"library target: declared floor {baseline} is already "
+                    f"safe; range left intact (no exact pin)"
+                )
+                return cand
+            # (b) Only PyPI requirements.txt / pyproject PEP 508 can emit a
+            #     range-preserving floor-raise today. For anything else, refuse
+            #     rather than corridor-pin a library's dep (that is the harm).
+            if not _supports_library_floor_raise(dep):
+                cand.status = "library_floor_raise_unsupported"
+                cand.detail = (
+                    f"library target: range-preserving floor-raise not yet "
+                    f"implemented for {dep.ecosystem} / {dep.declared_in.name}; "
+                    f"refusing to pin (would over-constrain consumers)"
+                )
+                cand.to_version = clean[-1].version
+                return cand
+            target_version = clean[-1].version   # minimal safe above baseline
+            cand.selection = "library_minimal"
+        else:
+            target_version = clean[0].version
         residual_advs: List[str] = []
         target_status = "promoted"
+    elif library_mode:
+        # Library posture + no clean version in range: the only remaining
+        # moves (bounded-downgrade / degraded promotion) pin a SPECIFIC
+        # version (== ), which would over-constrain a library's consumers —
+        # and a degraded pick is still vulnerable. Refuse rather than pin;
+        # the operator sees the dep flagged but the library isn't made worse.
+        cand.status = "library_floor_raise_unsupported"
+        cand.detail = (
+            "library target: no fully-safe version in the declared range; "
+            "refusing to pin a library to a single (or residual-vulnerable) "
+            "version. Remediate the range bounds manually or scan as an "
+            "application (RAPTOR_TARGET_KIND=application)."
+        )
+        return cand
     else:
         # No clean version exists at/above the pin. Before settling for a
         # still-vulnerable upgrade, try a BOUNDED DOWNGRADE: the highest
@@ -581,6 +740,12 @@ def _plan_one(
             f"downgrade to clean {target_version} "
             f"(>= recorded floor {dep.version_floor})"
         )
+    elif target_status == "promoted" and cand.selection == "library_minimal":
+        cand.detail = (
+            f"library target: minimal safe floor-raise to {target_version} "
+            f"(smallest clean version above {dep.version or '*'}) — preserves "
+            f"the dependency range for downstream consumers"
+        )
 
     # Full safety check — the "harden" promise. Beyond OSV/KEV/EPSS,
     # consult the bump-tier supply-chain signals (recent_publish,
@@ -625,12 +790,16 @@ def _has_rewriter(manifest: Path) -> bool:
     """True if ``update._rewrite_one`` knows how to patch this file.
 
     Mirrors the dispatch table in ``update.py``. Update both together
-    when adding a new rewriter.
+    when adding a new rewriter — and a drift here causes harden to
+    silently mark patchable manifests as ``unsupported_manifest``.
     """
     name = manifest.name
-    if name in ("pom.xml", "package.json", "pyproject.toml"):
+    if name in ("pom.xml", "package.json", "pyproject.toml",
+                "Directory.Packages.props", "libs.versions.toml"):
         return True
     if name.startswith("requirements") and name.endswith(".txt"):
+        return True
+    if manifest.suffix.lower() in (".csproj", ".fsproj", ".vbproj"):
         return True
     # Delegate to update's own predicate so the two dispatches stay
     # in lockstep when new file-shapes land.
@@ -1212,6 +1381,9 @@ def _apply(
             target=cand.to_version,
             manifest=Path(cand.manifest),
             advisory_ids=[],
+            # Library posture: the rewriter raises the floor to a range
+            # (``>=target``) instead of corridor-pinning ``==target``.
+            floor_raise=(cand.selection == "library_minimal"),
         )
     if not plans:
         return []
@@ -1249,6 +1421,20 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
     )
     p.add_argument("target", help="path to the project to harden")
     p.add_argument("--out", help="output dir (default: ./out/sca-harden-<ts>/)")
+    p.add_argument(
+        "--target-kind",
+        choices=("auto", "library", "hybrid", "application"),
+        default="auto",
+        help=(
+            "Classify the target so harden's pinning posture matches it. "
+            "'auto' (default) sniffs package manifests; 'library' / 'hybrid' "
+            "raise floors to ranges (>=X) instead of pinning (==X), preserve "
+            "already-safe ranges, and refuse forms that would force an exact "
+            "pin; 'application' pins to the newest safe version. Sets "
+            "RAPTOR_TARGET_KIND so the in-process inventory detector honours "
+            "the operator's intent."
+        ),
+    )
     p.add_argument("--allow-major", action="store_true",
                    help="emit candidates that cross a major-version boundary")
     p.add_argument("--allow-major-without-review", action="store_true",
@@ -1335,6 +1521,9 @@ def _write_report(
     path: Path,
     candidates: List[HardenCandidate],
     changes: List[UpgradeChange],
+    *,
+    target_kind: str = "unknown",
+    target_kind_reason: str = "",
 ) -> None:
     by_status: Dict[str, List[HardenCandidate]] = {}
     for c in candidates:
@@ -1344,6 +1533,22 @@ def _write_report(
     lines.append(f"_Generated: "
                  f"{datetime.now(timezone.utc):%Y-%m-%d %H:%M:%S} UTC_")
     lines.append("")
+    if target_kind in ("library", "hybrid"):
+        why = f" ({target_kind_reason})" if target_kind_reason else ""
+        lines.append(
+            f"> **Detected as a {target_kind} target**{why}. Dependency floors "
+            "are raised to the *minimal* safe version as a **range** "
+            "(`>=X`), not pinned (`==X`) — exact-pinning a library's deps "
+            "over-constrains downstream consumers' resolvers. Already-safe "
+            "ranges are left untouched, and ecosystems/forms that can't yet "
+            "express a range-preserving floor-raise are skipped rather than "
+            "pinned (see the `library_floor_raise_unsupported` rows).")
+        lines.append(">")
+        lines.append(
+            "> **Wrong call?** If this is actually an application, override "
+            "with `RAPTOR_TARGET_KIND=application raptor-sca fix --harden …` "
+            "to pin dependencies to the newest safe version instead.")
+        lines.append("")
     lines.append("## Summary")
     lines.append("")
     lines.append("| Status | Count |")
@@ -1351,6 +1556,7 @@ def _write_report(
     for status in (
         "promoted", "degraded_safety", "review_required", "up_to_date",
         "skipped_loose_pin", "unsupported_manifest",
+        "library_floor_raise_unsupported",
         "no_versions", "registry_unsupported",
         "needs_network", "error",
     ):
@@ -1380,6 +1586,25 @@ def _write_report(
             )
         lines.append("")
 
+    if "library_floor_raise_unsupported" in by_status:
+        lines.append("## Library floor-raise unsupported (refused, not pinned)")
+        lines.append("")
+        lines.append("Library mode refused to pin these — either the manifest "
+                     "form can only emit an exact pin (inline installs, "
+                     "Debian apt lines) or no fully-safe version exists in "
+                     "the declared range. Address them by widening the range "
+                     "manually, switching the dep to a range-capable manifest, "
+                     "or scanning as an application "
+                     "(`RAPTOR_TARGET_KIND=application`).")
+        lines.append("")
+        for c in by_status["library_floor_raise_unsupported"]:
+            tgt = f"would-be → `{c.to_version}`" if c.to_version else "no safe target"
+            lines.append(
+                f"- **{c.ecosystem}:{c.name}** `{c.from_version or '*'}` "
+                f"({tgt}) in `{c.manifest}` — {c.detail}"
+            )
+        lines.append("")
+
     if "degraded_safety" in by_status:
         lines.append("## Degraded safety (no fully-clean version exists)")
         lines.append("")
@@ -1405,14 +1630,31 @@ def _print_summary(
     candidates: List[HardenCandidate],
     changes: List[UpgradeChange],
     out_dir: Path,
+    *,
+    target_kind: str = "unknown",
 ) -> None:
     by_status: Dict[str, int] = {}
     for c in candidates:
         by_status[c.status] = by_status.get(c.status, 0) + 1
+    if target_kind in ("library", "hybrid"):
+        print(f"raptor-sca fix: target detected as a {target_kind} — raising "
+              f"dependency floors to safe ranges (>=X), not exact pins (==X). "
+              f"Override: RAPTOR_TARGET_KIND=application")
     print(f"raptor-sca fix: {len(candidates)} deps analysed, "
           f"{by_status.get('promoted', 0)} promoted, "
           f"{by_status.get('degraded_safety', 0)} degraded, "
           f"{by_status.get('review_required', 0)} need review")
+    if target_kind in ("library", "hybrid"):
+        # Library-posture-specific counters: how many were left alone because
+        # the declared range is already safe (skip-clean) and how many were
+        # refused (would have needed an exact pin).
+        clean_left = sum(1 for c in candidates
+                         if c.status == "up_to_date"
+                         and "library target" in (c.detail or ""))
+        refused = by_status.get("library_floor_raise_unsupported", 0)
+        if clean_left or refused:
+            print(f"raptor-sca fix (library): {clean_left} already-safe range(s) "
+                  f"left intact, {refused} refused (would force an exact pin)")
     print(f"raptor-sca fix: candidates.json   {out_dir / 'candidates.json'}")
     print(f"raptor-sca fix: report.md         {out_dir / 'report.md'}")
 

--- a/packages/sca/tests/test_harden_planner.py
+++ b/packages/sca/tests/test_harden_planner.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence
 
+import pytest
+
 from packages.sca.harden import HardenCandidate, _plan_one
 from packages.sca.models import (
     Advisory,
@@ -933,3 +935,201 @@ def test_bounded_downgrade_generalises_to_non_pypi() -> None:
     )
     assert cand.status == "downgraded_safety", cand.status
     assert cand.to_version == "2.5.0"   # highest clean in [2.0.0, 2.7.0)
+
+
+# ---------------------------------------------------------------------------
+# library_mode: minimal safe floor-raise (target_kind consumer)
+# ---------------------------------------------------------------------------
+
+def test_application_mode_picks_newest_safe() -> None:
+    """Default (application) posture: pin to the newest safe version in range."""
+    dep = _dep(version="1.0", pin_style=PinStyle.RANGE)
+    cand = _plan_one(
+        dep, registries={"PyPI": _FakeRegistry(["1.3", "1.2", "1.1", "1.0"])},
+        osv=_FakeOsv(), offline=False, allow_major=False,
+    )
+    assert cand.status == "promoted"
+    assert cand.to_version == "1.3"            # newest in range
+    assert cand.selection == "highest_safe"
+
+
+def test_library_mode_skips_clean_baseline() -> None:
+    """Library posture: an already-safe declared floor is left intact — don't
+    narrow an intentional range when there's no security reason."""
+    dep = _dep(version="1.0", pin_style=PinStyle.RANGE)  # floor 1.0 clean
+    cand = _plan_one(
+        dep, registries={"PyPI": _FakeRegistry(["1.3", "1.2", "1.1", "1.0"])},
+        osv=_FakeOsv(), offline=False, allow_major=False,
+        library_mode=True,
+    )
+    assert cand.status == "up_to_date"
+    assert "already safe" in cand.detail
+
+
+def test_library_mode_floor_raises_when_baseline_vulnerable() -> None:
+    """Vulnerable floor → minimal safe floor-raise (lowest clean above it)."""
+    dep = _dep(version="1.0", pin_style=PinStyle.RANGE)
+    osv = _FakeOsv({"1.0": [_adv("CVE-FLOOR")]})   # declared floor vulnerable
+    cand = _plan_one(
+        dep, registries={"PyPI": _FakeRegistry(["1.3", "1.2", "1.1", "1.0"])},
+        osv=osv, offline=False, allow_major=False,
+        library_mode=True,
+    )
+    assert cand.status == "promoted"
+    assert cand.to_version == "1.1"            # minimal safe, not 1.3
+    assert cand.selection == "library_minimal"
+
+
+def test_library_mode_minimal_skips_vulnerable_nearest() -> None:
+    """Minimal means minimal *clean*: skip a vulnerable nearest version."""
+    dep = _dep(version="1.0", pin_style=PinStyle.RANGE)
+    osv = _FakeOsv({"1.0": [_adv("C0")], "1.1": [_adv("C1")]})  # floor+1.1 vuln
+    cand = _plan_one(
+        dep, registries={"PyPI": _FakeRegistry(["1.3", "1.2", "1.1", "1.0"])},
+        osv=osv, offline=False, allow_major=False,
+        library_mode=True,
+    )
+    assert cand.status == "promoted"
+    assert cand.to_version == "1.2"            # lowest clean above floor
+
+
+def test_library_mode_npm_floor_raises_to_range() -> None:
+    """npm (Increment 2): a vulnerable library dep is promoted with a minimal,
+    range-preserving floor-raise (the bare→caret happens in _bump_npm_spec)."""
+    dep = replace(_dep(ecosystem="npm", name="lodash", version="1.0",
+                       pin_style=PinStyle.RANGE),
+                  declared_in=Path("/x/package.json"))
+    osv = _FakeOsv({"1.0": [_adv("C")]})        # vulnerable floor
+    cand = _plan_one(
+        dep, registries={"npm": _FakeRegistry(["1.3", "1.2", "1.1", "1.0"],
+                                              ecosystem="npm")},
+        osv=osv, offline=False, allow_major=False, library_mode=True,
+    )
+    assert cand.status == "promoted"
+    assert cand.to_version == "1.1"             # minimal safe above floor
+    assert cand.selection == "library_minimal"
+
+
+@pytest.mark.parametrize("eco,manifest", [
+    ("NuGet", "App.csproj"),
+    ("NuGet", "Directory.Packages.props"),
+    ("Maven", "pom.xml"),
+    ("Maven", "libs.versions.toml"),
+])
+def test_library_mode_min_version_ecosystem_promotes_not_skipped(eco, manifest) -> None:
+    """NuGet/Gradle/Maven (Increment 3): minimum/soft-version manifests resolve
+    by floor, so the normal bump is already a safe floor-raise — they promote,
+    they are not skipped."""
+    dep = replace(_dep(ecosystem=eco, name="some.pkg",
+                       version="1.0", pin_style=PinStyle.RANGE),
+                  declared_in=Path("/x") / manifest)
+    osv = _FakeOsv({"1.0": [_adv("C")]})
+    cand = _plan_one(
+        dep, registries={eco: _FakeRegistry(["1.3", "1.2", "1.1", "1.0"],
+                                            ecosystem=eco)},
+        osv=osv, offline=False, allow_major=False, library_mode=True,
+    )
+    assert cand.status == "promoted"
+    assert cand.selection == "library_minimal"
+    assert cand.to_version == "1.1"
+
+
+def test_library_mode_inline_install_is_unsupported_not_pinned() -> None:
+    """Inline installs (``pip install x==Y``) are exact by nature — refuse
+    rather than over-constrain a library."""
+    dep = replace(_dep(version="1.0", pin_style=PinStyle.RANGE),
+                  declared_in=Path("/x/Dockerfile"))
+    osv = _FakeOsv({"1.0": [_adv("C")]})
+    cand = _plan_one(
+        dep, registries={"PyPI": _FakeRegistry(["1.3", "1.2", "1.1", "1.0"])},
+        osv=osv, offline=False, allow_major=False, library_mode=True,
+    )
+    assert cand.status == "library_floor_raise_unsupported"
+    assert cand.selection == "highest_safe"     # never marked library_minimal
+
+
+@pytest.mark.parametrize("manifest,supported", [
+    ("requirements.txt", True), ("requirements-dev.txt", True),
+    ("pyproject.toml", True), ("package.json", True),
+    ("App.csproj", True), ("Directory.Packages.props", True),
+    ("libs.versions.toml", True), ("pom.xml", True),
+    ("Dockerfile", False), ("install.sh", False), ("setup.cfg", False),
+])
+def test_supports_library_floor_raise_matrix(manifest, supported) -> None:
+    from packages.sca.harden import _supports_library_floor_raise
+    dep = replace(_dep(), declared_in=Path("/x") / manifest)
+    assert _supports_library_floor_raise(dep) is supported
+
+
+def test_library_mode_no_clean_version_refuses_to_pin() -> None:
+    """Library + no safe version anywhere in range → refuse (never degrade-pin
+    a library to a single/residual-vulnerable version)."""
+    dep = _dep(version="1.0", pin_style=PinStyle.RANGE)
+    osv = _FakeOsv({v: [_adv(f"C-{v}")] for v in ("1.0", "1.1", "1.2", "1.3")})
+    cand = _plan_one(
+        dep, registries={"PyPI": _FakeRegistry(["1.3", "1.2", "1.1", "1.0"])},
+        osv=osv, offline=False, allow_major=False, library_mode=True,
+    )
+    assert cand.status == "library_floor_raise_unsupported"
+
+
+def test_pypi_floor_raise_spec_is_a_range_not_a_pin() -> None:
+    """The leaf: floor_raise raises the lower bound and drops the == pin."""
+    from packages.sca.update import _pypi_pin_preserving_bounds
+    # corridor (app): keep floor, add exact pin
+    assert _pypi_pin_preserving_bounds(">=2.0,<3.0", "2.1") == ">=2.0,==2.1,<3.0"
+    # floor-raise (library): raise floor, keep ceiling, NO ==
+    assert _pypi_pin_preserving_bounds(">=2.0,<3.0", "2.1",
+                                       floor_raise=True) == ">=2.1,<3.0"
+    assert "==" not in _pypi_pin_preserving_bounds(">=2.0", "2.1",
+                                                   floor_raise=True)
+
+
+def test_report_surfaces_library_detection_and_override() -> None:
+    """The report banner states detection + override, keyed on target_kind."""
+    import tempfile
+    from packages.sca.harden import _write_report
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "report.md"
+        _write_report(out, [], [], target_kind="library",
+                      target_kind_reason="pyproject.toml [project]")
+        text = out.read_text()
+    assert "Detected as a library target" in text
+    assert "pyproject.toml [project]" in text
+    assert "RAPTOR_TARGET_KIND=application" in text
+
+
+def test_report_lists_unsupported_section() -> None:
+    """When deps were refused, the report has a per-dep detail section so the
+    operator sees exactly which ones (and why) — not just a summary count."""
+    import tempfile
+    from packages.sca.harden import _write_report
+    cand = HardenCandidate(
+        ecosystem="PyPI", name="pkg", manifest="Dockerfile",
+        pin_style="range", from_version="1.0", to_version=None,
+        crosses_major=False, status="library_floor_raise_unsupported",
+        detail="library target: refusing to pin (would force exact pin)",
+    )
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "report.md"
+        _write_report(out, [cand], [], target_kind="library")
+        text = out.read_text()
+    assert "Library floor-raise unsupported" in text
+    assert "**PyPI:pkg**" in text and "Dockerfile" in text
+
+
+def test_target_kind_cli_flag_sets_env(monkeypatch) -> None:
+    """`raptor-sca fix --harden --target-kind library` sets RAPTOR_TARGET_KIND
+    so the in-process detector honours the operator's intent (the same env
+    consulted by resolve_library_mode)."""
+    monkeypatch.delenv("RAPTOR_TARGET_KIND", raising=False)
+    from packages.sca.harden import _parse_args
+    args = _parse_args(["/tmp", "--target-kind", "library"])
+    assert args.target_kind == "library"
+    # main() sets the env from args; replicate that single line here to keep
+    # this a focused unit test (full main() needs registries/cache).
+    import os
+    from core.config import RaptorConfig
+    if args.target_kind != "auto":
+        os.environ[RaptorConfig.ENV_TARGET_KIND] = args.target_kind
+    assert os.environ.get(RaptorConfig.ENV_TARGET_KIND) == "library"

--- a/packages/sca/update.py
+++ b/packages/sca/update.py
@@ -677,6 +677,14 @@ class _PlanEntry:
     target: str
     manifest: Path
     advisory_ids: List[str]
+    # Library posture (set by harden for library/hybrid targets): raise the
+    # dependency FLOOR to ``target`` and keep a usable range, rather than
+    # corridor-pinning ``==target``. Pinning a library's deps over-constrains
+    # downstream consumers' resolvers. Default off → ``update`` and the
+    # application path are unchanged. Only the PyPI requirements.txt /
+    # pyproject PEP 508 paths honour it; other forms refuse to rewrite under
+    # floor_raise rather than emit an exact pin (never make a library worse).
+    floor_raise: bool = False
 
 
 def _crosses_major(ecosystem: str, installed: str, target: str) -> bool:
@@ -972,7 +980,8 @@ def _rewrite_package_json(
     def _replace(m: re.Match) -> str:
         nonlocal rewrote
         prefix, current, suffix = m.group(1), m.group(2), m.group(3)
-        new_spec = _bump_npm_spec(current, plan.installed, plan.target)
+        new_spec = _bump_npm_spec(current, plan.installed, plan.target,
+                                  floor_raise=plan.floor_raise)
         if new_spec is None:
             return m.group(0)
         rewrote = True
@@ -989,23 +998,32 @@ def _rewrite_package_json(
     return text, False, "spec matched but not safely bumpable (out of declared range or unsupported form)"
 
 
-def _bump_npm_spec(current: str, installed: str, target: str) -> Optional[str]:
+def _bump_npm_spec(current: str, installed: str, target: str,
+                   floor_raise: bool = False) -> Optional[str]:
     """Compute the replacement spec.
 
     Preserves the operator's leading prefix (``^``, ``~``, ``>=``,
     blank). Returns ``None`` when the current spec is a tarball / git
     URL / npm-alias — those need manual review.
+
+    ``floor_raise`` (library posture, npm + Poetry): a BARE exact spec
+    (``"1.0.0"`` / empty / ``*`` / ``latest``) is an exact pin that
+    over-constrains a library's consumers, so emit a caret RANGE
+    (``^target``) instead of the bare version. Caret/tilde/comparator
+    forms are already ranges, so they're unchanged by this flag.
     """
+    # Bare result for the no-prefix cases: a caret range under floor_raise.
+    bare = f"^{target}" if floor_raise else target
     s = current.strip()
     if not s:
-        return target
+        return bare
     if s.startswith(("git+", "git@", "git:", "github:", "bitbucket:",
                      "gitlab:", "gist:", "file:", "npm:")):
         return None
     if s.startswith(("http://", "https://")):
         return None
     if s in ("*", "x", "X", "latest"):
-        return target
+        return bare
     for prefix in ("^", "~"):
         if s.startswith(prefix):
             return f"{prefix}{target}"
@@ -1035,7 +1053,7 @@ def _bump_npm_spec(current: str, installed: str, target: str) -> Optional[str]:
         except VersionError:
             return None
         return s[:lo.start(2)] + target + s[lo.end(2):]
-    return target
+    return bare
 
 
 # ----- requirements.txt -----------------------------------------------------
@@ -1096,7 +1114,8 @@ def _rewrite_requirements_txt(
         # pin instead of collapsing them — they record the safe corridor
         # for future up/downgrades. Splicing on the match end keeps any
         # trailing PEP 508 marker (``; python_version >= ...``) intact.
-        new_spec = _pypi_pin_preserving_bounds(m.group(2) or "", plan.target)
+        new_spec = _pypi_pin_preserving_bounds(
+            m.group(2) or "", plan.target, floor_raise=plan.floor_raise)
         new_inner = m.group(1) + new_spec + line_value[m.end():]
         new_line = f"{comment_prefix}{new_inner}" if comment_prefix else new_inner
         out_lines.append(raw.replace(stripped, new_line))
@@ -1201,6 +1220,15 @@ def _rewrite_inline_install(
     command keyword or sit inside its continued args.
     """
     eco = plan.ecosystem
+    # Library posture: an inline ``pip install pkg==X`` is inherently an exact
+    # pin; we have no range-preserving form for it, so refuse rather than
+    # over-constrain a library's dep. (Inline installs are an application/
+    # container concern far more than a library one.)
+    if plan.floor_raise:
+        return text, False, (
+            "library floor-raise unsupported for inline-install (would force "
+            "an exact pin); leaving the dependency unpinned"
+        )
     cmd_re = _INLINE_INSTALL_CMD_RES.get(eco)
     if cmd_re is None:
         return text, False, (
@@ -1261,9 +1289,16 @@ def _rewrite_inline_install(
 _PYPI_CLAUSE_RE = re.compile(r"^\s*(===|==|>=|<=|~=|!=|>|<)\s*(.+?)\s*$")
 
 
-def _pypi_pin_preserving_bounds(spec: str, target: str) -> str:
+def _pypi_pin_preserving_bounds(spec: str, target: str,
+                                floor_raise: bool = False) -> str:
     """Return a PEP 440 specifier that pins to ``target`` while keeping
     any range bounds from ``spec`` as a record of the safe corridor.
+
+    ``floor_raise`` (library posture): instead of adding ``==target``, RAISE
+    the lower bound to ``>=target`` and keep ceilings/excludes — a range,
+    not an exact pin — so a library's downstream consumers can still resolve.
+    Example: ``>=2.0,<3.0`` + target ``2.1`` → ``>=2.1,<3.0`` (vs the default
+    ``>=2.0,==2.1,<3.0``).
 
     ``spec`` is the specifier text *after* the package name::
 
@@ -1291,7 +1326,11 @@ def _pypi_pin_preserving_bounds(spec: str, target: str) -> str:
             uppers.append(f"{op}{ver}")
         elif op == "!=":
             excludes.append(f"{op}{ver}")
-        # ==, ===, ~= are dropped — replaced by the ==target below.
+        # ==, ===, ~= are dropped — replaced by the pin/floor below.
+    if floor_raise:
+        # Library posture: a single ``>=target`` floor (replacing any old
+        # lowers), keep ceilings/excludes, no exact pin.
+        return ",".join([f">={target}"] + uppers + excludes)
     return ",".join(lowers + [f"=={target}"] + uppers + excludes)
 
 
@@ -1567,7 +1606,11 @@ def _rewrite_pyproject_toml(
         nonlocal poetry_hit
         if _normalise_pypi_name(m.group(3)) != norm:
             return m.group(0)
-        new_spec = _bump_npm_spec(m.group(4), plan.installed, plan.target)
+        # Poetry specs are semver (caret/tilde/range), so _bump_npm_spec's
+        # floor_raise handles the library posture: caret/tilde/range forms
+        # stay ranges, a bare exact becomes a caret range.
+        new_spec = _bump_npm_spec(m.group(4), plan.installed, plan.target,
+                                  floor_raise=plan.floor_raise)
         if new_spec is None:
             return m.group(0)
         poetry_hit = True
@@ -1582,6 +1625,11 @@ def _rewrite_pyproject_toml(
     def _pep508_sub(m: re.Match) -> str:
         if _normalise_pypi_name(m.group(1)) != norm:
             return m.group(0)
+        if plan.floor_raise:
+            # Library posture: raise the floor, keep bounds, no exact pin.
+            new_spec = _pypi_pin_preserving_bounds(
+                m.group(2), plan.target, floor_raise=True)
+            return f'"{m.group(1)}{new_spec}"'
         return f'"{m.group(1)}=={plan.target}"'
 
     new_text = pep508_re.sub(_pep508_sub, new_text)


### PR DESCRIPTION
For library/hybrid targets, harden no longer over-constrains downstream consumers: it picks the MINIMAL safe version, raises floors to a RANGE (>=X) instead of pinning (==X) where the rewriter has an exact-pin path (PyPI via _pypi_pin_preserving_bounds; npm + PyPI Poetry via _bump_npm_spec(floor_raise=True)), trusts the min/soft-version rewrites (NuGet csproj/CPM, Gradle libs.versions.toml, Maven pom.xml — bumps are already safe floors), and REFUSES (no patch) forms that can only produce an exact pin (inline-install, Debian apt) rather than emit one. Skips already-safe declared ranges. Gated on _PlanEntry.floor_raise (default off → update + the application path are unchanged). Adds --target-kind {auto,library,hybrid,application} flag (sets RAPTOR_TARGET_KIND) and a detection banner / refusal section in the report. Also fixes a latent drift: harden._has_rewriter now matches update._rewrite_one's dispatch (was silently rejecting csproj/CPM/libs.versions.toml even for apps).